### PR TITLE
[REF][PHP8.2] Ensure _subscriptionDetails is consistently declared

### DIFF
--- a/CRM/Contribute/Form/ContributionRecur.php
+++ b/CRM/Contribute/Form/ContributionRecur.php
@@ -84,6 +84,14 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
   protected $selfService;
 
   /**
+   * Used by `CRM_Contribute_Form_UpdateSubscription`
+   *
+   * @var CRM_Core_DAO
+   * @deprecated This is being set temporarily - we should eventually just use the getter fn.
+   */
+  protected $_subscriptionDetails = NULL;
+
+  /**
    * Explicitly declare the entity api name.
    */
   public function getDefaultEntity() {

--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -21,8 +21,6 @@
 class CRM_Contribute_Form_UpdateBilling extends CRM_Contribute_Form_ContributionRecur {
   protected $_mode = NULL;
 
-  protected $_subscriptionDetails = NULL;
-
   public $_bltID = NULL;
 
   /**

--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -25,8 +25,6 @@ use Civi\Payment\Exception\PaymentProcessorException;
  */
 class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_ContributionRecur {
 
-  protected $_subscriptionDetails = NULL;
-
   public $_paymentProcessor = NULL;
 
   public $_paymentProcessorObj = NULL;


### PR DESCRIPTION
Overview
----------------------------------------
Ensure `_subscriptionDetails` is consistently declared

Before
----------------------------------------
`$_subscriptionDetails` was declared on `CRM_Contribute_Form_UpdateSubscription` and `CRM_Contribute_Form_UpdateBilling`. 

However, `$_subscriptionDetails` is set in the parent class `CRM_Contribute_Form_ContributionRecur`. `CRM_Contribute_Form_ContributionRecur` is also used by `CRM_Contribute_Form_CancelSubscription` which did not declare `$_subscriptionDetails` and therefore caused a deprecation notice (leading to test failures on PHP 8.2)

After
----------------------------------------
The `$_subscriptionDetails` declaration is moved to the parent class, and more explicitely marked as deprecated.
