### PR TITLE
(dev/core#4641) ListUnsubscribe - Fix HTTP URL generation on WordPress

### DIFF
--- a/CRM/Mailing/Service/ListUnsubscribe.php
+++ b/CRM/Mailing/Service/ListUnsubscribe.php
@@ -64,7 +64,7 @@ class CRM_Mailing_Service_ListUnsubscribe extends \Civi\Core\Service\AutoService
       $listUnsubscribe[] = $params['List-Unsubscribe'];
     }
     if (array_intersect(['http', 'oneclick'], $methods)) {
-      $listUnsubscribe[] = '<' . Civi::url('civicrm/mailing/unsubscribe', $this->urlFlags)->addQuery([
+      $listUnsubscribe[] = '<' . Civi::url('frontend://civicrm/mailing/unsubscribe', $this->urlFlags)->addQuery([
         'reset' => 1,
         'jid' => $m[1],
         'qid' => $m[2],


### PR DESCRIPTION
Overview
----------------------------------------

Follow-up to recent #28964. This fixes an issue with generating the unsubscribe URL on WordPress.

Before
----------------------------------------

If I execute the mailing job via CLI:

```
cv api -U admin job.process_mailing
```

Then the resulting email has `List-Unsubscribe` which points to the WP backend, e.g.

```
http://wpmaster.127.0.0.1.nip.io:8001/wp-admin/admin.php?page=CiviCRM&q=civicrm%2Fmailing%2Funsubscribe&reset=1&jid=4&qid=25&h=77jhhesmltetm6uk
```

This URL doesn't actually work for purposes of HTTP One-Click.

After
----------------------------------------

The resulting email has `List-Unsubscribe` which points to the WP frontend. Depending on whether clean URL support is active, this can be either:

```
http://wpmaster.127.0.0.1.nip.io:8001/civicrm/?civiwp=CiviCRM&q=civicrm%2Fmailing%2Funsubscribe&reset=1&jid=3&qid=28&h=o9qdzkepvkuvwkoo
```

or

```
http://wpmaster.127.0.0.1.nip.io:8001/civicrm/mailing/unsubscribe/?reset=1&jid=3&qid=28&h=o9qdzkepvkuvwkoo
```

Either style works for purposes of HTTP One-Click.