### PR TITLE
Fix notices in participant status change templates

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1408,7 +1408,6 @@ UPDATE  civicrm_participant
         [
           'workflow' => 'participant_' . strtolower($mailType),
           'contactId' => $contactId,
-          'tokenContext' => ['participantId' => $participantId],
           'tplParams' => [
             'participant' => $participantValues,
             'event' => $eventDetails,
@@ -1418,6 +1417,11 @@ UPDATE  civicrm_participant
             'isExpired' => $mailType === 'Expired',
             'isConfirm' => $mailType === 'Confirm',
             'checksumValue' => $checksumValue,
+          ],
+          'modelProps' => [
+            'participantID' => (int) $participantId,
+            'eventID' => (int) $eventDetails['id'],
+            'contactID' => (int) $contactId,
           ],
           'from' => $receiptFrom,
           'toName' => $participantName,

--- a/CRM/Event/WorkflowMessage/ParticipantConfirm.php
+++ b/CRM/Event/WorkflowMessage/ParticipantConfirm.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\WorkflowMessage\GenericWorkflowMessage;
+
+/**
+ * Notification that a registration has been cancelled.
+ *
+ * @support template-only
+ *
+ * @see CRM_Event_BAO_Participant::sendTransitionParticipantMail
+ */
+class CRM_Event_WorkflowMessage_ParticipantConfirm extends GenericWorkflowMessage {
+  use CRM_Event_WorkflowMessage_ParticipantTrait;
+
+  public const WORKFLOW = 'participant_confirm';
+
+}

--- a/CRM/Event/WorkflowMessage/ParticipantExpired.php
+++ b/CRM/Event/WorkflowMessage/ParticipantExpired.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\WorkflowMessage\GenericWorkflowMessage;
+
+/**
+ * Notification that a registration has been cancelled.
+ *
+ * @support template-only
+ *
+ * @see CRM_Event_BAO_Participant::sendTransitionParticipantMail
+ */
+class CRM_Event_WorkflowMessage_ParticipantExpired extends GenericWorkflowMessage {
+  use CRM_Event_WorkflowMessage_ParticipantTrait;
+
+  public const WORKFLOW = 'participant_expired';
+
+}

--- a/xml/templates/message_templates/participant_cancelled_html.tpl
+++ b/xml/templates/message_templates/participant_cancelled_html.tpl
@@ -46,71 +46,72 @@
        {participant.role_id:label}
       </td>
      </tr>
-
-    {if !empty($isShowLocation)}
-          <tr>
-            <td colspan="2" {$valueStyle}>
-                {event.location}
-            </td>
-          </tr>
-        {/if}
+    {if {event.is_show_location|boolean}}
+        <tr>
+          <td colspan="2" {$valueStyle}>
+            {event.location}
+          </td>
+        </tr>
+      {/if}
 
     {if {event.loc_block_id.phone_id.phone|boolean} || {event.loc_block_id.email_id.email|boolean}}
+        <tr>
+          <td colspan="2" {$labelStyle}>
+            {ts}Event Contacts:{/ts}
+          </td>
+        </tr>
+
+        {if {event.loc_block_id.phone_id.phone|boolean}}
           <tr>
-            <td colspan="2" {$labelStyle}>
-                {ts}Event Contacts:{/ts}
+            <td {$labelStyle}>
+              {if {event.loc_block_id.phone_id.phone_type_id|boolean}}
+                {event.loc_block_id.phone_id.phone_type_id:label}
+              {else}
+                {ts}Phone{/ts}
+              {/if}
+            </td>
+            <td {$valueStyle}>
+              {event.loc_block_id.phone_id.phone} {if {event.loc_block_id.phone_id.phone_ext|boolean}}&nbsp;{ts}ext.{/ts} {event.loc_block_id.phone_id.phone_ext}{/if}
             </td>
           </tr>
-
-            {if {event.loc_block_id.phone_id.phone|boolean}}
-              <tr>
-                <td {$labelStyle}>
-                    {if {event.loc_block_id.phone_id.phone_type_id|boolean}}
-                        {event.loc_block_id.phone_id.phone_type_id:label}
-                    {else}
-                        {ts}Phone{/ts}
-                    {/if}
-                </td>
-                <td {$valueStyle}>
-                    {event.loc_block_id.phone_id.phone} {if {event.loc_block_id.phone_id.phone_ext|boolean}}&nbsp;{ts}ext.{/ts} {event.loc_block_id.phone_id.phone_ext}{/if}
-                </td>
-              </tr>
-            {/if}
-            {if {event.loc_block_id.phone_2_id.phone|boolean}}
-              <tr>
-                <td {$labelStyle}>
-                    {if {event.loc_block_id.phone_2_id.phone_type_id|boolean}}
-                        {event.loc_block_id.phone_2_id.phone_type_id:label}
-                    {else}
-                        {ts}Phone{/ts}
-                    {/if}
-                </td>
-                <td {$valueStyle}>
-                    {event.loc_block_id.phone_2_id.phone} {if {event.loc_block_id.phone_2_id.phone_ext|boolean}}&nbsp;{ts}ext.{/ts} {event.loc_block_id.phone_2_id.phone_ext}{/if}
-                </td>
-              </tr>
-            {/if}
-            {if {event.loc_block_id.email_id.email|boolean}}
-              <tr>
-                <td {$labelStyle}>
-                    {ts}Email{/ts}
-                </td>
-                <td {$valueStyle}>
-                    {event.loc_block_id.email_id.email}
-                </td>
-              </tr>
-            {/if}
-            {if {event.loc_block_id.email_2_id.email|boolean}}
-              <tr>
-                <td {$labelStyle}>
-                    {ts}Email{/ts}
-                </td>
-                <td {$valueStyle}>
-                    {event.loc_block_id.email_2_id.email}
-                </td>
-              </tr>
-            {/if}
         {/if}
+        {if {event.loc_block_id.phone_2_id.phone|boolean}}
+          <tr>
+            <td {$labelStyle}>
+              {if {event.loc_block_id.phone_2_id.phone_type_id|boolean}}
+                {event.loc_block_id.phone_2_id.phone_type_id:label}
+              {else}
+                {ts}Phone{/ts}
+              {/if}
+            </td>
+            <td {$valueStyle}>
+              {event.loc_block_id.phone_2_id.phone} {if {event.loc_block_id.phone_2_id.phone_ext|boolean}}&nbsp;{ts}ext.{/ts} {event.loc_block_id.phone_2_id.phone_ext}{/if}
+            </td>
+          </tr>
+        {/if}
+
+        {if {event.loc_block_id.email_id.email|boolean}}
+          <tr>
+            <td {$labelStyle}>
+              {ts}Email{/ts}
+            </td>
+            <td {$valueStyle}>
+              {event.loc_block_id.email_id.email}
+            </td>
+          </tr>
+        {/if}
+
+        {if {event.loc_block_id.email_2_id.email|boolean}}
+          <tr>
+            <td {$labelStyle}>
+              {ts}Email{/ts}
+            </td>
+            <td {$valueStyle}>
+              {event.loc_block_id.email_2_id.email}
+            </td>
+          </tr>
+        {/if}
+      {/if}
 
     {if '{contact.email}'}
       <tr>

--- a/xml/templates/message_templates/participant_confirm_html.tpl
+++ b/xml/templates/message_templates/participant_confirm_html.tpl
@@ -23,7 +23,7 @@
     <p>{ts}This is an invitation to complete your registration that was initially waitlisted.{/ts}</p>
    </td>
   </tr>
-  {if !$isAdditional and $participant.id}
+  {if !$isAdditional and {participant.id|boolean}}
    <tr>
     <th {$headerStyle}>
      {ts}Confirm Your Registration{/ts}
@@ -31,14 +31,14 @@
    </tr>
    <tr>
     <td colspan="2" {$valueStyle}>
-     {capture assign=confirmUrl}{crmURL p='civicrm/event/confirm' q="reset=1&participantId=`$participant.id`&cs=`$checksumValue`" a=true h=0 fe=1}{/capture}
+     {capture assign=confirmUrl}{crmURL p='civicrm/event/confirm' q="reset=1&participantId={participant.id}&cs=`$checksumValue`" a=true h=0 fe=1}{/capture}
      <a href="{$confirmUrl}">{ts}Click here to confirm and complete your registration{/ts}</a>
     </td>
    </tr>
   {/if}
-  {if $event.allow_selfcancelxfer}
+  {if {event.allow_selfcancelxfer|boolean}}
   {ts}This event allows for{/ts}
-  {capture assign=selfService}{crmURL p='civicrm/event/selfsvcupdate' q="reset=1&pid=`$participant.id`&{contact.checksum}" h=0 a=1 fe=1}{/capture}
+  {capture assign=selfService}{crmURL p='civicrm/event/selfsvcupdate' q="reset=1&pid={participant.id}&{contact.checksum}" h=0 a=1 fe=1}{/capture}
        <a href="{$selfService}"> {ts}self service cancel or transfer{/ts}</a>
   {/if}
 
@@ -52,8 +52,8 @@
      </tr>
      <tr>
       <td colspan="2" {$valueStyle}>
-       {$event.event_title}<br />
-       {$event.event_start_date|crmDate}{if $event.event_end_date}-{if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}{$event.event_end_date|crmDate:0:1}{else}{$event.event_end_date|crmDate}{/if}{/if}
+       {event.title}<br />
+       {event.start_date|crmDate:"%A"} {event.start_date|crmDate}{if {event.end_date|boolean}}-{if '{event.end_date|crmDate:"%Y%m%d"}' === '{event.start_date|crmDate:"%Y%m%d"}'}{event.end_date|crmDate:"Time"}{else}{event.end_date|crmDate:"%A"} {event.end_date|crmDate}{/if}{/if}
       </td>
      </tr>
      <tr>
@@ -61,60 +61,86 @@
        {ts}Participant Role{/ts}:
       </td>
       <td {$valueStyle}>
-       {$participant.role}
+        {participant.role_id:label}
       </td>
      </tr>
-
-     {if $isShowLocation}
-      <tr>
-       <td colspan="2" {$valueStyle}>
-        {$event.location.address.1.display|nl2br}
-       </td>
-      </tr>
-     {/if}
-
-     {if $event.location.phone.1.phone || $event.location.email.1.email}
-      <tr>
-       <td colspan="2" {$labelStyle}>
-        {ts}Event Contacts:{/ts}
-       </td>
-      </tr>
-      {foreach from=$event.location.phone item=phone}
-       {if $phone.phone}
+     {if {event.is_show_location|boolean}}
         <tr>
-         <td {$labelStyle}>
-          {if $phone.phone_type}{$phone.phone_type_display}{else}{ts}Phone{/ts}{/if}
-         </td>
-         <td {$valueStyle}>
-          {$phone.phone}
-         </td>
+          <td colspan="2" {$valueStyle}>
+            {event.location}
+          </td>
         </tr>
-       {/if}
-      {/foreach}
-      {foreach from=$event.location.email item=eventEmail}
-       {if $eventEmail.email}
-        <tr>
-         <td {$labelStyle}>
-          {ts}Email{/ts}
-         </td>
-         <td {$valueStyle}>
-          {$eventEmail.email}
-         </td>
-        </tr>
-       {/if}
-      {/foreach}
-     {/if}
+      {/if}
 
-     {if $event.is_public}
+     {if {event.loc_block_id.phone_id.phone|boolean} || {event.loc_block_id.email_id.email|boolean}}
+        <tr>
+          <td colspan="2" {$labelStyle}>
+            {ts}Event Contacts:{/ts}
+          </td>
+        </tr>
+
+        {if {event.loc_block_id.phone_id.phone|boolean}}
+          <tr>
+            <td {$labelStyle}>
+              {if {event.loc_block_id.phone_id.phone_type_id|boolean}}
+                {event.loc_block_id.phone_id.phone_type_id:label}
+              {else}
+                {ts}Phone{/ts}
+              {/if}
+            </td>
+            <td {$valueStyle}>
+              {event.loc_block_id.phone_id.phone} {if {event.loc_block_id.phone_id.phone_ext|boolean}}&nbsp;{ts}ext.{/ts} {event.loc_block_id.phone_id.phone_ext}{/if}
+            </td>
+          </tr>
+        {/if}
+        {if {event.loc_block_id.phone_2_id.phone|boolean}}
+          <tr>
+            <td {$labelStyle}>
+              {if {event.loc_block_id.phone_2_id.phone_type_id|boolean}}
+                {event.loc_block_id.phone_2_id.phone_type_id:label}
+              {else}
+                {ts}Phone{/ts}
+              {/if}
+            </td>
+            <td {$valueStyle}>
+              {event.loc_block_id.phone_2_id.phone} {if {event.loc_block_id.phone_2_id.phone_ext|boolean}}&nbsp;{ts}ext.{/ts} {event.loc_block_id.phone_2_id.phone_ext}{/if}
+            </td>
+          </tr>
+        {/if}
+
+        {if {event.loc_block_id.email_id.email|boolean}}
+          <tr>
+            <td {$labelStyle}>
+              {ts}Email{/ts}
+            </td>
+            <td {$valueStyle}>
+              {event.loc_block_id.email_id.email}
+            </td>
+          </tr>
+        {/if}
+
+        {if {event.loc_block_id.email_2_id.email|boolean}}
+          <tr>
+            <td {$labelStyle}>
+              {ts}Email{/ts}
+            </td>
+            <td {$valueStyle}>
+              {event.loc_block_id.email_2_id.email}
+            </td>
+          </tr>
+        {/if}
+      {/if}
+
+     {if {event.is_public|boolean}}
      <tr>
        <td colspan="2" {$valueStyle}>
-           {capture assign=icalFeed}{crmURL p='civicrm/event/ical' q="reset=1&id=`$event.id`" h=0 a=1 fe=1}{/capture}
+           {capture assign=icalFeed}{crmURL p='civicrm/event/ical' q="reset=1&id={event.id}" h=0 a=1 fe=1}{/capture}
          <a href="{$icalFeed}">{ts}Download iCalendar entry for this event.{/ts}</a>
        </td>
      </tr>
      <tr>
        <td colspan="2" {$valueStyle}>
-           {capture assign=gCalendar}{crmURL p='civicrm/event/ical' q="gCalendar=1&reset=1&id=`$event.id`" h=0 a=1 fe=1}{/capture}
+           {capture assign=gCalendar}{crmURL p='civicrm/event/ical' q="gCalendar=1&reset=1&id={event.id}" h=0 a=1 fe=1}{/capture}
          <a href="{$gCalendar}">{ts}Add event to Google Calendar{/ts}</a>
        </td>
      </tr>
@@ -133,13 +159,13 @@
       </tr>
      {/if}
 
-     {if $register_date}
+     {if {participant.register_date|boolean}}
       <tr>
        <td {$labelStyle}>
         {ts}Registration Date{/ts}
        </td>
        <td {$valueStyle}>
-        {$participant.register_date|crmDate}
+         {participant.register_date}
        </td>
       </tr>
      {/if}
@@ -147,7 +173,7 @@
     </table>
    </td>
   </tr>
-  {if $event.allow_selfcancelxfer}
+  {if {event.allow_selfcancelxfer|boolean}}
    <tr>
      <td colspan="2" {$valueStyle}>
        {ts 1=$selfcancelxfer_time 2=$selfservice_preposition}You may transfer your registration to another participant or cancel your registration up to %1 hours %2 the event.{/ts} {if $totalAmount}{ts}Cancellations are not refundable.{/ts}{/if}<br />

--- a/xml/templates/message_templates/participant_expired_html.tpl
+++ b/xml/templates/message_templates/participant_expired_html.tpl
@@ -21,7 +21,7 @@
   <tr>
    <td>
     {assign var="greeting" value="{contact.email_greeting_display}"}{if $greeting}<p>{$greeting},</p>{/if}
-    <p>{ts 1=$event.event_title}Your pending event registration for %1 has expired
+    <p>{ts 1="{event.title}"}Your pending event registration for %1 has expired
 because you did not confirm your registration.{/ts}</p>
     <p>{ts 1='{domain.phone}' 2='{domain.email}'}Please contact us at %1 or send email to %2 if you have questions
 or want to inquire about reinstating your registration for this event.{/ts}</p>
@@ -37,8 +37,8 @@ or want to inquire about reinstating your registration for this event.{/ts}</p>
      </tr>
      <tr>
       <td colspan="2" {$valueStyle}>
-       {$event.event_title}<br />
-       {$event.event_start_date|crmDate}{if $event.event_end_date}-{if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}{$event.event_end_date|crmDate:0:1}{else}{$event.event_end_date|crmDate}{/if}{/if}
+       {event.title}<br />
+       {event.start_date|crmDate:"%A"} {event.start_date|crmDate}{if {event.end_date|boolean}}-{if '{event.end_date|crmDate:"%Y%m%d"}' === '{event.start_date|crmDate:"%Y%m%d"}'}{event.end_date|crmDate:"Time"}{else}{event.end_date|crmDate:"%A"} {event.end_date|crmDate}{/if}{/if}
       </td>
      </tr>
      <tr>
@@ -46,70 +46,84 @@ or want to inquire about reinstating your registration for this event.{/ts}</p>
        {ts}Participant Role{/ts}:
       </td>
       <td {$valueStyle}>
-       {$participant.role}
+        {participant.role_id:label}
       </td>
      </tr>
 
-     {if $isShowLocation}
-      <tr>
-       <td colspan="2" {$valueStyle}>
-        {$event.location.address.1.display|nl2br}
-       </td>
-      </tr>
-     {/if}
-
-     {if !empty($event.location.phone.1.phone) || !empty($event.location.email.1.email)}
-      <tr>
-       <td colspan="2" {$labelStyle}>
-        {ts}Event Contacts:{/ts}
-       </td>
-      </tr>
-      {foreach from=$event.location.phone item=phone}
-       {if $phone.phone}
+    {if {event.is_show_location|boolean}}
         <tr>
-         <td {$labelStyle}>
-          {if $phone.phone_type}{$phone.phone_type_display}{else}{ts}Phone{/ts}{/if}
-         </td>
-         <td {$valueStyle}>
-          {$phone.phone}
-         </td>
+          <td colspan="2" {$valueStyle}>
+            {event.location}
+          </td>
         </tr>
-       {/if}
-      {/foreach}
-      {foreach from=$event.location.email item=eventEmail}
-       {if $eventEmail.email}
+      {/if}
+
+    {if {event.loc_block_id.phone_id.phone|boolean} || {event.loc_block_id.email_id.email|boolean}}
         <tr>
-         <td {$labelStyle}>
-          {ts}Email{/ts}
-         </td>
-         <td {$valueStyle}>
-          {$eventEmail.email}
-         </td>
+          <td colspan="2" {$labelStyle}>
+            {ts}Event Contacts:{/ts}
+          </td>
         </tr>
-       {/if}
-      {/foreach}
-     {/if}
 
-     {if '{contact.email}'}
-      <tr>
-       <th {$headerStyle}>
-        {ts}Registered Email{/ts}
-       </th>
-      </tr>
-      <tr>
-       <td colspan="2" {$valueStyle}>
-        {contact.email}
-       </td>
-      </tr>
-     {/if}
+        {if {event.loc_block_id.phone_id.phone|boolean}}
+          <tr>
+            <td {$labelStyle}>
+              {if {event.loc_block_id.phone_id.phone_type_id|boolean}}
+                {event.loc_block_id.phone_id.phone_type_id:label}
+              {else}
+                {ts}Phone{/ts}
+              {/if}
+            </td>
+            <td {$valueStyle}>
+              {event.loc_block_id.phone_id.phone} {if {event.loc_block_id.phone_id.phone_ext|boolean}}&nbsp;{ts}ext.{/ts} {event.loc_block_id.phone_id.phone_ext}{/if}
+            </td>
+          </tr>
+        {/if}
+        {if {event.loc_block_id.phone_2_id.phone|boolean}}
+          <tr>
+            <td {$labelStyle}>
+              {if {event.loc_block_id.phone_2_id.phone_type_id|boolean}}
+                {event.loc_block_id.phone_2_id.phone_type_id:label}
+              {else}
+                {ts}Phone{/ts}
+              {/if}
+            </td>
+            <td {$valueStyle}>
+              {event.loc_block_id.phone_2_id.phone} {if {event.loc_block_id.phone_2_id.phone_ext|boolean}}&nbsp;{ts}ext.{/ts} {event.loc_block_id.phone_2_id.phone_ext}{/if}
+            </td>
+          </tr>
+        {/if}
 
-     {if $register_date}
+        {if {event.loc_block_id.email_id.email|boolean}}
+          <tr>
+            <td {$labelStyle}>
+              {ts}Email{/ts}
+            </td>
+            <td {$valueStyle}>
+              {event.loc_block_id.email_id.email}
+            </td>
+          </tr>
+        {/if}
+
+        {if {event.loc_block_id.email_2_id.email|boolean}}
+          <tr>
+            <td {$labelStyle}>
+              {ts}Email{/ts}
+            </td>
+            <td {$valueStyle}>
+              {event.loc_block_id.email_2_id.email}
+            </td>
+          </tr>
+        {/if}
+      {/if}
+
+    {if {participant.register_date|boolean}}
       <tr>
        <td {$labelStyle}>
         {ts}Registration Date{/ts}
        </td>
        <td {$valueStyle}>
-        {$participant.register_date|crmDate}
+        {participant.register_date}
        </td>
       </tr>
      {/if}

--- a/xml/templates/message_templates/participant_transferred_html.tpl
+++ b/xml/templates/message_templates/participant_transferred_html.tpl
@@ -34,8 +34,8 @@
      </tr>
      <tr>
       <td colspan="2" {$valueStyle}>
-       {$event.event_title}<br />
-       {$event.event_start_date|crmDate}{if $event.event_end_date}-{if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}{$event.event_end_date|crmDate:0:1}{else}{$event.event_end_date|crmDate}{/if}{/if}
+       {event.event_title}<br />
+       {event.start_date|crmDate:"%A"} {event.start_date|crmDate}{if {event.end_date|boolean}}-{if '{event.end_date|crmDate:"%Y%m%d"}' === '{event.start_date|crmDate:"%Y%m%d"}'}{event.end_date|crmDate:"Time"}{else}{event.end_date|crmDate:"%A"} {event.end_date|crmDate}{/if}{/if}
       </td>
      </tr>
      <tr>
@@ -43,49 +43,76 @@
        {ts}Participant Role{/ts}:
       </td>
       <td {$valueStyle}>
-       {$participant.role}
+       {participant.role_id:label}
       </td>
      </tr>
 
-     {if $isShowLocation}
-      <tr>
-       <td colspan="2" {$valueStyle}>
-        {$event.location.address.1.display|nl2br}
-       </td>
-      </tr>
-     {/if}
+     {if {event.is_show_location|boolean}}
+        <tr>
+          <td colspan="2" {$valueStyle}>
+            {event.location}
+          </td>
+        </tr>
+      {/if}
 
-     {if !empty($event.location.phone.1.phone) || !empty($event.location.email.1.email)}
-      <tr>
-       <td colspan="2" {$labelStyle}>
-        {ts}Event Contacts:{/ts}
-       </td>
-      </tr>
-      {foreach from=$event.location.phone item=phone}
-       {if $phone.phone}
+     {if {event.loc_block_id.phone_id.phone|boolean} || {event.loc_block_id.email_id.email|boolean}}
         <tr>
-         <td {$labelStyle}>
-          {if $phone.phone_type}{$phone.phone_type_display}{else}{ts}Phone{/ts}{/if}
-         </td>
-         <td {$valueStyle}>
-          {$phone.phone}
-         </td>
+          <td colspan="2" {$labelStyle}>
+            {ts}Event Contacts:{/ts}
+          </td>
         </tr>
-       {/if}
-      {/foreach}
-      {foreach from=$event.location.email item=eventEmail}
-       {if $eventEmail.email}
-        <tr>
-         <td {$labelStyle}>
-          {ts}Email{/ts}
-         </td>
-         <td {$valueStyle}>
-          {$eventEmail.email}
-         </td>
-        </tr>
-       {/if}
-      {/foreach}
-     {/if}
+
+        {if {event.loc_block_id.phone_id.phone|boolean}}
+          <tr>
+            <td {$labelStyle}>
+              {if {event.loc_block_id.phone_id.phone_type_id|boolean}}
+                {event.loc_block_id.phone_id.phone_type_id:label}
+              {else}
+                {ts}Phone{/ts}
+              {/if}
+            </td>
+            <td {$valueStyle}>
+              {event.loc_block_id.phone_id.phone} {if {event.loc_block_id.phone_id.phone_ext|boolean}}&nbsp;{ts}ext.{/ts} {event.loc_block_id.phone_id.phone_ext}{/if}
+            </td>
+          </tr>
+        {/if}
+        {if {event.loc_block_id.phone_2_id.phone|boolean}}
+          <tr>
+            <td {$labelStyle}>
+              {if {event.loc_block_id.phone_2_id.phone_type_id|boolean}}
+                {event.loc_block_id.phone_2_id.phone_type_id:label}
+              {else}
+                {ts}Phone{/ts}
+              {/if}
+            </td>
+            <td {$valueStyle}>
+              {event.loc_block_id.phone_2_id.phone} {if {event.loc_block_id.phone_2_id.phone_ext|boolean}}&nbsp;{ts}ext.{/ts} {event.loc_block_id.phone_2_id.phone_ext}{/if}
+            </td>
+          </tr>
+        {/if}
+
+        {if {event.loc_block_id.email_id.email|boolean}}
+          <tr>
+            <td {$labelStyle}>
+              {ts}Email{/ts}
+            </td>
+            <td {$valueStyle}>
+              {event.loc_block_id.email_id.email}
+            </td>
+          </tr>
+        {/if}
+
+        {if {event.loc_block_id.email_2_id.email|boolean}}
+          <tr>
+            <td {$labelStyle}>
+              {ts}Email{/ts}
+            </td>
+            <td {$valueStyle}>
+              {event.loc_block_id.email_2_id.email}
+            </td>
+          </tr>
+        {/if}
+      {/if}
 
      {if '{contact.email}'}
       <tr>
@@ -100,13 +127,13 @@
       </tr>
      {/if}
 
-     {if $register_date}
+      {if {participant.register_date|boolean}}
       <tr>
        <td {$labelStyle}>
         {ts}Registration Date{/ts}
        </td>
        <td {$valueStyle}>
-        {$participant.register_date|crmDate}
+        {participant.register_date}
        </td>
       </tr>
      {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Fix notices in participant status change templates

Before
----------------------------------------
Tests find notices in these sometimes - https://test.civicrm.org/job/CiviCRM-Core-Matrix-PR/8106/BKPROF=dfl,SUITES=phpunit-crm,label=bknix-tmp/testReport/junit/(root)/CRM_Event_Form_SelfSvcTransferTest/testCancel/



After
----------------------------------------
Standardised blocks for location, role, copied from event offline template used to replace the noticey ones

Relevant previews (note the rendering of these is standard enough that it is enough we have some tests go through them & we can otherwise use the previews to confim the tpl fixes)


![image](https://github.com/civicrm/civicrm-core/assets/336308/e605593d-fa60-43fb-ad2f-e37839b53ee9)

![image](https://github.com/civicrm/civicrm-core/assets/336308/e7b44e98-0fc8-467f-9147-d4a4e1cc6622)

![image](https://github.com/civicrm/civicrm-core/assets/336308/84ae54a9-7759-46c4-b79b-a1cab6b5a655)

![image](https://github.com/civicrm/civicrm-core/assets/336308/1bff0858-c8da-4241-967f-7c3268fdcba5)


Technical Details
----------------------------------------
This also adds preview for a couple of them

Comments
----------------------------------------
