### PR TITLE
(NFC) setting-admin@1 - Fix the `@since` metadata

### DIFF
--- a/mixin/setting-admin@1/mixin.php
+++ b/mixin/setting-admin@1/mixin.php
@@ -23,7 +23,7 @@
  *   <civix><setting-page-title>My Custom Title</setting-page-title></civix>
  *
  * @mixinName setting-admin
- * @mixinVersion 1.0.0
+ * @mixinVersion 1.1.0
  * @since 5.68
  */
 

--- a/mixin/setting-admin@1/mixin.php
+++ b/mixin/setting-admin@1/mixin.php
@@ -24,7 +24,7 @@
  *
  * @mixinName setting-admin
  * @mixinVersion 1.0.0
- * @since 5.67
+ * @since 5.68
  */
 
 namespace Civi\Mixin\SettingAdminV1;


### PR DESCRIPTION
Overview
----------------------------------------

The code was originally written during 5.67.alpha and then merged during 5.68.alpha. So the `@since` is slightly off.

Follow-up to #27569