### PR TITLE
Clean up  code to add custom data to forms, implement on back office participant form

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1700,14 +1700,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
         $form->assign('qfKey', $qf);
         Civi::cache('customData')->set($qf, $formValues);
       }
-
-      // hack for field type File
-      $formUploadNames = $form->get('uploadNames');
-      if (is_array($formUploadNames)) {
-        $uploadNames = array_unique(array_merge($formUploadNames, $uploadNames));
-      }
-
-      $form->set('uploadNames', $uploadNames);
+      $form->registerFileField($uploadNames);
     }
 
     return $formattedGroupTree;

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -665,6 +665,23 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   }
 
   /**
+   * Register a field with quick form as supporting a file upload.
+   *
+   * @param array $fieldNames
+   *
+   * @return void
+   */
+  public function registerFileField(array $fieldNames): void {
+    // hack for field type File
+    $formUploadNames = $this->get('uploadNames');
+    if (is_array($formUploadNames)) {
+      $fieldNames = array_unique(array_merge($formUploadNames, $fieldNames));
+    }
+
+    $this->set('uploadNames', $fieldNames);
+  }
+
+  /**
    * This virtual function is used to build the form.
    *
    * It replaces the buildForm associated with QuickForm_Page. This allows us to put

--- a/CRM/Custom/Form/CustomDataTrait.php
+++ b/CRM/Custom/Form/CustomDataTrait.php
@@ -47,6 +47,7 @@ trait CRM_Custom_Form_CustomDataTrait {
       'values' => $filters,
       'where' => [
         ['type', '=', 'Custom'],
+        ['readonly', '=', FALSE],
       ],
       'checkPermissions' => TRUE,
     ])->indexBy('custom_field_id');

--- a/CRM/Custom/Form/CustomDataTrait.php
+++ b/CRM/Custom/Form/CustomDataTrait.php
@@ -1,1 +1,92 @@
 <?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This trait supports adding custom data to forms.
+ *
+ * @internal
+ */
+trait CRM_Custom_Form_CustomDataTrait {
+
+  /**
+   * Add custom data fields to the form.
+   *
+   * This function takes responsibility for registering the appropriate fields with QuickForm.
+   *
+   * It does not assign variables to the smarty layer to assist with rendering or setDefaults.
+   * Those additional steps are not required on the 'main form' when the CustomDataForm is
+   * being rendered by ajax as that process takes care of the presentation.
+   *
+   * However, the fields need to be registered with QuickForm to ensure that on submit
+   * they are 'accepted' by quick form. Quick form validates the contents of $_POST
+   * and only fields that have been registered make it through to the values
+   * available in `$form->getSubmittedValues()`.
+   *
+   * @param string $entity
+   * @param array $filters
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function addCustomDataFieldsToForm(string $entity, array $filters = []): void {
+    $fields = civicrm_api4($entity, 'getFields', [
+      'action' => 'create',
+      'values' => $filters,
+      'where' => [
+        ['type', '=', 'Custom'],
+      ],
+      'checkPermissions' => TRUE,
+    ])->indexBy('custom_field_id');
+
+    $customGroupSuffixes = [];
+    foreach ($fields as $field) {
+      // This default suffix indicates the contact has no existing row in the table.
+      // It will be overridden below with the id of any row the contact DOES have in the table.
+      $customGroupSuffixes[$field['table_name']] = '_-1';
+    }
+    if (!empty($filters['id'])) {
+      $query = [];
+      foreach (array_keys($customGroupSuffixes) as $tableName) {
+        $query[] = CRM_Core_DAO::composeQuery(
+          'SELECT %1 as table_name, id FROM %2 WHERE entity_id = %3',
+          [
+            1 => [$tableName, 'String'],
+            2 => [$tableName, 'MysqlColumnNameOrAlias'],
+            3 => [$filters['id'], 'Integer'],
+          ]
+        );
+      }
+      $tables = CRM_Core_DAO::executeQuery(implode(' UNION ', $query));
+      while ($tables->fetch()) {
+        $customGroupSuffixes[$tables->table_name] = '_' . $tables->id;
+      }
+    }
+
+    foreach ($fields as $field) {
+      $suffix = $customGroupSuffixes[$field['table_name']];
+      $elementName = 'custom_' . $field['custom_field_id'] . $suffix;
+      // Note that passing required = TRUE here does not seem to actually do anything. As long
+      // as the form opens in pop up mode jquery validation from the ajax form ensures required fields are
+      // submitted. In non-popup mode however the required is not enforced. This appears to be
+      // a bug that has been around for a while.
+      CRM_Core_BAO_CustomField::addQuickFormElement($this, $elementName, $field['custom_field_id'], $field['required']);
+      if ($field['input_type'] === 'File') {
+        $this->registerFileField([$elementName]);
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
The existing function is crazy complicated & interacts with lots of undefined properties, per tests - but on digging the actual code used by non-contact, non multiple record form is actually quite simple - this adds a simple function that does the things that actually need to be done for processing custom data & implements it on the participant form

Before
----------------------------------------
Incredibly confusing code with lots of notices & undefined properties, causing php 8.x tests to fail

After
----------------------------------------
I managed to figure out what the end result of all that building group trees & passing group trees around & reformatting them and the part that is needed for forms that are not doing the actual rendering is https://github.com/civicrm/civicrm-core/pull/28733/files#diff-82b0e2eac7cfc3882a5e3cf5db3be5f7a8b42257f64366e8db74f2ddafb1f18cR45-R91

Which compares favourably to https://github.com/civicrm/civicrm-core/blob/7d4bb5eff5c101a1859ded124330af4013dd3727/CRM/Custom/Form/CustomData.php#L82-L199

I suspect there might be a better way to load the custom data entity IDs that @colemanw will suggest - although I would prefer to do that as a follow up at this point (since it has been a slog & what is there is not that bad)

Technical Details
----------------------------------------
I identified that required fields are enforced by ajax in popup mode but nothing enforces them in non popup mode - that was pre-existing.

I tested with money, number, text, radio and file fields and with custom groups extending role, event id, and event type on create new and on edit

Comments
----------------------------------------