### PR TITLE
[REF] CRM_Core_Session - Streamline lookup of current user id & display name

### DIFF
--- a/CRM/Core/Session.php
+++ b/CRM/Core/Session.php
@@ -550,12 +550,9 @@ class CRM_Core_Session {
    * @return int|null
    *   contact ID of logged in user
    */
-  public static function getLoggedInContactID() {
-    $session = CRM_Core_Session::singleton();
-    if (!is_numeric($session->get('userID'))) {
-      return NULL;
-    }
-    return (int) $session->get('userID');
+  public static function getLoggedInContactID(): ?int {
+    $userId = CRM_Core_Session::singleton()->get('userID');
+    return is_numeric($userId) ? (int) $userId : NULL;
   }
 
   /**
@@ -565,12 +562,12 @@ class CRM_Core_Session {
    *
    * @throws CRM_Core_Exception
    */
-  public function getLoggedInContactDisplayName() {
+  public function getLoggedInContactDisplayName(): string {
     $userContactID = CRM_Core_Session::getLoggedInContactID();
     if (!$userContactID) {
       return '';
     }
-    return civicrm_api3('Contact', 'getvalue', ['id' => $userContactID, 'return' => 'display_name']);
+    return CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $userContactID, 'display_name') ?? '';
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Minor performance improvement, simplifies user lookups in CRM_Core_Session.

Technical Details
----------------------------------------
Fetching a session variable involves a few extra calculations, so let's not do it twice for no reason.

Calling the api uses an uncached query, vs getFieldValue which is faster and caches the result.
