### PR TITLE
[NFC] CustomField - Add @deprecated notice to old function

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2356,7 +2356,8 @@ AND      default_value IS NOT NULL";
   }
 
   /**
-   * @deprecated old function only used by APIv3.
+   * @deprecated Old function with weirdly ambiguous logic.
+   * Only used by APIv3. Use at your peril.
    *
    * @param string $fieldName Field name or label
    * @param string|null $groupName (Optional) Group name or label
@@ -2399,7 +2400,7 @@ AND      default_value IS NOT NULL";
   }
 
   /**
-   * Given ID of a custom field, return its name as well as the name of the custom group it belongs to.
+   * @deprecated Old function only used by APIv3.
    *
    * @param array $ids
    *


### PR DESCRIPTION
Overview
----------------------------------------
NFC comment added.

Comments
----------------------------------------
Function is not used outside APIv3. This notice should discourage further proliferation.