### PR TITLE
Align financial information in participant offline receipt with online receipt

### DIFF
--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -1,16 +1,19 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
- <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
- <title></title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <title></title>
 </head>
 <body>
 
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
 {capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
 {capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
+{capture assign=tdfirstStyle}style="width: 180px; padding-bottom: 15px;"{/capture}
+{capture assign=tdStyle}style="width: 100px;"{/capture}
+{capture assign=participantTotalStyle}style="margin: 0.5em 0 0.5em;padding: 0.5em;background-color: #999999;font-weight: bold;color: #FAFAFA;border-radius: 2px;"{/capture}
 
-  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
+<table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->
@@ -32,8 +35,8 @@
     {elseif !empty($isRequireApproval)}
       <p>{ts}Your registration has been submitted.{/ts}</p>
       <p>{ts}Once your registration has been reviewed, you will receive an email with a link to a web page where you can complete the registration process.{/ts}</p>
-    {elseif $is_pay_later}
-     <p>{$pay_later_receipt}</p> {* FIXME: this might be text rather than HTML *}
+    {elseif {contribution.is_pay_later|boolean} && {contribution.balance_amount|boolean}}
+     <p>{event.pay_later_receipt}</p> {* FIXME: this might be text rather than HTML *}
     {/if}
 
    </td>
@@ -73,41 +76,40 @@
      {/if}
 
      {if {event.loc_block_id.phone_id.phone|boolean} || {event.loc_block_id.email_id.email|boolean}}
-      <tr>
-       <td colspan="2" {$labelStyle}>
-        {ts}Event Contacts:{/ts}
-       </td>
-      </tr>
+       <tr>
+         <td colspan="2" {$labelStyle}>
+           {ts}Event Contacts:{/ts}
+         </td>
+       </tr>
 
        {if {event.loc_block_id.phone_id.phone|boolean}}
-        <tr>
-         <td {$labelStyle}>
-          {if {event.loc_block_id.phone_id.phone_type_id|boolean}}
-            {event.loc_block_id.phone_id.phone_type_id:label}
-          {else}
-           {ts}Phone{/ts}
-          {/if}
-         </td>
+         <tr>
+           <td {$labelStyle}>
+             {if {event.loc_block_id.phone_id.phone_type_id|boolean}}
+               {event.loc_block_id.phone_id.phone_type_id:label}
+             {else}
+               {ts}Phone{/ts}
+             {/if}
+           </td>
          <td {$valueStyle}>
           {event.loc_block_id.phone_id.phone} {if {event.loc_block_id.phone_id.phone_ext|boolean}}&nbsp;{ts}ext.{/ts} {event.loc_block_id.phone_id.phone_ext}{/if}
          </td>
         </tr>
        {/if}
-         {if {event.loc_block_id.phone_2_id.phone|boolean}}
-           <tr>
-             <td {$labelStyle}>
-                 {if {event.loc_block_id.phone_2_id.phone_type_id|boolean}}
-                     {event.loc_block_id.phone_2_id.phone_type_id:label}
-                 {else}
-                     {ts}Phone{/ts}
-                 {/if}
-             </td>
-             <td {$valueStyle}>
-                 {event.loc_block_id.phone_2_id.phone} {if {event.loc_block_id.phone_2_id.phone_ext|boolean}}&nbsp;{ts}ext.{/ts} {event.loc_block_id.phone_2_id.phone_ext}{/if}
-             </td>
-           </tr>
-         {/if}
-
+       {if {event.loc_block_id.phone_2_id.phone|boolean}}
+         <tr>
+           <td {$labelStyle}>
+             {if {event.loc_block_id.phone_2_id.phone_type_id|boolean}}
+               {event.loc_block_id.phone_2_id.phone_type_id:label}
+             {else}
+               {ts}Phone{/ts}
+             {/if}
+           </td>
+           <td {$valueStyle}>
+             {event.loc_block_id.phone_2_id.phone} {if {event.loc_block_id.phone_2_id.phone_ext|boolean}}&nbsp;{ts}ext.{/ts} {event.loc_block_id.phone_2_id.phone_ext}{/if}
+           </td>
+         </tr>
+       {/if}
 
        {if {event.loc_block_id.email_id.email|boolean}}
         <tr>
@@ -115,7 +117,7 @@
           {ts}Email{/ts}
          </td>
          <td {$valueStyle}>
-             {event.loc_block_id.email_id.email}
+           {event.loc_block_id.email_id.email}
          </td>
         </tr>
        {/if}
@@ -123,14 +125,13 @@
        {if {event.loc_block_id.email_2_id.email|boolean}}
          <tr>
            <td {$labelStyle}>
-               {ts}Email{/ts}
+             {ts}Email{/ts}
            </td>
            <td {$valueStyle}>
                {event.loc_block_id.email_2_id.email}
            </td>
          </tr>
        {/if}
-
      {/if}
 
      {if {event.is_public|boolean}}
@@ -165,267 +166,251 @@
      {if {event.is_monetary|boolean}}
 
       <tr>
-       <th {$headerStyle}>
-        {event.fee_label}
-       </th>
+        <th {$headerStyle}>
+            {event.fee_label}
+        </th>
       </tr>
-
-      {if !empty($lineItem)}
-       {foreach from=$lineItem item=value key=priceset}
-        {if $value neq 'skip'}
-          {if $lineItem|@count GT 1} {* Header for multi participant registration cases. *}
-           <tr>
-            <td colspan="2" {$labelStyle}>
-             {ts 1=$priceset+1}Participant %1{/ts}
+        {if $isShowLineItems}
+          {foreach from=$participants key=index item=currentParticipant}
+            {if $isPrimary || {participant.id} === $currentParticipant.id}
+              {if $isPrimary && $lineItems|@count GT 1} {* Header for multi participant registration cases. *}
+                <tr>
+                  <td colspan="2" {$labelStyle}>
+                      {ts 1=$currentParticipant.index}Participant %1{/ts} {$currentParticipant.contact.display_name}
+                  </td>
+                </tr>
+              {/if}
+              <tr>
+                <td colspan="2" {$valueStyle}>
+                  <table>
+                    <tr>
+                      <th>{ts}Item{/ts}</th>
+                      <th>{ts}Qty{/ts}</th>
+                      <th>{ts}Each{/ts}</th>
+                      {if $isShowTax && {contribution.tax_amount|boolean}}
+                        <th>{ts}Subtotal{/ts}</th>
+                        <th>{ts}Tax Rate{/ts}</th>
+                        <th>{ts}Tax Amount{/ts}</th>
+                      {/if}
+                      <th>{ts}Total{/ts}</th>
+                        {if !empty($pricesetFieldsCount)}
+                          <th>{ts}Total Participants{/ts}</th>
+                        {/if}
+                    </tr>
+                    {foreach from=$currentParticipant.line_items item=line}
+                      <tr>
+                        <td {$tdfirstStyle}>{$line.title}</td>
+                        <td {$tdStyle} align="middle">{$line.qty}</td>
+                        <td {$tdStyle}>{$line.unit_price|crmMoney:$currency}</td>
+                          {if $line.tax_rate || $line.tax_amount != ""}
+                            <td>{$line.line_total|crmMoney:$currency}</td>
+                            <td>{$line.tax_rate|string_format:"%.2f"}%</td>
+                            <td>{$line.tax_amount|crmMoney:$currency}</td>
+                          {else}
+                            <td></td>
+                            <td></td>
+                          {/if}
+                        <td {$tdStyle}>
+                            {$line.line_total+$line.tax_amount|crmMoney:$currency}
+                        </td>
+                        {if !empty($pricesetFieldsCount)}
+                          <td {$tdStyle}>{$line.participant_count}</td>
+                        {/if}
+                      </tr>
+                    {/foreach}
+                    {if $isShowTax}
+                      <tr {$participantTotalStyle}>
+                        <td colspan=3>{ts}Participant Total{/ts}</td>
+                        <td colspan=2>{$currentParticipant.totals.total_amount_exclusive|crmMoney}</td>
+                        <td colspan=1>{$currentParticipant.totals.tax_amount|crmMoney}</td>
+                        <td colspan=2>{$currentParticipant.totals.total_amount_inclusive|crmMoney}</td>
+                      </tr>
+                    {/if}
+                  </table>
+                </td>
+              </tr>
+            {/if}
+          {/foreach}
+        {/if}
+        {if !$isShowLineItems}
+          {foreach from=$participants key=index item=currentParticipant}
+            {if $isPrimary || {participant.id} === $currentParticipant.id}
+              {foreach from=$currentParticipant.line_items key=index item=currentLineItem}
+                <tr>
+                  <td {$valueStyle}>
+                    {$currentLineItem.label} {if $isPrimary} - {$currentParticipant.contact.display_name}{/if}
+                  </td>
+                  <td {$valueStyle}>
+                    {$currentLineItem.line_total|crmMoney:$currency}
+                  </td>
+                </tr>
+              {/foreach}
+            {/if}
+          {/foreach}
+       {/if}
+        {if $isShowTax && {contribution.tax_amount|boolean}}
+          <tr>
+            <td {$labelStyle}>
+                {ts}Amount Before Tax:{/ts}
             </td>
-           </tr>
+            <td {$valueStyle}>
+                {if $isPrimary}{contribution.tax_exclusive_amount}{else}{$participant.totals.total_amount_exclusive|crmMoney}{/if}
+            </td>
+          </tr>
+          {if !$isPrimary}
+            {* Use the participant specific tax rate breakdown *}
+            {assign var=taxRateBreakdown value=$participant.tax_rate_breakdown}
+          {/if}
+          {foreach from=$taxRateBreakdown item=taxDetail key=taxRate}
+            <tr>
+              <td {$labelStyle}>{if $taxRate == 0}{ts}No{/ts} {$taxTerm}{else}{$taxTerm} {$taxDetail.percentage}%{/if}</td>
+              <td {$valueStyle}>{$taxDetail.amount|crmMoney:'{contribution.currency}'}</td>
+            </tr>
+          {/foreach}
+        {/if}
+        {if $isShowTax && {contribution.tax_amount|boolean}}
+          <tr>
+            <td {$labelStyle}>
+              {ts}Total Tax Amount{/ts}
+            </td>
+            <td {$valueStyle}>
+              {if $isPrimary}{contribution.tax_amount}{else}{$participant.totals.tax_amount|crmMoney}{/if}
+            </td>
+          </tr>
+        {/if}
+        {if $isPrimary}
+          <tr>
+            <td {$labelStyle}>
+              {ts}Total Amount{/ts}
+            </td>
+            <td {$valueStyle}>
+              {contribution.total_amount} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
+            </td>
+          </tr>
+          {if !empty($pricesetFieldsCount)}
+            <tr>
+              <td {$labelStyle}>
+                  {ts}Total Participants{/ts}</td>
+              <td {$valueStyle}>
+                  {assign var="count" value= 0}
+                  {foreach from=$lineItem item=pcount}
+                      {assign var="lineItemCount" value=0}
+                      {if $pcount neq 'skip'}
+                          {foreach from=$pcount item=p_count}
+                              {assign var="lineItemCount" value=$lineItemCount+$p_count.participant_count}
+                          {/foreach}
+                          {if $lineItemCount < 1}{assign var="lineItemCount" value=1}
+                          {/if}
+                          {assign var="count" value=$count+$lineItemCount}
+                      {/if}
+                  {/foreach}
+                  {$count}
+              </td>
+            </tr>
+          {/if}
+          {if {contribution.is_pay_later|boolean} && {contribution.balance_amount|boolean}}
+            <tr>
+              <td colspan="2" {$labelStyle}>
+                {$pay_later_receipt}
+              </td>
+            </tr>
           {/if}
 
-         <tr>
-          <td colspan="2" {$valueStyle}>
-           <table>
+          {if {participant.register_date|boolean}}
             <tr>
-             <th>{ts}Item{/ts}</th>
-             <th>{ts}Qty{/ts}</th>
-             <th>{ts}Each{/ts}</th>
-             {if $isShowTax && {contribution.tax_amount|boolean}}
-              <th>{ts}SubTotal{/ts}</th>
-              <th>{ts}Tax Rate{/ts}</th>
-              <th>{ts}Tax Amount{/ts}</th>
-             {/if}
-             <th>{ts}Total{/ts}</th>
-       {if !empty($pricesetFieldsCount)}<th>{ts}Total Participants{/ts}</th>{/if}
+              <td {$labelStyle}>
+                {ts}Registration Date{/ts}
+              </td>
+              <td {$valueStyle}>
+                {participant.register_date}
+              </td>
             </tr>
-            {foreach from=$value item=line}
-             <tr>
-              <td>
-        {if $line.html_type eq 'Text'}{$line.label}{else}{$line.field_title} - {$line.label}{/if} {if $line.description}<div>{$line.description|truncate:30:"..."}</div>{/if}
+          {/if}
+
+          {if {contribution.receive_date|boolean}}
+            <tr>
+              <td {$labelStyle}>
+                  {ts}Transaction Date{/ts}
               </td>
-              <td>
-               {$line.qty}
+              <td {$valueStyle}>
+                {contribution.receive_date}
               </td>
-              <td>
-               {$line.unit_price|crmMoney}
+            </tr>
+          {/if}
+
+          {if {contribution.financial_type_id|boolean}}
+            <tr>
+              <td {$labelStyle}>
+                  {ts}Financial Type{/ts}
               </td>
-              {if !empty($dataArray)}
-               <td>
-                {$line.unit_price*$line.qty|crmMoney}
-               </td>
-               {if $line.tax_rate || $line.tax_amount != ""}
-                <td>
-                 {$line.tax_rate|string_format:"%.2f"}%
-                </td>
-                <td>
-                 {$line.tax_amount|crmMoney}
-                </td>
-               {else}
-                <td></td>
-                <td></td>
-               {/if}
-              {/if}
-              <td>
-               {$line.line_total+$line.tax_amount|crmMoney}
+              <td {$valueStyle}>
+                {contribution.financial_type_id:label}
               </td>
-        {if !empty($pricesetFieldsCount)}
-        <td>
-    {$line.participant_count}
+            </tr>
+          {/if}
+
+          {if {contribution.trxn_id|boolean}}
+            <tr>
+              <td {$labelStyle}>
+                  {ts}Transaction #{/ts}
               </td>
+              <td {$valueStyle}>
+                {contribution.trxn_id}
+              </td>
+            </tr>
+          {/if}
+
+          {if {contribution.payment_instrument_id|boolean} && {contribution.paid_amount|boolean}}
+            <tr>
+              <td {$labelStyle}>
+                  {ts}Paid By{/ts}
+              </td>
+              <td {$valueStyle}>
+                  {contribution.payment_instrument_id:label}
+              </td>
+            </tr>
+          {/if}
+
+          {if {contribution.check_number|boolean}}
+            <tr>
+              <td {$labelStyle}>
+                  {ts}Check Number{/ts}
+              </td>
+              <td {$valueStyle}>
+                {contribution.check_number}
+              </td>
+            </tr>
+          {/if}
+
+          {if !empty($billingName)}
+            <tr>
+              <th {$headerStyle}>
+                {ts}Billing Name and Address{/ts}
+              </th>
+            </tr>
+            <tr>
+              <td colspan="2" {$valueStyle}>
+                {$billingName}<br/>
+                {$address|nl2br}
+              </td>
+            </tr>
+          {/if}
+
+          {if !empty($credit_card_type)}
+            <tr>
+              <th {$headerStyle}>
+                {ts}Credit Card Information{/ts}
+              </th>
+            </tr>
+            <tr>
+              <td colspan="2" {$valueStyle}>
+                {$credit_card_type}<br/>
+                {$credit_card_number}<br/>
+                {ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}
+              </td>
+            </tr>
+          {/if}
         {/if}
-             </tr>
-            {/foreach}
-           </table>
-          </td>
-         </tr>
-        {/if}
-       {/foreach}
-       {if !empty($dataArray)}
-        {if $totalAmount and $totalTaxAmount}
-        <tr>
-         <td {$labelStyle}>
-          {ts}Amount Before Tax:{/ts}
-         </td>
-         <td {$valueStyle}>
-          {$totalAmount-$totalTaxAmount|crmMoney}
-         </td>
-        </tr>
-        {/if}
-        {foreach from=$dataArray item=value key=priceset}
-          <tr>
-           {if $priceset || $priceset == 0}
-            <td>&nbsp;{$taxTerm} {$priceset|string_format:"%.2f"}%</td>
-            <td>&nbsp;{$value|crmMoney:$currency}</td>
-           {/if}
-          </tr>
-        {/foreach}
-       {/if}
-      {/if}
-
-      {if !empty($amount) && !$lineItem}
-       {foreach from=$amount item=amnt key=level}
-        <tr>
-         <td colspan="2" {$valueStyle}>
-          {$amnt.amount|crmMoney} {$amnt.label}
-         </td>
-        </tr>
-       {/foreach}
-      {/if}
-      {if {contribution.tax_amount|boolean}}
-       <tr>
-        <td {$labelStyle}>
-         {ts}Total Tax Amount{/ts}
-        </td>
-        <td {$valueStyle}>
-          {contribution.tax_amount}
-        </td>
-       </tr>
-      {/if}
-      {if {event.is_monetary|boolean}}
-       {if {contribution.balance_amount|boolean}}
-         <tr>
-           <td {$labelStyle}>{ts}Total Paid{/ts}</td>
-           <td {$valueStyle}>
-             {contribution.paid_amount} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
-           </td>
-          </tr>
-          <tr>
-           <td {$labelStyle}>{ts}Balance{/ts}</td>
-           <td {$valueStyle}>{contribution.balance_amount}</td>
-         </tr>
-        {else}
-         <tr>
-           <td {$labelStyle}>{ts}Total Amount{/ts}</td>
-           <td {$valueStyle}>
-             {contribution.total_amount} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
-           </td>
-         </tr>
-       {/if}
-       {if !empty($pricesetFieldsCount)}
-     <tr>
-       <td {$labelStyle}>
-   {ts}Total Participants{/ts}</td>
-       <td {$valueStyle}>
-   {assign var="count" value= 0}
-         {foreach from=$lineItem item=pcount}
-         {assign var="lineItemCount" value=0}
-         {if $pcount neq 'skip'}
-           {foreach from=$pcount item=p_count}
-           {assign var="lineItemCount" value=$lineItemCount+$p_count.participant_count}
-           {/foreach}
-           {if $lineItemCount < 1}
-           assign var="lineItemCount" value=1}
-           {/if}
-           {assign var="count" value=$count+$lineItemCount}
-         {/if}
-         {/foreach}
-   {$count}
-       </td>
-     </tr>
-     {/if}
-     {if {contribution.is_pay_later|boolean} && {contribution.balance_amount|boolean}}
-        <tr>
-         <td colspan="2" {$labelStyle}>
-          {$pay_later_receipt}
-         </td>
-        </tr>
-       {/if}
-
-       {if {participant.register_date|boolean}}
-        <tr>
-         <td {$labelStyle}>
-          {ts}Registration Date{/ts}
-         </td>
-         <td {$valueStyle}>
-           {participant.register_date}
-         </td>
-        </tr>
-       {/if}
-
-       {if {contribution.receive_date|boolean}}
-        <tr>
-         <td {$labelStyle}>
-          {ts}Transaction Date{/ts}
-         </td>
-         <td {$valueStyle}>
-           {contribution.receive_date}
-         </td>
-        </tr>
-       {/if}
-
-       {if {contribution.financial_type_id|boolean}}
-        <tr>
-         <td {$labelStyle}>
-          {ts}Financial Type{/ts}
-         </td>
-         <td {$valueStyle}>
-           {contribution.financial_type_id:label}
-         </td>
-        </tr>
-       {/if}
-
-       {if {contribution.financial_trxn_id|boolean}}
-        <tr>
-         <td {$labelStyle}>
-          {ts}Transaction #{/ts}
-         </td>
-         <td {$valueStyle}>
-           {contribution.financial_trxn_id}
-         </td>
-        </tr>
-       {/if}
-
-       {if {contribution.payment_instrument_id|boolean}}
-        <tr>
-         <td {$labelStyle}>
-          {ts}Paid By{/ts}
-         </td>
-         <td {$valueStyle}>
-           {contribution.payment_instrument_id:label}
-         </td>
-        </tr>
-       {/if}
-
-       {if {contribution.check_number|boolean}}
-        <tr>
-         <td {$labelStyle}>
-          {ts}Check Number{/ts}
-         </td>
-         <td {$valueStyle}>
-           {contribution.check_number}
-         </td>
-        </tr>
-       {/if}
-
-       {if !empty($billingName)}
-        <tr>
-         <th {$headerStyle}>
-          {ts}Billing Name and Address{/ts}
-         </th>
-        </tr>
-        <tr>
-         <td colspan="2" {$valueStyle}>
-          {$billingName}<br />
-          {$address|nl2br}
-         </td>
-        </tr>
-       {/if}
-
-       {if !empty($credit_card_type)}
-        <tr>
-         <th {$headerStyle}>
-          {ts}Credit Card Information{/ts}
-         </th>
-        </tr>
-        <tr>
-         <td colspan="2" {$valueStyle}>
-          {$credit_card_type}<br />
-          {$credit_card_number}<br />
-          {ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}
-         </td>
-        </tr>
-       {/if}
-
-      {/if}
-
      {/if} {* End of conditional section for Paid events *}
 
      {if !empty($customGroup)}

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -216,6 +216,7 @@
                             <td {$tdStyle} align="middle">{$line.qty}</td>
                             <td {$tdStyle}>{$line.unit_price|crmMoney:$currency}</td>
                             {if $line.tax_rate || $line.tax_amount != ""}
+                              <td>{$line.line_total|crmMoney:$currency}</td>
                               <td>{$line.tax_rate|string_format:"%.2f"}%</td>
                               <td>{$line.tax_amount|crmMoney:$currency}</td>
                             {else}


### PR DESCRIPTION
Overview
----------------------------------------
Align financial information in participant offline receipt with online receipt

This brings across all the financial code around displaying line item amounts etc from the online receipt to the offline one. It also adds the same styles.

Before
----------------------------------------
offline receipt code block differs from online one & is broken in different ways 

After
----------------------------------------
Breakage aligned :-) Which is probably mostly a bit of formatting now the leakage should be fixed

![image](https://github.com/civicrm/civicrm-core/assets/336308/e1d1d716-a349-4c0b-b3ad-6a7051abc887)

Technical Details
----------------------------------------
The case for even having online vs offline receipts is kinda weak - I'm trying to make them as much the same as possible

Comments
----------------------------------------
Give the susbtantive code change in event code & receipts around php8 & notices etc in this release I think we should merge this & https://github.com/civicrm/civicrm-core/pull/27479 asap & do a solid round of QA once everything is merged