### PR TITLE
When auto-renew option available, don't auto-hide the auto-renew checkbox

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/MainMembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MainMembershipBlock.tpl
@@ -134,7 +134,7 @@
       var priceSetName = "price_"+{/literal}'{$membershipFieldID}'{literal};
       var considerUserInput = {/literal}'{$takeUserSubmittedAutoRenew}'{literal};
       if ( memTypeId ) considerUserInput = false;
-      if ( !memTypeId ) memTypeId = cj('input:radio[name='+priceSetName+']:checked').attr('membership-type');
+      if ( !memTypeId ) memTypeId = cj('input:radio[name='+priceSetName+']:checked').attr('data-membership-type-id');
 
       //does this page has only one membership type.
       var renewOptions  = {/literal}{$autoRenewMembershipTypeOptions}{literal};


### PR DESCRIPTION

Overview
----------------------------------------
memTypeId was previously "undefined" after trying to read attribute "membership-type".  The DOM shows an attribute
"data-membership-type-id" and this patch modifies the attribute read to "data-membership-type-id", which is also consistent with the variable name in the code.

Before
----------------------------------------
[Verified old behaviour with demo sandbox: probably not just me this time!]

Membership type & contribution page both set to "auto-renew option". Membership amount shown, but not the "Please renew my membership automatically." checkbox. Clicking on the membership amount shows the autorenew checkbox (!).

After
----------------------------------------
Autorenew checkbox shows immediately on page load.

