### PR TITLE
[NFC] Partial backport of 0c1d533c to avoid random test fails

### DIFF
--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -339,8 +339,8 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     $amountsPaid = [300, 100, 200];
     // The first participant, as the primary participant, (only) will have the full total in the email
     $this->assertStringContainsString('$600', $mailSent[0]['body']);
-    $this->assertStringNotContainsString(600, $mailSent[1]['body']);
-    $this->assertStringNotContainsString(600, $mailSent[2]['body']);
+    $this->assertStringNotContainsString('$600', $mailSent[1]['body']);
+    $this->assertStringNotContainsString('$600', $mailSent[2]['body']);
 
     // The $100 paid by the second participant will be in the emails to the primary but and second participant
     $this->assertStringContainsString('$100', $mailSent[0]['body']);


### PR DESCRIPTION
Overview
----------------------------------------
Random test fails because the url port is e.g. 5600 so the links in the email body cause the assertNotContains to fail.

This was fixed in master from [#0c1d533c](https://github.com/civicrm/civicrm-core/commit/0c1d533c77e520cc45fd08f06f3a2f6ce13204c7), so backporting that part of it since still seeing it on 5.66 PRs.