### PR TITLE
CiviMail - Save mailing_id, is_test in test mode, where job is available

### DIFF
--- a/CRM/Mailing/Event/BAO/MailingEventQueue.php
+++ b/CRM/Mailing/Event/BAO/MailingEventQueue.php
@@ -31,6 +31,16 @@ class CRM_Mailing_Event_BAO_MailingEventQueue extends CRM_Mailing_Event_DAO_Mail
     if (empty($params['id']) && empty($params['hash'])) {
       $eq->hash = self::hash();
     }
+    if (empty($params['id']) && !empty($params['job_id']) && empty($params['mailing_id'])) {
+      // mailing_id is a new field in 5.67. Calling code should pass it in going forwards
+      // but temporary handling will set it. (We should make the field required
+      // when we remove this in future)
+      CRM_Core_Error::deprecatedWarning('mailing_id should be passed into EventQueue create calls. Temporary handling has set it for now');
+      $query = CRM_Core_DAO::executeQuery('SELECT mailing_id, is_test
+        FROM civicrm_mailing_job job LEFT JOIN civicrm_mailing m ON m.id = mailing_id WHERE job.id = %1', [1 => [$params['job_id'], 'Integer']]);
+      $eq->mailing_id = $query->mailing_id;
+      $eq->is_test = $query->is_test;
+    }
     $eq->save();
     return $eq;
   }

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -663,8 +663,10 @@ function civicrm_api3_mailing_send_test($params) {
         civicrm_api3('MailingEventQueue', 'create',
           [
             'job_id' => $job['id'],
+            'is_test' => TRUE,
             'email_id' => $emailId,
             'contact_id' => $contactId,
+            'mailing_id' => $params['mailing_id'],
           ]
         );
       }


### PR DESCRIPTION
Overview
----------------------------------------
Save mailing_id, is_test in test mode, where job is available

Before
----------------------------------------
Gaps in where mailing_id is saved

After
----------------------------------------
less gaps

Technical Details
----------------------------------------
Addresses https://github.com/civicrm/civicrm-core/pull/27557#issuecomment-1746290527

Note I think we are moving towards mailing_id being required at the DAO level so I added some noise if it is not passed in

Comments
----------------------------------------