### PR TITLE
Tweak money/numeric error messages to not mention point (could be a comma)

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1153,21 +1153,21 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
 
       case 'Float':
         if ($field->is_search_range && $search) {
-          $qf->addRule($elementName . '_from', ts('%1 From must be a number (with or without decimal point).', [1 => $label]), 'numeric');
-          $qf->addRule($elementName . '_to', ts('%1 To must be a number (with or without decimal point).', [1 => $label]), 'numeric');
+          $qf->addRule($elementName . '_from', ts('%1 From must be a number (with or without decimals).', [1 => $label]), 'numeric');
+          $qf->addRule($elementName . '_to', ts('%1 To must be a number (with or without decimals).', [1 => $label]), 'numeric');
         }
         elseif ($widget == 'Text') {
-          $qf->addRule($elementName, ts('%1 must be a number (with or without decimal point).', [1 => $label]), 'numeric');
+          $qf->addRule($elementName, ts('%1 must be a number (with or without decimals).', [1 => $label]), 'numeric');
         }
         break;
 
       case 'Money':
         if ($field->is_search_range && $search) {
-          $qf->addRule($elementName . '_from', ts('%1 From must in proper money format. (decimal point/comma/space is allowed).', [1 => $label]), 'money');
-          $qf->addRule($elementName . '_to', ts('%1 To must in proper money format. (decimal point/comma/space is allowed).', [1 => $label]), 'money');
+          $qf->addRule($elementName . '_from', ts('%1 From must in money format (a number with or without decimals, ex: %2).', [1 => $label, 2 => Civi::format()->number(123.98)]), 'money');
+          $qf->addRule($elementName . '_to', ts('%1 To must in money format (a number with or without decimals, ex: %2).', [1 => $label, 2 => Civi::format()->number(123.98)]), 'money');
         }
         elseif ($widget == 'Text') {
-          $qf->addRule($elementName, ts('%1 must be in proper money format. (decimal point/comma/space is allowed).', [1 => $label]), 'money');
+          $qf->addRule($elementName, ts('%1 must be in money format (a number with or without decimals, ex: %2).', [1 => $label, 2 => Civi::format()->number(123.98)]), 'money');
         }
         break;
 
@@ -2754,30 +2754,22 @@ WHERE      f.id IN ($ids)";
       switch ($dataType) {
         case 'Int':
           $ruleName = 'integer';
-          $errorMsg = ts('%1 must be an integer (whole number).',
-            [1 => $fieldTitle]
-          );
+          $errorMsg = ts('%1 must be an integer (whole number).', [1 => $fieldTitle]);
           break;
 
         case 'Money':
           $ruleName = 'money';
-          $errorMsg = ts('%1 must in proper money format. (decimal point/comma/space is allowed).',
-            [1 => $fieldTitle]
-          );
+          $errorMsg = ts('%1 must be in money format (a number with or without decimals, ex: %2).', [1 => $fieldTitle, 2 => Civi::format()->number(123.98)]);
           break;
 
         case 'Float':
           $ruleName = 'numeric';
-          $errorMsg = ts('%1 must be a number (with or without decimal point).',
-            [1 => $fieldTitle]
-          );
+          $errorMsg = ts('%1 must be a number (with or without decimals).', [1 => $fieldTitle]);
           break;
 
         case 'Link':
           $ruleName = 'wikiURL';
-          $errorMsg = ts('%1 must be valid Website.',
-            [1 => $fieldTitle]
-          );
+          $errorMsg = ts('%1 must be valid Website.', [1 => $fieldTitle]);
           break;
       }
 

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -349,7 +349,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           $type = 'money';
         }
         else {
-          $message = ts('%1 must be a number (with or without decimal point).', [1 => $label]);
+          $message = ts('%1 must be a number (with or without decimals).', [1 => $label]);
           $type = 'numeric';
         }
         // integers will have numeric rule applied to them.

--- a/tests/phpunit/CRM/Case/Form/CustomDataTest.php
+++ b/tests/phpunit/CRM/Case/Form/CustomDataTest.php
@@ -11,8 +11,20 @@ class CRM_Case_Form_CustomDataTest extends CiviCaseTestCase {
 
   public function setUp(): void {
     parent::setUp();
+    CRM_Core_I18n::singleton()->setLocale('en_US');
+    CRM_Core_Config::singleton()->defaultCurrency = 'USD';
+    CRM_Core_Config::singleton()->monetaryThousandSeparator = ',';
+    CRM_Core_Config::singleton()->monetaryDecimalPoint = '.';
     $this->custom_group = $this->customGroupCreate(['extends' => 'Case']);
     $this->custom_group = $this->custom_group['values'][$this->custom_group['id']];
+  }
+
+  public function tearDown(): void {
+    parent::tearDown();
+    CRM_Core_Config::singleton()->defaultCurrency = 'USD';
+    CRM_Core_Config::singleton()->monetaryThousandSeparator = ',';
+    CRM_Core_Config::singleton()->monetaryDecimalPoint = '.';
+    CRM_Core_I18n::singleton()->setLocale('en_US');
   }
 
   /**
@@ -93,11 +105,6 @@ class CRM_Case_Form_CustomDataTest extends CiviCaseTestCase {
     CRM_Core_Config::singleton()->monetaryDecimalPoint = ',';
 
     $this->testChangeCustomDataFormattedDetails($input, $expected);
-
-    CRM_Core_Config::singleton()->defaultCurrency = 'USD';
-    CRM_Core_Config::singleton()->monetaryThousandSeparator = ',';
-    CRM_Core_Config::singleton()->monetaryDecimalPoint = '.';
-    CRM_Core_I18n::singleton()->setLocale('en_US');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

Invalid values entered in Numeric and Money fields mention "enter with or without decimal points". While decimal points do not necessarily mean that they are separated with a period, it can be a bit confusing what the expected format it.

Based on PR #25714 by @highfalutin
 

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/4bc38b9f-3dad-403f-893a-c33f2fc2468e)

After
----------------------------------------

Numeric field:

![image](https://github.com/civicrm/civicrm-core/assets/254741/65790758-7a84-474a-8b5a-3e88d39eb81a)

Money fields:

![image](https://github.com/civicrm/civicrm-core/assets/254741/9823fb8b-cec5-4552-b74c-ec85c12677a2)

(I decided to be extra-pedantic on the money fields, because the error does not mention the currency, and it can be entered, then stripped automatically... but it can be confusing to know which separator to use, although `Civi::format()->money` uses the "inherit from locale" settings, and not the actual separators... but imo they are legacy and should go away.

Comments
----------------

"proper money format" seemed a bit too posh for my tastes.