### PR TITLE
Php 8.2 notice fix on soft credit report

### DIFF
--- a/CRM/Report/Form/Contribute/SoftCredit.php
+++ b/CRM/Report/Form/Contribute/SoftCredit.php
@@ -376,7 +376,7 @@ class CRM_Report_Form_Contribute_SoftCredit extends CRM_Report_Form {
         }
       }
     }
-    $this->selectClause = $select;
+    $this->_selectClauses = $select;
 
     $this->_select = 'SELECT ' . implode(', ', $select) . ' ';
   }
@@ -457,7 +457,7 @@ class CRM_Report_Form_Contribute_SoftCredit extends CRM_Report_Form {
 
   public function groupBy() {
     $this->_rollup = 'WITH ROLLUP';
-    $this->_select = CRM_Contact_BAO_Query::appendAnyValueToSelect($this->selectClause, ["{$this->_aliases['civicrm_contribution_soft']}.contact_id", "constituentname.id"]);
+    $this->_select = CRM_Contact_BAO_Query::appendAnyValueToSelect($this->_selectClauses, ["{$this->_aliases['civicrm_contribution_soft']}.contact_id", "constituentname.id"]);
     $this->_groupBy = "
 GROUP BY {$this->_aliases['civicrm_contribution_soft']}.contact_id, constituentname.id {$this->_rollup}";
   }


### PR DESCRIPTION


Overview
----------------------------------------
Php 8.2 notice fix on soft credit report

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/2f2d4521-f418-4a31-97d7-86b582f9ba25)

After
----------------------------------------
Uses the same variable name as other reports for selectClauses - which means it is no longer undefined / causing test fails on edge

Technical Details
----------------------------------------

Comments
----------------------------------------
