### PR TITLE
(dev/core#4877) CiviContribute - Re-calculate prices when using "Go Back"

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1170,10 +1170,17 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
   /**
    * Process the form submission.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function postProcess() {
     // we first reset the confirm page so it accepts new values
     $this->controller->resetPage('Confirm');
+    // Update order to the submitted values (in case the back button has been used
+    // and the submitted values have changed.
+    $this->set('lineItem', NULL);
+    $this->order->setPriceSelectionFromUnfilteredInput($this->getSubmittedValues());
+    $this->order->recalculateLineItems();
 
     // get the submitted form values.
     $params = $this->controller->exportValues($this->_name);

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -823,6 +823,17 @@ class CRM_Financial_BAO_Order {
   }
 
   /**
+   * Recalculate the line items.
+   *
+   * @return void
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function recalculateLineItems(): void {
+    $this->lineItems = $this->calculateLineItems();
+  }
+
+  /**
    * Get line items in a 'traditional' indexing format.
    *
    * This ensures the line items are indexed by


### PR DESCRIPTION
Overview
----------------------------------------
Forget previously submitted price options on back

Before
----------------------------------------
Submitted price options are sticky - even when the user uses 'back' & then changes them

After
----------------------------------------
The new values are heeded

Technical Details
----------------------------------------

Comments
----------------------------------------
