### PR TITLE
Add searchkit and afform display

### DIFF
--- a/ext/civicrm_admin_ui/ang/afsearchHeadersFootersAndAutomatedMessages.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchHeadersFootersAndAutomatedMessages.aff.html
@@ -1,0 +1,3 @@
+<div af-fieldset="">
+  <crm-search-display-table search-name="Headers_Footers_and_Automated_Messages" display-name="Headers_Footers_and_Automated_Messages_Table_1"></crm-search-display-table>
+</div>

--- a/ext/civicrm_admin_ui/ang/afsearchHeadersFootersAndAutomatedMessages.aff.php
+++ b/ext/civicrm_admin_ui/ang/afsearchHeadersFootersAndAutomatedMessages.aff.php
@@ -1,0 +1,14 @@
+<?php
+use CRM_CivicrmAdminUi_ExtensionUtil as E;
+
+return [
+  'type' => 'search',
+  'title' => E::ts('Headers, Footers, and Automated Messages'),
+  'icon' => 'fa-list-alt',
+  'server_route' => 'civicrm/admin/component',
+  'permission' => [
+    'access CiviCRM',
+    'access CiviMail',
+  ],
+  'modified_date' => '2023-12-04 10:53:21',
+];

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Headers_Footers_and_Automated_Messages.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Headers_Footers_and_Automated_Messages.mgd.php
@@ -1,0 +1,220 @@
+<?php
+use CRM_CivicrmAdminUi_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'SavedSearch_Headers_Footers_and_Automated_Messages',
+    'entity' => 'SavedSearch',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Headers_Footers_and_Automated_Messages',
+        'label' => E::ts('Headers, Footers, and Automated Messages'),
+        'api_entity' => 'MailingComponent',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'name',
+            'component_type:label',
+            'subject',
+            'body_html',
+            'body_text',
+            'is_default',
+            'is_active',
+          ],
+          'orderBy' => [],
+          'where' => [],
+          'groupBy' => [],
+          'join' => [],
+          'having' => [],
+        ],
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'SavedSearch_Headers_Footers_and_Automated_Messages_SearchDisplay_Headers_Footers_and_Automated_Messages_Table_1',
+    'entity' => 'SearchDisplay',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Headers_Footers_and_Automated_Messages_Table_1',
+        'label' => E::ts('Headers, Footers, and Automated Messages'),
+        'saved_search_id.name' => 'Headers_Footers_and_Automated_Messages',
+        'type' => 'table',
+        'settings' => [
+          'description' => NULL,
+          'sort' => [
+            [
+              'component_type',
+              'ASC',
+            ],
+          ],
+          'limit' => 50,
+          'pager' => [],
+          'placeholder' => 5,
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'name',
+              'dataType' => 'String',
+              'label' => E::ts('Name'),
+              'sortable' => FALSE,
+              'editable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'component_type:label',
+              'dataType' => 'String',
+              'label' => E::ts('Type'),
+              'sortable' => FALSE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'subject',
+              'dataType' => 'String',
+              'label' => E::ts('Subject'),
+              'sortable' => FALSE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'body_html',
+              'dataType' => 'Text',
+              'label' => E::ts('Body HTML'),
+              'sortable' => FALSE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'body_text',
+              'dataType' => 'Text',
+              'label' => E::ts('Body Text'),
+              'sortable' => FALSE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'is_default',
+              'dataType' => 'Boolean',
+              'label' => E::ts('Default?'),
+              'sortable' => FALSE,
+              'rewrite' => '[none]',
+              'title' => NULL,
+              'icons' => [
+                [
+                  'icon' => 'fa-check',
+                  'side' => 'left',
+                  'if' => [
+                    'is_default',
+                    '=',
+                    TRUE,
+                  ],
+                ],
+              ],
+            ],
+            [
+              'type' => 'field',
+              'key' => 'is_active',
+              'dataType' => 'Boolean',
+              'label' => E::ts('Enabled?'),
+              'sortable' => FALSE,
+              'icons' => [],
+              'rewrite' => '',
+            ],
+            [
+              'links' => [
+                [
+                  'entity' => 'MailingComponent',
+                  'action' => 'update',
+                  'join' => '',
+                  'target' => 'crm-popup',
+                  'icon' => '',
+                  'text' => E::ts('Edit'),
+                  'style' => 'default',
+                  'path' => '',
+                  'task' => '',
+                  'condition' => [],
+                ],
+                [
+                  'task' => 'disable',
+                  'entity' => 'MailingComponent',
+                  'join' => '',
+                  'target' => 'crm-popup',
+                  'icon' => '',
+                  'text' => E::ts('Disable'),
+                  'style' => 'default',
+                  'path' => '',
+                  'action' => '',
+                  'condition' => [
+                    'is_active',
+                    '=',
+                    TRUE,
+                  ],
+                ],
+                [
+                  'task' => 'enable',
+                  'entity' => 'MailingComponent',
+                  'join' => '',
+                  'target' => 'crm-popup',
+                  'icon' => '',
+                  'text' => E::ts('Enable'),
+                  'style' => 'default',
+                  'path' => '',
+                  'action' => '',
+                  'condition' => [
+                    'is_active',
+                    '=',
+                    FALSE,
+                  ],
+                ],
+              ],
+              'type' => 'links',
+              'alignment' => 'text-right',
+            ],
+          ],
+          'actions' => FALSE,
+          'classes' => [
+            'table-striped',
+            'table',
+          ],
+          'toolbar' => [
+            [
+              'action' => 'add',
+              'entity' => 'MailingComponent',
+              'text' => E::ts('Add Mailing Component'),
+              'icon' => 'fa-plus',
+              'style' => 'primary',
+              'target' => 'crm-popup',
+              'join' => '',
+              'path' => '',
+              'task' => '',
+              'condition' => [
+                'check user permission',
+                '=',
+                [
+                  'access CiviMail',
+                ],
+              ],
+            ],
+          ],
+          'cssRules' => [
+            [
+              'disabled',
+              'is_active',
+              '=',
+              FALSE,
+            ],
+          ],
+        ],
+      ],
+      'match' => [
+        'saved_search_id',
+        'name',
+      ],
+    ],
+  ],
+];


### PR DESCRIPTION
Overview
----------------------------------------
Adds afform / searchkit display to replace 'Headers Footers and Automated Messages' in menu.

Before
----------------------------------------
Interface not using searchkit / afform
![28484-hft](https://github.com/civicrm/civicrm-core/assets/1892544/81ece83f-698c-4c7a-b2c5-9d37d0d0a89d)



After
---------
Interface now using searchkit /afform
![28484-hft-sk](https://github.com/civicrm/civicrm-core/assets/1892544/023b9130-27ef-4f6e-a1a1-6082bab01065)

Comments
--------
Clicking on any edit link - say Mailing Footer - (http://wpcvmaster.local:8080/wp-admin/admin.php?page=CiviCRM&q=civicrm%2Fadmin%2Fcomponent&action=update&id=2&reset=1)  generates a popup.  

The popup is new, and it may be  a beter UX to open in full screen as before.
