### PR TITLE
Improve test cover for full form flow of separate payment

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -274,7 +274,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $this->_params['ip_address'] = CRM_Utils_System::ipAddress();
     $this->_params['amount'] = $this->get('amount');
     if (isset($this->_params['amount'])) {
-      $this->setFormAmountFields($this->_params['priceSetId']);
+      $this->setFormAmountFields($this->getPriceSetID());
     }
 
     $this->_useForMember = $this->get('useForMember');
@@ -1855,7 +1855,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @param int $priceSetID
    */
   public function setFormAmountFields($priceSetID) {
-    $isQuickConfig = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $this->_params['priceSetId'], 'is_quick_config');
     $priceField = new CRM_Price_DAO_PriceField();
     $priceField->price_set_id = $priceSetID;
     $priceField->orderBy('weight');
@@ -1866,7 +1865,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       if ($priceField->name == "contribution_amount") {
         $paramWeDoNotUnderstand = $priceField->id;
       }
-      if ($isQuickConfig && !empty($this->_params["price_{$priceField->id}"])) {
+      if ($this->isQuickConfig() && !empty($this->_params["price_{$priceField->id}"])) {
         if ($this->_values['fee'][$priceField->id]['html_type'] != 'Text') {
           // @todo - stop setting amount level in this function & call the CRM_Price_BAO_PriceSet::getAmountLevel
           // function to get correct amount level consistently. Remove setting of the amount level in

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1215,7 +1215,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
     if ($this->isQuickConfig()) {
       $priceField = new CRM_Price_DAO_PriceField();
-      $priceField->price_set_id = $params['priceSetId'];
+      $priceField->price_set_id = $this->getPriceSetID();
       $priceField->orderBy('weight');
       $priceField->find();
 

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -34,6 +34,8 @@
     function clearAmountOther(otherPriceFieldName) {
       cj('#' + otherPriceFieldName).val('');
       cj('#' + otherPriceFieldName).blur();
+      // @todo - remove the next 2 lines - they seems to relate to a field that is never present
+      // as amount_other will be (e.g) price_4
       if (document.Main.amount_other == null) return; // other_amt field not present; do nothing
       document.Main.amount_other.value = "";
     }

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -444,7 +444,60 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
       'Tax Rate',
       'Subtotal',
     ]);
+  }
 
+  /**
+   * Test submit with a membership block in place.
+   *
+   * This test uses a quick config price set - which means line items
+   * do not show on the receipts. Separate payments are only supported
+   * with quick config.
+   *
+   * We are expecting a separate payment for the membership vs the contribution.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function testSubmitMembershipBlockIsSeparatePaymentPaymentProcessorNow(): void {
+    $this->contributionPageQuickConfigCreate([], [], TRUE, TRUE, TRUE, TRUE);
+    $processor = \Civi\Payment\System::singleton()->getById($this->ids['PaymentProcessor']['dummy']);
+    $processor->setDoDirectPaymentResult(['payment_status_id' => 1, 'fee_amount' => .72]);
+    $this->submitOnlineContributionForm([
+      'payment_processor_id' => $this->ids['PaymentProcessor']['dummy'],
+      'price_' . $this->ids['PriceField']['contribution_amount'] => $this->ids['PriceFieldValue']['contribution_amount_15'],
+      'price_' . $this->ids['PriceField']['membership_amount'] => $this->ids['PriceFieldValue']['membership_general'],
+      'id' => $this->getContributionPageID(),
+    ] + $this->getBillingSubmitValues(),
+    $this->getContributionPageID());
+
+    $contributions = $this->callAPISuccess('Contribution', 'get', [
+      'contribution_page_id' => $this->getContributionPageID(),
+      'contribution_status_id' => 1,
+    ])['values'];
+    $this->assertCount(2, $contributions);
+    $membershipPayment = $this->callAPISuccess('MembershipPayment', 'getsingle', ['return' => ['contribution_id', 'membership_id']]);
+    $this->assertArrayHasKey($membershipPayment['contribution_id'], $contributions);
+    $membership = $this->callAPISuccessGetSingle('Membership', ['id' => $membershipPayment['membership_id']]);
+    $this->assertEquals($membership['contact_id'], $contributions[$membershipPayment['contribution_id']]['contact_id']);
+    $lineItem = $this->callAPISuccessGetSingle('LineItem', ['entity_table' => 'civicrm_membership']);
+    $this->assertEquals($membership['id'], $lineItem['entity_id']);
+    $this->assertEquals($membershipPayment['contribution_id'], $lineItem['contribution_id']);
+    $this->assertEquals(1, $lineItem['qty']);
+    $this->assertEquals(100, $lineItem['unit_price']);
+    $this->assertEquals(100, $lineItem['line_total']);
+    foreach ($contributions as $contribution) {
+      $this->assertEquals(.72, $contribution['fee_amount']);
+      $this->assertEquals($contribution['total_amount'] - .72, $contribution['net_amount']);
+    }
+    $this->assertMailSentContainingStrings(['$15.00', 'Contribution Information'], 0);
+    $this->assertMailSentContainingStrings([
+      'Membership Information',
+      'Membership Type',
+      'General',
+      'Membership Start Date',
+      'Membership Fee',
+      '$100',
+    ], 1);
   }
 
 }

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -547,52 +547,6 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
   /**
    * Test submit with a membership block in place.
    *
-   * This test uses a quick config price set - which means line items
-   * do not show on the receipts. Separate payments are only supported
-   * with quick config.
-   *
-   * We are expecting a separate payment for the membership vs the contribution.
-   *
-   * @throws \CRM_Core_Exception
-   * @throws \Civi\API\Exception\UnauthorizedException
-   */
-  public function testSubmitMembershipBlockIsSeparatePaymentPaymentProcessorNow(): void {
-    $mut = new CiviMailUtils($this, TRUE);
-    $this->setUpMembershipContributionPage(TRUE);
-    $processor = Civi\Payment\System::singleton()->getById($this->ids['PaymentProcessor']['dummy']);
-    $processor->setDoDirectPaymentResult(['payment_status_id' => 1, 'fee_amount' => .72]);
-    $submitParams = $this->getSubmitParamsContributionPlusMembership(TRUE);
-
-    $this->callAPISuccess('ContributionPage', 'submit', $submitParams);
-    $contributions = $this->callAPISuccess('Contribution', 'get', [
-      'contribution_page_id' => $this->getContributionPageID(),
-      'contribution_status_id' => 1,
-    ]);
-    $this->assertCount(2, $contributions['values']);
-    $membershipPayment = $this->callAPISuccess('MembershipPayment', 'getsingle', ['return' => ['contribution_id', 'membership_id']]);
-    $this->assertArrayHasKey($membershipPayment['contribution_id'], $contributions['values']);
-    $membership = $this->callAPISuccessGetSingle('Membership', ['id' => $membershipPayment['membership_id']]);
-    $this->assertEquals($membership['contact_id'], $contributions['values'][$membershipPayment['contribution_id']]['contact_id']);
-    $lineItem = $this->callAPISuccessGetSingle('LineItem', ['entity_table' => 'civicrm_membership']);
-    $this->assertEquals($membership['id'], $lineItem['entity_id']);
-    $this->assertEquals($membershipPayment['contribution_id'], $lineItem['contribution_id']);
-    $this->assertEquals(1, $lineItem['qty']);
-    $this->assertEquals(2, $lineItem['unit_price']);
-    $this->assertEquals(2, $lineItem['line_total']);
-    foreach ($contributions['values'] as $contribution) {
-      $this->assertEquals(.72, $contribution['fee_amount']);
-      $this->assertEquals($contribution['total_amount'] - .72, $contribution['net_amount']);
-    }
-    // The total string is currently absent & it seems worse with - although at some point
-    // it may have been intended
-    $mut->checkAllMailLog(['$2.00', 'Contribution Information', '$88.00'], ['Total:']);
-    $mut->stop();
-    $mut->clearMessages();
-  }
-
-  /**
-   * Test submit with a membership block in place.
-   *
    * Ensure a separate payment for the membership vs the contribution, with
    * correct amounts.
    *


### PR DESCRIPTION
Overview
----------------------------------------
Improve test cover for full form flow of separate payment

Before
----------------------------------------
The separate payment tests do not use the full form flow & the set up is not easily re-usable

After
----------------------------------------
one test moved over, & a fairly solid set up established in a trait

Technical Details
----------------------------------------
The changes outside the tests are just standardisations to use `getPriceSetID()` and `isQuickConfig()` which have previously been established as the preferred functions. I found some issues which I will add further testing / follow up for

Comments
----------------------------------------
