### PR TITLE
(dev/release#22) Greenwich - Phase-out/off-load Glyphicons

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -206,7 +206,7 @@
         "url": "https://github.com/twbs/bootstrap-sass/archive/v{$version}.zip",
         "path": "ext/greenwich/extern/bootstrap3",
         "version": "3.4.1",
-        "ignore": ["test", "tasks", "lib"]
+        "ignore": ["fonts", "test", "tasks", "lib"]
       },
       "font-awesome": {
         "url": "https://github.com/FortAwesome/Font-Awesome/archive/v4.7.0.zip",

--- a/ext/greenwich/scss/_greenwich.scss
+++ b/ext/greenwich/scss/_greenwich.scss
@@ -78,8 +78,13 @@ $headings-color: rgb(0, 0, 0);
 //
 //## Specify custom location and filename of the included Glyphicons icon font. Useful for those including Bootstrap via Bower.
 
+// (dev/release#22) The licensing around Bootstrap3 and glyphicons-halflings is confusing/FUDdy.  It's _probably_ OK to redistribute these font files under
+// MIT-compatible licensing, but that's not clear.  Regardless, `glyphicons` are deprecated within CiviCRM, so we generally don't need them.  Using the CDN
+// means we don't have to distribute them -- but there's still a fallback for old/oddball addons which still reference glyphicons.
+
 //** Load fonts from this directory.
-$icon-font-path: "../extern/bootstrap3/assets/fonts/bootstrap/";
+$icon-font-path: 'https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/fonts/';
+// $icon-font-path: "../extern/bootstrap3/assets/fonts/bootstrap/";
 //** File name for all font files.
 $icon-font-name: "glyphicons-halflings-regular";
 //** Element ID within SVG icon file.


### PR DESCRIPTION
Overview
----------------------------------------

Modify the default theme (`greenwich`) with an aim toward phasing-out support for the font `glyphicons-halflings` -- also known by the Boostrap3 classes, `glyphicon-XXX`:

https://getbootstrap.com/docs/3.3/components/#glyphicons

This variant does not completely remove support for `glyphicons-halflings` -- if you have access to a CDN, then you can still get a copy.

Before
----------------------------------------

Greenwich supports BS3 `glyphicon-*` CSS classes. It includes the font dataset provided by BS3.

After
----------------------------------------

Greenwich supports BS3 `glyphicon-*` CSS classes. It relies on a third-party host (`cdn.jsdelivr.net`) to provide font dataset.

Comments
----------------------------------------

* For general background about Bootstrap3, Glyphicon, FontAwesome, motivation, licensing, etc... see https://lab.civicrm.org/dev/release/-/issues/22
* This approach makes a soft-break. 
    * It means that `civicrm.org` doesn't copy/distribute any of those files. And in general usage, users don't load them. 
    * But if you have an add-on that relies on them, then you still get the data. And it Just Works -- there's no faffing with hidden settings or obscure installation steps.
* I'm generally not a fan of hard-coding a specific CDN or requiring online access. But it should be emphasized that this is only used as a fallback for a deprecated edge-case. (This shouldn't be taken as a precedent for handling normal scenarios/normal code.)