### PR TITLE
dev/core#4905 - Deprecate CustomGroup::getAllCustomGroupsByBaseEntity

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1198,7 +1198,6 @@ ORDER BY civicrm_custom_group.weight,
    * @deprecated since 5.71, will be removed around 5.85
    */
   public static function &getActiveGroups($entityType, $path, $cidToken = '%%cid%%') {
-    CRM_Core_Error::deprecatedFunctionWarning('CRM_Core_BAO_CustomGroup::getPermitted');
     // for Group's
     $customGroupDAO = new CRM_Core_DAO_CustomGroup();
 
@@ -1206,7 +1205,7 @@ ORDER BY civicrm_custom_group.weight,
     $customGroupDAO->whereAdd("style IN ('Tab', 'Tab with table')");
     $customGroupDAO->whereAdd("is_active = 1");
 
-    // add whereAdd for entity type
+    // Emits a noisy deprecation notice
     self::_addWhereAdd($customGroupDAO, $entityType, $cidToken);
 
     $groups = [];
@@ -1254,9 +1253,7 @@ ORDER BY civicrm_custom_group.weight,
   }
 
   /**
-   * Get a list of custom groups which extend a given entity type.
-   * If there are custom-groups which only apply to certain subtypes,
-   * those WILL be included.
+   * @deprecated since 5.71 will be removed around 5.85
    *
    * @param string $entityType
    *
@@ -1264,22 +1261,16 @@ ORDER BY civicrm_custom_group.weight,
    */
   public static function getAllCustomGroupsByBaseEntity($entityType) {
     $customGroupDAO = new CRM_Core_DAO_CustomGroup();
+    // Emits a noisy deprecation notice
     self::_addWhereAdd($customGroupDAO, $entityType, NULL, TRUE);
     return $customGroupDAO;
   }
 
   /**
-   * Add the whereAdd clause for the DAO depending on the type of entity
-   * the custom group is extending.
-   *
-   * @param object $customGroupDAO
-   * @param string $entityType
-   *   What entity are we extending here ?.
-   *
-   * @param int $entityID
-   * @param bool $allSubtypes
+   * @deprecated since 5.71 will be removed around 5.85
    */
   private static function _addWhereAdd(&$customGroupDAO, $entityType, $entityID = NULL, $allSubtypes = FALSE) {
+    CRM_Core_Error::deprecatedFunctionWarning('CRM_Core_BAO_CustomGroup::getAll');
     $addSubtypeClause = FALSE;
     // This function isn't really accessible with user data but since the string
     // is not passed as a param to the query CRM_Core_DAO::escapeString seems like a harmless
@@ -1543,7 +1534,7 @@ ORDER BY civicrm_custom_group.weight,
   }
 
   /**
-   * Old function only called from one place...
+   * @deprecated function only called from one place...
    * @see CRM_Dedupe_Finder::formatParams
    *
    * @param array $groupTree

--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -203,13 +203,11 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
    */
   public function entityCustomDataLogTables($extends) {
     $customGroupTables = [];
-    $customGroupDAO = CRM_Core_BAO_CustomGroup::getAllCustomGroupsByBaseEntity($extends);
-    $customGroupDAO->find();
-    while ($customGroupDAO->fetch()) {
-      // logging is disabled for the table (e.g by hook) then $this->logs[$customGroupDAO->table_name]
+    foreach (CRM_Core_BAO_CustomGroup::getAll(['extends' => $extends]) as $customGroup) {
+      // logging is disabled for the table (e.g by hook) then $this->logs[$customGroup['table_name']]
       // will be empty.
-      if (!empty($this->logs[$customGroupDAO->table_name])) {
-        $customGroupTables[$customGroupDAO->table_name] = $this->logs[$customGroupDAO->table_name];
+      if (!empty($this->logs[$customGroup['table_name']])) {
+        $customGroupTables[$customGroup['table_name']] = $this->logs[$customGroup['table_name']];
       }
     }
     return $customGroupTables;

--- a/CRM/UF/Page/ProfileEditor.php
+++ b/CRM/UF/Page/ProfileEditor.php
@@ -300,33 +300,28 @@ class CRM_UF_Page_ProfileEditor extends CRM_Core_Page {
       'is_addable' => FALSE,
     ];
 
-    $customGroup = CRM_Core_BAO_CustomGroup::getAllCustomGroupsByBaseEntity($extends);
-    $customGroup->orderBy('weight');
-    $customGroup->is_active = 1;
-    $customGroup->find();
-    while ($customGroup->fetch()) {
-      $sectionName = 'cg_' . $customGroup->id;
+    $customGroups = \CRM_Core_BAO_CustomGroup::getAll(['extends' => $extends, 'is_active' => TRUE]);
+    foreach ($customGroups as $customGroup) {
+      $sectionName = 'cg_' . $customGroup['id'];
       $section = [
-        'title' => ts('%1: %2', [1 => $title, 2 => $customGroup->title]),
-        'is_addable' => !$customGroup->is_reserved,
-        'custom_group_id' => $customGroup->id,
-        'extends_entity_column_id' => $customGroup->extends_entity_column_id,
-        'extends_entity_column_value' => CRM_Utils_Array::explodePadded($customGroup->extends_entity_column_value),
-        'is_reserved' => (bool) $customGroup->is_reserved,
+        'title' => ts('%1: %2', [1 => $title, 2 => $customGroup['title']]),
+        'is_addable' => !$customGroup['is_reserved'],
+        'custom_group_id' => (string) $customGroup['id'],
+        'extends_entity_column_id' => $customGroup['extends_entity_column_id'],
+        'extends_entity_column_value' => $customGroup['extends_entity_column_value'],
+        'is_reserved' => $customGroup['is_reserved'],
       ];
       $result['sections'][$sectionName] = $section;
-    }
-
-    // put fields in their sections
-    $fields = CRM_Core_BAO_CustomField::getFields($extends);
-    foreach ($fields as $fieldId => $field) {
-      $sectionName = 'cg_' . $field['custom_group_id'];
-      $fieldName = 'custom_' . $fieldId;
-      if (isset($result['schema'][$fieldName])) {
-        $result['schema'][$fieldName]['section'] = $sectionName;
-        $result['schema'][$fieldName]['civiIsMultiple'] = (bool) CRM_Core_BAO_CustomField::isMultiRecordField($fieldId);
+      // put fields in their sections
+      foreach ($customGroup['fields'] as $field) {
+        $fieldName = 'custom_' . $field['id'];
+        if (isset($result['schema'][$fieldName])) {
+          $result['schema'][$fieldName]['section'] = $sectionName;
+          $result['schema'][$fieldName]['civiIsMultiple'] = $customGroup['is_multiple'];
+        }
       }
     }
+
     return $result;
   }
 

--- a/Civi/Core/SqlTrigger/TimestampTriggers.php
+++ b/Civi/Core/SqlTrigger/TimestampTriggers.php
@@ -299,12 +299,10 @@ class TimestampTriggers {
     $relations = $this->getRelations();
 
     if ($this->getCustomDataEntity()) {
-      $customGroupDAO = \CRM_Core_BAO_CustomGroup::getAllCustomGroupsByBaseEntity($this->getCustomDataEntity());
-      $customGroupDAO->is_multiple = 0;
-      $customGroupDAO->find();
-      while ($customGroupDAO->fetch()) {
+      $customGroups = \CRM_Core_BAO_CustomGroup::getAll(['extends' => $this->getCustomDataEntity(), 'is_multiple' => FALSE]);
+      foreach ($customGroups as $customGroup) {
         $relations[] = [
-          'table' => $customGroupDAO->table_name,
+          'table' => $customGroup['table_name'],
           'column' => 'entity_id',
         ];
       }


### PR DESCRIPTION
Overview
----------------------------------------
Actively deprecates older uncached functions that were used to fetch custom fields, in favor of the new one added for [dev/core#4905](https://lab.civicrm.org/dev/core/-/issues/4905).

Technical Details
----------
I did a before/after var_dump + diff of the output from `ProfileEditor:: convertCiviModelToBackboneModel` and verified it's exactly the same.