### PR TITLE
[REF][PHP8.2] Remove unused dynamic property

### DIFF
--- a/CRM/Admin/Page/Job.php
+++ b/CRM/Admin/Page/Job.php
@@ -120,9 +120,6 @@ class CRM_Admin_Page_Job extends CRM_Core_Page_Basic {
     $this->_action = CRM_Utils_Request::retrieve('action', 'String',
       $this, FALSE, 0
     );
-    $this->_context = CRM_Utils_Request::retrieve('context', 'String',
-      $this, FALSE, 0
-    );
 
     if (($this->_action & CRM_Core_Action::COPY) && (!empty($this->_id))) {
       try {


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused dynamic property `_context` from `CRM_Admin_Page_Job`

Before
----------------------------------------
`_context` was declared dynamically, causing deprecation warnings, and resulting in test failures on PHP 8.2.

After
----------------------------------------
`_context` is removed.

Technical Details
----------------------------------------
I can see no reference to `_context` being used in `CRM_Admin_Page_Job`. Furthermore, I've reviewed any links to `crm/admin/job` and `civicrm/admin/job/edit`, and can not see any case where a `?context` query argument is passed with the URL. Therefore, this looks safe to remove.