### PR TITLE
E_WARNING for "file" on civicontribute component settings

### DIFF
--- a/ext/financialacls/settings/financialacls.setting.php
+++ b/ext/financialacls/settings/financialacls.setting.php
@@ -13,7 +13,7 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'help_text' => NULL,
-    'help' => ['id' => 'acl_financial_type'],
+    'help' => ['id' => 'acl_financial_type', 'file' => 'CRM/Admin/Form/Preferences/Contribute.hlp'],
     'settings_pages' => ['contribute' => ['weight' => 30]],
     'on_change' => [
       'financialacls_toggle',


### PR DESCRIPTION
Overview
----------------------------------------

Before
----------------------------------------
`Warning: Undefined array key "file" in include() (line 14 of templates_c/en_US/%%0B/0B9/0B956D8A%%Field.tpl.php).`

After
----------------------------------------


Technical Details
----------------------------------------
If it's not referenced in a tpl file with the same root filename as the hlp file where the help is located then it should set the file param. I debated updating field.tpl instead, but it got messier than that file is already and it seems better to just set the file param when needed. I also considered moving the hlp file to the extension that controls the setting but I couldn't easily figure out how to do that - it seems unable to find it.

Comments
----------------------------------------
Need to clear cache to pick up the change since it's in a settings file.