### PR TITLE
Fix JS error and allow focus of Other Amount field

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -23,6 +23,9 @@
         if ( element.type == 'radio' && element.name === mainPriceFieldName ) {
           if (element.value == '0' ) {
             element.checked = true;
+            // Copied from `updatePriceSetHighlight()` below which isn't available here.
+            cj('#priceset .price-set-row span').removeClass('highlight');
+            cj('#priceset .price-set-row input:checked').parent().addClass('highlight');
           }
           else {
             element.checked = false;
@@ -321,7 +324,7 @@
       var isRecur = cj('input[id="is_recur"]:checked');
 
       var quickConfig = {/literal}'{$quickConfig}'{literal};
-      if (cj("#auto_renew") && quickConfig) {
+      if (cj("#auto_renew").length && quickConfig) {
         showHideAutoRenew(null);
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Follow up to #29021 

Before
----------------------------------------
JS error & input label not highlighted.

After
----------------------------------------
No JS error & input label is highlighted.

Comments
----------------------------------------
Lab issue ref: https://lab.civicrm.org/dev/core/-/issues/4912