### PR TITLE
Fix notices on Additional Payment Form

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -24,6 +24,7 @@ use Civi\Payment\Exception\PaymentProcessorException;
 class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_AbstractEditPayment {
   use CRM_Contact_Form_ContactFormTrait;
   use CRM_Contribute_Form_ContributeFormTrait;
+  use CRM_Event_Form_EventFormTrait;
 
   /**
    * Id of the component entity
@@ -215,16 +216,9 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     $this->add('textarea', 'receipt_text', ts('Confirmation Message'));
 
     $this->addField('trxn_date', ['entity' => 'FinancialTrxn', 'label' => $this->isARefund() ? ts('Refund Date') : ts('Contribution Date'), 'context' => 'Contribution'], FALSE, FALSE);
+    $this->assign('eventName', $this->getEventValue('title'));
 
-    if ($this->_contactId && $this->_id) {
-      if ($this->_component === 'event') {
-        $eventId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $this->_id, 'event_id', 'id');
-        $event = CRM_Event_BAO_Event::getEvents(0, $eventId);
-        $this->assign('eventName', $event[$eventId]);
-      }
-    }
-
-    $this->assign('displayName', $this->_contributorDisplayName);
+    $this->assign('displayName', $this->getContactValue('display_name'));
     $this->assign('component', $this->_component);
     $this->assign('email', $this->_contributorEmail);
 
@@ -295,13 +289,9 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
   public function postProcess() {
     $submittedValues = $this->controller->exportValues($this->_name);
     $this->submit($submittedValues);
-    $childTab = 'contribute';
-    if ($this->_component === 'event') {
-      $childTab = 'participant';
-    }
     $session = CRM_Core_Session::singleton();
     $session->replaceUserContext(CRM_Utils_System::url('civicrm/contact/view',
-      "reset=1&cid={$this->_contactId}&selectedChild={$childTab}"
+      "reset=1&cid={$this->_contactId}&selectedChild=" . $this->getParticipantID() ? 'participant' : 'contribute'
     ));
   }
 
@@ -319,7 +309,6 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
         ($this->_mode === 'test')
       );
     }
-    $this->assign('displayName', $this->getContactValue('display_name'));
 
     $paymentResult = [];
     if ($this->_mode) {
@@ -381,7 +370,6 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     // we need to retrieve email address
     if ($this->_context === 'standalone' && $this->getSubmittedValue('is_email_receipt')) {
       [$displayName] = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->_contactId);
-      $this->assign('displayName', $displayName);
     }
 
     // at this point we've created a contact and stored its address etc
@@ -537,6 +525,23 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       $this->_contactID = $this->getContributionValue('contact_id');
     }
     return (int) $this->_contactID;
+  }
+
+  /**
+   * Get the relevant participant ID, if any, in use.
+   *
+   * @return int
+   *
+   * @api supported for external use.
+   *
+   * @noinspection PhpDocMissingThrowsInspection
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function getParticipantID(): ?int {
+    if (CRM_Utils_Request::retrieve('component', 'String', $this, FALSE, 'contribution') !== 'event') {
+      return NULL;
+    }
+    return (int) CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
   }
 
   /**

--- a/CRM/Event/Form/EventFormTrait.php
+++ b/CRM/Event/Form/EventFormTrait.php
@@ -56,10 +56,14 @@ trait CRM_Event_Form_EventFormTrait {
    * is only given where there is specific test cover.
    *
    * @noinspection PhpUnhandledExceptionInspection
-   * @noinspection PhpDocMissingThrowsInspection
    */
   public function getEventID(): ?int {
-    throw new CRM_Core_Exception('`getEventID` must be implemented');
+    try {
+      return $this->getParticipantValue('event_id');
+    }
+    catch (CRM_Core_Exception $e) {
+      throw new CRM_Core_Exception('`getEventID` must be implemented');
+    }
   }
 
   /**

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -97,12 +97,12 @@
           </tr>
           <tr class="crm-payment-form-block-fee_amount">
             <td class="label">{$form.fee_amount.label}</td>
-            <td{$valueStyle}>{$form.fee_amount.html}</td>
+            <td>{$form.fee_amount.html}</td>
           </tr>
         </table>
       </div>
       {/if}
-      {include file='CRM/Core/BillingBlockWrapper.tpl'}
+      {include file='CRM/Core/BillingBlockWrapper.tpl' currency=false}
     </div>
 
     {literal}


### PR DESCRIPTION
Overview
----------------------------------------
Fix notices on Additional Payment Form

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/0b2afa07-e230-426e-b627-a9bcb4f479f7)

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/4b344b5a-477b-44e4-b212-b1a8b8bc5e6f)


Technical Details
----------------------------------------
The remaining notice deserves a bit of a logic-split which is better done once this is merged

There is some consolidation of the assignment of `displayName` - which was otherwise done in 3 places. I checked & displayName and eventName are both already escaped

Comments
----------------------------------------
