### PR TITLE
Greenwich - Fix styling of summary collapsible element

### DIFF
--- a/ext/greenwich/scss/_tweaks.scss
+++ b/ext/greenwich/scss/_tweaks.scss
@@ -25,3 +25,7 @@ input[type="search"]::-webkit-search-cancel-button {
   font-size: inherit;
   font-weight: normal;
 }
+/* Bootstrap3 styles these as block which is non-compliant with html standards */
+summary {
+  display: list-item;
+}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes incorrect styling of summary/details collapsible element by Bootstrap3.

Before
------------
Little triangle doesn't appear, margins incorrect

After
----------
Renders the way it should.