### PR TITLE
Participant: Store custom field values before post hook

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -110,6 +110,13 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant implements \Ci
 
     $participantBAO->save();
 
+    // add custom field values
+    if (!empty($params['custom']) &&
+      is_array($params['custom'])
+    ) {
+      CRM_Core_BAO_CustomValueTable::store($params['custom'], 'civicrm_participant', $participantBAO->id);
+    }
+
     CRM_Contact_BAO_GroupContactCache::opportunisticCacheFlush();
 
     if (!empty($params['id'])) {
@@ -194,13 +201,6 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant implements \Ci
     $id = $session->get('userID');
     if (!$id) {
       $id = $params['contact_id'] ?? NULL;
-    }
-
-    // add custom field values
-    if (!empty($params['custom']) &&
-      is_array($params['custom'])
-    ) {
-      CRM_Core_BAO_CustomValueTable::store($params['custom'], 'civicrm_participant', $participant->id);
     }
 
     //process note, CRM-7634


### PR DESCRIPTION
Overview
----------------------------------------
Store custom field values before the post hook is dispatched.

Before
----------------------------------------
The post hook is dispatched before custom field values are stored. If custom field values are fetched from the DB during the post hook they still contain the old values.

After
----------------------------------------
The post hook is dispatched after custom field values are stored.
