### PR TITLE
standalone: fix failing E2E test due to getting resource base URL

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -387,7 +387,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
     }
 
     return [
-      'url' => CRM_Utils_File::addTrailingSlash('', '/'),
+      'url' => CRM_Utils_File::addTrailingSlash(CIVICRM_UF_BASEURL, '/') . '/core/',
       'path' => CRM_Utils_File::addTrailingSlash($civicrm_root),
     ];
   }


### PR DESCRIPTION
Fixes E2E\Core\PathUrlTest::testPaths_getUrl


## Before

It may be right to enable this test, but it is failing :

```
1) E2E\Core\PathUrlTest::testPaths_getUrl                                                                                                             
Failed asserting that '' matches PCRE pattern ";https://civicrm.org/licensing;".                                                                      
                                                                                                                                                      
/buildkit/civicrm-buildkit/build/so2/web/core/tests/phpunit/E2E/Core/PathUrlTest.php:168                                                              
/buildkit/civicrm-buildkit/build/so2/web/core/tests/phpunit/E2E/Core/PathUrlTest.php:33                                                               
/buildkit/civicrm-buildkit/extern/phpunit9/phpunit9.phar:2307                                                                                         
```

On my buildkit, it's getting: http://so2.localhost:8100/js/Common.js but it *should* be fetching 
http://so2.localhost:8100/core/js/Common.js

Despite the Resource URL page saying: 

> CiviCRM Resource URL   	http://so2.localhost:8100/core

## After

Tests pass.

@ufundo 