### PR TITLE
Fix dev/core#4566 by ensuring groupNames are fetched

### DIFF
--- a/ang/crmMailing/EditUnsubGroupCtrl.js
+++ b/ang/crmMailing/EditUnsubGroupCtrl.js
@@ -1,10 +1,12 @@
 (function(angular, $, _) {
 
-  angular.module('crmMailing').controller('EditUnsubGroupCtrl', function EditUnsubGroupCtrl($scope) {
+  angular.module('crmMailing').controller('EditUnsubGroupCtrl', function EditUnsubGroupCtrl($scope, crmMailingLoader) {
     // CRM.crmMailing.groupNames is a global constant - since it doesn't change, we can digest & cache.
     var mandatoryIds = [];
 
     $scope.isUnsubGroupRequired = function isUnsubGroupRequired(mailing) {
+      crmMailingLoader.getGroupNames(mailing);
+
       if (!_.isEmpty(CRM.crmMailing.groupNames)) {
         _.each(CRM.crmMailing.groupNames, function(grp) {
           if (grp.is_hidden == "1") {

--- a/ang/crmMailing/ViewRecipCtrl.js
+++ b/ang/crmMailing/ViewRecipCtrl.js
@@ -1,81 +1,12 @@
 (function(angular, $, _) {
 
-  angular.module('crmMailing').controller('ViewRecipCtrl', function ViewRecipCtrl($scope) {
-    var mids = [];
-    var gids = [];
-    var groupNames = [];
-    var mailings = [];
-    var civimailings = [];
-    var civimails = [];
-
-    function getGroupNames(mailing) {
-      if (-1 == mailings.indexOf(mailing.id)) {
-        mailings.push(mailing.id);
-        _.each(mailing.recipients.groups.include, function(id) {
-          if (-1 == gids.indexOf(id)) {
-            gids.push(id);
-          }
-        });
-        _.each(mailing.recipients.groups.exclude, function(id) {
-          if (-1 == gids.indexOf(id)) {
-            gids.push(id);
-          }
-        });
-        _.each(mailing.recipients.groups.base, function(id) {
-          if (-1 == gids.indexOf(id)) {
-            gids.push(id);
-          }
-        });
-        if (!_.isEmpty(gids)) {
-          CRM.api3('Group', 'get', {'id': {"IN": gids}}).then(function(result) {
-            _.each(result.values, function(grp) {
-              if (_.isEmpty(_.where(groupNames, {id: parseInt(grp.id)}))) {
-                groupNames.push({id: parseInt(grp.id), title: grp.title, is_hidden: grp.is_hidden});
-              }
-            });
-            CRM.crmMailing.groupNames = groupNames;
-            $scope.$parent.crmMailingConst.groupNames = groupNames;
-          });
-        }
-      }
-    }
-
-    function getCiviMails(mailing) {
-      if (-1 == civimailings.indexOf(mailing.id)) {
-        civimailings.push(mailing.id);
-        _.each(mailing.recipients.mailings.include, function(id) {
-          if (-1 == mids.indexOf(id)) {
-            mids.push(id);
-          }
-        });
-        _.each(mailing.recipients.mailings.exclude, function(id) {
-          if (-1 == mids.indexOf(id)) {
-            mids.push(id);
-          }
-        });
-        if (!_.isEmpty(mids)) {
-          CRM.api3('Mailing', 'get', {'id': {"IN": mids}}).then(function(result) {
-            _.each(result.values, function(mail) {
-              if (_.isEmpty(_.where(civimails, {id: parseInt(mail.id)}))) {
-                civimails.push({id: parseInt(mail.id), name: mail.name});
-              }
-            });
-            CRM.crmMailing.civiMails = civimails;
-            $scope.$parent.crmMailingConst.civiMails = civimails;
-          });
-        }
-      }
-    }
+  angular.module('crmMailing').controller('ViewRecipCtrl', function ViewRecipCtrl($scope, crmMailingLoader) {
 
     $scope.getIncludesAsString = function(mailing) {
       var first = true;
       var names = '';
-      if (_.isEmpty(CRM.crmMailing.groupNames)) {
-        getGroupNames(mailing);
-      }
-      if (_.isEmpty(CRM.crmMailing.civiMails)) {
-        getCiviMails(mailing);
-      }
+      crmMailingLoader.getGroupNames(mailing);
+      crmMailingLoader.getCiviMails(mailing);
       _.each(mailing.recipients.groups.include, function(id) {
         var group = _.where(CRM.crmMailing.groupNames, {id: parseInt(id)});
         if (group.length) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#4566](https://lab.civicrm.org/dev/core/-/issues/4566)

Technical Details
----------------------------------------
The problem was that `EditUnsubGroupCtrl` needed `CRM.crmMailing.groupNames` to be fetched, but wasn't doing anything about it. Instead it was passively waiting around for someone else to call for them to be loaded. The only place doing this was `ViewRecipCtrl`, and not consistently. It was working in core but not in Mosaico.

I solved this by moving the loader functions to a service so they could be called from both places.