### PR TITLE
Fix master-only regression - tax term not assigned

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -486,7 +486,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
     $this->assign('receiptFromEmail', $this->_values['receipt_from_email'] ?? NULL);
     $this->assign('amount_block_is_active', $this->isFormSupportsNonMembershipContributions());
-    $this->assign('taxTerm', \Civi::settings()->get('taxTerm'));
+    $this->assign('taxTerm', \Civi::settings()->get('tax_term'));
     $this->assign('totalTaxAmount', $this->order->getTotalTaxAmount());
     $isDisplayLineItems = $this->_priceSetId && !CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $this->_priceSetId, 'is_quick_config');
     $this->assign('isDisplayLineItems', $isDisplayLineItems);


### PR DESCRIPTION
Overview
----------------------------------------
Typo in just merged code
 - sales tax is not assigned

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/983dc6ef-a08e-4c72-8c31-7d0be05ebdda)


After
----------------------------------------
(actually the double up was because I had locally un-merged code to test the var - so not that bit)
![image](https://github.com/civicrm/civicrm-core/assets/336308/cb150048-7ce3-417e-8a26-02996ff1735d)


Technical Details
----------------------------------------
Note the sales tax is right but the total isn't - I went back to check past versions & found they were a little more wrong - so I'm looking at that as a follow up

Witness that in 5.64 this shows up as taxable on the Main page but by the Confirm page the tax is gone from the contribution line

![image](https://github.com/civicrm/civicrm-core/assets/336308/86ea7993-2421-4b00-a8bd-2b80f6d6093c)


![image](https://github.com/civicrm/civicrm-core/assets/336308/93ec2663-3c08-428e-9a16-d16d2579314e)

Master

![image](https://github.com/civicrm/civicrm-core/assets/336308/58ab35c5-3819-4d6c-9dcd-e9cc3ee909e0)



Comments
----------------------------------------
