### PR TITLE
APIv4 - Pass form values to autocomplete field

### DIFF
--- a/Civi/Api4/Generic/AutocompleteAction.php
+++ b/Civi/Api4/Generic/AutocompleteAction.php
@@ -36,6 +36,7 @@ use Civi\Core\Event\GenericHookEvent;
  */
 class AutocompleteAction extends AbstractAction {
   use Traits\SavedSearchInspectorTrait;
+  use Traits\GetSetValueTrait;
 
   /**
    * Autocomplete search input for search mode
@@ -87,6 +88,17 @@ class AutocompleteAction extends AbstractAction {
    * @var string
    */
   protected $key;
+
+  /**
+   * Known entity values.
+   *
+   * Value will be populated by the form based on data entered at the time.
+   * They can be used by hooks for contextual filtering.
+   *
+   * Format: [fieldName => value][]
+   * @var array
+   */
+  protected $values = [];
 
   /**
    * Search conditions that will be automatically added to the WHERE or HAVING clauses

--- a/ext/afform/core/ang/af/fields/EntityRef.html
+++ b/ext/afform/core/ang/af/fields/EntityRef.html
@@ -5,7 +5,7 @@
        ng-model="getSetSelect"
        ng-model-options="{getterSetter: true}"
        crm-autocomplete="$ctrl.defn.fk_entity"
-       crm-autocomplete-params="{formName: 'afform:' + $ctrl.afFieldset.getFormName(), fieldName: $ctrl.afFieldset.getName() + ':' + $ctrl.fieldName}"
+       crm-autocomplete-params="{formName: 'afform:' + $ctrl.afFieldset.getFormName(), fieldName: $ctrl.afFieldset.getName() + ':' + $ctrl.fieldName, values: dataProvider.getFieldData()}"
        multi="$ctrl.defn.input_attrs.multiple"
        auto-open="$ctrl.defn.input_attrs.autoOpen"
        quick-add="$ctrl.defn.input_attrs.quickAdd"


### PR DESCRIPTION
Overview
----------------------------------------
When triggering the "Autocomplete" API4 AJAX request on a autocomplete field we don't know what the user selected on the form. We would like to know so we can do things (eg. filter the autocomplete results) based on the user selections.

Before
----------------------------------------
No user selections available on form.

After
----------------------------------------
User selections available (for current entity only)

Technical Details
----------------------------------------
Gets the selected values from the form and submits them with the request.

Comments
----------------------------------------
We tried (and failed) to get all form values. This is because the local scope doesn't allow access to the whole form but only the current fieldset (eg. Membership1).
