### PR TITLE
dev/core#4802 Fix amount truncation with non-English formatting

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1297,6 +1297,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
     $priceSetID = $this->getPriceSetID();
     if (!empty($this->_ccid)) {
+      // @todo - verify that this is the same as `$this->>getLineItems()` which it should be & consolidate
       $this->set('lineItem', [$this->getPriceSetID() => $this->getExistingContributionLineItems()]);
     }
     elseif ($priceSetID) {
@@ -1336,7 +1337,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
           $params['amount'] = $proceFieldAmount;
         }
       }
-      $this->set('lineItem', $lineItem);
+      $this->set('lineItem', [$this->getPriceSetID() => $this->getLineItems()]);
     }
 
     if ($params['amount'] != 0 && (($this->_values['is_pay_later'] &&

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1262,34 +1262,6 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     // @todo - stepping through the code indicates that amount is always set before this point so it never matters.
     // Move more of the above into this function...
     $params['amount'] = $this->getMainContributionAmount();
-    //If the membership & contribution is used in contribution page & not separate payment
-    $memPresent = $membershipLabel = $fieldOption = NULL;
-    $proceFieldAmount = 0;
-    if (property_exists($this, '_separateMembershipPayment') && $this->_separateMembershipPayment == 0) {
-      if ($this->isQuickConfig()) {
-        foreach ($this->_priceSet['fields'] as $fieldKey => $fieldVal) {
-          if ($fieldVal['name'] == 'membership_amount' && !empty($params['price_' . $fieldKey])) {
-            $fieldId = $fieldVal['id'];
-            $fieldOption = $params['price_' . $fieldId];
-            $proceFieldAmount += $fieldVal['options'][$this->_submitValues['price_' . $fieldId]]['amount'];
-            $memPresent = TRUE;
-          }
-          else {
-            if (!empty($params['price_' . $fieldKey]) && $memPresent && ($fieldVal['name'] == 'other_amount' || $fieldVal['name'] == 'contribution_amount')) {
-              $fieldId = $fieldVal['id'];
-              if ($fieldVal['name'] == 'other_amount') {
-                $proceFieldAmount += $this->_submitValues['price_' . $fieldId];
-              }
-              elseif ($fieldVal['name'] == 'contribution_amount' && $this->_submitValues['price_' . $fieldId] > 0) {
-                $proceFieldAmount += $fieldVal['options'][$this->_submitValues['price_' . $fieldId]]['amount'];
-              }
-              unset($params['price_' . $fieldId]);
-              break;
-            }
-          }
-        }
-      }
-    }
 
     if (!isset($params['amount_other'])) {
       $this->set('amount_level', CRM_Utils_Array::value('amount_level', $params));
@@ -1326,17 +1298,6 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         CRM_Price_BAO_PriceSet::processAmount($this->_values['fee'], $params, $lineItem[$priceSetID], $priceSetID);
       }
 
-      if ($proceFieldAmount) {
-        $lineItem[$priceSetID][$fieldOption]['unit_price'] = $proceFieldAmount;
-        $lineItem[$priceSetID][$fieldOption]['line_total'] = $proceFieldAmount;
-        if (isset($lineItem[$priceSetID][$fieldOption]['tax_amount'])) {
-          $proceFieldAmount += $lineItem[$priceSetID][$fieldOption]['tax_amount'];
-        }
-        if (!$this->_membershipBlock['is_separate_payment']) {
-          //require when separate membership not used
-          $params['amount'] = $proceFieldAmount;
-        }
-      }
       $this->set('lineItem', [$this->getPriceSetID() => $this->getLineItems()]);
     }
 

--- a/Civi/Test/ContributionPageTestTrait.php
+++ b/Civi/Test/ContributionPageTestTrait.php
@@ -283,7 +283,6 @@ trait ContributionPageTestTrait {
    * - use false to suppress the creation of this field.
    * @param string $identifier
    *
-   * @throws \CRM_Core_Exception
    * @noinspection PhpUnhandledExceptionInspection
    */
   public function contributionPageQuickConfigCreate(array $contributionPageParameters = [], array $priceSetParameters = [], bool $isSeparatePayment = FALSE, bool $membershipAmountField = TRUE, bool $contributionAmountField = TRUE, bool $otherAmountField = TRUE, string $identifier = 'QuickConfig'): void {

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -196,6 +196,30 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that submitting other amount works with non-english currency formatting.
+   *
+   * @dataProvider getThousandSeparators
+   *
+   * @param string $thousandSeparator
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testOtherAmountConfirm(string $thousandSeparator) : void {
+    $this->setCurrencySeparators($thousandSeparator);
+    $this->contributionPageQuickConfigCreate([], [], FALSE, TRUE, TRUE, TRUE);
+    $processor = \Civi\Payment\System::singleton()->getById($this->ids['PaymentProcessor']['dummy']);
+    $processor->setDoDirectPaymentResult(['payment_status_id' => 1, 'fee_amount' => .72]);
+    $this->submitOnlineContributionForm([
+      'payment_processor_id' => $this->ids['PaymentProcessor']['dummy'],
+      'price_' . $this->ids['PriceField']['other_amount'] => $this->formatMoneyInput(555.00),
+      'price_' . $this->ids['PriceField']['membership_amount'] => $this->ids['PriceFieldValue']['membership_general'],
+      'id' => $this->getContributionPageID(),
+    ] + $this->getBillingSubmitValues(), $this->getContributionPageID());
+    $contribution = $this->callAPISuccessGetSingle('Contribution', ['contribution_page_id' => $this->getContributionPageID(), 'version' => 4]);
+    $this->assertEquals(655, $contribution['total_amount']);
+  }
+
+  /**
    * Test the confirm form with a separate membership payment configured.
    */
   public function testSeparatePaymentConfirm(): void {
@@ -281,6 +305,8 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
 
   /**
    * @param bool $isSeparateMembershipPayment
+   *
+   * @deprecated see testSeparatePaymentWithTax for preferred way to get valid config.
    *
    * @return \Civi\Test\FormWrapper|\Civi\Test\FormWrappers\EventFormOnline|\Civi\Test\FormWrappers\EventFormParticipant|null
    */


### PR DESCRIPTION
Overview
----------------------------------------
[dev/core#4802 Fix amount truncation with non-English formatting](https://github.com/civicrm/civicrm-core/commit/d4387c923300c5091b50b45fa3056a9ee9648670)

Before
----------------------------------------
Entering an 'other amount' with non-English money formatting results in the amount being truncated

After
----------------------------------------
Amount retained

Technical Details
----------------------------------------
I verified this behaviour in 5.60 so it is non-regressive but uncool

Comments
----------------------------------------
