### PR TITLE
Dedupe - Include EntityReference custom fields

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2697,9 +2697,6 @@ SELECT contact_id
    * @throws \CRM_Core_Exception
    */
   public static function getReferencesToContactTable() {
-    if (isset(\Civi::$statics[__CLASS__]) && isset(\Civi::$statics[__CLASS__]['contact_references'])) {
-      return \Civi::$statics[__CLASS__]['contact_references'];
-    }
     $contactReferences = [];
     $coreReferences = CRM_Core_DAO::getReferencesToTable('civicrm_contact');
     foreach ($coreReferences as $coreReference) {
@@ -2714,8 +2711,7 @@ SELECT contact_id
     }
     self::appendCustomTablesExtendingContacts($contactReferences);
     self::appendCustomContactReferenceFields($contactReferences);
-    \Civi::$statics[__CLASS__]['contact_references'] = $contactReferences;
-    return \Civi::$statics[__CLASS__]['contact_references'];
+    return $contactReferences;
   }
 
   /**
@@ -2741,6 +2737,7 @@ SELECT contact_id
   /**
    * Add custom tables that extend contacts to the list of contact references.
    *
+   * @internal
    * Includes all contact custom groups including inactive, multiple & subtypes.
    *
    * @param array $cidRefs
@@ -2755,6 +2752,7 @@ SELECT contact_id
   /**
    * Add custom ContactReference fields to the list of contact references.
    *
+   * @internal
    * Includes both ContactReference and EntityReference type fields.
    * Includes active and inactive fields/groups
    *

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2741,20 +2741,14 @@ SELECT contact_id
   /**
    * Add custom tables that extend contacts to the list of contact references.
    *
-   * CRM_Core_BAO_CustomGroup::getAllCustomGroupsByBaseEntity seems like a safe-ish
-   * function to be sure all are retrieved & we don't miss subtypes or inactive or multiples
-   * - the down side is it is not cached.
-   *
-   * Further changes should be include tests in the CRM_Core_MergerTest class
-   * to ensure that disabled, subtype, multiple etc groups are still captured.
+   * Includes all contact custom groups including inactive, multiple & subtypes.
    *
    * @param array $cidRefs
    */
   public static function appendCustomTablesExtendingContacts(&$cidRefs) {
-    $customValueTables = CRM_Core_BAO_CustomGroup::getAllCustomGroupsByBaseEntity('Contact');
-    $customValueTables->find();
-    while ($customValueTables->fetch()) {
-      $cidRefs[$customValueTables->table_name][] = 'entity_id';
+    $customGroups = CRM_Core_BAO_CustomGroup::getAll(['extends' => 'Contact']);
+    foreach ($customGroups as $customGroup) {
+      $cidRefs[$customGroup['table_name']][] = 'entity_id';
     }
   }
 

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2753,22 +2753,24 @@ SELECT contact_id
   }
 
   /**
-   * Add custom ContactReference fields to the list of contact references
+   * Add custom ContactReference fields to the list of contact references.
    *
-   * This includes active and inactive fields/groups
+   * Includes both ContactReference and EntityReference type fields.
+   * Includes active and inactive fields/groups
    *
    * @param array $cidRefs
-   *
-   * @throws \CRM_Core_Exception
    */
   public static function appendCustomContactReferenceFields(&$cidRefs) {
-    $fields = civicrm_api3('CustomField', 'get', [
-      'return'    => ['column_name', 'custom_group_id.table_name'],
-      'data_type' => 'ContactReference',
-      'options' => ['limit' => 0],
-    ])['values'];
-    foreach ($fields as $field) {
-      $cidRefs[$field['custom_group_id.table_name']][] = $field['column_name'];
+    $contactTypes = array_merge(['Contact'], CRM_Contact_BAO_ContactType::basicTypes(TRUE));
+    foreach (CRM_Core_BAO_CustomGroup::getAll() as $customGroup) {
+      foreach ($customGroup['fields'] as $field) {
+        if (
+          $field['data_type'] === 'ContactReference' ||
+          in_array($field['fk_entity'], $contactTypes, TRUE)
+        ) {
+          $cidRefs[$customGroup['table_name']][] = $field['column_name'];
+        }
+      }
     }
   }
 

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -996,6 +996,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
       'name'    => 'test_group_activity',
       'extends' => 'Activity',
     ]);
+    // Contact reference fields
     $refFieldContact = $this->customFieldCreate([
       'custom_group_id' => $contactGroup['id'],
       'label'           => 'field_1' . $contactGroup['id'],
@@ -1006,6 +1007,21 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
       'custom_group_id' => $activityGroup['id'],
       'label'           => 'field_1' . $activityGroup['id'],
       'data_type'       => 'ContactReference',
+      'default_value'   => NULL,
+    ]);
+    // Entity reference fields
+    $entityrefFieldContact = $this->customFieldCreate([
+      'custom_group_id' => $contactGroup['id'],
+      'label'           => 'field_2' . $contactGroup['id'],
+      'data_type'       => 'EntityReference',
+      'fk_entity'       => 'Individual',
+      'default_value'   => NULL,
+    ]);
+    $entityrefFieldActivity = $this->customFieldCreate([
+      'custom_group_id' => $activityGroup['id'],
+      'label'           => 'field_2' . $activityGroup['id'],
+      'data_type'       => 'EntityReference',
+      'fk_entity'       => 'Contact',
       'default_value'   => NULL,
     ]);
 
@@ -1021,11 +1037,13 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
       'last_name'               => 'Contact',
       'email'                    => 'unrelated@example.com',
       "custom_{$refFieldContact['id']}" => $duplicateContactID,
+      "custom_{$entityrefFieldContact['id']}" => $duplicateContactID,
     ]);
     // also create an activity with a ContactReference custom field
     $activity = $this->activityCreate([
       'target_contact_id'                => $unrelatedContact,
       "custom_{$refFieldActivity['id']}" => $duplicateContactID,
+      "custom_{$entityrefFieldActivity['id']}" => $duplicateContactID,
     ]);
 
     // verify that the fields were set
@@ -1037,12 +1055,15 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
 
     // verify that the ContactReference fields were updated to point to the surviving contact post-merge
     $this->assertCustomFieldValue($unrelatedContact, $originalContactID, "custom_{$refFieldContact['id']}");
+    $this->assertCustomFieldValue($unrelatedContact, $originalContactID, "custom_{$entityrefFieldContact['id']}");
     $this->assertEntityCustomFieldValue('Activity', $activity['id'], $originalContactID, "custom_{$refFieldActivity['id']}_id");
 
     // cleanup created custom set
     $this->callAPISuccess('CustomField', 'delete', ['id' => $refFieldContact['id']]);
+    $this->callAPISuccess('CustomField', 'delete', ['id' => $entityrefFieldContact['id']]);
     $this->callAPISuccess('CustomGroup', 'delete', ['id' => $contactGroup['id']]);
     $this->callAPISuccess('CustomField', 'delete', ['id' => $refFieldActivity['id']]);
+    $this->callAPISuccess('CustomField', 'delete', ['id' => $entityrefFieldActivity['id']]);
     $this->callAPISuccess('CustomGroup', 'delete', ['id' => $activityGroup['id']]);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
What started as code cleanup ended as a bugfix + test.

Before
----------------------------------------
When merging duplicate contacts, the contents of a ContactReference custom field are updated, but EntityReference custom fields of type "contact" are not.

After
----------------------------------------
Both ContactReference and EntityReference custom field are updated correctly. Test coverage added.

Technical Details
----------------------------------------
This switches to the new cached function for fetching custom field data (see https://lab.civicrm.org/dev/core/-/issues/4905 ) and removes redundant/wasteful caching in other layers.
