### PR TITLE
CiviMail - Speed up generation of VERP URLs

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1017,12 +1017,14 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       $verp['reply'] = "\"{$this->from_name}\" <{$this->from_email}>";
     }
 
+    // Generating URLs is expensive, so we only call it once for each of these 5 URLs.
+    $genericURL = CRM_Utils_System::url('civicrm/mailing/genericUrlPath', "reset=1&jid={$job_id}&qid={$event_queue_id}&h={$hash}", TRUE, NULL, TRUE, TRUE);
     $urls = [
-      'forward' => CRM_Utils_System::url('civicrm/mailing/forward', "reset=1&jid={$job_id}&qid={$event_queue_id}&h={$hash}", TRUE, NULL, TRUE, TRUE),
-      'unsubscribeUrl' => CRM_Utils_System::url('civicrm/mailing/unsubscribe', "reset=1&jid={$job_id}&qid={$event_queue_id}&h={$hash}", TRUE, NULL, TRUE, TRUE),
-      'resubscribeUrl' => CRM_Utils_System::url('civicrm/mailing/resubscribe', "reset=1&jid={$job_id}&qid={$event_queue_id}&h={$hash}", TRUE, NULL, TRUE, TRUE),
-      'optOutUrl' => CRM_Utils_System::url('civicrm/mailing/optout', "reset=1&jid={$job_id}&qid={$event_queue_id}&h={$hash}", TRUE, NULL, TRUE, TRUE),
-      'subscribeUrl' => CRM_Utils_System::url('civicrm/mailing/subscribe', 'reset=1', TRUE, NULL, TRUE, TRUE),
+      'forward' => str_replace('genericUrlPath', 'forward', $genericURL),
+      'unsubscribeUrl' => str_replace('genericUrlPath', 'unsubscribe', $genericURL),
+      'resubscribeUrl' => str_replace('genericUrlPath', 'resubscribe', $genericURL),
+      'optOutUrl' => str_replace('genericUrlPath', 'optout', $genericURL),
+      'subscribeUrl' => str_replace('genericUrlPath', 'subscribe', $genericURL),
     ];
 
     $headers = [


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/4626

Overview
----------------------------------------
Generating URLs on Drupal 8+ is extremely expensive.  This PR significantly cuts the amount of time to generate a mailing.

Before
----------------------------------------
Slower mailings.

After
----------------------------------------
25% reduction in time needed for mailings.
