### PR TITLE
Display labels for numeric custom field key values in Log Detail Report

### DIFF
--- a/CRM/Logging/ReportDetail.php
+++ b/CRM/Logging/ReportDetail.php
@@ -175,6 +175,9 @@ class CRM_Logging_ReportDetail extends CRM_Report_Form {
       return [];
     }
 
+    // $cfDataTypesToBeFormatted corresponds to values in the db column civicrm_custom_field.data_type
+    $cfDataTypesToBeFormatted = array("Int", "ContactReference", "EntityReference");
+
     // populate $rows with only the differences between $changed and $original (skipping certain columns and NULL ↔ empty changes unless raw requested)
     $skipped = ['id'];
     $nRows = $rows = [];
@@ -218,12 +221,24 @@ class CRM_Logging_ReportDetail extends CRM_Report_Form {
           $to = implode(', ', array_filter($tos));
         }
 
+        $cfArray = [];
         $tableDAOClass = CRM_Core_DAO_AllCoreTables::getClassForTable($table);
+        $fkClassName = NULL;
         if (!empty($tableDAOClass)) {
           $tableDAOFields = (new $tableDAOClass())->fields();
           // If this field is a foreign key, then we can later use the foreign
           // class to translate the id into something more useful for display.
           $fkClassName = $tableDAOFields[$field]['FKClassName'] ?? NULL;
+        }
+        else {
+          // Since this table didn't match a core table, check if it's a custom field.
+          $customGroup = CRM_Core_BAO_CustomGroup::getGroup(['table_name' => $table]);
+          foreach ($customGroup['fields'] ?? [] as $customField) {
+            if ($customField['column_name'] === $field) {
+              $cfArray = $customField;
+              break;
+            }
+          }
         }
         if (isset($values[$field][$from])) {
           $from = $values[$field][$from];
@@ -231,12 +246,42 @@ class CRM_Logging_ReportDetail extends CRM_Report_Form {
         elseif (!empty($from) && !empty($fkClassName)) {
           $from = $this->convertForeignKeyValuesToLabels($fkClassName, $field, $from);
         }
+        elseif (!empty($from) && is_numeric($from) && array_key_exists("id", $cfArray) && is_int($cfArray["id"])) {
+          // Translate the id into something more useful for display, namely for id's that refer to option values and contacts.
+          $fromAsArray = civicrm_api3('CustomValue', 'getdisplayvalue', [
+            'entity_id' => $this->cid,
+            'custom_field_id' => $cfArray["id"],
+            'custom_field_value' => $from,
+          ]);
+          if (array_key_exists("data_type", $cfArray) && in_array($cfArray["data_type"], $cfDataTypesToBeFormatted)) {
+            $from = $this->formatLabelAndIdForDisplay($fromAsArray['values'][$cfArray["id"]]['display'], $from);
+          }
+          elseif (!empty($fromAsArray['values'][$cfArray["id"]]['display'])) {
+            $from = $fromAsArray['values'][$cfArray["id"]]['display'];
+          }
+        }
+
         if (isset($values[$field][$to])) {
           $to = $values[$field][$to];
         }
         elseif (!empty($to) && !empty($fkClassName)) {
           $to = $this->convertForeignKeyValuesToLabels($fkClassName, $field, $to);
         }
+        elseif (!empty($to) && is_numeric($to) && array_key_exists("id", $cfArray) && is_int($cfArray["id"])) {
+          // Translate the id into something more useful for display, namely for id's that refer to option values and contacts.
+          $toAsArray = civicrm_api3('CustomValue', 'getdisplayvalue', [
+            'entity_id' => $this->cid,
+            'custom_field_id' => $cfArray["id"],
+            'custom_field_value' => $to,
+          ]);
+          if (array_key_exists("data_type", $cfArray) && in_array($cfArray["data_type"], $cfDataTypesToBeFormatted)) {
+            $to = $this->formatLabelAndIdForDisplay($toAsArray['values'][$cfArray["id"]]['display'], $to);
+          }
+          elseif (!empty($toAsArray['values'][$cfArray["id"]]['display'])) {
+            $to = $toAsArray['values'][$cfArray["id"]]['display'];
+          }
+        }
+
         if (isset($titles[$field])) {
           $field = $titles[$field];
         }
@@ -486,6 +531,17 @@ class CRM_Logging_ReportDetail extends CRM_Report_Form {
       return "{$labelValue} (id: {$keyval})";
     }
     return (string) $keyval;
+  }
+
+  /**
+   * Return a string with the label and value combined.
+   *
+   * @param string $labelValue
+   * @param int $keyval
+   * @return string
+   */
+  private function formatLabelAndIdForDisplay(string $labelValue, int $keyval): string {
+    return empty($labelValue) ? (string) $keyval : "{$labelValue} (id: {$keyval})";
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Enhancement to the Log Detail Report to **display the text labels** for numeric foreign key values (option values or contact IDs) on custom fields.
See [forum post 45744](https://civicrm.stackexchange.com/questions/45744/how-to-generate-a-report-of-changes-to-a-contacts-custom-fields-showing-the-be)

Before
----------------------------------------
The "Changed From" and "Changed To" columns displayed only the numeric ids.

With sample custom fields as...
![image](https://github.com/civicrm/civicrm-core/assets/112041049/bf1fe456-9056-42d7-a778-d6d93adf6fb6)

... the log report only displays the ids.
![image](https://github.com/civicrm/civicrm-core/assets/112041049/02c0d201-83cf-457a-b678-541d0a26aebf)


After
----------------------------------------
The "Changed From" and "Changed To" columns display the lookup value of the numeric id, in addition to the id.

![image](https://github.com/civicrm/civicrm-core/assets/112041049/1baf2a33-ed0a-48ce-b626-8c3b8e3ff26d)


Comments
----------------------------------------
This enhancement only works for single numeric values, not for multi-select custom fields, which contain a list of numeric ids.
