### PR TITLE
dev/core#4780 handle bounce processing when verp unverified

### DIFF
--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -118,7 +118,14 @@ class CRM_Utils_Mail_EmailProcessor {
     // process fifty at a time, CRM-4002
     while ($mails = $store->fetchNext(MAIL_BATCH_SIZE)) {
       foreach ($mails as $key => $mail) {
-        $incomingMail = new CRM_Utils_Mail_IncomingMail($mail, (string) $dao->domain, (string) $dao->localpart);
+        try {
+          $incomingMail = new CRM_Utils_Mail_IncomingMail($mail, (string) $dao->domain, (string) $dao->localpart);
+        }
+        catch (CRM_Core_Exception $e) {
+          $store->markIgnored($key);
+          continue;
+        }
+
         $action = $incomingMail->getAction();
         $job = $incomingMail->getJobID();
         $queue = $incomingMail->getQueueID();


### PR DESCRIPTION
Overview
----------------------------------------
When cycling through bounced emails, the current behavior is to exit with a fatal error if Verp handling is enabled and the email is not verified. This effectively prevents any bounces from processing. Instead we should skip the problem email and continue processing.

Before
----------------------------------------
Bounce processing exits with a fatal error.

After
----------------------------------------
Bounce record is skipped and processing continues.
