### PR TITLE
Use currentPath method to build QuickForm post URL, fixes some nginx/WordPress "Could not find valid value for id" errors

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -108,12 +108,12 @@ abstract class CRM_Utils_System_Base {
    *   The url to post the form.
    */
   public function postURL($action) {
-    $config = CRM_Core_Config::singleton();
     if (!empty($action)) {
       return $action;
     }
 
-    return $this->url(CRM_Utils_Array::value($config->userFrameworkURLVar, $_GET),
+    $current_path = CRM_Utils_System::currentPath();
+    return $this->url($current_path,
       NULL, TRUE, NULL, FALSE
     );
   }


### PR DESCRIPTION
Overview
----------------------------------------
Protects against untrimmed path in post URL as observed in [this ticket on Lab](https://lab.civicrm.org/dev/core/-/issues/4735#note_153283)

Before
----------------------------------------
Post URL path is not trimmed.

After
----------------------------------------
Post URL path is trimmed.

Comments
----------------------------------------
Whilst this PR protects against malformed paths, it also papers over [misconfigured nginx environments](https://lab.civicrm.org/dev/core/-/issues/4735#note_153277). Question is: is it better to do so or not?