### PR TITLE
[REF][PHP8.2] Tidy up use of properties in CRM_Campaign_Form_Task_Release

### DIFF
--- a/CRM/Campaign/Form/Task/Release.php
+++ b/CRM/Campaign/Form/Task/Release.php
@@ -47,12 +47,12 @@ class CRM_Campaign_Form_Task_Release extends CRM_Campaign_Form_Task {
    * Build all the data structures needed to build the form.
    */
   public function preProcess() {
-    $this->_interviewToRelease = $this->get('interviewToRelease');
-    if ($this->_interviewToRelease) {
+    $interviewToRelease = $this->get('interviewToRelease');
+    if ($interviewToRelease) {
       //user came from interview form.
-      foreach (['surveyId', 'contactIds', 'interviewerId'] as $fld) {
-        $this->{"_$fld"} = $this->get($fld);
-      }
+      $this->_surveyId = $this->get('surveyId');
+      $this->_contactIds = $this->get('contactIds');
+      $this->_interviewerId = $this->get('interviewerId');
 
       if (!empty($this->_contactIds)) {
         $this->assign('totalSelectedContacts', count($this->_contactIds));


### PR DESCRIPTION
Overview
----------------------------------------
Tidy up use of properties in `CRM_Campaign_Form_Task_Release`

Before
----------------------------------------
`CRM_Campaign_Form_Task_Release` used a dynamic property, which is deprecated in PHP8.2.

In addition the code was overly complex, so this has been cleaned up.

After
----------------------------------------
`$interviewToRelease` is now just a variable, as it didn't need to be a property - it is not read from anywhere else.

The code to set the properties `_surveyId`, `_contactIds` and `_interviewerId` has been simplified, to make the code easier to read.