### PR TITLE
BAO - Handle hypothetical userId in addSelectWhereClause

### DIFF
--- a/CRM/Core/BAO/Note.php
+++ b/CRM/Core/BAO/Note.php
@@ -538,12 +538,14 @@ WHERE participant.contact_id = %1 AND  note.entity_table = 'civicrm_participant'
       $clauses['entity_table'] = [$relatedClauses];
     }
     // Enforce note privacy setting
-    if (!CRM_Core_Permission::check('view all notes')) {
+    if (!CRM_Core_Permission::check('view all notes', $userId)) {
+      // It was ok to have $userId = NULL for the permission check but must be an int for the query
+      $cid = $userId ?? (int) CRM_Core_Session::getLoggedInContactID();
       $clauses['privacy'] = [
         [
           '= 0',
           // OR
-          '= 1 AND {contact_id} = ' . (int) CRM_Core_Session::getLoggedInContactID(),
+          "= 1 AND {contact_id} = $cid",
         ],
       ];
     }

--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -159,8 +159,10 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements HookInterface
   public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
     $clauses = [];
     if (!\CRM_Core_Permission::check('administer queues', $userId)) {
+      // It was ok to have $userId = NULL for the permission check but must be an int for the query
+      $cid = $userId ?? (int) CRM_Core_Session::getLoggedInContactID();
       // Only allow access to users' own jobs (or templates)
-      $clauses['created_id'][] = '= ' . (int) CRM_Core_Session::getLoggedInContactID() . ' OR {is_template} = 1';
+      $clauses['created_id'][] = "= $cid OR {is_template} = 1";
     }
     CRM_Utils_Hook::selectWhereClause($this, $clauses, $userId, $conditions);
     return $clauses;


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #28325 per conversation with @eileenmcnaughton 

Technical Details
----------------------------------------
This is aspirational - CiviCRM doesn't fully support checking permissions for anyone other than the current user, but this nudges us a bit closer to what that support would look like.