### PR TITLE
Contact Relationships: alter markup for help texts

### DIFF
--- a/ang/afform/afsearchTabRel.aff.html
+++ b/ang/afform/afsearchTabRel.aff.html
@@ -1,9 +1,12 @@
 <div af-fieldset="">
-  <div class="alert alert-warning">
+  <div class="help">
     <strong>{{:: ts('Permissioned Relationships:') }}</strong>
     <i class="crm-i fa-eye"></i> {{:: ts('This contact can be viewed by the other.') }}
     <i class="crm-i fa-pencil-square"></i> {{:: ts('This contact can be viewed and edited by the other.') }}
   </div>
+  <h3>{{:: ts('Current Relationships') }}</h3>
   <crm-search-display-table search-name="Contact_Summary_Relationships" display-name="Contact_Summary_Relationships_Active" filters="{near_contact_id: options.contact_id, is_current: true}"></crm-search-display-table>
+  <h3>{{:: ts('Inactive Relationships') }}</h3>
+  <div class="help">{{:: ts('These relationships are Disabled OR have a past End Date.') }}</div>
   <crm-search-display-table search-name="Contact_Summary_Relationships" display-name="Contact_Summary_Relationships_Inactive" filters="{near_contact_id: options.contact_id, is_current: false}"></crm-search-display-table>
 </div>

--- a/managed/contactSummary/SavedSearch_Contact_Summary_Relationships.mgd.php
+++ b/managed/contactSummary/SavedSearch_Contact_Summary_Relationships.mgd.php
@@ -293,7 +293,7 @@ return [
         'saved_search_id.name' => 'Contact_Summary_Relationships',
         'type' => 'table',
         'settings' => [
-          'description' => ts('These relationships are Disabled OR have a past End Date.'),
+          'description' => '',
           'sort' => [],
           'limit' => 50,
           'pager' => [


### PR DESCRIPTION
Overview
----------------------------------------

The new SearchKit for the Contact Relationships changes the markup used for help messages, and causes some confusion because of what might be considered a help text, vs an alert.

Before
----------------------------------------

- Yellow help text (usually associated with warnings)
- Blue "not found" text, but also some blue help text (about past/inactive relationships)
- Missing "h3" titles for the two lists (Current vs Inactive relationships)

![image](https://github.com/civicrm/civicrm-core/assets/254741/8763050f-1e95-48f4-96f3-7624804357db)

After
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/b98f9ff6-998e-4cd1-b525-53fb552064f2)

Technical Details / Comments
----------------------------------------

- Most people would expect the h3 to be 15pixels, like it was before, but greenwitch loads bootstrap and calculates `ceil(($font-size-base * 1.7)) // ~24px`. I think that's fine for h3, since 15 pixels for h3 makes little in 2024, but there's a bit of a clash with the regular font size. This PR merely adds back the old markup, and would rather avoid the rabbit hole of the old theme.
- SearchKit always considers "descriptions" of the SK to be an alert message. I hesitated to change it to always be a "help" message, but perhaps it would have broken many existing searchkits.
- I did not add back the css class `font-red` on the inactive relationships, because I don't think it's relevant to do so.
- (rabbit hole) I would have liked to remove the help text about the view/edit permissions, but hovering the icons in the listing no longer shows the help text.

Initial bug report by Rose: https://lab.civicrm.org/extensions/theisland/-/issues/8

cc @colemanw @artfulrobot @vingle 