### PR TITLE
[REF] dev/core#4747 Fix Binary Regex by casting field to Binary

### DIFF
--- a/Civi/Api4/Query/Api4Query.php
+++ b/Civi/Api4/Query/Api4Query.php
@@ -404,7 +404,7 @@ abstract class Api4Query {
     }
 
     if ($operator == 'REGEXP' || $operator == 'NOT REGEXP' || $operator == 'REGEXP BINARY' || $operator == 'NOT REGEXP BINARY') {
-      return sprintf('%s %s "%s"', $fieldAlias, $operator, \CRM_Core_DAO::escapeString($value));
+      return sprintf('%s %s "%s"', (str_ends_with($operator, 'BINARY') ? 'CAST(' . $fieldAlias . ' AS BINARY)' : $fieldAlias), $operator, \CRM_Core_DAO::escapeString($value));
     }
 
     if (!$value && ($operator === 'IN' || $operator === 'NOT IN')) {


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix the test failure on [api\\v4\\Action\\ContactGetTest.testRegexpOperators](https://test.civicrm.org/job/CiviCRM-Core-Matrix/BKPROF=max,CIVIVER=master,SUITES=phpunit-api4,label=bknix-tmp/lastCompletedBuild/testReport/(root)/api_v4_Action_ContactGetTest/testRegexpOperators/)

Before
----------------------------------------
Test fails

After
----------------------------------------
Test passes locally for me

Technical Details
----------------------------------------
https://stackoverflow.com/questions/64668364/character-set-binary-cannot-be-used-in-conjunction-with-utf8mb4-unicode-ci-i

ping @totten @eileenmcnaughton @colemanw