### PR TITLE
faster activity counting

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2632,13 +2632,12 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
         return CRM_Case_BAO_Case::caseCount($contactId);
 
       case 'activity':
-        $input = [
-          'contact_id' => $contactId,
-          'admin' => FALSE,
-          'caseId' => NULL,
-          'context' => 'activity',
-        ];
-        return CRM_Activity_BAO_Activity::getActivitiesCount($input);
+        return \Civi\Api4\Activity::get(TRUE)
+          ->addJoin('ActivityContact AS activity_contact', 'INNER')
+          ->addWhere('activity_contact.contact_id', '=', $contactId)
+          ->addWhere('is_test', '=', FALSE)
+          ->execute()
+          ->count();
 
       case 'mailing':
         $params = ['contact_id' => $contactId];


### PR DESCRIPTION
Overview
----------------------------------------
Counting activities for the activity tab can get very slow on large databases.  It uses api v3, which uses subqueries and is convoluted - presumably (partly) because it dates the creation of `civicrm_activity_contact`.

Before
----------------------------------------
Count activities with API v3.

After
----------------------------------------
Count activities with API v4.

Technical Details
----------------------------------------
`CRM_Activity_BAO_Activity::getActivitiesCount($input)` is used for far too many things.  This use case is far simpler.

Comments
----------------------------------------
This will return incorrect values if the database uses activity revisions, because I chose not to filter by latest revision.  Given that they were deprecated in 5.33, this feels like a bit of positive bit rot to remind folks to start moving off of them.
