### PR TITLE
dev/core#4938 - crash after saving a civireport

### DIFF
--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -29,6 +29,11 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance implem
       return NULL;
     }
 
+    if (empty($params['grouprole'])) {
+      // an empty array is getting stored as '' but it needs to be null
+      $params['grouprole'] = NULL;
+    }
+
     if (!isset($params['id'])) {
       $params['domain_id'] ??= CRM_Core_Config::domainID();
       // CRM-17256 set created_id on report creation.


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4938

Before
----------------------------------------
1. Edit a civireport.
2. Click save.
3. `TypeError: Cannot access offset of type string on string in HTML_QuickForm_advmultiselect->toHtml() (line 807 of ...\sites\all\modules\civicrm\packages\HTML\QuickForm\advmultiselect.php).`

After
----------------------------------------
null

Technical Details
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/28707 changes how the grouprole parameter gets saved. An empty array was being converted to the empty string but it needs to be null.

Note that saving a fresh new civireport from template without first viewing the results seems to be js-broken at the moment, but I'm not sure when that broke, and I'm not sure how often that's something you would do anyway, at least not by a typical user - they'd probably want to see the results before saving it. In any case it's a separate problem.

Comments
----------------------------------------

