### PR TITLE
CiviMember - Fix checkbox for optional auto-renewals

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -750,6 +750,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
       $this->assign('membershipBlock', $this->_membershipBlock);
       $this->assign('showRadio', FALSE);
+      $this->assignTotalAmounts();
       $this->assign('membershipTypes', $membershipTypes);
       $this->assign('autoRenewMembershipTypeOptions', json_encode($autoRenewMembershipTypeOptions));
       //give preference to user submitted auto_renew value.

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -617,17 +617,18 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
    *
    * @throws \CRM_Core_Exception
    */
-  private function buildMembershipBlock() {
+  private function buildMembershipBlock(): ?bool {
     $cid = $this->_membershipContactID;
     $separateMembershipPayment = FALSE;
     $this->addOptionalQuickFormElement('auto_renew');
+    $this->addExpectedSmartyVariable('renewal_mode');
     if ($this->_membershipBlock) {
 
       $membershipTypeIds = $membershipTypes = $radio = $radioOptAttrs = [];
       // This is always true if this line is reachable - remove along with the upcoming if.
       $membershipPriceset = TRUE;
 
-      $allowAutoRenewMembership = $autoRenewOption = FALSE;
+      $allowAutoRenewMembership = FALSE;
       $autoRenewMembershipTypeOptions = [];
 
       $separateMembershipPayment = $this->_membershipBlock['is_separate_payment'] ?? NULL;
@@ -651,30 +652,17 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         $this->_membershipTypeValues = $membershipTypeValues;
         $endDate = NULL;
 
-        // Check if we support auto-renew on this contribution page
-        // FIXME: If any of the payment processors do NOT support recurring you cannot setup an
-        //   auto-renew payment even if that processor is not selected.
-        $allowAutoRenewOpt = TRUE;
-        if (is_array($this->_paymentProcessors)) {
-          foreach ($this->_paymentProcessors as $id => $val) {
-            if ($id && !$val['is_recur']) {
-              $allowAutoRenewOpt = FALSE;
-            }
-          }
-        }
+        $allowAutoRenewOpt = $this->isPageHasPaymentProcessorSupportForRecurring();
         foreach ($membershipTypeIds as $value) {
           $memType = $membershipTypeValues[$value];
           if ($memType['is_active']) {
-
+            $autoRenewMembershipTypeOptions["autoRenewMembershipType_{$value}"] = $this->getConfiguredAutoRenewOptionForMembershipType($value);
             if ($allowAutoRenewOpt) {
               $javascriptMethod = ['onclick' => "return showHideAutoRenew( this.value );"];
-              $isAvailableAutoRenew = $this->_membershipBlock['auto_renew'][$value] ?? 1;
-              $autoRenewMembershipTypeOptions["autoRenewMembershipType_{$value}"] = (int) $memType['auto_renew'] * $isAvailableAutoRenew;
               $allowAutoRenewMembership = TRUE;
             }
             else {
               $javascriptMethod = NULL;
-              $autoRenewMembershipTypeOptions["autoRenewMembershipType_{$value}"] = 0;
             }
 
             //add membership type.
@@ -717,9 +705,8 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       //give preference to user submitted auto_renew value.
       $takeUserSubmittedAutoRenew = (!empty($_POST) || $this->isSubmitted());
       $this->assign('takeUserSubmittedAutoRenew', $takeUserSubmittedAutoRenew);
-
+      $autoRenewOption = $this->getAutoRenewOption();
       // Assign autorenew option (0:hide,1:optional,2:required) so we can use it in confirmation etc.
-      $autoRenewOption = CRM_Price_BAO_PriceSet::checkAutoRenewForPriceSet($this->_priceSetId);
       $this->assign('autoRenewOption', $autoRenewOption);
 
       if ((!$this->_values['is_pay_later'] || is_array($this->_paymentProcessors)) && ($allowAutoRenewMembership || $autoRenewOption)) {
@@ -1810,6 +1797,75 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $membershipTypeIDs[$lineItem['membership_type_id']] = $lineItem['membership_type_id'];
     }
     return $membershipTypeIDs;
+  }
+
+  /**
+   * @return int
+   */
+  private function getAutoRenewOption(): int {
+    $autoRenewOption = 0;
+    foreach ($this->getPriceFieldMetaData() as $field) {
+      foreach ($field['options'] as $option) {
+        if ($option['membership_type_id.auto_renew'] === 1) {
+          $autoRenewOption = 1;
+          break 2;
+        }
+        if ($option['membership_type_id.auto_renew'] === 2) {
+          $autoRenewOption = 2;
+        }
+      }
+    }
+    return $autoRenewOption;
+  }
+
+  /**
+   * Get configured auto renew option.
+   *
+   * One of
+   * 0 = never
+   * 1 = optional
+   * 2 - always
+   *
+   * This is based on the membership type but 1 can be moved up or down by membership block configuration.
+   *
+   * @param int $membershipTypeID
+   *
+   * @return int
+   * @throws \CRM_Core_Exception
+   */
+  private function getConfiguredAutoRenewOptionForMembershipType($membershipTypeID): int {
+    if (!$this->isPageHasPaymentProcessorSupportForRecurring()) {
+      return 0;
+    }
+    if (!$this->isQuickConfig()) {
+      return CRM_Member_BAO_MembershipType::getMembershipType($membershipTypeID)['auto_renew'];
+    }
+    $membershipTypeAutoRenewOption = CRM_Member_BAO_MembershipType::getMembershipType($membershipTypeID)['auto_renew'];
+    if ($membershipTypeAutoRenewOption === 2 || $membershipTypeAutoRenewOption === 0) {
+      // It is not possible to override never or always at the membership block leve.
+      return $membershipTypeAutoRenewOption;
+    }
+    // For quick config it is possible to override the give option membership type setting in the membership block.
+    return $this->_membershipBlock['auto_renew'][$membershipTypeID] ?? $membershipTypeAutoRenewOption;
+  }
+
+  /**
+   * Is there payment processor support for recurring contributions on the the contribution page.
+   *
+   * As our front end js is not clever enough to deal with switching this returns FALSE
+   * if any configured processor will not do recurring.
+   *
+   * @return bool
+   */
+  private function isPageHasPaymentProcessorSupportForRecurring(): bool {
+    if (is_array($this->_paymentProcessors)) {
+      foreach ($this->_paymentProcessors as $id => $val) {
+        if ($id && !$val['is_recur']) {
+          return FALSE;
+        }
+      }
+    }
+    return TRUE;
   }
 
 }

--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -49,6 +49,7 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
     $this->assign('thankyou_footer', CRM_Utils_Array::value('thankyou_footer', $this->_values));
     $this->assign('max_reminders', CRM_Utils_Array::value('max_reminders', $this->_values));
     $this->assign('initial_reminder_day', CRM_Utils_Array::value('initial_reminder_day', $this->_values));
+    $this->assignTotalAmounts();
     // Link (button) for users to create their own Personal Campaign page
     if ($linkText = CRM_PCP_BAO_PCP::getPcpBlockStatus($this->getContributionPageID(), 'contribute')) {
       $linkTextUrl = CRM_Utils_System::url('civicrm/contribute/campaign',

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1527,6 +1527,23 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   }
 
   /**
+   * Assign the total amounts for display on Confirm and ThankYou pages.
+   *
+   * These values are used in the separate payments section.
+   *
+   * @return void
+   * @throws \CRM_Core_Exception
+   */
+  protected function assignTotalAmounts(): void {
+    // orderTotal includes both payments, if separate.
+    $orderTotal = $this->getOrder() ? $this->order->getTotalAmount() : 0;
+    $membershipTotalAmount = $this->getOrder() ? $this->order->getMembershipTotalAmount() : 0;
+    $this->assign('orderTotal', $orderTotal);
+    $this->assign('membershipTotalAmount', $membershipTotalAmount);
+    $this->assign('nonMembershipTotalAmount', $orderTotal - $membershipTotalAmount);
+  }
+
+  /**
    * Get the currency for the form.
    *
    * Rather historic - might have unneeded stuff

--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -40,15 +40,15 @@
         {elseif $is_separate_payment}
           {if $amount AND $minimum_fee}
             {$membership_name} {ts}Membership{/ts}:
-            <strong>{$minimum_fee|crmMoney}</strong>
+            <strong>{$membershipTotalAmount|crmMoney}</strong>
             <br/>
             {ts}Additional Contribution{/ts}:
-            <strong>{$amount|crmMoney}</strong>
+            <strong>{$nonMembershipTotalAmount|crmMoney}</strong>
             <br/>
             <strong> -------------------------------------------</strong>
             <br/>
             {ts}Total{/ts}:
-            <strong>{$amount+$minimum_fee|crmMoney}</strong>
+            <strong>{$orderTotal|crmMoney}</strong>
             <br/>
           {elseif $amount}
             {ts}Amount{/ts}:

--- a/templates/CRM/Contribute/Form/Contribution/MainMembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MainMembershipBlock.tpl
@@ -20,10 +20,10 @@
           </div>
         {/if}
       {else}
-        {if $membershipBlock.new_title}
+        {if array_key_exists('new_title', $membershipBlock) && $membershipBlock.new_title}
           <legend>{$membershipBlock.new_title}</legend>
         {/if}
-        {if $membershipBlock.new_text}
+        {if array_key_exists('new_text', $membershipBlock) && $membershipBlock.new_text}
           <div id="membership-intro" class="crm-section membership_new_intro-section">
             {$membershipBlock.new_text}
           </div>
@@ -52,23 +52,7 @@
   </div>
   {literal}
   <script type="text/javascript">
-    CRM.$(function($) {
-      //if price set is set we use below below code to show for showing auto renew
-      var autoRenewOption =  {/literal}'{$autoRenewOption}'{literal};
-      var autoRenew = $("#auto_renew_section");
-      var autoRenewCheckbox = $("#auto_renew");
-      var forceRenew = $("#force_renew");
-      autoRenew.hide();
-      forceRenew.hide();
-      if ( autoRenewOption == 1 ) {
-        autoRenew.show();
-      } else if ( autoRenewOption == 2 ) {
-        autoRenewCheckbox.prop('checked',  true );
-        autoRenewCheckbox.attr( 'readonly', true );
-        autoRenew.hide();
-        forceRenew.show();
-      }
-    });
+
   </script>
 {/literal}
 </div>
@@ -155,13 +139,16 @@
       //does this page has only one membership type.
       var renewOptions  = {/literal}{$autoRenewMembershipTypeOptions}{literal};
       var currentOption = eval( "renewOptions." + 'autoRenewMembershipType_' + memTypeId );
+      if (memTypeId === undefined) {
+        currentOption = 0;
+      }
       var autoRenew = cj('#auto_renew_section');
       var autoRenewC = cj('input[name="auto_renew"]');
       var forceRenew = cj("#force_renew");
 
       var readOnly = false;
       var isChecked  = false;
-      if ( currentOption == 0 ) {
+      if (currentOption == 0 ) {
         isChecked = false;
         forceRenew.hide();
         autoRenew.hide();

--- a/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
@@ -13,13 +13,13 @@
 {if $membershipBlock AND $is_quick_config}
     <div class="header-dark">
       {if $renewal_mode}
-        {if $membershipBlock.renewal_title}
+        {if array_key_exists('renewal_title', $membershipBlock) && $membershipBlock.renewal_title}
           {$membershipBlock.renewal_title}
         {else}
           {ts}Select a Membership Renewal Level{/ts}
         {/if}
       {else}
-        {if $membershipBlock.new_title}
+        {if array_key_exists('new_title', $membershipBlock) && $membershipBlock.new_title}
           {$membershipBlock.new_title}
         {else}
           {ts}Select a Membership Level{/ts}

--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -93,7 +93,7 @@
             {/if}
           {/if}
           <strong> -------------------------------------------</strong><br />
-          {ts}Total{/ts}: <strong>{$amount+$membership_amount|crmMoney}</strong><br />
+          {ts}Total{/ts}: <strong>{$orderTotal|crmMoney}</strong><br />
         {else}
           {if $totalTaxAmount}
             {ts}Tax Amount{/ts}: <strong>{$totalTaxAmount|crmMoney}</strong><br />

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -95,21 +95,19 @@
                 </div>
 
             {/if}
-              {if !empty($extends) && $extends eq "Membership"}
-                {if ($element.id == $priceSet.auto_renew_membership_field)}
-                  <div id="allow_auto_renew">
-                    <div class='crm-section auto-renew'>
-                      <div class='label'></div>
-                      <div class='content' id="auto_renew_section">
-                        {if $form.auto_renew}
-                          {$form.auto_renew.html}&nbsp;{$form.auto_renew.label|smarty:nodefaults|purify}
-                        {/if}
-                      </div>
-                      <div class='content' id="force_renew" style='display: none'>{ts}Membership will renew automatically.{/ts}</div>
-                    </div>
+            {if (array_key_exists('auto_renew', $form)) && !empty($extends) && $extends eq "Membership" && array_key_exists('supports_auto_renew', $element) && $element.supports_auto_renew}
+              <div id="allow_auto_renew">
+                <div class='crm-section auto-renew'>
+                  <div class='label'></div>
+                  <div class='content' id="auto_renew_section">
+                    {if $form.auto_renew}
+                      {$form.auto_renew.html}&nbsp;{$form.auto_renew.label|smarty:nodefaults|purify}
+                    {/if}
                   </div>
-                {/if}
-              {/if}
+                  <div class='content' id="force_renew" style='display: none'>{ts}Membership will renew automatically.{/ts}</div>
+                </div>
+              </div>
+            {/if}
               <div class="clear"></div>
           </div>
         {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Fix auto-renew checkbox with memberships to work with more than one configured membership 


![image](https://github.com/civicrm/civicrm-core/assets/336308/069ad6f8-2f29-4260-b463-2099f62006ca)



Before
----------------------------------------
If I configure 2 membership types on the demo site with different auto-renew frequencies the display of the check box to auto renew is inconsistent

After
----------------------------------------
This appears to be offering me the option appropriately now

Technical Details
----------------------------------------
I'm not 100% sure if this is a regression. I fixed a lot of notices in this code in 5.69 and also a bug where the membership block was being updated on the fly in this code to sync it with the membership types (so it is clear that a change to make the membership type more restrictive is supposed to flow through) 

However, this might be a pre-existing bug - ie https://lab.civicrm.org/dev/core/-/issues/3963 rather than a regression. 

My approach with 5.69 is that because there is so much change in this code we should fix it to the correct behaviour rather than our usual focus on determining if it is a regression & then soft-freeze this code for a number of months until we are comfortable any 5.69 regressions are resolved. So if we don't merge this to 5.69 I think we should delay to around about 5.74

Comments
----------------------------------------
