### PR TITLE
Simplify setDefaults function on contact import mapfields

### DIFF
--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -267,21 +267,6 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test the MapField function getting defaults from column names.
-   *
-   * @dataProvider getHeaderMatchDataProvider
-   *
-   * @param $columnHeader
-   * @param $mapsTo
-   *
-   * @throws \CRM_Core_Exception
-   */
-  public function testDefaultFromColumnNames($columnHeader, $mapsTo): void {
-    $this->setUpMapFieldForm();
-    $this->assertEquals($mapsTo, $this->form->defaultFromColumnName($columnHeader));
-  }
-
-  /**
    * Get data to use for default from column names.
    *
    * @return array


### PR DESCRIPTION
Overview
----------------------------------------
Simplify setDefaults function on contact import mapfields

Before
----------------------------------------
The code for setting the defaults on the map field based on the column names was consolidated for other import mapFields, but not this one

![image](https://github.com/civicrm/civicrm-core/assets/336308/a068bdcb-216b-4ad0-ba5f-9a2d7c471ed9)

After
----------------------------------------
It still takes a good stab at it - screenshot looks the same (good)

![image](https://github.com/civicrm/civicrm-core/assets/336308/892b0e98-09f8-4486-9d00-7606929ffba3)

Technical Details
----------------------------------------

Comments
----------------------------------------
