### PR TITLE
Php8.x fix calls to CRM_Contribute_BAO_Contribution::createAddress

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1649,22 +1649,23 @@ LEFT JOIN civicrm_option_value contribution_status ON (civicrm_contribution.cont
   /**
    * Create address associated with contribution record.
    *
-   * As long as there is one or more billing field in the parameters we will create the address.
+   * As long as there is one or more billing field in the parameters we will
+   * create the address.
    *
-   * (historically the decision to create or not was based on the payment 'type' but these lines are greyer than once
-   * thought).
+   * (historically the decision to create or not was based on the payment
+   * 'type' but these lines are greyer than once thought).
    *
    * @param array $params
-   * @param int $billingLocationTypeID
    *
-   * @return int
+   * @return int|null
    *   address id
+   * @throws \CRM_Core_Exception
    */
-  public static function createAddress($params, $billingLocationTypeID) {
+  public static function createAddress(array $params): ?int {
+    $billingLocationTypeID = CRM_Core_BAO_LocationType::getBilling();
     [$hasBillingField, $addressParams] = self::getBillingAddressParams($params, $billingLocationTypeID);
     if ($hasBillingField) {
-      $address = CRM_Core_BAO_Address::writeRecord($addressParams);
-      return $address->id;
+      return CRM_Core_BAO_Address::writeRecord($addressParams)->id;
     }
     return NULL;
 

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1332,7 +1332,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     // add these values for the recurringContrib function ,CRM-10188
     $params['financial_type_id'] = $financialType->id;
 
-    $contributionParams['address_id'] = CRM_Contribute_BAO_Contribution::createAddress($params, $billingLocationID);
+    $contributionParams['address_id'] = CRM_Contribute_BAO_Contribution::createAddress($params);
 
     //@todo - this is being set from the form to resolve CRM-10188 - an
     // eNotice caused by it not being set @ the front end

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1047,7 +1047,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     // add these values for the recurringContrib function ,CRM-10188
     $params['financial_type_id'] = $financialType->id;
 
-    $contributionParams['address_id'] = CRM_Contribute_BAO_Contribution::createAddress($params, $billingLocationID);
+    $contributionParams['address_id'] = CRM_Contribute_BAO_Contribution::createAddress($params);
 
     //@todo - this is being set from the form to resolve CRM-10188 - an
     // eNotice caused by it not being set @ the front end

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1782,13 +1782,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       );
     }
     $contribParams['revenue_recognition_date'] = $this->getRevenueRecognitionDate();
-
-    //create an contribution address
-    // The concept of contributeMode is deprecated. Elsewhere we use the function processBillingAddress() - although
-    // currently that is only inherited by back-office forms.
-    if ($form->_contributeMode != 'notify' && empty($params['is_pay_later'])) {
-      $contribParams['address_id'] = CRM_Contribute_BAO_Contribution::createAddress($params, $form->_bltID);
-    }
+    $contribParams['address_id'] = CRM_Contribute_BAO_Contribution::createAddress($params);
 
     $contribParams['skipLineItem'] = 1;
     $contribParams['skipCleanMoney'] = 1;

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -461,8 +461,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
     $this->assign('address', CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($params, $this->_bltID));
 
-    // The concept of contributeMode is deprecated.
-    if ($this->_contributeMode === 'direct' && empty($params['is_pay_later'])) {
+    if ($this->getSubmittedValue('credit_card_number')) {
       if (isset($params['credit_card_exp_date'])) {
         $date = CRM_Utils_Date::format($params['credit_card_exp_date']);
         $date = CRM_Utils_Date::mysqlToIso($date);

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -1012,11 +1012,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       }
     }
     //create an contribution address
-    // The concept of contributeMode is deprecated. Elsewhere we use the function processBillingAddress() - although
-    // currently that is only inherited by back-office forms.
-    if ($form->_contributeMode != 'notify' && empty($params['is_pay_later'])) {
-      $contribParams['address_id'] = CRM_Contribute_BAO_Contribution::createAddress($params, $form->_bltID);
-    }
+    $contribParams['address_id'] = CRM_Contribute_BAO_Contribution::createAddress($params);
 
     $contribParams['skipLineItem'] = 1;
     $contribParams['skipCleanMoney'] = 1;


### PR DESCRIPTION

Overview
----------------------------------------
Php8.x fix calls to CRM_Contribute_BAO_Contribution::createAddress

This addresses 2 issues
1) passing the sometimes-undefined-property bltId
In practice we always just pass the value derived from the LocationType::getBilling() anything else was a never implemented good intention 2) checking the deprecated contributeMode. the createAddress function does a check for the presence of billing fields - if the form collected them we should show them, otherwise not.
- we don't need to check contributeMode

Before
----------------------------------------
More undefined property access, 

After
----------------------------------------
less

Technical Details
----------------------------------------
I also removed one more reference to contributeMode

Comments
----------------------------------------
