### PR TITLE
path changes for PDFFormat

### DIFF
--- a/CRM/Admin/Page/PdfFormats.php
+++ b/CRM/Admin/Page/PdfFormats.php
@@ -51,13 +51,13 @@ class CRM_Admin_Page_PdfFormats extends CRM_Core_Page_Basic {
       self::$_links = [
         CRM_Core_Action::UPDATE => [
           'name' => ts('Edit'),
-          'url' => 'civicrm/admin/pdfFormats',
+          'url' => 'civicrm/admin/pdfFormats/edit',
           'qs' => 'action=update&id=%%id%%&reset=1',
           'title' => ts('Edit PDF Page Format'),
         ],
         CRM_Core_Action::DELETE => [
           'name' => ts('Delete'),
-          'url' => 'civicrm/admin/pdfFormats',
+          'url' => 'civicrm/admin/pdfFormats/edit',
           'qs' => 'action=delete&id=%%id%%',
           'title' => ts('Delete PDF Page Format'),
         ],

--- a/CRM/Core/xml/Menu/Admin.xml
+++ b/CRM/Core/xml/Menu/Admin.xml
@@ -341,6 +341,11 @@
      <weight>70</weight>
   </item>
   <item>
+     <path>civicrm/admin/pdfFormats/edit</path>
+     <title>Print Page (PDF) Formats</title>
+     <page_callback>CRM_Admin_Page_PdfFormats</page_callback>
+  </item>
+  <item>
      <path>civicrm/admin/options/communication_style</path>
      <title>Communication Style Options</title>
      <desc>Options for Communication Style selection.</desc>


### PR DESCRIPTION
Overview
----------------------------------------
To replace the old QF admin page for PDF Formats by a new FB Admin UI we need to add a path.
 
Before
----------------------------------------
old path /civicrm/admin/pdfFormats

After
----------------------------------------
new path /civicrm/admin/pdfFormats/edit

Comments
----------------------------------------
Refer to https://github.com/civicrm/civicrm-core/pull/28520
