### PR TITLE
remove incorrect message that grant could not be deleted

### DIFF
--- a/ext/civigrant/CRM/Grant/Form/Task/Delete.php
+++ b/ext/civigrant/CRM/Grant/Form/Task/Delete.php
@@ -63,7 +63,7 @@ class CRM_Grant_Form_Task_Delete extends CRM_Grant_Form_Task {
   public function postProcess() {
     $deleted = $failed = 0;
     foreach ($this->_grantIds as $grantId) {
-      if (CRM_Grant_BAO_Grant::del($grantId)) {
+      if (CRM_Grant_BAO_Grant::deleteRecord(['id' => $grantId])) {
         $deleted++;
       }
       else {


### PR DESCRIPTION
Overview
----------------------------------------
Deleting grants from the "Find Grants" search gives a false warning that the grants could not be deleted, even though they were.

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/1796012/19ef040f-8a20-4deb-b86e-54746b532071)

After
----------------------------------------
No error.  Well, the timeout message still happens but that might just be a caching issue.

Technical Details
----------------------------------------
#26594 converted grants to using `writeRecord()` and deprecated the `del()` method on the BAO, but it was a) still used here, b) now returned the wrong result.  So the issue is cosmetic but misleading.

I know this is technically a regression.  Given that it's 4 releases back and relatively minor (and rarely encountered) I'm putting it against master.