### PR TITLE
Enable Smarty3, smarty notices  by default for all localhost or demo builds

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -167,7 +167,7 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
 
     $this->assign('crmPermissions', new CRM_Core_Smarty_Permissions());
 
-    if ($config->debug) {
+    if ($config->debug || str_contains(CIVICRM_UF_BASEURL, 'localhost')) {
       $this->error_reporting = E_ALL;
     }
   }

--- a/settings/Developer.setting.php
+++ b/settings/Developer.setting.php
@@ -62,7 +62,8 @@ return [
     'config_key' => 'debug',
     'type' => 'Boolean',
     'quick_form_type' => 'YesNo',
-    'default' => '0',
+    // default to TRUE for demo or localhost sites.
+    'default' => str_contains(CIVICRM_UF_BASEURL, 'localhost') || str_contains(CIVICRM_UF_BASEURL, 'demo.civicrm.org'),
     'add' => '4.3',
     'title' => ts('Enable Debugging'),
     'is_domain' => 1,

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -202,18 +202,6 @@ if (!defined('CIVICRM_TEMPLATE_COMPILEDIR')) {
 //}
 
 /**
- * Specify a Smarty 3 autoload file.
- *
- * If you wish to experiment with Smarty3 you can do so by installing it
- * to a directory using composer (composer require smarty/smarty:^3)
- * and then defining the path to that
- * autoload. file.
- */
-if (!defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
-// define('CIVICRM_SMARTY3_AUTOLOAD_PATH', $civicrm_root . '/packages/smarty3/vendor/autoload.php');
-}
-
-/**
  * Smarty escape on output.
  *
  * This does not currently work if you have a Smarty 3 path defined
@@ -262,6 +250,21 @@ if (!defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
  */
 if (!defined('CIVICRM_UF_BASEURL')) {
   define( 'CIVICRM_UF_BASEURL'      , '%%baseURL%%');
+}
+
+
+/**
+ * Specify a Smarty 3 autoload file.
+ *
+ * Smarty3 is the version of Smarty we are in the process of adopting. To enable it
+ * un-comment the line describing the path. Note that this will become always enabled in
+ * the near future - this opt-in setting is transitional.
+ */
+if (!defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
+  // enable by default for dev & demo sites for now - will soon enable by default for all new installs.
+  if (str_contains(CIVICRM_UF_BASEURL, 'localhost') || str_contains(CIVICRM_UF_BASEURL, 'demo.civicrm.org')) {
+    define('CIVICRM_SMARTY3_AUTOLOAD_PATH', $civicrm_root . '/packages/smarty3/vendor/autoload.php');
+  }
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
Enable Smarty3, smarty notices  by default for all localhost or demo builds

Before
----------------------------------------
We are getting close to enabling both Smarty3 & Smarty notice level reporting on all sites. However, developers have to actively enable it  - which means they are less likely to spot upcoming issues

After
----------------------------------------
I set the civicrm.settings.php template to enable Smarty3 for sites with localhost or demo.civicrm.org in the url. I also set the debugging setting to default to TRUE in those cases

Technical Details
----------------------------------------
It has previously been pointed out the define would be wrong for a composer installed drupal site - am hoping @totten can help there.

I was originally looking at putting the debug thing into the Smarty class but then thought a setting default made more sense - assuming it is reliable. I left the change in the Smarty class there to signpost the location but suspect the setting default makes more sense.

Comments
----------------------------------------
We have been hesitant to enable smarty debugging on demo sites in the past because of the risk of them being used to assess CiviCRM but I think we have now driven out the notices to the extent which making the remaining ones visible / getting them fixed is more important.