### PR TITLE
[REF] Rewrite PCP enumeration to avoid caching bug

### DIFF
--- a/CRM/Contribute/PseudoConstant.php
+++ b/CRM/Contribute/PseudoConstant.php
@@ -307,34 +307,19 @@ class CRM_Contribute_PseudoConstant extends CRM_Core_PseudoConstant {
   }
 
   /**
-   * Get all the Personal campaign pages.
-   *
-   *
-   * @param string|null $pageType
-   * @param int $id
-   *
-   * @return array
-   *   array reference of all pcp if any
+   * Get all the active Personal Campaign Pages.
    */
-  public static function &pcPage($pageType = NULL, $id = NULL) {
-    if (!isset(self::$pcPage[$pageType])) {
-      if ($pageType) {
-        $params = "page_type='{$pageType}'";
-      }
-      else {
-        $params = '';
-      }
-      CRM_Core_PseudoConstant::populate(self::$pcPage[$pageType],
-        'CRM_PCP_DAO_PCP',
-        FALSE, 'title', 'is_active', $params
-      );
+  public static function &pcPage(): array {
+    if (!isset(self::$pcPage)) {
+      $result = (array) \Civi\Api4\PCP::get(FALSE)
+        ->addSelect('id', 'title')
+        ->addWhere('is_active', '=', TRUE)
+        ->execute()
+        ->indexBy('id');
+      $returnValue = \CRM_Utils_Type::escapeAll(array_column($result, 'title', 'id'), 'String');
+      self::$pcPage = $returnValue;
     }
-    $result = self::$pcPage[$pageType];
-    if ($id) {
-      return $result = $result[$id] ?? NULL;
-    }
-
-    return $result;
+    return self::$pcPage;
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/PseudoConstantTest.php
+++ b/tests/phpunit/CRM/Contribute/PseudoConstantTest.php
@@ -15,6 +15,8 @@
  */
 class CRM_Contribute_PseudoConstantTest extends CiviUnitTestCase {
 
+  use CRMTraits_PCP_PCPTestTrait;
+
   /**
    * Clean up after tests.
    */
@@ -71,6 +73,17 @@ class CRM_Contribute_PseudoConstantTest extends CiviUnitTestCase {
         $this->assertEquals('Deposit Bank Account', $financialAccounts[$financialAccountID]['name']);
       }
     }
+  }
+
+  public function testPcPages(): void {
+    $blockParams = $this->pcpBlockParams();
+    $pcpBlock = CRM_PCP_BAO_PCPBlock::writeRecord($blockParams);
+
+    $params = $this->pcpParams();
+    $params['pcp_block_id'] = $pcpBlock->id;
+    CRM_PCP_BAO_PCP::writeRecord($params);
+    $result = \CRM_Contribute_PseudoConstant::pcPage();
+    $this->assertCount(1, $result);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Occasionally, due to caching issues, the PCP section doesn't appear when editing a contribution.  This function relies on deprecated code, so I've rewritten it with modern code.

Before
----------------------------------------
PCPs sometimes don't show up when editing contribution pages.

After
----------------------------------------
PCPs show up consistently.  Code looks better. Unit tests.


Comments
----------------------------------------
None of the calling functions of this method pass any arguments, so I removed them.  I feel OK about that because a) this isn't part of the developer contract, and b) calling this function is perhaps the least obvious way of getting this data.