### PR TITLE
SavedSearchMappingTest - Fix compat with php73

### DIFF
--- a/tests/phpunit/Civi/ActionSchedule/SavedSearchMappingTest.php
+++ b/tests/phpunit/Civi/ActionSchedule/SavedSearchMappingTest.php
@@ -12,7 +12,7 @@ use Civi\Api4\Contact;
  */
 class SavedSearchMappingTest extends AbstractMappingTest {
 
-  protected array $savedSearch = [];
+  protected $savedSearch = [];
 
   protected function setUp(): void {
     parent::setUp();


### PR DESCRIPTION
Overview
----------------------------------------

Fix a test failure that appears in the matrix for 5.66-rc+php73. (The test was recently introduced circa 5.66 via #27081.)