### PR TITLE
Extend normal form for delete action

### DIFF
--- a/CRM/Event/Form/Participant/Delete.php
+++ b/CRM/Event/Form/Participant/Delete.php
@@ -19,7 +19,7 @@
 /**
  * Back office participant delete form.
  */
-class CRM_Event_Form_Participant_Delete extends CRM_Contribute_Form_AbstractEditPayment {
+class CRM_Event_Form_Participant_Delete extends CRM_Core_Form {
   use CRM_Event_Form_EventFormTrait;
   use CRM_Contact_Form_ContactFormTrait;
 


### PR DESCRIPTION
Overview
----------------------------------------
Extend normal form for delete action

Before
----------------------------------------
`CRM_Event_Form_Participant_Delete` extends `CRM_Contribute_Form_AbstractEditPayment`

After
----------------------------------------
`CRM_Event_Form_Participant_Delete` extends `CRM_Core_Form`

Technical Details
----------------------------------------
@colemanw this was an oversight from the form separation

Comments
----------------------------------------
