### PR TITLE
dev/user-interface#64 civicrm.css: fix cancel/done button alignment

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -1905,7 +1905,6 @@ input.crm-form-entityref {
   cursor: pointer;
   border: 1px solid #3e3e3e;
   display: inline-block;
-  overflow: hidden;
   line-height: 135%;
   border-radius: 3px;
 }


### PR DESCRIPTION
Overview
----------------------------------------

Fixes: https://lab.civicrm.org/dev/user-interface/-/issues/64 reported by @demeritcowboy 

Related #28784

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/92edca34-970f-44b3-9dc1-b794b92e98c0)

After
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/87e88179-ee5e-42c7-acc8-8a05a805667c)

Technical Details
----------------------------------------

I really don't understand why this works, but the `overflow: hidden`  is silly to begin with?

cc @colemanw the git log mentions 353282c5b07 in 2020, but you were just shuffling code around. I wonder if it has an impact on SearchKit though.