### PR TITLE
dev/core##4146 Remove unused variables from custom smarty functions

### DIFF
--- a/CRM/Core/Smarty/plugins/prefilter.htxtFilter.php
+++ b/CRM/Core/Smarty/plugins/prefilter.htxtFilter.php
@@ -6,10 +6,9 @@
  * evaluate unassigned variables.
  *
  * @param string $tpl_source
- * @param $smarty
  * @return string
  */
-function smarty_prefilter_htxtFilter($tpl_source, &$smarty) {
+function smarty_prefilter_htxtFilter($tpl_source) {
   if (strpos($tpl_source, '{htxt') === FALSE) {
     return $tpl_source;
   }

--- a/CRM/Core/Smarty/plugins/prefilter.resetExtScope.php
+++ b/CRM/Core/Smarty/plugins/prefilter.resetExtScope.php
@@ -3,11 +3,11 @@
 /**
  * Wrap every Smarty template in a {crmScope} tag that sets the
  * variable "extensionKey" to blank.
- * @param $tpl_source
- * @param $smarty
+ * @param string $tpl_source
+ *
  * @return string
  */
-function smarty_prefilter_resetExtScope($tpl_source, &$smarty) {
+function smarty_prefilter_resetExtScope($tpl_source) {
   return '{crmScope extensionKey=""}'
     . $tpl_source
     . '{/crmScope}';

--- a/CRM/Core/Smarty/resources/String.php
+++ b/CRM/Core/Smarty/resources/String.php
@@ -15,11 +15,10 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  * @param $tpl_name
  * @param $tpl_source
- * @param $smarty_obj
  *
  * @return bool
  */
-function civicrm_smarty_resource_string_get_template($tpl_name, &$tpl_source, &$smarty_obj) {
+function civicrm_smarty_resource_string_get_template($tpl_name, &$tpl_source) {
   $tpl_source = $tpl_name;
   return TRUE;
 }
@@ -27,30 +26,24 @@ function civicrm_smarty_resource_string_get_template($tpl_name, &$tpl_source, &$
 /**
  * @param string $tpl_name
  * @param $tpl_timestamp
- * @param CRM_Core_Smarty $smarty_obj
  *
  * @return bool
  */
-function civicrm_smarty_resource_string_get_timestamp($tpl_name, &$tpl_timestamp, &$smarty_obj) {
+function civicrm_smarty_resource_string_get_timestamp($tpl_name, &$tpl_timestamp) {
   $tpl_timestamp = time();
   return TRUE;
 }
 
 /**
- * @param string $tpl_name
- * @param CRM_Core_Smarty $smarty_obj
- *
  * @return bool
  */
-function civicrm_smarty_resource_string_get_secure($tpl_name, &$smarty_obj) {
+function civicrm_smarty_resource_string_get_secure() {
   return TRUE;
 }
 
 /**
- * @param string $tpl_name
- * @param CRM_Core_Smarty $smarty_obj
  */
-function civicrm_smarty_resource_string_get_trusted($tpl_name, &$smarty_obj) {
+function civicrm_smarty_resource_string_get_trusted() {
 
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused variables from custom smarty functions

In smarty 3 the `$smarty` object is not passed as they last value & these receive-by-reference variables fail

From https://github.com/civicrm/civicrm-core/pull/27565

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/f8846bd6-7188-46ab-937c-946ad1bf62dc)


After
----------------------------------------
unused variables removed

Technical Details
----------------------------------------

Comments
----------------------------------------
