### PR TITLE
Bubble up deprecation if getVar used to get a deprecated property

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -18,6 +18,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\Utils\ReflectionUtils;
+
 require_once 'HTML/QuickForm/Page.php';
 
 /**
@@ -2095,6 +2097,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @return mixed
    */
   public function getVar($name) {
+    if (!empty(ReflectionUtils::getCodeDocs((new ReflectionProperty($this, $name)), 'Property')['deprecated'])) {
+      CRM_Core_Error::deprecatedWarning('deprecated property accessed :' . $name);
+    }
+    // @todo - add warnings for internal properties & protected properties.
     return $this->$name;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
using `getVar()` allows extensions to access properties with less visibility on their deprecation status (it is actually itself deprecated) - this at least adds deprecation warnings if the property is deprecated. We should add more warnings for dangerous coding practices like accessing internal properties & protected properties - but want to see anything that bubbles up from this first & try to get those things fixed

Before
----------------------------------------
No warning when accessing a deprecated property via getVar

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/925fd254-547f-49a7-a428-1723dba8908c)

Technical Details
----------------------------------------
`_single` is not actually deprecated - I temporarily added the annotation for testing

Comments
----------------------------------------
