### PR TITLE
Update cancelRecurContribution to unset next_sched_contribution_date …

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -290,6 +290,9 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
         'contribution_status_id:name' => 'Cancelled',
         'cancel_reason' => $params['cancel_reason'] ?? NULL,
         'cancel_date' => $params['cancel_date'] ?? 'now',
+        // reset the next_sched_contribution_date and failure_retry_date to null if cancel recur
+        'next_sched_contribution_date' => NULL,
+        'failure_retry_date' => NULL,
       ])->execute();
 
     // @todo - all of this should be moved to the post hook.


### PR DESCRIPTION
…and failure_retry_date

Overview
----------------------------------------
It make sense to unset the next schedule date and the next retry date if we cancel the recurring

Before
----------------------------------------
we might have the next retry date later than the cancelled date, which we did have double check before we send to recurring, but if we can unset the next schedule date and the failure_retry_date, then less check is needed when we do next recurring trigger

After
----------------------------------------
For any cancelled recur contribution, will not need to double check cancel date and status, to avoid potential duplicate charge one step earlier

