### PR TITLE
Fix misunderstanding about return value of getKeyId

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2311,7 +2311,8 @@ AND      default_value IS NOT NULL";
     $customData = [];
 
     foreach ($params as $key => $value) {
-      if ($customFieldInfo = CRM_Core_BAO_CustomField::getKeyID($key, TRUE)) {
+      $customFieldInfo = CRM_Core_BAO_CustomField::getKeyID($key, TRUE);
+      if ($customFieldInfo[0]) {
 
         // for autocomplete transfer hidden value instead of label
         if ($params[$key] && isset($params[$key . '_id'])) {

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -3169,7 +3169,8 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
 
         //FIX ME: We need to loop defaults, but once we move to custom_1_x convention this code can be simplified.
         foreach ($defaults as $customKey => $customValue) {
-          if ($customFieldDetails = CRM_Core_BAO_CustomField::getKeyID($customKey, TRUE)) {
+          $customFieldDetails = CRM_Core_BAO_CustomField::getKeyID($customKey, TRUE);
+          if ($customFieldDetails[0]) {
             if ($name == 'custom_' . $customFieldDetails[0]) {
 
               //hack to set default for checkbox


### PR DESCRIPTION
Overview
----------------------------------------
Cleans up some custom fieldname parsing code that looked wrong.

Technical Details
----------------------------------------
There seems to be a misunderstanding in these lines. When passed TRUE as the second param, this function always returns a non-empty array, so the conditional would always be TRUE.

This changes them to do what they thought they were doing.