### PR TITLE
Add since to deprecated tag

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1554,7 +1554,8 @@ abstract class CRM_Utils_Hook {
 
   /**
    * Deprecated: use hook_civicrm_selectWhereClause instead.
-   * @deprecated
+   * @deprecated since 5.67 will be removed around 5.85
+   * .
    * @param array &$noteValues
    */
   public static function notePrivacy(&$noteValues) {


### PR DESCRIPTION
Overview
----------------------------------------
@colemanw I've been using since with deprecated tags lately - the end date is a bit arbitrary but I kinda start from 12 months & go up or down from there (in this case up cos it's a hook but not that much cos it's a silly hook)