### PR TITLE
Notice fix - specify emailMode is false when including SocialNetwork.tpl

### DIFF
--- a/templates/CRM/Campaign/Form/Petition/Signature.tpl
+++ b/templates/CRM/Campaign/Form/Petition/Signature.tpl
@@ -38,7 +38,7 @@
   {if $duplicate}
     <p>{ts}Thank you for your support.{/ts}</p>
     {if $is_share}
-      {include file="CRM/Campaign/Page/Petition/SocialNetwork.tpl" petition_id=$survey_id petitionTitle=$petitionTitle}
+      {include file="CRM/Campaign/Page/Petition/SocialNetwork.tpl" petition_id=$survey_id petitionTitle=$petitionTitle emailMode=false}
     {/if}
   {else}
     <div class="crm-section crm-petition-contact-profile">

--- a/templates/CRM/Campaign/Page/Petition/Confirm.tpl
+++ b/templates/CRM/Campaign/Page/Petition/Confirm.tpl
@@ -25,6 +25,6 @@
   {/if}
   </div>
   {if $is_share}
-    {include file="CRM/Campaign/Page/Petition/SocialNetwork.tpl"}
+    {include file="CRM/Campaign/Page/Petition/SocialNetwork.tpl" emailMode=false}
   {/if}
 {/if}

--- a/templates/CRM/Campaign/Page/Petition/SocialNetwork.tpl
+++ b/templates/CRM/Campaign/Page/Petition/SocialNetwork.tpl
@@ -4,4 +4,4 @@ You might have a specific page that displays more information that the form.
 Check SocialNetwork.drupal as an example
 *}
 {capture assign=petitionURL}{crmURL p='civicrm/petition/sign' q="sid=`$petition_id`" a=1 fe=1 h=1}{/capture}
-{include file="CRM/common/SocialNetwork.tpl" url=$petitionURL title=$petitionTitle pageURL=$petitionURL}
+{include file="CRM/common/SocialNetwork.tpl" url=$petitionURL title=$petitionTitle pageURL=$petitionURL emailMode=false}

--- a/templates/CRM/Campaign/Page/Petition/ThankYou.tpl
+++ b/templates/CRM/Campaign/Page/Petition/ThankYou.tpl
@@ -38,7 +38,7 @@
     </div>
   {/if}
   {if $is_share}
-    {include file="CRM/Campaign/Page/Petition/SocialNetwork.tpl" petition_id=$survey_id petitionTitle=$petitionTitle}
+    {include file="CRM/Campaign/Page/Petition/SocialNetwork.tpl" petition_id=$survey_id petitionTitle=$petitionTitle emailMode=false}
   {/if}
 {/if}
 

--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -315,6 +315,6 @@
   </div>
   {if $isShare}
     {capture assign=contributionUrl}{crmURL p='civicrm/contribute/transact' q="$qParams" a=1 fe=1 h=1}{/capture}
-    {include file="CRM/common/SocialNetwork.tpl" url=$contributionUrl title=$title pageURL=$contributionUrl}
+    {include file="CRM/common/SocialNetwork.tpl" url=$contributionUrl title=$title pageURL=$contributionUrl emailMode=false}
   {/if}
 </div>

--- a/templates/CRM/Event/Form/Registration/ThankYou.tpl
+++ b/templates/CRM/Event/Form/Registration/ThankYou.tpl
@@ -203,6 +203,6 @@
     {/if}
     {if $event.is_share}
       {capture assign=eventUrl}{crmURL p='civicrm/event/info' q="id=`$event.id`&amp;reset=1" a=1 fe=1 h=1}{/capture}
-      {include file="CRM/common/SocialNetwork.tpl" url=$eventUrl title=$event.title pageURL=$eventUrl}
+      {include file="CRM/common/SocialNetwork.tpl" url=$eventUrl title=$event.title pageURL=$eventUrl emailMode=false}
     {/if}
 </div>

--- a/templates/CRM/Friend/Form.tpl
+++ b/templates/CRM/Friend/Form.tpl
@@ -81,5 +81,5 @@
   {else}
     {capture assign=pageURL}{crmURL p='civicrm/contribute/transact' q="reset=1&amp;id=`$entityID`" a=1 fe=1 h=1}{/capture}
   {/if}
-  {include file="CRM/common/SocialNetwork.tpl" url=$pageURL title=$title pageURL=$pageURL}
+  {include file="CRM/common/SocialNetwork.tpl" url=$pageURL title=$title pageURL=$pageURL emailMode=false}
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Notice fix - specify emailMode is false when including SocialNetwork.tpl

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/01640829-ac73-4a64-aee2-53d5e51b9dcc)

After
----------------------------------------
less red

Technical Details
----------------------------------------
When the tpl is included from the message templates emailMode is passed as TRUE. Otherwise it is implicitly FALSE  - which this makes explicit

Comments
----------------------------------------
