### PR TITLE
Declare caseId, caseIds as public properties

### DIFF
--- a/CRM/Contact/Form/Task/PDF.php
+++ b/CRM/Contact/Form/Task/PDF.php
@@ -36,6 +36,28 @@ class CRM_Contact_Form_Task_PDF extends CRM_Contact_Form_Task {
   public $_activityId = NULL;
 
   /**
+   * This should be replaced by an externally supposed getCaseID() method.
+   *
+   * Property may change as it is not really required.
+   *
+   * @var int|null
+   *
+   * @internal
+   */
+  public $_caseId;
+
+  /**
+   * This should be replaced by an externally supposed getCaseID() method.
+   *
+   * Property may change as it is kinda weird.
+   *
+   * @var int|null
+   *
+   * @internal
+   */
+  public $_caseIds;
+
+  /**
    * Build all the data structures needed to build the form.
    */
   public function preProcess() {


### PR DESCRIPTION
Overview
----------------------------------------
 Property may change as it is kinda weird.

Before
----------------------------------------
Undeclared

After
----------------------------------------
declared, public, internal

Technical Details
----------------------------------------
I think these properties are kinda horrible & especially the way it does funky custom token handling off the back of them & no-where else  - but this is also not code I want to get too bogged down with

Comments
----------------------------------------
