### PR TITLE
Standardise fetching of variables on recur management screens

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -384,6 +384,7 @@ SELECT rec.id                   as recur_id,
        mp.membership_id";
 
     if ($entity == 'recur') {
+      // This should be always true now.
       $sql .= "
       FROM civicrm_contribution_recur rec
 LEFT JOIN civicrm_contribution       con ON ( con.contribution_recur_id = rec.id )
@@ -391,6 +392,7 @@ LEFT  JOIN civicrm_membership_payment mp  ON ( mp.contribution_id = con.id )
      WHERE rec.id = %1";
     }
     elseif ($entity == 'contribution') {
+      CRM_Core_Error::deprecatedWarning('no longer used');
       $sql .= "
       FROM civicrm_contribution       con
 INNER JOIN civicrm_contribution_recur rec ON ( con.contribution_recur_id = rec.id )
@@ -398,6 +400,7 @@ LEFT  JOIN civicrm_membership_payment mp  ON ( mp.contribution_id = con.id )
      WHERE con.id = %1";
     }
     elseif ($entity == 'membership') {
+      CRM_Core_Error::deprecatedWarning('no longer used');
       $sql .= "
       FROM civicrm_membership_payment mp
 INNER JOIN civicrm_membership         mem ON ( mp.membership_id = mem.id )

--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -30,7 +30,7 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Contribute_Form_Contribution
    */
   public function preProcess() {
     parent::preProcess();
-    if ($this->_crid) {
+    if ($this->getContributionRecurID()) {
       // Are we cancelling a recurring contribution that is linked to an auto-renew membership?
       if ($this->getSubscriptionDetails()->membership_id) {
         $this->_mid = $this->getSubscriptionDetails()->membership_id;


### PR DESCRIPTION
Overview
----------------------------------------
Standardise fetching of variables on recur management screens

Before
----------------------------------------
Maze of properties

After
----------------------------------------
This switches to use the standardised methods we have been implementing across forms - notably

`getContributionRecurID()`
`getContributionID()`
`getMembershipID()`

and the associated `getContributionRecurValue()`, `getContributionValue()` `getMembershipValue()`. These latter functions use the new lazy-load Entity lookup trait - which means they can retrieve any apiv4 style values if the former are defined.

The `getContributionRecurID()` now works a bit harder & ensures it figures out the recurring contribution ID regardless of whether a contribution ID, a recurring contribution ID or a membership ID has been provided - allowing us to remove some of the handling lower down

Technical Details
----------------------------------------

This is really the guts of the change 
https://github.com/civicrm/civicrm-core/pull/28652/files#diff-d647851f675f2f40df83eefc66b687f9d5f12ff8958de36c77b16499542f99eaR197-R205

All the rest is either cleanup that ^^ enables or setting up the standard functions in line with the other existing variants of `getXValue()`

Comments
----------------------------------------
