### PR TITLE
Standalone - prevent users from deleting own user

### DIFF
--- a/ext/standaloneusers/CRM/Standaloneusers/BAO/User.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/BAO/User.php
@@ -41,4 +41,26 @@ class CRM_Standaloneusers_BAO_User extends CRM_Standaloneusers_DAO_User implemen
     return $timeZones;
   }
 
+  /**
+   * Check access permission
+   *
+   * @param string $entityName
+   * @param string $action
+   * @param array $record
+   * @param integer|null $userID
+   * @return boolean
+   * @see CRM_Core_DAO::checkAccess
+   */
+  public static function _checkAccess(string $entityName, string $action, array $record, ?int $userID): bool {
+    // Prevent users from deleting their own user account
+    if (in_array($action, ['delete'], TRUE)) {
+      $sess = CRM_Core_Session::singleton();
+      $ufID = (int) $sess->get('ufID');
+      if ($record['id'] == $ufID) {
+        return FALSE;
+      };
+    }
+    return TRUE;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

Prevent users from deleting their own account.

Before
----------------------------------------

User can delete their own user account.

After
----------------------------------------

User unable to delete their own user account.

Comments
--------------

See also #28451 which is similar.

This won't stop admin users from deleting their own user until #28445 is merged but it will stop users with other roles from deleting their own user. 
