### PR TITLE
Remove check for core-error, never thrown

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1445,10 +1445,7 @@ UPDATE  civicrm_participant
           'is_test' => $participantValues['is_test'],
           'status_id' => 2,
         ];
-
-        if (is_a(CRM_Activity_BAO_Activity::create($activityParams), 'CRM_Core_Error')) {
-          throw new CRM_Core_Exception('Failed creating Activity for expiration mail');
-        }
+        CRM_Activity_BAO_Activity::create($activityParams);
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove check for core-error, never thrown

Before
----------------------------------------
We no longer throw `CRM_Core_Error` in create methods


After
----------------------------------------

Technical Details
----------------------------------------

Comments
----------------------------------------
