### PR TITLE
[php8] dev/core#4807 - Move $_entityTagValues to where it's used

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -186,6 +186,20 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   private $authenticatedContactID;
 
   /**
+   * @var array
+   * @internal
+   * This gets used in CRM_Core_Form_Tag via multiple routes
+   */
+  public $_entityTagValues;
+
+  /**
+   * @var array
+   * @internal
+   * This gets used in CRM_Core_Form_Tag via multiple routes
+   */
+  public $_tagsetInfo;
+
+  /**
    * @return string
    */
   public function getContext() {

--- a/CRM/Core/Form/Tag.php
+++ b/CRM/Core/Form/Tag.php
@@ -19,7 +19,6 @@
  * This class generates form element for free tag widget.
  */
 class CRM_Core_Form_Tag {
-  public $_entityTagValues;
 
   /**
    * Build tag widget if correct parent is passed


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4807

Before
----------------------------------------
There are php 8.2 errors about it being undeclared. It's declared, but in the wrong place.

After
----------------------------------------
Moved to where it's used.
Also $_tagsetInfo.

Technical Details
----------------------------------------
CRM_Core_Form_Tag isn't really a form it's a collection of utilities, and these vars are always referenced as $form->var where $form is some other form. There are a couple other options as mentioned in the ticket but I'm taking the easy way out because it's pretty varied where this gets called from.

Comments
----------------------------------------
