### PR TITLE
Stop over-sharing - MailingJob::findPendingTasks

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -738,64 +738,6 @@ AND    record_type_id = $targetRecordID
   }
 
   /**
-   * Search the mailing-event queue for a list of pending delivery tasks.
-   *
-   * @param int $jobId
-   * @param string $medium
-   *   Ex: 'email' or 'sms'.
-   *
-   * @return \CRM_Mailing_Event_BAO_MailingEventQueue
-   *   A query object whose rows provide ('id', 'contact_id', 'hash') and ('email' or 'phone').
-   */
-  public static function findPendingTasks(int $jobId, string $medium): CRM_Mailing_Event_BAO_MailingEventQueue {
-    $eq = new CRM_Mailing_Event_BAO_MailingEventQueue();
-
-    $query = "  SELECT      queue.id,
-                                email.email as email,
-                                queue.contact_id,
-                                queue.hash,
-                                NULL as phone
-                    FROM        civicrm_mailing_event_queue queue
-                    INNER JOIN  civicrm_email email
-                            ON  queue.email_id = email.id
-                    INNER JOIN  civicrm_contact contact
-                            ON  contact.id = email.contact_id
-                    LEFT JOIN   civicrm_mailing_event_delivered delivered
-                            ON  queue.id = delivered.event_queue_id
-                    LEFT JOIN   civicrm_mailing_event_bounce bounce
-                            ON  queue.id = bounce.event_queue_id
-                    WHERE       queue.job_id = " . $jobId . "
-                        AND     delivered.id IS null
-                        AND     bounce.id IS null
-                        AND     contact.is_opt_out = 0";
-
-    if ($medium === 'sms') {
-      $query = "
-                    SELECT      queue.id,
-                                phone,
-                                queue.contact_id,
-                                queue.hash,
-                                NULL as email
-                    FROM        civicrm_mailing_event_queue queue
-                    INNER JOIN  civicrm_phone phone
-                            ON  queue.phone_id = phone.id
-                    INNER JOIN  civicrm_contact contact
-                            ON  contact.id = phone.contact_id
-                    LEFT JOIN   civicrm_mailing_event_delivered delivered
-                            ON  queue.id = delivered.event_queue_id
-                    LEFT JOIN   civicrm_mailing_event_bounce bounce
-                            ON  queue.id = bounce.event_queue_id
-                    WHERE       queue.job_id = " . $jobId . "
-                        AND     delivered.id IS null
-                        AND     bounce.id IS null
-                        AND    ( contact.is_opt_out = 0
-                        OR       contact.do_not_sms = 0 )";
-    }
-    $eq->query($query);
-    return $eq;
-  }
-
-  /**
    * Delete the mailing job.
    *
    * @param int $id

--- a/ext/flexmailer/src/Listener/DefaultBatcher.php
+++ b/ext/flexmailer/src/Listener/DefaultBatcher.php
@@ -38,13 +38,16 @@ class DefaultBatcher extends BaseListener {
     // make sure that there's no more than $mailerBatchLimit mails processed in a run
     $mailerBatchLimit = \CRM_Core_Config::singleton()->mailerBatchLimit;
 
-    $eq = \CRM_Mailing_BAO_MailingJob::findPendingTasks((int) $job->id, 'email');
+    $eq = $this->findPendingTasks((int) $job->id);
     $tasks = [];
     while ($eq->fetch()) {
       if ($mailerBatchLimit > 0 && \CRM_Mailing_BAO_MailingJob::$mailsProcessed >= $mailerBatchLimit) {
         if (!empty($tasks)) {
           $e->visit($tasks);
         }
+        // This ->free() is required because ->query() function is called not CRM_Core_ExecuteQuery
+        // (which cleans up it's own memory use)
+        // @todo - there is probably no reason not to just switch
         $eq->free();
         $e->setCompleted(FALSE);
         return;
@@ -57,6 +60,9 @@ class DefaultBatcher extends BaseListener {
       if (count($tasks) == \CRM_Mailing_BAO_MailingJob::MAX_CONTACTS_TO_PROCESS) {
         $isDelivered = $e->visit($tasks);
         if (!$isDelivered) {
+          // This ->free() is required because ->query() function is called not CRM_Core_ExecuteQuery
+          // (which cleans up it's own memory use)
+          // @todo - there is probably no reason not to just switch
           $eq->free();
           $e->setCompleted($isDelivered);
           return;
@@ -64,13 +70,49 @@ class DefaultBatcher extends BaseListener {
         $tasks = [];
       }
     }
-
+    // This ->free() is required because ->query() function is called not CRM_Core_ExecuteQuery
+    // (which cleans up it's own memory use)
+    // @todo - there is probably no reason not to just switch
     $eq->free();
 
     if (!empty($tasks)) {
       $isDelivered = $e->visit($tasks);
     }
     $e->setCompleted($isDelivered);
+  }
+
+  /**
+   * Search the mailing-event queue for a list of pending delivery tasks.
+   *
+   * @param int $jobId
+   *
+   * @return \CRM_Mailing_Event_BAO_MailingEventQueue
+   *   A query object whose rows provide ('id', 'contact_id', 'hash') and ('email' or 'phone').
+   */
+  private function findPendingTasks(int $jobId): \CRM_Mailing_Event_BAO_MailingEventQueue {
+    $eq = new \CRM_Mailing_Event_BAO_MailingEventQueue();
+
+    $query = "  SELECT      queue.id,
+                                email.email as email,
+                                queue.contact_id,
+                                queue.hash,
+                                NULL as phone
+                    FROM        civicrm_mailing_event_queue queue
+                    INNER JOIN  civicrm_email email
+                            ON  queue.email_id = email.id
+                    INNER JOIN  civicrm_contact contact
+                            ON  contact.id = email.contact_id
+                    LEFT JOIN   civicrm_mailing_event_delivered delivered
+                            ON  queue.id = delivered.event_queue_id
+                    LEFT JOIN   civicrm_mailing_event_bounce bounce
+                            ON  queue.id = bounce.event_queue_id
+                    WHERE       queue.job_id = " . $jobId . "
+                        AND     delivered.id IS null
+                        AND     bounce.id IS null
+                        AND     contact.is_opt_out = 0";
+    // note this `query` function leaks memory more than CRM_Core_DAO::ExecuteQuery()
+    $eq->query($query);
+    return $eq;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Stop over-sharing - MailingJob::findPendingTasks

Before
----------------------------------------
MailingJob::findPendingTasks called from 2 places & runs 2 totally different queries from those 2 places. The 2 lines they do share are lines which would ideally be converted to CRM_Core_DAO::executeQuery - but that is hard to do because the impacts on both places need to be considered. There are no other universe callers & this isn't the sort of function non-core users could reasonably expect to use in a supported way

After
----------------------------------------
Each function has it's own private copy of the function

Technical Details
----------------------------------------
The usage in the SMS class is probably leaking memory but I'm not trying to address that here

Comments
----------------------------------------