### PR TITLE
dev/core#4674 - Add Oauth links for AdminUi MailSettings

### DIFF
--- a/ext/civi_mail/Civi/Api4/Service/Links/MailSettingsLinksProvider.php
+++ b/ext/civi_mail/Civi/Api4/Service/Links/MailSettingsLinksProvider.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Links;
+
+use Civi\API\Event\RespondEvent;
+
+/**
+ * @service
+ * @internal
+ */
+class MailSettingsLinksProvider extends \Civi\Core\Service\AutoSubscriber {
+  use LinksProviderTrait;
+
+  public static function getSubscribedEvents(): array {
+    return [
+      'civi.api.respond' => 'alterLinksResult',
+    ];
+  }
+
+  public static function alterLinksResult(RespondEvent $e): void {
+    $request = $e->getApiRequest();
+    if ($request['version'] == 4 && is_a($request, '\Civi\Api4\Action\GetLinks') && $request->getEntityName() === 'MailSettings') {
+      $links = (array) $e->getResponse();
+      $addLinkIndex = self::getActionIndex($links, 'add');
+      // Unset the generic "add" link and replace it with links to each mailSetup account
+      // @see \CRM_Utils_Hook::mailSetupActionsx
+      if (isset($addLinkIndex) && $request->getExpandMultiple()) {
+        // Use the single add link from the schema as a template
+        $addTemplate = $links[$addLinkIndex];
+        $newLinks = [];
+        foreach (\CRM_Core_BAO_MailSettings::getSetupActions() as $key => $action) {
+          $link = $addTemplate;
+          $link['text'] = $action['title'];
+          // The standard link is fine as-is. Others use a redirect:
+          if ($key !== 'standard') {
+            $link['path'] = "civicrm/ajax/setupMailAccount?type=$key";
+            $link['target'] = '_blank';
+          }
+          $newLinks[] = $link;
+          if (isset($addTemplate['weight'])) {
+            $addTemplate['weight']++;
+          }
+        }
+        array_splice($links, $addLinkIndex, 1, $newLinks);
+      }
+      $e->getResponse()->exchangeArray(array_values($links));
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
---------
This fixes https://lab.civicrm.org/dev/core/-/issues/4674 by adding a LinksProvider for the new GetLinks action from #27973.

Before
---------
No dropdown for multiple providers in the AdminUI version of this page.

After
---------
![image](https://github.com/civicrm/civicrm-core/assets/2874912/0a5c060f-e0fa-46f2-aca9-584cb61daf22)

Technical Details
----------------------------------------

It uses the `CRM_Core_BAO_MailSettings::getSetupActions()` function to generate the extra links, but there is a mismatch between the two functions:

- `getSetupActions()` returns a fully-formed url.
- `api4.getLinks()` returns a path.

However, I noticed that while in theory `hook_civicrm_mailSetupActions` could return various urls, in practice they are all the same: a generic `civicrm/ajax/setupMailAccount` redirect. So this always returns that as the path and it works.

Perhaps we can deprecate the option to return a url from `hook_civicrm_mailSetupActions` (or just remove it, since it appears to be unused & YAGNI).
