### PR TITLE
Go without supper 🥪🚫

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2163,7 +2163,7 @@ AND cl.modified_id  = c.id
     }
 
     // Check for target and assignee contacts.
-    // First check for supper permission.
+    // First check for super permission.
     $supPermission = 'view all contacts';
     if ($action == CRM_Core_Action::UPDATE) {
       $supPermission = 'edit all contacts';

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -2502,7 +2502,7 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
     $actionOperations = ['view', 'edit', 'delete'];
     if (in_array($operation, $actionOperations)) {
 
-      //do cache when user has non/supper permission.
+      // Do cache when user has non-super permission.
       static $allowOperations;
 
       if (!is_array($allowOperations) ||
@@ -2546,7 +2546,7 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
             'edit',
           ])
           ) {
-            //do we have supper permission.
+            // Check for super permission.
             if (in_array('access all cases and activities', $hasPermissions[$operation])) {
               $allowOperations[$operation] = $allow = TRUE;
             }
@@ -2608,8 +2608,7 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
         }
       }
       else {
-        //use cache.
-        //here contact might have supper/non permission.
+        // Use cache; user might have non-super permission.
         $allow = $allowOperations[$operation];
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
User should not have supper permissions. That sort of thing just isn't allowed in CiviCRM.

Before
----------------------------------------
Meal-based permissions may be present.

After
----------------------------------------
No supper. Also checked the codebase and verified we are not granting permissions for breakfast, lunch, dinner, dessert, afternoon tea, or second breakfast.
