### PR TITLE
Fix message within exception (PayPalIPN)

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -430,7 +430,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
       $this->contribution = new CRM_Contribute_BAO_Contribution();
       $this->contribution->id = $this->getContributionID();
       if (!$this->contribution->find(TRUE)) {
-        throw new CRM_Core_Exception('Failure: Could not find contribution record for ' . (int) $contribution->id, NULL, ['context' => "Could not find contribution record: {$contribution->id} in IPN request: "]);
+        throw new CRM_Core_Exception('Failure: Could not find contribution record for ' . (int) $this->contribution->id, NULL, ['context' => "Could not find contribution record: {$this->contribution->id} in IPN request: "]);
       }
       if ((int) $this->contribution->contact_id !== $this->getContactID()) {
         CRM_Core_Error::debug_log_message("Contact ID in IPN not found but contact_id found in contribution.");


### PR DESCRIPTION
Overview
----------------------------------------
Fix message within exeption in `CRM_Core_Payment_PayPalIPN`

Before
----------------------------------------
The exception message referenced `$contribution` which doesn't exist.

After
----------------------------------------
References `$this->contribution` instead.

Comments
----------------------------------------
It looks like this was recently refactored in https://github.com/civicrm/civicrm-core/pull/26560.
