### PR TITLE
Add ContributionFormTrait

### DIFF
--- a/CRM/Contribute/Form/ContributeFormTrait.php
+++ b/CRM/Contribute/Form/ContributeFormTrait.php
@@ -1,0 +1,91 @@
+<?php
+
+use Civi\API\EntityLookupTrait;
+
+/**
+ * Trait implements functions to retrieve contribution related values.
+ */
+trait CRM_Contribute_Form_ContributeFormTrait {
+
+  use EntityLookupTrait;
+
+  /**
+   * Get the value for a field relating to the contribution.
+   *
+   * All values returned in apiv4 format. Escaping may be required.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @param string $fieldName
+   *
+   * @return mixed
+   * @throws \CRM_Core_Exception
+   */
+  public function getContributionValue(string $fieldName) {
+    if ($this->isDefined('Contribution')) {
+      return $this->lookup('Contribution', $fieldName);
+    }
+    $id = $this->getContributionID();
+    if ($id) {
+      $this->define('Contribution', 'Contribution', ['id' => $id]);
+      return $this->lookup('Contribution', $fieldName);
+    }
+    return NULL;
+  }
+
+  /**
+   * Get the selected Contribution ID.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function getContributionID(): ?int {
+    throw new CRM_Core_Exception('`getContributionID` must be implemented');
+  }
+
+  /**
+   * Get id of contribution page being acted on.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function getContributionPageID(): ?int {
+    throw new CRM_Core_Exception('`ContributionPageID` must be implemented');
+  }
+
+  /**
+   * Get a value from the contribution being acted on.
+   *
+   * All values returned in apiv4 format. Escaping may be required.
+   *
+   * @param string $fieldName
+   *
+   * @return mixed
+   * @noinspection PhpUnhandledExceptionInspection
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   */
+  public function getContributionPageValue(string $fieldName) {
+    if ($this->isDefined('ContributionPage')) {
+      return $this->lookup('ContributionPage', $fieldName);
+    }
+    $id = $this->getContributionPageID();
+    if ($id) {
+      $this->define('ContributionPage', 'ContributionPage', ['id' => $id]);
+      return $this->lookup('ContributionPage', $fieldName);
+    }
+    return NULL;
+  }
+
+}

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -18,6 +18,7 @@ use Civi\Payment\Exception\PaymentProcessorException;
  */
 class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditPayment {
   use CRM_Contact_Form_ContactFormTrait;
+  use CRM_Contribute_Form_ContributeFormTrait;
 
   /**
    * The id of the contribution that we are processing.
@@ -240,8 +241,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     $this->assign('action', $this->_action);
 
     // Get the contribution id if update
-    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive');
-    $this->assign('isUsePaymentBlock', !empty($this->_id));
+    $this->assign('isUsePaymentBlock', (bool) $this->getContributionID());
     if (!empty($this->_id)) {
       $this->assignPaymentInfoBlock();
       $this->assign('contribID', $this->_id);
@@ -2058,12 +2058,32 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
   }
 
   /**
-   * Get the contribution ID.
+   * Get the selected Contribution ID.
    *
-   * @return int|null
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @noinspection PhpUnhandledExceptionInspection
    */
-  protected function getContributionID(): ?int {
-    return $this->_id;
+  public function getContributionID(): ?int {
+    if (!$this->_id) {
+      $this->_id = CRM_Utils_Request::retrieve('id', 'Positive');
+    }
+    return $this->_id ? (int) $this->_id : NULL;
+  }
+
+  /**
+   * Get id of contribution page being acted on.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function getContributionPageID(): ?int {
+    return $this->getContributionID() ? $this->getContributionValue('contribution_page_id') : NULL;
   }
 
   /**

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -20,6 +20,7 @@
  */
 class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   use CRM_Financial_Form_FrontEndPaymentFormTrait;
+  use CRM_Contribute_Form_ContributeFormTrait;
 
   /**
    * The id of the contribution page that we are processing.
@@ -274,6 +275,28 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   }
 
   /**
+   * Get id of contribution page being acted on.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @return int
+   */
+  public function getContributionPageID(): int {
+    if (!$this->_id) {
+      /** @noinspection PhpUnhandledExceptionInspection */
+      $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+      if (!$this->_id) {
+        // seems like the session is corrupted and/or we lost the id trail
+        // lets just bump this to a regular session error and redirect user to main page
+        $this->controller->invalidKeyRedirect();
+      }
+    }
+    return $this->_id;
+  }
+
+  /**
    * Set variables up before form is built.
    *
    * @throws \CRM_Contribute_Exception_InactiveContributionPageException
@@ -282,13 +305,8 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   public function preProcess() {
 
     // current contribution page id
-    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    $this->getContributionPageID();
     $this->_ccid = CRM_Utils_Request::retrieve('ccid', 'Positive', $this);
-    if (!$this->_id) {
-      // seems like the session is corrupted and/or we lost the id trail
-      // lets just bump this to a regular session error and redirect user to main page
-      $this->controller->invalidKeyRedirect();
-    }
     $this->_emailExists = $this->get('emailExists');
 
     $this->_contactID = $this->_membershipContactID = $this->getContactID();

--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -21,6 +21,7 @@ use Civi\Api4\Contribution;
  * This class generates form components for Payment-Instrument.
  */
 class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
+  use CRM_Contribute_Form_ContributeFormTrait;
 
   /**
    * Set variables up before form is built.
@@ -28,7 +29,7 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
    * @throws \CRM_Core_Exception
    */
   public function preProcess() {
-    $id = $this->getID();
+    $id = $this->getContributionID();
 
     // Check permission for action.
     $actionMapping = [
@@ -86,7 +87,7 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
     }
 
     // get received into i.e to_financial_account_id from last trxn
-    $financialTrxnId = CRM_Core_BAO_FinancialTrxn::getFinancialTrxnId($this->getID(), 'DESC');
+    $financialTrxnId = CRM_Core_BAO_FinancialTrxn::getFinancialTrxnId($this->getContributionID(), 'DESC');
     $values['to_financial_account'] = '';
     $values['payment_processor_name'] = '';
     if (!empty($financialTrxnId['financialTrxnId'])) {
@@ -176,7 +177,7 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
     }
 
     //assign soft credit record if exists.
-    $SCRecords = CRM_Contribute_BAO_ContributionSoft::getSoftContribution($this->getID(), TRUE);
+    $SCRecords = CRM_Contribute_BAO_ContributionSoft::getSoftContribution($this->getContributionID(), TRUE);
     $this->assign('softContributions', empty($SCRecords['soft_credit']) ? NULL : $SCRecords['soft_credit']);
     // unset doesn't complain if array member missing
     unset($SCRecords['soft_credit']);
@@ -266,7 +267,7 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
         $urlParams = "reset=1&id={$id}&cid={$values['contact_id']}&action=update&context={$context}&key={$searchKey}";
       }
       if (!$contribution['is_template']) {
-        foreach (CRM_Contribute_BAO_Contribution::getContributionPaymentLinks($this->getID(), $contributionStatus) as $paymentButton) {
+        foreach (CRM_Contribute_BAO_Contribution::getContributionPaymentLinks($this->getContributionID(), $contributionStatus) as $paymentButton) {
           $paymentButton['icon'] = 'fa-plus-circle';
           $linkButtons[] = $paymentButton;
         }
@@ -378,7 +379,7 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
     try {
       return Contribution::checkAccess()
         ->setAction($action)
-        ->addValue('id', $this->getID())
+        ->addValue('id', $this->getContributionID())
         ->execute()->first()['access'];
     }
     catch (CRM_Core_Exception $e) {
@@ -387,16 +388,33 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
   }
 
   /**
-   * Get the contribution ID.
+   * Get the selected Contribution ID.
    *
-   * @return int
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @noinspection PhpUnhandledExceptionInspection
    */
-  private function getID(): int {
+  public function getContributionID(): ?int {
     $id = $this->get('id');
-    if (empty($id)) {
-      CRM_Core_Error::statusBounce('Contribution ID is required');
+    if (!$id) {
+      $id = CRM_Utils_Request::retrieve('id', 'Positive');
     }
-    return $id;
+    return (int) $id;
+  }
+
+  /**
+   * Get id of contribution page being acted on.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function getContributionPageID(): ?int {
+    return $this->getContributionID() ? $this->getContributionValue('contribution_page_id') : NULL;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This adds the standardisation from https://github.com/civicrm/civicrm-core/pull/27797

Before
----------------------------------------
Our preferred functions not available to getContributionID, getContributionPageID

After
----------------------------------------
They are


Technical Details
----------------------------------------
@seamuslee001 I'm having scope  blow out on https://github.com/civicrm/civicrm-core/pull/27797 so just wanting to get these merged to simplify the task at hand (also I think I found a pre-existing bug in financial acls)

Comments
----------------------------------------

