### PR TITLE
Require all fields in signature, as always passed

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -592,15 +592,8 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       $form->add('hidden', 'priceSetId', $priceSetID);
 
       // CRM-14492 Admin price fields should show up on event registration if user has 'administer CiviCRM' permissions
-      $adminFieldVisible = FALSE;
-      if (CRM_Core_Permission::check('administer CiviCRM data')) {
-        $adminFieldVisible = TRUE;
-      }
-
-      $hideAdminValues = TRUE;
-      if (CRM_Core_Permission::check('edit event participants')) {
-        $hideAdminValues = FALSE;
-      }
+      $adminFieldVisible = CRM_Core_Permission::check('administer CiviCRM data');
+      $hideAdminValues = !CRM_Core_Permission::check('edit event participants');
 
       foreach ($form->_feeBlock as $field) {
         // public AND admin visibility fields are included for back-office registration and back-office change selections

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -537,6 +537,10 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
   /**
    * Build the radio/text form elements for the amount field
    *
+   * @internal function is not currently called by any extentions in our civi
+   * 'universe' and is not supported for such use. Signature has changed & will
+   * change again.
+   *
    * @param CRM_Event_Form_Registration_Register $form
    *   Form object.
    * @param bool $required
@@ -547,7 +551,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
    *
    * @throws \CRM_Core_Exception
    */
-  public static function buildAmount(&$form, $required = TRUE, $discountId = NULL, $priceSetID = NULL) {
+  public static function buildAmount($form, $required, $discountId, $priceSetID) {
     $feeFields = $form->_values['fee'] ?? NULL;
 
     if (is_array($feeFields)) {


### PR DESCRIPTION
Overview
----------------------------------------
Require all fields in signature, as always passed

Before
----------------------------------------
All calls to the function pass all variables but they show up as optional

![image](https://github.com/civicrm/civicrm-core/assets/336308/ecbb05d4-9968-4e5f-b8be-41a9d14d60c0)

After
----------------------------------------
They are required

Technical Details
----------------------------------------
This is clearer & allows the addition of more required fields at the end

I did a universe search... it's not called from outside core code thankfully 

![image](https://github.com/civicrm/civicrm-core/assets/336308/c98c002b-2ce5-4da9-a39b-cca24f847bf0)


Comments
----------------------------------------
