### PR TITLE
Switch from html2text to soundasleep/html2text

### DIFF
--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -445,8 +445,7 @@ class CRM_Utils_String {
    */
   public static function htmlToText($html) {
     $token_html = preg_replace('!\{([a-z_.]+)\}!i', 'token:{$1}', $html);
-    $converter = new \Html2Text\Html2Text($token_html, ['do_links' => 'table', 'width' => 75]);
-    $token_text = $converter->getText();
+    $token_text = \Soundasleep\Html2Text::convert($token_html, ['ignore_errors' => TRUE]);
     $text = preg_replace('!token\:\{([a-z_.]+)\}!i', '{$1}', $token_text);
     return $text;
   }

--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,7 @@
     "symfony/polyfill-php80": "^1.0",
     "symfony/polyfill-php81": "^1.0",
     "symfony/polyfill-php82": "^1.0",
-    "html2text/html2text": "^4.3.1",
+    "soundasleep/html2text": "^2.1",
     "psr/container": "~1.0 || ~2.0",
     "ext-fileinfo": "*"
   },
@@ -274,9 +274,6 @@
       "adrienrn/php-mimetyper": {
         "Update gitignore to ensure that sites that manage via git don't miss out on the important db.json file": "https://patch-diff.githubusercontent.com/raw/adrienrn/php-mimetyper/pull/15.patch",
         "Apply patch to fix php8.2 deprecation notice on dynamic property $filename": "https://patch-diff.githubusercontent.com/raw/adrienrn/php-mimetyper/pull/17.patch"
-      },
-      "html2text/html2text": {
-        "Fix deprecation warning in php8.1 on html_entity_decode": "https://raw.githubusercontent.com/civicrm/civicrm-core/e758d20e9f613ca6c4cf652c23d2cd7e5d3af3ce/tools/scripts/composer/html2text_html2_text_php81_deprecation.patch"
       },
       "pear/db": {
         "Apply patch to ensure that MySQLI reporting remains the same in php8.1": "https://patch-diff.githubusercontent.com/raw/pear/DB/pull/13.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "377176179275d0aa4262d031e5bc4559",
+    "content-hash": "d112a69d39ea11b6ad870811b2960200",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -965,47 +965,6 @@
                 }
             ],
             "time": "2023-04-17T16:00:37+00:00"
-        },
-        {
-            "name": "html2text/html2text",
-            "version": "4.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mtibben/html2text.git",
-                "reference": "61ad68e934066a6f8df29a3d23a6460536d0855c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mtibben/html2text/zipball/61ad68e934066a6f8df29a3d23a6460536d0855c",
-                "reference": "61ad68e934066a6f8df29a3d23a6460536d0855c",
-                "shasum": ""
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance",
-                "symfony/polyfill-mbstring": "If you can't install ext-mbstring"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Html2Text\\": [
-                        "src/",
-                        "test/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Converts HTML to formatted plain text",
-            "support": {
-                "issues": "https://github.com/mtibben/html2text/issues",
-                "source": "https://github.com/mtibben/html2text/tree/4.3.1"
-            },
-            "time": "2020-04-16T23:44:31+00:00"
         },
         {
             "name": "laminas/laminas-escaper",
@@ -3413,6 +3372,61 @@
                 "source": "https://github.com/scssphp/scssphp/tree/v1.10.3"
             },
             "time": "2022-05-16T07:22:18+00:00"
+        },
+        {
+            "name": "soundasleep/html2text",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/soundasleep/html2text.git",
+                "reference": "83502b6f8f1aaef8e2e238897199d64f284b4af3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/soundasleep/html2text/zipball/83502b6f8f1aaef8e2e238897199d64f284b4af3",
+                "reference": "83502b6f8f1aaef8e2e238897199d64f284b4af3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "php": "^7.3|^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.9",
+                "phpunit/phpunit": "^7.0|^8.0|^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Soundasleep\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jevon Wright",
+                    "homepage": "https://jevon.org",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A PHP script to convert HTML into a plain text format",
+            "homepage": "https://github.com/soundasleep/html2text",
+            "keywords": [
+                "email",
+                "html",
+                "php",
+                "text"
+            ],
+            "support": {
+                "email": "support@jevon.org",
+                "issues": "https://github.com/soundasleep/html2text/issues",
+                "source": "https://github.com/soundasleep/html2text/tree/2.1.0"
+            },
+            "time": "2023-01-06T09:28:15+00:00"
         },
         {
             "name": "symfony/config",

--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ClickTracker/TextClickTrackerTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ClickTracker/TextClickTrackerTest.php
@@ -45,19 +45,14 @@ class TextClickTrackerTest extends \CiviUnitTestCase {
       '<p><a href=\'tracking(https://sub.example.com/foo.php?whiz=%2Fbang%2F&pie[fruit]=apple)\' rel=\'nofollow\'>Foo</a></p>',
     ];
     $exs[] = [
-      // Messy looking URL, designed to trip-up quote handling
+      // Messy looking URL, designed to trip-up quote handling, no tracking as no http
       '<p><a href="javascript:alert(\'Cheese\')">Foo</a></p>',
-      '<p><a href="tracking(javascript:alert(\'Cheese\'))" rel=\'nofollow\'>Foo</a></p>',
+      '<p><a href="javascript:alert(\'Cheese\')" rel=\'nofollow\'>Foo</a></p>',
     ];
     $exs[] = [
-      // Messy looking URL, designed to trip-up quote handling
+      // Messy looking URL, designed to trip-up quote handling, no tracking as no http
       '<p><a href=\'javascript:alert("Cheese")\'>Foo</a></p>',
-      '<p><a href=\'tracking(javascript:alert("Cheese"))\' rel=\'nofollow\'>Foo</a></p>',
-    ];
-    $exs[] = [
-      // Messy looking URL, funny whitespace
-      '<p><a href="http://example.com/' . "\n" . 'weird">Foo</a></p>',
-      '<p><a href="tracking(http://example.com/' . "\n" . 'weird)" rel=\'nofollow\'>Foo</a></p>',
+      '<p><a href=\'javascript:alert("Cheese")\' rel=\'nofollow\'>Foo</a></p>',
     ];
     $exs[] = [
       // Messy looking URL, funny whitespace

--- a/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
@@ -163,14 +163,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
         // Default header
         "Sample Header for TEXT formatted content.\n" .
         //  body_html, filtered
-        "You can go to Google \\[1\\] or opt out \\[2\\]\\.\n" .
-        "\n" .
-        "\n" .
-        "Links:\n" .
-        "------\n" .
-        "\\[1\\] http://example.net/first\\?cs=[0-9a-f_]+\n" .
-        "\\[2\\] http.*civicrm/mailing/optout.*\n" .
-        "\n" .
+        "You can go to \\[Google\\]\\(http://example.net/first\?cs=[0-9a-f_]+\\) or \\[opt out\\]\\(http.*civicrm/mailing/optout.*\\)\\.\n" .
         // Default footer
         "to unsubscribe: http.*civicrm/mailing/optout" .
         ";",
@@ -217,14 +210,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
       $this->assertMatchesRegularExpression(
         ";" .
         //  body_html, filtered
-        "You can go to Google \\[1\\] or opt out \\[2\\]\\.\n" .
-        "\n" .
-        "\n" .
-        "Links:\n" .
-        "------\n" .
-        "\\[1\\] http.*(extern/url.php|civicrm/mailing/url)(\?|&)u=\d+&qid=\d+\n" .
-        "\\[2\\] http.*civicrm/mailing/optout.*\n" .
-        "\n" .
+        "You can go to \\[Google\\]\\(http.*(extern/url.php|civicrm/mailing/url)(\?|&)u=\d+&qid=\d+\\) or \\[opt out\\]\\(http.*civicrm/mailing/optout.*\\)\\.\n" .
         // Default footer
         "to unsubscribe: http.*civicrm/mailing/optout" .
         ";",
@@ -249,20 +235,20 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
     $cases[0] = [
       '<p><a href="http://example.net/">Foo</a></p>',
       ';<p><a href="http://example\.net/">Foo</a></p>;',
-      ';\\[1\\] http://example\.net/;',
+      ';\\(http://example\.net/\\);',
       ['url_tracking' => 0],
     ];
     $cases[1] = [
       '<p><a href="http://example.net/?id={contact.contact_id}">Foo</a></p>',
       // FIXME: Legacy tracker adds extra quote after URL
       ';<p><a href="http://example\.net/\?id=\d+""?>Foo</a></p>;',
-      ';\\[1\\] http://example\.net/\?id=\d+;',
+      ';\\(http://example\.net/\?id=\d+\\);',
       ['url_tracking' => 0],
     ];
     $cases[2] = [
       '<p><a href="{action.optOutUrl}">Foo</a></p>',
       ';<p><a href="http.*civicrm/mailing/optout.*">Foo</a></p>;',
-      ';\\[1\\] http.*civicrm/mailing/optout.*;',
+      ';\\(http.*civicrm/mailing/optout.*\\);',
       ['url_tracking' => 0],
     ];
     $cases[3] = [
@@ -284,13 +270,13 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
     $cases[5] = [
       '<p><a href="http://example.net/">Foo</a></p>',
       ';<p><a href=[\'"].*(extern/url.php|civicrm/mailing/url)(\?|&amp\\;)u=\d+.*[\'"]>Foo</a></p>;',
-      ';\\[1\\] .*(extern/url.php|civicrm/mailing/url)[\?&]u=\d+.*;',
+      ';\\(.*(extern/url.php|civicrm/mailing/url)[\?&]u=\d+.*\\);',
       ['url_tracking' => 1],
     ];
     $cases['url_trackin_enabled'] = [
       '<p><a href="http://example.net/?id={contact.contact_id}">Foo</a></p>',
       ';<p><a href=[\'"].*(extern/url.php|civicrm/mailing/url)(\?|&amp\\;)u=\d+.*&amp\\;id=\d+.*[\'"]>Foo</a></p>;',
-      ';\\[1\\] .*(extern/url.php|civicrm/mailing/url)[\?&]u=\d+.*&id=\d+.*;',
+      ';\\(.*(extern/url.php|civicrm/mailing/url)[\?&]u=\d+.*&id=\d+.*\\);',
       ['url_tracking' => 1],
     ];
 
@@ -298,7 +284,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
       // It would be redundant/slow to track the action URLs?
       '<p><a href="{action.optOutUrl}">Foo</a></p>',
       ';<p><a href="http.*civicrm/mailing/optout.*">Foo</a></p>;',
-      ';\\[1\\] http.*civicrm/mailing/optout.*;',
+      ';\\(http.*civicrm/mailing/optout.*\\);',
       ['url_tracking' => 1],
     ];
     $cases[8] = [

--- a/tests/phpunit/CRM/Utils/HtmlToTextTest.php
+++ b/tests/phpunit/CRM/Utils/HtmlToTextTest.php
@@ -25,27 +25,18 @@ class CRM_Utils_HtmlToTextTest extends CiviUnitTestCase {
 
     $cases[] = [
       "\n<p>\n" .
-      "This is a paragraph with <b>Bold</b> and <i>italics</i>\n" .
+      "This is a paragraph with <b>Bold</b> and <i>italics</i>.\n" .
       "Also some <a href=\"http://www.example.com\">hrefs</a> and a\n" .
       "few <mailto:\"info@example.org\">mailto</mailto> tags.\n" .
       "This is also a really long long line\n" .
       "\n",
-      "This is a paragraph with BOLD and _italics_ Also some hrefs [1] and a few\n" .
-      "mailto tags. This is also a really long long line\n" .
-      "\n" .
-      "Links:\n" .
-      "------\n" .
-      "[1] http://www.example.com\n" .
-      "",
+      "This is a paragraph with Bold and italics. Also some [hrefs](http://www.example.com)" .
+      " and a few mailto tags. This is also a really long long line",
     ];
 
     $cases[] = [
       "<p>\nA <a href=\"{action.do_something}\">token</a>\nis not treated as a relative URL",
-      "A token [1] is not treated as a relative URL\n" .
-      "\n" .
-      "Links:\n" .
-      "------\n" .
-      "[1] {action.do_something}\n",
+      "A [token]({action.do_something}) is not treated as a relative URL",
     ];
 
     return $cases;

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -1122,7 +1122,7 @@ United States', $tokenProcessor->getRow(0)->render('message'));
     ]);
     $context['eventId'] = $this->eventCreateUnpaid([
       'title' => 'The Webinar',
-      'description' => '<p>Some online webinar thingy.</p> <p>Attendees will need to install the <a href="http://telefoo.example.com">TeleFoo</a> app.</p>',
+      'description' => '<p>Some online webinar thingy.</p><p>Attendees will need to install the <a href="http://telefoo.example.com">TeleFoo</a> app.</p>',
     ])['id'];
 
     $messages = $expected = [];
@@ -1138,15 +1138,10 @@ United States', $tokenProcessor->getRow(0)->render('message'));
     $messages['event_text'] = 'You signed up for this event: {event.title}: {event.description}';
     $expected['event_text'] = 'You signed up for this event: The Webinar: Some online webinar thingy.
 
-Attendees will need to install the TeleFoo [1] app.
-
-
-Links:
-------
-[1] http://telefoo.example.com';
+Attendees will need to install the [TeleFoo](http://telefoo.example.com) app.';
 
     $messages['event_html'] = '<p>You signed up for this event:</p> <h3>{event.title}</h3> {event.description}';
-    $expected['event_html'] = '<p>You signed up for this event:</p> <h3>The Webinar</h3> <p>Some online webinar thingy.</p> <p>Attendees will need to install the <a href="http://telefoo.example.com">TeleFoo</a> app.</p>';
+    $expected['event_html'] = '<p>You signed up for this event:</p> <h3>The Webinar</h3> <p>Some online webinar thingy.</p><p>Attendees will need to install the <a href="http://telefoo.example.com">TeleFoo</a> app.</p>';
 
     $rendered = CRM_Core_TokenSmarty::render($messages, $context);
 

--- a/tests/phpunit/Civi/Token/TokenProcessorTest.php
+++ b/tests/phpunit/Civi/Token/TokenProcessorTest.php
@@ -524,7 +524,7 @@ class TokenProcessorTest extends \CiviUnitTestCase {
     $testCases['TextMessages with HtmlData'] = [
       'text/plain',
       [
-        'This is {my_rich_text.and_such}...' => 'This is TESTING & SUCH...',
+        'This is {my_rich_text.and_such}...' => 'This is testing & such...',
         'This is {my_rich_text.and_such|lower}...' => 'This is testing & such...',
         'This is {my_rich_text.and_such|upper}!' => 'This is TESTING & SUCH!',
       ],


### PR DESCRIPTION
Overview
----------------------------------------
[html2text/html2text](https://github.com/mtibben/html2text) seems to do weird things including turning bold to SHOUTY, changing `<td>` to newlines and some kind of indentation for tables within tables. [soundasleep/html2text](https://github.com/soundasleep/html2text/) seems a little more sane, it ignores bold, changes `<td>` to tabs, and ignores tables within tables. The message templates seem a little more reasonable this way.

This would be in service of #27688.

So let's see what breaks with this!