### PR TITLE
Use names rather than variables for table names in findPendingTasks

### DIFF
--- a/CRM/Mailing/BAO/SMSJob.php
+++ b/CRM/Mailing/BAO/SMSJob.php
@@ -62,7 +62,7 @@ class CRM_Mailing_BAO_SMSJob extends CRM_Mailing_BAO_MailingJob {
 
     // make sure that there's no more than $mailerBatchLimit mails processed in a run
     $mailerBatchLimit = Civi::settings()->get('mailerBatchLimit');
-    $eq = self::findPendingTasks($this->id, $mailing->sms_provider_id ? 'sms' : 'email');
+    $eq = self::findPendingTasks((int) $this->id, 'sms');
     while ($eq->fetch()) {
       if ($mailerBatchLimit > 0 && self::$mailsProcessed >= $mailerBatchLimit) {
         if (!empty($fields)) {

--- a/ext/flexmailer/src/Listener/DefaultBatcher.php
+++ b/ext/flexmailer/src/Listener/DefaultBatcher.php
@@ -38,7 +38,7 @@ class DefaultBatcher extends BaseListener {
     // make sure that there's no more than $mailerBatchLimit mails processed in a run
     $mailerBatchLimit = \CRM_Core_Config::singleton()->mailerBatchLimit;
 
-    $eq = \CRM_Mailing_BAO_MailingJob::findPendingTasks($job->id, 'email');
+    $eq = \CRM_Mailing_BAO_MailingJob::findPendingTasks((int) $job->id, 'email');
     $tasks = [];
     while ($eq->fetch()) {
       if ($mailerBatchLimit > 0 && \CRM_Mailing_BAO_MailingJob::$mailsProcessed >= $mailerBatchLimit) {


### PR DESCRIPTION
Overview
----------------------------------------
Use names rather than variables for table names in findPendingTasks

Before
----------------------------------------
SQL made hard to read by unnecessary variables


After
----------------------------------------
Fixed

Technical Details
----------------------------------------

Comments
----------------------------------------
