### PR TITLE
Add dummy file in place of removed file for Joomla! installers

### DIFF
--- a/Civi/ActionSchedule/Mapping.php
+++ b/Civi/ActionSchedule/Mapping.php
@@ -1,0 +1,4 @@
+<?php
+
+// Empty file to ensure the old one is overwritten on Joomla! installs.
+// It otherwise causes Declaration of Civi\\ActionSchedule\\Mapping::getValueHeader() must be compatible with Civi\\ActionSchedule\\MappingInterface::getValueHeader():


### PR DESCRIPTION
Overview
----------------------------------------
Add dummy file in place of removed file for Joomla! installers

Per chat https://chat.civicrm.org/civicrm/pl/moaqksto8jroxbhzqf7j9o378y

Before
----------------------------------------
Error for Joomla! users as the old file is not deleted & causes problems

After
----------------------------------------
Old file overwritten by this harmless one

Technical Details
----------------------------------------
An elephant never forgets. Joomla! never deletes

Comments
----------------------------------------
