### PR TITLE
Manage Extensions: hide the type/module column

### DIFF
--- a/templates/CRM/Admin/Page/Extensions/Main.tpl
+++ b/templates/CRM/Admin/Page/Extensions/Main.tpl
@@ -1,6 +1,5 @@
 {*
 Display a table of locally-available extensions.
-
 Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
 *}
 {if $localExtensionRows}
@@ -13,7 +12,6 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
           <th>{ts}Name{/ts}</th>
           <th>{ts}Status{/ts}</th>
           <th>{ts}Version{/ts}</th>
-          <th>{ts}Type{/ts}</th>
           <th></th>
         </tr>
       </thead>
@@ -39,11 +37,8 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
               {icon icon="fa-check-circle crm-extensions-stage"}{ts}This is a stable release version.{/ts}{/icon}
             {/if}
           </td>
-          <td class="crm-extensions-description">{$row.type|escape|capitalize}</td>
           <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
-                
-            
         {/foreach}
       </tbody>
     </table>
@@ -51,7 +46,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
   </div>
 {else}
   <div class="messages status no-popup">
-       {icon icon="fa-info-circle"}{/icon}
-      {ts 1="https://civicrm.org/extensions"}There are no extensions to display. Click the "Add New" tab to browse and install extensions posted on the <a href="%1">public CiviCRM Extensions Directory</a>. If you have downloaded extensions manually and don't see them here, try clicking the "Refresh" button.{/ts}
+    {icon icon="fa-info-circle"}{/icon}
+    {ts 1="https://civicrm.org/extensions"}There are no extensions to display. Click the "Add New" tab to browse and install extensions posted on the <a href="%1">public CiviCRM Extensions Directory</a>. If you have downloaded extensions manually and don't see them here, try clicking the "Refresh" button.{/ts}
   </div>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------

Go to Administer > System Settings > Extensions

The "Type" column is always "Module", which isn't terribly useful.

A very long time ago, we had other types, such as "report" or maybe payment-processor, but they haven't been in use in a very long time. If we were to re-introduce this kind of taxonomy, it would probably be in the form of a filter field (ex: themes, payment processor, event, mail, etc).

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/aa43e43b-9bff-4b9c-9712-0ca16641777e)

After
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/5fb9e015-cc45-4a5a-8925-378a31cb55eb)

Comments
----------------------------------------

I know we keep saying that we need to convert this to SearchKit, but this was a quickfix :grimacing: 