### PR TITLE
Permissions - Make implied permissions declarative

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -128,8 +128,7 @@ class CRM_Core_Permission {
       }
       else {
         // This is an individual permission
-        $impliedPermissions = self::getImpliedPermissionsFor($permission);
-        $impliedPermissions[] = $permission;
+        $impliedPermissions = self::getImpliedBy($permission);
         foreach ($impliedPermissions as $permissionOption) {
           $granted = CRM_Core_Config::singleton()->userPermissionClass->check($permissionOption, $userId);
           // Call the permission_check hook to permit dynamic escalation (CRM-19256)
@@ -566,9 +565,10 @@ class CRM_Core_Permission {
    * @param bool $includeDisabled
    *   Include permissions from disabled components/settings.
    * @param bool $returnAssociative
-   *   Whether to return full info including description, or just label.
+   *   If true, returns arrays with keys: [label, description, disabled, implies, implied_by].
+   *   If false, returns strings (label only).
    *
-   * @return array
+   * @return array[]|string[]
    */
   public static function basicPermissions($includeDisabled = FALSE, $returnAssociative = FALSE): array {
     $permissions = Civi::$statics[__CLASS__][__FUNCTION__] ??= self::assembleBasicPermissions();
@@ -588,7 +588,33 @@ class CRM_Core_Permission {
   protected static function assembleBasicPermissions(): array {
     $permissions = self::getCoreAndComponentPermissions();
     $module_permissions = CRM_Core_Config::singleton()->userPermissionClass->getAllModulePermissions();
-    return array_merge($permissions, $module_permissions);
+    $allPermissions = array_merge($permissions, $module_permissions);
+    // Propagate implied permissions to their children
+    foreach ($allPermissions as $name => $permission) {
+      if (!empty($permission['implies'])) {
+        self::setImpliedBy([$name], $permission['implies'], $allPermissions);
+      }
+    }
+    return $allPermissions;
+  }
+
+  /**
+   * Recursively sets the 'implied_by' value for every sub-permission,
+   * based on the 'implies' declaration in meta-permissions.
+   *
+   * @param array $metaPermissions
+   * @param array $subPermissions
+   * @param array $allPermissions
+   */
+  protected static function setImpliedBy(array $metaPermissions, array $subPermissions, array &$allPermissions): void {
+    foreach ($subPermissions as $name) {
+      if (isset($allPermissions[$name])) {
+        $allPermissions[$name]['implied_by'] = array_unique(array_merge($allPermissions[$name]['implied_by'] ?? [], $metaPermissions));
+        if (!empty($allPermissions[$name]['implies'])) {
+          self::setImpliedBy(array_merge([$name], $metaPermissions), $allPermissions[$name]['implies'], $allPermissions);
+        }
+      }
+    }
   }
 
   /**
@@ -668,6 +694,10 @@ class CRM_Core_Permission {
       'administer CiviCRM' => [
         'label' => $prefix . ts('administer CiviCRM'),
         'description' => ts('Perform all tasks in the Administer CiviCRM control panel and Import Contacts'),
+        'implies' => [
+          'administer CiviCRM system',
+          'administer CiviCRM data',
+        ],
       ],
       'skip IDS check' => [
         'label' => $prefix . ts('skip IDS check'),
@@ -871,14 +901,27 @@ class CRM_Core_Permission {
       'administer CiviCRM system' => [
         'label' => $prefix . ts('administer CiviCRM System'),
         'description' => ts('Perform all system administration tasks in CiviCRM'),
+        'implies' => [
+          'edit system workflow message templates',
+        ],
       ],
       'administer CiviCRM data' => [
         'label' => $prefix . ts('administer CiviCRM Data'),
         'description' => ts('Permit altering all restricted data options'),
+        'implies' => [
+          'edit message templates',
+          'administer dedupe rules',
+        ],
       ],
+      // This is a very special permission that supersedes all others;
+      // it's the equivalent of user 1 in Drupal.
       'all CiviCRM permissions and ACLs' => [
         'label' => $prefix . ts('all CiviCRM permissions and ACLs'),
         'description' => ts('Administer and use CiviCRM bypassing any other permission or ACL checks and enabling the creation of displays and forms that allow others to bypass checks. This permission should be given out with care'),
+        // This line is here more as a bit of documentation (so it will show in `Civi\Api4\Permission::get()`).
+        // The functionality that actually propagates this permission into all others
+        // is in `self::getImpliedBy`.
+        'implies' => ['*'],
       ],
     ];
     if (self::isMultisiteEnabled()) {
@@ -893,43 +936,22 @@ class CRM_Core_Permission {
   }
 
   /**
-   * Get permissions implied by 'superset' permissions.
+   * Get all permissions that would grant the given permission.
    *
+   * This always includes the permission itself and the super 'all CiviCRM permissions and ACLs'
+   * plus any meta-permissions that imply this one.
+   *
+   * @param string $permissionName
    * @return array
    */
-  public static function getImpliedAdminPermissions(): array {
-    return [
-      'administer CiviCRM' => ['implied_permissions' => ['administer CiviCRM system', 'administer CiviCRM data']],
-      'administer CiviCRM data' => ['implied_permissions' => ['edit message templates', 'administer dedupe rules']],
-      'administer CiviCRM system' => ['implied_permissions' => ['edit system workflow message templates']],
-    ];
-  }
-
-  /**
-   * Get any super-permissions that imply the given permission.
-   *
-   * @param string $permission
-   *
-   * @return array
-   */
-  public static function getImpliedPermissionsFor(string $permission): array {
-    if (in_array($permission[0], ['@', '*'], TRUE)) {
+  private static function getImpliedBy(string $permissionName): array {
+    if (in_array($permissionName[0], ['@', '*'], TRUE)) {
       // Special permissions like '*always deny*' - see DynamicFKAuthorizationTest.
       // Also '@afform - see AfformUsageTest.
-      return [];
+      return [$permissionName];
     }
-    $implied = Civi::cache('metadata')->get('implied_permissions', []);
-    if (isset($implied[$permission])) {
-      return $implied[$permission];
-    }
-    $implied[$permission] = ['all CiviCRM permissions and ACLs'];
-    foreach (self::getImpliedAdminPermissions() as $key => $details) {
-      if (in_array($permission, $details['implied_permissions'] ?? [], TRUE)) {
-        $implied[$permission][] = $key;
-      }
-    }
-    Civi::cache('metadata')->set('implied_permissions', $implied);
-    return $implied[$permission];
+    $impliedPermissions = self::basicPermissions(TRUE, TRUE)[$permissionName]['implied_by'] ?? [];
+    return array_merge([$permissionName, 'all CiviCRM permissions and ACLs'], $impliedPermissions);
   }
 
   /**

--- a/CRM/Core/Permission/Base.php
+++ b/CRM/Core/Permission/Base.php
@@ -392,6 +392,7 @@ class CRM_Core_Permission_Base {
    *
    * @return array
    *   Array of permissions, in the same format as CRM_Core_Permission::getCorePermissions().
+   * @throws RuntimeException
    */
   public function getAllModulePermissions(): array {
     $permissions = [];

--- a/CRM/Core/Permission/List.php
+++ b/CRM/Core/Permission/List.php
@@ -38,6 +38,7 @@ class CRM_Core_Permission_List {
         'title' => $corePerm['label'],
         'description' => $corePerm['description'] ?? NULL,
         'is_active' => empty($corePerm['disabled']),
+        'implies' => $corePerm['implies'] ?? NULL,
       ];
     }
   }
@@ -83,6 +84,7 @@ class CRM_Core_Permission_List {
    */
   public static function findConstPermissions(GenericHookEvent $e) {
     // There are a handful of special permissions defined in CRM/Core/Permission.
+    // Enforcement of them is handled in `CRM_Core_Permission_*::check()`
     $e->permissions[\CRM_Core_Permission::ALWAYS_DENY_PERMISSION] = [
       'group' => 'const',
       'title' => ts('Generic: Deny all users'),
@@ -92,6 +94,9 @@ class CRM_Core_Permission_List {
       'group' => 'const',
       'title' => ts('Generic: Allow all users (including anonymous)'),
       'is_synthetic' => TRUE,
+      // This line is here more as a bit of documentation (so it will show in `Civi\Api4\Permission::get()`).
+      // The functionality that actually handles this pseudo-permission is in `CRM_Core_Permission_*::check()`
+      'implies' => ['*'],
     ];
   }
 

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2310,6 +2310,7 @@ abstract class CRM_Utils_Hook {
    *
    * @return null
    *   The return value is ignored
+   * @throws RuntimeException
    */
   public static function permission(&$newPermissions) {
     $null = NULL;

--- a/Civi/Api4/Permission.php
+++ b/Civi/Api4/Permission.php
@@ -79,6 +79,12 @@ class Permission extends Generic\AbstractEntity {
           'default' => TRUE,
           'data_type' => 'Boolean',
         ],
+        [
+          'name' => 'implies',
+          'title' => 'Implies',
+          'description' => 'List of sub-permissions automatically granted by this one',
+          'data_type' => 'Array',
+        ],
       ];
     }))->setCheckPermissions($checkPermissions);
   }

--- a/tests/phpunit/CRM/Core/Permission/BaseTest.php
+++ b/tests/phpunit/CRM/Core/Permission/BaseTest.php
@@ -57,7 +57,16 @@ class CRM_Core_Permission_BaseTest extends CiviUnitTestCase {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = [
       'administer CiviCRM',
     ];
+    $this->assertTrue(CRM_Core_Permission::check('administer CiviCRM'));
+    // administer CiviCRM implies the following two:
+    $this->assertTrue(CRM_Core_Permission::check('administer CiviCRM system'));
     $this->assertTrue(CRM_Core_Permission::check('administer CiviCRM data'));
+    // cascading implications from the previous two
+    $this->assertTrue(CRM_Core_Permission::check('edit system workflow message templates'));
+    $this->assertTrue(CRM_Core_Permission::check('edit message templates'));
+    $this->assertTrue(CRM_Core_Permission::check('administer dedupe rules'));
+    // administer CiviCRM does NOT imply edit all contacts
+    $this->assertFalse(CRM_Core_Permission::check('edit all contacts'));
   }
 
   /**
@@ -68,6 +77,7 @@ class CRM_Core_Permission_BaseTest extends CiviUnitTestCase {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = [
       'all CiviCRM permissions and ACLs',
     ];
+    $this->assertTrue(CRM_Core_Permission::check('administer CiviCRM system'));
     $this->assertTrue(CRM_Core_Permission::check('view all contacts'));
   }
 

--- a/tests/phpunit/api/v4/Entity/PermissionTest.php
+++ b/tests/phpunit/api/v4/Entity/PermissionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Entity;
+
+use Civi\Api4\Permission;
+use api\v4\Api4TestBase;
+
+/**
+ * @group headless
+ */
+class PermissionTest extends Api4TestBase {
+
+  public function testGet(): void {
+    $permissions = (array) Permission::get(FALSE)->execute()->indexBy('name');
+    $this->assertArrayHasKey('*always deny*', $permissions);
+    $this->assertEquals(['*'], $permissions['*always allow*']['implies']);
+    $this->assertEquals(['*'], $permissions['all CiviCRM permissions and ACLs']['implies']);
+    $this->assertContains('edit message templates', $permissions['administer CiviCRM data']['implies']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This improves the implied-permission system to make it simpler for us to say that one permission implies another.

Before
----------------------------------------
Implied permissions were off in their own little space.

After
----------------------------------------
Every permission declaration can include an 'implies' key which tells the permission system which sub-permissions it includes.
