### PR TITLE
make grouptree protected so that it can be accessed via hook

### DIFF
--- a/CRM/Custom/Form/CustomDataByType.php
+++ b/CRM/Custom/Form/CustomDataByType.php
@@ -29,7 +29,7 @@ class CRM_Custom_Form_CustomDataByType extends CRM_Core_Form {
   /**
    * @var array
    */
-  private $groupTree;
+  protected $groupTree;
 
   /**
    * @var array


### PR DESCRIPTION
Overview
----------------------------------------
Making group tree protected can make the field accessible via hook using getVar() or setvar(). 

Was possible to access the field for Civi < 5.65