### PR TITLE
Afform  - ensure prefill entities are populated correctly

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -70,6 +70,7 @@
               result.forEach((item) => {
                 // Use _.each() because item.values could be cast as an object if array keys are not sequential
                 _.each(item.values, (values, index) => {
+                  data[item.name][index] = data[item.name][index] || {};
                   data[item.name][index].joins = {};
                   angular.merge(data[item.name][index], values, {fields: _.cloneDeep(schema[item.name].data || {})});
                 });


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug introduced in 5.66 causing Afform.prefill to crash.
See detailed problem desciption: https://github.com/civicrm/civicrm-core/pull/27121#issuecomment-1694757070

Technical Details
----------------------------------------
Unit test confirms prefill is already working as expected (no changes needed, it already works) - the bug was in the form javascript (sigh).