### PR TITLE
APIv4 - Smarter matching params in Managed export action

### DIFF
--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -134,6 +134,11 @@ class Entity extends Generic\AbstractEntity {
       'description' => 'When joining entities in the UI, which fields should be presented by default in the ON clause',
     ],
     [
+      'name' => 'match_fields',
+      'data_type' => 'Array',
+      'description' => 'Combination of fields used for unique matching',
+    ],
+    [
       'name' => 'group_weights_by',
       'data_type' => 'Array',
       'description' => 'For sortable entities, what field groupings are used to order by weight',

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -154,6 +154,15 @@ abstract class AbstractEntity {
       $info['dao'] = $dao;
       $info['table_name'] = $dao::$_tableName;
       $info['icon_field'] = (array) ($dao::fields()['icon']['name'] ?? NULL);
+      if (method_exists($dao, 'indices')) {
+        foreach (\CRM_Utils_Array::findAll($dao::indices(FALSE), ['unique' => TRUE, 'localizable' => FALSE]) as $index) {
+          foreach ($index['field'] as $field) {
+            // Trim `field(length)` to just `field`
+            [$field] = explode('(', $field);
+            $info['match_fields'][] = $field;
+          }
+        }
+      }
     }
     foreach (ReflectionUtils::getTraits(static::class) as $trait) {
       $info['type'][] = CoreUtil::stripNamespace($trait);

--- a/Civi/Api4/Generic/AutocompleteAction.php
+++ b/Civi/Api4/Generic/AutocompleteAction.php
@@ -285,16 +285,8 @@ class AutocompleteAction extends AbstractAction {
    */
   private function getKeyField() {
     $entityName = $this->savedSearch['api_entity'];
-    if ($this->key) {
-      /** @var \CRM_Core_DAO $dao */
-      $dao = CoreUtil::getInfoItem($entityName, 'dao');
-      if ($dao && method_exists($dao, 'indices')) {
-        foreach ($dao::indices(FALSE) as $index) {
-          if (!empty($index['unique']) && in_array($this->key, $index['field'], TRUE)) {
-            return $this->key;
-          }
-        }
-      }
+    if ($this->key && in_array($this->key, CoreUtil::getInfoItem($entityName, 'match_fields') ?? [], TRUE)) {
+      return $this->key;
     }
     return $this->display['settings']['keyField'] ?? CoreUtil::getIdFieldName($entityName);
   }

--- a/Civi/Api4/Navigation.php
+++ b/Civi/Api4/Navigation.php
@@ -16,6 +16,7 @@ namespace Civi\Api4;
  * @searchable none
  * @orderBy weight
  * @groupWeightsBy domain_id,parent_id
+ * @matchFields name,domain_id
  * @since 5.19
  * @package Civi\Api4
  */

--- a/Civi/Api4/OptionValue.php
+++ b/Civi/Api4/OptionValue.php
@@ -17,6 +17,7 @@ namespace Civi\Api4;
  * @searchable secondary
  * @orderBy weight
  * @groupWeightsBy option_group_id
+ * @matchFields option_group_id,name
  * @since 5.19
  * @package Civi\Api4
  */

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchExportTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchExportTest.php
@@ -81,6 +81,10 @@ class SearchExportTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
     // Readonly fields should not be included
     $this->assertArrayNotHasKey('created_date', $export['SavedSearch_TestSearchToExport_SearchDisplay_TestDisplayToExport']['params']['values']);
     $this->assertArrayNotHasKey('modified_date', $export['SavedSearch_TestSearchToExport_SearchDisplay_TestDisplayToExport']['params']['values']);
+    // Match criteria
+    $this->assertEquals(['name'], $export['SavedSearch_TestSearchToExport']['params']['match']);
+    sort($export['SavedSearch_TestSearchToExport_SearchDisplay_TestDisplayToExport']['params']['match']);
+    $this->assertEquals(['name', 'saved_search_id'], $export['SavedSearch_TestSearchToExport_SearchDisplay_TestDisplayToExport']['params']['match']);
 
     // Add a second display
     SearchDisplay::create(FALSE)

--- a/tests/phpunit/api/v4/Action/ExportTest.php
+++ b/tests/phpunit/api/v4/Action/ExportTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4\Action;
+
+use api\v4\Api4TestBase;
+use Civi\Api4\Navigation;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class ExportTest extends Api4TestBase implements TransactionalInterface {
+
+  public function testExportNavigation(): void {
+    $sampleNav = Navigation::get(FALSE)
+      ->setLimit(1)
+      ->execute()->single();
+
+    $export = Navigation::export(FALSE)
+      ->setId($sampleNav['id'])
+      ->execute()->single();
+
+    sort($export['params']['match']);
+    $this->assertEquals(['domain_id', 'name'], $export['params']['match']);
+    $this->assertArrayNotHasKey('id', $export['params']['values']);
+    $this->assertArrayNotHasKey('domain_id', $export['params']['values']);
+    $this->assertArrayHasKey('name', $export['params']['values']);
+  }
+
+}

--- a/tests/phpunit/api/v4/Custom/ExportCustomGroupTest.php
+++ b/tests/phpunit/api/v4/Custom/ExportCustomGroupTest.php
@@ -57,8 +57,16 @@ class ExportCustomGroupTest extends CustomTestBase {
       ->setId($customGroup['id'])
       ->execute();
 
-    // 1 custom group + 3 fields + 1 option group + 3 options
+    // 1 custom group + 1 option group + 3 options + 3 fields
     $this->assertCount(8, $export);
+    $this->assertEquals('CustomGroup', $export[0]['entity']);
+    $this->assertEquals('OptionGroup', $export[1]['entity']);
+    $this->assertEquals('OptionValue', $export[2]['entity']);
+    $this->assertEquals('OptionValue', $export[3]['entity']);
+    $this->assertEquals('OptionValue', $export[4]['entity']);
+    $this->assertEquals('CustomField', $export[5]['entity']);
+    $this->assertEquals('CustomField', $export[6]['entity']);
+    $this->assertEquals('CustomField', $export[7]['entity']);
     // 2 fields share an option group
     $this->assertEquals($export[5]['params']['values']['option_group_id.name'], $export[7]['params']['values']['option_group_id.name']);
     // Option group name matches
@@ -69,6 +77,17 @@ class ExportCustomGroupTest extends CustomTestBase {
     $this->assertTrue(!isset($export[6]['params']['values']['option_group_id']));
     $this->assertArrayNotHasKey('option_group_id.name', $export[6]['params']['values']);
     $this->assertArrayNotHasKey('option_values', $export[6]['params']['values']);
+
+    // Match customGroup by name
+    $this->assertEquals(['name'], $export[0]['params']['match']);
+    // Match optionGroup by name
+    $this->assertEquals(['name'], $export[1]['params']['match']);
+    // Match optionValue by name and option_group_id
+    sort($export[2]['params']['match']);
+    $this->assertEquals(['name', 'option_group_id'], $export[2]['params']['match']);
+    // Match customField by name and custom_group_id
+    sort($export[5]['params']['match']);
+    $this->assertEquals(['custom_group_id', 'name'], $export[5]['params']['match']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Does a better job of setting the `match` param when exporting managed entities.

Before
----------------------------------------
Defaults to `"name"` which works for some entities & is totally wrong for others.

After
----------------------------------------
Set based on metadata.

Technical Details
----------------------------------------
Adds a new bit of entity metadata: `match_fields` which describes the combination of fields used for unique matching (e.g "name" + "domain_id").