### PR TITLE
Fix Main Contribution form to identify money fields

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1390,8 +1390,13 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     if ($this->getExistingContributionID()) {
       $this->order->setTemplateContributionID($this->getExistingContributionID());
     }
-    $this->order->setPriceSelectionFromUnfilteredInput($this->getSubmittedValues());
     $this->order->setForm($this);
+    foreach ($this->getPriceFieldMetaData() as $priceField) {
+      if ($priceField['html_type'] === 'Text') {
+        $this->submittableMoneyFields[] = 'price_' . $priceField['id'];
+      }
+    }
+    $this->order->setPriceSelectionFromUnfilteredInput($this->getSubmittedValues());
   }
 
   protected function defineRenewalMembership(): void {


### PR DESCRIPTION
Overview
----------------------------------------
Fix Main Contribution form to identify money fields

Before
----------------------------------------\
The function `getSubmittedValues()` can't identify the money fields because it is called before the metadata is set 

After
----------------------------------------
Slight re-order to enable `getSubmittedValues()` to set the `submittableMoneyFields` before calling `getSubmittedValues()`

Technical Details
----------------------------------------
This means the results of `$this-getSubmittedValues()` have money reliable formatted to non-localised

Comments
----------------------------------------
