### PR TITLE
Fix getTaxDetails notices on Confirm page

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -257,13 +257,6 @@ WHERE li.contribution_id = %1";
         $getTaxDetails = TRUE;
       }
     }
-    if (Civi::settings()->get('invoicing')) {
-      // @todo - this is an inappropriate place to be doing form level assignments.
-      $taxTerm = Civi::settings()->get('tax_term');
-      $smarty = CRM_Core_Smarty::singleton();
-      $smarty->assign('taxTerm', $taxTerm);
-      $smarty->assign('getTaxDetails', $getTaxDetails);
-    }
     return $lineItems;
   }
 

--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -36,7 +36,7 @@
         {if $isDisplayLineItems && $lineItem}
           {if !$amount}{assign var="amount" value=0}{/if}
           {assign var="totalAmount" value=$amount}
-          {include file="CRM/Price/Page/LineItem.tpl" context="Contribution" displayLineItemFinancialType=false pricesetFieldsCount=false currencySymbol='' hookDiscount=''}
+          {include file="CRM/Price/Page/LineItem.tpl" context="Contribution" getTaxDetails=$totalTaxAmount displayLineItemFinancialType=false pricesetFieldsCount=false currencySymbol='' hookDiscount=''}
         {elseif $is_separate_payment}
           {if $amount AND $minimum_fee}
             {$membership_name} {ts}Membership{/ts}:

--- a/tests/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/tests/templates/message_templates/contribution_online_receipt_html.tpl
@@ -34,8 +34,7 @@
   {if !empty($is_quick_config)}
   is_quick_config:::{$is_quick_config}
   {/if}
-  {if !empty($getTaxDetails)}
-  getTaxDetails:::{$getTaxDetails}
+  {if !empty($totalTaxAmount)}
   totalTaxAmount:::{$totalTaxAmount}
   {/if}
   {if !empty($is_monetary)}


### PR DESCRIPTION
Overview
----------------------------------------
Fix `getTaxDetails notices` on Confirm page

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/91a04a19-92f4-47c0-b017-8dfc268e5794)

After
----------------------------------------
Well it's less....

![image](https://github.com/civicrm/civicrm-core/assets/336308/f854d613-a0b9-4574-bb0b-a095d5bbd5ec)

Technical Details
----------------------------------------
 I removed the conditional assignment that is in the wrong place - anywhere where we rely on that would show up as a notice like the above & there are no other pages in the Contribution or Event flow of price field config or Contribution view flow that appear to be affected - so I think this needs to be done for each form & this is the last 
![image](https://github.com/civicrm/civicrm-core/assets/336308/192afb7d-0d5c-47fa-bca5-5bd8a8a8a98c)


Comments
----------------------------------------

