### PR TITLE
fix standalone permission for civimail subscribe pages

### DIFF
--- a/setup/plugins/init/StandaloneUsers.civi-setup.php
+++ b/setup/plugins/init/StandaloneUsers.civi-setup.php
@@ -50,7 +50,7 @@ if (!defined('CIVI_SETUP')) {
           'label' => ts('Everyone, including anonymous users'),
           // Provide default open permissions
           'permissions' => [
-            'CiviMail subscribe/unsubscribe pages',
+            'access CiviMail subscribe/unsubscribe pages',
             'make online contributions',
             'view event info',
             'register for events',


### PR DESCRIPTION
Before
----------------------------------------
Typo in the permission means it's not granted to everyone role on install.

Incidentally causes this E2E test fail https://test.civicrm.org/job/CiviCRM-E2E-Matrix/BKPROF=min,BLDTYPE=standalone-clean,CIVIVER=master,label=bknix-tmp/lastCompletedBuild/testReport/(root)/E2E_Core_PathUrlTest/testSystemRouter/

After
----------------------------------------
New people can sign up :love_letter: 

Test should pass