### PR TITLE
Fix admin forms to not call deprecated functions

### DIFF
--- a/CRM/Admin/Form.php
+++ b/CRM/Admin/Form.php
@@ -15,6 +15,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\Utils\ReflectionUtils;
+
 /**
  * Base class for admin forms.
  */
@@ -154,7 +156,13 @@ class CRM_Admin_Form extends CRM_Core_Form {
     if (isset($this->_id) && CRM_Utils_Rule::positiveInteger($this->_id)) {
       if ($this->retrieveMethod === 'retrieve') {
         $params = ['id' => $this->_id];
-        $this->_BAOName::retrieve($params, $this->_values);
+        if (!empty(ReflectionUtils::getCodeDocs((new \ReflectionMethod($this->_BAOName, 'retrieve')), 'Method')['deprecated'])) {
+          CRM_Core_DAO::commonRetrieve($this->_BAOName, $params, $this->_values);
+        }
+        else {
+          // Are there still some out there?
+          $this->_BAOName::retrieve($params, $this->_values);
+        }
       }
       elseif ($this->retrieveMethod === 'api4') {
         $this->_values = civicrm_api4($this->getDefaultEntity(), 'get', [

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1520,6 +1520,8 @@ LIKE %1
   /**
    * Fetch object based on array of properties.
    *
+   * @internal - extensions should always use the api
+   *
    * @param string $daoName
    *   Name of the dao class.
    * @param array $params


### PR DESCRIPTION
Overview
----------------------------------------
Fix admin forms to not call deprecated functions

Before
----------------------------------------
deprecation notices

After
----------------------------------------
should be gone

Technical Details
----------------------------------------
@colemanw we chatted on chat about just removing the deprecation notice but then this seemed like a fairly easy way to fix them. The downside is it is not really possible to test all the forms but I  *think* you only added the deprecation warnings when they are boilerplate...

Comments
----------------------------------------
