### PR TITLE
[REF][PHP8.2] Update CRM_Batch_Form_Entry

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -108,6 +108,11 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
   protected $currentRowExistingMembership;
 
   /**
+   * @var array
+   */
+  protected $_priceSet;
+
+  /**
    * Get the contribution id for the current row.
    *
    * @return int
@@ -915,7 +920,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
   /**
    * Send email receipt.
    *
-   * @param CRM_Core_Form $form
+   * @param CRM_Batch_Form_Entry $form
    *   Form object.
    * @param array $formValues
    *
@@ -952,22 +957,22 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
     }
     $form->assign('membership_name', CRM_Member_PseudoConstant::membershipType($membership->membership_type_id));
 
-    [$form->_contributorDisplayName, $form->_contributorEmail]
+    [$contributorDisplayName, $contributorEmail]
       = CRM_Contact_BAO_Contact_Location::getEmailDetails($formValues['contact_id']);
-    $form->_receiptContactId = $formValues['contact_id'];
+    $receiptContactId = $formValues['contact_id'];
 
     CRM_Core_BAO_MessageTemplate::sendTemplate(
       [
         'workflow' => 'membership_offline_receipt',
         'from' => $this->getFromEmailAddress(),
-        'toName' => $form->_contributorDisplayName,
-        'toEmail' => $form->_contributorEmail,
+        'toName' => $contributorDisplayName,
+        'toEmail' => $contributorEmail,
         'PDFFilename' => ts('receipt') . '.pdf',
         'isEmailPdf' => Civi::settings()->get('invoice_is_email_pdf'),
         'isTest' => (bool) ($form->_action & CRM_Core_Action::PREVIEW),
         'modelProps' => [
           'contributionID' => $this->getCurrentRowContributionID(),
-          'contactID' => $form->_receiptContactId,
+          'contactID' => $receiptContactId,
           'membershipID' => $this->getCurrentRowMembershipID(),
         ],
       ]


### PR DESCRIPTION
Overview
----------------------------------------
Ensure `CRM_Batch_Form_Entry` does not use dynamic properties (deprecated in PHP 8.2.

Before
----------------------------------------
Dynamic properties caused decrecation warnings (and subsequent test fails)

After
----------------------------------------
`_priceSet` is declared as a protected property.

Properties in `emailReceipt` have been turned into standard variables - I couldn't see any way in which they could be accessed outside of the function scope (although this might be something for reviewers to double-check my thinking on).
