### PR TITLE
[REF][PHP8.2] Declare properties in CRM_Queue_ErrorPolicy

### DIFF
--- a/CRM/Queue/ErrorPolicy.php
+++ b/CRM/Queue/ErrorPolicy.php
@@ -26,7 +26,21 @@
  * will be necessary to get reuse from the other parts of this class.
  */
 class CRM_Queue_ErrorPolicy {
-  public $active;
+
+  /**
+   * @var bool
+   */
+  protected $active;
+
+  /**
+   * @var int
+   */
+  protected $level;
+
+  /**
+   * @var array
+   */
+  protected $backup;
 
   /**
    * @param null|int $level
@@ -43,7 +57,7 @@ class CRM_Queue_ErrorPolicy {
   /**
    * Enable the error policy.
    */
-  public function activate() {
+  protected function activate() {
     $this->active = TRUE;
     $this->backup = [];
     foreach ([
@@ -55,14 +69,12 @@ class CRM_Queue_ErrorPolicy {
       ini_set($key, 0);
     }
     set_error_handler([$this, 'onError'], $this->level);
-    // FIXME make this temporary/reversible
   }
 
   /**
    * Disable the error policy.
    */
-  public function deactivate() {
-    $this->errorScope = NULL;
+  protected function deactivate() {
     restore_error_handler();
     foreach ([
       'display_errors',
@@ -137,7 +149,7 @@ class CRM_Queue_ErrorPolicy {
    * @param array $error
    *   The PHP error (with "type", "message", etc).
    */
-  public function reportError($error) {
+  protected function reportError($error) {
     $response = [
       'is_error' => 1,
       'is_continue' => 0,
@@ -158,7 +170,7 @@ class CRM_Queue_ErrorPolicy {
    * @param Exception $e
    *   The unhandled exception.
    */
-  public function reportException(Exception $e) {
+  protected function reportException(Exception $e) {
     CRM_Core_Error::debug_var('CRM_Queue_ErrorPolicy_reportException', CRM_Core_Error::formatTextException($e));
 
     $response = [


### PR DESCRIPTION
Overview
----------------------------------------
Declares properties in `CRM_Queue_ErrorPolicy`, to avoid dynamic property deprecations on PHP 8.2.

Also makes some internal methods protected.

Before
----------------------------------------
Use of dynamic properties would cause deprecation notices on PHP 8.2.


After
----------------------------------------
No more dynamic properties.

Comments
----------------------------------------
It should be noted that this is:

a) Not covered by tests,
b) Fairly difficult to test manually (as you need to trigger an error within a queue)

Therefore this probably wants a more thorough review than is customary.

I did wonder about adding tests, but it's awkward to test as most of the ineresting logic lives within a `register_shutdown_function`.