### PR TITLE
[REF][PHP8.2] Remove unused dynamic props

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -85,11 +85,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       $this->_contributionId = $this->_id;
     }
 
-    $paymentDetails = CRM_Contribute_BAO_Contribution::getPaymentInfo($this->_id, $this->_component, FALSE, TRUE);
     $paymentAmt = $this->getAmountDue();
-
-    $this->_amtPaid = $paymentDetails['paid'];
-    $this->_amtTotal = $paymentDetails['total'];
 
     if ($paymentAmt >= 0) {
       $this->_owed = $paymentAmt;
@@ -468,11 +464,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     if (!empty($params['contribution_id'])) {
       $this->_contributionId = $params['contribution_id'];
 
-      $paymentDetails = CRM_Contribute_BAO_Contribution::getPaymentInfo($this->_contributionId, $entityType, FALSE, TRUE);
-
       $paymentAmount = $this->getAmountDue();
-      $this->_amtPaid = $paymentDetails['paid'];
-      $this->_amtTotal = $paymentDetails['total'];
 
       if ($paymentAmount > 0) {
         $this->_owed = $paymentAmount;


### PR DESCRIPTION
Overview
----------------------------------------
Removed the dynamic properties `_amtPaid` and `_amtTotal`. The `$paymentDetails` variable was only used to set these properties, so is also removed.

Before
----------------------------------------
`_amtPaid` and `_amtTotal` were dynamic properties (deperectaed in PHP 8.2) which were set, but never read.

The code which read these properties was removed a couple of years back: https://github.com/civicrm/civicrm-core/pull/13649

After
----------------------------------------
A step closer to PHP 8.2 compatiability.

Comments
----------------------------------------
I consider it unlikely that `_amtPaid` and `_amtTotal` are being used by third-party extensions, but I must admit I didn't check universe.
