### PR TITLE
Fix PHP warning if status_id not set in FinancialProcessor

### DIFF
--- a/CRM/Contribute/BAO/FinancialProcessor.php
+++ b/CRM/Contribute/BAO/FinancialProcessor.php
@@ -88,7 +88,7 @@ class CRM_Contribute_BAO_FinancialProcessor {
         'currency' => $currency,
         'amount' => self::getFinancialItemAmountFromParams($inputParams, $context, $lineItemDetails, $isARefund, $previousLineItemTotal),
         'description' => $prevFinancialItem['description'] ?? NULL,
-        'status_id' => $prevFinancialItem['status_id'],
+        'status_id' => $prevFinancialItem['status_id'] ?? NULL,
         'financial_account_id' => $financialAccount,
         'entity_table' => 'civicrm_line_item',
         'entity_id' => $lineItemDetails['id'],


### PR DESCRIPTION
Overview
----------------------------------------
Fix PHP warning

Before
----------------------------------------
Warning if unset

After
----------------------------------------
Ok to be unset

Technical Details
----------------------------------------
FinancialItem['status_id'] will be unset if a contribution is created and does not have one of the statuses hardcoded in `CRM_Financial_BAO_FinancialItem::add()`.
So for example when a template contribution is created `CRM_Financial_BAO_FinancialItem::add()` is called and sets FinancialItem.status_id = NULL.

CRM_Contribute_BAO_FinancialProcessor::createFinancialItemsForLine() then triggers a PHP warning because `$prevFinancialItem['status_id']` is not set.


Comments
----------------------------------------
Note comment in DB for FinancialItem::status_id: "Payment status: test, paid, part_paid, unpaid (if empty assume unpaid)"
