### PR TITLE
LocalizedDataTest - Fix for standalone

### DIFF
--- a/tests/phpunit/E2E/Core/LocalizedDataTest.php
+++ b/tests/phpunit/E2E/Core/LocalizedDataTest.php
@@ -57,6 +57,7 @@ class LocalizedDataTest extends \CiviEndToEndTestCase {
       'WordPress' => [$this, '_getSqlFile'],
       'Backdrop' => [$this, '_getSqlFile'],
       'Joomla' => [$this, '_getSqlFile'],
+      'Standalone' => [$this, '_getSqlFile'],
     ];
     if (isset($installerTypes[$uf])) {
       return $installerTypes[$uf];


### PR DESCRIPTION
Overview
----------------------------------------

Test fails on `Standalone` because it has some tuning-bits for all UFs except `Standalone`.

Before
----------------------------------------

Ignorance


After
----------------------------------------

Revelation

