### PR TITLE
RelationshipCache - Add status check to ensure cache table is up-to-date

### DIFF
--- a/Civi/Api4/Action/RelationshipCache/Rebuild.php
+++ b/Civi/Api4/Action/RelationshipCache/Rebuild.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\RelationshipCache;
+
+/**
+ * Rebuild contents of the `civicrm_relationship_cache` table.
+ */
+class Rebuild extends \Civi\Api4\Generic\AbstractAction {
+
+  public function _run(\Civi\Api4\Generic\Result $result) {
+    \CRM_Contact_BAO_RelationshipCache::rebuild();
+  }
+
+}

--- a/Civi/Api4/RelationshipCache.php
+++ b/Civi/Api4/RelationshipCache.php
@@ -42,6 +42,15 @@ class RelationshipCache extends Generic\AbstractEntity {
   }
 
   /**
+   * @param bool $checkPermissions
+   * @return Action\RelationshipCache\Rebuild
+   */
+  public static function rebuild($checkPermissions = TRUE) {
+    return (new Action\RelationshipCache\Rebuild(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
    * @return array
    */
   public static function getInfo() {

--- a/ang/crmStatusPage/StatusPageCtrl.js
+++ b/ang/crmStatusPage/StatusPageCtrl.js
@@ -57,6 +57,11 @@
             case 'api3':
               refresh([action.params], action.title);
               break;
+
+            case 'api4':
+              $('#crm-status-list').block();
+              CRM.api4([action.params]).then(() => refresh());
+              break;
           }
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
We get occasional bug reports [like this one](https://civicrm.stackexchange.com/questions/46082/relationships-no-longer-working-as-expected-data-corruption), where for unknown reasons the RelationshipCache is not populated. This adds a check with an easy way to fix the problem:

![image](https://github.com/civicrm/civicrm-core/assets/2874912/b14ff55f-8b8b-498c-9af3-15496410b2f3)


Comments
-------
The rebuild action lacks pagination, so may time-out on very large databases (they would need to run it via cli instead).