### PR TITLE
Smarty3 & php8.x fixes on New Contact (organization)

### DIFF
--- a/templates/CRM/Contact/Form/Edit/Organization.tpl
+++ b/templates/CRM/Contact/Form/Edit/Organization.tpl
@@ -11,26 +11,28 @@
 <table class="form-layout-compressed">
   {crmRegion name="contact-form-edit-organization"}
     <tr>
-      <td>{
-        $form.organization_name.label}<br/>
+      <td>
+        {$form.organization_name.label|smarty:nodefaults|purify}<br/>
         {$form.organization_name.html}
       </td>
       <td>
-        {$form.legal_name.label}<br/>
+        {$form.legal_name.label|smarty:nodefaults|purify}<br/>
         {$form.legal_name.html}
       </td>
       <td>
-        {$form.nick_name.label}<br/>
+        {$form.nick_name.label|smarty:nodefaults|purify}<br/>
         {$form.nick_name.html}
       </td>
       <td>
-        {$form.sic_code.label}<br/>
+        {$form.sic_code.label|smarty:nodefaults|purify}<br/>
         {$form.sic_code.html}
       </td>
-      <td>
-        {$form.contact_sub_type.label}<br />
-        {$form.contact_sub_type.html}
-      </td>
+      {if array_key_exists('contact_sub_type', $form)}
+        <td>
+          {$form.contact_sub_type.label|smarty:nodefaults|purify}<br />
+          {$form.contact_sub_type.html}
+        </td>
+      {/if}
     </tr>
   {/crmRegion}
 </table>

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -67,8 +67,8 @@
           <div {if $context neq 'dialog'}id="profilewrap{$field.group_id}"{/if}>
           <fieldset><legend>{$field.groupTitle}</legend>
         {/if}
-        {assign var=fieldset  value=`$field.groupTitle`}
-        {assign var=groupHelpPost  value=`$field.groupHelpPost`}
+        {assign var=fieldset  value=$field.groupTitle}
+        {assign var=groupHelpPost  value=$field.groupHelpPost}
         {if $field.groupHelpPre}
           <div class="messages help">{$field.groupHelpPre}</div>
         {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Smarty3 & php8.x fixes on New Contact (organization)

Before
----------------------------------------
note - tag notices might go away on rebuild but the contact_sub_type ones are as reported by @jofranz in https://lab.civicrm.org/dev/core/-/issues/4720 & rely on there being no contact subtypes.

Also notice the smarty-3 issue at the start of the accordian - due to extraneous spaces.

![image](https://github.com/civicrm/civicrm-core/assets/336308/1dd4fc08-101b-4e40-9599-4f94512429bc)

In testing I also found the modal new org didn't work with Smarty 3

After
----------------------------------------
Fixed,

I added 'smarty:nodefaults|purify' to the labels - not because they are insecure (based on a quick check I don't think they are)  but because I felt that clarifies how to treat them as we move to escape on output (as with most quickform labels they can potentially have html in them for the required notation - quite yuck really)

Technical Details
----------------------------------------

Comments
----------------------------------------
