### PR TITLE
Stop saying N contacts removed when they were already removed.

### DIFF
--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -201,14 +201,15 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact implemen
         CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache($groupId);
       }
       else {
+        // 'Removed' means we add a history record and ensure the GroupContact record exists with a 'Removed' status.
         $groupContact = new CRM_Contact_DAO_GroupContact();
         $groupContact->group_id = $groupId;
         $groupContact->contact_id = $contactId;
-        // check if the selected contact id already a member, or if this is
+        // check if the selected contact is already listed as Removed
         // an opt-out of a smart group.
         // if not a member remove to groupContact else keep the count of contacts that are not removed
-        if ($groupContact->find(TRUE) || $group->saved_search_id) {
-          // remove the contact from the group
+        if (($groupContact->find(TRUE) || $group->saved_search_id) && $groupContact->status !== $status) {
+          // remove the contact from the group.
           $numContactsRemoved++;
         }
         else {


### PR DESCRIPTION
Before
----------------------------------------


Calling the bulk remove contacts from groups function for a contact that is already Removed reports that it removed them. Which is confusing. 


After
----------------------------------------

If there's already a GroupContact record with Removed status, and we want to Remove the contact, we don't count that as a removal. Because you can't remove what isn't there, right?!


Technical Details
----------------------------------------

This is a NFC in terms of what happens to records, it's just the counts that are returned from the function that are now more correct.

This was doing my nut while working on some sync code: why does it keep needing to remove the same contacts?! Oh it doesn't!
