### PR TITLE
Fix dev/core#4638 - SearchKit conditional option matching fix

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
@@ -32,8 +32,10 @@
       this.getField = searchMeta.getField;
 
       this.fields = function() {
-        var selectFields = ctrl.crmSearchAdmin.getSelectFields();
-        var permissionField = [{
+        let selectFields = ctrl.crmSearchAdmin.getSelectFields();
+        // Use machine names not labels for option matching
+        selectFields.forEach((field) => field.id = field.id.replace(':label', ':name'));
+        let permissionField = [{
           text: ts('Current User Permission'),
           id: 'check user permission',
           description: ts('Check permission of logged-in user')

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminCssRules.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminCssRules.component.js
@@ -28,9 +28,12 @@
       this.styles.strikethrough = ts('Strikethrough');
 
       this.fields = function() {
-        var allFields = ctrl.crmSearchAdmin.getAllFields(':name', ['Field', 'Custom', 'Extra', 'Pseudo']);
+        let allFields = ctrl.crmSearchAdmin.getAllFields(':name', ['Field', 'Custom', 'Extra', 'Pseudo']);
+        let selectFields = ctrl.crmSearchAdmin.getSelectFields();
+        // Use machine names not labels for option matching
+        selectFields.forEach((field) => field.id = field.id.replace(':label', ':name'));
         return {
-          results: ctrl.crmSearchAdmin.getSelectFields().concat(allFields)
+          results: selectFields.concat(allFields)
         };
       };
 

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminIcons.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminIcons.component.js
@@ -16,9 +16,12 @@
       this.getField = searchMeta.getField;
 
       this.fields = function() {
-        var allFields = ctrl.crmSearchAdmin.getAllFields(':name', ['Field', 'Custom', 'Extra', 'Pseudo']);
+        let allFields = ctrl.crmSearchAdmin.getAllFields(':name', ['Field', 'Custom', 'Extra', 'Pseudo']);
+        let selectFields = ctrl.crmSearchAdmin.getSelectFields();
+        // Use machine names not labels for option matching
+        selectFields.forEach((field) => field.id = field.id.replace(':label', ':name'));
         return {
-          results: ctrl.crmSearchAdmin.getSelectFields().concat(allFields)
+          results: selectFields.concat(allFields)
         };
       };
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/4638

Before
----------------------------------------
Conditionals (e.g. for styles, icons, links) appeared flaky. The underlying cause was matching by (English-only) `:label` instead of the more stable `:name`.

After
----------------------------------------
Fixed.