### PR TITLE
Fix month date string format support in imports

### DIFF
--- a/tests/phpunit/CRM/Utils/DateTest.php
+++ b/tests/phpunit/CRM/Utils/DateTest.php
@@ -2712,7 +2712,12 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
       '10/1/2022 15:54:56' => ['date' => '10/1/2022 15:54:56', 'format' => CRM_Utils_Date::DATE_mm_dd_yyyy, 'expected' => '20221001155456'],
 
       // DATE_Month_dd_yyyy ie December, 12 2023
-      'December, 12 2023' => ['date' => 'December, 12 2023', 'format' => CRM_Utils_Date::DATE_Month_dd_yyyy, 'expected' => '20221001035456', 'ignore_reason' => 'Example syntax is broken. Investigate'],
+      'December, 11 2023' => ['date' => 'December, 11 2023', 'format' => CRM_Utils_Date::DATE_Month_dd_yyyy, 'expected' => '20231211000000'],
+      'December, 1 2023' => ['date' => 'December, 1 2023', 'format' => CRM_Utils_Date::DATE_Month_dd_yyyy, 'expected' => '20231201000000'],
+      'December, 1 23' => ['date' => 'December, 1 23', 'format' => CRM_Utils_Date::DATE_Month_dd_yyyy, 'expected' => '20231201000000'],
+      'December,  1 2023-with-tab' => ['date' => "December,\t1 2023", 'format' => CRM_Utils_Date::DATE_Month_dd_yyyy, 'expected' => '20231201000000'],
+      'December 1 2023-no-comma' => ['date' => 'December 1 2023', 'format' => CRM_Utils_Date::DATE_Month_dd_yyyy, 'expected' => '20231201000000'],
+      'December 1 2023 15:35:35' => ['date' => 'December 1 2023 15:35:35', 'format' => CRM_Utils_Date::DATE_Month_dd_yyyy, 'expected' => '20231201153535'],
 
       // dd_mon_yy format (NZ, Australia) - eg. 01-10-22 or 01/10/22 WHERE 01 is the DAY. 2 digit year.
       '01/10/22' => ['date' => '01/10/22', 'format' => CRM_Utils_Date::DATE_dd_mon_yy, 'expected' => '20221001000000'],
@@ -2728,8 +2733,6 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
       '1/10/2022' => ['date' => '1/10/2022', 'format' => CRM_Utils_Date::DATE_dd_mm_yyyy, 'expected' => '20221001000000'],
       '1/10/2022 15:54:56' => ['date' => '1/10/2022 15:54:56', 'format' => CRM_Utils_Date::DATE_dd_mm_yyyy, 'expected' => '20221001155456'],
       '1/10/2022 3:54:56' => ['date' => '1/10/2022 3:54:56', 'format' => CRM_Utils_Date::DATE_dd_mm_yyyy, 'expected' => '20221001035456'],
-      '1-Oct-2022 15:54:56' => ['date' => '1-Oct-2022 15:54:56', 'format' => CRM_Utils_Date::DATE_dd_mm_yyyy, 'expected' => '20221001155456', 'ignore_reason' => 'Time not handled correctly in this instance.'],
-      '1-Oct-2022 3:54:56' => ['date' => '1-Oct-2022 3:54:56', 'format' => CRM_Utils_Date::DATE_dd_mm_yyyy, 'expected' => '20221001035456', 'ignore_reason' => 'Time not handled correctly in this instance.'],
       '1-10-2022 15:54:56' => ['date' => '1-10-2022 15:54:56', 'format' => CRM_Utils_Date::DATE_dd_mm_yyyy, 'expected' => '20221001155456'],
       '1-10-2022 3:54:56' => ['date' => '1-10-2022 3:54:56', 'format' => CRM_Utils_Date::DATE_dd_mm_yyyy, 'expected' => '20221001035456'],
     ];


### PR DESCRIPTION
Overview
----------------------------------------
Fix month string format support in imports

Before
----------------------------------------
In writing tests for how the dates should work I found that the declared syntax for `DATE_Month_dd_yyyy` - December, 12 2023
didn't actually work. For the sake so completeness I felt it should. 

After
----------------------------------------
In digging into the code I found handling (at least in the regex) for a string month followed by a comma or white space and then a numeric month and 4 digit year.  I fixed to make this work along with the variants (single digit month, 2 digit year) that work in other places. 

In addition I found that the regex would block any non-a-z characters so I switched the regex to use a list of locale-appropriate months.

Technical Details
----------------------------------------
Unit tests added ...

Comments
----------------------------------------
