### PR TITLE
Remove ids from membership functions

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -1041,7 +1041,6 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
     $changeToday = NULL;
     $numRenewTerms = 1;
     $format = '%Y%m%d';
-    $ids = [];
     $isPayLater = NULL;
     $memParams = $this->getCurrentRowMembershipParams();
     $currentMembership = $this->getCurrentMembership();
@@ -1061,7 +1060,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
         $memParams[$dateType] = $memParams[$dateType] ?: ($dates[$dateType] ?? NULL);
       }
 
-      $ids['membership'] = $currentMembership['id'];
+      $memParams['id'] = $currentMembership['id'];
 
       //set the log start date.
       $memParams['log_start_date'] = CRM_Utils_Date::customFormat($dates['log_start_date'], $format);
@@ -1091,7 +1090,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
       $memParams['log_start_date'] = CRM_Utils_Date::customFormat($dates['log_start_date'], $format);
 
       if (!empty($currentMembership['id'])) {
-        $ids['membership'] = $currentMembership['id'];
+        $memParams['id'] = $currentMembership['id'];
       }
       $memParams['membership_activity_status'] = $isPayLater ? 'Scheduled' : 'Completed';
     }
@@ -1111,7 +1110,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
     // Load all line items & process all in membership. Don't do in contribution.
     // Relevant tests in api_v3_ContributionPageTest.
     // @todo stop passing $ids (membership and userId may be set by this point)
-    $membership = CRM_Member_BAO_Membership::create($memParams, $ids);
+    $membership = CRM_Member_BAO_Membership::create($memParams);
 
     // not sure why this statement is here, seems quite odd :( - Lobo: 12/26/2010
     // related to: http://forum.civicrm.org/index.php/topic,11416.msg49072.html#msg49072

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2857,7 +2857,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $statusFormat = '%Y-%m-%d';
     $membershipTypeDetails = CRM_Member_BAO_MembershipType::getMembershipType($membershipTypeID);
     $dates = [];
-    $ids = [];
 
     // CRM-7297 - allow membership type to be be changed during renewal so long as the parent org of new membershipType
     // is the same as the parent org of an existing membership of the contact
@@ -2921,7 +2920,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         }
 
         if (!empty($currentMembership['id'])) {
-          $ids['membership'] = $currentMembership['id'];
+          $memParams['id'] = $currentMembership['id'];
         }
         $memParams = array_merge($currentMembership, $memParams);
         $memParams['membership_type_id'] = $membershipTypeID;
@@ -2963,7 +2962,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         }
 
         if (!empty($currentMembership['id'])) {
-          $ids['membership'] = $currentMembership['id'];
+          $memParams['id'] = $currentMembership['id'];
         }
         $memParams['membership_activity_status'] = ($pending || $isPayLater) ? 'Scheduled' : 'Completed';
       }
@@ -3031,15 +3030,13 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       // @todo this param is likely unused now.
       $memParams['is_for_organization'] = TRUE;
     }
-    $params['modified_id'] = $modifiedID ?? $contactID;
 
     $memParams['contribution'] = $contribution;
     $memParams['custom'] = $customFieldsFormatted;
     // Load all line items & process all in membership. Don't do in contribution.
     // Relevant tests in api_v3_ContributionPageTest.
     $memParams['line_item'] = $lineItems;
-    // @todo stop passing $ids (membership and userId may be set by this point)
-    $membership = CRM_Member_BAO_Membership::create($memParams, $ids);
+    $membership = CRM_Member_BAO_Membership::create($memParams);
 
     // not sure why this statement is here, seems quite odd :( - Lobo: 12/26/2010
     // related to: http://forum.civicrm.org/index.php/topic,11416.msg49072.html#msg49072

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -726,7 +726,6 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
    */
   public function processMembership($memParams, $changeToday, $numRenewTerms, $pending) {
     $allStatus = CRM_Member_PseudoConstant::membershipStatus();
-    $ids = [];
     $currentMembership = civicrm_api3('Membership', 'getsingle', ['id' => $memParams['id']]);
 
     // Do NOT do anything.
@@ -758,12 +757,12 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     if ($isMembershipCurrent) {
       // CURRENT Membership
       if (!empty($currentMembership['id'])) {
-        $ids['membership'] = $currentMembership['id'];
+        $memParams['id'] = $currentMembership['id'];
       }
     }
 
     // @todo stop passing $ids (membership and userId may be set by this point)
-    $membership = CRM_Member_BAO_Membership::create($memParams, $ids);
+    $membership = CRM_Member_BAO_Membership::create($memParams);
 
     // not sure why this statement is here, seems quite odd :( - Lobo: 12/26/2010
     // related to: http://forum.civicrm.org/index.php/topic,11416.msg49072.html#msg49072

--- a/api/v3/Membership.php
+++ b/api/v3/Membership.php
@@ -120,19 +120,15 @@ function civicrm_api3_membership_create($params) {
   }
 
   // Fixme: This code belongs in the BAO
-  $ids = [];
   if (empty($params['id'])) {
     $params['action'] = CRM_Core_Action::ADD;
   }
   else {
     // edit mode
     $params['action'] = CRM_Core_Action::UPDATE;
-    // @todo remove $ids['membership'] is required in CRM_Price_BAO_LineItem::processPriceSet
-    $ids['membership'] = $params['id'];
   }
 
-  // @todo stop passing $ids (membership and userId may be set above)
-  $membershipBAO = CRM_Member_BAO_Membership::create($params, $ids);
+  $membershipBAO = CRM_Member_BAO_Membership::create($params);
 
   if (property_exists($membershipBAO, 'is_error')) {
     // In case of no valid status for given dates, $membershipBAO


### PR DESCRIPTION
Overview
----------------------------------------
Remove legacy `$ids` from membership functions

Before
----------------------------------------
Legacy `$ids` passed in

After
----------------------------------------
Legacy `$ids` not passed in

Technical Details
----------------------------------------

Comments
----------------------------------------

