### PR TITLE
dev/core#4364 - Don't reset weights when updating managed entity

### DIFF
--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -291,7 +291,13 @@ class CRM_Core_ManagedEntities {
     }
     elseif ($doUpdate && $item['params']['version'] == 4) {
       $params = ['checkPermissions' => FALSE] + $item['params'];
-      $params['values']['id'] = $item['entity_id'];
+      $idField = CoreUtil::getIdFieldName($item['entity_type']);
+      $params['values'][$idField] = $item['entity_id'];
+      // Exclude "weight" as that auto-adjusts
+      if (in_array('SortableEntity', CoreUtil::getInfoItem($item['entity_type'], 'type'), TRUE)) {
+        $weightCol = CoreUtil::getInfoItem($item['entity_type'], 'order_by');
+        unset($params['values'][$weightCol]);
+      }
       // 'match' param doesn't apply to "update" action
       unset($params['match']);
       try {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes (at least partially) https://lab.civicrm.org/dev/core/-/issues/4364

Before
----------------------------------------
Your changes to the sorting of navigation items would get undone every time caches were cleared.

After
----------------------------------------
Weights remain stable even when managed entities are recalculated

Technical Details
----------------------------------------
There is a symmetry here to this other section of the same class:
https://github.com/civicrm/civicrm-core/blob/bcfb60395f862903afca4f49436131dbbab10c92/CRM/Core/ManagedEntities.php#L155-L159