### PR TITLE
[NFC] Improve docblocks for case activities

### DIFF
--- a/CRM/Case/Form/Activity/ChangeCaseStartDate.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStartDate.php
@@ -21,7 +21,7 @@
 class CRM_Case_Form_Activity_ChangeCaseStartDate {
 
   /**
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    *
    * @throws Exception
    */
@@ -39,7 +39,7 @@ class CRM_Case_Form_Activity_ChangeCaseStartDate {
    *
    * For edit/view mode the default values are retrieved from the database.
    *
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    *
    * @return array
    */
@@ -66,7 +66,7 @@ class CRM_Case_Form_Activity_ChangeCaseStartDate {
   }
 
   /**
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    */
   public static function buildQuickForm(&$form) {
     $form->removeElement('status_id');
@@ -85,7 +85,7 @@ class CRM_Case_Form_Activity_ChangeCaseStartDate {
    *   Posted values of the form.
    *
    * @param $files
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    *
    * @return array
    *   list of errors to be posted back to the form
@@ -98,7 +98,7 @@ class CRM_Case_Form_Activity_ChangeCaseStartDate {
    * Process the form submission.
    *
    *
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    * @param array $params
    */
   public static function beginPostProcess(&$form, &$params) {
@@ -111,7 +111,7 @@ class CRM_Case_Form_Activity_ChangeCaseStartDate {
    * Process the form submission.
    *
    *
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    * @param array $params
    * @param $activity
    */

--- a/CRM/Case/Form/Activity/ChangeCaseStatus.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStatus.php
@@ -21,7 +21,7 @@
 class CRM_Case_Form_Activity_ChangeCaseStatus {
 
   /**
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    *
    * @throws Exception
    */
@@ -43,7 +43,7 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
    * For edit/view mode the default values are retrieved from the database.
    *
    *
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    *
    * @return array
    */
@@ -56,7 +56,7 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
   }
 
   /**
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    */
   public static function buildQuickForm(&$form) {
     $form->removeElement('status_id');
@@ -111,7 +111,7 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
    *   Posted values of the form.
    *
    * @param $files
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    *
    * @return array
    *   list of errors to be posted back to the form
@@ -123,7 +123,7 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
   /**
    * Process the form submission.
    *
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    * @param array $params
    */
   public static function beginPostProcess(&$form, &$params) {
@@ -144,7 +144,7 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
   /**
    * Process the form submission.
    *
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    * @param array $params
    * @param CRM_Activity_BAO_Activity $activity
    */

--- a/CRM/Case/Form/Activity/ChangeCaseType.php
+++ b/CRM/Case/Form/Activity/ChangeCaseType.php
@@ -21,7 +21,7 @@
 class CRM_Case_Form_Activity_ChangeCaseType {
 
   /**
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    *
    * @throws Exception
    */
@@ -36,7 +36,7 @@ class CRM_Case_Form_Activity_ChangeCaseType {
    *
    * For edit/view mode the default values are retrieved from the database.
    *
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    *
    * @return array
    */
@@ -52,7 +52,7 @@ class CRM_Case_Form_Activity_ChangeCaseType {
   }
 
   /**
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    */
   public static function buildQuickForm(&$form) {
     $form->removeElement('status_id');
@@ -82,7 +82,7 @@ class CRM_Case_Form_Activity_ChangeCaseType {
    *   Posted values of the form.
    *
    * @param $files
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    *
    * @return array
    *   list of errors to be posted back to the form
@@ -95,7 +95,7 @@ class CRM_Case_Form_Activity_ChangeCaseType {
    * Process the form submission.
    *
    *
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    * @param array $params
    */
   public static function beginPostProcess(&$form, &$params) {
@@ -112,7 +112,7 @@ class CRM_Case_Form_Activity_ChangeCaseType {
    * Process the form submission.
    *
    *
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    * @param array $params
    * @param $activity
    */

--- a/CRM/Case/Form/Activity/LinkCases.php
+++ b/CRM/Case/Form/Activity/LinkCases.php
@@ -21,7 +21,7 @@
 class CRM_Case_Form_Activity_LinkCases {
 
   /**
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    *
    * @throws Exception
    */
@@ -50,7 +50,7 @@ class CRM_Case_Form_Activity_LinkCases {
   /**
    * Set default values for the form.
    *
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    *
    * @return array
    */
@@ -63,7 +63,7 @@ class CRM_Case_Form_Activity_LinkCases {
   }
 
   /**
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    */
   public static function buildQuickForm(&$form) {
     $excludeCaseIds = (array) $form->_caseId;
@@ -90,7 +90,7 @@ class CRM_Case_Form_Activity_LinkCases {
    *   Posted values of the form.
    *
    * @param $files
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    *
    * @return array
    *   list of errors to be posted back to the form
@@ -124,7 +124,7 @@ class CRM_Case_Form_Activity_LinkCases {
    * Process the form submission.
    *
    *
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    * @param array $params
    */
   public static function beginPostProcess(&$form, &$params) {
@@ -134,7 +134,7 @@ class CRM_Case_Form_Activity_LinkCases {
    * Process the form submission.
    *
    *
-   * @param CRM_Core_Form $form
+   * @param CRM_Case_Form_Case $form
    * @param array $params
    * @param CRM_Activity_BAO_Activity $activity
    */


### PR DESCRIPTION
Overview
----------------------------------------
Makes the `@param` hints more specific for `CRM_Case_Form_Activity_*` classes.

This will make it easier to figure out what needs to happen to make these classes PHP 8.2 compatiable (removing dynamic property uses)
