### PR TITLE
dev/core#4798 Extend line item notice fix from Confirm to Thank you page

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -82,7 +82,7 @@
         {if $lineItem and $priceSetID}
           {if !$amount}{assign var="amount" value=0}{/if}
           {assign var="totalAmount" value=$amount}
-          {include file="CRM/Price/Page/LineItem.tpl" context="Contribution"}
+          {include file="CRM/Price/Page/LineItem.tpl" context="Contribution" displayLineItemFinancialType=false pricesetFieldsCount=false currencySymbol='' hookDiscount=''}
         {elseif $membership_amount}
           {$membership_name} {ts}Membership{/ts}: <strong>{$membership_amount|crmMoney}</strong><br />
           {if $amount}


### PR DESCRIPTION
Overview
----------------------------------------
Same fix as https://github.com/civicrm/civicrm-core/pull/28205 - ensures event-relevant variables are assigned  but on the thank you page

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/2c66d155-56b4-4c60-9667-c7d943e2e881)

After
----------------------------------------
The line item ones are gone

Technical Details
----------------------------------------

Comments
----------------------------------------
