### PR TITLE
dev/core#4781 Handle invalid deprecated fields with more grace

### DIFF
--- a/CRM/Member/Import/Form/MapField.php
+++ b/CRM/Member/Import/Form/MapField.php
@@ -177,29 +177,4 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
     return $highlightedFields;
   }
 
-  /**
-   * Get default values for the mapping.
-   *
-   * @return array
-   *
-   * @throws \CRM_Core_Exception
-   */
-  protected function getDefaults(): array {
-    $defaults = [];
-    $headerPatterns = $this->getHeaderPatterns();
-    $fieldMappings = $this->getFieldMappings();
-    foreach ($this->getColumnHeaders() as $i => $columnHeader) {
-      if ($this->getSubmittedValue('savedMapping')) {
-        $fieldMapping = $fieldMappings[$i] ?? NULL;
-        if (isset($fieldMappings[$i])) {
-          $defaults["mapper[$i]"] = ($fieldMapping['name'] !== 'do_not_import') ? $fieldMapping['name'] : NULL;
-        }
-      }
-      if (!isset($defaults["mapper[$i]"]) && $this->getSubmittedValue('skipColumnHeader')) {
-        $defaults["mapper[$i]"] = $this->defaultFromHeader($columnHeader, $headerPatterns);
-      }
-    }
-    return $defaults;
-  }
-
 }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4781 Handle invalid deprecated fields with more grace

Before
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4781 reports a membership import failing after a specific upgrade - I can't see any reason why that upgrade would break the import and the error report identified the upgrade as the timing rather than the cause. However, the issue is consistent with there being a field in the saved mapping that is not one of the currently supported fields. That is pretty easy to replicate - ie do a membership import, save a mapping and then edit the field name of one of the fields in the mapping to something made up. In that scenario the user is able to submit the `MapField` form, but if they have not changed the value of the un-mappable field then the bad field name is retained and when they go to actually import the reported error is experienced

After
---------------------------------------
At the point of loading the mapping the field is checked for validity. If the field is not valid then it is unset & a warning pops up

![image](https://github.com/civicrm/civicrm-core/assets/336308/10687f80-c887-4166-97af-88dd3f829a7f)


Technical Details
----------------------------------------
I have only tested Membership & Contact import - the latter is unaffected by this. It seems likely that on further testing others might be affected - but this is the only one that has reportedly been experienced as a regression at this stage (there may be some other factor as to why this one was hit). I am still evaluating whether / how to deal with other imports but I don't think that should delay this being merged / included in the next 5.69 point release. However, I did move the fixed function into the parent to support further fixes.



Comments
----------------------------------------

