### PR TITLE
Update get_parent_class in SmartyCompatibility.php

### DIFF
--- a/CRM/Core/SmartyCompatibility.php
+++ b/CRM/Core/SmartyCompatibility.php
@@ -54,6 +54,7 @@ if (!class_exists('Smarty')) {
  *
  */
 class CRM_Core_SmartyCompatibility extends Smarty {
+  
   public function loadFilter($type, $name) {
     if (method_exists(get_parent_class("CRM_Core_SmartyCompatibility"), 'load_filter')) {
       parent::load_filter($type, $name);

--- a/CRM/Core/SmartyCompatibility.php
+++ b/CRM/Core/SmartyCompatibility.php
@@ -4,7 +4,7 @@
  | Copyright CiviCRM LLC. All rights reserved.                        |
  |                                                                    |
  | This work is published under the GNU AGPLv3 license with some      |
- | permitted exceptions and without any warranty. For full license    |
+ | permitted exceptions and without any warranty. or full license    |
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
  */
@@ -54,9 +54,8 @@ if (!class_exists('Smarty')) {
  *
  */
 class CRM_Core_SmartyCompatibility extends Smarty {
-
   public function loadFilter($type, $name) {
-    if (method_exists(get_parent_class(), 'load_filter')) {
+    if (method_exists(get_parent_class("CRM_Core_SmartyCompatibility"), 'load_filter')) {
       parent::load_filter($type, $name);
       return;
     }
@@ -72,7 +71,7 @@ class CRM_Core_SmartyCompatibility extends Smarty {
    * @throws \SmartyException
    */
   public function load_filter($type, $name) {
-    if (method_exists(get_parent_class(), 'load_filter')) {
+    if (method_exists(get_parent_class("CRM_Core_SmartyCompatibility"), 'load_filter')) {
       parent::load_filter($type, $name);
       return;
     }
@@ -88,7 +87,7 @@ class CRM_Core_SmartyCompatibility extends Smarty {
    * @param string $modifier_impl name of PHP function to register
    */
   public function register_modifier($modifier, $modifier_impl) {
-    if (method_exists(get_parent_class(), 'register_modifier')) {
+    if (method_exists(get_parent_class("CRM_Core_SmartyCompatibility"), 'register_modifier')) {
       parent::register_modifier($modifier, $modifier_impl);
       return;
     }
@@ -96,7 +95,7 @@ class CRM_Core_SmartyCompatibility extends Smarty {
   }
 
   public function registerPlugin($type, $name, $callback, $cacheable = TRUE, $cache_attr = NULL) {
-    if (method_exists(get_parent_class(), 'registerPlugin')) {
+    if (method_exists(get_parent_class("CRM_Core_SmartyCompatibility"), 'registerPlugin')) {
       parent::registerPlugin($type, $name, $callback, $cacheable = TRUE, $cache_attr = NULL);
       return;
     }
@@ -112,7 +111,7 @@ class CRM_Core_SmartyCompatibility extends Smarty {
    * @param array $functions array of functions to handle resource
    */
   public function register_resource($type, $functions) {
-    if (method_exists(get_parent_class(), 'register_resource')) {
+    if (method_exists(get_parent_class("CRM_Core_SmartyCompatibility"), 'register_resource')) {
       parent::register_resource($type, $functions);
       return;
     }
@@ -130,7 +129,7 @@ class CRM_Core_SmartyCompatibility extends Smarty {
    * @throws \SmartyException
    */
   public function register_function($function, $function_impl, $cacheable = TRUE, $cache_attrs = NULL) {
-    if (method_exists(get_parent_class(), 'register_function')) {
+    if (method_exists(get_parent_class("CRM_Core_SmartyCompatibility"), 'register_function')) {
       parent::register_function($function, $function_impl, $cacheable = TRUE, $cache_attrs = NULL);
       return;
     }
@@ -145,7 +144,7 @@ class CRM_Core_SmartyCompatibility extends Smarty {
    * @return array
    */
   public function &get_template_vars($name = NULL) {
-    if (method_exists(get_parent_class(), 'get_template_vars')) {
+    if (method_exists(get_parent_class("CRM_Core_SmartyCompatibility"), 'get_template_vars')) {
       return parent::get_template_vars($name);
     }
     $var = parent::getTemplateVars($name);
@@ -165,7 +164,7 @@ class CRM_Core_SmartyCompatibility extends Smarty {
    * @return mixed variable value or or array of variables
    */
   public function getTemplateVars($varName = NULL, Smarty_Internal_Data $_ptr = NULL, $searchParents = TRUE) {
-    if (method_exists(get_parent_class(), 'getTemplateVars')) {
+    if (method_exists(get_parent_class("CRM_Core_SmartyCompatibility"), 'getTemplateVars')) {
       return parent::getTemplateVars($varName, $_ptr, $searchParents);
     }
     return parent::get_template_vars($varName);
@@ -181,7 +180,7 @@ class CRM_Core_SmartyCompatibility extends Smarty {
    * @return mixed|null|void
    */
   public function assign_by_ref($tpl_var, &$value) {
-    if (method_exists(get_parent_class(), 'assign_by_ref')) {
+    if (method_exists(get_parent_class("CRM_Core_SmartyCompatibility"), 'assign_by_ref')) {
       parent::assign_by_ref($tpl_var, $value);
       return;
     }
@@ -197,7 +196,7 @@ class CRM_Core_SmartyCompatibility extends Smarty {
    * @return mixed|null|void
    */
   public function clear_assign($tpl_var) {
-    if (method_exists(get_parent_class(), 'clear_assign')) {
+    if (method_exists(get_parent_class("CRM_Core_SmartyCompatibility"), 'clear_assign')) {
       parent::clear_assign($tpl_var);
       return;
     }
@@ -213,7 +212,7 @@ class CRM_Core_SmartyCompatibility extends Smarty {
    * @throws \SmartyException
    */
   public function template_exists($tpl_file) {
-    if (method_exists(get_parent_class(), 'template_exists')) {
+    if (method_exists(get_parent_class("CRM_Core_SmartyCompatibility"), 'template_exists')) {
       return parent::template_exists($tpl_file);
     }
     return parent::templateExists($tpl_file);
@@ -228,7 +227,7 @@ class CRM_Core_SmartyCompatibility extends Smarty {
    * @throws \SmartyException
    */
   public function templateExists($resource_name) {
-    if (method_exists(get_parent_class(), 'templateExists')) {
+    if (method_exists(get_parent_class("CRM_Core_SmartyCompatibility"), 'templateExists')) {
       return parent::templateExists($resource_name);
     }
     return parent::template_exists($resource_name);


### PR DESCRIPTION
Overview
----------------------------------------
Despite the PHP manual stating that get_parent_class when called with no argument from within the relevant class returns the parent class, under PHP 8.3 (https://www.php.net/manual/en/function.get-parent-class.php) we get:

Deprecated function: Calling get_parent_class() without arguments is deprecated in CRM_Core_SmartyCompatibility->getTemplateVars() (line 168 of <Drupal root>/vendor/civicrm/civicrm-core/CRM/Core/SmartyCompatibility.php.

and other similar errors.

Before
----------------------------------------
We get errors like the one above.

After
----------------------------------------
We get no similar error.

Technical Details
----------------------------------------
We replace get_parent_class() with get_parent_class("CRM_Core_SmartyCompatibility") wherever it occurs.

Comments
----------------------------------------
I am not certain that this is the right replacement. I played around with using $this instead, but it gave rise to errorrs.
