### PR TITLE
Fix missing links on contact summary relationships tab

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -2279,7 +2279,7 @@ SELECT count(*)
       if (empty($record["contact_id_$ab"]) && !empty($record['id'])) {
         $record["contact_id_$ab"] = CRM_Core_DAO::getFieldValue(__CLASS__, $record['id'], "contact_id_$ab");
       }
-      if (!\Civi\Api4\Utils\CoreUtil::checkAccessDelegated('Contact', 'update', ['id' => $record["contact_id_$ab"]], $userID)) {
+      if (!empty($record["contact_id_$ab"]) && !\Civi\Api4\Utils\CoreUtil::checkAccessDelegated('Contact', 'update', ['id' => $record["contact_id_$ab"]], $userID)) {
         return FALSE;
       }
     }

--- a/Civi/Api4/Action/GetLinks.php
+++ b/Civi/Api4/Action/GetLinks.php
@@ -151,9 +151,8 @@ class GetLinks extends BasicGetAction {
     if (!$this->getCheckPermissions()) {
       return;
     }
-    $allowedApiActions = $this->getAllowedEntityActions();
     foreach ($links as $index => $link) {
-      if (!in_array($link['api_action'], $allowedApiActions, TRUE)) {
+      if (!$this->isActionAllowed($link['entity'], $link['api_action'])) {
         unset($links[$index]);
         continue;
       }
@@ -167,9 +166,13 @@ class GetLinks extends BasicGetAction {
     }
   }
 
-  private function getAllowedEntityActions(): array {
+  private function isActionAllowed(string $entityName, string $actionName): bool {
+    $allowedApiActions = $this->getAllowedEntityActions($entityName);
+    return in_array($actionName, $allowedApiActions, TRUE);
+  }
+
+  private function getAllowedEntityActions(string $entityName): array {
     $uid = \CRM_Core_Session::getLoggedInContactID();
-    $entityName = $this->getEntityName();
     if (!isset(\Civi::$statics[__CLASS__]['actions'][$entityName][$uid])) {
       \Civi::$statics[__CLASS__]['actions'][$entityName][$uid] = civicrm_api4($entityName, 'getActions', ['checkPermissions' => TRUE])->column('name');
     }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -415,9 +415,7 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     // 1st link is to a quickform-based action
     $this->assertArrayNotHasKey('task', $result[0]['columns'][1]['links'][0]);
     $this->assertStringContainsString('id=' . $relationships[0]['id'], $result[0]['columns'][1]['links'][0]['url']);
-    // 2nd link is to the native SK bulk-delete task
-    $this->assertArrayNotHasKey('url', $result[0]['columns'][1]['links'][1]);
-    $this->assertEquals('delete', $result[0]['columns'][1]['links'][1]['task']);
+    // 2nd link is to delete
     $this->assertEquals('fa-trash', $result[0]['columns'][1]['links'][1]['icon']);
     // Ensure "empty" titles are still returned
     $this->assertEquals('0', $result[0]['columns'][1]['links'][1]['title']);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes missing "Add Relationship" button and "Edit" links for each relationship.

Technical Details
----------------------------------------
Must check the correct entity for the link, not just assume it's the same as the api action.