### PR TITLE
Remove function use of reference

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -167,7 +167,7 @@ class CRM_Utils_Date {
    *   0-based array with abbreviated weekday names
    *
    */
-  public static function getAbbrWeekdayNames() {
+  public static function getAbbrWeekdayNames(): array {
     $key = 'abbrDays_' . \CRM_Core_I18n::getLocale();
     if (empty(\Civi::$statics[__CLASS__][$key])) {
       $intl_formatter = IntlDateFormatter::create(CRM_Core_I18n::getLocale(), IntlDateFormatter::MEDIUM, IntlDateFormatter::MEDIUM, NULL, IntlDateFormatter::GREGORIAN, 'E');
@@ -204,7 +204,7 @@ class CRM_Utils_Date {
    *   0-based array with full weekday names
    *
    */
-  public static function getFullWeekdayNames() {
+  public static function getFullWeekdayNames(): array {
     $key = 'fullDays_' . \CRM_Core_I18n::getLocale();
     if (empty(\Civi::$statics[__CLASS__][$key])) {
       $intl_formatter = IntlDateFormatter::create(CRM_Core_I18n::getLocale(), IntlDateFormatter::MEDIUM, IntlDateFormatter::MEDIUM, NULL, IntlDateFormatter::GREGORIAN, 'EEEE');
@@ -258,13 +258,12 @@ class CRM_Utils_Date {
   /**
    * Return abbreviated month names according to the locale.
    *
-   * @param bool $month
+   * @param bool|string $month
    *
-   * @return array
+   * @return array|string
    *   1-based array with abbreviated month names
-   *
    */
-  public static function &getAbbrMonthNames($month = FALSE) {
+  public static function getAbbrMonthNames($month = FALSE) {
     $key = 'abbrMonthNames_' . \CRM_Core_I18n::getLocale();
     if (empty(\Civi::$statics[__CLASS__][$key])) {
       // Note: IntlDateFormatter provides even more strings than `strftime()` or `l10n/*/civicrm.mo`.
@@ -291,7 +290,7 @@ class CRM_Utils_Date {
    *   1-based array with full month names
    *
    */
-  public static function &getFullMonthNames() {
+  public static function getFullMonthNames(): array {
     $key = 'fullMonthNames_' . \CRM_Core_I18n::getLocale();
     if (empty(\Civi::$statics[__CLASS__][$key])) {
       // Note: IntlDateFormatter provides even more strings than `strftime()` or `l10n/*/civicrm.mo`.

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -258,7 +258,7 @@ class CRM_Utils_Date {
   /**
    * Return abbreviated month names according to the locale.
    *
-   * @param bool|string $month
+   * @param bool|string $month (deprecated)
    *
    * @return array|string
    *   1-based array with abbreviated month names
@@ -278,6 +278,7 @@ class CRM_Utils_Date {
       ));
     }
     if ($month) {
+      CRM_Core_Error::deprecatedWarning('passing in month is deprecated');
       return \Civi::$statics[__CLASS__][$key][$month];
     }
     return \Civi::$statics[__CLASS__][$key];


### PR DESCRIPTION

Overview
----------------------------------------
Remove function use of reference

Before
----------------------------------------
`function &get....()`

After
----------------------------------------
`function get....()`

Technical Details
----------------------------------------
We have removed a bunch of these (added for php4.x support) with no issues - it's only where there is inheritance we have hit issues

Comments
----------------------------------------
