### PR TITLE
Declare property from paypal express as public

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -40,6 +40,15 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
   protected $_snippet;
 
   /**
+   * Variable for legacy paypal express implementation.
+   *
+   * @var string
+   *
+   * @internal - only to be used by legacy paypal express implementation.
+   */
+  public $_expressButtonName;
+
+  /**
    * Get the active UFGroups (profiles) on this form
    * Many forms load one or more UFGroups (profiles).
    * This provides a standard function to retrieve the IDs of those profiles from the form


### PR DESCRIPTION
Overview
----------------------------------------
Declare property from paypal express as public

Before
----------------------------------------
Property set by paypal express as a way of passing it to the form is not declared

After
----------------------------------------
Declared

Technical Details
----------------------------------------
bad, horrible, awful - but this has very limited surface area so let's just make it go away

Comments
----------------------------------------
