### PR TITLE
Fix notice, undefined property on Pcp page

### DIFF
--- a/CRM/PCP/Page/PCP.php
+++ b/CRM/PCP/Page/PCP.php
@@ -38,6 +38,16 @@ class CRM_PCP_Page_PCP extends CRM_Core_Page_Basic {
   }
 
   /**
+   * This holds the value taken from the url for the A-Z pager.
+   *
+   * It seems like the A-Z pager is a bit broken & could be removed
+   * from this page.
+   *
+   * @var string|null
+   */
+  protected $_sortByCharacter;
+
+  /**
    * Get action Links.
    *
    * @return array

--- a/templates/CRM/PCP/Page/PCP.tpl
+++ b/templates/CRM/PCP/Page/PCP.tpl
@@ -19,7 +19,6 @@
 {if $rows}
 <div id="ltype">
 <p></p>
-{include file="CRM/common/pager.tpl" location="top"}
 {include file="CRM/common/pagerAToZ.tpl"}
 {include file="CRM/common/jsortable.tpl"}
 {strip}


### PR DESCRIPTION
Overview
----------------------------------------
This address 2 issues - the notice from smarty & the undefined property on sortByCharacter on https://dmaster.localhost:32353/civicrm/admin/pcp?force=1&qfKey=&sortByCharacter=N - the page's level of brokenness is otherwise unchanged

Before
----------------------------------------
The 'sort by character' property relates to the alpha bar at the top & specifically bolds the selected value - this worked fine with the property being protected. Selecting it didn't seem to filter the page in any meaningful way to my eye - but that is unchanged 

![image](https://github.com/civicrm/civicrm-core/assets/336308/573353dc-ca63-4c71-b7ff-4d377302a783)

The pager generated a notice & I could see no evidence it would ever be set. I tested this by adding hundreds of rows to the table & seeing no paging so I removed the inclusing of the pager tpl file

After
----------------------------------------
php / smarty notices fixed

Technical Details
----------------------------------------

Comments
----------------------------------------
