### PR TITLE
TemplateTrait - Fix references to CRM_Core_Exception

### DIFF
--- a/Civi/WorkflowMessage/Traits/TemplateTrait.php
+++ b/Civi/WorkflowMessage/Traits/TemplateTrait.php
@@ -13,6 +13,7 @@ namespace Civi\WorkflowMessage\Traits;
 
 use Civi\Api4\Contact;
 use Civi\Api4\MessageTemplate;
+use CRM_Core_Exception;
 
 /**
  * @method getTemplate(): ?array


### PR DESCRIPTION
Overview
----------------------------------------

There are a few places where this class throws exceptions. It's quite uncommon. But if it happens, then it won't work right.

Before
----------------------------------------

Various exceptions are obscured. Instead, they riase "class not found" errors re: `CRM_Core_Exception`.

After
----------------------------------------

If there's an exception, it will be a *real* exception.
