### PR TITLE
LegacyRestTest - No need to test `extern/rest.php` on `Standalone`

### DIFF
--- a/tests/phpunit/E2E/Extern/LegacyRestTest.php
+++ b/tests/phpunit/E2E/Extern/LegacyRestTest.php
@@ -16,9 +16,11 @@
  */
 class E2E_Extern_LegacyRestTest extends E2E_Extern_BaseRestTest {
 
+  protected $LEGACY_EXTERN_SUPPORTED = ['Drupal', 'Backdrop', 'Joomla', 'WordPress'];
+
   protected function setUp(): void {
-    if (CIVICRM_UF === 'Drupal8') {
-      $this->markTestSkipped('Legacy extern/rest.php does not apply to Drupal 8+');
+    if (!in_array(CIVICRM_UF, $this->LEGACY_EXTERN_SUPPORTED)) {
+      $this->markTestSkipped('Legacy extern/rest.php is not supported by ' . CIVICRM_UF);
     }
     parent::setUp();
   }


### PR DESCRIPTION
Overview
----------------------------------------

Test checks whether the old `extern/rest.php` entry-point is working. This entry-point is only needed for continuity on existing configurations that rely upon `extern/rest.php`. We don't need it on `Standalone`.

