### PR TITLE
REF - Swap CRM_Utils_Array::collect with vanilla array_column

### DIFF
--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -456,8 +456,8 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Core\
       $caseType = new CRM_Case_DAO_CaseType();
       $caseType->id = $event->id;
       $refCounts = $caseType->getReferenceCounts();
-      $total = array_sum(CRM_Utils_Array::collect('count', $refCounts));
-      if (array_sum(CRM_Utils_Array::collect('count', $refCounts))) {
+      $total = array_sum(array_column($refCounts, 'count'));
+      if ($total) {
         throw new CRM_Core_Exception(ts("You can not delete this case type -- it is assigned to %1 existing case record(s). If you do not want this case type to be used going forward, consider disabling it instead.", [1 => $total]));
       }
     }

--- a/CRM/Contact/Form/Edit/TagsAndGroups.php
+++ b/CRM/Contact/Form/Edit/TagsAndGroups.php
@@ -171,7 +171,7 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
       $contactGroup = CRM_Contact_BAO_GroupContact::getContactGroup($id, 'Added', NULL, FALSE, TRUE, FALSE, TRUE, NULL, TRUE);
       if ($contactGroup) {
         if ($groupElementType == 'select') {
-          $defaults[$fName] = implode(',', CRM_Utils_Array::collect('group_id', $contactGroup));
+          $defaults[$fName] = implode(',', array_column($contactGroup, 'group_id'));
         }
         else {
           foreach ($contactGroup as $group) {

--- a/Civi/Api4/Action/Queue/RunItems.php
+++ b/Civi/Api4/Action/Queue/RunItems.php
@@ -56,7 +56,7 @@ class RunItems extends \Civi\Api4\Generic\AbstractAction {
     if (!empty($this->items)) {
       $this->validateItemStubs();
       $queue = \Civi::queue($this->items[0]['queue']);
-      $ids = \CRM_Utils_Array::collect('id', $this->items);
+      $ids = array_column($this->items, 'id');
       if (count($ids) > 1 && !($queue instanceof \CRM_Queue_Queue_BatchQueueInterface)) {
         throw new \CRM_Core_Exception("runItems: Error: Running multiple items requires BatchQueueInterface");
       }

--- a/Civi/Api4/Generic/BasicReplaceAction.php
+++ b/Civi/Api4/Generic/BasicReplaceAction.php
@@ -95,7 +95,7 @@ class BasicReplaceAction extends AbstractBatchAction {
     }
 
     $idField = $this->getSelect()[0];
-    $toDelete = array_diff_key(array_column($items, NULL, $idField), array_flip(array_filter(\CRM_Utils_Array::collect($idField, $this->records))));
+    $toDelete = array_diff_key(array_column($items, NULL, $idField), array_flip(array_column($this->records, $idField)));
 
     $saveAction = \Civi\API\Request::create($this->getEntityName(), 'save', ['version' => 4]);
     $saveAction

--- a/tests/phpunit/CRM/Activity/Form/Task/PDFTest.php
+++ b/tests/phpunit/CRM/Activity/Form/Task/PDFTest.php
@@ -51,7 +51,7 @@ class CRM_Activity_Form_Task_PDFTest extends CiviUnitTestCase {
     $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['activityId']]);
 
     $this->assertEquals(array_merge($this->getActivityTokens(), CRM_Core_SelectValues::domainTokens()), $tokenProcessor->listTokens());
-    $html_message = "\n" . implode("\n", CRM_Utils_Array::collect('0', $data)) . "\n";
+    $html_message = "\n" . implode("\n", array_column($data, '0')) . "\n";
     $form = $this->getFormObject('CRM_Activity_Form_Task_PDF');
     try {
       $output = $form->createDocument([$activity['id']], $html_message, []);


### PR DESCRIPTION
Overview
----------------------------------------
Minor refactor to use vanilla php function instead of in-house function when the swap was easy.

Technical Details
----------------------------------------
The only difference between these functions (when only passed 2 params) is the order of the params, and the fact that `array_column` does not preserve keys. So `CRM_Utils_Array::collect` can be swapped out 1-1 with `array_column` anywhere that the keys don't matter to the return value.