### PR TITLE
Fix activity view bug where an activity type id in the url overrides …

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -20,6 +20,8 @@
  */
 class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
+  use CRM_Activity_Form_ActivityFormTrait;
+
   /**
    * The id of the object being edited / created
    *
@@ -65,7 +67,6 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
    */
   protected $_sourceContactId;
   protected $_targetContactId;
-  protected $_asigneeContactId;
 
   protected $_single;
 
@@ -266,32 +267,18 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     $this->assign('context', $this->_context);
 
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this);
-
-    if ($this->_action & CRM_Core_Action::DELETE) {
+    if ($this->getAction() & CRM_Core_Action::DELETE) {
       if (!CRM_Core_Permission::check('delete activities')) {
         CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
       }
     }
 
-    // CRM-6957
-    // When we come from contact search, activity id never comes.
-    // So don't try to get from object, it might gives you wrong one.
-
-    // if we're not adding new one, there must be an id to
-    // an activity we're trying to work on.
-    if ($this->_action != CRM_Core_Action::ADD &&
-      get_class($this->controller) !== 'CRM_Contact_Controller_Search'
-    ) {
-      $this->_activityId = CRM_Utils_Request::retrieve('id', 'Positive', $this);
-    }
-
-    $this->_activityTypeId = CRM_Utils_Request::retrieve('atype', 'Positive', $this);
+    $this->_activityTypeId = $this->getActivityValue('activity_type_id') ?: CRM_Utils_Request::retrieve('atype', 'Positive', $this);
     $this->assign('atype', $this->_activityTypeId);
-
     $this->assign('activityId', $this->_activityId);
 
     // Check for required permissions, CRM-6264.
-    if ($this->_activityId &&
+    if ($this->getActivityID() &&
       in_array($this->_action, [CRM_Core_Action::UPDATE, CRM_Core_Action::VIEW]) &&
       !CRM_Activity_BAO_Activity::checkPermission($this->_activityId, $this->_action)
     ) {
@@ -302,13 +289,6 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     ) {
       $this->assign('permission', 'edit');
       $this->assign('allow_edit_inbound_emails', CRM_Activity_BAO_Activity::checkEditInboundEmailsPermissions());
-    }
-
-    if (!$this->_activityTypeId && $this->_activityId) {
-      $this->_activityTypeId = CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity',
-        $this->_activityId,
-        'activity_type_id'
-      );
     }
 
     $this->assignActivityType();
@@ -373,8 +353,10 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       [$this->_activityTypeName, $activityTypeDescription] = CRM_Core_BAO_OptionValue::getActivityTypeDetails($this->_activityTypeId);
     }
 
-    // Set activity type name and description to template.
-    $this->assign('activityTypeName', $this->_activityTypeName ?? FALSE);
+    // Set activity type name and description to template. Type should no longer be used anywhere
+    // except the case_activity workflow template - unsure how to test that... We want to remove
+    // it due to mis-naming of the variable. The workflow template can use a token...
+    $this->assign('activityTypeName', $this->_activityTypeName);
     $this->assign('activityTypeDescription', $activityTypeDescription ?? FALSE);
 
     // set user context
@@ -1263,8 +1245,29 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
         }
       }
     }
-
     $this->assign('activityTypeNameAndLabel', $activityTypeNameAndLabel);
+  }
+
+  /**
+   * Get the activity ID.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function getActivityID(): ?int {
+    // CRM-6957
+    // When we come from contact search, activity id never comes.
+    // So don't try to get from object, it might gives you wrong one.
+    if ($this->controller instanceof \CRM_Contact_Controller_Search) {
+      return NULL;
+    }
+    if (!isset($this->_activityId) && $this->_action != CRM_Core_Action::ADD) {
+      $this->_activityId = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    }
+    return $this->_activityId ? (int) $this->_activityId : FALSE;
   }
 
 }

--- a/CRM/Activity/Form/ActivityFormTrait.php
+++ b/CRM/Activity/Form/ActivityFormTrait.php
@@ -1,0 +1,51 @@
+<?php
+
+use Civi\API\EntityLookupTrait;
+
+/**
+ * Trait implements functions to retrieve activity related values.
+ */
+trait CRM_Activity_Form_ActivityFormTrait {
+
+  use EntityLookupTrait;
+
+  /**
+   * Get the value for a field relating to the activity.
+   *
+   * All values returned in apiv4 format. Escaping may be required.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @param string $fieldName
+   *
+   * @return mixed
+   * @throws \CRM_Core_Exception
+   */
+  public function getActivityValue(string $fieldName) {
+    if ($this->isDefined('Activity')) {
+      return $this->lookup('Activity', $fieldName);
+    }
+    $id = $this->getActivityID();
+    if ($id) {
+      $this->define('Activity', 'Activity', ['id' => $id]);
+      return $this->lookup('Activity', $fieldName);
+    }
+    return NULL;
+  }
+
+  /**
+   * Get the selected Activity ID.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function getActivityID(): ?int {
+    throw new CRM_Core_Exception('`getActivityID` must be implemented');
+  }
+
+}

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -12,7 +12,7 @@
     <div class="crm-block crm-content-block crm-activity-view-block">
   {else}
     {if $activityTypeDescription}
-      <div class="help">{$activityTypeDescription}</div>
+      <div class="help">{$activityTypeDescription|purify}</div>
     {/if}
     <div class="crm-block crm-form-block crm-activity-form-block">
   {/if}
@@ -29,7 +29,7 @@
 
   {if $action eq 4}
     {if $activityTypeDescription}
-    <div class="help">{$activityTypeDescription}</div>
+    <div class="help">{$activityTypeDescription|purify}</div>
     {/if}
   {else}
     {if $context eq 'standalone' or $context eq 'search' or $context eq 'smog'}

--- a/templates/CRM/Activity/Form/ActivityView.tpl
+++ b/templates/CRM/Activity/Form/ActivityView.tpl
@@ -9,7 +9,7 @@
 *}
 <div class="crm-block crm-content-block crm-activity-view-block">
       {if $activityTypeDescription}
-        <div class="help">{$activityTypeDescription}</div>
+        <div class="help">{$activityTypeDescription|purify}</div>
       {/if}
       <table class="crm-info-panel">
         <tr>

--- a/templates/CRM/Case/Form/Activity.tpl
+++ b/templates/CRM/Case/Form/Activity.tpl
@@ -23,7 +23,7 @@
   <table class="form-layout">
     {if $activityTypeDescription}
       <tr>
-        <div class="help">{$activityTypeDescription}</div>
+        <div class="help">{$activityTypeDescription|purify}</div>
       </tr>
     {/if}
     {* Block for change status, case type and start date. *}

--- a/templates/CRM/Case/Form/Case.tpl
+++ b/templates/CRM/Case/Form/Case.tpl
@@ -27,7 +27,7 @@
 <table class="form-layout">
     {if $activityTypeDescription}
         <tr>
-            <div class="help">{$activityTypeDescription}</div>
+            <div class="help">{$activityTypeDescription|purify}</div>
         </tr>
     {/if}
 {if $clientName}

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -357,7 +357,7 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
     $client_id_2 = $this->individualCreate([], 1);
     $caseObj_2 = $this->createCase($client_id_2, $loggedInUser);
     $case_id_2 = $caseObj_2->id;
-
+    $_REQUEST['action'] = 'add';
     $form = $this->getFormObject('CRM_Case_Form_Activity', [
       'activity_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Link Cases'),
       'link_to_case_id' => $case_id_2,


### PR DESCRIPTION

Overview
----------------------------------------
Fix activity view bug where an activity type id in the url overrides the actual activity type id


When we view an activity there is code in the template that renders differently depending on the activity type id. However, if the activity ID (atype) is wrong in the url it gives the url precedence

This is a bit obscure - I hit it when I changed the activity type id in the database & the view did not update

Before
----------------------------------------
Create an activity with details 

```
-ALTERNATIVE ITEM 0-
Hi,

Wassup!?!?

Let's check if the output when viewing the form has legible line breaks in the output.

Thanks!

-ALTERNATIVE ITEM 1-

<div dir="ltr">Hi,<br></div>
<div dir="ltr"><br></div>
<div dir="ltr">Wassup!?!?<br></div>
<div dir="ltr"><br></div>
<div dir="ltr">Let&#39;s check if the output when viewing the form has legible line breaks in the output.<br></div>
<div dir="ltr"><br></div>
<div dir="ltr">Thanks!<br></div>
-ALTERNATIVE END-
```

(might need to save directly to DB UPDATE - no through the UI works)

View the activity - it looks like

![image](https://github.com/civicrm/civicrm-core/assets/336308/4bda012e-e510-4cfb-8506-454e31abf248)

Alter the activity view url - put the activity type ID for pdf letter (default install = 22 ) into the url as `atype` - you get the unadulterated version

![image](https://github.com/civicrm/civicrm-core/assets/336308/72dee378-8557-418f-a19a-ae6d5a786067)


After
----------------------------------------
The activity type ID comes from the activity not the url

Technical Details
----------------------------------------
A bit of minor clean up too

Comments
----------------------------------------
