### PR TITLE
dev/core#4912 Fix 'other amount' losing focus

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -22,7 +22,7 @@
         element = document.Main.elements[i];
         if ( element.type == 'radio' && element.name === mainPriceFieldName ) {
           if (element.value == '0' ) {
-            element.click();
+            element.checked = true;
           }
           else {
             element.checked = false;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/4912 using haystack's fix.

Before
----------------------------------------
The 'other amount' field immediately loses focus

After
----------------------------------------
It does not

Technical Details
----------------------------------------
element.click() seems to remove focus
