### PR TITLE
Price field and value weights not respected

### DIFF
--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -764,6 +764,7 @@ WHERE  id = %1";
       $data['fields'] = (array) PriceField::get(FALSE)
         ->addWhere('price_set_id', '=', $priceSetID)
         ->addSelect('*', 'visibility_id:name')
+        ->addOrderBy('weight', 'ASC')
         ->execute()->indexBy('id');
       foreach ($data['fields'] as &$field) {
         $field['options'] = [];
@@ -777,6 +778,7 @@ WHERE  id = %1";
       $options = PriceFieldValue::get(FALSE)
         ->addWhere('price_field_id', 'IN', array_keys($data['fields']))
         ->setSelect($select)
+        ->addOrderBy('weight', 'ASC')
         ->execute();
       $taxRates = CRM_Core_PseudoConstant::getTaxRates();
       foreach ($options as $option) {


### PR DESCRIPTION
Overview
----------------------------------------
#27902 causes price field and value weights not to be respected.
Lab ticket: https://lab.civicrm.org/dev/core/-/issues/4880

Before
----------------------------------------
Price fields and value sorted by primary key.

After
----------------------------------------
Price fields and value sorted by weight.

Comments
----------------------------------------
See also #28356.
