### PR TITLE
PHP 7.x - Use get_class() instead of $object::class

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -3170,7 +3170,7 @@ SELECT contact_id
   public static function getSelectWhereClause($tableAlias = NULL, $entityName = NULL, $conditions = []) {
     $bao = new static();
     $tableAlias = $tableAlias ?? $bao->tableName();
-    $entityName = $entityName ?? CRM_Core_DAO_AllCoreTables::getBriefName($bao::class);
+    $entityName = $entityName ?? CRM_Core_DAO_AllCoreTables::getBriefName(get_class($bao));
     $finalClauses = [];
     $fields = static::getSupportedFields();
     $selectWhereClauses = $bao->addSelectWhereClause($entityName, NULL, $conditions);

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -633,7 +633,7 @@ abstract class CRM_Utils_Hook {
    *   Values from WHERE or ON clause
    */
   public static function selectWhereClause($entity, array &$clauses, int $userId = NULL, array $conditions = []): void {
-    $entityName = is_object($entity) ? CRM_Core_DAO_AllCoreTables::getBriefName($entity::class) : $entity;
+    $entityName = is_object($entity) ? CRM_Core_DAO_AllCoreTables::getBriefName(get_class($entity)) : $entity;
     $null = NULL;
     $userId = $userId ?? (int) CRM_Core_Session::getLoggedInContactID();
     self::singleton()->invoke(['entity', 'clauses', 'userId', 'conditions'],


### PR DESCRIPTION
Overview
----------------------------------------

Follow up to #27472. Fixes recent compatibility-regression in `master`. cc @colemanw 

