### PR TITLE
dev/core#4726 Ensure that quickform mapper default value is set corre…

### DIFF
--- a/CRM/Import/ImportProcessor.php
+++ b/CRM/Import/ImportProcessor.php
@@ -583,11 +583,6 @@ class CRM_Import_ImportProcessor {
   public function getSavedQuickformDefaultsForColumn($column) {
     $fieldMapping = [];
 
-    // $sel1 is either unmapped, a relationship or a target field.
-    if ($this->getFieldName($column) === 'do_not_import') {
-      return $fieldMapping;
-    }
-
     if ($this->getValidRelationshipKey($column)) {
       $fieldMapping[] = $this->getValidRelationshipKey($column);
     }

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -261,7 +261,7 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
       [
         ['name' => 'do_not_import', 'contact_type' => 'Individual', 'column_number' => 0],
         "swapOptions(document.forms.MapField, 'mapper[0]', 0, 4, 'hs_mapper_0_');\n",
-        ['mapper[0]' => []],
+        ['mapper[0]' => ['do_not_import']],
       ],
     ];
   }


### PR DESCRIPTION
…ctly for do_not_import fields in saved mappings on import

Overview
----------------------------------------
This aims to fix a problem when using saved field mappings that if you have any columns marked as do_not_merge that on non english sites the wrong default might show up on the mapper

Before
----------------------------------------
Wrong field shown

After
----------------------------------------
Correct field shown

ping @eileenmcnaughton @demeritcowboy