### PR TITLE
dev/core#4778 - php notice causes civi menu to go missing

### DIFF
--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -86,7 +86,7 @@ class CRM_Admin_Page_AJAX {
       $result[] = [
         'key' => $key,
         'value' => $allOptions[$key]['label'],
-        'adv_search_legacy' => $allOptions[$key]['adv_search_legacy'],
+        'adv_search_legacy' => $allOptions[$key]['adv_search_legacy'] ?? '',
       ];
     }
     return $result;


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4778

Before
----------------------------------------
Menu missing - notice in console `Undefined array key "adv_search_legacy"`

After
----------------------------------------


Technical Details
----------------------------------------
Whether it borks your menu or not will depend on how strict your dev environment is setup. But at a minimum there's a php notice.

Comments
----------------------------------------

