### PR TITLE
[REF][PHP8.2] Properties in TopDonor report

### DIFF
--- a/CRM/Report/Form/Contribute/TopDonor.php
+++ b/CRM/Report/Form/Contribute/TopDonor.php
@@ -38,6 +38,16 @@ class CRM_Report_Form_Contribute_TopDonor extends CRM_Report_Form {
   public $_drilldownReport = ['contribute/detail' => 'Link to Detail Report'];
 
   /**
+   * @var string
+   */
+  protected $_outerCluase = '';
+
+  /**
+   * @var string
+   */
+  protected $_groupLimit = '';
+
+  /**
    */
   public function __construct() {
     $this->_autoIncludeIndexedFieldsAsOrderBys = 1;


### PR DESCRIPTION
Overview
----------------------------------------
Declare properties in `CRM_Report_Form_Contribute_TopDonor`.

Before
----------------------------------------
Dynamic properties cause test failures on PHP 8.2, due to deprecation notices.

After
----------------------------------------
Properties declared.

Comments
----------------------------------------
As with https://github.com/civicrm/civicrm-core/pull/28028 I've gone `protected` on the properties. The leading underscore indicates the property should be considered private.