### PR TITLE
Fix isMultiRecordField function to return group id

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2527,17 +2527,19 @@ WHERE      f.id IN ($ids)";
   }
 
   /**
-   * Is this field a multi record field.
+   * If custom field belongs to a multi-record group, return the group id.
    *
-   * @param int $customId
+   * @param string|int $customId
+   *   Either the numeric id or a string like "custom_xx"
    *
-   * @return bool
+   * @return int|false
    */
   public static function isMultiRecordField($customId) {
     if (!is_numeric($customId)) {
       $customId = self::getKeyID($customId);
     }
-    return self::getField((int) $customId)['custom_group']['is_multiple'] ?? FALSE;
+    $customGroup = self::getField((int) $customId)['custom_group'] ?? NULL;
+    return empty($customGroup['is_multiple']) ? FALSE : $customGroup['id'];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a master-only regression where a function's output was changed during refactor.
See #29011

Technical Details
----------------------------------------
In bc255dc3 I made the naive mistake of believing what the docblock said about this function, and so I accidentally changed its output. The docblock was wrong: it didn't always return a boolean.

This changes it back to return `int|bool`, and updates the docblock to actually say what the function does.