### PR TITLE
Standalone - set default value to active when adding new user role

### DIFF
--- a/ext/standaloneusers/ang/afformEditRole.aff.html
+++ b/ext/standaloneusers/ang/afformEditRole.aff.html
@@ -4,7 +4,7 @@
     <af-field name="name" />
     <af-field name="label" />
     <af-field name="permissions" />
-    <af-field name="is_active" />
+    <af-field name="is_active" defn="{afform_default: '1', input_attrs: {}}" />
   </fieldset>
   <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()">Submit</button>
 </af-form>


### PR DESCRIPTION
Overview
----------------------------------------
When a user creates a new user role, the `is_active` field should be set to true by default.

Before
----------------------------------------

`is_active` tickbox is unticked.

After
----------------------------------------

`is_active` tickbox is ticked.

Comments
----------------------------------------
Even though the tickbox is unticked currently the user role would still be set to active by default which is confusing to the user. 
