### PR TITLE
civicrm.css: replace button float:left by inline-block

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -1863,8 +1863,10 @@ input.crm-form-entityref {
 
 .crm-container .crm-submit-buttons,
 .crm-container .action-link {
-  height: 27px;
   margin: 4px 0 4px 2px;
+}
+.crm-container .action-link {
+  height: 27px;
 }
 
 .crm-container .register_link-top {
@@ -1902,8 +1904,7 @@ input.crm-form-entityref {
   text-decoration: none;
   cursor: pointer;
   border: 1px solid #3e3e3e;
-  display: block;
-  float: left;
+  display: inline-block;
   overflow: hidden;
   line-height: 135%;
   border-radius: 3px;


### PR DESCRIPTION
Overview
----------------------------------------

CiviCRM buttons have a `float: left` by default, which is a bit annoying because it messes with borders and backgrounds. I regularly encounter situations where I need to remove the `float`.

The parent div also has a very specific height of 27px, which often needs to be overridden.

Before
----------------------------------------

`float: left`

![image](https://github.com/civicrm/civicrm-core/assets/254741/f11cdb27-df67-481e-a406-21150d0d5bd7)

After
----------------------------------------

`display: inline-block`

![image](https://github.com/civicrm/civicrm-core/assets/254741/622a7971-b824-44bc-a929-dc8dd9423ab9)

Technical Details
----------------------------------------

I chose `inline-block` because that is what Shoreditch / The Island uses, and provides the best result when there are multiple buttons. 

cc @vingle @artfulrobot 