### PR TITLE
Clean up event full handling on backoffice participant form

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -10,6 +10,8 @@
 
  */
 
+use Civi\Api4\Participant;
+
 /**
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
@@ -1481,25 +1483,19 @@ UPDATE  civicrm_participant
    *
    * @return string
    */
-  public static function eventFullMessage($eventId, $participantId = NULL) {
+  public static function eventFullMessage(int $eventId, $participantId = NULL) {
     $eventfullMsg = $dbStatusId = NULL;
-    $checkEventFull = TRUE;
     if ($participantId) {
       $dbStatusId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $participantId, 'status_id');
       if (array_key_exists($dbStatusId, CRM_Event_PseudoConstant::participantStatus(NULL, 'is_counted = 1'))) {
         //participant already in counted status no need to check for event full messages.
-        $checkEventFull = FALSE;
+        return FALSE;
       }
     }
 
-    //early return.
-    if (!$eventId || !$checkEventFull) {
-      return $eventfullMsg;
-    }
-
     //event is truly full.
-    $emptySeats = self::eventFull($eventId, FALSE, FALSE);
-    if (is_string($emptySeats) && $emptySeats !== NULL) {
+    $emptySeats = self::eventFull($eventId, TRUE, FALSE);
+    if ($emptySeats < 1) {
       $maxParticipants = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $eventId, 'max_participants');
       $eventfullMsg = ts("This event currently has the maximum number of participants registered (%1). However, you can still override this limit and register additional participants using this form.", [
         1 => $maxParticipants,

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1660,7 +1660,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
   public function getParticipantID(): ?int {
     if ($this->isOverloadFeesMode()) {
       $participantID = CRM_Utils_Request::retrieve('participantId', 'Positive', $this);
-      return $participantID ? (int)  $participantID: NULL;
+      return $participantID ? (int) $participantID : NULL;
     }
     if ($this->_id === NULL) {
       $id = CRM_Utils_Request::retrieve('id', 'Positive', $this);


### PR DESCRIPTION
Overview
----------------------------------------
Clean up event full handling on backoffice participant form

Before
----------------------------------------
Code using the horrible way where it calls the eventFull function with the expectation of it returning a text result

After
----------------------------------------
no change in output but it generates it's own text
![image](https://github.com/civicrm/civicrm-core/assets/336308/8436613d-ed1e-4c02-8edc-5ec71d8d102b)

Technical Details
----------------------------------------

Comments
----------------------------------------
