### PR TITLE
dev/core#4732 - ScheduleReminder - Fix form to handle serialized values

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -22,6 +22,8 @@ use Civi\Token\TokenProcessor;
  */
 class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
 
+  protected $retrieveMethod = 'api4';
+
   /**
    * @return string
    */


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug described in [dev/core#4732](https://lab.civicrm.org/dev/core/-/issues/4732)

Technical Details
---------
dc742067004cb2e47bed3d55387e2ed3fbfd72b6 introduced the `CRM_Admin_Form::$retrieveMethod` variable specifically for use on this form, but somehow got omitted from the final commit. This adds it back.