### PR TITLE
ContactSummary - Exclude deleted contacts from relationship tab

### DIFF
--- a/managed/contactSummary/SavedSearch_Contact_Summary_Relationships.mgd.php
+++ b/managed/contactSummary/SavedSearch_Contact_Summary_Relationships.mgd.php
@@ -45,7 +45,9 @@ return [
             'is_active',
           ],
           'orderBy' => [],
-          'where' => [],
+          'where' => [
+            ['RelationshipCache_Contact_far_contact_id_01.is_deleted', '=', FALSE],
+          ],
           'groupBy' => [],
           'join' => $joins,
           'having' => [],


### PR DESCRIPTION
Overview
----------------------------------------
Ensures deleted contacts don't appear on a contact's "Relationships" tab.

Technical Details
----------------------------------------
This tab was recently replaced by SearchKit. Before that I'm fairly sure the old version was excluding these, so this could be considered a regression.

See also https://civicrm.stackexchange.com/questions/46113/why-would-related-contact-deletion-keeps-a-relationship-active