### PR TITLE
Move the locale default getting from the money() function to the getFormatter function

### DIFF
--- a/Civi/Core/Format.php
+++ b/Civi/Core/Format.php
@@ -44,10 +44,6 @@ class Format extends \Civi\Core\Service\AutoService {
     if (!$currency) {
       $currency = Civi::settings()->get('defaultCurrency');
     }
-    if (!isset($locale)) {
-      global $civicrmLocale;
-      $locale = $civicrmLocale->moneyFormat ?? (Civi::settings()->get('format_locale') ?? CRM_Core_I18n::getLocale());
-    }
     $currencyObject = CRM_Utils_Money::getCurrencyObject($currency);
     $money = Money::of($amount, $currencyObject, NULL, RoundingMode::HALF_UP);
     $formatter = $this->getMoneyFormatter($currency, $locale);
@@ -92,7 +88,7 @@ class Format extends \Civi\Core\Service\AutoService {
    * @noinspection PhpDocMissingThrowsInspection
    * @noinspection PhpUnhandledExceptionInspection
    */
-  public function moneyNumber($amount, string $currency, $locale): string {
+  public function moneyNumber($amount, string $currency, $locale = NULL): string {
     if (($amount = $this->checkAndConvertAmount($amount)) === '') {
       return '';
     }
@@ -195,9 +191,7 @@ class Format extends \Civi\Core\Service\AutoService {
   }
 
   /**
-   * Get the money formatter for when we are using configured thousand separators.
-   *
-   * Our intent is to phase out these settings in favour of deriving them from the locale.
+   * Get the cached money formatter.
    *
    * @param string|null $currency
    * @param string|null $locale
@@ -215,7 +209,10 @@ class Format extends \Civi\Core\Service\AutoService {
     if (!$currency) {
       $currency = Civi::settings()->get('defaultCurrency');
     }
-    $locale = $locale ?: \Civi\Core\Locale::detect()->moneyFormat;
+    if (!isset($locale)) {
+      global $civicrmLocale;
+      $locale = $civicrmLocale->moneyFormat ?? (Civi::settings()->get('format_locale') ?? CRM_Core_I18n::getLocale());
+    }
 
     $cacheKey = __CLASS__ . $currency . '_' . $locale . '_' . $style . (!empty($attributes) ? md5(json_encode($attributes)) : '');
     if (!isset(\Civi::$statics[$cacheKey])) {


### PR DESCRIPTION


Overview
----------------------------------------
`Civi::format()` provides a handful of money formatting funcitons, only `Civi::format()->money()` has much any real non-test-usage. The others are hard to use because they don't determine the locale (when not provided) the same way as  `Civi::format()->money()` - this moves the code that does that to the shared function

Before
----------------------------------------
`money()` will load the money locale from the setting if not provided but similar functions (mostly intended to get the decimal formatting but not currency symbol) don't. As a result we use `CRM_Utils_Money` class & the new functions go unused

After
----------------------------------------
The code to get the locales is moved to the shared function

Technical Details
----------------------------------------

Comments
----------------------------------------
