### PR TITLE
[WIP]

### DIFF
--- a/settings/Developer.setting.php
+++ b/settings/Developer.setting.php
@@ -63,7 +63,7 @@ return [
     'type' => 'Boolean',
     'quick_form_type' => 'YesNo',
     // default to TRUE for demo or localhost sites.
-    'default' => str_contains(CIVICRM_UF_BASEURL, 'localhost') || str_contains(CIVICRM_UF_BASEURL, 'demo.civicrm.org'),
+    'default' => str_contains(CIVICRM_UF_BASEURL, 'localhost') || str_contains(CIVICRM_UF_BASEURL, 'demo.civicrm.org') || (defined('CIVICRM_TEST') && CIVICRM_TEST),
     'add' => '4.3',
     'title' => ts('Enable Debugging'),
     'is_domain' => 1,


### PR DESCRIPTION
Overview
----------------------------------------
This has been bugging me because I couldn't figure out why I couldn't reproduce locally and why it wasn't showing up in the test runs here.

Before
----------------------------------------
No errors, but there should be at least some errors about "undefined array key 'debugging'".

After
----------------------------------------
Let's see.

Technical Details
----------------------------------------
There's two parts. One is that debug_enabled is not getting enabled because the test runs aren't running on urls named localhost or demo. This means among other things that debug.tpl is not getting included when compiling templates. That tpl by itself isn't a big deal, but is why the actual bug isn't showing up.

The actual bug:
1. Smarty is only initialized once, in [initialize](https://github.com/civicrm/civicrm-core/blob/0356489088e4bdf9d50d5539f00609b7c556b4ff/CRM/Core/Smarty.php#L131), and during test runs because of static that only happens once for the whole run.
2. Note that clearTemplateVars makes an exception for config and session when [clearing the vars](https://github.com/civicrm/civicrm-core/blob/0356489088e4bdf9d50d5539f00609b7c556b4ff/CRM/Core/Smarty.php#L285).
3. But then for the template var 'debugging', it gets wiped and then runs into [this problem](https://github.com/civicrm/civicrm-core/blob/0356489088e4bdf9d50d5539f00609b7c556b4ff/CRM/Core/Page.php#L176-L179).

Comments
----------------------------------------

