### PR TITLE
Minor variable consolidation, reduce notices

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -542,7 +542,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         }
       }
     }
-    $form->assign('ispricelifetime', $checklifetime);
+    $form->assign('hasExistingLifetimeMembership', $checklifetime);
   }
 
   /**
@@ -688,7 +688,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
                 if ($membership["membership_type_id.duration_unit:name"] === 'lifetime') {
                   unset($radio[$memType['id']]);
                   unset($radioOptAttrs[$memType['id']]);
-                  $this->assign('islifetime', TRUE);
+                  $this->assign('hasExistingLifetimeMembership', TRUE);
                   continue;
                 }
                 $this->assign('renewal_mode', TRUE);

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -66,7 +66,7 @@
     </div>
     {include file="CRM/common/cidzero.tpl"}
 
-    {if $isShowMembershipBlock && ($islifetime or $ispricelifetime)}
+    {if $isShowMembershipBlock && $hasExistingLifetimeMembership}
       <div class="help">{ts}You have a current Lifetime Membership which does not need to be renewed.{/ts}</div>
     {/if}
 


### PR DESCRIPTION
This consolidates them to 1, reducing notices

Overview
----------------------------------------
Minor variable consolidation, reduce notices

Before
----------------------------------------
lifetime & pricelifetime both have one function - to trigger the message in the touched tpl.

If either are set then effectively both are set. 

After
----------------------------------------
Set `hasExistingLifetimeMembership` instead

Technical Details
----------------------------------------

Comments
----------------------------------------