### PR TITLE
dev/core#4796 - Fix Cancel button on the "unsubscribe mailing"

### DIFF
--- a/CRM/Mailing/Page/Common.php
+++ b/CRM/Mailing/Page/Common.php
@@ -44,7 +44,7 @@ class CRM_Mailing_Page_Common extends CRM_Core_Page {
     }
 
     $cancel = CRM_Utils_Request::retrieve("_qf_{$this->_type}_cancel", 'String');
-    if ($cancel) {
+    if (isset($cancel)) {
       $config = CRM_Core_Config::singleton();
       CRM_Utils_System::redirect($config->userFrameworkBaseURL);
     }


### PR DESCRIPTION
Overview
----------------------------------------

Related issue: [https://lab.civicrm.org/dev/core/-/issues/4796](https://lab.civicrm.org/dev/core/-/issues/4796)

The footer of a mailing (civicrm/admin/component?action=update&id=2) includes the token {action.optOutUrl}, but, if you create a new footer with the token {action.unsubscribeUrl} and send a mailing, when you click to unsubscribe from the group, a mailing is resent allowing you to resubscribe. In this last form "civicrm/mailing/resubscribe" if you click on the cancel button, you resubscribe.

Before
----------------------------------------
- When I click on the “here” link in the re-subscribe confirmation and then on button “Cancel”, we still get re-subscribed.

After
----------------------------------------
- Cancel button redirects to `userFrameworkBaseURL`.



