### PR TITLE
dev/core#4917 Ensure total is always updated when other amount is selected

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -389,6 +389,8 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
             'price' => json_encode([$elementName, '0|0']),
             'data-currency' => $currencyName,
             'onclick' => 'clearAmountOther();',
+            'data-amount' => 0,
+            'data-is-null-option' => TRUE,
           ];
         }
 
@@ -408,6 +410,8 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           $choiceAttrs['0'] = [
             'price' => json_encode([$elementName, '0']),
             'data-membership-type-id' => NULL,
+            'data-amount' => 0,
+            'data-is-null-option' => TRUE,
           ] + $incomingExtra;
         }
 

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -16,31 +16,29 @@
 {literal}
   <script type="text/javascript">
 
-    // Putting these functions directly in template so they are available for standalone forms
+    // Putting these functions directly in template for historical reasons.
     function useAmountOther(mainPriceFieldName) {
-     for( i=0; i < document.Main.elements.length; i++ ) {
-        element = document.Main.elements[i];
-        if ( element.type == 'radio' && element.name === mainPriceFieldName ) {
-          if (element.value == '0' ) {
-            element.checked = true;
-            // Copied from `updatePriceSetHighlight()` below which isn't available here.
-            cj('#priceset .price-set-row span').removeClass('highlight');
-            cj('#priceset .price-set-row input:checked').parent().addClass('highlight');
-          }
-          else {
-            element.checked = false;
+      var currentFocus = CRM.$(':focus');
+      CRM.$('input[name=' + mainPriceFieldName + ']:radio:unchecked').each(
+        function () {
+          if (CRM.$(this).data('is-null-option') !== undefined) {
+            // Triggering this click here because over in Calculate.tpl
+            // a blur action is attached
+            CRM.$(this).prop('checked', true).trigger('click');
           }
         }
-      }
+      );
+      // Copied from `updatePriceSetHighlight()` below which isn't available here.
+      // @todo - consider adding this to the actions assigned in Calculate.tpl
+      CRM.$('#priceset .price-set-row span').removeClass('highlight');
+      CRM.$('#priceset .price-set-row input:checked').parent().addClass('highlight');
+      // Return the focus we blurred earlier.
+      currentFocus.trigger('focus');
+
     }
 
     function clearAmountOther(otherPriceFieldName) {
-      cj('#' + otherPriceFieldName).val('');
-      cj('#' + otherPriceFieldName).blur();
-      // @todo - remove the next 2 lines - they seems to relate to a field that is never present
-      // as amount_other will be (e.g) price_4
-      if (document.Main.amount_other == null) return; // other_amt field not present; do nothing
-      document.Main.amount_other.value = "";
+      cj('#' + otherPriceFieldName).val('').trigger('blur');
     }
 
   </script>


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4917 Ensure total is always updated when other amount is selected

https://lab.civicrm.org/dev/core/-/issues/4917

Before
----------------------------------------
When clicking on the 'Other Amount' text box in quick config mode and in price sets upgraded from quick config (e.g the demo site one where the hidden-for-non-quick-config option civicrm_contribution_page.is_use_other_amount is set) the radio selection is moved to 'Other Amount' but the total is not updated. For quick config price sets this total is hidden but can be unhidden using js and should be correct even if hidden.

After
----------------------------------------
total correctly udpated

Technical Details
----------------------------------------

Comments
----------------------------------------
