### PR TITLE
dev/core#4761 - CRM\Core\DAO - Generate unique name, case-insensitive

### DIFF
--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
@@ -74,10 +74,12 @@ class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessI
       ->addValue('label', 'My test search')
       ->execute()->first();
     // Name will be created from munged label
-    $this->assertEquals('My_test_search', $savedSearch0['name']);
-    // Name will have _1, _2, etc. appended to ensure it's unique
-    $this->assertEquals('My_test_search_1', $savedSearch1['name']);
-    $this->assertEquals('My_test_search_2', $savedSearch2['name']);
+    $this->assertEquals('My_test_search', $savedSearch0['name'], "SavedSearch 0");
+    // Name will have _r appended to ensure it's unique, where r is a string of
+    // random chars.
+    $this->assertEquals('My_test_search_', substr($savedSearch1['name'], 0, 15), "SavedSearch 1");
+    $this->assertEquals('My_test_search_', substr($savedSearch2['name'], 0, 15), "SavedSearch 2");
+    $this->assertNotSame($savedSearch1['name'], $savedSearch2['name'], "SavedSearch 1,2");
 
     $display0 = SearchDisplay::create()
       ->addValue('saved_search_id', $savedSearch0['id'])
@@ -95,11 +97,12 @@ class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessI
       ->addValue('type', 'table')
       ->execute()->first();
     // Name will be created from munged label
-    $this->assertEquals('My_test_display', $display0['name']);
-    // Name will have _1 appended to ensure it's unique to savedSearch0
-    $this->assertEquals('My_test_display_1', $display1['name']);
-    // This is for a different saved search so doesn't need a number appended
-    $this->assertEquals('My_test_display', $display2['name']);
+    $this->assertEquals('My_test_display', $display0['name'], "SearchDisplay 0");
+    // Name will have _r appended (r is random string) to ensure it's unique to
+    // savedSearch0.
+    $this->assertEquals('My_test_display_', substr($display1['name'], 0, 16), "SearchDisplay 1");
+    // This is for a different saved search so doesn't need a suffix appended
+    $this->assertEquals('My_test_display', $display2['name'], "SearchDisplay 2");
   }
 
 }


### PR DESCRIPTION
This duplicates on the 5.68 branch changes made to master in https://github.com/civicrm/civicrm-core/pull/28168.

See that PR for details.