### PR TITLE
(dev/core#4490) Queues - Add setting and hook to pause/resume background-queues

### DIFF
--- a/CRM/Queue/Queue.php
+++ b/CRM/Queue/Queue.php
@@ -61,9 +61,15 @@ abstract class CRM_Queue_Queue {
    * @throws \CRM_Core_Exception
    */
   public function isActive(): bool {
+    // Queues work with concurrent processes. We want to make sure status info is up-to-date (never cached).
     $status = CRM_Core_DAO::getFieldValue('CRM_Queue_DAO_Queue', $this->_name, 'status', 'name', TRUE);
-    if ($status === 'active' && \Civi::settings()->get('queue_suspended')) {
-      $status = 'deferred';
+    if ($status === 'active') {
+      $suspend = CRM_Core_DAO::singleValueQuery('SELECT value FROM civicrm_setting WHERE name = "queue_suspended" AND domain_id = %1', [
+        1 => [CRM_Core_BAO_Domain::getDomain()->id, 'Positive'],
+      ]);
+      if (!empty(CRM_Utils_String::unserialize($suspend))) {
+        $status = 'deferred';
+      }
     }
     $event = GenericHookEvent::create([
       'status' => &$status,

--- a/CRM/Queue/Queue.php
+++ b/CRM/Queue/Queue.php
@@ -62,7 +62,7 @@ abstract class CRM_Queue_Queue {
    */
   public function isActive(): bool {
     $status = CRM_Core_DAO::getFieldValue('CRM_Queue_DAO_Queue', $this->_name, 'status', 'name', TRUE);
-    if ($status === 'active' && \Civi::settings()->get('is_queue_processing_disabled')) {
+    if ($status === 'active' && \Civi::settings()->get('queue_suspended')) {
       $status = 'deferred';
     }
     $event = GenericHookEvent::create([

--- a/CRM/Queue/Queue.php
+++ b/CRM/Queue/Queue.php
@@ -64,11 +64,11 @@ abstract class CRM_Queue_Queue {
     // Queues work with concurrent processes. We want to make sure status info is up-to-date (never cached).
     $status = CRM_Core_DAO::getFieldValue('CRM_Queue_DAO_Queue', $this->_name, 'status', 'name', TRUE);
     if ($status === 'active') {
-      $suspend = CRM_Core_DAO::singleValueQuery('SELECT value FROM civicrm_setting WHERE name = "queue_suspended" AND domain_id = %1', [
+      $suspend = CRM_Core_DAO::singleValueQuery('SELECT value FROM civicrm_setting WHERE name = "queue_paused" AND domain_id = %1', [
         1 => [CRM_Core_BAO_Domain::getDomain()->id, 'Positive'],
       ]);
       if (!empty(CRM_Utils_String::unserialize($suspend))) {
-        $status = 'deferred';
+        $status = 'paused';
       }
     }
     $event = GenericHookEvent::create([

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -1201,8 +1201,8 @@ return [
     'description' => ts('How long should HTTP requests through Guzzle application run for in seconds'),
     'help_text' => ts('Set the number of seconds http requests should run for before terminating'),
   ],
-  'queue_suspended' => [
-    'name' => 'queue_suspended',
+  'queue_paused' => [
+    'name' => 'queue_paused',
     'type' => 'Boolean',
     'default' => FALSE,
     'html_type' => 'yesno',

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -1201,4 +1201,16 @@ return [
     'description' => ts('How long should HTTP requests through Guzzle application run for in seconds'),
     'help_text' => ts('Set the number of seconds http requests should run for before terminating'),
   ],
+  'is_queue_processing_disabled' => [
+    'name' => 'is_queue_processing_disabled',
+    'type' => 'Boolean',
+    'default' => FALSE,
+    'html_type' => 'yesno',
+    'add' => '5.67',
+    'title' => ts('Is background queue processing disabled?'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => ts('If enabled, CiviCRM will not process background queues.'),
+    'help_text' => ts('This setting will only affect sites that have background queue processing enabled (eg. coworker)'),
+  ],
 ];

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -1201,13 +1201,13 @@ return [
     'description' => ts('How long should HTTP requests through Guzzle application run for in seconds'),
     'help_text' => ts('Set the number of seconds http requests should run for before terminating'),
   ],
-  'is_queue_processing_disabled' => [
-    'name' => 'is_queue_processing_disabled',
+  'queue_suspended' => [
+    'name' => 'queue_suspended',
     'type' => 'Boolean',
     'default' => FALSE,
     'html_type' => 'yesno',
     'add' => '5.67',
-    'title' => ts('Is background queue processing disabled?'),
+    'title' => ts('Is background queue temporarily disabled?'),
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => ts('If enabled, CiviCRM will not process background queues.'),


### PR DESCRIPTION
Overview
----------------------------------------

dev/core#4490 Add hook for `is_queue_active`


https://lab.civicrm.org/dev/core/-/issues/4490

Before
----------------------------------------
No way to 'tell the queue' to stop claiming items (eg.  because of server load) or because site is under maintenance

After
----------------------------------------
- Setting to put queues in maintenance mode (`queue_maintenance_mode`) which will prevent background processes from claiming items
- site can implement hook to prevent queue processing 

Technical Details
----------------------------------------
@totten @seamuslee001 how does this look compared to the discussion on the call ?

I updated the gitlab as per my understanding of the discussion https://lab.civicrm.org/dev/core/-/issues/4490

I did kinda think during discussion that the maintenance mode check would be done via a listener - so I just put the setting in

- I called the setting `queue_maintenance_mode` rather than just `maintenance_mode` as it felt like the latter might be over-promising?

- I haven't added to the UI as yet - I wasn't sure which page  - candidates are
  -  Settings - Debugging and Error Handling
  -  Misc (Undelete, PDFs, Limits, Logging, etc.)
  -  Settings - Cleanup Caches and Update Paths
  -  A brave new page - together with `enableBackgroundQueue` (& possibly some combo of  `prevNextBackend` `import_batch_size` `logging`, `environment`)

(If we went with the last option & it got tricksy it could be a follow up)


Comments
----------------------------------------

