### PR TITLE
(dev/core#4839) WorkflowMessage - Send email. Don't overwrite $to.

### DIFF
--- a/Civi/WorkflowMessage/Traits/AddressingTrait.php
+++ b/Civi/WorkflowMessage/Traits/AddressingTrait.php
@@ -249,7 +249,7 @@ trait AddressingTrait {
    * @see \Civi\WorkflowMessage\Traits\ReflectiveWorkflowTrait::import
    */
   protected function importExtraEnvelope_toAddress(array &$values): void {
-    if (array_key_exists('toEmail', $values) || array_key_exists('toName', $values)) {
+    if (isset($values['toEmail']) || isset($values['toName'])) {
       $this->setTo(['name' => $values['toName'] ?? NULL, 'email' => $values['toEmail'] ?? NULL]);
       unset($values['toName']);
       unset($values['toEmail']);

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -432,6 +432,52 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
     $this->assertStringContainsString('Case ID : 1234', $message);
   }
 
+  public function testSendToEmail_variantA(): void {
+    $mut = new CiviMailUtils($this, TRUE);
+    $cid = $this->individualCreate();
+
+    $msg = \Civi\WorkflowMessage\WorkflowMessage::create('petition_sign', [
+      'from' => '"The Sender" <sender-a@example.com>',
+      'toEmail' => 'demo-a@example.com',
+      'contactId' => 204,
+    ]);
+    $msg->sendTemplate([
+      'messageTemplate' => [
+        'msg_subject' => 'Hello world',
+        'msg_text' => 'Hello',
+        'msg_html' => '<p>Hello</p>',
+      ],
+    ]);
+    $mut->checkMailLog([
+      'From: "The Sender" <sender-a@example.com>',
+      'To: <demo-a@example.com>',
+      "Subject: Hello world",
+    ]);
+    $mut->stop();
+  }
+
+  public function testSendToEmail_variantB(): void {
+    $mut = new CiviMailUtils($this, TRUE);
+    $cid = $this->individualCreate();
+
+    \Civi\WorkflowMessage\WorkflowMessage::create('petition_sign')
+      ->setFrom(['name' => 'The Sender', 'email' => 'sender-b@example.com'])
+      ->setTo(['name' => 'The Recipient', 'email' => 'demo-b@example.com'])
+      ->setContactID($cid)
+      ->setTemplate([
+        'msg_subject' => 'Bonjour le monde',
+        'msg_text' => 'Ça va',
+        'msg_html' => '<p>Ça va</p>',
+      ])
+      ->sendTemplate();
+    $mut->checkMailLog([
+      'From: The Sender <sender-b@example.com>',
+      'To: The Recipient <demo-b@example.com>',
+      "Subject: Bonjour le monde",
+    ]);
+    $mut->stop();
+  }
+
   /**
    * Test rendering of domain tokens.
    *


### PR DESCRIPTION
Overview
----------------------------------------

Fixes a problem where `MessageTemplate`s (`WorkflowMessage`s) may not send emails.

The problem depends on when/how you pass the addressing information. It has the effect of blanking out the `$to` address. This is why (e.g.) the "Password Reset" email is not being sent.

(See also: https://lab.civicrm.org/dev/core/-/issues/4839)

Before
----------------------------------------

* In `renderTemplateRaw()`, the default `$params` include blank placeholder properties (`toEmail=>null` and `toName=>null`).
* In `renderTemplateRaw()`, it has multiple sources of truth (defaults, `$params`, `$model`). It reconciles the sources.
* During this process, it copies the blank-placeholder and overwrites the real value of `$to`.

After
----------------------------------------

Placeholder values of `toEmail`/`toName` do not overwrite the real values of `to`.
