### PR TITLE
Update CustomField default_value to NULL instead of '' for floats

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.69.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.69.alpha1.mysql.tpl
@@ -1,4 +1,7 @@
 {* file to handle db changes in 5.69.alpha1 during upgrade *}
+-- Fix default for any custom fields of data-type float to be NULL rather than empty string --
+UPDATE civicrm_custom_field SET default_value = NULL WHERE default_value = '' AND data_type = 'Float';
+
 -- Add missing provinces for Zambia
 SELECT @country_id := id FROM civicrm_country WHERE name = 'Zambia';
 INSERT IGNORE INTO `civicrm_state_province` (`country_id`, `abbreviation`, `name`) VALUES (@country_id, 'C', 'Central');


### PR DESCRIPTION
Overview
----------------------------------------
Update CustomField default_value to NULL instead of '' for floats

To replicate enable debugging, create a custom field of type `Number`
![image](https://github.com/civicrm/civicrm-core/assets/336308/f7e9b380-d296-4351-b5a0-57dbb4b54e60)

Then directly in the database edit the default_value for this custom field to an empty string rather than NULL - on creating entries deprecation notices should start showing up

Before
----------------------------------------
We have been seeing log noise like 

ller: CRM_Utils_Money::formatLocaleNumericRoundedByPrecision {"civi.tag":"deprecated"} []
[2023-06-22T12:36:25.812334-04:00] civicrm.WARNING: Passing an empty string for amount is deprecated. Caller: CRM_Core_BAO_CustomGroup::setDefaults {"civi.tag":"deprecated"} []
[2023-06-22T12:36:25.813276-04:00] civicrm.WARNING: Formatting non-numeric values is no longer supported:  Caller: CRM_Utils_Money::formatLocaleNumericRoundedByPrecision {"civi.tag":"deprecated"} []

I tracked it down to a custom field created a very very long time ago with the data_type of FLOAT but a default of ''. If I create a new field with this data_type the default_value is NULL but this legacy field didn't get the memo

After
----------------------------------------
This update should ensure no sites are getting unnecessary log noise as a result of this issue

Technical Details
----------------------------------------

Comments
----------------------------------------
