### PR TITLE
dev/core#4740 - Fix missing tagsets when label doesn't match name

### DIFF
--- a/CRM/Core/Form/Tag.php
+++ b/CRM/Core/Form/Tag.php
@@ -46,10 +46,7 @@ class CRM_Core_Form_Tag {
     $form->assign('isTagset', FALSE);
     $mode = NULL;
 
-    foreach ($parentNames as &$parentNameItem) {
-      // get the parent id for tag list input for keyword
-      $parentId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Tag', $parentNameItem, 'id', 'name');
-
+    foreach ($parentNames as $parentId => $parentNameItem) {
       // check if parent exists
       if ($parentId) {
         $tagsetItem = $tagsetElementName . 'parentId_' . $parentId;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the bug documented in [dev/core#4740](https://lab.civicrm.org/dev/core/-/issues/4740).


Technical Details
----------------------------------------
`CRM_Core_Form_Tag::buildQuickForm` was previously being passed an array of `[id => name]` but it was wastefully ignoring the passed ids and looking `id` up from the `name`.

Now due to bcf668d it is being passed an array of `[id => label] `which is all it needs, just had to remove the redundant `id`-from-`name` lookup when it's already there.