### PR TITLE
Asset builder test

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -420,7 +420,30 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
   }
 
   /**
+   * Get the params used to render crm-l10n.js
+   * Gets called above the caching layer and then used
+   * in the render function below
+   */
+  public static function getL10nJsParams(): array {
+    $settings = Civi::settings();
+    return [
+      'cid' => CRM_Core_Session::getLoggedInContactID() ?: 0,
+      'includeEmailInName' => (bool) $settings->get('includeEmailInName'),
+      'ajaxPopupsEnabled' => (bool) $settings->get('ajaxPopupsEnabled'),
+      'allowAlertAutodismissal' => (bool) $settings->get('allow_alert_autodismissal'),
+      'resourceCacheCode' => Civi::resources()->getCacheCode(),
+      'locale' => CRM_Core_I18n::getLocale(),
+      'lcMessages' => $settings->get('lcMessages'),
+      'dateInputFormat' => $settings->get('dateInputFormat'),
+      'timeInputFormat' => $settings->get('timeInputFormat'),
+      'moneyFormat' => CRM_Utils_Money::format(1234.56),
+    ];
+  }
+
+  /**
    * Create dynamic script for localizing js widgets.
+   * Params come from the function above
+   * @see getL10nJsParams
    */
   public static function renderL10nJs(GenericHookEvent $e) {
     if ($e->asset !== 'crm-l10n.js') {

--- a/CRM/Core/Resources/Common.php
+++ b/CRM/Core/Resources/Common.php
@@ -206,18 +206,7 @@ class CRM_Core_Resources_Common {
 
     // Dynamic localization script
     if (!CRM_Core_Config::isUpgradeMode()) {
-      $items[] = Civi::service('asset_builder')->getUrl('crm-l10n.js', [
-        'cid' => $contactID,
-        'includeEmailInName' => (bool) $settings->get('includeEmailInName'),
-        'ajaxPopupsEnabled' => (bool) $settings->get('ajaxPopupsEnabled'),
-        'allowAlertAutodismissal' => (bool) $settings->get('allow_alert_autodismissal'),
-        'resourceCacheCode' => Civi::resources()->getCacheCode(),
-        'locale' => CRM_Core_I18n::getLocale(),
-        'lcMessages' => $settings->get('lcMessages'),
-        'dateInputFormat' => $settings->get('dateInputFormat'),
-        'timeInputFormat' => $settings->get('timeInputFormat'),
-        'moneyFormat' => CRM_Utils_Money::format(1234.56),
-      ]);
+      $items[] = Civi::service('asset_builder')->getUrl('crm-l10n.js', CRM_Core_Resources::getL10nJsParams());
     }
 
     // These scripts are only needed by back-office users

--- a/tests/phpunit/E2E/Core/PathUrlTest.php
+++ b/tests/phpunit/E2E/Core/PathUrlTest.php
@@ -77,7 +77,11 @@ class PathUrlTest extends \CiviEndToEndTestCase {
     // Make some requests for actual URLs
     $this->assertUrlContentRegex(';MIT-LICENSE.txt;', \Civi::url('[civicrm.packages]/jquery/plugins/jquery.timeentry.js', 'a'));
     $this->assertUrlContentRegex(';MIT-LICENSE.txt;', \Civi::url('asset://[civicrm.packages]/jquery/plugins/jquery.timeentry.js', 'a'));
-    $this->assertUrlContentRegex(';Please enter a valid email address;', \Civi::url('assetBuilder://crm-l10n.js?locale=en_US', 'a'));
+    // crm-10n.js needs a fair few url params
+    $this->assertUrlContentRegex(
+        ';Please enter a valid email address;',
+         \Civi::url('assetBuilder://crm-l10n.js', 'a')->addQuery(\CRM_Core_Resources::getL10nJsParams())
+    );
     $this->assertUrlContentRegex(';.module..crmSearchAdmin;', \Civi::url('ext://org.civicrm.search_kit/ang/crmSearchAdmin.module.js', 'a'));
     $this->assertUrlContentRegex(';crm-section event_date_time-section;', \Civi::url('frontend://civicrm/event/info?id=1', 'a'));
 


### PR DESCRIPTION
Before
----------------------------------------
Asset builder test is failing on Standalone because it doesn't get all the params it needs from the url.

(It appears the missing param errors get swallowed on other CMSes)

After
----------------------------------------
Dedicated function to fetch the asset builder params, which can then be used in the test.

