### PR TITLE
Consolidate fee preProcess into feeBuildForm

### DIFF
--- a/CRM/Event/Form/EventFees.php
+++ b/CRM/Event/Form/EventFees.php
@@ -24,11 +24,14 @@ class CRM_Event_Form_EventFees {
   /**
    * Set variables up before form is built.
    *
+   * @deprecated since 5.69 will be removed around 5.74
+   *
    * @param CRM_Core_Form $form
    *
    * @throws \CRM_Core_Exception
    */
   public static function preProcess(&$form) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     //as when call come from register.php
     if (!$form->_eventId) {
       $form->_eventId = CRM_Utils_Request::retrieve('eventId', 'Positive', $form);

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -295,7 +295,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       if (CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $_GET['eventId'], 'is_monetary')) {
         $this->assign('feeBlockPaid', TRUE);
       }
-      CRM_Event_Form_EventFees::preProcess($this);
       return;
     }
 
@@ -318,7 +317,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       if ($this->_submitValues['event_id']) {
         $this->_eventId = (int) $this->_submitValues['event_id'];
       }
-      CRM_Event_Form_EventFees::preProcess($this);
       $this->buildEventFeeForm($this);
       CRM_Event_Form_EventFees::setDefaultValues($this);
     }
@@ -1238,6 +1236,20 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    * @throws \Exception
    */
   public function buildEventFeeForm($form) {
+    //as when call come from register.php
+    if (!$form->_eventId) {
+      $form->_eventId = CRM_Utils_Request::retrieve('eventId', 'Positive', $form);
+    }
+
+    $form->_pId = CRM_Utils_Request::retrieve('participantId', 'Positive', $form);
+    $form->_discountId = CRM_Utils_Request::retrieve('discountId', 'Positive', $form);
+
+    //CRM-6907 set event specific currency.
+    if ($form->_eventId &&
+      ($currency = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $form->_eventId, 'currency'))
+    ) {
+      CRM_Core_Config::singleton()->defaultCurrency = $currency;
+    }
     if ($form->_eventId) {
       $form->_isPaidEvent = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $form->_eventId, 'is_monetary');
       if ($form->_isPaidEvent) {


### PR DESCRIPTION
Overview
----------------------------------------
Consolidate fee preProcess into feeBuildForm

Before
----------------------------------------
`CRM_Event_Form_EventFees::preProcess()` is called from only 2 places - both of which are on the participant form. In one case it is called directly before `$this->buildEventFeeForm($this);` - in the other it is called effectively before `$this->buildEventFeeForm($this);` - since it directly returns & the the next function calls `$this->buildEventFeeForm($this);`

After
----------------------------------------
Consolidated into `$this->buildEventFeeForm($this);` 

Technical Details
----------------------------------------
I discovered that the stuff so set currency needs to be incorporated into `getCurrency()` but I felt it made sense to move it first - @mattwire that's what you spotted

Comments
----------------------------------------
