### PR TITLE
dev/core##4146 [NFC] More Smarty 3+ prep, mostly quoting strings and removing backticks

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Groups.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Groups.mgd.php
@@ -124,7 +124,7 @@ return [
               'dataType' => 'String',
               'label' => E::ts('Fields'),
               'sortable' => TRUE,
-              'rewrite' => "{capture assign=fields}[GROUP_CONCAT_CustomGroup_CustomField_custom_group_id_01_label]{/capture}{ \$fields|replace:',':'<br>'}",
+              'rewrite' => "{capture assign=fields}[GROUP_CONCAT_CustomGroup_CustomField_custom_group_id_01_label]{/capture}{\$fields|replace:',':'<br>'}",
             ],
             [
               'size' => 'btn-xs',

--- a/ext/ckeditor4/templates/CRM/Ckeditor4/Form/CKEditorConfig.tpl
+++ b/ext/ckeditor4/templates/CRM/Ckeditor4/Form/CKEditorConfig.tpl
@@ -47,7 +47,7 @@
 {/literal}</style>
 {* Force the custom config file to reload by appending a new query string *}
 <script type="text/javascript">
-  {if $configUrl}CKEDITOR.config.customConfig = '{$configUrl}?{php}print str_replace(array(' ', '.'), array('', '='), microtime());{/php}'{/if};
+  {if $configUrl}CKEDITOR.config.customConfig = '{$configUrl}?{$smarty.now}'{/if};
 </script>
 
 <div class="ui-tabs">

--- a/templates/CRM/Admin/Form/ContactType.tpl
+++ b/templates/CRM/Admin/Form/ContactType.tpl
@@ -19,7 +19,7 @@
    <tr class="crm-contact-type-form-block-label">
       <td class="label">{$form.label.label}
       {if $action eq 2}
-        {include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_contact_type' field='label' id= $cid}
+        {include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_contact_type' field='label' id=$cid}
       {/if}
       </td>
       <td>{$form.label.html}</td>
@@ -48,7 +48,7 @@
    <tr class="crm-contact-type-form-block-description">
      <td class="label">{$form.description.label}
      {if $action eq 2}
-       {include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_contact_type' field='description' id= $cid}
+       {include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_contact_type' field='description' id=$cid}
      {/if}
      </td>
      <td>{$form.description.html}</td>

--- a/templates/CRM/Admin/Form/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Form/PaymentProcessor.tpl
@@ -55,41 +55,41 @@
 <legend>{ts}Processor Details for Live Payments{/ts}</legend>
     <table class="form-layout-compressed">
         <tr class="crm-paymentProcessor-form-block-user_name">
-            <td class="label">{$form.user_name.label}</td><td>{$form.user_name.html} {help id=$ppTypeName|cat:'-live-user-name' title=$form.user_name.label}</td>
+            <td class="label">{$form.user_name.label}</td><td>{$form.user_name.html} {help id="$ppTypeName-live-user-name" title=$form.user_name.label}</td>
         </tr>
 {if !empty($form.password)}
         <tr class="crm-paymentProcessor-form-block-password">
-            <td class="label">{$form.password.label}</td><td>{$form.password.html} {help id=$ppTypeName|cat:'-live-password' title=$form.password.label}</td>
+            <td class="label">{$form.password.label}</td><td>{$form.password.html} {help id="$ppTypeName-live-password" title=$form.password.label}</td>
         </tr>
 {/if}
 {if !empty($form.signature)}
         <tr class="crm-paymentProcessor-form-block-signature">
-            <td class="label">{$form.signature.label}</td><td>{$form.signature.html} {help id=$ppTypeName|cat:'-live-signature' title=$form.signature.label}</td>
+            <td class="label">{$form.signature.label}</td><td>{$form.signature.html} {help id="$ppTypeName-live-signature" title=$form.signature.label}</td>
         </tr>
 {/if}
 {if !empty($form.subject)}
         <tr class="crm-paymentProcessor-form-block-subject">
-            <td class="label">{$form.subject.label}</td><td>{$form.subject.html} {help id=$ppTypeName|cat:'-live-subject' title=$form.subject.label}</td>
+            <td class="label">{$form.subject.label}</td><td>{$form.subject.html} {help id="$ppTypeName-live-subject" title=$form.subject.label}</td>
         </tr>
 {/if}
 {if !empty($form.url_site)}
         <tr class="crm-paymentProcessor-form-block-url_site">
-            <td class="label">{$form.url_site.label}</td><td>{$form.url_site.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-live-url-site' title=$form.url_site.label}</td>
+            <td class="label">{$form.url_site.label}</td><td>{$form.url_site.html|crmAddClass:huge} {help id="$ppTypeName-live-url-site" title=$form.url_site.label}</td>
         </tr>
 {/if}
 {if !empty($form.url_api)}
         <tr class="crm-paymentProcessor-form-block-url_api">
-            <td class="label">{$form.url_api.label}</td><td>{$form.url_api.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-live-url-api' title=$form.url_api.label}</td>
+            <td class="label">{$form.url_api.label}</td><td>{$form.url_api.html|crmAddClass:huge} {help id="$ppTypeName-live-url-api" title=$form.url_api.label}</td>
         </tr>
 {/if}
 {if !empty($form.url_recur)}
         <tr class="crm-paymentProcessor-form-block-url_recur">
-            <td class="label">{$form.url_recur.label}</td><td>{$form.url_recur.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-live-url-recur' title=$form.url_recur.label}</td>
+            <td class="label">{$form.url_recur.label}</td><td>{$form.url_recur.html|crmAddClass:huge} {help id="$ppTypeName-live-url-recur" title=$form.url_recur.label}</td>
         </tr>
 {/if}
 {if !empty($form.url_button)}
         <tr class="crm-paymentProcessor-form-block-url_button">
-            <td class="label">{$form.url_button.label}</td><td>{$form.url_button.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-live-url-button' title=$form.url_button.label}</td>
+            <td class="label">{$form.url_button.label}</td><td>{$form.url_button.html|crmAddClass:huge} {help id="$ppTypeName-live-url-button" title=$form.url_button.label}</td>
         </tr>
 {/if}
     </table>
@@ -99,40 +99,40 @@
 <legend>{ts}Processor Details for Test Payments{/ts}</legend>
     <table class="form-layout-compressed">
         <tr class="crm-paymentProcessor-form-block-test_user_name">
-            <td class="label">{$form.test_user_name.label}</td><td>{$form.test_user_name.html} {help id=$ppTypeName|cat:'-test-user-name' title=$form.test_user_name.label}</td></tr>
+            <td class="label">{$form.test_user_name.label}</td><td>{$form.test_user_name.html} {help id="$ppTypeName-test-user-name" title=$form.test_user_name.label}</td></tr>
 {if !empty($form.test_password)}
         <tr class="crm-paymentProcessor-form-block-test_password">
-            <td class="label">{$form.test_password.label}</td><td>{$form.test_password.html} {help id=$ppTypeName|cat:'-test-password' title=$form.test_password.label}</td>
+            <td class="label">{$form.test_password.label}</td><td>{$form.test_password.html} {help id="$ppTypeName-test-password" title=$form.test_password.label}</td>
         </tr>
 {/if}
 {if !empty($form.test_signature)}
         <tr class="crm-paymentProcessor-form-block-test_signature">
-            <td class="label">{$form.test_signature.label}</td><td>{$form.test_signature.html} {help id=$ppTypeName|cat:'-test-signature' title=$form.test_signature.label}</td>
+            <td class="label">{$form.test_signature.label}</td><td>{$form.test_signature.html} {help id="$ppTypeName-test-signature" title=$form.test_signature.label}</td>
         </tr>
 {/if}
 {if !empty($form.test_subject)}
         <tr class="crm-paymentProcessor-form-block-test_subject">
-            <td class="label">{$form.test_subject.label}</td><td>{$form.test_subject.html} {help id=$ppTypeName|cat:'-test-subject' title=$form.test_subject.label}</td>
+            <td class="label">{$form.test_subject.label}</td><td>{$form.test_subject.html} {help id="$ppTypeName-test-subject" title=$form.test_subject.label}</td>
         </tr>
 {/if}
 {if !empty($form.test_url_site)}
         <tr class="crm-paymentProcessor-form-block-test_url_site">
-            <td class="label">{$form.test_url_site.label}</td><td>{$form.test_url_site.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-test-url-site' title=$form.test_url_site.label}</td>
+            <td class="label">{$form.test_url_site.label}</td><td>{$form.test_url_site.html|crmAddClass:huge} {help id="$ppTypeName-test-url-site" title=$form.test_url_site.label}</td>
         </tr>
 {/if}
 {if !empty($form.test_url_api)}
         <tr class="crm-paymentProcessor-form-block-test_url_api">
-            <td class="label">{$form.test_url_api.label}</td><td>{$form.test_url_api.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-test-url-api' title=$form.test_url_api.label}</td>
+            <td class="label">{$form.test_url_api.label}</td><td>{$form.test_url_api.html|crmAddClass:huge} {help id="$ppTypeName-test-url-api" title=$form.test_url_api.label}</td>
         </tr>
 {/if}
 {if !empty($form.test_url_recur)}
         <tr class="crm-paymentProcessor-form-block-test_url_recur">
-            <td class="label">{$form.test_url_recur.label}</td><td>{$form.test_url_recur.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-test-url-recur' title=$form.test_url_recur.label}</td>
+            <td class="label">{$form.test_url_recur.label}</td><td>{$form.test_url_recur.html|crmAddClass:huge} {help id="$ppTypeName-test-url-recur" title=$form.test_url_recur.label}</td>
         </tr>
 {/if}
 {if !empty($form.test_url_button)}
         <tr class="crm-paymentProcessor-form-block-test_url_button">
-            <td class="label">{$form.test_url_button.label}</td><td>{$form.test_url_button.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-test-url-button' title=$form.test_url_button.label}</td>
+            <td class="label">{$form.test_url_button.label}</td><td>{$form.test_url_button.html|crmAddClass:huge} {help id="$ppTypeName-test-url-button" title=$form.test_url_button.label}</td>
         </tr>
 {/if}
 {/if}

--- a/templates/CRM/Admin/Form/Preferences/Address.tpl
+++ b/templates/CRM/Admin/Form/Preferences/Address.tpl
@@ -42,7 +42,7 @@
                 {help id="id-token-text" tplFile=$tplFile file="CRM/Contact/Form/Task/Email.hlp"}
               </div>
                 {$form.address_format.html|crmAddClass:huge12}<br />
-                <span class="description">{ts}Format for displaying addresses in the Contact Summary and Event Information screens.{/ts}<br />{ts 1=&#123;contact.state_province&#125; 2=&#123;contact.state_province_name&#125;}Use %1 for state/province abbreviation or %2 for state province name.{/ts}</span>
+                <span class="description">{ts}Format for displaying addresses in the Contact Summary and Event Information screens.{/ts}<br />{ts 1="&#123;contact.state_province&#125;" 2="&#123;contact.state_province_name&#125;"}Use %1 for state/province abbreviation or %2 for state province name.{/ts}</span>
               </td>
           </tr>
       </table>

--- a/templates/CRM/Case/Form/ActivityTab.tpl
+++ b/templates/CRM/Case/Form/ActivityTab.tpl
@@ -31,12 +31,12 @@
         </tr>
         <tr>
           <td class="crm-case-caseview-form-block-activity_date_low">
-            {assign var=activitylow  value=activity_date_low_$caseID}
+            {assign var=activitylow  value="activity_date_low_`$caseID`"}
             {$form.$activitylow.label}<br />
             {$form.$activitylow.html}
           </td>
           <td class="crm-case-caseview-form-block-activity_date_high">
-            {assign var=activityhigh  value=activity_date_high_$caseID}
+            {assign var=activityhigh  value="activity_date_high_`$caseID`"}
             {$form.$activityhigh.label}<br />
             {$form.$activityhigh.html}
           </td>

--- a/templates/CRM/Contact/Form/Domain.tpl
+++ b/templates/CRM/Contact/Form/Domain.tpl
@@ -27,7 +27,7 @@
     </table>
 
     <h3>{ts}Default Organization Address{/ts}</h3>
-        <div class="description">{ts 1=&#123;domain.address&#125;}CiviMail mailings must include the sending organization's address. This is done by putting the %1 token in either the body or footer of the mailing. This token may also be used in regular 'Email - send now' messages and in other Message Templates. The token is replaced by the address entered below when the message is sent.{/ts}</div>
+        <div class="description">{ts 1="&#123;domain.address&#125;"}CiviMail mailings must include the sending organization's address. This is done by putting the %1 token in either the body or footer of the mailing. This token may also be used in regular 'Email - send now' messages and in other Message Templates. The token is replaced by the address entered below when the message is sent.{/ts}</div>
         {include file="CRM/Contact/Form/Edit/Address.tpl" blockId=1 masterAddress='' parseStreetAddress='' className=''}
     <h3>{ts}Organization Contact Information{/ts}</h3>
         <div class="description">{ts}You can also include general email and/or phone contact information in mailings.{/ts} {help id="additional-contact"}</div>

--- a/templates/CRM/Contact/Form/Edit/Address.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address.tpl
@@ -50,9 +50,9 @@
      <table id="address_table_{$blockId}" class="form-layout-compressed">
          {* build address block w/ address sequence. *}
          {foreach item=addressElement from=$addressSequence}
-              {include file=CRM/Contact/Form/Edit/Address/$addressElement.tpl}
+              {include file="CRM/Contact/Form/Edit/Address/`$addressElement`.tpl"}
          {/foreach}
-         {include file=CRM/Contact/Form/Edit/Address/geo_code.tpl}
+         {include file="CRM/Contact/Form/Edit/Address/geo_code.tpl"}
      </table>
         </td>
         <td colspan="2">

--- a/templates/CRM/Contact/Form/Inline/Address.tpl
+++ b/templates/CRM/Contact/Form/Inline/Address.tpl
@@ -43,9 +43,9 @@
         <table id="address_table_{$blockId}" class="form-layout-compressed">
            {* build address block w/ address sequence. *}
            {foreach item=addressElement from=$addressSequence}
-            {include file=CRM/Contact/Form/Edit/Address/$addressElement.tpl}
+            {include file="CRM/Contact/Form/Edit/Address/`$addressElement`.tpl"}
            {/foreach}
-           {include file=CRM/Contact/Form/Edit/Address/geo_code.tpl}
+           {include file="CRM/Contact/Form/Edit/Address/geo_code.tpl"}
        </table>
       </td>
      </tr>

--- a/templates/CRM/Contact/Form/RelatedContact.tpl
+++ b/templates/CRM/Contact/Form/RelatedContact.tpl
@@ -9,7 +9,7 @@
 *}
 {* This file provides the HTML for the edit Related contact form *}
 
-{include file=CRM/Contact/Form/OnBehalfOf.tpl}
+{include file="CRM/Contact/Form/OnBehalfOf.tpl"}
 
 <div class="crm-submit-buttons">
     {$form.buttons.html}

--- a/templates/CRM/Contact/Form/Search/ResultTasks.tpl
+++ b/templates/CRM/Contact/Form/Search/ResultTasks.tpl
@@ -34,7 +34,7 @@
   <tr>
     <td style="width: 30%;">
         {if !empty($savedSearch.name)}{$savedSearch.name} ({ts}smart group{/ts}) - {/if}
-        {ts count=$pager->_totalItems plural='%count Contacts'}%count Contact{/ts}
+        {ts count=$pager->_totalItems plural="%count Contacts"}%count Contact{/ts}
     </td>
 
     {* Search criteria are passed to tpl in the $qill array *}
@@ -48,7 +48,7 @@
     <td> {ts}Select Records{/ts}:</td>
     <td class="nowrap">
       {assign var="checked" value=$selectedContactIds|@count}
-      {$form.radio_ts.ts_all.html} <label for="{$ts_all_id}">{ts count=$pager->_totalItems plural='All %count records'}The found record{/ts}</label>
+      {$form.radio_ts.ts_all.html} <label for="{$ts_all_id}">{ts count=$pager->_totalItems plural="All %count records"}The found record{/ts}</label>
       {if $pager->_totalItems > 1}
         &nbsp; {$form.radio_ts.ts_sel.html} <label for="{$ts_sel_id}">{ts 1="<span>$checked</span>"}%1 Selected records only{/ts}</label>
       {/if}

--- a/templates/CRM/Contact/Form/Task/Batch.tpl
+++ b/templates/CRM/Contact/Form/Task/Batch.tpl
@@ -38,7 +38,7 @@
       {assign var=n value=$field.name}
       {if $field.options_per_line}
         <td class="compressed">
-          {assign var="count" value="1"}
+          {assign var="count" value=1}
           {strip}
             <table class="form-layout-compressed">
             <tr>
@@ -50,9 +50,9 @@
                   {if $count == $field.options_per_line}
                   </tr>
                   <tr>
-                    {assign var="count" value="1"}
+                    {assign var="count" value=1}
                     {else}
-                    {assign var="count" value=`$count+1`}
+                    {assign var="count" value=$count+1}
                   {/if}
                 {/if}
               {/foreach}

--- a/templates/CRM/Contribute/Form/AdditionalInfo/Premium.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalInfo/Premium.tpl
@@ -50,7 +50,7 @@
         }
 {/literal}
        var index = 1;
-       {foreach from= $mincontribution item=amt key=id}
+       {foreach from=$mincontribution item=amt key=id}
          {literal}amount[index]{/literal} = "{$amt}"
          {literal}index = index + 1{/literal}
        {/foreach}

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -169,7 +169,7 @@
         </div>
       {/if}
       {if $showMainEmail}
-        {assign var=n value=email-$bltID}
+        {assign var=n value="email-`$bltID`"}
         <div class="crm-public-form-item crm-section {$form.$n.name}-section">
           <div class="label">{$form.$n.label}</div>
           <div class="content">

--- a/templates/CRM/Contribute/Form/ContributionPage/Tab.hlp
+++ b/templates/CRM/Contribute/Form/ContributionPage/Tab.hlp
@@ -13,49 +13,49 @@
 {htxt id="id-configure-contrib-pages"}
 <table>
 <tr>
-    <td><a href="{crmURL p='civicrm/admin/contribute/settings' q="reset=1&action=update&id=`$contributionPageID`"}" id="idContribPageSettings"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Title and Settings{/ts}</a></td>
+    <td><a href="{crmURL p="civicrm/admin/contribute/settings" q="reset=1&action=update&id=`$contributionPageID`"}" id="idContribPageSettings"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Title and Settings{/ts}</a></td>
     <td>{ts}Use this form to edit the page title, financial type (e.g. donation, campaign contribution, etc.), goal amount, introduction, and status (active/inactive) for this online contribution page.{/ts}</td>
 </tr>
 <tr>
-    <td><a href="{crmURL p='civicrm/admin/contribute/amount' q="reset=1&action=update&id=`$contributionPageID`"}" id="idAmount"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Amount{/ts}</a></td>
+    <td><a href="{crmURL p="civicrm/admin/contribute/amount" q="reset=1&action=update&id=`$contributionPageID`"}" id="idAmount"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Amount{/ts}</a></td>
     <td>{ts}Use this form to configure Contribution Amount options. You can give contributors the ability to enter their own contribution amounts and/or provide a fixed list of amounts. For fixed amounts, you can enter a label for each 'level' of contribution (e.g. Friend, Sustainer, etc.). If you allow people to enter their own dollar amounts, you can also set minimum and maximum values. Depending on your choice of Payment Processor, you may be able to offer a recurring contribution option.{/ts}</td>
 </tr>
 <tr>
-    <td><a href="{crmURL p='civicrm/admin/contribute/membership' q="reset=1&action=update&id=`$contributionPageID`"}" id="idMembership"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Memberships{/ts}</a></td>
+    <td><a href="{crmURL p="civicrm/admin/contribute/membership" q="reset=1&action=update&id=`$contributionPageID`"}" id="idMembership"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Memberships{/ts}</a></td>
      <td>{ts}Use this form to enable and configure a Membership Signup and Renewal section for this Online Contribution Page. If you're not using this page for membership signup, leave the Enabled box un-checked.{/ts}</td>
 </tr>
 <tr>
-    <td><a href="{crmURL p='civicrm/admin/contribute/thankYou' q="reset=1&action=update&id=`$contributionPageID`"}" id="idThanks"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Thank-you and Receipting{/ts}</a></td>
+    <td><a href="{crmURL p="civicrm/admin/contribute/thankYou" q="reset=1&action=update&id=`$contributionPageID`"}" id="idThanks"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Thank-you and Receipting{/ts}</a></td>
     <td>{ts}Use this form to configure the thank-you message and receipting options. Contributors will see a confirmation and thank-you page after whenever an online contribution is successfully processed. You provide the content and layout of the thank-you section below. You also control whether an electronic receipt is automatically emailed to each contributor, and you can add a custom message to that receipt.{/ts}</td>
 </tr>
 <tr>
-    <td><a href="{crmURL p='civicrm/admin/contribute/friend' q="reset=1&action=update&id=`$contributionPageID`"}" id="idFriend"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Tell a Friend{/ts}</a></td>
+    <td><a href="{crmURL p="civicrm/admin/contribute/friend" q="reset=1&action=update&id=`$contributionPageID`"}" id="idFriend"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Tell a Friend{/ts}</a></td>
     <td>{ts}Tell a Friend gives your contributors an easy way to spread the word about this fundraising campaign. The contribution thank-you page will include a link to a form where they can enter their friends' email addresses, along with a personalized message. CiviCRM will record these solicitation activities, and will add the friends to your database.{/ts}</td>
 </tr>
 <tr>
-   <td><a href="{crmURL p='civicrm/admin/contribute/custom' q="reset=1&action=update&id=`$contributionPageID`"}" id="idCustom"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Include Profiles{/ts}</a></td>
+   <td><a href="{crmURL p="civicrm/admin/contribute/custom" q="reset=1&action=update&id=`$contributionPageID`"}" id="idCustom"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Include Profiles{/ts}</a></td>
     <td>{ts}You may want to collect information from contributors beyond what is required to make a contribution. For example, you may want to inquire about volunteer availability and skills. Add any number of fields to your contribution form by selecting CiviCRM Profiles (collections of fields) to include at the beginning of the page, and/or at the bottom.{/ts}<br />
 {capture assign=adminGroupURL}{crmURL p="civicrm/admin/uf/group" q="reset=1&action=browse"}{/capture}
 {ts 1=$adminGroupURL}You can use existing CiviCRM Profiles on your page or create profile(s) specifically for use in Online Contribution pages. Go to <a href="%1"><strong>Administer CiviCRM Profiles</strong></a> if you need to review, modify or create profiles (you can come back at any time to select or update the Profile(s) used for this page).{/ts}</td>
 </tr>
 <tr>
-   <td><a href="{crmURL p='civicrm/admin/contribute/premium q="reset=1&action=update&id=`$contributionPageID`"}" id="idPremium"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Premiums{/ts}</a></td>
+   <td><a href="{crmURL p="civicrm/admin/contribute/premium" q="reset=1&action=update&id=`$contributionPageID`"}" id="idPremium"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Premiums{/ts}</a></td>
     <td>{ts}Enable the Premiums section for this Online Contribution Page, and customize the title and introductory message (e.g ...in appreciation of your support, you will be able to select from a number of exciting thank-you gifts...). You can optionally provide a contact email address and/or phone number for inquiries. Then select and review the premiums that you want to offer on this contribution page.{/ts}</td>
 </tr>
 <tr>
-   <td><a href="{crmURL p='civicrm/admin/contribute/widget' q="reset=1&action=update&id=`$contributionPageID`"}" id="idWidget"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Widget{/ts}</a></td>
+   <td><a href="{crmURL p="civicrm/admin/contribute/widget" q="reset=1&action=update&id=`$contributionPageID`"}" id="idWidget"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Widget{/ts}</a></td>
    <td>{ts}Widgets allow you and your supporters to easily promote this fund-raising campaign. Widget code can be added to any web page.  They will provide a real-time display of current contribution results, and a direct link to this contribution page.{/ts}</td>
 </tr>
 <tr>
-  <td><a href="{crmURL p='civicrm/admin/contribute/pcp' q="reset=1&action=update&id=`$contributionPageID`"}" id="idPCP"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Personal Campaign Pages{/ts}</a></td>
+  <td><a href="{crmURL p="civicrm/admin/contribute/pcp" q="reset=1&action=update&id=`$contributionPageID`"}" id="idPCP"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Personal Campaign Pages{/ts}</a></td>
   <td>{ts}Allow constituents to create their own personal fundraising pages linked to this contribution page.{/ts}</td>
 </tr>
 <tr>
-  <td><a href="{crmURL p='civicrm/contribute/transact' q="reset=1&action=preview&id=`$contributionPageID`"}" id="idTest"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Online Contribution{/ts}</a><br /> ({ts}Test-drive{/ts})</td>
+  <td><a href="{crmURL p="civicrm/contribute/transact" q="reset=1&action=preview&id=`$contributionPageID`"}" id="idTest"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Online Contribution{/ts}</a><br /> ({ts}Test-drive{/ts})</td>
   <td>{ts}Test-drive the entire contribution process&mdash;including custom fields, confirmation, thank-you page, and receipting. Transactions will be directed to your payment processor's test server. No live financial transactions will be submitted. However, a contact record will be created or updated and a test contribution record will be saved to the database. Use obvious test contact names so you can review and delete these records as needed. Test contributions are not visible on the Contributions tab, but can be viewed by searching for 'Test Contributions' in the CiviContribute search form.{/ts}</td>
 </tr>
 <tr>
-  <td><a href="{crmURL p='civicrm/contribute/transact' q="reset=1&id=`$contributionPageID`"}" id="idLive"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Online Contribution{/ts}</a><br /> ({ts}Live{/ts})</td>
+  <td><a href="{crmURL p="civicrm/contribute/transact" q="reset=1&id=`$contributionPageID`"}" id="idLive"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Online Contribution{/ts}</a><br /> ({ts}Live{/ts})</td>
   <td>{ts}Review your customized <strong>LIVE</strong> online contribution page here. Use the following URL in links and buttons on any website to send visitors to this live page:{/ts}<br />
       <strong>{crmURL a=1 fe=1 p="civicrm/contribute/transact" q="reset=1&id=`$contributionPageID`"}</strong></td>
 </tr>

--- a/templates/CRM/Contribute/Page/ContributionPage.hlp
+++ b/templates/CRM/Contribute/Page/ContributionPage.hlp
@@ -11,7 +11,7 @@
   {ts}Contribution Pages{/ts}
 {/htxt}
 {htxt id="id-intro"}
-    {capture assign=newPageURL}{crmURL p='civicrm/admin/contribute/add' q='action=add&reset=1'}{/capture}
+    {capture assign=newPageURL}{crmURL p="civicrm/admin/contribute/add" q="action=add&reset=1"}{/capture}
     <p>{ts}CiviContribute allows you to create and maintain any number of Online Contribution Pages. You can create different pages for different programs or campaigns, and you can customize text, amounts, types of information collected from contributors, etc.{/ts}</p>
     {ts}For existing pages{/ts}:
     <ul class="indented">

--- a/templates/CRM/Custom/Form/Edit/CustomField.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomField.tpl
@@ -18,15 +18,15 @@
   <tr class="custom_field-row {$element.element_name}-row">
     <td class="label">{$formElement.label}{if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$element.label}{/if}</td>
     <td class="html-adjust">
-      {assign var="count" value="1"}
+      {assign var="count" value=1}
       {foreach name=outer key=key item=item from=$formElement}
         {if is_array($item) && array_key_exists('html', $item)}
           {$item.html}
           {if $count == $element.options_per_line}
             <br />
-            {assign var="count" value="1"}
+            {assign var="count" value=1}
           {else}
-            {assign var="count" value=`$count+1`}
+            {assign var="count" value=$count+1}
           {/if}
         {else}
           {* Skip because this isn't one of the numeric keyed elements that are the options to display, it's non-numeric keys like the field label and metadata. *}

--- a/templates/CRM/Custom/Form/Preview.tpl
+++ b/templates/CRM/Custom/Form/Preview.tpl
@@ -34,12 +34,11 @@
             <tr><td class="label"></td><td class="description">{$element.help_pre}</td></tr>
         {/if}
   {if !empty($element.options_per_line)}
-        {*assign var="element_name" value=$element.custom_group_id|cat:_|cat:$field_id|cat:_|cat:$element.name*}
         {assign var="element_name" value=$element.element_name}
         <tr>
          <td class="label">{$form.$element_name.label}{if !empty($element.help_post)}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$form.$element_name.label}{/if}</td>
          <td>
-            {assign var="count" value="1"}
+            {assign var="count" value=1}
                 <table class="form-layout-compressed">
                  <tr>
                    {* sort by fails for option per line. Added a variable to iterate through the element array*}
@@ -48,10 +47,10 @@
                      {if is_array($item) && array_key_exists('html', $item)}
                           <td class="labels font-light">{$form.$element_name.$key.html}</td>
                               {if $count == $element.options_per_line}
-                                {assign var="count" value="1"}
+                                {assign var="count" value=1}
                            </tr>
                             {else}
-                                {assign var="count" value=`$count+1`}
+                                {assign var="count" value=$count+1}
                             {/if}
                          {/if}
                     {/foreach}

--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -51,7 +51,7 @@
                 {include file="CRM/Price/Page/LineItem.tpl" context="Event"}
             {elseif $amounts || $amount == 0}
           <div class="crm-section no-label amount-item-section">
-                    {foreach from= $amounts item=amount key=level}
+                    {foreach from=$amounts item=amount key=level}
               <div class="content">
                   {$amount.amount|crmMoney}&nbsp;&nbsp;{$amount.label}
               </div>

--- a/templates/CRM/Event/Form/Registration/ThankYou.tpl
+++ b/templates/CRM/Event/Form/Registration/ThankYou.tpl
@@ -84,7 +84,7 @@
                 {include file="CRM/Price/Page/LineItem.tpl" context="Event"}
             {elseif $amount || $amount == 0}
               <div class="crm-section no-label amount-item-section">
-                    {foreach from= $finalAmount item=amount key=level}
+                    {foreach from=$finalAmount item=amount key=level}
                   <div class="content">
                       {$amount.amount|crmMoney}&nbsp;&nbsp;{$amount.label}
                   </div>

--- a/templates/CRM/Event/Form/Task/Batch.tpl
+++ b/templates/CRM/Event/Form/Task/Batch.tpl
@@ -57,7 +57,7 @@
                 {* CRM-19860 Copied from templates/CRM/Contact/Form/Task/Batch.tpl *}
                 {if $field.options_per_line}
                   <td class="compressed">
-                    {assign var="count" value="1"}
+                    {assign var="count" value=1}
                     {strip}
                       <table class="form-layout-compressed">
                       <tr>
@@ -69,9 +69,9 @@
                             {if $count == $field.options_per_line}
                             </tr>
                             <tr>
-                              {assign var="count" value="1"}
+                              {assign var="count" value=1}
                               {else}
-                              {assign var="count" value=`$count+1`}
+                              {assign var="count" value=$count+1}
                             {/if}
                           {/if}
                         {/foreach}

--- a/templates/CRM/Import/Form/DataSource.tpl
+++ b/templates/CRM/Import/Form/DataSource.tpl
@@ -19,7 +19,7 @@
     </div>
   {/if}
   <div class="help">
-    {ts 1=$importEntity 2= $importEntities}The %1 Import Wizard allows you to easily upload %2 from other applications into CiviCRM.{/ts}
+    {ts 1=$importEntity 2=$importEntities}The %1 Import Wizard allows you to easily upload %2 from other applications into CiviCRM.{/ts}
   </div>
   <div id="choose-data-source" class="form-item">
     <h3>{ts}Choose Data Source{/ts}</h3>

--- a/templates/CRM/Pledge/Form/Pledge.tpl
+++ b/templates/CRM/Pledge/Form/Pledge.tpl
@@ -22,7 +22,7 @@
     {math equation="x / y" x=$amount y=$installments format="%.2f" assign="currentInstallment"}
     {* Check if current Total Pledge Amount is different from original pledge amount. *}
     {if $currentInstallment NEQ $eachPaymentAmount}
-      {assign var=originalPledgeAmount value=`$installments*$eachPaymentAmount`}
+      {assign var=originalPledgeAmount value=$installments*$eachPaymentAmount}
     {/if}
 {/if}
 <div class="crm-block crm-form-block crm-pledge-form-block">

--- a/templates/CRM/Pledge/Form/PledgeView.tpl
+++ b/templates/CRM/Pledge/Form/PledgeView.tpl
@@ -10,7 +10,7 @@
 {math equation="x / y" x=$amount y=$installments format="%.2f" assign="currentInstallment"}
 {* Check if current Total Pledge Amount is different from original pledge amount. *}
 {if $currentInstallment NEQ $original_installment_amount}
-    {assign var=originalPledgeAmount value=`$installments*$original_installment_amount`}
+    {assign var=originalPledgeAmount value=$installments*$original_installment_amount}
 {/if}
 
 <div class="crm-block crm-content-block crm-pledge-view-block">

--- a/templates/CRM/Pledge/Form/Selector.tpl
+++ b/templates/CRM/Pledge/Form/Selector.tpl
@@ -49,7 +49,7 @@
             {/if}
             <td class="right">{$row.pledge_amount|crmMoney:$row.pledge_currency}</td>
             <td class="right">{$row.pledge_total_paid|crmMoney:$row.pledge_currency}</td>
-            <td class="right">{$row.pledge_amount-$row.pledge_total_paid|crmMoney:$row.pledge_currency}</td>
+            <td class="right">{($row.pledge_amount-$row.pledge_total_paid)|crmMoney:$row.pledge_currency}</td>
             <td>{$row.pledge_financial_type}</td>
             <td>{$row.pledge_create_date|truncate:10:''|crmDate}</td>
             <td>{$row.pledge_next_pay_date|truncate:10:''|crmDate}</td>

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -31,18 +31,18 @@
             {if $element.help_pre}<span class="content description">{$element.help_pre}</span><br />{/if}
             <div class="crm-section {$element.name}-section crm-price-field-id-{$field_id}">
             {if ($element.html_type eq 'CheckBox' || $element.html_type == 'Radio') && $element.options_per_line}
-              {assign var="element_name" value="price_"|cat:$field_id}
+              {assign var="element_name" value="price_`$field_id`"}
               <div class="label">{$form.$element_name.label}</div>
               <div class="content {$element.name}-content">
                 {assign var="elementCount" value="0"}
                 {assign var="optionCount" value="0"}
                 {assign var="rowCount" value="0"}
                 {foreach name=outer key=key item=item from=$form.$element_name}
-                  {assign var="elementCount" value=`$elementCount+1`}
+                  {assign var="elementCount" value=$elementCount+1}
                   {if is_numeric($key)}
-                    {assign var="optionCount" value=`$optionCount+1`}
+                    {assign var="optionCount" value=$optionCount+1}
                     {if $optionCount == 1}
-                      {assign var="rowCount" value=`$rowCount+1`}
+                      {assign var="rowCount" value=$rowCount+1}
                       <div class="price-set-row {$element.name}-row{$rowCount}">
                     {/if}
                     <span class="price-set-option-content">{$form.$element_name.$key.html}</span>
@@ -68,7 +68,7 @@
                     <span class="price-field-amount{if $form.$element_name.frozen EQ 1} sold-out-option{/if}">
                     {foreach item=option from=$element.options}
                       {if ($option.tax_amount || $option.tax_amount == "0") && $displayOpt && $invoicing}
-                        {assign var="amount" value=`$option.amount+$option.tax_amount`}
+                        {assign var="amount" value=$option.amount+$option.tax_amount}
                         {if $displayOpt == 'Do_not_show'}
                           {$amount|crmMoney:$currency}
                         {elseif $displayOpt == 'Inclusive'}

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -98,7 +98,7 @@
           <div class="crm-section editrow_{$n}-section form-item" id="editrow-{$n}">
             <div class="label">{$form.$n.label}</div>
             <div class="content edit-value">
-              {assign var="count" value="1"}
+              {assign var="count" value=1}
               {strip}
                 <table class="form-layout-compressed">
                 <tr>
@@ -110,9 +110,9 @@
                       {if $count == $field.options_per_line}
                       </tr>
                       <tr>
-                        {assign var="count" value="1"}
+                        {assign var="count" value=1}
                         {else}
-                        {assign var="count" value=`$count+1`}
+                        {assign var="count" value=$count+1}
                       {/if}
                     {/if}
                   {/foreach}
@@ -129,7 +129,7 @@
             </div>
             <div class="edit-value content">
               {if $n|substr:0:3 eq 'im-'}
-                {assign var="provider" value=$n|cat:"-provider_id"}
+                {assign var="provider" value="$n-provider_id"}
                 {$form.$provider.html}&nbsp;
               {/if}
               {if $n eq 'email_greeting' or  $n eq 'postal_greeting' or $n eq 'addressee'}

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 <div class="crm-profile-name-{$ufGroupName}">
-{crmRegion name=profile-form-`$ufGroupName`}
+{crmRegion name="profile-form-`$ufGroupName`"}
 
 {* Profile forms when embedded in CMS account create (mode=1) or
     cms account edit (mode=8) or civicrm/profile (mode=4) pages *}

--- a/templates/CRM/Profile/Page/Dynamic.tpl
+++ b/templates/CRM/Profile/Page/Dynamic.tpl
@@ -14,7 +14,7 @@
     {else}
         <div id="crm-container" class="crm-container" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
             <div class="crm-profile-name-{$ufGroupName}">
-            {crmRegion name=profile-view-`$ufGroupName`}
+            {crmRegion name="profile-view-`$ufGroupName`"}
             {foreach from=$profileFields item=field key=rowName}
               <div id="row-{$rowName}" class="crm-section {$rowName}-section">
                 <div class="label">

--- a/templates/CRM/Profile/Page/Listings.tpl
+++ b/templates/CRM/Profile/Page/Listings.tpl
@@ -9,7 +9,7 @@
 *}
 
 <div class="crm-profile-name-{$ufGroupName}">
-{crmRegion name=profile-search-`$ufGroupName`}
+{crmRegion name="profile-search-`$ufGroupName`"}
 
 {* make sure there are some fields in the selector *}
 {if ! empty($columnHeaders) || $isReset}

--- a/templates/CRM/Profile/Page/Overlay.tpl
+++ b/templates/CRM/Profile/Page/Overlay.tpl
@@ -14,7 +14,7 @@
   </tr>
   <tr>
     <td>
-      {assign var="count" value="0"}
+      {assign var="count" value=0}
       {assign var="totalRows" value=$row|@count}
       <div class="crm-summary-col-0">
     {foreach from=$profileFields item=field key=rowName}
@@ -23,7 +23,7 @@
     </td>
     <td>
       <div class="crm-summary-col-1">
-        {assign var="count" value="1"}
+        {assign var="count" value=1}
         {/if}
       <div class="crm-section {$rowName}-section">
         <div class="label">
@@ -34,7 +34,7 @@
         </div>
         <div class="clear"></div>
       </div>
-      {assign var="count" value=`$count+1`}
+      {assign var="count" value=$count+1}
     {/foreach}
       </div>
     </td>

--- a/templates/CRM/Report/Form/Campaign/SurveyCoverSheet.tpl
+++ b/templates/CRM/Report/Form/Campaign/SurveyCoverSheet.tpl
@@ -66,7 +66,7 @@
    {* clean separation of each response question *}
    <tr><td><br /></td></tr>
 
-     {assign var=resFldCnt value=`$resFldCnt+1`}
+     {assign var=resFldCnt value=$resFldCnt+1}
      {/foreach}
 
 </table>

--- a/templates/CRM/Report/Form/Contact/Detail.tpl
+++ b/templates/CRM/Report/Form/Contact/Detail.tpl
@@ -63,14 +63,14 @@
                                         {if $header.colspan}
                                             <th colspan={$header.colspan}>{$header.title}</th>
                                             {assign var=skip value=true}
-                                            {assign var=skipCount value=`$header.colspan`}
+                                            {assign var=skipCount value=$header.colspan}
                                             {assign var=skipMade  value=1}
                                         {else}
                                             <th>{$header.title}</th>
                                             {assign var=skip value=false}
                                         {/if}
                                     {else} {* for skip case *}
-                                        {assign var=skipMade value=`$skipMade+1`}
+                                        {assign var=skipMade value=$skipMade+1}
                                         {if $skipMade >= $skipCount}{assign var=skip value=false}{/if}
                                     {/if}
                                 {/foreach}

--- a/templates/CRM/Report/Form/Layout/Overlay.tpl
+++ b/templates/CRM/Report/Form/Layout/Overlay.tpl
@@ -22,14 +22,14 @@
                    {if $header.colspan}
                       <td colspan={$header.colspan}>{$header.title}</td>
                       {assign var=skip value=true}
-                      {assign var=skipCount value=`$header.colspan`}
+                      {assign var=skipCount value=$header.colspan}
                       {assign var=skipMade  value=1}
                    {else}
                       <td>{$header.title}</td>
                        {assign var=skip value=false}
                    {/if}
                 {else} {* for skip case *}
-                   {assign var=skipMade value=`$skipMade+1`}
+                   {assign var=skipMade value=$skipMade+1}
                    {if $skipMade >= $skipCount}{assign var=skip value=false}{/if}
                 {/if}
             {/foreach}

--- a/templates/CRM/Report/Form/Layout/Table.tpl
+++ b/templates/CRM/Report/Form/Layout/Table.tpl
@@ -28,14 +28,14 @@
                    {if $header.colspan}
                        <th colspan={$header.colspan}>{$header.title|escape}</th>
                       {assign var=skip value=true}
-                      {assign var=skipCount value=`$header.colspan`}
+                      {assign var=skipCount value=$header.colspan}
                       {assign var=skipMade  value=1}
                    {else}
                        <th {$class}>{$header.title|escape}</th>
                    {assign var=skip value=false}
                    {/if}
                 {else} {* for skip case *}
-                   {assign var=skipMade value=`$skipMade+1`}
+                   {assign var=skipMade value=$skipMade+1}
                    {if $skipMade >= $skipCount}{assign var=skip value=false}{/if}
                 {/if}
             {/foreach}

--- a/templates/CRM/Report/Form/Tabs/FieldSelection.tpl
+++ b/templates/CRM/Report/Form/Tabs/FieldSelection.tpl
@@ -10,7 +10,7 @@
 
   <div id="report-tab-col-groups" class="civireport-criteria">
     {foreach from=$colGroups item=grpFields key=dnc}
-      {assign  var="count" value="0"}
+      {assign  var="count" value=0}
       {* Wrap custom field sets in collapsed accordion pane. *}
       {if !empty($grpFields.use_accordian_for_field_selection)}
         <div class="crm-accordion-wrapper crm-accordion collapsed">
@@ -22,7 +22,7 @@
       <table class="criteria-group">
         <tr class="crm-report crm-report-criteria-field crm-report-criteria-field-{$dnc}">
           {foreach from=$grpFields.fields item=title key=field}
-          {assign var="count" value=`$count+1`}
+          {assign var="count" value=$count+1}
           <td width="25%">{$form.fields.$field.html}</td>
           {if $count is div by 4}
         </tr><tr class="crm-report crm-report-criteria-field crm-report-criteria-field_{$dnc}">

--- a/templates/CRM/Report/Form/Tabs/GroupBy.tpl
+++ b/templates/CRM/Report/Form/Tabs/GroupBy.tpl
@@ -8,11 +8,11 @@
  +--------------------------------------------------------------------+
 *}
   <div id="report-tab-group-by-elements" class="civireport-criteria">
-    {assign  var="count" value="0"}
+    {assign  var="count" value=0}
     <table class="report-layout">
       <tr class="crm-report crm-report-criteria-groupby">
         {foreach from=$groupByElements item=gbElem key=dnc}
-        {assign var="count" value=`$count+1`}
+        {assign var="count" value=$count+1}
         <td width="25%">
           {$form.group_bys[$gbElem].html}
           {if $form.group_bys_freq && array_key_exists($gbElem, $form.group_bys_freq)}:<br>

--- a/templates/CRM/Report/Form/Tabs/ReportOptions.tpl
+++ b/templates/CRM/Report/Form/Tabs/ReportOptions.tpl
@@ -14,7 +14,7 @@
       <tr class="crm-report crm-report-criteria-field">
         {foreach from=$otherOptions item=optionField key=optionName}
         {if array_key_exists($optionName, $form)}
-          {assign var="optionCount" value=`$optionCount+1`}
+          {assign var="optionCount" value=$optionCount+1}
           <td>{if $form.$optionName.label}{$form.$optionName.label}&nbsp;{/if}{$form.$optionName.html}</td>
           {if $optionCount is div by 2}
         </tr><tr class="crm-report crm-report-criteria-field">

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -52,7 +52,7 @@
         <div class="label option-label">{$formElement.label}</div>
         <div class="content 3">
 
-          {assign var="count" value="1"}
+          {assign var="count" value=1}
           {strip}
             <table class="form-layout-compressed">
               <tr>
@@ -64,9 +64,9 @@
                 {if $count == $field.options_per_line}
               </tr>
               <tr>
-                {assign var="count" value="1"}
+                {assign var="count" value=1}
                 {else}
-                {assign var="count" value=`$count+1`}
+                {assign var="count" value=$count+1}
                 {/if}
                 {/if}
                 {/foreach}

--- a/templates/CRM/common/checkUsernameAvailable.tpl
+++ b/templates/CRM/common/checkUsernameAvailable.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {* This included tpl checks if a given username is taken or available. *}
-{crmSigner var=checkUserSig for=civicrm/ajax/cmsuser}
+{crmSigner var=checkUserSig for="civicrm/ajax/cmsuser"}
 {literal}
 var lastName = null;
 cj("#checkavailability").click(function() {

--- a/templates/CRM/common/jcalendar.tpl
+++ b/templates/CRM/common/jcalendar.tpl
@@ -18,9 +18,9 @@
     {$form.$elementName.$elementIndex.html}
 {elseif $blockId and $blockSection}
     {assign var='elementId'   value=$form.$blockSection.$blockId.$elementName.id}
-    {assign var="tElement" value=`$elementName`_time}
+    {assign var="tElement" value="`$elementName`_time"}
     {$form.$blockSection.$blockId.$elementName.html}
-    {assign var="timeElement" value=`$blockSection`_`$blockId`_`$elementName`_time}
+    {assign var="timeElement" value="`$blockSection`_`$blockId`_`$elementName`_time"}
     {if $tElement}
       &nbsp;&nbsp;{$form.$blockSection.$blockId.$tElement.label}
       &nbsp;&nbsp;{$form.$blockSection.$blockId.$tElement.html|crmAddClass:six}

--- a/templates/CRM/common/searchResultTasks.tpl
+++ b/templates/CRM/common/searchResultTasks.tpl
@@ -14,7 +14,7 @@
   <tr>
     <td style="width: 40%;">
     {if !empty($savedSearch.name)}{$savedSearch.name} ({ts}smart group{/ts}) - {/if}
-    {ts count=$pager->_totalItems plural='%count Results'}%count Result{/ts}{if $selectorLabel}&nbsp;-&nbsp;{$selectorLabel}{/if}
+    {ts count=$pager->_totalItems plural="%count Results"}%count Result{/ts}{if $selectorLabel}&nbsp;-&nbsp;{$selectorLabel}{/if}
     {if $context == 'Event' && $participantCount && ($pager->_totalItems ne $participantCount)}
         <br />{ts}Actual participant count{/ts} : {$participantCount} {help id="id-actual_participant_count" file="CRM/Event/Form/Search/Results.hlp"} &nbsp;
     {/if}
@@ -36,7 +36,7 @@
   <tr>
     <td>{ts}Select Records{/ts}:</td>
     <td class="nowrap">
-      {$form.radio_ts.ts_all.html} <label for="{$ts_all_id}">{ts count=$pager->_totalItems plural='All %count records'}The found record{/ts}</label> &nbsp; {if $pager->_totalItems > 1} {$form.radio_ts.ts_sel.html} <label for="{$ts_sel_id}">{ts 1="<span></span>"}%1 Selected records only{/ts}</label>{/if}
+      {$form.radio_ts.ts_all.html} <label for="{$ts_all_id}">{ts count=$pager->_totalItems plural="All %count records"}The found record{/ts}</label> &nbsp; {if $pager->_totalItems > 1} {$form.radio_ts.ts_sel.html} <label for="{$ts_sel_id}">{ts 1="<span></span>"}%1 Selected records only{/ts}</label>{/if}
     </td>
   </tr>
   <tr>

--- a/xml/templates/message_templates/pledge_acknowledge_html.tpl
+++ b/xml/templates/message_templates/pledge_acknowledge_html.tpl
@@ -64,7 +64,7 @@
      </tr>
 
      {if $payments}
-      {assign var="count" value="1"}
+      {assign var="count" value=1}
       {foreach from=$payments item=payment}
        <tr>
         <td {$labelStyle}>
@@ -74,7 +74,7 @@
          {$payment.amount|crmMoney:$currency} {if $payment.status eq 1}{ts}paid{/ts} {$payment.receive_date|truncate:10:''|crmDate}{else}{ts}due{/ts} {$payment.due_date|truncate:10:''|crmDate}{/if}
         </td>
        </tr>
-       {assign var="count" value=`$count+1`}
+       {assign var="count" value=$count+1}
       {/foreach}
      {/if}
 

--- a/xml/templates/message_templates/pledge_acknowledge_text.tpl
+++ b/xml/templates/message_templates/pledge_acknowledge_text.tpl
@@ -21,11 +21,11 @@
 {/if}
 
 {if $payments}
-{assign var="count" value="1"}
+{assign var="count" value=1}
 {foreach from=$payments item=payment}
 
 {ts 1=$count}Payment %1{/ts}: {$payment.amount|crmMoney:$currency} {if $payment.status eq 1}{ts}paid{/ts} {$payment.receive_date|truncate:10:''|crmDate}{else}{ts}due{/ts} {$payment.due_date|truncate:10:''|crmDate}{/if}
-{assign var="count" value=`$count+1`}
+{assign var="count" value=$count+1}
 {/foreach}
 {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
1) Remove one `{php}`
2) Quote strings when assigning that contain characters other than `a-zA-Z0-9_` (and a couple with underscores for good measure)
3) Remove some extra spaces when assigning
4) Remove backticks that were making Smarty 3 unhappy where math was being done with ints (backticks are find with strings, can't have them with ints). Many of these are just repetition of our good friend options_per_line.
5) Some other Smarty clean up (switching single quotes to double, simplifying concatenation
6) Fix broken Administer Custom Field Groups in AdminUI (can't have a space at the start in Smarty 3)

Comments
----------------------------------------
These were all the unquoted strings I could find by greping, but it's possible that there's something weird that I missed.