### PR TITLE
Use the correct "to account" when recording a payment

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -920,7 +920,12 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
     if (!empty($params['payment_processor_id'])) {
       return CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($params['payment_processor_id'], NULL, 'civicrm_payment_processor');
     }
+
     if (!empty($params['payment_instrument_id'])) {
+      return CRM_Financial_BAO_EntityFinancialAccount::getInstrumentFinancialAccount($params['payment_instrument_id']);
+    }
+
+    if (!empty($contribution['payment_instrument_id'])) {
       return CRM_Financial_BAO_EntityFinancialAccount::getInstrumentFinancialAccount($contribution['payment_instrument_id']);
     }
     else {


### PR DESCRIPTION
Before
----------------------------------------
1- Create a pending contribution and use “Cash” as payment method. On a standard CiviCRM installation, the default financial account for Cash payment method is "Deposit Bank Account" , but pending contributions gets submitted to the Account receivable and that will be the value for the `to_financial_account_id"   on the created financial transaction, thus the payment method for pending contributions has no impact on the created financial transaction (which is all correct for now).

2- Now record a payment against this pending contribution, but use different payment method such as Credit Card, by default the financial account for Credit Card payment method is "Payment Processor Account", but if you look at the newly created financial transaction, the `from_financial_account_id` will be "Account receivable" which is correct, where the `to_financial_account_id`  will point to the account of the initially selected payment method when the contribution was created, which is "Deposit Bank Account" (Given the original payment method when the pending contribution was created was Cash).

Here is an example where I created a pending contribution with amount = 100 and used "Cash" as payment method, then recorded a payment against the contribution using "Credit Card" payment method, the first transaction (with id = 1381) goes into the "Accounting Receivable" financial account which is correct, but the 2nd transaction should move from the "Accounting Receivable" to the "Payment Processor Account" not to the "Deposit Bank Account":

![2023-10-31 17_32_25-CiviCRM APIv4 (FinancialTrxn__get) _ compuclient22sspv3](https://github.com/civicrm/civicrm-core/assets/6275540/d4e2768d-0749-4dcb-b3ad-ed86c72c42bd)

This only occurs when using "Record Payment" action and not when using "Submit Credit Card Payment" action, since when using "Submit Credit Card Payment" action the  financial account of the payment processor will be used as "to financial account" which is correct .

After
----------------------------------------
The financial account of the payment method  used when recording the payment (using "Record Payment" action) is used for the `to_financial_account_id`  instead of using the one for the payment method that was selected when the contribution was initially created:

![2023-10-31 17_40_10-CiviCRM APIv4 (FinancialTrxn__get) _ compuclient22sspv3](https://github.com/civicrm/civicrm-core/assets/6275540/2d766c2d-33e6-4ee5-b448-acb98abe848d)

Technical Details
----------------------------------------
The code that does this was  originally added here: 

https://github.com/civicrm/civicrm-core/pull/7473

But there is no good reason there why it checks if `payment_instrument_id` in the parameters exists but end up using the one on the contribution, so my guess it was done by mistake and no one noticed.

