### PR TITLE
Minor clean up in test class

### DIFF
--- a/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
@@ -16,9 +16,16 @@
  */
 class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
 
+  /**
+   * API version in use.
+   *
+   * @var int
+   */
+  protected $_apiversion = 4;
+
   public function setUp(): void {
     parent::setUp();
-    $this->ids['Contact']['individual_0'] = $this->individualCreate();
+    $this->individualCreate();
     $this->eventCreateUnpaid();
   }
 
@@ -69,9 +76,6 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
     $this->assertDBCompareValue('CRM_Event_BAO_Participant', $updatedParticipant->id, 'status_id',
       'id', 3, 'Check DB for updated status id  of the participant'
     );
-
-    $this->contactDelete($this->ids['Contact']['individual_0']);
-    $this->eventDelete($this->getEventID());
   }
 
   /**
@@ -93,7 +97,7 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
       'register_date' => '2007-02-19 00:00:00',
       'role_id' => 1,
       'status_id' => 2,
-      'source' => 'Wimbeldon',
+      'source' => 'Wimbledon',
       'contact_id' => $this->ids['Contact']['individual_0'],
       'id' => $participantID,
       'campaign_id' => NULL,
@@ -114,10 +118,6 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
         $this->assertEquals($compareValues->$key, $params[$key], 'Check for ' . $key . ' for given participant');
       }
     }
-
-    $this->participantDelete($participantID);
-    $this->contactDelete($this->ids['Contact']['individual_0']);
-    $this->eventDelete($this->getEventID());
   }
 
   /**
@@ -134,20 +134,15 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
    * EventFull() method (checking the event for full).
    */
   public function testEventFull(): void {
-    $eventParams = [
+    $this->callAPISuccess('Event', 'update', [
       'max_participants' => 1,
       'id' => $this->getEventID(),
-    ];
-    CRM_Event_BAO_Event::add($eventParams);
+    ]);
 
-    $participantId = $this->participantCreate(['contact_id' => $this->ids['Contact']['individual_0'], 'event_id' => $this->getEventID()]);
+    $this->participantCreate(['contact_id' => $this->ids['Contact']['individual_0'], 'event_id' => $this->getEventID()]);
     $eventFull = CRM_Event_BAO_Participant::eventFull($this->getEventID());
 
     $this->assertEquals('Sorry! We are already full', $eventFull, 'Checking if Event is full.');
-
-    $this->participantDelete($participantId);
-    $this->contactDelete($this->ids['Contact']['individual_0']);
-    $this->eventDelete($this->getEventID());
   }
 
   /**
@@ -156,9 +151,6 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
   public function testImportableFields(): void {
     $importableFields = CRM_Event_BAO_Participant::importableFields();
     $this->assertNotCount(0, $importableFields, 'Checking array not to be empty.');
-
-    $this->contactDelete($this->ids['Contact']['individual_0']);
-    $this->eventDelete($this->getEventID());
   }
 
   /**
@@ -173,17 +165,13 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
     $this->assertCount(3, $participantDetails, 'Equating the array contains.');
     $this->assertEquals($participantDetails['name'], $params['name'], 'Checking Name of Participant.');
     $this->assertEquals($participantDetails['title'], $params['title'], 'Checking Event Title in which participant is enrolled.');
-
-    $this->participantDelete($participant['id']);
-    $this->contactDelete($this->ids['Contact']['individual_0']);
-    $this->eventDelete($this->getEventID());
   }
 
   /**
    * DeleteParticipant() method.
    */
   public function testDeleteParticipant(): void {
-    $params = [
+    $this->createTestEntity('Participant', [
       'send_receipt' => 1,
       'is_test' => 0,
       'is_pay_later' => 0,
@@ -193,24 +181,9 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
       'status_id' => 1,
       'source' => 'Event_' . $this->getEventID(),
       'contact_id' => $this->ids['Contact']['individual_0'],
-    ];
-
-    // New Participant Created
-    $participant = CRM_Event_BAO_Participant::add($params);
-
-    $this->assertDBNotNull('CRM_Event_BAO_Participant', $this->ids['Contact']['individual_0'], 'id',
-      'contact_id', 'Check DB for Participant of the contact'
-    );
-
-    $this->assertDBCompareValue('CRM_Event_BAO_Participant', $participant->id, 'contact_id',
-      'id', $this->ids['Contact']['individual_0'], 'Check DB for contact of the participant'
-    );
-
-    CRM_Event_BAO_Participant::deleteParticipant($participant->id);
-    $this->assertDBNull('CRM_Event_BAO_Participant', $participant->id, 'contact_id', 'id', 'Check DB for deleted Participant.');
-
-    $this->contactDelete($this->ids['Contact']['individual_0']);
-    $this->eventDelete($this->getEventID());
+    ]);
+    CRM_Event_BAO_Participant::deleteParticipant($this->ids['Participant']['default']);
+    $this->assertDBNull('CRM_Event_BAO_Participant', $this->ids['Participant']['default'], 'contact_id', 'id', 'Check DB for deleted Participant.');
   }
 
   /**
@@ -292,15 +265,6 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
     //Checking for participant contact_id added to activity target.
     $params_activity = ['contact_id' => $this->ids['Contact']['individual_0'], 'record_type_id' => 3];
     $this->assertDBCompareValues('CRM_Activity_DAO_ActivityContact', $params_activity, $params_activity);
-
-    //Deleting the Participant created by create function in this function
-    CRM_Event_BAO_Participant::deleteParticipant($participant->id);
-    $this->assertDBNull('CRM_Event_DAO_Participant', $this->ids['Contact']['individual_0'], 'id',
-      'contact_id', 'Check DB for deleted participant. Should be NULL.'
-    );
-
-    $this->contactDelete($this->ids['Contact']['individual_0']);
-    $this->eventDelete($this->getEventID());
   }
 
   /**
@@ -309,9 +273,6 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
   public function testExportableFields(): void {
     $exportableFields = CRM_Event_BAO_Participant::exportableFields();
     $this->assertNotCount(0, $exportableFields, 'Checking array not to be empty.');
-
-    $this->contactDelete($this->ids['Contact']['individual_0']);
-    $this->eventDelete($this->getEventID());
   }
 
   /**
@@ -335,7 +296,7 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
    * @param bool $isBackOffice
    * @param bool $successExpected  A boolean that indicates whether this test should pass or fail.
    */
-  public function testGetSelfServiceEligibility(int $selfSvcEnabled, int $selfSvcHours, $hoursToEvent, $participantStatusID, bool $isBackOffice, bool $successExpected): void {
+  public function testGetSelfServiceEligibility(int $selfSvcEnabled, int $selfSvcHours, int $hoursToEvent, int $participantStatusID, bool $isBackOffice, bool $successExpected): void {
     $participantId = $this->participantCreate(['contact_id' => $this->ids['Contact']['individual_0'], 'event_id' => $this->getEventID(), 'status_id' => $participantStatusID]);
     $now = new Datetime();
     if ($hoursToEvent >= 0) {

--- a/tests/phpunit/CRM/Event/Form/Task/BadgeTest.php
+++ b/tests/phpunit/CRM/Event/Form/Task/BadgeTest.php
@@ -95,7 +95,7 @@ class CRM_Event_Form_Task_BadgeTest extends CiviUnitTestCase {
       '{participant.status_id}' => 2,
       '{participant.role_id}' => 1,
       '{participant.register_date}' => 'February 19th, 2007',
-      '{participant.source}' => 'Wimbeldon',
+      '{participant.source}' => 'Wimbledon',
       '{participant.fee_level}' => 'low',
       '{participant.fee_amount}' => '$0.00',
       '{participant.registered_by_id}' => NULL,

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -709,7 +709,7 @@ contribution_recur.payment_instrument_id:name :Check
     return "participant.status_id :2
 participant.role_id :1
 participant.register_date :February 19th, 2007
-participant.source :Wimbeldon
+participant.source :Wimbledon
 participant.fee_level :steep
 participant.fee_amount :$50.00
 participant.registered_by_id :

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -781,7 +781,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       'status_id' => 2,
       'role_id' => 1,
       'register_date' => 20070219,
-      'source' => 'Wimbeldon',
+      'source' => 'Wimbledon',
       'event_level' => 'Payment',
       'debug' => 1,
     ];

--- a/tests/phpunit/api/v3/ParticipantTest.php
+++ b/tests/phpunit/api/v3/ParticipantTest.php
@@ -166,7 +166,7 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess('participant', 'get', $params);
     $this->assertEquals($result['values'][$this->ids['Participant']['primary']]['event_id'], $this->getEventID());
     $this->assertEquals('2007-02-19 00:00:00', $result['values'][$this->ids['Participant']['primary']]['participant_register_date']);
-    $this->assertEquals('Wimbeldon', $result['values'][$this->ids['Participant']['primary']]['participant_source']);
+    $this->assertEquals('Wimbledon', $result['values'][$this->ids['Participant']['primary']]['participant_source']);
     $params = [
       'id' => $this->ids['Participant']['primary'],
       'return' => 'id,participant_register_date,event_id',
@@ -210,7 +210,7 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess('participant', 'get', $params);
     $this->assertEquals($result['values'][$this->ids['Participant']['primary']]['event_id'], $this->getEventID());
     $this->assertEquals('2007-02-19 00:00:00', $result['values'][$this->ids['Participant']['primary']]['participant_register_date']);
-    $this->assertEquals('Wimbeldon', $result['values'][$this->ids['Participant']['primary']]['participant_source']);
+    $this->assertEquals('Wimbledon', $result['values'][$this->ids['Participant']['primary']]['participant_source']);
     $this->assertEquals($result['id'], $result['values'][$this->ids['Participant']['primary']]['id']);
   }
 
@@ -232,7 +232,7 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess('Participant', 'get', $params)['values'];
     $this->assertEquals($this->getEventID(), $result[$this->ids['Participant']['primary']]['event_id']);
     $this->assertEquals('2007-02-19 00:00:00', $result[$this->ids['Participant']['primary']]['participant_register_date']);
-    $this->assertEquals('Wimbeldon', $result[$this->ids['Participant']['primary']]['participant_source']);
+    $this->assertEquals('Wimbledon', $result[$this->ids['Participant']['primary']]['participant_source']);
     $this->assertEquals($this->getEventID(), $result[$this->ids['Participant']['primary']]['api.event.get']['id']);
   }
 
@@ -262,7 +262,7 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
     $this->assertEquals($this->ids['Participant']['primary'], $participant['id']);
     $this->assertEquals($this->getEventID(), $participant['values'][$participant['id']]['event_id']);
     $this->assertEquals('2007-02-19 00:00:00', $participant['values'][$participant['id']]['participant_register_date']);
-    $this->assertEquals('Wimbeldon', $participant['values'][$participant['id']]['participant_source']);
+    $this->assertEquals('Wimbledon', $participant['values'][$participant['id']]['participant_source']);
     $this->assertEquals($participant['id'], $participant['values'][$participant['id']]['id']);
   }
 
@@ -312,7 +312,7 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
     $participant = $this->callAPISuccess('Participant', 'get', $params);
     $this->assertEquals($participant['values'][$this->ids['Participant']['primary']]['event_id'], $this->getEventID());
     $this->assertEquals('2007-02-19 00:00:00', $participant['values'][$this->ids['Participant']['primary']]['participant_register_date']);
-    $this->assertEquals('Wimbeldon', $participant['values'][$this->ids['Participant']['primary']]['participant_source']);
+    $this->assertEquals('Wimbledon', $participant['values'][$this->ids['Participant']['primary']]['participant_source']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This notably removes some of the in-test cleanup - which is also done in the `tearDown` & is more reliable there. BAO crud entities are not called unless being specifically tested