### PR TITLE
Use api to get price set metadata - Online Contribution Page

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -491,8 +491,8 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     $adminFieldVisible = CRM_Core_Permission::check('administer CiviCRM');
     $checklifetime = FALSE;
     foreach ($this->getPriceFieldMetaData() as $id => $field) {
-      if ($field['visibility'] === 'public' ||
-        ($field['visibility'] === 'admin' && $adminFieldVisible)
+      if ($field['visibility_id:name'] === 'public' ||
+        ($field['visibility_id:name'] === 'admin' && $adminFieldVisible)
       ) {
         $options = $field['options'] ?? NULL;
         if ($this->_membershipContactID && $options) {
@@ -508,7 +508,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         }
         if (!CRM_Core_Permission::check('edit contributions')) {
           foreach ($options as $key => $currentOption) {
-            if ($currentOption['visibility_id'] == CRM_Price_BAO_PriceField::getVisibilityOptionID('admin')) {
+            if ($currentOption['visibility_id:name'] === 'admin') {
               unset($options[$key]);
             }
           }

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -556,7 +556,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       if ($form->_action & CRM_Core_Action::UPDATE) {
         $form->_values['line_items'] = CRM_Price_BAO_LineItem::getLineItems($form->_id, 'contribution');
       }
-      $form->_priceSet = [$this->getPriceSetID() => $this->order->getPriceSetMetadata()];
+      $form->_priceSet = $this->order->getPriceSetMetadata();
       $this->setPriceFieldMetaData($this->order->getPriceFieldsMetadata());
       $form->set('priceSet', $form->_priceSet);
     }

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -711,8 +711,6 @@ class CRM_Financial_BAO_Order {
     if (empty($this->priceSetMetadata)) {
       $this->priceSetMetadata = CRM_Price_BAO_PriceSet::getCachedPriceSetDetail($this->getPriceSetID());
       $this->priceSetMetadata['id'] = $this->getPriceSetID();
-      // @todo - make sure this is an array - commented out for now as this PR is against the rc.
-      // $priceSetMetadata['extends'] = explode(CRM_Core_DAO::VALUE_SEPARATOR, $priceSetMetadata['extends']);
       $this->setPriceFieldMetadata($this->priceSetMetadata['fields']);
       unset($this->priceSetMetadata['fields']);
     }
@@ -725,8 +723,7 @@ class CRM_Financial_BAO_Order {
     }
     // Access the property if set, to avoid a potential loop when the hook is called.
     $priceSetMetadata = $this->priceSetMetadata ?: $this->getPriceSetMetadata();
-    $extends = explode(CRM_Core_DAO::VALUE_SEPARATOR, $priceSetMetadata['extends']);
-    return in_array(CRM_Core_Component::getComponentID('CiviMember'), $extends, FALSE);
+    return in_array(CRM_Core_Component::getComponentID('CiviMember'), $priceSetMetadata['extends'], FALSE);
   }
 
   /**

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -683,10 +683,10 @@ class CRM_Financial_BAO_Order {
           if (!empty($option['membership_type_id'])) {
             $membershipType = CRM_Member_BAO_MembershipType::getMembershipType((int) $option['membership_type_id']);
             $metadata[$index]['options'][$optionID]['auto_renew'] = (int) $membershipType['auto_renew'];
-            if ($membershipType['auto_renew'] && empty($this->priceSetMetadata['auto_renew_membership_type'])) {
+            if ($membershipType['auto_renew'] && empty($this->priceSetMetadata['auto_renew_membership_field'])) {
               // Quick form layer supports one auto-renew membership type per price set. If we
               // want more for any reason we can add another array property.
-              $this->priceSetMetadata['auto_renew_membership_type'] = (int) $option['membership_type_id'];
+              $this->priceSetMetadata['auto_renew_membership_field'] = (int) $option['membership_type_id'];
             }
           }
         }
@@ -711,6 +711,7 @@ class CRM_Financial_BAO_Order {
     if (empty($this->priceSetMetadata)) {
       $this->priceSetMetadata = CRM_Price_BAO_PriceSet::getCachedPriceSetDetail($this->getPriceSetID());
       $this->priceSetMetadata['id'] = $this->getPriceSetID();
+      $this->priceSetMetadata['auto_renew_membership_field'] = NULL;
       $this->setPriceFieldMetadata($this->priceSetMetadata['fields']);
       unset($this->priceSetMetadata['fields']);
     }

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -313,7 +313,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
 
         if (!empty($fieldOptions[$optionKey]['label'])) {
           //check for label.
-          $label = $fieldOptions[$optionKey]['label'];
+          $label = CRM_Utils_String::purifyHTML($fieldOptions[$optionKey]['label']);
         }
         // @todo - move this back to the only calling function on Contribution_Form_Main.php
         if ($isQuickConfig && $field->name === 'other_amount') {
@@ -383,7 +383,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
             $qf->assign('membershipFieldID', $field->id);
           }
 
-          $choice[$opt['id']] = $priceOptionText['label'];
+          $choice[$opt['id']] = CRM_Utils_String::purifyHTML($priceOptionText['label']);
           $choiceAttrs[$opt['id']] = $extra;
           if ($is_pay_later) {
             $qf->add('text', 'txt-' . $elementName, $label, ['size' => '4']);
@@ -771,12 +771,12 @@ WHERE  id IN (" . implode(',', array_keys($priceFields)) . ')';
    */
   public static function buildPriceOptionText($opt, $isDisplayAmounts, $valueFieldName) {
     $preHelpText = $postHelpText = '';
-    $optionLabel = !empty($opt['label']) ? '<span class="crm-price-amount-label">' . $opt['label'] . '</span>' : '';
-    if (!empty($opt['help_pre'])) {
-      $preHelpText = '<span class="crm-price-amount-help-pre description">' . $opt['help_pre'] . '</span><span class="crm-price-amount-help-pre-separator">:&nbsp;</span>';
+    $optionLabel = !empty($opt['label']) ? '<span class="crm-price-amount-label">' . CRM_Utils_String::purifyHTML($opt['label']) . '</span>' : '';
+    if (CRM_Utils_String::purifyHTML($opt['help_pre'] ?? '')) {
+      $preHelpText = '<span class="crm-price-amount-help-pre description">' . CRM_Utils_String::purifyHTML($opt['help_pre']) . '</span><span class="crm-price-amount-help-pre-separator">:&nbsp;</span>';
     }
-    if (!empty($opt['help_post'])) {
-      $postHelpText = '<span class="crm-price-amount-help-post-separator">:&nbsp;</span><span class="crm-price-amount-help-post description">' . $opt['help_post'] . '</span>';
+    if (CRM_Utils_String::purifyHTML($opt['help_post'] ?? '')) {
+      $postHelpText = '<span class="crm-price-amount-help-post-separator">:&nbsp;</span><span class="crm-price-amount-help-post description">' . CRM_Utils_String::purifyHTML($opt['help_post']) . '</span>';
     }
 
     $invoicing = Civi::settings()->get('invoicing');

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -15,6 +15,10 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\PriceField;
+use Civi\Api4\PriceFieldValue;
+use Civi\Api4\PriceSet;
+
 /**
  * Business object for managing price sets.
  *
@@ -757,30 +761,50 @@ WHERE  id = %1";
   }
 
   /**
-   * Wrapper for getSetDetail with caching.
+   * Get PriceSet + Fields + FieldValues nested, with caching.
+   *
+   * This gets the same values as getSet but uses apiv4 for more
+   * predictability & better variable typing.
    *
    * We seem to be passing this array around in a painful way - presumably to avoid the hit
    * of loading it - so lets make it callable with caching.
    *
-   * Why not just add caching to the other function? We could do - it just seemed a bit unclear the best caching pattern
-   * & the function was already pretty fugly. Also, I feel like we need to migrate the interaction with price-sets into
-   * a more granular interaction - ie. retrieve specific data using specific functions on this class & have the form
-   * think less about the price sets.
-   *
    * @param int $priceSetID
    *
    * @return array
+   *
+   * @noinspection PhpUnhandledExceptionInspection
    */
-  public static function getCachedPriceSetDetail($priceSetID) {
+  public static function getCachedPriceSetDetail(int $priceSetID): array {
     $cacheKey = __CLASS__ . __FUNCTION__ . '_' . $priceSetID;
     $cache = CRM_Utils_Cache::singleton();
-    $values = $cache->get($cacheKey);
-    if (empty($values)) {
-      $data = self::getSetDetail($priceSetID);
-      $values = $data[$priceSetID];
-      $cache->set($cacheKey, $values);
+    $data = $cache->get($cacheKey);
+    if (empty($data)) {
+      $data = PriceSet::get(FALSE)
+        ->addWhere('id', '=', $priceSetID)
+        ->addSelect('*', 'visibility_id:name', 'extends:name')
+        ->execute()->first();
+      $data['fields'] = (array) PriceField::get(FALSE)
+        ->addWhere('price_set_id', '=', $priceSetID)
+        ->addSelect('*', 'visibility_id:name')
+        ->execute()->indexBy('id');
+      foreach ($data['fields'] as &$field) {
+        $field['options'] = [];
+        // Add in visibility because Smarty templates expect it and it is hard to adjust them to colon format.
+        $field['visibility'] = $field['visibility_id:name'];
+      }
+      $options = PriceFieldValue::get(FALSE)
+        ->addWhere('price_field_id', 'IN', array_keys($data['fields']))
+        ->addSelect('*', 'membership_type_id.name', 'visibility_id:name')
+        ->execute();
+      foreach ($options as $option) {
+        // Add in visibility because Smarty templates expect it and it is hard to adjust them to colon format.
+        $option['visibility'] = $option['visibility_id:name'];
+        $data['fields'][$option['price_field_id']]['options'][$option['id']] = $option;
+      }
+      $cache->set($cacheKey, $data);
     }
-    return $values;
+    return $data;
   }
 
   /**

--- a/templates/CRM/Price/Form/Field.tpl
+++ b/templates/CRM/Price/Form/Field.tpl
@@ -81,12 +81,12 @@
 <div class="crm-block crm-form-block crm-price-field-form-block">
   <table class="form-layout">
     <tr class="crm-price-field-form-block-label">
-      <td class="label">{$form.label.label}</td>
+      <td class="label">{$form.label.label|escape}</td>
       <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_price_field' field='label' id=$fid}{/if}{$form.label.html}
       </td>
     </tr>
     <tr class="crm-price-field-form-block-html_type">
-      <td class="label">{$form.html_type.label}</td>
+      <td class="label">{$form.html_type.label|escape}</td>
       <td>{$form.html_type.html}
       </td>
     </tr>
@@ -103,7 +103,7 @@
   <div id="price-block" {if $action eq 2 && $form.html_type.value.0 eq 'Text'} class="show-block" {else} class="hiddenElement" {/if}>
     <table class="form-layout">
       <tr class="crm-price-field-form-block-price">
-        <td class="label">{$form.price.label} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></td>
+        <td class="label">{$form.price.label|escape} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></td>
         <td>{$form.price.html}
         {if $action neq 4}
           <br /><span class="description">{ts}Unit price.{/ts}</span> {help id="id-negative"}
@@ -111,25 +111,25 @@
         </td>
       </tr>
       <tr class="crm-price-field-form-block-non-deductible-amount">
-        <td class="label">{$form.non_deductible_amount.label}</td>
+        <td class="label">{$form.non_deductible_amount.label|escape}</td>
         <td>{$form.non_deductible_amount.html}</td>
       </tr>
     {if $useForEvent}
       <tr class="crm-price-field-form-block-count">
-        <td class="label">{$form.count.label}</td>
+        <td class="label">{$form.count.label|escape}</td>
         <td>{$form.count.html}<br />
           <span class="description">{ts}Enter a value here if you want to increment the number of registered participants per unit against the maximum number of participants allowed for this event.{/ts}</span>
           {help id="id-participant-count"}
         </td>
       </tr>
       <tr class="crm-price-field-form-block-max_value">
-        <td class="label">{$form.max_value.label}</td>
+        <td class="label">{$form.max_value.label|escape}</td>
         <td>{$form.max_value.html}
         </td>
       </tr>
     {/if}
       <tr class="crm-price-field-form-block-financial_type">
-        <td class="label">{$form.financial_type_id.label}<span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></td></td>
+        <td class="label">{$form.financial_type_id.label|escape}<span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></td></td>
         <td>
         {if !$financialType}
           {capture assign=ftUrl}{crmURL p='civicrm/admin/financial/financialType' q="reset=1"}{/capture}
@@ -169,7 +169,7 @@
     </tr>
 
     <tr class="crm-price-field-form-block-help_pre">
-      <td class="label">{$form.help_pre.label}</td>
+      <td class="label">{$form.help_pre.label|escape}</td>
       <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_price_field' field='help_pre' id=$fid}{/if}{$form.help_pre.html|crmAddClass:huge}&nbsp;
       {if $action neq 4}
         <div class="description">{ts}Explanatory text displayed to users at the beginning of this field.{/ts}</div>
@@ -178,7 +178,7 @@
     </tr>
 
     <tr class="crm-price-field-form-block-help_post">
-      <td class="label">{$form.help_post.label}</td>
+      <td class="label">{$form.help_post.label|escape}</td>
       <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_price_field' field='help_post' id=$fid}{/if}{$form.help_post.html|crmAddClass:huge}&nbsp;
       {if $action neq 4}
         <div class="description">{ts}Explanatory text displayed to users below this field.{/ts}</div>

--- a/templates/CRM/Price/Form/Option.tpl
+++ b/templates/CRM/Price/Form/Option.tpl
@@ -28,11 +28,11 @@
         </tr>
       {/if}
       <tr class="crm-price-option-form-block-label">
-        <td class="label">{$form.label.label}</td>
+        <td class="label">{$form.label.label|escape}</td>
         <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_price_field_value' field='label' id=$optionId}{/if}{$form.label.html}</td>
       </tr>
       <tr class="crm-price-option-form-block-amount">
-        <td class="label">{$form.amount.label}</td>
+        <td class="label">{$form.amount.label|escape}</td>
         <td>{$form.amount.html}</td>
       </tr>
       <tr class="crm-price-option-form-block-non-deductible-amount">
@@ -44,11 +44,11 @@
         <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_price_field_value' field='description' id=$optionId}{/if}{$form.description.html}</td>
       </tr>
       <tr class="crm-price-option-form-block-help-pre">
-        <td class="label">{$form.help_pre.label}</td>
+        <td class="label">{$form.help_pre.label|escape}</td>
         <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_price_field_value' field='help_pre' id=$optionId}{/if}{$form.help_pre.html}</td>
       </tr>
       <tr class="crm-price-option-form-block-help-post">
-        <td class="label">{$form.help_post.label}</td>
+        <td class="label">{$form.help_post.label|escape}</td>
         <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_price_field_value' field='help_post' id=$optionId}{/if}{$form.help_post.html}</td>
       </tr>
       <tr class="crm-price-option-form-block-financial-type">

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -10,7 +10,7 @@
 {crmRegion name="price-set-1"}
 <div id="priceset" class="crm-section price_set-section">
     {if $priceSet.help_pre}
-        <div class="messages help">{$priceSet.help_pre}</div>
+        <div class="messages help">{$priceSet.help_pre|escape}</div>
     {/if}
 
     {assign var='adminFld' value=false}
@@ -28,12 +28,12 @@
     {foreach from=$priceSet.fields item=element key=field_id}
         {* Skip 'Admin' visibility price fields WHEN this tpl is used in online registration unless user has administer CiviCRM permission. *}
         {if $element.visibility EQ 'public' || ($element.visibility EQ 'admin' && $adminFld EQ true) || $context eq 'standalone' || $context eq 'advanced' || $context eq 'search' || $context eq 'participant' || $context eq 'dashboard'}
-            {if $element.help_pre}<span class="content description">{$element.help_pre}</span><br />{/if}
-            <div class="crm-section {$element.name}-section crm-price-field-id-{$field_id}">
+            {if $element.help_pre}<span class="content description">{$element.help_pre|escape}</span><br />{/if}
+            <div class="crm-section {$element.name|escape}-section crm-price-field-id-{$field_id}">
             {if ($element.html_type eq 'CheckBox' || $element.html_type == 'Radio') && $element.options_per_line}
               {assign var="element_name" value="price_`$field_id`"}
-              <div class="label">{$form.$element_name.label}</div>
-              <div class="content {$element.name}-content">
+              <div class="label">{$form.$element_name.label|purify}</div>
+              <div class="content {$element.name|escape}-content">
                 {assign var="elementCount" value="0"}
                 {assign var="optionCount" value="0"}
                 {assign var="rowCount" value="0"}
@@ -43,7 +43,7 @@
                     {assign var="optionCount" value=$optionCount+1}
                     {if $optionCount == 1}
                       {assign var="rowCount" value=$rowCount+1}
-                      <div class="price-set-row {$element.name}-row{$rowCount}">
+                      <div class="price-set-row {$element.name|escape}-row{$rowCount}">
                     {/if}
                     <span class="price-set-option-content">{$form.$element_name.$key.html}</span>
                     {if $optionCount == $element.options_per_line || $elementCount == $form.$element_name|@count}
@@ -53,15 +53,15 @@
                   {/if}
                 {/foreach}
                 {if $element.help_post}
-                  <div class="description">{$element.help_post}</div>
+                  <div class="description">{$element.help_post|escape}</div>
                 {/if}
               </div>
             {else}
 
                 {assign var="element_name" value="price_"|cat:$field_id}
 
-                <div class="label">{$form.$element_name.label}</div>
-                <div class="content {$element.name}-content">
+                <div class="label">{$form.$element_name.label|escape}</div>
+                <div class="content {$element.name|escape}-content">
                   {$form.$element_name.html}
                   {if $element.html_type eq 'Text'}
                     {if $element.is_display_amounts}
@@ -91,7 +91,7 @@
                       {/if}
                     {/if}
                   {/if}
-                  {if $element.help_post}<br /><span class="description">{$element.help_post}</span>{/if}
+                  {if $element.help_post}<br /><span class="description">{$element.help_post|escape}</span>{/if}
                 </div>
 
             {/if}
@@ -102,7 +102,7 @@
                       <div class='label'></div>
                       <div class='content' id="auto_renew_section">
                         {if $form.auto_renew}
-                          {$form.auto_renew.html}&nbsp;{$form.auto_renew.label}
+                          {$form.auto_renew.html}&nbsp;{$form.auto_renew.label|escape}
                         {/if}
                       </div>
                       <div class='content' id="force_renew" style='display: none'>{ts}Membership will renew automatically.{/ts}</div>
@@ -116,7 +116,7 @@
     {/foreach}
 
     {if $priceSet.help_post}
-      <div class="messages help">{$priceSet.help_post}</div>
+      <div class="messages help">{$priceSet.help_post|escape}</div>
     {/if}
 
     {include file="CRM/Price/Form/Calculate.tpl"}

--- a/templates/CRM/Price/Page/Option.tpl
+++ b/templates/CRM/Price/Page/Option.tpl
@@ -59,11 +59,11 @@
           <tbody>
           {foreach from=$customOption item=row}
             <tr id="price_field_value-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"}{if !empty($row.class)} {$row.class}{/if}{if NOT $row.is_active} disabled{/if}">
-              <td class="crm-price-option-label crm-editable" data-field="label">{$row.label}</td>
+              <td class="crm-price-option-label crm-editable" data-field="label">{$row.label|escape}</td>
               <td class="crm-price-option-value">{$row.amount|crmMoney}</td>
               <td class="crm-price-option-non-deductible-amount">{$row.non_deductible_amount|crmMoney}</td>
-              <td class="crm-price-option-pre-help">{$row.help_pre}</td>
-              <td class="crm-price-option-post-help">{$row.help_post}</td>
+              <td class="crm-price-option-pre-help">{$row.help_pre|escape}</td>
+              <td class="crm-price-option-post-help">{$row.help_post|escape}</td>
               {if $isEvent}
                 <td class="crm-price-option-count">{$row.count}</td>
                 <td class="crm-price-option-max">{$row.max_value}</td>

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/MainTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/MainTest.php
@@ -214,7 +214,44 @@ class CRM_Contribute_Form_Contribution_MainTest extends CiviUnitTestCase {
     $allFields = $form->getPriceFieldMetadata();
     $this->assertCount(1, $allFields);
     $field = current($allFields);
-    $this->assertEquals('test_valid_price_field', $field['name']);
+    $expectedValues = [
+      'name' => 'test_valid_price_field',
+      'label' => 'test valid price field',
+      'html_type' => 'Radio',
+      'is_enter_qty' => 1,
+      'weight' => TRUE,
+      'is_display_amounts' => TRUE,
+      'options_per_line' => 1,
+      'is_active' => TRUE,
+      'active_on' => NULL,
+      'expire_on' => NULL,
+      'javascript' => NULL,
+      'visibility_id:name' => 'public',
+      'visibility_id' => 1,
+      'is_required' => TRUE,
+    ];
+    foreach ($expectedValues as $key => $value) {
+      $this->assertEquals($value, $field[$key]);
+    }
+
+    $option = reset($field['options']);
+    $expectedValues = [
+      'name' => 'rye grass',
+      'label' => 'juicy and healthy',
+      'amount' => 1,
+      'weight' => 1,
+      'membership_type_id' => $this->ids['MembershipType']['test'],
+      'membership_num_terms' => 2,
+      'is_default' => FALSE,
+      'is_active' => TRUE,
+      'financial_type_id' => '1',
+      'non_deductible_amount' => 0,
+      'visibility_id' => '1',
+    ];
+    foreach ($expectedValues as $key => $value) {
+      $this->assertEquals($value, $option[$key]);
+    }
+
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Use api to get price set metadata - Online Contribution Page

Before
----------------------------------------
The `getCachedPriceSetDetail()` is not otherwise used to assign values to the form but is used to retrieve metadata for form usage. As we are starting to expose it more (via `BAO_Order->getPriceSetMetadata()` it feels like now is the right time to switch to apiv4 - so we can rely on typing. In general when we expose things for public access they use apiv4 format.

After
----------------------------------------
Apiv4 used for retrieval, escaping added to smarty.

![image](https://github.com/civicrm/civicrm-core/assets/336308/d5883f63-e015-4477-b076-abf086bd8ed3)


Technical Details
----------------------------------------
I filled all the text fields in civicrm_price_set, price_field & price_field value with script & fixed all the places that triggered my script - + a few more that didn't just for form.

Comments
----------------------------------------
There is also a recently merged regression fixed in here - @colemanw we should merge this before anyone hits it

Going through this exercise also reduces the risk of us accidentally introducing unescaped fields in future