### PR TITLE
standalone - set explicit userID=0 for anon user

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -48,6 +48,19 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
   }
 
   /**
+   * @inheritDoc
+   */
+  public function sessionStart() {
+    parent::sessionStart();
+
+    // for anonymous user sessions we need to set explicit 0 rather than NULL
+    $session = CRM_Core_Session::singleton();
+    if (!$session->get('userID')) {
+      $session->set('userID', 0);
+    }
+  }
+
+  /**
    * @inheritdoc
    */
   public function getDefaultFileStorage() {


### PR DESCRIPTION
Overview
----------------------------------------
Sets an explicit 0 for the userID when starting a new session as this is expected for anonymous users.

Before
----------------------------------------
At least one test fails where it's assuming it will get 0 for anonymous user: `E2E\Core\PathUrlTest.testUrl`

Maybe some stuff that isn't tests fails too?

After
----------------------------------------
The `E2E\Core\PathUrlTest.testUrl` will still fail because it needs some standalone specific urls - coming soon.

Technical Details
----------------------------------------
Whole session storage to go to DB tables but hopefully gets some tests green first :)
