### PR TITLE
Membership Renewal: do not renew an expired membership

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -822,8 +822,12 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
       $dao->whereAdd('is_test = 0');
     }
 
-    //avoid pending membership as current membership: CRM-3027
-    $statusIds = [array_search('Pending', CRM_Member_PseudoConstant::membershipStatus())];
+    // Avoid pending and expired membership as current membership: CRM-3027
+    $statusIds = \Civi\Api4\MembershipStatus::get(TRUE)
+      ->addSelect('id')
+      ->addWhere('name', 'IN', ['expired', 'pending'])
+      ->execute()
+      ->column('id');
     if (!$membershipId) {
       // CRM-15475
       $statusIds[] = array_search(


### PR DESCRIPTION
Overview
----------------------------------------

If a membership has expired, create a new membership record instead of renewing the old one.

Before
----------------------------------------

When a membership expired, members can use a contribution page to renew their expired membership.

CiviCRM then takes their old expired membership, and renews it:

- Join date: the initial join date
- Start date: the new membership start date
- End date: the new end date

Sometimes this is fine, but then we did not record that there was a gap in the membership.

This can be extra confusing if the member has 2 different expired membership types, because `getContactMembership` returns a random membership. The use-case I encountered, the member had:

- an expired "Y" membership-type from 2019
- an active "Z" membership-type from 2021

The member renewed, opting for a "Y" membership (downgrading their membership from Z to Y).

CiviCRM renewed the expired "Y" membership, with a start in 2019, now expiring in 2024. This is super confusing for admins.

After
----------------------------------------

When the member renews, a new membership record is created. The old records are kept as expired.

If they had an active membership, the active membership is upgraded/downgraded. Same as the old behaviour.

Comments
----------------------------------------

I'm a bit curious if the tests will explode.