### PR TITLE
dev/core#4772 fix authx on Joomla

### DIFF
--- a/ext/authx/Civi/Authx/Joomla.php
+++ b/ext/authx/Civi/Authx/Joomla.php
@@ -81,7 +81,6 @@ class Joomla implements AuthxInterface {
     // In any event, this work-around passes `AllFlowsTest::testMultipleStateless`.
 
     \JFactory::getSession()->destroy();
-    \JFactory::getSession()->setHandler(new \CRM_Utils_FakeJoomlaSession('CIVISCRIPT'));
     $user = new \JUser($userId);
     $session = \JFactory::getSession();
     $session->set('user', $user);


### PR DESCRIPTION
Overview
----------------------------------------
When using Authx to authenticate external CURL API calls in Joomla, we receive the error:
`Class "CRM_Utils_FakeJoomlaSession" not found.`

Before
----------------------------------------
CURL API calls to Joomla with Authx fail.

After
----------------------------------------
API calls are successful.

Technical Details
----------------------------------------
The line removed is not necessary and is currently calling a non-existent class. 