### PR TITLE
Thank you page notice - ensure friendText & linkText is assigned

### DIFF
--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -132,9 +132,9 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
 
     $qParams = "reset=1&amp;id={$this->_id}";
     //pcp elements
+    $this->assign('pcpBlock', FALSE);
     if ($this->_pcpId) {
       $qParams .= "&amp;pcpId={$this->_pcpId}";
-      $this->assign('pcpBlock', FALSE);
 
       // display honor roll data only if it's enabled for the PCP page
       if (!empty($this->_pcpInfo['is_honor_roll'])) {

--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -49,6 +49,15 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
     $this->assign('thankyou_footer', CRM_Utils_Array::value('thankyou_footer', $this->_values));
     $this->assign('max_reminders', CRM_Utils_Array::value('max_reminders', $this->_values));
     $this->assign('initial_reminder_day', CRM_Utils_Array::value('initial_reminder_day', $this->_values));
+    // Link (button) for users to create their own Personal Campaign page
+    if ($linkText = CRM_PCP_BAO_PCP::getPcpBlockStatus($this->getContributionPageID(), 'contribute')) {
+      $linkTextUrl = CRM_Utils_System::url('civicrm/contribute/campaign',
+        "action=add&reset=1&pageId=' . $this->getContributionPageID() . '&component=contribute",
+        FALSE, NULL, TRUE
+      );
+    }
+    $this->assign('linkTextUrl', $linkTextUrl ?? NULL);
+    $this->assign('linkText', $linkText);
     $this->setTitle(CRM_Utils_Array::value('thankyou_title', $this->_values));
     // Make the contributionPageID available to the template
     $this->assign('contributionPageID', $this->_id);
@@ -248,6 +257,9 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
       $this->assign('friendText', $friendText);
       $subUrl = "eid={$this->_id}&pcomponent=contribute";
       $tellAFriend = TRUE;
+    }
+    else {
+      $this->assign('friendText');
     }
 
     if ($tellAFriend) {

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -483,16 +483,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $this->_pcpInfo = $pcp['pcpInfo'];
     }
 
-    // Link (button) for users to create their own Personal Campaign page
-    if ($linkText = CRM_PCP_BAO_PCP::getPcpBlockStatus($this->_id, 'contribute')) {
-      $linkTextUrl = CRM_Utils_System::url('civicrm/contribute/campaign',
-        "action=add&reset=1&pageId={$this->_id}&component=contribute",
-        FALSE, NULL, TRUE
-      );
-      $this->assign('linkTextUrl', $linkTextUrl);
-      $this->assign('linkText', $linkText);
-    }
-
     $this->assign('pledgeBlock', !empty($this->_values['pledge_block_id']));
 
     // @todo - move this check to `getMembershipBlock`

--- a/CRM/Friend/Form.php
+++ b/CRM/Friend/Form.php
@@ -285,8 +285,6 @@ class CRM_Friend_Form extends CRM_Core_Form {
           FALSE, NULL, TRUE,
           TRUE
         );
-        $this->assign('linkTextUrl', $linkTextUrl);
-        $this->assign('linkText', $linkText);
       }
     }
     elseif ($this->_entityTable === 'civicrm_event') {
@@ -297,11 +295,10 @@ class CRM_Friend_Form extends CRM_Core_Form {
           "action=add&reset=1&pageId={$defaults['entity_id']}&component=event",
           FALSE, NULL, TRUE,
           TRUE);
-        $this->assign('linkTextUrl', $linkTextUrl);
-        $this->assign('linkText', $linkText);
       }
     }
-
+    $this->assign('linkTextUrl', $linkTextUrl ?? NULL);
+    $this->assign('linkText', $linkText ?? NULL);
     $this->setTitle($defaults['thankyou_title']);
     $this->assign('thankYouText', $defaults['thankyou_text']);
   }

--- a/CRM/PCP/Page/PCPInfo.php
+++ b/CRM/PCP/Page/PCPInfo.php
@@ -206,9 +206,9 @@ class CRM_PCP_Page_PCPInfo extends CRM_Core_Page {
         TRUE, NULL, TRUE,
         TRUE
       );
-      $this->assign('linkTextUrl', $linkTextUrl);
-      $this->assign('linkText', $pcpBlock->link_text);
     }
+    $this->assign('linkTextUrl', $linkTextUrl ?? NULL);
+    $this->assign('linkText', $pcpBlock->link_text ?? NULL);
 
     $this->assign('honor', $honor);
     $this->assign('total', $totalAmount ?: '0.0');


### PR DESCRIPTION
Overview
----------------------------------------
Fixes notices on the thank you page in the online contribution flow

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/5f77d2e7-b383-4fd8-9417-f7495101a1bf)

After
----------------------------------------
Less red

Technical Details
----------------------------------------
I moved the `linkText` assignment out of the parent because it is not called from the other forms in the flow. I also moved the assignments to be unconditional in the other places where it IS called

![image](https://github.com/civicrm/civicrm-core/assets/336308/51f31e4b-7c72-4abe-8e51-cc7970991a6e)

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
