### PR TITLE
Prevent notice on non-monetary event

### DIFF
--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -348,17 +348,19 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
         CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/event/register', "reset=1&id={$form->getEventID()}", FALSE, NULL, FALSE, TRUE));
       }
     }
-    $form->_feeBlock = $form->_values['fee'];
-    CRM_Event_Form_Registration_Register::formatFieldsForOptionFull($form);
+    if ($form->getEventValue('is_monetary')) {
+      $form->_feeBlock = $form->_values['fee'];
+      CRM_Event_Form_Registration_Register::formatFieldsForOptionFull($form);
 
-    if (!empty($form->_priceSetId) &&
-      !$form->_requireApproval && !$form->_allowWaitlist
+      if (!empty($form->_priceSetId) &&
+        !$form->_requireApproval && !$form->_allowWaitlist
       ) {
-      $errors = self::validatePriceSet($form, $form->_params);
-      if (!empty($errors)) {
-        CRM_Core_Session::setStatus(ts('You have been returned to the start of the registration process and any sold out events have been removed from your selections. You will not be able to continue until you review your booking and select different events if you wish.'), ts('Unfortunately some of your options have now sold out for one or more participants.'), 'error');
-        CRM_Core_Session::setStatus(ts('Please note that the options which are marked or selected are sold out for participant being viewed.'), ts('Sold out:'), 'error');
-        CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/event/register', "_qf_Register_display=true&qfKey={$fields['qfKey']}"));
+        $errors = self::validatePriceSet($form, $form->_params);
+        if (!empty($errors)) {
+          CRM_Core_Session::setStatus(ts('You have been returned to the start of the registration process and any sold out events have been removed from your selections. You will not be able to continue until you review your booking and select different events if you wish.'), ts('Unfortunately some of your options have now sold out for one or more participants.'), 'error');
+          CRM_Core_Session::setStatus(ts('Please note that the options which are marked or selected are sold out for participant being viewed.'), ts('Sold out:'), 'error');
+          CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/event/register', "_qf_Register_display=true&qfKey={$fields['qfKey']}"));
+        }
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Prevent notice on non-monetary event

Before
----------------------------------------
Monetary aspects skipped with noise for non-monetary events

After
----------------------------------------
Skipped more quietly

Technical Details
----------------------------------------
This is causing a test I'm working on to fail

Comments
----------------------------------------
