### PR TITLE
[php8]] Replace undeclared class var with local var

### DIFF
--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -438,9 +438,9 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
       return;
     }
 
-    $this->_group = CRM_Core_PseudoConstant::nestedGroup();
-    if ($this->_group) {
-      $this->add('select', 'group', $this->getGroupLabel(), $this->_group, FALSE,
+    $nestedGroup = CRM_Core_PseudoConstant::nestedGroup();
+    if ($nestedGroup) {
+      $this->add('select', 'group', $this->getGroupLabel(), $nestedGroup, FALSE,
         [
           'id' => 'group',
           'multiple' => 'multiple',


### PR DESCRIPTION
Overview
----------------------------------------
undeclared class variable

Before
----------------------------------------
1. Do e.g. Find Contributions.
2. `Creation of dynamic property CRM_Contribute_Form_Search::$_group is deprecated in CRM_Core_Form_Search->addContactSearchFields() (line 441`

After
----------------------------------------


Technical Details
----------------------------------------
Pretty sure `$this->_group` is just a local var and different from any other instances of `_group`. Searching and limiting to a group still works.

Comments
----------------------------------------

