### PR TITLE
Do not attempt to register string resources for Smarty3+

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -290,8 +290,10 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
   }
 
   public static function registerStringResource() {
-    require_once 'CRM/Core/Smarty/resources/String.php';
-    civicrm_smarty_register_string_resource();
+    if (method_exists('Smarty', 'register_resource')) {
+      require_once 'CRM/Core/Smarty/resources/String.php';
+      civicrm_smarty_register_string_resource();
+    }
   }
 
   /**

--- a/CRM/Core/SmartyCompatibility.php
+++ b/CRM/Core/SmartyCompatibility.php
@@ -116,6 +116,10 @@ class CRM_Core_SmartyCompatibility extends Smarty {
       parent::register_resource($type, $functions);
       return;
     }
+    if ($type === 'string') {
+      // Not valid / required for Smarty3+
+      return;
+    }
     parent::registerResource($type, $functions);
   }
 


### PR DESCRIPTION

Overview
----------------------------------------
It turns out this is not required for Smarty3 & it breaks for Smarty4.

Further, it is the only thing that breaks for Smarty4

Before
----------------------------------------
If I go to the smarty3 package and upgrade it to Smarty4 the page fails to load with

![image](https://github.com/civicrm/civicrm-core/assets/336308/d615ad8f-f2ac-4cef-9e5e-4a497e1ab7b3)

After
----------------------------------------
With this change Smarty4 works - as @demeritcowboy points out the code can also go for Smarty 3 "We should probably remove that line for smarty3 too? In smarty3 string resource is "native", in smarty2 it was something civi added that just happened to then be the same as what smarty added."

Technical Details
----------------------------------------


Comments
----------------------------------------
It turned out the step from Smarty3 to Smarty4 is actually very small indeed - this is the only thing I have hit 
https://smarty-php.github.io/smarty/5.x/upgrading/#upgrading-from-v3-to-v4

We did make the define `'CIVICRM_SMARTY3_AUTOLOAD_PATH'` - which suggests perhaps we should add Smarty4 to it's own  folder in packages & add a v4 version & when we are ready put that rather than 3 in composer. 

It's also possible that the leap to 5 will be sane...it's not stable yet though