### PR TITLE
Add API4 Payment.create

### DIFF
--- a/Civi/Api4/Action/Payment/Create.php
+++ b/Civi/Api4/Action/Payment/Create.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Payment;
+
+use Civi\Api4\CustomField;
+
+/**
+ * This API Action creates a payment and supports setting custom fields on FinancialTrxn
+ *
+ */
+class Create extends \Civi\Api4\Generic\AbstractCreateAction {
+
+  public static function getCreateFields() {
+    // Basically a copy of _civicrm_api3_payment_create_spec;
+    $fields = [
+      [
+        'name' => 'contribution_id',
+        'required' => TRUE,
+        'description' => ts('Contribution ID'),
+        'data_type' => 'Integer',
+        'fk_entity' => 'Contribution',
+        'input_type' => 'EntityRef',
+      ],
+      [
+        'name' => 'total_amount',
+        'required' => TRUE,
+        'description' => ts('Total Payment Amount'),
+        'data_type' => 'Float',
+      ],
+      [
+        'name' => 'fee_amount',
+        'description' => ts('Fee Amount'),
+        'data_type' => 'Float',
+      ],
+      [
+        'name' => 'payment_processor_id',
+        'data_type' => 'Integer',
+        'description' => ts('Payment Processor for this payment'),
+        'fk_entity' => 'PaymentProcessor',
+        'input_type' => 'EntityRef',
+      ],
+      [
+        'name' => 'trxn_date',
+        'description' => ts('Payment Date'),
+        'data_type' => 'Datetime',
+        'default' => 'now',
+        'required' => TRUE,
+      ],
+      [
+        'name' => 'is_send_contribution_notification',
+        'description' => ts('Send out notifications based on contribution status change?'),
+        'data_type' => 'Boolean',
+        'default' => TRUE,
+      ],
+      [
+        'name' => 'payment_instrument_id',
+        'data_type' => 'Integer',
+        'description' => ts('Payment Method (FK to payment_instrument option group values)'),
+        'pseudoconstant' => [
+          'optionGroupName' => 'payment_instrument',
+          'optionEditPath' => 'civicrm/admin/options/payment_instrument',
+        ],
+      ],
+      [
+        'name' => 'card_type_id',
+        'data_type' => 'Integer',
+        'description' => ts('Card Type ID (FK to accept_creditcard option group values)'),
+        'pseudoconstant' => [
+          'optionGroupName' => 'accept_creditcard',
+          'optionEditPath' => 'civicrm/admin/options/accept_creditcard',
+        ],
+      ],
+      [
+        'name' => 'trxn_result_code',
+        'data_type' => 'String',
+        'description' => ts('Transaction Result Code'),
+      ],
+      [
+        'name' => 'trxn_id',
+        'data_type' => 'String',
+        'description' => ts('Transaction ID supplied by external processor. This may not be unique.'),
+      ],
+      [
+        'name' => 'order_reference',
+        'data_type' => 'String',
+        'description' => ts('Payment Processor external order reference'),
+      ],
+      [
+        'name' => 'check_number',
+        'data_type' => 'String',
+        'description' => ts('Check Number'),
+      ],
+      [
+        'name' => 'pan_truncation',
+        'type' => 'String',
+        'description' => ts('PAN Truncation (Last 4 digits of credit card)'),
+      ],
+    ];
+    $customFields = CustomField::get(FALSE)
+      ->addSelect('custom_group_id:name', 'name', 'label', 'data_type')
+      ->addWhere('custom_group_id.extends', '=', 'FinancialTrxn')
+      ->execute();
+    foreach ($customFields as $customField) {
+      $customField['name'] = $customField['custom_group_id:name'] . '.' . $customField['name'];
+      unset($customField['id'], $customField['custom_group_id:name']);
+      $customField['description'] = $customField['label'];
+      $fields[] = $customField;
+    }
+    return $fields;
+  }
+
+  public function fields(): array {
+    return self::getCreateFields();
+  }
+
+  /**
+   *
+   * Note that the result class is that of the annotation below, not the h
+   * in the method (which must match the parent class)
+   *
+   * @var \Civi\Api4\Generic\Result $result
+   */
+  public function _run(\Civi\Api4\Generic\Result $result) {
+    $trxn = \CRM_Financial_BAO_Payment::create($this->values);
+
+    $customFields = CustomField::get(FALSE)
+      ->addSelect('id', 'custom_group_id:name', 'name', 'label', 'data_type')
+      ->addWhere('custom_group_id.extends', '=', 'FinancialTrxn')
+      ->execute();
+    foreach ($customFields as $customField) {
+      $key = $customField['custom_group_id:name'] . '.' . $customField['name'];
+      if (isset($this->values[$key])) {
+        $customParams['custom_' . $customField['id']] = $this->values[$key];
+      }
+    }
+    if (!empty($customParams)) {
+      $customParams['entity_id'] = $trxn->id;
+      civicrm_api3('CustomValue', 'create', $customParams);
+    }
+
+    $result->exchangeArray($trxn);
+    return $result;
+  }
+
+}

--- a/Civi/Api4/Payment.php
+++ b/Civi/Api4/Payment.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Civi\Api4;
+
+/**
+ * Payment abstract entity API.
+ *
+ * @searchable none
+ * @since 5.69
+ * @package Civi\Api4
+ */
+class Payment extends Generic\AbstractEntity {
+
+  /**
+   * @param bool $checkPermissions
+   * @return Generic\BasicGetFieldsAction
+   */
+  public static function getFields($checkPermissions = TRUE) {
+    return (new Generic\BasicGetFieldsAction(__CLASS__, __FUNCTION__, function() {
+      return [];
+    }))->setCheckPermissions($checkPermissions);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds API4 Payment.create

Related to https://github.com/civicrm/civicrm-core/pull/28403

Before
----------------------------------------
No API4 Payment.create

After
----------------------------------------
API4 Payment.create


Technical Details
----------------------------------------
This behaves a bit differently to API3 version:
1. It accepts and saves custom fields on the FinancialTrxn.
2. It does not do "clean money".
3. It does not support refunds.

Comments
----------------------------------------
My intention is to add more targetted Payment APIs for Refund and for Update so that we don't overcomplicate the "Create" API.

See https://lab.civicrm.org/extensions/mjwpaymentapi for draft/work in progress APIs