### PR TITLE
(dev/core#4696) Upgrader - Don't crash on long duplicate names

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.66.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.66.alpha1.mysql.tpl
@@ -1,10 +1,12 @@
 {* file to handle db changes in 5.66.alpha1 during upgrade *}
 
 {* Ensure action_schedule.name has a unique value *}
-UPDATE `civicrm_action_schedule` SET name = COALESCE(CONCAT('repeat_', used_for, '_', entity_value), CONCAT('schedule_', id)) WHERE name IS NULL OR name = '';
+UPDATE `civicrm_action_schedule`
+  SET name = COALESCE(CONCAT('repeat_', used_for, '_', entity_value), CONCAT('schedule_', id))
+  WHERE name IS NULL OR name = '';
 UPDATE `civicrm_action_schedule` a1, `civicrm_action_schedule` a2
-SET a2.name = CONCAT(a2.name, '_', a2.id)
-WHERE a2.name = a1.name AND a2.id > a1.id;
+  SET a2.name = CONCAT(a2.name, '_', a2.id)
+  WHERE a2.name = a1.name AND a2.id > a1.id;
 
 {* Set default value for Discount.entity_table *}
 UPDATE `civicrm_discount` SET `entity_table` = 'civicrm_event' WHERE `entity_table` IS NULL;

--- a/CRM/Upgrade/Incremental/sql/5.66.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.66.alpha1.mysql.tpl
@@ -1,11 +1,14 @@
 {* file to handle db changes in 5.66.alpha1 during upgrade *}
 
 {* Ensure action_schedule.name has a unique value *}
+
+SELECT @maxlen := 63-LENGTH(MAX(id))
+  FROM civicrm_action_schedule;
 UPDATE `civicrm_action_schedule`
   SET name = COALESCE(CONCAT('repeat_', used_for, '_', entity_value), CONCAT('schedule_', id))
   WHERE name IS NULL OR name = '';
 UPDATE `civicrm_action_schedule` a1, `civicrm_action_schedule` a2
-  SET a2.name = CONCAT(a2.name, '_', a2.id)
+  SET a2.name = CONCAT(SUBSTRING(a2.name, 1, @maxlen), '_', a2.id)
   WHERE a2.name = a1.name AND a2.id > a1.id;
 
 {* Set default value for Discount.entity_table *}


### PR DESCRIPTION
Overview
----------------------------------------

Fix an upgrade issue involving "Scheduled Reminders" with duplicate names.

See also: 
* https://lab.civicrm.org/dev/core/-/issues/4696
* https://github.com/civicrm/civicrm-core/pull/27003

Steps to reproduce:
-----------------------

* Install 5.65
* Create several scheduled reminders with title:
  "A very-long, upgrade-crashing name that has more words than you might reasonably expect"
* In MySQL, hack the IDs so that they are more than 1 digit long
    ```
    UPDATE civicrm_action_schedule SET id = id + 9000;
    ALTER TABLE civicrm_action_schedule AUTO_INCREMENT = 10000;
    ```
* Run the upgrade

Before
----------------------------------------

* Upgrade fails because the new name (`a2.name = CONCAT(a2.name, '_', a2.id)`) is too long

After
----------------------------------------

* Upgrade succeeds
 
Comments
----------------------------------------

* I have `r-run` this patch to ensure that it works.