### PR TITLE
Afform - Remove redundant status checks

### DIFF
--- a/ext/afform/core/Civi/Afform/StatusChecks.php
+++ b/ext/afform/core/Civi/Afform/StatusChecks.php
@@ -24,33 +24,8 @@ class StatusChecks {
   public static function hook_civicrm_check($e) {
     $hasAuthx = \CRM_Extension_System::singleton()->getMapper()->isActiveModule('authx');
     $tokenFormCount = count(Tokens::getTokenForms());
-    if (!$hasAuthx) {
-      if ($tokenFormCount) {
-        $e->messages[] = new \CRM_Utils_Check_Message(
-          'afform_token_authx',
-          E::ts('Email token support has been configured for %2 form(s), which requires extended authentication services. Please enable "AuthX" in <a href="%1">Manage Extensions</a>.', [
-            1 => \CRM_Utils_System::url('civicrm/admin/extensions', 'reset=1'),
-            2 => $tokenFormCount,
-          ]),
-          E::ts('AuthX Required'),
-          \Psr\Log\LogLevel::ERROR,
-          'fa-chain-broken'
-        );
-      }
-      else {
-        $e->messages[] = new \CRM_Utils_Check_Message(
-          'afform_token_authx',
-          E::ts('To generate authenticated email links for custom forms, enable extended authentication services (AuthX) in <a href="%1">Manage Extensions</a>.', [
-            1 => \CRM_Utils_System::url('civicrm/admin/extensions', 'reset=1'),
-          ]),
-          E::ts('AuthX Suggested'),
-          \Psr\Log\LogLevel::INFO,
-          'fa-lightbulb-o'
-        );
-      }
-    }
 
-    if ($hasAuthx && $tokenFormCount > 0 && !in_array('jwt', \Civi::settings()->get('authx_auto_cred'))) {
+    if ($hasAuthx && $tokenFormCount && !in_array('jwt', \Civi::settings()->get('authx_auto_cred'))) {
       $e->messages[] = new \CRM_Utils_Check_Message(
         'afform_token_authx',
         E::ts('Email token support has been configured for %1 form(s). This requires JWT authentication, <code>authx_auto_cred</code> does not include JWT. ', [


### PR DESCRIPTION
Overview
----------------------------------------
Removes unnecessary status checks.


Technical Details
----------------------------------------
Now that [Afform and Authx are both required extensions](https://github.com/civicrm/civicrm-core/pull/27293), status check for the presence of Authx is redundant.