### PR TITLE
dev/core#4905 - More efficient loading and caching of custom field metadata

### DIFF
--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -844,15 +844,13 @@ WHERE ($subtypeClause)";
       $dao = CRM_Core_DAO::executeQuery($query->toSQL());
       $contactTypes = array_column($dao->fetchAll(), NULL, 'name');
       $parents = array_column($contactTypes, NULL, 'id');
-      foreach ($contactTypes as $name => $contactType) {
-        $contactTypes[$name]['parent'] = $contactType['parent_id'] ? $parents[$contactType['parent_id']]['name'] : NULL;
-        $contactTypes[$name]['parent_label'] = $contactType['parent_id'] ? $parents[$contactType['parent_id']]['label'] : NULL;
+      foreach ($contactTypes as $name => &$contactType) {
         // Cast int/bool types.
-        $contactTypes[$name]['id'] = (int) $contactType['id'];
-        $contactTypes[$name]['parent_id'] = ((int) $contactType['parent_id']) ?: NULL;
-        $contactTypes[$name]['is_active'] = (bool) $contactType['is_active'];
-        $contactTypes[$name]['is_reserved'] = (bool) $contactType['is_reserved'];
-        $contactTypes[$name]['icon'] = $contactType['icon'] ?? $parents[$contactType['parent_id']]['icon'] ?? NULL;
+        self::formatFieldValues($contactType);
+        // Fill data from parents
+        $contactType['parent'] = $parents[$contactType['parent_id']]['name'] ?? NULL;
+        $contactType['parent_label'] = $parents[$contactType['parent_id']]['label'] ?? NULL;
+        $contactType['icon'] ??= $parents[$contactType['parent_id']]['icon'] ?? NULL;
       }
       $cache->set($cacheKey, $contactTypes);
     }

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -616,6 +616,47 @@ class CRM_Core_DAO extends DB_DataObject {
   }
 
   /**
+   * Format field values according to fields() metadata.
+   *
+   * When fetching results from a query, every field is returned as a string.
+   * This function automatically converts them to the correct data type.
+   *
+   * @param array $fieldValues
+   * @return void
+   */
+  public static function formatFieldValues(array &$fieldValues) {
+    $fields = array_column((array) static::fields(), NULL, 'name');
+    foreach ($fieldValues as $fieldName => $fieldValue) {
+      $fieldSpec = $fields[$fieldName] ?? NULL;
+      $fieldValues[$fieldName] = self::formatFieldValue($fieldValue, $fieldSpec);
+    }
+  }
+
+  /**
+   * Format a value according to field metadata.
+   *
+   * @param string|null $value
+   * @param array|null $fieldSpec
+   * @return mixed
+   */
+  protected static function formatFieldValue($value, ?array $fieldSpec) {
+    if (!isset($value) || !isset($fieldSpec)) {
+      return $value;
+    }
+    $dataType = $fieldSpec['type'] ?? NULL;
+    if ($dataType === CRM_Utils_Type::T_INT) {
+      return (int) $value;
+    }
+    if ($dataType === CRM_Utils_Type::T_BOOLEAN) {
+      return (bool) $value;
+    }
+    if (!empty($fieldSpec['serialize'])) {
+      return self::unSerializeField($value, $fieldSpec['serialize']);
+    }
+    return $value;
+  }
+
+  /**
    * Get/set an associative array of table columns
    *
    * @return array

--- a/Civi/Api4/Service/Schema/Joinable/CustomGroupJoinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/CustomGroupJoinable.php
@@ -56,9 +56,7 @@ class CustomGroupJoinable extends Joinable {
         continue;
       }
       foreach ($customGroup['fields'] as $fieldArray) {
-        $fieldArray['custom_group_id.name'] = $customGroup['name'];
-        $fieldArray['custom_group_id.title'] = $customGroup['title'];
-        $entityFields[] = SpecFormatter::arrayToField($fieldArray, $baseEntity);
+        $entityFields[] = SpecFormatter::arrayToField($fieldArray, $baseEntity, $customGroup);
       }
     }
     return $entityFields;

--- a/Civi/Api4/Service/Schema/Joinable/CustomGroupJoinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/CustomGroupJoinable.php
@@ -12,7 +12,7 @@
 
 namespace Civi\Api4\Service\Schema\Joinable;
 
-use Civi\Api4\CustomField;
+use Civi\Api4\Service\Spec\SpecFormatter;
 use Civi\Api4\Utils\CoreUtil;
 
 class CustomGroupJoinable extends Joinable {
@@ -50,18 +50,16 @@ class CustomGroupJoinable extends Joinable {
    * @inheritDoc
    */
   public function getEntityFields() {
-    $cacheKey = 'APIv4_CustomGroupJoinable-' . $this->getTargetTable();
-    $entityFields = (array) \Civi::cache('metadata')->get($cacheKey);
-    if (!$entityFields) {
-      $baseEntity = CoreUtil::getApiNameFromTableName($this->getBaseTable());
-      $fields = CustomField::get(FALSE)
-        ->setSelect(['custom_group_id.name', 'custom_group_id.extends', 'custom_group_id.table_name', 'custom_group_id.title', '*'])
-        ->addWhere('custom_group_id.table_name', '=', $this->getTargetTable())
-        ->execute();
-      foreach ($fields as $field) {
-        $entityFields[] = \Civi\Api4\Service\Spec\SpecFormatter::arrayToField($field, $baseEntity);
+    $baseEntity = CoreUtil::getApiNameFromTableName($this->getBaseTable());
+    foreach (\CRM_Core_BAO_CustomGroup::getActive() as $customGroup) {
+      if ($customGroup['table_name'] !== $this->getTargetTable()) {
+        continue;
       }
-      \Civi::cache('metadata')->set($cacheKey, $entityFields);
+      foreach ($customGroup['fields'] as $fieldArray) {
+        $fieldArray['custom_group_id.name'] = $customGroup['name'];
+        $fieldArray['custom_group_id.title'] = $customGroup['title'];
+        $entityFields[] = SpecFormatter::arrayToField($fieldArray, $baseEntity);
+      }
     }
     return $entityFields;
   }

--- a/Civi/Api4/Service/Schema/SchemaMapBuilder.php
+++ b/Civi/Api4/Service/Schema/SchemaMapBuilder.php
@@ -105,63 +105,44 @@ class SchemaMapBuilder extends AutoService {
     if (!$customInfo) {
       return;
     }
-    $select = ['f.name', 'f.data_type', 'f.label', 'f.column_name', 'f.option_group_id', 'f.serialize', 'f.fk_entity'];
-    // Prevent errors during upgrade by only selecting fields supported by the current version
-    $supportedFields = \CRM_Utils_Array::prefixKeys(\CRM_Core_BAO_CustomField::getSupportedFields(), 'f.');
-    $select = array_intersect($select, array_keys($supportedFields));
-    // Also select fields from the custom_group table (these fields are so old we don't have to worry about upgrade issues)
-    $select = array_merge(['g.name as custom_group_name', 'g.table_name', 'g.is_multiple'], $select);
-    $fieldData = \CRM_Utils_SQL_Select::from('civicrm_custom_field f')
-      ->join('custom_group', 'INNER JOIN civicrm_custom_group g ON g.id = f.custom_group_id')
-      ->select($select)
-      ->where('g.extends IN (@entity)', ['@entity' => $customInfo['extends']])
-      ->where('g.is_active')
-      ->where('f.is_active')
-      ->execute();
 
-    $links = [];
+    foreach (\CRM_Core_BAO_CustomGroup::getActive() as $customGroup) {
+      if (!$customGroup['fields'] || !in_array($customGroup['extends'], $customInfo['extends'])) {
+        continue;
+      }
+      $customTable = new Table($customGroup['table_name']);
 
-    while ($fieldData->fetch()) {
-      $tableName = $fieldData->table_name;
-
-      $customTable = $map->getTableByName($tableName);
-      if (!$customTable) {
-        $customTable = new Table($tableName);
-        // Add entity_id join from multi-record custom group to the
-        if (!empty($fieldData->is_multiple)) {
-          $newJoin = new Joinable($baseTable->getName(), $customInfo['column'], 'entity_id');
-          $customTable->addTableLink('entity_id', $newJoin);
-          // Deprecated "contact" join name
-          $oldJoin = new Joinable($baseTable->getName(), $customInfo['column'], AllCoreTables::convertEntityNameToLower($entityName));
-          $oldJoin->setDeprecatedBy('entity_id');
-          $customTable->addTableLink('entity_id', $oldJoin);
-        }
+      // Add entity_id join from multi-record custom group to the base entity
+      if (!empty($customGroup['is_multiple'])) {
+        $newJoin = new Joinable($baseTable->getName(), $customInfo['column'], 'entity_id');
+        $customTable->addTableLink('entity_id', $newJoin);
+        // Deprecated "contact" join name
+        $oldJoin = new Joinable($baseTable->getName(), $customInfo['column'], AllCoreTables::convertEntityNameToLower($entityName));
+        $oldJoin->setDeprecatedBy('entity_id');
+        $customTable->addTableLink('entity_id', $oldJoin);
       }
 
+      // Add joins for entityReference fields
+      foreach ($customGroup['fields'] as $field) {
+        if ($field['data_type'] === 'EntityReference' && isset($field['fk_entity'])) {
+          $targetTable = self::getTableName($field['fk_entity']);
+          $joinable = new Joinable($targetTable, 'id', $field['name']);
+          $customTable->addTableLink($field['column_name'], $joinable);
+        }
+
+        if ($field['data_type'] === 'ContactReference') {
+          $joinable = new Joinable('civicrm_contact', 'id', $field['name']);
+          if ($field['serialize']) {
+            $joinable->setSerialize((int) $field['serialize']);
+          }
+          $customTable->addTableLink($field['column_name'], $joinable);
+        }
+      }
       $map->addTable($customTable);
 
-      $alias = $fieldData->custom_group_name;
-      $links[$alias]['tableName'] = $tableName;
-      $links[$alias]['isMultiple'] = !empty($fieldData->is_multiple);
-      $links[$alias]['columns'][$fieldData->name] = $fieldData->column_name;
-
-      if ($fieldData->data_type === 'EntityReference' && isset($fieldData->fk_entity)) {
-        $targetTable = self::getTableName($fieldData->fk_entity);
-        $joinable = new Joinable($targetTable, 'id', $fieldData->name);
-        $customTable->addTableLink($fieldData->column_name, $joinable);
-      }
-
-      if ($fieldData->data_type === 'ContactReference') {
-        $joinable = new Joinable('civicrm_contact', 'id', $fieldData->name);
-        if ($fieldData->serialize) {
-          $joinable->setSerialize((int) $fieldData->serialize);
-        }
-        $customTable->addTableLink($fieldData->column_name, $joinable);
-      }
-    }
-
-    foreach ($links as $alias => $link) {
-      $joinable = new CustomGroupJoinable($link['tableName'], $alias, $link['isMultiple'], $link['columns']);
+      // Add custom join
+      $columns = array_column($customGroup['fields'], 'column_name', 'name');
+      $joinable = new CustomGroupJoinable($customGroup['table_name'], $customGroup['name'], $customGroup['is_multiple'], $columns);
       $baseTable->addTableLink($customInfo['column'], $joinable);
     }
   }

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -30,7 +30,7 @@ class SpecFormatter {
     // Custom field
     if (!empty($data['custom_group_id.name'])) {
       $field = new CustomFieldSpec($data['name'], $entityName, $dataTypeName);
-      if (strpos($entityName, 'Custom_') !== 0) {
+      if (!str_starts_with($entityName, 'Custom_')) {
         $field->setName($data['custom_group_id.name'] . '.' . $data['name']);
       }
       else {

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -28,7 +28,7 @@ class SpecFormatter {
 
     $hasDefault = isset($data['default']) && $data['default'] !== '';
     // Custom field
-    if (!empty($data['custom_group_id'])) {
+    if (!empty($data['custom_group_id.name'])) {
       $field = new CustomFieldSpec($data['name'], $entityName, $dataTypeName);
       if (strpos($entityName, 'Custom_') !== 0) {
         $field->setName($data['custom_group_id.name'] . '.' . $data['name']);
@@ -313,7 +313,7 @@ class SpecFormatter {
       $inputAttrs['step'] = $dataTypeName === 'Integer' ? 1 : .01;
     }
     // Date/time settings from custom fields
-    if ($inputType == 'Date' && !empty($data['custom_group_id'])) {
+    if ($inputType == 'Date' && !empty($data['custom_group_id.name'])) {
       $inputAttrs['time'] = empty($data['time_format']) ? FALSE : ($data['time_format'] == 1 ? 12 : 24);
       $inputAttrs['date'] = $data['date_format'];
       $inputAttrs['start_date_years'] = isset($data['start_date_years']) ? (int) $data['start_date_years'] : NULL;

--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -12,7 +12,6 @@
 
 namespace Civi\Api4\Service\Spec;
 
-use Civi\Api4\CustomField;
 use Civi\Api4\Service\Spec\Provider\Generic\SpecProviderInterface;
 use Civi\Api4\Utils\CoreUtil;
 use Civi\Core\Service\AutoService;
@@ -145,8 +144,6 @@ class SpecGatherer extends AutoService {
   private function addCustomFields(string $entity, RequestSpec $spec, bool $checkPermissions) {
     $values = $spec->getValues();
 
-    // Handle contact type pseudo-entities
-    $contactTypes = \CRM_Contact_BAO_ContactType::basicTypes();
     // If contact type is given
     if ($entity === 'Contact' && !empty($values['contact_type'])) {
       $entity = $values['contact_type'];
@@ -156,88 +153,77 @@ class SpecGatherer extends AutoService {
     if (!$customInfo) {
       return;
     }
-    $extends = $customInfo['extends'];
     $grouping = $customInfo['grouping'];
-    if ($entity === 'Contact' || in_array($entity, $contactTypes, TRUE)) {
+    if (CoreUtil::isContact($entity)) {
       $grouping = 'contact_sub_type';
     }
 
-    $query = CustomField::get(FALSE)
-      ->setSelect(['custom_group_id.name', 'custom_group_id.title', '*'])
-      ->addWhere('is_active', '=', TRUE)
-      ->addWhere('custom_group_id.is_active', '=', TRUE)
-      ->addWhere('custom_group_id.is_multiple', '=', FALSE);
-
-    // Enforce permissions
-    if ($checkPermissions && !\CRM_Core_Permission::customGroupAdmin()) {
-      $allowedGroups = \CRM_Core_Permission::customGroup();
-      if (!$allowedGroups) {
-        return;
-      }
-      $query->addWhere('custom_group_id', 'IN', $allowedGroups);
+    if ($checkPermissions) {
+      $permissionType = in_array($spec->getAction(), ['create', 'update', 'save', 'delete', 'replace']) ?
+        \CRM_Core_Permission::EDIT :
+        \CRM_Core_Permission::VIEW;
+      $customGroups = \CRM_Core_BAO_CustomGroup::getPermitted($permissionType);
+    }
+    else {
+      $customGroups = \CRM_Core_BAO_CustomGroup::getActive();
     }
 
-    if (is_string($grouping) && array_key_exists($grouping, $values)) {
-      if (empty($values[$grouping])) {
-        $query->addWhere('custom_group_id.extends_entity_column_value', 'IS EMPTY');
-      }
-      else {
-        $clause = [
-          ['custom_group_id.extends_entity_column_value', 'IS EMPTY'],
-        ];
-        foreach ((array) $values[$grouping] as $value) {
-          $clause[] = ['custom_group_id.extends_entity_column_value', 'CONTAINS', $value];
+    foreach ($customGroups as $customGroup) {
+      if ($this->customGroupBelongsTo($customGroup, $customInfo['extends'], $values, $grouping)) {
+        foreach ($customGroup['fields'] as $fieldArray) {
+          $fieldArray['custom_group_id.name'] = $customGroup['name'];
+          $fieldArray['custom_group_id.title'] = $customGroup['title'];
+          $field = SpecFormatter::arrayToField($fieldArray, $entity);
+          $spec->addFieldSpec($field);
         }
-        $query->addClause('OR', $clause);
       }
+    }
+  }
+
+  /**
+   * Check if custom group belongs to $extends entity and meets criteria from $values
+   */
+  private function customGroupBelongsTo(array $customGroup, array $extends, array $values, $grouping): bool {
+    if ($customGroup['is_multiple'] || !in_array($customGroup['extends'], $extends)) {
+      return FALSE;
+    }
+    // No values or grouping = no filtering needed
+    if (empty($values) ||
+      (empty($customGroup['extends_entity_column_value']) && empty($customGroup['extends_entity_column_id']))
+    ) {
+      return TRUE;
+    }
+    if (is_string($grouping) && array_key_exists($grouping, $values)) {
+      foreach ((array) $values[$grouping] as $value) {
+        if (in_array($value, $customGroup['extends_entity_column_value'])) {
+          return TRUE;
+        }
+      }
+      return empty($customGroup['extends_entity_column_value']);
     }
     // Handle multiple groupings
-    // (In core, only Participant custom fields have multiple groupings)
+    // (in core, only Participant custom fields have multiple groupings)
     elseif (is_array($grouping)) {
-      $clauses = [];
       foreach ($grouping as $columnId => $group) {
         if (array_key_exists($group, $values)) {
           if (empty($values[$group])) {
-            $clauses[] = [
-              'AND',
-              [
-                ['custom_group_id.extends_entity_column_id', '=', $columnId],
-                ['custom_group_id.extends_entity_column_value', 'IS EMPTY'],
-              ],
-            ];
-          }
-          else {
-            $clause = [];
-            foreach ((array) $values[$group] as $value) {
-              $clause[] = ['custom_group_id.extends_entity_column_value', 'CONTAINS', $value];
+            if (
+              !$customGroup['extends_entity_column_value'] &&
+              $customGroup['extends_entity_column_id'] == $columnId
+            ) {
+              return TRUE;
             }
-            $clauses[] = [
-              'AND',
-              [
-                ['custom_group_id.extends_entity_column_id', '=', $columnId],
-                ['OR', $clause],
-              ],
-            ];
+          }
+          elseif (
+            array_intersect((array) $values[$group], (array) $customGroup['extends_entity_column_value']) &&
+            $customGroup['extends_entity_column_id'] == $columnId
+          ) {
+            return TRUE;
           }
         }
       }
-      if ($clauses) {
-        $clauses[] = [
-          'AND',
-          [
-            ['custom_group_id.extends_entity_column_id', 'IS EMPTY'],
-            ['custom_group_id.extends_entity_column_value', 'IS EMPTY'],
-          ],
-        ];
-        $query->addClause('OR', $clauses);
-      }
     }
-    $query->addWhere('custom_group_id.extends', 'IN', $extends);
-
-    foreach ($query->execute() as $fieldArray) {
-      $field = SpecFormatter::arrayToField($fieldArray, $entity);
-      $spec->addFieldSpec($field);
-    }
+    return FALSE;
   }
 
   /**

--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -171,9 +171,7 @@ class SpecGatherer extends AutoService {
     foreach ($customGroups as $customGroup) {
       if ($this->customGroupBelongsTo($customGroup, $customInfo['extends'], $values, $grouping)) {
         foreach ($customGroup['fields'] as $fieldArray) {
-          $fieldArray['custom_group_id.name'] = $customGroup['name'];
-          $fieldArray['custom_group_id.title'] = $customGroup['title'];
-          $field = SpecFormatter::arrayToField($fieldArray, $entity);
+          $field = SpecFormatter::arrayToField($fieldArray, $entity, $customGroup);
           $spec->addFieldSpec($field);
         }
       }
@@ -235,10 +233,7 @@ class SpecGatherer extends AutoService {
       if ($customGroup['name'] === $customGroupName) {
         foreach ($customGroup['fields'] as $fieldArray) {
           if ($fieldArray['is_active']) {
-            $fieldArray['custom_group_id.name'] = $customGroup['name'];
-            $fieldArray['custom_group_id.table_name'] = $customGroup['table_name'];
-            $fieldArray['custom_group_id.title'] = $customGroup['title'];
-            $field = SpecFormatter::arrayToField($fieldArray, 'Custom_' . $customGroupName);
+            $field = SpecFormatter::arrayToField($fieldArray, 'Custom_' . $customGroupName, $customGroup);
             $specification->addFieldSpec($field);
           }
         }

--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -241,19 +241,23 @@ class SpecGatherer extends AutoService {
   }
 
   /**
-   * @param string $customGroup
+   * @param string $customGroupName
    * @param \Civi\Api4\Service\Spec\RequestSpec $specification
    */
-  private function getCustomGroupFields($customGroup, RequestSpec $specification) {
-    $customFields = CustomField::get(FALSE)
-      ->addWhere('custom_group_id.name', '=', $customGroup)
-      ->addWhere('is_active', '=', TRUE)
-      ->setSelect(['custom_group_id.name', 'custom_group_id.table_name', 'custom_group_id.title', '*'])
-      ->execute();
-
-    foreach ($customFields as $fieldArray) {
-      $field = SpecFormatter::arrayToField($fieldArray, 'Custom_' . $customGroup);
-      $specification->addFieldSpec($field);
+  private function getCustomGroupFields($customGroupName, RequestSpec $specification): void {
+    foreach (\CRM_Core_BAO_CustomGroup::getAll() as $customGroup) {
+      if ($customGroup['name'] === $customGroupName) {
+        foreach ($customGroup['fields'] as $fieldArray) {
+          if ($fieldArray['is_active']) {
+            $fieldArray['custom_group_id.name'] = $customGroup['name'];
+            $fieldArray['custom_group_id.table_name'] = $customGroup['table_name'];
+            $fieldArray['custom_group_id.title'] = $customGroup['title'];
+            $field = SpecFormatter::arrayToField($fieldArray, 'Custom_' . $customGroupName);
+            $specification->addFieldSpec($field);
+          }
+        }
+        return;
+      }
     }
   }
 

--- a/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTypeTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTypeTest.php
@@ -126,6 +126,9 @@ class CRM_Contact_BAO_ContactType_ContactTypeTest extends CiviUnitTestCase {
       'icon' => 'fa-random',
     ];
     $this->assertEquals($expected, $allTypes);
+    // Verify function returns field values formatted correctly by type
+    $this->assertTrue(is_int($allTypes['blah']['id']));
+    $this->assertFalse($allTypes['blah']['is_active']);
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -27,6 +27,26 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     parent::tearDown();
   }
 
+  public function testLoadAll(): void {
+    $this->quickCleanup([], TRUE);
+
+    $activeGroup = $this->CustomGroupCreate(['title' => 'ActiveGroup', 'weight' => 1]);
+    $this->customFieldCreate(['label' => 'Active', 'custom_group_id' => $activeGroup['id']]);
+    $this->customFieldCreate(['label' => 'Disabled', 'is_active' => 0, 'custom_group_id' => $activeGroup['id']]);
+
+    $inactiveGroup = $this->CustomGroupCreate(['title' => 'InactiveGroup', 'weight' => 2, 'is_active' => 0]);
+    $this->customFieldCreate(['label' => 'Inactive', 'custom_group_id' => $inactiveGroup['id']]);
+
+    $allGroups = CRM_Core_BAO_CustomGroup::getAll();
+    $activeGroups = CRM_Core_BAO_CustomGroup::getActive();
+
+    $this->assertCount(2, $allGroups);
+    $this->assertCount(2, $allGroups[0]['fields']);
+    $this->assertCount(1, $allGroups[1]['fields']);
+    $this->assertCount(1, $activeGroups);
+    $this->assertCount(1, $activeGroups[0]['fields']);
+  }
+
   /**
    * Test getTree().
    */

--- a/tests/phpunit/api/v4/Spec/SpecFormatterTest.php
+++ b/tests/phpunit/api/v4/Spec/SpecFormatterTest.php
@@ -43,14 +43,10 @@ class SpecFormatterTest extends Api4TestBase {
   }
 
   public function testCustomFieldWillBeReturned(): void {
-    $customGroupId = 1432;
     $customFieldId = 3333;
     $name = 'MyFancyField';
 
     $data = [
-      'custom_group_id' => $customGroupId,
-      'custom_group_id.name' => 'my_group',
-      'custom_group_id.title' => 'My Group',
       'id' => $customFieldId,
       'name' => $name,
       'label' => $name,
@@ -60,9 +56,13 @@ class SpecFormatterTest extends Api4TestBase {
       'serialize' => 1,
       'is_view' => FALSE,
     ];
+    $customGroup = [
+      'name' => 'my_group',
+      'title' => 'My Group',
+    ];
 
     /** @var \Civi\Api4\Service\Spec\CustomFieldSpec $field */
-    $field = SpecFormatter::arrayToField($data, 'TestEntity');
+    $field = SpecFormatter::arrayToField($data, 'TestEntity', $customGroup);
 
     $this->assertInstanceOf(CustomFieldSpec::class, $field);
     $this->assertEquals('my_group', $field->getCustomGroupName());


### PR DESCRIPTION
Overview
----------------------------------------
Significantly improves SearchKit & APIv4 performance by caching custom field metadata.
Starts cleaning up other places that fetch that same data.
See https://lab.civicrm.org/dev/core/-/issues/4905

Before
----------------------------------------
~~A dozen or so~~ maybe a hundred (I keep finding more) methods exist to gather custom field info, and all of them are pretty bad. Some don't cache at all, which hurts performance. Others do cache but still manage to be quite inefficient about it. Some are too limited in their abilities, others are hopelessly overcomplicated.

After
----------------------------------------
Ok ok, now there's [yet another one](https://imgs.xkcd.com/comics/standards_2x.png). But this is the ONE TRUE METHOD.

Technical Details
----------------------------------------
The ONE TRUE METHOD doesn't have any of the baggage or limitations of its predecessors. Most if not all of them should be deprecated & refactored to use the new method.
