### PR TITLE
phpstorm - Generate hints for Civi::paths(), Civi::url(), CRM_Utils_System::url()

### DIFF
--- a/tools/extensions/phpstorm/Civi/PhpStorm/PathGenerator.php
+++ b/tools/extensions/phpstorm/Civi/PhpStorm/PathGenerator.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Civi\PhpStorm;
+
+use Civi\Api4\Entity;
+use Civi\Api4\Route;
+use Civi\Core\Service\AutoService;
+use Civi\Test\Invasive;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @service civi.phpstorm.path
+ */
+class PathGenerator extends AutoService implements EventSubscriberInterface {
+
+  public static function getSubscribedEvents() {
+    return [
+      'civi.phpstorm.flush' => 'generate',
+    ];
+  }
+
+  public function generate() {
+    $pathVars = array_keys(Invasive::get([\Civi::paths(), 'variableFactory']));
+    $pathVarExprs = [];
+    foreach ($pathVars as $pathVar) {
+      $pathVarExprs[] = "[$pathVar]/.";
+    }
+
+    $builder = new PhpStormMetadata('paths', __CLASS__);
+
+    $builder->registerArgumentsSet('pathVars', ...$pathVars);
+    $builder->addExpectedArguments('\Civi\Core\Paths::getPath()', 0, 'pathVarExprs');
+    $builder->addExpectedArguments('\Civi\Core\Paths::getUrl()', 0, 'pathVarExprs');
+
+    $builder->registerArgumentsSet('pathVarExprs', ...$pathVarExprs);
+    $builder->registerArgumentsSet('pathVarAttrs', 'path', 'url');
+    $builder->addExpectedArguments('\Civi\Core\Paths::hasVariable()', 0, 'pathVars');
+    $builder->addExpectedArguments('\Civi\Core\Paths::getVariable()', 0, 'pathVars');
+    $builder->addExpectedArguments('\Civi\Core\Paths::getVariable()', 1, 'pathVarAttrs');
+
+    $builder->write();
+  }
+
+}

--- a/tools/extensions/phpstorm/Civi/PhpStorm/UrlGenerator.php
+++ b/tools/extensions/phpstorm/Civi/PhpStorm/UrlGenerator.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Civi\PhpStorm;
+
+use Civi\Api4\Entity;
+use Civi\Api4\Route;
+use Civi\Core\Service\AutoService;
+use Civi\Test\Invasive;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @service civi.phpstorm.url
+ */
+class UrlGenerator extends AutoService implements EventSubscriberInterface {
+
+  public static function getSubscribedEvents() {
+    return [
+      'civi.phpstorm.flush' => 'generate',
+    ];
+  }
+
+  public function generate() {
+    $routes = Route::get(FALSE)
+      ->addSelect('path', 'is_public', 'page_callback')
+      ->addOrderBy('path')
+      ->execute();
+
+    $urls = [];
+    foreach ($routes as $route) {
+      // $callback = (is_array($route['page_callback'])) ? $route['page_callback'][0] : $route['page_callback'];
+      // $suffix = (preg_match('/_Form_/', $callback ?? '')) ? '?reset=1' : '';
+      $suffix = '';
+
+      if (preg_match('/(ajax|ipn)/', $route['path'])) {
+        // We should have real metadata for web-service routes, but we'll use this weak guess for now...
+        $urls[] = "service://"  . $route['path'];
+      }
+      $urls[] = (empty($route['is_public']) ? 'backend' : 'frontend') . "://" . $route['path'] . $suffix;
+      $urls[] = "current://"  . $route['path'] . $suffix;
+      $urls[] = "default://"  . $route['path'] . $suffix;
+    }
+    foreach (\CRM_Extension_System::singleton()->getFullContainer()->getKeys() as $key) {
+      $urls[] = "ext://$key/";
+    }
+    foreach (array_keys(Invasive::get([\Civi::paths(), 'variableFactory'])) as $pathVar) {
+      $urls[] = "asset://[$pathVar]/";
+    }
+    $urls[] = 'assetBuilder://'; /* Currently don't have a feed listing buildable assets... */
+
+    $builder = new PhpStormMetadata('urls', __CLASS__);
+    $builder->registerArgumentsSet('routes', ...$routes->column('path'));
+    $builder->registerArgumentsSet('urls', ...$urls);
+    $builder->addExpectedArguments('\CRM_Utils_System::url()', 0, 'routes');
+    $builder->addExpectedArguments('\Civi::url()', 0, 'urls');
+
+    $builder->write();
+  }
+
+}


### PR DESCRIPTION
# Overview

This expands the set of autocompletion hints on PhpStorm to include a few more functions.

ping @eileenmcnaughton @colemanw 

# Civi::url()

![Screenshot from 2023-10-10 20-15-30](https://github.com/civicrm/civicrm-core/assets/1336047/5855df1c-9bdd-4533-9269-ce657cb73d06)

<!-- ![Screenshot from 2023-10-10 20-16-04](https://github.com/civicrm/civicrm-core/assets/1336047/966a0f21-24e9-453b-80fd-f19a57e608d6) -->

![Screenshot from 2023-10-10 20-24-42](https://github.com/civicrm/civicrm-core/assets/1336047/784946ee-63c8-4d85-ad49-736e19203162)

![Screenshot from 2023-10-10 20-15-50](https://github.com/civicrm/civicrm-core/assets/1336047/d3a377cb-4a69-4e58-9e0e-8e583abb4db5)

# Civi::paths()

![Screenshot from 2023-10-10 20-17-16](https://github.com/civicrm/civicrm-core/assets/1336047/d5462ad0-8a03-4798-a114-b1f656d61e79)

# CRM_Utils_System::url()

![Screenshot from 2023-10-10 20-16-47](https://github.com/civicrm/civicrm-core/assets/1336047/31af28d2-b35e-43ba-886f-dba59280ec89)

