### PR TITLE
dev/core#4787 Standalone: add viewport meta to improve mobile support

### DIFF
--- a/templates/CRM/common/standalone.tpl
+++ b/templates/CRM/common/standalone.tpl
@@ -3,7 +3,7 @@
  <head>
   <meta http-equiv="Content-Style-Type" content="text/css" />
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="Shortcut Icon" type="image/x-icon" href="{$config->resourceBase}i/widget/favicon.png" />
 
   {* @todo crmRegion below should replace this, but not working? *}


### PR DESCRIPTION
Overview
----------------------------------------

Adds the viewport meta, so that using CiviCRM Standalone on a small screen (ex: mobile device) works better.

https://lab.civicrm.org/dev/core/-/issues/4787

Before
----------------------------------------

Viewport is always large, not resized for the device.

![image](https://github.com/civicrm/civicrm-core/assets/254741/a1399fc3-4de6-40fb-892b-c77d3c2e5e30)


After
----------------------------------------

Viewport is adjusted to the device. 

![image](https://github.com/civicrm/civicrm-core/assets/254741/20d0b17f-34a8-4213-a62c-ddc06b1bc510)


Comments
----------------------------------------

The mobile menu toggle sometimes behaves weirdly on Firefox when running mobile emulation, but it seems to work fine on a real mobile device.

cc @artfulrobot 