### PR TITLE
Php8.x fixes on Main online contribution page

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1002,7 +1002,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
             'price_' . $field['id'],
             $field['id'],
             FALSE,
-            CRM_Utils_Array::value('is_required', $field, FALSE),
+            $field['is_required'] ?? FALSE,
             NULL,
             $options
           );

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -541,12 +541,13 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
           }
         }
         if (!empty($options)) {
+          $label = (!empty($this->_membershipBlock) && $field['name'] === 'contribution_amount') ? ts('Additional Contribution') : $field['label'];
           CRM_Price_BAO_PriceField::addQuickFormElement($form,
             'price_' . $field['id'],
             $field['id'],
             FALSE,
-            CRM_Utils_Array::value('is_required', $field, FALSE),
-            NULL,
+            $field['is_required'] ?? FALSE,
+            $label,
             $options
           );
         }

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -126,14 +126,14 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       // remove component related fields
       foreach ($this->_fields as $name => $fieldInfo) {
         //don't set custom data Used for Contribution (CRM-1344)
-        if (substr($name, 0, 7) == 'custom_') {
+        if (substr($name, 0, 7) === 'custom_') {
           $id = substr($name, 7);
           if (!CRM_Core_BAO_CustomGroup::checkCustomField($id, ['Contribution', 'Membership'])) {
             continue;
           }
           // ignore component fields
         }
-        elseif (array_key_exists($name, $contribFields) || (substr($name, 0, 11) == 'membership_') || (substr($name, 0, 13) == 'contribution_')) {
+        elseif (array_key_exists($name, $contribFields) || (substr($name, 0, 11) === 'membership_') || (substr($name, 0, 13) == 'contribution_')) {
           continue;
         }
         $fields[$name] = $fieldInfo;
@@ -146,8 +146,9 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $billingDefaults = $this->getProfileDefaults('Billing', $contactID);
       $this->_defaults = array_merge($this->_defaults, $billingDefaults);
     }
-    if (!empty($this->_ccid) && !empty($this->_pendingAmount)) {
-      $this->_defaults['total_amount'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($this->_pendingAmount);
+    $balance = $this->getContributionBalance();
+    if ($balance) {
+      $this->_defaults['total_amount'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($balance);
     }
 
     /*
@@ -401,10 +402,9 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         CRM_Core_BAO_CMSUser::buildForm($this, $profileID, TRUE);
       }
     }
-    if ($this->_pcpId && empty($this->_ccid)) {
+    if ($this->getPcpID() && empty($this->_ccid)) {
       if (CRM_PCP_BAO_PCP::displayName($this->_pcpId)) {
         $pcp_supporter_text = CRM_PCP_BAO_PCP::getPcpSupporterText($this->_pcpId, $this->_id, 'contribute');
-        $this->assign('pcpSupporterText', $pcp_supporter_text);
       }
       $prms = ['id' => $this->_pcpId];
       CRM_Core_DAO::commonRetrieve('CRM_PCP_DAO_PCP', $prms, $pcpInfo);
@@ -420,6 +420,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         $this->addField('pcp_personal_note', ['entity' => 'ContributionSoft', 'context' => 'create', 'style' => 'height: 3em; width: 40em;']);
       }
     }
+    $this->assign('pcpSupporterText', $pcp_supporter_text ?? NULL);
     if (empty($this->_values['fee']) && empty($this->_ccid)) {
       throw new CRM_Core_Exception(ts('This page does not have any price fields configured or you may not have permission for them. Please contact the site administrator for more details.'));
     }
@@ -542,18 +543,74 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         }
         if (!empty($options)) {
           $label = (!empty($this->_membershipBlock) && $field['name'] === 'contribution_amount') ? ts('Additional Contribution') : $field['label'];
+          $extra = [];
+          $fieldID = (int) $field['id'];
+          if ($fieldID === $this->getPriceFieldOtherID()) {
+            $extra = [
+              'onclick' => 'useAmountOther("price_' . $this->getPriceFieldMainID() . '");',
+              'autocomplete' => 'off',
+            ];
+          }
+          if ($fieldID === $this->getPriceFieldMainID()) {
+            $extra = [
+              'onclick' => 'clearAmountOther("price_' . $this->getPriceFieldOtherID() . '");',
+            ];
+          }
+
           CRM_Price_BAO_PriceField::addQuickFormElement($form,
-            'price_' . $field['id'],
+            'price_' . $fieldID,
             $field['id'],
             FALSE,
             $field['is_required'] ?? FALSE,
             $label,
-            $options
+            $options,
+            [],
+            $extra
           );
         }
       }
     }
     $form->assign('ispricelifetime', $checklifetime);
+  }
+
+  /**
+   * Get the idea of the other amount field if the form is configured to offer it.
+   *
+   * The other amount field is an alternative to the configured radio options,
+   * specific to this form.
+   *
+   * @return int|null
+   */
+  private function getPriceFieldOtherID(): ?int {
+    if (!$this->isQuickConfig()) {
+      return NULL;
+    }
+    foreach ($this->order->getPriceFieldsMetadata() as $field) {
+      if ($field['name'] === 'other_amount') {
+        return (int) $field['id'];
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Get the idea of the other amount field if the form is configured to offer an other amount.
+   *
+   * The other amount field is an alternative to the configured radio options,
+   * specific to this form.
+   *
+   * @return int|null
+   */
+  private function getPriceFieldMainID(): ?int {
+    if (!$this->isQuickConfig() || !$this->getPriceFieldOtherID()) {
+      return NULL;
+    }
+    foreach ($this->order->getPriceFieldsMetadata() as $field) {
+      if ($field['name'] !== 'other_amount') {
+        return (int) $field['id'];
+      }
+    }
+    return NULL;
   }
 
   /**
@@ -1000,7 +1057,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     }
 
     if (isset($fields['selectProduct']) &&
-      $fields['selectProduct'] != 'no_thanks'
+      $fields['selectProduct'] !== 'no_thanks'
     ) {
       $productDAO = new CRM_Contribute_DAO_Product();
       $productDAO->id = $fields['selectProduct'];
@@ -1223,9 +1280,9 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         }
       }
     }
-
-    if (!empty($this->_ccid) && !empty($this->_pendingAmount)) {
-      $params['amount'] = $this->_pendingAmount;
+    $balance = $this->getContributionBalance();
+    if ($balance) {
+      $params['amount'] = $balance;
     }
     else {
       // from here on down, $params['amount'] holds a monetary value (or null) rather than an option ID
@@ -1425,24 +1482,11 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       }
     }
     $this->assign('dummyTitle', $dummyTitle);
-
+    $this->assign('pendingAmount', $this->getContributionBalance());
     if (empty($this->getExistingContributionID())) {
       return;
     }
-    if (!$this->getContactID()) {
-      CRM_Core_Error::statusBounce(ts("Returning since there is no contact attached to this contribution id."));
-    }
-
-    $paymentBalance = CRM_Contribute_BAO_Contribution::getContributionBalance($this->_ccid);
-    //bounce if the contribution is not pending.
-    if ((float) $paymentBalance <= 0) {
-      CRM_Core_Error::statusBounce(ts("Returning since contribution has already been handled."));
-    }
-    if (!empty($paymentBalance)) {
-      $this->_pendingAmount = $paymentBalance;
-      $this->assign('pendingAmount', $this->_pendingAmount);
-    }
-
+    // @todo - all this stuff is likely obsolete.
     if ($taxAmount = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $this->_ccid, 'tax_amount')) {
       $this->assign('taxAmount', $taxAmount);
     }
@@ -1451,6 +1495,29 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     $this->assign('lineItem', [$this->getPriceSetID() => $lineItems]);
     $this->assign('is_quick_config', $this->isQuickConfig());
     $this->assign('priceSetID', $this->getPriceSetID());
+  }
+
+  /**
+   * Get the balance amount if an existing contribution is being paid.
+   *
+   * @return float|null
+   *
+   * @throws \CRM_Core_Exception
+   */
+  private function getContributionBalance(): ?float {
+    if (empty($this->getExistingContributionID())) {
+      return NULL;
+    }
+    if (!$this->getContactID()) {
+      CRM_Core_Error::statusBounce(ts('Returning since there is no contact attached to this contribution id.'));
+    }
+
+    $paymentBalance = CRM_Contribute_BAO_Contribution::getContributionBalance($this->_ccid);
+    //bounce if the contribution is not pending.
+    if ((float) $paymentBalance <= 0) {
+      CRM_Core_Error::statusBounce(ts('Returning since contribution has already been handled.'));
+    }
+    return $paymentBalance;
   }
 
   /**
@@ -1474,7 +1541,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
    *
    * @param array $params
    *
-   * @return mixed
+   * @return bool
    * @throws \CRM_Core_Exception
    */
   protected function hasSeparateMembershipPaymentAmount($params) {

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -115,6 +115,8 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    * Pcp id
    *
    * @var int
+   *
+   * @internal use getPcpID().
    */
   public $_pcpId;
 
@@ -468,10 +470,9 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     $this->set('membershipBlock', $this->getMembershipBlock());
 
     // Handle PCP
-    $pcpId = CRM_Utils_Request::retrieve('pcpId', 'Positive', $this);
-    if ($pcpId) {
+    $pcpId = $this->getPcpID();
+    if ($this->getPcpID()) {
       $pcp = CRM_PCP_BAO_PCP::handlePcp($pcpId, 'contribute', $this->_values);
-      $this->_pcpId = $pcp['pcpId'];
       $this->_pcpBlock = $pcp['pcpBlock'];
       $this->_pcpInfo = $pcp['pcpInfo'];
     }
@@ -800,8 +801,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
           }
         }
 
-        $this->assign($name, $fields);
-
         if ($profileContactType && count($viewOnlyFileValues[$profileContactType])) {
           $this->assign('viewOnlyPrefixFileValues', $viewOnlyFileValues);
         }
@@ -810,6 +809,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         }
       }
     }
+    $this->assign($name, $fields ?? NULL);
   }
 
   /**
@@ -987,7 +987,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
               ];
             }
             $locDataURL = CRM_Utils_System::url('civicrm/ajax/permlocation', $args, FALSE, NULL, FALSE);
-            $form->assign('locDataURL', $locDataURL);
           }
           if (count($organizations) > 0) {
             $form->add('select', 'onbehalfof_id', '', CRM_Utils_Array::collect('name', $organizations));
@@ -1022,7 +1021,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
           CRM_Core_Permission::CREATE, NULL
         );
 
-        $form->assign('onBehalfOfFields', $profileFields);
         if (!empty($form->_submitValues['onbehalf'])) {
           if (!empty($form->_submitValues['onbehalfof_id'])) {
             $form->assign('submittedOnBehalf', $form->_submitValues['onbehalfof_id']);
@@ -1055,6 +1053,8 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         }
       }
     }
+    $form->assign('locDataURL', $locDataURL ?? NULL);
+    $form->assign('onBehalfOfFields', $profileFields ?? NULL);
 
   }
 
@@ -1404,6 +1404,18 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $lineItems[$id]['id'] = $id;
     }
     return $lineItems;
+  }
+
+  /**
+   * Get the PCP ID being contributed to.
+   *
+   * @return int|null
+   */
+  protected function getPcpID(): ?int {
+    if ($this->_pcpId === NULL) {
+      $this->_pcpId = CRM_Utils_Request::retrieve('pcpId', 'Positive', $this);
+    }
+    return $this->_pcpId ? (int) $this->_pcpId : NULL;
   }
 
 }

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -256,7 +256,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
       /* FIXME: failure! */
       return NULL;
     }
-
+    $label = $label ?: $field['label'];
     $is_pay_later = 0;
     $isQuickConfig = CRM_Price_BAO_PriceSet::isQuickConfig($field->price_set_id);
     if (isset($qf->_mode) && empty($qf->_mode)) {
@@ -273,10 +273,6 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
     $qf->assign('currency', $config->defaultCurrency);
     // get currency name for price field and option attributes
     $currencyName = $config->defaultCurrency;
-
-    if (!isset($label)) {
-      $label = (!empty($qf->_membershipBlock) && $field->name === 'contribution_amount') ? ts('Additional Contribution') : $field->label;
-    }
 
     if (isset($qf->_online) && $qf->_online) {
       $useRequired = FALSE;

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -889,13 +889,11 @@ class CRM_Profile_Form extends CRM_Core_Form {
     $this->setDefaultsValues();
 
     $action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, NULL);
-
-    if ($this->_mode == self::MODE_CREATE || $this->_mode == self::MODE_EDIT) {
+    $isCreateOrEditMode = $this->_mode == self::MODE_CREATE || $this->_mode == self::MODE_EDIT;
+    if ($isCreateOrEditMode) {
       CRM_Core_BAO_CMSUser::buildForm($this, $this->_gid, $emailPresent, $action);
     }
-    else {
-      $this->assign('showCMS', FALSE);
-    }
+    $this->assign('showCMS', $isCreateOrEditMode);
 
     $this->assign('groupId', $this->_gid);
 

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -17,12 +17,10 @@
   <script type="text/javascript">
 
     // Putting these functions directly in template so they are available for standalone forms
-    function useAmountOther() {
-      var priceset = {/literal}{if $contriPriceset}'{$contriPriceset}'{else}0{/if}{literal};
-
-      for( i=0; i < document.Main.elements.length; i++ ) {
+    function useAmountOther(mainPriceFieldName) {
+     for( i=0; i < document.Main.elements.length; i++ ) {
         element = document.Main.elements[i];
-        if ( element.type == 'radio' && element.name == priceset ) {
+        if ( element.type == 'radio' && element.name === mainPriceFieldName ) {
           if (element.value == '0' ) {
             element.click();
           }
@@ -33,12 +31,9 @@
       }
     }
 
-    function clearAmountOther() {
-      var priceset = {/literal}{if $priceset}'#{$priceset}'{else}0{/if}{literal}
-      if( priceset ){
-        cj(priceset).val('');
-        cj(priceset).blur();
-      }
+    function clearAmountOther(otherPriceFieldName) {
+      cj('#' + otherPriceFieldName).val('');
+      cj('#' + otherPriceFieldName).blur();
       if (document.Main.amount_other == null) return; // other_amt field not present; do nothing
       document.Main.amount_other.value = "";
     }
@@ -71,7 +66,7 @@
     </div>
     {include file="CRM/common/cidzero.tpl"}
 
-    {if $islifetime or $ispricelifetime}
+    {if $isShowMembershipBlock && ($islifetime or $ispricelifetime)}
       <div class="help">{ts}You have a current Lifetime Membership which does not need to be renewed.{/ts}</div>
     {/if}
 
@@ -118,13 +113,13 @@
               {$form.pledge_frequency_unit.html}<span id="pledge_installments_num">&nbsp;{ts}for{/ts}&nbsp;{$form.pledge_installments.html}&nbsp;{ts}installments.{/ts}</span>
             </div>
             <div class="clear"></div>
-            {if $start_date_editable}
+            {if array_key_exists('start_date', $form) && $start_date_editable}
               {if $is_date}
                 <div class="label">{$form.start_date.label}</div><div class="content">{$form.start_date.html}</div>
               {else}
                 <div class="label">{$form.start_date.label}</div><div class="content">{$form.start_date.html}</div>
               {/if}
-            {else}
+            {elseif array_key_exists('start_date', $form)}
               <div class="label">{$form.start_date.label}</div>
               <div class="content">{$start_date_display|crmDate:'%b %e, %Y'}</div>
             {/if}


### PR DESCRIPTION
Overview
----------------------------------------
[Php8.x fixes on Main online contribution page](https://github.com/civicrm/civicrm-core/commit/9faf023919405283a52bba24ead59ff9c2d16895)

Before
----------------------------------------
- notices on 'contriPriceFieldId' and 'priceset' (not page 3), undefined property `_pendingAmount`, various other minor notices
 
After
----------------------------------------
Some notices & undefined properties fix - notably the 2 above. For the first it relates to the shipped contribution page 3 - the 'other amount' field should result in the radio moving to 'other amount' when selected & clear the text amount when a radio is selected.

Technical Details
----------------------------------------
The js fix is the most siginificant in here - the approach is to move the form-specific aspects of it back to the form - this will also make it easier to reduce undefined property checks on related forms

Comments
----------------------------------------
@demeritcowboy this form hasn't had much clean up love - I tried to stop slightly short of having my soul destroyed but may not have succeeded. There is still a screed of notices - if my soul starts to grow back a bit I may try to tackle some of them