### PR TITLE
php notices for "description"

### DIFF
--- a/templates/CRM/Core/Form/Field.tpl
+++ b/templates/CRM/Core/Form/Field.tpl
@@ -16,7 +16,7 @@
   </td>
   <td>
     {if $form.$fieldName.html}{$form.$fieldName.html}{else}{$fieldSpec.place_holder}{/if}{if array_key_exists('post_html_text', $fieldSpec) && $fieldSpec.post_html_text}{$fieldSpec.post_html_text}{/if}<br />
-    {if $fieldSpec.description}<span class="description">{$fieldSpec.description}</span>{/if}
+    {if array_key_exists('description', $fieldSpec) && $fieldSpec.description}<span class="description">{$fieldSpec.description}</span>{/if}
     {if array_key_exists('documentation_link', $fieldSpec) && $fieldSpec.documentation_link.page}{docURL page=$fieldSpec.documentation_link.page resource=$fieldSpec.documentation_link.resource}{/if}
   </td>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
Go to e.g. Adminster - CiviContribute - CiviContribute Component Settings.
Warnings about "description".

After
----------------------------------------


Technical Details
----------------------------------------
Yes I'm using array_key_exists. So when reviewing:
* Check for typos
* Check that it handles empty properly
* Check that '0' is handled sensibly if appropriate (although in this case that would be a silly description field)

Comments
----------------------------------------

