### PR TITLE
CustomGroup - Allow increasing max_multiple

### DIFF
--- a/templates/CRM/Custom/Form/Group.tpl
+++ b/templates/CRM/Custom/Form/Group.tpl
@@ -172,7 +172,7 @@ CRM.$(function($) {
   // When changing or initializing the `is_multiple` field
   // Check if this set supports multiple records and adjust other options accordingly
   function handleMultiple() {
-    if ($(this).is(':checked')) {
+    if ($(this).is(':checked') || ($(this).attr('type') === 'hidden' && $(this).val() === '1')) {
       $('tr.field-max_multiple', $form).show();
       if (tabWithTableOption) {
         $('select[name=style]', $form).append(tabWithTableOption);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug in the CustomGroup form code that wouldn't allow max_mutliple to be increased for multi-record custom groups.

Before
----------------------------------------
Form doesn't show max_multiple field due to js bug.

After
----------------------------------------
Field is shown. For custom groups containing data, the max can be increased but not decreased.