### PR TITLE
Fix fatal error when firebase/php-jwt library is 'replaced' in composer

### DIFF
--- a/Civi/Crypto/CryptoJwt.php
+++ b/Civi/Crypto/CryptoJwt.php
@@ -60,7 +60,12 @@ class CryptoJwt {
    * @throws CryptoException
    */
   public function decode($token, $keyTag = 'SIGN') {
-    $useKeyObj = version_compare(\Composer\InstalledVersions::getVersion('firebase/php-jwt'), '6', '>=');
+    // Version 6.x+ has 2 parameters, earlier versions had 3
+    $reflection = new \ReflectionMethod('Firebase\JWT\JWT::decode');
+    $useKeyObj = ($reflection->getNumberOfParameters() === 2) ?? FALSE;
+
+    // Composer\InstalledVersions returns 0 if the library has been replaced using "replace" in composer.json
+    // $useKeyObj = version_compare(\Composer\InstalledVersions::getVersion('firebase/php-jwt'), '6', '>=');
     if (!$useKeyObj) {
       \CRM_Core_Error::deprecatedWarning('Using deprecated version of firebase/php-jwt. Upgrade to 6.x+.');
     }


### PR DESCRIPTION
Overview
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/28055 updates recommended php-jwt to 6.x and handles a signature change on `JWT::decode` (old version 3 parameters, new version 2 parameters).
The problem is that the composer version check doesn't work if an extension also uses php-jwt (eg. https://github.com/mjwconsult/nz.co.fuzion.civixero/blob/mjw/composer.json#L7) because the check returns version = 0.

This PR performs a more direct check of the function to see if it actually is defined with 2 or 3 parameters which should never fail and is independent of the actual version.

Before
----------------------------------------
Crash due to library conflicts if firebase/php-jwt is required in more than one place.

After
----------------------------------------
No crash, breaking changes are inspected and handled.

Technical Details
----------------------------------------
#28055 was merged in 5.69 so this is a potencial issue from that version.

Comments
----------------------------------------

