### PR TITLE
Deprecate `returnWailingCount`

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -314,7 +314,7 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant implements \Ci
    *   Consider waiting list in event full.
    *                 calculation or not. (it is for cron job  purpose)
    *
-   * @param bool $returnWaitingCount
+   * @param false $returnWaitingCount deprecated, always false
    * @param bool $considerTestParticipant deprecated, unused
    * @param bool $onlyPositiveStatuses
    *   When FALSE, count all participant statuses where is_counted = 1.  This includes
@@ -375,6 +375,7 @@ INNER JOIN  civicrm_event event ON ( event.id = participant.event_id )
       if ($hasWaitlistedParticipants) {
         //oops here event is full and we don't want waiting count.
         if ($returnWaitingCount) {
+          CRM_Core_Error::deprecatedWarning('never reached');
           return CRM_Event_BAO_Event::eventTotalSeats($eventId, $eventSeatsWhere);
         }
         return CRM_Core_DAO::singleValueQuery('SELECT event_full_text FROM civicrm_event WHERE id = ' . (int) $eventId) ?: ts('This event is full.');

--- a/CRM/Event/Form/Registration/ParticipantConfirm.php
+++ b/CRM/Event/Form/Registration/ParticipantConfirm.php
@@ -96,7 +96,7 @@ class CRM_Event_Form_Registration_ParticipantConfirm extends CRM_Event_Form_Regi
 
       //need to confirm that though participant confirming
       //registration - but is there enough space to confirm.
-      $emptySeats = CRM_Event_BAO_Participant::eventFull($this->_eventId, TRUE, FALSE, TRUE, FALSE, TRUE);
+      $emptySeats = CRM_Event_BAO_Participant::eventFull($this->_eventId, TRUE, FALSE, FALSE, FALSE, TRUE);
       $additionalIds = CRM_Event_BAO_Participant::getAdditionalParticipantIds($this->_participantId);
       $requireSpace = 1 + count($additionalIds);
       if ($emptySeats !== NULL && ($requireSpace > $emptySeats)) {


### PR DESCRIPTION
This parameter was originally passed from 2 places. In 1 place it was passed with includeWaitingList = FALSE, making the line that used it unreacahble.

In the other the desired value really was a count of the waitlisted participants so returning some other value made no sense

https://github.com/civicrm/civicrm-core/pull/29007/files#diff-b63efe17bfef3a78023717c1172cab610664a2571caa6c53f56c45dd71b4e61dR1507
