### PR TITLE
Tag `getSubmittedValue()` as externally supported

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -202,6 +202,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * to combine fields from the various screens & save the resulting 'submitted_values'
    * to the UserJob.
    *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
    * @return array
    */
   public function getSubmittedValues(): array {
@@ -218,6 +222,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * To make fields in related forms (ie within the same wizard like
    * Contribution_Main and Contribution_Confirm) accessible you can override
    * this function as CRM_Import_Forms does.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
    *
    * @return string[]
    */
@@ -3000,6 +3008,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * they have permission to (setContactID does do that) and can be used to check if the user is
    * accessing their own record.
    *
+   * @deprecated use getAuthenticatedContactID()
+   *
    * @return int|false
    * @throws \CRM_Core_Exception
    */
@@ -3016,14 +3026,20 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   }
 
   /**
-   * Get values submitted by the user.
+   * Get value submitted by the user.
    *
    * These values have been validated against the fields added to the form.
    * https://pear.php.net/manual/en/package.html.html-quickform.html-quickform.exportvalues.php
    *
+   * Any money processing has also been done.
+   *
    * @param string $fieldName
    *
    * @return mixed|null
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
    */
   public function getSubmittedValue(string $fieldName) {
     if (empty($this->exportedValues)) {


### PR DESCRIPTION
Overview
----------------------------------------
Tag `getSubmittedValue()` as externally supported

Before
----------------------------------------
Low visibility for this function  - but it is the preferred way to get a value as it is an easy way to grab a field & handles money formatting

After
----------------------------------------
tagged

Technical Details
----------------------------------------

Comments
----------------------------------------
