### PR TITLE
dev/core#4905 - Deprecate redundant functions that fetch custom groups

### DIFF
--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -417,18 +417,18 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
     }
 
     // now add all the custom tabs
-    $entityType = $this->get('contactType');
-    $activeGroups = CRM_Core_BAO_CustomGroup::getActiveGroups(
-      $entityType,
-      'civicrm/contact/view/cd',
-      $this->_contactId
-    );
+    $extends = ['Contact', $this->get('contactType')];
+    $style = ['Tab', 'Tab with table'];
+    $activeGroups = CRM_Core_BAO_CustomGroup::getPermitted(CRM_Core_Permission::VIEW);
 
     foreach ($activeGroups as $group) {
+      if (!in_array($group['extends'], $extends) || !in_array($group['style'], $style)) {
+        continue;
+      }
       $id = "custom_{$group['id']}";
       $allTabs[] = [
         'id' => $id,
-        'url' => CRM_Utils_System::url($group['path'], $group['query'] . "&selectedChild=$id"),
+        'url' => CRM_Utils_System::url('civicrm/contact/view/cd', "reset=1&gid={$group['id']}&cid={$this->_contactId}&selectedChild=$id"),
         'title' => $group['title'],
         'weight' => $weight,
         'count' => NULL,

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1195,19 +1195,11 @@ ORDER BY civicrm_custom_group.weight,
   }
 
   /**
-   * Get the table name for the entity type
-   * currently if entity type is 'Contact', 'Individual', 'Household', 'Organization'
-   * tableName is 'civicrm_contact'
-   *
-   * @param string $entityType
-   *   What entity are we extending here ?.
-   *
-   * @return string
-   *
-   *
-   * @see _apachesolr_civiAttachments_dereference_file_parent
+   * Unused function.
+   * @deprecated since 5.71 will be removed around 5.85
    */
   public static function getTableNameByEntityName($entityType) {
+    CRM_Core_Error::deprecatedFunctionWarning('CoreUtil::getTableName');
     switch ($entityType) {
       case 'Contact':
       case 'Individual':

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1154,13 +1154,10 @@ ORDER BY civicrm_custom_group.weight,
   }
 
   /**
-   * @param $entityType
-   * @param $path
-   * @param string $cidToken
-   *
-   * @return array
+   * @deprecated since 5.71, will be removed around 5.85
    */
   public static function &getActiveGroups($entityType, $path, $cidToken = '%%cid%%') {
+    CRM_Core_Error::deprecatedFunctionWarning('CRM_Core_BAO_CustomGroup::getPermitted');
     // for Group's
     $customGroupDAO = new CRM_Core_DAO_CustomGroup();
 

--- a/Civi/API/Subscriber/DynamicFKAuthorization.php
+++ b/Civi/API/Subscriber/DynamicFKAuthorization.php
@@ -14,8 +14,13 @@ namespace Civi\API\Subscriber;
 use Civi\API\Events;
 use CRM_Core_DAO_AllCoreTables as AllCoreTables;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Civi\Api4\Utils\CoreUtil;
 
 /**
+ * This is only used by the APIv3 "Attachment" entity.
+ *
+ * @deprecated APIv3 only.
+ *
  * Given an entity which dynamically attaches itself to another entity,
  * determine if one has permission to the other entity.
  *
@@ -362,7 +367,7 @@ class DynamicFKAuthorization implements EventSubscriberInterface {
         'field_name' => $query->field_name,
         'table_name' => $query->table_name,
         'extends' => $query->extends,
-        'entity_table' => \CRM_Core_BAO_CustomGroup::getTableNameByEntityName($query->extends),
+        'entity_table' => CoreUtil::getTableName($query->extends),
       ];
     }
     return $rows;

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -435,44 +435,6 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test getActiveGroups() with Invalid Params()
-   *
-   * @throws \CRM_Core_Exception
-   */
-  public function testGetActiveGroupsWithInvalidParams(): void {
-    $contactId = $this->individualCreate();
-    $activeGroups = CRM_Core_BAO_CustomGroup::getActiveGroups('ABC', 'civicrm/contact/view/cd', $contactId);
-    $this->assertEquals(empty($activeGroups), TRUE, 'Check that Emprt params are retreived');
-  }
-
-  public function testGetActiveGroups(): void {
-    $contactId = $this->individualCreate();
-    $customGroupTitle = 'Custom Group';
-    $groupParams = [
-      'title' => $customGroupTitle,
-      'name' => 'test_custom_group',
-      'style' => 'Tab',
-      'extends' => 'Individual',
-      'weight' => 10,
-      'is_active' => 1,
-    ];
-
-    $customGroup = $this->customGroupCreate($groupParams);
-    $activeGroup = CRM_Core_BAO_CustomGroup::getActiveGroups('Individual', 'civicrm/contact/view/cd', $contactId);
-    foreach ($activeGroup as $key => $value) {
-      if ($value['id'] == $customGroup['id']) {
-        $this->assertEquals('civicrm/contact/view/cd', $value['path']);
-        $this->assertEquals($value['title'], $customGroupTitle);
-        $query = 'reset=1&gid=' . $customGroup['id'] . '&cid=' . $contactId;
-        $this->assertEquals($value['query'], $query);
-      }
-    }
-
-    $this->customGroupDelete($customGroup['id']);
-    $this->contactDelete($contactId);
-  }
-
-  /**
    * Test create()
    *
    * @throws \CRM_Core_Exception


### PR DESCRIPTION
Overview
----------------------------------------
Deprecates a couple redundant functions, following up to #28975


Technical Details
----------------------------------------
- **getActiveGroups:** This overcomplicated function was only used in 1 place & was easily swapped for the new cached function.
- **getTableNameByEntityName:** Was only used once and was redundant with `CoreUtil::getTableName`
