### PR TITLE
dev/core#4903 - undefined variable in New Individual on-the-fly popup

### DIFF
--- a/CRM/Profile/Form/Edit.php
+++ b/CRM/Profile/Form/Edit.php
@@ -145,6 +145,7 @@ SELECT module,is_reserved
 
     $this->assign('recentlyViewed', FALSE);
 
+    $cancelURL = '';
     if ($this->_context !== 'dialog') {
       $this->_postURL = $this->_ufGroup['post_url'];
       $cancelURL = $this->_ufGroup['cancel_url'];


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4903

Before
----------------------------------------
There's a couple ways to see it. Here's one:
1. Open the browser network tab.
1. New Contribution
1. In the contact field click New Individual.
1. Note the url of the ajax call in the browser network tab, and remove the snippet param and then visit it in another tab: `/civicrm/profile/create?reset=1&context=dialog&gid=4&returnExtra=display_name,sort_name,email&crmAngularModules=crmResource`
1. `Warning: Undefined variable $cancelURL in CRM_Profile_Form_Edit->buildQuickForm() (line 199 of .../CRM/Profile/Form/Edit.php)`

After
----------------------------------------


Technical Details
----------------------------------------
The removal of this line https://github.com/civicrm/civicrm-core/pull/28759/files#diff-0c836dd4fc1aa712fa755a6c3f3dec1891dc608bc020cffa74b0afd4a27c93e3L28, means it no longer has a default existence. It only gets set when context is not dialog.

Comments
----------------------------------------

