### PR TITLE
[REF] CRM/Mailing - Refactor unnecessary uses of CRM_Utils_Array::value

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2863,7 +2863,7 @@ ORDER BY civicrm_mailing.id DESC";
       $mailing['openstats'] = "Opens: " .
         CRM_Utils_Array::value($values['mailing_id'], $openCounts, 0) .
         "<br />Clicks: " .
-        CRM_Utils_Array::value($values['mailing_id'], $clickCounts, 0);
+        $clickCounts[$values['mailing_id']] ?? 0;
 
       $actionLinks = [
         CRM_Core_Action::VIEW => [

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -45,7 +45,7 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
       throw new CRM_Core_Exception("Failed to create job: Unknown mailing ID");
     }
     $op = empty($params['id']) ? 'create' : 'edit';
-    CRM_Utils_Hook::pre($op, 'MailingJob', CRM_Utils_Array::value('id', $params), $params);
+    CRM_Utils_Hook::pre($op, 'MailingJob', $params['id'] ?? NULL, $params);
 
     $jobDAO = new CRM_Mailing_BAO_MailingJob();
     $jobDAO->copyValues($params);


### PR DESCRIPTION
Overview
----------------------------------------
Part of ongoing cleanup work to deprecate/remove php5-era function `CRM_Utils_Array::value`.