### PR TITLE
rc only regression - price set validation on participant form

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -733,8 +733,8 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       if (empty($values['payment_instrument_id'])) {
         $errorMsg['payment_instrument_id'] = ts('Payment Method is a required field.');
       }
-      if ($self->getPriceSetID()) {
-        CRM_Price_BAO_PriceField::priceSetValidation($self->getPriceSetID(), $values, $errorMsg);
+      if (!empty($values['priceSetId'])) {
+        CRM_Price_BAO_PriceField::priceSetValidation($values['priceSetId'], $values, $errorMsg);
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
rc only regression - price set validation on participant form


Before
----------------------------------------
When editing a pending event registration validation fails requiring prices set info to be selected
![image](https://github.com/civicrm/civicrm-core/assets/336308/f80b80f1-9d26-4b4b-a728-43583e84aa57)

After
----------------------------------------
Price set validation only kicks in if the priceset field is on the form & has been selected

Technical Details
----------------------------------------

Comments
----------------------------------------
