### PR TITLE
Correct message template warning in MessageTemplates.php

### DIFF
--- a/CRM/Admin/Page/MessageTemplates.php
+++ b/CRM/Admin/Page/MessageTemplates.php
@@ -260,6 +260,10 @@ class CRM_Admin_Page_MessageTemplates extends CRM_Core_Page_Basic {
     $messageTemplate->find();
     while ($messageTemplate->fetch()) {
       $values[$messageTemplate->id] = ['class' => ''];
+      // Make the subject a empty string if it isn't defined
+      if (!isset($messageTemplate->msg_subject)) {
+        $messageTemplate->msg_subject = "";
+      }
       CRM_Core_DAO::storeValues($messageTemplate, $values[$messageTemplate->id]);
       // populate action links
       $this->action($messageTemplate, $action, $values[$messageTemplate->id], $links, CRM_Core_Permission::EDIT);


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
When a mailing template did not have a subject, CiviCRM gave this error:
Warning: Undefined array key "msg_subject" in content_6xxxx (line 308 of sites\default\files\civicrm\templates_c\xxxx.file.MessageTemplates.tpl.php).

After
----------------------------------------
No error message is displayed

Technical Details
----------------------------------------
We test if $messageTemplate->msg_subject is set around line 263 of <Drupal root>/CRM/Admin/Page/MessageTemplates.php and if not set assign it to the empty string. Thus eliminates the warning message.

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
