### PR TITLE
APIv4 - ensure action names get camelCase properly

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -153,12 +153,19 @@ abstract class AbstractAction implements \ArrayAccess {
    * @param string $actionName
    */
   public function __construct($entityName, $actionName) {
-    // If a namespaced class name is passed in
-    if (strpos($entityName, '\\') !== FALSE) {
-      $entityName = substr($entityName, strrpos($entityName, '\\') + 1);
+    // If a namespaced class name is passed in, convert to entityName
+    $this->_entityName = CoreUtil::stripNamespace($entityName);
+    // Normalize action name case (because PHP is case-insensitive, we have to do an extra check)
+    $thisClassName = CoreUtil::stripNamespace(get_class($this));
+    // If this was called via magic method, $actionName won't necessarily have the
+    // correct case because PHP doesn't care about case when calling methods.
+    if (strtolower($thisClassName) === strtolower($actionName)) {
+      $this->_actionName = lcfirst($thisClassName);
     }
-    $this->_entityName = $entityName;
-    $this->_actionName = $actionName;
+    // If called via static method, case should already be correct.
+    else {
+      $this->_actionName = $actionName;
+    }
     $this->_id = \Civi\API\Request::getNextId();
   }
 

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -12,6 +12,7 @@
 namespace Civi\Api4\Generic;
 
 use Civi\API\Exception\NotImplementedException;
+use Civi\Api4\Utils\CoreUtil;
 use Civi\Api4\Utils\ReflectionUtils;
 
 /**
@@ -75,7 +76,7 @@ abstract class AbstractEntity {
    * @return string
    */
   public static function getEntityName(): string {
-    return self::stripNamespace(static::class);
+    return CoreUtil::stripNamespace(static::class);
   }
 
   /**
@@ -128,7 +129,7 @@ abstract class AbstractEntity {
       'name' => $entityName,
       'title' => static::getEntityTitle(),
       'title_plural' => static::getEntityTitle(TRUE),
-      'type' => [self::stripNamespace(get_parent_class(static::class))],
+      'type' => [CoreUtil::stripNamespace(get_parent_class(static::class))],
       'paths' => [],
       'class' => static::class,
       'primary_key' => ['id'],
@@ -148,7 +149,7 @@ abstract class AbstractEntity {
       $info['icon_field'] = (array) ($dao::fields()['icon']['name'] ?? NULL);
     }
     foreach (ReflectionUtils::getTraits(static::class) as $trait) {
-      $info['type'][] = self::stripNamespace($trait);
+      $info['type'][] = CoreUtil::stripNamespace($trait);
     }
     // Get DocBlock from APIv4 Entity class
     $reflection = new \ReflectionClass(static::class);
@@ -177,16 +178,6 @@ abstract class AbstractEntity {
     }
 
     return $info;
-  }
-
-  /**
-   * Remove namespace prefix from a class name
-   *
-   * @param string $className
-   * @return string
-   */
-  private static function stripNamespace(string $className): string {
-    return substr($className, strrpos($className, '\\') + 1);
   }
 
 }

--- a/Civi/Api4/Query/SqlExpression.php
+++ b/Civi/Api4/Query/SqlExpression.php
@@ -11,6 +11,8 @@
 
 namespace Civi\Api4\Query;
 
+use Civi\Api4\Utils\CoreUtil;
+
 /**
  * Base class for SqlColumn, SqlString, SqlBool, and SqlFunction classes.
  *
@@ -174,8 +176,7 @@ abstract class SqlExpression {
    * @return string
    */
   public function getType(): string {
-    $className = get_class($this);
-    return substr($className, strrpos($className, '\\') + 1);
+    return CoreUtil::stripNamespace(get_class($this));
   }
 
   /**

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -437,4 +437,14 @@ class CoreUtil {
     }
   }
 
+  /**
+   * Strips leading namespace from a classname
+   * @param string $className
+   * @return string
+   */
+  public static function stripNamespace(string $className): string {
+    $slashPos = strrpos($className, '\\');
+    return $slashPos === FALSE ? $className : substr($className, $slashPos + 1);
+  }
+
 }

--- a/ext/oauth-client/Civi/Api4/Action/OAuthClient/AbstractGrantAction.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthClient/AbstractGrantAction.php
@@ -47,10 +47,6 @@ abstract class AbstractGrantAction extends \Civi\Api4\Generic\AbstractBatchActio
    */
   private $clientDef = NULL;
 
-  public function __construct($entityName, $actionName) {
-    parent::__construct($entityName, $actionName, ['*']);
-  }
-
   /**
    * @throws \CRM_Core_Exception
    */

--- a/ext/oauth-client/Civi/Api4/Action/OAuthSysToken/Refresh.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthSysToken/Refresh.php
@@ -41,10 +41,6 @@ class Refresh extends BasicBatchAction {
   private $selectFields = ['id', 'client_id', 'access_token', 'refresh_token', 'expires', 'token_type', 'raw'];
   private $providers = [];
 
-  public function __construct($entityName, $actionName) {
-    parent::__construct($entityName, $actionName);
-  }
-
   protected function getSelect() {
     return $this->selectFields;
   }

--- a/tests/phpunit/api/v4/Action/ActionNameTest.php
+++ b/tests/phpunit/api/v4/Action/ActionNameTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4\Action;
+
+use api\v4\Api4TestBase;
+use Civi\Api4\MockArrayEntity;
+
+/**
+ * @group headless
+ */
+class ActionNameTest extends Api4TestBase {
+
+  public function testActionCaseSensitive(): void {
+    // This test checks that an action called via STATIC method will internally
+    // be converted to the proper case.
+    // First: ensure the static method DOES exist. If the class is ever refactored to change this,
+    // then this test will no longer be testing what it thinks it's testing!
+    $this->assertTrue(method_exists(MockArrayEntity::class, 'getFields'));
+
+    // PHP is case-insensitive so this will work <sigh>
+    $action = MOCKarrayENTITY::GETFiELDS();
+    // Ensure case was converted internally by the action class
+    $this->assertEquals('getFields', $action->getActionName());
+    $this->assertEquals('MockArrayEntity', $action->getEntityName());
+  }
+
+  public function testActionCaseSensitiveViaMagicMethod(): void {
+    // This test checks that an action called via MAGIC method will internally
+    // be converted to the proper case.
+    // First: ensure the static method does NOT exist. If the class is ever refactored to change this,
+    // then this test will no longer be testing what it thinks it's testing!
+    $this->assertFalse(method_exists(MockArrayEntity::class, 'doNothing'));
+
+    // PHP is case-insensitive so this will work <sigh>
+    $action = moCKarrayENTIty::DOnothING();
+    // Ensure case was converted internally by the action class
+    $this->assertEquals('doNothing', $action->getActionName());
+    $this->assertEquals('MockArrayEntity', $action->getEntityName());
+  }
+
+}

--- a/tests/phpunit/api/v4/Action/ActionNameTest.php
+++ b/tests/phpunit/api/v4/Action/ActionNameTest.php
@@ -47,6 +47,12 @@ class ActionNameTest extends Api4TestBase {
     // then this test will no longer be testing what it thinks it's testing!
     $this->assertFalse(method_exists(MockArrayEntity::class, 'doNothing'));
 
+    // Try it with normal case
+    $action = MockArrayEntity::doNothing();
+    // Ensure case was converted internally by the action class
+    $this->assertEquals('doNothing', $action->getActionName());
+    $this->assertEquals('MockArrayEntity', $action->getEntityName());
+
     // PHP is case-insensitive so this will work <sigh>
     $action = moCKarrayENTIty::DOnothING();
     // Ensure case was converted internally by the action class

--- a/tests/phpunit/api/v4/Custom/CoreUtilTest.php
+++ b/tests/phpunit/api/v4/Custom/CoreUtilTest.php
@@ -77,4 +77,19 @@ class CoreUtilTest extends CustomTestBase {
     $this->assertEquals('Civi\Api4\CustomValue', CoreUtil::getApiClass('Custom_' . $multiGroup['name']));
   }
 
+  public function getNamespaceExamples(): array {
+    return [
+      ['\Foo', 'Foo'],
+      ['\Foo\Bar', 'Bar'],
+      ['Baz', 'Baz'],
+    ];
+  }
+
+  /**
+   * @dataProvider getNamespaceExamples
+   */
+  public function testStripNamespace($input, $expected): void {
+    $this->assertEquals($expected, CoreUtil::stripNamespace($input));
+  }
+
 }

--- a/tests/phpunit/api/v4/Mock/Api4/Action/MockArrayEntity/DoNothing.php
+++ b/tests/phpunit/api/v4/Mock/Api4/Action/MockArrayEntity/DoNothing.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Civi\Api4\Action\MockArrayEntity;
+
+use Civi\Api4\Generic\Result;
+
+/**
+ * Action that does nothing; called via magic method
+ */
+class DoNothing extends \Civi\Api4\Generic\AbstractAction {
+
+  /**
+   * @inheritDoc
+   */
+  public function _run(Result $result) {
+    // Doing exactly as advertised.
+  }
+
+}

--- a/tests/phpunit/api/v4/Mock/Api4/MockArrayEntity.php
+++ b/tests/phpunit/api/v4/Mock/Api4/MockArrayEntity.php
@@ -21,7 +21,8 @@ namespace Civi\Api4;
 /**
  * MockArrayEntity entity.
  *
- * @method static Generic\BasicGetAction get()
+ * @method static Action\MockArrayEntity\Get get()
+ * @method static Action\MockArrayEntity\DoNothing doNothing()
  *
  * @package Civi\Api4
  */


### PR DESCRIPTION
Overview
----------------------------------------
Fixes weird edge-case in APIv4.

Technical Details
----------------------------------------
In APIv4, `$entityName` and `$actionName` get passed around as strings. Strings are case-sensitive. However, most entities and actions are defined as PHP classes, and PHP classes are *not* case-sensitive! So there's nothing we can actually do about someone calling `\cIvI\aPi4\cOnTaCt::gEtFiElDs()`, but this normalizes the strings.