### PR TITLE
CRM_Utils_String - Deprecate startsWith and endsWith

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2335,8 +2335,8 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
     $params['rowCount'] = $params['rp'];
     $params['sort'] = $params['sortBy'] ?? NULL;
     $params['caseId'] = NULL;
-    $context = $params['context'] ?? NULL;
-    $showContactOverlay = !CRM_Utils_String::startsWith($context, "dashlet");
+    $context = $params['context'] ?? '';
+    $showContactOverlay = !str_starts_with($context, "dashlet");
     $activityTypeInfo = civicrm_api3('OptionValue', 'get', [
       'option_group_id' => "activity_type",
       'options' => ['limit' => 0],

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -383,7 +383,7 @@ class CRM_Extension_Mapper {
   public function getKeysByPath($pattern) {
     $keys = [];
 
-    if (CRM_Utils_String::endsWith($pattern, '*')) {
+    if (str_ends_with($pattern, '*')) {
       $prefix = rtrim($pattern, '*');
       foreach ($this->container->getKeys() as $key) {
         $path = CRM_Utils_File::addTrailingSlash($this->container->getPath($key));

--- a/CRM/Utils/EnglishNumber.php
+++ b/CRM/Utils/EnglishNumber.php
@@ -136,14 +136,14 @@ class CRM_Utils_EnglishNumber {
     $strBuf = strtolower(str_replace('-', '', $english));
 
     foreach (self::$intervalsOfTen as $num => $name) {
-      if (CRM_Utils_String::startsWith($strBuf, strtolower($name))) {
+      if (str_starts_with($strBuf, strtolower($name))) {
         $intBuf += 10 * $num;
         $strBuf = substr($strBuf, strlen($name));
         break;
       }
     }
     foreach (array_reverse(self::$lowNumbers, TRUE) as $num => $name) {
-      if (CRM_Utils_String::startsWith($strBuf, strtolower($name))) {
+      if (str_starts_with($strBuf, strtolower($name))) {
         $intBuf += $num;
         $strBuf = substr($strBuf, strlen($name));
         break;

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -876,7 +876,7 @@ class CRM_Utils_String {
   }
 
   /**
-   * Determine if $string starts with $fragment.
+   * @deprecated
    *
    * @param string $string
    *   The long string.
@@ -885,15 +885,12 @@ class CRM_Utils_String {
    * @return bool
    */
   public static function startsWith($string, $fragment) {
-    if ($fragment === '') {
-      return TRUE;
-    }
-    $len = strlen($fragment ?? '');
-    return substr(($string ?? ''), 0, $len) === $fragment;
+    CRM_Core_Error::deprecatedFunctionWarning('str_starts_with');
+    return str_starts_with((string) $string, (string) $fragment);
   }
 
   /**
-   * Determine if $string ends with $fragment.
+   * @deprecated
    *
    * @param string $string
    *   The long string.
@@ -902,11 +899,8 @@ class CRM_Utils_String {
    * @return bool
    */
   public static function endsWith($string, $fragment) {
-    if ($fragment === '') {
-      return TRUE;
-    }
-    $len = strlen($fragment ?? '');
-    return substr(($string ?? ''), -1 * $len) === $fragment;
+    CRM_Core_Error::deprecatedFunctionWarning('str_ends_with');
+    return str_ends_with((string) $string, (string) $fragment);
   }
 
   /**
@@ -920,7 +914,7 @@ class CRM_Utils_String {
     $patterns = (array) $patterns;
     $result = [];
     foreach ($patterns as $pattern) {
-      if (!\CRM_Utils_String::endsWith($pattern, '*')) {
+      if (!str_ends_with($pattern, '*')) {
         if ($allowNew || in_array($pattern, $allStrings)) {
           $result[] = $pattern;
         }
@@ -928,7 +922,7 @@ class CRM_Utils_String {
       else {
         $prefix = rtrim($pattern, '*');
         foreach ($allStrings as $key) {
-          if (\CRM_Utils_String::startsWith($key, $prefix)) {
+          if (str_starts_with($key, $prefix)) {
             $result[] = $key;
           }
         }

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1585,7 +1585,7 @@ class CRM_Utils_Token {
       default:
         if (in_array($token, $supportedTokens)) {
           $value = $membership[$token];
-          if (CRM_Utils_String::endsWith($token, '_date')) {
+          if (str_ends_with($token, '_date')) {
             $value = CRM_Utils_Date::customFormat($value);
           }
         }
@@ -1746,7 +1746,7 @@ class CRM_Utils_Token {
         $value = CRM_Core_PseudoConstant::getLabel('CRM_Contact_BAO_Contact', $token, $value);
       }
     }
-    elseif ($value && CRM_Utils_String::endsWith($token, '_date')) {
+    elseif ($value && str_ends_with($token, '_date')) {
       $value = CRM_Utils_Date::customFormat($value);
     }
     return $value;

--- a/Civi/Api4/Utils/ReflectionUtils.php
+++ b/Civi/Api4/Utils/ReflectionUtils.php
@@ -206,7 +206,7 @@ class ReflectionUtils {
 
       yield from [];
       foreach ($clazz->getMethods(\ReflectionMethod::IS_PUBLIC | \ReflectionMethod::IS_PROTECTED) as $m) {
-        if (\CRM_Utils_String::startsWith($m->getName(), $prefix)) {
+        if (str_starts_with($m->getName(), $prefix)) {
           yield $m;
         }
       }

--- a/Civi/Test/HttpTestTrait.php
+++ b/Civi/Test/HttpTestTrait.php
@@ -75,7 +75,7 @@ trait HttpTestTrait {
    * @return mixed
    */
   protected function callApi4AjaxSuccess(string $entity, string $action, $params = []) {
-    $method = \CRM_Utils_String::startsWith($action, 'get') ? 'GET' : 'POST';
+    $method = str_starts_with($action, 'get') ? 'GET' : 'POST';
     $response = $this->createGuzzle()->request($method, "civicrm/ajax/api4/$entity/$action", [
       'headers' => ['X-Requested-With' => 'XMLHttpRequest'],
       // This should probably be 'form_params', but 'query' is more representative of frontend.
@@ -99,7 +99,7 @@ trait HttpTestTrait {
    * @return mixed
    */
   protected function callApi4AjaxError(string $entity, string $action, $params = []) {
-    $method = \CRM_Utils_String::startsWith($action, 'get') ? 'GET' : 'POST';
+    $method = str_starts_with($action, 'get') ? 'GET' : 'POST';
     $response = $this->createGuzzle()->request($method, "civicrm/ajax/api4/$entity/$action", [
       'headers' => ['X-Requested-With' => 'XMLHttpRequest'],
       // This should probably be 'form_params', but 'query' is more representative of frontend.

--- a/ext/authx/authx.php
+++ b/ext/authx/authx.php
@@ -73,7 +73,7 @@ function _authx_redact(array $keys) {
 function _authx_reload($route, $queryString) {
   parse_str($queryString, $query);
   foreach (array_keys($query) as $key) {
-    if (CRM_Utils_String::startsWith($key, '_authx')) {
+    if (str_starts_with($key, '_authx')) {
       unset($query[$key]);
     }
   }

--- a/ext/legacycustomsearches/CRM/Utils/QueryFormatter.php
+++ b/ext/legacycustomsearches/CRM/Utils/QueryFormatter.php
@@ -283,7 +283,7 @@ class CRM_Utils_QueryFormatter {
     //Return if searched string ends with an unsupported operator.
     //Or if the string contains an invalid joint occurrence of operators.
     foreach ($operators as $val) {
-      if ($text == '@' || CRM_Utils_String::endsWith($text, $val) || preg_match("/[{$expression}]{2,}/", $text)) {
+      if ($text == '@' || str_ends_with($text, $val) || preg_match("/[{$expression}]{2,}/", $text)) {
         $csid = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionValue', 'CRM_Contact_Form_Search_Custom_FullText', 'value', 'name');
         $url = CRM_Utils_System::url("civicrm/contact/search/custom", "csid={$csid}&reset=1");
         $operators = implode("', '", $operators);

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1319,7 +1319,7 @@ Expires: ',
     $discountedItems = 0;
     foreach ($lineItemResult['values'] as $lineItem) {
       $this->assertEquals(round($lineItem['line_total'] * .1, 2), $lineItem['tax_amount']);
-      if (CRM_Utils_String::startsWith($lineItem['label'], 'Long Haired Goat')) {
+      if (str_starts_with($lineItem['label'], 'Long Haired Goat')) {
         $this->assertEquals(15.0, $lineItem['line_total']);
         $this->assertEquals('Long Haired Goat - one leg free!', $lineItem['label']);
         $discountedItems++;

--- a/tests/phpunit/CRM/Member/Form/Task/PDFLetterTest.php
+++ b/tests/phpunit/CRM/Member/Form/Task/PDFLetterTest.php
@@ -68,7 +68,7 @@ class CRM_Member_Form_Task_PDFLetterTest extends CiviUnitTestCase {
 
       // Form an expected array replacing tokens for each contact.
       foreach ($tokens as $key => $val) {
-        if (CRM_Utils_String::endsWith($val, '_date')) {
+        if (str_ends_with($val, '_date')) {
           $formattedDate = CRM_Utils_Date::customFormat($params[$val]);
           $expected[$contactId][$val] = "{$key} - {$formattedDate}";
         }

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -191,43 +191,6 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
     $this->assertSame($expected, $actual);
   }
 
-  /**
-   * Data provider for checking how strings start and end.
-   *
-   * @noinspection SpellCheckingInspection
-   */
-  public function startEndCases(): array {
-    $cases = [];
-    $cases[] = ['startsWith', 'foo', '', TRUE];
-    $cases[] = ['startsWith', 'foo', 'f', TRUE];
-    $cases[] = ['startsWith', 'foo', 'fo', TRUE];
-    $cases[] = ['startsWith', 'foo', 'foo', TRUE];
-    $cases[] = ['startsWith', 'foo', 'fooo', FALSE];
-    $cases[] = ['startsWith', 'foo', 'o', FALSE];
-    $cases[] = ['endsWith', 'foo', 'f', FALSE];
-    $cases[] = ['endsWith', 'foo', '', TRUE];
-    $cases[] = ['endsWith', 'foo', 'o', TRUE];
-    $cases[] = ['endsWith', 'foo', 'oo', TRUE];
-    $cases[] = ['endsWith', 'foo', 'foo', TRUE];
-    $cases[] = ['endsWith', 'foo', 'fooo', FALSE];
-    $cases[] = ['endsWith', 'foo*', '*', TRUE];
-    return $cases;
-  }
-
-  /**
-   * @param string $function
-   *   One of: 'startsWith' or 'endsWith'.
-   * @param $string
-   * @param $fragment
-   * @param $expectedResult
-   *
-   * @dataProvider startEndCases
-   */
-  public function testStartEndWith(string $function, $string, $fragment, $expectedResult): void {
-    $actualResult = CRM_Utils_String::$function($string, $fragment);
-    $this->assertEquals($expectedResult, $actualResult, "Checking $function($string,$fragment)");
-  }
-
   public function wildcardCases(): array {
     $cases = [];
     $cases[] = ['*', ['foo.bar.1', 'foo.bar.2', 'foo.whiz', 'bang.bang']];


### PR DESCRIPTION
Overview
----------------------------------------
Gets rid of a couple polyfill functions in `CRM_Utils_String` now that we have PHP8 polyfills in core.