### PR TITLE
Fixes Backdrop summary/detail admin theme clash

### DIFF
--- a/css/backdrop.css
+++ b/css/backdrop.css
@@ -57,3 +57,16 @@
 .crm-container.ui-dialog .ui-dialog-titlebar-close .ui-icon.fa-compress::before {
   content: "\f066";
 }
+
+/* Resets details/summary appearance for accordions */
+
+.crm-container details {
+  border: 0 solid transparent;
+  background-color: inherit;
+  padding: 0;
+  margin: inherit;
+}
+.crm-container details summary span {
+  color: inherit;
+  font-size: inherit;
+}


### PR DESCRIPTION
As described here: https://lab.civicrm.org/dev/core/-/issues/4884. The issue raised there can also be seen on the extensions and advanced search screens, as well as new FormBuilder / SearchKit output.

Overview
----------------------------------------
Backdrop's current admin theme describes `<details>` and`<summary>` in ways that overwrites civicrm.css. This fix resets the admin theme's added borders/padding and link colouring, as highlighted in this issue: https://lab.civicrm.org/dev/core/-/issues/4884
 
Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/1175967/d424d52f-9d47-452a-8e66-2b9085b8956a)
<img width="910" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/1f01ac41-baa5-422f-9b4b-372c7b6d0674">

After
----------------------------------------
<img width="1099" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/bd289ccc-1bfd-48a3-aa42-29d789c6fc7f">
<img width="887" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/87ba06ec-c015-46b6-9548-f4be67aeb998">

Comments
----------------------------------------
Only merge this fix if this file will **only** load on Backdrop instances; it's not been tested elsewhere.