### PR TITLE
AdminUI: Fix filtering logs by scheduled job

### DIFF
--- a/ext/civicrm_admin_ui/ang/afsearchScheduledJobsLog.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchScheduledJobsLog.aff.html
@@ -2,12 +2,14 @@
   <div class="btn-group pull-right">
     
     
+    
     <a class="btn btn-primary" ng-href="{{:: crmUrl('civicrm/admin/job', {reset: 1}) }}">
       <i class="crm-i fa-list-alt"/>
       {{:: ts('Scheduled Jobs Listing') }}
     </a>
   
   
+  
   </div>
-  <crm-search-display-table search-name="Scheduled_Jobs_Log" display-name="Scheduled_Jobs_Log_Table_1"></crm-search-display-table>
+  <crm-search-display-table search-name="Scheduled_Jobs_Log" display-name="Scheduled_Jobs_Log_Table_1" filters="{job_id: routeParams.job_id}"></crm-search-display-table>
 </div>

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Scheduled_Jobs.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Scheduled_Jobs.mgd.php
@@ -167,7 +167,7 @@ return [
                   'icon' => 'fa-file-o',
                   'text' => E::ts('View joblog'),
                   'style' => 'default',
-                  'path' => 'civicrm/admin/joblog?jid=[id]&reset=1',
+                  'path' => 'civicrm/admin/joblog#?job_id=[id]',
                   'condition' => [],
                 ],
                 [


### PR DESCRIPTION
Overview
----------------------------------------
Filtering the scheduled job logs by scheduled job did not work - "view joblog" always displayed all jobs.

Before
----------------------------------------
Filter not working

After
----------------------------------------
Filter working

Technical Details
----------------------------------------
Looks like this never got implemented.

Comments
----------------------------------------

