### PR TITLE
Simplify CustomField::displayValue to expect an ID & have deprecated handling for anything else

### DIFF
--- a/api/v3/CustomValue.php
+++ b/api/v3/CustomValue.php
@@ -360,7 +360,7 @@ function civicrm_api3_custom_value_gettree($params) {
       if (!empty($fieldInfo['customValue'])) {
         $field['value'] = CRM_Utils_Array::first($fieldInfo['customValue']);
         if (!$toReturn['custom_value'] || in_array('display', $toReturn['custom_value'])) {
-          $field['value']['display'] = CRM_Core_BAO_CustomField::displayValue($field['value']['data'], $fieldInfo);
+          $field['value']['display'] = CRM_Core_BAO_CustomField::displayValue($field['value']['data'], $fieldInfo['id']);
         }
         foreach (array_keys($field['value']) as $key) {
           if ($toReturn['custom_value'] && !in_array($key, $toReturn['custom_value'])) {

--- a/tests/phpunit/CRM/Core/BAO/CustomQueryTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomQueryTest.php
@@ -163,8 +163,6 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
 
   /**
    * Test filtering by relative custom data dates.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testSearchCustomDataDateFromTo(): void {
     $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, 'ContactTestTest');
@@ -194,7 +192,7 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
     $this->assertEquals($queryObj->_qill[0][0], "date field BETWEEN 'June 6th, 2014 12:00 AM AND June 6th, 2015 11:59 PM'");
 
     //CRM-17236 - Test custom date is correctly displayed without time.
-    $formattedValue = CRM_Core_BAO_CustomField::displayValue(date('Ymdhms'), $dateCustomField['id']);
+    $formattedValue = CRM_Core_BAO_CustomField::displayValue(date('Ymdhms'), (int) $dateCustomField['id']);
     $this->assertEquals(date('m/d/Y'), $formattedValue);
   }
 


### PR DESCRIPTION

Overview
----------------------------------------
Simplify CustomField::displayValue to expect an ID & have deprecated handling for anything else

All this passing objects & then maybe casting to arrays is confusing - let's just encourage ID to be passed in & the rest can be handled but not encouraged

Before
----------------------------------------
function specifies field as `CRM_Core_BAO_CustomField|int|array|string`

After
----------------------------------------
function only advertises `fieldID` as int - although it still handles the others. The confusing loading is moved out of the function

Technical Details
----------------------------------------


Comments
----------------------------------------
