### PR TITLE
SearchKit - Allow rewrite with only whitespace

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
@@ -46,7 +46,7 @@
     {{:: ts('Rewrite Text') }}
   </label>
   <a crm-ui-help="hs({id: 'rewrite', title: ts('Rewrite Text')})"></a>
-  <textarea rows="2" class="form-control crm-flex-1" ng-if="col.rewrite" ng-model="col.rewrite" ng-model-options="{updateOn: 'blur'}"></textarea>
+  <textarea rows="2" class="form-control crm-flex-1" ng-if="col.rewrite" ng-model="col.rewrite" ng-model-options="{updateOn: 'blur'}" ng-trim="false"></textarea>
   <crm-search-admin-token-select ng-if="col.rewrite" model="col" field="rewrite" suffix=":label"></crm-search-admin-token-select>
 </div>
 <div class="form-inline">


### PR DESCRIPTION
Overview
----------------------------------------
Sometimes you genuinely want to rewrite a field to be blank (e.g. to only show an icon). This was already allowed in the searchkit renderer but the UI prevented it. This lifts the UI restriction.

Before
----------------------------------------
When configuring a search display, entering a blank space as the value for "Rewrite Text" would not be saved.

After
----------------------------------------
Now it is.