### PR TITLE
Fix a couple more places to use tokens participant role

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -99,7 +99,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
     $fieldValue = $this->getFieldValue($row, $field);
     if (is_array($fieldValue)) {
       // eg. role_id for participant would be an array here.
-      $fieldValue = implode(',', $fieldValue);
+      $fieldValue = implode(', ', $fieldValue);
     }
 
     if ($this->isPseudoField($field)) {

--- a/CRM/Event/WorkflowMessage/EventExamples.php
+++ b/CRM/Event/WorkflowMessage/EventExamples.php
@@ -115,7 +115,8 @@ class CRM_Event_WorkflowMessage_EventExamples extends WorkflowMessageExample {
     $messageTemplate->setContribution($contribution);
     $messageTemplate->setOrder($mockOrder);
     $messageTemplate->setParticipantContacts($participantContacts);
-    $messageTemplate->setParticipant(['id' => $isPrimary ? $primaryParticipantID : $otherParticipantID, 'registered_by_id' => $isPrimary ? NULL : $primaryParticipantID, 'register_date' => date('Y-m-d')]);
+    $roleID = Event::get(FALSE)->addWhere('id', '=', $example['event_id'])->addSelect('default_role_id')->execute()->first()['default_role_id'];
+    $messageTemplate->setParticipant(['id' => $isPrimary ? $primaryParticipantID : $otherParticipantID, 'registered_by_id' => $isPrimary ? NULL : $primaryParticipantID, 'register_date' => date('Y-m-d'), 'role_id' => $roleID]);
   }
 
   /**

--- a/tests/templates/message_templates/event_online_receipt_text.tpl
+++ b/tests/templates/message_templates/event_online_receipt_text.tpl
@@ -29,14 +29,9 @@ pay_later_receipt:::{$pay_later_receipt}
 event.event_title:::{$event.event_title}
 event.event_start_date:::{$event.event_start_date|crmDate:"%A"}
 event.event_end_date:::{event.end_date|crmDate:"%Y%m%d"}
-{if !empty($event.is_monetary)}
-event.is_monetary:::{$event.is_monetary}
-{/if}
+event.is_monetary:::{event.is_monetary|boolean}
 event.fee_label:::{event.fee_label}
-{if !empty($event.participant_role)}
-  event.participant_role::{$event.participant_role}
-  defaultRole:::{$defaultRole}
-{/if}
+event.participant_role::{event.participant_role_id:label}
 {if !empty($isShowLocation)}
 isShowLocation:::{$isShowLocation}
 location.address.1.display:::{$location.address.1.display}

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -53,13 +53,13 @@
       </td>
      </tr>
 
-     {if !empty($event.participant_role) and $event.participant_role neq 'Attendee' and !empty($defaultRole)}
+     {if "{participant.role_id:label}" neq 'Attendee'}
       <tr>
        <td {$labelStyle}>
         {ts}Participant Role{/ts}
        </td>
        <td {$valueStyle}>
-        {$event.participant_role}
+         {participant.role_id:label}
        </td>
       </tr>
      {/if}

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -40,8 +40,8 @@
 {event.title}
 {event.start_date|crmDate}{if {event.end_date|boolean}}-{if '{event.end_date|crmDate:"%Y%m%d"}' === '{event.start_date|crmDate:"%Y%m%d"}'}{event.end_date|crmDate:"Time"}{else}{event.end_date}{/if}{/if}
 
-{if !empty($event.participant_role) and $event.participant_role neq 'Attendee' and empty($defaultRole)}
-{ts}Participant Role{/ts}: {$event.participant_role}
+{if "{participant.role_id:label}" neq 'Attendee'}
+{ts}Participant Role{/ts}: {participant.role_id:label}
 {/if}
 
 {if !empty($isShowLocation)}

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -66,13 +66,13 @@
           </td>
         </tr>
 
-        {if !empty($event.participant_role) and $event.participant_role neq 'Attendee' and !empty($defaultRole)}
+        {if "{participant.role_id:label}" neq 'Attendee'}
           <tr>
             <td {$labelStyle}>
               {ts}Participant Role{/ts}
             </td>
             <td {$valueStyle}>
-              {$event.participant_role}
+              {participant.role_id:label}
             </td>
           </tr>
         {/if}
@@ -317,13 +317,13 @@
                 </tr>
               {/if}
 
-              {if $register_date}
+              {if {participant.register_date|boolean}}
                 <tr>
                   <td {$labelStyle}>
                     {ts}Registration Date{/ts}
                   </td>
                   <td {$valueStyle}>
-                    {$register_date|crmDate}
+                    {participant.register_date}
                   </td>
                 </tr>
               {/if}

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -50,8 +50,8 @@
 {event.title}
 {event.start_date|crmDate:"%A"} {event.start_date|crmDate}{if {event.end_date|boolean}}-{if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}{$event.event_end_date|crmDate:0:1}{else}{$event.event_end_date|crmDate:"%A"} {$event.event_end_date|crmDate}{/if}{/if}
 
-{if !empty($event.participant_role) and $event.participant_role neq 'Attendee' and !empty($defaultRole)}
-{ts}Participant Role{/ts}: {$event.participant_role}
+{if "{participant.role_id:label}" neq 'Attendee'}
+{ts}Participant Role{/ts}: {participant.role_id:label}
 {/if}
 
 {if !empty($isShowLocation)}


### PR DESCRIPTION

Overview
----------------------------------------
Use tokens for `role_id` in participant forms

Before
----------------------------------------
Relies on form assigns

After
----------------------------------------
tokens

note 
- I had to choose whether to change the test to accept 'Attendee,Volunteer' or change the code to output 
'Attendee, Volunteer' - I went with the space

- I could make no sense of the whole default role ID thingI removed it

Technical Details
----------------------------------------

Comments
----------------------------------------
