### PR TITLE
Fix notice on New Pledge form

### DIFF
--- a/templates/CRM/Pledge/Form/Pledge.tpl
+++ b/templates/CRM/Pledge/Form/Pledge.tpl
@@ -42,7 +42,7 @@
             <td class="label">{$form.amount.label}</td>
             <td>
               <span>{$form.currency.html|crmAddClass:eight}&nbsp;{$form.amount.html|crmAddClass:eight}</span>
-              {if $originalPledgeAmount}<div class="messages status no-popup">{icon icon="fa-info-circle"}{/icon}{ts 1=$originalPledgeAmount|crmMoney:$currency} Pledge total has changed due to payment adjustments. Original pledge amount was %1.{/ts}</div>{/if}
+              {if $action EQ 2 && $originalPledgeAmount}<div class="messages status no-popup">{icon icon="fa-info-circle"}{/icon}{ts 1=$originalPledgeAmount|crmMoney:$currency} Pledge total has changed due to payment adjustments. Original pledge amount was %1.{/ts}</div>{/if}
             </td>
           </tr>
           <tr class="crm-pledge-form-block-installments">


### PR DESCRIPTION
Overview
----------------------------------------
Fix notice on New Pledge form

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/22588d15-dc83-451f-b4ad-09147f03117f)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/0fe73920-fae8-4f07-9b00-a71009d89633)

& in edit more this is the text
![Uploading image.png…]()


Technical Details
----------------------------------------
`$originalPledgeAmount` is assigned in-tpl a few lines earlier - but only if the action is 2

![image](https://github.com/civicrm/civicrm-core/assets/336308/42b4aaba-63c1-437f-9f82-68b06892da6f)

I didn't tackle the `contributionMode` one - but my take on it is that it is copy & paste & the variable is never assigned

Comments
----------------------------------------
