### PR TITLE
dev/core#4702 - Fix country/state chainSelect validation when country is deselected

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2866,10 +2866,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   private function validateChainSelectFields() {
     foreach ($this->_chainSelectFields as $control => $target) {
       if ($this->elementExists($control) && $this->elementExists($target)) {
-        $controlValue = (array) $this->getElementValue($control);
+        $controlValue = (array) $this->getSubmitValue($control);
         $targetField = $this->getElement($target);
         $controlType = $targetField->getAttribute('data-callback') == 'civicrm/ajax/jqCounty' ? 'stateProvince' : 'country';
-        $targetValue = array_filter((array) $targetField->getValue());
+        $targetValue = array_filter((array) $this->getSubmitValue($target));
         if ($targetValue || $this->getElementError($target)) {
           $options = CRM_Core_BAO_Location::getChainSelectValues($controlValue, $controlType, TRUE);
           if ($targetValue) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug that no one noticed for the past 9 years.
https://lab.civicrm.org/dev/core/-/issues/4702

Technical Details
----------
I guess `getSubmitValue` returns the value actually submitted even if blank, but `getElementValue` returns the default value for the element if submitted blank.
