### PR TITLE
[REF][PHP8.2] Declare properties in CRM_Event_Form_Task_Badge

### DIFF
--- a/CRM/Event/Form/Task/Badge.php
+++ b/CRM/Event/Form/Task/Badge.php
@@ -35,6 +35,13 @@ class CRM_Event_Form_Task_Badge extends CRM_Event_Form_Task {
   public $_componentClause;
 
   /**
+   * The context this page is being rendered in
+   *
+   * @var string
+   */
+  protected $_context;
+
+  /**
    * Build all the data structures needed to build the form.
    *
    * @return void


### PR DESCRIPTION
Overview
----------------------------------------
Declare properties in `CRM_Event_Form_Task_Badge`.

Before
----------------------------------------
`_context` was not declared, causing deprecation warnings on PHP 8.2 (and as a result, test failures)

After
----------------------------------------
Property declared.

Technical Details
----------------------------------------
This is one of those tricky ones to choose between `public` or `protected`. The leading underscore should indicate that the property is for internal use, so I went for `protected`, but arguably it is a breaking change, so I can change if needed.