### PR TITLE
crmDashboard - Fix deleting item from 2nd column

### DIFF
--- a/ang/crmDashboard/Dashboard.html
+++ b/ang/crmDashboard/Dashboard.html
@@ -18,9 +18,9 @@
     </div>
   </fieldset>
   <div class="crm-flex-box">
-    <div ng-repeat="column in $ctrl.columns" class="crm-flex-{{2 + $index}} crm-dashboard-droppable" ng-model="column" ui-sortable="$ctrl.sortableOptions">
+    <div ng-repeat="(colIndex, column) in $ctrl.columns" class="crm-flex-{{2 + colIndex}} crm-dashboard-droppable" ng-model="column" ui-sortable="$ctrl.sortableOptions">
       <div ng-repeat="dashlet in column" class="crm-dashlet">
-        <crm-dashlet dashlet="dashlet" remove="$ctrl.removeDashlet($parent.$index, $index)" fullscreen="$ctrl.showFullscreen(dashlet)" ng-if="$ctrl.fullscreenDashlet !== dashlet.name"></crm-dashlet>
+        <crm-dashlet dashlet="dashlet" remove="$ctrl.removeDashlet(colIndex, $index)" fullscreen="$ctrl.showFullscreen(dashlet)" ng-if="$ctrl.fullscreenDashlet !== dashlet.name"></crm-dashlet>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug where clicking the `x` to remove a dashlet only works if the dashlet is in the 1st column.

Before
----------------------------------------
Go to the home dashboard and try to remove a dashlet from the 2nd column. It won't work.

After
----------------------------------------
Fixed.