### PR TITLE
SearchKit - Fix field transformation UI to handle number 0

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -161,7 +161,7 @@
       this.changeArg = function(index) {
         var val = ctrl.args[index].value;
         // Delete empty value
-        if (index && !val && ctrl.args.length > ctrl.fn.params[0].min_expr) {
+        if (index && !val && val !== 0 && ctrl.args.length > ctrl.fn.params[0].min_expr) {
           ctrl.args.splice(index, 1);
         }
         ctrl.writeExpr();
@@ -176,7 +176,7 @@
       this.writeExpr = function() {
         if (ctrl.fnName) {
           var args = _.transform(ctrl.args, function(args, arg, index) {
-            if (arg.value || arg.flag_before) {
+            if (arg.value || arg.value === 0 || arg.flag_before) {
               var prefix = arg.flag_before || arg.name ? (index ? ' ' : '') + (arg.flag_before || arg.name) + (arg.value ? ' ' : '') : (index ? ', ' : '');
               args.push(prefix + (arg.type === 'string' ? JSON.stringify(arg.value) : arg.value));
             }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug in the SearchKit "Field Transformation" UI where the number zero would not be accepted.

Technical Details
----------------------------------------
This is the old number 0 is falsey bug.
To reproduce, add a field transformation such as if/else, clear the field values and select numbers.
The number zero will be treated as empty and not work.