### PR TITLE
Check financial acls for product in extension

### DIFF
--- a/Civi/Test/ContributionPageTestTrait.php
+++ b/Civi/Test/ContributionPageTestTrait.php
@@ -117,6 +117,37 @@ trait ContributionPageTestTrait {
       'entity_id' => $contributionPageResult['id'],
       'price_set_id' => $this->ids['PriceSet'][$identifier],
     ]);
+    $this->createTestEntity('Product', [
+      'name' => '5_dollars',
+      'description' => '5 dollars worth of monopoly money',
+      'options' => 'White, Black, Green',
+      'price' => 1,
+      'min_contribution' => 5,
+      'cost' => .05,
+    ], '5_dollars');
+    $this->createTestEntity('Product', [
+      'name' => '10_dollars',
+      'description' => '10 dollars worth of monopoly money',
+      'options' => 'White, Black, Green',
+      'price' => 2,
+      'min_contribution' => 10,
+      'cost' => .05,
+    ], '10_dollars');
+    $this->createTestEntity('Premium', [
+      'entity_id' => $this->getContributionPageID($identifier),
+      'entity_table' => 'civicrm_contribution_page',
+      'premiums_intro_title' => 'Get free monopoly money with your donation',
+    ], $identifier);
+    $this->createTestEntity('PremiumsProduct', [
+      'premiums_id' => $this->ids['Premium'][$identifier],
+      'product_id' => $this->ids['Product']['5_dollars'],
+      'weight' => 1,
+    ]);
+    $this->createTestEntity('PremiumsProduct', [
+      'premiums_id' => $this->ids['Premium'][$identifier],
+      'product_id' => $this->ids['Product']['10_dollars'],
+      'weight' => 2,
+    ]);
     return $contributionPageResult;
   }
 

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/BaseTestClass.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/BaseTestClass.php
@@ -7,6 +7,7 @@ use Civi\Api4\FinancialType;
 use Civi\Api4\PriceField;
 use Civi\Api4\PriceFieldValue;
 use Civi\Api4\PriceSet;
+use Civi\Api4\Product;
 use Civi\Test;
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
@@ -49,6 +50,7 @@ class BaseTestClass extends TestCase implements HeadlessInterface, HookInterface
   public function tearDown(): void {
     Contribution::delete(FALSE)->addWhere('id', '>', 0)->execute();
     FinancialType::delete(FALSE)->addWhere('name', 'LIKE', '%test%')->execute();
+    Product::delete(FALSE)->addWhere('name', '=', '10_dollars')->execute();
     $this->cleanupPriceSets();
   }
 

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/ProductTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/ProductTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Civi\Financialacls;
+
+require_once 'BaseTestClass.php';
+
+/**
+ * @group headless
+ */
+class ProductTest extends BaseTestClass {
+
+  /**
+   * Test api applies permissions on line item actions (delete & get).
+   *
+   * @dataProvider versionThreeAndFour
+   */
+  public function testProductApiPermissions($version): void {
+    $this->createTestEntity('Product', [
+      'name' => '10_dollars',
+      'description' => '10 dollars worth of monopoly money',
+      'options' => 'White, Black, Green',
+      'price' => 2,
+      'min_contribution' => 10,
+      'cost' => .05,
+      'financial_type_id:name' => 'Member Dues',
+    ], '10_dollars');
+    $this->_apiversion = $version;
+    $this->setupLoggedInUserWithLimitedFinancialTypeAccess();
+    $products = $this->callAPISuccess('Product', 'get', ['sequential' => TRUE])['values'];
+    $this->assertCount(1, $products);
+    $this->callAPISuccessGetCount('Product', ['check_permissions' => TRUE], 0);
+    $this->callAPIFailure('Product', 'Delete', ['check_permissions' => TRUE, 'id' => $products[0]['id']]);
+    $this->callAPISuccess('Product', 'Delete', ['check_permissions' => FALSE, 'id' => $products[0]['id']]);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Check financial acls for product in extension

Before
----------------------------------------
Apiv4 doesn't check financial acls on products

After
----------------------------------------
now it does

Technical Details
----------------------------------------
Fix is to allow replacing some code in Contribution Page with apiv4 call - apiv3 out of scope but it worked on the GET & needed something or other to get the test working with Delete 

Comments
----------------------------------------
