### PR TITLE
(dev/release#22) Greenwich - Drop Glyphicons

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -206,7 +206,7 @@
         "url": "https://github.com/twbs/bootstrap-sass/archive/v{$version}.zip",
         "path": "ext/greenwich/extern/bootstrap3",
         "version": "3.4.1",
-        "ignore": ["test", "tasks", "lib"]
+        "ignore": ["fonts", "test", "tasks", "lib"]
       },
       "font-awesome": {
         "url": "https://github.com/FortAwesome/Font-Awesome/archive/v4.7.0.zip",

--- a/ext/greenwich/composer.compile.json
+++ b/ext/greenwich/composer.compile.json
@@ -8,7 +8,10 @@
       ],
       "watch-files": ["scss", "../../bower_components/select2/select2-bootstrap.css"],
       "scss-files": {"dist/bootstrap3.css": "scss/main.scss"},
-      "scss-imports": ["scss", "extern/bootstrap3/assets/stylesheets", "extern/select2"]
+      "scss-imports": ["scss", "extern/bootstrap3/assets/stylesheets", "extern/select2"],
+      "scss-import-prefixes": {
+        "bootstrap": "scss/bootstrap-override"
+      }
     }
   ]
 }

--- a/ext/greenwich/scss/bootstrap-override/glyphicons.scss
+++ b/ext/greenwich/scss/bootstrap-override/glyphicons.scss
@@ -1,0 +1,5 @@
+/*
+CiviCRM uses FontAwesome rather than Glyphicons. This override-file disables glyphicon support.
+There probably isn't much harm in including glyphicon, but the weird license situation is a distraction.
+See https://lab.civicrm.org/dev/release/-/issues/22
+*/


### PR DESCRIPTION
Overview
----------------------------------------

Modify the default theme (`greenwich`) and drop support for the font `glyphicons-halfings` -- also known by the Boostrap3 classes, `glyphicon-XXX`:

https://getbootstrap.com/docs/3.3/components/#glyphicons

Before
----------------------------------------

Greenwich supports BS3 `glyphicon-*` CSS classes.

After
----------------------------------------

Greenwich does not support BS3 `glyphicon-*` CSS classes.

Comments
----------------------------------------

* For general background about Bootstrap3, Glyphicon, FontAwesome, motivation, licensing, universe, etc... see https://lab.civicrm.org/dev/release/-/issues/22
* From a core POV, this draft makes a "clean break". However, that means that some things (*probably obscure things?*) would be missing icons.
