### PR TITLE
Default mailing footer component incorrectly describes opt-out action as unsubscribe

### DIFF
--- a/sql/civicrm_data/civicrm_mailing_component.sqldata.php
+++ b/sql/civicrm_data/civicrm_mailing_component.sqldata.php
@@ -24,8 +24,8 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_mailing_component')
       'name' => ts("Mailing Footer"),
       "component_type" => "Footer",
       'subject' => ts("Descriptive Title for this Footer."),
-      'body_html' => ts('Sample Footer for HTML formatted content<br/><a href="{action.optOutUrl}">Unsubscribe</a>  <br/> {domain.address}'),
-      'body_text' => ts("to unsubscribe: {action.optOutUrl}\n{domain.address}"),
+      'body_html' => ts('Sample Footer for HTML formatted content<br/><a href="{action.optOutUrl}">Opt out of any future emails</a>  <br/> {domain.address}'),
+      'body_text' => ts("Opt out of any future emails: {action.optOutUrl}\n{domain.address}"),
     ],
     [
       'name' => ts('Subscribe Message'),

--- a/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
@@ -165,7 +165,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
         //  body_html, filtered
         "You can go to \\[Google\\]\\(http://example.net/first\?cs=[0-9a-f_]+\\) or \\[opt out\\]\\(http.*civicrm/mailing/optout.*\\)\\.\n" .
         // Default footer
-        "to unsubscribe: http.*civicrm/mailing/optout" .
+        "Opt out of any future emails: http.*civicrm/mailing/optout" .
         ";",
         $textPart->text
       );


### PR DESCRIPTION

Overview
----------------------------------------
CiviCRM defaults, incorrectly describes opt-out action as "unsubscribe" which confuses users and site owners alike.

Opt-out stops all emails. Unsubscribe stops just the current mailing list only. Very different actions.

Before
----------------------------------------
Opt-out link is referred to as "unsubscribe".

After
----------------------------------------
Opt-out link is referred to as "Opt out of any future emails".

Technical Details
----------------------------------------

Comments
----------------------------------------
Happy to discuss and listen to any feedback improvements.


Agileware Ref: CIVICRM-2190