### PR TITLE
[REF] Refactor replacement of current_domain to work for CSS rules as…

### DIFF
--- a/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
+++ b/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
@@ -112,6 +112,7 @@ trait ArrayQueryActionTrait {
    * @throws \Civi\API\Exception\NotImplementedException
    */
   public static function filterCompare(array $row, array $condition, int $index = NULL): bool {
+    $condition = self::replaceCurrentDomainCondition($condition);
     $value = $row[$condition[0]] ?? NULL;
     $operator = $condition[1];
     $expected = $condition[2] ?? NULL;
@@ -252,6 +253,19 @@ trait ArrayQueryActionTrait {
       $values = array_slice($values, $this->getOffset() ?: 0, $this->getLimit() ?: NULL);
     }
     return $values;
+  }
+
+  private static function replaceCurrentDomainCondition(array $condition): array {
+    // Convert the conditional value of 'current_domain' into an actual value that filterCompare can work with
+    if ($condition[2] === 'current_domain') {
+      if (str_ends_with($condition[0], ':label') !== FALSE) {
+        $condition[2] = \CRM_Core_BAO_Domain::getDomain()->name;
+      }
+      else {
+        $condition[2] = \CRM_Core_Config::domainID();
+      }
+    }
+    return $condition;
   }
 
 }

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -644,15 +644,6 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       }
       return \CRM_Core_Permission::check($permissions) == ($op !== '!=');
     }
-    // Convert the conditional value of 'current_domain' into an actual value that filterCompare can work with
-    if ($item['condition'][2] === 'current_domain') {
-      if (str_ends_with($item['condition'][0], ':label') !== FALSE) {
-        $item['condition'][2] = \CRM_Core_BAO_Domain::getDomain()->name;
-      }
-      else {
-        $item['condition'][2] = \CRM_Core_Config::domainID();
-      }
-    }
     return self::filterCompare($data, $item['condition']);
   }
 


### PR DESCRIPTION
… well as menu links in search kit

Overview
----------------------------------------
This moves the replacement of `curernt_domain` in filter conditions into a centralised place so that it doesn't just work for menu links in search displays but row and column css rules and icons potentially

ping @colemanw 