### PR TITLE
Replace smarty-math with assigned value

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -913,6 +913,7 @@ class CRM_Financial_BAO_Order {
         $lineItem['tax_amount'] = ($taxRate / 100) * $lineItem['line_total'];
       }
       $lineItem['title'] = $this->getLineItemTitle($lineItem);
+      $lineItem['line_total_inclusive'] = $lineItem['line_total'] + $lineItem['tax_amount'];
     }
     return $lineItems;
   }

--- a/xml/templates/message_templates/contribution_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_html.tpl
@@ -97,7 +97,7 @@
               {/if}
             {/if}
             <td>
-             {$line.line_total+$line.tax_amount|crmMoney:'{contribution.currency}'}
+             {$line.line_total_inclusive|crmMoney:'{contribution.currency}'}
             </td>
            </tr>
           {/foreach}

--- a/xml/templates/message_templates/contribution_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_text.tpl
@@ -27,7 +27,7 @@
 {$ts_item|string_format:"%-30s"} {$ts_qty|string_format:"%5s"} {$ts_each|string_format:"%10s"} {if $isShowTax && {contribution.tax_amount|boolean}} {$ts_subtotal|string_format:"%10s"} {$ts_taxRate} {$ts_taxAmount|string_format:"%10s"} {/if} {$ts_total|string_format:"%10s"}
 ----------------------------------------------------------
 {foreach from=$lineItems item=line}
-{capture assign=ts_item}{$line.title}{/capture}{$ts_item|truncate:30:"..."|string_format:"%-30s"} {$line.qty|string_format:"%5s"} {$line.unit_price|crmMoney:'{contribution.currency}'|string_format:"%10s"} {if $isShowTax && {contribution.tax_amount|boolean}}{$line.unit_price*$line.qty|crmMoney:'{contribution.currency}'|string_format:"%10s"} {if $line.tax_rate || $line.tax_amount != ""} {$line.tax_rate|string_format:"%.2f"} %   {$line.tax_amount|crmMoney:'{contribution.currency}'|string_format:"%10s"} {else}                  {/if} {/if}   {$line.line_total+$line.tax_amount|crmMoney:'{contribution.currency}'|string_format:"%10s"}
+{capture assign=ts_item}{$line.title}{/capture}{$ts_item|truncate:30:"..."|string_format:"%-30s"} {$line.qty|string_format:"%5s"} {$line.unit_price|crmMoney:'{contribution.currency}'|string_format:"%10s"} {if $isShowTax && {contribution.tax_amount|boolean}}{$line.unit_price*$line.qty|crmMoney:'{contribution.currency}'|string_format:"%10s"} {if $line.tax_rate || $line.tax_amount != ""} {$line.tax_rate|string_format:"%.2f"} %   {$line.tax_amount|crmMoney:'{contribution.currency}'|string_format:"%10s"} {else}                  {/if} {/if}   {$line.line_total_inclusive|crmMoney:'{contribution.currency}'|string_format:"%10s"}
 {/foreach}
 {/if}
 

--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -71,7 +71,7 @@
                   {/if}
                 {/if}
                 <td>
-                  {$line.line_total+$line.tax_amount|crmMoney:$currency}
+                  {$line.line_total_inclusive|crmMoney:$currency}
                 </td>
               </tr>
             {/foreach}

--- a/xml/templates/message_templates/contribution_online_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_text.tpl
@@ -29,7 +29,7 @@
 {$ts_item|string_format:"%-30s"} {$ts_qty|string_format:"%5s"} {$ts_each|string_format:"%10s"} {if $isShowTax && {contribution.tax_amount|boolean}} {$ts_subtotal|string_format:"%10s"} {$ts_taxRate} {$ts_taxAmount|string_format:"%10s"} {/if} {$ts_total|string_format:"%10s"}
 ----------------------------------------------------------
 {foreach from=$lineItems item=line}
-{capture assign=ts_item}{$line.title}{/capture}{$ts_item|truncate:30:"..."|string_format:"%-30s"} {$line.qty|string_format:"%5s"} {$line.unit_price|crmMoney:$currency|string_format:"%10s"} {if $isShowTax && {contribution.tax_amount|boolean}}{$line.unit_price*$line.qty|crmMoney:$currency|string_format:"%10s"} {if $line.tax_rate || $line.tax_amount != ""}  {$line.tax_rate|string_format:"%.2f"} %  {$line.tax_amount|crmMoney:$currency|string_format:"%10s"} {else}                  {/if}  {/if} {$line.line_total+$line.tax_amount|crmMoney:$currency|string_format:"%10s"}
+{capture assign=ts_item}{$line.title}{/capture}{$ts_item|truncate:30:"..."|string_format:"%-30s"} {$line.qty|string_format:"%5s"} {$line.unit_price|crmMoney:$currency|string_format:"%10s"} {if $isShowTax && {contribution.tax_amount|boolean}}{$line.unit_price*$line.qty|crmMoney:$currency|string_format:"%10s"} {if $line.tax_rate || $line.tax_amount != ""}  {$line.tax_rate|string_format:"%.2f"} %  {$line.tax_amount|crmMoney:$currency|string_format:"%10s"} {else}                  {/if}  {/if} {$line.line_total_inclusive|crmMoney:$currency|string_format:"%10s"}
 {/foreach}
 
 {if $isShowTax && {contribution.tax_amount|boolean}}

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -213,7 +213,7 @@
                             {/if}
                           {/if}
                         <td {$tdStyle}>
-                            {$line.line_total+$line.tax_amount|crmMoney:$currency}
+                            {$line.line_total_inclusive|crmMoney:$currency}
                         </td>
                         {if !empty($pricesetFieldsCount)}
                           <td {$tdStyle}>{$line.participant_count}</td>

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -226,7 +226,7 @@
                               {/if}
                             {/if}
                             <td {$tdStyle}>
-                              {$line.line_total+$line.tax_amount|crmMoney:$currency}
+                              {$line.line_total_inclusive|crmMoney:$currency}
                             </td>
                             {if !empty($pricesetFieldsCount)}
                               <td {$tdStyle}>{$line.participant_count}</td>

--- a/xml/templates/message_templates/membership_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_html.tpl
@@ -122,7 +122,7 @@
                                 <td></td>
                               {/if}
                               <td>
-                                {$line.line_total+$line.tax_amount|crmMoney:'{contribution.currency}'}
+                                {$line.line_total_inclusive|crmMoney:'{contribution.currency}'}
                               </td>
                             {/if}
                             <td>

--- a/xml/templates/message_templates/membership_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_text.tpl
@@ -40,7 +40,7 @@
 --------------------------------------------------------------------------------------------------
 
 {foreach from=$lineItems item=line}
-{line.title} {$line.line_total|crmMoney|string_format:"%10s"}  {if $isShowTax && {contribution.tax_amount|boolean}} {$line.unit_price*$line.qty|crmMoney:'{contribution.currency}'|string_format:"%10s"} {if $line.tax_rate || $line.tax_amount != ""}  {$line.tax_rate|string_format:"%.2f"} %  {$line.tax_amount|crmMoney:'{contribution.currency}'|string_format:"%10s"}  {else}                  {/if}   {$line.line_total+$line.tax_amount|crmMoney|string_format:"%10s"} {/if} {$line.membership.start_date|string_format:"%20s"} {$line.membership.end_date|string_format:"%20s"}
+{line.title} {$line.line_total|crmMoney|string_format:"%10s"}  {if $isShowTax && {contribution.tax_amount|boolean}} {$line.unit_price*$line.qty|crmMoney:'{contribution.currency}'|string_format:"%10s"} {if $line.tax_rate || $line.tax_amount != ""}  {$line.tax_rate|string_format:"%.2f"} %  {$line.tax_amount|crmMoney:'{contribution.currency}'|string_format:"%10s"}  {else}                  {/if}   {$line.line_total_inclusive|crmMoney|string_format:"%10s"} {/if} {$line.membership.start_date|string_format:"%20s"} {$line.membership.end_date|string_format:"%20s"}
 {/foreach}
 
 {if $isShowTax && {contribution.tax_amount|boolean}}


### PR DESCRIPTION
Overview
----------------------------------------
Replace smarty-math with assigned value

Before
----------------------------------------
Smarty 2 & 3 seemed to feel differently about this line

```
$line.line_total+$line.tax_amount
```

Smarty3

![Uploading image.png…]()


After
----------------------------------------
I added `line_total_inclusive` to the line items & used that - this is inline with the proposed addition of it to the schema 
https://lab.civicrm.org/dev/core/-/issues/4378

Technical Details
----------------------------------------
I fixed all templates except membership online - which still have the old `$lineItem` array in use

Comments
----------------------------------------
