### PR TITLE
Use lookup not form property for BillingID in payment form class

### DIFF
--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -55,7 +55,7 @@ class CRM_Core_Payment_Form {
     $form->assign('paymentTypeLabel', self::getPaymentLabel($processor['object']));
     $form->assign('isBackOffice', $isBackOffice);
     $form->_paymentFields = self::getPaymentFieldMetadata($processor);
-    $form->_paymentFields = array_merge($form->_paymentFields, self::getBillingAddressMetadata($processor, $form->_bltID));
+    $form->_paymentFields = array_merge($form->_paymentFields, self::getBillingAddressMetadata($processor));
     $form->assign('paymentFields', self::getPaymentFields($processor));
     self::setBillingAddressFields($form, $processor);
   }
@@ -67,7 +67,7 @@ class CRM_Core_Payment_Form {
    * @param CRM_Core_Payment $processor
    */
   protected static function setBillingAddressFields(&$form, $processor) {
-    $billingID = $form->_bltID;
+    $billingID = CRM_Core_BAO_LocationType::getBilling();
     $smarty = CRM_Core_Smarty::singleton();
     $smarty->assign('billingDetailsFields', self::getBillingAddressFields($processor, $billingID));
   }
@@ -147,27 +147,25 @@ class CRM_Core_Payment_Form {
    * Get the billing fields that apply to this processor.
    *
    * @param array $paymentProcessor
-   * @param int $billingLocationID
-   *   ID of billing location type.
    *
    * @todo sometimes things like the country alter the required fields (e.g postal code). We should possibly
    * set these before calling getPaymentFormFields (as we identify them).
    *
    * @return array
    */
-  public static function getBillingAddressFields($paymentProcessor, $billingLocationID) {
+  public static function getBillingAddressFields($paymentProcessor) {
+    $billingLocationID = CRM_Core_BAO_LocationType::getBilling();
     return $paymentProcessor['object']->getBillingAddressFields($billingLocationID);
   }
 
   /**
    * @param array $paymentProcessor
    *
-   * @param int $billingLocationID
-   *
    * @return array
    * @throws \CRM_Core_Exception
    */
-  public static function getBillingAddressMetadata($paymentProcessor, $billingLocationID) {
+  public static function getBillingAddressMetadata($paymentProcessor) {
+    $billingLocationID = CRM_Core_BAO_LocationType::getBilling();
     $paymentProcessorObject = Civi\Payment\System::singleton()->getByProcessor($paymentProcessor);
     return array_intersect_key(
       $paymentProcessorObject->getBillingAddressFieldsMetadata($billingLocationID),
@@ -268,17 +266,17 @@ class CRM_Core_Payment_Form {
   public static function setDefaultValues(&$form, $contactID) {
     $billingDefaults = $form->getProfileDefaults('Billing', $contactID);
     $form->_defaults = array_merge($form->_defaults, $billingDefaults);
-
+    $billingLocationID = CRM_Core_BAO_LocationType::getBilling();
     // set default country & state from config if no country set
     // note the effect of this is to set the billing country to default to the site default
     // country if the person has an address but no country (for anonymous country is set above)
     // this could have implications if the billing profile is filled but hidden.
     // this behaviour has been in place for a while but the use of js to hide things has increased
-    if (empty($form->_defaults["billing_country_id-{$form->_bltID}"])) {
-      $form->_defaults["billing_country_id-{$form->_bltID}"] = CRM_Core_Config::singleton()->defaultContactCountry;
+    if (empty($form->_defaults["billing_country_id-{$billingLocationID}"])) {
+      $form->_defaults["billing_country_id-{$billingLocationID}"] = CRM_Core_Config::singleton()->defaultContactCountry;
     }
-    if (empty($form->_defaults["billing_state_province_id-{$form->_bltID}"])) {
-      $form->_defaults["billing_state_province_id-{$form->_bltID}"] = CRM_Core_Config::singleton()
+    if (empty($form->_defaults["billing_state_province_id-{$billingLocationID}"])) {
+      $form->_defaults["billing_state_province_id-{$billingLocationID}"] = CRM_Core_Config::singleton()
         ->defaultContactStateProvince;
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
We have been moving away from having to set a variable with an undecipherable name (to those not steeped in CiviCRM code) given it is always the same value - this does it in another class

Before
----------------------------------------
Gets value from _bltID

After
----------------------------------------
Gets value from the funciton used to populate _bltID

Technical Details
----------------------------------------

Comments
----------------------------------------
