### PR TITLE
[REF][PHP8.2] Replace dynamic property with local var - mailing browse page

### DIFF
--- a/CRM/Mailing/Page/Browse.php
+++ b/CRM/Mailing/Page/Browse.php
@@ -139,9 +139,9 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
     }
     $this->set('scheduled', $this->_scheduled);
 
-    $this->_createdId = CRM_Utils_Request::retrieve('cid', 'Positive', $this, FALSE, 0);
-    if ($this->_createdId) {
-      $this->set('createdId', $this->_createdId);
+    $createdId = CRM_Utils_Request::retrieve('cid', 'Positive', $this, FALSE, 0);
+    if ($createdId) {
+      $this->set('createdId', $createdId);
     }
 
     if ($this->_sms) {


### PR DESCRIPTION
Overview
----------------------------------------
Replace dynamic property with local var to improve PHP 8.2. support.

Before
----------------------------------------
Use of dynamic property (which is deprecated as of PHP 8.2)

After
----------------------------------------
Local variable used instead. The property was only used for the purpose of setting `$this->set('createdId', $createdId)`, and the value is later read with `$this->_parent->get('createdId')`, so the property is not needed.

