### PR TITLE
dev/core#4736 - fix on-the-fly popup

### DIFF
--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -889,11 +889,10 @@ class CRM_Profile_Form extends CRM_Core_Form {
     $this->setDefaultsValues();
 
     $action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, NULL);
-    $isCreateOrEditMode = $this->_mode == self::MODE_CREATE || $this->_mode == self::MODE_EDIT;
-    if ($isCreateOrEditMode) {
+    if ($this->_mode == self::MODE_CREATE || $this->_mode == self::MODE_EDIT) {
       CRM_Core_BAO_CMSUser::buildForm($this, $this->_gid, $emailPresent, $action);
     }
-    $this->assign('showCMS', $isCreateOrEditMode);
+    $this->assign('showCMS', FALSE);
 
     $this->assign('groupId', $this->_gid);
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4736

Before
----------------------------------------
1. Create contribution
2. Click New Individual in the contact field.
3. CMS account creation form comes up instead of the usual popup

After
----------------------------------------
ok

Technical Details
----------------------------------------
Refactor in https://github.com/civicrm/civicrm-core/commit/8f2bc9fd1b8d511833f6453f5#diff-56e3e33dca0a0cd8b307d9a0da04b3c089b14522bd6cab03d084342641f5c2dbL892 wasn't right. The original never set showCMS to true, so the refactor shouldn't either.

Comments
----------------------------------------

