### PR TITLE
Fix issue merging contact with custom field of type date

### DIFF
--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -630,6 +630,14 @@ AND    cf.id IN ( $fieldIDList )
         if (is_array($fieldValue['value']) && CRM_Core_BAO_CustomField::isSerialized($dao)) {
           $fieldValue['value'] = CRM_Utils_Array::implodePadded($fieldValue['value']);
         }
+
+        if ($dataType == 'Timestamp') {
+          // Replace format YYYY-MM-DD HH:MM:SS with YYYYMMDDHHMMSS
+          if (preg_match('/^\d{4}\-\d{2}\-\d{2}\s\d{2}\:\d{2}\:\d{2}$/', $fieldValue['value'])) {
+            $fieldValue['value'] = str_replace(['-', ' ', ':'], "", $fieldValue['value']);
+          }
+        }
+
         // Format null values correctly
         if ($fieldValue['value'] === NULL || $fieldValue['value'] === '') {
           switch ($dataType) {


### PR DESCRIPTION
Overview
----------------------------------------
Error occurred when trying to merge contacts with custom_fields that contain Date type.

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/2327763/d3392e3a-d077-439e-808a-fc06eb09c27a)


Error: `value: 2012-01-05 00:00:00 is not of the right field data type: Date`

After
----------------------------------------
Merge is done

