### PR TITLE
(dev/core#4851) composer.json - Allow newer version of oauth2-google

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
     "civicrm/composer-downloads-plugin": "^3.0",
     "league/csv": "~9.7.4",
     "league/oauth2-client": "^2.4",
-    "league/oauth2-google": "^3.0",
+    "league/oauth2-google": "^3.0 || ^4.0",
     "tplaner/when": "~3.1",
     "xkerman/restricted-unserialize": "~1.1",
     "typo3/phar-stream-wrapper": "^2 || ^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9bd88911ac05e61e199444889b78fc8e",
+    "content-hash": "4d83914e1eba4abeb1a44bcc1512aa47",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -1174,6 +1174,7 @@
                     "type": "community_bridge"
                 }
             ],
+            "abandoned": true,
             "time": "2020-09-14T14:23:00+00:00"
         },
         {


### PR DESCRIPTION
Overview
----------------------------------------

For [dev/core#3581](https://lab.civicrm.org/dev/core/-/issues/4851), declare broader compatibility with the `oauth2-google` library.

Technical Details
----------------------------------------

I looked at the diffs for v3.0.4 and 4.0.0.

* They raised the requirements to PHP 7.3/8.0 and added some type-hints.
* They raised the test-env to PHPUnit 8/9
* They updated some metadata to say ^^^.
* That's it.... that's the change...
* The main contracts are provided by `league/oauth2-client` -- which hasn't changed. It's still the same v2.x requirement.
* I don't believe that Civi directly extends/overrides any of the Google Auth stuff.

Comments
----------------------------------------

I haven't `r-run`, but note that this doesn't change the `composer.lock`, so it should work the same for zip/tar users. If you want, you could [make a D10 build of the PR](https://test.civicrm.org/job/CiviCRM-Manual/), enable OAuth Client, add a Google connection, and try to connect. Dummy details may be good enough -- you just want to see that the updated classes are loadable (*no syntax conflicts from the type-hints*).