### PR TITLE
dev/financial#221 - Bring back missing time field

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -1987,7 +1987,7 @@ class CRM_Utils_Date {
           $field['smarty_view_format'] = $dateAttributes['smarty_view_format'];
         }
         $field['datepicker']['extra'] = self::getDatePickerExtra($field);
-        $field['datepicker']['extra']['time'] = $fieldMetaData['type'] == CRM_Utils_Type::T_TIMESTAMP;
+        $field['datepicker']['extra']['time'] = $fieldMetaData['type'] == CRM_Utils_Type::T_TIMESTAMP || $fieldMetaData['type'] == (CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME);
         $field['datepicker']['attributes'] = self::getDatePickerAttributes($field);
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/financial/-/issues/221

Before
----------------------------------------
Time field is missing for some fields like contribution date and receipt date on the contribution form.

After
----------------------------------------


Technical Details
----------------------------------------
This is one way to fix it. I'm not sure why it doesn't affect similar fields like activity date.

Comments
----------------------------------------
Affects 5.66+
