### PR TITLE
[NFC] Array formatting cleanup

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -691,9 +691,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
     foreach ($result as $id => $activity) {
       $isBulkActivity = (!$bulkActivityTypeID || ($bulkActivityTypeID === $activity['activity_type_id']));
       foreach ($mappingParams as $apiKey => $expectedName) {
-        if (in_array($apiKey, [
-          'target_contact_name',
-        ])) {
+        if (in_array($apiKey, ['target_contact_name'])) {
 
           if ($isBulkActivity) {
             // @todo  - how is this used? Couldn't we use 'is_bulk' or something clearer?

--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -292,10 +292,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
     // Check for required permissions, CRM-6264.
     if ($this->_activityId &&
-      in_array($this->_action, [
-        CRM_Core_Action::UPDATE,
-        CRM_Core_Action::VIEW,
-      ]) &&
+      in_array($this->_action, [CRM_Core_Action::UPDATE, CRM_Core_Action::VIEW]) &&
       !CRM_Activity_BAO_Activity::checkPermission($this->_activityId, $this->_action)
     ) {
       CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
@@ -406,13 +403,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       }
       $this->assign('searchKey', $qfKey);
     }
-    elseif (in_array($this->_context, [
-      'standalone',
-      'home',
-      'dashlet',
-      'dashletFullscreen',
-    ])
-    ) {
+    elseif (in_array($this->_context, ['standalone', 'home', 'dashlet', 'dashletFullscreen'])) {
       $urlParams = 'reset=1';
       $urlString = 'civicrm/dashboard';
     }

--- a/CRM/Activity/Form/ActivityView.php
+++ b/CRM/Activity/Form/ActivityView.php
@@ -51,12 +51,7 @@ class CRM_Activity_Form_ActivityView extends CRM_Core_Form {
     }
 
     $session = CRM_Core_Session::singleton();
-    if (!in_array($context, [
-      'home',
-      'dashlet',
-      'dashletFullscreen',
-    ])
-    ) {
+    if (!in_array($context, ['home', 'dashlet', 'dashletFullscreen'])) {
       $url = CRM_Utils_System::url('civicrm/contact/view', "reset=1&cid={$cid}&selectedChild=activity");
     }
     else {

--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -325,10 +325,7 @@ class CRM_Activity_Page_AJAX {
 
     // Mark previous activity as deleted. If it was a non-case activity
     // then just change the subject.
-    if (in_array($params['mode'], [
-      'move',
-      'file',
-    ])) {
+    if (in_array($params['mode'], ['move', 'file'])) {
       $caseActivity = new CRM_Case_DAO_CaseActivity();
       $caseActivity->case_id = $params['caseID'];
       $caseActivity->activity_id = $otherActivity->id;

--- a/CRM/Activity/Page/Tab.php
+++ b/CRM/Activity/Page/Tab.php
@@ -184,10 +184,7 @@ class CRM_Activity_Page_Tab extends CRM_Core_Page {
         'Print PDF Letter'
       );
 
-      if (in_array($activityTypeId, [
-        $emailTypeValue,
-        $letterTypeValue,
-      ])) {
+      if (in_array($activityTypeId, [$emailTypeValue, $letterTypeValue])) {
         return;
       }
     }

--- a/CRM/Campaign/BAO/Survey.php
+++ b/CRM/Campaign/BAO/Survey.php
@@ -266,10 +266,7 @@ SELECT  survey.id    as id,
 
     $select = $from = [];
     foreach ($returnProperties as $property => $ignore) {
-      $value = (in_array($property, [
-        'city',
-        'street_address',
-      ])) ? 'address' : $property;
+      $value = (in_array($property, ['city', 'street_address'])) ? 'address' : $property;
       switch ($property) {
         case 'sort_name':
         case 'contact_type':

--- a/CRM/Campaign/Form/Search.php
+++ b/CRM/Campaign/Form/Search.php
@@ -65,12 +65,7 @@ class CRM_Campaign_Form_Search extends CRM_Core_Form_Search {
     //operation for state machine.
     $this->_operation = CRM_Utils_Request::retrieve('op', 'String', $this, FALSE, 'reserve');
     //validate operation.
-    if (!in_array($this->_operation, [
-      'reserve',
-      'release',
-      'interview',
-    ])
-    ) {
+    if (!in_array($this->_operation, ['reserve', 'release', 'interview'])) {
       $this->_operation = 'reserve';
       $this->set('op', $this->_operation);
     }

--- a/CRM/Campaign/Form/Task/Interview.php
+++ b/CRM/Campaign/Form/Task/Interview.php
@@ -59,11 +59,7 @@ class CRM_Campaign_Form_Task_Interview extends CRM_Campaign_Form_Task {
     $this->_reserveToInterview = $this->get('reserveToInterview');
     if ($this->_reserveToInterview || $this->_votingTab) {
       //user came from voting tab / reserve form.
-      foreach ([
-        'surveyId',
-        'contactIds',
-        'interviewerId',
-      ] as $fld) {
+      foreach (['surveyId', 'contactIds', 'interviewerId'] as $fld) {
         $this->{"_$fld"} = $this->get($fld);
       }
       //get the target voter ids.
@@ -428,11 +424,7 @@ WHERE {$clause}
     }
     elseif ($buttonName == '_qf_Interview_next_interviewToRelease') {
       //get ready to jump to release form.
-      foreach ([
-        'surveyId',
-        'contactIds',
-        'interviewerId',
-      ] as $fld) {
+      foreach (['surveyId', 'contactIds', 'interviewerId'] as $fld) {
         $this->controller->set($fld, $this->{"_$fld"});
       }
       $this->controller->set('interviewToRelease', TRUE);

--- a/CRM/Campaign/Form/Task/Release.php
+++ b/CRM/Campaign/Form/Task/Release.php
@@ -50,11 +50,7 @@ class CRM_Campaign_Form_Task_Release extends CRM_Campaign_Form_Task {
     $this->_interviewToRelease = $this->get('interviewToRelease');
     if ($this->_interviewToRelease) {
       //user came from interview form.
-      foreach ([
-        'surveyId',
-        'contactIds',
-        'interviewerId',
-      ] as $fld) {
+      foreach (['surveyId', 'contactIds', 'interviewerId'] as $fld) {
         $this->{"_$fld"} = $this->get($fld);
       }
 

--- a/CRM/Campaign/Page/AJAX.php
+++ b/CRM/Campaign/Page/AJAX.php
@@ -127,10 +127,7 @@ class CRM_Campaign_Page_AJAX {
     }
 
     //format multi-select group and contact types.
-    foreach ([
-      'group',
-      'contact_type',
-    ] as $param) {
+    foreach (['group', 'contact_type'] as $param) {
       $paramValue = $params[$param] ?? NULL;
       if ($paramValue) {
         unset($params[$param]);

--- a/CRM/Case/Audit/Audit.php
+++ b/CRM/Case/Audit/Audit.php
@@ -102,11 +102,7 @@ class CRM_Case_Audit_Audit {
 
               //CRM-4570
               if ($printReport) {
-                if (!in_array($label, [
-                  'Activity Type',
-                  'Status',
-                ])
-                ) {
+                if (!in_array($label, ['Activity Type', 'Status'])) {
                   $caseActivities[$activityindex][$fieldindex] = [];
                   $caseActivities[$activityindex][$fieldindex]['name'] = $name;
                   $caseActivities[$activityindex][$fieldindex]['label'] = $label;

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -2541,11 +2541,7 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
         //has permissions.
         if (!empty($hasPermissions)) {
           //need to check activity object specific.
-          if (in_array($operation, [
-            'view',
-            'edit',
-          ])
-          ) {
+          if (in_array($operation, ['view', 'edit'])) {
             // Check for super permission.
             if (in_array('access all cases and activities', $hasPermissions[$operation])) {
               $allowOperations[$operation] = $allow = TRUE;

--- a/CRM/Case/Form/DeleteClient.php
+++ b/CRM/Case/Form/DeleteClient.php
@@ -66,10 +66,7 @@ class CRM_Case_Form_DeleteClient extends CRM_Core_Form {
     elseif ($context == 'dashboard') {
       $url = CRM_Utils_System::url('civicrm/case', 'reset=1');
     }
-    elseif (in_array($context, [
-      'dashlet',
-      'dashletFullscreen',
-    ])) {
+    elseif (in_array($context, ['dashlet', 'dashletFullscreen'])) {
       $url = CRM_Utils_System::url('civicrm/dashboard', 'reset=1');
     }
     $session = CRM_Core_Session::singleton();

--- a/CRM/Case/Form/EditClient.php
+++ b/CRM/Case/Form/EditClient.php
@@ -45,10 +45,7 @@ class CRM_Case_Form_EditClient extends CRM_Core_Form {
     elseif ($context == 'dashboard') {
       $url = CRM_Utils_System::url('civicrm/case', 'reset=1');
     }
-    elseif (in_array($context, [
-      'dashlet',
-      'dashletFullscreen',
-    ])) {
+    elseif (in_array($context, ['dashlet', 'dashletFullscreen'])) {
       $url = CRM_Utils_System::url('civicrm/dashboard', 'reset=1');
     }
     $session = CRM_Core_Session::singleton();

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1272,12 +1272,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
       $fields = CRM_Contact_DAO_Contact::import();
 
       // get the fields thar are meant for contact types
-      if (in_array($contactType, [
-        'Individual',
-        'Household',
-        'Organization',
-        'All',
-      ])) {
+      if (in_array($contactType, ['Individual', 'Household', 'Organization', 'All'])) {
         $fields = array_merge($fields, CRM_Core_OptionValue::getFields('', $contactType));
       }
 
@@ -1431,12 +1426,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
         $fields = CRM_Contact_DAO_Contact::export();
 
         // The fields are meant for contact types.
-        if (in_array($contactType, [
-          'Individual',
-          'Household',
-          'Organization',
-          'All',
-        ])) {
+        if (in_array($contactType, ['Individual', 'Household', 'Organization', 'All'])) {
           $fields = array_merge($fields, CRM_Core_OptionValue::getFields('', $contactType));
         }
         // add current employer for individuals
@@ -3057,10 +3047,7 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
           continue;
         }
         // build directly accessible action menu.
-        if (in_array($values['ref'], [
-          'view-contact',
-          'edit-contact',
-        ])) {
+        if (in_array($values['ref'], ['view-contact', 'edit-contact'])) {
           $contextMenu['primaryActions'][$key] = [
             'title' => $values['title'],
             'ref' => $values['ref'],
@@ -3169,9 +3156,7 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
         ) {
           $hasAllPermissions = TRUE;
         }
-        elseif (in_array($menuOptions['ref'], [
-          'new-email',
-        ])) {
+        elseif (in_array($menuOptions['ref'], ['new-email'])) {
           // grant permissions for these tasks.
           $hasAllPermissions = TRUE;
         }

--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -584,10 +584,7 @@ UPDATE civicrm_contact
       }
 
       // check permission on acl basis.
-      if (in_array($task, [
-        'view',
-        'edit',
-      ])) {
+      if (in_array($task, ['view', 'edit'])) {
         $aclPermission = CRM_Core_Permission::VIEW;
         if ($task == 'edit') {
           $aclPermission = CRM_Core_Permission::EDIT;

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -680,10 +680,8 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
             if (!empty($blockValues['is_primary'])) {
               $hasPrimary[] = $instance;
               if (!$primaryID &&
-                in_array($name, [
-                  'email',
-                  'openid',
-                ]) && !empty($blockValues[$name])
+                in_array($name, ['email', 'openid']) &&
+                !empty($blockValues[$name])
               ) {
                 $primaryID = $blockValues[$name];
               }
@@ -1397,10 +1395,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
           'street_name',
           'street_unit',
         ] as $fld) {
-          if (in_array($fld, [
-            'street_name',
-            'street_unit',
-          ])) {
+          if (in_array($fld, ['street_name', 'street_unit'])) {
             $streetAddress .= ' ';
           }
           // CRM-17619 - if the street number suffix begins with a number, add a space

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -283,10 +283,7 @@ class CRM_Contact_Form_Edit_Address {
             'street_name',
             'street_unit',
           ] as $fld) {
-            if (in_array($fld, [
-              'street_name',
-              'street_unit',
-            ])) {
+            if (in_array($fld, ['street_name', 'street_unit'])) {
               $streetAddress .= ' ';
             }
             // CRM-17619 - if the street number suffix begins with a number, add a space

--- a/CRM/Contact/Form/RelatedContact.php
+++ b/CRM/Contact/Form/RelatedContact.php
@@ -137,11 +137,7 @@ class CRM_Contact_Form_RelatedContact extends CRM_Core_Form {
     $params = $this->controller->exportValues($this->_name);
 
     $locType = CRM_Core_BAO_LocationType::getDefault();
-    foreach ([
-      'phone',
-      'email',
-      'address',
-    ] as $locFld) {
+    foreach (['phone', 'email', 'address'] as $locFld) {
       if (!empty($this->_defaults[$locFld]) && $this->_defaults[$locFld][1]['location_type_id']) {
         $params[$locFld][1]['is_primary'] = $this->_defaults[$locFld][1]['is_primary'];
         $params[$locFld][1]['location_type_id'] = $this->_defaults[$locFld][1]['location_type_id'];

--- a/CRM/Contact/Form/Task/Result.php
+++ b/CRM/Contact/Form/Task/Result.php
@@ -30,10 +30,7 @@ class CRM_Contact_Form_Task_Result extends CRM_Contact_Form_Task {
     $this->set('searchRows', '');
 
     $context = $this->get('context');
-    if (in_array($context, [
-      'smog',
-      'amtg',
-    ])) {
+    if (in_array($context, ['smog', 'amtg'])) {
       $urlParams = 'reset=1&force=1&context=smog&gid=';
       $urlParams .= ($context == 'smog') ? $this->get('gid') : $this->get('amtgID');
       $session->replaceUserContext(CRM_Utils_System::url('civicrm/group/search', $urlParams));

--- a/CRM/Contact/Task.php
+++ b/CRM/Contact/Task.php
@@ -301,11 +301,7 @@ class CRM_Contact_Task extends CRM_Core_Task {
         self::LABEL_CONTACTS => self::$_tasks[self::LABEL_CONTACTS]['title'],
       ];
 
-      foreach ([
-        self::MAP_CONTACTS,
-        self::CREATE_MAILING,
-        self::TASK_SMS,
-      ] as $task) {
+      foreach ([self::MAP_CONTACTS, self::CREATE_MAILING, self::TASK_SMS] as $task) {
         if (isset(self::$_tasks[$task]) &&
           !empty(self::$_tasks[$task]['title'])
         ) {

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -427,11 +427,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     elseif (!empty($this->_values['is_for_organization'])) {
       // no on behalf of an organization, CRM-5519
       // so reset loc blocks from main params.
-      foreach ([
-        'phone',
-        'email',
-        'address',
-      ] as $blk) {
+      foreach (['phone', 'email', 'address'] as $blk) {
         if (isset($this->_params[$blk])) {
           unset($this->_params[$blk]);
         }

--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -483,10 +483,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
         $val = $defaultVal;
       }
 
-      if (in_array($field, [
-        'min_amount',
-        'max_amount',
-      ])) {
+      if (in_array($field, ['min_amount', 'max_amount'])) {
         $val = CRM_Utils_Rule::cleanMoney($val);
       }
 

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -259,10 +259,7 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
       $this->_formValues['is_template'] = 0;
     }
 
-    foreach ([
-      'contribution_amount_low',
-      'contribution_amount_high',
-    ] as $f) {
+    foreach (['contribution_amount_low', 'contribution_amount_high'] as $f) {
       if (isset($this->_formValues[$f])) {
         // @todo - stop changing formValues - respect submitted form values, change a working array.
         $this->_formValues[$f] = CRM_Utils_Rule::cleanMoney($this->_formValues[$f]);

--- a/CRM/Contribute/Page/DashBoard.php
+++ b/CRM/Contribute/Page/DashBoard.php
@@ -35,11 +35,7 @@ class CRM_Contribute_Page_DashBoard extends CRM_Core_Page {
 
     //get contribution dates.
     $dates = CRM_Contribute_BAO_Contribution::getContributionDates();
-    foreach ([
-      'now',
-      'yearDate',
-      'monthDate',
-    ] as $date) {
+    foreach (['now', 'yearDate', 'monthDate'] as $date) {
       $$date = $dates[$date];
     }
     // fiscal years end date

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -720,10 +720,7 @@ ORDER BY civicrm_address.is_primary DESC, civicrm_address.location_type_id DESC,
     ];
 
     // overwriting $streetUnitFormats for 'en_CA' and 'fr_CA' locale
-    if (in_array($locale, [
-      'en_CA',
-      'fr_CA',
-    ])) {
+    if (in_array($locale, ['en_CA', 'fr_CA'])) {
       $streetUnitFormats = ['APT', 'APP', 'SUITE', 'BUREAU', 'UNIT'];
     }
     //@todo per CRM-14459 this regex picks up words with the string in them - e.g APT picks up

--- a/CRM/Core/Block.php
+++ b/CRM/Core/Block.php
@@ -218,10 +218,7 @@ class CRM_Core_Block {
     $block = [];
     foreach (self::properties() as $id => $value) {
       if ($value['active']) {
-        if (in_array($id, [
-          self::ADD,
-          self::CREATE_NEW,
-        ])) {
+        if (in_array($id, [self::ADD, self::CREATE_NEW])) {
           $hasAccess = TRUE;
           if (!CRM_Core_Permission::check('add contacts') &&
             !CRM_Core_Permission::check('edit groups')

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -626,10 +626,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $this->postProcessHook();
 
     // Respond with JSON if in AJAX context (also support legacy value '6')
-    if ($allowAjax && !empty($_REQUEST['snippet']) && in_array($_REQUEST['snippet'], [
-      CRM_Core_Smarty::PRINT_JSON,
-      6,
-    ])) {
+    if ($allowAjax && !empty($_REQUEST['snippet']) && in_array($_REQUEST['snippet'], [CRM_Core_Smarty::PRINT_JSON, 6])) {
       $this->ajaxResponse['buttonName'] = str_replace('_qf_' . $this->getAttribute('id') . '_', '', $this->controller->getButtonName());
       $this->ajaxResponse['action'] = $this->_action;
       if (isset($this->_id) || isset($this->id)) {

--- a/CRM/Core/OptionValue.php
+++ b/CRM/Core/OptionValue.php
@@ -306,12 +306,7 @@ class CRM_Core_OptionValue {
       elseif ($mode == '') {
         //the fields email greeting and postal greeting are meant only for Individual and Household
         //the field addressee is meant for all contact types, CRM-4575
-        if (in_array($contactType, [
-          'Individual',
-          'Household',
-          'Organization',
-          'All',
-        ])) {
+        if (in_array($contactType, ['Individual', 'Household', 'Organization', 'All'])) {
           $nameTitle = [
             'addressee' => [
               'name' => 'addressee',

--- a/CRM/Core/Page/AJAX/Location.php
+++ b/CRM/Core/Page/AJAX/Location.php
@@ -210,15 +210,8 @@ class CRM_Core_Page_AJAX_Location {
     );
     // lets output only required fields.
     foreach ($addressOptions as $element => $isSet) {
-      if ($isSet && (!in_array($element, [
-        'im',
-        'openid',
-      ]))) {
-        if (in_array($element, [
-          'country',
-          'state_province',
-          'county',
-        ])) {
+      if ($isSet && (!in_array($element, ['im', 'openid']))) {
+        if (in_array($element, ['country', 'state_province', 'county'])) {
           $element .= '_id';
         }
         elseif ($element == 'address_name') {
@@ -227,29 +220,17 @@ class CRM_Core_Page_AJAX_Location {
         $fld = "address[1][{$element}]";
         $value = $location['address'][1][$element] ?? NULL;
         $value = $value ?: "";
-        $result[str_replace([
-          '][',
-          '[',
-          "]",
-        ], ['_', '_', ''], $fld)] = $value;
+        $result[str_replace(['][', '[', ']'], ['_', '_', ''], $fld)] = $value;
       }
     }
 
-    foreach ([
-      'email',
-      'phone_type_id',
-      'phone',
-    ] as $element) {
+    foreach (['email', 'phone_type_id', 'phone'] as $element) {
       $block = ($element == 'phone_type_id') ? 'phone' : $element;
       for ($i = 1; $i < 3; $i++) {
         $fld = "{$block}[{$i}][{$element}]";
         $value = $location[$block][$i][$element] ?? NULL;
         $value = $value ?: "";
-        $result[str_replace([
-          '][',
-          '[',
-          "]",
-        ], ['_', '_', ''], $fld)] = $value;
+        $result[str_replace(['][', '[', ']'], ['_', '_', ''], $fld)] = $value;
       }
     }
 

--- a/CRM/Core/Smarty/plugins/function.simpleActivityContacts.php
+++ b/CRM/Core/Smarty/plugins/function.simpleActivityContacts.php
@@ -50,10 +50,7 @@ function smarty_function_simpleActivityContacts($params, &$smarty) {
     $baseContactParams['return.' . $field] = 1;
   }
 
-  foreach ([
-    'target',
-    'assignee',
-  ] as $role) {
+  foreach (['target', 'assignee'] as $role) {
     $contact = [];
     if (!empty($activity[$role . '_contact_id'])) {
       $contact_id = array_shift($activity[$role . '_contact_id']);

--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -191,10 +191,7 @@ class CRM_Dedupe_Finder {
     }
 
     // handle {birth,deceased}_date
-    foreach ([
-      'birth_date',
-      'deceased_date',
-    ] as $date) {
+    foreach (['birth_date', 'deceased_date'] as $date) {
       if (!empty($fields[$date])) {
         $flat[$date] = $fields[$date];
         if (is_array($flat[$date])) {

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -211,10 +211,7 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant implements \Ci
     }
     $noteValue = NULL;
     $hasNoteField = FALSE;
-    foreach ([
-      'note',
-      'participant_note',
-    ] as $noteFld) {
+    foreach (['note', 'participant_note'] as $noteFld) {
       if (array_key_exists($noteFld, $params)) {
         $noteValue = $params[$noteFld];
         $hasNoteField = TRUE;

--- a/CRM/Event/BAO/Query.php
+++ b/CRM/Event/BAO/Query.php
@@ -434,11 +434,7 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
       case 'event_type_id':
       case 'event_title':
         $qillName = $name;
-        if (in_array($name, [
-          'event_id',
-          'event_title',
-          'event_is_public',
-        ])) {
+        if (in_array($name, ['event_id', 'event_title', 'event_is_public'])) {
           $name = str_replace('event_', '', $name);
         }
         $dataType = !empty($fields[$qillName]['type']) ? CRM_Utils_Type::typeToString($fields[$qillName]['type']) : 'String';

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -216,10 +216,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
         $taxAmount += $v['tax_amount'];
         if (is_array($v)) {
           $this->cleanMoneyFields($v);
-          foreach ([
-            'first_name',
-            'last_name',
-          ] as $name) {
+          foreach (['first_name', 'last_name'] as $name) {
             if (isset($v['billing_' . $name]) &&
               !isset($v[$name])
             ) {

--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -331,11 +331,7 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
     }
 
     //set values for ipn code.
-    foreach ([
-      'fee_amount',
-      'check_number',
-      'payment_instrument_id',
-    ] as $field) {
+    foreach (['fee_amount', 'check_number', 'payment_instrument_id'] as $field) {
       if (!$input[$field] = CRM_Utils_Array::value($field, $params)) {
         $input[$field] = $contribution->$field;
       }

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -1126,11 +1126,7 @@ class CRM_Export_BAO_ExportProcessor {
 
         return CRM_Core_BAO_CustomField::displayValue($fieldValue, $cfID);
       }
-      elseif (in_array($field, [
-        'email_greeting',
-        'postal_greeting',
-        'addressee',
-      ])) {
+      elseif (in_array($field, ['email_greeting', 'postal_greeting', 'addressee'])) {
         //special case for greeting replacement
         $fldValue = "{$field}_display";
         return $iterationDAO->$fldValue;
@@ -2138,11 +2134,9 @@ WHERE  id IN ( $deleteIDString )
           $fieldValue = $imProviders[$relationValue] ?? NULL;
         }
         // CRM-13995
-        elseif (is_object($relDAO) && in_array($relationField, [
-          'email_greeting',
-          'postal_greeting',
-          'addressee',
-        ])) {
+        elseif (is_object($relDAO) &&
+          in_array($relationField, ['email_greeting', 'postal_greeting', 'addressee'])
+        ) {
           //special case for greeting replacement
           $fldValue = "{$relationField}_display";
           $fieldValue = $relDAO->$fldValue;

--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -482,12 +482,7 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
    */
   public static function getProcessorForEntity($entityID, $component = 'contribute', $type = 'id') {
     $result = NULL;
-    if (!in_array($component, [
-      'membership',
-      'contribute',
-      'recur',
-    ])
-    ) {
+    if (!in_array($component, ['membership', 'contribute', 'recur'])) {
       return $result;
     }
 

--- a/CRM/Financial/Form/FinancialAccount.php
+++ b/CRM/Financial/Form/FinancialAccount.php
@@ -200,12 +200,7 @@ class CRM_Financial_Form_FinancialAccount extends CRM_Contribute_Form {
       if ($this->_action & CRM_Core_Action::UPDATE) {
         $params['id'] = $this->_id;
       }
-      foreach ([
-        'is_active',
-        'is_deductible',
-        'is_tax',
-        'is_default',
-      ] as $field) {
+      foreach (['is_active', 'is_deductible', 'is_tax', 'is_default'] as $field) {
         $params[$field] = $params[$field] ?? FALSE;
       }
       $financialAccount = CRM_Financial_BAO_FinancialAccount::writeRecord($params);

--- a/CRM/Financial/Form/FinancialType.php
+++ b/CRM/Financial/Form/FinancialType.php
@@ -117,11 +117,7 @@ class CRM_Financial_Form_FinancialType extends CRM_Core_Form {
       if ($this->_id) {
         $params['id'] = $this->_id;
       }
-      foreach ([
-        'is_active',
-        'is_reserved',
-        'is_deductible',
-      ] as $field) {
+      foreach (['is_active', 'is_reserved', 'is_deductible'] as $field) {
         $params[$field] = $params[$field] ?? FALSE;
       }
       $financialType = civicrm_api3('FinancialType', 'create', $params);

--- a/CRM/Friend/Form.php
+++ b/CRM/Friend/Form.php
@@ -56,10 +56,7 @@ class CRM_Friend_Form extends CRM_Core_Form {
 
     $pcomponent = CRM_Utils_Request::retrieve('pcomponent', 'String', $this, TRUE);
 
-    if (in_array($pcomponent, [
-      'contribute',
-      'event',
-    ])) {
+    if (in_array($pcomponent, ['contribute', 'event'])) {
       $values = [];
       $params = ['id' => $this->_entityId];
       CRM_Core_DAO::commonRetrieve('CRM_Contribute_DAO_ContributionPage',

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -616,11 +616,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing implements \Civi\C
 
       $this->preparedTemplates = [];
 
-      foreach ([
-        'html',
-        'text',
-        'subject',
-      ] as $key) {
+      foreach (['html', 'text', 'subject'] as $key) {
         if (!isset($templates[$key])) {
           continue;
         }

--- a/CRM/Mailing/Form/Component.php
+++ b/CRM/Mailing/Form/Component.php
@@ -146,10 +146,7 @@ class CRM_Mailing_Form_Component extends CRM_Core_Form {
       $InvalidTokens = ['action.forward' => ts("This token can only be used in send mailing context (body, header, footer)..")];
     }
     $errors = [];
-    foreach ([
-      'text',
-      'html',
-    ] as $type) {
+    foreach (['text', 'html'] as $type) {
       $dataErrors = [];
       foreach ($InvalidTokens as $token => $desc) {
         if ($params['body_' . $type]) {

--- a/CRM/Mailing/MailStore.php
+++ b/CRM/Mailing/MailStore.php
@@ -191,11 +191,7 @@ class CRM_Mailing_MailStore {
   public function maildir($name) {
     $config = CRM_Core_Config::singleton();
     $dir = $config->customFileUploadDir . DIRECTORY_SEPARATOR . $name;
-    foreach ([
-      'cur',
-      'new',
-      'tmp',
-    ] as $sub) {
+    foreach (['cur', 'new', 'tmp'] as $sub) {
       if (!file_exists($dir . DIRECTORY_SEPARATOR . $sub)) {
         if ($this->_debug) {
           print "creating $dir/$sub\n";

--- a/CRM/Mailing/MailStore/Maildir.php
+++ b/CRM/Mailing/MailStore/Maildir.php
@@ -82,10 +82,7 @@ class CRM_Mailing_MailStore_Maildir extends CRM_Mailing_MailStore {
     // set property text attachment as file CRM-5408
     $parser->options->parseTextAttachmentsAsFiles = TRUE;
 
-    foreach ([
-      'cur',
-      'new',
-    ] as $subdir) {
+    foreach (['cur', 'new'] as $subdir) {
       $dir = $this->_dir . DIRECTORY_SEPARATOR . $subdir;
       foreach (scandir($dir) as $file) {
         if ($file == '.' or $file == '..') {

--- a/CRM/Mailing/Selector/Browse.php
+++ b/CRM/Mailing/Selector/Browse.php
@@ -378,14 +378,8 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
             $actionMask = CRM_Core_Action::PREVIEW;
           }
         }
-        if (in_array($row['status'], [
-          'Scheduled',
-          'Running',
-          'Paused',
-        ])) {
-          if ($allAccess ||
-            ($showApprovalLinks && $showCreateLinks && $showScheduleLinks)
-          ) {
+        if (in_array($row['status'], ['Scheduled', 'Running', 'Paused'])) {
+          if ($allAccess || ($showApprovalLinks && $showCreateLinks && $showScheduleLinks)) {
 
             $actionMask |= CRM_Core_Action::DISABLE;
             if ($row['status'] === "Paused") {

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -298,11 +298,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType implem
     $membershipTypeDetails = self::getMembershipTypeDetails($membershipTypeId);
 
     // Convert all dates to 'Y-m-d' format.
-    foreach ([
-      'joinDate',
-      'startDate',
-      'endDate',
-    ] as $dateParam) {
+    foreach (['joinDate', 'startDate', 'endDate'] as $dateParam) {
       if (!empty($$dateParam)) {
         $$dateParam = CRM_Utils_Date::processDate($$dateParam, NULL, FALSE, 'Y-m-d');
       }

--- a/CRM/Member/Page/UserDashboard.php
+++ b/CRM/Member/Page/UserDashboard.php
@@ -38,10 +38,7 @@ class CRM_Member_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBoard 
 
       //get the membership status and type values.
       $statusANDType = CRM_Member_BAO_Membership::getStatusANDTypeValues($dao->id);
-      foreach ([
-        'status',
-        'membership_type',
-      ] as $fld) {
+      foreach (['status', 'membership_type'] as $fld) {
         $membership[$dao->id][$fld] = $statusANDType[$dao->id][$fld] ?? NULL;
       }
       if (!empty($statusANDType[$dao->id]['is_current_member'])) {

--- a/CRM/PCP/Form/Event.php
+++ b/CRM/PCP/Form/Event.php
@@ -100,10 +100,7 @@ class CRM_PCP_Form_Event extends CRM_Event_Form_ManageEvent {
     $pcpBlock->find(TRUE);
 
     if (!empty($pcpBlock->id) && CRM_PCP_BAO_PCP::getPcpBlockInUse($pcpBlock->id)) {
-      foreach ([
-        'target_entity_type',
-        'target_entity_id',
-      ] as $element_name) {
+      foreach (['target_entity_type', 'target_entity_id'] as $element_name) {
         $element = $this->getElement($element_name);
         $element->freeze();
       }

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -473,11 +473,8 @@ class CRM_Profile_Form extends CRM_Core_Form {
           }
 
         }
-        elseif (!empty($this->_multiRecordFields)
-          && (!$this->_multiRecord || !in_array($this->_multiRecord, [
-            CRM_Core_Action::DELETE,
-            CRM_Core_Action::UPDATE,
-          ]))
+        elseif (!empty($this->_multiRecordFields) &&
+          (!$this->_multiRecord || !in_array($this->_multiRecord, [CRM_Core_Action::DELETE, CRM_Core_Action::UPDATE]))
         ) {
           CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'js/crm.livePage.js', 1, 'html-header');
           //multi-record listing page

--- a/CRM/Profile/Form/Search.php
+++ b/CRM/Profile/Form/Search.php
@@ -63,10 +63,7 @@ class CRM_Profile_Form_Search extends CRM_Profile_Form {
           $value[$item] = 1;
         }
       }
-      elseif (in_array($key, [
-        'birth_date',
-        'deceased_date',
-      ])) {
+      elseif (in_array($key, ['birth_date', 'deceased_date'])) {
         list($value) = CRM_Utils_Date::setDateDefaults($value);
       }
 

--- a/CRM/Profile/Selector/Listings.php
+++ b/CRM/Profile/Selector/Listings.php
@@ -310,11 +310,7 @@ class CRM_Profile_Selector_Listings extends CRM_Core_Selector_Base implements CR
                 $locationTypeName = $locationTypes[$lType];
               }
 
-              if (in_array($fieldName, [
-                'phone',
-                'im',
-                'email',
-              ])) {
+              if (in_array($fieldName, ['phone', 'im', 'email'])) {
                 if ($type) {
                   $name = "`$locationTypeName-$fieldName-$type`";
                 }
@@ -523,11 +519,7 @@ class CRM_Profile_Selector_Listings extends CRM_Core_Selector_Base implements CR
               continue;
             }
             $locationTypeName = str_replace(' ', '_', $locationTypeName);
-            if (in_array($fieldName, [
-              'phone',
-              'im',
-              'email',
-            ])) {
+            if (in_array($fieldName, ['phone', 'im', 'email'])) {
               if ($type) {
                 $names[] = "{$locationTypeName}-{$fieldName}-{$type}";
               }
@@ -643,10 +635,7 @@ class CRM_Profile_Selector_Listings extends CRM_Core_Selector_Base implements CR
           $dname = $name . '_display';
           $row[] = $result->$dname;
         }
-        elseif (in_array($name, [
-          'birth_date',
-          'deceased_date',
-        ])) {
+        elseif (in_array($name, ['birth_date', 'deceased_date'])) {
           $row[] = CRM_Utils_Date::customFormat($result->$name);
         }
         elseif (isset($result->$name)) {

--- a/CRM/Queue/ErrorPolicy.php
+++ b/CRM/Queue/ErrorPolicy.php
@@ -60,11 +60,7 @@ class CRM_Queue_ErrorPolicy {
   protected function activate() {
     $this->active = TRUE;
     $this->backup = [];
-    foreach ([
-      'display_errors',
-      'html_errors',
-      'xmlrpc_errors',
-    ] as $key) {
+    foreach (['display_errors', 'html_errors', 'xmlrpc_errors'] as $key) {
       $this->backup[$key] = ini_get($key);
       ini_set($key, 0);
     }
@@ -76,11 +72,7 @@ class CRM_Queue_ErrorPolicy {
    */
   protected function deactivate() {
     restore_error_handler();
-    foreach ([
-      'display_errors',
-      'html_errors',
-      'xmlrpc_errors',
-    ] as $key) {
+    foreach (['display_errors', 'html_errors', 'xmlrpc_errors'] as $key) {
       ini_set($key, $this->backup[$key]);
     }
     $this->active = FALSE;

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4272,14 +4272,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
   protected function isFieldFiltered($prop) {
     if (!empty($prop['filters']) && $this->_customGroupFilters) {
       foreach ($prop['filters'] as $fieldAlias => $val) {
-        foreach ([
-          'value',
-          'min',
-          'max',
-          'relative',
-          'from',
-          'to',
-        ] as $attach) {
+        foreach (['value', 'min', 'max', 'relative', 'from', 'to'] as $attach) {
           if (isset($this->_params[$fieldAlias . '_' . $attach]) &&
             (!empty($this->_params[$fieldAlias . '_' . $attach])
               || ($attach != 'relative' &&

--- a/CRM/Report/Form/Campaign/SurveyDetails.php
+++ b/CRM/Report/Form/Campaign/SurveyDetails.php
@@ -628,10 +628,7 @@ INNER JOIN  civicrm_custom_group cg ON ( cg.id = cf.custom_group_id )
       if ($responseField->option_group_id) {
         //show value for print and pdf.
         $value = $responseField->label;
-        if (in_array($this->_outputMode, [
-          'print',
-          'pdf',
-        ])) {
+        if (in_array($this->_outputMode, ['print', 'pdf'])) {
           $value = $responseField->value;
         }
         $fieldValueMap[$responseField->option_group_id][$responseField->value] = $value;

--- a/CRM/Report/Form/Contribute/Summary.php
+++ b/CRM/Report/Form/Contribute/Summary.php
@@ -481,11 +481,7 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
     $errors = $self->customDataFormRule($fields, $ignoreFields);
 
     if (empty($fields['fields']['total_amount'])) {
-      foreach ([
-        'total_count_value',
-        'total_sum_value',
-        'total_avg_value',
-      ] as $val) {
+      foreach (['total_count_value', 'total_sum_value', 'total_avg_value'] as $val) {
         if (!empty($fields[$val])) {
           $errors[$val] = ts("Please select the Amount Statistics");
         }

--- a/CRM/Report/Form/Contribute/TopDonor.php
+++ b/CRM/Report/Form/Contribute/TopDonor.php
@@ -226,11 +226,7 @@ class CRM_Report_Form_Contribute_TopDonor extends CRM_Report_Form {
     $op = $fields['total_range_op'] ?? NULL;
     $val = $fields['total_range_value'] ?? NULL;
 
-    if (!in_array($op, [
-      'eq',
-      'lte',
-    ])
-    ) {
+    if (!in_array($op, ['eq', 'lte'])) {
       $errors['total_range_op'] = ts("Please select 'Is equal to' OR 'Is Less than or equal to' operator");
     }
 

--- a/CRM/Report/Form/Mailing/Detail.php
+++ b/CRM/Report/Form/Mailing/Detail.php
@@ -271,12 +271,7 @@ class CRM_Report_Form_Mailing_Detail extends CRM_Report_Form {
           if (!empty($field['required']) ||
             !empty($this->_params['fields'][$fieldName])
           ) {
-            if (in_array($fieldName, [
-              'unsubscribe_id',
-              'optout_id',
-              'forward_id',
-              'reply_id',
-            ])) {
+            if (in_array($fieldName, ['unsubscribe_id', 'optout_id', 'forward_id', 'reply_id'])) {
               $select[] = "IF({$field['dbAlias']} IS NULL, 'No', 'Yes') as {$tableName}_{$fieldName}";
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = $field['no_display'] ?? NULL;

--- a/CRM/Report/Form/Membership/Summary.php
+++ b/CRM/Report/Form/Membership/Summary.php
@@ -319,11 +319,7 @@ LEFT  JOIN civicrm_contribution  {$this->_aliases['civicrm_contribution']}
     $this->assign('statistics', $this->statistics($rows));
 
     if (!empty($this->_params['charts'])) {
-      foreach ([
-        'receive_date',
-        $this->_interval,
-        'value',
-      ] as $ignore) {
+      foreach (['receive_date', $this->_interval, 'value'] as $ignore) {
         unset($graphRows[$ignore][$count - 1]);
       }
 

--- a/CRM/Report/Form/Pledge/Pbnp.php
+++ b/CRM/Report/Form/Pledge/Pbnp.php
@@ -198,11 +198,7 @@ class CRM_Report_Form_Pledge_Pbnp extends CRM_Report_Form {
 
     $allStatus = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
     $pendingStatus = array_search('Pending', $allStatus);
-    foreach ([
-      'Pending',
-      'In Progress',
-      'Overdue',
-    ] as $statusKey) {
+    foreach (['Pending', 'In Progress', 'Overdue'] as $statusKey) {
       if ($key = CRM_Utils_Array::key($statusKey, $allStatus)) {
         $unpaidStatus[] = $key;
       }

--- a/CRM/Report/Utils/Get.php
+++ b/CRM/Report/Utils/Get.php
@@ -190,10 +190,7 @@ class CRM_Report_Utils_Get {
    */
   public static function processChart(&$defaults) {
     $chartType = $_GET["charts"] ?? NULL;
-    if (in_array($chartType, [
-      'barChart',
-      'pieChart',
-    ])) {
+    if (in_array($chartType, ['barChart', 'pieChart'])) {
       $defaults["charts"] = $chartType;
     }
   }

--- a/CRM/SMS/Form/Group.php
+++ b/CRM/SMS/Form/Group.php
@@ -170,12 +170,7 @@ class CRM_SMS_Form_Group extends CRM_Contact_Form_Task {
 
     $groups = [];
 
-    foreach ([
-      'name',
-      'group_id',
-      'is_sms',
-      'sms_provider_id',
-    ] as $n) {
+    foreach (['name', 'group_id', 'is_sms', 'sms_provider_id'] as $n) {
       if (!empty($values[$n])) {
         $params[$n] = $values[$n];
         if ($n == 'sms_provider_id') {
@@ -237,10 +232,7 @@ class CRM_SMS_Form_Group extends CRM_Contact_Form_Task {
       $mailingTableName = CRM_Mailing_BAO_Mailing::getTableName();
 
       // delete previous includes/excludes, if mailing already existed
-      foreach ([
-        'groups',
-        'mailings',
-      ] as $entity) {
+      foreach (['groups', 'mailings'] as $entity) {
         $mg = new CRM_Mailing_DAO_MailingGroup();
         $mg->mailing_id = $ids['mailing_id'];
         $mg->entity_table = ($entity == 'groups') ? $groupTableName : $mailingTableName;

--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -578,12 +578,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
    *   List of errors to be posted back to the form.
    */
   public static function formRuleSubType($fieldType, $groupType, &$errors) {
-    if (in_array($fieldType, [
-      'Participant',
-      'Contribution',
-      'Membership',
-      'Activity',
-    ])) {
+    if (in_array($fieldType, ['Participant', 'Contribution', 'Membership', 'Activity'])) {
       $individualSubTypes = CRM_Contact_BAO_ContactType::subTypes('Individual');
       foreach ($groupType as $value) {
         if (!in_array($value, $individualSubTypes) &&
@@ -744,12 +739,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
       $errors['field_name'] = ts('Please select a field name');
     }
 
-    if ($in_selector && in_array($entityName, [
-      'Contribution',
-      'Participant',
-      'Membership',
-      'Activity',
-    ])
+    if ($in_selector && in_array($entityName, ['Contribution', 'Participant', 'Membership', 'Activity'])
     ) {
       $errors['in_selector'] = ts("'Results Column' cannot be checked for %1 fields.", [1 => $entityName]);
     }
@@ -979,10 +969,8 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
   protected function setMessageIfCountryNotAboveState($fieldName, $locationTypeID, $weight, $ufGroupID) {
     $message = ts('For best results, the Country field should precede the State-Province field in your Profile form. You can use the up and down arrows on field listing page for this profile to change the order of these fields or manually edit weight for Country/State-Province Field.');
 
-    if (in_array($fieldName, [
-      'country',
-      'state_province',
-    ]) && count(CRM_Core_Config::singleton()->countryLimit) > 1
+    if (in_array($fieldName, ['country', 'state_province']) &&
+      count(CRM_Core_Config::singleton()->countryLimit) > 1
     ) {
       // get state or country field weight if exists
       $ufFieldDAO = new CRM_Core_DAO_UFField();

--- a/CRM/Utils/Chart.php
+++ b/CRM/Utils/Chart.php
@@ -196,11 +196,7 @@ class CRM_Utils_Chart {
     $chartData['yname'] = $rows['yname'] ?? NULL;
 
     // carry some chart params if pass.
-    foreach ([
-      'xSize',
-      'ySize',
-      'divName',
-    ] as $f) {
+    foreach (['xSize', 'ySize', 'divName'] as $f) {
       if (!empty($rows[$f])) {
         $chartData[$f] = $rows[$f];
       }
@@ -236,11 +232,7 @@ class CRM_Utils_Chart {
     }
 
     // carry some chart params if pass.
-    foreach ([
-      'xSize',
-      'ySize',
-      'divName',
-    ] as $f) {
+    foreach (['xSize', 'ySize', 'divName'] as $f) {
       if (!empty($rows[$f])) {
         $chartData[$f] = $rows[$f];
       }

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1135,11 +1135,7 @@ class CRM_Utils_Token {
         }
 
         // special case for greeting replacement
-        foreach ([
-          'email_greeting',
-          'postal_greeting',
-          'addressee',
-        ] as $val) {
+        foreach (['email_greeting', 'postal_greeting', 'addressee'] as $val) {
           if (!empty($contactDetails[$contactID][$val])) {
             $contactDetails[$contactID][$val] = $contactDetails[$contactID]["{$val}_display"];
           }
@@ -1258,11 +1254,7 @@ class CRM_Utils_Token {
   public static function flattenTokens(&$tokens) {
     $flattenTokens = [];
 
-    foreach ([
-      'html',
-      'text',
-      'subject',
-    ] as $prop) {
+    foreach (['html', 'text', 'subject'] as $prop) {
       if (!isset($tokens[$prop])) {
         continue;
       }

--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -265,11 +265,7 @@ function civicrm_api3_activity_get($params) {
 function _civicrm_activity_get_handleSourceContactNameOrderBy(&$params, &$options, $sql) {
   $sourceContactID = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_ActivityContact', 'record_type_id', 'Activity Source');
   if (!empty($options['sort'])
-    && in_array($options['sort'], [
-      'source_contact_name',
-      'source_contact_name desc',
-      'source_contact_name asc',
-    ])) {
+    && in_array($options['sort'], ['source_contact_name', 'source_contact_name desc', 'source_contact_name asc'])) {
     $order = substr($options['sort'], -4) === 'desc' ? 'desc' : 'asc';
     $sql->join(
       'source_contact',

--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/Listener/SimpleFilterTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/Listener/SimpleFilterTest.php
@@ -49,10 +49,7 @@ class SimpleFilterTest extends \CiviUnitTestCase {
     SimpleFilter::byValue($e, 'text', function ($value, $t, $e) use ($test) {
       $test->assertInstanceOf('Civi\FlexMailer\FlexMailerTask', $t);
       $test->assertInstanceOf('Civi\FlexMailer\Event\ComposeBatchEvent', $e);
-      $test->assertTrue(in_array($value, [
-        'eat more cheese',
-        'eat more ice cream',
-      ]));
+      $test->assertTrue(in_array($value, ['eat more cheese', 'eat more ice cream']));
       return preg_replace('/more/', 'thoughtfully considered quantities of', $value);
     });
 

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/PriceSet.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/PriceSet.php
@@ -63,11 +63,7 @@ class CRM_Contact_Form_Search_Custom_PriceSet extends CRM_Contact_Form_Search_Cu
 ';
 
     foreach ($this->_columns as $fieldName) {
-      if (in_array($fieldName, [
-        'contact_id',
-        'participant_id',
-        'display_name',
-      ])) {
+      if (in_array($fieldName, ['contact_id', 'participant_id', 'display_name'])) {
         continue;
       }
       $sql .= "{$fieldName} int default 0,\n";
@@ -259,10 +255,7 @@ contact_a.id             as contact_id  ,
 contact_a.display_name   as display_name";
 
       foreach ($this->_columns as $dontCare => $fieldName) {
-        if (in_array($fieldName, [
-          'contact_id',
-          'display_name',
-        ])) {
+        if (in_array($fieldName, ['contact_id', 'display_name'])) {
           continue;
         }
         $selectClause .= ",\ntempTable.{$fieldName} as {$fieldName}";

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -1380,10 +1380,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
               $entity[$fieldName] = strtolower($entity[$fieldName]);
             }
             // typecast with array to satisfy changes made in CRM-13160
-            if ($entityName == 'MembershipType' && in_array($fieldName, [
-              'relationship_type_id',
-              'relationship_direction',
-            ])) {
+            if ($entityName == 'MembershipType' && in_array($fieldName, ['relationship_type_id', 'relationship_direction'])) {
               $entity[$fieldName] = (array) $entity[$fieldName];
             }
           }


### PR DESCRIPTION
Overview
----------------------------------------
Whitespace-only cleanup of arrays that were formatted by a robot, to give them a more human touch.

Comments
----------------------------------------
Multiline arrays are a good rule-of-thumb, but not always.
These were all done by an autoformatting tool which got a little too zealous about breaking every array into multiple lines. They are especially silly when the array is declared inline within `if()` or `foreach()` statements.