### PR TITLE
dev/core#4907 Form-layer consolidation on getting the number of spaces for the event

### DIFF
--- a/CRM/Event/Form/EventFormTrait.php
+++ b/CRM/Event/Form/EventFormTrait.php
@@ -30,6 +30,14 @@ trait CRM_Event_Form_EventFormTrait {
    */
   public function getEventValue(string $fieldName) {
     if ($this->isDefined('Event')) {
+      if ($fieldName === 'available_spaces') {
+        // This is temporary. Apiv4 returns available_spaces as a calculated field.
+        // However, there is not total parity between it and the old function.
+        // That needs to be worked through - per https://lab.civicrm.org/dev/core/-/issues/4907
+        // In order to allow the forms to switch over to the 'final' signature we
+        // re-direct to the old function for now.
+        return $this->getAvailableSpaces();
+      }
       return $this->lookup('Event', $fieldName);
     }
     $id = $this->getEventID();
@@ -90,6 +98,24 @@ trait CRM_Event_Form_EventFormTrait {
       return $this->lookup('Participant', $fieldName);
     }
     return NULL;
+  }
+
+  /**
+   * Get the number of available spaces in the given event.
+   *
+   * @internal this is a transitional function - eventually it will be removed
+   * and the api will handle it.
+   *
+   * @return int
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function getAvailableSpaces(): int {
+    $availableSpaces = CRM_Event_BAO_Participant::eventFull($this->getEventID(),
+      TRUE,
+      $this->getEventValue('has_waitlist')
+    );
+    return is_numeric($availableSpaces) ? (int) $availableSpaces : 0;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4907 Form-layer consolidation on getting the number of spaces for the event

Before
----------------------------------------
`CRM_Event_BAO_Participant::eventFull()` is called 12 times with a mixture of parameters & a mixture of results. One of the anomalies is that sometimes it returns text rather than a number. This fixes one of those places (the event info screen) to NOT expect text to be returned (which seems like an antipattern)

After
----------------------------------------
Unchanged UI 

![image](https://github.com/civicrm/civicrm-core/assets/336308/e72554d9-dcc5-4fdd-9182-8bdce2ebf396)

Technical Details
----------------------------------------
In the medium term we want the form layer to use apiv4 to get the available_spaces. The parity is not there at the moment - partly as fixed in https://github.com/civicrm/civicrm-core/pull/28983 but there is also some other stuff going on that does give me confidence they are like for like. However, we can update the forms to call `getEventValue('available_spaces')` & it will use the old method for now but once we are confident we can just remove this extra temporary wrangling from this one place

I also added the `getPriceSetID()` function for consistency with similar forms

Comments
----------------------------------------
