### PR TITLE
(alternate 1) Fix bad smarty3 compile filenames

### DIFF
--- a/CRM/Core/Form/Renderer.php
+++ b/CRM/Core/Form/Renderer.php
@@ -235,6 +235,7 @@ class CRM_Core_Form_Renderer extends HTML_QuickForm_Renderer_ArraySmarty {
     // Adding this is preparatory to smarty 3....
     if (!function_exists('smarty_function_eval') && !file_exists(SMARTY_DIR . '/plugins/function.eval.php')) {
       $smarty = $this->_tpl;
+      $tplSource = trim($tplSource);
       $smarty->assign('var', $tplSource);
       return $smarty->fetch("string:$tplSource");
     }


### PR DESCRIPTION
Overview
----------------------------------------
Alternate to https://github.com/civicrm/civicrm-packages/pull/378

Before
----------------------------------------
With smarty3 the filename can end up with newlines and squiggles in it. I guess this works on unix but doesn't on windows. An example page is New Contribution.

After
----------------------------------------


Technical Details
----------------------------------------
If the smarty being compiled ends with newlines the filename looks something like
```
templates_c/en_US/01/01/blahblahblah.if}

.php
```

Comments
----------------------------------------

