### PR TITLE
[REF] ContactType - Fix 2 functions to be more reliable and efficient

### DIFF
--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -238,81 +238,43 @@ class CRM_Contact_BAO_ContactType extends CRM_Contact_DAO_ContactType implements
    * @param bool $isSeparator
    * @param string $separator
    *
-   * @return mixed
-   * @throws \Civi\Core\Exception\DBQueryException
+   * @return array
    */
   public static function getSelectElements(
     $all = FALSE,
     $isSeparator = TRUE,
     $separator = '__'
-  ) {
-    // @todo - use Cache class - ie like Civi::cache('contactTypes')
-    static $_cache = NULL;
+  ): array {
+    $contactTypes = self::getAllContactTypes();
+    foreach ($contactTypes as $contactType) {
+      $parent = $contactType['parent'] ? $contactTypes[$contactType['parent']] : NULL;
+      if (!$all && (!$contactType['is_active'] || ($parent && !$parent['is_active']))) {
+        continue;
+      }
+      if ($parent) {
+        $key = $isSeparator ? $parent['name'] . $separator . $contactType['name'] : $contactType['name'];
+        $label = "- {$contactType['label']}";
+        $pName = $parent['name'];
+      }
+      else {
+        $key = $contactType['name'];
+        $label = $contactType['label'];
+        $pName = $contactType['name'];
+      }
 
-    if ($_cache === NULL) {
-      $_cache = [];
+      if (!isset($values[$pName])) {
+        $values[$pName] = [];
+      }
+      $values[$pName][] = ['key' => $key, 'label' => $label];
     }
 
-    // @todo - call getAllContactTypes & return filtered results.
-    $argString = $all ? 'CRM_CT_GSE_1' : 'CRM_CT_GSE_0';
-    $argString .= $isSeparator ? '_1' : '_0';
-    $argString .= $separator;
-    $argString = CRM_Utils_Cache::cleanKey($argString);
-    if (!array_key_exists($argString, $_cache)) {
-      $cache = CRM_Utils_Cache::singleton();
-      $_cache[$argString] = $cache->get($argString);
-
-      if (!$_cache[$argString]) {
-        $_cache[$argString] = [];
-
-        $sql = '
-SELECT    c.name as child_name , c.label as child_label , c.id as child_id,
-          p.name as parent_name, p.label as parent_label, p.id as parent_id
-FROM      civicrm_contact_type c
-LEFT JOIN civicrm_contact_type p ON ( c.parent_id = p.id )
-WHERE     ( c.name IS NOT NULL )
-';
-
-        if ($all === FALSE) {
-          $sql .= '
-AND   c.is_active = 1
-AND   ( p.is_active = 1 OR p.id IS NULL )
-';
-        }
-        $sql .= " ORDER BY c.id";
-
-        $values = [];
-        $dao = CRM_Core_DAO::executeQuery($sql);
-        while ($dao->fetch()) {
-          if (!empty($dao->parent_id)) {
-            $key = $isSeparator ? $dao->parent_name . $separator . $dao->child_name : $dao->child_name;
-            $label = "- {$dao->child_label}";
-            $pName = $dao->parent_name;
-          }
-          else {
-            $key = $dao->child_name;
-            $label = $dao->child_label;
-            $pName = $dao->child_name;
-          }
-
-          if (!isset($values[$pName])) {
-            $values[$pName] = [];
-          }
-          $values[$pName][] = ['key' => $key, 'label' => $label];
-        }
-
-        $selectElements = [];
-        foreach ($values as $pName => $elements) {
-          foreach ($elements as $element) {
-            $selectElements[$element['key']] = $element['label'];
-          }
-        }
-        $_cache[$argString] = $selectElements;
-
-        $cache->set($argString, $_cache[$argString]);
+    $selectElements = [];
+    foreach ($values as $elements) {
+      foreach ($elements as $element) {
+        $selectElements[$element['key']] = $element['label'];
       }
     }
-    return $_cache[$argString];
+    return $selectElements;
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTypeTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTypeTest.php
@@ -10,7 +10,7 @@ class CRM_Contact_BAO_ContactType_ContactTypeTest extends CiviUnitTestCase {
   public function setUp(): void {
     parent::setUp();
     $params = [
-      'label' => 'sub1_individual',
+      'label' => 'Sub1 Individual',
       'name' => 'sub1_individual',
       'parent_id:name' => 'Individual',
       'is_active' => 1,
@@ -19,7 +19,7 @@ class CRM_Contact_BAO_ContactType_ContactTypeTest extends CiviUnitTestCase {
     $this->ids['ContactType'][] = ContactType::create()->setValues($params)->execute()->first()['id'];
 
     $params = [
-      'label' => 'sub2_individual',
+      'label' => 'Sub2 Individual',
       'name' => 'sub2_individual',
       'parent_id:name' => 'Individual',
       'is_active' => 1,
@@ -28,7 +28,7 @@ class CRM_Contact_BAO_ContactType_ContactTypeTest extends CiviUnitTestCase {
     $this->ids['ContactType'][] = ContactType::create()->setValues($params)->execute()->first()['id'];
 
     $params = [
-      'label' => 'sub_organization',
+      'label' => 'Sub Organization',
       'name' => 'sub_organization',
       'parent_id:name' => 'Organization',
       'is_active' => 1,
@@ -37,7 +37,7 @@ class CRM_Contact_BAO_ContactType_ContactTypeTest extends CiviUnitTestCase {
     $this->ids['ContactType'][] = ContactType::create()->setValues($params)->execute()->first()['id'];
 
     $params = [
-      'label' => 'sub_household',
+      'label' => 'Sub Household',
       'name' => 'sub_household',
       'parent_id:name' => 'Household',
       'is_active' => 1,
@@ -120,6 +120,18 @@ class CRM_Contact_BAO_ContactType_ContactTypeTest extends CiviUnitTestCase {
       'sub_household' => 'Household',
     ];
     $this->assertEquals($subTypeToType, CRM_Contact_BAO_ContactType::getBasicType(array_keys($subTypeToType)));
+
+    // Test getSelectElements
+    $selectElements = CRM_Contact_BAO_ContactType::getSelectElements();
+    $this->assertEquals('- Sub1 Individual', $selectElements['Individual__sub1_individual']);
+    $this->assertEquals('- Sub Organization', $selectElements['Organization__sub_organization']);
+    $selectOrder = array_flip(array_keys($selectElements));
+    // Individual is always first
+    $this->assertEquals(0, $selectOrder['Individual']);
+    // Sub-types should come after the primary type, but before the next primary type
+    $this->assertGreaterThan($selectOrder['Individual__sub1_individual'], $selectOrder['Individual__sub2_individual']);
+    $this->assertGreaterThan($selectOrder['Individual__sub1_individual'], $selectOrder['Organization']);
+    $this->assertGreaterThan($selectOrder['Organization'], $selectOrder['Organization__sub_organization']);
   }
 
   /**
@@ -265,7 +277,7 @@ class CRM_Contact_BAO_ContactType_ContactTypeTest extends CiviUnitTestCase {
       'sub1_individual' => [
         'id' => $this->ids['ContactType'][0],
         'name' => 'sub1_individual',
-        'label' => 'sub1_individual',
+        'label' => 'Sub1 Individual',
         'parent_id' => 1,
         'is_active' => TRUE,
         'is_reserved' => FALSE,
@@ -278,7 +290,7 @@ class CRM_Contact_BAO_ContactType_ContactTypeTest extends CiviUnitTestCase {
       'sub2_individual' => [
         'id' => $this->ids['ContactType'][1],
         'name' => 'sub2_individual',
-        'label' => 'sub2_individual',
+        'label' => 'Sub2 Individual',
         'parent_id' => 1,
         'is_active' => TRUE,
         'is_reserved' => FALSE,
@@ -291,7 +303,7 @@ class CRM_Contact_BAO_ContactType_ContactTypeTest extends CiviUnitTestCase {
       'sub_organization' => [
         'id' => $this->ids['ContactType'][2],
         'name' => 'sub_organization',
-        'label' => 'sub_organization',
+        'label' => 'Sub Organization',
         'parent_id' => 3,
         'is_active' => TRUE,
         'is_reserved' => FALSE,
@@ -304,7 +316,7 @@ class CRM_Contact_BAO_ContactType_ContactTypeTest extends CiviUnitTestCase {
       'sub_household' => [
         'id' => $this->ids['ContactType'][3],
         'name' => 'sub_household',
-        'label' => 'sub_household',
+        'label' => 'Sub Household',
         'parent_id' => 2,
         'is_active' => TRUE,
         'is_reserved' => FALSE,

--- a/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTypeTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTypeTest.php
@@ -96,20 +96,30 @@ class CRM_Contact_BAO_ContactType_ContactTypeTest extends CiviUnitTestCase {
     $this->assertEquals(sort($subtypes), sort($result));
     $this->strictArrayCompare($this->getExpectedAllSubtypes(), CRM_Contact_BAO_ContactType::subTypeInfo());
 
-  }
-
-  /**
-   * Test subTypes() methods with invalid data
-   */
-  public function testGetMethodsInvalid(): void {
-
+    // Invalid input yields empty result
     $params = 'invalid';
     $result = CRM_Contact_BAO_ContactType::subTypes($params);
-    $this->assertEquals(empty($result), TRUE);
+    $this->assertEmpty($result);
 
     $params = ['invalid'];
     $result = CRM_Contact_BAO_ContactType::subTypes($params);
-    $this->assertEquals(empty($result), TRUE);
+    $this->assertEmpty($result);
+
+    // Test getBasicType with string input
+    $this->assertEquals('Individual', CRM_Contact_BAO_ContactType::getBasicType('sub1_individual'));
+    $this->assertEquals('Individual', CRM_Contact_BAO_ContactType::getBasicType('sub2_individual'));
+    $this->assertEquals('Organization', CRM_Contact_BAO_ContactType::getBasicType('sub_organization'));
+    $this->assertEquals('Household', CRM_Contact_BAO_ContactType::getBasicType('sub_household'));
+    $this->assertNull(CRM_Contact_BAO_ContactType::getBasicType('invalid'));
+
+    // Test getBasicTypes with array input
+    $subTypeToType = [
+      'sub1_individual' => 'Individual',
+      'sub2_individual' => 'Individual',
+      'sub_organization' => 'Organization',
+      'sub_household' => 'Household',
+    ];
+    $this->assertEquals($subTypeToType, CRM_Contact_BAO_ContactType::getBasicType(array_keys($subTypeToType)));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes 2 outstanding `fixmes` in the ContactType BAO. Makes the functions more reliable and efficient.

Technical Details
----------------------------------------
2 old functions were fetching and caching contactType data but it was redundant - we already have that data loaded & cached.
Switching them to use the standard method reduces SLOC, db queries & memory usage.