### PR TITLE
[REF][PHP8.2] Add PHP8.2 support to CRM_Contact_Page_View_Summary

### DIFF
--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -21,6 +21,42 @@
 class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
 
   /**
+   * Contents of contact_view_options setting.
+   *
+   * @var array
+   * @internal
+   */
+  public $_viewOptions;
+
+  /**
+   * Provide support for extensions that are using the _show{Block} properties
+   * (e.g. `_showCustomData`, `_showAddress`, `_showPhone` etc)
+   *
+   * These properties were dynamically defined,
+   * based on the available `contact_edit_options`,
+   * and so have been deprecated for PHP 8.2 support.
+   *
+   * Extension authors can read contact_edit_options directly.
+   * The show{Block} values are also still assigned to the template layer.
+   *
+   * @param string $name
+   * @return bool|null
+   */
+  public function __get($name) {
+    if (str_starts_with($name, '_show')) {
+      $blockName = substr($name, strlen('_show'));
+      $editOptions = CRM_Core_BAO_Setting::valueOptions(
+        CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
+        'contact_edit_options'
+      );
+
+      CRM_Core_Error::deprecatedWarning('_show{Block} properties are deprecated in CRM_Contact_Page_View_Summary. Read contact_edit_options directly instead.');
+      return $editOptions[$blockName] ?? FALSE;
+    }
+    return NULL;
+  }
+
+  /**
    * Heart of the viewing process.
    *
    * The runner gets all the meta data for the contact and calls the appropriate type of page to view.
@@ -216,9 +252,8 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
     );
 
     foreach ($editOptions as $blockName => $value) {
-      $varName = '_show' . $blockName;
-      $this->$varName = $value;
-      $this->assign(substr($varName, 1), $this->$varName);
+      $varName = 'show' . $blockName;
+      $this->assign($varName, $value);
     }
 
     // get contact name of shared contact names


### PR DESCRIPTION
Overview
----------------------------------------
Add PHP8.2 support to `CRM_Contact_Page_View_Summary`.

Before
----------------------------------------
`CRM_Contact_Page_View_Summary` used dynamic properties. Dynamic properties are deprecated in PHP 8.2, and this was causing a test fail (as well as triggering notices on PHP 8.2+ installations). 

After
----------------------------------------
This feels like a class where we want to play it safe in terms of backwards compatiabilty, as it's so core to what CiviCRM does. As such:

 `_viewOptions` is declared. To maintain backwards compatiability I've gone `public`, but marked `internal`. 
 
I've added a `__get()` magic method to deal with the truly dynamic `show{Block}` variables. It wasn't really practical to individual declare all of these, because:

a. There is a lot of them.
b. (At least in theory) an extension could add their own values to the contact_edit_options group.

Adding a `__get()` gets around this, and is a pattern which has recently been used elsewhere (e.g. https://github.com/civicrm/civicrm-core/pull/28276). 

Currently the `__get()` has a noisy deprecation. Perhaps you'd prefer to go for a softer deprecation in the short-term; if so I can remove the deprecation warning.
