### PR TITLE
Fix master-only-over-aggressive escaping

### DIFF
--- a/templates/CRM/Price/Form/Field.tpl
+++ b/templates/CRM/Price/Form/Field.tpl
@@ -81,12 +81,12 @@
 <div class="crm-block crm-form-block crm-price-field-form-block">
   <table class="form-layout">
     <tr class="crm-price-field-form-block-label">
-      <td class="label">{$form.label.label|escape}</td>
+      <td class="label">{$form.label.label|smarty:nodefaults|purify}</td>
       <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_price_field' field='label' id=$fid}{/if}{$form.label.html}
       </td>
     </tr>
     <tr class="crm-price-field-form-block-html_type">
-      <td class="label">{$form.html_type.label|escape}</td>
+      <td class="label">{$form.html_type.label|smarty:nodefaults|purify}</td>
       <td>{$form.html_type.html}
       </td>
     </tr>
@@ -103,7 +103,7 @@
   <div id="price-block" {if $action eq 2 && $form.html_type.value.0 eq 'Text'} class="show-block" {else} class="hiddenElement" {/if}>
     <table class="form-layout">
       <tr class="crm-price-field-form-block-price">
-        <td class="label">{$form.price.label|escape} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></td>
+        <td class="label">{$form.price.label|smarty:nodefaults|purify} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></td>
         <td>{$form.price.html}
         {if $action neq 4}
           <br /><span class="description">{ts}Unit price.{/ts}</span> {help id="id-negative"}
@@ -111,25 +111,25 @@
         </td>
       </tr>
       <tr class="crm-price-field-form-block-non-deductible-amount">
-        <td class="label">{$form.non_deductible_amount.label|escape}</td>
+        <td class="label">{$form.non_deductible_amount.label|smarty:nodefaults|purify}</td>
         <td>{$form.non_deductible_amount.html}</td>
       </tr>
     {if $useForEvent}
       <tr class="crm-price-field-form-block-count">
-        <td class="label">{$form.count.label|escape}</td>
+        <td class="label">{$form.count.label|smarty:nodefaults|purify}</td>
         <td>{$form.count.html}<br />
           <span class="description">{ts}Enter a value here if you want to increment the number of registered participants per unit against the maximum number of participants allowed for this event.{/ts}</span>
           {help id="id-participant-count"}
         </td>
       </tr>
       <tr class="crm-price-field-form-block-max_value">
-        <td class="label">{$form.max_value.label|escape}</td>
+        <td class="label">{$form.max_value.label|smarty:nodefaults|purify}</td>
         <td>{$form.max_value.html}
         </td>
       </tr>
     {/if}
       <tr class="crm-price-field-form-block-financial_type">
-        <td class="label">{$form.financial_type_id.label|escape}<span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></td></td>
+        <td class="label">{$form.financial_type_id.label|smarty:nodefaults|purify}<span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></td></td>
         <td>
         {if !$financialType}
           {capture assign=ftUrl}{crmURL p='civicrm/admin/financial/financialType' q="reset=1"}{/capture}
@@ -169,7 +169,7 @@
     </tr>
 
     <tr class="crm-price-field-form-block-help_pre">
-      <td class="label">{$form.help_pre.label|escape}</td>
+      <td class="label">{$form.help_pre.label|smarty:nodefaults|purify}</td>
       <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_price_field' field='help_pre' id=$fid}{/if}{$form.help_pre.html|crmAddClass:huge}&nbsp;
       {if $action neq 4}
         <div class="description">{ts}Explanatory text displayed to users at the beginning of this field.{/ts}</div>
@@ -178,7 +178,7 @@
     </tr>
 
     <tr class="crm-price-field-form-block-help_post">
-      <td class="label">{$form.help_post.label|escape}</td>
+      <td class="label">{$form.help_post.label|smarty:nodefaults|purify}</td>
       <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_price_field' field='help_post' id=$fid}{/if}{$form.help_post.html|crmAddClass:huge}&nbsp;
       {if $action neq 4}
         <div class="description">{ts}Explanatory text displayed to users below this field.{/ts}</div>
@@ -243,7 +243,7 @@
 {/literal}
 
 {* Give link to view/edit choice options if in edit mode and html_type is one of the multiple choice types *}
-{if $action eq 2 AND ($form.data_type.value.1.0 eq 'CheckBox' OR $form.data_type.value.1.0 eq 'Radio' OR $form.data_type.value.1.0 eq 'Select')}
+{if $action eq 2 AND array_key_exists('data_type', $form) && ($form.data_type.value.1.0 eq 'CheckBox' OR $form.data_type.value.1.0 eq 'Radio' OR $form.data_type.value.1.0 eq 'Select')}
 <div class="action-link">
   <a href="{crmURL p="civicrm/admin/event/field/option" q="reset=1&action=browse&fid=`$fid`"}" class="button"><span>{ts}Multiple Choice Options{/ts}</span></a>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Fix master-only-over-aggressive escaping

A recent switch to assigning apiv4 values to the tpl in some instances caused me to add escaping - but a bit too much

https://lab.civicrm.org/dev/financial/-/issues/219

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/0d006dbf-c747-4edb-adc3-3a5971473b04)

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/217045a3-188c-4b62-853f-3da6727972a0)

Technical Details
----------------------------------------
The purify / smarty nodefaults is not strictly needed but at least flags the fields have been considered for escaping 

Comments
----------------------------------------
