### PR TITLE
APIv4 - Fix missing tag filer on Individual,Organization,Household

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/EntityTagFilterSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/EntityTagFilterSpecProvider.php
@@ -53,6 +53,9 @@ class EntityTagFilterSpecProvider extends \Civi\Core\Service\AutoService impleme
     if ($action !== 'get') {
       return FALSE;
     }
+    if (CoreUtil::isContact($entity)) {
+      return TRUE;
+    }
     $usedFor = \CRM_Core_OptionGroup::values('tag_used_for', FALSE, FALSE, FALSE, NULL, 'name');
     return in_array($entity, $usedFor, TRUE);
   }

--- a/tests/phpunit/api/v4/Entity/TagTest.php
+++ b/tests/phpunit/api/v4/Entity/TagTest.php
@@ -21,6 +21,7 @@ namespace api\v4\Entity;
 use Civi\Api4\Contact;
 use api\v4\Api4TestBase;
 use Civi\Api4\EntityTag;
+use Civi\Api4\Individual;
 use Civi\Api4\Tag;
 use Civi\Test\TransactionalInterface;
 
@@ -79,7 +80,7 @@ class TagTest extends Api4TestBase implements TransactionalInterface {
     $this->assertCount(1, $shouldReturnContact1);
     $this->assertEquals($contact1['id'], $shouldReturnContact1->first()['id']);
 
-    $shouldReturnContact2 = Contact::get(FALSE)
+    $shouldReturnContact2 = Individual::get(FALSE)
       ->addSelect('id')
       ->addWhere('tags', 'IN', [$setChild['id']])
       ->execute();


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an oversight in #27659 

Before
----------------------------------------
Tag filter only available for "Contact" API.

After
----------------------------------------
Tag filter also available for the Individual,Organization,Household pseudo-entities.