### PR TITLE
Releaser - Only update core extensions for stable versions

### DIFF
--- a/tools/bin/scripts/set-version.php
+++ b/tools/bin/scripts/set-version.php
@@ -82,8 +82,8 @@ updateFile("sql/test_data_second_domain.mysql", function ($content) use ($newVer
   return str_replace($oldVersion, $newVersion, $content);
 });
 
-// Update core extension info
-$infoXmls = findCoreInfoXml();
+// Update core extensions if this is a stable release
+$infoXmls = isPreRelease($newVersion) ? [] : findCoreInfoXml();
 foreach ($infoXmls as $infoXml) {
   updateXmlFile($infoXml, function (DOMDocument $dom) use ($newVersion) {
     // Update extension version
@@ -190,6 +190,10 @@ function makeVerName($version) {
 
 function isVersionValid($v) {
   return $v && preg_match('/^[0-9a-z\.\-]+$/', $v);
+}
+
+function isPreRelease(string $v): bool {
+  return (bool) preg_match('/[a-z]+/', $v);
 }
 
 /**

--- a/tools/bin/scripts/set-version.php
+++ b/tools/bin/scripts/set-version.php
@@ -83,7 +83,7 @@ updateFile("sql/test_data_second_domain.mysql", function ($content) use ($newVer
 });
 
 // Update core extensions if this is a stable release
-$infoXmls = isPreRelease($newVersion) ? [] : findCoreInfoXml();
+$infoXmls = isPreReleaseIncrement($newVersion) ? [] : findCoreInfoXml();
 foreach ($infoXmls as $infoXml) {
   updateXmlFile($infoXml, function (DOMDocument $dom) use ($newVersion) {
     // Update extension version
@@ -192,8 +192,8 @@ function isVersionValid($v) {
   return $v && preg_match('/^[0-9a-z\.\-]+$/', $v);
 }
 
-function isPreRelease(string $v): bool {
-  return (bool) preg_match('/[a-z]+/', $v);
+function isPreReleaseIncrement(string $v): bool {
+  return (bool) preg_match('/(alpha|beta)/', $v) && !preg_match('/(beta1|alpha1)$/', $v);
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
It can be a little confusing when a stable extension is flagged "alpha" on a dev site. And all the version updates to core extensions aren't really necessary during alpha/beta cycles. This dials it back to only update them when doing a stable release.
