### PR TITLE
Fix notice on intro_text when none configured for the page

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -104,8 +104,8 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     if (!empty($this->_pcpInfo['id']) && !empty($this->_pcpInfo['intro_text'])) {
       $this->assign('intro_text', $this->_pcpInfo['intro_text']);
     }
-    elseif (!empty($this->_values['intro_text'])) {
-      $this->assign('intro_text', $this->_values['intro_text']);
+    else {
+      $this->assign('intro_text', $this->getContributionPageValue('intro_text'));
     }
 
     $qParams = "reset=1&amp;id={$this->_id}";

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -62,7 +62,7 @@
     {/crmRegion}
 
     <div id="intro_text" class="crm-public-form-item crm-section intro_text-section">
-      {$intro_text}
+      {$intro_text|purify}
     </div>
     {include file="CRM/common/cidzero.tpl"}
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix notice on intro_text when none configured for the page

Before
----------------------------------------
Notice if not configured

After
----------------------------------------
always assigned

Technical Details
----------------------------------------
I switched to using `getContributionPageValue()` to be more transparent about where the value is coming from - since that ultimately uses apiv4 I added purity

Comments
----------------------------------------
