### PR TITLE
dev/core#2998 - Fix standalone throwing exception when fetching unkno…

### DIFF
--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -81,7 +81,7 @@ class Security {
     return \Civi\Api4\User::get(FALSE)
       ->addWhere('username', '=', $username)
       ->execute()
-      ->single()['id'] ?? NULL;
+      ->first()['id'] ?? NULL;
   }
 
   /**

--- a/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
@@ -426,6 +426,12 @@ class SecurityTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
     $this->assertEquals('Password reset link for Demonstrators Anonymous', $result['subject']);
   }
 
+  public function testGetUserIDFromUsername() {
+    [$contactID, $adminUserID, $security] = $this->createFixtureContactAndUser();
+    $this->assertEquals($adminUserID, $security->getUserIDFromUsername('user_one'), 'Should return admin user ID');
+    $this->assertNull($security->getUserIDFromUsername('user_unknown'), 'Should return NULL for non-existent user');
+  }
+
   protected function deleteStuffWeMade() {
     User::delete(FALSE)->addWhere('username', '=', 'testuser1')->execute();
   }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an issue where getUserIDFromUsername() was throwing an exception when fetching unknown users, rather than return NULL.

Before
----------------------------------------
Unknown username throws exception due to use of `single()`

After
----------------------------------------
No exception, returns NULL

Comments
----------------------------------------
This should fix a few tests
