### PR TITLE
CRM_Core_DAO::copyValues() deduplicate pseudo-constant fields 

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -119,6 +119,8 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact implements Civi\Co
           // CRM-7925
           throw new CRM_Core_Exception(ts('The Contact Sub Type does not match the Contact type for this record'));
         }
+        // Cast to array as serialization in CRM_Core_DAO::copyValues() will happen only if it is an array.
+        $params['contact_sub_type'] = (array) ($params['contact_sub_type']);
       }
     }
 

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -119,7 +119,6 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact implements Civi\Co
           // CRM-7925
           throw new CRM_Core_Exception(ts('The Contact Sub Type does not match the Contact type for this record'));
         }
-        $params['contact_sub_type'] = CRM_Utils_Array::implodePadded($params['contact_sub_type']);
       }
     }
 

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -119,8 +119,10 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact implements Civi\Co
           // CRM-7925
           throw new CRM_Core_Exception(ts('The Contact Sub Type does not match the Contact type for this record'));
         }
-        // Cast to array as serialization in CRM_Core_DAO::copyValues() will happen only if it is an array.
-        $params['contact_sub_type'] = (array) ($params['contact_sub_type']);
+        // Ensure value is an array so it can be handled properly by `copyValues()`
+        if (is_string($params['contact_sub_type'])) {
+          $params['contact_sub_type'] = CRM_Core_DAO::unSerializeField($params['contact_sub_type'], self::fields()['contact_sub_type']['serialize']);
+        }
       }
     }
 

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -780,6 +780,10 @@ class CRM_Core_DAO extends DB_DataObject {
           }
         }
         elseif (is_array($value) && !empty($field['serialize'])) {
+          if (!empty($field['pseudoconstant'])) {
+            // Pseudoconstant implies 1-1 option matching; duplicates would not make sense
+            $value = array_unique($value);
+          }
           $this->$dbName = CRM_Core_DAO::serializeField($value, $field['serialize']);
           $allNull = FALSE;
         }

--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -258,7 +258,11 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
       'contact_sub_type' => $sub_contact_type,
     ];
     $contact = CRM_Contact_BAO_Contact::add($params);
-    $this->assertSame($sub_contact_type, $contact->contact_sub_type, 'Wrong contact sub-type saved.');
+    $this->assertSame(
+      CRM_Core_DAO::serializeField($sub_contact_type, $contact->fields()['contact_sub_type']['serialize']),
+      $contact->contact_sub_type,
+      'Wrong contact sub-type saved.'
+    );
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -231,6 +231,37 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test case for add( ) with duplicated sub contact types.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testAddWithDuplicatedSubContactType(): void {
+    // Sub contact-type as array
+    $sub_contact_type = ['Staff', 'Parent', 'Staff'];
+    $params = [
+      'first_name' => 'Duplicated sub contact-type as array',
+      'contact_type' => 'Individual',
+      'contact_sub_type' => $sub_contact_type,
+    ];
+    $contact = CRM_Contact_BAO_Contact::add($params);
+    $this->assertSame(
+      CRM_Core_DAO::serializeField((array_unique($sub_contact_type)), $contact->fields()['contact_sub_type']['serialize']),
+      $contact->contact_sub_type,
+      'Contact sub-type not deduplicated.'
+    );
+
+    // Sub contact-type as string
+    $sub_contact_type = 'Staff';
+    $params = [
+      'first_name' => 'Sub contact-type as string',
+      'contact_type' => 'Individual',
+      'contact_sub_type' => $sub_contact_type,
+    ];
+    $contact = CRM_Contact_BAO_Contact::add($params);
+    $this->assertSame($sub_contact_type, $contact->contact_sub_type, 'Wrong contact sub-type saved.');
+  }
+
+  /**
    * Test case for create.
    *
    * Test with missing params.


### PR DESCRIPTION
Overview
----------------------------------------
`Contact.create` allows duplicated sub contact types to be saved (e.g. `["Staff", "Staff"]`).
As sub contact types are stored as a string (pseudo-array) in the database, this causes issues for example in Search Kit queries. Operators `=`, `!=`, `is one of`, `is not one of` will not work as intended.

![Screenshot from 2023-10-09 21-39-24](https://github.com/civicrm/civicrm-core/assets/51154903/630fd7c2-af0b-4b42-a163-693048851a94)


Before
----------------------------------------
(Output trimmed for brevity)
```
$ cv api4 Contact.update '{"values":{"contact_sub_type":["Staff","Staff"]},"where":[["id","=",110]]}'
[
    {
        "contact_sub_type": [
            "Staff",
            "Staff"
        ]
    }
]

```

After
----------------------------------------
(Output trimmed for brevity)
```
$ cv api4 Contact.update '{"values":{"contact_sub_type":["Staff","Staff"]},"where":[["id","=",110]]}'
[
    {
        "contact_sub_type": [
            "Staff"
        ]
    }
]

```

Technical Details
----------------------------------------
Yes, it should be the callers responsibility to not pass duplicate types, but here (at a single point) we can prevent this from happening, as I can't see any use-case for duplicated (sub) contact types.