### PR TITLE
[REF][PHP8.2] Declare _lastParticipant property

### DIFF
--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -28,6 +28,14 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
   public $additionalParticipantId = NULL;
 
   /**
+   * Tracks whether we are at the last participant.
+   *
+   * @var bool
+   * @internal
+   */
+  public $_lastParticipant = FALSE;
+
+  /**
    * Get the active UFGroups (profiles) on this form
    * Many forms load one or more UFGroups (profiles).
    * This provides a standard function to retrieve the IDs of those profiles from the form


### PR DESCRIPTION
Overview
----------------------------------------
Declare `_lastParticipant` property on `CRM_Event_Form_Registration_AdditionalParticipant`.

Before
----------------------------------------
Test failure:

```
CRM_Event_Form_Registration_ConfirmTest::testMailMultipleParticipant
Creation of dynamic property CRM_Event_Form_Registration_AdditionalParticipant::$_lastParticipant is deprecated
```

After
----------------------------------------
Property declared 

Comments
----------------------------------------
This is one of a few missing properties on this class, but I suspect some of this may generate discussion, so starting small!
