### PR TITLE
SearchKit - Fix wrong column being removed from displays

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -319,8 +319,8 @@
           let selectAliases = ctrl.savedSearch.api_params.select.map(selectExpr => selectToKey(selectExpr));
           // Delete any column that is no longer in the
           activeColumns.reverse().forEach((key, index) => {
-            if (key && !_.includes(selectAliases, key)) {
-              ctrl.display.settings.columns.splice(index, 1);
+            if (key && !selectAliases.includes(key)) {
+              ctrl.removeCol(activeColumns.length - 1 - index);
             }
           });
         }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes recent (master-only) regression from 4099cd6 causing the wrong column to be removed from a display. 

Before
----------------------------------------
To reproduce: Create a search display, go back to the main search criteria and delete a column, then tab back to the display. The deleted column should have been removed but instead the wrong one is still there.

After
----------------------------------------
Correct column is removed.