### PR TITLE
[REF][PHP8.2] Remove unused id property

### DIFF
--- a/tests/phpunit/CRM/Core/Payment/ProcessorFormTest.php
+++ b/tests/phpunit/CRM/Core/Payment/ProcessorFormTest.php
@@ -169,10 +169,8 @@ class CRM_Core_Payment_ProcessorFormTest extends CiviUnitTestCase {
    * indicates whether the billing block can be hidden, or not.
    */
   public function checkPaymentProcessorWithProfile($processorClass, $case): bool {
-    $whichProcessor = $case . 'ProcessorID';
     $profileID = $this->ids['UFGroup'][$case . '_billing'];
     $processor = new $processorClass();
-    $processor->id = $this->$whichProcessor;
 
     $missingBillingFields = [];
 


### PR DESCRIPTION
Before
----------------------------------------
One of the failing tests on PHP 8.2 is:
```
CRM_Core_Payment_ProcessorFormTest::testPaymentProcessorWithStandardBillingRequirements
Creation of dynamic property PaymentProcessorWithStandardBillingRequirements::$id is deprecated

/home/homer/buildkit/build/build-4/web/sites/all/modules/civicrm/tests/phpunit/CRM/Core/Payment/ProcessorFormTest.php:175
/home/homer/buildkit/build/build-4/web/sites/all/modules/civicrm/tests/phpunit/CRM/Core/Payment/ProcessorFormTest.php:213
/home/homer/buildkit/build/build-4/web/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:242
/home/homer/buildkit/extern/phpunit9/phpunit9.phar:2307
```

After
----------------------------------------
This is a bit of an experiement - I don't think the property is acutally being used, but let's see if the tests agree...