### PR TITLE
dev/financial#206 Switch templates to use token for tax_exclusive_amount

### DIFF
--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -85,7 +85,7 @@
             {ts} Amount before Tax : {/ts}
           </td>
           <td {$valueStyle}>
-            {$amount-$totalTaxAmount|crmMoney:$currency}
+            {contribution.tax_exclusive_amount}
           </td>
         </tr>
 

--- a/xml/templates/message_templates/contribution_online_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_text.tpl
@@ -33,7 +33,7 @@
 {/foreach}
 
 {if $isShowTax && {contribution.tax_amount|boolean}}
-{ts}Amount before Tax:{/ts} {$amount-$totalTaxAmount|crmMoney:$currency}
+{ts}Amount before Tax:{/ts} {contribution.tax_exclusive_amount}
   {foreach from=$taxRateBreakdown item=taxDetail key=taxRate}
     {if $taxRate == 0}{ts}No{/ts} {$taxTerm}{else}{$taxTerm} {$taxDetail.percentage}%{/if} : {$taxDetail.amount|crmMoney:'{contribution.currency}'}
   {/foreach}

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -211,7 +211,7 @@
           {ts}Amount Before Tax:{/ts}
          </td>
          <td {$valueStyle}>
-          {$amount-$totalTaxAmount|crmMoney}
+           {contribution.tax_exclusive_amount}
          </td>
         </tr>
         {foreach from=$dataArray item=value key=priceset}

--- a/xml/templates/message_templates/membership_online_receipt_text.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_text.tpl
@@ -70,7 +70,7 @@
 {/foreach}
 
 {if !empty($dataArray)}
-{ts}Amount before Tax:{/ts} {$amount-$totalTaxAmount|crmMoney:$currency}
+{ts}Amount before Tax:{/ts} {contribution.tax_exclusive_amount}
 
 {foreach from=$dataArray item=value key=priceset}
 {if $priceset || $priceset == 0}


### PR DESCRIPTION
Overview
----------------------------------------
dev/financial#206 Switch templates to use token for tax_exclusive_amount

https://lab.civicrm.org/dev/financial/-/issues/206

Before
----------------------------------------
Regardless of whether this is working property in Smarty2 (see gitlab issue) it will not render correctly in Smarty3

After
----------------------------------------

This brings 2 online templates into sync with the use of tokens in the offline contribution template

Technical Details
----------------------------------------

Comments
----------------------------------------
