### PR TITLE
Remove possibly-unavailable job_id from unsub function

### DIFF
--- a/CRM/Mailing/Event/BAO/MailingEventQueue.php
+++ b/CRM/Mailing/Event/BAO/MailingEventQueue.php
@@ -71,8 +71,7 @@ class CRM_Mailing_Event_BAO_MailingEventQueue extends CRM_Mailing_Event_DAO_Mail
   /**
    * Verify that a queue event exists with the specified id/job id/hash.
    *
-   * @param int|int $job_id
-   *   The job ID of the event to find.
+   * @param null $unused
    * @param int $queue_id
    *   The Queue Event ID to find.
    * @param string $hash
@@ -81,7 +80,7 @@ class CRM_Mailing_Event_BAO_MailingEventQueue extends CRM_Mailing_Event_DAO_Mail
    * @return object|null
    *   The queue event if verified, or null
    */
-  public static function verify($job_id, $queue_id, $hash) {
+  public static function verify($unused, $queue_id, $hash) {
     $success = NULL;
     $q = new CRM_Mailing_Event_BAO_MailingEventQueue();
     if ($queue_id && $hash) {

--- a/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
@@ -93,8 +93,7 @@ WHERE  email = %2
   /**
    * Unsubscribe a contact from all groups that received this mailing.
    *
-   * @param int $job_id
-   *   The job ID.
+   * @param null $unused
    * @param int $queue_id
    *   The Queue Event ID of the recipient.
    * @param string $hash
@@ -107,7 +106,7 @@ WHERE  email = %2
    *
    * @throws \CRM_Core_Exception
    */
-  public static function unsub_from_mailing($job_id, $queue_id, $hash, $return = FALSE): ?array {
+  public static function unsub_from_mailing($unused, $queue_id, $hash, $return = FALSE): ?array {
     // First make sure there's a matching queue event.
 
     $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
@@ -117,7 +116,7 @@ WHERE  email = %2
 
     $contact_id = $q->contact_id;
 
-    $mailing_id = (int) civicrm_api3('MailingJob', 'getvalue', ['id' => $job_id, 'return' => 'mailing_id']);
+    $mailing_id = (int) civicrm_api3('MailingJobQueue', 'getvalue', ['id' => $queue_id, 'return' => 'mailing_id']);
     $mailing_type = CRM_Core_DAO::getFieldValue('CRM_Mailing_DAO_Mailing', $mailing_id, 'mailing_type', 'id');
 
     // We need a mailing id that points to the mailing that defined the recipients.

--- a/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
@@ -116,7 +116,7 @@ WHERE  email = %2
 
     $contact_id = $q->contact_id;
 
-    $mailing_id = (int) civicrm_api3('MailingJobQueue', 'getvalue', ['id' => $queue_id, 'return' => 'mailing_id']);
+    $mailing_id = (int) civicrm_api3('MailingEventQueue', 'getvalue', ['id' => $queue_id, 'return' => 'mailing_id']);
     $mailing_type = CRM_Core_DAO::getFieldValue('CRM_Mailing_DAO_Mailing', $mailing_id, 'mailing_type', 'id');
 
     // We need a mailing id that points to the mailing that defined the recipients.
@@ -334,8 +334,6 @@ WHERE  email = %2
   public static function send_unsub_response($queue_id, $groups, $is_domain, $job) {
     $config = CRM_Core_Config::singleton();
     $domain = CRM_Core_BAO_Domain::getDomain();
-    $jobObject = new CRM_Mailing_BAO_MailingJob();
-    $jobTable = $jobObject->getTableName();
     $mailingObject = new CRM_Mailing_DAO_Mailing();
     $mailingTable = $mailingObject->getTableName();
     $contactsObject = new CRM_Contact_DAO_Contact();
@@ -350,9 +348,9 @@ WHERE  email = %2
 
     $dao = new CRM_Mailing_BAO_Mailing();
     $dao->query("   SELECT * FROM $mailingTable
-                        INNER JOIN $jobTable ON
-                            $jobTable.mailing_id = $mailingTable.id
-                        WHERE $jobTable.id = $job");
+                        INNER JOIN civicrm_mailing_event_queue queue ON
+                            queue.mailing_id = $mailingTable.id
+                        WHERE queue.id = $queue_id");
     $dao->fetch();
 
     $component = new CRM_Mailing_BAO_MailingComponent();


### PR DESCRIPTION
Overview
----------------------------------------
Remove possibly-unavailable job_id from unsub function

Before
----------------------------------------
The primary place where the mailing_id for an mailing_event_queue record resides is now the mailing_event_queue table, not the mailing_job table. In looking at https://github.com/civicrm/civicrm-core/pull/28964/files the job ID is still being required for the unsub function - this is not really right anymore. It is likely symptomless as in practice most sites have mailing_job records but they are no longer required

After
----------------------------------------
We correctly reference the field in the mailing_event_queue table

Technical Details
----------------------------------------

Comments
----------------------------------------
