### PR TITLE
Contact Changelog: use h3 for page title

### DIFF
--- a/templates/CRM/Contact/Page/View/Log.tpl
+++ b/templates/CRM/Contact/Page/View/Log.tpl
@@ -8,10 +8,8 @@
  +--------------------------------------------------------------------+
 *}
 <div id="changeLog" class="view-content">
-   <p></p>
-   <div class="bold">{ts}Change Log:{/ts} {$displayName}</div>
+   <h3>{ts}Change Log:{/ts} {$displayName}</h3>
    {if $useLogging}
-     <br />
      <div class='instance_data'><div class="crm-loading-element"></div></div>
    {else}
     <div class="form-item">


### PR DESCRIPTION
Overview
----------------------------------------

Uses more standard markup for the Contact > ChangeLog page/tab.

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/ff4144c5-e00f-4630-a845-9a4b2b711c45)

After
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/20e65b17-8d0a-4ba4-af4c-d45c0fc2cd1b)

Technical Details
----------------------------------------

Now it looks more like other tabs that use h3:

![image](https://github.com/civicrm/civicrm-core/assets/254741/54aff49d-113e-4be8-be74-a47de4886069)

Comments
----------------------------------------

Shoreditch/TheIsland have a few lines of CSS just for this title, and I figured may as well fix upstream.

cc @vingle