### PR TITLE
Update the list of required extensions to install during test db populate

### DIFF
--- a/Civi/Test.php
+++ b/Civi/Test.php
@@ -125,7 +125,7 @@ class Test {
       ->callback(function ($ctx) {
         \Civi\Test::data()->populate();
       }, 'populate');
-    $builder->install(['org.civicrm.search_kit']);
+    $builder->install(['org.civicrm.search_kit', 'org.civicrm.afform', 'authx']);
     return $builder;
   }
 

--- a/ext/afform/core/ang/af.ang.php
+++ b/ext/afform/core/ang/af.ang.php
@@ -9,7 +9,6 @@ return [
   // 'css' => ['ang/af.css'],
   'partials' => ['ang/af'],
   'requires' => ['crmUtil'],
-  'settings' => [],
   'basePages' => [],
   'exports' => [
     'af-entity' => 'E',

--- a/ext/afform/core/ang/afCore.ang.php
+++ b/ext/afform/core/ang/afCore.ang.php
@@ -9,6 +9,5 @@ return [
   'css' => ['ang/afCore.css'],
   'requires' => ['crmUi', 'crmUtil', 'api4', 'checklist-model', 'angularFileUpload'],
   'partials' => ['ang/afCore'],
-  'settings' => [],
   'basePages' => [],
 ];

--- a/ext/afform/core/ang/afformStandalone.ang.php
+++ b/ext/afform/core/ang/afformStandalone.ang.php
@@ -5,6 +5,5 @@ return [
     'ang/afformStandalone.js',
   ],
   'css' => [],
-  'settings' => [],
   'requires' => [],
 ];

--- a/tests/phpunit/Civi/Angular/ManagerTest.php
+++ b/tests/phpunit/Civi/Angular/ManagerTest.php
@@ -56,7 +56,11 @@ class ManagerTest extends \CiviUnitTestCase {
       if (isset($module['js'])) {
         $this->assertTrue(is_array($module['js']));
         foreach ($module['js'] as $file) {
-          $this->assertTrue(file_exists($this->res->getPath($module['ext'], $file)), "File '$file' not found for " . $module['ext']);
+          $filePath = $this->res->getPath($module['ext'], $file);
+          // Some files aren't real paths, like assetBuilder://afform.js?...
+          if ($filePath !== FALSE) {
+            $this->assertTrue(file_exists($filePath), "File '$file' not found for " . $module['ext']);
+          }
           $counts['js']++;
         }
       }

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -102,6 +102,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       'Logging',
     ];
     $this->toBeImplemented['create'] = [
+      'Afform',
       'Cxn',
       'CxnApp',
       'SurveyRespondant',
@@ -845,6 +846,9 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
     if ($entityName === 'Note') {
       $this->markTestIncomplete('Note can not be processed here because of a vagary in the note api, it adds entity_table=contact to the get params when id is not present - which makes sense almost always but kills this test');
     }
+    elseif ($entityName === 'Afform') {
+      $this->markTestSkipped('Not necessary.');
+    }
     $this->quickCleanup(['civicrm_uf_match']);
     // so subsidiary activities are created
     $this->createLoggedInUser();
@@ -1096,7 +1100,8 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
     $toBeIgnored = array_merge($this->toBeImplemented['get'],
       $this->getDeprecatedAPIs(),
       $this->toBeSkipped_get(TRUE),
-      $this->toBeSkippedGetByID()
+      $this->toBeSkippedGetByID(),
+      ['Afform']
     );
     if (in_array($entityName, $toBeIgnored)) {
       return;


### PR DESCRIPTION
Overview
----------------------------------------
There are some more required extses now.

Before
----------------------------------------
Difficult to properly test things locally unless you're set up however the jenkins run does it.

After
----------------------------------------
Can run phpunit like a normal person and have the right extses installed.

Technical Details
----------------------------------------


Comments
----------------------------------------
@highfalutin @kurund This addresses the inability to reproduce the test fails for https://github.com/civicrm/civicrm-core/pull/27107 locally.

Flexmailer is in sql/civicrm_data/civicrm_extension.sqldata.php. I'm not sure why there's two places.