### PR TITLE
Preventing undefined array key error in php 8

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -651,12 +651,14 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       return \CRM_Core_Permission::check($permissions) == ($op !== '!=');
     }
     // Convert the conditional value of 'current_domain' into an actual value that filterCompare can work with
-    if ($item['condition'][2] ?? '' === 'current_domain') {
-      if (str_ends_with($item['condition'][0], ':label') !== FALSE) {
-        $item['condition'][2] = \CRM_Core_BAO_Domain::getDomain()->name;
-      }
-      else {
-        $item['condition'][2] = \CRM_Core_Config::domainID();
+    if(isset($item['condition'][2])) {
+      if ($item['condition'][2] ?? '' === 'current_domain') {
+        if (str_ends_with($item['condition'][0], ':label') !== FALSE) {
+          $item['condition'][2] = \CRM_Core_BAO_Domain::getDomain()->name;
+        }
+        else {
+          $item['condition'][2] = \CRM_Core_Config::domainID();
+        }
       }
     }
     return self::filterCompare($data, $item['condition']);


### PR DESCRIPTION
Overview
----------------------------------------
Getting following warning after upgrade to php 8:
Warning: Undefined array key 2 in Civi\Api4\Action\SearchDisplay\AbstractRunAction->checkLinkCondition() (line 654 of .../vendor/civicrm/civicrm-core/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php)


Before
----------------------------------------
Warning as above

After
----------------------------------------
No error

Comments
----------------------------------------
My php level is beginner! So not sure if this is the best way to address the error :)
