### PR TITLE
Add helper functions to contribution page

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1900,16 +1900,16 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     $paramsProcessedForForm = $form->_params = self::getFormParams($params['id'], $params);
 
-    $order = new CRM_Financial_BAO_Order();
-    $order->setPriceSetIDByContributionPageID($params['id']);
-    $order->setPriceSelectionFromUnfilteredInput($params);
+    $form->order = new CRM_Financial_BAO_Order();
+    $form->order->setPriceSetIDByContributionPageID($params['id']);
+    $form->order->setPriceSelectionFromUnfilteredInput($params);
     if (isset($params['amount']) && !$form->isSeparateMembershipPayment()) {
       // @todo deprecate receiving amount, calculate on the form.
-      $order->setOverrideTotalAmount((float) $params['amount']);
+      $form->order->setOverrideTotalAmount((float) $params['amount']);
     }
-    $amount = $order->getTotalAmount();
+    $amount = $form->order->getTotalAmount();
     if ($form->isSeparateMembershipPayment()) {
-      $amount -= $order->getMembershipTotalAmount();
+      $amount -= $form->order->getMembershipTotalAmount();
     }
     $form->_amount = $params['amount'] = $form->_params['amount'] = $amount;
     // hack these in for test support.
@@ -1948,9 +1948,9 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
     $priceFields = $priceFields[$priceSetID]['fields'];
 
-    $form->_lineItem = [$priceSetID => $order->getLineItems()];
+    $form->_lineItem = [$priceSetID => $form->order->getLineItems()];
     $membershipPriceFieldIDs = [];
-    foreach ($order->getLineItems() as $lineItem) {
+    foreach ($form->order->getLineItems() as $lineItem) {
       if (!empty($lineItem['membership_type_id'])) {
         $form->set('useForMember', 1);
         $form->_useForMember = 1;

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -1122,6 +1122,18 @@ class CRM_Financial_BAO_Order {
   }
 
   /**
+   * Set the line item array.
+   *
+   * This is mostly useful when they have been calculated & stored
+   * on the form & we want to rebuild the line item object.
+   *
+   * @param array $lineItems
+   */
+  public function setLineItems(array $lineItems): void {
+    $this->lineItems = $lineItems;
+  }
+
+  /**
    * @param int|string $index
    *
    * @return string


### PR DESCRIPTION
Overview
----------------------------------------
This adds the helper functions from https://github.com/civicrm/civicrm-core/pull/28223 along with fixes specific to the test flow and a couple on enhancements to the order set up (registering the form for hooks, setting any existing contribution ID being paid against and using the stored line items, if any

Before
----------------------------------------
Getting snarled up jugging code

After
----------------------------------------
Helper functions put up separately

Technical Details
----------------------------------------

Comments
----------------------------------------
