### PR TITLE
Autocomplete - Fix incorrect matching on id instead of value

### DIFF
--- a/Civi/Api4/Event/Subscriber/AutocompleteFieldSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/AutocompleteFieldSubscriber.php
@@ -67,6 +67,11 @@ class AutocompleteFieldSubscriber extends AutoService implements EventSubscriber
           $apiRequest->addFilter($key, $value);
         }
 
+        // Autocomplete for field with option values
+        if ($apiRequest->getEntityName() === 'OptionValue' && !empty($fieldSpec['custom_field_id'])) {
+          $apiRequest->setKey('value');
+        }
+
         if ($formType === 'qf') {
           $this->autocompleteProfilePermissions($apiRequest, $formName, $fieldSpec);
         }

--- a/Civi/Api4/Generic/AutocompleteAction.php
+++ b/Civi/Api4/Generic/AutocompleteAction.php
@@ -285,6 +285,10 @@ class AutocompleteAction extends AbstractAction {
    */
   private function getKeyField() {
     $entityName = $this->savedSearch['api_entity'];
+    // Temp hack for 5.67. Fixed in 5.68. See https://github.com/civicrm/civicrm-core/pull/28283
+    if ($entityName === 'OptionValue' && $this->key === 'value') {
+      return 'value';
+    }
     if ($this->key) {
       /** @var \CRM_Core_DAO $dao */
       $dao = CoreUtil::getInfoItem($entityName, 'dao');


### PR DESCRIPTION
Backports https://github.com/civicrm/civicrm-core/pull/28283 
Fixes https://lab.civicrm.org/dev/core/-/issues/4799 

Custom fields of type Autocomplete-Select were incorrectly using the id of the optionValue. This fixes it to use the value, and also show the value in the autocomplete results.
