### PR TITLE
Always assign noCid when the tpl is included

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -321,10 +321,9 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     $this->addPaymentProcessorFieldsToForm();
     $this->assign('is_pay_later', $this->getCurrentPaymentProcessor() === 0 && $this->_values['is_pay_later']);
     $this->assign('pay_later_text', $this->getCurrentPaymentProcessor() === 0 ? $this->getPayLaterLabel() : NULL);
-
+    $this->assign('nocid', $contactID === 0);
     if ($contactID === 0) {
       $this->addCidZeroOptions();
-
     }
 
     //build pledge block.

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2614,7 +2614,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * and a dozen other small ones to be refactored into a shared parent with the reduction of much code duplication
    */
   public function addCIDZeroOptions() {
-    $this->assign('nocid', TRUE);
     $profiles = [];
     if ($this->_values['custom_pre_id']) {
       $profiles[] = $this->_values['custom_pre_id'];

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -430,8 +430,9 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         $this->addPaymentProcessorFieldsToForm();
       }
     }
-
-    if ($contactID === 0 && !$this->_values['event']['is_multiple_registrations']) {
+    $isSelectContactID = ($contactID === 0 && !$this->_values['event']['is_multiple_registrations']);
+    $this->assign('nocid', $isSelectContactID);
+    if ($isSelectContactID) {
       //@todo we are blocking for multiple registrations because we haven't tested
       $this->addCIDZeroOptions();
     }

--- a/templates/CRM/Member/Form/MembershipType.tpl
+++ b/templates/CRM/Member/Form/MembershipType.tpl
@@ -106,7 +106,6 @@
     </fieldset>
 
     {include file="CRM/common/customDataBlock.tpl"}
-
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
   {/if}
     <div class="spacer"></div>

--- a/templates/CRM/common/cidzero.tpl
+++ b/templates/CRM/common/cidzero.tpl
@@ -1,4 +1,4 @@
-{if !empty($nocid)}
+{if $nocid}
   <div class="crm-other-contact-row messages status">
     <span>{ts}You are completing this form on behalf of someone else. Please enter their details.</span>{/ts}
   {if !empty($selectable)}


### PR DESCRIPTION
Fixes notices by moving the assign out of the function that adds the form elements

This one only matters when smarty is in secure mode:
