### PR TITLE
dev/core#4605 - Add yet another guard against failed upgrades

### DIFF
--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -252,7 +252,7 @@ class CRM_Core_Invoke {
         CRM_Utils_System::setTitle($item['title']);
       }
 
-      if (isset($item['breadcrumb']) && empty($item['is_public'])) {
+      if (!CRM_Core_Config::isUpgradeMode() && isset($item['breadcrumb']) && empty($item['is_public'])) {
         CRM_Utils_System::appendBreadCrumb($item['breadcrumb']);
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Don't add breadcrumbs during upgrade since they're pointless during upgrade.

Before
----------------------------------------
Theme rebuild while adding breadcrumbs during upgrade can lead to a crash similar to others where hooks get called and it's looking for files that have been moved to extensions but the extensions aren't installed yet.

After
----------------------------------------
Skip the carbs.

Technical Details
----------------------------------------
See lab ticket https://lab.civicrm.org/dev/core/-/issues/4605

Comments
----------------------------------------
I've only tested on drupal 7. And this only comes up using the UI upgrader.

I don't know how to reproduce this now that https://github.com/civicrm/civicrm-core/pull/27481 has been merged since it addresses a similar cause more generally and also fixes the problem. So this is now intended as an extra guard.