### PR TITLE
[REF][PHP8.2] Declare properties in CRM_Activity_Page_Tab

### DIFF
--- a/CRM/Activity/Page/Tab.php
+++ b/CRM/Activity/Page/Tab.php
@@ -21,6 +21,20 @@
 class CRM_Activity_Page_Tab extends CRM_Core_Page {
 
   /**
+   * Case ID, passed in via query param.
+   *
+   * @var int
+   */
+  public $_caseId;
+
+  /**
+   * Contact ID, passed in via query param
+   *
+   * @var int
+   */
+  public $_contactId;
+
+  /**
    * Browse all activities for a particular contact.
    */
   public function browse() {
@@ -111,7 +125,7 @@ class CRM_Activity_Page_Tab extends CRM_Core_Page {
     $this->assign('contactID', $this->_contactId);
 
     // check logged in url permission
-    CRM_Contact_Page_View::checkUserPermission($this);
+    CRM_Contact_Page_View::checkUserPermission($this, $this->_contactId);
 
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
     $this->assign('action', $this->_action);


### PR DESCRIPTION
Overview
----------------------------------------
Declare properties in `CRM_Activity_Page_Tab`

Before
----------------------------------------
Dynamic properties were causing test failures on PHP 8.2

After
----------------------------------------
Properties declared.

Technical Details
----------------------------------------
I was a little unsure whether to go `protected` or `public` here. In the end I went `public` to ensure backwards compatiabilty, but updated `checkUserPermission` to explicitly pass in the property, to make it clearer how `_contactId` is being used.