### PR TITLE
Move implementation of financial type acl out of core (leverage existing extension hooks)

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -239,6 +239,13 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
     }
 
+    if ($this->_action & CRM_Core_Action::UPDATE && !Contribution::checkAccess()
+      ->setAction('update')
+      ->addValue('id', $this->getContributionID())
+      ->execute()->first()['access']) {
+      CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
+    }
+
     parent::preProcess();
 
     $this->_formType = $_GET['formType'] ?? NULL;
@@ -579,18 +586,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         ],
       ]);
       return;
-    }
-
-    // FIXME: This probably needs to be done in preprocess
-    if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()
-      && $this->_action & CRM_Core_Action::UPDATE
-      && !empty($this->_values['financial_type_id'])
-    ) {
-      $financialTypeID = CRM_Contribute_PseudoConstant::financialType($this->_values['financial_type_id']);
-      CRM_Financial_BAO_FinancialType::checkPermissionedLineItems($this->_id, 'edit');
-      if (!CRM_Core_Permission::check('edit contributions of type ' . $financialTypeID)) {
-        CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
-      }
     }
     $allPanes = [];
 

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -250,13 +250,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
       // check for is_monetary status
       $isMonetary = $this->getEventValue('is_monetary');
-      // check for ability to add contributions of type
-      if ($isMonetary
-        && CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()
-        && !CRM_Core_Permission::check('add contributions of type ' . CRM_Contribute_PseudoConstant::financialType($this->_values['event']['financial_type_id']))
-      ) {
-        CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
-      }
 
       $this->checkValidEvent();
       // get the participant values, CRM-4320

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -347,7 +347,7 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType im
   /**
    * Function to check if lineitems present in a contribution have permissioned FTs.
    *
-   * @deprecated since 5.68 not part of core - to be handled within financialacls extension
+   * @deprecated since 5.68 not part of core - to be removed 5.74
    *
    * @param int $id
    *   contribution id
@@ -359,6 +359,7 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType im
    * @return bool
    */
   public static function checkPermissionedLineItems($id, $op, $force = TRUE, $contactID = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning('use financial acls extension');
     if (!self::isACLFinancialTypeStatus()) {
       return TRUE;
     }

--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -311,7 +311,7 @@ function _civicrm_financial_acls_check_permissioned_line_items($id, $op, $force 
   $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($id);
   $flag = FALSE;
   foreach ($lineItems as $items) {
-    if (!CRM_Core_Permission::check($op . ' contributions of type ' . CRM_Contribute_PseudoConstant::financialType($items['financial_type_id']), $contactID)) {
+    if (!CRM_Core_Permission::check($op . ' contributions of type ' . CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'financial_type_id', $items['financial_type_id']), $contactID)) {
       if ($force) {
         throw new CRM_Core_Exception(ts('You do not have permission to access this page.'));
       }
@@ -420,7 +420,7 @@ function financialacls_civicrm_alterMenu(array &$menu): void {
 
 /**
  * @param string $formName
- * @param \CRM_Core_Form $form
+ * @param \CRM_Event_Form_Registration|\CRM_Contribute_Form_Contribution $form
  */
 function financialacls_civicrm_preProcess(string $formName, \CRM_Core_Form $form): void {
   if (!financialacls_is_acl_limiting_enabled()) {
@@ -431,6 +431,14 @@ function financialacls_civicrm_preProcess(string $formName, \CRM_Core_Form $form
     if (!CRM_Core_Permission::check('add contributions of type ' . $form->getContributionPageValue('financial_type_id:name'))) {
       CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
     }
+  }
+
+  // check for ability to add contributions of type
+  if (str_starts_with($formName, 'CRM_Event_Form_Registration_') && $form->getEventValue('is_monetary')
+    && !CRM_Core_Permission::check(
+      'add contributions of type ' . CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'financial_type_id', $form->getEventValue('financial_type_id')))
+  ) {
+    CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
   }
 
 }

--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -458,25 +458,23 @@ function financialacls_civicrm_links(string $op, ?string $objectName, $objectID,
   }
   if ($objectName === 'Contribution') {
     // Now check for lineItems
-    if (Civi::settings()->get('acl_financial_type')) {
-      $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID((int) $objectID);
-      foreach ($lineItems as $item) {
-        $financialType = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'financial_type_id', $item['financial_type_id']);
-        if (!CRM_Core_Permission::check('view contributions of type ' . $financialType)) {
-          // Remove all links & early return for this contribution if there is an un-viewable financial type.
-          $links = [];
-          return;
-        }
-        if (!CRM_Core_Permission::check('edit contributions of type ' . $financialType)) {
-          unset($links[CRM_Core_Action::UPDATE]);
-        }
-        if (!CRM_Core_Permission::check('delete contributions of type ' . $financialType)) {
-          unset($links[CRM_Core_Action::DELETE]);
-        }
+    $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID((int) $objectID);
+    foreach ($lineItems as $item) {
+      $financialType = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'financial_type_id', $item['financial_type_id']);
+      if (!CRM_Core_Permission::check('view contributions of type ' . $financialType)) {
+        // Remove all links & early return for this contribution if there is an un-viewable financial type.
+        $links = [];
+        return;
       }
-      $financialTypeID = $values['financial_type_id'] ?? CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $objectID, 'financial_type_id');
-      $financialType = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'financial_type_id', $financialTypeID);
+      if (!CRM_Core_Permission::check('edit contributions of type ' . $financialType)) {
+        unset($links[CRM_Core_Action::UPDATE]);
+      }
+      if (!CRM_Core_Permission::check('delete contributions of type ' . $financialType)) {
+        unset($links[CRM_Core_Action::DELETE]);
+      }
     }
+    $financialTypeID = $values['financial_type_id'] ?? CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $objectID, 'financial_type_id');
+    $financialType = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'financial_type_id', $financialTypeID);
   }
 
   if (!empty($financialType)) {

--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -447,6 +447,31 @@ function financialacls_civicrm_links(string $op, ?string $objectName, $objectID,
   }
   if ($objectName === 'MembershipType') {
     $financialType = CRM_Core_PseudoConstant::getName('CRM_Member_BAO_MembershipType', 'financial_type_id', CRM_Member_BAO_MembershipType::getMembershipType($objectID)['financial_type_id']);
+  }
+  if ($objectName === 'Contribution') {
+    // Now check for lineItems
+    if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()) {
+      $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID((int) $objectID);
+      foreach ($lineItems as $item) {
+        $financialType = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'financial_type_id', $item['financial_type_id']);
+        if (!CRM_Core_Permission::check('view contributions of type ' . $financialType)) {
+          // Remove all links & early return for this contribution if there is an un-viewable financial type.
+          $links = [];
+          return;
+        }
+        if (!CRM_Core_Permission::check('edit contributions of type ' . $financialType)) {
+          unset($links[CRM_Core_Action::UPDATE]);
+        }
+        if (!CRM_Core_Permission::check('delete contributions of type ' . $financialType)) {
+          unset($links[CRM_Core_Action::DELETE]);
+        }
+      }
+      $financialTypeID = $values['financial_type_id'] ?? CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $objectID, 'financial_type_id');
+      $financialType = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'financial_type_id', $financialTypeID);
+    }
+  }
+
+  if (!empty($financialType)) {
     $hasEditPermission = CRM_Core_Permission::check('edit contributions of type ' . $financialType);
     $hasDeletePermission = CRM_Core_Permission::check('delete contributions of type ' . $financialType);
     if (!$hasDeletePermission || !$hasEditPermission) {

--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -458,7 +458,7 @@ function financialacls_civicrm_links(string $op, ?string $objectName, $objectID,
   }
   if ($objectName === 'Contribution') {
     // Now check for lineItems
-    if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()) {
+    if (Civi::settings()->get('acl_financial_type')) {
       $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID((int) $objectID);
       foreach ($lineItems as $item) {
         $financialType = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'financial_type_id', $item['financial_type_id']);

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialTypeTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialTypeTest.php
@@ -78,7 +78,7 @@ class FinancialTypeTest extends BaseTestClass {
   }
 
   /**
-   * Check method testCheckPermissionedLineItems()
+   * Check method test_civicrm_financial_acls_check_permissioned_line_items()
    *
    * @throws \CRM_Core_Exception
    */
@@ -139,7 +139,7 @@ class FinancialTypeTest extends BaseTestClass {
     ]);
 
     try {
-      \CRM_Financial_BAO_FinancialType::checkPermissionedLineItems($contribution['id'], 'view');
+      _civicrm_financial_acls_check_permissioned_line_items($contribution['id'], 'view');
       $this->fail('Missed expected exception');
     }
     catch (\CRM_Core_Exception $e) {
@@ -150,7 +150,7 @@ class FinancialTypeTest extends BaseTestClass {
       'view contributions of type Donation',
     ]);
     try {
-      \CRM_Financial_BAO_FinancialType::checkPermissionedLineItems($contribution['id'], 'view');
+      _civicrm_financial_acls_check_permissioned_line_items($contribution['id'], 'view');
     }
     catch (\CRM_Core_Exception $e) {
       $this->fail('permissions should be established');


### PR DESCRIPTION
Overview
----------------------------------------
Move implementation of financial type acl out of core (leverage existing extension hooks)

Before
----------------------------------------
Advisor user needs access to civicontribute, view all contacts & edit & delete in civicontribute + some financial acl permissions per 
![image](https://github.com/civicrm/civicrm-core/assets/336308/547494ec-33db-4c4b-81a8-76bb15a8628a)

After
----------------------------------------
No behaviour change - screen shots are just to demonstrate r-run results

The UI is awful - but unchanged here - see the status warning...
![image](https://github.com/civicrm/civicrm-core/assets/336308/22951ff1-58bc-4441-8b24-74d2de31b2f9)

For edit I further removed edit permission on event & could load the event edit page for Donation but not Event Fee

![image](https://github.com/civicrm/civicrm-core/assets/336308/07c29142-c987-4439-8e0f-86b17a56a5c9)

For the links - you can see the different links available for donations vs event fees here

![image](https://github.com/civicrm/civicrm-core/assets/336308/dacde54b-2409-49bb-9649-f0edae6f3adf)

Behaviour when attempting to access an event that is not permitted
![image](https://github.com/civicrm/civicrm-core/assets/336308/d5517311-8284-4439-8548-d361fbef22d8)


Technical Details
----------------------------------------
I confirmed that only the 2 contributions were deleted per the advice - but that part is unchanged anyway

Comments
----------------------------------------
