### PR TITLE
[REF][PHP8.2] Declare _context in CRM_Contact_Selector

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -82,6 +82,13 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
   protected $_contextMenu;
 
   /**
+   * The search context
+   *
+   * @var string
+   */
+  public $_context;
+
+  /**
    * Params is the array in a value used by the search query creator
    *
    * @var array


### PR DESCRIPTION
Overview
----------------------------------------
Declare property `_context` in CRM_Contact_Selector.

Before
----------------------------------------
Property was not declared, causing deprecation notices, and responsible for many of the test failures on PHP 8.2.

After
----------------------------------------
Property declared.

Comments
----------------------------------------
Tricky to know if this one should be `public` or `protected`. `public` felt safest given this class is quite heavily used on different search screens.