### PR TITLE
dev/core#1290 Don't hard-delete user record when soft-deleting contact

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -754,10 +754,6 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
     ];
     CRM_Utils_Hook::pre('edit', $contact->contact_type, $contact->id, $updateParams);
 
-    $params = [1 => [$contact->id, 'Integer']];
-    $query = 'DELETE FROM civicrm_uf_match WHERE contact_id = %1';
-    CRM_Core_DAO::executeQuery($query, $params);
-
     $contact->copyValues($updateParams);
     $contact->save();
     CRM_Core_BAO_Log::register($contact->id, 'civicrm_contact', $contact->id);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/1290

Before
----------------------------------------
Soft-deleting a contact (move to trash) will permanently delete their user info.

After
----------------------------------------
User info is deleted only when the contact is permanently deleted.

Technical Details
----------------------------------------
The foreign key in `UfMatch.contact_id` already has `ON DELETE CASCADE` so this is going to happen anyway.

Comments
----------------------------------------
My only question about this is what happens during deduping? Will the user record get migrated to the new contact or...?
