### PR TITLE
[wip] Access line items in a more standard manner when processing contribution page

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1413,7 +1413,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         if (!empty($membershipParams['auto_renew'])) {
           $isRecurForFirstTransaction = FALSE;
         }
-        $membershipParams['total_amount'] = $totalAmount;
         $membershipParams['skipLineItem'] = 0;
         CRM_Price_BAO_LineItem::getLineItemArray($membershipParams);
       }

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1407,7 +1407,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $totalAmount = $membershipParams['amount'];
 
     if ($isPaidMembership) {
-      if ($isProcessSeparateMembershipTransaction) {
+      if ($this->isSeparatePaymentSelected()) {
         // If we have 2 transactions only one can use the invoice id.
         $membershipParams['invoiceID'] .= '-2';
         if (!empty($membershipParams['auto_renew'])) {
@@ -1441,7 +1441,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       }
     }
 
-    if ($isProcessSeparateMembershipTransaction) {
+    if ($this->isSeparatePaymentSelected()) {
       try {
         $this->_lineItem = $unprocessedLineItems;
         if (empty($this->_params['auto_renew']) && !empty($membershipParams['is_recur'])) {
@@ -2201,7 +2201,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $this->_useForMember = $this->get('useForMember');
 
     // store the fact that this is a membership and membership type is selected
-    if ($this->isMembershipSelected($membershipParams)) {
+    if ($this->isMembershipSelected()) {
       $this->doMembershipProcessing($contactID, $membershipParams, $premiumParams);
     }
     else {
@@ -2266,20 +2266,11 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
   /**
    * Return True/False if we have a membership selected on the contribution page
-   * @param array $membershipParams
    *
    * @return bool
    */
-  private function isMembershipSelected($membershipParams) {
-    $priceFieldIds = $this->get('memberPriceFieldIDS');
-    if ((!empty($membershipParams['selectMembership']) && $membershipParams['selectMembership'] != 'no_thanks')
-        && empty($priceFieldIds)) {
-      return TRUE;
-    }
-    else {
-      $membershipParams = $this->getMembershipParamsFromPriceSet($membershipParams);
-    }
-    return !empty($membershipParams['selectMembership']);
+  private function isMembershipSelected(): bool {
+    return !empty($this->getMembershipLineItems());
   }
 
   /**
@@ -2380,10 +2371,10 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
 
     $membershipParams = $this->getMembershipParamsFromPriceSet($membershipParams);
-    if (!empty($membershipParams['selectMembership'])) {
+    if ($this->isMembershipSelected()) {
       // CRM-12233
       $membershipLineItems = [$this->getPriceSetID() => $this->getLineItems()];;
-      if ($this->_separateMembershipPayment && $this->isFormSupportsNonMembershipContributions()) {
+      if ($this->isSeparatePaymentSelected()) {
         $membershipLineItems = [];
         foreach ($this->_values['fee'] as $key => $feeValues) {
           if ($feeValues['name'] == 'membership_amount') {

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1414,7 +1414,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           $isRecurForFirstTransaction = FALSE;
         }
         $membershipParams['skipLineItem'] = 0;
-        CRM_Price_BAO_LineItem::getLineItemArray($membershipParams);
+        $membershipParams['line_item'] = [$this->getPriceSetID() => $this->getMainContributionLineItems()];
       }
       else {
         // Skip line items in the contribution processing transaction.
@@ -1442,7 +1442,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     if ($this->isSeparatePaymentSelected()) {
       try {
-        $this->_lineItem = $unprocessedLineItems;
         if (empty($this->_params['auto_renew']) && !empty($membershipParams['is_recur'])) {
           unset($membershipParams['is_recur']);
         }
@@ -2372,18 +2371,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $membershipParams = $this->getMembershipParamsFromPriceSet($membershipParams);
     if ($this->isMembershipSelected()) {
       // CRM-12233
-      $membershipLineItems = [$this->getPriceSetID() => $this->getLineItems()];;
-      if ($this->isSeparatePaymentSelected()) {
-        $membershipLineItems = [];
-        foreach ($this->_values['fee'] as $key => $feeValues) {
-          if ($feeValues['name'] == 'membership_amount') {
-            $fieldId = $this->_params['price_' . $key];
-            unset($this->_lineItem[$this->_priceSetId][$fieldId]);
-            $membershipLineItems[$this->_priceSetId][$fieldId] = $this->getLineItems()[$fieldId];
-            break;
-          }
-        }
-      }
+      $membershipLineItems = [$this->getPriceSetID() => $this->getMainContributionLineItems()];
+      $membershipLineItems['total_amount'] = $this->getMainContributionAmount();
       try {
         $this->processMembership($membershipParams, $contactID, $customFieldsFormatted, $premiumParams, $membershipLineItems);
       }

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1264,7 +1264,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     $params['separate_amount'] = $params['amount'];
     // @todo - stepping through the code indicates that amount is always set before this point so it never matters.
     // Move more of the above into this function...
-    $params['amount'] = $this->getMainContributionAmount($params);
+    $params['amount'] = $this->getMainContributionAmount();
     //If the membership & contribution is used in contribution page & not separate payment
     $memPresent = $membershipLabel = $fieldOption = NULL;
     $proceFieldAmount = 0;

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1149,25 +1149,20 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   /**
    * Get the amount for the main contribution.
    *
-   * The goal is to expand this function so that all the argy-bargy of figuring out the amount
-   * winds up here as the main spaghetti shrinks.
-   *
    * If there is a separate membership contribution this is the 'other one'. Otherwise there
    * is only one.
-   *
-   * @param $params
    *
    * @return float
    *
    * @throws \CRM_Core_Exception
    */
-  protected function getMainContributionAmount($params) {
-    if (!empty($params['selectMembership'])) {
-      if (empty($params['amount']) && !$this->_separateMembershipPayment) {
-        return CRM_Member_BAO_MembershipType::getMembershipType($params['selectMembership'])['minimum_fee'] ?? 0;
-      }
+  protected function getMainContributionAmount(): float {
+    $amount = 0;
+    foreach ($this->getMainContributionLineItems() as $lineItem) {
+      // Line total inclusive should really be always set but this is a safe fall back.
+      $amount += $lineItem['line_total_inclusive'] ?? ($lineItem['line_total'] + $lineItem['tax_amount']);
     }
-    return $params['amount'] ?? 0;
+    return $amount;
   }
 
   /**

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -581,6 +581,16 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   }
 
   /**
+   * Is the form separate payment AND has the user selected 2 options,
+   * resulting in 2 payments.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function isSeparatePaymentSelected(): bool {
+    return (bool) $this->getSecondaryMembershipContributionLineItems();
+  }
+
+  /**
    * Set the line items for the secondary membership contribution.
    *
    * Return false if the page is not configured for separate contributions,
@@ -602,7 +612,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         $lineItems[$index] = $lineItem;
       }
     }
-    if (empty($lineItems) || count($lineItems) === $this->getLineItems()) {
+    if (empty($lineItems) || count($lineItems) === count($this->getLineItems())) {
       return FALSE;
     }
     return $lineItems;

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -314,7 +314,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
         'Y' => (int) (CRM_Utils_Time::date('Y')) + 1,
       ],
       'price_' . $this->ids['PriceField']['membership'] => $this->ids['PriceFieldValue']['membership_general'],
-      'other_amount' => 100,
+      'price_' . $this->ids['PriceField']['contribution'] => $this->ids['PriceFieldValue']['contribution'],
       'priceSetId' => $this->ids['PriceSet']['membership_block'],
       'credit_card_type' => 'Visa',
       'email-5' => 'test@test.com',

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -976,12 +976,14 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test non-recur contribution with membership payment
+   * Test non-recur contribution with membership payment selected.
+   *
+   * In this scenario the contribution option was not selected so only
+   * one contribution is actually created.
    *
    * @throws \CRM_Core_Exception
-   * @throws \Civi\API\Exception\UnauthorizedException
    */
-  public function testSubmitMembershipIsSeparatePaymentNotRecur(): void {
+  public function testSubmitMembershipIsSeparatePaymentNotRecurMembershipOnly(): void {
     $this->setUpMembershipContributionPage(TRUE, TRUE);
     $dummyPP = Civi\Payment\System::singleton()->getById($this->ids['PaymentProcessor']['dummy']);
     $dummyPP->setDoDirectPaymentResult(['payment_status_id' => 1, 'trxn_id' => 'create_first_success']);


### PR DESCRIPTION
Overview
----------------------------------------
Access line items in a more standard manner when processing contribution page

This adds functions to get & set the line items & makes these publicly accessible. Some minor tidy up is possible here as I was able to remove a couple of sets that are no longer used in the receipt

Before
----------------------------------------
Inconsistent access to the line items = super confusing. There is a bug relating to tax that I'm trying to deal with - https://lab.civicrm.org/dev/financial/-/issues/154 but this doesn't make it better or worse - it just means that it becomes less fragile when I attempt to address it

After
----------------------------------------

Technical Details
----------------------------------------

The line items still look the same on the ThankYou page - those extra values added were from the receipt - but we have switched the membership receipt over this release

![image](https://github.com/civicrm/civicrm-core/assets/336308/0e999b2d-776c-49fd-9b34-dd3a7151fd9d)



Comments
----------------------------------------
