### PR TITLE
[NFC] Make null really null

### DIFF
--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -951,7 +951,7 @@ LIMIT {$offset}, {$rowCount}
   public static function toggleDedupeSelect() {
     $pnid = $_REQUEST['pnid'];
     $isSelected = CRM_Utils_Type::escape($_REQUEST['is_selected'], 'Boolean');
-    $cacheKeyString = CRM_Utils_Request::retrieve('cacheKey', 'Alphanumeric', $null, FALSE);
+    $cacheKeyString = CRM_Utils_Request::retrieve('cacheKey', 'Alphanumeric', NULL, FALSE);
 
     $params = [
       1 => [$isSelected, 'Boolean'],


### PR DESCRIPTION
Overview
----------------------------------------
When it looks like `null`, behaves like `null`, but isn't `null`.

Before
----------------------------------------
`$null` was being used, but never defined. 

After
----------------------------------------
Just use `NULL` instead.

Comments
----------------------------------------
I did a quick search and can't see any other places where we're making this mistake with `$null`.
