### PR TITLE
dev/core#4567 Make civicrm_mailing_event_queue.job_id changeable for verp purposes

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -443,22 +443,22 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
         }
 
         $params[] = [
-          $this->id,
-          $recipients->email_id,
-          $recipients->contact_id,
-          $recipients->phone_id,
+          'job_id' => $this->id,
+          'email_id' => $recipients->email_id,
+          'contact_id' => $recipients->contact_id,
+          'phone_id' => $recipients->phone_id,
         ];
         $count++;
         // dev/core#1768 Mail sync interval is now configurable.
         if ($count % $mail_sync_interval == 0) {
-          CRM_Mailing_Event_BAO_MailingEventQueue::bulkCreate($params, $now);
+          CRM_Mailing_Event_BAO_MailingEventQueue::bulkCreate($params);
           $count = 0;
           $params = [];
         }
       }
 
       if (!empty($params)) {
-        CRM_Mailing_Event_BAO_MailingEventQueue::bulkCreate($params, $now);
+        CRM_Mailing_Event_BAO_MailingEventQueue::bulkCreate($params);
       }
     }
   }

--- a/CRM/Mailing/Event/BAO/MailingEventBounce.php
+++ b/CRM/Mailing/Event/BAO/MailingEventBounce.php
@@ -24,7 +24,7 @@ class CRM_Mailing_Event_BAO_MailingEventBounce extends CRM_Mailing_Event_DAO_Mai
    * @return bool|null
    */
   public static function recordBounce(&$params) {
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($params['job_id'] ?? NULL,
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL,
       $params['event_queue_id'] ?? NULL,
       $params['hash'] ?? NULL
     );

--- a/CRM/Mailing/Event/BAO/MailingEventDelivered.php
+++ b/CRM/Mailing/Event/BAO/MailingEventDelivered.php
@@ -25,7 +25,7 @@ class CRM_Mailing_Event_BAO_MailingEventDelivered extends CRM_Mailing_Event_DAO_
    * @return \CRM_Mailing_Event_BAO_MailingEventDelivered
    */
   public static function recordDelivery(&$params) {
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($params['job_id'],
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL,
       $params['event_queue_id'],
       $params['hash']
     );

--- a/CRM/Mailing/Event/BAO/MailingEventForward.php
+++ b/CRM/Mailing/Event/BAO/MailingEventForward.php
@@ -29,7 +29,7 @@ class CRM_Mailing_Event_BAO_MailingEventForward extends CRM_Mailing_Event_DAO_Ma
    * @return bool
    */
   public static function &forward($job_id, $queue_id, $hash, $forward_email, $fromEmail = NULL, $comment = NULL) {
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
 
     $successfulForward = FALSE;
     $contact_id = NULL;

--- a/CRM/Mailing/Event/BAO/MailingEventReply.php
+++ b/CRM/Mailing/Event/BAO/MailingEventReply.php
@@ -39,7 +39,7 @@ class CRM_Mailing_Event_BAO_MailingEventReply extends CRM_Mailing_Event_DAO_Mail
    */
   public static function &reply($job_id, $queue_id, $hash, $replyto = NULL) {
     // First make sure there's a matching queue event.
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
 
     $success = NULL;
 

--- a/CRM/Mailing/Event/BAO/MailingEventResubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventResubscribe.php
@@ -40,7 +40,7 @@ class CRM_Mailing_Event_BAO_MailingEventResubscribe {
   public static function &resub_to_mailing($job_id, $queue_id, $hash) {
     // First make sure there's a matching queue event.
 
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
     $success = NULL;
     if (!$q) {
       return $success;

--- a/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
@@ -38,7 +38,7 @@ class CRM_Mailing_Event_BAO_MailingEventUnsubscribe extends CRM_Mailing_Event_DA
    *   Was the contact successfully unsubscribed?
    */
   public static function unsub_from_domain($job_id, $queue_id, $hash) {
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
     if (!$q) {
       return FALSE;
     }
@@ -110,7 +110,7 @@ WHERE  email = %2
   public static function unsub_from_mailing($job_id, $queue_id, $hash, $return = FALSE): ?array {
     // First make sure there's a matching queue event.
 
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
     if (!$q) {
       return NULL;
     }

--- a/CRM/Mailing/Form/ForwardMailing.php
+++ b/CRM/Mailing/Form/ForwardMailing.php
@@ -27,7 +27,7 @@ class CRM_Mailing_Form_ForwardMailing extends CRM_Core_Form {
       $this, NULL
     );
 
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
 
     if ($q == NULL) {
 

--- a/CRM/Mailing/Form/Optout.php
+++ b/CRM/Mailing/Form/Optout.php
@@ -56,7 +56,7 @@ class CRM_Mailing_Form_Optout extends CRM_Core_Form {
     }
 
     // verify that the three numbers above match
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
     if (!$q) {
       CRM_Utils_System::sendResponse(
         new \GuzzleHttp\Psr7\Response(400, [], ts("Invalid request: bad parameters"))

--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -57,7 +57,7 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
     }
 
     // verify that the three numbers above match
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
     if (!$q) {
       CRM_Utils_System::sendResponse(
         new \GuzzleHttp\Psr7\Response(400, [], ts("Invalid request: bad parameters"))

--- a/CRM/Mailing/Page/Common.php
+++ b/CRM/Mailing/Page/Common.php
@@ -38,7 +38,7 @@ class CRM_Mailing_Page_Common extends CRM_Core_Page {
     }
 
     // verify that the three numbers above match
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
     if (!$q) {
       throw new CRM_Core_Exception(ts("There was an error in your request"));
     }

--- a/CRM/Utils/Mail/IncomingMail.php
+++ b/CRM/Utils/Mail/IncomingMail.php
@@ -209,7 +209,7 @@ class CRM_Utils_Mail_IncomingMail {
       [, $this->action, $this->jobID, $this->queueID, $this->hash] = $matches;
     }
     if ($this->isVerp()) {
-      $queue = CRM_Mailing_Event_BAO_MailingEventQueue::verify($this->getJobID(), $this->getQueueID(), $this->getHash());
+      $queue = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $this->getQueueID(), $this->getHash());
       if (!$queue) {
         throw new CRM_Core_Exception('Contact could not be found from civimail response');
       }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4567 Make civicrm_mailing_event_queue.job_id nullable for verp purposes

This is a step towards some of the changes proposed in https://lab.civicrm.org/dev/core/-/issues/4567

The basic ideal is that if civicrm_mailing_event_queue had the additional field/s mailing_id
is_test
The it would be possible to prune data from civicrm_mailing_job (after some field updating & query re-writing).

However, the first step along this path is to make it such that replies could still be handled if the job_id had been nulled out.

This does that by ignoring job_id when checking if the queue_id & hash match, thus loading the record that is being responded to.



Before
----------------------------------------
job_id is required to verify verp addresses & to create hashes

After
----------------------------------------
job_id is not created or used when dealing with replys to mailings or other mailing related actions

Technical Details
----------------------------------------

The queue id is included when creating the hash but to be honest the created hash is no more secure for the inclusion of the email_id or the job_id. I added the SITE_KEY in cos that seemed like the sort of thing we do. Also as @seamuslee001 pointed out md5 is way more hip

Provided the hash & queue_id are not a guessable combo (which I don't think they are) having the job_id only adds illusory extra benefits IMHO



Comments
----------------------------------------
Note that this needs the schema changes to allow pruning - but there is a real world scenario that we can implement this for straight away. 

Basically we have created a new job ids to track each instance of a transactional mailing (thank you letter) (not via the new extension but through some nasty code dating back to civicrm 4.2). As the civicrm_mailing dashboard left joins onto the mailing_job table to get a list of mailings this proliferation of civicrm_mailing_job records makes that query run for ? hours ? days? While I would prefer to truncate all those rows the change to civicrm_mailing_event_queue is not something we can do outside a scheduled outage - but we could re-link our queue entries to a much smaller number of jobs to make the query runable.

The transactional mailing extension (by @jitendrapurohit et al) only creates one job to start with - not the horrible thing we have done - but it would be able to not create a mailing_job record at all one the job record is optional

This does raise the interesting question of whether a civicrm_mailing would be needed for that transaction email - using the verp / bounce tracking system might be a lot lighter weight & perhaps some options for 'track email' just being a check box on the 'send email form' and only the Queue / action records being created. 

`</stream of consciousness ends>`