### PR TITLE
CRM_Campaign_BAO_Petition::confirmSignature: call pre/post hooks

### DIFF
--- a/CRM/Campaign/BAO/Petition.php
+++ b/CRM/Campaign/BAO/Petition.php
@@ -38,12 +38,12 @@ class CRM_Campaign_BAO_Petition extends CRM_Campaign_BAO_Survey {
    * Takes an associative array and creates a petition signature activity.
    *
    * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
+   *   an assoc array of name/value pairs.
    *
    * @return mixed
    *   CRM_Campaign_BAO_Petition or NULl or void
    */
-  public function createSignature(&$params) {
+  public function createSignature($params) {
     if (empty($params)) {
       return NULL;
     }

--- a/CRM/Campaign/BAO/Petition.php
+++ b/CRM/Campaign/BAO/Petition.php
@@ -102,33 +102,24 @@ class CRM_Campaign_BAO_Petition extends CRM_Campaign_BAO_Survey {
    * @return bool
    */
   public function confirmSignature($activity_id, $contact_id, $petition_id) {
-    // change activity status to completed (status_id = 2)
-    // I wonder why do we need contact_id when we have activity_id anyway? [chastell]
-    $sql = 'UPDATE civicrm_activity SET status_id = 2 WHERE id = %1';
-    $activityContacts = CRM_Activity_BAO_ActivityContact::buildOptions('record_type_id', 'validate');
-    $sourceID = CRM_Utils_Array::key('Activity Source', $activityContacts);
-    $params = [
-      1 => [$activity_id, 'Integer'],
-      2 => [$contact_id, 'Integer'],
-      3 => [$sourceID, 'Integer'],
-    ];
-    CRM_Core_DAO::executeQuery($sql, $params);
+    // change activity status to completed
+    \Civi\Api4\Activity::update(FALSE)
+      ->addValue('status_id:name', 'Completed')
+      ->addWhere('id', '=', $activity_id)
+      ->execute();
+    \Civi\Api4\ActivityContact::update(FALSE)
+      ->addValue('contact_id', $contact_id)
+      ->addWhere('activity_id', '=', $activity_id)
+      ->addWhere('record_type_id:name', '=', 'Activity Source')
+      ->execute();
 
-    $sql = 'UPDATE civicrm_activity_contact SET contact_id = %2 WHERE activity_id = %1 AND record_type_id = %3';
-    CRM_Core_DAO::executeQuery($sql, $params);
     // remove 'Unconfirmed' tag for this contact
-    $tag_name = Civi::settings()->get('tag_unconfirmed');
+    \Civi\Api4\EntityTag::delete(FALSE)
+      ->addWhere('tag_id:name', '=', Civi::settings()->get('tag_unconfirmed'))
+      ->addWhere('entity_table', '=', 'civicrm_contact')
+      ->addWhere('entity_id', '=', $contact_id)
+      ->execute();
 
-    $sql = "
-DELETE FROM civicrm_entity_tag
-WHERE       entity_table = 'civicrm_contact'
-AND         entity_id = %1
-AND         tag_id = ( SELECT id FROM civicrm_tag WHERE name = %2 )";
-    $params = [
-      1 => [$contact_id, 'Integer'],
-      2 => [$tag_name, 'String'],
-    ];
-    CRM_Core_DAO::executeQuery($sql, $params);
     // validate arguments to setcookie are numeric to prevent header manipulation
     if (isset($petition_id) && is_numeric($petition_id)
       && isset($activity_id) && is_numeric($activity_id)) {

--- a/tests/phpunit/CRM/Campaign/BAO/PetitionTest.php
+++ b/tests/phpunit/CRM/Campaign/BAO/PetitionTest.php
@@ -75,4 +75,58 @@ Thank you for signing Test Petition.
     $mut->stop();
   }
 
+  public function testCreateAndConfirmSignatures(): void {
+    // Prepare
+    $params_campaign = [
+      'title' => 'Test Petition Campaign',
+    ];
+    $params_survey = [
+      'title' => 'Test Create And Confirm Signatures Petition',
+      'activity_type_id' => 'Petition',
+    ];
+    $params_tag = [
+      'name' => Civi::settings()->get('tag_unconfirmed'),
+      'used_for' => 'civicrm_contact',
+    ];
+    $campaign = $this->callAPISuccess('Campaign', 'create', $params_campaign);
+    $survey = $this->callAPISuccess('Survey', 'create', $params_survey);
+    $tag = $this->callAPISuccess('Tag', 'create', $params_tag);
+    $contactID = $this->individualCreate();
+    // Add Unconfirmed tag
+    $this->callAPISuccess('EntityTag', 'create', [
+      'tag_id' => $tag['id'],
+      'entity_table' => 'civicrm_contact',
+      'entity_id' => $contactID,
+    ]);
+
+    $bao = new CRM_Campaign_BAO_Petition();
+
+    // Test create signature
+    $params = [
+      'sid' => $survey['id'],
+      'contactId' => $contactID,
+      'statusId' => '1',
+      'activity_campaign_id' => $campaign['id'],
+    ];
+    $activity = $bao->createSignature($params);
+    $this->callAPISuccessGetCount('Activity', [
+      'source_contact_id' => $contactID,
+      'target_contact_id' => $contactID,
+      'source_record_id' => $survey['id'],
+      'subject' => $params_survey['title'],
+      'status_id' => $params['statusId'],
+      'activity_campaign_id' => $campaign['id'],
+    ], 1);
+
+    // Test confirm signature
+    $this->assertTrue($bao->confirmSignature($activity->id, $contactID, $survey['id']), 'Signature not confirmed');
+    $this->assertEquals(2, $this->callAPISuccessGetValue('Activity', ['id' => $activity->id, 'return' => 'status_id']), 'Activity status not changed');
+    // Check Unconfirmed tag removed
+    $this->callAPISuccessGetCount('EntityTag', [
+      'tag_id' => $tag['id'],
+      'entity_table' => 'civicrm_contact',
+      'entity_id' => $contactID,
+    ], 0);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
`CRM_Campaign_BAO_Petition::confirmSignature()` use direct SQL to confirm signatures. This prevents pre & post hooks to fire, so not possible to hook into this process in an extension and won't trigger any CiviRules.

Before
----------------------------------------
Hooks not fired.

After
----------------------------------------
Hooks are fired.

Technical Details
----------------------------------------
Direct SQL queries are changed to APIv4.
