### PR TITLE
Fixes two advanced search accordions UX regressions

### DIFF
--- a/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
+++ b/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
@@ -24,7 +24,6 @@ CRM.$(function($) {
     var header = $(this).parent();
     header.next().html('');
     header.removeClass('active');
-    header.parent('.crm-ajax-accordion:not(.collapsed)').crmAccordionToggle();
     // Reset results-display mode if it depends on this pane
     var mode = modes[$('#component_mode').val()] || null;
     if (mode && header.attr('id') == mode) {
@@ -72,6 +71,8 @@ CRM.$(function($) {
       CRM.loadPage(url, {target: body, block: false});
     }
   }
+  // Keeps the detail/accordion of 'active' fieldsets open after a search
+  $('summary.active').parent('details').attr('open', '');
 });
 </script>
 {/literal}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes regression Example 2 & 3 described here: https://lab.civicrm.org/dev/core/-/issues/4856.

Before
----------------------------------------
Fieldsets with values in them that define a search are closed after a search.
A further problem (example 3 in the linked issue) sees fieldsets that are 'deactivated' via the right hand close button, not be able to open again.

After
----------------------------------------
Both these problems should be fixed

![image](https://github.com/civicrm/civicrm-core/assets/1175967/427ab31b-87e0-4155-8399-7f5623521509)

Technical Details
----------------------------------------
Example 3 was this resolved by the removed line (which doesn't seem to be needed as the AccordionToggle has been replaced with `<details>`).
Example 2 was fixed with the additional line. This was written with LLM support. Flagging in the interest of code health/disclosure. PR has been tested but more tests in different environments welcome.