### PR TITLE
Fixes two small accordion UX regressions

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2274,6 +2274,7 @@ div.crm-master-accordion-header a.helpicon {
 }
 
 .crm-container div.collapsed .crm-accordion-body,
+.crm-container fieldset.collapsed .crm-accordion-body,
 .crm-container .crm-collapsible.collapsed .collapsible-title + * {
   display: none;
 }

--- a/templates/CRM/Activity/Form/Search.tpl
+++ b/templates/CRM/Activity/Form/Search.tpl
@@ -9,7 +9,7 @@
 *}
 {* Search form and results for Activities *}
 <div class="crm-form-block crm-search-form-block">
-  <details class="crm-accordion-wrapper crm-advanced_search_form-accordion" open="">
+  <details class="crm-accordion-wrapper crm-advanced_search_form-accordion" {if !$rows}open=""{/if}">
     <summary class="crm-accordion-header crm-master-accordion-header">
       {ts}Edit Search Criteria{/ts}
     </summary>


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes two small UX issues introduced in 5.69's work on accessible accordions:
 - Keeps search criteria fieldset closed when results are found. This PR https://github.com/civicrm/civicrm-core/pull/28421 removed the feature that the search criteria are closed after results are found, and instead defaulted to always open. This was identified in https://github.com/civicrm/civicrm-core/pull/28661 by @demeritcowboy for the Advanced Search screen. This fixes it for the Activity Search screen.
  - Adds fallback support in civicrm.css for fieldsets that use the old '.collapsed' pattern. The targeting of this had been tightened in this commit: https://github.com/civicrm/civicrm-core/commit/1602ec3e104de40e7bd785496f0cde323fe870ed  to only target divs, but this excludes fieldsets used with this pattern (identified in [ThemeTest, Accordion 4](https://lab.civicrm.org/extensions/themetest/-/blob/main/ang/themetest/snippets/accordion4.html)).
  
Before
----------------------------------------
- Activity Search criteria accordion is open whether or not there are results.
- Fieldset accordions default to always open 

After
----------------------------------------
- Activity Search criteria accordion is closed if results are found 
- Fieldset accordions bodies in old layout aren't shown 

Technical Details
----------------------------------------
Things work without this PR, this just restores the behavior they had until 5.68.

Comments
----------------------------------------
Maybe this should be two PRs, but both seem small regressions and relate to open/closed states.
