### PR TITLE
Fix last notices on Online event registration by removing variables

### DIFF
--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -75,20 +75,10 @@
     function buildPaymentBlock(type) {
       var $form = $('#billing-payment-block').closest('form');
       {/literal}
-      {if !$isBackOffice && $contributionPageID}
-        {capture assign='contributionPageID'}&id={$contributionPageID}{/capture}
-      {else}
-        {capture assign='contributionPageID'}{/capture}
-      {/if}
       {if !$isBackOffice && $custom_pre_id}
         {capture assign='preProfileID'}&pre_profile_id={$custom_pre_id}{/capture}
       {else}
         {capture assign='preProfileID'}{/capture}
-      {/if}
-      {if $urlPathVar}
-        {capture assign='urlPathVar'}&{$urlPathVar}{/capture}
-      {else}
-        {capture assign='urlPathVar'}{/capture}
       {/if}
       {* Billing profile ID is only ever set on front end forms, to force entering address for pay later. *}
       {if !$isBackOffice && $billing_profile_id}
@@ -104,7 +94,7 @@
       var currency = '{$currency}';
       currency = currency == '' ? $('#currency').val() : currency;
 
-      var dataUrl = "{crmURL p='civicrm/payment/form' h=0 q="formName=`$form.formName``$urlPathVar``$isBackOfficePathVar``$profilePathVar``$contributionPageID``$preProfileID`"}";
+      var dataUrl = "{crmURL p='civicrm/payment/form' h=0 q="formName=`$form.formName``$isBackOfficePathVar``$profilePathVar``$preProfileID`"}";
       {literal}
       if (typeof(CRM.vars) != "undefined") {
         if (typeof(CRM.vars.coreForm) != "undefined") {


### PR DESCRIPTION

Overview
----------------------------------------
Fix last notices on Online event registration by removing variables

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/fa96b3c1-27bf-4ae6-ad10-60f8f540e149)


After
----------------------------------------
I hunted through to see why these variables are assigned and they pre-date the switch to load the payment block from the

CRM_Financial_Form_Payment

There is no evidence of that form looking them up in any way - so I think they can go....
https://github.com/civicrm/civicrm-core/commit/aaff4c697d6f94f01f5dacf5a3d876a95e50f5cb#diff-660258b71b4d1db49bdef38c7b3fcb4b698004ab39b57dcbd49083e256444272

Technical Details
----------------------------------------
By 'last' I mean - with all open PRs merged that is the last one I'm getting loading the first page...

Comments
----------------------------------------
