### PR TITLE
Schedule Job fails with a fatal error if configured with an absolute date

### DIFF
--- a/CRM/Contribute/ActionMapping/ByPage.php
+++ b/CRM/Contribute/ActionMapping/ByPage.php
@@ -78,10 +78,13 @@ class CRM_Contribute_ActionMapping_ByPage extends CRM_Contribute_ActionMapping {
     $query['casContactTableAlias'] = NULL;
 
     // $schedule->start_action_date is user-supplied data. validate.
-    if (!array_key_exists($schedule->start_action_date, $this->getDateFields())) {
+    if (empty($schedule->absolute_date) && !array_key_exists($schedule->start_action_date, $this->getDateFields())) {
       throw new CRM_Core_Exception("Invalid date field");
     }
-    $query['casDateField'] = $schedule->start_action_date;
+    $query['casDateField'] = $schedule->start_action_date ?? '';
+    if (empty($query['casDateField']) && $schedule->absolute_date) {
+      $query['casDateField'] = "'" . CRM_Utils_Type::escape($schedule->absolute_date, 'String') . "'";
+    }
 
     // build where clause
     if (!empty($selectedValues)) {

--- a/CRM/Contribute/ActionMapping/ByType.php
+++ b/CRM/Contribute/ActionMapping/ByType.php
@@ -119,11 +119,13 @@ class CRM_Contribute_ActionMapping_ByType extends CRM_Contribute_ActionMapping {
     $query['casContactTableAlias'] = NULL;
 
     // $schedule->start_action_date is user-supplied data. validate.
-    if (!array_key_exists($schedule->start_action_date, $this->getDateFields())) {
+    if (empty($schedule->absolute_date) && !array_key_exists($schedule->start_action_date, $this->getDateFields())) {
       throw new CRM_Core_Exception("Invalid date field");
     }
-    $query['casDateField'] = $schedule->start_action_date;
-
+    $query['casDateField'] = $schedule->start_action_date ?? '';
+    if (empty($query['casDateField']) && $schedule->absolute_date) {
+      $query['casDateField'] = "'" . CRM_Utils_Type::escape($schedule->absolute_date, 'String') . "'";
+    }
     // build where clause
     if (!empty($selectedValues)) {
       $query->where("e.financial_type_id IN (@selectedValues)")

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -163,6 +163,18 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends AbstractMappingTest {
     ];
 
     $cs[] = [
+      '2015-02-02 00:00:00',
+      'addAliceDues addBobDonation scheduleForDonationWithAbsoluteDate useHelloFirstName',
+      [
+        [
+          'time' => '2015-02-02 00:00:00',
+          'to' => ['bob@example.org'],
+          'subject' => '/Hello, Bob.*via subject/',
+        ],
+      ],
+    ];
+
+    $cs[] = [
       '2015-02-03 00:00:00',
       'addAliceDues addBobDonation scheduleForSoftCreditor startWeekAfter useHelloFirstName',
       [
@@ -244,6 +256,16 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends AbstractMappingTest {
   public function scheduleForDonation(): void {
     $this->schedule->mapping_id = 'contribtype';
     $this->schedule->start_action_date = 'receive_date';
+    $this->schedule->entity_value = CRM_Utils_Array::implodePadded([2]);
+    $this->schedule->entity_status = CRM_Utils_Array::implodePadded(NULL);
+  }
+
+  /**
+   * Schedule message delivery for contribution with an absolute date.
+   */
+  public function scheduleForDonationWithAbsoluteDate(): void {
+    $this->schedule->mapping_id = 'contribtype';
+    $this->schedule->absolute_date = date('Y-m-d', strtotime($this->targetDate));
     $this->schedule->entity_value = CRM_Utils_Array::implodePadded([2]);
     $this->schedule->entity_status = CRM_Utils_Array::implodePadded(NULL);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Schedule Job fails with a fatal error if configured with an absolute date.

Before
----------------------------------------
To replicate:

Create the reminder with the following config:

<img width="564" alt="image" src="https://github.com/civicrm/civicrm-core/assets/5929648/888fe78b-d392-44eb-90d0-7aba8debd073">

See job log of sched reminder:

>Finished execution of Scheduled reminders sender with result: Failure, Error message: Invalid date field

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Ignore validating the absolute date field with relative fields.

