### PR TITLE
Notice fixes on price field options

### DIFF
--- a/CRM/Price/Page/Option.php
+++ b/CRM/Price/Page/Option.php
@@ -105,6 +105,7 @@ class CRM_Price_Page_Option extends CRM_Core_Page {
    * @return void
    */
   public function browse(): void {
+    $this->assign('usedBy', NULL);
     $priceOptions = civicrm_api3('PriceFieldValue', 'get', [
       'price_field_id' => $this->_fid,
          // Explicitly do not check permissions so we are not
@@ -157,6 +158,8 @@ class CRM_Price_Page_Option extends CRM_Core_Page {
         }
       }
       $customOption[$id]['order'] = $customOption[$id]['weight'];
+      $customOption[$id]['help_pre'] = $customOption[$id]['help_pre'] ?? NULL;
+      $customOption[$id]['help_post'] = $customOption[$id]['help_post'] ?? NULL;
       $customOption[$id]['action'] = CRM_Core_Action::formLink(self::actionLinks(), $action,
         [
           'oid' => $id,
@@ -205,6 +208,7 @@ class CRM_Price_Page_Option extends CRM_Core_Page {
 
       $usedBy = CRM_Price_BAO_PriceSet::getUsedBy($sid);
     }
+    $this->assign('usedBy', $usedBy ?? NULL);
     // set the userContext stack
     $session = CRM_Core_Session::singleton();
 
@@ -224,7 +228,6 @@ class CRM_Price_Page_Option extends CRM_Core_Page {
         $url
       );
       $this->assign('usedPriceSetTitle', CRM_Price_BAO_PriceFieldValue::getOptionLabel($oid));
-      $this->assign('usedBy', $usedBy);
       $comps = [
         'Event' => 'civicrm_event',
         'Contribution' => 'civicrm_contribution_page',


### PR DESCRIPTION


Overview
----------------------------------------
Fixes smarty notices on
https://dmaster.localhost:32353/civicrm/admin/price/field/option?action=browse&reset=1&sid=3&fid=2

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/758114c7-00de-491c-8a49-4c765e6991f0)

After
----------------------------------------

Technical Details
----------------------------------------

Comments
----------------------------------------
