### PR TITLE
Use getCurrency() function for currency retrieval

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -404,15 +404,17 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
     $this->assign_by_ref('paymentProcessor', $this->_paymentProcessor);
   }
 
+
   /**
-   * Get current currency from DB or use default currency.
+   * Get the currency in use.
    *
-   * @param array $submittedValues
+   * This just defaults to getting the default currency
+   * where the form does not have better currency support.
    *
    * @return string
    */
-  public function getCurrency($submittedValues = []) {
-    return $submittedValues['currency'] ?? $this->_values['currency'] ?? CRM_Core_Config::singleton()->defaultCurrency;
+  public function getCurrency(): string {
+    return (string) \Civi::settings()->get('defaultCurrency');
   }
 
   /**

--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -404,19 +404,6 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
     $this->assign_by_ref('paymentProcessor', $this->_paymentProcessor);
   }
 
-
-  /**
-   * Get the currency in use.
-   *
-   * This just defaults to getting the default currency
-   * where the form does not have better currency support.
-   *
-   * @return string
-   */
-  public function getCurrency(): string {
-    return (string) \Civi::settings()->get('defaultCurrency');
-  }
-
   /**
    * @param array $submittedValues
    *

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -556,6 +556,15 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
   }
 
   /**
+   * Get submitted currency, or use default.
+   *
+   * @return string
+   */
+  public function getCurrency(): string {
+    return (string) $this->getSubmittedValue('currency') ?: CRM_Core_Config::singleton()->defaultCurrency;
+  }
+
+  /**
    * Build the form object.
    *
    * @throws \CRM_Core_Exception
@@ -1963,7 +1972,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
       $params = [
         'contact_id' => $this->_contactID,
-        'currency' => $this->getCurrency($submittedValues),
+        'currency' => $this->getCurrency(),
         'skipCleanMoney' => TRUE,
         'id' => $this->_id,
       ];

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -556,15 +556,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
   }
 
   /**
-   * Get submitted currency, or use default.
-   *
-   * @return string
-   */
-  public function getCurrency(): string {
-    return (string) $this->getSubmittedValue('currency') ?: CRM_Core_Config::singleton()->defaultCurrency;
-  }
-
-  /**
    * Build the form object.
    *
    * @throws \CRM_Core_Exception

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1502,4 +1502,25 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     }
   }
 
+  /**
+   * Get the currency for the form.
+   *
+   * Rather historic - might have unneeded stuff
+   *
+   * @return string
+   */
+  public function getCurrency() {
+    $currency = $this->_values['currency'] ?? NULL;
+    // For event forms, currency is in a different spot
+    if (empty($currency)) {
+      $currency = CRM_Utils_Array::value('currency', CRM_Utils_Array::value('event', $this->_values));
+    }
+    if (empty($currency)) {
+      $currency = CRM_Utils_Request::retrieveValue('currency', 'String');
+    }
+    // @todo If empty there is a problem - we should probably put in a deprecation notice
+    // to warn if that seems to be happening.
+    return (string) $currency;
+  }
+
 }

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2937,14 +2937,9 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * historic, possible handling in here. As we clean that up we should
    * add deprecation notices into here.
    *
-   * @param array $submittedValues
-   *   Array allowed so forms inheriting this class do not break.
-   *   Ideally we would make a clear standard around how submitted values
-   *   are stored (is $this->_values consistently doing that?).
-   *
    * @return string
    */
-  public function getCurrency($submittedValues = []) {
+  public function getCurrency() {
     $currency = $this->_values['currency'] ?? NULL;
     // For event forms, currency is in a different spot
     if (empty($currency)) {

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2933,24 +2933,17 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   /**
    * Get the currency for the form.
    *
-   * @todo this should be overriden on the forms rather than having this
-   * historic, possible handling in here. As we clean that up we should
-   * add deprecation notices into here.
-   *
    * @return string
    */
   public function getCurrency() {
-    $currency = $this->_values['currency'] ?? NULL;
-    // For event forms, currency is in a different spot
-    if (empty($currency)) {
-      $currency = CRM_Utils_Array::value('currency', CRM_Utils_Array::value('event', $this->_values));
+    if ($this->getSubmittedValue('currency')) {
+      return $this->getSubmittedValue('currency');
     }
-    if (empty($currency)) {
-      $currency = CRM_Utils_Request::retrieveValue('currency', 'String');
+    $currency = CRM_Utils_Request::retrieveValue('currency', 'String');
+    if ($currency) {
+      return $currency;
     }
-    // @todo If empty there is a problem - we should probably put in a deprecation notice
-    // to warn if that seems to be happening.
-    return $currency;
+    return \Civi::settings()->get('defaultCurrency');
   }
 
   /**

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1037,7 +1037,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           }
         }
         unset($params['note']);
-        $contributionParams['currency'] = \Civi::settings()->get('defaultCurrency');;
+        $contributionParams['currency'] = $this->getCurrency();
         $contributionParams['contact_id'] = $this->_contactID;
 
         if ($this->_id) {
@@ -1423,7 +1423,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     }
     else {
       //lets carry currency, CRM-4453
-      $params['fee_currency'] = \Civi::settings()->get('defaultCurrency');
+      $params['fee_currency'] = $this->getCurrency();
       if (!isset($lineItem[0])) {
         $lineItem[0] = [];
       }
@@ -1506,7 +1506,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       'tax_amount' => $params['tax_amount'],
       'amount_level' => $params['amount_level'],
       'invoice_id' => $params['invoiceID'],
-      'currency' => \Civi::settings()->get('defaultCurrency'),
+      'currency' => $this->getCurrency(),
       'source' => $this->getSourceText(),
       'is_pay_later' => FALSE,
       'campaign_id' => $this->getSubmittedValue('campaign_id'),
@@ -1582,7 +1582,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       'fee_level' => $params['amount_level'] ?? NULL,
       'is_pay_later' => FALSE,
       'fee_amount' => $params['fee_amount'] ?? NULL,
-      'fee_currency' => \Civi::settings()->get('defaultCurrency'),
+      'fee_currency' => $this->getCurrency(),
       'campaign_id' => $this->getSubmittedValue('campaign_id'),
       'note' => $this->getSubmittedValue('note'),
       'is_test' => ($this->_mode === 'test)'),

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1727,4 +1727,25 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     return $this->getPriceSetID() && CRM_Price_BAO_PriceSet::isQuickConfig($this->getPriceSetID());
   }
 
+  /**
+   * Get the currency for the form.
+   *
+   * Rather historic - might have unneeded stuff
+   *
+   * @return string
+   */
+  public function getCurrency() {
+    $currency = $this->_values['currency'] ?? NULL;
+    // For event forms, currency is in a different spot
+    if (empty($currency)) {
+      $currency = CRM_Utils_Array::value('currency', CRM_Utils_Array::value('event', $this->_values));
+    }
+    if (empty($currency)) {
+      $currency = CRM_Utils_Request::retrieveValue('currency', 'String');
+    }
+    // @todo If empty there is a problem - we should probably put in a deprecation notice
+    // to warn if that seems to be happening.
+    return $currency;
+  }
+
 }

--- a/CRM/Financial/Form/Payment.php
+++ b/CRM/Financial/Form/Payment.php
@@ -69,13 +69,10 @@ class CRM_Financial_Form_Payment extends CRM_Core_Form {
   /**
    * Get currency
    *
-   * @param array $submittedValues
-   *   Required for consistency with other form methods.
-   *
    * @return string
    */
-  public function getCurrency($submittedValues = []) {
-    return $this->currency;
+  public function getCurrency(): string {
+    return (string) $this->currency;
   }
 
   /**

--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -643,21 +643,6 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
   }
 
   /**
-   * Get the currency in use.
-   *
-   * This just defaults to getting the default currency
-   * as other currencies are not supported on the membership
-   * forms at the moment.
-   *
-   * @param array $submittedValues
-   *
-   * @return string
-   */
-  public function getCurrency($submittedValues = []): string {
-    return CRM_Core_Config::singleton()->defaultCurrency;
-  }
-
-  /**
    * Get the relevant payment instrument id.
    *
    * @return int


### PR DESCRIPTION
Overview
----------------------------------------
Follow up to https://github.com/civicrm/civicrm-core/pull/28166#discussion_r1403720478 - use function to `getCurrency()` & if that event cart one does then .. whoa just read that line

Before
----------------------------------------
Direct setting lookup

After
----------------------------------------
Function used

Technical Details
----------------------------------------
It turned out there was inheritance in play - the parenty parent (CRM_Core_Form) was requiring a parameter that it didn't use for inheritance - but inheritors can require more params just not less (so says my IDE) so I removed that & simplified the function on the AbstractEditPayment - realistically the parenty parent should be moved to the class that uses it - probably online contribution & online event & instead have the simple version from AbstractEditPayment


Hmm - implementation search

![image](https://github.com/civicrm/civicrm-core/assets/336308/ecad1a3a-13b6-4b0f-a77f-c5d5145a3625)

- looks like only `ContributionBase` uses the parenty parent version

Comments
----------------------------------------
