### PR TITLE
[REF][PHP8.1] Fix deprecation notice on passing NULL as the 3rd param…

### DIFF
--- a/CRM/Utils/Geocode/Google.php
+++ b/CRM/Utils/Geocode/Google.php
@@ -66,7 +66,7 @@ class CRM_Utils_Geocode_Google {
 
     if (!empty($values['state_province']) || (!empty($values['state_province_id']) && $values['state_province_id'] != 'null')) {
       if (!empty($values['state_province_id'])) {
-        $stateProvince = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_StateProvince', $values['state_province_id']);
+        $stateProvince = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_StateProvince', $values['state_province_id']) ?? '';
       }
       else {
         if (!$stateName) {
@@ -74,10 +74,10 @@ class CRM_Utils_Geocode_Google {
             $values['state_province'],
             'name',
             'abbreviation'
-          );
+          ) ?? '';
         }
         else {
-          $stateProvince = $values['state_province'];
+          $stateProvince = $values['state_province'] ?? '';
         }
       }
 


### PR DESCRIPTION
… to str_replace for Google geocoding

Overview
----------------------------------------
This aims to fix deprecation notice on passing NULL as the 3rd param to str_replace or passing null into class_exists is deprecated in php8.1

Before
----------------------------------------
Deprecation notice triggered when state province is not provided.

After
----------------------------------------
Deprecation notice not triggered when state province is not provided.