### PR TITLE
set-version.php - Autocommit changes for version.json

### DIFF
--- a/tools/bin/scripts/set-version.php
+++ b/tools/bin/scripts/set-version.php
@@ -112,7 +112,7 @@ foreach ($infoXmls as $infoXml) {
 
 if ($doCommit) {
   $files = array_filter(
-    array_merge(['xml/version.xml', 'sql/civicrm_generated.mysql', 'sql/test_data_second_domain.mysql', $phpFile, $sqlFile], $infoXmls),
+    array_merge(['xml/version.xml', 'js/version.json', 'sql/civicrm_generated.mysql', 'sql/test_data_second_domain.mysql', $phpFile, $sqlFile], $infoXmls),
     function($file) {
       return $file && file_exists($file);
     }


### PR DESCRIPTION
Overview
----------------------------------------

Tweak the release workflow. The file `js/version.json` was recently added (524383d8b69499e3116711f6b437ce2dec4d4641). We just need to make sure the file is consistently committed.


Before
----------------------------------------

During release lifecycle, `version.json` is updated locally - but not committed/published. Hence, follow-ups like #28591 and #28592.

After
----------------------------------------

During release lifecycle, `version.json` is updated locally - and then committed/published.

