### PR TITLE
(NFC) composer.json - Add comments block for the `patches` section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -264,6 +264,7 @@
         "ignore": ["examples"]
       }
     },
+    "patches-comments": "For information about defining patches via composer.json, see https://docs.civicrm.org/dev/en/latest/core/dependencies/",
     "patches": {
       "adrienrn/php-mimetyper": {
         "Update gitignore to ensure that sites that manage via git don't miss out on the important db.json file": "https://patch-diff.githubusercontent.com/raw/adrienrn/php-mimetyper/pull/15.patch",


### PR DESCRIPTION
Overview
----------------------------------------

Add some in-place documentation for how to handle the `patches` list.

cc @aydun @demeritcowboy 

Technical Details
----------------------------------------

Adding comments to `composer.json` is generally awkward:

* JSON lacks support for language-level comments
* `composer` validates the JSON and complains about unrecognized keys

___But___ the `extra` section is exempt from validation. So we can add the item `extra["-PATCHES-COMMENTS-"]` right in front of `extra["patches"]`
