### PR TITLE
SearchKit - New getLinks API action for advanced link handling

### DIFF
--- a/CRM/Activity/Form/ActivityLinks.php
+++ b/CRM/Activity/Form/ActivityLinks.php
@@ -28,73 +28,20 @@ class CRM_Activity_Form_ActivityLinks extends CRM_Core_Form {
    * @param self $self
    */
   public static function commonBuildQuickForm($self) {
-    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $self);
-    if (!$contactId) {
-      $contactId = CRM_Utils_Request::retrieve('cid', 'Positive');
-    }
-    $urlParams = "action=add&reset=1&cid={$contactId}&selectedChild=activity&atype=";
-
-    $allTypes = CRM_Utils_Array::value('values', civicrm_api3('OptionValue', 'get', [
-      'option_group_id' => 'activity_type',
-      'is_active' => 1,
-      'options' => ['limit' => 0, 'sort' => 'weight'],
-    ]));
+    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $self) ?: CRM_Utils_Request::retrieve('cid', 'Positive');
 
     $activityTypes = [];
 
-    foreach ($allTypes as $act) {
-      $url = 'civicrm/activity/add';
-      if ($act['name'] === 'Email') {
-        if (!CRM_Utils_Mail::validOutBoundMail() || !$contactId) {
-          continue;
-        }
-        [, $email, $doNotEmail, , $isDeceased] = CRM_Contact_BAO_Contact::getContactDetails($contactId);
-        if (!$doNotEmail && $email && !$isDeceased) {
-          $url = 'civicrm/activity/email/add';
-          $act['label'] = ts('Send an Email');
-        }
-        else {
-          continue;
-        }
-      }
-      elseif ($act['name'] === 'SMS') {
-        if (!$contactId || !CRM_SMS_BAO_Provider::activeProviderCount() || !CRM_Core_Permission::check('send SMS')) {
-          continue;
-        }
-        // Check for existence of a mobile phone and ! do not SMS privacy setting
-        try {
-          $phone = civicrm_api3('Phone', 'getsingle', [
-            'contact_id' => $contactId,
-            'phone_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Phone', 'phone_type_id', 'Mobile'),
-            'return' => ['phone', 'contact_id'],
-            'options' => ['limit' => 1, 'sort' => "is_primary DESC"],
-            'api.Contact.getsingle' => [
-              'id' => '$value.contact_id',
-              'return' => 'do_not_sms',
-            ],
-          ]);
-        }
-        catch (CRM_Core_Exception $e) {
-          continue;
-        }
-        if (!$phone['api.Contact.getsingle']['do_not_sms'] && $phone['phone']) {
-          $url = 'civicrm/activity/sms/add';
-        }
-        else {
-          continue;
-        }
-      }
-      elseif ($act['name'] == 'Print PDF Letter') {
-        $url = 'civicrm/activity/pdf/add';
-      }
-      elseif (!empty($act['filter']) || (!empty($act['component_id']) && $act['component_id'] != '1')) {
-        continue;
-      }
-      $act['url'] = CRM_Utils_System::url($url,
-        "{$urlParams}{$act['value']}", FALSE, NULL, FALSE
-      );
-      $act += ['icon' => 'fa-plus-square-o'];
-      $activityTypes[$act['value']] = $act;
+    $activityLinks = \Civi\Api4\Activity::getLinks()
+      ->addValue('target_contact_id', $contactId)
+      ->addWhere('ui_action', '=', 'add')
+      ->execute();
+    foreach ($activityLinks as $activityLink) {
+      $activityTypes[] = [
+        'label' => $activityLink['text'],
+        'icon' => $activityLink['icon'],
+        'url' => CRM_Utils_System::url($activityLink['path'], NULL, FALSE, NULL, FALSE),
+      ];
     }
 
     $self->assign('activityTypes', $activityTypes);

--- a/CRM/Activity/Form/ActivityLinks.php
+++ b/CRM/Activity/Form/ActivityLinks.php
@@ -35,6 +35,7 @@ class CRM_Activity_Form_ActivityLinks extends CRM_Core_Form {
     $activityLinks = \Civi\Api4\Activity::getLinks()
       ->addValue('target_contact_id', $contactId)
       ->addWhere('ui_action', '=', 'add')
+      ->setExpandMultiple(TRUE)
       ->execute();
     foreach ($activityLinks as $activityLink) {
       $activityTypes[] = [

--- a/CRM/Core/Action.php
+++ b/CRM/Core/Action.php
@@ -76,6 +76,7 @@ class CRM_Core_Action {
     'revert' => self::REVERT,
     'close' => self::CLOSE,
     'reopen' => self::REOPEN,
+    'advanced' => self::ADVANCED,
   ];
 
   private static function getInfo(): array {

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -1044,4 +1044,26 @@ class CRM_Utils_String {
     return $templateString;
   }
 
+  /**
+   * Parse a string for SearchKit-style [square_bracket] tokens.
+   * @internal
+   * @param string $raw
+   * @return array
+   */
+  public static function getSquareTokens(string $raw): array {
+    $matches = $tokens = [];
+    if (str_contains($raw, '[')) {
+      preg_match_all('/\\[([^]]+)\\]/', $raw, $matches);
+      foreach (array_unique($matches[1]) as $match) {
+        [$field, $suffix] = array_pad(explode(':', $match), 2, NULL);
+        $tokens[$match] = [
+          'token' => "[$match]",
+          'field' => $field,
+          'suffix' => $suffix,
+        ];
+      }
+    }
+    return $tokens;
+  }
+
 }

--- a/Civi/API/Event/RespondEvent.php
+++ b/Civi/API/Event/RespondEvent.php
@@ -21,7 +21,7 @@ namespace Civi\API\Event;
  */
 class RespondEvent extends Event {
   /**
-   * @var mixed
+   * @var \Civi\Api4\Generic\Result|mixed
    */
   private $response;
 
@@ -30,7 +30,7 @@ class RespondEvent extends Event {
    *   The API provider responsible for executing the request.
    * @param array $apiRequest
    *   The full description of the API request.
-   * @param mixed $response
+   * @param \Civi\Api4\Generic\Result|mixed $response
    *   The response to return to the client.
    * @param \Civi\API\Kernel $apiKernel
    *   The kernel which fired the event.
@@ -41,7 +41,7 @@ class RespondEvent extends Event {
   }
 
   /**
-   * @return mixed
+   * @return \Civi\Api4\Generic\Result|mixed
    */
   public function getResponse() {
     return $this->response;

--- a/Civi/Api4/Action/GetLinks.php
+++ b/Civi/Api4/Action/GetLinks.php
@@ -22,6 +22,10 @@ use Civi\Core\Event\GenericHookEvent;
  * Get action links for the $ENTITY entity.
  *
  * Action links are paths to forms for e.g. view, edit, or delete actions.
+ * @method string getEntityTitle()
+ * @method $this setEntityTitle(string $entityTitle)
+ * @method bool getExpandMultiple()
+ * @method $this setExpandMultiple(bool $expandMultiple)
  */
 class GetLinks extends BasicGetAction {
   use \Civi\Api4\Generic\Traits\GetSetValueTrait;
@@ -37,6 +41,12 @@ class GetLinks extends BasicGetAction {
    * @var bool|string
    */
   protected $entityTitle = TRUE;
+
+  /**
+   * Should multiple links e.g. to create different subtypes all be returned?
+   * @var bool
+   */
+  protected bool $expandMultiple = FALSE;
 
   public function _run(Result $result) {
     parent::_run($result);

--- a/Civi/Api4/Action/GetLinks.php
+++ b/Civi/Api4/Action/GetLinks.php
@@ -1,0 +1,212 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action;
+
+use Civi\API\Request;
+use Civi\Api4\Generic\BasicGetAction;
+use Civi\Api4\Generic\Result;
+use Civi\Api4\Utils\CoreUtil;
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * Get action links for the $ENTITY entity.
+ *
+ * Action links are paths to forms for e.g. view, edit, or delete actions.
+ */
+class GetLinks extends BasicGetAction {
+  use \Civi\Api4\Generic\Traits\GetSetValueTrait;
+
+  /**
+   * Links will be returned appropriate to the specified values (e.g. ['contact_type' => 'Individual'])
+   *
+   * @var array
+   */
+  protected $values = [];
+
+  /**
+   * @var bool|string
+   */
+  protected $entityTitle = TRUE;
+
+  public function _run(Result $result) {
+    parent::_run($result);
+    // Do expensive processing *after* parent has filtered down the result per the WHERE clause
+    if ($this->getSelect() !== ['row_count']) {
+      $links = $result->getArrayCopy();
+      $this->replaceTokens($links);
+      $this->filterByPermission($links);
+      $result->exchangeArray(array_values($links));
+    }
+  }
+
+  protected function getRecords(): array {
+    $entityName = $this->getEntityName();
+    $locale = $GLOBALS['tsLocale'] ?? '';
+    $cacheKey = "api4.$entityName.links.$locale";
+    $links = \Civi::cache('metadata')->get($cacheKey);
+    if (!isset($links)) {
+      $links = $this->fetchLinks();
+      \Civi::cache('metadata')->set($cacheKey, $links);
+    }
+    return $links;
+  }
+
+  /**
+   * Get the full set of links for an entity
+   *
+   * This function sits behind a cache so the heavy processing happens here.
+   * @return array
+   */
+  private function fetchLinks(): array {
+    $links = [];
+    $apiActionMap = [
+      'add' => 'create',
+      'delete' => 'delete',
+      'view' => 'get',
+      'browse' => 'get',
+      'export' => 'get',
+      'preview' => 'get',
+    ];
+    $entityName = $this->getEntityName();
+    $paths = CoreUtil::getInfoItem($entityName, 'paths') ?? [];
+    foreach ($paths as $actionName => $path) {
+      $actionKey = \CRM_Core_Action::mapItem($actionName);
+      $link = [
+        'ui_action' => $actionName,
+        'api_action' => $apiActionMap[$actionName] ?? 'update',
+        'api_values' => NULL,
+        'entity' => $entityName,
+        'path' => $path,
+        'text' => \CRM_Core_Action::getTitle($actionKey, '%1'),
+        'icon' => \CRM_Core_Action::getIcon($actionKey),
+        'weight' => (int) \CRM_Core_Action::getWeight($actionKey),
+        'target' => 'crm-popup',
+      ];
+      $links[] = $link;
+    }
+    // Allow entity to override with extra links
+    $event = GenericHookEvent::create(['entity' => $entityName, 'links' => &$links]);
+    \Civi::dispatcher()->dispatch('civi.api4.getLinks', $event);
+    // Fill in optional keys from hook links
+    foreach ($links as $index => $link) {
+      $links[$index] += [
+        'api_values' => NULL,
+        'entity' => $entityName,
+        'weight' => 0,
+        'target' => 'crm-popup',
+      ];
+    }
+    usort($links, ['CRM_Utils_Sort', 'cmpFunc']);
+    return $links;
+  }
+
+  /**
+   * Replace [square_bracket] tokens in the path and `%1` placeholders in the text.
+   * @param array $links
+   * @return void
+   */
+  private function replaceTokens(array &$links): void {
+    // Text was translated with `%1` placeholders preserved so it could be cached
+    // Now we'll replace `%1` placeholders with the entityTitle, unless FALSE
+    $entityTitle = $this->entityTitle === TRUE ? CoreUtil::getInfoItem($this->getEntityName(), 'title') : $this->entityTitle;
+    foreach ($links as &$link) {
+      // Swap placeholders with $entityTitle (TRUE means use default title)
+      if ($entityTitle !== FALSE && !empty($link['text'])) {
+        $link['text'] = str_replace('%1', $entityTitle, $link['text']);
+      }
+      // Swap path tokens with values
+      if ($this->getValues() && !empty($link['path'])) {
+        $tokens = \CRM_Utils_String::getSquareTokens($link['path']);
+        foreach ($tokens as $fieldExpr => $token) {
+          $value = $this->getValue($fieldExpr);
+          if (isset($value)) {
+            $link['path'] = str_replace($token['token'], $value, $link['path']);
+          }
+        }
+      }
+    }
+  }
+
+  private function filterByPermission(array &$links): void {
+    if (!$this->getCheckPermissions()) {
+      return;
+    }
+    $allowedApiActions = $this->getAllowedEntityActions();
+    foreach ($links as $index => $link) {
+      if (!in_array($link['api_action'], $allowedApiActions, TRUE)) {
+        unset($links[$index]);
+        continue;
+      }
+      $values = array_merge($this->values, (array) $link['api_values']);
+      // These 2 lines are the heart of the `checkAccess` api action.
+      // Calling this directly is more performant than going through the api wrapper
+      $apiRequest = Request::create($link['entity'], $link['api_action'], ['version' => 4, 'checkPermissions' => TRUE]);
+      if (!CoreUtil::checkAccessRecord($apiRequest, $values)) {
+        unset($links[$index]);
+      }
+    }
+  }
+
+  private function getAllowedEntityActions(): array {
+    $uid = \CRM_Core_Session::getLoggedInContactID();
+    $entityName = $this->getEntityName();
+    if (!isset(\Civi::$statics[__CLASS__]['actions'][$entityName][$uid])) {
+      \Civi::$statics[__CLASS__]['actions'][$entityName][$uid] = civicrm_api4($entityName, 'getActions', ['checkPermissions' => TRUE])->column('name');
+    }
+    return \Civi::$statics[__CLASS__]['actions'][$entityName][$uid];
+  }
+
+  public function fields() {
+    return [
+      [
+        'name' => 'ui_action',
+        'description' => 'Action corresponding to CRM_Core_Action',
+      ],
+      [
+        'name' => 'api_action',
+        'description' => 'Action corresponding to API.getActions',
+      ],
+      [
+        'name' => 'api_values',
+        'data_type' => 'Array',
+        'description' => 'API values associated with this action (e.g. for a sub_type)',
+      ],
+      [
+        'name' => 'entity',
+        'description' => 'API entity name',
+      ],
+      [
+        'name' => 'path',
+        'description' => 'Link path',
+      ],
+      [
+        'name' => 'text',
+        'description' => 'Link text',
+      ],
+      [
+        'name' => 'icon',
+        'description' => 'Link icon css class',
+      ],
+      [
+        'name' => 'weight',
+        'data_type' => 'Integer',
+        'description' => 'Sort order',
+      ],
+      [
+        'name' => 'target',
+        'description' => 'HTML target attribute',
+      ],
+    ];
+  }
+
+}

--- a/Civi/Api4/CustomValue.php
+++ b/Civi/Api4/CustomValue.php
@@ -62,6 +62,16 @@ class CustomValue {
   /**
    * @param string $customGroup
    * @param bool $checkPermissions
+   * @return \Civi\Api4\Action\GetLinks
+   */
+  public static function getLinks($customGroup = NULL, $checkPermissions = TRUE) {
+    return (new \Civi\Api4\Action\GetLinks("Custom_$customGroup", __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param string $customGroup
+   * @param bool $checkPermissions
    * @return Action\CustomValue\Save
    * @throws \CRM_Core_Exception
    */

--- a/Civi/Api4/Event/Subscriber/PermissionCheckSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/PermissionCheckSubscriber.php
@@ -42,7 +42,12 @@ class PermissionCheckSubscriber extends \Civi\Core\Service\AutoService implement
     /** @var \Civi\Api4\Generic\AbstractAction $apiRequest */
     $apiRequest = $event->getApiRequest();
     if ($apiRequest['version'] == 4) {
-      if (!$apiRequest->getCheckPermissions() || $apiRequest->isAuthorized(\CRM_Core_Session::singleton()->getLoggedInContactID())) {
+      if (
+        !$apiRequest->getCheckPermissions() ||
+        // This action checks permissions internally
+        $apiRequest->getActionName() === 'getLinks' ||
+        $apiRequest->isAuthorized(\CRM_Core_Session::singleton()->getLoggedInContactID())
+      ) {
         $event->authorize();
         $event->stopPropagation();
       }

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -57,6 +57,15 @@ abstract class AbstractEntity {
   }
 
   /**
+   * @param bool $checkPermissions
+   * @return \Civi\Api4\Action\GetLinks
+   */
+  public static function getLinks($checkPermissions = TRUE) {
+    return (new \Civi\Api4\Action\GetLinks(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
    * Returns a list of permissions needed to access the various actions in this api.
    *
    * @return array

--- a/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
+++ b/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
@@ -361,12 +361,7 @@ trait SavedSearchInspectorTrait {
    * @return array
    */
   protected function getTokens(string $str): array {
-    if (strpos($str, '[') === FALSE) {
-      return [];
-    }
-    $tokens = [];
-    preg_match_all('/\\[([^]]+)\\]/', $str, $tokens);
-    return array_unique($tokens[1]);
+    return array_keys(\CRM_Utils_String::getSquareTokens($str));
   }
 
   /**

--- a/Civi/Api4/Service/Links/ActivityLinksProvider.php
+++ b/Civi/Api4/Service/Links/ActivityLinksProvider.php
@@ -1,0 +1,148 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Links;
+
+use Civi\API\Event\RespondEvent;
+use Civi\Api4\OptionValue;
+
+/**
+ * @service
+ * @internal
+ */
+class ActivityLinksProvider extends \Civi\Core\Service\AutoSubscriber {
+  use LinksProviderTrait;
+
+  public static function getSubscribedEvents(): array {
+    return [
+      'civi.api.respond' => 'alterActivityLinksResult',
+    ];
+  }
+
+  public static function alterActivityLinksResult(RespondEvent $e): void {
+    $request = $e->getApiRequest();
+    if ($request['version'] == 4 && $request->getEntityName() === 'Activity' && is_a($request, '\Civi\Api4\Action\GetLinks')) {
+      $links = (array) $e->getResponse();
+      $addLinkIndex = self::getActionIndex($links, 'add');
+      $editLinkIndex = self::getActionIndex($links, 'update');
+      $deleteLinkIndex = self::getActionIndex($links, 'delete');
+      // Expand the "add" link to multiple activity types if it exists (otherwise the WHERE clause excluded it and we should too)
+      if ($request->getExpandMultiple() && isset($addLinkIndex)) {
+        // Expanding the "add" link requires a value for target_contact.
+        // This might come back from SearchKit in a couple different ways,
+        // either an implicit join on 'target_contact_id' or as an explicit join.
+        $targetContactId = $request->getValue('target_contact_id');
+        foreach ($request->getValues() as $valueKey => $value) {
+          if (!$targetContactId && is_numeric($value) && preg_match('/^Activity_ActivityContact_Contact_\d\d\.id$/', $valueKey)) {
+            $targetContactId = $value;
+          }
+        }
+        if ($targetContactId) {
+          // Ensure links contain exactly the return values requested in the SELECT clause
+          $addLinks = self::getActivityTypeAddLinks($targetContactId, $request->getCheckPermissions());
+          foreach ($addLinks as &$addLink) {
+            $addLink += $links[$addLinkIndex];
+            $addLink = array_intersect_key($addLink, $links[$addLinkIndex]);
+          }
+          // Replace the one generic "add" link with multiple per-activity-type links
+          array_splice($links, $addLinkIndex, 1, $addLinks);
+        }
+      }
+      // With an activity type provided, alter path of edit links appropriately
+      $activityType = $request->getValue('activity_type_id:name');
+      $activityId = $request->getValue('id');
+      // Lookup activity type from id
+      if (!$activityType && $activityId) {
+        $activityTypeId = \CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity', $activityId, 'activity_type_id');
+        $activityType = \CRM_Core_PseudoConstant::getName('CRM_Activity_DAO_Activity', 'activity_type_id', $activityTypeId);
+      }
+      if ($activityType) {
+        $viewOnlyTypes = \CRM_Activity_BAO_Activity::getViewOnlyActivityTypeIDs($request->getCheckPermissions());
+        // Remove edit & delete links for "view only" types
+        if (isset($viewOnlyTypes[$activityType])) {
+          unset($links[$editLinkIndex], $links[$deleteLinkIndex]);
+        }
+      }
+      $e->getResponse()->exchangeArray(array_values($links));
+    }
+  }
+
+  private static function getActivityTypeAddLinks($contactId, $checkPermissions): array {
+    $addLinks = [];
+    $activityTypeQuery = OptionValue::get(FALSE)
+      ->addSelect('name', 'label', 'icon', 'value')
+      ->addWhere('option_group_id:name', '=', 'activity_type')
+      ->addWhere('is_active', '=', TRUE)
+      ->addWhere('filter', 'IS EMPTY')
+      ->addWhere('component_id', 'IS NULL')
+      ->addOrderBy('weight');
+
+    // TODO: Code block was moved from CRM_Activity_Form_ActivityLinks and could use further cleanup
+    $urlParams = "action=add&reset=1&cid={$contactId}&selectedChild=activity&atype=";
+    foreach ($activityTypeQuery->execute() as $act) {
+      $url = 'civicrm/activity/add';
+      if ($act['name'] === 'Email') {
+        if (!\CRM_Utils_Mail::validOutBoundMail()) {
+          continue;
+        }
+        [, $email, $doNotEmail, , $isDeceased] = \CRM_Contact_BAO_Contact::getContactDetails($contactId);
+        if (!$doNotEmail && $email && !$isDeceased) {
+          $url = 'civicrm/activity/email/add';
+          $act['label'] = ts('Send an Email');
+        }
+        else {
+          continue;
+        }
+      }
+      elseif ($act['name'] === 'SMS') {
+        if (!\CRM_SMS_BAO_Provider::activeProviderCount() ||
+          ($checkPermissions && !\CRM_Core_Permission::check('send SMS'))
+        ) {
+          continue;
+        }
+        // Check for existence of a mobile phone and ! do not SMS privacy setting
+        try {
+          $phone = civicrm_api3('Phone', 'getsingle', [
+            'contact_id' => $contactId,
+            'phone_type_id' => \CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Phone', 'phone_type_id', 'Mobile'),
+            'return' => ['phone', 'contact_id'],
+            'options' => ['limit' => 1, 'sort' => "is_primary DESC"],
+            'api.Contact.getsingle' => [
+              'id' => '$value.contact_id',
+              'return' => 'do_not_sms',
+            ],
+          ]);
+        }
+        catch (\CRM_Core_Exception $e) {
+          continue;
+        }
+        if (!$phone['api.Contact.getsingle']['do_not_sms'] && $phone['phone']) {
+          $url = 'civicrm/activity/sms/add';
+        }
+        else {
+          continue;
+        }
+      }
+      elseif ($act['name'] == 'Print PDF Letter') {
+        $url = 'civicrm/activity/pdf/add';
+      }
+
+      $act['icon'] = $act['icon'] ?? 'fa-plus-square-o';
+      $act['path'] = "$url?$urlParams{$act['value']}";
+      $act['text'] = $act['label'];
+      $addLinks[] = $act;
+    }
+
+    return $addLinks;
+  }
+
+}

--- a/Civi/Api4/Service/Links/ContactLinksProvider.php
+++ b/Civi/Api4/Service/Links/ContactLinksProvider.php
@@ -12,6 +12,7 @@
 
 namespace Civi\Api4\Service\Links;
 
+use Civi\API\Event\RespondEvent;
 use Civi\Api4\Utils\CoreUtil;
 use Civi\Core\Event\GenericHookEvent;
 
@@ -25,6 +26,7 @@ class ContactLinksProvider extends \Civi\Core\Service\AutoSubscriber {
   public static function getSubscribedEvents(): array {
     return [
       'civi.api4.getLinks' => 'alterContactLinks',
+      'civi.api.respond' => 'alterContactLinksResult',
     ];
   }
 
@@ -32,49 +34,74 @@ class ContactLinksProvider extends \Civi\Core\Service\AutoSubscriber {
     if (CoreUtil::isContact($e->entity)) {
       foreach ($e->links as $index => $link) {
         // Contacts are too cumbersome to view in a popup
-        if (in_array($link['ui_action'], ['view', 'update'], TRUE)) {
+        if (in_array($link['ui_action'], ['add', 'view', 'update'], TRUE)) {
           $e->links[$index]['target'] = '';
-        }
-      }
-      // Unset the generic "add" link and replace it with links per contact-type and sub-type
-      $addLinkIndex = self::getActionIndex($e->links, 'add');
-      if ($addLinkIndex !== NULL) {
-        $addTemplate = $e->links[$addLinkIndex];
-        unset($e->links[$addLinkIndex]);
-        // For contact entity, add links for every contact type
-        if ($e->entity === 'Contact') {
-          foreach (\CRM_Contact_BAO_ContactType::basicTypes() as $contactType) {
-            self::addLinks($contactType, $addTemplate, $e);
-          }
-        }
-        // For Individual, Organization, Household entity
-        else {
-          self::addLinks($e->entity, $addTemplate, $e);
         }
       }
     }
   }
 
-  private static function addLinks(string $contactType, array $addTemplate, GenericHookEvent $e) {
-    $addTemplate['path'] = str_replace('[contact_type]', $contactType, $addTemplate['path']);
+  public static function alterContactLinksResult(RespondEvent $e): void {
+    $request = $e->getApiRequest();
+    if ($request['version'] == 4 && is_a($request, '\Civi\Api4\Action\GetLinks') && CoreUtil::isContact($request->getEntityName())) {
+      $links = (array) $e->getResponse();
+      $addLinkIndex = self::getActionIndex($links, 'add');
+      // Unset the generic "add" link and replace it with links per contact-type and sub-type
+      if (isset($addLinkIndex) && $request->getExpandMultiple()) {
+        // Use the single add link from the schema as a template
+        $addTemplate = $links[$addLinkIndex];
+        $newLinks = [];
+        $contactType = $request->getValue('contact_type') ?: $request->getEntityName();
+        // For contact entity, add links for every contact type
+        if ($contactType === 'Contact') {
+          foreach (\CRM_Contact_BAO_ContactType::basicTypes() as $type) {
+            self::addLinks($newLinks, $type, $addTemplate, $request->getEntityName());
+          }
+        }
+        // For Individual, Organization, Household entity
+        else {
+          self::addLinks($newLinks, $contactType, $addTemplate, $request->getEntityName());
+        }
+        array_splice($links, $addLinkIndex, 1, $newLinks);
+      }
+      $e->getResponse()->exchangeArray(array_values($links));
+    }
+  }
+
+  private static function addLinks(array &$newLinks, string $contactType, array $addTemplate, string $apiEntity) {
+    // Since this runs after api processing, not all fields may be returned,
+    // depending on the SELECT clause, so avoid undefined indexes.
+    if (!empty($addTemplate['path'])) {
+      $addTemplate['path'] = str_replace('[contact_type]', $contactType, $addTemplate['path']);
+    }
+    // Link to contact type
+    if ($apiEntity === 'Contact') {
+      $addTemplate['api_values'] = ['contact_type' => $contactType];
+    }
     $link = $addTemplate;
-    if ($e->entity === 'Contact') {
-      $link['text'] = str_replace('%1', CoreUtil::getInfoItem($contactType, 'title'), $link['text']);
-      $link['api_values'] = ['contact_type' => $contactType];
+    $link['text'] = ts('Add %1', [1 => \CRM_Contact_BAO_ContactType::getLabel($contactType)]);
+    if (array_key_exists('icon', $addTemplate)) {
       $link['icon'] = CoreUtil::getInfoItem($contactType, 'icon');
     }
-    $e->links[] = $link;
+    $newLinks[] = $link;
+    // Links to contact sub-types
     $subTypes = \CRM_Contact_BAO_ContactType::subTypeInfo($contactType);
     $labels = array_column($subTypes, 'label');
     array_multisort($labels, SORT_NATURAL, $subTypes);
     foreach ($subTypes as $subType) {
-      $addTemplate['weight']++;
+      if (isset($addTemplate['weight'])) {
+        $addTemplate['weight']++;
+      }
       $link = $addTemplate;
-      $link['path'] .= '&cst=' . $subType['name'];
-      $link['icon'] = $subType['icon'] ?? $link['icon'];
-      $link['text'] = str_replace('%1', $subType['label'], $link['text']);
-      $link['api_values'] = ['contact_sub_type' => $subType['name']];
-      $e->links[] = $link;
+      if (!empty($link['path'])) {
+        $link['path'] .= '&cst=' . $subType['name'];
+      }
+      if (array_key_exists('icon', $addTemplate)) {
+        $link['icon'] = $subType['icon'] ?? $link['icon'];
+      }
+      $link['text'] = ts('Add %1', [1 => $subType['label']]);
+      $link['api_values']['contact_sub_type'] = $subType['name'];
+      $newLinks[] = $link;
     }
   }
 

--- a/Civi/Api4/Service/Links/ContactLinksProvider.php
+++ b/Civi/Api4/Service/Links/ContactLinksProvider.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Links;
+
+use Civi\Api4\Utils\CoreUtil;
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * @service
+ * @internal
+ */
+class ContactLinksProvider extends \Civi\Core\Service\AutoSubscriber {
+
+  public static function getSubscribedEvents(): array {
+    return [
+      'civi.api4.getLinks' => 'alterContactLinks',
+    ];
+  }
+
+  public static function alterContactLinks(GenericHookEvent $e): void {
+    if (CoreUtil::isContact($e->entity)) {
+      foreach ($e->links as $index => $link) {
+        // Contacts are too cumbersome to view in a popup
+        if (in_array($link['ui_action'], ['view', 'update'], TRUE)) {
+          $e->links[$index]['target'] = '';
+        }
+        // Unset the generic "add" link and replace it with links per contact-type and sub-type
+        if ($link['ui_action'] === 'add') {
+          $addTemplate = $link;
+          unset($e->links[$index]);
+        }
+      }
+      if ($e->entity === 'Contact') {
+        foreach (\CRM_Contact_BAO_ContactType::basicTypes() as $contactType) {
+          self::addLinks($contactType, $addTemplate, $e);
+        }
+      }
+      else {
+        self::addLinks($e->entity, $addTemplate, $e);
+      }
+    }
+  }
+
+  private static function addLinks(string $contactType, array $addTemplate, GenericHookEvent $e) {
+    $addTemplate['path'] = str_replace('[contact_type]', $contactType, $addTemplate['path']);
+    $link = $addTemplate;
+    if ($e->entity === 'Contact') {
+      $link['text'] = str_replace('%1', CoreUtil::getInfoItem($contactType, 'title'), $link['text']);
+      $link['api_values'] = ['contact_type' => $contactType];
+      $link['icon'] = CoreUtil::getInfoItem($contactType, 'icon');
+    }
+    $e->links[] = $link;
+    $subTypes = \CRM_Contact_BAO_ContactType::subTypeInfo($contactType);
+    $labels = array_column($subTypes, 'label');
+    array_multisort($labels, SORT_NATURAL, $subTypes);
+    foreach ($subTypes as $subType) {
+      $addTemplate['weight']++;
+      $link = $addTemplate;
+      $link['path'] .= '&cst=' . $subType['name'];
+      $link['icon'] = $subType['icon'] ?? $link['icon'];
+      $link['text'] = str_replace('%1', $subType['label'], $link['text']);
+      $link['api_values'] = ['contact_sub_type' => $subType['name']];
+      $e->links[] = $link;
+    }
+  }
+
+}

--- a/Civi/Api4/Service/Links/LinksProviderTrait.php
+++ b/Civi/Api4/Service/Links/LinksProviderTrait.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Links;
+
+trait LinksProviderTrait {
+
+  /**
+   * Given a set of links, find the one with the specified ui_action
+   *
+   * @param $links
+   * @param $uiAction
+   * @return int|null
+   */
+  protected static function getActionIndex($links, $uiAction): ?int {
+    foreach ($links as $index => $link) {
+      if (($link['ui_action'] ?? NULL) === $uiAction || str_contains($link['path'] ?? '', "action=$uiAction")) {
+        return $index;
+      }
+    }
+    return NULL;
+  }
+
+}

--- a/Civi/Api4/Service/Links/RelationshipCacheLinksProvider.php
+++ b/Civi/Api4/Service/Links/RelationshipCacheLinksProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Links;
+
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * @service
+ * @internal
+ */
+class RelationshipCacheLinksProvider extends \Civi\Core\Service\AutoSubscriber {
+
+  public static function getSubscribedEvents(): array {
+    return [
+      'civi.api4.getLinks' => 'alterRelationshipCacheLinks',
+    ];
+  }
+
+  public static function alterRelationshipCacheLinks(GenericHookEvent $e): void {
+    if ($e->entity === 'RelationshipCache') {
+      foreach ($e->links as &$link) {
+        $link['entity'] = 'Relationship';
+      }
+    }
+  }
+
+}

--- a/ext/civi_case/Civi/Api4/Service/Links/CaseLinksProvider.php
+++ b/ext/civi_case/Civi/Api4/Service/Links/CaseLinksProvider.php
@@ -1,0 +1,97 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Links;
+
+use Civi\API\Event\RespondEvent;
+use Civi\Api4\Utils\CoreUtil;
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * @service
+ * @internal
+ */
+class CaseLinksProvider extends \Civi\Core\Service\AutoSubscriber {
+  use LinksProviderTrait;
+
+  public static function getSubscribedEvents(): array {
+    return [
+      'civi.api4.getLinks' => 'alterCaseLinks',
+      'civi.api.respond' => ['alterActivityLinksResult', -50],
+    ];
+  }
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @return void
+   */
+  public static function alterCaseLinks(GenericHookEvent $e): void {
+    // Tweak case view/edit links
+    if ($e->entity === 'Case') {
+      foreach ($e->links as $index => $link) {
+        // Cases are too cumbersome to view in a popup
+        if (in_array($link['ui_action'], ['view', 'update'], TRUE)) {
+          $e->links[$index]['target'] = '';
+        }
+      }
+    }
+  }
+
+  /**
+   * Customize case activity links
+   *
+   * @param \Civi\API\Event\RespondEvent $e
+   * @return void
+   * @throws \CRM_Core_Exception
+   */
+  public static function alterActivityLinksResult(RespondEvent $e): void {
+    $request = $e->getApiRequest();
+    if ($request['version'] == 4 && $request->getEntityName() === 'Activity' && is_a($request, '\Civi\Api4\Action\GetLinks')) {
+      $activityId = $request->getValue('id');
+      $caseId = $request->getValue('case_id');
+      if (!$caseId && $activityId) {
+        $caseId = \CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseActivity', 'case_id', $activityId, 'activity_id');
+      }
+      if (!$caseId) {
+        return;
+      }
+      $links = (array) $e->getResponse();
+      $viewLinkIndex = self::getActionIndex($links, 'view');
+      $editLinkIndex = self::getActionIndex($links, 'update');
+      $deleteLinkIndex = self::getActionIndex($links, 'delete');
+      // Add link to manage case
+      $links[] = [
+        'ui_action' => 'advanced',
+        'api_action' => 'update',
+        'api_values' => NULL,
+        'entity' => 'Case',
+        'path' => "civicrm/contact/view/case?reset=1&id=$caseId&action=view",
+        'text' => ts('Manage Case'),
+        'icon' => CoreUtil::getInfoItem('Case', 'icon'),
+        'weight' => 80,
+        'target' => NULL,
+      ];
+      $idToken = $activityId ?: '[id]';
+      // Change view/edit/delete links to the CiviCase version
+      if (isset($links[$viewLinkIndex]['path'])) {
+        $links[$viewLinkIndex]['path'] = "civicrm/case/activity/view?reset=1&caseid=$caseId&aid=$idToken";
+      }
+      if (isset($links[$editLinkIndex]['path'])) {
+        $links[$editLinkIndex]['path'] = "civicrm/case/activity?reset=1&caseid=$caseId&id=$idToken&action=update";
+      }
+      if (isset($links[$deleteLinkIndex]['path'])) {
+        $links[$deleteLinkIndex]['path'] = "civicrm/case/activity?reset=1&caseid=$caseId&id=$idToken&action=delete";
+      }
+      $e->getResponse()->exchangeArray(array_values($links));
+    }
+  }
+
+}

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -162,7 +162,7 @@ class Run extends AbstractRunAction {
       if (!$this->checkLinkCondition($button, $data)) {
         continue;
       }
-      $button = $this->formatLink($button, $data);
+      $button = $this->formatLink($button, $data, TRUE);
       if ($button) {
         $toolbar[] = $button;
       }

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -44,6 +44,7 @@ class Run extends AbstractRunAction {
     // Pager can operate in "page" mode for traditional pager, or "scroll" mode for infinite scrolling
     $pagerMode = NULL;
 
+    $this->preprocessLinks();
     $this->augmentSelectClause($apiParams);
     $this->applyFilters();
 

--- a/ext/search_kit/Civi/Search/Display.php
+++ b/ext/search_kit/Civi/Search/Display.php
@@ -12,7 +12,6 @@
 namespace Civi\Search;
 
 use CRM_Search_ExtensionUtil as E;
-use Civi\Api4\Utils\CoreUtil;
 
 /**
  * Class Display
@@ -58,42 +57,19 @@ class Display {
    * @return array[]
    */
   public static function getEntityLinks(string $entity, $addLabel = FALSE): array {
-    $paths = CoreUtil::getInfoItem($entity, 'paths') ?? [];
-    $links = [];
-    // Hack to support links to relationships
-    if ($entity === 'RelationshipCache') {
-      $entity = 'Relationship';
-    }
-    if ($addLabel === TRUE) {
-      $addLabel = CoreUtil::getInfoItem($entity, 'title');
-    }
-    // If addLabel is false the placeholder needs to be passed through to javascript
-    $label = $addLabel ?: '%1';
+    $links = (array) civicrm_api4($entity, 'getLinks', [
+      'checkPermissions' => FALSE,
+      'entityTitle' => $addLabel,
+      'select' => ['ui_action', 'entity', 'text', 'icon', 'target'],
+    ]);
     $styles = [
       'delete' => 'danger',
       'add' => 'primary',
     ];
-    foreach (array_keys($paths) as $actionName) {
-      $actionKey = \CRM_Core_Action::mapItem($actionName);
-      $link = [
-        'action' => $actionName,
-        'entity' => $entity,
-        'text' => \CRM_Core_Action::getTitle($actionKey, $label),
-        'icon' => \CRM_Core_Action::getIcon($actionKey),
-        'weight' => \CRM_Core_Action::getWeight($actionKey),
-        'style' => $styles[$actionName] ?? 'default',
-        'target' => 'crm-popup',
-      ];
-      // Contacts and cases are too cumbersome to view in a popup
-      if (in_array($entity, ['Contact', 'Case']) && in_array($actionName, ['view', 'update'])) {
-        $link['target'] = '_blank';
-      }
-      $links[$actionName] = $link;
-    }
-    // Sort by weight, then discard it
-    uasort($links, ['CRM_Utils_Sort', 'cmpFunc']);
-    foreach ($links as $index => $link) {
-      unset($links[$index]['weight']);
+    foreach ($links as &$link) {
+      $link['action'] = $link['ui_action'];
+      $link['style'] = $styles[$link['ui_action']] ?? 'default';
+      unset($link['ui_action']);
     }
     return $links;
   }

--- a/ext/search_kit/ang/crmSearchDisplay/toolbar.html
+++ b/ext/search_kit/ang/crmSearchDisplay/toolbar.html
@@ -1,4 +1,19 @@
-<a ng-repeat="link in $ctrl.toolbar" ng-href="{{:: link.url }}" class="btn btn-{{:: link.style }}" target="{{:: link.target }}">
-  <i ng-if="link.icon" class="crm-i {{:: link.icon }}"></i>
-  {{:: link.text }}
-</a>
+<div class="btn-group" ng-repeat="link in $ctrl.toolbar">
+  <a ng-if="link.url" ng-href="{{:: link.url }}" class="btn btn-{{:: link.style }}" target="{{:: link.target }}">
+    <i ng-if="link.icon" class="crm-i {{:: link.icon }}"></i>
+    {{:: link.text }}
+  </a>
+  <button ng-if="link.children" type="button" class="btn btn-{{:: link.style }} dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <i ng-if="link.icon" class="crm-i {{:: link.icon }}"></i>
+    {{:: link.text  }}
+    <span class="caret"></span>
+  </button>
+  <ul ng-if="link.children" class="dropdown-menu dropdown-menu-right">
+    <li ng-repeat="child in link.children">
+      <a ng-href="{{:: child.url }}" target="{{:: child.target }}">
+        <i ng-if="child.icon" class="crm-i {{:: child.icon }}"></i>
+        {{:: child.text }}
+      </a>
+    </li>
+  </ul>
+</div>

--- a/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.html
+++ b/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.html
@@ -3,7 +3,7 @@
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>
     <span ng-if="$ctrl.settings.headerCount" ng-include="'~/crmSearchDisplay/ResultCount.html'"></span>
-    <div class="btn-group pull-right" ng-include="'~/crmSearchDisplay/toolbar.html'" ng-if="$ctrl.toolbar"></div>
+    <div class="form-group pull-right" ng-include="'~/crmSearchDisplay/toolbar.html'" ng-if="$ctrl.toolbar"></div>
   </div>
   <div
     class="crm-search-display-grid-container crm-search-display-grid-layout-{{$ctrl.settings.colno}}"

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.html
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.html
@@ -3,7 +3,7 @@
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>
     <span ng-if="$ctrl.settings.headerCount" ng-include="'~/crmSearchDisplay/ResultCount.html'"></span>
-    <div class="btn-group pull-right" ng-include="'~/crmSearchDisplay/toolbar.html'" ng-if="$ctrl.toolbar"></div>
+    <div class="form-group pull-right" ng-include="'~/crmSearchDisplay/toolbar.html'" ng-if="$ctrl.toolbar"></div>
   </div>
   <ol ng-if=":: $ctrl.settings.style === 'ol'" ng-include="'~/crmSearchDisplayList/crmSearchDisplayList' + ($ctrl.loading ? 'Loading' : 'Items') + '.html'" ng-style="{'list-style': $ctrl.settings.symbol}"></ol>
   <ul ng-if=":: $ctrl.settings.style !== 'ol'" ng-include="'~/crmSearchDisplayList/crmSearchDisplayList' + ($ctrl.loading ? 'Loading' : 'Items') + '.html'" ng-style="{'list-style': $ctrl.settings.symbol}"></ul>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -4,7 +4,7 @@
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>
     <crm-search-tasks-menu ng-if="$ctrl.settings.actions && $ctrl.taskManager" ids="$ctrl.selectedRows" task-manager="$ctrl.taskManager"></crm-search-tasks-menu>
     <span ng-if="$ctrl.settings.headerCount" ng-include="'~/crmSearchDisplay/ResultCount.html'"></span>
-    <div class="btn-group pull-right" ng-include="'~/crmSearchDisplay/toolbar.html'" ng-if="$ctrl.toolbar"></div>
+    <div class="form-group pull-right" ng-include="'~/crmSearchDisplay/toolbar.html'" ng-if="$ctrl.toolbar"></div>
   </div>
   <table class="{{:: $ctrl.settings.classes.join(' ') }}">
     <thead>

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -2055,11 +2055,12 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
 
     $result = civicrm_api4('SearchDisplay', 'run', $params);
     $this->assertCount(1, $result->toolbar);
-    $button = $result->toolbar[0];
-    $this->assertEquals('crm-popup', $button['target']);
-    $this->assertEquals('fa-plus', $button['icon']);
-    $this->assertEquals('primary', $button['style']);
-    $this->assertEquals('Add Contact', $button['text']);
+    $menu = $result->toolbar[0];
+    $this->assertEquals('Add Contact', $menu['text']);
+    $this->assertEquals('fa-plus', $menu['icon']);
+    $button = $menu['children'][0];
+    $this->assertEquals('fa-user', $button['icon']);
+    $this->assertEquals('Add Individual', $button['text']);
     $this->assertStringContainsString('=Individual', $button['url']);
 
     // Try with pseudoconstant (for proper test the label needs to be different from the name)
@@ -2068,9 +2069,14 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
       ->addWhere('name', '=', 'Organization')
       ->execute();
     $params['filters'] = ['contact_type:label' => 'Disorganization'];
+    // Use default label this time
+    unset($params['display']['settings']['toolbar'][0]['text']);
     $result = civicrm_api4('SearchDisplay', 'run', $params);
-    $button = $result->toolbar[0];
+    $menu = $result->toolbar[0];
+    $this->assertEquals('Add Disorganization', $menu['text']);
+    $button = $menu['children'][0];
     $this->assertStringContainsString('=Organization', $button['url']);
+    $this->assertEquals('Add Disorganization', $button['text']);
 
     // Test legacy 'addButton' setting
     $params['display']['settings']['toolbar'] = NULL;

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -428,7 +428,7 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertStringContainsString('Enable', $result[3]['columns'][1]['links'][2]['title']);
     // 4th link is to the case, and only for the relevant entity
     $this->assertEquals('Manage Case', $result[2]['columns'][1]['links'][3]['text']);
-    $this->assertStringContainsString('civicrm', $result[3]['columns'][1]['links'][3]['url']);
+    $this->assertStringContainsString("id={$case['id']}", $result[3]['columns'][1]['links'][3]['url']);
   }
 
   /**

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../../../../../../../tests/phpunit/api/v4/Api4TestBase.
 
 use api\v4\Api4TestBase;
 use Civi\API\Exception\UnauthorizedException;
+use Civi\Api4\Action\GetLinks;
 use Civi\Api4\Activity;
 use Civi\Api4\Address;
 use Civi\Api4\Contact;
@@ -2049,6 +2050,9 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertCount(0, $result->toolbar);
     // With 'add contacts' permission the button will be shown
     \CRM_Core_Config::singleton()->userPermissionClass->permissions[] = 'add contacts';
+    // Clear getLinks cache after changing permissions
+    \Civi::$statics[GetLinks::class] = [];
+
     $result = civicrm_api4('SearchDisplay', 'run', $params);
     $this->assertCount(1, $result->toolbar);
     $button = $result->toolbar[0];

--- a/tests/phpunit/api/v4/Action/GetLinksTest.php
+++ b/tests/phpunit/api/v4/Action/GetLinksTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Action;
+
+use api\v4\Api4TestBase;
+use Civi\Api4\Contact;
+use Civi\Api4\ContactType;
+use Civi\Api4\Individual;
+use Civi\Api4\RelationshipCache;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class GetLinksTest extends Api4TestBase implements TransactionalInterface {
+
+  public function testContactLinks(): void {
+    $links = Contact::getLinks(FALSE)
+      ->addWhere('api_action', '=', 'create')
+      ->execute()->indexBy('path');
+    $this->assertEquals('Add Individual', $links['civicrm/contact/add?reset=1&ct=Individual']['text']);
+    $this->assertEquals('fa-user', $links['civicrm/contact/add?reset=1&ct=Individual']['icon']);
+    $this->assertEquals('Add Organization', $links['civicrm/contact/add?reset=1&ct=Organization']['text']);
+    $this->assertEquals('Add Household', $links['civicrm/contact/add?reset=1&ct=Household']['text']);
+    $this->assertEquals(['contact_type' => 'Household'], $links['civicrm/contact/add?reset=1&ct=Household']['api_values']);
+
+    $links = Contact::getLinks(FALSE)
+      ->addWhere('ui_action', 'IN', ['view', 'update', 'delete'])
+      ->execute()->indexBy('ui_action');
+    $this->assertEquals('', $links['view']['target']);
+    $this->assertEquals('', $links['update']['target']);
+    $this->assertEquals('crm-popup', $links['delete']['target']);
+  }
+
+  public function testIndividualLinks(): void {
+    // Add some individual contact types
+    foreach (['Squirrel', 'Chipmunk', 'Rabbit'] as $type) {
+      ContactType::create(FALSE)
+        ->addValue('label', $type)
+        ->addValue('name', substr($type, 0, 3))
+        ->addValue('icon', strtolower("fa-$type"))
+        ->addValue('parent_id:name', 'Individual')
+        ->execute();
+    }
+    // Red herring belongs to Organization not Individual
+    ContactType::create(FALSE)
+      ->addValue('label', 'Herring')
+      ->addValue('name', 'Her')
+      ->addValue('icon', "fa-herring")
+      ->addValue('parent_id:name', 'Organization')
+      ->execute();
+    $links = Individual::getLinks(FALSE)
+      ->addWhere('api_action', '=', 'create')
+      ->execute();
+    $this->assertStringContainsString('ct=Individual', $links[0]['path']);
+    $this->assertEquals('Add Individual', $links[0]['text']);
+    $this->assertEquals(0, $links[0]['weight']);
+    $this->assertNull($links[0]['api_values']);
+    $links = $links->indexBy('text');
+    $this->assertEquals('fa-squirrel', $links['Add Squirrel']['icon']);
+    $this->assertGreaterThan($links['Add Rabbit']['weight'], $links['Add Squirrel']['weight']);
+    $this->assertGreaterThan($links['Add Chipmunk']['weight'], $links['Add Rabbit']['weight']);
+    $this->assertStringContainsString('ct=Individual', $links['Add Squirrel']['path']);
+    $this->assertStringContainsString('cst=Squ', $links['Add Squirrel']['path']);
+    $this->assertArrayNotHasKey('Add Organization', (array) $links);
+    $this->assertArrayNotHasKey('Add Household', (array) $links);
+    $this->assertArrayNotHasKey('Add Herring', (array) $links);
+  }
+
+  public function testRelationshipCacheLinks(): void {
+    $links = RelationshipCache::getLinks(FALSE)
+      ->addValue('relationship_id', 1)
+      ->addValue('near_contact_id', 2)
+      ->addValue('orientation:name', 'a_b')
+      ->execute()->indexBy('ui_action');
+    $this->assertGreaterThan(1, $links->count());
+    foreach ($links as $link) {
+      $this->assertEquals('Relationship', $link['entity']);
+    }
+    $this->assertStringContainsString('id=1', $links['view']['path']);
+    $this->assertStringContainsString('id=1', $links['update']['path']);
+    $this->assertStringContainsString('id=1', $links['delete']['path']);
+    $this->assertStringContainsString('cid=2', $links['add']['path']);
+    $this->assertStringContainsString('cid=2', $links['view']['path']);
+    $this->assertStringContainsString('cid=2', $links['update']['path']);
+    $this->assertStringContainsString('rtype=a_b', $links['update']['path']);
+    $this->assertStringContainsString('cid=2', $links['delete']['path']);
+  }
+
+}

--- a/tests/phpunit/api/v4/Action/GetLinksTest.php
+++ b/tests/phpunit/api/v4/Action/GetLinksTest.php
@@ -34,6 +34,7 @@ class GetLinksTest extends Api4TestBase implements TransactionalInterface {
   public function testContactLinks(): void {
     $links = Contact::getLinks(FALSE)
       ->addWhere('api_action', '=', 'create')
+      ->setExpandMultiple(TRUE)
       ->execute()->indexBy('path');
     $this->assertEquals('Add Individual', $links['civicrm/contact/add?reset=1&ct=Individual']['text']);
     $this->assertEquals('fa-user', $links['civicrm/contact/add?reset=1&ct=Individual']['icon']);
@@ -68,6 +69,7 @@ class GetLinksTest extends Api4TestBase implements TransactionalInterface {
       ->execute();
     $links = Individual::getLinks(FALSE)
       ->addWhere('api_action', '=', 'create')
+      ->setExpandMultiple(TRUE)
       ->execute();
     $this->assertStringContainsString('ct=Individual', $links[0]['path']);
     $this->assertEquals('Add Individual', $links[0]['text']);

--- a/tests/phpunit/api/v4/Custom/CustomValueTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomValueTest.php
@@ -289,11 +289,11 @@ class CustomValueTest extends CustomTestBase {
 
     $this->assertNotContains("Custom_$groupName", Entity::get()->execute()->column('name'));
 
-    CustomGroup::create(FALSE)
+    $customGroup = CustomGroup::create(FALSE)
       ->addValue('title', $groupName)
       ->addValue('extends', 'Contact')
       ->addValue('is_multiple', FALSE)
-      ->execute();
+      ->execute()->single();
 
     $this->assertNotContains("Custom_$groupName", Entity::get()->execute()->column('name'));
 
@@ -302,6 +302,12 @@ class CustomValueTest extends CustomTestBase {
       ->addValue('is_multiple', TRUE)
       ->execute();
     $this->assertContains("Custom_$groupName", Entity::get()->execute()->column('name'));
+
+    $links = CustomValue::getLinks($groupName, FALSE)
+      ->addValue('id', 3)
+      ->execute()->indexBy('ui_action');
+    $this->assertStringContainsString('gid=' . $customGroup['id'], $links['view']['path']);
+    $this->assertStringContainsString('recId=3', $links['view']['path']);
 
     CustomGroup::update(FALSE)
       ->addWhere('name', '=', $groupName)


### PR DESCRIPTION
Overview
----------------------------------------
This adds a new generic APIv4 action: 'getLinks', and uses it in SearchKit to improve link handling.

- Unblocks #27717 
- Fixes [dev/core#4804 SearchKit: New toolbar in SearchKit doesn't show for contacts entity](https://lab.civicrm.org/dev/core/-/issues/4804)
- Unblocks [dev/core#4674 civicrm_admin_ui blocks links from oauth-client](https://lab.civicrm.org/dev/core/-/issues/4674)
- Unblocks https://github.com/civicrm/civicrm-core/pull/28810

Before
----------------------------------------
SearchKit can display simple links, but some entities require more complex logic.
In the metadata, links for each entity are in a flat static array in the DAO, with some logic sprinkled around `SearchKit` and `CRM_Core_Action` to transform that into something useful.

After
----------------------------------------
The new API action can check permissions, replace tokens, and output translated labels and icons. The hookability of the API give additional flexibility for entities that need extra logic.

This enables SearchKit to work with the complex logic in e.g. Activity or Contact links.

![image](https://github.com/civicrm/civicrm-core/assets/2874912/bf68a717-ac34-4855-8ae6-63da388b0b2d)


Technical Details
----------------------------------------
This centralizes the link rendering done by SearchKit, and will allow SearchKit to handle more dynamic stuff like multiple "Add" links in the toolbar.