### PR TITLE
Fix broken address_billing tokens, add test to prevent repeat

### DIFF
--- a/CRM/Contact/Tokens.php
+++ b/CRM/Contact/Tokens.php
@@ -407,7 +407,7 @@ class CRM_Contact_Tokens extends CRM_Core_EntityTokens {
           // Set audience to sysadmin in case adding them to UI annoys people. If people ask to see this
           // in the UI we could set to 'user'.
           $field['audience'] = 'sysadmin';
-          $field['name'] = $entity . '_billing.' . $field['name'];
+          $field['name'] = str_replace('_primary.', '_billing.', $field['name']);
           $this->addFieldToTokenMetadata($tokensMetadata, $field, $exposedFields, $entity . '_billing');
         }
       }
@@ -417,6 +417,9 @@ class CRM_Contact_Tokens extends CRM_Core_EntityTokens {
     $tokensMetadata['address_primary.state_province_id:abbr'] = $tokensMetadata['address_primary.state_province_id:label'];
     $tokensMetadata['address_primary.state_province_id:abbr']['name'] = 'address_primary.state_province_id:abbr';
     $tokensMetadata['address_primary.state_province_id:abbr']['audience'] = 'user';
+    $tokensMetadata['address_billing.state_province_id:abbr'] = $tokensMetadata['address_billing.state_province_id:label'];;
+    $tokensMetadata['address_billing.state_province_id:abbr']['name'] = 'address_billing.state_province_id:abbr';
+
     // Hide the label for now because we are not sure if there are paths
     // where legacy token resolution is in play where this could not be resolved.
     $tokensMetadata['address_primary.state_province_id:label']['audience'] = 'sysadmin';

--- a/Civi/Test/ExampleData/Contact/Barb.php
+++ b/Civi/Test/ExampleData/Contact/Barb.php
@@ -50,6 +50,13 @@ class Barb extends EntityExample {
       'email_primary.email' => 'barb@testing.net',
       'email_greeting_display' => 'Dear Barb',
       'postal_greeting_display' => 'Dear Barb',
+      'address_billing.street_address' => '1407 Graymalkin Lane',
+      'address_billing.city' => 'New York',
+      'address_billing.supplemental_address_1' => 'Salem Center',
+      'address_billing.postal_code' => 10573,
+      'address_billing.name' => 'Xavier Institute for Higher Learning',
+      'address_billing.country_id' => \CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Address', 'country_id', 'United States'),
+      'address_billing.state_province_id:abbr' => 'NY',
     ];
   }
 

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -345,15 +345,24 @@ Czech Republic
    */
   public function testLocationTokens(): void {
     $contactID = $this->individualCreate(['email' => 'me@example.com']);
-    Address::create()->setValues([
+    $this->createTestEntity('Address', [
       'contact_id' => $contactID,
       'is_primary' => TRUE,
       'street_address' => 'Heartbreak Hotel',
       'supplemental_address_1' => 'Lonely Street',
-    ])->execute();
-    $text = '{contact.first_name} {contact.email_primary.email} {contact.address_primary.street_address}';
-    $text = $this->renderText(['contactId' => $contactID], $text);
-    $this->assertEquals('Anthony me@example.com Heartbreak Hotel', $text);
+    ], 'primary');
+
+    $this->createTestEntity('Address', [
+      'contact_id' => $contactID,
+      'is_billing' => TRUE,
+      'street_address' => 'Heartbreak Motel',
+      'supplemental_address_1' => 'Lonely Avenue',
+      'country_id:name' => 'United States',
+      'state_province_id:name' => 'California',
+    ], 'billing');
+    $template = '{contact.first_name} {contact.email_primary.email} {contact.address_primary.street_address} {contact.address_billing.supplemental_address_1} {contact.address_billing.state_province_id:abbr}';
+    $text = $this->renderText(['contactId' => $contactID], $template);
+    $this->assertEquals('Anthony me@example.com Heartbreak Hotel Lonely Avenue CA', $text);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix broken address_billing tokens, add test to prevent repeat

Before
----------------------------------------
Tokens like `{contact.address_billing.street_address}` stopped working - but quite a while back
 
After
----------------------------------------
Fixes, with test

Technical Details
----------------------------------------

Comments
----------------------------------------
