### PR TITLE
dev/core#4605 - Add yet another guard against failed upgrades

### DIFF
--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -249,7 +249,7 @@ class CRM_Core_Invoke {
         CRM_Utils_System::setTitle($item['title']);
       }
 
-      if (isset($item['breadcrumb']) && empty($item['is_public'])) {
+      if (!CRM_Core_Config::isUpgradeMode() && isset($item['breadcrumb']) && empty($item['is_public'])) {
         CRM_Utils_System::appendBreadCrumb($item['breadcrumb']);
       }
 


### PR DESCRIPTION
Backport #27518 from 5.66-rc to 5.65-stable.

(I'm the fence about whether we should have it on 5.65; but since 5.65 will go out soon, I want the tests to start running regardless. ping @demeritcowboy)