### PR TITLE
[REF] Remove getEmailAddress method which cannot work

### DIFF
--- a/CRM/Mailing/Event/BAO/MailingEventQueue.php
+++ b/CRM/Mailing/Event/BAO/MailingEventQueue.php
@@ -85,33 +85,6 @@ class CRM_Mailing_Event_BAO_MailingEventQueue extends CRM_Mailing_Event_DAO_Mail
   }
 
   /**
-   * Given a queue event ID, find the corresponding email address.
-   *
-   * @param int $queue_id
-   *   The queue event ID.
-   *
-   * @return string
-   *   The email address
-   */
-  public static function getEmailAddress($queue_id) {
-    $email = CRM_Core_BAO_Email::getTableName();
-    $eq = self::getTableName();
-    $query = "  SELECT      $email.email as email
-                    FROM        $email
-                    INNER JOIN  $eq
-                    ON          $eq.email_id = $email.id
-                    WHERE       $eq.id = " . CRM_Utils_Type::rule($queue_id, 'Integer');
-
-    $q = new CRM_Mailing_Event_BAO_MailingEventQueue();
-    $q->query($query);
-    if (!$q->fetch()) {
-      return NULL;
-    }
-
-    return $q->email;
-  }
-
-  /**
    * Count up events given a mailing id and optional job id.
    *
    * @param int $mailing_id


### PR DESCRIPTION
Overview
----------------------------------------
Remove `getEmailAddress` method from `CRM_Mailing_Event_BAO_MailingEventQueue`, as it cannot work.

Before
----------------------------------------
`getEmailAddress` calls `CRM_Utils_Type::rule($queue_id, 'Integer');`. However, there is no such method `rule` on `CRM_Utils_Type` (and it actually looks like there may never have been).

After
----------------------------------------
Nobody can be using `CRM_Mailing_Event_BAO_MailingEventQueue::getEmailAddress()` as it simply wouldn't work. Let's remove it.

Comments
----------------------------------------
An alternative would have been to make the method work, but seems preferable to be reducing the number of functions to maintain, as we can be confident it's not being used.
