### PR TITLE
dev/core#4798 Unshared toxic function `getNonDeductibleAmount()`

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -210,7 +210,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    *
    * @return array
    */
-  public static function getNonDeductibleAmount($params, $financialType, $online, $form) {
+  private function getNonDeductibleAmount($params, $financialType, $online, $form) {
     if (isset($params['non_deductible_amount']) && (!empty($params['non_deductible_amount']))) {
       return $params['non_deductible_amount'];
     }
@@ -1046,7 +1046,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       );
 
       $contributionParams['payment_processor'] = $result ? ($result['payment_processor'] ?? NULL) : NULL;
-      $contributionParams['non_deductible_amount'] = self::getNonDeductibleAmount($params, $financialType, TRUE, $form);
+      $contributionParams['non_deductible_amount'] = $this->getNonDeductibleAmount($params, $financialType, TRUE, $form);
       $contributionParams['skipCleanMoney'] = TRUE;
       // @todo this is the wrong place for this - it should be done as close to form submission
       // as possible


### PR DESCRIPTION
Overview
----------------------------------------
Unshared toxic function `getNonDeductibleAmount()`

Before
----------------------------------------
Function called from 2 places in universe which share it - it is pretty broken!

![image](https://github.com/civicrm/civicrm-core/assets/336308/debfdb81-cbe0-46a1-9bb8-3d6796d85936)


After
----------------------------------------
Divide & conquer! We now have 2 private functions & can fix up for the one I have confirmed it to be broken in (fixes are likely to be different as the whole function is early returning for the online contribution flow because it missed the memo about our 4.2 release with the move to pricesets & line items for all contributions 

Technical Details
----------------------------------------

Comments
----------------------------------------
