### PR TITLE
Standalone - Protect admin and everyone roles

### DIFF
--- a/ext/standaloneusers/CRM/Standaloneusers/BAO/Role.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/BAO/Role.php
@@ -14,4 +14,25 @@ class CRM_Standaloneusers_BAO_Role extends CRM_Standaloneusers_DAO_Role implemen
     Civi::cache('metadata')->clear();
   }
 
+  /**
+   * Check access permission
+   *
+   * @param string $entityName
+   * @param string $action
+   * @param array $record
+   * @param integer|null $userID
+   * @return boolean
+   * @see CRM_Core_DAO::checkAccess
+   */
+  public static function _checkAccess(string $entityName, string $action, array $record, ?int $userID): bool {
+    // Prevent users from updating or deleting the admin and everyone roles
+    if (in_array($action, ['delete', 'update'], TRUE)) {
+      $name = $record['name'] ?? CRM_Core_DAO::getFieldValue(self::class, $record['id']);
+      if (in_array($name, ['admin', 'everyone'], TRUE)) {
+        return FALSE;
+      }
+    }
+    return TRUE;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

We shouldn't allow users to edit or delete the `admin` and `everyone` roles as this could break the site.

Before
----------------------------------------

Users can edit and delete the `admin` and `everyone` roles and break the site.

After
----------------------------------------

Users are unable to edit and delete the `admin` and `everyone` roles.

Comments
----------------------------------------

For this PR to be fully effective, we need to limit the ability of super admins to do everything - see #28445.
