### PR TITLE
Remove parent-declared properties

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -37,16 +37,7 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
 
   public $_action;
 
-  public $_bltID;
-
   public $_fields = [];
-
-  /**
-   * Current payment processor including a copy of the object in 'object' key.
-   *
-   * @var array
-   */
-  public $_paymentProcessor;
 
   /**
    * Available recurring processors.


### PR DESCRIPTION
Overview
----------------------------------------
Remove parent-declared properties

Before
----------------------------------------
Now I've switched to php7.4 in my IDE it hatest stuff like this

![image](https://github.com/civicrm/civicrm-core/assets/336308/d08ed4c9-2e0f-4537-815d-31620c483152)

After
----------------------------------------
We don't need to declare these - the parent does

Technical Details
----------------------------------------

Comments
----------------------------------------
