### PR TITLE
APIv4 - Add fk_column to getFields metadata

### DIFF
--- a/Civi/Api4/Generic/DAOGetFieldsAction.php
+++ b/Civi/Api4/Generic/DAOGetFieldsAction.php
@@ -131,6 +131,11 @@ class DAOGetFieldsAction extends BasicGetFieldsAction {
   public function fields() {
     $fields = parent::fields();
     $fields[] = [
+      'name' => 'fk_column',
+      'data_type' => 'String',
+      'description' => 'Name of fk_entity column this field references.',
+    ];
+    $fields[] = [
       'name' => 'dfk_entities',
       'description' => 'List of possible entity types this field could be referencing.',
       'data_type' => 'Array',

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -117,6 +117,9 @@ class SpecFormatter {
     elseif (($data['html']['type'] ?? NULL) === 'EntityRef' && !empty($data['pseudoconstant']['table'])) {
       $field->setFkEntity(CoreUtil::getApiNameFromTableName($data['pseudoconstant']['table']));
     }
+    if (!empty($data['FKColumnName'])) {
+      $field->setFkColumn($data['FKColumnName']);
+    }
 
     return $field;
   }

--- a/Civi/Schema/Traits/DataTypeSpecTrait.php
+++ b/Civi/Schema/Traits/DataTypeSpecTrait.php
@@ -44,6 +44,11 @@ trait DataTypeSpecTrait {
   /**
    * @var string
    */
+  public $fkColumn;
+
+  /**
+   * @var string
+   */
   public $dfkEntities;
 
   /**
@@ -98,7 +103,27 @@ trait DataTypeSpecTrait {
    */
   public function setFkEntity($fkEntity) {
     $this->fkEntity = $fkEntity;
+    // If the field has a FK Entity, then FK Column also must be set.
+    if ($fkEntity) {
+      // Ensure a sensible default if not already set.
+      $this->fkColumn ??= 'id';
+    }
+    return $this;
+  }
 
+  /**
+   * @return string|null
+   */
+  public function getFkColumn(): ?string {
+    return $this->fkColumn;
+  }
+
+  /**
+   * @param string $fkColumn
+   * @return $this
+   */
+  public function setFkColumn($fkColumn) {
+    $this->fkColumn = $fkColumn;
     return $this;
   }
 

--- a/tests/phpunit/api/v4/Action/GetFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetFieldsTest.php
@@ -253,6 +253,7 @@ class GetFieldsTest extends Api4TestBase implements TransactionalInterface {
     // fk_entity should be specific to specified entity_table, but dfk_entities should still contain all values
     $this->assertEquals('Activity', $tagFields['entity_id']['fk_entity']);
     $this->assertContains('Contact', $tagFields['entity_id']['dfk_entities']);
+    $this->assertEquals('id', $tagFields['entity_id']['fk_column']);
 
     $tagFields = EntityTag::getFields(FALSE)
       ->addValue('entity_table:name', 'Contact')

--- a/tests/phpunit/api/v4/Custom/CustomEntityReferenceTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomEntityReferenceTest.php
@@ -58,6 +58,7 @@ class CustomEntityReferenceTest extends CustomTestBase {
     $this->assertNull($spec['suffixes']);
     $this->assertEquals('EntityRef', $spec['input_type']);
     $this->assertEquals('Activity', $spec['fk_entity']);
+    $this->assertEquals('id', $spec['fk_column']);
     $this->assertEquals($subject, $spec['input_attrs']['filter']['subject']);
     // Check results
     $activities = $this->saveTestRecords('Activity', [


### PR DESCRIPTION
Overview
----------------------------------------
Improves APIv4 getFields metadata to include the name of the FK column in addition to the FK entity.

Before
----------------------------------------
getFields contained incomplete info about foreign keys, so trying to map the schema was unnecessarily difficult.

After
----------------------------------------
No need to use extra DAO methods like `getReferenceColumns()` to find out about FKs. All the info is returned by getFields.