### PR TITLE
Fix for initialization of Boolean custom fields in afform

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -279,6 +279,10 @@
       // Getter/Setter function for most fields (except select & entityRef)
       $scope.getSetValue = function(val) {
         var currentVal = $scope.dataProvider.getFieldData()[ctrl.fieldName];
+        // boolean custom fields uses 0/1 as radio button values
+        if (ctrl.defn.data_type === 'Boolean' && currentVal !== undefined && ctrl.fieldName.includes('.')) {
+          currentVal = currentVal ? 1 : 0;
+        }
         // Setter
         if (arguments.length) {
           if (ctrl.search_operator) {


### PR DESCRIPTION
Overview
----------------------------------------
Boolean custom field are not properly displayed in prefilled afforms.

Before
----------------------------------------
![ksnip_20231128-171927](https://github.com/civicrm/civicrm-core/assets/372004/adc64205-d47e-472d-ac19-f5cfc81df8c3)


After
----------------------------------------
![ksnip_20231128-171752](https://github.com/civicrm/civicrm-core/assets/372004/4dcbca25-4441-41ab-9161-55fd3b249d1c)


Comments
----------------------------------------
Boolean custom field radio button are using 0/1 instead of true/false.

We differentiate custom field by checking if they have a dot in their name. There is likely a better way.
