### PR TITLE
Fix rc-only regression -  back-office registration does not reload contact ID

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -769,7 +769,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         $errorMsg['payment_instrument_id'] = ts('Payment Method is a required field.');
       }
       if (!empty($values['priceSetId'])) {
-        CRM_Price_BAO_PriceField::priceSetValidation($values['priceSetId'], $values, $errorMsg);
+        CRM_Price_BAO_PriceField::priceSetValidation($self->getPriceSetID(), $values, $errorMsg);
       }
     }
 

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1995,13 +1995,13 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
    * @noinspection PhpDocSignatureIsNotCompleteInspection
    */
   public function getContactID():?int {
+    // Always set it back to the submitted value if there is one - this is to prevent it being set in
+    // proProcess & then ignoring the actual submitted value in post-process.
+    if ($this->getSubmittedValue('contact_id')) {
+      $this->_contactID = $this->getSubmittedValue('contact_id');
+    }
     if ($this->_contactID === NULL) {
-      if ($this->getSubmittedValue('contact_id')) {
-        $contactID = $this->getSubmittedValue('contact_id');
-      }
-      else {
-        $contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
-      }
+      $contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
       if (!$contactID && $this->getParticipantID()) {
         $contactID = $this->getParticipantValue('contact_id');
       }


### PR DESCRIPTION
Overview
----------------------------------------
Fix rc-only regression -  back-office registration does not reload contact ID

Before
----------------------------------------
In 5.70 (but not 5.69) :

1) register a contact for an event
2) Choose register new participant
3) attempt to register the same participant for the same event - it will fail 
4) change the contact 
5) it registered the event for the contact ID in 3 not 4


After
----------------------------------------
Saves against the right contact

I tested & found a related behaviour when changing the event - in this case it would not pass validation. That was also present in 5.65 so not a regression but it made sense to keep the fixes together

Technical Details
----------------------------------------
The `getContactID()` function was not revisiting it's priors - ie the value set during `preProcess()` being returned because it could

This is a new-ish function so no concerns about compatibility

Comments
----------------------------------------
