### PR TITLE
Remove es6 polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -202,9 +202,6 @@
         "path": "bower_components/es-module-shims/dist/es-module-shims.js",
         "_comment": "See also https://github.com/guybedford/es-module-shims/. MIT license."
       },
-      "es6-promise": {
-        "url": "https://github.com/components/es6-promise/archive/v4.2.4.zip"
-      },
       "ext-greenwich-bootstrap3": {
         "url": "https://github.com/twbs/bootstrap-sass/archive/v{$version}.zip",
         "path": "ext/greenwich/extern/bootstrap3",

--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -125,10 +125,5 @@
     functions: []
   };
 
-  // Load polyfill
-  if (!('Promise' in window)) {
-    CRM.loadScript(CRM.config.resourceBase + 'bower_components/es6-promise/es6-promise.auto.min.js');
-  }
-
 })(jQuery);
 {/literal}


### PR DESCRIPTION
Overview
----------------------------------------
Well it's been 4 years since [we added this one polyfill](https://github.com/civicrm/civicrm-core/pull/13955) for ES6, and in the meantime we're now using ES6 code all over the place, so if a browser doesn't support ES6 it's going to crash for a lot more reasons than this one function.