### PR TITLE
Add system check for if people disabled default location type

### DIFF
--- a/CRM/Utils/Check/Component/LocationTypes.php
+++ b/CRM/Utils/Check/Component/LocationTypes.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Psr\Log\LogLevel;
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class CRM_Utils_Check_Component_LocationTypes extends CRM_Utils_Check_Component {
+
+  /**
+   * Display warning about invalid priceFields
+   *
+   * @return CRM_Utils_Check_Message[]
+   * @throws \CRM_Core_Exception
+   */
+  public function checkPriceFields(): array {
+    $messages = [];
+    if (!CRM_Core_DAO::singleValueQuery('SELECT id FROM civicrm_location_type WHERE is_active = 1 AND is_default = 1')) {
+      $url = CRM_Utils_System::url('civicrm/admin/locationType', [
+        'reset' => 1,
+      ]);
+      $msg = ts('Your site default location type does not exist or is disabled.')
+        . " <a href='$url'>" . ts('Configure location types') . '</a>';
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__,
+        $msg,
+        ts('Location Type Misconfiguration'),
+        LogLevel::ERROR,
+        'fa-lock'
+      );
+    }
+    return $messages;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Not having an enabled default location type causes all kinds of problems -  but may be hard to spot



Before
----------------------------------------
No warning other than hard-errors

After
----------------------------------------

System check
![image](https://github.com/civicrm/civicrm-core/assets/336308/a086331e-f1d4-4d37-8ee0-8b87c95e633d)


Technical Details
----------------------------------------

Comments
----------------------------------------
