### PR TITLE
Stop passing unused parameter

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -543,13 +543,9 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     if ($priceSetId) {
       if ($form->_action & CRM_Core_Action::UPDATE) {
         $form->_values['line_items'] = CRM_Price_BAO_LineItem::getLineItems($form->_id, 'contribution');
-        $required = FALSE;
-      }
-      else {
-        $required = TRUE;
       }
 
-      $priceSet = CRM_Price_BAO_PriceSet::getSetDetail($priceSetId, $required);
+      $priceSet = CRM_Price_BAO_PriceSet::getSetDetail($priceSetId);
       $form->_priceSet = $priceSet[$priceSetId] ?? NULL;
       $form->_values['fee'] = $form->_priceSet['fields'] ?? NULL;
       $form->set('priceSet', $form->_priceSet);

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -594,13 +594,8 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
         else {
           $form->_values['line_items'] = CRM_Price_BAO_LineItem::getLineItems($form->_participantId, 'participant');
         }
-        $required = FALSE;
       }
-      else {
-        $required = TRUE;
-      }
-
-      $priceSet = CRM_Price_BAO_PriceSet::getSetDetail($priceSetId, $required, $doNotIncludeExpiredFields);
+      $priceSet = CRM_Price_BAO_PriceSet::getSetDetail($priceSetId, NULL, $doNotIncludeExpiredFields);
       $form->_priceSet = $priceSet[$priceSetId] ?? NULL;
       $form->_values['fee'] = $form->_priceSet['fields'] ?? NULL;
 


### PR DESCRIPTION
Overview
----------------------------------------
Stop passing unused parameter

Before
----------------------------------------
`$required is calculated & passed to `getPriceSetDetail` ... and ignored
![image](https://github.com/civicrm/civicrm-core/assets/336308/8618bdfe-b7da-4bb7-81a2-b5f3379b186a)


After
----------------------------------------
Not passed

Technical Details
----------------------------------------
 

Comments
----------------------------------------
