### PR TITLE
Remove financial acls properties in core that are set but not accessed

### DIFF
--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -20,18 +20,6 @@ use Civi\Api4\EntityFinancialAccount;
 class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType implements \Civi\Core\HookInterface {
 
   /**
-   * Static cache holder of available financial types for this session
-   * @var array
-   */
-  public static $_availableFinancialTypes = [];
-
-  /**
-   * Static cache holder of status of ACL-FT enabled/disabled for this session
-   * @var array
-   */
-  public static $_statusACLFt = [];
-
-  /**
    * @deprecated
    * @param array $params
    * @param array $defaults

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2553,8 +2553,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     CRM_Contribute_PseudoConstant::flush('membershipType');
     // Pseudoconstants may be saved to the cache table.
     CRM_Core_DAO::executeQuery("TRUNCATE civicrm_cache");
-    CRM_Financial_BAO_FinancialType::$_statusACLFt = [];
-    CRM_Financial_BAO_FinancialType::$_availableFinancialTypes = NULL;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Remove financial acls properties in core that are set but not accessed

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/38cc54c4-e684-4c86-93da-87a32419297f)

![image](https://github.com/civicrm/civicrm-core/assets/336308/c573bc98-e7b5-4edd-b324-95b87352d124)


After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
