### PR TITLE
Cast _action to an int

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1312,7 +1312,11 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @return int
    */
   public function getAction() {
-    return $this->_action;
+    if (!is_numeric($this->_action)) {
+      CRM_Core_Error::deprecatedWarning('action should be an integer');
+      return $this->_action;
+    }
+    return (int) $this->_action;
   }
 
   /**
@@ -1322,7 +1326,13 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *   The mode we want to set the form.
    */
   public function setAction($action) {
-    $this->_action = $action;
+    if (is_numeric($action)) {
+      $this->_action = (int) $action;
+    }
+    else {
+      CRM_Core_Error::deprecatedWarning('action should be an integer');
+      $this->_action = $action;
+    }
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Case _action to an int

Before
----------------------------------------
`$form->getAction()` returns '2'

After
----------------------------------------
`$form->getAction()` returns 2

Technical Details
----------------------------------------
There is a lot of code comparing to action which is unsure whether it is dealing with 2 or '2'. It should be possible to always cast to an int but I have added deprecation just in case...

Comments
----------------------------------------
This reduces the risk of introducing a bug by comparing '2' with an integer. My grepping suggests it would never be hit