### PR TITLE
Remove unused extra param in getAllModulePermissions

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -590,7 +590,7 @@ class CRM_Core_Permission {
     $permissions = self::getCoreAndComponentPermissions($all);
 
     // Add any permissions defined in hook_civicrm_permission implementations.
-    $module_permissions = CRM_Core_Config::singleton()->userPermissionClass->getAllModulePermissions(TRUE);
+    $module_permissions = CRM_Core_Config::singleton()->userPermissionClass->getAllModulePermissions();
     $permissions = array_merge($permissions, $module_permissions);
     if (!$descriptions) {
       foreach ($permissions as $name => $attr) {

--- a/CRM/Core/Permission/Base.php
+++ b/CRM/Core/Permission/Base.php
@@ -390,25 +390,15 @@ class CRM_Core_Permission_Base {
    * Get the permissions defined in the hook_civicrm_permission implementation
    * in all enabled CiviCRM module extensions.
    *
-   * @param bool $descriptions
-   *
    * @return array
    *   Array of permissions, in the same format as CRM_Core_Permission::getCorePermissions().
    */
-  public function getAllModulePermissions($descriptions = FALSE): array {
+  public function getAllModulePermissions(): array {
     $permissions = [];
     CRM_Utils_Hook::permission($permissions);
 
-    if ($descriptions) {
-      foreach ($permissions as $permission => $label) {
-        $permissions[$permission] = (is_array($label)) ? $label : [$label];
-      }
-    }
-    else {
-      // Passing in false here is to be deprecated.
-      foreach ($permissions as $permission => $label) {
-        $permissions[$permission] = (is_array($label)) ? array_shift($label) : $label;
-      }
+    foreach ($permissions as $permission => $label) {
+      $permissions[$permission] = (is_array($label)) ? $label : [$label];
     }
     return $permissions;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused deprecated function param in the permissions class.

Technical Details
----------------------------------------
This function is only called in one place and always with the same param.