### PR TITLE
Fix tax total not showing on thank you

### DIFF
--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -78,6 +78,8 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
 
   /**
    * Build the form object.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function buildQuickForm() {
     // FIXME: Some of this code is identical to Confirm.php and should be broken out into a shared function
@@ -109,10 +111,10 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
           }
         }
       }
-      $this->assign('getTaxDetails', $getTaxDetails);
-      $this->assign('taxTerm', CRM_Invoicing_Utils::getTaxTerm());
-      $this->assign('totalTaxAmount', $params['tax_amount']);
     }
+    $this->assign('getTaxDetails', (bool) $this->order->getTotalTaxAmount());
+    $this->assign('totalTaxAmount', $this->order->getTotalTaxAmount());
+    $this->assign('taxTerm', \Civi::settings()->get('tax_term'));
 
     if ($this->_priceSetId && !CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $this->_priceSetId, 'is_quick_config')) {
       $this->assign('lineItem', $tplLineItems);

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -385,6 +385,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $this->order = new CRM_Financial_BAO_Order();
       $this->order->setPriceSetID($this->getPriceSetID());
       $this->order->setIsExcludeExpiredFields(TRUE);
+      $this->order->setPriceSelectionFromUnfilteredInput($this->getSubmittedValues());
     }
     else {
       CRM_Core_Error::deprecatedFunctionWarning('forms require a price set ID');
@@ -1240,6 +1241,48 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    */
   protected function getExistingContributionID(): ?int {
     return $this->_ccid ?: CRM_Utils_Request::retrieve('ccid', 'Positive', $this);
+  }
+
+  /**
+   * Get the submitted value, accessing it from whatever form in the flow it is
+   * submitted on.
+   *
+   * @param string $fieldName
+   *
+   * @return mixed|null
+   */
+  public function getSubmittedValue(string $fieldName) {
+    $value = $this->controller->exportValue('Main', $fieldName);
+    if (in_array($fieldName, $this->submittableMoneyFields, TRUE)) {
+      return CRM_Utils_Rule::cleanMoney($value);
+    }
+
+    // Numeric fields are not in submittableMoneyFields (for now)
+    $fieldRules = $this->_rules[$fieldName] ?? [];
+    foreach ($fieldRules as $rule) {
+      if ('money' === $rule['type']) {
+        return CRM_Utils_Rule::cleanMoney($value);
+      }
+    }
+    return $value;
+  }
+
+  /**
+   * Get the fields that can be submitted in this form flow.
+   *
+   * This is overridden to make the fields submitted on the first
+   * form (Contribution_Main) available from the others in the same flow
+   * (Contribution_Confirm, Contribution_ThankYou).
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @return string[]
+   */
+  protected function getSubmittableFields(): array {
+    $fieldNames = array_keys($this->controller->exportValues('Main'));
+    return array_fill_keys($fieldNames, $this->_name);
   }
 
   /**

--- a/api/v3/ContributionPage.php
+++ b/api/v3/ContributionPage.php
@@ -103,12 +103,23 @@ function civicrm_api3_contribution_page_validate($params) {
   // one being generated so we generate one first.
   $originalRequest = $_REQUEST;
   $qfKey = $_REQUEST['qfKey'] ?? NULL;
-  if (!$qfKey) {
-    $_REQUEST['qfKey'] = CRM_Core_Key::get('CRM_Core_Controller', TRUE);
-  }
+  $_REQUEST['id'] = $params['id'];
+  $requestMethod = $_SERVER['REQUEST_METHOD'] ?? NULL;
+  // This is set to POST in a test - (probably cos we didn't have full form
+  // testing when it was written). It needs to be get for long enough to
+  // get past the constructor.
+  $_SERVER['REQUEST_METHOD'] = 'GET';
   $form = new CRM_Contribute_Form_Contribution_Main();
-  $form->controller = new CRM_Core_Controller();
-  $form->set('id', $params['id']);
+  $form->controller = new CRM_Contribute_Controller_Contribution();
+  if ($requestMethod) {
+    $_SERVER['REQUEST_METHOD'] = $requestMethod;
+  }
+  $form->controller->setStateMachine(new CRM_Contribute_StateMachine_Contribution($form->controller));
+  // The submitted values are on the Main form.
+  $_SESSION['_' . $form->controller->_name . '_container']['values']['Main'] = $params;
+  if (!$qfKey) {
+    $_REQUEST['qfKey'] = CRM_Core_Key::get('CRM_Contribute_Controller_Contribution', TRUE);
+  }
   $form->preProcess();
   $errors = CRM_Contribute_Form_Contribution_Main::formRule($params, [], $form);
   if ($errors === TRUE) {

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ThankYouTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ThankYouTest.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Test\ContributionPageTestTrait;
+
 /**
  *  Test CRM_Contribute_Form_Contribution_ThankYou
  *
@@ -17,6 +19,8 @@
  * @group headless
  */
 class CRM_Contribute_Form_Contribution_ThankYouTest extends CiviUnitTestCase {
+
+  use ContributionPageTestTrait;
 
   /**
    * Clean up DB.
@@ -60,13 +64,16 @@ class CRM_Contribute_Form_Contribution_ThankYouTest extends CiviUnitTestCase {
   /**
    * Get CRM_Contribute_Form_Contribution_ThankYou form with attached contribution.
    *
-   * @param $paymentProcessorID
+   * @param int $paymentProcessorID
    * @param bool $withPendingContribution
    * @param bool $isTestContribution
    * @return CRM_Contribute_Form_Contribution_ThankYou
    */
-  private function getThankYouFormWithContribution($paymentProcessorID, $withPendingContribution = FALSE, $isTestContribution = FALSE) {
+  private function getThankYouFormWithContribution(int $paymentProcessorID, $withPendingContribution = FALSE, $isTestContribution = FALSE) {
     $pageContribution = $this->getPageContribution((($withPendingContribution) ? 2 : 1), $isTestContribution);
+    if (!isset($this->ids['ContributionPage'])) {
+      $this->contributionPageCreatePaid(['payment_processor' => $paymentProcessorID])['id'];
+    }
     $form = $this->getThankYouForm();
     $form->_lineItem = [];
     $form->_bltID = 5;
@@ -76,8 +83,9 @@ class CRM_Contribute_Form_Contribution_ThankYouTest extends CiviUnitTestCase {
     $form->_params['email-5'] = 'demo@example.com';
     $form->_params['payment_processor_id'] = $paymentProcessorID;
     if ($isTestContribution) {
-      $form->_mode = 'test';
+      $_REQUEST['action'] = 1024;
     }
+
     $form->_values = [
       'custom_pre_id' => NULL,
       'custom_post_id' => NULL,
@@ -116,9 +124,8 @@ class CRM_Contribute_Form_Contribution_ThankYouTest extends CiviUnitTestCase {
    * @return CRM_Contribute_Form_Contribution_ThankYou
    */
   private function getThankYouForm() {
-    $form = new CRM_Contribute_Form_Contribution_ThankYou();
-    $_SERVER['REQUEST_METHOD'] = 'GET';
-    $form->controller = new CRM_Contribute_Controller_Contribution();
+    $form = $this->getFormObject('CRM_Contribute_Form_Contribution_ThankYou', [], ['id' => $this->getContributionPageID()]);
+    $form->preProcess();
     return $form;
   }
 

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2983,6 +2983,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
         break;
 
       case 'CRM_Contribute_Form_Contribution_Confirm':
+      case 'CRM_Contribute_Form_Contribution_ThankYou':
         $form->controller = new CRM_Contribute_Controller_Contribution();
         $form->controller->setStateMachine(new CRM_Contribute_StateMachine_Contribution($form->controller));
         // The submitted values are on the Main form.


### PR DESCRIPTION
Overview
----------------------------------------
Fix tax total not showing on thank you

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/45cdb8a2-907c-425e-a501-771488cea47f)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/6fe88091-c203-4952-a693-d6c235cc44fa)

I also tested with a discount

![image](https://github.com/civicrm/civicrm-core/assets/336308/7ab763ff-3cb2-4ab6-89e1-0dc5b6001cac)



Technical Details
----------------------------------------
This adds support for calling `getSubmittedValue()` & `getSubmittedValues()` from anywhere in the flow, similar to what has been used to simplify the Import forms - but it is only used in this very narrow assign instance

Comments
----------------------------------------
