### PR TITLE
Report notice fix - batch id

### DIFF
--- a/CRM/Report/Form/Contribute/Summary.php
+++ b/CRM/Report/Form/Contribute/Summary.php
@@ -58,6 +58,7 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
    * Class constructor.
    */
   public function __construct() {
+    $batches = CRM_Batch_BAO_Batch::getBatches();
     $this->_columns = [
       'civicrm_contact' => [
         'dao' => 'CRM_Contact_DAO_Contact',
@@ -342,6 +343,9 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
 
     $this->addCampaignFields('civicrm_contribution', TRUE);
 
+    if (!$batches) {
+      unset($this->_columns['civicrm_batch']);
+    }
     // Add charts support
     $this->_charts = [
       '' => ts('Tabular'),
@@ -383,7 +387,7 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
               case 'FISCALYEAR':
                 $config = CRM_Core_Config::singleton();
                 $fy = $config->fiscalYearStart;
-                $fiscal = self::fiscalYearOffset($field['dbAlias']);
+                $fiscal = $this->fiscalYearOffset($field['dbAlias']);
 
                 $select[] = "DATE_ADD(MAKEDATE({$fiscal}, 1), INTERVAL ({$fy['M']})-1 MONTH) AS {$tableName}_{$fieldName}_start";
                 $select[] = "{$fiscal} AS {$tableName}_{$fieldName}_subtotal";
@@ -750,7 +754,7 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
 
       foreach ($currencies as $currency) {
         $softTotalAmount[] = CRM_Utils_Money::format($currSoftAmount[$currency], $currency) .
-          " (" . $currSoftCount[$currency] . ")";
+          ' (' . $currSoftCount[$currency] . ')';
         $softAverage[] = CRM_Utils_Money::format(($currSoftAverage[$currency] / $averageSoftCount[$currency]), $currency);
       }
     }

--- a/CRM/Report/Form/Contribute/Summary.php
+++ b/CRM/Report/Form/Contribute/Summary.php
@@ -156,12 +156,6 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
             'default' => [1],
             'type' => CRM_Utils_Type::T_INT,
           ],
-          'contribution_page_id' => [
-            'title' => ts('Contribution Page'),
-            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Contribute_PseudoConstant::contributionPage(),
-            'type' => CRM_Utils_Type::T_INT,
-          ],
           'currency' => [
             'title' => ts('Currency'),
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
@@ -277,7 +271,7 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
           'batch_id' => [
             'title' => ts('Batch Title'),
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Batch_BAO_Batch::getBatches(),
+            'options' => $batches,
             'type' => CRM_Utils_Type::T_INT,
           ],
         ],


### PR DESCRIPTION
Overview
----------------------------------------
Report notice fix - batch id filter causes notice,  when there are none to filter by



Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/0aa564fe-a481-4910-9904-8d09e9e9303f)




After
----------------------------------------
If batches is empty then it is not in columns, filters, group by etc (as it there is nothing to report on)

Technical Details
----------------------------------------

Comments
----------------------------------------
