### PR TITLE
 dev/core#4367 APi v4 Order api create action (basic implemention, apiv3 parity)

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -382,10 +382,7 @@ WHERE li.contribution_id = %1";
       return;
     }
 
-    foreach ($lineItems as $priceSetId => &$values) {
-      if (!$priceSetId) {
-        continue;
-      }
+    foreach ($lineItems as &$values) {
 
       foreach ($values as &$line) {
         if (empty($line['entity_table'])) {

--- a/Civi/Api4/Action/Order/Create.php
+++ b/Civi/Api4/Action/Order/Create.php
@@ -1,0 +1,71 @@
+<?php
+
+  /*
+   +--------------------------------------------------------------------+
+   | Copyright CiviCRM LLC. All rights reserved.                        |
+   |                                                                    |
+   | This work is published under the GNU AGPLv3 license with some      |
+   | permitted exceptions and without any warranty. For full license    |
+   | and copyright information, see https://civicrm.org/licensing       |
+   +--------------------------------------------------------------------+
+   */
+
+namespace Civi\Api4\Action\Order;
+
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Result;
+
+/**
+ *
+ * @method $this setContributionValues(array $contributionValues) Set contribution values.
+ * @method array getContributionValues() Get Contribution Values
+ */
+class Create extends AbstractAction {
+
+  /**
+   * Values corresponding to the contribution entity.
+   *
+   * @var array
+   */
+  protected $contributionValues;
+
+  protected $lineItems;
+
+  /**
+   * @param array $lineItem
+   *
+   * @return $this
+   */
+  public function addLineItem(array $lineItem): Create {
+    $this->lineItems[] = $lineItem;
+    return $this;
+  }
+
+  /**
+   * @param array $lineItems
+   *
+   * @return $this
+   */
+  public function setLineItems(array $lineItems): Create {
+    $this->lineItems = $lineItems;
+    return $this;
+  }
+
+  /**
+   * Run the api Action.
+   *
+   * @param \Civi\Api4\Generic\Result $result
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function _run(Result $result): void {
+    $order = new \CRM_Financial_BAO_Order();
+    $order->setDefaultFinancialTypeID($this->getContributionValues()['financial_type_id'] ?? NULL);
+
+    foreach ($this->lineItems as $index => $lineItem) {
+      $order->setLineItem($lineItem, $index);
+    }
+    $result = $order->save($this->getContributionValues());
+  }
+
+}

--- a/Civi/Api4/Order.php
+++ b/Civi/Api4/Order.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Api4;
+
+use Civi\Api4\Action\Order\Create;
+use Civi\Api4\Generic\BasicGetFieldsAction;
+
+/**
+ * Order manipulation
+ *
+ * Add and alter Orders in CiviCRM, with corresponding business logic.
+ *
+ * @searchable none
+ * @since 5.68
+ * @package Civi\Api4
+ */
+class Order extends Generic\AbstractEntity {
+
+  /**
+   * @param bool $checkPermissions
+   *
+   * @return \Civi\Api4\Action\Order\Create
+   */
+  public static function create(bool $checkPermissions = TRUE): Create {
+    return (new Create(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return Generic\BasicGetFieldsAction
+   */
+  public static function getFields(bool $checkPermissions = TRUE): BasicGetFieldsAction {
+    return (new Generic\BasicGetFieldsAction(__CLASS__, __FUNCTION__, function() {
+      return [];
+    }))->setCheckPermissions($checkPermissions);
+  }
+
+}

--- a/tests/phpunit/CRM/Financial/BAO/OrderTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/OrderTest.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\Api4\Contribution;
+use Civi\Api4\LineItem;
+use Civi\Api4\Order;
+use Civi\Api4\Participant;
+use Civi\Test\EventTestTrait;
+
+/**
+ * Class CRM_Financial_BAO_OrderTest
+ *
+ * @group headless
+ */
+class CRM_Financial_BAO_OrderTest extends CiviUnitTestCase {
+  use EventTestTrait;
+
+  public function tearDown(): void {
+    $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function testCreateOrderParticipantAndDonation(): void {
+    $this->eventCreatePaid();
+    $this->individualCreate();
+    Order::create()
+      ->setContributionValues([
+        'contact_id' => $this->ids['Contact']['individual_0'],
+        'financial_type_id' => 1,
+      ])
+      ->addLineItem([
+        'entity_table' => 'civicrm_participant',
+        'entity_id.event_id' => $this->getEventID(),
+        'entity_id.contact_id' => $this->ids['Contact']['individual_0'],
+        'financial_type_id' => 3,
+        'price_field_value_id' => $this->ids['PriceFieldValue']['PaidEvent_student_early'],
+      ])
+      ->execute();
+    $contribution = Contribution::get(FALSE)
+      ->addWhere('contact_id', '=', $this->ids['Contact']['individual_0'])
+      ->execute()->single();
+    $this->assertEquals(50, $contribution['total_amount']);
+    $lineItem = LineItem::get(FALSE)
+      ->addWhere('contribution_id', '=', $contribution['id'])
+      ->execute()->single();
+    $this->assertEquals('civicrm_participant', $lineItem['entity_table']);
+    $participant = Participant::get()
+      ->addWhere('id', '=', $lineItem['entity_id'])
+      ->execute()->single();
+    $this->assertEquals($this->ids['Contact']['individual_0'], $participant['contact_id']);
+
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This implements the basic outline of the apiv4 Order create api, providing parity with apiv3 but a different signature

Before
----------------------------------------
No apiv4 version of the order api

After
----------------------------------------
The api exists and largely has parity with Apiv3 Order create

Missing for parity
- [x] ~protection against passing in chaining on the entities to be created~ - not relevant - not possible via api v4
- [x] ~Handling for pseudoconstants - ie financial_type_id:name doesn't work at the moment~
- [ ] A check that the participant status is one of the pending statues as calculated via the participant status table
- [x] ~code to transfer contribution_recur_id from the contribution down to any membership~
-  [ ] adding line items to the return array

![image](https://github.com/civicrm/civicrm-core/assets/336308/0f387abe-c4da-4b99-b721-9cc0b51f9953)

There are a bunch of required & optional follow on tasks
- [ ] Review apiv3 parity items
- [ ] Add actions for `Order::addLineItem()`,  `Order::removeLineItem()`  `Order::modifyLineItem()`
- [ ] Add tests to ensure that more than one price set can be used in the same order & various usage variations
- [ ] Figure out & add tests for various apiv4 usages
- [ ] Add `Order:validate()` - this would cover things like verifying that the event has available places, - which @bjendres & @jensschuppe have been working to scope out ( ie we don't actually have a flow chart explaining what goes on here & it's really confusion)
- [ ] Potentialy call order.validate from Order.create, optionally
- [ ] Feature request - use mysql locks to ensure that once `validate` has confirmed a space is available another Order.api call in another php process can't steal it (this is likely to not work with code that doesn't call the order api itself).

Technical Details
----------------------------------------

A couple of Q& Aas raised in https://lab.civicrm.org/dev/core/-/issues/4367

1) "the `entity_id.` prefix is hard to read to me. Is it saying that this key refers to whatever entity is to be created by `entity_table`"
One of the api v4 principles has been to stick as close to the schema as possible - hence the use of `entity_id` & `entity_table` rather than anticipating that the entity would be `Participant` and creating a structure around that

2) "The api3 version has a thing that lets you describe multiple line items per related-entity. Are we getting rid of that?"

YES - that is not how the schema works - there is only one entity per line item in the schema & it was the primary reason why the nesting of arrays was so hard to figure out in apiv3

3) "will then return a representation of all the entities it created, along with all the data it calculated along the way? Would this be an extension of Api4\\Generic\\Result? would it have equivalent getters (getLineItems())? What would getArrayCopy() look like on the result? What would the array representation of Order.create call look like?" 

- All good questions. The apiv3 version adds the line items back onto the Contribution.create array before returning but I rather think that an extension of the Generic Result object makes sense. My understanding of `getArrayCopy()` is that it is the same as casting to an array - but I guess the question is more like 'what would the array structure look like & I'm expecting it to have contribution & line items (which would reveal the various entity IDs in the entity_id field) but not necessarily any thing else

4) I have all these good examples that are complex. My name is Matt & here they are https://lab.civicrm.org/dev/core/-/issues/4367#note_91607

Great - you are all in a room together at a sprint - I look forward to you hammering them out :-)


Comments
----------------------------------------
