### PR TITLE
Update custom contact entity reference field values on contact merge

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2667,8 +2667,9 @@ SELECT contact_id
         $contactReferences[$coreReference->getReferenceTable()][] = $coreReference->getReferenceKey();
       }
     }
-    self::appendCustomTablesExtendingContacts($contactReferences);
-    self::appendCustomContactReferenceFields($contactReferences);
+    CRM_Core_DAO_Helper_ContactReferenceField::appendCustomTablesExtendingContacts($contactReferences);
+    CRM_Core_DAO_Helper_ContactReferenceField::appendCustomContactReferenceFields($contactReferences);
+    CRM_Core_DAO_Helper_ContactReferenceField::appendCustomContactEntityReferenceFields($contactReferences);
     \Civi::$statics[__CLASS__]['contact_references'] = $contactReferences;
     return \Civi::$statics[__CLASS__]['contact_references'];
   }
@@ -2691,46 +2692,6 @@ SELECT contact_id
       }
     }
     return \Civi::$statics[__CLASS__]['contact_references_dynamic'][$tableName];
-  }
-
-  /**
-   * Add custom tables that extend contacts to the list of contact references.
-   *
-   * CRM_Core_BAO_CustomGroup::getAllCustomGroupsByBaseEntity seems like a safe-ish
-   * function to be sure all are retrieved & we don't miss subtypes or inactive or multiples
-   * - the down side is it is not cached.
-   *
-   * Further changes should be include tests in the CRM_Core_MergerTest class
-   * to ensure that disabled, subtype, multiple etc groups are still captured.
-   *
-   * @param array $cidRefs
-   */
-  public static function appendCustomTablesExtendingContacts(&$cidRefs) {
-    $customValueTables = CRM_Core_BAO_CustomGroup::getAllCustomGroupsByBaseEntity('Contact');
-    $customValueTables->find();
-    while ($customValueTables->fetch()) {
-      $cidRefs[$customValueTables->table_name][] = 'entity_id';
-    }
-  }
-
-  /**
-   * Add custom ContactReference fields to the list of contact references
-   *
-   * This includes active and inactive fields/groups
-   *
-   * @param array $cidRefs
-   *
-   * @throws \CRM_Core_Exception
-   */
-  public static function appendCustomContactReferenceFields(&$cidRefs) {
-    $fields = civicrm_api3('CustomField', 'get', [
-      'return'    => ['column_name', 'custom_group_id.table_name'],
-      'data_type' => 'ContactReference',
-      'options' => ['limit' => 0],
-    ])['values'];
-    foreach ($fields as $field) {
-      $cidRefs[$field['custom_group_id.table_name']][] = $field['column_name'];
-    }
   }
 
   /**

--- a/CRM/Core/DAO/Helper/ContactReferenceField.php
+++ b/CRM/Core/DAO/Helper/ContactReferenceField.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types = 1);
+
+use Civi\Api4\CustomField;
+
+final class CRM_Core_DAO_Helper_ContactReferenceField {
+
+  /**
+   * Add custom ContactReference fields to the list of contact references.
+   *
+   * This includes active and inactive fields/groups.
+   *
+   * @phpstan-param array<string, array<string>> $cidRefs
+   *   Mapping of table name to column names.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public static function appendCustomContactEntityReferenceFields(array &$cidRefs): void {
+    $fields = CustomField::get(FALSE)
+      ->setSelect(['column_name', 'custom_group_id.table_name'])
+      ->addWhere('data_type', '=', 'EntityReference')
+      ->addWhere('fk_entity', 'IN', ['Contact', 'Household', 'Individual', 'Organization'])
+      ->execute();
+    foreach ($fields as $field) {
+      $cidRefs[$field['custom_group_id.table_name']][] = $field['column_name'];
+    }
+  }
+
+  /**
+   * Add custom ContactReference fields to the list of contact references
+   *
+   * This includes active and inactive fields/groups
+   *
+   * @phpstan-param array<string, array<string>> $cidRefs
+   *   Mapping of table name to column names.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public static function appendCustomContactReferenceFields(array &$cidRefs): void {
+    $fields = civicrm_api3('CustomField', 'get', [
+      'return' => ['column_name', 'custom_group_id.table_name'],
+      'data_type' => 'ContactReference',
+      'options' => ['limit' => 0],
+    ])['values'];
+    foreach ($fields as $field) {
+      $cidRefs[$field['custom_group_id.table_name']][] = $field['column_name'];
+    }
+  }
+
+  /**
+   * Add custom tables that extend contacts to the list of contact references.
+   *
+   * CRM_Core_BAO_CustomGroup::getAllCustomGroupsByBaseEntity seems like a safe-ish
+   * function to be sure all are retrieved & we don't miss subtypes or inactive or multiples
+   * - the down side is it is not cached.
+   *
+   * Further changes should be include tests in the CRM_Core_MergerTest class
+   * to ensure that disabled, subtype, multiple etc groups are still captured.
+   *
+   * @phpstan-param array<string, array<string>> $cidRefs
+   *   Mapping of table name to column names.
+   */
+  public static function appendCustomTablesExtendingContacts(array &$cidRefs): void {
+    $customValueTables = CRM_Core_BAO_CustomGroup::getAllCustomGroupsByBaseEntity('Contact');
+    $customValueTables->find();
+    while ($customValueTables->fetch()) {
+      $cidRefs[$customValueTables->table_name][] = 'entity_id';
+    }
+  }
+
+}

--- a/tests/phpunit/CRM/Core/DAO/Helper/CRM_Core_DAO_Helper_ContactReferenceFieldTest.php
+++ b/tests/phpunit/CRM/Core/DAO/Helper/CRM_Core_DAO_Helper_ContactReferenceFieldTest.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types = 1);
+
+use Civi\Api4\CustomField;
+use Civi\Api4\CustomGroup;
+
+/**
+ * @covers \CRM_Core_DAO_Helper_ContactReferenceField
+ *
+ * @group headless
+ */
+final class CRM_Core_DAO_Helper_ContactReferenceFieldTest extends CiviUnitTestCase {
+
+  public function testAppendCustomContactEntityReferenceFields(): void {
+    $customGroup1 = CustomGroup::create()
+      ->setValues([
+        'name' => 'cg1',
+        'title' => 'Custom Group',
+        'extends' => 'Group',
+      ])
+      ->execute()
+      ->single();
+    $customGroup2 = CustomGroup::create()
+      ->setValues([
+        'name' => 'cg2',
+        'title' => 'Custom Group',
+        'extends' => 'Contact',
+      ])
+      ->execute()
+      ->single();
+
+    $contactCustomField = $this->createCustomField($customGroup1['id'], 'Contact');
+    $householdCustomField = $this->createCustomField($customGroup1['id'], 'Household');
+    $individualCustomField = $this->createCustomField($customGroup2['id'], 'Individual');
+    $organizationCustomField = $this->createCustomField($customGroup2['id'], 'Organization');
+    $groupCustomField = $this->createCustomField($customGroup2['id'], 'Group');
+
+    $expectedCidRefs = [
+      $customGroup1['table_name'] => [
+        $contactCustomField['column_name'],
+        $householdCustomField['column_name'],
+      ],
+      $customGroup2['table_name'] => [
+        $individualCustomField['column_name'],
+        $organizationCustomField['column_name'],
+      ],
+    ];
+    $cidRefs = [];
+    CRM_Core_DAO_Helper_ContactReferenceField::appendCustomContactEntityReferenceFields($cidRefs);
+    static::assertEquals($expectedCidRefs, $cidRefs);
+
+    // cleanup
+    $this->callAPISuccess('CustomField', 'delete', ['id' => $contactCustomField['id']]);
+    $this->callAPISuccess('CustomField', 'delete', ['id' => $householdCustomField['id']]);
+    $this->callAPISuccess('CustomField', 'delete', ['id' => $individualCustomField['id']]);
+    $this->callAPISuccess('CustomField', 'delete', ['id' => $organizationCustomField['id']]);
+    $this->callAPISuccess('CustomField', 'delete', ['id' => $groupCustomField['id']]);
+    $this->callAPISuccess('CustomGroup', 'delete', ['id' => $customGroup1['id']]);
+    $this->callAPISuccess('CustomGroup', 'delete', ['id' => $customGroup2['id']]);
+  }
+
+  private function createCustomField(int $customGroupId, string $fkEntity): array {
+    static $count = 0;
+    ++$count;
+
+    return CustomField::create(FALSE)
+      ->setValues([
+        'custom_group_id' => $customGroupId,
+        'name' => 'field' . $count,
+        'data_type' => 'EntityReference',
+        'fk_entity' => $fkEntity,
+        'label' => 'Field' . $count,
+        'html_type' => 'Select',
+      ])
+      ->execute()
+      ->single();
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Custom `EntityReference` field values referencing a contact are updated on contact merge just like `ContactReference` field values.
