### PR TITLE
Advanced search UX regression - collapses search criteria when there's results

### DIFF
--- a/templates/CRM/Contact/Form/Search/Advanced.tpl
+++ b/templates/CRM/Contact/Form/Search/Advanced.tpl
@@ -13,7 +13,7 @@
 
   {include file="CRM/Contact/Form/Search/Intro.tpl"}
 
-  <details class="crm-advanced_search_form-accordion" {if $rows}{else}open{/if} >
+  <details class="crm-advanced_search_form-accordion" {if !$rows}open{/if} >
     <summary class="crm-master-accordion-header">
       {if !empty($savedSearch)}
         {ts 1=$savedSearch.name}Edit %1 Smart Group Criteria{/ts}

--- a/templates/CRM/Contact/Form/Search/Advanced.tpl
+++ b/templates/CRM/Contact/Form/Search/Advanced.tpl
@@ -13,7 +13,7 @@
 
   {include file="CRM/Contact/Form/Search/Intro.tpl"}
 
-  <details class="crm-advanced_search_form-accordion" open>
+  <details class="crm-advanced_search_form-accordion" {if $rows}{else}open{/if} >
     <summary class="crm-master-accordion-header">
       {if !empty($savedSearch)}
         {ts 1=$savedSearch.name}Edit %1 Smart Group Criteria{/ts}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes 5.69 regression example 1, described [here](https://lab.civicrm.org/dev/core/-/issues/4856,), introduced [here](https://github.com/civicrm/civicrm-core/pull/28418/files).

Before
----------------------------------------
> Advanced search
> - Open contributions tab and search for an id like 30 that you know exists.
> - It finds the results, but all the criteria are still open. It didn't used to do that because now you have to scroll all the way down. (Compare to Find Contributions which still collapses after finding results.)

After
----------------------------------------
If the search has results the main criteria accordion is closed. Otherwise, if there are no results, or the page is loaded for the first time, the criteria are open.

![image](https://github.com/civicrm/civicrm-core/assets/1175967/d8780f87-f427-4f9b-9763-92fe26a61a97)
