### PR TITLE
Update the parameters passed to the hook_QueueTaskError

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -3116,7 +3116,7 @@ abstract class CRM_Utils_Hook {
    */
   public static function queueTaskError(CRM_Queue_Queue $queue, $item, &$outcome, ?Throwable $exception) {
     $null = NULL;
-    return self::singleton()->invoke(['job', 'params'], $queue, $item,
+    return self::singleton()->invoke(['queue', 'item', 'outcome', 'exception'], $queue, $item,
       $outcome, $exception, $null, $null,
       'civicrm_queueTaskError'
     );


### PR DESCRIPTION
Issue: https://lab.civicrm.org/dev/core/-/issues/4774

Overview
----------------------------------------
The QueueTaskError throws an exception stating  the function got 2 parameters instead of 4.

Before
----------------------------------------
The QueueTaskError throws the exception stated above

After
----------------------------------------
The QueueTaskError doesn't throw the exception

