### PR TITLE
Stop passing billingID to `CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters`

### DIFF
--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -367,10 +367,7 @@ class CRM_Contribute_Form_AdditionalInfo {
     $form->assign('ccContribution', $ccContribution);
     if ($ccContribution) {
       $form->assignBillingName($params);
-      $form->assign('address', CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters(
-        $params,
-        $form->_bltID
-      ));
+      $form->assign('address', CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($params));
 
       $valuesForForm = CRM_Contribute_Form_AbstractEditPayment::formatCreditCardDetails($params);
       $form->assignVariables($valuesForForm, ['credit_card_exp_date', 'credit_card_type', 'credit_card_number']);

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -387,10 +387,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       $this->_params['invoiceID'] = $this->_params['invoice_id'];
     }
 
-    $this->assign('address', CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters(
-      $this->_params,
-      $this->_bltID
-    ));
+    $this->assign('address', CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($this->_params));
 
     //Add common data to formatted params
     $params = $this->_params;

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -648,10 +648,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       }
     }
 
-    $this->assign('address', CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters(
-      $this->_params,
-      $this->_bltID
-    ));
+    $this->assign('address', CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($this->_params,));
 
     if (!empty($this->_params['onbehalf_profile_id']) && !empty($this->_params['onbehalf'])) {
       $this->assign('onBehalfName', $this->_params['organization_name']);

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -468,7 +468,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       }
     }
 
-    $this->assign('address', CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($params, $this->_bltID));
+    $this->assign('address', CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($params));
 
     if ($this->getSubmittedValue('credit_card_number')) {
       if (isset($params['credit_card_exp_date'])) {

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1493,10 +1493,7 @@ DESC limit 1");
 
     if ($this->_mode) {
       // @todo move this outside shared code as Batch entry just doesn't
-      $this->assign('address', CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters(
-        $this->_params,
-        $this->_bltID
-      ));
+      $this->assign('address', CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($this->_params));
 
       $valuesForForm = CRM_Contribute_Form_AbstractEditPayment::formatCreditCardDetails($this->_params);
       $this->assignVariables($valuesForForm, ['credit_card_exp_date', 'credit_card_type', 'credit_card_number']);

--- a/CRM/Utils/Address.php
+++ b/CRM/Utils/Address.php
@@ -451,17 +451,17 @@ class CRM_Utils_Address {
    * Extract the billing fields from the form submission and format them for display.
    *
    * @param array $params
-   * @param int $billingLocationTypeID
    *
    * @return string
    */
-  public static function getFormattedBillingAddressFieldsFromParameters($params, $billingLocationTypeID) {
+  public static function getFormattedBillingAddressFieldsFromParameters(array $params): string {
+    $billingLocationTypeID = CRM_Core_BAO_LocationType::getBilling();
     $addressParts = [
-      "street_address" => "billing_street_address-{$billingLocationTypeID}",
-      "city" => "billing_city-{$billingLocationTypeID}",
-      "postal_code" => "billing_postal_code-{$billingLocationTypeID}",
-      "state_province" => "state_province-{$billingLocationTypeID}",
-      "country" => "country-{$billingLocationTypeID}",
+      'street_address' => "billing_street_address-{$billingLocationTypeID}",
+      'city' => "billing_city-{$billingLocationTypeID}",
+      'postal_code' => "billing_postal_code-{$billingLocationTypeID}",
+      'state_province' => "state_province-{$billingLocationTypeID}",
+      'country' => "country-{$billingLocationTypeID}",
     ];
 
     $addressFields = [];
@@ -478,12 +478,12 @@ class CRM_Utils_Address {
           $value = $params[$alternateName];
         }
       }
-      if (is_numeric($value) && ($name == 'state_province' || $name == 'country')) {
-        if ($name == 'state_province') {
+      if (is_numeric($value) && ($name === 'state_province' || $name === 'country')) {
+        if ($name === 'state_province') {
           $addressFields[$name] = CRM_Core_PseudoConstant::stateProvinceAbbreviation($value);
           $addressFields[$name . '_name'] = CRM_Core_PseudoConstant::stateProvince($value);
         }
-        if ($name == 'country') {
+        if ($name === 'country') {
           $addressFields[$name] = CRM_Core_PseudoConstant::countryIsoCode($value);
         }
       }
@@ -491,7 +491,7 @@ class CRM_Utils_Address {
         $addressFields[$name] = $value;
       }
     }
-    return CRM_Utils_Address::format($addressFields);
+    return (string) CRM_Utils_Address::format($addressFields);
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/AddressTest.php
+++ b/tests/phpunit/CRM/Utils/AddressTest.php
@@ -35,40 +35,40 @@ class CRM_Utils_AddressTest extends CiviUnitTestCase {
    */
   public function testStateProvinceFormattedBillingAddress(): void {
     $params = [
-      'billing_street_address-99' => '123 Happy Place',
-      'billing_city-99' => 'Miami',
-      'billing_postal_code-99' => 33101,
+      'billing_street_address-' . CRM_Core_BAO_LocationType::getBilling() => '123 Happy Place',
+      'billing_city-' . CRM_Core_BAO_LocationType::getBilling() => 'Miami',
+      'billing_postal_code-' . CRM_Core_BAO_LocationType::getBilling() => 33101,
       // 1000 => Alabama (AL)
-      'state_province-99' => '1000',
-      'country-99' => 'United States',
+      'state_province-' . CRM_Core_BAO_LocationType::getBilling() => '1000',
+      'country-' . CRM_Core_BAO_LocationType::getBilling() => 'United States',
     ];
 
     // Set address_format (we are only interested in state_province & state_province_name).
     $addFormat = '{contact.state_province}';
     Civi::settings()->set('address_format', $addFormat);
-    $formatted_address = CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($params, '99');
+    $formatted_address = CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($params);
     $this->assertEquals("AL\n", $formatted_address);
 
     $addFormat = '{contact.state_province_name}';
     Civi::settings()->set('address_format', $addFormat);
-    $formatted_address = CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($params, '99');
+    $formatted_address = CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($params);
     $this->assertEquals("Alabama\n", $formatted_address);
 
     // Test using alternate names for state/province field.
-    unset($params['state_province-99']);
+    unset($params['state_province-' . CRM_Core_BAO_LocationType::getBilling()]);
     // Alternate name 1.
-    $params['billing_state_province-99'] = '1000';
+    $params['billing_state_province-' . CRM_Core_BAO_LocationType::getBilling()] = '1000';
     $addFormat = '{contact.state_province_name}';
     Civi::settings()->set('address_format', $addFormat);
-    $formatted_address = CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($params, '99');
+    $formatted_address = CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($params);
     $this->assertEquals("Alabama\n", $formatted_address);
 
-    unset($params['state_province-99']);
+    unset($params['state_province-' . CRM_Core_BAO_LocationType::getBilling()]);
     // alternate name 2
-    $params['billing_state_province_id-99'] = '1000';
+    $params['billing_state_province_id-' . CRM_Core_BAO_LocationType::getBilling()] = '1000';
     $addFormat = '{contact.state_province_name}';
     Civi::settings()->set('address_format', $addFormat);
-    $formatted_address = CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($params, '99');
+    $formatted_address = CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($params);
     $this->assertEquals("Alabama\n", $formatted_address);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Stop passing billingID to `CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters`

Before
----------------------------------------
BillingID is only ever derived from the `getBillingID()` looks up but then it gets set on all the forms (sometimes as an undefined property) before being passed around

After
----------------------------------------
Billing ID looked up in the function that uses it

Technical Details
----------------------------------------

Comments
----------------------------------------
