### PR TITLE
Pass `NULL` instead of a value where function requires a parameter but does not use it

### DIFF
--- a/CRM/Mailing/Event/BAO/MailingEventBounce.php
+++ b/CRM/Mailing/Event/BAO/MailingEventBounce.php
@@ -24,7 +24,7 @@ class CRM_Mailing_Event_BAO_MailingEventBounce extends CRM_Mailing_Event_DAO_Mai
    * @return bool|null
    */
   public static function recordBounce(&$params) {
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($params['job_id'] ?? NULL,
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL,
       $params['event_queue_id'] ?? NULL,
       $params['hash'] ?? NULL
     );

--- a/CRM/Mailing/Event/BAO/MailingEventDelivered.php
+++ b/CRM/Mailing/Event/BAO/MailingEventDelivered.php
@@ -25,7 +25,7 @@ class CRM_Mailing_Event_BAO_MailingEventDelivered extends CRM_Mailing_Event_DAO_
    * @return \CRM_Mailing_Event_BAO_MailingEventDelivered
    */
   public static function recordDelivery(&$params) {
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($params['job_id'],
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL,
       $params['event_queue_id'],
       $params['hash']
     );

--- a/CRM/Mailing/Event/BAO/MailingEventForward.php
+++ b/CRM/Mailing/Event/BAO/MailingEventForward.php
@@ -29,7 +29,7 @@ class CRM_Mailing_Event_BAO_MailingEventForward extends CRM_Mailing_Event_DAO_Ma
    * @return bool
    */
   public static function &forward($job_id, $queue_id, $hash, $forward_email, $fromEmail = NULL, $comment = NULL) {
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
 
     $successfulForward = FALSE;
     $contact_id = NULL;

--- a/CRM/Mailing/Event/BAO/MailingEventReply.php
+++ b/CRM/Mailing/Event/BAO/MailingEventReply.php
@@ -39,7 +39,7 @@ class CRM_Mailing_Event_BAO_MailingEventReply extends CRM_Mailing_Event_DAO_Mail
    */
   public static function &reply($job_id, $queue_id, $hash, $replyto = NULL) {
     // First make sure there's a matching queue event.
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
 
     $success = NULL;
 

--- a/CRM/Mailing/Event/BAO/MailingEventResubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventResubscribe.php
@@ -40,7 +40,7 @@ class CRM_Mailing_Event_BAO_MailingEventResubscribe {
   public static function &resub_to_mailing($job_id, $queue_id, $hash) {
     // First make sure there's a matching queue event.
 
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
     $success = NULL;
     if (!$q) {
       return $success;

--- a/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
@@ -38,7 +38,7 @@ class CRM_Mailing_Event_BAO_MailingEventUnsubscribe extends CRM_Mailing_Event_DA
    *   Was the contact successfully unsubscribed?
    */
   public static function unsub_from_domain($job_id, $queue_id, $hash) {
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
     if (!$q) {
       return FALSE;
     }
@@ -110,7 +110,7 @@ WHERE  email = %2
   public static function unsub_from_mailing($job_id, $queue_id, $hash, $return = FALSE): ?array {
     // First make sure there's a matching queue event.
 
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
     if (!$q) {
       return NULL;
     }

--- a/CRM/Mailing/Form/ForwardMailing.php
+++ b/CRM/Mailing/Form/ForwardMailing.php
@@ -27,7 +27,7 @@ class CRM_Mailing_Form_ForwardMailing extends CRM_Core_Form {
       $this, NULL
     );
 
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
 
     if ($q == NULL) {
 

--- a/CRM/Mailing/Form/Optout.php
+++ b/CRM/Mailing/Form/Optout.php
@@ -56,7 +56,7 @@ class CRM_Mailing_Form_Optout extends CRM_Core_Form {
     }
 
     // verify that the three numbers above match
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
     if (!$q) {
       CRM_Utils_System::sendResponse(
         new \GuzzleHttp\Psr7\Response(400, [], ts("Invalid request: bad parameters"))

--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -57,7 +57,7 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
     }
 
     // verify that the three numbers above match
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
     if (!$q) {
       CRM_Utils_System::sendResponse(
         new \GuzzleHttp\Psr7\Response(400, [], ts("Invalid request: bad parameters"))

--- a/CRM/Mailing/Page/Common.php
+++ b/CRM/Mailing/Page/Common.php
@@ -38,7 +38,7 @@ class CRM_Mailing_Page_Common extends CRM_Core_Page {
     }
 
     // verify that the three numbers above match
-    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
     if (!$q) {
       throw new CRM_Core_Exception(ts("There was an error in your request"));
     }

--- a/CRM/Utils/Mail/IncomingMail.php
+++ b/CRM/Utils/Mail/IncomingMail.php
@@ -209,7 +209,7 @@ class CRM_Utils_Mail_IncomingMail {
       [, $this->action, $this->jobID, $this->queueID, $this->hash] = $matches;
     }
     if ($this->isVerp()) {
-      $queue = CRM_Mailing_Event_BAO_MailingEventQueue::verify($this->getJobID(), $this->getQueueID(), $this->getHash());
+      $queue = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $this->getQueueID(), $this->getHash());
       if (!$queue) {
         throw new CRM_Core_Exception('Contact could not be found from civimail response');
       }


### PR DESCRIPTION
Overview
----------------------------------------
Pass NULL instead of a value where function requires a parameter but does not use it

Follow up clean up on  https://github.com/civicrm/civicrm-core/pull/27531  - $job_id is now unused so pass NULL rather than a variable for clarity