### PR TITLE
php8.x Stop receiving billingID in createAddress

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1656,12 +1656,12 @@ LEFT JOIN civicrm_option_value contribution_status ON (civicrm_contribution.cont
    * thought).
    *
    * @param array $params
-   * @param int $billingLocationTypeID
    *
    * @return int
    *   address id
    */
-  public static function createAddress($params, $billingLocationTypeID) {
+  public static function createAddress($params) {
+    $billingLocationTypeID = CRM_Core_BAO_LocationType::getBilling();
     [$hasBillingField, $addressParams] = self::getBillingAddressParams($params, $billingLocationTypeID);
     if ($hasBillingField) {
       $address = CRM_Core_BAO_Address::writeRecord($addressParams);


### PR DESCRIPTION


Overview
----------------------------------------
Stop receiving billingID in createAddress


Before
----------------------------------------
billing ID passed around

After
----------------------------------------
Billing ID determined where it is used

Technical Details
----------------------------------------

BillingID is determined in the form in one of 2 ways
- calling the function CRM_Core_BAO_LocationType::getBilling();
- hard-coding the number 5

There is no magic whereby it varies depending on the form or can be changed & it is a source of many undefined property errors.

I did a broader PR https://github.com/civicrm/civicrm-core/pull/27561 removing it, which stalled, so making this change makes it easier to remove piecemeal

Comments
----------------------------------------
