### PR TITLE
dev/core##4146 Remove our override of Smartyv2 fetch function

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -184,35 +184,6 @@ class CRM_Core_Smarty extends Smarty {
   }
 
   /**
-   * Executes & returns or displays the template results
-   *
-   * @param string $resource_name
-   * @param string $cache_id
-   * @param string $compile_id
-   * @param bool $display
-   *
-   * @return bool|mixed|string
-   *
-   * @noinspection PhpDocMissingThrowsInspection
-   * @noinspection PhpUnhandledExceptionInspection
-   */
-  public function fetch($resource_name, $cache_id = NULL, $compile_id = NULL, $display = FALSE) {
-    if (preg_match('/^(\s+)?string:/', $resource_name)) {
-      $old_security = $this->security;
-      $this->security = TRUE;
-    }
-    try {
-      $output = parent::fetch($resource_name, $cache_id, $compile_id, $display);
-    }
-    finally {
-      if (isset($old_security)) {
-        $this->security = $old_security;
-      }
-    }
-    return $output;
-  }
-
-  /**
    * Handle smarty error in one off string.
    *
    * @param int $errorNumber


### PR DESCRIPTION
Overview
----------------------------------------
Remove our override of Smartyv2 fetch function

Before
----------------------------------------
We have overridden Smartyv2 `fetch` function to escalate security when it is being used to fetch a string. This function does not have the same signature as Smartyv3 so having it there is a blocker to us testing Smartyv3

We do have an alternate function that can be used to parse a string through smarty invoking security (see https://github.com/civicrm/civicrm-core/pull/27586) but realistically it's gonna be safer to keep the functionality until we can get off Smarty v2

After
----------------------------------------
This PR https://github.com/civicrm/civicrm-packages/pull/372 moves the security functionality to Smartyv2 package so once that is merged we simply remove it from CRM with this PR

Technical Details
----------------------------------------
I hate overriding packages but in this case it should be short-term & help us eliminate our overrides

Comments
----------------------------------------