### PR TITLE
add Member Signup/Renewal status to membership online receipt

### DIFF
--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -25,7 +25,7 @@
      <p>{$receipt_text|htmlize}</p>
     {/if}
 
-    {if $is_pay_later}
+    {if '{contribution.contribution_status_id:name}' === 'Pending'}
      <p>{$pay_later_receipt}</p> {* FIXME: this might be text rather than HTML *}
     {/if}
 

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -25,7 +25,7 @@
      <p>{$receipt_text|htmlize}</p>
     {/if}
 
-    {if '{contribution.contribution_status_id:name}' === 'Pending'}
+    {if '{contribution.contribution_status_id:name}' === 'Pending' && {contribution.is_pay_later|boolean}}
      <p>{$pay_later_receipt}</p> {* FIXME: this might be text rather than HTML *}
     {/if}
 

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -41,6 +41,14 @@
       </tr>
       <tr>
        <td {$labelStyle}>
+        {ts}Membership Status{/ts}
+       </td>
+       <td {$valueStyle}>
+         Member {if empty('{latestcurrentmembership.status}') or '{latestcurrentmembership.status}' == 'New'}Signup{else}Renewal{/if}
+       </td>
+      </tr>
+      <tr>
+       <td {$labelStyle}>
         {ts}Membership Type{/ts}
        </td>
        <td {$valueStyle}>

--- a/xml/templates/message_templates/membership_online_receipt_subject.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_subject.tpl
@@ -1,1 +1,1 @@
-{if '{contribution.contribution_status_id:name}' === 'Pending'}{ts}Invoice{/ts}{else}{ts}Receipt{/ts}{/if} - {$title} - {contact.display_name}
+{if '{contribution.contribution_status_id:name}' === 'Pending'}{ts}Invoice{/ts}{else}{ts}Receipt{/ts}{/if} - Member {if empty('{latestcurrentmembership.status}') or '{latestcurrentmembership.status}' == 'New'}Signup{else}Renewal{/if}: {$membership_name} - {contact.display_name}


### PR DESCRIPTION
Overview
----------------------------------------
Add Membership Status to the Subject and body of the `membership_online_receipt` Message Template.
In the Subject, replacing the title of the form, which by default seems to be `Member Signup and Renewal` with the Membership Status of `Signup` or `Renewal`.

Before
----------------------------------------
No mention of Signup versus Renewal in the receipt.

Example Subject:
`Receipt - Member Signup and Renewal - Firstname Lastname`

Example Body (partial section):
```
Membership Information
--
Membership Type       | Full Membership
Membership Start Date | March 15th, 2022
Membership End Date   | April 9th, 2024
```

After
----------------------------------------
Includes `Member Signup` or `Member Renewal` in the Subject and body of the `membership_online_receipt` Message Template.

`Subject: Receipt - Member Renewal: Full Membership - Firstname Lastname`

Example Body (partial section):
```
Membership Information
--
Membership Status     | Member Renewal
Membership Type       | Full Membership
Membership Start Date | March 15th, 2022
Membership End Date   | April 9th, 2024
```

If a new membership, would be `Member Signup` instead of `Member Renewal` in the example.

Comments
----------------------------------------
Everything but the 0bee60c commit _contribution.added is_pay_later check per Eileen_ (which should've been written as *added contribution.is_pay_later…*) is from a running system.