### PR TITLE
Smarty3 compatibilty with Contribution Amount tab

### DIFF
--- a/CRM/Contribute/Form/ContributionPage.php
+++ b/CRM/Contribute/Form/ContributionPage.php
@@ -46,7 +46,7 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
    *
    * @var int
    */
-  protected $_priceSetID = NULL;
+  protected $_priceSetID;
 
   protected $_values;
 
@@ -68,11 +68,7 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
    * Set variables up before form is built.
    */
   public function preProcess() {
-    // current contribution page id
-    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive',
-      $this, FALSE, NULL, 'REQUEST'
-    );
-    $this->assign('contributionPageID', $this->_id);
+    $this->assign('contributionPageID', $this->getContributionPageID());
 
     // get the requested action
     $this->_action = CRM_Utils_Request::retrieve('action', 'String',
@@ -258,10 +254,8 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
 
       // get price set of type contributions
       //this is the value for stored in db if price set extends contribution
-      $usedFor = 2;
-      $this->_priceSetID = CRM_Price_BAO_PriceSet::getFor('civicrm_contribution_page', $this->_id, $usedFor, 1);
-      if ($this->_priceSetID) {
-        $defaults['price_set_id'] = $this->_priceSetID;
+      if ($this->getPriceSetID()) {
+        $defaults['price_set_id'] = $this->getPriceSetID();
       }
     }
     else {
@@ -404,6 +398,38 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
       self::$_template->assign('isForm', FALSE);
       return 'CRM/Contribute/Form/ContributionPage/Tab.tpl';
     }
+  }
+
+  /**
+   * Get the price set ID for the event.
+   *
+   * @return int|null
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   */
+  public function getContributionPageID(): ?int {
+    if (!$this->_id) {
+      $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    }
+    return $this->_id ? (int) $this->_id : NULL;
+  }
+
+  /**
+   * Get the price set ID for the contribution page.
+   *
+   * @return int|null
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   */
+  public function getPriceSetID(): ?int {
+    if (!$this->_priceSetID && $this->getContributionPageID()) {
+      $this->_priceSetID = CRM_Price_BAO_PriceSet::getFor('civicrm_contribution_page', $this->getContributionPageID());
+    }
+    return $this->_priceSetID ? (int) $this->_priceSetID : NULL;
   }
 
 }

--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -98,9 +98,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
     if (count($recurringPaymentProcessor)) {
       $this->assign('recurringPaymentProcessor', $recurringPaymentProcessor);
     }
-    if (count($futurePaymentProcessor)) {
-      $this->assign('futurePaymentProcessor', $futurePaymentProcessor);
-    }
+    $this->assign('futurePaymentProcessor', json_encode($futurePaymentProcessor ?? [], TRUE));
     if (count($paymentProcessor)) {
       $this->assign('paymentProcessor', $paymentProcessor);
     }
@@ -144,7 +142,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
     else {
       $this->assign('price', TRUE);
     }
-
+    $this->assign('isQuick', $this->isQuickConfig());
     $this->addSelect('price_set_id', [
       'entity' => 'PriceSet',
       'option_url' => 'civicrm/admin/price',
@@ -208,12 +206,10 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
     if (empty($defaults['pay_later_text'])) {
       $defaults['pay_later_text'] = ts('I will send payment by check');
     }
-
     if (!empty($defaults['amount_block_is_active'])) {
 
       if ($priceSetId = CRM_Price_BAO_PriceSet::getFor('civicrm_contribution_page', $this->_id, NULL)) {
-        if ($isQuick = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $priceSetId, 'is_quick_config')) {
-          $this->assign('isQuick', $isQuick);
+        if ($this->isQuickConfig()) {
           //$priceField = CRM_Core_DAO::getFieldValue( 'CRM_Price_DAO_PriceField', $priceSetId, 'id', 'price_set_id' );
           $options = $pFIDs = [];
           $priceFieldParams = ['price_set_id' => $priceSetId];
@@ -826,6 +822,15 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
       }
     }
     parent::endPostProcess();
+  }
+
+  /**
+   * Is the price set quick config.
+   *
+   * @return bool
+   */
+  private function isQuickConfig(): bool {
+    return $this->getPriceSetID() && CRM_Price_BAO_PriceSet::isQuickConfig($this->getPriceSetID());
   }
 
   /**

--- a/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
@@ -199,12 +199,7 @@
 {literal}
 <script type="text/javascript">
 
-   var futurePaymentProcessorMapper = [];
-   {/literal}{if $futurePaymentProcessor}
-   {foreach from=$futurePaymentProcessor item="futurePaymentProcessor" key="index"}{literal}
-     futurePaymentProcessorMapper[{/literal}{$index}{literal}] = '{/literal}{$futurePaymentProcessor}{literal}';
-   {/literal}{/foreach}
-   {literal}
+   {/literal}{if $futurePaymentProcessor}{literal}
    CRM.$(function($) {
      var defId = $('input[name="pledge_default_toggle"][value="contribution_date"]').attr('id');
      var calId = $('input[name="pledge_default_toggle"][value="calendar_date"]').attr('id');
@@ -382,13 +377,13 @@
     function showAdjustRecurring( paymentProcessorIds ) {
         var display = true;
         cj.each(paymentProcessorIds, function(k, id){
-            if( cj.inArray(id, futurePaymentProcessorMapper) == -1 ) {
-                display = false;
-            }
+           if( cj.inArray(parseInt(id), {/literal}{$futurePaymentProcessor}{literal}) == -1 ) {
+              display = false;
+          }
         });
 
         if(display) {
-            cj( '#adjustRecurringFields' ).show( );
+            cj('#adjustRecurringFields').show();
         } else {
             if ( cj( '#adjust_recur_start_date' ).prop('checked' ) ) {
                 cj( '#adjust_recur_start_date' ).prop('checked', false);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes to the Amount tab in the contribution page set for Smarty3

Before
----------------------------------------
With smarty 3 at this url https://dmaster.localhost:32353/civicrm/admin/contribute/amount?reset=1&action=update&id=3&snippet=json we see

![image](https://github.com/civicrm/civicrm-core/assets/336308/36ba3e99-6c12-4b9d-b133-45251a86505c)


After
----------------------------------------
fixed

The code drives the display of the recurring pledge start date - see

![image](https://github.com/civicrm/civicrm-core/assets/336308/1c795510-b807-40ba-8a28-27b5a4b91830)


Technical Details
----------------------------------------
Once I got down to it the problem was just silly use of variable names but in the process I
- simplified it by assigning json from the form layer
- added some of our standardised `get` functions
- fixed an e-notice on `$isQuick` - there are still a bunch of them but they are swallowed by the ajax rendering

Comments
----------------------------------------

