### PR TITLE
Add Afform field for input type `Url`

### DIFF
--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -333,6 +333,7 @@ class BasicGetFieldsAction extends BasicGetAction {
           'Select' => ts('Select'),
           'Text' => ts('Single-Line Text'),
           'TextArea' => ts('Multi-Line Text'),
+          'Url' => ts('URL'),
         ],
       ],
       [

--- a/ext/afform/core/ang/af/fields/Url.html
+++ b/ext/afform/core/ang/af/fields/Url.html
@@ -1,0 +1,6 @@
+<input ng-if=":: !$ctrl.defn.search_range" class="form-control" type="url" ng-required="$ctrl.defn.required" id="{{:: fieldId }}" ng-model="getSetValue" ng-model-options="{getterSetter: true}" placeholder="{{:: $ctrl.defn.input_attrs.placeholder }}" >
+<div ng-if=":: $ctrl.defn.search_range" class="form-inline">
+  <input class="form-control" type="url" id="{{:: fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]['>=']" placeholder="{{:: $ctrl.defn.input_attrs.placeholder }}" >
+  <span class="af-field-range-sep">-</span>
+  <input class="form-control" type="url" id="{{:: fieldId }}2" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]['<=']" placeholder="{{:: $ctrl.defn.input_attrs.placeholder2 }}" >
+</div>


### PR DESCRIPTION
Overview
----------------------------------------
This adds an Afform field template for fields with input type `Url`.

Before
----------------------------------------
Fields with input type `Url` couldn't be used in Afform. Only the label was shown and the browser console displayed this error:
```
TypeError: Cannot read properties of null (reading '~/af/fields/Url.html')
```

After
----------------------------------------
Fields with input type `Url` can be used in Afform.

Comments
----------------------------------------
`Url` should be probably added here: https://github.com/civicrm/civicrm-core/blob/b3103eaf43288d8923a9dd95a8f2142500136d43/Civi/Api4/Generic/BasicGetFieldsAction.php#L335
Shall I add it to this PR?
