### PR TITLE
Fix docblock for loadUser()

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -261,11 +261,11 @@ abstract class CRM_Utils_System_Base {
   /**
    * Load user into session.
    *
-   * @param obj $user
+   * @param string $username
    *
    * @return bool
    */
-  public function loadUser($user) {
+  public function loadUser($username) {
     return TRUE;
   }
 


### PR DESCRIPTION
The original code in `CRM/Utils/System/Base.php` declared the function param as Object but all subclasses assume/require a string.

Looks like it should be a string.

This is a NFC, but fixes errors in IDEs' static analysis.

For your convenience, here's all the concrete implementations:

```
Backdrop.php:  public function loadUser($username) {
Drupal8.php:  public function loadUser($username) {
Drupal.php:  public function loadUser($username) {
Joomla.php-  /**
Joomla.php-   * @param \string $username
Joomla.php-   * @param \string $password
Joomla.php-   *
Joomla.php-   * @return bool
Joomla.php-   */
Joomla.php:  public function loadUser($username, $password = NULL) {
Standalone.php:  public function loadUser($username) {
WordPress.php-  /**
WordPress.php-   * @param \string $user
WordPress.php-   *
WordPress.php-   * @return bool
WordPress.php-   */
WordPress.php:  public function loadUser($user) {
```

