### PR TITLE
dev/core#4563 - fix related contact mapping fields on import

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -82,6 +82,9 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function preProcess(): void {
+    // Don't mess up the fields for related contacts
+    $this->shouldSortMapperFields = FALSE;
+
     parent::preProcess();
     //format custom field names, CRM-2676
     $contactType = $this->getContactType();

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -32,6 +32,11 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
   protected $_mapperFields;
 
   /**
+   * @var bool
+   */
+  protected $shouldSortMapperFields = TRUE;
+
+  /**
    * Column headers, if we have them
    *
    * @var array
@@ -72,7 +77,9 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     if (empty($_POST) && count($fieldMappings) > 0 && count($this->getColumnHeaders()) !== count($fieldMappings)) {
       CRM_Core_Session::singleton()->setStatus(ts('The data columns in this import file appear to be different from the saved mapping. Please verify that you have selected the correct saved mapping before continuing.'));
     }
-    asort($this->_mapperFields);
+    if ($this->shouldSortMapperFields) {
+      asort($this->_mapperFields);
+    }
     parent::preProcess();
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4563

Before
----------------------------------------
1. Import contacts
2. Notice the fields for related contacts are all jumbled and disconnected from their "section header label" `- related contact info -`. They used to be together at the bottom. In some translations it makes the section header label come first which causes problems where it should be "do not import".

After
----------------------------------------
1. More like before.

Technical Details
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/25869 some code was moved to parent preprocess which caused the fields to now get "sorted", but which is undesirable here and they are already sorted.

Comments
----------------------------------------

