### PR TITLE
php8.2 stop using yet-another undeclared property for _membershipId.

### DIFF
--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -427,6 +427,21 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
   }
 
   /**
+   * Get the membership ID.
+   *
+   * For new memberships this may initially be NULL.
+   *
+   * @return int
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   */
+  public function getMembershipID(): ?int {
+    return $this->_id;
+  }
+
+  /**
    * Set variables in a way that can be accessed from different places.
    *
    * This is part of refactoring for unit testability on the submit function.

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1822,10 +1822,10 @@ DESC limit 1");
   /**
    * Get the created or edited membership ID.
    *
-   * @return false|mixed
+   * @return int|null
    */
-  protected function getMembershipID() {
-    return reset($this->_membershipIDs);
+  public function getMembershipID(): ?int {
+    return $this->_membershipIDs[0] ?? NULL;
   }
 
   /**
@@ -1848,7 +1848,7 @@ DESC limit 1");
    */
   protected function setMembership(array $membership): void {
     if (!in_array($membership['id'], $this->_membershipIDs, TRUE)) {
-      $this->_membershipIDs[] = $membership['id'];
+      $this->_membershipIDs[] = (int) $membership['id'];
     }
     $this->membership = $membership;
   }
@@ -1894,7 +1894,7 @@ DESC limit 1");
     $ids = [];
     foreach ($contribution['values'][$contribution['id']]['line_item'] as $line) {
       if ($line['entity_table'] ?? '' === 'civicrm_membership') {
-        $ids[] = $line['entity_id'];
+        $ids[] = (int) $line['entity_id'];
       }
     }
     $this->setMembershipIDs($ids);

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -490,9 +490,8 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     $this->_params['total_amount'] = CRM_Utils_Array::value('total_amount', $this->_params,
       CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType', $this->_memType, 'minimum_fee')
     );
-    $this->_membershipId = $this->_id;
     $customFieldsFormatted = CRM_Core_BAO_CustomField::postProcess($this->_params,
-      $this->_id,
+      $this->getMembershipID(),
       'Membership'
     );
     if (empty($this->_params['financial_type_id'])) {
@@ -580,7 +579,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     $pending = ($this->_params['contribution_status_id'] == CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending'));
 
     $membershipParams = [
-      'id' => $this->_membershipId,
+      'id' => $this->getMembershipID(),
       'membership_type_id' => $this->_params['membership_type_id'][1],
       'modified_id' => $this->_contactID,
       'custom' => $customFieldsFormatted,
@@ -660,7 +659,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
         $customFields["custom_{$k}"] = $field;
       }
     }
-    $members = [['member_id', '=', $this->_membershipId, 0, 0]];
+    $members = [['member_id', '=', $this->getMembershipID(), 0, 0]];
     // check whether its a test drive
     if ($this->_mode === 'test') {
       $members[] = ['member_test', '=', 1, 0, 0];
@@ -705,7 +704,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
           'receiptText' => $this->getSubmittedValue('receipt_text'),
           'contactID' => $this->_receiptContactId,
           'contributionID' => $this->getContributionID(),
-          'membershipID' => $this->_membershipId,
+          'membershipID' => $this->getMembershipID(),
         ],
       ]
     );

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -536,6 +536,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $form->buildForm();
     $form->postProcess();
     $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_individualId]);
+    $this->assertEquals($form->getMembershipID(), $membership['id']);
     $membershipEndYear = date('Y') + 1;
     if (date('m-d') === '12-31') {
       // If you join on Dec 31, then the first term would end right away, so


### PR DESCRIPTION

Overview
----------------------------------------
php8.2 stop using yet-another undeclared property for _membershipId.

CRM_Member_Form_MembershipRenewalTest::testSubmitPayLater
Creation of dynamic property CRM_Member_Form_MembershipRenewal::$_membershipId is deprecated

Instead follow our new practice of having consistent (externally supported) functions for getting the main id variables

Before
----------------------------------------
`_membershipId` set as a duplicate of `id`

After
----------------------------------------
The one 'right' way to access is `getMembershipID()`

Technical Details
----------------------------------------

Comments
----------------------------------------
