### PR TITLE
Find out how much we are leveraging this / deprecate our smarty::fetch override

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -200,6 +200,7 @@ class CRM_Core_Smarty extends Smarty {
     if (preg_match('/^(\s+)?string:/', $resource_name)) {
       $old_security = $this->security;
       $this->security = TRUE;
+      CRM_Core_Error::deprecatedFunctionWarning('CRM_Utils_String::parseOneOffStringThroughSmarty');
     }
     try {
       $output = parent::fetch($resource_name, $cache_id, $compile_id, $display);

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -382,7 +382,7 @@ class CRM_Utils_String {
     $params = explode('&', $query);
     foreach ($params as $p) {
       if (strpos($p, '=')) {
-        list($k, $v) = explode('=', $p);
+        [$k, $v] = explode('=', $p);
         if ($k == $urlVar) {
           return $v;
         }
@@ -516,7 +516,7 @@ class CRM_Utils_String {
     $values = explode("\n", $string);
     $result = [];
     foreach ($values as $value) {
-      list($n, $v) = CRM_Utils_System::explode('=', $value, 2);
+      [$n, $v] = CRM_Utils_System::explode('=', $value, 2);
       if (!empty($v)) {
         $result[trim($n)] = trim($v);
       }
@@ -721,7 +721,7 @@ class CRM_Utils_String {
    *   returns the masked Email address
    */
   public static function maskEmail($email, $maskChar = '*', $percent = 50) {
-    list($user, $domain) = preg_split("/@/", $email);
+    [$user, $domain] = preg_split("/@/", $email);
     $len = strlen($user);
     $maskCount = floor($len * $percent / 100);
     $offset = floor(($len - $maskCount) / 2);
@@ -1025,19 +1025,22 @@ class CRM_Utils_String {
    * many times it is run. This compares to it otherwise creating one file for every parsed string.
    *
    * @param string $templateString
+   * @param array $variables
+   *  Variables to assign.
    *
    * @return string
    *
    * @noinspection PhpDocRedundantThrowsInspection
    *
-   * @throws \CRM_Core_Exception
    */
-  public static function parseOneOffStringThroughSmarty($templateString) {
+  public static function parseOneOffStringThroughSmarty($templateString, $variables = []) {
     if (!CRM_Utils_String::stringContainsTokens($templateString)) {
       // Skip expensive smarty processing.
       return $templateString;
     }
+
     $smarty = CRM_Core_Smarty::singleton();
+    $smarty->pushScope($variables);
     $cachingValue = $smarty->caching;
     set_error_handler([$smarty, 'handleSmartyError'], E_USER_ERROR);
     $smarty->caching = 0;
@@ -1048,6 +1051,7 @@ class CRM_Utils_String {
     $smarty->caching = $cachingValue;
     $smarty->assign('smartySingleUseString');
     restore_error_handler();
+    $smarty->popScope();
     return $templateString;
   }
 

--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -554,7 +554,7 @@ abstract class AbstractAction implements \ArrayAccess {
       throw new \CRM_Core_Exception('Illegal character in expression');
     }
     $tpl = "{if $expr}1{else}0{/if}";
-    return (bool) trim(\CRM_Core_Smarty::singleton()->fetchWith('string:' . $tpl, $vars));
+    return (bool) trim(\CRM_Utils_String::parseOneOffStringThroughSmarty($tpl, $vars));
   }
 
   /**


### PR DESCRIPTION


Overview
----------------------------------------
This override of fetch does not follow the same signature as the smarty3 code. We have overriden the parent to add security - but we have an alternate function - so perhaps we are not (or don't have to) handle strings coming through here now?

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
