### PR TITLE
standalone: implement cms-prefixed permissions as concrete ones

### DIFF
--- a/ext/standaloneusers/Civi/Api4/Role.php
+++ b/ext/standaloneusers/Civi/Api4/Role.php
@@ -10,4 +10,13 @@ namespace Civi\Api4;
  */
 class Role extends Generic\DAOEntity {
 
+  /**
+   * Declare permissions needed to access this entity.
+   */
+  public static function permissions() {
+    return [
+      'default' => ['cms:administer users'],
+    ];
+  }
+
 }

--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -29,8 +29,6 @@ class Security {
   /**
    * CRM_Core_Permission_Standalone::check() delegates here.
    *
-   * @param \CRM_Core_Permission_Standalone $permissionObject
-   *
    * @param string $permissionName
    *   The permission to check.
    *
@@ -40,7 +38,7 @@ class Security {
    * @return bool
    *   true if yes, else false
    */
-  public function checkPermission(\CRM_Core_Permission_Standalone $permissionObject, string $permissionName, ?int $userID = NULL) {
+  public function checkPermission(string $permissionName, ?int $userID = NULL) {
     if ($permissionName == \CRM_Core_Permission::ALWAYS_DENY_PERMISSION) {
       return FALSE;
     }

--- a/ext/standaloneusers/standaloneusers.php
+++ b/ext/standaloneusers/standaloneusers.php
@@ -75,6 +75,9 @@ function standaloneusers_civicrm_enable() {
 /**
  * Implements hook_civicrm_permission().
  */
-function standalone_civicrm_permission(&$permissions) {
+function standaloneusers_civicrm_permission(&$permissions) {
   $permissions['access password resets'] = ts('Allow users to access the reset password system');
+  // Concrete implementations of synthetic cms: permissions.
+  $permissions['administer users'] = ts('Administer user accounts');
+  $permissions['view user account'] = ts('View user accounts');
 }

--- a/setup/plugins/init/StandaloneUsers.civi-setup.php
+++ b/setup/plugins/init/StandaloneUsers.civi-setup.php
@@ -141,6 +141,9 @@ if (!defined('CIVI_SETUP')) {
             'view own manual batches',
             'access all custom data',
             'access contact reference fields',
+            // Standalone-defined permissions that have the same name as the cms: prefixed synthetic ones
+            'administer users',
+            'view user account',
             // The admninister CiviCRM data implicitly sets other permissions as well.
             // Such as, edit message templates and admnister dedupe rules.
             'administer CiviCRM Data',


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/4857


Before
----------------------------------------

Can't assign administer users to a role; so only the super admin account had those permissions.


After
----------------------------------------

Can assign.


