### PR TITLE
Make error message more traceable

### DIFF
--- a/CRM/Event/Selector/Search.php
+++ b/CRM/Event/Selector/Search.php
@@ -329,7 +329,7 @@ class CRM_Event_Selector_Search extends CRM_Core_Selector_Base implements CRM_Co
 
       // Skip registration if event_id is NULL
       if (empty($row['event_id'])) {
-        Civi::log()->warning('Participant record without event ID. You have invalid data in your database!');
+        Civi::log()->warning('Participant record (' . $row['participant_id'] . ') without event ID. You have invalid data in your database!');
         continue;
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
I have a site which logs `Participant record without event ID. You have invalid data in your database!` every day or so. But the message doesn't make it very easy to trace because it provides no IDs.

Before
----------------------------------------
Hard to trace error message.

After
----------------------------------------
Error includes the participant_id that triggered the error. Easier to trace...

Technical Details
----------------------------------------


Comments
----------------------------------------
