### PR TITLE
Clean up search settings page, update group cache text

### DIFF
--- a/CRM/Admin/Form/Setting/Search.php
+++ b/CRM/Admin/Form/Setting/Search.php
@@ -21,18 +21,6 @@
  */
 class CRM_Admin_Form_Setting_Search extends CRM_Admin_Form_Setting {
 
-  protected $_settings = [
-    'includeWildCardInName' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
-    'includeEmailInName' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
-    'searchPrimaryDetailsOnly' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
-    'includeNickNameInName' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
-    'includeAlphabeticalPager' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
-    'includeOrderByClause' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
-    'defaultSearchProfileID' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
-    'smartGroupCacheTimeout' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
-    'quicksearch_options' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
-  ];
-
   /**
    * Build the form object.
    */

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -321,7 +321,7 @@ return [
     'help_text' => NULL,
     'serialize' => CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
     'validate_callback' => 'CRM_Admin_Form_Setting_Search::enableOptionOne',
-    'settings_pages' => ['search' => ['weight' => 80]],
+    'settings_pages' => ['search' => ['weight' => 120]],
   ],
   'contact_reference_options' => [
     'group_name' => 'CiviCRM Preferences',
@@ -341,7 +341,7 @@ return [
     'help_text' => NULL,
     'serialize' => CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
     'validate_callback' => 'CRM_Admin_Form_Setting_Search::enableOptionOne',
-    'settings_pages' => ['search' => ['weight' => 90]],
+    'settings_pages' => ['search' => ['weight' => 130]],
   ],
   'contact_smart_group_display' => [
     'group_name' => 'CiviCRM Preferences',

--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -17,6 +17,8 @@
 /*
  * Settings metadata file
  */
+$optimizationSeeAlso = '<br/>' . ts('See also: <a href="%1">Search Optimization</a>', [1 => 'https://docs.civicrm.org/sysadmin/en/latest/setup/optimizations/" target="_blank"']);
+$searchConfigSeeAlso = '<br/>' . ts('See also: <a %1>Search Configuration Options</a>', [1 => 'https://docs.civicrm.org/en/user/latest/initial-set-up/customizing-the-user-interface/#customizing-search-preferences" target="_blank"']);
 return [
   'search_autocomplete_count' => [
     'group_name' => 'Search Preferences',
@@ -32,6 +34,7 @@ return [
     'is_contact' => 0,
     'description' => ts('The maximum number of contacts to show at a time when typing in an autocomplete field.'),
     'help_text' => NULL,
+    'settings_pages' => ['search' => ['weight' => 150]],
   ],
   'includeOrderByClause' => [
     'group_name' => 'Search Preferences',
@@ -46,6 +49,7 @@ return [
     'is_contact' => 0,
     'description' => ts('If disabled, the search results will not be ordered. This may improve response time on search results on large datasets.'),
     'help_text' => NULL,
+    'settings_pages' => ['search' => ['weight' => 60]],
   ],
   'includeWildCardInName' => [
     'group_name' => 'Search Preferences',
@@ -60,6 +64,7 @@ return [
     'is_contact' => 0,
     'description' => ts("If enabled, wildcards are automatically added to the beginning AND end of the search term when users search for contacts by Name. EXAMPLE: Searching for 'ada' will return any contact whose name includes those letters - e.g. 'Adams, Janet', 'Nadal, Jorge', etc. If disabled, a wildcard is added to the end of the search term only. EXAMPLE: Searching for 'ada' will return any contact whose last name begins with those letters - e.g. 'Adams, Janet' but NOT 'Nadal, Jorge'. Disabling this feature will speed up search significantly for larger databases, but users must manually enter wildcards ('%' or '_') to the beginning of the search term if they want to find all records which contain those letters. EXAMPLE: '%ada' will return 'Nadal, Jorge'."),
     'help_text' => NULL,
+    'settings_pages' => ['search' => ['weight' => 10]],
   ],
   'includeEmailInName' => [
     'group_name' => 'Search Preferences',
@@ -74,6 +79,7 @@ return [
     'is_contact' => 0,
     'description' => ts('If enabled, email addresses are automatically included when users search by Name. Disabling this feature will speed up search significantly for larger databases, but users will need to use the Email search fields (from Advanced Search, Search Builder, or Profiles) to find contacts by email address.'),
     'help_text' => NULL,
+    'settings_pages' => ['search' => ['weight' => 20]],
   ],
   'includeNickNameInName' => [
     'group_name' => 'Search Preferences',
@@ -88,6 +94,7 @@ return [
     'is_contact' => 0,
     'description' => ts('If enabled, nicknames are automatically included when users search by Name.'),
     'help_text' => NULL,
+    'settings_pages' => ['search' => ['weight' => 40]],
   ],
   'includeAlphabeticalPager' => [
     'group_name' => 'Search Preferences',
@@ -102,6 +109,7 @@ return [
     'is_contact' => 0,
     'description' => ts('If disabled, the alphabetical pager will not be displayed on the search screens. This will improve response time on search results on large datasets.'),
     'help_text' => NULL,
+    'settings_pages' => ['search' => ['weight' => 50]],
   ],
   'smartGroupCacheTimeout' => [
     'group_name' => 'Search Preferences',
@@ -115,8 +123,9 @@ return [
     'title' => ts('Smart group cache timeout'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => ts('The number of minutes to cache smart group contacts. We strongly recommend that this value be greater than zero, since a value of zero means no caching at all. If your contact data changes frequently, you should set this value to at least 5 minutes.'),
-    'help_text' => NULL,
+    'description' => ts('The number of minutes to cache smart group contacts. The best value will depend on your site and the complexity of the groups and acls you use. A value of zero means no caching at all. You may need to experiment with this.') . $optimizationSeeAlso,
+    'help_text' => '',
+    'settings_pages' => ['search' => ['weight' => 80]],
   ],
   'defaultSearchProfileID' => [
     'group_name' => 'Search Preferences',
@@ -138,6 +147,7 @@ return [
     'is_contact' => 0,
     'description' => ts('If set, this will be the default profile used for contact search.'),
     'help_text' => NULL,
+    'settings_pages' => ['search' => ['weight' => 70]],
   ],
   'prevNextBackend' => [
     'group_name' => 'Search Preferences',
@@ -159,6 +169,9 @@ return [
     ],
     'description' => ts('When performing a search, how should the search-results be cached?'),
     'help_text' => '',
+    // Not exposed in UI as breakage possible. As with the SmartGroupCache time out a different page
+    // might make more sense.
+    'settings_pages' => [],
   ],
   'searchPrimaryDetailsOnly' => [
     'group_name' => 'Search Preferences',
@@ -173,6 +186,7 @@ return [
     'is_contact' => 0,
     'description' => ts('If enabled, only primary details (eg contact\'s primary email, phone, etc) will be included in Basic and Advanced Search results. Disabling this feature will allow users to match contacts using any email, phone etc detail.'),
     'help_text' => NULL,
+    'settings_pages' => ['search' => ['weight' => 30]],
   ],
   'quicksearch_options' => [
     'group_name' => 'Search Preferences',
@@ -203,6 +217,7 @@ return [
     'is_contact' => 0,
     'description' => ts("Which fields can be searched on in the menubar quicksearch box? Don't see your custom field here? Make sure it is marked as Searchable."),
     'help_text' => NULL,
+    'settings_pages' => ['search' => ['weight' => 90]],
   ],
   'default_pager_size' => [
     'group_name' => 'Search Preferences',


### PR DESCRIPTION
Overview
----------------------------------------
This turned out to be quite a big dig just to fix some description text...

The primary goal of this PR was to update the text around the cache setting to not make statements that are arguable & instead provide documentation links 

![image](https://github.com/civicrm/civicrm-core/assets/336308/4ee44dfb-41cf-41fb-b6ff-9fdba47931b5)

However, in the process I determined that we should be using settings metadata to add to the form which led me to

1) realise ordering by weight wasn't working right
2)Realise that "Autocomplete Results: This determines the maximum number of results that will be displayed when typing in an autocomplete field." is documented as being on this page, but is not present
 
https://docs.civicrm.org/user/en/latest/initial-set-up/customizing-the-user-interface/#customizing-search-preferences

Before
----------------------------------------
Search setting page not a good role model :-(

After
----------------------------------------
Mostly unchanged despite the metadata changes, except for the points in the overview

![image](https://github.com/civicrm/civicrm-core/assets/336308/b3756810-e6a8-4ade-b2a2-f6c4308491fc)

![image](https://github.com/civicrm/civicrm-core/assets/336308/c5fc73db-4912-4771-b21d-7c7193f1fc96)

Technical Details
----------------------------------------

Comments
----------------------------------------
