### PR TITLE
Remove dead code - checkSQLConstraint functions

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -142,34 +142,6 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
   }
 
   /**
-   * @param $constraints
-   *
-   * @return array
-   */
-  public function checkSQLConstraints(&$constraints) {
-    $pass = $fail = 0;
-    foreach ($constraints as $constraint) {
-      if ($this->checkSQLConstraint($constraint)) {
-        $pass++;
-      }
-      else {
-        $fail++;
-      }
-      return [$pass, $fail];
-    }
-  }
-
-  /**
-   * @param $constraint
-   *
-   * @return bool
-   */
-  public function checkSQLConstraint($constraint) {
-    // check constraint here
-    return TRUE;
-  }
-
-  /**
    * @param string $fileName
    * @param bool $isQueryString
    */


### PR DESCRIPTION
Overview
----------------------------------------
Remove dead code - `checkSQLConstraint` and `checkSQLConstraints` functions.

Before
----------------------------------------
Many factors make me believe this code can be removed:

1. Nothing in core uses the functions,
2. The code dates back to the import from SVN, and even then the code was not being used (I check with `git log -S checkSQLConstraint`,
3. `checkSQLConstraint` was seemingly never implemented,
4. The `return` in `checkSQLConstraints` is within the `foreach` loop which would never have worked properly

After
----------------------------------------
The code is gone.