### PR TITLE
dev/core##4146 Update `Renderer::_tplFetch` to work with `Smarty3`

### DIFF
--- a/CRM/Core/Form/Renderer.php
+++ b/CRM/Core/Form/Renderer.php
@@ -218,6 +218,34 @@ class CRM_Core_Form_Renderer extends HTML_QuickForm_Renderer_ArraySmarty {
   }
 
   /**
+   * Process an template sourced in a string with Smarty
+   *
+   * This overrides the quick form function which has not been updated in a while.
+   *
+   * The function is called when render the code to mark a field as 'required'
+   *
+   * The notes on the quick form function seem to refer to older smarty - ie:
+   * Smarty has no core function to render a template given as a string.
+   * So we use the smarty eval plugin function to do this.
+   *
+   * @param string $tplSource The template source
+   */
+  public function _tplFetch($tplSource) {
+    // Smarty3 does not have this function defined so the parent fails.
+    // Adding this is preparatory to smarty 3....
+    if (!function_exists('smarty_function_eval') && !file_exists(SMARTY_DIR . '/plugins/function.eval.php')) {
+      $smarty = $this->_tpl;
+      $smarty->assign('var', $tplSource);
+      return $smarty->fetch("string:$tplSource");
+    }
+    // This part is what the parent does & is suitable to Smarty 2.
+    if (!function_exists('smarty_function_eval')) {
+      require SMARTY_DIR . '/plugins/function.eval.php';
+    }
+    return smarty_function_eval(['var' => $tplSource], $this->_tpl);
+  }
+
+  /**
    * Convert IDs to values and format for display.
    *
    * @param HTML_QuickForm_element $field


### PR DESCRIPTION
Overview
----------------------------------------
Update `Renderer::_tplFetch` to work with `Smarty3`

Before
----------------------------------------
`CRM_Core_Renderer` extends  Quickform class `ArraySmarty`. This latter has a function that calls smarty eval to render the required-ness on fields. The smarty eval function if is calling is not present in Smarty3

After
----------------------------------------
An override function on `CRM_Core_Renderer`  implements no change on Smarty2 but something that works fine on Smarty 3

Technical Details
----------------------------------------
This is a no-change patch, unless tinkering with Smarty3

Comments
----------------------------------------
