### PR TITLE
Fix Event iCalendar regression

### DIFF
--- a/CRM/Event/ICalendar.php
+++ b/CRM/Event/ICalendar.php
@@ -54,10 +54,7 @@ class CRM_Event_ICalendar {
     $config = CRM_Core_Config::singleton();
 
     $template->assign('events', $info);
-
-    $timezones = [@date_default_timezone_get()];
-
-    $template->assign('timezone', $timezones[0]);
+    $template->assign('timezone', date_default_timezone_get());
 
     // Send data to the correct template for formatting (iCal vs. gData)
     if ($rss) {


### PR DESCRIPTION
Overview
----------------------------------------
Attempts to generate iCal files fail with a fatal error.

Before
----------------------------------------
```
TypeError: CRM_Utils_ICalendar::generate_timezones(): Argument #1 ($timezones) must be of type array, null given, called in /var/www/mysite/web/sites/all/modules/civicrm/CRM/Utils/ICalendar.php on line 248 in CRM_Utils_ICalendar::generate_timezones() (line 169 of /var/www/mysite/web/sites/all/modules/civicrm/CRM/Utils/ICalendar.php).
```

After
----------------------------------------
iCal file generated successfully.

Technical Details
----------------------------------------
PR #26980 introduced a regression in Civi 5.68 by refactoring some code into a new function but not passing a required variable into the new function.

Comments
----------------------------------------
I suspect this entire function was copy-pasted from somewhere, since it handles the possibility of an array of timezones, but we only ever pass in the results of `date_default_timezone_get()` which is a string.  We wrapped it in an array, but instead I just removed array handling.

I also remove handling of empty timezones because `date_default_timezone_get()` always returns a timezone.

If we had PHPStan running in our CI this would never have been merged (since we passed an uninitialized variable to a function that requires an array).  I'm hopeful that the release of standalone will allow us to use PHPStan in our CI to catch these regressions in the future.