### PR TITLE
set extension browser timeout to minimum of 10 seconds.

### DIFF
--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -35,11 +35,6 @@ class CRM_Extension_Browser {
   const SINGLE_FILE_PATH = '/single';
 
   /**
-   * Timeout for when the connection or the server is slow
-   */
-  const CHECK_TIMEOUT = 5;
-
-  /**
    * @var GuzzleHttp\Client
    */
   protected $guzzleClient;
@@ -219,9 +214,11 @@ class CRM_Extension_Browser {
 
     $url = $this->getRepositoryUrl() . $this->indexPath;
     $client = $this->getGuzzleClient();
+    // Timeout should be a minimum of 10 seconds. See https://lab.civicrm.org/infra/ops/-/issues/1009.
+    $timeout = max(10, \Civi::settings()->get('http_timeout'));
     try {
       $response = $client->request('GET', $url, [
-        'timeout' => \Civi::settings()->get('http_timeout'),
+        'timeout' => $timeout,
       ]);
     }
     catch (GuzzleException $e) {


### PR DESCRIPTION
Overview
----------------------------------------
The default timeout waiting for a Guzzle request to respond is 5 seconds.  The "extdir" app at https://civicrm.org/extdir sometimes takes more than 5 seconds to respond if the response isn't cached.  This leads to false positives in the CiviCRM extension check.

For more discussion, see https://lab.civicrm.org/infra/ops/-/issues/1009.

Before
----------------------------------------
Guzzle timeout comes from `http_timeout` setting (defaults to 5 seconds).

After
----------------------------------------
Guzzle timeout has a minimum of 10 seconds in `CRM_Extension_Browser`.