### PR TITLE
dev/core#4905 - Add CRM_Core_BAO_CustomGroup::getAll() with optional filters

### DIFF
--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -422,7 +422,7 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
       'extends' => $this->get('contactType'),
       'style' => ['Tab', 'Tab with table'],
     ];
-    $activeGroups = CRM_Core_BAO_CustomGroup::getFiltered($filters, CRM_Core_Permission::VIEW);
+    $activeGroups = CRM_Core_BAO_CustomGroup::getAll($filters, CRM_Core_Permission::VIEW);
 
     foreach ($activeGroups as $group) {
       $id = "custom_{$group['id']}";

--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -417,14 +417,14 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
     }
 
     // now add all the custom tabs
-    $extends = ['Contact', $this->get('contactType')];
-    $style = ['Tab', 'Tab with table'];
-    $activeGroups = CRM_Core_BAO_CustomGroup::getPermitted(CRM_Core_Permission::VIEW);
+    $filters = [
+      'is_active' => TRUE,
+      'extends' => $this->get('contactType'),
+      'style' => ['Tab', 'Tab with table'],
+    ];
+    $activeGroups = CRM_Core_BAO_CustomGroup::getFiltered($filters, CRM_Core_Permission::VIEW);
 
     foreach ($activeGroups as $group) {
-      if (!in_array($group['extends'], $extends) || !in_array($group['style'], $style)) {
-        continue;
-      }
       $id = "custom_{$group['id']}";
       $allTabs[] = [
         'id' => $id,

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -640,6 +640,10 @@ class CRM_Core_DAO extends DB_DataObject {
    * @return mixed
    */
   protected static function formatFieldValue($value, ?array $fieldSpec) {
+    // DAO queries return `null` db values as empty string
+    if ($value === '' && empty($fieldSpec['required'])) {
+      return NULL;
+    }
     if (!isset($value) || !isset($fieldSpec)) {
       return $value;
     }

--- a/Civi/Api4/Service/Schema/Joinable/CustomGroupJoinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/CustomGroupJoinable.php
@@ -56,7 +56,7 @@ class CustomGroupJoinable extends Joinable {
       'is_active' => TRUE,
       'table_name' => $this->getTargetTable(),
     ];
-    foreach (\CRM_Core_BAO_CustomGroup::getFiltered($filters) as $customGroup) {
+    foreach (\CRM_Core_BAO_CustomGroup::getAll($filters) as $customGroup) {
       foreach ($customGroup['fields'] as $fieldArray) {
         $entityFields[] = SpecFormatter::arrayToField($fieldArray, $baseEntity, $customGroup);
       }

--- a/Civi/Api4/Service/Schema/Joinable/CustomGroupJoinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/CustomGroupJoinable.php
@@ -49,12 +49,14 @@ class CustomGroupJoinable extends Joinable {
   /**
    * @inheritDoc
    */
-  public function getEntityFields() {
+  public function getEntityFields(): array {
+    $entityFields = [];
     $baseEntity = CoreUtil::getApiNameFromTableName($this->getBaseTable());
-    foreach (\CRM_Core_BAO_CustomGroup::getActive() as $customGroup) {
-      if ($customGroup['table_name'] !== $this->getTargetTable()) {
-        continue;
-      }
+    $filters = [
+      'is_active' => TRUE,
+      'table_name' => $this->getTargetTable(),
+    ];
+    foreach (\CRM_Core_BAO_CustomGroup::getFiltered($filters) as $customGroup) {
       foreach ($customGroup['fields'] as $fieldArray) {
         $entityFields[] = SpecFormatter::arrayToField($fieldArray, $baseEntity, $customGroup);
       }

--- a/Civi/Api4/Service/Schema/SchemaMapBuilder.php
+++ b/Civi/Api4/Service/Schema/SchemaMapBuilder.php
@@ -105,11 +105,12 @@ class SchemaMapBuilder extends AutoService {
     if (!$customInfo) {
       return;
     }
-
-    foreach (\CRM_Core_BAO_CustomGroup::getActive() as $customGroup) {
-      if (!$customGroup['fields'] || !in_array($customGroup['extends'], $customInfo['extends'])) {
-        continue;
-      }
+    $filters = [
+      'extends' => $customInfo['extends'],
+      'is_active' => TRUE,
+      'fields' => TRUE,
+    ];
+    foreach (\CRM_Core_BAO_CustomGroup::getFiltered($filters) as $customGroup) {
       $customTable = new Table($customGroup['table_name']);
 
       // Add entity_id join from multi-record custom group to the base entity

--- a/Civi/Api4/Service/Schema/SchemaMapBuilder.php
+++ b/Civi/Api4/Service/Schema/SchemaMapBuilder.php
@@ -110,7 +110,7 @@ class SchemaMapBuilder extends AutoService {
       'is_active' => TRUE,
       'fields' => TRUE,
     ];
-    foreach (\CRM_Core_BAO_CustomGroup::getFiltered($filters) as $customGroup) {
+    foreach (\CRM_Core_BAO_CustomGroup::getAll($filters) as $customGroup) {
       $customTable = new Table($customGroup['table_name']);
 
       // Add entity_id join from multi-record custom group to the base entity

--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -169,7 +169,7 @@ class SpecGatherer extends AutoService {
         \CRM_Core_Permission::EDIT :
         \CRM_Core_Permission::VIEW;
     }
-    $customGroups = \CRM_Core_BAO_CustomGroup::getFiltered($filters, $permissionType);
+    $customGroups = \CRM_Core_BAO_CustomGroup::getAll($filters, $permissionType);
 
     foreach ($customGroups as $customGroup) {
       if ($this->customGroupBelongsTo($customGroup, $values, $grouping)) {

--- a/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTypeTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTypeTest.php
@@ -45,6 +45,18 @@ class CRM_Contact_BAO_ContactType_ContactTypeTest extends CiviUnitTestCase {
     $this->ids['ContactType'][] = (int) ContactType::create()->setValues($params)->execute()->first()['id'];
   }
 
+  private function strictArrayCompare($arr1, $arr2) {
+    ksort($arr1);
+    foreach ($arr1 as &$value) {
+      ksort($value);
+    }
+    ksort($arr2);
+    foreach ($arr2 as &$value) {
+      ksort($value);
+    }
+    $this->assertSame($arr1, $arr2);
+  }
+
   /**
    * Cleanup contact types.
    *
@@ -66,23 +78,23 @@ class CRM_Contact_BAO_ContactType_ContactTypeTest extends CiviUnitTestCase {
     // check for type:Individual
     $result = CRM_Contact_BAO_ContactType::subTypes('Individual');
     $this->assertEquals(array_keys($this->getExpectedContactSubTypes('Individual')), $result);
-    $this->assertEquals($this->getExpectedContactSubTypes('Individual'), CRM_Contact_BAO_ContactType::subTypeInfo('Individual'));
+    $this->strictArrayCompare($this->getExpectedContactSubTypes('Individual'), CRM_Contact_BAO_ContactType::subTypeInfo('Individual'));
 
     // check for type:Organization
     $result = CRM_Contact_BAO_ContactType::subTypes('Organization');
     $this->assertEquals(array_keys($this->getExpectedContactSubTypes('Organization')), $result);
-    $this->assertEquals($this->getExpectedContactSubTypes('Organization'), CRM_Contact_BAO_ContactType::subTypeInfo('Organization'));
+    $this->strictArrayCompare($this->getExpectedContactSubTypes('Organization'), CRM_Contact_BAO_ContactType::subTypeInfo('Organization'));
 
     // check for type:Household
     $result = CRM_Contact_BAO_ContactType::subTypes('Household');
     $this->assertEquals(array_keys($this->getExpectedContactSubTypes('Household')), $result);
-    $this->assertEquals($this->getExpectedContactSubTypes('Household'), CRM_Contact_BAO_ContactType::subTypeInfo('Household'));
+    $this->strictArrayCompare($this->getExpectedContactSubTypes('Household'), CRM_Contact_BAO_ContactType::subTypeInfo('Household'));
 
     // check for all contact types
     $result = CRM_Contact_BAO_ContactType::subTypes();
     $subtypes = array_keys($this->getExpectedAllSubtypes());
     $this->assertEquals(sort($subtypes), sort($result));
-    $this->assertEquals($this->getExpectedAllSubtypes(), CRM_Contact_BAO_ContactType::subTypeInfo());
+    $this->strictArrayCompare($this->getExpectedAllSubtypes(), CRM_Contact_BAO_ContactType::subTypeInfo());
 
   }
 
@@ -110,7 +122,7 @@ class CRM_Contact_BAO_ContactType_ContactTypeTest extends CiviUnitTestCase {
     $createdType = ContactType::create()->setValues($blahType)->execute()->first();
     $activeTypes = CRM_Contact_BAO_ContactType::contactTypeInfo();
     $expected = $this->getExpectedContactTypes();
-    $this->assertEquals($expected, $activeTypes);
+    $this->strictArrayCompare($expected, $activeTypes);
     $allTypes = CRM_Contact_BAO_ContactType::contactTypeInfo(TRUE);
     $expected['blah'] = [
       'is_active' => FALSE,
@@ -121,14 +133,12 @@ class CRM_Contact_BAO_ContactType_ContactTypeTest extends CiviUnitTestCase {
       'is_reserved' => FALSE,
       'parent' => 'Individual',
       'parent_label' => 'Individual',
-      'description' => '',
-      'image_URL' => '',
+      'description' => NULL,
+      'image_URL' => NULL,
       'icon' => 'fa-random',
     ];
-    $this->assertEquals($expected, $allTypes);
     // Verify function returns field values formatted correctly by type
-    $this->assertTrue(is_int($allTypes['blah']['id']));
-    $this->assertFalse($allTypes['blah']['is_active']);
+    $this->strictArrayCompare($expected, $allTypes);
   }
 
   /**
@@ -138,174 +148,162 @@ class CRM_Contact_BAO_ContactType_ContactTypeTest extends CiviUnitTestCase {
    */
   public function getExpectedContactTypes() {
     return [
-      'Individual' =>
-        [
-          'id' => '1',
-          'name' => 'Individual',
-          'label' => 'Individual',
-          'is_active' => TRUE,
-          'is_reserved' => TRUE,
-          'description' => '',
-          'parent_id' => NULL,
-          'parent' => NULL,
-          'parent_label' => NULL,
-          'image_URL' => '',
-          'icon' => 'fa-user',
-        ],
-      'Household' =>
-        [
-          'id' => '2',
-          'name' => 'Household',
-          'label' => 'Household',
-          'is_active' => TRUE,
-          'is_reserved' => TRUE,
-          'description' => '',
-          'parent_id' => NULL,
-          'parent' => NULL,
-          'parent_label' => NULL,
-          'image_URL' => '',
-          'icon' => 'fa-home',
-        ],
-      'Organization' =>
-        [
-          'id' => '3',
-          'name' => 'Organization',
-          'label' => 'Organization',
-          'is_active' => TRUE,
-          'is_reserved' => TRUE,
-          'description' => '',
-          'parent_id' => NULL,
-          'parent' => NULL,
-          'parent_label' => NULL,
-          'image_URL' => '',
-          'icon' => 'fa-building',
-        ],
-      'Student' =>
-        [
-          'id' => 4,
-          'name' => 'Student',
-          'label' => 'Student',
-          'parent_id' => 1,
-          'is_active' => '1',
-          'is_reserved' => FALSE,
-          'description' => '',
-          'parent' => 'Individual',
-          'parent_label' => 'Individual',
-          'image_URL' => '',
-          'icon' => 'fa-graduation-cap',
-        ],
-      'Parent' =>
-        [
-          'id' => 5,
-          'name' => 'Parent',
-          'label' => 'Parent',
-          'parent_id' => 1,
-          'is_active' => TRUE,
-          'is_reserved' => FALSE,
-          'description' => '',
-          'parent' => 'Individual',
-          'parent_label' => 'Individual',
-          'image_URL' => '',
-          'icon' => 'fa-user-circle-o',
-        ],
-      'Staff' =>
-        [
-          'id' => 6,
-          'name' => 'Staff',
-          'label' => 'Staff',
-          'parent_id' => 1,
-          'is_active' => TRUE,
-          'is_reserved' => FALSE,
-          'description' => '',
-          'parent' => 'Individual',
-          'parent_label' => 'Individual',
-          'image_URL' => '',
-          'icon' => 'fa-id-badge',
-        ],
-      'Team' =>
-        [
-          'id' => 7,
-          'name' => 'Team',
-          'label' => 'Team',
-          'parent_id' => 3,
-          'is_active' => TRUE,
-          'is_reserved' => FALSE,
-          'description' => '',
-          'parent' => 'Organization',
-          'parent_label' => 'Organization',
-          'image_URL' => '',
-          'icon' => 'fa-users',
-        ],
-      'Sponsor' =>
-        [
-          'id' => 8,
-          'name' => 'Sponsor',
-          'label' => 'Sponsor',
-          'parent_id' => 3,
-          'is_active' => TRUE,
-          'is_reserved' => FALSE,
-          'description' => '',
-          'parent' => 'Organization',
-          'parent_label' => 'Organization',
-          'image_URL' => '',
-          'icon' => 'fa-leaf',
-        ],
-      'sub1_individual' =>
-        [
-          'id' => $this->ids['ContactType'][0],
-          'name' => 'sub1_individual',
-          'label' => 'sub1_individual',
-          'parent_id' => 1,
-          'is_active' => TRUE,
-          'is_reserved' => FALSE,
-          'description' => '',
-          'parent' => 'Individual',
-          'parent_label' => 'Individual',
-          'image_URL' => '',
-          'icon' => '',
-        ],
-      'sub2_individual' =>
-        [
-          'id' => $this->ids['ContactType'][1],
-          'name' => 'sub2_individual',
-          'label' => 'sub2_individual',
-          'parent_id' => 1,
-          'is_active' => TRUE,
-          'is_reserved' => FALSE,
-          'description' => '',
-          'parent' => 'Individual',
-          'parent_label' => 'Individual',
-          'image_URL' => '',
-          'icon' => '',
-        ],
-      'sub_organization' =>
-        [
-          'id' => $this->ids['ContactType'][2],
-          'name' => 'sub_organization',
-          'label' => 'sub_organization',
-          'parent_id' => 3,
-          'is_active' => TRUE,
-          'is_reserved' => FALSE,
-          'description' => '',
-          'parent' => 'Organization',
-          'parent_label' => 'Organization',
-          'image_URL' => '',
-          'icon' => '',
-        ],
-      'sub_household' =>
-        [
-          'id' => $this->ids['ContactType'][3],
-          'name' => 'sub_household',
-          'label' => 'sub_household',
-          'parent_id' => 2,
-          'is_active' => TRUE,
-          'is_reserved' => FALSE,
-          'description' => '',
-          'parent' => 'Household',
-          'parent_label' => 'Household',
-          'image_URL' => '',
-          'icon' => '',
-        ],
+      'Individual' => [
+        'id' => 1,
+        'name' => 'Individual',
+        'label' => 'Individual',
+        'is_active' => TRUE,
+        'is_reserved' => TRUE,
+        'description' => NULL,
+        'parent_id' => NULL,
+        'parent' => NULL,
+        'parent_label' => NULL,
+        'image_URL' => NULL,
+        'icon' => 'fa-user',
+      ],
+      'Household' => [
+        'id' => 2,
+        'name' => 'Household',
+        'label' => 'Household',
+        'is_active' => TRUE,
+        'is_reserved' => TRUE,
+        'description' => NULL,
+        'parent_id' => NULL,
+        'parent' => NULL,
+        'parent_label' => NULL,
+        'image_URL' => NULL,
+        'icon' => 'fa-home',
+      ],
+      'Organization' => [
+        'id' => 3,
+        'name' => 'Organization',
+        'label' => 'Organization',
+        'is_active' => TRUE,
+        'is_reserved' => TRUE,
+        'description' => NULL,
+        'parent_id' => NULL,
+        'parent' => NULL,
+        'parent_label' => NULL,
+        'image_URL' => NULL,
+        'icon' => 'fa-building',
+      ],
+      'Student' => [
+        'id' => 4,
+        'name' => 'Student',
+        'label' => 'Student',
+        'parent_id' => 1,
+        'is_active' => TRUE,
+        'is_reserved' => FALSE,
+        'description' => NULL,
+        'parent' => 'Individual',
+        'parent_label' => 'Individual',
+        'image_URL' => NULL,
+        'icon' => 'fa-graduation-cap',
+      ],
+      'Parent' => [
+        'id' => 5,
+        'name' => 'Parent',
+        'label' => 'Parent',
+        'parent_id' => 1,
+        'is_active' => TRUE,
+        'is_reserved' => FALSE,
+        'description' => NULL,
+        'parent' => 'Individual',
+        'parent_label' => 'Individual',
+        'image_URL' => NULL,
+        'icon' => 'fa-user-circle-o',
+      ],
+      'Staff' => [
+        'id' => 6,
+        'name' => 'Staff',
+        'label' => 'Staff',
+        'parent_id' => 1,
+        'is_active' => TRUE,
+        'is_reserved' => FALSE,
+        'description' => NULL,
+        'parent' => 'Individual',
+        'parent_label' => 'Individual',
+        'image_URL' => NULL,
+        'icon' => 'fa-id-badge',
+      ],
+      'Team' => [
+        'id' => 7,
+        'name' => 'Team',
+        'label' => 'Team',
+        'parent_id' => 3,
+        'is_active' => TRUE,
+        'is_reserved' => FALSE,
+        'description' => NULL,
+        'parent' => 'Organization',
+        'parent_label' => 'Organization',
+        'image_URL' => NULL,
+        'icon' => 'fa-users',
+      ],
+      'Sponsor' => [
+        'id' => 8,
+        'name' => 'Sponsor',
+        'label' => 'Sponsor',
+        'parent_id' => 3,
+        'is_active' => TRUE,
+        'is_reserved' => FALSE,
+        'description' => NULL,
+        'parent' => 'Organization',
+        'parent_label' => 'Organization',
+        'image_URL' => NULL,
+        'icon' => 'fa-leaf',
+      ],
+      'sub1_individual' => [
+        'id' => $this->ids['ContactType'][0],
+        'name' => 'sub1_individual',
+        'label' => 'sub1_individual',
+        'parent_id' => 1,
+        'is_active' => TRUE,
+        'is_reserved' => FALSE,
+        'description' => NULL,
+        'parent' => 'Individual',
+        'parent_label' => 'Individual',
+        'image_URL' => NULL,
+        'icon' => 'fa-user',
+      ],
+      'sub2_individual' => [
+        'id' => $this->ids['ContactType'][1],
+        'name' => 'sub2_individual',
+        'label' => 'sub2_individual',
+        'parent_id' => 1,
+        'is_active' => TRUE,
+        'is_reserved' => FALSE,
+        'description' => NULL,
+        'parent' => 'Individual',
+        'parent_label' => 'Individual',
+        'image_URL' => NULL,
+        'icon' => 'fa-user',
+      ],
+      'sub_organization' => [
+        'id' => $this->ids['ContactType'][2],
+        'name' => 'sub_organization',
+        'label' => 'sub_organization',
+        'parent_id' => 3,
+        'is_active' => TRUE,
+        'is_reserved' => FALSE,
+        'description' => NULL,
+        'parent' => 'Organization',
+        'parent_label' => 'Organization',
+        'image_URL' => NULL,
+        'icon' => 'fa-building',
+      ],
+      'sub_household' => [
+        'id' => $this->ids['ContactType'][3],
+        'name' => 'sub_household',
+        'label' => 'sub_household',
+        'parent_id' => 2,
+        'is_active' => TRUE,
+        'is_reserved' => FALSE,
+        'description' => NULL,
+        'parent' => 'Household',
+        'parent_label' => 'Household',
+        'image_URL' => NULL,
+        'icon' => 'fa-home',
+      ],
     ];
   }
 

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -38,7 +38,7 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     $this->customFieldCreate(['label' => 'Inactive', 'custom_group_id' => $inactiveGroup['id']]);
 
     $allGroups = CRM_Core_BAO_CustomGroup::getAll();
-    $activeGroups = CRM_Core_BAO_CustomGroup::getFiltered(['is_active' => TRUE]);
+    $activeGroups = CRM_Core_BAO_CustomGroup::getAll(['is_active' => TRUE]);
 
     $this->assertCount(2, $allGroups);
     $this->assertCount(2, $allGroups[0]['fields']);
@@ -47,11 +47,11 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     $this->assertEquals($activeGroup['id'], $activeGroups[0]['id']);
     $this->assertCount(1, $activeGroups[0]['fields']);
 
-    $activityGroups = CRM_Core_BAO_CustomGroup::getFiltered(['extends' => 'Activity']);
+    $activityGroups = CRM_Core_BAO_CustomGroup::getAll(['extends' => 'Activity']);
     $this->assertCount(1, $activityGroups);
     $this->assertEquals($inactiveGroup['id'], $activityGroups[0]['id']);
 
-    $contactGroups = CRM_Core_BAO_CustomGroup::getFiltered(['extends' => 'Contact']);
+    $contactGroups = CRM_Core_BAO_CustomGroup::getAll(['extends' => 'Contact']);
     $this->assertEquals($activeGroup['id'], $contactGroups[0]['id']);
     $this->assertCount(2, $contactGroups[0]['fields']);
   }

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -37,13 +37,17 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     $inactiveGroup = $this->CustomGroupCreate(['title' => 'InactiveGroup', 'weight' => 2, 'is_active' => 0, 'extends' => 'Activity']);
     $this->customFieldCreate(['label' => 'Inactive', 'custom_group_id' => $inactiveGroup['id']]);
 
-    $allGroups = CRM_Core_BAO_CustomGroup::getAll();
-    $activeGroups = CRM_Core_BAO_CustomGroup::getAll(['is_active' => TRUE]);
+    $activityTypeGroup = $this->CustomGroupCreate(['title' => 'ActivityTypeGroup', 'weight' => 3, 'extends' => 'Activity', 'extends_entity_column_value' => [1, 2]]);
 
-    $this->assertCount(2, $allGroups);
+    $allGroups = CRM_Core_BAO_CustomGroup::getAll();
+
+    $this->assertCount(3, $allGroups);
     $this->assertCount(2, $allGroups[0]['fields']);
     $this->assertCount(1, $allGroups[1]['fields']);
-    $this->assertCount(1, $activeGroups);
+    $this->assertCount(0, $allGroups[2]['fields']);
+
+    $activeGroups = CRM_Core_BAO_CustomGroup::getAll(['is_active' => TRUE]);
+    $this->assertCount(2, $activeGroups);
     $this->assertTrue($activeGroups[0]['is_active']);
     $this->assertSame($activeGroup['id'], $activeGroups[0]['id']);
     $this->assertCount(1, $activeGroups[0]['fields']);
@@ -51,12 +55,24 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     $this->assertNull($activeGroups[0]['fields'][0]['help_pre']);
 
     $activityGroups = CRM_Core_BAO_CustomGroup::getAll(['extends' => 'Activity']);
-    $this->assertCount(1, $activityGroups);
+    $this->assertCount(2, $activityGroups);
     $this->assertEquals($inactiveGroup['id'], $activityGroups[0]['id']);
 
-    $contactGroups = CRM_Core_BAO_CustomGroup::getAll(['extends' => 'Contact']);
-    $this->assertEquals($activeGroup['id'], $contactGroups[0]['id']);
-    $this->assertCount(2, $contactGroups[0]['fields']);
+    // When in an array, "Contact" means "Contact only" so the household group will not be returned
+    $contactActivityGroups = CRM_Core_BAO_CustomGroup::getAll(['is_active' => TRUE, 'extends' => ['Contact', 'Activity']]);
+    $this->assertCount(1, $contactActivityGroups);
+    $this->assertEquals([$activityTypeGroup['id']], array_column($contactActivityGroups, 'id'));
+    $this->assertCount(0, $contactActivityGroups[0]['fields']);
+
+    // When passed as a string, "Contact" means ["Contact", "Individual", "Household", "Organization"]
+    $contactGroups = CRM_Core_BAO_CustomGroup::getAll(['is_active' => TRUE, 'extends' => 'Contact']);
+    $this->assertEquals([$activeGroup['id']], array_column($contactGroups, 'id'));
+    $this->assertCount(1, $contactGroups[0]['fields']);
+
+    $this->assertCount(0, CRM_Core_BAO_CustomGroup::getAll(['extends_entity_column_value' => 3]));
+    $this->assertCount(1, CRM_Core_BAO_CustomGroup::getAll(['extends_entity_column_value' => 2]));
+    $this->assertCount(1, CRM_Core_BAO_CustomGroup::getAll(['extends_entity_column_value' => [2, 4]]));
+    $this->assertCount(3, CRM_Core_BAO_CustomGroup::getAll(['extends_entity_column_value' => [1, NULL]]));
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -27,7 +27,7 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     parent::tearDown();
   }
 
-  public function testGetFiltered(): void {
+  public function testGetAll(): void {
     $this->quickCleanup([], TRUE);
 
     $activeGroup = $this->CustomGroupCreate(['title' => 'ActiveGroup', 'weight' => 1, 'extends' => 'Household']);
@@ -44,8 +44,11 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     $this->assertCount(2, $allGroups[0]['fields']);
     $this->assertCount(1, $allGroups[1]['fields']);
     $this->assertCount(1, $activeGroups);
-    $this->assertEquals($activeGroup['id'], $activeGroups[0]['id']);
+    $this->assertTrue($activeGroups[0]['is_active']);
+    $this->assertSame($activeGroup['id'], $activeGroups[0]['id']);
     $this->assertCount(1, $activeGroups[0]['fields']);
+    $this->assertTrue($activeGroups[0]['fields'][0]['is_active']);
+    $this->assertNull($activeGroups[0]['fields'][0]['help_pre']);
 
     $activityGroups = CRM_Core_BAO_CustomGroup::getAll(['extends' => 'Activity']);
     $this->assertCount(1, $activityGroups);


### PR DESCRIPTION
Overview
----------------------------------------
Makes future refactoring of custom group/field code easier by standardizing on a single getter function that's both useful and efficient.

Tweaks just-added-to-master functions from #28975.

Technical Details
-----------
The problem with so many other functions like this is that they end up with a huge pile of parameters, like
https://github.com/civicrm/civicrm-core/blob/b6498f3d0f49ab4a3daf3f916faabf94f75ab0d2/CRM/Core/BAO/CustomField.php#L348-L357

One alternative is to create several functions like `getAll()`, `getPermitted()`, `getActive()`, `getForEntity()`, but that ends up getting just as unwieldy (and what if you want a combination of what they output like "only active fields for a specific entity and also check permissions").

I finally settled on the pattern of using a single array for filters. I'm finding it very usable as I go through and refactor older code to use this new method. It's clear what it does, and it's flexible enough that we shouldn't need to add more params to this function in the future.