### PR TITLE
[event][templates] Stop assigning `isPrimary` for WorkFlow Messages at form layer

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -2096,11 +2096,6 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
     $notSent = [];
     $this->assign('module', 'Event Registration');
     $this->assignEventDetailsToTpl($params['event_id'], CRM_Utils_Array::value('role_id', $params), CRM_Utils_Array::value('receipt_text', $params));
-    // @todo - this is no longer in core templates as of 5.63
-    // we should remove once we have done a 'push upgrade' on addresses - ie advised
-    // people to upgrade their templates in an upgrade message, as
-    // opposed to just updating unmodified templates.
-    $this->assign('isPrimary', (int) $this->_isPaidEvent);
     if ($this->_isPaidEvent) {
       $paymentInstrument = CRM_Contribute_PseudoConstant::paymentInstrument();
       if (!$this->_mode) {

--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -365,11 +365,7 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
       $this->assign('totalAmount', $this->contributionAmt);
       $this->assign('checkNumber', CRM_Utils_Array::value('check_number', $params));
     }
-    // @todo isPrimary no longer used from 5.63 in core templates, remove
-    // once users have been 'pushed' to update their templates (via
-    // upgrade message - which we don't always do whenever we change
-    // a minor variable.
-    $this->assign('isPrimary', $this->_isPaidEvent);
+
     $this->assign('register_date', $params['register_date']);
 
     // Retrieve the name and email of the contact - this will be the TO for receipt email

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1636,9 +1636,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
     foreach ($additionalIDs as $participantID => $contactId) {
       if ($participantID == $registerByID) {
-        //set as Primary Participant
-        $this->assign('isPrimary', 1);
-
         $customProfile = CRM_Event_BAO_Event::buildCustomProfile($participantID, $this->_values, NULL, $isTest);
 
         if (count($customProfile)) {
@@ -1647,7 +1644,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
         }
       }
       else {
-        $this->assign('isPrimary', 0);
         $this->assign('customProfile', NULL);
       }
 

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -866,8 +866,6 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       foreach ($additionalIDs as $participantID => $contactId) {
         $participantNum = 0;
         if ($participantID == $registerByID) {
-          //set as Primary Participant
-          $this->assign('isPrimary', 1);
           //build an array of custom profile and assigning it to template.
           $customProfile = CRM_Event_BAO_Event::buildCustomProfile($participantID, $this->_values, NULL, $isTest);
 
@@ -887,8 +885,6 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
           $participantParams = ['id' => $participantID];
           CRM_Event_BAO_Participant::getValues($participantParams, $participantValues, $ids);
           $this->_values['participant'] = $participantValues[$participantID];
-
-          $this->assign('isPrimary', 0);
           $this->assign('customProfile', NULL);
           //Additional Participant should get only it's payment information
           if (!empty($this->_amount)) {


### PR DESCRIPTION

Overview
----------------------------------------
Stop assigning `isPrimary` for WorkFlow Messages at form layer

Before
----------------------------------------
`isPrimary` is assigned at the form layer for work flow templates. However, these are overwritten by `Event_WorkflowMessage_ParticipantTrait`
- which looks up the value from the record 
so have no effect

After
----------------------------------------
The assigns are removed


Note that there is some test cover of emails for mulitple participants

Technical Details
----------------------------------------
Despite the comments we are actually leaning into isPrimary in the templates.

Note the tpl files do not use isPrimary
![image](https://github.com/civicrm/civicrm-core/assets/336308/5ca7821a-ed4a-4b25-a36b-985f019c8a2d)


Comments
----------------------------------------
