### PR TITLE
Replace last tpl uses of `contributeMode`

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -321,7 +321,6 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
 
     if ($this->_mode) {
       // process credit card
-      $this->assign('contributeMode', 'direct');
       $this->processCreditCard();
     }
 

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -609,6 +609,22 @@ abstract class CRM_Core_Payment {
         }
         return ts('Make Contribution');
 
+      case 'eventContinueText':
+        // This use of the ts function uses the legacy interpolation of the button name to avoid translations having to be re-done.
+        if ((int) $this->_paymentProcessor['billing_mode'] === self::BILLING_MODE_NOTIFY) {
+          return ts('Click <strong>%1</strong> to checkout with %2.', [1 => ts('Register'), 2 => $this->_paymentProcessor['frontend_title']]);
+        }
+        return ts('Click <strong>%1</strong> to complete your registration.', [1 => ts('Register')]);
+
+      case 'eventConfirmText':
+        if ((int) $this->_paymentProcessor['billing_mode'] === self::BILLING_MODE_NOTIFY) {
+          return ts('Your registration payment has been submitted to %1 for processing', [1 => $this->_paymentProcessor['frontend_title']]);
+        }
+        return '';
+
+      case 'eventConfirmEmailText':
+        return ts('A registration confirmation email will be sent to %1 once the transaction is processed successfully.', [1 => $params['email']]);
+
       case 'cancelRecurDetailText':
         if ($params['mode'] === 'auto_renew') {
           return ts('Click the button below if you want to cancel the auto-renewal option for your %1 membership. This will not cancel your membership. However you will need to arrange payment for renewal when your membership expires.',

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -382,10 +382,8 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     }
     // The concept of contributeMode is deprecated.
     $this->_contributeMode = $this->get('contributeMode');
-    $this->assign('contributeMode', $this->_contributeMode);
 
-    $this->assign('paidEvent', $this->_values['event']['is_monetary']);
-
+    $this->assign('paidEvent', $this->getEventValue('is_monetary'));
     // we do not want to display recently viewed items on Registration pages
     $this->assign('displayRecent', FALSE);
 

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -272,6 +272,8 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       $this->assign('amounts', $this->_amount);
       $this->assign('totalAmount', $this->_totalAmount);
       $this->set('totalAmount', $this->_totalAmount);
+      // This use of the ts function uses the legacy interpolation of the button name to avoid translations having to be re-done.
+      $this->assign('verifyText', !$this->_totalAmount ? ts('Click <strong>%1</strong> to complete your registration.', [1 => ts('Register')]) : $this->getPaymentProcessorObject()->getText('eventContinueText', []));
 
       $showPaymentOnConfirm = (in_array($this->_eventId, \Civi::settings()->get('event_show_payment_on_confirm')) || in_array('all', \Civi::settings()->get('event_show_payment_on_confirm')));
       $this->assign('showPaymentOnConfirm', $showPaymentOnConfirm);

--- a/CRM/Event/Form/Registration/ThankYou.php
+++ b/CRM/Event/Form/Registration/ThankYou.php
@@ -72,13 +72,17 @@ class CRM_Event_Form_Registration_ThankYou extends CRM_Event_Form_Registration {
   public function buildQuickForm() {
     // Assign the email address from a contact id lookup as in CRM_Event_BAO_Event->sendMail()
     $primaryContactId = $this->get('primaryContactId');
+    $email = NULL;
     if ($primaryContactId) {
       $email = CRM_Utils_Array::valueByRegexKey('/^email-/', current($this->_params));
       if (!$email) {
         $email = CRM_Contact_BAO_Contact::getPrimaryEmail($primaryContactId);
       }
-      $this->assign('email', $email);
     }
+    $this->assign('email', $email ?? NULL);
+    $this->assign('eventConfirmText', $this->getEventValue('is_monetary') ? $this->getPaymentProcessorObject()->getText('eventConfirmText', []) : '');
+    $this->assign('eventConfirmEmailText', ($email && $this->getEventValue('is_monetary')) ? $this->getPaymentProcessorObject()->getText('eventConfirmEmailText', ['email' => $email]) : '');
+
     $this->assignToTemplate();
 
     $invoicing = CRM_Invoicing_Utils::isInvoicingEnabled();

--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -22,11 +22,7 @@
         {ts 1=$register}Click <strong>%1</strong> to submit your registration for approval.{/ts}
     {else}
         {ts}Please verify your information.{/ts}
-        {if $contributeMode EQ 'notify' and !$is_pay_later and !$isAmountzero}
-            {ts 1=$register 2=$paymentProcessor.frontend_title}Click <strong>%1</strong> to checkout with %2.{/ts}
-        {else}
-            {ts 1=$register}Click <strong>%1</strong> to complete your registration.{/ts}
-        {/if}
+        {$verifyText}
     {/if}
     </p></div>
     {if $is_pay_later and !$isAmountzero and !$isOnWaitlist and !$isRequireApproval}

--- a/templates/CRM/Event/Form/Registration/ThankYou.tpl
+++ b/templates/CRM/Event/Form/Registration/ThankYou.tpl
@@ -51,11 +51,11 @@
             {if $is_email_confirm}
                 <p>{ts 1=$email}An email with event details has been sent to %1.{/ts}</p>
             {/if}
-        {* PayPal_Standard sets contribution_mode to 'notify'. We don't know if transaction is successful until we receive the IPN (payment notification) *}
-        {elseif $contributeMode EQ 'notify' and $paidEvent}
-            <p>{ts 1=$paymentProcessor.name}Your registration payment has been submitted to %1 for processing.{/ts}</p>
+        {* This text is determined by the payment processor *}
+        {elseif $eventConfirmText}
+            <p>{$eventConfirmText}</p>
             {if $is_email_confirm}
-                <p>{ts 1=$email}A registration confirmation email will be sent to %1 once the transaction is processed successfully.{/ts}</p>
+                <p>{$eventEmailConfirmText}</p>
             {/if}
         {else}
             <p>{ts}Your registration has been processed successfully.{/ts}</p>


### PR DESCRIPTION
Overview
----------------------------------------
Replace last tpl uses of `contributeMode`

Before
----------------------------------------
Text in event confirm & thank you templates depends on conditions based on deprecated `contributeMode`

After
----------------------------------------
Text that is processor dependent comes from the processor

Screenshots show unchanged behaviour 

Paypal pro (form based )
![image](https://github.com/civicrm/civicrm-core/assets/336308/bd0d84d6-d8a6-4849-b2e4-30bed4d2fb75)

![image](https://github.com/civicrm/civicrm-core/assets/336308/320e0da0-0095-4904-99dc-d897affc5e98)

Pay later

![image](https://github.com/civicrm/civicrm-core/assets/336308/ddd78577-628d-4ff9-9c2a-b23e80d77586)

![image](https://github.com/civicrm/civicrm-core/assets/336308/fa3415fc-02a2-434a-8c76-c317331b81cb)
- this latter one comes from unchanged tpl code - ie 
![image](https://github.com/civicrm/civicrm-core/assets/336308/e403554f-459a-4fcc-8ed5-0dcff37cf7c7)


Notify mode  (sts is just a random bit of cat-keyboard typing for the frontend_title
![image](https://github.com/civicrm/civicrm-core/assets/336308/ec120dbc-6ac6-40c0-beb7-00c274d482c1)

![image](https://github.com/civicrm/civicrm-core/assets/336308/f8ad2b9c-9f06-43e8-8868-0c48c4cde0e2)

Technical Details
----------------------------------------


Comments
----------------------------------------

@mattwire 