### PR TITLE
dev/core#4554  Delete related Queue when user job deleted

### DIFF
--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -16,6 +16,7 @@
  */
 
 use Civi\Api4\Mapping;
+use Civi\Api4\Queue;
 use Civi\Api4\UserJob;
 use Civi\Core\ClassScanner;
 use Civi\Core\Event\PreEvent;
@@ -101,6 +102,9 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements HookInterface
     if ($event->entity === 'Mapping' && $event->action === 'delete') {
       $mappingName = Mapping::get(FALSE)->addWhere('id', '=', $event->id)->addSelect('name')->execute()->first()['name'];
       UserJob::delete(FALSE)->addWhere('name', '=', 'import_' . $mappingName)->execute();
+    }
+    if ($event->entity === 'UserJob' && $event->action === 'delete') {
+      Queue::delete(FALSE)->addWhere('name', '=', 'user_job_' . $event->id)->execute();
     }
   }
 

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -638,6 +638,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
 
   /**
    * Outputs and downloads the csv of outcomes from an import job.
+   * Function is accessed from civicrm/import/outcome path.
    *
    * This gets the rows from the temp table that match the relevant status
    * and output them as a csv.

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -26,6 +26,7 @@ use Civi\Api4\IM;
 use Civi\Api4\LocationType;
 use Civi\Api4\OpenID;
 use Civi\Api4\Phone;
+use Civi\Api4\Queue;
 use Civi\Api4\Relationship;
 use Civi\Api4\RelationshipType;
 use Civi\Api4\UserJob;
@@ -1238,6 +1239,10 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       CRM_Import_Forms::outputCSV();
     }
     catch (CRM_Core_Exception_PrematureExitException $e) {
+      UserJob::delete()->addWhere('id', '=', $dataSource->getUserJobID())->execute();
+      $this->assertCount(0, Queue::get()
+        ->addWhere('name', '=', 'user_job_' . $dataSource->getUserJobID())
+        ->execute());
       // For now just check it got this far without error.
       ob_end_clean();
       return;


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4554  Delete related Queue when user job deleted

Before
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/4554 deleting the UserJob without the corresponding Queue record can cause errors

After
----------------------------------------
Queue deleted when the job is

Technical Details
----------------------------------------
This is a regression albeit not that recent - I'm not sure why it hasn't been hit more - there must be mitigating factors

Comments
----------------------------------------
@wmortada 