### PR TITLE
Remove notice from main donate page

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -319,9 +319,9 @@
 
     function toggleRecur() {
       var isRecur = cj('input[id="is_recur"]:checked');
-      var allowAutoRenew = {/literal}'{$allowAutoRenewMembership}'{literal};
+
       var quickConfig = {/literal}'{$quickConfig}'{literal};
-      if (allowAutoRenew && cj("#auto_renew") && quickConfig) {
+      if (cj("#auto_renew") && quickConfig) {
         showHideAutoRenew(null);
       }
 


### PR DESCRIPTION

Overview
----------------------------------------
Remove notice from main donate page

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/fd16dab9-d570-46d9-bd83-311240790619)

After
----------------------------------------
poof

Technical Details
----------------------------------------
auto_renew is added to the form after allowAutoRenewMembership is assigned, and only if it is true - so the check for cj('auto_renew') is not enhanced by the check for the variable
- but it DOES lead to notices on the other pages

Comments
----------------------------------------
