### PR TITLE
[PHP8.2] Fix test fails on event cart

### DIFF
--- a/ext/eventcart/CRM/Event/Cart/Form/Cart.php
+++ b/ext/eventcart/CRM/Event/Cart/Form/Cart.php
@@ -23,13 +23,11 @@ class CRM_Event_Cart_Form_Cart extends CRM_Core_Form {
 
     $this->checkWaitingList();
 
-    $this->assignBillingType();
-
     $event_titles = [];
     foreach ($this->cart->get_main_events_in_carts() as $event_in_cart) {
       $event_titles[] = $event_in_cart->event->title;
     }
-    $this->description = ts("Online Registration for %1", [1 => implode(", ", $event_titles)]);
+
     if (!isset($this->discounts)) {
       $this->discounts = [];
     }
@@ -91,9 +89,7 @@ class CRM_Event_Cart_Form_Cart extends CRM_Core_Form {
     if (is_string($empty_seats)) {
       return 0;
     }
-    else {
-      return NULL;
-    }
+    return NULL;
   }
 
   /**
@@ -114,8 +110,7 @@ class CRM_Event_Cart_Form_Cart extends CRM_Core_Form {
     }
 
     // check if the user is registered and we have a contact ID
-    $session = CRM_Core_Session::singleton();
-    return $session->get('userID');
+    return CRM_Core_Session::getLoggedInContactID();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
[PHP8.2] Fix test fails on event cart

Before
----------------------------------------
php 8.x test failures on setting `_bltID` (which stands for bouncy legume truck ID) - but after digging into the variable a bit I am confident that does not need to be set here in any of the 3 ways `assignBillingType()` sets it - so that call is removed, as is the unused `description`

After
----------------------------------------
Will pass

Technical Details
----------------------------------------
The form object is not passed to any other functions 

Comments
----------------------------------------

It would be great to find a way to make it clear this extension is not supported for php 8 & make it clearly unsupported...
