### PR TITLE
Fix quotes causing function call to be in quotes (master only regression)

### DIFF
--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -52,7 +52,7 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
     // Link (button) for users to create their own Personal Campaign page
     if ($linkText = CRM_PCP_BAO_PCP::getPcpBlockStatus($this->getContributionPageID(), 'contribute')) {
       $linkTextUrl = CRM_Utils_System::url('civicrm/contribute/campaign',
-        "action=add&reset=1&pageId=' . $this->getContributionPageID() . '&component=contribute",
+        'action=add&reset=1&pageId=' . $this->getContributionPageID() . '&component=contribute',
         FALSE, NULL, TRUE
       );
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fix quotes causing function call to be in quotes (master only regression)

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/d9c31577-93f8-4fd9-ae40-979adcf7b08d)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/731ea9f6-098f-4100-a492-f7577ab7ec01)

Technical Details
----------------------------------------
This is the answer to https://github.com/civicrm/civicrm-core/pull/28364#pullrequestreview-1755140692 now I have had some sleep

Comments
----------------------------------------
