### PR TITLE
Fix notice on payment processor object

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -752,7 +752,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
     $form->assign('is_recur_interval', $this->getContributionPageValue('is_recur_interval'));
     $form->assign('is_recur_installments', $this->getContributionPageValue('is_recur_installments'));
-    $paymentObject = $this->_paymentProcessor['object'];
+    $paymentObject = $this->getPaymentProcessorObject();
     if ($paymentObject) {
       $form->assign('recurringHelpText', $paymentObject->getText('contributionPageRecurringHelp', [
         'is_recur_installments' => !empty($form->_values['is_recur_installments']),


### PR DESCRIPTION
Overview
----------------------------------------
Fixes master-only notice regression

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/166a5bfc-81b5-4444-bf73-b6978c362972)

After
----------------------------------------
gone

Technical Details
----------------------------------------
recently introduced here - https://github.com/civicrm/civicrm-core/commit/6ce23a46eb0f39a0b3af4020a354e59ac01a2de9#diff-9319a4134599e85c273c3be5706ffb5d642b7659904fd644dd4273791467384aR750 but it didn't degrade quitely when the processor was not yet determined - but the use of the function does

AFAIK other places touched in that PR are OK but will find them if not as I view the forms

Comments
----------------------------------------
