### PR TITLE
don't warn users about invalid financial types on unused price sets

### DIFF
--- a/CRM/Utils/Check/Component/PriceFields.php
+++ b/CRM/Utils/Check/Component/PriceFields.php
@@ -27,6 +27,17 @@ class CRM_Utils_Check_Component_PriceFields extends CRM_Utils_Check_Component {
       INNER JOIN civicrm_price_field psf ON psf.price_set_id = ps.id
       INNER JOIN civicrm_price_field_value pfv ON pfv.price_field_id = psf.id
       LEFT JOIN civicrm_financial_type cft ON cft.id = pfv.financial_type_id
+      INNER JOIN civicrm_price_set_entity pse ON entity_table = 'civicrm_contribution_page' AND ps.id = pse.price_set_id
+      INNER JOIN civicrm_contribution_page cp ON cp.id = pse.entity_id AND cp.is_active = 1
+      WHERE cft.id IS NULL OR cft.is_active = 0
+      UNION
+      SELECT DISTINCT ps.title as ps_title, ps.id as ps_id, psf.label as psf_label
+      FROM civicrm_price_set ps
+      INNER JOIN civicrm_price_field psf ON psf.price_set_id = ps.id
+      INNER JOIN civicrm_price_field_value pfv ON pfv.price_field_id = psf.id
+      LEFT JOIN civicrm_financial_type cft ON cft.id = pfv.financial_type_id
+      INNER JOIN civicrm_price_set_entity pse ON entity_table = 'civicrm_event' AND ps.id = pse.price_set_id
+      INNER JOIN civicrm_event ce ON ce.id = pse.entity_id AND ce.is_active = 1
       WHERE cft.id IS NULL OR cft.is_active = 0";
     $dao = CRM_Core_DAO::executeQuery($sql);
     $count = 0;


### PR DESCRIPTION
Overview
----------------------------------------
The check we use for locating invalid price sets is too broad.  We shouldn't create work for end users by warning them about financial types that aren't in use.

To replicate:
* Create a new financial type "2022 Payments".
* Create an event or contribution page "2022 page" that uses the financial type.
* Disable the financial type.
* Disable the event/contribution page because it's no longer 2022.

Before
----------------------------------------
You'll get an "invalid financial type" warning for "2022 payments".

After
----------------------------------------
No warning because it's not used on an active page.

Comments
----------------------------------------
Is there a way to do this without a `UNION` or sub-select?
