### PR TITLE
Fix rc-unreleased regression - tax amount not loading

### DIFF
--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -801,9 +801,12 @@ WHERE  id = %1";
         ->addWhere('price_field_id', 'IN', array_keys($data['fields']))
         ->setSelect($select)
         ->execute();
+      $taxRates = CRM_Core_PseudoConstant::getTaxRates();
       foreach ($options as $option) {
         // Add in visibility because Smarty templates expect it and it is hard to adjust them to colon format.
         $option['visibility'] = $option['visibility_id:name'];
+        $option['tax_rate'] = (float) ($taxRates[$option['financial_type_id']] ?? 0);
+        $option['tax_amount'] = (float) ($option['tax_rate'] ? CRM_Contribute_BAO_Contribution_Utils::calculateTaxAmount($option['amount'], $option['tax_rate'])['tax_amount'] : 0);
         $data['fields'][$option['price_field_id']]['options'][$option['id']] = $option;
       }
       $cache->set($cacheKey, $data);


### PR DESCRIPTION
Overview
----------------------------------------
Fix rc-unreleased regression - tax amount not loading

Before
----------------------------------------
A recent change to assigning metadata to the template did not include the tax amount on the options - leading to it not being added on the Main contribution page

![image](https://github.com/civicrm/civicrm-core/assets/336308/255b7552-3a2c-41f4-b8fb-46c41482ad34)


After
----------------------------------------
now assiged & shows up again

![image](https://github.com/civicrm/civicrm-core/assets/336308/b37897d1-790f-48bc-8a0c-82a3efae83c3)

Technical Details
----------------------------------------
Affects rc only

Comments
----------------------------------------
I'm gonna try to add a test but it will be more challenging so will look to do it as a follow up in master