### PR TITLE
Authx - validate if the user is blocked

### DIFF
--- a/ext/authx/Civi/Authx/Authenticator.php
+++ b/ext/authx/Civi/Authx/Authenticator.php
@@ -262,6 +262,10 @@ class Authenticator extends AutoService implements HookInterface {
       return !empty($a) && (string) $a === (string) $b;
     };
 
+    if ($tgt->userId !== NULL && $this->authxUf->getUserIsBlocked($tgt->userId)) {
+      $this->reject('Cannot login. User is blocked.');
+    }
+
     if (\CRM_Core_Session::getLoggedInContactID() || $this->authxUf->getCurrentUserId()) {
       if ($isSameValue(\CRM_Core_Session::getLoggedInContactID(), $tgt->contactId)  && $isSameValue($this->authxUf->getCurrentUserId(), $tgt->userId)) {
         // Already logged in. Post-condition met - but by unusual means.

--- a/ext/authx/Civi/Authx/AuthxInterface.php
+++ b/ext/authx/Civi/Authx/AuthxInterface.php
@@ -71,4 +71,12 @@ interface AuthxInterface {
    */
   public function getCurrentUserId();
 
+  /**
+   * Determine the user status, if is blocked or not.
+   *
+   * @param int|string $userId
+   * @return int|NULL
+   */
+  public function getUserIsBlocked($userId);
+
 }

--- a/ext/authx/Civi/Authx/Backdrop.php
+++ b/ext/authx/Civi/Authx/Backdrop.php
@@ -55,4 +55,12 @@ class Backdrop implements AuthxInterface {
     return $user && $user->uid ? $user->uid : NULL;
   }
 
+  /**
+   * @inheritDoc
+   */
+  public function getUserIsBlocked($userId) {
+    // ToDo
+    return FALSE;
+  }
+
 }

--- a/ext/authx/Civi/Authx/Drupal.php
+++ b/ext/authx/Civi/Authx/Drupal.php
@@ -55,4 +55,12 @@ class Drupal implements AuthxInterface {
     return $user && $user->uid ? $user->uid : NULL;
   }
 
+  /**
+   * @inheritDoc
+   */
+  public function getUserIsBlocked($userId) {
+    // ToDo
+    return FALSE;
+  }
+
 }

--- a/ext/authx/Civi/Authx/Drupal8.php
+++ b/ext/authx/Civi/Authx/Drupal8.php
@@ -57,4 +57,16 @@ class Drupal8 implements AuthxInterface {
     return $user && $user->getAccount()->id() ? $user->getAccount()->id() : NULL;
   }
 
+  /**
+   * @inheritDoc
+   */
+  public function getUserIsBlocked($userId) {
+    $user = \Drupal\user\Entity\User::load($userId);
+    // The user will not be blocked if there is no existence.
+    if (!$user) {
+      return FALSE;
+    }
+    return $user->isBlocked();
+  }
+
 }

--- a/ext/authx/Civi/Authx/Joomla.php
+++ b/ext/authx/Civi/Authx/Joomla.php
@@ -95,4 +95,12 @@ class Joomla implements AuthxInterface {
     return ($user->guest) ? NULL : $user->id;
   }
 
+  /**
+   * @inheritDoc
+   */
+  public function getUserIsBlocked($userId) {
+    // ToDo
+    return FALSE;
+  }
+
 }

--- a/ext/authx/Civi/Authx/None.php
+++ b/ext/authx/Civi/Authx/None.php
@@ -48,4 +48,12 @@ class None implements AuthxInterface {
     throw new \Exception("Cannot determine active user: Unrecognized user framework");
   }
 
+  /**
+   * @inheritDoc
+   */
+  public function getUserIsBlocked($userId) {
+    // ToDo
+    return FALSE;
+  }
+
 }

--- a/ext/authx/Civi/Authx/WordPress.php
+++ b/ext/authx/Civi/Authx/WordPress.php
@@ -67,4 +67,12 @@ class WordPress implements AuthxInterface {
     return empty($id) ? NULL : $id;
   }
 
+  /**
+   * @inheritDoc
+   */
+  public function getUserIsBlocked($userId) {
+    // ToDo
+    return FALSE;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Verify if the user is blocked in the CMS if want to use the API Rest by authx

Before
----------------------------------------

You can make a API call by webservice if the user is blocked.
With the configuration in `civicrm/admin/setting/authx` is required, like in the image.

![image](https://github.com/civicrm/civicrm-core/assets/2327763/92412255-4246-4b00-b13c-2f4ed3f0e53e)

Image of user blocked in drupal
![image](https://github.com/civicrm/civicrm-core/assets/2327763/12bd322c-6157-4fd5-b163-9f816d6368e4)


After
----------------------------------------

Verify if the user is blocked(only drupal8/9, the other cases in ToDo) in the case that is blocked launch a exception;

`Cannot login. User is blocked`

Comments
----------------------------------------

Ref other MR with the deprecated way to call the API

https://github.com/civicrm/civicrm-core/pull/26185
