### PR TITLE
Do not return params from doSubmitActions, it is unchanged

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -452,13 +452,11 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing implements \Civi\C
    *
    * @param array $params
    * @param \CRM_Mailing_DAO_Mailing $mailing
-   *
-   * @return array
    */
-  protected static function doSubmitActions(array $params, CRM_Mailing_DAO_Mailing $mailing): array {
+  protected static function doSubmitActions(array $params, CRM_Mailing_DAO_Mailing $mailing): void {
     // Create parent job if not yet created.
     // Condition on the existence of a scheduled date.
-    if (!empty($params['scheduled_date']) && $params['scheduled_date'] != 'null' && empty($params['_skip_evil_bao_auto_schedule_'])) {
+    if (!empty($params['scheduled_date']) && $params['scheduled_date'] !== 'null' && empty($params['_skip_evil_bao_auto_schedule_'])) {
 
       if (!isset($params['is_completed']) || $params['is_completed'] !== 1) {
         $mailingGroups = \Civi\Api4\MailingGroup::get()
@@ -499,7 +497,6 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing implements \Civi\C
     if (empty($params['_skip_evil_bao_auto_recipients_'])) {
       self::getRecipients($mailing->id);
     }
-    return $params;
   }
 
   /**
@@ -1644,7 +1641,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     // point we will create a 'submit' function which will do the crud+submit
     // but for now only CRUD is available via v4 api.
     if (($params['version'] ?? '') !== 4) {
-      $params = self::doSubmitActions($params, $mailing);
+      self::doSubmitActions($params, $mailing);
     }
 
     return $mailing;


### PR DESCRIPTION
Overview
----------------------------------------
Do not return params from doSubmitActions, it is unchanged

Before
----------------------------------------
`$params` has the appearance of being returned by the function - but in fact is what is passed in

After
----------------------------------------
return removed

Technical Details
----------------------------------------

Comments
----------------------------------------
