### PR TITLE
ConfigTaskList: a few language tweaks and add reference to CiviCRM themes

### DIFF
--- a/templates/CRM/Admin/Page/ConfigTaskList.tpl
+++ b/templates/CRM/Admin/Page/ConfigTaskList.tpl
@@ -9,42 +9,43 @@
 *}
 {capture assign="linkTitle"}{ts}Edit settings{/ts}{/capture}
 {capture assign="adminMenu"}{crmURL p="civicrm/admin" q="reset=1"}{/capture}
-
 <div class="help">
-    {ts 1=$adminMenu}Use this checklist to review and complete configuration tasks for your site. You will be redirected back to this checklist after saving each setting. Settings which you have not yet reviewed will be <span class="status-overdue">displayed in red</span>. After you have visited a page, the links will <span class="status-pending">display in green</span>  (although you may still need to revisit the page to complete or update the settings). You can access this page again from the <a href="%1">Administer CiviCRM</a> menu at any time.{/ts}
+  {ts 1=$adminMenu}Use this checklist to review configuration tasks for your site. Settings that you have not yet reviewed will be <span class="status-overdue">displayed in red</span>. After you have visited a page, the links will <span class="status-pending">display in green</span>. You can access this page again from the <a href="%1">Administer CiviCRM</a> menu at any time.{/ts}
 </div>
-
 <table class="selector">
     <tr class="columnheader">
-        <td colspan="2">{ts}Site Configuration and Registration{/ts}</td>
+        <td colspan="2">{ts}Site Configuration{/ts}</td>
+    </tr>
+    <tr class="even">
+        <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/domain" q="action=update&reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}Organization Contact Information{/ts}</a></td>
+        <td>{ts}Configure your organization name, email address and postal address.{/ts}</td>
     </tr>
     <tr class="even">
         <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/setting/localization" q="reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}Localization{/ts}</a></td>
         <td>{ts}Localization settings include user language, default currency and available countries for address input.{/ts}</td>
     </tr>
     <tr class="even">
-        <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/domain" q="action=update&reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}Organization Address and Contact Info{/ts}</a></td>
-        <td>{ts}Organization name, email address for system-generated emails, organization address{/ts}</td>
+        <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/setting/component" q="action=update&reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}Components{/ts}</a></td>
+        <td>{ts}Enable or disable Components such as CiviContribute, CiviEvent, CiviCase, etc.{/ts}</td>
     </tr>
     <tr class="even">
-        <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/setting/component" q="action=update&reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}Enable components{/ts}</a></td>
-        <td>{ts}Enable the required CiviCRM components.(CiviContribute, CiviEvent etc.){/ts}</td>
+        <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/extensions" q="reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}Extensions{/ts}</a></td>
+        <td>{ts}Extensions are installable packages which give CiviCRM new functionality.{/ts} {ts}Some extenions are shipped with CiviCRM (known as core extensions, such as SearchKit and FormBuilder), but there are also many extensions developed by the community.{/ts}</td>
     </tr>
     <tr class="even">
         <td class="tasklist nowrap"><a href="{$registerSite}" title="{ts}Register your site at CiviCRM.org. Opens in a new window.{/ts}" target="_blank">{ts}Register your site{/ts}</a></td>
-        <td>{ts}Register your site, join the community, and help CiviCRM remain a leading CRM for organizations worldwide.{/ts}</td>
+        <td>{ts}Join the community and help CiviCRM remain a leading CRM for organizations worldwide.{/ts}</td>
     </tr>
-
     <tr class="columnheader">
         <td colspan="2">{ts}Viewing and Editing Contacts{/ts}</td>
     </tr>
     <tr class="even">
         <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/setting/preferences/display" q="reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}Display Preferences{/ts}</a></td>
-        <td>{ts}Configure screen and form elements for Viewing Contacts, Editing Contacts, Advanced Search, Contact Dashboard and WYSIWYG Editor.{/ts}</td>
+        <td>{ts}Configure screen and form elements for Viewing Contacts, Editing Contacts, Advanced Search, Contact Dashboard and WYSIWYG Editor.{/ts} {ts 1="href='https://civicrm.org/themes' target='_blank'"}You can also change the theme here, but first it must be installed as an extension. You can <a %1>explore CiviCRM themes</a> on the extension directory.{/ts}</td>
     </tr>
     <tr class="even">
         <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/setting/preferences/address" q="reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}Address Settings{/ts}</a></td>
-        <td>{ts}Format addresses in mailing labels, input forms and screen display.{/ts}</td>
+        <td>{ts}Format addresses in mailing labels, input forms and how they are displayed on screens.{/ts}</td>
     </tr>
     <tr class="even">
         <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/setting/mapping" q="reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}Mapping and Geocoding{/ts}</a></td>
@@ -55,16 +56,11 @@
         <td>{ts}Adjust search behaviors including wildcards, and data to include in quick search results. Adjusting search settings can improve performance for larger datasets.{/ts}</td>
     </tr>
     <tr class="even">
-        <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/setting/misc" q="reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}Misc (Undelete, PDFs, Limits, Logging, etc.){/ts}</a></td>
-        <td>{ts}Version reporting, alerts and attachments.{/ts}</td>
-    </tr>
-    <tr class="even">
         <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/options/subtype" q="reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}Contact Types{/ts}</a></td>
         <td>{ts}You can modify the names of the built-in contact types (Individual, Household, Organizations), and you can create or modify "contact subtypes" for more specific uses (e.g. Student, Parent, Team, etc.).{/ts}</td>
     </tr>
-
     <tr class="columnheader">
-        <td colspan="2">{ts}Sending Emails (includes contribution receipts and event confirmations){/ts}</td>
+        <td colspan="2">{ts}Sending Emails (also used for contribution receipts and event confirmations){/ts}</td>
     </tr>
     <tr class="even">
         <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/options/from_email_address" q="reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}From Email Addresses{/ts}</a></td>
@@ -74,7 +70,6 @@
         <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/setting/smtp" q="reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}Outbound Email{/ts}</a></td>
         <td>{ts}Settings for outbound email - either SMTP server, port and authentication or Sendmail path and argument.{/ts}</td>
     </tr>
-
     <tr class="columnheader">
         <td colspan="2">{ts}Online Contributions / Online Membership Signup / Online Event Registration{/ts}</td>
     </tr>
@@ -133,7 +128,6 @@
     </tr>
 </table>
 <br />
-
 <div class="description">
     {ts}Now you can move on to exploring, configuring and using the various optional components for fundraising and constituent engagement. The links below will take you to the online documentation for each component.{/ts}
 </div>
@@ -168,9 +162,5 @@
     <tr class="even">
         <td class="tasklist nowrap">{docURL page="user/case-management/what-is-civicase" text=$componentTitles.CiviCase}</td>
         <td>{ts}Integrated case management for human service providers{/ts}</td>
-    </tr>
-    <tr class="even">
-        <td class="tasklist nowrap">{docURL page="user/grants/what-is-civigrant" text=$componentTitles.CiviGrant}</td>
-        <td>{ts}Distribute funds to others, for example foundations, grant givers, etc.{/ts}</td>
     </tr>
 </table>


### PR DESCRIPTION
Overview
----------------------------------------

Initially my motivation was to add a reference to CiviCRM themes (https://civicrm.org/themes). While I was there I did a few tweaks to civi-jargon so that, I hope, the page is a bit more pleasant to read (civi-jargon tends to be overly pedantic).

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/ddbbfa92-3db7-47b9-a81c-031b2e5b97b5)

![image](https://github.com/civicrm/civicrm-core/assets/254741/7f787596-3233-4251-8e06-3add9554ec4b)


After
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/4c5565e7-bfd4-4534-850c-9b825582aced)

Not visible:

- Removed the "Misc" link, because it's  rather obscure and odd for new users
- Removed the CiviGrant link because it was broken (not a component anymore)
- Changed "Site Configuration and Registration" to "Site Configuration" because it's CiviPedantic (I initially wanted to avoid breaking too many translations, but it annoyed me).

Comments
----------------------------------------

I had interesting discussions at the Ashbourne/UK sprint with people who said that they had an positive experience from using this checklist, including the fact that link colours changed.

I think the Checklist has some potential for folks who don't like reading documentation and just want to poke around.