### PR TITLE
SearchKit - Fix and add test for scenario where the same display is used twice on a form

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/OptionGroupCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/OptionGroupCreationSpecProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\RequestSpec;
+
+/**
+ * @service
+ * @internal
+ */
+class OptionGroupCreationSpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
+
+  /**
+   * @inheritDoc
+   */
+  public function modifySpec(RequestSpec $spec) {
+    $spec->getFieldByName('name')->setRequired(FALSE);
+    $spec->getFieldByName('title')->setRequiredIf('empty($values.name)');
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function applies($entity, $action) {
+    return $entity === 'OptionGroup' && $action === 'create';
+  }
+
+}

--- a/ext/afform/mock/ang/testDisplaysSharingSameFieldset.aff.html
+++ b/ext/afform/mock/ang/testDisplaysSharingSameFieldset.aff.html
@@ -1,0 +1,7 @@
+<div af-fieldset="">
+  <div class="af-container af-layout-inline">
+    <af-field name="label" />
+  </div>
+  <crm-search-display-table filters="{is_active: true, 'option_group_id:name': dummy_var}" search-name="testDisplaysSharingSameFieldset" display-name="testDisplaysSharingSameFieldset"></crm-search-display-table>
+  <crm-search-display-table filters="{is_active: false, 'option_group_id:name': dummy_var}" search-name="testDisplaysSharingSameFieldset" display-name="testDisplaysSharingSameFieldset"></crm-search-display-table>
+</div>


### PR DESCRIPTION
Overview
----------------------------------------
Enables the scenario where the same search display is reused with different filters on the same form.

Before
----------------------------------------
Doesn't work.

After
----------------------------------------
Works. Test added.

Comments
----------------------------------------
I originally hit this bug when working on the [Contact Relationships Tab](https://github.com/civicrm/civicrm-core/pull/27701). My first draft of that PR used the exact same display twice & passed each a different value for `is_current`. The current iteration of that PR actually uses different displays because there were a few things about them (styling, links) I wanted to tweak. So I spun off this fix into its own PR as it's no longer on the critical path.

The Afform GUI still doesn't handle this scenario well, but that's another issue. IMO this is fine to merge as-is. It's an improvement and has a test.