### PR TITLE
Fix codeGen assign to do what it says on the box

### DIFF
--- a/CRM/Core/CodeGen/Util/Template.php
+++ b/CRM/Core/CodeGen/Util/Template.php
@@ -128,7 +128,7 @@ class CRM_Core_CodeGen_Util_Template {
    * @param $value
    */
   public function assign($key, $value) {
-    $this->smarty->assign_by_ref($key, $value);
+    $this->smarty->assign($key, $value);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix codeGen assign to do what it says on the box

Before
----------------------------------------
CodeGen assign calls smarty assign_by_ref

After
----------------------------------------
CodeGen assign calls smarty assign

Technical Details
----------------------------------------
The use of assign_by_ref & passing by ref in general was a thing when CiviCRM was supporting php4 because it was perceived to be more performant. That theory was discredited by Xavier around 2010. We have removed a tonne of pass-by-ref but the `assign_by_ref` have rarely bubbled up to our awareness, although there is potential for them creating hard-to-find bugs

With the switch to Smarty3 this is bubbling up & in particular in this codeGen code it turns out we still need to migrate it to Smarty3 & switching to assign seems a better option than temporary handling for both methods

Comments
----------------------------------------
