### PR TITLE
dev/core#4951 Add support for smarty debugging

### DIFF
--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -1043,7 +1043,15 @@ class CRM_Utils_String {
     // Adding this is preparatory to smarty 3. The original PR failed some
     // tests so we check for the function.
     if (!function_exists('smarty_function_eval') && !file_exists(SMARTY_DIR . '/plugins/function.eval.php')) {
-      $templateString = (string) $smarty->fetch('eval:{eval var=$smartySingleUseString|smarty:nodefaults}');
+      try {
+        $templateString = (string) $smarty->fetch('eval:' . $templateString);
+      }
+      catch (SmartyCompilerException $e) {
+        \Civi::log('smarty')->info('parsing smarty template {template}', [
+          'template' => $templateString,
+        ]);
+        throw new \CRM_Core_Exception('Message was not parsed due to invalid smarty syntax : ' . $e->getMessage() . ((CIVICRM_UF === 'UnitTest' || CRM_Utils_Constant::value('SMARTY_DEBUG_STRINGS')) ? $templateString : ''));
+      }
     }
     else {
       $templateString = (string) $smarty->fetch('string:{eval var=$smartySingleUseString|smarty:nodefaults}');


### PR DESCRIPTION
Overview
----------------------------------------

- catches exceptions
- outputs full error in tests
- uses a more straight forward way to 'eval' (the double eval was a smarty2 hack)
- adds support for constant to include more debut output


Note this is called all the time so I just did  a quick check that message templates still render - but in fact all these changes came out of my efforts to get Smarty3 tests passing so have been put through the test ringer
