### PR TITLE
dev/core#4447 fix inability to import to master_id

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -301,7 +301,6 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address implements Civi\Core\Hoo
         'contact_id',
         'is_billing',
         'display',
-        'master_id',
       ])) {
         continue;
       }
@@ -899,6 +898,8 @@ SELECT is_primary,
    * Fix the shared address if address is already shared
    * or if address will be shared with itself.
    *
+   * Add in the details from the master address.
+   *
    * @param array $params
    *   Associated array of address params.
    */
@@ -913,6 +914,12 @@ SELECT is_primary,
     if (($params['id'] ?? NULL) == $params['master_id']) {
       $params['master_id'] = NULL;
       CRM_Core_Session::setStatus(ts("You can't connect an address to itself"), '', 'warning');
+    }
+    if ($params['master_id']) {
+      $masterAddressParams = Address::get(FALSE)
+        ->addWhere('id', '=', $params['master_id'])->execute()->first();
+      unset($masterAddressParams['id'], $masterAddressParams['is_primary'], $masterAddressParams['is_billing'], $masterAddressParams['contact_id']);
+      $params += $masterAddressParams;
     }
   }
 

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -310,6 +310,22 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * @throws \CRM_Core_Exception
+   */
+  public function testImportMasterAddress(): void {
+    $this->individualCreate(['external_identifier' => 'billy', 'first_name' => 'William'], 'billy-the-kid');
+    $address = $this->callAPISuccess('Address', 'create', ['street_address' => 'out yonder', 'contact_id' => $this->ids['Contact']['billy-the-kid']]);
+    $this->individualCreate(['external_identifier' => '', 'first_name' => 'Daddy Bill'], 'billy-the-dad');
+    $this->runImport([
+      'id' => $this->ids['Contact']['billy-the-dad'],
+      'master_id' => $address['id'],
+    ], CRM_Import_Parser::DUPLICATE_UPDATE, CRM_Import_Parser::VALID);
+    $newAddress = $this->callAPISuccessGetSingle('Address', ['contact_id' => $this->ids['Contact']['billy-the-dad']]);
+    $this->assertEquals($address['id'], $newAddress['master_id']);
+    $this->assertEquals('out yonder', $newAddress['street_address']);
+  }
+
+  /**
    * Test updating an existing contact with external_identifier match but
    * subtype mismatch.
    *

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -2986,9 +2986,9 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       [
         'first_name' => 'Joe',
         'last_name' => 'Miller',
-        'Home-street_address' => '',
-        'Home-city' => '',
-        'Home-country' => '',
+        'Home-street_address' => 'Ambachtstraat 23',
+        'Home-city' => 'Brummen',
+        'Home-country' => 'Netherlands',
         'Home-email' => 'joe_miller@civicrm.org',
       ],
     ], $result);

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -1114,9 +1114,9 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'Contact is in Trash' => '',
       'Created Date' => '2019-07-11 10:28:15',
       'Modified Date' => '2019-07-11 10:28:15',
-      'Addressee' => 'Mr. Anthony J. Anderson II, Dr. Sarah J. Smith II',
-      'Email Greeting' => 'Dear Anthony, Sarah',
-      'Postal Greeting' => 'Dear Anthony, Sarah',
+      'Addressee' => 'Mr. Anthony J. Anderson II, Mr. Joe M. Miller II',
+      'Email Greeting' => 'Dear Anthony, Joe',
+      'Postal Greeting' => 'Dear Anthony, Joe',
       'Current Employer' => '',
       'Location Type' => 'Home',
       'Street Address' => 'Ambachtstraat 23',
@@ -1189,9 +1189,9 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       ],
     ]);
     $this->assertExpectedOutput([
-      'Addressee' => 'random string Mr. Anthony Anderson II, Dr. Sarah Smith II',
-      'Email Greeting' => 'II Anderson and first is Anthony , II Smith Sarah ',
-      'Postal Greeting' => 'II Anderson and first is Anthony , II Smith Sarah ',
+      'Addressee' => 'random string Mr. Anthony Anderson II, Mr. Joe Miller II',
+      'Email Greeting' => 'II Anderson and first is Anthony , II Miller Joe ',
+      'Postal Greeting' => 'II Anderson and first is Anthony , II Miller Joe ',
     ], $this->csv->fetchOne());
     // 3 contacts merged to 2.
     $this->assertCount(2, $this->csv);
@@ -3004,7 +3004,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     $params = [
       'contact_id' => $contact3,
       'location_type_id' => 'Home',
-      'street_address' => 'Ambachtstraat 23',
+      'street_address' => 'A different address',
       'postal_code' => '6971 BN',
       'country_id' => '1152',
       'city' => 'Brummen',


### PR DESCRIPTION
Overview
----------------------------------------

Fixes a bug where importing to a contact and specifying the master_id only works if at least one other address field is included in the import

The bug report is https://lab.civicrm.org/dev/core/-/issues/4447

But my read of the documentation says that " taking over the address of another contact " was never part of the feature

"Master Address Belongs To is a special import field that only works with the CiviCRM_Address.id. The information needed to use this field for imports is only available directly from the MySQL database tables directly. They are not shown anywhere in CiviCRM including on data screens, link urls, profiles, or exports. [Information on how to use this special field is available in the Wiki](http://wiki.civicrm.org/confluence/display/CRMDOC/Importing+Data+-+Notes)."

Before
----------------------------------------
Importing a csv with contact ID & master address ID doesn't change anything but if another field (e.g) city is present it updates both the city & master ID

After
----------------------------------------
The update takes place even if only master_id is present. In addition the details from the master address are filled into the saved address

Technical Details
----------------------------------------
This is handled in the BAO & I think it changed there at some point.

Comments
----------------------------------------
