### PR TITLE
Recurring Activity: avoid validation if the fieldset is visible but not used

### DIFF
--- a/templates/CRM/Core/Form/RecurringEntity.tpl
+++ b/templates/CRM/Core/Form/RecurringEntity.tpl
@@ -213,6 +213,10 @@
           previewDialog();
         }
       }
+      else {
+        // Avoid jquery validation on required fields if they are visible
+        $('#recurring-entity-block :input').removeClass('required');
+      }
     });
 
     // Enable/disable form buttons when not embedded in another form


### PR DESCRIPTION
Overview
----------------------------------------

- Create/edit an activity
- Uncollapse the "Repeat Activity" fieldset (make it visible)
- Leave all the fields empty
- Submit the form

The form validation will show an error that the "After" field is mandatory, see before screenshot:

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/217249bf-53b2-4ba7-99d4-8565940c6ad4)

It's a bit confusing to explain to users: it shows as required, and you obviously don't want it to recur, but to avoid that error message, you have to collapse the fieldset.

After
----------------------------------------

Error is displayed only if we filled in a field of the recurring section.

Technical Details
----------------------------------------

The form tpl already sets a hidden input, `#allowRepeatConfigToSubmit`, and this is what triggers the PHP form validation.

Removing the `required` class only disables the jQuery validation. And if the PHP validation fails for some reason, then the form is reloaded, and the class is back.

I also tested if the form is submitted with other jQuery validation errors, and that somehow seems to work too (the required class is not removed).

In any case, the biggest risk is that the form would be submitted, and then PHP validation happens, reloading the form.