### PR TITLE
Standalone - anonymous user access denied handling

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -584,10 +584,17 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
       CRM_Core_Error::statusBounce(ts("Access denied"), CRM_Utils_System::url('civicrm'));
     }
     else {
-      CRM_Utils_System::redirect('/civicrm/login?anonAccessDenied');
-    }
+      http_response_code(403);
 
-    // TODO: Prettier error page
+      // render a login page
+      if (class_exists('CRM_Standaloneusers_Page_Login')) {
+        $loginPage = new CRM_Standaloneusers_Page_Login();
+        $loginPage->assign('anonAccessDenied', TRUE);
+        return $loginPage->run();
+      }
+
+      throw new CRM_Core_Exception('Access denied. Standaloneusers extension not found');
+    }
   }
 
 }

--- a/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
@@ -17,7 +17,6 @@ class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
     // Remove breadcrumb for login page.
     $this->assign('breadcrumb', NULL);
 
-    $this->assign('anonAccessDenied', isset($_GET['anonAccessDenied']));
     $this->assign('justLoggedOut', isset($_GET['justLoggedOut']));
 
     parent::run();

--- a/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
+++ b/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
@@ -58,7 +58,12 @@
       }
       else {
         // OK response (it includes contact_id and user_id in JSON, but we don't need those)
-        window.location = '/civicrm/';
+
+        // reload the page
+        // if we were trying to access a specific url, we will be taken to it
+        // if we reload the /civicrm/login we will be redirected to the home page
+        // (or an alternative url if we make that configurable)
+        location.reload();
       }
     });
   });


### PR DESCRIPTION
Overview
----------------------------------------
Update behaviour when an anonymous user tries to access a page they aren't allowed to.

Before
----------------------------------------
User is redirected to the login page, and show a "You might need to log in" message.

The status codes are 301 then 200, so the server doesn't register any "denied". 

[E2E tests fail where they expect to hit a 403](https://test.civicrm.org/job/CiviCRM-E2E-Matrix/BKPROF=max,BLDTYPE=standalone-clean,CIVIVER=master,label=bknix-tmp/lastCompletedBuild/testReport/(root)/E2E_Core_ErrorTest/testErrorStatus_with_data_set__frontend_permission_/). 


After
----------------------------------------
User is shown a 403 on the original page, with a login form, with the "You might need to log in" message.

Test passes.

Also on signing in, the page is refreshed so they go straight where they want to go :).


Technical Details
----------------------------------------
Is there an issue with not sending all logins through the `/civicrm/login` route? Might make e.g. SSO a bit trickier down the line?

Though maybe SSO extension would just supplant `CRM_Standaloneusers_Page_Login` everywhere, so fine here too. :shrug: 

