### PR TITLE
Remove unused paramter (was to support email forward deprecated function - but that no longer calls this)

### DIFF
--- a/CRM/Mailing/ActionTokens.php
+++ b/CRM/Mailing/ActionTokens.php
@@ -83,9 +83,7 @@ class CRM_Mailing_ActionTokens extends \Civi\Token\AbstractTokenSubscriber {
     list($verp, $urls) = CRM_Mailing_BAO_Mailing::getVerpAndUrls(
       $row->context['mailingJobId'],
       $row->context['mailingActionTarget']['id'] ?? NULL,
-      $row->context['mailingActionTarget']['hash'] ?? NULL,
-      // Note: Behavior is already undefined for SMS/'phone' mailings...
-      $row->context['mailingActionTarget']['email'] ?? NULL
+      $row->context['mailingActionTarget']['hash'] ?? NULL
     );
 
     $row->format('text/plain')->tokens($entity, $field,

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -936,20 +936,18 @@ ORDER BY   civicrm_email.is_bulkmail DESC
    *   ID of the EventQueue.
    * @param string $hash
    *   Hash of the EventQueue.
-   * @param string $email
-   *   Destination address.
    *
    * @return array
    *   (reference) array    array ref that hold array refs to the verp info and urls
    */
-  public static function getVerpAndUrls($job_id, $event_queue_id, $hash, $email) {
+  public static function getVerpAndUrls($job_id, $event_queue_id, $hash) {
     // create a skeleton object and set its properties that are required by getVerpAndUrlsAndHeaders()
     $bao = new CRM_Mailing_BAO_Mailing();
     $bao->_domain = CRM_Core_BAO_Domain::getDomain();
     $bao->from_name = $bao->from_email = $bao->subject = '';
 
     // use $bao's instance method to get verp and urls
-    [$verp, $urls, $_] = $bao->getVerpAndUrlsAndHeaders($job_id, $event_queue_id, $hash, $email);
+    [$verp, $urls, $_] = $bao->getVerpAndUrlsAndHeaders($job_id, $event_queue_id, $hash);
     return [$verp, $urls];
   }
 
@@ -962,15 +960,11 @@ ORDER BY   civicrm_email.is_bulkmail DESC
    *   ID of the EventQueue.
    * @param string $hash
    *   Hash of the EventQueue.
-   * @param string $email
-   *   Destination address.
-   *
-   * @param bool $isForward
    *
    * @return array
    *   array ref that hold array refs to the verp info, urls, and headers
    */
-  public function getVerpAndUrlsAndHeaders($job_id, $event_queue_id, $hash, $email, $isForward = FALSE) {
+  public function getVerpAndUrlsAndHeaders($job_id, $event_queue_id, $hash) {
     $config = CRM_Core_Config::singleton();
 
     /**
@@ -1035,9 +1029,6 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       'List-Unsubscribe' => "<mailto:{$verp['unsubscribe']}>",
     ];
     self::addMessageIdHeader($headers, 'm', $job_id, $event_queue_id, $hash);
-    if ($isForward) {
-      $headers['Subject'] = "[Fwd:{$this->subject}]";
-    }
     return [&$verp, &$urls, &$headers];
   }
 
@@ -1084,9 +1075,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     [$verp, $urls, $headers] = $this->getVerpAndUrlsAndHeaders(
       $job_id,
       $event_queue_id,
-      $hash,
-      $email,
-      $isForward
+      $hash
     );
 
     //set from email who is forwarding it and not original one.

--- a/CRM/Mailing/Event/BAO/MailingEventResubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventResubscribe.php
@@ -226,7 +226,7 @@ class CRM_Mailing_Event_BAO_MailingEventResubscribe {
       }
     }
 
-    list($addresses, $urls) = CRM_Mailing_BAO_Mailing::getVerpAndUrls($job, $queue_id, $eq->hash, $eq->email);
+    list($addresses, $urls) = CRM_Mailing_BAO_Mailing::getVerpAndUrls($job, $queue_id, $eq->hash);
     $bao = new CRM_Mailing_BAO_Mailing();
     $bao->body_text = $text;
     $bao->body_html = $html;

--- a/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
@@ -392,7 +392,7 @@ WHERE  email = %2
       }
     }
 
-    [$addresses, $urls] = CRM_Mailing_BAO_Mailing::getVerpAndUrls($job, $queue_id, $eq->hash, $eq->email);
+    [$addresses, $urls] = CRM_Mailing_BAO_Mailing::getVerpAndUrls($job, $queue_id, $eq->hash);
     $bao = new CRM_Mailing_BAO_Mailing();
     $bao->body_text = $text;
     $bao->body_html = $html;

--- a/ext/flexmailer/src/Listener/BasicHeaders.php
+++ b/ext/flexmailer/src/Listener/BasicHeaders.php
@@ -40,8 +40,7 @@ class BasicHeaders extends AutoService {
       }
 
       list($verp) = $mailing->getVerpAndUrlsAndHeaders(
-        $e->getJob()->id, $task->getEventQueueId(), $task->getHash(),
-        $task->getAddress());
+        $e->getJob()->id, $task->getEventQueueId(), $task->getHash());
 
       $mailParams = [];
       $mailParams['List-Unsubscribe'] = "<mailto:{$verp['unsubscribe']}>";

--- a/ext/flexmailer/src/Listener/BounceTracker.php
+++ b/ext/flexmailer/src/Listener/BounceTracker.php
@@ -36,8 +36,7 @@ class BounceTracker extends AutoService {
     foreach ($e->getTasks() as $task) {
       /** @var \Civi\FlexMailer\FlexMailerTask $task */
       list($verp) = $mailing->getVerpAndUrlsAndHeaders(
-        $e->getJob()->id, $task->getEventQueueId(), $task->getHash(),
-        $task->getAddress());
+        $e->getJob()->id, $task->getEventQueueId(), $task->getHash());
 
       if (!$task->getMailParam('Return-Path')) {
         $task->setMailParam('Return-Path', $defaultReturnPath ?? $verp['bounce']);


### PR DESCRIPTION
Overview
----------------------------------------
Remove `$is_forward` from `getVerpAndUrlsAndHeaders` as it used to be passed by the (deprecated) email forward functionality but now is never passed (& is weird). 

![image](https://github.com/civicrm/civicrm-core/assets/336308/7f9af2dd-c168-4ade-8191-cb6fbc6fff93)


Before
----------------------------------------
Unused parameters part of signature

After
----------------------------------------
Gone

That makes the unused `$email`  the last variable in the signature - which I removed too

Technical Details
----------------------------------------


Comments
----------------------------------------
