### PR TITLE
Fix ID retrieval for MailingComponent edit page

### DIFF
--- a/CRM/Mailing/DAO/MailingComponent.php
+++ b/CRM/Mailing/DAO/MailingComponent.php
@@ -37,8 +37,9 @@ class CRM_Mailing_DAO_MailingComponent extends CRM_Core_DAO {
    * @var string[]
    */
   protected static $_paths = [
-    'add' => 'civicrm/admin/component?action=add&reset=1',
-    'update' => 'civicrm/admin/component?action=update&id=[id]&reset=1',
+    'add' => 'civicrm/admin/component/edit?action=add&reset=1',
+    'update' => 'civicrm/admin/component/edit?action=update&id=[id]&reset=1',
+    'browse' => 'civicrm/admin/component?action=browse&id=[id]&reset=1',
   ];
 
   /**

--- a/CRM/Mailing/Form/Component.php
+++ b/CRM/Mailing/Form/Component.php
@@ -35,8 +35,7 @@ class CRM_Mailing_Form_Component extends CRM_Core_Form {
   protected $_BAOName;
 
   public function preProcess() {
-    $this->_id = $this->get('id');
-    $this->_BAOName = $this->get('BAOName');
+    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
   }
 
   /**
@@ -94,8 +93,7 @@ class CRM_Mailing_Form_Component extends CRM_Core_Form {
 
     if (isset($this->_id)) {
       $params = ['id' => $this->_id];
-      $baoName = $this->_BAOName;
-      $baoName::retrieve($params, $defaults);
+      CRM_Mailing_BAO_MailingComponent::retrieve($params, $defaults);
     }
     else {
       $defaults['is_active'] = 1;

--- a/CRM/Mailing/xml/Menu/Mailing.xml
+++ b/CRM/Mailing/xml/Menu/Mailing.xml
@@ -29,6 +29,15 @@
     <weight>410</weight>
   </item>
   <item>
+    <path>civicrm/admin/component/edit</path>
+    <title>Headers, Footers, and Automated Messages</title>
+    <page_callback>CRM_Mailing_Form_Component</page_callback>
+    <desc>Configure the header and footer used for mailings. Customize the content of automated Subscribe, Unsubscribe, Resubscribe and Opt-out messages.</desc>
+    <access_arguments>access CiviCRM,access CiviMail</access_arguments>
+    <adminGroup>CiviMail</adminGroup>
+    <weight>411</weight>
+  </item>
+  <item>
     <path>civicrm/admin/options/from_email_address/civimail</path>
     <title>From Email Addresses</title>
     <desc>List of Email Addresses which can be used when sending emails to contacts.</desc>

--- a/xml/schema/Mailing/MailingComponent.xml
+++ b/xml/schema/Mailing/MailingComponent.xml
@@ -7,8 +7,9 @@
   <comment>Stores information about the mailing components (header/footer).</comment>
   <component>CiviMail</component>
   <paths>
-    <add>civicrm/admin/component?action=add&amp;reset=1</add>
-    <update>civicrm/admin/component?action=update&amp;id=[id]&amp;reset=1</update>
+    <add>civicrm/admin/component/edit?action=add&amp;reset=1</add>
+    <update>civicrm/admin/component/edit?action=update&amp;id=[id]&amp;reset=1</update>
+    <browse>civicrm/admin/component?action=browse&amp;id=[id]&amp;reset=1</browse>
   </paths>
   <field>
     <name>id</name>


### PR DESCRIPTION
Overview
----------------------------------------
'Headers, Footers, and Automated Messages' new searchkit page edit button now retrieves values

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/54142191/2d71a9ee-21d7-41a9-aabd-a204ce02930e)
Values empty even when the id is properly passed via the URL

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/54142191/be58fc1d-553f-4abf-9464-d9e4bfde705b)
Updating the retrieval mechanism to pull directly from the URL now properly loads the values


Technical Details
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/28484
https://github.com/civicrm/civicrm-core/pull/28472

Comments
----------------------------------------
Thanks @pradpnayak @kurund 
