### PR TITLE
Fix handling for available registrations in event Register::formRule

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1228,6 +1228,22 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
   }
 
   /**
+   * Get the number of available spaces in the given event.
+   *
+   * @internal this is a transitional function to handle this form's
+   * odd behaviour whereby sometimes the fetched value is text. We need to wean
+   * the places that access it off this...
+   *
+   * @return int
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function getAvailableSpaces(): int {
+    // non numeric would be 'event full text'....
+    return is_numeric($this->_availableRegistrations) ? (int) $this->_availableRegistrations : 0;
+  }
+
+  /**
    * Validate price set submitted params for price option limit.
    *
    * User should select at least one price field option.

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -803,12 +803,12 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     if (!$form->_skipDupeRegistrationCheck) {
       self::checkRegistration($fields, $form);
     }
+    $spacesAvailable = $form->getEventValue('available_spaces');
     //check for availability of registrations.
     if (!$form->_allowConfirmation && empty($fields['bypass_payment']) &&
-      is_numeric($form->_availableRegistrations) &&
-      CRM_Utils_Array::value('additional_participants', $fields) >= $form->_availableRegistrations
+      ($fields['additional_participants'] ?? 0) >= $spacesAvailable
     ) {
-      $errors['additional_participants'] = ts("There is only enough space left on this event for %1 participant(s).", [1 => $form->_availableRegistrations]);
+      $errors['additional_participants'] = ts("There is only enough space left on this event for %1 participant(s).", [1 => $spacesAvailable]);
     }
 
     $numberAdditionalParticipants = $fields['additional_participants'] ?? 0;
@@ -827,8 +827,8 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
 
     //don't allow to register w/ waiting if enough spaces available.
     if (!empty($fields['bypass_payment']) && $form->_allowConfirmation) {
-      if (!is_numeric($form->_availableRegistrations) ||
-        (empty($fields['priceSetId']) && CRM_Utils_Array::value('additional_participants', $fields) < $form->_availableRegistrations)
+      if ($spacesAvailable === 0 ||
+        (empty($fields['priceSetId']) && CRM_Utils_Array::value('additional_participants', $fields) < $spacesAvailable)
       ) {
         $errors['bypass_payment'] = ts("You have not been added to the waiting list because there are spaces available for this event. We recommend registering yourself for an available space instead.");
       }
@@ -854,10 +854,9 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
 
       if (empty($fields['bypass_payment']) &&
         !$form->_allowConfirmation &&
-        is_numeric($form->_availableRegistrations) &&
-        $form->_availableRegistrations < $totalParticipants
+        $spacesAvailable < $totalParticipants
       ) {
-        $errors['_qf_default'] = ts("Only %1 Registrations available.", [1 => $form->_availableRegistrations]);
+        $errors['_qf_default'] = ts("Only %1 Registrations available.", [1 => $spacesAvailable]);
       }
 
       $lineItem = [];


### PR DESCRIPTION
Overview
----------------------------------------
Fix handling for available registrations in Register::formRule

Before
----------------------------------------
There is an anti-pattern where `$this->_availableRegistrations` is text when there are no available spaces - but only if there is a waitlist. This leads to quite a bit of wrangling in the code that handles it & is also crazy. But there are quite a few places & they can be a bit head hurty so this uses a local variable to tackle one set of them - once https://github.com/civicrm/civicrm-core/pull/28984 is merged I can iterate on the transitional method

After
----------------------------------------
local variable used in form rule to handle non-numeric exactly once

Technical Details
----------------------------------------

Comments
----------------------------------------
