### PR TITLE
Remove irrelevant code from previously shared form

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1702,12 +1702,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     // CRM-11124
     CRM_Event_BAO_Participant::createDiscountTrxn($form->_eventId, $contribParams, NULL, CRM_Price_BAO_PriceSet::parseFirstPriceSetValueIDFromParams($params));
 
-    // process soft credit / pcp pages
-    if (!empty($params['pcp_made_through_id'])) {
-      CRM_Contribute_BAO_ContributionSoft::formatSoftCreditParams($params, $form);
-      CRM_Contribute_BAO_ContributionSoft::processSoftContribution($params, $contribution);
-    }
-
     $transaction->commit();
 
     return $contribution;

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -1022,12 +1022,6 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     // CRM-11124
     CRM_Event_BAO_Participant::createDiscountTrxn($form->_eventId, $contribParams, NULL, CRM_Price_BAO_PriceSet::parseFirstPriceSetValueIDFromParams($params));
 
-    // process soft credit / pcp pages
-    if (!empty($params['pcp_made_through_id'])) {
-      CRM_Contribute_BAO_ContributionSoft::formatSoftCreditParams($params, $form);
-      CRM_Contribute_BAO_ContributionSoft::processSoftContribution($params, $contribution);
-    }
-
     $transaction->commit();
 
     return $contribution;


### PR DESCRIPTION
Overview
----------------------------------------
Remove irrelevant code from previously shared form

Before
----------------------------------------
`pcp_made_through_id` is not relevant to event forms - but when the function was unshared the event forms got a copy

![image](https://github.com/civicrm/civicrm-core/assets/336308/e91fb1a6-d161-45f9-8bd1-d933387ad23b)


After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------