### PR TITLE
Setup: able to download translation files automatically

### DIFF
--- a/setup/plugins/init/Backdrop.civi-setup.php
+++ b/setup/plugins/init/Backdrop.civi-setup.php
@@ -57,6 +57,8 @@ if (!defined('CIVI_SETUP')) {
     // $model->paths['civicrm.files']['url'] = $filePublicPath;
     $model->paths['civicrm.files']['path'] = implode(DIRECTORY_SEPARATOR,
       [_backdrop_civisetup_getPublicFiles(), 'civicrm']);
+    $model->paths['civicrm.private']['path'] = implode(DIRECTORY_SEPARATOR,
+      [_backdrop_civisetup_getPrivateFiles(), 'civicrm']);
 
     // Compute templateCompileDir.
     $model->templateCompilePath = implode(DIRECTORY_SEPARATOR,

--- a/setup/plugins/init/Drupal.civi-setup.php
+++ b/setup/plugins/init/Drupal.civi-setup.php
@@ -55,6 +55,8 @@ if (!defined('CIVI_SETUP')) {
     // $model->paths['civicrm.files']['url'] = $filePublicPath;
     $model->paths['civicrm.files']['path'] = implode(DIRECTORY_SEPARATOR,
       [_drupal_civisetup_getPublicFiles(), 'civicrm']);
+    $model->paths['civicrm.private']['path'] = implode(DIRECTORY_SEPARATOR,
+      [_drupal_civisetup_getPrivateFiles(), 'civicrm']);
 
     // Compute templateCompileDir.
     $model->templateCompilePath = implode(DIRECTORY_SEPARATOR,

--- a/setup/plugins/init/Drupal8.civi-setup.php
+++ b/setup/plugins/init/Drupal8.civi-setup.php
@@ -59,6 +59,7 @@ if (!defined('CIVI_SETUP')) {
     // Compute general paths
     $model->paths['civicrm.files']['url'] = implode('/', [$model->cmsBaseUrl, \Drupal\Core\StreamWrapper\PublicStream::basePath(), 'civicrm']);
     $model->paths['civicrm.files']['path'] = implode(DIRECTORY_SEPARATOR, [_drupal8_civisetup_getPublicFiles(), 'civicrm']);
+    $model->paths['civicrm.private']['path'] = implode(DIRECTORY_SEPARATOR, [_drupal8_civisetup_getPrivateFiles(), 'civicrm']);
 
     // Compute templateCompileDir.
     $model->templateCompilePath = implode(DIRECTORY_SEPARATOR, [_drupal8_civisetup_getPrivateFiles(), 'civicrm', 'templates_c']);

--- a/setup/plugins/init/Standalone.civi-setup.php
+++ b/setup/plugins/init/Standalone.civi-setup.php
@@ -75,7 +75,7 @@ function _standalone_setup_scheme(): string {
     if (empty($projectRootPath)) {
       throw new \RuntimeException("Failed to identify standalone root. (TIP: Set extras.standaloneRoot)");
     }
-
+    $model->paths['civicrm.private']['path'] = implode(DIRECTORY_SEPARATOR, [$projectRootPath, 'data']);
     $model->settingsPath = implode(DIRECTORY_SEPARATOR, [$projectRootPath, 'data', 'civicrm.settings.php']);
     $model->templateCompilePath = implode(DIRECTORY_SEPARATOR, [$projectRootPath, 'data', 'templates_c']);
     // print "\n-------------------------\nSet model values:\n" . json_encode($model->getValues(), JSON_PRETTY_PRINT) . "\n-----------------------------\n";

--- a/setup/plugins/init/WordPress.civi-setup.php
+++ b/setup/plugins/init/WordPress.civi-setup.php
@@ -47,6 +47,7 @@ if (!defined('CIVI_SETUP')) {
       $model->settingsPath = $preferredSettingsPath;
     }
 
+    $model->paths['civicrm.private']['path'] = implode(DIRECTORY_SEPARATOR, [$uploadDir['basedir'], 'civicrm']);
     $model->templateCompilePath = implode(DIRECTORY_SEPARATOR, [$uploadDir['basedir'], 'civicrm', 'templates_c']);
 
     // Compute DSN.

--- a/setup/plugins/installFiles/l10nDownload.civi-setup.php
+++ b/setup/plugins/installFiles/l10nDownload.civi-setup.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @file
+ *
+ * Generate the civicrm.settings.php file.
+ */
+
+if (!defined('CIVI_SETUP')) {
+  exit("Installation plugins must only be loaded by the installer.\n");
+}
+
+/**
+ * Validate the $model.
+ */
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setup.checkRequirements', function(\Civi\Setup\Event\CheckRequirementsEvent $e) {
+    $lang = \Civi\Setup::instance()->getModel()->lang;
+    if ($lang && $lang != 'en_US') {
+      // Use CiviCRM Core directory as a fall back.
+      $baseDir = $e->getModel()->srcPath;
+      if (isset($e->getModel()->paths['civicrm.private']['path'])) {
+        // If the civicrm files directory is set use this as the base path.
+        $baseDir = $e->getModel()->paths['civicrm.private']['path'];
+      }
+      // Set l10n basedir as a define. The GenCode.php tries to locate the l10n files
+      // from this location if other than l10n in the civicrm core directory.
+      if (!isset($e->getModel()->paths['civicrm.l10n']['path'])) {
+        if (\CRM_Utils_Constant::value('CIVICRM_L10N_BASEDIR')) {
+          $e->getModel()->paths['civicrm.l10n']['path'] = \CRM_Utils_Constant::value('CIVICRM_L10N_BASEDIR');
+        }
+        else {
+          $e->getModel()->paths['civicrm.l10n']['path'] = $baseDir . DIRECTORY_SEPARATOR . 'l10n';
+        }
+      }
+      if (getenv('CIVICRM_L10N_BASEDIR') === FALSE) {
+        // Set the environment variable CIVICRM_L10N_BASEDIR which is used in xml/GenCode.php
+        // to create the localized sql files.
+        putenv('CIVICRM_L10N_BASEDIR=' . $e->getModel()->paths['civicrm.l10n']['path']);
+      }
+      if (!is_dir($e->getModel()->paths['civicrm.l10n']['path'])) {
+        \Civi\Setup::log()->info("Creating directory: " . $e->getModel()->paths['civicrm.l10n']['path']);
+        \CRM_Utils_File::createDir($e->getModel()->paths['civicrm.l10n']['path'], FALSE);
+      }
+    }
+  }, \Civi\Setup::PRIORITY_MAIN);
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setup.installFiles', function (\Civi\Setup\Event\InstallFilesEvent $e) {
+    $lang = \Civi\Setup::instance()->getModel()->lang;
+    if ($lang && $lang != 'en_US') {
+      $downloadDir = $e->getModel()->paths['civicrm.l10n']['path'] . DIRECTORY_SEPARATOR . $lang . DIRECTORY_SEPARATOR . 'LC_MESSAGES';
+      if (!is_dir($downloadDir)) {
+        \Civi\Setup::log()->info("Creating directory: " . $downloadDir);
+        \CRM_Utils_File::createDir($downloadDir, FALSE);
+      }
+
+      foreach ($e->getModel()->moFiles as $moFile => $url) {
+        $l10DownloadFile = str_replace('[locale]', $lang, $url);
+        \Civi\Setup::log()
+          ->info("Download translation '.$moFile.' from " . $l10DownloadFile . ' into ' . $downloadDir);
+        $client = new \GuzzleHttp\Client();
+        $response = $client->get($l10DownloadFile);
+        if ($response->getStatusCode() == 200) {
+          $success = file_put_contents($downloadDir . DIRECTORY_SEPARATOR . $moFile, $response->getBody());
+          if (!$success) {
+            $e->addError('l10n', 'download', 'Unable to download translation file');
+          }
+        }
+      }
+    }
+  }, \Civi\Setup::PRIORITY_MAIN);

--- a/setup/src/Setup/Model.php
+++ b/setup/src/Setup/Model.php
@@ -3,6 +3,7 @@ namespace Civi\Setup;
 
 /**
  * Class Model
+ *
  * @package Civi\Setup
  *
  * The `Model` defines the main options and inputs that are used to configure
@@ -62,6 +63,10 @@ namespace Civi\Setup;
  *   Keys should be prefixed based on which plugin manages the field.
  *   Values must only be scalars (bool/int/string) and arrays.
  *   Ex: ['opt-in.version-check' => TRUE].
+ * @property array $moFiles
+ *   Open-ended list translations files which should be downloaded. Each entry is a url of an mo-file.
+ *   Provide each entry with en_US langugae code. That code will be replaced with the actual language.
+ *   The default is: ['https://download.civicrm.org/civicrm-l10n-core/mo/en_US/civicrm.mo']
  */
 class Model {
 
@@ -171,6 +176,14 @@ class Model {
       'name' => 'extras',
       'type' => 'array',
       'value' => array(),
+    ));
+    $this->addField(array(
+      'description' => 'l10n download files. The [locale] will be replaced with the selected language.',
+      'name' => 'moFiles',
+      'type' => 'array',
+      'value' => array(
+        'civicrm.mo' => 'https://download.civicrm.org/civicrm-l10n-core/mo/[locale]/civicrm.mo',
+      ),
     ));
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

With this PR the CiviCRM setup utility will download the translation files automatically. So making the download of the l10n civicrm files an obsolete step.

Before
----------------------------------------

One had to download the civicrm-l10n files before installing CiviCRM. Otherwise CiviCRM could not be installed into another language then English.

After
----------------------------------------

The setup utility now downloads the translation file for the selected language (if other than english).

Technical Details
----------------------------------------

The setup plugin creates a directory under civicrm-core/l10n

Comments
----------------------------------------

Thanks for the good documentation of the setup utility that made making this change pretty straight forward! 
