### PR TITLE
CiviMail - VERP should no longer require job_id for verification

### DIFF
--- a/CRM/Mailing/Event/BAO/MailingEventQueue.php
+++ b/CRM/Mailing/Event/BAO/MailingEventQueue.php
@@ -56,7 +56,7 @@ class CRM_Mailing_Event_BAO_MailingEventQueue extends CRM_Mailing_Event_DAO_Mail
   /**
    * Verify that a queue event exists with the specified id/job id/hash.
    *
-   * @param int $job_id
+   * @param int|int $job_id
    *   The job ID of the event to find.
    * @param int $queue_id
    *   The Queue Event ID to find.
@@ -66,12 +66,11 @@ class CRM_Mailing_Event_BAO_MailingEventQueue extends CRM_Mailing_Event_DAO_Mail
    * @return object|null
    *   The queue event if verified, or null
    */
-  public static function &verify($job_id, $queue_id, $hash) {
+  public static function verify($job_id, $queue_id, $hash) {
     $success = NULL;
     $q = new CRM_Mailing_Event_BAO_MailingEventQueue();
-    if (!empty($job_id) && !empty($queue_id) && !empty($hash)) {
+    if ($queue_id && $hash) {
       $q->id = $queue_id;
-      $q->job_id = $job_id;
       $q->hash = $hash;
       if ($q->find(TRUE)) {
         $success = $q;


### PR DESCRIPTION

Overview
----------------------------------------
Fix verify verp function to cope with job_id having been deleted

This allows the record to be validated based on queue_id & hash (which is still pretty insane to brute force & allows us to purge job records


Before
----------------------------------------
Job record must be unchanged in DB

After
----------------------------------------
Job record can be change or (pending merge of schema PR) deleted & verp still verifies

Technical Details
----------------------------------------
Partial of https://github.com/civicrm/civicrm-core/pull/27512 but should be mergeable by itself

Comments
----------------------------------------
