### PR TITLE
AdminUI - Replace Contact Summary Activities tab

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -250,13 +250,15 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     }
     $this->assign('contactId', $this->_currentlyViewedContactId);
 
-    // Give the context.
+    // FIXME: Overcomplicated 'context' causes push-pull between various use-cases for the form
+    // FIXME: the solution is typically to ditch 'context' and just respond to the data
+    // (e.g. is an activity_type_id present? is case_id present?)
     if (!isset($this->_context)) {
       $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
       if (CRM_Contact_Form_Search::isSearchContext($this->_context)) {
         $this->_context = 'search';
       }
-      elseif (!in_array($this->_context, ['dashlet', 'case', 'dashletFullscreen'])
+      elseif (!in_array($this->_context, ['standalone', 'dashlet', 'case', 'dashletFullscreen'])
         && $this->_currentlyViewedContactId
       ) {
         $this->_context = 'activity';

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1106,6 +1106,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     if (empty($this->_id) && !empty($contribution->id)) {
       $this->_id = $contribution->id;
     }
+    $this->ajaxResponse['updateTabs']['#tab_activity'] = TRUE;
     if (!empty($this->_id) && CRM_Core_Permission::access('CiviMember')) {
       $membershipPaymentCount = civicrm_api3('MembershipPayment', 'getCount', ['contribution_id' => $this->_id]);
       if ($membershipPaymentCount) {

--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -126,8 +126,13 @@ class AfformMetadataInjector {
       // If 'operators' is present in the field definition, use it as a limiter
       // Afform expects 'operators' in the fieldDefn to be associative key/label, not just a flat array
       // like it is in the schema.
-      if (!empty($fieldInfo['operators'])) {
-        $operators = array_intersect_key($operators, array_flip($fieldInfo['operators']));
+      $allowedOperators = $fieldInfo['operators'] ?? NULL;
+      // Use list of allowed operators if set on the form (should be in js plain array format)
+      if (!empty($fieldDefn['operators'])) {
+        $allowedOperators = \CRM_Utils_JS::decode($fieldDefn['operators']);
+      }
+      if ($allowedOperators) {
+        $operators = array_intersect_key($operators, array_flip($allowedOperators));
       }
       $fieldDefn['operators'] = \CRM_Utils_JS::encode($operators);
     }

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -167,6 +167,7 @@ function afform_civicrm_tabset($tabsetName, &$tabs, $context) {
   if ($tabsetName !== 'civicrm/contact/view') {
     return;
   }
+  $existingTabs = array_combine(array_keys($tabs), array_column($tabs, 'id'));
   $contactTypes = array_merge((array) ($context['contact_type'] ?? []), $context['contact_sub_type'] ?? []);
   $afforms = Civi\Api4\Afform::get(FALSE)
     ->addSelect('name', 'title', 'icon', 'module_name', 'directive_name', 'summary_contact_type', 'summary_weight')
@@ -179,6 +180,11 @@ function afform_civicrm_tabset($tabsetName, &$tabs, $context) {
     if (!$summaryContactType || !$contactTypes || array_intersect($summaryContactType, $contactTypes)) {
       // Convention is to name the afform like "afformTabMyInfo" which gets the tab name "my_info"
       $tabId = CRM_Utils_String::convertStringToSnakeCase(preg_replace('#^(afformtab|afsearchtab|afform|afsearch)#i', '', $afform['name']));
+      // If a tab with that id already exists, allow the afform to replace it.
+      $existingTab = array_search($tabId, $existingTabs);
+      if ($existingTab !== FALSE) {
+        unset($tabs[$existingTab]);
+      }
       $tabs[] = [
         'id' => $tabId,
         'title' => $afform['title'],

--- a/ext/afform/core/ang/af/afFieldWithSearchOperator.html
+++ b/ext/afform/core/ang/af/afFieldWithSearchOperator.html
@@ -1,4 +1,4 @@
-<select class="form-control" crm-ui-select ng-model="$ctrl.search_operator" ng-change="$ctrl.onChangeOperator()">
+<select class="form-control afform-search-operator" crm-ui-select ng-model="$ctrl.search_operator" ng-change="$ctrl.onChangeOperator()">
   <option ng-repeat="(name, label) in $ctrl.defn.operators" value="{{ name }}">{{ label }}</option>
 </select>
 <div class="crm-af-field" ng-include="'~/af/fields/' + $ctrl.defn.input_type + '.html'"></div>

--- a/ext/afform/core/ang/afCore.css
+++ b/ext/afform/core/ang/afCore.css
@@ -36,6 +36,10 @@ af-form {
   display: inline-block;
 }
 
+#bootstrap-theme .input-group .afform-search-operator {
+  width: 6rem;
+}
+
 [af-repeat-item] {
   position: relative;
 }

--- a/ext/civicrm_admin_ui/ang/afsearchTabActivity.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchTabActivity.aff.html
@@ -1,0 +1,9 @@
+<div af-fieldset="" store-values="1">
+  <div class="af-container af-layout-inline">
+    <af-field name="activity_type_id" defn="{input_attrs: {multiple: true, placeholder: ts('Include')}, label: false, search_operator: 'IN'}" />
+    <af-field name="activity_type_id" defn="{input_attrs: {multiple: true, placeholder: ts('Exclude')}, label: false, search_operator: 'NOT IN'}" />
+    <af-field name="status_id" defn="{input_attrs: {multiple: true, placeholder: ts('Status')}, label: false}" />
+    <af-field name="activity_date_time" defn="{input_type: 'Select', search_range: true, input_attrs: {placeholder: ts('Date')}, label: false}" />
+  </div>
+  <crm-search-display-table search-name="Contact_Summary_Activities" display-name="Contact_Summary_Activities_Tab" filters="{'Activity_ActivityContact_Contact_01.id': options.contact_id}"></crm-search-display-table>
+</div>

--- a/ext/civicrm_admin_ui/ang/afsearchTabActivity.aff.php
+++ b/ext/civicrm_admin_ui/ang/afsearchTabActivity.aff.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+  'type' => 'search',
+  'title' => ts('Activities'),
+  'description' => '',
+  'contact_summary' => 'tab',
+  'summary_weight' => 70,
+  'icon' => 'fa-tasks',
+  'permission' => [
+    'access CiviCRM',
+  ],
+  'permission_operator' => 'AND',
+];

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Activities.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Activities.mgd.php
@@ -1,0 +1,258 @@
+<?php
+
+// Conditionally exclude CiviCase activities
+$excludeCaseActivities = (CRM_Core_Component::isEnabled('CiviCase') && !\Civi::settings()->get('civicaseShowCaseActivities'));
+return [
+  [
+    'name' => 'SavedSearch_Contact_Summary_Activities',
+    'entity' => 'SavedSearch',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Contact_Summary_Activities',
+        'label' => ts('Contact Summary Activities'),
+        'api_entity' => 'Activity',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'activity_type_id:label',
+            'subject',
+            'activity_date_time',
+            'status_id:label',
+            'GROUP_CONCAT(UNIQUE Activity_ActivityContact_Contact_02.sort_name) AS GROUP_CONCAT_Activity_ActivityContact_Contact_02_sort_name',
+            'GROUP_CONCAT(UNIQUE Activity_ActivityContact_Contact_03.sort_name) AS GROUP_CONCAT_Activity_ActivityContact_Contact_03_sort_name',
+            'GROUP_CONCAT(UNIQUE Activity_ActivityContact_Contact_04.sort_name) AS GROUP_CONCAT_Activity_ActivityContact_Contact_04_sort_name',
+          ],
+          'orderBy' => [],
+          'where' => $excludeCaseActivities ? [['case_id', 'IS EMPTY']] : [],
+          'groupBy' => [
+            'id',
+          ],
+          'join' => [
+            [
+              'Contact AS Activity_ActivityContact_Contact_01',
+              'INNER',
+              'ActivityContact',
+              [
+                'id',
+                '=',
+                'Activity_ActivityContact_Contact_01.activity_id',
+              ],
+            ],
+            [
+              'Contact AS Activity_ActivityContact_Contact_02',
+              'LEFT',
+              'ActivityContact',
+              [
+                'id',
+                '=',
+                'Activity_ActivityContact_Contact_02.activity_id',
+              ],
+              [
+                'Activity_ActivityContact_Contact_02.record_type_id:name',
+                '=',
+                '"Activity Source"',
+              ],
+            ],
+            [
+              'Contact AS Activity_ActivityContact_Contact_03',
+              'LEFT',
+              'ActivityContact',
+              [
+                'id',
+                '=',
+                'Activity_ActivityContact_Contact_03.activity_id',
+              ],
+              [
+                'Activity_ActivityContact_Contact_03.record_type_id:name',
+                '=',
+                '"Activity Targets"',
+              ],
+            ],
+            [
+              'Contact AS Activity_ActivityContact_Contact_04',
+              'LEFT',
+              'ActivityContact',
+              [
+                'id',
+                '=',
+                'Activity_ActivityContact_Contact_04.activity_id',
+              ],
+              [
+                'Activity_ActivityContact_Contact_04.record_type_id:name',
+                '=',
+                '"Activity Assignees"',
+              ],
+            ],
+          ],
+          'having' => [],
+        ],
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'SavedSearch_Contact_Summary_Activities_SearchDisplay_Contact_Summary_Activities_Tab',
+    'entity' => 'SearchDisplay',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Contact_Summary_Activities_Tab',
+        'label' => ts('Contact Summary Activities Tab'),
+        'saved_search_id.name' => 'Contact_Summary_Activities',
+        'type' => 'table',
+        'settings' => [
+          'description' => NULL,
+          'sort' => [
+            [
+              'activity_date_time',
+              'DESC',
+            ],
+          ],
+          'limit' => 50,
+          'pager' => [
+            'hide_single' => TRUE,
+            'show_count' => TRUE,
+            'expose_limit' => TRUE,
+          ],
+          'placeholder' => 5,
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'activity_type_id:label',
+              'dataType' => 'Integer',
+              'label' => ts('Type'),
+              'sortable' => TRUE,
+              'icons' => [
+                [
+                  'field' => 'activity_type_id:icon',
+                  'side' => 'left',
+                ],
+              ],
+            ],
+            [
+              'type' => 'field',
+              'key' => 'subject',
+              'dataType' => 'String',
+              'label' => ts('Subject'),
+              'sortable' => TRUE,
+              'editable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'activity_date_time',
+              'dataType' => 'Timestamp',
+              'label' => ts('Date'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'status_id:label',
+              'dataType' => 'Integer',
+              'label' => ts('Status'),
+              'sortable' => TRUE,
+              'editable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'GROUP_CONCAT_Activity_ActivityContact_Contact_02_sort_name',
+              'dataType' => 'String',
+              'label' => ts('Added By'),
+              'sortable' => TRUE,
+              'link' => [
+                'entity' => 'Contact',
+                'action' => 'view',
+                'join' => 'Activity_ActivityContact_Contact_02',
+                'target' => '_blank',
+              ],
+            ],
+            [
+              'type' => 'field',
+              'key' => 'GROUP_CONCAT_Activity_ActivityContact_Contact_03_sort_name',
+              'dataType' => 'String',
+              'label' => ts('With'),
+              'sortable' => TRUE,
+              'link' => [
+                'entity' => 'Contact',
+                'action' => 'view',
+                'join' => 'Activity_ActivityContact_Contact_03',
+                'target' => '_blank',
+              ],
+            ],
+            [
+              'type' => 'field',
+              'key' => 'GROUP_CONCAT_Activity_ActivityContact_Contact_04_sort_name',
+              'dataType' => 'String',
+              'label' => ts('Assigned'),
+              'sortable' => TRUE,
+              'link' => [
+                'entity' => 'Contact',
+                'action' => 'view',
+                'join' => 'Activity_ActivityContact_Contact_04',
+                'target' => '_blank',
+              ],
+            ],
+            [
+              'text' => '',
+              'style' => 'default',
+              'size' => 'btn-xs',
+              'icon' => 'fa-bars',
+              'links' => [
+                [
+                  'entity' => 'Activity',
+                  'action' => 'view',
+                  'target' => 'crm-popup',
+                  'icon' => 'fa-external-link',
+                  'text' => ts('View Activity'),
+                  'style' => 'default',
+                ],
+                [
+                  'entity' => 'Activity',
+                  'action' => 'update',
+                  'target' => 'crm-popup',
+                  'icon' => 'fa-pencil',
+                  'text' => ts('Update Activity'),
+                  'style' => 'default',
+                ],
+                [
+                  'entity' => 'Activity',
+                  'action' => 'delete',
+                  'target' => 'crm-popup',
+                  'icon' => 'fa-trash',
+                  'text' => ts('Delete Activity'),
+                  'style' => 'danger',
+                ],
+              ],
+              'type' => 'menu',
+              'alignment' => 'text-right',
+            ],
+          ],
+          'classes' => [
+            'table',
+            'table-striped',
+          ],
+          'toolbar' => [
+            [
+              'action' => 'add',
+              'entity' => 'Activity',
+              'text' => ts('Add Activity'),
+              'icon' => 'fa-plus',
+              'style' => 'primary',
+              'target' => 'crm-popup',
+            ],
+          ],
+        ],
+      ],
+      'match' => [
+        'name',
+        'saved_search_id',
+      ],
+    ],
+  ],
+];

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -137,8 +137,8 @@ class Run extends AbstractRunAction {
       return [];
     }
     // There is no row data, but some values can be inferred from query filters
-    // First pass: gather raw data from the where clause
-    foreach ($this->_apiParams['where'] as $clause) {
+    // First pass: gather raw data from the where & having clauses
+    foreach (array_merge($this->_apiParams['where'], $this->_apiParams['having'] ?? []) as $clause) {
       if ($clause[1] === '=' || $clause[1] === 'IN') {
         $data[$clause[0]] = $clause[2];
       }

--- a/templates/CRM/common/TabHeader.js
+++ b/templates/CRM/common/TabHeader.js
@@ -123,6 +123,9 @@
    * @param count {Number}
    */
   CRM.tabHeader.updateCount = function(tab, count) {
+    if (typeof count === 'boolean') {
+      return;
+    }
     var oldClass = getCountClass(tab);
     if (oldClass) {
       $(tab).removeClass(oldClass);


### PR DESCRIPTION
Overview
----------------------------------------
3rd core contact summary tab to be replaced by SearchKit!
Unlike #27610 and #27701 this one is added to the optional *Admin UI* extension instead of directly to core, since it's more complex and more heavily used. This will give a trial period with some time to test the new version & update any customizations they've made to the old version of the tab.

Before
----------------------------------------
![Before](https://github.com/civicrm/civicrm-core/assets/2874912/b0ae685d-0e26-4661-88a3-0ae745e02bfa)

After
----------------------------------------
![After](https://github.com/civicrm/civicrm-core/assets/2874912/fca9f2aa-8e50-463d-9f37-a402abdd2819)

Comments
-----------
A couple differences between the before & after UI:

1. The (rather obscure) 'preserve_activity_tab_filter' system setting is now ignored. Filters are always remembered on this tab. Instead of via the setting, the behavior can be disabled by toggling "Remember Filters" in the Afform (thanks to #27737 it's now a general feature for every search form not just the activity tab).
2. ~~To create a new activity, instead of picking an activity type from a dropdown and then getting a popup, you get a popup and then pick the activity type from a dropdown.~~ Fixed via #27973, see updated screenshot above.

**Note:** The `civicaseShowCaseActivities` system setting is respected by this new display. Case activities will be shown if that setting is enabled. However, once this code gets migrated from AdminUI to core, we should probably look at phasing out that setting since it can be achieved simply by editing the SavedSearch criteria.