### PR TITLE
[REF] Afform - Namespace mock tests for autoloading

### DIFF
--- a/ext/afform/mock/phpunit.xml.dist
+++ b/ext/afform/mock/phpunit.xml.dist
@@ -1,30 +1,15 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         convertDeprecationsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         bootstrap="tests/phpunit/bootstrap.php"
-         cacheResult="false">
-  <coverage>
-    <include>
-      <directory suffix=".php">./</directory>
-    </include>
-  </coverage>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" cacheResult="false" bootstrap="tests/phpunit/bootstrap.php">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>
     </testsuite>
-    <testsuite name="form-tests">
-      <directory suffix=".test.php">./ang</directory>
-    </testsuite>
   </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformAutocompleteUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformAutocompleteUsageTest.php
@@ -1,4 +1,5 @@
 <?php
+namespace api\v4\Afform;
 
 use Civi\Api4\Afform;
 use Civi\Api4\Contact;
@@ -13,7 +14,7 @@ use Civi\Api4\SavedSearch;
  *
  * @group headless
  */
-class api_v4_AfformAutocompleteUsageTest extends api_v4_AfformUsageTestCase {
+class AfformAutocompleteUsageTest extends AfformUsageTestCase {
 
   /**
    * Ensure that Afform restricts autocomplete results when it's set to use a SavedSearch
@@ -33,7 +34,7 @@ EOHTML;
 
     $this->useValues([
       'layout' => $layout,
-      'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
     ]);
 
     // Saved search for filtering
@@ -95,7 +96,7 @@ EOHTML;
         ->execute();
       $this->fail();
     }
-    catch (CRM_Core_Exception $e) {
+    catch (\CRM_Core_Exception $e) {
       $this->assertEquals('Validation Error', $e->getMessage());
     }
 
@@ -163,7 +164,7 @@ EOHTML;
 
     $this->useValues([
       'layout' => $layout,
-      'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
     ]);
 
     $result = Contact::autocomplete()
@@ -195,7 +196,7 @@ EOHTML;
         ->execute();
       $this->fail();
     }
-    catch (CRM_Core_Exception $e) {
+    catch (\CRM_Core_Exception $e) {
       $this->assertEquals('Validation Error', $e->getMessage());
     }
 
@@ -257,7 +258,7 @@ EOHTML;
 
     $this->useValues([
       'layout' => $layout,
-      'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
     ]);
 
     $result = Contact::autocomplete()
@@ -293,7 +294,7 @@ EOHTML;
         ->execute();
       $this->fail();
     }
-    catch (CRM_Core_Exception $e) {
+    catch (\CRM_Core_Exception $e) {
       $this->assertEquals('Validation Error', $e->getMessage());
     }
 

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformContactUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformContactUsageTest.php
@@ -1,13 +1,16 @@
 <?php
+namespace api\v4\Afform;
 
 use Civi\Api4\Afform;
+use Civi\Api4\AfformSubmission;
+use Civi\Api4\Contact;
 
 /**
  * Test case for Afform.checkAccess, Afform.prefill and Afform.submit.
  *
  * @group headless
  */
-class api_v4_AfformContactUsageTest extends api_v4_AfformUsageTestCase {
+class AfformContactUsageTest extends AfformUsageTestCase {
 
   public static function setUpBeforeClass(): void {
     parent::setUpBeforeClass();
@@ -80,11 +83,11 @@ EOHTML;
   public function testAboutMeAllowed(): void {
     $this->useValues([
       'layout' => self::$layouts['aboutMe'],
-      'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
     ]);
 
     $cid = $this->createLoggedInUser();
-    CRM_Core_Config::singleton()->userPermissionTemp = new CRM_Core_Permission_Temp();
+    \CRM_Core_Config::singleton()->userPermissionTemp = new \CRM_Core_Permission_Temp();
 
     // Autofill form with current user. See `Civi\Afform\Behavior\ContactAutofill`
     $prefill = Afform::prefill()
@@ -103,7 +106,7 @@ EOHTML;
       ->setValues(['me' => $submission])
       ->execute();
 
-    $contact = Civi\Api4\Contact::get(FALSE)->addWhere('id', '=', $cid)->execute()->first();
+    $contact = Contact::get(FALSE)->addWhere('id', '=', $cid)->execute()->first();
     $this->assertEquals('Firsty', $contact['first_name']);
     $this->assertEquals('Lasty', $contact['last_name']);
   }
@@ -111,7 +114,7 @@ EOHTML;
   public function testChainSelect(): void {
     $this->useValues([
       'layout' => self::$layouts['aboutMe'],
-      'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
     ]);
 
     // Get states for USA
@@ -120,7 +123,7 @@ EOHTML;
       ->setModelName('me')
       ->setFieldName('state_province_id')
       ->setJoinEntity('Address')
-      ->setValues(['country_id' => CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Country', 'United States', 'id', 'name')])
+      ->setValues(['country_id' => \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Country', 'United States', 'id', 'name')])
       ->execute();
     $this->assertEquals('Alabama', $result[0]['label']);
 
@@ -130,7 +133,7 @@ EOHTML;
       ->setModelName('me')
       ->setFieldName('state_province_id')
       ->setJoinEntity('Address')
-      ->setValues(['country_id' => CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Country', 'United Kingdom', 'id', 'name')])
+      ->setValues(['country_id' => \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Country', 'United Kingdom', 'id', 'name')])
       ->execute();
     $this->assertEquals('Aberdeen City', $result[0]['label']);
   }
@@ -138,7 +141,7 @@ EOHTML;
   public function testCheckEntityReferenceFieldsReplacement(): void {
     $this->useValues([
       'layout' => self::$layouts['registerSite'],
-      'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
       'create_submission' => TRUE,
     ]);
 
@@ -170,7 +173,7 @@ EOHTML;
       ->setValues($values)
       ->execute();
 
-    $submission = Civi\Api4\AfformSubmission::get(FALSE)
+    $submission = AfformSubmission::get(FALSE)
       ->addOrderBy('id', 'DESC')
       ->execute()->first();
 
@@ -204,8 +207,8 @@ EOHTML;
       'permission' => ['access CiviCRM'],
     ]);
     $this->createLoggedInUser();
-    CRM_Core_Config::singleton()->userPermissionTemp = NULL;
-    CRM_Core_Config::singleton()->userPermissionClass->permissions = [
+    \CRM_Core_Config::singleton()->userPermissionTemp = NULL;
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = [
       'access Contact Dashboard',
     ];
     $check = Afform::checkAccess()
@@ -213,7 +216,7 @@ EOHTML;
       ->setAction('get')
       ->execute()->first();
     $this->assertFalse($check['access']);
-    CRM_Core_Config::singleton()->userPermissionClass->permissions = [
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = [
       'access CiviCRM',
     ];
     $check = Afform::checkAccess()
@@ -226,11 +229,11 @@ EOHTML;
   public function testAboutMeForbidden(): void {
     $this->useValues([
       'layout' => self::$layouts['aboutMe'],
-      'permission' => CRM_Core_Permission::ALWAYS_DENY_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_DENY_PERMISSION,
     ]);
 
     $this->createLoggedInUser();
-    CRM_Core_Config::singleton()->userPermissionTemp = new CRM_Core_Permission_Temp();
+    \CRM_Core_Config::singleton()->userPermissionTemp = new \CRM_Core_Permission_Temp();
 
     try {
       Afform::prefill()
@@ -262,7 +265,7 @@ EOHTML;
   public function testEmployerReference(): void {
     $this->useValues([
       'layout' => self::$layouts['employer'],
-      'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
     ]);
 
     $firstName = uniqid(__FUNCTION__);
@@ -303,7 +306,7 @@ EOHTML;
   public function testEmptyEmployerReference(): void {
     $this->useValues([
       'layout' => self::$layouts['employer'],
-      'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
     ]);
 
     $firstName = uniqid(__FUNCTION__);
@@ -342,12 +345,12 @@ EOHTML;
     $this->useValues([
       'layout' => self::$layouts['employer'],
       'create_submission' => TRUE,
-      'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
     ]);
 
     $individualEmail = uniqid('individual@') . '.test';
     $orgEmail = uniqid('org@') . '.test';
-    $locationType = CRM_Core_BAO_LocationType::getDefault()->id;
+    $locationType = \CRM_Core_BAO_LocationType::getDefault()->id;
     $values = [
       'Individual1' => [
         [
@@ -413,7 +416,7 @@ EOHTML;
 EOHTML;
     $this->useValues([
       'layout' => $layout,
-      'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
     ]);
 
     $lastName = uniqid(__FUNCTION__);
@@ -423,7 +426,7 @@ EOHTML;
       ->addValue('email_primary.email', '123@example.com')
       ->execute()->single();
 
-    $locationType = CRM_Core_BAO_LocationType::getDefault()->id;
+    $locationType = \CRM_Core_BAO_LocationType::getDefault()->id;
     $values = [
       'Individual1' => [
         [
@@ -455,7 +458,7 @@ EOHTML;
   public function testFormValidationEntityFields(): void {
     $this->useValues([
       'layout' => self::$layouts['updateInfo'],
-      'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
     ]);
 
     $values = [
@@ -491,7 +494,7 @@ EOHTML;
   public function testFormValidationEntityJoinFields(): void {
     $this->useValues([
       'layout' => self::$layouts['updateInfo'],
-      'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
     ]);
 
     $values = [
@@ -526,13 +529,13 @@ EOHTML;
   public function testSubmissionLimit() {
     $this->useValues([
       'layout' => self::$layouts['aboutMe'],
-      'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
       'create_submission' => TRUE,
       'submit_limit' => 3,
     ]);
 
     $cid = $this->createLoggedInUser();
-    CRM_Core_Config::singleton()->userPermissionTemp = new CRM_Core_Permission_Temp();
+    \CRM_Core_Config::singleton()->userPermissionTemp = new \CRM_Core_Permission_Temp();
 
     $submitValues = [
       ['fields' => ['first_name' => 'Firsty', 'last_name' => 'Lasty']],

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformCustomFieldUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformCustomFieldUsageTest.php
@@ -1,4 +1,5 @@
 <?php
+namespace api\v4\Afform;
 
 use Civi\Api4\Afform;
 use Civi\Api4\Contact;
@@ -10,7 +11,7 @@ use Civi\Api4\CustomGroup;
  *
  * @group headless
  */
-class api_v4_AfformCustomFieldUsageTest extends api_v4_AfformUsageTestCase {
+class AfformCustomFieldUsageTest extends AfformUsageTestCase {
 
   public static function setUpBeforeClass(): void {
     parent::setUpBeforeClass();
@@ -68,7 +69,7 @@ EOHTML;
 
     $this->useValues([
       'layout' => self::$layouts['customMulti'],
-      'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
     ]);
     $firstName = uniqid(__FUNCTION__);
     $values = [

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformFileUploadTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformFileUploadTest.php
@@ -1,4 +1,5 @@
 <?php
+namespace api\v4\Afform;
 
 /**
  * Test case for Afform.prefill and Afform.submit.
@@ -13,7 +14,7 @@ use Civi\Api4\CustomGroup;
 
 require_once __DIR__ . '/AfformTestCase.php';
 require_once __DIR__ . '/AfformUsageTestCase.php';
-class api_v4_AfformFileUploadTest extends api_v4_AfformUsageTestCase {
+class AfformFileUploadTest extends AfformUsageTestCase {
 
   public static function setUpBeforeClass(): void {
     parent::setUpBeforeClass();
@@ -74,7 +75,7 @@ EOHTML;
 
     $this->useValues([
       'layout' => self::$layouts['customFiles'],
-      'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
     ]);
 
     $lastName = uniqid(__FUNCTION__);

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformPrefillUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformPrefillUsageTest.php
@@ -1,4 +1,5 @@
 <?php
+namespace api\v4\Afform;
 
 use Civi\Api4\Afform;
 
@@ -7,7 +8,7 @@ use Civi\Api4\Afform;
  *
  * @group headless
  */
-class api_v4_AfformPrefillUsageTest extends api_v4_AfformUsageTestCase {
+class AfformPrefillUsageTest extends AfformUsageTestCase {
   use \Civi\Test\Api4TestTrait;
 
   /**
@@ -35,7 +36,7 @@ EOHTML;
 
     $this->useValues([
       'layout' => $layout,
-      'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
     ]);
 
     $cid = $this->saveTestRecords('Contact', [
@@ -120,7 +121,7 @@ EOHTML;
 
     $this->useValues([
       'layout' => $layout,
-      'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
     ]);
 
     $uid = $this->createLoggedInUser();

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformRelationshipUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformRelationshipUsageTest.php
@@ -1,4 +1,5 @@
 <?php
+namespace api\v4\Afform;
 
 use Civi\Api4\Afform;
 use Civi\Api4\Contact;
@@ -10,7 +11,7 @@ use Civi\Api4\RelationshipType;
  *
  * @group headless
  */
-class api_v4_AfformRelationshipUsageTest extends api_v4_AfformUsageTestCase {
+class AfformRelationshipUsageTest extends AfformUsageTestCase {
 
   /**
    * Tests creating a relationship between multiple contacts
@@ -34,7 +35,7 @@ EOHTML;
 
     $this->useValues([
       'layout' => $layout,
-      'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
     ]);
 
     $lastName = uniqid(__FUNCTION__);
@@ -91,7 +92,7 @@ EOHTML;
 
     $this->useValues([
       'layout' => $layout,
-      'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
     ]);
 
     $types = [
@@ -162,7 +163,7 @@ EOHTML;
 
     $this->useValues([
       'layout' => $layout,
-      'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
     ]);
 
     $contact = Contact::save(FALSE)

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformRoutingTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformRoutingTest.php
@@ -1,4 +1,5 @@
 <?php
+namespace api\v4\Afform;
 
 use Civi\Api4\Afform;
 
@@ -6,7 +7,7 @@ use Civi\Api4\Afform;
  * Ensure that the routes created by Afform are working.
  * @group e2e
  */
-class api_v4_AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \Civi\Test\EndToEndInterface {
+class AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \Civi\Test\EndToEndInterface {
 
   protected $formName = 'mockPage';
 
@@ -35,7 +36,7 @@ class api_v4_AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \C
   public function testChangingPermissions(): void {
     $http = new \GuzzleHttp\Client(['http_errors' => FALSE]);
     $url = function ($path, $query = NULL) {
-      return CRM_Utils_System::url($path, $query, TRUE, NULL, FALSE);
+      return \CRM_Utils_System::url($path, $query, TRUE, NULL, FALSE);
     };
 
     $result = $http->get($url('civicrm/mock-page'));
@@ -44,7 +45,7 @@ class api_v4_AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \C
     Afform::update()
       ->setCheckPermissions(FALSE)
       ->addWhere('name', '=', $this->formName)
-      ->addValue('permission', CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION)
+      ->addValue('permission', \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION)
       ->execute();
 
     $result = $http->get($url('civicrm/mock-page'));
@@ -54,13 +55,13 @@ class api_v4_AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \C
   public function testChangingPath(): void {
     $http = new \GuzzleHttp\Client(['http_errors' => FALSE]);
     $url = function ($path, $query = NULL) {
-      return CRM_Utils_System::url($path, $query, TRUE, NULL, FALSE);
+      return \CRM_Utils_System::url($path, $query, TRUE, NULL, FALSE);
     };
 
     Afform::update()
       ->setCheckPermissions(FALSE)
       ->addWhere('name', '=', $this->formName)
-      ->addValue('permission', CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION)
+      ->addValue('permission', \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION)
       ->execute();
 
     $this->assertOpensPage($http->get($url('civicrm/mock-page')), 'mock-page');
@@ -77,10 +78,10 @@ class api_v4_AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \C
   }
 
   /**
-   * @param $result
+   * @param \Psr\Http\Message\ResponseInterface $result
    * @param string $directive
    */
-  private function assertNotAuthorized(Psr\Http\Message\ResponseInterface $result, $directive) {
+  private function assertNotAuthorized(\Psr\Http\Message\ResponseInterface $result, string $directive) {
     $contents = $result->getBody()->getContents();
     $this->assertEquals(403, $result->getStatusCode());
     $this->assertMatchesRegularExpression(';You are not authorized to access;', $contents);
@@ -88,11 +89,11 @@ class api_v4_AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \C
   }
 
   /**
-   * @param $result
+   * @param \Psr\Http\Message\ResponseInterface $result
    * @param string $directive
    *   The name of the directive which auto-opens.
    */
-  private function assertOpensPage(Psr\Http\Message\ResponseInterface $result, $directive) {
+  private function assertOpensPage(\Psr\Http\Message\ResponseInterface $result, string $directive) {
     $contents = $result->getBody()->getContents();
     $this->assertEquals(200, $result->getStatusCode());
     $this->assertDoesNotMatchRegularExpression(';You are not authorized to access;', $contents);

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformTest.php
@@ -1,4 +1,5 @@
 <?php
+namespace api\v4\Afform;
 
 use Civi\Api4\Afform;
 use Civi\Api4\Dashboard;
@@ -8,7 +9,7 @@ use Civi\Api4\Dashboard;
  * This is a generic test class implemented with PHPUnit.
  * @group headless
  */
-class api_v4_AfformTest extends api_v4_AfformTestCase {
+class AfformTest extends AfformTestCase {
   use \Civi\Test\Api3TestTrait;
   use \Civi\Test\ContactTestTrait;
 
@@ -131,7 +132,7 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
   public function getFormatExamples() {
     $ex = [];
     $formats = ['html', 'shallow', 'deep'];
-    foreach (glob(__DIR__ . '/formatExamples/*.php') as $exampleFile) {
+    foreach (glob(__DIR__ . '/../formatExamples/*.php') as $exampleFile) {
       $example = require $exampleFile;
       if (isset($example['deep'])) {
         foreach ($formats as $updateFormat) {
@@ -227,7 +228,7 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
 
   public function getWhitespaceExamples() {
     $ex = [];
-    foreach (glob(__DIR__ . '/formatExamples/*.php') as $exampleFile) {
+    foreach (glob(__DIR__ . '/../formatExamples/*.php') as $exampleFile) {
       $example = require $exampleFile;
       if (isset($example['pretty'])) {
         $ex[] = ['mockBareFile', $example, $exampleFile];
@@ -278,7 +279,7 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
 
     // The default mockPage has 1 explicit requirement + 2 automatic requirements.
     Afform::revert()->addWhere('name', '=', $formName)->execute();
-    $angModule = Civi::service('angular')->getModule($formName);
+    $angModule = \Civi::service('angular')->getModule($formName);
     sort($angModule['requires']);
     $storedRequires = Afform::get()->addWhere('name', '=', $formName)->addSelect('requires')->execute();
     $this->assertEquals(['afCore', 'mockBareFile', 'mockBespoke', 'mockFoo'], $angModule['requires']);
@@ -290,7 +291,7 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
       ->setLayoutFormat('html')
       ->setValues(['layout' => '<div>The bare file says "<mock-bare-file/>"</div>'])
       ->execute();
-    $angModule = Civi::service('angular')->getModule($formName);
+    $angModule = \Civi::service('angular')->getModule($formName);
     sort($angModule['requires']);
     $storedRequires = Afform::get()->addWhere('name', '=', $formName)->addSelect('requires')->execute();
     $this->assertEquals(['afCore', 'mockBareFile', 'mockBespoke'], $angModule['requires']);
@@ -305,13 +306,13 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
         'requires' => [],
       ])
       ->execute();
-    $angModule = Civi::service('angular')->getModule($formName);
+    $angModule = \Civi::service('angular')->getModule($formName);
     $this->assertEquals(['afCore'], $angModule['requires']);
     $storedRequires = Afform::get()->addWhere('name', '=', $formName)->addSelect('requires')->execute();
     $this->assertEquals([], $storedRequires[0]['requires']);
 
     Afform::revert()->addWhere('name', '=', $formName)->execute();
-    $angModule = Civi::service('angular')->getModule($formName);
+    $angModule = \Civi::service('angular')->getModule($formName);
     sort($angModule['requires']);
     $this->assertEquals(['afCore', 'mockBareFile', 'mockBespoke', 'mockFoo'], $angModule['requires']);
   }

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformTestCase.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformTestCase.php
@@ -1,4 +1,5 @@
 <?php
+namespace api\v4\Afform;
 
 use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
@@ -6,7 +7,7 @@ use Civi\Test\TransactionalInterface;
 /**
  * Base class for Afform API tests.
  */
-abstract class api_v4_AfformTestCase extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
+abstract class AfformTestCase extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
 
   /**
    * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
@@ -23,8 +24,8 @@ abstract class api_v4_AfformTestCase extends \PHPUnit\Framework\TestCase impleme
    */
   public function setUp(): void {
     parent::setUp();
-    CRM_Core_Config::singleton()->userPermissionTemp = new CRM_Core_Permission_Temp();
-    CRM_Core_Config::singleton()->userPermissionTemp->grant('administer CiviCRM');
+    \CRM_Core_Config::singleton()->userPermissionTemp = new \CRM_Core_Permission_Temp();
+    \CRM_Core_Config::singleton()->userPermissionTemp->grant('administer CiviCRM');
   }
 
 }

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformUsageTestCase.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformUsageTestCase.php
@@ -1,4 +1,5 @@
 <?php
+namespace api\v4\Afform;
 
 use Civi\Api4\Afform;
 
@@ -7,7 +8,7 @@ use Civi\Api4\Afform;
  *
  * @group headless
  */
-abstract class api_v4_AfformUsageTestCase extends api_v4_AfformTestCase {
+abstract class AfformUsageTestCase extends AfformTestCase {
   use \Civi\Test\Api3TestTrait;
   use \Civi\Test\ContactTestTrait;
 


### PR DESCRIPTION
Overview
----------------------------------------
Restructures the Afform tests to use PSR-4 because I could never get them to run in my IDE without hacking in some `require once`.

After this change... I still can't get them to run. But at least now they match the PSR structure of our other core/ext tests.

Still scratching my head about how to run them without hacks...