### PR TITLE
Invert logic for collapsing contact summary accordions for custom field sets

### DIFF
--- a/templates/CRM/Contact/Page/View/CustomDataView.tpl
+++ b/templates/CRM/Contact/Page/View/CustomDataView.tpl
@@ -14,7 +14,7 @@
   {assign var="count" value=$customGroupCount%2}
   {if ($count eq $side) or $skipTitle}
     {foreach from=$customValues item=cd_edit key=cvID}
-      <details class="customFieldGroup crm-accordion-wrapper ui-corner-all {$cd_edit.name} crm-custom-set-block-{$customGroupId}" {if !empty($cd_edit.collapse_display)} open{/if}>
+      <details class="customFieldGroup crm-accordion-wrapper ui-corner-all {$cd_edit.name} crm-custom-set-block-{$customGroupId}" {if empty($cd_edit.collapse_display)} open{/if}>
         <summary class="crm-accordion-header crm-master-accordion-header">
           {$cd_edit.title}
         </summary>


### PR DESCRIPTION
Overview
----------------------------------------
After upgrading to 5.69.2, the option for collapsing sets on initial display seems to be working just the opposite. When the checkbox is checked, the set is displayed  and it is collapsed when checkbox is unchecked.

The accordion was changed in #28430 but this caused the logic to be inverted so the accordion collapse state is the opposite of what it should be.

See https://chat.civicrm.org/civicrm/pl/bxzo99dfsjbkjx5tmftqk9zboa

Before
----------------------------------------

Accordion collapse logic inverted.

After
----------------------------------------

Accordion collapse logic correct.


