### PR TITLE
Move assigning customGroup to offline participant template out of the form layer

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -856,6 +856,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
           && $field['custom_group_id.is_public']
           && (
             !empty($entityValueMatches)
+            || empty($entityFilters)
             || empty($field['custom_group_id.extends_entity_column_id'])
           )
           && (

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -2133,21 +2133,6 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
       $this->assign('receive_date', $params['receive_date']);
     }
 
-    $customGroup = [];
-    $customFieldFilters = [
-      'ParticipantRole' => $this->getSubmittedValue('role_id'),
-      'ParticipantEventName' => $this->getEventID(),
-      'ParticipantEventType' => $this->getEventValue('event_type_id'),
-    ];
-    $customFields = CRM_Core_BAO_CustomField::getViewableCustomFields('Participant', $customFieldFilters);
-    foreach ($params['custom'] as $fieldID => $values) {
-      foreach ($values as $fieldValue) {
-        $formattedValue = CRM_Core_BAO_CustomField::displayValue($fieldValue['value'], $fieldID, $participants[0]->id);
-        $customGroup[$customFields[$fieldID]['custom_group_id.title']][$customFields[$fieldID]['label']] = str_replace('&nbsp;', '', $formattedValue);
-      }
-    }
-    $this->assign('customGroup', $customGroup);
-
     $fromEmails = CRM_Event_BAO_Event::getFromEmailIds($this->getEventID());
     foreach ($this->_contactIds as $num => $contactID) {
       // Retrieve the name and email of the contact - this will be the TO for receipt email

--- a/CRM/Event/WorkflowMessage/EventOfflineReceipt.php
+++ b/CRM/Event/WorkflowMessage/EventOfflineReceipt.php
@@ -10,6 +10,7 @@
  */
 
 use Civi\WorkflowMessage\GenericWorkflowMessage;
+use Civi\WorkflowMessage\Traits\CustomFieldTrait;
 
 /**
  * Receipt sent when confirming a back office participation record.
@@ -22,7 +23,72 @@ use Civi\WorkflowMessage\GenericWorkflowMessage;
 class CRM_Event_WorkflowMessage_EventOfflineReceipt extends GenericWorkflowMessage {
   use CRM_Event_WorkflowMessage_ParticipantTrait;
   use CRM_Contribute_WorkflowMessage_ContributionTrait;
+  use CustomFieldTrait;
 
   public const WORKFLOW = 'event_offline_receipt';
+
+  /**
+   * Viewable custom fields for the primary participant.
+   *
+   * This array is in the format
+   *
+   * ['customGroupLabel' => [['customFieldLabel' => 'customFieldValue'], ['customFieldLabel' => 'customFieldValue']]
+   *
+   * It is only added for the primary participant (which reflects historical
+   * form behaviour) and only fields were the group has is_public = TRUE
+   * and the field has is_view = FALSE. Fields are restricted to
+   * those viewable by the logged in user (reflecting the fact this
+   * is historically triggered by a back office user form submission
+   * and also preventing using an email to see acl-blocked custom fields).
+   *
+   * @var array
+   *
+   * @scope tplParams as customGroup
+   */
+  public $customFields;
+
+  /**
+   * Get the custom fields for display for the participant, if not primary.
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  public function getCustomFields(): array {
+    // Non-primary custom field info can't be gathered on the back office
+    // form so historically it has not shown up. This keeps that behaviour
+    // (although a future person could probably change it if they wanted
+    // to think through any potential downsides.
+    if (!$this->getIsPrimary()) {
+      return [];
+    }
+    $participant = $this->getParticipant();
+    // We re-filter the custom fields to eliminate any custom groups
+    // not associated with the role, event_id etc. Realistically participants
+    // should not have such data. But, out of caution we do this becasue
+    // historical code did.
+    $filters = [
+      'ParticipantRole' => $participant['role_id'],
+      'ParticipantEventName' => $participant['event_id'],
+      'ParticipantEventType' => $participant['event_id.event_type_id'],
+    ];
+    return $this->getCustomFieldDisplay($participant, 'Participant', $filters);
+  }
+
+  /**
+   * Get the participant fields we need to load.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function getFieldsToLoadForParticipant(): array {
+    $fields = ['registered_by_id', 'role_id', 'event_id', 'event_id.event_type_id'];
+    // Request the relevant custom fields. This list is
+    // restricted by view-ability but we don't have the information
+    // at this point to filter by the finer tuned entity extends information
+    // which relies on us knowing role etc.
+    foreach ($this->getFilteredCustomFields('Participant') as $field) {
+      $fields[] = $field['custom_group_id.name'] . '.' . $field['name'];
+    }
+    return $fields;
+  }
 
 }

--- a/CRM/Event/WorkflowMessage/ParticipantTrait.php
+++ b/CRM/Event/WorkflowMessage/ParticipantTrait.php
@@ -179,9 +179,16 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
     if (!$this->participant) {
       $this->participant = Participant::get(FALSE)
         ->addWhere('id', '=', $this->participantID)
-        ->addSelect('registered_by_id')->execute()->first();
+        ->setSelect($this->getFieldsToLoadForParticipant())->execute()->first();
     }
     return $this->participant;
+  }
+
+  /**
+   * Get the participant fields we need to load.
+   */
+  protected function getFieldsToLoadForParticipant(): array {
+    return ['registered_by_id'];
   }
 
   /**

--- a/Civi/WorkflowMessage/Traits/CustomFieldTrait.php
+++ b/Civi/WorkflowMessage/Traits/CustomFieldTrait.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\WorkflowMessage\Traits;
+
+/**
+ * Adds a block of custom fields, as traditionally used in back office receipts.
+ */
+trait CustomFieldTrait {
+
+  /**
+   * Get a list of custom fields that are 'viewable'.
+   *
+   * Viewable is defined as
+   *  - is_public = TRUE (group level)
+   *  - is_view = FALSE (field level).
+   *    This indicate a calculated field (which could be private fundraising info)
+   *    and has not been historically visible as it is not on the edit form.
+   *  - is not acl blocked for the current user (this is used in back office
+   *    context so the user is an admin not the recipient).
+   *
+   * @param string $entity
+   * @param array $filters
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  protected function getFilteredCustomFields(string $entity, array $filters = []): array {
+    return \CRM_Core_BAO_CustomField::getViewableCustomFields($entity, $filters);
+  }
+
+  /**
+   * Given an entity loaded through apiv4 return an array of custom fields for display.
+   *
+   * @param array $entityRecord
+   * @param string $entity
+   * @param array $filters
+   *
+   * @return array
+   * @throws \Brick\Money\Exception\UnknownCurrencyException
+   * @throws \CRM_Core_Exception
+   */
+  protected function getCustomFieldDisplay(array $entityRecord, string $entity, array $filters = []): array {
+    // Fetch the fields, filtered by the entity_extends values
+    $viewableFields = $this->getFilteredCustomFields($entity, $filters);
+
+    $fields = [];
+    foreach ($viewableFields as $fieldSpec) {
+      $fieldName = $fieldSpec['custom_group_id.name'] . '.' . $fieldSpec['name'];
+      $value = str_replace('&nbsp;', '', \CRM_Core_BAO_CustomField::displayValue($entityRecord[$fieldName], $fieldSpec['id'], $entityRecord['id']));
+      // I can't see evidence we have filtered out empty strings here historically
+      // but maybe we should?
+      $fields[$fieldSpec['custom_group_id.title']][$fieldSpec['label']] = $value;
+    }
+    return $fields;
+  }
+
+}


### PR DESCRIPTION

Overview
----------------------------------------
Move assigning customGroup to offline participant template out of the form layer

Builds on https://github.com/civicrm/civicrm-core/pull/27552 & moves the determination of the custom fields out of the form onto the workflow template
Unit test for this functionality added in 
https://github.com/civicrm/civicrm-core/pull/27552/files#diff-a22240af3e1461ef0bd11694690c6c356c26a09a025e6b9b0a0b64fcd0d47fa9R61

Before
----------------------------------------
the form determines the `customGroups` variable that is assigned to the offline_event workflow template

After
----------------------------------------
The workflow template does - with a good deal more commentary


Technical Details
----------------------------------------
Screenshots of the array from the form

![image](https://github.com/civicrm/civicrm-core/assets/336308/743403fa-fc99-4c62-9c5a-8c230404ed90)

from the trait

![image](https://github.com/civicrm/civicrm-core/assets/336308/3a9927b7-1c72-430c-a8ef-4b2eee30beba)


Comments
----------------------------------------
