### PR TITLE
Add test cover for event additional profiles

### DIFF
--- a/Civi/Test/EventTestTrait.php
+++ b/Civi/Test/EventTestTrait.php
@@ -292,6 +292,7 @@ trait EventTestTrait {
     try {
       $this->setTestEntity('UFJoin', UFJoin::create(FALSE)->setValues([
         'module' => $additionalSuffix ? 'CiviEvent_Additional' : 'CiviEvent',
+        'entity_table' => 'civicrm_event',
         'uf_group_id:name' => $profileName,
         'entity_table' => 'civicrm_event',
         'entity_id' => $this->getEventID($identifier),

--- a/tests/phpunit/CRMTraits/Event/ScenarioTrait.php
+++ b/tests/phpunit/CRMTraits/Event/ScenarioTrait.php
@@ -48,6 +48,7 @@ trait CRMTraits_Event_ScenarioTrait {
     $form = $this->getTestForm('CRM_Event_Form_Registration_Register', [
       'first_name' => 'Participant1',
       'last_name' => 'LastName',
+      'job_title' => 'oracle',
       'email-Primary' => 'participant1@example.com',
       'additional_participants' => 2,
       'payment_processor_id' => 0,
@@ -60,6 +61,7 @@ trait CRMTraits_Event_ScenarioTrait {
       ->addSubsequentForm('CRM_Event_Form_Registration_AdditionalParticipant', [
         'first_name' => 'Participant2',
         'last_name' => 'LastName',
+        'job_title' => 'wizard',
         'email-Primary' => 'participant2@example.com',
         'priceSetId' => $this->getPriceSetID('PaidEvent'),
         'price_' . $this->ids['PriceField']['PaidEvent'] => $this->ids['PriceFieldValue']['PaidEvent_student'],
@@ -67,6 +69,7 @@ trait CRMTraits_Event_ScenarioTrait {
       ->addSubsequentForm('CRM_Event_Form_Registration_AdditionalParticipant', [
         'first_name' => 'Participant3',
         'last_name' => 'LastName',
+        'job_title' => 'seer',
         'email-Primary' => 'participant3@example.com',
         'priceSetId' => $this->getPriceSetID('PaidEvent'),
         'price_' . $this->ids['PriceField']['PaidEvent'] => $this->ids['PriceFieldValue']['PaidEvent_student_plus'],


### PR DESCRIPTION
Overview
----------------------------------------
Add test cover for event additional profiles

Before
----------------------------------------
No test cover to ensure no leakage in additional participants in pay later registration

After
----------------------------------------
Cover added

Technical Details
----------------------------------------
The tests revealed a discrepancy in that the form flow includes the profile details of the other participants for the primary but the payment.create flow does not - this is probably minor but if we do fix we should do it in the context of clear & maintainable profile variables across the forms that display them

Comments
----------------------------------------
