### PR TITLE
APIv4 - Add previous/next SortableEntity fields

### DIFF
--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -305,6 +305,12 @@ class CRM_Core_ManagedEntities {
       if (CoreUtil::isType($item['entity_type'], 'SortableEntity')) {
         $weightCol = CoreUtil::getInfoItem($item['entity_type'], 'order_by');
         unset($params['values'][$weightCol]);
+        // Also exclude "previous" and "next" which evaluate to weight
+        foreach (array_keys($params['values']) as $key) {
+          if (str_starts_with($key, 'previous.') || str_starts_with($key, 'next.')) {
+            unset($params['values'][$key]);
+          }
+        }
       }
       // 'match' param doesn't apply to "update" action
       unset($params['match']);

--- a/Civi/Api4/Event/Subscriber/SortableEntitySchemaMapSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/SortableEntitySchemaMapSubscriber.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Civi\Api4\Event\Subscriber;
+
+use Civi\Api4\Event\SchemaMapBuildEvent;
+use Civi\Api4\Service\Schema\Joinable\ExtraJoinable;
+use Civi\Api4\Utils\CoreUtil;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @service
+ * @internal
+ */
+class SortableEntitySchemaMapSubscriber extends \Civi\Core\Service\AutoService implements EventSubscriberInterface {
+
+  /**
+   * @return array
+   */
+  public static function getSubscribedEvents() {
+    return [
+      'api.schema_map.build' => 'onSchemaBuild',
+    ];
+  }
+
+  /**
+   * This creates a joinable which gets exposed and rendered by:
+   * @see \Civi\Api4\Service\Spec\Provider\SortableEntitySpecProvider
+   *
+   * @param \Civi\Api4\Event\SchemaMapBuildEvent $event
+   */
+  public function onSchemaBuild(SchemaMapBuildEvent $event) {
+    $schema = $event->getSchemaMap();
+    foreach ($schema->getTables() as $table) {
+      $entityName = $table->getEntityName();
+      if (!$entityName || !CoreUtil::isType($entityName, 'SortableEntity')) {
+        continue;
+      }
+      $weightColumn = CoreUtil::getInfoItem($entityName, 'order_by');
+      $groupings = (array) CoreUtil::getInfoItem($entityName, 'group_weights_by');
+      foreach (['previous' => '-', 'next' => '+'] as $type => $op) {
+        $link = new ExtraJoinable($table->getName(), 'id', $type);
+        $link->setBaseTable($table->getName());
+        $link->setJoinType(ExtraJoinable::JOIN_TYPE_ONE_TO_ONE);
+        foreach ($groupings as $grouping) {
+          $link->addCondition("`{target_table}`.`$grouping` = `{base_table}`.`$grouping`");
+        }
+        $link->addCondition("`{target_table}`.`$weightColumn` = (`{base_table}`.`$weightColumn` $op 1)");
+        $table->addTableLink('id', $link);
+      }
+    }
+  }
+
+}

--- a/Civi/Api4/Service/Schema/Table.php
+++ b/Civi/Api4/Service/Schema/Table.php
@@ -13,6 +13,7 @@
 namespace Civi\Api4\Service\Schema;
 
 use Civi\Api4\Service\Schema\Joinable\Joinable;
+use Civi\Api4\Utils\CoreUtil;
 
 class Table {
 
@@ -50,6 +51,14 @@ class Table {
     $this->name = $name;
 
     return $this;
+  }
+
+  /**
+   * Get API entity for this table
+   * @return string|null
+   */
+  public function getEntityName(): ?string {
+    return CoreUtil::getApiNameFromTableName($this->name);
   }
 
   /**

--- a/Civi/Api4/Service/Spec/Provider/SortableEntitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/SortableEntitySpecProvider.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\FieldSpec;
+use Civi\Api4\Service\Spec\RequestSpec;
+use Civi\Api4\Utils\CoreUtil;
+
+/**
+ * @service
+ * @internal
+ */
+class SortableEntitySpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
+
+  /**
+   * Adds fields to expose the join created by:
+   * @see \Civi\Api4\Event\Subscriber\SortableEntitySchemaMapSubscriber
+   *
+   * @param \Civi\Api4\Service\Spec\RequestSpec $spec
+   */
+  public function modifySpec(RequestSpec $spec): void {
+    $entityName = $spec->getEntity();
+    $field = (new FieldSpec("previous", $entityName, 'Integer'))
+      ->setTitle(ts('Previous %1', [1 => CoreUtil::getInfoItem('title', $entityName)]))
+      ->setColumnName('id')
+      ->setFkEntity($entityName)
+      ->setDescription(ts('Item that comes before this one in the sorted group'))
+      ->setSqlRenderer(['\Civi\Api4\Service\Schema\Joiner', 'getExtraJoinSql']);
+    $spec->addFieldSpec($field);
+
+    $field = (new FieldSpec("next", $entityName, 'Integer'))
+      ->setTitle(ts('Next %1', [1 => CoreUtil::getInfoItem('title', $entityName)]))
+      ->setColumnName('id')
+      ->setFkEntity($entityName)
+      ->setDescription(ts('Item that comes after this one in the sorted group'))
+      ->setSqlRenderer(['\Civi\Api4\Service\Schema\Joiner', 'getExtraJoinSql']);
+    $spec->addFieldSpec($field);
+  }
+
+  /**
+   * @param string $entity
+   * @param string $action
+   *
+   * @return bool
+   */
+  public function applies($entity, $action): bool {
+    return CoreUtil::isType($entity, 'SortableEntity');
+  }
+
+}

--- a/tests/phpunit/api/v4/Entity/SortableEntityTest.php
+++ b/tests/phpunit/api/v4/Entity/SortableEntityTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4\Entity;
+
+use api\v4\Api4TestBase;
+use Civi\Api4\OptionValue;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class SortableEntityTest extends Api4TestBase implements TransactionalInterface {
+
+  public function testGetFields(): void {
+    $fields = OptionValue::getFields(FALSE)
+      ->addWhere('type', '=', 'Extra')
+      ->execute()
+      ->indexBy('name');
+    $this->assertEquals('OptionValue', $fields['previous']['fk_entity']);
+  }
+
+  public function testPrevNextWeight(): void {
+    // Create 2 option groups.
+    $this->saveTestRecords('OptionGroup', [
+      'records' => [
+        ['name' => 'enGroup'],
+        ['name' => 'esGroup'],
+      ],
+    ]);
+    $sampleData = [
+      ['label' => 'One', 'name' => 'option_1', 'value' => 1],
+      ['label' => 'Two', 'name' => 'option_2', 'value' => 2],
+      ['label' => 'Three', 'name' => 'option_3', 'value' => 3],
+    ];
+    OptionValue::save(FALSE)
+      ->setRecords($sampleData)
+      ->addDefault('option_group_id.name', 'enGroup')
+      ->execute();
+    $sampleData = [
+      ['label' => 'Uno', 'name' => 'option_1', 'value' => 1],
+      ['label' => 'Dos', 'name' => 'option_2', 'value' => 2],
+      ['label' => 'Tres', 'name' => 'option_3', 'value' => 3],
+    ];
+    OptionValue::save(FALSE)
+      ->setRecords($sampleData)
+      ->addDefault('option_group_id.name', 'esGroup')
+      ->execute();
+
+    $optionOne = OptionValue::get(FALSE)
+      ->addSelect('label', 'previous.label', 'next.label')
+      ->addWhere('value', '=', 1)
+      ->addWhere('option_group_id:name', '=', 'enGroup')
+      ->execute()->single();
+    $this->assertNull($optionOne['previous.label']);
+    $this->assertEquals('One', $optionOne['label']);
+    $this->assertEquals('Two', $optionOne['next.label']);
+
+    $optionTwo = OptionValue::get(FALSE)
+      ->addSelect('previous', 'next')
+      ->addWhere('value', '=', 2)
+      ->addWhere('option_group_id:name', '=', 'esGroup')
+      ->execute()->single();
+    $this->assertEquals($optionTwo['id'] - 1, $optionTwo['previous']);
+    $this->assertEquals($optionTwo['id'] + 1, $optionTwo['next']);
+
+    $optionTres = OptionValue::get(FALSE)
+      ->addSelect('label', 'previous.label', 'next.label')
+      ->addWhere('value', '=', 3)
+      ->addWhere('option_group_id:name', '=', 'esGroup')
+      ->execute()->single();
+    $this->assertNull($optionTres['next.label']);
+    $this->assertEquals('Tres', $optionTres['label']);
+    $this->assertEquals('Dos', $optionTres['previous.label']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Addresses item `#4` in https://lab.civicrm.org/dev/core/-/issues/4711

Before
----------------------------------------
When inserting into the navigation menu (or other sortable list like an option group), picking a weight is pure guesswork. You just have to put in an integer and hope it lands in the right spot. Picking 0 will pretty reliably place it at the top; anything else is a roll of the dice.

After
----------------------------------------
Adds a `previous` and `next` joins in APIv4 which allows you to insert before/after another item by name.

For example, to add a navigation item just below "Find Contacts", you'd say `['previous.name' => 'Find Contacts']` in your managed declaration (in lieu of `'weight' => 5').

Technical Details
----------------------------------------
It's neat.