### PR TITLE
REF - Normalize internal format of permissions

### DIFF
--- a/CRM/Campaign/Info.php
+++ b/CRM/Campaign/Info.php
@@ -41,13 +41,8 @@ class CRM_Campaign_Info extends CRM_Core_Component_Info {
 
   /**
    * @inheritDoc
-   * @param bool $getAllUnconditionally
-   * @param bool $descriptions
-   *   Whether to return permission descriptions
-   *
-   * @return array
    */
-  public function getPermissions($getAllUnconditionally = FALSE, $descriptions = FALSE) {
+  public function getPermissions(): array {
     $permissions = [
       'administer CiviCampaign' => [
         'label' => ts('administer CiviCampaign'),
@@ -77,13 +72,6 @@ class CRM_Campaign_Info extends CRM_Core_Component_Info {
         'label' => ts('sign CiviCRM Petition'),
       ],
     ];
-
-    if (!$descriptions) {
-      foreach ($permissions as $name => $attr) {
-        $permissions[$name] = array_shift($attr);
-      }
-    }
-
     return $permissions;
   }
 

--- a/CRM/Case/Info.php
+++ b/CRM/Case/Info.php
@@ -42,13 +42,8 @@ class CRM_Case_Info extends CRM_Core_Component_Info {
 
   /**
    * @inheritDoc
-   * @param bool $getAllUnconditionally
-   * @param bool $descriptions
-   *   Whether to return permission descriptions
-   *
-   * @return array
    */
-  public function getPermissions($getAllUnconditionally = FALSE, $descriptions = FALSE) {
+  public function getPermissions(): array {
     $permissions = [
       'delete in CiviCase' => [
         'label' => ts('delete in CiviCase'),
@@ -71,13 +66,6 @@ class CRM_Case_Info extends CRM_Core_Component_Info {
         'description' => ts('Open a new case'),
       ],
     ];
-
-    if (!$descriptions) {
-      foreach ($permissions as $name => $attr) {
-        $permissions[$name] = array_shift($attr);
-      }
-    }
-
     return $permissions;
   }
 

--- a/CRM/Contribute/Info.php
+++ b/CRM/Contribute/Info.php
@@ -51,21 +51,8 @@ class CRM_Contribute_Info extends CRM_Core_Component_Info {
 
   /**
    * @inheritDoc
-   * Provides permissions that are used by component.
-   * Needs to be implemented in component's information
-   * class.
-   *
-   * NOTE: if using conditionally permission return,
-   * implementation of $getAllUnconditionally is required.
-   *
-   * @param bool $getAllUnconditionally
-   * @param bool $descriptions
-   *   Whether to return permission descriptions
-   *
-   * @return array|null
-   *   collection of permissions, null if none
    */
-  public function getPermissions($getAllUnconditionally = FALSE, $descriptions = FALSE) {
+  public function getPermissions(): array {
     $permissions = [
       'access CiviContribute' => [
         'label' => ts('access CiviContribute'),
@@ -83,13 +70,6 @@ class CRM_Contribute_Info extends CRM_Core_Component_Info {
         'description' => ts('Delete contributions'),
       ],
     ];
-
-    if (!$descriptions) {
-      foreach ($permissions as $name => $attr) {
-        $permissions[$name] = array_shift($attr);
-      }
-    }
-
     return $permissions;
   }
 

--- a/CRM/Core/Component/Info.php
+++ b/CRM/Core/Component/Info.php
@@ -140,19 +140,11 @@ abstract class CRM_Core_Component_Info {
   }
 
   /**
-   * Provides permissions that are used by component.
-   * Needs to be implemented in component's information
-   * class.
+   * Defines permissions that are used by component.
    *
-   * NOTE: if using conditionally permission return,
-   * implementation of $getAllUnconditionally is required.
-   *
-   * @param bool $getAllUnconditionally
-   *
-   * @return array|null
-   *   collection of permissions, null if none
+   * @return array
    */
-  abstract public function getPermissions($getAllUnconditionally = FALSE);
+  abstract public function getPermissions();
 
   /**
    * Determine how many other records refer to a given record.

--- a/CRM/Core/Permission/Base.php
+++ b/CRM/Core/Permission/Base.php
@@ -402,6 +402,9 @@ class CRM_Core_Permission_Base {
     // Convert them all to associative arrays.
     foreach ($permissions as $name => $defn) {
       $defn = (array) $defn;
+      if (!isset($defn['label'])) {
+        CRM_Core_Error::deprecatedWarning("Permission '$name' should be declared with 'label' and 'description' keys. See https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/");
+      }
       $permission = [
         'label' => $defn['label'] ?? $defn[0],
         'description' => $defn['description'] ?? $defn[1] ?? NULL,

--- a/CRM/Core/Permission/Base.php
+++ b/CRM/Core/Permission/Base.php
@@ -397,8 +397,17 @@ class CRM_Core_Permission_Base {
     $permissions = [];
     CRM_Utils_Hook::permission($permissions);
 
-    foreach ($permissions as $permission => $label) {
-      $permissions[$permission] = (is_array($label)) ? $label : [$label];
+    // Normalize permission array format.
+    // Historically, a string was acceptable (interpreted as label), as was a non-associative array.
+    // Convert them all to associative arrays.
+    foreach ($permissions as $name => $defn) {
+      $defn = (array) $defn;
+      $permission = [
+        'label' => $defn['label'] ?? $defn[0],
+        'description' => $defn['description'] ?? $defn[1] ?? NULL,
+        'disabled' => $defn['disabled'] ?? NULL,
+      ];
+      $permissions[$name] = array_filter($permission, fn($item) => isset($item));
     }
     return $permissions;
   }

--- a/CRM/Core/Permission/List.php
+++ b/CRM/Core/Permission/List.php
@@ -31,14 +31,13 @@ class CRM_Core_Permission_List {
    * @see \CRM_Utils_Hook::permissionList
    */
   public static function findCiviPermissions(GenericHookEvent $e) {
-    $activeCorePerms = \CRM_Core_Permission::basicPermissions(FALSE);
     $allCorePerms = \CRM_Core_Permission::basicPermissions(TRUE, TRUE);
     foreach ($allCorePerms as $permName => $corePerm) {
       $e->permissions[$permName] = [
         'group' => 'civicrm',
-        'title' => $corePerm['label'] ?? $corePerm[0] ?? $permName,
-        'description' => $corePerm['description'] ?? $corePerm[1] ?? NULL,
-        'is_active' => isset($activeCorePerms[$permName]),
+        'title' => $corePerm['label'],
+        'description' => $corePerm['description'] ?? NULL,
+        'is_active' => empty($corePerm['disabled']),
       ];
     }
   }

--- a/CRM/Event/Info.php
+++ b/CRM/Event/Info.php
@@ -41,13 +41,8 @@ class CRM_Event_Info extends CRM_Core_Component_Info {
 
   /**
    * @inheritDoc
-   * @param bool $getAllUnconditionally
-   * @param bool $descriptions
-   *   Whether to return permission descriptions
-   *
-   * @return array
    */
-  public function getPermissions($getAllUnconditionally = FALSE, $descriptions = FALSE) {
+  public function getPermissions(): array {
     $permissions = [
       'access CiviEvent' => [
         'label' => ts('access CiviEvent'),
@@ -81,13 +76,6 @@ class CRM_Event_Info extends CRM_Core_Component_Info {
         'description' => ts('Allow users to create, edit and copy event-related profile forms used for online event registration.'),
       ],
     ];
-
-    if (!$descriptions) {
-      foreach ($permissions as $name => $attr) {
-        $permissions[$name] = array_shift($attr);
-      }
-    }
-
     return $permissions;
   }
 

--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -139,13 +139,8 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
 
   /**
    * @inheritDoc
-   * @param bool $getAllUnconditionally
-   * @param bool $descriptions
-   *   Whether to return permission descriptions
-   *
-   * @return array
    */
-  public function getPermissions($getAllUnconditionally = FALSE, $descriptions = FALSE) {
+  public function getPermissions(): array {
     $permissions = [
       'access CiviMail' => [
         'label' => ts('access CiviMail'),
@@ -162,25 +157,19 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
         'label' => ts('view public CiviMail content'),
       ],
     ];
-
-    if (self::workflowEnabled() || $getAllUnconditionally) {
-      $permissions['create mailings'] = [
-        'label' => ts('create mailings'),
-      ];
-      $permissions['schedule mailings'] = [
-        'label' => ts('schedule mailings'),
-      ];
-      $permissions['approve mailings'] = [
-        'label' => ts('approve mailings'),
-      ];
-    }
-
-    if (!$descriptions) {
-      foreach ($permissions as $name => $attr) {
-        $permissions[$name] = array_shift($attr);
-      }
-    }
-
+    // Workflow permissions
+    $permissions['create mailings'] = [
+      'label' => ts('create mailings'),
+      'disabled' => !self::workflowEnabled(),
+    ];
+    $permissions['schedule mailings'] = [
+      'label' => ts('schedule mailings'),
+      'disabled' => !self::workflowEnabled(),
+    ];
+    $permissions['approve mailings'] = [
+      'label' => ts('approve mailings'),
+      'disabled' => !self::workflowEnabled(),
+    ];
     return $permissions;
   }
 

--- a/CRM/Member/Info.php
+++ b/CRM/Member/Info.php
@@ -50,21 +50,8 @@ class CRM_Member_Info extends CRM_Core_Component_Info {
 
   /**
    * @inheritDoc
-   * Provides permissions that are used by component.
-   * Needs to be implemented in component's information
-   * class.
-   *
-   * NOTE: if using conditionally permission return,
-   * implementation of $getAllUnconditionally is required.
-   *
-   * @param bool $getAllUnconditionally
-   * @param bool $descriptions
-   *   Whether to return permission descriptions
-   *
-   * @return array|null
-   *   collection of permissions, null if none
    */
-  public function getPermissions($getAllUnconditionally = FALSE, $descriptions = FALSE) {
+  public function getPermissions(): array {
     $permissions = [
       'access CiviMember' => [
         'label' => ts('access CiviMember'),
@@ -79,13 +66,6 @@ class CRM_Member_Info extends CRM_Core_Component_Info {
         'description' => ts('Delete memberships'),
       ],
     ];
-
-    if (!$descriptions) {
-      foreach ($permissions as $name => $attr) {
-        $permissions[$name] = array_shift($attr);
-      }
-    }
-
     return $permissions;
   }
 

--- a/CRM/Pledge/Info.php
+++ b/CRM/Pledge/Info.php
@@ -45,21 +45,8 @@ class CRM_Pledge_Info extends CRM_Core_Component_Info {
 
   /**
    * @inheritDoc
-   * Provides permissions that are used by component.
-   * Needs to be implemented in component's information
-   * class.
-   *
-   * NOTE: if using conditionally permission return,
-   * implementation of $getAllUnconditionally is required.
-   *
-   * @param bool $getAllUnconditionally
-   * @param bool $descriptions
-   *   Whether to return permission descriptions
-   *
-   * @return array|null
-   *   collection of permissions, null if none
    */
-  public function getPermissions($getAllUnconditionally = FALSE, $descriptions = FALSE) {
+  public function getPermissions(): array {
     $permissions = [
       'access CiviPledge' => [
         'label' => ts('access CiviPledge'),
@@ -74,13 +61,6 @@ class CRM_Pledge_Info extends CRM_Core_Component_Info {
         'description' => ts('Delete pledges'),
       ],
     ];
-
-    if (!$descriptions) {
-      foreach ($permissions as $name => $attr) {
-        $permissions[$name] = array_shift($attr);
-      }
-    }
-
     return $permissions;
   }
 

--- a/CRM/Report/Info.php
+++ b/CRM/Report/Info.php
@@ -45,21 +45,8 @@ class CRM_Report_Info extends CRM_Core_Component_Info {
 
   /**
    * @inheritDoc
-   * Provides permissions that are used by component.
-   * Needs to be implemented in component's information
-   * class.
-   *
-   * NOTE: if using conditionally permission return,
-   * implementation of $getAllUnconditionally is required.
-   *
-   * @param bool $getAllUnconditionally
-   * @param bool $descriptions
-   *   Whether to return permission descriptions
-   *
-   * @return array|null
-   *   collection of permissions, null if none
    */
-  public function getPermissions($getAllUnconditionally = FALSE, $descriptions = FALSE) {
+  public function getPermissions(): array {
     $permissions = [
       'access CiviReport' => [
         'label' => ts('access CiviReport'),
@@ -90,13 +77,6 @@ class CRM_Report_Info extends CRM_Core_Component_Info {
         'description' => ts('View sql used in CiviReports'),
       ],
     ];
-
-    if (!$descriptions) {
-      foreach ($permissions as $name => $attr) {
-        $permissions[$name] = array_shift($attr);
-      }
-    }
-
     return $permissions;
   }
 

--- a/mixin/setting-admin@1/mixin.php
+++ b/mixin/setting-admin@1/mixin.php
@@ -157,7 +157,10 @@ return function ($mixInfo, $bootCache) {
     $about = About::instance($mixInfo);
     $perm = 'administer ' . $mixInfo->shortName;
     if (!isset($permissions[$perm])) {
-      $permissions[$perm] = ts('%1: Administer settings', [1 => $about->getLabel()]);
+      $permissions[$perm] = [
+        'label' => ts('%1: Administer settings', [1 => $about->getLabel()]),
+        'description' => ts('Edit configuration settings for the %1 extension', [1 => $about->getLabel()]),
+      ];
     }
   }, -1000);
 


### PR DESCRIPTION
Overview
----------------------------------------
**Note for extension authors:** Switching your extension's [hook_civicrm_permissions](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/) to return the preferred format (with 'label' & 'description' array keys) will avoid deprecation notices added by this PR. It is safe to make that change without requiring the latest version of CiviCRM, as the preferred format is supported for every 5.x.x. version.

Historically, there have been 3 formats for defining a permission. This consolidates the format internally, while maintaining backward-support for the other two.
Includes a documentation update: https://lab.civicrm.org/documentation/docs/dev/-/merge_requests/1148

Before
----------------------------------------
Permissions added via hook might be in associative or non-associative array format, or they might be a plain string.

After
----------------------------------------
Internally they are now always associative regardless of how they are passed in from `hook_civicrm_permission()`.
Deprecation notice issued for extensions that pass them in the old ways.

Technical Details
----------------------------------------
Deprecation notice added to alert extension devs to update the format.

This also improves efficiency by only calling the hook once, and improves memory use by caching the array once.
