### PR TITLE
Switch templates to use correctly named variable

### DIFF
--- a/templates/CRM/Case/Form/Activity.tpl
+++ b/templates/CRM/Case/Form/Activity.tpl
@@ -15,10 +15,10 @@
     <i class="crm-i fa-info-circle" aria-hidden="true"></i> &nbsp;
     {if $action eq 8}
       {* activityTypeName means label here not name, but it's ok because label is desired here (dev/core#1116-ok-label) *}
-      {ts 1=$activityTypeName}Click Delete to move this &quot;%1&quot; activity to the Trash.{/ts}
+      {ts 1=$activityTypeNameAndLabel.displayLabel|escape}Click Delete to move this &quot;%1&quot; activity to the Trash.{/ts}
     {else}
       {* activityTypeName means label here not name, but it's ok because label is desired here (dev/core#1116-ok-label) *}
-      {ts 1=$activityTypeName}Click Restore to retrieve this &quot;%1&quot; activity from the Trash.{/ts}
+      {ts 1=$activityTypeNameAndLabel.displayLabel|escape}Click Restore to retrieve this &quot;%1&quot; activity from the Trash.{/ts}
     {/if}
   </div><br />
   {else}
@@ -90,7 +90,7 @@
                 <tr class="crm-case-activity-form-block-activityTypeName">
                   <td class="label">{ts}Activity Type{/ts}</td>
                   {* activityTypeName means label here not name, but it's ok because label is desired here (dev/core#1116-ok-label) *}
-                  <td class="view-value bold">{$activityTypeName|escape}</td>
+                  <td class="view-value bold">{$activityTypeNameAndLabel.label|escape}</td>
                 </tr>
                 <tr class="crm-case-activity-form-block-source_contact_id">
                   <td class="label">{$form.source_contact_id.label}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Switch templates to use correctly named variable

Before
----------------------------------------
Use of `{$activityTypeName}` which confusing means label

After
----------------------------------------
Use of disambiguaion variable `{$activityTypeNameAndLabel.label|escape}`

Technical Details
----------------------------------------
@demeritcowboy if we do this we could 'amost' get rid of or change the mis-named variable. The gotcha is the `case_activity` work flow tpl - I have no idea how that is called. It should ideally use the token `{activity.activity_type_id:label}`

Comments
----------------------------------------
