### PR TITLE
Add system check to warn if CiviReport disabled & logging enabled

### DIFF
--- a/tests/phpunit/CRM/Utils/Check/Component/EnvTest.php
+++ b/tests/phpunit/CRM/Utils/Check/Component/EnvTest.php
@@ -18,7 +18,7 @@ class CRM_Utils_Check_Component_EnvTest extends CiviUnitTestCase {
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
   public function testResourceUrlCheck(): void {
-    $check = new \CRM_Utils_Check_Component_Env();
+    $check = new CRM_Utils_Check_Component_Env();
     $failRequest = $check->fileExists('https://civicrm.org', 0.001);
     $successRequest = $check->fileExists('https://civicrm.org', 0);
 


### PR DESCRIPTION
Overview
----------------------------------------
Add system check to warn if CiviReport disabled & logging enabled

Before
----------------------------------------
If a site admin enables logging & disables CiviReport the logging ChangeLog tab becomes (at least partially) unavailable but the admin is not warned

After
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/336308/72209297-aa5b-4c24-ab5b-bb52d3ed55ee)


Technical Details
----------------------------------------
Comments
----------------------------------------
