### PR TITLE
[Ref] Minor cleanup in handling of additional participants when sending mail + improve test

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1187,13 +1187,13 @@ WHERE civicrm_event.is_active = 1
 
         $sendTemplateParams = [
           'workflow' => 'event_online_receipt',
-          'contactId' => $contactID,
           'isTest' => $isTest,
           'tplParams' => $tplParams,
           'PDFFilename' => ts('confirmation') . '.pdf',
           'modelProps' => [
             'participantID' => (int) $participantId,
             'eventID' => (int) $values['event']['id'],
+            'contactID' => (int) $contactID,
           ],
         ];
 

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1602,6 +1602,8 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     $primaryContactId = $this->get('primaryContactId');
 
     //build an array of custom profile and assigning it to template.
+    // @todo - don't call buildCustomProfile to get additionalParticipants.
+    // CRM_Event_BAO_Participant::getAdditionalParticipantIds is a better fit.
     $additionalIDs = CRM_Event_BAO_Event::buildCustomProfile($registerByID, NULL,
       $primaryContactId, $isTest, TRUE
     );

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -779,6 +779,8 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     else {
 
       //build an array of cId/pId of participants
+      // @todo - don't call buildCustomProfile to get additionalParticipants.
+      // CRM_Event_BAO_Participant::getAdditionalParticipantIds is a better fit.
       $additionalIDs = CRM_Event_BAO_Event::buildCustomProfile($registerByID,
         NULL, $primaryContactId, $isTest,
         TRUE

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -230,7 +230,6 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testTaxMultipleParticipant(): void {
-    $this->swapMessageTemplateForTestTemplate('event_online_receipt', 'text');
     $this->createLoggedInUser();
     $this->createScenarioMultipleParticipantPendingWithTax();
 
@@ -247,8 +246,8 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     $this->assertEquals(660, $contribution['total_amount'], 'Invalid Tax amount.');
     $mailSent = $this->sentMail;
     $this->assertCount(3, $mailSent, 'Three mails should have been sent to the 3 participants.');
-    $this->assertStringContainsString('contactID:::' . $contribution['contact_id'], $mailSent[0]['body']);
-    $this->assertStringContainsString('contactID:::' . ($contribution['contact_id'] + 1), $mailSent[1]['body']);
+    $this->assertStringContainsString('Dear Participant1', $mailSent[0]['body']);
+    $this->assertStringContainsString('Dear Participant2', $mailSent[1]['body']);
     $mut = new CiviMailUtils($this);
     $this->validateAllContributions();
     $this->validateAllPayments();
@@ -256,12 +255,11 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     $mailSent = $mut->getAllMessages();
     $this->assertCount(3, $mailSent);
 
-    $this->assertStringContainsString('participant_status:::Registered', $mailSent[0]);
-    $this->assertStringContainsString('Dear Participant2', $mailSent[0]);
+    $this->assertStringContainsString('Registered', $mailSent[0]);
 
-    $this->assertStringContainsString('contactID:::' . ($contribution['contact_id'] + 1), $mailSent[0]);
-    $this->assertStringContainsString('contactID:::' . ($contribution['contact_id'] + 2), $mailSent[1]);
-    $this->assertStringContainsString('contactID:::' . $contribution['contact_id'], $mailSent[2]);
+    $this->assertStringContainsString('Dear Participant1', $mailSent[2]);
+    $this->assertStringContainsString('Dear Participant2', $mailSent[0]);
+    $this->assertStringContainsString('Dear Participant3', $mailSent[1]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
[Ref] Minor cleanup in handling of additional participants when sending mail + improve test

Before
----------------------------------------
The test was not testing the actual content of the email but rather the test-only one. We have found this approach is not really as good.

After
----------------------------------------
Tests actual email - in the process I did a little clean up to load the additional participants in a more sane manner

Technical Details
----------------------------------------
I also removed the apparent copy & paste save - there isn't a world in which we are relying on the send-email function to update the participant statuses - or else we would have had people reporting it not happening when no email is sent

Comments
----------------------------------------
