### PR TITLE
(REF) CiviMail - Use safer insert

### DIFF
--- a/CRM/Mailing/Event/BAO/MailingEventQueue.php
+++ b/CRM/Mailing/Event/BAO/MailingEventQueue.php
@@ -36,21 +36,24 @@ class CRM_Mailing_Event_BAO_MailingEventQueue extends CRM_Mailing_Event_DAO_Mail
   }
 
   /**
-   * Create a security hash from the job, email and contact ids.
+   * Create a unique-ish string to stare in the hash table.
    *
-   * @param array $params
+   * This is included in verp emails such that bounces go to a unique
+   * address (e.g. b.123456.456ABC456ABC.my-email-address@example.com). In this case
+   * b is the action (bounce), 123456 is the queue_id and the last part is the
+   * random string from this function. Note that the local part of the email
+   * can have a max of 64 characters
+   *
+   * https://issues.civicrm.org/jira/browse/CRM-2574
+   *
+   * The hash combined with the queue id provides a fairly unguessable combo for the emails
+   * (enough that a sysadmin should notice if someone tried to brute force it!)
    *
    * @return string
    *   The hash
    */
-  public static function hash($params) {
-    $jobId = $params['job_id'];
-    $emailId = CRM_Utils_Array::value('email_id', $params, '');
-    $contactId = $params['contact_id'];
-
-    return substr(sha1("{$jobId}:{$emailId}:{$contactId}:" . time()),
-      0, 16
-    );
+  public static function hash() {
+    return base64_encode(random_bytes(16));
   }
 
   /**

--- a/CRM/Utils/SQL/Insert.php
+++ b/CRM/Utils/SQL/Insert.php
@@ -186,4 +186,19 @@ class CRM_Utils_SQL_Insert {
     return $sql;
   }
 
+  /**
+   * Execute the query.
+   *
+   * @param bool $i18nRewrite
+   *   If the system has multilingual features, should the field/table
+   *   names be rewritten?
+   * @return CRM_Core_DAO
+   * @see CRM_Core_DAO::executeQuery
+   * @see CRM_Core_I18n_Schema::rewriteQuery
+   */
+  public function execute($i18nRewrite = TRUE) {
+    return CRM_Core_DAO::executeQuery($this->toSQL(), [], TRUE, NULL,
+      FALSE, $i18nRewrite, FALSE);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

Follow-up to FIXME identified in #27533.  ping @eileenmcnaughton 

(*This is really only one commit, but it depends on #27533. You should be able to merge after the other one is merged. It shouldn't need a re-base/re-test unless it sits idle for 4 weeks.*)

Before
------

* Generates an INSERT statement without escaping. This is technically not a problem because the data comes from a trusted source. But it become a problem if the data changed, and there's no need for the risk.

After
-----

* Generate an INSERT statement with escaping.

Comments
-----------

I did some `r-run` -- executing a full mail-blast and checking that the generated event-queue items worked.