### PR TITLE
APIv4 - Add autocomplete & fix joins in CustomValue entities

### DIFF
--- a/Civi/Api4/Action/Entity/GetLinks.php
+++ b/Civi/Api4/Action/Entity/GetLinks.php
@@ -36,7 +36,7 @@ class GetLinks extends \Civi\Api4\Generic\BasicGetAction {
           'links' => [],
         ];
         foreach ($table->getTableLinks() as $link) {
-          if (!$link->isDeprecated()) {
+          if (!$link->isDeprecatedBy()) {
             $item['links'][] = $link->toArray();
           }
         }

--- a/Civi/Api4/CustomValue.php
+++ b/Civi/Api4/CustomValue.php
@@ -29,6 +29,17 @@ class CustomValue {
   /**
    * @param string $customGroup
    * @param bool $checkPermissions
+   * @return \Civi\Api4\Generic\AutocompleteAction
+   * @throws \API_Exception
+   */
+  public static function autocomplete(string $customGroup, $checkPermissions = TRUE) {
+    return (new \Civi\Api4\Generic\AutocompleteAction("Custom_$customGroup", __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param string $customGroup
+   * @param bool $checkPermissions
    * @return Action\CustomValue\Get
    * @throws \CRM_Core_Exception
    */

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -833,9 +833,9 @@ class Api4SelectQuery extends Api4Query {
             return;
           }
         }
-        if ($link->isDeprecated()) {
+        if ($link->isDeprecatedBy()) {
           $deprecatedAlias = $link->getAlias();
-          \CRM_Core_Error::deprecatedWarning("Deprecated join alias '$deprecatedAlias' used in APIv4 get. Should be changed to '{$deprecatedAlias}_id'");
+          \CRM_Core_Error::deprecatedWarning("Deprecated join alias '$deprecatedAlias' used in APIv4 {$this->getEntity()} join to $joinEntity. Should be changed to '{$link->isDeprecatedBy()}'.");
         }
         $virtualField = $link->getSerialize();
         $baseTableAlias = $joinTreeNode['#table_alias'];

--- a/Civi/Api4/Service/Autocomplete/CustomValueAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/CustomValueAutocompleteProvider.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Autocomplete;
+
+use Civi\Api4\Utils\CoreUtil;
+use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\HookInterface;
+
+/**
+ * @service
+ * @internal
+ */
+class CustomValueAutocompleteProvider extends \Civi\Core\Service\AutoService implements HookInterface {
+
+  /**
+   * Provide default SearchDisplay for autocompletes of multi-record custom values
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   */
+  public static function on_civi_search_defaultDisplay(GenericHookEvent $e) {
+    if ($e->display['settings'] || $e->display['type'] !== 'autocomplete' || !str_starts_with($e->savedSearch['api_entity'], 'Custom_')) {
+      return;
+    }
+    $customGroupName = explode('_', $e->savedSearch['api_entity'], 2)[1];
+
+    // Custom groups could contain any fields & we have no idea what's in them
+    // but this is just the default display and can be overridden.
+    // Our best guess for a "title" is the first text field in the group
+    $titleField = \Civi\Api4\CustomValue::getFields('Multi_Stuff', FALSE)
+      ->addWhere('data_type', '=', 'String')
+      ->addWhere('input_type', '=', 'Text')
+      ->execute()->first()['name'] ?? NULL;
+
+    // Include search label of parent entity (e.g. `entity_id.sort_name` for Contact custom groups)
+    $customGroupExtends = \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $customGroupName, 'extends', 'name');
+    $extendsLabelField = CoreUtil::getInfoItem($customGroupExtends, 'search_fields')[0] ?? NULL;
+
+    if (!$extendsLabelField && !$titleField) {
+      // Got nothing, fall back to the default which displays id only.
+      return;
+    }
+
+    $mainColumn = [
+      'type' => 'field',
+      'key' => $titleField ?? "entity_id.$extendsLabelField",
+    ];
+    if ($titleField && $extendsLabelField) {
+      $mainColumn['rewrite'] = "[entity_id.$extendsLabelField] - [$titleField]";
+    }
+
+    $e->display['settings'] = [
+      'sort' => [
+        [$mainColumn['key'], 'ASC'],
+      ],
+      'columns' => [
+        $mainColumn,
+        [
+          'type' => 'field',
+          'key' => 'id',
+          'rewrite' => '#[id]',
+        ],
+      ],
+    ];
+  }
+
+}

--- a/Civi/Api4/Service/Autocomplete/EntityAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/EntityAutocompleteProvider.php
@@ -22,7 +22,7 @@ use Civi\Core\HookInterface;
 class EntityAutocompleteProvider extends \Civi\Core\Service\AutoService implements HookInterface {
 
   /**
-   * Provide default SearchDisplay for ContactType autocompletes
+   * Provide default SearchDisplay for autocompletes of API Entity names
    *
    * @param \Civi\Core\Event\GenericHookEvent $e
    */

--- a/Civi/Api4/Service/Schema/Joinable/Joinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/Joinable.php
@@ -78,7 +78,7 @@ class Joinable {
   /**
    * @var bool
    */
-  protected $deprecated = FALSE;
+  protected $deprecatedBy = FALSE;
 
   /**
    * @param $targetTable
@@ -282,17 +282,16 @@ class Joinable {
   /**
    * @return bool
    */
-  public function isDeprecated() {
-    return $this->deprecated;
+  public function isDeprecatedBy() {
+    return $this->deprecatedBy;
   }
 
   /**
-   * @param bool $deprecated
-   *
+   * @param string|null $deprecatedBy
    * @return $this
    */
-  public function setDeprecated(bool $deprecated = TRUE) {
-    $this->deprecated = $deprecated;
+  public function setDeprecatedBy(string $deprecatedBy = NULL) {
+    $this->deprecatedBy = $deprecatedBy ?? $this->alias . '_id';
     return $this;
   }
 

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/DefaultDisplaySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/DefaultDisplaySubscriber.php
@@ -59,10 +59,9 @@ class DefaultDisplaySubscriber extends \Civi\Core\Service\AutoService implements
       throw new \CRM_Core_Exception("Entity name is required to get autocomplete default display.");
     }
     $idField = CoreUtil::getIdFieldName($entityName);
-    $searchFields = CoreUtil::getSearchFields($entityName);
-    if (!$searchFields) {
-      throw new \CRM_Core_Exception("Entity $entityName has no default label field.");
-    }
+
+    // If there's no label field, fall back on id. That's a pretty lame autocomplete but better than nothing.
+    $searchFields = CoreUtil::getSearchFields($entityName) ?: [$idField];
 
     // Default sort order
     $e->display['settings']['sort'] = self::getDefaultSort($entityName);

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -1154,10 +1154,10 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
     $this->hookClass->setHook('civicrm_aclWhereClause', [$this, 'aclWhereOnlyOne']);
     $this->cleanupCachedPermissions();
 
-    $customValues = CustomValue::get($group)->addSelect('*', 'contact.first_name')->execute();
+    $customValues = CustomValue::get($group)->addSelect('*', 'entity_id.first_name')->execute();
     $this->assertCount(1, $customValues);
     $this->assertEquals($c2, $customValues[0]['entity_id']);
-    $this->assertEquals('C2', $customValues[0]['contact.first_name']);
+    $this->assertEquals('C2', $customValues[0]['entity_id.first_name']);
 
     $customValues = Contact::get()
       ->addJoin('Custom_' . $group . ' AS cf')


### PR DESCRIPTION
Overview
----------------------------------------
This PR contains 3 interrelated fixes:

1. Fixes autocomplete widgets for entity types that do not have a label field declared (instead of an error, they will now at least allow a search by id).
2. Adds the ability to autocomplete-search for CustomValue entities (aka multi-record custom field groups)
3. Fixes a bug preventing joins in SearchKit from a multi-record custom entity back to the parent contact.
