### PR TITLE
SearchKit - Expose Address.proximity filter as Afform search filter

### DIFF
--- a/ext/afform/core/ang/af/fields/Location.html
+++ b/ext/afform/core/ang/af/fields/Location.html
@@ -1,0 +1,8 @@
+<div class="form-inline">
+  <input class="form-control" type="number" ng-model="dataProvider.getFieldData()[$ctrl.fieldName].distance" placeholder="{{:: ts('Distance') }}" >
+  <select class="form-control" ng-model="dataProvider.getFieldData()[$ctrl.fieldName].distance_unit">
+    <option value="km">{{:: ts('Km') }}</option>
+    <option value="miles">{{:: ts('Miles') }}</option>
+  </select>
+  <input class="form-control" ng-model="dataProvider.getFieldData()[$ctrl.fieldName].address" placeholder="{{:: ts('Street, City, State, Country') }}" ng-model-options="{updateOn: 'blur'}" >
+</div>

--- a/tests/phpunit/CRM/Utils/Geocode/TestProvider.php
+++ b/tests/phpunit/CRM/Utils/Geocode/TestProvider.php
@@ -1,6 +1,9 @@
 <?php
 
 class CRM_Utils_Geocode_TestProvider {
+  public const ADDRESS = '600 Pennsylvania Avenue NW, Washington';
+  public const GEO_CODE_1 = '38.897957';
+  public const GEO_CODE_2 = '-77.036560';
 
   public static function format(&$values, $stateName = FALSE) {
     $address = ($values['street_address'] ?? '') . ($values['city'] ?? '');
@@ -18,8 +21,8 @@ class CRM_Utils_Geocode_TestProvider {
   }
 
   public static function getCoordinates($address): array {
-    if (strpos($address, '600 Pennsylvania Avenue NW, Washington') === 0) {
-      return ['geo_code_1' => '38.897957', 'geo_code_2' => '-77.036560'];
+    if (str_starts_with($address, self::ADDRESS)) {
+      return ['geo_code_1' => self::GEO_CODE_1, 'geo_code_2' => self::GEO_CODE_2];
     }
     return [];
   }

--- a/tests/phpunit/api/v4/Action/AddressGetCoordinatesTest.php
+++ b/tests/phpunit/api/v4/Action/AddressGetCoordinatesTest.php
@@ -43,9 +43,9 @@ class AddressGetCoordinatesTest extends Api4TestBase implements TransactionalInt
   }
 
   public function testGetCoordinatesWhiteHouse(): void {
-    $coordinates = Address::getCoordinates()->setAddress('600 Pennsylvania Avenue NW, Washington, DC, USA')->execute()->first();
-    $this->assertEquals('38.897957', $coordinates['geo_code_1']);
-    $this->assertEquals('-77.036560', $coordinates['geo_code_2']);
+    $coordinates = Address::getCoordinates()->setAddress(\CRM_Utils_Geocode_TestProvider::ADDRESS)->execute()->first();
+    $this->assertEquals(\CRM_Utils_Geocode_TestProvider::GEO_CODE_1, $coordinates['geo_code_1']);
+    $this->assertEquals(\CRM_Utils_Geocode_TestProvider::GEO_CODE_2, $coordinates['geo_code_2']);
   }
 
   public function testGetCoordinatesNoAddress(): void {


### PR DESCRIPTION
Overview
----------------------------------------
Allows the Address proximity filter to be exposed to a search form.

Before
----------------------------------------
No proximity filter in Afforms

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/2874912/9336b93a-2ce0-46a7-bbf2-e7c3f62c73b8)
