### PR TITLE
Ensure auto renew is set on Membership price set

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -690,7 +690,7 @@ class CRM_Financial_BAO_Order {
           elseif (!empty($option['membership_type_id'])) {
             $membershipType = CRM_Member_BAO_MembershipType::getMembershipType((int) $option['membership_type_id']);
             $metadata[$index]['options'][$optionID]['membership_type_id.auto_renew'] = (int) $membershipType['auto_renew'];
-            $metadata[$index]['supports_auto_renew'] = $membershipType['auto_renew'] ?: (bool) $membershipType['auto_renew'];
+            $metadata[$index]['supports_auto_renew'] = $metadata[$index]['supports_auto_renew'] ?? $membershipType['auto_renew'] ?: (bool) $membershipType['auto_renew'];
           }
           else {
             $metadata[$index]['options'][$optionID]['membership_type_id.auto_renew'] = NULL;


### PR DESCRIPTION
Overview
----------------------------------------
`supports_auto_renew` is set to false if last iterator of the for loop is a non recur mem type option.

Before
----------------------------------------
Auto Renew checkbox is not loaded if membership price option list has non recur option set to last.

After
----------------------------------------
Auto Renew checkbox is loaded irrespective of mem type ordering.

Technical Details
----------------------------------------
If the last iterator of the for loop is a non recur mem type option, it overrides the `supports_auto_renew ` value and set it to false leading to no renew checkbox on the page.

Comments
----------------------------------------
fyi @eileenmcnaughton @totten 