### PR TITLE
[REF][PHP8.2] Declare properties in advanced search form

### DIFF
--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -21,6 +21,24 @@
 class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
 
   /**
+   * @var string
+   * @internal
+   */
+  public $_searchPane;
+
+  /**
+   * @var array
+   * @internal
+   */
+  public $_searchOptions = [];
+
+  /**
+   * @var array
+   * @internal
+   */
+  public $_paneTemplatePath = [];
+
+  /**
    * Processing needed for buildForm and later.
    */
   public function preProcess() {


### PR DESCRIPTION
Overview
----------------------------------------
Declare properties in `CRM_Contact_Form_Search_Advanced`

Before
----------------------------------------
`CRM_Contact_Form_Search_Advanced` causes PHP 8.2 deprecatation warnings due to dynamic property access (including in tests).

After
----------------------------------------
Properties declared.

Technical Details
----------------------------------------
I've gone `public`, `@internal` to ensure backwards compatiability. Felt like there could be people using these properties.
