### PR TITLE
dev/core#4146 Don't repeat Smarty blocks

### DIFF
--- a/CRM/Core/Smarty/plugins/block.crmButton.php
+++ b/CRM/Core/Smarty/plugins/block.crmButton.php
@@ -24,33 +24,37 @@
  *   Contents of block.
  * @param CRM_Core_Smarty $smarty
  *   The Smarty object.
+ * @param bool $repeat
+ *   Repeat is true for the opening tag, false for the closing tag
  *
- * @return string
+ * @return string|null
  *   The generated html.
  */
-function smarty_block_crmButton($params, $text, &$smarty) {
-  // Generate url (pass 'html' param as false to avoid double-encode by htmlAttributes)
-  if (empty($params['href'])) {
-    $params['href'] = CRM_Utils_System::crmURL($params + ['h' => FALSE]);
-  }
-  // Always add class 'button' - fixme probably should be crm-button
-  $params['class'] = empty($params['class']) ? 'button' : 'button ' . $params['class'];
-  // Any FA icon works
-  if (array_key_exists('icon', $params) && !$params['icon']) {
-    // icon=0 should produce a button with no icon
-    $iconMarkup = '';
-  }
-  else {
-    $icon = $params['icon'] ?? 'fa-pencil';
-    // Assume for now that all icons are Font Awesome v4.x but handle if it's
-    // specified
-    if (strpos($icon, 'fa-') !== 0) {
-      $icon = "fa-$icon";
+function smarty_block_crmButton($params, $text, &$smarty, &$repeat) {
+  if (!$repeat) {
+    // Generate url (pass 'html' param as false to avoid double-encode by htmlAttributes)
+    if (empty($params['href'])) {
+      $params['href'] = CRM_Utils_System::crmURL($params + ['h' => FALSE]);
     }
-    $iconMarkup = "<i class='crm-i $icon' aria-hidden=\"true\"></i> ";
+    // Always add class 'button' - fixme probably should be crm-button
+    $params['class'] = empty($params['class']) ? 'button' : 'button ' . $params['class'];
+    // Any FA icon works
+    if (array_key_exists('icon', $params) && !$params['icon']) {
+      // icon=0 should produce a button with no icon
+      $iconMarkup = '';
+    }
+    else {
+      $icon = $params['icon'] ?? 'fa-pencil';
+      // Assume for now that all icons are Font Awesome v4.x but handle if it's
+      // specified
+      if (strpos($icon, 'fa-') !== 0) {
+        $icon = "fa-$icon";
+      }
+      $iconMarkup = "<i class='crm-i $icon' aria-hidden=\"true\"></i> ";
+    }
+    // All other params are treated as html attributes
+    CRM_Utils_Array::remove($params, 'icon', 'p', 'q', 'a', 'f', 'h', 'fb', 'fe');
+    $attributes = CRM_Utils_String::htmlAttributes($params);
+    return "<a $attributes><span>$iconMarkup$text</span></a>";
   }
-  // All other params are treated as html attributes
-  CRM_Utils_Array::remove($params, 'icon', 'p', 'q', 'a', 'f', 'h', 'fb', 'fe');
-  $attributes = CRM_Utils_String::htmlAttributes($params);
-  return "<a $attributes><span>$iconMarkup$text</span></a>";
 }

--- a/CRM/Core/Smarty/plugins/block.crmUpgradeSnapshot.php
+++ b/CRM/Core/Smarty/plugins/block.crmUpgradeSnapshot.php
@@ -32,11 +32,13 @@
  * @param string|null $text
  *   The SELECT query which supplies the interesting data to be stored in the snapshot.
  * @param CRM_Core_Smarty $smarty
+ * @param bool $repeat
+ *   Repeat is true for the opening tag, false for the closing tag
  * @return string|null
  * @throws \CRM_Core_Exception
  */
-function smarty_block_crmUpgradeSnapshot($params, $text, &$smarty) {
-  if ($text === NULL) {
+function smarty_block_crmUpgradeSnapshot($params, $text, &$smarty, &$repeat) {
+  if ($repeat || $text === NULL) {
     return NULL;
   }
 

--- a/CRM/Core/Smarty/plugins/block.edit.php
+++ b/CRM/Core/Smarty/plugins/block.edit.php
@@ -30,11 +30,15 @@
  *   {edit} block contents from the template.
  * @param CRM_Core_Smarty $smarty
  *   The Smarty object.
+ * @param bool $repeat
+ *   Repeat is true for the opening tag, false for the closing tag
  *
- * @return string
+ * @return string|null
  *   the string, translated by gettext
  */
-function smarty_block_edit($params, $text, &$smarty) {
-  $action = $smarty->_tpl_vars['action'];
-  return ($action & 3) ? $text : NULL;
+function smarty_block_edit($params, $text, &$smarty, &$repeat) {
+  if (!$repeat) {
+    $action = $smarty->get_template_vars()['action'];
+    return ($action & 3) ? $text : NULL;
+  }
 }

--- a/CRM/Core/Smarty/plugins/block.htxt.php
+++ b/CRM/Core/Smarty/plugins/block.htxt.php
@@ -26,12 +26,14 @@
  *   {ts} block contents from the template.
  * @param CRM_Core_Smarty $smarty
  *   The Smarty object.
+ * @param bool $repeat
+ *   Repeat is true for the opening tag, false for the closing tag
  *
- * @return string
+ * @return string|null
  *   the string, translated by gettext
  */
-function smarty_block_htxt($params, $text, &$smarty) {
-  if ($params['id'] == $smarty->_tpl_vars['id']) {
+function smarty_block_htxt($params, $text, &$smarty, &$repeat) {
+  if (!$repeat && $params['id'] == $smarty->_tpl_vars['id']) {
     $smarty->assign('override_help_text', !empty($params['override']));
     return $text;
   }

--- a/CRM/Core/Smarty/plugins/block.icon.php
+++ b/CRM/Core/Smarty/plugins/block.icon.php
@@ -30,14 +30,19 @@
  *
  * @param $smarty
  *
- * @return string
+ * @param bool $repeat
+ *   Repeat is true for the opening tag, false for the closing tag
+ *
+ * @return string|null
  */
-function smarty_block_icon($params, $text, &$smarty) {
-  $condition = array_key_exists('condition', $params) ? $params['condition'] : 1;
-  $icon = $params['icon'] ?? 'fa-check';
-  $dontPass = [
-    'condition' => 1,
-    'icon' => 1,
-  ];
-  return CRM_Core_Page::crmIcon($icon, $text, $condition, array_diff_key($params, $dontPass));
+function smarty_block_icon($params, $text, &$smarty, &$repeat) {
+  if (!$repeat) {
+    $condition = array_key_exists('condition', $params) ? $params['condition'] : 1;
+    $icon = $params['icon'] ?? 'fa-check';
+    $dontPass = [
+      'condition' => 1,
+      'icon' => 1,
+    ];
+    return CRM_Core_Page::crmIcon($icon, $text, $condition, array_diff_key($params, $dontPass));
+  }
 }

--- a/CRM/Core/Smarty/plugins/block.ts.php
+++ b/CRM/Core/Smarty/plugins/block.ts.php
@@ -29,13 +29,17 @@
  *   {ts} block contents from the template.
  * @param CRM_Core_Smarty $smarty
  *   The Smarty object.
+ * @param bool $repeat
+ *   Repeat is true for the opening tag, false for the closing tag
  *
- * @return string
+ * @return string|null
  *   the string, translated by gettext
  */
-function smarty_block_ts($params, $text, &$smarty) {
-  if (!isset($params['domain']) && $extensionKey = $smarty->get_template_vars('extensionKey')) {
-    $params['domain'] = is_array($extensionKey) ? $extensionKey : [$extensionKey, NULL];
+function smarty_block_ts($params, $text, &$smarty, &$repeat) {
+  if (!$repeat) {
+    if (!isset($params['domain']) && $extensionKey = $smarty->get_template_vars('extensionKey')) {
+      $params['domain'] = is_array($extensionKey) ? $extensionKey : [$extensionKey, NULL];
+    }
+    return _ts($text, $params);
   }
-  return _ts($text, $params);
 }

--- a/CRM/Core/Smarty/plugins/block.url.php
+++ b/CRM/Core/Smarty/plugins/block.url.php
@@ -34,10 +34,13 @@
  *   Contents of block.
  * @param CRM_Core_Smarty $smarty
  *   The Smarty object.
+ * @param bool $repeat
+ *   Repeat is true for the opening tag, false for the closing tag
+ *
  * @return string
  */
-function smarty_block_url($params, $text, &$smarty) {
-  if ($text === NULL) {
+function smarty_block_url($params, $text, &$smarty, &$repeat) {
+  if ($repeat || $text === NULL) {
     return NULL;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
[See Smarty docs](https://www.smarty.net/docsv2/en/plugins.block.functions.tpl). This works in both Smarty 2 and 3.
Have done for all blocks except one that is unused (#27619 deletes).

Tested all in Smarty 2 and 3, except the upgrade snapshot - not entirely sure how to test that, but it seems unlikely to be an issue.
{edit} is barely used (a few times in core, a couple in extensions), but actually seems like a good idea, so I left it rather than remove.