### PR TITLE
dev/core#4567 Update code creating queue entries to save mailing_id

### DIFF
--- a/CRM/Utils/SQL/Insert.php
+++ b/CRM/Utils/SQL/Insert.php
@@ -145,7 +145,12 @@ class CRM_Utils_SQL_Insert {
 
     $escapedRow = [];
     foreach ($this->columns as $column) {
-      $escapedRow[$column] = $this->escapeString($row[$column]);
+      if (is_bool($row[$column])) {
+        $escapedRow[$column] = (int) $row[$column];
+      }
+      else {
+        $escapedRow[$column] = $this->escapeString($row[$column]);
+      }
     }
     $this->rows[] = $escapedRow;
 
@@ -184,6 +189,21 @@ class CRM_Utils_SQL_Insert {
     $sql .= "\n";
 
     return $sql;
+  }
+
+  /**
+   * Execute the query.
+   *
+   * @param bool $i18nRewrite
+   *   If the system has multilingual features, should the field/table
+   *   names be rewritten?
+   * @return CRM_Core_DAO
+   * @see CRM_Core_DAO::executeQuery
+   * @see CRM_Core_I18n_Schema::rewriteQuery
+   */
+  public function execute($i18nRewrite = TRUE) {
+    return CRM_Core_DAO::executeQuery($this->toSQL(), [], TRUE, NULL,
+      FALSE, $i18nRewrite);
   }
 
 }

--- a/ext/flexmailer/src/Listener/BasicHeaders.php
+++ b/ext/flexmailer/src/Listener/BasicHeaders.php
@@ -39,7 +39,7 @@ class BasicHeaders extends BaseListener {
 
       $mailParams = array();
       $mailParams['List-Unsubscribe'] = "<mailto:{$verp['unsubscribe']}>";
-      \CRM_Mailing_BAO_Mailing::addMessageIdHeader($mailParams, 'm', $e->getJob()->id, $task->getEventQueueId(), $task->getHash());
+      \CRM_Mailing_BAO_Mailing::addMessageIdHeader($mailParams, 'm', NULL, $task->getEventQueueId(), $task->getHash());
       $mailParams['Precedence'] = 'bulk';
       $mailParams['job_id'] = $e->getJob()->id;
 

--- a/tests/phpunit/api/v3/JobProcessMailingTest.php
+++ b/tests/phpunit/api/v3/JobProcessMailingTest.php
@@ -100,8 +100,6 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
 
   /**
    * Test that a contact deleted after the mailing is queued is not emailed.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testDeletedRecipient(): void {
     $this->createContactsInGroup(2, $this->_groupID);
@@ -260,7 +258,7 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
     $this->_mut->assertRecipients($this->getRecipients(1, 2));
   }
 
-  public function concurrencyExamples() {
+  public function concurrencyExamples(): array {
     $es = [];
 
     // Launch 3 workers, but mailerJobsMax limits us to 1 worker.
@@ -489,7 +487,7 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function testBatchActivityTargets($isBulk) {
+  public function testBatchActivityTargets($isBulk): void {
     $loggedInUserId = $this->createLoggedInUser();
 
     \Civi::settings()->set('mailerBatchLimit', 2);


### PR DESCRIPTION

Overview
----------------------------------------
Update code creating queue entries to save mailing_id

https://lab.civicrm.org/dev/core/-/issues/4567

Before
----------------------------------------
`civicrm_mailing_event_queue` table now has columns for `mailing_id` & `is_test` - but they are not, as yet, being saved

After
----------------------------------------
the new column values are saved

The old `bulkCreate` function is abandoned in favour of `writeRecords`

Technical Details
----------------------------------------
This covers all the places I found except the forward action I will tackle that separately - how does that even get called?

Comments
----------------------------------------
