### PR TITLE
[REF][PHP8.2] Update CRM_SMS_Page_Provider

### DIFF
--- a/CRM/SMS/Page/Provider.php
+++ b/CRM/SMS/Page/Provider.php
@@ -52,13 +52,6 @@ class CRM_SMS_Page_Provider extends CRM_Core_Page_Basic {
     ];
     CRM_Utils_System::appendBreadCrumb($breadCrumb);
 
-    $this->_id = CRM_Utils_Request::retrieve('id', 'String',
-      $this, FALSE, 0
-    );
-    $this->_action = CRM_Utils_Request::retrieve('action', 'String',
-      $this, FALSE, 0
-    );
-
     return parent::run();
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Update `CRM_SMS_Page_Provider` to work better on PHP 8.2.

Before
----------------------------------------
`_id` was not defined, and so a dynamic property deprecation notice was thrown on PHP 8.2.

After
----------------------------------------
`_id` is no longer set.

I also removed `_action`, as it's set as part of `parent::run()`.

Technical Details
----------------------------------------
This screen isn't covered by tests. I feel like maybe it should be, but can't figure out quite what the tests would look like.

However, I have done some manual testing and this change doesn't seem to introduce regressions.