### PR TITLE
Add system check encouraging Smarty3

### DIFF
--- a/CRM/Utils/Check/Component/Smarty.php
+++ b/CRM/Utils/Check/Component/Smarty.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Psr\Log\LogLevel;
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class CRM_Utils_Check_Component_Smarty extends CRM_Utils_Check_Component {
+
+  /**
+   * Check if Smarty3 has been enabled.
+   *
+   * @return CRM_Utils_Check_Message[]
+   */
+  public function checkSmarty3(): array {
+    $messages = [];
+    if (!defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
+      $smartyPath = rtrim(\Civi::paths()->getPath('[civicrm.packages]/'), '/') . DIRECTORY_SEPARATOR . 'smarty3/vendor/autoload.php';
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__,
+        ts('We are in the process of migrating from Smarty2 onto Smarty3 and then Smarty4 for performance and security reasons. '
+          . 'As of CiviCRM 5.69 switching to Smarty3 is optional but recommended.'
+          . ' In order to switch you need to add the following to your civicrm.settings.php file: ')
+        . "<pre>define('CIVICRM_SMARTY3_AUTOLOAD_PATH', $smartyPath');</pre>"
+        . ts('In some cases your extensions will not be compatible with Smarty 3 and will not have released compatible versions. '
+          . ' Smarty2 will be supported in the ESR programme for at least another 6 months
+          '),
+        ts('Smarty3 recommended'),
+        LogLevel::WARNING,
+        'fa-lock'
+      );
+    }
+    return $messages;
+  }
+
+}

--- a/CRM/Utils/Check/Component/Smarty.php
+++ b/CRM/Utils/Check/Component/Smarty.php
@@ -24,19 +24,24 @@ class CRM_Utils_Check_Component_Smarty extends CRM_Utils_Check_Component {
    * @return CRM_Utils_Check_Message[]
    */
   public function checkSmarty3(): array {
+    $p = function($text) {
+      return '<p>' . $text . '</p>';
+    };
+
     $messages = [];
     if (!defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
-      $smartyPath = rtrim(\Civi::paths()->getPath('[civicrm.packages]/'), '/') . DIRECTORY_SEPARATOR . 'smarty3/vendor/autoload.php';
+      $smartyPath = \Civi::paths()->getPath('[civicrm.packages]/smarty3/vendor/autoload.php');
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('We are in the process of migrating from Smarty2 onto Smarty3 and then Smarty4 for performance and security reasons. '
-          . 'As of CiviCRM 5.69 switching to Smarty3 is optional but recommended.'
-          . ' In order to switch you need to add the following to your civicrm.settings.php file: ')
-        . "<pre>define('CIVICRM_SMARTY3_AUTOLOAD_PATH', '$smartyPath');</pre>"
-        . ts('In some cases your extensions will not be compatible with Smarty 3 and will not have released compatible versions. '
-          . ' Smarty2 will be supported in the ESR programme for at least another 6 months
-          '),
-        ts('Smarty3 recommended'),
+        $p(ts('CiviCRM is updating a major library (<em>Smarty</em>) to improve performance and security. In CiviCRM v5.69, the update is optional, but you should try it now.'))
+        . $p(ts('To apply the update, add this statement to <code>civicrm.settings.php</code>:'))
+        . sprintf("<pre>  define('CIVICRM_SMARTY3_AUTOLOAD_PATH',\n    %s);</pre>", htmlentities(var_export($smartyPath, 1)))
+        . $p('Some extensions may not work yet with Smarty v3. If you encounter problems, then simply remove the statement.')
+        . $p(ts('Upcoming versions will standardize on Smarty v3. CiviCRM <a %1>v5.69-ESR</a> will provide extended support for Smarty v2. To learn more and discuss, see the <a %2>Smarty transition page</a>.', [
+          1 => 'target="_blank" href="' . htmlentities('https://civicrm.org/esr') . '"',
+          2 => 'target="_blank" href="' . htmlentities('https://civicrm.org/redirect/smarty-v3') . '"',
+        ])),
+        ts('Smarty Update (v2 => v3)'),
         LogLevel::WARNING,
         'fa-lock'
       );

--- a/CRM/Utils/Check/Component/Smarty.php
+++ b/CRM/Utils/Check/Component/Smarty.php
@@ -32,7 +32,7 @@ class CRM_Utils_Check_Component_Smarty extends CRM_Utils_Check_Component {
         ts('We are in the process of migrating from Smarty2 onto Smarty3 and then Smarty4 for performance and security reasons. '
           . 'As of CiviCRM 5.69 switching to Smarty3 is optional but recommended.'
           . ' In order to switch you need to add the following to your civicrm.settings.php file: ')
-        . "<pre>define('CIVICRM_SMARTY3_AUTOLOAD_PATH', $smartyPath');</pre>"
+        . "<pre>define('CIVICRM_SMARTY3_AUTOLOAD_PATH', '$smartyPath');</pre>"
         . ts('In some cases your extensions will not be compatible with Smarty 3 and will not have released compatible versions. '
           . ' Smarty2 will be supported in the ESR programme for at least another 6 months
           '),


### PR DESCRIPTION
Overview
----------------------------------------
Add system check encouraging Smarty3

Before
----------------------------------------
As of 5.69 Smarty3 works with core & people should start using it in preparation for us doing a hard swap. However, there is nothing to warn site users of that

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/c0371500-a386-46e5-bfbb-9c5337150837)


Technical Details
----------------------------------------
We probably want a blog or docs update to point to for more information. In addition it would be good to check the civix version of installed extensions & specify whether they have been updated for Smarty3

Comments
----------------------------------------
