### PR TITLE
[NFC] Mail Logger: cleanup CIVICRM_MAIL_LOG_AND SEND

### DIFF
--- a/CRM/Utils/Mail/Logger.php
+++ b/CRM/Utils/Mail/Logger.php
@@ -33,7 +33,7 @@ class CRM_Utils_Mail_Logger {
   public static function filter($mailer, &$recipients, &$headers, &$body) {
     if (defined('CIVICRM_MAIL_LOG')) {
       static::log($recipients, $headers, $body);
-      if (!defined('CIVICRM_MAIL_LOG_AND_SEND') && !defined('CIVICRM_MAIL_LOG_AND SEND')) {
+      if (!defined('CIVICRM_MAIL_LOG_AND_SEND')) {
         return TRUE;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------

Remove code that makes no sense in CRM/Utils/Mail/loggger.php.

I saw it copy-pasted in extension code, which made me go :thinking: 

It's not clear where it comes from, but I found a reference here: https://github.com/civicrm/civicrm-core/blob/43ef9cc474c4d7078cc7cb12144e16269cd8ccdc/tools/scripts/composer/patches/pear-mail.patch.txt

>  Note: "CIVICRM_MAIL_LOG_AND SEND" (space not underscore) was a typo that existed for some years, so kept here for compatibility, but it should not be used.

