### PR TITLE
Stop using & deprectate `getSalesTaxTerm`

### DIFF
--- a/CRM/Financial/Form/SalesTaxTrait.php
+++ b/CRM/Financial/Form/SalesTaxTrait.php
@@ -18,8 +18,11 @@ trait CRM_Financial_Form_SalesTaxTrait {
 
   /**
    * Assign the sales tax term to the template.
+   *
+   * @deprecated since 5.69 will be removed around 5.80
    */
   public function assignSalesTaxTermToTemplate() {
+    CRM_Core_Error::deprecatedFunctionWarning('assign the setting');
     $this->assign('taxTerm', $this->getSalesTaxTerm());
   }
 
@@ -47,7 +50,7 @@ trait CRM_Financial_Form_SalesTaxTrait {
    */
   public function assignSalesTaxMetadataToTemplate() {
     $this->assignSalesTaxRates();
-    $this->assignSalesTaxTermToTemplate();
+    $this->assign('taxTerm', $this->getSalesTaxTerm());
   }
 
   /**

--- a/CRM/Price/Page/Option.php
+++ b/CRM/Price/Page/Option.php
@@ -189,7 +189,7 @@ class CRM_Price_Page_Option extends CRM_Core_Page {
     $this->assign('customOption', $customOption);
     $this->assign('sid', $this->_sid);
     $this->assign('isEvent', $isEvent);
-    $this->assignSalesTaxTermToTemplate();
+    $this->assign('taxTerm', $this->getSalesTaxTerm());
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Stop using & deprectate `getSalesTaxTerm`

Before
----------------------------------------
This function made sense we we have that non-standard way of saving the taxTerm setting but now it just hides what the one-liner is doing

After
----------------------------------------
Deprecated

Technical Details
----------------------------------------

Comments
----------------------------------------
