### PR TITLE
dev/core#4907 Include participant role filter in apiv4 event available spaces calculation

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -315,8 +315,7 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant implements \Ci
    *                 calculation or not. (it is for cron job  purpose)
    *
    * @param bool $returnWaitingCount
-   * @param bool $considerTestParticipant
-   *   When TRUE, include participant records where is_test = 1.
+   * @param bool $considerTestParticipant deprecated, unused
    * @param bool $onlyPositiveStatuses
    *   When FALSE, count all participant statuses where is_counted = 1.  This includes
    *   both "Positive" participants (Registered, Attended, etc.) and waitlisted
@@ -325,6 +324,7 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant implements \Ci
    *
    * @return bool|int|null|string
    *   1. false                 => If event having some empty spaces.
+   * @throws \CRM_Core_Exception
    */
   public static function eventFull(
     $eventId,
@@ -345,28 +345,16 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant implements \Ci
     // It might be case there are some empty spaces and still event
     // is full, as waitlist might represent group require spaces > empty.
 
-    $participantRoles = CRM_Event_PseudoConstant::participantRole(NULL, 'filter = 1');
-    $countedStatuses = CRM_Event_PseudoConstant::participantStatus(NULL, 'is_counted = 1');
+    $countedStatuses = \CRM_Event_BAO_Participant::buildOptions('status_id', NULL, ['is_counted' => 1]);;
     $positiveStatuses = CRM_Event_PseudoConstant::participantStatus(NULL, "class = 'Positive'");
     $waitingStatuses = CRM_Event_PseudoConstant::participantStatus(NULL, "class = 'Waiting'");
     $onWaitlistStatusId = array_search('On waitlist', $waitingStatuses);
 
-    $where = [' event.id = %1 '];
-    if (!$considerTestParticipant) {
-      $where[] = ' participant.is_test = 0 ';
+    $where = [' event.id = %1 ', ' participant.is_test = 0 '];
+    $participantRoleClause = self::getParticipantRoleClause();
+    if ($participantRoleClause) {
+      $where[] = " participant.role_id " . $participantRoleClause;
     }
-
-    // Only count Participant Roles with the "Counted?" flag.
-    if (!empty($participantRoles)) {
-      $escapedRoles = [];
-      foreach (array_keys($participantRoles) as $participantRole) {
-        $escapedRoles[] = CRM_Utils_Type::escape($participantRole, 'String');
-      }
-
-      $regexp = "([[:cntrl:]]|^)" . implode('([[:cntrl:]]|$)|([[:cntrl:]]|^)', $escapedRoles) . "([[:cntrl:]]|$)";
-      $where[] = " participant.role_id REGEXP '{$regexp}'";
-    }
-
     $eventParams = [1 => [$eventId, 'Positive']];
 
     //in case any waiting, straight forward event is full.
@@ -378,22 +366,18 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant implements \Ci
       $eventSeatsWhere = implode(' AND ', $where) . " AND ( participant.status_id = $onWaitlistStatusId )";
 
       $query = "
-    SELECT  participant.id id,
-            event.event_full_text as event_full_text
+    SELECT  participant.id id
       FROM  civicrm_participant participant
 INNER JOIN  civicrm_event event ON ( event.id = participant.event_id )
             {$whereClause}";
 
-      $eventFullText = ts('This event is full.');
-      $participants = CRM_Core_DAO::executeQuery($query, $eventParams);
-      while ($participants->fetch()) {
+      $hasWaitlistedParticipants = CRM_Core_DAO::singleValueQuery($query, $eventParams);
+      if ($hasWaitlistedParticipants) {
         //oops here event is full and we don't want waiting count.
         if ($returnWaitingCount) {
           return CRM_Event_BAO_Event::eventTotalSeats($eventId, $eventSeatsWhere);
         }
-        else {
-          return ($participants->event_full_text) ? $participants->event_full_text : $eventFullText;
-        }
+        return CRM_Core_DAO::singleValueQuery('SELECT event_full_text FROM civicrm_event WHERE id = ' . (int) $eventId) ?: ts('This event is full.');
       }
     }
 
@@ -1784,12 +1768,18 @@ WHERE    civicrm_participant.contact_id = {$contactID} AND
   public static function buildOptions($fieldName, $context = NULL, $props = []) {
     $params = ['condition' => []];
 
-    if ($fieldName == 'status_id' && $context != 'validate') {
+    if ($fieldName === 'status_id' && $context !== 'validate') {
       // Get rid of cart-related option if disabled
       // FIXME: Why does this option even exist if cart is disabled?
       if (!Civi::settings()->get('enable_cart')) {
         $params['condition'][] = "name <> 'Pending in cart'";
       }
+    }
+    if ($fieldName === 'status_id' && isset($props['is_counted'])) {
+      $params['condition'][] = 'is_counted = ' . $props['is_counted'];
+    }
+    if ($fieldName === 'role_id' && isset($props['filter'])) {
+      $params['condition'][] = 'filter = ' . $props['filter'];
     }
 
     return CRM_Core_PseudoConstant::get(__CLASS__, $fieldName, $params, $context);
@@ -1932,6 +1922,34 @@ WHERE    civicrm_participant.contact_id = {$contactID} AND
         }
       }
     }
+  }
+
+  /**
+   * Get the clause to exclude uncounted participant roles.
+   *
+   * @internal do not call from outside core code.
+   *
+   * @return string
+   * @throws \CRM_Core_Exception
+   */
+  public static function getParticipantRoleClause(): string {
+    // Only count Participant Roles with the "Counted?" flag.
+    $participantRoles = self::buildOptions('role_id', NULL, ['filter' => TRUE]);
+    $allRoles = self::buildOptions('role_id');
+    if ($participantRoles === $allRoles) {
+      // Don't complicate the query if no roles are excluded.
+      return '';
+    }
+    if (!empty($participantRoles)) {
+      $escapedRoles = [];
+      foreach (array_keys($participantRoles) as $participantRole) {
+        $escapedRoles[] = CRM_Utils_Type::escape($participantRole, 'String');
+      }
+
+      $regexp = "([[:cntrl:]]|^)" . implode('([[:cntrl:]]|$)|([[:cntrl:]]|^)', $escapedRoles) . "([[:cntrl:]]|$)";
+      $participantRoleClause = "REGEXP '{$regexp}'";
+    }
+    return $participantRoleClause ?? '';
   }
 
 }

--- a/ext/civi_event/Civi/Api4/Service/Spec/Provider/EventGetSpecProvider.php
+++ b/ext/civi_event/Civi/Api4/Service/Spec/Provider/EventGetSpecProvider.php
@@ -48,12 +48,26 @@ class EventGetSpecProvider extends \Civi\Core\Service\AutoService implements Gen
    * @param array $maxField
    * @param \Civi\Api4\Query\Api4SelectQuery $query
    * return string
+   *
+   * @throws \CRM_Core_Exception
    */
   public static function getRemainingParticipants(array $maxField, Api4SelectQuery $query): string {
-    $statuses = \CRM_Event_PseudoConstant::participantStatus(NULL, 'is_counted = 1');
+    $statuses = \CRM_Event_BAO_Participant::buildOptions('status_id', NULL, ['is_counted' => 1]);
     $statusIds = implode(',', array_keys($statuses));
     $idField = $query->getFieldSibling($maxField, 'id');
-    return "IF($maxField[sql_name], (CAST($maxField[sql_name] AS SIGNED) - (SELECT COUNT(`p`.`id`) FROM `civicrm_participant` `p`, `civicrm_contact` `c` WHERE `p`.`event_id` = $idField[sql_name] AND `p`.`contact_id` = `c`.`id` AND `p`.`is_test` = 0 AND `c`.`is_deleted` = 0 AND `p`.status_id IN ($statusIds))), NULL)";
+    $whereClauses = [
+      '`p`.`event_id` = ' . $idField['sql_name'],
+      '`p`.`contact_id` = `c`.`id`',
+      '`p`.`is_test` = 0',
+      '`c`.`is_deleted` = 0',
+      "`p`.status_id IN ($statusIds)",
+    ];
+    $participantRoleClause = \CRM_Event_BAO_Participant::getParticipantRoleClause();
+    if ($participantRoleClause) {
+      $whereClauses[] = 'role_id ' . $participantRoleClause;
+    }
+    return "IF($maxField[sql_name], (CAST($maxField[sql_name] AS SIGNED) - (SELECT COUNT(`p`.`id`) FROM `civicrm_participant` `p`, `civicrm_contact` `c`
+      WHERE " . implode(' AND ', $whereClauses) . ")), NULL)";
   }
 
 }

--- a/ext/civi_event/Civi/Api4/Service/Spec/Provider/EventGetSpecProvider.php
+++ b/ext/civi_event/Civi/Api4/Service/Spec/Provider/EventGetSpecProvider.php
@@ -52,7 +52,7 @@ class EventGetSpecProvider extends \Civi\Core\Service\AutoService implements Gen
    * @throws \CRM_Core_Exception
    */
   public static function getRemainingParticipants(array $maxField, Api4SelectQuery $query): string {
-    $statuses = \CRM_Event_BAO_Participant::buildOptions('status_id', NULL, ['is_counted' => 1]);
+    $statuses = \CRM_Event_BAO_Participant::buildOptions('status_id', NULL, ['is_counted' => 1]) ?: [0];
     $statusIds = implode(',', array_keys($statuses));
     $idField = $query->getFieldSibling($maxField, 'id');
     $whereClauses = [


### PR DESCRIPTION
…



Overview
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/4907 there are a bunch of inconsistencies in the determination of how many spaces remain on the event. This addresses 1 - ie the apiv4 does not give due attention to whether the role should be counted or not. It also does some refactoring in the eventFull function, towards future sanity

Before
----------------------------------------
APIv4 does not consider whether participant roles should be counted when determining available spaces

After
----------------------------------------
participant roles with is_filter = 0 excluded from the count

Technical Details
----------------------------------------

Comments
----------------------------------------
