### PR TITLE
[REF][PHP8.2] Declare missing properties on CRM_Event_Form_Registration_AdditionalParticipant

### DIFF
--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -22,10 +22,49 @@
 class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_Registration {
 
   /**
-   * Pre-registered additional participant id.
+   * Additional participant id.
+   *
    * @var int
+   * @internal
    */
-  public $additionalParticipantId = NULL;
+  public $_additionalParticipantId = NULL;
+
+  /**
+   * Tracks whether we are at the last participant.
+   *
+   * @var bool
+   * @internal
+   */
+  public $_lastParticipant = FALSE;
+
+  /**
+   * @var bool
+   * @internal
+   */
+  public $_resetAllowWaitlist = FALSE;
+
+  /**
+   * @var int
+   * @internal
+   */
+  public $_contactId;
+
+  /**
+   * Used within CRM_Event_Form_EventFees
+   *
+   * @var int
+   * @internal
+   */
+  public $_discountId;
+
+  /**
+   * Alias of $this->_additionalParticipantId,
+   * Used within CRM_Event_Form_EventFees
+   *
+   * @var int
+   * @internal
+   */
+  public $_pId;
 
   /**
    * Get the active UFGroups (profiles) on this form


### PR DESCRIPTION
Overview
----------------------------------------
Declare missing properties on CRM_Event_Form_Registration_AdditionalParticipant.

Follow up to https://github.com/civicrm/civicrm-core/pull/28783 which declared a single property to start.

Before
----------------------------------------
PHP 8.2 incompatiability.

After
----------------------------------------
Properties declared.

Comments
----------------------------------------
Ping @eileenmcnaughton, this is based on [your comment](https://github.com/civicrm/civicrm-core/pull/28783#issuecomment-1868158150) on the last PR.

I've still not declared `_feeBlock`, as I can't see where it is ever set in the additional participant flow. Perhaps someone else can take a look?
