### PR TITLE
[NFC] Simplify translatePermission() switch statement

### DIFF
--- a/CRM/Core/Permission/Base.php
+++ b/CRM/Core/Permission/Base.php
@@ -60,14 +60,12 @@ class CRM_Core_Permission_Base {
     [$civiPrefix, $name] = CRM_Utils_String::parsePrefix(':', $perm, NULL);
     switch ($civiPrefix) {
       case $nativePrefix:
+      case NULL:
         return $name;
 
       // pass through
       case 'cms':
-        return CRM_Utils_Array::value($name, $map, CRM_Core_Permission::ALWAYS_DENY_PERMISSION);
-
-      case NULL:
-        return $name;
+        return $map[$name] ?? CRM_Core_Permission::ALWAYS_DENY_PERMISSION;
 
       default:
         return CRM_Core_Permission::ALWAYS_DENY_PERMISSION;


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup in `CRM_Core_Permission_Base`.

Before
----------------------------------------
Larger `switch{}`

After
----------------------------------------
Smaller `switch{}`; does the same thing.

Comments
----------------------------------------
IDK why, but `switch{}` statements always seems to trip people up and result in unnecessarily complicated code. This is actually one of the least-bad examples of that.