### PR TITLE
[REF][PHP8.2] Remove need for _allowMultiClient property

### DIFF
--- a/CRM/Case/Form/Activity/OpenCase.php
+++ b/CRM/Case/Form/Activity/OpenCase.php
@@ -32,10 +32,6 @@ class CRM_Case_Form_Activity_OpenCase {
    * @throws \CRM_Core_Exception
    */
   public static function preProcess(&$form) {
-    //get multi client case configuration
-    $xmlProcessorProcess = new CRM_Case_XMLProcessor_Process();
-    $form->_allowMultiClient = (bool) $xmlProcessorProcess->getAllowMultipleCaseClients();
-
     if ($form->_context == 'caseActivity') {
       $contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $form);
       $atype = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Change Case Start Date');
@@ -140,9 +136,12 @@ class CRM_Case_Form_Activity_OpenCase {
       return;
     }
     if ($form->_context == 'standalone') {
+      //get multi client case configuration
+      $xmlProcessorProcess = new CRM_Case_XMLProcessor_Process();
+
       $form->addEntityRef('client_id', ts('Client'), [
         'create' => TRUE,
-        'multiple' => $form->_allowMultiClient,
+        'multiple' => (bool) $xmlProcessorProcess->getAllowMultipleCaseClients(),
       ], TRUE);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove need for `_allowMultiClient` property.

Before
----------------------------------------
`_allowMultiClient` was set dynamically, causing deprecation warnings on PHP 8.2

We can see it was set, but read only once:
<img width="507" alt="Screenshot 2023-11-18 at 16 49 33" src="https://github.com/civicrm/civicrm-core/assets/1931323/e4b1a030-99e9-443d-910b-d804763b2a0e">


After
----------------------------------------
The code that reads from `CRM_Case_XMLProcessor_Process` has been moved to avoid the need for a new property on `CRM_Case_Form_Case`.

Comments
----------------------------------------
`CRM_Case_Form_Activity_*` are pretty confusing classes, so I'm tackling them piece-by-piece. More work is needed to make this class fully 8.2 compatiable.
