### PR TITLE
DAO - Remove buggy caching from import/export

### DIFF
--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -403,35 +403,28 @@ class CRM_Core_DAO_AllCoreTables {
    * @param array $foreignDAOs
    *   Historically used for... something? Currently never set by any core BAO.
    * @return array
+   * @internal
    */
   public static function getExports($dao, $labelName, $prefix, $foreignDAOs = []) {
-    // Bug-level compatibility -- or sane behavior?
-    $cacheKey = $dao . ':export';
-    // $cacheKey = $dao . ':' . ($prefix ? 'export-prefix' : 'export');
+    $exports = [];
 
-    if (!isset(Civi::$statics[__CLASS__][$cacheKey])) {
-      $exports = [];
-      $fields = $dao::fields();
-
-      foreach ($fields as $name => $field) {
-        if (!empty($field['export'])) {
-          if ($prefix) {
-            $exports[$labelName] = & $fields[$name];
-          }
-          else {
-            $exports[$name] = & $fields[$name];
-          }
+    foreach ($dao::fields() as $name => $field) {
+      if (!empty($field['export'])) {
+        if ($prefix) {
+          $exports[$labelName] = $field;
+        }
+        else {
+          $exports[$name] = $field;
         }
       }
-
-      // TODO: Remove this bit; no core DAO actually uses it
-      foreach ($foreignDAOs as $foreignDAO) {
-        $exports = array_merge($exports, $foreignDAO::export(TRUE));
-      }
-
-      Civi::$statics[__CLASS__][$cacheKey] = $exports;
     }
-    return Civi::$statics[__CLASS__][$cacheKey];
+
+    // TODO: Remove this bit; no core DAO actually uses it
+    foreach ($foreignDAOs as $foreignDAO) {
+      $exports = array_merge($exports, $foreignDAO::export(TRUE));
+    }
+
+    return $exports;
   }
 
   /**
@@ -445,35 +438,28 @@ class CRM_Core_DAO_AllCoreTables {
    * @param array $foreignDAOs
    *   Historically used for... something? Currently never set by any core BAO.
    * @return array
+   * @internal
    */
-  public static function getImports($dao, $labelName, $prefix, $foreignDAOs = []) {
-    // Bug-level compatibility -- or sane behavior?
-    $cacheKey = $dao . ':import';
-    // $cacheKey = $dao . ':' . ($prefix ? 'import-prefix' : 'import');
+  public static function getImports($dao, $labelName, $prefix, $foreignDAOs = []): array {
+    $imports = [];
 
-    if (!isset(Civi::$statics[__CLASS__][$cacheKey])) {
-      $imports = [];
-      $fields = $dao::fields();
-
-      foreach ($fields as $name => $field) {
-        if (!empty($field['import'])) {
-          if ($prefix) {
-            $imports[$labelName] = & $fields[$name];
-          }
-          else {
-            $imports[$name] = & $fields[$name];
-          }
+    foreach ($dao::fields() as $name => $field) {
+      if (!empty($field['import'])) {
+        if ($prefix) {
+          $imports[$labelName] = $field;
+        }
+        else {
+          $imports[$name] = $field;
         }
       }
-
-      // TODO: Remove this bit; no core DAO actually uses it
-      foreach ($foreignDAOs as $foreignDAO) {
-        $imports = array_merge($imports, $foreignDAO::import(TRUE));
-      }
-
-      Civi::$statics[__CLASS__][$cacheKey] = $imports;
     }
-    return Civi::$statics[__CLASS__][$cacheKey];
+
+    // TODO: Remove this bit; no core DAO actually uses it
+    foreach ($foreignDAOs as $foreignDAO) {
+      $imports = array_merge($imports, $foreignDAO::import(TRUE));
+    }
+
+    return $imports;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Removes a useless layer of caching that provided nothing but bugs.

Before
----------------------------------------
Buggy cache wastes memory & ignores function params.

After
----------------------------------------
Function just as fast without cache; potential bug eliminated.

Technical Details
----------------------------------------
Back in https://github.com/civicrm/civicrm-core/commit/84a0493ce59dc0d76a7b5239031a709f1e4dc5f3 @totten noticed that the existing function had a caching bug where the `$prefix` mode was ignored; so whatever mode was called first would be cached and returned to all subsequent callers of the function.

Presumably to expedite an already huge refactor, he kept the bug, adding a commented-out fix with a cryptic note for posterity: "Bug-level compatibility -- or sane behavior?" That question has haunted us since 2016.

Since the buggy behavior hasn't resulted in any reported problems in all these years, I'm guessing that these functions aren't called very often (and never with opposite values for `$prefix` during the same request).

I think the "sane behavior" is to just remove the cache entirely, as it achieves practically nothing:
all these functions actually *do* is filter a small array (returned from the already-cached `fields()` function), and that's such a trivial operation in PHP that caching it does nothing but waste memory.