### PR TITLE
organizer field should ONLY be included if ics is used for group scheduling

### DIFF
--- a/templates/CRM/Core/Calendar/ICal.tpl
+++ b/templates/CRM/Core/Calendar/ICal.tpl
@@ -53,9 +53,6 @@ DTEND;TZID={$timezone}:{$event.start_date|crmICalDate}
 {if $event.is_show_location EQ 1 && $event.location}
 LOCATION:{$event.location|crmICalText}
 {/if}
-{if $event.contact_email}
-ORGANIZER:MAILTO:{$event.contact_email|crmICalText}
-{/if}
 {if $event.url}
 URL:{$event.url}
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
The ICS file that is downloaded from an event page includes the Organizer field, which is not supposed to be included in an ICS file that is intended to be directly imported into your calendar.

The Organizer field is only supposed to be in ICS files that are sent via email as part of a group scheduling process (where you are prompted to indicate if you can make the meeting or not).

According to the [spec](https://www.rfc-editor.org/rfc/rfc5545#section-3.8.4.3):

> This property MUST  NOT be specified in an iCalendar object that specifies only a time zone definition or that defines calendar components that are not group-scheduled components, but are components only on a single user's calendar.

Since the ICS file downloaded from an event page is designed to be directly imported into a Calendar (and therefore not used for group scheduling), it should never have the Organizer component.

Some calendars don't seem to care, but if you import an ICS file into outlook that has the organizer specified, Outlook will ask you if accept/decline/etc. and then will freeze when you select an option.

Before
----------------------------------------

When downloading an ICS file form an event page in which an event email is defined, the Organizer component is included with that email.

After
----------------------------------------
The organizer component is never included.

