### PR TITLE
Fix notices on tasks for less permissioned user

### DIFF
--- a/CRM/Event/Task.php
+++ b/CRM/Event/Task.php
@@ -151,13 +151,13 @@ class CRM_Event_Task extends CRM_Core_Task {
     }
     else {
       $tasks = [
-        self::TASK_EXPORT => self::$_tasks[self::TASK_EXPORT]['title'],
-        self::TASK_EMAIL => self::$_tasks[self::TASK_EMAIL]['title'],
+        self::TASK_EXPORT => self::tasks()[self::TASK_EXPORT]['title'],
+        self::TASK_EMAIL => self::tasks()[self::TASK_EMAIL]['title'],
       ];
 
       //CRM-4418,
       if (CRM_Core_Permission::check('delete in CiviEvent')) {
-        $tasks[self::TASK_DELETE] = self::$_tasks[self::TASK_DELETE]['title'];
+        $tasks[self::TASK_DELETE] = self::tasks()[self::TASK_DELETE]['title'];
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix notices on tasks for less permissioned user

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/7a15b8c6-670e-4aa4-9c38-aad7e96f30d0)

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/4c6a2207-0aac-4a4c-8278-1d8aa4cf1c56)

Technical Details
----------------------------------------
tasks not populated until `getTasks()` is called

Comments
----------------------------------------
