### PR TITLE
Alternate to alternate packages path for smarty3

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -263,7 +263,12 @@ if (!defined('CIVICRM_UF_BASEURL')) {
 if (!defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
   // enable by default for dev & demo sites for now - will soon enable by default for all new installs.
   if (str_contains(CIVICRM_UF_BASEURL, 'localhost') || str_contains(CIVICRM_UF_BASEURL, 'demo.civicrm.org')) {
-    define('CIVICRM_SMARTY3_AUTOLOAD_PATH', $civicrm_root . '/packages/smarty3/vendor/autoload.php');
+    if (is_dir($civicrm_root . '/packages')) {
+      define('CIVICRM_SMARTY3_AUTOLOAD_PATH', $civicrm_root . '/packages/smarty3/vendor/autoload.php');
+    }
+    elseif (is_dir($civicrm_root . '/../civicrm-packages')) {
+      define('CIVICRM_SMARTY3_AUTOLOAD_PATH', $civicrm_root . '/../civicrm-packages/smarty3/vendor/autoload.php');
+    }
   }
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
Alternate to https://github.com/civicrm/civicrm-core/pull/28745

Before
----------------------------------------
drupal8 test/dev sites likely to crash after https://github.com/civicrm/civicrm-core/pull/28725

After
----------------------------------------
Minimal hunt for packages folder since this is all temporary anyway

Technical Details
----------------------------------------
It's most likely to be in one of these two spots.

Comments
----------------------------------------

