### PR TITLE
Logging - If valid, then set a locale

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -655,9 +655,13 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    */
   public static function createDebugLogger($prefix = '') {
     self::generateLogFileName($prefix);
-    return Log::singleton('file', \Civi::$statics[__CLASS__]['logger_file' . $prefix], '', [
+    $log = Log::singleton('file', \Civi::$statics[__CLASS__]['logger_file' . $prefix], '', [
       'timeFormat' => '%Y-%m-%d %H:%M:%S%z',
     ]);
+    if (is_callable([$log, 'setLocale'])) {
+      $log->setLocale(CRM_Core_I18n::getLocale());
+    }
+    return $log;
   }
 
   /**

--- a/composer.json
+++ b/composer.json
@@ -284,7 +284,7 @@
         "Apply CiviCRM Customisations for the pear:db package": "https://raw.githubusercontent.com/civicrm/civicrm-core/2ad420c394/tools/scripts/composer/pear_db_civicrm_changes.patch"
       },
       "pear/log": {
-        "Apply patch for php8.1": "https://patch-diff.githubusercontent.com/raw/pear/Log/pull/23.patch"
+        "Apply patch for php8.1": "https://gist.githubusercontent.com/totten/d99d47dd9d19a5cb02858954a5577609/raw/0e5e4628a475219c2aec6af76e69894cdec42a55/pear-log-locale.patch"
       },
       "pear/mail": {
         "Apply CiviCRM Customisations for CRM-1367 and CRM-5946": "https://raw.githubusercontent.com/civicrm/civicrm-core/36319938a5bf26c1e7e2110a26a65db6a5979268/tools/scripts/composer/patches/pear-mail.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "377176179275d0aa4262d031e5bc4559",
+    "content-hash": "11bd73682ccf3e9de1d825ce08bbf371",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",


### PR DESCRIPTION
Overview
----------------------------------------

This is an updated variation of @seamuslee001's #27974, with two key differences:

1. It calls `setLocale()` one time -- from within `createDebugLogger()`. (This becomes an internal detail of how `createDebugLogger()` builds the instance. You don't need to sprinkle it into the log-consuming code.)
2. It calls `setLocale()` conditionally -- if the method actually exists. It's not certain whether the method will ultimately be part of the official `pear/log` releases.  (*And once upstream changes, it may immediately affect D9/D10-style builds.*) This change means that civicrm-core should with `pear/log` in either contingency.

Before
----------------------------------------

* ~~Log file locale is en_US~~
* Log file locale is based on some system default (which may not always be reliably operational)

After
----------------------------------------

* Log file locale is what is set in CiviCRM