### PR TITLE
[NFC] Remove unused var

### DIFF
--- a/tests/phpunit/CRM/Dedupe/BAO/RuleGroupTest.php
+++ b/tests/phpunit/CRM/Dedupe/BAO/RuleGroupTest.php
@@ -321,7 +321,6 @@ class CRM_Dedupe_BAO_RuleGroupTest extends CiviUnitTestCase {
     ];
 
     $count = 1;
-    $contact_id;
     foreach ($params as $param) {
       $contact = $this->callAPISuccess('contact', 'create', $param);
       $this->contactIDs[$count++] = $contact['id'];


### PR DESCRIPTION
Overview
----------------------------------------
Remove an unused variable reference.

Before
----------------------------------------
We're calling `$contact_id;`. As we're neither reading or writing, this seems totally pointless...

After
----------------------------------------
Slightly cleaner.

Comments
----------------------------------------
This stops PHPStan (and likely similar tools) stop complaining about this file.