### PR TITLE
[REF][PHP8.2] Fix MembershipTest on PHP 8.2

### DIFF
--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -812,7 +812,6 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
       'payment_instrument_id' => array_search('Check', $this->paymentInstruments, TRUE),
       'check_number' => 'check-12345',
     ];
-    $form->cid = $this->_individualId;
     $form->testSubmit($submitParams);
     $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_individualId]);
     // check the membership status after additional payment, if its changed to 'New'


### PR DESCRIPTION
Overview
----------------------------------------
 Fix `CRM_Member_Form_MembershipTest` on PHP 8.2 (deprecated dynamic properties)

Before
----------------------------------------
Failing test:
```
CRM_Member_Form_MembershipTest::testSubmitPartialPayment with data set #1 (',')
Creation of dynamic property CRM_Contribute_Form_AdditionalPayment::$cid is deprecated

/home/homer/buildkit/build/build-2/web/sites/all/modules/civicrm/tests/phpunit/CRM/Member/Form/MembershipTest.php:815
/home/homer/buildkit/build/build-2/web/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:242
/home/homer/buildkit/extern/phpunit9/phpunit9.phar:2307
```

After
----------------------------------------
The test will pass as `CRM_Contribute_Form_AdditionalPayment::$cid` is no longer set.

Technical Details
----------------------------------------
`CRM_Contribute_Form_AdditionalPayment` (nor it's parents) ever reference a `$cid` property. They do however call `$this->set('cid', $this->_contactId);`, but `_contactId` is correctly set from the `$submitParams` array passed into `testSubmit`. 