### PR TITLE
dev/core#4630 add Bypass permission for SK autocomplete displays

### DIFF
--- a/Civi/Api4/Generic/AutocompleteAction.php
+++ b/Civi/Api4/Generic/AutocompleteAction.php
@@ -133,7 +133,9 @@ class AutocompleteAction extends AbstractAction {
     $this->loadSearchDisplay();
 
     // Pass-through this parameter
-    $this->display['acl_bypass'] = !$this->getCheckPermissions();
+    if (!isset($this->display['acl_bypass'])) {
+      $this->display['acl_bypass'] = !$this->getCheckPermissions();
+    }
 
     $keyField = $this->getKeyField();
     $displayFields = $this->getDisplayFields();

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplayHeader.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplayHeader.html
@@ -2,18 +2,7 @@
   <div class="form-inline">
     <label for="crm-search-admin-display-label">{{:: ts('Name') }} <span class="crm-marker">*</span></label>
     <input id="crm-search-admin-display-label" type="text" class="form-control" ng-model="$ctrl.display.label" required placeholder="{{:: ts('Untitled') }}"/>
-    <div class="form-control" ng-class="{disabled: !$ctrl.parent.isSuperAdmin}" title="{{:: $ctrl.parent.aclBypassHelp }}">
-      <label>
-        <input type="checkbox" ng-if="$ctrl.parent.isSuperAdmin" ng-model="$ctrl.display.acl_bypass" style="display: none;">
-        <i class="crm-i fa-lock text-success" ng-if="!$ctrl.display.acl_bypass"></i>
-        <i class="crm-i fa-unlock text-danger" ng-if="$ctrl.display.acl_bypass"></i>
-        <span>{{ $ctrl.display.acl_bypass ? ts('Bypass Permissions') : ts('Enforce Permissions') }}</span>
-      </label>
-    </div>
-    <div class="help-block bg-warning" ng-if="$ctrl.display.acl_bypass">
-      <i class="crm-i fa-unlock"></i>
-      {{:: ts('Anyone who can view this display will be able to see all results, regardless of their permission level.') }}
-    </div>
+    <div ng-include="'~/crmSearchAdmin/crmSearchAdminDisplayPemissions.html'"></div>
   </div>
   <div>
     <textarea class="form-control" placeholder="{{:: ts('Description (shown above)') }}" ng-model="$ctrl.display.settings.description"></textarea>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplayPemissions.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplayPemissions.html
@@ -1,0 +1,12 @@
+<div class="form-control" ng-class="{disabled: !$ctrl.parent.isSuperAdmin}" title="{{:: $ctrl.parent.aclBypassHelp }}">
+  <label>
+    <input type="checkbox" ng-if="$ctrl.parent.isSuperAdmin" ng-model="$ctrl.display.acl_bypass" style="display: none;">
+    <i class="crm-i fa-lock text-success" ng-if="!$ctrl.display.acl_bypass"></i>
+    <i class="crm-i fa-unlock text-danger" ng-if="$ctrl.display.acl_bypass"></i>
+    <span>{{ $ctrl.display.acl_bypass ? ts('Bypass Permissions') : ts('Enforce Permissions') }}</span>
+  </label>
+</div>
+<div class="help-block bg-warning" ng-if="$ctrl.display.acl_bypass">
+  <i class="crm-i fa-unlock"></i>
+  {{:: ts('Anyone who can view this display will be able to see all results, regardless of their permission level.') }}
+</div>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayAutocomplete.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayAutocomplete.html
@@ -1,3 +1,4 @@
+<fieldset ng-include="'~/crmSearchAdmin/crmSearchAdminDisplayPemissions.html'"></fieldset>
 
 <fieldset ng-include="'~/crmSearchAdmin/crmSearchAdminDisplaySort.html'"></fieldset>
 


### PR DESCRIPTION
Overview
----------------------------------------
Searchkit: add Bypass permission to Autocomplete display

Before
----------------------------------------
No UI and no support of SK acl_bypass

After
----------------------------------------
![ksnip_20230929-114157](https://github.com/civicrm/civicrm-core/assets/372004/0d3cc29b-58bc-4749-88c1-31c3497e0e0e)

