### PR TITLE
[REF][PHP8.2] address dynamic properties in CRM_Event_Form_SearchEvent

### DIFF
--- a/CRM/Event/Form/SearchEvent.php
+++ b/CRM/Event/Form/SearchEvent.php
@@ -30,12 +30,12 @@ class CRM_Event_Form_SearchEvent extends CRM_Core_Form {
     $defaults = [];
     $defaults['eventsByDates'] = 0;
 
-    $this->_showHide = new CRM_Core_ShowHideBlocks();
+    $showHide = new CRM_Core_ShowHideBlocks();
     if (empty($defaults['eventsByDates'])) {
-      $this->_showHide->addHide('id_fromToDates');
+      $showHide->addHide('id_fromToDates');
     }
 
-    $this->_showHide->addToTemplate();
+    $showHide->addToTemplate();
     return $defaults;
   }
 
@@ -51,7 +51,6 @@ class CRM_Event_Form_SearchEvent extends CRM_Core_Form {
 
     $this->addSelect('event_type_id', ['multiple' => TRUE, 'context' => 'search']);
 
-    $eventsByDates = [];
     $searchOption = [ts('Show Current and Upcoming Events'), ts('Search All or by Date Range')];
     $this->addRadio('eventsByDates', ts('Events by Dates'), $searchOption, ['onclick' => "return showHideByValue('eventsByDates','1','id_fromToDates','block','radio',true);"], '&nbsp;');
 


### PR DESCRIPTION
Overview
----------------------------------------
Address dynamic properties in `CRM_Event_Form_SearchEvent`

Before
----------------------------------------
`$this->_showHide` is used as a dynamic property. Dynamic properties are deprecated in PHP 8.2.

After
----------------------------------------
Local variable used instead.

Technical Details
----------------------------------------
This doens't impact tests, but still good from an overall PHP 8.2. perspective.

From a backwards-compatiability perspective, I can't see why any extension would need to get hold of the `CRM_Core_ShowHideBlocks` object, so a local variable (rather than a property) seems fine.