### PR TITLE
Standalone - give admin role super permission

### DIFF
--- a/setup/plugins/init/StandaloneUsers.civi-setup.php
+++ b/setup/plugins/init/StandaloneUsers.civi-setup.php
@@ -149,7 +149,9 @@ if (!defined('CIVI_SETUP')) {
         [
           'name' => 'admin',
           'label' => ts('Administrator'),
-          'permissions' => array_keys(\CRM_Core_SelectValues::permissions()),
+          'permissions' => [
+            'all CiviCRM permissions and ACLs',
+          ],
         ],
       ])
       ->execute()->indexBy('name');


### PR DESCRIPTION
Overview
----------------------------------------

Rather than hard code the full list of permissions we should give the admin role the super permission.

Before
----------------------------------------

The admin role was given the full list of permissions as at the time of install but this may change in future and the new permissions wouldn't be added. 

After
----------------------------------------

The admin role has a single permission `all CiviCRM permissions and ACLs` which gives full access to CiviCRM including any new permissions that are added in future.
