### PR TITLE
API4 - Trigger civi.api.exception event in API4

### DIFF
--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -80,10 +80,6 @@ class Kernel {
       return $this->formatResult($apiRequest, $apiResponse);
     }
     catch (\Exception $e) {
-      if ($apiRequest) {
-        $this->dispatcher->dispatch('civi.api.exception', new ExceptionEvent($e, NULL, $apiRequest, $this));
-      }
-
       if ($e instanceof \CRM_Core_Exception) {
         $err = $this->formatApiException($e, $apiRequest);
       }
@@ -139,23 +135,31 @@ class Kernel {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function runRequest($apiRequest) {
-    $this->boot($apiRequest);
-
-    [$apiProvider, $apiRequest] = $this->resolve($apiRequest);
-
     try {
-      $this->authorize($apiProvider, $apiRequest);
+      $this->boot($apiRequest);
+
+      [$apiProvider, $apiRequest] = $this->resolve($apiRequest);
+
+      try {
+        $this->authorize($apiProvider, $apiRequest);
+      }
+      catch (\Civi\API\Exception\UnauthorizedException $e) {
+        // We catch and re-throw to log for visibility
+        \CRM_Core_Error::backtrace('API Request Authorization failed', TRUE);
+        throw $e;
+      }
+
+      [$apiProvider, $apiRequest] = $this->prepare($apiProvider, $apiRequest);
+      $result = $apiProvider->invoke($apiRequest);
+
+      return $this->respond($apiProvider, $apiRequest, $result);
     }
-    catch (\Civi\API\Exception\UnauthorizedException $e) {
-      // We catch and re-throw to log for visibility
-      \CRM_Core_Error::backtrace('API Request Authorization failed', TRUE);
+    catch (\Exception $e) {
+      if ($apiRequest) {
+        $this->dispatcher->dispatch('civi.api.exception', new ExceptionEvent($e, NULL, $apiRequest, $this));
+      }
       throw $e;
     }
-
-    [$apiProvider, $apiRequest] = $this->prepare($apiProvider, $apiRequest);
-    $result = $apiProvider->invoke($apiRequest);
-
-    return $this->respond($apiProvider, $apiRequest, $result);
   }
 
   /**

--- a/tests/phpunit/Civi/API/KernelTest.php
+++ b/tests/phpunit/Civi/API/KernelTest.php
@@ -72,7 +72,30 @@ class KernelTest extends \CiviUnitTestCase {
     $this->assertEquals('badzes', $result['the']);
   }
 
-  // TODO testAuthorizeException, testPrepareException, testRespondException, testExceptionException
+  public function testExceptionException(): void {
+    $test = $this;
+    $this->dispatcher->addListener('civi.api.exception', function (\Civi\API\Event\ExceptionEvent $event) use ($test) {
+      $test->assertEquals('Frobnication encountered an exception', $event->getException()->getMessage());
+    });
+
+    $this->kernel->registerApiProvider($this->createWidgetFrobnicateProvider());
+    $result = $this->kernel->runSafe('Widget', 'frobnicate', [
+      'version' => self::MOCK_VERSION,
+      'exception' => 'Frobnication encountered an exception',
+    ]);
+
+    $expectedEventSequence = [
+      ['name' => 'civi.api.resolve', 'class' => 'Civi\API\Event\ResolveEvent'],
+      ['name' => 'civi.api.authorize', 'class' => 'Civi\API\Event\AuthorizeEvent'],
+      ['name' => 'civi.api.prepare', 'class' => 'Civi\API\Event\PrepareEvent'],
+      ['name' => 'civi.api.exception', 'class' => 'Civi\API\Event\ExceptionEvent'],
+    ];
+    $this->assertEquals($expectedEventSequence, $this->actualEventSequence);
+    $this->assertEquals('Frobnication encountered an exception', $result['error_message']);
+    $this->assertEquals(1, $result['is_error']);
+  }
+
+  // TODO testAuthorizeException, testPrepareException, testRespondException
 
   /**
    * Create an API provider for entity "Widget" with action "frobnicate".
@@ -82,6 +105,9 @@ class KernelTest extends \CiviUnitTestCase {
   public function createWidgetFrobnicateProvider() {
     $provider = new \Civi\API\Provider\AdhocProvider(self::MOCK_VERSION, 'Widget');
     $provider->addAction('frobnicate', 'access CiviCRM', function ($apiRequest) {
+      if (!empty($apiRequest['params']['exception'])) {
+        throw new \Exception($apiRequest['params']['exception']);
+      }
       return civicrm_api3_create_success([98 => 'frob']);
     });
     return $provider;


### PR DESCRIPTION
Overview
----------------------------------------
In API3, exceptions that are encountered during execution trigger a `civi.api.exception` event. Since API4 uses a different entry point to the API Kernel (`runSafe()` vs. `runRequest()` called in `AbstractAction::run()`), the event is not triggered via API4. This is fixed by triggering the event in `runRequest()` instead.

Before
----------------------------------------
Exceptions encountered in API4 actions do not trigger `civi.api.exception` events.

After
----------------------------------------
Exceptions trigger `civi.api.exception` events.

Technical Details
----------------------------------------
Moving the event trigger means that other exceptions thrown in `runSafe()` would no longer trigger `civi.api.exception`. In practice, this currently only applies to one exception in `Request::create()`. If this is a concern, we may want to duplicate the event trigger in `AbstractAction::execute()` instead, or refactor the Kernel so there's a common entry point for API3 and API4.

Comments
----------------------------------------
I tried to add an API4-specific test case, but couldn't quite figure out a way to get an ad-hoc API4 to use the test kernel. I added a test that should cover any API3 regressions.