### PR TITLE
Fix notice (smarty) in Event fee tab

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/Fee.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Fee.tpl
@@ -18,10 +18,6 @@
     {/if}
 <div class="crm-block crm-form-block crm-event-manage-fee-form-block">
     <table class="form-layout">
-       <tr class="crm-event-manage-fee-form-block-title">
-    <td class="label">{$form.title.label}</td>
-    <td>{$form.title.html}</td>
-       </tr>
        <tr class="crm-event-manage-fee-form-block-is_monetary">
           <td class="label">{$form.is_monetary.label}</td>
           <td>{$form.is_monetary.html}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Fix notice (smarty) in Event fee tab

Before
----------------------------------------
With Smarty 3 we get this notice (once the hard-error in https://github.com/civicrm/civicrm-core/pull/27742 is fixed)

![image](https://github.com/civicrm/civicrm-core/assets/336308/6f2f471a-f1ef-4f70-b357-28f6ea3e1884)



After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/7c48a8b3-cf0d-4ba3-8f48-0ae7a3ff92be)

Technical Details
----------------------------------------
The title seems to be part of the 'outer' not the tab & the tpl doesn't seem to be included from anywhere else

Comments
----------------------------------------
