### PR TITLE
dev/core#4231 Fix failure to import non-default state

### DIFF
--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_country_state.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_country_state.csv
@@ -1,0 +1,2 @@
+First Name,Last Name,State,Country
+Bob,Smith,Alberta,Canada

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -330,17 +330,24 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
    */
   public function testImportNonDefaultCountryState(): void {
     \Civi::settings()->set('defaultContactCountry', 1228);
-    $this->validateCSV('individual_country_state.csv', [
+    $csv = 'individual_country_state.csv';
+    $mapper = [
       ['first_name'],
       ['last_name'],
       ['state_province', 'Primary'],
       ['country', 'Primary'],
-    ]);
-    $dataSource = $this->getDataSource();
-    $row = $dataSource->getRow();
+    ];
+    $this->validateCSV($csv, $mapper);
+    $this->importCSV($csv, $mapper);
+    $address = Address::get(FALSE)
+      ->addWhere('country_id.name', '=', 'Canada')
+      ->addWhere('state_province_id.name', '=', 'Alberta')
+      ->addSelect('contact_id.display_name')
+      ->execute()->single();
+    $this->assertEquals('Bob Smith', $address['contact_id.display_name']);
   }
 
-    /**
+  /**
    * Test updating an existing contact with external_identifier match but
    * subtype mismatch.
    *

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -326,6 +326,21 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * @throws \CRM_Core_Exception
+   */
+  public function testImportNonDefaultCountryState(): void {
+    \Civi::settings()->set('defaultContactCountry', 1228);
+    $this->validateCSV('individual_country_state.csv', [
+      ['first_name'],
+      ['last_name'],
+      ['state_province', 'Primary'],
+      ['country', 'Primary'],
+    ]);
+    $dataSource = $this->getDataSource();
+    $row = $dataSource->getRow();
+  }
+
+    /**
    * Test updating an existing contact with external_identifier match but
    * subtype mismatch.
    *


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/4231

Before
----------------------------------------
As described in https://lab.civicrm.org/dev/core/-/issues/4231 & as replicated in the attached test

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
The import is relying on apiv4 getfields to return the available state options here
https://github.com/civicrm/civicrm-core/blob/68108b0a1dd4ea65d213030ed0b17d58cdf3cfc9/CRM/Import/Parser.php#L1741-L1745

getFields is returning only the states from the default country, not other countries even though the api call does not specify them.

Note that the default country is not configured by default & perhaps is more commonly used on older sites. Also note that when set it literally is the default country, not the only country

Comments
----------------------------------------
