### PR TITLE
Allow `civicrm_campaign` as `entity_table` for `FinancialItem` API entity

### DIFF
--- a/CRM/Financial/BAO/FinancialItem.php
+++ b/CRM/Financial/BAO/FinancialItem.php
@@ -281,6 +281,7 @@ WHERE cc.id IN (' . implode(',', $contactIds) . ') AND con.is_test = 0';
     return [
       'civicrm_line_item' => ts('Line Item'),
       'civicrm_financial_trxn' => ts('Financial Trxn'),
+      'civicrm_campaign' => ts('Campaign'),
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://github.com/civicrm/civicrm-core/commit/6844be6437e325c4fa211f2a211ab6b765f2f26e in #20464 explicitly restricted allowed values for the `entity_table` parameter of the `FinancialItem` API entity. The [*Campaign Manager*](https://github.com/systopia/de.systopia.campaign) extension made use of those entities linking them to campaigns as expenses. This does not work anymore, i.e. no expenses are found for campaigns, see systopia/de.systopia.campaign#98.

Before
----------------------------------------
`FinancialItem`s cannot be linked to campaigns anymore.

After
----------------------------------------
`FinancialItems` can again be linked to campaigns, *Campaign Manager* is working correctly again.

Technical Details
----------------------------------------
Before, any entity seems to have been allowed, as there was no `pseudoconstant` callback defined.

Comments
----------------------------------------
I'm not sure whether linking `FinancialItem`s to `Campaign`s makes sense in the first place, or if the entity type is supposed to be used for that. Maybe there should be a specific BAO entity like `CampaignExpense` instead for not relying on Core entities that were designed for a different purpose? The *Campaign Manager* code is actually quite old and API entities do not match BAO entities. Thoughts on that will be much appreciated.

But, if there's no harm in adding `civicrm_campaign` as allowed value for the `entity_table` parameter on the `FinancialItem` entity, that'd be a quick fix.