### PR TITLE
Add getParticipantID() to register

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -963,6 +963,17 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
   }
 
   /**
+   * Get id of participant being acted on.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   */
+  public function getParticipantID(): ?int {
+    return $this->_participantId;
+  }
+
+  /**
    * Format user submitted price set params.
    *
    * Convert price set each param as an array.


### PR DESCRIPTION
Overview
----------------------------------------
Add getParticipantID() to register

Before
----------------------------------------
Cividiscount switched over to use these preferred methods  but online event form didn't have it - causing errors in cividisount - the fix is to add to master

After
----------------------------------------
Function exists where it should

Technical Details
----------------------------------------
I'm going to self merge this to reduce confusion - civi-discount is enabled by default by buildkit & is broken without this so let's fix quickly & not hurt people's heads

Comments
----------------------------------------
