### PR TITLE
PHP 7.4 - Simplify expressions with null coalescing assignment operator

### DIFF
--- a/CRM/ACL/Form/ACL.php
+++ b/CRM/ACL/Form/ACL.php
@@ -256,7 +256,7 @@ class CRM_ACL_Form_ACL extends CRM_Admin_Form {
     }
     else {
       $params = $this->controller->exportValues($this->_name);
-      $params['is_active'] = $params['is_active'] ?? FALSE;
+      $params['is_active'] ??= FALSE;
       $params['entity_table'] = 'civicrm_acl_role';
 
       // Figure out which type of object we're permissioning on and set object_table and object_id.

--- a/CRM/Activity/Form/ActivityView.php
+++ b/CRM/Activity/Form/ActivityView.php
@@ -88,11 +88,11 @@ class CRM_Activity_Form_ActivityView extends CRM_Core_Form {
     }
 
     // ensure these are set so that they get assigned to the template
-    $values['mailingId'] = $values['mailingId'] ?? NULL;
-    $values['campaign'] = $values['campaign'] ?? NULL;
-    $values['engagement_level'] = $values['engagement_level'] ?? NULL;
+    $values['mailingId'] ??= NULL;
+    $values['campaign'] ??= NULL;
+    $values['engagement_level'] ??= NULL;
     // also this which doesn't get set for bulk emails
-    $values['target_contact_value'] = $values['target_contact_value'] ?? NULL;
+    $values['target_contact_value'] ??= NULL;
 
     // Get the campaign.
     $campaignId = $defaults['campaign_id'] ?? NULL;

--- a/CRM/Admin/Form/MailSettings.php
+++ b/CRM/Admin/Form/MailSettings.php
@@ -126,15 +126,15 @@ class CRM_Admin_Form_MailSettings extends CRM_Admin_Form {
   public function setDefaultValues() {
     $defaults = parent::setDefaultValues();
 
-    $defaults['is_ssl'] = $defaults['is_ssl'] ?? TRUE;
-    $defaults['is_default'] = $defaults['is_default'] ?? 0;
+    $defaults['is_ssl'] ??= TRUE;
+    $defaults['is_default'] ??= 0;
     $defaults['activity_type_id'] = $defaults['activity_type_id'] ??
       CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Inbound Email');
-    $defaults['activity_status'] = $defaults['activity_status'] ?? 'Completed';
-    $defaults['activity_source'] = $defaults['activity_source'] ?? 'from';
-    $defaults['activity_targets'] = $defaults['activity_targets'] ?? 'to,cc,bcc';
-    $defaults['activity_assignees'] = $defaults['activity_assignees'] ?? 'from';
-    $defaults['is_active'] = $defaults['is_active'] ?? TRUE;
+    $defaults['activity_status'] ??= 'Completed';
+    $defaults['activity_source'] ??= 'from';
+    $defaults['activity_targets'] ??= 'to,cc,bcc';
+    $defaults['activity_assignees'] ??= 'from';
+    $defaults['is_active'] ??= TRUE;
 
     return $defaults;
   }

--- a/CRM/Admin/Form/RelationshipType.php
+++ b/CRM/Admin/Form/RelationshipType.php
@@ -141,7 +141,7 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
     else {
       // store the submitted values in an array
       $params = $this->exportValues();
-      $params['is_active'] = $params['is_active'] ?? FALSE;
+      $params['is_active'] ??= FALSE;
 
       if ($this->_action & CRM_Core_Action::UPDATE) {
         $params['id'] = $this->_id;

--- a/CRM/Badge/BAO/Layout.php
+++ b/CRM/Badge/BAO/Layout.php
@@ -50,9 +50,9 @@ class CRM_Badge_BAO_Layout extends CRM_Core_DAO_PrintLabel {
    * @return object
    */
   public static function create(&$params) {
-    $params['is_active'] = $params['is_active'] ?? FALSE;
-    $params['is_default'] = $params['is_default'] ?? FALSE;
-    $params['is_reserved'] = $params['is_reserved'] ?? FALSE;
+    $params['is_active'] ??= FALSE;
+    $params['is_default'] ??= FALSE;
+    $params['is_reserved'] ??= FALSE;
 
     $params['label_type_id'] = CRM_Core_PseudoConstant::getKey('CRM_Core_DAO_PrintLabel', 'label_type_id', 'Event Badge');
 

--- a/CRM/Batch/BAO/Batch.php
+++ b/CRM/Batch/BAO/Batch.php
@@ -73,7 +73,7 @@ class CRM_Batch_BAO_Batch extends CRM_Batch_DAO_Batch implements \Civi\Core\Hook
    * @deprecated
    */
   public static function retrieve(array $params, ?array &$defaults = NULL) {
-    $defaults = $defaults ?? [];
+    $defaults ??= [];
     return self::commonRetrieve(self::class, $params, $defaults);
   }
 

--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -1162,7 +1162,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
     }
 
     // The latter format would be normal here - it's unclear if it is sometimes in the former format.
-    $row['membership_type_id'] = $row['membership_type_id'] ?? $row['membership_type'][1];
+    $row['membership_type_id'] ??= $row['membership_type'][1];
     unset($row['membership_type']);
     // total_amount is required.
     $row['total_amount'] = (float) $row['total_amount'];

--- a/CRM/Campaign/Form/Campaign.php
+++ b/CRM/Campaign/Form/Campaign.php
@@ -291,7 +291,7 @@ class CRM_Campaign_Form_Campaign extends CRM_Core_Form {
       $params['created_date'] = date('YmdHis');
     }
     // format params
-    $params['is_active'] = $params['is_active'] ?? FALSE;
+    $params['is_active'] ??= FALSE;
     $params['last_modified_id'] = $session->get('userID');
     $params['last_modified_date'] = date('YmdHis');
     $result = self::submit($params, $this);

--- a/CRM/Campaign/Form/Petition.php
+++ b/CRM/Campaign/Form/Petition.php
@@ -291,7 +291,7 @@ WHERE  $whereClause
 
     $params['last_modified_id'] = $session->get('userID');
     $params['last_modified_date'] = date('YmdHis');
-    $params['is_share'] = $params['is_share'] ?? FALSE;
+    $params['is_share'] ??= FALSE;
 
     if ($this->_surveyId) {
 
@@ -309,9 +309,9 @@ WHERE  $whereClause
       $params['created_date'] = date('YmdHis');
     }
 
-    $params['bypass_confirm'] = $params['bypass_confirm'] ?? 0;
-    $params['is_active'] = $params['is_active'] ?? 0;
-    $params['is_default'] = $params['is_default'] ?? 0;
+    $params['bypass_confirm'] ??= 0;
+    $params['is_active'] ??= 0;
+    $params['is_default'] ??= 0;
 
     $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params, $this->getEntityId(), $this->getDefaultEntity());
 

--- a/CRM/Campaign/Form/Survey/Main.php
+++ b/CRM/Campaign/Form/Survey/Main.php
@@ -155,8 +155,8 @@ class CRM_Campaign_Form_Survey_Main extends CRM_Campaign_Form_Survey {
       $params['created_date'] = date('YmdHis');
     }
 
-    $params['is_active'] = $params['is_active'] ?? 0;
-    $params['is_default'] = $params['is_default'] ?? 0;
+    $params['is_active'] ??= 0;
+    $params['is_default'] ??= 0;
 
     $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params, $this->getEntityId(), $this->getDefaultEntity());
 

--- a/CRM/Case/Form/Activity/ChangeCaseStartDate.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStartDate.php
@@ -186,7 +186,7 @@ class CRM_Case_Form_Activity_ChangeCaseStartDate {
 
       // @todo This can go eventually but is still needed to keep them linked together if there is an existing revision. Just focusing right now on not creating new revisions.
       // original_id always refers to the first activity, so if it's null or missing, then it means no previous revisions and we can keep it null.
-      $openCaseParams['original_id'] = $openCaseParams['original_id'] ?? NULL;
+      $openCaseParams['original_id'] ??= NULL;
 
       $newActivity = CRM_Activity_BAO_Activity::create($openCaseParams);
       if (is_a($newActivity, 'CRM_Core_Error')) {

--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -151,7 +151,7 @@ WHERE contact_id IN ({$contact_id_list})
    */
   public static function allow($id, $type = CRM_Core_Permission::VIEW, $userID = NULL) {
     // Default to logged in user if not supplied
-    $userID = $userID ?? CRM_Core_Session::getLoggedInContactID();
+    $userID ??= CRM_Core_Session::getLoggedInContactID();
 
     // first: check if contact is trying to view own contact
     if ($userID == $id && ($type == CRM_Core_Permission::VIEW && CRM_Core_Permission::check('view my contact')
@@ -389,7 +389,7 @@ AND    $operationClause
     }
 
     // Default to currently logged in user
-    $userID = $userID ?? CRM_Core_Session::getLoggedInContactID();
+    $userID ??= CRM_Core_Session::getLoggedInContactID();
     if (empty($userID)) {
       return [];
     }

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5344,7 +5344,7 @@ civicrm_relationship.start_date > {$today}
       }
 
       if ($secondDate) {
-        $highDBFieldName = $highDBFieldName ?? $dbFieldName;
+        $highDBFieldName ??= $dbFieldName;
         $this->_where[$grouping][] = "
 ( {$tableName}.{$dbFieldName} $firstOP '$firstDate' ) AND
 ( {$tableName}.{$highDBFieldName} $secondOP '$secondDate' )
@@ -5398,8 +5398,8 @@ civicrm_relationship.start_date > {$today}
     }
 
     // Ensure the tables are set, but don't whomp anything.
-    $this->_tables[$tableName] = $this->_tables[$tableName] ?? 1;
-    $this->_whereTables[$tableName] = $this->_whereTables[$tableName] ?? 1;
+    $this->_tables[$tableName] ??= 1;
+    $this->_whereTables[$tableName] ??= 1;
   }
 
   /**
@@ -7056,8 +7056,8 @@ AND   displayRelType.is_active = 1
     $filters = CRM_Core_OptionGroup::values('relative_date_filters');
     $grouping = $values[3] ?? NULL;
     // If the table value is already set for a custom field it will be more nuanced than just '1'.
-    $this->_tables[$tableName] = $this->_tables[$tableName] ?? 1;
-    $this->_whereTables[$tableName] = $this->_whereTables[$tableName] ?? 1;
+    $this->_tables[$tableName] ??= 1;
+    $this->_whereTables[$tableName] ??= 1;
 
     $dates = CRM_Utils_Date::getFromTo($value, NULL, NULL);
     // Where end would be populated only if we are handling one of the weird ones with different from & to fields.

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -250,9 +250,9 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
       $loggedInContactID = CRM_Core_Session::getLoggedInContactID();
       if ($loggedInContactID) {
         if ($event->action === 'create') {
-          $event->params['created_id'] = $event->params['created_id'] ?? $loggedInContactID;
+          $event->params['created_id'] ??= $loggedInContactID;
         }
-        $event->params['modified_id'] = $event->params['modified_id'] ?? $loggedInContactID;
+        $event->params['modified_id'] ??= $loggedInContactID;
       }
       // Set by mysql
       unset($event->params['modified_date']);

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -1055,7 +1055,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
 
     if (array_key_exists('CommunicationPreferences', $this->_editOptions)) {
       // this is a chekbox, so mark false if we dont get a POST value
-      $params['is_opt_out'] = $params['is_opt_out'] ?? FALSE;
+      $params['is_opt_out'] ??= FALSE;
 
       CRM_Utils_Array::formatArrayKeys($params['preferred_communication_method']);
     }

--- a/CRM/Contact/Form/Inline/CommunicationPreferences.php
+++ b/CRM/Contact/Form/Inline/CommunicationPreferences.php
@@ -65,7 +65,7 @@ class CRM_Contact_Form_Inline_CommunicationPreferences extends CRM_Contact_Form_
     // Process / save communication preferences
 
     // this is a chekbox, so mark false if we dont get a POST value
-    $params['is_opt_out'] = $params['is_opt_out'] ?? FALSE;
+    $params['is_opt_out'] ??= FALSE;
     $params['contact_type'] = $this->_contactType;
     $params['contact_id'] = $this->_contactId;
 

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -766,7 +766,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
 
     //get the button name
     $buttonName = $this->controller->getButtonName();
-    $this->_formValues['uf_group_id'] = $this->_formValues['uf_group_id'] ?? $this->get('uf_group_id');
+    $this->_formValues['uf_group_id'] ??= $this->get('uf_group_id');
 
     if (isset($this->_componentMode) && empty($this->_formValues['component_mode'])) {
       $this->_formValues['component_mode'] = $this->_componentMode;

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2244,7 +2244,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
       }
     }
 
-    $contributionParams['source'] = $contributionParams['source'] ?? ts('Recurring contribution');
+    $contributionParams['source'] ??= ts('Recurring contribution');
 
     $createContribution = civicrm_api3('Contribution', 'create', $contributionParams);
     $temporaryObject = new CRM_Contribute_BAO_Contribution();

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -504,7 +504,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
       $templateContributionParams['on_behalf'] = TRUE;
       $templateContributionParams['source_contact_id'] = $relatedContact['individual_id'];
     }
-    $templateContributionParams['source'] = $templateContributionParams['source'] ?? ts('Recurring contribution');
+    $templateContributionParams['source'] ??= ts('Recurring contribution');
     $templateContribution = Contribution::create(FALSE)
       ->setValues($templateContributionParams)
       ->execute()

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -947,7 +947,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     $form->_priceSet = $priceSet[$priceSetId] ?? NULL;
     $validPriceFieldIds = array_keys($form->_priceSet['fields']);
 
-    $form->_priceSet['id'] = $form->_priceSet['id'] ?? $priceSetId;
+    $form->_priceSet['id'] ??= $priceSetId;
     $form->assign('priceSet', $form->_priceSet);
 
     $feeBlock = &$form->_priceSet['fields'];

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1162,8 +1162,8 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         ->addWhere('id', '=', $selectedMembershipTypeID)
         ->execute()
         ->first();
-      $this->_params['frequency_interval'] = $this->_params['frequency_interval'] ?? $this->_values['fee'][$priceFieldId]['options'][$priceFieldValue]['membership_num_terms'];
-      $this->_params['frequency_unit'] = $this->_params['frequency_unit'] ?? $membershipTypeDetails['duration_unit'];
+      $this->_params['frequency_interval'] ??= $this->_values['fee'][$priceFieldId]['options'][$priceFieldValue]['membership_num_terms'];
+      $this->_params['frequency_unit'] ??= $membershipTypeDetails['duration_unit'];
     }
     elseif (!$this->_separateMembershipPayment && (in_array($selectedMembershipTypeID, $membershipTypes['autorenew_required'])
       || in_array($selectedMembershipTypeID, $membershipTypes['autorenew_optional']))) {

--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -494,8 +494,8 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
       $params['recur_frequency_unit'] = implode(CRM_Core_DAO::VALUE_SEPARATOR,
         array_keys($params['recur_frequency_unit'])
       );
-      $params['is_recur_interval'] = $params['is_recur_interval'] ?? FALSE;
-      $params['is_recur_installments'] = $params['is_recur_installments'] ?? FALSE;
+      $params['is_recur_interval'] ??= FALSE;
+      $params['is_recur_installments'] ??= FALSE;
     }
 
     if (!empty($params['adjust_recur_start_date'])) {

--- a/CRM/Contribute/Form/ContributionPage/Premium.php
+++ b/CRM/Contribute/Form/ContributionPage/Premium.php
@@ -113,8 +113,8 @@ class CRM_Contribute_Form_ContributionPage_Premium extends CRM_Contribute_Form_C
       $params['id'] = $premiumID;
     }
 
-    $params['premiums_active'] = $params['premiums_active'] ?? FALSE;
-    $params['premiums_display_min_contribution'] = $params['premiums_display_min_contribution'] ?? FALSE;
+    $params['premiums_active'] ??= FALSE;
+    $params['premiums_display_min_contribution'] ??= FALSE;
     $params['entity_table'] = 'civicrm_contribution_page';
     $params['entity_id'] = $this->_id;
 

--- a/CRM/Contribute/Form/ContributionPage/Settings.php
+++ b/CRM/Contribute/Form/ContributionPage/Settings.php
@@ -311,11 +311,11 @@ class CRM_Contribute_Form_ContributionPage_Settings extends CRM_Contribute_Form_
       $params['currency'] = $config->defaultCurrency;
     }
 
-    $params['is_confirm_enabled'] = $params['is_confirm_enabled'] ?? FALSE;
-    $params['is_share'] = $params['is_share'] ?? FALSE;
-    $params['is_active'] = $params['is_active'] ?? FALSE;
-    $params['is_credit_card_only'] = $params['is_credit_card_only'] ?? FALSE;
-    $params['honor_block_is_active'] = $params['honor_block_is_active'] ?? FALSE;
+    $params['is_confirm_enabled'] ??= FALSE;
+    $params['is_share'] ??= FALSE;
+    $params['is_active'] ??= FALSE;
+    $params['is_credit_card_only'] ??= FALSE;
+    $params['honor_block_is_active'] ??= FALSE;
     $params['is_for_organization'] = !empty($params['is_organization']) ? CRM_Utils_Array::value('is_for_organization', $params, FALSE) : 0;
     $params['goal_amount'] = CRM_Utils_Rule::cleanMoney($params['goal_amount']);
 

--- a/CRM/Contribute/Form/ContributionPage/ThankYou.php
+++ b/CRM/Contribute/Form/ContributionPage/ThankYou.php
@@ -100,7 +100,7 @@ class CRM_Contribute_Form_ContributionPage_ThankYou extends CRM_Contribute_Form_
     $params = $this->controller->exportValues($this->_name);
 
     $params['id'] = $this->_id;
-    $params['is_email_receipt'] = $params['is_email_receipt'] ?? FALSE;
+    $params['is_email_receipt'] ??= FALSE;
     if (!$params['is_email_receipt']) {
       $params['receipt_from_name'] = NULL;
       $params['receipt_from_email'] = NULL;

--- a/CRM/Contribute/Form/ContributionPage/Widget.php
+++ b/CRM/Contribute/Form/ContributionPage/Widget.php
@@ -267,7 +267,7 @@ class CRM_Contribute_Form_ContributionPage_Widget extends CRM_Contribute_Form_Co
       $params['id'] = $this->_widget->id;
     }
     $params['contribution_page_id'] = $this->_id;
-    $params['is_active'] = $params['is_active'] ?? FALSE;
+    $params['is_active'] ??= FALSE;
     $params['url_homepage'] = 'null';
 
     $widget = new CRM_Contribute_DAO_Widget();

--- a/CRM/Contribute/WorkflowMessage/Contribution/BasicContribution.php
+++ b/CRM/Contribute/WorkflowMessage/Contribution/BasicContribution.php
@@ -119,7 +119,7 @@ class CRM_Contribute_WorkflowMessage_Contribution_BasicContribution extends Work
   private function addExampleData(GenericWorkflowMessage $messageTemplate, $example): void {
     $messageTemplate->setContact(Test::example('entity/Contact/Barb'));
     $contribution = Test::example('entity/Contribution/Euro5990/completed');
-    $example['currency'] = $example['currency'] ?? \Civi::settings()->get('defaultCurrency');
+    $example['currency'] ??= \Civi::settings()->get('defaultCurrency');
     if (isset($example['contribution_params'])) {
       $contribution = array_merge($contribution, $example['contribution_params']);
     }

--- a/CRM/Core/Action.php
+++ b/CRM/Core/Action.php
@@ -79,7 +79,7 @@ class CRM_Core_Action {
   ];
 
   private static function getInfo(): array {
-    Civi::$statics[__CLASS__ . 'Info'] = Civi::$statics[__CLASS__ . 'Info'] ?? [
+    Civi::$statics[__CLASS__ . 'Info'] ??= [
       self::ADD => [
         'name' => 'add',
         'label' => ts('Add'),

--- a/CRM/Core/BAO/ActionLog.php
+++ b/CRM/Core/BAO/ActionLog.php
@@ -29,7 +29,7 @@ class CRM_Core_BAO_ActionLog extends CRM_Core_DAO_ActionLog {
    */
   public static function create($params) {
     if (empty($params['id'])) {
-      $params['action_date_time'] = $params['action_date_time'] ?? date('YmdHis');
+      $params['action_date_time'] ??= date('YmdHis');
     }
 
     return self::writeRecord($params);

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -2558,7 +2558,7 @@ SELECT  civicrm_custom_group.id as groupID, civicrm_custom_group.title as groupT
       ];
     }
     foreach ($options as &$option) {
-      $option['icon'] = $option['icon'] ?? \Civi\Api4\Utils\CoreUtil::getInfoItem($option['id'], 'icon');
+      $option['icon'] ??= \Civi\Api4\Utils\CoreUtil::getInfoItem($option['id'], 'icon');
     }
     return $options;
   }

--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -396,8 +396,8 @@ class CRM_Core_BAO_CustomQuery {
   protected function joinCustomTableForField($field) {
     $name = $field['table_name'];
     $join = "\nLEFT JOIN $name ON $name.entity_id = {$field['search_table']}.id";
-    $this->_tables[$name] = $this->_tables[$name] ?? $join;
-    $this->_whereTables[$name] = $this->_whereTables[$name] ?? $join;
+    $this->_tables[$name] ??= $join;
+    $this->_whereTables[$name] ??= $join;
 
     $joinTable = $field['search_table'];
     if ($joinTable) {

--- a/CRM/Core/BAO/MailSettings.php
+++ b/CRM/Core/BAO/MailSettings.php
@@ -136,8 +136,8 @@ class CRM_Core_BAO_MailSettings extends CRM_Core_DAO_MailSettings {
     }
 
     if (empty($params['id'])) {
-      $params['is_ssl'] = $params['is_ssl'] ?? FALSE;
-      $params['is_default'] = $params['is_default'] ?? FALSE;
+      $params['is_ssl'] ??= FALSE;
+      $params['is_default'] ??= FALSE;
     }
 
     //handle is_default.

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -75,8 +75,8 @@ class CRM_Core_BAO_Navigation extends CRM_Core_DAO_Navigation {
    */
   public static function add(&$params) {
     if (empty($params['id'])) {
-      $params['is_active'] = $params['is_active'] ?? FALSE;
-      $params['has_separator'] = $params['has_separator'] ?? FALSE;
+      $params['is_active'] ??= FALSE;
+      $params['has_separator'] ??= FALSE;
       $params['domain_id'] = CRM_Utils_Array::value('domain_id', $params, CRM_Core_Config::domainID());
     }
 

--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -48,10 +48,10 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue implements \Civi
    * @param array $params
    */
   public static function setDefaults(&$params) {
-    $params['label'] = $params['label'] ?? $params['name'];
-    $params['name'] = $params['name'] ?? CRM_Utils_String::titleToVar($params['label']);
-    $params['weight'] = $params['weight'] ?? self::getDefaultWeight($params);
-    $params['value'] = $params['value'] ?? self::getDefaultValue($params);
+    $params['label'] ??= $params['name'];
+    $params['name'] ??= CRM_Utils_String::titleToVar($params['label']);
+    $params['weight'] ??= self::getDefaultWeight($params);
+    $params['value'] ??= self::getDefaultValue($params);
   }
 
   /**

--- a/CRM/Core/BAO/StatusPreference.php
+++ b/CRM/Core/BAO/StatusPreference.php
@@ -31,7 +31,7 @@ class CRM_Core_BAO_StatusPreference extends CRM_Core_DAO_StatusPreference {
     $statusPreference = new CRM_Core_DAO_StatusPreference();
 
     // Default severity level to ignore is 0 (DEBUG).
-    $params['ignore_severity'] = $params['ignore_severity'] ?? 0;
+    $params['ignore_severity'] ??= 0;
 
     // Severity can be either text ('critical') or an integer <= 7.
     // It's a magic number, but based on PSR-3 standards.

--- a/CRM/Core/BAO/Tag.php
+++ b/CRM/Core/BAO/Tag.php
@@ -413,7 +413,7 @@ class CRM_Core_BAO_Tag extends CRM_Core_DAO_Tag {
 
     // save creator id and time
     if (!$id) {
-      $params['created_id'] = $params['created_id'] ?? CRM_Core_Session::getLoggedInContactID();
+      $params['created_id'] ??= CRM_Core_Session::getLoggedInContactID();
     }
 
     $tag = self::writeRecord($params);

--- a/CRM/Core/CodeGen/Specification.php
+++ b/CRM/Core/CodeGen/Specification.php
@@ -391,7 +391,7 @@ class CRM_Core_CodeGen_Specification {
     $field['usage'] = array_merge(array_fill_keys(['import', 'export', 'duplicate_matching'], $import), $usage);
     // Usage for tokens has not historically been in the metadata so we can default to FALSE.
     // historically hard-coded lists have been used.
-    $field['usage']['token'] = $field['usage']['token'] ?? 'FALSE';
+    $field['usage']['token'] ??= 'FALSE';
     $field['import'] = $field['usage']['import'];
     $field['export'] = $export ?? $import;
     $field['rule'] = $this->value('rule', $fieldXML);

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1432,7 +1432,7 @@ LIKE %1
       throw new CRM_Core_Exception('getFieldValue failed');
     }
 
-    self::$_dbColumnValueCache = self::$_dbColumnValueCache ?? [];
+    self::$_dbColumnValueCache ??= [];
 
     while (strpos($daoName, '_BAO_') !== FALSE) {
       $daoName = get_parent_class($daoName);
@@ -3186,8 +3186,8 @@ SELECT contact_id
    */
   public static function getSelectWhereClause($tableAlias = NULL, $entityName = NULL, $conditions = []) {
     $bao = new static();
-    $tableAlias = $tableAlias ?? $bao->tableName();
-    $entityName = $entityName ?? CRM_Core_DAO_AllCoreTables::getBriefName(get_class($bao));
+    $tableAlias ??= $bao->tableName();
+    $entityName ??= CRM_Core_DAO_AllCoreTables::getBriefName(get_class($bao));
     $finalClauses = [];
     $fields = static::getSupportedFields();
     $selectWhereClauses = $bao->addSelectWhereClause($entityName, NULL, $conditions);

--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -641,7 +641,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
     if ($field['type'] !== 'Custom' && !$isExposed) {
       return;
     }
-    $field['audience'] = $field['audience'] ?? 'user';
+    $field['audience'] ??= 'user';
     if ($field['name'] === 'contact_id') {
       // Since {contact.id} is almost always present don't confuse users
       // by also adding (e.g {participant.contact_id)

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -535,7 +535,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
 
       $attributes['data-crm-datepicker'] = json_encode((array) $extra);
       if (!empty($attributes['aria-label']) || $label) {
-        $attributes['aria-label'] = $attributes['aria-label'] ?? $label;
+        $attributes['aria-label'] ??= $label;
       }
       $type = 'text';
     }
@@ -1114,7 +1114,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   protected function handlePreApproval(&$params) {
     try {
       $payment = Civi\Payment\System::singleton()->getByProcessor($this->_paymentProcessor);
-      $params['component'] = $params['component'] ?? 'contribute';
+      $params['component'] ??= 'contribute';
       $result = $payment->doPreApproval($params);
       if (empty($result)) {
         // This could happen, for example, when paypal looks at the button value & decides it is not paypal express.
@@ -1426,7 +1426,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         }
       }
       // We use a class here to avoid html5 issues with collapsed cutsomfield sets.
-      $optAttributes['class'] = $optAttributes['class'] ?? '';
+      $optAttributes['class'] ??= '';
       if ($required) {
         $optAttributes['class'] .= ' required';
       }
@@ -1856,7 +1856,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       }
       if ($context == 'search') {
         $widget = $widget == 'Select2' ? $widget : 'Select';
-        $props['multiple'] = $props['multiple'] ?? TRUE;
+        $props['multiple'] ??= TRUE;
       }
       elseif (!empty($fieldSpec['serialize'])) {
         $props['multiple'] = TRUE;
@@ -1894,7 +1894,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       case 'Number':
       case 'Email':
         //TODO: Autodetect ranges
-        $props['size'] = $props['size'] ?? 60;
+        $props['size'] ??= 60;
         return $this->add(strtolower($widget), $name, $label, $props, $required);
 
       case 'hidden':
@@ -1902,8 +1902,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
 
       case 'TextArea':
         //Set default columns and rows for textarea.
-        $props['rows'] = $props['rows'] ?? 4;
-        $props['cols'] = $props['cols'] ?? 60;
+        $props['rows'] ??= 4;
+        $props['cols'] ??= 60;
         if (empty($props['maxlength']) && isset($fieldSpec['length'])) {
           $props['maxlength'] = $fieldSpec['length'];
         }
@@ -1988,7 +1988,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         return $this->addEntityRef($name, $label, $props, $required);
 
       case 'Password':
-        $props['size'] = $props['size'] ?? 60;
+        $props['size'] ??= 60;
         return $this->add('password', $name, $label, $props, $required);
 
       // Check datatypes of fields
@@ -2332,7 +2332,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       $props['api']['fieldName'] = $this->getDefaultEntity() . '.' . $name;
     }
     $props['class'] = ltrim(($props['class'] ?? '') . ' crm-form-autocomplete');
-    $props['placeholder'] = $props['placeholder'] ?? self::selectOrAnyPlaceholder($props, $required);
+    $props['placeholder'] ??= self::selectOrAnyPlaceholder($props, $required);
     $props['data-select-params'] = json_encode($props['select']);
     $props['data-api-params'] = json_encode($props['api']);
     $props['data-api-entity'] = $props['entity'];
@@ -2372,7 +2372,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       unset($props['create']);
     }
 
-    $props['placeholder'] = $props['placeholder'] ?? self::selectOrAnyPlaceholder($props, $required);
+    $props['placeholder'] ??= self::selectOrAnyPlaceholder($props, $required);
 
     $defaults = [];
     if (!empty($props['multiple'])) {

--- a/CRM/Core/OptionValue.php
+++ b/CRM/Core/OptionValue.php
@@ -181,7 +181,7 @@ class CRM_Core_OptionValue {
    *
    */
   public static function addOptionValue(&$params, $optionGroupName, $action, $optionValueID) {
-    $params['is_active'] = $params['is_active'] ?? FALSE;
+    $params['is_active'] ??= FALSE;
     // checking if the group name with the given id or name (in $groupParams) exists
     $groupParams = ['name' => $optionGroupName, 'is_active' => 1];
     $optionGroup = CRM_Core_BAO_OptionGroup::retrieve($groupParams, $defaults);

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -97,7 +97,7 @@ class CRM_Core_Payment_Form {
   protected static function addCommonFields(&$form, $paymentFields) {
     $requiredPaymentFields = $paymentFieldsMetadata = [];
     foreach ($paymentFields as $name => $field) {
-      $field['extra'] = $field['extra'] ?? NULL;
+      $field['extra'] ??= NULL;
       if ($field['htmlType'] == 'chainSelect') {
         $form->addChainSelect($field['name'], ['required' => FALSE]);
       }

--- a/CRM/Core/Resources/CollectionTrait.php
+++ b/CRM/Core/Resources/CollectionTrait.php
@@ -111,7 +111,7 @@ trait CRM_Core_Resources_CollectionTrait {
       $res = Civi::resources();
       list ($ext, $file) = $snippet['scriptFile'];
 
-      $snippet['translate'] = $snippet['translate'] ?? TRUE;
+      $snippet['translate'] ??= TRUE;
       if ($snippet['translate']) {
         $domain = ($snippet['translate'] === TRUE) ? $ext : $snippet['translate'];
         // Is this too early?

--- a/CRM/Custom/Page/Group.php
+++ b/CRM/Custom/Page/Group.php
@@ -136,7 +136,7 @@ class CRM_Custom_Page_Group extends CRM_Core_Page {
         $customGroups[$id]['style_display'] = $customGroupStyle[$customGroups[$id]['style']];
       }
       $customGroups[$id]['extends_display'] = $customGroupExtends[$customGroups[$id]['extends']];
-      $customGroups[$id]['extends_entity_column_value'] = $customGroups[$id]['extends_entity_column_value'] ?? NULL;
+      $customGroups[$id]['extends_entity_column_value'] ??= NULL;
     }
 
     // FIXME: This hardcoded array is mostly redundant with CRM_Core_BAO_CustomGroup::getSubTypes

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1651,7 +1651,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
         $mainContactValue = $mainTree[$gid]['fields'][$fid]['customValue'] ?? NULL;
         $otherContactValue = $otherTree[$gid]['fields'][$fid]['customValue'] ?? NULL;
         if (in_array($fid, $compareFields['custom'])) {
-          $rows["custom_group_$gid"]['title'] = $rows["custom_group_$gid"]['title'] ?? $group['title'];
+          $rows["custom_group_$gid"]['title'] ??= $group['title'];
 
           if ($mainContactValue) {
             foreach ($mainContactValue as $valueId => $values) {

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -102,7 +102,7 @@ class CRM_Event_BAO_Event extends CRM_Event_DAO_Event implements \Civi\Core\Hook
         // unless we are explicitly trying to create a new template
         // we want to set the `is_template` flag on the clone to false
         // so that the copy is a new event rather than a new template
-        $params['is_template'] = $params['is_template'] ?? 0;
+        $params['is_template'] ??= 0;
 
         //fix for api from template creation bug
         civicrm_api4('ActionSchedule', 'update', [
@@ -2043,7 +2043,7 @@ WHERE  ce.loc_block_id = $locBlockId";
    * @throws \CRM_Core_Exception
    */
   public static function checkPermission(int $eventId, $permissionType = CRM_Core_Permission::VIEW, $userId = NULL) {
-    $userId = $userId ?? CRM_Core_Session::getLoggedInContactID();
+    $userId ??= CRM_Core_Session::getLoggedInContactID();
     switch ($permissionType) {
       case CRM_Core_Permission::EDIT:
         // We also set the cached "view" permission to TRUE if "edit" is TRUE

--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -91,9 +91,9 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     $this->assign('description', $defaults['description'] ?? '');
 
     // Provide suggested text for event full and waitlist messages if they're empty
-    $defaults['event_full_text'] = $defaults['event_full_text'] ?? ts('This event is currently full.');
+    $defaults['event_full_text'] ??= ts('This event is currently full.');
 
-    $defaults['waitlist_text'] = $defaults['waitlist_text'] ?? ts('This event is currently full. However you can register now and get added to a waiting list. You will be notified if spaces become available.');
+    $defaults['waitlist_text'] ??= ts('This event is currently full. However you can register now and get added to a waiting list. You will be notified if spaces become available.');
     $defaults['template_id'] = $this->_templateId;
 
     return $defaults;
@@ -216,15 +216,15 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     $params = array_merge($this->controller->exportValues($this->_name), $this->_submitValues);
 
     //format params
-    $params['start_date'] = $params['start_date'] ?? NULL;
-    $params['end_date'] = $params['end_date'] ?? NULL;
-    $params['has_waitlist'] = $params['has_waitlist'] ?? FALSE;
-    $params['is_map'] = $params['is_map'] ?? FALSE;
-    $params['is_active'] = $params['is_active'] ?? FALSE;
-    $params['is_public'] = $params['is_public'] ?? FALSE;
-    $params['is_share'] = $params['is_share'] ?? FALSE;
-    $params['is_show_calendar_links'] = $params['is_show_calendar_links'] ?? FALSE;
-    $params['default_role_id'] = $params['default_role_id'] ?? FALSE;
+    $params['start_date'] ??= NULL;
+    $params['end_date'] ??= NULL;
+    $params['has_waitlist'] ??= FALSE;
+    $params['is_map'] ??= FALSE;
+    $params['is_active'] ??= FALSE;
+    $params['is_public'] ??= FALSE;
+    $params['is_share'] ??= FALSE;
+    $params['is_show_calendar_links'] ??= FALSE;
+    $params['default_role_id'] ??= FALSE;
     $params['id'] = $this->_id;
     //merge params with defaults from templates
     if (!empty($params['template_id'])) {

--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -551,8 +551,8 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
       $params['payment_processor'] = 'null';
     }
 
-    $params['is_pay_later'] = $params['is_pay_later'] ?? 0;
-    $params['is_billing_required'] = $params['is_billing_required'] ?? 0;
+    $params['is_pay_later'] ??= 0;
+    $params['is_billing_required'] ??= 0;
 
     if ($this->_id) {
 

--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -162,10 +162,10 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     }
 
     // provide defaults for required fields if empty (and as a 'hint' for approval message field)
-    $defaults['registration_link_text'] = $defaults['registration_link_text'] ?? ts('Register Now');
-    $defaults['confirm_title'] = $defaults['confirm_title'] ?? ts('Confirm Your Registration Information');
-    $defaults['thankyou_title'] = $defaults['thankyou_title'] ?? ts('Thank You for Registering');
-    $defaults['approval_req_text'] = $defaults['approval_req_text'] ?? ts('Participation in this event requires approval. Submit your registration request here. Once approved, you will receive an email with a link to a web page where you can complete the registration process.');
+    $defaults['registration_link_text'] ??= ts('Register Now');
+    $defaults['confirm_title'] ??= ts('Confirm Your Registration Information');
+    $defaults['thankyou_title'] ??= ts('Thank You for Registering');
+    $defaults['approval_req_text'] ??= ts('Participation in this event requires approval. Submit your registration request here. Once approved, you will receive an email with a link to a web page where you can complete the registration process.');
 
     return $defaults;
   }
@@ -783,12 +783,12 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     $params['id'] = $this->_id;
 
     // format params
-    $params['is_online_registration'] = $params['is_online_registration'] ?? FALSE;
+    $params['is_online_registration'] ??= FALSE;
     // CRM-11182
-    $params['is_confirm_enabled'] = $params['is_confirm_enabled'] ?? FALSE;
-    $params['is_multiple_registrations'] = $params['is_multiple_registrations'] ?? FALSE;
-    $params['allow_same_participant_emails'] = $params['allow_same_participant_emails'] ?? FALSE;
-    $params['requires_approval'] = $params['requires_approval'] ?? FALSE;
+    $params['is_confirm_enabled'] ??= FALSE;
+    $params['is_multiple_registrations'] ??= FALSE;
+    $params['allow_same_participant_emails'] ??= FALSE;
+    $params['requires_approval'] ??= FALSE;
 
     // reset is_email confirm if not online reg
     if (!$params['is_online_registration']) {

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -495,7 +495,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
     $this->assign('is_email_confirm', $this->_values['event']['is_email_confirm'] ?? NULL);
     // assign pay later stuff
-    $params['is_pay_later'] = $params['is_pay_later'] ?? FALSE;
+    $params['is_pay_later'] ??= FALSE;
     $this->assign('is_pay_later', $params['is_pay_later']);
     $this->assign('pay_later_text', $params['is_pay_later'] ? $this->getPayLaterLabel() : FALSE);
     $this->assign('pay_later_receipt', $params['is_pay_later'] ? $this->_values['event']['pay_later_receipt'] : NULL);

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -669,7 +669,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
           }
         }
       }
-      $form->_priceSet['id'] = $form->_priceSet['id'] ?? $priceSetID;
+      $form->_priceSet['id'] ??= $priceSetID;
       $form->assign('priceSet', $form->_priceSet);
     }
     else {

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -953,7 +953,7 @@ class CRM_Financial_BAO_Order {
       elseif ($taxRate) {
         $lineItem['tax_amount'] = ($taxRate / 100) * $lineItem['line_total'];
       }
-      $lineItem['membership_type_id'] = $lineItem['membership_type_id'] ?? NULL;
+      $lineItem['membership_type_id'] ??= NULL;
       if ($lineItem['membership_type_id']) {
         $lineItem['entity_table'] = 'civicrm_membership';
       }
@@ -1219,8 +1219,8 @@ class CRM_Financial_BAO_Order {
       }
     }
     $lineItem['unit_price'] = $lineItem['line_total'] ?? $option['amount'];
-    $lineItem['label'] = $lineItem['label'] ?? $option['label'];
-    $lineItem['field_title'] = $lineItem['field_title'] ?? $option['label'];
+    $lineItem['label'] ??= $option['label'];
+    $lineItem['field_title'] ??= $option['label'];
     $lineItem['financial_type_id'] = $lineItem['financial_type_id'] ?: ($this->getDefaultFinancialTypeID() ?? $option['financial_type_id']);
     return $lineItem;
   }

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -49,7 +49,7 @@ class CRM_Financial_BAO_Payment {
     $paymentTrxnParams = array_intersect_key($params, array_fill_keys($whiteList, 1));
     $paymentTrxnParams['is_payment'] = 1;
     // Really we should have a DB default.
-    $paymentTrxnParams['fee_amount'] = $paymentTrxnParams['fee_amount'] ?? 0;
+    $paymentTrxnParams['fee_amount'] ??= 0;
 
     if (isset($paymentTrxnParams['payment_processor_id']) && empty($paymentTrxnParams['payment_processor_id'])) {
       // Don't pass 0 - ie the Pay Later processor as it is  a pseudo-processor.

--- a/CRM/Financial/Form/FinancialAccount.php
+++ b/CRM/Financial/Form/FinancialAccount.php
@@ -201,7 +201,7 @@ class CRM_Financial_Form_FinancialAccount extends CRM_Contribute_Form {
         $params['id'] = $this->_id;
       }
       foreach (['is_active', 'is_deductible', 'is_tax', 'is_default'] as $field) {
-        $params[$field] = $params[$field] ?? FALSE;
+        $params[$field] ??= FALSE;
       }
       $financialAccount = CRM_Financial_BAO_FinancialAccount::writeRecord($params);
       CRM_Core_Session::setStatus(ts('The Financial Account \'%1\' has been saved.', [1 => $financialAccount->name]), ts('Saved'), 'success');

--- a/CRM/Financial/Form/FinancialType.php
+++ b/CRM/Financial/Form/FinancialType.php
@@ -118,7 +118,7 @@ class CRM_Financial_Form_FinancialType extends CRM_Core_Form {
         $params['id'] = $this->_id;
       }
       foreach (['is_active', 'is_reserved', 'is_deductible'] as $field) {
-        $params[$field] = $params[$field] ?? FALSE;
+        $params[$field] ??= FALSE;
       }
       $financialType = civicrm_api3('FinancialType', 'create', $params);
       if ($this->_action & CRM_Core_Action::UPDATE) {

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -331,8 +331,8 @@ WHERE  title = %1
         $params['group_type'] = [];
       }
 
-      $params['is_reserved'] = $params['is_reserved'] ?? FALSE;
-      $params['is_active'] = $params['is_active'] ?? FALSE;
+      $params['is_reserved'] ??= FALSE;
+      $params['is_active'] ??= FALSE;
       $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
         $this->_id,
         'Group'

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -848,7 +848,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    */
   protected function checkContactDuplicate(&$formatValues) {
     //retrieve contact id using contact dedupe rule
-    $formatValues['contact_type'] = $formatValues['contact_type'] ?? $this->getContactType();
+    $formatValues['contact_type'] ??= $this->getContactType();
     $formatValues['version'] = 3;
     $params = $formatValues;
     static $cIndieFields = NULL;

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1472,7 +1472,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       $params = self::processWorkflowPermissions($params);
     }
     if (!$id) {
-      $params['domain_id'] = $params['domain_id'] ?? CRM_Core_Config::domainID();
+      $params['domain_id'] ??= CRM_Core_Config::domainID();
     }
     if (
       ((!$id && empty($params['replyto_email'])) || !isset($params['replyto_email'])) &&

--- a/CRM/Mailing/BAO/Query.php
+++ b/CRM/Mailing/BAO/Query.php
@@ -450,8 +450,8 @@ class CRM_Mailing_BAO_Query {
    */
   public static function tableNames(&$tables) {
     if (isset($tables['civicrm_mailing_job'])) {
-      $tables['civicrm_mailing'] = $tables['civicrm_mailing'] ?? 1;
-      $tables['civicrm_mailing_recipients'] = $tables['civicrm_mailing_recipients'] ?? 1;
+      $tables['civicrm_mailing'] ??= 1;
+      $tables['civicrm_mailing_recipients'] ??= 1;
     }
   }
 

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -322,7 +322,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
 
     $transaction = new CRM_Core_Transaction();
 
-    $params['id'] = $params['id'] ?? $ids['membership'] ?? NULL;
+    $params['id'] ??= $ids['membership'] ?? NULL;
     $membership = self::add($params);
 
     if (is_a($membership, 'CRM_Core_Error')) {

--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -43,9 +43,9 @@ class CRM_PCP_BAO_PCP extends CRM_PCP_DAO_PCP implements \Civi\Core\HookInterfac
     if ($event->action === 'create') {
       // For some reason `status_id` is allowed to be empty
       // FIXME: Why?
-      $event->params['status_id'] = $event->params['status_id'] ?? 0;
+      $event->params['status_id'] ??= 0;
       // Supply default for `currency`
-      $event->params['currency'] = $event->params['currency'] ?? Civi::settings()->get('defaultCurrency');
+      $event->params['currency'] ??= Civi::settings()->get('defaultCurrency');
     }
   }
 

--- a/CRM/PCP/Form/Contribute.php
+++ b/CRM/PCP/Form/Contribute.php
@@ -145,8 +145,8 @@ class CRM_PCP_Form_Contribute extends CRM_Contribute_Form_ContributionPage {
     $dao->find(TRUE);
     $params['id'] = $dao->id;
     $params['is_active'] = $params['pcp_active'] ?? FALSE;
-    $params['is_approval_needed'] = $params['is_approval_needed'] ?? FALSE;
-    $params['is_tellfriend_enabled'] = $params['is_tellfriend_enabled'] ?? FALSE;
+    $params['is_approval_needed'] ??= FALSE;
+    $params['is_tellfriend_enabled'] ??= FALSE;
 
     CRM_PCP_BAO_PCPBlock::writeRecord($params);
 

--- a/CRM/PCP/Form/Event.php
+++ b/CRM/PCP/Form/Event.php
@@ -185,8 +185,8 @@ class CRM_PCP_Form_Event extends CRM_Event_Form_ManageEvent {
     $dao->find(TRUE);
     $params['id'] = $dao->id;
     $params['is_active'] = $params['pcp_active'] ?? FALSE;
-    $params['is_approval_needed'] = $params['is_approval_needed'] ?? FALSE;
-    $params['is_tellfriend_enabled'] = $params['is_tellfriend_enabled'] ?? FALSE;
+    $params['is_approval_needed'] ??= FALSE;
+    $params['is_tellfriend_enabled'] ??= FALSE;
 
     CRM_PCP_BAO_PCPBlock::writeRecord($params);
 

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -836,7 +836,7 @@ WHERE  id = %1";
         }
       }
     }
-    $form->_priceSet['id'] = $form->_priceSet['id'] ?? $priceSetId;
+    $form->_priceSet['id'] ??= $priceSetId;
     $form->assign('priceSet', $form->_priceSet);
 
     if ($className == 'CRM_Contribute_Form_Contribution_Main') {

--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -666,12 +666,12 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
       $params['option_amount'][$key] = CRM_Utils_Rule::cleanMoney($amount);
     }
 
-    $params['is_display_amounts'] = $params['is_display_amounts'] ?? FALSE;
-    $params['is_required'] = $params['is_required'] ?? FALSE;
-    $params['is_active'] = $params['is_active'] ?? FALSE;
-    $params['financial_type_id'] = $params['financial_type_id'] ?? FALSE;
-    $params['visibility_id'] = $params['visibility_id'] ?? FALSE;
-    $params['count'] = $params['count'] ?? FALSE;
+    $params['is_display_amounts'] ??= FALSE;
+    $params['is_required'] ??= FALSE;
+    $params['is_active'] ??= FALSE;
+    $params['financial_type_id'] ??= FALSE;
+    $params['visibility_id'] ??= FALSE;
+    $params['count'] ??= FALSE;
 
     // need the FKEY - price set id
     $params['price_set_id'] = $this->_sid;
@@ -689,7 +689,7 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
     if (isset($params['option_name'])) {
       $params['option_value'] = $params['option_name'];
     }
-    $params['is_enter_qty'] = $params['is_enter_qty'] ?? FALSE;
+    $params['is_enter_qty'] ??= FALSE;
 
     if ($params['html_type'] === 'Text') {
       // if html type is Text, force is_enter_qty on

--- a/CRM/Price/Form/Option.php
+++ b/CRM/Price/Form/Option.php
@@ -328,9 +328,9 @@ class CRM_Price_Form_Option extends CRM_Core_Form {
         $params[$field] = CRM_Utils_Rule::cleanMoney(trim($params[$field]));
       }
       $params['price_field_id'] = $this->_fid;
-      $params['is_default'] = $params['is_default'] ?? FALSE;
-      $params['is_active'] = $params['is_active'] ?? FALSE;
-      $params['visibility_id'] = $params['visibility_id'] ?? FALSE;
+      $params['is_default'] ??= FALSE;
+      $params['is_active'] ??= FALSE;
+      $params['visibility_id'] ??= FALSE;
       $ids = [];
       if ($this->_oid) {
         $params['id'] = $this->_oid;

--- a/CRM/Price/Form/Set.php
+++ b/CRM/Price/Form/Set.php
@@ -243,8 +243,8 @@ class CRM_Price_Form_Set extends CRM_Core_Form {
     // get the submitted form values.
     $params = $this->controller->exportValues('Set');
     $nameLength = CRM_Core_DAO::getAttribute('CRM_Price_DAO_PriceSet', 'name');
-    $params['is_active'] = $params['is_active'] ?? FALSE;
-    $params['financial_type_id'] = $params['financial_type_id'] ?? FALSE;
+    $params['is_active'] ??= FALSE;
+    $params['financial_type_id'] ??= FALSE;
 
     $compIds = [];
     $extends = $params['extends'] ?? NULL;

--- a/CRM/Price/Page/Option.php
+++ b/CRM/Price/Page/Option.php
@@ -163,8 +163,8 @@ class CRM_Price_Page_Option extends CRM_Core_Page {
         }
       }
       $customOption[$id]['order'] = $customOption[$id]['weight'];
-      $customOption[$id]['help_pre'] = $customOption[$id]['help_pre'] ?? NULL;
-      $customOption[$id]['help_post'] = $customOption[$id]['help_post'] ?? NULL;
+      $customOption[$id]['help_pre'] ??= NULL;
+      $customOption[$id]['help_post'] ??= NULL;
       $customOption[$id]['action'] = CRM_Core_Action::formLink(self::actionLinks(), $action,
         [
           'oid' => $id,

--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -47,10 +47,10 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance implem
     }
 
     if (!$instanceID || !isset($params['id'])) {
-      $params['is_reserved'] = $params['is_reserved'] ?? FALSE;
-      $params['domain_id'] = CRM_Utils_Array::value('domain_id', $params, CRM_Core_Config::domainID());
+      $params['is_reserved'] ??= FALSE;
+      $params['domain_id'] ??= CRM_Core_Config::domainID();
       // CRM-17256 set created_id on report creation.
-      $params['created_id'] = $params['created_id'] ?? CRM_Core_Session::getLoggedInContactID();
+      $params['created_id'] ??= CRM_Core_Session::getLoggedInContactID();
     }
 
     if ($instanceID) {

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1396,7 +1396,7 @@ class CRM_Report_Form extends CRM_Core_Form {
         if (empty($field['operatorType'])) {
           $field['operatorType'] = '';
         }
-        $field['no_display'] = $field['no_display'] ?? FALSE;
+        $field['no_display'] ??= FALSE;
         $filterGroups[$groupingKey]['tables'][$table][$fieldName] = $field;
         // Filters is deprecated in favour of filterGroups.
         $filters[$table][$fieldName] = $field;
@@ -3686,7 +3686,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
    * @return array
    */
   public function limit($rowCount = NULL) {
-    $rowCount = $rowCount ?? $this->getRowCount();
+    $rowCount ??= $this->getRowCount();
     // lets do the pager if in html mode
     $this->_limit = NULL;
 
@@ -3737,7 +3737,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
    * @param int|null $rowCount
    */
   public function setPager($rowCount = NULL) {
-    $rowCount = $rowCount ?? $this->getRowCount();
+    $rowCount ??= $this->getRowCount();
     // CRM-14115, over-ride row count if rowCount is specified in URL
     if ($this->_dashBoardRowCount) {
       $rowCount = $this->_dashBoardRowCount;

--- a/CRM/Report/Form/ActivitySummary.php
+++ b/CRM/Report/Form/ActivitySummary.php
@@ -505,7 +505,7 @@ class CRM_Report_Form_ActivitySummary extends CRM_Report_Form {
    * @param int|null $rowCount
    */
   public function setPager($rowCount = NULL) {
-    $rowCount = $rowCount ?? $this->getRowCount();
+    $rowCount ??= $this->getRowCount();
     $this->_rowsFound = $this->totalRows;
     parent::setPager($rowCount);
   }

--- a/CRM/Report/Form/Contact/Detail.php
+++ b/CRM/Report/Form/Contact/Detail.php
@@ -797,7 +797,7 @@ HERESQL;
    * @param int|null $rowCount
    */
   public function limit($rowCount = NULL) {
-    $rowCount = $rowCount ?? $this->getRowCount();
+    $rowCount ??= $this->getRowCount();
     parent::limit($rowCount);
   }
 
@@ -806,7 +806,7 @@ HERESQL;
    * @param int|null $rowCount
    */
   public function setPager($rowCount = NULL): void {
-    $rowCount = $rowCount ?? $this->getRowCount();
+    $rowCount ??= $this->getRowCount();
     parent::setPager($rowCount);
   }
 

--- a/CRM/Report/Form/Contribute/DeferredRevenue.php
+++ b/CRM/Report/Form/Contribute/DeferredRevenue.php
@@ -352,7 +352,7 @@ class CRM_Report_Form_Contribute_DeferredRevenue extends CRM_Report_Form {
    * @param int|null $rowCount
    */
   public function limit($rowCount = NULL) {
-    $rowCount = $rowCount ?? $this->getRowCount();
+    $rowCount ??= $this->getRowCount();
     $this->_limit = NULL;
   }
 

--- a/CRM/Report/Form/Contribute/History.php
+++ b/CRM/Report/Form/Contribute/History.php
@@ -494,7 +494,7 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
    * @return array
    */
   public function limit($rowCount = NULL) {
-    $rowCount = $rowCount ?? $this->getRowCount();
+    $rowCount ??= $this->getRowCount();
     return parent::limit($rowCount);
   }
 
@@ -504,7 +504,7 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
    * @param int|null $rowCount
    */
   public function setPager($rowCount = NULL) {
-    $rowCount = $rowCount ?? $this->getRowCount();
+    $rowCount ??= $this->getRowCount();
     parent::setPager($rowCount);
   }
 

--- a/CRM/Report/Form/Contribute/TopDonor.php
+++ b/CRM/Report/Form/Contribute/TopDonor.php
@@ -346,7 +346,7 @@ class CRM_Report_Form_Contribute_TopDonor extends CRM_Report_Form {
    * @param int $rowCount
    */
   public function limit($rowCount = NULL) {
-    $rowCount = $rowCount ?? $this->getRowCount();
+    $rowCount ??= $this->getRowCount();
     // lets do the pager if in html mode
     $this->_limit = NULL;
 

--- a/CRM/Report/Form/Event/Income.php
+++ b/CRM/Report/Form/Event/Income.php
@@ -225,7 +225,7 @@ class CRM_Report_Form_Event_Income extends CRM_Report_Form {
    * @inheritDoc
    */
   public function limit($rowCount = NULL) {
-    $rowCount = $rowCount ?? $this->getRowCount();
+    $rowCount ??= $this->getRowCount();
     parent::limit($rowCount);
 
     // Modify limit.
@@ -243,7 +243,7 @@ class CRM_Report_Form_Event_Income extends CRM_Report_Form {
    * @param int|null $rowCount
    */
   public function setPager($rowCount = NULL) {
-    $rowCount = $rowCount ?? $this->getRowCount();
+    $rowCount ??= $this->getRowCount();
     $params = [
       'total' => $this->_rowsFound,
       'rowCount' => $rowCount,

--- a/CRM/Report/Form/Instance.php
+++ b/CRM/Report/Form/Instance.php
@@ -246,7 +246,7 @@ class CRM_Report_Form_Instance {
 
     if ($instanceID) {
       // this is already retrieved via Form.php
-      $defaults['description'] = $defaults['description'] ?? NULL;
+      $defaults['description'] ??= NULL;
       if (!empty($defaults['header'])) {
         $defaults['report_header'] = $defaults['header'];
       }

--- a/CRM/SMS/Form/Provider.php
+++ b/CRM/SMS/Form/Provider.php
@@ -157,8 +157,8 @@ class CRM_SMS_Form_Provider extends CRM_Core_Form {
     }
 
     $recData = $values = $this->controller->exportValues($this->_name);
-    $recData['is_active'] = $recData['is_active'] ?? 0;
-    $recData['is_default'] = $recData['is_default'] ?? 0;
+    $recData['is_active'] ??= 0;
+    $recData['is_default'] ??= 0;
 
     if ($this->_action && (CRM_Core_Action::UPDATE || CRM_Core_Action::ADD)) {
       if ($this->_id) {

--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -192,7 +192,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
       CRM_Core_BAO_UFField::retrieve($params, $defaults);
 
       // set it to null if so (avoids crappy E_NOTICE errors below
-      $defaults['location_type_id'] = $defaults['location_type_id'] ?? NULL;
+      $defaults['location_type_id'] ??= NULL;
 
       //CRM-20861 - Include custom fields defined for address to set its default location type to 0.
       $specialFields = array_merge(CRM_Core_BAO_UFGroup::getLocationFields(), $addressCustomFields);

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -651,7 +651,7 @@ abstract class CRM_Utils_Hook {
   public static function selectWhereClause($entity, array &$clauses, int $userId = NULL, array $conditions = []): void {
     $entityName = is_object($entity) ? CRM_Core_DAO_AllCoreTables::getBriefName(get_class($entity)) : $entity;
     $null = NULL;
-    $userId = $userId ?? (int) CRM_Core_Session::getLoggedInContactID();
+    $userId ??= (int) CRM_Core_Session::getLoggedInContactID();
     self::singleton()->invoke(['entity', 'clauses', 'userId', 'conditions'],
       $entityName, $clauses, $userId, $conditions,
       $null, $null,

--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -202,7 +202,7 @@ class CRM_Utils_Money {
    * @throws \Brick\Money\Exception\UnknownCurrencyException
    */
   protected static function formatLocaleNumeric(string $amount, $locale = NULL, $currency = NULL, $numberOfPlaces = 2): string {
-    $currency = $currency ?? CRM_Core_Config::singleton()->defaultCurrency;
+    $currency ??= CRM_Core_Config::singleton()->defaultCurrency;
     $currencyObject = self::getCurrencyObject($currency);
     $money = Money::of($amount, $currencyObject, new CustomContext($numberOfPlaces), RoundingMode::HALF_UP);
     $formatter = new \NumberFormatter($locale ?? CRM_Core_I18n::getLocale(), NumberFormatter::DECIMAL);

--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -93,10 +93,10 @@ class CRM_Utils_Recent {
         return [];
       }
     }
-    $params['title'] = $params['title'] ?? self::getTitle($params['entity_type'], $params['entity_id']);
-    $params['view_url'] = $params['view_url'] ?? self::getUrl($params['entity_type'], $params['entity_id'], 'view');
-    $params['edit_url'] = $params['edit_url'] ?? self::getUrl($params['entity_type'], $params['entity_id'], 'update');
-    $params['delete_url'] = $params['delete_url'] ?? (empty($params['is_deleted']) ? self::getUrl($params['entity_type'], $params['entity_id'], 'delete') : NULL);
+    $params['title'] ??= self::getTitle($params['entity_type'], $params['entity_id']);
+    $params['view_url'] ??= self::getUrl($params['entity_type'], $params['entity_id'], 'view');
+    $params['edit_url'] ??= self::getUrl($params['entity_type'], $params['entity_id'], 'update');
+    $params['delete_url'] ??= (empty($params['is_deleted']) ? self::getUrl($params['entity_type'], $params['entity_id'], 'delete') : NULL);
     self::add($params['title'], $params['view_url'], $params['entity_id'], $params['entity_type'], $params['contact_id'] ?? NULL, NULL, $params);
     return $params;
   }

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -254,8 +254,8 @@ class CRM_Utils_System {
     $forceBackend = FALSE
   ) {
     // handle legacy null params
-    $path = $path ?? '';
-    $query = $query ?? '';
+    $path ??= '';
+    $query ??= '';
 
     $query = self::makeQueryString($query);
 

--- a/Civi/API/Subscriber/DebugSubscriber.php
+++ b/Civi/API/Subscriber/DebugSubscriber.php
@@ -80,12 +80,12 @@ class DebugSubscriber implements EventSubscriberInterface {
       && (empty($apiRequest['params']['check_permissions']) || \CRM_Core_Permission::check('view debug output'))
     ) {
       if (is_a($result, '\Civi\Api4\Generic\Result')) {
-        $result->debug = $result->debug ?? [];
+        $result->debug ??= [];
         $debug =& $result->debug;
       }
       // result would not be an array for api3 getvalue
       elseif (is_array($result)) {
-        $result['xdebug'] = $result['xdebug'] ?? [];
+        $result['xdebug'] ??= [];
         $debug =& $result['xdebug'];
       }
       else {

--- a/Civi/Api4/Generic/AutocompleteAction.php
+++ b/Civi/Api4/Generic/AutocompleteAction.php
@@ -188,7 +188,7 @@ class AutocompleteAction extends AbstractAction {
       if (!$initialSearchById && !empty($this->display['settings']['columns'][0]['rewrite'])) {
         $searchFields = array_merge($searchFields, $this->getTokens($this->display['settings']['columns'][0]['rewrite']));
       }
-      $this->display['settings']['limit'] = $this->display['settings']['limit'] ?? \Civi::settings()->get('search_autocomplete_count');
+      $this->display['settings']['limit'] ??= \Civi::settings()->get('search_autocomplete_count');
       $this->display['settings']['pager'] = [];
       $return = 'scroll:' . $this->page;
       // SearchKit treats comma-separated fieldnames as OR clauses

--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -136,7 +136,7 @@ class BasicGetFieldsAction extends BasicGetAction {
       ], $fieldDefaults);
       $field += $defaults + $fieldDefaults;
       if (array_key_exists('label', $fieldDefaults)) {
-        $field['label'] = $field['label'] ?? $field['title'] ?? $field['name'];
+        $field['label'] ??= $field['title'] ?? $field['name'];
       }
       if (isset($field['options']) && is_array($field['options']) && empty($field['suffixes']) && array_key_exists('suffixes', $field)) {
         $this->setFieldSuffixes($field);

--- a/Civi/Api4/Service/Spec/Provider/MailingGetSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/MailingGetSpecProvider.php
@@ -195,7 +195,7 @@ class MailingGetSpecProvider extends \Civi\Core\Service\AutoService implements G
 
     }
 
-    $count = $count ?? "$tableName.event_queue_id";
+    $count ??= "$tableName.event_queue_id";
     $query = "(
       SELECT      COUNT($count)
       FROM        $tableName

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -239,7 +239,7 @@ class CoreUtil {
    * @throws \CRM_Core_Exception
    */
   public static function checkAccessRecord(AbstractAction $apiRequest, array $record, int $userID = NULL): ?bool {
-    $userID = $userID ?? \CRM_Core_Session::getLoggedInContactID() ?? 0;
+    $userID ??= \CRM_Core_Session::getLoggedInContactID() ?? 0;
     $idField = self::getIdFieldName($apiRequest->getEntityName());
 
     // Super-admins always have access to everything

--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -162,7 +162,7 @@ class PropertyBag implements \ArrayAccess {
   public function offsetExists ($offset): bool {
     $prop = $this->handleLegacyPropNames($offset, TRUE);
     // If there's no prop, assume it's a custom property.
-    $prop = $prop ?? $offset;
+    $prop ??= $offset;
     return array_key_exists($prop, $this->props['default']);
   }
 

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -490,7 +490,7 @@ function civicrm_api3_contribution_completetransaction($params): array {
     throw new CRM_Core_Exception(ts('Contribution already completed'), 'contribution_completed');
   }
 
-  $params['trxn_id'] = $params['trxn_id'] ?? $contribution->trxn_id;
+  $params['trxn_id'] ??= $contribution->trxn_id;
 
   $passThroughParams = [
     'fee_amount',

--- a/api/v3/Generic.php
+++ b/api/v3/Generic.php
@@ -63,7 +63,7 @@ function civicrm_api3_generic_getfields($apiRequest, $unique = TRUE) {
   $subentity = $apiRequest['params']['contact_type'] ?? NULL;
   $action = $apiRequest['params']['action'] ?? NULL;
   $sequential = empty($apiRequest['params']['sequential']) ? 0 : 1;
-  $apiRequest['params']['options'] = $apiRequest['params']['options'] ?? [];
+  $apiRequest['params']['options'] ??= [];
   $optionsToResolve = (array) ($apiRequest['params']['options']['get_options'] ?? []);
 
   if (!$action || $action == 'getvalue' || $action == 'getcount') {

--- a/api/v3/LocBlock.php
+++ b/api/v3/LocBlock.php
@@ -54,7 +54,7 @@ function civicrm_api3_loc_block_create($params) {
         }
         // Bother calling the api.
         else {
-          $info['contact_id'] = $info['contact_id'] ?? 'null';
+          $info['contact_id'] ??= 'null';
           $result = civicrm_api3($item, 'create', $info);
           $entities[$key] = $result['values'][$result['id']];
           $params[$key . '_id'] = $result['id'];

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -294,7 +294,7 @@ function civicrm_api3_mailing_submit($params) {
   if (isset($params['approval_date'])) {
     $updateParams['approval_date'] = $params['approval_date'];
     $updateParams['approver_id'] = CRM_Core_Session::getLoggedInContactID();
-    $updateParams['approval_status_id'] = $updateParams['approval_status_id'] ?? CRM_Core_OptionGroup::getDefaultValue('mail_approval_status');
+    $updateParams['approval_status_id'] ??= CRM_Core_OptionGroup::getDefaultValue('mail_approval_status');
   }
   if (isset($params['approval_note'])) {
     $updateParams['approval_note'] = $params['approval_note'];

--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -131,7 +131,7 @@ function civicrm_api3_order_create(array $params): array {
         && (!CRM_Event_BAO_ParticipantStatusType::getIsValidStatusForClass($entityParams['participant_status_id'], 'Pending'))) {
         throw new CRM_Core_Exception('Creating a participant via the Order API with a non "pending" status is not supported');
       }
-      $entityParams['participant_status_id'] = $entityParams['participant_status_id'] ?? 'Pending from incomplete transaction';
+      $entityParams['participant_status_id'] ??= 'Pending from incomplete transaction';
       $entityParams['status_id'] = $entityParams['participant_status_id'];
       $entityParams['skipLineItem'] = TRUE;
       $entityResult = civicrm_api3('Participant', 'create', $entityParams);

--- a/api/v3/Profile.php
+++ b/api/v3/Profile.php
@@ -606,7 +606,7 @@ function _civicrm_api3_buildprofile_submitfields($profileID, $optionsBehaviour, 
        */
     }
   }
-  $profileFields[$profileID] = $profileFields[$profileID] ?? [];
+  $profileFields[$profileID] ??= [];
   uasort($profileFields[$profileID], "_civicrm_api3_order_by_weight");
   return $profileFields[$profileID];
 }

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -425,7 +425,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
       if (!empty($entity['data'])) {
         // If no submitted values but data exists, fill the minimum number of records
         for ($index = 0; $index < $entity['min']; $index++) {
-          $entityValues[$entityName][$index] = $entityValues[$entityName][$index] ?? ['fields' => []];
+          $entityValues[$entityName][$index] ??= ['fields' => []];
         }
         // Predetermined values override submitted values
         foreach ($entityValues[$entityName] as $index => $vals) {

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -221,7 +221,7 @@ function afform_civicrm_pageRun(&$page) {
     // If Afform specifies a contact type, lookup the contact and compare
     if (!empty($afform['summary_contact_type'])) {
       // Contact.get only needs to happen once
-      $contact = $contact ?? civicrm_api4('Contact', 'get', [
+      $contact ??= civicrm_api4('Contact', 'get', [
         'select' => ['contact_type', 'contact_sub_type'],
         'where' => [['id', '=', $cid]],
       ])->first();

--- a/ext/afform/mock/tests/phpunit/Civi/AfformMock/FormTestCase.php
+++ b/ext/afform/mock/tests/phpunit/Civi/AfformMock/FormTestCase.php
@@ -88,7 +88,7 @@ abstract class FormTestCase extends \PHPUnit\Framework\TestCase implements \Civi
    * @return mixed
    */
   protected function prefill($params) {
-    $params['name'] = $params['name'] ?? $this->getFormName();
+    $params['name'] ??= $this->getFormName();
     return $this->callApi4AjaxSuccess('Afform', 'prefill', $params);
   }
 
@@ -100,7 +100,7 @@ abstract class FormTestCase extends \PHPUnit\Framework\TestCase implements \Civi
    * @return mixed
    */
   protected function prefillError($params) {
-    $params['name'] = $params['name'] ?? $this->getFormName();
+    $params['name'] ??= $this->getFormName();
     return $this->callApi4AjaxError('Afform', 'prefill', $params);
   }
 
@@ -112,7 +112,7 @@ abstract class FormTestCase extends \PHPUnit\Framework\TestCase implements \Civi
    * @return mixed
    */
   protected function submit($params) {
-    $params['name'] = $params['name'] ?? $this->getFormName();
+    $params['name'] ??= $this->getFormName();
     return $this->callApi4AjaxSuccess('Afform', 'submit', $params);
   }
 
@@ -124,7 +124,7 @@ abstract class FormTestCase extends \PHPUnit\Framework\TestCase implements \Civi
    * @return mixed
    */
   protected function submitError($params) {
-    $params['name'] = $params['name'] ?? $this->getFormName();
+    $params['name'] ??= $this->getFormName();
     return $this->callApi4AjaxError('Afform', 'submit', $params);
   }
 

--- a/ext/authx/Civi/Authx/Authenticator.php
+++ b/ext/authx/Civi/Authx/Authenticator.php
@@ -421,7 +421,7 @@ class AuthenticatorTarget {
    */
   public function setPrincipal($args) {
     if (!empty($args['user'])) {
-      $args['userId'] = $args['userId'] ?? \CRM_Core_Config::singleton()->userSystem->getUfId($args['user']);
+      $args['userId'] ??= \CRM_Core_Config::singleton()->userSystem->getUfId($args['user']);
       if ($args['userId']) {
         unset($args['user']);
       }

--- a/ext/oauth-client/Civi/OAuth/OAuthLeagueFacade.php
+++ b/ext/oauth-client/Civi/OAuth/OAuthLeagueFacade.php
@@ -41,7 +41,7 @@ class OAuthLeagueFacade {
       $clientDef['options'] ?? [],
       $localOptions
     );
-    $options['redirectUri'] = $options['redirectUri'] ?? \CRM_OAuth_BAO_OAuthClient::getRedirectUri();
+    $options['redirectUri'] ??= \CRM_OAuth_BAO_OAuthClient::getRedirectUri();
 
     return [$class, $options];
   }

--- a/ext/oauth-client/Civi/OAuth/OAuthTokenFacade.php
+++ b/ext/oauth-client/Civi/OAuth/OAuthTokenFacade.php
@@ -28,7 +28,7 @@ class OAuthTokenFacade {
    * @see \League\OAuth2\Client\Provider\AbstractProvider::getAccessToken()
    */
   public function init($options): array {
-    $options['storage'] = $options['storage'] ?? 'OAuthSysToken';
+    $options['storage'] ??= 'OAuthSysToken';
     if (!preg_match(self::STORAGE_TYPES, $options['storage'])) {
       throw new \CRM_Core_Exception("Invalid token storage ({$options['storage']})");
     }

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -118,7 +118,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     }
 
     $this->_apiParams['checkPermissions'] = $this->savedSearch['api_params']['checkPermissions'] = empty($this->display['acl_bypass']);
-    $this->display['settings']['columns'] = $this->display['settings']['columns'] ?? [];
+    $this->display['settings']['columns'] ??= [];
 
     $this->processResult($result);
   }
@@ -388,7 +388,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
           $iconClass = \CRM_Utils_Array::first(array_filter((array) $data[$iconField]));
         }
       }
-      $iconClass = $iconClass ?? $icon['icon'];
+      $iconClass ??= $icon['icon'];
       if ($iconClass && !empty($icon['if'])) {
         $condition = $this->getRuleCondition($icon['if'], $isMulti);
         if (!is_null($condition[0]) && !(self::filterCompare($data, $condition, $isMulti ? $index : NULL))) {

--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -49,7 +49,7 @@ class Security {
     }
 
     // NULL means the current logged-in user
-    $userID = $userID ?? $this->getLoggedInUfID() ?? 0;
+    $userID ??= $this->getLoggedInUfID() ?? 0;
 
     if (!isset(\Civi::$statics[__METHOD__][$userID])) {
 

--- a/tests/extensions/test.extension.manager.paymenttest/main.php
+++ b/tests/extensions/test.extension.manager.paymenttest/main.php
@@ -8,22 +8,22 @@ class test_extension_manager_paymenttest extends CRM_Core_Payment {
   public static $counts = [];
 
   public function install() {
-    self::$counts['install'] = self::$counts['install'] ?? 0;
+    self::$counts['install'] ??= 0;
     self::$counts['install'] = 1 + (int) self::$counts['install'];
   }
 
   public function uninstall() {
-    self::$counts['uninstall'] = self::$counts['uninstall'] ?? 0;
+    self::$counts['uninstall'] ??= 0;
     self::$counts['uninstall'] = 1 + (int) self::$counts['uninstall'];
   }
 
   public function disable() {
-    self::$counts['disable'] = self::$counts['disable'] ?? 0;
+    self::$counts['disable'] ??= 0;
     self::$counts['disable'] = 1 + (int) self::$counts['disable'];
   }
 
   public function enable() {
-    self::$counts['enable'] = self::$counts['enable'] ?? 0;
+    self::$counts['enable'] ??= 0;
     self::$counts['enable'] = 1 + (int) self::$counts['enable'];
   }
 

--- a/tests/phpunit/CRM/Core/CopyTest.php
+++ b/tests/phpunit/CRM/Core/CopyTest.php
@@ -102,7 +102,7 @@ class CRM_Core_CopyTest extends CiviUnitTestCase {
 
     // init in case it's not defined
     foreach ($locParams as $field) {
-      $eventData[$field] = $eventData[$field] ?? '';
+      $eventData[$field] ??= '';
     }
 
     // differencing the data in original content for each locales

--- a/tests/phpunit/CRM/Member/BAO/MembershipLogTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipLogTest.php
@@ -163,7 +163,7 @@ class CRM_Member_BAO_MembershipLogTest extends CiviUnitTestCase {
    */
   private function setupMembership($modifiedID = NULL): array {
     $contactID = $this->individualCreate();
-    $modifiedID = $modifiedID ?? $contactID;
+    $modifiedID ??= $contactID;
 
     $params = [
       'contact_id' => $contactID,

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -1197,7 +1197,7 @@ Attendees will need to install the [TeleFoo](http://telefoo.example.com) app.';
    * @return string
    */
   protected function renderText(array $rowContext, string $text, array $context = [], $isHtml = TRUE): string {
-    $context['schema'] = $context['schema'] ?? [];
+    $context['schema'] ??= [];
     foreach (array_keys($rowContext) as $key) {
       $context['schema'][] = $key;
     }

--- a/tests/phpunit/api/v4/Request/AjaxTest.php
+++ b/tests/phpunit/api/v4/Request/AjaxTest.php
@@ -39,7 +39,7 @@ class AjaxTest extends Api4TestBase implements TransactionalInterface {
       'httpx' => $_SERVER['HTTP_X_REQUESTED_WITH'] ?? NULL,
     ];
     $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
-    $_SERVER['HTTP_REFERER'] = $_SERVER['HTTP_REFERER'] ?? NULL;
+    $_SERVER['HTTP_REFERER'] ??= NULL;
     http_response_code(200);
   }
 

--- a/tools/mixin/src/Mixlib.php
+++ b/tools/mixin/src/Mixlib.php
@@ -75,7 +75,7 @@ class Mixlib {
 
     $phpCode = $this->getSourceCode($mixin);
     $mixinSpec = $this->parseString($phpCode);
-    $mixinSpec['mixinName'] = $mixinSpec['mixinName'] ?? preg_replace(';@.*$;', '', $mixin);
+    $mixinSpec['mixinName'] ??= preg_replace(';@.*$;', '', $mixin);
 
     $parts = explode('@', $mixin);
     $effectiveVersion = !empty($mixinSpec['mixinVersion']) ? $mixinSpec['mixinVersion'] : ($parts[1] ?? '');


### PR DESCRIPTION
Overview
----------------------------------------
Now that we've [dropped support for PHP 7.3](https://lab.civicrm.org/dev/core/-/issues/4812) we're free to use [this new syntax](https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.null-coalescing-assignment-operator).

Before
----------------------------------------
`$foo = $foo ?? $bar;`

After
----------------------------------------
`$foo ??= $bar;`