### PR TITLE
Fix notice on is_quick_config - Main contribution page

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {* Callback snippet: On-behalf profile *}
-{if $snippet and !empty($isOnBehalfCallback) and !$ccid}
+{if $snippet and !empty($isOnBehalfCallback) and !$isPaymentOnExistingContribution}
   <div class="crm-public-form-item crm-section">
     {include file="CRM/Contribute/Form/Contribution/OnBehalfOf.tpl" context="front-end"}
   </div>
@@ -54,7 +54,7 @@
   <div class="crm-contribution-page-id-{$contributionPageID} crm-block crm-contribution-main-form-block" data-page-id="{$contributionPageID}" data-page-template="main">
 
     {crmRegion name='contribution-main-not-you-block'}
-    {if $contact_id && !$ccid}
+    {if $contact_id && !$isPaymentOnExistingContribution}
       <div class="messages status no-popup crm-not-you-message">
         {ts 1=$display_name}Welcome %1{/ts}. (<a href="{crmURL p='civicrm/contribute/transact' q="cid=0&reset=1&id=`$contributionPageID`"}" title="{ts}Click here to do this for a different person.{/ts}">{ts 1=$display_name}Not %1, or want to do this for a different person{/ts}</a>?)
       </div>
@@ -70,11 +70,11 @@
       <div class="help">{ts}You have a current Lifetime Membership which does not need to be renewed.{/ts}</div>
     {/if}
 
-    {if $isShowMembershipBlock && !$ccid}
+    {if $isShowMembershipBlock && !$isPaymentOnExistingContribution}
       <div class="crm-public-form-item crm-section">
         {include file="CRM/Contribute/Form/Contribution/MainMembershipBlock.tpl"}
       </div>
-    {elseif !empty($ccid)}
+    {elseif $isPaymentOnExistingContribution}
       {if $lineItem && $priceSetID && !$is_quick_config}
         <div class="header-dark">
           {ts}Contribution Information{/ts}{if $display_name} &ndash; {$display_name}{/if}
@@ -93,7 +93,7 @@
       </div>
     {/if}
 
-    {if !$ccid}
+    {if !$isPaymentOnExistingContribution}
       {crmRegion name='contribution-main-pledge-block'}
       {if $pledgeBlock}
         {if array_key_exists('pledge_amount', $form)}

--- a/templates/CRM/Contribute/Form/Contribution/MainMembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MainMembershipBlock.tpl
@@ -73,7 +73,9 @@
 {/literal}
 </div>
 
-{if $membershipBlock AND $is_quick_config}
+{if $isPaymentOnExistingContribution && $membershipBlock && $is_quick_config}
+    {* This code is hit only when ccid is in the url to pay on an existing contribution and it is quick config *}
+    {* Removing the contents of this if does not result in any apparent change & it may be removable *}
     {strip}
       <table id="membership-listings">
           {foreach from=$membershipTypes item=row}


### PR DESCRIPTION

Overview
----------------------------------------
Fix notice on is_quick_config - Main contribution page

Before
----------------------------------------
notice on is_quick_config on membership pages unless ccid=x&cid=y is in the url & the page is being used to make payment on an existing contribution

After
----------------------------------------
is_quick_config only checked in the scenario where it might be assigned - ie ccid=x&cid=y is in the url & the page is being used to make payment on an existing contribution

Technical Details
----------------------------------------
is_quick_config is only assigned when a payment is being made on an existing contribution - this was a bit hard to figure out so I switched to using a variable that explicitly says what it means (rather than guess at ccid) and ensured that is_quick_config was only accessed within these blocks

Also, I pulled the assignment on the Dummy processor name from out of the unrelated function

Comments
----------------------------------------
