### PR TITLE
Standardise `getTemplateVars()`

### DIFF
--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -426,7 +426,7 @@ class CRM_Contact_Form_Edit_Address {
       CRM_Contact_Form_Edit_Address::storeRequiredCustomDataInfo($form, $groupTree);
 
       $tplGroupTree = CRM_Core_Smarty::singleton()
-        ->get_template_vars('address_groupTree');
+        ->getTemplateVars('address_groupTree');
       $tplGroupTree = empty($tplGroupTree) ? [] : $tplGroupTree;
 
       $form->assign('address_groupTree', $tplGroupTree + [$blockId => $groupTree]);

--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -623,12 +623,23 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
   /**
    * Returns an array containing template variables.
    *
+   * @deprecated since 5.69 will be removed around 5.93. use getTemplateVars.
+   *
    * @param string $name
    *
    * @return array
    */
   public function get_template_vars($name = NULL) {
-    return self::$_template->get_template_vars($name);
+    return $this->getTemplateVars($name);
+  }
+
+  /**
+   * Get the value/s assigned to the Template Engine (Smarty).
+   *
+   * @param string|null $name
+   */
+  public function getTemplateVars($name = NULL) {
+    return self::$_template->getTemplateVars($name);
   }
 
   /**

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1392,12 +1392,23 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   /**
    * Returns an array containing template variables.
    *
+   * @deprecated since 5.69 will be removed around 5.93. use getTemplateVars.
+   *
    * @param string $name
    *
    * @return array
    */
   public function get_template_vars($name = NULL) {
-    return self::$_template->get_template_vars($name);
+    return $this->getTemplateVars($name);
+  }
+
+  /**
+   * Get the value/s assigned to the Template Engine (Smarty).
+   *
+   * @param string|null $name
+   */
+  public function getTemplateVars($name = NULL) {
+    return self::$_template->getTemplateVars($name);
   }
 
   /**

--- a/CRM/Core/Form/Tag.php
+++ b/CRM/Core/Form/Tag.php
@@ -88,7 +88,7 @@ class CRM_Core_Form_Tag {
       $form->_tagsetInfo = $tagset;
       $form->assign("tagsetType", $mode);
       // Merge this tagset info with possibly existing info in the template
-      $tagsetInfo = (array) $form->get_template_vars("tagsetInfo");
+      $tagsetInfo = (array) $form->getTemplateVars("tagsetInfo");
       if (empty($tagsetInfo[$mode])) {
         $tagsetInfo[$mode] = [];
       }

--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -343,12 +343,23 @@ class CRM_Core_Page {
   /**
    * Returns an array containing template variables.
    *
+   * @deprecated since 5.69 will be removed around 5.93. use getTemplateVars.
+   *
    * @param string $name
    *
    * @return array
    */
   public function get_template_vars($name = NULL) {
-    return self::$_template->get_template_vars($name);
+    return $this->getTemplateVars($name);
+  }
+
+  /**
+   * Get the value/s assigned to the Template Engine (Smarty).
+   *
+   * @param string|null $name
+   */
+  public function getTemplateVars($name = NULL) {
+    return self::$_template->getTemplateVars($name);
   }
 
   /**

--- a/CRM/Core/Page/Inline/Help.php
+++ b/CRM/Core/Page/Inline/Help.php
@@ -40,7 +40,7 @@ class CRM_Core_Page_Inline_Help {
       if ($smarty->template_exists($additionalTPLFile)) {
         $extraoutput .= trim($smarty->fetch($additionalTPLFile));
         // Allow override param to replace default text e.g. {hlp id='foo' override=1}
-        if ($smarty->get_template_vars('override_help_text')) {
+        if ($smarty->getTemplateVars('override_help_text')) {
           $output = '';
         }
       }

--- a/CRM/Core/Region.php
+++ b/CRM/Core/Region.php
@@ -76,7 +76,7 @@ class CRM_Core_Region implements CRM_Core_Resources_CollectionInterface, CRM_Cor
           break;
 
         case 'template':
-          $tmp = $smarty->get_template_vars('snippet');
+          $tmp = $smarty->getTemplateVars('snippet');
           $smarty->assign('snippet', $snippet);
           $html .= $smarty->fetch($snippet['template']);
           $smarty->assign('snippet', $tmp);

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -234,7 +234,7 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
       'template' => FALSE,
     ];
 
-    $tabs = $this->get_template_vars('tabHeader');
+    $tabs = $this->getTemplateVars('tabHeader');
     foreach ((array) $tabs as $i => $tab) {
       $tabs[$i] = array_merge($defaults, $tab);
     }
@@ -269,7 +269,7 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
    * @param $value
    */
   public function appendValue($name, $value) {
-    $currentValue = $this->get_template_vars($name);
+    $currentValue = $this->getTemplateVars($name);
     if (!$currentValue) {
       $this->assign($name, $value);
     }
@@ -337,7 +337,7 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
    * @see popScope
    */
   public function pushScope($vars) {
-    $oldVars = $this->get_template_vars();
+    $oldVars = $this->getTemplateVars();
     $backupFrame = [];
     foreach ($vars as $key => $value) {
       $backupFrame[$key] = array_key_exists($key, $oldVars) ? $oldVars[$key] : static::$UNDEFINED_VALUE;

--- a/CRM/Core/Smarty/plugins/block.edit.php
+++ b/CRM/Core/Smarty/plugins/block.edit.php
@@ -38,7 +38,7 @@
  */
 function smarty_block_edit($params, $text, &$smarty, &$repeat) {
   if (!$repeat) {
-    $action = $smarty->get_template_vars()['action'];
+    $action = $smarty->getTemplateVars()['action'];
     return ($action & 3) ? $text : NULL;
   }
 }

--- a/CRM/Core/Smarty/plugins/block.url.php
+++ b/CRM/Core/Smarty/plugins/block.url.php
@@ -51,7 +51,7 @@ function smarty_block_url($params, $text, &$smarty, &$repeat) {
   $url = (string) Civi::url($text, $flags)->addVars($params);
 
   // This could be neat, but see discussion in CRM_Core_Smarty_plugins_UrlTest for why it's currently off.
-  // $url->setVarsCallback([$smarty, 'get_template_vars']);
+  // $url->setVarsCallback([$smarty, 'getTemplateVars']);
 
   if ($assign !== NULL) {
     $smarty->assign([$assign => $url]);

--- a/CRM/Report/Form/Contact/LoggingDetail.php
+++ b/CRM/Report/Form/Contact/LoggingDetail.php
@@ -38,7 +38,7 @@ class CRM_Report_Form_Contact_LoggingDetail extends CRM_Logging_ReportDetail {
     if ($this->cid) {
       // link back to contact summary
       $this->assign('backURL', CRM_Utils_System::url('civicrm/contact/view', "reset=1&selectedChild=log&cid={$this->cid}", FALSE, NULL, FALSE));
-      $this->assign('revertURL', self::$_template->get_template_vars('revertURL') . "&cid={$this->cid}");
+      $this->assign('revertURL', self::$_template->getTemplateVars('revertURL') . "&cid={$this->cid}");
     }
     else {
       // link back to summary report

--- a/CRM/Report/OutputHandler/Csv.php
+++ b/CRM/Report/OutputHandler/Csv.php
@@ -63,7 +63,7 @@ class CRM_Report_OutputHandler_Csv extends OutputHandlerBase implements OutputHa
    */
   public function getOutputString():string {
     //@todo Hmm. See note in CRM_Report_Form::endPostProcess about $rows.
-    $rows = $this->getForm()->getTemplate()->get_template_vars('rows');
+    $rows = $this->getForm()->getTemplate()->getTemplateVars('rows');
 
     // avoid pass-by-ref warning
     $form = $this->getForm();
@@ -76,7 +76,7 @@ class CRM_Report_OutputHandler_Csv extends OutputHandlerBase implements OutputHa
    */
   public function download() {
     //@todo Hmm. See note in CRM_Report_Form::endPostProcess about $rows.
-    $rows = $this->getForm()->getTemplate()->get_template_vars('rows');
+    $rows = $this->getForm()->getTemplate()->getTemplateVars('rows');
 
     // avoid pass-by-ref warning
     $form = $this->getForm();

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -201,7 +201,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
    */
   public function appendBreadCrumb($breadCrumbs) {
     $template = CRM_Core_Smarty::singleton();
-    $bc = $template->get_template_vars('breadcrumb');
+    $bc = $template->getTemplateVars('breadcrumb');
 
     if (is_array($breadCrumbs)) {
       foreach ($breadCrumbs as $crumbs) {

--- a/Civi/Test/FormWrapper.php
+++ b/Civi/Test/FormWrapper.php
@@ -129,7 +129,7 @@ class FormWrapper {
     if ($state > self::VALIDATED) {
       $this->postProcess();
     }
-    $this->templateVariables = \CRM_Core_Smarty::singleton()->get_template_vars();
+    $this->templateVariables = \CRM_Core_Smarty::singleton()->getTemplateVars();
     \CRM_Core_Smarty::singleton()->popScope([]);
     return $this;
   }

--- a/ext/eventcart/CRM/Event/Cart/Form/MerParticipant.php
+++ b/ext/eventcart/CRM/Event/Cart/Form/MerParticipant.php
@@ -34,7 +34,7 @@ class CRM_Event_Cart_Form_MerParticipant extends CRM_Core_Form {
     foreach ($custom_fields_post as $key => $field) {
       CRM_Core_BAO_UFGroup::buildProfile($form, $field, CRM_Profile_Form::MODE_CREATE, $this->participant->id);
     }
-    $custom = $form->get_template_vars()['custom'] ?? [];
+    $custom = $form->getTemplateVars()['custom'] ?? [];
     $form->assign('custom', array_merge($custom, [
       $this->html_field_name('customPre') => $custom_fields_pre,
       $this->html_field_name('customPost') => $custom_fields_post,

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/MembershipTypesTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/MembershipTypesTest.php
@@ -29,7 +29,7 @@ class MembershipTypesTest extends BaseTestClass {
     $page = new \CRM_Member_Page_MembershipType();
     $types = $this->setUpMembershipTypesACLLimited();
     $page->browse();
-    $assigned = \CRM_Core_Smarty::singleton()->get_template_vars();
+    $assigned = \CRM_Core_Smarty::singleton()->getTemplateVars();
     $this->assertArrayNotHasKey($types['Forbidden']['id'], $assigned['rows']);
     $this->assertArrayHasKey($types['Go for it']['id'], $assigned['rows']);
     $links = $assigned['rows'][$types['Go for it']['id']]['action'];
@@ -46,7 +46,7 @@ class MembershipTypesTest extends BaseTestClass {
     }
     $this->setPermissions($permissions);
     $page->browse();
-    $assigned = \CRM_Core_Smarty::singleton()->get_template_vars();
+    $assigned = \CRM_Core_Smarty::singleton()->getTemplateVars();
     $this->assertEquals('<span></span>', $assigned['rows'][$types['Go for it']['id']]['action']);
   }
 

--- a/templates/CRM/ACL/Header.tpl
+++ b/templates/CRM/ACL/Header.tpl
@@ -15,7 +15,7 @@
 </div>
 
 {php}
-  $currentStep = $this->get_template_vars('step');
+  $currentStep = $this->getTemplateVars('step');
   $wizard = [
     'style' => ['barClass' => '', 'showTitle' => FALSE],
     'currentStepNumber' => $currentStep,

--- a/tests/phpunit/CRM/Activity/Form/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Form/ActivityTest.php
@@ -303,7 +303,7 @@ class CRM_Activity_Form_ActivityTest extends CiviUnitTestCase {
     $form->assignActivityType();
 
     // Check the smarty template has the correct values assigned.
-    $keyValuePair = $form->getTemplate()->get_template_vars('activityTypeNameAndLabel');
+    $keyValuePair = $form->getTemplate()->getTemplateVars('activityTypeNameAndLabel');
     $this->assertEquals('47395hc', $keyValuePair['machineName']);
     $this->assertEquals('Hide Cookies', $keyValuePair['displayLabel']);
 

--- a/tests/phpunit/CRM/Activity/Form/ActivityViewTest.php
+++ b/tests/phpunit/CRM/Activity/Form/ActivityViewTest.php
@@ -82,7 +82,7 @@ class CRM_Activity_Form_ActivityViewTest extends CiviUnitTestCase {
 
     // check one of the smarty template vars
     // not checking EVERYTHING
-    $templateVar = CRM_Activity_Form_ActivityView::getTemplate()->get_template_vars('values');
+    $templateVar = CRM_Activity_Form_ActivityView::getTemplate()->getTemplateVars('values');
     $expected = [
       'assignee_contact' => [0 => $activity['target_contact_id']],
       // it's always Julia

--- a/tests/phpunit/CRM/Case/XMLProcessor/ReportTest.php
+++ b/tests/phpunit/CRM/Case/XMLProcessor/ReportTest.php
@@ -65,7 +65,7 @@ class CRM_Case_XMLProcessor_ReportTest extends CiviCaseTestCase {
 
     // run the thing we're testing and get the output vars
     $template = CRM_Case_XMLProcessor_Report::populateCaseReportTemplate($client_id, $case_id, $activitySetName, $caseReportParams, $this->report);
-    $assigned_vars = $template->get_template_vars();
+    $assigned_vars = $template->getTemplateVars();
 
     // Update $expected now since dataprovider doesn't have access to the variables from setup() because it runs before setup.
     $this->updateExpectedBecauseDataProviderEvaluatesBeforeEverything($expected, $client_id, $case_id);
@@ -116,7 +116,7 @@ class CRM_Case_XMLProcessor_ReportTest extends CiviCaseTestCase {
 
     // run the thing we're testing and get the output vars
     $template = CRM_Case_XMLProcessor_Report::populateCaseReportTemplate($client_id, $case_id, 'standard_timeline', $caseReportParams, $this->report);
-    $assigned_vars = $template->get_template_vars();
+    $assigned_vars = $template->getTemplateVars();
 
     // We don't want to run all the data in the dataprovider but we know
     // in this case it should be the same as the second one in the

--- a/tests/phpunit/CRM/Contact/Form/Task/SMSCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/SMSCommonTest.php
@@ -102,7 +102,7 @@ class CRM_Contact_Form_Task_SMSCommonTest extends CiviUnitTestCase {
     $form->_contactIds = array_values($this->ids['Contact']);
     $form->_single = FALSE;
     CRM_Contact_Form_Task_SMSCommon::buildQuickForm($form);
-    $contacts = json_decode($form->get_template_vars('toContact'));
+    $contacts = json_decode($form->getTemplateVars('toContact'));
     $smsRecipientsActual = [];
 
     $phoneNumbers = [

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -192,7 +192,7 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
     $expectedJS = "<script type='text/javascript'>
 " . $expectedJS . '</script>';
 
-    $this->assertEquals($expectedJS, trim((string) CRM_Core_Smarty::singleton()->get_template_vars('initHideBoxes')));
+    $this->assertEquals($expectedJS, trim((string) CRM_Core_Smarty::singleton()->getTemplateVars('initHideBoxes')));
     $this->assertEquals($expectedDefaults, $this->form->_defaultValues);
   }
 

--- a/tests/phpunit/CRM/Contact/Page/View/UserDashboard/GroupContactTest.php
+++ b/tests/phpunit/CRM/Contact/Page/View/UserDashboard/GroupContactTest.php
@@ -84,7 +84,7 @@ class CRM_Contact_Page_View_UserDashboard_GroupContactTest extends CiviUnitTestC
     $page = new CRM_Contact_Page_View_UserDashBoard_GroupContact();
     $page->run();
 
-    $groupIn = CRM_Core_Smarty::singleton()->get_template_vars('groupIn');
+    $groupIn = CRM_Core_Smarty::singleton()->getTemplateVars('groupIn');
     $groupInTitles = CRM_Utils_Array::collect('title', $groupIn);
     $this->assertContains($publicSmartGroupTitle, $groupInTitles, "Group '$publicSmartGroupTitle' should be in listed groups, but is not.");
     $this->assertContains($publicStdGroupTitle, $groupInTitles, "Group '$publicStdGroupTitle' should be in listed groups, but is not.");
@@ -156,7 +156,7 @@ class CRM_Contact_Page_View_UserDashboard_GroupContactTest extends CiviUnitTestC
     $page = new CRM_Contact_Page_View_UserDashBoard_GroupContact();
     $page->run();
 
-    $form = CRM_Core_Smarty::singleton()->get_template_vars('form');
+    $form = CRM_Core_Smarty::singleton()->getTemplateVars('form');
     $group_id_field_html = $form['group_id']['html'];
     $this->assertStringContainsString($publicSmartGroupTitle, $group_id_field_html, "Group '$publicSmartGroupTitle' should be in listed available groups, but is not.");
     $this->assertStringContainsString($publicStdGroupTitle, $group_id_field_html, "Group '$publicStdGroupTitle' should be in listed available groups, but is not.");
@@ -180,7 +180,7 @@ class CRM_Contact_Page_View_UserDashboard_GroupContactTest extends CiviUnitTestC
     $page = new CRM_Contact_Page_View_UserDashBoard_GroupContact();
     $page->run();
 
-    $form = CRM_Core_Smarty::singleton()->get_template_vars('form');
+    $form = CRM_Core_Smarty::singleton()->getTemplateVars('form');
     $group_id_field_html = $form['group_id']['html'];
     $this->assertStringNotContainsString('* ' . $publicSmartGroupTitle, $group_id_field_html, "Group '$publicSmartGroupTitle' should not be in listed available groups, but is.");
     $this->assertStringNotContainsString($publicStdGroupTitle, $group_id_field_html, "Group '$publicStdGroupTitle' should not be in listed available groups, but is.");

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -197,7 +197,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     ]);
     $this->assertEquals([$organizationID], $activity['target_contact_id']);
     $this->assertEquals($individualID, $activity['source_contact_id']);
-    $assignedVariables = $form->get_template_vars();
+    $assignedVariables = $form->getTemplateVars();
     $this->assertFalse($assignedVariables['is_separate_payment']);
   }
 

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ThankYouTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ThankYouTest.php
@@ -41,25 +41,25 @@ class CRM_Contribute_Form_Contribution_ThankYouTest extends CiviUnitTestCase {
 
     $form = $this->getThankYouFormWithContribution($paymentProcessorID, FALSE, FALSE);
     $form->buildQuickForm();
-    $isPendingOutcome = $form->get_template_vars('isPendingOutcome');
+    $isPendingOutcome = $form->getTemplateVars('isPendingOutcome');
 
     $this->assertEquals(FALSE, $isPendingOutcome, 'Outcome should not be pending.');
 
     $form = $this->getThankYouFormWithContribution($paymentProcessorID, TRUE, FALSE);
     $form->buildQuickForm();
-    $isPendingOutcome = $form->get_template_vars('isPendingOutcome');
+    $isPendingOutcome = $form->getTemplateVars('isPendingOutcome');
 
     $this->assertEquals(TRUE, $isPendingOutcome, 'Outcome should be pending.');
 
     $form = $this->getThankYouFormWithContribution($paymentProcessorID, FALSE, TRUE);
     $form->buildQuickForm();
-    $isPendingOutcome = $form->get_template_vars('isPendingOutcome');
+    $isPendingOutcome = $form->getTemplateVars('isPendingOutcome');
 
     $this->assertEquals(FALSE, $isPendingOutcome, 'Outcome should not be pending.');
 
     $form = $this->getThankYouFormWithContribution($paymentProcessorID, TRUE, TRUE);
     $form->buildQuickForm();
-    $isPendingOutcome = $form->get_template_vars('isPendingOutcome');
+    $isPendingOutcome = $form->getTemplateVars('isPendingOutcome');
 
     $this->assertEquals(TRUE, $isPendingOutcome, 'Outcome should be pending.');
   }

--- a/tests/phpunit/CRM/Contribute/Page/TabTest.php
+++ b/tests/phpunit/CRM/Contribute/Page/TabTest.php
@@ -34,7 +34,7 @@ class CRM_Contribute_Page_TabTest extends CiviUnitTestCase {
   public function testLinksManual(): void {
     [$contactID, $recurID] = $this->setupTemplate();
 
-    $templateVariable = CRM_Core_Smarty::singleton()->get_template_vars();
+    $templateVariable = CRM_Core_Smarty::singleton()->getTemplateVars();
     $this->assertEquals('Mr. Anthony Anderson II', $templateVariable['displayName']);
     $this->assertEquals("<span><a href=\"/index.php?q=civicrm/contact/view/contributionrecur&amp;reset=1&amp;id=" . $recurID . '&amp;cid=' . $contactID . "&amp;context=contribution\" class=\"action-item crm-hover-button\" title='View Recurring Payment' >View</a><a href=\"/index.php?q=civicrm/contribute/updaterecur&amp;reset=1&amp;action=update&amp;crid=1&amp;cid=3&amp;context=contribution\" class=\"action-item crm-hover-button\" title='Edit Recurring Payment' >Edit</a><a href=\"/index.php?q=civicrm/contribute/unsubscribe&amp;reset=1&amp;crid=" . $recurID . '&amp;cid=' . $contactID . "&amp;context=contribution\" class=\"action-item crm-hover-button\" title='Cancel' >Cancel</a></span>",
       $this->getActionHtml()
@@ -110,7 +110,7 @@ class CRM_Contribute_Page_TabTest extends CiviUnitTestCase {
    */
   protected function getActionHtml(): string {
     return CRM_Core_Smarty::singleton()
-      ->get_template_vars()['activeRecurRows'][1]['action'];
+      ->getTemplateVars()['activeRecurRows'][1]['action'];
   }
 
   /**
@@ -120,7 +120,7 @@ class CRM_Contribute_Page_TabTest extends CiviUnitTestCase {
    */
   protected function getDashboardActionHtml(): string {
     return CRM_Core_Smarty::singleton()
-      ->get_template_vars()['recurRows'][1]['action'];
+      ->getTemplateVars()['recurRows'][1]['action'];
   }
 
 }

--- a/tests/phpunit/CRM/Core/SmartyTest.php
+++ b/tests/phpunit/CRM/Core/SmartyTest.php
@@ -26,14 +26,14 @@ class CRM_Core_SmartyTest extends CiviUnitTestCase {
    */
   public function testFetchWith_CleanNonExistent(): void {
     $smarty = CRM_Core_Smarty::singleton();
-    $this->assertFalse(array_key_exists('my_variable', $smarty->get_template_vars()));
+    $this->assertFalse(array_key_exists('my_variable', $smarty->getTemplateVars()));
 
     $rendered = $smarty->fetchWith('string:({$my_variable})', [
       'my_variable' => 'temporary value',
     ]);
     $this->assertEquals('(temporary value)', $rendered);
 
-    $this->assertFalse(array_key_exists('my_variable', $smarty->get_template_vars()));
+    $this->assertFalse(array_key_exists('my_variable', $smarty->getTemplateVars()));
   }
 
   /**
@@ -47,7 +47,7 @@ class CRM_Core_SmartyTest extends CiviUnitTestCase {
   public function testFetchWith_CleanNull(): void {
     $smarty = CRM_Core_Smarty::singleton();
     $smarty->assign('my_variable', NULL);
-    $this->assertEquals(NULL, $smarty->get_template_vars()['my_variable']);
+    $this->assertEquals(NULL, $smarty->getTemplateVars()['my_variable']);
 
     $tpl = 'string:({$my_variable})';
     $this->assertEquals('()', $smarty->fetchWith($tpl, []));
@@ -56,7 +56,7 @@ class CRM_Core_SmartyTest extends CiviUnitTestCase {
     ]));
 
     // Assert global state
-    $this->assertEquals(NULL, $smarty->get_template_vars()['my_variable']);
+    $this->assertEquals(NULL, $smarty->getTemplateVars()['my_variable']);
   }
 
 }

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -370,7 +370,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     CRM_Event_Form_Registration_Confirm::assignProfiles($form);
 
     $smarty = CRM_Core_Smarty::singleton();
-    $tplVar = $smarty->get_template_vars();
+    $tplVar = $smarty->getTemplateVars();
     $this->assertEquals([
       'CustomPre' => ['First Name' => NULL],
       'CustomPreGroupTitle' => 'Public title',
@@ -424,7 +424,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     CRM_Event_Form_Registration_Confirm::assignProfiles($form);
 
     $smarty = CRM_Core_Smarty::singleton();
-    $tplVar = $smarty->get_template_vars();
+    $tplVar = $smarty->getTemplateVars();
     $this->assertEquals([
       'CustomPre' => ['First Name' => NULL, 'Comment' => NULL],
       'CustomPreGroupTitle' => 'Public title',

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1738,7 +1738,7 @@ Expires: ',
     $membershipViewForm->preProcess();
 
     // Get contribution rows related to membership payments.
-    $templateVar = $membershipViewForm::getTemplate()->get_template_vars('rows');
+    $templateVar = $membershipViewForm::getTemplate()->getTemplateVars('rows');
 
     $this->assertEquals($templateVar[0]['contribution_id'], $contribution1->id);
     $this->assertEquals($templateVar[0]['contact_id'], $contactId2);

--- a/tests/phpunit/CRM/Member/Page/MembershipTypeTest.php
+++ b/tests/phpunit/CRM/Member/Page/MembershipTypeTest.php
@@ -24,7 +24,7 @@ class CRM_Member_Page_MembershipTypeTest extends CiviUnitTestCase {
     $page = new CRM_Member_Page_MembershipType();
     $id = $this->membershipTypeCreate(['weight' => 1]);
     $page->browse();
-    $assigned = CRM_Core_Smarty::singleton()->get_template_vars();
+    $assigned = CRM_Core_Smarty::singleton()->getTemplateVars();
     $this->assertEquals([
       $id => [
         'id' => '1',

--- a/tests/phpunit/CRMTraits/Page/PageTestTrait.php
+++ b/tests/phpunit/CRMTraits/Page/PageTestTrait.php
@@ -56,7 +56,7 @@ trait CRMTraits_Page_PageTestTrait {
     // Ideally we would validate $content as valid html here.
     // Suppress console output.
     $content = '';
-    $this->smartyVariables = CRM_Core_Smarty::singleton()->get_template_vars();
+    $this->smartyVariables = CRM_Core_Smarty::singleton()->getTemplateVars();
   }
 
   /**

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3661,7 +3661,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
     $this->checkCreditCardDetails($mut, $order['id']);
     $mut->stop();
-    $tplVars = CRM_Core_Smarty::singleton()->get_template_vars();
+    $tplVars = CRM_Core_Smarty::singleton()->getTemplateVars();
     $this->assertEquals('bob', $tplVars['billingName']);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Standardise `getTemplateVars()`

Before
----------------------------------------
With the SmartyCompatibility layer both `get_template_vars()` and `getTemplateVars()` work with `CRM_Core_Smarty`. The former is smarty2 & we will phase it out over time. However, 3 core classes had `get_template_vars()` methods which made it confusing as in some cases that was still 'right'

After
----------------------------------------
Those 3 classes have their own `getTemplateVars()` - the `get_template_vars()` function is deprecated but unlike much of our deprecated code there is unlikely to be much of a burden in keeping it around so I have set it to have 2 years (min) in deprecation & not added any notices at this stage

Technical Details
----------------------------------------
Although our core code uses `CRM_Core_Smarty` the GenCode still loads Smarty2 directly. This is causing problems for @demeritcowboy  in a test scenario so we need to switch that code over- but it's really confusing to find the 'right spot' so change the function for that code so this aims to reduce a lot of the noise (it doesn't change all the places - I wanted to get a big chunk past jenkins & then work through the rest)

Comments
----------------------------------------
