### PR TITLE
Do not permit a contact to be deleted if it is linked to a CMS user issue1290

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -758,10 +758,6 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
     ];
     CRM_Utils_Hook::pre('edit', $contact->contact_type, $contact->id, $updateParams);
 
-    $params = [1 => [$contact->id, 'Integer']];
-    $query = 'DELETE FROM civicrm_uf_match WHERE contact_id = %1';
-    CRM_Core_DAO::executeQuery($query, $params);
-
     $contact->copyValues($updateParams);
     $contact->save();
     CRM_Core_BAO_Log::register($contact->id, 'civicrm_contact', $contact->id);
@@ -911,6 +907,15 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
     $contact = new CRM_Contact_DAO_Contact();
     $contact->id = $id;
     if (!$contact->find(TRUE)) {
+      return FALSE;
+    }
+
+    // Note: we're not using CRM_Core_BAO_UFMatch::getUFId() because that's cached.
+    $ufmatch = new CRM_Core_DAO_UFMatch();
+    $ufmatch->contact_id = $id;
+    $ufmatch->domain_id = CRM_Core_Config::domainID();
+    if ($ufmatch->find(TRUE)) {
+      // Do not permit a contact to be deleted if it is linked to a site user.
       return FALSE;
     }
 

--- a/ext/search_kit/tests/phpunit/api/v4/SearchSegment/SearchSegmentTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchSegment/SearchSegmentTest.php
@@ -25,12 +25,20 @@ class SearchSegmentTest extends \PHPUnit\Framework\TestCase implements HeadlessI
   }
 
   public function tearDown(): void {
-    foreach (['Activity', 'SearchSegment', 'CustomGroup', 'Contact'] as $entity) {
+    foreach (['Activity', 'SearchSegment', 'CustomGroup'] as $entity) {
       civicrm_api4($entity, 'delete', [
         'checkPermissions' => FALSE,
         'where' => [['id', '>', '0']],
       ]);
     }
+    // Delete all contacts without a UFMatch.
+    $contacts = Contact::get(FALSE)
+      ->addSelect('id')
+      ->addJoin('UFMatch AS uf_match', 'EXCLUDE')
+      ->execute()->column('id');
+    Contact::delete(FALSE)
+      ->addWhere('id', 'IN', $contacts)
+      ->execute();
     parent::tearDown();
   }
 


### PR DESCRIPTION
Successor to https://github.com/civicrm/civicrm-core/pull/27997

Fixes: https://lab.civicrm.org/dev/core/-/issues/1290

This PR makes it impossible to Trash OR Delete a contact if it has a CMS user attached, for reasons discussed on the issue, and at: https://github.com/civicrm/civicrm-core/pull/27997#issuecomment-1792648769

I have a phpunit test to add to this too, but I'm waiting on https://github.com/civicrm/civicrm-core/pull/28877 to be merged first.