### PR TITLE
Standalone - user edit pop-up and entity link

### DIFF
--- a/ext/standaloneusers/managed/SavedSearch_Administer_Users.mgd.php
+++ b/ext/standaloneusers/managed/SavedSearch_Administer_Users.mgd.php
@@ -73,9 +73,8 @@ return [
               'label' => E::ts('Username'),
               'sortable' => TRUE,
               'link' => [
-                'path' => '/civicrm/admin/user#?User1=[id]',
-                'entity' => '',
-                'action' => '',
+                'entity' => 'User',
+                'action' => 'update',
                 'join' => '',
                 'target' => 'crm-popup',
               ],

--- a/ext/standaloneusers/managed/SavedSearch_Administer_Users.mgd.php
+++ b/ext/standaloneusers/managed/SavedSearch_Administer_Users.mgd.php
@@ -77,7 +77,7 @@ return [
                 'entity' => '',
                 'action' => '',
                 'join' => '',
-                'target' => '',
+                'target' => 'crm-popup',
               ],
             ],
             [


### PR DESCRIPTION
Overview
----------------------------------------
Pop up the user edit form -- consistent with popping up the role edit form on Administer Roles page https://github.com/civicrm/civicrm-core/blob/e828aab3db290dcf9936fe5cd96235bc7a1f4fb7/ext/standaloneusers/managed/SavedSearch_Administer_Roles.mgd.php#L91

Also use the entity Update link rather than hard-coded path
