### PR TITLE
Fix tests calling AdditionalPayment form to use full flow, add standard ID get functions

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -959,8 +959,6 @@ Receipt Date: ' . date('m/d/Y'),
 
   /**
    * Test the submit function that completes the partially paid payment using Credit Card
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testPartialPaymentWithCreditCard(): void {
     // create a partially paid contribution by using back-office form
@@ -979,11 +977,7 @@ Receipt Date: ' . date('m/d/Y'),
     $this->callAPISuccess('Payment', 'create', ['contribution_id' => $contribution['id'], 'total_amount' => 10, 'payment_instrument_id' => 'Cash']);
     $contribution = $this->callAPISuccessGetSingle('Contribution', ['id' => $contribution['id']]);
     $this->assertEquals('Partially paid', $contribution['contribution_status']);
-    // pay additional amount by using Credit Card
-    $form = new CRM_Contribute_Form_AdditionalPayment();
-    $form->testSubmit([
-      'contribution_id' => $contribution['id'],
-      'contact_id' => $this->_individualId,
+    $form = $this->getTestForm('CRM_Contribute_Form_AdditionalPayment', [
       'total_amount' => 40,
       'currency' => 'USD',
       'financial_type_id' => 1,
@@ -998,7 +992,8 @@ Receipt Date: ' . date('m/d/Y'),
       'billing_postal_code-5' => 1321312,
       'billing_country_id-5' => 1228,
       'trxn_date' => '2017-04-11 13:05:11',
-    ], 'live');
+    ], ['id' => $contribution['id'], 'mode' => 'live'])->processForm();
+    $this->assertEquals($contribution['id'], $form->getContributionID());
     $contribution = $this->callAPISuccessGetSingle('Contribution', []);
     $this->assertNotEmpty($contribution);
     $this->assertEquals('Completed', $contribution['contribution_status']);

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -21,6 +21,7 @@ use Civi\Api4\FinancialType;
 use Civi\Api4\Membership;
 use Civi\Api4\MembershipType;
 use Civi\Api4\PriceFieldValue;
+use Civi\Test\FormTrait;
 
 /**
  *  Test CRM_Member_Form_Membership functions.
@@ -32,6 +33,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
 
   use CRMTraits_Financial_OrderTrait;
   use CRMTraits_Financial_PriceSetTrait;
+  use FormTrait;
 
   /**
    * @var int
@@ -799,20 +801,18 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
 
     // Step 2: submit the other half of the partial payment
     //  via AdditionalPayment form to complete the related contribution
-    $form = new CRM_Contribute_Form_AdditionalPayment();
-    $submitParams = [
-      'contribution_id' => $contribution['contribution_id'],
-      'contact_id' => $this->_individualId,
-      'total_amount' => $this->formatMoneyInput(25),
-      'currency' => 'USD',
-      'financial_type_id' => 2,
-      'receive_date' => '2015-04-21 23:27:00',
+    $this->getTestForm('CRM_Contribute_Form_AdditionalPayment', [
+      'total_amount' => 150.00,
       'trxn_date' => '2017-04-11 13:05:11',
-      'payment_processor_id' => 0,
-      'payment_instrument_id' => array_search('Check', $this->paymentInstruments, TRUE),
+      'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Financial_BAO_FinancialTrxn', 'payment_instrument_id', 'Check'),
       'check_number' => 'check-12345',
-    ];
-    $form->testSubmit($submitParams);
+      'trxn_id' => '',
+      'currency' => 'USD',
+      'fee_amount' => '',
+      'net_amount' => '',
+      'payment_processor_id' => 0,
+      'contact_id' => $this->_individualId,
+    ], ['id' => $contribution['id']])->processForm();
     $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_individualId]);
     // check the membership status after additional payment, if its changed to 'New'
     $this->assertEquals(array_search('New', CRM_Member_PseudoConstant::membershipStatus(), TRUE), $membership['status_id']);
@@ -1511,7 +1511,7 @@ Expires: ',
       'price_' . $fieldOption['price_field_id'] => $fieldOption['id'],
       'total_amount' => 55,
       'receive_date' => date('Y-m-d') . ' 20:36:00',
-      'payment_instrument_id' => array_search('Check', $this->paymentInstruments, TRUE),
+      'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Financial_BAO_FinancialTrxn', 'payment_instrument_id', 'Check'),
       'contribution_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed'),
       //Member dues, see data.xml
       'financial_type_id' => 2,
@@ -1648,16 +1648,15 @@ Expires: ',
       'contact_id' => $this->_individualId,
     ]);
     $endDate = (new DateTime(date('Y-m-d')))->modify('+3 years')->modify('-1 day');
-    $endDate = $endDate->format("Y-m-d");
+    $endDate = $endDate->format('Y-m-d');
 
     $this->assertEquals($endDate, $membership['end_date'], 'Membership Expiration Date should be ' . $endDate);
-    $this->assertEquals(1, count($contribution['values']), 'Pending contribution should be created.');
+    $this->assertCount(1, $contribution['values'], 'Pending contribution should be created.');
     $contribution = $contribution['values'][$contribution['id']];
-    $additionalPaymentForm = new CRM_Contribute_Form_AdditionalPayment();
-    $additionalPaymentForm->testSubmit([
+    $this->getTestForm('CRM_Contribute_Form_AdditionalPayment', [
       'total_amount' => 150.00,
-      'trxn_date' => date("Y-m-d H:i:s"),
-      'payment_instrument_id' => array_search('Check', $this->paymentInstruments),
+      'trxn_date' => date('Y-m-d H:i:s'),
+      'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Financial_BAO_FinancialTrxn', 'payment_instrument_id', 'Check'),
       'check_number' => 'check-12345',
       'trxn_id' => '',
       'currency' => 'USD',
@@ -1666,8 +1665,7 @@ Expires: ',
       'net_amount' => '',
       'payment_processor_id' => 0,
       'contact_id' => $this->_individualId,
-      'contribution_id' => $contribution['id'],
-    ]);
+    ], ['id' => $contribution['id']])->processForm();
     $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_individualId]);
     $contribution = $this->callAPISuccess('Contribution', 'get', [
       'contact_id' => $this->_individualId,


### PR DESCRIPTION
Overview
----------------------------------------
FIx tests caling AdditionalPayment form to use full flow, add getContributionID(), getPaymentProcessorID() functions

Before
----------------------------------------
tests call an artifical `testSubmit()` function

After
----------------------------------------
tests use the FormTrait, standardised externally supported `getContributionID()` added & tested

Technical Details
----------------------------------------
Also removes setting the source - this is from previously shared code where it set up the value for contribution source - but this form only interacts with the Payment api, not the contribution

Comments
----------------------------------------
