### PR TITLE
Fix dev/core#4852 - View notes renders as form instead of page

### DIFF
--- a/CRM/Note/Form/Note.php
+++ b/CRM/Note/Form/Note.php
@@ -98,6 +98,10 @@ class CRM_Note_Form_Note extends CRM_Core_Form {
    * @return void
    */
   public function buildQuickForm() {
+    if ($this->_action & CRM_Core_Action::VIEW) {
+      $this->view();
+      return;
+    }
     if ($this->_action & CRM_Core_Action::DELETE) {
       $this->addButtons([
           [
@@ -175,6 +179,26 @@ class CRM_Note_Form_Note extends CRM_Core_Form {
     $this->setEntityId($note->id);
 
     CRM_Core_Session::setStatus(ts('Your Note has been saved.'), ts('Saved'), 'success');
+  }
+
+  /**
+   * View details of a note.
+   */
+  private function view() {
+    $note = \Civi\Api4\Note::get()
+      ->addSelect('*', 'privacy:label')
+      ->addWhere('id', '=', $this->_id)
+      ->execute()
+      ->single();
+    $note['privacy'] = $note['privacy:label'];
+    $this->assign('note', $note);
+
+    $comments = CRM_Core_BAO_Note::getNoteTree($this->_id, 1);
+    $this->assign('comments', $comments);
+
+    // add attachments part
+    $currentAttachmentInfo = CRM_Core_BAO_File::getEntityFile('civicrm_note', $this->_id);
+    $this->assign('currentAttachmentInfo', $currentAttachmentInfo);
   }
 
 }

--- a/templates/CRM/Note/Form/Note.tpl
+++ b/templates/CRM/Note/Form/Note.tpl
@@ -7,8 +7,41 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
+{* View action *}
+{if ($action eq 4)}
+  <div class="crm-block crm-content-block crm-note-view-block">
+    <table class="crm-info-panel">
+      <tr><td class="label">{ts}Subject{/ts}</td><td>{$note.subject}</td></tr>
+      <tr><td class="label">{ts}Date:{/ts}</td><td>{$note.note_date|crmDate}</td></tr>
+      <tr><td class="label">{ts}Modified Date:{/ts}</td><td>{$note.modified_date|crmDate}</td></tr>
+      <tr><td class="label">{ts}Privacy:{/ts}</td><td>{$note.privacy}</td></tr>
+      <tr><td class="label">{ts}Note:{/ts}</td><td>{$note.note|nl2br}</td></tr>
+
+        {if $currentAttachmentInfo}
+            {include file="CRM/Form/attachment.tpl"}
+        {/if}
+    </table>
+    <div class="crm-submit-buttons">
+        {crmButton class="cancel" icon="times" p='civicrm/contact/view' q="selectedChild=note&reset=1&cid=`$note.entity_id`"}{ts}Done{/ts}{/crmButton}
+    </div>
+
+      {if $comments}
+        <fieldset>
+          <legend>{ts}Comments{/ts}</legend>
+          <table class="display">
+            <thead>
+            <tr><th>{ts}Comment{/ts}</th><th>{ts}Created By{/ts}</th><th>{ts}Date{/ts}</th><th>{ts}Modified Date{/ts}</th></tr>
+            </thead>
+              {foreach from=$comments item=comment}
+                <tr class="{cycle values='odd-row,even-row'}"><td>{$comment.note}</td><td>{$comment.createdBy}</td><td>{$comment.note_date}</td><td>{$comment.modified_date}</td></tr>
+              {/foreach}
+          </table>
+        </fieldset>
+      {/if}
+
+  </div>
 {* Delete action *}
-{if ($action eq 8)}
+{elseif ($action eq 8)}
   <div class=status>{ts}Are you sure you want to delete this note?{/ts}</div>
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>
 {* Create/Update actions *}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#4852](https://lab.civicrm.org/dev/core/-/issues/4852) viewing of notes.

Before
----------------------------------------
Clicking on "View" for a contact note brings up an empty form.

After
----------------------------------------
Brings up page to view the note.

Technical Details
-------------
This adds back 2 pieces that were deleted in 8ad23a073215ad851ec4f7e4ab9b74808d7426a6

