### PR TITLE
Afform - Add default values to metadata

### DIFF
--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -140,6 +140,7 @@ class Afform extends Generic\AbstractEntity {
           'name' => 'type',
           'title' => E::ts('Type'),
           'pseudoconstant' => ['optionGroupName' => 'afform_type'],
+          'default_value' => 'form',
         ],
         [
           'name' => 'requires',
@@ -195,16 +196,19 @@ class Afform extends Generic\AbstractEntity {
           'name' => 'is_public',
           'title' => E::ts('Is Public'),
           'data_type' => 'Boolean',
+          'default_value' => FALSE,
         ],
         [
           'name' => 'permission',
           'title' => E::ts('Permission'),
           'data_type' => 'Array',
+          'default_value' => ['access CiviCRM'],
         ],
         [
           'name' => 'permission_operator',
           'title' => E::ts('Permission Operator'),
           'data_type' => 'String',
+          'default_value' => 'AND',
           'options' => \CRM_Core_SelectValues::andOr(),
         ],
         [


### PR DESCRIPTION
Overview
----------------------------------------
Make explicit what were previously implied default values.
This is a bite-sized piece of #27783 

Before
----------------------------------------
Less explicit metadata.

After
----------------------------------------
More explicit metadata.

Technical Details
--------------
Declaring defaults here requires less wrangling deeper-down in the Afform code, and also makes them discoverable to 3rd-party devs or anyone casually browsing the API Explorer.