### PR TITLE
Afform - Format DisplayOnly fields as view value

### DIFF
--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -415,6 +415,33 @@ class CoreUtil {
     return $formatted;
   }
 
+  public static function formatViewValue(string $entityName, string $fieldName, array $values, string $action = 'get') {
+    if (!isset($values[$fieldName]) || $values[$fieldName] === '') {
+      return '';
+    }
+    $params = [
+      'action' => $action,
+      'where' => [['name', '=', $fieldName]],
+      'loadOptions' => ['id', 'label'],
+      'checkPermissions' => FALSE,
+      'values' => $values,
+    ];
+    $fieldInfo = civicrm_api4($entityName, 'getFields', $params)->single();
+    $dataType = $fieldInfo['data_type'] ?? NULL;
+    if (!empty($fieldInfo['options'])) {
+      return FormattingUtil::replacePseudoconstant(array_column($fieldInfo['options'], 'label', 'id'), $values[$fieldName]);
+    }
+    elseif ($dataType === 'Boolean') {
+      return $values[$fieldName] ? ts('Yes') : ts('No');
+    }
+    elseif ($dataType === 'Date' || $dataType === 'Timestamp') {
+      $values[$fieldName] = \CRM_Utils_Date::customFormat($values[$fieldName]);
+    }
+    if (is_array($values[$fieldName])) {
+      $values[$fieldName] = implode(', ', $values[$fieldName]);
+    }
+  }
+
   /**
    * Gets info about all available sql functions
    * @return array

--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -170,6 +170,14 @@ class AfformMetadataInjector {
       unset($fieldInfo['options'], $fieldDefn['options']);
     }
 
+    if ($inputType === 'DisplayOnly' && isset($fieldDefn['afform_default'])) {
+      $fieldName = $fieldInfo['name'];
+      $defaultValue = \CRM_Utils_JS::decode($fieldDefn['afform_default']);
+      $defaultValue = Utils::formatViewValue($fieldName, $fieldInfo, [$fieldName => $defaultValue]);
+      $fieldDefn['afform_default'] = \CRM_Utils_JS::encode($defaultValue);
+      unset($fieldInfo['options'], $fieldDefn['options']);
+    }
+
     foreach ($fieldInfo as $name => $prop) {
       // Merge array props 1 level deep
       if (in_array($name, $deep) && !empty($fieldDefn[$name])) {

--- a/ext/afform/core/Civi/Afform/FormDataModel.php
+++ b/ext/afform/core/Civi/Afform/FormDataModel.php
@@ -195,9 +195,10 @@ class FormDataModel {
    * @param string $entityName
    * @param string $fieldName
    * @param string $action
+   * @param array $values
    * @return array|NULL
    */
-  public static function getField(string $entityName, string $fieldName, string $action): ?array {
+  public static function getField(string $entityName, string $fieldName, string $action, array $values = []): ?array {
     // For explicit joins, strip the alias off the field name
     if (strpos($entityName, ' AS ')) {
       [$entityName, $alias] = explode(' AS ', $entityName);
@@ -219,11 +220,8 @@ class FormDataModel {
       'loadOptions' => ['id', 'label'],
       // If the admin included this field on the form, then it's OK to get metadata about the field regardless of user permissions.
       'checkPermissions' => FALSE,
+      'values' => $values,
     ];
-    if (in_array($entityName, \CRM_Contact_BAO_ContactType::basicTypes(TRUE))) {
-      $params['values'] = ['contact_type' => $entityName];
-      $entityName = 'Contact';
-    }
     foreach (civicrm_api4($entityName, 'getFields', $params) as $field) {
       // In the highly unlikely event of 2 fields returned, prefer the exact match
       if ($field['name'] === $fieldName) {

--- a/ext/afform/core/Civi/Afform/Utils.php
+++ b/ext/afform/core/Civi/Afform/Utils.php
@@ -12,6 +12,7 @@
 
 namespace Civi\Afform;
 
+use Civi\Api4\Utils\FormattingUtil;
 use CRM_Afform_ExtensionUtil as E;
 
 /**
@@ -98,6 +99,26 @@ class Utils {
 
     return $isChanged('server_route') ||
       (!empty($updatedAfform['server_route']) && $isChanged('title'));
+  }
+
+  public static function formatViewValue(string $fieldName, array $fieldInfo, array $values): string {
+    $value = $values[$fieldName] ?? NULL;
+    if (isset($value)) {
+      $dataType = $fieldInfo['data_type'] ?? NULL;
+      if (!empty($fieldInfo['options'])) {
+        $value = FormattingUtil::replacePseudoconstant(array_column($fieldInfo['options'], 'label', 'id'), $value);
+      }
+      elseif ($dataType === 'Boolean') {
+        $value = $value ? ts('Yes') : ts('No');
+      }
+      elseif ($dataType === 'Date' || $dataType === 'Timestamp') {
+        $value = \CRM_Utils_Date::customFormat($value);
+      }
+      if (is_array($value)) {
+        $value = implode(', ', $value);
+      }
+    }
+    return $value ?? '';
   }
 
 }

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -281,7 +281,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     $directFk = FALSE;
     // First look for a direct foreign key field e.g. `contact_id`
     foreach (self::getEntityFields($joinEntityType) as $field) {
-      if ($field['fk_entity'] === $mainEntityType) {
+      if ($field['fk_entity'] === $mainEntityType && $field['type'] === 'Field') {
         $directFk = TRUE;
         $params[] = [$field['name'], '=', $mainEntityId];
       }

--- a/ext/afform/core/Civi/Api4/Action/Afform/Prefill.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Prefill.php
@@ -21,18 +21,31 @@ class Prefill extends AbstractProcessor {
     foreach ($entityValues as $afformEntityName => &$valueSets) {
       $afformEntity = $this->_formDataModel->getEntity($afformEntityName);
       if ($this->matchField) {
-        $matchFieldDefn = $this->_formDataModel->getField($afformEntity['type'], $this->matchField, 'create');
-        // When creating an entity based on an existing one e.g. Event.template_id
-        if (($matchFieldDefn['input_attrs']['autofill'] ?? NULL) === 'create') {
-          $idField = CoreUtil::getIdFieldName($afformEntity['type']);
-          foreach ($valueSets as &$valueSet) {
-            $valueSet['fields'][$this->matchField] = $valueSet['fields'][$idField];
-            unset($valueSet['fields'][$idField]);
-          }
-        }
+        $this->handleMatchField($afformEntity['type'], $valueSets);
       }
     }
     return \CRM_Utils_Array::makeNonAssociative($entityValues, 'name', 'values');
+  }
+
+  /**
+   * Set entity values based on an existing record.
+   *
+   * This is used for e.g. Event.template_id,
+   * based on 'autofill' => 'create' metadata in APIv4 getFields.
+   *
+   * @param string $entityType
+   * @param array $valueSets
+   */
+  private function handleMatchField(string $entityType, array &$valueSets): void {
+    $matchFieldDefn = $this->_formDataModel->getField($entityType, $this->matchField, 'create');
+    // @see EventCreationSpecProvider for the `template_id` declaration which includes this 'autofill' = 'create' flag.
+    if (($matchFieldDefn['input_attrs']['autofill'] ?? NULL) === 'create') {
+      $idField = CoreUtil::getIdFieldName($entityType);
+      foreach ($valueSets as &$valueSet) {
+        $valueSet['fields'][$this->matchField] = $valueSet['fields'][$idField];
+        unset($valueSet['fields'][$idField]);
+      }
+    }
   }
 
 }

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -182,7 +182,9 @@
       // Set default value; ensure data type matches input type
       function setValue(value) {
         // correct the value type
-        value = correctValueType(value, ctrl.defn.data_type);
+        if (ctrl.defn.input_type !== 'DisplayOnly') {
+          value = correctValueType(value, ctrl.defn.data_type);
+        }
 
         if (ctrl.defn.input_type === 'Date' && typeof value === 'string' && value.startsWith('now')) {
           value = getRelativeDate(value);

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformPrefillUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformPrefillUsageTest.php
@@ -74,11 +74,12 @@ EOHTML;
     // One email should have been filled
     $this->assertCount(1, $prefill['Individual1']['values'][1]['joins']['Email']);
     $this->assertEquals('b@afform.test', $prefill['Individual1']['values'][1]['joins']['Email'][0]['email']);
-    $this->assertEmpty($prefill['Individual1']['values'][0]['joins']['Email']);
+    $joins = $prefill['Individual1']['values'][0]['joins'];
+    $this->assertEmpty($joins['Email']);
     $this->assertEmpty($prefill['Individual1']['values'][2]['joins']['Email']);
 
     // Phone join has `max="2"`
-    $this->assertCount(2, $prefill['Individual1']['values'][0]['joins']['Phone']);
+    $this->assertCount(2, $joins['Phone']);
     $this->assertCount(1, $prefill['Individual1']['values'][2]['joins']['Phone']);
     $this->assertEquals('2-1', $prefill['Individual1']['values'][2]['joins']['Phone'][0]['phone']);
     $this->assertEmpty($prefill['Individual1']['values'][1]['joins']['Phone']);
@@ -163,6 +164,70 @@ EOHTML;
     $this->assertContains('Co', array_column($parents, 'first_name'));
     $this->assertContains($uid, array_column($parents, 'id'));
     $this->assertContains($cid[0], array_column($parents, 'id'));
+  }
+
+  public function testPrefillWithDisplayOnlyFields(): void {
+
+    $layout = <<<EOHTML
+<af-form ctrl="afform">
+  <af-entity data="{contact_type: 'Individual'}" type="Contact" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="RBAC"  />
+  <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1" min="1" af-repeat="Add">
+    <af-field name="id" />
+    <afblock-name-individual />
+    <af-field name="gender_id" defn="{input_type: 'DisplayOnly', input_attrs: {}}" />
+    <af-field name="is_opt_out" defn="{input_type: 'DisplayOnly', input_attrs: {}}" />
+    <af-field name="birth_date" defn="{input_type: 'DisplayOnly', input_attrs: {}}" />
+    <div af-join="Address" af-repeat="Add" min="1" max="2">
+      <af-field name="country_id" defn="{input_type: 'DisplayOnly', input_attrs: {}}" />
+      <af-field name="state_province_id" defn="{input_type: 'DisplayOnly', input_attrs: {}}" />
+      <af-field name="is_primary" defn="{input_type: 'DisplayOnly', input_attrs: {}}" />
+    </div>
+  </fieldset>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()">Submit</button>
+</af-form>
+EOHTML;
+
+    $this->useValues([
+      'layout' => $layout,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+    ]);
+
+    $cid = $this->saveTestRecords('Individual', [
+      'records' => [
+        ['first_name' => 'One', 'last_name' => 'Name', 'gender_id:name' => 'Female', 'is_opt_out' => TRUE, 'birth_date' => '01-02-2001'],
+        ['first_name' => 'Two', 'last_name' => 'Name', 'gender_id:name' => 'Male', 'is_opt_out' => FALSE],
+      ],
+    ])->column('id');
+
+    $this->saveTestRecords('Address', [
+      'records' => [
+        ['contact_id' => $cid[0], 'country_id:name' => 'United States', 'state_province_id:name' => 'California', 'is_primary' => TRUE],
+        ['contact_id' => $cid[0], 'country_id:name' => 'Canada', 'state_province_id:name' => 'Manitoba', 'is_primary' => FALSE],
+      ],
+    ]);
+
+    $prefill = Afform::prefill()
+      ->setName($this->formName)
+      ->setArgs(['Individual1' => $cid])
+      ->execute()
+      ->indexBy('name');
+    $this->assertCount(2, $prefill['Individual1']['values']);
+    // First contact
+    $this->assertEquals('One', $prefill['Individual1']['values'][0]['fields']['first_name']);
+    $this->assertEquals('Female', $prefill['Individual1']['values'][0]['fields']['gender_id']);
+    $this->assertEquals('Yes', $prefill['Individual1']['values'][0]['fields']['is_opt_out']);
+    $this->assertEquals('February 1st, 2001', $prefill['Individual1']['values'][0]['fields']['birth_date']);
+    $joins = $prefill['Individual1']['values'][0]['joins'];
+    $this->assertEquals('United States', $joins['Address'][0]['country_id']);
+    $this->assertEquals('California', $joins['Address'][0]['state_province_id']);
+    $this->assertEquals('Yes', $joins['Address'][0]['is_primary']);
+    $this->assertEquals('Canada', $joins['Address'][1]['country_id']);
+    $this->assertEquals('Manitoba', $joins['Address'][1]['state_province_id']);
+    $this->assertEquals('No', $joins['Address'][1]['is_primary']);
+    // Second contact
+    $this->assertEquals('Two', $prefill['Individual1']['values'][1]['fields']['first_name']);
+    $this->assertEquals('Male', $prefill['Individual1']['values'][1]['fields']['gender_id']);
+    $this->assertEquals('No', $prefill['Individual1']['values'][1]['fields']['is_opt_out']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Improves display-only fields in formBuilder to show meaningful values.

See https://lab.civicrm.org/dev/core/-/issues/3779

Before
-------
- A field with dropdown options (e.g. "Activity type") would show the numeric value (e.g. "2") 
- A boolean field would show 1 or 0.
- A date would show in machine format e.g. `01-02-2001`.

After
--------
- A field with dropdown options (e.g. "Activity type") will show label e.g. "Meeting".
- A boolean field will show "Yes" or "No".
- A date is formatted locally e.g. "February 1st, 2001"