### PR TITLE
Update path in civicrm.settings.php.template for smarty3

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -209,9 +209,9 @@ if (!defined('CIVICRM_TEMPLATE_COMPILEDIR')) {
  * and then defining the path to that
  * autoload. file.
  */
-//if (!defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
-//  define('CIVICRM_SMARTY3_AUTOLOAD_PATH', '/my/path/vendor/autoload.php');
-//}
+if (!defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
+// define('CIVICRM_SMARTY3_AUTOLOAD_PATH', $civicrm_root . '/packages/smarty3/vendor/autoload.php');
+}
 
 /**
  * Smarty escape on output.


### PR DESCRIPTION
Overview
----------------------------------------
Update path in civicrm.settings.php.template for smarty3

Before
----------------------------------------
You had to specify the path of the autoload for smarty 3

After
----------------------------------------
As we have merged it to packages we know the path & can make it so they just have to uncomment it

Technical Details
----------------------------------------

Comments
----------------------------------------
