### PR TITLE
Fix Smarty3 error in online event registration

### DIFF
--- a/CRM/Event/WorkflowMessage/ParticipantTrait.php
+++ b/CRM/Event/WorkflowMessage/ParticipantTrait.php
@@ -51,6 +51,17 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
   public $isShowParticipantCount;
 
   /**
+   * What is the participant count, if 'specifically configured'.
+   *
+   * See getter notes.
+   *
+   * @var bool
+   *
+   * @scope tplParams as participantCount
+   */
+  public $participantCount;
+
+  /**
    * @var int
    *
    * @scope tokenContext as eventId, tplParams as eventID
@@ -175,12 +186,28 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
    * @throws \CRM_Core_Exception
    */
   public function getIsShowParticipantCount(): bool {
+    return (bool) $this->getParticipantCount();
+  }
+
+  /**
+   * Get the count of participants, where count is used in the line items.
+   *
+   * This might be the case where a line item represents a table of 6 people.
+   *
+   * Where the price field value does not record the participant count we ignore.
+   *
+   * This lack of specifying it is a bit unclear but seems to be 'presumed 1'.
+   * From the templates point of view it is not information to present if not
+   * configured.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function getParticipantCount() {
+    $count = 0;
     foreach ($this->getLineItems() as $lineItem) {
-      if ((int) $lineItem['participant_count'] > 1) {
-        return TRUE;
-      }
+      $count += $lineItem['participant_count'];
     }
-    return FALSE;
+    return $count;
   }
 
   /**

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -206,7 +206,7 @@
                               <th>{ts}Tax Amount{/ts}</th>
                             {/if}
                           <th>{ts}Total{/ts}</th>
-                          {if !empty($pricesetFieldsCount)}
+                          {if $isShowParticipantCount}
                             <th>{ts}Total Participants{/ts}</th>
                           {/if}
                         </tr>
@@ -228,7 +228,7 @@
                             <td {$tdStyle}>
                               {$line.line_total_inclusive|crmMoney:$currency}
                             </td>
-                            {if !empty($pricesetFieldsCount)}
+                            {if $isShowParticipantCount}
                               <td {$tdStyle}>{$line.participant_count}</td>
                             {/if}
                           </tr>
@@ -300,25 +300,12 @@
                   {contribution.total_amount} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
                 </td>
               </tr>
-              {if !empty($pricesetFieldsCount)}
+              {if $isShowParticipantCount}
                 <tr>
                   <td {$labelStyle}>
                     {ts}Total Participants{/ts}</td>
                   <td {$valueStyle}>
-                    {assign var="count" value= 0}
-                    {foreach from=$lineItem item=pcount}
-                      {assign var="lineItemCount" value=0}
-                      {if $pcount neq 'skip'}
-                        {foreach from=$pcount item=p_count}
-                          {assign var="lineItemCount" value=$lineItemCount+$p_count.participant_count}
-                        {/foreach}
-                        {if $lineItemCount < 1}
-                          {assign var="lineItemCount" value=1}
-                        {/if}
-                        {assign var="count" value=$count+$lineItemCount}
-                      {/if}
-                    {/foreach}
-                    {$count}
+                    {$participantCount}
                   </td>
                 </tr>
               {/if}


### PR DESCRIPTION
port https://github.com/civicrm/civicrm-core/pull/28884

Since we are encouraging people to use Smarty3 in 5.69 we should fix this in 5.69 - It only kicks in when the price set has configured participant counts - in which case it would be at best unreliably calculated but we see this escalated to an error here - 
https://test.civicrm.org/job/CiviCRM-Core-Matrix-PR/7981/BKPROF=dfl,SUITES=phpunit-api3,label=bknix-tmp/testReport/junit/(root)/api_v3_PaymentTest/testPaymentEmailReceiptFullyPaid/

Not doing a push update -but at least the fix should be readily available