### PR TITLE
dev/core#4918 On back office form check if participants are limited before eventFull check

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1238,9 +1238,10 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       if ($form->_isPaidEvent) {
         $form->addElement('hidden', 'hidden_feeblock', 1);
       }
-
-      $eventfullMsg = CRM_Event_BAO_Participant::eventFullMessage($form->_eventId, $this->getParticipantID());
-      $form->addElement('hidden', 'hidden_eventFullMsg', $eventfullMsg, ['id' => 'hidden_eventFullMsg']);
+      if ($this->getEventValue('max_participants') !== NULL) {
+        $eventfullMsg = CRM_Event_BAO_Participant::eventFullMessage($form->_eventId, $this->getParticipantID());
+      }
+      $form->addElement('hidden', 'hidden_eventFullMsg', $eventfullMsg ?? NULL, ['id' => 'hidden_eventFullMsg']);
     }
 
     if ($form->_isPaidEvent) {


### PR DESCRIPTION
Overview
----------------------------------------
On back office form check if participants are limited before eventFull check

Before
----------------------------------------
Per https://github.com/civicrm/civicrm-core/pull/29083 we have some over-zelous event full checking going on - for the back office form it's only coming from one place so easy just to wrap in a max_participants check 

After
----------------------------------------

Technical Details
----------------------------------------

Comments
----------------------------------------
