### PR TITLE
Standalone - Change html type to email

### DIFF
--- a/ext/standaloneusers/xml/schema/CRM/Standaloneusers/User.xml
+++ b/ext/standaloneusers/xml/schema/CRM/Standaloneusers/User.xml
@@ -71,7 +71,7 @@
     <length>255</length>
     <comment>Email (e.g. for password resets)</comment>
     <html>
-      <type>Text</type>
+      <type>Email</type>
     </html>
   </field>
 


### PR DESCRIPTION
Overview
----------------------------------------
Email = Email

Comments
--------
Per fast-evolving discussion on https://chat.civicrm.org/civicrm/channels/standalone I'm not sure if this table will be around much longer, but wherever we put this field - this is the correct input type :)