### PR TITLE
PoC: Order Complete event

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3850,10 +3850,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     }
 
     if ($contributionParams['contribution_status_id'] === $completedContributionStatusID) {
-      self::updateMembershipBasedOnCompletionOfContribution(
-        $contributionID,
-        $input['trxn_date'] ?? date('YmdHis')
-      );
+      $dateTodayForDatesCalculations = $input['trxn_date'] ?? date('YmdHis');
+      \Civi::dispatcher()->dispatch('civi.order.complete', new \Civi\Order\Event\OrderCompleteEvent($contributionID, $dateTodayForDatesCalculations));
     }
 
     $participantPayments = civicrm_api3('ParticipantPayment', 'get', ['contribution_id' => $contributionID, 'return' => 'participant_id', 'sequential' => 1])['values'];

--- a/Civi/Core/Event/ServiceListener.php
+++ b/Civi/Core/Event/ServiceListener.php
@@ -89,4 +89,8 @@ class ServiceListener {
     return $this;
   }
 
+  public function getInertCb() {
+    return implode('::', $this->inertCb);
+  }
+
 }

--- a/Civi/Membership/OrderCompleteSubscriber.php
+++ b/Civi/Membership/OrderCompleteSubscriber.php
@@ -1,0 +1,33 @@
+<?php
+namespace Civi\Membership;
+
+use Civi\Core\Service\AutoSubscriber;
+use Civi\Order\Event\OrderCompleteEvent;
+
+/**
+ * Class OrderCompleteSubscriber
+ * @package Civi\Membership
+ *
+ * This class handles the smarty processing of tokens.
+ */
+class OrderCompleteSubscriber extends AutoSubscriber {
+
+  /**
+   * @inheritDoc
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      'civi.order.complete' => ['onOrderComplete', 0],
+    ];
+  }
+
+  /**
+   * Apply the various CRM_Utils_Token helpers.
+   *
+   * @param \Civi\Order\Event\OrderCompleteEvent $event
+   */
+  public function onOrderComplete(OrderCompleteEvent $event): void {
+    \CRM_Contribute_BAO_Contribution::updateMembershipBasedOnCompletionOfContribution($event->contributionID, $event->dateTodayForDatesCalculations);
+  }
+
+}

--- a/Civi/Order/Event/OrderCompleteEvent.php
+++ b/Civi/Order/Event/OrderCompleteEvent.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Order\Event;
+
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * Class OrderCompleteEvent
+ *
+ * @package Civi\Order\Event
+ */
+class OrderCompleteEvent extends GenericHookEvent {
+
+  /**
+   * The Contribution ID that was Completed
+   *
+   * @var int
+   */
+  public int $contributionID;
+
+  /**
+   * If provided, specify an alternative date to use as "today" calculation of membership dates
+   *
+   * @var string
+   */
+  public string $dateTodayForDatesCalculations;
+
+  /**
+   * Class constructor
+   *
+   * @param int $contributionID
+   * @param string $dateTodayForDatesCalculations
+   */
+  public function __construct(int $contributionID, string $dateTodayForDatesCalculations) {
+    $this->contributionID = $contributionID;
+    $this->dateTodayForDatesCalculations = $dateTodayForDatesCalculations;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getHookValues() {
+    return [$this->contributionID, $this->dateTodayForDatesCalculations];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
An "Order Complete" event would allow us to perform actions on order complete (eg. what `CRM_Contribute_BAO_Contribution::updateMembershipBasedOnCompletionOfContribution()` currently does).

Before
----------------------------------------
Membership dates/status are updated on completion of contribution. No way to override/change.

After
----------------------------------------
- Membership dates/status are updated on completion of contribution via `civi.order.complete` event.
- Now possible to add additional functionality by intercepting a listener for the `civi.order.complete` event - eg. a custom extension that creates a "Dispatch Order" activity or changes a case status.
- Also possible (but see note below) to remove existing listeners so we can alter/disable default behaviour.

Technical Details
----------------------------------------
- Implements a new event, listener and subscriber `civi.order.completed`.
- Moves call to `CRM_Contribute_BAO_Contribution::updateMembershipBasedOnCompletionOfContribution()` to a new subscriber class.
- Adds a way to identify the listener so we can identify and remove it if we don't want it to happen - https://github.com/civicrm/civicrm-core/commit/aab9f2fe050e209869669b2b6c083f0ea635423f#diff-b595270d96dce4b990ffd2c4ae84db76bb30aff70a5e6cce124acd2dd6b0f298R92-R94

Comments
----------------------------------------
Problem: We can `addListener`, `getListeners` and `removeListener`. But there is no way (that I can find) to *identify* an existing listener to remove it. So I added `getInertCb()` to `Civi/Core/Event/ServiceListener.php` class so I could do a proof of concept.

You can then use code like this to remove specific subscribers before the `civi.order.complete` event is dispatched:
```
    $listeners = \Civi::dispatcher()->getListeners('civi.order.complete');
    foreach ($listeners as $listener) {
      if ($listener->getInertCb() === 'Civi\Membership\OrderCompleteSubscriber::onOrderComplete') {
        \Civi::log()->debug('disabled Civi\Membership\OrderCompleteSubscriber::onOrderComplete');
        \Civi::dispatcher()->removeListener('civi.order.complete', $listener);
        break;
      }
    }
```
So for example, you might prepare a call to API Payment.create knowing that you want to complete the contribution (which "completes" the order) but you *don't* want to update the linked membership. Run the above code to remove the listener before doing so and `updateMembershipBasedOnCompletionOfContribution` will not be called!