### PR TITLE
Use `supportsNoReturn()` instead of contributeMode check

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2721,7 +2721,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       if (!empty($form->_paymentProcessor)) {
         try {
           $payment = Civi\Payment\System::singleton()->getByProcessor($form->_paymentProcessor);
-          if ($form->_contributeMode == 'notify') {
+          if ($this->getPaymentProcessorObject()->supports('noReturn')) {
             // We want to get rid of this & make it generic - eg. by making payment processing the last thing
             // and always calling it first.
             $form->postProcessHook();

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1872,6 +1872,20 @@ abstract class CRM_Core_Payment {
   }
 
   /**
+   * Checks if payment processor supports not returning to the form processing.
+   *
+   * The exists to support historical event form logic where emails are sent
+   * & the form postProcess hook is called before redirecting the browser where
+   * the user is redirected.
+   *
+   * @return bool
+   */
+  public function supportsNoReturn(): bool {
+    $billingMode = (int) $this->_paymentProcessor['billing_mode'];
+    return $billingMode === self::BILLING_MODE_NOTIFY || $billingMode === self::BILLING_MODE_BUTTON;
+  }
+
+  /**
    * Checks if payment processor supports recurring contributions
    *
    * @return bool

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1581,10 +1581,9 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $this->set('participantInfo', $this->_participantInfo);
     }
 
-    //send mail Confirmation/Receipt
-    if ($this->_contributeMode != 'checkout' ||
-      $this->_contributeMode != 'notify'
+    if ($this->getPaymentProcessorObject()->supports('noReturn')
     ) {
+      // Send mail Confirmation/Receipt.
       $this->sendMails($params, $registerByID, $participantCount);
     }
   }

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -550,8 +550,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
         if (!empty($value['is_pay_later']) ||
           $value['amount'] == 0 ||
           // The concept of contributeMode is deprecated.
-          $this->_contributeMode == 'checkout' ||
-          $this->_contributeMode == 'notify'
+          $this->getPaymentProcessorObject()->supports('noReturn')
         ) {
           if ($value['amount'] != 0) {
             $pending = TRUE;
@@ -749,8 +748,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
 
     // for Transfer checkout.
     // The concept of contributeMode is deprecated.
-    if (($this->_contributeMode == 'checkout' ||
-        $this->_contributeMode == 'notify'
+    if (($this->getPaymentProcessorObject()->supports('noReturn')
       ) && empty($params[0]['is_pay_later']) &&
       !$this->_allowWaitlist && !$this->_requireApproval &&
       $this->_totalAmount > 0


### PR DESCRIPTION


Overview
----------------------------------------
Use supports noReturn instead of contributeMode check

Before
----------------------------------------
In some cases actions are taken on notify contributions because they won't return - ie call hooks or send emails. - the deprecated `_contributeMode` is checked

After
----------------------------------------
I added a new `supportsNoReturn`

In all cases but 1 paypal express is treated the same as notify - I think this last case is oversight not design.


Technical Details
----------------------------------------
Payment processors don't need to make any change for this as `supportsNoReturn` looks up the same value that `_contributeMode` did - although in general it's good to override the supports functions for clarity

Comments
----------------------------------------

@mattwire - almost there...