### PR TITLE
Update file ID in entity field on file upload in Afform

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
@@ -89,7 +89,7 @@ class SubmitFile extends AbstractProcessor {
       ],
     ];
 
-    if ($this->isCustomField($this->fieldName)) {
+    if ($this->isCustomField($apiEntity, $this->fieldName)) {
       $attachmentParams['field_name'] = $this->convertFieldNameToApi3($apiEntity, $this->fieldName);
     }
     else {
@@ -98,7 +98,7 @@ class SubmitFile extends AbstractProcessor {
 
     $file = civicrm_api3('Attachment', 'create', $attachmentParams);
 
-    if (!$this->isCustomField($this->fieldName)) {
+    if (!$this->isCustomField($apiEntity, $this->fieldName)) {
       civicrm_api4($apiEntity, 'update', [
         'values' => [
           $idField => $entityId,
@@ -144,8 +144,9 @@ class SubmitFile extends AbstractProcessor {
     return $fieldName;
   }
 
-  private function isCustomField(string $fieldName): bool {
-    return strpos($fieldName, '.') !== FALSE;
+  private function isCustomField(string $entityName, string $fieldName): bool {
+    $field = static::getEntityField($entityName, $fieldName);
+    return !empty($field['custom_field_id']);
   }
 
 }

--- a/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
@@ -89,7 +89,7 @@ class SubmitFile extends AbstractProcessor {
       ],
     ];
 
-    if (strpos($this->fieldName, '.')) {
+    if ($this->isCustomField($this->fieldName)) {
       $attachmentParams['field_name'] = $this->convertFieldNameToApi3($apiEntity, $this->fieldName);
     }
     else {
@@ -98,13 +98,13 @@ class SubmitFile extends AbstractProcessor {
 
     $file = civicrm_api3('Attachment', 'create', $attachmentParams);
 
-    // Update multi-record custom field with value
-    if (strpos($apiEntity, 'Custom_') === 0) {
+    if (!$this->isCustomField($this->fieldName)) {
       civicrm_api4($apiEntity, 'update', [
         'values' => [
           $idField => $entityId,
           $this->fieldName => $file['id'],
         ],
+        'checkPermissions' => FALSE,
       ]);
     }
 
@@ -142,6 +142,10 @@ class SubmitFile extends AbstractProcessor {
       return 'custom_' . $fields[0]['custom_field_id'];
     }
     return $fieldName;
+  }
+
+  private function isCustomField(string $fieldName): bool {
+    return strpos($fieldName, '.') !== FALSE;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This PR calls the entity `update` action to set the new file ID on file upload in Affom.

Before
----------------------------------------
On Afform file upload the entity field containing the file ID is not updated.

After
----------------------------------------
On Afform file upload the entity field containing the file ID is updated.

Technical Details
----------------------------------------
A possible previous file is not deleted. Is that something that should be done, too? Or is it in the responsibility of the entity `update` action?
