### PR TITLE
php 8.x Ensure profiles are assigned to template, even when empty

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -493,6 +493,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    */
   public function buildCustom($id, $name) {
     if (!$id) {
+      $this->assign($name, []);
       return;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Ensure profiles are assigned to template, even when empty

Before
----------------------------------------
Notice in php8.x when a profile is not present

After
----------------------------------------
Fixed

Technical Details
----------------------------------------

Comments
----------------------------------------
