### PR TITLE
Case Custom Data: fix non-US numeric decimals - 5.68

### DIFF
--- a/CRM/Case/Form/CustomData.php
+++ b/CRM/Case/Form/CustomData.php
@@ -110,7 +110,7 @@ class CRM_Case_Form_CustomData extends CRM_Core_Form {
    * @throws \CRM_Core_Exception
    */
   public function postProcess(): void {
-    $params = $this->controller->exportValues($this->_name);
+    $params = $this->getSubmittedValues();
 
     $transaction = new CRM_Core_Transaction();
 


### PR DESCRIPTION
Overview
----------------------------------------

Related to #27917, this fixes numeric (float) custom fields on Cases (when editing the case custom data).

Same PR as #28369, but for the RC.

Before
----------------------------------------

- Set decimal separator to a comma (`,`)
- Create a new custom field of type numeric for cases
- Create a new case, enter values
- Edit case data, save

Decimal values such as `1,99` generate an error message.

After
----------------------------------------

Decimals are interpreted correctly.
