### PR TITLE
allow showing detailed error messages from AJAX

### DIFF
--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -137,7 +137,7 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
       $status = $statusMap[get_class($e)] ?? 500;
       // Send error code (but don't overwrite success code if there are multiple calls and one was successful)
       $this->httpResponseCode = $this->httpResponseCode ?: $status;
-      if (CRM_Core_Permission::check('view debug output')) {
+      if (CRM_Core_Permission::check('view debug output') || ($e->getErrorData()['show_detailed_error'] ?? FALSE)) {
         $response['error_code'] = $e->getCode();
         $response['error_message'] = $e->getMessage();
         if (!empty($params['debug'])) {


### PR DESCRIPTION
Overview
----------------------------------------
When AJAX requests throw an error (e.g. on Afform) and the user doesn't have the "View Debug Output" permission, they get a generic "Sorry an error occurred" message.

This is unhelpful when you want to display a user-facing validation error.  This PR is a conversation piece - is a flag to show the detailed error the correct solution?

Relevant PRs/discussions:
https://lab.civicrm.org/dev/core/-/issues/4174
https://github.com/civicrm/civicrm-core/pull/25533
https://lab.civicrm.org/extensions/stripe/-/issues/449

Before
----------------------------------------
Users without "View Debug Output" always see "Sorry an error occurred".

After
----------------------------------------
Users can see a detailed error message.

Comments
----------------------------------------
@mlutfy has a [JS-based solution](https://lab.civicrm.org/dev/core/-/issues/4174#note_90982) to a mostly-overlapping problem.

Pinging @JKingsnorth - this is a possible solution to https://lab.civicrm.org/extensions/stripe/-/issues/449.

Here's an example of this code in use: https://lab.civicrm.org/extensions/stripe/-/merge_requests/233