### PR TITLE
Pass contact id to sendmail function

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -691,6 +691,7 @@ FROM civicrm_action_schedule cas
       'subject' => $tokenRow->render('subject'),
       'entity' => 'action_schedule',
       'entity_id' => $schedule->id,
+      'toContactID' => $toContactID,
     ];
     $body_text = $tokenRow->render('body_text');
     $mailParams['html'] = $tokenRow->render('body_html');

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -691,7 +691,7 @@ FROM civicrm_action_schedule cas
       'subject' => $tokenRow->render('subject'),
       'entity' => 'action_schedule',
       'entity_id' => $schedule->id,
-      'toContactID' => $toContactID,
+      'contactId' => $toContactID,
     ];
     $body_text = $tokenRow->render('body_text');
     $mailParams['html'] = $tokenRow->render('body_html');


### PR DESCRIPTION
Overview
----------------------------------------
Pass the contact ID to send mail; use this in `CRM_Utils_Hook::alterMailParams` or `CRM_Utils_Hook::postEmailSend` if required.

Before
----------------------------------------
It's difficult to find the correct contact ID based on an email address.

After
----------------------------------------
The contact ID is present on the hook.
