### PR TITLE
Add comments to settings definition to clarify that this is not the preferred method

### DIFF
--- a/CRM/Admin/Form/Setting.php
+++ b/CRM/Admin/Form/Setting.php
@@ -22,6 +22,14 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
 
   use CRM_Admin_Form_SettingTrait;
 
+  /**
+   * Subset of settings on the page as defined using the legacy method.
+   *
+   * @var array
+   *
+   * @deprecated - do not add new settings here - the page to display
+   * settings on should be defined in the setting metadata.
+   */
   protected $_settings = [];
 
   /**

--- a/CRM/Admin/Form/Setting/Case.php
+++ b/CRM/Admin/Form/Setting/Case.php
@@ -20,7 +20,16 @@
  */
 class CRM_Admin_Form_Setting_Case extends CRM_Admin_Form_Setting {
 
+  /**
+   * Subset of settings on the page as defined using the legacy method.
+   *
+   * @var array
+   *
+   * @deprecated - do not add new settings here - the page to display
+   * settings on should be defined in the setting metadata.
+   */
   protected $_settings = [
+    // @todo remove these, define any not yet defined in the setting metadata.
     'civicaseRedactActivityEmail' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
     'civicaseAllowMultipleClients' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
     'civicaseNaturalActivityTypeSort' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,

--- a/CRM/Admin/Form/Setting/Component.php
+++ b/CRM/Admin/Form/Setting/Component.php
@@ -21,7 +21,16 @@
 class CRM_Admin_Form_Setting_Component extends CRM_Admin_Form_Setting {
   protected $_components;
 
+  /**
+   * Subset of settings on the page as defined using the legacy method.
+   *
+   * @var array
+   *
+   * @deprecated - do not add new settings here - the page to display
+   * settings on should be defined in the setting metadata.
+   */
   protected $_settings = [
+    // @todo remove these, define any not yet defined in the setting metadata.
     'enable_components' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
   ];
 

--- a/CRM/Admin/Form/Setting/Date.php
+++ b/CRM/Admin/Form/Setting/Date.php
@@ -20,7 +20,16 @@
  */
 class CRM_Admin_Form_Setting_Date extends CRM_Admin_Form_Setting {
 
-  public $_settings = [
+  /**
+   * Subset of settings on the page as defined using the legacy method.
+   *
+   * @var array
+   *
+   * @deprecated - do not add new settings here - the page to display
+   * settings on should be defined in the setting metadata.
+   */
+  protected $_settings = [
+    // @todo remove these, define any not yet defined in the setting metadata.
     'dateformatDatetime' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'dateformatFull' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'dateformatPartial' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,

--- a/CRM/Admin/Form/Setting/Debugging.php
+++ b/CRM/Admin/Form/Setting/Debugging.php
@@ -20,7 +20,16 @@
  */
 class CRM_Admin_Form_Setting_Debugging extends CRM_Admin_Form_Setting {
 
+  /**
+   * Subset of settings on the page as defined using the legacy method.
+   *
+   * @var array
+   *
+   * @deprecated - do not add new settings here - the page to display
+   * settings on should be defined in the setting metadata.
+   */
   protected $_settings = [
+    // @todo remove these, define any not yet defined in the setting metadata.
     'debug_enabled' => CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME,
     'backtrace' => CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME,
     'fatalErrorHandler' => CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME,

--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -23,7 +23,16 @@ use Civi\Api4\OptionValue;
  */
 class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
 
+  /**
+   * Subset of settings on the page as defined using the legacy method.
+   *
+   * @var array
+   *
+   * @deprecated - do not add new settings here - the page to display
+   * settings on should be defined in the setting metadata.
+   */
   protected $_settings = [
+    // @todo remove these, define any not yet defined in the setting metadata.
     'contact_default_language' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'countryLimit' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'customTranslateFunction' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,

--- a/CRM/Admin/Form/Setting/Mail.php
+++ b/CRM/Admin/Form/Setting/Mail.php
@@ -20,7 +20,16 @@
  */
 class CRM_Admin_Form_Setting_Mail extends CRM_Admin_Form_Setting {
 
+  /**
+   * Subset of settings on the page as defined using the legacy method.
+   *
+   * @var array
+   *
+   * @deprecated - do not add new settings here - the page to display
+   * settings on should be defined in the setting metadata.
+   */
   protected $_settings = [
+    // @todo remove these, define any not yet defined in the setting metadata.
     'mailerBatchLimit' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
     'mailThrottleTime' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
     'mailerJobSize' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,

--- a/CRM/Admin/Form/Setting/Mapping.php
+++ b/CRM/Admin/Form/Setting/Mapping.php
@@ -20,7 +20,16 @@
  */
 class CRM_Admin_Form_Setting_Mapping extends CRM_Admin_Form_Setting {
 
+  /**
+   * Subset of settings on the page as defined using the legacy method.
+   *
+   * @var array
+   *
+   * @deprecated - do not add new settings here - the page to display
+   * settings on should be defined in the setting metadata.
+   */
   protected $_settings = [
+    // @todo remove these, define any not yet defined in the setting metadata.
     'mapAPIKey' => CRM_Core_BAO_Setting::MAP_PREFERENCES_NAME,
     'mapProvider' => CRM_Core_BAO_Setting::MAP_PREFERENCES_NAME,
     'geoAPIKey' => CRM_Core_BAO_Setting::MAP_PREFERENCES_NAME,

--- a/CRM/Admin/Form/Setting/Miscellaneous.php
+++ b/CRM/Admin/Form/Setting/Miscellaneous.php
@@ -20,7 +20,16 @@
  */
 class CRM_Admin_Form_Setting_Miscellaneous extends CRM_Admin_Form_Setting {
 
+  /**
+   * Subset of settings on the page as defined using the legacy method.
+   *
+   * @var array
+   *
+   * @deprecated - do not add new settings here - the page to display
+   * settings on should be defined in the setting metadata.
+   */
   protected $_settings = [
+    // @todo remove these, define any not yet defined in the setting metadata.
     'max_attachments' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
     'max_attachments_backend' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
     'contact_undelete' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,

--- a/CRM/Admin/Form/Setting/Path.php
+++ b/CRM/Admin/Form/Setting/Path.php
@@ -20,7 +20,16 @@
  */
 class CRM_Admin_Form_Setting_Path extends CRM_Admin_Form_Setting {
 
+  /**
+   * Subset of settings on the page as defined using the legacy method.
+   *
+   * @var array
+   *
+   * @deprecated - do not add new settings here - the page to display
+   * settings on should be defined in the setting metadata.
+   */
   protected $_settings = [
+    // @todo remove these, define any not yet defined in the setting metadata.
     'uploadDir' => CRM_Core_BAO_Setting::DIRECTORY_PREFERENCES_NAME,
     'imageUploadDir' => CRM_Core_BAO_Setting::DIRECTORY_PREFERENCES_NAME,
     'customFileUploadDir' => CRM_Core_BAO_Setting::DIRECTORY_PREFERENCES_NAME,

--- a/CRM/Admin/Form/Setting/Smtp.php
+++ b/CRM/Admin/Form/Setting/Smtp.php
@@ -20,7 +20,17 @@
  */
 class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
   protected $_testButtonName;
+
+  /**
+   * Subset of settings on the page as defined using the legacy method.
+   *
+   * @var array
+   *
+   * @deprecated - do not add new settings here - the page to display
+   * settings on should be defined in the setting metadata.
+   */
   protected $_settings = [
+    // @todo remove these, define any not yet defined in the setting metadata.
     'allow_mail_from_logged_in_contact' => CRM_Core_BAO_Setting::DIRECTORY_PREFERENCES_NAME,
   ];
 

--- a/CRM/Admin/Form/Setting/UF.php
+++ b/CRM/Admin/Form/Setting/UF.php
@@ -20,8 +20,6 @@
  */
 class CRM_Admin_Form_Setting_UF extends CRM_Admin_Form_Setting {
 
-  protected $_settings = [];
-
   protected $_uf = NULL;
 
   /**

--- a/CRM/Admin/Form/Setting/Url.php
+++ b/CRM/Admin/Form/Setting/Url.php
@@ -19,7 +19,17 @@
  * This class generates form components for Site Url.
  */
 class CRM_Admin_Form_Setting_Url extends CRM_Admin_Form_Setting {
+
+  /**
+   * Subset of settings on the page as defined using the legacy method.
+   *
+   * @var array
+   *
+   * @deprecated - do not add new settings here - the page to display
+   * settings on should be defined in the setting metadata.
+   */
   protected $_settings = [
+    // @todo remove these, define any not yet defined in the setting metadata.
     'disable_core_css' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
     'defaultExternUrl' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
     'userFrameworkResourceURL' => CRM_Core_BAO_Setting::URL_PREFERENCES_NAME,


### PR DESCRIPTION
Overview
----------------------------------------
Add comments to settings definition to clarify that this is not the preferred method

Before
----------------------------------------
Although we have been declaring settings location on front end forms via the setting metadata now it is easy to not realise that & add them to the setting forms

After
----------------------------------------
The setting forms make it clear the metadata should be used

Technical Details
----------------------------------------
Allowing people to define settings here means someone else has to come along later & add the missing metadata to the settings definition & remove them from here - we have been switching them over time but it is easier to do the switch if new ones don't keep getting added. I recently did the search form but it's definitely no the case when converting that having them all on the form is more work than having them in both places - I found that the more that are on the form the more work it is.

Comments
----------------------------------------
