### PR TITLE
CRM_Utils_Array::value - remove "todo" which we don't actually want to do

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -70,8 +70,6 @@ class CRM_Utils_Array {
     if ($list instanceof ArrayAccess) {
       return $list->offsetExists($key) ? $list[$key] : $default;
     }
-    // @todo - eliminate invalid usages from core & uncomment this line.
-    CRM_Core_Error::deprecatedFunctionWarning('an array/ArrayAccess for the "list" parameter');
     return $default;
   }
 

--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -70,8 +70,8 @@ class CRM_Utils_Array {
     if ($list instanceof ArrayAccess) {
       return $list->offsetExists($key) ? $list[$key] : $default;
     }
-    // @todo - eliminate these from core & uncomment this line.
-    // CRM_Core_Error::deprecatedFunctionWarning('You have passed an invalid parameter for the "list"');
+    // @todo - eliminate invalid usages from core & uncomment this line.
+    CRM_Core_Error::deprecatedFunctionWarning('an array/ArrayAccess for the "list" parameter');
     return $default;
   }
 


### PR DESCRIPTION
This function is very widely called within the CiviCRM [universe](https://docs.civicrm.org/dev/en/latest/tools/universe/) and is tantalizingly close to being identical to the PHP null-coalescing operator, `??`.

The old "todo" in the code comments would make the function less similar to `??`, and would break a lot of things inside and outside core, and create a lot of work. Instead we'll focus on moving away from using this function in the first place.