### PR TITLE
Fix sort_name & display_name settings to support new-style tokens

### DIFF
--- a/CRM/Contact/BAO/Individual.php
+++ b/CRM/Contact/BAO/Individual.php
@@ -31,12 +31,12 @@ class CRM_Contact_BAO_Individual extends CRM_Contact_DAO_Contact {
    *
    * @param array $params
    *   (reference ) an assoc array of name/value pairs.
-   * @param CRM_Contact_BAO_Contact $contact
+   * @param CRM_Contact_DAO_Contact $contact
    *   Contact object.
    *
-   * @return CRM_Contact_BAO_Contact
+   * @return CRM_Contact_DAO_Contact
    */
-  public static function format(&$params, &$contact) {
+  public static function format(&$params, $contact) {
     if (!self::dataExists($params)) {
       return NULL;
     }
@@ -59,13 +59,8 @@ class CRM_Contact_BAO_Individual extends CRM_Contact_DAO_Contact {
     $formalTitle = CRM_Utils_Array::value('formal_title', $params, '');
 
     // get prefix and suffix names
-    $prefix = $suffix = NULL;
-    if ($prefix_id) {
-      $params['individual_prefix'] = $prefix = CRM_Core_PseudoConstant::getLabel('CRM_Contact_DAO_Contact', 'prefix_id', $prefix_id);
-    }
-    if ($suffix_id) {
-      $params['individual_suffix'] = $suffix = CRM_Core_PseudoConstant::getLabel('CRM_Contact_DAO_Contact', 'suffix_id', $suffix_id);
-    }
+    $params['prefix_id:label'] = $prefix = CRM_Core_PseudoConstant::getLabel('CRM_Contact_DAO_Contact', 'prefix_id', $prefix_id);
+    $params['suffix_id:label'] = $suffix = CRM_Core_PseudoConstant::getLabel('CRM_Contact_DAO_Contact', 'suffix_id', $suffix_id);
 
     $individual = NULL;
     if ($contact->id) {
@@ -87,12 +82,12 @@ class CRM_Contact_BAO_Individual extends CRM_Contact_DAO_Contact {
           }
         }
 
-        foreach (['prefix', 'suffix'] as $name) {
-          $dbName = "{$name}_id";
-          $value = $individual->$dbName;
-          if ($value && !empty($params['preserveDBName'])) {
-            $useDBNames[] = $name;
-          }
+        if ($individual->suffix_id && !empty($params['preserveDBName'])) {
+          $useDBNames[] = 'suffix_id';
+        }
+
+        if ($individual->prefix_id && !empty($params['preserveDBName'])) {
+          $useDBNames[] = 'prefix_id';
         }
 
         if ($individual->formal_title && !empty($params['preserveDBName'])) {
@@ -168,8 +163,8 @@ class CRM_Contact_BAO_Individual extends CRM_Contact_DAO_Contact {
         'middle_name' => $middleName,
         'last_name' => $lastName,
         'nick_name' => $nickName,
-        'individual_suffix' => $suffix,
-        'individual_prefix' => $prefix,
+        'suffix_id:label' => $suffix,
+        'prefix_id:label' => $prefix,
         'prefix_id' => $prefix_id,
         'suffix_id' => $suffix_id,
         'formal_title' => $formalTitle,

--- a/CRM/Utils/Address.php
+++ b/CRM/Utils/Address.php
@@ -76,12 +76,14 @@ class CRM_Utils_Address {
       // replacements in case of Individual Name Format
       $replacements = [
         'contact.display_name' => $fields['display_name'] ?? NULL,
-        'contact.individual_prefix' => $fields['individual_prefix'] ?? NULL,
         'contact.formal_title' => $fields['formal_title'] ?? NULL,
         'contact.first_name' => $fields['first_name'] ?? NULL,
         'contact.middle_name' => $fields['middle_name'] ?? NULL,
         'contact.last_name' => $fields['last_name'] ?? NULL,
-        'contact.individual_suffix' => $fields['individual_suffix'] ?? NULL,
+        'contact.individual_prefix' => $fields['prefix_id:label'] ?? ($fields['individual_prefix'] ?? NULL),
+        'contact.prefix_id:label' => $fields['prefix_id:label'] ?? ($fields['individual_prefix'] ?? NULL),
+        'contact.individual_suffix' => $fields['suffix_id:label'] ?? ($fields['individual_suffix'] ?? NULL),
+        'contact.suffix_id:label' => $fields['suffix_id:label'] ?? ($fields['individual_suffix'] ?? NULL),
         'contact.address_name' => $fields['address_name'] ?? NULL,
         'contact.street_address' => $fields['street_address'] ?? NULL,
         'contact.supplemental_address_1' => $fields['supplemental_address_1'] ?? NULL,

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -142,7 +142,7 @@ return [
     'name' => 'display_name_format',
     'type' => 'String',
     'html_type' => 'textarea',
-    'default' => '{contact.individual_prefix}{ }{contact.first_name}{ }{contact.last_name}{ }{contact.individual_suffix}',
+    'default' => '{contact.prefix_id:label}{ }{contact.first_name}{ }{contact.last_name}{ }{contact.suffix_id:label}',
     'add' => '4.1',
     'title' => ts('Individual Display Name Format'),
     'is_domain' => 1,

--- a/tests/phpunit/CRM/Contact/BAO/IndividualTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/IndividualTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Contact_BAO_IndividualTest extends CiviUnitTestCase {
 
+  public function tearDown(): void {
+    $this->revertSetting('display_name_format');
+    parent::tearDown();
+  }
+
   /**
    * Test case for format() with "null" value dates.
    *
@@ -30,7 +35,6 @@ class CRM_Contact_BAO_IndividualTest extends CiviUnitTestCase {
    *  Standard formatting is assumed.
    */
   public function testFormatDisplayName(): void {
-
     $params = [
       'contact_type' => 'Individual',
       'first_name' => 'Ben',
@@ -38,13 +42,17 @@ class CRM_Contact_BAO_IndividualTest extends CiviUnitTestCase {
       'individual_prefix' => 'Mr.',
       'individual_suffix' => 'Jr.',
     ];
-
     $contact = new CRM_Contact_DAO_Contact();
-
     CRM_Contact_BAO_Individual::format($params, $contact);
+    $this->assertEquals('Mr. Ben Lee Jr.', $contact->display_name);
+    $this->assertEquals('Lee, Ben', $contact->sort_name);
 
-    $this->assertEquals("Mr. Ben Lee Jr.", $contact->display_name);
-    $this->assertEquals("Lee, Ben", $contact->sort_name);
+    // Check with legacy tokens too.
+    \Civi::settings()->set('display_name_format', '{contact.individual_prefix}{ }{contact.first_name}{ }{contact.last_name}{ }{contact.individual_suffix}');
+    $contact = new CRM_Contact_DAO_Contact();
+    CRM_Contact_BAO_Individual::format($params, $contact);
+    $this->assertEquals('Mr. Ben Lee Jr.', $contact->display_name);
+    $this->assertEquals('Lee, Ben', $contact->sort_name);
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Fix sort_name & display_name settings to support new-style tokens

Before
----------------------------------------
display_name & sort_name formats support legacy `{contact.individual_suffix}` and `{contact.individual_prefix}` 

After
----------------------------------------
display_name & sort_name formats support legacy `{contact.individual_suffix}` and `{contact.individual_prefix}` 

and `{contact.suffix_id:label}` and `{contact.prefix_id:label}`

Technical Details
----------------------------------------
I was resistant to this change
https://github.com/civicrm/civicrm-core/pull/27114#issuecomment-1722110045

because it added another instance of '{individual_suffix}' - but this PR makes both sort_name & display_name support the new style as well.

Unit tests lock in support for the old style & I have not put
pro-active upgrade in place - but we would want to before fully moving over to tokens

Comments
----------------------------------------
