### PR TITLE
REG: Fix fatal error on pledge delete

### DIFF
--- a/CRM/Pledge/Form/Pledge.php
+++ b/CRM/Pledge/Form/Pledge.php
@@ -107,7 +107,7 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
     $defaults = $this->_values;
 
     if ($this->_action & CRM_Core_Action::DELETE) {
-      return $defaults;
+      return $defaults ?? [];
     }
 
     if (!empty($defaults['is_test'])) {

--- a/CRM/Pledge/Form/Pledge.php
+++ b/CRM/Pledge/Form/Pledge.php
@@ -43,7 +43,7 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
    * The Pledge values if an existing pledge.
    * @var array
    */
-  public $_values;
+  public $_values = [];
 
   /**
    * The Pledge frequency Units.
@@ -107,7 +107,7 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
     $defaults = $this->_values;
 
     if ($this->_action & CRM_Core_Action::DELETE) {
-      return $defaults ?? [];
+      return $defaults;
     }
 
     if (!empty($defaults['is_test'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Deleting a pledge results into a fatal error

Before
----------------------------------------
To replicate: Delete a pledge on https://dmaster.demo.civicrm.org/civicrm/contact/view?reset=1&cid=43&selectedChild=pledge

>TypeError: CRM_Pledge_Form_Pledge::setDefaultValues(): Return value must be of type array, null returned in CRM_Pledge_Form_Pledge->setDefaultValues() (line 110 of /srv/buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Pledge/Form/Pledge.php).

<img width="1396" alt="image" src="https://github.com/civicrm/civicrm-core/assets/5929648/735d930d-f36d-410b-9d69-c0dfd2537300">

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Ensure array is returned to avoid TypeError on setDefaultValues()

