### PR TITLE
PHp8.x notice fix - remove use of legacy paymentObject

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -71,13 +71,6 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
   protected $_paymentProcessors = [];
 
   /**
-   * Instance of the payment processor object.
-   *
-   * @var CRM_Core_Payment
-   */
-  protected $_paymentObject;
-
-  /**
    * Entity that $this->_id relates to.
    *
    * If set the contact id is not required in the url.

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -19,6 +19,7 @@ use Civi\Payment\Exception\PaymentProcessorException;
 class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditPayment {
   use CRM_Contact_Form_ContactFormTrait;
   use CRM_Contribute_Form_ContributeFormTrait;
+  use CRM_Financial_Form_PaymentProcessorFormTrait;
 
   /**
    * The id of the contribution that we are processing.
@@ -1154,8 +1155,8 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $this->_lineItem = $lineItem;
     }
 
-    $this->_paymentObject = Civi\Payment\System::singleton()->getById($submittedValues['payment_processor_id']);
-    $this->_paymentProcessor = $this->_paymentObject->getPaymentProcessor();
+    $paymentObject = Civi\Payment\System::singleton()->getById($submittedValues['payment_processor_id']);
+    $this->_paymentProcessor = $paymentObject->getPaymentProcessor();
 
     // Set source if not set
     if (empty($submittedValues['source'])) {
@@ -2363,7 +2364,7 @@ WHERE  contribution_id = {$id}
 
     $form->assign('is_recur_interval', $form->_values['is_recur_interval'] ?? NULL);
     $form->assign('is_recur_installments', $form->_values['is_recur_installments'] ?? NULL);
-    $paymentObject = $form->getVar('_paymentObject');
+    $paymentObject = $this->getPaymentProcessorObject();
     if ($paymentObject) {
       $form->assign('recurringHelpText', $paymentObject->getText('contributionPageRecurringHelp', [
         'is_recur_installments' => !empty($form->_values['is_recur_installments']),

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -747,7 +747,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
     $form->assign('is_recur_interval', $this->getContributionPageValue('is_recur_interval'));
     $form->assign('is_recur_installments', $this->getContributionPageValue('is_recur_installments'));
-    $paymentObject = $form->getVar('_paymentObject');
+    $paymentObject = $this->_paymentProcessor['object'];
     if ($paymentObject) {
       $form->assign('recurringHelpText', $paymentObject->getText('contributionPageRecurringHelp', [
         'is_recur_installments' => !empty($form->_values['is_recur_installments']),

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -23,6 +23,7 @@ use Civi\Api4\PriceSet;
 class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   use CRM_Financial_Form_FrontEndPaymentFormTrait;
   use CRM_Contribute_Form_ContributeFormTrait;
+  use CRM_Financial_Form_PaymentProcessorFormTrait;
 
   /**
    * The id of the contribution page that we are processing.
@@ -59,8 +60,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    * @var array
    */
   public $_paymentProcessor;
-
-  public $_paymentObject = NULL;
 
   /**
    * Order object, used to calculate amounts, line items etc.
@@ -869,8 +868,8 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
     // The concept of contributeMode is deprecated.
     // The payment processor object can provide info about the fields it shows.
-    if ($isMonetary && $this->_paymentProcessor['object'] instanceof \CRM_Core_Payment) {
-      $paymentProcessorObject = $this->_paymentProcessor['object'];
+    if ($isMonetary) {
+      $paymentProcessorObject = $this->getPaymentProcessorObject();
       $this->assign('paymentAgreementTitle', $paymentProcessorObject->getText('agreementTitle', []));
       $this->assign('paymentAgreementText', $paymentProcessorObject->getText('agreementText', []));
       $paymentFields = $paymentProcessorObject->getPaymentFormFields();
@@ -1053,18 +1052,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       // If we don't have that and the membership type is auto recur or opt into recur set is_recur to 0.
       $this->_params['is_recur'] = $this->_values['is_recur'] = 0;
     }
-  }
-
-  /**
-   * Get the payment processor object for the submission, returning the manual one for offline payments.
-   *
-   * @return CRM_Core_Payment
-   */
-  protected function getPaymentProcessorObject() {
-    if (!empty($this->_paymentProcessor)) {
-      return $this->_paymentProcessor['object'];
-    }
-    return new CRM_Core_Payment_Manual();
   }
 
   /**

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -945,8 +945,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         ) {
           $this->_paymentProcessor = $paymentProcessorDetail;
           $this->assign('paymentProcessor', $this->_paymentProcessor);
-          // Setting this is a bit of a legacy overhang.
-          $this->_paymentObject = $paymentProcessorDetail['object'];
         }
       }
       // It's not clear why we set this on the form.

--- a/CRM/Core/Payment/ProcessorForm.php
+++ b/CRM/Core/Payment/ProcessorForm.php
@@ -42,14 +42,14 @@ class CRM_Core_Payment_ProcessorForm {
       return;
     }
     $form->set('paymentProcessor', $form->_paymentProcessor);
-    $form->_paymentObject = System::singleton()->getByProcessor($form->_paymentProcessor);
+    $paymentObject = System::singleton()->getByProcessor($form->_paymentProcessor);
     if ($form->paymentInstrumentID) {
-      $form->_paymentObject->setPaymentInstrumentID($form->paymentInstrumentID);
+      $paymentObject->setPaymentInstrumentID($form->paymentInstrumentID);
     }
-    $form->_paymentObject->setBackOffice($form->isBackOffice);
+    $paymentObject->setBackOffice($form->isBackOffice);
     $form->assign('isBackOffice', $form->isBackOffice);
 
-    $form->assign('suppressSubmitButton', $form->_paymentObject->isSuppressSubmitButtons());
+    $form->assign('suppressSubmitButton', $paymentObject->isSuppressSubmitButtons());
 
     CRM_Financial_Form_Payment::addCreditCardJs($form->getPaymentProcessorID());
     $form->assign('paymentProcessorID', $form->getPaymentProcessorID());
@@ -61,7 +61,7 @@ class CRM_Core_Payment_ProcessorForm {
 
     // also set cancel subscription url
     if (!empty($form->_paymentProcessor['is_recur']) && !empty($form->_values['is_recur'])) {
-      $form->_values['cancelSubscriptionUrl'] = $form->_paymentObject->subscriptionURL(NULL, NULL, 'cancel');
+      $form->_values['cancelSubscriptionUrl'] = $paymentObject->subscriptionURL(NULL, NULL, 'cancel');
     }
 
     $paymentProcessorBillingFields = array_keys($form->_paymentProcessor['object']->getBillingAddressFields());
@@ -110,7 +110,7 @@ class CRM_Core_Payment_ProcessorForm {
 
     if (!empty($form->_membershipBlock) && !empty($form->_membershipBlock['is_separate_payment']) &&
       (!empty($form->_paymentProcessor['class_name']) &&
-        !$form->_paymentObject->supports('MultipleConcurrentPayments')
+        !$paymentObject->supports('MultipleConcurrentPayments')
       )
     ) {
 

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -18,6 +18,7 @@
  * This class generates form components for processing Event.
  */
 class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
+  use CRM_Financial_Form_PaymentProcessorFormTrait;
 
   /**
    * The fields involved in this page.

--- a/CRM/Financial/Form/PaymentProcessorFormTrait.php
+++ b/CRM/Financial/Form/PaymentProcessorFormTrait.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Trait implements functions to retrieve payment processor related values.
+ *
+ * Note that any functions on this class that are supported to be used from
+ * outside of core are specifically tagged.
+ */
+trait CRM_Financial_Form_PaymentProcessorFormTrait {
+
+  /**
+   * Get the payment processors that are available on the form.
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  protected function getAvailablePaymentProcessors(): array {
+    return CRM_Financial_BAO_PaymentProcessor::getPaymentProcessors([ucfirst($this->getPaymentProcessorMode()) . 'Mode'], $this->getAvailablePaymentProcessorIDS());
+  }
+
+  /**
+   * Get the payment processor IDs available on the form.
+   *
+   * @return false|array
+   */
+  protected function getAvailablePaymentProcessorIDS() {
+    return FALSE;
+  }
+
+  /**
+   * Get the mode (test or live) of the payment processor.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @return string|null
+   *   test or live
+   * @throws \CRM_Core_Exception
+   */
+  public function getPaymentProcessorMode(): ?string {
+    return CRM_Utils_Request::retrieve('mode', 'Alphanumeric', $this);
+  }
+
+  /**
+   * Get the payment processor object for the submission, returning the manual one for offline payments.
+   *
+   * @return CRM_Core_Payment
+   */
+  protected function getPaymentProcessorObject() {
+    if (!empty($this->_paymentProcessor)) {
+      return $this->_paymentProcessor['object'];
+    }
+    return new CRM_Core_Payment_Manual();
+  }
+
+}

--- a/ext/eventcart/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/ext/eventcart/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -162,8 +162,6 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
           ) {
             $this->_paymentProcessor = $paymentProcessorDetail;
             $this->assign('paymentProcessor', $this->_paymentProcessor);
-            // Setting this is a bit of a legacy overhang.
-            $this->_paymentObject = $paymentProcessorDetail['object'];
           }
         }
         // It's not clear why we set this on the form.


### PR DESCRIPTION
Overview
----------------------------------------
PHp8.x notice fix - remove use of legacy paymentObject

CRM_Event_Form_Registration_ConfirmTest::testPaidSubmit with data set #0 ('.')
Creation of dynamic property CRM_Event_Form_Registration_Register::$_paymentObject is deprecated

/home/homer/buildkit/build/build-0/web/sites/all/modules/civicrm/CRM/Core/Form.php:949
/home/homer/buildkit/build/build-0/web/sites/all/modules/civicrm/CRM/Event/Form/Registration.php:312
/home/homer/buildkit/build/build-0/web/sites/all/modules/civicrm/CRM/Event/Form/Registration/Register.php:158
/home/homer/buildkit/build/build-0/web/sites/all/modules/civicrm/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php:545
/home/homer/buildkit/build/build-0/web/sites/all/modules/civicrm/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php:63
/home/homer/buildkit/build/build-0/web/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:242
/home/homer/buildkit/extern/phpunit9/phpunit9.phar:2307

Before
----------------------------------------
As we can see this property is set a lot but not used a lot - 
![image](https://github.com/civicrm/civicrm-core/assets/336308/ce78d696-49a7-4f53-a66f-24f681198153)

In almost all cases it is used in the same function where it is declared. The 2 exceptions are the `buildRecurBlock()` functions which are in previously shared code - however these are able to load the payment processor in other ways

![image](https://github.com/civicrm/civicrm-core/assets/336308/be587bf3-8d6c-46bc-ad62-e8cf311bdc78)




After
----------------------------------------
Code includes the start of a trait to consolidate this code

Technical Details
----------------------------------------

Comments
----------------------------------------
