### PR TITLE
Stop weird action override on confirm form

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -803,22 +803,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
   }
 
   /**
-   * Overwrite action.
-   *
-   * Since we are only showing elements in frozen mode no help display needed.
-   *
-   * @return int
-   */
-  public function getAction() {
-    if ($this->_action & CRM_Core_Action::PREVIEW) {
-      return CRM_Core_Action::VIEW | CRM_Core_Action::PREVIEW;
-    }
-    else {
-      return CRM_Core_Action::VIEW;
-    }
-  }
-
-  /**
    * Set default values for the form.
    *
    * Note that in edit/view mode


### PR DESCRIPTION


Overview
----------------------------------------
Stop weird action override on confirm form

Before
----------------------------------------
Most (all)? calls to `getAction()` return 1 whereas accessing action direction or via `getVar` returns (e.g) 4 - this makes for confusion

After
----------------------------------------
consistent return value

Technical Details
----------------------------------------
This causes problems because getAction() !== _action & I traced it back to svn & can't see why it makes sense & it's super prone to caus rbeakage
... it was linked to paypal

Comments
----------------------------------------