### PR TITLE
Fix dev/core#4813: CRM_Report_Form_Activity: Add Employer fields, and…

### DIFF
--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -1158,6 +1158,12 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    */
   public function testActivityDetails(): void {
     $this->createContactsWithActivities();
+    // Add employers for created contacts.
+    foreach ($this->contactIDs as $i => $contactID) {
+      $organizationIDs[] = $organizationID = $this->organizationCreate(['organization_name' => 'Test Organization ' . $i]);
+      $this->callAPISuccess('Contact', 'create', ['id' => $contactID, 'employer_id' => $organizationID]);
+    }
+
     $fields = [
       'contact_source' => '1',
       'contact_assignee' => '1',
@@ -1210,8 +1216,8 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     $rows = $this->callAPISuccess('report_template', 'getrows', $params)['values'];
     $expected = [
       'civicrm_contact_contact_source' => 'Łąchowski-Roberts, Anthony II',
-      'civicrm_contact_contact_assignee' => '<a title=\'View Contact Summary for this Contact\' href=\'/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=4\'>Łąchowski-Roberts, Anthony II</a>',
-      'civicrm_contact_contact_target' => '<a title=\'View Contact Summary for this Contact\' href=\'/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=3\'>Brzęczysław, Anthony II</a>; <a title=\'View Contact Summary for this Contact\' href=\'/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=4\'>Łąchowski-Roberts, Anthony II</a>',
+      'civicrm_contact_contact_assignee' => '<a title=\'View Contact Summary for this Contact\' href=\'/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=' . $this->contactIDs[1] . '\'>Łąchowski-Roberts, Anthony II</a>',
+      'civicrm_contact_contact_target' => '<a title=\'View Contact Summary for this Contact\' href=\'/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=' . $this->contactIDs[0] . '\'>Brzęczysław, Anthony II</a>; <a title=\'View Contact Summary for this Contact\' href=\'/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=' . $this->contactIDs[1] . '\'>Łąchowski-Roberts, Anthony II</a>',
       'civicrm_contact_contact_source_id' => $this->contactIDs[2],
       'civicrm_contact_contact_assignee_id' => $this->contactIDs[1],
       'civicrm_contact_contact_target_id' => $this->contactIDs[0] . ';' . $this->contactIDs[1],
@@ -1249,6 +1255,9 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
       'civicrm_contact_contact_source_hover' => 'View Contact Summary for this Contact',
       'civicrm_activity_activity_type_id_hover' => 'View Activity Record',
       'class' => NULL,
+      'civicrm_contact_contact_source_employer_id' => $organizationIDs[2],
+      'civicrm_contact_contact_assignee_employer_id' => $organizationIDs[1],
+      'civicrm_contact_contact_target_employer_id' => $organizationIDs[0] . ';' . $organizationIDs[1],
     ];
     $row = $rows[0];
     // This link is not relative - skip for now


### PR DESCRIPTION
… "contact"-based custom fields:

Overview
----------------------------------------
Per original issue: https://lab.civicrm.org/dev/core/-/issues/4813:

Changes to the CiviCRM core "Activity Detail" report (CRM_Report_Form_Activity):
* add "Current Employer" as an available column (not filter), to display with its Display Name, as a link to the employer contact
* auto-include "contact"-based custom fields (currently only "individual"-based custom fields get this treatment)

Before
----------------------------------------
1. Custom fields are only available if they are configured for Individual-type contacts
2. "Employer" columns not available for any of the contacts listed in this report (target / source / assignee)

After
----------------------------------------
1. Custom fields are available (as column and as filter) if they are configured any (or no) contact types
![custom](https://github.com/civicrm/civicrm-core/assets/759449/8cf88e8d-0662-46ca-a131-9d1304afc482)

2. "Employer" columns are available for all of the contacts listed in this report (target / source / assignee)
![columns1](https://github.com/civicrm/civicrm-core/assets/759449/b47116a1-8dd1-425b-9d63-a983e586acdd)

![columns2](https://github.com/civicrm/civicrm-core/assets/759449/93db1c1c-4e19-48c0-b37d-128b3cc06324)

Technical Details
----------------------------------------
@eileenmcnaughton suggested emulating `CRM_Report_Form_Contribute_Detail` as the preferred way to add employer columns to a report. However, `CRM_Report_Form_Activity` is pretty unique in its inclusion of contact data related to source / target / assignee contacts. So, I instead opted to emulate this report does that already for other related data, e.g. phone.

Comments
----------------------------------------
@colemanw noted that there's no plan to continue improving core reports but that such a PR would be considered if offered.
