### PR TITLE
[REF][PHP8.2] Survey details report - dynamic properties

### DIFF
--- a/CRM/Report/Form/Campaign/SurveyDetails.php
+++ b/CRM/Report/Form/Campaign/SurveyDetails.php
@@ -16,9 +16,10 @@
  */
 class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
 
-  protected $_emailField = FALSE;
-
-  protected $_phoneField = FALSE;
+  /**
+   * @var array
+   */
+  protected $surveyResponseFields = [];
 
   protected $_locationBasedPhoneField = FALSE;
 
@@ -236,7 +237,7 @@ class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
         ) {
 
           $fieldsName = CRM_Utils_Array::value(1, explode('_', $tableName));
-          if ($fieldsName) {
+          if ($fieldsName && property_exists($this, "_$fieldsName" . 'Field')) {
             $this->{"_$fieldsName" . 'Field'} = TRUE;
           }
 
@@ -282,7 +283,7 @@ class CRM_Report_Form_Campaign_SurveyDetails extends CRM_Report_Form {
     $this->joinEmailFromContact();
 
     if ($this->_locationBasedPhoneField) {
-      foreach ($this->_surveyResponseFields as $key => $value) {
+      foreach ($this->surveyResponseFields as $key => $value) {
         if (substr($key, 0, 5) == 'phone' && !empty($value['location_type_id'])
         ) {
           $fName = str_replace('-', '_', $key);
@@ -676,7 +677,7 @@ INNER JOIN  civicrm_custom_group cg ON ( cg.id = cf.custom_group_id )
     $responseFields = [];
     foreach ($surveyIds as $surveyId) {
       $responseFields += CRM_Campaign_BAO_Survey::getSurveyResponseFields($surveyId);
-      $this->_surveyResponseFields = $responseFields;
+      $this->surveyResponseFields = $responseFields;
     }
     foreach ($responseFields as $key => $value) {
       if (substr($key, 0, 5) == 'phone' && !empty($value['location_type_id'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix class `CRM_Report_Form_Campaign_SurveyDetails` to work smoothly on PHP 8.2.

Before
----------------------------------------
Dynamic properties are deprecated in PHP 8.2, and this class was resulting in 4 test fails on PHP 8.2+.

After
----------------------------------------
Properties are only used where declared.

Technical Details
----------------------------------------
The definitions for `_emailField` and `_phoneField` have been removed, as these are declared in the parent class `CRM_Report_Form`.

`surveyResponseFields` is declared.

On line 240, there is this code `$this->{"_$fieldsName" . 'Field'} = TRUE;`. The parent class does have `_addressField`, `_emailField`, and `_phoneField` properties, and so I don't think this line can be removed together. However, in my testing, it is safe to only set the property dynamically if the property actually exists.