### PR TITLE
When creating links use title if defined

### DIFF
--- a/CRM/Core/Action.php
+++ b/CRM/Core/Action.php
@@ -352,7 +352,7 @@ class CRM_Core_Action {
           $classes .= " small-popup";
         }
 
-        $linkContent = $link['name'];
+        $linkContent = $link['title'] ?? $link['name'];
         if (!empty($link['icon'])) {
           if ($iconMode === 'icon') {
             $linkContent = CRM_Core_Page::crmIcon($link['icon'], $link['name'], TRUE, ['title' => '']);


### PR DESCRIPTION
Overview
----------------------------------------
When creating links use title if defined

Before
----------------------------------------
When defining links it is possible to set title & this is encouraged for search kit links - but the 'name' key is what is displayed in the link in normal forms

After
----------------------------------------
title used if relevant

Technical Details
----------------------------------------
The original need for this was to fix the recently added link in Move Contrib to use the title - @lcdservices [has since updated the name to be the same as the title](https://github.com/lcdservices/biz.lcdservices.movecontrib/blob/master/movecontrib.php#L47) - but really I think it's better practice to put a machine friendly name in the name field (not specifically here - just generally the meaning of name as a field) so we should support using title in core



Comments
----------------------------------------
