### PR TITLE
[REF] Fix Hard Fail when loading back office add membership form with membe…

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -427,7 +427,7 @@ DESC limit 1");
           $selOrgMemType[$memberOfContactId][$key] = $values['name'] ?? NULL;
         }
       }
-      $totalAmount = $values['minimum_fee'] ?? NULL;
+      $totalAmount = $values['minimum_fee'] ?? 0;
       // build membership info array, which is used when membership type is selected to:
       // - set the payment information block
       // - set the max related block


### PR DESCRIPTION
…rship types with no minimum fee set

Overview
----------------------------------------
This aims to fix a hard type error fail when you are trying to add a membership onto a contact via the non credit card add membership form on the back office when you have a membership type that doesn't have a minimum fee set

Note this has come up in chat twice https://chat.civicrm.org/civicrm/pl/wa5yuexetbgb7fsrdf945x61je https://chat.civicrm.org/civicrm/pl/cw3pmwkrt7yxupcumfp39nr7qa

Before
----------------------------------------
"Network error" caused by a type error about passing NULL in when it expects a float

After
----------------------------------------
Form loads

ping @eileenmcnaughton @totten 