### PR TITLE
Fix legacy custom searches to not use hacky method to access protected property on core class

### DIFF
--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom.php
@@ -16,7 +16,10 @@
  */
 class CRM_Contact_Form_Search_Custom extends CRM_Contact_Form_Search {
 
-  protected $_customClass = NULL;
+  /**
+   * @var CRM_Contact_Form_Search_Custom_Base
+   */
+  protected $_customClass;
 
   public function preProcess() {
     // SearchFormName is deprecated & to be removed - the replacement is for the task to
@@ -30,11 +33,7 @@ class CRM_Contact_Form_Search_Custom extends CRM_Contact_Form_Search {
     $ssID = CRM_Utils_Request::retrieve('ssID', 'Integer', $this);
     $gID = CRM_Utils_Request::retrieve('gid', 'Integer', $this);
 
-    list(
-      $this->_customSearchID,
-      $this->_customSearchClass,
-      $formValues
-      ) = CRM_Contact_BAO_SearchCustom::details($csID, $ssID, $gID);
+    [$this->_customSearchID, $this->_customSearchClass, $formValues] = CRM_Contact_BAO_SearchCustom::details($csID, $ssID, $gID);
 
     if (!$this->_customSearchID) {
       CRM_Core_Error::statusbounce(ts('Could not get details for custom search.'));
@@ -107,9 +106,21 @@ class CRM_Contact_Form_Search_Custom extends CRM_Contact_Form_Search {
    */
   public function buildTaskList() {
     // call the parent method to populate $this->_taskList for the custom search
-    parent::buildTaskList();
-
-    return $this->_customClass->buildTaskList($this);
+    // amtg = 'Add members to group'
+    if ($this->_context !== 'amtg') {
+      $taskParams['deletedContacts'] = FALSE;
+      if ($this->_componentMode == CRM_Contact_BAO_Query::MODE_CONTACTS || $this->_componentMode == CRM_Contact_BAO_Query::MODE_CONTACTSRELATED) {
+        $taskParams['deletedContacts'] = $this->_formValues['deleted_contacts'] ?? NULL;
+      }
+      $className = $this->_modeValue['taskClassName'];
+      $taskParams['ssID'] = $this->_ssID ?? NULL;
+      $this->_taskList += $className::permissionedTaskTitles(CRM_Core_Permission::getPermission(), $taskParams);
+    }
+    $reflectionClass = new ReflectionClass($this->_customClass);
+    if ($reflectionClass->getMethod('buildTaskList')->class == get_class($this->_customClass)) {
+      return $this->_customClass->buildTaskList($this);
+    }
+    return $this->_taskList;
   }
 
   public function buildQuickForm() {

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Base.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Base.php
@@ -57,6 +57,7 @@ class CRM_Contact_Form_Search_Custom_Base {
    * @return array
    */
   public function buildTaskList(CRM_Core_Form_Search $form) {
+    CRM_Core_Error::deprecatedFunctionWarning('this does not seem reachable');
     return $form->getVar('_taskList');
   }
 


### PR DESCRIPTION




Overview
----------------------------------------
Fix legacy custom searches to not use hacky method to access protected property on core class

Before
----------------------------------------
Unnecessary hacki-ness to subvert protected property

After
----------------------------------------
Property accessed from it's own class

This still works - ie I checked the actions are still available in custom searches but respects the principle that protected variables are not public

![image](https://github.com/civicrm/civicrm-core/assets/336308/ffd10b1a-fa12-4322-9c38-c2466e7ece55)

Technical Details
----------------------------------------
This avoids passing the form object to a function simply to extract the links value & instead only calls the form object is it actually implements the links function - which they basically don't...

Comments
----------------------------------------
