### PR TITLE
Update Merger.php to compare strict type for checkboxes where a dummy…

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1561,8 +1561,8 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
         $value[1] = NULL;
       }
 
-      // Display a checkbox to migrate, only if the values are different
-      if ($value != $main[$field]) {
+      // Display a checkbox to migrate, only if the values are different, should check type also for true value
+      if ($value !== $main[$field]) {
         // Don't check source if main is empty, because the source of the other contact is not the source of the merged contact
         $isChecked = ($field === 'source') ? FALSE : (!isset($main[$field]) || $main[$field] === '');
         $elements[] = [


### PR DESCRIPTION
Update Merger.php to compare strict type for checkboxes where a dummy-string is being used, to prevent this matching  'true'

Overview
----------------------------------------
If try to Manual merge two Individual contacts, and those contacts have different Is Opt Out value
currently, no checkbox under the column "Mark All"

Before
----------------------------------------
Currently no checkbox for Opt Out value,
like https://civicrm.wikimedia.org/civicrm/contact/merge?reset=1&action=update&cid=205&oid=61133966
<img width="1075" alt="Screenshot 2023-11-07 at 2 16 26 PM" src="https://github.com/wikimediaWfan/civicrm-core/assets/96108825/33dfe278-bb7b-45a3-9349-59f8f629071c">

After
----------------------------------------
After this patch, you will able to see the checkbox for this field if values are different

Technical Details
----------------------------------------
Update Merger.php to compare strict type for checkbox true situation

Comments
----------------------------------------
for users to have ability to check/uncheck overwrite for Is Opt Out when merge
