### PR TITLE
[REF][PHP8.2] Declare properties in TimeSpent report

### DIFF
--- a/CRM/Report/Form/Case/TimeSpent.php
+++ b/CRM/Report/Form/Case/TimeSpent.php
@@ -17,6 +17,30 @@
 class CRM_Report_Form_Case_TimeSpent extends CRM_Report_Form {
 
   /**
+   * @var array
+   * @internal
+   */
+  public $activityTypes;
+
+  /**
+   * @var array
+   * @internal
+   */
+  public $activityStatuses;
+
+  /**
+   * @var array
+   * @internal
+   */
+  public $has_grouping;
+
+  /**
+   * @var array
+   * @internal
+   */
+  public $has_activity_type;
+
+  /**
    * Class constructor.
    */
   public function __construct() {


### PR DESCRIPTION
Overview
----------------------------------------
Declare properties in TimeSpent report.

Before
----------------------------------------
Properties in `CRM_Report_Form_Case_TimeSpent` were not declared, causing test failures on PHP 8.2.

After
----------------------------------------
Properties declared

Technical Details
----------------------------------------
As with https://github.com/civicrm/civicrm-core/pull/28432 I've left the properties `public` to be on the safe side for backwards-compatibility, but marked them as internal to allow moving to `protected` in future.
