### PR TITLE
Fix e-notice on contact create for low-permissioned user

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -987,14 +987,9 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       $params['preferred_communication_method'] = 'null';
     }
 
-    $group = $params['group'] ?? NULL;
-    $params['group'] = ($params['group'] == '') ? [] : $params['group'];
-    if (!empty($group)) {
-      $group = is_array($group) ? $group : explode(',', $group);
-      $params['group'] = [];
-      foreach ($group as $key => $value) {
-        $params['group'][$value] = 1;
-      }
+    if (array_key_exists('group', $params)) {
+      $group = is_array($params['group']) ? $params['group'] : explode(',', $params['group']);
+      $params['group'] = array_fill_keys($group, 1);
     }
 
     if (!empty($params['image_URL'])) {


### PR DESCRIPTION
Overview
----------------------------------------
This cleans up some very messy code which was emitting e-notices when the 'group' key was missing. This can happen when the current user does not have permissions to add contacts to groups.

Replaces #28742

Before
--------
Overcomplicated code does, badly, what 2 lines can do.

After
------
2 lines do it better.