### PR TITLE
[NFC] Pass correct param types to file_get_contents

### DIFF
--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -272,7 +272,7 @@ trait CRM_Contact_Form_Task_PDFTrait {
 
     if ($tee) {
       $tee->stop();
-      $content = file_get_contents($tee->getFileName(), NULL, NULL, NULL, 5);
+      $content = file_get_contents($tee->getFileName(), FALSE, NULL, 0, 5);
       if (empty($content)) {
         throw new \CRM_Core_Exception("Failed to capture document content (type=$type)!");
       }


### PR DESCRIPTION
For `file_get_contents` the argument signature is:

<img width="298" alt="Screenshot 2023-12-01 at 18 59 10" src="https://github.com/civicrm/civicrm-core/assets/1931323/10ba958d-623b-4670-b395-d5b317da6810">

We were passing `NULL` to `$use_include_path`, which is a non-nullable boolean, and `NULL` to `$offset` which is a non-nullable int.

I'm not sure passing `NULL` was actually causing any problems at the moment, but would likely start to do so in future versions of PHP - PHP internal function signatures are increasingly becoming more strictly typed.