### PR TITLE
[REF][PHP8.2] Declare _params property

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -165,6 +165,14 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
   protected $contributionID;
 
   /**
+   * The params submitted by the form
+   *
+   * @var array
+   * @internal
+   */
+  public $_params = [];
+
+  /**
    * Get the contribution id that has been created or is being edited.
    *
    * @internal - not supported for outside core.


### PR DESCRIPTION
Overview
----------------------------------------
Declare `_params` property on `CRM_Contribute_Form_AbstractEditPayment`.

Before
----------------------------------------
A lot of event/payment related tests are failing on PHP 8.2 due to `Creation of dynamic property CRM_Contribute_Form_AdditionalPayment::$_params is deprecated`.

After
----------------------------------------
`_params` is declared on the parent class of `CRM_Contribute_Form_AdditionalPayment`.

Comments
----------------------------------------
It's pretty tricky to follow all the ways `_params` is used. As such I've gone `public`, but marked as `internal`.

There are other dynamic properties which touch `CRM_Contribute_Form_AdditionalPayment`, so I don't think this will have a big impact on the test results alone, but it's a step in the right direction.
