### PR TITLE
SearchKit - Run filterTasksForDisplay after all other hooks

### DIFF
--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SearchDisplayTasksSubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SearchDisplayTasksSubscriber.php
@@ -22,14 +22,20 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class SearchDisplayTasksSubscriber extends \Civi\Core\Service\AutoService implements EventSubscriberInterface {
 
   /**
-   * Filter tasks with a priority of -50, which allows W_MIDDLE & W_EARLY to go first, but W_LATE to go after.
+   * Listen for hook_civicrm_searchKitTasks with a low priority so that most other hooks have gone first.
+   * Setting the priority to -200 because:
+   *  - The default for symfony-style hooks is W_MIDDLE = 0.
+   *  - The default for CMS-style hooks is DEFAULT_HOOK_PRIORITY = -100.
+   *
+   * Generally speaking, the configuration settings enforced by `filterTasksForDisplay` should be respected,
+   * but if an extension needs to override them it can do so by listening to this event with an even lower priority.
    *
    * @return array
    */
   public static function getSubscribedEvents() {
     return [
       'hook_civicrm_searchKitTasks' => [
-        ['filterTasksForDisplay', -50],
+        ['filterTasksForDisplay', -200],
       ],
     ];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Filter SearchKit tasks *after* extensions have had the chance to add them.

See discussion at https://chat.civicrm.org/civicrm/pl/tenet3e1qifhtex91daxzwdyro

Before
----------
Try creating a search display of FormBuilder submissions, but disable the "Process Submissions" action:
![image](https://github.com/civicrm/civicrm-core/assets/2874912/44e79172-ec20-4a1a-a42a-b83aa78b3ed2)

The disabled action will still appear in the display.

After
------
The disabled action will be hidden.

Technical Details
-----------
Extensions can provide tasks via [hook_civicrm_searchKitTasks](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_searchKitTasks/). Also, administrators can filter out tasks from a specific display, and this filtering is achieved [using the same hook](https://github.com/civicrm/civicrm-core/blob/e71c81f3dcde95182df1edcaed6403ae75490cbd/ext/search_kit/Civi/Api4/Event/Subscriber/SearchDisplayTasksSubscriber.php#L40).
So, generally speaking, we want the hook listeners that *add* tasks to run before the listener that *removes* tasks.
This adjusts the priority so that happens, and adds a comment about how an extension could provide special handling if needed.

