### PR TITLE
Test to check order by contact_sub_type

### DIFF
--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -21,6 +21,7 @@ namespace api\v4\Action;
 
 use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
+use Civi\Api4\ContactType;
 use Civi\Api4\Relationship;
 use Civi\Test\TransactionalInterface;
 
@@ -70,7 +71,7 @@ class ContactGetTest extends Api4TestBase implements TransactionalInterface {
    public function testGetWithOrderBy(): void {
     $last_name = uniqid('GetWithOrderByTest');
 
-	ContactType::create(FALSE)
+	  ContactType::create(FALSE)
         ->addValue('name', 'Membre')
         ->addValue('label', '1.Actif')
         ->addValue('parent_id.name', 'Individual')
@@ -85,42 +86,42 @@ class ContactGetTest extends Api4TestBase implements TransactionalInterface {
         ->addValue('label', '3.Soutien')
         ->addValue('parent_id.name', 'Individual')
         ->execute();
-	ContactType::create(FALSE)
+	  ContactType::create(FALSE)
         ->addValue('name', 'Employ_')
         ->addValue('label', '5.Employé')
         ->addValue('parent_id.name', 'Individual')
         ->execute();
-	ContactType::create(FALSE)
+	  ContactType::create(FALSE)
         ->addValue('name', 'DCD')
         ->addValue('label', '0.Décédé')
         ->addValue('parent_id.name', 'Individual')
         ->execute();
 
-	$bob = Contact::create()
+	  $bob = Contact::create()
       ->setValues(['first_name' => 'Bob', 'last_name' => $last_name, 'contact_sub_type' => 'Membre'])
       ->execute()->first();
 
-	$jan = Contact::create()
+	  $jan = Contact::create()
       ->setValues(['first_name' => 'Jan', 'last_name' => $last_name, 'contact_sub_type' => 'Proche'])
       ->execute()->first();
 
-	$dan = Contact::create()
+	  $dan = Contact::create()
       ->setValues(['first_name' => 'Dan', 'last_name' => $last_name, 'contact_sub_type' => 'Soutien'])
       ->execute()->first();
 
-	$joe = Contact::create()
+	  $joe = Contact::create()
       ->setValues(['first_name' => 'Joe', 'last_name' => $last_name, 'contact_sub_type' => 'MembreEmploy_'])
       ->execute()->first();
 
-	$eli = Contact::create()
+	  $eli = Contact::create()
       ->setValues(['first_name' => 'Eli', 'last_name' => $last_name, 'contact_sub_type' => 'DCDMembre'])
       ->execute()->first();
 
-	$yan = Contact::create()
+	  $yan = Contact::create()
       ->setValues(['first_name' => 'Yan', 'last_name' => $last_name, 'contact_sub_type' => ''])
       ->execute()->first();
 
-	$contacts = \Civi\Api4\Contact::get(TRUE)
+	  $contacts = \Civi\Api4\Contact::get(TRUE)
 	  ->addSelect('id', 'contact_type', 'contact_sub_type', 'contact_sub_type:label')
 	  ->addWhere('contact_type', '=', 'Individual')
 	  ->addOrderBy('contact_sub_type:label', 'ASC')

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -59,6 +59,88 @@ class ContactGetTest extends Api4TestBase implements TransactionalInterface {
     $this->assertContains($del['id'], $contacts->column('id'));
   }
 
+  /**
+   * Test ordering of contact by contact_sub_type when field
+   * contains more than one type and contact_type label and name 
+   * are different enough to get sorted in different order.
+   *
+   * 
+   */
+
+   public function testGetWithOrderBy(): void {
+    $last_name = uniqid('GetWithOrderByTest');
+
+	ContactType::create(FALSE)
+        ->addValue('name', 'Membre')
+        ->addValue('label', '1.Actif')
+        ->addValue('parent_id.name', 'Individual')
+        ->execute();
+    ContactType::create(FALSE)
+        ->addValue('name', 'Proche')
+        ->addValue('label', '2.Proche')
+        ->addValue('parent_id.name', 'Individual')
+        ->execute();
+    ContactType::create(FALSE)
+        ->addValue('name', 'Soutien')
+        ->addValue('label', '3.Soutien')
+        ->addValue('parent_id.name', 'Individual')
+        ->execute();
+	ContactType::create(FALSE)
+        ->addValue('name', 'Employ_')
+        ->addValue('label', '5.Employé')
+        ->addValue('parent_id.name', 'Individual')
+        ->execute();
+	ContactType::create(FALSE)
+        ->addValue('name', 'DCD')
+        ->addValue('label', '0.Décédé')
+        ->addValue('parent_id.name', 'Individual')
+        ->execute();
+
+	$bob = Contact::create()
+      ->setValues(['first_name' => 'Bob', 'last_name' => $last_name, 'contact_sub_type' => 'Membre'])
+      ->execute()->first();
+
+	$jan = Contact::create()
+      ->setValues(['first_name' => 'Jan', 'last_name' => $last_name, 'contact_sub_type' => 'Proche'])
+      ->execute()->first();
+
+	$dan = Contact::create()
+      ->setValues(['first_name' => 'Dan', 'last_name' => $last_name, 'contact_sub_type' => 'Soutien'])
+      ->execute()->first();
+
+	$joe = Contact::create()
+      ->setValues(['first_name' => 'Joe', 'last_name' => $last_name, 'contact_sub_type' => 'MembreEmploy_'])
+      ->execute()->first();
+
+	$eli = Contact::create()
+      ->setValues(['first_name' => 'Eli', 'last_name' => $last_name, 'contact_sub_type' => 'DCDMembre'])
+      ->execute()->first();
+
+	$yan = Contact::create()
+      ->setValues(['first_name' => 'Yan', 'last_name' => $last_name, 'contact_sub_type' => ''])
+      ->execute()->first();
+
+	$contacts = \Civi\Api4\Contact::get(TRUE)
+	  ->addSelect('id', 'contact_type', 'contact_sub_type', 'contact_sub_type:label')
+	  ->addWhere('contact_type', '=', 'Individual')
+	  ->addOrderBy('contact_sub_type:label', 'ASC')
+	  ->setLimit(10)
+	  ->execute();
+
+	foreach ($contacts as $contact) {
+	  // do something
+	}
+
+    $msg = '';
+    try {
+//      $limit2->single();
+    }
+    catch (\CRM_Core_Exception $e) {
+      $msg = $e->getMessage();
+    }
+}
+
+
   public function testGetWithLimit(): void {
     $last_name = uniqid('getWithLimitTest');
 

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -22,12 +22,14 @@ namespace api\v4\Action;
 use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
 use Civi\Api4\ContactType;
+use Civi\Api4\Email;
 use Civi\Api4\Relationship;
 use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
+
 class ContactGetTest extends Api4TestBase implements TransactionalInterface {
 
   public function testGetDeletedContacts(): void {
@@ -62,85 +64,151 @@ class ContactGetTest extends Api4TestBase implements TransactionalInterface {
 
   /**
    * Test ordering of contact by contact_sub_type when field
-   * contains more than one type and contact_type label and name 
+   * contains more than one type and contact_type label and name
    * are different enough to get sorted in different order.
    *
-   * 
+   *
    */
-
-   public function testGetWithOrderBy(): void {
-    $last_name = uniqid('GetWithOrderByTest');
-
-	  ContactType::create(FALSE)
-        ->addValue('name', 'Membre')
-        ->addValue('label', '1.Actif')
+  public function testGetWithOrderBy(): void {
+ 
+    // Test dataset #1 : Contact sub type name, label
+    $CntctType = array(0=>array('Membre', '1.Actif'),
+                       1=>array('Proche', '2.Proche'),
+                       2=>array('Soutien', '3.Soutien'),
+                       3=>array('Employ_', '5.Employé'),
+                       4=>array('DCD', '0.Décédé'));
+    
+    //Print ("\nCreating contact sub type\n");
+    foreach ($CntctType as $CntctT) {
+      //print ($CntctT[0] . " : " . $CntctT[1] . "\n");
+      ContactType::create(FALSE)
+        ->addValue('name', $CntctT[0])
+        ->addValue('label', $CntctT[1])
         ->addValue('parent_id.name', 'Individual')
         ->execute();
-    ContactType::create(FALSE)
-        ->addValue('name', 'Proche')
-        ->addValue('label', '2.Proche')
-        ->addValue('parent_id.name', 'Individual')
-        ->execute();
-    ContactType::create(FALSE)
-        ->addValue('name', 'Soutien')
-        ->addValue('label', '3.Soutien')
-        ->addValue('parent_id.name', 'Individual')
-        ->execute();
-	  ContactType::create(FALSE)
-        ->addValue('name', 'Employ_')
-        ->addValue('label', '5.Employé')
-        ->addValue('parent_id.name', 'Individual')
-        ->execute();
-	  ContactType::create(FALSE)
-        ->addValue('name', 'DCD')
-        ->addValue('label', '0.Décédé')
-        ->addValue('parent_id.name', 'Individual')
-        ->execute();
+    }
 
-	  $bob = Contact::create()
-      ->setValues(['first_name' => 'Bob', 'last_name' => $last_name, 'contact_sub_type' => 'Membre'])
-      ->execute()->first();
+    //Print ("\nSort contact sub type array on label\n");
+    // Sort contact sub type multidimensional array on label
+    usort($CntctType, fn($a, $b) => $a[1] <=> $b[1]);
 
-	  $jan = Contact::create()
-      ->setValues(['first_name' => 'Jan', 'last_name' => $last_name, 'contact_sub_type' => 'Proche'])
-      ->execute()->first();
+    // Query Contact sub type, order by label
+	  $QRcontactTypes = \Civi\Api4\ContactType::get(TRUE)
+      ->addSelect('name', 'label', 'parent_id.name')
+      ->addWhere('parent_id.name', '=', 'Individual')
+      ->addOrderBy('label', 'ASC')
+      ->setLimit(5)
+      ->execute();
+	
+	  $this->assertCount(5, $QRcontactTypes);
+ 
+    //Print ("\nAssert sorted query results equals sorted dataset #1 array\n");
+    $CntctT = reset ($CntctType);
+    foreach ($QRcontactTypes as $contactType) {
+      //print ($contactType['name'] . " = " . $CntctT[0] . " : ");
+      //print ($contactType['label'] . " = " . $CntctT[1] . "\n");
+      $this->assertEquals($contactType['name'], $CntctT[0]);
+      $this->assertEquals($contactType['label'], $CntctT[1]);
+      $CntctT = next($CntctType);
+	  }
+	  //print ("\n" );
+    
+    // Test dataset #2 : Contact first_name, contact_sub_type:label
+    $CntctData2 = array(0=>array('Bob2', ['1.Actif']),
+                        1=>array('Jan2', ['2.Proche']),
+                        2=>array('Dan2', ['3.Soutien']),
+                        3=>array('Joe2', ['5.Employé','1.Actif']),
+                        4=>array('Eli2', ['0.Décédé','1.Actif']),
+                        5=>array('Yan2', []));
+              
+    Print ("\nCreating contact using dataset #2\n");
+    $last_name = "Series2";
+    foreach ($CntctData2 as $Cntct) {
+      print ($Cntct[0] . " : ");
+      $ind = Contact::create()
+              ->setValues(['first_name' => $Cntct[0], 'last_name' => $last_name])
+              ->execute()->first();
+      if ($Cntct[1]) {
+        foreach ($Cntct[1] as $CntctSubL) {
+          print ($CntctSubL . "  "); 
+        }
+        Contact::update()
+          ->addValue('contact_sub_type:label', $Cntct[1])
+          ->addWhere('id', '=', $ind['id'])
+          ->execute();
+      }
+      print ("\n");
+    }
+        
+    Print ("\nQuery contact, order by contact_sub_type:label\n");
+    $QRContacts2 = \Civi\Api4\Contact::get(TRUE)
+      ->addSelect('id', 'contact_type', 'contact_sub_type', 'contact_sub_type:label', 'first_name', 'last_name')
+      ->addWhere('contact_type', '=', 'Individual')
+      ->addWhere('last_name', '=', 'Series2')
+      ->addOrderBy('contact_sub_type:label', 'ASC')
+      ->setLimit(10)
+      ->execute();
 
-	  $dan = Contact::create()
-      ->setValues(['first_name' => 'Dan', 'last_name' => $last_name, 'contact_sub_type' => 'Soutien'])
-      ->execute()->first();
+    $this->assertCount(6, $QRContacts2);
 
-	  $joe = Contact::create()
-      ->setValues(['first_name' => 'Joe', 'last_name' => $last_name, 'contact_sub_type' => 'MembreEmploy_'])
-      ->execute()->first();
+    Print ("\nPrint query results\n");
+    foreach ($QRContacts2 as $contact) {
+      print ($contact['first_name'] . " : ");
+	    if ($contact['contact_sub_type']) {
+        foreach ($contact['contact_sub_type:label'] as $contactLabel) {
+          print ($contactLabel . "  ");
+       }
+      }
+	    print ("\n");
+    }
 
-	  $eli = Contact::create()
-      ->setValues(['first_name' => 'Eli', 'last_name' => $last_name, 'contact_sub_type' => 'DCDMembre'])
-      ->execute()->first();
+    //print ("\nSort CntcData2 contact_sub_type:label sub array\n");
+    foreach ($CntctData2 as &$contact) {
+	    if ($contact[1]) { sort($contact[1]); }
+    }
 
-	  $yan = Contact::create()
-      ->setValues(['first_name' => 'Yan', 'last_name' => $last_name, 'contact_sub_type' => ''])
-      ->execute()->first();
+    //print ("\nSort CntcData2 on contact_sub_type:label value\n");
+    usort($CntctData2, function($a, $b) {
+      $ara = "";
+      $arb = "";
+      if (array_key_exists(0, $a[1])) { $ara = $a[1][0]; }
+      if (array_key_exists(0, $b[1])) { $arb = $b[1][0]; }
+      return $ara <=> $arb;
+    });
 
-	  $contacts = \Civi\Api4\Contact::get(TRUE)
-	  ->addSelect('id', 'contact_type', 'contact_sub_type', 'contact_sub_type:label')
-	  ->addWhere('contact_type', '=', 'Individual')
-	  ->addOrderBy('contact_sub_type:label', 'ASC')
-	  ->setLimit(10)
-	  ->execute();
+    Print ("\nSorted dataset #2\n");
+    foreach ($CntctData2 as $Cntct) {
+      print ($Cntct[0] . " : ");
+      if ($Cntct[1]) {
+        foreach ($Cntct[1] as $CntctSubL) {
+          print ($CntctSubL . "  "); 
+        }
+      }
+      print ("\n");
+    }
 
-	foreach ($contacts as $contact) {
-	  // do something
-	}
-
+    Print ("\nAssert contact query results equals sorted dataset #2 array\n");
+    $Cntct = reset ($CntctData2);
+    foreach ($QRContacts2 as $QRcontact) {
+      $stCn = "NULL";
+      $stQr = "NULL";
+      if (array_key_exists(0, $Cntct[1])) { $stCn = $Cntct[1][0]; }
+      if ($QRcontact['contact_sub_type:label']) { $stQr = $QRcontact['contact_sub_type:label'][0]; } 
+      $this->assertEquals($QRcontact['first_name'], $Cntct[0]);
+      $this->assertEquals($stQR, $stCn);
+      print ($QRcontact['first_name'] . " : " . $stQr . " = " . $Cntct[0] . " : " . $stCn . "\n");
+      $Cntct = next($CntctData2);
+	  }
+	
     $msg = '';
     try {
-//      $limit2->single();
+      //  $limit2->single();
     }
+
     catch (\CRM_Core_Exception $e) {
       $msg = $e->getMessage();
     }
-}
-
+  }
 
   public function testGetWithLimit(): void {
     $last_name = uniqid('getWithLimitTest');


### PR DESCRIPTION
Overview
----------------------------------------
_Test on ordering Contact by contact_sub_type label field .   https://chat.civicrm.org/civicrm/pl/xwcwwif8ztbq78te1th9pjqy8e_

Before
----------------------------------------
_N/A_

After
----------------------------------------
_N/A_

Technical Details
----------------------------------------
_This a code snippet to reproduce a problem with query to pull contact and ordering them by the contact sub type label.  It currently does not work when the field contains multiples sub type and the sub type name and label have a different sorting position.  I.e. different beginning characters._

Comments
----------------------------------------
_As discusse with Coleman in the FormBuilder channel_
