### PR TITLE
Fix support for DB logging with multilingual

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -81,10 +81,6 @@ class CRM_Logging_Schema {
     if (!(CRM_Core_DAO::checkTriggerViewPermission(FALSE)) && $value) {
       throw new CRM_Core_Exception(ts("In order to use this functionality, the installation's database user must have privileges to create triggers and views (if binary logging is enabled – this means the SUPER privilege). This install does not have the required privilege(s) enabled."));
     }
-    // dev/core#1812 Disable logging in a multilingual environment.
-    if (CRM_Core_I18n::isMultilingual() && $value) {
-      throw new CRM_Core_Exception(ts("Logging is not supported in a multilingual environment!"));
-    }
     return TRUE;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

CiviCRM had previously disabled support for database/detailed logging and multilingual, because it didn't work well.

Symbiotic has been running this patch for many years, and a few others have chimed in that it works for them too. I had previously been reluctant to submit the patch, because we do sometimes run into problems when running upgrades over multiple versions (ex: we often jump 5.60 -> 5.65 -> etc). When new fields are added it can cause the upgrader to crash. Re-running the upgrader from the last successful version usually works (ex: 5.64.99 if 5.65.alpha1 failed). 

Comments
----------------------------------------

Based on work by @samuelsov and feedback from @MegaphoneJon and @seamuslee001