### PR TITLE
Notice fix on payment block

### DIFF
--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -52,8 +52,7 @@
    */
   function skipPaymentMethod() {
     var isHide = false;
-    var isMultiple = {/literal}{$event.is_multiple_registrations|@json_encode}{literal};
-    var alwaysShowFlag = (isMultiple && cj("#additional_participants").val());
+    var alwaysShowFlag = (cj("#additional_participants").val());
     var alwaysHideFlag = (cj("#bypass_payment").val() == 1);
     var total_amount_tmp =  cj('#pricevalue').data('raw-total');
     // Hide billing questions if this is free


### PR DESCRIPTION


Overview
----------------------------------------
Notice fix on payment block

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/50529db0-7099-4085-88eb-631ec5b22be0)

After
----------------------------------------
another one bites the dust

Technical Details
----------------------------------------
We don't need to check if we are dealing with a multiple participant event because that is the only scenario where the field additional_participants is present & it will fail gracefully if it is not present. This has been causing notices across all flows that include the payment block

Comments
----------------------------------------
