### PR TITLE
Remove unused implied_permissions declaration

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1795,7 +1795,6 @@ class CRM_Core_Permission {
   protected static function getCoreAndComponentPermissions(bool $all): array {
     $permissions = self::getCorePermissions();
     $permissions = array_merge($permissions, self::getComponentPermissions($all));
-    $permissions['all CiviCRM permissions and ACLs']['implied_permissions'] = array_keys($permissions);
     return $permissions;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Checking to see if this passes tests.

Technical Details
----------------------------------------
This appears to be handled elsewhere in the `getImpliedPermissionsFor()` function.