### PR TITLE
dev/core#4881 Do not fatal if params is not an array

### DIFF
--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -498,6 +498,10 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
         }
       }
     }
+    if (!is_array($params)) {
+      CRM_Core_Error::deprecatedWarning('this could indicate a bug - see https://lab.civicrm.org/dev/core/-/issues/4881');
+      $params = [];
+    }
 
     //remove name related fields and construct name string with prefix/suffix
     //which will be later assigned to template


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4881 Do not fatal if params is not an array

Before
----------------------------------------
Reported fatal in https://lab.civicrm.org/dev/core/-/issues/4881 - which I could not replicate

After
----------------------------------------
It would not fatal but rather give a deprecation warning

Technical Details
----------------------------------------
Fatals are bad

Comments
----------------------------------------
