### PR TITLE
(NFC) phpunit.xml.dist - Drop stale reference to old suite

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,9 +24,6 @@
     <testsuite name="Civi_AllTests">
       <directory>./tests/phpunit/Civi</directory>
     </testsuite>
-    <testsuite name="WebTest_AllTests">
-      <directory>./tests/phpunit/WebTest</directory>
-    </testsuite>
   </testsuites>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">


### PR DESCRIPTION
Overview
----------------------------------------

Drop a configuration note that suggests that `phpunit` should scan a folder that doesn't exist.
