### PR TITLE
[REF] CRM/Admin - Refactor unnecessary uses of CRM_Utils_Array::value

### DIFF
--- a/CRM/Admin/Form/MailSettings.php
+++ b/CRM/Admin/Form/MailSettings.php
@@ -211,7 +211,7 @@ class CRM_Admin_Form_MailSettings extends CRM_Admin_Form {
         'is_contact_creation_disabled_if_no_match',
         'is_active',
       ])) {
-        $params[$f] = CRM_Utils_Array::value($f, $formValues, FALSE);
+        $params[$f] = $formValues[$f] ?? FALSE;
       }
       else {
         $params[$f] = $formValues[$f] ?? NULL;

--- a/CRM/Admin/Form/PaymentProcessorType.php
+++ b/CRM/Admin/Form/PaymentProcessorType.php
@@ -146,7 +146,7 @@ class CRM_Admin_Form_PaymentProcessorType extends CRM_Admin_Form {
     $attributes = CRM_Core_DAO::getAttribute('CRM_Financial_DAO_PaymentProcessorType');
 
     foreach ($this->_fields as $field) {
-      $required = CRM_Utils_Array::value('required', $field, FALSE);
+      $required = $field['required'] ?? FALSE;
       $this->add('text', $field['name'],
         $field['label'], $attributes['name'], $required
       );
@@ -210,9 +210,9 @@ UPDATE civicrm_payment_processor SET is_default = 0";
     $dao = new CRM_Financial_DAO_PaymentProcessorType();
 
     $dao->id = $this->_id;
-    $dao->is_default = CRM_Utils_Array::value('is_default', $values, 0);
-    $dao->is_active = CRM_Utils_Array::value('is_active', $values, 0);
-    $dao->is_recur = CRM_Utils_Array::value('is_recur', $values, 0);
+    $dao->is_default = $values['is_default'] ?? 0;
+    $dao->is_active = $values['is_active'] ?? 0;
+    $dao->is_recur = $values['is_recur'] ?? 0;
 
     $dao->name = $values['name'];
     $dao->description = $values['description'];

--- a/CRM/Admin/Form/Preferences/Contribute.php
+++ b/CRM/Admin/Form/Preferences/Contribute.php
@@ -167,7 +167,7 @@ class CRM_Admin_Form_Preferences_Contribute extends CRM_Admin_Form_Preferences {
     // too. This means that saving from api will not have the desired core effect.
     // but we should fix that elsewhere - ie. stop abusing the settings
     // and fix the code repetition associated with invoicing
-    $invoiceParams['invoicing'] = CRM_Utils_Array::value('invoicing', $params, 0);
+    $invoiceParams['invoicing'] = $params['invoicing'] ?? 0;
     Civi::settings()->set('contribution_invoice_settings', $invoiceParams);
     parent::postProcess();
   }

--- a/CRM/Admin/Form/RelationshipType.php
+++ b/CRM/Admin/Form/RelationshipType.php
@@ -141,7 +141,7 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
     else {
       // store the submitted values in an array
       $params = $this->exportValues();
-      $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
+      $params['is_active'] = $params['is_active'] ?? FALSE;
 
       if ($this->_action & CRM_Core_Action::UPDATE) {
         $params['id'] = $this->_id;


### PR DESCRIPTION
Overview
----------------------------------------
Part of ongoing cleanup work to deprecate/remove php5-era function `CRM_Utils_Array::value`.