### PR TITLE
Stop ignoring tests when apiv4 function does not exist

### DIFF
--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -515,8 +515,6 @@ trait Api3TestTrait {
       $actionInfo = \civicrm_api4($v4Entity, 'getActions', ['checkPermissions' => FALSE, 'where' => [['name', '=', $v4Action]]]);
     }
     catch (NotImplementedException $e) {
-      // For now we'll mark the test incomplete if a v4 entity doesn't exit yet
-      $this->markTestIncomplete($e->getMessage());
     }
     if (!isset($actionInfo[0])) {
       throw new \Exception("Api4 $v4Entity $v4Action does not exist.");

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -670,7 +670,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     $this->getContributionPageID());
 
     $contribution = $this->callAPISuccessGetSingle('Contribution', ['contribution_page_id' => $this->getContributionPageID()]);
-    $this->callAPISuccessGetSingle('MembershipPayment', ['contribution_id' => $contribution['id'], 'version' => 3]);
+    $this->callAPISuccessGetSingle('MembershipPayment', ['version' => 3, 'contribution_id' => $contribution['id']]);
     //Assert only one mail is being sent.
     $this->assertMailSentCount(1);
     $this->assertMailSentContainingStrings([


### PR DESCRIPTION
Overview
----------------------------------------
Stop ignoring tests when apiv4 function does not exist

Before
----------------------------------------
I discovered some tests are not running due to this....

After
----------------------------------------

Technical Details
----------------------------------------

Comments
----------------------------------------
