### PR TITLE
karma.conf.js - Switch from PhantomJS to ChromeHeadless

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,7 +20,7 @@ var angularTempFile = cv(['php:eval', '-U', _CV.ADMIN_USER, cmd]);
 module.exports = function(config) {
   config.set({
     autoWatch: true,
-    browsers: ['PhantomJS'],
+    browsers: ['ChromeHeadless'],
     exclude: [
       'ang/api4Explorer/Explorer.js'
     ],


### PR DESCRIPTION
Overview
----------------------------------------
PhantomJS was abandoned upstream in favor of ChromeHeadless

Technical Details
----------------------------------------

* https://developer.chrome.com/blog/headless-karma-mocha-chai/
* https://medium.com/@sheng_di/karma-test-runner-with-headless-chrome-9391d800091
* https://github.com/civicrm/civicrm-buildkit/pull/818

With 818, I had success with this configuration locally. 818 is merged, so we should (*fingers crossed*) see this work on in CI.