### PR TITLE
Fix notice on showCMS:

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -319,6 +319,9 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     // Required for footer.tpl,
     // See CRM_Activity_Form_ActivityTest:testInboundEmailDisplaysWithLineBreaks.
     'footer_status_severity',
+    // Required for some profiles (e.g on the Main page of the contribution form flow).
+    // A bit tricky to add closer to the usage due to conditionality of inclusion
+    'showCMS',
   ];
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix notice on showCMS

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/59710602-0b4f-4f15-b359-4ad04f6944bb)


After
----------------------------------------
that one gone

Technical Details
----------------------------------------
Adding variables to this top level array is our bluntest sledge hammer but this one is a bit tricksy as you have to figure out quite a bit to decide to otherwise assign it or what pages might be affected. Also I broke something last time I tried that approach

Comments
----------------------------------------
