### PR TITLE
Share event lookup functions in a trait

### DIFF
--- a/CRM/Event/Form/EventFormTrait.php
+++ b/CRM/Event/Form/EventFormTrait.php
@@ -1,0 +1,95 @@
+<?php
+
+use Civi\API\EntityLookupTrait;
+
+/**
+ * Trait implements getContactValue + overridable getContactID functions.
+ *
+ * These are commonly used on forms - although getContactID() would often
+ * be overridden. By using these functions it is not necessary to know
+ * if the Contact ID has already been defined as `getContactID()` will retrieve
+ * them form the values available (unless it is yet to be created).
+ */
+trait CRM_Event_Form_EventFormTrait {
+
+  use EntityLookupTrait;
+
+  /**
+   * Get the value for a field relating to the event.
+   *
+   * All values returned in apiv4 format. Escaping may be required.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @param string $fieldName
+   *
+   * @return mixed
+   * @throws \CRM_Core_Exception
+   */
+  public function getEventValue(string $fieldName) {
+    if ($this->isDefined('Event')) {
+      return $this->lookup('Event', $fieldName);
+    }
+    $id = $this->getEventID();
+    if ($id) {
+      $this->define('Event', 'Event', ['id' => $id]);
+      return $this->lookup('Event', $fieldName);
+    }
+    return NULL;
+  }
+
+  /**
+   * Get the selected Event ID.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   * @noinspection PhpDocMissingThrowsInspection
+   */
+  public function getEventID(): ?int {
+    throw new CRM_Core_Exception('`getEventID` must be implemented');
+  }
+
+  /**
+   * Get id of participant being acted on.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   */
+  public function getParticipantID(): ?int {
+    throw new CRM_Core_Exception('`getParticipantID` must be implemented');
+  }
+
+  /**
+   * Get a value from the participant being acted on.
+   *
+   * All values returned in apiv4 format. Escaping may be required.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @param string $fieldName
+   *
+   * @return mixed
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function getParticipantValue(string $fieldName) {
+    if ($this->isDefined('Participant')) {
+      return $this->lookup('Participant', $fieldName);
+    }
+    $id = $this->getParticipantID();
+    if ($id) {
+      $this->define('Participant', 'Participant', ['id' => $id]);
+      return $this->lookup('Participant', $fieldName);
+    }
+    return NULL;
+  }
+
+}

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -25,6 +25,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
   use EntityLookupTrait;
   use CRM_Contact_Form_ContactFormTrait;
+  use CRM_Event_Form_EventFormTrait;
 
   /**
    * Participant ID - use getParticipantID.
@@ -93,13 +94,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    * @deprecated
    */
   public $_contactId;
-
-  /**
-   * Array of event values.
-   *
-   * @var array
-   */
-  protected $_event;
 
   /**
    * Are we operating in "single mode", i.e. adding / editing only
@@ -206,13 +200,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    * @todo add explanatory note about this
    */
   public $_onlinePendingContributionId;
-
-  /**
-   * Stored participant record.
-   *
-   * @var array
-   */
-  protected $participantRecord;
 
   /**
    * Params for creating a payment to add to the contribution.
@@ -1887,36 +1874,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    */
   protected function isPaymentOnExistingContribution(): bool {
     return ($this->getParticipantID() && $this->_action & CRM_Core_Action::UPDATE) && $this->_paymentId;
-  }
-
-  /**
-   * Get the value for a field relating to the event.
-   *
-   * @param string $fieldName
-   *
-   * @return mixed
-   * @throws \CRM_Core_Exception
-   */
-  protected function getEventValue(string $fieldName) {
-    if (!isset($this->_event)) {
-      $this->_event = civicrm_api3('Event', 'getsingle', ['id' => $this->_eventId]);
-    }
-    return $this->_event[$fieldName];
-  }
-
-  /**
-   * Get a value from the existing participant record (applies to edits).
-   *
-   * @param string $fieldName
-   *
-   * @return array
-   * @throws \CRM_Core_Exception
-   */
-  protected function getParticipantValue($fieldName) {
-    if (!$this->participantRecord) {
-      $this->participantRecord = civicrm_api3('Participant', 'getsingle', ['id' => $this->getParticipantID()]);
-    }
-    return $this->participantRecord[$fieldName] ?? $this->participantRecord['participant_' . $fieldName];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Share event lookup functions in a trait

This is a step to standardising our event-related forms to all supporting the same consistent public functions
- getEventID()
- getParticipantID()
- getEventValue()
- getPartcipantValue()

& ouside this PR
- getContactID
- getContactValue()
- getPriceSetID()
- getDiscountID()

Note I didn't implement the participant stuff for the online registration form at this point because it needs a bit more though


Before
----------------------------------------
These functions locally implemented on Participant Form

- getParticipantValue()
- getEventValue()

After
----------------------------------------
Functions shared with Registration form & ParticipantFeeSelection (ie this one)

![image](https://github.com/civicrm/civicrm-core/assets/336308/af4be878-e7af-4dd5-b6f4-79c07d471838)


Technical Details
----------------------------------------

Comments
----------------------------------------
@colemanw there is a tonne of follow on tidy up possible - I kept it limited