### PR TITLE
dev/core#1403 - Contribution Invoice, Invoice Date is hard coded to use today as the "invoice date" (the date the invoice was downloaded) instead of using the Contribution Receive Date

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -294,10 +294,10 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
       // @todo - stop assigning invoiceDate to the template - use
       // {contribution.total_amount} or {domain.now} instead - both of which support
       // formatting via |crmDate
-      $invoiceDate = date("F j, Y");
+      $invoiceDate = $contributionReceiveDate;
       $dueDateSetting = Civi::settings()->get('invoice_due_date');
       $dueDatePeriodSetting = Civi::settings()->get('invoice_due_date_period');
-      $dueDate = date('F j, Y', strtotime($contributionReceiveDate . "+" . $dueDateSetting . "" . $dueDatePeriodSetting));
+      $dueDate = date('F j, Y', strtotime($contributionReceiveDate . '+' . $dueDateSetting . $dueDatePeriodSetting));
       // @todo - use {contribution.balance_amount} & {contribution.amount_paid} in the template
       // - remove these 2
       $amountPaid = CRM_Core_BAO_FinancialTrxn::getTotalPayments($contributionID, TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
Contribution Invoice, Invoice Date is hard coded to use today as the "invoice date" (the date the invoice was downloaded) instead of using the Contribution Receive Date. Which is both the wrong date and can cause the Due Date to be BEFORE the Invoice Date shown on the Invoice PDF.

People have noticed this bug and been complaining about this bug in CiviCRM for quite some time - some quick Googl'ing shows.

For example:

- https://forum.civicrm.org/index.php%3Ftopic=16420.0.html
- https://civicrm.stackexchange.com/questions/21128/how-do-i-print-the-received-date-on-an-invoice
- https://lab.civicrm.org/dev/core/-/issues/1403


Before
----------------------------------------
**Invoice Date changes each day the Invoice PDF is generated.**

Due Date can then be displayed **prior** to the Invoice Date which is a bit non-nonsensical: "this invoice is due before I gave it to you!"

![image](https://github.com/civicrm/civicrm-core/assets/58866555/72cc34aa-5e4f-4d65-9128-cfcf224d1107)


After
----------------------------------------
**Invoice Date is consistently shown on the Invoice PDF regardless of the date it is generated.**

Due Date is logically after the Invoice Date.

![image](https://github.com/civicrm/civicrm-core/assets/58866555/35507b12-dabc-4656-9a49-ace014032e41)


Technical Details
----------------------------------------
None.

Comments
----------------------------------------
Replaced use of " as well, which seem redundant here.

Agileware Ref: CIVICRM-2197