### PR TITLE
dev/core#2998 - Fix JWT cookie test in standalone

### DIFF
--- a/ext/authx/tests/phpunit/Civi/Authx/AbstractFlowsTest.php
+++ b/ext/authx/tests/phpunit/Civi/Authx/AbstractFlowsTest.php
@@ -379,6 +379,7 @@ class AbstractFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndI
     $quirks = [
       'Joomla' => ['sendsExcessCookies', 'authErrorShowsForm'],
       'WordPress' => ['sendsExcessCookies'],
+      'Standalone' => ['sendsExcessCookies'],
     ];
     return $quirks[CIVICRM_UF] ?? [];
   }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a test failure in JwtCredsTest with standalone due to session cookies being sent.

Before
----------------------------------------
Test fails with `Response should not have cookies [...]` due to a missing cookie quirk for standalone.

After
----------------------------------------
Test fails for other reasons. 🥳 

