### PR TITLE
dev/core#3202 Fix incorrect display of join date in membership detail  report

### DIFF
--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -16,7 +16,7 @@
  */
 class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
 
-  protected $_summary = NULL;
+  protected $_summary;
 
   protected $_customGroupExtends = [
     'Membership',
@@ -27,7 +27,7 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
     'Organization',
   ];
 
-  protected $_customGroupGroupBy = FALSE;
+  protected $_customGroupGroupBy;
 
   /**
    * This report has not been optimised for group filtering.
@@ -90,7 +90,7 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
             'title' => ts('Primary/Inherited?'),
             'default' => TRUE,
           ],
-          'join_date' => [
+          'membership_join_date' => [
             'title' => ts('Member Since'),
             'default' => TRUE,
           ],
@@ -197,13 +197,13 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
           'financial_type_id' => [
             'title' => ts('Financial Type'),
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Contribute_PseudoConstant::financialType(),
+            'options' => CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'search'),
             'type' => CRM_Utils_Type::T_INT,
           ],
           'payment_instrument_id' => [
             'title' => ts('Payment Type'),
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Contribute_PseudoConstant::paymentInstrument(),
+            'options' => CRM_Contribute_BAO_Contribution::buildOptions('payment_instrument_id', 'search'),
             'type' => CRM_Utils_Type::T_INT,
           ],
           'currency' => [
@@ -270,7 +270,7 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
     parent::__construct();
   }
 
-  public function preProcess() {
+  public function preProcess(): void {
     $this->assign('reportTitle', ts('Membership Detail Report'));
     parent::preProcess();
   }
@@ -316,7 +316,7 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
                  ON ({$this->_aliases['civicrm_membership']}.id = cmp.membership_id";
       $this->_from .= $groupedBy ? "
                  AND cmp.id = (SELECT MAX(id) FROM civicrm_membership_payment WHERE civicrm_membership_payment.membership_id = {$this->_aliases['civicrm_membership']}.id))"
-                 : ")";
+                 : ')';
       $this->_from .= "
              LEFT JOIN civicrm_contribution {$this->_aliases['civicrm_contribution']}
                  ON cmp.contribution_id={$this->_aliases['civicrm_contribution']}.id\n";
@@ -397,7 +397,7 @@ HERESQL;
     }
   }
 
-  public function getOperationPair($type = 'string', $fieldName = NULL) {
+  public function getOperationPair($type = 'string', $fieldName = NULL): array {
     //re-name IS NULL/IS NOT NULL for clarity
     if ($fieldName === 'owner_membership_id') {
       $result = [];
@@ -468,12 +468,12 @@ HERESQL;
         $rows[$rowNum]['civicrm_contact_sort_name'] &&
         array_key_exists('civicrm_contact_id', $row)
       ) {
-        $url = CRM_Utils_System::url("civicrm/contact/view",
+        $url = CRM_Utils_System::url('civicrm/contact/view',
           'reset=1&cid=' . $row['civicrm_contact_id'],
           $this->_absoluteUrl
         );
         $rows[$rowNum]['civicrm_contact_sort_name_link'] = $url;
-        $rows[$rowNum]['civicrm_contact_sort_name_hover'] = ts("View Contact Summary for this Contact.");
+        $rows[$rowNum]['civicrm_contact_sort_name_hover'] = ts('View Contact Summary for this Contact.');
         $entryFound = TRUE;
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
per https://lab.civicrm.org/dev/core/-/issues/3202 the date format is wrong for membership join date - this fixes

Before
----------------------------------------
Join date not formatted

After
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/336308/8cabe6e8-9723-487a-8495-bac71295087c)

Technical Details
----------------------------------------
I also removed a couple of deprecated function called - I searched other reports for the preferred context to use

Comments
----------------------------------------
