### PR TITLE
Fix rc-only regression where submitting back office contribution with a price set selected fatals

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -611,16 +611,9 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       ($this->_priceSetId || !empty($_POST['price_set_id']))
     ) {
       $buildPriceSet = TRUE;
-      $getOnlyPriceSetElements = TRUE;
-      if (!$this->_priceSetId) {
-        $this->_priceSetId = $_POST['price_set_id'];
-        $getOnlyPriceSetElements = FALSE;
-      }
-
       $this->buildPriceSet();
-
-      // get only price set form elements.
-      if ($getOnlyPriceSetElements) {
+      if (!$this->isSubmitted()) {
+        // This is being called in overload mode to render the price set.
         return;
       }
     }
@@ -2402,13 +2395,19 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
   /**
    * Get the price set ID.
    *
-   * Note that the function currently returns NULL if not submitted
-   * but will over time be fixed to always return an ID.
+   * @api Supported for external use.
    *
    * @return int|null
    */
-  protected function getPriceSetID() {
-    return $this->getSubmittedValue('price_set_id') ?: CRM_Utils_Request::retrieve('priceSetId', 'Integer');
+  public function getPriceSetID(): ?int {
+    $priceSetID = $this->getSubmittedValue('price_set_id') ?: CRM_Utils_Request::retrieve('priceSetId', 'Integer');
+    // Ideally we would use $this->isFormBuilt() here to know when to access the _POST
+    // array directly. However, the parent sets isBuilt before, building the form,
+    // rather than after.
+    if (!$priceSetID && !empty($this->getSubmitValue('price_set_id'))) {
+      return (int) $this->getSubmitValue('price_set_id');
+    }
+    return $priceSetID ?? NULL;
   }
 
   /**

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -712,6 +712,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * buildQuickForm.
    */
   public function buildForm() {
+    // @todo - move this to the end of the function - then it can be checked
+    // ie $this->isBuilt() to determine whether variables are not yet in getSubmittedValues()
     $this->_formBuilt = TRUE;
 
     $this->preProcess();

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -678,7 +678,7 @@ WHERE  id = %1";
       [$params, $lineItem] = self::getLine($params, $lineItem, $priceSetID, $field, $id);
     }
     $order = new CRM_Financial_BAO_Order();
-    $order->setLineItems($lineItem);
+    $order->setLineItems((array) $lineItem);
     $params['amount_level'] = $order->getAmountLevel();
     $params['amount'] = $order->getTotalAmount();
     $params['tax_amount'] = $order->getTotalTaxAmount();


### PR DESCRIPTION

Overview
----------------------------------------
Fix rc-only regression where submitting back office contribution with a price set selected fatals

Before
----------------------------------------
When submitting a back-office contribution & selecting a price set it fails to pick up the `priceSetID()`  & crashes

After
----------------------------------------
In the buildForm stage it looks in `submitValue()`- which is basically `_POST` since it's too soon for `getSubmittedValues()`

Technical Details
----------------------------------------
rc-only issue

Comments
----------------------------------------
