### PR TITLE
dev/core#4948 Fix online_receipt template to include receipt text

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2668,6 +2668,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         }
       }
       else {
+        $values['modelProps'] = $input['modelProps'] ?? [];
         return CRM_Contribute_BAO_ContributionPage::sendMail($ids['contact'], $values, $isTest, $returnMessageText);
       }
     }

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -417,6 +417,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         'tokenContext' => $tokenContext,
         'isTest' => $isTest,
         'PDFFilename' => 'receipt.pdf',
+        'modelProps' => $values['modelProps'] ?? [],
       ];
 
       if ($returnMessageText) {

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -401,15 +401,12 @@ function civicrm_api3_contribution_sendconfirmation($params) {
     'receipt_text',
     'pay_later_receipt',
     'payment_processor_id',
-    'model',
   ];
   $input = array_intersect_key($params, array_flip($allowedParams));
-  if (!isset($input['model'])) {
-    $input['model'] = [
-      // Pass through legacy receipt_text.
-      'userEnteredText' => $input['tplParams']['receipt_text'] ?? NULL,
-    ];
-  }
+  $input['modelProps'] = [
+    // Pass through legacy receipt_text.
+    'userEnteredText' => $params['receipt_text'] ?? NULL,
+  ];
   CRM_Contribute_BAO_Contribution::sendMail($input, [], $params['id']);
   return [];
 }

--- a/api/v3/MessageTemplate.php
+++ b/api/v3/MessageTemplate.php
@@ -107,12 +107,9 @@ function civicrm_api3_message_template_send($params) {
       unset($params[$field]);
     }
   }
-  if (!isset($params['model'])) {
-    $params['model'] = [
-      // Pass through legacy receipt_text.
-      'userEnteredText' => $params['tplParams']['receipt_text'] ?? NULL,
-    ];
-  }
+  $params['modelProps'] = [
+    'userEnteredText' => $params['tplParams']['receipt_text'] ?? NULL,
+  ];
   if (empty($params['messageTemplateID'])) {
     if (empty($params['workflow'])) {
       // Can't use civicrm_api3_verify_mandatory for this because it would give the wrong field names

--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -21,9 +21,11 @@
   <tr>
    <td>
      {assign var="greeting" value="{contact.email_greeting_display}"}{if $greeting}<p>{$greeting},</p>{/if}
-    {if !empty($receipt_text)}
-     <p>{$receipt_text|htmlize}</p>
-    {/if}
+     {if $userText}
+       <p>{$userText}</p>
+     {elseif {contribution.contribution_page_id.receipt_text|boolean}}
+       <p>{contribution.contribution_page_id.receipt_text}</p>
+     {/if}
 
     {if $is_pay_later}
      <p>{$pay_later_receipt}</p> {* FIXME: this might be text rather than HTML *}


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4948 Fix online_receipt template to include receipt text

Before
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/4948 the receipt text is missing

After
----------------------------------------
It's rendered by template

Technical Details
----------------------------------------
The reporter confirmed the token works. I also included `userText`  because that could get into the template from apiv3 Contribution.sendconfirmation - and there is test cover to ensure it does

Comments
----------------------------------------
This doesn't really solve it for existing sites but the reporter has manually adjusted their template so current priority is just to get the default template right
