### PR TITLE
Add check for deprecated token in event online receipt

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1798,6 +1798,9 @@ class CRM_Utils_Token {
           '$participant_status_id' => 'participant.status_id',
 
         ],
+        'event_online_receipt' => [
+          '`$participant.id`' => 'participant.id',
+        ],
         'pledge_acknowledgement' => [
           '$domain' => ts('no longer available / relevant'),
           '$contact' => ts('no longer available / relevant'),


### PR DESCRIPTION
Overview
----------------------------------------
Civi 5.67 deprecated a token in the event online template but the "Outdated Tokens" check wasn't updated to match.

Before
----------------------------------------
Cancellation links in emails have no participant, can't cancel online.

After
----------------------------------------
Pre-5.67 behavior restored.

Comments
----------------------------------------
I put backticks around the token because that's how it appears in the receipt, even though other token deprecations don't have it.  I wanted to make clear to an end user that they should also be replacing the backticks.  But if folks feel otherwise I can remove them.
