### PR TITLE
Coworker create Searchkit over view of queue status

### DIFF
--- a/Civi/Api4/Queue.php
+++ b/Civi/Api4/Queue.php
@@ -20,7 +20,7 @@ use Civi\Api4\Action\Queue\Run;
  * Registering a queue in this table (and setting `is_auto=1`) can
  * allow it to execute tasks automatically in the background.
  *
- * @searchable none
+ * @searchable secondary
  * @since 5.47
  * @package Civi\Api4
  */

--- a/ext/civicrm_admin_ui/ang/afsearchCiviCRMQueues.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchCiviCRMQueues.aff.html
@@ -1,0 +1,5 @@
+<div af-fieldset="">
+  <af-field name="name" defn="{required: false, input_attrs: {}}" />
+  <af-field name="status" defn="{input_type: 'Select', input_attrs: {multiple: true}}" />
+  <crm-search-display-table search-name="Queues" display-name="Queues_Table_1"></crm-search-display-table>
+</div>

--- a/ext/civicrm_admin_ui/ang/afsearchCiviCRMQueues.aff.php
+++ b/ext/civicrm_admin_ui/ang/afsearchCiviCRMQueues.aff.php
@@ -5,7 +5,7 @@ return [
   'type' => 'search',
   'title' => E::ts('CiviCRM Queues'),
   'icon' => 'fa-list-alt',
-  'server_route' => 'civicrm/queues',
+  'server_route' => 'civicrm/admin/queue',
   'permission' => ['administer queues'],
   'placement' => [],
   'permission_operator' => "AND",

--- a/ext/civicrm_admin_ui/ang/afsearchCiviCRMQueues.aff.php
+++ b/ext/civicrm_admin_ui/ang/afsearchCiviCRMQueues.aff.php
@@ -1,0 +1,12 @@
+<?php
+use CRM_CivicrmAdminUi_ExtensionUtil as E;
+
+return [
+  'type' => 'search',
+  'title' => E::ts('CiviCRM Queues'),
+  'icon' => 'fa-list-alt',
+  'server_route' => 'civicrm/queues',
+  'permission' => ['administer queues'],
+  'placement' => [],
+  'permission_operator' => "AND",
+];

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Queues.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Queues.mgd.php
@@ -1,0 +1,100 @@
+<?php
+
+use CRM_CivicrmAdminUi_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'SavedSearch_Queues',
+    'entity' => 'SavedSearch',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Queues',
+        'label' => E::ts('Queues'),
+        'api_entity' => 'Queue',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'id',
+            'name',
+            'type:label',
+            'status:label',
+          ],
+          'orderBy' => [],
+          'where' => [],
+          'groupBy' => [],
+          'join' => [],
+          'having' => [],
+        ],
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'SavedSearch_Queues_SearchDisplay_Queues_Table_1',
+    'entity' => 'SearchDisplay',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Queues_Table_1',
+        'label' => E::ts('Queues'),
+        'saved_search_id.name' => 'Queues',
+        'type' => 'table',
+        'settings' => [
+          'description' => NULL,
+          'sort' => [],
+          'limit' => 50,
+          'pager' => [],
+          'placeholder' => 5,
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'id',
+              'dataType' => 'Integer',
+              'label' => E::ts('System Queue ID'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'name',
+              'dataType' => 'String',
+              'label' => E::ts('Name'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'type:label',
+              'dataType' => 'String',
+              'label' => E::ts('Type'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'status:label',
+              'dataType' => 'String',
+              'label' => E::ts('Status'),
+              'sortable' => TRUE,
+              'rewrite' => '',
+              'editable' => TRUE,
+            ],
+          ],
+          'actions' => FALSE,
+          'classes' => [
+            'table',
+            'table-striped',
+          ],
+        ],
+      ],
+      'match' => [
+        'saved_search_id',
+        'name',
+      ],
+    ],
+  ],
+];


### PR DESCRIPTION
Overview
----------------------------------------
This PR adds a Formbuilder page and SearchKit form that helps administrators with Queue privileges to view the status of Civi Queues.

Issue: https://lab.civicrm.org/dev/core/-/issues/4815

Before
----------------------------------------
The queue status can only be viewed using a SQL query

After
----------------------------------------
The status for all the queues can be viewed conveniently on the browser in `https://{CIVI_DOMAIN}/civicrm/queues`

Technical Details
----------------------------------------
The SearchKit and Formbuilder Afforms were added to the CiviCRM admin UI extension, hence this requires the installation of the extension to work.

<img width="819" alt="Screenshot 2023-11-28 at 21 32 50" src="https://github.com/civicrm/civicrm-core/assets/29501113/1143ac4c-432a-4598-b1e6-700694489031">


Comments
----------------------------------------
_Anything else you would like the reviewer to note_
