### PR TITLE
Afform - Remove unused css for collapsible containers

### DIFF
--- a/ext/afform/core/ang/afCore.css
+++ b/ext/afform/core/ang/afCore.css
@@ -46,23 +46,6 @@ af-form {
   right: 0;
 }
 
-/* Collapsible containers */
-.af-collapsible > .af-title {
-  cursor: pointer;
-}
-.af-collapsible > .af-title:before {
-  font-family: "FontAwesome";
-  display: inline-block;
-  width: 1em;
-  content: "\f0d7";
-}
-.af-collapsible.af-collapsed > .af-title:before {
-  content: "\f0da";
-}
-.af-collapsible.af-collapsed > .af-title ~ * {
-  display: none !important;
-}
-
 /* Card style */
 #bootstrap-theme .af-container-style-pane {
   background-color: white;
@@ -82,9 +65,6 @@ af-form {
   width: calc(100% + 10px);
   margin-top: 0;
   margin-bottom: 10px;
-}
-#bootstrap-theme .af-container-style-pane.af-collapsed > .af-title {
-  margin-bottom: 0;
 }
 
 /* Admin edit links */


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an oversight in https://github.com/civicrm/civicrm-core/pull/28449 which removed js but not the corresponding css, which would leave existing collapsible elements on forms in a half-broken state.

Technical Details
----------------------------------------
Collapsible container markup [has been switched to using summary/details elements](https://github.com/civicrm/civicrm-core/pull/28449).

Without this PR, collapsible Afform containers made pre 5.69 would appear broken, as they would get collapsible styling but no clickable functionality.

With this PR, they will be completely reverted to non-collapsible.

Comments
--------
This is a very obscure feature, but if any form actually exists out there in the wild with a collapsible container, upgrading to 5.69 will revert it to a normal non-collapsible container. The collapsible functionality can be re-added simply by editing the form and selecting "Collapsible" from the element-type dropdown:

![image](https://github.com/civicrm/civicrm-core/assets/2874912/fb8b526f-53a4-4556-82cb-fc74b60a2d21)
