### PR TITLE
Standalone - access denied status code 403

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -577,9 +577,8 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
       CRM_Core_Error::statusBounce(ts("Access denied"), CRM_Utils_System::url('civicrm'));
     }
     else {
-      CRM_Utils_System::redirect('/civicrm/login?anonAccessDenied');
+      CRM_Utils_System::redirect('/civicrm/login?accessDenied=anon');
     }
-
     // TODO: Prettier error page
   }
 

--- a/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
@@ -17,6 +17,10 @@ class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
     // Remove breadcrumb for login page.
     $this->assign('breadcrumb', NULL);
 
+    if ('anon' === CRM_Utils_Request::retrieve('accessDenied', 'String')) {
+      // should this be 401?
+      http_response_code(403);
+    }
     parent::run();
   }
 
@@ -26,7 +30,7 @@ class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
   public static function logout() {
     Security::singleton()->logoutUser();
     // Dump them back on the log-IN page.
-    CRM_Utils_System::redirect('/civicrm/login?justLoggedOut');
+    CRM_Utils_System::redirect('/civicrm/login?justLoggedOut=1');
   }
 
 }

--- a/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
+++ b/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
@@ -26,12 +26,14 @@ document.addEventListener('DOMContentLoaded', () => {
         password = document.getElementById('passwordInput'),
         loggedOutNotice = document.getElementById('loggedOutNotice');
 
-  // Special messages.
-  if (window.location.search === '?justLoggedOut') {
+  // Get special messages from url params
+  const url = new URL(window.location);
+
+  if (url.searchParams.get('justLoggedOut')) {
     loggedOutNotice.style.display = '';
     console.log("successful logout");
   }
-  else if (window.location.search === '?anonAccessDenied') {
+  if ('anon' === url.searchParams.get('accessDenied')) {
     anonAccessDenied.style.display = '';
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://test.civicrm.org/job/CiviCRM-E2E-Matrix/BKPROF=min,BLDTYPE=standalone-clean,CIVIVER=master,label=bknix-tmp/lastCompletedBuild/testReport/(root)/E2E_Core_ErrorTest/testErrorStatus_with_data_set__frontend_permission_/ 
 wants us to return a 403 when an anonymous user tries to access something they aren't allowed to.


Before
----------------------------------------
Currently they are redirected to the login page, which is helpful user behaviour.  But they don't receive a 403 at any point. And the test isn't happy.

After
----------------------------------------
Anonymous user trying to access something they shouldn't is redirected to login, the login page is served as a 403.

Technical Details
----------------------------------------
I'm not sure if it's the right thing to do. I think ideally the 403 would be on the url that you were denied access to. 

Better alternatives could be:
- to serve a 403 page saying "You need to log in to do that" and then have a link to the login page and/or a Javascript redirect from that page
- to serve a 403 page at the original URL which includes the login form

I also think maybe it _should_ be a 401 ("you haven't told us who you are") rather than a 403 ("we know who you are, but you're not allowed to do that") - but that's going to complicate the test no end...

