### PR TITLE
dev/core#4905 - Use cache to fetch custom groups by contact type

### DIFF
--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -474,11 +474,12 @@ WHERE  subtype.name IN ('" . implode("','", $subType) . "' )";
     // Before deleting a contactType, check references by custom groups
     if ($event->action === 'delete') {
       $name = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_ContactType', $event->id);
-      $sep = CRM_Core_DAO::VALUE_SEPARATOR;
-      $custom = new CRM_Core_DAO_CustomGroup();
-      $custom->whereAdd("extends_entity_column_value LIKE '%{$sep}{$name}{$sep}%'");
-      if ($custom->find()) {
-        throw new CRM_Core_Exception(ts("You can not delete this contact type -- it is used by %1 custom field group(s). The custom fields must be deleted first.", [1 => $custom->N]));
+      $customGroups = CRM_Core_BAO_CustomGroup::getAll([
+        'extends' => 'Contact',
+        'extends_entity_column_value' => $name,
+      ]);
+      if ($customGroups) {
+        throw new CRM_Core_Exception(ts("You can not delete this contact type -- it is used by %1 custom field group(s). The custom fields must be deleted first.", [1 => count($customGroups)]));
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Use already-loaded custom field info instead of refetching it from the database.

Part of https://lab.civicrm.org/dev/core/-/issues/4905

Technical Details
--------
This improves performance when deleting a contact type, and also fixes a potential edge-case bug, because previously 'extends' was not specified so non-contact groups could potentially cause false-positives