### PR TITLE
DAO - ensure all entities are loaded when flushing cache

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -431,6 +431,9 @@ class Container {
       [new Reference('service_container')]
     ))->setFactory([new Reference(self::SELF), 'createEsmLoader'])->setPublic(TRUE);
 
+    // Reset list of entities to be populated by newly registered event listeners
+    \CRM_Core_DAO_AllCoreTables::flush();
+
     \CRM_Utils_Hook::container($container);
 
     return $container;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://github.com/systopia/de.systopia.eck/issues/104
Simpler version of #29013

Before
----------------------------------------
When the ECK extension is installed, you get an "Entity not loaded" fatal error after every cache flush.

After
----------------------------------------
No error.