### PR TITLE
Fix double fieldset for honoree section

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -208,7 +208,7 @@
           {/if}
           {/crmRegion}
           <div id="honorType" class="honoree-name-email-section">
-            {include file="CRM/UF/Form/Block.tpl" fields=$honoreeProfileFields mode=8 prefix='honor' hideFieldset=false}
+            {include file="CRM/UF/Form/Block.tpl" fields=$honoreeProfileFields mode=8 prefix='honor' hideFieldset=true}
           </div>
         </fieldset>
       {/if}


### PR DESCRIPTION
Overview
----------------------------------------
fieldset appears twice

Before
----------------------------------------
1. Enable the honoree section on a contribution page, on the title and settings tab.
2. When visiting the contribution page it shows the profile title "Honoree Individual", which is from a reserved profile where you can't change the title in the UI. It didn't used to show this before. It already has the configurable fieldset title from the settings on the contribution page.

After
----------------------------------------
Like before

Technical Details
----------------------------------------
The change is just from yesterday (or today depending on your point of view) in https://github.com/civicrm/civicrm-core/pull/27483

Comments
----------------------------------------

