### PR TITLE
Fix typo in smarty compatibility class

### DIFF
--- a/CRM/Core/SmartyCompatibility.php
+++ b/CRM/Core/SmartyCompatibility.php
@@ -166,7 +166,7 @@ class CRM_Core_SmartyCompatibility extends Smarty {
    */
   public function getTemplateVars($varName = NULL, Smarty_Internal_Data $_ptr = NULL, $searchParents = TRUE) {
     if (method_exists(get_parent_class(), 'getTemplateVars')) {
-      return parent::getTemplateVars($varName . $_ptr, $searchParents);
+      return parent::getTemplateVars($varName, $_ptr, $searchParents);
     }
     return parent::get_template_vars($varName);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix typo in smarty compatibility class

Before
----------------------------------------
. combines parameters

After
----------------------------------------
, separates them

Technical Details
----------------------------------------
This is best fixed in 5.69 to prevent difficult debugging, if hit

Comments
----------------------------------------
