### PR TITLE
Switch pay_later check to use tokens in line with membership receipt

### DIFF
--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -25,7 +25,7 @@
      <p>{$receipt_text|htmlize}</p>
     {/if}
 
-    {if $is_pay_later}
+    {if {contribution.is_pay_later|boolean} && {contribution.balance_amount|boolean}}
      <p>{$pay_later_receipt}</p> {* FIXME: this might be text rather than HTML *}
     {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
Switch pay_later variable to tokens

Replacement for https://github.com/civicrm/civicrm-core/pull/26977 @composerjk 

Before
----------------------------------------
variable used


After
----------------------------------------
Tokens used, consistent with online membership receipt - except I spotted a bug there...

Screen shot shows "pay me" coming from the token

![image](https://github.com/civicrm/civicrm-core/assets/336308/bca0edc4-7d38-4a7f-9522-e0a496570d38)


Technical Details
----------------------------------------

Comments
----------------------------------------
