### PR TITLE
[php8.x] Fully remove interaction with `_params` from backoffice participant form

### DIFF
--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -404,7 +404,6 @@
               <td colspan="2" {$valueStyle}>
                 {$credit_card_type}<br/>
                 {$credit_card_number}<br/>
-                {ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}
               </td>
             </tr>
           {/if}


### PR DESCRIPTION

Overview
----------------------------------------
This removes the last places _params was accessed & adds a comment to switch to __get for any external access to it. 
We can't quite do that in this commit as there is one place in  a shared function that sets a different undeclared property  - we can tackle that by unsharing that function in https://github.com/civicrm/civicrm-core/pull/28646 & then removing it from the unshared function 

Note this also removes the expiry date from the template. I can't find the discussion we had about this (maybe on chat) but it was generally agreed that since we hadn't added a column for this in the DB it made sense to exclude from the template (as the template should be the same however it is sent). There was some difference of opinion about whether it should have stored in the DB though

Before
----------------------------------------
`_params` is hardly used in this form & it is hard to know what it 'means' as it has no clear contract but it still causes php 8.x errors

After
----------------------------------------
By removing it & offering up a `__get` external callers have space to transition off this method to a supported method to get the submitted values

Technical Details
----------------------------------------
The only thing that was still in use that was accessing `_params` was the template assignments for the workflow template - these are slated for removal in favour of tokens but for now the assignment is just moved into the form

Comments
----------------------------------------
