### PR TITLE
Simplify use of word 'Register'

### DIFF
--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -305,7 +305,6 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     //consider total amount.
     $this->assign('isAmountzero', $this->_totalAmount <= 0);
 
-    $contribButton = ts('Register');
     $this->addButtons([
       [
         'type' => 'back',
@@ -313,7 +312,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       ],
       [
         'type' => 'next',
-        'name' => $contribButton,
+        'name' => ts('Register'),
         'isDefault' => TRUE,
       ],
     ]);

--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -13,18 +13,19 @@
 
 <div class="crm-event-id-{$event.id} crm-block crm-event-confirm-form-block">
     <div class="messages status section continue_message-section"><p>
+    {capture assign=register}{ts}Register{/ts}{/capture}
     {if $isOnWaitlist}
         {ts}Please verify your information.{/ts} <strong>{ts}If space becomes available you will receive an email with a link to complete your registration.{/ts}</strong>
-        {ts 1=$form.buttons._qf_Confirm_next.html|strip_tags}Click <strong>%1</strong> to be added to the WAIT LIST for this event.{/ts}
+        {ts 1=$register}Click <strong>%1</strong> to be added to the WAIT LIST for this event.{/ts}
     {elseif $isRequireApproval}
         {ts}Please verify your information.{/ts} <strong>{ts}Once approved, you will receive an email with a link to complete the registration process.{/ts}</strong>
-        {ts 1=$form.buttons._qf_Confirm_next.html|strip_tags}Click <strong>%1</strong> to submit your registration for approval.{/ts}
+        {ts 1=$register}Click <strong>%1</strong> to submit your registration for approval.{/ts}
     {else}
         {ts}Please verify your information.{/ts}
         {if $contributeMode EQ 'notify' and !$is_pay_later and !$isAmountzero}
-            {ts 1=$form.buttons._qf_Confirm_next.html|strip_tags 2=$paymentProcessor.frontend_title}Click <strong>%1</strong> to checkout with %2.{/ts}
+            {ts 1=$register 2=$paymentProcessor.frontend_title}Click <strong>%1</strong> to checkout with %2.{/ts}
         {else}
-            {ts 1=$form.buttons._qf_Confirm_next.html|strip_tags}Click <strong>%1</strong> to complete your registration.{/ts}
+            {ts 1=$register}Click <strong>%1</strong> to complete your registration.{/ts}
         {/if}
     {/if}
     </p></div>


### PR DESCRIPTION
Overview
----------------------------------------
Simplify use of word 'Register'

Before
----------------------------------------
Thanks to the wonders of copy & paste the word 'Register' is being assigned to a variable, added to a button & then extracted from the button using Smarty strip_tags to retrieve it & insert it in a sentenct

After
----------------------------------------
Complexity reduced - still displays

![image](https://github.com/civicrm/civicrm-core/assets/336308/3f7041db-0296-4895-9752-d637ddb08348)

Technical Details
----------------------------------------
Although there is no technical need for it to be in a variable at all I left it there at the smarty layer because I worried about the effect on translations if I just wrote it into the text - @mlutfy I presume that is safer?

Comments
----------------------------------------
