### PR TITLE
dev/core#4905 - Add CustomGroup::getGroup() function

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2647,7 +2647,7 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
       default:
         if (!$tableName) {
           $custom = explode('_', $type);
-          $tableName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $custom[1], 'table_name');
+          $tableName = CRM_Core_BAO_CustomGroup::getGroup(['id' => $custom[1]])['table_name'];
         }
         $queryString = "SELECT count(id) FROM $tableName WHERE entity_id = $contactId";
         return (int) CRM_Core_DAO::singleValueQuery($queryString);

--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -768,7 +768,7 @@ WHERE extends = %1 AND ' . implode(" OR ", $subTypeClause);
       return FALSE;
     }
 
-    $tableName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $gID, 'table_name');
+    $tableName = CRM_Core_BAO_CustomGroup::getGroup(['id' => $gID])['table_name'];
 
     // drop triggers CRM-13587
     CRM_Core_DAO::dropTriggers($tableName);

--- a/CRM/Contact/Form/CustomData.php
+++ b/CRM/Contact/Form/CustomData.php
@@ -274,7 +274,7 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
       $this->_tableID,
       $this->_entityType
     );
-    $table = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $this->_groupID, 'table_name');
+    $table = CRM_Core_BAO_CustomGroup::getGroup(['id' => $this->_groupID])['table_name'];
     $cgcount = CRM_Core_BAO_CustomGroup::customGroupDataExistsForEntity($this->_tableID, $table, TRUE);
     $cgcount += 1;
     $buttonName = $this->controller->getButtonName();

--- a/CRM/Contact/Page/View/CustomData.php
+++ b/CRM/Contact/Page/View/CustomData.php
@@ -42,7 +42,7 @@ class CRM_Contact_Page_View_CustomData extends CRM_Core_Page {
 
     // If no cid supplied, look it up
     if (!$this->_contactId && $this->_recId) {
-      $tableName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $this->_groupId, 'table_name');
+      $tableName = CRM_Core_BAO_CustomGroup::getGroup(['id' => $this->_groupId])['table_name'] ?? NULL;
       if ($tableName) {
         $this->_contactId = CRM_Core_DAO::singleValueQuery("SELECT entity_id FROM `$tableName` WHERE id = %1", [1 => [$this->_recId, 'Integer']]);
       }

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -29,6 +29,26 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
   }
 
   /**
+   * Retrieve a group by id, name, etc.
+   *
+   * @param array $filter
+   *   e.g. `['id' => 23]` or `['name' => 'MyGroup']`
+   * @return array|null
+   *   Result includes all custom fields in addition to group info.
+   */
+  public static function getGroup(array $filter): ?array {
+    if (isset($filter['id']) && count($filter) === 1) {
+      return self::getAll()[$filter['id']] ?? NULL;
+    }
+    foreach (self::getAll() as $group) {
+      if (array_intersect_assoc($filter, $group) === $filter) {
+        return $group;
+      }
+    }
+    return NULL;
+  }
+
+  /**
    * Return custom groups and fields in a nested array, with optional filters and permissions applied.
    *
    * With no params, this returns every custom group and field, including disabled.

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -193,7 +193,7 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
    */
   public function buildQuickForm() {
     if ($this->_gid) {
-      $this->_title = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $this->_gid, 'title');
+      $this->_title = CRM_Core_BAO_CustomGroup::getGroup(['id' => $this->_gid])['title'];
       $this->setTitle($this->_title . ' - ' . ($this->_id ? ts('Edit Field') : ts('New Field')));
     }
     $this->assign('gid', $this->_gid);
@@ -826,7 +826,7 @@ AND    option_group_id = %2";
           $options = array_map(['CRM_Core_DAO', 'escapeString'], array_filter($fields['option_value'], 'strlen'));
           $optionQuery = '"' . implode('","', $options) . '"';
         }
-        $table = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $self->_gid, 'table_name');
+        $table = CRM_Core_BAO_CustomGroup::getGroup(['id' => $self->_gid])['table_name'];
         $column = $self->_values['column_name'];
         $invalid = CRM_Core_DAO::singleValueQuery("SELECT COUNT(*) FROM `$table` WHERE `$column` NOT IN ($optionQuery)");
         if ($invalid) {
@@ -944,7 +944,7 @@ AND    option_group_id = %2";
    * @throws CRM_Core_Exception
    */
   public function getMultiValueCount() {
-    $table = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $this->_gid, 'table_name');
+    $table = CRM_Core_BAO_CustomGroup::getGroup(['id' => $this->_gid])['table_name'];
     $column = $this->_values['column_name'];
     $sp = CRM_Core_DAO::VALUE_SEPARATOR;
     $sql = "SELECT COUNT(*) FROM `$table` WHERE `$column` LIKE '{$sp}%{$sp}%{$sp}'";

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -74,6 +74,14 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     $this->assertCount(1, CRM_Core_BAO_CustomGroup::getAll(['extends_entity_column_value' => 2]));
     $this->assertCount(1, CRM_Core_BAO_CustomGroup::getAll(['extends_entity_column_value' => [2, 4]]));
     $this->assertCount(3, CRM_Core_BAO_CustomGroup::getAll(['extends_entity_column_value' => [1, NULL]]));
+
+    // Test getGroup by id
+    $this->assertEquals('ActiveGroup', CRM_Core_BAO_CustomGroup::getGroup(['id' => $activeGroup['id']])['title']);
+    $this->assertEquals('ActivityTypeGroup', CRM_Core_BAO_CustomGroup::getGroup(['id' => $activityTypeGroup['id']])['title']);
+    // Test getGroup by other criteria
+    $this->assertFalse(CRM_Core_BAO_CustomGroup::getGroup(['name' => 'InactiveGroup'])['is_active']);
+    $this->assertEquals('InactiveGroup', CRM_Core_BAO_CustomGroup::getGroup(['name' => 'InactiveGroup', 'is_active' => FALSE])['title']);
+    $this->assertEquals('ActivityTypeGroup', CRM_Core_BAO_CustomGroup::getGroup(['name' => 'ActivityTypeGroup', 'extends' => 'Activity', 'is_active' => TRUE])['title']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
New helper function to make it simple to retrieve custom group from the cache.
Refactors uncached lookups to use the new function.

Part of https://lab.civicrm.org/dev/core/-/issues/4905 cleanup.