### PR TITLE
Issue #4752: Fix undefined index warnings in Action.php.

### DIFF
--- a/CRM/Core/Action.php
+++ b/CRM/Core/Action.php
@@ -314,7 +314,7 @@ class CRM_Core_Action {
     $url = [];
 
     usort($seqLinks, static function ($a, $b) {
-      return (int) ((int) ($a['weight']) > (int) ($b['weight']));
+      return (int) ((int) ($a['weight'] ?? 0) > (int) ($b['weight'] ?? 0));
     });
 
     foreach ($seqLinks as $i => $link) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/4752.

The dblog was filling up with errors with this message:
Notice: Undefined index: weight in CRM_Core_Action::{closure}() (line 317 of /mysite/modules/contrib/civicrm/CRM/Core/Action.php).

Before
----------------------------------------

The dblog was filling up with errors with this message:
Notice: Undefined index: weight in CRM_Core_Action::{closure}() (line 317 of /mysite/modules/contrib/civicrm/CRM/Core/Action.php).

After
----------------------------------------

No more dblog errors.

Technical Details
----------------------------------------

Evidently, this closure was getting called to sort things that didn't have a `weight` index defined.

Comments
----------------------------------------
N/A
