### PR TITLE
Clean up event message templates line items

### DIFF
--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -173,10 +173,10 @@
         {if $isShowLineItems}
           {foreach from=$participants key=index item=currentParticipant}
             {if $isPrimary || {participant.id} === $currentParticipant.id}
-              {if $isPrimary && $lineItems|@count GT 1} {* Header for multi participant registration cases. *}
+              {if $isPrimary && ($participants|@count > 1)} {* Header for multi participant registration cases. *}
                 <tr>
                   <td colspan="2" {$labelStyle}>
-                      {ts 1=$currentParticipant.index}Participant %1{/ts} {$currentParticipant.contact.display_name}
+                    {$currentParticipant.contact.display_name}
                   </td>
                 </tr>
               {/if}
@@ -202,13 +202,15 @@
                         <td {$tdfirstStyle}>{$line.title}</td>
                         <td {$tdStyle} align="middle">{$line.qty}</td>
                         <td {$tdStyle}>{$line.unit_price|crmMoney:$currency}</td>
-                          {if $line.tax_rate || $line.tax_amount != ""}
+                          {if $isShowTax && {contribution.tax_amount|boolean}}
                             <td>{$line.line_total|crmMoney:$currency}</td>
-                            <td>{$line.tax_rate|string_format:"%.2f"}%</td>
-                            <td>{$line.tax_amount|crmMoney:$currency}</td>
-                          {else}
-                            <td></td>
-                            <td></td>
+                            {if $line.tax_rate || $line.tax_amount != ""}
+                              <td>{$line.tax_rate|string_format:"%.2f"}%</td>
+                              <td>{$line.tax_amount|crmMoney:$currency}</td>
+                            {else}
+                              <td></td>
+                              <td></td>
+                            {/if}
                           {/if}
                         <td {$tdStyle}>
                             {$line.line_total+$line.tax_amount|crmMoney:$currency}
@@ -218,9 +220,9 @@
                         {/if}
                       </tr>
                     {/foreach}
-                    {if $isShowTax}
+                    {if $isShowTax && $isPrimary && ($participants|@count > 1)}
                       <tr {$participantTotalStyle}>
-                        <td colspan=3>{ts}Participant Total{/ts}</td>
+                        <td colspan=3>{ts 1=$currentParticipant.contact.display_name}Total for %1{/ts}</td>
                         <td colspan=2>{$currentParticipant.totals.total_amount_exclusive|crmMoney}</td>
                         <td colspan=1>{$currentParticipant.totals.tax_amount|crmMoney}</td>
                         <td colspan=2>{$currentParticipant.totals.total_amount_inclusive|crmMoney}</td>
@@ -238,7 +240,7 @@
               {foreach from=$currentParticipant.line_items key=index item=currentLineItem}
                 <tr>
                   <td {$valueStyle}>
-                    {$currentLineItem.label} {if $isPrimary} - {$currentParticipant.contact.display_name}{/if}
+                    {$currentLineItem.label}{if $isPrimary && ($participants|@count > 1)} - {$currentParticipant.contact.display_name}{/if}
                   </td>
                   <td {$valueStyle}>
                     {$currentLineItem.line_total|crmMoney:$currency}

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -186,10 +186,10 @@
             {if $isShowLineItems}
               {foreach from=$participants key=index item=currentParticipant}
                 {if $isPrimary || {participant.id} === $currentParticipant.id}
-                  {if $isPrimary && $lineItems|@count GT 1} {* Header for multi participant registration cases. *}
+                  {if $isPrimary && ($participants|@count > 1)} {* Header for multi participant registration cases. *}
                     <tr>
                       <td colspan="2" {$labelStyle}>
-                        {ts 1=$currentParticipant.index}Participant %1{/ts} {$currentParticipant.contact.display_name}
+                        {$currentParticipant.contact.display_name}
                       </td>
                     </tr>
                   {/if}
@@ -215,13 +215,15 @@
                             <td {$tdfirstStyle}>{$line.title}</td>
                             <td {$tdStyle} align="middle">{$line.qty}</td>
                             <td {$tdStyle}>{$line.unit_price|crmMoney:$currency}</td>
-                            {if $line.tax_rate || $line.tax_amount != ""}
+                            {if $isShowTax && {contribution.tax_amount|boolean}}
                               <td>{$line.line_total|crmMoney:$currency}</td>
-                              <td>{$line.tax_rate|string_format:"%.2f"}%</td>
-                              <td>{$line.tax_amount|crmMoney:$currency}</td>
-                            {else}
-                              <td></td>
-                              <td></td>
+                              {if $line.tax_rate || $line.tax_amount != ""}
+                                <td>{$line.tax_rate|string_format:"%.2f"}%</td>
+                                <td>{$line.tax_amount|crmMoney:$currency}</td>
+                              {else}
+                                <td></td>
+                                <td></td>
+                              {/if}
                             {/if}
                             <td {$tdStyle}>
                               {$line.line_total+$line.tax_amount|crmMoney:$currency}
@@ -231,9 +233,9 @@
                             {/if}
                           </tr>
                         {/foreach}
-                        {if $isShowTax}
+                        {if $isShowTax && $isPrimary && ($participants|@count > 1)}
                           <tr {$participantTotalStyle}>
-                            <td colspan=3>{ts}Participant Total{/ts}</td>
+                            <td colspan=3>{ts 1=$currentParticipant.contact.display_name}Total for %1{/ts}</td>
                             <td colspan=2>{$currentParticipant.totals.total_amount_exclusive|crmMoney}</td>
                             <td colspan=1>{$currentParticipant.totals.tax_amount|crmMoney}</td>
                             <td colspan=2>{$currentParticipant.totals.total_amount_inclusive|crmMoney}</td>
@@ -251,7 +253,7 @@
                   {foreach from=$currentParticipant.line_items key=index item=currentLineItem}
                   <tr>
                     <td {$valueStyle}>
-                      {$currentLineItem.label} {if $isPrimary} - {$currentParticipant.contact.display_name}{/if}
+                      {$currentLineItem.label}{if $isPrimary && ($participants|@count > 1)} - {$currentParticipant.contact.display_name}{/if}
                     </td>
                     <td {$valueStyle}>
                       {$currentLineItem.line_total|crmMoney:$currency}


### PR DESCRIPTION
Overview
----------------------------------------
Follow up to #27624 and others.
Fix line items table when tax.
Also only show participant name when there is more than one participant.
Only show the per-participant tax subtotal if there is more than one participant, show participant name here.
Simplify the `Participant N - Display Name` label, just show the participant name instead.

Before
----------------------------------------
For example, with only one participant
![image](https://github.com/civicrm/civicrm-core/assets/25517556/74d68be7-e8d2-46b0-b424-2ee17173226d)

After
----------------------------------------
Multiple participants price set
<img width="711" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/9d3c085e-c231-4fd4-86e7-2d8b4f016b16">

Single participant price set
<img width="704" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/604027d6-b28c-4a2f-a7bb-dee08bc9fe74">

Multiple quick config
<img width="704" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/58a01487-cb87-4a6f-916d-457a61fc15a9">

Single quick config
<img width="706" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/ee942f6d-734a-4749-b6c7-6f1eb92e0a54">


Comments
----------------------------------------
Column widths and styles could use some clean up (not sure why we are setting fixed pixel widths for some and one is align=middle but others aren't), but that's a project for another day.