### PR TITLE
Align online membership receipt with other templates for line items, tax

### DIFF
--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -425,7 +425,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     $this->assertCount(2, $contributions);
     $this->callAPISuccess('membership_payment', 'getsingle', ['contribution_id' => ['IN' => array_keys($contributions)]]);
     $mut->checkMailLog([
-      'Membership Amount',
+      'Membership Fee',
       '$2.00',
     ]);
     $mut->stop();


### PR DESCRIPTION

Overview
----------------------------------------
Align online membership receipt with other templates for line items, tax

This uses the same code as the offline for the online which

1) removes the last usage on the mystical 'dataArray', allowing us to deprecate it and remove a lot of code
2) fixes one of the 3 known smarty3 issues in core


Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/6e654ec1-4c2d-4425-a24f-39ba62b2af3a)

After
----------------------------------------
Per the screenshot - no discernable change

![image](https://github.com/civicrm/civicrm-core/assets/336308/0ee6854e-5271-4784-85b1-ae92a07bf353)


Technical Details
----------------------------------------
I've spent a lot of time breaking my brain on the complexity of this template - however most of that complexity relates to the separate payment flow - which is mutually exclusive with the not-quick-config / show line items flow. So in the end this change doesn't touch that stuff.

It does remove the handling for suppressing the membership start date & end data columns if you are sending this membership receipt on a purchase that does not include any memberships.

However, I tested that scenario & found it to be unreachable due to form validation

![image](https://github.com/civicrm/civicrm-core/assets/336308/e44a92ca-f4c4-412d-aa17-7f3caeb6501c)


Comments
----------------------------------------
