### PR TITLE
[PHP 8] Undefined array key "email_comment"

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -471,6 +471,8 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
 
       // condition to check for download PDF Invoice or email Invoice
       if ($isCreatePDF) {
+        // email_comment is an optional variable in this case, and won't usually be present, but allow it to be.
+        $sendTemplateParams['tplParams'] = array_merge($tplParams, ['email_comment' => ($params['email_comment'] ?? '')]);
         [$sent, $subject, $message, $html] = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
         if (isset($params['forPage'])) {
           return $html;

--- a/tests/phpunit/CRM/Contribute/Form/Task/InvoiceTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/InvoiceTest.php
@@ -83,6 +83,9 @@ class CRM_Contribute_Form_Task_InvoiceTest extends CiviUnitTestCase {
       $invoiceHTML[current($contributionID)] = CRM_Contribute_Form_Task_Invoice::printPDF($contributionID, $params, $contactIds);
     }
 
+    // For some reason php warnings are in the html output, not triggering test fails, so manually check.
+    $this->assertStringNotContainsString('Warning: ', $invoiceHTML[$result['id']]);
+
     $this->assertStringNotContainsString('Due Date', $invoiceHTML[$result['id']]);
     $this->assertStringNotContainsString('PAYMENT ADVICE', $invoiceHTML[$result['id']]);
     $this->assertStringContainsString('Mr. Anthony Anderson II', $invoiceHTML[$result['id']]);


### PR DESCRIPTION
Overview
----------------------------------------
Undefined array key "email_comment"

Before
----------------------------------------
1. Turn on Invoicing at Administer - CiviContribute - CiviContribute Component Settings
  (Ignore the warning about "file" - I thought I had fixed that already - TBD)
3. View a contribution and click the Download Invoice button.
4. Look at the pdf. The text itself contains part of the error - it's trying to say Undefined array key "email_comment"

After
----------------------------------------


Technical Details
----------------------------------------
This is the same as line 497 and 512, but since it's usually not present in this case allow it to be optional. "email_comment" is a field on the form, so is usually only present when using the invoice task from search results and choosing "email".

Comments
----------------------------------------
Has test, sort of. It does come up in at least CRM/Contribute/Form/Task/InvoiceTest.php, but for some reason in jenkins here you don't see it, but I do see it in other test environments. I've forced it by checking the html output and if you look at https://github.com/civicrm/civicrm-core/pull/27760 you can see the html has the error in it before the PR.