### PR TITLE
dev/core#4905 - Refactor legacy CustomGroup getters to use cached data provider

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -956,7 +956,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
    *   title
    */
   public static function getTitle($id) {
-    return CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $id, 'title');
+    return self::getAll()[$id]['title'] ?? NULL;
   }
 
   /**

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1860,39 +1860,30 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
   }
 
   /**
-   * Get the custom group titles by custom field ids.
+   * @deprecated Silly function that shouldn't exist.
+   *
+   * @see CRM_Core_BAO_CustomField::getField()
+   * for a better alternative.
    *
    * @param array $fieldIds
    *   Array of custom field ids.
    *
-   * @return array|NULL
+   * @return array
    *   array consisting of groups and fields labels with ids.
    */
-  public static function getGroupTitles($fieldIds) {
-    if (!is_array($fieldIds) && empty($fieldIds)) {
-      return NULL;
-    }
-
+  public static function getGroupTitles(array $fieldIds): array {
     $groupLabels = [];
-    $fIds = "(" . implode(',', $fieldIds) . ")";
-
-    $query = "
-SELECT  civicrm_custom_group.id as groupID, civicrm_custom_group.title as groupTitle,
-        civicrm_custom_field.label as fieldLabel, civicrm_custom_field.id as fieldID
-  FROM  civicrm_custom_group, civicrm_custom_field
- WHERE  civicrm_custom_group.id = civicrm_custom_field.custom_group_id
-   AND  civicrm_custom_field.id IN {$fIds}";
-
-    $dao = CRM_Core_DAO::executeQuery($query);
-    while ($dao->fetch()) {
-      $groupLabels[$dao->fieldID] = [
-        'fieldID' => $dao->fieldID,
-        'fieldLabel' => $dao->fieldLabel,
-        'groupID' => $dao->groupID,
-        'groupTitle' => $dao->groupTitle,
-      ];
+    foreach ($fieldIds as $fieldId) {
+      $field = CRM_Core_BAO_CustomField::getField($fieldId);
+      if ($field) {
+        $groupLabels[$fieldId] = [
+          'fieldID' => (string) $fieldId,
+          'fieldLabel' => $field['label'],
+          'groupID' => (string) $field['custom_group']['id'],
+          'groupTitle' => $field['custom_group']['title'],
+        ];
+      }
     }
-
     return $groupLabels;
   }
 

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1585,32 +1585,19 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
   }
 
   /**
-   * Check the type of custom field type (eg: Used for Individual, Contribution, etc)
-   * this function is used to get the custom fields of a type (eg: Used for Individual, Contribution, etc )
+   * @deprecated Silly function that does almost nothing.
+   * @see CRM_Core_BAO_CustomField::getField()
+   * for a more useful alternative.
    *
    * @param int $customFieldId
-   *   Custom field id.
    * @param array $removeCustomFieldTypes
    *   Remove custom fields of a type eg: array("Individual") ;.
    *
    * @return bool
-   *   false if it matches else true
-   *
-   * @throws \CRM_Core_Exception
    */
   public static function checkCustomField($customFieldId, $removeCustomFieldTypes) {
-    $query = 'SELECT cg.extends as extends
-                  FROM civicrm_custom_group as cg, civicrm_custom_field as cf
-                  WHERE cg.id = cf.custom_group_id
-                    AND cf.id =' .
-      CRM_Utils_Type::escape($customFieldId, 'Integer');
-
-    $extends = CRM_Core_DAO::singleValueQuery($query);
-
-    if (in_array($extends, $removeCustomFieldTypes)) {
-      return FALSE;
-    }
-    return TRUE;
+    $extends = CRM_Core_BAO_CustomField::getField($customFieldId)['custom_group']['extends'];
+    return !in_array($extends, $removeCustomFieldTypes);
   }
 
   /**

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -691,23 +691,6 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
   }
 
   /**
-   * Suppose you have a SQL column, $column, which includes a delimited list, and you want
-   * a WHERE condition for rows that include $value. Use whereListHas().
-   *
-   * @param string $column
-   * @param string $value
-   * @param string $delimiter
-   * @return string
-   *   SQL condition.
-   */
-  private static function whereListHas($column, $value, $delimiter = CRM_Core_DAO::VALUE_SEPARATOR) {
-    // ?
-    $bareValue = trim($value, $delimiter);
-    $escapedValue = CRM_Utils_Type::escape("%{$delimiter}{$bareValue}{$delimiter}%", 'String', FALSE);
-    return "($column LIKE \"$escapedValue\")";
-  }
-
-  /**
    * Check whether the custom group has any data for the given entity.
    *
    * @param int $entityID

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -303,16 +303,6 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test getTitle() with Invalid Params()
-   */
-  public function testGetTitleWithInvalidParams(): void {
-    $params = 99;
-    $customGroupTitle = CRM_Core_BAO_CustomGroup::getTitle($params);
-
-    $this->assertNull($customGroupTitle, 'Check that no custom Group Title is retreived');
-  }
-
-  /**
    * Test getTitle()
    */
   public function testGetTitle(): void {
@@ -328,13 +318,14 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     $customGroup = $this->customGroupCreate($groupParams);
     $customGroupId = $customGroup['id'];
 
+    // Should return NULL for a group that doesn't exist
+    $this->assertNull(CRM_Core_BAO_CustomGroup::getTitle($customGroupId + 99));
+
     //get the custom group title
     $title = CRM_Core_BAO_CustomGroup::getTitle($customGroupId);
 
     //check for object update
     $this->assertEquals($customGroupTitle, $title);
-
-    $this->customGroupDelete($customGroupId);
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -160,10 +160,14 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
    * Test calling GetTree for a custom field that extends a non numerical Event Type.
    */
   public function testGetTreeEventSubTypeAlphabetical(): void {
-    $eventType = $this->callAPISuccess('OptionValue', 'Create', ['option_group_id' => 'event_type', 'value' => 'meeting', 'label' => 'Meeting']);
-    $customGroup = $this->CustomGroupCreate(['extends' => 'Event', 'extends_entity_column_value' => ['Meeting']]);
+    $eventType = $this->callAPISuccess('OptionValue', 'Create', ['option_group_id' => 'event_type', 'value' => '99_ish', 'name' => 'Meeting_99', 'label' => 'Meeting 99']);
+    $customGroup = $this->CustomGroupCreate(['extends' => 'Event', 'extends_entity_column_value' => ['99_ish']]);
     $customField = $this->customFieldCreate(['custom_group_id' => $customGroup['id']]);
-    $result1 = CRM_Core_BAO_CustomGroup::getTree('Event', NULL, NULL, NULL, CRM_Core_DAO::VALUE_SEPARATOR . 'meeting' . CRM_Core_DAO::VALUE_SEPARATOR);
+    $result1 = CRM_Core_BAO_CustomGroup::getTree('Event', NULL, NULL, NULL, CRM_Core_DAO::VALUE_SEPARATOR . 'meeting_99' . CRM_Core_DAO::VALUE_SEPARATOR);
+    $this->assertEquals('Custom Field', $result1[$customGroup['id']]['fields'][$customField['id']]['label']);
+    $result1 = CRM_Core_BAO_CustomGroup::getTree('Event', NULL, NULL, NULL, ['99_ish']);
+    $this->assertEquals('Custom Field', $result1[$customGroup['id']]['fields'][$customField['id']]['label']);
+    $result1 = CRM_Core_BAO_CustomGroup::getTree('Event', NULL, NULL, NULL, ['99_ISH']);
     $this->assertEquals('Custom Field', $result1[$customGroup['id']]['fields'][$customField['id']]['label']);
     $this->customGroupDelete($customGroup['id']);
     $this->callAPISuccess('OptionValue', 'delete', ['id' => $eventType['id']]);

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -530,48 +530,34 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test getGroupTitles() with Invalid Params()
-   */
-  public function testGetGroupTitlesWithInvalidParams(): void {
-    $params = [99];
-    $groupTitles = CRM_Core_BAO_CustomGroup::getGroupTitles($params);
-    $this->assertTrue(empty($groupTitles), 'Check that no titles are received');
-  }
-
-  /**
    * Test getGroupTitles()
    */
   public function testGetGroupTitles(): void {
     $groupParams = [
       'title' => 'Test Group',
       'name' => 'test_custom_group',
-      'style' => 'Tab',
-      'extends' => 'Individual',
-      'weight' => 10,
-      'is_active' => 1,
+      'is_active' => 0,
     ];
 
     $customGroup = $this->customGroupCreate($groupParams);
 
     $fieldParams = [
       'label' => 'Custom Field',
-      'html_type' => 'Text',
-      'data_type' => 'String',
-      'is_required' => 1,
-      'is_searchable' => 0,
-      'is_active' => 1,
+      'is_active' => 0,
       'custom_group_id' => $customGroup['id'],
     ];
 
     $customField = $this->customFieldCreate($fieldParams);
     $customFieldId = $customField['id'];
 
-    $params = [$customFieldId];
+    $this->assertEmpty(CRM_Core_BAO_CustomGroup::getGroupTitles([$customFieldId + 99]));
 
-    $groupTitles = CRM_Core_BAO_CustomGroup::getGroupTitles($params);
+    $groupTitles = CRM_Core_BAO_CustomGroup::getGroupTitles([$customFieldId]);
 
-    $this->assertEquals($groupTitles[$customFieldId]['groupTitle'], 'Test Group', 'Check Group Title.');
-    $this->customGroupDelete($customGroup['id']);
+    $this->assertEquals('Test Group', $groupTitles[$customFieldId]['groupTitle']);
+    $this->assertEquals($customGroup['id'], $groupTitles[$customFieldId]['groupID']);
+    $this->assertEquals('Custom Field', $groupTitles[$customFieldId]['fieldLabel']);
+    $this->assertEquals($customField['id'], $groupTitles[$customFieldId]['fieldID']);
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -401,10 +401,6 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
       'title' => 'My Custom Group',
       'name' => 'my_custom_group',
       'extends' => 'Individual',
-      'help_pre' => 'Custom Group Help Pre',
-      'help_post' => 'Custom Group Help Post',
-      'is_active' => 1,
-      'collapse_display' => 1,
     ];
 
     $customGroup = $this->customGroupCreate($groupParams);
@@ -415,23 +411,12 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     $fieldParams = [
       'custom_group_id' => $customGroupId,
       'label' => $customFieldLabel,
-      'html_type' => 'Text',
-      'data_type' => 'String',
-      'is_required' => 1,
-      'is_searchable' => 0,
-      'is_active' => 1,
     ];
 
     $customField = $this->customFieldCreate($fieldParams);
     $customField = $customField['values'][$customField['id']];
 
     $customFieldId = $customField['id'];
-
-    //check db for custom field
-    $dbCustomFieldLabel = $this->assertDBNotNull('CRM_Core_DAO_CustomField', $customFieldId, 'label', 'id',
-      'Database check for custom field record.'
-    );
-    $this->assertEquals($customFieldLabel, $dbCustomFieldLabel);
 
     //check the custom field type.
     $usedFor = CRM_Core_BAO_CustomGroup::checkCustomField(
@@ -443,9 +428,6 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
       $customFieldId, ['Contribution', 'Membership', 'Participant']
     );
     $this->assertEquals(TRUE, $usedFor);
-
-    $this->customFieldDelete($customField['id']);
-    $this->customGroupDelete($customGroup['id']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Cleans up some legacy functions to be less inscrutable, more efficient, and better tested.

See https://lab.civicrm.org/dev/core/-/issues/4905

Technical Details
----------------------------------------
Some of these functions were pretty awful. My goal here was to keep their signatures and output exactly the same. I've annotated them all `@deprecated` to discourage any further use. But at least for now they will be more efficient.