### PR TITLE
dev/core#4893 Fix failure to send event emails on non-monetary events  with no confirm page

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1573,7 +1573,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $this->set('participantInfo', $participantInfo);
     }
 
-    if ($this->getPaymentProcessorObject()->supports('noReturn')
+    if (!$this->getEventValue('is_monetary') || $this->getPaymentProcessorObject()->supports('noReturn')
     ) {
       // Send mail Confirmation/Receipt.
       $this->sendMails($params, $registerByID, $participantCount);

--- a/Civi/Test/FormTrait.php
+++ b/Civi/Test/FormTrait.php
@@ -76,6 +76,9 @@ trait FormTrait {
    * @param int $mailIndex
    */
   protected function assertMailSentContainingString(string $string, int $mailIndex = 0): void {
+    if (!$this->form->getMail()) {
+      $this->fail('No mail sent');
+    }
     $mail = $this->form->getMail()[$mailIndex];
     $this->assertStringContainsString(preg_replace('/\s+/', '', $string), preg_replace('/\s+/', '', $mail['body']), 'String not found: ' . $string . "\n" . $mail['body']);
   }

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -613,6 +613,18 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     $this->sentMail = $mailUtil->getAllMessages();
   }
 
+  /**
+   * Ensure an email is sent when confirm is disabled for unpaid events.
+   */
+  public function testSubmitUnpaidEventNoConfirm(): void {
+    $this->eventCreateUnpaid(['is_confirm_enabled' => FALSE]);
+    $form = $this->getTestForm('CRM_Event_Form_Registration_Register', [
+      'email-Primary' => 'demo@example.com',
+    ], ['id' => $this->getEventID()]);
+    $form->processForm();
+    $this->assertMailSentContainingStrings(['Event']);
+  }
+
   public function testRegistrationWithoutCiviContributeEnabled(): void {
     $mut = new CiviMailUtils($this, TRUE);
     $event = $this->eventCreateUnpaid([


### PR DESCRIPTION


Overview
----------------------------------------
dev/core#4893 Fix failure to send event emails on non-monetary events  with no confirm page

Before
----------------------------------------
per https://lab.civicrm.org/dev/core/-/issues/4893 - I found I need to disable the confirm page 

After
----------------------------------------
mail sending resumed

Technical Details
----------------------------------------
I just added an additional check for non-monetary events. All other places in the original PR were positive tests for a processor attribute

Comments
----------------------------------------
