### PR TITLE
Further clarify dedupe custom field handling

### DIFF
--- a/tests/phpunit/api/v3/JobTestCustomDataTest.php
+++ b/tests/phpunit/api/v3/JobTestCustomDataTest.php
@@ -134,9 +134,8 @@ class api_v3_JobTestCustomDataTest extends CiviUnitTestCase {
    *
    * @param array $dataSet
    *
-   * @throws \CRM_Core_Exception
    */
-  public function testBatchMergeCheckboxCustomFieldHandling($dataSet) {
+  public function testBatchMergeCheckboxCustomFieldHandling(array $dataSet): void {
     $customFieldLabel = 'custom_' . $this->customStringCheckboxID;
     $contact1Params = is_array($dataSet['contacts'][0]) ? [$customFieldLabel => $dataSet['contacts'][0]] : [];
     $contact2Params = is_array($dataSet['contacts'][1]) ? [$customFieldLabel => $dataSet['contacts'][1]] : [];


### PR DESCRIPTION
Overview
----------------------------------------
Further clarify dedupe custom field handling

Before
----------------------------------------
After @colemanw's clean up there was still this misleading comment https://github.com/civicrm/civicrm-core/pull/29006/files#diff-fe60c89ebe94bbd40114d135459371cc53708db1f2952ade6c0ce9b3468c4dabR1671 and there was also unnecessary loops that could be solved by only retrieving 1 contact

After
----------------------------------------
This is mostly a lot of comments to explain the confusing handling of empty values

Technical Details
----------------------------------------


Comments
----------------------------------------

