### PR TITLE
Remove getVar call, access protected property in same class directly

### DIFF
--- a/CRM/Campaign/Form/Survey.php
+++ b/CRM/Campaign/Form/Survey.php
@@ -168,15 +168,13 @@ class CRM_Campaign_Form_Survey extends CRM_Core_Form {
   /**
    * @return string
    */
-  public function getTemplateFileName() {
-    if ($this->controller->getPrint() || $this->getVar('_surveyId') <= 0) {
+  public function getTemplateFileName(): string {
+    if ($this->_surveyId <= 0 || $this->controller->getPrint()) {
       return parent::getTemplateFileName();
     }
-    else {
-      // hack lets suppress the form rendering for now
-      self::$_template->assign('isForm', FALSE);
-      return 'CRM/Campaign/Form/Survey/Tab.tpl';
-    }
+    // hack lets suppress the form rendering for now
+    self::$_template->assign('isForm', FALSE);
+    return 'CRM/Campaign/Form/Survey/Tab.tpl';
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Remove getVar call, access protected property in same class directly

Before
----------------------------------------
Calling `$this->getVar('_surveyId') <= 0` is the same as `$this->_surveyId`

After
----------------------------------------
use `$this->_surveyId`

Technical Details
----------------------------------------
minor code cleanup - cheaper if clause first, do not use else where the if has already returned

Comments
----------------------------------------
