### PR TITLE
Standalone - Restrict User API access

### DIFF
--- a/ext/standaloneusers/Civi/Api4/Action/User/WriteTrait.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/WriteTrait.php
@@ -146,4 +146,23 @@ trait WriteTrait {
     return $saved;
   }
 
+  public function isAuthorized(): bool {
+    if (parent::isAuthorized()) {
+      return TRUE;
+    }
+    $isPermittedAction = in_array($this->getActionName(), [
+      'update',
+      'save',
+    ]);
+    $isPermittedValueSubset = array_intersect_key(array_keys($this->getValues()), [
+      'password',
+    ]) == array_keys($this->getValues());
+    if ($isPermittedValueSubset && $isPermittedAction) {
+      // we rely on validateValues() to further lock down access to password
+      // updates based on permissions or verification of actorPassword
+      return TRUE;
+    }
+    return FALSE;
+  }
+
 }

--- a/ext/standaloneusers/Civi/Api4/User.php
+++ b/ext/standaloneusers/Civi/Api4/User.php
@@ -56,7 +56,7 @@ class User extends Generic\DAOEntity {
    */
   public static function permissions() {
     return [
-      'default'           => ['access CiviCRM'],
+      'default'           => ['cms:administer users'],
       'passwordReset'     => ['access password resets'],
       'sendPasswordReset' => ['access password resets'],
     ];


### PR DESCRIPTION
Overview
----------------------------------------
Restrict access to the User API while still permitting certain operations.

Before
----------------------------------------
Anyone with `access CiviCRM` has full access to the User API4.

After
----------------------------------------
Only users with `cms:administer users` permission have full access to the User API4. Other users are limited to `User.save`/`User.update` specifically with just the `password` field (so they can still change their own password.)

Comments
----------------------------------------
Just a quick POC to see if something like this would work. Not sure if this should be done on the API4 class itself, `BAO::_checkAccess()`, or some permission check event.
