### PR TITLE
 Applies accessible accordion to Activity Search

### DIFF
--- a/templates/CRM/Activity/Form/Search.tpl
+++ b/templates/CRM/Activity/Form/Search.tpl
@@ -9,10 +9,10 @@
 *}
 {* Search form and results for Activities *}
 <div class="crm-form-block crm-search-form-block">
-  <div class="crm-accordion-wrapper crm-advanced_search_form-accordion {if $rows}collapsed{/if}">
-    <div class="crm-accordion-header crm-master-accordion-header">
+  <details class="crm-accordion-wrapper crm-advanced_search_form-accordion" open="">
+    <summary class="crm-accordion-header crm-master-accordion-header">
       {ts}Edit Search Criteria{/ts}
-    </div>
+    </summary>
     <!-- /.crm-accordion-header -->
     <div class="crm-accordion-body">
       <div id="searchForm" class="form-item">
@@ -41,7 +41,7 @@
         {/strip}
       </div>
     </div>
-  </div>
+  </details>
 </div>
 
 {if $rowsEmpty || $rows}


### PR DESCRIPTION
Overview
----------------------------------------
Following this issue https://lab.civicrm.org/dev/core/-/issues/3294 and the addition of support for `<details>` in https://github.com/civicrm/civicrm-core/pull/28415 - this PR changes the Accordions in Activity Search.

Before
----------------------------------------
Accordions in Activity Search cannot be open/closed with the keyboard.
<img width="904" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/e5b9d496-9a83-4739-801a-3f898451e590">

After
----------------------------------------
They can be:
<img width="1103" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/0fe19efc-c2f5-4d43-85a3-3ef6ad8560c9">

Comments
----------------------------------------
Don't merge this before https://github.com/civicrm/civicrm-core/pull/28418. Consequences for themes (duplicate expand/collapse icons) are described in #28415.