### PR TITLE
Formbuilder: support rows and columns values for Note (textarea) custom field type

### DIFF
--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -322,7 +322,9 @@ class SpecFormatter {
     if ($inputType == 'TextArea') {
       foreach (['rows', 'cols', 'note_rows', 'note_columns'] as $prop) {
         if (!empty($data[$prop])) {
-          $inputAttrs[str_replace('note_', '', $prop)] = (int) $data[$prop];
+          $key = str_replace('note_', '', $prop);
+          $key = str_replace('columns', 'cols', $key);  // per @colemanw https://github.com/civicrm/civicrm-core/pull/28388#issuecomment-1835717428
+          $inputAttrs[$key] = (int) $data[$prop];
         }
       }
     }

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -323,7 +323,8 @@ class SpecFormatter {
       foreach (['rows', 'cols', 'note_rows', 'note_columns'] as $prop) {
         if (!empty($data[$prop])) {
           $key = str_replace('note_', '', $prop);
-          $key = str_replace('columns', 'cols', $key);  // per @colemanw https://github.com/civicrm/civicrm-core/pull/28388#issuecomment-1835717428
+          // per @colemanw https://github.com/civicrm/civicrm-core/pull/28388#issuecomment-1835717428
+          $key = str_replace('columns', 'cols', $key);
           $inputAttrs[$key] = (int) $data[$prop];
         }
       }

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -320,7 +320,7 @@ class SpecFormatter {
       $inputAttrs['maxlength'] = (int) $data['maxlength'];
     }
     if ($inputType == 'TextArea') {
-      foreach (['rows', 'cols', 'note_rows', 'note_cols'] as $prop) {
+      foreach (['rows', 'cols', 'note_rows', 'note_columns'] as $prop) {
         if (!empty($data[$prop])) {
           $inputAttrs[str_replace('note_', '', $prop)] = (int) $data[$prop];
         }

--- a/ext/afform/core/ang/af/fields/TextArea.html
+++ b/ext/afform/core/ang/af/fields/TextArea.html
@@ -1,1 +1,1 @@
-<textarea class="crm-form-textarea" id="{{:: fieldId }}" ng-required="$ctrl.defn.required" ng-model="getSetValue" ng-model-options="{getterSetter: true}" ></textarea>
+<textarea class="crm-form-textarea" id="{{:: fieldId }}" rows="{{:: $ctrl.defn.input_attrs.rows || 4 }}" cols="{{:: $ctrl.defn.input_attrs.columns || 60 }}" ng-required="$ctrl.defn.required" ng-model="getSetValue" ng-model-options="{getterSetter: true}" ></textarea>

--- a/ext/afform/core/ang/af/fields/TextArea.html
+++ b/ext/afform/core/ang/af/fields/TextArea.html
@@ -1,1 +1,1 @@
-<textarea class="crm-form-textarea" id="{{:: fieldId }}" rows="{{:: $ctrl.defn.input_attrs.rows || 4 }}" cols="{{:: $ctrl.defn.input_attrs.columns || 60 }}" ng-required="$ctrl.defn.required" ng-model="getSetValue" ng-model-options="{getterSetter: true}" ></textarea>
+<textarea class="crm-form-textarea" id="{{:: fieldId }}" rows="{{:: $ctrl.defn.input_attrs.rows || 4 }}" cols="{{:: $ctrl.defn.input_attrs.cols || 60 }}" ng-required="$ctrl.defn.required" ng-model="getSetValue" ng-model-options="{getterSetter: true}" ></textarea>


### PR DESCRIPTION
Overview
----------------------------------------
Before Form Builder, defining a Note with rows and columns (defaulting to 4 and 60) would show a `textarea` tag with `rows` and `cols` attributes set. Form Builder does not currently set those attributes.

Briefly mentioned on [Mattermost](https://chat.civicrm.org/civicrm/pl/3kqcc83ymfryjkq6nnqkq84c5a).

Before
----------------------------------------
Displaying a custom field of type `Note` in Form Builder would show the browser default for a `textarea` tag.

After
----------------------------------------
Displaying a custom field of type `Note` in Form Builder now shows  the `textarea` tag with `rows` and `cols` set to the custom field definition set by the admin for that field.

Technical Details
----------------------------------------
In the `civicrm_custom_field` table, there are field names of `note_rows` and `note_columns`. Form Builder was setting `input_attrs` for `rows` but not `columns` since it was looking for `note_cols`. This PR corrects that lookup.

Then, the angular field definition for TextArea adds the `rows` and `cols` attributes reference the settings of `input_attrs.rows` and `input_attrs.columns` with defaults of 4 and 60, respectively, if those attributes were somehow not defined.

Comments
----------------------------------------
Someone should decide if `cols` should also become `columns` to match `note_columns` in the [`foreach` line of SpecFormatter.php](https://github.com/asmac-org/civicrm-core/blob/0bd36ff3dda6c64a16d92236f524b931bab32bb8/Civi/Api4/Service/Spec/SpecFormatter.php#L323). 
