### PR TITLE
Fix test on secondary membership contribution to use full form flow

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1290,11 +1290,11 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $this->set('amount_level', CRM_Utils_Array::value('amount_level', $params));
     }
 
-    $priceSetId = $params['priceSetId'] ?? NULL;
+    $priceSetID = $this->getPriceSetID();
     if (!empty($this->_ccid)) {
       $this->set('lineItem', [$this->getPriceSetID() => $this->getExistingContributionLineItems()]);
     }
-    elseif ($priceSetId) {
+    elseif ($priceSetID) {
       $lineItem = [];
       if ($this->isQuickConfig()) {
         foreach ($this->_values['fee'] as $key => & $val) {
@@ -1314,17 +1314,17 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       }
 
       if ($this->_membershipBlock) {
-        $this->processAmountAndGetAutoRenew($this->_values['fee'], $params, $lineItem[$priceSetId], $priceSetId);
+        $this->processAmountAndGetAutoRenew($this->_values['fee'], $params, $lineItem[$priceSetID]);
       }
       else {
-        CRM_Price_BAO_PriceSet::processAmount($this->_values['fee'], $params, $lineItem[$priceSetId], $priceSetId);
+        CRM_Price_BAO_PriceSet::processAmount($this->_values['fee'], $params, $lineItem[$priceSetID], $priceSetID);
       }
 
       if ($proceFieldAmount) {
-        $lineItem[$params['priceSetId']][$fieldOption]['unit_price'] = $proceFieldAmount;
-        $lineItem[$params['priceSetId']][$fieldOption]['line_total'] = $proceFieldAmount;
-        if (isset($lineItem[$params['priceSetId']][$fieldOption]['tax_amount'])) {
-          $proceFieldAmount += $lineItem[$params['priceSetId']][$fieldOption]['tax_amount'];
+        $lineItem[$priceSetID][$fieldOption]['unit_price'] = $proceFieldAmount;
+        $lineItem[$priceSetID][$fieldOption]['line_total'] = $proceFieldAmount;
+        if (isset($lineItem[$priceSetID][$fieldOption]['tax_amount'])) {
+          $proceFieldAmount += $lineItem[$priceSetID][$fieldOption]['tax_amount'];
         }
         if (!$this->_membershipBlock['is_separate_payment']) {
           //require when separate membership not used

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1093,10 +1093,9 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    *   Params reflecting form input e.g with fields 'price_5' => 7, 'price_8' => array(7, 8)
    * @param $lineItems
    *   Line item array to be altered.
-   * @param int $priceSetID
    */
-  public function processAmountAndGetAutoRenew($fields, &$params, &$lineItems, $priceSetID = NULL) {
-    CRM_Price_BAO_PriceSet::processAmount($fields, $params, $lineItems, $priceSetID);
+  public function processAmountAndGetAutoRenew($fields, &$params, &$lineItems) {
+    CRM_Price_BAO_PriceSet::processAmount($fields, $params, $lineItems, $this->getPriceSetID());
     $autoRenew = [];
     $autoRenew[0] = $autoRenew[1] = $autoRenew[2] = 0;
     foreach ($lineItems as $lineItem) {
@@ -1255,6 +1254,27 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $this->_pcpId = CRM_Utils_Request::retrieve('pcpId', 'Positive', $this);
     }
     return $this->_pcpId ? (int) $this->_pcpId : NULL;
+  }
+
+  /**
+   * Get the selected Contribution ID.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function getContributionID(): ?int {
+    if ($this->getExistingContributionID()) {
+      return $this->getExistingContributionID();
+    }
+    if (property_exists($this, '_contributionID')) {
+      // Available on Confirm form (which is tested), so this avoids
+      // accessing that directly & will work for ThankYou in time.
+      return $this->_contributionID;
+    }
+    return NULL;
   }
 
 }

--- a/Civi/Test/FormWrapper.php
+++ b/Civi/Test/FormWrapper.php
@@ -63,6 +63,13 @@ class FormWrapper {
     return $this->getFirstMail()['body'] ?? '';
   }
 
+  /**
+   * @return array
+   */
+  public function getTemplateVariables(): array {
+    return $this->templateVariables;
+  }
+
   private $redirects;
 
   private $mailSpoolID;
@@ -112,6 +119,7 @@ class FormWrapper {
     if ($state > self::VALIDATED) {
       $this->postProcess();
     }
+    $this->templateVariables = $this->form->get_template_vars();
     return $this;
   }
 

--- a/tests/phpunit/CRMTraits/Financial/PriceSetTrait.php
+++ b/tests/phpunit/CRMTraits/Financial/PriceSetTrait.php
@@ -168,7 +168,7 @@ trait CRMTraits_Financial_PriceSetTrait {
       ], $membershipTypeParams);
       $this->ids['MembershipType'] = [$this->membershipTypeCreate($membershipTypeParams)];
     }
-    $priceField = $this->callAPISuccess('price_field', 'create', [
+    $priceField = $this->callAPISuccess('PriceField', 'create', [
       'price_set_id' => $this->ids['PriceSet']['membership_block'],
       'name' => 'membership_amount',
       'label' => 'Membership Amount',


### PR DESCRIPTION


Overview
----------------------------------------
Fix test on secondary membership contribution to use full form flow

This includes minor standardisation on the priceSetID references - the variable is being referred to from both the get & within params but the getter is the primary source

Before
----------------------------------------
Test does not follow full form flow, or use valid data

After
----------------------------------------
Test is more valid

Technical Details
----------------------------------------

Comments
----------------------------------------
