### PR TITLE
Update Smarty autoload constant to be version agnostic

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -147,7 +147,9 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
     }
 
     if (CRM_Utils_Constant::value('CIVICRM_SMARTY_DEFAULT_ESCAPE')
-      && !CRM_Utils_Constant::value('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
+      && !CRM_Utils_Constant::value('CIVICRM_SMARTY3_AUTOLOAD_PATH')
+      && !CRM_Utils_Constant::value('CIVICRM_SMARTY_AUTOLOAD_PATH')
+    ) {
       // Currently DEFAULT escape does not work with Smarty3
       // dunno why - thought it would be the default with Smarty3 - but
       // getting onto Smarty 3 is higher priority.

--- a/CRM/Core/SmartyCompatibility.php
+++ b/CRM/Core/SmartyCompatibility.php
@@ -18,15 +18,14 @@
 /**
  * Smarty Compatibility class.
  *
- * This class implements but Smarty v2 & Smarty v3 functions so that
+ * This class implements both Smarty v2 & Smarty v3+ functions so that
  *
  * 1) we can start to transition functions like `$smarty->assign_var` to
  * `$smarty->assignVar()`
- * 2) if someone adds the Smarty3 package onto their site and
- * defines CIVICRM_SMARTY3_AUTOLOAD_PATH then Smarty3 will load from that
+ * 2) if someone defines CIVICRM_SMARTY_AUTOLOAD_PATH then Smarty will load from that
  * location.
  *
- * Note that experimenting with `CIVICRM_SMARTY3_AUTOLOAD_PATH` will not
+ * Note that experimenting with `CIVICRM_SMARTY_AUTOLOAD_PATH` will not
  * go well if extensions are installed that have not run civix upgrade
  * somewhat recently (ie have the old version of the hook_civicrm_config
  * with reference to `$template =& CRM_Core_Smarty::singleton();`
@@ -37,12 +36,12 @@
  * other similar PEAR packages. doubt it
  */
 if (!class_exists('Smarty')) {
-  if (defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
-    // @todo - this is experimental but it allows someone to
-    // get Smarty3 to load instead of Smarty2 if set.
-    // It is likely the final Smarty3 solution will look
-    // different but this makes testing possible without re-inventing
-    // it each time we try...
+  if (defined('CIVICRM_SMARTY_AUTOLOAD_PATH')) {
+    // Specify the smarty version to load.
+    require_once CIVICRM_SMARTY_AUTOLOAD_PATH;
+  }
+  elseif (defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
+    // older version of the above constant.
     require_once CIVICRM_SMARTY3_AUTOLOAD_PATH;
   }
   else {

--- a/CRM/Utils/Check/Component/Smarty.php
+++ b/CRM/Utils/Check/Component/Smarty.php
@@ -29,13 +29,13 @@ class CRM_Utils_Check_Component_Smarty extends CRM_Utils_Check_Component {
     };
 
     $messages = [];
-    if (!defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
+    if (!defined('CIVICRM_SMARTY_AUTOLOAD_PATH') && !defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
       $smartyPath = \Civi::paths()->getPath('[civicrm.packages]/smarty3/vendor/autoload.php');
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
         $p(ts('CiviCRM is updating a major library (<em>Smarty</em>) to improve performance and security. In CiviCRM v5.69, the update is optional, but you should try it now.'))
         . $p(ts('To apply the update, add this statement to <code>civicrm.settings.php</code>:'))
-        . sprintf("<pre>  define('CIVICRM_SMARTY3_AUTOLOAD_PATH',\n    %s);</pre>", htmlentities(var_export($smartyPath, 1)))
+        . sprintf("<pre>  define('CIVICRM_SMARTY_AUTOLOAD_PATH',\n    %s);</pre>", htmlentities(var_export($smartyPath, 1)))
         . $p('Some extensions may not work yet with Smarty v3. If you encounter problems, then simply remove the statement.')
         . $p(ts('Upcoming versions will standardize on Smarty v3. CiviCRM <a %1>v5.69-ESR</a> will provide extended support for Smarty v2. To learn more and discuss, see the <a %2>Smarty transition page</a>.', [
           1 => 'target="_blank" href="' . htmlentities('https://civicrm.org/esr') . '"',

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -260,14 +260,14 @@ if (!defined('CIVICRM_UF_BASEURL')) {
  * un-comment the line describing the path. Note that this will become always enabled in
  * the near future - this opt-in setting is transitional.
  */
-if (!defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
+if (!defined('CIVICRM_SMARTY_AUTOLOAD_PATH')) {
   // enable by default for dev & demo sites for now - will soon enable by default for all new installs.
   if (strpos(CIVICRM_UF_BASEURL, 'localhost') !== FALSE || strpos(CIVICRM_UF_BASEURL, 'demo.civicrm.org') !== FALSE) {
     if (is_dir($civicrm_root . '/packages')) {
-      define('CIVICRM_SMARTY3_AUTOLOAD_PATH', $civicrm_root . '/packages/smarty3/vendor/autoload.php');
+      define('CIVICRM_SMARTY_AUTOLOAD_PATH', $civicrm_root . '/packages/smarty3/vendor/autoload.php');
     }
     elseif (is_dir($civicrm_root . '/../civicrm-packages')) {
-      define('CIVICRM_SMARTY3_AUTOLOAD_PATH', $civicrm_root . '/../civicrm-packages/smarty3/vendor/autoload.php');
+      define('CIVICRM_SMARTY_AUTOLOAD_PATH', $civicrm_root . '/../civicrm-packages/smarty3/vendor/autoload.php');
     }
   }
 }


### PR DESCRIPTION
Overview
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/4954 it seems that we can switch to Smarty4 as easily as Smarty3 - but the version is baked into the constant name. This adds a new constant without the version & uses that for new installs/ in the message telling people to switch. If people have already switched to the old constant that still works & we don't need to encourage them to switch again

Before
----------------------------------------
It's possible to switch to Smarty4 or even Smarty 5 with open packages PRs merged - but then the const is called `'CIVICRM_SMARTY3_AUTOLOAD_PATH'`

After
----------------------------------------
Preferred const is called `'CIVICRM_SMARTY_AUTOLOAD_PATH'`,

`'CIVICRM_SMARTY3_AUTOLOAD_PATH'` still works & people who have switched to that do not need to take any action

Technical Details
----------------------------------------

Comments
----------------------------------------
