### PR TITLE
dev/core#4791 - Set cache folder for dompdf

### DIFF
--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -258,8 +258,35 @@ class CRM_Utils_PDF_Utils {
         $settings[$setting] = $value;
       }
     }
+
+    // core#4791 - Set cache dir to prevent files being generated in font dir
+    $cacheDir = self::getCacheDir($settings);
+    if ($cacheDir !== "") {
+      $settings['font_cache'] = $cacheDir;
+    }
     $options->set($settings);
     return $options;
+  }
+
+  /**
+   * Get location of cache folder.
+   *
+   * @param array $settings
+   * @return string
+   */
+  private static function getCacheDir(array $settings): string {
+    // Use subfolder of custom font dir if it is writable
+    if (isset($settings['font_dir']) && is_writable($settings['font_dir'])) {
+      $cacheDir = $settings['font_dir'] . DIRECTORY_SEPARATOR . 'font_cache';
+    }
+    else {
+      $cacheDir = Civi::paths()->getPath('[civicrm.files]/upload/font_cache');
+    }
+    // Try to create dir if it doesn't exist or return empty string
+    if ((!is_dir($cacheDir)) && (!mkdir($cacheDir))) {
+      $cacheDir = "";
+    }
+    return $cacheDir;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

See https://lab.civicrm.org/dev/core/-/issues/4791

Before
----------------------------------------
The cache folder for dompdf isn't set so cache files are created in the font folder.

After
----------------------------------------
CiviCRM defines the cache folder for dompdf that is outside of the codebase. Files are not generated within the codebase which keeps the codebase tidier and means that the codebase can be mounted read only.

Comments
----------------------------------------

This could potentially be made as a user editable setting, but I'm not sure this is necessary so haven't done this.

I'm not sure where would be best to create the cached files. I've chosen `[civicrm.files]/upload` for simplicity, but perhaps it would be better in a separate folder or subfolder?