### PR TITLE
SearchKit - Optionally remember filter values when user revisits sear…

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
@@ -77,4 +77,12 @@
       </div>
     </div>
   </fieldset>
+
+  <fieldset>
+    <legend>{{:: ts('Options') }}</legend>
+    <label>{{:: ts('Remember Filters') }} <input type="checkbox" ng-model="$ctrl.display.fieldset['store-values']"></label>
+    <p class="help-block">
+      {{:: ts('Filter fields will retain their value when the same user revisits the form.') }}
+    </p>
+  </fieldset>
 </div>

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -120,6 +120,9 @@
           else if (urlArgs && (ctrl.fieldName in urlArgs)) {
             setValue(urlArgs[ctrl.fieldName]);
           }
+          else if (ctrl.afFieldset.getStoredValue(ctrl.fieldName) !== undefined) {
+            setValue(ctrl.afFieldset.getStoredValue(ctrl.fieldName));
+          }
           // Set default value based on field defn
           else if ('afform_default' in ctrl.defn) {
             setValue(ctrl.defn.afform_default);

--- a/ext/afform/core/ang/af/afFieldset.directive.js
+++ b/ext/afform/core/ang/af/afFieldset.directive.js
@@ -5,7 +5,8 @@
       restrict: 'A',
       require: ['afFieldset', '?^^afForm'],
       bindToController: {
-        modelName: '@afFieldset'
+        modelName: '@afFieldset',
+        storeValues: '<'
       },
       link: function($scope, $el, $attr, ctrls) {
         var self = ctrls[0];
@@ -39,6 +40,26 @@
         };
         this.getFormName = function() {
           return ctrl.afFormCtrl ? ctrl.afFormCtrl.getFormMeta().name : $scope.meta.name;
+        };
+
+        // If `storeValue` setting is enabled, field values are cached in localStorage
+        function getCacheKey() {
+          return 'afform:' + ctrl.getFormName() + ctrl.getName();
+        }
+        this.getStoredValue = function(fieldName) {
+          if (!this.storeValues) {
+            return;
+          }
+          return CRM.cache.get(getCacheKey(), {})[fieldName];
+        };
+        this.$onInit = function() {
+          if (this.storeValues) {
+            $scope.$watch(ctrl.getFieldData, function(newVal, oldVal) {
+              if (typeof newVal === 'object' && typeof oldVal === 'object' && Object.keys(newVal).length) {
+                CRM.cache.set(getCacheKey(), newVal);
+              }
+            }, true);
+          }
         };
       }
     };


### PR DESCRIPTION
Overview
----------------------------------------
Adds a new per-search-form setting which will remember field values if the same user revisits a form.

![image](https://github.com/civicrm/civicrm-core/assets/2874912/cfb096cc-33da-402d-90a1-6eace964ab55)

Before
----------------------------------------
Field values can be passed through the url and defaults can be set on the form. No "remember filters" option.

After
----------------------------------------
"Remember Filters" option added. Values are stored in a session variable (using Html5 `localStorage`). Field values passed through the url will still take priority over stored values. Stored values take priority over form defaults.

Comments
----------------------------------------
Requires #27736 
