### PR TITLE
Regression: fix CMS creation issue from profile

### DIFF
--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -886,10 +886,10 @@ class CRM_Profile_Form extends CRM_Core_Form {
     $this->setDefaultsValues();
 
     $action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, NULL);
+    $this->assign('showCMS', FALSE);
     if ($this->_mode == self::MODE_CREATE || $this->_mode == self::MODE_EDIT) {
       CRM_Core_BAO_CMSUser::buildForm($this, $this->_gid, $emailPresent, $action);
     }
-    $this->assign('showCMS', FALSE);
 
     $this->assign('groupId', $this->_gid);
 


### PR DESCRIPTION
Overview
----------------------------------------
https://civicrm.stackexchange.com/questions/46162/user-creation-feature-is-no-longer-visible

Before
----------------------------------------
<img width="518" alt="Screenshot 2024-01-11 at 11 29 23" src="https://github.com/civicrm/civicrm-core/assets/2053075/7b8f62c6-9108-4cf8-a4fe-3ee5024ab9d1">


After
----------------------------------------
<img width="874" alt="Screenshot 2024-01-11 at 11 27 45" src="https://github.com/civicrm/civicrm-core/assets/2053075/d10324f6-55e6-4ee9-b8b2-f6a32b1b6c61">


Comments
----------------------------------------
Regression from: https://github.com/civicrm/civicrm-core/pull/27960/files
