### PR TITLE
SearchBuilder - Add deprecation notice to users

### DIFF
--- a/templates/CRM/Contact/Form/Search/Builder.tpl
+++ b/templates/CRM/Contact/Form/Search/Builder.tpl
@@ -8,7 +8,11 @@
  +--------------------------------------------------------------------+
 *}
 {* Search Builder *}
-
+<div class="messages status no-popup">
+  {icon icon="fa-info-circle"}{/icon}
+  {capture assign='skUrl'}{crmURL p='civicrm/admin/search'}{/capture}
+  {ts 1="href='$skUrl'"}Search Builder is a legacy part of CiviCRM. It is recommended to <a %1>use SearchKit instead</a>.{/ts}
+</div>
 <div class="crm-form-block crm-search-form-block">
   <div class="crm-accordion-wrapper crm-search_builder-accordion {if $rows and !$showSearchForm}collapsed{/if}">
     <div class="crm-accordion-header crm-master-accordion-header">


### PR DESCRIPTION
Overview
----------------------------------------
Following on #22778 this adds a user-facing notice that Search Builder is deprecated in favor of SearchKit:

![image](https://github.com/civicrm/civicrm-core/assets/2874912/1a91af75-b1d4-4892-a4ee-9e7a08de0f60)
