### PR TITLE
Extract code that defines the renewal membership

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -305,46 +305,9 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     $this->_emailExists = $this->get('emailExists');
 
     $this->_contactID = $this->_membershipContactID = $this->getContactID();
-    $this->getRenewalMembershipID();
 
     if ($this->getRenewalMembershipID()) {
-      $membership = new CRM_Member_DAO_Membership();
-      $membership->id = $this->getRenewalMembershipID();
-
-      if ($membership->find(TRUE)) {
-        $this->_defaultMemTypeId = $membership->membership_type_id;
-        if ($membership->contact_id != $this->_contactID) {
-          $validMembership = FALSE;
-          $organizations = CRM_Contact_BAO_Relationship::getPermissionedContacts($this->getAuthenticatedContactID(), NULL, NULL, 'Organization');
-          if (!empty($organizations) && array_key_exists($membership->contact_id, $organizations)) {
-            $this->_membershipContactID = $membership->contact_id;
-            $this->assign('membershipContactID', $this->_membershipContactID);
-            $this->assign('membershipContactName', $organizations[$this->_membershipContactID]['name']);
-            $validMembership = TRUE;
-          }
-          else {
-            $membershipType = new CRM_Member_BAO_MembershipType();
-            $membershipType->id = $membership->membership_type_id;
-            if ($membershipType->find(TRUE)) {
-              // CRM-14051 - membership_type.relationship_type_id is a CTRL-A padded string w one or more ID values.
-              // Convert to comma separated list.
-              $inheritedRelTypes = implode(',', CRM_Utils_Array::explodePadded($membershipType->relationship_type_id));
-              $permContacts = CRM_Contact_BAO_Relationship::getPermissionedContacts($this->getAuthenticatedContactID(), $membershipType->relationship_type_id);
-              if (array_key_exists($membership->contact_id, $permContacts)) {
-                $this->_membershipContactID = $membership->contact_id;
-                $validMembership = TRUE;
-              }
-            }
-          }
-          if (!$validMembership) {
-            CRM_Core_Session::setStatus(ts("Oops. The membership you're trying to renew appears to be invalid. Contact your site administrator if you need assistance. If you continue, you will be issued a new membership."), ts('Membership Invalid'), 'alert');
-          }
-        }
-      }
-      else {
-        CRM_Core_Session::setStatus(ts("Oops. The membership you're trying to renew appears to be invalid. Contact your site administrator if you need assistance. If you continue, you will be issued a new membership."), ts('Membership Invalid'), 'alert');
-      }
-      unset($membership);
+      $this->defineRenewalMembership();
     }
 
     // we do not want to display recently viewed items, so turn off
@@ -1426,6 +1389,45 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     }
     $this->order->setPriceSelectionFromUnfilteredInput($this->getSubmittedValues());
     $this->order->setForm($this);
+  }
+
+  protected function defineRenewalMembership(): void {
+    $membership = new CRM_Member_DAO_Membership();
+    $membership->id = $this->getRenewalMembershipID();
+
+    if ($membership->find(TRUE)) {
+      $this->_defaultMemTypeId = $membership->membership_type_id;
+      if ($membership->contact_id != $this->_contactID) {
+        $validMembership = FALSE;
+        $organizations = CRM_Contact_BAO_Relationship::getPermissionedContacts($this->getAuthenticatedContactID(), NULL, NULL, 'Organization');
+        if (!empty($organizations) && array_key_exists($membership->contact_id, $organizations)) {
+          $this->_membershipContactID = $membership->contact_id;
+          $this->assign('membershipContactID', $this->_membershipContactID);
+          $this->assign('membershipContactName', $organizations[$this->_membershipContactID]['name']);
+          $validMembership = TRUE;
+        }
+        else {
+          $membershipType = new CRM_Member_BAO_MembershipType();
+          $membershipType->id = $membership->membership_type_id;
+          if ($membershipType->find(TRUE)) {
+            // CRM-14051 - membership_type.relationship_type_id is a CTRL-A padded string w one or more ID values.
+            // Convert to comma separated list.
+            $inheritedRelTypes = implode(',', CRM_Utils_Array::explodePadded($membershipType->relationship_type_id));
+            $permContacts = CRM_Contact_BAO_Relationship::getPermissionedContacts($this->getAuthenticatedContactID(), $membershipType->relationship_type_id);
+            if (array_key_exists($membership->contact_id, $permContacts)) {
+              $this->_membershipContactID = $membership->contact_id;
+              $validMembership = TRUE;
+            }
+          }
+        }
+        if (!$validMembership) {
+          CRM_Core_Session::setStatus(ts("Oops. The membership you're trying to renew appears to be invalid. Contact your site administrator if you need assistance. If you continue, you will be issued a new membership."), ts('Membership Invalid'), 'alert');
+        }
+      }
+    }
+    else {
+      CRM_Core_Session::setStatus(ts("Oops. The membership you're trying to renew appears to be invalid. Contact your site administrator if you need assistance. If you continue, you will be issued a new membership."), ts('Membership Invalid'), 'alert');
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Extract code that defines the renewal membership

Before
----------------------------------------
Big chunk of code

After
----------------------------------------
Extracted to a function

Technical Details
----------------------------------------
(none of this is blocking on this PR - just looking at the next step )

What I'm trying to figure - you might know @mlutfy - is whether two concepts in the forms can be defined 

1) the RenewalMembership - this is the membership identified by `mid` in the url & what this function does is look it up & if valid & permissioned uses it to set the default membership type ID (which would pre-fill a form option) and the default membership contact ID (along with a couple of assigns)

2) the CurrentMembership - this appears to be any current membership the contact has (based on the membership contact ID - which might be the one provided by the renewal membership of one of the membership types that is available on the form. It assigns a couple of values (start & end date) and sets the default membership type ID.

I guess as long as 1 is somewhat optional - ie it sets the pre-loads but might be changed on the form then they are effectively the same concept & just need to be processed in order to 'CurrentMembership' - perhaps better defined as 'ExistingMembership' & then 'membership' would be valid on the confirm & thank you pages once it is not just 'the membership we propose to alter'.

Note that the work @MegaphoneJon did on making lifetime memberships not renew doesn't appear to be been extended to concept 1

Comments
----------------------------------------
