### PR TITLE
dev/core#4761 - CRM\Core\DAO - Generate unique name, case-insensitve

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -3417,38 +3417,71 @@ SELECT contact_id
     // unique suffix composed of an underscore + 4 alphanumeric chars,
     // supporting up to 36^4=1,679,616 unique names for any given value of
     // $label. Half that amount could be considered the working limit, as
-    // much above that the time to find a non-existent value becomes
+    // much above that the time to find a non-existent suffix becomes
     // unacceptable.
     $maxSuffixLen = 5;
     $maxLen = static::getSupportedFields()['name']['maxlength'] ?? 255;
     $name = CRM_Utils_String::munge($label, '_', $maxLen - $maxSuffixLen);
-    $name_lc = strtolower($name);
 
-    // Find existing records with the same name.
-    // The default 'name' column collation, and thus the index on which it is
-    // based, is case-insensitive, so we'll use the lower-case version of $name
-    // from now on to avoid confusion and to support the unexpected case of a
-    // name column with case-sensitive collation.
-    $sql = new CRM_Utils_SQL_Select($this::getTableName());
-    $sql->select(['id', 'name']);
-    $sql->where('name LIKE @name', ['@name' => $name_lc . '%']);
-    // Include all fields that are part of the index
-    foreach (array_diff($indexNameWith, ['name']) as $field) {
-      $sql->where("`$field` = @val", ['@val' => $this->$field]);
-    }
-    $query = $sql->toSQL();
-    $existing = self::executeQuery($query)->fetchMap('id', 'name');
-    $suffix = '';
+    // Define an arbitrary limit on how many guesses we will perform before
+    // throwing an exception. This would occur only in some unanticipated use
+    // case.
+    $max_guesses = 36 ^ ($maxSuffixLen - 1);
 
-    // Add a unique suffix if there exists a record having the same name. The
-    // comparison is performed case-insensitive to support both case-sensitive
-    // and insensitive collation.
-    $existing_lc = array_map('strtolower', $existing);
+    $guesses_per_loop = 5;
+    $guess_count = 0;
 
-    while (in_array($name_lc . $suffix, $existing_lc)) {
-      $suffix = '_' . CRM_Utils_String::createRandom($maxSuffixLen - 1, 'abcdefghijklmnopqrstuvwxyz0123456789');
-    }
-    $this->name = $name_lc . $suffix;
+    do {
+      // Make an initial attempt to guess a unique name by searching for
+      // 5 candidates (the original $name plus $name with 4 random suffixes).
+      // If all of these happen to exist in the table, we'll keep trying,
+      // doubling the number of guesses each time through the loop.
+      for ($i = 0; $i < $guesses_per_loop; $i++, $guess_count++) {
+        $suffix = $guess_count == 0 ? '' :
+          '_' . CRM_Utils_String::createRandom($maxSuffixLen - 1, 'abcdefghijklmnopqrstuvwxyz0123456789');
+        $candidates[$i] = $name . $suffix;
+      }
+
+      $sql = new CRM_Utils_SQL_Select($this::getTableName());
+      $sql->select(['id', 'LOWER(name) name_lc']);
+      $sql->where('name IN (@candidates)', ['@candidates' => $candidates]);
+
+      // Narrow the search by specifying the value of any additional fields
+      // that may be part of the index.
+      foreach (array_diff($indexNameWith, ['name']) as $field) {
+        $sql->where("`$field` = @val", ['@val' => $this->$field]);
+      }
+      $query = $sql->toSQL();
+
+      // Search the table for our candidates using case-sensitivity determined
+      // by the collation of the name column -- case-insensitive by default.
+      // Array $existing_lc will contains all the candidates found in the table,
+      // converted to lower-case.
+      $existing_lc = self::executeQuery($query)->fetchMap('id', 'name_lc');
+
+      if (count($existing_lc) < $guesses_per_loop) {
+        // Not all of our candidates were found in the table, so we'll search
+        // for the first element of $candidates that wasn't found. This search
+        // is performed case-insensitive to ensure that the selected candidate
+        // is unique with both ci and cs collation of the name column. If the
+        // original (unsuffixed) value of $name doesn't exist in the table, then
+        // that value will be our selected candidate.
+        foreach ($candidates as $c) {
+          if (!in_array(strtolower($c), $existing_lc)) {
+            $this->name = $c;
+            return;
+          }
+        }
+      }
+      else {
+        // All candidates were found in the table. Try harder next time.
+        $guesses_per_loop = min(1000, $guesses_per_loop * 2);
+
+        if ($guess_count > $max_guesses) {
+          throw new CRM_Core_Exception("CRM_Core_DAO::makeNameFromLabel failed to generate a unique name for label $label.");
+        }
+      }
+    } while (1);
   }
 
   /**

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
@@ -74,10 +74,12 @@ class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessI
       ->addValue('label', 'My test search')
       ->execute()->first();
     // Name will be created from munged label
-    $this->assertEquals('My_test_search', $savedSearch0['name']);
-    // Name will have _1, _2, etc. appended to ensure it's unique
-    $this->assertEquals('My_test_search_1', $savedSearch1['name']);
-    $this->assertEquals('My_test_search_2', $savedSearch2['name']);
+    $this->assertEquals('My_test_search', $savedSearch0['name'], "SavedSearch 0");
+    // Name will have _r appended to ensure it's unique, where r is a string of
+    // random chars.
+    $this->assertEquals('My_test_search_', substr($savedSearch1['name'], 0, 15), "SavedSearch 1");
+    $this->assertEquals('My_test_search_', substr($savedSearch2['name'], 0, 15), "SavedSearch 2");
+    $this->assertNotSame($savedSearch1['name'], $savedSearch2['name'], "SavedSearch 1,2");
 
     $display0 = SearchDisplay::create()
       ->addValue('saved_search_id', $savedSearch0['id'])
@@ -95,11 +97,12 @@ class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessI
       ->addValue('type', 'table')
       ->execute()->first();
     // Name will be created from munged label
-    $this->assertEquals('My_test_display', $display0['name']);
-    // Name will have _1 appended to ensure it's unique to savedSearch0
-    $this->assertEquals('My_test_display_1', $display1['name']);
-    // This is for a different saved search so doesn't need a number appended
-    $this->assertEquals('My_test_display', $display2['name']);
+    $this->assertEquals('My_test_display', $display0['name'], "SearchDisplay 0");
+    // Name will have _r appended (r is random string) to ensure it's unique to
+    // savedSearch0.
+    $this->assertEquals('My_test_display_', substr($display1['name'], 0, 16), "SearchDisplay 1");
+    // This is for a different saved search so doesn't need a suffix appended
+    $this->assertEquals('My_test_display', $display2['name'], "SearchDisplay 2");
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Modified CRM\Core\DAO::makeNameFromLabel() to ensure that `name` values derived from the value of a label are unique in a case-insensitive context, as required by the `name` column's case-insensitive collation.

Before
----------------------------------------
* `name` was generated with case-sensitive uniqueness, causing failures when saving reminders or copying events. The modified function is believed to be used in other contexts as well, so there were potentially other failure modes.
* `name` was generated based on the value of label truncated at `columnWidth('name') - 3`. The 3-character suffix (an underscore + 2 digits) supported uniquifying only 100 names formed for any given value of label of that length or greater.

After
----------------------------------------
* `name` is generated with case-insensitive uniqueness, supporting both case-insensitive (default) and case-sensitive collation (should that ever be needed).
* A 5-character suffix is used (underscore + 4 alphanumerics), supporting generation of over 800,000 names from any given value of label (truncated at `columnWidth('name') - 5`).

Technical Details
----------------------------------------
underscore + 4 alphanumeric chars supports up to 36^4=1,679,616 unique names for any given value of label. However, as we approach all of the possible values for any given value of label being already present, the required number of guesses increases exponentially. With 50% of the possible values present, there is a 1/(2<sup>1</sup>) or 50% chance of failing to guess a unique value on the first try, and 1/(2<sup>20</sup>) or 0.000095% chance of failing to guess a unique value by the 20th try. It is expected that in all imaginable real scenarios, a unique value will be achieved on the first or second guess.

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
