### PR TITLE
[REF] Tidy up use of _cancelURL property

### DIFF
--- a/CRM/Contribute/Form/ContributionPage.php
+++ b/CRM/Contribute/Form/ContributionPage.php
@@ -131,14 +131,14 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
     $this->applyFilter('__ALL__', 'trim');
 
     $session = CRM_Core_Session::singleton();
-    $this->_cancelURL = $_POST['cancelURL'] ?? NULL;
+    $cancelURL = $_POST['cancelURL'] ?? NULL;
 
-    if (!$this->_cancelURL) {
-      $this->_cancelURL = CRM_Utils_System::url('civicrm/admin/contribute', 'reset=1');
+    if (!$cancelURL) {
+      $cancelURL = CRM_Utils_System::url('civicrm/admin/contribute', 'reset=1');
     }
 
-    if ($this->_cancelURL) {
-      $this->addElement('hidden', 'cancelURL', $this->_cancelURL);
+    if ($cancelURL) {
+      $this->addElement('hidden', 'cancelURL', $cancelURL);
     }
 
     $buttons = [
@@ -154,7 +154,7 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
     ];
     $this->addButtons($buttons);
 
-    $session->replaceUserContext($this->_cancelURL);
+    $session->replaceUserContext($cancelURL);
 
     // don't show option for contribution amounts section if membership price set
     // this flag is sent to template

--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -55,8 +55,6 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
    */
   protected $_templateId;
 
-  protected $_cancelURL = NULL;
-
   /**
    * The campaign id of the existing event, we use this to know if we need to update
    * the participant records
@@ -246,23 +244,23 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
   public function buildQuickForm() {
     $session = CRM_Core_Session::singleton();
 
-    $this->_cancelURL = $_POST['cancelURL'] ?? NULL;
+    $cancelURL = $_POST['cancelURL'] ?? NULL;
 
-    if (!$this->_cancelURL) {
+    if (!$cancelURL) {
       if ($this->_isTemplate) {
-        $this->_cancelURL = CRM_Utils_System::url('civicrm/admin/eventTemplate',
+        $cancelURL = CRM_Utils_System::url('civicrm/admin/eventTemplate',
           'reset=1'
         );
       }
       else {
-        $this->_cancelURL = CRM_Utils_System::url('civicrm/event/manage',
+        $cancelURL = CRM_Utils_System::url('civicrm/event/manage',
           'reset=1'
         );
       }
     }
 
-    if ($this->_cancelURL) {
-      $this->addElement('hidden', 'cancelURL', $this->_cancelURL);
+    if ($cancelURL) {
+      $this->addElement('hidden', 'cancelURL', $cancelURL);
     }
 
     if ($this->_single) {
@@ -301,7 +299,7 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
 
       $this->addButtons($buttons);
     }
-    $session->replaceUserContext($this->_cancelURL);
+    $session->replaceUserContext($cancelURL);
     $this->add('hidden', 'is_template', $this->_isTemplate);
   }
 

--- a/CRM/Profile/Form/Edit.php
+++ b/CRM/Profile/Form/Edit.php
@@ -25,7 +25,6 @@
  */
 class CRM_Profile_Form_Edit extends CRM_Profile_Form {
   protected $_postURL = NULL;
-  protected $_cancelURL = NULL;
   protected $_errorURL = NULL;
   protected $_context;
   protected $_blockNo;
@@ -148,7 +147,7 @@ SELECT module,is_reserved
 
     if ($this->_context !== 'dialog') {
       $this->_postURL = $this->_ufGroup['post_url'];
-      $this->_cancelURL = $this->_ufGroup['cancel_url'];
+      $cancelURL = $this->_ufGroup['cancel_url'];
 
       $gidString = $this->_gid;
       if (!empty($this->_profileIds)) {
@@ -172,15 +171,15 @@ SELECT module,is_reserved
         }
       }
 
-      if (!$this->_cancelURL) {
-        $this->_cancelURL = CRM_Utils_System::url('civicrm/profile',
+      if (!$cancelURL) {
+        $cancelURL = CRM_Utils_System::url('civicrm/profile',
           "reset=1&gid={$gidString}"
         );
       }
 
       // we do this gross hack since qf also does entity replacement
       $this->_postURL = str_replace('&amp;', '&', ($this->_postURL ?? ''));
-      $this->_cancelURL = str_replace('&amp;', '&', ($this->_cancelURL ?? ''));
+      $cancelURL = str_replace('&amp;', '&', ($cancelURL ?? ''));
 
       // also retain error URL if set
       $this->_errorURL = $_POST['errorURL'] ?? NULL;
@@ -197,7 +196,7 @@ SELECT module,is_reserved
 
     parent::buildQuickForm();
 
-    $this->assign('cancelURL', $this->_cancelURL);
+    $this->assign('cancelURL', $cancelURL);
 
     $cancelButtonValue = !empty($this->_ufGroup['cancel_button_text']) ? $this->_ufGroup['cancel_button_text'] : ts('Cancel');
     $this->assign('cancelButtonText', $cancelButtonValue);


### PR DESCRIPTION
Overview
----------------------------------------
Tidy up use of `_cancelURL` property

Before/ After
----------------------------------------
One of the test failures on PHP 8.2 is this:
```
CRM_Contribute_Form_ContributionTest::testOpeningWidgetAdminPage
Creation of dynamic property CRM_Contribute_Form_ContributionPage_Widget::$_cancelURL is deprecated
```

In `CRM_Contribute_Form_ContributionPage_Widget` the `_cancelURL` property was only used within a single method, `buildQuickForm`. Therefore, it might as well be a local-scope variable.

`CRM_Profile_Form_Edit` and `CRM_Event_Form_ManageEvent` had almost identical code, except a `protected` property was declared. These two have also been switched over to a normal variable, and the property definition deleted.