### PR TITLE
Fix missing participant params regression from #27605

### DIFF
--- a/CRM/Event/Form/EventFees.php
+++ b/CRM/Event/Form/EventFees.php
@@ -73,6 +73,8 @@ class CRM_Event_Form_EventFees {
       $params = ['id' => $form->_pId];
 
       CRM_Event_BAO_Participant::getValues($params, $defaults, $ids);
+      $defaults += $defaults[$form->_pId];
+      unset($defaults[$form->_pId]);
       if ($form->_action == CRM_Core_Action::UPDATE) {
         $discounts = [];
         if (!empty($form->_values['discount'])) {


### PR DESCRIPTION
Before
----------------------------------------
Values from getValues aren't flattened to match the change in #27605.

You can see this by editing a participant with line items and noting the total is missing below Selections.

After
----------------------------------------
Values flattened into array.
