### PR TITLE
[REF][PHP8.2] Declare properties in CRM_Contact_Form_Task_Delete

### DIFF
--- a/CRM/Contact/Form/Task/Delete.php
+++ b/CRM/Contact/Form/Task/Delete.php
@@ -32,9 +32,25 @@ class CRM_Contact_Form_Task_Delete extends CRM_Contact_Form_Task {
 
   /**
    * Cache shared address message so we don't query twice
-   * @var string
+   *
+   * @var array
    */
   protected $_sharedAddressMessage = NULL;
+
+  /**
+   * @var string
+   */
+  protected $_searchKey;
+
+  /**
+   * @var bool
+   */
+  protected $_skipUndelete;
+
+  /**
+   * @var bool
+   */
+  protected $_restore;
 
   /**
    * Build all the data structures needed to build the form.


### PR DESCRIPTION
Overview
----------------------------------------
Declare properties in `CRM_Contact_Form_Task_Delete`

Before
----------------------------------------
On PHP8.2 tests relating to class `CRM_Contact_Form_Task_Delete` were failing due to the use of deprecated dynamic properties.

Also, `$_sharedAddressMessage` was wrongly documented as a `string`.

After
----------------------------------------
Properties declared.

Technical Details
----------------------------------------
The choice of visibility `public`/`protected`/`private` could be argued either way. I went `protected` due to the leading underscore, which indicates the property is for internal use.