### PR TITLE
Angular - Always load CiviMail modules if component is enabled

### DIFF
--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -137,14 +137,6 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
    * @see CRM_Utils_Hook::angularModules
    */
   public function getAngularModules() {
-    // load angular files only if valid permissions are granted to the user
-    if (!CRM_Core_Permission::check('access CiviMail')
-      && !CRM_Core_Permission::check('create mailings')
-      && !CRM_Core_Permission::check('schedule mailings')
-      && !CRM_Core_Permission::check('approve mailings')
-    ) {
-      return [];
-    }
     global $civicrm_root;
 
     $result = [];


### PR DESCRIPTION
Overview
----------------------------------------
Loads CiviMail Angular modules regardless of user permissions.

Before
----------------------------------------
Unnecessary permission checks before loading modules. This is nonstandard, and permissions are checked in other places.

After
----------------------------------------
Just load the modules.

Technical Details
----------------------------------------
Instead of checking for CiviMail permissions, the module loader should just check if the component is enabled, and that's already happening here:
https://github.com/civicrm/civicrm-core/blob/5f05c2d0274d4117396540eb926f906f1ffc393a/Civi/Angular/Manager.php#L131-L133

Comments
--------

This should be the last blocker to #27783 to allow modules to be cached independently of user role or other runtime conditions.