### PR TITLE
Replace smarty.get with assigned snippet_type in tpl

### DIFF
--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -132,6 +132,8 @@ class CRM_Core_Page {
     // in 'body.tpl
     'suppressForm',
     'beginHookFormElements',
+    // This is checked in validate.tpl
+    'snippet_type',
   ];
 
   /**

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -136,6 +136,7 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
       'cacheCleanup' => CRM_Utils_Request::retrieveValue('cacheCleanup', 'Integer'),
       'configReset' => CRM_Utils_Request::retrieveValue('configReset', 'Integer'),
     ]);
+    $this->assign('snippet_type', CRM_Utils_Request::retrieveValue('snippet', 'String'));
 
     $tsLocale = CRM_Core_I18n::getLocale();
     $this->assign('tsLocale', $tsLocale);

--- a/templates/CRM/Form/validate.tpl
+++ b/templates/CRM/Form/validate.tpl
@@ -9,7 +9,7 @@
 *}
 {* Initialize jQuery validate on a form *}
 {* Extra params and functions may be added to the CRM.validate object before this template is loaded *}
-{if empty($crm_form_validate_included) && ((isset($smarty.get.snippet|smarty:nodefaults) && $smarty.get.snippet neq 'json') || !isset($smarty.get.snippet|smarty:nodefaults)) && !empty($form) && !empty($form.formClass)}
+{if empty($crm_form_validate_included) && $snippet_type neq 'json' && !empty($form) && !empty($form.formClass)}
   {assign var=crm_form_validate_included value=1}
   {literal}
   <script type="text/javascript">


### PR DESCRIPTION
Overview
----------------------------------------
Replace smarty.get with assigned snippet_type in tpl

Before
----------------------------------------
`$smarty.get` doesn't play nice with Smarty3

![image](https://github.com/civicrm/civicrm-core/assets/336308/e1e2f299-ba1f-4376-b74c-0a7cfe0307ae)


After
----------------------------------------
It is assigned to the template

![image](https://github.com/civicrm/civicrm-core/assets/336308/20d4c1ce-ce50-455f-af83-242558bc296e)


Technical Details
----------------------------------------

Comments
----------------------------------------