### PR TITLE
Update Smart Group Caching setting text

### DIFF
--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -115,7 +115,7 @@ return [
     'title' => ts('Smart group cache timeout'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => ts('The number of minutes to cache smart group contacts. We strongly recommend that this value be greater than zero, since a value of zero means no caching at all. If your contact data changes frequently, you should set this value to at least 5 minutes.'),
+    'description' => ts('The number of minutes to cache smart group contacts. The best value will depend on your site and the complexity of the groups and acls you use. A value of zero means no caching at all. You may need to experiment with this.'),
     'help_text' => NULL,
   ],
   'defaultSearchProfileID' => [


### PR DESCRIPTION
Overview
----------------------------------------
Update Smart Group Caching setting text

Before
----------------------------------------
Help text is strident about the need to use the smart group cache

After
----------------------------------------
Help text is circumspect

Technical Details
----------------------------------------
I think setting smart group cache to 0 is a valid option and have had good results on both small and large sites in testing so I don't think we should 'strongly recommend' this value is non-zero

Note I did a longer PR with links to the docs - 
https://github.com/civicrm/civicrm-core/pull/28753
- but I'm putting this up in case that stalls so we at least get some improved text in (merging that will make this go stale so if this gets merged I'll have to rebase or close that one)

Comments
----------------------------------------
