### PR TITLE
[REF][PHP8.2] Local variable for tagGroup

### DIFF
--- a/CRM/Contact/Form/Edit/TagsAndGroups.php
+++ b/CRM/Contact/Form/Edit/TagsAndGroups.php
@@ -58,9 +58,7 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
     $groupElementType = 'checkbox',
     $public = FALSE
   ) {
-    if (!isset($form->_tagGroup)) {
-      $form->_tagGroup = [];
-    }
+    $tagGroup = [];
     $form->addExpectedSmartyVariable('type');
     $form->addOptionalQuickFormElement('group');
     // NYSS 5670
@@ -109,7 +107,7 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
             $groupsOptions[$key] = $group;
           }
           else {
-            $form->_tagGroup[$fName][$id]['description'] = $group['description'];
+            $tagGroup[$fName][$id]['description'] = $group['description'];
             $elements[] = &$form->addElement('advcheckbox', $id, NULL, $group['text'], $attributes);
           }
         }
@@ -143,7 +141,7 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
       $parentNames = CRM_Core_BAO_Tag::getTagSet('civicrm_contact');
       CRM_Core_Form_Tag::buildQuickForm($form, $parentNames, 'civicrm_contact', $contactId, FALSE, TRUE);
     }
-    $form->assign('tagGroup', $form->_tagGroup);
+    $form->assign('tagGroup', $tagGroup);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Convert dyanmic property into local variable.

Before
----------------------------------------
Test failing on PHP 8.2:

```
CRM_Profile_Form_EditTest::testProfileRequireTag
Creation of dynamic property CRM_Profile_Form_Edit::$_tagGroup is deprecated
```
After
----------------------------------------
Local variable used instead.

Technical Details
----------------------------------------
This is potentially _slightly_ risky from a backwards-compat point-of-view, but seems much cleaner than `_tagGroup` needing to be declared on any class using `CRM_Contact_Form_Edit_TagsAndGroups`.