### PR TITLE
Activity - Fix backwards logic in getViewOnlyActivityTypeIDs

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2317,7 +2317,7 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
     $viewOnlyActivities = [
       'Email' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Email'),
     ];
-    if (self::checkEditInboundEmailsPermissions()) {
+    if (!self::checkEditInboundEmailsPermissions()) {
       $viewOnlyActivities['Inbound Email'] = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Inbound Email');
     }
     return $viewOnlyActivities;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes apparently backwards logic.

Comments
----------------------------------------
I stumbled across this and stared at it for a while trying to understand how it makes sense. I came to the conclusion that it's backwards.

Before
--------
"Inbound Email" activities are 'view only' if you *do* have permission to edit them.

After
--------
"Inbound Email" activities are 'view only' if you *do not* have permission to edit them.