### PR TITLE
Fix wonkyness if contribution page includes a profile with both groups & tags

### DIFF
--- a/CRM/Contact/Form/Edit/TagsAndGroups.php
+++ b/CRM/Contact/Form/Edit/TagsAndGroups.php
@@ -58,7 +58,6 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
     $groupElementType = 'checkbox',
     $public = FALSE
   ) {
-    $tagGroup = [];
     $form->addExpectedSmartyVariable('type');
     $form->addOptionalQuickFormElement('group');
     // NYSS 5670
@@ -131,6 +130,7 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
     $form->assign('groupElementType', $groupElementType ?? NULL);
 
     if ($type & self::TAG) {
+      $tagGroup = [];
       $tags = CRM_Core_BAO_Tag::getColorTags('civicrm_contact');
 
       if (!empty($tags)) {
@@ -141,7 +141,7 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
       $parentNames = CRM_Core_BAO_Tag::getTagSet('civicrm_contact');
       CRM_Core_Form_Tag::buildQuickForm($form, $parentNames, 'civicrm_contact', $contactId, FALSE, TRUE);
     }
-    $form->assign('tagGroup', $tagGroup);
+    $form->assign('tagGroup', $tagGroup ?? NULL);
   }
 
   /**

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -65,8 +65,39 @@
 
           {if $profileFieldName eq 'email_greeting' or  $profileFieldName eq 'postal_greeting' or $profileFieldName eq 'addressee'}
             {include file="CRM/Profile/Form/GreetingType.tpl"}
+          {elseif $profileFieldName eq 'tag'}
+          <table class="form-layout-compressed{if $context EQ 'profile'} crm-profile-tagsandgroups{/if}">
+            <tr>
+              <td>
+            <div class="crm-section tag-section">
+              {if !empty($title)}{$form.tag.label}<br>{/if}
+              {$form.tag.html}
+            </div>
+              </td>
+            </tr>
+          </table>
           {elseif ($profileFieldName eq 'group' && $form.group) || ($profileFieldName eq 'tag' && $form.tag)}
-            {include file="CRM/Contact/Form/Edit/TagsAndGroups.tpl" type=$profileFieldName title=null context="profile"}
+            <table class="form-layout-compressed{if $context EQ 'profile'} crm-profile-tagsandgroups{/if}">
+              <tr>
+                <td>
+            {if $groupElementType eq 'select'}
+              <div class="crm-section group-section">
+                {if $title}{$form.group.label}<br>{/if}
+                {$form.group.html}
+              </div>
+            {else}
+              {foreach key=key item=item from=$tagGroup.group}
+                <div class="group-wrapper">
+                  {$form.group.$key.html}
+                  {if $item.description}
+                    <div class="description">{$item.description}</div>
+                  {/if}
+                </div>
+              {/foreach}
+            {/if}
+                </td>
+              </tr>
+            </table>
           {elseif array_key_exists('is_datetime_field', $field) && $field.is_datetime_field && $action & 4}
             <span class="crm-frozen-field">
               {$formElement.value|crmDate:$field.smarty_view_format}


### PR DESCRIPTION

Overview
----------------------------------------
Fix wonkyness if contribution page includes a profile with both groups & tags

Before
----------------------------------------
I'm not 100% sure what is meant by the issue https://lab.civicrm.org/dev/core/-/issues/4957 & specifically "Furthermore, and more importantly, the checkboxes are no longer rendered at all on the form."

But when I tested the contribution page with a profile with BOTH group & tag custom fields in it they were added as a block, twice

![image](https://github.com/civicrm/civicrm-core/assets/336308/406e2533-eb5a-4692-80c1-277936fbc9da)

After
----------------------------------------
They are just added the once

![image](https://github.com/civicrm/civicrm-core/assets/336308/ff1a157d-9c55-4735-8508-f92aeff2d880)


Technical Details
----------------------------------------
Including `TagsAndGroups.tpl` seemed to be making it really complex! Instead I copied the bit relevant to each field into the caller

I really didn't want to copy back the fact each of the 2 fields is nested in a table but concluded it made sense for the rc / stable & could possibly go in master

Comments
----------------------------------------
