### PR TITLE
Replace getTemplateVars() in test, assignTemplateVariables

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -215,7 +215,7 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
    */
   public function ensureVariablesAreAssigned(array $variables): void {
     foreach ($variables as $variable) {
-      if (!isset($this->get_template_vars()[$variable])) {
+      if (!isset($this->getTemplateVars()[$variable])) {
         $this->assign($variable);
       }
     }

--- a/tests/extensions/test.extension.manager.reporttest/main.php
+++ b/tests/extensions/test.extension.manager.reporttest/main.php
@@ -36,7 +36,7 @@ class test_extension_manager_reporttest extends CRM_Core_Report {
     if ($this->cid) {
       // link back to contact summary
       $this->assign('backURL', CRM_Utils_System::url('civicrm/contact/view', "reset=1&selectedChild=log&cid={$this->cid}", FALSE, NULL, FALSE));
-      $this->assign('revertURL', self::$_template->get_template_vars('revertURL') . "&cid={$this->cid}");
+      $this->assign('revertURL', self::$_template->getTemplateVars('revertURL') . "&cid={$this->cid}");
     }
     else {
       // link back to summary report


### PR DESCRIPTION
Overview
----------------------------------------
Replace getTemplateVars() in test, assignTemplateVariables

Before
----------------------------------------
`get_template_vars()`

After
----------------------------------------
`getTemplateVars()`

Technical Details
----------------------------------------
One of these is in a test class, the other extends the smarty compatibility class directly

Comments
----------------------------------------
