### PR TITLE
APIv4 - Trim output of Export action to only non-default values

### DIFF
--- a/CRM/Utils/Type.php
+++ b/CRM/Utils/Type.php
@@ -70,7 +70,7 @@ class CRM_Utils_Type {
    * @return string
    *   String identifying the data type, e.g. 'Int' or 'String'.
    */
-  public static function typeToString($type) {
+  public static function typeToString($type): string {
     // @todo Use constants in the case statements, e.g. "case T_INT:".
     // @todo return directly, instead of assigning a value.
     // @todo Use a lookup array, as a property or as a local variable.
@@ -134,7 +134,7 @@ class CRM_Utils_Type {
         break;
     }
 
-    return (isset($string)) ? $string : "";
+    return $string ?? '';
   }
 
   /**

--- a/Civi/Api4/Generic/ExportAction.php
+++ b/Civi/Api4/Generic/ExportAction.php
@@ -161,6 +161,12 @@ class ExportAction extends AbstractAction {
         unset($record[$fieldName]);
       }
     }
+    // Unset values that match the default
+    foreach ($allFields as $fieldName => $field) {
+      if (($record[$fieldName] ?? NULL) === $field['default_value']) {
+        unset($record[$fieldName]);
+      }
+    }
     $export = [
       'name' => $name,
       'entity' => $entityType,

--- a/Civi/Api4/Generic/Traits/ManagedEntity.php
+++ b/Civi/Api4/Generic/Traits/ManagedEntity.php
@@ -27,8 +27,7 @@ trait ManagedEntity {
    */
   public static function revert($checkPermissions = TRUE) {
     return (new BasicBatchAction(static::getEntityName(), __FUNCTION__, function($item, BasicBatchAction $action) {
-      $params = ['entity_type' => $action->getEntityName(), 'entity_id' => $item['id']];
-      if (\CRM_Core_ManagedEntities::singleton()->revert($params)) {
+      if (\CRM_Core_ManagedEntities::singleton()->revert($action->getEntityName(), $item['id'])) {
         return $item;
       }
       else {

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -130,14 +130,15 @@ class SpecFormatter {
    * @return string
    */
   private static function getDataType(array $data) {
-    if (isset($data['data_type'])) {
-      return !empty($data['time_format']) ? 'Timestamp' : $data['data_type'];
+    $dataType = $data['data_type'] ?? $data['dataType'] ?? NULL;
+    if (isset($dataType)) {
+      return !empty($data['time_format']) ? 'Timestamp' : $dataType;
     }
 
     $dataTypeInt = $data['type'] ?? NULL;
     $dataTypeName = \CRM_Utils_Type::typeToString($dataTypeInt);
 
-    return $dataTypeName;
+    return $dataTypeName === 'Int' ? 'Integer' : $dataTypeName;
   }
 
   /**
@@ -303,10 +304,10 @@ class SpecFormatter {
       self::setLegacyDateFormat($inputAttrs);
     }
     // Number input for numeric fields
-    if ($inputType === 'Text' && in_array($dataTypeName, ['Int', 'Float'], TRUE)) {
+    if ($inputType === 'Text' && in_array($dataTypeName, ['Integer', 'Float'], TRUE)) {
       $inputType = 'Number';
       // Todo: make 'step' configurable for the custom field
-      $inputAttrs['step'] = $dataTypeName === 'Int' ? 1 : .01;
+      $inputAttrs['step'] = $dataTypeName === 'Integer' ? 1 : .01;
     }
     // Date/time settings from custom fields
     if ($inputType == 'Date' && !empty($data['custom_group_id'])) {

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -401,9 +401,16 @@ class FormattingUtil {
         case 'Float':
           return (float) $value;
 
+        case 'Timestamp':
         case 'Date':
+          // Convert mysql-style default to api-style default
+          if (str_contains($value, 'CURRENT_TIMESTAMP')) {
+            return 'now';
+          }
           // Strip time from date-only fields
-          return substr($value, 0, 10);
+          if ($dataType === 'Date' && $value) {
+            return substr($value, 0, 10);
+          }
       }
     }
     return $value;

--- a/tests/phpunit/api/v4/Action/GetFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetFieldsTest.php
@@ -29,6 +29,7 @@ use Civi\Api4\Contribution;
 use Civi\Api4\CustomGroup;
 use Civi\Api4\Email;
 use Civi\Api4\EntityTag;
+use Civi\Api4\OptionValue;
 use Civi\Api4\UserJob;
 use Civi\Api4\Utils\CoreUtil;
 use Civi\Test\TransactionalInterface;
@@ -176,6 +177,12 @@ class GetFieldsTest extends Api4TestBase implements TransactionalInterface {
     $this->assertTrue($aclFields['is_active']['default_value']);
     $this->assertFalse($aclFields['is_active']['nullable']);
     $this->assertFalse($aclFields['is_active']['required']);
+
+    $optionValueFields = OptionValue::getFields(FALSE)
+      ->setAction('create')
+      ->execute()->indexBy('name');
+    $this->assertIsInt($optionValueFields['filter']['default_value']);
+    $this->assertEquals(0, $optionValueFields['filter']['default_value']);
   }
 
   public function testGetSuffixes(): void {

--- a/tests/phpunit/api/v4/Action/GetFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetFieldsTest.php
@@ -162,6 +162,8 @@ class GetFieldsTest extends Api4TestBase implements TransactionalInterface {
     $this->assertTrue($actFields['subject']['nullable']);
     $this->assertFalse($actFields['subject']['deprecated']);
     $this->assertTrue($actFields['phone_id']['deprecated']);
+    $this->assertEquals('now', $actFields['created_date']['default_value']);
+    $this->assertEquals('now', $actFields['activity_date_time']['default_value']);
 
     $getFields = Activity::getFields(FALSE)
       ->setAction('get')

--- a/tests/phpunit/api/v4/Custom/ExportCustomGroupTest.php
+++ b/tests/phpunit/api/v4/Custom/ExportCustomGroupTest.php
@@ -66,7 +66,7 @@ class ExportCustomGroupTest extends CustomTestBase {
     // Should be only name, not id
     $this->assertArrayNotHasKey('option_group_id', $export[5]['params']['values']);
     // Field with no options
-    $this->assertNull($export[6]['params']['values']['option_group_id']);
+    $this->assertTrue(!isset($export[6]['params']['values']['option_group_id']));
     $this->assertArrayNotHasKey('option_group_id.name', $export[6]['params']['values']);
     $this->assertArrayNotHasKey('option_values', $export[6]['params']['values']);
   }

--- a/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
+++ b/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
@@ -410,7 +410,7 @@ class ManagedEntityTest extends TestCase implements HeadlessInterface, Transacti
       ->addChain('export', OptionGroup::export()->setId('$id'))
       ->execute()->first();
     $this->assertEquals('from_email_address', $result['export'][1]['params']['values']['option_group_id.name']);
-    $this->assertNull($result['export'][1]['params']['values']['visibility_id']);
+    $this->assertArrayNotHasKey('visibility_id', $result['export'][1]['params']['values']);
     $this->assertStringStartsWith('OptionGroup_from_email_address_OptionValue_', $result['export'][1]['name']);
     // All references should be from the current domain
     foreach (array_slice($result['export'], 1) as $reference) {


### PR DESCRIPTION
Overview
----------------------------------------
Results in more-readable `.mgd.php` files by omitting irrelevant values. Also fixes a bug in APIv4 getFields and adds a test.

Before
----------------------------------------
Managed file looks like
```
return [
  [
    'name' => 'OptionValue_Phone',
    'entity' => 'OptionValue',
    'cleanup' => 'unused',
    'update' => 'unmodified',
    'params' => [
      'version' => 4,
      'values' => [
        'option_group_id.name' => 'preferred_communication_method',
        'label' => E::ts('Phone'),
        'value' => '1',
        'name' => 'Phone',
        'grouping' => NULL,
        'filter' => 0,
        'is_default' => FALSE,
        'weight' => 1,
        'description' => NULL,
        'is_optgroup' => FALSE,
        'is_reserved' => FALSE,
        'is_active' => TRUE,
        'component_id' => NULL,
        'domain_id' => NULL,
        'visibility_id' => NULL,
        'icon' => NULL,
        'color' => NULL,
      ],
      'match' => [
        'name',
      ],
    ],
  ],
];
```

After
----------------------------------------
Managed file looks like
```
return [
  [
    'name' => 'OptionValue_Phone',
    'entity' => 'OptionValue',
    'cleanup' => 'unused',
    'update' => 'unmodified',
    'params' => [
      'version' => 4,
      'values' => [
        'option_group_id.name' => 'preferred_communication_method',
        'label' => E::ts('Phone'),
        'value' => '1',
        'name' => 'Phone',
        'weight' => 1,
      ],
      'match' => [
        'name',
      ],
    ],
  ],
];
```

Technical Details
----------
Instead of "kitchen sink" arrays, we can just include the relevant fields. This PR updates the "Revert" action to backfill the defaults so that an entity can still be reverted to a pristine state even if default values are not declared in the `mgd.php` file.