### PR TITLE
dev/core#3344 and dev/core#3810 - Correct the frequency of quarterly/yearly membership contributions

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1162,7 +1162,9 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         ->addWhere('id', '=', $selectedMembershipTypeID)
         ->execute()
         ->first();
-      $this->_params['frequency_interval'] = $this->_params['frequency_interval'] ?? $this->_values['fee'][$priceFieldId]['options'][$priceFieldValue]['membership_num_terms'];
+      // below updated per issue #3344 and issue 3810
+      // $this->_params['frequency_interval'] = $this->_params['frequency_interval'] ?? $this->_values['fee'][$priceFieldId]['options'][$priceFieldValue]['membership_num_terms'];
+      $this->_params['frequency_interval'] = $membershipTypeDetails['duration_interval'] ?? $this->_values['fee'][$priceFieldId]['options'][$priceFieldValue]['membership_num_terms'];
       $this->_params['frequency_unit'] = $this->_params['frequency_unit'] ?? $membershipTypeDetails['duration_unit'];
     }
     elseif (!$this->_separateMembershipPayment && (in_array($selectedMembershipTypeID, $membershipTypes['autorenew_required'])


### PR DESCRIPTION
Overview
----------------------------------------
Issue 3344: When using membership price sets, the recurring contribution created currently doesn't match the term of the membership selected, it matches the term of the first membership in the price set. I applied the patch for this [mentioned here](https://lab.civicrm.org/dev/core/-/issues/3344).
Issue 3810: The frequency setting is being ignored for auto renew memberships with a term in months. Instead it is getting renewed every 1 month.

Before
----------------------------------------
Memberships with a quarterly or yearly fee are producing contributions and SEPA mandates with the quarterly / yearly amount every month.

After
----------------------------------------
Memberships with a quarterly or yearly fee are producing contributions and SEPA mandates quarterly / yearly.

Technical Details
----------------------------------------


Comments
----------------------------------------

