### PR TITLE
Use distinct test workflow message for workflow message tests

### DIFF
--- a/tests/phpunit/CRM/Case/WorkflowMessage/CaseActivityTest.php
+++ b/tests/phpunit/CRM/Case/WorkflowMessage/CaseActivityTest.php
@@ -10,6 +10,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\WorkflowMessage\WorkflowMessage;
+
 /**
  * Class CRM_Case_WorkflowMessage_CaseActivityTest
  * @group msgtpl
@@ -18,18 +20,18 @@ class CRM_Case_WorkflowMessage_CaseActivityTest extends CiviUnitTestCase {
   use \Civi\Test\WorkflowMessageTestTrait;
 
   public function getWorkflowClass(): string {
-    return CRM_Case_WorkflowMessage_CaseActivity::class;
+    return CRM_Case_WorkflowMessage_CaseActivityTestWorkflow::class;
   }
 
   public function testAdhocClassEquiv(): void {
     $examples = \Civi\Api4\ExampleData::get(0)
       ->setSelect(['name', 'data'])
-      ->addWhere('name', 'IN', ['workflow/case_activity/CaseAdhocExample', 'workflow/case_activity/CaseModelExample'])
+      ->addWhere('name', 'IN', ['workflow/case_activity_test/CaseAdhocExample', 'workflow/case_activity_test/CaseModelExample'])
       ->execute()
       ->indexBy('name')
       ->column('data');
-    $byAdhoc = Civi\WorkflowMessage\WorkflowMessage::create('case_activity', $examples['workflow/case_activity/CaseAdhocExample']);
-    $byClass = new CRM_Case_WorkflowMessage_CaseActivity($examples['workflow/case_activity/CaseModelExample']);
+    $byAdhoc = WorkflowMessage::create('case_activity_test', $examples['workflow/case_activity_test/CaseAdhocExample']);
+    $byClass = new CRM_Case_WorkflowMessage_CaseActivityTestWorkflow($examples['workflow/case_activity_test/CaseModelExample']);
     $this->assertSameWorkflowMessage($byClass, $byAdhoc, 'Compare byClass and byAdhoc: ');
   }
 
@@ -53,8 +55,8 @@ class CRM_Case_WorkflowMessage_CaseActivityTest extends CiviUnitTestCase {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function testExampleGet(): void {
-    $file = \Civi::paths()->getPath('[civicrm.root]/tests/phpunit/CRM/Case/WorkflowMessage/CaseActivity/CaseModelExample.php');
-    $name = 'workflow/case_activity/CaseModelExample';
+    $file = \Civi::paths()->getPath('[civicrm.root]/tests/phpunit/CRM/Case/WorkflowMessage/CaseActivityTestWorkflow/CaseModelExample.php');
+    $name = 'workflow/case_activity_test/CaseModelExample';
 
     $this->assertTrue(file_exists($file), "Expect find canary file ($file)");
 

--- a/tests/phpunit/CRM/Case/WorkflowMessage/CaseActivityTestWorkflow.php
+++ b/tests/phpunit/CRM/Case/WorkflowMessage/CaseActivityTestWorkflow.php
@@ -9,18 +9,17 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\WorkflowMessage\GenericWorkflowMessage;
+
 /**
- * When an activity is created in a case, the "case_activity" email is sent.
- * Generally, the email is sent to the assignee, although (depending on
- * the configuration/add-ons) additional copies may be sent.
+ * Sample to test test model architecture.
  *
  * @see CRM_Case_BAO_Case::sendActivityCopy
  * @support template-only
  */
-class CRM_Case_WorkflowMessage_CaseActivity extends Civi\WorkflowMessage\GenericWorkflowMessage {
+class CRM_Case_WorkflowMessage_CaseActivityTestWorkflow extends GenericWorkflowMessage {
 
-  const GROUP = 'msg_tpl_workflow_case';
-  const WORKFLOW = 'case_activity';
+  const WORKFLOW = 'case_activity_test';
 
   /**
    * The recipient of the notification. The `{contact.*}` tokens will reference this person.

--- a/tests/phpunit/CRM/Case/WorkflowMessage/CaseActivityTestWorkflow/CaseAdhocExample.php
+++ b/tests/phpunit/CRM/Case/WorkflowMessage/CaseActivityTestWorkflow/CaseAdhocExample.php
@@ -1,6 +1,6 @@
 <?php
 
-class CRM_Case_WorkflowMessage_CaseActivity_CaseAdhocExample extends \Civi\WorkflowMessage\WorkflowMessageExample {
+class CRM_Case_WorkflowMessage_CaseActivityTestWorkflow_CaseAdhocExample extends \Civi\WorkflowMessage\WorkflowMessageExample {
 
   /**
    * @inheritDoc
@@ -10,7 +10,7 @@ class CRM_Case_WorkflowMessage_CaseActivity_CaseAdhocExample extends \Civi\Workf
       return []; /* CaseActivity WfMsg is temporarily in tests/phpunit, so it's not reliably loadable.  Temp work-around. */
     }
     yield [
-      'name' => "workflow/{$this->wfName}/{$this->exName}",
+      'name' => 'workflow/case_activity_test/CaseAdhocExample',
       'title' => ts('Case Activity (Adhoc-style example)'),
       'tags' => [],
     ];

--- a/tests/phpunit/CRM/Case/WorkflowMessage/CaseActivityTestWorkflow/CaseModelExample.php
+++ b/tests/phpunit/CRM/Case/WorkflowMessage/CaseActivityTestWorkflow/CaseModelExample.php
@@ -1,5 +1,5 @@
 <?php
-class CRM_Case_WorkflowMessage_CaseActivity_CaseModelExample extends \Civi\WorkflowMessage\WorkflowMessageExample {
+class CRM_Case_WorkflowMessage_CaseActivityTestWorkflow_CaseModelExample extends \Civi\WorkflowMessage\WorkflowMessageExample {
 
   /**
    * @inheritDoc
@@ -9,7 +9,7 @@ class CRM_Case_WorkflowMessage_CaseActivity_CaseModelExample extends \Civi\Workf
       return []; /* CaseActivity WfMsg is temporarily in tests/phpunit, so it's not reliably loadable.  Temp work-around. */
     }
     yield [
-      'name' => "workflow/{$this->wfName}/{$this->exName}",
+      'name' => 'workflow/case_activity_test/CaseModelExample',
       'title' => ts('Case Activity (Class-style example)'),
       'tags' => ['phpunit', 'preview'],
     ];

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -396,8 +396,11 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
   public function testCaseActivityCopyTemplate():void {
     $client_id = $this->individualCreate();
     $contact_id = $this->individualCreate();
-
-    $msg = WorkflowMessage::create('case_activity', [
+    \CRM_Core_DAO::executeQuery("
+      INSERT INTO civicrm_msg_template (msg_text, msg_subject, workflow_name, is_active, is_default)
+      VALUES('" . $this->getActivityCaseText() . "', '" . $this->getActivityCaseSubject() . "', 'case_activity_test', 1, 1)
+    ");
+    $msg = WorkflowMessage::create('case_activity_test', [
       'modelProps' => [
         'contactID' => $contact_id,
         'contact' => ['role' => 'Sand grain counter'],
@@ -420,7 +423,7 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
     $this->assertEquals([], Invasive::get([$msg, '_extras']));
 
     [, $subject, $message] = $msg->sendTemplate([
-      'workflow' => 'case_activity',
+      'workflow' => 'case_activity_test',
       'from' => 'admin@example.com',
       'toName' => 'Demo',
       'toEmail' => 'admin@example.com',
@@ -434,9 +437,9 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
 
   public function testSendToEmail_variantA(): void {
     $mut = new CiviMailUtils($this, TRUE);
-    $cid = $this->individualCreate();
+    $this->individualCreate();
 
-    $msg = \Civi\WorkflowMessage\WorkflowMessage::create('petition_sign', [
+    $msg = WorkflowMessage::create('petition_sign', [
       'from' => '"The Sender" <sender-a@example.com>',
       'toEmail' => 'demo-a@example.com',
       'contactId' => 204,
@@ -456,11 +459,67 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
     $mut->stop();
   }
 
+  /**
+   * Get the contents of the case activity text template, from when the test was written.
+   * @return string
+   */
+  public function getActivityCaseSubject(): string {
+    return '{if !empty($idHash)}[case #{$idHash}]{/if} {$activitySubject}';
+  }
+
+  /**
+   * Get the contents of the case activity text template, from when the test was written.
+   * @return string
+   */
+  public function getActivityCaseText(): string {
+    return '===========================================================
+{ts}Activity Summary{/ts} - {$activityTypeName}
+===========================================================
+{if !empty($isCaseActivity)}
+{ts}Your Case Role(s){/ts} : {$contact.role|default:""}
+{if !empty($manageCaseURL)}
+{ts}Manage Case{/ts} : {$manageCaseURL}
+{/if}
+{/if}
+
+{if !empty($editActURL)}
+{ts}Edit activity{/ts} : {$editActURL}
+{/if}
+{if !empty($viewActURL)}
+{ts}View activity{/ts} : {$viewActURL}
+{/if}
+
+{foreach from=$activity.fields item=field}
+{if $field.type eq "Date"}
+{$field.label} : {$field.value|crmDate:$config->dateformatDatetime}
+{else}
+{$field.label} : {$field.value}
+{/if}
+{/foreach}
+
+{if !empty($activity.customGroups)}
+{foreach from=$activity.customGroups key=customGroupName item=customGroup}
+==========================================================
+{$customGroupName}
+==========================================================
+{foreach from=$customGroup item=field}
+{if $field.type eq "Date"}
+{$field.label} : {$field.value|crmDate:$config->dateformatDatetime}
+{else}
+{$field.label} : {$field.value}
+{/if}
+{/foreach}
+
+{/foreach}
+{/if}
+';
+  }
+
   public function testSendToEmail_variantB(): void {
     $mut = new CiviMailUtils($this, TRUE);
     $cid = $this->individualCreate();
 
-    \Civi\WorkflowMessage\WorkflowMessage::create('petition_sign')
+    WorkflowMessage::create('petition_sign')
       ->setFrom(['name' => 'The Sender', 'email' => 'sender-b@example.com'])
       ->setTo(['name' => 'The Recipient', 'email' => 'demo-b@example.com'])
       ->setContactID($cid)

--- a/tests/phpunit/api/v4/Entity/WorkflowMessageTest.php
+++ b/tests/phpunit/api/v4/Entity/WorkflowMessageTest.php
@@ -40,7 +40,10 @@ class WorkflowMessageTest extends Api4TestBase implements TransactionalInterface
       ->addWhere('name', 'LIKE', 'case%')
       ->execute()
       ->indexBy('name');
-    $this->assertTrue(isset($result['case_activity']));
+    // Temporarily make this false - we are going to put the real slim shady
+    // in place soon - at which point we can re-enable but turn off for
+    // the bait & switch.
+    $this->assertFalse(isset($result['case_activity']));
   }
 
   /**

--- a/tests/phpunit/api/v4/Entity/WorkflowMessageTest.php
+++ b/tests/phpunit/api/v4/Entity/WorkflowMessageTest.php
@@ -47,8 +47,15 @@ class WorkflowMessageTest extends Api4TestBase implements TransactionalInterface
    * @throws \CRM_Core_Exception
    */
   public function testRenderDefaultTemplate(): void {
+    \CRM_Core_DAO::executeQuery("
+      INSERT INTO civicrm_msg_template (msg_text, workflow_name, is_active, is_default)
+      VALUES('" . '{foreach from=$activity.fields item=field}
+{$field.label} : {$field.value}
+{/foreach}' . "', 'case_activity_test', 1, 1)
+    ");
+
     $ex = ExampleData::get(FALSE)
-      ->addWhere('name', '=', 'workflow/case_activity/CaseModelExample')
+      ->addWhere('name', '=', 'workflow/case_activity_test/CaseModelExample')
       ->addSelect('data')
       ->addChain('render', WorkflowMessage::render()
         ->setWorkflow('$data.workflow')
@@ -64,12 +71,12 @@ class WorkflowMessageTest extends Api4TestBase implements TransactionalInterface
    */
   public function testRenderCustomTemplate(): void {
     $ex = ExampleData::get(0)
-      ->addWhere('name', '=', 'workflow/case_activity/CaseModelExample')
+      ->addWhere('name', '=', 'workflow/case_activity_test/CaseModelExample')
       ->addSelect('data')
       ->execute()
       ->single();
     $result = WorkflowMessage::render(0)
-      ->setWorkflow('case_activity')
+      ->setWorkflow('case_activity_test')
       ->setValues($ex['data']['modelProps'])
       ->setMessageTemplate([
         'msg_text' => 'The role is {$contact.role}.',


### PR DESCRIPTION

Overview
----------------------------------------
Use distinct test workflow message for workflow message tests

Before
----------------------------------------
Testing the workflow message subsystem tied to one pseudo workflow message class & a live template

After
----------------------------------------
Only test data used for the subsystem tests (we have other tests that cover the content of the message templates)

Technical Details
----------------------------------------
The tests for the workflow message subsystem use an instance of a test case_activity template attached the real message workflow template. They test the text version - meaning that removing it, like we have with others, causes various fails. In addition adding a real template that does not match the test version causes mayhem.

In this case we want to ensure we keep all the tests for the subsystem functionality but undo the tethering to a particular template to allow that template to have updates without having to go deep into this code

Comments
----------------------------------------
