### PR TITLE
Fix PHP warning: trying to use null as array

### DIFF
--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -263,7 +263,7 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
         $maxInstances = (string) $recordXML->max_instances;
         $activityTypeInfo = $activityTypes[$activityTypeName] ?? NULL;
 
-        if ($activityTypeInfo['id']) {
+        if ($activityTypeInfo) {
           if ($maskAction) {
             if ($maskAction == 'edit' && '0' === (string) $recordXML->editable) {
               $result[$maskAction][] = $activityTypeInfo['id'];


### PR DESCRIPTION
Overview
----------------------------------------
Avoids a PHP warning: Trying to access array offset on value of type null at CRM/Case/XMLProcessor/Process.php:266