### PR TITLE
[NFC] Remove unused variable

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -394,7 +394,7 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address implements Civi\Core\Hoo
           }
         }
       }
-      $stree = $address->street_address;
+
       $values = [];
       CRM_Core_DAO::storeValues($address, $values);
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused variable.

Before
----------------------------------------
`$stree` is set, but never read.

After
----------------------------------------
`$stree` is never set, making this code ever slightly so easier to follow.