### PR TITLE
Remove no-longer-used parameters from function signature

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -846,7 +846,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       $params['total_amount'] = CRM_Utils_Rule::cleanMoney($params['total_amount']);
     }
     if ($this->_isPaidEvent) {
-      [$contributionParams, $lineItem, $additionalParticipantDetails, $params] = $this->preparePaidEventProcessing($params);
+      [$contributionParams, $lineItem, $params] = $this->preparePaidEventProcessing($params);
     }
 
     $this->_params = $params;
@@ -1202,7 +1202,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     }
 
     if (!empty($params['send_receipt'])) {
-      $result = $this->sendReceipts($params, $participants, $lineItem[0] ?? [], $additionalParticipantDetails ?? []);
+      $result = $this->sendReceipts($params, $participants);
     }
 
     // set the participant id if it is not set
@@ -1531,7 +1531,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       }
     }
 
-    return [$contributionParams, $lineItem, $additionalParticipantDetails, $params];
+    return [$contributionParams, $lineItem, $params];
   }
 
   /**
@@ -1893,14 +1893,12 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
   /**
    * @param $params
    * @param array $participants
-   * @param $lineItem
-   * @param $additionalParticipantDetails
    *
    * @return array
    * @throws \CRM_Core_Exception
    * @throws \Brick\Money\Exception\UnknownCurrencyException
    */
-  protected function sendReceipts($params, array $participants, $lineItem, $additionalParticipantDetails): array {
+  protected function sendReceipts($params, array $participants): array {
     $sent = [];
     $notSent = [];
     $this->assignEventDetailsToTpl($params['event_id'], CRM_Utils_Array::value('role_id', $params), CRM_Utils_Array::value('receipt_text', $params));


### PR DESCRIPTION
Overview
----------------------------------------

Remove no-longer-used parameters from function signature

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/4dd39002-fcfd-4d6d-b354-ff6a97a7286e)


After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
