### PR TITLE
Fix incoming bounce processing

### DIFF
--- a/CRM/Utils/Mail/IncomingMail.php
+++ b/CRM/Utils/Mail/IncomingMail.php
@@ -161,13 +161,13 @@ class CRM_Utils_Mail_IncomingMail {
     $twoDigitString = $twoDigitStringMin . $verpSeparator;
 
     // a common-for-all-actions regex to handle CiviCRM 2.2 address patterns
-    $regex = '/^' . $emailLocalPart . '(b|c|e|o|r|u)' . $twoDigitString . '([0-9a-f]{16})@' . $emailDomain . '$/';
+    $regex = '/^' . $emailLocalPart . '(b|c|e|o|r|u)' . $twoDigitString . '([0-9a-z]{16})@' . $emailDomain . '$/';
 
     // a tighter regex for finding bounce info in soft bounces’ mail bodies
-    $rpRegex = '/Return-Path:\s*' . $emailLocalPart . '(b)' . $twoDigitString . '([0-9a-f]{16})@' . $emailDomain . '/';
+    $rpRegex = '/Return-Path:\s*' . $emailLocalPart . '(b)' . $twoDigitString . '([0-9a-z]{16})@' . $emailDomain . '/';
 
     // a regex for finding bound info X-Header
-    $rpXHeaderRegex = '/X-CiviMail-Bounce: ' . $emailLocalPart . '(b)' . $twoDigitString . '([0-9a-f]{16})@' . $emailDomain . '/i';
+    $rpXHeaderRegex = '/X-CiviMail-Bounce: ' . $emailLocalPart . '(b)' . $twoDigitString . '([0-9a-z]{16})@' . $emailDomain . '/i';
     // CiviMail in regex and Civimail in header !!!
     $matches = NULL;
     foreach ($this->mail->to as $address) {

--- a/tests/phpunit/CRM/Utils/Mail/EmailProcessorTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/EmailProcessorTest.php
@@ -200,7 +200,7 @@ class CRM_Utils_Mail_EmailProcessorTest extends CiviUnitTestCase {
     ])['id'];
     $this->createMailing(['scheduled_date' => 'now', 'groups' => ['include' => [$groupID]]]);
     $this->callAPISuccess('job', 'process_mailing', []);
-    $this->eventQueue = $this->callAPISuccess('MailingEventQueue', 'get', ['api.MailingEventQueue.create' => ['hash' => 'aaaaaaaaaaaaaaaa']]);
+    $this->eventQueue = $this->callAPISuccess('MailingEventQueue', 'get', ['api.MailingEventQueue.create' => ['hash' => 'aaaaaaaaaaaaaaaz']]);
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/Mail/data/bounces/bounce_no_verp.txt
+++ b/tests/phpunit/CRM/Utils/Mail/data/bounces/bounce_no_verp.txt
@@ -18,7 +18,7 @@ Return-Path: <>
 Received: by 10.67.22.67 with SMTP id hq3mr12327267pad.132; Thu, 23 Jan 2014
  12:45:42 -0800 (PST)
 From: Mail Delivery Subsystem <mailer-daemon@googlemail.com>
-To: b.2.1.aaaaaaaaaaaaaaaa@example.com
+To: b.2.1.aaaaaaaaaaaaaaaz@example.com
 X-Failed-Recipients: undeliverable@example.com
 Subject: Delivery Status Notification (Failure)
 Message-ID: <047d7b5dbbd42675d704f0a953a8@google.com>

--- a/tests/phpunit/CRM/Utils/Mail/data/bounces/test_invalid_character.eml
+++ b/tests/phpunit/CRM/Utils/Mail/data/bounces/test_invalid_character.eml
@@ -3,7 +3,7 @@ Received: by 10.2.13.84 with SMTP id 1234567890;
         Wed, 19 Dec 2018 10:01:11 +0100 (CET)
 Return-Path: <SRS0=z9mA=EY=donate.long-example.org=b.51907682.51575594.57daed525aaca713@example.org>
 From: Postmaster@example.com
-To: b.2.1.aaaaaaaaaaaaaaaa@example.com
+To: b.2.1.aaaaaaaaaaaaaaaz@example.com
 Subject: Delivery Status Notification (Failure)
 Message-ID: <abc.def.fhi@example.com>
 Date: Wed, 19 Dec 2018 10:01:07 +0100

--- a/tests/phpunit/CRM/Utils/Mail/data/bounces/test_nested_message.eml
+++ b/tests/phpunit/CRM/Utils/Mail/data/bounces/test_nested_message.eml
@@ -1,23 +1,23 @@
 Return-Path: <>
-X-Original-To: b.2.1.aaaaaaaaaaaaaaaa@donate.example.org
-Delivered-To: b.2.1.aaaaaaaaaaaaaaaa@example.com
+X-Original-To: b.2.1.aaaaaaaaaaaaaaaz@donate.example.org
+Delivered-To: b.2.1.aaaaaaaaaaaaaaaz@example.com
 Received: from mx1001.example.org (mx1001.example.org [127.0.0.1])
 by civicrm.example.org (Postfix) with ESMTPS id 381BD2E95DC
-for <b.aaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaa@donate.example.org>; Sun,  3 Dec 2017 11:29:12 +0000 (UTC)
+for <b.aaaaaaaaaaaaaaaz.aaaaaaaaaaaaaaaz@donate.example.org>; Sun,  3 Dec 2017 11:29:12 +0000 (UTC)
 Received: from mail-qt0-x241.example.org ([1111:2222:3333:c0d::241]:34862)
 by mx1001.example.org with esmtps (TLS1.2:ECDHE_RSA_AES_128_GCM_SHA256:128)
 (Exim 4.84_2)
 id 1eLSSM-0003Vj-7E
-for b.aaaaaaaaaaaaaaaa.b322af9943c6facb@donate.example.org; Sun, 03 Dec 2017 11:29:12 +0000
+for b.aaaaaaaaaaaaaaaz.b322af9943c6facb@donate.example.org; Sun, 03 Dec 2017 11:29:12 +0000
 Received: by mail-qt0-x241.example.org with SMTP id u10so18073433qtg.2
-       for <b.aaaaaaaaaaaaaaaa.b322af9943c6facb@donate.example.org>; Sun, 03 Dec 2017 03:29:10 -0800 (PST)
+       for <b.aaaaaaaaaaaaaaaz.b322af9943c6facb@donate.example.org>; Sun, 03 Dec 2017 03:29:10 -0800 (PST)
 X-Received: by 127.0.0.1 with SMTP id f2mr16998556qth.140.1512300550024;
        Sun, 03 Dec 2017 03:29:10 -0800 (PST)
 Content-Type: multipart/report; boundary="f403043ae60413e73f055f6de970"; report-type=delivery-status
 Received: by 127.0.0.1 with SMTP id xxxxxxxx.140; Sun, 03 Dec 2017
 03:29:10 -0800 (PST)
 From: Mail Delivery Subsystem <mailer-daemon@example.com>
-To: b.2.1.aaaaaaaaaaaaaaaa@example.com
+To: b.2.1.aaaaaaaaaaaaaaaz@example.com
 Auto-Submitted: auto-replied
 Subject: Delivery Status Notification (Failure)
 References: <xxxxxxxxxxxxxxxxxxxxxxxx@civicrm-mailer>
@@ -47,7 +47,7 @@ Learn more here: https://checkspam.secureserver.net/?sid=3Dxxxxxxxxxxxx=
 (Warning: This link will take you to a third-party site)
 
 The response from the remote server was:
-552 5.2.0 aaaaaaaaaaaaaaaa - bbbbbbbbbbbbbbbb This message has been =
+552 5.2.0 aaaaaaaaaaaaaaaz - bbbbbbbbbbbbbbbb This message has been =
 rejected due to content judged to be spam by the internet community IB212 -=
 If you feel this is in error, please submit a request using the following =
 page. <https://checkspam.secureserver.net/?sid=3Dxxxxxxxxxxxx&mid=3Dxxxxx=
@@ -105,7 +105,7 @@ This link will take you to a third-party site
 <td align=3D"left" style=3D"padding:48px 10px">
 The response from the remote server was:<br/>
 <p style=3D"font-family:monospace">
-552 5.2.0 aaaaaaaaaaaaaaaa - bbbbbbbbbbbbbbbbbbb This message has been =
+552 5.2.0 aaaaaaaaaaaaaaaz - bbbbbbbbbbbbbbbbbbb This message has been =
 rejected due to content judged to be spam by the internet community IB212 -=
 If you feel this is in error, please submit a request using the following =
 page. &lt;https://checkspam.secureserver.net/?sid=3Dxxxxxxxx&amp;m=
@@ -245,7 +245,7 @@ AABJRU5ErkJggg==
 Content-Type: message/global-delivery-status
 
 Reporting-MTA: dns; example.com
-Received-From-MTA: dns; b.aaaaaaaaaaaaaaaa.b322af9943c6facb@donate.example.org
+Received-From-MTA: dns; b.aaaaaaaaaaaaaaaz.b322af9943c6facb@donate.example.org
 Arrival-Date: Sun, 03 Dec 2017 03:29:08 -0800 (PST)
 X-Original-Message-ID: <xxxxxxxxxxxxxxxxxxxxxxxx@civicrm-mailer>
 
@@ -253,9 +253,9 @@ Final-Recipient: rfc822; bob@example.com
 Action: failed
 Status: 5.2.0
 Remote-MTA: dns; smtp.secureserver.net (22.33.44.55, the relay for the domain.)
-Diagnostic-Code: smtp; 552 5.2.0 aaaaaaaaaaaaaaaaa - bbbbbbbbbbbbbbbbbbb This message has been rejected due to content judged to b
+Diagnostic-Code: smtp; 552 5.2.0 aaaaaaaaaaaaaaaza - bbbbbbbbbbbbbbbbbbb This message has been rejected due to content judged to b
 e spam by the internet community IB212 - If you feel this is in error, please submit a request using the following page. <https://che
-ckspam.secureserver.net/?sid=aaaaaaaaaaaaaaaaaaa&mid=bbbbbbbbbbbbbbbbbbb>
+ckspam.secureserver.net/?sid=aaaaaaaaaaaaaaazaaa&mid=bbbbbbbbbbbbbbbbbbb>
 Last-Attempt-Date: Sun, 03 Dec 2017 03:29:10 -0800 (PST)
 
 --f403043ae60413e73f055f6de970
@@ -263,7 +263,7 @@ Content-Type: message/rfc822
 
 X-Received: by 127.0.0.1 with SMTP id f2mr16998507qth.140.1512300548827;
        Sun, 03 Dec 2017 03:29:08 -0800 (PST)
-Return-Path: <b.aaaaaaaaaaaaaaaa.b322af9943c6facb@donate.example.org>
+Return-Path: <b.aaaaaaaaaaaaaaaz.b322af9943c6facb@donate.example.org>
 Received: from civicrm.example.org (civicrm.example.org. [111.222.33.44])
        by mx.example.org with ESMTPS id w61si1072744qte.335.2017.12.22.33.44.55
        for <bob@example.com>

--- a/tests/phpunit/CRM/Utils/Mail/data/bounces/test_sample_message.eml
+++ b/tests/phpunit/CRM/Utils/Mail/data/bounces/test_sample_message.eml
@@ -1,5 +1,5 @@
 Return-Path: <xxxxxx@acm.org>
-To: b.2.1.aaaaaaaaaaaaaaaa@example.com
+To: b.2.1.aaaaaaaaaaaaaaaz@example.com
 Subject: Testing Manuel Lemos' MIME E-mail composing and sending PHP class: HTML message
 From: xxxxxx <xxxxxx@acm.org>
 Reply-To: xxxxxx <xxxxxx@acm.org>

--- a/tests/phpunit/CRM/Utils/Mail/data/bounces/test_utf8mb4_character.txt
+++ b/tests/phpunit/CRM/Utils/Mail/data/bounces/test_utf8mb4_character.txt
@@ -3,7 +3,7 @@ Received: by 10.2.13.84 with SMTP id 1234567890;
         Wed, 19 Dec 2018 10:01:11 +0100 (CET)
 Return-Path: <>
 From: my@example.com
-To: b.2.1.aaaaaaaaaaaaaaaa@example.com
+To: b.2.1.aaaaaaaaaaaaaaaz@example.com
 Subject: Vacation
 Message-ID: <abc.def.fhi@example.com>
 Date: Wed, 19 Dec 2018 10:01:07 +0100


### PR DESCRIPTION
Overview
----------------------------------------
Fix incoming bounce processing

We switched to a less misleading method of calculating the hash here https://github.com/civicrm/civicrm-core/pull/27533/files#diff-942a60901c838eb11bfd85cd3e84672748d9f1d49f8cbe62684bc898b02c7a90R58 but did not spot that the regex was expecting only letters a-f whereas the new method is a-z

- note that the emails will re-process if moved back from ignored to inbox
- am still fixing tests to provide cover
@totten we should push this out asap

Before
----------------------------------------
The hash portion on new verp emails (created in 5.67+) can contain all alphabetical letters but the processor expects only a-f

After
----------------------------------------
The hashes are processed & incoming mail can be processed

Technical Details
----------------------------------------
Prior to last week's back port  https://github.com/civicrm/civicrm-core/pull/28242 the emails that were not able to be processed were causing the job to fail. The fix however meant that the emails were moved to the ignored folder. In order for sites to get the bounces, replies etc to process post fix they need to move the emails from ignored to Inbox within their mail system

Comments
----------------------------------------
@agileware-justin  this is the regex issue you were hitting

Note that this has had production testing - I deployed the patch on the site @Stoob manages that had the issue and was able to move the emails back from Ignored to Inbox & confirm that they processed correctly