### PR TITLE
dev/core#4616 - Fix js syntax error on contribution page / nonfunctioning honoree toggle

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -323,7 +323,7 @@
     function toggleRecur() {
       var isRecur = cj('input[id="is_recur"]:checked');
       var allowAutoRenew = {/literal}'{$allowAutoRenewMembership}'{literal};
-      var quickConfig = {/literal}{$quickConfig}{literal};
+      var quickConfig = {/literal}'{$quickConfig}'{literal};
       if (allowAutoRenew && cj("#auto_renew") && quickConfig) {
         showHideAutoRenew(null);
       }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4616

Before
----------------------------------------
`var quickConfig = ;` when using a contribution page with a priceset.

After
----------------------------------------
better

Technical Details
----------------------------------------
See lab ticket. There was some discussion about whether this variable is even needed. There's some evidence it is, so have just done the same thing as the line above.

Comments
----------------------------------------
Affects master only.
