### PR TITLE
Remove extraneous call to check financial acl

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -662,17 +662,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     if (!is_array($eventFee) || empty($eventFee)) {
       $form->_values['fee'] = [];
     }
-    if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()
-      && !empty($form->_values['fee'])
-    ) {
-      foreach ($form->_values['fee'] as $k => $fees) {
-        foreach ($fees['options'] as $options) {
-          if (!CRM_Core_Permission::check('add contributions of type ' . CRM_Contribute_PseudoConstant::financialType($options['financial_type_id']))) {
-            unset($form->_values['fee'][$k]);
-          }
-        }
-      }
-    }
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Remove extraneous call to check financial acl

BuildAmount hook already does this

Before
----------------------------------------
Code in core specifically removes the option limited by the financial acl -ie 2 out of 3 show because the user does not have access to the 3rd  later buildAmount hook is called but does nothing as it has been removed
![image](https://github.com/civicrm/civicrm-core/assets/336308/e03b66c0-3c30-4561-9474-4fa7b9cae741)

After
----------------------------------------
Relies on buildAmount

You can see that of the 2 options only 2 are visible due to the acl having been activated in the build hook

![image](https://github.com/civicrm/civicrm-core/assets/336308/59abd0f5-f693-4a88-afac-05d33ac8f30a)

Technical Details
----------------------------------------

Comments
----------------------------------------
