### PR TITLE
Fix Duplicate declaration of static variable under PHP 8.3

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1128,11 +1128,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
 
     // get the formatted location blocks into params - w/ 3.0 format, CRM-4605
     if (!empty($values['location_type_id'])) {
-      $fields = NULL;
-      if ($fields == NULL) {
-        $fields = [];
-      }
-
       foreach (['Phone', 'Email', 'IM', 'OpenID', 'Phone_Ext'] as $block) {
         $name = strtolower($block);
         if (!array_key_exists($name, $values)) {

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1128,7 +1128,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
 
     // get the formatted location blocks into params - w/ 3.0 format, CRM-4605
     if (!empty($values['location_type_id'])) {
-      static $fields = NULL;
+      $fields = NULL;
       if ($fields == NULL) {
         $fields = [];
       }

--- a/CRM/Mailing/Event/BAO/MailingEventForward.php
+++ b/CRM/Mailing/Event/BAO/MailingEventForward.php
@@ -233,11 +233,6 @@ class CRM_Mailing_Event_BAO_MailingEventForward extends CRM_Mailing_Event_DAO_Ma
 
     // get the formatted location blocks into params - w/ 3.0 format, CRM-4605
     if (!empty($values['location_type_id'])) {
-      $fields = NULL;
-      if ($fields == NULL) {
-        $fields = [];
-      }
-
       foreach (['Phone', 'Email', 'IM', 'OpenID', 'Phone_Ext'] as $block) {
         $name = strtolower($block);
         if (!array_key_exists($name, $values)) {

--- a/CRM/Mailing/Event/BAO/MailingEventForward.php
+++ b/CRM/Mailing/Event/BAO/MailingEventForward.php
@@ -233,7 +233,7 @@ class CRM_Mailing_Event_BAO_MailingEventForward extends CRM_Mailing_Event_DAO_Ma
 
     // get the formatted location blocks into params - w/ 3.0 format, CRM-4605
     if (!empty($values['location_type_id'])) {
-      static $fields = NULL;
+      $fields = NULL;
       if ($fields == NULL) {
         $fields = [];
       }


### PR DESCRIPTION
Overview
----------------------------------------
This was triggered by Issue 4879 where the web site crashed with duplicate declaration errors.
Fixes https://lab.civicrm.org/dev/core/-/issues/4879

Before
----------------------------------------
The web site crashed with:
```
PHP Fatal error:  Duplicate declaration of static variable $fields in <drupal root>/vendor/civicrm/civicrm-core/CRM/Mailing/Event/BAO/MailingEventForward.php on line 236
````
and
```
PHP Fatal error:  Duplicate declaration of static variable $fields in <drupal root>/vendor/civicrm/civicrm-core/CRM/Import/Parser.php on line 1131
```
After
----------------------------------------
The web site opens normally.

Technical Details
----------------------------------------
The 'offending' line and the three following ones are deleted in the two files above.

Comments
----------------------------------------
The changes were suggested by @colemanw .
