### PR TITLE
[REF] Fix notice error on undefined array key perm

### DIFF
--- a/CRM/Campaign/Form/Survey.php
+++ b/CRM/Campaign/Form/Survey.php
@@ -86,6 +86,7 @@ class CRM_Campaign_Form_Survey extends CRM_Core_Form {
 
     // CRM-11480, CRM-11682
     // Preload libraries required by the "Questions" tab
+    $this->assign('perm', (bool) CRM_Core_Permission::check('administer CiviCRM'));
     CRM_UF_Page_ProfileEditor::registerProfileScripts();
     CRM_UF_Page_ProfileEditor::registerSchemas(['IndividualModel', 'ActivityModel']);
 

--- a/CRM/Contribute/Form/ContributionPage.php
+++ b/CRM/Contribute/Form/ContributionPage.php
@@ -85,10 +85,7 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
       $title = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_ContributionPage', $this->_id, 'title');
     }
 
-    // CRM-16776 - show edit/copy/create buttons on Profiles Tab if user has required permission.
-    if (CRM_Core_Permission::check('administer CiviCRM')) {
-      $this->assign('perm', TRUE);
-    }
+    $this->assign('perm', (bool) CRM_Core_Permission::check('administer CiviCRM'));
     // set up tabs
     CRM_Contribute_Form_ContributionPage_TabHeader::build($this);
 

--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -177,6 +177,9 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
     if (CRM_Core_Permission::check($checkPermission) || !empty($ufCreate) || !empty($ufEdit)) {
       $this->assign('perm', TRUE);
     }
+    else {
+      $this->assign('perm', FALSE);
+    }
 
     // also set up tabs
     CRM_Event_Form_ManageEvent_TabHeader::build($this);


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a smarty notice about undefined array key perm by always assigning the variable where this profile editing tool is used

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/6799125/fee9abca-c3d5-426b-8bb9-bbe6dd62d9f1)

After
----------------------------------------
no notice

ping @eileenmcnaughton @colemanw 