### PR TITLE
Activity case filter speedup

### DIFF
--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -336,12 +336,14 @@ function _civicrm_api3_activity_get_extraFilters(&$params, &$sql) {
       'join' => '!joinType civicrm_entity_file !alias ON (!alias.entity_table = "civicrm_activity" AND !alias.entity_id = a.id)',
       'column' => 'file_id',
     ],
-    'case_id' => [
+  ];
+  if (\CRM_Core_Component::isEnabled('CiviCase')) {
+    $rels['case_id'] = [
       'subquery' => 'a.id IN (SELECT activity_id FROM civicrm_case_activity WHERE !clause)',
       'join' => '!joinType civicrm_case_activity !alias ON (!alias.activity_id = a.id)',
       'column' => 'case_id',
-    ],
-  ];
+    ];
+  }
   foreach ($rels as $filter => $relSpec) {
     if (!empty($params[$filter])) {
       if (!is_array($params[$filter])) {


### PR DESCRIPTION
Overview
----------------------------------------
This provides a speed boost to sites without CiviCase when viewing contacts and activities.

See https://lab.civicrm.org/dev/core/-/issues/4822

Before
----------------------------------------
Determining the count of a contact's activities took ~71 seconds.

After
----------------------------------------
Determining the count of a contact's activities took ~.25 seconds.

Comments
----------------------------------------
I don't know why retrieving the activity count started taking so long all of a sudden - so many variables changed at once.  But this should at least provide relief to users without CiviCase.
