### PR TITLE
Smarty notices & errors, message template screen

### DIFF
--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -151,7 +151,6 @@ trait CRM_Contact_Form_Task_PDFTrait {
     $form->assign('totalSelectedContacts', !is_null($form->_contactIds) ? count($form->_contactIds) : 0);
 
     $form->add('select', 'document_type', ts('Document Type'), CRM_Core_SelectValues::documentFormat());
-
     $documentTypes = implode(',', CRM_Core_SelectValues::documentApplicationType());
     $form->addElement('file', "document_file", 'Upload Document', 'size=30 maxlength=255 accept="' . $documentTypes . '"');
     $form->addUploadElement("document_file");

--- a/templates/CRM/Admin/Form/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Form/MessageTemplates.tpl
@@ -42,7 +42,7 @@
           <td>
             {$form.msg_subject.html|crmAddClass:huge}
             <input class="crm-token-selector big" data-field="msg_subject" />
-            {help id="id-token-subject" tplFile=$tplFile isAdmin=$isAdmin file="CRM/Contact/Form/Task/Email.hlp"}
+            {help id="id-token-subject" tplFile=$tplFile file="CRM/Contact/Form/Task/Email.hlp"}
           </td>
         </tr>
         <tr>
@@ -73,7 +73,7 @@
         <div class="crm-accordion-body">
           <div class="helpIcon" id="helphtml">
             <input class="crm-token-selector big" data-field="msg_html" />
-            {help id="id-token-html" tplFile=$tplFile isAdmin=$isAdmin file="CRM/Contact/Form/Task/Email.hlp"}
+            {help id="id-token-html" tplFile=$tplFile file="CRM/Contact/Form/Task/Email.hlp"}
           </div>
           <div class="clear"></div>
           <div class='html'>

--- a/templates/CRM/Contact/Form/Task/PDFLetterCommon.hlp
+++ b/templates/CRM/Contact/Form/Task/PDFLetterCommon.hlp
@@ -24,13 +24,12 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{php}$this->assign('uploadFormatsSupported', '.' . implode(', .', array_keys(CRM_Utils_PDF_Document::$ooxmlMap)));{/php}
 {htxt id="template"}
   <p>
     {ts}Select a pre-existing template, or upload a document for mail merge.{/ts}
   </p>
   <p>
-    {ts 1=$uploadFormatsSupported}Supported file formats: %1{/ts}
+    {ts 1="docx, odt"}Supported file formats: docx, odt{/ts}
   </p>
 {/htxt}
 


### PR DESCRIPTION


Overview
----------------------------------------
Smarty notices & errors, message template screen

isAdmin is never assigned - or used in the called template so it is removed.

The php block breaks in smarty3 & is moved to the php layer

Before
----------------------------------------
Smarty errors & hard fail with Smarty3

After
----------------------------------------

Technical Details
----------------------------------------

Comments
----------------------------------------
