### PR TITLE
Online membership receipt simplification

### DIFF
--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -425,9 +425,9 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     $this->assertEquals($membership['contact_id'], $contributions[$membershipPayment['contribution_id']]['contact_id']);
     $mut->checkMailLog([
       'Gruff',
-      'General Membership',
-      '$0.00',
-      'Membership Fee',
+      'General',
+      'Membership Information',
+      'Membership Type',
     ]);
     $mut->stop();
     $mut->clearMessages();

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -179,18 +179,18 @@
       </tr>
     {/if}
 
-    {if !empty($receive_date)}
+    {if {contribution.receive_date|boolean}}
       <tr>
         <td {$labelStyle}>
           {ts}Date{/ts}
         </td>
         <td {$valueStyle}>
-          {$receive_date|crmDate}
+          {contribution.receive_date}
         </td>
       </tr>
     {/if}
 
-    {if !empty($is_monetary) and !empty($trxn_id)}
+    {if !empty($trxn_id)}
       <tr>
        <td {$labelStyle}>
         {ts}Transaction #{/ts}

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -72,7 +72,7 @@
         <th {$headerStyle}>{ts}Membership Fee{/ts}</th>
       </tr>
 
-      {if !$useForMember and isset($membership_amount) and !empty($is_quick_config)}
+      {if !$isShowLineItems && {contribution.total_amount|boolean}}
         <tr>
           <td {$labelStyle}>
             {ts 1=$membership_name}%1 Membership{/ts}
@@ -175,20 +175,6 @@
         </td>
         <td {$valueStyle}>
             {contribution.total_amount} {if isset($amount_level)} - {$amount_level}{/if}
-        </td>
-      </tr>
-    {elseif isset($membership_amount)}
-      <tr>
-        <th {$headerStyle}>
-          {ts}Membership Fee{/ts}
-        </th>
-      </tr>
-      <tr>
-        <td {$labelStyle}>
-          {ts 1=$membership_name}%1 Membership{/ts}
-        </td>
-        <td {$valueStyle}>
-          {$membership_amount|crmMoney}
         </td>
       </tr>
     {/if}


### PR DESCRIPTION

Overview
----------------------------------------
Online membership receipt simplification

Before
----------------------------------------
It's taken me ages to figure this out but... the receipt has a structure like 

```
if ($amount) {

}
elseif ($membership_amount) {

}
```

The latter is hit when we are dealing with a separate payment contribution form where 'no thank you' is selected as an option - so 'amount', being the contribution amount is empty but 'membership_amount' is not. 

How does this differ from a not-separate-payment membership only? It doesn't need to....if it is allowed to enter that first 'if;' then it will display the membership name & amount - which is all that elseif offers (well it adds membership fee - but that is neither here nor there)

After
----------------------------------------
SImplifed to one check for there being an amount at all on the form - via the token

Technical Details
----------------------------------------
I've been building up test cover on this stuff but will continue to do that + UI testing once the current swag are merged. My goal is to get these changes consolidated in one release to permit rc testing

Comments
----------------------------------------

