### PR TITLE
Remove unused phantomjs-polyfill package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -248,9 +248,6 @@
         "url": "https://github.com/lodash/lodash-compat/archive/3.0.1.zip",
         "ignore": [".*", "*.log", "*.md", "component.json", "package.json", "node_modules"]
       },
-      "phantomjs-polyfill": {
-        "url": "https://github.com/conversocial/phantomjs-polyfill/archive/v0.0.2.zip"
-      },
       "select2": {
         "url": "https://github.com/colemanw/select2/archive/v3.5-civicrm-1.0.zip"
       },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a85ba6e6b1dda6e40fb5478865870489",
+    "content-hash": "9bd88911ac05e61e199444889b78fc8e",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -25,7 +25,6 @@ module.exports = function(config) {
       'ang/api4Explorer/Explorer.js'
     ],
     files: [
-      'bower_components/phantomjs-polyfill/bind-polyfill.js',
       'bower_components/jquery/dist/jquery.min.js',
       'bower_components/jquery-ui/jquery-ui.min.js',
       'bower_components/lodash-compat/lodash.min.js',


### PR DESCRIPTION
Overview
----------------------------------------
As of #27941 we no longer use PhantomJS so this package should not be needed.