### PR TITLE
[REF][PHP8.2] Declare properties in CRM_Contribute_Form_ContributionPage_Widget

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/Widget.php
+++ b/CRM/Contribute/Form/ContributionPage/Widget.php
@@ -15,9 +15,35 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 class CRM_Contribute_Form_ContributionPage_Widget extends CRM_Contribute_Form_ContributionPage {
-  protected $_colors;
 
+  /**
+   * Configuration for each form field
+   *
+   * @var array
+   * @internal
+   */
+  public $_fields = [];
+
+  /**
+   * Configuration for each color field
+   *
+   * @var array
+   * @internal
+   */
+  public $_colorFields = [];
+
+  /**
+   * @var CRM_Contribute_DAO_Widget
+   */
   protected $_widget;
+
+  /**
+   * Name of the refresh button,
+   * used to display the widget preview
+   *
+   * @var string
+   */
+  protected $_refreshButtonName;
 
   public function preProcess() {
     parent::preProcess();


### PR DESCRIPTION
Overview
----------------------------------------
Declare properties in `CRM_Contribute_Form_ContributionPage_Widget`.

Before
----------------------------------------
Dynamic properties are deprecated in PHP 8.2. This class was using dynamic properties, causing test failures on PHP 8.2+

After
----------------------------------------
Properties are declared (as well as extra comments added to the properties which already existed).

Technical Details
----------------------------------------
`_colors` was declared, but never used.

It is plausable an extension could be using `_fields` or `_colorFields`. To be on the safe side I've gone `public` but marked `internal`