### PR TITLE
Fixes advanced Search UX regression - keeps criteria with data open

### DIFF
--- a/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
+++ b/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
@@ -69,6 +69,13 @@ CRM.$(function($) {
       body.html('<div class="crm-loading-element"><span class="loading-text">{/literal}{ts escape='js'}Loading{/ts}{literal}...</span></div>');
       header.append('{/literal}<a href="#" class="crm-close-accordion crm-hover-button css_right" title="{ts escape='js'}Remove from search criteria{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>{literal}');
       header.addClass('active');
+      const summaries = document.querySelectorAll('summary.active');
+      summaries.forEach(function (summary) {
+            const details = summary.parentNode;
+            if (details && details.tagName === 'DETAILS') {
+                details.setAttribute('open', 'open');
+            }
+        });
       CRM.loadPage(url, {target: body, block: false});
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes regression Example 2 described here: https://lab.civicrm.org/dev/core/-/issues/4856.

Before
----------------------------------------
> Advanced search
> Open contributions tab and search for an id like -1 or 10000 that you know doesn't exist.
> It used to redisplay the form showing no results but with the contributions tab open so you could see what you had selected.

After
----------------------------------------
It keeps the tabs that are active (ie have been opened/edited) open.

![image](https://github.com/civicrm/civicrm-core/assets/1175967/6479a13c-49bd-44b1-bb76-4e962de35ba4)

Technical Details
----------------------------------------
This JS was written by ChatGPT3.5, but it makes sense to me, and works. However no offense if this PR is rejected for this reason alone!