### PR TITLE
Php 8.x notice fix on tags & groups fields

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -840,7 +840,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     }
 
     // build tags and groups
-    CRM_Contact_Form_Edit_TagsAndGroups::buildQuickForm($this, 0, CRM_Contact_Form_Edit_TagsAndGroups::ALL,
+    CRM_Contact_Form_Edit_TagsAndGroups::buildQuickForm($this, $this->getContactID(), CRM_Contact_Form_Edit_TagsAndGroups::ALL,
       FALSE, NULL, 'Group(s)', 'Tag(s)', NULL, 'select');
 
     // build location blocks.

--- a/CRM/Contact/Form/Edit/TagsAndGroups.php
+++ b/CRM/Contact/Form/Edit/TagsAndGroups.php
@@ -63,6 +63,7 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
     $form->addOptionalQuickFormElement('group');
     // NYSS 5670
     if (!$contactId && !empty($form->_contactId)) {
+      CRM_Core_Error::deprecatedWarning('this is thought to be unreachable, should be passed in');
       $contactId = $form->_contactId;
     }
 
@@ -73,8 +74,10 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
       if ($fieldName) {
         $fName = $fieldName;
       }
+      // The optional url parameter grid is refers to Group ID.
+      // If it set the group options on the page are limited to that group
+      $groupID = is_numeric(CRM_Utils_Request::retrieve('grid', 'Integer', $form)) ? (int) CRM_Utils_Request::retrieve('grid', 'Integer', $form) : NULL;
 
-      $groupID = $form->_grid ?? NULL;
       if ($groupID && $visibility) {
         $ids = [$groupID => $groupID];
       }

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -58,6 +58,9 @@ class CRM_Profile_Form extends CRM_Core_Form {
    * The group id that we are passing in url.
    *
    * @var int
+   *
+   * @deprecated
+   * @internal
    */
   public $_grid;
 


### PR DESCRIPTION
Overview
----------------------------------------
Php 8.x notice fix on tags & groups fields

Before
----------------------------------------
Notice on `_grid` when tags or groups are added to a profile & it is (e.g) on a contribution page

After
----------------------------------------
poof

Technical Details
----------------------------------------
There is only one form that has _grid set - CRM_Core_Profile - I couldn't see how that form would reach this function (which is only called from 3 places) - but that form DOES specify the property so a property_exists check is adequate & I added a deprecation warning so we can remove it (assuming it is not in fact called).

Of the 2 forms that call this one was passing `$contactID` and the other wasn't so I fixed the contact edit form to pass it & it worked fine both in new contact & edit contact mode. I added a deprecation for the now unreachable (I think) condition

Comments
----------------------------------------
