### PR TITLE
dev/core#4729 - Menu doesn't build because wrong array key

### DIFF
--- a/mixin/setting-admin@1/mixin.php
+++ b/mixin/setting-admin@1/mixin.php
@@ -194,7 +194,10 @@ return function ($mixInfo, $bootCache) {
 
     // Skip if we're already in the menu. (Ignore optional suffix `?reset=1`)
     $found = Nav::walk($menu, function(&$item) use ($about) {
-      return strpos($item['attribute']['url'], $about->getPath()) === 0 ? 'found' : NULL;
+      if (!isset($item['attributes']['url'])) {
+        return NULL;
+      }
+      return strpos($item['attributes']['url'], $about->getPath()) === 0 ? 'found' : NULL;
     });
     if ($found) {
       return;


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4729

Before
----------------------------------------
attribute

After
----------------------------------------
attributes (with an "s")

Technical Details
----------------------------------------
I updated my local which was about a week old and then the menu disappeared. The ajax is mangled because of an error about `undefined array key "attribute"`.

Also not all menu items have a `url` element. Like the "home" menu (the one that's just the civi icon).

Comments
----------------------------------------
I admit I don't really follow what this code is about but everywhere else it's attributes and if you debug the array it's attributes.
