### PR TITLE
Revert "Remove parent-declared properties"

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -37,7 +37,16 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
 
   public $_action;
 
+  public $_bltID;
+
   public $_fields = [];
+
+  /**
+   * Current payment processor including a copy of the object in 'object' key.
+   *
+   * @var array
+   */
+  public $_paymentProcessor;
 
   /**
    * Available recurring processors.


### PR DESCRIPTION
Reverts civicrm/civicrm-core#28703

This is being weird - it was on the parent - honest guv - but now I'm not so sure - back out for now