### PR TITLE
SearchKit - When hiding pager, also hide page count

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/Pager.html
+++ b/ext/search_kit/ang/crmSearchDisplay/Pager.html
@@ -20,7 +20,7 @@
     ></ul>
   </div>
   <div>
-    <div class="form-inline text-right" ng-if="$ctrl.settings.pager.expose_limit">
+    <div class="form-inline text-right" ng-if="$ctrl.settings.pager.expose_limit && (!$ctrl.settings.pager.hide_single || $ctrl.rowCount > $ctrl.limit)">
       <label for="crm-search-results-page-size" >
         {{:: ts('Page Size') }}
       </label>


### PR DESCRIPTION
Overview
----------------------------------------
Hides unnecessary pager count on search displays.

Before
----------------------------------------
Pager count shown even when pager is hidden

After
----------------------------------------
Hidden together