### PR TITLE
Accordions css – tidies up / bug fixes / simplifies theming / adds two utility classes

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2211,7 +2211,7 @@ div.crm-master-accordion-header a.helpicon {
   color: #3e3e3e;
 }
 
-.crm-container summary {
+.crm-container summary { /* default summary setting*/
   display: list-item;
   list-style: none;
   cursor: pointer;
@@ -2223,7 +2223,7 @@ div.crm-master-accordion-header a.helpicon {
 .crm-container .crm-accordion-header,
 .crm-container .collapsed .crm-accordion-header,
 .crm-container .crm-accordion-bold > summary,
-.crm-container details > .crm-accordion-header {
+.crm-container details > .crm-accordion-header { /* applies civi's default accordion header to summary & .crm-accrdion-bold */
   color: #f5f6f1;
   font-weight: normal;
   padding: 4px 8px;
@@ -2233,12 +2233,12 @@ div.crm-master-accordion-header a.helpicon {
 
 .crm-container div.crm-accordion-header,
 .crm-container details[open] > .crm-accordion-header,
-.crm-container .crm-accordion-bold[open] > summary {
-  border-radius: 4px 4px 0 0;
+.crm-container .crm-accordion-bold[open] > summary { /* open version of that */
+  border-radius: 4px 4px 0 0; 
 }
 
 .crm-container .crm-accordion-header.active,
-.crm-container .crm-accordion-bold > summary.active {
+.crm-container .crm-accordion-bold > summary.active { /* active version of that */
   font-weight: bold;
   background-color: #3e3e3e;
 }
@@ -2246,7 +2246,7 @@ div.crm-master-accordion-header a.helpicon {
 .crm-container .crm-accordion-header:hover,
 .crm-container .crm-accordion-header:focus,
 .crm-container .crm-accordion-bold > summary:hover,
-.crm-container .crm-accordion-bold > summary:focus {
+.crm-container .crm-accordion-bold > summary:focus { /* hover version of that */
   background-color: #2f2f2e;
 }
 
@@ -2254,17 +2254,20 @@ div.crm-master-accordion-header a.helpicon {
   background-color: #e8e8de;
 }
 
-.crm-container .crm-accordion-wrapper .crm-master-accordion-header {
+.crm-container .crm-accordion-wrapper .crm-master-accordion-header,
+.crm-container .crm-accordion-light > summary { /* adds a utility class to match civi's transparent accordion header style */
   background-color: transparent;
+  font-weight: normal;
   color: #3e3e3e;
-}
-
-.crm-container .crm-accordion-wrapper .crm-master-accordion-header {
-  font-size: 16px;
+  font-size: 1rem;
 }
 
 .crm-container .crm-master-accordion-header.crm-accordion-header:hover,
-.crm-container .crm-collapsible .collapsible-title:hover {
+.crm-container .crm-accordion-light > summary:hover,
+.crm-container .crm-collapsible .collapsible-title:hover,
+.crm-container .crm-master-accordion-header.crm-accordion-header:focus,
+.crm-container .crm-accordion-light > summary:focus,
+.crm-container .crm-collapsible .collapsible-title:focus { /* hover state for this */
   color: #121a2d;
 }
 

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2204,7 +2204,7 @@ div.crm-master-accordion-header a.helpicon {
 }
 
 .crm-container summary::-webkit-details-marker { /* Safari fix to remove summary icon */
-  display: none; 
+  display: none;
 }
 
 #crm-container .widget-content .crm-accordion-header {
@@ -2236,7 +2236,7 @@ div.crm-master-accordion-header a.helpicon {
 .crm-container div.crm-accordion-header,
 .crm-container details[open] > .crm-accordion-header,
 .crm-container .crm-accordion-bold[open] > summary { /* open version of that */
-  border-radius: 4px 4px 0 0; 
+  border-radius: 4px 4px 0 0;
 }
 
 .crm-container .crm-accordion-header.active,
@@ -2305,7 +2305,7 @@ div.crm-master-accordion-header a.helpicon {
 .crm-container span.expanded:before,
 .crm-container a.expanded:before,
 .crm-container .crm-expand-row.expanded:before,
-.crm-container details[open] > summary:before  {
+.crm-container details[open] > summary:before {
   font-family: "FontAwesome";
   content: "\f0d7";
 }

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2219,6 +2219,12 @@ div.crm-master-accordion-header a.helpicon {
   border-radius: 4px 4px 0 0;
 }
 
+.crm-container summary {
+  display: list-item;
+  list-style: none;
+  cursor: pointer;
+}
+
 .crm-container .collapsed .crm-accordion-header {
   border-radius: 4px;
 }
@@ -2259,10 +2265,12 @@ div.crm-master-accordion-header a.helpicon {
 
 /* General icon settings for all collapsible things */
 .crm-container div.crm-accordion-header:before,
+.crm-container .collapsed .crm-accordion-header:before,
 .crm-container .crm-collapsible .collapsible-title:before,
 .crm-container span.collapsed:before,
 .crm-container a.collapsed:before,
-.crm-container .crm-expand-row:before {
+.crm-container .crm-expand-row:before,
+.crm-container details > summary:before {
   font-family: "FontAwesome";
   display: inline-block;
   width: 1em;
@@ -2270,21 +2278,13 @@ div.crm-master-accordion-header a.helpicon {
   font-size: 13px;
 }
 
-/* Collapsed icon */
-.crm-container .collapsed div.crm-accordion-header:before,
-.crm-container .crm-collapsible.collapsed .collapsible-title:before,
-.crm-container span.collapsed:before,
-.crm-container a.collapsed:before,
-.crm-container .crm-expand-row:before {
-  content: "\f0da";
-}
-
 /* Expanded icon */
 .crm-container div.crm-accordion-header:before,
 .crm-container .crm-collapsible .collapsible-title:before,
 .crm-container span.expanded:before,
 .crm-container a.expanded:before,
-.crm-container .crm-expand-row.expanded:before {
+.crm-container .crm-expand-row.expanded:before,
+.crm-container details[open] > summary:before  {
   font-family: "FontAwesome";
   content: "\f0d7";
 }

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2184,8 +2184,7 @@ div.crm-master-accordion-header a.helpicon {
 .crm-container .crm-collapsible .collapsible-title,
 .crm-container span.collapsed,
 .crm-container a.collapsed,
-.crm-container .crm-expand-row,
-.crm-container summary {
+.crm-container .crm-expand-row {
   cursor: pointer;
 }
 
@@ -2195,9 +2194,17 @@ div.crm-master-accordion-header a.helpicon {
 
 /* Specific types of headers */
 
-.crm-container summary:not(.crm-master-accordion-header, .crm-accordion-header) /* For older CMS themes not styling summary */ {
+.crm-container summary { /* default summary setting*/
+  display: list-item;
+  list-style: none;
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 0.5rem;
   font-weight: bold;
-  padding: 0.75rem 0;
+}
+
+.crm-container summary::-webkit-details-marker { /* Safari fix to remove summary icon */
+  display: none; 
 }
 
 #crm-container .widget-content .crm-accordion-header {
@@ -2211,13 +2218,8 @@ div.crm-master-accordion-header a.helpicon {
   color: #3e3e3e;
 }
 
-.crm-container summary { /* default summary setting*/
-  display: list-item;
-  list-style: none;
-  cursor: pointer;
-  font-size: 1rem;
-  padding: 0.5rem 0;
-  font-weight: bold;
+.crm-container details .crm-accordion-body {
+  display: block; /* Fix for old JS trying to hide crm-accordion-body */
 }
 
 .crm-container .crm-accordion-header,
@@ -2274,6 +2276,10 @@ div.crm-master-accordion-header a.helpicon {
 .crm-container .collapsed .crm-accordion-body,
 .crm-container .crm-collapsible.collapsed .collapsible-title + * {
   display: none;
+}
+
+.crm-container details details {
+  padding: 0 0.25rem; /* adds padding for nested accordions */
 }
 
 /* Collapse icon */

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2312,7 +2312,8 @@ div.crm-master-accordion-header a.helpicon {
 
 /* Accordion bodies */
 
-.crm-container .crm-accordion-body {
+.crm-container .crm-accordion-wrapper .crm-accordion-body,
+.crm-container details.crm-accordion-bold .crm-accordion-body {
   border-radius: 0 0 4px 4px;
   border: 1px solid #70716b;
   border-top: 0;
@@ -2323,13 +2324,15 @@ div.crm-master-accordion-header a.helpicon {
   border-color: #e8e8de;
 }
 
-.crm-container .crm-master-accordion-header+.crm-accordion-body {
+.crm-container .crm-master-accordion-header+.crm-accordion-body,
+.crm-accordion-wrapper.crm-accordion-light {
   border: none;
   padding: 0;
 }
 
 #crm-container .widget-content .crm-accordion-body,
-.crm-container .crm-accordion-body.padded {
+.crm-container .crm-accordion-body.padded,
+.crm-container details.padded {
   padding-left: .5em;
   padding-right: .5em;
 }

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2215,6 +2215,9 @@ div.crm-master-accordion-header a.helpicon {
   display: list-item;
   list-style: none;
   cursor: pointer;
+  font-size: 1rem;
+  padding: 0.5rem 0;
+  font-weight: bold;
 }
 
 .crm-container .crm-accordion-header,
@@ -2234,12 +2237,16 @@ div.crm-master-accordion-header a.helpicon {
   border-radius: 4px 4px 0 0;
 }
 
-.crm-container .crm-accordion-header.active {
+.crm-container .crm-accordion-header.active,
+.crm-container .crm-accordion-bold > summary.active {
   font-weight: bold;
   background-color: #3e3e3e;
 }
 
-.crm-container .crm-accordion-header:hover {
+.crm-container .crm-accordion-header:hover,
+.crm-container .crm-accordion-header:focus,
+.crm-container .crm-accordion-bold > summary:hover,
+.crm-container .crm-accordion-bold > summary:focus {
   background-color: #2f2f2e;
 }
 

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2211,22 +2211,27 @@ div.crm-master-accordion-header a.helpicon {
   color: #3e3e3e;
 }
 
-.crm-container .crm-accordion-header {
-  color: #f5f6f1;
-  font-weight: normal;
-  padding: 4px 8px;
-  background-color: #5d677b;
-  border-radius: 4px 4px 0 0;
-}
-
 .crm-container summary {
   display: list-item;
   list-style: none;
   cursor: pointer;
 }
 
-.crm-container .collapsed .crm-accordion-header {
+.crm-container .crm-accordion-header,
+.crm-container .collapsed .crm-accordion-header,
+.crm-container .crm-accordion-bold > summary,
+.crm-container details > .crm-accordion-header {
+  color: #f5f6f1;
+  font-weight: normal;
+  padding: 4px 8px;
+  background-color: #5d677b;
   border-radius: 4px;
+}
+
+.crm-container div.crm-accordion-header,
+.crm-container details[open] > .crm-accordion-header,
+.crm-container .crm-accordion-bold[open] > summary {
+  border-radius: 4px 4px 0 0;
 }
 
 .crm-container .crm-accordion-header.active {
@@ -2265,7 +2270,7 @@ div.crm-master-accordion-header a.helpicon {
 
 /* General icon settings for all collapsible things */
 .crm-container div.crm-accordion-header:before,
-.crm-container .collapsed .crm-accordion-header:before,
+.crm-container .collapsed div.crm-accordion-header:before,
 .crm-container .crm-collapsible .collapsible-title:before,
 .crm-container span.collapsed:before,
 .crm-container a.collapsed:before,


### PR DESCRIPTION
Overview
----------------------------------------
This PR is specific to the CSS around accordions following the changes in #28449, #28441, #28430, #28421, #28418, #28415 & #28473 (currently open). The goal with this PR is:

1.  minimise & simplify work for themers to adopt the accessible accordion changes. Changes are commentedand together so themers should be able to adapt in one go.
2.  reliably handle new elements `<details><summary>` in ways as close to the old civi accordions as possible  (Bootstrap3, for e.g. turns both to a block, breaking them; Safari has a quirk leading to two icons; etc) 
3.  provide two new utility classes to apply Civi/Greenwich's two main accordion styles: plain (aka `.crm-accordion-light`) and with a background colour (aka `.crm-accordion-bold). While we want to avoid adding new patterns, it's hard to see how else to re-apply Civi's UI patterns on new elements without inheriting some tech debt. The impact of this is small, but can be seen, for e.g., in this PR for the extension directory: #28473. These will be documented after merge.
 
Before
----------------------------------------
- `<summary>` is triggering a browser expand/close icon, rather than using Civi's. 
- Some of the hover/.active/etc states from the old accordion pattern had been lost.
- some visual bugs in some contexts.

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/1175967/a004bc72-2796-4c95-a628-f10fc9da3867)
- Using `.crm-accordion-light` as a class on `<details>` matches Civi's transparent background, non-bold accordion style.
- Using `.crm-accordion-bold` as a class on `<details>` matches the dark bg, light type, bold Civi accordion style.
- A number of small bugs fixes, e.g. rounded corners on expanded summaries, double icon in safari.
- CSS is commented

Technical Details
----------------------------------------
Quick testing on Firefox (Gecko), Safari (Webkit). Reverts a few changes made in https://github.com/civicrm/civicrm-core/pull/28415/ - and also tidies a little redundant CSS in civicrm.css (e.g. specifying the close/expand icon)

Comments
----------------------------------------
To test this in action on new markup pattern pages: it's on Advanced Search, the Civi news feed, Activities Search, SearchKit UI, Contact dashboard custom field. To check on old pages, Participants Search, and New Mailing uses the old transparent pattern.

Given this impacts changes currently headed for release 5.69, it'd be good to get this merged alongside them (ie before 5.70).