### PR TITLE
dev/core#4798 [LineItems] Replace ref to undeclared property with tax-inclusive lookup

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -690,7 +690,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         }
 
         $membershipTypeValues = CRM_Member_BAO_Membership::buildMembershipTypeValues($this, $membershipTypeIds);
-        $this->_membershipTypeValues = $membershipTypeValues;
         $endDate = NULL;
 
         // Check if we support auto-renew on this contribution page
@@ -1130,15 +1129,13 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     // CRM-14354: For an auto-renewing membership with an additional contribution,
     // if separate payments is not enabled, make sure only the membership fee recurs
-    if (!empty($this->_membershipBlock)
-      && $this->_membershipBlock['is_separate_payment'] === '0'
+    if ($this->isSeparateMembershipPayment()
       && isset($params['selectMembership'])
-      && $this->_values['is_allow_other_amount'] == '1'
+      && $this->getContributionPageValue('is_allow_other_amount')
       // CRM-16331
-      && !empty($this->_membershipTypeValues)
-      && !empty($this->_membershipTypeValues[$params['selectMembership']]['minimum_fee'])
+      && !empty($this->order->getMembershipTotalAmount())
     ) {
-      $recurParams['amount'] = $this->_membershipTypeValues[$params['selectMembership']]['minimum_fee'];
+      $recurParams['amount'] = $this->order->getMembershipTotalAmount();
     }
 
     $recurParams['is_test'] = 0;


### PR DESCRIPTION
Overview
----------------------------------------
Replace ref to undeclared property with tax-inclusive lookup

Before
----------------------------------------
In the specific scenario where we have a non-separate payment with a membership and the person also selected an additional amount and a recurring contribution is being created then the recurring contribution is to be for the  membership amount only - but 2 issues

1) inconsistent with other code amount calculations
2) refers to undefined property
3) I believe it would fail to include tax
4) who is counting?

After
----------------------------------------


Technical Details
----------------------------------------

Comments
----------------------------------------
