### PR TITLE
ensure exception class supports getErrorData

### DIFF
--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -137,7 +137,7 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
       $status = $statusMap[get_class($e)] ?? 500;
       // Send error code (but don't overwrite success code if there are multiple calls and one was successful)
       $this->httpResponseCode = $this->httpResponseCode ?: $status;
-      if (CRM_Core_Permission::check('view debug output') || ($e->getErrorData()['show_detailed_error'] ?? FALSE)) {
+      if (CRM_Core_Permission::check('view debug output') || (method_exists($e, 'getErrorData') && ($e->getErrorData()['show_detailed_error'] ?? FALSE))) {
         $response['error_code'] = $e->getCode();
         $response['error_message'] = $e->getMessage();
         if (!empty($params['debug']) && CRM_Core_Permission::check('view debug output')) {


### PR DESCRIPTION
Overview
----------------------------------------
A recent change is to allow showing detailed errors to end users from AJAX where appropriate by adding a `show_detailed_error` param to the exception:

```
if (CRM_Core_Permission::check('view debug output') || ($e->getErrorData()['show_detailed_error'] ?? FALSE)) {
```

However, some AJAX API calls (notably `System.check` call Guzzle, and Guzzle exceptions don't have the `getErrorData()` method, so we never see the exception, we get a "method doesn't exist" message.

This adds a check that the method exists before calling it.

Before
----------------------------------------
Guzzle failures in `System.check` when called via AJAX API crashes on exception.

After
----------------------------------------
Guzzle failures in `System.check` when called via AJAX API are logged.

Comments
----------------------------------------
This feels messy to me and maybe it's in the wrong spot.  Is it possible to intercept a Guzzle exception with `catch` and then emit a `CRM_Core_Exception`? But this is better in than out.