### PR TITLE
dev/core#4930 Fix Activity count when contact is assigned multiple roles

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2633,9 +2633,11 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
 
       case 'activity':
         return \Civi\Api4\Activity::get(TRUE)
+          ->selectRowCount()
           ->addJoin('ActivityContact AS activity_contact', 'INNER')
           ->addWhere('activity_contact.contact_id', '=', $contactId)
           ->addWhere('is_test', '=', FALSE)
+          ->addGroupBy('id')
           ->execute()
           ->count();
 


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/4930

Regression on 5.70/RC:

- Disable the AdminUI extension
- Go to a contact record
- New activity / Meeting
- Enter the same contact in the fields "with contact" and "assigned to contact"
- Save

The activity count displayed on the tab will count will be 3 instead of 1:

![image](https://github.com/civicrm/civicrm-core/assets/254741/6a3bd2f8-0a24-4ce6-ad6e-8775e481c140)

The AdminUI core-ext mitigates this problem by re-calculating, but we still see the incorrect count for a few seconds.

Comments
----------------------------------------

@MegaphoneJon FYI - This change might hurt performance a bit. I know it's weird to assign multiple roles, but this bug was found by a client, likely others will be confused too.