### PR TITLE
CiviCase - Clear value before reusing editCaseRoleDialog

### DIFF
--- a/templates/CRM/Case/Form/CaseView.js
+++ b/templates/CRM/Case/Form/CaseView.js
@@ -97,6 +97,8 @@
     },
     '#editCaseRoleDialog': {
       pre: function(data) {
+        // Clear stale value since this form can be reused multiple times
+        $('[name=edit_role_contact_id]', this).val('');
         prepareRelationshipField(data.rel_type, $('[name=edit_role_contact_id]', this));
       },
       post: function(data) {

--- a/templates/CRM/Case/Form/CaseView.js
+++ b/templates/CRM/Case/Form/CaseView.js
@@ -177,6 +177,12 @@
     });
   }
 
+  function showHideInactiveRoles() {
+    let showInactive = $('#role_inactive').prop('checked');
+    $('[id^=caseRoles-selector] tbody tr').not('.disabled').toggle(!showInactive);
+    $('[id^=caseRoles-selector] tbody tr.disabled').toggle(showInactive);
+  }
+
   $('#crm-container').on('crmLoad', '#crm-main-content-wrapper', detachMiniForms);
 
   $(document).ready(function() {
@@ -224,6 +230,9 @@
           $('#case_id_' + id).dataTable().api().draw();
         });
       })
+      // Toggle to show/hide inactive case roles
+      .on('crmLoad', 'table#caseRoles-selector-' + caseId(), showHideInactiveRoles)
+      .on('change', '#role_inactive', showHideInactiveRoles)
       .on('click', 'a.case-miniform', function(e) {
         var dialog,
           $el = $(this),

--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -154,23 +154,7 @@
         {* Add checkbox to show inactive roles. For open cases, default value is unchecked, i.e. show active roles. For closed cases default is checked. *}
         <label><input type="checkbox" id="role_inactive" name="role_inactive[]"{if $caseDetails.status_class neq 'Opened'} checked="checked"{/if}>{ts}Show Inactive relationships{/ts}</label>
       </div>
-      {literal}
-        <script type="text/javascript">
-            (function($) {
-                // hide the inactive role when checkbox is checked
-                $('input[type=checkbox][id=role_inactive]').change(function() {
-                  if (this.checked == true) {
-                    CRM.$('[id^=caseRoles-selector] tbody tr').not('.disabled').hide();
-                    CRM.$('[id^=caseRoles-selector] tbody tr.disabled').show();
-                  } else if (this.checked == false) {
-                    CRM.$('[id^=caseRoles-selector] tbody tr').not('.disabled').show();
-                    CRM.$('[id^=caseRoles-selector] tbody tr.disabled').hide();
-                  }
-                });
-            })(CRM.$);
-        </script>
-      {/literal}
-      <table id="caseRoles-selector-{$caseID}"  class="report-layout crm-ajax-table" data-page-length="10">
+      <table id="caseRoles-selector-{$caseID}" class="report-layout crm-ajax-table" data-page-length="10">
         <thead>
           <tr>
             <th data-data="relation">{ts}Case Role{/ts}</th>
@@ -188,19 +172,9 @@
         <script type="text/javascript">
           (function($) {
             var caseId = {/literal}{$caseID}{literal};
-            CRM.$('table#caseRoles-selector-' + caseId).data({
+            $('table#caseRoles-selector-' + caseId).data({
               "ajax": {
                 "url": {/literal}'{crmURL p="civicrm/ajax/caseroles" h=0 q="snippet=4&caseID=$caseId&cid=$contactID&userID=$userID"}'{literal},
-                "complete" : function(){
-                  if (CRM.$('input[type=checkbox][id=role_inactive]').prop('checked')) {
-                    CRM.$('[id^=caseRoles-selector] tbody tr').not('.disabled').hide();
-                    CRM.$('[id^=caseRoles-selector] tbody tr.disabled').show();
-                  }
-                  else {
-                    CRM.$('[id^=caseRoles-selector] tbody tr').not('.disabled').show();
-                    CRM.$('[id^=caseRoles-selector] tbody tr.disabled').hide();
-                  }
-                }
               }
             });
           })(CRM.$);

--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -147,7 +147,7 @@
       {/if}
 
       <div id="editCaseRoleDialog" class="hiddenElement">
-        <div><label for="edit_role_contact_id">{ts}Change To{/ts}:</label></div>
+        <div><label for="edit_role_contact_id">{ts}Change To{/ts} <span class="crm-marker">*</span></label></div>
         <div><input name="edit_role_contact_id" placeholder="{ts}- select contact -{/ts}" class="huge" /></div>
       </div>
       <div id="caseRoles-selector-show-active">


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup and a UI fix in CiviCase

Before
----------------------------------------
1. Go to the "Manage Case" screen (create a new case or edit an existing one)
2. Open the "Case Roles" section
3. Click the pencil icon to set or change a role
4. Save changes
5. Do it again for another row
6. Notice the widget has the wrong name populated & an error in the console

After
----------------------------------------
Form is reset every time

Comments
---------
Also cleans up some overcomplicated code that was doing almost nothing.