### PR TITLE
searchui : new screen label format

### DIFF
--- a/ext/civicrm_search_ui/ang/afsearchLabelFormat.aff.html
+++ b/ext/civicrm_search_ui/ang/afsearchLabelFormat.aff.html
@@ -1,0 +1,12 @@
+<div af-fieldset="">
+  <div class="af-markup">
+    
+    <div class="help">
+    <div>{{:: ts('You can configure one or more Label Formats for your CiviCRM installation. Label Formats are used when creating mailing labels.')}}<br/>
+{{:: ts('You can change which fields are printed on each label in')}} <a href="/civicrm/admin/setting/preferences/address?reset=1">{{:: ts('Address Settings')}}</a>.</div>
+    </div>
+
+  
+  </div>
+  <crm-search-display-table search-name="label_format" display-name="label_format_Table_1"></crm-search-display-table>
+</div>

--- a/ext/civicrm_search_ui/ang/afsearchLabelFormat.aff.php
+++ b/ext/civicrm_search_ui/ang/afsearchLabelFormat.aff.php
@@ -1,0 +1,11 @@
+<?php
+use CRM_CivicrmSearchUi_ExtensionUtil as E;
+
+return [
+  'type' => 'search',
+  'title' => E::ts('Label Format form'),
+  'description' => E::ts('Label Format form'),
+  'icon' => 'fa-list-alt',
+  'server_route' => 'civicrm/searchkit_ui/admin/labelFormats',
+  'modified_date' => '2023-12-05 04:11:31',
+];

--- a/ext/civicrm_search_ui/managed/SavedSearch_label_format.mgd.php
+++ b/ext/civicrm_search_ui/managed/SavedSearch_label_format.mgd.php
@@ -1,0 +1,200 @@
+<?php
+use CRM_CivicrmSearchUi_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'SavedSearch_label_format',
+    'entity' => 'SavedSearch',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'label_format',
+        'label' => E::ts('label format'),
+        'api_entity' => 'OptionGroup',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'OptionGroup_OptionValue_option_group_id_01.label',
+            'title',
+            'description',
+            'is_active',
+            'is_reserved',
+            'OptionGroup_OptionValue_option_group_id_01.grouping',
+          ],
+          'orderBy' => [],
+          'where' => [
+            [
+              'name',
+              'IN',
+              [
+                'label_format',
+                'name_badge',
+              ],
+            ],
+          ],
+          'groupBy' => [],
+          'join' => [
+            [
+              'OptionValue AS OptionGroup_OptionValue_option_group_id_01',
+              'LEFT',
+              [
+                'id',
+                '=',
+                'OptionGroup_OptionValue_option_group_id_01.option_group_id',
+              ],
+            ],
+          ],
+          'having' => [],
+        ],
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'SavedSearch_label_format_SearchDisplay_label_format_Table_1',
+    'entity' => 'SearchDisplay',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'label_format_Table_1',
+        'label' => E::ts('label format Table 1'),
+        'saved_search_id.name' => 'label_format',
+        'type' => 'table',
+        'settings' => [
+          'description' => '',
+          'sort' => [],
+          'limit' => 50,
+          'pager' => [],
+          'placeholder' => 5,
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'OptionGroup_OptionValue_option_group_id_01.label',
+              'dataType' => 'String',
+              'label' => E::ts('Name'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'title',
+              'dataType' => 'String',
+              'label' => E::ts('Used for'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'OptionGroup_OptionValue_option_group_id_01.grouping',
+              'dataType' => 'String',
+              'label' => E::ts('Grouping'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'is_active',
+              'dataType' => 'Boolean',
+              'label' => E::ts('Enabled'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'is_reserved',
+              'dataType' => 'Boolean',
+              'label' => E::ts('Reserved'),
+              'sortable' => TRUE,
+            ],
+            [
+              'size' => 'btn-xs',
+              'links' => [
+                [
+                  'entity' => '',
+                  'action' => '',
+                  'join' => '',
+                  'target' => 'crm-popup',
+                  'icon' => '',
+                  'text' => E::ts('Edit'),
+                  'style' => 'default',
+                  'path' => 'civicrm/admin/labelFormats?action=update&id=[OptionGroup_OptionValue_option_group_id_01.id]&group=[name]&reset=1',
+                  'task' => '',
+                  'condition' => [],
+                ],
+              ],
+              'type' => 'buttons',
+              'alignment' => 'text-right',
+            ],
+            [
+              'size' => 'btn-xs',
+              'links' => [
+                [
+                  'entity' => '',
+                  'action' => '',
+                  'join' => '',
+                  'target' => '',
+                  'icon' => '',
+                  'text' => E::ts('Copy'),
+                  'style' => 'default',
+                  'path' => 'civicrm/admin/labelFormats?action=copy&id=[OptionGroup_OptionValue_option_group_id_01.id]&group=[name]&reset=1',
+                  'task' => '',
+                  'condition' => [],
+                ],
+              ],
+              'type' => 'buttons',
+              'alignment' => 'text-right',
+            ],
+            [
+              'size' => 'btn-xs',
+              'links' => [
+                [
+                  'entity' => 'OptionValue',
+                  'action' => 'delete',
+                  'join' => 'OptionGroup_OptionValue_option_group_id_01',
+                  'target' => 'crm-popup',
+                  'icon' => 'fa-trash',
+                  'text' => E::ts('Delete'),
+                  'style' => 'danger',
+                  'path' => '',
+                  'task' => '',
+                  'condition' => [
+                    'OptionGroup_OptionValue_option_group_id_01.grouping',
+                    '=',
+                    'Custom',
+                  ],
+                ],
+              ],
+              'type' => 'buttons',
+              'alignment' => 'text-right',
+            ],
+          ],
+          'actions' => FALSE,
+          'classes' => [
+            'table',
+            'table-striped',
+          ],
+          'toolbar' => [
+            [
+              'action' => '',
+              'entity' => '',
+              'text' => E::ts('Add Label Format'),
+              'icon' => '',
+              'style' => 'default',
+              'target' => 'crm-popup',
+              'join' => '',
+              'path' => 'civicrm/admin/labelFormats?action=add&reset=1',
+              'task' => '',
+              'condition' => [],
+            ],
+          ],
+        ],
+      ],
+      'match' => [
+        'saved_search_id',
+        'name',
+      ],
+    ],
+  ],
+];


### PR DESCRIPTION
Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._
here i create a new screen of listing of label format `civicrm/admin/labelFormats` for searchkit ui

Before
----------------------------------------
old interface quickform

After
----------------------------------------
new interface with searchkit and formbuilder

Technical Details
----------------------------------------


Comments
----------------------------------------
The link in actions button keep the old interface for the moment
