### PR TITLE
dev/core#4730 - Case tagsets showing name instead of label

### DIFF
--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -457,16 +457,16 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
         'entity_table' => 'civicrm_case',
         'tag_id.parent_id.is_tagset' => 1,
         'options' => ['limit' => 0],
-        'return' => ["tag_id.parent_id", "tag_id.parent_id.name", "tag_id.name"],
+        'return' => ["tag_id.parent_id", "tag_id.parent_id.label", "tag_id.label"],
       ]);
       foreach ($tagSetItems['values'] as $tag) {
         $tagSetTags += [
           $tag['tag_id.parent_id'] => [
-            'name' => $tag['tag_id.parent_id.name'],
+            'label' => $tag['tag_id.parent_id.label'],
             'items' => [],
           ],
         ];
-        $tagSetTags[$tag['tag_id.parent_id']]['items'][] = $tag['tag_id.name'];
+        $tagSetTags[$tag['tag_id.parent_id']]['items'][] = $tag['tag_id.label'];
       }
     }
     $this->assign('tagSetTags', $tagSetTags);

--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -304,8 +304,8 @@
 
    {foreach from=$tagSetTags item=displayTagset}
      <p class="crm-block crm-content-block crm-case-caseview-display-tagset">
-       &nbsp;&nbsp;<strong>{$displayTagset.name}:</strong>
-       {', '|implode:$displayTagset.items}
+       &nbsp;&nbsp;<strong>{$displayTagset.label}:</strong>
+       {', '|implode:$displayTagset.items|escape}
      </p>
    {/foreach}
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4730

This is the other half (eighth?) of https://github.com/civicrm/civicrm-core/pull/27924

Before
----------------------------------------
1. Create a tagset for cases.
2. Create a tag for it, say "my tag".
3. Add it to a case.
4. Change the tag definition, say to "My Tag Label".
5. Go to view the case. It will still show as "my tag".

After
----------------------------------------
My Tag Label

Technical Details
----------------------------------------


Comments
----------------------------------------

