### PR TITLE
CiviContribute - Do not delete price_set_entity record while page supports payment

### DIFF
--- a/CRM/Contribute/Form/ContributionPage.php
+++ b/CRM/Contribute/Form/ContributionPage.php
@@ -14,6 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
+use Civi\Api4\MembershipBlock;
 
 /**
  * Contribution Page form.
@@ -411,6 +412,18 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
       $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
     }
     return $this->_id ? (int) $this->_id : NULL;
+  }
+
+  /**
+   * Get the membership Block ID, if any, attached to the contribution page.
+   *
+   * @return int|null
+   */
+  public function getMembershipBlockID(): ?int {
+    return MembershipBlock::get(FALSE)
+      ->addWhere('entity_table', '=', 'civicrm_contribution_page')
+      ->addWhere('entity_id', '=', $this->getContributionPageID())
+      ->addWhere('is_active', '=', TRUE)->execute()->first()['id'] ?? NULL;
   }
 
   /**

--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -543,10 +543,12 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
     $contributionPageID = $contributionPage->id;
 
     // prepare for data cleanup.
-    $deleteAmountBlk = $deletePledgeBlk = $deletePriceSet = FALSE;
-    if ($this->_priceSetID) {
-      $deletePriceSet = TRUE;
-    }
+    $deleteAmountBlk = $deletePledgeBlk = FALSE;
+    // We delete the link to the price set (the price set entity record) when
+    // one exists and there is neither a contribution or membership section enabled.
+    // This amount form can set & unset the contribution section but must check the database
+    // for the membership section (membership block).
+    $deletePriceSet = $this->_priceSetID && !$this->getSubmittedValue('amount_block_is_active') && !$this->getMembershipBlockID();
     if ($this->_pledgeBlockID) {
       $deletePledgeBlk = TRUE;
     }
@@ -558,9 +560,9 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
 
       if (!empty($params['amount_block_is_active'])) {
         // handle price set.
+        $deletePriceSet = FALSE;
         if ($priceSetID) {
           // add/update price set.
-          $deletePriceSet = FALSE;
           if (!empty($params['price_field_id']) || !empty($params['price_field_other'])) {
             $deleteAmountBlk = TRUE;
           }
@@ -568,8 +570,6 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
           CRM_Price_BAO_PriceSet::addTo('civicrm_contribution_page', $contributionPageID, $priceSetID);
         }
         else {
-
-          $deletePriceSet = FALSE;
           // process contribution amount block
           $deleteAmountBlk = FALSE;
 
@@ -795,7 +795,6 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
           }
           else {
             $deleteAmountBlk = TRUE;
-            $deletePriceSet = TRUE;
           }
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Do not delete price_set_entity record while page supports payment

Before
----------------------------------------
This addresses a perceived randomness @totten experienced while testing. Since 4.2ish there has been an expectation that contribution pages would use a price set whenever payment was involved. 
However, it turns out that some old code deletes the price_set_entity record when the amount tab is saved - and when that happens the behaviour changes in unexpected ways

![image](https://github.com/civicrm/civicrm-core/assets/336308/6037d18f-adb9-4cef-aafc-f82401864349)


After
----------------------------------------
The prices set entity is not deleted unless there really is no payment on the page

Technical Details
----------------------------------------
This bug is not new - I haven't checked the pre 5.69 behaviour for comparison but there is a lot of code removal in 5.69 so it might be that the handling has changed. If we establish that to be true then we should add an upgrade script  too.

Comments
----------------------------------------
