### PR TITLE
Stop bypassing hooks on ContributionRecur.cancel

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -275,14 +275,12 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
    *   Recur contribution params
    *
    * @return bool
+   * @throws \CRM_Core_Exception
+   * @internal
+   *
    */
-  public static function cancelRecurContribution($params) {
-    if (is_numeric($params)) {
-      CRM_Core_Error::deprecatedFunctionWarning('You are using a BAO function whose signature has changed. Please use the ContributionRecur.cancel api');
-      $params = ['id' => $params];
-    }
-    $recurId = $params['id'];
-    if (!$recurId) {
+  public static function cancelRecurContribution(array $params): bool {
+    if (!$params['id']) {
       return FALSE;
     }
     $activityParams = [
@@ -292,7 +290,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
 
     $cancelledId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionRecur', 'contribution_status_id', 'Cancelled');
     $recur = new CRM_Contribute_DAO_ContributionRecur();
-    $recur->id = $recurId;
+    $recur->id = $params['id'];
     $recur->whereAdd("contribution_status_id != $cancelledId");
 
     if ($recur->find(TRUE)) {
@@ -303,7 +301,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
       $recur->save();
 
       // @fixme https://lab.civicrm.org/dev/core/issues/927 Cancelling membership etc is not desirable for all use-cases and we should be able to disable it
-      $dao = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($recurId);
+      $dao = CRM_Contribute_BAO_ContributionRecur::getSubscriptionDetails($params['id']);
       if ($dao && $dao->recur_id) {
         $details = $activityParams['details'] ?? NULL;
         if ($dao->auto_renew && $dao->membership_id) {

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -339,16 +339,6 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
       $transaction->commit();
       return TRUE;
     }
-    else {
-      // if already cancelled, return true
-      $recur->whereAdd();
-      $recur->whereAdd("contribution_status_id = $cancelledId");
-      if ($recur->find(TRUE)) {
-        return TRUE;
-      }
-    }
-
-    return FALSE;
   }
 
   /**

--- a/api/v3/ContributionRecur.php
+++ b/api/v3/ContributionRecur.php
@@ -71,7 +71,8 @@ function civicrm_api3_contribution_recur_get($params) {
  * @throws \CRM_Core_Exception
  */
 function civicrm_api3_contribution_recur_cancel(array $params): array {
-  $existing = ContributionRecur::get(TRUE)
+  $params['check_permissions'] = $params['check_permissions'] ?? FALSE;
+  $existing = ContributionRecur::get($params['check_permissions'])
     ->addWhere('id', '=', $params['id'])
     ->addSelect('contribution_status_id:name')
     ->execute()->first();

--- a/api/v3/ContributionRecur.php
+++ b/api/v3/ContributionRecur.php
@@ -64,10 +64,11 @@ function civicrm_api3_contribution_recur_get($params) {
  * @param array $params
  *   Array containing id of the recurring contribution.
  *
- * @return bool
+ * @return array
  *   returns true is successfully cancelled
+ * @throws \CRM_Core_Exception
  */
-function civicrm_api3_contribution_recur_cancel($params) {
+function civicrm_api3_contribution_recur_cancel(array $params): array {
   return CRM_Contribute_BAO_ContributionRecur::cancelRecurContribution($params) ? civicrm_api3_create_success() : civicrm_api3_create_error(ts('Error while cancelling recurring contribution'));
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
[Stop bypassing hooks on ContributionRecur.cancel](https://github.com/civicrm/civicrm-core/commit/de7d2e0866d2011a416a07a68e730ca89616e25e)

Before
----------------------------------------
The apiv3 ContributionRecur.cancel function bypasses hooks by calling `save` directly

After
----------------------------------------
Internally it calls apiv4 update - which calls hooks

Technical Details
----------------------------------------
Per code comments I think the additional logic would be ideally moved to a `post` hook & should kick in whenever this update is made. I commented to that effect but felt that the  preliminary clean up I did was enough for this round

Comments
----------------------------------------
