### PR TITLE
[REF][PHP8.2] Tidy up properties in CRM_Badge_BAO_Badge

### DIFF
--- a/CRM/Badge/BAO/Badge.php
+++ b/CRM/Badge/BAO/Badge.php
@@ -25,6 +25,11 @@ use Civi\Token\TokenProcessor;
 class CRM_Badge_BAO_Badge {
 
   /**
+   * @var CRM_Utils_PDF_Label
+   */
+  public $pdf;
+
+  /**
    * @var bool
    */
   public $debug = FALSE;
@@ -168,9 +173,6 @@ class CRM_Badge_BAO_Badge {
    * @param int $cellspacing
    */
   public function labelCreator($formattedRow, $cellspacing = 0) {
-    $this->lMarginLogo = 18;
-    $this->tMarginName = 20;
-
     $x = $this->pdf->GetAbsX();
     $y = $this->pdf->getY();
 
@@ -363,10 +365,8 @@ class CRM_Badge_BAO_Badge {
       $y = $this->pdf->GetY();
     }
 
-    $this->imgRes = 300;
-
     if ($img) {
-      [$w, $h] = self::getImageProperties($img, $this->imgRes, $w, $h);
+      [$w, $h] = self::getImageProperties($img, 300, $w, $h);
       $this->pdf->Image($img, $x, $y, $w, $h, '', '', '', FALSE, 72, '', FALSE,
         FALSE, $this->debug, FALSE, FALSE, FALSE);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Sort out PHP 8.2 compatiability in class `CRM_Badge_BAO_Badge`

Before
----------------------------------------
Dynamic properties caused deprecation warnings (and test failures) on PHP 8.2

After
----------------------------------------
Properties declared.

Technical Details
----------------------------------------

 - `$pdf` declared public, to maintain backwards compatiability for users of `CRM_Utils_Hook::alterBadge`
 - `lMarginLogo` and `tMarginName` were never used (I think they were mistakenly copied from `CRM_Event_Badge_Logo5395` and `CRM_Event_Badge_Logo` where such properties _are_ used.
 - It seemed silly to be setting `imgRes` when it was only used once within the same function. There could be an argument that this is a breaking change, so can switch to the alternative of declaring a `imgRes` property if needed.