### PR TITLE
Queue::runAll() - Add API for running several tasks

### DIFF
--- a/CRM/Queue/Queue.php
+++ b/CRM/Queue/Queue.php
@@ -59,6 +59,15 @@ abstract class CRM_Queue_Queue {
    * @throws \CRM_Core_Exception
    */
   public function isActive(): bool {
+    return ($this->getStatus() === 'active');
+  }
+
+  /**
+   * @return string|null
+   * @throws \CRM_Core_Exception
+   * @see \CRM_Queue_BAO_Queue::getStatuses()
+   */
+  public function getStatus() {
     // Queues work with concurrent processes. We want to make sure status info is up-to-date (never cached).
     $status = CRM_Core_DAO::getFieldValue('CRM_Queue_DAO_Queue', $this->_name, 'status', 'name', TRUE);
     if ($status === 'active') {
@@ -72,7 +81,7 @@ abstract class CRM_Queue_Queue {
     CRM_Utils_Hook::queueActive($status, $this->getName(), $this->queueSpec);
     // Note in future we might want to consider whether an upgrade is in progress.
     // Should we set the setting at that point?
-    return ($status === 'active');
+    return $status;
   }
 
   /**

--- a/Civi/Api4/Action/Queue/RunAll.php
+++ b/Civi/Api4/Action/Queue/RunAll.php
@@ -24,7 +24,7 @@ use Civi\Api4\Queue;
  * @method ?int getMaxDuration()
  * @method $this setMaxDuration(?int $maxDuration)
  */
-class RunLoop extends \Civi\Api4\Generic\AbstractAction {
+class RunAll extends \Civi\Api4\Generic\AbstractAction {
 
   /**
    * Name of the target queue.

--- a/Civi/Api4/Action/Queue/RunLoop.php
+++ b/Civi/Api4/Action/Queue/RunLoop.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Civi\Api4\Action\Queue;
+
+use Civi\Api4\Generic\Result;
+use Civi\Api4\Queue;
+
+/**
+ * Run a series of items from a queue.
+ *
+ * This is a lightweight main-loop for development/testing. It may have some limited utility for
+ * sysadmins who want to fine-tune runners on a specific queue.
+ *
+ * Basically, this runs until the queue is empty -- or until you reach one of the limits.
+ *
+ * For more functionality (queue auto-detection, fatal recovery, more tunable limits,
+ * process pooling, privilege separation, wait-support), you should look to `coworker` or
+ * write a custom main-loop.
+ *
+ * @method ?string getQueue
+ * @method $this setQueue(?string $queue)
+ * @method ?int getMaxRequests()
+ * @method $this setMaxRequests(?int $maxRequests)
+ * @method ?int getMaxDuration()
+ * @method $this setMaxDuration(?int $maxDuration)
+ */
+class RunLoop extends \Civi\Api4\Generic\AbstractAction {
+
+  /**
+   * Name of the target queue.
+   *
+   * @var string
+   * @required
+   */
+  protected $queue;
+
+  /**
+   * Maximum number of tasks to execute.
+   *
+   * After reaching this limit, the loop will stop taking new tasks.
+   *
+   * @var int|null
+   *   Special values `null` and `-1` indicate infinite execution.
+   * @see \Civi\Coworker\Configuration::$maxWorkerRequests
+   */
+  public $maxRequests = 10;
+
+  /**
+   * Maximum amount of time (seconds) for which a single worker should execute.
+   *
+   * After reaching this limit, no more tasks will be given to the worker.
+   *
+   * @var int|null
+   *   Special values `null` and `-1` indicate infinite execution.
+   * @see \Civi\Coworker\Configuration::$maxWorkerDuration
+   */
+  public $maxDuration = 120;
+
+  public function _run(Result $result) {
+    $queue = \Civi::queue($this->queue);
+    $startTime = microtime(TRUE);
+    $requests = 0;
+    $errors = 0;
+    $successes = 0;
+    $message = NULL;
+    $perm = $this->getCheckPermissions();
+
+    while (TRUE) {
+      if (!$queue->isActive()) {
+        break;
+      }
+
+      if (static::isFinite($this->maxRequests) && $requests >= $this->maxRequests) {
+        $message = sprintf('Reached request limit (%d)', $this->maxRequests);
+        break;
+      }
+      if (static::isFinite($this->maxDuration) && (microtime(TRUE) - $startTime) >= $this->maxDuration) {
+        $message = sprintf('Reached duration limit (%d)', $this->maxDuration);
+        break;
+      }
+
+      try {
+        $requests++;
+
+        $claims = Queue::claimItems($perm)->setQueue($this->queue)->execute()->getArrayCopy();
+        if (empty($claims)) {
+          $message = 'No claimable items';
+          break;
+        }
+
+        $batchResults = Queue::runItems($perm)->setQueue($this->queue)->setItems($claims)->execute();
+      }
+      catch (\Throwable $t) {
+        $errors++;
+        $message = sprintf('Queue-item raised unhandled exception (%s: %s)', get_class($t), $t->getMessage());
+        break;
+      }
+
+      foreach ($batchResults as $batchResult) {
+        if ($batchResult['outcome'] === 'ok') {
+          $successes++;
+        }
+        else {
+          $errors++;
+          // Should we stop? No, we're just reporting stats.
+          // What about queues with policy "error=>abort"? They must update ("status=>aborted") under the aegis of runItems().
+          // Stopping here would obscure problems that affect all main-loops.
+        }
+      }
+    }
+
+    $result[] = [
+      'loop_duration' => sprintf('%.3f', microtime(TRUE) - $startTime),
+      'loop_requests' => $requests,
+      'item_successes' => $successes,
+      'item_errors' => $errors,
+      'queue_ready' => $queue->getStatistic('ready'),
+      'queue_blocked' => $queue->getStatistic('blocked'),
+      'queue_total' => $queue->getStatistic('total'),
+      'exit_message' => $message,
+    ];
+  }
+
+  private static function isFinite($value): bool {
+    return $value !== NULL && $value >= 0;
+  }
+
+}

--- a/Civi/Api4/Action/Queue/RunLoop.php
+++ b/Civi/Api4/Action/Queue/RunLoop.php
@@ -67,6 +67,7 @@ class RunLoop extends \Civi\Api4\Generic\AbstractAction {
 
     while (TRUE) {
       if (!$queue->isActive()) {
+        $message = sprintf('Queue is not active (status => %s)', $queue->getStatus());
         break;
       }
 

--- a/Civi/Api4/Queue.php
+++ b/Civi/Api4/Queue.php
@@ -11,8 +11,8 @@
 namespace Civi\Api4;
 
 use Civi\Api4\Action\Queue\ClaimItems;
+use Civi\Api4\Action\Queue\RunAll;
 use Civi\Api4\Action\Queue\RunItems;
-use Civi\Api4\Action\Queue\RunLoop;
 
 /**
  * Track a list of durable/scannable queues.
@@ -71,13 +71,13 @@ class Queue extends \Civi\Api4\Generic\DAOEntity {
    *
    * Note: This is appropriate for persistent, auto-run queues.
    *
-   * Note: `runLoop()` executes several units-of-work. It may handle multiple batches.
+   * Note: `runAll()` executes several units-of-work. It may handle multiple batches.
    *
    * @param bool $checkPermissions
-   * @return \Civi\Api4\Action\Queue\RunLoop
+   * @return \Civi\Api4\Action\Queue\RunAll
    */
-  public static function runLoop($checkPermissions = TRUE) {
-    return (new RunLoop(static::getEntityName(), __FUNCTION__))
+  public static function runAll($checkPermissions = TRUE) {
+    return (new RunAll(static::getEntityName(), __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 

--- a/Civi/Api4/Queue.php
+++ b/Civi/Api4/Queue.php
@@ -12,6 +12,7 @@ namespace Civi\Api4;
 
 use Civi\Api4\Action\Queue\ClaimItems;
 use Civi\Api4\Action\Queue\RunItems;
+use Civi\Api4\Action\Queue\RunLoop;
 
 /**
  * Track a list of durable/scannable queues.
@@ -62,6 +63,21 @@ class Queue extends \Civi\Api4\Generic\DAOEntity {
    */
   public static function runItems($checkPermissions = TRUE) {
     return (new RunItems(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * Run a series of items from a queue.
+   *
+   * Note: This is appropriate for persistent, auto-run queues.
+   *
+   * Note: `runLoop()` executes several units-of-work. It may handle multiple batches.
+   *
+   * @param bool $checkPermissions
+   * @return \Civi\Api4\Action\Queue\RunLoop
+   */
+  public static function runLoop($checkPermissions = TRUE) {
+    return (new RunLoop(static::getEntityName(), __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 

--- a/tests/phpunit/api/v4/Entity/QueueTest.php
+++ b/tests/phpunit/api/v4/Entity/QueueTest.php
@@ -171,8 +171,8 @@ class QueueTest extends Api4TestBase {
     $this->assertEquals([6], \Civi::$statics[__CLASS__]['onHookQueueRunLog'][2]);
   }
 
-  public function testRunLoop() {
-    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_runloop';
+  public function testRunAll() {
+    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_runall';
     \Civi::dispatcher()->addListener('hook_civicrm_queueRun_testStuff', [$this, 'onHookQueueRun']);
     $queue = \Civi::queue($queueName, [
       'type' => 'SqlParallel',
@@ -187,7 +187,7 @@ class QueueTest extends Api4TestBase {
     }
 
     // 20 items ==> 4 per batch ==> 5 batches. Let's run the first 3...
-    $result = Queue::runLoop(0)->setQueue($queueName)->setMaxRequests(3)->execute();
+    $result = Queue::runAll(0)->setQueue($queueName)->setMaxRequests(3)->execute();
     $this->assertEquals([0, 1, 2, 3], \Civi::$statics[__CLASS__]['onHookQueueRunLog'][0], 'Scope of first batch');
     $this->assertEquals([4, 5, 6, 7], \Civi::$statics[__CLASS__]['onHookQueueRunLog'][1], 'Scope of second batch');
     $this->assertEquals([8, 9, 10, 11], \Civi::$statics[__CLASS__]['onHookQueueRunLog'][2], 'Scope of third batch');
@@ -201,7 +201,7 @@ class QueueTest extends Api4TestBase {
     $this->assertEquals(8, $result[0]['queue_total'], 'Due to request limit, we left some items in queue');
 
     // And run any remaining batches...
-    $result = Queue::runLoop(0)->setQueue($queueName)->setMaxRequests(10)->execute();
+    $result = Queue::runAll(0)->setQueue($queueName)->setMaxRequests(10)->execute();
     $this->assertEquals([12, 13, 14, 15], \Civi::$statics[__CLASS__]['onHookQueueRunLog'][3], 'Scope of fourth batch');
     $this->assertEquals([16, 17, 18, 19], \Civi::$statics[__CLASS__]['onHookQueueRunLog'][4], 'Scope of fifth batch');
     $this->assertEquals(8, $result[0]['item_successes']);
@@ -214,8 +214,8 @@ class QueueTest extends Api4TestBase {
     $this->assertEquals(0, $result[0]['queue_total'], 'Queue should be empty');
   }
 
-  public function testRunLoop_abort() {
-    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_runloopabort';
+  public function testRunAll_abort() {
+    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_runall';
     $queue = \Civi::queue($queueName, [
       'type' => 'Sql',
       'runner' => 'task',
@@ -230,7 +230,7 @@ class QueueTest extends Api4TestBase {
     \Civi::queue($queueName)->createItem(new \CRM_Queue_Task([__CLASS__, 'dummyTask'], ['ok']));  /*E*/
 
     // 20 items ==> 4 per batch ==> 5 batches. Let's run the first 3...
-    $result = Queue::runLoop(0)->setQueue($queueName)->execute();
+    $result = Queue::runAll(0)->setQueue($queueName)->execute();
     $this->assertEquals(3, $result[0]['item_successes'], "Executed A+B+C");
     $this->assertEquals(1, $result[0]['item_errors'], "Exception on D");
     $this->assertEquals(4, $result[0]['loop_requests'], "Attempted A+B+C+D");


### PR DESCRIPTION
Overview
----------------------------------------

Alternative to #27691. I'll post some notes over there for why `runLoop()` might be better name than `runAll()`, but I'm OK with either. This PR will let tests run with this name.

(*If this variant is merged, then we should copy-over the full description.*)