### PR TITLE
Add `QueueItem` api

### DIFF
--- a/Civi/Api4/Action/Contact/ContactSaveTrait.php
+++ b/Civi/Api4/Action/Contact/ContactSaveTrait.php
@@ -90,4 +90,21 @@ trait ContactSaveTrait {
     }
   }
 
+  /**
+   * Get fields the logged in user is not permitted to act on.
+   *
+   * Override parent to exclude api_key as this is dealt with elsewhere.
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  public function getUnpermittedFields(): array {
+    $fields = parent::getUnpermittedFields();
+    if (\CRM_Core_Session::getLoggedInContactID()) {
+      // This is handled in the BAO to allow for edit own api key.
+      unset($fields['api_key']);
+    }
+    return $fields;
+  }
+
 }

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -27,6 +27,44 @@ trait DAOActionTrait {
   private $_maxWeights = [];
 
   /**
+   * Get fields the logged in user is not permitted to act on.
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  public function getUnpermittedFields(): array {
+    $unpermittedFields = [];
+    if ($this->getCheckPermissions()) {
+      $fields = $this->entityFields();
+      foreach ($fields as $field) {
+        if (!empty($field['permission']) && !\CRM_Core_Permission::check($field['permission'])) {
+          $unpermittedFields[$field['name']] = ['permission' => $field['permission'], 'own_permission' => []];
+        }
+      }
+    }
+    return $unpermittedFields;
+  }
+
+  /**
+   * Filter out any fields with field level permissions.
+   *
+   * @param array $items
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function filterUnpermittedFields(array &$items): void {
+    $unpermittedFields = $this->getUnpermittedFields();
+    $userID = \CRM_Core_Session::getLoggedInContactID();
+    if ($unpermittedFields) {
+      foreach ($items as &$item) {
+        foreach ($unpermittedFields as $unpermittedField => $permissions) {
+          unset($item[$unpermittedField]);
+        }
+      }
+    }
+  }
+
+  /**
    * @return \CRM_Core_DAO|string
    */
   protected function getBaoName() {
@@ -165,6 +203,7 @@ trait DAOActionTrait {
     $baoName = $this->getBaoName();
 
     $method = method_exists($baoName, 'create') ? 'create' : (method_exists($baoName, 'add') ? 'add' : NULL);
+    $this->filterUnpermittedFields($items);
     // Use BAO create or add method if not deprecated
     if ($method && !ReflectionUtils::isMethodDeprecated($baoName, $method)) {
       foreach ($items as $item) {

--- a/Civi/Api4/QueueItem.php
+++ b/Civi/Api4/QueueItem.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Api4;
+
+use Civi\Api4\Generic\DAOEntity;
+
+/**
+ * Track the list if items with CiviCRM processing queues.
+ *
+ * @searchable secondary
+ * @since 5.69
+ * @package Civi\Api4
+ */
+class QueueItem extends DAOEntity {
+
+  use Generic\Traits\ManagedEntity;
+
+  /**
+   * @return array
+   */
+  public static function permissions(): array {
+    return [
+      'meta' => ['access CiviCRM'],
+      // Note that the queue items can have private information in them
+      // e.g other users imports.
+      // so only users with administer queues should access.
+      'default' => ['administer queues'],
+    ];
+  }
+
+}

--- a/Civi/Api4/Service/Spec/Provider/QueueItemSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/QueueItemSpecProvider.php
@@ -16,6 +16,10 @@ use Civi\Api4\Service\Spec\RequestSpec;
 use Civi\Core\Service\AutoService;
 
 /**
+ * Set permissions on Queue Items to allow some fields (release_date etc) but NOT the data to be
+ * edited for queue items - this allows search kits to be used to manage queue items but not to inject
+ * executable code.
+ *
  * @service
  * @internal
  */
@@ -32,7 +36,10 @@ class QueueItemSpecProvider extends AutoService implements Generic\SpecProviderI
    * @inheritDoc
    */
   public function applies($entity, $action): bool {
-    return $entity === 'QueueItem' && in_array($action, ['create', 'update']);
+    // Currently we do for all actions - it might be OK to select - but it fails anyway as
+    // it is an serialized object & there are no non-crud actions. create & update are the minimum
+    // required here.
+    return $entity === 'QueueItem';
   }
 
 }

--- a/Civi/Api4/Service/Spec/Provider/QueueItemSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/QueueItemSpecProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\RequestSpec;
+use Civi\Core\Service\AutoService;
+
+/**
+ * @service
+ * @internal
+ */
+class QueueItemSpecProvider extends AutoService implements Generic\SpecProviderInterface {
+
+  /**
+   * @inheritDoc
+   */
+  public function modifySpec(RequestSpec $spec): void {
+    $spec->getFieldByName('data')->setPermission([\CRM_Core_Permission::ALWAYS_DENY_PERMISSION]);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function applies($entity, $action): bool {
+    return $entity === 'QueueItem' && in_array($action, ['create', 'update']);
+  }
+
+}

--- a/ext/standaloneusers/Civi/Api4/Action/User/WriteTrait.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/WriteTrait.php
@@ -140,4 +140,15 @@ trait WriteTrait {
     return $saved;
   }
 
+  /**
+   * Get fields the logged in user is not permitted to act on.
+   *
+   * Override parent to implement custom handling.
+   *
+   * @return array
+   */
+  public function getUnpermittedFields(): array {
+    return [];
+  }
+
 }

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -55,7 +55,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    *
    * @var string
    */
-  protected $entity = 'Contact';
+  protected string $entity = 'Contact';
 
   /**
    * Test setup for every test.
@@ -613,13 +613,23 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
     // Disallow edit -- because we don't have permission
     $config->userPermissionClass->permissions = ['access CiviCRM', 'edit all contacts'];
-    $result = $this->callAPIFailure('Contact', 'create', [
-      'check_permissions' => 1,
-      'id' => $contactId,
-      'api_key' => 'defg4321',
-    ]);
-    $this->assertMatchesRegularExpression(';Permission denied to modify api key;', $result['error_message']);
-
+    if ($version === 3) {
+      $result = $this->callAPIFailure('Contact', 'create', [
+        'check_permissions' => 1,
+        'id' => $contactId,
+        'api_key' => 'defg4321',
+      ]);
+      $this->assertMatchesRegularExpression(';Permission denied to modify api key;', $result['error_message']);
+    }
+    else {
+      $this->callAPISuccess('Contact', 'create', [
+        'check_permissions' => 1,
+        'id' => $contactId,
+        'api_key' => 'defg4321',
+      ]);
+      $this->callAPISuccess('Contact', 'get', ['id' => $contactId]);
+      $this->assertEquals('abcd1234', CRM_Core_DAO::singleValueQuery(' SELECT api_key FROM civicrm_contact WHERE id = ' . $contactId));
+    }
     // Return everything -- because permissions are not being checked
     $config->userPermissionClass->permissions = [];
     $result = $this->callAPISuccess('Contact', 'create', [
@@ -1555,7 +1565,6 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * https://issues.civicrm.org/jira/browse/CRM-16084
    * @param int $version
    *
-   * @throws \CRM_Core_Exception
    * @dataProvider versionThreeAndFour
    */
   public function testDirectionChainingRelationshipsCRM16084(int $version): void {

--- a/tests/phpunit/api/v4/Action/ContactApiKeyTest.php
+++ b/tests/phpunit/api/v4/Action/ContactApiKeyTest.php
@@ -184,19 +184,16 @@ class ContactApiKeyTest extends Api4TestBase implements TransactionalInterface {
     \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'add contacts'];
     $key = uniqid();
 
-    $error = '';
-    try {
-      Contact::create()
-        ->addValue('first_name', 'Api')
-        ->addValue('last_name', 'Key1')
-        ->addValue('api_key', $key)
-        ->execute()
-        ->first();
-    }
-    catch (\Exception $e) {
-      $error = $e->getMessage();
-    }
-    $this->assertStringContainsString('key', $error);
+    Contact::create()
+      ->addValue('first_name', 'Api')
+      ->addValue('last_name', 'Key1')
+      ->addValue('api_key', $key)
+      ->execute()
+      ->first();
+    $contact = Contact::get(FALSE)
+      ->addWhere('first_name', '=', 'Api')
+      ->execute()->single();
+    $this->assertEmpty($contact['api_key']);
   }
 
   public function testGetApiKeyViaJoin(): void {
@@ -250,24 +247,17 @@ class ContactApiKeyTest extends Api4TestBase implements TransactionalInterface {
       ->first();
 
     $error = '';
-    try {
-      // Try to update the key without permissions; nothing should happen
-      Contact::update()
-        ->addWhere('id', '=', $contact['id'])
-        ->addValue('api_key', "NotAllowed")
-        ->execute();
-    }
-    catch (\Exception $e) {
-      $error = $e->getMessage();
-    }
+    // Try to update the key without permissions; nothing should happen
+    Contact::update()
+      ->addWhere('id', '=', $contact['id'])
+      ->addValue('api_key', "NotAllowed")
+      ->execute();
 
     $result = Contact::get(FALSE)
       ->addWhere('id', '=', $contact['id'])
       ->addSelect('api_key')
       ->execute()
       ->first();
-
-    $this->assertStringContainsString('key', $error);
 
     // Assert key is still the same
     $this->assertEquals($result['api_key'], $key);
@@ -301,19 +291,10 @@ class ContactApiKeyTest extends Api4TestBase implements TransactionalInterface {
       ->execute()
       ->first();
 
-    $error = '';
-    try {
-      // Try to update the key without permissions; nothing should happen
-      Contact::update()
-        ->addWhere('id', '=', $contact['id'])
-        ->addValue('api_key', "NotAllowed")
-        ->execute();
-    }
-    catch (\Exception $e) {
-      $error = $e->getMessage();
-    }
-
-    $this->assertStringContainsString('key', $error);
+    Contact::update()
+      ->addWhere('id', '=', $contact['id'])
+      ->addValue('api_key', "NotAllowed")
+      ->execute();
 
     $result = Contact::get(FALSE)
       ->addWhere('id', '=', $contact['id'])
@@ -339,7 +320,7 @@ class ContactApiKeyTest extends Api4TestBase implements TransactionalInterface {
       ->first();
 
     // Assert key was updated
-    $this->assertEquals($result['api_key'], "MyId!");
+    $this->assertEquals("MyId!", $result['api_key']);
   }
 
   public function testApiKeyWithGetFields(): void {


### PR DESCRIPTION
Overview
----------------------------------------
Add `QueueItem` api

Before
----------------------------------------
It is not possible for a suitably permissioned user to view / edit queue items

After
----------------------------------------
Possible for user with `administer queues' to configure a search kit to view queue items & potentially alter the release time  or delete an item from the damaged queue after investigating / otherwise resolving

Technical Details
----------------------------------------
In doing this I had to fix the api to support field-specific permissions in edit mode. I hit some difficulties with this as talking with @colemanw he felt we should prune out the fields at the api layer if there were no permissions. This means people don't get a situation where something might be on the form as available in select mode but causes an error on submit if the user does not have permission to edit the field. The flow on effect was that  `contact.api_key` and `user.password` did not get to the next layer, which implemented 'edit own api key' and 'password can be created by anon user but not edited except....'.  This is being handled by implementing functions on those api to prevent the parent class from pruning the fields. 

Another challenge is that the metadata permissions are basically read permissions but the permissions might differ from edit - but the metadata is read permissions

It might make sense to use a permissions call back within the metadata but that felt like a bit too big a lift for this time around.


I picked up the ManagedEntity trait because I copied the`Queue` - I'm inclined to keep it cos if you can export a queue you probably want the items (e.g if copying back to local to debug)

Comments
----------------------------------------
@totten OK with this?