### PR TITLE
menubar spin: stop after 10 seconds

### DIFF
--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -145,6 +145,12 @@
     },
     spin: function(spin) {
       $('.crm-logo-sm', '#civicrm-menu').toggleClass('fa-spin', spin);
+      // Sometimes the logo does not stop spinning (ex: file downloads)
+      if (spin) {
+        window.setTimeout(function() {
+          CRM.menubar.spin(false);
+        }, 10000);
+      }
     },
     getItem: function(itemName) {
       return traverse(CRM.menubar.data.menu, itemName, 'get');


### PR DESCRIPTION
Overview
----------------------------------------

The CiviCRM logo spins when we click to load a new page, but sometimes it spins forever, such as sometimes when doing file downloads.

Steps to reproduce:

- Search contacts
- Select all > Actions > Export
- Leave defaults and click the button to download the file.

Result:  logo spins forever, making people think that the download is not yet finished.

Before
----------------------------------------

Sometimes spins forever.

After
----------------------------------------

Spins max 10 seconds.

Comments
----------------------------------------

This was reported by a user.