### PR TITLE
Move the participantCount logic to the template

### DIFF
--- a/CRM/Contribute/WorkflowMessage/ContributionTrait.php
+++ b/CRM/Contribute/WorkflowMessage/ContributionTrait.php
@@ -31,6 +31,18 @@ trait CRM_Contribute_WorkflowMessage_ContributionTrait {
   public $isShowTax;
 
   /**
+   * Is it a good idea to show the line item subtotal.
+   *
+   * This would be true if at least one line has a quantity > 1.
+   * Otherwise it is very repetitive.
+   *
+   * @var bool
+   *
+   * @scope tplParams
+   */
+  public $isShowLineSubtotal;
+
+  /**
    * Line items associated with the contribution.
    *
    * @var array
@@ -109,6 +121,25 @@ trait CRM_Contribute_WorkflowMessage_ContributionTrait {
       return FALSE;
     }
     return !$this->order->getPriceSetMetadata()['is_quick_config'];
+    return $this->isShowLineItems;
+  }
+
+  /**
+   * Is it a good idea to show the line item subtotal.
+   *
+   * This would be true if at least one line has a quantity > 1.
+   * Otherwise it is very repetitive.
+   *
+   * @return bool
+   * @throws \CRM_Core_Exception
+   */
+  public function getIsShowLineSubtotal(): bool {
+    foreach ($this->getLineItems() as $lineItem) {
+      if ((int) $lineItem['qty'] > 1) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
   /**

--- a/CRM/Event/WorkflowMessage/ParticipantTrait.php
+++ b/CRM/Event/WorkflowMessage/ParticipantTrait.php
@@ -38,6 +38,19 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
   public $isPrimary;
 
   /**
+   * Should a participant count column be shown.
+   *
+   * This would be true if there is a line item on the receipt
+   * with more than one participant in it. Otherwise it's confusing to
+   * show.
+   *
+   * @var bool
+   *
+   * @scope tplParams as isShowParticipantCount
+   */
+  public $isShowParticipantCount;
+
+  /**
    * @var int
    *
    * @scope tokenContext as eventId, tplParams as eventID
@@ -152,7 +165,26 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
   }
 
   /**
-   * Set contribution object.
+   * It is a good idea to show the participant count column.
+   *
+   * This would be true if there is a line item on the receipt
+   * with more than one participant in it. Otherwise it's confusing to
+   * show.
+   *
+   * @return bool
+   * @throws \CRM_Core_Exception
+   */
+  public function getIsShowParticipantCount(): bool {
+    foreach ($this->getLineItems() as $lineItem) {
+      if ((int) $lineItem['participant_count'] > 1) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Set participant object.
    *
    * @param array $participant
    *

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -164,7 +164,6 @@
 
 
      {if {event.is_monetary|boolean}}
-
       <tr>
         <th {$headerStyle}>
             {event.fee_label}
@@ -193,7 +192,7 @@
                         <th>{ts}Tax Amount{/ts}</th>
                       {/if}
                       <th>{ts}Total{/ts}</th>
-                        {if !empty($pricesetFieldsCount)}
+                        {if $iShowParticipantCount}
                           <th>{ts}Total Participants{/ts}</th>
                         {/if}
                     </tr>
@@ -215,7 +214,7 @@
                         <td {$tdStyle}>
                             {$line.line_total+$line.tax_amount|crmMoney:$currency}
                         </td>
-                        {if !empty($pricesetFieldsCount)}
+                        {if $isShowParticipantCount}
                           <td {$tdStyle}>{$line.participant_count}</td>
                         {/if}
                       </tr>
@@ -289,25 +288,10 @@
               {contribution.total_amount} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
             </td>
           </tr>
-          {if !empty($pricesetFieldsCount)}
+          {if $isShowParticipantCount}
             <tr>
-              <td {$labelStyle}>
-                  {ts}Total Participants{/ts}</td>
-              <td {$valueStyle}>
-                  {assign var="count" value= 0}
-                  {foreach from=$lineItem item=pcount}
-                      {assign var="lineItemCount" value=0}
-                      {if $pcount neq 'skip'}
-                          {foreach from=$pcount item=p_count}
-                              {assign var="lineItemCount" value=$lineItemCount+$p_count.participant_count}
-                          {/foreach}
-                          {if $lineItemCount < 1}{assign var="lineItemCount" value=1}
-                          {/if}
-                          {assign var="count" value=$count+$lineItemCount}
-                      {/if}
-                  {/foreach}
-                  {$count}
-              </td>
+              <td {$labelStyle}>{ts}Total Participants{/ts}</td>
+              <td {$valueStyle}>{$line.participant_count}</td>
             </tr>
           {/if}
           {if {contribution.is_pay_later|boolean} && {contribution.balance_amount|boolean}}


### PR DESCRIPTION
Overview
----------------------------------------
Move the participantCount logic to the template

Before
----------------------------------------
the `$pricesetFieldsCount` value is assigned from the form

After
----------------------------------------
`$isShowParticipantCount` assigned from the template

Technical Details
----------------------------------------
`$isShowLineSubtotal` is conceptually similar & my last version of this (https://github.com/civicrm/civicrm-core/pull/27377) added it to the template. That bit of the template has been reworked since then so I didn't bring the template edit back to life - but I did ressurect adding the variable as it made sense to add if adding this one

Comments
----------------------------------------
