### PR TITLE
Update log files to use new setLocale function

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -598,6 +598,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     $config = CRM_Core_Config::singleton();
 
     $file_log = self::createDebugLogger($prefix);
+    $file_log->setLocale(CRM_Core_I18n::getLocale());
     $file_log->log("$message\n", $priority);
 
     $str = '<p/><code>' . htmlspecialchars($message) . '</code>';

--- a/CRM/Queue/Runner.php
+++ b/CRM/Queue/Runner.php
@@ -404,6 +404,7 @@ class CRM_Queue_Runner {
       $this->taskCtx->queue = $this->queue;
       // $this->taskCtx->log = CRM_Core_Config::getLog();
       $this->taskCtx->log = CRM_Core_Error::createDebugLogger();
+      $this->taskCtx->log->setLocale(CRM_Core_I18n::getLocale());
     }
     return $this->taskCtx;
   }

--- a/CRM/Queue/TaskRunner.php
+++ b/CRM/Queue/TaskRunner.php
@@ -111,6 +111,7 @@ class CRM_Queue_TaskRunner {
     $taskCtx = new \CRM_Queue_TaskContext();
     $taskCtx->queue = $queue;
     $taskCtx->log = \CRM_Core_Error::createDebugLogger();
+    $taskCtx->log->setLocale(CRM_Core_I18n::getLocale());
     return $taskCtx;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This takes into account of updates to the PR / patch to pear_log to handle for strftime being deprecated

Before
----------------------------------------
Log file locale is en_US

After
----------------------------------------
Log file locale is what is set in CiviCRM

ping @mlutfy @kcristiano @colemanw @demeritcowboy 