### PR TITLE
Use token to avoid breaky-smarty3-maths

### DIFF
--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -95,7 +95,7 @@
               {ts}Total{/ts}
             </td>
             <td {$valueStyle}>
-              {$amount+$membership_amount|crmMoney}
+              {contribution.total_amount}
             </td>
           </tr>
         {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Use token to avoid breaky-smarty3-maths

Before
----------------------------------------
The values of the 2 line items are added together in the template

After
----------------------------------------
The value of the 2 line items is the contribution total amount so we use that token  - note we are in this if

`  {if $amount && !$is_separate_payment}`

Technical Details
----------------------------------------

Comments
----------------------------------------