### PR TITLE
Fix notices on premiums across all 3 pages

### DIFF
--- a/CRM/Contribute/BAO/Premium.php
+++ b/CRM/Contribute/BAO/Premium.php
@@ -140,7 +140,7 @@ class CRM_Contribute_BAO_Premium extends CRM_Contribute_DAO_Premium {
         }
       }
       if (count($products)) {
-        $form->assign('showPremium', $formItems);
+        $form->assign('showPremiumSelectionFields', $formItems);
         $form->assign('showSelectOptions', $formItems);
         $form->assign('premiumBlock', $premiumBlock);
       }

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -500,11 +500,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     if (!empty($params['selectProduct']) && $params['selectProduct'] !== 'no_thanks') {
       $option = $params['options_' . $params['selectProduct']] ?? NULL;
-      $productID = $params['selectProduct'];
-      $this->buildPremiumsBlock(FALSE,
-        $productID, $option
-      );
-      $this->set('productID', $productID);
+      $this->buildPremiumsBlock(FALSE, $option);
       $this->set('option', $option);
     }
     else {

--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -95,13 +95,12 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
     // FIXME: Some of this code is identical to Confirm.php and should be broken out into a shared function
     $this->assignToTemplate();
     $this->_ccid = $this->get('ccid');
-    $productID = $this->get('productID');
     $option = $this->get('option');
     $membershipTypeID = $this->get('membershipTypeID');
     $this->assign('receiptFromEmail', CRM_Utils_Array::value('receipt_from_email', $this->_values));
 
-    if ($productID) {
-      $this->buildPremiumsBlock(FALSE, $productID, $option);
+    if ($this->getProductID()) {
+      $this->buildPremiumsBlock(FALSE, $option);
     }
 
     $params = $this->_params;

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1153,7 +1153,10 @@ class CRM_Core_Permission {
     ];
     $permissions['line_item'] = $permissions['contribution'];
     $permissions['product'] = $permissions['premiums'] = $permissions['premiums_product'] = $permissions['contribution'];
-    $permissions['product']['get'] = $permissions['premiums']['get'] = $permissions['premiums_product']['get'] = [['access CiviCRM', 'access CiviContribute', 'make online contributions']];
+    // Add 'make online contributions' permissions to allow anon users to access these entities
+    // (permissions are controlled by financial ACLs)
+    $permissions['product']['get'] = $permissions['premium']['get'] = $permissions['premiums_product']['get'] = [['access CiviCRM', 'access CiviContribute', 'make online contributions']];
+    $permissions['product']['meta'] = $permissions['premium']['meta'] = $permissions['premiums_product']['meta'] = [['access CiviCRM', 'access CiviContribute', 'make online contributions']];
 
     $permissions['financial_item'] = $permissions['contribution'];
     $permissions['financial_type']['get'] = $permissions['contribution']['get'];

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1152,7 +1152,8 @@ class CRM_Core_Permission {
       ],
     ];
     $permissions['line_item'] = $permissions['contribution'];
-    $permissions['product'] = $permissions['contribution'];
+    $permissions['product'] = $permissions['premiums'] = $permissions['premiums_product'] = $permissions['contribution'];
+    $permissions['product']['get'] = $permissions['premiums']['get'] = $permissions['premiums_product']['get'] = [['access CiviCRM', 'access CiviContribute', 'make online contributions']];
 
     $permissions['financial_item'] = $permissions['contribution'];
     $permissions['financial_type']['get'] = $permissions['contribution']['get'];

--- a/Civi/Test/ContributionPageTestTrait.php
+++ b/Civi/Test/ContributionPageTestTrait.php
@@ -122,6 +122,7 @@ trait ContributionPageTestTrait {
       'description' => '5 dollars worth of monopoly money',
       'options' => 'White, Black, Green',
       'price' => 1,
+      'is_active' => TRUE,
       'min_contribution' => 5,
       'cost' => .05,
     ], '5_dollars');
@@ -130,6 +131,7 @@ trait ContributionPageTestTrait {
       'description' => '10 dollars worth of monopoly money',
       'options' => 'White, Black, Green',
       'price' => 2,
+      'is_active' => TRUE,
       'min_contribution' => 10,
       'cost' => .05,
     ], '10_dollars');
@@ -137,6 +139,7 @@ trait ContributionPageTestTrait {
       'entity_id' => $this->getContributionPageID($identifier),
       'entity_table' => 'civicrm_contribution_page',
       'premiums_intro_title' => 'Get free monopoly money with your donation',
+      'premiums_active' => TRUE,
     ], $identifier);
     $this->createTestEntity('PremiumsProduct', [
       'premiums_id' => $this->ids['Premium'][$identifier],

--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -268,7 +268,7 @@
     {/if}
     {/crmRegion}
 
-  {include file="CRM/Contribute/Form/Contribution/PremiumBlock.tpl" context="confirmContribution"}
+  {include file="CRM/Contribute/Form/Contribution/PremiumBlock.tpl" context="confirmContribution" showPremiumSelectionFields=false preview=false}
 
   {if $customPost}
     <fieldset class="label-left crm-profile-view">

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -185,7 +185,7 @@
         {include file="CRM/common/CMSUser.tpl"}
       </div>
       <div class="crm-public-form-item crm-section premium_block-section">
-        {include file="CRM/Contribute/Form/Contribution/PremiumBlock.tpl" context="makeContribution" preview=false}
+        {include file="CRM/Contribute/Form/Contribution/PremiumBlock.tpl" context="makeContribution" preview=false showPremiumSelectionFields=true}
       </div>
 
       {if $honoreeProfileFields && $honoreeProfileFields|@count}

--- a/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
@@ -12,11 +12,11 @@
     {if $context EQ "makeContribution"}
       <fieldset class="crm-group premiums_select-group">
       {if $premiumBlock.premiums_intro_title}
-        <legend>{$premiumBlock.premiums_intro_title}</legend>
+        <legend>{$premiumBlock.premiums_intro_title|escape}</legend>
       {/if}
       {if $premiumBlock.premiums_intro_text}
         <div id="premiums-intro" class="crm-section premiums_intro-section">
-          {$premiumBlock.premiums_intro_text}
+          {$premiumBlock.premiums_intro_text|escape}
         </div>
       {/if}
     {/if}
@@ -25,7 +25,7 @@
     <div class="crm-group premium_display-group">
       <div class="header-dark">
         {if $premiumBlock.premiums_intro_title}
-          {$premiumBlock.premiums_intro_title}
+          {$premiumBlock.premiums_intro_title|escape}
         {else}
           {ts}Your Premium Selection{/ts}
         {/if}
@@ -33,23 +33,23 @@
     {/if}
 
     {if $preview}
-      {assign var="showSelectOptions" value="1"}
+      {assign var="showPremiumSelectionFields" value="1"}
     {/if}
 
     {strip}
       <div id="premiums-listings">
-      {if $showPremium AND !$preview AND $premiumBlock.premiums_nothankyou_position EQ 1}
+      {if $showPremiumSelectionFields AND !$preview AND $premiumBlock.premiums_nothankyou_position EQ 1}
         <div class="premium premium-no_thanks" id="premium_id-no_thanks" min_contribution="0">
           <div class="premium-short">
-            <input type="checkbox" disabled="disabled" /> {$premiumBlock.premiums_nothankyou_label}
+            <input type="checkbox" disabled="disabled" /> {$premiumBlock.premiums_nothankyou_label|escape}
           </div>
           <div class="premium-full">
-            <input type="checkbox" checked="checked" disabled="disabled" /> {$premiumBlock.premiums_nothankyou_label}
+            <input type="checkbox" checked="checked" disabled="disabled" /> {$premiumBlock.premiums_nothankyou_label|escape}
           </div>
         </div>
       {/if}
       {foreach from=$products item=row}
-        <div class="premium {if $showPremium}premium-selectable{/if}" id="premium_id-{$row.id}" min_contribution="{$row.min_contribution}">
+        <div class="premium {if $showPremiumSelectionFields}premium-selectable{/if}" id="premium_id-{$row.id}" min_contribution="{$row.min_contribution}">
           <div class="premium-short">
             {if $row.thumbnail}<div class="premium-short-thumbnail"><img src="{$row.thumbnail|purify}" alt="{$row.name|escape}" /></div>{/if}
             <div class="premium-short-content">{$row.name|escape}</div>
@@ -69,13 +69,11 @@
               <div class="premium-full-description">
                 {$row.description|escape}
               </div>
-              {if $showSelectOptions}
-                {assign var="pid" value="options_"|cat:$row.id}
-                {if $pid}
+              {if $showPremiumSelectionFields}
+                {assign var="premium_option" value="options_"|cat:$row.id}
                   <div class="premium-full-options">
-                    <p>{$form.$pid.html}</p>
+                    <p>{$form.$premium_option.html}</p>
                   </div>
-                {/if}
               {else}
                 <div class="premium-full-options">
                   <p><strong>{$row.options|purify}</strong></p>
@@ -90,13 +88,13 @@
           <div style="clear:both"></div>
         </div>
       {/foreach}
-      {if $showPremium AND !$preview AND $premiumBlock.premiums_nothankyou_position EQ 2}
+      {if $showPremiumSelectionFields AND !$preview AND $premiumBlock.premiums_nothankyou_position EQ 2}
         <div class="premium premium-no_thanks" id="premium_id-no_thanks" min_contribution="0">
           <div class="premium-short">
-            <input type="checkbox" disabled="disabled" /> {$premiumBlock.premiums_nothankyou_label}
+            <input type="checkbox" disabled="disabled" /> {$premiumBlock.premiums_nothankyou_label|escape}
           </div>
           <div class="premium-full">
-            <input type="checkbox" checked="checked" disabled="disabled" /> {$premiumBlock.premiums_nothankyou_label}
+            <input type="checkbox" checked="checked" disabled="disabled" /> {$premiumBlock.premiums_nothankyou_label|escape}
           </div>
         </div>
       {/if}

--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -300,7 +300,7 @@
     {/crmRegion}
   {/if}
 
-  {include file="CRM/Contribute/Form/Contribution/PremiumBlock.tpl" context="thankContribution"}
+  {include file="CRM/Contribute/Form/Contribution/PremiumBlock.tpl" context="thankContribution" showPremiumSelectionFields=false preview=false}
 
   {if $customPost}
     <fieldset class="label-left crm-profile-view">

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1662,6 +1662,9 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       'civicrm_price_set_entity',
       'civicrm_price_field_value',
       'civicrm_price_field',
+      'civicrm_product',
+      'civicrm_premiums',
+      'civicrm_premiums_product',
     ];
     $this->quickCleanup($tablesToTruncate);
     CRM_Core_DAO::executeQuery("DELETE FROM civicrm_membership_status WHERE name NOT IN('New', 'Current', 'Grace', 'Expired', 'Pending', 'Cancelled', 'Deceased')");

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -136,19 +136,6 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
   /**
    * Test form submission with basic price set.
    */
-  public function testSubmit(): void {
-    $this->setUpContributionPage();
-    $submitParams = $this->getBasicSubmitParams();
-
-    $this->callAPISuccess('ContributionPage', 'submit', $submitParams);
-    $contribution = $this->callAPISuccess('Contribution', 'getsingle', ['contribution_page_id' => $this->getContributionPageID(), 'return' => ['non_deductible_amount']]);
-    //assert non-deductible amount
-    $this->assertEquals(5.00, $contribution['non_deductible_amount']);
-  }
-
-  /**
-   * Test form submission with basic price set.
-   */
   public function testSubmitZeroDollar(): void {
     $this->setUpContributionPage();
     $priceFieldID = reset($this->_ids['price_field']);


### PR DESCRIPTION
Overview
----------------------------------------
[Fix notices on premiums across all 3 pages](https://github.com/civicrm/civicrm-core/commit/2c901bf2cf36be60fb601bb49befb321257fa5c9)

Before
----------------------------------------
Notices relating to premiums on Main, Confirm and ThankYou page

After
----------------------------------------
Notices resolved

Technical Details
----------------------------------------
This builds on moving the financialacls check to the extension https://github.com/civicrm/civicrm-core/pull/28316 and then uses apiv4. To ensure this doesn't cause problems with escaping escape is added to the template

Comments
----------------------------------------
