### PR TITLE
Use writeRecord from mailing job DAO

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -40,20 +40,11 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
    * @return \CRM_Mailing_BAO_MailingJob
    * @throws \CRM_Core_Exception
    */
-  public static function create($params) {
-    if (empty($params['id']) && empty($params['mailing_id'])) {
-      throw new CRM_Core_Exception("Failed to create job: Unknown mailing ID");
-    }
-    $op = empty($params['id']) ? 'create' : 'edit';
-    CRM_Utils_Hook::pre($op, 'MailingJob', $params['id'] ?? NULL, $params);
-
-    $jobDAO = new CRM_Mailing_BAO_MailingJob();
-    $jobDAO->copyValues($params);
-    $jobDAO->save();
+  public static function create(array $params): self {
+    $jobDAO = self::writeRecord($params);
     if (!empty($params['mailing_id']) && empty('is_calling_function_updated_to_reflect_deprecation')) {
       CRM_Mailing_BAO_Mailing::getRecipients($params['mailing_id']);
     }
-    CRM_Utils_Hook::post($op, 'MailingJob', $jobDAO->id, $jobDAO);
     return $jobDAO;
   }
 

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -37,6 +37,8 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
    *
    * @param array $params
    *
+   * @deprecated since 5.71 will be removed around 5.85
+   *
    * @return \CRM_Mailing_BAO_MailingJob
    * @throws \CRM_Core_Exception
    */


### PR DESCRIPTION
Overview
----------------------------------------
Use writeRecord from mailing job DAO

Before
----------------------------------------
Function has it's own special code

After
----------------------------------------
Function is generic

Technical Details
----------------------------------------
I took a look at the commit that added the hook in & it was tidy up - not any particular use case & I searched for `'MailingJob'` in universe & didn't find any hook implementations. So I think it's Ok to move the hook order slightly. Logically it would be bad to rely on that function being called before the hook since we are moving to NOT letting that function be called in MailingJob::create()

Comments
----------------------------------------
