### PR TITLE
dev/core#4619 Remove removable instances of contribute Mode

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1594,15 +1594,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           $pending = $membershipContribution->contribution_status_id == CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');
         }
         else {
-          // The concept of contributeMode is deprecated.
-          // the is_monetary concept probably should be too as it can be calculated from
-          // the existence of 'amount' & seems fragile.
-          if (((isset($this->_contributeMode)) || !empty($this->_params['is_pay_later'])
-            ) &&
-            (($this->_values['is_monetary'] && $this->_amount > 0.0))
-          ) {
-            $pending = TRUE;
-          }
           $pending = FALSE;
         }
 

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1161,8 +1161,6 @@ WHERE civicrm_event.is_active = 1
           'email' => $notifyEmail,
           'confirm_email_text' => $values['event']['confirm_email_text'] ?? NULL,
           'isShowLocation' => $values['event']['is_show_location'] ?? NULL,
-          // The concept of contributeMode is deprecated.
-          'contributeMode' => $template->_tpl_vars['contributeMode'] ?? NULL,
           'customPre' => $profilePre[0],
           'customPre_grouptitle' => empty($profilePre[1]) ? NULL : [CRM_Core_BAO_UFGroup::getFrontEndTitle((int) $preProfileID)],
           'customPost' => $profilePost[0],
@@ -1203,8 +1201,6 @@ WHERE civicrm_event.is_active = 1
         $displayAddress = $values['address'] ?? NULL;
         if ($displayAddress) {
           $sendTemplateParams['tplParams']['address'] = $displayAddress;
-          // The concept of contributeMode is deprecated.
-          $sendTemplateParams['tplParams']['contributeMode'] = NULL;
         }
 
         // set lineItem details

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -1307,7 +1307,6 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     $form->_values['custom_pre_id'] = $params['custom_pre_id'] ?? NULL;
     $form->_values['custom_post_id'] = $params['custom_post_id'] ?? NULL;
     $form->_values['event'] = $params['event'] ?? NULL;
-    $form->_contributeMode = $params['contributeMode'];
     $eventParams = ['id' => $params['id']];
     CRM_Event_BAO_Event::retrieve($eventParams, $form->_values['event']);
     $form->set('registerByID', $params['registerByID']);

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -463,7 +463,6 @@ class CRM_Financial_BAO_Payment {
     // and assign. Note we should update the tpl to use {if $billingName}
     // and ditch contributeMode - although it might need to be deprecated rather than removed.
     $todoParams = [
-      'contributeMode',
       'billingName',
       'address',
       'credit_card_type',

--- a/templates/CRM/Event/Form/Registration/ThankYou.tpl
+++ b/templates/CRM/Event/Form/Registration/ThankYou.tpl
@@ -115,7 +115,7 @@
                   <div class="clear"></div>
                 </div>
             {/if}
-            {if $contributeMode ne 'notify' AND $trxn_id}
+            {if $trxn_id}
                 <div class="crm-section no-label trxn_id-section">
                     <div class="content bold">{ts}Transaction #{/ts}: {$trxn_id}</div>
                 <div class="clear"></div>


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4619 Remove removable instances of contribute Mode

I did an audit of remaining usage. Ones that need some thought are here https://lab.civicrm.org/dev/core/-/issues/4619 

Ones that can be removed are in this PR or https://github.com/civicrm/civicrm-core/pull/27561

Before
----------------------------------------
places where `_contributeMode` unnecessarily used

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
