### PR TITLE
Fix JS error and allow focus of Other Amount field

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -23,6 +23,9 @@
         if ( element.type == 'radio' && element.name === mainPriceFieldName ) {
           if (element.value == '0' ) {
             element.checked = true;
+            // Copied from `updatePriceSetHighlight()` below which isn't available here.
+            cj('#priceset .price-set-row span').removeClass('highlight');
+            cj('#priceset .price-set-row input:checked').parent().addClass('highlight');
           }
           else {
             element.checked = false;
@@ -321,7 +324,7 @@
       var isRecur = cj('input[id="is_recur"]:checked');
 
       var quickConfig = {/literal}'{$quickConfig}'{literal};
-      if (cj("#auto_renew") && quickConfig) {
+      if (cj("#auto_renew").length && quickConfig) {
         showHideAutoRenew(null);
       }
 


### PR DESCRIPTION
reviewer's commit of https://github.com/civicrm/civicrm-core/pull/29033 - this is the same patch - I just moved to the rc branch

![image](https://github.com/civicrm/civicrm-core/assets/336308/ba85bec9-949a-4135-9007-9f2b831b9797)

Plus non-highlighting of selected value