### PR TITLE
getTree: initialize variable before it's used (PHP8 compat)

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -550,6 +550,7 @@ ORDER BY civicrm_custom_group.weight,
       $cacheString .= "_Inline";
     }
 
+    $multipleFieldGroups = [];
     $cacheKey = "CRM_Core_DAO_CustomGroup_Query " . md5($cacheString);
     $multipleFieldGroupCacheKey = "CRM_Core_DAO_CustomGroup_QueryMultipleFields " . md5($cacheString);
     $cache = CRM_Utils_Cache::singleton();


### PR DESCRIPTION
Overview
----------------------------------------
`CRM_Core_BAO_CustomGroup::getTree()` can crash when `$multipleFieldGroups` is `NULL` and not an empty array.

Before
----------------------------------------
Crash.  Backtrace below.

After
----------------------------------------
No crash.

Comments
----------------------------------------
I can't replicate this myself, it seems to be related to permissions.  But it seems sufficiently common-sense that we should initialize a variable, so hopefully this is inoffensive enough to go through without replication steps.

```
TypeError: in_array(): Argument #2 ($haystack) must be of type array, null given in in_array() (line 593 of /code/vendor/civicrm/civicrm-core/CRM/Core/BAO/CustomGroup.php)

#0 /code/vendor/civicrm/civicrm-core/CRM/Core/BAO/CustomGroup.php(593): in_array('civicrm_value_e...', NULL)
#1 /code/vendor/civicrm/civicrm-core/api/v3/utils.php(1425): CRM_Core_BAO_CustomGroup::getTree('Relationship', Array, 44261, NULL, Array, NULL, true, NULL, true, 2)
#2 /code/vendor/civicrm/civicrm-core/api/v3/Relationship.php(105): _civicrm_api3_custom_data_get(Array, true, 'Relationship', 44261, NULL, '36')
#3 /code/vendor/civicrm/civicrm-core/Civi/API/Provider/MagicFunctionProvider.php(89): civicrm_api3_relationship_get(Array)
#4 /code/vendor/civicrm/civicrm-core/Civi/API/Kernel.php(158): Civi\API\Provider\MagicFunctionProvider->invoke(Array)
#5 /code/vendor/civicrm/civicrm-core/Civi/API/Kernel.php(81): Civi\API\Kernel->runRequest(Array)
#6 /code/vendor/civicrm/civicrm-core/api/api.php(133): Civi\API\Kernel->runSafe('Relationship', 'get', Array)
#7 /code/sites/all/civicrm/extensions/org.wikimedia.relationshipblock/CRM/Relationshipblock/Utils/RelationshipBlock.php(20): civicrm_api3('Relationship', 'get', Array)
#8 /code/sites/all/civicrm/extensions/org.wikimedia.relationshipblock/CRM/Relationshipblock/Page/Inline/RelationshipBlock.php(27): CRM_Relationshipblock_Utils_RelationshipBlock::getExistingRelationships(2695)
#9 /code/sites/all/civicrm/extensions/org.wikimedia.relationshipblock/relationshipblock.php(97): CRM_Relationshipblock_Page_Inline_RelationshipBlock::addKeyRelationshipsBlock(Object(CRM_Contact_Page_View_Summary), 2695)
#10 /code/vendor/civicrm/civicrm-core/CRM/Utils/Hook.php(272): relationshipblock_civicrm_pageRun(Object(CRM_Contact_Page_View_Summary))
#11 /code/vendor/civicrm/civicrm-core/CRM/Utils/Hook/DrupalBase.php(73): CRM_Utils_Hook->runHooks(Array, 'civicrm_pageRun', 1, Object(CRM_Contact_Page_View_Summary), NULL, NULL, NULL, NULL, NULL)
#12 /code/vendor/civicrm/civicrm-core/Civi/Core/CiviEventDispatcher.php(310): CRM_Utils_Hook_DrupalBase->invokeViaUF(1, Object(CRM_Contact_Page_View_Summary), NULL, NULL, NULL, NULL, NULL, 'civicrm_pageRun')
#13 /code/vendor/symfony/event-dispatcher/EventDispatcher.php(251): Civi\Core\CiviEventDispatcher::delegateToUF(Object(Civi\Core\Event\GenericHookEvent), 'hook_civicrm_pa...', Object(Civi\Core\UnoptimizedEventDispatcher))
#14 /code/vendor/symfony/event-dispatcher/EventDispatcher.php(73): Symfony\Component\EventDispatcher\EventDispatcher->callListeners(Array, 'hook_civicrm_pa...', Object(Civi\Core\Event\GenericHookEvent))
#15 /code/vendor/civicrm/civicrm-core/Civi/Core/CiviEventDispatcher.php(263): Symfony\Component\EventDispatcher\EventDispatcher->dispatch(Object(Civi\Core\Event\GenericHookEvent), 'hook_civicrm_pa...')
#16 /code/vendor/civicrm/civicrm-core/CRM/Utils/Hook.php(168): Civi\Core\CiviEventDispatcher->dispatch('hook_civicrm_pa...', Object(Civi\Core\Event\GenericHookEvent))
#17 /code/vendor/civicrm/civicrm-core/CRM/Utils/Hook.php(984): CRM_Utils_Hook->invoke(Array, Object(CRM_Contact_Page_View_Summary), NULL, NULL, NULL, NULL, NULL, 'civicrm_pageRun')
#18 /code/vendor/civicrm/civicrm-core/CRM/Core/Page.php(212): CRM_Utils_Hook::pageRun(Object(CRM_Contact_Page_View_Summary))
#19 /code/vendor/civicrm/civicrm-core/CRM/Contact/Page/View/Summary.php(86): CRM_Core_Page->run()
#20 /code/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php(319): CRM_Contact_Page_View_Summary->run(Array, NULL)
#21 /code/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php(69): CRM_Core_Invoke::runItem(Array)
#22 /code/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php(36): CRM_Core_Invoke::_invoke(Array)
#23 /code/modules/contrib/civicrm/src/Civicrm.php(88): CRM_Core_Invoke::invoke(Array)
#24 /code/modules/contrib/civicrm/src/Controller/CivicrmController.php(83): Drupal\civicrm\Civicrm->invoke(Array)
#25 [internal function]: Drupal\civicrm\Controller\CivicrmController->main(Array, '')
#26 /code/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(123): call_user_func_array(Array, Array)
#27 /code/core/lib/Drupal/Core/Render/Renderer.php(580): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#28 /code/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(124): Drupal\Core\Render\Renderer->executeInRenderContext(Object(Drupal\Core\Render\RenderContext), Object(Closure))
#29 /code/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(97): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext(Array, Array)
#30 /code/vendor/symfony/http-kernel/HttpKernel.php(169): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#31 /code/vendor/symfony/http-kernel/HttpKernel.php(81): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#32 /code/core/lib/Drupal/Core/StackMiddleware/Session.php(58): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#33 /code/core/lib/Drupal/Core/StackMiddleware/KernelPreHandle.php(48): Drupal\Core\StackMiddleware\Session->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#34 /code/core/modules/page_cache/src/StackMiddleware/PageCache.php(106): Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#35 /code/core/modules/page_cache/src/StackMiddleware/PageCache.php(85): Drupal\page_cache\StackMiddleware\PageCache->pass(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#36 /code/core/lib/Drupal/Core/StackMiddleware/ReverseProxyMiddleware.php(48): Drupal\page_cache\StackMiddleware\PageCache->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#37 /code/core/lib/Drupal/Core/StackMiddleware/NegotiationMiddleware.php(51): Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#38 /code/vendor/stack/builder/src/Stack/StackedHttpKernel.php(23): Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#39 /code/core/lib/Drupal/Core/DrupalKernel.php(718): Stack\StackedHttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#40 /code/index.php(19): Drupal\Core\DrupalKernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#41 {main}
```
