### PR TITLE
Fix recursive display of payment_reminders

### DIFF
--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -147,9 +147,11 @@ class CRM_Contribute_Form_AdditionalInfo {
    *
    * Build the form object for PaymentReminders Information.
    *
+   * @deprecated since 5.68 will be removed around 5.78.
    * @param CRM_Core_Form $form
    */
   public static function buildPaymentReminders(&$form) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative, will be removed around 5.78');
     //PaymentReminders section
     $form->add('hidden', 'hidden_PaymentReminders', 1);
     $form->add('text', 'initial_reminder_day', ts('Send Initial Reminder'), ['size' => 3]);

--- a/CRM/Pledge/Form/Pledge.php
+++ b/CRM/Pledge/Form/Pledge.php
@@ -195,33 +195,28 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
       $contactField->freeze();
     }
 
-    $showAdditionalInfo = FALSE;
-    $formType = CRM_Utils_Request::retrieveValue('form_type', 'String');
-    $defaults = [];
+    $formType = CRM_Utils_Request::retrieveValue('formType', 'String');
 
-    $paneNames = [
-      ts('Payment Reminders') => 'PaymentReminders',
+    $allPanes[ts('Payment Reminders')] = [
+      'open' => 'false',
+      'id' => 'PaymentReminders',
     ];
-    foreach ($paneNames as $name => $type) {
-      $urlParams = "snippet=4&formType={$type}";
-      $allPanes[$name] = [
-        'url' => CRM_Utils_System::url('civicrm/contact/view/pledge', $urlParams),
-        'open' => 'false',
-        'id' => $type,
-      ];
-      // see if we need to include this paneName in the current form
-      if ($formType == $type || !empty($_POST["hidden_{$type}"]) ||
-        !empty($defaults["hidden_{$type}"])
-      ) {
-        $showAdditionalInfo = TRUE;
-        $allPanes[$name]['open'] = 'true';
-      }
-      $fnName = "build{$type}";
-      CRM_Contribute_Form_AdditionalInfo::$fnName($this);
+    // see if we need to include this paneName in the current form
+    if ($formType === 'PaymentReminders' || !empty($_POST['hidden_PaymentReminders'])
+    ) {
+      $allPanes[ts('Payment Reminders')]['open'] = 'true';
     }
 
+    $this->add('hidden', 'hidden_PaymentReminders', 1);
+    $this->add('text', 'initial_reminder_day', ts('Send Initial Reminder'), ['size' => 3]);
+    $this->addRule('initial_reminder_day', ts('Please enter a valid reminder day.'), 'positiveInteger');
+    $this->add('text', 'max_reminders', ts('Send up to'), ['size' => 3]);
+    $this->addRule('max_reminders', ts('Please enter a valid No. of reminders.'), 'positiveInteger');
+    $this->add('text', 'additional_reminder_day', ts('Send additional reminders'), ['size' => 3]);
+    $this->addRule('additional_reminder_day', ts('Please enter a valid additional reminder day.'), 'positiveInteger');
+
     $this->assign('allPanes', $allPanes);
-    $this->assign('showAdditionalInfo', $showAdditionalInfo);
+    $this->assign('showAdditionalInfo', TRUE);
 
     $this->assign('formType', $formType);
     if ($formType) {
@@ -297,8 +292,8 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
       $frequencyUnit->freeze();
       $frequencyDay->freeze();
       $eachPaymentAmount = $this->_values['original_installment_amount'];
-      $this->assign('eachPaymentAmount', $eachPaymentAmount);
     }
+    $this->assign('eachPaymentAmount', $eachPaymentAmount ?? NULL);
 
     if (($this->_values['status_id'] ?? NULL) !=
       CRM_Core_PseudoConstant::getKey('CRM_Pledge_BAO_Pledge', 'status_id', 'Cancelled')

--- a/templates/CRM/Pledge/Form/Pledge.tpl
+++ b/templates/CRM/Pledge/Form/Pledge.tpl
@@ -157,11 +157,6 @@
     // load panes function calls for snippet based on id of crm-accordion-header
     function loadPanes( id ) {
       var url = "{/literal}{crmURL p='civicrm/contact/view/pledge' q='snippet=4&formType=' h=0}{literal}" + id;
-      {/literal}
-        {if $contributionMode}
-          url = url + "&mode={$contributionMode}";
-        {/if}
-      {literal}
       if ( ! $('div.'+id).html() ) {
         var loading = '<img src="{/literal}{$config->resourceBase}i/loading.gif{literal}" alt="{/literal}{ts escape='js'}loading{/ts}{literal}" />&nbsp;{/literal}{ts escape='js'}Loading{/ts}{literal}...';
         $('div.'+id).html(loading);


### PR DESCRIPTION
Overview
----------------------------------------
Fix recursive display of payment_reminders

Before
----------------------------------------
When the payment reminders accordian is expanded it renders the whole form again in there
![image](https://github.com/civicrm/civicrm-core/assets/336308/9c3620fc-7306-48d4-b59b-e489a9ec737d)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/f6a518b7-d1e1-4d40-b2ed-4785a8f0163d)


Technical Details
----------------------------------------
Note in the process I broke the copy & paste connection to ` CRM_Contribute_Form_AdditionalInfo` which made me confident the noticey contributionMode in the smarty tpl was pure copy & paste

Comments
----------------------------------------
