### PR TITLE
Fix Smarty help text block

### DIFF
--- a/CRM/Core/Smarty/plugins/block.htxt.php
+++ b/CRM/Core/Smarty/plugins/block.htxt.php
@@ -32,12 +32,10 @@
  * @return string|null
  *   the string, translated by gettext
  */
-function smarty_block_htxt($params, $text, &$smarty, &$repeat) {
-  if (!$repeat && $params['id'] == $smarty->_tpl_vars['id']) {
+function smarty_block_htxt($params, $text, $smarty, &$repeat) {
+  if (!$repeat && $params['id'] == $smarty->getTemplateVars('id')) {
     $smarty->assign('override_help_text', !empty($params['override']));
     return $text;
   }
-  else {
-    return NULL;
-  }
+  return NULL;
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix Smarty help text block

Before
----------------------------------------
Accessing ->_tplVars directly is deprecated

After
----------------------------------------
fixed

Technical Details
----------------------------------------
There is an open Pr that fixes a bunch of these, but is currently stale. Pulling this out to get it merged as it is one of the most commonly hit

Comments
----------------------------------------
