### PR TITLE
[REF] Fix Smarty Notices on Dedupe Rules screen by setting weight

### DIFF
--- a/CRM/Contact/Page/DedupeRules.php
+++ b/CRM/Contact/Page/DedupeRules.php
@@ -52,6 +52,7 @@ class CRM_Contact_Page_DedupeRules extends CRM_Core_Page_Basic {
           'url' => 'civicrm/contact/dedupefind',
           'qs' => 'reset=1&rgid=%%id%%&action=preview',
           'title' => ts('Use DedupeRule'),
+          'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::VIEW),
         ];
       }
       if (CRM_Core_Permission::check('administer dedupe rules')) {
@@ -60,6 +61,7 @@ class CRM_Contact_Page_DedupeRules extends CRM_Core_Page_Basic {
           'url' => 'civicrm/contact/deduperules',
           'qs' => 'action=update&id=%%id%%',
           'title' => ts('Edit DedupeRule'),
+          'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::UPDATE),
         ];
         $links[CRM_Core_Action::DELETE] = [
           'name' => ts('Delete'),
@@ -67,6 +69,7 @@ class CRM_Contact_Page_DedupeRules extends CRM_Core_Page_Basic {
           'qs' => 'action=delete&id=%%id%%',
           'extra' => 'onclick = "return confirm(\'' . $deleteExtra . '\');"',
           'title' => ts('Delete DedupeRule'),
+          'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::DELETE),
         ];
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
This adds weights to the Dedupe Rules links

Before
----------------------------------------
Notice errors on Dedupe Rules links

![image](https://github.com/civicrm/civicrm-core/assets/6799125/293ecdff-c583-4757-bb31-f25ea4d37619)

After
----------------------------------------
No Notices

@eileenmcnaughton 