### PR TITLE
Fix regression in 5.68 on selecting a premium (when at least one is unavailable)

### DIFF
--- a/CRM/Contribute/BAO/Premium.php
+++ b/CRM/Contribute/BAO/Premium.php
@@ -112,9 +112,9 @@ class CRM_Contribute_BAO_Premium extends CRM_Contribute_DAO_Premium {
             }
           }
           else {
+            // Why? should we not skip if not found?
             CRM_Core_DAO::storeValues($productDAO, $products[$productDAO->id]);
           }
-          $products[$productDAO->id] += ['thumbnail' => '', 'image' => ''];
         }
         $options = $temp = [];
         $temp = explode(',', $productDAO->options);


### PR DESCRIPTION
Overview
----------------------------------------
Fix regression in 5.68 on selecting a premium (when at least one is unavailabl)

Before
----------------------------------------
When the product is not found it tries to merge an array into NULL & gives an error

![image](https://github.com/civicrm/civicrm-core/assets/336308/5730053a-8d1b-4ff0-8300-b24ffc16e827)

After
----------------------------------------
works

Technical Details
----------------------------------------
I moved this line https://github.com/civicrm/civicrm-core/pull/27852/files#diff-73245585628ab051007aca1205aa3793e2609c4050d66b83394c8931358176a4R117 to where we could be more sure the array exists

Comments
----------------------------------------
