### PR TITLE
Autocomplete - Fix incorrect matching on id instead of value

### DIFF
--- a/Civi/Api4/Event/Subscriber/AutocompleteFieldSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/AutocompleteFieldSubscriber.php
@@ -67,6 +67,11 @@ class AutocompleteFieldSubscriber extends AutoService implements EventSubscriber
           $apiRequest->addFilter($key, $value);
         }
 
+        // Autocomplete for field with option values
+        if ($apiRequest->getEntityName() === 'OptionValue' && !empty($fieldSpec['custom_field_id'])) {
+          $apiRequest->setKey('value');
+        }
+
         if ($formType === 'qf') {
           $this->autocompleteProfilePermissions($apiRequest, $formName, $fieldSpec);
         }

--- a/Civi/Api4/OptionValue.php
+++ b/Civi/Api4/OptionValue.php
@@ -17,7 +17,7 @@ namespace Civi\Api4;
  * @searchable secondary
  * @orderBy weight
  * @groupWeightsBy option_group_id
- * @matchFields option_group_id,name
+ * @matchFields option_group_id,name,value
  * @since 5.19
  * @package Civi\Api4
  */

--- a/Civi/Api4/Service/Autocomplete/OptionValueAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/OptionValueAutocompleteProvider.php
@@ -47,6 +47,8 @@ class OptionValueAutocompleteProvider extends \Civi\Core\Service\AutoService imp
         [
           'type' => 'field',
           'key' => 'description',
+          'rewrite' => '#[value] [description]',
+          'empty_value' => '#[value]',
         ],
       ],
     ];

--- a/tests/phpunit/api/v4/Custom/ExportCustomGroupTest.php
+++ b/tests/phpunit/api/v4/Custom/ExportCustomGroupTest.php
@@ -84,7 +84,7 @@ class ExportCustomGroupTest extends CustomTestBase {
     $this->assertEquals(['name'], $export[1]['params']['match']);
     // Match optionValue by name and option_group_id
     sort($export[2]['params']['match']);
-    $this->assertEquals(['name', 'option_group_id'], $export[2]['params']['match']);
+    $this->assertEquals(['name', 'option_group_id', 'value'], $export[2]['params']['match']);
     // Match customField by name and custom_group_id
     sort($export[5]['params']['match']);
     $this->assertEquals(['custom_group_id', 'name'], $export[5]['params']['match']);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/4799 
Custom fields of type Autocomplete-Select were incorrectly using the id of the optionValue. This fixes it to use the value, and also show the value in the autocomplete results.
