### PR TITLE
Afform - Fix display of boolean checkboxes

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -124,7 +124,7 @@
 
       $scope.hasOptions = function() {
         var inputType = $scope.getProp('input_type');
-        return _.contains(['CheckBox', 'Radio', 'Select'], inputType) && !(inputType === 'CheckBox' && !ctrl.getDefn().options);
+        return _.contains(['CheckBox', 'Radio', 'Select'], inputType) && !(inputType === 'CheckBox' && ctrl.getDefn().data_type === 'Boolean');
       };
 
       this.getOptions = function() {
@@ -142,7 +142,7 @@
           }
           return entityRefOptions;
         }
-        return ctrl.getDefn().options || ($scope.getProp('input_type') === 'CheckBox' ? null : yesNo);
+        return ctrl.getDefn().options || (ctrl.getDefn().data_type === 'Boolean' ? yesNo : null);
       };
 
       $scope.resetOptions = function() {
@@ -341,6 +341,10 @@
             if (ctrl.node.defn && ctrl.node.defn.input_attrs && 'multiple' in ctrl.node.defn.input_attrs && !ctrl.canBeMultiple()) {
               delete ctrl.node.defn.input_attrs.multiple;
               clearOut(ctrl.node, ['defn', 'input_attrs']);
+            }
+            // Boolean checkbox has no options
+            if (val === 'CheckBox' && ctrl.getDefn().data_type === 'Boolean' && ctrl.node.defn) {
+              delete ctrl.node.defn.options;
             }
           }
           setFieldDefn();

--- a/ext/afform/admin/ang/afGuiEditor/inputType/CheckBox.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/CheckBox.html
@@ -1,7 +1,7 @@
-<ul class="crm-checkbox-list" ng-if="$ctrl.getOptions()" title="{{:: ts('Set default value') }}">
+<ul class="crm-checkbox-list" ng-if="$ctrl.getDefn().data_type !== 'Boolean'" title="{{:: ts('Set default value') }}">
   <li ng-repeat="opt in $ctrl.getOptions()" >
     <input type="checkbox" ng-checked="defaultValueContains(opt.id)" ng-click="toggleDefaultValueItem(opt.id)" >
     <label>{{ opt.label }}</label>
   </li>
 </ul>
-<input type="checkbox" ng-if="!$ctrl.getOptions()" ng-checked="defaultValueContains('1')" ng-click="toggleDefaultValueItem('1') ">
+<input type="checkbox" ng-if="$ctrl.getDefn().data_type === 'Boolean'" ng-checked="defaultValueContains('1')" ng-click="toggleDefaultValueItem('1') ">

--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -161,6 +161,11 @@ class AfformMetadataInjector {
       }
     }
 
+    // Boolean checkbox has no options
+    if ($fieldInfo['data_type'] === 'Boolean' && $inputType === 'CheckBox') {
+      unset($fieldInfo['options'], $fieldDefn['options']);
+    }
+
     foreach ($fieldInfo as $name => $prop) {
       // Merge array props 1 level deep
       if (in_array($name, $deep) && !empty($fieldDefn[$name])) {

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -41,6 +41,11 @@
           this.search_operator = this.defn.search_operator;
         }
 
+        // Ensure boolean options are truly boolean
+        if (this.defn.data_type === 'Boolean' && this.defn.options) {
+          this.defn.options.forEach((option) => option.id = !!option.id);
+        }
+
         // is_primary field - watch others in this afRepeat block to ensure only one is selected
         if (ctrl.fieldName === 'is_primary' && 'repeatIndex' in $scope.dataProvider) {
           $scope.$watch('dataProvider.afRepeat.getEntityController().getData()', function (items, prev) {
@@ -167,7 +172,7 @@
       this.isMultiple = function() {
         return (
           (['Select', 'EntityRef', 'ChainSelect'].includes(ctrl.defn.input_type) && ctrl.defn.input_attrs.multiple) ||
-          (ctrl.defn.input_type === 'CheckBox' && ctrl.defn.options)
+          (ctrl.defn.input_type === 'CheckBox' && ctrl.defn.data_type !== 'Boolean')
         );
       };
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix inconsistencies with boolean fields being rendered as checkboxes or radios.

Before
----------------------------------------
- Boolean custom fields worked as radios but not as checkboxes.
- Boolean core field (e.g. "Do not mail") worked as checkboxes but not radios.
- Customizing options for boolean fields was buggy - default values for customized options was broken.

After
----------------------------------------
Any boolean field will work as a checkbox, radio, or select. Customizing options works.