### PR TITLE
Use static caching to reduce lookups in import display

### DIFF
--- a/ext/civiimport/Civi/Api4/Import/ImportSpecProvider.php
+++ b/ext/civiimport/Civi/Api4/Import/ImportSpecProvider.php
@@ -41,10 +41,7 @@ class ImportSpecProvider extends AutoService implements SpecProviderInterface {
       // table is deleted - & hence we get an error.
       return;
     }
-    // CheckPermissions does not reach us here - so we will have to rely on earlier permission filters.
-    $userJobID = substr($spec->getEntity(), (strpos($spec->getEntity(), '_') + 1));
-    $userJob = UserJob::get(FALSE)->addWhere('id', '=', $userJobID)->addSelect('metadata', 'job_type', 'created_id')->execute()->first();
-    $entity = CRM_Core_BAO_UserJob::getType($userJob['job_type'])['entity'];
+    $userJobType = $this->getJobType($spec);
     foreach ($columns as $column) {
       $isInternalField = strpos($column['name'], '_') === 0;
       $exists = $isInternalField && $spec->getFieldByName($column['name']);
@@ -60,14 +57,9 @@ class ImportSpecProvider extends AutoService implements SpecProviderInterface {
       $field->setDescription(ts('Data being imported into the field.'));
       $field->setColumnName($column['name']);
       if ($column['name'] === '_entity_id') {
-        $jobTypes = CRM_Core_BAO_UserJob::getTypes();
-        foreach ($jobTypes as $jobType) {
-          if ($userJob['job_type'] === $jobType['id'] && $jobType['entity']) {
-            $field->setFkEntity($jobType['entity']);
-            $field->setInputType('EntityRef');
-            $field->setInputAttrs(['label' => $entity]);
-          }
-        }
+        $field->setFkEntity($userJobType['entity']);
+        $field->setInputType('EntityRef');
+        $field->setInputAttrs(['label' => $userJobType['entity']]);
       }
       $spec->addFieldSpec($field);
     }
@@ -79,6 +71,29 @@ class ImportSpecProvider extends AutoService implements SpecProviderInterface {
    */
   public function applies($entity, $action): bool {
     return strpos($entity, 'Import_') === 0;
+  }
+
+  /**
+   * Get the user job type detail.
+   *
+   * @param \Civi\Api4\Service\Spec\RequestSpec $spec
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  public function getJobType(RequestSpec $spec): array {
+    if (!isset(\Civi::$statics[__CLASS__][$spec->getEntity()])) {
+      // CheckPermissions does not reach us here - so we will have to rely on earlier permission filters.
+      $userJobID = substr($spec->getEntity(), (strpos($spec->getEntity(), '_') + 1));
+      $userJob = UserJob::get(FALSE)
+        ->addWhere('id', '=', $userJobID)
+        ->addSelect('metadata', 'job_type', 'created_id')
+        ->execute()
+        ->first();
+      \Civi::$statics[__CLASS__][$spec->getEntity()] = CRM_Core_BAO_UserJob::getType($userJob['job_type']);
+    }
+
+    return \Civi::$statics[__CLASS__][$spec->getEntity()];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Use static caching to reduce lookups in import display

Before
----------------------------------------
When loading an import display the `modifiySpec` function is called once per editable field * the number of lines. As each field is set to editable this means the number of columns in the csv * the number of rows. Commonly the number of columns is large because an export from civicrm has a large number of columns and the default number of rows displayed is 25 - so in the api call that is cached here is called hundreds of times (at least) to render the view

After
----------------------------------------
The use of the static cache removes this point of repetitiveness - and makes sense IMHO but the `getEditableInfo` function remains extremely slow as this is small part of that function

Technical Details
----------------------------------------
I used static caching rather than metadata cache as the information is quick to load and that way we can do it once per job. If we use the cache then we get into how we clear it & wind up putting all the jobs in one cache - which risks being slow to serialize & unserialize

Comments
----------------------------------------
