### PR TITLE
Fix assigning of customGroup data to be more re-usable & use undefined properties less

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -615,6 +615,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         ->addSelect('custom_group_id.extends_entity_column_value')
         ->addSelect('custom_group_id.is_active')
         ->addSelect('custom_group_id.name')
+        ->addSelect('custom_group_id.title')
         ->addSelect('custom_group_id.table_name')
         ->addSelect('custom_group_id.is_public');
       if ($permissionType && !CRM_Core_Permission::customGroupAdmin()) {
@@ -806,6 +807,67 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     $entity = in_array($field['custom_group_id.extends'], CRM_Contact_BAO_ContactType::basicTypes(TRUE), TRUE) ? 'Contact' : $field['custom_group_id.extends'];
     $field['options'] = self::getFieldOptions($field['id'], $field['option_group_id'], $field['data_type'], $entity);
     return $field;
+  }
+
+  /**
+   * Gets an array of custom fields that are public.
+   *
+   * @internal do not use from untested or external code - signature may change.
+   *
+   * This takes into account
+   *  - the is_public setting on the Custom Group
+   *  - the is_view permission on the field (these are generally suppressed).
+   *
+   * @param string $extends
+   * @param array $extendsEntity
+   *   Keyed by name values from CRM_Core_BAO_CustomGroup::getExtendsEntityColumnIdOptions()
+   *   Values can be an int or an array.
+   *   eg ['ParticipantRole' = [1], 'ParticipantEventType' => 2], ['ParticipantEventName' => 3]
+   * @param int $permissionType
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  public static function getViewableCustomFields(string $extends, array $extendsEntity = [], $permissionType = CRM_Core_Permission::VIEW): array {
+    $entityFilters = [];
+    // Convert from ['ParticipantRole' = [1], 'ParticipantEventType' => 2], ['ParticipantEventName' => 3]
+    // to [1 => [1], 2 => [2], 3 = [3]
+    if (!empty($extendsEntity)) {
+      $entityColumns = CRM_Core_BAO_CustomGroup::getExtendsEntityColumnIdOptions();
+      foreach ($entityColumns as $entityColumn) {
+        if (isset($extendsEntity[$entityColumn['name']])) {
+          $entityFilters[(int) $entityColumn['id']] = (array) $extendsEntity[$entityColumn['name']];
+          foreach ($entityFilters[$entityColumn['id']] as &$value) {
+            // Cast to string because we don't want the calling function to have to worry
+            // but also the array intersect fails otherwise.
+            $value = (string) $value;
+          }
+        }
+      }
+    }
+    $cacheKey = $extends . $permissionType . CRM_Core_Config::domainID() . '_' . CRM_Core_I18n::getLocale() . substr(md5(json_encode($extendsEntity)), 0, 30);
+    if (!isset(\Civi::$statics[__CLASS__][__FUNCTION__][$cacheKey])) {
+      \Civi::$statics[__CLASS__][__FUNCTION__][$cacheKey] = [];
+      $allFields = CRM_Core_BAO_CustomField::getAllCustomFields($permissionType);
+      foreach ($allFields as $field) {
+        $entityValueMatches = array_intersect((array) $field['custom_group_id.extends_entity_column_value'], ($entityFilters[$field['custom_group_id.extends_entity_column_id']] ?? []));
+        if (
+          !$field['is_view']
+          && $field['custom_group_id.is_public']
+          && (
+            !empty($entityValueMatches)
+            || empty($field['custom_group_id.extends_entity_column_id'])
+          )
+          && (
+            $field['custom_group_id.extends'] === $extends
+            || ($field['extends'] === 'Contact' && in_array($extends, ['Individual', 'Organization', 'Household']))
+          )
+        ) {
+          \Civi::$statics[__CLASS__][__FUNCTION__][$cacheKey][(int) $field['id']] = $field;
+        }
+      }
+    }
+    return \Civi::$statics[__CLASS__][__FUNCTION__][$cacheKey];
   }
 
   /**

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -21,6 +21,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
   use FormTrait;
   use CRMTraits_Financial_OrderTrait;
   use CRMTraits_Financial_PriceSetTrait;
+  use CRMTraits_Custom_CustomDataTrait;
 
   public function tearDown(): void {
     $this->quickCleanUpFinancialEntities();
@@ -55,6 +56,19 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
       ],
     ])->postProcess()->getFirstMailBody();
     $this->assertStringContainsString('Volunteer, Speaker', $email);
+  }
+
+  public function testSubmitWithCustomData(): void {
+    $this->createCustomGroupWithFieldOfType(['extends' => 'Participant', 'extends_entity_column_id' => 1, 'extends_entity_column_value' => CRM_Core_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'role_id', 'Volunteer')]);
+    $email = $this->getForm([], [
+      'status_id' => 1,
+      'register_date' => date('Ymd'),
+      'send_receipt' => 1,
+      'from_email_address' => 'admin@email.com',
+      'role_id' => [CRM_Core_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'role_id', 'Volunteer')],
+      $this->getCustomFieldName() => 'Random thing',
+    ])->postProcess()->getFirstMailBody();
+    $this->assertStringContainsStrings($email, ['Enter text here', 'Random thing', 'Group with field text']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix assigning of customGroup data to be more re-usable & use undefined properties less

Before
----------------------------------------
This chunk of code is repeated many places

https://github.com/civicrm/civicrm-core/compare/master...eileenmcnaughton:custom_field_trait?expand=1#diff-a1c8943f991b49e1c885133fad3edc222523542e1ce97b89d7fbba222197000fL2136-L2158

After
----------------------------------------
The guts of it is not in a consolidated function `CRM_Core_BAO_CustomField::getViewableCustomFields` which I will use from other places/ move out of the form onto the workflow message

Technical Details
----------------------------------------

Comments
----------------------------------------