### PR TITLE
Bump min PHP version to 7.4.0

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -40,7 +40,7 @@ class CRM_Upgrade_Incremental_General {
    *
    * @see install/index.php
    */
-  const MIN_INSTALL_PHP_VER = '7.3.0';
+  const MIN_INSTALL_PHP_VER = '7.4.0';
 
   /**
    * The minimum recommended MySQL version.

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
   "include-path": ["vendor/tecnickcom"],
   "config": {
     "platform": {
-      "php": "7.3.0"
+      "php": "7.4.0"
     },
     "allow-plugins": {
       "civicrm/composer-compile-plugin": true,
@@ -50,7 +50,7 @@
     }
   },
   "require": {
-    "php": "~7.3 || ~8",
+    "php": "~7.4 || ~8",
     "composer-runtime-api": "~2.0",
     "dompdf/dompdf" : "~2.0.2",
     "firebase/php-jwt": ">=3 <7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aaf2da4db21436c628b6081c643cdc1e",
+    "content-hash": "288c4d344661b0b774a177675d8ee65b",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -5506,7 +5506,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~7.3 || ~8",
+        "php": "~7.4 || ~8",
         "composer-runtime-api": "~2.0",
         "ext-intl": "*",
         "ext-json": "*",
@@ -5514,7 +5514,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.3.0"
+        "php": "7.4.0"
     },
     "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
See https://lab.civicrm.org/dev/core/-/issues/4812

Last bump was [a year ago](https://github.com/civicrm/civicrm-core/pull/25147).
