### PR TITLE
validate text fields in price sets

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -328,6 +328,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
             [
               'price' => json_encode([$optionKey, $priceVal]),
               'size' => '4',
+              'pattern' => '[\d\.]*',
             ]
           ),
           $useRequired && $field->is_required


### PR DESCRIPTION
Overview
----------------------------------------
When using price sets with text fields, it's invalid to add a currency symbol, or a thousands separator.  We also occasionally get people putting "no thank you" or similar.

This PR adds basic validation to the field.  There are some other approaches we could take, discussed below.

Before
----------------------------------------
Error on submission when invalid data submitted.

After
----------------------------------------
Data is validated immediately.

Comments
----------------------------------------
There are a couple of other approaches we should consider here, so this is a discussion piece.
* We could set `type=number` but this will add a spinner.  Folks won't like the change to their page, but hiding it with CSS needs to be handled gently to avoid theme conflicts.
* This currently gives an "Invalid Format" error message.  Not helpful! This is added by jQuery Validation.  We should override this, or remove jQuery Validation.  Is it serving a purpose in an HTML5 world?
