### PR TITLE
dev/core#3344 Fix probable regression on frequency unit handling in 5.69

### DIFF
--- a/CRM/Core/Payment/Dummy.php
+++ b/CRM/Core/Payment/Dummy.php
@@ -223,7 +223,9 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
     // does this, it needs to invoke this hook after it has done translation,
     // but before it actually starts talking to its proprietary back-end.
     if ($propertyBag->getIsRecur()) {
-      $throwAnENoticeIfNotSetAsTheseAreRequired = $propertyBag->getRecurFrequencyInterval() . $propertyBag->getRecurFrequencyUnit();
+      if (empty($params['frequency_interval']) || empty($params['frequency_unit'])) {
+        CRM_Core_Error::deprecatedWarning('contracted frequency params not passed');
+      }
     }
     // no translation in Dummy processor
     CRM_Utils_Hook::alterPaymentProcessorParams($this, $params, $propertyBag);


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#3344 Fix regression on frequency unit handling in 5.69

Regression found testing [dev/core#3344 ](https://lab.civicrm.org/dev/core/-/issues/3810)  follow up fix will also addresses that bug but I'm doing a jenkins dance to get test cover to work

Before
----------------------------------------
hard error with frequency not set in payment params
![image](https://github.com/civicrm/civicrm-core/assets/336308/46283d7d-0b49-4b54-b49f-195c3d14ca1f)

After
----------------------------------------
This PR just degrades it from a fatal to deprecated - I'm separately fixing tests / values passed but need to do some rounds of fighting jenkins

Technical Details
----------------------------------------

Comments
----------------------------------------
