### PR TITLE
Fix undefined property on fromEmails for Participant fee

### DIFF
--- a/CRM/Event/Form/EventFees.php
+++ b/CRM/Event/Form/EventFees.php
@@ -37,9 +37,6 @@ class CRM_Event_Form_EventFees {
     $form->_pId = CRM_Utils_Request::retrieve('participantId', 'Positive', $form);
     $form->_discountId = CRM_Utils_Request::retrieve('discountId', 'Positive', $form);
 
-    // @todo - stop setting this, call the function, as appropriate. This is in a weird place.
-    $form->_fromEmails = CRM_Event_BAO_Event::getFromEmailIds($form->_eventId);
-
     //CRM-6907 set event specific currency.
     if ($form->_eventId &&
       ($currency = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $form->_eventId, 'currency'))

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -2147,6 +2147,8 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
       }
     }
     $this->assign('customGroup', $customGroup);
+
+    $fromEmails = CRM_Event_BAO_Event::getFromEmailIds($this->getEventID());
     foreach ($this->_contactIds as $num => $contactID) {
       // Retrieve the name and email of the contact - this will be the TO for receipt email
       [, $this->_contributorEmail, $this->_toDoNotEmail] = CRM_Contact_BAO_Contact::getContactDetails($contactID);
@@ -2235,8 +2237,8 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
         $sendTemplateParams['from'] = $params['from_email_address'];
         $sendTemplateParams['toName'] = $this->getContactValue('display_name');
         $sendTemplateParams['toEmail'] = $this->_contributorEmail;
-        $sendTemplateParams['cc'] = $this->_fromEmails['cc'] ?? NULL;
-        $sendTemplateParams['bcc'] = $this->_fromEmails['bcc'] ?? NULL;
+        $sendTemplateParams['cc'] = $fromEmails['cc'] ?? NULL;
+        $sendTemplateParams['bcc'] = $fromEmails['bcc'] ?? NULL;
       }
 
       //send email with pdf invoice


### PR DESCRIPTION
Overview
----------------------------------------
Fix undefined property on fromEmails for Participant fee

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/336308/d2edf9c0-d067-460b-8d43-523dad48e7e3)


After
----------------------------------------
References to property removed

With online event no longer calling EventFees::preProcess from https://github.com/civicrm/civicrm-core/pull/27577 we can see that only Participant form does. That means we no longer need to set the non-defined property `fromEmals` in the preProcess & instead can just determine the value when we need it on the form


Technical Details
----------------------------------------

Comments
----------------------------------------
