### PR TITLE
Improve 3 way fallback of name,title, frontend_title

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -958,7 +958,11 @@ class CRM_Core_DAO extends DB_DataObject {
     if (empty($values[$idField]) && array_key_exists('frontend_title', $fields) && empty($values['frontend_title'])) {
       $instance->frontend_title = $instance->title;
     }
-    if (empty($values[$idField]) && array_key_exists('title', $fields) && empty($values['title']) && !empty($values['frontend_title'])) {
+    if (empty($values[$idField]) && array_key_exists('frontend_title', $fields) && !$instance->frontend_title) {
+      // Still empty? Fall back to name.
+      $instance->frontend_title = $instance->name;
+    }
+    if (empty($values[$idField]) && array_key_exists('title', $fields) && empty($values['title']) && array_key_exists('frontend_title', $fields) && $instance->frontend_title) {
       $instance->title = $instance->frontend_title;
     }
     $instance->save();


### PR DESCRIPTION
Overview
----------------------------------------
Improve 3 way fallback of name,title, frontend_title

Before
----------------------------------------
Frontend title falls back to title, but not name

After
----------------------------------------
falls back to name

Technical Details
----------------------------------------
This is a change adding these fields to membership type & uf_group has in common
https://github.com/civicrm/civicrm-core/pull/28492

Comments
----------------------------------------