### PR TITLE
dev/core#4567 Add upgrade script to mailing-queue-table alter

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSixtySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtySeven.php
@@ -85,6 +85,11 @@ class CRM_Upgrade_Incremental_php_FiveSixtySeven extends CRM_Upgrade_Incremental
       FOREIGN KEY (`job_id`)
       REFERENCES `civicrm_mailing_job`(`id`) ON DELETE SET NULL
     ', [], FALSE, FALSE, FALSE, FALSE);
+      CRM_Core_DAO::executeQuery('
+UPDATE  civicrm_mailing_event_queue q
+INNER JOIN civicrm_mailing_job job ON job.id = q.job_id
+SET q.mailing_id = job.mailing_id, q.is_test=job.is_test
+WHERE q.mailing_id IS NULL');
     }
     catch (\Civi\Core\Exception\DBQueryException $e) {
       throw new CRM_Core_Exception(


### PR DESCRIPTION
Overview
----------------------------------------
Add upgrade script to mailing-queue-table alter

Before
----------------------------------------
We had merged the addition of the mailing_id & is_test fields - but not the backfill

After
----------------------------------------
Backfill added

Technical Details
----------------------------------------
We have discussed adding code to allow the upgrade part to be done in batches - but also putting it in in the normal 'do this upgrade' way & we can add the batching after as seems needed.

I did some timings.... the 2 alter queries take around 35 minutes between them on 50m rows. The update takes around 19 minutes

```
Start 12.25 - end 12.40

ALTER TABLE civicrm_mailing_event_queue MODIFY job_id int unsigned null comment 'Mailing Job',
ADD COLUMN mailing_id int(10) unsigned DEFAULT NULL COMMENT 'Related mailing. Used for reporting on mailing success, if present.',
ADD CONSTRAINT FOREIGN KEY (`mailing_id`)
REFERENCES `civicrm_mailing` (`id`) ON DELETE SET NULL,
ADD COLUMN is_test tinyint(4) NOT NULL DEFAULT 0,
DROP FOREIGN KEY FK_civicrm_mailing_event_queue_job_id;

Start 12.40 to 13.00
ALTER TABLE `civicrm_mailing_event_queue`
ADD CONSTRAINT `FK_civicrm_mailing_event_queue_job_id`
FOREIGN KEY (`job_id`)
REFERENCES `civicrm_mailing_job`(`id`) ON DELETE SET NULL;

ALTER TABLE `dev_civicrm`.log_civicrm_group ADD   `cache_fill_took` double DEFAULT NULL COMMENT 'Seconds taken to fill smart group cache, not always related to cache_date'
UPDATE  civicrm_mailing_event_queue q
 INNER JOIN civicrm_mailing_job job ON job.id = q.job_id
 SET q.mailing_id = job.mailing_id, q.is_test=job.is_test
 WHERE q.mailing_id IS NULL LIMIT 100000;
Query OK, 100000 rows affected (2.523 sec)
Rows matched: 100000  Changed: 100000  Warnings: 0


UPDATE  civicrm_mailing_event_queue q
INNER JOIN civicrm_mailing_job job ON job.id = q.job_id
SET q.mailing_id = job.mailing_id, q.is_test=job.is_test
WHERE q.mailing_id IS NULL LIMIT 1000000;
Query OK, 1000000 rows affected (34.565 sec)


UPDATE  civicrm_mailing_event_queue q
INNER JOIN civicrm_mailing_job job ON job.id = q.job_id
SET q.mailing_id = job.mailing_id, q.is_test=job.is_test
WHERE q.mailing_id IS NULL LIMIT 5000000;

Query OK, 5000000 rows affected (3 min 21.613 sec)
Rows matched: 5000000  Changed: 5000000  Warnings: 0

UPDATE  civicrm_mailing_event_queue q
INNER JOIN civicrm_mailing_job job ON job.id = q.job_id
SET q.mailing_id = job.mailing_id, q.is_test=job.is_test
WHERE q.mailing_id IS NULL;
Query OK, 43894676 rows affected (19 min 12.085 sec)
```

Comments
----------------------------------------
