### PR TITLE
Set formBuilt to TRUE when, erm, it is built

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -2401,10 +2401,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
    */
   public function getPriceSetID(): ?int {
     $priceSetID = $this->getSubmittedValue('price_set_id') ?: CRM_Utils_Request::retrieve('priceSetId', 'Integer');
-    // Ideally we would use $this->isFormBuilt() here to know when to access the _POST
-    // array directly. However, the parent sets isBuilt before, building the form,
-    // rather than after.
-    if (!$priceSetID && !empty($this->getSubmitValue('price_set_id'))) {
+    if (!$this->isFormBuilt() && !empty($this->getSubmitValue('price_set_id'))) {
       return (int) $this->getSubmitValue('price_set_id');
     }
     return $priceSetID ?? NULL;

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -726,10 +726,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * buildQuickForm.
    */
   public function buildForm() {
-    // @todo - move this to the end of the function - then it can be checked
-    // ie $this->isBuilt() to determine whether variables are not yet in getSubmittedValues()
-    $this->_formBuilt = TRUE;
-
     $this->preProcess();
 
     CRM_Utils_Hook::preProcess(get_class($this), $this);
@@ -787,6 +783,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     // it's already been initialized.
     self::$_template->ensureVariablesAreAssigned($this->expectedSmartyVariables);
     self::$_template->addExpectedTabHeaderKeys();
+    $this->_formBuilt = TRUE;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Set formBuilt to TRUE when, erm, it is built

Before
----------------------------------------
the buildForm function sets isBuilt to TRUE before it starts

After
----------------------------------------
it sets isBuilt to TRUE when it has finished building the form

Technical Details
----------------------------------------
The primary use case for `isBuilt` is for determining whether to call `buildForm` as in the screenshot (which is an 'after' as it includes the code change to use it). However, in some cases the functions that it calls can benefit from knowing whether the form has been built or not at the time they are being called.

When the form has been built then all the elements (fields) will have been added to the form so the correct place to look for values is `getSubmittedValues()` or a variant of that. However, when the form is still being built (e.g earlier in the build process) the value will not be there & while we have various hacks to decide when to access `_POST` or `_submitValues` directly it would be cleaner to check `isFormBuilt()`

![image](https://github.com/civicrm/civicrm-core/assets/336308/ad2faadc-143c-4ed8-b590-d9adb4ca6a7c)


Comments
----------------------------------------
