### PR TITLE
fixes core#2929: Don't crash a contribution because of a geocoding failure

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1283,8 +1283,13 @@ SELECT is_primary,
     catch (CRM_Core_Exception $e) {
       $providerExists = FALSE;
     }
-    if ($providerExists) {
-      $provider::format($params);
+    try {
+      if ($providerExists) {
+        $provider::format($params);
+      }
+    }
+    catch (CRM_Core_Exception $e) {
+      \Civi::log()->error('Geocoding error:' . $e->getMessage());
     }
     // dev/core#2379 - Limit geocode length to 14 characters to avoid validation error on save in UI.
     foreach (['geo_code_1', 'geo_code_2'] as $geocode) {

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1289,7 +1289,7 @@ SELECT is_primary,
       }
     }
     catch (CRM_Core_Exception $e) {
-      \Civi::log()->error('Geocoding error:' . $e->getMessage());
+      \Civi::log()->error('Geocoding error:' . $e->getMessage(), ['geocoder' => get_class($provider), 'input' => $params]);
     }
     // dev/core#2379 - Limit geocode length to 14 characters to avoid validation error on save in UI.
     foreach (['geo_code_1', 'geo_code_2'] as $geocode) {


### PR DESCRIPTION
Overview
----------------------------------------
Geocoding failures will cause a contribution to fail, giving a WSOD to the donor.

Before
----------------------------------------
WSOD.

After
----------------------------------------
Error logged in ConfigAndLog.  Contribution completes.

Comments
----------------------------------------
Not really.
