### PR TITLE
Standalone - Fix favicon

### DIFF
--- a/templates/CRM/common/standalone.tpl
+++ b/templates/CRM/common/standalone.tpl
@@ -3,7 +3,7 @@
  <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="Shortcut Icon" type="image/x-icon" href="{$config->resourceBase}i/widget/favicon.png" />
+  <link rel="icon" type="image/png" href="{$config->resourceBase}i/logo_lg.png" >
 
   {* @todo crmRegion below should replace this, but not working? *}
   {if isset($pageHTMLHead)}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes missing favicon in Civi Standalone.

Before
---------
Icon missing from browser tab.

After
-------
Civi icon shows.

Comments
------
Maybe this could become a configurable option, but for now this fixes what was already there but broken.