### PR TITLE
Fix Checking Auto renew for Non Quick Config Price Set when Membershi…

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1852,9 +1852,9 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       return 0;
     }
     if (!$this->isQuickConfig()) {
-      return CRM_Member_BAO_MembershipType::getMembershipType($membershipTypeID)['auto_renew'];
+      return CRM_Member_BAO_MembershipType::getMembershipType($membershipTypeID)['auto_renew'] ?? 0;
     }
-    $membershipTypeAutoRenewOption = CRM_Member_BAO_MembershipType::getMembershipType($membershipTypeID)['auto_renew'];
+    $membershipTypeAutoRenewOption = CRM_Member_BAO_MembershipType::getMembershipType($membershipTypeID)['auto_renew'] ?? 0;
     if ($membershipTypeAutoRenewOption === 2 || $membershipTypeAutoRenewOption === 0) {
       // It is not possible to override never or always at the membership block leve.
       return $membershipTypeAutoRenewOption;


### PR DESCRIPTION
Overview
----------------------------------------
This Fixes a PHP Type Error when using membership types that have the auto_renew column set to NULL and that membership type is used in a price field in a non quick config price set

Before
----------------------------------------
Type Error

"TypeError: CRM_Contribute_Form_Contribution_Main::getConfiguredAutoRenewOptionForMembershipType(): Return value must be of type int, null returned in CRM_Contribute_Form_Contribution_Main->getConfiguredAutoRenewOptionForMembershipType() (line 1855 of /srv/buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Contribute/Form/Contribution/Main.php)."

After
----------------------------------------
No Type Error

Technical Details
----------------------------------------
When creating a membership type in the UI or api the auto_renew field is not required. Whilst there is a default value specified it seems that we insert NULL values instead.  Which means the return value of L1855 is NULL not an int

ping @colemanw @eileenmcnaughton 