### PR TITLE
Fix missing blank href attr on <a> links in searchkit angular

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/colType/buttons.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/buttons.html
@@ -1,5 +1,5 @@
 <span ng-repeat="link in colData.links">
-  <a class="btn {{:: $ctrl.settings.columns[colIndex].size }} btn-{{:: link.style }}" target="{{:: link.target }}" ng-href="{{:: link.url }}" title="{{:: link.title }}" ng-click="$ctrl.onClickLink(link, row.key, $event)">
+  <a class="btn {{:: $ctrl.settings.columns[colIndex].size }} btn-{{:: link.style }}" target="{{:: link.target }}" ng-attr-href="{{ link.url || '' }}" title="{{:: link.title }}" ng-click="$ctrl.onClickLink(link, row.key, $event)">
     <i ng-if=":: link.icon" class="crm-i {{:: link.icon }}"></i>
     {{:: link.text }}
   </a>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/field.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/field.html
@@ -15,7 +15,7 @@
 </span>
 <span ng-if="colData.links && !$ctrl.isEditing(rowIndex, colIndex)">
   <span ng-repeat="link in colData.links">
-    <a target="{{:: link.target }}" ng-href="{{:: link.url }}" title="{{:: link.title }}" class="{{:: link.style }} ng-click="$ctrl.onClickLink(link, row.key, $event)">
+    <a target="{{:: link.target }}" ng-attr-href="{{ link.url || '' }}" title="{{:: link.title }}" class="{{:: link.style }} ng-click="$ctrl.onClickLink(link, row.key, $event)">
       <i ng-if="colData.icons.left[$index]" class="crm-i {{:: colData.icons.left[$index] }}"></i>
       {{:: link.text }}<i ng-if="colData.icons.right[$index]" class="crm-i {{:: colData.icons.right[$index] }}"> </i></a><span ng-if="!$last">,
     </span>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/image.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/image.html
@@ -1,6 +1,6 @@
 <span ng-if="::colData.links && colData.img">
   <span ng-repeat="link in colData.links">
-    <a target="{{:: link.target }}" ng-href="{{:: link.url }}">
+    <a target="{{:: link.target }}" ng-attr-href="{{ link.url || '' }}">
       <img ng-src="{{:: colData.img.src }}" alt="{{:: colData.val }}" height="{{:: colData.img.height }}" width="{{:: colData.img.width }}"/>
     </a>
   </span>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/links.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/links.html
@@ -1,5 +1,5 @@
 <span ng-repeat="link in colData.links">
-  <a class="text-{{:: link.style }}" target="{{:: link.target }}" ng-href="{{:: link.url }}" title="{{:: link.title }}" ng-click="$ctrl.onClickLink(link, row.key, $event)">
+  <a class="text-{{:: link.style }}" target="{{:: link.target }}" ng-attr-href="{{ link.url || '' }}" title="{{:: link.title }}" ng-click="$ctrl.onClickLink(link, row.key, $event)">
     <i ng-if=":: link.icon" class="crm-i {{:: link.icon }}"></i>
     {{:: link.text }}
   </a>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/menu.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/menu.html
@@ -6,7 +6,7 @@
   </button>
   <ul class="dropdown-menu {{ $ctrl.settings.columns[colIndex].alignment === 'text-right' ? 'dropdown-menu-right' : '' }}" ng-if=":: colData.open">
     <li ng-repeat="link in colData.links" class="bg-{{:: link.style }}">
-      <a ng-href="{{:: link.url }}" target="{{:: link.target }}" title="{{:: link.title }}" ng-click="$ctrl.onClickLink(link, row.key, $event)">
+      <a ng-attr-href="{{ link.url || '' }}" target="{{:: link.target }}" title="{{:: link.title }}" ng-click="$ctrl.onClickLink(link, row.key, $event)">
         <i ng-if=":: link.icon" class="crm-i {{:: link.icon }}"></i>
         {{:: link.text }}
       </a>


### PR DESCRIPTION
Before
----------------------------------------

SK AngularJS generates 'links' without `href` attributes. This means that the browser does not identify the clickable thing as a link. This has accessibility and visual problems (e.g. mouse shows as caret not pointer)

After
----------------------------------------

Blank hrefs supported where there isn't an actual href. Browser treats the clickable content as links :

![image](https://github.com/civicrm/civicrm-core/assets/870343/824756c1-cf80-4ae9-afb2-56fc251f6073)

