### PR TITLE
Fix dev/core#4737 - APIv4 getFields crashes with no tags

### DIFF
--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -169,7 +169,7 @@ class SpecFormatter {
     }
     else {
       $options = \CRM_Utils_Array::makeNonAssociative($optionLabels, 'id', 'label');
-      if (is_array($returnFormat)) {
+      if (is_array($returnFormat) && $options) {
         self::addOptionProps($options, $spec, $bao, $fieldName, $values, $returnFormat);
       }
     }

--- a/tests/phpunit/api/v4/Action/GetFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetFieldsTest.php
@@ -188,6 +188,34 @@ class GetFieldsTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals(0, $optionValueFields['filter']['default_value']);
   }
 
+  public function testActivityTagGetFields(): void {
+    Tag::delete(FALSE)
+      ->addWhere('used_for:name', 'CONTAINS', 'Activity')
+      ->execute();
+
+    $tagField = Activity::getFields(FALSE)
+      ->addWhere('name', '=', 'tags')
+      ->setLoadOptions(['id', 'name', 'label', 'description', 'color'])
+      ->execute()->single();
+    $this->assertEquals([], $tagField['options']);
+
+    Tag::create(FALSE)
+      ->addValue('used_for:name', ['Activity'])
+      ->addValue('label', 'Act Tag')
+      ->addValue('description', 'Test tag for activities')
+      ->addValue('color', '#aaaaaa')
+      ->execute();
+
+    $tagField = Activity::getFields(FALSE)
+      ->addWhere('name', '=', 'tags')
+      ->setLoadOptions(['id', 'name', 'label', 'description', 'color'])
+      ->execute()->single();
+    $this->assertCount(1, $tagField['options']);
+    $this->assertEquals('Act_Tag', $tagField['options'][0]['name']);
+    $this->assertEquals('Test tag for activities', $tagField['options'][0]['description']);
+    $this->assertEquals('#aaaaaa', $tagField['options'][0]['color']);
+  }
+
   public function testGetSuffixes(): void {
     $actFields = Activity::getFields(FALSE)
       ->execute()->indexBy('name');


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug in https://lab.civicrm.org/dev/core/-/issues/4737 and adds a test.

Before
----------------------------------------
Crash

After
----------------------------------------
No crash