### PR TITLE
Move report test to civi_report

### DIFF
--- a/ext/civi_report/phpunit.xml.dist
+++ b/ext/civi_report/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" cacheResult="false" bootstrap="tests/phpunit/bootstrap.php">
+  <testsuites>
+    <testsuite name="My Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/ext/civi_report/tests/phpunit/ReportTest.php
+++ b/ext/civi_report/tests/phpunit/ReportTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use Civi\Test;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test CiviReport functionality.
+ *
+ * Tips:
+ *  - With HookInterface, you may implement CiviCRM hooks directly in the test class.
+ *    Simply create corresponding functions (e.g. "hook_civicrm_post(...)" or similar).
+ *  - With TransactionalInterface, any data changes made by setUp() or test****() functions will
+ *    rollback automatically -- as long as you don't manipulate schema or truncate tables.
+ *    If this test needs to manipulate schema or truncate tables, then either:
+ *       a. Do all that using setupHeadless() and Civi\Test.
+ *       b. Disable TransactionalInterface, and handle all setup/teardown yourself.
+ *
+ * @group headless
+ */
+class ReportTest extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  /**
+   * Setup used when HeadlessInterface is implemented.
+   *
+   * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+   *
+   * @link https://github.com/civicrm/org.civicrm.testapalooza/blob/master/civi-test.md
+   *
+   * @return \Civi\Test\CiviEnvBuilder
+   *
+   * @throws \CRM_Extension_Exception_ParseException
+   */
+  public function setUpHeadless(): CiviEnvBuilder {
+    return Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  /**
+   * Test makeCsv functionality.
+   *
+   * Include some special characters to check they are handled.
+   */
+  public function testMakeCsv(): void {
+    $form = new CRM_Report_Form();
+    $form->_columnHeaders = [
+      'civicrm_activity_activity_type_id' => [
+        'title' => 'Activity Type',
+        'type' => 2,
+      ],
+      'civicrm_activity_activity_subject' => [
+        'title' => 'Subject',
+        'type' => 2,
+      ],
+      'civicrm_activity_details' => [
+        'title' => 'Activity Details',
+        'type' => NULL,
+      ],
+    ];
+
+    $details = <<<ENDDETAILS
+<p>Here&#39;s some typical data from an activity details field.</p>
+<p>дè some non-ascii and <strong>html</strong> styling and these ̋“weird” quotes - ’.</p>
+<p>Also some named entities &quot;hello&quot;. And &amp; &eacute;. Also, some math like 2 &lt; 4.</p>
+ENDDETAILS;
+
+    $expectedOutput = <<<ENDOUTPUT
+\xEF\xBB\xBF"Activity Type","Subject","Activity Details"\r
+"Meeting","Meeting with the apostrophe's and that person who does ""air quotes"". Some non-ascii characters: дè","Here's some typical data from an activity details field.
+дè some non-ascii and html styling and these ̋“weird” quotes - ’.
+Also some named entities ""hello"". And & é. Also, some math like 2 < 4."\r
+
+ENDOUTPUT;
+
+    $rows = [
+      [
+        'civicrm_activity_activity_type_id' => 'Meeting',
+        'civicrm_activity_activity_subject' => 'Meeting with the apostrophe\'s and that person who does "air quotes". Some non-ascii characters: дè',
+        'civicrm_activity_details' => $details,
+      ],
+    ];
+
+    $csvString = CRM_Report_Utils_Report::makeCsv($form, $rows);
+    $this->assertEquals($expectedOutput, $csvString);
+  }
+
+}

--- a/ext/civi_report/tests/phpunit/bootstrap.php
+++ b/ext/civi_report/tests/phpunit/bootstrap.php
@@ -1,0 +1,65 @@
+<?php
+
+ini_set('memory_limit', '2G');
+
+// phpcs:disable
+eval(cv('php:boot --level=classloader', 'phpcode'));
+// phpcs:enable
+// Allow autoloading of PHPUnit helper classes in this extension.
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->add('CRM_', [__DIR__ . '/../..', __DIR__]);
+$loader->addPsr4('Civi\\', [__DIR__ . '/../../Civi', __DIR__ . '/Civi']);
+$loader->add('api_', [__DIR__ . '/../..', __DIR__]);
+$loader->addPsr4('api\\', [__DIR__ . '/../../api', __DIR__ . '/api']);
+
+$loader->register();
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return mixed
+ *   Response output (if the command executed normally).
+ *   For 'raw' or 'phpcode', this will be a string. For 'json', it could be any JSON value.
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv(string $cmd, string $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => STDERR];
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv('CV_OUTPUT=json');
+
+  // Execute `cv` in the original folder. This is a work-around for
+  // phpunit/codeception, which seem to manipulate PWD.
+  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== '/*BEGINPHP*/' || substr(trim($result), -10) !== '/*ENDPHP*/') {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}

--- a/tests/phpunit/CRM/Report/Utils/ReportTest.php
+++ b/tests/phpunit/CRM/Report/Utils/ReportTest.php
@@ -18,58 +18,6 @@
 class CRM_Report_Utils_ReportTest extends CiviUnitTestCase {
 
   /**
-   * Test makeCsv
-   */
-  public function testMakeCsv(): void {
-    $form = new CRM_Report_Form();
-    $form->_columnHeaders = [
-      'civicrm_activity_activity_type_id' => [
-        'title' => 'Activity Type',
-        'type' => 2,
-      ],
-      'civicrm_activity_activity_subject' => [
-        'title' => 'Subject',
-        'type' => 2,
-      ],
-      'civicrm_activity_details' => [
-        'title' => 'Activity Details',
-        'type' => NULL,
-      ],
-    ];
-
-    $details = <<<ENDDETAILS
-<p>Here&#39;s some typical data from an activity details field.
-  </p>
-<p>дè some non-ascii and <strong>html</strong> styling and these ̋“weird” quotes’s.
-  </p>
-<p>Also some named entities &quot;hello&quot;. And &amp; &eacute;. Also some math like 2 &lt; 4.
-  </p>
-ENDDETAILS;
-
-    $expectedOutput = <<<ENDOUTPUT
-\xEF\xBB\xBF"Activity Type","Subject","Activity Details"\r
-"Meeting","Meeting with the apostrophe's and that person who does ""air quotes"". Some non-ascii characters: дè","Here's some typical data from an activity details field.
-  
-дè some non-ascii and html styling and these ̋“weird” quotes’s.
-  
-Also some named entities ""hello"". And & é. Also some math like 2 < 4.
-  "\r
-
-ENDOUTPUT;
-
-    $rows = [
-      [
-        'civicrm_activity_activity_type_id' => 'Meeting',
-        'civicrm_activity_activity_subject' => 'Meeting with the apostrophe\'s and that person who does "air quotes". Some non-ascii characters: дè',
-        'civicrm_activity_details' => $details,
-      ],
-    ];
-
-    $csvString = CRM_Report_Utils_Report::makeCsv($form, $rows);
-    $this->assertEquals($expectedOutput, $csvString);
-  }
-
-  /**
    * Test when you choose Print from the actions dropdown.
    *
    * We're not too concerned about the actual report rows - there's other


### PR DESCRIPTION
Overview
----------------------------------------
Move report test to civi_report

Before
----------------------------------------
Civi-report specific test in main CRM test suite

After
----------------------------------------
Moved to the civi-report extension

Technical Details
----------------------------------------
I limited this move to a single test within the class to make this part easy & especially as I wasn't sure if CI needed to be configured to support this move ... @seamuslee001 ?

Comments
----------------------------------------
