### PR TITLE
Fix e-notice on contact create for low-permissioned user

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -987,13 +987,15 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       $params['preferred_communication_method'] = 'null';
     }
 
-    $group = $params['group'] ?? NULL;
-    $params['group'] = ($params['group'] == '') ? [] : $params['group'];
-    if (!empty($group)) {
-      $group = is_array($group) ? $group : explode(',', $group);
-      $params['group'] = [];
-      foreach ($group as $key => $value) {
-        $params['group'][$value] = 1;
+    if (array_key_exists('group', $params)) {
+      $group = $params['group'] ?? NULL;
+      $params['group'] = ($params['group'] == '') ? [] : $params['group'];
+      if (!empty($group)) {
+        $group = is_array($group) ? $group : explode(',', $group);
+        $params['group'] = [];
+        foreach ($group as $value) {
+          $params['group'][$value] = 1;
+        }
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix e-notice on contact create for low-permissioned user

Before
----------------------------------------
I gave the default 'advisor' user (password advisor) 'create contacts' permission & created a contact & this error popped up

![image](https://github.com/civicrm/civicrm-core/assets/336308/302e7f1d-f9df-41c1-9b6a-635e51aaa7a6)


After
----------------------------------------
If the `group` value is not submitted it is not handled - it might be some config in this line https://github.com/civicrm/civicrm-core/blob/0e26e94d370f56005cf53ac46ab1695fe8b4b5cf/CRM/Contact/Form/Contact.php#L1066-L1069 that caused the field not to be present instead - but the fact remains that if the field is not added to the form then that means it should be skipped

Technical Details
----------------------------------------

Comments
----------------------------------------
