### PR TITLE
Remove discussion about format from html box on email form

### DIFF
--- a/templates/CRM/Admin/Form/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Form/MessageTemplates.tpl
@@ -78,14 +78,14 @@
           <div class="clear"></div>
           <div class='html'>
             {$form.msg_html.html|crmAddClass:huge}
-            <div class="description">{ts}An HTML formatted version of this message will be sent to contacts whose Email Format preference is 'HTML' or 'Both'.{/ts}</div>
           </div>
         </div><!-- /.crm-accordion-body -->
       </div><!-- /.crm-accordion-wrapper -->
 
       <div id="msg_text_section" class="crm-accordion-wrapper crm-plaint_text_email-accordion ">
         <div class="crm-accordion-header">
-          {ts}Plain-Text Format{/ts}
+          {ts}Optional Plain-Text Format{/ts}
+          {help id="id-message-plain" file="CRM/Contact/Form/Task/Email.hlp"}
         </div><!-- /.crm-accordion-header -->
         <div class="crm-accordion-body">
           <div class="helpIcon" id="helptext">
@@ -95,7 +95,6 @@
           <div class="clear"></div>
           <div class='text'>
             {$form.msg_text.html|crmAddClass:huge}
-            <div class="description">{ts}Text formatted message.{/ts}</div>
           </div>
         </div><!-- /.crm-accordion-body -->
       </div><!-- /.crm-accordion-wrapper -->

--- a/templates/CRM/Contact/Form/Task/Email.hlp
+++ b/templates/CRM/Contact/Form/Task/Email.hlp
@@ -55,7 +55,15 @@ be an equal sign and a number (=12). The number (12 in this example) is the id o
   {ts}Message Text{/ts}
 {/htxt}
 {htxt id="id-message-text"}
-<p>{ts}You can send your email as a simple text-only message, as an HTML formatted message, or both. Text-only messages are sufficient for most email communication - and some recipients may prefer not to receive HTML formatted messages.{/ts}</p>
-<p>{ts}HTML messages have more visual impact, allow you to include images, and may be more readable if you are including links to website pages. However, different email programs may interpret HTML formats differently - so use this option cautiously unless you have a template format that has been tested with different web and desktop email programs.{/ts}</p>
+<p>{ts}You can include tokens in your message{/ts}</p>
 <p>{docURL page="user/common-workflows/tokens-and-mail-merge" text=$tokentext}</p>
+{/htxt}
+{htxt id="id-message-text-title"}
+  {ts}Message Plain Text{/ts}
+{/htxt}
+{htxt id="id-message-plain"}
+<p>{ts}Configuring a plain text version of a message is optional will be removed from CiviCRM in a future version.{/ts}</p>
+<p>{ts}If the text version is blank one will be automatically generated from the HTML content.{/ts}</p>
+{capture assign=plainText}{ts}Find out more about including a plain text version{/ts}{/capture}
+<p>{docURL page="user/common-workflows/tokens-and-mail-merge" text=$plainText}</p>
 {/htxt}


### PR DESCRIPTION
Overview
----------------------------------------
Remove discussion about format from html box on email form

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/e425e852-5a5e-414d-aa86-f0597051c71b)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/b3b643fb-4b24-49cb-a14c-a8abc641f7da)

![image](https://github.com/civicrm/civicrm-core/assets/336308/70828696-6589-4849-b1f2-083f5dd1c782)



Technical Details
----------------------------------------

Comments
----------------------------------------
I really can't think of anything else useful to say here - but this gets rid of the actively bad text. We could do more on the plain text bit (eg. remove it!) but out of scope for this PR 