### PR TITLE
Remove support for pre-2019 usage of core function

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -275,14 +275,12 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
    *   Recur contribution params
    *
    * @return bool
+   * @throws \CRM_Core_Exception
+   * @internal
+   *
    */
-  public static function cancelRecurContribution($params) {
-    if (is_numeric($params)) {
-      CRM_Core_Error::deprecatedFunctionWarning('You are using a BAO function whose signature has changed. Please use the ContributionRecur.cancel api');
-      $params = ['id' => $params];
-    }
-    $recurId = $params['id'];
-    if (!$recurId) {
+  public static function cancelRecurContribution(array $params): bool {
+    if (!$params['id']) {
       return FALSE;
     }
     $activityParams = [
@@ -292,7 +290,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
 
     $cancelledId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionRecur', 'contribution_status_id', 'Cancelled');
     $recur = new CRM_Contribute_DAO_ContributionRecur();
-    $recur->id = $recurId;
+    $recur->id = $params['id'];
     $recur->whereAdd("contribution_status_id != $cancelledId");
 
     if ($recur->find(TRUE)) {
@@ -303,7 +301,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
       $recur->save();
 
       // @fixme https://lab.civicrm.org/dev/core/issues/927 Cancelling membership etc is not desirable for all use-cases and we should be able to disable it
-      $dao = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($recurId);
+      $dao = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($params['id']);
       if ($dao && $dao->recur_id) {
         $details = $activityParams['details'] ?? NULL;
         if ($dao->auto_renew && $dao->membership_id) {

--- a/api/v3/ContributionRecur.php
+++ b/api/v3/ContributionRecur.php
@@ -64,10 +64,11 @@ function civicrm_api3_contribution_recur_get($params) {
  * @param array $params
  *   Array containing id of the recurring contribution.
  *
- * @return bool
+ * @return array
  *   returns true is successfully cancelled
+ * @throws \CRM_Core_Exception
  */
-function civicrm_api3_contribution_recur_cancel($params) {
+function civicrm_api3_contribution_recur_cancel(array $params): array {
   return CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution($params) ? civicrm_api3_create_success() : civicrm_api3_create_error(ts('Error while cancelling recurring contribution'));
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove support for pre-2019 usage of core function

Before
----------------------------------------
This function is only accessed from the v3 ContributionRecur.cancel api 

![image](https://github.com/civicrm/civicrm-core/assets/336308/6a2f66e0-4720-4de9-bf09-8aff8c2f9e56)

The signature was changed in 2019 such that the function expected an array not an integer & noisy deprecation was added

After
----------------------------------------
Support for passing in an integer removed entirely

Technical Details
----------------------------------------
Test cover in the highlighted line & in api_v3_ContributionRecurTest::testContributionRecurCancel

Comments
----------------------------------------
