### PR TITLE
Fix rc regression - balance amount missing

### DIFF
--- a/CRM/Event/WorkflowMessage/EventExamples.php
+++ b/CRM/Event/WorkflowMessage/EventExamples.php
@@ -1,5 +1,6 @@
 <?php
 
+use Civi\API\EntityLookupTrait;
 use Civi\Api4\Event;
 use Civi\Api4\PriceSetEntity;
 use Civi\Api4\WorkflowMessage;
@@ -14,6 +15,8 @@ use Civi\Api4\PriceFieldValue;
  * @noinspection PhpUnused
  */
 class CRM_Event_WorkflowMessage_EventExamples extends WorkflowMessageExample {
+
+  use EntityLookupTrait;
 
   /**
    * IDs of events permitting multiple participants.
@@ -44,6 +47,19 @@ class CRM_Event_WorkflowMessage_EventExamples extends WorkflowMessageExample {
           'is_multiple_registrations' => $priceSet['is_multiple_registrations'],
           'is_primary' => TRUE,
           'price_set_id' => $priceSet['id'],
+          'is_partially_paid' => FALSE,
+        ];
+        yield [
+          'name' => 'workflow/' . $workflow . '/' . 'price_set_' . $priceSet['name'] . '_partially_paid',
+          'title' => ts('Partially Paid Registration') . ($priceSet['is_multiple_registrations'] ? ' ' . ts('primary participant') : '') . ' : ' . $priceSet['title'],
+          'tags' => ['preview'],
+          'workflow' => $workflow,
+          'is_show_line_items' => !$priceSet['is_quick_config'],
+          'event_id' => $priceSet['event_id'],
+          'is_multiple_registrations' => $priceSet['is_multiple_registrations'],
+          'is_primary' => TRUE,
+          'price_set_id' => $priceSet['id'],
+          'is_partially_paid' => TRUE,
         ];
         if ($priceSet['is_multiple_registrations']) {
           yield [
@@ -56,6 +72,7 @@ class CRM_Event_WorkflowMessage_EventExamples extends WorkflowMessageExample {
             'is_multiple_registrations' => $priceSet['is_multiple_registrations'],
             'is_primary' => FALSE,
             'price_set_id' => $priceSet['id'],
+            'is_partially_paid' => FALSE,
           ];
         }
       }
@@ -87,6 +104,7 @@ class CRM_Event_WorkflowMessage_EventExamples extends WorkflowMessageExample {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   private function addExampleData(GenericWorkflowMessage $messageTemplate, array $example): void {
+    $this->define('Event', 'event_' . $example['event_id'], ['id' => $example['event_id']]);
     $messageTemplate->setContact(\Civi\Test::example('entity/Contact/Barb'));
     $messageTemplate->setEventID($example['event_id']);
     $isPrimary = $example['is_primary'];
@@ -112,6 +130,9 @@ class CRM_Event_WorkflowMessage_EventExamples extends WorkflowMessageExample {
     $contribution['total_amount'] = $mockOrder->getTotalAmount();
     $contribution['tax_amount'] = $mockOrder->getTotalTaxAmount() ? round($mockOrder->getTotalTaxAmount(), 2) : 0;
     $contribution['tax_exclusive_amount'] = $contribution['total_amount'] - $contribution['tax_amount'];
+    $contribution['is_pay_later'] = $example['is_partially_paid'] && $this->lookup('event_' . $example['event_id'], 'is_pay_later');
+    $contribution['paid_amount'] = $example['is_partially_paid'] ? $contribution['total_amount'] / 2 : 0;
+    $contribution['balance_amount'] = $contribution['total_amount'] - $contribution['paid_amount'];
     $messageTemplate->setContribution($contribution);
     $messageTemplate->setOrder($mockOrder);
     $messageTemplate->setParticipantContacts($participantContacts);

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -1041,6 +1041,7 @@ class CRM_Financial_BAO_Order {
       }
       $lineItem['tax_rate'] = $this->getTaxRate($lineItem['financial_type_id']);
       $lineItem['tax_amount'] = ($lineItem['tax_rate'] / 100) * $lineItem['line_total'];
+      $lineItem['line_total_inclusive'] = $lineItem['tax_amount'] + $lineItem['line_total'];
     }
     if (!empty($lineItem['membership_type_id'])) {
       $lineItem['entity_table'] = 'civicrm_membership';

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -520,10 +520,9 @@ London,',
    * @dataProvider getBooleanDataProvider
    *
    * @param bool $isQuickConfig
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testSubmitPartialPayment(bool $isQuickConfig): void {
+    $this->swapMessageTemplateForInput('event_offline_receipt', '', 'text');
     $email = $this->submitForm(['is_monetary' => 1, 'start_date' => '2023-02-15 15:00', 'end_date' => '2023-02-15 18:00'], [
       'contribution_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed'),
       'total_amount' => '20',
@@ -663,17 +662,23 @@ London,',
       'From: "FIXME" <info@EXAMPLE.ORG>',
       'To: "Mr. Anthony Anderson II" <anthony_anderson@civicrm.org>',
       'Subject: Event Confirmation - Annual CiviCRM meet - Mr. Anthony Anderson II',
-      'Dear Anthony,Contact the Development Department if you need to make any changes to your registration.',
+      'Dear Anthony',
+      'Contact the Development Department if you need to make any changes to your registration.',
       'Event Information and Location',
       'Annual CiviCRM meet',
       'Registered Email',
       'Contact the Development Department if you need to make any changes to your registration.',
-      $isQuickConfig ? $this->formatMoneyInput(1550.55) . ' Family Deal - 1' : 'Fundraising Dinner - Family...',
-      $isAmountPaidOnForm ? 'Total Paid: $20.00' : 'Total Paid: ',
-      $isAmountPaidOnForm ? 'Balance: $1,530.55' : 'Balance: $1,550.55',
-      'Financial Type: Event Fee',
+      $this->formatMoneyInput(1550.55),
+      $isQuickConfig ? ' Family Deal' : 'Fundraising Dinner - Family Deal',
+      $isAmountPaidOnForm ? 'Total Paid' : '',
+      $isAmountPaidOnForm ? $this->formatMoneyInput(20.00) : '',
+      'Balance',
+      $isAmountPaidOnForm ? $this->formatMoneyInput(1530.55) : $this->formatMoneyInput(1550.55),
+      'Financial Type',
+      'Event Fee',
       'February 15th, 2023  3:00 PM- 6:00 PM',
-      'Check Number: 879',
+      'Check Number',
+      '879',
     ]);
   }
 

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -192,7 +192,7 @@
                         <th>{ts}Tax Amount{/ts}</th>
                       {/if}
                       <th>{ts}Total{/ts}</th>
-                        {if $iShowParticipantCount}
+                        {if $isShowParticipantCount}
                           <th>{ts}Total Participants{/ts}</th>
                         {/if}
                     </tr>
@@ -285,19 +285,31 @@
               {ts}Total Amount{/ts}
             </td>
             <td {$valueStyle}>
-              {contribution.total_amount} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
+              {contribution.total_amount}
             </td>
           </tr>
+          {if {contribution.balance_amount|boolean} && {contribution.paid_amount|boolean}}
+            <tr>
+              <td {$labelStyle}>{ts}Total Paid{/ts}</td>
+              <td {$valueStyle}>
+                {contribution.paid_amount|crmMoney}
+              </td>
+            </tr>
+            <tr>
+              <td {$labelStyle}>{ts}Balance{/ts}</td>
+              <td {$valueStyle}>{contribution.balance_amount}</td>
+            </tr>
+          {/if}
           {if $isShowParticipantCount}
             <tr>
               <td {$labelStyle}>{ts}Total Participants{/ts}</td>
               <td {$valueStyle}>{$line.participant_count}</td>
             </tr>
           {/if}
-          {if {contribution.is_pay_later|boolean} && {contribution.balance_amount|boolean}}
+          {if {contribution.is_pay_later|boolean} && {contribution.balance_amount|boolean} && {event.pay_later_receipt|boolean}}
             <tr>
               <td colspan="2" {$labelStyle}>
-                {$pay_later_receipt}
+                {event.pay_later_receipt}
               </td>
             </tr>
           {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Fix rc regression - balance amount missing

This is pretty hard to get to (outside the test). You need to configure an event with a pending contribution and then partially pay it and go back & send a receipt.



This updates the test to check the html version, puts back the removed text and adds it to the preview screen

Before
----------------------------------------
Paid amount & balance amount no longer showing (where the contribution is not fully paid)

After
----------------------------------------
Shows correctly
 
![image](https://github.com/civicrm/civicrm-core/assets/336308/a9a7742d-6b7c-491f-8ae1-296bd000f558)
In addition it is now available in preview mode

![image](https://github.com/civicrm/civicrm-core/assets/336308/a8c8d1c4-9b51-4974-99f1-e12e6785c5d5)

I also fixed it so the pay later text appears if it is pay later & the event has pay later text

![image](https://github.com/civicrm/civicrm-core/assets/336308/5fb338d6-9e39-4122-8710-824d101c6f8f)


Technical Details
----------------------------------------
Unfortunately the
Paid amount & Balance amount
 got removed from the html version by accident
and the tests didn't pick it up because they were testing the text version - which had not had many of the recent updates applied (it was going to be done after but we have since decided to remove the text version).

Note the `hookDiscountMessage` didn't make sense where it was so I searched for it & found it only gets assigned in the online event form

Comments
----------------------------------------

