### PR TITLE
(alternate 2) Fix bad smarty3 compile filenames

### DIFF
--- a/CRM/Core/Form/Renderer.php
+++ b/CRM/Core/Form/Renderer.php
@@ -236,7 +236,7 @@ class CRM_Core_Form_Renderer extends HTML_QuickForm_Renderer_ArraySmarty {
     if (!function_exists('smarty_function_eval') && !file_exists(SMARTY_DIR . '/plugins/function.eval.php')) {
       $smarty = $this->_tpl;
       $smarty->assign('var', $tplSource);
-      return $smarty->fetch("string:$tplSource");
+      return $smarty->fetch("eval:$tplSource");
     }
     // This part is what the parent does & is suitable to Smarty 2.
     if (!function_exists('smarty_function_eval')) {


### PR DESCRIPTION
Overview
----------------------------------------
Alternate to https://github.com/civicrm/civicrm-core/pull/28904

Before
----------------------------------------
With smarty3 the filename can end up with newlines and squiggles in it. I guess this works on unix but doesn't on windows. An example page is New Contribution.

After
----------------------------------------


Technical Details
----------------------------------------
If the smarty being compiled ends with newlines the filename looks something like
```
templates_c/en_US/01/01/blahblahblah.if}

.php
```

Comments
----------------------------------------
See https://www.smarty.net/docs/en/resources.string.tpl. This use of `eval` seems identical to string but without making a cache file. In terms of performance I expect it would be no worse than before with smarty 2.
