### PR TITLE
dev/core#4811 AngularJs - Load on every page

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2325,9 +2325,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $props['data-select-params'] = json_encode($props['select']);
     $props['data-api-params'] = json_encode($props['api']);
     $props['data-api-entity'] = $props['entity'];
-    if (!empty($props['select']['quickAdd'])) {
-      Civi::service('angularjs.loader')->addModules(['af']);
-    }
+
     CRM_Utils_Array::remove($props, 'select', 'api', 'entity');
     return $this->add('text', $name, $label, $props, $required);
   }

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -381,6 +381,9 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
     if (!self::isAjaxMode()) {
       $this->addBundle('coreResources');
       $this->addCoreStyles($region);
+      // This ensures that if a popup link requires AngularJS, it will always be available.
+      // Additional Ang modules required by popups will be loaded on-the-fly by Civi\Angular\AngularLoader
+      Civi::service('angularjs.loader')->addModules(['crmResource']);
     }
     return $this;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#4811](https://lab.civicrm.org/dev/core/-/issues/4811)
This ensures that if a popup link requires AngularJS, it will always be available.

Before
--------
Loading a popup was unreliable if it contained Afforms, search displays, or other Ang elements.

After
------
Works more betterly.

Comments
-----------
Every other page uses Angular these days... might as well just load it unconditionally.
