### PR TITLE
Core/DAO - Add boilerplate import/export functions to base class 

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -207,6 +207,26 @@ class CRM_Core_DAO extends DB_DataObject {
   }
 
   /**
+   * Returns the list of fields that can be imported
+   *
+   * @param bool $prefix
+   * @return array
+   */
+  public static function import($prefix = FALSE) {
+    return CRM_Core_DAO_AllCoreTables::getImports(static::class, substr(static::$_tableName, 8), $prefix);
+  }
+
+  /**
+   * Returns the list of fields that can be exported
+   *
+   * @param bool $prefix
+   * @return array
+   */
+  public static function export($prefix = FALSE) {
+    return CRM_Core_DAO_AllCoreTables::getExports(static::class, substr(static::$_tableName, 8), $prefix);
+  }
+
+  /**
    * Initialize the DAO object.
    *
    * @param string $dsn

--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -395,15 +395,16 @@ class CRM_Core_DAO_AllCoreTables {
   /**
    * (Quasi-Private) Do not call externally. For use by DAOs.
    *
-   * @param string $dao
+   * @param string|CRM_Core_DAO $dao
    *   Ex: 'CRM_Core_DAO_Address'.
    * @param string $labelName
    *   Ex: 'address'.
    * @param bool $prefix
    * @param array $foreignDAOs
+   *   Historically used for... something? Currently never set by any core BAO.
    * @return array
    */
-  public static function getExports($dao, $labelName, $prefix, $foreignDAOs) {
+  public static function getExports($dao, $labelName, $prefix, $foreignDAOs = []) {
     // Bug-level compatibility -- or sane behavior?
     $cacheKey = $dao . ':export';
     // $cacheKey = $dao . ':' . ($prefix ? 'export-prefix' : 'export');
@@ -423,6 +424,7 @@ class CRM_Core_DAO_AllCoreTables {
         }
       }
 
+      // TODO: Remove this bit; no core DAO actually uses it
       foreach ($foreignDAOs as $foreignDAO) {
         $exports = array_merge($exports, $foreignDAO::export(TRUE));
       }
@@ -435,15 +437,16 @@ class CRM_Core_DAO_AllCoreTables {
   /**
    * (Quasi-Private) Do not call externally. For use by DAOs.
    *
-   * @param string $dao
+   * @param string|CRM_Core_DAO $dao
    *   Ex: 'CRM_Core_DAO_Address'.
    * @param string $labelName
    *   Ex: 'address'.
    * @param bool $prefix
    * @param array $foreignDAOs
+   *   Historically used for... something? Currently never set by any core BAO.
    * @return array
    */
-  public static function getImports($dao, $labelName, $prefix, $foreignDAOs) {
+  public static function getImports($dao, $labelName, $prefix, $foreignDAOs = []) {
     // Bug-level compatibility -- or sane behavior?
     $cacheKey = $dao . ':import';
     // $cacheKey = $dao . ':' . ($prefix ? 'import-prefix' : 'import');
@@ -463,6 +466,7 @@ class CRM_Core_DAO_AllCoreTables {
         }
       }
 
+      // TODO: Remove this bit; no core DAO actually uses it
       foreach ($foreignDAOs as $foreignDAO) {
         $imports = array_merge($imports, $foreignDAO::import(TRUE));
       }

--- a/mixin/entity-types-php@1/example/CRM/Shimmy/DAO/ShimThing.php
+++ b/mixin/entity-types-php@1/example/CRM/Shimmy/DAO/ShimThing.php
@@ -120,61 +120,6 @@ class CRM_Shimmy_DAO_ShimThing extends CRM_Core_DAO {
   }
 
   /**
-   * Return a mapping from field-name to the corresponding key (as used in fields()).
-   *
-   * @return array
-   *   Array(string $name => string $uniqueName).
-   */
-  public static function &fieldKeys() {
-    if (!isset(Civi::$statics[__CLASS__]['fieldKeys'])) {
-      Civi::$statics[__CLASS__]['fieldKeys'] = array_flip(CRM_Utils_Array::collect('name', self::fields()));
-    }
-    return Civi::$statics[__CLASS__]['fieldKeys'];
-  }
-
-  /**
-   * Returns the names of this table
-   *
-   * @return string
-   */
-  public static function getTableName() {
-    return self::$_tableName;
-  }
-
-  /**
-   * Returns if this table needs to be logged
-   *
-   * @return bool
-   */
-  public function getLog() {
-    return self::$_log;
-  }
-
-  /**
-   * Returns the list of fields that can be imported
-   *
-   * @param bool $prefix
-   *
-   * @return array
-   */
-  public static function &import($prefix = FALSE) {
-    $r = CRM_Core_DAO_AllCoreTables::getImports(__CLASS__, 'shim_thing', $prefix, []);
-    return $r;
-  }
-
-  /**
-   * Returns the list of fields that can be exported
-   *
-   * @param bool $prefix
-   *
-   * @return array
-   */
-  public static function &export($prefix = FALSE) {
-    $r = CRM_Core_DAO_AllCoreTables::getExports(__CLASS__, 'shim_thing', $prefix, []);
-    return $r;
-  }
-
-  /**
    * Returns the list of indices
    *
    * @param bool $localize


### PR DESCRIPTION
Overview
----------------------------------------
Toward removing a bunch of repetitive boilerplate.

Before
----------------------------------------
Duplicate import/export functions in every generated DAO file.

After
----------------------------------------
Import/export functions in every generated DAO file *and* in the base class.
(next step after merging this is to remove them from the generated files).

Details
-----------
As with 9d89b14 removing the `&` prefix from the parent functions but leaving them in the overrides doesn't cause any problem for php.
As with 18ebac87cab135e21e2bf8e0cca5cc3c40ad2be3 it might be smart to wait a few versions before ripping them out of `DAO.tpl`, to give time for extensions to catch up.