### PR TITLE
Unshare `buildAmount` block functions from front_end form

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -2181,7 +2181,6 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
     $optionFullTotalAmount = 0;
     $currentParticipantNo = (int) substr($form->_name, 12);
     foreach ($form->_feeBlock as & $field) {
-      $optionFullIds = [];
       $fieldId = $field['id'];
       if (!is_array($field['options'])) {
         continue;
@@ -2200,15 +2199,9 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
             (empty($form->_lineItem[$currentParticipantNo][$optId]['price_field_id']) || $dbTotalCount >= $maxValue))
         ) {
           $isFull = TRUE;
-          $optionFullIds[$optId] = $optId;
-          if ($field['html_type'] != 'Select') {
+          if ($field['html_type'] !== 'Select') {
             if (in_array($optId, $defaultPricefieldIds)) {
               $optionFullTotalAmount += $option['amount'] ?? 0;
-            }
-          }
-          else {
-            if (!empty($defaultPricefieldIds) && in_array($optId, $defaultPricefieldIds)) {
-              unset($optionFullIds[$optId]);
             }
           }
         }

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -618,8 +618,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         // public AND admin visibility fields are included for back-office registration and back-office change selections
         if (($field['visibility'] ?? NULL) == 'public' ||
           (($field['visibility'] ?? NULL) == 'admin' && $adminFieldVisible == TRUE) ||
-          $className == 'CRM_Event_Form_Participant' ||
-          $className === 'CRM_Event_Form_Task_Register' ||
           $className == 'CRM_Event_Form_ParticipantFeeSelection'
         ) {
           $fieldId = $field['id'];
@@ -632,7 +630,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
 
           //user might modified w/ hook.
           $options = $field['options'] ?? NULL;
-          $formClasses = ['CRM_Event_Form_Participant', 'CRM_Event_Form_Task_Register', 'CRM_Event_Form_ParticipantFeeSelection'];
+          $formClasses = ['CRM_Event_Form_ParticipantFeeSelection'];
 
           if (!is_array($options)) {
             continue;
@@ -681,10 +679,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
 
           //CRM-7632, CRM-6201
           $totalAmountJs = NULL;
-          if ($className == 'CRM_Event_Form_Participant' || $className === 'CRM_Event_Form_Task_Register') {
-            $totalAmountJs = ['onClick' => "fillTotalAmount(" . $fee['value'] . ")"];
-          }
-
           $eventFeeBlockValues['amount_id_' . $fee['amount_id']] = $fee['value'];
           $elements[$fee['amount_id']] = CRM_Utils_Money::format($fee['value']) . ' ' . $fee['label'];
           $elementJS[$fee['amount_id']] = $totalAmountJs;
@@ -793,11 +787,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         $option['is_full'] = $isFull;
         $option['db_total_count'] = $dbTotalCount;
         $option['total_option_count'] = $dbTotalCount + $currentTotalCount;
-      }
-
-      //ignore option full for offline registration.
-      if ($className == 'CRM_Event_Form_Participant' || $className === 'CRM_Event_Form_Task_Register') {
-        $optionFullIds = [];
       }
 
       //finally get option ids in.


### PR DESCRIPTION

Overview
----------------------------------------
Unshare `buildAmount` block functions from front_end form

Before
----------------------------------------
The back office & front end event forms are working really hard to share code

After
----------------------------------------
The functions are copied to the back office event form, allowing simplification to follow

Technical Details
----------------------------------------
Sharing these functions complicates rather than simplifies. We are setting & un-setting a lot of random things... to keep the stack of cards upright

Comments
----------------------------------------
