### PR TITLE
Use getSubmittedValues() rather than ad-hoc money 'cleaning' on membershipType form

### DIFF
--- a/CRM/Member/Form/MembershipType.php
+++ b/CRM/Member/Form/MembershipType.php
@@ -23,6 +23,8 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
 
   use CRM_Core_Form_EntityFormTrait;
 
+  protected $submittableMoneyFields = ['minimum_fee'];
+
   /**
    * Set entity fields to be assigned to the form.
    */
@@ -287,7 +289,7 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
       $errors['financial_type_id'] = ts('Please enter the financial Type.');
     }
 
-    if (empty($params['duration_interval']) and $params['duration_unit'] != 'lifetime') {
+    if (empty($params['duration_interval']) and $params['duration_unit'] !== 'lifetime') {
       $errors['duration_interval'] = ts('Please enter a duration interval.');
     }
 
@@ -295,15 +297,15 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
       1,
       2,
     ])) {
-      if (($params['duration_interval'] > 1 && $params['duration_unit'] == 'year') ||
-        ($params['duration_interval'] > 12 && $params['duration_unit'] == 'month')
+      if (($params['duration_interval'] > 1 && $params['duration_unit'] === 'year') ||
+        ($params['duration_interval'] > 12 && $params['duration_unit'] === 'month')
       ) {
         $errors['duration_unit'] = ts('Automatic renewals are not supported by the currently available payment processors when the membership duration is greater than 1 year / 12 months.');
       }
     }
 
-    if ($params['period_type'] == 'fixed' &&
-      $params['duration_unit'] == 'day'
+    if ($params['period_type'] === 'fixed' &&
+      $params['duration_unit'] === 'day'
     ) {
       $errors['period_type'] = ts('Period type should be Rolling when duration unit is Day');
     }
@@ -362,11 +364,7 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
       CRM_Core_Session::setStatus(ts('Selected membership type has been deleted.'), ts('Record Deleted'), 'success');
     }
     else {
-      $params = $this->exportValues();
-
-      if ($params['minimum_fee']) {
-        $params['minimum_fee'] = CRM_Utils_Rule::cleanMoney($params['minimum_fee']);
-      }
+      $params = $this->getSubmittedValues();
 
       $hasRelTypeVal = FALSE;
       if (!CRM_Utils_System::isNull($params['relationship_type_id'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Use getSubmittedValues() rather than ad-hoc money 'cleaning' on membershipType form

Before
----------------------------------------
`$params = $this->exportValues();` followed by cleaning used


After
----------------------------------------
`getSubmittedValues()` used

Technical Details
----------------------------------------
This is mostly about modelling best practice - but it is technically possible to enable custom fields on this form - in  which case this would be relevant to money handling on them

Comments
----------------------------------------
