### PR TITLE
dev/core#4918 Fix over-zealous event full on info page

### DIFF
--- a/CRM/Event/Form/EventFormTrait.php
+++ b/CRM/Event/Form/EventFormTrait.php
@@ -118,4 +118,47 @@ trait CRM_Event_Form_EventFormTrait {
     return is_numeric($availableSpaces) ? (int) $availableSpaces : 0;
   }
 
+  /**
+   * Is the event full already.
+   *
+   * This function may be calculated by v4 api in time, in which case the function
+   * will call that instead but will remain available.
+   *
+   * @return bool
+   *
+   * @throws \CRM_Core_Exception
+   * @api This function will not change in a minor release and is supported for
+   *  use outside of core. This annotation / external support for properties
+   *  is only given where there is specific test cover.
+   */
+  public function isEventFull(): bool {
+    $maximum = $this->getEventValue('max_participants');
+    return !($maximum === NULL) && $this->getEventValue('available_spaces') < 1;
+  }
+
+  /**
+   * Is the event ready for online registrations.
+   *
+   * @internal - the handling of waitlist in this function may change.
+   *
+   * @return bool
+   * @throws \CRM_Core_Exception
+   */
+  protected function isAvailableForOnlineRegistration(): bool {
+    if (!$this->getEventValue('is_online_registration')) {
+      return FALSE;
+    }
+    if ($this->isEventFull() && !$this->getEventValue('has_waitlist')) {
+      return FALSE;
+    }
+    if (!CRM_Event_BAO_Event::validRegistrationRequest([
+      'registration_start_date' => $this->getEventValue('registration_start_date'),
+      'registration_end_date' => $this->getEventValue('registration_end_date'),
+      'end_date' => $this->getEventValue('end_date'),
+    ], $this->getEventID())) {
+      return FALSE;
+    }
+    return TRUE;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix over-zealous event full on info page

Before
----------------------------------------
In master branch event full not configured is being treated the same as max participants = NULL on the event info page

After
----------------------------------------
It checks a new `isEventFull()`  function

Technical Details
----------------------------------------
I also simplified one of several confusing IF clauses

I think we should possibly have some event full in the v4 api once we get there (rather than it being calculated from available_spaces which is not relevant in all events) - but there is still a much bigger issue with apiv4 event full calculations - it is not taking into account line items with multiple paricipants.

I'm not sure this covers the entire regression but on the Event Info page I think this makes sense & improves readability

Comments
----------------------------------------