### PR TITLE
Update 'Some kind of numbery-looky-printy thing.'  - ie `CRM_Utils_Number::formatUnitSize`

### DIFF
--- a/CRM/Admin/Form/Setting/Miscellaneous.php
+++ b/CRM/Admin/Form/Setting/Miscellaneous.php
@@ -48,9 +48,13 @@ class CRM_Admin_Form_Setting_Miscellaneous extends CRM_Admin_Form_Setting {
   /**
    * Basic setup.
    */
-  public function preProcess() {
-    // check for post max size
-    CRM_Utils_Number::formatUnitSize(ini_get('post_max_size'), TRUE);
+  public function preProcess(): void {
+    $maxImportFileSize = CRM_Utils_Number::formatUnitSize(ini_get('upload_max_filesize'));
+    $postMaxSize = CRM_Utils_Number::formatUnitSize(ini_get('post_max_size'));
+    if ($maxImportFileSize > $postMaxSize) {
+      CRM_Core_Session::setStatus(ts("Note: Upload max filesize ('upload_max_filesize') should not exceed Post max size ('post_max_size') as defined in PHP.ini, please check with your system administrator."), ts("Warning"), "alert");
+    }
+
     // This is a temp hack for the fact we really don't need to hard-code each setting in the tpl but
     // we haven't worked through NOT doing that. These settings have been un-hardcoded.
     $this->assign('pure_config_settings', [
@@ -100,8 +104,8 @@ class CRM_Admin_Form_Setting_Miscellaneous extends CRM_Admin_Form_Setting {
     $errors = [];
 
     // validate max file size
-    $iniBytes = CRM_Utils_Number::formatUnitSize(ini_get('upload_max_filesize'), FALSE);
-    $inputBytes = CRM_Utils_Number::formatUnitSize($fields['maxFileSize'] . 'M', FALSE);
+    $iniBytes = CRM_Utils_Number::formatUnitSize(ini_get('upload_max_filesize'));
+    $inputBytes = ((int) $fields['maxFileSize']) * 1024 * 1024;
 
     if ($inputBytes > $iniBytes) {
       $errors['maxFileSize'] = ts("Maximum file size cannot exceed limit defined in \"php.ini\" (\"upload_max_filesize=%1\").", [

--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -442,9 +442,8 @@ AND       CEF.entity_id    = %2";
     // Assign maxAttachments count to template for help message
     $form->assign('maxAttachments', $numAttachments);
 
-    $config = CRM_Core_Config::singleton();
     // set default max file size as 2MB
-    $maxFileSize = $config->maxFileSize ? $config->maxFileSize : 2;
+    $maxFileSize = \Civi::settings()->get('maxFileSize') ?: 2;
 
     $currentAttachmentInfo = self::getEntityFile($entityTable, $entityID, TRUE);
     $totalAttachments = $currentAttachmentInfo ? count($currentAttachmentInfo) : 0;

--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -48,12 +48,12 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
   public function buildQuickForm(&$form) {
     $form->add('hidden', 'hidden_dataSource', 'CRM_Import_DataSource_CSV');
 
-    $uploadFileSize = CRM_Utils_Number::formatUnitSize(Civi::settings()->get('maxFileSize') . 'm', TRUE);
+    $uploadFileSize = $uploadSize = \Civi::settings()->get('maxFileSize');
     //Fetch uploadFileSize from php_ini when $config->maxFileSize is set to "no limit".
     if (empty($uploadFileSize)) {
-      $uploadFileSize = CRM_Utils_Number::formatUnitSize(ini_get('upload_max_filesize'), TRUE);
+      $uploadFileSize = CRM_Utils_Number::formatUnitSize(ini_get('upload_max_filesize'));
+      $uploadSize = round(($uploadFileSize / (1024 * 1024)), 2);
     }
-    $uploadSize = round(($uploadFileSize / (1024 * 1024)), 2);
     $form->assign('uploadSize', $uploadSize);
     $form->add('File', 'uploadFile', ts('Import Data File'), NULL, TRUE);
     $form->add('text', 'fieldSeparator', ts('Import Field Separator'), ['size' => 2], TRUE);

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -37,8 +37,6 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
    */
   public function preProcess(): void {
     $this->pushUrlToUserContext();
-    // check for post max size
-    CRM_Utils_Number::formatUnitSize(ini_get('post_max_size'), TRUE);
     $this->assign('importEntity', $this->getTranslatedEntity());
     $this->assign('importEntities', $this->getTranslatedEntities());
   }

--- a/CRM/Utils/Number.php
+++ b/CRM/Utils/Number.php
@@ -66,14 +66,13 @@ class CRM_Utils_Number {
   }
 
   /**
-   * Some kind of numbery-looky-printy thing.
+   * Convert a file size value from the formats allowed in php_ini to the number of bytes.
    *
    * @param string $size
-   * @param bool $checkForPostMax
    *
    * @return int
    */
-  public static function formatUnitSize($size, $checkForPostMax = FALSE) {
+  public static function formatUnitSize($size): int {
     if ($size) {
       $last = strtolower($size[strlen($size) - 1]);
       $size = (int) $size;
@@ -86,19 +85,6 @@ class CRM_Utils_Number {
           $size *= 1024;
         case 'k':
           $size *= 1024;
-      }
-
-      if ($checkForPostMax) {
-        $maxImportFileSize = self::formatUnitSize(ini_get('upload_max_filesize'));
-        $postMaxSize = self::formatUnitSize(ini_get('post_max_size'));
-        if ($maxImportFileSize > $postMaxSize && $postMaxSize == $size) {
-          CRM_Core_Session::setStatus(ts("Note: Upload max filesize ('upload_max_filesize') should not exceed Post max size ('post_max_size') as defined in PHP.ini, please check with your system administrator."), ts("Warning"), "alert");
-        }
-        // respect php.ini upload_max_filesize
-        if ($size > $maxImportFileSize && $size !== $postMaxSize) {
-          $size = $maxImportFileSize;
-          CRM_Core_Session::setStatus(ts("Note: Please verify your configuration for Maximum File Size (in MB) <a href='%1'>Administrator >> System Settings >> Misc</a>. It should support 'upload_max_size' as defined in PHP.ini.Please check with your system administrator.", [1 => CRM_Utils_System::url('civicrm/admin/setting/misc', 'reset=1')]), ts("Warning"), "alert");
-        }
       }
       return $size;
     }


### PR DESCRIPTION
Overview
----------------------------------------
Update 'Some kind of numbery-looky-printy thing.'  - ie `CRM_Utils_Number::formatUnitSize`

Before
----------------------------------------
Per the code comment  `CRM_Utils_Number::formatUnitSize` did 'Some kind of numbery-looky-printy thing.' - but I wanted to figure out what that actually was.

It turns out it does 2 things

1) Sets a message warning if there is a mismatch between 2 php_ini settings
2) takes a size in the format supported by those settings & converts them to bytes (this is tested)

It also had code to set a message if the incoming `$size` value was greater than one of those ini settings & not equal to the other - this was potentially displaying on the import screen where the user was redirected to a config screen which didn't allow them to access the command line to change ini settings.... However, in practice it was always called with `$size` equal to one of the ini values & this was not hit. 

After
----------------------------------------
1) the messaging is reduced to warning about the ini mismatch and only on the relevant admin screen. I don't think it's helpful on the import screen & the stuff that is never triggered isn't that helpful...
2) we no longer pass values to the function that are already numerically formatted (ie from the setting) - cos it's clearer if we just multiply the number
3) the part of the function that set the status message is moved to the form
4) goodbye 'Some kind of numbery-looky-printy thing.'

Technical Details
----------------------------------------


Comments
----------------------------------------
