### PR TITLE
Unconditionally assign priceSet on event forms to avoid notices

### DIFF
--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -221,6 +221,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
     if ($this->_values['event']['is_monetary']) {
       CRM_Event_Form_Registration_Register::buildAmount($this, TRUE, NULL, $this->_priceSetId);
     }
+    $this->assign('priceSet', $this->_priceSet);
 
     //Add pre and post profiles on the form.
     foreach (['pre', 'post'] as $keys) {

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -455,7 +455,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       //@todo we are blocking for multiple registrations because we haven't tested
       $this->addCIDZeroOptions();
     }
-
+    $this->assign('priceSet', $this->_priceSet);
     $this->addElement('hidden', 'bypass_payment', NULL, ['id' => 'bypass_payment']);
     $this->assign('bypassPayment', $bypassPayment);
 
@@ -664,7 +664,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         }
       }
       $form->_priceSet['id'] ??= $priceSetID;
-      $form->assign('priceSet', $form->_priceSet);
     }
     else {
       // Is this reachable?


### PR DESCRIPTION
Overview
----------------------------------------
Unconditionally assign priceSet on event forms to avoid notices

Before
----------------------------------------
Notices when the event is not monetary

![image](https://github.com/civicrm/civicrm-core/assets/336308/451f471e-50bd-4c56-b4e5-8351f61f3f59)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/7accd0c1-b482-48bb-afac-b51c9165eee8)

Technical Details
----------------------------------------
`buildAmount` not otherwise called

![image](https://github.com/civicrm/civicrm-core/assets/336308/87d3b083-86cd-485c-909a-81c74427dd73)

![image](https://github.com/civicrm/civicrm-core/assets/336308/cf011d7d-015a-4ffa-a430-8e02bbdef6fa)


Comments
----------------------------------------
