### PR TITLE
dev/core#4623 Standalone: fix currentPath on AngularJS pages (ex: New Mailing)

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -213,9 +213,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    */
   public static function currentPath() {
     $path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
-    if ($path[0] == '/') {
-      $path = substr($path, 1);
-    }
+    $path = trim($path, '/');
     return $path;
   }
 


### PR DESCRIPTION

Overview
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/4623

Fixes a regression caused by #27040 on AngularJS pages such as New Mailing.

Before
----------------------------------------

Page does not load.

After
----------------------------------------

Page loads.

Technical Details
----------------------------------------

It was returning `civicrm/a/`  instead of `civicrm/a`

h/t @artfulrobot for finding/reporting the issue