### PR TITLE
Use apv4 rather than V3 for cached membershipTypes retrieval

### DIFF
--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\MembershipType;
+
 /**
  *
  * @package CRM
@@ -805,28 +807,13 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType implem
   public static function getAllMembershipTypes(): array {
     $cacheString = __CLASS__ . __FUNCTION__ . CRM_Core_Config::domainID() . '_' . CRM_Core_I18n::getLocale();
     if (!Civi::cache('metadata')->has($cacheString)) {
-      $types = civicrm_api3('MembershipType', 'get', ['options' => ['limit' => 0, 'sort' => 'weight']])['values'];
+      $types = (array) MembershipType::get(FALSE)->addOrderBy('weight')->execute()->indexBy('id');
       $taxRates = CRM_Core_PseudoConstant::getTaxRates();
-      $keys = ['description', 'relationship_type_id', 'relationship_direction', 'max_related', 'auto_renew'];
-      // In order to avoid down-stream e-notices we undo api v3 filtering of NULL values. This is covered
-      // in Unit tests & ideally we might switch to apiv4 but I would argue we should build caching
-      // of metadata entities like this directly into apiv4.
       foreach ($types as $id => $type) {
-        foreach ($keys as $key) {
-          if (!isset($type[$key])) {
-            $types[$id][$key] = NULL;
-          }
-        }
-        if (isset($type['contribution_type_id'])) {
-          unset($types[$id]['contribution_type_id']);
-        }
         $types[$id]['tax_rate'] = (float) ($taxRates[$type['financial_type_id']] ?? 0.0);
         $multiplier = 1;
         if ($types[$id]['tax_rate'] !== 0.0) {
           $multiplier += ($types[$id]['tax_rate'] / 100);
-        }
-        if (!array_key_exists('minimum_fee', $types[$id])) {
-          $types[$id]['minimum_fee'] = 0;
         }
         $types[$id]['minimum_fee_with_tax'] = (float) $types[$id]['minimum_fee'] * $multiplier;
       }

--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -15,7 +15,6 @@
  */
 class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
 
-  private $_contactID;
   private $_membershipStatusID;
   private $_membershipTypeID;
 
@@ -57,17 +56,17 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       //Default domain ID
       'domain_id' => 1,
       'member_of_contact_id' => $organizationId,
-      'financial_type_id' => "Member Dues",
-      'duration_unit' => "year",
+      'financial_type_id' => 'Member Dues',
+      'duration_unit' => 'year',
       'duration_interval' => 1,
-      'period_type' => "rolling",
+      'period_type' => 'rolling',
       'name' => 'Organization Membership Type',
       'relationship_type_id' => ($withRelationship) ? 5 : NULL,
       'relationship_direction' => ($withRelationship) ? 'b_a' : NULL,
       'max_related' => $maxRelated ?: NULL,
     ]);
 
-    return $membershipType["values"][$membershipType["id"]];
+    return $membershipType['values'][$membershipType["id"]];
   }
 
   /**
@@ -808,31 +807,34 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     $form = new CRM_Core_Form();
     $values = CRM_Member_BAO_Membership::buildMembershipTypeValues($form);
     $this->assertEquals([
-      'id' => '1',
-      'minimum_fee' => '100.000000000',
+      'id' => 1,
+      'minimum_fee' => 100.00,
       'name' => 'General',
-      'is_active' => '1',
+      'is_active' => 1,
       'description' => 'Regular annual membership.',
-      'financial_type_id' => '2',
-      'auto_renew' => '0',
+      'financial_type_id' => 2,
+      'auto_renew' => 0,
       'member_of_contact_id' => $values[1]['member_of_contact_id'],
       'relationship_type_id' => [7],
       'relationship_direction' => ['b_a'],
       'max_related' => NULL,
       'duration_unit' => 'year',
-      'duration_interval' => '2',
-      'domain_id' => '1',
+      'duration_interval' => 2,
+      'domain_id' => 1,
       'period_type' => 'rolling',
       'visibility' => 'Public',
-      'weight' => '1',
+      'weight' => 1,
       'tax_rate' => 0.0,
       'minimum_fee_with_tax' => 100.0,
+      'fixed_period_start_day' => NULL,
+      'fixed_period_rollover_day' => NULL,
+      'receipt_text_signup' => NULL,
+      'receipt_text_renewal' => NULL,
     ], $values[1]);
   }
 
   /**
    * @return array
-   * @throws \CRM_Core_Exception
    */
   protected function setupMembership(): array {
     $contactId = $this->individualCreate();
@@ -1026,11 +1028,9 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
    * Checks the given membership ID can be found.
    *
    * @param int $membershipID
-   *
-   * @throws \CRM_Core_Exception
    */
   private function assertMembershipExists(int $membershipID): void {
-    $membership = $this->callAPISuccess("Membership", "get", [
+    $membership = $this->callAPISuccess('Membership', "get", [
       'id' => $membershipID,
     ]);
     $this->assertEquals(1, $membership['count']);


### PR DESCRIPTION
Overview
----------------------------------------
Use apv3 rather than v4 for cached membershipTypes retrieval

Before
----------------------------------------
All the joys of v3 - no type casting & empty keys are missing, required notice protection

![image](https://github.com/civicrm/civicrm-core/assets/336308/df94ad04-365a-40b4-9f90-2472dc6a11e9)


After
----------------------------------------
v4

![image](https://github.com/civicrm/civicrm-core/assets/336308/b9192972-5d7d-4f24-8917-1ad8cfc317a2)
![image](https://github.com/civicrm/civicrm-core/assets/336308/d2f0e521-3721-48ad-aae1-2bad280635bb)


Technical Details
----------------------------------------

Comments
----------------------------------------
