### PR TITLE
REF Move paymentProcessorAuthorizeNetCreate test function to authorizenet test trait

### DIFF
--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -9,6 +9,7 @@ use Civi\Api4\Contribution;
  */
 class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
   use CRMTraits_Financial_OrderTrait;
+  use CRM_Core_Payment_AuthorizeNetTrait;
 
   protected $_financialTypeID = 1;
   protected $_contactID;

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetTrait.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetTrait.php
@@ -29,6 +29,36 @@ trait CRM_Core_Payment_AuthorizeNetTrait {
   protected $isRecur = FALSE;
 
   /**
+   * Create test Authorize.net instance.
+   *
+   * @param array $params
+   * @param string $identifier
+   *
+   * @return int
+   */
+  public function paymentProcessorAuthorizeNetCreate(array $params = [], string $identifier = 'authorize_net'): int {
+    $params = array_merge([
+      'name' => 'Authorize',
+      'domain_id' => CRM_Core_Config::domainID(),
+      'payment_processor_type_id:name' => 'AuthNet',
+      'title' => 'AuthNet',
+      'is_active' => 1,
+      'is_default' => 0,
+      'is_test' => 1,
+      'is_recur' => 1,
+      'user_name' => '4y5BfuW7jm',
+      'password' => '4cAmW927n8uLf5J8',
+      'url_site' => 'https://test.authorize.net/gateway/transact.dll',
+      'url_recur' => 'https://apitest.authorize.net/xml/v1/request.api',
+      'class_name' => 'Payment_AuthorizeNet',
+      'billing_mode' => 1,
+    ], $params);
+
+    $result = $this->createTestEntity('PaymentProcessor', $params, $identifier);
+    return (int) $result['id'];
+  }
+
+  /**
    * Get the expected response from Authorize.net.
    *
    * @return string

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -14,6 +14,7 @@
  * @group headless
  */
 class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
+  use CRM_Core_Payment_AuthorizeNetTrait;
 
   protected $_financialTypeId;
   protected $_contributionParams;

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -761,36 +761,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   }
 
   /**
-   * Create test Authorize.net instance.
-   *
-   * @param array $params
-   * @param string $identifier
-   *
-   * @return int
-   */
-  public function paymentProcessorAuthorizeNetCreate(array $params = [], string $identifier = 'authorize_net'): int {
-    $params = array_merge([
-      'name' => 'Authorize',
-      'domain_id' => CRM_Core_Config::domainID(),
-      'payment_processor_type_id:name' => 'AuthNet',
-      'title' => 'AuthNet',
-      'is_active' => 1,
-      'is_default' => 0,
-      'is_test' => 1,
-      'is_recur' => 1,
-      'user_name' => '4y5BfuW7jm',
-      'password' => '4cAmW927n8uLf5J8',
-      'url_site' => 'https://test.authorize.net/gateway/transact.dll',
-      'url_recur' => 'https://apitest.authorize.net/xml/v1/request.api',
-      'class_name' => 'Payment_AuthorizeNet',
-      'billing_mode' => 1,
-    ], $params);
-
-    $result = $this->createTestEntity('PaymentProcessor', $params, $identifier);
-    return (int) $result['id'];
-  }
-
-  /**
    * Create Participant.
    *
    * @param array $params

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -33,6 +33,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   use CRMTraits_Financial_TaxTrait;
   use CRMTraits_Financial_PriceSetTrait;
   use FormTrait;
+  use CRM_Core_Payment_AuthorizeNetTrait;
 
   protected $individualID;
   protected $financialTypeID = 1;


### PR DESCRIPTION
Overview
----------------------------------------
Just moves a function to put payment processor specific stuff in the same place

Before
----------------------------------------
In shared test code

After
----------------------------------------
In authorizenet trait.

Technical Details
----------------------------------------


Comments
----------------------------------------
