### PR TITLE
[php8.x] Remove unused undeclared property `_params`, provide __get for transitional support

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -322,7 +322,6 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
         $paramSubType = implode(',', $contactSubType);
       }
 
-      $this->_getCachedTree = FALSE;
       unset($customGroupCount[0]);
       foreach ($customGroupCount as $groupID => $groupCount) {
         if ($groupCount > 1) {
@@ -330,7 +329,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
           //loop the group
           for ($i = 1; $i <= $groupCount; $i++) {
             CRM_Custom_Form_CustomData::preProcess($this, NULL, $contactSubType,
-              $i, $this->_contactType, $this->_contactId
+              $i, $this->_contactType, $this->_contactId, NULL, FALSE
             );
             CRM_Contact_Form_Edit_CustomData::buildQuickForm($this);
           }

--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -235,6 +235,24 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
   protected $invoiceID;
 
   /**
+   * Provide support for extensions that are used to being able to retrieve _lineItem
+   *
+   * Note extension should call getPriceSetID() and getLineItems() directly.
+   * They are supported for external use per the api annotation.
+   *
+   * @param string $name
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function __get($name) {
+    if ($name === '_params') {
+      CRM_Core_Error::deprecatedWarning('attempt to access undefined property _params - use externally supported function getSubmittedValues()');
+      return $this->getSubmittedValues();
+    }
+    CRM_Core_Error::deprecatedWarning('attempt to access invalid property :' . $name);
+  }
+
+  /**
    * Get the unique invoice ID.
    *
    * This is generated if one has not already been generated.

--- a/CRM/Custom/Form/CustomData.php
+++ b/CRM/Custom/Form/CustomData.php
@@ -72,15 +72,16 @@ class CRM_Custom_Form_CustomData {
    *   participant data this could be a value representing role.
    * @param null|string $subType
    * @param null|int $groupCount
-   * @param string $type
+   * @param null $type
    * @param null|int $entityID
    * @param null $onlySubType
+   * @param bool $isLoadFromCache
    *
    * @throws \CRM_Core_Exception
    */
   public static function preProcess(
     &$form, $extendsEntityColumn = NULL, $subType = NULL,
-    $groupCount = NULL, $type = NULL, $entityID = NULL, $onlySubType = NULL
+    $groupCount = NULL, $type = NULL, $entityID = NULL, $onlySubType = NULL, $isLoadFromCache = TRUE
   ) {
     if (!$type) {
       CRM_Core_Error::deprecatedWarning('type should be passed in');
@@ -131,7 +132,6 @@ class CRM_Custom_Form_CustomData {
     }
 
     $gid = (isset($form->_groupID)) ? $form->_groupID : NULL;
-    $getCachedTree = $form->_getCachedTree ?? TRUE;
     if (!is_array($subType) && str_contains(($subType ?? ''), CRM_Core_DAO::VALUE_SEPARATOR)) {
       CRM_Core_Error::deprecatedWarning('Using a CRM_Core_DAO::VALUE_SEPARATOR separated subType deprecated, use a comma-separated string instead.');
       $subType = str_replace(CRM_Core_DAO::VALUE_SEPARATOR, ',', trim($subType, CRM_Core_DAO::VALUE_SEPARATOR));
@@ -154,7 +154,7 @@ class CRM_Custom_Form_CustomData {
       $gid,
       $subType,
       $extendsEntityColumn,
-      $getCachedTree,
+      $isLoadFromCache,
       $onlySubType,
       FALSE,
       CRM_Core_Permission::EDIT,

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -876,9 +876,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     if ($this->_isPaidEvent) {
       [$lineItem, $params] = $this->preparePaidEventProcessing($params);
     }
-    // @todo - params is unused - remove in favour of __get
-    // but there is another parameter we need to fix first.
-    $this->_params = $params;
     // @todo - stop assigning these - pass financial_trxnId in token context
     // and swap template to use tokens.
     $this->assign('credit_card_type', $this->getSubmittedValue('credit_card_type'));


### PR DESCRIPTION

Overview
----------------------------------------
[php8.x] Remove unused undeclared property `_params`, provide __get for transitional support

Before
----------------------------------------
undeclared property `_params` is set but unused

After
----------------------------------------
property is gone, however, transitional support is provided through `__get`

Technical Details
----------------------------------------

Comments
----------------------------------------
