### PR TITLE
Fix test setup method towards enhancing test cover for rc regression

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1860,10 +1860,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       // @todo deprecate receiving amount, calculate on the form.
       $form->order->setOverrideTotalAmount((float) $params['amount']);
     }
-    $amount = $form->order->getTotalAmount();
-    if ($form->isSeparateMembershipPayment()) {
-      $amount -= $form->order->getMembershipTotalAmount();
-    }
     // hack these in for test support.
     $form->_fields['billing_first_name'] = 1;
     $form->_fields['billing_last_name'] = 1;

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -923,8 +923,9 @@ class CRM_Financial_BAO_Order {
         if ($valueID !== '') {
           $this->setPriceSetIDFromSelectedField($fieldID);
           $throwAwayArray = [];
+          $temporaryParams = $params;
           // @todo - still using getLine for now but better to bring it to this class & do a better job.
-          $newLines = CRM_Price_BAO_PriceSet::getLine($params, $throwAwayArray, $this->getPriceSetID(), $this->getPriceFieldSpec($fieldID), $fieldID)[1];
+          $newLines = CRM_Price_BAO_PriceSet::getLine($temporaryParams, $throwAwayArray, $this->getPriceSetID(), $this->getPriceFieldSpec($fieldID), $fieldID)[1];
           foreach ($newLines as $newLine) {
             $lineItems[$newLine['price_field_value_id']] = $newLine;
           }

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -378,7 +378,12 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
       'is_test' => FALSE,
     ]);
     $contributionPageID = $this->createContributionPage(['payment_processor' => $paymentProcessorID], FALSE);
-    $this->setUpMembershipBlockPriceSet(['minimum_fee' => 1000]);
+
+    if (empty($this->ids['MembershipType'])) {
+      $membershipTypeParams = ['minimum_fee' => 1000];
+      $this->ids['MembershipType'] = [$this->membershipTypeCreate($membershipTypeParams)];
+    }
+    $this->setUpMembershipBlockPriceSet();
     $this->createTestEntity('PriceSetEntity', [
       'entity_table' => 'civicrm_contribution_page',
       'entity_id' => $contributionPageID,

--- a/tests/phpunit/CRMTraits/Financial/PriceSetTrait.php
+++ b/tests/phpunit/CRMTraits/Financial/PriceSetTrait.php
@@ -152,12 +152,10 @@ trait CRMTraits_Financial_PriceSetTrait {
    * page with non-quick config membership and an optional
    * additional contribution non-membership amount.
    *
-   * @param array $membershipTypeParams
-   *
    * @noinspection PhpDocMissingThrowsInspection
    * @noinspection PhpUnhandledExceptionInspection
    */
-  protected function setUpMembershipBlockPriceSet(array $membershipTypeParams = []): void {
+  protected function setUpMembershipBlockPriceSet(): void {
     $this->ids['PriceSet']['membership_block'] = PriceSet::create(FALSE)
       ->setValues([
         'is_quick_config' => TRUE,
@@ -167,12 +165,6 @@ trait CRMTraits_Financial_PriceSetTrait {
       ])
       ->execute()->first()['id'];
 
-    if (empty($this->ids['MembershipType'])) {
-      $membershipTypeParams = array_merge([
-        'minimum_fee' => 2,
-      ], $membershipTypeParams);
-      $this->ids['MembershipType'] = [$this->membershipTypeCreate($membershipTypeParams)];
-    }
     $priceField = $this->callAPISuccess('PriceField', 'create', [
       'price_set_id' => $this->ids['PriceSet']['membership_block'],
       'name' => 'membership_amount',

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -992,7 +992,13 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
    *   MembershipType.create API
    */
   public function setUpMembershipContributionPage(bool $isSeparatePayment = FALSE, bool $isRecur = FALSE, array $membershipTypeParams = []): void {
-    $this->setUpMembershipBlockPriceSet($membershipTypeParams);
+    if (empty($this->ids['MembershipType'])) {
+      $membershipTypeParams = array_merge([
+        'minimum_fee' => 2,
+      ], $membershipTypeParams);
+      $this->ids['MembershipType'] = [$this->membershipTypeCreate($membershipTypeParams)];
+    }
+    $this->setUpMembershipBlockPriceSet();
     $this->setupPaymentProcessor();
     $contributionPageParameters = !$isRecur ? [] : [
       'is_recur' => TRUE,

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -300,8 +300,8 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     $mut = new CiviMailUtils($this, TRUE);
     $this->setUpMembershipContributionPage(TRUE);
     $submitParams = [
-      $this->getPriceFieldLabel('contribution') => 1,
-      $this->getPriceFieldLabel('membership') => $this->getPriceFieldValue('general'),
+      'price_' . $this->ids['PriceField']['other_amount'] => 1,
+      $this->getPriceFieldLabel('membership_amount') => $this->getPriceFieldValue('general'),
       'id' => $this->getContributionPageID(),
       'billing_first_name' => 'Billy',
       'billing_middle_name' => 'Goat',
@@ -340,8 +340,8 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     $this->ids['MembershipType'] = [$this->membershipTypeCreate(['minimum_fee' => 2])];
     //Pay later
     $submitParams = [
-      $this->getPriceFieldLabel('contribution') => 1,
-      $this->getPriceFieldLabel('membership') => $this->getPriceFieldValue('general'),
+      $this->getPriceFieldLabel('other_amount') => 1,
+      $this->getPriceFieldLabel('membership_amount') => $this->getPriceFieldValue('general'),
       'id' => $this->getContributionPageID(),
       'billing_first_name' => 'Billy',
       'billing_middle_name' => 'Goat',
@@ -998,22 +998,11 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       ], $membershipTypeParams);
       $this->ids['MembershipType'] = [$this->membershipTypeCreate($membershipTypeParams)];
     }
-    $this->setUpMembershipBlockPriceSet();
-    $this->setupPaymentProcessor();
     $contributionPageParameters = !$isRecur ? [] : [
       'is_recur' => TRUE,
       'recur_frequency_unit' => 'month',
     ];
-    $this->setUpContributionPage($contributionPageParameters, ['id' => $this->getPriceSetID('membership_block')]);
-
-    $this->callAPISuccess('MembershipBlock', 'create', [
-      'entity_id' => $this->getContributionPageID(),
-      'entity_table' => 'civicrm_contribution_page',
-      'is_required' => TRUE,
-      'is_active' => TRUE,
-      'is_separate_payment' => $isSeparatePayment,
-      'membership_type_default' => $this->ids['MembershipType'],
-    ]);
+    $this->contributionPageQuickConfigCreate($contributionPageParameters, [], $isSeparatePayment, TRUE, TRUE, TRUE);
   }
 
   /**
@@ -1520,7 +1509,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
    */
   private function getSubmitParamsContributionPlusMembership(bool $isCardPayment = FALSE, string $membershipType = 'general'): array {
     $params = $this->getSubmitParamsMembership($isCardPayment, $membershipType);
-    $params[$this->getPriceFieldLabel('contribution')] = 1;
+    $params['price_' . $this->ids['PriceField']['other_amount']] = 88;
     return $params;
   }
 
@@ -1534,7 +1523,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
    */
   protected function getSubmitParamsMembership(bool $isCardPayment = FALSE, string $membershipType = 'general'): array {
     $params = [
-      $this->getPriceFieldLabel('membership') => $this->getPriceFieldValue($membershipType),
+      'price_' . $this->ids['PriceField']['membership_amount'] => $this->ids['PriceFieldValue']['membership_' . $membershipType],
       'id' => $this->getContributionPageID(),
       'billing_first_name' => 'Billy',
       'billing_middle_name' => 'Goat',


### PR DESCRIPTION
Overview
----------------------------------------
Fix test setup method towards enhancing test cover for rc regression

Before
----------------------------------------
Tests not catching a regression & set up is non-standard

After
----------------------------------------
Set up more standard - still working on actually addressing the issue

Technical Details
----------------------------------------
The changes outside the test class are

1) update to test-only submit function 
2) fix a call in the order class to make it clear the pass-by-reference aspect only leads to throw away changes
Both of these are things that confused me in making this change

Comments
----------------------------------------
