### PR TITLE
dev/core#4886 fix syntax error in contact summary template

### DIFF
--- a/templates/CRM/Contact/Import/Form/Summary.tpl
+++ b/templates/CRM/Contact/Import/Form/Summary.tpl
@@ -118,7 +118,7 @@
     {if $groupAdditions}
     <tr><td class="label crm-grid-cell">{ts}Import to Groups{/ts}</td>
         <td colspan="2" class="explanation">
-            {foreach from="$groupAdditions" item="group"}
+            {foreach from=$groupAdditions item="group"}
                 <label><a href="{$group.url}">{$group.name}</a></label>:
                 {if $group.new}
                     {ts count=$group.added plural='%count contacts added to this new group.'}One contact added to this new group.{/ts}
@@ -134,7 +134,7 @@
     {if $tagAdditions}
     <tr><td class="label crm-grid-cell">{ts}Tagged Imported Contacts{/ts}</td>
         <td colspan="2" class="explanation">
-            {foreach from="$tagAdditions" item="tag"}
+            {foreach from=$tagAdditions item="tag"}
                 <label>{$tag.name}</label>:
                 {ts count=$tag.added plural='%count contacts are tagged with this tag.'}One contact is tagged with this tag.{/ts}
                 {if $tag.notAdded}{ts count=$tag.notAdded plural='%count contacts NOT tagged (already tagged to this tag).'}One contact NOT tagged (already tagged to this tag).{/ts}{/if}<br />


### PR DESCRIPTION
Overview
----------------------------------------
Smarty3 errors reported in https://lab.civicrm.org/dev/core/-/issues/4886 surfaced a problem with the smarty syntax causing invalid output

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/8d20b17e-0bd0-4dec-9c28-b7a29a9a683e)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/941b4d27-1055-4b7b-a137-49d19de4e570)

Technical Details
----------------------------------------
Comments
----------------------------------------
