### PR TITLE
Make financialacls require civi-contribute

### DIFF
--- a/CRM/Extension/Upgrader/Component.php
+++ b/CRM/Extension/Upgrader/Component.php
@@ -1,5 +1,4 @@
 <?php
-use CRM_AfformAdmin_ExtensionUtil as E;
 
 /**
  * Upgrader base class ONLY for core component extensions (e.g. `civi_mail`, `civi_event`).
@@ -22,7 +21,7 @@ class CRM_Extension_Upgrader_Component extends CRM_Extension_Upgrader_Base {
   }
 
   /**
-   * Get of component (e.g. CiviMail)
+   * Get name of component corresponding to this extension (e.g. CiviMail)
    *
    * @return string
    */

--- a/ext/financialacls/info.xml
+++ b/ext/financialacls/info.xml
@@ -31,6 +31,9 @@
   <mixins>
     <mixin>setting-php@1.0.0</mixin>
   </mixins>
+  <requires>
+    <ext>civi_contribute</ext>
+  </requires>
   <civix>
     <namespace>CRM/Financialacls</namespace>
     <format>23.02.1</format>

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -800,9 +800,10 @@ return [
     'help_text' => NULL,
     'on_change' => [
       'CRM_Case_Info::onToggleComponents',
+      'CRM_Core_Component::preToggleComponents',
     ],
     'post_change' => [
-      'CRM_Core_Component::onToggleComponents',
+      'CRM_Core_Component::postToggleComponents',
     ],
     'pseudoconstant' => [
       'callback' => 'CRM_Core_SelectValues::getComponentSelectValues',


### PR DESCRIPTION
Overview
----------------------------------------
Make financialacls require civi-contribute

Before
----------------------------------------
I think disabling civi-contribute & leaving financialacls enabled would be risky

After
----------------------------------------
there is a required

Technical Details
----------------------------------------
This actually fails on tests & I don't know how to fix - but I put up the PR to highlight it

CRM_Event_Form_Registration_ConfirmTest::testRegistrationWithoutCiviContributeEnabled
Exception: CRM_Extension_Exception_DependencyException: "Cannot disable extension due to dependencies. Consider disabling all these: civi_contribute,financialacls"
#0 /home/homer/buildkit/build/build-4/web/sites/all/modules/civicrm/CRM/Core/Component.php(451): CRM_Extension_Manager->disable((Array:1))
#1 [internal function](): CRM_Core_Component::onToggleComponents((Array:6), (Array:5), (Array:16), 1)
#2 /home/homer/buildkit/build/build-4/web/sites/all/modules/civicrm/Civi/Core/SettingsBag.php(440): call_user_func((Array:2), (Array:6), (Array:5), (Array:16), 1)
#3 /home/homer/buildkit/build/build-4/web/sites/all/modules/civicrm/Civi/Core/SettingsBag.php(250): Civi\Core\SettingsBag->setDb("enable_components", (Array:5))
#4 /home/homer/buildkit/build/build-4/web/sites/all/modules/civicrm/CRM/Core/BAO/ConfigSetting.php(366): Civi\Core\SettingsBag->set("enable_components", (Array:5))
#5 /home/homer/buildkit/build/build-4/web/sites/all/modules/civicrm/CRM/Core/BAO/ConfigSetting.php(355): CRM_Core_BAO_ConfigSetting::setEnabledComponents((Array:5))

Comments
----------------------------------------
