### PR TITLE
[REF] Civi - Refactor unnecessary uses of CRM_Utils_Array::value

### DIFF
--- a/Civi/API/Api3SelectQuery.php
+++ b/Civi/API/Api3SelectQuery.php
@@ -157,8 +157,8 @@ class Api3SelectQuery extends SelectQuery {
     }
     foreach ($this->apiFieldSpec as $field) {
       if (
-        $fieldName == \CRM_Utils_Array::value('uniqueName', $field) ||
-        array_search($fieldName, \CRM_Utils_Array::value('api.aliases', $field, [])) !== FALSE
+        $fieldName == ($field['uniqueName'] ?? NULL) ||
+        array_search($fieldName, $field['api.aliases'] ?? []) !== FALSE
       ) {
         return $field;
       }

--- a/Civi/API/SelectQuery.php
+++ b/Civi/API/SelectQuery.php
@@ -217,7 +217,7 @@ abstract class SelectQuery {
       }
       $fieldInfo = $fkField['FKApiSpec'][$fieldName] ?? NULL;
 
-      $keyColumn = \CRM_Utils_Array::value('FKKeyColumn', $fkField, 'id');
+      $keyColumn = $fkField['FKKeyColumn'] ?? 'id';
       if (!$fieldInfo || !isset($fkField['FKApiSpec'][$keyColumn])) {
         // Join doesn't exist - might be another param with a dot in it for some reason, we'll just ignore it.
         return NULL;
@@ -404,7 +404,7 @@ abstract class SelectQuery {
       $words = preg_split("/[\s]+/", $item);
       if ($words) {
         // Direction defaults to ASC unless DESC is specified
-        $direction = strtoupper(\CRM_Utils_Array::value(1, $words, '')) == 'DESC' ? ' DESC' : '';
+        $direction = strtoupper($words[1] ?? '') === 'DESC' ? ' DESC' : '';
         $field = $this->getField($words[0]);
         if ($field) {
           $this->query->orderBy(self::MAIN_TABLE_ALIAS . '.' . $field['name'] . $direction, NULL, $index);

--- a/Civi/API/Subscriber/ChainSubscriber.php
+++ b/Civi/API/Subscriber/ChainSubscriber.php
@@ -162,17 +162,16 @@ class ChainSubscriber implements EventSubscriberInterface {
               $defaultSubParams[$lowercase_entity . "_id"] = $parentAPIValues['id'];
             }
           }
-          // @todo remove strtolower: $subEntity is already lower case
-          if ($entity != 'Contact' && \CRM_Utils_Array::value(strtolower($subEntity . "_id"), $parentAPIValues)) {
+          if ($entity !== 'Contact' && !empty($parentAPIValues[$subEntity . '_id'])) {
             //e.g. if event_id is in the values returned & subentity is event
             //then pass in event_id as 'id' don't do this for contact as it
             //does some weird things like returning primary email &
             //thus limiting the ability to chain email
             //TODO - this might need the camel treatment
-            $defaultSubParams['id'] = $parentAPIValues[$subEntity . "_id"];
+            $defaultSubParams['id'] = $parentAPIValues[$subEntity . '_id'];
           }
 
-          if (\CRM_Utils_Array::value('entity_table', $result['values'][$idIndex]) == $subEntity) {
+          if (($result['values'][$idIndex]['entity_table'] ?? NULL) == $subEntity) {
             $defaultSubParams['id'] = $result['values'][$idIndex]['entity_id'];
           }
           // if we are dealing with the same entity pass 'id' through

--- a/Civi/API/Subscriber/DynamicFKAuthorization.php
+++ b/Civi/API/Subscriber/DynamicFKAuthorization.php
@@ -177,7 +177,7 @@ class DynamicFKAuthorization implements EventSubscriberInterface {
         $this->authorizeDelegate(
           $apiRequest['action'],
           $apiRequest['params']['entity_table'],
-          \CRM_Utils_Array::value('entity_id', $apiRequest['params'], NULL),
+          $apiRequest['params']['entity_id'] ?? NULL,
           $apiRequest
         );
         return;

--- a/Civi/API/WhitelistRule.php
+++ b/Civi/API/WhitelistRule.php
@@ -181,7 +181,7 @@ class WhitelistRule {
         // Kind'a silly we need to (re(re))parse here for each rule; would be more
         // performant if pre-parsed by Request::create().
         $options = _civicrm_api3_get_options_from_params($apiRequest['params'], TRUE, $apiRequest['entity'], 'get');
-        $return = \CRM_Utils_Array::value('return', $options, []);
+        $return = $options['return'] ?? [];
         $activatedFields = array_merge($activatedFields, array_keys($return));
       }
 

--- a/Civi/Core/SettingsManager.php
+++ b/Civi/Core/SettingsManager.php
@@ -239,7 +239,7 @@ class SettingsManager {
    */
   protected function getMandatory($entity) {
     if ($this->mandatory === NULL) {
-      $this->mandatory = self::parseMandatorySettings(\CRM_Utils_Array::value('civicrm_setting', $GLOBALS));
+      $this->mandatory = self::parseMandatorySettings($GLOBALS['civicrm_setting'] ?? NULL);
     }
     return $this->mandatory[$entity];
   }

--- a/Civi/Core/SettingsMetadata.php
+++ b/Civi/Core/SettingsMetadata.php
@@ -155,7 +155,7 @@ class SettingsMetadata {
       // but it's tightly coupled to DAO/field. However, if you really need to support
       // more pseudoconstant types, then probably best to refactor it. For now, KISS.
       if (!empty($pseudoconstant['optionGroupName'])) {
-        $keyColumn = \CRM_Utils_Array::value('keyColumn', $pseudoconstant, 'value');
+        $keyColumn = $pseudoconstant['keyColumn'] ?? 'value';
         if (is_array($optionsFormat)) {
           $optionValues = \CRM_Core_OptionValue::getValues(['name' => $pseudoconstant['optionGroupName']]);
           foreach ($optionValues as $option) {

--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -187,7 +187,7 @@ class TokenRow {
       'return' => $customFieldName,
       'id' => $entityID,
     ]);
-    $fieldValue = \CRM_Utils_Array::value($customFieldName, $record, '');
+    $fieldValue = $record[$customFieldName] ?? '';
     $originalValue = $fieldValue;
     // format the raw custom field value into proper display value
     if (isset($fieldValue)) {
@@ -281,7 +281,7 @@ class TokenRow {
               if ($entity == 'activity' && $field == 'details') {
                 $htmlTokens[$entity][$field] = $value;
               }
-              elseif (\CRM_Utils_Array::value('data_type', \CRM_Utils_Array::value($field, $entityFields['values'])) == 'Memo') {
+              elseif (($entityFields['values'][$field]['data_type'] ?? NULL) === 'Memo') {
                 // Memo fields aka custom fields of type Note are html.
                 $htmlTokens[$entity][$field] = \CRM_Utils_String::purifyHTML($value);
               }


### PR DESCRIPTION
Overview
----------------------------------------
Part of ongoing cleanup work to deprecate/remove php5-era function `CRM_Utils_Array::value`.

Before
----------------------------------------
Code less readable; deprecated function used.

After
----------------------------------------
Code more readable and up-to-date.