### PR TITLE
fix error on confirm page when using on-behalf-of

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2065,7 +2065,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       if (array_key_exists('onbehalf_location', $params) && is_array($params['onbehalf_location'])) {
         foreach ($params['onbehalf_location'] as $block => $vals) {
           //fix for custom data (of type checkbox, multi-select)
-          if (str_starts_with($block, 0, 'custom_')) {
+          if (str_starts_with($block, 'custom_')) {
             continue;
           }
           // fix the index of block elements


### PR DESCRIPTION
Overview
----------------------------------------

Before
----------------------------------------
1. Configure a contribution page with on-behalf-of.
2. On confirm page it crashes.

After
----------------------------------------

Technical Details
----------------------------------------
https://github.com/civicrm/civicrm-core/commit/349261ad38a0ed996330c049b0666cc0fa877913#diff-fa1d97e1889c16127a161492e1fed358409b2d2b39cc37e799e648ac68b5efd8R2090

Comments
----------------------------------------
