### PR TITLE
dev/drupal#133 - Remove bad and unnecessary breadcrumb on Domain Contact info form

### DIFF
--- a/CRM/Contact/Form/Domain.php
+++ b/CRM/Contact/Form/Domain.php
@@ -64,8 +64,6 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
 
   public function preProcess() {
     $this->setTitle(ts('Organization Address and Contact Info'));
-    $breadCrumbPath = CRM_Utils_System::url('civicrm/admin', 'reset=1');
-    CRM_Utils_System::appendBreadCrumb(ts('Administer'), $breadCrumbPath);
     $session = CRM_Core_Session::singleton();
     $session->replaceUserContext(CRM_Utils_System::url('civicrm/admin', 'reset=1'));
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/drupal/-/issues/133

This also affects standalone, and is actually worse since it's a fatal.

Before
----------------------------------------
1. Go to Admin - Communications - Org Info (which by the way is the first thing the status check tells you to do on a new install).
2. On drupal 8, screen has a warning about foreach() argument must be of type array|object, string given. On standalone it's the same type of thing but it's a fatal error about argument 1 must be of type array, string given.

After
----------------------------------------
Ok

Technical Details
----------------------------------------
1. This is an unnecessary breadcrumb because it's already there, and in fact fixing it causes it to show a duplicate on drupal 7 (where it's not an error before the patch because its version of addBreadcrumb ignores bad input).
2. It's passing in two args instead of what the function is expecting: one arg that's an array of arrays: `[['title' => ts('Administer'), 'url' => $breadCrumbPath]]`

Comments
----------------------------------------
Wordpress and joomla appear to do the same as drupal 7.
