### PR TITLE
Remove unused place_holder

### DIFF
--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -179,7 +179,6 @@ trait CRM_Core_Form_EntityFormTrait {
         'post_html_text' => '',
         'description' => '',
         'documentation_link' => ['page' => '', 'resource' => ''],
-        'place_holder' => '',
       ], $fields);
     }
     $this->assign('entityFields', $this->entityFields);

--- a/CRM/Member/Form/MembershipType.php
+++ b/CRM/Member/Form/MembershipType.php
@@ -53,7 +53,8 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
       'auto_renew' => [
         'name' => 'auto_renew',
         'options' => CRM_Core_SelectValues::memberAutoRenew(),
-        'place_holder' => ts('You will need to select and configure a supported payment processor (currently Authorize.Net, PayPal Pro, or PayPal Website Standard) in order to offer automatically renewing memberships.'),
+        // Note this doesn't get used currently because the template has its own code for this field. Note also the documentation link that you see in the template is added later here down below.
+        'description' => ts('You will need to select and configure a supported payment processor (currently Authorize.Net, PayPal Pro, or PayPal Website Standard) in order to offer automatically renewing memberships.'),
       ],
       'duration_interval' => [
         'name' => 'duration_interval',
@@ -99,7 +100,7 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
 
     if (!CRM_Financial_BAO_PaymentProcessor::hasPaymentProcessorSupporting(['Recurring'])) {
       $this->entityFields['auto_renew']['not-auto-addable'] = TRUE;
-      $this->entityFields['auto_renew']['documentation_link'] = ['page' => 'user/contributions/payment-processors'];
+      $this->entityFields['auto_renew']['documentation_link'] = ['page' => 'user/contributions/payment-processors', 'resource' => ''];
     }
   }
 

--- a/templates/CRM/Core/Form/Field.tpl
+++ b/templates/CRM/Core/Form/Field.tpl
@@ -15,7 +15,7 @@
     {if $action == 2 && array_key_exists('is_add_translate_dialog', $fieldSpec)}{include file='CRM/Core/I18n/Dialog.tpl' table=$entityTable field=$fieldName id=$entityID}{/if}
   </td>
   <td>
-    {if $form.$fieldName.html}{$form.$fieldName.html}{else}{$fieldSpec.place_holder}{/if}{if array_key_exists('post_html_text', $fieldSpec) && $fieldSpec.post_html_text}{$fieldSpec.post_html_text}{/if}<br />
+    {if $form.$fieldName.html}{$form.$fieldName.html}{/if}{if array_key_exists('post_html_text', $fieldSpec) && $fieldSpec.post_html_text}{$fieldSpec.post_html_text}{/if}<br />
     {if array_key_exists('description', $fieldSpec) && $fieldSpec.description}<span class="description">{$fieldSpec.description}</span>{/if}
     {if array_key_exists('documentation_link', $fieldSpec) && $fieldSpec.documentation_link.page}{docURL page=$fieldSpec.documentation_link.page resource=$fieldSpec.documentation_link.resource}{/if}
   </td>


### PR DESCRIPTION
Overview
----------------------------------------
Avoid php notices

Before
----------------------------------------
place_holder can give notices but it's only ever set in one place in universe, and then doesn't actually get used.

To see this text, disable all your payment processors and then visit the add new membership type form. Note also that if you edit the place_holder text before the PR nothing changes on screen.

After
----------------------------------------
No actual change since it isn't used, but metadata updated in case it ever does get used.

Technical Details
----------------------------------------
The membershiptype.tpl template has its own code for displaying the auto_renew field, so the metadata isn't used, but even if it was, it doesn't need this special feature.

Comments
----------------------------------------

