### PR TITLE
Fix unreleased regression on premium block, notices

### DIFF
--- a/CRM/Contribute/BAO/Premium.php
+++ b/CRM/Contribute/BAO/Premium.php
@@ -114,6 +114,7 @@ class CRM_Contribute_BAO_Premium extends CRM_Contribute_DAO_Premium {
           else {
             CRM_Core_DAO::storeValues($productDAO, $products[$productDAO->id]);
           }
+          $products[$productDAO->id] += ['thumbnail' => '', 'image' => ''];
         }
         $options = $temp = [];
         $temp = explode(',', $productDAO->options);
@@ -127,10 +128,10 @@ class CRM_Contribute_BAO_Premium extends CRM_Contribute_DAO_Premium {
       if (count($products)) {
         $form->assign('showPremium', $formItems);
         $form->assign('showSelectOptions', $formItems);
-        $form->assign('products', $products);
         $form->assign('premiumBlock', $premiumBlock);
       }
     }
+    $form->assign('products', $products ?? NULL);
   }
 
   /**

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -487,10 +487,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $this->assign('linkText', $linkText);
     }
 
-    //set pledge block if block id is set
-    if (!empty($this->_values['pledge_block_id'])) {
-      $this->assign('pledgeBlock', TRUE);
-    }
+    $this->assign('pledgeBlock', !empty($this->_values['pledge_block_id']));
 
     // @todo - move this check to `getMembershipBlock`
     if (!$this->isFormSupportsNonMembershipContributions() &&

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -252,7 +252,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
     $freezeOptions = [],
     array $extra = []
   ) {
-
+    $incomingExtra = $extra;
     $field = new CRM_Price_DAO_PriceField();
     $field->id = $fieldId;
     if (!$field->find(TRUE)) {
@@ -367,13 +367,13 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           else {
             $visibility_id = self::getVisibilityOptionID('public');
           }
-          $extra += [
+          $extra = [
             'price' => json_encode([$elementName, $priceOptionText['priceVal']]),
             'data-amount' => $opt[$valueFieldName],
             'data-currency' => $currencyName,
             'data-price-field-values' => json_encode($customOption),
             'visibility' => $visibility_id,
-          ];
+          ] + $incomingExtra;
           // @todo - move this back to the only calling function on Contribution_Form_Main.php
           if ($field->name == 'membership_amount') {
             $extra += [

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -183,7 +183,7 @@
         {include file="CRM/common/CMSUser.tpl"}
       </div>
       <div class="crm-public-form-item crm-section premium_block-section">
-        {include file="CRM/Contribute/Form/Contribution/PremiumBlock.tpl" context="makeContribution"}
+        {include file="CRM/Contribute/Form/Contribution/PremiumBlock.tpl" context="makeContribution" preview=false}
       </div>
 
       {if $honoreeProfileFields && $honoreeProfileFields|@count}

--- a/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
@@ -114,7 +114,7 @@
     {literal}
     <script>
       CRM.$(function($) {
-        var is_separate_payment = {/literal}{if $membershipBlock.is_separate_payment}{$membershipBlock.is_separate_payment}{else}0{/if}{literal};
+        var is_separate_payment = {/literal}{if $isShowMembershipBlock && $membershipBlock.is_separate_payment}{$membershipBlock.is_separate_payment}{else}0{/if}{literal};
 
         // select a new premium
         function select_premium(premium_id) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix unreleased regression on premium block, notices

Before
----------------------------------------
Within current master mishandling of an array led to the premium being unselectable

![image](https://github.com/civicrm/civicrm-core/assets/336308/fa7696aa-9a13-473b-9351-de62271d21ed)

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/0a9966c2-2f32-4a9d-a105-73dcc0b52b5f)


Technical Details
----------------------------------------
The array `$extra` was originally reset each loop. IN order to pass external params to it it became an input -but the reset-per-loop was lost & hence some relevant data. This re-instates

Comments
----------------------------------------
