### PR TITLE
Fix event.location token to include supplemental address details, use in event receipts

### DIFF
--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -177,14 +177,9 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
     if (!Civi::cache('metadata')->has($cacheKey)) {
       $event = Event::get($this->checkPermissions)->addWhere('id', '=', $eventID)
         ->setSelect(array_merge([
-          'loc_block_id.address_id.name',
-          'loc_block_id.address_id.street_address',
-          'loc_block_id.address_id.supplemental_address_1',
-          'loc_block_id.address_id.supplemental_address_2',
-          'loc_block_id.address_id.supplemental_address_3',
-          'loc_block_id.address_id.city',
+          'loc_block_id.address_id.*',
           'loc_block_id.address_id.state_province_id:label',
-          'loc_block_id.address_id.postal_code',
+          'loc_block_id.address_id.country_id:label',
           'loc_block_id.email_id.email',
           'loc_block_id.email_2_id.email',
           'loc_block_id.phone_id.phone',
@@ -209,16 +204,17 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
           'custom.*',
         ], $this->getExposedFields()))
         ->execute()->first();
-      $tokens['location']['text/plain'] = \CRM_Utils_Address::format([
+      $addressValues = [
         'address_name' => $event['loc_block_id.address_id.name'],
-        'street_address' => $event['loc_block_id.address_id.street_address'],
-        'supplemental_address_1' => $event['loc_block_id.address_id.supplemental_address_1'],
-        'supplemental_address_2' => $event['loc_block_id.address_id.supplemental_address_2'],
-        'supplemental_address_3' => $event['loc_block_id.address_id.supplemental_address_3'],
-        'city' => $event['loc_block_id.address_id.city'],
         'state_province' => $event['loc_block_id.address_id.state_province_id:label'],
-        'postal_code' => $event['loc_block_id.address_id.postal_code'],
-      ]);
+        'country' => $event['loc_block_id.address_id.country_id:label'],
+      ];
+      foreach ($event as $key => $value) {
+        if (strpos($key, 'loc_block_id.address_id.') === 0) {
+          $addressValues[str_replace('loc_block_id.address_id.', '', $key)] = $value;
+        }
+      }
+      $tokens['location']['text/plain'] = \CRM_Utils_Address::format($addressValues);
       $tokens['info_url']['text/html'] = \CRM_Utils_System::url('civicrm/event/info', 'reset=1&id=' . $eventID, TRUE, NULL, FALSE, TRUE);
       $tokens['registration_url']['text/html'] = \CRM_Utils_System::url('civicrm/event/register', 'reset=1&id=' . $eventID, TRUE, NULL, FALSE, TRUE);
       $tokens['start_date']['text/html'] = !empty($event['start_date']) ? new DateTime($event['start_date']) : '';

--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -177,7 +177,11 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
     if (!Civi::cache('metadata')->has($cacheKey)) {
       $event = Event::get($this->checkPermissions)->addWhere('id', '=', $eventID)
         ->setSelect(array_merge([
+          'loc_block_id.address_id.name',
           'loc_block_id.address_id.street_address',
+          'loc_block_id.address_id.supplemental_address_1',
+          'loc_block_id.address_id.supplemental_address_2',
+          'loc_block_id.address_id.supplemental_address_3',
           'loc_block_id.address_id.city',
           'loc_block_id.address_id.state_province_id:label',
           'loc_block_id.address_id.postal_code',
@@ -206,7 +210,11 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
         ], $this->getExposedFields()))
         ->execute()->first();
       $tokens['location']['text/plain'] = \CRM_Utils_Address::format([
+        'address_name' => $event['loc_block_id.address_id.name'],
         'street_address' => $event['loc_block_id.address_id.street_address'],
+        'supplemental_address_1' => $event['loc_block_id.address_id.supplemental_address_1'],
+        'supplemental_address_2' => $event['loc_block_id.address_id.supplemental_address_2'],
+        'supplemental_address_3' => $event['loc_block_id.address_id.supplemental_address_3'],
         'city' => $event['loc_block_id.address_id.city'],
         'state_province' => $event['loc_block_id.address_id.state_province_id:label'],
         'postal_code' => $event['loc_block_id.address_id.postal_code'],

--- a/CRM/Utils/Address.php
+++ b/CRM/Utils/Address.php
@@ -55,7 +55,7 @@ class CRM_Utils_Address {
 
     $fullPostalCode = $fields['postal_code'] ?? NULL;
     if (!empty($fields['postal_code_suffix'])) {
-      $fullPostalCode .= "-$fields[postal_code_suffix]";
+      $fullPostalCode .= '-' . $fields['postal_code_suffix'];
     }
 
     // make sure that some of the fields do have values

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -340,11 +340,8 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
       'contribution.balance_amount|boolean:::No',
       'contribution.paid_amount|boolean:::Yes',
       '<p>Test event type - 1</p>event.location:8 Baker Street<br />
+Upstairs<br />
 London,',
-      '$location.address.1.display:<div class="location vcard"><span class="adr"><span class="street-address">8 Baker Street</span><br />
-<span class="extended-address">Upstairs</span><br />
-<span class="locality">London</span>,<br />
-</span></div>',
     ]);
 
     $this->callAPISuccess('Email', 'delete', ['id' => $email['id']]);

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -715,6 +715,7 @@ event.loc_block_id.email_id.email :event@example.com
 event.loc_block_id.phone_id.phone :456 789
 event.description :event description
 event.location :15 Walton St<br />
+up the road<br />
 Emerald City, Maine 90210<br />
 event.info_url :' . CRM_Utils_System::url('civicrm/event/info', NULL, TRUE) . '&reset=1&id=1
 event.registration_url :' . CRM_Utils_System::url('civicrm/event/register', NULL, TRUE) . '&reset=1&id=1

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -52,7 +52,7 @@ class CRM_Utils_TokenConsistencyTest extends CiviUnitTestCase {
     // WORKAROUND: CRM_Event_Tokens copies `civicrm_event` data into metadata cache. That should probably change, but that's a different scope-of-work.
     // `clear()` works around it. This should be removed if that's updated, but it will be safe either way.
     Civi::cache('metadata')->clear();
-
+    $this->revertSetting('mailing_format');
     parent::tearDown();
   }
 
@@ -716,7 +716,8 @@ event.loc_block_id.phone_id.phone :456 789
 event.description :event description
 event.location :15 Walton St<br />
 up the road<br />
-Emerald City, Maine 90210<br />
+Emerald City, Maine 90210-1234<br />
+United States<br />
 event.info_url :' . CRM_Utils_System::url('civicrm/event/info', NULL, TRUE) . '&reset=1&id=1
 event.registration_url :' . CRM_Utils_System::url('civicrm/event/register', NULL, TRUE) . '&reset=1&id=1
 event.pay_later_receipt :Please transfer funds to our bank account.
@@ -1078,7 +1079,9 @@ United States', $tokenProcessor->getRow(0)->render('message'));
       'city' => 'Emerald City',
       'state_province_id:label' => 'Maine',
       'postal_code' => 90210,
+      'postal_code_suffix' => 1234,
     ])->execute()->first()['id'];
+    \Civi::settings()->set('mailing_format', '{contact.street_address}{ }{contact.supplemental_address_1}{ }{contact.supplemental_address_2}{ }{contact.city}{ }{contact.state_province}{ }{contact.postal_code}');
     $phoneID = Phone::create()
       ->setValues(['phone' => '456 789'])
       ->execute()

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -108,9 +108,14 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   protected $tempDirs;
 
   /**
-   * @var CRM_Core_Transaction|null
+   * @var CRM_Core_Transaction
    */
-  private $tx = NULL;
+  private $tx;
+
+  /**
+   * @var array
+   */
+  protected $originalSettings = [];
 
   /**
    * Array of IDs created to support the test.
@@ -333,6 +338,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     $this->renameLabels();
     $this->ensureMySQLMode(['IGNORE_SPACE', 'ERROR_FOR_DIVISION_BY_ZERO', 'STRICT_TRANS_TABLES']);
     putenv('CIVICRM_SMARTY_DEFAULT_ESCAPE=1');
+    $this->originalSettings = \Civi::settings()->all();
   }
 
   /**
@@ -495,6 +501,13 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     }
     unset(CRM_Core_Config::singleton()->userPermissionClass->permissions);
     parent::tearDown();
+  }
+
+  /**
+   * @param string $setting
+   */
+  protected function revertSetting(string $setting): void {
+    \Civi::settings()->set($setting, $this->originalSettings[$setting]);
   }
 
   /**

--- a/tests/templates/message_templates/event_offline_receipt_html.tpl
+++ b/tests/templates/message_templates/event_offline_receipt_html.tpl
@@ -1,2 +1,1 @@
 event.location:{event.location}
-$location.address.1.display:{$location.address.1.display|smarty:nodefaults|nl2br}

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -67,7 +67,7 @@
      {if {event.is_show_location|boolean}}
       <tr>
        <td colspan="2" {$valueStyle}>
-        {$location.address.1.display|nl2br}
+         {event.location}
        </td>
       </tr>
      {/if}

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -45,7 +45,7 @@
 {/if}
 
 {if !empty($isShowLocation)}
-{$location.address.1.display|strip_tags:false}
+{event.location}
 {/if}{*End of isShowLocation condition*}
 
 {if {event.loc_block_id.phone_id.phone|boolean} || {event.loc_block_id.email_id.email|boolean}}

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -80,7 +80,7 @@
         {if !empty($isShowLocation)}
           <tr>
             <td colspan="2" {$valueStyle}>
-              {$location.address.1.display|nl2br}
+              {event.location}
             </td>
           </tr>
         {/if}

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -55,7 +55,7 @@
 {/if}
 
 {if !empty($isShowLocation)}
-{$location.address.1.display|strip_tags:false}
+{event.location}
 {/if}{*End of isShowLocation condition*}
 
 {if {event.loc_block_id.phone_id.phone|boolean} || {event.loc_block_id.email_id.email|boolean}}


### PR DESCRIPTION
Overview
----------------------------------------
Fix event.location token to include supplemental address details, use in event receipts

Before
----------------------------------------
`$location` is notice prone in event receipts & requires a lot of work on the form layer

After
----------------------------------------
`{event.location}` is used. We didn't add this earlier cos I needed to check if losing the vcards mattered but I questioned that via the dev-digest & there was no case made to keep it (& some to remove) - https://lab.civicrm.org/dev/core/-/issues/4366

The only other gap was the missing supplemental field data- which this adds

Technical Details
----------------------------------------

Comments
----------------------------------------
