### PR TITLE
[REF][PHP8.2] Declare properties in CRM_Utils_PDF_Label

### DIFF
--- a/CRM/Utils/PDF/Label.php
+++ b/CRM/Utils/PDF/Label.php
@@ -141,6 +141,20 @@ class CRM_Utils_PDF_Label extends TCPDF {
   public $countY = 0;
 
   /**
+   * Custom method for generating label, called against $this->generatorObject
+   *
+   * @var string|null
+   */
+  protected $generatorMethod = NULL;
+
+  /**
+   * Custom object used for generating label, used alongside $this->generatorMethod
+   *
+   * @var object
+   */
+  protected $generatorObject;
+
+  /**
    * Constructor.
    *
    * @param $format


### PR DESCRIPTION
Overview
----------------------------------------
Declare properties in `CRM_Utils_PDF_Label`

Before
----------------------------------------
Properties were not declared, causing dynamic property deprecation notices on PHP 8.2 (and as a result causing test fails)

After
----------------------------------------
Properties declared.

Comments
----------------------------------------
The formatting in this file seems a bit off - I wonder how much unrelated formatting I'll have to do to make the tests pass...
