### PR TITLE
POC: keyboard navigation among SearchKit in-place edit fields

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/colType/field.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/field.html
@@ -1,5 +1,17 @@
-<crm-search-display-editable row="row" col="colData" cancel="$ctrl.editing = null;" ng-if="colData.edit && $ctrl.isEditing(rowIndex, colIndex)"></crm-search-display-editable>
-<span ng-if="!colData.links && !$ctrl.isEditing(rowIndex, colIndex)" ng-class="{'crm-editable-enabled': colData.edit && !$ctrl.editing, 'crm-editable-disabled': colData.edit && $ctrl.editing}" ng-click="colData.edit && !$ctrl.editing && ($ctrl.editing = [rowIndex, colIndex])">
+<crm-search-display-editable
+  row="row"
+  col="colData"
+  cancel="$ctrl.lastEdited = $ctrl.editing; $ctrl.editing = null;"
+  ng-if="colData.edit && $ctrl.isEditing(rowIndex, colIndex)">
+</crm-search-display-editable>
+<span
+  ng-if="!colData.links && !$ctrl.isEditing(rowIndex, colIndex)"
+  ng-class="{'crm-editable-enabled': colData.edit && !$ctrl.editing, 'crm-editable-disabled': colData.edit && $ctrl.editing}"
+  ng-click="colData.edit && !$ctrl.editing && ($ctrl.editing = [rowIndex, colIndex])"
+  ng-focus="colData.edit && !$ctrl.editing && !manualFocus && ($ctrl.editing = [rowIndex, colIndex])"
+  ng-attr-tabindex="{{:: $ctrl.zeroIfEditable(colIndex)}}"
+  crm-search-input-focus="colData.edit && $ctrl.wasEditing(rowIndex, colIndex) && !($ctrl.lastEdited = false)"
+>
   <span ng-if="!$ctrl.isArray(colData.val)">
     <i ng-if="colData.icons.left[0]" class="crm-i {{:: colData.icons.left[0] }}"></i>
     {{:: colData.val }}

--- a/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
@@ -11,7 +11,7 @@
       cancel: '&'
     },
     templateUrl: '~/crmSearchDisplay/crmSearchDisplayEditable.html',
-    controller: function($scope, $element, crmApi4, crmStatus) {
+    controller: function($scope, $element, crmApi4, crmStatus, $timeout) {
       var ctrl = this,
         initialValue,
         col;
@@ -38,6 +38,15 @@
           }
           else if (e.key === 'Enter') {
             $scope.$apply(() => ctrl.save());
+          }
+          else if (e.key === 'Tab') {
+            // Prevent the user from tabbing outside the in-place-edit form
+            var focusBeforeTab = $(':focus');
+            $timeout(function () {
+              if ($(':focus').closest('crm-search-display-editable').length === 0) {
+                focusBeforeTab.trigger('focus');
+              }
+            });
           }
         });
 

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -201,6 +201,12 @@
       },
       isEditing: function(rowIndex, colIndex) {
         return this.editing && this.editing[0] === rowIndex && this.editing[1] === colIndex;
+      },
+      wasEditing: function(rowIndex, colIndex) {
+        return this.lastEdited && this.lastEdited[0] === rowIndex && this.lastEdited[1] === colIndex;
+      },
+      zeroIfEditable: function (colIndex) {
+        return this.settings.columns[colIndex].editable ? "0" : undefined;
       }
     };
   });

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputFocus.directive.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputFocus.directive.js
@@ -1,0 +1,37 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('crmSearchTasks').directive('crmSearchInputFocus', function($timeout) {
+    return {
+      link: function(scope, element, attrs) {
+        const e = $(element[0]);
+
+        var focusOnElement = function() {
+          scope.manualFocus = true;
+          e.trigger('focus');
+        };
+
+        var removeFocus = function () {
+          e.trigger('blur');
+        };
+
+        var endManualFocus = function () {
+          scope.manualFocus = false;
+        };
+
+        scope.$watch(attrs.crmSearchInputFocus, function(flag) {
+          if(flag === true) {
+            $timeout(focusOnElement).then(endManualFocus);
+          }
+        });
+
+        scope.$watch(attrs.crmSearchInputBlinkFocus, function(flag) {
+          if(flag === true) {
+            $timeout(focusOnElement).then(removeFocus).then(endManualFocus);
+          }
+        });
+      }
+    };
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/text.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/text.html
@@ -1,5 +1,5 @@
 <div class="form-group" ng-if="!$ctrl.isMulti()" >
-  <input type="text" class="form-control" ng-model="$ctrl.value" ng-required="!$ctrl.field.nullable">
+  <input type="text" class="form-control" ng-model="$ctrl.value" ng-required="!$ctrl.field.nullable" crm-search-input-focus="true">
 </div>
 <div class="form-group" ng-if="$ctrl.isMulti()" >
   <input class="form-control" ng-model="$ctrl.value" ng-required="!$ctrl.field.nullable" crm-ui-select="{multiple: true, tags: [], tokenSeparators: [','], formatNoMatches: ''}" ng-list>


### PR DESCRIPTION
Overview
----------------------------------------
Proof of concept: using the Tab key to move between in-place-edit fields in SearchKit.

Before
----------------------------------------
You had to use a mouse click to initiate "edit mode" for each field in a SearchKit display.

After
----------------------------------------
You can navigate from field to field using Tab/Shift-Tab; "edit mode" opens when you tab onto a field.

Proof of concept only -- there are plenty of rough edges.

![keynav](https://github.com/civicrm/civicrm-core/assets/385812/9911f278-cc12-4b7a-b795-aef4118aa7f2)
