### PR TITLE
cache results of CRM_Core_Menu::items()

### DIFF
--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -22,13 +22,6 @@
 class CRM_Core_Menu {
 
   /**
-   * The list of menu items.
-   *
-   * @var array
-   */
-  public static $_items = NULL;
-
-  /**
    * The list of permissioned menu items.
    *
    * @var array
@@ -55,7 +48,7 @@ class CRM_Core_Menu {
    * @return array
    */
   public static function &xmlItems($fetchFromXML = FALSE) {
-    if (!self::$_items || $fetchFromXML) {
+    if (!\Civi::cache('menu')->has('items') || $fetchFromXML) {
       // We needs this until Core becomes a component
       $coreMenuFilesNamespace = 'CRM_Core_xml_Menu';
       $coreMenuFilesPath = str_replace('_', DIRECTORY_SEPARATOR, $coreMenuFilesNamespace);
@@ -70,15 +63,16 @@ class CRM_Core_Menu {
       // lets call a hook and get any additional files if needed
       CRM_Utils_Hook::xmlMenu($files);
 
-      self::$_items = [];
+      $items = [];
       foreach ($files as $file) {
-        self::read($file, self::$_items);
+        self::read($file, $items);
       }
 
-      CRM_Utils_Hook::alterMenu(self::$_items);
+      CRM_Utils_Hook::alterMenu($items);
+      \Civi::cache('menu')->set('items', $items);
     }
-
-    return self::$_items;
+    $items ?: \Civi::cache('menu')->get('items');
+    return $items;
   }
 
   /**

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -182,6 +182,7 @@ class Container {
       'fields' => 'contact fields',
       'contactTypes' => 'contactTypes',
       'metadata' => 'metadata',
+      'menu' => 'menu',
     ];
     $verSuffixCaches = ['metadata'];
     $verSuffix = '_' . preg_replace(';[^0-9a-z_];', '_', \CRM_Utils_System::version());


### PR DESCRIPTION
Overview
----------------------------------------
Following on from the discussion at #27686.

Drupal 8+ rebuilds the menu routes on every page load and API request.  This means scanning for all the XML files on each page load.

Other CMSes only call `CRM_Core_Menu::items()` on cache clear, so they're unaffected.

Before
----------------------------------------
`CRM_Core_Menu::items()` makes expensive file/SQL calls on every page load.

After
----------------------------------------
Menu items stored in cache.

Comments
----------------------------------------
It seems like there must be a better way for D8 to get the routes - the other CMSes don't have this issue.  But this definitely works, and replacing "static array as cache" with `Civi::cache()` seems like a win regardless.