### PR TITLE
Update regen online script to use php 8.1 since this doesn't have polyfills available and now str_contains makes it fail

### DIFF
--- a/.github/workflows/regen.yml
+++ b/.github/workflows/regen.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: shivammathur/setup-php@v2
         with:
-            php-version: 7.4
+            php-version: 8.1
             extensions: dom, curl, libxml, mbstring, zip, pdo, mysql, pdo_mysql, bcmath, soap, intl, gd, exif, iconv
             coverage: none
             tools: composer:v2


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
fails with php 7.4

After
----------------------------------------


Technical Details
----------------------------------------
str_contains was added recently to civicrm.settings.php and now that fails without polyfills which are normally available but aren't with regen.

Comments
----------------------------------------
I'm not sure if this might also come up in another environment that processes civicrm.settings.php without access to polyfills. A wider update might be to only use php7.4-safe things in civicrm.settings.php
