### PR TITLE
dev/core#4897 Fix Search Kit row link conditions

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -651,7 +651,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       return \CRM_Core_Permission::check($permissions) == ($op !== '!=');
     }
     // Convert the conditional value of 'current_domain' into an actual value that filterCompare can work with
-    if ($item['condition'][2] ?? '' === 'current_domain') {
+    if (($item['condition'][2] ?? '') === 'current_domain') {
       if (str_ends_with($item['condition'][0], ':label') !== FALSE) {
         $item['condition'][2] = \CRM_Core_BAO_Domain::getDomain()->name;
       }


### PR DESCRIPTION
Overview
----------------------------------------
Fix for operator precedence.

https://lab.civicrm.org/dev/core/-/issues/4897

Before
----------------------------------------
Link conditions with 3 part clauses evaluate unexpectedly to FALSE 


After
----------------------------------------
Link conditions with 3 part clauses work again.

Technical details
---------------------------------------
The `===` is evaluated before the `??`, so the conditional evaluates to true when it shouldn't and then the clause gets garbled.



