### PR TITLE
dev/user-interface#49 SearchKit default label

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -46,7 +46,6 @@ class Admin {
       'defaultPagerSize' => (int) \Civi::settings()->get('default_pager_size'),
       'defaultDisplay' => SearchDisplay::getDefault(FALSE)->setSavedSearch(['id' => NULL])->execute()->first(),
       'modules' => \CRM_Core_BAO_Managed::getBaseModules(),
-      'defaultContactType' => \CRM_Contact_BAO_ContactType::basicTypeInfo()['Individual']['name'] ?? NULL,
       'defaultDistanceUnit' => \CRM_Utils_Address::getDefaultDistanceUnit(),
       'jobFrequency' => \Civi\Api4\Job::getFields()
         ->addWhere('name', '=', 'run_frequency')
@@ -56,6 +55,7 @@ class Admin {
         ->addSelect('id', 'label', 'color', 'is_selectable', 'description')
         ->addWhere('used_for', 'CONTAINS', 'civicrm_saved_search')
         ->execute(),
+      'myName' => \CRM_Core_Session::singleton()->getLoggedInContactDisplayName(),
     ];
     $perms = \Civi\Api4\Permission::get()
       ->addWhere('group', 'IN', ['civicrm', 'cms'])

--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -88,7 +88,7 @@
       // Changing entity will refresh the angular page
       $scope.$watch('$ctrl.savedSearch.api_entity', function(newEntity, oldEntity) {
         if (newEntity && oldEntity && newEntity !== oldEntity) {
-          $location.url('/create/' + newEntity + (ctrl.savedSearch.label ? '?label=' + ctrl.savedSearch.label : ''));
+          $location.url('/create/' + newEntity + ($routeParams.label ? '?label=' + $routeParams.label : ''));
         }
       });
     })

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -70,10 +70,6 @@
             defaults[param] = [];
           }
         });
-        // Default to Individuals
-        if (this.savedSearch.api_entity === 'Contact' && CRM.crmSearchAdmin.defaultContactType) {
-          defaults.where.push(['contact_type:name', '=', CRM.crmSearchAdmin.defaultContactType]);
-        }
 
         $scope.$bindToRoute({
           param: 'params',
@@ -82,11 +78,16 @@
           default: defaults
         });
 
+        // Set default label
+        ctrl.savedSearch.label = ts('%1 Search by %2', {
+          1: searchMeta.getEntity(ctrl.savedSearch.api_entity).title,
+          2: CRM.crmSearchAdmin.myName
+        });
         $scope.$bindToRoute({
           param: 'label',
           expr: '$ctrl.savedSearch.label',
           format: 'raw',
-          default: ''
+          default: ctrl.savedSearch.label
         });
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Implements a small chunk of https://lab.civicrm.org/dev/user-interface/-/issues/49 by setting default label when creating a new saved search.

Before
----------------------------------------
Cannot save the search without first entering a label.

After
----------------------------------------
Default label based on entity and user:
![image](https://github.com/civicrm/civicrm-core/assets/2874912/6fad0cac-b238-4d5f-80d1-1dd324451d62)
