### PR TITLE
fix bug saving a new recurring contribution to the database

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -940,7 +940,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
 
     if ($paymentStatus == 'Completed'
       && CRM_Contribute_PseudoConstant::contributionStatus($existing['contribution_status_id'], 'name') == 'Pending') {
-      $params['contribution_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'In Progress');
+      $params['contribution_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionRecur', 'contribution_status_id', 'In Progress');
     }
     if ($paymentStatus == 'Failed') {
       $params['failure_count'] = $existing['failure_count'];
@@ -948,7 +948,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
     $params['modified_date'] = date('Y-m-d H:i:s');
 
     if (!empty($existing['installments']) && self::isComplete($recurringContributionID, $existing['installments'])) {
-      $params['contribution_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
+      $params['contribution_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionRecur', 'contribution_status_id', 'Completed');
       $params['next_sched_contribution_date'] = 'null';
       $params['end_date'] = 'now';
     }

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -940,7 +940,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
 
     if ($paymentStatus == 'Completed'
       && CRM_Contribute_PseudoConstant::contributionStatus($existing['contribution_status_id'], 'name') == 'Pending') {
-      $params['contribution_status_id'] = 'In Progress';
+      $params['contribution_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'In Progress');
     }
     if ($paymentStatus == 'Failed') {
       $params['failure_count'] = $existing['failure_count'];
@@ -948,7 +948,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
     $params['modified_date'] = date('Y-m-d H:i:s');
 
     if (!empty($existing['installments']) && self::isComplete($recurringContributionID, $existing['installments'])) {
-      $params['contribution_status_id'] = 'Completed';
+      $params['contribution_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
       $params['next_sched_contribution_date'] = 'null';
       $params['end_date'] = 'now';
     }

--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -1261,6 +1261,10 @@
 - name        : Patrick Corbett
   organization: Redfin Solutions
 
+- github      : patricklam
+  name        : Patrick Lam
+  organization: University of Waterloo
+
 - name        : Paul Barmak
 
 - github      : pbatroff


### PR DESCRIPTION
I experienced a bug in CiviCRM 5.69.2 with the Stripe plugin from mjw. Adding a new recurring contribution (for an annual membership), CiviCRM reports the error:

2024-01-12 04:49:44-0500  [error] CRM_Contribute_Form_Contribution_Confirm::completeTransaction CRM_Core_Exception: contribution_status_id is not a valid integer

and the error message "Failed to update contribution in database".

I tracked this down to the code patched here in contributionRecur, which attempts to store "In Progress" as the contribution_status_id, which is indeed not a valid integer. It looks like everywhere else in the code, CiviCRM is going to do a PseudoConstant lookup to store the relevant ID. I've modified the code here to match the convention elsewhere.

The patch appears to work on my own install of CiviCRM.

I don't have a CiviCRM account yet. I was planning to report it on the bug tracker, but my account hasn't been approved yet. Anyway, I can report it there once I have an account. Or not, if you just merge this patch. Thanks for all the work maintaining this software!

Overview
----------------------------------------
It looks like stale code dealing with recurring contributions is trying to put invalid values into the database, and getting rejected.

Before
----------------------------------------
Adding a new recurring contribution (for an annual membership), CiviCRM reports the error:

2024-01-12 04:49:44-0500  [error] CRM_Contribute_Form_Contribution_Confirm::completeTransaction CRM_Core_Exception: contribution_status_id is not a valid integer

and the error message "Failed to update contribution in database".

After
----------------------------------------
Adding a new recurring contribution appears to work.
