### PR TITLE
Handle custom tokens for mailing labels.

### DIFF
--- a/CRM/Utils/Address.php
+++ b/CRM/Utils/Address.php
@@ -387,6 +387,14 @@ class CRM_Utils_Address {
       }
     }
 
+    if (!empty($fields['id'])) {
+      // Render additional custom token that are not handled yet.
+      $additionalTokenFormatting = CRM_Core_TokenSmarty::render(
+        ['labels' => $formatted],
+        ['contactId' => $fields['id'], 'smarty' => FALSE]);
+      $formatted = $additionalTokenFormatting['labels'];
+    }
+
     // drop any {...} constructs from lines' ends
     $formatted = "\n$formatted\n";
 


### PR DESCRIPTION
Overview
----------------------------------------
The custom tokens are not handled and get printed as they are without curly braces.

Before
----------------------------------------
Token were not printed

After
----------------------------------------
Token are printed

Steps
----------------------------------------
Step 1: 
For testing, i used https://github.com/eileenmcnaughton/nz.co.fuzion.civitoken , enabled few latest current membership tokens, added tokens in `/civicrm/admin/setting/preferences/address?reset=1`, 
`Mailing Label Format` -> 
```
{contact.addressee}
Membership Expires: {latestcurrentmembership.end_date}
{contact.street_address}
{contact.city}{, }{contact.state_province}{ }{contact.postal_code}
```
Step 2: Search for active membership and print the label with any label type. Labels contain `latestcurrentmembership.end_date` , which means values never get replaced.

Step 3: Apply the above patch and retry step 2.

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
