### PR TITLE
Remove bltID from eventFees class

### DIFF
--- a/CRM/Event/Form/EventFees.php
+++ b/CRM/Event/Form/EventFees.php
@@ -57,6 +57,7 @@ class CRM_Event_Form_EventFees {
    */
   public static function setDefaultValues(&$form) {
     $defaults = [];
+    $billingLocationTypeID = CRM_Core_BAO_LocationType::getBilling();
 
     if ($form->_pId) {
       $ids = [];
@@ -86,12 +87,12 @@ class CRM_Event_Form_EventFees {
     if ($form->_mode) {
       $config = CRM_Core_Config::singleton();
       // set default country from config if no country set
-      if (empty($defaults["billing_country_id-{$form->_bltID}"])) {
-        $defaults["billing_country_id-{$form->_bltID}"] = $config->defaultContactCountry;
+      if (empty($defaults["billing_country_id-{$billingLocationTypeID}"])) {
+        $defaults["billing_country_id-{$billingLocationTypeID}"] = $config->defaultContactCountry;
       }
 
-      if (empty($defaults["billing_state_province_id-{$form->_bltID}"])) {
-        $defaults["billing_state_province_id-{$form->_bltID}"] = $config->defaultContactStateProvince;
+      if (empty($defaults["billing_state_province_id-{$billingLocationTypeID}"])) {
+        $defaults["billing_state_province_id-{$billingLocationTypeID}"] = $config->defaultContactStateProvince;
       }
 
       $billingDefaults = $form->getProfileDefaults('Billing', $form->_contactId);


### PR DESCRIPTION
Overview
----------------------------------------
Stop referring to `_bltID` in event fees class

Before
----------------------------------------
bltID stands for Bright Little Twinkie ID & is always set  (assuming no-one forgot to set it) to the value returned by `CRM_Core_BAO_LocationType::getBilling()` 

After
----------------------------------------
We just look it up as needed in from `CRM_Core_BAO_LocationType::getBilling()`

Technical Details
----------------------------------------

Comments
----------------------------------------
