### PR TITLE
dev/core#4726 Set field to do-not-import if not configured

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -275,7 +275,12 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
         $last_key = array_key_last($mapper[$i]);
       }
       elseif ($this->getSubmittedValue('savedMapping') && $processor->getFieldName($i)) {
-        $defaults["mapper[$i]"] = $processor->getSavedQuickformDefaultsForColumn($i);
+        $defaultField = $processor->getSavedQuickformDefaultsForColumn($i);
+        if (!array_key_exists($defaultField[0], $this->_mapperFields)) {
+          $defaultField = ['do_not_import'];
+          CRM_Core_Session::setStatus(ts('Data was configured to be imported to column %1 but it is not available. The field has been set to "%2"', [1 => $columnHeader, 2 => $this->_mapperFields['do_not_import']]));
+        }
+        $defaults["mapper[$i]"] = $defaultField;
         $last_key = array_key_last($defaults["mapper[$i]"]) ?? 0;
       }
       else {


### PR DESCRIPTION
Overview
----------------------------------------
Set field to do-not-import if not configured

This bug is easier to see in French...

To replicate 
1) do an import to the contact entity **in update mode**  - map the ID field & save the import
2) try to use the template in ignore mode
![image](https://github.com/civicrm/civicrm-core/assets/336308/2e09bcd1-a1cb-49ac-bd0a-07dd0e12a789)
3) on the map field screen the id field cannot be imported but instead of being set to 'do not import' it is set to something french


Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/239caa34-b09a-46ba-813e-4998c23696ed)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/491d2c53-bfcc-4a2a-9489-f0cdd7e1e5f9)

Technical Details
----------------------------------------


Comments
----------------------------------------
