### PR TITLE
Minor standardisation in test class

### DIFF
--- a/Civi/Test/ContributionPageTestTrait.php
+++ b/Civi/Test/ContributionPageTestTrait.php
@@ -37,8 +37,8 @@ trait ContributionPageTestTrait {
   /**
    * Create a contribution page for test purposes.
    *
-   * Only call this directly for unpaid contribution pages.
-   * Otherwise use contributionPageCreatePaid.
+   * Generally this function is not called directly -
+   * use contributionPageCreatePaid.
    *
    * @param array $contributionPageValues
    * @param string $identifier

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2146,7 +2146,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    *
    * @return int $result['id'] payment processor id
    */
-  public function paymentProcessorCreate(array $params = [], $identifier = 'test'): int {
+  public function paymentProcessorCreate(array $params = [], string $identifier = 'test'): int {
     $params = array_merge([
       'title' => $params['name'] ?? 'demo',
       'domain_id' => CRM_Core_Config::domainID(),


### PR DESCRIPTION

Overview
----------------------------------------
Minor standardisation in test class

Refer to the payment processor in a way that is more consistent with other classes


Before
----------------------------------------
We have been consolidating the way we create objects & reference them, but this class still refers to `$this->_ids['payment_processor']]`

After
----------------------------------------
Refers to `$this->ids['PaymentProcessor']['dummy']`

Technical Details
----------------------------------------
I'm trying to move some of these to the form test classes but there are differences in how the 2 reference the various things 

Comments
----------------------------------------
