### PR TITLE
Show membership info on pay later receipts

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2632,7 +2632,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         foreach ($this->_relatedObjects['membership'] as $membership) {
           if ($membership->id) {
             $values['membership_id'] = $membership->id;
-            $values['isMembership'] = TRUE;
             $values['membership_assign'] = TRUE;
 
             // need to set the membership values here

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -405,11 +405,18 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
       }
 
       // use either the contribution or membership receipt, based on whether it’s a membership-related contrib or not
+      $tokenContext = ['contactId' => (int) $contactID];
+      if (!empty($tplParams['contributionID'])) {
+        $tokenContext['contributionId'] = $tplParams['contributionID'];
+      }
+      if (!empty($values['membership_id'])) {
+        $tokenContext['membershipId'] = $values['membership_id'];
+      }
       $sendTemplateParams = [
-        'workflow' => !empty($values['isMembership']) ? 'membership_online_receipt' : 'contribution_online_receipt',
+        'workflow' => !empty($values['membership_id']) ? 'membership_online_receipt' : 'contribution_online_receipt',
         'contactId' => $contactID,
         'tplParams' => $tplParams,
-        'tokenContext' => $tplParams['contributionID'] ? ['contributionId' => (int) $tplParams['contributionID'], 'contactId' => $contactID] : ['contactId' => $contactID],
+        'tokenContext' => $tokenContext,
         'isTest' => $isTest,
         'PDFFilename' => 'receipt.pdf',
       ];

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1437,7 +1437,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $membershipContribution = NULL;
     $isTest = $membershipParams['is_test'] ?? FALSE;
     $errors = $paymentResults = [];
-    $this->_values['isMembership'] = TRUE;
+
     $isRecurForFirstTransaction = $this->_params['is_recur'] ?? $membershipParams['is_recur'] ?? NULL;
 
     $totalAmount = $membershipParams['amount'];
@@ -1586,7 +1586,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
           //CRM-15232: Check if membership is created and on the basis of it use
           //membership receipt template to send payment receipt
-          $this->_values['isMembership'] = TRUE;
+          $this->_values['membership_id'] = $membership->id;
         }
       }
       if ($this->_priceSetId && !empty($this->_useForMember) && !empty($this->_lineItem)) {
@@ -1670,6 +1670,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $emailValues = array_merge($membershipParams, $this->_values);
     $emailValues['membership_assign'] = 1;
     $emailValues['useForMember'] = !empty($this->_useForMember);
+    $emailValues['membership_id'] = !empty($membership) ? $membership->id : NULL;
 
     // Finally send an email receipt for pay-later scenario (although it might sometimes be caught above!)
     if ($totalAmount == 0) {

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -224,8 +224,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
       'Membership Information',
       'Membership Type       </td>
        <td style="padding: 4px; border-bottom: 1px solid #999;">
-        General
-       </td>',
+         General       </td>',
       '$1,000.00',
       'Membership Start Date',
       '************1111',

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -33,7 +33,7 @@
   </tr>
   </table>
   <table style="width:100%; max-width:500px; border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse;">
-    {if $membership_assign && !$useForMember}
+    {if {membership.id|boolean} && !$isShowLineItems}
       <tr>
        <th {$headerStyle}>
         {ts}Membership Information{/ts}
@@ -44,26 +44,26 @@
         {ts}Membership Type{/ts}
        </td>
        <td {$valueStyle}>
-        {$membership_name}
+         {ts}{membership.membership_type_id:name}{/ts}
        </td>
       </tr>
-      {if $mem_start_date}
+      {if {membership.start_date|boolean}}
        <tr>
         <td {$labelStyle}>
          {ts}Membership Start Date{/ts}
         </td>
         <td {$valueStyle}>
-         {$mem_start_date|crmDate}
+          {membership.start_date}
         </td>
        </tr>
       {/if}
-      {if $mem_end_date}
+      {if {membership.end_date|boolean}}
        <tr>
         <td {$labelStyle}>
          {ts}Membership Expiration Date{/ts}
         </td>
         <td {$valueStyle}>
-          {$mem_end_date|crmDate}
+          {membership.end_date}
         </td>
        </tr>
       {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Builds on https://github.com/civicrm/civicrm-core/pull/28181 & ensures that membership info is present on all quick config receipts, even when pay later

Before
----------------------------------------
Membership info missing on membership receipt when confirmed via pay later

After
----------------------------------------
Present 

Technical Details
----------------------------------------

Comments
----------------------------------------
