### PR TITLE
[REF][PHP8.2] Declare donorEmail and donorDisplayName properties

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -29,6 +29,13 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
   protected $_donorEmail = '';
 
   /**
+   * The contributor display name (for emails)
+   *
+   * @var string
+   */
+  protected $_donorDisplayName = '';
+
+  /**
    * Should custom data be suppressed on this form.
    *
    * We override to suppress custom data because historically it has not been

--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -44,6 +44,13 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
   public $_contactID;
 
   /**
+   * The contributor email
+   *
+   * @var string
+   */
+  protected $_donorEmail = '';
+
+  /**
    * Pre-processing for the form.
    *
    * @throws \Exception
@@ -112,7 +119,8 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
     $this->assign('editableScheduleFields', array_diff($this->editableScheduleFields, $alreadyHardCodedFields));
 
     if ($this->_subscriptionDetails->contact_id) {
-      [$this->_donorDisplayName, $this->_donorEmail] = CRM_Contact_BAO_Contact::getContactDetails($this->_subscriptionDetails->contact_id);
+      $contactDetails = CRM_Contact_BAO_Contact::getContactDetails($this->_subscriptionDetails->contact_id);
+      $this->_donorEmail = $contactDetails[1];
     }
 
     $this->setTitle(ts('Update Recurring Contribution'));


### PR DESCRIPTION
Overview
----------------------------------------
Fix deprecation notices on PHP 8.2:
```
CRM_Contribute_Form_CancelSubscriptionTest::testMail
Creation of dynamic property CRM_Contribute_Form_CancelSubscription::$_donorDisplayName is deprecated
```

Before
----------------------------------------
Dynamic properties cause deprecation warnings and test failures on PHP 8.2.

After
----------------------------------------
Properties declared.

Technical Details
----------------------------------------
I went for `protected` visibility. `_donorEmail` was already declared protected in `CRM_Contribute_Form_CancelSubscription`, and the leading underscore should have indicated that the property was not for third-party use.

In `CRM_Contribute_Form_UpdateSubscription`, `_donorDisplayName` was set but never used.