### PR TITLE
Preliminary cleanup - remove function overrides that do not override

### DIFF
--- a/CRM/Report/Form/Contribute/SoftCredit.php
+++ b/CRM/Report/Form/Contribute/SoftCredit.php
@@ -308,11 +308,7 @@ class CRM_Report_Form_Contribute_SoftCredit extends CRM_Report_Form {
     parent::__construct();
   }
 
-  public function preProcess() {
-    parent::preProcess();
-  }
-
-  public function select() {
+  public function select(): void {
     $select = [];
     $this->_columnHeaders = [];
     foreach ($this->_columns as $tableName => $table) {
@@ -381,19 +377,7 @@ class CRM_Report_Form_Contribute_SoftCredit extends CRM_Report_Form {
     $this->_select = 'SELECT ' . implode(', ', $select) . ' ';
   }
 
-  /**
-   * @param array $fields
-   * @param array $files
-   * @param CRM_Core_Form $self
-   *
-   * @return array
-   */
-  public static function formRule($fields, $files, $self) {
-    $errors = $grouping = [];
-    return $errors;
-  }
-
-  public function from() {
+  public function from(): void {
     $alias_constituent = 'constituentname';
     $alias_creditor = 'contact_civireport';
     $this->_from = "


### PR DESCRIPTION
Overview
----------------------------------------
Preliminary cleanup - remove function overrides that do not override

Before
----------------------------------------
`formRule()` does nothing & does not prevent parent from doing something, `preProcess` just calls the parent

After
----------------------------------------
poof

Technical Details
----------------------------------------
This report has multiple issues around notices, properties & smarty - easing my way in

Comments
----------------------------------------
