### PR TITLE
PHP 8.x: fix TypeError in config hook

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1487,7 +1487,7 @@ abstract class CRM_Utils_Hook {
       $count++;
     }
     $defaultFlags = ['civicrm' => FALSE, 'uf' => FALSE, 'instances' => $count];
-    $flags = array_merge($defaultFlags, $flags);
+    $flags = !empty($flags) ? array_merge($defaultFlags, $flags) : $defaultFlags;
     $null = NULL;
     return self::singleton()->invoke(['config', 'flags'], $config,
       $flags, $null, $null, $null, $null,


### PR DESCRIPTION
Overview
----------------------------------------

Using vanilla CiviCRM with the old ckeditor 4, attempting to upload a file results in a fatal TypeError on PHP 8.0 and later.

To reproduce:

- Login to https://dmaster.demo.civicrm.org/civicrm/
- Go to Mailing > New Mailing
- Click the image icon
- then click "browse server"

Before
----------------------------------------

>  TypeError: array_merge(): Argument #2 must be of type array, null given in array_merge() (line 1490 of /srv/buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Utils/Hook.php). 


After
----------------------------------------

no error

Technical Details
----------------------------------------

Changing the function definition to default to `$flags = []` didn't seem to help, so I opted for an ugly fix.

I opened this PR against the RC, because it's a fatal PHP 8 bug.