### PR TITLE
DRAFT: getLoggedInContactID should always return 0 rather than null if no logged in user

### DIFF
--- a/CRM/ACL/API.php
+++ b/CRM/ACL/API.php
@@ -46,12 +46,6 @@ class CRM_ACL_API {
     if ($contactID == NULL) {
       $contactID = CRM_Core_Session::getLoggedInContactID();
     }
-
-    if (!$contactID) {
-      // anonymous user
-      $contactID = 0;
-    }
-
     return CRM_ACL_BAO_ACL::check($str, $contactID);
   }
 

--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2239,7 +2239,7 @@ AND cl.modified_id  = c.id
    * @return array
    */
   protected static function getPermittedActivityTypes() {
-    $userID = (int) CRM_Core_Session::getLoggedInContactID();
+    $userID = CRM_Core_Session::getLoggedInContactID();
     if (!isset(Civi::$statics[__CLASS__]['permitted_activity_types'][$userID])) {
       $permittedActivityTypes = [];
       $components = self::activityComponents(FALSE);

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -3042,7 +3042,7 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
   }
 
   private static function getAccessMyCasesClause(int $userId = NULL): string {
-    $user = $userId ?? (int) CRM_Core_Session::getLoggedInContactID();
+    $user = $userId ?? CRM_Core_Session::getLoggedInContactID();
     return "IN (
       SELECT r.case_id FROM civicrm_relationship r, civicrm_case_contact cc WHERE r.is_active = 1 AND cc.case_id = r.case_id AND (
         (r.contact_id_a = cc.contact_id AND r.contact_id_b = $user) OR (r.contact_id_b = cc.contact_id AND r.contact_id_a = $user)

--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -92,7 +92,7 @@ class CRM_Contact_BAO_Contact_Permission {
 
     // get logged in user
     $contactID = CRM_Core_Session::getLoggedInContactID();
-    if (empty($contactID)) {
+    if (!$contactID) {
       return [];
     }
 
@@ -327,7 +327,7 @@ AND    $operationClause
       }
     }
 
-    $contactID = (int) CRM_Core_Session::getLoggedInContactID();
+    $contactID = CRM_Core_Session::getLoggedInContactID();
     self::cache($contactID);
 
     if (is_array($contactAlias) && !empty($contactAlias)) {
@@ -360,7 +360,7 @@ AND    $operationClause
    */
   public static function cacheSubquery() {
     if (!CRM_Core_Permission::check([['view all contacts', 'edit all contacts']])) {
-      $contactID = (int) CRM_Core_Session::getLoggedInContactID();
+      $contactID = CRM_Core_Session::getLoggedInContactID();
       self::cache($contactID);
       return "IN (SELECT contact_id FROM civicrm_acl_contact_cache WHERE user_id = $contactID)";
     }

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1271,7 +1271,7 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = c.contact_id )
       'details' => $message,
       'subject' => ts('Payment failed at payment processor'),
       'source_record_id' => $contributionID,
-      'source_contact_id' => CRM_Core_Session::getLoggedInContactID() ? CRM_Core_Session::getLoggedInContactID() : $contactID,
+      'source_contact_id' => CRM_Core_Session::getLoggedInContactID() ?: $contactID,
     ]);
 
     // CRM-20336 Make sure that the contribution status is Failed, not Pending.

--- a/CRM/Core/BAO/Note.php
+++ b/CRM/Core/BAO/Note.php
@@ -540,7 +540,7 @@ WHERE participant.contact_id = %1 AND  note.entity_table = 'civicrm_participant'
     // Enforce note privacy setting
     if (!CRM_Core_Permission::check('view all notes', $userId)) {
       // It was ok to have $userId = NULL for the permission check but must be an int for the query
-      $cid = $userId ?? (int) CRM_Core_Session::getLoggedInContactID();
+      $cid = $userId ?? CRM_Core_Session::getLoggedInContactID();
       $clauses['privacy'] = [
         [
           '= 0',

--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -160,7 +160,7 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements HookInterface
     $clauses = [];
     if (!\CRM_Core_Permission::check('administer queues', $userId)) {
       // It was ok to have $userId = NULL for the permission check but must be an int for the query
-      $cid = $userId ?? (int) CRM_Core_Session::getLoggedInContactID();
+      $cid = $userId ?? CRM_Core_Session::getLoggedInContactID();
       // Only allow access to users' own jobs (or templates)
       $clauses['created_id'][] = "= $cid OR {is_template} = 1";
     }

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2521,7 +2521,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     if ($this->authenticatedContactID === NULL) {
       $this->authenticatedContactID = $this->getAuthenticatedCheckSumContactID();
       if (!$this->authenticatedContactID) {
-        $this->authenticatedContactID = (int) CRM_Core_Session::getLoggedInContactID();
+        $this->authenticatedContactID = CRM_Core_Session::getLoggedInContactID();
       }
     }
     return $this->authenticatedContactID;

--- a/CRM/Core/Resources/Common.php
+++ b/CRM/Core/Resources/Common.php
@@ -177,7 +177,7 @@ class CRM_Core_Resources_Common {
    */
   protected static function coreResourceList($region) {
     $settings = Civi::settings();
-    $contactID = (int) CRM_Core_Session::getLoggedInContactID();
+    $contactID = CRM_Core_Session::getLoggedInContactID();
 
     // Scripts needed by everyone, everywhere
     // FIXME: This is too long; list needs finer-grained segmentation

--- a/CRM/Core/Session.php
+++ b/CRM/Core/Session.php
@@ -547,13 +547,13 @@ class CRM_Core_Session {
   /**
    * Retrieve contact id of the logged in user.
    *
-   * @return int|null
-   *   contact ID of logged in user
+   * @return int
+   *   contact ID of logged in user OR 0 if no logged-in user
    */
   public static function getLoggedInContactID() {
     $session = CRM_Core_Session::singleton();
     if (!is_numeric($session->get('userID'))) {
-      return NULL;
+      return 0;
     }
     return (int) $session->get('userID');
   }

--- a/CRM/Queue/BAO/Queue.php
+++ b/CRM/Queue/BAO/Queue.php
@@ -23,7 +23,7 @@ class CRM_Queue_BAO_Queue extends CRM_Queue_DAO_Queue implements \Civi\Core\Hook
   public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
     $clauses = [];
     if (!\CRM_Core_Permission::check('administer queues')) {
-      $cid = (int) CRM_Core_Session::getLoggedInContactID();
+      $cid = CRM_Core_Session::getLoggedInContactID();
       $clauses['id'] = "IN (SELECT queue_id FROM `civicrm_user_job` WHERE created_id = $cid)";
     }
     CRM_Utils_Hook::selectWhereClause($this, $clauses, $userId, $conditions);

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -651,7 +651,7 @@ abstract class CRM_Utils_Hook {
   public static function selectWhereClause($entity, array &$clauses, int $userId = NULL, array $conditions = []): void {
     $entityName = is_object($entity) ? CRM_Core_DAO_AllCoreTables::getBriefName(get_class($entity)) : $entity;
     $null = NULL;
-    $userId = $userId ?? (int) CRM_Core_Session::getLoggedInContactID();
+    $userId = $userId ?? CRM_Core_Session::getLoggedInContactID();
     self::singleton()->invoke(['entity', 'clauses', 'userId', 'conditions'],
       $entityName, $clauses, $userId, $conditions,
       $null, $null,

--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -225,7 +225,7 @@ class Kernel {
    */
   public function authorize($apiProvider, $apiRequest) {
     /** @var \Civi\API\Event\AuthorizeEvent $event */
-    $event = $this->dispatcher->dispatch('civi.api.authorize', new AuthorizeEvent($apiProvider, $apiRequest, $this, \CRM_Core_Session::getLoggedInContactID() ?: 0));
+    $event = $this->dispatcher->dispatch('civi.api.authorize', new AuthorizeEvent($apiProvider, $apiRequest, $this, \CRM_Core_Session::getLoggedInContactID()));
     if (!$event->isAuthorized()) {
       throw new \Civi\API\Exception\UnauthorizedException("Authorization failed");
     }

--- a/Civi/Api4/Action/WorkflowMessage/Render.php
+++ b/Civi/Api4/Action/WorkflowMessage/Render.php
@@ -141,7 +141,7 @@ class Render extends \Civi\Api4\Generic\AbstractAction {
       foreach ($fields as $fieldName => $fieldSpec) {
         $fieldValue = $record[$fieldName] ?? NULL;
         if ($fieldSpec->getFkEntity() && !empty($fieldValue)) {
-          if (!empty($params['check_permissions']) && !\Civi\Api4\Utils\CoreUtil::checkAccessDelegated($fieldSpec->getFkEntity(), 'get', ['id' => $fieldValue], CRM_Core_Session::getLoggedInContactID() ?: 0)) {
+          if (!empty($params['check_permissions']) && !\Civi\Api4\Utils\CoreUtil::checkAccessDelegated($fieldSpec->getFkEntity(), 'get', ['id' => $fieldValue], CRM_Core_Session::getLoggedInContactID())) {
             $e->addError($recordKey, $fieldName, 'nonexistent_id', ts('Referenced record does not exist or is not visible (%1).', [
               1 => $this->getWorkflow() . '::' . $fieldName,
             ]));

--- a/Civi/Api4/Event/ActiveUserTrait.php
+++ b/Civi/Api4/Event/ActiveUserTrait.php
@@ -19,7 +19,7 @@ trait ActiveUserTrait {
    * @return $this
    */
   protected function setUser(int $userID) {
-    $loggedInContactID = \CRM_Core_Session::getLoggedInContactID() ?: 0;
+    $loggedInContactID = \CRM_Core_Session::getLoggedInContactID();
     if ($userID !== $loggedInContactID) {
       throw new \RuntimeException("The API subsystem does not yet fully support variable user IDs.");
       // Traditionally, the API events did not emit information about the current user; it was assumed

--- a/Civi/Api4/Generic/AbstractCreateAction.php
+++ b/Civi/Api4/Generic/AbstractCreateAction.php
@@ -46,7 +46,7 @@ abstract class AbstractCreateAction extends AbstractAction {
       throw new \CRM_Core_Exception("Mandatory values missing from Api4 {$this->getEntityName()}::{$this->getActionName()}: " . implode(", ", $unmatched), "mandatory_missing", ["fields" => $unmatched]);
     }
 
-    if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $this->getValues(), \CRM_Core_Session::getLoggedInContactID() ?: 0)) {
+    if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $this->getValues(), \CRM_Core_Session::getLoggedInContactID())) {
       throw new UnauthorizedException("ACL check failed");
     }
 

--- a/Civi/Api4/Generic/AbstractSaveAction.php
+++ b/Civi/Api4/Generic/AbstractSaveAction.php
@@ -92,7 +92,7 @@ abstract class AbstractSaveAction extends AbstractAction {
     if ($this->checkPermissions) {
       foreach ($this->records as $record) {
         $action = empty($record[$idField]) ? 'create' : 'update';
-        if (!CoreUtil::checkAccessDelegated($this->getEntityName(), $action, $record, \CRM_Core_Session::getLoggedInContactID() ?: 0)) {
+        if (!CoreUtil::checkAccessDelegated($this->getEntityName(), $action, $record, \CRM_Core_Session::getLoggedInContactID())) {
           throw new UnauthorizedException("ACL check failed");
         }
       }

--- a/Civi/Api4/Generic/AbstractUpdateAction.php
+++ b/Civi/Api4/Generic/AbstractUpdateAction.php
@@ -87,7 +87,7 @@ abstract class AbstractUpdateAction extends AbstractBatchAction {
     // Update a single record by primary key (if this entity has a single primary key)
     if (count($this->where) === 1 && count($primaryKeys) === 1 && $primaryKeys === $this->getSelect() && $this->where[0][0] === $id && $this->where[0][1] === '=' && !empty($this->where[0][2])) {
       $this->values[$id] = $this->where[0][2];
-      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $this->values, \CRM_Core_Session::getLoggedInContactID() ?: 0)) {
+      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $this->values, \CRM_Core_Session::getLoggedInContactID())) {
         throw new UnauthorizedException("ACL check failed");
       }
       $items = [$this->values];
@@ -100,7 +100,7 @@ abstract class AbstractUpdateAction extends AbstractBatchAction {
     $items = $this->getBatchRecords();
     foreach ($items as &$item) {
       $item = $this->values + $item;
-      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $item, \CRM_Core_Session::getLoggedInContactID() ?: 0)) {
+      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $item, \CRM_Core_Session::getLoggedInContactID())) {
         throw new UnauthorizedException("ACL check failed");
       }
     }

--- a/Civi/Api4/Generic/BasicBatchAction.php
+++ b/Civi/Api4/Generic/BasicBatchAction.php
@@ -71,7 +71,7 @@ class BasicBatchAction extends AbstractBatchAction {
   public function _run(Result $result) {
     $items = $this->getBatchRecords();
     foreach ($items as $item) {
-      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $item, \CRM_Core_Session::getLoggedInContactID() ?: 0)) {
+      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $item, \CRM_Core_Session::getLoggedInContactID())) {
         throw new UnauthorizedException("ACL check failed");
       }
     }

--- a/Civi/Api4/Generic/CheckAccessAction.php
+++ b/Civi/Api4/Generic/CheckAccessAction.php
@@ -47,7 +47,7 @@ class CheckAccessAction extends AbstractAction {
       $granted = TRUE;
     }
     else {
-      $granted = CoreUtil::checkAccessDelegated($this->getEntityName(), $this->action, $this->values, \CRM_Core_Session::getLoggedInContactID() ?: 0);
+      $granted = CoreUtil::checkAccessDelegated($this->getEntityName(), $this->action, $this->values, \CRM_Core_Session::getLoggedInContactID());
     }
     $result->exchangeArray([['access' => $granted]]);
   }

--- a/Civi/Api4/Generic/DAODeleteAction.php
+++ b/Civi/Api4/Generic/DAODeleteAction.php
@@ -39,7 +39,7 @@ class DAODeleteAction extends AbstractBatchAction {
       $idField = CoreUtil::getIdFieldName($this->getEntityName());
       foreach ($items as $key => $item) {
         // Don't pass the entire item because only the id is a trusted value
-        if (!CoreUtil::checkAccessRecord($this, [$idField => $item[$idField]], \CRM_Core_Session::getLoggedInContactID() ?: 0)) {
+        if (!CoreUtil::checkAccessRecord($this, [$idField => $item[$idField]], \CRM_Core_Session::getLoggedInContactID())) {
           throw new UnauthorizedException("ACL check failed");
         }
         $items[$key]['check_permissions'] = TRUE;

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -213,7 +213,7 @@ function _civicrm_api3_contribution_create_legacy_support_45(&$params) {
 function civicrm_api3_contribution_delete($params) {
 
   $contributionID = !empty($params['contribution_id']) ? $params['contribution_id'] : $params['id'];
-  if (!empty($params['check_permissions']) && !\Civi\Api4\Utils\CoreUtil::checkAccessDelegated('Contribution', 'delete', ['id' => $contributionID], CRM_Core_Session::getLoggedInContactID() ?: 0)) {
+  if (!empty($params['check_permissions']) && !\Civi\Api4\Utils\CoreUtil::checkAccessDelegated('Contribution', 'delete', ['id' => $contributionID], CRM_Core_Session::getLoggedInContactID())) {
     throw new CRM_Core_Exception('You do not have permission to delete this contribution');
   }
   if (CRM_Contribute_BAO_Contribution::deleteContribution($contributionID)) {

--- a/ext/civiimport/Civi/Api4/Import/CheckAccessAction.php
+++ b/ext/civiimport/Civi/Api4/Import/CheckAccessAction.php
@@ -32,7 +32,7 @@ class CheckAccessAction extends \Civi\Api4\Generic\CheckAccessAction {
     // Prevent circular checks
     $action = $this->action;
     $entity = $this->getEntityName();
-    $userID = \CRM_Core_Session::getLoggedInContactID() ?: 0;
+    $userID = \CRM_Core_Session::getLoggedInContactID();
     if ($action === 'checkAccess') {
       $granted = TRUE;
     }


### PR DESCRIPTION
Overview
----------------------------------------
Always return explicit 0 from `getLoggedInContactID` if no logged-in user.

Before
----------------------------------------
On at least Drupal, the session provides an anonymous user session with userID set to 0 - so this will return 0 anyway.

On Standalone there's currently no userID in the session for anonymous user, which causes `E2E\Core\PathUrlTest.testUrl ` to fail.

After
----------------------------------------
Hopefully no `NULL` vs `0` issues. We can trust it to be an int and don't have to cast it a bunch of times.

Technical details
---------------------------------------
Have tried to look through all the calls to getLoggedInContactID to find anywhere which might expect `NULL` for some reason. There's a bunch of places where NULL looks like it would be bad...
