### PR TITLE
dev/core#4798 Stop setting unused, undefined property `_lineItem` in contribution forms

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -263,9 +263,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    */
   public function preProcess() {
     parent::preProcess();
-
-    // lineItem isn't set until Register postProcess
-    $this->_lineItem = [$this->getPriceSetID() => $this->getLineItems()];;
     $this->_ccid = $this->get('ccid');
 
     $this->_params = $this->controller->exportValues('Main');

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -239,7 +239,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    */
   public function __get($name) {
     if ($name === '_lineItem') {
-      // At some point add a deprecation notice here.
+      CRM_Core_Error::deprecatedWarning('attempt to access undefined property _lineItem - use externally supported function getLineItems()');
       return [$this->getPriceSetID() => $this->getLineItems()];
     }
     CRM_Core_Error::deprecatedWarning('attempt to access invalid property :' . $name);
@@ -256,6 +256,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    */
   public function __set($name, $value) {
     if ($name === '_lineItem') {
+      CRM_Core_Error::deprecatedWarning('attempt to access undefined property _lineItem - use externally supported function setLineItems()');
       $this->order->setLineItems($value[$this->getPriceSetID()]);
       return;
     }

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -228,6 +228,41 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   }
 
   /**
+   * Provide support for extensions that are used to being able to retrieve _lineItem
+   *
+   * Note extension should call getPriceSetID() and getLineItems() directly.
+   * They are supported for external use per the api annotation.
+   *
+   * @param string $name
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function __get($name) {
+    if ($name === '_lineItem') {
+      // At some point add a deprecation notice here.
+      return [$this->getPriceSetID() => $this->getLineItems()];
+    }
+    CRM_Core_Error::deprecatedWarning('attempt to access invalid property :' . $name);
+  }
+
+  /**
+   * Provide support for extensions that are used to being able to retrieve _lineItem
+   *
+   * Note extension should call getPriceSetID() and getLineItems() directly.
+   * They are supported for external use per the api annotation.
+   *
+   * @param string $name
+   * @param mixed $value
+   */
+  public function __set($name, $value) {
+    if ($name === '_lineItem') {
+      $this->order->setLineItems($value[$this->getPriceSetID()]);
+      return;
+    }
+    CRM_Core_Error::deprecatedWarning('attempt to set invalid property :' . $name);
+  }
+
+  /**
    * Is the form being submitted in test mode.
    *
    * @api this function is supported for external use.
@@ -246,6 +281,10 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    * form. It does not confer meaningful performance benefits & adds confusion.
    *
    * Out of caution we still allow `get`, `set` to take precedence.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
    *
    * @return int|null
    * @throws \CRM_Core_Exception
@@ -724,7 +763,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
     foreach ($vars as $v) {
       if (isset($this->_params[$v])) {
-        if ($v == "amount" && $this->_params[$v] === 0) {
+        if ($v === 'amount' && $this->_params[$v] === 0) {
           $this->_params[$v] = CRM_Utils_Money::format($this->_params[$v], NULL, NULL, TRUE);
         }
         $this->assign($v, $this->_params[$v]);


### PR DESCRIPTION

Overview
----------------------------------------
Stop setting unused, undefined property `_lineItem` in contribution forms

This removes the last reference to _lineItem in the Contribution flow.

However, magic methods are added to support most extension access to them

PLEASE HIGHLIGHT THIS IN RELEASE NOTES / BLOG

Change log update https://lab.civicrm.org/documentation/docs/dev/-/commit/751977babff46ad0c9c07e4fc667550dc42316b9

Meta issue https://lab.civicrm.org/dev/core/-/issues/4798

Before
----------------------------------------
We have been hitting php 8.x errors on undefined properties - the last of these in the Contribution Form flow is on `_lineItem`. This property has long been problematic in the form as it was altered through the flow to have & to not have all the line items in order to wrangle the various membership scenarios. There were also places where the calculated line items were completely ignored & loaded from a different method. The handling within the form has been updated to use various functions to get the relevant line items to the moment in the code. 

However, simply removing `_lineItem`now it it is of no use would cause problems for extensions that access it. I spotted 2/3 extensions that would be affected if we simply removed it. - LineItemEditor  by @JoeMurray pricesetfrequency by @agileware-justin & taxcalculator by @mlutfy 

After
----------------------------------------
`_lineItem` is unused so it is removed. This will help php8.2 tests pass

The addition of `__GET` & `__SET` functions should enable the pricesetfrequency externsion to work without change by my reading of the code. I do highly recommend testing of it though

I think taxcalculator needs a small patch - which I will open an MR for- https://lab.civicrm.org/extensions/taxcalculator/-/merge_requests/9

I didn't dig into lineItemEdit - but it's possible I'm just picking up a property used internally to _lineItemEdit

Technical Details
----------------------------------------
I also elevated `getPriceSetID()` to be supported for external use - this is consistent with changes to other forms to try to make some form functions consistent + externally supported (`getContributionPageID()`, `getEventID()` `getParticipantID()` etc)  

Comments
----------------------------------------
