### PR TITLE
Remove unreachable code

### DIFF
--- a/CRM/Event/Selector/Search.php
+++ b/CRM/Event/Selector/Search.php
@@ -337,16 +337,6 @@ class CRM_Event_Selector_Search extends CRM_Core_Selector_Base implements CRM_Co
       $row['campaign'] = $allCampaigns[$result->participant_campaign_id] ?? NULL;
       $row['campaign_id'] = $result->participant_campaign_id;
 
-      // gross hack to show extra information for pending status
-      $statusClass = NULL;
-      if ((isset($row['participant_status_id'])) &&
-        ($statusId = array_search($row['participant_status_id'], $statusTypes))
-      ) {
-        $statusClass = $statusClasses[$statusId];
-      }
-
-      $row['showConfirmUrl'] = $statusClass == 'Pending';
-
       if (!empty($row['participant_is_test'])) {
         $row['participant_status'] = CRM_Core_TestEntity::appendTestText($row['participant_status']);
       }

--- a/templates/CRM/Event/Page/UserDashboard.tpl
+++ b/templates/CRM/Event/Page/UserDashboard.tpl
@@ -39,11 +39,6 @@
                             {/if}
                        </td>
                        <td class="crm-participant-participant_status">{$row.participant_status}</td>
-                       <td class="crm-participant-showConfirmUrl">
-                            {if !empty($row.showConfirmUrl)}
-                                <a href="{crmURL p='civicrm/event/confirm' q="reset=1&participantId=`$row.participant_id`"}">{ts}Confirm Registration{/ts}</a>
-                            {/if}
-                        </td>
                     </tr>
                 {/foreach}
             </table>


### PR DESCRIPTION


Overview
----------------------------------------
Remove unreachable code

Before
----------------------------------------
In 2020 this commit by @mlutfy 
https://github.com/civicrm/civicrm-core/commit/10f289cab793ff8292560eba7d780ec8295a5862 removed the call to get the participant list from the search object and instead replaced it with a call to get it from the v4 api.

In the process confirmEventUrl stopped being assinged to the template and no-one noticed. 

After
----------------------------------------
This removes the traces of it

Technical Details
----------------------------------------

No remaining references

![image](https://github.com/civicrm/civicrm-core/assets/336308/f91571b8-0442-43d6-b991-dfdd777a7cc4)


Comments
----------------------------------------
