### PR TITLE
dev/core#1083 Partial fix on non-deductible amount not being set on the contribution in online contribution page

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -984,6 +984,23 @@ class CRM_Financial_BAO_Order {
    *
    * @throws \CRM_Core_Exception
    */
+  public function getNonDeductibleAmount() :float {
+    $amount = 0.0;
+    foreach ($this->getLineItems() as $lineItem) {
+      if ($lineItem['non_deductible_amount'] > 0 && $lineItem['qty'] > 0) {
+        $amount += ($lineItem['non_deductible_amount'] * $lineItem['qty']);
+      }
+    }
+    return $amount;
+  }
+
+  /**
+   * Get the total amount for the order.
+   *
+   * @return float
+   *
+   * @throws \CRM_Core_Exception
+   */
   public function getTotalAmount() :float {
     $amount = 0.0;
     foreach ($this->getLineItems() as $lineItem) {

--- a/Civi/Test/ContributionPageTestTrait.php
+++ b/Civi/Test/ContributionPageTestTrait.php
@@ -194,9 +194,9 @@ trait ContributionPageTestTrait {
    * @param array $priceSetParameters
    */
   public function contributionPageWithPriceSetCreate(array $contributionPageParameters = [], array $priceSetParameters = []): void {
-    $this->contributionPageCreatePaid($contributionPageParameters, $priceSetParameters);
+    $this->contributionPageCreatePaid($contributionPageParameters, $priceSetParameters + ['is_quick_config' => FALSE]);
     $priceSetID = $this->ids['PriceSet']['ContributionPage'];
-    $this->createTestEntity('FinancialType', ['name' => 'Financial Type 1'], 'first');
+    $this->createTestEntity('FinancialType', ['name' => 'Financial Type 1', 'is_deductible' => TRUE], 'first');
     $this->createTestEntity('FinancialType', ['name' => 'Financial Type 2'], 'second');
     $this->createTestEntity('FinancialType', ['name' => 'Financial Type 3'], 'third');
     $priceField = $this->createTestEntity('PriceField', [


### PR DESCRIPTION
Overview
----------------------------------------
Partial fix on non-deductible amount not being set on the contribution in online contribution page.

I had multiple issues configuring this to test my theory that it wasn't working - so I suspect it might not be much used. However, if you configure a premium for a product then the non-deductible amount should be set appropriately on the contribution and line item. This fixes for the contribution (only at this stage) in the quick config flow & leaves the non-quick-config to continue to get the value from the line item. I'd like to get to the full fix but I need to get some other open PRs resolved before I can tackle that to avoid conflicts (including in the test code I want to add to) so I'm just fixing one part of it in this PR (which will also make it easier to fix the next parts)

Before
----------------------------------------
If you set up a contribution page with a premium & select enough of a donation you can choose a premium

![image](https://github.com/civicrm/civicrm-core/assets/336308/b1ec1a96-44f0-4c35-9d32-14074b60fa5c)

The expectation is that the contribution should then have a non-deductible amount IF
1) the financial type of the contribution page is deductible
2) the page is quick config

However, in my testing it is not being set

In the case of not-quick-config my expectation is that the value will be calculated from the line items before and after this patch.


After
----------------------------------------
The non-deductible amount is set based on the product price when the page is quick config and the financial type is deductible

Technical Details
----------------------------------------
Note that I hope to do a follow on fix to put the non_deductible amount into the line item

Comments
----------------------------------------
