### PR TITLE
Fix tax when selection a contribution with the membership, test

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1431,6 +1431,9 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         // Skip line items in the contribution processing transaction.
         // We will create them with the membership for proper linking.
         $membershipParams['skipLineItem'] = 1;
+        // Since we are not letting Contribution::create set up the line items
+        // we need to specify the tax.
+        $membershipParams['tax_amount'] = $this->order->getTotalTaxAmount();
       }
 
       $paymentResult = $this->processConfirm(


### PR DESCRIPTION
Overview
----------------------------------------
Fix tax when selection a contribution with the membership, test

Before
----------------------------------------
Tax amount not correctly set on the contribution when tax enabled for membership + contribution

After
----------------------------------------
Set, tested

Technical Details
----------------------------------------
Note that issues with this date back prior to this release -although they have moved slightly in this release. I am going to put out a dev-digest highlighting a couple of issues where the 'right' behaviour is not 100% clear but this part is pretty clear cut

Comments
----------------------------------------
