### PR TITLE
"Fix" test fail E2E_Extern_WidgetTest::testWidget by skipping it

### DIFF
--- a/tests/phpunit/E2E/Extern/WidgetTest.php
+++ b/tests/phpunit/E2E/Extern/WidgetTest.php
@@ -26,7 +26,8 @@ class E2E_Extern_WidgetTest extends CiviEndToEndTestCase {
    * Return widget Javascript.
    */
   public function testWidget(): void {
-    if (CIVICRM_UF !== 'Drupal8') {
+    if (!in_array(CIVICRM_UF, ['Drupal8', 'Standalone'])) {
+      // Skip the traditional tests for Drupal8+ and Standalone as these are unsupported.
       $endpoints['traditional'] = CRM_Core_Resources::singleton()->getUrl('civicrm', 'extern/widget.php');
     }
     $endpoints['normal'] = CRM_Utils_System::url('civicrm/contribute/widget', NULL, TRUE, NULL, FALSE, TRUE);


### PR DESCRIPTION
Drupal8+ does not support the extern widgets, so we do the same for standalone.

As agreed with @totten

This fixes the test showing as failed at

https://test.civicrm.org/job/CiviCRM-E2E-Matrix/BKPROF=min,BLDTYPE=standalone-clean,CIVIVER=master,label=bknix-tmp/lastCompletedBuild/testReport/(root)/E2E_Extern_WidgetTest/testWidget/