### PR TITLE
APIv4 - Ensure 'search_fields' defaults to 'label_field' for Entity.get

### DIFF
--- a/Civi/Api4/Provider/ActionObjectProvider.php
+++ b/Civi/Api4/Provider/ActionObjectProvider.php
@@ -161,11 +161,20 @@ class ActionObjectProvider extends AutoService implements EventSubscriberInterfa
       // Allow extensions to modify the list of entities
       $event = GenericHookEvent::create(['entities' => &$entities]);
       \Civi::dispatcher()->dispatch('civi.api4.entityTypes', $event);
+      $this->fillEntityDefaults($entities);
       ksort($entities);
       $cache->set('api4.entities.info', $entities);
     }
 
     return $entities;
+  }
+
+  public function fillEntityDefaults(array &$entities) {
+    foreach ($entities as &$entity) {
+      if (!isset($entity['search_fields'])) {
+        $entity['search_fields'] = (array) ($entity['label_field'] ?? NULL);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a SearchKit crash with some custom entities such as ECK.

See https://chat.civicrm.org/civicrm/pl/6ge4ic81oid4dkb7a5gqz7mjqw

Technical Details
----------------------------------------
This default is set in the AbstractEntity class, but not every entity inherits from that class, e.g. ECK does not.
So it needs to be filled in by the Entity.get action