### PR TITLE
Rid us of id=crm-container in favour of class=crm-container

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -1,20 +1,20 @@
 /* Styles specific to admin pages/forms */
 
 /* Config Task List */
-#crm-container td.tasklist a {
+.crm-container td.tasklist a {
   font-weight: bold;
 }
 
-#crm-container table.selector td.tasklist {
+.crm-container table.selector td.tasklist {
   border-right: 1px solid #dddddd;
   width: 20%;
 }
 
-#crm-container td.tasklist a:link {
+.crm-container td.tasklist a:link {
   color: #ff0105;
 }
 
-#crm-container td.tasklist a:visited {
+.crm-container td.tasklist a:visited {
   color: green;
 }
 
@@ -38,7 +38,7 @@
   color: #e43d2b !important;
 }
 
-#crm-container .crm-extensions-upgrade {
+.crm-container .crm-extensions-upgrade {
   background: #ffb;
   border: 1px solid #000;
   text-align: center;
@@ -60,17 +60,17 @@
 }
 
 @media screen and (min-width: 480px) {
-  #crm-container .admin-section-items {
+  .crm-container .admin-section-items {
     column-count: 2;
     column-gap: 1em;
   }
-  #crm-container .admin-section-items dl {
+  .crm-container .admin-section-items dl {
     -webkit-column-break-inside: avoid;
     page-break-inside: avoid;
     break-inside: avoid;
     margin: 0 1em;
   }
-  #crm-container .admin-section-items dt {
+  .crm-container .admin-section-items dt {
     font-weight: bold;
   }
 }

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -75,12 +75,12 @@ input.crm-form-checkbox + label {
   font-weight: normal;
 }
 
-#crm-container .hiddenElement,
+.crm-container .hiddenElement,
 .crm-container .hiddenElement {
   display: none;
 }
 
-#crm-container .clear,
+.crm-container .clear,
 .crm-container .clear {
   clear: both;
 }
@@ -92,7 +92,7 @@ input.crm-form-checkbox + label {
   text-decoration: none;
 }
 
-#crm-container .crm-content-block {
+.crm-container .crm-content-block {
   padding: 0;
 }
 
@@ -235,7 +235,7 @@ input.crm-form-entityref {
 }
 
 /* Override line-height from style.css */
-#crm-container,
+.crm-container,
 .crm-container {
   line-height: 135%;
 }
@@ -442,7 +442,7 @@ input.crm-form-entityref {
   margin-left: 0;
 }
 
-#crm-container #cvv2 {
+.crm-container #cvv2 {
   vertical-align: top;
 }
 
@@ -780,7 +780,7 @@ input.crm-form-entityref {
   background-color: transparent;
 }
 
-#crm-container .col1 {
+.crm-container .col1 {
   float: left;
   vertical-align: top;
   width: 40%;
@@ -788,7 +788,7 @@ input.crm-form-entityref {
   margin: 0 25px 0 25px;
 }
 
-#crm-container .col2 {
+.crm-container .col2 {
   float: right;
   vertical-align: top;
   width: 50%;
@@ -796,16 +796,16 @@ input.crm-form-entityref {
   margin: 0;
 }
 
-#crm-container ul.indented {
+.crm-container ul.indented {
   padding-left: 3em;
 }
 
-#crm-container tr.subevent td.event-title,
-#crm-container tr.subevent td.event-info {
+.crm-container tr.subevent td.event-title,
+.crm-container tr.subevent td.event-info {
   padding-left: 3em;
 }
 
-#crm-container span.child-indent {
+.crm-container span.child-indent {
   padding-left: 1em;
 }
 
@@ -891,121 +891,121 @@ input.crm-form-entityref {
 }
 
 /* Styles for record browser and report tables, and pager bar */
-#crm-container #map-field table,
-#crm-container table.report,
-#crm-container table.chart {
+.crm-container #map-field table,
+.crm-container table.report,
+.crm-container table.chart {
   width: auto;
 }
 
-#crm-container .crm-flashchart {
+.crm-container .crm-flashchart {
   overflow: auto;
 }
 
-#crm-container td.enclosingNested {
+.crm-container td.enclosingNested {
   padding: 0;
 }
 
-#crm-container .nowrap {
+.crm-container .nowrap {
   white-space: nowrap;
 }
 
-#crm-container tr.columnheader {
+.crm-container tr.columnheader {
   background-color: #e6e6e6;
   color: #000000;
   border: 1px solid #ddd;
 }
 
-#crm-container tr.columnheader a {
+.crm-container tr.columnheader a {
   color: #000;
   text-decoration: none;
   vertical-align: top;
 }
 
-#crm-container tr.columnheader-dark th {
+.crm-container tr.columnheader-dark th {
   background-color: #999999;
   color: #fafafa;
   border: 1px solid #696969;
 }
 
-#crm-container tr.columnheader-dark td,
-#crm-container tr.columnheader-dark th,
-#crm-container tr.columnheader td,
-#crm-container tr.columnfooter td {
+.crm-container tr.columnheader-dark td,
+.crm-container tr.columnheader-dark th,
+.crm-container tr.columnheader td,
+.crm-container tr.columnfooter td {
   font-size: 1.1em;
   font-weight: bold;
 }
 
 /* dev/core#1039 Make contact details in popup on merge screen non bold */
-#crm-container tr.columnheader td [class*="crm-summary-col-"] {
+.crm-container tr.columnheader td [class*="crm-summary-col-"] {
   font-size: 13px;
   font-weight: normal;
 }
 
-#crm-container tr.columnheader-dark th span.extra {
+.crm-container tr.columnheader-dark th span.extra {
   font-size: .95em;
   font-weight: normal;
 }
 
-#crm-container tr.columnfooter {
+.crm-container tr.columnfooter {
   border-top: 2px solid #999999;
   font-size: 1.1em;
 }
 
-#crm-container #map-field th {
+.crm-container #map-field th {
   border-right: 1px solid #999999;
 }
 
-#crm-container #map-field td,
-#crm-container .report td,
-#crm-container .chart td {
+.crm-container #map-field td,
+.crm-container .report td,
+.crm-container .chart td {
   padding: 10px 10px 4px 10px;
 }
 
-#crm-container .report td {
+.crm-container .report td {
   border: 1px solid #999999;
   background-color: #f6f6f6;
 }
 
 /* double line right border for last cell in a horizontal grouping */
-#crm-container table.report td.splitter {
+.crm-container table.report td.splitter {
   border-right: 5px double #999999;
 }
 
-#crm-container .report td.separator {
+.crm-container .report td.separator {
   padding-top: 1em;
   background-color: #ffffff;
   border-left-color: #ffffff;
   border-right-color: #ffffff;
 }
 
-#crm-container .chart td {
+.crm-container .chart td {
   border: 2px solid #999999;
 }
 
-#crm-container .float-left {
+.crm-container .float-left {
   float: left;
   padding: 4px 0;
   clear: none;
 }
 
-#crm-container .float-left + .float-left {
+.crm-container .float-left + .float-left {
   margin-left: 1em;
 }
 
-#crm-container .float-right {
+.crm-container .float-right {
   float: right;
   width: auto;
   padding: 4px 0;
   clear: none;
 }
 
-#crm-container .align-right {
+.crm-container .align-right {
   display: block;
   margin-right: 20px;
   text-align: right;
 }
 
-#crm-container .element-right {
+.crm-container .element-right {
   float: right;
   margin-right: 35px;
 }
@@ -1042,7 +1042,7 @@ input.crm-form-entityref {
 }
 
 .crm-container #search-status ul li,
-#crm-container ul.left-alignment li {
+.crm-container ul.left-alignment li {
   display: list-item;
   margin-left: 2em;
   list-style-position: inside;
@@ -1058,13 +1058,13 @@ input.crm-form-entityref {
   padding-left: 5px;
 }
 
-#crm-container .section-hidden {
+.crm-container .section-hidden {
   display: block;
   margin: 0;
   padding: 5px;
   font-size: 0.95em;
 }
-#crm-container form .section-hidden-border {
+.crm-container form .section-hidden-border {
   background-color: #5c5c59;
   border: medium none;
   color: #ffffff;
@@ -1074,10 +1074,10 @@ input.crm-form-entityref {
   padding: 2px 0 0 0;
 }
 
-#crm-container .section-shown {
+.crm-container .section-shown {
   padding: 0 5px;
 }
-#crm-container .data-group-first {
+.crm-container .data-group-first {
   margin: 10px 5px 5px 5px;
   padding: 5px;
   border-top: 2px solid #999999;
@@ -1085,7 +1085,7 @@ input.crm-form-entityref {
 }
 
 /* Styles for Wizard Progress Bars */
-#crm-container ul.wizard-bar {
+.crm-container ul.wizard-bar {
   border-collapse: collapse;
   padding: 0 0 0 1em;
   white-space: nowrap;
@@ -1098,7 +1098,7 @@ input.crm-form-entityref {
   text-align: center;
 }
 
-#crm-container ul.wizard-bar li {
+.crm-container ul.wizard-bar li {
   display: inline;
   background-color: #fafafa;
   border: 1px solid #999999;
@@ -1110,23 +1110,23 @@ input.crm-form-entityref {
   background-image: none;
 }
 
-#crm-container ul.wizard-bar li.current-step {
+.crm-container ul.wizard-bar li.current-step {
   background-color: #4a89dc;
   border-color: #4a89dc;
   color: #ffffff;
   font-weight: bold;
 }
 
-#crm-container ul.wizard-bar li.past-step {
+.crm-container ul.wizard-bar li.past-step {
   background-color: #f5f5f5;
   color: #666;
 }
 
-#crm-container ul.wizard-bar li:first-child {
+.crm-container ul.wizard-bar li:first-child {
   border-radius: 8px 0 0 8px;
 }
 
-#crm-container ul.wizard-bar li:last-child {
+.crm-container ul.wizard-bar li:last-child {
   border-radius: 0 8px 8px 0;
 }
 
@@ -1224,7 +1224,7 @@ input.crm-form-entityref {
   cursor: pointer;
 }
 
-#crm-container button.submit-link {
+.crm-container button.submit-link {
   color: #285286;
   background: none transparent;
   border: none;
@@ -1245,7 +1245,7 @@ input.crm-form-entityref {
   content: "\00BB";
 }
 
-#crm-container.clear,
+.crm-container.clear,
 .crm-container .crm-group-summary .clear {
   /* generic container (i.e. div) for floating buttons */
   overflow: hidden;
@@ -1254,7 +1254,7 @@ input.crm-form-entityref {
 
 #location .form-layout table,
 #location .form-layout td,
-#crm-container div#location table.form-layout table.inner-table td {
+.crm-container div#location table.form-layout table.inner-table td {
   border: 0;
   vertical-align: top;
   margin-bottom: -5px;
@@ -1262,29 +1262,29 @@ input.crm-form-entityref {
 }
 
 /* class for personal campaign info page */
-#crm-container table.campaign th,
+.crm-container table.campaign th,
 .crm-container table.campaign td,
-#crm-container table.campaign,
-#crm-container table.campaign table.form-layout td {
+.crm-container table.campaign,
+.crm-container table.campaign table.form-layout td {
   font-size: 9pt;
   border: 0;
   width: auto;
   vertical-align: top;
 }
 
-#crm-container table.campaign table {
+.crm-container table.campaign table {
   background: #f7f7f7;
 }
 
-#crm-container div.remaining {
+.crm-container div.remaining {
   background: url("../i/contribute/pcp_remain.gif");
 }
 
-#crm-container div.achieved {
+.crm-container div.achieved {
   background: url("../i/contribute/pcp_achieve.gif");
 }
 
-#crm-container .honor_roll {
+.crm-container .honor_roll {
   margin: 1em 20px 0 0;
   padding: 10px;
   width: 120px;
@@ -1294,21 +1294,21 @@ input.crm-form-entityref {
   overflow: hidden;
 }
 
-#crm-container .thermometer-wrapper,
-#crm-container .honor-roll-wrapper {
+.crm-container .thermometer-wrapper,
+.crm-container .honor-roll-wrapper {
   float: left;
   width: 150px;
   margin-left: 1em;
 }
 
-#crm-container .thermometer-fill-wrapper {
+.crm-container .thermometer-fill-wrapper {
   background: transparent url("../i/contribute/pcp_remain.gif") repeat-y scroll left bottom;
   height: 220px;
   position: relative;
   margin: 1em 0 1.5em 0;
 }
 
-#crm-container .thermometer-fill {
+.crm-container .thermometer-fill {
   background: transparent url(../i/contribute/pcp_achieve.gif) repeat-y scroll 0 bottom;
   bottom: 0;
   left: 0;
@@ -1316,7 +1316,7 @@ input.crm-form-entityref {
   width: 130px;
 }
 
-#crm-container .thermometer-pointer {
+.crm-container .thermometer-pointer {
   padding-left: 45px;
   /* width of thermometer + a little actual padding */
   position: absolute;
@@ -1325,83 +1325,83 @@ input.crm-form-entityref {
   line-height: 1em;
 }
 
-#crm-container .pcp-intro-text {
+.crm-container .pcp-intro-text {
   padding-bottom: 1em;
 }
 
-#crm-container .pcp-image {
+.crm-container .pcp-image {
   float: left;
   margin: 0 1em 1em 0;
 }
 
-#crm-container .pcp-image img {
+.crm-container .pcp-image img {
   max-width: 360px;
 }
 
-#crm-container .pcp-widgets {
+.crm-container .pcp-widgets {
   border: 1px solid #cccccc;
   float: right;
   margin: 0 0 1em 1em;
   padding: 0.5em;
 }
 
-#crm-container .pcp_honor_roll_entry {
+.crm-container .pcp_honor_roll_entry {
   margin-bottom: 1em;
 }
 
-#crm-container .pcp-honor_roll-nickname {
+.crm-container .pcp-honor_roll-nickname {
   font-weight: bold;
 }
 
-#crm-container .pcp-donate {
+.crm-container .pcp-donate {
   height: 24px;
 }
-#crm-container a.pcp-contribute-button {
+.crm-container a.pcp-contribute-button {
   font-weight: bold;
 }
 
-#crm-container .pcp-create-your-own {
+.crm-container .pcp-create-your-own {
   clear: left;
   margin: 1em 0;
 }
 
-#crm-container .pcp-page-text {
+.crm-container .pcp-page-text {
   margin-bottom: 1em;
 }
 
-#crm-container table.nestedSelector {
+.crm-container table.nestedSelector {
   margin: 0;
   width: 100%;
   border-bottom: 0;
 }
 
-#crm-container table.nestedSelector tr.columnheader th {
+.crm-container table.nestedSelector tr.columnheader th {
   border: 0;
 }
 
-#crm-container table.caseSelector {
+.crm-container table.caseSelector {
   vertical-align: top;
   border: 0;
   margin: 0.5em 0.1em;
 }
 
-#crm-container table.caseSelector tr {
+.crm-container table.caseSelector tr {
   border-bottom: 1px solid #999999;
 }
 
-#crm-container table.caseSelector td {
+.crm-container table.caseSelector td {
   border-right: 0;
   padding: 4px;
 }
 
-#crm-container table.nestedActivitySelector {
+.crm-container table.nestedActivitySelector {
   margin: 0;
   width: 100%;
   border: 0;
   color: #333333;
 }
 
-#crm-container table.nestedActivitySelector tr.columnheader th {
+.crm-container table.nestedActivitySelector tr.columnheader th {
   color: #000000;
   background-color: #cfcec3;
   border-top-color: #fff;
@@ -1410,75 +1410,75 @@ input.crm-form-entityref {
   border-bottom-color: #999999;
 }
 
-#crm-container table#activities-selector.nestedActivitySelector,
-#crm-container table#activities-selector.nestedActivitySelector td {
+.crm-container table#activities-selector.nestedActivitySelector,
+.crm-container table#activities-selector.nestedActivitySelector td {
   border: 0;
 }
 
-#crm-container table.nestedActivitySelector td {
+.crm-container table.nestedActivitySelector td {
   border-right: 0;
 }
 
-#crm-container table.nestedActivitySelector tr.priority-urgent,
-#crm-container table.nestedActivitySelector tr a.priority-urgent {
+.crm-container table.nestedActivitySelector tr.priority-urgent,
+.crm-container table.nestedActivitySelector tr a.priority-urgent {
   background-color: #ffdddd;
 }
 
-#crm-container table.nestedActivitySelector tr.priority-low,
-#crm-container table.nestedActivitySelector tr a.priority-low {
+.crm-container table.nestedActivitySelector tr.priority-low,
+.crm-container table.nestedActivitySelector tr a.priority-low {
   background-color: #ddffdd;
 }
 
-#crm-container table.nestedActivitySelector tr.status-scheduled,
-#crm-container table.nestedActivitySelector tr a.status-scheduled {
+.crm-container table.nestedActivitySelector tr.status-scheduled,
+.crm-container table.nestedActivitySelector tr a.status-scheduled {
   color: #006633;
 }
 
-#crm-container table.nestedActivitySelector tr.status-completed,
-#crm-container table.nestedActivitySelector tr a.status-completed {
+.crm-container table.nestedActivitySelector tr.status-completed,
+.crm-container table.nestedActivitySelector tr a.status-completed {
   color: #333333;
 }
 
-#crm-container table.nestedActivitySelector tr.status-overdue,
-#crm-container table.nestedActivitySelector tr a.status-overdue {
+.crm-container table.nestedActivitySelector tr.status-overdue,
+.crm-container table.nestedActivitySelector tr a.status-overdue {
   color: #ff0000;
 }
 
-#crm-container table.nestedActivitySelector tr a.crm-activity-status {
+.crm-container table.nestedActivitySelector tr a.crm-activity-status {
   cursor: pointer;
 }
 
-#crm-container #activities-selector tr:hover td,
-#crm-container #activities-selector tr:hover td.sorted,
-#crm-container #activities-selector tr.trOver td.sorted,
-#crm-container #activities-selector tr.trOver td {
+.crm-container #activities-selector tr:hover td,
+.crm-container #activities-selector tr:hover td.sorted,
+.crm-container #activities-selector tr.trOver td.sorted,
+.crm-container #activities-selector tr.trOver td {
   background: transparent;
 }
 
 /* Styles for Actions Ribbon */
-#crm-container .crm-actions-ribbon {
+.crm-container .crm-actions-ribbon {
   margin: 0 0 8px 0;
 }
 
-#crm-container .crm-actions-ribbon ul {
+.crm-container .crm-actions-ribbon ul {
   margin: 0;
   padding: 0;
 }
 
-#crm-container .crm-actions-ribbon li {
+.crm-container .crm-actions-ribbon li {
   float: left;
   margin: 0 8px 0 0;
   padding: 0;
   list-style: none;
 }
 
-#crm-container .crm-actions-ribbon li.crm-previous-action,
-#crm-container .crm-actions-ribbon li.crm-next-action {
+.crm-container .crm-actions-ribbon li.crm-previous-action,
+.crm-container .crm-actions-ribbon li.crm-next-action {
   float: right;
   margin: 0 0 0 8px;
 }
 
-#crm-container .ac_results li {
+.crm-container .ac_results li {
   float: none;
   padding: 4px;
   margin: 0;
@@ -1667,16 +1667,16 @@ input.crm-form-entityref {
   font-style: normal;
 }
 
-#crm-container div.ui-accordion-content {
+.crm-container div.ui-accordion-content {
   padding: .5em 1em !important;
 }
 
-#crm-container .ui-tabs-panel {
+.crm-container .ui-tabs-panel {
   padding: 4px;
   min-height: 12em;
 }
 
-#crm-container div.contact_details {
+.crm-container div.contact_details {
   padding: 4px;
   line-height: 1.4em;
   clear: both;
@@ -1699,7 +1699,7 @@ input.crm-form-entityref {
 
 /* reports */
 
-#crm-container div.buttons {
+.crm-container div.buttons {
   text-align: right;
   margin: 8px 0 0;
   padding: 4px 4px 2px 0;
@@ -1707,31 +1707,31 @@ input.crm-form-entityref {
   border: none;
 }
 
-#crm-container div.buttons input,
-#crm-container div.buttons select {
+.crm-container div.buttons input,
+.crm-container div.buttons select {
   font-size: 0.9em;
   vertical-align: top !important;
 }
 
-#crm-container div.buttons #actions {
+.crm-container div.buttons #actions {
   text-align: left;
   float: left;
 }
-#crm-container div.buttons ul#actions {
+.crm-container div.buttons ul#actions {
   list-style-type: none;
   padding-left: 0;
 }
-#crm-container div.buttons #actions li {
+.crm-container div.buttons #actions li {
   float: left;
   padding: 0;
   margin: 0 5px 0 0;
 }
 
-#crm-container div.crm-case-dashboard-buttons {
+.crm-container div.crm-case-dashboard-buttons {
   height: 33px;
 }
 
-#crm-container div.crm-case-dashboard-switch-view-buttons {
+.crm-container div.crm-case-dashboard-switch-view-buttons {
   float: right;
 }
 
@@ -1752,19 +1752,19 @@ input.crm-form-entityref {
   margin-bottom: .1em;
 }
 
-#crm-container .separator {
+.crm-container .separator {
   border-bottom: solid 2px #ccc;
 }
 
-#crm-container .report-layout {
+.crm-container .report-layout {
   border: none;
 }
 
-#crm-container .reports-header-right {
+.crm-container .reports-header-right {
   text-align: right;
 }
 
-#crm-container .report-contents {
+.crm-container .report-contents {
   background-color: #f5f5f5;
   border: 1px solid #cdcdc3;
   padding: 4px;
@@ -1773,33 +1773,33 @@ input.crm-form-entityref {
   font-size: 0.95em;
 }
 
-#crm-container .report-contents-right {
+.crm-container .report-contents-right {
   border: 1px solid #cdcdc3;
   padding: 4px;
   font-size: 0.95em;
   text-align: right;
 }
 
-#crm-container table.report-layout td {
+.crm-container table.report-layout td {
   padding: 4px;
   border-bottom: 1px solid #cdcdc3;
   vertical-align: top;
 }
 
-#crm-container table.report-layout tr {
+.crm-container table.report-layout tr {
   font-size: 0.95em;
 }
 
-#crm-container .report-label {
+.crm-container .report-label {
   text-align: right;
   font-weight: bold;
 }
 
-#crm-container table.report-layout th.report-contents {
+.crm-container table.report-layout th.report-contents {
   background-color: #f5f5f5;
 }
 
-#crm-container table.report-layout th.statistics {
+.crm-container table.report-layout th.statistics {
   width: 5%;
   white-space: nowrap;
 }
@@ -1809,13 +1809,13 @@ input.crm-form-entityref {
   color: #000000;
 }
 
-#crm-container table.view-layout {
+.crm-container table.view-layout {
   margin: 0;
   border-collapse: collapse;
   border: 0 none;
 }
 
-#crm-container table.view-layout .label {
+.crm-container table.view-layout .label {
   color: DimGray;
   font-size: 0.95em;
   vertical-align: top;
@@ -1825,11 +1825,11 @@ input.crm-form-entityref {
   width: 20%;
 }
 
-#crm-container th.contriTotalRight {
+.crm-container th.contriTotalRight {
   border-right: 1px solid #999999;
 }
 
-#crm-container th.contriTotalLeft {
+.crm-container th.contriTotalLeft {
   border-left: 1px solid #999999;
 }
 
@@ -1851,7 +1851,7 @@ input.crm-form-entityref {
 
 /* Set/alter ICONS */
 
-#crm-container .order-icon {
+.crm-container .order-icon {
   height: 15px;
   width: 10px;
   padding-top: 4px;
@@ -2194,7 +2194,7 @@ div.crm-master-accordion-header a.helpicon {
 
 /* Specific types of headers */
 
-#crm-container .widget-content .crm-accordion-header {
+.crm-container .widget-content .crm-accordion-header {
   background-color: #efefe5;
   color: #080808;
 }
@@ -2226,7 +2226,7 @@ div.crm-master-accordion-header a.helpicon {
   background-color: #2f2f2e;
 }
 
-#crm-container .widget-content .crm-accordion-header:hover {
+.crm-container .widget-content .crm-accordion-header:hover {
   background-color: #e8e8de;
 }
 
@@ -2292,7 +2292,7 @@ div.crm-master-accordion-header a.helpicon {
   padding: 4px 0;
 }
 
-#crm-container .widget-content .crm-accordion-body {
+.crm-container .widget-content .crm-accordion-body {
   border-color: #e8e8de;
 }
 
@@ -2301,7 +2301,7 @@ div.crm-master-accordion-header a.helpicon {
   padding: 0;
 }
 
-#crm-container .widget-content .crm-accordion-body,
+.crm-container .widget-content .crm-accordion-body,
 .crm-container .crm-accordion-body.padded {
   padding-left: .5em;
   padding-right: .5em;
@@ -2380,8 +2380,8 @@ div.crm-master-accordion-header a.helpicon {
   min-width: 20px;
   min-height: 20px;
 }
-#crm-container .crm-tooltip table,
-#crm-container .crm-tooltip table tr td {
+.crm-container .crm-tooltip table,
+.crm-container .crm-tooltip table tr td {
   background-color: #2f2f2e;
   border: none;
   color: #fff;
@@ -2437,28 +2437,28 @@ div.crm-master-accordion-header a.helpicon {
   margin-right: 45px;
 }
 
-#crm-container ul li {
+.crm-container ul li {
   list-style-image: none;
 }
 
 /* privacy icons */
-#crm-container div span.privacy-flag {
+.crm-container div span.privacy-flag {
   float: right;
   font-size: 80%;
 }
 
 /* specific, targeted fixes */
-#crm-container .dashboard-elements,
-#crm-container #membership-listings,
-#crm-container #premiums-listings,
-#crm-container #searchForm table {
+.crm-container .dashboard-elements,
+.crm-container #membership-listings,
+.crm-container #premiums-listings,
+.crm-container #searchForm table {
   margin: 0;
   border-collapse: collapse;
   border: 0 none;
 }
 
 /* ID selector is needed to override Drupal 2em margin-bottom on forms (we don't want to give up that space) */
-div#crm-container form,
+div.crm-container form,
 div.crm-container form {
   margin-bottom: 0;
 }
@@ -2677,22 +2677,22 @@ div.crm-container form {
   overflow: auto;
 }
 
-#crm-container .signature {
+.crm-container .signature {
   width: 495px;
 }
 
 /* editor skin tweaks */
 
-#crm-container span.cke_skin_kama {
+.crm-container span.cke_skin_kama {
   border: none;
 }
-#crm-container .cke_skin_kama .cke_wrapper {
+.crm-container .cke_skin_kama .cke_wrapper {
   background-image: none;
 }
 
 /* skin */
 
-#crm-container .crm-title {
+.crm-container .crm-title {
   line-height: 1.1;
   margin-bottom: 8px;
 }
@@ -2776,7 +2776,7 @@ tbody.scrollContent tr.alternateRow {
 
 
 /*contact summary page */
-#crm-container div.contact_details {
+.crm-container div.contact_details {
   background-color: transparent;
 }
 
@@ -2800,7 +2800,7 @@ tbody.scrollContent tr.alternateRow {
   color: #999999 !important;
 }
 
-#crm-container tr.crm-job {
+.crm-container tr.crm-job {
   text-decoration: none !important;
 }
 
@@ -2864,7 +2864,7 @@ tbody.scrollContent tr.alternateRow {
   color: #52534d;
 }
 
-#crm-container .crm-tasks table {
+.crm-container .crm-tasks table {
   margin: 0;
 }
 
@@ -3212,11 +3212,11 @@ span.crm-select-item-color {
   background-color: #fffdb2;
 }
 
-#crm-container .crm-socialnetwork {
+.crm-container .crm-socialnetwork {
   margin-top: 1em;
 }
 
-#crm-container .crm-fb-tweet-buttons {
+.crm-container .crm-fb-tweet-buttons {
   width: 93%;
 }
 
@@ -3464,29 +3464,29 @@ span.crm-select-item-color {
 /*end crm-10345*/
 
 /* alter display of parent and child groups in Manage Groups selector */
-#crm-container .crm-group-parent td.crm-group-name {
+.crm-container .crm-group-parent td.crm-group-name {
   padding-left: 20px;
   text-indent: -20px;
 }
 
-#crm-container .crm-group-child td.crm-group-name.level_2 {
+.crm-container .crm-group-child td.crm-group-name.level_2 {
   padding-left: 40px;
   text-indent: -20px;
 }
-#crm-container .crm-group-child td.crm-group-name.level_3 {
+.crm-container .crm-group-child td.crm-group-name.level_3 {
   padding-left: 60px;
   text-indent: -20px;
 }
-#crm-container .crm-group-name span.crm-editable-enabled {
+.crm-container .crm-group-name span.crm-editable-enabled {
   text-indent: 0;
 }
 
-#crm-container div.crm-row-parent-name {
+.crm-container div.crm-row-parent-name {
   padding: 3px 0 0 .5em;
   opacity: 0.75;
 }
-#crm-container td span.show-children,
-#crm-container td span.crm-no-children {
+.crm-container td span.show-children,
+.crm-container td span.crm-no-children {
   padding-left: 20px;
 }
 
@@ -3614,10 +3614,10 @@ span.crm-status-icon {
 
 /* Public Pages */
 
-#crm-container.crm-public input[type="text"],
-#crm-container.crm-public input[type="password"],
-#crm-container.crm-public input[type="email"],
-#crm-container.crm-public select {
+.crm-container.crm-public input[type="text"],
+.crm-container.crm-public input[type="password"],
+.crm-container.crm-public input[type="email"],
+.crm-container.crm-public select {
   font-size: 15px;
   padding: 5px;
   border-radius: 3px;
@@ -3625,8 +3625,8 @@ span.crm-status-icon {
   max-width: 100%;
 }
 
-#crm-container.crm-public .label,
-#crm-container.crm-public .price-field-amount {
+.crm-container.crm-public .label,
+.crm-container.crm-public .price-field-amount {
   padding-top: 6px;
   font-size: 15px;
 }
@@ -3663,112 +3663,112 @@ span.crm-status-icon {
   padding-top: 6px;
 }
 
-#crm-container.crm-public .calc-value,
-#crm-container.crm-public .content {
+.crm-container.crm-public .calc-value,
+.crm-container.crm-public .content {
   padding-top: 6px;
   font-size: 15px;
 }
 
-#crm-container.crm-public .crm-section,
+.crm-container.crm-public .crm-section,
 .crm-section {
   margin-bottom: 0;
 }
 
-#crm-container.crm-public #crm-submit-buttons {
+.crm-container.crm-public #crm-submit-buttons {
   margin-top: 30px;
 }
 
-#crm-container.crm-public #premiums-listings {
+.crm-container.crm-public #premiums-listings {
   margin-top: 10px;
   min-width: 450px;
   width: 60%;
 }
 
-#crm-container.crm-public #premiums-listings .premium {
+.crm-container.crm-public #premiums-listings .premium {
   margin: 5px 0;
 }
 
-#crm-container.crm-public #premiums-listings .premium .premium-short {
+.crm-container.crm-public #premiums-listings .premium .premium-short {
   padding: 10px;
   border: 2px solid #ffffff;
   background-color: #f0f0f0;
   cursor: pointer;
 }
 
-#crm-container.crm-public #premiums-listings .premium .premium-short:hover {
+.crm-container.crm-public #premiums-listings .premium .premium-short:hover {
   border: 2px solid #b0b0b0;
 }
 
-#crm-container.crm-public #premiums-listings .premium .premium-short-thumbnail {
+.crm-container.crm-public #premiums-listings .premium .premium-short-thumbnail {
   float: left;
   width: 50px;
 }
 
-#crm-container.crm-public #premiums-listings .premium .premium-short-thumbnail img {
+.crm-container.crm-public #premiums-listings .premium .premium-short-thumbnail img {
   width: 50px;
 }
 
-#crm-container.crm-public #premiums-listings .premium .premium-short-content {
+.crm-container.crm-public #premiums-listings .premium .premium-short-content {
   text-align: center;
   font-size: 20px;
   font-weight: bold;
   padding: 20px;
 }
 
-#crm-container.crm-public #premiums-listings .premium .premium-full {
+.crm-container.crm-public #premiums-listings .premium .premium-full {
   display: none;
   padding: 5px;
   border: 2px solid #cfcfcf;
   background-color: #ffffff;
 }
 
-#crm-container.crm-public #premiums-listings .premium .premium-full .premium-full-image {
+.crm-container.crm-public #premiums-listings .premium .premium-full .premium-full-image {
   float: left;
   width: 200px;
   padding: 10px;
 }
 
-#crm-container.crm-public #premiums-listings .premium .premium-full .premium-full-image img {
+.crm-container.crm-public #premiums-listings .premium .premium-full .premium-full-image img {
   width: 200px;
 }
 
-#crm-container.crm-public #premiums-listings .premium .premium-full .premium-full-title {
+.crm-container.crm-public #premiums-listings .premium .premium-full .premium-full-title {
   text-align: center;
   font-size: 1.5em;
   font-weight: bold;
   padding: 20px;
 }
 
-#crm-container.crm-public #premiums-listings .premium .premium-full .premium-full-min {
+.crm-container.crm-public #premiums-listings .premium .premium-full .premium-full-min {
   font-size: .9em;
   font-style: italic;
 }
 
-#crm-container.crm-public #premiums-listings .premium.premium-no_thanks .premium-short {
+.crm-container.crm-public #premiums-listings .premium.premium-no_thanks .premium-short {
   text-align: center;
   font-size: 1.3em;
   padding: 10px;
 }
 
-#crm-container.crm-public #premiums-listings .premium.premium-no_thanks .premium-full {
+.crm-container.crm-public #premiums-listings .premium.premium-no_thanks .premium-full {
   text-align: center;
   font-size: 1.3em;
   font-weight: bold;
   padding: 10px;
 }
 
-#crm-container.crm-public #premiums-listings .premium.premium-disabled .premium-short,
-#crm-container.crm-public #premiums-listings .premium.premium-disabled .premium-full .premium-full-image,
-#crm-container.crm-public #premiums-listings .premium.premium-disabled .premium-full .premium-full-title,
-#crm-container.crm-public #premiums-listings .premium.premium-disabled .premium-full .premium-full-description,
-#crm-container.crm-public #premiums-listings .premium.premium-disabled .premium-full .premium-full-options,
-#crm-container.crm-public #premiums-listings .premium.premium-disabled .premium-full .premium-full-min {
+.crm-container.crm-public #premiums-listings .premium.premium-disabled .premium-short,
+.crm-container.crm-public #premiums-listings .premium.premium-disabled .premium-full .premium-full-image,
+.crm-container.crm-public #premiums-listings .premium.premium-disabled .premium-full .premium-full-title,
+.crm-container.crm-public #premiums-listings .premium.premium-disabled .premium-full .premium-full-description,
+.crm-container.crm-public #premiums-listings .premium.premium-disabled .premium-full .premium-full-options,
+.crm-container.crm-public #premiums-listings .premium.premium-disabled .premium-full .premium-full-min {
   opacity: 0.5;
 }
-#crm-container.crm-public #premiums-listings .premium .premium-full-disabled {
+.crm-container.crm-public #premiums-listings .premium .premium-full-disabled {
   display: none;
 }
-#crm-container.crm-public #premiums-listings .premium.premium-disabled .premium-full-disabled {
+.crm-container.crm-public #premiums-listings .premium.premium-disabled .premium-full-disabled {
   display: block;
   color: #ff0000;
   text-align: center;
@@ -3776,42 +3776,42 @@ span.crm-status-icon {
   margin-bottom: .5em;
 }
 
-#crm-container.crm-public .price-set-row {
+.crm-container.crm-public .price-set-row {
   font-size: 15px;
   margin-bottom: 5px;
 }
 
-#crm-container.crm-public .price-set-row input,
-#crm-container.crm-public .price-set-row label {
+.crm-container.crm-public .price-set-row input,
+.crm-container.crm-public .price-set-row label {
   vertical-align: middle;
   cursor: pointer;
 }
 
-#crm-container.crm-public .price-set-row .crm-price-amount-amount {
+.crm-container.crm-public .price-set-row .crm-price-amount-amount {
   min-width: 2em;
   color: #333333;
 }
 
-#crm-container.crm-public .price-set-row .crm-price-amount-label {
+.crm-container.crm-public .price-set-row .crm-price-amount-label {
   color: #444444;
 }
 
-#crm-container.crm-public .price-set-row .highlight label {
+.crm-container.crm-public .price-set-row .highlight label {
   color: #000000;
   font-weight: bold;
 }
 
-#crm-container.crm-public .price-set-row .highlight .crm-price-amount-label {
+.crm-container.crm-public .price-set-row .highlight .crm-price-amount-label {
   color: #222222;
 }
 
-#crm-container.crm-public .price-set-option-content > tt {
+.crm-container.crm-public .price-set-option-content > tt {
   display: none;
 }
 
-#crm-container .sold-out-option,
-#crm-container .price-set-row span.sold-out-option .crm-price-amount-label,
-#crm-container .price-set-row span.sold-out-option .crm-price-amount-amount {
+.crm-container .sold-out-option,
+.crm-container .price-set-row span.sold-out-option .crm-price-amount-label,
+.crm-container .price-set-row span.sold-out-option .crm-price-amount-amount {
   font-style: italic !important;
   font-weight: normal !important;
   font-size: 15px;
@@ -3864,11 +3864,11 @@ span.crm-status-icon {
 }
 
 /* Avoid weird border around the images (some themes will add a border around images) */
-#crm-container .credit_card_type-section .crm-credit_card_type-icons a,
-#crm-container .credit_card_type-section .crm-credit_card_type-icons a:link,
-#crm-container .credit_card_type-section .crm-credit_card_type-icons a:hover,
-#crm-container .credit_card_type-section .crm-credit_card_type-icons a:focus,
-#crm-container .credit_card_type-section .crm-credit_card_type-icons a:active {
+.crm-container .credit_card_type-section .crm-credit_card_type-icons a,
+.crm-container .credit_card_type-section .crm-credit_card_type-icons a:link,
+.crm-container .credit_card_type-section .crm-credit_card_type-icons a:hover,
+.crm-container .credit_card_type-section .crm-credit_card_type-icons a:focus,
+.crm-container .credit_card_type-section .crm-credit_card_type-icons a:active {
   color: #fff;
 }
 

--- a/css/contactSummary.css
+++ b/css/contactSummary.css
@@ -21,18 +21,18 @@ div#crm-contact-thumbnail {
   border-bottom: 1px solid #fff;
 }
 
-#crm-container div.crm-inline-edit {
+.crm-container div.crm-inline-edit {
   border: 2px dashed transparent;
   background: none;
   position: relative;
 }
 
-#crm-container .crm-edit-ready .crm-inline-edit:hover {
+.crm-container .crm-edit-ready .crm-inline-edit:hover {
   cursor: pointer;
   border: 2px dashed lightgrey;
 }
 
-#crm-container div.crm-inline-edit.form {
+.crm-container div.crm-inline-edit.form {
   cursor: default;
   border: 2px dashed #6665bf;
   box-shadow: rgba(255, 255, 255, 0.3) 0 0 0 99999px;
@@ -45,11 +45,11 @@ div#crm-contact-thumbnail {
   float: right;
 }
 
-#crm-container .crm-inline-edit.add-new {
+.crm-container .crm-inline-edit.add-new {
   min-height: 2.5em;
 }
 
-#crm-container div.crm-summary-block .crm-edit-help {
+.crm-container div.crm-summary-block .crm-edit-help {
   display: none;
   position: absolute;
   right: 0;
@@ -59,74 +59,74 @@ div#crm-contact-thumbnail {
   border-bottom-left-radius: 1em;
 }
 
-#crm-container .crm-address-block+.crm-address-block .add-new .crm-edit-help {
+.crm-container .crm-address-block+.crm-address-block .add-new .crm-edit-help {
   display: block;
   background-color: #ebebeb;
 }
 
-#crm-container .crm-edit-ready .crm-summary-block .crm-inline-edit:hover .crm-edit-help {
+.crm-container .crm-edit-ready .crm-summary-block .crm-inline-edit:hover .crm-edit-help {
   display: block;
   background-color: #dfe1ff;
 }
 
-#crm-container div.crm-inline-edit.form .crm-edit-help {
+.crm-container div.crm-inline-edit.form .crm-edit-help {
   display: none !important;
 }
 
-#crm-container .crm-address-block+.crm-address-block .add-new .crm-summary-row {
+.crm-container .crm-address-block+.crm-address-block .add-new .crm-summary-row {
   display: none;
 }
 
-#crm-container span.crm-custom-greeting {
+.crm-container span.crm-custom-greeting {
   font-size: 9px;
 }
 
-#crm-container table.crm-inline-edit-form td,
-#crm-container div.crm-inline-edit-form {
+.crm-container table.crm-inline-edit-form td,
+.crm-container div.crm-inline-edit-form {
   background-color: #efefe5;
   white-space: nowrap;
 }
-#crm-container table.crm-inline-edit-form td.crm-label,
-#crm-container div.crm-inline-edit-form .crm-label,
-#crm-container div.crm-inline-edit-form .messages {
+.crm-container table.crm-inline-edit-form td.crm-label,
+.crm-container div.crm-inline-edit-form .crm-label,
+.crm-container div.crm-inline-edit-form .messages {
   white-space: normal;
 }
 
-#crm-container div.crm-inline-edit-field {
+.crm-container div.crm-inline-edit-field {
   display: inline-block;
   padding: 4px 5px;
 }
 
-#crm-container div.crm-summary-contactname-block {
+.crm-container div.crm-summary-contactname-block {
   padding-bottom: 8px;
   margin-top: -10px;
 }
 
-#crm-container div.crm-summary-display_name {
+.crm-container div.crm-summary-display_name {
   font-size: 19px;
   padding-bottom: 10px;
 }
 
-#crm-container div.contactCardLeft,
-#crm-container div#Top {
+.crm-container div.contactCardLeft,
+.crm-container div#Top {
   width: 49%;
   display: block;
   float: left;
   clear: both;
 }
 
-#crm-container div.contactCardRight {
+.crm-container div.contactCardRight {
   width: 49%;
   display: block;
   float: right;
 }
 
-#crm-container div.contact_panel table {
+.crm-container div.contact_panel table {
   margin-bottom: 0;
 }
 
-#crm-container div.contactCardLeft .label,
-#crm-container div.contactCardRight .label {
+.crm-container div.contactCardLeft .label,
+.crm-container div.contactCardRight .label {
   color: #2f2f2f;
   font-weight: normal;
   font-size: 11px;
@@ -134,8 +134,8 @@ div#crm-contact-thumbnail {
   margin-right: 10px;
 }
 
-#crm-container div.contactCardLeft .grouplabel,
-#crm-container div.contactCardRight .grouplabel {
+.crm-container div.contactCardLeft .grouplabel,
+.crm-container div.contactCardRight .grouplabel {
   border-bottom: grey 1px solid;
   width: 100%;
   font-size: 0.95em;
@@ -143,34 +143,34 @@ div#crm-contact-thumbnail {
   background-color: #ddd;
 }
 
-#crm-container div.contact_panel .spacer {
+.crm-container div.contact_panel .spacer {
   padding: 8px;
 }
 
-#crm-container div.contact_panel td {
+.crm-container div.contact_panel td {
   padding: 4px;
   vertical-align: top;
   border-bottom: 1px solid #e2e2e2;
 }
 
-#crm-container div.contact_panel td.label {
+.crm-container div.contact_panel td.label {
   width: 28%;
 }
 
-#crm-container div.contact_panel td.last {
+.crm-container div.contact_panel td.last {
   border-bottom: 0;
 }
 
-#crm-container #customFields {
+.crm-container #customFields {
   width: 100%;
 }
 
-#crm-container #customFields div.contact_panel td.talabel {
+.crm-container #customFields div.contact_panel td.talabel {
   padding: 4px 0 0 4px;
   border: 0;
 }
 
-#crm-container #customFields .contact_panel .customFieldGroup {
+.crm-container #customFields .contact_panel .customFieldGroup {
   line-height: 1.4em;
   padding: 4px;
   width: 100%;
@@ -179,10 +179,10 @@ div#crm-contact-thumbnail {
   border-bottom: 2px solid #d7d7d0 !important;
 }
 
-#crm-container div.contact_panel .crm-address-block {
+.crm-container div.contact_panel .crm-address-block {
   margin-bottom: 6px;
 }
-#crm-container .crm-add-address-wrapper {
+.crm-container .crm-add-address-wrapper {
   height: 25px;
 }
 
@@ -194,14 +194,14 @@ div#crm-contact-thumbnail {
   visibility: hidden;
 }
 
-#crm-container div.crm-summary-row {
+.crm-container div.crm-summary-row {
   background-color: #f4f4ed;
   border-top: 1px solid #ffffff;
   margin-bottom: 1px;
   min-height: 17px;
 }
 
-#crm-container div.crm-summary-row div.crm-label {
+.crm-container div.crm-summary-row div.crm-label {
   background-color: #fafafa;
   color: #777760;
   text-align: left;
@@ -210,7 +210,7 @@ div#crm-contact-thumbnail {
   padding: 4px;
 }
 
-#crm-container div.crm-summary-row div.crm-content {
+.crm-container div.crm-summary-row div.crm-content {
   padding: 4px;
   margin-left: 130px;
 }
@@ -289,45 +289,45 @@ div#crm-contact-thumbnail {
 
 /* Responsive layout changes */
 
-#crm-container .contact_basic_information-section.narrowform table.form-layout-compressed,
-#crm-container .contact_basic_information-section.narrowform table.form-layout-compressed tbody,
-#crm-container .contact_basic_information-section.narrowform.xnarrowform table.form-layout-compressed tr {
+.crm-container .contact_basic_information-section.narrowform table.form-layout-compressed,
+.crm-container .contact_basic_information-section.narrowform table.form-layout-compressed tbody,
+.crm-container .contact_basic_information-section.narrowform.xnarrowform table.form-layout-compressed tr {
   display: block;
   width: 100%;
 }
 
-#crm-container .contact_basic_information-section.narrowform table.form-layout-compressed tr {
+.crm-container .contact_basic_information-section.narrowform table.form-layout-compressed tr {
   display: inline-block;
   width: 49%;
   vertical-align: top;
 }
 
-#crm-container .contact_basic_information-section.narrowform table.form-layout-compressed td {
+.crm-container .contact_basic_information-section.narrowform table.form-layout-compressed td {
   display: block;
   clear: left;
   vertical-align: top;
   margin-bottom: .5ex;
 }
 
-#crm-container .contact_basic_information-section.narrowform table.form-layout-compressed td.hashelpicon {
+.crm-container .contact_basic_information-section.narrowform table.form-layout-compressed td.hashelpicon {
   position: relative;
 }
 
-#crm-container .contact_basic_information-section.narrowform table.form-layout-compressed td.hashelpicon label {
+.crm-container .contact_basic_information-section.narrowform table.form-layout-compressed td.hashelpicon label {
   padding-bottom: 16px;
 }
 
-#crm-container .contact_basic_information-section.narrowform table.form-layout-compressed td .helpicon {
+.crm-container .contact_basic_information-section.narrowform table.form-layout-compressed td .helpicon {
   position: absolute;
   bottom: -12px;
   left: 2px;
 }
 
-#crm-container .contact_basic_information-section.narrowform table.form-layout-compressed td br {
+.crm-container .contact_basic_information-section.narrowform table.form-layout-compressed td br {
   display: none;
 }
 
-#crm-container .contact_basic_information-section.narrowform table.form-layout-compressed td label {
+.crm-container .contact_basic_information-section.narrowform table.form-layout-compressed td label {
   display: block;
   box-sizing: border-box;
   -moz-box-sizing: border-box;
@@ -336,15 +336,15 @@ div#crm-contact-thumbnail {
   padding-right: 1%;
 }
 
-#crm-container .contact_basic_information-section.narrowform table.form-layout-compressed td input {
+.crm-container .contact_basic_information-section.narrowform table.form-layout-compressed td input {
   box-sizing: border-box;
   -moz-box-sizing: border-box;
   width: 75%;
 }
 
-#crm-container #mainTabContainer.narrowpage #contact-summary div.customFieldGroup,
-#crm-container #mainTabContainer.narrowpage #contact-summary div.contactCardLeft,
-#crm-container #mainTabContainer.narrowpage #contact-summary div.contactCardRight {
+.crm-container #mainTabContainer.narrowpage #contact-summary div.customFieldGroup,
+.crm-container #mainTabContainer.narrowpage #contact-summary div.contactCardLeft,
+.crm-container #mainTabContainer.narrowpage #contact-summary div.contactCardRight {
   box-sizing: border-box;
   -moz-box-sizing: border-box;
   float: none;

--- a/css/joomla.css
+++ b/css/joomla.css
@@ -27,13 +27,13 @@ img {
   border: 0;
 }
 /* Added in CiviCRM 2.0 to alleviate tiny font issues. */
-#crm-container tr,
-#crm-container tr td {
+.crm-container tr,
+.crm-container tr td {
   font-size: 1em;
 }
 
 /* Added in CiviCRM 2.1 to overwrite tiny font in TinyMCE editor. */
-#crm-container #content table.mceLayout td {
+.crm-container #content table.mceLayout td {
   font-size: 0em;
 }
 
@@ -110,13 +110,13 @@ br.clear {
   list-style: disc;
 }
 /* Override .9em field help size from civicrm.css - CiviCRM 2.0 */
-#crm-container div.description,
-#crm-container span.description,
-#crm-container dd.description {
+.crm-container div.description,
+.crm-container span.description,
+.crm-container dd.description {
   font-size: 1em;
 }
-#crm-container div.description,
-#crm-container span.description {
+.crm-container div.description,
+.crm-container span.description {
   margin: 2px 0 15px 0;
   display: block;
 }
@@ -333,13 +333,13 @@ div#toolbar-box div.m {
   padding-bottom: 0;
   border: 1px solid #999 !important;
 }
-#crm-container {
+.crm-container {
   font-size: 11px;
 }
-#crm-container .col1 {
+.crm-container .col1 {
   margin: 0;
 }
-#crm-container .footer {
+.crm-container .footer {
   font-size: 1em;
 }
 .ac_results .ac_odd {
@@ -374,12 +374,12 @@ div#toolbar-box div.m {
   font-weight: normal;
 }
 
-#crm-container .form-layout td.label,
+.crm-container .form-layout td.label,
 .crm-container .form-layout td.label {
   width: inherit;
 }
 
-#crm-container .crm-event-form-fee-block .label {
+.crm-container .crm-event-form-fee-block .label {
   background-color: inherit;
   width: inherit;
   display: block;

--- a/css/print.css
+++ b/css/print.css
@@ -1,10 +1,10 @@
 /* CiviCRM Print Media Stylesheet */
 
 /* Hide any buttons or other form items when printing*/
-#crm-container .buttons,
-#crm-container .crm-submit-buttons,
-#crm-container .crm-actions-ribbon,
-#crm-container .crm-form-submit {
+.crm-container .buttons,
+.crm-container .crm-submit-buttons,
+.crm-container .crm-actions-ribbon,
+.crm-container .crm-form-submit {
   display: none;
 }
 
@@ -18,113 +18,113 @@ table.form-layout th {
 .form-item .element-right {
   display: none;
 }
-#crm-container {
+.crm-container {
   overflow: visible !important;
   font-family: DejaVu Sans, serif;
   margin: 0px 10px 0px 10px;
 }
 
 /* CSS for Print and PDF of Reports */
-#crm-container .report-layout {
+.crm-container .report-layout {
   border: 1px groove #dddddd;
   width: 100%;
   border-collapse: collapse;
 }
 
-#crm-container .bold {
+.crm-container .bold {
   font-weight: bold;
   font-size: 1.1em;
 }
 
-#crm-container .criterial-group {
+.crm-container .criterial-group {
   border-bottom: 2px solid #dcdcdc;
 }
 
-#crm-container .reports-header-right {
+.crm-container .reports-header-right {
   text-align: right;
 }
 
-#crm-container .reports-header {
+.crm-container .reports-header {
   text-align: left;
 }
 
-#crm-container .report-contents {
+.crm-container .report-contents {
   border: 1px groove #dddddd;
   padding: 4px;
   width: 20%;
 }
 
-#crm-container .report-contents-right {
+.crm-container .report-contents-right {
   border: 1px groove #dddddd;
   padding: 4px;
   text-align: right;
 }
 
-#crm-container table.report-layout td {
+.crm-container table.report-layout td {
   border: 1px groove #dddddd;
   padding: 4px;
 }
 
-#crm-container table.report-layout tr {
+.crm-container table.report-layout tr {
   font-size: 0.9em;
 }
 
-#crm-container table.report-layout tr.group-row {
+.crm-container table.report-layout tr.group-row {
   font-size: 1em;
 }
 
-#crm-container table.report-layout tr.total-row {
+.crm-container table.report-layout tr.total-row {
   font-size: 1em;
   border-top: 2px groove #dcdcdc;
 }
 
-#crm-container div.page-break {
+.crm-container div.page-break {
   page-break-before: always;
   height: 0;
 }
 
-#crm-container .report-label {
+.crm-container .report-label {
   text-align: right;
   font-weight: bold;
 }
 
-#crm-container table.report-layout th {
+.crm-container table.report-layout th {
   padding: 4px;
   background-color: #dcdcdc;
   /*text-align       : left;*/
   vertical-align: top;
 }
 
-#crm-container table.report-layout th.report-contents {
+.crm-container table.report-layout th.report-contents {
   background-color: #f5f5f5;
 }
 
-#crm-container table.report-layout th.statistics {
+.crm-container table.report-layout th.statistics {
   width: 5%;
   white-space: nowrap;
   text-align: left;
 }
 
-#crm-container table.report-layout th.statistics,
-#crm-container table.report-layout th.label {
+.crm-container table.report-layout th.statistics,
+.crm-container table.report-layout th.label {
   width: 20%;
   text-align: left;
 }
 
-#crm-container h1 {
+.crm-container h1 {
   text-align: center;
   font-size: 1.5em;
   font-style: italic;
   margin: 0;
 }
 
-#crm-container h2 {
+.crm-container h2 {
   text-align: left;
   font-size: 1.2em;
 }
 
 
-#crm-container div#report-date {
+.crm-container div#report-date {
   font-size: .8em;
   font-style: italic;
   float: right;

--- a/css/searchForm.css
+++ b/css/searchForm.css
@@ -20,7 +20,7 @@
 }
 
 /* alpha filter styles */
-#crm-container #alpha-filter ul {
+.crm-container #alpha-filter ul {
   border-collapse: collapse;
   padding: 0;
   list-style-type: none;

--- a/js/Common.js
+++ b/js/Common.js
@@ -1598,7 +1598,7 @@ if (!CRM.vars) CRM.vars = {};
     $.blockUI.defaults.message = null;
     $.blockUI.defaults.ignoreIfBlocked = true;
 
-    if ($('#crm-container').hasClass('crm-public')) {
+    if ($('.crm-container').hasClass('crm-public')) {
       $.fn.select2.defaults.dropdownCssClass = $.ui.dialog.prototype.options.dialogClass = 'crm-container crm-public';
     }
 
@@ -1608,7 +1608,7 @@ if (!CRM.vars) CRM.vars = {};
     if ($('#crm-notification-container').length) {
       // Initialize notifications
       $('#crm-notification-container').notify();
-      messagesFromMarkup.call($('#crm-container'));
+      messagesFromMarkup.call($('.crm-container'));
     }
 
     $('body')

--- a/js/crm.addNew.js
+++ b/js/crm.addNew.js
@@ -3,6 +3,6 @@
 CRM.$(function($) {
   var emptyMsg = $('.crm-empty-table');
   if (emptyMsg.length) {
-    $('.action-link a.button', '#crm-container').click();
+    $('.action-link a.button', '.crm-container').click();
   }
 });

--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -9,7 +9,7 @@
     settings: {collapsibleBehavior: 'accordion'},
     position: 'over-cms-menu',
     toggleButton: (CRM.config.userFramework != 'Standalone'),
-    attachTo: (CRM.menubar && CRM.menubar.position === 'above-crm-container') ? '#crm-container' : 'body',
+    attachTo: (CRM.menubar && CRM.menubar.position === 'above-crm-container') ? '.crm-container' : 'body',
     initialize: function() {
       var cache = CRM.cache.get('menubar');
       if (cache && cache.code === CRM.menubar.cacheCode && cache.locale === CRM.config.locale && cache.cid === CRM.config.cid && localStorage.civiMenubar) {
@@ -28,11 +28,11 @@
 
       // Wait for crm-container present on the page as it's faster than document.ready
       function insert(markup) {
-        if (document.getElementById('crm-container')) {
+        if (document.querySelector('.crm-container')) {
           render(markup);
         } else {
           new MutationObserver(function(mutations, observer) {
-            if (document.getElementById('crm-container')) {
+            if (document.querySelector('.crm-container')) {
               observer.disconnect();
               render(markup);
             }

--- a/js/crm.searchForm.js
+++ b/js/crm.searchForm.js
@@ -105,7 +105,7 @@
     $('.crm-form-text:input:visible:first', 'form.crm-search-form').focus();
 
     // Handle user interactions with search results
-    $('#crm-container')
+    $('.crm-container')
       // When toggling between "all records" and "selected records only"
       .on('change', '[name=radio_ts]', function() {
         clearTaskMenu();

--- a/js/jquery/jquery.crmProfileSelector.js
+++ b/js/jquery/jquery.crmProfileSelector.js
@@ -84,7 +84,7 @@
     });
   };
 
-  $('#crm-container').on('crmLoad', function() {
+  $('.crm-container').on('crmLoad', function() {
     $('.crm-profile-selector:not(.rendered)', this).each(function() {
       $(this).crmProfileSelector({
         groupTypeFilter: $(this).data('groupType'),

--- a/templates/CRM/Admin/Page/Navigation.tpl
+++ b/templates/CRM/Admin/Page/Navigation.tpl
@@ -138,10 +138,10 @@
           message: '{/literal}{ts escape='js'}This will add links for all currently active reports to the "Reports" menu under the relevant component. If you have added report instances to other menus, they will be moved to "Reports".  Are you sure?{/ts}{literal}'
         })
           .on('crmConfirm:yes', function() {
-            $('#crm-container').block();
+            $('.crm-container').block();
             CRM.api3('Navigation', 'reset', {'for': 'report'}, true)
               .then(function() {
-                $('#crm-container').unblock();
+                $('.crm-container').unblock();
                 $("#navigation-tree").jstree(true).refresh();
                 refreshMenubar();
               });

--- a/templates/CRM/Batch/Form/Entry.tpl
+++ b/templates/CRM/Batch/Form/Entry.tpl
@@ -140,7 +140,7 @@ CRM.$(function($) {
     }
   });
 
-  $('#crm-container').on('keyup change', '*.selector-rows', function () {
+  $('.crm-container').on('keyup change', '*.selector-rows', function () {
     // validate rows
     checkColumns($(this));
   });

--- a/templates/CRM/Case/Audit/Report.tpl
+++ b/templates/CRM/Case/Audit/Report.tpl
@@ -16,7 +16,7 @@
 </head>
 
 <body>
-<div id="crm-container" class="crm-container">
+<div class="crm-container">
 <h1>{$pageTitle}</h1>
 <div id="report-date">{$reportDate}</div>
 {if $case}

--- a/templates/CRM/Case/Form/CaseView.js
+++ b/templates/CRM/Case/Form/CaseView.js
@@ -175,11 +175,11 @@
     });
   }
 
-  $('#crm-container').on('crmLoad', '#crm-main-content-wrapper', detachMiniForms);
+  $('.crm-container').on('crmLoad', '#crm-main-content-wrapper', detachMiniForms);
 
   $(document).ready(function() {
     detachMiniForms();
-    $('#crm-container')
+    $('.crm-container')
       .on('change', 'select[name=add_activity_type_id]', function() {
         open($(this).val());
         $(this).select2('val', '');

--- a/templates/CRM/Contact/Form/Contact.tpl
+++ b/templates/CRM/Contact/Form/Contact.tpl
@@ -113,7 +113,7 @@
       $('.crm-accordion-wrapper').not('.crm-accordion-wrapper .crm-accordion-wrapper').each(function() {
         highlightTabs(this);
       });
-      $('#crm-container').on('change click', '.crm-accordion-body :input, .crm-accordion-body a', function() {
+      $('.crm-container').on('change click', '.crm-accordion-body :input, .crm-accordion-body a', function() {
         highlightTabs($(this).parents('.crm-accordion-wrapper'));
       });
     }

--- a/templates/CRM/Contact/Form/Task/EmailCommon.js
+++ b/templates/CRM/Contact/Form/Task/EmailCommon.js
@@ -1,14 +1,14 @@
 CRM.$(function($) {
   //do not copy & paste this - find a way to generalise it
   'use strict';
-  // NOTE: Target only fullscreen forms (using #crm-container as context) because popups already have this feature
-   $('.crm-form-submit', '#crm-container').not('.cancel').on("click", function() {
-     $('.crm-form-submit', '#crm-container').not('.cancel').attr({value: ts('Processing')});
+  // NOTE: Target only fullscreen forms (using .crm-container as context) because popups already have this feature
+   $('.crm-form-submit', '.crm-container').not('.cancel').on("click", function() {
+     $('.crm-form-submit', '.crm-container').not('.cancel').attr({value: ts('Processing')});
      // CRM-13449 : setting a 0 ms timeout is needed
      // for some browsers like chrome. Used for purpose of
      // submit the form and stop accidental multiple clicks
      setTimeout(function(){
-       $('.crm-form-submit', '#crm-container').not('.cancel').prop({disabled: true});
+       $('.crm-form-submit', '.crm-container').not('.cancel').prop({disabled: true});
      }, 0);
    });
 });

--- a/templates/CRM/Contact/Page/View/Print.tpl
+++ b/templates/CRM/Contact/Page/View/Print.tpl
@@ -11,7 +11,7 @@
 {literal}
 <style type="text/css" media="screen, print">
 <!--
-  #crm-container div {
+  .crm-container div {
     font-size: 12px;
   }
 -->

--- a/templates/CRM/Contact/Page/View/Summary.js
+++ b/templates/CRM/Contact/Page/View/Summary.js
@@ -301,7 +301,7 @@
         $('.crm-inline-edit.form :submit[name$=cancel]').click();
       }
     });
-    $('#crm-container')
+    $('.crm-container')
       // Switch tabs when clicking log link
       .on('click', '#crm-record-log a.crm-log-view', function() {
         $('#tab_log a').click();
@@ -360,10 +360,10 @@
      * Make contact summary fit in small screens
      */
     function onResize() {
-      var contactwidth = $('#crm-container #mainTabContainer').width();
+      var contactwidth = $('.crm-container #mainTabContainer').width();
       if (contactwidth < 600) {
-        $('#crm-container #mainTabContainer').addClass('narrowpage');
-        $('#crm-container #mainTabContainer.narrowpage #contactTopBar td').each(function (index) {
+        $('.crm-container #mainTabContainer').addClass('narrowpage');
+        $('.crm-container #mainTabContainer.narrowpage #contactTopBar td').each(function (index) {
           if (index > 1) {
             if (index % 2 === 0) {
               $(this).parent().after('<tr class="narrowadded"></tr>');
@@ -374,8 +374,8 @@
         });
       }
       else {
-        $('#crm-container #mainTabContainer.narrowpage').removeClass('narrowpage');
-        $('#crm-container #mainTabContainer #contactTopBar tr.narrowadded td').each(function () {
+        $('.crm-container #mainTabContainer.narrowpage').removeClass('narrowpage');
+        $('.crm-container #mainTabContainer #contactTopBar tr.narrowadded td').each(function () {
           var nitem = $(this);
           var parent = $(this).parent();
           $(this).parent().prev().append(nitem);
@@ -383,23 +383,23 @@
             parent.remove();
           }
         });
-        $('#crm-container #mainTabContainer.narrowpage #contactTopBar tr.added').detach();
+        $('.crm-container #mainTabContainer.narrowpage #contactTopBar tr.added').detach();
       }
-      var cformwidth = $('#crm-container #Contact .contact_basic_information-section').width();
+      var cformwidth = $('.crm-container #Contact .contact_basic_information-section').width();
 
       if (cformwidth < 720) {
-        $('#crm-container .contact_basic_information-section').addClass('narrowform');
-        $('#crm-container .contact_basic_information-section table.form-layout-compressed td .helpicon').parent().addClass('hashelpicon');
+        $('.crm-container .contact_basic_information-section').addClass('narrowform');
+        $('.crm-container .contact_basic_information-section table.form-layout-compressed td .helpicon').parent().addClass('hashelpicon');
         if (cformwidth < 480) {
-          $('#crm-container .contact_basic_information-section').addClass('xnarrowform');
+          $('.crm-container .contact_basic_information-section').addClass('xnarrowform');
         }
         else {
-          $('#crm-container .contact_basic_information-section.xnarrowform').removeClass('xnarrowform');
+          $('.crm-container .contact_basic_information-section.xnarrowform').removeClass('xnarrowform');
         }
       }
       else {
-        $('#crm-container .contact_basic_information-section.narrowform').removeClass('narrowform');
-        $('#crm-container .contact_basic_information-section.xnarrowform').removeClass('xnarrowform');
+        $('.crm-container .contact_basic_information-section.narrowform').removeClass('narrowform');
+        $('.crm-container .contact_basic_information-section.xnarrowform').removeClass('xnarrowform');
       }
     }
 

--- a/templates/CRM/Custom/Page/CustomDataView.tpl
+++ b/templates/CRM/Custom/Page/CustomDataView.tpl
@@ -143,7 +143,7 @@
     {literal}
     CRM.$(function($) {
       // Handle delete of multi-record custom data
-      $('#crm-container')
+      $('.crm-container')
         .off('.customValueDel')
         .on('click.customValueDel', '.crm-custom-value-del', function(e) {
           e.preventDefault();

--- a/templates/CRM/Event/Form/ManageEvent/Registration.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.tpl
@@ -381,7 +381,7 @@ invert              = 0
       strSameAs = '{/literal}{ts escape='js'}- same as for main contact -{/ts}{literal}',
       strSelect = '{/literal}{ts escape='js'}- select -{/ts}{literal}';
 
-    $('#crm-container').on('crmLoad', function() {
+    $('.crm-container').on('crmLoad', function() {
         var $container = $("[id^='additional_profile_'],.additional_profile").not('.processed').addClass('processed');
         $container.find(".crm-profile-selector-select select").each( function() {
             var $select = $(this);
@@ -432,7 +432,7 @@ $(function($) {
     $('#registration_blocks').on('click', '.crm-button-add-profile', addBottomProfile);
     $('#registration_blocks').on('click', '.crm-button-rem-profile', removeBottomProfile);
 
-    $('#crm-container').on('crmLoad', function(e) {
+    $('.crm-container').on('crmLoad', function(e) {
         $('tr[id^="additional_profile"] input[id^="additional_custom_"]').change(function(e) {
             var $input = $(e.target);
             if ( $input.val() == '') {

--- a/templates/CRM/Financial/Form/Search.tpl
+++ b/templates/CRM/Financial/Form/Search.tpl
@@ -298,7 +298,7 @@ CRM.$(function($) {
     return false;
   });
 
-  $('#crm-container').on('click', 'a.action-item[href="#"]', function(event) {
+  $('.crm-container').on('click', 'a.action-item[href="#"]', function(event) {
     event.stopImmediatePropagation();
     editRecords([$(this).closest('tr').attr('data-id')], $(this).attr('rel'));
     return false;

--- a/templates/CRM/Group/Form/Search.tpl
+++ b/templates/CRM/Group/Form/Search.tpl
@@ -165,7 +165,7 @@
         $('table.crm-group-selector').DataTable().draw();
       });
     });
-    $('#crm-container')
+    $('.crm-container')
       .on('click', 'a.button, a.action-item[href*="action=update"], a.action-item[href*="action=delete"]', CRM.popup)
       .on('crmPopupFormSuccess', 'a.button, a.action-item[href*="action=update"], a.action-item[href*="action=delete"]', function() {
           // Refresh datatable when form completes

--- a/templates/CRM/Mailing/Page/Event.tpl
+++ b/templates/CRM/Mailing/Page/Event.tpl
@@ -56,7 +56,7 @@
   <script type="text/javascript">
     var totalPages = {/literal}{$pager->_totalPages}{literal};
     CRM.$(function($) {
-      $("#crm-container .crm-pager button.crm-form-submit").click(function () {
+      $(".crm-container .crm-pager button.crm-form-submit").click(function () {
         submitPagerData(this);
       });
     });

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -32,7 +32,7 @@
   {if $action eq 1 or $action eq 2 or $action eq 4}
   <div id="crm-profile-block" class="crm-container crm-public">
     {else}
-  <div id="crm-container" class="crm-container crm-public" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
+  <div class="crm-container crm-public" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
   {/if}
 
   {if $showSaveDuplicateButton}

--- a/templates/CRM/Profile/Page/Dynamic.tpl
+++ b/templates/CRM/Profile/Page/Dynamic.tpl
@@ -12,7 +12,7 @@
     {if $overlayProfile}
         {include file="CRM/Profile/Page/Overlay.tpl"}
     {else}
-        <div id="crm-container" class="crm-container" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
+        <div class="crm-container" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
             <div class="crm-profile-name-{$ufGroupName}">
             {crmRegion name="profile-view-`$ufGroupName`"}
             {foreach from=$profileFields item=field key=rowName}

--- a/templates/CRM/common/CMSPrint.tpl
+++ b/templates/CRM/common/CMSPrint.tpl
@@ -11,7 +11,7 @@
 {include file="CRM/common/debug.tpl"}
 {/if}
 
-<div id="crm-container" class="crm-container{if $urlIsPublic} crm-public{/if}" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
+<div class="crm-container{if $urlIsPublic} crm-public{/if}" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
 
 {if $breadcrumb}
   <div class="breadcrumb">

--- a/templates/CRM/common/fatal.tpl
+++ b/templates/CRM/common/fatal.tpl
@@ -23,9 +23,9 @@
   </style>
 </head>
 <body>
-<div id="crm-container" class="crm-container" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
+<div class="crm-container" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
 {else}
-<div id="crm-container" class="crm-container" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
+<div class="crm-container" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
   <style type="text/css" media="screen">
     @import url({$config->resourceBase}css/civicrm.css);
     @import url({$config->resourceBase}css/crm-i.css);

--- a/templates/CRM/common/joomla.tpl
+++ b/templates/CRM/common/joomla.tpl
@@ -11,7 +11,7 @@
 {include file="CRM/common/debug.tpl"}
 {/if}
 
-<div id="crm-container" class="crm-container{if !empty($urlIsPublic)} crm-public{/if}" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
+<div class="crm-container{if !empty($urlIsPublic)} crm-public{/if}" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
 
 <table border="0" cellpadding="0" cellspacing="0" id="crm-content">
   <tr>

--- a/templates/CRM/common/print.tpl
+++ b/templates/CRM/common/print.tpl
@@ -23,7 +23,7 @@
 {if $config->debug}
   {include file="CRM/common/debug.tpl"}
 {/if}
-<div id="crm-container" class="crm-container" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
+<div class="crm-container" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
 {crmRegion name='page-header' allowCmsOverride=0}{/crmRegion}
 {* Check for Status message for the page (stored in session->getStatus). Status is cleared on retrieval. *}
 {include file="CRM/common/status.tpl"}

--- a/templates/CRM/common/standalone.tpl
+++ b/templates/CRM/common/standalone.tpl
@@ -28,7 +28,7 @@
   {include file="CRM/common/debug.tpl"}
   {/if}
 
-  <div id="crm-container" class="crm-container" lang="{$config->lcMessages|substr:0:2}" xml:lang="{$config->lcMessages|substr:0:2}">
+  <div class="crm-container" lang="{$config->lcMessages|substr:0:2}" xml:lang="{$config->lcMessages|substr:0:2}">
     {if $breadcrumb}
       <nav aria-label="{ts}Breadcrumb{/ts}" class="breadcrumb"><ol>
         <li><a href="/civicrm/dashboard?reset=1" >{ts}Home{/ts}</a></li>

--- a/tests/phpunit/CRM/Activity/Form/Task/PDFTest.php
+++ b/tests/phpunit/CRM/Activity/Form/Task/PDFTest.php
@@ -135,7 +135,7 @@ class CRM_Activity_Form_Task_PDFTest extends CiviUnitTestCase {
     }
     catch (CRM_Core_Exception_PrematureExitException $e) {
       $html = $e->errorData['html'];
-      $this->assertStringContainsString('<div id="crm-container">
+      $this->assertStringContainsString('<div class="crm-container">
 Unknown token:
     </div>', $html);
       return;

--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
@@ -294,7 +294,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
     <style type="text/css">@import url(' . CRM_Core_Config::singleton()->userFrameworkResourceURL . 'css/print.css);</style>
 ' . "    \n" . '  </head>
   <body>
-    <div id="crm-container">
+    <div class="crm-container">
 id : 1
 total_amount : €9,999.99
 fee_amount : €1,111.11


### PR DESCRIPTION
Overview
----------------------------------------

Theming is hard and messy because we have a mix of `.crm-container` and `#crm-container`. This PR suggests simply ditching the `id` one.


Before
----------------------------------------

The id is in some places; I can't promise it's unique within all HTML documents as it's supposed to be. 

But wherever there was this id, there was *also* the class already. The only place where there was id but no class was in a test template (and corresponding test).


After
----------------------------------------

The id is gone, leaving just the class. HTML, CSS, JS, tests updated.


Comments
----------------------------------------

I've had a quick scoot around on Greenwich (and Aah) and things generally look fine.

I expect some 3rd party themes may need some adjustments, but I believe they'll thank us in the end.

I'm opening this draft PR so that anyone interested can easiliy grab the [diff](url) (it wasn't quite as easy as a global find and replace)  for their consideration.

But welcoming discussion and I'm open to closing it if we decide there really does need to be an id attribute.