### PR TITLE
dev/core#4905 - Refactor CustomField getters to use cached provider

### DIFF
--- a/CRM/Contact/Form/Search/Builder.php
+++ b/CRM/Contact/Form/Search/Builder.php
@@ -568,9 +568,11 @@ class CRM_Contact_Form_Search_Builder extends CRM_Contact_Form_Search {
 
       foreach ($value as $key1 => $value1) {
         //CRM-2676, replacing the conflict for same custom field name from different custom group.
-        $customGroupName = CRM_Core_BAO_Mapping::getCustomGroupName($key1);
+        $customFieldId = CRM_Core_BAO_CustomField::getKeyID($key1);
 
-        if ($customGroupName) {
+        if ($customFieldId) {
+          $customGroupName = CRM_Core_BAO_CustomField::getField($customFieldId)['custom_group']['title'];
+          $customGroupName = CRM_Utils_String::ellipsify($customGroupName, 13);
           $relatedMapperFields[$key][$key1] = $mapperFields[$key][$key1] = $customGroupName . ': ' . $value1['title'];
         }
         else {

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -561,25 +561,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
    */
   public static function getFieldObject($fieldID) {
     $field = new CRM_Core_BAO_CustomField();
-
-    // check if we can get the field values from the system cache
-    $cacheKey = "CRM_Core_DAO_CustomField_{$fieldID}";
-    $cache = CRM_Utils_Cache::singleton();
-    $fieldValues = $cache->get($cacheKey);
-    if (empty($fieldValues)) {
-      $field->id = $fieldID;
-      if (!$field->find(TRUE)) {
-        throw new CRM_Core_Exception('Cannot find Custom Field ' . $fieldID);
-      }
-      $fieldValues = [];
-      CRM_Core_DAO::storeValues($field, $fieldValues);
-
-      $cache->set($cacheKey, $fieldValues);
-    }
-    else {
-      $field->copyValues($fieldValues);
-    }
-
+    $field->copyValues(self::getField($fieldID));
     return $field;
   }
 

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -114,9 +114,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
       $custom = [];
       $select = ['g.*'];
       foreach (array_keys(CRM_Core_BAO_CustomField::getSupportedFields()) as $fieldKey) {
-        if ($fieldKey !== 'custom_group_id') {
-          $select[] = "f.`$fieldKey` AS `field__$fieldKey`";
-        }
+        $select[] = "f.`$fieldKey` AS `field__$fieldKey`";
       }
       // Avoid calling the API to prevent recursion or early-bootstrap issues.
       $data = \CRM_Utils_SQL_Select::from('civicrm_custom_group g')

--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -532,15 +532,16 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping implements \Civi\Core\Ho
   }
 
   /**
-   * Function returns all  Custom group Names.
+   * Unused function.
+   * @deprecated since 5.71 will be removed around 5.85.
    *
-   * @param int $customfieldId
-   *   Related file id.
+   * @param string $customfieldId
    *
    * @return null|string
    *   $customGroupName all custom group names
    */
   public static function getCustomGroupName($customfieldId) {
+    CRM_Core_Error::deprecatedFunctionWarning('CRM_Core_BAO_CustomField::getField');
     if ($customFieldId = CRM_Core_BAO_CustomField::getKeyID($customfieldId)) {
       $customGroupId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', $customFieldId, 'custom_group_id');
       $customGroupName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $customGroupId, 'title');

--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -240,8 +240,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
       foreach ($value as $key1 => $value1) {
         //CRM-2676, replacing the conflict for same custom field name from different custom group.
         if ($customFieldId = CRM_Core_BAO_CustomField::getKeyID($key1)) {
-          $customGroupId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', $customFieldId, 'custom_group_id');
-          $customGroupName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $customGroupId, 'title');
+          $customGroupName = CRM_Core_BAO_CustomField::getField($customFieldId)['custom_group']['title'];
           $this->_mapperFields[$key][$key1] = $value1['title'] . ' :: ' . $customGroupName;
           if (in_array($key1, $addressCustomFields)) {
             $noSearchable[] = $value1['title'] . ' :: ' . $customGroupName;


### PR DESCRIPTION
Overview
----------------------------------------
More cleanup for https://lab.civicrm.org/dev/core/-/issues/4905 
Reduces code complexity and wastes less memory by consolidating a few different techniques for retrieving custom fields.