### PR TITLE
[REF]  Convert _checkAccess to event listener

### DIFF
--- a/CRM/Contact/AccessTrait.php
+++ b/CRM/Contact/AccessTrait.php
@@ -15,30 +15,33 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\Event\AuthorizeRecordEvent;
+use Civi\Api4\Utils\CoreUtil;
+
 /**
  * Trait shared with entities attached to the contact record.
  */
 trait CRM_Contact_AccessTrait {
 
   /**
-   * @param string $entityName
-   * @param string $action
-   * @param array $record
-   * @param int $userID
-   * @return bool
    * @see \Civi\Api4\Utils\CoreUtil::checkAccessRecord
    */
-  public static function _checkAccess(string $entityName, string $action, array $record, int $userID) {
+  public static function self_civi_api4_authorizeRecord(AuthorizeRecordEvent $e): void {
+    $record = $e->getRecord();
+    $userID = $e->getUserID();
+    $delegateAction = $e->getActionName() === 'get' ? 'get' : 'update';
     $cid = $record['contact_id'] ?? NULL;
     if (!$cid && !empty($record['id'])) {
       $cid = CRM_Core_DAO::getFieldValue(__CLASS__, $record['id'], 'contact_id');
     }
     if (!$cid) {
       // With no contact id this must be part of an event locblock
-      return in_array(__CLASS__, ['CRM_Core_BAO_Phone', 'CRM_Core_BAO_Email', 'CRM_Core_BAO_Address']) &&
-        CRM_Core_Permission::check('edit all events', $userID);
+      $e->setAuthorized(in_array(__CLASS__, ['CRM_Core_BAO_Phone', 'CRM_Core_BAO_Email', 'CRM_Core_BAO_Address']) &&
+        CRM_Core_Permission::check('edit all events', $userID));
     }
-    return \Civi\Api4\Utils\CoreUtil::checkAccessDelegated('Contact', 'update', ['id' => $cid], $userID);
+    else {
+      $e->setAuthorized(CoreUtil::checkAccessDelegated('Contact', $delegateAction, ['id' => $cid], $userID));
+    }
   }
 
 }

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -9,6 +9,7 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Event\AuthorizeRecordEvent;
 use Civi\Token\TokenProcessor;
 
 /**
@@ -3587,17 +3588,17 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
   }
 
   /**
-   * @param string $entityName
-   * @param string $action
-   * @param array $record
-   * @param $userID
-   * @return bool
+   * Check contact access.
    * @see \Civi\Api4\Utils\CoreUtil::checkAccessRecord
    */
-  public static function _checkAccess(string $entityName, string $action, array $record, $userID): bool {
-    switch ($action) {
+  public static function self_civi_api4_authorizeRecord(AuthorizeRecordEvent $e): void {
+    $record = $e->getRecord();
+    $userID = $e->getUserID();
+
+    switch ($e->getActionName()) {
       case 'create':
-        return CRM_Core_Permission::check('add contacts', $userID);
+        $e->setAuthorized(CRM_Core_Permission::check('add contacts', $userID));
+        return;
 
       case 'get':
         $actionType = CRM_Core_Permission::VIEW;
@@ -3612,7 +3613,7 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
         break;
     }
 
-    return CRM_Contact_BAO_Contact_Permission::allow($record['id'], $actionType, $userID);
+    $e->setAuthorized(CRM_Contact_BAO_Contact_Permission::allow($record['id'], $actionType, $userID));
   }
 
   /**

--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Event\AuthorizeRecordEvent;
+
 /**
  *
  * @package CRM
@@ -868,23 +870,18 @@ WHERE ($subtypeClause)";
   }
 
   /**
-   * @param string $entityName
-   * @param string $action
-   * @param array $record
-   * @param $userID
-   * @return bool
+   * Check write access.
    * @see \Civi\Api4\Utils\CoreUtil::checkAccessRecord
    */
-  public static function _checkAccess(string $entityName, string $action, array $record, $userID): bool {
+  public static function self_civi_api4_authorizeRecord(AuthorizeRecordEvent $e): void {
     // Only records with a parent may be deleted
-    if ($action === 'delete') {
+    if ($e->getActionName() === 'delete') {
+      $record = $e->getRecord();
       if (!array_key_exists('parent_id', $record)) {
         $record['parent_id'] = CRM_Core_DAO::getFieldValue(parent::class, $record['id'], 'parent_id');
       }
-      return (bool) $record['parent_id'];
+      $e->setAuthorized((bool) $record['parent_id']);
     }
-    // Gatekeeper permissions suffice for everything else
-    return TRUE;
   }
 
 }

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -9,14 +9,16 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Event\AuthorizeRecordEvent;
 use Civi\Api4\Group;
+use Civi\Core\HookInterface;
 
 /**
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
+class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group implements HookInterface {
 
   /**
    * @deprecated
@@ -1441,32 +1443,26 @@ WHERE {$whereClause}";
   }
 
   /**
-   * @param string $entityName
-   * @param string $action
-   * @param array $record
-   * @param $userID
-   * @return bool
+   * Check write access.
    * @see \Civi\Api4\Utils\CoreUtil::checkAccessRecord
    */
-  public static function _checkAccess(string $entityName, string $action, array $record, $userID): bool {
-    switch ($action) {
-      case 'create':
-        $groupType = (array) ($record['group_type:name'] ?? []);
-        // If not already in :name format, transform to name
-        foreach ((array) ($record['group_type'] ?? []) as $typeId) {
-          $groupType[] = CRM_Core_PseudoConstant::getName(self::class, 'group_type', $typeId);
-        }
-        if ($groupType === ['Mailing List']) {
-          // If it's only a Mailing List, edit groups OR create mailings will work
-          return CRM_Core_Permission::check(['access CiviCRM', ['edit groups', 'access CiviMail', 'create mailings']], $userID);
-        }
-        else {
-          return CRM_Core_Permission::check(['access CiviCRM', 'edit groups'], $userID);
-        }
-
-      default:
-        // All other actions just rely on gatekeeper permissions
-        return TRUE;
+  public static function self_civi_api4_authorizeRecord(AuthorizeRecordEvent $e): void {
+    $record = $e->getRecord();
+    $userID = $e->getUserID();
+    // Check create permission (all other actions just rely on gatekeeper permissions)
+    if ($e->getActionName() === 'create') {
+      $groupType = (array) ($record['group_type:name'] ?? []);
+      // If not already in :name format, transform to name
+      foreach ((array) ($record['group_type'] ?? []) as $typeId) {
+        $groupType[] = CRM_Core_PseudoConstant::getName(self::class, 'group_type', $typeId);
+      }
+      if ($groupType === ['Mailing List']) {
+        // If it's only a Mailing List, edit groups OR create mailings will work
+        $e->setAuthorized(CRM_Core_Permission::check(['access CiviCRM', ['edit groups', 'access CiviMail', 'create mailings']], $userID));
+      }
+      else {
+        $e->setAuthorized(CRM_Core_Permission::check(['access CiviCRM', 'edit groups'], $userID));
+      }
     }
   }
 

--- a/CRM/Core/BAO/CustomValue.php
+++ b/CRM/Core/BAO/CustomValue.php
@@ -15,10 +15,12 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\Event\AuthorizeRecordEvent;
+
 /**
  * Business objects for managing custom data values.
  */
-class CRM_Core_BAO_CustomValue extends CRM_Core_DAO {
+class CRM_Core_BAO_CustomValue extends CRM_Core_DAO implements \Civi\Core\HookInterface {
 
   /**
    * Validate a value against a CustomField type.
@@ -230,36 +232,28 @@ class CRM_Core_BAO_CustomValue extends CRM_Core_DAO {
   }
 
   /**
-   * Special checkAccess function for multi-record custom pseudo-entities
-   *
-   * @param string $entityName
-   *   APIv4-style entity name e.g. 'Custom_Foobar'
-   * @param string $action
-   * @param array $record
-   * @param int $userID
-   *   Contact ID of the active user (whose access we must check). 0 for anonymous.
-   * @return bool
-   *   TRUE if granted. FALSE if prohibited. NULL if indeterminate.
+   * Access check for multi-record custom pseudo-entities
+   * @see \Civi\Api4\Utils\CoreUtil::checkAccessRecord
    */
-  public static function _checkAccess(string $entityName, string $action, array $record, int $userID): ?bool {
+  public static function on_civi_api4_authorizeRecord(AuthorizeRecordEvent $e): void {
+    $groupName = \Civi\Api4\Utils\CoreUtil::getCustomGroupName($e->getEntityName());
+    if (!$groupName) {
+      return;
+    }
+
     // This check implements two rules: you must have access to the specific custom-data-group - and to the underlying record (e.g. Contact).
+    $record = $e->getRecord();
+    $userID = $e->getUserID();
+    $action = $e->getActionName();
 
     // Expecting APIv4-style entity name
-    $groupName = \Civi\Api4\Utils\CoreUtil::getCustomGroupName($entityName);
     $extends = \CRM_Core_BAO_CustomGroup::getEntityForGroup($groupName);
     $id = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $groupName, 'id', 'name');
-    if (!$groupName) {
-      // $groupName is required but the function signature has to match the parent.
-      throw new CRM_Core_Exception('Missing required group-name in CustomValue::checkAccess');
-    }
-
-    if (empty($extends) || empty($id)) {
-      throw new CRM_Core_Exception('Received invalid group-name in CustomValue::checkAccess');
-    }
 
     $actionType = $action === 'get' ? CRM_Core_Permission::VIEW : CRM_Core_Permission::EDIT;
     if (!\CRM_Core_BAO_CustomGroup::checkGroupAccess($id, $actionType, $userID)) {
-      return FALSE;
+      $e->setAuthorized(FALSE);
+      return;
     }
 
     $eid = $record['entity_id'] ?? NULL;
@@ -270,7 +264,7 @@ class CRM_Core_BAO_CustomValue extends CRM_Core_DAO {
 
     // Do we have access to the target record?
     $delegatedAction = $action === 'get' ? 'get' : 'update';
-    return \Civi\Api4\Utils\CoreUtil::checkAccessDelegated($extends, $delegatedAction, ['id' => $eid], $userID);
+    $e->setAuthorized(\Civi\Api4\Utils\CoreUtil::checkAccessDelegated($extends, $delegatedAction, ['id' => $eid], $userID));
   }
 
 }

--- a/CRM/Core/BAO/EntityTag.php
+++ b/CRM/Core/BAO/EntityTag.php
@@ -15,7 +15,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
+class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag implements \Civi\Core\HookInterface {
   use CRM_Core_DynamicFKAccessTrait;
 
   /**

--- a/CRM/Core/BAO/Website.php
+++ b/CRM/Core/BAO/Website.php
@@ -18,7 +18,7 @@
 /**
  * This class contain function for Website handling.
  */
-class CRM_Core_BAO_Website extends CRM_Core_DAO_Website {
+class CRM_Core_BAO_Website extends CRM_Core_DAO_Website implements Civi\Core\HookInterface {
   use CRM_Contact_AccessTrait;
 
   /**

--- a/CRM/Core/DynamicFKAccessTrait.php
+++ b/CRM/Core/DynamicFKAccessTrait.php
@@ -15,20 +15,21 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\Event\AuthorizeRecordEvent;
+use Civi\Api4\Utils\CoreUtil;
+
 /**
  * Trait for with entities with an entity_table + entity_id dynamic FK.
  */
 trait CRM_Core_DynamicFKAccessTrait {
 
   /**
-   * @param string $entityName
-   * @param string $action
-   * @param array $record
-   * @param int $userID
-   * @return bool
    * @see \Civi\Api4\Utils\CoreUtil::checkAccessRecord
    */
-  public static function _checkAccess(string $entityName, string $action, array $record, int $userID): bool {
+  public static function self_civi_api4_authorizeRecord(AuthorizeRecordEvent $e): void {
+    $record = $e->getRecord();
+    $userID = $e->getUserID();
+    $delegateAction = $e->getActionName() === 'get' ? 'get' : 'update';
     $eid = $record['entity_id'] ?? NULL;
     $table = $record['entity_table'] ?? NULL;
     if (!$eid && !empty($record['id'])) {
@@ -43,9 +44,8 @@ trait CRM_Core_DynamicFKAccessTrait {
         throw new \CRM_Core_Exception(sprintf('Cannot resolve permissions for dynamic foreign key in "%s". Invalid table reference "%s".',
           static::getTableName(), $table));
       }
-      return \Civi\Api4\Utils\CoreUtil::checkAccessDelegated($targetEntity, 'update', ['id' => $eid], $userID);
+      $e->setAuthorized(CoreUtil::checkAccessDelegated($targetEntity, $delegateAction, ['id' => $eid], $userID));
     }
-    return TRUE;
   }
 
 }

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Event\AuthorizeRecordEvent;
+
 /**
  *
  * @package CRM
@@ -2189,17 +2191,17 @@ WHERE  ce.loc_block_id = $locBlockId";
   }
 
   /**
-   * @param string $entityName
-   * @param string $action
-   * @param array $record
-   * @param int $userID
-   * @return bool
+   * Check event access.
    * @see \Civi\Api4\Utils\CoreUtil::checkAccessRecord
    */
-  public static function _checkAccess(string $entityName, string $action, array $record, $userID): bool {
-    switch ($action) {
+  public static function self_civi_api4_authorizeRecord(AuthorizeRecordEvent $e): void {
+    $record = $e->getRecord();
+    $userID = $e->getUserID();
+
+    switch ($e->getActionName()) {
       case 'create':
-        return CRM_Core_Permission::check('access CiviEvent', $userID);
+        $e->setAuthorized(CRM_Core_Permission::check('access CiviEvent', $userID));
+        return;
 
       case 'get':
         $actionType = CRM_Core_Permission::VIEW;
@@ -2214,7 +2216,7 @@ WHERE  ce.loc_block_id = $locBlockId";
         break;
     }
 
-    return self::checkPermission($record['id'], $actionType, $userID);
+    $e->setAuthorized(self::checkPermission($record['id'], $actionType, $userID));
   }
 
   /**

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -244,7 +244,7 @@ class CoreUtil {
 
     // For get actions, just run a get and ACLs will be applied to the query.
     // It's a cheap trick and not as efficient as not running the query at all,
-    // but BAO::checkAccess doesn't consistently check permissions for the "get" action.
+    // but authorizeRecord doesn't consistently check permissions for the "get" action.
     if (is_a($apiRequest, '\Civi\Api4\Generic\AbstractGetAction')) {
       return (bool) $apiRequest->addSelect($idField)->addWhere($idField, '=', $record[$idField])->execute()->count();
     }
@@ -252,18 +252,16 @@ class CoreUtil {
     $event = new \Civi\Api4\Event\AuthorizeRecordEvent($apiRequest, $record, $userID);
     \Civi::dispatcher()->dispatch('civi.api4.authorizeRecord', $event);
 
-    // Note: $bao::_checkAccess() is a quasi-listener. TODO: Convert to straight-up listener.
+    // $bao::_checkAccess() is deprecated in favor of `civi.api4.authorizeRecord` event.
     if ($event->isAuthorized() === NULL) {
       $baoName = self::getBAOFromApiName($apiRequest->getEntityName());
       if ($baoName && method_exists($baoName, '_checkAccess')) {
+        \CRM_Core_Error::deprecatedWarning("$baoName::_checkAccess is deprecated and should be replaced with 'civi.api4.authorizeRecord' event listener.");
         $authorized = $baoName::_checkAccess($event->getEntityName(), $event->getActionName(), $event->getRecord(), $event->getUserID());
         $event->setAuthorized($authorized);
       }
-      else {
-        $event->setAuthorized(TRUE);
-      }
     }
-    return $event->isAuthorized();
+    return $event->isAuthorized() ?? TRUE;
   }
 
   /**

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -405,7 +405,13 @@ class Container {
     ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
 
     $dispatcherDefn = $container->getDefinition('dispatcher');
-    foreach (\CRM_Core_DAO_AllCoreTables::getBaoClasses() as $baoEntity => $baoClass) {
+    // Get all declared BAO classes
+    $baoClasses = \CRM_Core_DAO_AllCoreTables::getBaoClasses();
+    // "Extra" BAO classes that don't have a DAO but still need to listen to hooks
+    $baoClasses[] = \CRM_Core_BAO_CustomValue::class;
+    foreach ($baoClasses as $key => $baoClass) {
+      // Key will be a valid entity name for all but the "extra" classes which don't have a DAO entity.
+      $baoEntity = is_numeric($key) ? NULL : $key;
       $listenerMap = EventScanner::findListeners($baoClass, $baoEntity);
       if ($listenerMap) {
         $file = (new \ReflectionClass($baoClass))->getFileName();

--- a/ext/oauth-client/CRM/OAuth/BAO/OAuthContactToken.php
+++ b/ext/oauth-client/CRM/OAuth/BAO/OAuthContactToken.php
@@ -1,6 +1,8 @@
 <?php
 
-class CRM_OAuth_BAO_OAuthContactToken extends CRM_OAuth_DAO_OAuthContactToken {
+use Civi\Api4\Event\AuthorizeRecordEvent;
+
+class CRM_OAuth_BAO_OAuthContactToken extends CRM_OAuth_DAO_OAuthContactToken implements \Civi\Core\HookInterface {
 
   /**
    * Create or update OAuthContactToken based on array-data
@@ -26,21 +28,18 @@ class CRM_OAuth_BAO_OAuthContactToken extends CRM_OAuth_DAO_OAuthContactToken {
   }
 
   /**
-   * @param string $entityName
-   * @param string $action
-   * @param array $record
-   * @param $userId
-   * @return bool
    * @see \Civi\Api4\Utils\CoreUtil::checkAccessRecord
    */
-  public static function _checkAccess(string $entityName, string $action, array $record, $userId): bool {
+  public static function self_civi_api4_authorizeRecord(AuthorizeRecordEvent $e): void {
+    $record = $e->getRecord();
+    $userId = $e->getUserID();
     try {
       $record['check_permissions'] = TRUE;
       self::fillAndValidate($record, $userId);
-      return TRUE;
+      $e->setAuthorized(TRUE);
     }
-    catch (\Civi\API\Exception\UnauthorizedException $e) {
-      return FALSE;
+    catch (\Civi\API\Exception\UnauthorizedException $exception) {
+      $e->setAuthorized(FALSE);
     }
   }
 

--- a/ext/search_kit/CRM/Search/BAO/SearchDisplay.php
+++ b/ext/search_kit/CRM/Search/BAO/SearchDisplay.php
@@ -9,49 +9,47 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Event\AuthorizeRecordEvent;
+
 /**
  * Search Display BAO
  */
-class CRM_Search_BAO_SearchDisplay extends CRM_Search_DAO_SearchDisplay {
+class CRM_Search_BAO_SearchDisplay extends CRM_Search_DAO_SearchDisplay implements \Civi\Core\HookInterface {
 
   /**
-   * Ensure only super-admins are allowed to create or update displays with acl_bypass
-   *
-   * @param string $entityName
-   * @param string $action
-   * @param array $record
-   * @param int $userCID
-   * @return bool
+   * @see \Civi\Api4\Utils\CoreUtil::checkAccessRecord
    */
-  public static function _checkAccess(string $entityName, string $action, array $record, int $userCID) {
-    // Super-admins can do anything with search displays
-    if (CRM_Core_Permission::check('all CiviCRM permissions and ACLs', $userCID)) {
-      return TRUE;
-    }
-    // Must be at least a SearchKit administrator
-    if (!CRM_Core_Permission::check([['administer CiviCRM data', 'administer search_kit']], $userCID)) {
-      return FALSE;
-    }
-    if (in_array($action, ['create', 'update'], TRUE)) {
-      // Do not allow acl_bypass to be set to TRUE
-      if (!empty($record['acl_bypass'])) {
-        return FALSE;
-      }
-      // Do not allow edits to an existing record with acl_bypass = TRUE
-      if (!empty($record['id'])) {
-        return !CRM_Core_DAO::getFieldValue(__CLASS__, $record['id'], 'acl_bypass');
-      }
-    }
-    return TRUE;
-  }
+  public static function on_civi_api4_authorizeRecord(AuthorizeRecordEvent $e): void {
+    $recordType = $e->getEntityName();
+    $record = $e->getRecord();
+    $userCID = $e->getUserID();
 
-  /**
-   * Ensure only super-admins may update SavedSearches linked to displays with acl_bypass
-   *
-   * @param \Civi\Api4\Event\AuthorizeRecordEvent $e
-   */
-  public static function savedSearchCheckAccessByDisplay(\Civi\Api4\Event\AuthorizeRecordEvent $e) {
-    if ($e->getActionName() === 'update') {
+    // Control access to search displays that have `acl_bypass` set.
+    if ($recordType === 'SearchDisplay') {
+      // Super-admins can do anything with search displays
+      if (CRM_Core_Permission::check('all CiviCRM permissions and ACLs', $userCID)) {
+        $e->setAuthorized(TRUE);
+        return;
+      }
+      // Must be at least a SearchKit administrator
+      if (!CRM_Core_Permission::check([['administer CiviCRM data', 'administer search_kit']], $userCID)) {
+        $e->setAuthorized(FALSE);
+        return;
+      }
+      if (in_array($e->getActionName(), ['create', 'update'], TRUE)) {
+        // Do not allow acl_bypass to be set to TRUE
+        if (!empty($record['acl_bypass'])) {
+          $e->setAuthorized(FALSE);
+        }
+        // Do not allow edits to an existing record with acl_bypass = TRUE
+        elseif (!empty($record['id'])) {
+          $e->setAuthorized(!CRM_Core_DAO::getFieldValue(__CLASS__, $record['id'], 'acl_bypass'));
+        }
+      }
+    }
+
+    // Ensure only super-admins may update SavedSearches linked to displays with `acl_bypass`
+    elseif ($recordType === 'SavedSearch' && $e->getActionName() === 'update') {
       $id = (int) $e->getRecord()['id'];
       $sql = "SELECT COUNT(id) FROM civicrm_search_display WHERE acl_bypass = 1 AND saved_search_id = $id";
       if (CRM_Core_DAO::singleValueQuery($sql)) {

--- a/ext/search_kit/search_kit.php
+++ b/ext/search_kit/search_kit.php
@@ -14,17 +14,6 @@ function search_kit_civicrm_config(&$config) {
 }
 
 /**
- * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
- */
-function search_kit_civicrm_container($container) {
-  $container->getDefinition('dispatcher')
-    ->addMethodCall('addListener', [
-      'civi.api4.authorizeRecord::SavedSearch',
-      ['CRM_Search_BAO_SearchDisplay', 'savedSearchCheckAccessByDisplay'],
-    ]);
-}
-
-/**
  * Implements hook_civicrm_permission().
  *
  * Define SearchKit permissions.

--- a/ext/standaloneusers/CRM/Standaloneusers/BAO/Role.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/BAO/Role.php
@@ -4,6 +4,7 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\Event\AuthorizeRecordEvent;
 use CRM_Standaloneusers_ExtensionUtil as E;
 
 class CRM_Standaloneusers_BAO_Role extends CRM_Standaloneusers_DAO_Role implements \Civi\Core\HookInterface {
@@ -18,24 +19,18 @@ class CRM_Standaloneusers_BAO_Role extends CRM_Standaloneusers_DAO_Role implemen
   }
 
   /**
-   * Check access permission
-   *
-   * @param string $entityName
-   * @param string $action
-   * @param array $record
-   * @param integer|null $userID
-   * @return boolean
    * @see \Civi\Api4\Utils\CoreUtil::checkAccessRecord
    */
-  public static function _checkAccess(string $entityName, string $action, array $record, ?int $userID): bool {
+  public static function self_civi_api4_authorizeRecord(AuthorizeRecordEvent $e): void {
+    $record = $e->getRecord();
+    $action = $e->getActionName();
     // Prevent users from updating or deleting the admin and everyone roles
     if (in_array($action, ['delete', 'update'], TRUE)) {
       $name = $record['name'] ?? CRM_Core_DAO::getFieldValue(self::class, $record['id']);
       if (in_array($name, ['admin', 'everyone'], TRUE)) {
-        return FALSE;
+        $e->setAuthorized(FALSE);
       }
     }
-    return TRUE;
   }
 
 }

--- a/ext/standaloneusers/CRM/Standaloneusers/BAO/User.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/BAO/User.php
@@ -74,25 +74,19 @@ class CRM_Standaloneusers_BAO_User extends CRM_Standaloneusers_DAO_User implemen
   }
 
   /**
-   * Check access permission
-   *
-   * @param string $entityName
-   * @param string $action
-   * @param array $record
-   * @param integer|null $userID
-   * @return boolean
    * @see \Civi\Api4\Utils\CoreUtil::checkAccessRecord
    */
-  public static function _checkAccess(string $entityName, string $action, array $record, ?int $userID): bool {
+  public static function self_civi_api4_authorizeRecord(AuthorizeRecordEvent $e): void {
+    $record = $e->getRecord();
+    $action = $e->getActionName();
     // Prevent users from deleting their own user account
     if (in_array($action, ['delete'], TRUE)) {
       $sess = CRM_Core_Session::singleton();
       $ufID = (int) $sess->get('ufID');
       if ($record['id'] == $ufID) {
-        return FALSE;
+        $e->setAuthorized(FALSE);
       };
     }
-    return TRUE;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a FIXME that @totten left for me to fix in #20533

Also see https://lab.civicrm.org/dev/core/-/issues/4887

Before
----------------------------------------
`// Note: $bao::_checkAccess() is a quasi-listener. TODO: Convert to straight-up listener.`

After
----------------------------------------
Straight-up listener
