### PR TITLE
Avoid crash in extensions that call getVar

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2111,8 +2111,13 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @return mixed
    */
   public function getVar($name) {
-    if (!empty(ReflectionUtils::getCodeDocs((new ReflectionProperty($this, $name)), 'Property')['deprecated'])) {
-      CRM_Core_Error::deprecatedWarning('deprecated property accessed :' . $name);
+    try {
+      if (!empty(ReflectionUtils::getCodeDocs((new ReflectionProperty($this, $name)), 'Property')['deprecated'])) {
+        CRM_Core_Error::deprecatedWarning('deprecated property accessed :' . $name);
+      }
+    }
+    catch (\ReflectionException $e) {
+      // If the variable isn't defined you can't access its properties to check if it's deprecated. Let php 8.2 deal with those warnings.
     }
     // @todo - add warnings for internal properties & protected properties.
     return $this->$name;


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
Extensions sometimes call getVar() on properties that aren't defined in the class declaration. Some recently added code in core tries to access the docblock but it crashes if they aren't defined.

After
----------------------------------------
Let php 8.2 handle undefined property warnings.

Technical Details
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/28748

Comments
----------------------------------------

