### PR TITLE
Fix online contribution form Confirm page  to get text from processor

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -565,23 +565,20 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $this->assign('is_separate_payment', $this->isSeparateMembershipPayment());
 
     $this->assign('priceSetID', $this->_priceSetId);
-
-    // The concept of contributeMode is deprecated.
-    if ($this->_contributeMode === 'notify' ||
-      $this->_amount <= 0.0 || $this->_params['is_pay_later']
-    ) {
-      $contribButton = ts('Continue');
-    }
-    elseif (!empty($this->_ccid)) {
-      $contribButton = ts('Make Payment');
-    }
-    else {
-      $contribButton = ts('Make Contribution');
-    }
-    $this->assign('button', $contribButton);
+    $contributionButtonText = $this->getPaymentProcessorObject()->getText('contributionPageButtonText', [
+      'is_payment_to_existing' => !empty($this->_ccid),
+      'amount' => $this->_amount,
+    ]);
+    $this->assign('button', $contributionButtonText);
 
     $this->assign('continueText',
       $this->getPaymentProcessorObject()->getText('contributionPageContinueText', [
+        'is_payment_to_existing' => !empty($this->_ccid),
+        'amount' => $this->_amount,
+      ])
+    );
+    $this->assign('confirmText',
+      $this->getPaymentProcessorObject()->getText('contributionPageConfirmText', [
         'is_payment_to_existing' => !empty($this->_ccid),
         'amount' => $this->_amount,
       ])
@@ -590,7 +587,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $this->addButtons([
       [
         'type' => 'next',
-        'name' => $contribButton,
+        'name' => $contributionButtonText,
         'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
         'isDefault' => TRUE,
       ],

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -504,7 +504,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     $this->set('amount_block_is_active', $this->isFormSupportsNonMembershipContributions());
 
     $this->_contributeMode = $this->get('contributeMode');
-    $this->assign('contributeMode', $this->_contributeMode);
 
     //assigning is_monetary and is_email_receipt to template
     $this->assign('is_monetary', $this->_values['is_monetary']);

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -591,6 +591,24 @@ abstract class CRM_Core_Payment {
       case 'contributionPageContinueText':
         return ts('Click the <strong>Continue</strong> button to proceed with the payment.');
 
+      case 'contributionPageConfirmText':
+        if ($params['amount'] <= 0.0) {
+          return '';
+        }
+        if ((int) $this->_paymentProcessor['billing_mode'] !== 4) {
+          return ts('Your contribution will not be completed until you click the <strong>%1</strong> button. Please click the button one time only.', [1 => ts('Make Contribution')]);
+        }
+        return '';
+
+      case 'contributionPageButtonText':
+        if ($params['amount'] <= 0.0 || (int) $this->_paymentProcessor['billing_mode'] === 4) {
+          return ts('Continue');
+        }
+        if ($params['is_payment_to_existing']) {
+          return ts('Make Payment');
+        }
+        return ts('Make Contribution');
+
       case 'cancelRecurDetailText':
         if ($params['mode'] === 'auto_renew') {
           return ts('Click the button below if you want to cancel the auto-renewal option for your %1 membership. This will not cancel your membership. However you will need to arrange payment for renewal when your membership expires.',

--- a/CRM/Core/Payment/Manual.php
+++ b/CRM/Core/Payment/Manual.php
@@ -272,13 +272,16 @@ class CRM_Core_Payment_Manual extends CRM_Core_Payment {
    *
    * @return string
    */
-  public function getText($context, $params) {
+  public function getText($context, $params): string {
     switch ($context) {
       case 'contributionPageContinueText':
-        if ($params['amount'] <= 0) {
-          return ts('To complete this transaction, click the <strong>Continue</strong> button below.');
-        }
-        return ts('To complete your contribution, click the <strong>Continue</strong> button below.');
+        return '';
+
+      case 'contributionPageButtonText':
+        return ts('Continue');
+
+      case 'contributionPageConfirmText':
+        return '';
 
       default:
         return parent::getText($context, $params);

--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -276,14 +276,10 @@
     </fieldset>
   {/if}
 
-  {if $contributeMode NEQ 'notify' and $is_monetary and ( $amount GT 0 OR $minimum_fee GT 0 )} {* In 'notify mode, contributor is taken to processor payment forms next *}
+  {if $confirmText}
     <div class="messages status continue_instructions-section">
       <p>
-        {if $is_pay_later OR $amount LE 0.0}
-          {ts 1=$button}Your transaction will not be completed until you click the <strong>%1</strong> button. Please click the button one time only.{/ts}
-        {else}
-          {ts 1=$button}Your contribution will not be completed until you click the <strong>%1</strong> button. Please click the button one time only.{/ts}
-        {/if}
+        {$confirmText}
       </p>
     </div>
   {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Fix online contributioen form Confirm page  to get text from processor

Note there is a deliberate change to pay later (cos it didn't make sense before) but otherwise this is just a refactor to get rid of `contributeMode`

Before
----------------------------------------
PayPal Std with $$
![image](https://github.com/civicrm/civicrm-core/assets/336308/002d2e8f-9e03-47b5-bdff-ddef181ce171)

Paypal Std - free

![image](https://github.com/civicrm/civicrm-core/assets/336308/38256e37-9862-44aa-8104-afb2f001c604)

Paylater (broken actually)  - with money
![image](https://github.com/civicrm/civicrm-core/assets/336308/78f85df8-cd93-49fa-acc1-f4e58a19bccf)

Pay later - free
![image](https://github.com/civicrm/civicrm-core/assets/336308/452fe9b8-4a1b-4e34-bc6a-26ebf514f7c5)

Dummy - free
![image](https://github.com/civicrm/civicrm-core/assets/336308/c12c8405-3928-4478-b2e6-0661b31c32f9)

Dummy - with payment
![image](https://github.com/civicrm/civicrm-core/assets/336308/6b87f848-3759-4fee-9bb0-a550d3791a67)


After
----------------------------------------

Paypal std with $
![image](https://github.com/civicrm/civicrm-core/assets/336308/57fcf1d8-f7e6-4f93-b908-5a3bd246a746)


Paypal Std free
![image](https://github.com/civicrm/civicrm-core/assets/336308/753e8e9b-1398-4f46-818a-5a238f23c84e)


Pay later (with money)

![image](https://github.com/civicrm/civicrm-core/assets/336308/9b868cc5-cf0a-4cee-8539-20fe6c972557)

Pay later free

![image](https://github.com/civicrm/civicrm-core/assets/336308/27564140-72d2-49d9-ae6c-03bfb40accc0)

Dummy free
![image](https://github.com/civicrm/civicrm-core/assets/336308/385b6f6f-75d2-4015-9520-5223e49beb8b)

Dummy with payment

![image](https://github.com/civicrm/civicrm-core/assets/336308/0bce8742-9a94-4f7c-8900-11e0b28c38ff)



Technical Details
----------------------------------------

Comments
----------------------------------------
@mattwire once this change is made the only way the contribution form still uses 'contributeMode' is in deciding whether to call the `postProcess` hook before `doPayment` because it will otherwise not be called when redirect happens.

This seems fairly easy to move to the Payment object - I'm just not quite sure on the name...
spitballing

`supportsNoReturn()`
`supportsFormHookBeforePayment()`
`isNotReturnOnPayment()`

thoughts?

![image](https://github.com/civicrm/civicrm-core/assets/336308/8a78b992-78e4-4ea7-922b-c5cc575fb999)

