### PR TITLE
dev/core#4932 - Bring back missing actions when viewing contact summary

### DIFF
--- a/Civi/Api4/Service/Links/ActivityLinksProvider.php
+++ b/Civi/Api4/Service/Links/ActivityLinksProvider.php
@@ -79,11 +79,9 @@ class ActivityLinksProvider extends \Civi\Core\Service\AutoSubscriber {
   private static function getActivityTypeAddLinks($contactId, $checkPermissions): array {
     $addLinks = [];
     $activityTypeQuery = OptionValue::get(FALSE)
-      ->addSelect('name', 'label', 'icon', 'value')
+      ->addSelect('name', 'label', 'icon', 'value', 'filter', 'component_id')
       ->addWhere('option_group_id:name', '=', 'activity_type')
       ->addWhere('is_active', '=', TRUE)
-      ->addWhere('filter', 'IS EMPTY')
-      ->addWhere('component_id', 'IS NULL')
       ->addOrderBy('weight');
 
     // TODO: Code block was moved from CRM_Activity_Form_ActivityLinks and could use further cleanup
@@ -134,6 +132,9 @@ class ActivityLinksProvider extends \Civi\Core\Service\AutoSubscriber {
       }
       elseif ($act['name'] == 'Print PDF Letter') {
         $url = 'civicrm/activity/pdf/add';
+      }
+      elseif (!empty($act['filter']) || (!empty($act['component_id']) && $act['component_id'] != '1')) {
+        continue;
       }
 
       $act['icon'] = $act['icon'] ?? 'fa-plus-square-o';


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4932

Before
----------------------------------------
Outbound SMS and Send Email missing from actions dropdown when viewing contact summary

After
----------------------------------------
Now back

Technical Details
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/27973 changed the order of how filter=1 is checked to be excluded up front instead of after checking for special types. This puts the check back.

Comments
----------------------------------------

