### PR TITLE
Trim text emails when checking if empty

### DIFF
--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -190,7 +190,7 @@ class CRM_Utils_Mail {
       $htmlMessage = FALSE;
     }
     $attachments = $params['attachments'] ?? NULL;
-    if (!empty($params['text'])) {
+    if (!empty($params['text']) && trim($params['text'])) {
       $textMessage = $params['text'];
     }
     else {

--- a/tests/phpunit/CRM/Utils/MailTest.php
+++ b/tests/phpunit/CRM/Utils/MailTest.php
@@ -2,6 +2,7 @@
 
 /**
  * Class CRM_Utils_MailTest
+ *
  * @group headless
  */
 class CRM_Utils_MailTest extends CiviUnitTestCase {
@@ -12,41 +13,40 @@ class CRM_Utils_MailTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test case for add( )
    * test with empty params.
    */
   public function testFormatRFC822(): void {
 
     $values = [
       [
-        'name' => "Test User",
-        'email' => "foo@bar.com",
-        'result' => "Test User <foo@bar.com>",
+        'name' => 'Test User',
+        'email' => 'foo@bar.com',
+        'result' => 'Test User <foo@bar.com>',
       ],
       [
         'name' => '"Test User"',
-        'email' => "foo@bar.com",
-        'result' => "Test User <foo@bar.com>",
+        'email' => 'foo@bar.com',
+        'result' => 'Test User <foo@bar.com>',
       ],
       [
-        'name' => "User, Test",
-        'email' => "foo@bar.com",
+        'name' => 'User, Test',
+        'email' => 'foo@bar.com',
         'result' => '"User, Test" <foo@bar.com>',
       ],
       [
         'name' => '"User, Test"',
-        'email' => "foo@bar.com",
+        'email' => 'foo@bar.com',
         'result' => '"User, Test" <foo@bar.com>',
       ],
       [
         'name' => '"Test User"',
-        'email' => "foo@bar.com",
+        'email' => 'foo@bar.com',
         'result' => '"Test User" <foo@bar.com>',
         'useQuote' => TRUE,
       ],
       [
-        'name' => "User, Test",
-        'email' => "foo@bar.com",
+        'name' => 'User, Test',
+        'email' => 'foo@bar.com',
         'result' => '"User, Test" <foo@bar.com>',
         'useQuote' => TRUE,
       ],
@@ -75,6 +75,19 @@ class CRM_Utils_MailTest extends CiviUnitTestCase {
 
     $this->assertFalse(CRM_Utils_Mail::send($params));
     $this->assertEquals('Unable to send email. Please report this message to the site administrator', CRM_Core_Session::singleton()->getStatus()[0]['text']);
+  }
+
+  public function testEmptyText(): void {
+    $mailHelper = new CiviMailUtils($this);
+    $params = [
+      'toEmail' => 'a@example.com',
+      'from' => 'b@example.com',
+      'html' => '<p>hi</p><p>How are <b>you</b></p>',
+      'text' => " \n\t",
+      'subject' => 'hey',
+    ];
+    CRM_Utils_Mail::send($params);
+    $mailHelper->checkAllMailLog(['How are you']);
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Trim text emails when checking if empty

I was concerned that inadvertant white space might block the addiiton of a text version.

The unit test showed that to be the case so I added the extra trim


Before
----------------------------------------
We attach a generated text version if one is not supplied - however it turned out that we were checking for a truly empty string rather than an 'empty to the eye' string

After
----------------------------------------
We trim whitepace before determining the text to be non empty

Technical Details
----------------------------------------

Comments
----------------------------------------
