### PR TITLE
Remove spaces around curly braces to prepare for Smarty 3+

### DIFF
--- a/ext/civigrant/templates/CRM/Grant/Form/Grant.tpl
+++ b/ext/civigrant/templates/CRM/Grant/Form/Grant.tpl
@@ -16,7 +16,7 @@
          {ts}Are you sure you want to delete this Grant?{/ts} {ts}This action cannot be undone.{/ts}</p>
          <p>{include file="CRM/Grant/Form/Task.tpl"}</p>
      </div>
-  {elseif $action eq 4 }
+  {elseif $action eq 4}
       {include file="CRM/Grant/Form/GrantView.tpl"}
   {else}
      <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>

--- a/ext/civigrant/templates/CRM/Grant/Form/Selector.tpl
+++ b/ext/civigrant/templates/CRM/Grant/Form/Selector.tpl
@@ -15,7 +15,7 @@
 <table class="selector row-highlight">
   <thead class="sticky">
   <tr>
-  {if ! $single and $context eq 'Search' }
+  {if ! $single and $context eq 'Search'}
      <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
   {/if}
   {foreach from=$columnHeaders item=header}
@@ -35,8 +35,8 @@
   {foreach from=$rows item=row}
   <tr id='crm-grant_{$row.grant_id}' class="{cycle values="odd-row,even-row"} crm-grant crm-grant_status-{$row.grant_status_id}">
 
-  {if !$single }
-     {if $context eq 'Search' }
+  {if !$single}
+     {if $context eq 'Search'}
         {assign var=cbName value=$row.checkbox}
         <td>{$form.$cbName.html}</td>
      {/if}

--- a/ext/civigrant/templates/CRM/Grant/Form/Task.tpl
+++ b/ext/civigrant/templates/CRM/Grant/Form/Task.tpl
@@ -10,7 +10,7 @@
 {if $totalSelectedGrants}
     {ts 1=$totalSelectedGrants}Number of selected grants: %1{/ts}
 {/if}
-{if $rows }
+{if $rows}
 <div class="form-item">
 <table width="30%">
   <tr class="columnheader">

--- a/ext/civigrant/templates/CRM/Grant/Form/Task/Print.tpl
+++ b/ext/civigrant/templates/CRM/Grant/Form/Task/Print.tpl
@@ -9,7 +9,7 @@
 *}
 <p>
 
-{if $rows }
+{if $rows}
 <div class="crm-submit-buttons element-right">{$form.buttons.html}</div>
 <div class="spacer"></div>
 <br />

--- a/ext/civigrant/templates/CRM/Grant/Page/DashBoard.tpl
+++ b/ext/civigrant/templates/CRM/Grant/Page/DashBoard.tpl
@@ -10,7 +10,7 @@
 {* CiviGrant DashBoard (launch page) *}
 <div class="help">
     {capture assign=findContactURL}{crmURL p="civicrm/contact/search/basic" q="reset=1"}{/capture}
-    <p>{ts 1=$findContactURL }CiviGrant allows you to input and track grants to Organizations, Individuals or Households. The grantee must first be entered as a contact in CiviCRM. Use <a href='%1'>Find Contacts</a> to see if there's already a record for the grantee. Once you've located or created the contact record, click <strong>View</strong> to go to their summary page, select the <strong>Grants</strong> tab and click <strong>New Grant</strong>.{/ts}
+    <p>{ts 1=$findContactURL}CiviGrant allows you to input and track grants to Organizations, Individuals or Households. The grantee must first be entered as a contact in CiviCRM. Use <a href='%1'>Find Contacts</a> to see if there's already a record for the grantee. Once you've located or created the contact record, click <strong>View</strong> to go to their summary page, select the <strong>Grants</strong> tab and click <strong>New Grant</strong>.{/ts}
     </p>
 </div>
 <h3>{ts}Grants Summary{/ts}</h3>

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/ActivitySearch.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/ActivitySearch.tpl
@@ -60,8 +60,8 @@
               <thead class="sticky">
                 <th scope="col" title="Select All Rows">{$form.toggleSelect.html}</th>
                 {foreach from=$columnHeaders item=header}
-                  {if ($header.sort eq 'activity_id') or ($header.sort eq 'case_id') }
-                  {elseif ($header.sort eq 'sort_name') or ($header.sort eq 'activity_status_id') or ($header.sort eq 'activity_type_id') or ($header.sort eq 'activity_subject') or ($header.sort eq 'source_contact') or ($header.SORT eq 'activity_date') or ($header.name eq null) }
+                  {if ($header.sort eq 'activity_id') or ($header.sort eq 'case_id')}
+                  {elseif ($header.sort eq 'sort_name') or ($header.sort eq 'activity_status_id') or ($header.sort eq 'activity_type_id') or ($header.sort eq 'activity_subject') or ($header.sort eq 'source_contact') or ($header.SORT eq 'activity_date') or ($header.name eq null)}
                     <th scope="col">
                       {if $header.sort}
                         {assign var='key' value=$header.sort}
@@ -81,13 +81,13 @@
                   {assign var=cbName value=$row.checkbox}
                   <td>{$form.$cbName.html}</td>
                   {foreach from=$columnHeaders item=header}
-                    {if ($header.sort eq 'sort_name') or ($header.sort eq 'activity_status_id') or ($header.sort eq 'activity_type_id') or ($header.sort eq 'activity_subject') or ($header.sort eq 'source_contact') or ($header.SORT eq 'activity_date') or ($header.name eq null) }
+                    {if ($header.sort eq 'sort_name') or ($header.sort eq 'activity_status_id') or ($header.sort eq 'activity_type_id') or ($header.sort eq 'activity_subject') or ($header.sort eq 'source_contact') or ($header.SORT eq 'activity_date') or ($header.name eq null)}
                       {assign var=fName value=$header.sort}
                       {if $fName eq 'sort_name'}
                          <td><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`&key=`$qfKey`"}">{$row.sort_name}</a></td>
                       {elseif $fName eq 'activity_subject'}
                          <td>
-                           {if $row.case_id }
+                           {if $row.case_id}
                               <a href="{crmURL p='civicrm/case/activity/view' q="reset=1&aid=`$row.activity_id`&cid=`$row.contact_id`&caseID=`$row.case_id`"}" title="{ts}View activity details{/ts}">
                            {else}
                               <a href="{crmURL p='civicrm/contact/view/activity' q="atype=`$row.activity_type_id`&action=view&reset=1&id=`$row.activity_id`&cid=`$row.contact_id`"}" title="{ts}View activity details{/ts}">

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/FullText.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/FullText.tpl
@@ -37,7 +37,7 @@
 {* @TODO: This is confusing - the variable `table` is already set and used above, and now we set it again to something that is technically different but has the same value, except on a blank form where it doesn't exist, but effectively then is the same value that it already has which is ''. So do we need this line even? *}
 {if $form.table.value && (array_key_exists(0, $form.table.value))}{assign var=table value=$form.table.value.0}{/if}
 {assign var=text  value=$form.text.value}
-{if !empty($summary.Contact) }
+{if !empty($summary.Contact)}
   <div class="section">
     {* Search request has returned 1 or more matching rows. Display results. *}
     <h3>{ts}Contacts{/ts}
@@ -75,7 +75,7 @@
   </div>
 {/if}
 
-{if !empty($summary.Activity) }
+{if !empty($summary.Activity)}
   <div class="section">
     {* Search request has returned 1 or more matching rows. Display results. *}
 
@@ -115,7 +115,7 @@
             </td>
             {if $allowFileSearch}<td>{$row.fileHtml}</td>{/if}
             <td>
-              {if $row.case_id }
+              {if $row.case_id}
                 <a href="{crmURL p='civicrm/case/activity/view'
                 q="reset=1&aid=`$row.activity_id`&cid=`$row.client_id`&caseID=`$row.case_id`&context=fulltext&key=`$qfKey`"}">
               {else}
@@ -138,7 +138,7 @@
   </div>
 {/if}
 
-{if !empty($summary.Case) }
+{if !empty($summary.Case)}
   <div class="section">
     {* Search request has returned 1 or more matching rows. Display results. *}
     <h3>{ts}Cases{/ts}
@@ -195,7 +195,7 @@
   </div>
 {/if}
 
-{if !empty($summary.Contribution) }
+{if !empty($summary.Contribution)}
   <div class="section">
     {* Search request has returned 1 or more matching rows. Display results. *}
 
@@ -249,7 +249,7 @@
   </div>
 {/if}
 
-{if !empty($summary.Participant) }
+{if !empty($summary.Participant)}
   <div class="section">
     {* Search request has returned 1 or more matching rows. *}
 
@@ -305,7 +305,7 @@
   </div>
 {/if}
 
-{if !empty($summary.Membership) }
+{if !empty($summary.Membership)}
   <div class="section">
     {* Search request has returned 1 or more matching rows. *}
 
@@ -362,7 +362,7 @@
   </div>
 {/if}
 
-{if !empty($summary.File) }
+{if !empty($summary.File)}
 <div class="section">
 {* Search request has returned 1 or more matching rows. *}
 

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -11,7 +11,7 @@
   {if $action eq 4}
     <div class="crm-block crm-content-block crm-activity-view-block">
   {else}
-    {if $activityTypeDescription }
+    {if $activityTypeDescription}
       <div class="help">{$activityTypeDescription}</div>
     {/if}
     <div class="crm-block crm-form-block crm-activity-form-block">
@@ -28,7 +28,7 @@
   <table class="{if $action eq 4}crm-info-panel{else}form-layout{/if}">
 
   {if $action eq 4}
-    {if $activityTypeDescription }
+    {if $activityTypeDescription}
     <div class="help">{$activityTypeDescription}</div>
     {/if}
   {else}
@@ -147,7 +147,7 @@
   <tr class="crm-activity-form-block-priority_id">
     <td class="label">{$form.priority_id.label}</td><td class="view-value">{$form.priority_id.html}</td>
   </tr>
-  {if !empty($surveyActivity) }
+  {if !empty($surveyActivity)}
   <tr class="crm-activity-form-block-result">
     <td class="label">{$form.result.label}</td><td class="view-value">{$form.result.html}</td>
   </tr>
@@ -232,7 +232,7 @@
   </table>
   <div class="crm-submit-buttons">
   {if $action eq 4 && ($activityTypeNameAndLabel.machineName neq 'Inbound Email' || $allow_edit_inbound_emails == 1)}
-    {if !$context }
+    {if !$context}
       {assign var="context" value='activity'}
     {/if}
     {if $permission EQ 'edit'}

--- a/templates/CRM/Activity/Form/ActivityView.tpl
+++ b/templates/CRM/Activity/Form/ActivityView.tpl
@@ -41,7 +41,7 @@
   {/if}
 
         <tr>
-            <td class="label">{ts}Date and Time{/ts}</td><td class="view-value">{$values.activity_date_time|crmDate }</td>
+            <td class="label">{ts}Date and Time{/ts}</td><td class="view-value">{$values.activity_date_time|crmDate}</td>
         </tr>
         {if (array_key_exists('mailingId', $values) && $values.mailingId)}
             <tr>

--- a/templates/CRM/Activity/Form/Search.tpl
+++ b/templates/CRM/Activity/Form/Search.tpl
@@ -44,7 +44,7 @@
   </div>
 </div>
 
-{if $rowsEmpty || $rows }
+{if $rowsEmpty || $rows}
   <div class="crm-content-block">
     {if $rowsEmpty}
       <div class="crm-results-block crm-results-block-empty">

--- a/templates/CRM/Activity/Form/Selector.tpl
+++ b/templates/CRM/Activity/Form/Selector.tpl
@@ -16,7 +16,7 @@
 <table class="selector row-highlight">
    <thead class="sticky">
      <tr>
-       {if !$single and $context eq 'Search' }
+       {if !$single and $context eq 'Search'}
           <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
        {/if}
        {foreach from=$columnHeaders item=header}
@@ -38,8 +38,8 @@
   {counter start=0 skip=1 print=false}
   {foreach from=$rows item=row}
   <tr id='rowid{$row.activity_id}' class="{cycle values="odd-row,even-row"}{if !empty($row.class)} {$row.class}{/if}">
-  {if !$single }
-        {if $context eq 'Search' }
+  {if !$single}
+        {if $context eq 'Search'}
           {assign var=cbName value=$row.checkbox}
           <td>{$form.$cbName.html}</td>
      {/if}

--- a/templates/CRM/Activity/Form/Task.tpl
+++ b/templates/CRM/Activity/Form/Task.tpl
@@ -9,7 +9,7 @@
 *}
 {ts 1=$totalSelectedActivities}Number of selected Activities: %1{/ts}
 
-{if $rows }
+{if $rows}
 <div class="form-item">
 <table width="30%">
   <tr class="columnheader">

--- a/templates/CRM/Activity/Form/Task/Print.tpl
+++ b/templates/CRM/Activity/Form/Task/Print.tpl
@@ -9,7 +9,7 @@
 *}
 <div class="crm-block crm-activity_task_print-form-block">
 <p>
-{if $rows }
+{if $rows}
 <div class="crm-submit-buttons element-right">
   {include file="CRM/common/formButtons.tpl" location="top"}
 </div>

--- a/templates/CRM/Admin/Form/ContactType.tpl
+++ b/templates/CRM/Admin/Form/ContactType.tpl
@@ -19,7 +19,7 @@
    <tr class="crm-contact-type-form-block-label">
       <td class="label">{$form.label.label}
       {if $action eq 2}
-        {include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_contact_type' field='label' id= $cid }
+        {include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_contact_type' field='label' id= $cid}
       {/if}
       </td>
       <td>{$form.label.html}</td>

--- a/templates/CRM/Admin/Form/LabelFormats.tpl
+++ b/templates/CRM/Admin/Form/LabelFormats.tpl
@@ -120,7 +120,7 @@
     selectPaper(document.getElementById('paper_size').value);
 
     function selectPaper(val) {
-      dataUrl = {/literal}"{crmURL p='civicrm/ajax/paperSize' h=0 }"{literal};
+      dataUrl = {/literal}"{crmURL p='civicrm/ajax/paperSize' h=0}"{literal};
       cj.post(dataUrl, {paperSizeName: val}, function (data) {
         cj("#paper_size").val(data.name);
         metric = document.getElementById('metric').value;

--- a/templates/CRM/Admin/Form/Mapping.tpl
+++ b/templates/CRM/Admin/Form/Mapping.tpl
@@ -9,7 +9,7 @@
 *}
 {* this template is used for adding/editing a saved mapping *}
 <div class="crm-block crm-form-block crm-mapping-form-block">
-    {if $action eq 1 or $action eq 2 }
+    {if $action eq 1 or $action eq 2}
       <table class="form-layout-compressed">
        <tr class="crm-mapping-form-block-name">
           <td class="label">{$form.name.label}</td>

--- a/templates/CRM/Admin/Form/PdfFormats.tpl
+++ b/templates/CRM/Admin/Form/PdfFormats.tpl
@@ -74,7 +74,7 @@ selectPaper( document.getElementById('paper_size').value );
 
 function selectPaper( val )
 {
-    dataUrl = {/literal}"{crmURL p='civicrm/ajax/paperSize' h=0 }"{literal};
+    dataUrl = {/literal}"{crmURL p='civicrm/ajax/paperSize' h=0}"{literal};
     cj.post( dataUrl, {paperSizeName: val}, function( data ) {
         cj("#paper_size").val( data.name );
         metric = document.getElementById('metric').value;

--- a/templates/CRM/Admin/Page/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Page/MessageTemplates.tpl
@@ -111,7 +111,7 @@
             </div>
             <div class="spacer"></div>
           {/if}
-            {if !empty( $template_row) }
+            {if !empty( $template_row)}
               <table class="display">
                 <thead>
                   <tr>
@@ -145,7 +145,7 @@
               <div class="spacer"></div>
             {/if}
 
-            {if empty( $template_row) }
+            {if empty( $template_row)}
                 <div class="messages status no-popup">
                     {icon icon="fa-info-circle"}{/icon}
                     {ts 1=$crmURL}There are no User-driven Message Templates entered. You can <a href='%1'>add one</a>.{/ts}

--- a/templates/CRM/Batch/Form/Entry.tpl
+++ b/templates/CRM/Batch/Form/Entry.tpl
@@ -95,7 +95,7 @@
           {elseif $n eq 'total_amount'}
              <div class="compressed crm-grid-cell">
                {$form.field.$rowNumber.$n.html}
-               {if $batchType eq 3 }
+               {if $batchType eq 3}
 		 {ts}<span id={$rowNumber} class="pledge-adjust-option"><a href='#'>adjust payment amount</a></span>{/ts}
                  <span id="adjust-select-{$rowNumber}" class="adjust-selectbox">{$form.option_type.$rowNumber.html}</span>
                {/if}
@@ -155,7 +155,7 @@ CRM.$(function($) {
     calculateActualTotal();
   });
 
-  {/literal}{if $batchType eq 1 }{literal}
+  {/literal}{if $batchType eq 1}{literal}
   // hide all dates if send receipt is checked
   hideSendReceipt();
 

--- a/templates/CRM/Campaign/Form/Gotv.tpl
+++ b/templates/CRM/Campaign/Form/Gotv.tpl
@@ -106,7 +106,7 @@
 
   function loadVoterList( )
   {
-    var sourceUrl = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q='snippet=4&className=CRM_Campaign_Page_AJAX&fnName=voterList' }"{literal};
+    var sourceUrl = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q='snippet=4&className=CRM_Campaign_Page_AJAX&fnName=voterList'}"{literal};
 
     var searchVoterFor = {/literal}'{$searchVoterFor}'{literal};
     CRM.$( 'table.gotvVoterRecords', 'form.{/literal}{$form.formClass}{literal}').dataTable({

--- a/templates/CRM/Campaign/Form/Petition/Signature.tpl
+++ b/templates/CRM/Campaign/Form/Petition/Signature.tpl
@@ -15,7 +15,7 @@
 {/literal}
 </script>
 
-{if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCampaign') }
+{if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCampaign')}
   {capture assign="buttonTitle"}{ts}Edit Petition{/ts}{/capture}
   {crmButton target="_blank" p="civicrm/petition/add" q="reset=1&action=update&id=`$petition.id`" fb=1 title="$buttonTitle" icon="fa-wrench"}{ts}Configure{/ts}{/crmButton}
   <div class='clear'></div>

--- a/templates/CRM/Campaign/Form/ResultOptions.tpl
+++ b/templates/CRM/Campaign/Form/ResultOptions.tpl
@@ -118,7 +118,7 @@
             return false;
         }
 
-       var dataUrl = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q='className=CRM_Campaign_Page_AJAX&fnName=loadOptionGroupDetails' }"{literal}
+       var dataUrl = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q='className=CRM_Campaign_Page_AJAX&fnName=loadOptionGroupDetails'}"{literal}
 
       // build new options
       cj.post( dataUrl, data, function( opGroup ) {

--- a/templates/CRM/Campaign/Form/Search/Campaign.tpl
+++ b/templates/CRM/Campaign/Form/Search/Campaign.tpl
@@ -144,7 +144,7 @@
   };
 
   window.loadCampaignList = function() {
-    var sourceUrl = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q='snippet=4&className=CRM_Campaign_Page_AJAX&fnName=campaignList' }"{literal};
+    var sourceUrl = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q='snippet=4&className=CRM_Campaign_Page_AJAX&fnName=campaignList'}"{literal};
 
     //build the search qill.
     //get the search criteria.

--- a/templates/CRM/Campaign/Form/Search/Petition.tpl
+++ b/templates/CRM/Campaign/Form/Search/Petition.tpl
@@ -136,7 +136,7 @@ function searchPetitions( qfKey )
 
 function loadPetitionList( )
 {
-     var sourceUrl = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q='snippet=4&className=CRM_Campaign_Page_AJAX&fnName=petitionList' }"{literal};
+     var sourceUrl = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q='snippet=4&className=CRM_Campaign_Page_AJAX&fnName=petitionList'}"{literal};
 
      //build the search qill.
      //get the search criteria.

--- a/templates/CRM/Campaign/Form/Search/Survey.tpl
+++ b/templates/CRM/Campaign/Form/Search/Survey.tpl
@@ -144,7 +144,7 @@ function searchSurveys( qfKey )
 
 function loadSurveyList( )
 {
-     var sourceUrl = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q='snippet=4&className=CRM_Campaign_Page_AJAX&fnName=surveyList' }"{literal};
+     var sourceUrl = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q='snippet=4&className=CRM_Campaign_Page_AJAX&fnName=surveyList'}"{literal};
 
      //build the search qill.
      //get the search criteria.
@@ -254,7 +254,7 @@ function displayResultSet( surveyId, surveyTitle, OptionGroupId ) {
   data['option_group_id'] = OptionGroupId;
   data['survey_id']       = surveyId;
 
-  var dataUrl  = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q='className=CRM_Campaign_Page_AJAX&fnName=loadOptionGroupDetails' }"{literal};
+  var dataUrl  = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q='className=CRM_Campaign_Page_AJAX&fnName=loadOptionGroupDetails'}"{literal};
   var content  = '<tr><th>{/literal}{ts escape='js'}Label{/ts}{literal}</th><th>{/literal}{ts escape='js'}Value{/ts}{literal}</th><th>{/literal}{ts escape='js'}Recontact Interval{/ts}{literal}</th><th>{/literal}{ts escape='js'}Order{/ts}{literal}</th></tr>';
   var setTitle = '{/literal}{ts escape='js'}Result Set for{/ts} {literal}' + surveyTitle;
 

--- a/templates/CRM/Campaign/Form/Selector.tpl
+++ b/templates/CRM/Campaign/Form/Selector.tpl
@@ -15,7 +15,7 @@
 <table class="selector row-highlight">
   <thead class="sticky">
   <tr>
-    {if !$single and $context eq 'Search' }
+    {if !$single and $context eq 'Search'}
         <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
     {/if}
     <th scope="col"></th>
@@ -36,8 +36,8 @@
   {counter start=0 skip=1 print=false}
   {foreach from=$rows item=row}
   <tr id='rowid{$row.contact_id}' class="{cycle values="odd-row,even-row"} crm-campaign">
-    {if !$single }
-        {if $context eq 'Search' }
+    {if !$single}
+        {if $context eq 'Search'}
           {assign var=cbName value=$row.checkbox}
           <td>{$form.$cbName.html}</td>
    {/if}

--- a/templates/CRM/Campaign/Form/SurveyType.tpl
+++ b/templates/CRM/Campaign/Form/SurveyType.tpl
@@ -1,1 +1,1 @@
-{include file="CRM/Admin/Form/Options.tpl" }
+{include file="CRM/Admin/Form/Options.tpl"}

--- a/templates/CRM/Campaign/Form/Task/Print.tpl
+++ b/templates/CRM/Campaign/Form/Task/Print.tpl
@@ -11,7 +11,7 @@
      <span class="element-right">{$form.buttons.html}</span>
 </div>
 
-{if $rows }
+{if $rows}
 <p></p>
 {include file="CRM/Campaign/Form/Selector.tpl"}
 

--- a/templates/CRM/Campaign/Page/SurveyType.tpl
+++ b/templates/CRM/Campaign/Page/SurveyType.tpl
@@ -1,6 +1,6 @@
 <div class="crm-content-block crm-block">
-{if ($action eq 1) or ($action eq 2) or ($action eq 8) }
-  {include file="CRM/Campaign/Form/SurveyType.tpl" }
+{if ($action eq 1) or ($action eq 2) or ($action eq 8)}
+  {include file="CRM/Campaign/Form/SurveyType.tpl"}
 {else}
 {if $rows}
 <div class="action-link">

--- a/templates/CRM/Case/Form/Activity.tpl
+++ b/templates/CRM/Case/Form/Activity.tpl
@@ -10,7 +10,7 @@
 
 {* this template is used for adding/editing activities for a case. *}
 <div class="crm-block crm-form-block crm-case-activity-form-block">
-  {if $action eq 8 or $action eq 32768 }
+  {if $action eq 8 or $action eq 32768}
   <div class="messages status no-popup">
     <i class="crm-i fa-info-circle" aria-hidden="true"></i> &nbsp;
     {if $action eq 8}
@@ -23,7 +23,7 @@
   </div><br />
   {else}
   <table class="form-layout">
-    {if $activityTypeDescription }
+    {if $activityTypeDescription}
       <tr>
         <div class="help">{$activityTypeDescription}</div>
       </tr>

--- a/templates/CRM/Case/Form/ActivityToCase.tpl
+++ b/templates/CRM/Case/Form/ActivityToCase.tpl
@@ -59,13 +59,13 @@
         subject = $("#file_on_case_activity_subject").val(),
         targetContactId = $("#file_on_case_target_contact_id").val();
 
-      var postUrl = {/literal}"{crmURL p='civicrm/ajax/activity/convert' h=0 }"{literal};
+      var postUrl = {/literal}"{crmURL p='civicrm/ajax/activity/convert' h=0}"{literal};
       $.post( postUrl, { activityID: activityID, caseID: selectedCaseId, contactID: contactId, newSubject: subject, targetContactIds: targetContactId, mode: action, key: {/literal}"{crmKey name='civicrm/ajax/activity/convert'}"{literal} },
         function( values ) {
           if ( values.error_msg ) {
             $().crmError(values.error_msg, "{/literal}{ts escape='js'}Unable to file on case.{/ts}{literal}");
           } else {
-            var destUrl = {/literal}"{crmURL p='civicrm/contact/view/case' q='reset=1&action=view&id=' h=0 }"{literal};
+            var destUrl = {/literal}"{crmURL p='civicrm/contact/view/case' q='reset=1&action=view&id=' h=0}"{literal};
             var context = '';
             {/literal}{if !empty($fulltext)}{literal}
             context = '&context={/literal}{$fulltext}{literal}';

--- a/templates/CRM/Case/Form/Case.tpl
+++ b/templates/CRM/Case/Form/Case.tpl
@@ -14,7 +14,7 @@
 <div class="crm-block crm-form-block crm-case-form-block">
 
 <h3>{if $action eq 8}{ts}Delete Case{/ts}{elseif $action eq 32768}{ts}Restore Case{/ts}{/if}</h3>
-{if $action eq 8 or $action eq 32768 }
+{if $action eq 8 or $action eq 32768}
       <div class="messages status no-popup">
         {icon icon="fa-info-circle"}{/icon}
           {if $action eq 8}
@@ -25,7 +25,7 @@
       </div>
 {else}
 <table class="form-layout">
-    {if $activityTypeDescription }
+    {if $activityTypeDescription}
         <tr>
             <div class="help">{$activityTypeDescription}</div>
         </tr>

--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -309,7 +309,7 @@
      </p>
    {/foreach}
 
-   {if !$tags && !$tagSetTags }
+   {if !$tags && !$tagSetTags}
      <div class="status">
        {ts}There are no tags currently assigned to this case.{/ts}
      </div>

--- a/templates/CRM/Case/Form/Search/Common.tpl
+++ b/templates/CRM/Case/Form/Search/Common.tpl
@@ -25,7 +25,7 @@
     {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="case_start_date" to='' from='' colspan='' class ='' hideRelativeLabel=0}
   </tr>
   <tr>
-    {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="case_end_date" to='' from='' colspan='' class ='' hideRelativeLabel=0 }
+    {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="case_end_date" to='' from='' colspan='' class ='' hideRelativeLabel=0}
   </tr>
 
   <tr id='case_search_form'>

--- a/templates/CRM/Case/Form/Selector.tpl
+++ b/templates/CRM/Case/Form/Selector.tpl
@@ -12,7 +12,7 @@
 <table class="caseSelector row-highlight">
   <tr class="columnheader">
 
-  {if ! $single and $context eq 'Search' }
+  {if ! $single and $context eq 'Search'}
     <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
   {/if}
 
@@ -59,7 +59,7 @@
   {/foreach}
 
     {* Dashboard only lists 10 most recent cases. *}
-    {if $context EQ 'dashboard' and $limit and $pager->_totalItems GT $limit }
+    {if $context EQ 'dashboard' and $limit and $pager->_totalItems GT $limit}
       <tr class="even-row">
         <td colspan="10"><a href="{crmURL p='civicrm/case/search' q='reset=1'}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Find more cases{/ts}... </a></td>
       </tr>

--- a/templates/CRM/Case/Form/Task.tpl
+++ b/templates/CRM/Case/Form/Task.tpl
@@ -9,7 +9,7 @@
 *}
 {ts 1=$totalSelectedCases}Number of selected cases: %1{/ts}
 
-{if $rows }
+{if $rows}
 <div class="crm-block-crm-form-block crm-case-task-form-block">
 <table width="30%">
   <tr class="columnheader">

--- a/templates/CRM/Case/Form/Task/Print.tpl
+++ b/templates/CRM/Case/Form/Task/Print.tpl
@@ -9,7 +9,7 @@
 *}
 <p>
 
-{if $rows }
+{if $rows}
 <div class="crm-submit-buttons">
      <span class="element-right">{include file="CRM/common/formButtons.tpl" location="top"}</span>
 </div>

--- a/templates/CRM/Case/Page/Tab.tpl
+++ b/templates/CRM/Case/Page/Tab.tpl
@@ -25,7 +25,7 @@
 
     {capture assign=newCaseURL}{crmURL p="civicrm/case/add" q="reset=1&action=add&cid=`$contactId`&context=case"}{/capture}
 
-    {if $action eq 1 or $action eq 2 or $action eq 8 or $action eq 32768 } {* add, update, delete, restore*}
+    {if $action eq 1 or $action eq 2 or $action eq 8 or $action eq 32768} {* add, update, delete, restore*}
         {include file="CRM/Case/Form/Case.tpl"}
     {elseif $action eq 4 }
         {include file="CRM/Case/Form/CaseView.tpl"}

--- a/templates/CRM/Contact/Form/Contact.tpl
+++ b/templates/CRM/Contact/Form/Contact.tpl
@@ -15,7 +15,7 @@
     {include file="CRM/Contact/Form/Edit/Lock.tpl"}
   {/if}
   <div class="crm-form-block crm-search-form-block">
-    {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM') }
+    {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM')}
       <a href='{crmURL p="civicrm/admin/setting/preferences/display" q="reset=1"}' title="{ts}Click here to configure the panes.{/ts}"><i class="crm-i fa-wrench" aria-hidden="true"></i></a>
     {/if}
     <span style="float:right;"><a href="#expand" id="expand">{ts}Expand all tabs{/ts}</a></span>
@@ -77,7 +77,7 @@
     </div><!-- /.crm-accordion-wrapper -->
 
     {foreach from = $editOptions item = "title" key="name"}
-      {if $name eq 'CustomData' }
+      {if $name eq 'CustomData'}
         <div id='customData'>{include file="CRM/Contact/Form/Edit/CustomData.tpl" isSingleRecordEdit=false}</div>
       {else}
         {include file="CRM/Contact/Form/Edit/$name.tpl"}

--- a/templates/CRM/Contact/Form/Edit/Address.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address.tpl
@@ -22,7 +22,7 @@
  <div id="Address_Block_{$blockId}" {if $className eq 'CRM_Contact_Form_Contact'} class="boxBlock crm-edit-address-block crm-address_{$blockId}"{/if}>
   {if $blockId gt 1}<fieldset><legend>{ts}Supplemental Address{/ts}</legend>{/if}
   <table class="form-layout-compressed crm-edit-address-form">
-     {if $masterAddress && $masterAddress.$blockId gt 0 }
+     {if $masterAddress && $masterAddress.$blockId gt 0}
         <tr><td><div class="message status">{icon icon="fa-info-circle"}{/icon} {ts 1=$masterAddress.$blockId}This address is shared with %1 contact record(s). Modifying this address will automatically update the shared address for these contacts.{/ts}</div></td></tr>
      {/if}
 

--- a/templates/CRM/Contact/Form/Inline/Email.tpl
+++ b/templates/CRM/Contact/Form/Inline/Email.tpl
@@ -19,7 +19,7 @@
   </tr>
   <tr>
     <td>{ts}Email{/ts}&nbsp;
-      {if $actualBlockCount lt 5 }
+      {if $actualBlockCount lt 5}
         <span id="add-more-email" title="{ts}click to add more{/ts}">
           <a class="crm-hover-button action-item add-more-inline" href="#">{ts}add{/ts}</a>
         </span>

--- a/templates/CRM/Contact/Form/Inline/IM.tpl
+++ b/templates/CRM/Contact/Form/Inline/IM.tpl
@@ -19,7 +19,7 @@
     </tr>
     <tr>
       <td>{ts}Instant Messenger{/ts}&nbsp;
-      {if $actualBlockCount lt 5 }
+      {if $actualBlockCount lt 5}
         <span id="add-more-im" title="{ts}click to add more{/ts}"><a class="crm-hover-button action-item add-more-inline" href="#">{ts}add{/ts}</a></span>
       {/if}
       </td>

--- a/templates/CRM/Contact/Form/Inline/OpenID.tpl
+++ b/templates/CRM/Contact/Form/Inline/OpenID.tpl
@@ -20,7 +20,7 @@
 
   <tr>
     <td>{ts}Open ID{/ts}&nbsp;
-    {if $actualBlockCount lt 5 }
+    {if $actualBlockCount lt 5}
       <span id="add-more-openid" title="{ts}click to add more{/ts}"><a class="crm-hover-button action-item add-more-inline" href="#">{ts}add{/ts}</a></span>
     {/if}
     </td>

--- a/templates/CRM/Contact/Form/Inline/Phone.tpl
+++ b/templates/CRM/Contact/Form/Inline/Phone.tpl
@@ -19,7 +19,7 @@
     </tr>
     <tr>
       <td>{ts}Phone{/ts}&nbsp;
-      {if $actualBlockCount lt 5 }
+      {if $actualBlockCount lt 5}
         <span id="add-more-phone" title="{ts}click to add more{/ts}"><a class="crm-hover-button action-item add-more-inline" href="#">{ts}add{/ts}</a></span>
       {/if}
       </td>

--- a/templates/CRM/Contact/Form/Inline/Website.tpl
+++ b/templates/CRM/Contact/Form/Inline/Website.tpl
@@ -21,7 +21,7 @@
     <tr>
       <td>{ts}Website{/ts}
         {help id="id-website" file="CRM/Contact/Form/Contact.hlp"}
-        {if $actualBlockCount lt 25 }
+        {if $actualBlockCount lt 25}
           &nbsp;&nbsp;<span id="add-more-website" title="{ts}click to add more{/ts}"><a class="crm-hover-button action-item add-more-inline" href="#">{ts}add{/ts}</a></span>
         {/if}
       </td>

--- a/templates/CRM/Contact/Form/Merge.tpl
+++ b/templates/CRM/Contact/Form/Merge.tpl
@@ -142,12 +142,12 @@
 
             <td>
               {* Display location for fields with locations *}
-              {if $blockName eq 'email' || $blockName eq 'phone' || $blockName eq 'address' || $blockName eq 'im' }
+              {if $blockName eq 'email' || $blockName eq 'phone' || $blockName eq 'address' || $blockName eq 'im'}
                 {$form.location_blocks.$blockName.$blockId.locTypeId.html}&nbsp;
               {/if}
 
               {* Display other_type_id for websites, ims and phones *}
-              {if $blockName eq 'website' || $blockName eq 'im' || $blockName eq 'phone' }
+              {if $blockName eq 'website' || $blockName eq 'im' || $blockName eq 'phone'}
                 {$form.location_blocks.$blockName.$blockId.typeTypeId.html}&nbsp;
               {/if}
 

--- a/templates/CRM/Contact/Form/Relationship.tpl
+++ b/templates/CRM/Contact/Form/Relationship.tpl
@@ -60,7 +60,7 @@
       <div class="spacer"></div>
     </div>
   {/if}
-  {if ($action EQ 1) OR ($action EQ 2) }
+  {if ($action EQ 1) OR ($action EQ 2)}
     {*include custom data js file *}
     {include file="CRM/common/customData.tpl"}
     <script type="text/javascript">

--- a/templates/CRM/Contact/Form/Search/Criteria/Relationship.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Relationship.tpl
@@ -53,7 +53,7 @@
       <td colspan="2"><label>{ts}Active Period{/ts}</label> {help id="id-relationship-active-period" file="CRM/Contact/Form/Search/Advanced.hlp"}<br /></td>
     </tr>
     <tr>
-      {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="relation_active_period_date" to='' from='' colspan='' class ='' hideRelativeLabel=1 }
+      {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="relation_active_period_date" to='' from='' colspan='' class ='' hideRelativeLabel=1}
     </tr>
     {if !empty($relationshipGroupTree)}
       <tr>

--- a/templates/CRM/Contact/Form/Selector.tpl
+++ b/templates/CRM/Contact/Form/Selector.tpl
@@ -36,7 +36,7 @@
 
   {counter start=0 skip=1 print=false}
 
-  { if $id }
+  {if $id}
       {foreach from=$rows item=row}
         <tr id='rowid{$row.contact_id}' class="{cycle values='odd-row,even-row'}">
             {assign var=cbName value=$row.checkbox}
@@ -52,9 +52,9 @@
             {foreach from=$row item=value key=key}
                {if ($key neq "checkbox") and ($key neq "action") and ($key neq "contact_type") and ($key neq "contact_type_orig") and ($key neq "status") and ($key neq "sort_name") and ($key neq "contact_id")}
               <td>
-                {if $key EQ "household_income_total" }
+                {if $key EQ "household_income_total"}
                     {$value|crmMoney}
-                {elseif strpos( $key, '_date' ) !== false }
+                {elseif strpos( $key, '_date' ) !== false}
                     {$value|crmDate}
                 {else}
                     {$value}

--- a/templates/CRM/Contact/Form/Task/AddToParentClass.tpl
+++ b/templates/CRM/Contact/Form/Task/AddToParentClass.tpl
@@ -30,7 +30,7 @@
                 </tr>
                 <tr><td></td><td>{$form.$refresh.html}&nbsp;&nbsp;{$form.$cancel.html}</td></tr>
      </table>
-         {if $searchDone } {* Search button clicked *}
+         {if $searchDone} {* Search button clicked *}
              {if $searchCount}
                  {if $searchRows} {* we've got rows to display *}
                      <fieldset><legend>{ts}Mark Target Contact(s) for this Relationship{/ts}</legend>

--- a/templates/CRM/Contact/Form/Task/Email.tpl
+++ b/templates/CRM/Contact/Form/Task/Email.tpl
@@ -100,7 +100,7 @@ CRM.$(function($) {
     $('.crm-contactEmail-form-block-'+type, $form).hide().find('input.crm-ajax-select').select2('data', []);
   });
 
-  var sourceDataUrl = "{/literal}{crmURL p='civicrm/ajax/checkemail' q='id=1' h=0 }{literal}";
+  var sourceDataUrl = "{/literal}{crmURL p='civicrm/ajax/checkemail' q='id=1' h=0}{literal}";
 
   function emailSelect(el, prepopulate) {
     $(el, $form).data('api-entity', 'contact').css({width: '40em', 'max-width': '90%'}).crmSelect2({

--- a/templates/CRM/Contact/Form/Task/EmailCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/EmailCommon.tpl
@@ -41,7 +41,7 @@
   </div><!-- /.crm-accordion-body -->
 </div><!-- /.crm-accordion-wrapper -->
 <div id="editMessageDetails" class="section">
-  {if call_user_func(array('CRM_Core_Permission','check'), 'edit message templates') }
+  {if call_user_func(array('CRM_Core_Permission','check'), 'edit message templates')}
       <div id="updateDetails" class="section" >
     {$form.updateTemplate.html}&nbsp;{$form.updateTemplate.label}
       </div>

--- a/templates/CRM/Contact/Form/Task/Map/Google.tpl
+++ b/templates/CRM/Contact/Form/Task/Map/Google.tpl
@@ -44,7 +44,7 @@
       {if $location.lat}
     var point  = new google.maps.LatLng({$location.lat},{$location.lng});
     var image  = null;
-    {if $location.image && ( $location.marker_class neq 'Event' ) }
+    {if $location.image && ( $location.marker_class neq 'Event' )}
        image = '{$location.image}';
     {else}
                  {if $location.marker_class eq 'Individual'}
@@ -67,7 +67,7 @@
         {if count($locations) gt 1}
             map.fitBounds(bounds);
             map.setMapTypeId(google.maps.MapTypeId.TERRAIN);
-        {elseif $location.marker_class eq 'Event' || $location.marker_class eq 'Individual'|| $location.marker_class eq 'Household' || $location.marker_class eq 'Organization' }
+        {elseif $location.marker_class eq 'Event' || $location.marker_class eq 'Individual'|| $location.marker_class eq 'Household' || $location.marker_class eq 'Organization'}
             map.setZoom({$defaultZoom});
         {else}
             map.setZoom({$defaultZoom});

--- a/templates/CRM/Contact/Form/Task/Map/OpenStreetMaps.tpl
+++ b/templates/CRM/Contact/Form/Task/Map/OpenStreetMaps.tpl
@@ -99,7 +99,7 @@
                         new OpenLayers.Projection("EPSG:4326"),
                         map.getProjectionObject()
                 );
-                {if $location.image && ( $location.marker_class neq 'Event' ) }
+                {if $location.image && ($location.marker_class neq 'Event')}
                     var image = '{$location.image}';
                 {else}
                     {if $location.marker_class eq 'Individual'}
@@ -121,7 +121,7 @@
         map.setCenter(bounds.getCenterLonLat());
         {if count($locations) gt 1}
             map.zoomToExtent(bounds);
-        {elseif $location.marker_class eq 'Event' || $location.marker_class eq 'Individual'|| $location.marker_class eq 'Household' || $location.marker_class eq 'Organization' }
+        {elseif $location.marker_class eq 'Event' || $location.marker_class eq 'Individual'|| $location.marker_class eq 'Household' || $location.marker_class eq 'Organization'}
             map.zoomTo({$defaultZoom});
         {else}
             map.zoomTo({$defaultZoom});

--- a/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
@@ -233,7 +233,7 @@ function selectFormat( val, bind ) {
     bind = false;
   }
 
-  var dataUrl = {/literal}"{crmURL p='civicrm/ajax/pdfFormat' h=0 }"{literal};
+  var dataUrl = {/literal}"{crmURL p='civicrm/ajax/pdfFormat' h=0}"{literal};
   cj.post( dataUrl, {formatId: val}, function( data ) {
     fillFormatInfo(data, bind);
   }, 'json');
@@ -241,7 +241,7 @@ function selectFormat( val, bind ) {
 
 function selectPaper( val )
 {
-    dataUrl = {/literal}"{crmURL p='civicrm/ajax/paperSize' h=0 }"{literal};
+    dataUrl = {/literal}"{crmURL p='civicrm/ajax/paperSize' h=0}"{literal};
     cj.post( dataUrl, {paperSizeName: val}, function( data ) {
         cj("#paper_size").val( data.name );
         metric = document.getElementById('metric').value;

--- a/templates/CRM/Contact/Form/Task/SMS.tpl
+++ b/templates/CRM/Contact/Form/Task/SMS.tpl
@@ -77,7 +77,7 @@
 
 {literal}
 CRM.$(function($){
-  var sourceDataUrl = "{/literal}{crmURL p='civicrm/ajax/checkphone' h=0 }{literal}";
+  var sourceDataUrl = "{/literal}{crmURL p='civicrm/ajax/checkphone' h=0}{literal}";
   function phoneSelect(el){
     $(el).data('api-entity', 'contact').crmSelect2({
       minimumInputLength: 1,

--- a/templates/CRM/Contact/Page/DedupeException.tpl
+++ b/templates/CRM/Contact/Page/DedupeException.tpl
@@ -53,11 +53,11 @@
 
           <td>
             {assign var="contact1name" value="contact_id1.display_name"}
-            <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$exception.contact_id1`"}" target="_blank">{ $exception.$contact1name }</a>
+            <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$exception.contact_id1`"}" target="_blank">{$exception.$contact1name}</a>
           </td>
           <td>
             {assign var="contact2name" value="contact_id2.display_name"}
-            <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$exception.contact_id2`"}" target="_blank">{ $exception.$contact2name }</a>
+            <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$exception.contact_id2`"}" target="_blank">{$exception.$contact2name}</a>
           </td>
           <td>
             <a id='duplicateContacts' href="#" title={ts}Remove Exception{/ts} onClick="processDupes( {$exception.contact_id1}, {$exception.contact_id2}, 'nondupe-dupe', 'dedupe-exception' );return false;"><i class="crm-i fa-trash" aria-hidden="true"></i> {ts}Remove Exception{/ts}</a>

--- a/templates/CRM/Contact/Page/View/CustomData.tpl
+++ b/templates/CRM/Contact/Page/View/CustomData.tpl
@@ -36,7 +36,7 @@
           CRM.confirm({
             message: '{/literal}{ts escape='js'}Are you sure you want to delete this record?{/ts}{literal}'
           }).on('crmConfirm:yes', function() {
-            var postUrl = {/literal}"{crmURL p='civicrm/ajax/customvalue' h=0 }"{literal};
+            var postUrl = {/literal}"{crmURL p='civicrm/ajax/customvalue' h=0}"{literal};
             var request = $.post(postUrl, $el.data('delete_params'));
             CRM.status({/literal}"{ts escape='js'}Record Deleted{/ts}"{literal}, request);
             request.done(function() {

--- a/templates/CRM/Contact/Page/View/Group.tpl
+++ b/templates/CRM/Contact/Page/View/Group.tpl
@@ -16,7 +16,7 @@
 <div id="groupContact">
  <p>
     <div class="form-item">
-    {if $groupCount > 0 }
+    {if $groupCount > 0}
        <table>
        <tr class="columnheader"><th>{ts}Group Listings{/ts}</th><th>{ts}In Date{/ts}</th><th>{ts}Out Date{/ts}</th><th></th></tr>
        {foreach from=$groupContact item=row}

--- a/templates/CRM/Contact/Page/View/GroupContact.tpl
+++ b/templates/CRM/Contact/Page/View/GroupContact.tpl
@@ -22,7 +22,7 @@
     {include file="CRM/Contact/Form/GroupContact.tpl"}
   {/if}
 
-  {if $groupIn }
+  {if $groupIn}
     <div class="ht-one"></div>
     <h3>{ts}Regular Groups{/ts}</h3>
     <div class="description">{ts 1=$displayName}%1 has joined or been added to these group(s).{/ts}</div>

--- a/templates/CRM/Contact/Page/View/Log.tpl
+++ b/templates/CRM/Contact/Page/View/Log.tpl
@@ -15,7 +15,7 @@
      <div class='instance_data'><div class="crm-loading-element"></div></div>
    {else}
     <div class="form-item">
-     {if $logCount > 0 }
+     {if $logCount > 0}
        <table>
        <tr class="columnheader"><th>{ts}Changed By{/ts}</th><th>{ts}Change Date{/ts}</th></tr>
        {foreach from=$log item=row}

--- a/templates/CRM/Contact/Page/View/Note.tpl
+++ b/templates/CRM/Contact/Page/View/Note.tpl
@@ -120,7 +120,7 @@
     }
 
     function showComments (response) {
-        var urlTemplate = '{/literal}{crmURL p='civicrm/contact/view' q="reset=1&cid=" h=0 }{literal}'
+        var urlTemplate = '{/literal}{crmURL p='civicrm/contact/view' q="reset=1&cid=" h=0}{literal}'
         if (response['values'][0] && response['values'][0].entity_id) {
             var noteId = response['values'][0].entity_id
             var row = cj('tr#Note-'+ noteId);

--- a/templates/CRM/Contact/Page/View/Relationship.tpl
+++ b/templates/CRM/Contact/Page/View/Relationship.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {* Relationship tab within View Contact - browse, and view relationships for a contact *}
-{if $action eq 4 } {* action = view *}
+{if $action eq 4} {* action = view *}
   {include file="CRM/Contact/Page/View/ViewRelationship.tpl"}
 {elseif $action neq 16} {* add, update *}
   {include file="CRM/Contact/Form/Relationship.tpl"}

--- a/templates/CRM/Contact/Page/View/UserDashBoard/GroupContact.tpl
+++ b/templates/CRM/Contact/Page/View/UserDashBoard/GroupContact.tpl
@@ -14,14 +14,14 @@
 {/crmRegion}
 <div id="groupContact">
     <div class="view-content">
-        {if $groupCount eq 0 }
+        {if $groupCount eq 0}
             <div class="messages status no-popup">
                     {icon icon="fa-info-circle"}{/icon}
                     {ts}You are not currently subscribed to any Groups.{/ts}
             </div>
         {/if}
 
-        {if $groupIn }
+        {if $groupIn}
             <div class="form-item">
                 <div>
                     {strip}
@@ -55,7 +55,7 @@
             {include file="CRM/Contact/Form/GroupContact.tpl"}
         {/if}
 
-        {if $groupPending }
+        {if $groupPending}
             <div class="form-item">
                 <div class="label status-pending">{ts}Pending Subscriptions{/ts}</div>
                 <div class="description">{ts}Your subscription to these group(s) is pending confirmation.{/ts}</div>
@@ -86,7 +86,7 @@
             </div>
         {/if}
 
-        {if $groupOut }
+        {if $groupOut}
             <div class="form-item">
                 <div class="label status-removed">{ts}Unsubscribed Groups{/ts}</div>
                 <div class="description">{ts}You are no longer subscribed to these group(s). Click Rejoin Group if you want to re-subscribe.{/ts}</div>

--- a/templates/CRM/Contact/Page/View/ViewRelationship.tpl
+++ b/templates/CRM/Contact/Page/View/ViewRelationship.tpl
@@ -18,7 +18,7 @@
             <tr><td class="label">{ts}Description{/ts}</td><td>{$row.description}</td></tr>
           {/if}
           {foreach from=$viewNote item="rec"}
-              {if $rec }
+              {if $rec}
                 <tr><td class="label">{ts}Note{/ts}</td><td>{$rec}</td></tr>
               {/if}
           {/foreach}

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -143,7 +143,7 @@
           <tr class="crm-contribution-form-block-contribution_status_id">
             <td class="label">{$form.contribution_status_id.label}</td>
             <td>{$form.contribution_status_id.html}
-              {if $contribution_status_id eq 2}{if $is_pay_later }: {ts}Pay Later{/ts} {else}: {ts}Incomplete Transaction{/ts}{/if}{/if}
+              {if $contribution_status_id eq 2}{if $is_pay_later}: {ts}Pay Later{/ts} {else}: {ts}Incomplete Transaction{/ts}{/if}{/if}
             </td>
             <td>
               {if !$isUsePaymentBlock && $contactId && $contribution_status_id eq 2 && $contribID && $contributionMode EQ null}
@@ -205,7 +205,7 @@
               <span class="description">{ts 1=$email}Automatically email a receipt for this payment to %1?{/ts}</span>
             </td>
           </tr>
-        {elseif empty($is_template) and $context eq 'standalone' and $outBound_option != 2 }
+        {elseif empty($is_template) and $context eq 'standalone' and $outBound_option != 2}
           <tr id="email-receipt" style="display:none;" class="crm-contribution-form-block-is_email_receipt">
             <td class="label">{$form.is_email_receipt.label}</td>
             <td>{$form.is_email_receipt.html}

--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -26,10 +26,10 @@
 
   {include file="CRM/Contribute/Form/Contribution/MembershipBlock.tpl"}
 
-  {if $amount GTE 0 OR $minimum_fee GTE 0 OR ( $isDisplayLineItems and $lineItem ) }
+  {if $amount GTE 0 OR $minimum_fee GTE 0 OR ($isDisplayLineItems and $lineItem)}
     <div class="crm-group amount_display-group">
       <div class="header-dark">
-        {if !$membershipBlock AND $amount OR ( $isDisplayLineItems and $lineItem ) }{ts}Contribution Amount{/ts}{else}{ts}Membership Fee{/ts} {/if}
+        {if !$membershipBlock AND $amount OR ($isDisplayLineItems and $lineItem)}{ts}Contribution Amount{/ts}{else}{ts}Membership Fee{/ts} {/if}
       </div>
 
       <div class="display-block">
@@ -37,7 +37,7 @@
           {if !$amount}{assign var="amount" value=0}{/if}
           {assign var="totalAmount" value=$amount}
           {include file="CRM/Price/Page/LineItem.tpl" context="Contribution"}
-        {elseif $is_separate_payment }
+        {elseif $is_separate_payment}
           {if $amount AND $minimum_fee}
             {$membership_name} {ts}Membership{/ts}:
             <strong>{$minimum_fee|crmMoney}</strong>
@@ -50,23 +50,23 @@
             {ts}Total{/ts}:
             <strong>{$amount+$minimum_fee|crmMoney}</strong>
             <br/>
-          {elseif $amount }
+          {elseif $amount}
             {ts}Amount{/ts}:
-            <strong>{$amount|crmMoney} {if $amount_level }<span class='crm-price-amount-label'>
+            <strong>{$amount|crmMoney} {if $amount_level}<span class='crm-price-amount-label'>
                 &ndash; {$amount_level}</span>{/if}</strong>
           {else}
             {$membership_name} {ts}Membership{/ts}:
             <strong>{$minimum_fee|crmMoney}</strong>
           {/if}
         {else}
-          {if $totalTaxAmount }
+          {if $totalTaxAmount}
             {ts 1=$taxTerm}Total %1 Amount{/ts}:
             <strong>{$totalTaxAmount|crmMoney} </strong>
             <br/>
           {/if}
           {if $amount}
             {if $installments}{ts}Installment Amount{/ts}{else}{ts}Total Amount{/ts}{/if}:
-            <strong>{$amount|crmMoney:$currency}{if $amount_level }<span class='crm-price-amount-label'>
+            <strong>{$amount|crmMoney:$currency}{if $amount_level}<span class='crm-price-amount-label'>
                 &ndash; {$amount_level}</span>{/if}</strong>
           {else}
             {$membership_name} {ts}Membership{/ts}:
@@ -131,7 +131,7 @@
           {/if}
         {/if}
 
-        {if $is_pledge }
+        {if $is_pledge}
           {if $pledge_frequency_interval GT 1}
             <p>
               <strong>{ts 1=$pledge_frequency_interval 2=$pledge_frequency_unit 3=$pledge_installments}I pledge to contribute this amount every %1 %2s for %3 installments.{/ts}</strong>
@@ -276,7 +276,7 @@
     </fieldset>
   {/if}
 
-  {if $contributeMode NEQ 'notify' and $is_monetary and ( $amount GT 0 OR $minimum_fee GT 0 ) } {* In 'notify mode, contributor is taken to processor payment forms next *}
+  {if $contributeMode NEQ 'notify' and $is_monetary and ( $amount GT 0 OR $minimum_fee GT 0 )} {* In 'notify mode, contributor is taken to processor payment forms next *}
     <div class="messages status continue_instructions-section">
       <p>
         {if $is_pay_later OR $amount LE 0.0}

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -50,7 +50,7 @@
     {include file="CRM/Contribute/Form/Contribution/PreviewHeader.tpl"}
   {/if}
 
-  {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM') }
+  {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM')}
     {capture assign="buttonTitle"}{ts}Configure Contribution Page{/ts}{/capture}
     {crmButton target="_blank" p="civicrm/admin/contribute/settings" q="reset=1&action=update&id=`$contributionPageID`" fb=1 title="$buttonTitle" icon="fa-wrench"}{ts}Configure{/ts}{/crmButton}
     <div class='clear'></div>

--- a/templates/CRM/Contribute/Form/Contribution/MainMembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MainMembershipBlock.tpl
@@ -78,7 +78,7 @@
       <table id="membership-listings">
           {foreach from=$membershipTypes item=row}
             <tr class="odd-row" valign="top">
-                {if $showRadio }
+                {if $showRadio}
                     {* unreachable - show radio is never true *}
                     {assign var="pid" value=$row.id}
                   <td style="width: 1em;">{$form.selectMembership.$pid.html}</td>
@@ -87,7 +87,7 @@
                 {/if}
               <td style="width: auto;">
                 <span class="bold">{$row.name} &nbsp;
-                {if ($membershipBlock.display_min_fee) AND $row.minimum_fee GT 0 }
+                {if ($membershipBlock.display_min_fee) AND $row.minimum_fee GT 0}
                     {if $is_separate_payment OR ! $form.amount.label}
                       &ndash; {$row.minimum_fee|crmMoney}
                     {else}
@@ -126,7 +126,7 @@
             </tr>
           {/if}
           {if $showRadio}{* unreachable *}
-              {if $showRadioNoThanks } {* Provide no-thanks option when Membership signup is not required - per membership block configuration. *}
+              {if $showRadioNoThanks} {* Provide no-thanks option when Membership signup is not required - per membership block configuration. *}
                 <tr class="odd-row">
                   <td>{$form.selectMembership.no_thanks.html}</td>
                   <td colspan="2"><strong>{ts}No thank you{/ts}</strong></td>

--- a/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
@@ -12,7 +12,7 @@
 </div>
 {if $membershipBlock AND $is_quick_config}
     <div class="header-dark">
-      {if $renewal_mode }
+      {if $renewal_mode}
         {if $membershipBlock.renewal_title}
           {$membershipBlock.renewal_title}
         {else}

--- a/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
@@ -69,7 +69,7 @@
               <div class="premium-full-description">
                 {$row.description}
               </div>
-              {if $showSelectOptions }
+              {if $showSelectOptions}
                 {assign var="pid" value="options_"|cat:$row.id}
                 {if $pid}
                   <div class="premium-full-options">
@@ -81,7 +81,7 @@
                   <p><strong>{$row.options}</strong></p>
                 </div>
               {/if}
-              {if ( ($premiumBlock.premiums_display_min_contribution AND $context EQ "makeContribution") OR $preview EQ 1) AND $row.min_contribution GT 0 }
+              {if (($premiumBlock.premiums_display_min_contribution AND $context EQ "makeContribution") OR $preview EQ 1) AND $row.min_contribution GT 0}
                 <div class="premium-full-min">{ts 1=$row.min_contribution|crmMoney}Minimum: %1{/ts}</div>
               {/if}
             <div style="clear:both"></div>

--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -72,10 +72,10 @@
 
   {include file="CRM/Contribute/Form/Contribution/MembershipBlock.tpl"}
 
-  {if $amount GTE 0 OR $minimum_fee GTE 0 OR ( $priceSetID and $lineItem ) }
+  {if $amount GTE 0 OR $minimum_fee GTE 0 OR ($priceSetID and $lineItem)}
     <div class="crm-group amount_display-group">
       <div class="header-dark">
-        {if !$membershipBlock AND $amount OR ( $priceSetID and $lineItem )}{ts}Contribution Information{/ts}{else}{ts}Membership Fee{/ts}{/if}
+        {if !$membershipBlock AND $amount OR ($priceSetID and $lineItem)}{ts}Contribution Information{/ts}{else}{ts}Membership Fee{/ts}{/if}
       </div>
 
       <div class="display-block">
@@ -98,7 +98,7 @@
           {if $totalTaxAmount}
             {ts}Tax Amount{/ts}: <strong>{$totalTaxAmount|crmMoney}</strong><br />
           {/if}
-          {if $installments}{ts}Installment Amount{/ts}{else}{ts}Amount{/ts}{/if}: <strong>{$amount|crmMoney:$currency}{if $amount_level } &ndash; {$amount_level}{/if}</strong>
+          {if $installments}{ts}Installment Amount{/ts}{else}{ts}Amount{/ts}{/if}: <strong>{$amount|crmMoney:$currency}{if $amount_level} &ndash; {$amount_level}{/if}</strong>
         {/if}
 
         {if $receive_date}

--- a/templates/CRM/Contribute/Form/ContributionPage/AddProduct.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/AddProduct.tpl
@@ -9,7 +9,7 @@
 *}
 {crmRegion name="contribute-form-contributionpage-addproduct-main"}
 {capture assign=managePremiumsURL}{crmURL p='civicrm/admin/contribute/managePremiums' q="reset=1"}{/capture}
-<h3>{if $action eq 2 }{ts}Add Products to This Page{/ts} {elseif $action eq 1024}{ts}Preview{/ts}{else} {ts}Remove Products from this Page{/ts}{/if}</h3>
+<h3>{if $action eq 2}{ts}Add Products to This Page{/ts} {elseif $action eq 1024}{ts}Preview{/ts}{else} {ts}Remove Products from this Page{/ts}{/if}</h3>
 <div class="crm-block crm-form-block crm-contribution-add_product-form-block">
   <div class="help">
     {if $action eq 1024}
@@ -33,7 +33,7 @@
     <tr class="crm-contribution-form-block-financial_type">
       <td class="label">{$form.financial_type_id.label}</td>
       <td>
-      {if !$financialType }
+      {if !$financialType}
         {capture assign=ftUrl}{crmURL p='civicrm/admin/financial/financialType' q="reset=1"}{/capture}
         {ts 1=$ftUrl}There are no financial types configured with linked 'Cost of Sales Premiums' and 'Premiums Inventory Account' accounts. If you want to generate accounting transactions which track the cost of premiums used <a href='%1'>click here</a> to configure financial types and accounts.{/ts}
       {else}

--- a/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
@@ -455,7 +455,7 @@
         message: {/literal}"{ts escape='js'}Once you switch to using a Price Set, you won't be able to switch back to your existing settings below except by re-entering them. Are you sure you want to switch to a Price Set?{/ts}"{literal}
       }).on('crmConfirm:yes', function() {
         {/literal}
-        var dataUrl = '{crmURL p="civicrm/ajax/rest" h=0 q="className=CRM_Core_Page_AJAX&fnName=setIsQuickConfig&context=civicrm_contribution_page&id=$contributionPageID" }';
+        var dataUrl = '{crmURL p="civicrm/ajax/rest" h=0 q="className=CRM_Core_Page_AJAX&fnName=setIsQuickConfig&context=civicrm_contribution_page&id=$contributionPageID"}';
         {literal}
         $.getJSON(dataUrl).done(function(result) {window.location = CRM.url("civicrm/admin/price/field", {reset: 1, action: 'browse', sid: result});});
       });

--- a/templates/CRM/Contribute/Form/ContributionView.tpl
+++ b/templates/CRM/Contribute/Form/ContributionView.tpl
@@ -87,7 +87,7 @@
       <td>{$revenue_recognition_date|crmDate:"%B, %Y"}</td>
     </tr>
   {/if}
-  {if $to_financial_account }
+  {if $to_financial_account}
     <tr class="crm-contribution-form-block-to_financial_account">
       <td class="label">{ts}Received Into{/ts}</td>
       <td>{$to_financial_account}</td>
@@ -151,7 +151,7 @@
     </tr>
   {/if}
   {foreach from=$note item="rec"}
-    {if $rec }
+    {if $rec}
       <tr class="crm-contribution-form-block-note">
         <td class="label">{ts}Note{/ts}</td>
         <td>{$rec}</td>

--- a/templates/CRM/Contribute/Form/ManagePremiums.tpl
+++ b/templates/CRM/Contribute/Form/ManagePremiums.tpl
@@ -139,7 +139,7 @@
  {/if}
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>
-{if $action eq 1 or $action eq 2 }
+{if $action eq 1 or $action eq 2}
 
 <script type="text/javascript">
 {literal}

--- a/templates/CRM/Contribute/Form/Selector.tpl
+++ b/templates/CRM/Contribute/Form/Selector.tpl
@@ -14,7 +14,7 @@
   <table class="selector row-highlight">
     <thead class="sticky">
     <tr>
-      {if !$single and $context eq 'Search' }
+      {if !$single and $context eq 'Search'}
         <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
       {/if}
       {if !$single}
@@ -36,8 +36,8 @@
     {counter start=0 skip=1 print=false}
     {foreach from=$rows item=row}
       <tr id="rowid{$row.contribution_id}" class="{cycle values="odd-row,even-row"} {if $row.contribution_cancel_date} cancelled{/if} crm-contribution_{$row.contribution_id}">
-        {if !$single }
-          {if $context eq 'Search' }
+        {if !$single}
+          {if $context eq 'Search'}
             {assign var=cbName value=$row.checkbox}
             <td>{$form.$cbName.html}</td>
           {/if}

--- a/templates/CRM/Contribute/Form/Task.tpl
+++ b/templates/CRM/Contribute/Form/Task.tpl
@@ -9,7 +9,7 @@
 *}
 {ts 1=$totalSelectedContributions}Number of selected contributions: %1{/ts}
 
-{if $rows }
+{if $rows}
 <div class="crm-block crm-form-block crm-contribution-task-form-block">
 <table width="30%">
   <tr class="columnheader">

--- a/templates/CRM/Contribute/Form/Task/Print.tpl
+++ b/templates/CRM/Contribute/Form/Task/Print.tpl
@@ -9,7 +9,7 @@
 *}
 <p>
 
-{if $rows }
+{if $rows}
 <div class="form-item crm-block crm-form-block crm-contribution-form-block">
      <span class="element-right">{$form.buttons.html}</span>
 </div>

--- a/templates/CRM/Contribute/Page/ContributionPage.tpl
+++ b/templates/CRM/Contribute/Page/ContributionPage.tpl
@@ -13,7 +13,7 @@
     </div>
 
     {include file="CRM/Contribute/Form/SearchContribution.tpl"}
-    {if NOT ($action eq 1 or $action eq 2) }
+    {if NOT ($action eq 1 or $action eq 2)}
       <table class="form-layout-compressed">
       <tr>
       <td><a href="{$newPageURL}" class="button"><span><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}Add Contribution Page{/ts}</span></a></td>

--- a/templates/CRM/Contribute/Page/ContributionTotals.tpl
+++ b/templates/CRM/Contribute/Page/ContributionTotals.tpl
@@ -22,7 +22,7 @@
         </tr>
     {/if}
 
-    {if $contributionSummary }
+    {if $contributionSummary}
       <tr>
           {if $contributionSummary.total.amount}
             <th class="contriTotalLeft right">{ts}Total{/ts} &ndash; {$contributionSummary.total.amount|smarty:nodefaults}</th>

--- a/templates/CRM/Contribute/Page/Premium.tpl
+++ b/templates/CRM/Contribute/Page/Premium.tpl
@@ -50,7 +50,7 @@
 {else}
   {if $showForm eq false}
     <div class="messages status no-popup">
-      {if $products ne null }
+      {if $products ne null}
         {icon icon="fa-info-circle"}{/icon}
         {capture assign=crmURL}{crmURL p='civicrm/admin/contribute/addProductToPage' q="reset=1&action=update&id=$id"}{/capture}
         {ts 1=$crmURL}There are no premiums offered on this contribution page yet. You can <a href='%1'>add one</a>.{/ts}

--- a/templates/CRM/Contribute/Page/UserDashboard.tpl
+++ b/templates/CRM/Contribute/Page/UserDashboard.tpl
@@ -50,7 +50,7 @@
                                 <a class="button no-popup nowrap"
                                    href="{crmURL p='civicrm/contribute/invoice' q=$urlParams}">
                                     <i class="crm-i fa-download" aria-hidden="true"></i>
-                                    {if empty($row.contribution_status_name) || (!empty($row.contribution_status_name) && $row.contribution_status_name != 'Refunded' && $row.contribution_status_name != 'Cancelled') }
+                                    {if empty($row.contribution_status_name) || (!empty($row.contribution_status_name) && $row.contribution_status_name != 'Refunded' && $row.contribution_status_name != 'Cancelled')}
                                         <span>{ts}Download Invoice{/ts}</span>
                                     {else}
                                         <span>{ts}Download Invoice and Credit Note{/ts}</span>

--- a/templates/CRM/Core/I18n/Dialog.tpl
+++ b/templates/CRM/Core/I18n/Dialog.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if $config->languageLimit && $config->languageLimit|@count >= 2 and $translatePermission }
+{if $config->languageLimit && $config->languageLimit|@count >= 2 and $translatePermission}
   <a href="{crmURL p='civicrm/i18n' q="reset=1&table=$table&field=$field&id=$id"}" data-field="{$field}" class="crm-hover-button crm-multilingual-edit-button" title="{ts}Languages{/ts}">
     <i class="crm-i fa-language fa-lg" aria-hidden="true"></i>
   </a>

--- a/templates/CRM/Custom/Form/Edit/CustomData.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomData.tpl
@@ -25,7 +25,7 @@
 </table>
 <div class="spacer"></div>
 {if $cd_edit.help_post}<div class="messages help">{$cd_edit.help_post}</div>{/if}
-{if !$isSingleRecordEdit && $cd_edit.is_multiple and ( ( $cd_edit.max_multiple eq '' )  or ( $cd_edit.max_multiple > 0 and $cd_edit.max_multiple > $cgCount ) ) }
+{if !$isSingleRecordEdit && $cd_edit.is_multiple and (($cd_edit.max_multiple eq '') or ($cd_edit.max_multiple > 0 and $cd_edit.max_multiple > $cgCount))}
   {if $skipTitle}
     {* We don't yet support adding new records in inline-edit forms *}
     <div class="messages help">

--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -44,7 +44,7 @@
       <td class="html-adjust">{$form.text_length.html}</td>
     </tr>
 
-    <tr id='showoption' {if $action eq 1 or $action eq 2 }class="hiddenElement"{/if}>
+    <tr id='showoption' {if $action eq 1 or $action eq 2}class="hiddenElement"{/if}>
       <td colspan="2">
         <table class="form-layout-compressed">
           {* Conditionally show table for setting up selection options - for field types = radio, checkbox or select *}
@@ -354,7 +354,7 @@
 </script>
 {/literal}
 {* Give link to view/edit option group *}
-{if $action eq 2 && !empty($hasOptionGroup) }
+{if $action eq 2 && !empty($hasOptionGroup)}
   <div class="action-link">
     {crmButton p="civicrm/admin/custom/group/field/option" q="reset=1&action=browse&fid=`$id`&gid=`$gid`" icon="pencil"}{ts}View / Edit Multiple Choice Options{/ts}{/crmButton}
   </div>

--- a/templates/CRM/Custom/Form/Option.tpl
+++ b/templates/CRM/Custom/Form/Option.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 <div class="crm-block {if $action eq 4}crm-content-block {else}crm-form-block {/if}crm-custom_option-form-block">
-<h3>{if $action eq 4 }{ts}View Option{/ts}{elseif $action eq 2}{ts}Edit Option{/ts}{elseif $action eq 8}{ts 1=$label}Delete Option "%1"{/ts}{else}{ts}Add Option{/ts}{/if}</h3>
+<h3>{if $action eq 4}{ts}View Option{/ts}{elseif $action eq 2}{ts}Edit Option{/ts}{elseif $action eq 8}{ts 1=$label}Delete Option "%1"{/ts}{else}{ts}Add Option{/ts}{/if}</h3>
     {if $action eq 8}
       <div class="messages status no-popup">
           {icon icon="fa-info-circle"}{/icon}

--- a/templates/CRM/Event/Form/EventFees.tpl
+++ b/templates/CRM/Event/Form/EventFees.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{assign var=isRecordPayment value=1 }
+{assign var=isRecordPayment value=1}
 {capture assign="isShowBillingBlock"}{if $action neq 2}1{else}0{/if}{/capture}
 {if $paid} {* We retrieve this tpl when event is selected - keep it empty if event is not paid *}
     <table class="form-layout">
@@ -43,7 +43,7 @@
             <td class="view-value"><table class="form-layout">{include file="CRM/Price/Form/PriceSet.tpl" extends="Event" hideTotal=false}</td>
           </fieldset>
         {else}
-          {assign var=isRecordPayment value=0 }
+          {assign var=isRecordPayment value=0}
           <div class='messages status'>{ts}No active price fields found for this event!{/ts}</div>
         {/if}
         </table>
@@ -52,7 +52,7 @@
       </tr>
     {/if}
 
-    {if $accessContribution and ! $participantMode and ($action neq 2 or !$rows.0.contribution_id or $onlinePendingContributionId) and $isRecordPayment and ! $registeredByParticipantId }
+    {if $accessContribution and ! $participantMode and ($action neq 2 or !$rows.0.contribution_id or $onlinePendingContributionId) and $isRecordPayment and ! $registeredByParticipantId}
       {assign var=isShowBillingBlock value=true}
         <tr class="crm-event-eventfees-form-block-record_contribution">
             <td class="label">{$form.record_contribution.label}</td>
@@ -71,7 +71,7 @@
                     <td class="label" >{$form.receive_date.label}</td>
                     <td>{$form.receive_date.html}</td>
                 </tr>
-                {if $showTransactionId }
+                {if $showTransactionId}
                     <tr class="crm-event-eventfees-form-block-trxn_id"><td class="label">{$form.trxn_id.label}</td><td>{$form.trxn_id.html}</td></tr>
                 {/if}
                 <tr class="crm-event-eventfees-form-block-contribution_status_id"><td class="label">{$form.contribution_status_id.label}</td><td>{$form.contribution_status_id.html}</td></tr>
@@ -117,7 +117,7 @@
         </tr>
       </table>
     </fieldset>
-{elseif $context eq 'standalone' and $outBound_option != 2 }
+{elseif $context eq 'standalone' and $outBound_option != 2}
     <fieldset id="email-receipt" style="display:none;"><legend>{if $paid}{ts}Registration Confirmation and Receipt{/ts}{else}{ts}Registration Confirmation{/ts}{/if}</legend>
       <table class="form-layout" style="width:auto;">
        <tr class="crm-event-eventfees-form-block-send_receipt">
@@ -146,7 +146,7 @@
     </fieldset>
 {/if}
 
-{if ($email and $outBound_option != 2) OR $context eq 'standalone' } {* Send receipt field only present if contact has a valid email address. *}
+{if ($email and $outBound_option != 2) OR $context eq 'standalone'} {* Send receipt field only present if contact has a valid email address. *}
 {include file="CRM/common/showHideByFieldValue.tpl"
     trigger_field_id    ="send_receipt"
     trigger_value       =""
@@ -165,7 +165,7 @@
 }
 {/if}
 
-{if $context eq 'standalone' and $outBound_option != 2 }
+{if $context eq 'standalone' and $outBound_option != 2}
 <script type="text/javascript">
 {literal}
   CRM.$(function($) {

--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
@@ -70,7 +70,7 @@
       <td class="label">{$form.max_participants.label} {help id="id-max_participants" waitlist=$waitlist}</td>
       <td>
         {$form.max_participants.html|crmAddClass:four}
-        {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM') }
+        {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM')}
           <a class="crm-popup crm-hover-button" target="_blank" title="{ts}Edit Participant Status Options{/ts}" href="{crmURL p='civicrm/admin/participant_status' q='reset=1'}"><i class="crm-i fa-wrench" aria-hidden="true"></i></a>
         {/if}
       </td>

--- a/templates/CRM/Event/Form/ManageEvent/Fee.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Fee.tpl
@@ -140,7 +140,7 @@
 
   {section name=rowLoop start=1 loop=6}
      {assign var=index value=$smarty.section.rowLoop.index}
-     <tr id="discount_{$index}" class=" crm-event-manage-fee-form-block-discount_{$index} {if $index GT 1 AND empty( $form.discount_name[$index].value) } hiddenElement {/if} form-item {cycle values="odd-row,even-row"}">
+     <tr id="discount_{$index}" class=" crm-event-manage-fee-form-block-discount_{$index} {if $index GT 1 AND empty( $form.discount_name[$index].value)} hiddenElement {/if} form-item {cycle values="odd-row,even-row"}">
            <td>{if $index GT 1} <a onclick="showHideDiscountRow('discount_{$index}', false, {$index}); return false;" name="discount_{$index}" href="#" class="form-link">{icon icon="fa-trash"}{ts}remove discount set{/ts}{/icon}</span></a>{/if}
            </td>
            <td class="crm-event-manage-fee-form-block-discount_name"> {$form.discount_name.$index.html}</td>
@@ -309,7 +309,7 @@
         message: {/literal}"{ts escape='js'}Once you switch to using a Price Set, you won't be able to switch back to your existing settings below except by re-entering them. Are you sure you want to switch to a Price Set?{/ts}"{literal}
       }).on('crmConfirm:yes', function() {
           {/literal}
-          var dataUrl  = '{crmURL p="civicrm/ajax/rest" h=0 q="className=CRM_Core_Page_AJAX&fnName=setIsQuickConfig&context=civicrm_event&id=$eventId" }';
+          var dataUrl  = '{crmURL p="civicrm/ajax/rest" h=0 q="className=CRM_Core_Page_AJAX&fnName=setIsQuickConfig&context=civicrm_event&id=$eventId"}';
           {literal}
         $.getJSON(dataUrl).done(function(result) {window.location = CRM.url("civicrm/admin/price/field", {reset: 1, action: 'browse', sid: result});});
         });

--- a/templates/CRM/Event/Form/ManageEvent/Registration.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.tpl
@@ -9,7 +9,7 @@
 *}
 {if $addProfileBottomAdd OR $addProfileBottom}
   <td scope="row" class="label" width="20%">
-    {if $addProfileBottomAdd }{$form.additional_custom_post_id_multiple[$profileBottomNumAdd].label}
+    {if $addProfileBottomAdd}{$form.additional_custom_post_id_multiple[$profileBottomNumAdd].label}
     {else}{$form.custom_post_id_multiple[$profileBottomNum].label}{/if}</td>
   <td>
     {if $addProfileBottomAdd}{$form.additional_custom_post_id_multiple[$profileBottomNumAdd].html}

--- a/templates/CRM/Event/Form/ParticipantView.tpl
+++ b/templates/CRM/Event/Form/ParticipantView.tpl
@@ -115,7 +115,7 @@
         </tr>
     {/if}
     {foreach from=$note item="rec"}
-      {if $rec }
+      {if $rec}
             <tr><td class="label">{ts}Note{/ts}</td><td>{$rec|nl2br}</td></tr>
       {/if}
     {/foreach}

--- a/templates/CRM/Event/Form/Registration/EventInfoBlock.tpl
+++ b/templates/CRM/Event/Form/Registration/EventInfoBlock.tpl
@@ -37,10 +37,10 @@
       <tr><td>{ts}Location{/ts}</td>
           <td>
             {$location.address.1.display|nl2br}
-            {if ( $event.is_map &&
+            {if ($event.is_map &&
             $config->mapProvider &&
-      ( ( !empty($location.address.1.geo_code_1) && is_numeric($location.address.1.geo_code_1) )  ||
-        ( !empty($location.address.1.city) AND !empty($location.address.1.state_province) ) ) ) }
+      ((!empty($location.address.1.geo_code_1) && is_numeric($location.address.1.geo_code_1)) ||
+        (!empty($location.address.1.city) AND !empty($location.address.1.state_province))))}
               <br/><a href="{crmURL p='civicrm/contact/map/event' q="reset=1&eid=`$event.id`"}" title="{ts}Map this Address{/ts}" target="_blank">{ts}Map this Location{/ts}</a>
             {/if}
           </td>

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM') }
+{if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM')}
   {capture assign="buttonTitle"}{ts}Configure Event{/ts}{/capture}
   {crmButton target="_blank" p="civicrm/event/manage/settings" q="reset=1&action=update&id=`$event.id`" fb=1 title="$buttonTitle" icon="fa-wrench"}{ts}Configure{/ts}{/crmButton}
   <div class='clear'></div>
@@ -83,7 +83,7 @@
       {include file="CRM/Price/Form/ParticipantCount.tpl"}
       {if ! $quickConfig}</fieldset>{/if}
     {/if}
-    {if $pcp && $is_honor_roll }
+    {if $pcp && $is_honor_roll}
       <fieldset class="crm-public-form-item crm-group pcp-group">
         <div class="crm-public-form-item crm-section pcp-section">
           <div class="crm-public-form-item crm-section display_in_roll-section">
@@ -162,7 +162,7 @@
     });
 
   {/literal}
-  {if $pcp && $is_honor_roll }
+  {if $pcp && $is_honor_roll}
     pcpAnonymous();
   {/if}
   {literal}
@@ -260,7 +260,7 @@
   }
 
   {/literal}
-  {if $pcp && $is_honor_roll }{literal}
+  {if $pcp && $is_honor_roll}{literal}
   function pcpAnonymous() {
     // clear nickname field if anonymous is true
     if (document.getElementsByName("pcp_is_anonymous")[1].checked) {

--- a/templates/CRM/Event/Form/Registration/ThankYou.tpl
+++ b/templates/CRM/Event/Form/Registration/ThankYou.tpl
@@ -196,7 +196,7 @@
         <a href="{crmURL p='civicrm/event/info' q="reset=1&id=`$event.id`"}"><i class="crm-i fa-chevron-left" aria-hidden="true"></i> {ts 1=$event.event_title}Back to "%1" event information{/ts}</a>
     </div>
 
-    {if $event.is_public }
+    {if $event.is_public}
       <div class="action-link section iCal_links-section">
         {include file="CRM/Event/Page/iCalLinks.tpl"}
       </div>

--- a/templates/CRM/Event/Form/Search/Common.tpl
+++ b/templates/CRM/Event/Form/Search/Common.tpl
@@ -58,7 +58,7 @@
 {include file="CRM/Campaign/Form/addCampaignToSearch.tpl"
 campaignTrClass='' campaignTdClass='crm-event-form-block-participant_campaign_id'}
 
-{if $participantGroupTree }
+{if $participantGroupTree}
 <tr>
   <td colspan="4">
   {include file="CRM/Custom/Form/Search.tpl" groupTree=$participantGroupTree showHideLinks=false}

--- a/templates/CRM/Event/Form/Selector.tpl
+++ b/templates/CRM/Event/Form/Selector.tpl
@@ -15,7 +15,7 @@
 <table class="selector row-highlight">
 <thead class="sticky">
     <tr>
-    {if ! $single and $context eq 'Search' }
+    {if ! $single and $context eq 'Search'}
       <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
     {/if}
     {foreach from=$columnHeaders item=header}
@@ -34,8 +34,8 @@
   {counter start=0 skip=1 print=false}
   {foreach from=$rows item=row}
   <tr id='rowid{$row.participant_id}' class="{cycle values="odd-row,even-row"} crm-event crm-event_{$row.event_id}">
-     {if ! $single }
-        {if $context eq 'Search' }
+     {if ! $single}
+        {if $context eq 'Search'}
             {assign var=cbName value=$row.checkbox}
             <td>{$form.$cbName.html}</td>
         {/if}
@@ -70,12 +70,12 @@
    </tr>
   {/foreach}
 {* Link to "View all participants" for Dashboard and Contact Summary *}
-{if $limit and $pager->_totalItems GT $limit }
-  {if $context EQ 'event_dashboard' }
+{if $limit and $pager->_totalItems GT $limit}
+  {if $context EQ 'event_dashboard'}
     <tr class="even-row">
     <td colspan="10"><a href="{crmURL p='civicrm/event/search' q='reset=1'}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Find more event participants{/ts}...</a></td></tr>
     </tr>
-  {elseif $context eq 'participant' }
+  {elseif $context eq 'participant'}
     <tr class="even-row">
     <td colspan="7"><a href="{crmURL p='civicrm/contact/view' q="reset=1&force=1&selectedChild=participant&cid=$contactId"}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}View all events for this contact{/ts}...</a></td></tr>
     </tr>

--- a/templates/CRM/Event/Form/Task.tpl
+++ b/templates/CRM/Event/Form/Task.tpl
@@ -9,7 +9,7 @@
 *}
 {ts 1=$totalSelectedParticipants}Number of selected participants: %1{/ts}
 
-{if $rows }
+{if $rows}
 <div class="form-item">
 <table width="30%">
   <tr class="columnheader">

--- a/templates/CRM/Event/Form/Task/Print.tpl
+++ b/templates/CRM/Event/Form/Task/Print.tpl
@@ -9,7 +9,7 @@
 *}
 <p>
 
-{if $rows }
+{if $rows}
 <div class="crm-submit-buttons">
      <span class="element-right">{include file="CRM/common/formButtons.tpl" location="top"}</span>
 </div>

--- a/templates/CRM/Event/Page/EventInfo.tpl
+++ b/templates/CRM/Event/Page/EventInfo.tpl
@@ -9,7 +9,7 @@
 *}
 {* this template is used for displaying event information *}
 
-{if $registerClosed }
+{if $registerClosed}
 <div class="spacer"></div>
 <div class="messages status no-popup">
   <i class="crm-i fa-info-circle" aria-hidden="true"></i>
@@ -133,9 +133,9 @@
             </div>
         {/if}
 
-      {if ( $event.is_map && $config->mapProvider &&
-          ( is_numeric($location.address.1.geo_code_1)  ||
-          ( $location.address.1.city AND $location.address.1.state_province ) ) ) }
+      {if ($event.is_map && $config->mapProvider &&
+          (is_numeric($location.address.1.geo_code_1) ||
+          ($location.address.1.city AND $location.address.1.state_province)))}
           <div class="crm-section event_map-section">
               <div class="content">
                     {assign var=showDirectly value="1"}
@@ -222,13 +222,13 @@
         {/if}
       {/crmRegion}
     </div>
-    {if $event.is_public }
+    {if $event.is_public}
         <div class="action-link section iCal_links-section">
           {include file="CRM/Event/Page/iCalLinks.tpl"}
         </div>
     {/if}
 
-    {if $event.is_share }
+    {if $event.is_share}
         {capture assign=eventUrl}{crmURL p='civicrm/event/info' q="id=`$event.id`&amp;reset=1" a=1 fe=1 h=1}{/capture}
         {include file="CRM/common/SocialNetwork.tpl" url=$eventUrl title=$event.title pageURL=$eventUrl emailMode=true}
     {/if}

--- a/templates/CRM/Financial/Form/BatchTransaction.tpl
+++ b/templates/CRM/Financial/Form/BatchTransaction.tpl
@@ -319,7 +319,7 @@ function selectAction( id, toggleSelectId, checkId ) {
 }
 
 function bulkAssignRemove( action ) {
-  var postUrl = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q="className=CRM_Financial_Page_AJAX&fnName=bulkAssignRemove&entityID=$entityID" }"{literal};
+  var postUrl = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q="className=CRM_Financial_Page_AJAX&fnName=bulkAssignRemove&entityID=$entityID"}"{literal};
   var fids = [];
   if (action == 'Assign') {
     CRM.$("input[id^='mark_x_']:checked").each( function () {

--- a/templates/CRM/Financial/Form/FinancialType.tpl
+++ b/templates/CRM/Financial/Form/FinancialType.tpl
@@ -9,7 +9,7 @@
 *}
 {* this template is used for adding/editing/deleting financial type  *}
 {include file="CRM/Core/Form/EntityForm.tpl"}
-{if $action eq 2 or $action eq 4 } {* Update or View*}
+{if $action eq 2 or $action eq 4} {* Update or View*}
   <div class="crm-submit-buttons">
     <a href="{crmURL p='civicrm/admin/financial/financialType/accounts' q="action=browse&reset=1&aid=$aid"}" class="button"><span>{ts}View or Edit Financial Accounts{/ts}</a></span>
   </div>

--- a/templates/CRM/Form/attachmentjs.tpl
+++ b/templates/CRM/Form/attachmentjs.tpl
@@ -9,7 +9,7 @@
         title: $el.attr('title'),
         message: ts(msg, {1: '<em>' + $el.data('filename') + '</em>'})
       }).on('crmConfirm:yes', function() {
-        var postUrl = {/literal}"{crmURL p='civicrm/file/delete' h=0 }"{literal};
+        var postUrl = {/literal}"{crmURL p='civicrm/file/delete' h=0}"{literal};
         var request = $.post(postUrl, $el.data('args'));
         CRM.status({success: '{/literal}{ts escape="js"}Removed{/ts}{literal}'}, request);
         request.done(function() {

--- a/templates/CRM/Friend/Form.tpl
+++ b/templates/CRM/Friend/Form.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {* Enduser Tell-a-Friend form. *}
-{if $status eq 'thankyou' } {* Form has been submitted. *}
+{if $status eq 'thankyou'} {* Form has been submitted. *}
     <div class="crm-section tell_friend_thankyou-section">
         {$thankYouText}
     </div>

--- a/templates/CRM/Import/Form/DataSource.tpl
+++ b/templates/CRM/Import/Form/DataSource.tpl
@@ -146,7 +146,7 @@
     function buildSubTypes( )
     {
       element = cj('input[name="contactType"]:checked').val( );
-      var postUrl = {/literal}"{crmURL p='civicrm/ajax/subtype' h=0 }"{literal};
+      var postUrl = {/literal}"{crmURL p='civicrm/ajax/subtype' h=0}"{literal};
       var param = 'parentId='+ element;
       cj.ajax({ type: "POST", url: postUrl, data: param, async: false, dataType: 'json',
         success: function(subtype)
@@ -171,7 +171,7 @@
     function buildDedupeRules( )
     {
       element = cj("input[name=contactType]:checked").val();
-      var postUrl = {/literal}"{crmURL p='civicrm/ajax/dedupeRules' h=0 }"{literal};
+      var postUrl = {/literal}"{crmURL p='civicrm/ajax/dedupeRules' h=0}"{literal};
       var param = 'parentId='+ element;
       cj.ajax({ type: "POST", url: postUrl, data: param, async: false, dataType: 'json',
         success: function(dedupe){

--- a/templates/CRM/Mailing/Form/InsertTokens.tpl
+++ b/templates/CRM/Mailing/Form/InsertTokens.tpl
@@ -141,7 +141,7 @@ function selectValue( val, prefix) {
     return;
   }
 
-  var dataUrl = {/literal}"{crmURL p='civicrm/ajax/template' h=0 }"{literal};
+  var dataUrl = {/literal}"{crmURL p='civicrm/ajax/template' h=0}"{literal};
 
   cj.post( dataUrl, {tid: val}, function( data ) {
     var hide = (data.document_body && isPDF) ? false : true;
@@ -310,7 +310,7 @@ CRM.$(function($) {
   function setSignature() {
     var emailID = $("#fromEmailAddress").val( );
     if ( !isNaN( emailID ) ) {
-      var dataUrl = {/literal}"{crmURL p='civicrm/ajax/signature' h=0 }"{literal};
+      var dataUrl = {/literal}"{crmURL p='civicrm/ajax/signature' h=0}"{literal};
       $.post( dataUrl, {emailID: emailID}, function( data ) {
 
         if (data.signature_text) {

--- a/templates/CRM/Mailing/Form/Task.tpl
+++ b/templates/CRM/Mailing/Form/Task.tpl
@@ -9,7 +9,7 @@
 *}
 {ts 1=$totalSelectedMailingRecipients}Number of selected Mailing Recipients: %1{/ts}
 
-{if $rows }
+{if $rows}
 <div class="crm-block crm-form-block crm-mailing-task-form-block">
 <table width="30%">
   <tr class="columnheader">

--- a/templates/CRM/Mailing/Page/Event.tpl
+++ b/templates/CRM/Mailing/Page/Event.tpl
@@ -9,7 +9,7 @@
 *}
 {include file="CRM/common/pager.tpl" location="top"}
 
-{if $rows }
+{if $rows}
   {include file="CRM/common/jsortable.tpl"}
   {strip}
     <table id="mailing_event">
@@ -71,8 +71,8 @@
         jumpTo = totalPages;
       }
       {/literal}
-      {foreach from=$pager->_linkData item=val key=k }
-        {if $k neq 'crmPID' && $k neq 'force' && $k neq 'q' }
+      {foreach from=$pager->_linkData item=val key=k}
+        {if $k neq 'crmPID' && $k neq 'force' && $k neq 'q'}
         {literal}
         urlParams += '&{/literal}{$k}={$val}{literal}';
         {/literal}
@@ -80,7 +80,7 @@
       {/foreach}
       {literal}
       urlParams += '&crmPID=' + parseInt(jumpTo);
-      var submitUrl = {/literal}'{crmURL p="civicrm/mailing/report/event" q="force=1" h=0 }'{literal};
+      var submitUrl = {/literal}'{crmURL p="civicrm/mailing/report/event" q="force=1" h=0}'{literal};
       document.location = submitUrl + urlParams;
     }
   </script>

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -35,7 +35,7 @@
   </script>
   {/literal}
 {else}
-  {if $membershipMode == 'test' }
+  {if $membershipMode == 'test'}
     {assign var=registerMode value="TEST"}
     {elseif $membershipMode == 'live'}
     {assign var=registerMode value="LIVE"}
@@ -442,7 +442,7 @@
     }
     {/literal}{/if}
 
-    {if $context eq 'standalone' and $isEmailEnabledForSite }
+    {if $context eq 'standalone' and $isEmailEnabledForSite}
     {literal}
     CRM.$(function($) {
       var $form = $("form.{/literal}{$form.formClass}{literal}");

--- a/templates/CRM/Member/Form/MembershipBlock.tpl
+++ b/templates/CRM/Member/Form/MembershipBlock.tpl
@@ -156,7 +156,7 @@
         message: {/literal}"{ts escape='js'}Once you switch to using a Price Set, you won't be able to switch back to your existing settings below except by re-entering them. Are you sure you want to switch to a Price Set?{/ts}"{literal}
       }).on('crmConfirm:yes', function() {
         {/literal}
-        var dataUrl = '{crmURL p="civicrm/ajax/rest" h=0 q="className=CRM_Core_Page_AJAX&fnName=setIsQuickConfig&context=civicrm_contribution_page&id=$contributionPageID" }';
+        var dataUrl = '{crmURL p="civicrm/ajax/rest" h=0 q="className=CRM_Core_Page_AJAX&fnName=setIsQuickConfig&context=civicrm_contribution_page&id=$contributionPageID"}';
         {literal}
         $.getJSON(dataUrl).done(function(result) {window.location = CRM.url("civicrm/admin/price/field", {reset: 1, action: 'browse', sid: result});});
       });

--- a/templates/CRM/Member/Form/MembershipCommon.tpl
+++ b/templates/CRM/Member/Form/MembershipCommon.tpl
@@ -38,7 +38,7 @@
           <td>{$form.payment_instrument_id.html} {help id="payment_instrument_id" file="CRM/Contribute/Page/Tab.hlp"}</td>
         </tr>
 
-        {if $action neq 2 }
+        {if $action neq 2}
           <tr class="crm-{$formClass}-form-block-trxn_id">
             <td class="label">{$form.trxn_id.label}</td>
             <td>{$form.trxn_id.html}</td>

--- a/templates/CRM/Member/Form/MembershipRenewal.tpl
+++ b/templates/CRM/Member/Form/MembershipRenewal.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {* this template is used for renewing memberships for a contact  *}
-  {if $membershipMode == 'test' }
+  {if $membershipMode == 'test'}
     {assign var=registerMode value="TEST"}
   {elseif $membershipMode == 'live'}
     {assign var=registerMode value="LIVE"}

--- a/templates/CRM/Member/Form/Selector.tpl
+++ b/templates/CRM/Member/Form/Selector.tpl
@@ -14,7 +14,7 @@
 {strip}
 <table class="selector row-highlight">
 <thead class="sticky">
-{if ! $single and $context eq 'Search' }
+{if ! $single and $context eq 'Search'}
   <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
 {/if}
   {foreach from=$columnHeaders item=header}
@@ -32,8 +32,8 @@
   {counter start=0 skip=1 print=false}
   {foreach from=$rows item=row}
   <tr id='rowid{$row.membership_id}' class="{cycle values="odd-row,even-row"} {*if $row.cancel_date} disabled{/if*} crm-membership_{$row.membership_id}">
-     {if ! $single }
-       {if $context eq 'Search' }
+     {if ! $single}
+       {if $context eq 'Search'}
           {assign var=cbName value=$row.checkbox}
           <td>{$form.$cbName.html}</td>
        {/if}

--- a/templates/CRM/Member/Form/Task.tpl
+++ b/templates/CRM/Member/Form/Task.tpl
@@ -9,7 +9,7 @@
 *}
 {ts 1=$totalSelectedMembers}Number of selected memberships: %1{/ts}
 
-{if $rows }
+{if $rows}
 <div class="form-item">
 <table width="30%">
   <tr class="columnheader">

--- a/templates/CRM/Member/Form/Task/Print.tpl
+++ b/templates/CRM/Member/Form/Task/Print.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 <p>
-{if $rows }
+{if $rows}
 <div class="form-item">
      <span class="element-right">{include file="CRM/common/formButtons.tpl" location="top"}</span>
 </div>

--- a/templates/CRM/Member/Page/DashBoard.tpl
+++ b/templates/CRM/Member/Page/DashBoard.tpl
@@ -242,7 +242,7 @@
 {* if $pager->_totalItems *}
   <h3>{ts}Recent Memberships{/ts}</h3>
   <div class="form-item">
-    { include file="CRM/Member/Form/Selector.tpl" context="dashboard" }
+    {include file="CRM/Member/Form/Selector.tpl" context="dashboard"}
   </div>
 {* /if *}
 {/if}

--- a/templates/CRM/Pledge/Form/Pledge.tpl
+++ b/templates/CRM/Pledge/Form/Pledge.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {* this template is used for adding/editing/deleting pledge *}
-{if $showAdditionalInfo and $formType }
+{if $showAdditionalInfo and $formType}
   {include file="CRM/Contribute/Form/AdditionalInfo/$formType.tpl"}
 {else}
 {if !$email and $action neq 8 and $context neq 'standalone'}
@@ -85,7 +85,7 @@
             </td>
           </tr>
             {/if}
-        {elseif $context eq 'standalone' and $outBound_option != 2 }
+        {elseif $context eq 'standalone' and $outBound_option != 2}
           <tr id="acknowledgment-receipt" style="display:none;">
             <td class="label">{$form.is_acknowledge.label}</td>
             <td>
@@ -233,7 +233,7 @@
      };
 
     {/literal}
-    {if $context eq 'standalone' and $outBound_option != 2 }
+    {if $context eq 'standalone' and $outBound_option != 2}
     {literal}
     CRM.$(function($) {
       var $form = $("form.{/literal}{$form.formClass}{literal}");

--- a/templates/CRM/Pledge/Form/Search.tpl
+++ b/templates/CRM/Pledge/Form/Search.tpl
@@ -31,7 +31,7 @@
 </div>
 </div>
 
-{if $rowsEmpty || $rows }
+{if $rowsEmpty || $rows}
 
 <div class="crm-content-block">
 

--- a/templates/CRM/Pledge/Form/Selector.tpl
+++ b/templates/CRM/Pledge/Form/Selector.tpl
@@ -15,7 +15,7 @@
 {strip}
 <table class="selector row-highlight">
     <thead class="sticky">
-        {if ! $single and $context eq 'Search' }
+        {if ! $single and $context eq 'Search'}
             <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
         {/if}
             <th></th>
@@ -33,15 +33,15 @@
     {counter start=0 skip=1 print=false}
     {foreach from=$rows item=row}
         {cycle values="odd-row,even-row" assign=rowClass}
-        <tr id='rowid{$row.pledge_id}' class='{$rowClass} {if $row.pledge_status_name eq 'Overdue' } status-overdue{/if}'>
-            {if $context eq 'Search' }
+        <tr id='rowid{$row.pledge_id}' class='{$rowClass} {if $row.pledge_status_name eq 'Overdue'} status-overdue{/if}'>
+            {if $context eq 'Search'}
                 {assign var=cbName value=$row.checkbox}
                 <td>{$form.$cbName.html}</td>
             {/if}
             <td>
                 <a class="crm-expand-row" title="{ts}view payments{/ts}" href="{crmURL p='civicrm/pledge/payment' q="action=browse&context=`$context`&pledgeId=`$row.pledge_id`&cid=`$row.contact_id`"}"></a>
             </td>
-            {if ! $single }
+            {if ! $single}
                 <td>{$row.contact_type}</td>
                 <td>
                     <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}">{$row.sort_name}</a>
@@ -60,7 +60,7 @@
     {/foreach}
 
     {* Dashboard only lists 10 most recent pledges. *}
-    {if $context EQ 'dashboard' and $limit and $pager->_totalItems GT $limit }
+    {if $context EQ 'dashboard' and $limit and $pager->_totalItems GT $limit}
         <tr class="even-row">
             <td colspan="10"><a href="{crmURL p='civicrm/pledge/search' q='reset=1'}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Find more pledges{/ts}... </a></td>
         </tr>

--- a/templates/CRM/Pledge/Form/Task.tpl
+++ b/templates/CRM/Pledge/Form/Task.tpl
@@ -9,7 +9,7 @@
 *}
 {ts 1=$totalSelectedPledges}Number of selected pledges: %1{/ts}
 
-{if $rows }
+{if $rows}
 <div class="crm-block crm-form-block crm-pledge-task-form-block">
 <table width="30%">
   <tr class="columnheader">

--- a/templates/CRM/Pledge/Form/Task/Print.tpl
+++ b/templates/CRM/Pledge/Form/Task/Print.tpl
@@ -9,7 +9,7 @@
 *}
 <p>
 
-{if $rows }
+{if $rows}
 <div class="form-item">
      <span class="element-right">{$form.buttons.html}</span>
 </div>

--- a/templates/CRM/Pledge/Page/DashBoard.tpl
+++ b/templates/CRM/Pledge/Page/DashBoard.tpl
@@ -21,46 +21,46 @@
 <tr>
     <td scope="row"><strong>{ts}Total Pledges{/ts}</strong></td>
     {* prior month *}
-        <td class="right"><a href="{$previousToDate.Completed.purl}">{$previousToDate.Completed.pledge_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $previousToDate.Completed.pledge_count }<a href="{$previousToDate.Completed.purl}">{$previousToDate.Completed.pledge_amount}</a>{/if}</td>
+        <td class="right"><a href="{$previousToDate.Completed.purl}">{$previousToDate.Completed.pledge_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $previousToDate.Completed.pledge_count}<a href="{$previousToDate.Completed.purl}">{$previousToDate.Completed.pledge_amount}</a>{/if}</td>
     {* current month *}
-        <td class="right"><a href="{$monthToDate.Completed.purl}">{$monthToDate.Completed.pledge_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $monthToDate.Completed.pledge_count }<a href="{$monthToDate.Completed.purl}">{$monthToDate.Completed.pledge_amount}</a>{/if}</td>
+        <td class="right"><a href="{$monthToDate.Completed.purl}">{$monthToDate.Completed.pledge_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $monthToDate.Completed.pledge_count}<a href="{$monthToDate.Completed.purl}">{$monthToDate.Completed.pledge_amount}</a>{/if}</td>
     {* current year *}
-        <td class="right"><a href="{$yearToDate.Completed.purl}">{$yearToDate.Completed.pledge_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $yearToDate.Completed.pledge_count }<a href="{$yearToDate.Completed.purl}">{$yearToDate.Completed.pledge_amount}</a>{/if}</td>
+        <td class="right"><a href="{$yearToDate.Completed.purl}">{$yearToDate.Completed.pledge_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $yearToDate.Completed.pledge_count}<a href="{$yearToDate.Completed.purl}">{$yearToDate.Completed.pledge_amount}</a>{/if}</td>
     {* cumulative *}
-        <td class="right"><a href="{$startToDate.Completed.purl}">{$startToDate.Completed.pledge_count}</a></td><td class="right">{if $startToDate.Completed.pledge_count }<a href="{$startToDate.Completed.purl}">{$startToDate.Completed.pledge_amount}</a>{/if}</td>
+        <td class="right"><a href="{$startToDate.Completed.purl}">{$startToDate.Completed.pledge_count}</a></td><td class="right">{if $startToDate.Completed.pledge_count}<a href="{$startToDate.Completed.purl}">{$startToDate.Completed.pledge_amount}</a>{/if}</td>
 </tr>
 <tr>
     <td scope="row"><strong>{ts}Payments Received{/ts}</strong></td>
     {* prior month *}
-     <td class="right"><a href="{$previousToDate.Completed.url}">{$previousToDate.Completed.received_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $previousToDate.Completed.received_count }<a href="{$previousToDate.Completed.url}">{$previousToDate.Completed.received_amount}</a>{/if}</td>
+     <td class="right"><a href="{$previousToDate.Completed.url}">{$previousToDate.Completed.received_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $previousToDate.Completed.received_count}<a href="{$previousToDate.Completed.url}">{$previousToDate.Completed.received_amount}</a>{/if}</td>
     {* current month *}
         <td class="right"><a href="{$monthToDate.Completed.url}">{$monthToDate.Completed.received_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $monthToDate.Completed.received_count}<a href="{$monthToDate.Completed.url}">{$monthToDate.Completed.received_amount}</a>{/if}</td>
     {* current year *}
-        <td class="right"><a href="{$yearToDate.Completed.url}">{$yearToDate.Completed.received_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $yearToDate.Completed.received_count }<a href="{$yearToDate.Completed.url}">{$yearToDate.Completed.received_amount}</a>{/if}</td>
+        <td class="right"><a href="{$yearToDate.Completed.url}">{$yearToDate.Completed.received_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $yearToDate.Completed.received_count}<a href="{$yearToDate.Completed.url}">{$yearToDate.Completed.received_amount}</a>{/if}</td>
     {* cumulative *}
-        <td class="right"><a href="{$startToDate.Completed.url}">{$startToDate.Completed.received_count}</a></td><td class="right">{if $startToDate.Completed.received_count }<a href="{$startToDate.Completed.url}">{$startToDate.Completed.received_amount}</a>{/if}</td>  
+        <td class="right"><a href="{$startToDate.Completed.url}">{$startToDate.Completed.received_count}</a></td><td class="right">{if $startToDate.Completed.received_count}<a href="{$startToDate.Completed.url}">{$startToDate.Completed.received_amount}</a>{/if}</td>
 </tr>
 <tr>
     <td scope="row"><strong>{ts}Balance Due{/ts}</strong></td>
     {* prior month *}
-        <td class="right"><a href="{$previousToDate.Pending.url}">{$previousToDate.Pending.received_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $previousToDate.Pending.received_count }<a href="{$previousToDate.Pending.url}">{$previousToDate.Pending.received_amount}</a>{/if}</td>
+        <td class="right"><a href="{$previousToDate.Pending.url}">{$previousToDate.Pending.received_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $previousToDate.Pending.received_count}<a href="{$previousToDate.Pending.url}">{$previousToDate.Pending.received_amount}</a>{/if}</td>
     {* current month *}
-        <td class="right"><a href="{$monthToDate.Pending.url}">{$monthToDate.Pending.received_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $monthToDate.Pending.received_count }<a href="{$monthToDate.Pending.url}">{$monthToDate.Pending.received_amount}</a>{/if}</td>
+        <td class="right"><a href="{$monthToDate.Pending.url}">{$monthToDate.Pending.received_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $monthToDate.Pending.received_count}<a href="{$monthToDate.Pending.url}">{$monthToDate.Pending.received_amount}</a>{/if}</td>
     {* current year *}
-        <td class="right"><a href="{$yearToDate.Pending.url}">{$yearToDate.Pending.received_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $yearToDate.Pending.received_count }<a href="{$yearToDate.Pending.url}">{$yearToDate.Pending.received_amount}</a>{/if}</td>
+        <td class="right"><a href="{$yearToDate.Pending.url}">{$yearToDate.Pending.received_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $yearToDate.Pending.received_count}<a href="{$yearToDate.Pending.url}">{$yearToDate.Pending.received_amount}</a>{/if}</td>
     {* cumulative *}
-        <td class="right"><a href="{$startToDate.Pending.url}">{$startToDate.Pending.received_count}</a></td><td class="right">{if $startToDate.Pending.received_count }<a href="{$startToDate.Pending.url}">{$startToDate.Pending.received_amount}</a>{/if}</td>
+        <td class="right"><a href="{$startToDate.Pending.url}">{$startToDate.Pending.received_count}</a></td><td class="right">{if $startToDate.Pending.received_count}<a href="{$startToDate.Pending.url}">{$startToDate.Pending.received_amount}</a>{/if}</td>
 </tr>
 <tr>
     <td scope="row"><strong>{ts}Past Due{/ts}</strong></td>
     {* prior month *}
-        <td class="right"><a href="{$previousToDate.Overdue.url}">{$previousToDate.Overdue.received_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $previousToDate.Overdue.received_count }<a href="{$previousToDate.Overdue.url}">{$previousToDate.Overdue.received_amount}</a>{/if}</td>
+        <td class="right"><a href="{$previousToDate.Overdue.url}">{$previousToDate.Overdue.received_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $previousToDate.Overdue.received_count}<a href="{$previousToDate.Overdue.url}">{$previousToDate.Overdue.received_amount}</a>{/if}</td>
     {* current month *}
-        <td class="right"><a href="{$monthToDate.Overdue.url}">{$monthToDate.Overdue.received_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $monthToDate.Overdue.received_count }<a href="{$monthToDate.Overdue.url}">{$monthToDate.Overdue.received_amount}</a>{/if}</td>
+        <td class="right"><a href="{$monthToDate.Overdue.url}">{$monthToDate.Overdue.received_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $monthToDate.Overdue.received_count}<a href="{$monthToDate.Overdue.url}">{$monthToDate.Overdue.received_amount}</a>{/if}</td>
     {* current year *}
-        <td class="right"><a href="{$yearToDate.Overdue.url}">{$yearToDate.Overdue.received_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $yearToDate.Overdue.received_count }<a href="{$yearToDate.Overdue.url}">{$yearToDate.Overdue.received_amount}</a>{/if}</td>
+        <td class="right"><a href="{$yearToDate.Overdue.url}">{$yearToDate.Overdue.received_count}</a></td><td class="right" style="border-right: 5px double #999999;">{if $yearToDate.Overdue.received_count}<a href="{$yearToDate.Overdue.url}">{$yearToDate.Overdue.received_amount}</a>{/if}</td>
     {* cumulative *}
-        <td class="right"><a href="{$startToDate.Overdue.url}">{$startToDate.Overdue.received_count}</a></td><td class="right">{if $startToDate.Overdue.received_count }<a href="{$startToDate.Overdue.url}">{$startToDate.Overdue.received_amount}</a>{/if}</td>
+        <td class="right"><a href="{$startToDate.Overdue.url}">{$startToDate.Overdue.received_count}</a></td><td class="right">{if $startToDate.Overdue.received_count}<a href="{$startToDate.Overdue.url}">{$startToDate.Overdue.received_amount}</a>{/if}</td>
 </tr>
 </table>
 

--- a/templates/CRM/Pledge/Page/Payment.tpl
+++ b/templates/CRM/Pledge/Page/Payment.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if $action eq 2 } {* update *}
+{if $action eq 2} {* update *}
     {include file="CRM/Pledge/Form/Payment.tpl"}
 {else}
 {if $context eq 'dashboard'}{assign var='context' value='pledgeDashboard'}{/if}
@@ -23,16 +23,16 @@
   </tr>
 
   {foreach from=$rows item=row}
-   <tr class="{cycle values="odd-row,even-row"} {if $row.status eq 'Overdue' } status-overdue{/if}">
+   <tr class="{cycle values="odd-row,even-row"} {if $row.status eq 'Overdue'} status-overdue{/if}">
     <td class="right">{$row.scheduled_amount|crmMoney:$row.currency}</td>
     <td>{$row.scheduled_date|truncate:10:''|crmDate}</td>
     <td class="right">{$row.total_amount|crmMoney:$row.currency}</td>
     <td>{$row.receive_date|truncate:10:''|crmDate}</td>
     <td>{$row.reminder_date|truncate:10:''|crmDate}</td>
     <td class="right">{if $row.reminder_count}{$row.reminder_count}{/if}</td>
-    <td {if ! ($permission EQ 'edit' and ($row.status eq 'Pending' or $row.status eq 'Overdue' or $row.status eq 'Completed')) } colspan="2"{/if} >{$row.label}</td>
+    <td {if ! ($permission EQ 'edit' and ($row.status eq 'Pending' or $row.status eq 'Overdue' or $row.status eq 'Completed'))} colspan="2"{/if} >{$row.label}</td>
 {if $context neq 'user'}
-    {if $permission EQ 'edit' and ($row.status eq 'Pending' or $row.status eq 'Overdue' or $row.status eq 'Completed') }
+    {if $permission EQ 'edit' and ($row.status eq 'Pending' or $row.status eq 'Overdue' or $row.status eq 'Completed')}
         <td class="nowrap">
         {if $row.status eq 'Completed'} {* Link to view contribution record for completed payment.*}
             {capture assign=viewContribURL}{crmURL p="civicrm/contact/view/contribution" q="reset=1&id=`$row.contribution_id`&cid=`$contactId`&action=view&context=`$context`"}{/capture}

--- a/templates/CRM/Pledge/Page/UserDashboard.tpl
+++ b/templates/CRM/Pledge/Page/UserDashboard.tpl
@@ -21,7 +21,7 @@
   </tr>
   {counter start=0 skip=1 print=false}
   {foreach from=$pledge_rows item=row}
-  <tr id='rowid{$row.pledge_id}' class="{cycle values="odd-row,even-row"} {if $row.pledge_status_name eq 'Overdue' } disabled{/if} crm-pledge crm-pledge_{$row.pledge_id} ">
+  <tr id='rowid{$row.pledge_id}' class="{cycle values="odd-row,even-row"} {if $row.pledge_status_name eq 'Overdue'} disabled{/if} crm-pledge crm-pledge_{$row.pledge_id} ">
     <td class="crm-pledge-pledge_amount">{$row.pledge_amount|crmMoney:$row.pledge_currency}</td>
     <td class="crm-pledge-pledge_total_paid">{$row.pledge_total_paid|crmMoney:$row.pledge_currency}</td>
     <td class="crm-pledge-pledge_amount">{$row.pledge_amount-$row.pledge_total_paid|crmMoney:$row.pledge_currency}</td>
@@ -32,7 +32,7 @@
     <td class="crm-pledge-pledge_status crm-pledge-pledge_status_{$row.pledge_status}">{$row.pledge_status}</td>
     {if empty($userChecksum)}
       <td>
-        {if $row.pledge_contribution_page_id and ($row.pledge_status_name neq 'Completed') and ( $row.contact_id eq $loggedUserID ) }
+        {if $row.pledge_contribution_page_id and ($row.pledge_status_name neq 'Completed') and ($row.contact_id eq $loggedUserID)}
           <a href="{crmURL p='civicrm/contribute/transact' q="reset=1&id=`$row.pledge_contribution_page_id`&pledgeId=`$row.pledge_id`"}">{ts}Make Payment{/ts}</a><br/>
         {/if}
         <a class="crm-expand-row" title="{ts}view payments{/ts}" href="{crmURL p='civicrm/pledge/payment' q="action=browse&context=`$context`&pledgeId=`$row.pledge_id`&cid=`$row.contact_id`"}">{ts}Payments{/ts}</a>

--- a/templates/CRM/Price/Form/Field.tpl
+++ b/templates/CRM/Price/Form/Field.tpl
@@ -243,7 +243,7 @@
 {/literal}
 
 {* Give link to view/edit choice options if in edit mode and html_type is one of the multiple choice types *}
-{if $action eq 2 AND ($form.data_type.value.1.0 eq 'CheckBox' OR $form.data_type.value.1.0 eq 'Radio' OR $form.data_type.value.1.0 eq 'Select') }
+{if $action eq 2 AND ($form.data_type.value.1.0 eq 'CheckBox' OR $form.data_type.value.1.0 eq 'Radio' OR $form.data_type.value.1.0 eq 'Select')}
 <div class="action-link">
   <a href="{crmURL p="civicrm/admin/event/field/option" q="reset=1&action=browse&fid=`$fid`"}" class="button"><span>{ts}Multiple Choice Options{/ts}</span></a>
 </div>

--- a/templates/CRM/Price/Form/LineItem.tpl
+++ b/templates/CRM/Price/Form/LineItem.tpl
@@ -127,7 +127,7 @@
             {assign var="intPCount" value=$p_count.participant_count|intval}
             {assign var="lineItemCount" value=$lineItemCount+$intPCount}
           {/foreach}
-          {if $lineItemCount < 1 }
+          {if $lineItemCount < 1}
             {assign var="lineItemCount" value=1}
           {/if}
           {assign var="totalcount" value=$totalcount+$lineItemCount}

--- a/templates/CRM/Price/Form/Option.tpl
+++ b/templates/CRM/Price/Form/Option.tpl
@@ -54,7 +54,7 @@
       <tr class="crm-price-option-form-block-financial-type">
         <td class="label">{$form.financial_type_id.label}</td>
         <td>
-          {if !$financialType }
+          {if !$financialType}
             {capture assign=ftUrl}{crmURL p='civicrm/admin/financial/financialType' q="reset=1"}{/capture}
             {ts 1=$ftUrl}There are no financial types configured with a linked 'Revenue Account of' account. <a href='%1'>Click here</a> if you want to configure financial types for your site.{/ts}
           {else}

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -14,7 +14,7 @@
     {/if}
 
     {assign var='adminFld' value=false}
-    {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM') }
+    {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM')}
       {assign var='adminFld' value=true}
       {if $priceSet.id && !$priceSet.is_quick_config}
         <div class='float-right'>
@@ -27,7 +27,7 @@
 
     {foreach from=$priceSet.fields item=element key=field_id}
         {* Skip 'Admin' visibility price fields WHEN this tpl is used in online registration unless user has administer CiviCRM permission. *}
-        {if $element.visibility EQ 'public' || ($element.visibility EQ 'admin' && $adminFld EQ true) || $context eq 'standalone' || $context eq 'advanced' || $context eq 'search' || $context eq 'participant' || $context eq 'dashboard' }
+        {if $element.visibility EQ 'public' || ($element.visibility EQ 'admin' && $adminFld EQ true) || $context eq 'standalone' || $context eq 'advanced' || $context eq 'search' || $context eq 'participant' || $context eq 'dashboard'}
             {if $element.help_pre}<span class="content description">{$element.help_pre}</span><br />{/if}
             <div class="crm-section {$element.name}-section crm-price-field-id-{$field_id}">
             {if ($element.html_type eq 'CheckBox' || $element.html_type == 'Radio') && $element.options_per_line}
@@ -39,7 +39,7 @@
                 {assign var="rowCount" value="0"}
                 {foreach name=outer key=key item=item from=$form.$element_name}
                   {assign var="elementCount" value=`$elementCount+1`}
-                  {if is_numeric($key) }
+                  {if is_numeric($key)}
                     {assign var="optionCount" value=`$optionCount+1`}
                     {if $optionCount == 1}
                       {assign var="rowCount" value=`$rowCount+1`}

--- a/templates/CRM/Price/Page/Field.tpl
+++ b/templates/CRM/Price/Page/Field.tpl
@@ -11,7 +11,7 @@
   {include file="CRM/Price/Form/Field.tpl"}
 {elseif $action eq 8 and !$usedBy and !$isReserved}
   {include file="CRM/Price/Form/DeleteField.tpl"}
-{elseif $action eq 1024 }
+{elseif $action eq 1024}
   {include file="CRM/Price/Form/Preview.tpl"}
 {elseif $usedBy}
   <div id="price_set_used_by" class="messages status no-popup">
@@ -64,7 +64,7 @@
                     {$taxTerm} ({$row.tax_rate|string_format:"%.2f"}%)
                 {/if}
       </td>
-            <td>{if $row.html_type eq "Text / Numeric Quantity" }{$row.tax_amount|crmMoney}{/if}</td>
+            <td>{if $row.html_type eq "Text / Numeric Quantity"}{$row.tax_amount|crmMoney}{/if}</td>
         {/if}
         <td class="field-action">{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
       </tr>

--- a/templates/CRM/Price/Page/LineItem.tpl
+++ b/templates/CRM/Price/Page/LineItem.tpl
@@ -114,7 +114,7 @@
           {assign var="intPCount" value=$p_count.participant_count|intval}
           {assign var="lineItemCount" value=$lineItemCount+$intPCount}
         {/foreach}
-        {if $lineItemCount < 1 }
+        {if $lineItemCount < 1}
           {assign var="lineItemCount" value=1}
         {/if}
         {assign var="totalcount" value=$totalcount+$lineItemCount}

--- a/templates/CRM/Price/Page/Option.tpl
+++ b/templates/CRM/Price/Page/Option.tpl
@@ -72,7 +72,7 @@
               <td class="nowrap crm-price-option-financial-type-id">{$row.financial_type_id}</td>
               <td class="nowrap crm-price-option-order">{$row.weight|smarty:nodefaults}</td>
               {if $getTaxDetails}
-                <td>{if $row.tax_rate != '' }
+                <td>{if $row.tax_rate != ''}
                       {$taxTerm} ({$row.tax_rate}%)
                     {/if}
                 </td>

--- a/templates/CRM/Price/Page/Set.tpl
+++ b/templates/CRM/Price/Page/Set.tpl
@@ -55,7 +55,7 @@
         {/foreach}
         </table>
 
-        {if NOT ($action eq 1 or $action eq 2) }
+        {if NOT ($action eq 1 or $action eq 2)}
         <div class="action-link">
             {crmButton p='civicrm/admin/price/edit' q="action=add&reset=1" id="newPriceSet"  icon="plus-circle"}{ts}Add Set of Price Fields{/ts}{/crmButton}
         </div>

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -29,7 +29,7 @@
 {* Wrap in crm-container div so crm styles are used.*}
 {* Replace div id "crm-container" only when profile is not loaded in civicrm container, i.e for profile shown in my account and in profile standalone mode otherwise id should be "crm-profile-block" *}
 
-  {if $action eq 1 or $action eq 2 or $action eq 4 }
+  {if $action eq 1 or $action eq 2 or $action eq 4}
   <div id="crm-profile-block" class="crm-container crm-public">
     {else}
   <div id="crm-container" class="crm-container crm-public" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">

--- a/templates/CRM/Profile/Form/Search.tpl
+++ b/templates/CRM/Profile/Form/Search.tpl
@@ -7,8 +7,8 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if ! empty( $fields )}
-  {if $groupId }
+{if ! empty($fields)}
+  {if $groupId}
   <div class="crm-accordion-wrapper crm-group-{$groupId}-accordion {if $rows}collapsed{/if}">
     <div class="crm-accordion-header crm-master-accordion-header">
       {ts}Edit Search Criteria{/ts}

--- a/templates/CRM/Profile/Page/Dynamic.tpl
+++ b/templates/CRM/Profile/Page/Dynamic.tpl
@@ -9,7 +9,7 @@
 *}
 {if ! empty( $row )}
 {* wrap in crm-container div so crm styles are used *}
-    {if $overlayProfile }
+    {if $overlayProfile}
         {include file="CRM/Profile/Page/Overlay.tpl"}
     {else}
         <div id="crm-container" class="crm-container" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">

--- a/templates/CRM/Profile/Page/Listings.tpl
+++ b/templates/CRM/Profile/Page/Listings.tpl
@@ -12,7 +12,7 @@
 {crmRegion name=profile-search-`$ufGroupName`}
 
 {* make sure there are some fields in the selector *}
-{if ! empty( $columnHeaders ) || $isReset }
+{if ! empty($columnHeaders) || $isReset}
 
 {if $search}
 <div class="crm-block crm-form-block">

--- a/templates/CRM/Profile/Page/Overlay.tpl
+++ b/templates/CRM/Profile/Page/Overlay.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if $overlayProfile }
+{if $overlayProfile}
 <table class="crm-table-group-summary">
   <tr>
     <td colspan="2">{$displayName}</td>

--- a/templates/CRM/Profile/Page/View.tpl
+++ b/templates/CRM/Profile/Page/View.tpl
@@ -10,7 +10,7 @@
 {* If you want a custom profile view, you can access field labels and values in $profileFields_N array - where N is profile ID. *}
 {* EXAMPLES *}{* $profileFields_1.last_name.label *}{* $profileFields_1.last_name.value *}
 
-{if $overlayProfile }
+{if $overlayProfile}
     {foreach from=$profileGroups item=group}
         <div class="crm-summary-group">
            {$group.content}

--- a/templates/CRM/Report/Form/Campaign/SurveyCoverSheet.tpl
+++ b/templates/CRM/Report/Form/Campaign/SurveyCoverSheet.tpl
@@ -35,7 +35,7 @@
 </table>
 </div>
 
-{/if }
+{/if}
 
 
 {* print survey response set option value and label *}

--- a/templates/CRM/Report/Form/Contact/Detail.tpl
+++ b/templates/CRM/Report/Form/Contact/Detail.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {* this div is being used to apply special css *}
-    {if !$section }
+    {if !$section}
     <div class="crm-block crm-form-block crm-report-field-form-block">
         {include file="CRM/Report/Form/Fields.tpl"}
     </div>
@@ -16,7 +16,7 @@
 
 <div class="crm-block crm-content-block crm-report-form-block">
 {include file="CRM/Report/Form/Actions.tpl"}
-{if !$section }
+{if !$section}
 {include file="CRM/Report/Form/Statistics.tpl" top=true bottom=false}
 {/if}
     {if $rows}
@@ -178,7 +178,7 @@
             </table>
         {/if}
 
-        {if !$section }
+        {if !$section}
             {*Statistics at the bottom of the page*}
             {include file="CRM/Report/Form/Statistics.tpl" top=false bottom=true}
         {/if}

--- a/templates/CRM/Report/Form/Event/Income.tpl
+++ b/templates/CRM/Report/Form/Event/Income.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {* this div is being used to apply special css *}
-    {if !$section }
+    {if !$section}
     <div class="crm-block crm-form-block crm-report-field-form-block">
     {include file="CRM/Report/Form/Fields.tpl"}
        </div>
@@ -17,7 +17,7 @@
 <div class="crm-block crm-content-block crm-report-form-block">
 {include file="CRM/Report/Form/Actions.tpl"}
 {*Statistics at the Top of the page*}
-    {if !$section }
+    {if !$section}
         {include file="CRM/Report/Form/Statistics.tpl" top=true bottom=false}
     {/if}
 
@@ -68,7 +68,7 @@
     <div class="report-pager">
             {include file="CRM/common/pager.tpl"}
         </div>
-        {if !$section }
+        {if !$section}
             {*Statistics at the bottom of the page*}
             {include file="CRM/Report/Form/Statistics.tpl" top=false bottom=true}
         {/if}

--- a/templates/CRM/Report/Form/Layout/Overlay.tpl
+++ b/templates/CRM/Report/Form/Layout/Overlay.tpl
@@ -135,7 +135,7 @@
     </div>
     {if $pager and $pager->_response and $pager->_response.numPages > 1}
         <div class="report-pager">
-            {include file="CRM/common/pager.tpl" }
+            {include file="CRM/common/pager.tpl"}
         </div>
     {/if}
 {/if}

--- a/templates/CRM/Tag/Form/Edit.tpl
+++ b/templates/CRM/Tag/Form/Edit.tpl
@@ -9,7 +9,7 @@
 *}
 {* this template is used for adding/editing a tag (admin)  *}
 <div class="crm-block crm-form-block crm-tag-form-block">
-  {if $action eq 1 or $action eq 2 }
+  {if $action eq 1 or $action eq 2}
     <table class="form-layout-compressed">
        <tr class="crm-tag-form-block-label">
           <td class="label">{$form.name.label}</td>

--- a/templates/CRM/UF/Form/Field.tpl
+++ b/templates/CRM/UF/Form/Field.tpl
@@ -144,7 +144,7 @@ function showLabel( ) {
   // Code to set Profile Field help, from custom data field help
   if (fieldId.substring(0, 7) == 'custom_') {
     fieldId = fieldId.substring( fieldId.length, 7);
-    var dataUrl = {/literal}"{crmURL p='civicrm/ajax/custom' h=0 }"{literal};
+    var dataUrl = {/literal}"{crmURL p='civicrm/ajax/custom' h=0}"{literal};
     cj.post( dataUrl, { id: fieldId }, function(data) {
       cj('#help_post').val(data.help_post);
       cj('#help_pre').val(data.help_pre);
@@ -203,7 +203,7 @@ CRM.$(function($) {
 function multiSummaryToggle(customId) {
   if (customId && customId.match(/custom_[\d]/)) {
 
-    var dataUrl = "{/literal}{crmURL p='civicrm/ajax/rest' q='className=CRM_UF_Page_AJAX&fnName=checkIsMultiRecord&json=1' h=0 }"{literal};
+    var dataUrl = "{/literal}{crmURL p='civicrm/ajax/rest' q='className=CRM_UF_Page_AJAX&fnName=checkIsMultiRecord&json=1' h=0}"{literal};
     dataUrl = dataUrl + '&customId=' + customId;
     cj.ajax({  url: dataUrl,
       async: false,

--- a/templates/CRM/UF/Form/Group.tpl
+++ b/templates/CRM/UF/Form/Group.tpl
@@ -12,7 +12,7 @@
   <h3>{ts}Delete CiviCRM Profile{/ts} - {$profileTitle}</h3>
 {/if}
 <div class="crm-block crm-form-block crm-uf_group-form-block">
-{if ($action eq 2 or $action eq 4) and $snippet neq 'json' } {* Update or View*}
+{if ($action eq 2 or $action eq 4) and $snippet neq 'json'} {* Update or View*}
   <div class="action-link">
     <a href="{crmURL p='civicrm/admin/uf/group/field' q="action=browse&reset=1&gid=$gid"}" class="button"><span>{ts}View or Edit Fields for this Profile{/ts}</a></span>
     <div class="clear"></div>

--- a/templates/CRM/UF/Page/Field.tpl
+++ b/templates/CRM/UF/Page/Field.tpl
@@ -8,9 +8,9 @@
  +--------------------------------------------------------------------+
 *}
 
-{if $action eq 1 or $action eq 2 or $action eq 4 or $action eq 8 }
+{if $action eq 1 or $action eq 2 or $action eq 4 or $action eq 8}
     {include file="CRM/UF/Form/Field.tpl"}
-{elseif $action eq 1024 }
+{elseif $action eq 1024}
     {include file="CRM/UF/Form/Preview.tpl"}
 {else}
 <div class="crm-content-block">
@@ -23,7 +23,7 @@
             <thead>
             <tr>
                 <th>{ts}Field Name{/ts}</th>
-                {if in_array("Profile",$otherModules) or in_array("Search Profile",$otherModules) }
+                {if in_array("Profile",$otherModules) or in_array("Search Profile",$otherModules)}
                 <th>{ts}Visibility{/ts}</th>
                 <th>{ts}Searchable?{/ts}</th>
                 <th>{ts}Results Column?{/ts}</th>
@@ -38,7 +38,7 @@
             {foreach from=$ufField item=row}
             <tr id="UFField-{$row.id}" data-action="setvalue" class="crm-entity {cycle values="odd-row,even-row"}{if !empty($row.class)} {$row.class}{/if}{if NOT $row.is_active} disabled{/if}">
                 <td><span class="crmf-label crm-editable">{$row.label}</span>({$row.field_type})</td>
-                {if in_array("Profile",$otherModules) or in_array("Search Profile",$otherModules) }
+                {if in_array("Profile",$otherModules) or in_array("Search Profile",$otherModules)}
                 <td class="crm-editable crmf-visibility" data-type="select">{$row.visibility_display}</td>
                 <td class="crm-editable crmf-is_searchable" data-type="boolean">{if $row.is_searchable eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
                 <td class="crm-editable crmf-in_selector" data-type="boolean">{if $row.in_selector eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
@@ -54,7 +54,7 @@
         {/strip}
         {if not ($action eq 2 or $action eq 1)}
             <div class="action-link">
-                {crmButton p="civicrm/admin/uf/group/field/add" q="reset=1&action=add&gid=$gid" icon="plus-circle"}{ts}Add Field{/ts}{/crmButton}{if !$isGroupReserved}{crmButton p="civicrm/admin/uf/group" q="action=update&id=`$gid`&reset=1&context=field" icon="wrench"}{ts}Edit Settings{/ts}{/crmButton}{/if}{crmButton p="civicrm/admin/uf/group" q="action=preview&id=`$gid`&reset=1&field=0&context=field" icon="television"}{ts}Preview (all fields){/ts}{/crmButton}{if !$skipCreate }{crmButton p="civicrm/profile/create" q="gid=$gid&reset=1" icon="play-circle"}{ts}Use (create mode){/ts}{/crmButton}{/if}
+                {crmButton p="civicrm/admin/uf/group/field/add" q="reset=1&action=add&gid=$gid" icon="plus-circle"}{ts}Add Field{/ts}{/crmButton}{if !$isGroupReserved}{crmButton p="civicrm/admin/uf/group" q="action=update&id=`$gid`&reset=1&context=field" icon="wrench"}{ts}Edit Settings{/ts}{/crmButton}{/if}{crmButton p="civicrm/admin/uf/group" q="action=preview&id=`$gid`&reset=1&field=0&context=field" icon="television"}{ts}Preview (all fields){/ts}{/crmButton}{if !$skipCreate}{crmButton p="civicrm/profile/create" q="gid=$gid&reset=1" icon="play-circle"}{ts}Use (create mode){/ts}{/crmButton}{/if}
                 <div class="clear"></div>
             </div>
         {/if}

--- a/templates/CRM/UF/Page/Group.tpl
+++ b/templates/CRM/UF/Page/Group.tpl
@@ -68,7 +68,7 @@
               </thead>
               <tbody>
                 {foreach from=$rows item=row}
-                {if !$row.is_reserved }
+                {if !$row.is_reserved}
                   <tr id="UFGroup-{$row.id}" data-action="setvalue" class="crm-entity {$row.class}{if NOT $row.is_active} disabled{/if}">
                     <td class="crmf-title crm-editable">{$row.title}</td>
                     <td class="crmf-frontend_title crm-editable">{$row.frontend_title}</td>

--- a/templates/CRM/common/CMSUser.tpl
+++ b/templates/CRM/common/CMSUser.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if $showCMS }{*true if is_cms_user field is set *}
+{if $showCMS}{*true if is_cms_user field is set *}
    <fieldset class="crm-group crm_user-group">
       <legend>{ts}Account{/ts}</legend>
       <div class="messages help cms_user_help-section">

--- a/templates/CRM/common/WizardHeader.tpl
+++ b/templates/CRM/common/WizardHeader.tpl
@@ -12,7 +12,7 @@
 <div id="wizard-steps">
    <ul class="wizard-bar{if $wizard.style.barClass}-{$wizard.style.barClass}{/if}">
     {section name=step loop=$wizard.steps}
-        {if count ( $wizard.steps ) > 5 }
+        {if count ( $wizard.steps ) > 5}
             {* truncate step titles so header isn't too wide *}
             {assign var="title" value=$wizard.steps[step].title|crmFirstWord}
         {else}

--- a/templates/CRM/common/checkUsernameAvailable.tpl
+++ b/templates/CRM/common/checkUsernameAvailable.tpl
@@ -47,7 +47,7 @@ cj("#checkavailability").click(function() {
       cj("#msgbox").removeClass().addClass('cmsmessagebox').css({"color":"#000","backgroundColor":"#FFC","border":"1px solid #c93"}).text(check).fadeIn("slow");
 
       //check the username exists or not from ajax
-   var contactUrl = {/literal}"{crmURL p='civicrm/ajax/cmsuser' h=0 }"{literal};
+   var contactUrl = {/literal}"{crmURL p='civicrm/ajax/cmsuser' h=0}"{literal};
 
    var checkUserParams = {
        cms_name: cj("#cms_name").val(),

--- a/templates/CRM/common/dedupe.tpl
+++ b/templates/CRM/common/dedupe.tpl
@@ -62,7 +62,7 @@ function saveProcessDupes( cid, oid, oper, context ) {
        var statusMsg = {/literal}'{ts escape="js"}Marked as duplicates.{/ts}'{literal};
     }
 
-    var url = {/literal}"{crmURL p='civicrm/ajax/rest' q='className=CRM_Contact_Page_AJAX&fnName=processDupes' h=0 }"{literal};
+    var url = {/literal}"{crmURL p='civicrm/ajax/rest' q='className=CRM_Contact_Page_AJAX&fnName=processDupes' h=0}"{literal};
     //post the data to process dupes.
     cj.post( url,
             {cid: cid, oid: oid, op: oper},

--- a/templates/CRM/common/searchResultTasks.tpl
+++ b/templates/CRM/common/searchResultTasks.tpl
@@ -15,7 +15,7 @@
     <td style="width: 40%;">
     {if !empty($savedSearch.name)}{$savedSearch.name} ({ts}smart group{/ts}) - {/if}
     {ts count=$pager->_totalItems plural='%count Results'}%count Result{/ts}{if $selectorLabel}&nbsp;-&nbsp;{$selectorLabel}{/if}
-    {if $context == 'Event' && $participantCount && ( $pager->_totalItems ne $participantCount ) }
+    {if $context == 'Event' && $participantCount && ($pager->_totalItems ne $participantCount)}
         <br />{ts}Actual participant count{/ts} : {$participantCount} {help id="id-actual_participant_count" file="CRM/Event/Form/Search/Results.hlp"} &nbsp;
     {/if}
     </td>

--- a/templates/CRM/common/standalone.tpl
+++ b/templates/CRM/common/standalone.tpl
@@ -17,8 +17,8 @@
   {/crmRegion}
 
 {* @todo This is probably not required? *}
-{if isset($buildNavigation) and !$urlIsPublic }
-    {include file="CRM/common/Navigation.tpl" }
+{if isset($buildNavigation) and !$urlIsPublic}
+    {include file="CRM/common/Navigation.tpl"}
 {/if}
 
   <title>{$docTitle}</title>

--- a/xml/templates/message_templates/case_activity_html.tpl
+++ b/xml/templates/message_templates/case_activity_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
   {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-  {capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-  {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+  {capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+  {capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
     <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 

--- a/xml/templates/message_templates/contribution_dupalert_html.tpl
+++ b/xml/templates/message_templates/contribution_dupalert_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 

--- a/xml/templates/message_templates/contribution_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 

--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
 <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 

--- a/xml/templates/message_templates/contribution_recurring_billing_html.tpl
+++ b/xml/templates/message_templates/contribution_recurring_billing_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 

--- a/xml/templates/message_templates/contribution_recurring_cancelled_html.tpl
+++ b/xml/templates/message_templates/contribution_recurring_cancelled_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 

--- a/xml/templates/message_templates/contribution_recurring_edit_html.tpl
+++ b/xml/templates/message_templates/contribution_recurring_edit_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 

--- a/xml/templates/message_templates/contribution_recurring_notify_html.tpl
+++ b/xml/templates/message_templates/contribution_recurring_notify_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
@@ -54,7 +54,7 @@
       <tr>
        <td>
         <p>{ts}Thanks for your recurring contribution sign-up.{/ts}</p>
-        <p>{ts 1=$recur_frequency_interval 2=$recur_frequency_unit}This recurring contribution will be automatically processed every %1 %2(s){/ts}{if $recur_installments }{ts 1=$recur_installments} for a total of %1 installment(s){/ts}{/if}.</p>
+        <p>{ts 1=$recur_frequency_interval 2=$recur_frequency_unit}This recurring contribution will be automatically processed every %1 %2(s){/ts}{if $recur_installments}{ts 1=$recur_installments} for a total of %1 installment(s){/ts}{/if}.</p>
         <p>{ts}Start Date{/ts}: {$recur_start_date|crmDate}</p>
        </td>
       </tr>

--- a/xml/templates/message_templates/contribution_recurring_notify_text.tpl
+++ b/xml/templates/message_templates/contribution_recurring_notify_text.tpl
@@ -20,7 +20,7 @@
 {ts}Thanks for your recurring contribution sign-up.{/ts}
 
 
-{ts 1=$recur_frequency_interval 2=$recur_frequency_unit 3=$recur_installments}This recurring contribution will be automatically processed every %1 %2(s){/ts}{if $recur_installments } {ts 1=$recur_installments} for a total of %1 installment(s){/ts}{/if}.
+{ts 1=$recur_frequency_interval 2=$recur_frequency_unit 3=$recur_installments}This recurring contribution will be automatically processed every %1 %2(s){/ts}{if $recur_installments} {ts 1=$recur_installments} for a total of %1 installment(s){/ts}{/if}.
 
 {ts}Start Date{/ts}:  {$recur_start_date|crmDate}
 

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
@@ -194,7 +194,7 @@
               <th>{ts}Tax Amount{/ts}</th>
              {/if}
              <th>{ts}Total{/ts}</th>
-       {if !empty($pricesetFieldsCount) }<th>{ts}Total Participants{/ts}</th>{/if}
+       {if !empty($pricesetFieldsCount)}<th>{ts}Total Participants{/ts}</th>{/if}
             </tr>
             {foreach from=$value item=line}
              <tr>
@@ -226,7 +226,7 @@
               <td>
                {$line.line_total+$line.tax_amount|crmMoney}
               </td>
-        {if  !empty($pricesetFieldsCount) }
+        {if !empty($pricesetFieldsCount)}
         <td>
     {$line.participant_count}
               </td>
@@ -299,7 +299,7 @@
            </td>
          </tr>
        {/if}
-       {if !empty($pricesetFieldsCount) }
+       {if !empty($pricesetFieldsCount)}
      <tr>
        <td {$labelStyle}>
    {ts}Total Participants{/ts}</td>
@@ -311,7 +311,7 @@
            {foreach from=$pcount item=p_count}
            {assign var="lineItemCount" value=$lineItemCount+$p_count.participant_count}
            {/foreach}
-           {if $lineItemCount < 1 }
+           {if $lineItemCount < 1}
            assign var="lineItemCount" value=1}
            {/if}
            {assign var="count" value=$count+$lineItemCount}

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -4,38 +4,38 @@
 {/if}
 
 {if !empty($isOnWaitlist)}
-==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
 {ts}You have been added to the WAIT LIST for this event.{/ts}
 
 {ts}If space becomes available you will receive an email with a link to a web page where you can complete your registration.{/ts}
 
-==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
 {elseif !empty($isRequireApproval)}
-==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
 {ts}Your registration has been submitted.{/ts}
 
 {ts}Once your registration has been reviewed, you will receive an email with a link to a web page where you can complete the registration process.{/ts}
 
-==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
 {elseif $isPrimary && {contribution.balance_amount|boolean} && {contribution.is_pay_later|boolean}}
 
-==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
 {$pay_later_receipt}
-==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
 {/if}
 
 
-==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
 {ts}Event Information and Location{/ts}
 
-==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
 {event.title}
 {event.start_date|crmDate}{if {event.end_date|boolean}}-{if '{event.end_date|crmDate:"%Y%m%d"}' === '{event.start_date|crmDate:"%Y%m%d"}'}{event.end_date|crmDate:"Time"}{else}{event.end_date}{/if}{/if}
@@ -76,20 +76,20 @@
 
 {if !empty($email)}
 
-==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
 {ts}Registered Email{/ts}
 
-==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
 {$email}
 {/if}
 {if {event.is_monetary|boolean}} {* This section for Paid events only.*}
 
-==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
 {event.fee_label}
-==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
 {if !empty($lineItem)}{foreach from=$lineItem item=value key=priceset}
 
@@ -99,7 +99,7 @@
 {ts 1=$priceset+1}Participant %1{/ts}
 {/if}
 {/if}
----------------------------------------------------------{if !empty($pricesetFieldsCount) }--------------------{/if}
+---------------------------------------------------------{if !empty($pricesetFieldsCount)}--------------------{/if}
 
 {capture assign=ts_item}{ts}Item{/ts}{/capture}
 {capture assign=ts_qty}{ts}Qty{/ts}{/capture}
@@ -110,12 +110,12 @@
 {capture assign=ts_taxAmount}{ts}Tax Amount{/ts}{/capture}
 {/if}
 {capture assign=ts_total}{ts}Total{/ts}{/capture}
-{capture assign=ts_participant_total}{if !empty($pricesetFieldsCount) }{ts}Total Participants{/ts}{/if}{/capture}
+{capture assign=ts_participant_total}{if !empty($pricesetFieldsCount)}{ts}Total Participants{/ts}{/if}{/capture}
 {$ts_item|string_format:"%-30s"} {$ts_qty|string_format:"%5s"} {$ts_each|string_format:"%10s"} {if !empty($dataArray)} {$ts_subtotal|string_format:"%10s"} {$ts_taxRate|string_format:"%10s"} {$ts_taxAmount|string_format:"%10s"} {/if} {$ts_total|string_format:"%10s"} {if !empty($ts_participant_total)}{$ts_participant_total|string_format:"%10s"}{/if}
-----------------------------------------------------------{if !empty($pricesetFieldsCount) }--------------------{/if}
+----------------------------------------------------------{if !empty($pricesetFieldsCount)}--------------------{/if}
 
 {foreach from=$value item=line}
-{if !empty($pricesetFieldsCount) }{capture assign=ts_participant_count}{$line.participant_count}{/capture}{/if}
+{if !empty($pricesetFieldsCount)}{capture assign=ts_participant_count}{$line.participant_count}{/capture}{/if}
 {capture assign=ts_item}{if $line.html_type eq 'Text'}{$line.label}{else}{$line.field_title} - {$line.label}{/if} {if $line.description} {$line.description}{/if}{/capture}{$ts_item|truncate:30:"..."|string_format:"%-30s"} {$line.qty|string_format:"%5s"} {$line.unit_price|crmMoney|string_format:"%10s"} {if !empty($dataArray)} {$line.unit_price*$line.qty|crmMoney:$currency|string_format:"%10s"} {if $line.tax_rate || $line.tax_amount != ""}  {$line.tax_rate|string_format:"%.2f"} %  {$line.tax_amount|crmMoney:$currency|string_format:"%10s"} {else}                  {/if}  {/if}  {$line.line_total+$line.tax_amount|crmMoney|string_format:"%10s"} {if !empty($ts_participant_count)}{$ts_participant_count|string_format:"%10s"}{/if}
 {/foreach}
 {/if}
@@ -149,7 +149,7 @@
 {else}{ts}Total Amount{/ts}: {contribution.total_amount}  {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
 {/if}
 
-{if !empty($pricesetFieldsCount) }
+{if !empty($pricesetFieldsCount)}
       {assign var="count" value= 0}
       {foreach from=$lineItem item=pcount}
       {assign var="lineItemCount" value=0}
@@ -157,7 +157,7 @@
         {foreach from=$pcount item=p_count}
         {assign var="lineItemCount" value=$lineItemCount+$p_count.participant_count}
         {/foreach}
-        {if $lineItemCount < 1 }
+        {if $lineItemCount < 1}
         {assign var="lineItemCount" value=1}
         {/if}
       {assign var="count" value=$count+$lineItemCount}
@@ -168,10 +168,10 @@
 {/if}
 
 {if $isPrimary && {contribution.balance_amount|boolean} && {contribution.is_pay_later|boolean}}
-==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
 {$pay_later_receipt}
-==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
 {/if}
 
@@ -195,11 +195,11 @@
 {/if}
 {if !empty($billingName)}
 
-==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
 {ts}Billing Name and Address{/ts}
 
-==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
 {$billingName}
 {$address}
@@ -209,7 +209,7 @@
 ===========================================================
 {ts}Credit Card Information{/ts}
 
-==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
 {$credit_card_type}
 {$credit_card_number}
@@ -220,10 +220,10 @@
 
 {if !empty($customGroup)}
 {foreach from=$customGroup item=value key=customName}
-=========================================================={if !empty($pricesetFieldsCount) }===================={/if}
+=========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
 {$customName}
-=========================================================={if !empty($pricesetFieldsCount) }===================={/if}
+=========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
 {foreach from=$value item=v key=n}
 {$n}: {$v}

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 {capture assign=tdfirstStyle}style="width: 180px; padding-bottom: 15px;"{/capture}
 {capture assign=tdStyle}style="width: 100px;"{/capture}
 {capture assign=participantTotalStyle}style="margin: 0.5em 0 0.5em;padding: 0.5em;background-color: #999999;font-weight: bold;color: #FAFAFA;border-radius: 2px;"{/capture}
@@ -294,7 +294,7 @@
                   {contribution.total_amount} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
                 </td>
               </tr>
-              {if !empty($pricesetFieldsCount) }
+              {if !empty($pricesetFieldsCount)}
                 <tr>
                   <td {$labelStyle}>
                     {ts}Total Participants{/ts}</td>
@@ -306,7 +306,7 @@
                         {foreach from=$pcount item=p_count}
                           {assign var="lineItemCount" value=$lineItemCount+$p_count.participant_count}
                         {/foreach}
-                        {if $lineItemCount < 1 }
+                        {if $lineItemCount < 1}
                           {assign var="lineItemCount" value=1}
                         {/if}
                         {assign var="count" value=$count+$lineItemCount}
@@ -465,7 +465,7 @@
         {/if}
 
       </table>
-      {if !empty($event.allow_selfcancelxfer) }
+      {if !empty($event.allow_selfcancelxfer)}
         <tr>
           <td colspan="2" {$valueStyle}>
             {ts 1=$selfcancelxfer_time 2=$selfservice_preposition}You may transfer your registration to another participant or cancel your registration up to %1 hours %2 the event.{/ts} {if !empty($totalAmount)}{ts}Cancellations are not refundable.{/ts}{/if}<br/>

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -107,12 +107,12 @@ You were registered by: {$payer.name}
 {capture assign=ts_taxAmount}{ts}Tax Amount{/ts}{/capture}
 {/if}
 {capture assign=ts_total}{ts}Total{/ts}{/capture}
-{if !empty($pricesetFieldsCount) }{capture assign=ts_participant_total}{ts}Total Participants{/ts}{/capture}{/if}
+{if !empty($pricesetFieldsCount)}{capture assign=ts_participant_total}{ts}Total Participants{/ts}{/capture}{/if}
 {$ts_item|string_format:"%-30s"} {$ts_qty|string_format:"%5s"} {$ts_each|string_format:"%10s"} {if $isShowTax && {contribution.tax_amount|boolean}} {$ts_subtotal|string_format:"%10s"} {$ts_taxRate|string_format:"%10s"} {$ts_taxAmount|string_format:"%10s"} {/if} {$ts_total|string_format:"%10s"} {if !empty($ts_participant_total)}{$ts_participant_total|string_format:"%10s"}{/if}
 -----------------------------------------------------------{if !empty($pricesetFieldsCount)}-----------------------------------------------------{/if}
 
 {foreach from=$value item=line}
-{if !empty($pricesetFieldsCount) }{capture assign=ts_participant_count}{$line.participant_count}{/capture}{/if}
+{if !empty($pricesetFieldsCount)}{capture assign=ts_participant_count}{$line.participant_count}{/capture}{/if}
 {capture assign=ts_item}{if $line.html_type eq 'Text'}{$line.label}{else}{$line.field_title} - {$line.label}{/if} {if $line.description} {$line.description}{/if}{/capture}{$ts_item|truncate:30:"..."|string_format:"%-30s"} {$line.qty|string_format:"%5s"} {$line.unit_price|crmMoney:$currency|string_format:"%10s"} {if $isShowTax && {contribution.tax_amount|boolean}} {$line.unit_price*$line.qty|crmMoney:$currency|string_format:"%10s"} {if $line.tax_rate || $line.tax_amount != ""}  {$line.tax_rate|string_format:"%.2f"} %  {$line.tax_amount|crmMoney:$currency|string_format:"%10s"} {else}                  {/if}  {/if} {$line.line_total+$line.tax_amount|crmMoney:$currency|string_format:"%10s"}{if !empty($ts_participant_count)}{$ts_participant_count|string_format:"%10s"}{/if}
 {/foreach}
 ----------------------------------------------------------------------------------------------------------------
@@ -143,7 +143,7 @@ You were registered by: {$payer.name}
 
 {ts}Total Amount{/ts}: {if !empty($totalAmount)}{$totalAmount|crmMoney:$currency}{/if} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
 
-{if !empty($pricesetFieldsCount) }
+{if !empty($pricesetFieldsCount)}
       {assign var="count" value= 0}
       {foreach from=$lineItem item=pcount}
       {assign var="lineItemCount" value=0}
@@ -151,7 +151,7 @@ You were registered by: {$payer.name}
         {foreach from=$pcount item=p_count}
         {assign var="lineItemCount" value=$lineItemCount+$p_count.participant_count}
         {/foreach}
-      {if $lineItemCount < 1 }
+      {if $lineItemCount < 1}
         {assign var="lineItemCount" value=1}
       {/if}
       {assign var="count" value=$count+$lineItemCount}
@@ -254,7 +254,7 @@ You were registered by: {$payer.name}
 {/foreach}
 {/if}
 
-{if !empty($event.allow_selfcancelxfer) }
+{if !empty($event.allow_selfcancelxfer)}
 {ts 1=$selfcancelxfer_time 2=$selfservice_preposition}You may transfer your registration to another participant or cancel your registration up to %1 hours %2 the event.{/ts} {if !empty($totalAmount)}{ts}Cancellations are not refundable.{/ts}{/if}
    {capture assign=selfService}{crmURL p='civicrm/event/selfsvcupdate' q="reset=1&pid=`$participant.id`&{contact.checksum}"  h=0 a=1 fe=1}{/capture}
 {ts}Transfer or cancel your registration:{/ts} {$selfService}

--- a/xml/templates/message_templates/event_registration_receipt_html.tpl
+++ b/xml/templates/message_templates/event_registration_receipt_html.tpl
@@ -6,8 +6,8 @@
   </head>
   <body>
     {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-    {capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-    {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+    {capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+    {capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
     {assign var="greeting" value="{contact.email_greeting_display}"}{if $greeting}<p>{$greeting},</p>{/if}
     {if $is_pay_later}

--- a/xml/templates/message_templates/friend_html.tpl
+++ b/xml/templates/message_templates/friend_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 

--- a/xml/templates/message_templates/membership_autorenew_billing_html.tpl
+++ b/xml/templates/message_templates/membership_autorenew_billing_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 

--- a/xml/templates/message_templates/membership_autorenew_cancelled_html.tpl
+++ b/xml/templates/message_templates/membership_autorenew_cancelled_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 

--- a/xml/templates/message_templates/membership_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_html.tpl
@@ -8,8 +8,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   <table id="crm-membership_receipt"
          style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">

--- a/xml/templates/message_templates/membership_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_text.tpl
@@ -70,7 +70,7 @@
 {/if}
 {/if}
 
-{if !empty($isPrimary) }
+{if !empty($isPrimary)}
 {if !empty($billingName)}
 
 ===========================================================

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
@@ -88,7 +88,7 @@
          {$membership_amount|crmMoney}
         </td>
        </tr>
-       {if $amount && !$is_separate_payment }
+       {if $amount && !$is_separate_payment}
          <tr>
           <td {$labelStyle}>
            {ts}Contribution Amount{/ts}

--- a/xml/templates/message_templates/membership_online_receipt_text.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_text.tpl
@@ -28,7 +28,7 @@
 ===========================================================
 {if !$useForMember && isset($membership_amount) && !empty($is_quick_config)}
 {ts 1=$membership_name}%1 Membership{/ts}: {$membership_amount|crmMoney}
-{if $amount && !$is_separate_payment }
+{if $amount && !$is_separate_payment}
 {ts}Contribution Amount{/ts}: {$amount|crmMoney}
 -------------------------------------------
 {ts}Total{/ts}: {$amount+$membership_amount|crmMoney}
@@ -87,7 +87,7 @@
 {ts}Total Tax Amount{/ts}: {$totalTaxAmount|crmMoney:$currency}
 {/if}
 
-{ts}Amount{/ts}: {$amount|crmMoney} {if isset($amount_level) } - {$amount_level} {/if}
+{ts}Amount{/ts}: {$amount|crmMoney} {if isset($amount_level)} - {$amount_level} {/if}
 {/if}
 {elseif isset($membership_amount)}
 ===========================================================
@@ -123,7 +123,7 @@
 {/if}
 {/if}
 
-{if $honor_block_is_active }
+{if $honor_block_is_active}
 ===========================================================
 {$soft_credit_type}
 ===========================================================

--- a/xml/templates/message_templates/participant_cancelled_html.tpl
+++ b/xml/templates/message_templates/participant_cancelled_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 

--- a/xml/templates/message_templates/participant_confirm_html.tpl
+++ b/xml/templates/message_templates/participant_confirm_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
   <!-- BEGIN HEADER -->
@@ -36,7 +36,7 @@
     </td>
    </tr>
   {/if}
-  {if $event.allow_selfcancelxfer }
+  {if $event.allow_selfcancelxfer}
   {ts}This event allows for{/ts}
   {capture assign=selfService}{crmURL p='civicrm/event/selfsvcupdate' q="reset=1&pid=`$participant.id`&{contact.checksum}" h=0 a=1 fe=1}{/capture}
        <a href="{$selfService}"> {ts}self service cancel or transfer{/ts}</a>
@@ -147,7 +147,7 @@
     </table>
    </td>
   </tr>
-  {if $event.allow_selfcancelxfer }
+  {if $event.allow_selfcancelxfer}
    <tr>
      <td colspan="2" {$valueStyle}>
        {ts 1=$selfcancelxfer_time 2=$selfservice_preposition}You may transfer your registration to another participant or cancel your registration up to %1 hours %2 the event.{/ts} {if $totalAmount}{ts}Cancellations are not refundable.{/ts}{/if}<br />

--- a/xml/templates/message_templates/participant_confirm_text.tpl
+++ b/xml/templates/message_templates/participant_confirm_text.tpl
@@ -12,7 +12,7 @@
 Click this link to go to a web page where you can confirm your registration online:
 {$confirmUrl}
 {/if}
-{if $event.allow_selfcancelxfer }
+{if $event.allow_selfcancelxfer}
 {ts 1=$selfcancelxfer_time 2=$selfservice_preposition}You may transfer your registration to another participant or cancel your registration up to %1 hours %2 the event.{/ts} {if $totalAmount}{ts}Cancellations are not refundable.{/ts}{/if}
    {capture assign=selfService}{crmURL p='civicrm/event/selfsvcupdate' q="reset=1&pid=`$participant.id`&{contact.checksum}"  h=0 a=1 fe=1}{/capture}
 {ts}Transfer or cancel your registration:{/ts} {$selfService}

--- a/xml/templates/message_templates/participant_expired_html.tpl
+++ b/xml/templates/message_templates/participant_expired_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 

--- a/xml/templates/message_templates/participant_transferred_html.tpl
+++ b/xml/templates/message_templates/participant_transferred_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 

--- a/xml/templates/message_templates/payment_or_refund_notification_html.tpl
+++ b/xml/templates/message_templates/payment_or_refund_notification_html.tpl
@@ -7,10 +7,10 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
-{capture assign=emptyBlockStyle }style="padding: 10px; border-bottom: 1px solid #999;background-color: #f7f7f7;"{/capture}
-{capture assign=emptyBlockValueStyle }style="padding: 10px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=emptyBlockStyle}style="padding: 10px; border-bottom: 1px solid #999;background-color: #f7f7f7;"{/capture}
+{capture assign=emptyBlockValueStyle}style="padding: 10px; border-bottom: 1px solid #999;"{/capture}
 
  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 

--- a/xml/templates/message_templates/pcp_notify_html.tpl
+++ b/xml/templates/message_templates/pcp_notify_html.tpl
@@ -7,9 +7,9 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
-{capture assign=pcpURL     }{crmURL p="civicrm/pcp/info" q="reset=1&id=`$pcpId`" h=0 a=1 fe=1}{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=pcpURL}{crmURL p="civicrm/pcp/info" q="reset=1&id=`$pcpId`" h=0 a=1 fe=1}{/capture}
 
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 

--- a/xml/templates/message_templates/pcp_owner_notify_html.tpl
+++ b/xml/templates/message_templates/pcp_owner_notify_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   {assign var="greeting" value="{contact.email_greeting_display}"}{if $greeting}<p>{$greeting},</p>{/if}
   <p>{ts}You have received a donation at your personal page{/ts}: <a href="{$pcpInfoURL}">{$page_title}</a></p>

--- a/xml/templates/message_templates/pcp_supporter_notify_html.tpl
+++ b/xml/templates/message_templates/pcp_supporter_notify_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 

--- a/xml/templates/message_templates/pledge_acknowledge_html.tpl
+++ b/xml/templates/message_templates/pledge_acknowledge_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 

--- a/xml/templates/message_templates/pledge_reminder_html.tpl
+++ b/xml/templates/message_templates/pledge_reminder_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 

--- a/xml/templates/message_templates/uf_notify_html.tpl
+++ b/xml/templates/message_templates/uf_notify_html.tpl
@@ -7,8 +7,8 @@
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
-{capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
-{capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
+{capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 

--- a/xml/templates/schema.tpl
+++ b/xml/templates/schema.tpl
@@ -51,5 +51,5 @@ CREATE TABLE `{$table.name}` ({assign var='first' value=true}
   CONSTRAINT {$foreign.uniqName} FOREIGN KEY (`{$foreign.name}`) REFERENCES `{$foreign.table}`(`{$foreign.key}`){if $foreign.onDelete} ON DELETE {$foreign.onDelete}{/if}{/foreach}{* table.foreignKey *}{/if}{strip}
   {* table.foreignKey *}{/strip}
 )
-{if $mysql eq 'modern' }{$table.attributes_modern}{else}{$table.attributes_simple}{/if};
+{if $mysql eq 'modern'}{$table.attributes_modern}{else}{$table.attributes_simple}{/if};
 {/foreach}{* tables *}


### PR DESCRIPTION
Overview
----------------------------------------
Smarty 3+ doesn't accept curly braces surrounded by whitespace, so I've removed all `{ ` and ` }`. Also removed a few parentheses with spaces around them to (Drupal style).