### PR TITLE
Fix offline contribution page handling of money fields

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1086,7 +1086,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       return;
     }
     // Get the submitted form values.
-    $submittedValues = $this->controller->exportValues($this->_name);
+    $submittedValues = $this->getSubmittedValues();
     if ($this->_values['is_template']) {
       // If we are a template contribution we don't allow the contribution_status_id to be set
       //   on the form but we need it for the submit function.
@@ -1769,7 +1769,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         $componentDetails = CRM_Contribute_BAO_Contribution::getComponentDetails($this->_id);
         if (empty($componentDetails['membership']) && empty($componentDetails['participant'])) {
           if (!($this->_action & CRM_Core_Action::UPDATE && (($this->_defaults['contribution_status_id'] != $submittedValues['contribution_status_id'])))) {
-            $lineItems[$itemId]['unit_price'] = $lineItems[$itemId]['line_total'] = CRM_Utils_Rule::cleanMoney(CRM_Utils_Array::value('total_amount', $submittedValues));
+            $lineItems[$itemId]['unit_price'] = $lineItems[$itemId]['line_total'] = $this->getSubmittedValue('total_amount');
           }
         }
 


### PR DESCRIPTION


Overview
----------------------------------------
Fixes Offline contribution page so this fix
https://github.com/civicrm/civicrm-core/pull/27917 works for it too.

Note the 2 changes on total_amount are just tidy ups to remove redundancy - but double cleaning can also cause breakage...

I prefer to use getSubmittedValue() whereever possible because it makes it clear we are using the user-submitted value not some value wrangled into an array along the way

Before
----------------------------------------
Fix does not apply to contribution page

After
----------------------------------------
Now it does

Technical Details
----------------------------------------

Comments
----------------------------------------
