### PR TITLE
Don't try to insert 0 as a user_id to ACL contact cache

### DIFF
--- a/CRM/Contact/BAO/Contact/Permission.php
+++ b/CRM/Contact/BAO/Contact/Permission.php
@@ -294,8 +294,8 @@ AND    $operationClause
 
     // Add in a row for the logged in contact. Do not try to combine with the above query or an ugly OR will appear in
     // the permission clause.
-    if (CRM_Core_Permission::check('edit my contact') ||
-      ($type == CRM_Core_Permission::VIEW && CRM_Core_Permission::check('view my contact'))) {
+    if ($userID && (CRM_Core_Permission::check('edit my contact') ||
+      ($type == CRM_Core_Permission::VIEW && CRM_Core_Permission::check('view my contact')))) {
       if (!CRM_Core_DAO::singleValueQuery("
         SELECT count(*) FROM civicrm_acl_contact_cache WHERE user_id = %1 AND contact_id = %1 AND operation = '{$operation}' LIMIT 1", $queryParams)) {
         CRM_Core_DAO::executeQuery("INSERT INTO civicrm_acl_contact_cache ( user_id, contact_id, operation ) VALUES(%1, %1, '{$operation}')", $queryParams);


### PR DESCRIPTION
Overview
----------------------------------------
Anonymous users, when they have "View My Contact" or "Edit My Contact" permissions, can cause a db constraint error.  This often happens during payments, causing the payment to fail.

This permission should never be granted - anonymous users don't have contacts - but we need to handle the case more gracefully.  

[Several others](https://civicrm.stackexchange.com/q/28002/12) have reported this issue as well.

This is similar in nature to #13451/[core/#660](https://lab.civicrm.org/dev/core/-/issues/660) but affects a different table.

#### Replication Steps
I could only replicate this with a customization where I a) had only one field in one profile on a contribution page, b) that field was a contribution field, c) I moved it out of place with jQuery.  However, folks have triggered this bug in other ways, and the problem is with the ACL cache.

Before
----------------------------------------
Database error on certain anonymous users triggering an email to be sent.

After
----------------------------------------
No problem.

Technical Details
----------------------------------------
If you're generating the contents of `civicrm_acl_contact_cache`, there is special handling for "View My Contact" and "Edit My Contact".  If you have one of those enabled for the anonymous user, it will try to run this SQL:

```sql
INSERT INTO civicrm_acl_contact_cache ( user_id, contact_id, operation ) VALUES(0, 0, 'View') -- or 'Edit'
```

Because the `user_id` has a foreign constraint to `civicrm_contact.id`, inserting `0` for a `user_id` will always cause a database constraint error.