### PR TITLE
dev/core#4898 Add getLinks to Import api

### DIFF
--- a/ext/civiimport/Civi/Api4/Import.php
+++ b/ext/civiimport/Civi/Api4/Import.php
@@ -10,6 +10,7 @@
  */
 namespace Civi\Api4;
 
+use Civi\Api4\Action\GetLinks;
 use Civi\Api4\Import\CheckAccessAction;
 use Civi\Api4\Generic\DAOGetAction;
 use Civi\Api4\Generic\DAOGetFieldsAction;
@@ -101,6 +102,17 @@ class Import {
    */
   public static function getActions(int $userJobID, bool $checkPermissions = TRUE): GetActions {
     return (new GetActions('Import_' . $userJobID, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param int $userJobID
+   * @param bool $checkPermissions
+   *
+   * @return \Civi\Api4\Action\GetLinks
+   */
+  public static function getLinks(int $userJobID, bool $checkPermissions = TRUE): GetLinks {
+    return (new GetLinks('Import_' . $userJobID, __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This addresses https://lab.civicrm.org/dev/core/-/issues/4898 - I'm pretty sure the `getLinks()` code was merged last week so should affect 5.70 but not 5.69. Per my comments on the gitlab - I think we should have some more handling in the api layer to allow for apis without this function

@colemanw