### PR TITLE
Fix typos in field.tpl

### DIFF
--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -176,7 +176,6 @@ trait CRM_Core_Form_EntityFormTrait {
       $this->entityFields[$index] = array_replace_recursive([
         'template' => '',
         'help' => ['id' => '', 'file' => ''],
-        'pre_html_text' => '',
         'post_html_text' => '',
         'description' => '',
         'documentation_link' => ['page' => '', 'resource' => ''],

--- a/templates/CRM/Core/Form/Field.tpl
+++ b/templates/CRM/Core/Form/Field.tpl
@@ -15,7 +15,7 @@
     {if $action == 2 && array_key_exists('is_add_translate_dialog', $fieldSpec)}{include file='CRM/Core/I18n/Dialog.tpl' table=$entityTable field=$fieldName id=$entityID}{/if}
   </td>
   <td>
-    {if $form.$fieldName.html}{$form.$fieldName.html}{else}{$fieldSpec.place_holder}{/if}{if array_key_exists('post_html', $fieldSpec) && $fieldSpec.post_html_text}{$fieldSpec.post_html_text}{/if}<br />
+    {if $form.$fieldName.html}{$form.$fieldName.html}{else}{$fieldSpec.place_holder}{/if}{if array_key_exists('post_html_text', $fieldSpec) && $fieldSpec.post_html_text}{$fieldSpec.post_html_text}{/if}<br />
     {if $fieldSpec.description}<span class="description">{$fieldSpec.description}</span>{/if}
     {if array_key_exists('documentation_link', $fieldSpec) && $fieldSpec.documentation_link.page}{docURL page=$fieldSpec.documentation_link.page resource=$fieldSpec.documentation_link.resource}{/if}
   </td>

--- a/templates/CRM/Core/Form/Field.tpl
+++ b/templates/CRM/Core/Form/Field.tpl
@@ -15,7 +15,7 @@
     {if $action == 2 && array_key_exists('is_add_translate_dialog', $fieldSpec)}{include file='CRM/Core/I18n/Dialog.tpl' table=$entityTable field=$fieldName id=$entityID}{/if}
   </td>
   <td>
-    {if array_key_exists('pre_html', $fieldSpec) && $fieldSpec.pre_html_text}{$fieldSpec.pre_html_text}{/if}{if $form.$fieldName.html}{$form.$fieldName.html}{else}{$fieldSpec.place_holder}{/if}{if array_key_exists('post_html', $fieldSpec) && $fieldSpec.post_html_text}{$fieldSpec.post_html_text}{/if}<br />
+    {if $form.$fieldName.html}{$form.$fieldName.html}{else}{$fieldSpec.place_holder}{/if}{if array_key_exists('post_html', $fieldSpec) && $fieldSpec.post_html_text}{$fieldSpec.post_html_text}{/if}<br />
     {if $fieldSpec.description}<span class="description">{$fieldSpec.description}</span>{/if}
     {if array_key_exists('documentation_link', $fieldSpec) && $fieldSpec.documentation_link.page}{docURL page=$fieldSpec.documentation_link.page resource=$fieldSpec.documentation_link.resource}{/if}
   </td>


### PR DESCRIPTION
Overview
----------------------------------------
Typos from https://github.com/civicrm/civicrm-core/pull/27590

Before
----------------------------------------
Go to add or edit a profile settings. The "used for" field normally has some extra stuff in it like `[X] CiviEvent [X] CiviContribute` (more on this later - this PR is the first of two or so more PRs on this file and I'm just fixing the simple bug right now).

After
----------------------------------------


Technical Details
----------------------------------------
Note `pre_html_text` is never used in universe so have just removed it.

Comments
----------------------------------------

