### PR TITLE
[REF] Apiv3 - Refactor unnecessary uses of CRM_Utils_Array::value

### DIFF
--- a/api/api.php
+++ b/api/api.php
@@ -135,7 +135,7 @@ function civicrm_api3(string $entity, string $action, array $params = []) {
   $params['version'] = 3;
   $result = \Civi::service('civi_api_kernel')->runSafe($entity, $action, $params);
   if (is_array($result) && !empty($result['is_error'])) {
-    throw new CRM_Core_Exception($result['error_message'], CRM_Utils_Array::value('error_code', $result, 'undefined'), $result);
+    throw new CRM_Core_Exception($result['error_message'], $result['error_code'] ?? 'undefined', $result);
   }
   return $result;
 }

--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -511,7 +511,7 @@ function _civicrm_api3_activity_get_formatResult($params, $activities, $options)
   if (!empty($returnProperties) || !empty($params['contact_id'])) {
     foreach ($activities as $activityId => $values) {
       //@todo - should possibly load activity type id if not loaded (update with id)
-      _civicrm_api3_custom_data_get($activities[$activityId], CRM_Utils_Array::value('check_permissions', $params), 'Activity', $activityId, NULL, CRM_Utils_Array::value('activity_type_id', $values));
+      _civicrm_api3_custom_data_get($activities[$activityId], $params['check_permissions'] ?? NULL, 'Activity', $activityId, NULL, $values['activity_type_id'] ?? NULL);
     }
   }
   return $activities;

--- a/api/v3/Attachment.php
+++ b/api/v3/Attachment.php
@@ -207,9 +207,9 @@ function _civicrm_api3_attachment_delete_spec(&$spec) {
   $spec['entity_table'] = $entityFileFields['entity_table'];
   // Historically this field had no pseudoconstant and APIv3 can't handle it
   $spec['entity_table']['pseudoconstant'] = NULL;
-  $spec['entity_table']['title'] = CRM_Utils_Array::value('title', $spec['entity_table'], 'Entity Table') . ' (write-once)';
+  $spec['entity_table']['title'] = ($spec['entity_table']['title'] ?? 'Entity Table') . ' (write-once)';
   $spec['entity_id'] = $entityFileFields['entity_id'];
-  $spec['entity_id']['title'] = CRM_Utils_Array::value('title', $spec['entity_id'], 'Entity ID') . ' (write-once)';
+  $spec['entity_id']['title'] = ($spec['entity_id']['title'] ?? 'Entity ID') . ' (write-once)';
 }
 
 /**
@@ -469,10 +469,10 @@ function _civicrm_api3_attachment_getfields() {
   // Historically this field had no pseudoconstant and APIv3 can't handle it
   $spec['entity_table']['pseudoconstant'] = NULL;
   // Would be hard to securely handle changes.
-  $spec['entity_table']['title'] = CRM_Utils_Array::value('title', $spec['entity_table'], 'Entity Table') . ' (write-once)';
+  $spec['entity_table']['title'] = ($spec['entity_table']['title'] ?? 'Entity Table') . ' (write-once)';
   $spec['entity_id'] = $entityFileFields['entity_id'];
   // would be hard to securely handle changes
-  $spec['entity_id']['title'] = CRM_Utils_Array::value('title', $spec['entity_id'], 'Entity ID') . ' (write-once)';
+  $spec['entity_id']['title'] = ($spec['entity_id']['title'] ?? 'Entity ID') . ' (write-once)';
   $spec['url'] = [
     'title' => 'URL (read-only)',
     'description' => 'URL for downloading the file (not searchable, expire-able)',

--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -571,7 +571,7 @@ function civicrm_api3_case_delete($params) {
   //check parameters
   civicrm_api3_verify_mandatory($params, NULL, ['id']);
 
-  if (CRM_Case_BAO_Case::deleteCase($params['id'], CRM_Utils_Array::value('move_to_trash', $params, FALSE))) {
+  if (CRM_Case_BAO_Case::deleteCase($params['id'], $params['move_to_trash'] ?? FALSE)) {
     return civicrm_api3_create_success($params, $params, 'Case', 'delete');
   }
   else {

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -35,7 +35,7 @@
  * @throws \CRM_Core_Exception
  */
 function civicrm_api3_contact_create($params) {
-  $contactID = CRM_Utils_Array::value('contact_id', $params, CRM_Utils_Array::value('id', $params));
+  $contactID = CRM_Utils_Array::value('contact_id', $params, $params['id'] ?? NULL);
 
   if ($contactID && !empty($params['check_permissions']) && !CRM_Contact_BAO_Contact_Permission::allow($contactID, CRM_Core_Permission::EDIT)) {
     throw new \Civi\API\Exception\UnauthorizedException('Permission denied to modify contact record');
@@ -55,13 +55,14 @@ function civicrm_api3_contact_create($params) {
 
   if (!$contactID) {
     // If we get here, we're ready to create a new contact
-    if (($email = CRM_Utils_Array::value('email', $params)) && !is_array($params['email'])) {
+    $email = $params['email'] ?? NULL;
+    if ($email && !is_array($params['email'])) {
       $defLocType = CRM_Core_BAO_LocationType::getDefault();
       $params['email'] = [
         1 => [
           'email' => $email,
           'is_primary' => 1,
-          'location_type_id' => ($defLocType->id) ? $defLocType->id : 1,
+          'location_type_id' => $defLocType->id ?: 1,
         ],
       ];
     }
@@ -471,8 +472,7 @@ function civicrm_api3_contact_delete($params) {
   if ($skipUndelete && CRM_Financial_BAO_FinancialItem::checkContactPresent([$contactID], $error)) {
     throw new CRM_Core_Exception($error['_qf_default']);
   }
-  if (CRM_Contact_BAO_Contact::deleteContact($contactID, $restore, $skipUndelete,
-    CRM_Utils_Array::value('check_permissions', $params))) {
+  if (CRM_Contact_BAO_Contact::deleteContact($contactID, $restore, $skipUndelete, $params['check_permissions'] ?? FALSE)) {
     return civicrm_api3_create_success();
   }
   throw new CRM_Core_Exception('Could not delete contact');
@@ -763,7 +763,7 @@ function civicrm_api3_contact_merge($params) {
     [],
     $params['mode'],
     FALSE,
-    CRM_Utils_Array::value('check_permissions', $params)
+    $params['check_permissions'] ?? FALSE
     )) != FALSE) {
 
     return civicrm_api3_create_success($result, $params);
@@ -1204,9 +1204,9 @@ function civicrm_api3_contact_duplicatecheck($params) {
     $params['match'],
     $params['match']['contact_type'],
     $params['rule_type'] ?? '',
-    CRM_Utils_Array::value('exclude', $params, []),
-    CRM_Utils_Array::value('check_permissions', $params),
-    CRM_Utils_Array::value('dedupe_rule_id', $params)
+    $params['exclude'] ?? [],
+    $params['check_permissions'] ?? FALSE,
+    $params['dedupe_rule_id'] ?? NULL
   );
   $values = [];
   if ($dupes && !empty($params['return'])) {

--- a/api/v3/CustomValue.php
+++ b/api/v3/CustomValue.php
@@ -120,7 +120,7 @@ function civicrm_api3_custom_value_get($params) {
 
   $getParams = [
     'entityID' => $params['entity_id'],
-    'entityType' => CRM_Utils_Array::value('entity_table', $params, ''),
+    'entityType' => $params['entity_table'] ?? '',
   ];
   if (strstr($getParams['entityType'], 'civicrm_')) {
     $getParams['entityType'] = ucfirst(substr($getParams['entityType'], 8));

--- a/api/v3/Cxn.php
+++ b/api/v3/Cxn.php
@@ -123,7 +123,7 @@ function civicrm_api3_cxn_unregister($params) {
 
   /** @var \Civi\Cxn\Rpc\RegistrationClient $client */
   $client = \Civi::service('cxn_reg_client');
-  list($cxnId, $result) = $client->unregister($appMeta, CRM_Utils_Array::value('force', $params, FALSE));
+  [$cxnId, $result] = $client->unregister($appMeta, $params['force'] ?? FALSE);
 
   return $result;
 }

--- a/api/v3/Dedupe.php
+++ b/api/v3/Dedupe.php
@@ -89,10 +89,10 @@ function civicrm_api3_dedupe_create($params) {
 function civicrm_api3_dedupe_getstatistics($params) {
   $stats = CRM_Dedupe_Merger::getMergeStats(CRM_Dedupe_Merger::getMergeCacheKeyString(
     $params['rule_group_id'],
-    CRM_Utils_Array::value('group_id', $params),
-    CRM_Utils_Array::value('criteria', $params, []),
+    $params['group_id'] ?? NULL,
+    $params['criteria'] ?? [],
     !empty($params['check_permissions']),
-    CRM_Utils_Array::value('search_limit', $params, 0)
+    $params['search_limit'] ?? 0
   ));
   return civicrm_api3_create_success($stats);
 }
@@ -139,7 +139,7 @@ function _civicrm_api3_dedupe_getstatistics_spec(&$params) {
  */
 function civicrm_api3_dedupe_getduplicates($params) {
   $options = _civicrm_api3_get_options_from_params($params);
-  $dupePairs = CRM_Dedupe_Merger::getDuplicatePairs($params['rule_group_id'], NULL, TRUE, $options['limit'], FALSE, TRUE, $params['criteria'], CRM_Utils_Array::value('check_permissions', $params), CRM_Utils_Array::value('search_limit', $params, 0), CRM_Utils_Array::value('is_force_new_search', $params));
+  $dupePairs = CRM_Dedupe_Merger::getDuplicatePairs($params['rule_group_id'], NULL, TRUE, $options['limit'], FALSE, TRUE, $params['criteria'], $params['check_permissions'] ?? FALSE, $params['search_limit'] ?? 0, $params['is_force_new_search'] ?? 0);
   return civicrm_api3_create_success($dupePairs);
 }
 

--- a/api/v3/EntityTag.php
+++ b/api/v3/EntityTag.php
@@ -123,8 +123,7 @@ function _civicrm_api3_entity_tag_common($params, $op = 'add') {
   if ($op == 'add') {
     $values['total_count'] = $values['added'] = $values['not_added'] = 0;
     foreach ($tagIDs as $tagID) {
-      list($te, $a, $na) = CRM_Core_BAO_EntityTag::addEntitiesToTag($entityIDs, $tagID, $entityTable,
-        CRM_Utils_Array::value('check_permissions', $params));
+      list($te, $a, $na) = CRM_Core_BAO_EntityTag::addEntitiesToTag($entityIDs, $tagID, $entityTable, $params['check_permissions'] ?? FALSE);
       $values['total_count'] += $te;
       $values['added'] += $a;
       $values['not_added'] += $na;
@@ -133,7 +132,7 @@ function _civicrm_api3_entity_tag_common($params, $op = 'add') {
   else {
     $values['total_count'] = $values['removed'] = $values['not_removed'] = 0;
     foreach ($tagIDs as $tagID) {
-      list($te, $r, $nr) = CRM_Core_BAO_EntityTag::removeEntitiesFromTag($entityIDs, $tagID, $entityTable, CRM_Utils_Array::value('check_permissions', $params));
+      list($te, $r, $nr) = CRM_Core_BAO_EntityTag::removeEntitiesFromTag($entityIDs, $tagID, $entityTable, $params['check_permissions'] ?? FALSE);
       $values['total_count'] += $te;
       $values['removed'] += $r;
       $values['not_removed'] += $nr;

--- a/api/v3/Extension.php
+++ b/api/v3/Extension.php
@@ -210,6 +210,7 @@ function _civicrm_api3_extension_uninstall_spec(&$fields) {
  *   API result
  */
 function civicrm_api3_extension_download($params) {
+  $params += ['install' => TRUE];
   if (!array_key_exists('url', $params)) {
     if (!CRM_Extension_System::singleton()->getBrowser()->isEnabled()) {
       throw new CRM_Core_Exception('Automatic downloading is disabled. Try adding parameter "url"');
@@ -241,7 +242,7 @@ function civicrm_api3_extension_download($params) {
   }
   CRM_Extension_System::singleton()->getCache()->flush();
   CRM_Extension_System::singleton(TRUE);
-  if (CRM_Utils_Array::value('install', $params, TRUE)) {
+  if ($params['install']) {
     CRM_Extension_System::singleton()->getManager()->install([$params['key']]);
   }
 
@@ -387,7 +388,7 @@ function civicrm_api3_extension_getremote($params) {
     $info = array_merge($info, (array) $obj);
     $result[] = $info;
   }
-  return _civicrm_api3_basic_array_get('Extension', $params, $result, 'id', CRM_Utils_Array::value('return', $params, []));
+  return _civicrm_api3_basic_array_get('Extension', $params, $result, 'id', $params['return'] ?? []);
 }
 
 /**

--- a/api/v3/Generic.php
+++ b/api/v3/Generic.php
@@ -60,11 +60,11 @@ function civicrm_api3_generic_getfields($apiRequest, $unique = TRUE) {
   }
   $entity = $apiRequest['entity'];
   $lowercase_entity = _civicrm_api_get_entity_name_from_camel($entity);
-  $subentity    = $apiRequest['params']['contact_type'] ?? NULL;
+  $subentity = $apiRequest['params']['contact_type'] ?? NULL;
   $action = $apiRequest['params']['action'] ?? NULL;
   $sequential = empty($apiRequest['params']['sequential']) ? 0 : 1;
-  $apiRequest['params']['options'] = CRM_Utils_Array::value('options', $apiRequest['params'], []);
-  $optionsToResolve = (array) CRM_Utils_Array::value('get_options', $apiRequest['params']['options'], []);
+  $apiRequest['params']['options'] = $apiRequest['params']['options'] ?? [];
+  $optionsToResolve = (array) ($apiRequest['params']['options']['get_options'] ?? []);
 
   if (!$action || $action == 'getvalue' || $action == 'getcount') {
     $action = 'get';
@@ -477,7 +477,7 @@ function _civicrm_api3_generic_getoptions_spec(&$params, $apiRequest) {
     $params['field']['options'] = [];
     foreach ($fields['values'] as $name => $field) {
       if (isset($field['pseudoconstant']) || CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_BOOLEAN) {
-        $params['field']['options'][$name] = CRM_Utils_Array::value('title', $field, $name);
+        $params['field']['options'][$name] = $field['title'] ?? $name;
       }
     }
   }

--- a/api/v3/Generic/Setvalue.php
+++ b/api/v3/Generic/Setvalue.php
@@ -56,7 +56,7 @@ function civicrm_api3_generic_setValue($apiRequest) {
   }
 
   $def = $fields[$fieldKey];
-  $title = CRM_Utils_Array::value('title', $def, ts('Field'));
+  $title = $def['title'] ?? ts('Field');
   // Disallow empty values except for the number zero.
   // TODO: create a utility for this since it's needed in many places
   if (!empty($def['required']) || !empty($def['is_required'])) {

--- a/api/v3/GroupContact.php
+++ b/api/v3/GroupContact.php
@@ -50,7 +50,7 @@ function civicrm_api3_group_contact_get($params) {
     //ie. id passed in so we have to return something
     return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
   }
-  $status = CRM_Utils_Array::value('status', $params, 'Added');
+  $status = $params['status'] ?? 'Added';
 
   $groupId = $params['group_id'] ?? NULL;
   $values = CRM_Contact_BAO_GroupContact::getContactGroup($params['contact_id'], $status, NULL, FALSE, TRUE, FALSE, TRUE, $groupId);
@@ -217,8 +217,8 @@ function _civicrm_api3_group_contact_common($params, $op = 'Added') {
     }
   }
 
-  $method = CRM_Utils_Array::value('method', $params, 'API');
-  $status = CRM_Utils_Array::value('status', $params, $op);
+  $method = $params['method'] ?? 'API';
+  $status = $params['status'] ?? $op;
   $tracking = $params['tracking'] ?? NULL;
 
   if ($op == 'Added' || $op == 'Pending') {
@@ -274,9 +274,9 @@ function civicrm_api3_group_contact_update_status($params) {
   CRM_Contact_BAO_GroupContact::addContactsToGroup(
     [$params['contact_id']],
     $params['group_id'],
-    CRM_Utils_Array::value('method', $params, 'API'),
+    $params['method'] ?? 'API',
     'Added',
-    CRM_Utils_Array::value('tracking', $params)
+    $params['tracking'] ?? NULL
   );
 
   return TRUE;

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -535,11 +535,10 @@ function civicrm_api3_job_process_batch_merge($params) {
       'options' => ['limit' => 1],
     ]);
   }
-  $rgid = $params['rgid'] ?? NULL;
   $gid = $params['gid'] ?? NULL;
-  $mode = CRM_Utils_Array::value('mode', $params, 'safe');
+  $mode = $params['mode'] ?? 'safe';
 
-  $result = CRM_Dedupe_Merger::batchMerge($rule_group_id, $gid, $mode, 1, 2, CRM_Utils_Array::value('criteria', $params, []), CRM_Utils_Array::value('check_permissions', $params), NULL, $params['search_limit']);
+  $result = CRM_Dedupe_Merger::batchMerge($rule_group_id, $gid, $mode, 1, 2, $params['criteria'] ?? [], $params['check_permissions'] ?? FALSE, NULL, $params['search_limit']);
 
   return civicrm_api3_create_success($result, $params);
 }
@@ -622,15 +621,15 @@ function civicrm_api3_job_run_payment_cron($params) {
  * @return array
  */
 function civicrm_api3_job_cleanup($params) {
-  $session   = CRM_Utils_Array::value('session', $params, TRUE);
-  $tempTable = CRM_Utils_Array::value('tempTables', $params, TRUE);
-  $jobLog    = CRM_Utils_Array::value('jobLog', $params, TRUE);
-  $expired   = CRM_Utils_Array::value('expiredDbCache', $params, TRUE);
-  $prevNext  = CRM_Utils_Array::value('prevNext', $params, TRUE);
-  $dbCache   = CRM_Utils_Array::value('dbCache', $params, FALSE);
-  $memCache  = CRM_Utils_Array::value('memCache', $params, FALSE);
-  $tplCache  = CRM_Utils_Array::value('tplCache', $params, FALSE);
-  $wordRplc  = CRM_Utils_Array::value('wordRplc', $params, FALSE);
+  $session = $params['session'] ?? TRUE;
+  $tempTable = $params['tempTables'] ?? TRUE;
+  $jobLog = $params['jobLog'] ?? TRUE;
+  $expired = $params['expiredDbCache'] ?? TRUE;
+  $prevNext = $params['prevNext'] ?? TRUE;
+  $dbCache = $params['dbCache'] ?? FALSE;
+  $memCache = $params['memCache'] ?? FALSE;
+  $tplCache = $params['tplCache'] ?? FALSE;
+  $wordRplc = $params['wordRplc'] ?? FALSE;
 
   if ($session || $tempTable || $prevNext || $expired) {
     CRM_Core_BAO_Cache::cleanup($session, $tempTable, $prevNext, $expired);

--- a/api/v3/LocBlock.php
+++ b/api/v3/LocBlock.php
@@ -54,7 +54,7 @@ function civicrm_api3_loc_block_create($params) {
         }
         // Bother calling the api.
         else {
-          $info['contact_id'] = CRM_Utils_Array::value('contact_id', $info, 'null');
+          $info['contact_id'] = $info['contact_id'] ?? 'null';
           $result = civicrm_api3($item, 'create', $info);
           $entities[$key] = $result['values'][$result['id']];
           $params[$key . '_id'] = $result['id'];

--- a/api/v3/Logging.php
+++ b/api/v3/Logging.php
@@ -27,7 +27,7 @@
  */
 function civicrm_api3_logging_revert($params) {
   $schema = new CRM_Logging_Schema();
-  $reverter = new CRM_Logging_Reverter($params['log_conn_id'], CRM_Utils_Array::value('log_date', $params));
+  $reverter = new CRM_Logging_Reverter($params['log_conn_id'], $params['log_date'] ?? NULL);
   $tables = !empty($params['tables']) ? (array) $params['tables'] : $schema->getLogTablesForContact();
   $reverter->calculateDiffsFromLogConnAndDate($tables);
   $reverter->revert();
@@ -79,7 +79,7 @@ function _civicrm_api3_logging_revert_spec(&$params) {
 function civicrm_api3_logging_get($params) {
   $schema = new CRM_Logging_Schema();
   $interval = (empty($params['log_date'])) ? NULL : $params['interval'];
-  $differ = new CRM_Logging_Differ($params['log_conn_id'], CRM_Utils_Array::value('log_date', $params), $interval);
+  $differ = new CRM_Logging_Differ($params['log_conn_id'], $params['log_date'] ?? NULL, $interval);
   $tables = !empty($params['tables']) ? (array) $params['tables'] : $schema->getLogTablesForContact();
   return civicrm_api3_create_success($differ->getAllChangesForConnection($tables));
 }

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -294,7 +294,7 @@ function civicrm_api3_mailing_submit($params) {
   if (isset($params['approval_date'])) {
     $updateParams['approval_date'] = $params['approval_date'];
     $updateParams['approver_id'] = CRM_Core_Session::getLoggedInContactID();
-    $updateParams['approval_status_id'] = CRM_Utils_Array::value('approval_status_id', $updateParams, CRM_Core_OptionGroup::getDefaultValue('mail_approval_status'));
+    $updateParams['approval_status_id'] = $updateParams['approval_status_id'] ?? CRM_Core_OptionGroup::getDefaultValue('mail_approval_status');
   }
   if (isset($params['approval_note'])) {
     $updateParams['approval_note'] = $params['approval_note'];

--- a/api/v3/Membership.php
+++ b/api/v3/Membership.php
@@ -95,10 +95,10 @@ function civicrm_api3_membership_create($params) {
       // This is a new membership, calculate the membership dates.
       $calcDates = CRM_Member_BAO_MembershipType::getDatesForMembershipType(
         $params['membership_type_id'],
-        CRM_Utils_Array::value('join_date', $params),
-        CRM_Utils_Array::value('start_date', $params),
-        CRM_Utils_Array::value('end_date', $params),
-        CRM_Utils_Array::value('num_terms', $params, 1)
+        $params['join_date'] ?? NULL,
+        $params['start_date'] ?? NULL,
+        $params['end_date'] ?? NULL,
+        $params['num_terms'] ?? 1
       );
     }
     else {
@@ -108,7 +108,7 @@ function civicrm_api3_membership_create($params) {
       $calcDates = CRM_Member_BAO_MembershipType::getRenewalDatesForMembershipType(
         $params['id'],
         NULL,
-        CRM_Utils_Array::value('membership_type_id', $params),
+        $params['membership_type_id'] ?? NULL,
         $params['num_terms']
       );
     }
@@ -212,7 +212,7 @@ function civicrm_api3_membership_get($params) {
     $activeOnly = $params['filters']['is_current'];
     unset($params['filters']['is_current']);
   }
-  $activeOnly = CRM_Utils_Array::value('active_only', $params, $activeOnly);
+  $activeOnly = $params['active_only'] ?? $activeOnly;
   if ($activeOnly && empty($params['status_id'])) {
     $params['status_id'] = ['IN' => CRM_Member_BAO_MembershipStatus::getMembershipStatusCurrent()];
   }
@@ -269,7 +269,7 @@ function _civicrm_api3_membership_relationsship_get_customv2behaviour(&$params, 
       $membershipValues[$membershipId]['relationship_name'] = $relationshipType->name_a_b;
     }
 
-    _civicrm_api3_custom_data_get($membershipValues[$membershipId], CRM_Utils_Array::value('check_permissions', $params), 'Membership', $membershipId, NULL, $values['membership_type_id']);
+    _civicrm_api3_custom_data_get($membershipValues[$membershipId], $params['check_permissions'] ?? FALSE, 'Membership', $membershipId, NULL, $values['membership_type_id']);
   }
 
   $members = $membershipValues;

--- a/api/v3/MembershipStatus.php
+++ b/api/v3/MembershipStatus.php
@@ -148,7 +148,7 @@ SELECT start_date, end_date, join_date, membership_type_id
   $dao = CRM_Core_DAO::executeQuery($query, $params);
   if ($dao->fetch()) {
     $membershipTypeID = empty($membershipParams['membership_type_id']) ? $dao->membership_type_id : $membershipParams['membership_type_id'];
-    $result = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($dao->start_date, $dao->end_date, $dao->join_date, 'now', CRM_Utils_Array::value('ignore_admin_only', $membershipParams), $membershipTypeID, $membershipParams);
+    $result = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($dao->start_date, $dao->end_date, $dao->join_date, 'now', $membershipParams['ignore_admin_only'] ?? FALSE, $membershipTypeID, $membershipParams);
     //make is error zero only when valid status found.
     if (!empty($result['id'])) {
       $result['is_error'] = 0;

--- a/api/v3/Participant.php
+++ b/api/v3/Participant.php
@@ -151,7 +151,7 @@ function civicrm_api3_participant_get($params) {
     $query->convertToPseudoNames($dao, FALSE, TRUE);
     $participant[$dao->participant_id] = $query->store($dao);
     //@todo - is this required - contribution & pledge use the same query but don't self-retrieve custom data
-    _civicrm_api3_custom_data_get($participant[$dao->participant_id], CRM_Utils_Array::value('check_permissions', $params), 'Participant', $dao->participant_id, NULL);
+    _civicrm_api3_custom_data_get($participant[$dao->participant_id], $params['check_permissions'] ?? FALSE, 'Participant', $dao->participant_id, NULL);
   }
 
   return civicrm_api3_create_success($participant, $params, 'Participant', 'get', $dao);

--- a/api/v3/Profile.php
+++ b/api/v3/Profile.php
@@ -81,7 +81,7 @@ function civicrm_api3_profile_get($params) {
 
       $contactFields = $activityFields = [];
       foreach ($profileFields as $fieldName => $field) {
-        if (CRM_Utils_Array::value('field_type', $field) == 'Activity') {
+        if (($field['field_type'] ?? NULL) === 'Activity') {
           $activityFields[$fieldName] = $field;
         }
         else {
@@ -244,7 +244,7 @@ function civicrm_api3_profile_submit($params) {
     ];
   }
 
-  $contactParams['contact_id'] = empty($params['contact_id']) ? CRM_Utils_Array::value('id', $params) : $params['contact_id'];
+  $contactParams['contact_id'] = empty($params['contact_id']) ? ($params['id'] ?? NULL) : $params['contact_id'];
   $contactParams['profile_id'] = $profileID;
   $contactParams['skip_custom'] = 1;
 
@@ -298,7 +298,7 @@ function _civicrm_api3_profile_submit_spec(&$params, $apirequest) {
     // we don't resolve state, country & county for performance reasons
     $resolveOptions = ($apirequest['params']['get_options'] ?? NULL) == 'all';
     $profileID = _civicrm_api3_profile_getProfileID($apirequest['params']['profile_id']);
-    $params = _civicrm_api3_buildprofile_submitfields($profileID, $resolveOptions, CRM_Utils_Array::value('cache_clear', $params));
+    $params = _civicrm_api3_buildprofile_submitfields($profileID, $resolveOptions, $params['cache_clear'] ?? FALSE);
   }
   elseif (isset($apirequest['params']['cache_clear'])) {
     _civicrm_api3_buildprofile_submitfields(FALSE, FALSE, TRUE);
@@ -360,10 +360,10 @@ function civicrm_api3_profile_apply($params) {
 
   list($data, $contactDetails) = CRM_Contact_BAO_Contact::formatProfileContactParams($params,
     $profileFields,
-    CRM_Utils_Array::value('contact_id', $params),
+    $params['contact_id'] ?? NULL,
     $params['profile_id'],
-    CRM_Utils_Array::value('contact_type', $params),
-    CRM_Utils_Array::value('skip_custom', $params, FALSE)
+    $params['contact_type'] ?? NULL,
+    $params['skip_custom'] ?? FALSE
   );
 
   if (empty($data)) {

--- a/api/v3/Setting.php
+++ b/api/v3/Setting.php
@@ -45,10 +45,10 @@ function civicrm_api3_setting_getfields($params) {
     $params['filters']['name'] = $params['name'];
   }
   $result = CRM_Core_BAO_Setting::getSettingSpecification(
-    CRM_Utils_Array::value('component_id', $params),
-    CRM_Utils_Array::value('filters', $params, []),
-    CRM_Utils_Array::value('domain_id', $params, NULL),
-    CRM_Utils_Array::value('profile', $params, NULL)
+    $params['component_id'] ?? NULL,
+    $params['filters'] ?? [],
+    $params['domain_id'] ?? NULL,
+    $params['profile'] ?? NULL
   );
   // find any supplemental information
   if (!empty($params['action'])) {
@@ -296,7 +296,7 @@ function _civicrm_api3_setting_create_spec(&$params) {
  */
 function civicrm_api3_setting_get($params) {
   $domains = _civicrm_api3_setting_getDomainArray($params);
-  $result = CRM_Core_BAO_Setting::getItems($params, $domains, CRM_Utils_Array::value('return', $params, []));
+  $result = CRM_Core_BAO_Setting::getItems($params, $domains, $params['return'] ?? []);
   return civicrm_api3_create_success($result, $params, 'Setting', 'get');
 }
 
@@ -338,11 +338,11 @@ function civicrm_api3_setting_getvalue($params) {
   //}
   return CRM_Core_BAO_Setting::getItem(
     NULL,
-    CRM_Utils_Array::value('name', $params),
-    CRM_Utils_Array::value('component_id', $params),
-    CRM_Utils_Array::value('default_value', $params),
-    CRM_Utils_Array::value('contact_id', $params),
-    CRM_Utils_Array::value('domain_id', $params)
+    $params['name'] ?? NULL,
+    $params['component_id'] ?? NULL,
+    $params['default_value'] ?? NULL,
+    $params['contact_id'] ?? NULL,
+    $params['domain_id'] ?? NULL
   );
 }
 

--- a/api/v3/System.php
+++ b/api/v3/System.php
@@ -29,8 +29,8 @@
  */
 function civicrm_api3_system_flush($params) {
   CRM_Core_Invoke::rebuildMenuAndCaches(
-    CRM_Utils_Array::value('triggers', $params, FALSE),
-    CRM_Utils_Array::value('session', $params, FALSE)
+    $params['triggers'] ?? FALSE,
+    $params['session'] ?? FALSE
   );
   return civicrm_api3_create_success();
 }

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -497,12 +497,12 @@ function _civicrm_api3_get_using_query_object($entity, $params, $additional_opti
   $options = _civicrm_api3_get_options_from_params($params, TRUE);
 
   $inputParams = array_merge(
-    CRM_Utils_Array::value('input_params', $options, []),
-    CRM_Utils_Array::value('input_params', $additional_options, [])
+    $options['input_params'] ?? [],
+    $additional_options['input_params'] ?? []
   );
   $returnProperties = array_merge(
-    CRM_Utils_Array::value('return', $options, []),
-    CRM_Utils_Array::value('return', $additional_options, [])
+    $options['return'] ?? [],
+    $additional_options['return'] ?? []
   );
   if (empty($returnProperties)) {
     $returnProperties = $defaultReturnProperties;
@@ -579,7 +579,7 @@ function _civicrm_api3_get_query_object($params, $mode, $entity) {
   $sort = $options['sort'] ?? NULL;
   $offset = $options['offset'] ?? NULL;
   $rowCount = $options['limit'] ?? NULL;
-  $inputParams = CRM_Utils_Array::value('input_params', $options, []);
+  $inputParams = $options['input_params'] ?? [];
   $returnProperties = $options['return'] ?? NULL;
   if (empty($returnProperties)) {
     $returnProperties = CRM_Contribute_BAO_Query::defaultReturnProperties($mode);
@@ -767,15 +767,15 @@ function _civicrm_api3_get_options_from_params($params, $queryObject = FALSE, $e
   $sort = $params['option_sort'] ?? $params['option.sort'] ?? $params['sort'] ?? 0;
   $offset = $params['option_offset'] ?? $params['option.offset'] ?? $params['offset'] ?? 0;
 
-  $limit = CRM_Utils_Array::value('rowCount', $params, 25);
-  $limit = CRM_Utils_Array::value('option.limit', $params, $limit);
-  $limit = CRM_Utils_Array::value('option_limit', $params, $limit);
+  $limit = $params['rowCount'] ?? 25;
+  $limit = $params['option.limit'] ?? $limit;
+  $limit = $params['option_limit'] ?? $limit;
 
   if (isset($params['options']) && is_array($params['options'])) {
     // is count is set by generic getcount not user
     $is_count = $params['options']['is_count'] ?? FALSE;
     $offset = $params['options']['offset'] ?? $offset;
-    $limit = CRM_Utils_Array::value('limit', $params['options'], $limit);
+    $limit = $params['options']['limit'] ?? $limit;
     $sort = $params['options']['sort'] ?? $sort;
   }
 
@@ -931,7 +931,7 @@ function _civicrm_api3_build_fields_array(&$bao, $unique = TRUE) {
 function _civicrm_api3_get_unique_name_array(&$bao) {
   $fields = $bao->fields();
   foreach ($fields as $field => $values) {
-    $uniqueFields[$field] = CRM_Utils_Array::value('name', $values, $field);
+    $uniqueFields[$field] = $values['name'] ?? $field;
   }
   return $uniqueFields;
 }
@@ -1694,7 +1694,7 @@ function _civicrm_api3_validate_date(&$params, &$fieldName, &$fieldInfo) {
   if (!empty($params[$fieldInfo['name']])) {
     $fieldValue = _civicrm_api3_getValidDate($fieldValue, $fieldInfo['name'], $fieldInfo['type']);
   }
-  if ((CRM_Utils_Array::value('name', $fieldInfo) != $fieldName) && !empty($fieldValue)) {
+  if (($fieldInfo['name'] ?? NULL) !== $fieldName && !empty($fieldValue)) {
     $fieldValue = _civicrm_api3_getValidDate($fieldValue, $fieldName, $fieldInfo['type']);
   }
 
@@ -1975,7 +1975,7 @@ function _civicrm_api_get_custom_fields($entity, &$params) {
     FALSE,
     FALSE,
     // we could / should probably test for other subtypes here - e.g. activity_type_id
-    CRM_Utils_Array::value('contact_sub_type', $params),
+    $params['contact_sub_type'] ?? NULL,
     NULL,
     FALSE,
     FALSE,
@@ -1988,7 +1988,7 @@ function _civicrm_api_get_custom_fields($entity, &$params) {
     // Regular fields have a 'name' property
     $value['name'] = 'custom_' . $key;
     $value['title'] = $value['label'];
-    if ($value['data_type'] == 'Date' && CRM_Utils_Array::value('time_format', $value, 0) > 0) {
+    if ($value['data_type'] == 'Date' && ($value['time_format'] ?? 0) > 0) {
       $value['data_type'] = 'DateTime';
     }
     $value['type'] = CRM_Utils_Array::value($value['data_type'], CRM_Core_BAO_CustomField::dataToType());
@@ -2317,7 +2317,7 @@ function _civicrm_api3_api_match_pseudoconstant(&$fieldValue, $entity, $fieldNam
     }
     $options = civicrm_api($entity, 'getoptions', $options_lookup_params);
 
-    $options = CRM_Utils_Array::value('values', $options, []);
+    $options = $options['values'] ?? [];
   }
 
   if (is_string($fieldValue) && strpos($fieldValue, CRM_Core_DAO::VALUE_SEPARATOR) !== FALSE) {
@@ -2327,12 +2327,12 @@ function _civicrm_api3_api_match_pseudoconstant(&$fieldValue, $entity, $fieldNam
   if (is_array($fieldValue)) {
     foreach ($fieldValue as &$value) {
       if (!is_array($value)) {
-        _civicrm_api3_api_match_pseudoconstant_value($value, $options, $fieldName, CRM_Utils_Array::value('api.required', $fieldInfo));
+        _civicrm_api3_api_match_pseudoconstant_value($value, $options, $fieldName, $fieldInfo['api.required'] ?? FALSE);
       }
     }
   }
   else {
-    _civicrm_api3_api_match_pseudoconstant_value($fieldValue, $options, $fieldName, CRM_Utils_Array::value('api.required', $fieldInfo));
+    _civicrm_api3_api_match_pseudoconstant_value($fieldValue, $options, $fieldName, $fieldInfo['api.required'] ?? FALSE);
   }
 }
 
@@ -2439,10 +2439,10 @@ function _civicrm_api3_api_resolve_alias($entity, $fieldName, $action = 'create'
     return $meta[$fieldName]['name'];
   }
   foreach ($meta as $info) {
-    if ($fieldName == $info['name'] || $fieldName == CRM_Utils_Array::value('uniqueName', $info)) {
+    if ($fieldName == $info['name'] || $fieldName == ($info['uniqueName'] ?? NULL)) {
       return $info['name'];
     }
-    if (array_search($fieldName, CRM_Utils_Array::value('api.aliases', $info, [])) !== FALSE) {
+    if (array_search($fieldName, $info['api.aliases'] ?? []) !== FALSE) {
       return $info['name'];
     }
   }
@@ -2615,7 +2615,7 @@ function _civicrm_api3_basic_array_get($entity, $params, $records, $idCol, $filt
     }
   }
 
-  $return = CRM_Utils_Array::value('return', $options, []);
+  $return = $options['return'] ?? [];
   if (!empty($return)) {
     $return['id'] = 1;
     $matches = CRM_Utils_Array::filterColumns($matches, array_keys($return));


### PR DESCRIPTION
Overview
----------------------------------------
Part of ongoing cleanup work to deprecate/remove php5-era function `CRM_Utils_Array::value`.

Before
----------------------------------------
Code less readable; deprecated function used.

After
----------------------------------------
Code more readable and up-to-date.

Comments
----------------------------------------
This is a lot of changes, but I supervised the regex, and there are a gazillion unit tests for APIv3.