### PR TITLE
(NFC) MenuXmlTest - Improve debug output. Use richer helpers.

### DIFF
--- a/Civi/Test/HttpTestTrait.php
+++ b/Civi/Test/HttpTestTrait.php
@@ -131,6 +131,37 @@ trait HttpTestTrait {
   }
 
   /**
+   * Assert that the response did NOT produce a normal page-view.
+   *
+   * This is basically `assertStatusCode(404)`, except that the local configuration
+   * (CMS/setings/exts/yaddayadda) may change how the error manifests.
+   *
+   * @param $response
+   * @return void
+   */
+  protected function assertPageNotShown($response = NULL): void {
+    $response = $this->resolveResponse($response);
+    $actualCode = $response->getStatusCode();
+    switch ($actualCode) {
+      case 404: /* Good! Right! */
+      case 403: /* Maybe request falls through to `/civicrm/dashboard` */
+      case 500: /* Maybe request falls through to `/civicrm/dashboard`, and it's weird */
+        // OK, close enough. You convinced that the page was not shown to the user.
+        // Bump the assertion-counter and carry on.
+        $this->assertTrue(TRUE);
+        return;
+
+      case 200:
+        // Hypothetically, you might do extra checks on the body to detected misreported errors.
+        // But for now, let's pretend that HTTP 200 means "OK, Page Found!"... since that is exactly what it means.
+        $this->fail("Expected HTTP response to indicate a failure (e.g. 404). Received HTTP response $actualCode.\n" . $this->formatFailure($response));
+
+      default:
+        $this->fail("Expected HTTP response, but the status code makes no sense. Received HTTP response $actualCode.\n" . $this->formatFailure($response));
+    }
+  }
+
+  /**
    * @param $expectType
    * @param \Psr\Http\Message\ResponseInterface|null $response
    *   If NULL, then it uses the last response.
@@ -146,6 +177,8 @@ trait HttpTestTrait {
   }
 
   /**
+   * Assert that the response body matches a regular-expression.
+   *
    * @param string $regexp
    * @param \Psr\Http\Message\ResponseInterface $response
    * @param string $message
@@ -156,8 +189,26 @@ trait HttpTestTrait {
     }
 
     $response = $this->resolveResponse($response);
-    $this->assertRegexp($regexp, (string) $response->getBody(),
+    $this->assertMatchesRegularExpression($regexp, (string) $response->getBody(),
       $message . 'Response body does not match pattern' . $this->formatFailure($response));
+    return $this;
+  }
+
+  /**
+   * Assert that the response body DOES NOT match a regular-expression.
+   *
+   * @param string $regexp
+   * @param \Psr\Http\Message\ResponseInterface $response
+   * @param string $message
+   */
+  protected function assertNotBodyRegexp($regexp, $response = NULL, $message = NULL) {
+    if ($message) {
+      $message .= "\n";
+    }
+
+    $response = $this->resolveResponse($response);
+    $this->assertDoesNotMatchRegularExpression($regexp, (string) $response->getBody(),
+      $message . 'Response body should not match pattern' . $this->formatFailure($response));
     return $this;
   }
 

--- a/mixin/menu-xml@1/example/tests/mixin/MenuXmlTest.php
+++ b/mixin/menu-xml@1/example/tests/mixin/MenuXmlTest.php
@@ -2,6 +2,8 @@
 
 namespace Civi\Shimmy\Mixins;
 
+use Civi\Test\HttpTestTrait;
+
 /**
  * Assert that the `xml/Menu/*.xml` mixin is working properly.
  *
@@ -12,11 +14,7 @@ namespace Civi\Shimmy\Mixins;
  */
 class MenuXmlTest extends \PHPUnit\Framework\Assert {
 
-  /**
-   * The URL of hte example route, `civicrm/shimmy/foobar`.
-   * @var string
-   */
-  protected $url;
+  use HttpTestTrait;
 
   public function testPreConditions($cv): void {
     $this->assertFileExists(static::getPath('/xml/Menu/shimmy.xml'), 'The shimmy extension must have a Menu XML file.');
@@ -27,21 +25,18 @@ class MenuXmlTest extends \PHPUnit\Framework\Assert {
     $items = $cv->api4('Route', 'get', ['where' => [['path', '=', 'civicrm/shimmy/foobar']]]);
     $this->assertEquals('CRM_Shimmy_Page_FooBar', $items[0]['page_callback']);
 
-    // And the menu item works...
-    $this->url = cv('url civicrm/shimmy/foobar');
-    $this->assertTrue(is_string($this->url));
-    $response = file_get_contents($this->url);
-    $this->assertMatchesRegularExpression(';hello world;', $response);
+    $response = $this->createGuzzle()->get('frontend://civicrm/shimmy/foobar');
+    $this->assertStatusCode(200, $response);
+    $this->assertBodyRegexp(';hello world;', $response);
   }
 
   public function testDisabled($cv): void {
     $items = $cv->api4('Route', 'get', ['where' => [['path', '=', 'civicrm/shimmy/foobar']]]);
     $this->assertEmpty($items);
 
-    $this->assertNotEmpty($this->url);
-    $response = file_get_contents($this->url, FALSE, stream_context_create(['http' => ['ignore_errors' => TRUE]]));
-    $this->assertDoesNotMatchRegularExpression(';hello world;', $response);
-    $this->assertDoesNotMatchRegularExpression(';HTTP.*200.*;', $http_response_header[0]);
+    $response = $this->createGuzzle(['http_errors' => FALSE])->get('frontend://civicrm/shimmy/foobar');
+    $this->assertPageNotShown($response);
+    $this->assertNotBodyRegexp(';hello world;', $response);
   }
 
   public function testUninstalled($cv): void {


### PR DESCRIPTION
Overview
----------------------------------------

In automated test-runs, the e2e test for `mixin/menu-xml@1` (`MenuXmlTest`) has been failing sporadically. The failure always involves one of the HTTP sub-requests, but it's never clear what actually happened in the HTTP sub-request. This patch improves the debug info (so we might now how the sub-request failed).

Before
----------------------------------------

Send HTTP sub-request with simple primitives (`cv url` + `file_get_contents`).  No detailed information about the failed request.

After
----------------------------------------

Send HTTP sub-request with `HttpTestTrait` (`guzzle`). Use rich assertions that log more detailed information.

For example, if I hack the test to provoke a failure, it looks like this:

```
1) E2E_Shimmy_LifecycleTest::testLifecycleWithSubprocesses
Expected HTTP response to indicate a failure (e.g. 404). Received HTTP response 200.
{
    "request": {
        "uri": "http://dmaster.127.0.0.1.nip.io:8001/civicrm/shimmy/foobar",
        "method": "GET",
        "headers": {
            "Host": "dmaster.127.0.0.1.nip.io:8001",
            "User-Agent": "GuzzleHttp/6.5.5 curl/7.83.1 PHP/7.4.29"
        },
        "body": ""
    },
    "response": {
        "status": "200 OK",
        "headers": {
            "Date": "Thu, 09 Nov 2023 00:22:53 GMT",
            "Server": "Apache/2.4.53 (Unix) OpenSSL/1.1.1o",
            "X-Powered-By": "PHP/8.1.19",
            "Expires": "Sun, 19 Nov 1978 05:00:00 GMT",
            "Cache-Control": "no-cache, must-revalidate",
            "X-Content-Type-Options": "nosniff",
            "Transfer-Encoding": "chunked",
            "Content-Type": "text/plain;charset=UTF-8"
        },
        "body": "hello world 1699489374.1819"
    }
}

/Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/Test/HttpTestTrait.php:157
/Users/totten/bknix/build/dmaster/web/sites/default/files/civicrm/ext/example-mixin/tests/mixin/MenuXmlTest.php:30
/Users/totten/bknix/build/dmaster/web/sites/default/files/civicrm/ext/example-mixin/tests/phpunit/E2E/Shimmy/LifecycleTest.php:96
/Users/totten/bknix/build/dmaster/web/sites/default/files/civicrm/ext/example-mixin/tests/phpunit/E2E/Shimmy/LifecycleTest.php:73
/Users/totten/bknix/build/dmaster/web/sites/default/files/civicrm/ext/example-mixin/tests/phpunit/E2E/Shimmy/LifecycleTest.php:43
/Users/totten/bknix/extern/phpunit9/phpunit9.phar:2307
```