### PR TITLE
Remove event cart sessions handling from offline event receipt text as gone from html

### DIFF
--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -48,23 +48,6 @@
 
 {event.title}
 {event.start_date|crmDate:"%A"} {event.start_date|crmDate}{if $event.event_end_date}-{if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}{$event.event_end_date|crmDate:0:1}{else}{$event.event_end_date|crmDate:"%A"} {$event.event_end_date|crmDate}{/if}{/if}
-{if !empty($conference_sessions)}
-
-
-{ts}Your schedule:{/ts}
-{assign var='group_by_day' value='NA'}
-{foreach from=$conference_sessions item=session}
-{if $session.start_date|crmDate:"%Y/%m/%d" != $group_by_day|crmDate:"%Y/%m/%d"}
-{assign var='group_by_day' value=$session.start_date}
-
-{$group_by_day|crmDate:"%m/%d/%Y"}
-
-
-{/if}
-{$session.start_date|crmDate:0:1}{if $session.end_date}-{$session.end_date|crmDate:0:1}{/if} {$session.title}
-{if $session.location}    {$session.location}{/if}
-{/foreach}
-{/if}
 
 {if !empty($event.participant_role) and $event.participant_role neq 'Attendee' and !empty($defaultRole)}
 {ts}Participant Role{/ts}: {$event.participant_role}


### PR DESCRIPTION
This just completes https://github.com/civicrm/civicrm-core/pull/27455 which missed the text only template