### PR TITLE
Smarty3 - fix space breaking syntax

### DIFF
--- a/templates/CRM/Contact/Form/Inline/CommunicationPreferences.tpl
+++ b/templates/CRM/Contact/Form/Inline/CommunicationPreferences.tpl
@@ -30,8 +30,7 @@
       {if $key eq 'privacy'}
       <div class="crm-summary-row">
         <div class="crm-label">&nbsp;</div>
-        <div class="crm-content">{
-          $form.is_opt_out.html} {$form.is_opt_out.label} {help id="id-optOut" file="CRM/Contact/Form/Contact.hlp"}
+        <div class="crm-content">{$form.is_opt_out.html} {$form.is_opt_out.label} {help id="id-optOut" file="CRM/Contact/Form/Contact.hlp"}
         </div>
       </div>
       {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Smarty3 - fix space breaking syntax

Before
----------------------------------------
With smartyv3 the erroneous space causes breakage

![image](https://github.com/civicrm/civicrm-core/assets/336308/65b1c1f0-94ca-480a-91e0-39d6889252fc)

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
not a regression but thematically appropriate to 5.68, esp as just cut & very safe fix

Comments
----------------------------------------
