### PR TITLE
Remove weird `<br>` tag on clear buttons on custom radio fields

### DIFF
--- a/templates/CRM/Custom/Form/Edit/CustomField.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomField.tpl
@@ -34,7 +34,7 @@
       {/foreach}
 
       {if $element.html_type == 'Radio' and $element.is_required == 0}
-        <br /><a href="#" class="crm-hover-button crm-clear-link" title="{ts}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
+        <a href="#" class="crm-hover-button crm-clear-link" title="{ts}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
       {/if}
     </td>
   </tr>


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
1. Create a radio custom field that is not required and give it an options-per-line.
2. The clear button shows underneath and it looks kinda weird:
3. 
<img width="197" alt="br" src="https://github.com/civicrm/civicrm-core/assets/2967821/2c646656-7909-49d3-ad7c-990f68e5fdeb">


After
----------------------------------------
One less br.

Technical Details
----------------------------------------
I don't think this was intentional, and @monishdeb makes a reference to removing it in the [lab ticket](https://lab.civicrm.org/dev/core/-/issues/1821#note_77747) during initial review, but then it happened to end up being in the final PR anyway.

Comments
----------------------------------------
If you set an options per line that matches the number of options, you still get a br, which is arguably a different bug, but you can avoid that one by just changing the options per line. You can't avoid this one.