### PR TITLE
Remove extraneous set from previously shared code

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -977,7 +977,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         $this->_params['receipt_date'] = NULL;
       }
 
-      $this->set('params', $this->_params);
       //add contribution record
       $this->_params['mode'] = $this->_mode;
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove extraneous set from previously shared code

Before
----------------------------------------
The set is used in the online form - but not the backoffice form - I didn't find universe references

![image](https://github.com/civicrm/civicrm-core/assets/336308/1407c725-1a81-4419-8a0d-92cf44dcf3cd)


After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
