### PR TITLE
Handle auto-renew correctly on original-price-sets

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -551,6 +551,17 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
             ];
           }
 
+          if (!empty($field['options'])) {
+            foreach ($field['options'] as $option) {
+              if (!empty($option['membership_type_id.auto_renew'])) {
+                $extra += [
+                  'onclick' => "return showHideAutoRenew(CRM.$(this).data('membershipTypeId'));",
+                ];
+                $this->assign('membershipFieldID', $fieldID);
+              }
+            }
+          }
+
           CRM_Price_BAO_PriceField::addQuickFormElement($form,
             'price_' . $fieldID,
             $field['id'],
@@ -623,8 +634,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     $this->addOptionalQuickFormElement('auto_renew');
     $this->addExpectedSmartyVariable('renewal_mode');
     if ($this->_membershipBlock) {
-
-      $membershipTypeIds = $membershipTypes = $radio = $radioOptAttrs = [];
+      $membershipTypeIds = $membershipTypes = $radio = [];
       // This is always true if this line is reachable - remove along with the upcoming if.
       $membershipPriceset = TRUE;
 
@@ -658,7 +668,6 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
           if ($memType['is_active']) {
             $autoRenewMembershipTypeOptions["autoRenewMembershipType_{$value}"] = $this->getConfiguredAutoRenewOptionForMembershipType($value);
             if ($allowAutoRenewOpt) {
-              $javascriptMethod = ['onclick' => "return showHideAutoRenew( this.value );"];
               $allowAutoRenewMembership = TRUE;
             }
             else {
@@ -667,14 +676,12 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
             //add membership type.
             $radio[$memType['id']] = NULL;
-            $radioOptAttrs[$memType['id']] = $javascriptMethod;
             if ($cid) {
               //show current membership, skip pending and cancelled membership records,
               $membership = $memberships[$memType['id']] ?? NULL;
               if ($membership) {
                 if ($membership["membership_type_id.duration_unit:name"] === 'lifetime') {
                   unset($radio[$memType['id']]);
-                  unset($radioOptAttrs[$memType['id']]);
                   $this->assign('hasExistingLifetimeMembership', TRUE);
                   unset($memberships[$memType['id']]);
                   continue;

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -372,16 +372,9 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
             'data-amount' => $opt[$valueFieldName],
             'data-currency' => $currencyName,
             'data-price-field-values' => json_encode($customOption),
+            'data-membership-type-id' => $opt['membership_type_id'] ?? NULL,
             'visibility' => $visibility_id,
           ] + $incomingExtra;
-          // @todo - move this back to the only calling function on Contribution_Form_Main.php
-          if ($field->name == 'membership_amount') {
-            $extra += [
-              'onclick' => "return showHideAutoRenew({$opt['membership_type_id']});",
-              'membership-type' => $opt['membership_type_id'],
-            ];
-            $qf->assign('membershipFieldID', $field->id);
-          }
 
           $choice[$opt['id']] = CRM_Utils_String::purifyHTML($priceOptionText['label']);
           $choiceAttrs[$opt['id']] = $extra;
@@ -412,7 +405,10 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           }
 
           $choice['0'] = '<span class="crm-price-amount-label">' . $none . '</span>';
-          $choiceAttrs['0'] = ['price' => json_encode([$elementName, '0'])];
+          $choiceAttrs['0'] = [
+            'price' => json_encode([$elementName, '0']),
+            'data-membership-type-id' => NULL,
+          ] + $incomingExtra;
         }
 
         $element = &$qf->addRadio($elementName, $label, $choice, [], NULL, FALSE, $choiceAttrs);


### PR DESCRIPTION
Overview
----------------------------------------
Handle auto-renew correctly on original-price-sets

Before
----------------------------------------
Auto-renew is handled differently on price sets created 'from scratch' vs created by transforming a quick config price set - the reason being the name 'membership_amount' for the price field is signficant

After
----------------------------------------
Auto-renew handling not dependent on price field name

Technical Details
----------------------------------------

Comments
----------------------------------------
