### PR TITLE
Remove extraneous space, breaks smarty3

### DIFF
--- a/templates/CRM/Price/Form/Field.tpl
+++ b/templates/CRM/Price/Form/Field.tpl
@@ -144,7 +144,7 @@
 
 {if $action eq 1}
 {* Conditionally show table for setting up selection options - for field types = radio, checkbox or select *}
-  <div id='showoption' class="hiddenElement">{ include file="CRM/Price/Form/OptionFields.tpl"}</div>
+  <div id='showoption' class="hiddenElement">{include file="CRM/Price/Form/OptionFields.tpl"}</div>
 {/if}
   <table class="form-layout">
     <tr id="optionsPerLine" class="crm-price-field-form-block-options_per_line">


### PR DESCRIPTION
Overview
----------------------------------------
Remove extraneous space, breaks smarty3

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/3f5afeee-add7-425d-b528-fd0a895fa100)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/0890651d-c4c8-4a52-9126-857a39f1662f)

Technical Details
----------------------------------------

Comments
----------------------------------------
