### PR TITLE
Fix apiv4 Mailing Api to not do scheduling 

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1638,7 +1638,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     // In v4 of the api they are not available via CRUD. At some
     // point we will create a 'submit' function which will do the crud+submit
     // but for now only CRUD is available via v4 api.
-    if (($params['version'] ?? '') !== 4) {
+    if (empty($params['skip_legacy_scheduling'])) {
       self::doSubmitActions($params, $mailing);
     }
 

--- a/ext/civi_mail/Civi/Api4/Action/Mailing/CreateAction.php
+++ b/ext/civi_mail/Civi/Api4/Action/Mailing/CreateAction.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Mailing;
+
+use Civi\Api4\Generic\DAOCreateAction;
+
+/**
+ * @inheritDoc
+ */
+class CreateAction extends DAOCreateAction {
+  use MailingSaveTrait;
+
+}

--- a/ext/civi_mail/Civi/Api4/Action/Mailing/MailingSaveTrait.php
+++ b/ext/civi_mail/Civi/Api4/Action/Mailing/MailingSaveTrait.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Mailing;
+
+trait MailingSaveTrait {
+
+  /**
+   * @inheritDoc
+   */
+  protected function write(array $items) {
+    foreach ($items as &$item) {
+      // Required by Mailing & MailingJob to avoid legacy behaviour.
+      $item['skip_legacy_scheduling'] = TRUE;
+    }
+    return parent::write($items);
+  }
+
+}

--- a/ext/civi_mail/Civi/Api4/Action/Mailing/SaveAction.php
+++ b/ext/civi_mail/Civi/Api4/Action/Mailing/SaveAction.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Mailing;
+
+use Civi\Api4\Generic\DAOSaveAction;
+
+/**
+ * @inheritDoc
+ */
+class SaveAction extends DAOSaveAction {
+  use MailingSaveTrait;
+
+}

--- a/ext/civi_mail/Civi/Api4/Action/Mailing/UpdateAction.php
+++ b/ext/civi_mail/Civi/Api4/Action/Mailing/UpdateAction.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Mailing;
+
+use Civi\Api4\Generic\DAOUpdateAction;
+
+/**
+ * @inheritDoc
+ */
+class UpdateAction extends DAOUpdateAction {
+  use MailingSaveTrait;
+
+}

--- a/ext/civi_mail/Civi/Api4/Mailing.php
+++ b/ext/civi_mail/Civi/Api4/Mailing.php
@@ -10,6 +10,10 @@
  */
 namespace Civi\Api4;
 
+use Civi\Api4\Action\Mailing\UpdateAction;
+use Civi\Api4\Action\Mailing\CreateAction;
+use Civi\Api4\Action\Mailing\SaveAction;
+
 /**
  * Mailing.
  *
@@ -21,5 +25,32 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class Mailing extends Generic\DAOEntity {
+
+  /**
+   * @param bool $checkPermissions
+   * @return \Civi\Api4\Action\Mailing\CreateAction
+   */
+  public static function create($checkPermissions = TRUE): CreateAction {
+    return (new CreateAction(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return \Civi\Api4\Action\Mailing\UpdateAction
+   */
+  public static function update($checkPermissions = TRUE) {
+    return (new UpdateAction(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return \Civi\Api4\Action\Mailing\SaveAction
+   */
+  public static function save($checkPermissions = TRUE): SaveAction {
+    return (new SaveAction(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
 
 }

--- a/tests/phpunit/api/v3/JobProcessMailingTest.php
+++ b/tests/phpunit/api/v3/JobProcessMailingTest.php
@@ -92,7 +92,7 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
     Civi::settings()->add([
       'mailerBatchLimit' => 2,
     ]);
-    $this->callAPISuccess('mailing', 'create', $this->_params);
+    $this->callAPISuccess('Mailing', 'create', $this->_params);
     $this->_mut->assertRecipients([]);
     $this->callAPISuccess('job', 'process_mailing', []);
     $this->_mut->assertRecipients($this->getRecipients(1, 2));

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -81,11 +81,8 @@ class api_v3_MailingTest extends CiviUnitTestCase {
    * Test civicrm_mailing_create.
    *
    * @dataProvider versionThreeAndFour
-   *
-   * @param int $version
    */
-  public function testMailerCreateSuccess(int $version): void {
-    $this->_apiversion = $version;
+  public function testMailerCreateSuccess(): void {
     $this->callAPISuccess('Campaign', 'create', ['name' => 'big campaign', 'title' => 'abc']);
     $result = $this->callAPISuccess('mailing', 'create', $this->_params + ['scheduled_date' => 'now', 'campaign_id' => 'big campaign']);
     $jobs = $this->callAPISuccess('MailingJob', 'get', ['mailing_id' => $result['id']]);
@@ -111,11 +108,8 @@ class api_v3_MailingTest extends CiviUnitTestCase {
    * Create a completed mailing (e.g when importing from a provider).
    *
    * @dataProvider versionThreeAndFour
-   *
-   * @param int $version
    */
-  public function testMailerCreateCompleted(int $version): void {
-    $this->_apiversion = $version;
+  public function testMailerCreateCompleted(): void {
     $this->_params['body_html'] = 'I am completed so it does not matter if there is an opt out link since I have already been sent by another system';
     $this->_params['is_completed'] = 1;
     $result = $this->callAPISuccess('mailing', 'create', $this->_params + ['scheduled_date' => 'now']);


### PR DESCRIPTION
Overview
----------------------------------------
When we added apiv4 Mailing.create we deliberately updated the BAO code such that the sometimes-unexpected scheduling would not take place when api v4 Mailing.create was called. However, somewhere along the way the BAO stopped receiving the version parameter - causing it to trigger the scheduling code

https://lab.civicrm.org/dev/core/-/issues/4385

Before
----------------------------------------
Scheduling code called by apiv4

After
----------------------------------------
Scheduling code not called

Technical Details
----------------------------------------
We have long agreed that the scheduling should be deliberate, not a by-product of the crud action, as there are varied reasons to create without wanting to schedule (either because the code is not ready or because the mailing is being created to reflect somethign sent through an external system.

However, this is a behavioural change to the api so there might be some dragons. Sadly not having a test eariler I'm unsure when it last worked as intended

Comments
----------------------------------------
Fix vs change of behaviour? The code is pretty clear this is the intended behaviour and it was logged as a bug. However, it has been wrong for a long time. I did a universe search & found only one v4 Mailing api caller - in @artfulrobot's mailgun extension. That code would mostly skip this as it creates completed mailings and the new  behaviour is the desirable behaviour for that code (it might slightly speed it up by skipping calling the mailing recipient calculate but that would not find any so be neither here nor there really).

I think a change log update + release notes is enough
