### PR TITLE
Afform - Scan core ang/afform directory

### DIFF
--- a/ext/afform/core/CRM/Afform/AfformScanner.php
+++ b/ext/afform/core/CRM/Afform/AfformScanner.php
@@ -60,6 +60,9 @@ class CRM_Afform_AfformScanner {
       }
     }
 
+    // Scan core ang/afform directory
+    $this->appendFilePaths($paths, Civi::paths()->getPath('[civicrm.root]/ang/afform'), 'civicrm');
+    // Scan uploads/files directory
     $this->appendFilePaths($paths, $this->getSiteLocalPath(), '');
 
     if ($this->isUseCachedPaths()) {


### PR DESCRIPTION
Overview
----------------------------------------
Small commit split off from #27610 which I hope will be merged soon (ahem), but for now this is holding up other projects like https://lab.civicrm.org/dev/core/-/issues/4484 so if it's easier then let's merge this one first.

Before
----------------------------------------
Only extensions and user files can define Afforms.

After
----------------------------------------
CiviCRM core can define Afforms.

Notes
-----------
To keep things organized, I put them in the `civicrm/ang/afform` directory rather than cluttering the base-level `civicrm/ang` directory.

Comments
-------
I was a little surprised to see that AfformScanner doesn't recurse into sub-directories. Tough to organize your files that way, but that can be a task for another day.