### PR TITLE
dev/core#4942 A couple more fixes on event full

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -852,7 +852,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         $totalParticipants += $numberAdditionalParticipants;
       }
 
-      if (empty($fields['bypass_payment']) &&
+      if ($form->getEventValue('max_participants') !== NULL && empty($fields['bypass_payment']) &&
         !$form->_allowConfirmation &&
         $spacesAvailable < $totalParticipants
       ) {

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -805,7 +805,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     }
     $spacesAvailable = $form->getEventValue('available_spaces');
     //check for availability of registrations.
-    if (!$form->_allowConfirmation && empty($fields['bypass_payment']) &&
+    if ($form->getEventValue('max_participants') !== NULL  && !$form->_allowConfirmation && empty($fields['bypass_payment']) &&
       ($fields['additional_participants'] ?? 0) >= $spacesAvailable
     ) {
       $errors['additional_participants'] = ts("There is only enough space left on this event for %1 participant(s).", [1 => $spacesAvailable]);

--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -67,7 +67,7 @@
                     <div class="clear"></div>
                   </div>
                 {/if}
-                {if $hookDiscount.message}
+                {if $hookDiscount}
                     <div class="crm-section hookDiscount-section">
                         <em>({$hookDiscount.message})</em>
                     </div>

--- a/templates/CRM/Event/Form/Registration/ThankYou.tpl
+++ b/templates/CRM/Event/Form/Registration/ThankYou.tpl
@@ -101,7 +101,7 @@
                     <div class="clear"></div>
                   </div>
 
-                    {if $hookDiscount.message}
+                    {if $hookDiscount}
                         <div class="crm-section hookDiscount-section">
                             <em>({$hookDiscount.message})</em>
                         </div>


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4942 A couple more fixes on event full

Before
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/4942 - master only regression

After
----------------------------------------
These places are fixed...

Technical Details
----------------------------------------
Also includes a notice fix that I tested with.

I'm not totally sure these are the last ones but I think I'm close. Also I'm figuring out what we should do to expose this in the api - I think the answer is to add calculated fields to the participant.get api for seats_used and seats_waitlisted & then be able to sum those - but of course event.get api has already 'available_seats' & that is wrong. The thing is there are different ways to calculate the seats being considered - still working my head through that


Comments
----------------------------------------
