### PR TITLE
Flush `AllCoreTables`' entity type cache when registering auto-subscribed listeners of BAO classes for `hook_civicrm_entityTypes`

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -417,7 +417,15 @@ class Container {
         $file = (new \ReflectionClass($baoClass))->getFileName();
         $container->addResource(new \Symfony\Component\Config\Resource\FileResource($file));
         $dispatcherDefn->addMethodCall('addListenerMap', [$baoClass, $listenerMap]);
+        if ([] !== array_filter($listenerMap, function($key) {
+            return strpos($key, 'hook_civicrm_entityTypes') !== FALSE;
+          }, ARRAY_FILTER_USE_KEY)) {
+          $flushEntityTypes = TRUE;
+        }
       }
+    }
+    if ($flushEntityTypes ?? FALSE) {
+      \CRM_Core_DAO_AllCoreTables::flush();
     }
 
     // FIXME: Automatically scan BasicServices for ProviderInterface.


### PR DESCRIPTION
… as otherwise entity types registered with an auto-subscribed listener for `hook_civicrm_entityTypes` will be missing in the first init after flushing caches.

An example scenario is being described in systopia/de.systopia.eck#104.

The `array_filter()` approach was chosen to cover hooks being registered with an `&` in front of the hook name as well.

Ping @colemanw because of https://github.com/systopia/de.systopia.eck/issues/104#issuecomment-1881070597