### PR TITLE
Do not suppress appropriate notices

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2082,7 +2082,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @return mixed
    */
   public function getVar($name) {
-    return $this->$name ?? NULL;
+    return $this->$name;
   }
 
   /**


### PR DESCRIPTION
If getVar is used to get a non-existent property then emitting a notice is the right behaviour
