### PR TITLE
(REF) MailSettings - Provide setup URL's through BAO (towards dev/core#4674)

### DIFF
--- a/CRM/Core/BAO/MailSettings.php
+++ b/CRM/Core/BAO/MailSettings.php
@@ -19,7 +19,7 @@ class CRM_Core_BAO_MailSettings extends CRM_Core_DAO_MailSettings {
   /**
    * Get a list of setup-actions.
    *
-   * @return array
+   * @return array{array{title:string, callback: mixed, url: string}}
    *   List of available actions. See description in the hook-docs.
    * @see CRM_Utils_Hook::mailSetupActions()
    */
@@ -31,6 +31,13 @@ class CRM_Core_BAO_MailSettings extends CRM_Core_DAO_MailSettings {
     ];
 
     CRM_Utils_Hook::mailSetupActions($setupActions);
+
+    foreach ($setupActions as $key => &$setupAction) {
+      if (!isset($setupAction['url'])) {
+        $setupAction['url'] = (string) Civi::url('//civicrm/ajax/setupMailAccount')->addQuery(['type' => $key]);
+      }
+    }
+
     return $setupActions;
   }
 

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1145,6 +1145,9 @@ abstract class CRM_Utils_Hook {
    *     - title: string
    *     - callback: string|array, the function which starts the setup process.
    *        The function is expected to return a 'url' for the config screen.
+   *     - url: string (optional), a URL which starts the setup process.
+   *        If omitted, then a default URL is generated. The effect of opening the URL is
+   *        to invoke the `callback`.
    * @return mixed
    */
   public static function mailSetupActions(&$setupActions) {

--- a/templates/CRM/Admin/Page/MailSettings.tpl
+++ b/templates/CRM/Admin/Page/MailSettings.tpl
@@ -61,7 +61,7 @@
             <select id="crm-mail-setup" name="crm-mail-setup" class="crm-select2 crm-form-select" aria-label="{ts}Add Mail Account{/ts}">
                 <option value="" aria-hidden="true">{ts}Add Mail Account{/ts}</option>
                 {foreach from=$setupActions key=setupActionsName item=setupAction}
-                    <option value="{$setupActionsName|escape}">{$setupAction.title|escape}</option>
+                    <option data-url="{$setupAction.url|escape}" value="{$setupActionsName|escape}">{$setupAction.title|escape}</option>
                 {/foreach}
             </select>
         </form>
@@ -80,8 +80,7 @@
                 return;
             }
             event.stopPropagation();
-            var url = CRM.url('civicrm/ajax/setupMailAccount', {type: event.val});
-            window.location = url;
+            window.location = cj(event.choice.element).data('url');
         });
     </script>
 {/literal}


### PR DESCRIPTION
Overview
----------------------------------------

For https://lab.civicrm.org/dev/core/-/issues/4674, we need to use email setup links in more contexts. This moves the URL construction to place that's easier to get.

cc @colemanw 

Before
----------------------------------------

* Setup links generated in Smarty tpl

After
----------------------------------------

* Setup links generated in BAO

