### PR TITLE
Declare _groupTree on MembershipRenewal form

### DIFF
--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -93,6 +93,17 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
   protected $membershipTypeName = '';
 
   /**
+   * Used in the wrangling of custom field data onto the form.
+   *
+   * There are known instances of extensions altering this array
+   * in order to affect the custom data displayed & there is no
+   * alternative recommendation.
+   *
+   * @var array
+   */
+  public $_groupTree;
+
+  /**
    * Set entity fields to be assigned to the form.
    */
   protected function setEntityFields() {
@@ -378,9 +389,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     $this->add('textarea', 'receipt_text', ts('Renewal Message'));
 
     // Retrieve the name and email of the contact - this will be the TO for receipt email
-    list($this->_contributorDisplayName,
-      $this->_contributorEmail
-      ) = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->_contactID);
+    [$this->_contributorDisplayName, $this->_contributorEmail] = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->_contactID);
     $this->assign('email', $this->_contributorEmail);
     // The member form uses emailExists. Assigning both while we transition / synchronise.
     $this->assign('emailExists', $this->_contributorEmail);
@@ -691,7 +700,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       }
     }
 
-    list($this->isMailSent) = CRM_Core_BAO_MessageTemplate::sendTemplate(
+    [$this->isMailSent] = CRM_Core_BAO_MessageTemplate::sendTemplate(
       [
         'workflow' => 'membership_offline_receipt',
         'from' => $receiptFrom,


### PR DESCRIPTION
Overview
----------------------------------------
Declare _groupTree on MembershipRenewal form

Before
----------------------------------------
CRM_Member_Form_MembershipRenewalTest::testSubmitRecur
Creation of dynamic property CRM_Member_Form_MembershipRenewal::$_groupTree is deprecated

/home/homer/buildkit/build/build-4/web/sites/all/modules/civicrm/CRM/Member/Form/MembershipRenewal.php:649
/home/homer/buildkit/build/build-4/web/sites/all/modules/civicrm/CRM/Member/Form/MembershipRenewal.php:630
/home/homer/buildkit/build/build-4/web/sites/all/modules/civicrm/CRM/Member/Form.php:610
/home/homer/buildkit/build/build-4/web/sites/all/modules/civicrm/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php:301
/home/homer/buildkit/build/build-4/web/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:242
/home/homer/buildkit/extern/phpunit9/phpunit9.phar:2307

After
----------------------------------------

Technical Details
----------------------------------------
This property is one that we have establised extensions have an interest in

Comments
----------------------------------------
