### PR TITLE
[REF] Flexmailer - Refactor unnecessary use of CRM_Utils_Array::value

### DIFF
--- a/ext/flexmailer/src/API/MailingPreview.php
+++ b/ext/flexmailer/src/API/MailingPreview.php
@@ -24,7 +24,7 @@ class MailingPreview {
 
     /** @var \CRM_Mailing_BAO_Mailing $mailing */
     $mailing = new \CRM_Mailing_BAO_Mailing();
-    $mailingID = \CRM_Utils_Array::value('id', $params);
+    $mailingID = $params['id'] ?? NULL;
     if ($mailingID) {
       $mailing->id = $mailingID;
       $mailing->find(TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
Part of ongoing cleanup work to deprecate/remove php5-era function `CRM_Utils_Array::value`.