### PR TITLE
Make function private,non static, after universe search

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -829,7 +829,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
    */
   public static function formRule($fields, $files, $self) {
     $errors = [];
-    $amount = self::computeAmount($fields, $self->_values);
+    $amount = $self->computeAmount($fields, $self->_values);
     if (!empty($fields['auto_renew']) && empty($fields['payment_processor_id'])) {
       $errors['auto_renew'] = ts('You cannot have auto-renewal on if you are paying later.');
     }
@@ -1141,7 +1141,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
    *
    * @return int|mixed|null|string
    */
-  public static function computeAmount($params, $formValues) {
+  private function computeAmount($params, $formValues) {
     $amount = 0;
     // First clean up the other amount field if present.
     if (isset($params['amount_other'])) {
@@ -1250,7 +1250,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     }
     else {
       // from here on down, $params['amount'] holds a monetary value (or null) rather than an option ID
-      $params['amount'] = self::computeAmount($params, $this->_values);
+      $params['amount'] = $this->computeAmount($params, $this->_values);
     }
 
     $params['separate_amount'] = $params['amount'];


### PR DESCRIPTION
Overview
----------------------------------------
Make function private,non static, after universe search

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/0ae01e16-1c25-44a0-a3e2-b1f9ad0cb2c2)


After
----------------------------------------
private

Technical Details
----------------------------------------
Function actually has some other issues too - which I might get to - but I used to think the static formRule function couldn't call a private function - which is probably why it wasn't private - however, we have test cover on the formRule & I stepped through it

Comments
----------------------------------------
