### PR TITLE
Fix pay-later receipt token in shipped version

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSeventy.php
+++ b/CRM/Upgrade/Incremental/php/FiveSeventy.php
@@ -31,4 +31,10 @@ class CRM_Upgrade_Incremental_php_FiveSeventy extends CRM_Upgrade_Incremental_Ba
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
   }
 
+  public function upgrade_5_70_beta1($rev): void {
+    $this->addTask('Replace incorrect pay later token',
+      'updateMessageToken', 'membership_online_receipt', 'contribution.pay_later_receipt', 'contribution.contribution_page_id.pay_later_receipt', $rev
+    );
+  }
+
 }

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -25,7 +25,7 @@
      <p>{$userText}</p>
     {/if}
     {if {contribution.balance_amount|boolean} && {contribution.is_pay_later|boolean}}
-      <p>{contribution.pay_later_receipt}</p>
+      <p>{contribution.contribution_page_id.pay_later_receipt}</p>
     {/if}
 
    </td>


### PR DESCRIPTION
Overview
----------------------------------------

Fix pay-later receipt token in shipped version

Before
----------------------------------------
Pay later text missing in online membership receipt (uncustomised version)
![image](https://github.com/civicrm/civicrm-core/assets/336308/9d072a54-5f79-4b53-925b-a3a705ba6a46)

The wrong token is present

![image](https://github.com/civicrm/civicrm-core/assets/336308/681a4487-d0a1-4a4e-94a9-27f4ec17779b)


After
----------------------------------------
Fixed

 - my text (erm 'hhh') is now present
![image](https://github.com/civicrm/civicrm-core/assets/336308/0b1119c5-991a-456d-a96a-899c23413a50)

& the token is right  (this is after r-running the upgrade script)

![image](https://github.com/civicrm/civicrm-core/assets/336308/336a86ac-e853-4a8a-b594-158e90b5087d)



Technical Details
----------------------------------------

Comments
----------------------------------------
Needs regen