### PR TITLE
PHP8.x Stop sharing EventFee::preProcess from Registration form

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -189,7 +189,26 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
 
     // get the participant values from EventFees.php, CRM-4320
     if ($this->_allowConfirmation) {
-      CRM_Event_Form_EventFees::preProcess($this);
+      $this->eventFeeWrangling($this);
+    }
+  }
+
+  /**
+   * This is previously shared code which is probably of little value.
+   *
+   * @param CRM_Core_Form $form
+   *
+   * @throws \CRM_Core_Exception
+   */
+  private function eventFeeWrangling($form) {
+    $form->_pId = CRM_Utils_Request::retrieve('participantId', 'Positive', $form);
+    $form->_discountId = CRM_Utils_Request::retrieve('discountId', 'Positive', $form);
+
+    //CRM-6907 set event specific currency.
+    if ($this->getEventID() &&
+      ($currency = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $form->_eventId, 'currency'))
+    ) {
+      CRM_Core_Config::singleton()->defaultCurrency = $currency;
     }
   }
 


### PR DESCRIPTION


Overview
----------------------------------------
Stop sharing EventFee::preProcess from Registration form

Most of what this function does is silly. In particular it sets the undeclared & not relevant _fromEmails property.

This also adds our standardised  function to
the online event forms. All event-related forms should wind up with this public supported function (along with an approprite mix of getParticipantID, getPriceSetID, getDiscountID

Before
----------------------------------------
Mostly unnecessary or unhelpful shared code sets an undeclared & irrelevant property

After
----------------------------------------
Copy of code moved back to the form, Potentially relevant parts retained

Technical Details
----------------------------------------

Comments
----------------------------------------
