### PR TITLE
Reduce passing of `lineItems`

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -267,7 +267,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     parent::preProcess();
 
     // lineItem isn't set until Register postProcess
-    $this->_lineItem = $this->get('lineItem');
+    $this->_lineItem = [$this->getPriceSetID() => $this->getLineItems()];;
     $this->_ccid = $this->get('ccid');
 
     $this->_params = $this->controller->exportValues('Main');
@@ -2242,7 +2242,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     // store the fact that this is a membership and membership type is selected
     if ($this->isMembershipSelected($membershipParams)) {
-      $this->doMembershipProcessing($contactID, $membershipParams, $premiumParams, $this->_lineItem);
+      $this->doMembershipProcessing($contactID, $membershipParams, $premiumParams);
     }
     else {
       // at this point we've created a contact and stored its address etc
@@ -2359,9 +2359,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @param int $contactID
    * @param array $membershipParams
    * @param array $premiumParams
-   * @param array $formLineItems
    */
-  protected function doMembershipProcessing($contactID, $membershipParams, $premiumParams, $formLineItems) {
+  protected function doMembershipProcessing($contactID, $membershipParams, $premiumParams) {
     if (!$this->_useForMember) {
       $this->set('membershipTypeID', $this->_params['selectMembership']);
     }
@@ -2423,7 +2422,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $membershipParams = $this->getMembershipParamsFromPriceSet($membershipParams);
     if (!empty($membershipParams['selectMembership'])) {
       // CRM-12233
-      $membershipLineItems = $formLineItems;
+      $membershipLineItems = [$this->getPriceSetID() => $this->getLineItems()];;
       if ($this->_separateMembershipPayment && $this->isFormSupportsNonMembershipContributions()) {
         $membershipLineItems = [];
         foreach ($this->_values['fee'] as $key => $feeValues) {


### PR DESCRIPTION

Overview
----------------------------------------
Reduce passing of `lineItems`

Before
----------------------------------------
The get() function is called when setting the order line items so calling getLineItems() will return the same thing. 

After
----------------------------------------
The value passed as `formLineItems` is simply the value from `getLineItems()` so rather than pass it get it at the point where it is needed

Technical Details
----------------------------------------

Comments
----------------------------------------
