### PR TITLE
Finally remove `dataArray` , some notice fixes

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1429,23 +1429,8 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $contribution = CRM_Contribute_BAO_Contribution::add($contributionParams);
 
       if (Civi::settings()->get('invoicing')) {
-        $dataArray = [];
-        // @todo - interrogate the line items passed in on the params array.
-        // No reason to assume line items will be set on the form.
-        foreach ($form->_lineItem as $lineItemKey => $lineItemValue) {
-          foreach ($lineItemValue as $key => $value) {
-            if (isset($value['tax_amount']) && isset($value['tax_rate'])) {
-              if (isset($dataArray[$value['tax_rate']])) {
-                $dataArray[$value['tax_rate']] = $dataArray[$value['tax_rate']] + $value['tax_amount'];
-              }
-              else {
-                $dataArray[$value['tax_rate']] = $value['tax_amount'];
-              }
-            }
-          }
-        }
         $smarty = CRM_Core_Smarty::singleton();
-        $smarty->assign('dataArray', $dataArray);
+        // @todo - probably this assign is no longer needed as we use a token.
         $smarty->assign('totalTaxAmount', $params['tax_amount'] ?? NULL);
       }
     }
@@ -2026,11 +2011,9 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     foreach ($lineItem as $key => $value) {
       foreach ($value as $v) {
         if (isset($taxRate[(string) CRM_Utils_Array::value('tax_rate', $v)])) {
-          $taxRate[(string) $v['tax_rate']] = $taxRate[(string) $v['tax_rate']] + ($v['tax_amount'] ?? 0);
         }
         else {
           if (isset($v['tax_rate'])) {
-            $taxRate[(string) $v['tax_rate']] = $v['tax_amount'] ?? NULL;
             $getTaxDetails = TRUE;
           }
         }
@@ -2039,14 +2022,13 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     if ($action & CRM_Core_Action::UPDATE) {
       $totalTaxAmount = $submittedValues['tax_amount'] ?? $this->_values['tax_amount'];
+      // Assign likely replaced by a token
       $this->assign('totalTaxAmount', $totalTaxAmount);
-      $this->assign('dataArray', $taxRate);
     }
     else {
       if (!empty($submittedValues['price_set_id'])) {
         $this->assign('totalTaxAmount', $submittedValues['tax_amount']);
         $this->assign('getTaxDetails', $getTaxDetails);
-        $this->assign('dataArray', $taxRate);
       }
       else {
         $this->assign('totalTaxAmount', CRM_Utils_Array::value('tax_amount', $submittedValues));

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1054,26 +1054,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
       $contribution = CRM_Contribute_BAO_Contribution::add($contributionParams);
 
-      if (Civi::settings()->get('invoicing')) {
-        $dataArray = [];
-        // @todo - interrogate the line items passed in on the params array.
-        // No reason to assume line items will be set on the form.
-        foreach ($form->_lineItem as $lineItemKey => $lineItemValue) {
-          foreach ($lineItemValue as $key => $value) {
-            if (isset($value['tax_amount']) && isset($value['tax_rate'])) {
-              if (isset($dataArray[$value['tax_rate']])) {
-                $dataArray[$value['tax_rate']] = $dataArray[$value['tax_rate']] + $value['tax_amount'];
-              }
-              else {
-                $dataArray[$value['tax_rate']] = $value['tax_amount'];
-              }
-            }
-          }
-        }
-        $smarty = CRM_Core_Smarty::singleton();
-        $smarty->assign('dataArray', $dataArray);
-      }
-
       // lets store it in the form variable so postProcess hook can get to this and use it
       $form->_contributionID = $contribution->id;
     }

--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -282,16 +282,9 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
       $amountDue = ($input['amount'] - $amountPaid);
 
       // retrieving the subtotal and sum of same tax_rate
-      $dataArray = [];
       $subTotal = 0;
       $lineItem = CRM_Price_BAO_LineItem::getLineItemsByContributionID($contributionID);
       foreach ($lineItem as $taxRate) {
-        if (isset($dataArray[(string) $taxRate['tax_rate']])) {
-          $dataArray[(string) $taxRate['tax_rate']] = $dataArray[(string) $taxRate['tax_rate']] + ($taxRate['tax_amount'] ?? 0);
-        }
-        else {
-          $dataArray[(string) $taxRate['tax_rate']] = $taxRate['tax_amount'] ?? NULL;
-        }
         $subTotal += $taxRate['subTotal'] ?? 0;
       }
 
@@ -385,8 +378,6 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
         'notes' => $invoiceNotes,
         // @todo not used in shipped template from 5.53
         'lineItem' => $lineItem,
-        // @todo not used in shipped template from 5.53
-        'dataArray' => $dataArray,
         // @todo not used in shipped template from 5.52
         'refundedStatusId' => $refundedStatusId,
         // @todo not used in shipped template from 5.52

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -681,7 +681,6 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
 
       $entityTable = 'civicrm_participant';
       $totalTaxAmount = 0;
-      $dataArray = [];
       foreach ($this->_lineItem as $key => $value) {
         if ($value == 'skip') {
           continue;
@@ -698,17 +697,10 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
           foreach ($value as $line) {
             if (isset($line['tax_amount']) && isset($line['tax_rate'])) {
               $totalTaxAmount = $line['tax_amount'] + $totalTaxAmount;
-              if (isset($dataArray[$line['tax_rate']])) {
-                $dataArray[$line['tax_rate']] = $dataArray[$line['tax_rate']] + ($line['tax_amount'] ?? 0);
-              }
-              else {
-                $dataArray[$line['tax_rate']] = $line['tax_amount'] ?? NULL;
-              }
             }
           }
         }
       }
-      $this->assign('dataArray', $dataArray);
       $this->assign('totalTaxAmount', $totalTaxAmount);
     }
 
@@ -888,8 +880,6 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
             }
             if (\Civi::settings()->get('invoicing')) {
               $individual = $this->get('individual');
-              $dataArray[key($dataArray)] = $individual[$participantNum]['totalTaxAmt'];
-              $this->assign('dataArray', $dataArray);
               $this->assign('totalAmount', $individual[$participantNum]['totalAmtWithTax']);
               $this->assign('totalTaxAmount', $individual[$participantNum]['totalTaxAmt']);
               $this->assign('individual', [$individual[$participantNum]]);

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1253,21 +1253,6 @@ DESC limit 1");
           $priceFieldOp['start_date'] = $priceFieldOp['end_date'] = 'N/A';
         }
       }
-      if (Civi::settings()->get('invoicing')) {
-        $dataArray = [];
-        foreach ($lineItem[$this->_priceSetId] as $value) {
-          if (isset($value['tax_amount']) && isset($value['tax_rate'])) {
-            if (isset($dataArray[$value['tax_rate']])) {
-              $dataArray[$value['tax_rate']] = $dataArray[$value['tax_rate']] + CRM_Utils_Array::value('tax_amount', $value);
-            }
-            else {
-              $dataArray[$value['tax_rate']] = $value['tax_amount'] ?? NULL;
-            }
-          }
-        }
-
-        $this->assign('dataArray', $dataArray);
-      }
     }
     $this->assign('lineItem', !empty($lineItem) && !$isQuickConfig ? $lineItem : FALSE);
 

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1762,17 +1762,23 @@ class CRM_Utils_Token {
       'WorkFlowMessageTemplates' => [
         'contribution_invoice_receipt' => [
           '$display_name' => 'contact.display_name',
+          '$dataArray' => ts('found within $taxBreakDown'),
         ],
         'contribution_online_receipt' => [
           '$contributeMode' => ts('no longer available / relevant'),
           '$first_name' => 'contact.first_name',
           '$last_name' => 'contact.last_name',
           '$displayName' => 'contact.display_name',
+          '$dataArray' => ts('found within $taxBreakDown'),
         ],
         'membership_offline_receipt' => [
           // receipt_text_renewal appears to be long gone.
           'receipt_text_renewal' => 'receipt_text',
           '$isAmountZero' => ts('no longer available / relevant'),
+          '$dataArray' => ts('found within $taxBreakDown'),
+        ],
+        'membership_online_receipt' => [
+          '$dataArray' => ts('found within $taxBreakDown'),
         ],
         'event_offline_receipt' => [
           '$contributeMode' => ts('no longer available / relevant'),
@@ -1800,6 +1806,7 @@ class CRM_Utils_Token {
         ],
         'event_online_receipt' => [
           '`$participant.id`' => 'participant.id',
+          '$dataArray' => ts('found within $taxBreakDown'),
         ],
         'pledge_acknowledgement' => [
           '$domain' => ts('no longer available / relevant'),

--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -36,7 +36,7 @@
         {if $isDisplayLineItems && $lineItem}
           {if !$amount}{assign var="amount" value=0}{/if}
           {assign var="totalAmount" value=$amount}
-          {include file="CRM/Price/Page/LineItem.tpl" context="Contribution"}
+          {include file="CRM/Price/Page/LineItem.tpl" context="Contribution" displayLineItemFinancialType=false pricesetFieldsCount=false currencySymbol='' hookDiscount=''}
         {elseif $is_separate_payment}
           {if $amount AND $minimum_fee}
             {$membership_name} {ts}Membership{/ts}:

--- a/tests/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/tests/templates/message_templates/contribution_online_receipt_html.tpl
@@ -133,12 +133,7 @@
   {/foreach}
  {/foreach}
  {/if}
- {if !empty($dataArray)}
- {foreach from=$dataArray item=value key=priceset}
-    dataArray: priceset:::$priceset
-    dataArray: value:::$value
- {/foreach}
- {/if}
+
  {if !empty($honoreeProfile)}
  {foreach from=$honoreeProfile item=value key=label}
     honoreeProfile: label:::$label

--- a/tests/templates/message_templates/event_online_receipt_text.tpl
+++ b/tests/templates/message_templates/event_online_receipt_text.tpl
@@ -70,10 +70,6 @@ part:::{foreach from=$part item=value key=key}
 {/foreach}
 {/if}
 
-{if !empty($dataArray)}
-dataArray:::{$dataArray}
-{/if}
-
 {if isset($totalTaxAmount)}
 totalTaxAmount:::{$totalTaxAmount}
 {/if}

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -24,9 +24,8 @@
     {if !empty($receipt_text)}
      <p>{$receipt_text|htmlize}</p>
     {/if}
-
-    {if $is_pay_later}
-     <p>{$pay_later_receipt}</p> {* FIXME: this might be text rather than HTML *}
+    {if {contribution.balance_amount|boolean} && {contribution.is_pay_later|boolean}}
+      <p>{contribution.pay_later_receipt}</p>
     {/if}
 
    </td>


### PR DESCRIPTION
Overview
----------------------------------------
Finally remove dataArray variable which was dumb & is no longer used

Before
----------------------------------------
Once upon a time someone thought `dataArray` was a useful variable name - no-one knew what it meant

After
----------------------------------------
`dataArray` turned out to be an array of taxes. We replaced the last instance of it with `taxBreakdown` this release - this PR completes the removal / deprecation

Technical Details
----------------------------------------
The PR contains a couple of commits that address notices hit during testing (ie https://github.com/civicrm/civicrm-core/pull/28195 ) & [some fixes on the lineItem include](https://github.com/civicrm/civicrm-core/pull/28205)

Comments
----------------------------------------
