### PR TITLE
Issue 4879

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1128,11 +1128,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
 
     // get the formatted location blocks into params - w/ 3.0 format, CRM-4605
     if (!empty($values['location_type_id'])) {
-      $fields = NULL;
-      if ($fields == NULL) {
-        $fields = [];
-      }
-
       foreach (['Phone', 'Email', 'IM', 'OpenID', 'Phone_Ext'] as $block) {
         $name = strtolower($block);
         if (!array_key_exists($name, $values)) {

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1128,7 +1128,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
 
     // get the formatted location blocks into params - w/ 3.0 format, CRM-4605
     if (!empty($values['location_type_id'])) {
-      static $fields = NULL;
+      $fields = NULL;
       if ($fields == NULL) {
         $fields = [];
       }

--- a/CRM/Mailing/Event/BAO/MailingEventForward.php
+++ b/CRM/Mailing/Event/BAO/MailingEventForward.php
@@ -233,11 +233,6 @@ class CRM_Mailing_Event_BAO_MailingEventForward extends CRM_Mailing_Event_DAO_Ma
 
     // get the formatted location blocks into params - w/ 3.0 format, CRM-4605
     if (!empty($values['location_type_id'])) {
-      $fields = NULL;
-      if ($fields == NULL) {
-        $fields = [];
-      }
-
       foreach (['Phone', 'Email', 'IM', 'OpenID', 'Phone_Ext'] as $block) {
         $name = strtolower($block);
         if (!array_key_exists($name, $values)) {

--- a/CRM/Mailing/Event/BAO/MailingEventForward.php
+++ b/CRM/Mailing/Event/BAO/MailingEventForward.php
@@ -233,7 +233,7 @@ class CRM_Mailing_Event_BAO_MailingEventForward extends CRM_Mailing_Event_DAO_Ma
 
     // get the formatted location blocks into params - w/ 3.0 format, CRM-4605
     if (!empty($values['location_type_id'])) {
-      static $fields = NULL;
+      $fields = NULL;
       if ($fields == NULL) {
         $fields = [];
       }


### PR DESCRIPTION
Overview
----------------------------------------

This attempts to cure Issue 4879 - duplicate static declarations.

Before
----------------------------------------
The site crashes with:
```
PHP Fatal error:  Duplicate declaration of static variable $fields in <drupal root>/vendor/civicrm/civicrm-core/CRM/Mailing/Event/BAO/MailingEventForward.php on line 236
```
and
```
PHP Fatal error:  Duplicate declaration of static variable $fields in <drupal root>/vendor/civicrm/civicrm-core/CRM\Import/Parser.php on line 1131
```
After
----------------------------------------
The home page appears.

Technical Details
----------------------------------------
Removing the _static_ declaration on the offending lines in the offending files affects the cure.

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
