### PR TITLE
Cache spec provider mods

### DIFF
--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -64,10 +64,17 @@ class SpecGatherer extends AutoService {
       }
     }
 
-    foreach ($this->specProviders as $provider) {
-      if ($provider->applies($entity, $action, $specification->getValues())) {
-        $provider->modifySpec($specification);
+    $cacheKey = $entity . $action . json_encode($specification->getValues());
+    if (isset(\Civi::$statics[$cacheKey])) {
+      $specification = \Civi::$statics[$cacheKey];
+    }
+    else {
+      foreach ($this->specProviders as $provider) {
+        if ($provider->applies($entity, $action, $specification->getValues())) {
+          $provider->modifySpec($specification);
+        }
       }
+      \Civi::$statics[$cacheKey] = $specification;
     }
 
     return $specification;


### PR DESCRIPTION
Overview
----------------------------------------
Cache spec provider mods

Before
----------------------------------------
25 rows load in 1.34 minutes

(500 error seems to be timeout related - ie 30 sec max_execution_time)

![image](https://github.com/civicrm/civicrm-core/assets/336308/c384155e-908d-45b2-9fdd-dbc19b933d61)


After
----------------------------------------
loads in 13.72 seconds


![image](https://github.com/civicrm/civicrm-core/assets/336308/27b88f13-7d90-4712-b5ea-1a42ef90429b)

Technical Details
----------------------------------------
@colemanw I'm not sure if this is the right place - it is still slow - ie 14 seconds is still too slow. The slowness seems to be at the php layer not sql  but the slowness seems to be only from `fieldBelongsToEntity` now - I feel like we used to have caching in the spec that got removed for other reasons but not all entities need this level of decision making & perhaps they could opt out of it.

ie `fieldBelongsToEntity` bypasses this caching because every row passes in different values - although none matter for this entitiy

Note that this timing (28 seconds) has the in-function caching https://github.com/civicrm/civicrm-core/pull/29059

![image](https://github.com/civicrm/civicrm-core/assets/336308/3ccd50c4-a4e0-490f-b2d5-4d64df6a4260)

That PLUS this seems to be marginally faster than just this 

![image](https://github.com/civicrm/civicrm-core/assets/336308/aa0cef7c-f9a3-40a0-b369-530608bd3d08)

Retrying that slow POST with profiling enabled it takes 35 seconds with this and the static caching applied with notable items being

- 6.3 seconds spent on 130,807 calls to `getCodeDocs()`
- 8.3 seconds spent on 80,028 calls to ` unoptimisedEventDispatcher->callListeners`

Big picture these are components of `formatEditiableColumn()` which takes up 33.7 seconds once this patch is applied - and 23.9 of that is used in `fieldBelongsToEntity()` - but what I'm not finding, which is highlighted by the above 2 items, is slowness due to too much mysql querying - rather too much php processing


Comments
----------------------------------------
