### PR TITLE
[NFC] Cleanup dummy DAO in ruleGroupTest class

### DIFF
--- a/tests/phpunit/CRM/Dedupe/BAO/RuleGroupTest.php
+++ b/tests/phpunit/CRM/Dedupe/BAO/RuleGroupTest.php
@@ -2,18 +2,7 @@
 
 class CRM_Dedupe_DAO_TestEntity extends CRM_Core_DAO {
 
-  /**
-   * Returns foreign keys and entity references.
-   *
-   * @return array
-   *   [CRM_Core_Reference_Interface]
-   */
-  public static function getReferenceColumns() {
-    if (!isset(Civi::$statics[__CLASS__]['links'])) {
-      Civi::$statics[__CLASS__]['links'][] = new CRM_Core_Reference_Basic('civicrm_dedupe_test_table', 'contact_id', 'civicrm_contact', 'id');
-    }
-    return Civi::$statics[__CLASS__]['links'];
-  }
+  public static $_tableName = 'civicrm_dedupe_test_table';
 
   /**
    * Returns all the column names of this table
@@ -38,6 +27,7 @@ class CRM_Dedupe_DAO_TestEntity extends CRM_Core_DAO {
           'table_name' => 'civicrm_dedupe_test_table',
           'entity' => 'TestEntity',
           'FKClassName' => 'CRM_Contact_DAO_Contact',
+          'FKColumnName' => 'id',
         ],
         'dedupe_test_field' => [
           'name' => 'dedupe_test_field',


### PR DESCRIPTION
Overview
----------------------------------------
Cleans up a DAO class to be more inline with the new convention (see #28827).

Technical Details
----------------------------------------
The `getReferenceColumns()` function is no longer needed and can just use the parent function.