### PR TITLE
dev/core#4411: follow up PR of the language pr, this cleans up an unused functions

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -482,18 +482,6 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
   }
 
   /**
-   * Function to return current language.
-   *
-   * @return string
-   */
-  public function getCurrentLanguage() {
-    if ($this->missingStandaloneExtension()) {
-      return NULL;
-    }
-    return Security::singleton()->getCurrentLanguage();
-  }
-
-  /**
    * I don't know why this needs to be here? Does it even?
    *
    * Helper function to extract path, query and route name from Civicrm URLs.

--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -248,12 +248,6 @@ class Security {
     return !empty($this->getLoggedInUfID());
   }
 
-  public function getCurrentLanguage() {
-    // @todo
-    \Civi::log()->debug('CRM_Utils_System_Standalone::getCurrentLanguage: not implemented');
-    return NULL;
-  }
-
   /**
    * This is the (perhaps temporary location for) the implementation of CRM_Utils_System_Standalone method.
    */


### PR DESCRIPTION
Overview
----------------------------------------

This cleans up unused function which are not needed anymore for setting the user language.

@artfulrobot can you review this?

See as well: https://lab.civicrm.org/dev/core/-/issues/4411