### PR TITLE
Remove {php} in hlp test

### DIFF
--- a/tests/phpunit/CiviTest/test.hlp
+++ b/tests/phpunit/CiviTest/test.hlp
@@ -1,1 +1,1 @@
-{php}echo date("Y-m-d") . ' boo!'{/php}
+Boo!


### PR DESCRIPTION
Overview
----------------------------------------
{php} can't be used in Smarty 3, so this needs to go.
@seamuslee001 @artfulrobot this was [added here](https://github.com/civicrm/civicrm-core/commit/d80e8fa62cad6661a0882753a8babf5512f9bb12). I'm not sure exactly what we're testing here, but I'm guessing we just need this file to exist. Is that right or is there some reason we have {php} here?