### PR TITLE
[REF] Use Token Processor to generate sort name and display name for individuals

### DIFF
--- a/CRM/Contact/BAO/Individual.php
+++ b/CRM/Contact/BAO/Individual.php
@@ -15,6 +15,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Token\TokenProcessor;
+
 /**
  * Class contains functions for individual contact type.
  */
@@ -185,19 +187,18 @@ class CRM_Contact_BAO_Individual extends CRM_Contact_DAO_Contact {
         }
       }
 
-      //build the sort name.
-      $format = Civi::settings()->get('sort_name_format');
-      $sortName = CRM_Utils_Address::format($formatted, $format,
-        FALSE, FALSE, $tokenFields
-      );
-      $sortName = trim($sortName);
-
-      //build the display name.
-      $format = Civi::settings()->get('display_name_format');
-      $displayName = CRM_Utils_Address::format($formatted, $format,
-        FALSE, FALSE, $tokenFields
-      );
-      $displayName = trim($displayName);
+      $formatted['id'] = $contact->id ?? $params['id'] ?? 0;
+      $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
+        'class' => __CLASS__,
+        'schema' => ['contactId'],
+      ]);
+      $tokenProcessor->addRow(['contactId' => $contactFields['id'] ?? 0, 'contact' => $formatted]);
+      $tokenProcessor->addMessage('sort_name', Civi::settings()->get('sort_name_format'), 'text/plain');
+      $tokenProcessor->addMessage('display_name', Civi::settings()->get('display_name_format'), 'text/plain');
+      $tokenProcessor->evaluate();
+      $row = $tokenProcessor->getRow(0);
+      $sortName = trim($row->render('sort_name'));
+      $displayName = trim($row->render('display_name'));
     }
 
     //start further check for email.

--- a/tests/phpunit/CRM/Contact/BAO/IndividualTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/IndividualTest.php
@@ -118,8 +118,51 @@ class CRM_Contact_BAO_IndividualTest extends CiviUnitTestCase {
     CRM_Contact_BAO_Individual::format($params, $contact);
 
     $this->assertEquals("bleu02@example.com", $contact->display_name);
-    $this->assertEquals("bleu02@example.com", $contact->sort_name);
+    $this->assertEquals('bleu02@example.com', $contact->sort_name);
 
+  }
+
+  /**
+   * Display Format cases
+   */
+  public static function displayFormatCases(): array {
+    return [
+      'Nick name with tilde' => ['{contact.first_name}{ }{contact.last_name}{ ~ }{contact.nick_name}', TRUE, FALSE],
+      'Empty nick name' => ['{contact.first_name}{ }{contact.last_name}{ ~ }{contact.nick_name}', FALSE, FALSE],
+      'No Nick Name but Prefix' => ['{contact.individual_prefix}{ }{contact.first_name}{ }{contact.middle_name}{ }{contact.last_name}{ }{contact.individual_suffix}{ ~ }{contact.nick_name}', FALSE, TRUE],
+    ];
+  }
+
+  /**
+   * @dataProvider displayFormatCases
+   */
+  public function testGenerateDisplayNameCustomFormats(string $displayNameFormat, bool $includeNickName, bool $includePrefix): void {
+    $params = [
+      'contact_type' => 'Individual',
+      'first_name' => 'Michael',
+      'last_name' => 'Jackson',
+      'individual_prefix' => 'Mr.',
+      'individual_suffix' => 'Jr.',
+    ];
+    if ($includeNickName) {
+      $params['nick_name'] = 'Mick';
+    }
+    \Civi::settings()->set('display_name_format', $displayNameFormat);
+    $contact = new CRM_Contact_DAO_Contact();
+
+    CRM_Contact_BAO_Individual::format($params, $contact);
+    if ($includeNickName) {
+      $this->assertEquals('Michael Jackson ~ Mick', $contact->display_name);
+    }
+    else {
+      if ($includePrefix) {
+        $this->assertEquals('Mr. Michael Jackson Jr.', $contact->display_name);
+      }
+      else {
+        $this->assertEquals('Michael Jackson', $contact->display_name);
+      }
+    }
+    \Civi::settings()->set('display_name_format', \Civi::settings()->getDefault('display_name_format'));
   }
 
 }

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -364,11 +364,11 @@ Czech Republic
     $variants = [
       [
         'string' => '{contact.individual_prefix}{ }{contact.first_name}{ }{contact.middle_name}{ }{contact.last_name}{ }{contact.individual_suffix}',
-        'expected' => 'Mr. Anthony  Anderson II',
+        'expected' => 'Mr. Anthony Anderson II',
       ],
       [
         'string' => '{contact.prefix_id:label}{ }{contact.first_name}{ }{contact.middle_name}{ }{contact.last_name}{ }{contact.suffix_id:label}',
-        'expected' => 'Mr. Anthony  Anderson II',
+        'expected' => 'Mr. Anthony Anderson II',
       ],
     ];
     $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [


### PR DESCRIPTION


Overview
----------------------------------------
[REF] Use Token Processor to generate sort name and display name for individuals

Revives https://github.com/civicrm/civicrm-core/pull/25496

Before
----------------------------------------
Sort name, display name & labels not handled through the token processor

After
----------------------------------------
Soft name & display name moved over - I think we could do the same for labels


Technical Details
----------------------------------------
@seamuslee001 I had a go at bringing this back to life - I think it covers known / likely use cases without opening it up too much & hopefully gets us past the hurdle of obscure unknown possible use-cases blocking us fixing known gaps/ bugs & allows us to fix https://github.com/civicrm/civicrm-core/pull/28186 in a sane way

Comments
----------------------------------------
