### PR TITLE
dev/core#4795 fix regression on other amount on main contribution page

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -578,7 +578,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       return NULL;
     }
     foreach ($this->order->getPriceFieldsMetadata() as $field) {
-      if ($field['name'] !== 'other_amount') {
+      if ($field['name'] === 'contribution_amount') {
         return (int) $field['id'];
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an rc-only regression where the other amount field is tied to the membership field rather than the contribution field

https://lab.civicrm.org/dev/core/-/issues/4795

Before
----------------------------------------
Using contribution page configured for Membership + contribution (not separate payment, not price set) with the other amount option available (screen shot of the contribution amounts section on the gitlab). The user is confronted with

![make_selection](https://lab.civicrm.org/dev/core/uploads/315cf6d676c8296356d1aea46abf19a9/image.png)

If they click on Other Amount the membership amount is incorrectly deselected

![iwrong](https://lab.civicrm.org/dev/core/uploads/c2ca8e57f2bde2141df546feee591cbd/image.png)

After
----------------------------------------
The contribution amount is selected instead

![image](https://github.com/civicrm/civicrm-core/assets/336308/d5b4930e-5d5a-44c1-91ab-8f8316c88e75)


Technical Details
----------------------------------------
Affects rc & master but not stable - the line was added here - https://github.com/civicrm/civicrm-core/pull/27836/commits/8f2bc9fd1b8d511833f6453f59663ff44b861891#diff-9319a4134599e85c273c3be5706ffb5d642b7659904fd644dd4273791467384aR609 & did not account for the possiblity of the membership_amount field. In the meantime I have gotten comfortable that it would always be contribution_amount as the name for a quick config contribution amount field

Comments
----------------------------------------
