### PR TITLE
[REF][PHP8.2] Remove unused property from CRM_Contact_Selector

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -198,8 +198,6 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
       );
       self::$_columnHeaders = NULL;
 
-      $this->_customFields = CRM_Core_BAO_CustomField::getFieldsForImport('Individual');
-
       $this->_returnProperties = CRM_Contact_BAO_Contact::makeHierReturnProperties($this->_fields);
       $this->_returnProperties['contact_type'] = 1;
       $this->_returnProperties['contact_sub_type'] = 1;


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused property from `CRM_Contact_Selector`

Before
----------------------------------------
`$this->_customFields` is set, but never read. Use of dynamic properties causes deprecation warnings and test failures on PHP 8.2.

3 other classes also set `_customFields`, but any usage is self-contained to the class that set the property.

After
----------------------------------------
Gone

Comments
----------------------------------------
There are very few "easy" PHP 8.2 fixes that impact tests after this.