### PR TITLE
APIv4 - Hide 'contact_type' from Individual,Organization,Household getFields

### DIFF
--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -146,6 +146,12 @@ class BasicGetFieldsAction extends BasicGetAction {
       }
       $field = array_diff_key($field, $internalProps);
     }
+    // Hide the 'contact_type' field from Individual,Organization,Household pseudo-entities
+    if (!$isInternal && $this->getEntityName() !== 'Contact' && CoreUtil::isContact($this->getEntityName())) {
+      $values = array_filter($values, function($field) {
+        return $field['name'] !== 'contact_type';
+      });
+    }
   }
 
   /**

--- a/Civi/Api4/Service/Autocomplete/ContactAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/ContactAutocompleteProvider.php
@@ -54,6 +54,12 @@ class ContactAutocompleteProvider extends \Civi\Core\Service\AutoService impleme
     if ($e->display['settings'] || $e->display['type'] !== 'autocomplete' || !CoreUtil::isContact($e->savedSearch['api_entity'])) {
       return;
     }
+    if ($e->savedSearch['api_entity'] === 'Contact') {
+      $contactTypeIcon = ['field' => 'contact_type:icon'];
+    }
+    else {
+      $contactTypeIcon = ['icon' => CoreUtil::getInfoItem($e->savedSearch['api_entity'], 'icon')];
+    }
     $e->display['settings'] = [
       'sort' => [
         ['sort_name', 'ASC'],
@@ -64,7 +70,7 @@ class ContactAutocompleteProvider extends \Civi\Core\Service\AutoService impleme
           'key' => 'sort_name',
           'icons' => [
             ['field' => 'contact_sub_type:icon'],
-            ['field' => 'contact_type:icon'],
+            $contactTypeIcon,
           ],
         ],
         [

--- a/tests/phpunit/api/v4/Action/GetExtraFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetExtraFieldsTest.php
@@ -24,6 +24,7 @@ use Civi\Api4\Activity;
 use Civi\Api4\Address;
 use Civi\Api4\Contact;
 use Civi\Api4\Household;
+use Civi\Api4\Individual;
 use Civi\Api4\Tag;
 
 /**
@@ -60,6 +61,16 @@ class GetExtraFieldsTest extends Api4TestBase {
     $this->assertTrue($householdFields['contact_type']['readonly']);
     $this->assertArrayNotHasKey('first_name', $householdFields);
     $this->assertArrayHasKey('household_name', $householdFields);
+  }
+
+  public function testContactPseudoEntityGetFields(): void {
+    $individualFields = (array) Individual::getFields(FALSE)
+      ->execute()->indexBy('name');
+    $this->assertArrayNotHasKey('sic_code', $individualFields);
+    $this->assertArrayNotHasKey('contact_type', $individualFields);
+    $this->assertArrayHasKey('last_name', $individualFields);
+    $this->assertEquals('Individual', $individualFields['birth_date']['entity']);
+    $this->assertEquals('Individual', $individualFields['age_years']['entity']);
   }
 
   public function testGetOptionsAddress(): void {

--- a/tests/phpunit/api/v4/Action/GetFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetFieldsTest.php
@@ -66,7 +66,7 @@ class GetFieldsTest extends Api4TestBase implements TransactionalInterface {
       ->execute()
       ->indexBy('name');
     // Ensure table & column are returned
-    $this->assertEquals('civicrm_contact', $fields['display_name']['table_name']);
+    $this->assertEquals('civicrm_contact', $fields['contact_type']['table_name']);
     $this->assertEquals('display_name', $fields['display_name']['column_name']);
 
     // Check suffixes


### PR DESCRIPTION
Overview
----------------------------------------
Usability improvement for SearchKit involves hiding an irrelevant field from the API metadata.

Before
----------------------------------------
Creating a new SearchKit search for Individual includes Contact Type in the default columns. This is confusing because the value of that field will never change.

After
----------------------------------------
The field is completely hidden for all but the Contact entity.

Technical Details
----------------------------------------
This field is irrelevant to these entities and shouldn't be needed.

- See #27659