### PR TITLE
allow email attachments with unicode

### DIFF
--- a/CRM/Core/QuickForm/Action/Upload.php
+++ b/CRM/Core/QuickForm/Action/Upload.php
@@ -77,7 +77,7 @@ class CRM_Core_QuickForm_Action_Upload extends CRM_Core_QuickForm_Action {
         // rename the uploaded file with a unique number at the end
         $value = $element->getValue();
 
-        $newName = CRM_Utils_File::makeFileName($value['name']);
+        $newName = CRM_Utils_File::makeFileName($value['name'], TRUE);
         $status = $element->moveUploadedFile($this->_uploadDir, $newName);
         if (!$status) {
           CRM_Core_Error::statusBounce(ts('We could not move the uploaded file %1 to the upload directory %2. Please verify that the \'Temporary Files\' setting points to a valid path which is writable by your web server.', [

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -418,22 +418,29 @@ class CRM_Utils_File {
    * Make a valid file name.
    *
    * @param string $name
+   * @param bool $unicode
    *
    * @return string
    */
-  public static function makeFileName($name) {
+  public static function makeFileName($name, bool $unicode = FALSE) {
     $uniqID = md5(uniqid(rand(), TRUE));
     $info = pathinfo($name);
     $basename = substr($info['basename'],
       0, -(strlen($info['extension'] ?? '') + (($info['extension'] ?? '') == '' ? 0 : 1))
     );
     if (!self::isExtensionSafe($info['extension'] ?? '')) {
+      if ($unicode) {
+        return self::makeFilenameWithUnicode("{$basename}_" . ($info['extension'] ?? '') . "_{$uniqID}", '_', 240) . ".unknown";
+      }
       // munge extension so it cannot have an embbeded dot in it
       // The maximum length of a filename for most filesystems is 255 chars.
       // We'll truncate at 240 to give some room for the extension.
       return CRM_Utils_String::munge("{$basename}_" . ($info['extension'] ?? '') . "_{$uniqID}", '_', 240) . ".unknown";
     }
     else {
+      if ($unicode) {
+        return self::makeFilenameWithUnicode("{$basename}_{$uniqID}", '_', 240) . "." . ($info['extension'] ?? '');
+      }
       return CRM_Utils_String::munge("{$basename}_{$uniqID}", '_', 240) . "." . ($info['extension'] ?? '');
     }
   }

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -276,7 +276,13 @@ class CRM_Utils_Mail {
           TRUE,
           'base64',
           'attachment',
-          (isset($attach['charset']) ? $attach['charset'] : '')
+          (isset($attach['charset']) ? $attach['charset'] : ''),
+          '',
+          '',
+          NULL,
+          NULL,
+          '',
+          'utf-8'
         );
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/4700.

Before
----------------------------------------
Email attachments can't have Unicode filenames.

After
----------------------------------------
Email attachments can have Unicode filenames.

Technical Details
----------------------------------------
`CRM_Utils_File::makeFileNameWithUnicode()` partly addresses this issue, but isn't a drop-in replacement because it doesn't handle unsafe extensions.

IMO `CRM_Utils_Munge()` should never have been used here.  It was designed to only allow valid characters for MySQL table/column names.

File names have a different set of issues.  We want to allow valid characters for filenames (which are different).  There's also a note about removing the dot before an unknown extension, presumably to deal with Windows hiding extensions (and someone uploading `readme.pdf.exe`).

Finally - `CRM_Utils_Mail()` wasn't passing a header encoding to MIME Mail, so it was defaulting to ASCII.  So Unicode characters were coming through mangled.  Which is in fact the original issue I wanted to solve, but caught the larger issue while simplifying my replication steps.