### PR TITLE
Allow API4 Job to be a ManagedEntity

### DIFF
--- a/Civi/Api4/Job.php
+++ b/Civi/Api4/Job.php
@@ -17,5 +17,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class Job extends Generic\DAOEntity {
+  use Generic\Traits\ManagedEntity;
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
In the mjwshared extension I've specified a scheduled Job using API4 ManagedEntity. It works.. but I was getting this error message
`civicrm.WARNING: ManagedEntity update policy "unmodified" specified for entity type Job which is not an APIv4 ManagedEntity. Falling back to policy "always".`

Here is the job definition:
https://lab.civicrm.org/extensions/mjwshared/-/blob/master/managed/ProcessPaymentprocessorWebhooks.mgd.php?ref_type=heads

It looks like it just needs the ManagedEntity trait adding? @colemanw is this right?

Before
----------------------------------------
Warnings when using ManagedEntities for API4 Job.

After
----------------------------------------
No warnings.

Technical Details
----------------------------------------
Described above.

Comments
----------------------------------------
@colemanw Can you confirm this is correct please?
@artfulrobot This might be another missing piece...
