### PR TITLE
dev/core##4146 Update debug.tpl to not be noticey with Smarty3

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -132,6 +132,14 @@ class CRM_Core_Smarty extends Smarty {
 
     $this->assign('config', $config);
     $this->assign('session', $session);
+    $this->assign('debugging', [
+      'smartyDebug' => CRM_Utils_Request::retrieveValue('smartyDebug', NULL, FALSE, FALSE, $_GET),
+      'sessionReset' => CRM_Utils_Request::retrieveValue('sessionReset', NULL, FALSE, FALSE, $_GET),
+      'sessionDebug' => CRM_Utils_Request::retrieveValue('sessionDebug', NULL, FALSE, FALSE, $_GET),
+      'directoryCleanup' => CRM_Utils_Request::retrieveValue('directoryCleanup', NULL, FALSE, FALSE, $_GET),
+      'cacheCleanup' => CRM_Utils_Request::retrieveValue('cacheCleanup', NULL, FALSE, FALSE, $_GET),
+      'configReset' => CRM_Utils_Request::retrieveValue('configReset', NULL, FALSE, FALSE, $_GET),
+    ]);
 
     $tsLocale = CRM_Core_I18n::getLocale();
     $this->assign('tsLocale', $tsLocale);

--- a/templates/CRM/common/debug.tpl
+++ b/templates/CRM/common/debug.tpl
@@ -8,26 +8,26 @@
  +--------------------------------------------------------------------+
 *}
 <!-- .tpl file invoked: {$tplFile}. Call via form.tpl if we have a form in the page. -->
-{if isset($smarty.get.smartyDebug|smarty:nodefaults)}
+{if $debugging.smartyDebug}
 {debug}
 {/if}
 
-{if isset($smarty.get.sessionReset|smarty:nodefaults)}
-{$session->reset($smarty.get.sessionReset)}
+{if $debugging.sessionReset}
+{$session->reset($debugging.sessionReset)}
 {/if}
 
-{if isset($smarty.get.sessionDebug|smarty:nodefaults)}
-{$session->debug($smarty.get.sessionDebug)}
+{if $debugging.sessionDebug}
+{$session->debug($debugging.sessionDebug)}
 {/if}
 
-{if isset($smarty.get.directoryCleanup|smarty:nodefaults)}
-{$config->cleanup($smarty.get.directoryCleanup)}
+{if $debugging.directoryCleanup}
+{$config->cleanup($debugging.directoryCleanup)}
 {/if}
 
-{if isset($smarty.get.cacheCleanup|smarty:nodefaults)}
+{if $debugging.cacheCleanup}
 {$config->clearDBCache()}
 {/if}
 
-{if isset($smarty.get.configReset|smarty:nodefaults)}
+{if $debugging.configReset}
 {$config->reset()}
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Update debug.tpl to not be noticey with Smarty3

Before
----------------------------------------
`$smarty.get` causes notices with Smarty3

After
----------------------------------------
consistently assigning the variables doesn't

Technical Details
----------------------------------------
one might wonder whether it is a good thing to still do these things - mine is not to reason why

Comments
----------------------------------------
