### PR TITLE
Correct jcalendar.tpl

### DIFF
--- a/templates/CRM/common/jcalendar.tpl
+++ b/templates/CRM/common/jcalendar.tpl
@@ -10,7 +10,7 @@
 {if $batchUpdate}
     {assign var='elementId'   value=$form.field.$elementIndex.$elementName.id}
     {assign var="tElement" value=$elementName|cat:"_time"}
-    {assign var="timeElement" value=field_`$elementIndex`_`$elementName`_time}
+    {assign var="timeElement" value="field_`$elementIndex`_`$elementName`_time"}
     {$form.field.$elementIndex.$elementName.html}
 {elseif $elementIndex}
     {assign var='elementId'   value=$form.$elementName.$elementIndex.id}


### PR DESCRIPTION
Overview
----------------------------------------
A custom search uses <drupal root>/vendor/civicrm/civicrm-core/templates/CRM\common/jcalendar.tpl. The search was crashing when run against the latest version of civicrm_core with:
```
PHP Fatal error:  Type of SmartyCompilerException::$line must be int (as in class Exception) in <drupal root>/vendor/civicrm/civicrm-packages/smarty3/vendor/smarty/smarty/libs/sysplugins/smartycompilerexception.php on line 8
```
On doing significant debugging, the real error was 
```
Syntax error in template "file:D:\CiviCRM_Custom.git\drupal8\vendor\civicrm\civicrm-core\templates\CRM\common\jcalendar.tpl"  on line 13 "{assign var="timeElement" value=field_`$elementIndex`_`$elementName`_time}"  - Unexpected "`", expected one of: "}"
```
but Smarty error handling has problems handling this, despite $line being 13.

Before
----------------------------------------
You get
```
PHP Fatal error:  Type of SmartyCompilerException::$line must be int (as in class Exception) in <drupal root>/vendor/civicrm/civicrm-packages/smarty3/vendor/smarty/smarty/libs/sysplugins/smartycompilerexception.php on line 8
```

After
----------------------------------------
You get the custom search form.

Technical Details
----------------------------------------

Put double quotes around value on line 13.

Comments
----------------------------------------

This does not solve the problem that Smarty did not display the real error message.