### PR TITLE
APIv4 - Add GROUP_FIRST aggregate function

### DIFF
--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -118,6 +118,13 @@ abstract class SqlFunction extends SqlExpression {
     if (static::$dataType) {
       $dataType = static::$dataType;
     }
+    elseif (static::$category === self::CATEGORY_AGGREGATE) {
+      $exprArgs = $this->getArgs();
+      // If the first expression is a SqlFunction/SqlEquation, allow it to control the aggregate dataType
+      if (method_exists($exprArgs[0]['expr'][0], 'formatOutputValue')) {
+        $exprArgs[0]['expr'][0]->formatOutputValue($dataType, $values, $key);
+      }
+    }
     if (isset($values[$key]) && $this->suffix && $this->suffix !== 'id') {
       $dataType = 'String';
       $value =& $values[$key];
@@ -162,7 +169,7 @@ abstract class SqlFunction extends SqlExpression {
    * @return string
    */
   protected function renderExpression(string $output): string {
-    return $this->getName() . '(' . $output . ')';
+    return $this->getName() . "($output)";
   }
 
   /**

--- a/Civi/Api4/Query/SqlFunctionGROUP_FIRST.php
+++ b/Civi/Api4/Query/SqlFunctionGROUP_FIRST.php
@@ -1,0 +1,66 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Sql function returns the first item in a GROUP_CONCAT set (per the ORDER_BY param)
+ * @since 5.69
+ */
+class SqlFunctionGROUP_FIRST extends SqlFunction {
+
+  public $supportsExpansion = TRUE;
+
+  protected static $category = self::CATEGORY_AGGREGATE;
+
+  protected static function params(): array {
+    return [
+      [
+        'max_expr' => 1,
+        'must_be' => ['SqlField', 'SqlFunction', 'SqlEquation'],
+        'optional' => FALSE,
+      ],
+      [
+        'name' => 'ORDER BY',
+        'label' => ts('Order by'),
+        'max_expr' => 1,
+        'flag_after' => ['ASC' => ts('Ascending'), 'DESC' => ts('Descending')],
+        'must_be' => ['SqlField'],
+        'optional' => TRUE,
+      ],
+    ];
+  }
+
+  /**
+   * @return string
+   */
+  public static function getTitle(): string {
+    return ts('First');
+  }
+
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('First value in the grouping.');
+  }
+
+  /**
+   * Render the final expression
+   * @param string $output
+   * @return string
+   */
+  protected function renderExpression(string $output): string {
+    $sep = \CRM_Core_DAO::VALUE_SEPARATOR;
+    return "SUBSTRING_INDEX(GROUP_CONCAT($output SEPARATOR '$sep'), '$sep', 1)";
+  }
+
+}

--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -190,7 +190,7 @@
         function getKeyword(whitelist) {
           var keyword;
           _.each(_.filter(whitelist), function(flag) {
-            if (argString.indexOf(flag + ' ') === 0) {
+            if (argString.indexOf(flag + ' ') === 0 || argString === flag) {
               keyword = flag;
               argString = _.trim(argString.substr(flag.length));
               return false;
@@ -241,7 +241,7 @@
               }
               getKeyword([',']);
             }
-            if (expr && !_.isEmpty(expr.flag_after)) {
+            if (info.args.length && !_.isEmpty(param.flag_after)) {
               _.last(info.args).flag_after = getKeyword(_.keys(param.flag_after));
             }
           } else if (param.flag_before && !param.optional) {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -44,19 +44,20 @@
         }
       });
 
-      this.addArg = function(exprType) {
+      this.addArg = function(exprType, optional) {
         var param = ctrl.getParam(ctrl.args.length),
           val = '';
         if (exprType === 'SqlNumber') {
           // Number: default to 0
           val = 0;
-        } else if (exprType === 'SqlField') {
+        } else if (exprType === 'SqlField' && !optional) {
           // Field: Default to first available field, making it easier to delete the value
           val = ctrl.getFields().results[0].children[0].id;
         }
         ctrl.args.push({
           type: ctrl.exprTypes[exprType].type,
           flag_before: _.filter(_.keys(param.flag_before))[0],
+          flag_after: _.filter(_.keys(param.flag_after))[0],
           name: param.name,
           value: val
         });
@@ -70,11 +71,11 @@
         _.each(ctrl.fn.params, function(param, index) {
           while (
             (ctrl.args.length - index < param.min_expr) &&
-            // TODO: Handle named params like "ORDER BY"
-            !(param.name && param.optional) &&
+            // Exclude 'api_default' params (should not be changed by the user)
+            !param.api_default &&
             (!param.optional || param.must_be.length === 1)
           ) {
-            ctrl.addArg(param.must_be[0]);
+            ctrl.addArg(param.must_be[0], param.optional);
           }
         });
       }
@@ -144,6 +145,7 @@
             ctrl.args.splice(pos, 0, {
               type: exprType ? ctrl.exprTypes[exprType].type : null,
               flag_before: _.filter(_.keys(ctrl.fn.params[pos].flag_before))[0],
+              flag_after: _.filter(_.keys(ctrl.fn.params[pos].flag_after))[0],
               name: ctrl.fn.params[pos].name,
               value: exprType === 'SqlNumber' ? 0 : ''
             });
@@ -152,6 +154,7 @@
           // Update fieldArg
           var fieldParam = ctrl.fn.params[pos];
           ctrl.fieldArg.flag_before = _.keys(fieldParam.flag_before)[0];
+          ctrl.fieldArg.flag_after = _.keys(fieldParam.flag_after)[0];
           ctrl.fieldArg.name = fieldParam.name;
           initFunction();
         }
@@ -159,9 +162,10 @@
       };
 
       this.changeArg = function(index) {
-        var val = ctrl.args[index].value;
-        // Delete empty value
-        if (index && !val && val !== 0 && ctrl.args.length > ctrl.fn.params[0].min_expr) {
+        var val = ctrl.args[index].value,
+          param = ctrl.getParam(index);
+        // Delete empty value if allowed
+        if (index && !val && val !== 0 && !param.optional && ctrl.args.length > param.min_expr) {
           ctrl.args.splice(index, 1);
         }
         ctrl.writeExpr();
@@ -178,7 +182,8 @@
           var args = _.transform(ctrl.args, function(args, arg, index) {
             if (arg.value || arg.value === 0 || arg.flag_before) {
               var prefix = arg.flag_before || arg.name ? (index ? ' ' : '') + (arg.flag_before || arg.name) + (arg.value ? ' ' : '') : (index ? ', ' : '');
-              args.push(prefix + (arg.type === 'string' ? JSON.stringify(arg.value) : arg.value));
+              var suffix = arg.flag_after ? ' ' + arg.flag_after : '';
+              args.push(prefix + (arg.type === 'string' ? JSON.stringify(arg.value) : arg.value) + suffix);
             }
           });
           // Replace fake function "e"

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.html
@@ -4,12 +4,13 @@
 <label ng-hide="$ctrl.mode !== 'select' && !$ctrl.fn">{{ $ctrl.fieldArg.field.label }}</label>
 
 <div class="form-group" ng-repeat="arg in $ctrl.args">
-  <crm-search-function-flag ng-if="$ctrl.fn" arg="arg" param="$ctrl.getParam($index)" write-expr="$ctrl.writeExpr()"></crm-search-function-flag>
+  <crm-search-function-flag ng-if="$ctrl.fn" flag="flag_before" arg="arg" param="$ctrl.getParam($index)" write-expr="$ctrl.writeExpr()"></crm-search-function-flag>
   <span ng-switch="arg.type" ng-if="arg !== $ctrl.fieldArg">
     <input ng-switch-when="number" class="form-control" type="number" ng-model="arg.value" placeholder="{{ $ctrl.getParam($index).label }}" ng-change="$ctrl.changeArg($index)" ng-model-options="{updateOn: 'blur'}">
     <input ng-switch-when="string" class="form-control" ng-model="arg.value" placeholder="{{ $ctrl.getParam($index).label }}" ng-change="$ctrl.changeArg($index)" ng-trim="false" ng-model-options="{updateOn: 'blur'}">
     <input ng-switch-when="field" class="form-control" ng-model="arg.value" crm-ui-select="{data: $ctrl.getFields, placeholder: $ctrl.getParam($index).label}" ng-change="$ctrl.changeArg($index)">
   </span>
+  <crm-search-function-flag ng-if="$ctrl.fn && arg.value" flag="flag_after" arg="arg" param="$ctrl.getParam($index)" write-expr="$ctrl.writeExpr()"></crm-search-function-flag>
 </div>
 <div class="btn-group" ng-if="$ctrl.canAddArg()">
   <button type="button" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunctionFlag.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunctionFlag.component.js
@@ -5,6 +5,7 @@
     bindings: {
       arg: '<',
       param: '<',
+      flag: '@',
       writeExpr: '&'
     },
     templateUrl: '~/crmSearchAdmin/crmSearchFunctionFlag.html',
@@ -13,9 +14,9 @@
         ctrl = this;
 
       this.$onInit = function() {
-        if (!ctrl.param || !ctrl.param.flag_before) {
+        if (!ctrl.param || !ctrl.param[ctrl.flag]) {
           this.widget = null;
-        } else if (_.keys(ctrl.param.flag_before).length === 2 && '' in ctrl.param.flag_before) {
+        } else if (_.keys(ctrl.param[ctrl.flag]).length === 2 && '' in ctrl.param[ctrl.flag]) {
           this.widget = 'checkbox';
         } else {
           this.widget = 'select';

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunctionFlag.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunctionFlag.component.js
@@ -13,13 +13,13 @@
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
 
-      this.$onInit = function() {
+      this.getWidget = function() {
         if (!ctrl.param || !ctrl.param[ctrl.flag]) {
-          this.widget = null;
+          return null;
         } else if (_.keys(ctrl.param[ctrl.flag]).length === 2 && '' in ctrl.param[ctrl.flag]) {
-          this.widget = 'checkbox';
+          return 'checkbox';
         } else {
-          this.widget = 'select';
+          return 'select';
         }
       };
     }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunctionFlag.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunctionFlag.html
@@ -1,4 +1,4 @@
-<span ng-switch="$ctrl.widget">
+<span ng-switch="$ctrl.getWidget()">
   <span ng-switch-when="checkbox">
     <label ng-repeat="(val, label) in $ctrl.param[$ctrl.flag]" ng-if="val">
       <input type="checkbox" ng-checked="$ctrl.arg[$ctrl.flag] === val" ng-click="$ctrl.arg[$ctrl.flag] = ($ctrl.arg[$ctrl.flag] === val ? null : val); $ctrl.writeExpr();" >

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunctionFlag.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunctionFlag.html
@@ -1,12 +1,12 @@
 <span ng-switch="$ctrl.widget">
   <span ng-switch-when="checkbox">
-    <label ng-repeat="(val, label) in $ctrl.param.flag_before" ng-if="val">
-      <input type="checkbox" ng-checked="$ctrl.arg.flag_before === val" ng-click="$ctrl.arg.flag_before = ($ctrl.arg.flag_before === val ? null : val); $ctrl.writeExpr();" >
+    <label ng-repeat="(val, label) in $ctrl.param[$ctrl.flag]" ng-if="val">
+      <input type="checkbox" ng-checked="$ctrl.arg[$ctrl.flag] === val" ng-click="$ctrl.arg[$ctrl.flag] = ($ctrl.arg[$ctrl.flag] === val ? null : val); $ctrl.writeExpr();" >
       {{ label }}
     </label>
   </span>
-  <select ng-switch-when="select" class="form-control" ng-model="$ctrl.arg.flag_before" ng-change="$ctrl.writeExpr();">
-    <option ng-repeat="(val, label) in $ctrl.param.flag_before" value="{{ val }}">
+  <select ng-switch-when="select" class="form-control" ng-model="$ctrl.arg[$ctrl.flag]" ng-change="$ctrl.writeExpr();">
+    <option ng-repeat="(val, label) in $ctrl.param[$ctrl.flag]" value="{{ val }}">
       {{ label }}
     </option>
   </select>


### PR DESCRIPTION
Overview
----------------------------------------
Adds a useful new SQL function to APIv4, and exposes it to SearchKit.

Before
---------
SearchKit has a "List" transformation (aka GROUP_CONCAT) but gives no control over ORDER BY and no way to return just one record from that list.

After
--------
"List" transformation now gives fine control of the ORDER BY param.
"First" transformation added, which returns the first item from "List". ORDER BY param gives control over which item is considered the first.

Technical Details
----------------------------------------
This fills a gap in the MySql spec. It returns the first result of a GROUP_CONCAT set. By flipping the ORDER BY param from ASC to DESC it will alternately return the _last_ result in the group.

Comments
-------
Adding a corresponding `GROUP_LAST` function would be trivial copy/paste/tweak... but OTOH, it's also trivial to change the ORDER BY from ASC to DESC in SearchKit and get the last element that way.