### PR TITLE
Allow searchkit joins via EntityRef fields in multivalue custom data

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -282,10 +282,10 @@ class Admin {
   public static function getJoins(array $allowedEntities):array {
     $joins = [];
     foreach ($allowedEntities as $entity) {
-      $isCustomEntity = in_array('CustomValue', $entity['type'], TRUE);
+      $isMultiValueCustomEntity = in_array('CustomValue', $entity['type'], TRUE);
 
-      // Non-custom DAO entities
-      if (!$isCustomEntity && !empty($entity['dao'])) {
+      // Normal DAO entities (excludes multi-value custom field entities)
+      if (!empty($entity['dao']) && !$isMultiValueCustomEntity) {
         /** @var \CRM_Core_DAO $daoClass */
         $daoClass = $entity['dao'];
         $references = $daoClass::getReferenceColumns();
@@ -401,7 +401,7 @@ class Admin {
 
       // Custom EntityRef joins
       foreach ($entity['fields'] as $field) {
-        if (($field['type'] === 'Custom' || $isCustomEntity) && $field['fk_entity'] && $field['input_type'] === 'EntityRef') {
+        if (($field['type'] === 'Custom' || $isMultiValueCustomEntity) && $field['fk_entity'] && $field['input_type'] === 'EntityRef') {
           $entityRefJoins = self::getEntityRefJoins($entity, $field);
           foreach ($entityRefJoins as $joinEntity => $joinInfo) {
             $joins[$joinEntity][] = $joinInfo;
@@ -413,7 +413,8 @@ class Admin {
   }
 
   /**
-   * Get joins for entity reference custom fields, and the entity_id fields in multi-record custom groups.
+   * Get joins for entity reference custom fields, and the entity_id field in
+   * multi-record custom groups.
    *
    * @return array[]
    */

--- a/ext/search_kit/tests/phpunit/Civi/Search/AdminTest.php
+++ b/ext/search_kit/tests/phpunit/Civi/Search/AdminTest.php
@@ -1,15 +1,17 @@
 <?php
 namespace Civi\Search;
 
-use Civi\Test\HeadlessInterface;
-use Civi\Test\TransactionalInterface;
+use api\v4\Api4TestBase;
+use Civi\Test\CiviEnvBuilder;
+
+require_once __DIR__ . '/../../../../../../tests/phpunit/api/v4/Api4TestBase.php';
 
 /**
  * @group headless
  */
-class AdminTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
+class AdminTest extends Api4TestBase {
 
-  public function setUpHeadless() {
+  public function setUpHeadless(): CiviEnvBuilder {
     return \Civi\Test::headless()->installMe(__DIR__)->apply();
   }
 
@@ -127,21 +129,62 @@ class AdminTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface
   }
 
   public function testEntityRefGetJoins(): void {
-    \Civi\Api4\CustomGroup::create()->setValues([
+    $this->createTestRecord('CustomGroup', [
       'title' => 'EntityRefFields',
       'extends' => 'Individual',
-    ])->execute();
-    \Civi\Api4\CustomField::create()->setValues([
+    ]);
+    $this->createTestRecord('CustomField', [
       'label' => 'Favorite Nephew',
       'name' => 'favorite_nephew',
       'custom_group_id.name' => 'EntityRefFields',
       'html_type' => 'Autocomplete-Select',
       'data_type' => 'EntityReference',
       'fk_entity' => 'Contact',
-    ])->execute();
+    ]);
     $allowedEntities = Admin::getSchema();
     $joins = Admin::getJoins($allowedEntities);
-    $this->assertContains('Contact Favorite Nephew', array_column($joins['Contact'], 'label'));
+
+    $entityRefJoin = \CRM_Utils_Array::findAll($joins['Contact'], ['alias' => 'Contact_Contact_favorite_nephew']);
+    $this->assertCount(1, $entityRefJoin);
+    $this->assertEquals([['EntityRefFields.favorite_nephew', '=', 'Contact_Contact_favorite_nephew.id']], $entityRefJoin[0]['conditions']);
+    $this->assertStringContainsString('Favorite Nephew', $entityRefJoin[0]['label']);
+  }
+
+  public function testMultiRecordCustomGetJoins(): void {
+    $this->createTestRecord('CustomGroup', [
+      'title' => 'Multiple Things',
+      'name' => 'MultiRecordActivity',
+      'extends' => 'Activity',
+      'is_multiple' => TRUE,
+    ]);
+    $this->createTestRecord('CustomField', [
+      'label' => 'Ref Group',
+      'name' => 'ref_group',
+      'custom_group_id.name' => 'MultiRecordActivity',
+      'html_type' => 'Autocomplete-Select',
+      'data_type' => 'EntityReference',
+      'fk_entity' => 'Group',
+    ]);
+    $allowedEntities = Admin::getSchema();
+    $joins = Admin::getJoins($allowedEntities);
+
+    $entityRefJoin = \CRM_Utils_Array::findAll($joins['Custom_MultiRecordActivity'], ['alias' => 'Custom_MultiRecordActivity_Group_ref_group']);
+    $this->assertCount(1, $entityRefJoin);
+    $this->assertEquals([['ref_group', '=', 'Custom_MultiRecordActivity_Group_ref_group.id']], $entityRefJoin[0]['conditions']);
+
+    $reverseJoin = \CRM_Utils_Array::findAll($joins['Group'], ['alias' => 'Group_Custom_MultiRecordActivity_ref_group']);
+    $this->assertCount(1, $reverseJoin);
+    $this->assertEquals([['id', '=', 'Group_Custom_MultiRecordActivity_ref_group.ref_group']], $reverseJoin[0]['conditions']);
+
+    $activityToCustomJoin = \CRM_Utils_Array::findAll($joins['Activity'], ['alias' => 'Activity_Custom_MultiRecordActivity_entity_id']);
+    $this->assertCount(1, $activityToCustomJoin);
+    $this->assertEquals([['id', '=', 'Activity_Custom_MultiRecordActivity_entity_id.entity_id']], $activityToCustomJoin[0]['conditions']);
+    $this->assertEquals('Multiple Things', $activityToCustomJoin[0]['label']);
+
+    $customToActivityJoin = \CRM_Utils_Array::findAll($joins['Custom_MultiRecordActivity'], ['alias' => 'Custom_MultiRecordActivity_Activity_entity_id']);
+    $this->assertCount(1, $customToActivityJoin);
+    $this->assertEquals([['entity_id', '=', 'Custom_MultiRecordActivity_Activity_entity_id.id']], $customToActivityJoin[0]['conditions']);
+    $this->assertEquals('Multiple Things Activity', $customToActivityJoin[0]['label']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Building on the following recent developments...

1. we now have a generic entity reference field
2. we now allow multi-value value custom data on any entity

... and with the intention of being able to model arbitrary many to many relationships in CiviCRM.

This PR surfaces joins in SearchKit via entity reference custom fields.

Before
----------------------------------------

Given an entity X, and a 'multi-value custom data entity' Y that has a entity reference field referencing X, users were not able to 

- join from X to Y via the entity reference field
- join from Y to X via the entity reference field

After
----------------------------------------

Given the same scenario, users are able to do both things.

Technical Details
----------------------------------------
The PR works for me in my tests locally but there are some things I am not sure of:

1. whether I should have thought of the multi-value custom data as a bridge entity (I don't think it is necessary or adds much but happy to be corrected on that.
2. appropriate values for `bridge`, `conditions` , `defaults` and `multi` in the join definitions that I am creating.

I factored out the entity reference join code that already existed for single value custom data into a seperate function which we are now also calling from multi-value custom data entities.

PS. I have a demo site set up with this code which I can give you access to if that would help anyone with getting their head around it or any testing.