### PR TITLE
Clean up helper functions for Contribution class

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1259,9 +1259,6 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     }
 
     $params['separate_amount'] = $params['amount'];
-    // @todo - stepping through the code indicates that amount is always set before this point so it never matters.
-    // Move more of the above into this function...
-    $params['amount'] = $this->getMainContributionAmount($params);
     //If the membership & contribution is used in contribution page & not separate payment
     $memPresent = $membershipLabel = $fieldOption = NULL;
     $proceFieldAmount = 0;

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -854,6 +854,26 @@ class CRM_Financial_BAO_Order {
   }
 
   /**
+   * Get line items that so not relate to memberships.
+   *
+   * This is used for the contribution page separate payment functionality
+   * and is not supported for any other use.
+   *
+   * return array
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function getNonMembershipLineItems():array {
+    $lines = $this->getLineItems();
+    foreach ($lines as $index => $line) {
+      if (!empty($line['membership_type_id'])) {
+        unset($lines[$index]);
+      }
+    }
+    return $lines;
+  }
+
+  /**
    * Get an array of all membership types included in the order.
    *
    * @return array
@@ -993,6 +1013,27 @@ class CRM_Financial_BAO_Order {
   public function getMembershipTotalAmount() :float {
     $amount = 0.0;
     foreach ($this->getMembershipLineItems() as $lineItem) {
+      $amount += ($lineItem['line_total'] ?? 0.0) + ($lineItem['tax_amount'] ?? 0.0);
+    }
+    return $amount;
+  }
+
+  /**
+   * Get the total amount relating to the non-membership part of the order.
+   *
+   * Get line items that so not relate to memberships.
+   *
+   * This is used for the contribution page separate payment functionality
+   * and is not supported for any other use.
+   *
+   *
+   * @return float
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function getNonMembershipTotalAmount() :float {
+    $amount = 0.0;
+    foreach ($this->getNonMembershipLineItems() as $lineItem) {
       $amount += ($lineItem['line_total'] ?? 0.0) + ($lineItem['tax_amount'] ?? 0.0);
     }
     return $amount;


### PR DESCRIPTION
Overview
----------------------------------------
Clean up helper functions for Contribution class

Before
----------------------------------------
I was having trouble with getting these helpers in cos of getting conflicted & then having to trawl my git history to find them

After
----------------------------------------
Helpers added - fixes to follow 

Technical Details
----------------------------------------
The one changed function wasn't really doing anything, per the comments, as it was early returning if amount was already set - which it is - even in the scenario it is trying to catch - ie there is a  contribution option & a membership option & only the latter is selected - but in that case amount is the membership amount by this point

![image](https://github.com/civicrm/civicrm-core/assets/336308/6798078d-45af-4637-84f4-eb8d11f9d7ac)


Comments
----------------------------------------
