### PR TITLE
php8.2 fix undeclared properties on backoffice contribution form

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -210,10 +210,23 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
   public $payment_instrument_id;
 
   /**
+   * @var bool
+   */
+  private $_payNow;
+
+  /**
    * Explicitly declare the form context.
    */
   public function getDefaultContext() {
     return 'create';
+  }
+
+  public function __get($name) {
+    if ($name === '_contributionID') {
+      CRM_Core_Error::deprecatedWarning('_contributionID is not a form property - use getContributionID()');
+      return $this->getContributionID();
+    }
+    return NULL;
   }
 
   /**
@@ -306,7 +319,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     // Set title
     if ($this->_mode && $this->_id) {
       $this->_payNow = TRUE;
-      $this->assign('payNow', $this->_payNow);
       $this->setTitle(ts('Pay with Credit Card'));
     }
     elseif ($this->_values['is_template']) {
@@ -318,6 +330,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     else {
       $this->setPageTitle($this->_ppID ? ts('Pledge Payment') : ts('Contribution'));
     }
+    $this->assign('payNow', $this->_payNow);
   }
 
   private function preProcessPledge(): void {
@@ -1468,9 +1481,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         $smarty->assign('dataArray', $dataArray);
         $smarty->assign('totalTaxAmount', $params['tax_amount'] ?? NULL);
       }
-
-      // lets store it in the form variable so postProcess hook can get to this and use it
-      $form->_contributionID = $contribution->id;
     }
 
     // process soft credit / pcp params first

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1558,8 +1558,20 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
    *
    * @throws \CRM_Core_Exception
    * @throws \Civi\Payment\Exception\PaymentProcessorException
+   *
+   * @deprecated since 5.68 will be removed around 5.80.
+   *
+   * Try something like
+   *  use   use \Civi\Test\FormTrait;
+   *  $form = $this->getTestForm('CRM_Contribute_Form_Contribution', $submittedValues, [
+   *   'id' =>  4;
+   *   'action' => 'update',
+   * ]);
+   * $form->processForm();
    */
   public function testSubmit($params, $action, $creditCardMode = NULL) {
+    // Note that this is really used from tests - so adding noisy deprecations would make them
+    // fail straight away.
     $defaults = [
       'soft_credit_contact_id' => [],
       'receive_date' => date('Y-m-d H:i:s'),
@@ -1605,7 +1617,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     $this->_fields = [];
     return $this->submit(array_merge($defaults, $params), $action, CRM_Utils_Array::value('pledge_payment_id', $params));
-
   }
 
   /**

--- a/Civi/Test/FormTrait.php
+++ b/Civi/Test/FormTrait.php
@@ -81,4 +81,16 @@ trait FormTrait {
     }
   }
 
+  /**
+   * Retrieve a deprecated property, ensuring a deprecation notice is thrown.
+   *
+   * @param string $property
+   *
+   * @return mixed
+   * @throws \CRM_Core_Exception
+   */
+  protected function getDeprecatedProperty(string $property) {
+    return $this->form->getDeprecatedProperty($property);
+  }
+
 }

--- a/Civi/Test/FormTrait.php
+++ b/Civi/Test/FormTrait.php
@@ -20,6 +20,11 @@ use Civi\Test\FormWrappers\EventFormParticipant;
 trait FormTrait {
 
   /**
+   * @var \Civi\Test\FormWrapper
+   */
+  private $form;
+
+  /**
    * @param $formName
    * @param $submittedValues
    * @param array $urlParameters
@@ -27,13 +32,53 @@ trait FormTrait {
    * @return \Civi\Test\FormWrapper
    */
   public function getTestForm($formName, $submittedValues, array $urlParameters = []) {
+    $this->form = NULL;
     if ($formName === 'CRM_Event_Form_Participant') {
-      return new EventFormParticipant($formName, $submittedValues, $urlParameters);
+      $this->form = new EventFormParticipant($formName, $submittedValues, $urlParameters);
     }
     if ($formName === 'CRM_Event_Form_Registration_Register') {
-      return new EventFormOnline($formName, $submittedValues, $urlParameters);
+      $this->form = new EventFormOnline($formName, $submittedValues, $urlParameters);
     }
-    return new FormWrapper($formName, $submittedValues, $urlParameters);
+    if (!$this->form) {
+      $this->form = new FormWrapper($formName, $submittedValues, $urlParameters);
+    }
+    return $this->form;
+  }
+
+  /**
+   * Assert that the sent mail included the supplied strings.
+   *
+   * @param array $strings
+   * @param int $mailIndex
+   */
+  protected function assertMailSentContainingStrings(array $strings, int $mailIndex = 0): void {
+    foreach ($strings as $string) {
+      $this->assertMailSentContainingString($string, $mailIndex);
+    }
+  }
+
+  /**
+   * Assert that the sent mail included the supplied string.
+   *
+   * @param string $string
+   * @param int $mailIndex
+   */
+  protected function assertMailSentContainingString(string $string, int $mailIndex = 0): void {
+    $mail = $this->form->getMail()[$mailIndex];
+    $this->assertStringContainsString($string, $mail['body']);
+  }
+
+  /**
+   * Assert that the sent mail included the supplied strings.
+   *
+   * @param array $recipients
+   * @param int $mailIndex
+   */
+  protected function assertMailSentTo(array $recipients, int $mailIndex = 0): void {
+    $mail = $this->form->getMail()[$mailIndex];
+    foreach ($recipients as $string) {
+      $this->assertStringContainsString($string, $mail['headers']);
+    }
   }
 
 }

--- a/Civi/Test/FormWrapper.php
+++ b/Civi/Test/FormWrapper.php
@@ -50,6 +50,15 @@ class FormWrapper {
     return $this->mail ? (array) reset($this->mail) : [];
   }
 
+  /**
+   * Get the number of emails sent.
+   *
+   * @return int
+   */
+  public function getMailCount(): int {
+    return count((array) $this->mail);
+  }
+
   public function getFirstMailBody() : string {
     return $this->getFirstMail()['body'] ?? '';
   }
@@ -182,7 +191,7 @@ class FormWrapper {
     $_POST = $formValues;
     $this->form = new $class();
     $_SERVER['REQUEST_METHOD'] = 'GET';
-    $_REQUEST += $urlParameters;
+    $_REQUEST = array_merge($_REQUEST, $urlParameters);
     switch ($class) {
       case 'CRM_Event_Cart_Form_Checkout_Payment':
       case 'CRM_Event_Cart_Form_Checkout_ParticipantsAndPrices':

--- a/Civi/Test/FormWrapper.php
+++ b/Civi/Test/FormWrapper.php
@@ -348,4 +348,25 @@ class FormWrapper {
     \Civi::settings()->set('mailing_backend', $this->originalMailSetting);
   }
 
+  /**
+   * Retrieve a deprecated property, ensuring a deprecation notice is thrown.
+   *
+   * @param string $property
+   *
+   * @return mixed
+   * @throws \CRM_Core_Exception
+   */
+  public function getDeprecatedProperty(string $property) {
+    try {
+      $this->form->$property;
+    }
+    catch (\Exception $e) {
+      $oldErrorLevel = error_reporting(0);
+      $value = $this->form->$property;
+      error_reporting($oldErrorLevel);
+      return $value;
+    }
+    throw new \CRM_Core_Exception('Deprecation should have been triggered');
+  }
+
 }

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -820,6 +820,8 @@ Receipt Date: ' . date('m/d/Y'),
 
   /**
    * Test the submit function on the contribution page.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testSubmitWithNoteCreditCard(): void {
     $this->submitContributionForm([
@@ -830,9 +832,10 @@ Receipt Date: ' . date('m/d/Y'),
       'contribution_status_id' => 1,
       'note' => 'Super cool and interesting stuff',
     ] + $this->getCreditCardParams());
-    $this->callAPISuccessGetCount('Contribution', ['contact_id' => $this->_individualId], 1);
+    $contribution = $this->callAPISuccessGetSingle('Contribution', ['contact_id' => $this->_individualId]);
     $note = $this->callAPISuccessGetSingle('note', ['entity_table' => 'civicrm_contribution']);
     $this->assertEquals('Super cool and interesting stuff', $note['note']);
+    $this->assertEquals($contribution['id'], $this->getDeprecatedProperty('_contributionID'));
   }
 
   /**

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -1173,8 +1173,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * Tests that additional financial records are created.
    *
    * Checks when online contribution with pay later option is created
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testCreateContributionPayLaterOnline(): void {
     $this->pageParams['is_pay_later'] = 1;
@@ -1238,8 +1236,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
   /**
    * Test that BAO defaults work.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testCreateBAODefaults(): void {
     unset($this->_params['contribution_source_id'], $this->_params['payment_instrument_id']);
@@ -1256,8 +1252,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
   /**
    * Test that getsingle can be chained with delete.
-   *
-   * @throws CRM_Core_Exception
    */
   public function testDeleteChainedGetSingle(): void {
     $contribution = $this->callAPISuccess('Contribution', 'create', $this->_params);
@@ -1393,8 +1387,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
   /**
    * Function tests that financial records are added when Contribution is Refunded.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testCreateUpdateContributionRefund(): void {
     $contributionParams = [
@@ -1686,8 +1678,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
   /**
    * Function tests that financial records are added when Financial Type is Changed.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testCreateUpdateContributionChangeFinancialType(): void {
     $contributionParams = [
@@ -2635,7 +2625,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * @return array
    * @throws \CRM_Core_Exception
    */
-  public function contributionStatusProvider() {
+  public function contributionStatusProvider(): array {
     $contributionStatuses = civicrm_api3('OptionValue', 'get', [
       'return' => ['id', 'name'],
       'option_group_id' => 'contribution_status',
@@ -3783,10 +3773,8 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    *
    * @param CiviMailUtils $mut
    * @param int $contributionID Contribution ID
-   *
-   * @throws \CRM_Core_Exception
    */
-  public function checkCreditCardDetails($mut, $contributionID) {
+  public function checkCreditCardDetails(CiviMailUtils $mut, int $contributionID): void {
     $this->callAPISuccess('contribution', 'create', $this->_params);
     $this->callAPISuccess('contribution', 'sendconfirmation', [
       'id' => $contributionID,
@@ -3991,8 +3979,9 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * @param int $contId
    *
    * @return null|string
+   * @throws \CRM_Core_Exception
    */
-  public function _getFinancialItemAmount($contId) {
+  public function _getFinancialItemAmount(int $contId): ?string {
     $lineItem = key(CRM_Price_BAO_LineItem::getLineItems($contId, 'contribution'));
     $query = "SELECT
      SUM(amount)
@@ -4536,10 +4525,8 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
   /**
    * Test sending a mail via the API.
-   *
-   * @throws \CRM_Core_Exception
    */
-  public function testSendMailWithRepeatTransactionAPIFalltoDomain(): void {
+  public function testSendMailWithRepeatTransactionAPIFailtoDomain(): void {
     $this->createLoggedInUser();
     $mut = new CiviMailUtils($this, TRUE);
     $contribution = $this->setUpRepeatTransaction([], 'single');
@@ -4828,8 +4815,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * @param string $op
    * @param string $objectName
    * @param int|null $objectId
-   *
-   * @throws \CRM_Core_Exception
    */
   public function civicrmPostContributionCustom(string $op, string $objectName, ?int $objectId): void {
     if ($objectName === 'Contribution' && $op === 'create') {


### PR DESCRIPTION
Overview
----------------------------------------
php8.2 fix undeclared properties on backoffice contribution form - fixing a bunch of tests

![image](https://github.com/civicrm/civicrm-core/assets/336308/1750ed68-b853-475b-8110-72274c3e4e25)


Before
----------------------------------------
php8.2 fails on the setting of `_contributionID` - this property is unused in core but there was intent when added that it could be accessed from hooks 

CRM_Contribute_Form_ContributionTest::testSubmitCreditCardWithBillingAddress
Creation of dynamic property CRM_Contribute_Form_Contribution::$_contributionID is deprecated

/home/homer/buildkit/build/build-3/web/sites/all/modules/civicrm/CRM/Contribute/Form/Contribution.php:1473
/home/homer/buildkit/build/build-3/web/sites/all/modules/civicrm/CRM/Contribute/Form/Contribution.php:1282
/home/homer/buildkit/build/build-3/web/sites/all/modules/civicrm/CRM/Contribute/Form/Contribution.php:1815
/home/homer/buildkit/build/build-3/web/sites/all/modules/civicrm/CRM/Contribute/Form/Contribution.php:1117
/home/homer/buildkit/build/build-3/web/sites/all/modules/civicrm/tests/phpunit/CRM/Contribute/Form/ContributionTest.php:2220
/home/homer/buildkit/build/build-3/web/sites/all/modules/civicrm/tests/phpunit/CRM/Contribute/Form/ContributionTest.php:525
/home/homer/buildkit/build/build-3/web/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:242
/home/homer/buildkit/extern/phpunit9/phpunit9.phar:2307

After
----------------------------------------
Property is not set - but is still transitionally available with a deprecation notice

Technical Details
----------------------------------------
php8.2 fix undeclared properties on backoffice contribution form
    
    There are just 2 properties
    
    _payNow is distinctly internal, and easily searched in universe so I made it private
    
    - _contributionID is specifically set for the purposes of hooks - although I expect that
    was more relevant when the code was shared with the front end form. However, I have
    set it up to still work for now, albeit with a deprecation notice


Comments
----------------------------------------
