### PR TITLE
dev/core#4154 Fix locale-formatted number custom field inputs

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -984,7 +984,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     }
 
     //get the submitted values in an array
-    $params = $this->controller->exportValues($this->_name);
+    $params = $this->getSubmittedValues();
     if (!isset($params['preferred_communication_method'])) {
       // If this field is empty QF will trim it so we have to add it in.
       $params['preferred_communication_method'] = 'null';

--- a/CRM/Contact/Form/Inline/CustomData.php
+++ b/CRM/Contact/Form/Inline/CustomData.php
@@ -72,7 +72,7 @@ class CRM_Contact_Form_Inline_CustomData extends CRM_Contact_Form_Inline {
   public function postProcess() {
     // Process / save custom data
     // Get the form values and groupTree
-    $params = $this->controller->exportValues($this->_name);
+    $params = $this->getSubmittedValues();
     CRM_Core_BAO_CustomValueTable::postProcess($params,
       'civicrm_contact',
       $this->_contactId,

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1153,11 +1153,11 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
 
       case 'Float':
         if ($field->is_search_range && $search) {
-          $qf->addRule($elementName . '_from', ts('%1 From must be a number (with or without decimals).', [1 => $label]), 'numeric');
-          $qf->addRule($elementName . '_to', ts('%1 To must be a number (with or without decimals).', [1 => $label]), 'numeric');
+          $qf->addRule($elementName . '_from', ts('%1 From must be a number (with or without decimals).', [1 => $label]), 'money');
+          $qf->addRule($elementName . '_to', ts('%1 To must be a number (with or without decimals).', [1 => $label]), 'money');
         }
         elseif ($widget == 'Text') {
-          $qf->addRule($elementName, ts('%1 must be a number (with or without decimals).', [1 => $label]), 'numeric');
+          $qf->addRule($elementName, ts('%1 must be a number (with or without decimals).', [1 => $label]), 'money');
         }
         break;
 

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -3049,6 +3049,15 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     if (in_array($fieldName, $this->submittableMoneyFields, TRUE)) {
       return CRM_Utils_Rule::cleanMoney($value);
     }
+    else {
+      // Numeric fields are not in submittableMoneyFields (for now)
+      $fieldRules = $this->_rules[$fieldName] ?? [];
+      foreach ($fieldRules as $rule) {
+        if ('money' === $rule['type']) {
+          return CRM_Utils_Rule::cleanMoney($value);
+        }
+      }
+    }
     return $value;
   }
 


### PR DESCRIPTION
(based on a patch by @highfalutin  and feedback from @eileenmcnaughton)

Overview
----------------------------------------

Alternate PR to #25714 to fix the formatting of custom field numeric inputs.

Before
----------------------------------------

(descriptions copied from #25714)

Number-type custom fields on Contacts and Activities reject input in any format except whitespace-free digits with an optional minus sign and optional decimal point (period/full-stop).

After
----------------------------------------

Number-type custom fields on Contacts and Activities expect input in the format appropriate for the system locale (a site config setting). For example, in a Civi instance set to use the France locale, you would enter 98 765,42 and this would be interpreted correctly as ninety-eight thousand, seven hundred sixty-five, and forty-two one hundredths.

The input format now matches the display format for these fields.

Comments
----------------------------------------

To do an r-run, just set the site locale to something that uses a non-period decimal point, create a custom field of type Number on either Contacts or Activities, and try filling the field out using different number formats.
