### PR TITLE
Afform - DisplayOnly field should show label not id

### DIFF
--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -120,6 +120,15 @@ class AfformMetadataInjector {
     // On a search form, search_range will present a pair of fields (or possibly 3 fields for date select + range)
     $isSearchRange = !empty($fieldDefn['search_range']) && \CRM_Utils_JS::decode($fieldDefn['search_range']);
 
+    // DisplayOnly field should show label not id
+    if ($inputType === 'DisplayOnly') {
+      if (in_array('label', $fieldInfo['suffixes'] ?? [], TRUE)) {
+        pq($afField)->attr('name', pq($afField)->attr('name') . ':label');
+      }
+      unset($fieldInfo['options']);
+    }
+    unset($fieldInfo['suffixes']);
+
     // On a search form, the exposed operator requires a list of options.
     if (!empty($fieldDefn['expose_operator'])) {
       $operators = Utils::getSearchOperators();

--- a/ext/afform/core/Civi/Afform/FormDataModel.php
+++ b/ext/afform/core/Civi/Afform/FormDataModel.php
@@ -208,7 +208,7 @@ class FormDataModel {
     if ($action === 'get' && strpos($fieldName, '.')) {
       $namesToMatch[] = substr($fieldName, 0, strrpos($fieldName, '.'));
     }
-    $select = ['name', 'label', 'input_type', 'data_type', 'input_attrs', 'help_pre', 'help_post', 'options', 'fk_entity', 'required'];
+    $select = ['name', 'label', 'input_type', 'data_type', 'input_attrs', 'help_pre', 'help_post', 'options', 'fk_entity', 'required', 'suffixes'];
     if ($action === 'get') {
       $select[] = 'operators';
     }

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -256,8 +256,12 @@
         };
       };
 
-      ctrl.getAutocompleteFieldName = function() {
-        return ctrl.afFieldset.modelName + (ctrl.afJoin ? ('+' + ctrl.afJoin.entity) : '') + ':' + ctrl.fieldName;
+      ctrl.getAutocompleteParams = function() {
+        return {
+          formName: 'afform:' + ctrl.afFieldset.getFormName(),
+          fieldName: ctrl.afFieldset.getName() + ':' + ctrl.fieldName,
+          values: $scope.dataProvider.getFieldData()
+        };
       };
 
       $scope.getOptions = function () {

--- a/ext/afform/core/ang/af/fields/EntityRef.html
+++ b/ext/afform/core/ang/af/fields/EntityRef.html
@@ -5,7 +5,7 @@
        ng-model="getSetSelect"
        ng-model-options="{getterSetter: true}"
        crm-autocomplete="$ctrl.defn.fk_entity"
-       crm-autocomplete-params="{formName: 'afform:' + $ctrl.afFieldset.getFormName(), fieldName: $ctrl.afFieldset.getName() + ':' + $ctrl.fieldName, values: dataProvider.getFieldData()}"
+       crm-autocomplete-params="$ctrl.getAutocompleteParams"
        multi="$ctrl.defn.input_attrs.multiple"
        auto-open="$ctrl.defn.input_attrs.autoOpen"
        quick-add="$ctrl.defn.input_attrs.quickAdd"

--- a/js/Common.js
+++ b/js/Common.js
@@ -570,6 +570,12 @@ if (!CRM.vars) CRM.vars = {};
 
   // Autocomplete based on APIv4 and Select2.
   $.fn.crmAutocomplete = function(entityName, apiParams, select2Options) {
+    function getApiParams() {
+      if (typeof apiParams === 'function') {
+        return apiParams();
+      }
+      return apiParams || {};
+    }
     if (entityName === 'destroy') {
       return $(this).off('.crmEntity').crmSelect2('destroy');
     }
@@ -578,8 +584,7 @@ if (!CRM.vars) CRM.vars = {};
       const $el = $(this).off('.crmEntity');
       let staticItems = getStaticOptions(select2Options.static),
         quickAddLinks = select2Options.quickAdd,
-        multiple = !!select2Options.multiple,
-        key = apiParams.key || 'id';
+        multiple = !!select2Options.multiple;
 
       $el.crmSelect2(_.extend({
         ajax: {
@@ -589,7 +594,7 @@ if (!CRM.vars) CRM.vars = {};
             return {params: JSON.stringify(_.assign({
               input: input,
               page: pageNum || 1
-            }, apiParams))};
+            }, getApiParams()))};
           },
           results: function(data) {
             return {
@@ -615,7 +620,7 @@ if (!CRM.vars) CRM.vars = {};
           if (!idsNeeded.length) {
             callback(multiple ? existing : existing[0]);
           } else {
-            var params = $.extend({}, apiParams || {}, {ids: idsNeeded});
+            var params = $.extend({}, getApiParams(), {ids: idsNeeded});
             CRM.api4(entityName, 'autocomplete', params).then(function (result) {
               callback(multiple ? result.concat(existing) : result[0]);
             });
@@ -663,6 +668,7 @@ if (!CRM.vars) CRM.vars = {};
               const response = data.submissionResponse && data.submissionResponse[0];
               let createdId;
               if (typeof response === 'object') {
+                let key = getApiParams().key || 'id';
                 // Loop through entities created by the afform (there should be only one)
                 Object.keys(response).forEach((entity) => {
                   if (Array.isArray(response[entity]) && response[entity][0] && response[entity][0][key]) {


### PR DESCRIPTION
Overview
----------------------------------------
Improves display-only fields in formBuilder to show more meaningful values.

See https://lab.civicrm.org/dev/core/-/issues/3779

Before
-------
A field with dropdown options (e.g. "Activity type") would show the numeric value (e.g. "2") instead of the label (e.g. "Meeting").

After
--------
Option labels are shown.

Comments
------
This includes the commit from #29092, without which the bug gets in the way of testing "Existing Contact" autocompletes.