### PR TITLE
[PHP 8.2] fix undefined property in CRM_Event_Form_SelfSvcUpdate

### DIFF
--- a/CRM/Event/Form/SelfSvcUpdate.php
+++ b/CRM/Event/Form/SelfSvcUpdate.php
@@ -95,6 +95,7 @@ class CRM_Event_Form_SelfSvcUpdate extends CRM_Core_Form {
    * @var bool
    */
   protected $isBackoffice = FALSE;
+  private string $_userContext;
 
   /**
    * Set variables up before form is built based on participant ID from URL

--- a/CRM/Event/Form/SelfSvcUpdate.php
+++ b/CRM/Event/Form/SelfSvcUpdate.php
@@ -95,7 +95,10 @@ class CRM_Event_Form_SelfSvcUpdate extends CRM_Core_Form {
    * @var bool
    */
   protected $isBackoffice = FALSE;
-  private string $_userContext;
+  /**
+   * @var string
+   */
+  protected $_userContext;
 
   /**
    * Set variables up before form is built based on participant ID from URL


### PR DESCRIPTION
Overview
----------------------------------------
Playing around learning if this is enough to fix a PHP deprecation

Before
----------------------------------------
[Test](https://test.civicrm.org/job/CiviCRM-Core-Edge/lastBuild/CIVIVER=master,label=bknix-tmp-edge/testReport/(root)/CRM_Event_Form_SelfSvcUpdateTest/testForm/) failed:
`Creation of dynamic property CRM_Event_Form_SelfSvcUpdate::$_userContext is deprecated`

After
----------------------------------------
[Test](https://test.civicrm.org/job/CiviCRM-Core-Edge/lastBuild/CIVIVER=master,label=bknix-tmp-edge/testReport/(root)/CRM_Event_Form_SelfSvcUpdateTest/testForm/) doesn't fail anymore?
