### PR TITLE
dev/core#4769 APIv4 - Fix access to case activities for administrators

### DIFF
--- a/ext/civi_case/civi_case.php
+++ b/ext/civi_case/civi_case.php
@@ -25,14 +25,16 @@ function civi_case_civicrm_managed(&$entities, $modules) {
  */
 function civi_case_civicrm_selectWhereClause($entityName, &$clauses, $userId, $conditions) {
   if ($entityName === 'Activity') {
+    $casePerms = CRM_Utils_SQL::mergeSubquery('Case');
+    if (!$casePerms) {
+      // Unrestricted access to CiviCase
+      return;
+    }
     // OR group: either it's a non-case activity OR case permissions apply
     $orGroup = [
       'NOT IN (SELECT activity_id FROM civicrm_case_activity)',
+      'IN (SELECT activity_id FROM civicrm_case_activity WHERE case_id ' . implode(' AND case_id ', $casePerms) . ')',
     ];
-    $casePerms = CRM_Utils_SQL::mergeSubquery('Case');
-    if ($casePerms) {
-      $orGroup[] = 'IN (SELECT activity_id FROM civicrm_case_activity WHERE case_id ' . implode(' AND case_id ', $casePerms) . ')';
-    }
     $clauses['id'][] = $orGroup;
   }
 }

--- a/tests/phpunit/api/v4/Entity/CaseTest.php
+++ b/tests/phpunit/api/v4/Entity/CaseTest.php
@@ -257,10 +257,11 @@ class CaseTest extends Api4TestBase {
     $this->assertCount(1, $result);
     $this->assertEquals($case1, $result[0]);
 
-    // CiviCase permission for all  cases
+    // CiviCase permission for all contacts and cases
     \CRM_Core_Config::singleton()->userPermissionClass->permissions = [
       'access CiviCRM',
       'view all contacts',
+      'access deleted contacts',
       'access all cases and activities',
       'administer CiviCase',
     ];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes API regression. See [dev/core#4769](https://lab.civicrm.org/dev/core/-/issues/4769).

Before
----------------------------------------
Case administrators with 'access deleted contacts' permission blocked from viewing Case activities in APIv4.

After
----------------------------------------
Permissions work correctly.

Technical Details
----------------------------------------
The problem was the hook logic was incorrectly interpreting empty permissions to mean "no access" when it actually means "unrestricted access".

Test updated to cover this scenario.