### PR TITLE
[REF] CRM_Event_PseudoConstant - Cleanup redundant caching

### DIFF
--- a/CRM/Event/PseudoConstant.php
+++ b/CRM/Event/PseudoConstant.php
@@ -16,58 +16,9 @@
  */
 
 /**
- * This class holds all the Pseudo constants that are specific to Event. This avoids
- * polluting the core class and isolates the Event
+ * @deprecated functions. Use the API instead.
  */
 class CRM_Event_PseudoConstant extends CRM_Core_PseudoConstant {
-
-  /**
-   * Event
-   *
-   * @var array
-   */
-  private static $event;
-
-  /**
-   * Participant Status
-   *
-   * @var array
-   */
-  private static $participantStatus;
-
-  /**
-   * Participant Role
-   *
-   * @var array
-   */
-  private static $participantRole;
-
-  /**
-   * Participant Listing
-   * @var array
-   * @deprecated
-   */
-  private static $participantListing;
-
-  /**
-   * Event Type.
-   *
-   * @var array
-   */
-  private static $eventType;
-
-  /**
-   * Event template titles
-   * @var array
-   */
-  private static $eventTemplates;
-
-  /**
-   * Personal campaign pages
-   * @var array
-   * @deprecated
-   */
-  private static $pcPage;
 
   /**
    * Get all events
@@ -81,28 +32,16 @@ class CRM_Event_PseudoConstant extends CRM_Core_PseudoConstant {
    *   array of all events if any
    */
   public static function event($id = NULL, $all = FALSE, $condition = NULL) {
-    $key = "{$id}_{$all}_{$condition}";
-
-    if (!isset(self::$event[$key])) {
-      self::$event[$key] = [];
-    }
-
-    if (!self::$event[$key]) {
-      CRM_Core_PseudoConstant::populate(self::$event[$key],
-        'CRM_Event_DAO_Event',
-        $all, 'title', 'is_active', $condition, NULL
-      );
-    }
+    $options = [];
+    CRM_Core_PseudoConstant::populate($options,
+      'CRM_Event_DAO_Event',
+      $all, 'title', 'is_active', $condition, NULL
+    );
 
     if ($id) {
-      if (array_key_exists($id, self::$event[$key])) {
-        return self::$event[$key][$id];
-      }
-      else {
-        return NULL;
-      }
+      return $options[$id] ?? NULL;
     }
-    return self::$event[$key];
+    return $options;
   }
 
   /**
@@ -119,26 +58,17 @@ class CRM_Event_PseudoConstant extends CRM_Core_PseudoConstant {
    * @return array|string
    *   array reference of all participant statuses if any, or single value if $id was passed
    */
-  public static function &participantStatus($id = NULL, $cond = NULL, $retColumn = 'name') {
-    if (self::$participantStatus === NULL) {
-      self::$participantStatus = [];
-    }
-
-    $index = $cond ?: 'No Condition';
-    $index = "{$index}_{$retColumn}";
-    if (empty(self::$participantStatus[$index])) {
-      self::$participantStatus[$index] = [];
-      CRM_Core_PseudoConstant::populate(self::$participantStatus[$index],
-        'CRM_Event_DAO_ParticipantStatusType',
-        FALSE, $retColumn, 'is_active', $cond, 'weight'
-      );
-    }
+  public static function participantStatus($id = NULL, $cond = NULL, $retColumn = 'name') {
+    $statuses = [];
+    CRM_Core_PseudoConstant::populate($statuses,
+      'CRM_Event_DAO_ParticipantStatusType',
+      FALSE, $retColumn, 'is_active', $cond, 'weight'
+    );
 
     if ($id) {
-      return self::$participantStatus[$index][$id];
+      return $statuses[$id] ?? NULL;
     }
-
-    return self::$participantStatus[$index];
+    return $statuses;
   }
 
   /**
@@ -161,13 +91,9 @@ class CRM_Event_PseudoConstant extends CRM_Core_PseudoConstant {
    * @return array
    *   Array of status classes, keyed by status type
    */
-  public static function &participantStatusClass() {
-    static $statusClasses = NULL;
-
-    if ($statusClasses === NULL) {
-      self::populate($statusClasses, 'CRM_Event_DAO_ParticipantStatusType', TRUE, 'class');
-    }
-
+  public static function participantStatusClass() {
+    $statusClasses = [];
+    self::populate($statusClasses, 'CRM_Event_DAO_ParticipantStatusType', TRUE, 'class');
     return $statusClasses;
   }
 
@@ -182,26 +108,14 @@ class CRM_Event_PseudoConstant extends CRM_Core_PseudoConstant {
    * @return array|string
    *   array reference of all participant roles if any
    */
-  public static function &participantRole($id = NULL, $cond = NULL) {
-    $index = $cond ?: 'No Condition';
-    if (empty(self::$participantRole[$index])) {
-      self::$participantRole[$index] = [];
-
-      $condition = NULL;
-
-      if ($cond) {
-        $condition = "AND $cond";
-      }
-
-      self::$participantRole[$index] = CRM_Core_OptionGroup::values('participant_role', FALSE, FALSE,
-        FALSE, $condition
-      );
-    }
+  public static function participantRole($id = NULL, $cond = NULL) {
+    $condition = empty($cond) ? NULL : "AND $cond";
+    $options = CRM_Core_OptionGroup::values('participant_role', FALSE, FALSE, FALSE, $condition);
 
     if ($id) {
-      return self::$participantRole[$index][$id];
+      return $options[$id] ?? NULL;
     }
-    return self::$participantRole[$index];
+    return $options;
   }
 
   /**
@@ -212,18 +126,14 @@ class CRM_Event_PseudoConstant extends CRM_Core_PseudoConstant {
    * @return array|string
    *   array reference of all participant listings if any
    */
-  public static function &participantListing($id = NULL) {
+  public static function participantListing($id = NULL) {
     CRM_Core_Error::deprecatedFunctionWarning('Function participantListing will be removed');
-    if (!self::$participantListing) {
-      self::$participantListing = [];
-      self::$participantListing = CRM_Core_OptionGroup::values('participant_listing');
-    }
+    $options = CRM_Core_OptionGroup::values('participant_listing');
 
     if ($id) {
-      return self::$participantListing[$id];
+      return $options[$id];
     }
-
-    return self::$participantListing;
+    return $options;
   }
 
   /**
@@ -234,17 +144,13 @@ class CRM_Event_PseudoConstant extends CRM_Core_PseudoConstant {
    * @return array|string
    *   array reference of all event types.
    */
-  public static function &eventType($id = NULL) {
-    if (!self::$eventType) {
-      self::$eventType = [];
-      self::$eventType = CRM_Core_OptionGroup::values('event_type');
-    }
+  public static function eventType($id = NULL) {
+    $options = CRM_Core_OptionGroup::values('event_type');
 
     if ($id) {
-      return self::$eventType[$id];
+      return $options[$id] ?? NULL;
     }
-
-    return self::$eventType;
+    return $options;
   }
 
   /**
@@ -257,21 +163,20 @@ class CRM_Event_PseudoConstant extends CRM_Core_PseudoConstant {
    *
    * @deprecated Use the API instead
    */
-  public static function &eventTemplates($id = NULL) {
+  public static function eventTemplates($id = NULL) {
     CRM_Core_Error::deprecatedFunctionWarning('Use the api');
-    if (!self::$eventTemplates) {
-      CRM_Core_PseudoConstant::populate(self::$eventTemplates,
-        'CRM_Event_DAO_Event',
-        FALSE,
-        'template_title',
-        'is_active',
-        'is_template = 1'
-      );
-    }
+    $options = [];
+    CRM_Core_PseudoConstant::populate($options,
+      'CRM_Event_DAO_Event',
+      FALSE,
+      'template_title',
+      'is_active',
+      'is_template = 1'
+    );
     if ($id) {
-      return self::$eventTemplates[$id];
+      return $options[$id];
     }
-    return self::$eventTemplates;
+    return $options;
   }
 
   /**
@@ -295,18 +200,17 @@ class CRM_Event_PseudoConstant extends CRM_Core_PseudoConstant {
    * @return array
    *   array reference of all pcp if any
    */
-  public static function &pcPage($id = NULL) {
+  public static function pcPage($id = NULL) {
     CRM_Core_Error::deprecatedFunctionWarning('Function pcPage will be removed');
-    if (!self::$pcPage) {
-      CRM_Core_PseudoConstant::populate(self::$pcPage,
-        'CRM_PCP_DAO_PCP',
-        FALSE, 'title'
-      );
-    }
+    $options = [];
+    CRM_Core_PseudoConstant::populate($options,
+      'CRM_PCP_DAO_PCP',
+      FALSE, 'title'
+    );
     if ($id) {
-      return self::$pcPage[$id] ?? NULL;
+      return $options[$id] ?? NULL;
     }
-    return self::$pcPage;
+    return $options;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Cleans up memory-wasting double-caching.

Before
----------
Values are cached twice
Functions prefixed with the old php4-era `&`.

After
-------
Values are cached once.
Function signatures cleaned up.

Technical Details
------------

All these functions were caching the output of functions that already use caching.
At best this is a dumb waste of memory.
At worst it can cause bugs when the 2 caches don't get flushed together.
