### PR TITLE
composer.json: Use current SPDX license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "civicrm/civicrm-core",
   "description": "Open source constituent relationship management for non-profits, NGOs and advocacy organizations.",
   "type": "library",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-or-later",
   "authors": [
     {
       "name": "Coleman Watts",


### PR DESCRIPTION
Overview
----------------------------------------
`APL-3.0` is a deprecated license identifier and should be replaced by the more specific `AGPL-3.0-only`. https://spdx.org/licenses/

Before
----------------------------------------
A deprecated SPDX license identifier is used in `composer.json`.

After
----------------------------------------
A current SPDX license identifier is used in `composer.json`.