### PR TITLE
UserJob - Fix deprecated syntax in addSelectWhereClause

### DIFF
--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -154,10 +154,9 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements HookInterface
    */
   public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
     $clauses = [];
-    if (!\CRM_Core_Permission::check('administer queues')) {
-      // @todo - the is_template should really be prefixed. We need to add support
-      // for that in the compiler & then this would be `{table}.is_template`
-      $clauses['created_id'] = '= ' . (int) CRM_Core_Session::getLoggedInContactID() . ' OR is_template = 1';
+    if (!\CRM_Core_Permission::check('administer queues', $userId)) {
+      // Only allow access to users' own jobs (or templates)
+      $clauses['created_id'][] = '= ' . (int) CRM_Core_Session::getLoggedInContactID() . ' OR {is_template} = 1';
     }
     CRM_Utils_Hook::selectWhereClause($this, $clauses, $userId, $conditions);
     return $clauses;


### PR DESCRIPTION
Overview
----------------------------------------
Updates UserJob BAO to use non-deprecated format for selectWhereClause.

Before
----------------------------------------
Notices for user without adminster queues

After
----------------------------------------
Fixed.
