### PR TITLE
[REF][PHP8.2] Declare properties in CRM_Contact_Form_GroupContact

### DIFF
--- a/CRM/Contact/Form/GroupContact.php
+++ b/CRM/Contact/Form/GroupContact.php
@@ -35,6 +35,13 @@ class CRM_Contact_Form_GroupContact extends CRM_Core_Form {
   protected $_contactId;
 
   /**
+   * The context this page is being rendered in
+   *
+   * @var string
+   */
+  protected $_context;
+
+  /**
    * Explicitly declare the entity api name.
    */
   public function getDefaultEntity() {


### PR DESCRIPTION
Overview
----------------------------------------
Declare properties in `CRM_Contact_Form_GroupContact`.

Before
----------------------------------------
`_context` was not declared, causing deprecation warnings on PHP 8.2 (and as a result, test failures)

After
----------------------------------------
Property declared.

Technical Details
----------------------------------------
This is one of those tricky ones to choose between `public` or `protected`. The leading underscore should indicate that the property is for internal use, so I went for `protected`, but arguably it is a breaking change, so I can change if needed.