### PR TITLE
Update price field metadata with override financial type

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -712,6 +712,15 @@ class CRM_Financial_BAO_Order {
       $this->priceSetMetadata = CRM_Price_BAO_PriceSet::getCachedPriceSetDetail($this->getPriceSetID());
       $this->priceSetMetadata['id'] = $this->getPriceSetID();
       $this->priceSetMetadata['auto_renew_membership_field'] = NULL;
+      if ($this->getOverrideFinancialTypeID()) {
+        foreach ($this->priceSetMetadata['fields'] as &$field) {
+          foreach ($field['options'] as &$option) {
+            $option['financial_type_id'] = $this->getOverrideFinancialTypeID();
+            $option['tax_rate'] = $this->getTaxRate($this->getFinancialTypeID());
+            $option['tax_amount'] = $option['tax_rate'] * $option['amount'];
+          }
+        }
+      }
       $this->setPriceFieldMetadata($this->priceSetMetadata['fields']);
       unset($this->priceSetMetadata['fields']);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Update price field metadata with override financial type

Before
----------------------------------------
When price field data is being built any known financial_type_id override is not factored in

After
----------------------------------------
the override financial type is used to set the financial type & tax on the options

Technical Details
----------------------------------------
At this stage this will not have any impact - it's part of splitting out some helper function fixes from a tricky code update

Comments
----------------------------------------
