### PR TITLE
Add deprecation to transition components

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1778,11 +1778,14 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
    * Use api contribute.completetransaction
    * For failures use failPayment (preferably exposing by api in the process).
    *
+   * @deprecated since 5.69 Will be remvoed ASAP since this is old & crufty &
+   * should never have been used outside core.
    */
   public static function transitionComponents($params) {
     // @todo fix the one place that calls this function to use Payment.create
     // remove this.
     // get minimum required values.
+    CRM_Core_Error::deprecatedFunctionWarning('use Payment.create api');
     $contributionId = $params['contribution_id'];
 
     // we process only ( Completed, Cancelled, or Failed ) contributions.


### PR DESCRIPTION
Overview
----------------------------------------
Add deprecation to transition components

There is one remaining usage - I'm hoping tests will fail on it

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
