### PR TITLE
[REF][PHP8.2] Declare _redactionRegexRules property

### DIFF
--- a/CRM/Case/XMLProcessor/Report.php
+++ b/CRM/Case/XMLProcessor/Report.php
@@ -31,6 +31,11 @@ class CRM_Case_XMLProcessor_Report extends CRM_Case_XMLProcessor {
   protected $_redactionStringRules = [];
 
   /**
+   * @var array
+   */
+  public $_redactionRegexRules;
+
+  /**
    */
   public function __construct() {
   }
@@ -725,7 +730,7 @@ LIMIT  1
    * @param int $caseID
    * @param string $activitySetName
    * @param array $params
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_XMLProcessor_Report $form
    *
    * @return CRM_Core_Smarty
    */


### PR DESCRIPTION
Overview
----------------------------------------
Declare `_redactionRegexRules` property.

Before
----------------------------------------
`_redactionRegexRules` was not declared, but used dynamically, causing deprecation warnings on PHP 8.2 (including test failures)

After
----------------------------------------
Property declared.

A seperate DocBlock is also updated to make it clearer that all properties elsewhere in the class are declared properly.

Comments
----------------------------------------
I've got a suspicion that the code using this property could possibly be removed, but it's not very clear what it's doing. That said, I'm not close enough to the reasons why the property was introduced, so for now let's just get the PHP 8.2 tests passing.

Perhaps the property should be marked deprecated?