### PR TITLE
dev/core#4154 Fix locale-formatted number custom field inputs (case activities)

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -382,7 +382,7 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
     // store the submitted values in an array
     // Explanation for why we only check the is_unittest element: Prior to adding that check, there was no check and so any $params passed in would have been overwritten. Just in case somebody is passing in some non-null params and that broken code would have inadvertently been working, we can maintain backwards compatibility by only checking for the is_unittest parameter, and so that broken code will still work. At the same time this allows unit tests to pass in a $params without it getting overwritten. See also PR #2077 for some discussion of when the $params parameter was added as a passed in variable.
     if (empty($params['is_unittest'])) {
-      $params = $this->controller->exportValues($this->_name);
+      $params = $this->getSubmittedValues();
     }
 
     //set parent id if its edit mode


### PR DESCRIPTION
Overview
----------------------------------------

Another followup to #27917, to apply the fix to custom fields on Case Activities.

Before
----------------------------------------

Numeric custom fields on Case Activities cannot be edited/saved when using a comma as a decimal separator.

After
----------------------------------------

Fixed
