### PR TITLE
Afform - Quick add links for Autocomplete fields

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2324,6 +2324,9 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $props['data-select-params'] = json_encode($props['select']);
     $props['data-api-params'] = json_encode($props['api']);
     $props['data-api-entity'] = $props['entity'];
+    if (!empty($props['select']['quickAdd'])) {
+      Civi::service('angularjs.loader')->addModules(['af']);
+    }
     CRM_Utils_Array::remove($props, 'select', 'api', 'entity');
     return $this->add('text', $name, $label, $props, $required);
   }

--- a/ang/afform/afformQuickAddIndividual.aff.html
+++ b/ang/afform/afformQuickAddIndividual.aff.html
@@ -1,0 +1,18 @@
+<af-form ctrl="afform">
+  <af-entity type="Individual" name="Individual1" actions="{create: true, update: false}" security="RBAC" />
+  <fieldset af-fieldset="Individual1" class="af-container">
+    <div class="af-container">
+      <div class="af-container af-layout-inline">
+        <af-field name="first_name" />
+        <af-field name="middle_name" />
+        <af-field name="last_name" />
+      </div>
+      <div af-join="Email" data="{is_primary: true}">
+        <div class="af-container af-layout-inline">
+          <af-field name="email" defn="{required: false}" />
+        </div>
+      </div>
+    </div>
+  </fieldset>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()">{{:: ts('Submit') }}</button>
+</af-form>

--- a/ang/afform/afformQuickAddIndividual.aff.php
+++ b/ang/afform/afformQuickAddIndividual.aff.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+  'type' => 'form',
+  'title' => ts('New Individual'),
+  'icon' => 'fa-list-alt',
+  'server_route' => 'civicrm/quick-add/Individual',
+  'permission' => [
+    'add contacts',
+  ],
+  'permission_operator' => 'AND',
+  'submit_enabled' => TRUE,
+  'create_submission' => FALSE,
+];

--- a/ang/afform/afformQuickAddOrganization.aff.html
+++ b/ang/afform/afformQuickAddOrganization.aff.html
@@ -1,0 +1,16 @@
+<af-form ctrl="afform">
+  <af-entity type="Organization" name="Organization1" actions="{create: true, update: false}" security="RBAC" />
+  <fieldset af-fieldset="Organization1" class="af-container">
+    <div class="af-container">
+      <div class="af-container af-layout-inline">
+        <af-field name="organization_name" />
+      </div>
+      <div af-join="Email" data="{is_primary: true}">
+        <div class="af-container af-layout-inline">
+          <af-field name="email" defn="{required: false}"/>
+        </div>
+      </div>
+    </div>
+  </fieldset>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()">{{:: ts('Submit') }}</button>
+</af-form>

--- a/ang/afform/afformQuickAddOrganization.aff.php
+++ b/ang/afform/afformQuickAddOrganization.aff.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+  'type' => 'form',
+  'title' => ts('New Organization'),
+  'icon' => 'fa-list-alt',
+  'server_route' => 'civicrm/quick-add/Organization',
+  'permission' => [
+    'add contacts',
+  ],
+  'permission_operator' => 'AND',
+  'submit_enabled' => TRUE,
+  'create_submission' => FALSE,
+];

--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -729,6 +729,7 @@
           crmAutocompleteParams: '<',
           multi: '<',
           autoOpen: '<',
+          quickAdd: '<',
           staticOptions: '<'
         },
         link: function(scope, element, attr, ctrl) {
@@ -791,6 +792,7 @@
                 // Only auto-open if there are no static options
                 minimumInputLength: ctrl.autoOpen && _.isEmpty(ctrl.staticOptions) ? 0 : 1,
                 static: ctrl.staticOptions || [],
+                quickAdd: ctrl.quickAdd,
               });
             });
           };

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -38,6 +38,11 @@
     <input crm-ui-select="{data: $ctrl.editor.securityModes}" ng-model="getSet('security')" ng-model-options="{getterSetter: true}" class="form-control">
   </div>
 </li>
+<li ng-if="$ctrl.fieldDefn.input_type === 'EntityRef'" title="{{:: ts('Allow a new entity to be created via quick-add popup') }}">
+  <div href ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
+    <input crm-ui-select="{data: $ctrl.quickAddLinks, multiple: true, placeholder: ts('Quick Add')}" ng-model="getSet('input_attrs.quickAdd')" ng-model-options="{getterSetter: true}" ng-list class="form-control">
+  </div>
+</li>
 <li ng-if="$ctrl.fieldDefn.input_type === 'EntityRef'">
   <a href ng-click="toggleAttr('input_attrs.autoOpen'); $event.stopPropagation(); $event.target.blur();" title="{{:: ts('Show autocomplete results without typing') }}">
     <i class="crm-i fa-{{ getProp('input_attrs.autoOpen') ? 'check-' : '' }}square-o"></i>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -47,6 +47,19 @@
             inputTypes.push(type);
           }
         });
+        // Quick-add links for autocompletes
+        this.quickAddLinks = [];
+        let allowedEntity = (ctrl.getFkEntity() || {}).entity;
+        let allowedEntities = (allowedEntity === 'Contact') ? ['Individual', 'Household', 'Organization'] : [allowedEntity];
+        (CRM.config.quickAdd || []).forEach((link) => {
+          if (allowedEntities.includes(link.entity)) {
+            this.quickAddLinks.push({
+              id: link.path,
+              icon: link.icon,
+              text: link.title,
+            });
+          }
+        });
         this.searchOperators = CRM.afAdmin.search_operators;
         // If field has limited operators, set appropriately
         if (ctrl.fieldDefn.operators && ctrl.fieldDefn.operators.length) {

--- a/ext/afform/core/ang/af/fields/EntityRef.html
+++ b/ext/afform/core/ang/af/fields/EntityRef.html
@@ -8,5 +8,6 @@
        crm-autocomplete-params="{formName: 'afform:' + $ctrl.afFieldset.getFormName(), fieldName: $ctrl.afFieldset.getName() + ':' + $ctrl.fieldName}"
        multi="$ctrl.defn.input_attrs.multiple"
        auto-open="$ctrl.defn.input_attrs.autoOpen"
+       quick-add="$ctrl.defn.input_attrs.quickAdd"
        placeholder="{{:: $ctrl.defn.input_attrs.placeholder }}"
        ng-change="$ctrl.onSelectEntity()" >

--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -24,6 +24,7 @@
   CRM.config.ajaxPopupsEnabled = {$ajaxPopupsEnabled|@json_encode};
   CRM.config.allowAlertAutodismissal = {$allowAlertAutodismissal|@json_encode};
   CRM.config.resourceCacheCode = {$resourceCacheCode|@json_encode};
+  CRM.config.quickAdd = {$quickAdd|@json_encode};
 
   // Merge entityRef settings
   CRM.config.entityRef = $.extend({ldelim}{rdelim}, {$entityRef|@json_encode}, CRM.config.entityRef || {ldelim}{rdelim});


### PR DESCRIPTION
Overview
----------------------------------------
APIv3-based *EntityRef* fields have quick-add buttons which link to profile forms (e.g. "New Individual"). This implements a similar feature for the newer APIv4-based *Autocomplete* fields, using Afforms instead of Profiles. 

See https://lab.civicrm.org/dev/core/-/issues/4484

Usage
--------
1. Create a new form in FormBuilder.
2. Add an Autocomplete field for Contacts (so far this PR only includes "New Individual" and "New Organization" quick-add forms for testing).
3. Configure the field and choose "New Individual" or "New Organization" (or both) from the "Quick Add" dropdown.
![image](https://github.com/civicrm/civicrm-core/assets/2874912/ad1995d9-3b8e-493b-a44d-0739bdf4c8e3)
4. Visit the form and you'll be able to add a new individual on-the-fly.

Technical Details
-------
For lack of anything fancier, the "quick-add" forms are identified by their route: any form with a route starting with "civicrm/quick-add" is automatically available in the dropdown pictured in step 3 (if the entity type matches).

This makes it quite configurable/flexible. You can make as many quick-add forms as you wish, to suit different types of Autocomplete fields.