### PR TITLE
Better defaults for CIVICRM_TEMPLATE_COMPILE_CHECK

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -187,21 +187,6 @@ if (!defined('CIVICRM_TEMPLATE_COMPILEDIR')) {
 }
 
 /**
- * SMARTY Compile Check:
- *
- * This tells Smarty whether to check for recompiling or not. Recompiling
- * does not need to happen unless a template or config file is changed.
- * Typically you enable this during development, and disable for production.
- *
- * Related issue:
- * https://lab.civicrm.org/dev/core/issues/1073
- *
- */
-//if (!defined('CIVICRM_TEMPLATE_COMPILE_CHECK')) {
-//  define('CIVICRM_TEMPLATE_COMPILE_CHECK', FALSE);
-//}
-
-/**
  * Smarty escape on output.
  *
  * This does not currently work if you have a Smarty 3 path defined
@@ -252,6 +237,21 @@ if (!defined('CIVICRM_UF_BASEURL')) {
   define( 'CIVICRM_UF_BASEURL'      , '%%baseURL%%');
 }
 
+/**
+ * SMARTY Compile Check:
+ *
+ * This tells Smarty whether to check for recompiling or not. Recompiling
+ * does not need to happen unless a template or config file is changed.
+ * Typically you enable this during development, and disable for production.
+ *
+ * Related issue:
+ * https://lab.civicrm.org/dev/core/issues/1073
+ *
+ */
+if (!defined('CIVICRM_TEMPLATE_COMPILE_CHECK')) {
+  $isProbablyDevelopmentSite = str_contains(CIVICRM_UF_BASEURL, 'localhost') || str_contains(CIVICRM_UF_BASEURL, 'staging') || str_contains(CIVICRM_UF_BASEURL, 'dev');
+  define('CIVICRM_TEMPLATE_COMPILE_CHECK',  $isProbablyDevelopmentSite);
+}
 
 /**
  * Specify a Smarty 3 autoload file.


### PR DESCRIPTION
Overview
----------------------------------------
Better defaults for `CIVICRM_TEMPLATE_COMPILE_CHECK`


Before
----------------------------------------
As documented here https://docs.civicrm.org/sysadmin/en/latest/setup/optimizations/  `CIVICRM_TEMPLATE_COMPILE_CHECK` is better set to TRUE for developers & FALSE on production sites. It is a trade off between potential confusion & performance. What to do? What to do? There is a conflict between developer & production site needs - conflict resolved by prioritising developers

After
----------------------------------------
Non-robust attempt made to default to the developer friendly option on 'probably development' sites & the prod friendly version on all other sites. Sites can still edit to the setting that is right for them

Technical Details
----------------------------------------
I think it makes more sense for developers to have to learn about & alter this setting than to default prod sites to something that does have a performance hit (not sure how much)

Comments
----------------------------------------
