### PR TITLE
Stop calling `CRM_Contribute_Form_Contribution::testSubmit()`, quiet deprecation

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1558,8 +1558,20 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
    *
    * @throws \CRM_Core_Exception
    * @throws \Civi\Payment\Exception\PaymentProcessorException
+   *
+   * @deprecated since 5.68 will be removed around 5.80.
+   *
+   * Try something like
+   *  use   use \Civi\Test\FormTrait;
+   *  $form = $this->getTestForm('CRM_Contribute_Form_Contribution', $submittedValues, [
+   *   'id' =>  4;
+   *   'action' => 'update',
+   * ]);
+   * $form->processForm();
    */
   public function testSubmit($params, $action, $creditCardMode = NULL) {
+    // Note that this is really used from tests - so adding noisy deprecations would make them
+    // fail straight away.
     $defaults = [
       'soft_credit_contact_id' => [],
       'receive_date' => date('Y-m-d H:i:s'),
@@ -1605,7 +1617,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     $this->_fields = [];
     return $this->submit(array_merge($defaults, $params), $action, CRM_Utils_Array::value('pledge_payment_id', $params));
-
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Stop calling `CRM_Contribute_Form_Contribution::testSubmit()`, quiet deprecation

Before
----------------------------------------
We used to use this function to move up submitting the Form_Contribution in tests - but now prefer

```
use   use \Civi\Test\FormTrait;
 $form = $this->getTestForm('CRM_Contribute_Form_Contribution', $submittedValues, [
   'id' =>  4;
    'action' => 'update',
  ]);
  $form->processForm();
```

After
----------------------------------------
Last call to `testSubmit` removed from core, Deprecation comment added. Note that adding noisy deprecation here is equivalent to removing the function - since it is a test-only function & tests would start failing.

It seems this would affect tests in 

- TSyS
- Line Item editor
- CDN tax calculator
- IATS

@KarinG @mlutfy @JoeMurray @agh1 - I've commented with the idea that a year would probably be a long enough deprecation period for this function - it's actually pretty easy to switch the tests over - but happy to change that recommended date in the comment if that seems scary. It's not a hard function to keep around (ie hard functions to keep around are the ones that call a bunch of other functions & we constantly hit the function when trying to reverse engineer how those other functions are invoked)

Technical Details
----------------------------------------

Comments
----------------------------------------
