### PR TITLE
PHPStorm - Add PHPSTORM_META about test functions

### DIFF
--- a/tools/extensions/phpstorm/Civi/PhpStorm/Api3Generator.php
+++ b/tools/extensions/phpstorm/Civi/PhpStorm/Api3Generator.php
@@ -17,18 +17,6 @@ class Api3Generator extends AutoService implements EventSubscriberInterface {
   }
 
   public function generate() {
-    /*
-     * FIXME: PHPSTORM_META doesn't seem to support compound dynamic arguments
-     * so even if you give it separate lists like
-     * ```
-     * expectedArguments(\civicrm_api4('Contact'), 1, 'a', 'b');
-     * expectedArguments(\civicrm_api4('Case'), 1, 'c', 'd');
-     * ```
-     * It doesn't differentiate them and always offers a,b,c,d for every entity.
-     * If they ever fix that upstream we could fetch a different list of actions per entity,
-     * but for now there's no point.
-     */
-
     $entities = \civicrm_api3('entity', 'get', []);
     $actions = ['create', 'delete', 'get', 'getactions', 'getcount', 'getfield', 'getfields', 'getlist', 'getoptions', 'getrefcount', 'getsingle', 'getunique', 'getvalue', 'replace', 'validate'];
 

--- a/tools/extensions/phpstorm/Civi/PhpStorm/Api4Generator.php
+++ b/tools/extensions/phpstorm/Civi/PhpStorm/Api4Generator.php
@@ -39,6 +39,8 @@ class Api4Generator extends AutoService implements EventSubscriberInterface {
     $builder->registerArgumentsSet('api4Entities', ...$entities);
     $builder->registerArgumentsSet('api4Actions', ...$actions);
     $builder->registerArgumentsSet('api4Properties', ...$properties);
+
+    // Define arguments for core functions
     $builder->addExpectedArguments('\civicrm_api4()', 0, 'api4Entities');
     $builder->addExpectedArguments('\civicrm_api4()', 1, 'api4Actions');
     $builder->addExpectedArguments('\Civi\Api4\Utils\CoreUtil::getBAOFromApiName()', 0, 'api4Entities');
@@ -53,6 +55,14 @@ class Api4Generator extends AutoService implements EventSubscriberInterface {
     $builder->addExpectedArguments('\Civi\Api4\Utils\CoreUtil::checkAccessDelegated()', 0, 'api4Entities');
     $builder->addExpectedArguments('\Civi\Api4\Utils\CoreUtil::checkAccessDelegated()', 1, 'api4Actions');
     $builder->addExpectedArguments('\Civi\API\EntityLookupTrait::define()', 0, 'api4Entities');
+
+    // Define arguments for unit test functions
+    $builder->addExpectedArguments('\Civi\Test\Api4TestTrait::createTestRecord()', 0, 'api4Entities');
+    $builder->addExpectedArguments('\Civi\Test\Api4TestTrait::saveTestRecords()', 0, 'api4Entities');
+    $builder->addExpectedArguments('\Civi\Test\EntityTrait::createTestEntity()', 0, 'api4Entities');
+    $builder->addExpectedArguments('\Civi\Test\EntityTrait::setTestEntity()', 0, 'api4Entities');
+    $builder->addExpectedArguments('\Civi\Test\EntityTrait::setTestEntityID()', 0, 'api4Entities');
+
     $builder->write();
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Makes typing test functions a fraction of a second faster. Totally worth time spent on PR. Don't question.