### PR TITLE
dev/core#4270 createDebugLogger/ConfigAndLog: use a standard date format

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -655,7 +655,9 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    */
   public static function createDebugLogger($prefix = '') {
     self::generateLogFileName($prefix);
-    return Log::singleton('file', \Civi::$statics[__CLASS__]['logger_file' . $prefix], '');
+    return Log::singleton('file', \Civi::$statics[__CLASS__]['logger_file' . $prefix], '', [
+      'timeFormat' => '%Y-%m-%d %H:%M:%S%z',
+    ]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

Discussion: https://lab.civicrm.org/dev/core/-/issues/4270

The CiviCRM "ConfigAndLog" logs use a weird custom format, which depends on the system/user's locale, so it can be, for example:

```
août 01 09:02:59  [info] $IDS Detector Details = Array
[...]
```

This format is difficult to parse.

Before
----------------------------------------

```
août 01 09:02:59  [info] $IDS Detector Details = Array
```

After
----------------------------------------

```
2023-08-01 09:02:59-0500  [info] $IDS Detector Details = Array
```

Technical Details
----------------------------------------

strftime is deprecated as of PHP 8.1, but PEAR Log seems to be using a shim for now.

Comments
----------------------------------------

I'd rather avoid the larger questions around logging. This is really just about the date format.

It might break extensions such as logviewer.

Example promtail (Grafana/Loki) config:

```
- job_name: civicrm_log
  static_configs:
  - targets:
      - localhost
    labels:
      job: civicrm_log
      host: myhost1.example.org
      __path__: /var/aegir/platforms/*/sites/*/files/civicrm/ConfigAndLog/CiviCRM.*.log
  pipeline_stages:
  - match:
      selector: '{job="civicrm_log"}'
      stages:
      - multiline:
          # Identify timestamps as first line of a multiline block. Enclose the string in single quotes.
          # Ex: 2038-01-01 23:50:12 (not matching on the TZ, less important here)
          firstline: '^\d{4}-\d{2}-\d{2}.\d{1,2}:\d{2}:\d{2}'
          max_wait_time: 3s
          # Backtraces can be insane sometimes
          max_lines: 5000
      - regex:
          # Flag (?s:.*) needs to be set for regex stage to capture full traceback log in the extracted map.
          # Ex: 2023-09-21 23:48:57-0500  [error] Error message..
          expression: '^(?P<time>\d{4}-\d{2}-\d{2}.\d{1,2}:\d{2}:\d{2}.\d{4})  \[?P<level>(\w+)\] (?P<message>(?s:.*))$'
      - timestamp:
          source: time
          format: '2006-01-02 15:04:05-0700'
```

cc @adixon @artfulrobot 