### PR TITLE
SearchKit - Fix missing label on group concat distinct dropdown

### DIFF
--- a/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
@@ -25,7 +25,7 @@ class SqlFunctionGROUP_CONCAT extends SqlFunction {
   protected static function params(): array {
     return [
       [
-        'flag_before' => ['' => NULL, 'DISTINCT' => ts('Distinct Value'), 'UNIQUE' => ts('Unique Record')],
+        'flag_before' => ['' => ts('All'), 'DISTINCT' => ts('Distinct Value'), 'UNIQUE' => ts('Unique Record')],
         'max_expr' => 1,
         'must_be' => ['SqlField', 'SqlFunction', 'SqlEquation'],
         'optional' => FALSE,


### PR DESCRIPTION
Overview
----------------------------------------
Backports #28187

Before
-----
Selecting the "List" field transformation in SearchKit, the dropdown for All/Distinct/Unique appears blank by default.

After
---------
Dropdown labelled appropriately.