### PR TITLE
dev/core#4905 - Use cached getFieldObject instead of new customField

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -550,13 +550,15 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
   }
 
   /**
-   * Use the cache to get all values of a specific custom field.
+   * Get specific custom field as an object.
+   * @deprecated
+   * @see CRM_Core_BAO_CustomField::getField()
+   * which does the same thing but returns an array instead of an object.
    *
    * @param int $fieldID
    *   The custom field ID.
    *
    * @return CRM_Core_BAO_CustomField
-   *   The field object.
    * @throws CRM_Core_Exception
    */
   public static function getFieldObject($fieldID) {
@@ -1181,9 +1183,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     $value = NULL
   ) {
     //get the type of custom field
-    $customField = new CRM_Core_BAO_CustomField();
-    $customField->id = $customFieldId;
-    $customField->find(TRUE);
+    $customField = self::getFieldObject($customFieldId);
 
     if (!$contactId) {
       if ($mode == CRM_Profile_Form::MODE_CREATE) {

--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -749,9 +749,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
       //get custom field id
       $customFieldId = explode('_', $profileFieldName);
       if ($customFieldId[0] == 'custom') {
-        $customField = new CRM_Core_DAO_CustomField();
-        $customField->id = $customFieldId[1];
-        $customField->find(TRUE);
+        $customField = CRM_Core_BAO_CustomField::getFieldObject($customFieldId[1]);
         $isCustomField = TRUE;
         if (!empty($fields['field_id']) && !$customField->is_active && $is_active) {
           $errors['field_name'] = ts('Cannot set this field "Active" since the selected custom field is disabled.');


### PR DESCRIPTION
Overview
----------------------------------------
Use already-loaded custom field info instead of refetching it from the database.

Part of https://lab.civicrm.org/dev/core/-/issues/4905
