### PR TITLE
[PHP8] Remove unneeded $this->_context in Case_Page_Tab

### DIFF
--- a/CRM/Case/Page/Tab.php
+++ b/CRM/Case/Page/Tab.php
@@ -43,7 +43,6 @@ class CRM_Case_Page_Tab extends CRM_Core_Page {
     }
 
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     if ($this->_contactId) {
       $this->assign('contactId', $this->_contactId);


### PR DESCRIPTION
Overview
----------------------------------------
`Creation of dynamic property CRM_Case_Page_Tab::$_context is deprecated in CRM_Case_Page_Tab->preProcess()`

Before
----------------------------------------
1. Visit e.g. Manage Case, or it also happens visiting the cases tab of a contact but there it's ajax so it's a bit hidden.

After
----------------------------------------


Technical Details
----------------------------------------
This "page" is never visited standalone, and everywhere else that's related that I can find the context gets set there, and links here get created with the correct context in the url so the other places pick it up. E.g. go to a contact cases tab and click Manage for a case, then click Done. It still goes back to the contact's cases tab.

Comments
----------------------------------------

