### PR TITLE
Cleanup notices around line Item display on Contribution Confirm Page

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -498,7 +498,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $this->_params['is_quick_config'] = 1;
     }
     else {
-      $this->assignLineItemsToTemplate([$this->getPriceSetID() => $this->order->getLineItems()]);
+      $this->assign('lineItem', [$this->getPriceSetID() => $this->order->getLineItems()]);
     }
 
     if (!empty($params['selectProduct']) && $params['selectProduct'] !== 'no_thanks') {

--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -41,7 +41,6 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
     parent::preProcess();
 
     $this->_params = $this->get('params');
-    $this->_lineItem = $this->get('lineItem');
     $this->_useForMember = $this->get('useForMember');
     $this->assign('thankyou_title', CRM_Utils_Array::value('thankyou_title', $this->_values));
     $this->assign('thankyou_text', CRM_Utils_Array::value('thankyou_text', $this->_values));
@@ -95,31 +94,11 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
     }
 
     $params = $this->_params;
-    $invoicing = CRM_Invoicing_Utils::isInvoicingEnabled();
-    // Make a copy of line items array to use for display only
-    $tplLineItems = $this->_lineItem;
-    if ($invoicing) {
-      $getTaxDetails = FALSE;
-      foreach ($this->_lineItem as $key => $value) {
-        foreach ($value as $k => $v) {
-          if (isset($v['tax_rate'])) {
-            if ($v['tax_rate'] != '') {
-              $getTaxDetails = TRUE;
-              // Cast to float to display without trailing zero decimals
-              $tplLineItems[$key][$k]['tax_rate'] = (float) $v['tax_rate'];
-            }
-          }
-        }
-      }
-    }
     $this->assign('getTaxDetails', (bool) $this->order->getTotalTaxAmount());
     $this->assign('totalTaxAmount', $this->order->getTotalTaxAmount());
     $this->assign('taxTerm', \Civi::settings()->get('tax_term'));
-
-    if ($this->_priceSetId && !CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $this->_priceSetId, 'is_quick_config')) {
-      $this->assign('lineItem', $tplLineItems);
-    }
-    else {
+    $this->assign('lineItem', $this->isQuickConfig() ? NULL : $this->order->getLineItems());
+    if (!$this->isQuickConfig()) {
       if (is_array($membershipTypeID)) {
         $membershipTypeID = current($membershipTypeID);
       }


### PR DESCRIPTION
Overview
----------------------------------------
Cleanup notices around line Item display on Contribution Thank Youu Page

Before
----------------------------------------
A screen of red

After
----------------------------------------
Extends the fix from Confirm to Thank You that resolved notices, missing details

![image](https://github.com/civicrm/civicrm-core/assets/336308/175157cc-33c2-47fd-b6fa-afb8c2646f07)


Technical Details
----------------------------------------
The LineItem.tpl takes several variables that are always false i this flow & apply more to events - these are passed in the include

Comments
----------------------------------------
