### PR TITLE
ContactType - Ensure stable order

### DIFF
--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -837,6 +837,8 @@ WHERE ($subtypeClause)";
     $contactTypes = $cache->get($cacheKey);
     if ($contactTypes === NULL) {
       $query = CRM_Utils_SQL_Select::from('civicrm_contact_type');
+      // Ensure stable order
+      $query->orderBy('id');
       $dao = CRM_Core_DAO::executeQuery($query->toSQL());
       $contactTypes = array_column($dao->fetchAll(), NULL, 'name');
       $parents = array_column($contactTypes, NULL, 'id');


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a potential instability with the expected order of contact types in the system.

Technical Details
----------------------------------------
MySql *usually* returns records ordered by id, but not always. This keeps it stable.