### PR TITLE
Allow to specify API4 job entity in Edit Job form

### DIFF
--- a/templates/CRM/Admin/Form/Job.tpl
+++ b/templates/CRM/Admin/Form/Job.tpl
@@ -35,57 +35,11 @@
     <tr class="crm-job-form-block-run_frequency">
         <td class="label">{$form.run_frequency.label}</td><td>{$form.run_frequency.html}</td>
     </tr>
+    <tr class="crm-job-form-block-api_entity">
+      <td class="label">{$form.api_entity.label}</td><td>{$form.api_entity.html}</td>
+    </tr>
     <tr class="crm-job-form-block-api_action">
-        <td class="label"><label>{ts}API call:{/ts}</label></td>
-        <td>
-
-        <div id="fname"><br/>
-        </div>
-        <select name="api_entity" type="text" id="api_entity" class="crm-form-select required">
-          {crmAPI entity="Entity" var="entities"}
-          {foreach from=$entities.values item=entity}
-            <option value="{$entity}"{if $entity eq $form.api_entity.value} selected="selected"{/if}>{$entity}</option>
-          {/foreach}
-        </select>
-        {$form.api_action.html}
-
-        <div class="description">{ts}Put in the API method name. You need to enter pieces of full API function name as described in the documentation.{/ts}</div>
-<script>
-{literal}
-CRM.$(function($) {
-  function assembleName( ) {
-
-    // dunno yet
-    var apiName = "";
-
-    // building prefix
-    if( $('#api_action').val() == '' ) {
-      $('#fname').html( "<em>API name will start appearing here as you type in fields below.</em>" );
-      return;
-    }
-
-    var apiPrefix = 'api'
-
-    // building entity
-    var apiEntity = $('#api_entity').val().replace( /([A-Z])/g, function($1) {
-      return $1.toLowerCase();
-    });
-    // building action
-    var apiAction = $('#api_action').val().replace(/(\_[a-z])/g, function($1) {return $1.toUpperCase().replace('_','');});
-    apiName = apiPrefix + '.' + apiEntity + '.' + apiAction;
-    $('#fname').text( apiName );
-  }
-
-  // bind to different events to build API name live
-  $('#api_entity').change(assembleName)
-  $('#api_action').change(assembleName).keyup(assembleName);
-  assembleName();
-});
-
-{/literal}
-</script>
-
-      </td>
+      <td class="label">{$form.api_action.label}</td><td>{$form.api_action.html}</td>
     </tr>
     <tr class="crm-job-form-block-parameters">
       <td class="label">{$form.parameters.label}<br />{docURL page="user/initial-set-up/scheduled-jobs/#parameters"}</td>


### PR DESCRIPTION
Overview
----------------------------------------
This allows you to specify an API4 entity in Edit Job form.

Previously there was some nice complicated javascript to hide the actual fields and give you a dropdown list and a fancy concatenated function name that doesn't mean anything... Removed all that and exposed the API entity and action text fields. I'm sure someone setting up a scheduled job can be trusted to type in those by hand.

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/2052161/fd449712-5cdc-4b85-88dd-2bdf9ffd74e1)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/2052161/e07444b2-03a4-4015-a1d8-5762d6ac9b5a)


Technical Details
----------------------------------------
With this change you can setup and run an API4 scheduled job by putting "version=4" in the parameters.

Comments
----------------------------------------
