### PR TITLE
php8.x Fix notice from adding esm_loader to wrong settings form

### DIFF
--- a/CRM/Admin/Form/Setting/Miscellaneous.php
+++ b/CRM/Admin/Form/Setting/Miscellaneous.php
@@ -62,7 +62,6 @@ class CRM_Admin_Form_Setting_Miscellaneous extends CRM_Admin_Form_Setting {
       'recentItemsMaxCount',
       'recentItemsProviders',
       'dedupe_default_limit',
-      'esm_loader',
       'prevNextBackend',
       'import_batch_size',
     ]);


### PR DESCRIPTION

Overview
----------------------------------------
Fix notice from adding esm_loader to wrong form

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/336308/a3cbaf25-ac8e-44fc-b8d1-8c23f183275b)

After
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/336308/aa365f9a-5c57-4409-a559-c3d89bedc44d)

It's still on the debugging form but no more notices on the form it ISN"T on
![image](https://github.com/civicrm/civicrm-core/assets/336308/9616c6a9-41c6-4f54-9dc1-3fa695985cd2)


Technical Details
----------------------------------------
It is on the debugging form - but perhaps it was gonna go here for a bit

Comments
----------------------------------------
