### PR TITLE
[REF] CRM/Utils - Refactor unnecessary uses of CRM_Utils_Array::value

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -280,16 +280,16 @@ class CRM_Utils_Date {
    * @return int
    */
   public static function unixTime($string) {
-    if (empty($string)) {
+    if (!$string) {
       return 0;
     }
     $parsedDate = date_parse($string);
-    return mktime(CRM_Utils_Array::value('hour', $parsedDate),
-      CRM_Utils_Array::value('minute', $parsedDate),
+    return mktime($parsedDate['hour'],
+       $parsedDate['minute'],
       59,
-      CRM_Utils_Array::value('month', $parsedDate),
-      CRM_Utils_Array::value('day', $parsedDate),
-      CRM_Utils_Array::value('year', $parsedDate)
+       $parsedDate['month'],
+       $parsedDate['day'],
+       $parsedDate['year']
     );
   }
 

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -452,12 +452,12 @@ class CRM_Utils_System {
 
     return self::url(
       $p,
-      CRM_Utils_Array::value('q', $params),
-      CRM_Utils_Array::value('a', $params, FALSE),
-      CRM_Utils_Array::value('f', $params),
-      CRM_Utils_Array::value('h', $params, TRUE),
-      CRM_Utils_Array::value('fe', $params, FALSE),
-      CRM_Utils_Array::value('fb', $params, FALSE)
+      $params['q'] ?? NULL,
+      $params['a'] ?? FALSE,
+      $params['f'] ?? NULL,
+      $params['h'] ?? TRUE,
+      $params['fe'] ?? FALSE,
+      $params['fb'] ?? FALSE
     );
   }
 

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -136,8 +136,8 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
   public function checkUserNameEmailExists(&$params, &$errors, $emailName = 'email') {
     $config = CRM_Core_Config::singleton();
 
-    $name = CRM_Utils_Array::value('name', $params);
-    $email = CRM_Utils_Array::value('mail', $params);
+    $name = $params['name'] ?? NULL;
+    $email = $params['mail'] ?? NULL;
     //don't allow the special characters and min. username length is two
     //regex \\ to match a single backslash would become '/\\\\/'
     $isNotValid = (bool) preg_match('/[\<|\>|\"|\'|\%|\;|\(|\)|\&|\\\\|\/]/im', $name);

--- a/CRM/Utils/Wrapper.php
+++ b/CRM/Utils/Wrapper.php
@@ -75,7 +75,7 @@ class CRM_Utils_Wrapper {
           $sessionVar = $params['sessionVar'] ?? NULL;
           $type = $params['type'] ?? NULL;
           $default = $params['default'] ?? NULL;
-          $abort = CRM_Utils_Array::value('abort', $params, FALSE);
+          $abort = $params['abort'] ?? FALSE;
 
           $value = NULL;
           $value = CRM_Utils_Request::retrieve(


### PR DESCRIPTION
Overview
----------------------------------------
Part of ongoing cleanup work to deprecate/remove php5-era function `CRM_Utils_Array::value`.