### PR TITLE
Handle NULL in table name check

### DIFF
--- a/ext/civiimport/civiimport.php
+++ b/ext/civiimport/civiimport.php
@@ -106,7 +106,7 @@ function _civiimport_civicrm_get_import_tables(): array {
   $importEntities = [];
   while ($tables->fetch()) {
     $tableName = json_decode($tables->metadata, TRUE)['DataSource']['table_name'];
-    if (!CRM_Utils_Rule::alphanumeric($tableName) || !CRM_Core_DAO::singleValueQuery('SHOW TABLES LIKE %1', [1 => [$tableName, 'String']])) {
+    if (!$tableName || !CRM_Utils_Rule::alphanumeric($tableName) || !CRM_Core_DAO::singleValueQuery('SHOW TABLES LIKE %1', [1 => [$tableName, 'String']])) {
       continue;
     }
     $createdBy = !$tables->display_name ? '' : ' (' . E::ts('created by %1', [1 => $tables->display_name]) . ')';


### PR DESCRIPTION
Overview
----------------------------------------
Handle NULL in table name check

Before
----------------------------------------
The check for whether it is an alpha numeric string passes on `NULL`

After
----------------------------------------
`NULL` considered as it's own condition

Technical Details
----------------------------------------
This is probably not replicable in normal use. It caught me out trying to do some dev on import extensions

Comments
----------------------------------------
