### PR TITLE
dev/core#4888 - Location field on case activity is misaligned

### DIFF
--- a/templates/CRM/Case/Form/Activity.tpl
+++ b/templates/CRM/Case/Form/Activity.tpl
@@ -115,7 +115,11 @@
               {/if}
               <tr class="crm-case-activity-form-block-medium_id">
                 <td class="label">{$form.medium_id.label}</td>
-                <td class="view-value">{$form.medium_id.html}&nbsp;&nbsp;&nbsp;{$form.location.label} &nbsp;{$form.location.html|crmAddClass:huge}</td>
+                <td class="view-value">{$form.medium_id.html}</td>
+              </tr>
+              <tr class="crm-case-activity-form-block-location">
+                <td class="label">{$form.location.label}</td>
+                <td class="view-value">{$form.location.html|crmAddClass:huge}</td>
               </tr>
               <tr class="crm-case-activity-form-block-activity_date_time">
                 <td class="label">{$form.activity_date_time.label}</td>


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4888

Before
----------------------------------------
<img width="327" alt="untitled3" src="https://github.com/civicrm/civicrm-core/assets/2967821/21f3882a-4b14-4516-852b-83d18fb08f26">


After
----------------------------------------
<img width="365" alt="untitled4" src="https://github.com/civicrm/civicrm-core/assets/2967821/2f8c224b-dc45-4984-89d4-c2d83c7737c6">


Technical Details
----------------------------------------
The medium widget used to be a regular dropdown and without the wrench beside it. It turns out it's not too recent and depends on the theme and sidebars etc, so have put against master.

There's no real reason the two fields need to be in the same `tr` - they are only loosely related.

Comments
----------------------------------------

