### PR TITLE
SearchUI - Move 'Experimental' menu from top level to underneath 'Search'

### DIFF
--- a/ext/civicrm_search_ui/managed/Navigation_Experimental.mgd.php
+++ b/ext/civicrm_search_ui/managed/Navigation_Experimental.mgd.php
@@ -6,7 +6,7 @@ return [
   [
     'name' => 'Navigation_Experimental',
     'entity' => 'Navigation',
-    'cleanup' => 'unused',
+    'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,
@@ -20,7 +20,7 @@ return [
           'access CiviCRM',
         ],
         'permission_operator' => 'AND',
-        'parent_id' => NULL,
+        'parent_id.name' => 'Search',
         'is_active' => TRUE,
         'has_separator' => 0,
         'weight' => 113,


### PR DESCRIPTION
Overview
----------------------------------------
Less prominent placement for experimental search menu.

See https://lab.civicrm.org/dev/core/-/issues/4715

Before
----------------------------------------
Menu at top level

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/2874912/1aaa9c79-a515-45a4-b22b-5e1a1fecfd57)


