### PR TITLE
Stop assigning ispricelifetime - used in previously shared usage

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1009,7 +1009,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         }
       }
     }
-    $form->assign('ispricelifetime', $checklifetime);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Stop assigning ispricelifetime - used in previously shared usage

Before
----------------------------------------
`ispricelifetime` assigned - but only usage is in previously tpl that used to share an assign

![image](https://github.com/civicrm/civicrm-core/assets/336308/cc670fd4-35c2-4e39-b6bd-c0af189be8e8)


After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
