### PR TITLE
[WIP] dev/core#4918 - allow an event to have more than 0 participants (option 1)

### DIFF
--- a/CRM/Event/Form/EventFormTrait.php
+++ b/CRM/Event/Form/EventFormTrait.php
@@ -115,7 +115,7 @@ trait CRM_Event_Form_EventFormTrait {
       TRUE,
       $this->getEventValue('has_waitlist')
     );
-    return is_numeric($availableSpaces) ? (int) $availableSpaces : 0;
+    return is_null($availableSpaces) ? PHP_INT_MAX : (is_numeric($availableSpaces) ? (int) $availableSpaces : 0);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4918

Before
----------------------------------------
All my events say currently full.

After
----------------------------------------


Technical Details
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/28984 it doesn't take into account that you can leave the max # participants box blank to mean unlimited.

Comments
----------------------------------------
Even though setting an arbitrary limit has shades of Y2K, in real life "max # participants" is a finite number. No event has unlimited capacity. I don't think mysql can even have PHP_INT_MAX contacts, at least on 64-bit machines.

I've called this option 1, but I don't have an option 2 at the moment. It would be something like everywhere you call this function or getEventValue, you also first check max participants to see if it was left blank and then act accordingly.