### PR TITLE
Add test cover for tax details in Dummy payment online contribution receipt

### DIFF
--- a/Civi/Test/ContributionPageTestTrait.php
+++ b/Civi/Test/ContributionPageTestTrait.php
@@ -326,4 +326,26 @@ trait ContributionPageTestTrait {
     }
   }
 
+  /**
+   * Get suitable values for submitting the contribution form with a billing block.
+   *
+   * @param string $processorIdentifier
+   *
+   * @return array
+   */
+  protected function getBillingSubmitValues(string $processorIdentifier = 'dummy'): array {
+    // @todo determine the fields from the processor.
+    return [
+      'billing_first_name' => 'Dave',
+      'billing_middle_name' => 'Joseph',
+      'billing_last_name' => 'Wong',
+      'email' => 'dave@example.com',
+      'payment_processor_id' => $this->ids['PaymentProcessor'][$processorIdentifier],
+      'credit_card_number' => '4111111111111111',
+      'credit_card_type' => 'Visa',
+      'credit_card_exp_date' => ['M' => 9, 'Y' => 2040],
+      'cvv2' => 123,
+    ];
+  }
+
 }

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -1542,44 +1542,6 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test form submission with multiple option price set.
-   *
-   * @param string $thousandSeparator
-   *   punctuation used to refer to thousands.
-   *
-   * @dataProvider getThousandSeparators
-   */
-  public function testSubmitContributionPageWithPriceSet(string $thousandSeparator): void {
-    $this->setCurrencySeparators($thousandSeparator);
-    $this->setUpContributionPage([], ['is_quick_config' => FALSE]);
-    $submitParams = [
-      'price_' . $this->_ids['price_field'][0] => reset($this->_ids['price_field_value']),
-      'id' => $this->getContributionPageID(),
-      'first_name' => 'Billy',
-      'last_name' => 'Gruff',
-      'email' => 'billy@goat.gruff',
-      'is_pay_later' => TRUE,
-    ];
-    $this->addPriceFields($submitParams);
-
-    $this->callAPISuccess('ContributionPage', 'submit', $submitParams);
-    $contribution = $this->callAPISuccessGetSingle('contribution', [
-      'contribution_page_id' => $this->getContributionPageID(),
-      'contribution_status_id' => 'Pending',
-    ]);
-    $this->assertEquals(80, $contribution['total_amount']);
-    $lineItems = $this->callAPISuccess('LineItem', 'get', [
-      'contribution_id' => $contribution['id'],
-    ]);
-    $this->assertEquals(3, $lineItems['count']);
-    $totalLineAmount = 0;
-    foreach ($lineItems['values'] as $lineItem) {
-      $totalLineAmount += $lineItem['line_total'];
-    }
-    $this->assertEquals(80, $totalLineAmount);
-  }
-
-  /**
    * Function to add additional price fields to price set.
    *
    * @param array $params


### PR DESCRIPTION

Overview
----------------------------------------
Add test cover for tax details in Dummy payment online contribution receipt

Before
----------------------------------------
Unclear if we had testing for tax details in online contribution receipt

After
----------------------------------------
Cover added

Technical Details
----------------------------------------
@demeritcowboy I didn't hit the regression you described here or in my own testing which got

![image](https://github.com/civicrm/civicrm-core/assets/336308/2f5b4591-f336-4d9f-838e-65ef94ffdc73)


But I did hit a smarty3 issue which I will put up a fix for

Comments
----------------------------------------