### PR TITLE
[REF] Fix Smarty Notices on Find Grants search

### DIFF
--- a/ext/civigrant/templates/CRM/Grant/Form/Search/Common.tpl
+++ b/ext/civigrant/templates/CRM/Grant/Form/Search/Common.tpl
@@ -37,7 +37,7 @@
   {assign var=notSetFieldName value=$fieldName|cat:'_notset'}
 <tr>
   <td>
-    {include file="CRM/Core/DatePickerRange.tpl" from='_low' to='_high'}
+    {include file="CRM/Core/DatePickerRange.tpl" from='_low' to='_high' hideRelativeLabel=0}
   </td>
   <td>
     &nbsp;{$form.$notSetFieldName.html}&nbsp;&nbsp;{$form.$notSetFieldName.label}

--- a/ext/civigrant/templates/CRM/Grant/Form/Selector.tpl
+++ b/ext/civigrant/templates/CRM/Grant/Form/Selector.tpl
@@ -33,7 +33,7 @@
 
   {counter start=0 skip=1 print=false}
   {foreach from=$rows item=row}
-  <tr id='crm-grant_{$row.grant_id}' class="{cycle values="odd-row,even-row"} crm-grant crm-grant_status-{$row.grant_status_id}">
+  <tr id='crm-grant_{$row.grant_id}' class="{cycle values="odd-row,even-row"} crm-grant crm-grant_status-{$row.grant_status}">
 
   {if !$single}
      {if $context eq 'Search'}


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix 5 notices that appear on the Find Grants search screen

Before
----------------------------------------
Notices
![image](https://github.com/civicrm/civicrm-core/assets/6799125/6fffeaf0-6fc6-48b8-bcea-dbdacf8e002c)

After
----------------------------------------
No Smarty Notices

ping @colemanw @eileenmcnaughton @JoeMurray 