### PR TITLE
SearchKit Toolbar - Fix conditionals, add tests

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -158,6 +158,9 @@ class Run extends AbstractRunAction {
       $settings['toolbar'][] = $settings['addButton'] + ['style' => 'primary', 'target' => 'crm-popup'];
     }
     foreach ($settings['toolbar'] ?? [] as $button) {
+      if (!$this->checkLinkCondition($button, $data)) {
+        continue;
+      }
       $button = $this->formatLink($button, $data);
       if ($button) {
         $toolbar[] = $button;

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
@@ -18,8 +18,9 @@
         linkProps = ['path', 'task', 'entity', 'action', 'join', 'target', 'icon', 'text', 'style', 'condition'];
 
       ctrl.permissionOperators = [
-        {key: '=', value: ts('Has')},
-        {key: '!=', value: ts('Lacks')}
+        {key: 'CONTAINS', value: ts('Includes')},
+        {key: '=', value: ts('Has All')},
+        {key: '!=', value: ts('Lacks All')}
       ];
 
       this.styles = CRM.crmSearchAdmin.styles;

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.html
@@ -39,7 +39,7 @@
         <input ng-model="item.condition[0]" crm-ui-select="{placeholder: item.action ? ts('Allowed') : ts('Always'), data: $ctrl.fields}" ng-change="$ctrl.onChangeCondition(item)">
         <div class="form-group" ng-if="item.condition[0] === 'check user permission'">
           <select class="form-control api4-operator" ng-model="item.condition[1]" ng-options="o.key as o.value for o in $ctrl.permissionOperators"></select>
-          <input class="form-control" crm-ui-select="{data: $ctrl.permissions}" ng-model="item.condition[2]">
+          <input class="form-control" crm-ui-select="{data: $ctrl.permissions, multiple: true}" ng-model="item.condition[2]" ng-list>
         </div>
         <crm-search-condition class="form-group"
           ng-if="item.condition[0] && item.condition[0] !== 'check user permission'"


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #27407 with bug fixes and unit tests to ensure the new toolbar buttons are correctly checking permissions and evaluating conditionals.

Allows more flexible permission check selector in SearchKit.