### PR TITLE
standaloneusers - Fix tokens+docblocks for "Password reset" email 

### DIFF
--- a/ext/standaloneusers/CRM/Standaloneusers/WorkflowMessage/PasswordReset.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/WorkflowMessage/PasswordReset.php
@@ -3,10 +3,10 @@ use Civi\WorkflowMessage\GenericWorkflowMessage;
 
 /**
  *
- * @method static setResetUrlPlaintext(string $s)
- * @method static setResetUrlHtml(string $s)
- * @method static setUsernamePlaintext(string $s)
- * @method static setUsernameHtml(string $s)
+ * @method $this setResetUrlPlaintext(string $s)
+ * @method $this setResetUrlHtml(string $s)
+ * @method $this setUsernamePlaintext(string $s)
+ * @method $this setUsernameHtml(string $s)
  *
  */
 class CRM_Standaloneusers_WorkflowMessage_PasswordReset extends GenericWorkflowMessage {
@@ -62,6 +62,7 @@ class CRM_Standaloneusers_WorkflowMessage_PasswordReset extends GenericWorkflowM
     $resetUrlHtml = htmlspecialchars($resetUrlPlaintext);
     $this->logParams = [
       'userID'   => $user['id'],
+      'contactID' => $user['contact_id'],
       'username' => $user['username'],
       'email'    => $user['uf_name'],
       'url'      => $resetUrlPlaintext,
@@ -71,7 +72,8 @@ class CRM_Standaloneusers_WorkflowMessage_PasswordReset extends GenericWorkflowM
       ->setResetUrlHtml($resetUrlHtml)
       ->setUsernamePlaintext($user['username'])
       ->setUsernameHtml(htmlspecialchars($user['username']))
-      ->setTo($user['uf_name']);
+      ->setTo(['name' => $user['username'], 'email' => $user['uf_name']])
+      ->setContactID($user['contact_id']);
     return $this;
   }
 

--- a/ext/standaloneusers/Civi/Api4/Action/User/SendPasswordReset.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/SendPasswordReset.php
@@ -41,7 +41,7 @@ class SendPasswordReset extends AbstractAction {
     }
 
     $user = User::get(FALSE)
-      ->addSelect('id', 'uf_name', 'username')
+      ->addSelect('id', 'uf_name', 'username', 'contact_id')
       ->addWhere('is_active', '=', TRUE)
       ->setLimit(1)
       ->addWhere(


### PR DESCRIPTION
Overview
----------------------------------------

This addresses a few minor issues with the "Password Reset" email.

ping @artfulrobot @pfigel

Before
----------------------------------------

* The message cannot use tokens like `{contact.display_name}`.
* When editing code in PHPStorm, some of the methods don't support auto-completion.

After
----------------------------------------

* Tokens work
* Auto-complete works

Comments
----------------------------------------

This includes/depends on #28522
