### PR TITLE
Update Fiscal Year Label on Contribution Totals

### DIFF
--- a/templates/CRM/Contribute/Page/ContributionTotals.tpl
+++ b/templates/CRM/Contribute/Page/ContributionTotals.tpl
@@ -13,7 +13,7 @@
 
     {if !empty($annual.count)}
         <tr>
-            <th class="contriTotalLeft right">{ts}Current Year-to-Date{/ts} &ndash; {$annual.amount|smarty:nodefaults}</th>
+            <th class="contriTotalLeft right">{ts}Current Fiscal Year-to-Date{/ts} &ndash; {$annual.amount|smarty:nodefaults}</th>
             <th class="right"> &nbsp; {ts}# Completed Contributions{/ts} &ndash; {$annual.count|smarty:nodefaults}</th>
             <th class="right contriTotalRight"> &nbsp; {ts}Avg Amount{/ts} &ndash; {$annual.avg|smarty:nodefaults}</th>
             {if $contributionSummary.cancel.amount|smarty:nodefaults}


### PR DESCRIPTION
Overview
----------------------------------------
Update the label on the Contribution Totals template to reflect the use of the Fiscal Year.

Before
----------------------------------------
`Current Year-To-Date`

After
----------------------------------------
`Current Fiscal Year-To-Date`


Comments
----------------------------------------
This template references `$amount` from `Contribution.php`, which calls `CRM_Contribute_BAO_Contribution::annual()` and uses the configured Fiscal Year in `CRM_Contribute_BAO_Contribution::getAnnualQuery()`.


