### PR TITLE
Fix error on relation-add where acl check fails

### DIFF
--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -131,7 +131,9 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
     // Check for permissions
     if (in_array($this->_action, [CRM_Core_Action::ADD, CRM_Core_Action::UPDATE, CRM_Core_Action::DELETE])) {
       if (!CRM_Contact_BAO_Contact_Permission::allow($this->_contactId, CRM_Core_Permission::EDIT)
-        && !CRM_Contact_BAO_Contact_Permission::allow($this->_values['contact_id_b'], CRM_Core_Permission::EDIT)) {
+        ||
+        (!empty($this->_values['contact_id_b']) && !CRM_Contact_BAO_Contact_Permission::allow($this->_values['contact_id_b'], CRM_Core_Permission::EDIT))
+      ) {
         CRM_Core_Error::statusBounce(ts('You do not have the necessary permission to edit this contact.'));
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fix error on relation-add where acl check fails

Before
----------------------------------------
When a contact tries to add an relationship to a contact they don't have permission to it fails with a 500 error 

After
----------------------------------------
it fails with a status bounce

Technical Details
----------------------------------------
In the add scenario there is only 1 contact ID to check for permissions. If that passes the `&&` meant it didn't check the second contact. But when it DID check the second contact (if the first one failed) it would up in `allow()` which calls `getFieldValue()` which throws an exception if no value is passed in. I tried to think of what might have made this error easier to figure out but didn't come up with something helpful. 

When I read the permission check I also felt that using an OR was wrong - ie they need permission to both contacts don't they? I can revert the and-to-or change out if people disagree

Comments
----------------------------------------
