### PR TITLE
CRM_Core_BAO_Domain - Deprecate unused functions

### DIFF
--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -164,9 +164,11 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
   }
 
   /**
+   * @deprecated
    * @return bool
    */
   public static function multipleDomains() {
+    CRM_Core_Error::deprecatedFunctionWarning('API');
     $session = CRM_Core_Session::singleton();
 
     $numberDomains = $session->get('numberDomains');
@@ -231,12 +233,12 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
 
   /**
    * @param int $contactID
-   *
-   * @return bool|null|object|string
-   *
+   * @return bool|int
+   * @deprecated
    * @throws \CRM_Core_Exception
    */
   public static function addContactToDomainGroup($contactID) {
+    CRM_Core_Error::deprecatedFunctionWarning('CRM_Contact_BAO_GroupContact::addContactsToGroup');
     $groupID = self::getGroupId();
 
     if ($groupID) {


### PR DESCRIPTION
Overview
----------------------------------------
Deprecates domain functions that are not used in core and also not used in the [Multisite extension](https://lab.civicrm.org/extensions/multisite).