### PR TITLE
Fix master-only regression on auto_renew

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -686,7 +686,7 @@ class CRM_Financial_BAO_Order {
             if ($membershipType['auto_renew'] && empty($this->priceSetMetadata['auto_renew_membership_field'])) {
               // Quick form layer supports one auto-renew membership type per price set. If we
               // want more for any reason we can add another array property.
-              $this->priceSetMetadata['auto_renew_membership_field'] = (int) $option['membership_type_id'];
+              $this->priceSetMetadata['auto_renew_membership_field'] = (int) $option['id'];
             }
           }
         }

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -686,7 +686,7 @@ class CRM_Financial_BAO_Order {
             if ($membershipType['auto_renew'] && empty($this->priceSetMetadata['auto_renew_membership_field'])) {
               // Quick form layer supports one auto-renew membership type per price set. If we
               // want more for any reason we can add another array property.
-              $this->priceSetMetadata['auto_renew_membership_field'] = (int) $option['id'];
+              $this->priceSetMetadata['auto_renew_membership_field'] = (int) $option['price_field_id'];
             }
           }
         }

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -96,7 +96,7 @@
 
             {/if}
               {if !empty($extends) && $extends eq "Membership"}
-                {if (!empty($priceSet) && $element.id == $priceSet.auto_renew_membership_field) || (empty($priceSet) && $element.name == 'membership_amount')}
+                {if ($element.id == $priceSet.auto_renew_membership_field)}
                   <div id="allow_auto_renew">
                     <div class='crm-section auto-renew'>
                       <div class='label'></div>

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -102,7 +102,7 @@
                       <div class='label'></div>
                       <div class='content' id="auto_renew_section">
                         {if $form.auto_renew}
-                          {$form.auto_renew.html}&nbsp;{$form.auto_renew.label|escape}
+                          {$form.auto_renew.html}&nbsp;{$form.auto_renew.label|smarty:nodefaults|purify}
                         {/if}
                       </div>
                       <div class='content' id="force_renew" style='display: none'>{ts}Membership will renew automatically.{/ts}</div>


### PR DESCRIPTION
Overview
----------------------------------------
Fix master-only regression on auto_renew

Before
----------------------------------------
Over-escaping on auto-renew text & auto renew option not showing - both recently merged master issues

After
----------------------------------------
fixed

Technical Details
----------------------------------------

Comments
----------------------------------------
