### PR TITLE
fixes core#4724 - on behalf of addresses crash with missing state/province

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -328,7 +328,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           [$field, $locType] = explode('-', $loc);
         }
 
-        if (in_array($field, $addressBlocks)) {
+        if (in_array($field, $addressBlocks) && !empty($value)) {
           if ($locType === 'Primary') {
             $defaultLocationType = CRM_Core_BAO_LocationType::getDefault();
             $locType = $defaultLocationType->id;


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/4724.

Before
----------------------------------------
"On behalf of" contributions with a missing state/province crash geocoding.

After
----------------------------------------
No crash.

Technical Details
----------------------------------------
When you do a pseudoconstant lookup with no value, it returns every value.  So instead of getting back a single state/province value  to pass to the geocoder, you get a whole array of them.  And when the array is passed through `strtolower()` you get a TypeError.

Comments
----------------------------------------
Rather than handle this on just the state/province, I'm skipping processing of any empty address field.  I don't know why we'd try to record an address field that doesn't exist.
