### PR TITLE
Follow up fixes on `maxFileSize`

### DIFF
--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -48,20 +48,16 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
   public function buildQuickForm(&$form) {
     $form->add('hidden', 'hidden_dataSource', 'CRM_Import_DataSource_CSV');
 
-    $uploadFileSize = $uploadSize = \Civi::settings()->get('maxFileSize');
-    //Fetch uploadFileSize from php_ini when $config->maxFileSize is set to "no limit".
-    if (empty($uploadFileSize)) {
-      $uploadFileSize = CRM_Utils_Number::formatUnitSize(ini_get('upload_max_filesize'));
-      $uploadSize = round(($uploadFileSize / (1024 * 1024)), 2);
-    }
-    $form->assign('uploadSize', $uploadSize);
+    $maxFileSizeMegaBytes = CRM_Utils_File::getMaxFileSize();
+    $maxFileSizeBytes = $maxFileSizeMegaBytes * 1024 * 1024;
+    $form->assign('uploadSize', $maxFileSizeMegaBytes);
     $form->add('File', 'uploadFile', ts('Import Data File'), NULL, TRUE);
     $form->add('text', 'fieldSeparator', ts('Import Field Separator'), ['size' => 2], TRUE);
-    $form->setMaxFileSize($uploadFileSize);
+    $form->setMaxFileSize($maxFileSizeBytes);
     $form->addRule('uploadFile', ts('File size should be less than %1 MBytes (%2 bytes)', [
-      1 => $uploadSize,
-      2 => $uploadFileSize,
-    ]), 'maxfilesize', $uploadFileSize);
+      1 => $maxFileSizeMegaBytes,
+      2 => $maxFileSizeBytes,
+    ]), 'maxfilesize', $maxFileSizeBytes);
     $form->addRule('uploadFile', ts('Input file must be in CSV format'), 'utf8File');
     $form->addRule('uploadFile', ts('A valid file must be uploaded.'), 'uploadedfile');
     $form->setDataSourceDefaults($this->getDefaultValues());

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -1160,4 +1160,23 @@ HTACCESS;
     return $is_dir;
   }
 
+  /**
+   * Get the maximum file size permitted for upload.
+   *
+   * This function contains logic to check the server setting if none
+   * is configured. It is unclear if this is still relevant but perhaps it is no
+   * harm-no-foul.
+   *
+   * @return int
+   *   Size in mega-bytes.
+   */
+  public static function getMaxFileSize(): int {
+    $maxFileSizeMegaBytes = \Civi::settings()->get('maxFileSize');
+    //Fetch maxFileSizeMegaBytes from php_ini when $config->maxFileSize is set to "no limit".
+    if (empty($maxFileSizeMegaBytes)) {
+      $maxFileSizeMegaBytes = round((CRM_Utils_Number::formatUnitSize(ini_get('upload_max_filesize')) / (1024 * 1024)), 2);
+    }
+    return $maxFileSizeMegaBytes;
+  }
+
 }


### PR DESCRIPTION

Overview
----------------------------------------
Follow up fixes on `maxFileSize`

This addresses an incorrect mixing of the size in bytes & megabytes that was just merged and extracts the getting of the maxFileSize to a generic file location


Before
----------------------------------------
Fall back logic to the server maxFileSize on the import csv datasource - but it feels like if it's worth having it should be on the Util class & generally available

- just merged regression mixing size in bytes & mb on the same class

After
----------------------------------------
Regression fixes, function put on the File helper class

Technical Details
----------------------------------------

Comments
----------------------------------------
