### PR TITLE
Move existing recur checks for apiv3 to the apiv3 function

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -275,14 +275,12 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
    *   Recur contribution params
    *
    * @return bool
+   * @throws \CRM_Core_Exception
+   * @internal
+   *
    */
-  public static function cancelRecurContribution($params) {
-    if (is_numeric($params)) {
-      CRM_Core_Error::deprecatedFunctionWarning('You are using a BAO function whose signature has changed. Please use the ContributionRecur.cancel api');
-      $params = ['id' => $params];
-    }
-    $recurId = $params['id'];
-    if (!$recurId) {
+  public static function cancelRecurContribution(array $params): bool {
+    if (!$params['id']) {
       return FALSE;
     }
     $activityParams = [
@@ -292,7 +290,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
 
     $cancelledId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionRecur', 'contribution_status_id', 'Cancelled');
     $recur = new CRM_Contribute_DAO_ContributionRecur();
-    $recur->id = $recurId;
+    $recur->id = $params['id'];
     $recur->whereAdd("contribution_status_id != $cancelledId");
 
     if ($recur->find(TRUE)) {
@@ -303,7 +301,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
       $recur->save();
 
       // @fixme https://lab.civicrm.org/dev/core/issues/927 Cancelling membership etc is not desirable for all use-cases and we should be able to disable it
-      $dao = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($recurId);
+      $dao = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($params['id']);
       if ($dao && $dao->recur_id) {
         $details = $activityParams['details'] ?? NULL;
         if ($dao->auto_renew && $dao->membership_id) {

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -339,16 +339,6 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
       $transaction->commit();
       return TRUE;
     }
-    else {
-      // if already cancelled, return true
-      $recur->whereAdd();
-      $recur->whereAdd("contribution_status_id = $cancelledId");
-      if ($recur->find(TRUE)) {
-        return TRUE;
-      }
-    }
-
-    return FALSE;
   }
 
   /**

--- a/api/v3/ContributionRecur.php
+++ b/api/v3/ContributionRecur.php
@@ -64,10 +64,11 @@ function civicrm_api3_contribution_recur_get($params) {
  * @param array $params
  *   Array containing id of the recurring contribution.
  *
- * @return bool
+ * @return array
  *   returns true is successfully cancelled
+ * @throws \CRM_Core_Exception
  */
-function civicrm_api3_contribution_recur_cancel($params) {
+function civicrm_api3_contribution_recur_cancel(array $params): array {
   return CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution($params) ? civicrm_api3_create_success() : civicrm_api3_create_error(ts('Error while cancelling recurring contribution'));
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
Move existing recur checks for apiv3 to the apiv3 function

Before
----------------------------------------
The function `cancelRecurContribution` is called only from apiv3 ContributionRecur.cancel & a test & the api would be the supported way to use it. 

Some of the code in it should be accessable from apiv4 / potentially moved to post hook - but the checks it does are really more to do with the history of the apiv3 code

After
----------------------------------------
Apiv3 specific code moved to the api

Technical Details
----------------------------------------

Comments
----------------------------------------
