### PR TITLE
Smarty3 Mark sectionTotals smarty function deprecated

### DIFF
--- a/CRM/Core/Smarty/plugins/function.sectionTotal.php
+++ b/CRM/Core/Smarty/plugins/function.sectionTotal.php
@@ -28,13 +28,14 @@
  *
  * @param array $params
  *   Template call's parameters.
- * @param CRM_Core_Smarty $smarty
- *   The Smarty object.
  *
  * @return string
  *   the string, translated by gettext
+ *
+ * @deprecated This is called from table.tpl but we aim to remove
+ * from there.
  */
-function smarty_function_sectionTotal($params, &$smarty) {
+function smarty_function_sectionTotal(array $params) {
   /* section totals are stored in template variable 'sectionTotals',
    * which is a two-dimensional array keyed to a string which is a delimited
    * concatenation (using CRM_Core_DAO::VALUE_SEPARATOR) of ordered permutations
@@ -59,5 +60,5 @@ function smarty_function_sectionTotal($params, &$smarty) {
   $totalsKey = implode(CRM_Core_DAO::VALUE_SEPARATOR, $sectionValues);
 
   // return the corresponding total
-  return $smarty->_tpl_vars['sectionTotals'][$totalsKey];
+  return $params['totals'][$totalsKey];
 }

--- a/templates/CRM/Report/Form/Layout/Table.tpl
+++ b/templates/CRM/Report/Form/Layout/Table.tpl
@@ -52,91 +52,89 @@
         {* pre-compile section header here, rather than doing it every time under foreach *}
         {capture assign=sectionHeaderTemplate}
             {assign var=columnCount value=$columnHeaders|@count}
-            {assign var=l value=$smarty.ldelim}
-            {assign var=r value=$smarty.rdelim}
             {assign var=pageBroke value=0}
-            {foreach from=$sections item=section key=column name=sections}
-                {counter assign="h"}
-                {$l}isValueChange value=$row.{$column} key="{$column}" assign=isValueChanged{$r}
-                {$l}if $isValueChanged{$r}
-
-                    {$l}if $sections.{$column}.type & 4{$r}
-                        {$l}assign var=printValue value=$row.{$column}|crmDate{$r}
-                    {$l}elseif $sections.{$column}.type eq 1024{$r}
-                        {$l}assign var=printValue value=$row.{$column}|crmMoney{$r}
-                    {$l}else{$r}
-                        {$l}assign var=printValue value=$row.{$column}{$r}
-                    {$l}/if{$r}
-                    {$l}if $rowid neq 0{$r}
-                      {if $section.pageBreak}
-                        {$l}if $pageBroke >= {$h} or $pageBroke == 0{$r}
-                          </table>
-                          <div class="page-break"></div>
-                          <table class="report-layout display">
-                        {$l}/if{$r}
-                        {$l}assign var=pageBroke value={$h}{$r}
-                      {/if}
-                    {$l}/if{$r}
-                    <tr class="crm-report-sectionHeader crm-report-sectionHeader-{$h}"><th colspan="{$columnCount}">
-
-                        <h{$h}>{$section.title|escape}: {$l}$printValue|default:"<em>none</em>"{$r}
-                            ({$l}sectionTotal key=$row.{$column} depth={$smarty.foreach.sections.index}{$r})
-                        </h{$h}>
-                    </th></tr>
-                    {if $smarty.foreach.sections.last}
-                        <tr class="crm-report-sectionCols">{$l}$tableHeader{$r}</tr>
-                    {/if}
-                {$l}/if{$r}
-            {/foreach}
         {/capture}
 
         {foreach from=$rows item=row key=rowid}
-           {eval var=$sectionHeaderTemplate}
-            <tr  class="{cycle values="odd-row,even-row"} {if $row.class}{$row.class}{/if} crm-report" id="crm-report_{$rowid}">
-                {foreach from=$columnHeaders item=header key=field}
-                    {assign var=fieldLink value=$field|cat:"_link"}
-                    {assign var=fieldHover value=$field|cat:"_hover"}
-                    {assign var=fieldClass value=$field|cat:"_class"}
-                    <td class="crm-report-{$field}{if $header.type eq 1024 OR $header.type eq 1 OR $header.type eq 512} report-contents-right{elseif array_key_exists($field, $row) && $row.$field eq 'Subtotal'} report-label{/if}">
-                        {if array_key_exists($fieldLink, $row) && $row.$fieldLink}
-                            <a href="{$row.$fieldLink}"
-                               {if array_key_exists($fieldHover, $row)}title="{$row.$fieldHover|escape}"{/if}
-                               {if array_key_exists($fieldClass, $row)}class="{$row.$fieldClass}"{/if}
-                            >
-                        {/if}
+          {foreach from=$sections item=section key=column name=sections}
+            {counter start=1 assign="h"}
+            {assign var=sectionColumn value=$sections.$column}
+            {isValueChange value=$row.$column key=$column assign=isValueChanged}
+              {if $isValueChanged}
 
-                        {if array_key_exists($field, $row) && is_array($row.$field)}
-                            {foreach from=$row.$field item=fieldrow key=fieldid}
-                                <div class="crm-report-{$field}-row-{$fieldid}">{$fieldrow}</div>
-                            {/foreach}
-                        {elseif array_key_exists($field, $row) && $row.$field eq 'Subtotal'}
-                            {$row.$field}
-                        {elseif $header.type & 4 OR $header.type & 256}
-                            {if $header.group_by eq 'MONTH' or $header.group_by eq 'QUARTER'}
-                                {$row.$field|crmDate:$config->dateformatPartial}
-                            {elseif $header.group_by eq 'YEAR'}
-                                {$row.$field|crmDate:$config->dateformatYear}
-                            {else}
-                                {if $header.type == 4}
-                                   {$row.$field|truncate:10:''|crmDate}
-                                {else}
-                                   {$row.$field|crmDate}
-                                {/if}
-                            {/if}
-                        {elseif $header.type eq 1024}
-                            {if $currencyColumn}
-                                <span class="nowrap">{$row.$field|crmMoney:$row.$currencyColumn}</span>
-                            {else}
-                                <span class="nowrap">{$row.$field|crmMoney}</span>
-                           {/if}
-                        {elseif array_key_exists($field, $row)}
-                            {$row.$field|smarty:nodefaults|purify}
-                        {/if}
+              {if $sectionColumn.type & 4}
+              {assign var=printValue value=$row.$column|crmDate}
+              {elseif $sectionColumn.type eq 1024}
+              {assign var=printValue value=$row.$column|crmMoney}
+              {else}
+              {assign var=printValue value=$row.$column}
+              {/if}
+              {if $rowid neq 0}
+              {if $section.pageBreak}
+                  {if $pageBroke >= $h or $pageBroke == 0}
+                </table>
+                <div class="page-break"></div>
+                <table class="report-layout display">
+                  {/if}
+                  {assign var=pageBroke value=$h}
+              {/if}
+              {/if}
+            <tr class="crm-report-sectionHeader crm-report-sectionHeader-{$h}"><th colspan="{$columnCount}">
 
-                        {if array_key_exists($fieldLink, $row) && $row.$fieldLink}</a>{/if}
-                    </td>
-                {/foreach}
-            </tr>
+                <h{$h}>{$section.title|escape}: {$printValue|default:"<em>none</em>"}
+                  ({sectionTotal key=$row.$column depth=$smarty.foreach.sections.index totals=$sectionTotals})
+                </h{$h}>
+              </th></tr>
+              {if $smarty.foreach.sections.last}
+                <tr class="crm-report-sectionCols">{$tableHeader}</tr>
+              {/if}
+              {/if}
+          {/foreach}
+          <tr  class="{cycle values="odd-row,even-row"} {if $row.class}{$row.class}{/if} crm-report" id="crm-report_{$rowid}">
+              {foreach from=$columnHeaders item=header key=field}
+                  {assign var=fieldLink value=$field|cat:"_link"}
+                  {assign var=fieldHover value=$field|cat:"_hover"}
+                  {assign var=fieldClass value=$field|cat:"_class"}
+                  <td class="crm-report-{$field}{if $header.type eq 1024 OR $header.type eq 1 OR $header.type eq 512} report-contents-right{elseif array_key_exists($field, $row) && $row.$field eq 'Subtotal'} report-label{/if}">
+                      {if array_key_exists($fieldLink, $row) && $row.$fieldLink}
+                          <a href="{$row.$fieldLink}"
+                             {if array_key_exists($fieldHover, $row)}title="{$row.$fieldHover|escape}"{/if}
+                             {if array_key_exists($fieldClass, $row)}class="{$row.$fieldClass}"{/if}
+                          >
+                      {/if}
+
+                      {if array_key_exists($field, $row) && is_array($row.$field)}
+                          {foreach from=$row.$field item=fieldrow key=fieldid}
+                              <div class="crm-report-{$field}-row-{$fieldid}">{$fieldrow}</div>
+                          {/foreach}
+                      {elseif array_key_exists($field, $row) && $row.$field eq 'Subtotal'}
+                          {$row.$field}
+                      {elseif $header.type & 4 OR $header.type & 256}
+                          {if $header.group_by eq 'MONTH' or $header.group_by eq 'QUARTER'}
+                              {$row.$field|crmDate:$config->dateformatPartial}
+                          {elseif $header.group_by eq 'YEAR'}
+                              {$row.$field|crmDate:$config->dateformatYear}
+                          {else}
+                              {if $header.type == 4}
+                                 {$row.$field|truncate:10:''|crmDate}
+                              {else}
+                                 {$row.$field|crmDate}
+                              {/if}
+                          {/if}
+                      {elseif $header.type eq 1024}
+                          {if $currencyColumn}
+                              <span class="nowrap">{$row.$field|crmMoney:$row.$currencyColumn}</span>
+                          {else}
+                              <span class="nowrap">{$row.$field|crmMoney}</span>
+                         {/if}
+                      {elseif array_key_exists($field, $row)}
+                          {$row.$field|smarty:nodefaults|purify}
+                      {/if}
+
+                      {if array_key_exists($fieldLink, $row) && $row.$fieldLink}</a>{/if}
+                  </td>
+              {/foreach}
+          </tr>
         {/foreach}
 
         {if $grandStat}

--- a/templates/CRM/Report/Form/Statistics.tpl
+++ b/templates/CRM/Report/Form/Statistics.tpl
@@ -37,9 +37,9 @@
         <tr>
           <th class="statistics" scope="row">{$row.title}</th>
           <td>
-            {if $row.type eq 1024}
+            {if array_key_exists('type', $row) && $row.type eq 1024}
               {$row.value|crmMoney|escape}
-            {elseif $row.type eq 2}
+            {elseif array_key_exists('type', $row) && $row.type eq 2}
               {$row.value|purify}
             {else}
                {$row.value|crmNumberFormat|escape}

--- a/templates/CRM/Report/Form/Tabs/Filters.tpl
+++ b/templates/CRM/Report/Form/Tabs/Filters.tpl
@@ -32,7 +32,7 @@
                     <td class="label report-contents">{if !empty($field.title)}{$field.title}{/if}</td>
                       {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName=$fieldName hideRelativeLabel=1 from='_from' to='_to' class='' colspan=''}
                   </tr>
-                {elseif $form.$fieldOp.html}
+                {elseif array_key_exists($fieldOp, $form) && $form.$fieldOp.html}
                   <tr class="report-contents crm-report crm-report-criteria-filter crm-report-criteria-filter-{$tableName}" {if array_key_exists('no_display', $field) && $field.no_display} style="display: none;"{/if}>
                     <td class="label report-contents">{if !empty($field.title)}{$field.title}{/if}</td>
                     <td class="report-contents">{$form.$fieldOp.html}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Mark sectionTotals smarty function deprecated

I couldn't find evidence of this in use so it didn't seem worth upgradeing for Smarty3

Before
----------------------------------------
Smarty 2
![image](https://github.com/civicrm/civicrm-core/assets/336308/6fd3c622-9282-4ac4-9c42-1642a2424b17)


Smarty3

![image](https://github.com/civicrm/civicrm-core/assets/336308/7cd7206c-9d50-44e6-b21c-876240bcc561)

After
----------------------------------------
Smarty3

![image](https://github.com/civicrm/civicrm-core/assets/336308/49c4630b-e4fc-4677-8d15-de1672a213c6)

Technical Details
----------------------------------------


Comments
----------------------------------------
