### PR TITLE
(REF) Flexmailer - Simplify service definitions

### DIFF
--- a/ext/flexmailer/flexmailer.php
+++ b/ext/flexmailer/flexmailer.php
@@ -48,3 +48,17 @@ function flexmailer_civicrm_container($container) {
   $container->addResource(new \Symfony\Component\Config\Resource\FileResource(__FILE__));
   \Civi\FlexMailer\Services::registerServices($container);
 }
+
+/**
+ * @see \CRM_Utils_Hook::scanClasses()
+ */
+function flexmailer_civicrm_scanClasses(array &$classes): void {
+  $prefix = 'Civi\\FlexMailer\\';
+  $dir = __DIR__ . '/src';
+  $delim = '\\';
+
+  foreach (\CRM_Utils_File::findFiles($dir, '*.php', TRUE) as $relFile) {
+    $relFile = str_replace(DIRECTORY_SEPARATOR, '/', $relFile);
+    $classes[] = $prefix . str_replace('/', $delim, substr($relFile, 0, -4));
+  }
+}

--- a/ext/flexmailer/src/ClickTracker/HtmlClickTracker.php
+++ b/ext/flexmailer/src/ClickTracker/HtmlClickTracker.php
@@ -10,7 +10,12 @@
  */
 namespace Civi\FlexMailer\ClickTracker;
 
-class HtmlClickTracker implements ClickTrackerInterface {
+use Civi\Core\Service\AutoService;
+
+/**
+ * @service civi_flexmailer_html_click_tracker
+ */
+class HtmlClickTracker extends AutoService implements ClickTrackerInterface {
 
   public function filterContent($msg, $mailing_id, $queue_id) {
     return self::replaceHrefUrls($msg,

--- a/ext/flexmailer/src/ClickTracker/TextClickTracker.php
+++ b/ext/flexmailer/src/ClickTracker/TextClickTracker.php
@@ -10,7 +10,12 @@
  */
 namespace Civi\FlexMailer\ClickTracker;
 
-class TextClickTracker implements ClickTrackerInterface {
+use Civi\Core\Service\AutoService;
+
+/**
+ * @service civi_flexmailer_text_click_tracker
+ */
+class TextClickTracker extends AutoService implements ClickTrackerInterface {
 
   public function filterContent($msg, $mailing_id, $queue_id) {
     return self::replaceTextUrls($msg,

--- a/ext/flexmailer/src/Listener/Abdicator.php
+++ b/ext/flexmailer/src/Listener/Abdicator.php
@@ -10,6 +10,7 @@
  */
 namespace Civi\FlexMailer\Listener;
 
+use Civi\Core\Service\AutoService;
 use Civi\FlexMailer\Event\RunEvent;
 
 /**
@@ -22,8 +23,12 @@ use Civi\FlexMailer\Event\RunEvent;
  *
  * During incubation, we want to mostly step-aside -- for traditional
  * mailings, simply continue using the old system.
+ *
+ * @service civi_flexmailer_abdicator
  */
-class Abdicator {
+class Abdicator extends AutoService {
+
+  use IsActiveTrait;
 
   /**
    * @param \CRM_Mailing_BAO_Mailing $mailing

--- a/ext/flexmailer/src/Listener/Attachments.php
+++ b/ext/flexmailer/src/Listener/Attachments.php
@@ -10,9 +10,15 @@
  */
 namespace Civi\FlexMailer\Listener;
 
+use Civi\Core\Service\AutoService;
 use Civi\FlexMailer\Event\ComposeBatchEvent;
 
-class Attachments extends BaseListener {
+/**
+ * @service civi_flexmailer_attachments
+ */
+class Attachments extends AutoService {
+
+  use IsActiveTrait;
 
   /**
    * Add any attachments.

--- a/ext/flexmailer/src/Listener/BasicHeaders.php
+++ b/ext/flexmailer/src/Listener/BasicHeaders.php
@@ -10,9 +10,15 @@
  */
 namespace Civi\FlexMailer\Listener;
 
+use Civi\Core\Service\AutoService;
 use Civi\FlexMailer\Event\ComposeBatchEvent;
 
-class BasicHeaders extends BaseListener {
+/**
+ * @service civi_flexmailer_basic_headers
+ */
+class BasicHeaders extends AutoService {
+
+  use IsActiveTrait;
 
   /**
    * Inject basic headers

--- a/ext/flexmailer/src/Listener/BounceTracker.php
+++ b/ext/flexmailer/src/Listener/BounceTracker.php
@@ -10,9 +10,15 @@
  */
 namespace Civi\FlexMailer\Listener;
 
+use Civi\Core\Service\AutoService;
 use Civi\FlexMailer\Event\ComposeBatchEvent;
 
-class BounceTracker extends BaseListener {
+/**
+ * @service civi_flexmailer_bounce_tracker
+ */
+class BounceTracker extends AutoService {
+
+  use IsActiveTrait;
 
   /**
    * Inject bounce-tracking codes.

--- a/ext/flexmailer/src/Listener/DefaultBatcher.php
+++ b/ext/flexmailer/src/Listener/DefaultBatcher.php
@@ -10,10 +10,16 @@
  */
 namespace Civi\FlexMailer\Listener;
 
+use Civi\Core\Service\AutoService;
 use Civi\FlexMailer\Event\WalkBatchesEvent;
 use Civi\FlexMailer\FlexMailerTask;
 
-class DefaultBatcher extends BaseListener {
+/**
+ * @service civi_flexmailer_default_batcher
+ */
+class DefaultBatcher extends AutoService {
+
+  use IsActiveTrait;
 
   /**
    * Given a MailingJob (`$e->getJob()`), enumerate the recipients as

--- a/ext/flexmailer/src/Listener/DefaultComposer.php
+++ b/ext/flexmailer/src/Listener/DefaultComposer.php
@@ -10,6 +10,7 @@
  */
 namespace Civi\FlexMailer\Listener;
 
+use Civi\Core\Service\AutoService;
 use Civi\FlexMailer\Event\ComposeBatchEvent;
 use Civi\FlexMailer\Event\RunEvent;
 use Civi\FlexMailer\FlexMailerTask;
@@ -22,8 +23,12 @@ use Civi\Token\TokenRow;
  *
  * The DefaultComposer uses a TokenProcessor to generate all messages as
  * a batch.
+ *
+ * @service civi_flexmailer_default_composer
  */
-class DefaultComposer extends BaseListener {
+class DefaultComposer extends AutoService {
+
+  use IsActiveTrait;
 
   public function onRun(RunEvent $e) {
     // FIXME: This probably doesn't belong here...

--- a/ext/flexmailer/src/Listener/DefaultSender.php
+++ b/ext/flexmailer/src/Listener/DefaultSender.php
@@ -10,9 +10,16 @@
  */
 namespace Civi\FlexMailer\Listener;
 
+use Civi\Core\Service\AutoService;
 use Civi\FlexMailer\Event\SendBatchEvent;
 
-class DefaultSender extends BaseListener {
+/**
+ * @service civi_flexmailer_default_sender
+ */
+class DefaultSender extends AutoService {
+
+  use IsActiveTrait;
+
   const BULK_MAIL_INSERT_COUNT = 10;
 
   public function onSend(SendBatchEvent $e) {

--- a/ext/flexmailer/src/Listener/HookAdapter.php
+++ b/ext/flexmailer/src/Listener/HookAdapter.php
@@ -10,9 +10,15 @@
  */
 namespace Civi\FlexMailer\Listener;
 
+use Civi\Core\Service\AutoService;
 use Civi\FlexMailer\Event\ComposeBatchEvent;
 
-class HookAdapter extends BaseListener {
+/**
+ * @service civi_flexmailer_hooks
+ */
+class HookAdapter extends AutoService {
+
+  use IsActiveTrait;
 
   /**
    * Expose to hook_civicrm_alterMailParams.

--- a/ext/flexmailer/src/Listener/IsActiveTrait.php
+++ b/ext/flexmailer/src/Listener/IsActiveTrait.php
@@ -10,12 +10,27 @@
  */
 namespace Civi\FlexMailer\Listener;
 
-/**
- * @deprecated
- *   As of Feb 2024, still used by Mosaico releases. Need at least a year to phase-out.
- */
-class BaseListener {
+trait IsActiveTrait {
 
-  use IsActiveTrait;
+  /**
+   * @var bool
+   */
+  private $active = TRUE;
+
+  /**
+   * @return bool
+   */
+  public function isActive() {
+    return $this->active;
+  }
+
+  /**
+   * @param bool $active
+   * @return $this
+   */
+  public function setActive($active) {
+    $this->active = $active;
+    return $this;
+  }
 
 }

--- a/ext/flexmailer/src/Listener/OpenTracker.php
+++ b/ext/flexmailer/src/Listener/OpenTracker.php
@@ -10,9 +10,15 @@
  */
 namespace Civi\FlexMailer\Listener;
 
+use Civi\Core\Service\AutoService;
 use Civi\FlexMailer\Event\ComposeBatchEvent;
 
-class OpenTracker extends BaseListener {
+/**
+ * @service civi_flexmailer_open_tracker
+ */
+class OpenTracker extends AutoService {
+
+  use IsActiveTrait;
 
   /**
    * Inject open-tracking codes.

--- a/ext/flexmailer/src/Listener/RequiredFields.php
+++ b/ext/flexmailer/src/Listener/RequiredFields.php
@@ -10,6 +10,7 @@
  */
 namespace Civi\FlexMailer\Listener;
 
+use Civi\Core\Service\AutoService;
 use CRM_Flexmailer_ExtensionUtil as E;
 use Civi\FlexMailer\Event\CheckSendableEvent;
 
@@ -19,7 +20,22 @@ use Civi\FlexMailer\Event\CheckSendableEvent;
  *
  * The RequiredFields listener checks that all mandatory fields have a value.
  */
-class RequiredFields extends BaseListener {
+class RequiredFields extends AutoService {
+
+  use IsActiveTrait;
+
+  /**
+   * @service civi_flexmailer_required_fields
+   */
+  public static function factory(): RequiredFields {
+    return new static([
+      'subject',
+      'name',
+      'from_name',
+      'from_email',
+      '(body_html|body_text)',
+    ]);
+  }
 
   /**
    * @var array

--- a/ext/flexmailer/src/Listener/RequiredTokens.php
+++ b/ext/flexmailer/src/Listener/RequiredTokens.php
@@ -10,6 +10,7 @@
  */
 namespace Civi\FlexMailer\Listener;
 
+use Civi\Core\Service\AutoService;
 use CRM_Flexmailer_ExtensionUtil as E;
 use Civi\FlexMailer\Event\CheckSendableEvent;
 
@@ -21,7 +22,27 @@ use Civi\FlexMailer\Event\CheckSendableEvent;
  * CiviMail tokens like `{action.unsubscribeUrl}`, which are often required
  * to comply with anti-spam regulations.
  */
-class RequiredTokens extends BaseListener {
+class RequiredTokens extends AutoService {
+
+  use IsActiveTrait;
+
+  /**
+   * @service civi_flexmailer_required_tokens
+   */
+  public static function factory(): RequiredTokens {
+    return new static(
+      ['traditional'],
+      [
+        'domain.address' => ts("Domain address - displays your organization's postal address."),
+        'action.optOutUrl or action.unsubscribeUrl' => [
+          'action.optOut' => ts("'Opt out via email' - displays an email address for recipients to opt out of receiving emails from your organization."),
+          'action.optOutUrl' => ts("'Opt out via web page' - creates a link for recipients to click if they want to opt out of receiving emails from your organization. Alternatively, you can include the 'Opt out via email' token."),
+          'action.unsubscribe' => ts("'Unsubscribe via email' - displays an email address for recipients to unsubscribe from the specific mailing list used to send this message."),
+          'action.unsubscribeUrl' => ts("'Unsubscribe via web page' - creates a link for recipients to unsubscribe from the specific mailing list used to send this message. Alternatively, you can include the 'Unsubscribe via email' token or one of the Opt-out tokens."),
+        ],
+      ]
+    );
+  }
 
   /**
    * @var array

--- a/ext/flexmailer/src/Listener/TestPrefix.php
+++ b/ext/flexmailer/src/Listener/TestPrefix.php
@@ -10,9 +10,15 @@
  */
 namespace Civi\FlexMailer\Listener;
 
+use Civi\Core\Service\AutoService;
 use Civi\FlexMailer\Event\ComposeBatchEvent;
 
-class TestPrefix extends BaseListener {
+/**
+ * @service civi_flexmailer_test_prefix
+ */
+class TestPrefix extends AutoService {
+
+  use IsActiveTrait;
 
   /**
    * For any test mailings, the "Subject:" should have a prefix.

--- a/ext/flexmailer/src/Listener/ToHeader.php
+++ b/ext/flexmailer/src/Listener/ToHeader.php
@@ -10,9 +10,15 @@
  */
 namespace Civi\FlexMailer\Listener;
 
+use Civi\Core\Service\AutoService;
 use Civi\FlexMailer\Event\ComposeBatchEvent;
 
-class ToHeader extends BaseListener {
+/**
+ * @service civi_flexmailer_to_header
+ */
+class ToHeader extends AutoService {
+
+  use IsActiveTrait;
 
   /**
    * Inject the "To:" header.

--- a/ext/flexmailer/src/Services.php
+++ b/ext/flexmailer/src/Services.php
@@ -51,12 +51,6 @@ class Services {
       ],
     ]))->setPublic(TRUE);
 
-    $container->setDefinition('civi_flexmailer_abdicator', new Definition('Civi\FlexMailer\Listener\Abdicator'))->setPublic(TRUE);
-    $container->setDefinition('civi_flexmailer_default_batcher', new Definition('Civi\FlexMailer\Listener\DefaultBatcher'))->setPublic(TRUE);
-    $container->setDefinition('civi_flexmailer_default_composer', new Definition('Civi\FlexMailer\Listener\DefaultComposer'))->setPublic(TRUE);
-    $container->setDefinition('civi_flexmailer_open_tracker', new Definition('Civi\FlexMailer\Listener\OpenTracker'))->setPublic(TRUE);
-    $container->setDefinition('civi_flexmailer_basic_headers', new Definition('Civi\FlexMailer\Listener\BasicHeaders'))->setPublic(TRUE);
-    $container->setDefinition('civi_flexmailer_to_header', new Definition('Civi\FlexMailer\Listener\ToHeader'))->setPublic(TRUE);
     $container->setDefinition('civi_flexmailer_attachments', new Definition('Civi\FlexMailer\Listener\Attachments'))->setPublic(TRUE);
     $container->setDefinition('civi_flexmailer_bounce_tracker', new Definition('Civi\FlexMailer\Listener\BounceTracker'))->setPublic(TRUE);
     $container->setDefinition('civi_flexmailer_default_sender', new Definition('Civi\FlexMailer\Listener\DefaultSender'))->setPublic(TRUE);

--- a/ext/flexmailer/src/Services.php
+++ b/ext/flexmailer/src/Services.php
@@ -29,28 +29,6 @@ class Services {
     $apiOverrides = $container->setDefinition('civi_flexmailer_api_overrides', new Definition('Civi\API\Provider\ProviderInterface'))->setPublic(TRUE);
     self::applyStaticFactory($apiOverrides, __CLASS__, 'createApiOverrides');
 
-    $container->setDefinition('civi_flexmailer_required_fields', new Definition('Civi\FlexMailer\Listener\RequiredFields', [
-      [
-        'subject',
-        'name',
-        'from_name',
-        'from_email',
-        '(body_html|body_text)',
-      ],
-    ]))->setPublic(TRUE);
-    $container->setDefinition('civi_flexmailer_required_tokens', new Definition('Civi\FlexMailer\Listener\RequiredTokens', [
-      ['traditional'],
-      [
-        'domain.address' => ts("Domain address - displays your organization's postal address."),
-        'action.optOutUrl or action.unsubscribeUrl' => [
-          'action.optOut' => ts("'Opt out via email' - displays an email address for recipients to opt out of receiving emails from your organization."),
-          'action.optOutUrl' => ts("'Opt out via web page' - creates a link for recipients to click if they want to opt out of receiving emails from your organization. Alternatively, you can include the 'Opt out via email' token."),
-          'action.unsubscribe' => ts("'Unsubscribe via email' - displays an email address for recipients to unsubscribe from the specific mailing list used to send this message."),
-          'action.unsubscribeUrl' => ts("'Unsubscribe via web page' - creates a link for recipients to unsubscribe from the specific mailing list used to send this message. Alternatively, you can include the 'Unsubscribe via email' token or one of the Opt-out tokens."),
-        ],
-      ],
-    ]))->setPublic(TRUE);
-
     foreach (self::getListenerSpecs() as $listenerSpec) {
       $container->findDefinition('dispatcher')->addMethodCall('addListenerService', $listenerSpec);
     }

--- a/ext/flexmailer/src/Services.php
+++ b/ext/flexmailer/src/Services.php
@@ -51,12 +51,6 @@ class Services {
       ],
     ]))->setPublic(TRUE);
 
-    $container->setDefinition('civi_flexmailer_attachments', new Definition('Civi\FlexMailer\Listener\Attachments'))->setPublic(TRUE);
-    $container->setDefinition('civi_flexmailer_bounce_tracker', new Definition('Civi\FlexMailer\Listener\BounceTracker'))->setPublic(TRUE);
-    $container->setDefinition('civi_flexmailer_default_sender', new Definition('Civi\FlexMailer\Listener\DefaultSender'))->setPublic(TRUE);
-    $container->setDefinition('civi_flexmailer_hooks', new Definition('Civi\FlexMailer\Listener\HookAdapter'))->setPublic(TRUE);
-    $container->setDefinition('civi_flexmailer_test_prefix', new Definition('Civi\FlexMailer\Listener\TestPrefix'))->setPublic(TRUE);
-
     $container->setDefinition('civi_flexmailer_html_click_tracker', new Definition('Civi\FlexMailer\ClickTracker\HtmlClickTracker'))->setPublic(TRUE);
     $container->setDefinition('civi_flexmailer_text_click_tracker', new Definition('Civi\FlexMailer\ClickTracker\TextClickTracker'))->setPublic(TRUE);
 

--- a/ext/flexmailer/src/Services.php
+++ b/ext/flexmailer/src/Services.php
@@ -51,9 +51,6 @@ class Services {
       ],
     ]))->setPublic(TRUE);
 
-    $container->setDefinition('civi_flexmailer_html_click_tracker', new Definition('Civi\FlexMailer\ClickTracker\HtmlClickTracker'))->setPublic(TRUE);
-    $container->setDefinition('civi_flexmailer_text_click_tracker', new Definition('Civi\FlexMailer\ClickTracker\TextClickTracker'))->setPublic(TRUE);
-
     foreach (self::getListenerSpecs() as $listenerSpec) {
       $container->findDefinition('dispatcher')->addMethodCall('addListenerService', $listenerSpec);
     }


### PR DESCRIPTION
Overview
----------------------------------------

This is a small code cleanup for services in `ext/flexmailer`.

Before
----------------------------------------

* Use `hook_container` (by way of `Civi\FlexMailer\Services.php`) to explicitly declare a bunch of `Definition`s.

After
----------------------------------------

* Use `@service`  and `AutoService`

Comments
----------------------------------------

FlexMailer predates `AutoService` and had its own base-class (`BaseListener`) used by several services. You might think it nice to update `BaseListener` to incorporate `AutoService` or `AutoServiceTrait`. However, this would break interop for extensions (like `mosaico`) which use `BaseListener` in the old (preAutoService) way. Coordinating conversions across repos/subprojects is annoying. So instead, this leaves `BaseListener` for interop; deprecates it; and switches to vanilla `AutoService`. For continuity, it also mixes-in `IsActiveTrait`.

(tldr: `BaseListener` => `AutoService`+`IsActiveTrait`)