### PR TITLE
[php8.x[ Remove notice-causing code that seems unreachable

### DIFF
--- a/templates/CRM/Member/Form/MembershipType.tpl
+++ b/templates/CRM/Member/Form/MembershipType.tpl
@@ -171,27 +171,6 @@ function showHidePeriodSettings() {
   }
 }
 
-//load the auto renew msg if recur allow.
-{/literal}{if $authorize and $allowAutoRenewMsg}{literal}
-CRM.$(function($) {
-  setReminder( null );
-});
-{/literal}{/if}{literal}
-
-function setReminder( autoRenewOpt ) {
-  //don't process.
-  var allowToProcess = {/literal}'{$allowAutoRenewMsg}'{literal};
-  if ( !allowToProcess ) {
-    return;
-  }
-  if ( !autoRenewOpt ) {
-    autoRenewOpt = cj( 'input:radio[name="auto_renew"]:checked').val();
-  }
-  funName = 'hide();';
-  if ( autoRenewOpt == 1 || autoRenewOpt == 2 ) funName = 'show();';
-  eval( "cj('#autoRenewalMsgId')." + funName );
-}
-
 function showHideMaxRelated(relTypeId) {
   if (relTypeId) {
     cj('#maxRelated').show();

--- a/templates/CRM/Member/Form/MembershipType.tpl
+++ b/templates/CRM/Member/Form/MembershipType.tpl
@@ -105,7 +105,7 @@
       </div>
     </fieldset>
 
-    {include file="CRM/common/customDataBlock.tpl"}
+    {include file="CRM/common/customDataBlock.tpl" customDataType='MembershipType' customDataSubType=false cid=false groupID=false}
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
   {/if}
     <div class="spacer"></div>


### PR DESCRIPTION
Overview
----------------------------------------

1) [php8.x[ Remove notice-causing code that seems unreachable
2) pass parameters when including customDataBlock.tpl

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/336308/15d6d6ce-dbd1-4e96-96f7-3424eb5bf7f0)


After
----------------------------------------


Technical Details
----------------------------------------
1) I really can't find any way this code could be triggered - I think it might have been quietly broken for years...
2) I think this customDataBlock include is to permit enabling custom data to extend MembershipType - however, other than entity, the fields are not relevant. (groupID was the one I hesitated over but it is when you want only one specific group)

Comments
----------------------------------------

@demeritcowboy not sure if you hit this notice configuring to test the membership page but my take on it is that it the code is doing nothing