### PR TITLE
Switch new queue listener to be a conventional hook

### DIFF
--- a/CRM/Queue/Queue.php
+++ b/CRM/Queue/Queue.php
@@ -9,8 +9,6 @@
  +--------------------------------------------------------------------+
  */
 
-use Civi\Core\Event\GenericHookEvent;
-
 /**
  * A queue is an object (usually backed by some persistent data store)
  * which stores a list of tasks or messages for use by other processes.
@@ -71,12 +69,7 @@ abstract class CRM_Queue_Queue {
         $status = 'paused';
       }
     }
-    $event = GenericHookEvent::create([
-      'status' => &$status,
-      'queue_name' => $this->_name,
-      'queue_spec' => $this->queueSpec,
-    ]);
-    \Civi::dispatcher()->dispatch('civi.queue.isActive', $event);
+    CRM_Utils_Hook::queueActive($status, $this->getName(), $this->queueSpec);
     // Note in future we might want to consider whether an upgrade is in progress.
     // Should we set the setting at that point?
     return ($status === 'active');

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -3000,6 +3000,33 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * Should queue processing proceed.
+   *
+   * This hook is called when a background process attempts to claim an item from
+   * the queue to process. A hook could alter the status from 'active' to denote
+   * that the server is busy & hence no item should be claimed and processed at
+   * this time.
+   *
+   * @param string $status
+   *   This will be set to active. It is recommended hooks change it to 'paused'
+   *   to prevent queue processing (although currently any value other than active
+   *   is treated as inactive 'paused')
+   * @param string $queueName
+   *   The name of the queue. Equivalent to civicrm_queue.name
+   * @param array $queueSpecification
+   *   Array of information about the queue loaded from civicrm_queue.
+   *
+   * @see https://docs.civicrm.org/dev/en/latest/framework/queues/
+   */
+  public static function queueActive(string &$status, string $queueName, array $queueSpecification): void {
+    $null = NULL;
+    self::singleton()->invoke(['status', 'queueName', 'queueSpecification'], $status,
+      $queueName, $queueSpecification, $null, $null, $null,
+      'civicrm_queueActive'
+    );
+  }
+
+  /**
    * Fire `hook_civicrm_queueRun_{$runner}`.
    *
    * This event only fires if these conditions are met:


### PR DESCRIPTION

Overview
----------------------------------------
Switch new queue listener to be a conventional hook

Per https://chat.civicrm.org/civicrm/pl/q3uzbd59sbdgixohqsiyq8r7ar:


Before
----------------------------------------
Newly merged hook is a symfony listener

After
----------------------------------------
Hook is a traditional hook

Technical Details
----------------------------------------
Per the discussion - we have considered symonfy style as internal / unsupported for external use whereas this is intended for external use. Hence we agreed to swap convention

Comments
----------------------------------------
We possibly need to think more about this topic - e.g we have encouraged use of the token hooks externally but they are actually 'internal' listeners. This issue punts resolving that issue
