### PR TITLE
Remove str_contains from civicrm.settings template

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -262,7 +262,7 @@ if (!defined('CIVICRM_UF_BASEURL')) {
  */
 if (!defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
   // enable by default for dev & demo sites for now - will soon enable by default for all new installs.
-  if (str_contains(CIVICRM_UF_BASEURL, 'localhost') || str_contains(CIVICRM_UF_BASEURL, 'demo.civicrm.org')) {
+  if (strpos(CIVICRM_UF_BASEURL, 'localhost') !== FALSE || strpos(CIVICRM_UF_BASEURL, 'demo.civicrm.org') !== FALSE) {
     if (is_dir($civicrm_root . '/packages')) {
       define('CIVICRM_SMARTY3_AUTOLOAD_PATH', $civicrm_root . '/packages/smarty3/vendor/autoload.php');
     }


### PR DESCRIPTION
Overview
----------------------------------------
Remove str_contains from civicrm.settings template

Before
----------------------------------------
Per https://github.com/civicrm/civicrm-core/pull/28751 use of str_contains in the civicrm.settings.php relies on having the php 8.x polyfill loaded - I hit another scenarios where this was not the case (running regen locally) & it seems like it's probably best to keep it simple & not use str_contains in this file for now

After
----------------------------------------
str_pos used instead

Technical Details
----------------------------------------

Comments
----------------------------------------
