### PR TITLE
dev/core#4905 - CiviReport - Use cached function to get custom groups & fields

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4171,13 +4171,7 @@ ORDER BY cg.weight, cf.weight";
       return;
     }
     $mapper = CRM_Core_BAO_CustomQuery::$extendsMap;
-    //CRM-18276 GROUP_CONCAT could be used with singleValueQuery and then exploded,
-    //but by default that truncates to 1024 characters, which causes errors with installs with lots of custom field sets
-    $customTables = [];
-    $customTablesDAO = CRM_Core_DAO::executeQuery("SELECT table_name FROM civicrm_custom_group");
-    while ($customTablesDAO->fetch()) {
-      $customTables[] = $customTablesDAO->table_name;
-    }
+    $customTables = array_column(CRM_Core_BAO_CustomGroup::getAll(), 'table_name');
 
     foreach ($this->_columns as $table => $prop) {
       if (in_array($table, $customTables)) {

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4180,7 +4180,7 @@ ORDER BY cg.weight, cf.weight";
         if ((!$this->isFieldSelected($prop)) || ($joinsForFiltersOnly && !$this->isFieldFiltered($prop))) {
           continue;
         }
-        $baseJoin = CRM_Utils_Array::value($prop['extends'], $this->_customGroupExtendsJoin, "{$this->_aliases[$extendsTable]}.id");
+        $baseJoin = $this->_customGroupExtendsJoin[$prop['extends']] ?? "{$this->_aliases[$extendsTable]}.id";
 
         $customJoin = is_array($this->_customGroupJoin) ? $this->_customGroupJoin[$table] : $this->_customGroupJoin;
         $this->_from .= "
@@ -4188,10 +4188,8 @@ ORDER BY cg.weight, cf.weight";
         // handle for ContactReference
         if (array_key_exists('fields', $prop)) {
           foreach ($prop['fields'] as $fieldName => $field) {
-            if (($field['dataType'] ?? NULL) ==
-              'ContactReference'
-            ) {
-              $columnName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', CRM_Core_BAO_CustomField::getKeyID($fieldName), 'column_name');
+            if (($field['dataType'] ?? NULL) === 'ContactReference') {
+              $columnName = CRM_Core_BAO_CustomField::getField(CRM_Core_BAO_CustomField::getKeyID($fieldName))['column_name'];
               $this->_from .= "
 LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_aliases[$table]}.{$columnName} ";
             }


### PR DESCRIPTION
Overview
----------------------------------------
Switch from doing it the hard way to doing it the easy way.

Part of https://lab.civicrm.org/dev/core/-/issues/4905 efforts.

Comments
-------
Looking at this code, I notice there's special handling for "ContactReference" custom fields that appears to be missing support for the new "EntityReference" custom fields. Maybe someone cares about that...