### PR TITLE
Remove "required extensions" from the in-app Extensions list

### DIFF
--- a/CRM/Admin/Page/Extensions.php
+++ b/CRM/Admin/Page/Extensions.php
@@ -162,7 +162,7 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
     $hiddenExtensions = $mapper->getKeysByTag('mgmt:hidden');
     $requiredExtensions = $mapper->getKeysByTag('mgmt:required');
     foreach ($keys as $key) {
-      if (in_array($key, $hiddenExtensions)) {
+      if (in_array($key, $hiddenExtensions) || in_array($key, $requiredExtensions)) {
         continue;
       }
       try {
@@ -208,7 +208,7 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
       }
       // TODO if extbrowser is enabled and extbrowser has newer version than extcontainer,
       // then $action += CRM_Core_Action::UPDATE
-      if ($action && !in_array($key, $requiredExtensions)) {
+      if ($action) {
         $row['action'] = CRM_Core_Action::formLink(self::links(),
           $action,
           ['id' => $row['id'], 'key' => $obj->key],


### PR DESCRIPTION
Overview
----------------------------------------

The text at the top of the Administer > System Settings > Extensions page says:

> Extensions allow you to install additional features for your site.

By this definition, a "required extension" is an oxymoron.

Much of CiviCRM core code is permanently enabled; the user/admin has no option to disable it through configuration; the features it provides are "baked in". So-called "required extensions" are really just "baked-in" pieces of core which happen to have an extension-y past life. There is no practical reason for them to be shown on the in-app Extensions management screen.

Before
----------------------------------------

The in-app Extensions page includes items which were optional "extensions" at one time, but which are now just (un-removeable) parts of core.

After
----------------------------------------

Only installable/removeable extensions are shown.