### PR TITLE
Switch all participant token listing to TokenProcessor, add deprecation

### DIFF
--- a/CRM/Badge/Form/Layout.php
+++ b/CRM/Badge/Form/Layout.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Token\TokenProcessor;
+
 /**
  *
  * @package CRM
@@ -49,21 +51,13 @@ class CRM_Badge_Form_Layout extends CRM_Admin_Form {
     $this->add('text', 'description', ts('Description'),
       CRM_Core_DAO::getAttribute('CRM_Core_DAO_PrintLabel', 'title'));
 
-    // get the tokens - at the point of rendering the token processor is used so
-    // the only reason for this cut-down set of tokens is UI on this
-    // screen and / or historical.
-    $contactTokens = CRM_Core_SelectValues::contactTokens();
-    $eventTokens = [
-      '{event.event_id}' => ts('Event ID'),
-      '{event.title}' => ts('Event Title'),
-      // This layout selection is day + month eg October 27th
-      // obviously someone felt year was not logical for dates.
-      '{event.start_date|crmDate:"%B %E%f"}' => ts('Event Start Date'),
-      '{event.end_date|crmDate:"%B %E%f"}' => ts('Event End Date'),
-    ];
-    $participantTokens = CRM_Core_SelectValues::participantTokens();
+    $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['participantId', 'contactId', 'eventId']]);
+    $tokens = $tokenProcessor->listTokens();
+    // This layout selection is day + month eg October 27th
+    // obviously someone felt year was not logical for dates.
+    $tokens['{event.start_date|crmDate:"%B %E%f"}'] = ts('Event Start Date - Day & Month');
+    $tokens[] = ts('Event End Date - Day & Month');
 
-    $tokens = array_merge($contactTokens, $eventTokens, $participantTokens);
     asort($tokens);
 
     $tokens = array_merge(['spacer' => ts('- spacer -')] + $tokens);

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -634,6 +634,7 @@ class CRM_Core_SelectValues {
    * @return array
    */
   public static function participantTokens(): array {
+    CRM_Core_Error::deprecatedFunctionWarning('user TokenProcessor');
     $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['participantId']]);
     $allTokens = $tokenProcessor->listTokens();
     foreach (array_keys($allTokens) as $token) {

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -752,9 +752,6 @@ December 21st, 2007
     $this->createLoggedInUser();
     $this->setupParticipantScheduledReminder();
 
-    $tokens = CRM_Core_SelectValues::participantTokens();
-    $this->assertEquals(array_diff_key($this->getParticipantTokens(), $this->getUnadvertisedTokens()), $tokens);
-
     $mut = new CiviMailUtils($this);
 
     $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
@@ -762,9 +759,7 @@ December 21st, 2007
       'smarty' => FALSE,
       'schema' => ['participantId'],
     ]);
-    $this->assertEquals(array_merge($tokens, $this->getEventTokens(), $this->getDomainTokens()), $tokenProcessor->listTokens());
-
-    $this->callAPISuccess('job', 'send_reminder', []);
+    $this->callAPISuccess('Job', 'send_reminder', []);
     $expected = $this->getExpectedParticipantTokenOutput();
     $mut->checkMailLog([$expected]);
 
@@ -1030,7 +1025,7 @@ United States', $tokenProcessor->getRow(0)->render('message'));
    *
    * @return string[]
    */
-  protected function getRecurEntityTokens($entity): array {
+  protected function getRecurEntityTokens(string $entity): array {
     return [
       '{' . $entity . '.contribution_recur_id.id}' => 'Recurring Contribution ID',
       '{' . $entity . '.contribution_recur_id.contact_id}' => 'Contact ID',


### PR DESCRIPTION
Overview
----------------------------------------
Switch all participant token listing to TokenProcessor, add deprecation

Before
----------------------------------------
Only one place in core (+ one test) accesses this function - which has held us back from adding deprecation noise as most similar functions have

After
----------------------------------------
No uses, deprecated

Note that the 'trade off' is the Badge page shows the same list of tokens as elsewhere (rather than a mini set). This is good and maybe also bad - but it is an obscure screen

 I added back in the specially formatted dates one in case it's there for a reason.

https://dmaster.localhost:32353/civicrm/admin/badgelayout?action=add&reset=1
![image](https://github.com/civicrm/civicrm-core/assets/336308/ce049088-f3a6-4cb7-a7bd-06f8952d45c1)

Technical Details
----------------------------------------


Comments
----------------------------------------