### PR TITLE
Case Activity: use select2 for Medium field

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -203,10 +203,7 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
       }
       $this->assign('targetContactValues', empty($targetContactValues) ? FALSE : $targetContactValues);
 
-      if (isset($this->_encounterMedium)) {
-        $this->_defaults['medium_id'] = $this->_encounterMedium;
-      }
-      elseif (empty($this->_defaults['medium_id'])) {
+      if (empty($this->_defaults['medium_id'])) {
         // set default encounter medium CRM-4816
         $medium = CRM_Core_OptionGroup::values('encounter_medium', FALSE, FALSE, FALSE, 'AND is_default = 1');
         if (count($medium) == 1) {
@@ -266,22 +263,13 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
 
     $this->assign('urlPath', 'civicrm/case/activity');
 
-    $encounterMediums = CRM_Case_PseudoConstant::encounterMedium();
-
     if ($this->_activityTypeFile == 'OpenCase' && $this->_action == CRM_Core_Action::UPDATE) {
       $this->getElement('activity_date_time')->freeze();
-
-      if ($this->_activityId) {
-        // Fixme: what's the justification for this? It seems like it is just re-adding an option in case it is the default and disabled.
-        // Is that really a big problem?
-        $this->_encounterMedium = CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity', $this->_activityId, 'medium_id');
-        if (!array_key_exists($this->_encounterMedium, $encounterMediums)) {
-          $encounterMediums[$this->_encounterMedium] = CRM_Core_PseudoConstant::getLabel('CRM_Activity_BAO_Activity', 'medium_id', $this->_encounterMedium);
-        }
-      }
     }
 
-    $this->add('select', 'medium_id', ts('Medium'), $encounterMediums, TRUE);
+    $this->addSelect('medium_id');
+
+    // Related contacts
     $i = 0;
     foreach ($this->_caseId as $key => $val) {
       $this->_relatedContacts[] = $rgc = CRM_Case_BAO_Case::getRelatedAndGlobalContacts($val);


### PR DESCRIPTION
Overview
----------------------------------------

Uses select2 for the "Medium" field on Case Activities. This makes it more consistent with other select fields.

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/c9434d5e-6509-48d2-b658-aa2bb27cc1fc)

After
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/efc46d06-4b9f-447f-a71f-42a2c48d2019)


Comments
----------------------------------------

I did a bit of cleanup because it seemed weird.