### PR TITLE
Stop accessng _tpl_vars in smarty from property

### DIFF
--- a/CRM/Core/Smarty/plugins/function.help.php
+++ b/CRM/Core/Smarty/plugins/function.help.php
@@ -27,12 +27,12 @@
  *   the help html to be inserted
  */
 function smarty_function_help($params, &$smarty) {
-  if (!isset($params['id']) || !isset($smarty->_tpl_vars['config'])) {
+  if (!isset($params['id']) || !isset($smarty->get_template_vars()['config'])) {
     return NULL;
   }
 
-  if (empty($params['file']) && isset($smarty->_tpl_vars['tplFile'])) {
-    $params['file'] = $smarty->_tpl_vars['tplFile'];
+  if (empty($params['file']) && isset($smarty->get_template_vars()['tplFile'])) {
+    $params['file'] = $smarty->get_template_vars()['tplFile'];
   }
   elseif (empty($params['file'])) {
     return NULL;


### PR DESCRIPTION

Overview
----------------------------------------
Stop accessng _tpl_vars in smarty from property

it's bad practice & it hard fails in smartyv3

Before
----------------------------------------
`$smarty->_tpl_vars`

After
----------------------------------------
`$smarty->get_template_vars()`

Technical Details
----------------------------------------
If https://github.com/civicrm/civicrm-core/pull/27585 was / is merged we can use the preferred v3 `getTemplateVars()` but it's really for the next stage to stop using the v2 style functions

Comments
----------------------------------------
