### PR TITLE
SearchKit - Fix switching to nonexistent tab

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -237,7 +237,7 @@
       if (display.id) {
         display.trashed = !display.trashed;
         if ($scope.controls.tab === ('display_' + index) && display.trashed) {
-          $scope.selectTab('compose');
+          $scope.selectTab('for');
         } else if (!display.trashed) {
           $scope.selectTab('display_' + index);
         }
@@ -255,7 +255,7 @@
           });
         }
       } else {
-        $scope.selectTab('compose');
+        $scope.selectTab('for');
         ctrl.savedSearch.displays.splice(index, 1);
       }
     };
@@ -300,7 +300,7 @@
         ctrl.savedSearch.groups.length = 0;
       }
       if ($scope.controls.tab === 'group') {
-        $scope.selectTab('compose');
+        $scope.selectTab('for');
       }
     };
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where SearchKit might switch you to a tab that doesn't exist.

Before
----------------------------------------
When deleting a search display, javascript error & no tab selected.

After
----------------------------------------
Correct behavior restored: when deleting a search display, switch back to first tab.

Technical Details
-------
Tabs were recently renamed in 80e7cea1d07804627e397013314813cac68956b5 so this keeps up with the change.