### PR TITLE
SearchKit - Hide empty menus

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/colType/menu.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/menu.html
@@ -1,4 +1,4 @@
-<div class="btn-group" role="group">
+<div class="btn-group" role="group" ng-if="colData.links.length">
   <button type="button" class="dropdown-toggle btn {{:: $ctrl.settings.columns[colIndex].size }} btn-{{:: $ctrl.settings.columns[colIndex].style }}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" ng-click="colData.open = true">
     <i ng-if=":: $ctrl.settings.columns[colIndex].icon" class="crm-i {{:: $ctrl.settings.columns[colIndex].icon }}"></i>
     {{:: colData.text }}


### PR DESCRIPTION
Overview
----------------------------------------
SearchKit UI improvement for less-permissioned users.

Before
----------------------------------------
Sometimes a user doesn't have access to any actions, resulting in a menu link that opens nothing.

After
----------------------------------------
Just hide the dropdown.