### PR TITLE
Add test cover for Dummy warnings

### DIFF
--- a/CRM/Core/Payment/Dummy.php
+++ b/CRM/Core/Payment/Dummy.php
@@ -223,7 +223,9 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
     // does this, it needs to invoke this hook after it has done translation,
     // but before it actually starts talking to its proprietary back-end.
     if ($propertyBag->getIsRecur()) {
-      $throwAnENoticeIfNotSetAsTheseAreRequired = $propertyBag->getRecurFrequencyInterval() . $propertyBag->getRecurFrequencyUnit();
+      if (empty($params['frequency_interval']) || empty($params['frequency_unit'])) {
+        CRM_Core_Error::deprecatedWarning('contracted frequency params not passed');
+      }
     }
     // no translation in Dummy processor
     CRM_Utils_Hook::alterPaymentProcessorParams($this, $params, $propertyBag);

--- a/CRM/Core/Payment/Dummy.php
+++ b/CRM/Core/Payment/Dummy.php
@@ -216,18 +216,18 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
       $result['payment_status'] = 'Completed';
       return $result;
     }
-
+    // Warn it the contracted variables are not provided
+    // The list is at https://docs.civicrm.org/dev/en/latest/extensions/payment-processors/paymentclass/#recurring-contribution-parameters
+    if ($propertyBag->getIsRecur()) {
+      if (empty($params['frequency_interval']) || empty($params['frequency_unit']) || empty($params['is_recur'])) {
+        CRM_Core_Error::deprecatedWarning('contracted frequency params not passed');
+      }
+    }
     // Invoke hook_civicrm_paymentProcessor
     // In Dummy's case, there is no translation of parameters into
     // the back-end's canonical set of parameters.  But if a processor
     // does this, it needs to invoke this hook after it has done translation,
     // but before it actually starts talking to its proprietary back-end.
-    if ($propertyBag->getIsRecur()) {
-      if (empty($params['frequency_interval']) || empty($params['frequency_unit'])) {
-        CRM_Core_Error::deprecatedWarning('contracted frequency params not passed');
-      }
-    }
-    // no translation in Dummy processor
     CRM_Utils_Hook::alterPaymentProcessorParams($this, $params, $propertyBag);
     // This means we can test failing transactions by setting a past year in expiry. A full expiry check would
     // be more complete.

--- a/tests/phpunit/CRM/Financial/BAO/PaymentProcessorTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/PaymentProcessorTest.php
@@ -10,12 +10,18 @@
  */
 
 use Civi\Api4\PaymentProcessor;
+use Civi\Payment\PropertyBag;
 
 /**
  * Class CRM_Financial_BAO_PaymentProcessorTypeTest
  * @group headless
  */
 class CRM_Financial_BAO_PaymentProcessorTest extends CiviUnitTestCase {
+
+  public function tearDown(): void {
+    $this->quickCleanup(['civicrm_payment_processor']);
+    parent::tearDown();
+  }
 
   /**
    * Check method create()
@@ -89,6 +95,8 @@ class CRM_Financial_BAO_PaymentProcessorTest extends CiviUnitTestCase {
 
   /**
    * Test the Manual processor supports 'NoEmailProvided'
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testManualProcessorSupportsNoEmailProvided(): void {
     $processors = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessors(['NoEmailProvided']);
@@ -100,6 +108,71 @@ class CRM_Financial_BAO_PaymentProcessorTest extends CiviUnitTestCase {
       }
     }
     $this->assertTrue($found, 'The Manual payment processor should support "NoEmailProvided"');
+  }
+
+  /**
+   * Test that deprecation warnings are emitted when required recur params not present
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
+   */
+  public function testDummyCheckArrayAccess(): void {
+    $this->dummyProcessorCreate();
+    $processor = Civi\Payment\System::singleton()->getById($this->ids['PaymentProcessor']['dummy']);
+    $parameters = ['amount' => 100, 'is_recur' => TRUE];
+    try {
+      $processor->doPayment($parameters);
+    }
+    catch (Exception $e) {
+      $this->assertEquals('contracted frequency params not passed Caller: CRM_Financial_BAO_PaymentProcessorTest::testDummyCheckArrayAccess', $e->getMessage());
+    }
+  }
+
+  /**
+   * Test that deprecation warnings are emitted when required recur params not present
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
+   */
+  public function testDummyCheckPropertyBag(): void {
+    $this->dummyProcessorCreate();
+    $processor = \Civi\Payment\System::singleton()->getById($this->ids['PaymentProcessor']['dummy']);
+    $parameters = ['amount' => 100, 'is_recur' => TRUE];
+    $parameters = PropertyBag::cast($parameters);
+    try {
+      $processor->doPayment($parameters);
+    }
+    catch (Exception $e) {
+      $this->assertEquals('contracted frequency params not passed Caller: CRM_Financial_BAO_PaymentProcessorTest::testDummyCheckPropertyBag', $e->getMessage());
+    }
+  }
+
+  /**
+   * Test that deprecation warnings are emitted when required recur params are present
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
+   */
+  public function testDummyCheckArrayAccessWithParams(): void {
+    $this->dummyProcessorCreate();
+    $processor = Civi\Payment\System::singleton()->getById($this->ids['PaymentProcessor']['dummy']);
+    $parameters = ['amount' => 100, 'is_recur' => TRUE, 'frequency_unit' => 'month', 'frequency_interval' => 1];
+    $parameters = PropertyBag::cast($parameters);
+    $processor->doPayment($parameters);
+  }
+
+  /**
+   * Test that deprecation warnings are emitted when required recur params are present
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
+   */
+  public function testDummyCheckPropertyBagWithParams(): void {
+    $this->dummyProcessorCreate();
+    $processor = Civi\Payment\System::singleton()->getById($this->ids['PaymentProcessor']['dummy']);
+    $parameters = ['amount' => 100, 'is_recur' => TRUE, 'frequency_unit' => 'month', 'frequency_interval' => 1];
+    $parameters = PropertyBag::cast($parameters);
+    $processor->doPayment($parameters);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Add test cover for Dummy warnings

Before
----------------------------------------
This builds on https://github.com/civicrm/civicrm-core/pull/28684 - the goal is to demonstrate that the deprecations when done this way trigger for both the contracted array access variables & the `propertyBag` where that might be passed in

After
----------------------------------------
test cover added

Technical Details
----------------------------------------

Comments
----------------------------------------
