### PR TITLE
Fix weights again on contribution page settings dropdown

### DIFF
--- a/CRM/Contribute/Page/ContributionPage.php
+++ b/CRM/Contribute/Page/ContributionPage.php
@@ -112,7 +112,8 @@ class CRM_Contribute_Page_ContributionPage extends CRM_Core_Page {
           'url' => $urlString . 'settings',
           'qs' => $urlParams,
           'uniqueName' => 'settings',
-          'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::ADD),
+          // This needs to be lower than Membership Settings since otherwise the order doesn't make sense.
+          'weight' => -20,
         ],
         CRM_Core_Action::UPDATE => [
           'name' => ts('Contribution Amounts'),
@@ -129,7 +130,7 @@ class CRM_Contribute_Page_ContributionPage extends CRM_Core_Page {
           'qs' => $urlParams,
           'uniqueName' => 'membership',
           // This should come after Title
-          'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::ADD),
+          'weight' => 0,
         ],
         CRM_Core_Action::EXPORT => [
           'name' => ts('Thank-you and Receipting'),


### PR DESCRIPTION
Overview
----------------------------------------
This is the same as https://github.com/civicrm/civicrm-core/pull/27448 but trying a different approach to avoid it happening again.

Before
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/27448

After
----------------------------------------


Technical Details
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/27501/commits/888b7b0c2dfd9f3f0d963c02b12f78cf00317e97#diff-5262f2a51e80fce6ce2b14d889545f254fea6308c016a5018e1b4ecfe82de0a3R115 the order was changed but not sure if AI or something else prompted it. Trying numbers to see if it avoids it.

Comments
----------------------------------------

