### PR TITLE
QuickSearch - Fix redirect to adv search with prepopulated criteria

### DIFF
--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -36,7 +36,7 @@ class CRM_Admin_Page_AJAX {
 
       $output = [
         'menu' => $menu,
-        'search' => CRM_Utils_Array::makeNonAssociative(self::getSearchOptions()),
+        'search' => self::getSearchOptions(),
       ];
       // Encourage browsers to cache for a long time - 1 year
       $ttl = 60 * 60 * 24 * 364;
@@ -80,15 +80,14 @@ class CRM_Admin_Page_AJAX {
 
   public static function getSearchOptions() {
     $searchOptions = Civi::settings()->get('quicksearch_options');
-    $labels = CRM_Core_SelectValues::quicksearchOptions();
+    $allOptions = array_column(CRM_Core_SelectValues::getQuicksearchOptions(), NULL, 'key');
     $result = [];
     foreach ($searchOptions as $key) {
-      $label = $labels[$key];
-      if (strpos($key, 'custom_') === 0) {
-        $key = 'custom_' . CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', substr($key, 7), 'id', 'name');
-        $label = array_slice(explode(': ', $label, 2), -1);
-      }
-      $result[$key] = $label;
+      $result[] = [
+        'key' => $key,
+        'value' => $allOptions[$key]['label'],
+        'adv_search_legacy' => $allOptions[$key]['adv_search_legacy'],
+      ];
     }
     return $result;
   }

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -1117,31 +1117,66 @@ class CRM_Core_SelectValues {
     return $optionValues;
   }
 
-  /**
-   * Dropdown options for quicksearch in the menu
-   *
-   * @return array
-   * @throws \CRM_Core_Exception
-   */
-  public static function quicksearchOptions() {
+  public static function getQuicksearchOptions(): array {
     $includeEmail = civicrm_api3('setting', 'getvalue', ['name' => 'includeEmailInName', 'group' => 'Search Preferences']);
     $options = [
-      'sort_name' => $includeEmail ? ts('Name/Email') : ts('Name'),
-      'id' => ts('Contact ID'),
-      'external_identifier' => ts('External ID'),
-      'first_name' => ts('First Name'),
-      'last_name' => ts('Last Name'),
-      'email_primary.email' => ts('Email'),
-      'phone_primary.phone_numeric' => ts('Phone'),
-      'address_primary.street_address' => ts('Street Address'),
-      'address_primary.city' => ts('City'),
-      'address_primary.postal_code' => ts('Postal Code'),
-      'employer_id.sort_name' => ts('Current Employer'),
-      'job_title' => ts('Job Title'),
+      [
+        'key' => 'sort_name',
+        'label' => $includeEmail ? ts('Name/Email') : ts('Name'),
+      ],
+      [
+        'key' => 'id',
+        'label' => ts('Contact ID'),
+      ],
+      [
+        'key' => 'external_identifier',
+        'label' => ts('External ID'),
+      ],
+      [
+        'key' => 'first_name',
+        'label' => ts('First Name'),
+      ],
+      [
+        'key' => 'last_name',
+        'label' => ts('Last Name'),
+      ],
+      [
+        'key' => 'email_primary.email',
+        'label' => ts('Email'),
+        'adv_search_legacy' => 'email',
+      ],
+      [
+        'key' => 'phone_primary.phone_numeric',
+        'label' => ts('Phone'),
+        'adv_search_legacy' => 'phone_numeric',
+      ],
+      [
+        'key' => 'address_primary.street_address',
+        'label' => ts('Street Address'),
+        'adv_search_legacy' => 'street_address',
+      ],
+      [
+        'key' => 'address_primary.city',
+        'label' => ts('City'),
+        'adv_search_legacy' => 'city',
+      ],
+      [
+        'key' => 'address_primary.postal_code',
+        'label' => ts('Postal Code'),
+        'adv_search_legacy' => 'postal_code',
+      ],
+      [
+        'key' => 'employer_id.sort_name',
+        'label' => ts('Current Employer'),
+      ],
+      [
+        'key' => 'job_title',
+        'label' => ts('Job Title'),
+      ],
     ];
     $custom = civicrm_api4('CustomField', 'get', [
       'checkPermissions' => FALSE,
-      'select' => ['name', 'label', 'custom_group_id.name', 'custom_group_id.title', 'option_group_id'],
+      'select' => ['id', 'name', 'label', 'custom_group_id.name', 'custom_group_id.title', 'option_group_id'],
       'where' => [
         ['custom_group_id.extends', 'IN', array_merge(['Contact'], CRM_Contact_BAO_ContactType::basicTypes())],
         ['data_type', 'NOT IN', ['ContactReference', 'Date', 'File']],
@@ -1155,9 +1190,23 @@ class CRM_Core_SelectValues {
       ],
     ]);
     foreach ($custom as $field) {
-      $options[$field['custom_group_id.name'] . '.' . $field['name'] . ($field['option_group_id'] ? ':label' : '')] = $field['custom_group_id.title'] . ': ' . $field['label'];
+      $options[] = [
+        'key' => $field['custom_group_id.name'] . '.' . $field['name'] . ($field['option_group_id'] ? ':label' : ''),
+        'label' => $field['custom_group_id.title'] . ': ' . $field['label'],
+        'adv_search_legacy' => 'custom_' . $field['id'],
+      ];
     }
     return $options;
+  }
+
+  /**
+   * Dropdown options for quicksearch in the menu
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  public static function quicksearchOptions() {
+    return array_column(self::getQuicksearchOptions(), 'label', 'key');
   }
 
   /**

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -88,7 +88,8 @@ class CoreUtil {
    */
   public static function getInfoItem(string $entityName, string $keyToReturn) {
     $provider = \Civi::service('action_object_provider');
-    return $provider->getEntities()[$entityName][$keyToReturn] ?? NULL;
+    $entities = $provider->getEntities();
+    return $entities[$entityName][$keyToReturn] ?? NULL;
   }
 
   /**

--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -388,6 +388,7 @@
           return false;
         }
         var $menu = $('#crm-qsearch-input').autocomplete('widget');
+        // If only one contact was returned, go directly to that contact page
         if ($('li.ui-menu-item', $menu).length === 1) {
           var cid = $('li.ui-menu-item', $menu).data('ui-autocomplete-item').value;
           if (cid > 0) {
@@ -404,7 +405,8 @@
       function setQuickSearchValue() {
         var $selection = $('.crm-quickSearchField input:checked'),
           label = $selection.parent().text(),
-          value = $selection.val();
+          // Set name because the mini-form submits directly to adv search
+          value = $selection.data('advSearchLegacy') || $selection.val();
         $('#crm-qsearch-input').attr({name: value, placeholder: '\uf002 ' + label});
       }
       $('.crm-quickSearchField').click(function() {
@@ -464,7 +466,7 @@
         '</a>' +
         '<ul>' +
           '<% _.forEach(items, function(item) { %>' +
-            '<li><a href="#" class="crm-quickSearchField"><label><input type="radio" value="<%= item.key %>" name="quickSearchField"> <%- item.value %></label></a></li>' +
+            '<li><a href="#" class="crm-quickSearchField"><label><input type="radio" value="<%= item.key %>" name="quickSearchField" data-adv-search-legacy="<%= item.adv_search_legacy %>"> <%- item.value %></label></a></li>' +
           '<% }) %>' +
         '</ul>' +
       '</li>',


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#4624](https://lab.civicrm.org/dev/core/-/issues/4624) regression caused by #26676.

Before
----------------------------------------
Choosing an option like "Phone" from the quicksearch dropdown in the menubar, type some numbers and quickly hit `Enter`. The advanced search will find all contacts (no phone criteria). 

After
----------------------------------------
AdvSearch criteria will be correct.

Technical Details
----------------------------------------
Bridges the mismatch between APIv4-style field names and AdvSearch-style field names with a good ol-fashioned mapper.
