### PR TITLE
API - More helpful authorization failed error message

### DIFF
--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -227,7 +227,7 @@ class Kernel {
     /** @var \Civi\API\Event\AuthorizeEvent $event */
     $event = $this->dispatcher->dispatch('civi.api.authorize', new AuthorizeEvent($apiProvider, $apiRequest, $this, \CRM_Core_Session::getLoggedInContactID() ?: 0));
     if (!$event->isAuthorized()) {
-      throw new \Civi\API\Exception\UnauthorizedException("Authorization failed");
+      throw new \Civi\API\Exception\UnauthorizedException("Authorization failed: CiviCRM APIv{$apiRequest['version']} ({$apiRequest['entity']}::{$apiRequest['action']})");
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Helps puzzled sysadmins diagnose problems by adding some basic info about the API request to the error message (api version, entity & action).

Before
----------------------------------------
Computer says "Authorization failed"

After
----------------------------------------
Computer says e.g. "Authorization failed: CiviCRM APIv3 (Contact::get)" or "Authorization failed: CiviCRM APIv4 (Participant::save)"
