### PR TITLE
Replace use of contributeMode with alternatives

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -918,9 +918,9 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   }
 
   /**
-   * @return int
+   * @return int|null
    */
-  public function getPaymentProcessorID(): int {
+  public function getPaymentProcessorID(): ?int {
     return (int) $this->_paymentProcessorID;
   }
 

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -21,6 +21,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
   use CRM_Financial_Form_FrontEndPaymentFormTrait;
   use CRM_Event_Form_EventFormTrait;
+  use CRM_Financial_Form_PaymentProcessorFormTrait;
 
   /**
    * The id of the event we are processing.

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -124,7 +124,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
    * @throws \CRM_Core_Exception
    */
   private function preProcessExpress() {
-    if ($this->_contributeMode !== 'express') {
+    if ($this->getPaymentProcessorValue('payment_processor_type_id:name') !== 'PayPal_Express') {
       return FALSE;
     }
     $params = [];
@@ -1008,12 +1008,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
         $contribParams['revenue_recognition_date'] = date('Ymd', strtotime($eventStartDate));
       }
     }
-    //create an contribution address
-    // The concept of contributeMode is deprecated. Elsewhere we use the function processBillingAddress() - although
-    // currently that is only inherited by back-office forms.
-    if ($form->_contributeMode != 'notify' && empty($params['is_pay_later'])) {
-      $contribParams['address_id'] = CRM_Contribute_BAO_Contribution::createAddress($params);
-    }
+    $contribParams['address_id'] = CRM_Contribute_BAO_Contribution::createAddress($params);
 
     $contribParams['skipLineItem'] = 1;
     $contribParams['skipCleanMoney'] = 1;

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -18,7 +18,6 @@
  * This class generates form components for processing Event.
  */
 class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
-  use CRM_Financial_Form_PaymentProcessorFormTrait;
 
   /**
    * The fields involved in this page.

--- a/CRM/Financial/Form/PaymentProcessorFormTrait.php
+++ b/CRM/Financial/Form/PaymentProcessorFormTrait.php
@@ -54,4 +54,51 @@ trait CRM_Financial_Form_PaymentProcessorFormTrait {
     return new CRM_Core_Payment_Manual();
   }
 
+  /**
+   * Get the value for a field relating to the in-use payment processor.
+   *
+   * All values returned in apiv4 format. Escaping may be required.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @param string $fieldName
+   *
+   * @return mixed
+   * @throws \CRM_Core_Exception
+   */
+  public function getPaymentProcessorValue(string $fieldName) {
+    if ($this->isDefined('PaymentProcessor')) {
+      return $this->lookup('PaymentProcessor', $fieldName);
+    }
+    $id = $this->getPaymentProcessorID();
+    if ($id === 0) {
+      $manualProcessor = [
+        'payment_processor_type_id' => 0,
+        'payment_processor_type_id.name' => 'Manual',
+        'payment_processor_type_id.class_name' => 'Payment_Manual',
+      ];
+      return $manualProcessor[$fieldName] ?? NULL;
+    }
+    if ($id) {
+      $this->define('PaymentProcessor', 'PaymentProcessor', ['id' => $id]);
+      return $this->lookup('PaymentProcessor', $fieldName);
+    }
+    return NULL;
+  }
+
+  /**
+   * Get the ID for the in-use payment processor.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @return int|null
+   */
+  public function getPaymentProcessorID(): ?int {
+    return isset($this->_paymentProcessor['id']) ? (int) $this->_paymentProcessor['id'] : NULL;
+  }
+
 }


### PR DESCRIPTION


Overview
----------------------------------------
This addresses 2 places contributeMode is used


Before
----------------------------------------
`CRM_Contribute_BAO_Contribution::createAddress` is wrapped in an unnecessary check - the function does not require this check - it works by checking if there are appropriate params from the billing profile - which will have been displayed on the form or not as required by the processor

A piece of paypal express specific code checks contributeMode

After
----------------------------------------
check removed for the first - fo rthe latter it replaces a specific check for paypal express with a check specific to that class name. In the process functions are added for getPaymentProcessorValue() in keeping with recently added getEventValue() getParticipantValue() etc

Technical Details
----------------------------------------
Although this introduces yet another way of getting a payment processor value - in this case it in in line with the externally supported methods we have already been adding

Comments
----------------------------------------
