### PR TITLE
[REF] Fix Smarty Notice on missing hideRelativeLabel

### DIFF
--- a/templates/CRM/Activity/Selector/Selector.tpl
+++ b/templates/CRM/Activity/Selector/Selector.tpl
@@ -22,9 +22,7 @@
           <td class="crm-contact-form-block-activity_type_exclude_filter_id crm-inline-edit-field">
             {$form.activity_type_exclude_filter_id.label}<br /> {$form.activity_type_exclude_filter_id.html|crmAddClass:medium}
           </td>
-          <td>
-            {include file="CRM/Core/DatePickerRange.tpl" fieldName="activity_date_time"}
-          </td>
+          {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="activity_date_time" hideRelativeLabel=false}
           <td class="crm-contact-form-block-activity_status_filter_id crm-inline-edit-field">
             <label>{ts}Status{/ts}</label><br /> {$form.status_id.html|crmAddClass:medium}
           </td>


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix a smarty notice error about underfined array key hideRelativeLabel

Before
----------------------------------------
Notice

After
----------------------------------------
No Notice and wrapper is used to be more standard

Notice was 

```
Warning: Undefined array key "hideRelativeLabel" in include() (line 9 of web/sites/default/files/civicrm/templates_c/en_US/%%48/480/480BECF5%%DatePickerRange.tpl.php)
#0 web/core/includes/bootstrap.inc(347): _drupal_error_handler_real()
#1 web/sites/default/files/civicrm/templates_c/en_US/%%48/480/480BECF5%%DatePickerRange.tpl.php(9): _drupal_error_handler()
#2 vendor/civicrm/civicrm-packages/Smarty/Smarty.class.php(1914): include('...')
#3 web/sites/default/files/civicrm/templates_c/en_US/%%06/060/060F37B7%%Selector.tpl.php(27): Smarty->_smarty_include()
#4 vendor/civicrm/civicrm-packages/Smarty/Smarty.class.php(1914): include('...')
#5 web/sites/default/files/civicrm/templates_c/en_US/%%14/14D/14D9A817%%Tab.tpl.php(22): Smarty->_smarty_include()
#6 vendor/civicrm/civicrm-packages/Smarty/Smarty.class.php(1914): include('...')
#7 web/sites/default/files/civicrm/templates_c/en_US/%%0C/0CB/0CBEC124%%default.tpl.php(19): Smarty->_smarty_include()
#8 vendor/civicrm/civicrm-packages/Smarty/Smarty.class.php(1914): include('...')
#9 web/sites/default/files/civicrm/templates_c/en_US/%%A0/A0D/A0D7E591%%snippet.tpl.php(26): Smarty->_smarty_include()
#10 vendor/civicrm/civicrm-packages/Smarty/Smarty.class.php(1273): include('...')
```

ping @eileenmcnaughton @demeritcowboy 