### PR TITLE
CiviMail - Generate email auth-code as random string

### DIFF
--- a/CRM/Mailing/Event/BAO/MailingEventQueue.php
+++ b/CRM/Mailing/Event/BAO/MailingEventQueue.php
@@ -36,21 +36,24 @@ class CRM_Mailing_Event_BAO_MailingEventQueue extends CRM_Mailing_Event_DAO_Mail
   }
 
   /**
-   * Create a security hash from the job, email and contact ids.
+   * Create a unique-ish string to stare in the hash table.
    *
-   * @param array $params
+   * This is included in verp emails such that bounces go to a unique
+   * address (e.g. b.123456.456ABC456ABC.my-email-address@example.com). In this case
+   * b is the action (bounce), 123456 is the queue_id and the last part is the
+   * random string from this function. Note that the local part of the email
+   * can have a max of 64 characters
+   *
+   * https://issues.civicrm.org/jira/browse/CRM-2574
+   *
+   * The hash combined with the queue id provides a fairly unguessable combo for the emails
+   * (enough that a sysadmin should notice if someone tried to brute force it!)
    *
    * @return string
    *   The hash
    */
-  public static function hash($params) {
-    $jobId = $params['job_id'];
-    $emailId = CRM_Utils_Array::value('email_id', $params, '');
-    $contactId = $params['contact_id'];
-
-    return substr(sha1("{$jobId}:{$emailId}:{$contactId}:" . time()),
-      0, 16
-    );
+  public static function hash() {
+    return base64_encode(random_bytes(16));
   }
 
   /**

--- a/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
@@ -66,6 +66,8 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
 
   /**
    * Generate a fully-formatted mailing with standard email headers.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testBasicHeaders(): void {
     $allMessages = $this->runMailingSuccess([
@@ -77,15 +79,15 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
 
       $offset = $k + 1;
 
-      $this->assertEquals("FIXME", $message->from->name);
-      $this->assertEquals("info@EXAMPLE.ORG", $message->from->email);
+      $this->assertEquals('FIXME', $message->from->name);
+      $this->assertEquals('info@EXAMPLE.ORG', $message->from->email);
       $this->assertEquals("Mr. Foo{$offset} Anderson II", $message->to[0]->name);
       $this->assertEquals("mail{$offset}@nul.example.com", $message->to[0]->email);
 
       $this->assertMatchesRegularExpression('#^text/plain; charset=utf-8#', $message->headers['Content-Type']);
-      $this->assertMatchesRegularExpression(';^b\.[\d\.a-f]+@chaos.org$;', $message->headers['Return-Path']);
-      $this->assertMatchesRegularExpression(';^b\.[\d\.a-f]+@chaos.org$;', $message->headers['X-CiviMail-Bounce'][0]);
-      $this->assertMatchesRegularExpression(';^\<mailto:u\.[\d\.a-f]+@chaos.org\>$;', $message->headers['List-Unsubscribe'][0]);
+      $this->assertMatchesRegularExpression(';^b\.[\d\.a-z]+@chaos.org$;', $message->headers['Return-Path']);
+      $this->assertMatchesRegularExpression(';^b\.[\d\.a-z]+@chaos.org$;', $message->headers['X-CiviMail-Bounce'][0]);
+      $this->assertMatchesRegularExpression(';^\<mailto:u\.[\d\.a-z]+@chaos.org\>$;', $message->headers['List-Unsubscribe'][0]);
       $this->assertEquals('bulk', $message->headers['Precedence'][0]);
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Use random string rather than sha string

As discussed on chat
https://chat.civicrm.org/civicrm/pl/r7h6cc7xo78zjgsd8af6ff9tee

this function just generates a hard-to-guess string that is stored in the civicrm_mailing_event_bounce table. This unique value is used in conjunction with the unique id value from the table to determine if it is a match but it's not ever reverse calculated so we don't need to use a reversable function


Before
----------------------------------------
Hash generated using ids & sha but it is not ever reverse-calclated so it is just confusing having it appear to be a crytographic string

After
----------------------------------------
Random number generated

Technical Details
----------------------------------------
Note verp addresses have a 65 char limit on the local side so this uses 19 of the characters. up to 9 more might be used by the queue_id (we currently use 8) so that leaves around 32 for the string part. I think that's ok - I think the risk of the email being accidentally too long is greater than the risk of someone guessing / brute forcing a 16 char string + an additional number 

Comments
----------------------------------------

@totten 