### PR TITLE
APIv4 - Super-admins don't always have access to everything

### DIFF
--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -242,11 +242,6 @@ class CoreUtil {
     $userID = $userID ?? \CRM_Core_Session::getLoggedInContactID() ?? 0;
     $idField = self::getIdFieldName($apiRequest->getEntityName());
 
-    // Super-admins always have access to everything
-    if (\CRM_Core_Permission::check('all CiviCRM permissions and ACLs', $userID)) {
-      return TRUE;
-    }
-
     // For get actions, just run a get and ACLs will be applied to the query.
     // It's a cheap trick and not as efficient as not running the query at all,
     // but BAO::checkAccess doesn't consistently check permissions for the "get" action.

--- a/ext/search_kit/CRM/Search/BAO/SearchDisplay.php
+++ b/ext/search_kit/CRM/Search/BAO/SearchDisplay.php
@@ -24,9 +24,12 @@ class CRM_Search_BAO_SearchDisplay extends CRM_Search_DAO_SearchDisplay {
    * @return bool
    */
   public static function _checkAccess(string $entityName, string $action, array $record, int $userCID) {
-    // If we hit this function at all, the user is not a super-admin
-    // But they must be at least a SearchKit administrator
-    if (!CRM_Core_Permission::check([['administer CiviCRM data', 'administer search_kit']])) {
+    // Super-admins can do anything with search displays
+    if (CRM_Core_Permission::check('all CiviCRM permissions and ACLs', $userCID)) {
+      return TRUE;
+    }
+    // Must be at least a SearchKit administrator
+    if (!CRM_Core_Permission::check([['administer CiviCRM data', 'administer search_kit']], $userCID)) {
       return FALSE;
     }
     if (in_array($action, ['create', 'update'], TRUE)) {


### PR DESCRIPTION
The Problem
----------------------------------------
There are certain things that even super-admins aren't allowed to do. For example:

1. Delete their own contact record
2. Delete the default organization
3. Delete financial types that are in-use

What this PR does
-------------
Functionally, it changes nothing. Super-admins have the same super permissions they have always had.
However BAOs and hooks now have the power to restrict access even for super-admins, for those rare cases when they shouldn't be allowed to do something.


Technical Details
---------
This hook was originally written to restrict access to search displays. The assumption was that super-admins can do anything, but it turns out that's not 100% the case, so this moves the assumption into the search display BAO so that others can do what they want.

Comments
---------
Supports https://github.com/civicrm/civicrm-core/pull/28451 by allowing permission checks to affect super-admins.