### PR TITLE
dev/core##4146 Add instance of smarty modifier to prevent errors when running smarty 3

### DIFF
--- a/CRM/Core/Smarty/plugins/modifier.smarty.php
+++ b/CRM/Core/Smarty/plugins/modifier.smarty.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * Implement smarty:nodefaults for Smarty3.
+ *
+ * Adding |smarty:nodefaults to strings is the smarty
+ * v2 way to indicates that a string should not be escaped.
+ * It doesn't work with smarty 3 but it is a useful way to make strings
+ * findable for this purpose as we figure out the best way for smarty 3.
+ *
+ * As a bridging mechanism this ensures the modifiers added in v2 do not error in v3.
+ *
+ * Eventually we want to run v3/v4 to escape by default but we are deferring that challenge
+ * until we have achieved the first set of upgrading to v3.
+ *
+ * @param string $string
+ *   The html to be tweaked.
+ * @param string $modifier
+ *   Either nodefaults or nothing
+ *
+ * @return string
+ *   the new modified html string
+ */
+function smarty_modifier_smarty($string, string $modifier) {
+  if ($modifier === 'nodefaults') {
+    return $string;
+  }
+  // For clarity - we don't do this.
+  throw new CRM_Core_Exception('unsupported modifier');
+}


### PR DESCRIPTION
Overview
----------------------------------------
Add instance of smarty modifier to prevent errors when running smarty 3

Before
----------------------------------------
We have added `|smarty:nodefaults` to our code to indicate strings that should not have default escaping applied in the v2 way. However, it's not the v3 way. This puts in a temporary solution to avoid crashes on it in v3. Note the work done is not wasted because we still want to do smarty default escaping & the string we have added to identify things that should not be escapted is a nicely grepable string 

After
----------------------------------------
Smarty3 can be enabled - see https://github.com/civicrm/civicrm-core/pull/27565 without hitting a bunch of errors

Technical Details
----------------------------------------
Note that with smarty v2 even with smarty-default escaping enabled this function is never called

Comments
----------------------------------------