### PR TITLE
Remove guts of civicrm Mailing.preview

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1305,6 +1305,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
    * @param CRM_Mailing_BAO_Mailing $mailing
    */
   public static function tokenReplace(&$mailing) {
+    CRM_Core_Error::deprecatedWarning('function no longer called, use flexmailer');
     $domain = CRM_Core_BAO_Domain::getDomain();
 
     foreach (['text', 'html'] as $type) {
@@ -2475,7 +2476,7 @@ LEFT JOIN civicrm_mailing_group g ON g.mailing_id   = m.id
    */
   public function getReturnProperties() {
     $tokens = &$this->getTokens();
-
+    CRM_Core_Error::deprecatedWarning('function no longer called - use flexmailer');
     $properties = [];
     if (isset($tokens['html']) &&
       isset($tokens['html']['contact'])

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1183,6 +1183,7 @@ class CRM_Utils_Token {
                                            $className = NULL,
                                            $jobID = NULL) {
     $details = [0 => []];
+    CRM_Core_Error::deprecatedFunctionWarning('function no longer used - see flexmailer');
     // also call a hook and get token details
     CRM_Utils_Hook::tokenValues($details[0],
       $contactIDs,

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -501,60 +501,10 @@ function civicrm_api3_mailing_event_open($params) {
  * @param array $params
  *   Array per getfields metadata.
  *
- * @return array
  * @throws \CRM_Core_Exception
  */
 function civicrm_api3_mailing_preview($params) {
-  $fromEmail = NULL;
-  if (!empty($params['from_email'])) {
-    $fromEmail = $params['from_email'];
-  }
-
-  $mailing = new CRM_Mailing_BAO_Mailing();
-  $mailingID = $params['id'] ?? NULL;
-  if ($mailingID) {
-    $mailing->id = $mailingID;
-    $mailing->find(TRUE);
-  }
-  else {
-    $mailing->copyValues($params);
-  }
-
-  $session = CRM_Core_Session::singleton();
-
-  CRM_Mailing_BAO_Mailing::tokenReplace($mailing);
-
-  // get and format attachments
-  $attachments = CRM_Core_BAO_File::getEntityFile('civicrm_mailing', $mailing->id);
-
-  $returnProperties = $mailing->getReturnProperties();
-  $contactID = $params['contact_id'] ?? NULL;
-  if (!$contactID) {
-    // If we still don't have a userID in a session because we are annon then set contactID to be 0
-    $contactID = empty($session->get('userID')) ? 0 : $session->get('userID');
-  }
-  $mailingParams = ['contact_id' => $contactID];
-
-  if (!$contactID) {
-    $details = CRM_Utils_Token::getAnonymousTokenDetails($mailingParams, $returnProperties, empty($mailing->sms_provider_id), TRUE, NULL, $mailing->getFlattenedTokens());
-    $details = $details[0][0] ?? NULL;
-  }
-  else {
-    [$details] = CRM_Utils_Token::getTokenDetails($mailingParams, $returnProperties, empty($mailing->sms_provider_id), TRUE, NULL, $mailing->getFlattenedTokens());
-    $details = $details[$contactID];
-  }
-
-  $mime = $mailing->compose(NULL, NULL, NULL, $contactID, $fromEmail, $fromEmail,
-    TRUE, $details, $attachments
-  );
-
-  return civicrm_api3_create_success([
-    'id' => $mailingID,
-    'contact_id' => $contactID,
-    'subject' => CRM_Utils_Array::value('Subject', $mime->headers(), ''),
-    'body_html' => $mime->getHTMLBody(),
-    'body_text' => $mime->getTXTBody(),
-  ]);
+  throw new CRM_Core_Exception('This is never called because flexmailer intercepts it');
 }
 
 /**

--- a/ext/flexmailer/src/API/MailingPreview.php
+++ b/ext/flexmailer/src/API/MailingPreview.php
@@ -3,7 +3,6 @@ namespace Civi\FlexMailer\API;
 
 use Civi\FlexMailer\FlexMailer;
 use Civi\FlexMailer\FlexMailerTask;
-use Civi\FlexMailer\Listener\Abdicator;
 
 class MailingPreview {
 
@@ -31,11 +30,6 @@ class MailingPreview {
     }
     else {
       $mailing->copyValues($params);
-    }
-
-    if (!Abdicator::isFlexmailPreferred($mailing) && empty($mailing->sms_provider_id)) {
-      require_once 'api/v3/Mailing.php';
-      return civicrm_api3_mailing_preview($params);
     }
 
     $contactID = \CRM_Utils_Array::value('contact_id', $params,


### PR DESCRIPTION
Overview
----------------------------------------
Remove guts of civicrm Mailing.preview

Before
----------------------------------------
`civicrm_api3_mailing_preview` is complex but unreachable

After
----------------------------------------
It is simple but unreachable

Technical Details
----------------------------------------
`flexmailer` interupts the api call. so the code in the api function is only called if flexmailer chooses to

Since 2022 flexmailer has not chose to as this statement has always returned FALSE 
```
if (!Abdicator::isFlexmailPreferred($mailing) && empty($mailing->sms_provider_id)) {
```

because it is effectively 

```
if (!empty($mailing->sms_provider_id) && empty($mailing->sms_provider_id)) {
```

Comments
----------------------------------------
I discovered this testing an SMS & realising it is never called. In addition to the 50 or so lines of code removed in this PR there are some hundreds of lines of code in functions it calls which are never reached as this is unreachable. Some of those are marked deprecated in this PR
