### PR TITLE
Fix internal links in AdminUI templates

### DIFF
--- a/ext/civicrm_admin_ui/ang/afsearchLabelFormats.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchLabelFormats.aff.html
@@ -1,7 +1,7 @@
 <div class="help">
 
   <div>{{:: ts('You can configure one or more Label Formats for your CiviCRM installation. Label Formats are used when creating mailing labels.')}}<br/>
-{{:: ts('You can change which fields are printed on each label in')}} <a href="/civicrm/admin/setting/preferences/address?reset=1">{{:: ts('Address Settings')}}</a>.</div>
+{{:: ts('You can change which fields are printed on each label in')}} <a ng-href="{{ crmUrl('civicrm/admin/setting/preferences/address?reset=1') }}">{{:: ts('Address Settings')}}</a>.</div>
 
 </div>
 <div crm-ui-tab-set="">

--- a/ext/civicrm_admin_ui/ang/afsearchRelationshipTypes.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchRelationshipTypes.aff.html
@@ -3,7 +3,7 @@
     <div class="help">
       <p>{{:: ts('Relationship types describe relationships between people, households and organizations. Relationship types labels describe the relationship from the perspective of each of the two entities (e.g. Parent &gt;-&lt; Child, Employer &gt;-&lt; Employee). For some types of relationships, the labels may be the same in both directions (e.g. Spouse &gt;-&lt; Spouse).') }} <a class="crm-doc-link no-popup"
           href="https://docs.civicrm.org/user/en/latest/organising-your-data/relationships" target="_blank">{{:: ts('(Learn more...)') }}</a></p>
-      <p>{{:: ts('You can define as many additional relationships types as needed to cover the types of relationships you want to track. Once a relationship type is created, you may also define custom fields to extend relationship information for that type from ') }} <a href="civicrm/admin/custom/group?reset=1">{{:: ts('Administer CiviCRM &raquo; Custom Data') }}</a></p>
+      <p>{{:: ts('You can define as many additional relationships types as needed to cover the types of relationships you want to track. Once a relationship type is created, you may also define custom fields to extend relationship information for that type from ') }} <a ng-href="{{ crmUrl('civicrm/admin/custom/group?reset=1') }}">{{:: ts('Administer CiviCRM &raquo; Custom Data') }}</a></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Internal links in AdminUI templates must be passed through `crmUrl()`.

Before
----------------------------------------
I haven't tested other CMSes, but these two internal links do not work in WordPress.

After
----------------------------------------
Internal links work in WordPress.