### PR TITLE
Contact tokens - Implement fall back from billing address to primary address

### DIFF
--- a/CRM/Contact/Tokens.php
+++ b/CRM/Contact/Tokens.php
@@ -452,6 +452,20 @@ class CRM_Contact_Tokens extends CRM_Core_EntityTokens {
     }
     $joins = [];
     $customFields = [];
+    $billingFields = [];
+    foreach ($requiredFields as $field) {
+      if (str_contains($field, '_billing.')) {
+        // Make sure we have enough data to fall back to primary.
+        $billingEntity = explode('.', $field)[0];
+        $billingFields[$field] = $billingEntity;
+        $extraFields = [$billingEntity . '.id', str_replace('_billing.', '_primary.', $field)];
+        foreach ($extraFields as $extraField) {
+          if (!in_array($extraField, $requiredFields, TRUE)) {
+            $requiredFields[] = $extraField;
+          }
+        }
+      }
+    }
     foreach ($requiredFields as $field) {
       $fieldSpec = $this->getMetadataForField($field);
       $prefix = '';
@@ -490,6 +504,11 @@ class CRM_Contact_Tokens extends CRM_Core_EntityTokens {
       // This is probably a test-only situation where tokens are retrieved for a
       // fake contact id - check `testReplaceGreetingTokens`
       return [];
+    }
+    foreach ($this->getEmptyBillingEntities($billingFields, $contact) as $billingEntityFields) {
+      foreach ($billingEntityFields as $billingField) {
+        $contact[$billingField] = $contact[str_replace('_billing.', '_primary.', $billingField)];
+      }
     }
 
     foreach ($this->getDeprecatedTokens() as $apiv3Name => $fieldName) {
@@ -688,6 +707,39 @@ class CRM_Contact_Tokens extends CRM_Core_EntityTokens {
         'audience' => 'sysadmin',
       ],
     ];
+  }
+
+  /**
+   * Get the array of related billing entities that are empty.
+   *
+   * The billing tokens fall back to the primary address tokens as we cannot rely
+   * on all contacts having an address with is_billing set and the code historically has
+   * treated billing addresses as 'get the best billing address', despite the failure
+   * to set the fields.
+   *
+   * Here we figure out the entities where swapping in the primary fields makes sense.
+   * This is the case when there is no billing address at all, but we don't want to 'supplement'
+   * a partial billing address with data from a possibly-completely-different primary address.
+   *
+   * @param array $billingFields
+   * @param array $contact
+   *
+   * @return array
+   */
+  private function getEmptyBillingEntities(array $billingFields, array $contact): array {
+    $billingEntitiesToReplaceWithPrimary = [];
+    foreach ($billingFields as $billingField => $billingEntity) {
+      // In most cases it is enough to check the 'id' is not present but it is possible
+      // that a partial address is passed in in preview mode - in which case
+      // we need to treat the entire address as 'usable'.
+      if (empty($contact[$billingField]) && empty($contact[$billingEntity . '.id'])) {
+        $billingEntitiesToReplaceWithPrimary[$billingEntity][] = $billingField;
+      }
+      else {
+        unset($billingEntitiesToReplaceWithPrimary[$billingEntity]);
+      }
+    }
+    return $billingEntitiesToReplaceWithPrimary;
   }
 
   /**

--- a/CRM/Contact/Tokens.php
+++ b/CRM/Contact/Tokens.php
@@ -407,7 +407,7 @@ class CRM_Contact_Tokens extends CRM_Core_EntityTokens {
           // Set audience to sysadmin in case adding them to UI annoys people. If people ask to see this
           // in the UI we could set to 'user'.
           $field['audience'] = 'sysadmin';
-          $field['name'] = $entity . '_billing.' . $field['name'];
+          $field['name'] = str_replace('_primary.', '_billing.', $field['name']);
           $this->addFieldToTokenMetadata($tokensMetadata, $field, $exposedFields, $entity . '_billing');
         }
       }
@@ -417,6 +417,9 @@ class CRM_Contact_Tokens extends CRM_Core_EntityTokens {
     $tokensMetadata['address_primary.state_province_id:abbr'] = $tokensMetadata['address_primary.state_province_id:label'];
     $tokensMetadata['address_primary.state_province_id:abbr']['name'] = 'address_primary.state_province_id:abbr';
     $tokensMetadata['address_primary.state_province_id:abbr']['audience'] = 'user';
+    $tokensMetadata['address_billing.state_province_id:abbr'] = $tokensMetadata['address_billing.state_province_id:label'];;
+    $tokensMetadata['address_billing.state_province_id:abbr']['name'] = 'address_billing.state_province_id:abbr';
+
     // Hide the label for now because we are not sure if there are paths
     // where legacy token resolution is in play where this could not be resolved.
     $tokensMetadata['address_primary.state_province_id:label']['audience'] = 'sysadmin';

--- a/Civi/Test/ExampleData/Contact/Barb.php
+++ b/Civi/Test/ExampleData/Contact/Barb.php
@@ -50,6 +50,13 @@ class Barb extends EntityExample {
       'email_primary.email' => 'barb@testing.net',
       'email_greeting_display' => 'Dear Barb',
       'postal_greeting_display' => 'Dear Barb',
+      'address_billing.street_address' => '1407 Graymalkin Lane',
+      'address_billing.city' => 'New York',
+      'address_billing.supplemental_address_1' => 'Salem Center',
+      'address_billing.postal_code' => 10573,
+      'address_billing.name' => 'Xavier Institute for Higher Learning',
+      'address_billing.country_id' => \CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Address', 'country_id', 'United States'),
+      'address_billing.state_province_id:abbr' => 'NY',
     ];
   }
 

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -350,6 +350,7 @@ Czech Republic
       'is_primary' => TRUE,
       'street_address' => 'Heartbreak Hotel',
       'supplemental_address_1' => 'Lonely Street',
+      'state_province_id:name' => 'New York',
     ], 'primary');
 
     $this->createTestEntity('Address', [
@@ -363,6 +364,9 @@ Czech Republic
     $template = '{contact.first_name} {contact.email_primary.email} {contact.address_primary.street_address} {contact.address_billing.supplemental_address_1} {contact.address_billing.state_province_id:abbr}';
     $text = $this->renderText(['contactId' => $contactID], $template);
     $this->assertEquals('Anthony me@example.com Heartbreak Hotel Lonely Avenue CA', $text);
+    Address::delete()->addWhere('id', '=', $this->ids['Address']['billing'])->execute();
+    $text = $this->renderText(['contactId' => $contactID], $template);
+    $this->assertEquals('Anthony me@example.com Heartbreak Hotel Lonely Street NY', $text);
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -345,15 +345,24 @@ Czech Republic
    */
   public function testLocationTokens(): void {
     $contactID = $this->individualCreate(['email' => 'me@example.com']);
-    Address::create()->setValues([
+    $this->createTestEntity('Address', [
       'contact_id' => $contactID,
       'is_primary' => TRUE,
       'street_address' => 'Heartbreak Hotel',
       'supplemental_address_1' => 'Lonely Street',
-    ])->execute();
-    $text = '{contact.first_name} {contact.email_primary.email} {contact.address_primary.street_address}';
-    $text = $this->renderText(['contactId' => $contactID], $text);
-    $this->assertEquals('Anthony me@example.com Heartbreak Hotel', $text);
+    ], 'primary');
+
+    $this->createTestEntity('Address', [
+      'contact_id' => $contactID,
+      'is_billing' => TRUE,
+      'street_address' => 'Heartbreak Motel',
+      'supplemental_address_1' => 'Lonely Avenue',
+      'country_id:name' => 'United States',
+      'state_province_id:name' => 'California',
+    ], 'billing');
+    $template = '{contact.first_name} {contact.email_primary.email} {contact.address_primary.street_address} {contact.address_billing.supplemental_address_1} {contact.address_billing.state_province_id:abbr}';
+    $text = $this->renderText(['contactId' => $contactID], $template);
+    $this->assertEquals('Anthony me@example.com Heartbreak Hotel Lonely Avenue CA', $text);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the tokens for the contact to provide data from the Primary address if no billing address exists. The billing address is a bit of an odd ball because it feels like they meant to implement 'is_billing' like 'is_primary' whereby each contact has exactly one at all times but somehow didn't quite do that. In the few places it is used in the code it is treated is 'get the best address to use for billing, treating is_billing as best, but use is_primary as a fall back' This is how the invoice class handles it - which is the class that has a need for these tokens


Before
----------------------------------------
billing tokens are empty if the contact has a primary address but not billing address

After
----------------------------------------
billing tokens fall back to the primary address where there is no billing address.

Technical Details
----------------------------------------
The billing address tokens were added a while back to be used from WorkflowMessage templates but have not been put in use as yet because most of the templates use the address attached to the contribution

On attempting to swap them out I found that the billing tokens have been broken for a while - fixed in https://github.com/civicrm/civicrm-core/pull/29120 & also incorporated into this PR  - this means we don't have to worry about unexpected behaviour changes :-)

Comments
----------------------------------------
