### PR TITLE
fix afform getCustomGroupBlocks early return

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Get.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Get.php
@@ -133,7 +133,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
    */
   public static function getCustomGroupBlocks($event) {
     // Early return if blocks are not requested
-    if ($event->getTypes && !in_array('block', $event->getTypes, TRUE)) {
+    if (!isset($event->getTypes) || !in_array('block', $event->getTypes, TRUE)) {
       return;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
On each page load, Afform is adding a bunch of overhead because getCustomGroupBlocks isn't returning early.

Before
----------------------------------------
Longer load times.

After
----------------------------------------
Shorter load times.

Technical Details
----------------------------------------
The comment says "Early return if blocks are not requested" but `$event->getTypes` can be `NULL`, which should also lead to an early return.  Because every page load (and API call!) calls `hook_civicrm_alterMenu`

Comments
----------------------------------------
Couldn't we cache the results of `CRM_Core_Menu::items()` such that we don't need to check it on every page load?