### PR TITLE
hook_links - Identify more quirks

### DIFF
--- a/CRM/Report/Page/InstanceList.php
+++ b/CRM/Report/Page/InstanceList.php
@@ -241,16 +241,19 @@ class CRM_Report_Page_InstanceList extends CRM_Core_Page {
         'url' => CRM_Utils_System::url($urlCommon, 'reset=1&output=copy'),
         'label' => ts('Save a Copy'),
         'confirm_message' => NULL,
+        'weight' => CRM_Core_Action::getWeight(\CRM_Core_Action::COPY),
       ],
       'pdf' => [
         'url' => CRM_Utils_System::url($urlCommon, 'reset=1&force=1&output=pdf'),
         'label' => ts('View as pdf'),
         'confirm_message' => NULL,
+        'weight' => CRM_Core_Action::getWeight(\CRM_Core_Action::EXPORT),
       ],
       'print' => [
         'url' => CRM_Utils_System::url($urlCommon, 'reset=1&force=1&output=print'),
         'label' => ts('Print report'),
         'confirm_message' => NULL,
+        'weight' => CRM_Core_Action::getWeight(\CRM_Core_Action::EXPORT),
       ],
     ];
     // Hackery, Hackera, Hacker ahahahahahaha a super nasty hack.
@@ -266,6 +269,7 @@ class CRM_Report_Page_InstanceList extends CRM_Core_Page {
         'url' => CRM_Utils_System::url($urlCommon, 'reset=1&force=1&output=csv'),
         'label' => ts('Export to csv'),
         'confirm_message' => NULL,
+        'weight' => CRM_Core_Action::getWeight(\CRM_Core_Action::EXPORT),
       ];
     }
     if (CRM_Core_Permission::check('administer Reports')) {
@@ -273,6 +277,7 @@ class CRM_Report_Page_InstanceList extends CRM_Core_Page {
         'url' => CRM_Utils_System::url($urlCommon, 'reset=1&action=delete'),
         'label' => ts('Delete report'),
         'confirm_message' => ts('Are you sure you want delete this report? This action cannot be undone.'),
+        'weight' => CRM_Core_Action::getWeight(\CRM_Core_Action::DELETE),
       ];
     }
     CRM_Utils_Hook::links('view.report.links',

--- a/tests/events/hook_civicrm_links.evch.php
+++ b/tests/events/hook_civicrm_links.evch.php
@@ -58,6 +58,7 @@ return new class() extends EventCheck implements HookInterface {
   protected $grandfatheredInvalidKeys = [
     'pledge.selector.row' => ['is_active'],
     'view.report.links' => ['confirm_message'],
+    'contribution.selector.row' => ['result', 'key', 'is_single_mode', 'title_single_mode', 'filters'],
   ];
 
   /**

--- a/tests/events/hook_civicrm_links.evch.php
+++ b/tests/events/hook_civicrm_links.evch.php
@@ -82,6 +82,16 @@ return new class() extends EventCheck implements HookInterface {
   ];
 
   /**
+   * The $objectId is usually numeric. Some links are based on non-numeric IDs.
+   *
+   * @var array
+   */
+  protected $objectIdTypes = [
+    'extension.local.action' => 'string',
+    'extension.remote.action' => 'string',
+  ];
+
+  /**
    * List of events with multiple problems. These are completely ignored.
    *
    * @var string[]
@@ -109,9 +119,14 @@ return new class() extends EventCheck implements HookInterface {
     $this->assertTrue((bool) preg_match(';^[A-Z][a-zA-Z0-9]+$;', $objectName) || !empty($matchGrandfatheredObjectNames),
       "$msg: Object name ($objectName) should be a CamelCase name or a grandfathered name");
 
-    // $this->assertType('integer|null', $objectId, "$msg: Object ID ($objectId) should be int|null");
-    $this->assertTrue($objectId === NULL || is_numeric($objectId), "$msg: Object ID ($objectId) should be int|null");
-    // Sometimes it's a string-style int. Patch-welcome if someone wants to clean that up. But this is what it currently does.
+    if (isset($this->objectIdTypes[$op])) {
+      $this->assertType($this->objectIdTypes[$op], $objectId, "$msg: Object ID ($objectId) should be " . $this->objectIdTypes[$op]);
+    }
+    else {
+      // $this->assertType('integer|null', $objectId, "$msg: Object ID ($objectId) should be int|null");
+      $this->assertTrue($objectId === NULL || is_numeric($objectId), "$msg: Object ID ($objectId) should be int|null");
+      // Sometimes it's a string-style int. Patch-welcome if someone wants to clean that up. But this is what it currently does.
+    }
 
     $this->assertType('array', $links, "$msg: Links should be an array");
     $this->assertType('integer|null', $mask, "$msg: Mask ($mask) should be int}null");


### PR DESCRIPTION
Overview
----------------------------------------

`hook_civicrm_links` is decidedly quirky -- depending on when exactly it's called, it gives different data. If you enable the `event_check` extension, these inconsistencies are reported as hard errors. 

The patch goes through some of the most of the most common hard errors. Generally, one should look at each commit separately. There are generally two plays to be made when we find a quirk:

1. Fix the thing which emits the inconsistent data -- make every flavor of `hook_links` be consistent with the docs. (Depending on the specific inconsistency, this may or may not be backward-comaptible...)
2. Add an exception to allow an existing deviation. (Then you use these exceptions to update the dev-docs.)

