### PR TITLE
Further test consolidation

### DIFF
--- a/Civi/Test/FormTrait.php
+++ b/Civi/Test/FormTrait.php
@@ -58,6 +58,18 @@ trait FormTrait {
   }
 
   /**
+   * Assert that the sent mail included the supplied strings.
+   *
+   * @param array $strings
+   * @param int $mailIndex
+   */
+  protected function assertMailSentNotContainStrings(array $strings, int $mailIndex = 0): void {
+    foreach ($strings as $string) {
+      $this->assertMailSentNotContainingString($string, $mailIndex);
+    }
+  }
+
+  /**
    * Assert that the sent mail included the supplied string.
    *
    * @param string $string
@@ -74,9 +86,29 @@ trait FormTrait {
    * @param string $string
    * @param int $mailIndex
    */
+  protected function assertMailSentNotContainingString(string $string, int $mailIndex = 0): void {
+    $mail = $this->form->getMail()[$mailIndex];
+    $this->assertStringNotContainsString(preg_replace('/\s+/', '', $string), preg_replace('/\s+/', '', $mail['body']));
+  }
+
+  /**
+   * Assert that the sent mail included the supplied string.
+   *
+   * @param string $string
+   * @param int $mailIndex
+   */
   protected function assertMailSentContainingHeaderString(string $string, int $mailIndex = 0): void {
     $mail = $this->form->getMail()[$mailIndex];
     $this->assertStringContainsString($string, $mail['headers']);
+  }
+
+  /**
+   * Assert the right number of mails were sent.
+   *
+   * @param int $count
+   */
+  protected function assertMailSentCount(int $count): void {
+    $this->assertCount($count, $this->form->getMail());
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -526,6 +526,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
       'Membership Fee',
       'Amount $100.00',
     ]);
+    $this->assertMailSentContainingHeaderString('Test Frontend title');
   }
 
 }

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -307,42 +307,6 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test submit with a membership block in place.
-   */
-  public function testSubmitMembershipBlockNotSeparatePaymentZeroDollarsWithEmail(): void {
-    $mut = new CiviMailUtils($this, TRUE);
-    $this->setUpMembershipContributionPage(FALSE, FALSE, ['minimum_fee' => 0]);
-    $this->addProfile('supporter_profile', $this->getContributionPageID());
-
-    $submitParams = [
-      $this->getPriceFieldLabel('membership') => $this->getPriceFieldValue('general'),
-      'id' => $this->getContributionPageID(),
-      'billing_first_name' => 'Billy',
-      'billing_middle_name' => 'Goat',
-      'billing_last_name' => 'Gruffier',
-      'email-Primary' => 'billy-goat@the-new-bridge.net',
-      'payment_processor_id' => $this->params['payment_processor_id'],
-    ];
-
-    $this->callAPISuccess('ContributionPage', 'submit', $submitParams);
-    $contribution = $this->callAPISuccess('contribution', 'getsingle', ['contribution_page_id' => $this->getContributionPageID()]);
-    $this->callAPISuccess('membership_payment', 'getsingle', ['contribution_id' => $contribution['id']]);
-    //Assert only one mail is being sent.
-    $msgs = $mut->getAllMessages();
-    $this->assertCount(1, $msgs);
-
-    $mut->checkMailLog([
-      'Membership Type',
-      'General',
-      'Gruffier',
-    ], [
-      'Amount',
-    ]);
-    $mut->stop();
-    $mut->clearMessages();
-  }
-
-  /**
    * Test submit with a pay later and check line item in mails.
    */
   public function testSubmitMembershipBlockIsSeparatePaymentPayLaterWithEmail(): void {

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -309,42 +309,6 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
   /**
    * Test submit with a membership block in place.
    */
-  public function testSubmitMembershipBlockNotSeparatePaymentWithEmail(): void {
-    $mut = new CiviMailUtils($this, TRUE);
-    $this->setUpMembershipContributionPage();
-    $this->addProfile('supporter_profile', $this->getContributionPageID());
-
-    $submitParams = [
-      $this->getPriceFieldLabel('contribution') => 1,
-      $this->getPriceFieldLabel('membership') => $this->getPriceFieldValue('general'),
-      'id' => $this->getContributionPageID(),
-      'billing_first_name' => 'Billy',
-      'billing_middle_name' => 'Goat',
-      'billing_last_name' => 'Gruff',
-      'selectMembership' => $this->ids['MembershipType'][0],
-      'email-Primary' => 'billy-goat@the-bridge.net',
-      'payment_processor_id' => $this->ids['PaymentProcessor']['dummy'],
-      'credit_card_number' => '4111111111111111',
-      'credit_card_type' => 'Visa',
-      'credit_card_exp_date' => ['M' => 9, 'Y' => 2040],
-      'cvv2' => 123,
-    ];
-
-    $this->callAPISuccess('ContributionPage', 'submit', $submitParams);
-    $contribution = $this->callAPISuccess('contribution', 'getsingle', ['contribution_page_id' => $this->getContributionPageID()]);
-    $this->callAPISuccess('MembershipPayment', 'getsingle', ['contribution_id' => $contribution['id']]);
-    $mut->checkMailLog([
-      'Membership Type',
-      'General',
-      'Test Frontend title',
-    ]);
-    $mut->stop();
-    $mut->clearMessages();
-  }
-
-  /**
-   * Test submit with a membership block in place.
-   */
   public function testSubmitMembershipBlockNotSeparatePaymentZeroDollarsWithEmail(): void {
     $mut = new CiviMailUtils($this, TRUE);
     $this->setUpMembershipContributionPage(FALSE, FALSE, ['minimum_fee' => 0]);


### PR DESCRIPTION
Part of an effort to improve & clarify cover over the Contribution page flow - I'm moving the tests to the 'right' place (on the form test class) and switching them to use more consistent & correct test data