### PR TITLE
dev/core#4798 [LineItem cleanup] Clean up & clarify code splitting line items in Contribution page membership flow

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -947,6 +947,9 @@ class CRM_Financial_BAO_Order {
       elseif ($taxRate) {
         $lineItem['tax_amount'] = ($taxRate / 100) * $lineItem['line_total'];
       }
+      if (!empty($lineItem['membership_type_id'])) {
+        $lineItem['entity_table'] = 'civicrm_membership';
+      }
       $lineItem['title'] = $this->getLineItemTitle($lineItem);
       $lineItem['line_total_inclusive'] = $lineItem['line_total'] + $lineItem['tax_amount'];
     }

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -1683,10 +1683,10 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       'contribution_id' => $id,
     ])['values'];
     $this->assertCount(3, $lines);
-    $this->assertEquals('civicrm_membership', $lines[0]['entity_table']);
-    $this->assertEquals($preExistingMembershipID + 1, $lines[0]['entity_id']);
-    $this->assertEquals('civicrm_contribution', $lines[1]['entity_table']);
-    $this->assertEquals($id, $lines[1]['entity_id']);
+    $this->assertEquals('civicrm_membership', $lines[1]['entity_table']);
+    $this->assertEquals($preExistingMembershipID + 1, $lines[1]['entity_id']);
+    $this->assertEquals('civicrm_contribution', $lines[0]['entity_table']);
+    $this->assertEquals($id, $lines[0]['entity_id']);
     $this->assertEquals('civicrm_membership', $lines[2]['entity_table']);
     return $lines;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Clean up & clarify code splitting line items in Contribution page membership flow

Before
----------------------------------------
Super confusing code

After
----------------------------------------
Separated into a function with an explanatory comment block

Technical Details
----------------------------------------
Note there is specific test cover in
testSubmitMembershipComplexPriceSetPaymentPaymentProcessorRecurInstantPayment and the changes to that test reflects the fact that the order in which the line items are created changes slightly (in a fundamentally neutral way


Comments
----------------------------------------
