### PR TITLE
Metadata - Refresh clientside resources when clearing cache

### DIFF
--- a/CRM/Extension/System.php
+++ b/CRM/Extension/System.php
@@ -273,6 +273,7 @@ class CRM_Extension_System {
       // Extension system starts before container. Manage our own cache.
       $this->cache = CRM_Utils_Cache::create([
         'name' => $cacheGroup,
+        'service' => 'extension_system',
         'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
         'prefetch' => TRUE,
         'withArray' => 'fast',

--- a/CRM/Utils/Cache.php
+++ b/CRM/Utils/Cache.php
@@ -206,7 +206,7 @@ class CRM_Utils_Cache {
       }
     }
     if (isset($cache)) {
-      return new CRM_Utils_Cache_CacheWrapper($cache, $params['name'] ?? NULL);
+      return new CRM_Utils_Cache_CacheWrapper($cache, $params['service'] ?? $params['name'] ?? NULL);
     }
     throw new CRM_Core_Exception("Failed to instantiate cache. No supported cache type found. " . print_r($params, 1));
   }

--- a/CRM/Utils/Cache/CacheWrapper.php
+++ b/CRM/Utils/Cache/CacheWrapper.php
@@ -22,7 +22,7 @@ class CRM_Utils_Cache_CacheWrapper implements CRM_Utils_Cache_Interface {
   /**
    * @var string
    */
-  private $cacheName;
+  private $serviceName;
 
   /**
    * @var CRM_Utils_Cache_Interface
@@ -31,11 +31,11 @@ class CRM_Utils_Cache_CacheWrapper implements CRM_Utils_Cache_Interface {
 
   /**
    * @param \CRM_Utils_Cache_Interface $delegate
-   * @param string $cacheName
+   * @param string $serviceName
    */
-  public function __construct(\CRM_Utils_Cache_Interface $delegate, $cacheName) {
+  public function __construct(\CRM_Utils_Cache_Interface $delegate, $serviceName) {
     $this->delegate = $delegate;
-    $this->cacheName = $cacheName;
+    $this->serviceName = $serviceName;
   }
 
   public function getMultiple($keys, $default = NULL) {
@@ -93,12 +93,12 @@ class CRM_Utils_Cache_CacheWrapper implements CRM_Utils_Cache_Interface {
 
   private function dispatchClearEvent($keys = NULL) {
     // FIXME: When would name ever be empty?
-    if ($this->cacheName) {
+    if ($this->serviceName) {
       $hookParams = [
         'items' => $keys,
       ];
       $event = \Civi\Core\Event\GenericHookEvent::create($hookParams);
-      Civi::dispatcher()->dispatch("civi.cache.$this->cacheName.clear", $event);
+      Civi::dispatcher()->dispatch("civi.cache.$this->serviceName.clear", $event);
     }
   }
 

--- a/CRM/Utils/Cache/CacheWrapper.php
+++ b/CRM/Utils/Cache/CacheWrapper.php
@@ -95,11 +95,10 @@ class CRM_Utils_Cache_CacheWrapper implements CRM_Utils_Cache_Interface {
     // FIXME: When would name ever be empty?
     if ($this->cacheName) {
       $hookParams = [
-        'cacheName' => $this->cacheName,
         'items' => $keys,
       ];
       $event = \Civi\Core\Event\GenericHookEvent::create($hookParams);
-      Civi::dispatcher()->dispatch('civi.cache.clear', $event);
+      Civi::dispatcher()->dispatch("civi.cache.$this->cacheName.clear", $event);
     }
   }
 

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -188,6 +188,8 @@ class Container {
     foreach ($basicCaches as $cacheSvc => $cacheGrp) {
       $definitionParams = [
         'name' => $cacheGrp . (in_array($cacheGrp, $verSuffixCaches) ? $verSuffix : ''),
+        // FIXME: Uncommenting below causes test failure
+        // 'service' => $cacheSvc,
         'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
       ];
       // For Caches that we don't really care about the ttl for and/or maybe accessed
@@ -435,6 +437,7 @@ class Container {
     $moduleEnvId = md5(\CRM_Core_Config_Runtime::getId());
     $angCache = \CRM_Utils_Cache::create([
       'name' => substr('angular_' . $moduleEnvId, 0, 32),
+      'service' => 'angular_manager',
       'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
       'withArray' => 'fast',
       'prefetch' => TRUE,

--- a/Civi/Core/MetadataFlush.php
+++ b/Civi/Core/MetadataFlush.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Core;
+
+/**
+ * Event subscriber for metadata cache clear events.
+ */
+class MetadataFlush extends Service\AutoSubscriber {
+
+  public static function getSubscribedEvents() {
+    return [
+      'civi.cache.metadata.clear' => 'onClearMetadata',
+    ];
+  }
+
+  /**
+   * When metadata is flushed, client-side resources also must be refreshed.
+   *
+   * This uses the Resources::resetCacheCode() method which doesn't delete any files
+   * from the assetBuilder directory, unlike the AssetBuilder::clear() method which does.
+   * This is to avoid concurrency issues where the user tries to download a resource
+   * as it's being deleted.
+   */
+  public static function onClearMetadata(): void {
+    \Civi::resources()->resetCacheCode();
+  }
+
+}

--- a/tests/phpunit/Civi/Core/Service/AutoDefinitionTest.php
+++ b/tests/phpunit/Civi/Core/Service/AutoDefinitionTest.php
@@ -104,7 +104,7 @@ class AutoDefinitionTest extends \CiviUnitTestCase {
     $this->assertInstanceOf(\CRM_Utils_Cache_CacheWrapper::class, $instance->cache);
     $cacheClass = Invasive::get([$instance->cache, 'delegate']);
     $this->assertInstanceOf(\CRM_Utils_Cache_SqlGroup::class, $cacheClass);
-    $this->assertEquals('extension_browser', Invasive::get([$instance->cache, 'cacheName']));
+    $this->assertEquals('extension_browser', Invasive::get([$cacheClass, 'group']));
   }
 
   /**
@@ -183,7 +183,7 @@ class AutoDefinitionTest extends \CiviUnitTestCase {
     $cacheWrapper = Invasive::get([$instance, 'cache']);
     $cacheClass = Invasive::get([$cacheWrapper, 'delegate']);
     $this->assertInstanceOf(\CRM_Utils_Cache_SqlGroup::class, $cacheClass);
-    $this->assertEquals('extension_browser', Invasive::get([$cacheWrapper, 'cacheName']));
+    $this->assertEquals('extension_browser', Invasive::get([$cacheWrapper, 'serviceName']));
     $this->assertEquals('extension_browser', Invasive::get([$cacheClass, 'group']));
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Ensures available user roles are always up-to-date (full fix).

Before
----------------------------------------
After saving a user role it is not immediately available for use.

After
----------------------------------------
Fixed.

Comments
-----
This builds on the partial fix from #28422 and the event added in #28428.