### PR TITLE
Remove arguable statement about refunds

### DIFF
--- a/xml/templates/message_templates/participant_confirm_html.tpl
+++ b/xml/templates/message_templates/participant_confirm_html.tpl
@@ -176,7 +176,7 @@
   {if {event.allow_selfcancelxfer|boolean}}
    <tr>
      <td colspan="2" {$valueStyle}>
-       {ts 1=$selfcancelxfer_time 2=$selfservice_preposition}You may transfer your registration to another participant or cancel your registration up to %1 hours %2 the event.{/ts} {if $totalAmount}{ts}Cancellations are not refundable.{/ts}{/if}<br />
+       {ts 1=$selfcancelxfer_time 2=$selfservice_preposition}You may transfer your registration to another participant or cancel your registration up to %1 hours %2 the event.{/ts}<br />
          {capture assign=selfService}{crmURL p='civicrm/event/selfsvcupdate' q="reset=1&pid={participant.id}&{contact.checksum}"  h=0 a=1 fe=1}{/capture}
        <a href="{$selfService}">{ts}Click here to transfer or cancel your registration.{/ts}</a>
      </td>


### PR DESCRIPTION
Overview
----------------------------------------
Remove arguable statement about refunds

Before
----------------------------------------
Participant confirm email has this ` {if $totalAmount}{ts}Cancellations are not refundable.{/ts}{/if}` - from @demeritcowboy testing it probably doesn't really show up much as `$totalAmount` is likely not assigned. However, it seems waaay too presumptive of business rules for us to include this statement in the default templates that ship with core

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
