### PR TITLE
Testing - Update example query (re:assetBuilder) to fix E2E test failures

### DIFF
--- a/tests/phpunit/E2E/Core/PathUrlTest.php
+++ b/tests/phpunit/E2E/Core/PathUrlTest.php
@@ -115,7 +115,7 @@ class PathUrlTest extends \CiviEndToEndTestCase {
     $urlPatterns[] = [';civicrm(/|%2F)a(/|%2F).*#/mailing/new\?angularDebug=1;', \Civi::url('backend://civicrm/a/#/mailing/new?angularDebug=1')];
     $urlPatterns[] = [';/jquery.timeentry.js\?r=.*#foo;', \Civi::url('asset://[civicrm.packages]/jquery/plugins/jquery.timeentry.js', 'c')->addFragment('foo')];
     $urlPatterns[] = [';/stuff.js\?r=.*#foo;', \Civi::url('ext://org.civicrm.search_kit/stuff.js', 'c')->addFragment('foo')];
-    $urlPatterns[] = [';#foo;', \Civi::url('assetBuilder://crm-l10n.js?locale=en_US')->addFragment('foo')];
+    $urlPatterns[] = [';#foo;', \Civi::url('assetBuilder://crm-l10n.js?locale=en_US')->addFragment('foo')->addQuery(\CRM_Core_Resources::getL10nJsParams())];
 
     // Some test-harnesses have HTTP_HOST. Some don't. It's pre-req for truly relative URLs.
     if (!empty($_SERVER['HTTP_HOST'])) {


### PR DESCRIPTION
Overview
----------------------------------------
PathURLTest fails on WP
Before
----------------------------------------
https://test.civicrm.org/job/CiviCRM-WordPress-Test/13/testReport/(root)/E2E_Core_PathUrlTest/testUrl/ 

After
----------------------------------------
tests pass

