### PR TITLE
Standalone - bootstrap script fixes

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -313,15 +313,13 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
 
     if (!isset($runOnce)) {
       $runOnce = TRUE;
+    }
+    else {
       return TRUE;
     }
 
-    $root = rtrim($this->cmsRootPath(), '/' . DIRECTORY_SEPARATOR);
-    if (empty($root) || !is_dir($root) || !chdir($root)) {
-      return FALSE;
-    }
-
-    require_once $root . '/../vendor/autoload.php'; /* assumes $root to be the _web_ root path, not the project root path. */
+    global $civicrm_paths;
+    require_once $civicrm_paths['civicrm.vendor']['path'] . '/autoload.php';
 
     // seems like we've bootstrapped drupal
     $config = CRM_Core_Config::singleton();
@@ -352,7 +350,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
       // if given username we expect a correct password.
       $user = $security->loadUserByName($params['name']);
       if ($user) {
-        if (!$security->checkPassword($params['pass'], $user['password'] ?? '')) {
+        if (!$security->checkPassword($params['pass'], $user['hashed_password'] ?? '')) {
           return FALSE;
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a few broken bits of Standalone::loadBootStrap so that admin user can be logged in for tests like `E2E\Core\PrevNextTest.testFillSql `

Before
----------------------------------------
The bootstrap script exits as soon as it has checked it's never been run before

After
----------------------------------------
The bootstrap script runs once and logs in user if passed in the params.

