### PR TITLE
Remove code cruft which is now ignored

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1787,6 +1787,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
   /**
    * This function sets the fields.
    *
+   * The results of it are likely unused.
+   *
    * - $this->_params['amount_level']
    * - $this->_params['selectMembership']
    * And under certain circumstances sets
@@ -1811,10 +1813,12 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           // function to get correct amount level consistently. Remove setting of the amount level in
           // CRM_Price_BAO_PriceSet::processAmount. Extend the unit tests in CRM_Price_BAO_PriceSetTest
           // to cover all variants.
+          // We expect this to be ignored.
           $this->_params['amount_level'] = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue',
             $this->_params["price_{$priceField->id}"], 'label');
         }
         if ($priceField->name == "membership_amount") {
+          // We expect this to be ignored.
           $this->_params['selectMembership'] = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue',
             $this->_params["price_{$priceField->id}"], 'membership_type_id');
         }
@@ -1833,6 +1837,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         && ($this->_params["price_{$paramWeDoNotUnderstand}"] ?? NULL) < 1
         && empty($this->_params["price_{$priceField->id}"])
       ) {
+        // We expect this to be ignored.
         $this->_params['amount'] = NULL;
       }
 
@@ -1846,6 +1851,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         && ($this->_values['fee'][$priceField->id]['name'] ?? NULL) == 'contribution_amount'
         && ($this->_params["price_{$priceField->id}"] ?? NULL) == '-1'
       ) {
+        // We expect this to be ignored.
         $this->_params['amount'] = NULL;
       }
     }

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1212,20 +1212,13 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   /**
    * Wrapper for processAmount that also sets autorenew.
    *
-   * @param $fields
-   *   This is the output of the function CRM_Price_BAO_PriceSet::getSetDetail($priceSetID, FALSE, FALSE);
-   *   And, it would make sense to introduce caching into that function and call it from here rather than
-   *   require the $fields array which is passed from pillar to post around the form in order to pass it in here.
    * @param array $params
    *   Params reflecting form input e.g with fields 'price_5' => 7, 'price_8' => array(7, 8)
-   * @param $lineItems
-   *   Line item array to be altered.
    */
-  public function processAmountAndGetAutoRenew($fields, &$params, &$lineItems) {
-    CRM_Price_BAO_PriceSet::processAmount($fields, $params, $lineItems, $this->getPriceSetID());
+  public function processAmountAndGetAutoRenew(&$params) {
     $autoRenew = [];
     $autoRenew[0] = $autoRenew[1] = $autoRenew[2] = 0;
-    foreach ($lineItems as $lineItem) {
+    foreach ($this->getLineItems() as $lineItem) {
       if (!empty($lineItem['auto_renew']) &&
         is_numeric($lineItem['auto_renew'])
       ) {


### PR DESCRIPTION
Overview
----------------------------------------
Remove code cruft which is now ignored

Before
----------------------------------------
The Main form did all sorts of postProcess magic to calculate the amounts & line items & then saved the output in various places - but those places are all pretty much ignored so this removes the extraneous code

After
----------------------------------------
gone

Technical Details
----------------------------------------

Comments
----------------------------------------
