### PR TITLE
dev/core#4841 Ensure that APIv4 have same default values which ensure…

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1561,8 +1561,8 @@ ORDER BY   civicrm_email.is_bulkmail DESC
         'url_tracking' => Civi::settings()->get('url_tracking_default'),
         'visibility' => 'Public Pages',
         'replyto_email' => $domain_email,
-        'header_id' => CRM_Mailing_PseudoConstant::defaultComponent('header_id', ''),
-        'footer_id' => CRM_Mailing_PseudoConstant::defaultComponent('footer_id', ''),
+        'header_id' => CRM_Mailing_PseudoConstant::defaultComponent('Header', ''),
+        'footer_id' => CRM_Mailing_PseudoConstant::defaultComponent('Footer', ''),
         'from_email' => $domain_email,
         'from_name' => $domain_name,
         'msg_template_id' => NULL,
@@ -2437,6 +2437,22 @@ LEFT JOIN civicrm_mailing_group g ON g.mailing_id   = m.id
    * @throws CRM_Core_Exception
    */
   public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
+    if ($event->action === 'create') {
+      $params = &$event->params;
+      $params['created_id'] ??= CRM_Core_Session::singleton()->getLoggedInContactID();
+      $params['override_verp'] ??= !Civi::settings()->get('track_civimail_replies');
+      $params['visibility'] ??= 'Public Pages';
+      $params['dedupe_email'] ??= Civi::settings()->get('dedupe_email_default');
+      $params['open_tracking'] ??= Civi::settings()->get('open_tracking_default');
+      $params['url_tracking'] ??= Civi::settings()->get('url_tracking_default');
+      $params['header_id'] ??= CRM_Mailing_PseudoConstant::defaultComponent('Header', '');
+      $params['footer_id'] ??= CRM_Mailing_PseudoConstant::defaultComponent('Footer', '');
+      $params['optout_id'] ??= CRM_Mailing_PseudoConstant::defaultComponent('OptOut', '');
+      $params['reply_id'] ??= CRM_Mailing_PseudoConstant::defaultComponent('Reply', '');
+      $params['resubscribe_id'] ??= CRM_Mailing_PseudoConstant::defaultComponent('Resubscribe', '');
+      $params['unsubscribe_id'] ??= CRM_Mailing_PseudoConstant::defaultComponent('Unsubscribe', '');
+      $params['mailing_type'] ??= 'standalone';
+    }
     if ($event->action === 'delete' && $event->id) {
       // Delete all file attachments
       CRM_Core_BAO_File::deleteEntityFile('civicrm_mailing', $event->id);

--- a/CRM/Mailing/PseudoConstant.php
+++ b/CRM/Mailing/PseudoConstant.php
@@ -190,7 +190,7 @@ class CRM_Mailing_PseudoConstant extends CRM_Core_PseudoConstant {
         self::$defaultComponent[$dao->component_type] = $dao->id;
       }
     }
-    $value = CRM_Utils_Array::value($type, self::$defaultComponent, $undefined);
+    $value = self::$defaultComponent[$type] ?? $undefined;
     return $value;
   }
 

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -117,24 +117,6 @@ function _civicrm_api3_mailing_gettokens_spec(&$params) {
  *   Array of parameters determined by getfields.
  */
 function _civicrm_api3_mailing_create_spec(&$params) {
-  $params['created_id']['api.default'] = 'user_contact_id';
-
-  $params['override_verp']['api.default'] = !CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME, 'track_civimail_replies');
-  $params['visibility']['api.default'] = 'Public Pages';
-  $params['dedupe_email']['api.default'] = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME, 'dedupe_email_default');
-
-  $params['forward_replies']['api.default'] = FALSE;
-  $params['auto_responder']['api.default'] = FALSE;
-  $params['open_tracking']['api.default'] = Civi::settings()->get('open_tracking_default');
-  $params['url_tracking']['api.default'] = Civi::settings()->get('url_tracking_default');
-
-  $params['header_id']['api.default'] = CRM_Mailing_PseudoConstant::defaultComponent('Header', '');
-  $params['footer_id']['api.default'] = CRM_Mailing_PseudoConstant::defaultComponent('Footer', '');
-  $params['optout_id']['api.default'] = CRM_Mailing_PseudoConstant::defaultComponent('OptOut', '');
-  $params['reply_id']['api.default'] = CRM_Mailing_PseudoConstant::defaultComponent('Reply', '');
-  $params['resubscribe_id']['api.default'] = CRM_Mailing_PseudoConstant::defaultComponent('Resubscribe', '');
-  $params['unsubscribe_id']['api.default'] = CRM_Mailing_PseudoConstant::defaultComponent('Unsubscribe', '');
-  $params['mailing_type']['api.default'] = 'standalone';
   $defaultAddress = CRM_Core_BAO_Domain::getNameAndEmail(TRUE, TRUE);
   foreach ($defaultAddress as $value) {
     if (preg_match('/"(.*)" <(.*)>/', $value, $match)) {


### PR DESCRIPTION
…s that all required selects are filled out when creating new bulk mailing from Search Kit

Overview
----------------------------------------
This fixes an issue where after creating a CiviMail from search kit result and filling out what seems to be all the required fields the next button still doesn't activate

Before
----------------------------------------
Cannot complete CiviMail created from search kit

After
----------------------------------------
Can complete mailing

ping @colemanw 