### PR TITLE
PHP8.2 Pass variables rather than co-erce properties when caling `AbstractEditPayment:processBillingAddress`

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -551,12 +551,18 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
    * Note that this function works based on the presence or otherwise of billing fields & can be called regardless of
    * whether they are 'expected' (due to assumptions about the payment processor type or the setting to collect billing
    * for pay later.
+   *
+   * @param int $contactID
+   * @param string $email
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
-  protected function processBillingAddress() {
+  protected function processBillingAddress(int $contactID, string $email): void {
     $fields = [];
 
     $fields['email-Primary'] = 1;
-    $this->_params['email-5'] = $this->_params['email-Primary'] = $this->_contributorEmail;
+    $this->_params['email-5'] = $this->_params['email-Primary'] = $email;
     // now set the values for the billing location.
     foreach (array_keys($this->_fields) as $name) {
       $fields[$name] = 1;
@@ -565,7 +571,7 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
     $fields["address_name-{$this->_bltID}"] = 1;
 
     //ensure we don't over-write the payer's email with the member's email
-    if ($this->_contributorContactID == $this->_contactID) {
+    if ($contactID == $this->_contactID) {
       $fields["email-{$this->_bltID}"] = 1;
     }
 
@@ -582,10 +588,10 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
       }
       //here we are setting up the billing contact - if different from the member they are already created
       // but they will get billing details assigned
-      $addressParams['contact_id'] = $this->_contributorContactID;
+      $addressParams['contact_id'] = $contactID;
       CRM_Contact_BAO_Contact::createProfileContact($addressParams, $fields,
-        $this->_contributorContactID, NULL, NULL,
-        CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $this->_contributorContactID, 'contact_type')
+        $contactID, NULL, NULL,
+        CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactID, 'contact_type')
       );
     }
 

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -314,8 +314,10 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
   public function submit($submittedValues) {
     $this->_params = $submittedValues;
     $this->beginPostProcess();
+    // _contributorContactID may no longer need to be set - setting it here
+    // was for use in processBillingAddress
     $this->_contributorContactID = $this->_contactID;
-    $this->processBillingAddress();
+    $this->processBillingAddress($this->_contactID, (string) $this->_contributorEmail);
     $participantId = NULL;
     if ($this->_component === 'event') {
       $participantId = $this->_id;

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1117,9 +1117,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     $now = date('YmdHis');
 
-    $this->_contributorEmail = $this->getContactValue('email_primary.email');
-    $this->_contributorContactID = $contactID;
-    $this->processBillingAddress();
+    $this->processBillingAddress($contactID, (string) $this->getContactValue('email_primary.email'));
     if (!empty($params['source'])) {
       unset($params['source']);
     }

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -933,7 +933,7 @@ DESC limit 1");
 
     $params = $softParams = [];
 
-    $this->processBillingAddress();
+    $this->processBillingAddress($this->getContributionContactID(), (string) $this->_contributorEmail);
     $formValues = $this->_params;
     $formValues = $this->setPriceSetParameters($formValues);
 

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -485,7 +485,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     $this->beginPostProcess();
     $now = CRM_Utils_Date::getToday(NULL, 'YmdHis');
     $this->assign('receive_date', CRM_Utils_Array::value('receive_date', $this->_params, CRM_Utils_Time::date('Y-m-d H:i:s')));
-    $this->processBillingAddress();
+    $this->processBillingAddress($this->getContributionContactID(), (string) $this->_contributorEmail);
 
     $this->_params['total_amount'] = CRM_Utils_Array::value('total_amount', $this->_params,
       CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType', $this->_memType, 'minimum_fee')


### PR DESCRIPTION
Overview
----------------------------------------
PHP8.2 Pass variables rather than co-erce properties when caling `AbstractEditPayment:processBillingAddress`

Before
----------------------------------------
Anti-pattern of setting properties in order to pass them to the (protected) function

![image](https://github.com/civicrm/civicrm-core/assets/336308/24394f2a-05c4-4ad9-95dc-84371c898f8c)


After
----------------------------------------
variables passed to the function. Property setting removed from the one form I looked more closely at

Technical Details
----------------------------------------

Comments
----------------------------------------
