### PR TITLE
Applies accessible accordion to SearchKit, adds fallbacks

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2184,7 +2184,8 @@ div.crm-master-accordion-header a.helpicon {
 .crm-container .crm-collapsible .collapsible-title,
 .crm-container span.collapsed,
 .crm-container a.collapsed,
-.crm-container .crm-expand-row {
+.crm-container .crm-expand-row,
+.crm-container summary {
   cursor: pointer;
 }
 
@@ -2193,6 +2194,12 @@ div.crm-master-accordion-header a.helpicon {
 }
 
 /* Specific types of headers */
+
+.crm-container summary:not(.crm-master-accordion-header, .crm-accordion-header) 
+/* For older CMS themes not styling summary */ {
+  font-weight: bold;
+  padding: 0.75rem 0;
+}
 
 #crm-container .widget-content .crm-accordion-header {
   background-color: #efefe5;

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2195,8 +2195,7 @@ div.crm-master-accordion-header a.helpicon {
 
 /* Specific types of headers */
 
-.crm-container summary:not(.crm-master-accordion-header, .crm-accordion-header) 
-/* For older CMS themes not styling summary */ {
+.crm-container summary:not(.crm-master-accordion-header, .crm-accordion-header) /* For older CMS themes not styling summary */ {
   font-weight: bold;
   padding: 0.75rem 0;
 }

--- a/ext/search_kit/ang/crmSearchAdmin/compose.html
+++ b/ext/search_kit/ang/crmSearchAdmin/compose.html
@@ -74,15 +74,14 @@
     </ul>
   </div>
 </div>
-<fieldset id="crm-search-build-functions">
-  <legend ng-click="controls.showFunctions = !controls.showFunctions">
-    <i class="crm-i fa-caret-{{ !controls.showFunctions ? 'right' : 'down' }}"></i>
+<details id="crm-search-build-functions">
+  <summary ng-click="controls.showFunctions = !controls.showFunctions">
     {{:: ts('Field Transformations') }}
-  </legend>
+  </sumary>
   <div ng-if="!!controls.showFunctions">
     <!-- Must use track by $index with an array of primitives, and manually refresh this loop when indexes change -->
     <fieldset ng-repeat="col in $ctrl.savedSearch.api_params.select track by $index" ng-if="!$ctrl.isPseudoField(col)">
       <crm-search-function class="form-inline" mode="select" expr="$ctrl.savedSearch.api_params.select[$index]"></crm-search-function>
     </fieldset>
   </div>
-</fieldset>
+</details>

--- a/ext/search_kit/ang/crmSearchAdmin/compose.html
+++ b/ext/search_kit/ang/crmSearchAdmin/compose.html
@@ -77,7 +77,7 @@
 <details id="crm-search-build-functions">
   <summary ng-click="controls.showFunctions = !controls.showFunctions">
     {{:: ts('Field Transformations') }}
-  </sumary>
+  </summary>
   <div ng-if="!!controls.showFunctions">
     <!-- Must use track by $index with an array of primitives, and manually refresh this loop when indexes change -->
     <fieldset ng-repeat="col in $ctrl.savedSearch.api_params.select track by $index" ng-if="!$ctrl.isPseudoField(col)">

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/debug.html
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/debug.html
@@ -1,9 +1,8 @@
-<fieldset id="crm-search-admin-debug">
-  <legend ng-click="$ctrl.showDebug = !$ctrl.showDebug">
-    <i class="crm-i fa-caret-{{ !$ctrl.showDebug ? 'right' : 'down' }}"></i>
+<details id="crm-search-admin-debug">
+  <summary>
     {{:: ts('Query Info') }}
-  </legend>
-  <div ng-if="$ctrl.showDebug">
+  </summary>
+  <div>
     <pre ng-if="$ctrl.debug.timeIndex">{{ ts('Request took %1 seconds.', {1: $ctrl.debug.timeIndex}) }}</pre>
     <div>
       <strong>API:</strong>
@@ -15,4 +14,4 @@
       <pre ng-repeat="query in $ctrl.debug.sql">{{ query }}</pre>
     </div>
   </div>
-</fieldset>
+</details>

--- a/ext/search_kit/css/crmSearchAdmin.css
+++ b/ext/search_kit/css/crmSearchAdmin.css
@@ -291,7 +291,3 @@ crm-search-admin-import {
   right: 0;
   background-color: white;
 }
-
-#bootstrap-theme summary {
-  display: list-item;
-}

--- a/ext/search_kit/css/crmSearchAdmin.css
+++ b/ext/search_kit/css/crmSearchAdmin.css
@@ -291,3 +291,7 @@ crm-search-admin-import {
   right: 0;
   background-color: white;
 }
+
+#bootstrap-theme summary {
+  display: list-item; 
+}

--- a/ext/search_kit/css/crmSearchAdmin.css
+++ b/ext/search_kit/css/crmSearchAdmin.css
@@ -293,5 +293,5 @@ crm-search-admin-import {
 }
 
 #bootstrap-theme summary {
-  display: list-item; 
+  display: list-item;
 }


### PR DESCRIPTION
Overview
----------------------------------------
SearchKit builder screen uses two custom angular accordions - this replaces them with `<details><summary>`.

Before
----------------------------------------
Search Kit accordions not accessible/keyboard controllable.
<img width="1102" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/5d781429-18c8-473b-ba32-53f597abf6fc">

After
----------------------------------------
They are.
<img width="1118" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/1cf04646-c31c-430d-a3b5-7d95f4c99c6c">

Technical Details
----------------------------------------
This PR adds some css to stop Bootstrap3 from breaking details/summary, and adds some fallback styling on details/summary as while many modern CMS admin themes will make the summary bold, and change the cursor, older ones don't.

Technical Details
----------------------------------------
There is a small UI change as the accordion previously used fieldset/legend.