### PR TITLE
Suppress pay now on user dashboard if none configured

### DIFF
--- a/CRM/Contribute/Page/UserDashboard.php
+++ b/CRM/Contribute/Page/UserDashboard.php
@@ -32,7 +32,9 @@ class CRM_Contribute_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBo
       // which the tpl can iterate through - this should allow us to cope with competing attempts to add new buttons
       // and allow extensions to assign new ones through the pageRun hook
       // We could check for balance_amount > 0 here? It feels more correct but this seems to be working.
-      if (in_array($row['contribution_status_id:name'], ['Pending', 'Partially paid'], TRUE)) {
+      if (in_array($row['contribution_status_id:name'], ['Pending', 'Partially paid'], TRUE)
+        && Civi::settings()->get('default_invoice_page')
+      ) {
         $row['buttons']['pay'] = [
           'class' => 'button',
           'label' => ts('Pay Now'),


### PR DESCRIPTION
Overview
----------------------------------------
Suppress pay now on user dashboard if none configured

Before
----------------------------------------
On the dmaster build currently if a user does a pay later contribution via a contribution page they will see a 'pay now' buttong. However, this does not work unless the site has a configured default payment page

![image](https://github.com/civicrm/civicrm-core/assets/336308/c67889a4-a482-4317-9732-686d256cb17c)


After
----------------------------------------
The link only shows if the default payment page is configured

Technical Details
----------------------------------------
This is a minimal fix, that attempts to honor what the existing code is doing. One thing that makes this worse is that the civicrm component settings form is messed up - ie the Default Payment Page is required rather than optional - so when it is not configured it appears configured. There are other issues with that form - the legacy of the `'contribution_invoice_settings'` pseudosetting.

However, I suspect @petednz might be happy with this fix & not want to push to get more fixed

Comments
----------------------------------------
