### PR TITLE
dev/core#4905 - Refactor out duplicate CustomField getter functions

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -595,11 +595,9 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
    */
   public static function getField(int $id): ?array {
     foreach (CRM_Core_BAO_CustomGroup::getAll() as $customGroup) {
-      foreach ($customGroup['fields'] as $field) {
-        if ($field['id'] === $id) {
-          $field['custom_group'] = array_diff_key($customGroup, ['fields' => 1]);
-          return $field;
-        }
+      if (isset($customGroup['fields'][$id])) {
+        $customGroup['fields'][$id]['custom_group'] = array_diff_key($customGroup, ['fields' => 1]);
+        return $customGroup['fields'][$id];
       }
     }
     return NULL;

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2536,26 +2536,10 @@ WHERE      f.id IN ($ids)";
    * @return bool
    */
   public static function isMultiRecordField($customId) {
-    $isMultipleWithGid = FALSE;
     if (!is_numeric($customId)) {
       $customId = self::getKeyID($customId);
     }
-    if (is_numeric($customId)) {
-      $sql = "SELECT cg.id cgId
- FROM civicrm_custom_group cg
- INNER JOIN civicrm_custom_field cf
- ON cg.id = cf.custom_group_id
-WHERE cf.id = %1 AND cg.is_multiple = 1";
-      $params[1] = [$customId, 'Integer'];
-      $dao = CRM_Core_DAO::executeQuery($sql, $params);
-      if ($dao->fetch()) {
-        if ($dao->cgId) {
-          $isMultipleWithGid = $dao->cgId;
-        }
-      }
-    }
-
-    return $isMultipleWithGid;
+    return self::getField((int) $customId)['custom_group']['is_multiple'] ?? FALSE;
   }
 
   /**
@@ -2608,7 +2592,7 @@ WHERE cf.id = %1 AND cg.is_multiple = 1";
    * @return string
    */
   public function getEntity() {
-    $entity = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $this->custom_group_id, 'extends');
+    $entity = self::getField($this->id)['custom_group']['extends'];
     return in_array($entity, CRM_Contact_BAO_ContactType::basicTypes(TRUE), TRUE) ? 'Contact' : $entity;
   }
 
@@ -2617,12 +2601,11 @@ WHERE cf.id = %1 AND cg.is_multiple = 1";
    * @return string
    */
   public function getEntityName(): string {
-    $isMultiple = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $this->custom_group_id, 'is_multiple');
-    if ($isMultiple) {
-      $groupName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $this->custom_group_id, 'name');
-      return "Custom_$groupName";
+    $customGroup = self::getField($this->id)['custom_group'];
+    if ($customGroup['is_multiple']) {
+      return "Custom_{$customGroup['name']}";
     }
-    return CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $this->custom_group_id, 'extends');
+    return $customGroup['extends'];
   }
 
   /**

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -94,10 +94,10 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
     // The `is_active` filter applies to fields as well as groups.
     if (!empty($filters['is_active'])) {
       foreach ($allGroups as $groupIndex => $group) {
-        $allGroups[$groupIndex]['fields'] = array_values(array_filter($group['fields'], fn($field) => $field['is_active']));
+        $allGroups[$groupIndex]['fields'] = array_filter($group['fields'], fn($field) => $field['is_active']);
       }
     }
-    return array_values($allGroups);
+    return $allGroups;
   }
 
   /**
@@ -125,19 +125,18 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
         ->orderBy(['g.weight', 'g.name', 'f.weight', 'f.name'])
         ->execute()->fetchAll();
       foreach ($data as $groupData) {
-        $groupName = $groupData['name'];
+        $groupId = (int) $groupData['id'];
         $fieldData = CRM_Utils_Array::filterByPrefix($groupData, 'field__');
-        if (!isset($custom[$groupName])) {
+        if (!isset($custom[$groupId])) {
           self::formatFieldValues($groupData);
           $groupData['fields'] = [];
-          $custom[$groupName] = $groupData;
+          $custom[$groupId] = $groupData;
         }
         if ($fieldData['id']) {
           CRM_Core_BAO_CustomField::formatFieldValues($fieldData);
-          $custom[$groupName]['fields'][] = $fieldData;
+          $custom[$groupId]['fields'][$fieldData['id']] = $fieldData;
         }
       }
-      $custom = array_values($custom);
       Civi::cache('metadata')->set($cacheString, $custom);
     }
     return $custom;

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -2036,11 +2036,11 @@ ORDER BY civicrm_custom_group.weight,
     foreach ($submitted as $key => $value) {
       if (strpos($key, 'custom_') === 0) {
         $fieldID = (int) substr($key, 7);
-        $fieldMetadata = CRM_Core_BAO_CustomField::getCustomFieldsForContactType($contactType, FALSE)[$fieldID] ?? NULL;
+        $fieldMetadata = CRM_Core_BAO_CustomField::getField($fieldID);
         if ($fieldMetadata) {
           $htmlType = (string) $fieldMetadata['html_type'];
-          $isSerialized = CRM_Core_BAO_CustomField::isSerialized($fieldMetadata);
-          $isView = (bool) $fieldMetadata['is_view'];
+          $isSerialized = $fieldMetadata['serialize'];
+          $isView = $fieldMetadata['is_view'];
           $submitted = self::processCustomFields($mainId, $key, $submitted, $value, $fieldID, $isView, $htmlType, $isSerialized);
           if ($isView) {
             $viewOnlyCustomFields[$key] = $submitted[$key];

--- a/CRM/Import/ImportProcessor.php
+++ b/CRM/Import/ImportProcessor.php
@@ -165,15 +165,12 @@ class CRM_Import_ImportProcessor {
    * @throws \CRM_Core_Exception
    */
   public function setMetadata(array $metadata) {
-    $fieldDetails = civicrm_api3('CustomField', 'get', [
-      'return' => ['custom_group_id.title'],
-      'options' => ['limit' => 0],
-    ])['values'];
     foreach ($metadata as $index => $field) {
       if (!empty($field['custom_field_id'])) {
+        $fieldDetails = CRM_Core_BAO_CustomField::getField($field['custom_field_id']);
         // The 'label' format for import is custom group title :: custom name title
         $metadata[$index]['name'] = $index;
-        $metadata[$index]['title'] .= ' :: ' . $fieldDetails[$field['custom_field_id']]['custom_group_id.title'];
+        $metadata[$index]['title'] .= ' :: ' . $fieldDetails['custom_group']['title'];
       }
     }
     $this->metadata = $metadata;

--- a/Civi/WorkflowMessage/Traits/CustomFieldTrait.php
+++ b/Civi/WorkflowMessage/Traits/CustomFieldTrait.php
@@ -29,13 +29,47 @@ trait CustomFieldTrait {
    *    context so the user is an admin not the recipient).
    *
    * @param string $entity
-   * @param array $filters
+   * @param array $extendsEntity
    *
    * @return array
    * @throws \CRM_Core_Exception
    */
-  protected function getFilteredCustomFields(string $entity, array $filters = []): array {
-    return \CRM_Core_BAO_CustomField::getViewableCustomFields($entity, $filters);
+  protected function getFilteredCustomFields(string $entity, array $extendsEntity = []): array {
+    $fields = $entityFilters = [];
+    // Convert from ['ParticipantRole' = [1], 'ParticipantEventType' => 2], ['ParticipantEventName' => 3]
+    // to [1 => [1], 2 => [2], 3 = [3]
+    if (!empty($extendsEntity)) {
+      $entityColumns = \CRM_Core_BAO_CustomGroup::getExtendsEntityColumnIdOptions(NULL, ['values' => ['extends' => $entity]]);
+      foreach ($entityColumns as $entityColumn) {
+        if (isset($extendsEntity[$entityColumn['name']])) {
+          $entityFilters[(int) $entityColumn['id']] = (array) $extendsEntity[$entityColumn['name']];
+          foreach ($entityFilters[$entityColumn['id']] as &$value) {
+            // Cast to string because we don't want the calling function to have to worry
+            // but also the array intersect fails otherwise.
+            $value = (string) $value;
+          }
+        }
+      }
+    }
+    $groupFilters = [
+      'is_active' => TRUE,
+      'is_public' => TRUE,
+      'extends' => $entity,
+    ];
+    $allGroups = \CRM_Core_BAO_CustomGroup::getAll($groupFilters, \CRM_Core_Permission::VIEW);
+    foreach ($allGroups as $group) {
+      $entityValueMatches = array_intersect((array) $group['extends_entity_column_value'], ($entityFilters[$group['extends_entity_column_id']] ?? []));
+      if ($entityValueMatches || !$entityFilters || empty($group['extends_entity_column_id'])) {
+        foreach ($group['fields'] as $field) {
+          if (!$field['is_view']) {
+            $field += \CRM_Utils_Array::prefixKeys(array_diff_key($group, ['fields' => 1]), 'custom_group_id.');
+            $field['custom_group_id'] = $group['id'];
+            $fields[$field['id']] = $field;
+          }
+        }
+      }
+    }
+    return $fields;
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -40,34 +40,35 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     $activityTypeGroup = $this->CustomGroupCreate(['title' => 'ActivityTypeGroup', 'weight' => 3, 'extends' => 'Activity', 'extends_entity_column_value' => [1, 2]]);
 
     $allGroups = CRM_Core_BAO_CustomGroup::getAll();
+    $this->assertSame([(int) $activeGroup['id'], (int) $inactiveGroup['id'], (int) $activityTypeGroup['id']], array_keys($allGroups));
 
-    $this->assertCount(3, $allGroups);
-    $this->assertCount(2, $allGroups[0]['fields']);
-    $this->assertCount(1, $allGroups[1]['fields']);
-    $this->assertCount(0, $allGroups[2]['fields']);
+    $this->assertCount(2, $allGroups[$activeGroup['id']]['fields']);
+    $this->assertCount(1, $allGroups[$inactiveGroup['id']]['fields']);
+    $this->assertCount(0, $allGroups[$activityTypeGroup['id']]['fields']);
 
     $activeGroups = CRM_Core_BAO_CustomGroup::getAll(['is_active' => TRUE]);
     $this->assertCount(2, $activeGroups);
-    $this->assertTrue($activeGroups[0]['is_active']);
-    $this->assertSame($activeGroup['id'], $activeGroups[0]['id']);
-    $this->assertCount(1, $activeGroups[0]['fields']);
-    $this->assertTrue($activeGroups[0]['fields'][0]['is_active']);
-    $this->assertNull($activeGroups[0]['fields'][0]['help_pre']);
+    $this->assertTrue($activeGroups[$activeGroup['id']]['is_active']);
+    $this->assertSame($activeGroup['id'], array_keys($activeGroups)[0]);
+    $activeFields = array_values($activeGroups[$activeGroup['id']]['fields']);
+    $this->assertCount(1, $activeFields);
+    $this->assertTrue($activeFields[0]['is_active']);
+    $this->assertNull($activeFields[0]['help_pre']);
 
     $activityGroups = CRM_Core_BAO_CustomGroup::getAll(['extends' => 'Activity']);
     $this->assertCount(2, $activityGroups);
-    $this->assertEquals($inactiveGroup['id'], $activityGroups[0]['id']);
+    $this->assertEquals($inactiveGroup['id'], array_values($activityGroups)[0]['id']);
 
     // When in an array, "Contact" means "Contact only" so the household group will not be returned
     $contactActivityGroups = CRM_Core_BAO_CustomGroup::getAll(['is_active' => TRUE, 'extends' => ['Contact', 'Activity']]);
     $this->assertCount(1, $contactActivityGroups);
-    $this->assertEquals([$activityTypeGroup['id']], array_column($contactActivityGroups, 'id'));
-    $this->assertCount(0, $contactActivityGroups[0]['fields']);
+    $this->assertEquals([$activityTypeGroup['id']], array_keys($contactActivityGroups));
+    $this->assertCount(0, $contactActivityGroups[$activityTypeGroup['id']]['fields']);
 
     // When passed as a string, "Contact" means ["Contact", "Individual", "Household", "Organization"]
     $contactGroups = CRM_Core_BAO_CustomGroup::getAll(['is_active' => TRUE, 'extends' => 'Contact']);
-    $this->assertEquals([$activeGroup['id']], array_column($contactGroups, 'id'));
-    $this->assertCount(1, $contactGroups[0]['fields']);
+    $this->assertEquals([$activeGroup['id']], array_keys($contactGroups));
+    $this->assertCount(1, $contactGroups[$activeGroup['id']]['fields']);
 
     $this->assertCount(0, CRM_Core_BAO_CustomGroup::getAll(['extends_entity_column_value' => 3]));
     $this->assertCount(1, CRM_Core_BAO_CustomGroup::getAll(['extends_entity_column_value' => 2]));


### PR DESCRIPTION
Overview
----------------------------------------
Favoring the new CRM_Core_BAO_CustomGroup::getExtendsEntityColumnIdOptions so we only load and cache the custom schema once.

See https://lab.civicrm.org/dev/core/-/issues/4905

Before
----------------------------------------
2 cached functions load custom fields.
(well, lots more than 2, but let's look at these 2 today).

After
----------------------------------------
One less.

Technical Details
----------------------------------------
The functions being refactored out here are all less than a year old and one is marked `@internal` so I think they are safe to remove.