### PR TITLE
dev/core#3994 Update membership block on membership type save & remove the same from the Manage form

### DIFF
--- a/CRM/Member/BAO/MembershipBlock.php
+++ b/CRM/Member/BAO/MembershipBlock.php
@@ -9,12 +9,16 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\MembershipBlock;
+use Civi\Core\Event\PostEvent;
+use Civi\Core\HookInterface;
+
 /**
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Member_BAO_MembershipBlock extends CRM_Member_DAO_MembershipBlock {
+class CRM_Member_BAO_MembershipBlock extends CRM_Member_DAO_MembershipBlock implements HookInterface {
 
   /**
    * Create or update a MembershipBlock.
@@ -38,6 +42,42 @@ class CRM_Member_BAO_MembershipBlock extends CRM_Member_DAO_MembershipBlock {
   public static function del($id) {
     CRM_Core_Error::deprecatedFunctionWarning('deleteRecord');
     return (bool) self::deleteRecord(['id' => $id]);
+  }
+
+  /**
+   * Update MembershipBlocks if autorenew option is changed.
+   *
+   * Available auto-renew options are
+   * 0 - Autorenew unavailable
+   * 1 - Give option
+   * 2 - Force auto-renewal
+   *
+   * In the case of 0 or 2 we need to ensure that all membership blocks are
+   * set to the same value. If the option is 1 no action is required as
+   * all 3 options are then valid at the membership block level.
+   *
+   * https://issues.civicrm.org/jira/browse/CRM-15573
+   *
+   * @param \Civi\Core\Event\PostEvent $event
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public static function on_hook_civicrm_post(PostEvent $event): void {
+    if ($event->entity === 'MembershipType' && $event->action === 'edit') {
+      $autoRenewOption = $event->object->auto_renew;
+      if ($event->id && $autoRenewOption !== NULL && ((int) $autoRenewOption) !== 1) {
+        $autoRenewOption = (int) $autoRenewOption;
+        $membershipBlocks = MembershipBlock::get(FALSE)->execute();
+        foreach ($membershipBlocks as $membershipBlock) {
+          if (array_key_exists($event->id, $membershipBlock['membership_types'])
+            && ((int) $membershipBlock['membership_types'][$event->id]) !== $autoRenewOption
+          ) {
+            $membershipBlock['membership_types'][$event->id] = $autoRenewOption;
+            MembershipBlock::update(FALSE)->setValues($membershipBlock)->execute();
+          }
+        }
+      }
+    }
   }
 
 }

--- a/CRM/Member/Form/MembershipBlock.php
+++ b/CRM/Member/Form/MembershipBlock.php
@@ -151,11 +151,6 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
         }
       }
 
-      //CRM-15573
-      if (!empty($params['id'])) {
-        $params['membership_types'] = serialize($membershipRequired);
-        CRM_Member_BAO_MembershipBlock::writeRecord($params);
-      }
       $this->add('hidden', 'mem_price_field_id', '', ['id' => 'mem_price_field_id']);
       $this->assign('is_recur', $isRecur);
       $this->assign('auto_renew', $renewOption);

--- a/CRM/Member/Form/MembershipBlock.php
+++ b/CRM/Member/Form/MembershipBlock.php
@@ -128,7 +128,7 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
         }
       }
 
-      $membership = $membershipDefault = $params = [];
+      $membership = $membershipDefault = [];
       $renewOption = [];
       foreach ($membershipTypes as $k => $v) {
         $membership[] = $this->createElement('advcheckbox', $k, NULL, $v);
@@ -137,14 +137,12 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
         if ($isRecur) {
           $autoRenew = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType', $k, 'auto_renew');
           $membershipRequired[$k] = $autoRenew;
-          $autoRenewOptions = [];
           if ($autoRenew) {
             $autoRenewOptions = [ts('Not offered'), ts('Give option'), ts('Required')];
             $this->addElement('select', "auto_renew_$k", ts('Auto-renew'), $autoRenewOptions);
             //CRM-15573
             if ($autoRenew == 2) {
               $this->freeze("auto_renew_$k");
-              $params['id'] = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipBlock', $this->_id, 'id', 'entity_id');
             }
             $renewOption[$k] = $autoRenew;
           }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#3994 Update membership block on membership type save & remove the same from the Manage form

Replaces Per https://github.com/civicrm/civicrm-core/pull/24997 

Before
----------------------------------------
As documented by @stesi561  here https://lab.civicrm.org/dev/core/-/issues/3994#note_89885

After
----------------------------------------
The saved option is re-presented


Technical Details
----------------------------------------
In order to fix https://issues.civicrm.org/jira/browse/CRM-15573 the Contribution Page Manage Membership form was edited to 'fix' the membership block in the `buildForm` to catch any cases where edits to the membership type resulted in the renewal options being out of sync with the form. I concluded this was the wrong place & moved it to a post-process hook when the membership type is saved. I confirmed that the MembershipType form does not bypass the create method to save the membership type & I don't think the form should be handling possible misconfiguration from an extension

Comments
----------------------------------------
