### PR TITLE
Exclude inactive groups on recipient lists for mailings

### DIFF
--- a/Civi/Api4/Service/Autocomplete/MailingRecipientsAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/MailingRecipientsAutocompleteProvider.php
@@ -70,6 +70,7 @@ class MailingRecipientsAutocompleteProvider extends AutoService implements Event
             ],
             'join' => [],
             'where' => [
+              ['is_active', '=', TRUE],
               ['group_type:name', 'CONTAINS', 'Mailing List'],
               ['OR', [['saved_search_id.expires_date', 'IS NULL'], ['saved_search_id.expires_date', '>', 'NOW()', TRUE]]],
               ['OR', [['is_hidden', '=', FALSE], [($mode === 'include' ? 'mailing_group.id' : '(NULL)'), 'IS NOT NULL']]],


### PR DESCRIPTION
Overview
----------------------------------------
Recently the code for including/excluding recipients was moved to APIv4: https://github.com/civicrm/civicrm-core/commit/4752454a6254a5f18c406fd522b31ac476eef18f

When this happened, it become possible for admins to select 'inactive' groups as recipients for mailings. This has confused some of our admins.

Before
----------------------------------------
Groups with 'is_active' unchecked can be selected when choosing mailing recipients.

After
----------------------------------------
Groups with 'is_active' unchecked are not present in the list when choosing mailing recipients.

Comments
----------------------------------------
Are there relevant tests for this to update? I didn't see any?
