### PR TITLE
[php8] undeclared property action and id in Page

### DIFF
--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -144,6 +144,16 @@ class CRM_Core_Page {
   public $_permission;
 
   /**
+   * @var int
+   */
+  protected $_action;
+
+  /**
+   * @var int
+   */
+  protected $_id;
+
+  /**
    * Class constructor.
    *
    * @param string $title


### PR DESCRIPTION
Overview
----------------------------------------
Undeclared class properties

Before
----------------------------------------
e.g. go to New Contribution. Warnings about $_action and $_id

After
----------------------------------------


Technical Details
----------------------------------------
In all the subclasses where they are declared, e.g. CRM_Contact_Page_View, it's marked protected, so protected seems the right choice.

Comments
----------------------------------------

