### PR TITLE
fix php 8 failure in CRM_Utils_Hook

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1487,7 +1487,7 @@ abstract class CRM_Utils_Hook {
       $count++;
     }
     $defaultFlags = ['civicrm' => FALSE, 'uf' => FALSE, 'instances' => $count];
-    $flags = array_merge($defaultFlags, $flags);
+    $flags = array_merge($defaultFlags, $flags ?? []);
     $null = NULL;
     return self::singleton()->invoke(['config', 'flags'], $config,
       $flags, $null, $null, $null, $null,


### PR DESCRIPTION
Overview
----------------------------------------
Just a PHP 8 fix.  The function signature says that `$flags` can be `NULL` so we just need to account for the `NULL` scenario.