### PR TITLE
[REF][PHP8.2] Cleanup discounts property in eventcart ext

### DIFF
--- a/ext/eventcart/CRM/Event/Cart/Form/Cart.php
+++ b/ext/eventcart/CRM/Event/Cart/Form/Cart.php
@@ -16,6 +16,17 @@ class CRM_Event_Cart_Form_Cart extends CRM_Core_Form {
   public $_mode;
   public $participants;
 
+  /**
+   * Provides way for extensions to add discounts to the event_registration_receipt emails.
+   *
+   * Todo: Do any extensions actually use this,
+   * or can it be removed, and the email templates cleaned up?
+   *
+   * @var array
+   * @deprecated Not recommended for new extensions.
+   */
+  public $discounts = [];
+
   public function preProcess() {
     $this->_action = CRM_Utils_Request::retrieveValue('action', 'String');
     $this->_mode = 'live';
@@ -26,10 +37,6 @@ class CRM_Event_Cart_Form_Cart extends CRM_Core_Form {
     $event_titles = [];
     foreach ($this->cart->get_main_events_in_carts() as $event_in_cart) {
       $event_titles[] = $event_in_cart->event->title;
-    }
-
-    if (!isset($this->discounts)) {
-      $this->discounts = [];
     }
   }
 

--- a/ext/eventcart/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/ext/eventcart/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -340,7 +340,6 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
         'credit_card_exp_date' => $params['credit_card_exp_date'],
         'credit_card_type' => $params['credit_card_type'],
         'credit_card_number' => "************" . substr($params['credit_card_number'], -4, 4),
-        // XXX cart->get_discounts
         'discounts' => $this->discounts,
         'email' => $contact_details[1],
         'events_in_cart' => $events_in_cart,


### PR DESCRIPTION
Overview
----------------------------------------
Cleanup discounts property in eventcart extension.

Before
----------------------------------------
Test failure on PHP 8.2:

```
CRM_Financial_Form_PaymentFormsTest::testEventPaymentForms
Creation of dynamic property CRM_Event_Cart_Form_Checkout_ParticipantsAndPrices::$discounts is deprecated

/home/homer/buildkit/build/build-3/web/sites/all/modules/civicrm/ext/eventcart/CRM/Event/Cart/Form/Cart.php:32
/home/homer/buildkit/build/build-3/web/sites/all/modules/civicrm/ext/eventcart/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.php:14
/home/homer/buildkit/build/build-3/web/sites/all/modules/civicrm/tests/phpunit/CRM/Financial/Form/PaymentFormsTest.php:98
/home/homer/buildkit/build/build-3/web/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:247
/home/homer/buildkit/extern/phpunit9/phpunit9.phar:2307
```

After
----------------------------------------
Property declared. 

Technical Details
----------------------------------------
Searching the codebase for `->discounts` showed usage in just two places:
 - `CRM_Event_Cart_Form_Cart` where it's (always) set to an empty array,
 - `CRM_Event_Cart_Form_Checkout_Payment` where it gets passed into the `event_registration_receipt` email template.

I know that it's been said that the eventcart stuff should never have become part of CiviCRM core, and I don't know of anyone using it. I'm 95% percent sure that this discounts property is always empty (and therefore redundant), and I can't see it being used by the `civiDiscount` extension either. The relevant code is old. 

However, there is a risk that it is being used and so for now I've just added a comment discouraging new use. If and when this get's properly removed the email templates should probably be cleaned up to remove the references to `discounts` - so there is a fair amount of cleanup which will be needed (which informed by decision to take the easy path for now)