### PR TITLE
Replace email smarty var with token

### DIFF
--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -156,7 +156,7 @@
       </tr>
       <tr>
        <td colspan="2" {$valueStyle}>
-         {contact.email_primary.email|boolean}
+         {contact.email_primary.email}
        </td>
       </tr>
      {/if}


### PR DESCRIPTION


Overview
----------------------------------------
Replace email smarty var with token

This replaces the variable email with the appropriate smarty token

I spent some time tracking back the various contact ID & email refs but concluded this value would always be the participant email, with is assigned as contact to the tokens.

Before
----------------------------------------
Maybe assigned variable

After
----------------------------------------
token

Technical Details
----------------------------------------

Comments
----------------------------------------
