### PR TITLE
dev/core#3810 dev/core#3339 Fix handling of auto renew memberships where frequency_interval > 1

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1162,8 +1162,10 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       // If membership_num_terms is not specified on the the price field value (which seems not uncommon
       // in default config) then the membership type provides the values.
       // @todo - access the line item value from $this->getLineItems() rather than _values['fee']
-      $this->_params['frequency_interval'] = $this->getSubmittedValue('frequency_interval') ?? ($this->_values['fee'][$priceFieldId]['options'][$priceFieldValue]['membership_num_terms'] ?? ($membershipTypeDetails['duration_interval'] ?? 1));
-      $this->_params['frequency_unit'] = $this->_params['frequency_unit'] ?? $membershipTypeDetails['duration_unit'];
+      $membershipNumTerms = $this->_values['fee'][$priceFieldId]['options'][$priceFieldValue]['membership_num_terms'] ?? 1;
+      $membershipDurationInterval = $membershipTypeDetails['duration_interval'] ?? 1;
+      $this->_params['frequency_interval'] = $this->getSubmittedValue('frequency_interval') ?? ($membershipNumTerms * $membershipDurationInterval);
+      $this->_params['frequency_unit'] = $this->getSubmittedValue('frequency_unit') ?? $membershipTypeDetails['duration_unit'];
     }
     // This seems like it repeats the above with less care...
     elseif (!$this->_separateMembershipPayment && ($membershipTypeDetails['auto_renew'] === 2


### PR DESCRIPTION
Overview
----------------------------------------
Fix handling of auto renew memberships where frequency_interval > 1

For more support of this interpretation see https://lab.civicrm.org/dev/core/-/issues/3752
https://lab.civicrm.org/dev/core/-/issues/3339

https://lab.civicrm.org/dev/core/-/issues/3810

And another one... https://github.com/civicrm/civicrm-core/pull/26895/files

Before
----------------------------------------
When you configure a price set with an auto-renew where the duration is greater than 1 then depending on whether `civicrm_price_field_value.membership_num_terms` is populated (which is inconsistent in my testing) then  when you sign up for this membership you may get 1 month or 2 months

![image](https://github.com/civicrm/civicrm-core/assets/336308/04167072-35c8-4d1e-b50c-36aae048bda4)

After
----------------------------------------
Unless the frequency_unit is offered up to be selected on the form you get the value on the `membership_type.duration_unit` * the value in `civicrm_price_field_value.membership_num_terms` - with both defaulting to 1 if not set


Technical Details
----------------------------------------
It is possible through UI configuration to wind up with either NULL or 1 in `civicrm_price_field_value.membership_num_terms` when the price set is configured (without specifically editing the membership) - I'm not 100% sure the steps to get NULL vs 1 - only that I got NULL and @totten got 1. It seems like the membership term is '2 months' and membership_num_terms is 'how many 2 month terms'

Note that the `qty` field is never exposed for the membership type options - they are always radio or select or check box and I think bad things would happen is someone attempted to hack that so we should see that as not-supporte

Comments
----------------------------------------
As there are related fixes including https://lab.civicrm.org/dev/core/-/issues/3344 already in 5.69 I have put this against 5.69. If we do not merge to 5.69 I don't think we should consider merging to master for several months because there is a large amount of change in code related to this flow in 5.69 & I don't want master diverging as that will make it hard to manage any regression fixes.
