### PR TITLE
Update language download during install to use existing folder if present

### DIFF
--- a/setup/plugins/installFiles/l10nDownload.civi-setup.php
+++ b/setup/plugins/installFiles/l10nDownload.civi-setup.php
@@ -55,7 +55,9 @@ if (!defined('CIVI_SETUP')) {
       }
       if (!is_dir($e->getModel()->paths['civicrm.l10n']['path'])) {
         \Civi\Setup::log()->info("Creating directory: " . $e->getModel()->paths['civicrm.l10n']['path']);
-        \CRM_Utils_File::createDir($e->getModel()->paths['civicrm.l10n']['path'], FALSE);
+        if (!mkdir($e->getModel()->paths['civicrm.l10n']['path'], 0777, TRUE)) {
+          $e->addError('system', 'l10nWritable', sprintf('Unable to create l10n directory "%s"', $e->getModel()->paths['civicrm.l10n']['path']));
+        }
       }
     }
   }, \Civi\Setup::PRIORITY_MAIN);
@@ -67,7 +69,9 @@ if (!defined('CIVI_SETUP')) {
       $downloadDir = $e->getModel()->paths['civicrm.l10n']['path'] . DIRECTORY_SEPARATOR . $lang . DIRECTORY_SEPARATOR . 'LC_MESSAGES';
       if (!is_dir($downloadDir)) {
         \Civi\Setup::log()->info("Creating directory: " . $downloadDir);
-        \CRM_Utils_File::createDir($downloadDir, FALSE);
+        if (!mkdir($downloadDir, 0777, TRUE)) {
+          $e->addError('system', 'l10nWritable', sprintf('Unable to create language directory "%s"', $downloadDir));
+        }
 
         foreach ($e->getModel()->moFiles as $moFile => $url) {
           $l10DownloadFile = str_replace('[locale]', $lang, $url);

--- a/setup/plugins/installFiles/l10nDownload.civi-setup.php
+++ b/setup/plugins/installFiles/l10nDownload.civi-setup.php
@@ -68,18 +68,18 @@ if (!defined('CIVI_SETUP')) {
       if (!is_dir($downloadDir)) {
         \Civi\Setup::log()->info("Creating directory: " . $downloadDir);
         \CRM_Utils_File::createDir($downloadDir, FALSE);
-      }
 
-      foreach ($e->getModel()->moFiles as $moFile => $url) {
-        $l10DownloadFile = str_replace('[locale]', $lang, $url);
-        \Civi\Setup::log()
-          ->info("Download translation '.$moFile.' from " . $l10DownloadFile . ' into ' . $downloadDir);
-        $client = new \GuzzleHttp\Client();
-        $response = $client->get($l10DownloadFile);
-        if ($response->getStatusCode() == 200) {
-          $success = file_put_contents($downloadDir . DIRECTORY_SEPARATOR . $moFile, $response->getBody());
-          if (!$success) {
-            $e->addError('l10n', 'download', 'Unable to download translation file');
+        foreach ($e->getModel()->moFiles as $moFile => $url) {
+          $l10DownloadFile = str_replace('[locale]', $lang, $url);
+          \Civi\Setup::log()
+            ->info("Download translation '.$moFile.' from " . $l10DownloadFile . ' into ' . $downloadDir);
+          $client = new \GuzzleHttp\Client();
+          $response = $client->get($l10DownloadFile);
+          if ($response->getStatusCode() == 200) {
+            $success = file_put_contents($downloadDir . DIRECTORY_SEPARATOR . $moFile, $response->getBody());
+            if (!$success) {
+              $e->addError('l10n', 'download', 'Unable to download translation file');
+            }
           }
         }
       }

--- a/setup/plugins/installFiles/l10nDownload.civi-setup.php
+++ b/setup/plugins/installFiles/l10nDownload.civi-setup.php
@@ -76,7 +76,7 @@ if (!defined('CIVI_SETUP')) {
         foreach ($e->getModel()->moFiles as $moFile => $url) {
           $l10DownloadFile = str_replace('[locale]', $lang, $url);
           \Civi\Setup::log()
-            ->info("Download translation '.$moFile.' from " . $l10DownloadFile . ' into ' . $downloadDir);
+            ->info("Download translation '$moFile' from " . $l10DownloadFile . ' into ' . $downloadDir);
           $client = new \GuzzleHttp\Client();
           $response = $client->get($l10DownloadFile);
           if ($response->getStatusCode() == 200) {


### PR DESCRIPTION
Overview
----------------------------------------
For example if you pre-install the language files somewhere else, the install process downloads another copy elsewhere unless you reconfigure your install script.

e.g. The demo builds are currently popping up a status check saying it has two l10n folders.

Before
----------------------------------------
It ALWAYS creates and downloads the folder.

After
----------------------------------------
1. It will look for an existing folder and use that to determine how to set the l10n folder.
2. Once the path is chosen, it won't re-download the given language if it's already downloaded in that location.

Note there are two steps involved: How to determine the l10n location, and whether to download.

Technical Details
----------------------------------------
Commit 1 looks messy but is mostly the same as before except that it additionally checks if the folder exists and if it doesn't goes on to the next candidate. The preferred order of how it ends up setting `['civicrm.l10n']` is the same as before though:
* If you've somehow worked around [some limitations](https://github.com/civicrm/cv/issues/183) and managed to set `['civicrm.l10n']` already, that's the first choice.
* If CIVICRM_L10N_BASEDIR is set either via `define` or environment variable, that's the second choice.
* `['civicrm.private']` is the third choice.
* The old-timey "standard" location of the civicrm root is the last choice.

Commit 2 is straightforward if viewed without whitespace. It just now only downloads if the language subfolder doesn't already exist.

Commits 3 and 4 are just extra.

Comments
----------------------------------------
Some examples:
1. Installing via the new UI installer on a brand new setup with no additional setup: It will create and download in sites/default/files/civicrm/l10n (or cms equivalent).
2. Ditto for cv.
3. `CIVICRM_L10N_BASEDIR=/path/to/l10n cv core:install --lang=aa_AA ...` will check if `/path/to/l10n` in exists, and if it does will use that, and if not will use sites/default/files/civicrm/l10n. Then, if the aa_AA lang is already downloaded in the determined location, it won't download again.
4. You've already somehow got the language files in civicrm_root/l10n, but then you create some other folder `/path/to/l10n` and you run `CIVICRM_L10N_BASEDIR=/path/to/l10n cv core:install --lang=aa_AA ...`. It will use `/path/to/l10n` and download another copy there. The existing status check will tell you about it and you can decide what to do.
5. You've already somehow got the language files in civicrm_root/l10n, and you run `cv core:install --lang=aa_AA ...`. It will use the files you already have in civicrm_root/l10n.
