### PR TITLE
timezone is corrected in event ics file, fixes #4860

### DIFF
--- a/CRM/Utils/ICalendar.php
+++ b/CRM/Utils/ICalendar.php
@@ -174,16 +174,17 @@ class CRM_Utils_ICalendar {
     $tz_items = [];
 
     foreach ($timezones as $tzstr) {
-      $timezone = new DateTimeZone($tzstr);
+      $utcTimezone = new DateTimeZone('UTC');
+      $eventTimezone = new DateTimeZone($tzstr);
 
-      $transitions = $timezone->getTransitions($date_min, $date_max);
+      $transitions = $eventTimezone->getTransitions($date_min, $date_max);
 
       if (count($transitions) === 1) {
         $transitions[] = array_values($transitions)[0];
       }
 
       $item = [
-        'id' => $timezone->getName(),
+        'id' => $eventTimezone->getName(),
         'transitions' => [],
       ];
 
@@ -195,9 +196,8 @@ class CRM_Utils_ICalendar {
           'offset_from' => self::format_tz_offset($last_transition['offset']),
           'offset_to' => self::format_tz_offset($transition['offset']),
           'abbr' => $transition['abbr'],
-          'dtstart' => date_create($transition['time'], $timezone)->format("Ymd\THis"),
+          'dtstart' => date_create($transition['time'], $utcTimezone)->setTimezone($eventTimezone)->format("Ymd\THis"),
         ];
-
         $last_transition = $transition;
       }
 

--- a/tests/phpunit/CRM/Utils/ICalendarTest.php
+++ b/tests/phpunit/CRM/Utils/ICalendarTest.php
@@ -165,14 +165,15 @@ class CRM_Utils_ICalendarTest extends CiviUnitTestCase {
     ];
     $this->eventCreateUnpaid($eventParameters);
 
+    $expectedDate = date('Ymd', strtotime('tomorrow'));
     $info = CRM_Event_BAO_Event::getCompleteInfo(NULL, NULL, $this->getEventId());
     $calendar = explode("\n", CRM_Utils_ICalendar::createCalendarFile($info));
     $expectedLines = [
       "TZID:America/Los_Angeles" => FALSE,
-      "DTSTART:20240104T190000" => FALSE,
-      "DTSTAMP;TZID=America/Los_Angeles:20240104T190000" => FALSE,
-      "DTSTART;TZID=America/Los_Angeles:20240104T190000" => FALSE,
-      "DTEND;TZID=America/Los_Angeles:20240104T200000" => FALSE,
+      "DTSTART:{$expectedDate}T190000" => FALSE,
+      "DTSTAMP;TZID=America/Los_Angeles:{$expectedDate}T190000" => FALSE,
+      "DTSTART;TZID=America/Los_Angeles:{$expectedDate}T190000" => FALSE,
+      "DTEND;TZID=America/Los_Angeles:{$expectedDate}T200000" => FALSE,
     ];
     foreach ($calendar as $line) {
       $line = trim($line);


### PR DESCRIPTION
Overview
----------------------------------------
As described in [the ticket](https://lab.civicrm.org/dev/core/-/issues/4860), the ICS file generated from the event page provides the time of the event using the UTC timezone instead of the local time zone, as specified in the Ical spec. This patch ensures the timezone is set properly.

Before
----------------------------------------
Previously, the generated ICS file's timezone section sets the DSTART item to UTC time, e.g. for an event that starts at 9:00 am America/New_York time, it would include:

```
BEGIN:VTIMEZONE
TZID:America/New_York
BEGIN:STANDARD
TZOFFSETFROM:-0500
TZOFFSETTO:-0500
TZNAME:EST
DTSTART:20240226T140000
END:STANDARD
END:VTIMEZONE

```

After
----------------------------------------

The timezone is properly set to local time, e.g.:

```
BEGIN:VTIMEZONE
TZID:America/New_York
BEGIN:STANDARD
TZOFFSETFROM:-0500
TZOFFSETTO:-0500
TZNAME:EST
DTSTART:20240226T090000
END:STANDARD
END:VTIMEZONE
```

Technical Details
----------------------------------------
The bug was introduced in the `date_create` function, which takes the actual timezone of the event as the second argument, not the aspirational timezone.

Comments
----------------------------------------
A test is included.