### PR TITLE
Fix master-only-regression- tax not visible on contribution view page

### DIFF
--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -31,6 +31,7 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
   public function preProcess() {
     $id = $this->getContributionID();
     $this->assign('taxTerm', Civi::settings()->get('tax_term'));
+    $this->assign('getTaxDetails', \Civi::settings()->get('invoicing'));
 
     // Check permission for action.
     $actionMapping = [


### PR DESCRIPTION
Overview
----------------------------------------
Fix master-only-regression- tax not visible on contribution view page

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/aeb68d3b-64d6-43ad-9560-90bc19fe72a5)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/f9bbc2af-8af9-48ea-bdca-f1f85c73d050)

Technical Details
----------------------------------------


Comments
----------------------------------------
