### PR TITLE
dev/core#4364 Use writeRecord for Navigations so menu changes for managed entities don't reset

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -74,7 +74,6 @@ class CRM_Core_BAO_Navigation extends CRM_Core_DAO_Navigation {
    * @return CRM_Core_DAO_Navigation
    */
   public static function add(&$params) {
-    $navigation = new CRM_Core_DAO_Navigation();
     if (empty($params['id'])) {
       $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
       $params['has_separator'] = CRM_Utils_Array::value('has_separator', $params, FALSE);
@@ -102,10 +101,7 @@ class CRM_Core_BAO_Navigation extends CRM_Core_DAO_Navigation {
       $params['permission'] = implode(',', $params['permission']);
     }
 
-    $navigation->copyValues($params);
-
-    $navigation->save();
-    return $navigation;
+    return self::writeRecord($params);
   }
 
   /**
@@ -513,11 +509,11 @@ ORDER BY weight";
         break;
 
       case "rename":
-        self::processRename($nodeID, $label);
+        self::writeRecord(['id' => $nodeID, 'label' => $label]);
         break;
 
       case "delete":
-        self::processDelete($nodeID);
+        self::deleteRecord(['id' => $nodeID]);
         break;
     }
 
@@ -578,8 +574,6 @@ ORDER BY weight";
       $incrementOtherNodes = FALSE;
     }
 
-    $transaction = new CRM_Core_Transaction();
-
     // now update the existing nodes to weight + 1, if required.
     if ($incrementOtherNodes) {
       $query = "UPDATE civicrm_navigation SET weight = weight + 1
@@ -588,11 +582,8 @@ ORDER BY weight";
       CRM_Core_DAO::executeQuery($query);
     }
 
-    // finally set the weight of current node
-    $query = "UPDATE civicrm_navigation SET weight = {$newWeight}, parent_id = {$newParentID} WHERE id = {$nodeID}";
-    CRM_Core_DAO::executeQuery($query);
-
-    $transaction->commit();
+    // finally set the weight and parent of current node
+    self::writeRecord(['id' => $nodeID, 'weight' => $newWeight, 'parent_id' => $newParentID]);
   }
 
   /**
@@ -600,19 +591,20 @@ ORDER BY weight";
    *
    * @param int $nodeID
    * @param $label
+   * @deprecated  - use API
    */
   public static function processRename($nodeID, $label) {
-    CRM_Core_DAO::setFieldValue('CRM_Core_DAO_Navigation', $nodeID, 'label', $label);
+    self::writeRecord(['id' => $nodeID, 'label' => $label]);
   }
 
   /**
    * Process delete action for tree.
    *
    * @param int $nodeID
+   * @deprecated - use API
    */
   public static function processDelete($nodeID) {
-    $query = "DELETE FROM civicrm_navigation WHERE id = {$nodeID}";
-    CRM_Core_DAO::executeQuery($query);
+    self::deleteRecord(['id' => $nodeID]);
   }
 
   /**

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -97,10 +97,6 @@ class CRM_Core_BAO_Navigation extends CRM_Core_DAO_Navigation {
       $params['weight'] = self::calculateWeight(CRM_Utils_Array::value('parent_id', $params));
     }
 
-    if (array_key_exists('permission', $params) && is_array($params['permission'])) {
-      $params['permission'] = implode(',', $params['permission']);
-    }
-
     return self::writeRecord($params);
   }
 
@@ -594,6 +590,7 @@ ORDER BY weight";
    * @deprecated  - use API
    */
   public static function processRename($nodeID, $label) {
+    CRM_Core_Error::deprecatedFunctionWarning('writeRecord');
     self::writeRecord(['id' => $nodeID, 'label' => $label]);
   }
 
@@ -604,6 +601,7 @@ ORDER BY weight";
    * @deprecated - use API
    */
   public static function processDelete($nodeID) {
+    CRM_Core_Error::deprecatedFunctionWarning('writeRecord');
     self::deleteRecord(['id' => $nodeID]);
   }
 

--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -240,7 +240,7 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance implem
       // When deleting a report, also delete from navigation menu
       $navId = CRM_Core_DAO::getFieldValue('CRM_Report_DAO_ReportInstance', $event->id, 'navigation_id');
       if ($navId) {
-        CRM_Core_BAO_Navigation::processDelete($navId);
+        CRM_Core_BAO_Navigation::deleteRecord(['id' => $navId]);
         CRM_Core_BAO_Navigation::resetNavigation();
       }
     }

--- a/CRM/Report/Form/Instance.php
+++ b/CRM/Report/Form/Instance.php
@@ -318,7 +318,7 @@ class CRM_Report_Form_Instance {
       // Delete navigation if exists.
       $navId = CRM_Core_DAO::getFieldValue('CRM_Report_DAO_ReportInstance', $instanceID, 'navigation_id', 'id');
       if ($navId) {
-        CRM_Core_BAO_Navigation::processDelete($navId);
+        CRM_Core_BAO_Navigation::deleteRecord(['id' => $navId]);
         CRM_Core_BAO_Navigation::resetNavigation();
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
See [issue.](https://lab.civicrm.org/dev/core/-/issues/4364)
This resolves issues with updates, but deletions still have the problem described in the issue, pending #24496.

Before
----------------------------------------
Pre and post hooks aren't called when adding, modifying or deleting navigation menu items, so these are reset on cache clear, erasing user changes.

After
----------------------------------------
Pre and post hooks are called.

Technical Details
----------------------------------------
We lose a transaction that used to wrap the weight changes in processMove. This seems fine though as the worst case scenario is the first query succeeds, but the writeRecord fails, in which case we have simply inserted a gap in the menu weights, which doesn't matter. 