### PR TITLE
dev/core#4017 - ensure having fields are selected in API4 query

### DIFF
--- a/Civi/Api4/Generic/Traits/GroupAndHavingParamTrait.php
+++ b/Civi/Api4/Generic/Traits/GroupAndHavingParamTrait.php
@@ -60,6 +60,18 @@ trait GroupAndHavingParamTrait {
       throw new \CRM_Core_Exception('Unsupported operator');
     }
     $this->having[] = [$expr, $op, $value];
+    $this->addSelect($expr);
+    return $this;
+  }
+
+  /**
+   * Overrides the default setter magic function to ensure we add having clauses to the select
+   */
+  public function setHaving(array $clauses) {
+    $this->having = [];
+    foreach ($clauses as $clause) {
+      $this->addHaving(...$clause);
+    }
     return $this;
   }
 

--- a/api/api.php
+++ b/api/api.php
@@ -85,6 +85,10 @@ function civicrm_api4(string $entity, string $action, array $params = [], $index
       if ($indexField && $indexField != $indexCol) {
         $apiCall->addSelect($indexField);
       }
+      // reset having to ensure having fields are re-added to select
+      if (!empty($params['having'])) {
+        $apiCall->setHaving($params['having']);
+      }
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to https://github.com/civicrm/civicrm-core/pull/28137 to fix [dev/core#4017](https://lab.civicrm.org/dev/core/-/issues/4017).

Technical Details
----------------------------------------
This attempts to ensure any HAVING fields are always SELECTed when API4 builds SQL queries - so you don't have to remember to include them in the `select` param. 

This is especially useful if you pass an index param, which implicitly limits the fields SELECTed - this was the cause of the original bug.

This approach retains the limited SELECT when using the api4 index param - which is maybe good for performance in some situations?

Comments
-----------------------------------------
Could there be any reason anyone is relying on a fail when passing a `having` that isnt included in the `select` ?