### PR TITLE
[Premiums] Fix access to undeclared property, remove unreachable code

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/AddProduct.php
+++ b/CRM/Contribute/Form/ContributionPage/AddProduct.php
@@ -187,23 +187,7 @@ class CRM_Contribute_Form_ContributionPage_AddProduct extends CRM_Contribute_For
     $this->addRule('weight', ts('Please enter integer value for weight'), 'integer');
     $session->pushUserContext(CRM_Utils_System::url($urlParams, 'action=update&reset=1&id=' . $this->_id));
 
-    if ($this->_single) {
-      $this->addButtons([
-        [
-          'type' => 'next',
-          'name' => ts('Save'),
-          'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;',
-          'isDefault' => TRUE,
-        ],
-        [
-          'type' => 'cancel',
-          'name' => ts('Cancel'),
-        ],
-      ]);
-    }
-    else {
-      parent::buildQuickForm();
-    }
+    parent::buildQuickForm();
   }
 
   /**

--- a/CRM/Contribute/Form/ContributionPage/Premium.php
+++ b/CRM/Contribute/Form/ContributionPage/Premium.php
@@ -68,20 +68,6 @@ class CRM_Contribute_Form_ContributionPage_Premium extends CRM_Contribute_Form_C
     $this->add('text', 'premiums_nothankyou_label', ts('No Thank-you Label'), $attributes['premiums_nothankyou_label']);
     $positions = [1 => ts('Before Premiums'), 2 => ts('After Premiums')];
     $this->add('select', 'premiums_nothankyou_position', ts('No Thank-you Option'), $positions);
-    $showForm = TRUE;
-
-    if ($this->_single) {
-      if ($this->_id) {
-        $daoPremium = new CRM_Contribute_DAO_Premium();
-        $daoPremium->entity_id = $this->_id;
-        $daoPremium->entity_table = 'civicrm_contribution_page';
-        $daoPremium->premiums_active = 1;
-        if ($daoPremium->find(TRUE)) {
-          $showForm = FALSE;
-        }
-      }
-    }
-    $this->assign('showForm', $showForm);
 
     parent::buildQuickForm();
     $this->addFormRule(['CRM_Contribute_Form_ContributionPage_Premium', 'formRule'], $this);

--- a/templates/CRM/Contribute/Page/Premium.tpl
+++ b/templates/CRM/Contribute/Page/Premium.tpl
@@ -48,16 +48,14 @@
     {/if}
 </div>
 {else}
-  {if $showForm eq false}
-    <div class="messages status no-popup">
-      {if $products ne null}
-        {icon icon="fa-info-circle"}{/icon}
-        {capture assign=crmURL}{crmURL p='civicrm/admin/contribute/addProductToPage' q="reset=1&action=update&id=$id"}{/capture}
-        {ts 1=$crmURL}There are no premiums offered on this contribution page yet. You can <a href='%1'>add one</a>.{/ts}
-      {else}
-        {icon icon="fa-info-circle"}{/icon}
-        {ts 1=$managePremiumsURL}There are no active premiums for your site. You can <a href='%1'>create and/or enable premiums here</a>.{/ts}
-      {/if}
-    </div>
-  {/if}
+  <div class="messages status no-popup">
+    {if $products ne null}
+      {icon icon="fa-info-circle"}{/icon}
+      {capture assign=crmURL}{crmURL p='civicrm/admin/contribute/addProductToPage' q="reset=1&action=update&id=$id"}{/capture}
+      {ts 1=$crmURL}There are no premiums offered on this contribution page yet. You can <a href='%1'>add one</a>.{/ts}
+    {else}
+      {icon icon="fa-info-circle"}{/icon}
+      {ts 1=$managePremiumsURL}There are no active premiums for your site. You can <a href='%1'>create and/or enable premiums here</a>.{/ts}
+    {/if}
+  </div>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Fix access to undeclared property, remove unreachable code

Before
----------------------------------------
There is a notice about `_single` not being defined. I could not find anywhere in the code or the UI that showed it being set so concluded it must be copy & paste & probably pre-ceded the accordian that shows up now


![image](https://github.com/civicrm/civicrm-core/assets/336308/a35943fd-769a-4572-8dc9-fdd34c2c0df9)

Note that if the undefined property were true it would lead to `showForm` being assigned as FALSE & permit the page to work - but as it never is the add premium code is suppressed & the form won't permit premium adding


![image](https://github.com/civicrm/civicrm-core/assets/336308/cb679989-70ca-427a-bcfb-f2e0d14accb3)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/f7d1506f-5ba0-46ee-8d3b-b0b62947f0d1)


Technical Details
----------------------------------------
showForm not otherwise assigned


![image](https://github.com/civicrm/civicrm-core/assets/336308/6bedc916-aed4-4344-989b-f22f1e5d6aad)


Comments
----------------------------------------
