### PR TITLE
PHP 8.x add getFromEmails() function, remove use of undeclared property

### DIFF
--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -169,9 +169,9 @@ trait CRM_Contact_Form_Task_PDFTrait {
   public function preProcessPDF(): void {
     $form = $this;
     $defaults = [];
-    $form->_fromEmails = CRM_Core_BAO_Email::getFromEmail();
-    if (is_numeric(key($form->_fromEmails))) {
-      $emailID = (int) key($form->_fromEmails);
+    $fromEmails = $this->getFromEmails();
+    if (is_numeric(key($fromEmails))) {
+      $emailID = (int) key($fromEmails);
       $defaults = CRM_Core_BAO_Email::getEmailSignatureDefaults($emailID);
     }
     if (!Civi::settings()->get('allow_mail_from_logged_in_contact')) {
@@ -179,6 +179,15 @@ trait CRM_Contact_Form_Task_PDFTrait {
     }
     $form->setDefaults($defaults);
     $form->setTitle(ts('Print/Merge Document'));
+  }
+
+  /**
+   * Get an array of email IDS from which the back-office user may select the from field.
+   *
+   * @return array
+   */
+  protected function getFromEmails(): array {
+    return CRM_Core_BAO_Email::getFromEmail();
   }
 
   /**

--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -95,7 +95,7 @@ AND    {$this->_componentClause}";
     $this->add('checkbox', 'receipt_update', ts('Update receipt dates for these contributions'), FALSE);
     $this->add('checkbox', 'override_privacy', ts('Override privacy setting? (Do not email / Do not mail)'), FALSE);
 
-    $this->add('select', 'from_email_address', ts('From Email'), $this->_fromEmails, FALSE);
+    $this->add('select', 'from_email_address', ts('From Email'), $this->getFromEmails(), FALSE);
 
     $this->addButtons([
       [
@@ -108,6 +108,15 @@ AND    {$this->_componentClause}";
         'name' => ts('Cancel'),
       ],
     ]);
+  }
+
+  /**
+   * Get an array of email IDS from which the back-office user may select the from field.
+   *
+   * @return array
+   */
+  public function getFromEmails(): array {
+    return CRM_Core_BAO_Email::getFromEmail();
   }
 
   /**

--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -80,7 +80,7 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
     $this->assign('suppressForm', FALSE);
 
     // Contribute PDF tasks allow you to email as well, so we need to add email address to those forms
-    $this->add('select', 'from_email_address', ts('From Email Address'), $this->_fromEmails, TRUE);
+    $this->add('select', 'from_email_address', ts('From Email Address'), $this->getFromEmails(), TRUE);
     $this->addPDFElementsToForm();
 
     // specific need for contributions


### PR DESCRIPTION
Overview
----------------------------------------
PHP 8.x add getFromEmails() function, remove use of undeclared property

Before
----------------------------------------
The only other references to  `_fromEmails` in pdf related tasks are in the deprecated functions 
https://github.com/civicrm/civicrm-core/pull/28346

![image](https://github.com/civicrm/civicrm-core/assets/336308/c37eb843-65b9-4f76-9df7-bf0842c01fd9)


After
----------------------------------------
function added

Technical Details
----------------------------------------

Comments
----------------------------------------
