### PR TITLE
[REF][PHP8.2] Replace dynmaic property with variable

### DIFF
--- a/CRM/Member/Form/MembershipBlock.php
+++ b/CRM/Member/Form/MembershipBlock.php
@@ -127,6 +127,7 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
       }
 
       $membership = $membershipDefault = $params = [];
+      $renewOption = [];
       foreach ($membershipTypes as $k => $v) {
         $membership[] = $this->createElement('advcheckbox', $k, NULL, $v);
         $membershipDefault[$k] = NULL;
@@ -143,7 +144,7 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
               $this->freeze("auto_renew_$k");
               $params['id'] = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipBlock', $this->_id, 'id', 'entity_id');
             }
-            $this->_renewOption[$k] = $autoRenew;
+            $renewOption[$k] = $autoRenew;
           }
         }
       }
@@ -155,9 +156,7 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
       }
       $this->add('hidden', "mem_price_field_id", '', ['id' => "mem_price_field_id"]);
       $this->assign('is_recur', $isRecur);
-      if (isset($this->_renewOption)) {
-        $this->assign('auto_renew', $this->_renewOption);
-      }
+      $this->assign('auto_renew', $renewOption);
       $this->addGroup($membership, 'membership_type', ts('Membership Types'));
       $this->addRadio('membership_type_default', ts('Membership Types Default'), $membershipDefault, ['allowClear' => TRUE]);
 


### PR DESCRIPTION
Overview
----------------------------------------
Replace dynmaic property with variable.

Before
----------------------------------------
`_renewOption` was declared dynamically, which is problematic in PHP 8.2.

After
----------------------------------------
It's no longer called dynamically. As the value was only used within a single function, we just need a straightforward variable.

Comments
----------------------------------------
As the leading underscore indicates the property is private, the risk of third-party extensions using `_renewOption` is low. There are no references to `_renewOption` in CiviCRM core.
