### PR TITLE
Fix tax on other_amount, treat as inclusive of tax

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -28,6 +28,8 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
   use FormTrait;
   use ContributionPageTestTrait;
 
+  public $_apiversion = 4;
+
   /**
    * Clean up DB.
    */


### PR DESCRIPTION
Overview
----------------------------------------
Fix tax on other_amount, treat as inclusive of tax

https://lab.civicrm.org/dev/core/-/issues/4806

Before
----------------------------------------
Not a new issue - but the 'cents' portion is truncated when entering 'other amount' with non-english separators (screenshots from 5.60)

![image](https://github.com/civicrm/civicrm-core/assets/336308/26ef3f23-45a1-4218-997a-5e2da3a59259)



![image](https://github.com/civicrm/civicrm-core/assets/336308/06128ff9-f0ba-4d6d-97fc-360953cd1ad1)


Also - note that in the before it we select the radio option then the tax is lost by the Confirm page

![image](https://github.com/civicrm/civicrm-core/assets/336308/4dcb7bad-25f0-4041-b251-41c316e46723)

But the final amount does have tax - and the line item tax !== the total tax

![image](https://github.com/civicrm/civicrm-core/assets/336308/87f0c739-9aa6-4744-89d9-939b1a06a9d5)



After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/36b3cd26-5aee-49a7-9902-48a369451557)

![image](https://github.com/civicrm/civicrm-core/assets/336308/35203bfb-badd-423d-bb20-1190a21a999d)

![image](https://github.com/civicrm/civicrm-core/assets/336308/d6a26eda-2d3c-467b-b325-dc5d01331e3d)

When selecting a contribution amount

![image](https://github.com/civicrm/civicrm-core/assets/336308/83cff20c-17b8-4c54-b5eb-71cd1032109e)

![image](https://github.com/civicrm/civicrm-core/assets/336308/ca5797e2-cbe6-443e-b012-bfad4641e7b1)

![image](https://github.com/civicrm/civicrm-core/assets/336308/7554e125-665a-417c-94c5-061a35daf197)

![image](https://github.com/civicrm/civicrm-core/assets/336308/42da1b17-393d-400f-bbde-f2bee2f9ee42)

![image](https://github.com/civicrm/civicrm-core/assets/336308/20180946-0504-4211-a602-4af1846d2791)


Technical Details
----------------------------------------
Note that in the before scenario (5.60) tax is presented on first screen based on the contribution page financial type

![image](https://github.com/civicrm/civicrm-core/assets/336308/48a60726-0c59-4e4c-afe1-32db359bc743)

But it disappears before the Confirm page

![image](https://github.com/civicrm/civicrm-core/assets/336308/3eabcf35-9196-4956-b22c-ca3bc68ba11a)

In the after scenario it applies tax to both contribution lines (contribution type dependent) but that is not clear on the first page. I thought about fixing it to be tax exclusive on the first but figured I should get some input & address that in a follow up PR - the options are to make it clear the amount being entered is tax exclusive or treat it as tax inclusive. I lean to the latter.

Comments
----------------------------------------
