### PR TITLE
SearchKit: Don't assume a comparison value when none exists

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -651,7 +651,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       return \CRM_Core_Permission::check($permissions) == ($op !== '!=');
     }
     // Convert the conditional value of 'current_domain' into an actual value that filterCompare can work with
-    if ($item['condition'][2] === 'current_domain') {
+    if ($item['condition'][2] ?? '' === 'current_domain') {
       if (str_ends_with($item['condition'][0], ':label') !== FALSE) {
         $item['condition'][2] = \CRM_Core_BAO_Domain::getDomain()->name;
       }


### PR DESCRIPTION
Overview
----------------------------------------
My logs were full of this:

```
Warning: Undefined array key 2 in Civi\Api4\Action\SearchDisplay\AbstractRunAction->checkLinkCondition() (line 654 of /home/jon/local/mysite/vendor/civicrm/civicrm-core/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php) 
```

This is caused by the condition set on the link in the screenshot below.

Conditions can have 3 elements (e.g. "field", "=", "5") or 2 (e.g. "field", "is_empty").  This code assumes there are always 3 elements without first checking, so I've added a check.

![Selection_2075](https://github.com/civicrm/civicrm-core/assets/1796012/8ebab758-7f14-4059-ab5f-f418203d1697)

Before
----------------------------------------
Lots of warnings on every SK display render.

After
----------------------------------------
No more.