### PR TITLE
Autocomplete - Fix search-by-id for entities without a numeric id

### DIFF
--- a/Civi/Api4/EntitySet.php
+++ b/Civi/Api4/EntitySet.php
@@ -39,6 +39,7 @@ class EntitySet extends Generic\AbstractEntity {
   }
 
   /**
+   * This isn't a "real" entity and doesn't have any fields
    * @return \Civi\Api4\Generic\BasicGetFieldsAction
    */
   public static function getFields($checkPermissions = TRUE) {
@@ -59,6 +60,13 @@ class EntitySet extends Generic\AbstractEntity {
    */
   protected static function getEntityTitle($plural = FALSE) {
     return $plural ? ts('Entity Sets') : ts('Entity Set');
+  }
+
+  public static function getInfo(): array {
+    $info = parent::getInfo();
+    // This isn't a "real" entity and doesn't have any fields, so no primary key
+    $info['primary_key'] = [];
+    return $info;
   }
 
 }

--- a/ext/afform/core/tests/phpunit/Civi/Afform/AfformGetTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/AfformGetTest.php
@@ -72,7 +72,9 @@ class AfformGetTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
   }
 
   public function testAfformAutocomplete(): void {
-    $title = uniqid();
+    // Use a numeric title to test that the "search by id" feature
+    // doesn't kick in for Afforms (which don't have a numeric "id")
+    $title = (string) rand(1000, 999999);
     Afform::create()
       ->addValue('name', $this->formName)
       ->addValue('title', $title)

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -169,7 +169,6 @@ class ConformanceTest extends Api4TestBase implements HookInterface {
     $this->assertNotEmpty($info['type']);
     $this->assertNotEmpty($info['description']);
     $this->assertIsArray($info['primary_key']);
-    $this->assertNotEmpty($info['primary_key']);
     $this->assertMatchesRegularExpression(';^\d\.\d+$;', $info['since']);
     $this->assertContains($info['searchable'], ['primary', 'secondary', 'bridge', 'none']);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#4560](https://lab.civicrm.org/dev/core/-/issues/4560)  and the intermittent failure of `AfformGetTest.testAfformAutocomplete`

Before
----------------------------------------
In CiviMail, cannot search for include or exclude mailings by numbers in their title.

After
----------------------------------------
Fixed