### PR TITLE
Improve Geocoding for addresses

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1297,6 +1297,8 @@ SELECT is_primary,
         // ensure that if the geocoding provider (Google, OSM etc) has returned the string 'null' because they can't geocode, ensure that contacts are not placed on null island 0,0
         if ($params[$geocode] !== 'null') {
           $params[$geocode] = (float) substr($params[$geocode], 0, 14);
+          //set manual_geo_code to 0
+          $params['manual_geo_code'] = FALSE;
         }
       }
     }

--- a/CRM/Utils/Address/BatchUpdate.php
+++ b/CRM/Utils/Address/BatchUpdate.php
@@ -131,6 +131,8 @@ class CRM_Utils_Address_BatchUpdate {
     if ($processGeocode) {
       $clause[] = '( a.geo_code_1 is null OR a.geo_code_1 = 0 )';
       $clause[] = '( a.geo_code_2 is null OR a.geo_code_2 = 0 )';
+      // the scheduled job is ignoring trying to geocode addresses where manual_geocode is 1
+      $clause[] = '( a.manual_geo_code = 0 )';
       $clause[] = '( a.country_id is not null )';
     }
 
@@ -210,6 +212,11 @@ class CRM_Utils_Address_BatchUpdate {
         if (isset($params['geo_code_1']) && $params['geo_code_1'] != 'null') {
           $totalGeocoded++;
           $addressParams = $params;
+        }
+        else {
+          // If an address has failed in the geocoding scheduled job i.e. no lat/long is fetched, we will update the manual_geocode field to 1.
+          $addressParams['manual_geo_code'] = TRUE;
+          $addressParams['geo_code_1'] = $addressParams['geo_code_2'] = 0;
         }
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Right now, the current scenario is that the geocode scheduled job [here](https://github.com/civicrm/civicrm-core/blob/master/api/v3/Job.php#L141) tries to update the lat/long for addresses in batches. This however does not store the fact that an address has failed geocoding. 

Before
----------------------------------------
No handling in case failed geocoding

After
----------------------------------------
Improve code to do the following:
1. If an address has failed in the geocoding scheduled job i.e. no lat/long is fetched, we will update the manual_geocode field to 1. 
2. Make sure that the scheduled job is ignoring trying to geocode addresses where manual_geocode is 1. 
3. When an address is updated, if manual_geocode is already set to 1, we get rid of that flag so that it can be geocoded again.
Before


