### PR TITLE
[REF][PHP8.2] Remove unused property $_loadedMappingId

### DIFF
--- a/CRM/Contact/Form/Search/Builder.php
+++ b/CRM/Contact/Form/Search/Builder.php
@@ -65,8 +65,6 @@ class CRM_Contact_Form_Search_Builder extends CRM_Contact_Form_Search {
       }
     }
 
-    $this->_loadedMappingId = $this->get('savedMapping');
-
     if ($this->get('showSearchForm')) {
       $this->assign('showSearchForm', TRUE);
     }


### PR DESCRIPTION
Before
----------------------------------------
`$_loadedMappingId` is set dynamically, but never used (anywhere in the entire CiviCRM codebase):

<img width="508" alt="Screenshot 2023-11-23 at 21 48 47" src="https://github.com/civicrm/civicrm-core/assets/1931323/21d42c06-fb05-4678-b9f0-19e7065749a7">

The property was not declared, causing deprecation warnings on PHP 8.2.

After
----------------------------------------
Gone

Technical Details
----------------------------------------
I think this property was once used, but has been moved around a bit over the years. @eileenmcnaughton recently removed where the property was declared - but from a completely different class! https://github.com/civicrm/civicrm-core/commit/52982c9e6e006ddc73a0be1de65f878574d01751
