### PR TITLE
CRM_Core_CodeGen_Schema: fix generated comments and whitespace

### DIFF
--- a/xml/templates/drop.tpl
+++ b/xml/templates/drop.tpl
@@ -8,11 +8,12 @@
 --
 -- Generated from {$smarty.template}
 -- {$generated}
---{/if}
+--
+{/if}
 -- /*******************************************************
 -- *
--- * Clean up the existing tables{if !$isOutputLicense} - this section generated from {$smarty.template}
-{/if}
+-- * Clean up the existing tables{if !$isOutputLicense} - this section generated from {$smarty.template}{/if}
+
 -- *
 -- *******************************************************/
 


### PR DESCRIPTION
Overview
----------------------------------------
Non-functional change. SQL generated by `CRM_Core_CodeGen_Schema::generateDropSql` without the licence part miss newlines in comments.

Before
----------------------------------------
```
-- DO NOT EDIT.  Generated by CRM_Core_CodeGen
---- /*******************************************************
-- *
-- * Clean up the existing tables-- *
-- *******************************************************/
```

After
----------------------------------------
```
-- DO NOT EDIT.  Generated by CRM_Core_CodeGen
--
-- /*******************************************************
-- *
-- * Clean up the existing tables
-- *
-- *******************************************************/
```

Technical Details
----------------------------------------
With licence there's no change.