### PR TITLE
[REF][PHP8.2] Update CRM_Activity_Form_ActivityView for PHP8.2 support

### DIFF
--- a/CRM/Activity/Form/ActivityView.php
+++ b/CRM/Activity/Form/ActivityView.php
@@ -26,6 +26,15 @@ class CRM_Activity_Form_ActivityView extends CRM_Core_Form {
   public $submitOnce = TRUE;
 
   /**
+   * Used by CRM_Mailing_BAO_Mailing::getMailingContent(), so cannot be removed
+   * (even though at first glance it may look safe)
+   *
+   * @var bool
+   * @internal
+   */
+  public $_mailing_id;
+
+  /**
    * Set variables up before form is built.
    */
   public function preProcess() {


### PR DESCRIPTION
Overview
----------------------------------------
Another pesky dynamic property dealt with.

Before
----------------------------------------
`_mailing_id` was a dynamic property

After
----------------------------------------
`_mailing_id` declared.

Technical Details
----------------------------------------
At first glance it seems `_mailing_id`  is only used within `preProcess` and so could be a local variable. However, in reality it needs to be accessible from within `CRM_Mailing_BAO_Mailing::getMailingContent()` (boo!)