### PR TITLE
dev/core#4855 - Avoid errors on contact relationships and notes tabs in stricter environments

### DIFF
--- a/ext/afform/core/CRM/Afform/ArrayHtml.php
+++ b/ext/afform/core/CRM/Afform/ArrayHtml.php
@@ -199,7 +199,12 @@ class CRM_Afform_ArrayHtml {
 
     $doc = new DOMDocument();
     $doc->preserveWhiteSpace = !$this->formatWhitespace;
-    @$doc->loadHTML("<?xml encoding=\"utf-8\" ?><html><body>$html</body></html>");
+    // Angular/js isn't fussy about arbitrary tags but libxml is for html data, so ignore errors.
+    // See also Civi\Afform\Symbols::scan()
+    $oldErrorStatus = libxml_use_internal_errors(TRUE);
+    $doc->loadHTML("<?xml encoding=\"utf-8\" ?><html><body>$html</body></html>");
+    libxml_clear_errors();
+    libxml_use_internal_errors($oldErrorStatus);
 
     // FIXME: Validate expected number of child nodes
 

--- a/ext/afform/core/tests/phpunit/CRM/Afform/PageTest.php
+++ b/ext/afform/core/tests/phpunit/CRM/Afform/PageTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class CRM_Afform_PageTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function testNotesTab(): void {
+    // temporarily be more error-y
+    set_error_handler(
+      function(int $errno, string $errstr, string $errfile, int $errline) {
+        throw new \ErrorException($errstr);
+      },
+      E_ALL
+    );
+    $errorToThrow = NULL;
+    try {
+      $result = \Civi\Api4\SearchDisplay::run()
+        ->setReturn('page:1')
+        ->setSavedSearch('Contact_Summary_Notes')
+        ->setDisplay('Contact_Summary_Notes_Tab')
+        ->setAfform('afsearchTabNote')
+        ->setFilters([
+          'entity_id' => 1,
+          'entity_table' => 'civicrm_contact',
+        ])->execute();
+      $this->assertNotEmpty($result->toolbar[0]);
+    }
+    catch (\ErrorException $e) {
+      $errorToThrow = $e;
+    }
+    finally {
+      // make sure to remove our handler no matter what happens
+      restore_error_handler();
+    }
+    if ($errorToThrow) {
+      throw $errorToThrow;
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4855

Before
----------------------------------------
In a stricter environment the new contact tabs for relationships and notes give an error 500 in the ajax call with `DOMDocument::loadHTML(): Tag crm-search-display-table invalid in Entity`

After
----------------------------------------


Technical Details
----------------------------------------
See also Civi\Afform\Symbols. Angular and javascript aren't as picky about inserting arbitrary tags into html, whereas libxml is for html-mode. This is the same workaround that was added to Symbols.

Comments
----------------------------------------

