### PR TITLE
dev/core#4704 Display 'registration is closed' only if users can register

### DIFF
--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -276,8 +276,8 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
         }
       }
     }
-    $this->assign('registerClosed', !empty($values['event']['is_online_registration']) && !$isEventOpenForRegistration);
 
+    $this->assign('registerClosed', !empty($values['event']['is_online_registration']) && !$isEventOpenForRegistration && CRM_Core_Permission::check('register for events'));
     $this->assign('allowRegistration', $allowRegistration);
 
     $session = CRM_Core_Session::singleton();


### PR DESCRIPTION
Overview
----------------------------------------

On public Event Registrations forms, the behaviour around the "registrations are closed" message has changed somewhat recently by [this commit](https://lab.civicrm.org/dev/core/-/commit/597e807091d835fba28a636ea8f9da76bf63b1a0).

There are sites that require users to login in order to register. If they are not logged in, the new behaviour is displaying "registrations are closed", event though they aren't. This PR fixes the behaviour to be like before.

https://lab.civicrm.org/dev/core/-/issues/4704

Before
----------------------------------------

As a non-logged-in user, I see "registrations are closed", even though they are not.

After
----------------------------------------

No error. I can login and register to the event.

Technical Details
----------------------------------------

https://lab.civicrm.org/dev/core/-/commit/597e807091d835fba28a636ea8f9da76bf63b1a0

