### PR TITLE
dev/core#4905 - Refactor CustomField::getFields() to use more efficient getter

### DIFF
--- a/CRM/Contact/ActionMapping.php
+++ b/CRM/Contact/ActionMapping.php
@@ -47,15 +47,18 @@ class CRM_Contact_ActionMapping extends \Civi\ActionSchedule\MappingBase {
   }
 
   public function getValueLabels(): array {
-    $allCustomFields = \CRM_Core_BAO_CustomField::getFields('');
+    $filter = ['extends' => 'Contact', 'is_multiple' => FALSE, 'is_active' => TRUE];
+    $contactCustomGroups = \CRM_Core_BAO_CustomGroup::getAll($filter);
     $dateFields = [
       'birth_date' => ts('Birth Date'),
       'created_date' => ts('Created Date'),
       'modified_date' => ts('Modified Date'),
     ];
-    foreach ($allCustomFields as $fieldID => $field) {
-      if ($field['data_type'] == 'Date') {
-        $dateFields["custom_$fieldID"] = $field['label'];
+    foreach ($contactCustomGroups as $customGroup) {
+      foreach ($customGroup['fields'] as $field) {
+        if ($field['data_type'] == 'Date') {
+          $dateFields["custom_{$field['id']}"] = $field['label'];
+        }
       }
     }
     return $dateFields;

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1509,8 +1509,7 @@ class CRM_Utils_System {
       = CRM_Contribute_BAO_Contribution::$_importableFields
         = CRM_Contribute_BAO_Contribution::$_exportableFields
           = CRM_Pledge_BAO_Pledge::$_exportableFields
-            = CRM_Core_BAO_CustomField::$_importFields
-              = CRM_Core_DAO::$_dbColumnValueCache = NULL;
+            = CRM_Core_DAO::$_dbColumnValueCache = NULL;
 
     CRM_Core_OptionGroup::flushAll();
     CRM_Utils_PseudoConstant::flushAll();


### PR DESCRIPTION
Overview
----------------------------------------
As part of https://lab.civicrm.org/dev/core/-/issues/4905 this simplifies a crufty old function.

Technical Details
----------------------------------------
This is more efficient, because the previous double-caching was wasting memory, and the db lookup was unnecessary now that we have `CustomGroup::getAll()`.
Standardizing on that function means the custom field schema only has to be loaded once and cached in a single place.

During the refactor I compared output before & after and coerced all the data types to be exactly what they were before (pretty much all `string`).