### PR TITLE
Move pledge block function back to the only form that calls it

### DIFF
--- a/CRM/Pledge/BAO/PledgeBlock.php
+++ b/CRM/Pledge/BAO/PledgeBlock.php
@@ -118,8 +118,11 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
    * @param CRM_Core_Form $form
    *
    * @throws \CRM_Core_Exception
+   *
+   * @deprecated since 5.68 will be removed around 5.74
    */
   public static function buildPledgeBlock($form) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     //build pledge payment fields.
     if (!empty($form->_values['pledge_id'])) {
       //get all payments required details.


### PR DESCRIPTION
Overview
----------------------------------------
Move pledge block function back to the only form that calls it

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/b1282de8-cafe-4005-b43d-d2f0513fab29)


After
----------------------------------------
Original function deprecated noisily & copy on the form that calls it

Technical Details
----------------------------------------
I could have removed the function based on my universe search but figured a 6 month deprecation would do no harm

Comments
----------------------------------------
