### PR TITLE
Standalone - Remove unused reference to nonexistent file

### DIFF
--- a/templates/CRM/common/standalone.tpl
+++ b/templates/CRM/common/standalone.tpl
@@ -15,11 +15,6 @@
   {crmRegion name='html-header'}
   {/crmRegion}
 
-{* @todo This is probably not required? *}
-{if isset($buildNavigation) and !$urlIsPublic}
-    {include file="CRM/common/Navigation.tpl"}
-{/if}
-
   <title>{if isset($docTitle)}{$docTitle}{else}CiviCRM{/if}</title>
 </head>
 <body>


### PR DESCRIPTION
Overview
----------------------------------------
Navigation.tpl was removed a long time ago.

Before
--------
`@todo This is probably not required?`

After
------
No it isn't.