### PR TITLE
Search/Advanced.tpl: strip accordion header to fix odd alignment

### DIFF
--- a/templates/CRM/Contact/Form/Search/Advanced.tpl
+++ b/templates/CRM/Contact/Form/Search/Advanced.tpl
@@ -14,6 +14,7 @@
   {include file="CRM/Contact/Form/Search/Intro.tpl"}
 
   <details class="crm-advanced_search_form-accordion" {if !$rows}open{/if} >
+    {strip}
     <summary class="crm-master-accordion-header">
       {if !empty($savedSearch)}
         {ts 1=$savedSearch.name}Edit %1 Smart Group Criteria{/ts}
@@ -24,6 +25,7 @@
       {/if}
       {help id='id-advanced-intro'}
     </summary>
+    {/strip}
     <div class="crm-accordion-body">
       {include file="CRM/Contact/Form/Search/AdvancedCriteria.tpl"}
     </div>


### PR DESCRIPTION
Overview
----------------------------------------

Fixes a 1-space alignment issue in the "Contacts > Advanced Search" accordion header.

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/b51b7608-c5b0-4ba6-a385-da43bfdb1c12)

After
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/4d051257-450c-49fd-bc49-96a1ce3fd90e)

cc @vingle @artfulrobot