### PR TITLE
SearchKit - Support non-contact multi-record custom groups

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -282,10 +282,11 @@ class Admin {
   public static function getJoins(array $allowedEntities):array {
     $joins = [];
     foreach ($allowedEntities as $entity) {
-      // Multi-record custom field groups (to-date only the contact entity supports these)
+      // Multi-record custom field groups
       if (in_array('CustomValue', $entity['type'])) {
-        // TODO: Lookup target entity from custom group if someday other entities support multi-record custom data
-        $targetEntity = $allowedEntities['Contact'];
+        // Get `extends` entity of custom group
+        $entityIdField = \CRM_Utils_Array::findAll($entity['fields'], ['name' => 'entity_id'])[0];
+        $targetEntity = $allowedEntities[$entityIdField['fk_entity']];
         // Join from Custom group to Contact (n-1)
         $alias = "{$entity['name']}_{$targetEntity['name']}_entity_id";
         $joins[$entity['name']][] = [


### PR DESCRIPTION
Overview
----------------------------------------
Makes SearchKit more flexible in supporting different types of multi-record custom groups.


Technical Details
----------------------------------------
Fixes a TODO, gets custom group 'extends' info from the metadata instead of hard-coding it.

Uses the metadata added in https://github.com/civicrm/civicrm-core/pull/27549