### PR TITLE
Fix notices on credit_card & bank number on Confirm & ThankYou

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1020,7 +1020,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   public function assignPaymentFields() {
     //fix for CRM-3767
     $isMonetary = FALSE;
-    if ($this->_amount > 0.0) {
+    if ($this->order->getTotalAmount() > 0.0) {
       $isMonetary = TRUE;
     }
     elseif (!empty($this->_params['selectMembership'])) {
@@ -1064,9 +1064,8 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         }
       }
       $this->assign('paymentFieldsetLabel', CRM_Core_Payment_Form::getPaymentLabel($paymentProcessorObject));
-      $this->assign('paymentFields', $paymentFields);
-
     }
+    $this->assign('paymentFields', $paymentFields ?? []);
   }
 
   /**

--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -231,14 +231,14 @@
 
   {* Show credit or debit card section for 'direct' mode, except for PayPal Express (detected because credit card number is empty) *}
     {crmRegion name="contribution-confirm-billing-block"}
-    {if in_array('credit_card_number', $form) || in_array('bank_account_number', $form)}
+    {if in_array('credit_card_number', $paymentFields) || in_array('bank_account_number', $paymentFields)}
       <div class="crm-group credit_card-group">
         {if $paymentFieldsetLabel}
           <div class="header-dark">
             {$paymentFieldsetLabel}
           </div>
         {/if}
-        {if in_array('bank_account_number', $form) && $bank_account_number}
+        {if in_array('bank_account_number', $paymentFields) && $bank_account_number}
           <div class="display-block">
             {ts}Account Holder{/ts}: {$account_holder}<br/>
             {ts}Bank Account Number{/ts}: {$bank_account_number}<br/>
@@ -256,7 +256,7 @@
             </div>
           {/if}
         {/if}
-        {if in_array('credit_card_number', $form) && $credit_card_number}
+        {if in_array('credit_card_number', $paymentFields) && $credit_card_number}
           <div class="crm-section no-label credit_card_details-section">
             <div class="content">{$credit_card_type}</div>
             <div class="content">{$credit_card_number}</div>

--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -273,7 +273,7 @@
     </div>
   {/if}
 
-  {if in_array('credit_card_number', $form) || in_array('bank_account_number', $form) && ($amount GT 0 OR $minimum_fee GT 0)}
+  {if in_array('credit_card_number', $paymentFields) || in_array('bank_account_number', $paymentFields) && ($amount GT 0 OR $minimum_fee GT 0)}
     {crmRegion name="contribution-thankyou-billing-block"}
       <div class="crm-group credit_card-group">
         {if $paymentFieldsetLabel}
@@ -281,7 +281,7 @@
             {$paymentFieldsetLabel}
           </div>
         {/if}
-          {if in_array('bank_account_number', $form) && $bank_account_number}
+          {if in_array('bank_account_number', $paymentFields) && $bank_account_number}
           <div class="display-block">
             {ts}Account Holder{/ts}: {$account_holder}<br />
             {ts}Bank Identification Number{/ts}: {$bank_identification_number}<br />


### PR DESCRIPTION
Overview
----------------------------------------
Fix notices on credit_card & bank number on Confirm & ThankYou

Before
----------------------------------------
It's checking the form to see if the fields are present

After
----------------------------------------
It checks an array of fields - that is now always assigned

Technical Details
----------------------------------------

Comments
----------------------------------------
