### PR TITLE
Fix metadata cache clear event

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -188,8 +188,7 @@ class Container {
     foreach ($basicCaches as $cacheSvc => $cacheGrp) {
       $definitionParams = [
         'name' => $cacheGrp . (in_array($cacheGrp, $verSuffixCaches) ? $verSuffix : ''),
-        // FIXME: Uncommenting below causes test failure
-        // 'service' => $cacheSvc,
+        'service' => $cacheSvc,
         'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
       ];
       // For Caches that we don't really care about the ttl for and/or maybe accessed

--- a/Civi/Core/MetadataFlush.php
+++ b/Civi/Core/MetadataFlush.php
@@ -31,7 +31,13 @@ class MetadataFlush extends Service\AutoSubscriber {
    * as it's being deleted.
    */
   public static function onClearMetadata(): void {
-    \Civi::resources()->resetCacheCode();
+    // This seems to cause problems during unit test setup
+    if (CIVICRM_UF === 'UnitTests') {
+      return;
+    }
+    if (\Civi\Core\Container::singleton()->has('resources')) {
+      \Civi::resources()->resetCacheCode();
+    }
   }
 
 }

--- a/tests/phpunit/Civi/Test/ExampleSubscriberTest.php
+++ b/tests/phpunit/Civi/Test/ExampleSubscriberTest.php
@@ -50,6 +50,7 @@ class ExampleSubscriberTest extends \PHPUnit\Framework\TestCase implements Headl
       'civi.api.prepare' => ['myCiviApiPrepare', 1234],
       'hook_civicrm_alterContent' => ['myAlterContentObject', -7000],
       '&hook_civicrm_alterContent' => ['myAlterContentParams', -8000],
+      'civi.cache.metadata.clear' => 'myCacheClear',
     ];
   }
 
@@ -69,6 +70,10 @@ class ExampleSubscriberTest extends \PHPUnit\Framework\TestCase implements Headl
     $content .= ' ' . __FUNCTION__;
   }
 
+  public function myCacheClear(GenericHookEvent $event): void {
+    $this->tracker['civi.cache.metadata.clear'][__FUNCTION__] = TRUE;
+  }
+
   public function testPageOutput(): void {
     ob_start();
     $p = new Main();
@@ -84,6 +89,12 @@ class ExampleSubscriberTest extends \PHPUnit\Framework\TestCase implements Headl
     \civicrm_api3('Contact', 'getfields', []);
     $this->assertEquals(['myCiviApiResolve' => TRUE], $this->tracker['civi.api.resolve']);
     $this->assertEquals(['myCiviApiPrepare' => TRUE], $this->tracker['civi.api.prepare']);
+  }
+
+  public function testCacheClearEvent(): void {
+    $this->tracker['civi.cache.metadata.clear'] = NULL;
+    \Civi::cache('metadata')->clear();
+    $this->assertEquals(['myCacheClear' => TRUE], $this->tracker['civi.cache.metadata.clear']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes #28442 to actually work, and adds a test.

Before
----------------------------------------
#28442 was stymied by a test-failure so a crucial part got commented out. Although the PR was merged, it wasn't actually doing anything.

After
----------------------------------------
Uncommented, test fixed. Now the clientside resource cache code actually gets reset.

Technical Details
----------------------------------------
The name of the "metadata" cache gets a version string appended to it to make it unique. This was breaking the event listener which was looking for a cache named "metadata" not "metadata_5_70_1". I fixed this by passing in the clean service name, but then APIv3 tests broke due to some kind of bootstrapping issue conflicting with CRM_Core_Resources. This adds a guard to prevent the test failures, while getting the actual thing to work.