### PR TITLE
(dev/core#4703) Groups - "Parent" field lost during re-save

### DIFF
--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -256,15 +256,9 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
     //build custom data
     CRM_Custom_Form_CustomData::buildQuickForm($this);
 
-    $doParentCheck = FALSE;
-    if (CRM_Core_Permission::isMultisiteEnabled()) {
-      $doParentCheck = !($this->_id && CRM_Core_BAO_Domain::isDomainGroup($this->_id));
-    }
-
     $options = [
       'selfObj' => $this,
       'parentGroups' => $parentGroups,
-      'doParentCheck' => $doParentCheck,
     ];
     $this->addFormRule(['CRM_Group_Form_Edit', 'formRule'], $options);
   }
@@ -283,28 +277,7 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
   public static function formRule($fields, $fileParams, $options) {
     $errors = [];
 
-    $doParentCheck = $options['doParentCheck'];
     $self = &$options['selfObj'];
-
-    if ($doParentCheck) {
-      $parentGroups = $options['parentGroups'];
-
-      $grpRemove = 0;
-      foreach ($fields as $key => $val) {
-        if (substr($key, 0, 20) == 'remove_parent_group_') {
-          $grpRemove++;
-        }
-      }
-
-      $grpAdd = 0;
-      if (!empty($fields['parents'])) {
-        $grpAdd++;
-      }
-
-      if ((count($parentGroups) >= 1) && (($grpRemove - $grpAdd) >= count($parentGroups))) {
-        $errors['parents'] = ts('Make sure at least one parent group is set.');
-      }
-    }
 
     // do check for both name and title uniqueness
     if (!empty($fields['title'])) {

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -201,6 +201,8 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
       }
     }
 
+    $parentGroupIds = explode(',', $this->_groupValues['parents']);
+    $defaults['parents'] = $parentGroupIds;
     if (empty($defaults['parents'])) {
       $defaults['parents'] = CRM_Core_BAO_Domain::getGroupId();
     }
@@ -402,9 +404,6 @@ WHERE  title = %1
         $parentGroups[$parentGroupId] = $groupNames[$parentGroupId];
         if (array_key_exists($parentGroupId, $groupNames)) {
           $parentGroupElements[$parentGroupId] = $groupNames[$parentGroupId];
-          $form->addElement('checkbox', "remove_parent_group_$parentGroupId",
-            $groupNames[$parentGroupId]
-          );
         }
       }
     }
@@ -412,6 +411,8 @@ WHERE  title = %1
 
     if (isset($form->_id)) {
       $potentialParentGroupIds = CRM_Contact_BAO_GroupNestingCache::getPotentialCandidates($form->_id, $groupNames);
+      // put back current groups because they are selected by default
+      $potentialParentGroupIds = array_merge($potentialParentGroupIds, $parentGroupIds);
     }
     else {
       $potentialParentGroupIds = array_keys($groupNames);
@@ -431,7 +432,7 @@ WHERE  title = %1
       else {
         $required = FALSE;
       }
-      $form->add('select', 'parents', ts('Add Parent'), $parentGroupSelectValues, $required, ['class' => 'crm-select2', 'multiple' => TRUE]);
+      $form->add('select', 'parents', ts('Parents'), $parentGroupSelectValues, $required, ['class' => 'crm-select2', 'multiple' => TRUE]);
     }
 
     return $parentGroups;

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -412,7 +412,9 @@ WHERE  title = %1
     if (isset($form->_id)) {
       $potentialParentGroupIds = CRM_Contact_BAO_GroupNestingCache::getPotentialCandidates($form->_id, $groupNames);
       // put back current groups because they are selected by default
-      $potentialParentGroupIds = array_merge($potentialParentGroupIds, $parentGroupIds);
+      if (!empty($parentGroupIds)) {
+        $potentialParentGroupIds = array_merge($potentialParentGroupIds, $parentGroupIds);
+      }
     }
     else {
       $potentialParentGroupIds = array_keys($groupNames);

--- a/templates/CRM/Group/Form/GroupsCommon.tpl
+++ b/templates/CRM/Group/Form/GroupsCommon.tpl
@@ -7,30 +7,12 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{*CRM-14190*}
-{if $parent_groups|@count > 0 || !empty($form.parents.html)}
-  <h3>{ts}Parent Groups{/ts} {help id="id-group-parent" file="CRM/Group/Page/Group.hlp"}</h3>
-  {if $parent_groups|@count > 0}
-    <table class="form-layout-compressed">
-      <tr>
-        <td><label>{ts}Remove Parent?{/ts}</label></td>
-      </tr>
-      {foreach from=$parent_groups item=cgroup key=group_id}
-        {assign var="element_name" value="remove_parent_group_"|cat:$group_id}
-        <tr>
-          <td>&nbsp;&nbsp;{$form.$element_name.html}&nbsp;{$form.$element_name.label}</td>
-        </tr>
-      {/foreach}
-    </table>
-    <br />
-  {/if}
-  <table class="form-layout-compressed">
-    <tr class="crm-group-form-block-parents">
-      <td class="label">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{$form.parents.label}</td>
-      <td>{$form.parents.html|crmAddClass:huge}</td>
-    </tr>
-  </table>
-{/if}
+<table class="form-layout-compressed">
+  <tr class="crm-group-form-block-parents">
+    <td class="label">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{$form.parents.label}</td>
+    <td>{$form.parents.html|crmAddClass:huge}</td>
+  </tr>
+</table>
 {if array_key_exists('organization_id', $form)}
   <h3>{ts}Associated Organization{/ts} {help id="id-group-organization" file="CRM/Group/Page/Group.hlp"}</h3>
   <table class="form-layout-compressed">


### PR DESCRIPTION
Overview
----------------------------------------
Regression following a few others PR regarding converting group management to AdminUI.

When using the Quickform CRM_Group_Form_Edit to edit a group with some parents, the existing parents are lost.

See https://github.com/civicrm/civicrm-core/pull/26260 or https://github.com/civicrm/civicrm-core/pull/26623

To make things a bit simpler, use a simple select2 widget in CRM_Group_Form_Edit like in SK.

Before
----------------------------------------
![ksnip_20231017-155445](https://github.com/civicrm/civicrm-core/assets/372004/637577a2-2699-452a-b1df-8408a3885cf0)

After
----------------------------------------
![ksnip_20231018-174638](https://github.com/civicrm/civicrm-core/assets/372004/25250fdc-3672-4d65-9fe3-f93683898e59)

Technical Details
----------------------------------------
Still a WIP:
- ~~code needs a bit more cleanup~~ removed the doParentCheck for multisites
- no unit-test (how can we test the form submit) ?
- not really tested except in very simple cases:
    * the template seems to be used templates/CRM/Group/Form/GroupsCommon.tpl when doing smart group
    * is it still working in multisite installation -> formRule with doParentCheck was removed
