### PR TITLE
Fix notice, caching, master-only-regression- showing inactive fields on membership config

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -672,6 +672,9 @@ class CRM_Financial_BAO_Order {
    */
   protected function setPriceFieldMetadata(array $metadata): void {
     foreach ($metadata as $index => $priceField) {
+      if ($this->isExcludeExpiredFields && !$priceField['is_active']) {
+        unset($metadata[$index]);
+      }
       if ($this->isExcludeExpiredFields && !empty($priceField['active_on']) && time() < strtotime($priceField['active_on'])) {
         unset($metadata[$index]);
       }
@@ -680,7 +683,10 @@ class CRM_Financial_BAO_Order {
       }
       elseif (!empty($priceField['options'])) {
         foreach ($priceField['options'] as $optionID => $option) {
-          if (!empty($option['membership_type_id'])) {
+          if (!$option['is_active']) {
+            unset($metadata[$index]['options'][$optionID]);
+          }
+          elseif (!empty($option['membership_type_id'])) {
             $membershipType = CRM_Member_BAO_MembershipType::getMembershipType((int) $option['membership_type_id']);
             $metadata[$index]['options'][$optionID]['auto_renew'] = (int) $membershipType['auto_renew'];
             if ($membershipType['auto_renew'] && empty($this->priceSetMetadata['auto_renew_membership_field'])) {

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1660,4 +1660,18 @@ WHERE     ct.id = cp.financial_type_id AND
     return $result;
   }
 
+  public static function hook_civicrm_post($op, $objectName, $objectId, &$objectRef): void {
+    if (in_array($objectName, ['PriceField', 'PriceFieldValue', 'PriceSet'], TRUE)) {
+      self::flushPriceSets();
+    }
+  }
+
+  public static function flushPriceSets(): void {
+    $cache = CRM_Utils_Cache::singleton();
+    foreach (PriceSet::get(FALSE)->addSelect('id')->execute() as $priceSet) {
+      $cacheKey = 'CRM_Price_BAO_PriceSetgetCachedPriceSetDetail_' . $priceSet['id'];
+      $cache->delete($cacheKey);
+    }
+  }
+
 }

--- a/templates/CRM/Contribute/Form/Contribution/MainMembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MainMembershipBlock.tpl
@@ -153,8 +153,6 @@
       if ( !memTypeId ) memTypeId = cj('input:radio[name='+priceSetName+']:checked').attr('membership-type');
 
       //does this page has only one membership type.
-      var singleMembership = {/literal}'{$singleMembership}'{literal};
-      if ( !memTypeId && singleMembership ) memTypeId = cj("input:radio[name="+priceSetName+"]").attr('membership-type');
       var renewOptions  = {/literal}{$autoRenewMembershipTypeOptions}{literal};
       var currentOption = eval( "renewOptions." + 'autoRenewMembershipType_' + memTypeId );
       var autoRenew = cj('#auto_renew_section');


### PR DESCRIPTION
Overview
----------------------------------------
Fixe notice, caching, showing inactive fields on membership config



Before
----------------------------------------
In trying to resolve  this notice (per image) I observed that inactive option values were showing up after being disabled due to a combo of caching & failure to filter out inactive fields.

![image](https://github.com/civicrm/civicrm-core/assets/336308/e5340310-b98c-497f-ad75-abdeed7c5e8d)

After
----------------------------------------
Notice resolved. I also fixed the inactive issue & caching as they make it hard to test

Technical Details
----------------------------------------
The variable relevant to the notice relates to the specific situation where there is only one membership type option available and it is not checked. However, it is never assigned - so the lines in question create notices with no other benefit.

In addition the only way that line changes the behaviour is that it lalters how jquery gets the membership type from the field but not expecting the value to be checked - ie 
```
 if ( !memTypeId ) memTypeId = cj('input:radio[name='+priceSetName+']:checked').attr('membership-type');

vs 
if ( !memTypeId && singleMembership ) memTypeId = cj("input:radio[name="+priceSetName+"]").attr('membership-type');
```

It's hard to make the case for why that would be anything other than historical

Comments
----------------------------------------

