### PR TITLE
dev/core#4798 Fixes to functions to determine if isMembership, isSeparatePayment

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1407,7 +1407,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $totalAmount = $membershipParams['amount'];
 
     if ($isPaidMembership) {
-      if ($isProcessSeparateMembershipTransaction) {
+      if ($this->isSeparatePaymentSelected()) {
         // If we have 2 transactions only one can use the invoice id.
         $membershipParams['invoiceID'] .= '-2';
         if (!empty($membershipParams['auto_renew'])) {
@@ -1441,7 +1441,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       }
     }
 
-    if ($isProcessSeparateMembershipTransaction) {
+    if ($this->isSeparatePaymentSelected()) {
       try {
         $this->_lineItem = $unprocessedLineItems;
         if (empty($this->_params['auto_renew']) && !empty($membershipParams['is_recur'])) {
@@ -2201,7 +2201,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $this->_useForMember = $this->get('useForMember');
 
     // store the fact that this is a membership and membership type is selected
-    if ($this->isMembershipSelected($membershipParams)) {
+    if ($this->isMembershipSelected()) {
       $this->doMembershipProcessing($contactID, $membershipParams, $premiumParams);
     }
     else {
@@ -2266,20 +2266,11 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
   /**
    * Return True/False if we have a membership selected on the contribution page
-   * @param array $membershipParams
    *
    * @return bool
    */
-  private function isMembershipSelected($membershipParams) {
-    $priceFieldIds = $this->get('memberPriceFieldIDS');
-    if ((!empty($membershipParams['selectMembership']) && $membershipParams['selectMembership'] != 'no_thanks')
-        && empty($priceFieldIds)) {
-      return TRUE;
-    }
-    else {
-      $membershipParams = $this->getMembershipParamsFromPriceSet($membershipParams);
-    }
-    return !empty($membershipParams['selectMembership']);
+  private function isMembershipSelected(): bool {
+    return !empty($this->getMembershipLineItems());
   }
 
   /**
@@ -2380,10 +2371,10 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
 
     $membershipParams = $this->getMembershipParamsFromPriceSet($membershipParams);
-    if (!empty($membershipParams['selectMembership'])) {
+    if ($this->isMembershipSelected()) {
       // CRM-12233
       $membershipLineItems = [$this->getPriceSetID() => $this->getLineItems()];;
-      if ($this->_separateMembershipPayment && $this->isFormSupportsNonMembershipContributions()) {
+      if ($this->isSeparatePaymentSelected()) {
         $membershipLineItems = [];
         foreach ($this->_values['fee'] as $key => $feeValues) {
           if ($feeValues['name'] == 'membership_amount') {

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -581,6 +581,16 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   }
 
   /**
+   * Is the form separate payment AND has the user selected 2 options,
+   * resulting in 2 payments.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function isSeparatePaymentSelected(): bool {
+    return (bool) $this->getSecondaryMembershipContributionLineItems();
+  }
+
+  /**
    * Set the line items for the secondary membership contribution.
    *
    * Return false if the page is not configured for separate contributions,
@@ -602,7 +612,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         $lineItems[$index] = $lineItem;
       }
     }
-    if (empty($lineItems) || count($lineItems) === $this->getLineItems()) {
+    if (empty($lineItems) || count($lineItems) === count($this->getLineItems())) {
       return FALSE;
     }
     return $lineItems;

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -216,7 +216,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
       '<td style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;">
          Amount        </td>
         <td style="padding: 4px; border-bottom: 1px solid #999;">
-         $1,000.00         </td>
+         $352.00         </td>
        </tr>',
       '************1111',
     ]);
@@ -314,7 +314,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
         'Y' => (int) (CRM_Utils_Time::date('Y')) + 1,
       ],
       'price_' . $this->ids['PriceField']['membership'] => $this->ids['PriceFieldValue']['membership_general'],
-      'other_amount' => 100,
+      'price_' . $this->ids['PriceField']['contribution'] => $this->ids['PriceFieldValue']['contribution'],
       'priceSetId' => $this->ids['PriceSet']['membership_block'],
       'credit_card_type' => 'Visa',
       'email-5' => 'test@test.com',

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -976,12 +976,14 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test non-recur contribution with membership payment
+   * Test non-recur contribution with membership payment selected.
+   *
+   * In this scenario the contribution option was not selected so only
+   * one contribution is actually created.
    *
    * @throws \CRM_Core_Exception
-   * @throws \Civi\API\Exception\UnauthorizedException
    */
-  public function testSubmitMembershipIsSeparatePaymentNotRecur(): void {
+  public function testSubmitMembershipIsSeparatePaymentNotRecurMembershipOnly(): void {
     $this->setUpMembershipContributionPage(TRUE, TRUE);
     $dummyPP = Civi\Payment\System::singleton()->getById($this->ids['PaymentProcessor']['dummy']);
     $dummyPP->setDoDirectPaymentResult(['payment_status_id' => 1, 'trxn_id' => 'create_first_success']);


### PR DESCRIPTION


Overview
----------------------------------------
Fixes to functions to determine if i`sMembership()`, `isSeparatePaymentSelected()`

Before
----------------------------------------
In the case of isSeparatePayment we have a function to determine if the form supports separate payments - but are using this interchangeably with whether the user has selected more than one option (if they only selected 1 there is only 1 payment). This adds `isSeparatePaymentSelected()`

There is an error in the (recently added ) `getMembershipLineItems()` 

After
----------------------------------------
New helper `isSeparatePaymentSelected()`, fix to `getSecondaryMembershipContributionLineItems()`, `isMembershipSelected()` aligned with other functions that inspect the selected line items

Test updated to reflect the gap between what it says it is testing & what it is actually testing

Technical Details
----------------------------------------
These are all  coming out of unit test issues when I try to remove hacks from the code & they highlight the original sins

Comments
----------------------------------------
