### PR TITLE
Ensure api/v3/utils.php required before civicrm_api3_create_error 5.68

### DIFF
--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -404,6 +404,7 @@ class Kernel {
       }
     }
 
+    require_once "api/v3/utils.php";
     $data = \civicrm_api3_create_error($msg, $data);
 
     if (isset($apiRequest['params']) && is_array($apiRequest['params']) && !empty($apiRequest['params']['api.has_parent'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Ensure api/v3/utils.php required before civicrm_api3_create_error called in scheduled job

Before
----------------------------------------
An error in a scheduled job attempts to call civicrm_api3_create_error() within the createError() method in Civi\API\Kernel.
However in this instance, this call is not available and so an exception is thrown.

See: https://lab.civicrm.org/dev/core/-/issues/4751

After
----------------------------------------
The change adds in a single line to bring in the definition of civicrm_api3_create_error() so the call can proceed as expected.

`
    require_once "api/v3/utils.php";
`

Technical Details
----------------------------------------


Comments
----------------------------------------

