### PR TITLE
[NFC] Cleanup array syntax in tests directory

### DIFF
--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -278,39 +278,31 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
       'is_primary' => 1,
     ];
     $compareParams = [
-      'street_address' => $params['address'][1]['street_address'] ?? NULL,
-      'supplemental_address_1' => CRM_Utils_Array::value('supplemental_address_1',
-        $params['address'][1]
-      ),
-      'supplemental_address_2' => CRM_Utils_Array::value('supplemental_address_2',
-        $params['address'][1]
-      ),
-      'supplemental_address_3' => CRM_Utils_Array::value('supplemental_address_3',
-        $params['address'][1]
-      ),
-      'city' => $params['address'][1]['city'] ?? NULL,
-      'postal_code' => $params['address'][1]['postal_code'] ?? NULL,
-      'country_id' => $params['address'][1]['country_id'] ?? NULL,
-      'state_province_id' => CRM_Utils_Array::value('state_province_id',
-        $params['address'][1]
-      ),
-      'geo_code_1' => $params['address'][1]['geo_code_1'] ?? NULL,
-      'geo_code_2' => $params['address'][1]['geo_code_2'] ?? NULL,
+      'street_address' => $params['address'][1]['street_address'],
+      'supplemental_address_1' => $params['address'][1]['supplemental_address_1'],
+      'supplemental_address_2' => $params['address'][1]['supplemental_address_2'],
+      'supplemental_address_3' => $params['address'][1]['supplemental_address_3'],
+      'city' => $params['address'][1]['city'],
+      'postal_code' => $params['address'][1]['postal_code'],
+      'country_id' => $params['address'][1]['country_id'],
+      'state_province_id' => $params['address'][1]['state_province_id'],
+      'geo_code_1' => $params['address'][1]['geo_code_1'],
+      'geo_code_2' => $params['address'][1]['geo_code_2'],
     ];
     $this->assertDBCompareValues('CRM_Core_DAO_Address', $searchParams, $compareParams);
 
     //Now check DB for Email
-    $compareParams = ['email' => CRM_Utils_Array::value('email', $params['email'][1])];
+    $compareParams = ['email' => $params['email'][1]['email']];
     $this->assertDBCompareValues('CRM_Core_DAO_Email', $searchParams, $compareParams);
 
     //Now check DB for openid
-    $compareParams = ['openid' => CRM_Utils_Array::value('openid', $params['openid'][1])];
+    $compareParams = ['openid' => $params['openid'][1]['openid']];
     $this->assertDBCompareValues('CRM_Core_DAO_OpenID', $searchParams, $compareParams);
 
     //Now check DB for IM
     $compareParams = [
-      'name' => $params['im'][1]['name'] ?? NULL,
-      'provider_id' => $params['im'][1]['provider_id'] ?? NULL,
+      'name' => $params['im'][1]['name'],
+      'provider_id' => $params['im'][1]['provider_id'],
     ];
     $this->assertDBCompareValues('CRM_Core_DAO_IM', $searchParams, $compareParams);
 
@@ -319,18 +311,18 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
       'location_type_id' => 1,
       'is_primary' => 1,
-      'phone_type_id' => $params['phone'][1]['phone_type_id'] ?? NULL,
+      'phone_type_id' => $params['phone'][1]['phone_type_id'],
     ];
-    $compareParams = ['phone' => CRM_Utils_Array::value('phone', $params['phone'][1])];
+    $compareParams = ['phone' => $params['phone'][1]['phone']];
     $this->assertDBCompareValues('CRM_Core_DAO_Phone', $searchParams, $compareParams);
 
     //Now check DB for Mobile
     $searchParams = [
       'contact_id' => $contactId,
       'location_type_id' => 1,
-      'phone_type_id' => $params['phone'][2]['phone_type_id'] ?? NULL,
+      'phone_type_id' => $params['phone'][2]['phone_type_id'],
     ];
-    $compareParams = ['phone' => CRM_Utils_Array::value('phone', $params['phone'][2])];
+    $compareParams = ['phone' => $params['phone'][2]['phone']];
     $this->assertDBCompareValues('CRM_Core_DAO_Phone', $searchParams, $compareParams);
 
     //Now check DB for Note
@@ -508,40 +500,40 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $this->assertEquals($params['contact_type'], $values['contact_type'], 'Check for contact type creation.');
 
     //Now check values of address
-    $this->assertAttributesEquals(CRM_Utils_Array::value('1', $params['address']),
-      CRM_Utils_Array::value('1', $values['address'])
+    $this->assertAttributesEquals($params['address']['1'],
+      $values['address']['1']
     );
 
     //Now check values of email
-    $this->assertAttributesEquals(CRM_Utils_Array::value('1', $params['email']),
-      CRM_Utils_Array::value('1', $values['email'])
+    $this->assertAttributesEquals($params['email']['1'],
+      $values['email']['1']
     );
 
     //Now check values of phone
-    $this->assertAttributesEquals(CRM_Utils_Array::value('1', $params['phone']),
-      CRM_Utils_Array::value('1', $values['phone'])
+    $this->assertAttributesEquals($params['phone']['1'],
+      $values['phone']['1']
     );
 
     //Now check values of mobile
-    $this->assertAttributesEquals(CRM_Utils_Array::value('2', $params['phone']),
-      CRM_Utils_Array::value('2', $values['phone'])
+    $this->assertAttributesEquals($params['phone']['2'],
+      $values['phone']['2']
     );
 
     //Now check values of openid
-    $this->assertAttributesEquals(CRM_Utils_Array::value('1', $params['openid']),
-      CRM_Utils_Array::value('1', $values['openid'])
+    $this->assertAttributesEquals($params['openid']['1'],
+      $values['openid']['1']
     );
 
     //Now check values of im
-    $this->assertAttributesEquals(CRM_Utils_Array::value('1', $params['im']),
-      CRM_Utils_Array::value('1', $values['im'])
+    $this->assertAttributesEquals($params['im']['1'],
+      $values['im']['1']
     );
 
     //Now check values of Note Count.
     $this->assertEquals(1, $values['noteTotalCount'], 'Check for total note count');
 
     foreach ($values['note'] as $key => $val) {
-      $retrieveNote = $val['note'] ?? NULL;
+      $retrieveNote = $val['note'];
       //check the note value
       $this->assertEquals($params['note'], $retrieveNote, 'Check for note');
     }
@@ -554,7 +546,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
       //Now check values of Relationship type.
       $this->assertEquals('Employee of', $val['relation'], 'Check for relationship type');
       //delete the organization.
-      $this->contactDelete(CRM_Utils_Array::value('contact_id_b', $val));
+      $this->contactDelete($val['contact_id_b']);
     }
   }
 
@@ -760,16 +752,16 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
       'is_primary' => 1,
     ];
     $compareParams = [
-      'street_address' => $profileParams['street_address-Primary'] ?? NULL,
-      'supplemental_address_1' => $profileParams['supplemental_address_1-Primary'] ?? NULL,
-      'supplemental_address_2' => $profileParams['supplemental_address_2-Primary'] ?? NULL,
-      'supplemental_address_3' => $profileParams['supplemental_address_3-Primary'] ?? NULL,
-      'city' => $profileParams['city-Primary'] ?? NULL,
-      'postal_code' => $profileParams['postal_code-Primary'] ?? NULL,
-      'country_id' => $profileParams['country-Primary'] ?? NULL,
-      'state_province_id' => $profileParams['state_province-Primary'] ?? NULL,
-      'geo_code_1' => $profileParams['geo_code_1-Primary'] ?? NULL,
-      'geo_code_2' => $profileParams['geo_code_2-Primary'] ?? NULL,
+      'street_address' => $profileParams['street_address-Primary'],
+      'supplemental_address_1' => $profileParams['supplemental_address_1-Primary'],
+      'supplemental_address_2' => $profileParams['supplemental_address_2-Primary'],
+      'supplemental_address_3' => $profileParams['supplemental_address_3-Primary'],
+      'city' => $profileParams['city-Primary'],
+      'postal_code' => $profileParams['postal_code-Primary'],
+      'country_id' => $profileParams['country-Primary'],
+      'state_province_id' => $profileParams['state_province-Primary'],
+      'geo_code_1' => $profileParams['geo_code_1-Primary'],
+      'geo_code_2' => $profileParams['geo_code_2-Primary'],
     ];
     $this->assertDBCompareValues('CRM_Core_DAO_Address', $searchParams, $compareParams);
 
@@ -779,8 +771,8 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
 
     //Now check DB for IM
     $compareParams = [
-      'name' => $profileParams['im-Primary'] ?? NULL,
-      'provider_id' => $profileParams['im-Primary-provider_id'] ?? NULL,
+      'name' => $profileParams['im-Primary'],
+      'provider_id' => $profileParams['im-Primary-provider_id'],
     ];
     $this->assertDBCompareValues('CRM_Core_DAO_IM', $searchParams, $compareParams);
 
@@ -797,7 +789,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $searchParams = [
       'contact_id' => $contactId,
       'location_type_id' => 1,
-      'phone_type_id' => $params['phone'][2]['phone_type_id'] ?? NULL,
+      'phone_type_id' => $params['phone'][2]['phone_type_id'],
     ];
     $compareParams = ['phone' => $profileParams['phone-Primary-2']];
 
@@ -965,16 +957,16 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
       'is_primary' => 1,
     ];
     $compareParams = [
-      'street_address' => $updatePfParams['street_address-Primary'] ?? NULL,
-      'supplemental_address_1' => $updatePfParams['supplemental_address_1-Primary'] ?? NULL,
-      'supplemental_address_2' => $updatePfParams['supplemental_address_2-Primary'] ?? NULL,
-      'supplemental_address_3' => $updatePfParams['supplemental_address_3-Primary'] ?? NULL,
-      'city' => $updatePfParams['city-Primary'] ?? NULL,
-      'postal_code' => $updatePfParams['postal_code-Primary'] ?? NULL,
-      'country_id' => $updatePfParams['country-Primary'] ?? NULL,
-      'state_province_id' => $updatePfParams['state_province-Primary'] ?? NULL,
-      'geo_code_1' => $updatePfParams['geo_code_1-Primary'] ?? NULL,
-      'geo_code_2' => $updatePfParams['geo_code_2-Primary'] ?? NULL,
+      'street_address' => $updatePfParams['street_address-Primary'],
+      'supplemental_address_1' => $updatePfParams['supplemental_address_1-Primary'],
+      'supplemental_address_2' => $updatePfParams['supplemental_address_2-Primary'],
+      'supplemental_address_3' => $updatePfParams['supplemental_address_3-Primary'],
+      'city' => $updatePfParams['city-Primary'],
+      'postal_code' => $updatePfParams['postal_code-Primary'],
+      'country_id' => $updatePfParams['country-Primary'],
+      'state_province_id' => $updatePfParams['state_province-Primary'],
+      'geo_code_1' => $updatePfParams['geo_code_1-Primary'],
+      'geo_code_2' => $updatePfParams['geo_code_2-Primary'],
     ];
     $this->assertDBCompareValues('CRM_Core_DAO_Address', $searchParams, $compareParams);
 
@@ -984,8 +976,8 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
 
     //Now check DB for IM
     $compareParams = [
-      'name' => $updatePfParams['im-Primary'] ?? NULL,
-      'provider_id' => $updatePfParams['im-Primary-provider_id'] ?? NULL,
+      'name' => $updatePfParams['im-Primary'],
+      'provider_id' => $updatePfParams['im-Primary-provider_id'],
     ];
     $this->assertDBCompareValues('CRM_Core_DAO_IM', $searchParams, $compareParams);
 
@@ -1002,7 +994,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $searchParams = [
       'contact_id' => $contactId,
       'location_type_id' => 1,
-      'phone_type_id' => $params['phone'][2]['phone_type_id'] ?? NULL,
+      'phone_type_id' => $params['phone'][2]['phone_type_id'],
     ];
     $compareParams = ['phone' => $updatePfParams['phone-Primary-2']];
     $this->assertDBCompareValues('CRM_Core_DAO_Phone', $searchParams, $compareParams);
@@ -1045,7 +1037,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $contactDetails = CRM_Contact_BAO_Contact::getContactDetails($contactId);
     $compareParams = [
       $params['first_name'] . ' ' . $params['last_name'],
-      CRM_Utils_Array::value('email', $params['email'][1]),
+      $params['email'][1]['email'],
       (bool ) $params['privacy']['do_not_email'],
     ];
     //Now check the contact details
@@ -1097,7 +1089,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     //get the primary email.
     $email = CRM_Contact_BAO_Contact::getPrimaryEmail($contactId);
     //Now check the primary email
-    $this->assertEquals($email, CRM_Utils_Array::value('email', $params['email'][2]), 'Check Primary Email');
+    $this->assertEquals($email, $params['email'][2]['email'], 'Check Primary Email');
 
     //cleanup DB by deleting the contact
     $this->contactDelete($contactId);
@@ -1115,7 +1107,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $contactId = $contact->id;
 
     //get the matching contact.
-    $match = CRM_Contact_BAO_Contact::matchContactOnEmail(CRM_Utils_Array::value('email', $params['email'][1]),
+    $match = CRM_Contact_BAO_Contact::matchContactOnEmail($params['email'][1]['email'],
       'Individual'
     );
     $this->assertEquals($contactId, $match->contact_id, 'Check For Matching Contact');
@@ -1504,7 +1496,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
       'is_primary' => 1,
     ];
     $compareParams = [
-      'street_address' => $updatePfParams['street_address-Primary'] ?? NULL,
+      'street_address' => $updatePfParams['street_address-Primary'],
     ];
     $this->assertDBCompareValues('CRM_Core_DAO_Address', $searchParams, $compareParams);
 

--- a/tests/phpunit/CRM/Contact/Form/Search/SearchContactTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Search/SearchContactTest.php
@@ -78,7 +78,7 @@ class CRM_Contact_Form_Search_SearchContactTest extends CiviUnitTestCase {
     $expectedResult = [$contacts['id']];
     $this->checkArrayEquals($expectedResult, $contactsResult);
     // get and assert qill string
-    $qill = trim(implode($query->getOperator(), CRM_Utils_Array::value(0, $query->qill())));
+    $qill = trim(implode($query->getOperator(), $query->qill()[0]));
     $this->assertEquals("Contact Type In IndividualANDContact Subtype Like {$contactSubType}", $qill);
   }
 

--- a/tests/phpunit/CRM/Contribute/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/SearchTest.php
@@ -147,7 +147,7 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
       // assert the contribution IDs
       $this->checkArrayEquals($case['expected_contribution'], $contributions);
       // get and assert qill string
-      $qill = trim(implode($query->getOperator(), CRM_Utils_Array::value(0, $query->qill())));
+      $qill = trim(implode($query->getOperator(), $query->qill()[0]));
       $this->assertEquals($case['expected_qill'], $qill);
     }
   }
@@ -249,7 +249,7 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
       // assert the contribution IDs
       $this->checkArrayEquals($case['expected_contribution'], $contributions);
       // get and assert qill string
-      $qill = trim(implode($query->getOperator(), CRM_Utils_Array::value(0, $query->qill())));
+      $qill = trim(implode($query->getOperator(), $query->qill()[0]));
       $this->assertEquals($case['expected_qill'], $qill);
     }
   }
@@ -346,7 +346,7 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
       // assert the contribution IDs
       $this->checkArrayEquals($case['expected_contribution'], $contributions);
       // get and assert qill string
-      $qill = trim(implode($query->getOperator(), CRM_Utils_Array::value(0, $query->qill())));
+      $qill = trim(implode($query->getOperator(), $query->qill()[0]));
       $this->assertEquals($case['expected_qill'], $qill);
     }
   }
@@ -401,7 +401,7 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
     $this->assertEquals($expectedCount, count($contacts));
     // get and assert qill string
     $qill = $query->qill();
-    $qillString = !empty($qill[1]) ? $qill[1] : CRM_Utils_Array::value(0, $qill);
+    $qillString = !empty($qill[1]) ? $qill[1] : $qill[0];
     $qill = trim(implode($query->getOperator(), $qillString));
     $this->assertEquals($expectedQill, $qill);
 
@@ -490,7 +490,7 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
       // assert the contribution IDs
       $this->checkArrayEquals($case['expected_contribution'], $contributions);
       // get and assert qill string
-      $qill = trim(implode($query->getOperator(), CRM_Utils_Array::value(0, $query->qill())));
+      $qill = trim(implode($query->getOperator(), $query->qill()[0]));
       $this->assertEquals($case['expected_qill'], $qill);
     }
   }

--- a/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
+++ b/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
@@ -170,7 +170,7 @@ class CRM_Core_BAO_FinancialTrxnTest extends CiviUnitTestCase {
       ]
     );
     $this->assertArrayNotHasKey('card_type_id', $financialTrxn);
-    $this->assertEquals(NULL, CRM_Utils_Array::value('pan_truncation', $financialTrxn));
+    $this->assertFalse(isset($financialTrxn['pan_truncation']));
     $params = [
       'card_type_id' => 2,
       'pan_truncation' => 4567,
@@ -210,8 +210,8 @@ class CRM_Core_BAO_FinancialTrxnTest extends CiviUnitTestCase {
         'return' => ['card_type_id', 'pan_truncation'],
       ]
     );
-    $this->assertEquals(CRM_Utils_Array::value('card_type_id', $financialTrxn), NULL);
-    $this->assertEquals(CRM_Utils_Array::value('pan_truncation', $financialTrxn), NULL);
+    $this->assertFalse(isset($financialTrxn['card_type_id']));
+    $this->assertFalse(isset($financialTrxn['pan_truncation']));
     CRM_Core_BAO_FinancialTrxn::updateCreditCardDetails($contribution['id'], 4567, 2);
     $financialTrxn = $this->callAPISuccessGetSingle(
       'FinancialTrxn',

--- a/tests/phpunit/CRM/Core/CommunityMessagesTest.php
+++ b/tests/phpunit/CRM/Core/CommunityMessagesTest.php
@@ -321,7 +321,7 @@ class CRM_Core_CommunityMessagesTest extends CiviUnitTestCase {
     $freq = [];
     for ($i = 0; $i < $trials; $i++) {
       $message = $communityMessages->pick();
-      $freq[$message['markup']] = CRM_Utils_Array::value($message['markup'], $freq, 0) + 1;
+      $freq[$message['markup']] = ($freq[$message['markup']] ?? 0) + 1;
     }
 
     // assert the probabilities
@@ -349,7 +349,7 @@ class CRM_Core_CommunityMessagesTest extends CiviUnitTestCase {
     $freq = [];
     for ($i = 0; $i < $trials; $i++) {
       $message = $communityMessages->pick();
-      $freq[$message['markup']] = CRM_Utils_Array::value($message['markup'], $freq, 0) + 1;
+      $freq[$message['markup']] = ($freq[$message['markup']] ?? 0) + 1;
     }
 
     $this->assertEquals($trials, $freq['<h1>Two</h1>']);

--- a/tests/phpunit/CRM/Core/FieldOptionsTest.php
+++ b/tests/phpunit/CRM/Core/FieldOptionsTest.php
@@ -79,7 +79,7 @@ class CRM_Core_FieldOptionsTest extends CiviUnitTestCase {
       foreach ($baoFields as $field) {
         $message = "BAO name: '{$baoName}', field: '{$field['fieldName']}'";
 
-        $props = CRM_Utils_Array::value('props', $field, []);
+        $props = ($field['props'] ?? []);
         $optionValues = $baoName::buildOptions($field['fieldName'], 'create', $props);
         $this->assertNotEmpty($optionValues, $message);
 
@@ -92,7 +92,7 @@ class CRM_Core_FieldOptionsTest extends CiviUnitTestCase {
         }
 
         // Ensure count of optionValues is not extraordinarily high.
-        $max = CRM_Utils_Array::value('max', $field, 10);
+        $max = ($field['max'] ?? 10);
         $this->assertLessThanOrEqual($max, count($optionValues), $message);
       }
     }

--- a/tests/phpunit/CRM/Core/PseudoConstantTest.php
+++ b/tests/phpunit/CRM/Core/PseudoConstantTest.php
@@ -959,7 +959,7 @@ class CRM_Core_PseudoConstantTest extends CiviUnitTestCase {
         else {
           foreach ($field['sample'] as $key => $value) {
             $this->assertArrayHasKey($key, $optionValues, $message);
-            $this->assertEquals(CRM_Utils_Array::value($key, $optionValues), $value, $message);
+            $this->assertEquals($optionValues[$key], $value, $message);
           }
         }
 
@@ -969,7 +969,7 @@ class CRM_Core_PseudoConstantTest extends CiviUnitTestCase {
         }
 
         // Ensure count of optionValues is not extraordinarily high.
-        $max = CRM_Utils_Array::value('max', $field, 20);
+        $max = $field['max'] ?? 20;
         $this->assertLessThanOrEqual($max, count($optionValues), $message);
       }
     }

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -2909,22 +2909,22 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     }
     $this->startCapturingOutput();
     try {
-      $exportMode = CRM_Utils_Array::value('exportMode', $params, CRM_Export_Form_Select::CONTACT_EXPORT);
-      $ids = CRM_Utils_Array::value('ids', $params, ($exportMode === CRM_Export_Form_Select::CONTACT_EXPORT ? $this->contactIDs : []));
+      $exportMode = ($params['exportMode'] ?? CRM_Export_Form_Select::CONTACT_EXPORT);
+      $ids = $params['ids'] ?? ($exportMode === CRM_Export_Form_Select::CONTACT_EXPORT ? $this->contactIDs : []);
       $defaultClause = (empty($ids) ? NULL : 'contact_a.id IN (' . implode(',', $ids) . ')');
       CRM_Export_BAO_Export::exportComponents(
-        CRM_Utils_Array::value('selectAll', $params, (empty($params['fields']))),
+        $params['selectAll'] ?? !$fields,
         $ids,
-        CRM_Utils_Array::value('params', $params, []),
-        CRM_Utils_Array::value('order', $params),
+        $params['params'] ?? [],
+        $params['order'] ?? NULL,
         $fields,
-        CRM_Utils_Array::value('moreReturnProperties', $params),
+        $params['moreReturnProperties'] ?? NULL,
         $exportMode,
-        CRM_Utils_Array::value('componentClause', $params, $defaultClause),
-        CRM_Utils_Array::value('componentTable', $params),
-        CRM_Utils_Array::value('mergeSameAddress', $params, FALSE),
-        CRM_Utils_Array::value('mergeSameHousehold', $params, FALSE),
-        CRM_Utils_Array::value('exportParams', $params, [])
+        $params['componentClause'] ?? $defaultClause,
+        $params['componentTable'] ?? NULL,
+        $params['mergeSameAddress'] ?? FALSE,
+        $params['mergeSameHousehold'] ?? FALSE,
+        $params['exportParams'] ?? []
       );
     }
     catch (CRM_Core_Exception_PrematureExitException $e) {

--- a/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
@@ -494,54 +494,54 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
 
     $contactIDPhoneRecords = [
       $contactID1 => [
-        'primary_phone_id' => CRM_Utils_Array::value('id', $this->callAPISuccess('Phone', 'create', [
+        'primary_phone_id' => $this->callAPISuccess('Phone', 'create', [
           'contact_id' => $contactID1,
           'phone' => "01 01",
           'location_type_id' => "Home",
           'phone_type_id' => "Mobile",
           'is_primary' => 1,
-        ])),
-        'other_phone_id' => CRM_Utils_Array::value('id', $this->callAPISuccess('Phone', 'create', [
+        ])['id'],
+        'other_phone_id' => $this->callAPISuccess('Phone', 'create', [
           'contact_id' => $contactID1,
           'phone' => "01 02",
           'location_type_id' => "Work",
           'phone_type_id' => "Mobile",
           'is_primary' => 0,
-        ])),
+        ])['id'],
       ],
       // Create the non-primary with a lower ID than the primary, to test CRM-21320
       $contactID2 => [
-        'other_phone_id' => CRM_Utils_Array::value('id', $this->callAPISuccess('Phone', 'create', [
+        'other_phone_id' => $this->callAPISuccess('Phone', 'create', [
           'contact_id' => $contactID2,
           'phone' => "02 01",
           'location_type_id' => "Home",
           'phone_type_id' => "Mobile",
           'is_primary' => 0,
-        ])),
-        'primary_phone_id' => CRM_Utils_Array::value('id', $this->callAPISuccess('Phone', 'create', [
+        ])['id'],
+        'primary_phone_id' => $this->callAPISuccess('Phone', 'create', [
           'contact_id' => $contactID2,
           'phone' => "02 02",
           'location_type_id' => "Work",
           'phone_type_id' => "Mobile",
           'is_primary' => 1,
-        ])),
+        ])['id'],
       ],
       // Create primary that cant recieve SMS but a secondary that can, to test core/384
       $contactID3 => [
-        'other_phone_id' => CRM_Utils_Array::value('id', $this->callAPISuccess('Phone', 'create', [
+        'other_phone_id' => $this->callAPISuccess('Phone', 'create', [
           'contact_id' => $contactID3,
           'phone' => "03 01",
           'location_type_id' => "Home",
           'phone_type_id' => "Mobile",
           'is_primary' => 0,
-        ])),
-        'primary_phone_id' => CRM_Utils_Array::value('id', $this->callAPISuccess('Phone', 'create', [
+        ])['id'],
+        'primary_phone_id' => $this->callAPISuccess('Phone', 'create', [
           'contact_id' => $contactID3,
           'phone' => "03 02",
           'location_type_id' => "Work",
           'phone_type_id' => "Phone",
           'is_primary' => 1,
-        ])),
+        ])['id'],
       ],
     ];
 

--- a/tests/phpunit/CRM/Report/Form/ActivityTest.php
+++ b/tests/phpunit/CRM/Report/Form/ActivityTest.php
@@ -97,11 +97,11 @@ class CRM_Report_Form_ActivityTest extends CiviReportTestCase {
     ]);
 
     // create dummy activity type
-    $activityTypeID = CRM_Utils_Array::value('id', $this->callAPISuccess('option_value', 'create', [
+    $activityTypeID = $this->callAPISuccess('option_value', 'create', [
       'option_group_id' => 'activity_type',
       'name' => 'Test activity type',
       'label' => 'Test activity type',
-    ]));
+    ])['id'];
     // create activity
     $result = $this->callAPISuccess('activity', 'create', [
       'subject' => 'Make-it-Happen Meeting',

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -88,8 +88,8 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
       $actual = [];
       CRM_Utils_String::extractName($case['full_name'], $actual);
       $this->assertEquals($actual['first_name'], $case['first_name']);
-      $this->assertEquals(CRM_Utils_Array::value('last_name', $actual), CRM_Utils_Array::value('last_name', $case));
-      $this->assertEquals(CRM_Utils_Array::value('middle_name', $actual), CRM_Utils_Array::value('middle_name', $case));
+      $this->assertEquals($actual['last_name'] ?? NULL, $case['last_name'] ?? NULL);
+      $this->assertEquals($actual['middle_name'] ?? NULL, $case['middle_name'] ?? NULL);
     }
   }
 

--- a/tests/phpunit/CRM/Utils/SystemTest.php
+++ b/tests/phpunit/CRM/Utils/SystemTest.php
@@ -71,9 +71,9 @@ class CRM_Utils_SystemTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function hook_civicrm_alterRedirect($urlQuery, $context) {
-    $this->assertEquals(CRM_Utils_Array::value('scheme', $context['expected']), $urlQuery->getScheme());
-    $this->assertEquals(CRM_Utils_Array::value('host', $context['expected']), $urlQuery->getHost());
-    $this->assertEquals(CRM_Utils_Array::value('query', $context['expected']), $urlQuery->getQuery());
+    $this->assertEquals($context['expected']['scheme'] ?? NULL, $urlQuery->getScheme());
+    $this->assertEquals($context['expected']['host'] ?? NULL, $urlQuery->getHost());
+    $this->assertEquals($context['expected']['query'] ?? NULL, $urlQuery->getQuery());
     $this->assertEquals($context['original'], CRM_Utils_Url::unparseUrl($urlQuery));
 
     throw new CRM_Core_Exception(ts('hook called'));

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1797,10 +1797,10 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     $fields = $this->callAPISuccess($entity, 'getfields', ['version' => 3, 'action' => 'get']);
     foreach ($fields['values'] as $field => $settings) {
       if (array_key_exists($field, $result)) {
-        $keys[CRM_Utils_Array::value('name', $settings, $field)] = $field;
+        $keys[($settings['name'] ?? $field)] = $field;
       }
       else {
-        $keys[CRM_Utils_Array::value('name', $settings, $field)] = CRM_Utils_Array::value('name', $settings, $field);
+        $keys[($settings['name'] ?? $field)] = ($settings['name'] ?? $field);
       }
       $type = $settings['type'] ?? NULL;
       if ($type === CRM_Utils_Type::T_DATE) {
@@ -1837,7 +1837,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       }
       if (in_array($key, $dateTimeFields, TRUE)) {
         $value = date('Y-m-d H:i:s', strtotime($value));
-        $result[$keys[$key]] = date('Y-m-d H:i:s', strtotime(CRM_Utils_Array::value($keys[$key], $result, CRM_Utils_Array::value($key, $result))));
+        $result[$keys[$key]] = date('Y-m-d H:i:s', strtotime(($result[$keys[$key]] ?? $result[$key])));
       }
       $this->assertEquals($value, $result[$keys[$key]], $key . " GetandCheck function determines that for key {$key} value: " . print_r($value, TRUE) . " doesn't match " . print_r($result[$keys[$key]], TRUE) . $errorText);
     }
@@ -2602,7 +2602,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     if ($context !== 'online' && $context !== 'payLater') {
       $compareParams = [
         'to_financial_account_id' => 6,
-        'total_amount' => (float) CRM_Utils_Array::value('total_amount', $params, 100.00),
+        'total_amount' => (float) ($params['total_amount'] ?? 100.00),
         'status_id' => 1,
       ];
     }
@@ -2612,15 +2612,15 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     elseif ($context === 'online') {
       $compareParams = [
         'to_financial_account_id' => 12,
-        'total_amount' => (float) CRM_Utils_Array::value('total_amount', $params, 100.00),
+        'total_amount' => (float) ($params['total_amount'] ?? 100.00),
         'status_id' => 1,
-        'payment_instrument_id' => CRM_Utils_Array::value('payment_instrument_id', $params, 1),
+        'payment_instrument_id' => $params['payment_instrument_id'] ?? 1,
       ];
     }
     elseif ($context === 'payLater') {
       $compareParams = [
         'to_financial_account_id' => 7,
-        'total_amount' => (float) CRM_Utils_Array::value('total_amount', $params, 100.00),
+        'total_amount' => (float) ($params['total_amount'] ?? 100.00),
         'status_id' => 2,
       ];
     }
@@ -2634,15 +2634,15 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       'id' => $entityTrxn['entity_id'],
     ];
     $compareParams = [
-      'amount' => (float) CRM_Utils_Array::value('total_amount', $params, 100.00),
+      'amount' => (float) ($params['total_amount'] ?? 100.00),
       'status_id' => 1,
-      'financial_account_id' => CRM_Utils_Array::value('financial_account_id', $params, 1),
+      'financial_account_id' => $params['financial_account_id'] ?? 1,
     ];
     if ($context === 'payLater') {
       $compareParams = [
-        'amount' => (float) CRM_Utils_Array::value('total_amount', $params, 100.00),
+        'amount' => (float) ($params['total_amount'] ?? 100.00),
         'status_id' => 3,
-        'financial_account_id' => CRM_Utils_Array::value('financial_account_id', $params, 1),
+        'financial_account_id' => $params['financial_account_id'] ?? 1,
       ];
     }
     $this->assertDBCompareValues('CRM_Financial_DAO_FinancialItem', $fitemParams, $compareParams);

--- a/tests/phpunit/api/v3/APIWrapperTest.php
+++ b/tests/phpunit/api/v3/APIWrapperTest.php
@@ -69,7 +69,7 @@ class api_v3_APIWrapperTest_Impl implements API_Wrapper {
    */
   public function fromApiInput($apiRequest) {
     if ($apiRequest['entity'] == 'Contact' && $apiRequest['action'] == 'create') {
-      if ('Invalid' == CRM_Utils_Array::value('contact_type', $apiRequest['params'])) {
+      if ('Invalid' == $apiRequest['params']['contact_type']) {
         $apiRequest['params']['contact_type'] = 'Individual';
       }
     }

--- a/tests/phpunit/api/v3/CustomValueTest.php
+++ b/tests/phpunit/api/v3/CustomValueTest.php
@@ -244,7 +244,7 @@ class api_v3_CustomValueTest extends CiviUnitTestCase {
     }
 
     foreach ($sqlOps as $op) {
-      $qillOp = CRM_Utils_Array::value($op, CRM_Core_SelectValues::getSearchBuilderOperators(), $op);
+      $qillOp = CRM_Core_SelectValues::getSearchBuilderOperators([$op], $op);
       switch ($op) {
         case '=':
           $result = $this->callAPISuccess('Contact', 'Get', ['custom_' . $customId => (is_array($selectedValue) ? implode(CRM_Core_DAO::VALUE_SEPARATOR, $selectedValue) : $selectedValue)]);

--- a/tests/phpunit/api/v3/ProfileTest.php
+++ b/tests/phpunit/api/v3/ProfileTest.php
@@ -84,7 +84,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
     ];
     $result = $this->callAPISuccess('profile', 'get', $params)['values'];
     foreach ($expected as $profileField => $value) {
-      $this->assertEquals($value, CRM_Utils_Array::value($profileField, $result));
+      $this->assertEquals($value, $result[$profileField]);
     }
   }
 
@@ -122,7 +122,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
 
     $result = $this->callAPISuccess('profile', 'get', $params)['values'];
     foreach ($expected as $profileField => $value) {
-      $this->assertEquals($value, CRM_Utils_Array::value($profileField, $result[$this->_profileID]), ' error message: ' . "missing/mismatching value for $profileField");
+      $this->assertEquals($value, $result[$this->_profileID][$profileField], ' error message: ' . "missing/mismatching value for $profileField");
     }
     $this->assertEquals('abc1', $result[1]['first_name'], ' error message: ' . 'missing/mismatching value for first name');
     $this->assertArrayNotHasKey('email-Primary', $result[1], 'profile 1 does not include email');
@@ -293,7 +293,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess('profile', 'get', $params);
 
     foreach ($expected as $profileField => $value) {
-      $this->assertEquals($value, CRM_Utils_Array::value($profileField, $result['values']), ' error message: ' . "missing/mismatching value for $profileField"
+      $this->assertEquals($value, $result['values'][$profileField], ' error message: ' . "missing/mismatching value for $profileField"
       );
     }
   }
@@ -446,7 +446,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
     $profileDetails = $this->callAPISuccess('profile', 'get', $getParams);
 
     foreach ($updateParams as $profileField => $value) {
-      $this->assertEquals($value, CRM_Utils_Array::value($profileField, $profileDetails['values']), "missing/mismatching value for $profileField"
+      $this->assertEquals($value, $profileDetails['values'][$profileField], "missing/mismatching value for $profileField"
       );
     }
     unset($params['email-primary']);
@@ -548,7 +548,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
     $profileDetails = $this->callAPISuccess('profile', 'get', $getParams);
 
     foreach ($updateParams as $profileField => $value) {
-      $this->assertEquals($value, CRM_Utils_Array::value($profileField, $profileDetails['values']), 'In line ' . __LINE__ . ' error message: ' . "missing/mismatching value for $profileField"
+      $this->assertEquals($value, $profileDetails['values'][$profileField], 'In line ' . __LINE__ . ' error message: ' . "missing/mismatching value for $profileField"
       );
     }
   }
@@ -628,7 +628,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess('profile', 'get', $params)['values'];
 
     foreach ($updateParams as $profileField => $value) {
-      $this->assertEquals($value, CRM_Utils_Array::value($profileField, $result), ' error message: ' . "missing/mismatching value for $profileField"
+      $this->assertEquals($value, $result[$profileField], ' error message: ' . "missing/mismatching value for $profileField"
       );
     }
   }
@@ -702,14 +702,14 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
     ];
 
     foreach ($expected['contact'] as $field => $value) {
-      $this->assertEquals($value, CRM_Utils_Array::value($field, $result['values']), "missing/mismatching value for $field"
+      $this->assertEquals($value, $result['values'][$field], "missing/mismatching value for $field"
       );
     }
 
     foreach (['email', 'phone', 'address'] as $fieldType) {
       $typeValues = array_pop($result['values'][$fieldType]);
       foreach ($expected[$fieldType] as $field => $value) {
-        $this->assertEquals($value, CRM_Utils_Array::value($field, $typeValues), "missing/mismatching value for $field ($fieldType)"
+        $this->assertEquals($value, $typeValues[$field], "missing/mismatching value for $field ($fieldType)"
         );
       }
     }

--- a/tests/phpunit/api/v3/SelectQueryTest.php
+++ b/tests/phpunit/api/v3/SelectQueryTest.php
@@ -59,7 +59,7 @@ class api_v3_SelectQueryTest extends CiviUnitTestCase {
   public function hook_civicrm_selectWhereClause($entity, &$clauses) {
     if ($entity == $this->hookEntity) {
       foreach ($this->hookCondition as $field => $clause) {
-        $clauses[$field] = array_merge(CRM_Utils_Array::value($field, $clauses, []), $clause);
+        $clauses[$field] = array_merge(($clauses[$field] ?? []), $clause);
       }
     }
   }

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -1370,7 +1370,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
             $entity[$fieldName] = ['sort_name' => "SortName2"];
           }
           else {
-            $entity[$fieldName] = substr('New String', 0, CRM_Utils_Array::Value('maxlength', $specs, 100));
+            $entity[$fieldName] = substr('New String', 0, $specs['maxlength'] ?? 100);
             if ($fieldName == 'email') {
               $entity[$fieldName] = strtolower($entity[$fieldName]);
             }
@@ -1424,7 +1424,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
           $entity[$field] = 'warm.beer.com';
       }
       if (empty($specs['FKClassName']) && (!empty($specs['pseudoconstant']) || !empty($specs['options']))) {
-        $options = CRM_Utils_Array::value('options', $specs, []);
+        $options = $specs['options'] ?? [];
         if (!$options) {
           //eg. pdf_format id doesn't ship with any
           if (isset($specs['pseudoconstant']['optionGroupName'])) {
@@ -1434,7 +1434,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
               'sequential' => 1,
             ]);
             $optionValue = $optionValue['values'];
-            $keyColumn = CRM_Utils_Array::value('keyColumn', $specs['pseudoconstant'], 'value');
+            $keyColumn = $specs['pseudoconstant']['keyColumn'] ?? 'value';
             $options[$optionValue[0][$keyColumn]] = 'new option value';
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------
As long as the tests still pass, this is simpler.

Technical Details
------
My thinking with this PR is that using `CRM_Utils_Array::value()` in a unit test smells sloppy. Unit tests usually want to strictly assert values and don't need/shouldn't use the hedge provided by that function. So I've removed it more aggressively in the test classes than I would from runtime code (without providing the extra `??` hedge unless the test actually needs it).