### PR TITLE
Unshare toxic function `getContributionParams()`

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -144,16 +144,15 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    *
    * @param array $params
    * @param int $financialTypeID
-   * @param array $paymentProcessorOutcome
    * @param string $receiptDate
    * @param int $recurringContributionID
    *
    * @return array
    * @throws \CRM_Core_Exception
    */
-  public static function getContributionParams(
+  private function getContributionParams(
     $params, $financialTypeID,
-    $paymentProcessorOutcome, $receiptDate, $recurringContributionID) {
+    $receiptDate, $recurringContributionID) {
     $contributionParams = [
       'financial_type_id' => $financialTypeID,
       'receive_date' => !empty($params['receive_date']) ? CRM_Utils_Date::processDate($params['receive_date']) : date('YmdHis'),
@@ -1039,9 +1038,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
 
     if (isset($params['amount'])) {
-      $contributionParams = array_merge(self::getContributionParams(
-        $params, $financialType->id,
-        NULL, $receiptDate,
+      $contributionParams = array_merge($this->getContributionParams(
+        $params, $financialType->id, $receiptDate,
         $recurringContributionID), $contributionParams
       );
 


### PR DESCRIPTION
Overview
----------------------------------------
Unshare another unhelpfully shared function

Before
----------------------------------------
No other usages in universe

![image](https://github.com/civicrm/civicrm-core/assets/336308/b430eb32-921e-44dd-97c7-ff7c9c48cee1)

After
----------------------------------------
Each class has it's own private copy

Technical Details
----------------------------------------

Comments
----------------------------------------
