### PR TITLE
Remove last references to `_contributeMode`

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -153,8 +153,6 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
    */
   public $_pledgeValues;
 
-  public $_contributeMode = 'direct';
-
   public $_context;
 
   public $_compId;

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -19,7 +19,6 @@
  * This form records additional payments needed when event/contribution is partially paid.
  */
 class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_AbstractEditPayment {
-  public $_contributeMode = 'direct';
 
   /**
    * Id of the component entity

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -96,8 +96,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
    */
   public $_pledgeValues;
 
-  public $_contributeMode = 'direct';
-
   public $_context;
 
   /**

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1974,15 +1974,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       // It can be blank with a $0 transaction - then no processor needs to be selected
       $form->_paymentProcessor = $form->_paymentProcessors[$form->_params['payment_processor_id']];
     }
-    if (!empty($params['payment_processor_id'])) {
-      // The concept of contributeMode is deprecated as is the billing_mode concept.
-      if ($form->_paymentProcessor['billing_mode'] == 1) {
-        $form->_contributeMode = 'direct';
-      }
-      else {
-        $form->_contributeMode = 'notify';
-      }
-    }
 
     if (!empty($params['useForMember'])) {
       $form->set('useForMember', 1);

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -166,22 +166,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   public $_action;
 
   /**
-   * Contribution mode.
-   *
-   * In general we are trying to deprecate this parameter but some templates and processors still
-   * require it to denote whether the processor redirects offsite (notify) or not.
-   *
-   * The intent is that this knowledge should not be required and all contributions should
-   * be created in a pending state and updated based on the payment result without needing to be
-   * aware of the processor workings.
-   *
-   * @var string
-   *
-   * @deprecated
-   */
-  public $_contributeMode;
-
-  /**
    * Contribution page supports memberships
    * @var bool
    */
@@ -509,8 +493,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     // This can probably go as nothing it 'getting it' anymore since the values data is loaded
     // on every form, rather than being passed from form to form.
     $this->set('amount_block_is_active', $this->isFormSupportsNonMembershipContributions());
-
-    $this->_contributeMode = $this->get('contributeMode');
 
     //assigning is_monetary and is_email_receipt to template
     $this->assign('is_monetary', $this->_values['is_monetary']);

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -153,15 +153,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    *
    * @var array
    */
-  public $_lineItem = NULL;
-
-  /**
-   * Contribution mode for event registration for offline mode.
-   *
-   * @var string
-   * @deprecated
-   */
-  public $_contributeMode = 'direct';
+  public $_lineItem;
 
   public $_online;
 

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -380,8 +380,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       );
       CRM_Utils_System::redirect($url);
     }
-    // The concept of contributeMode is deprecated.
-    $this->_contributeMode = $this->get('contributeMode');
 
     $this->assign('paidEvent', $this->getEventValue('is_monetary'));
     // we do not want to display recently viewed items on Registration pages

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -29,8 +29,6 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
    */
   public $_mode;
 
-  public $_contributeMode = 'direct';
-
   protected $_memTypeSelected;
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Remove last references to `_contributeMode`

Before
----------------------------------------
`_contributeMode` still set or declared in a few places but never used

![image](https://github.com/civicrm/civicrm-core/assets/336308/784fcfb3-a4cd-4275-b40e-e765c1b9d693)


After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
@mattwire