### PR TITLE
smarty3 - crash on viewing contribution

### DIFF
--- a/templates/CRM/Price/Page/LineItem.tpl
+++ b/templates/CRM/Price/Page/LineItem.tpl
@@ -72,7 +72,7 @@
         <td></td>
         <td></td>
       {/if}
-      <td class="right">{$line.line_total+$line.tax_amount|crmMoney:$currency}</td>
+      <td class="right">{assign var=totalWithTax value=$line.line_total+$line.tax_amount}{$totalWithTax|crmMoney:$currency}</td>
     {/if}
           {if $pricesetFieldsCount}
             <td class="right">{$line.participant_count}</td>
@@ -92,7 +92,7 @@
       {ts}Contribution Total{/ts}:
     {elseif $context EQ "Event"}
       {if $totalTaxAmount}
-        {ts}Event SubTotal: {$totalAmount-$totalTaxAmount|crmMoney:$currency}{/ts}<br />
+        {ts}Event SubTotal: {assign var=eventSubTotal value=$totalAmount-$totalTaxAmount}{$eventSubTotal|crmMoney:$currency}{/ts}<br />
       {/if}
       {ts}Total Amount{/ts}:
     {elseif $context EQ "Membership"}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/user-interface/-/issues/65#note_156715

Before
----------------------------------------
1. Turn on tax and invoicing.
2. View a contribution.
3. TypeError: Unsupported operand types: string + string in content_65a187dd750733_39675780() (line 203 of sites\default\files\civicrm\templates_c\en_US\3b\f5\d2\3bf5d2b5ac2e045e549cca5a76b7677716adc6ec_0.file.LineItem.tpl.php

After
----------------------------------------


Technical Details
----------------------------------------
It was formatting the tax as currency and then trying to add that formatted thing to the total amount.

Comments
----------------------------------------

