### PR TITLE
Updated fix for badge layouts

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSixtyNine.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtyNine.php
@@ -31,6 +31,12 @@ class CRM_Upgrade_Incremental_php_FiveSixtyNine extends CRM_Upgrade_Incremental_
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Add is_show_calendar_links column to Event table', 'addColumn', 'civicrm_event', 'is_show_calendar_links',
       'tinyint NOT NULL DEFAULT 1 COMMENT "If true, calendar links are shown for this event"');
+    $this->addTask('fix crmDate for installs that existed pre-5.43 - start date',
+      'updatePrintLabelToken', 'event.start_date|crmDate:"%B %E%f}"', 'event.start_date|crmDate:\\\"%B %E%f\\\"}"', $rev
+    );
+    $this->addTask('fix crmDate for installs that existed pre-5.43 - end date',
+      'updatePrintLabelToken', 'event.end_date|crmDate:"%B %E%f}"', 'event.end_date|crmDate:\\\"%B %E%f\\\"}"', $rev
+    );
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Trying to edit the default Badge Layout causes a WSOD if a) you haven't changed it, b) you installed Civi prior to 5.43.

This little bit of stored configuration in the database has caused a lot of issues!  It's had two updates - one in 5.43, another in 5.55 (see https://lab.civicrm.org/dev/core/-/issues/3952).  Another year, another attempt.

Before
----------------------------------------
Default badge layout crashes.

After
----------------------------------------
Default badge layout works.  Users with correct configuration should be unaffected.

Technical Details
----------------------------------------
The last fix had a missing quotation mark.  We identify records with the bad JSON and fix them with a find/replace.

I tested this by identifying an affected site, downloading the 5.69 nightly, and patching it with this PR.  After upgrade, the badge layout loaded correctly.