### PR TITLE
fix issue #4770 Ensure the followup_assignee_contact_id is an array so all assignees are saved, not just the first one

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1830,6 +1830,9 @@ AND cl.modified_id  = c.id
     $followupParams['activity_type_id'] = $params['followup_activity_type_id'];
     // Get Subject of Follow-up Activiity, CRM-4491
     $followupParams['subject'] = $params['followup_activity_subject'] ?? NULL;
+    if (!is_array($params['followup_assignee_contact_id'])) {
+      $params['followup_assignee_contact_id'] = explode(",", $params['followup_assignee_contact_id']);
+    }
     $followupParams['assignee_contact_id'] = $params['followup_assignee_contact_id'] ?? NULL;
 
     // Create target contact for followup.

--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1830,7 +1830,7 @@ AND cl.modified_id  = c.id
     $followupParams['activity_type_id'] = $params['followup_activity_type_id'];
     // Get Subject of Follow-up Activiity, CRM-4491
     $followupParams['subject'] = $params['followup_activity_subject'] ?? NULL;
-    if (!is_array($params['followup_assignee_contact_id'])) {
+    if (!is_array($params['followup_assignee_contact_id']) && !empty($params['followup_assignee_contact_id'])) {
       $params['followup_assignee_contact_id'] = explode(",", $params['followup_assignee_contact_id']);
     }
     $followupParams['assignee_contact_id'] = $params['followup_assignee_contact_id'] ?? NULL;


### PR DESCRIPTION
Overview
----------------------------------------
Making sure the followup_assignee_contact_id is an array so all assignees are saved, not just the first one

Before
----------------------------------------
followup_assignee_contact_id was filled from the parameters, but this comes as a comma separated string so only the first contact ID is saved.

After
----------------------------------------
If the followup_assignee_contact_id is not an array it is transferred into an array with an explode on ,
