### PR TITLE
Add missing aliases for billingCountry fields

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -44,6 +44,8 @@ class PropertyBag implements \ArrayAccess {
     'billing_state_province'      => 'billingStateProvince',
     'state_province'              => 'billingStateProvince',
     'billingCountry'              => TRUE,
+    'billing_country'             => 'billingCountry',
+    'country'                     => 'billingCountry',
     'contactID'                   => TRUE,
     'contact_id'                  => 'contactID',
     'contributionID'              => TRUE,
@@ -804,7 +806,7 @@ class PropertyBag implements \ArrayAccess {
    */
   public function setCurrency($value, $label = 'default') {
     if (!preg_match('/^[A-Z]{3}$/', $value)) {
-      throw new \InvalidArgumentException("Attemted to setCurrency with a value that was not an ISO 3166-1 alpha 3 currency code");
+      throw new \InvalidArgumentException("Attempted to setCurrency with a value that was not an ISO 3166-1 alpha 3 currency code");
     }
     return $this->set('currency', $label, $value);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Add missing aliases for billingCountry fields.

Eg. see https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Payment/AuthorizeNet.php#L355
If these aliases are not defined and `billingCountry` is not passed in we won't be able to access via the legacy names and Country will not be set.

Before
----------------------------------------
Missing aliases for `billingCountry`

After
----------------------------------------
Added aliases for `billingCountry`

Technical Details
----------------------------------------
There are a few places that might pass in `country` or `billing_country` in core instead of `billingCountry`. We need to specify the aliases so that we can ensure that Country is always set if we're using a PropertyBag.
Note that `billing_country` actually gets passed in with the billing address ID appended (eg. `billing_country-5`) and PropertyBag has some pretty clever code to make sure we always have a 2 character country code.

Comments
----------------------------------------
@artfulrobot 