### PR TITLE
Afform - improve display of error messages

### DIFF
--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -140,7 +140,7 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
       if (CRM_Core_Permission::check('view debug output') || ($e->getErrorData()['show_detailed_error'] ?? FALSE)) {
         $response['error_code'] = $e->getCode();
         $response['error_message'] = $e->getMessage();
-        if (!empty($params['debug'])) {
+        if (!empty($params['debug']) && CRM_Core_Permission::check('view debug output')) {
           if (method_exists($e, 'getUserInfo')) {
             $response['debug']['info'] = $e->getUserInfo();
           }

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -68,6 +68,11 @@
         if (toLoad) {
           crmApi4('Afform', 'prefill', params)
             .then((result) => {
+              // In some cases (noticed on Wordpress) the response header incorrectly outputs success when there's an error.
+              if (result.error_message) {
+                disableForm(result.error_message);
+                return;
+              }
               result.forEach((item) => {
                 // Use _.each() because item.values could be cast as an object if array keys are not sequential
                 _.each(item.values, (values, index) => {

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -77,12 +77,7 @@
                 });
               });
             }, (error) => {
-              if (error.status === 403) {
-                // Permission denied
-                disableForm();
-              } else {
-                // Unknown server error. What to do?
-              }
+              disableForm(error.error_message);
             });
         }
         // Clear existing contact selection
@@ -162,11 +157,11 @@
         return valid;
       }
 
-      function disableForm() {
-        CRM.alert(ts('This form is not currently open for submissions.'), ts('Sorry'), 'error');
+      function disableForm(errorMsg) {
         $('af-form[ng-form="' + ctrl.getFormMeta().name + '"]')
           .addClass('disabled')
           .find('button[ng-click="afform.submit()"]').prop('disabled', true);
+        CRM.alert(errorMsg, ts('Sorry'), 'error');
       }
 
       this.submit = function() {


### PR DESCRIPTION
Overview
----------------------------------------
Thanks to ddc3de8 from @MegaphoneJon we can now pass error messages directly to the client. This takes advantage of that new feature and switches from guessing what the message should be, to directly using the message that comes back from the server.

Before
----------------------------------------
1. Access denied error message was hard-coded client-side.
2. In some cases (noticed on WP site) the form was not being blocked even when the submission limit was reached.

After
----------------------------------------
1. Client shows whatever message is passed back from the server.
This allows 2 different error messages when the form is blocked so the user knows the difference between a form they have no access to vs a form that has reached its submission limit.
2. Bug fixed

To reproduce
---------
1. Create a submission form.
2. Give it a url and a submission limit of 1.
3. Visit the form and submit it.
4. Visit the form again.

At step 4, the form should become disabled and an error message should display alerting the user that the form is not open for submissions. On some WP sites this was broken entirely, and this PR fixes it. On other sites the behavior should be the same before & after.