### PR TITLE
Use some code for offline as online participant for payment section

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -2237,6 +2237,7 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
         ];
         //as we are using same template for online & offline registration.
         //So we have to build amount as array.
+        // @todo not used in core from 5.67 - remove
         $eventAmount = array_merge($eventAmount, $additionalParticipantDetails);
         $this->assign('amount', $eventAmount);
       }

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -891,6 +891,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
             $params = $this->get('params');
             $amount[$participantNum]['label'] = preg_replace('//', '', $params[$participantNum]['amount_level']);
             $amount[$participantNum]['amount'] = $params[$participantNum]['amount'];
+            // @todo - unused in core offline receipt template from 5.67. Remove at somepoint
             $this->assign('amounts', $amount);
           }
           if ($this->_lineItem) {

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -25,15 +25,22 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
    * Initial test of submit function.
    */
   public function testSubmit(): void {
-    $mut = new CiviMailUtils($this, TRUE);
     $this->submitPaidEvent();
-
-    $mut->checkMailLog([
+    $this->assertSentMailHasStrings([
       'Dear Kim,  Thank you for your registration.  This is a confirmation that your registration has been received and your status has been updated to Registered.',
       'Friday September 16th, 2022 12:00 PM-Saturday September 17th, 2022 12:00 PM',
+      'Add event to Google Calendar',
     ]);
-    $mut->stop();
-    $mut->clearMessages();
+  }
+
+  public function assertSentMailHasStrings(array $strings): void {
+    foreach ($strings as $string) {
+      $this->assertSentMailHasString($string);
+    }
+  }
+
+  public function assertSentMailHasString(string $string): void {
+    $this->assertStringContainsString($string, $this->sentMail[0]);
   }
 
   /**
@@ -645,6 +652,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
    * @param array $submitValues
    */
   protected function submitPaidEvent(array $submitValues = []): void {
+    $mailUtil = new CiviMailUtils($this, TRUE);
     $this->dummyProcessorCreate();
     $event = $this->eventCreatePaid(['payment_processor' => [$this->ids['PaymentProcessor']['dummy_live']], 'confirm_email_text' => '', 'is_pay_later' => FALSE, 'start_date' => '2022-09-16 12:00', 'end_date' => '2022-09-17 12:00']);
     $this->submitForm($event['id'], array_merge([
@@ -669,6 +677,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
       'billing_state_province-5' => 'AP',
       'billing_country-5' => 'US',
     ], $submitValues));
+    $this->sentMail = $mailUtil->getAllMessages();
   }
 
   public function testRegistrationWithoutCiviContributeEnabled(): void {

--- a/tests/phpunit/CiviTest/CiviMailUtils.php
+++ b/tests/phpunit/CiviTest/CiviMailUtils.php
@@ -124,9 +124,10 @@ class CiviMailUtils extends PHPUnit\Framework\TestCase {
    * @param string $type
    *   'raw'|'ezc'.
    *
-   * @throws CRM_Core_Exception
-   *
    * @return array(ezcMail)|array(string)
+   *
+   * @noinspection PhpMissingReturnTypeInspection
+   * @noinspection PhpDocMissingThrowsInspection
    */
   public function getAllMessages($type = 'raw') {
     $msgs = [];

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -35,7 +35,7 @@
     {elseif !empty($isRequireApproval)}
       <p>{ts}Your registration has been submitted.{/ts}</p>
       <p>{ts}Once your registration has been reviewed, you will receive an email with a link to a web page where you can complete the registration process.{/ts}</p>
-    {elseif $is_pay_later}
+    {elseif $isPrimary && {contribution.balance_amount|boolean} && {contribution.is_pay_later|boolean}}
      <p>{$pay_later_receipt}</p> {* FIXME: this might be text rather than HTML *}
     {/if}
 
@@ -151,7 +151,7 @@
       </tr>
      {/if}
 
-     {if $email}
+     {if {contact.email_primary.email|boolean}}
       <tr>
        <th {$headerStyle}>
         {ts}Registered Email{/ts}
@@ -159,7 +159,7 @@
       </tr>
       <tr>
        <td colspan="2" {$valueStyle}>
-        {$email}
+         {contact.email_primary.email}
        </td>
       </tr>
      {/if}
@@ -309,13 +309,13 @@
             </tr>
           {/if}
 
-          {if $register_date}
+          {if {participant.register_date|boolean}}
             <tr>
               <td {$labelStyle}>
                   {ts}Registration Date{/ts}
               </td>
               <td {$valueStyle}>
-                  {$register_date|crmDate}
+                {participant.register_date}
               </td>
             </tr>
           {/if}

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -134,8 +134,13 @@
 {/if}
 {/if}
 
-{if !empty($amount) && !$lineItem}
-{foreach from=$amount item=amnt key=level}{$amnt.amount|crmMoney} {$amnt.label}
+{if !$isShowLineItems}
+{foreach from=$participants key=index item=currentParticipant}
+{if $isPrimary || {participant.id} === $currentParticipant.id}
+{foreach from=$currentParticipant.line_items key=index item=currentLineItem}
+{$currentLineItem.label} {if $isPrimary} - {$currentParticipant.contact.display_name}{/if} - {$currentLineItem.line_total|crmMoney:$currency}
+{/foreach}
+{/if}
 {/foreach}
 {/if}
 

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -84,7 +84,7 @@
 
 {$email}
 {/if}
-{if !empty($event.is_monetary)} {* This section for Paid events only.*}
+{if {event.is_monetary|boolean}} {* This section for Paid events only.*}
 
 ==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
 

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -172,7 +172,7 @@
 {ts}Total Participants{/ts}: {$count}
 {/if}
 
-{if $is_pay_later}
+{elseif $isPrimary && {contribution.balance_amount|boolean} && {contribution.is_pay_later|boolean}}
 
 ==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
 

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -244,6 +244,22 @@
                 {/if}
               {/foreach}
             {/if}
+            {if !$isShowLineItems}
+              {foreach from=$participants key=index item=currentParticipant}
+                {if $isPrimary || {participant.id} === $currentParticipant.id}
+                  {foreach from=$currentParticipant.line_items key=index item=currentLineItem}
+                  <tr>
+                    <td {$valueStyle}>
+                      {$currentLineItem.label} {if $isPrimary} - {$currentParticipant.contact.display_name}{/if}
+                    </td>
+                    <td {$valueStyle}>
+                      {$currentLineItem.line_total|crmMoney:$currency}
+                    </td>
+                  </tr>
+                  {/foreach}
+                {/if}
+              {/foreach}
+            {/if}
             {if $isShowTax && {contribution.tax_amount|boolean}}
               <tr>
                 <td {$labelStyle}>
@@ -264,17 +280,6 @@
                 </tr>
               {/foreach}
             {/if}
-
-            {if !empty($amounts) && empty($lineItem)}
-              {foreach from=$amounts item=amnt key=level}
-                <tr>
-                  <td colspan="2" {$valueStyle}>
-                    {$amnt.amount|crmMoney:$currency} {$amnt.label}
-                  </td>
-                </tr>
-              {/foreach}
-            {/if}
-
             {if $isShowTax && {contribution.tax_amount|boolean}}
               <tr>
                 <td {$labelStyle}>

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -157,7 +157,7 @@
           </tr>
         {/if}
 
-        {if $event.is_share}
+        {if {event.is_share|boolean}}
           <tr>
             <td colspan="2" {$valueStyle}>
               {capture assign=eventUrl}{crmURL p='civicrm/event/info' q="id={event.id}&reset=1" a=true fe=1 h=1}{/capture}

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -46,7 +46,7 @@
             {if $isPrimary}
               <p>{ts}Once your registration has been reviewed, you will receive an email with a link to a web page where you can complete the registration process.{/ts}</p>
             {/if}
-        {elseif !empty($is_pay_later) && empty($isAmountzero) && empty($isAdditionalParticipant)}
+        {elseif $isPrimary && {contribution.balance_amount|boolean} && {contribution.is_pay_later|boolean}}
           <p>{if {event.pay_later_receipt|boolean}}{event.pay_later_receipt}{/if}</p>
         {/if}
     </td>

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -147,8 +147,13 @@ You were registered by: {$payer.name}
 {/if}
 {/if}
 
-{if !empty($amounts) && empty($lineItem)}
-{foreach from=$amounts item=amnt key=level}{$amnt.amount|crmMoney:$currency} {$amnt.label}
+{if !$isShowLineItems}
+{foreach from=$participants key=index item=currentParticipant}
+{if $isPrimary || {participant.id} === $currentParticipant.id}
+{foreach from=$currentParticipant.line_items key=index item=currentLineItem}
+{$currentLineItem.label} {if $isPrimary} - {$currentParticipant.contact.display_name}{/if} - {$currentLineItem.line_total|crmMoney:$currency}
+{/foreach}
+{/if}
 {/foreach}
 {/if}
 

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -96,7 +96,7 @@
 {if !empty($payer.name)}
 You were registered by: {$payer.name}
 {/if}
-{if !empty($event.is_monetary) and empty($isRequireApproval)} {* This section for Paid events only.*}
+{if {event.is_monetary|boolean} and empty($isRequireApproval)} {* This section for Paid events only.*}
 
 ==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -30,7 +30,7 @@
 {/if}
 ==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
-{elseif !empty($is_pay_later) && empty($isAmountzero) && empty($isAdditionalParticipant)}
+{elseif $isPrimary && {contribution.balance_amount|boolean} && {contribution.is_pay_later|boolean}}
 
 ==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
Use some code for offline as online participant for payment section

Builds on https://github.com/civicrm/civicrm-core/pull/27479 to use the same code for offline receipt

Before
----------------------------------------
Payment info in offline receipt differs from online for no apparent reason, does not show mulitple participant data reliably (if completing) 

After
----------------------------------------
offline uses same code as online for payment section, does not rely on the form, works in preview 

Technical Details
----------------------------------------

Comments
----------------------------------------
