### PR TITLE
Fix PHP 8 warning on Joomla

### DIFF
--- a/templates/CRM/common/joomla.tpl
+++ b/templates/CRM/common/joomla.tpl
@@ -37,7 +37,7 @@
 
     <div class="clear"></div>
 
-    {if $localTasks}
+    {if !empty($localTasks)}
         {include file="CRM/common/localNav.tpl"}
     {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------

This fixes a warning observed on PHP 8.1 with Joomla 4.2 and CiviCRM master (circa 5.69.alpha).

Before
----------------------------------------

```
( ! ) Warning: Undefined array key "localTasks" in /home/totten/bknix/build/hydra-joomla/web/media/civicrm/templates_c/en_US/%%EA/EAA/EAA96A89%%joomla.tpl.php on line 45
```

![Screenshot from 2023-11-15 00-00-50](https://github.com/civicrm/civicrm-core/assets/1336047/393599d1-49c5-4ad1-9d32-8e58a38ce9fb)

After
----------------------------------------

No warning

Technical Details
----------------------------------------

This is a very complicated case, Maude. You know, a lotta ins, a lotta outs, a lotta what-have-yous. And, uh, a lotta strands to keep in my head, man. Lotta strands in old Duder's head.