### PR TITLE
Clean up getMainContributionAmount() function

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1413,7 +1413,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         if (!empty($membershipParams['auto_renew'])) {
           $isRecurForFirstTransaction = FALSE;
         }
-        $membershipParams['total_amount'] = $totalAmount;
         $membershipParams['skipLineItem'] = 0;
         CRM_Price_BAO_LineItem::getLineItemArray($membershipParams);
       }

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1264,7 +1264,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     $params['separate_amount'] = $params['amount'];
     // @todo - stepping through the code indicates that amount is always set before this point so it never matters.
     // Move more of the above into this function...
-    $params['amount'] = $this->getMainContributionAmount($params);
+    $params['amount'] = $this->getMainContributionAmount();
     //If the membership & contribution is used in contribution page & not separate payment
     $memPresent = $membershipLabel = $fieldOption = NULL;
     $proceFieldAmount = 0;

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1139,25 +1139,20 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   /**
    * Get the amount for the main contribution.
    *
-   * The goal is to expand this function so that all the argy-bargy of figuring out the amount
-   * winds up here as the main spaghetti shrinks.
-   *
    * If there is a separate membership contribution this is the 'other one'. Otherwise there
    * is only one.
-   *
-   * @param $params
    *
    * @return float
    *
    * @throws \CRM_Core_Exception
    */
-  protected function getMainContributionAmount($params) {
-    if (!empty($params['selectMembership'])) {
-      if (empty($params['amount']) && !$this->_separateMembershipPayment) {
-        return CRM_Member_BAO_MembershipType::getMembershipType($params['selectMembership'])['minimum_fee'] ?? 0;
-      }
+  protected function getMainContributionAmount(): float {
+    $amount = 0;
+    foreach ($this->getMainContributionLineItems() as $lineItem) {
+      // Line total inclusive should really be always set but this is a safe fall back.
+      $amount += $lineItem['line_total_inclusive'] ?? ($lineItem['line_total'] + $lineItem['tax_amount']);
     }
-    return $params['amount'] ?? 0;
+    return $amount;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Clean up getMainContributionAmount() function

Before
----------------------------------------
Function is looking up some of our legacy values - but we calculate the amount from the line items now (no actual impact as it was being ignored a lot of the time)

After
----------------------------------------
Function consistent with similar functions. Called in one place on confirm where we want to be clear that amount reflects the amount of the main contribution (in most cases this is the only contribution).

Technical Details
----------------------------------------

Comments
----------------------------------------
