### PR TITLE
SearchKit - Fix Search Segments for contact type entities

### DIFF
--- a/ext/search_kit/Civi/Api4/Service/Spec/Provider/SearchSegmentExtraFieldProvider.php
+++ b/ext/search_kit/Civi/Api4/Service/Spec/Provider/SearchSegmentExtraFieldProvider.php
@@ -62,6 +62,11 @@ class SearchSegmentExtraFieldProvider implements Generic\SpecProviderInterface {
       }
       foreach ($searchSegments as $set) {
         \Civi::$statics['all_search_segments'][$set['entity_name']]['segment_' . $set['name']] = $set;
+        if ($set['entity_name'] === 'Contact') {
+          foreach (\CRM_Contact_BAO_ContactType::basicTypes() as $contactType) {
+            \Civi::$statics['all_search_segments'][$contactType]['segment_' . $set['name']] = $set;
+          }
+        }
       }
     }
     return \Civi::$statics['all_search_segments'][$entity] ?? [];

--- a/ext/search_kit/tests/phpunit/api/v4/SearchSegment/SearchSegmentTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchSegment/SearchSegmentTest.php
@@ -6,6 +6,7 @@ use Civi\Api4\Contact;
 use Civi\Api4\Contribution;
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
+use Civi\Api4\Individual;
 use Civi\Api4\Relationship;
 use Civi\Api4\SearchSegment;
 use Civi\Test\HeadlessInterface;
@@ -245,7 +246,7 @@ class SearchSegmentTest extends \PHPUnit\Framework\TestCase implements HeadlessI
       ['birth_date' => 'now - 33 year - 1 month'],
       [],
     ];
-    Contact::save(FALSE)
+    Individual::save(FALSE)
       ->setRecords($sampleData)
       ->addChain('rel', Relationship::create()
         ->addValue('relationship_type_id', 1)
@@ -273,6 +274,11 @@ class SearchSegmentTest extends \PHPUnit\Framework\TestCase implements HeadlessI
         ],
       ])
       ->execute();
+
+    $field = Individual::getFields(FALSE)
+      ->addWhere('name', '=', 'segment_Age_Range')
+      ->execute()->single();
+    $this->assertEquals('Age Range', $field['label']);
 
     $params = [
       'checkPermissions' => FALSE,


### PR DESCRIPTION
Overview
----------------------------------------
Followup fix to https://github.com/civicrm/civicrm-core/pull/27659

A SearchSegment created for the Contact entity should also apply to Individual, Organization & Household entities.