### PR TITLE
[REF][PHP8.2] Use correct form object to ensure properties exist

### DIFF
--- a/tests/phpunit/CRM/Contact/Form/Task/SMSCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/SMSCommonTest.php
@@ -97,7 +97,8 @@ class CRM_Contact_Form_Task_SMSCommonTest extends CiviUnitTestCase {
    * Test to ensure SMS Activity QuickForm displays the right phone numbers.
    */
   public function testQuickFormMobileNumbersDisplay(): void {
-    $form = $this->getFormObject('CRM_Core_Form');
+    /** @var CRM_Activity_Form_Task_SMS $form */
+    $form = $this->getFormObject('CRM_Contact_Form_Task_SMS');
     $form->_contactIds = array_values($this->ids['Contact']);
     $form->_single = FALSE;
     CRM_Contact_Form_Task_SMSCommon::buildQuickForm($form);


### PR DESCRIPTION
Before
----------------------------------------
One of the test failures on PHP 8.2 is:

```
CRM_Contact_Form_Task_SMSCommonTest::testQuickFormMobileNumbersDisplay
Creation of dynamic property CRM_Core_Form::$_contactIds is deprecated

/home/homer/buildkit/build/build-1/web/sites/all/modules/civicrm/tests/phpunit/CRM/Contact/Form/Task/SMSCommonTest.php:101
/home/homer/buildkit/build/build-1/web/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:247
/home/homer/buildkit/extern/phpunit9/phpunit9.phar:2307
```

This comes from this code:
```
$form = $this->getFormObject('CRM_Core_Form');
$form->_contactIds = array_values($this->ids['Contact']);
$form->_single = FALSE;
CRM_Contact_Form_Task_SMSCommon::buildQuickForm($form);
```

`_contactIds` and `_single` don't exist directly on `CRM_Core_Form`, hence the warning.

After
----------------------------------------
Outside of the tests, `CRM_Contact_Form_Task_SMSCommon::buildQuickForm` is never called with a plain instance of `CRM_Core_Form`. It's always called with either `CRM_Activity_Form_Task_SMS` or `CRM_Contact_Form_Task_SMS`, which do have `_contactIds` and `_single` defined.

Therefore, let's test based on one of the objects that is used in the real use of the code. The decision to use `CRM_Activity_Form_Task_SMS` rather than `CRM_Contact_Form_Task_SMS` was completely arbitrary.

Comments
----------------------------------------
I'm not sure if this will have any side-effects. Let's see what the test results have to say.
