### PR TITLE
Remove assignments for template that are not needed for updated template

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2636,9 +2636,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
             $template->assign('membership_name',
               CRM_Member_PseudoConstant::membershipType($membership->membership_type_id)
             );
-            $template->assign('mem_start_date', $membership->start_date);
-            $template->assign('mem_join_date', $membership->join_date);
-            $template->assign('mem_end_date', $membership->end_date);
             $membership_status = CRM_Member_PseudoConstant::membershipStatus($membership->status_id, NULL, 'label');
             $template->assign('mem_status', $membership_status);
             if ($membership_status === 'Pending' && $membership->is_pay_later == 1) {

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1533,10 +1533,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         );
 
         $this->set('renewal_mode', $renewalMode);
-        if (!empty($dates)) {
-          $this->assign('mem_start_date', CRM_Utils_Date::customFormat($dates['start_date'], '%Y%m%d'));
-          $this->assign('mem_end_date', CRM_Utils_Date::customFormat($dates['end_date'], '%Y%m%d'));
-        }
 
         if (!empty($membershipContribution)) {
           // Next line is probably redundant. Checks prevent it happening twice.

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1557,21 +1557,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           $this->_values['membership_id'] = $membership->id;
         }
       }
-      if ($this->_priceSetId && !empty($this->_useForMember) && !empty($this->_lineItem)) {
-        foreach ($this->_lineItem[$this->_priceSetId] as & $priceFieldOp) {
-          if (!empty($priceFieldOp['membership_type_id']) && $membership->membership_type_id == $priceFieldOp['membership_type_id']) {
-            $membershipOb = $membership;
-            $priceFieldOp['start_date'] = $membershipOb->start_date ? CRM_Utils_Date::formatDateOnlyLong($membershipOb->start_date) : '-';
-            $priceFieldOp['end_date'] = $membershipOb->end_date ? CRM_Utils_Date::formatDateOnlyLong($membershipOb->end_date) : '-';
-          }
-          else {
-            $priceFieldOp['start_date'] = $priceFieldOp['end_date'] = 'N/A';
-          }
-        }
-        $this->_values['lineItem'] = $this->_lineItem;
-        $this->assign('lineItem', $this->_lineItem);
-      }
     }
+    $this->assign('lineItem', $this->isQuickConfig() ? NULL : $this->getLineItems());
 
     if (!empty($errors)) {
       $message = $this->compileErrorMessage($errors);
@@ -2661,12 +2648,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       }
       if (isset($paymentParams['contribution_source'])) {
         $form->_params['source'] = $paymentParams['contribution_source'];
-      }
-
-      // get the price set values for receipt.
-      if ($form->_priceSetId && $form->_lineItem) {
-        $form->_values['lineItem'] = $form->_lineItem;
-        $form->_values['priceSetID'] = $form->_priceSetId;
       }
 
       $form->_values['contribution_id'] = $contribution->id;

--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -368,6 +368,15 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'event_offline_receipt', 'type' => 'subject'],
         ],
       ],
+      [
+        'version' => '5.69.alpha1',
+        'upgrade_descriptor' => ts('Significant changes to the template and available variables. Text version is discontinued'),
+        'templates' => [
+          ['name' => 'membership_online_receipt', 'type' => 'text'],
+          ['name' => 'membership_online_receipt', 'type' => 'html'],
+          ['name' => 'membership_online_receipt', 'type' => 'subject'],
+        ],
+      ],
     ];
   }
 

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1779,6 +1779,9 @@ class CRM_Utils_Token {
         ],
         'membership_online_receipt' => [
           '$dataArray' => ts('found within $taxBreakDown'),
+          '$mem_start_date' => 'membership.start_date',
+          '$mem_end_date' => 'membership.end_date',
+          '$mem_join_date' => 'membership.join_date',
         ],
         'event_offline_receipt' => [
           '$contributeMode' => ts('no longer available / relevant'),


### PR DESCRIPTION
Overview
----------------------------------------
Remove assignments for template that are not needed for updated template

Before
----------------------------------------
Extra assigns creating code complexity

After
----------------------------------------
poof

Technical Details
----------------------------------------
The membership online receipt is this releases big-cleanup-template - this adds noise to the upgrade for it & also removes some assigns that are specific to this template but no longer used in the template.

Note we don't put `lineItem` in the deprecation list as it will pick up `$lineItems` - which is used

Comments
----------------------------------------
