### PR TITLE
Remove unused _tempClause

### DIFF
--- a/CRM/Report/Form/Contribute/TopDonor.php
+++ b/CRM/Report/Form/Contribute/TopDonor.php
@@ -257,7 +257,7 @@ class CRM_Report_Form_Contribute_TopDonor extends CRM_Report_Form {
 
   public function where() {
     $clauses = [];
-    $this->_tempClause = $this->_outerCluase = $this->_groupLimit = '';
+    $this->_outerCluase = $this->_groupLimit = '';
     foreach ($this->_columns as $tableName => $table) {
       if (array_key_exists('filters', $table)) {
         foreach ($table['filters'] as $fieldName => $field) {


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused  property`$_tempClause` on `CRM_Report_Form_Contribute_TopDonor`.

Before
----------------------------------------
It's set dynamically, but without a value, and causing a PHP 8.2 test fail.

We can see the property is never read, only set:

<img width="434" alt="Screenshot 2023-11-28 at 19 37 43" src="https://github.com/civicrm/civicrm-core/assets/1931323/1e7524d2-2746-4747-9451-63a6080ef582">


After
----------------------------------------
Property removed.