### PR TITLE
Searchdisplay issue with contact join activity and _ on the end of custom field

### DIFF
--- a/Civi/Api4/Query/SqlExpression.php
+++ b/Civi/Api4/Query/SqlExpression.php
@@ -66,6 +66,26 @@ abstract class SqlExpression {
 
   abstract protected function initialize();
 
+  private static function munge($name, $char = '_', $len = 63) {
+    // Replace all white space and non-alpha numeric with $char
+    // we only use the ascii character set since mysql does not create table names / field names otherwise
+    // CRM-11744
+    $name = preg_replace('/[^a-zA-Z0-9_]+/', $char, trim($name));
+
+    // If there are no ascii characters present.
+    if (!strlen(trim($name, $char))) {
+      $name = \CRM_Utils_String::createRandom($len, \CRM_Utils_String::ALPHANUMERIC);
+    }
+
+    if ($len) {
+      // lets keep variable names short
+      return substr($name, 0, $len);
+    }
+    else {
+      return $name;
+    }
+  }
+
   /**
    * Converts a string to a SqlExpression object.
    *
@@ -80,7 +100,7 @@ abstract class SqlExpression {
   public static function convert(string $expression, $parseAlias = FALSE, $mustBe = []) {
     $as = $parseAlias ? strrpos($expression, ' AS ') : FALSE;
     $expr = $as ? substr($expression, 0, $as) : $expression;
-    $alias = $as ? \CRM_Utils_String::munge(substr($expression, $as + 4), '_', 256) : NULL;
+    $alias = $as ? self::munge(substr($expression, $as + 4), '_', 256) : NULL;
     $bracketPos = strpos($expr, '(');
     $firstChar = substr($expr, 0, 1);
     $lastChar = substr($expr, -1);


### PR DESCRIPTION
Overview
----------------------------------------
Steps:
1. Create a custom field on an activity with an underscore on the end of the name.
2. Create a search with contact joined to activity and grouped by contact ID.
3. See that value of custom field *is* shown on search.
4. Create a searchdisplay for the same.
5. See that value of custom field *is not* shown on search display because the key is wrong (eg. `testfield_label` instead of `testfield__label`.

Before
----------------------------------------
Bizarre failures - stuff is not displayed when you expect it to be.

After
----------------------------------------
Fields display correctly.

Technical Details
----------------------------------------
This is caused because `CRM_Utils_String::munge()` is called and the regex replaces `_:` with `_`.

Comments
----------------------------------------
@colemanw as we discussed in https://chat.civicrm.org/civicrm/pl/p9pupgpho3gt8rx7ko6sqhbu7o
