### PR TITLE
SearchKit - Remove irrelevant links from default display

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetDefault.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetDefault.php
@@ -146,10 +146,10 @@ class GetDefault extends \Civi\Api4\Generic\AbstractAction {
    */
   public function getLinksMenu() {
     $menu = [];
-    $discard = array_flip(['add', 'browse']);
+    $exclude = ['add', 'browse'];
     $mainEntity = $this->savedSearch['api_entity'] ?? NULL;
     if ($mainEntity && !$this->canAggregate(CoreUtil::getIdFieldName($mainEntity))) {
-      foreach (array_diff_key(Display::getEntityLinks($mainEntity, TRUE), $discard) as $link) {
+      foreach (Display::getEntityLinks($mainEntity, TRUE, $exclude) as $link) {
         $link['join'] = NULL;
         $menu[] = $link;
       }
@@ -159,7 +159,7 @@ class GetDefault extends \Civi\Api4\Generic\AbstractAction {
       if (!$this->canAggregate($join['alias'] . '.' . CoreUtil::getIdFieldName($join['entity']))) {
         foreach (array_filter(array_intersect_key($join, $keys)) as $joinEntity) {
           $joinLabel = $this->getJoinLabel($join['alias']);
-          foreach (array_diff_key(Display::getEntityLinks($joinEntity, $joinLabel), $discard) as $link) {
+          foreach (Display::getEntityLinks($joinEntity, $joinLabel, $exclude) as $link) {
             $link['join'] = $join['alias'];
             $menu[] = $link;
           }

--- a/ext/search_kit/Civi/Search/Display.php
+++ b/ext/search_kit/Civi/Search/Display.php
@@ -54,14 +54,19 @@ class Display {
    * @param string|bool $addLabel
    *   Pass a string to supply a custom label, TRUE to use the default,
    *   or FALSE to keep the %1 placeholders in the text (used for the admin UI)
+   * @param array|null $excludeActions
    * @return array[]
    */
-  public static function getEntityLinks(string $entity, $addLabel = FALSE): array {
-    $links = (array) civicrm_api4($entity, 'getLinks', [
+  public static function getEntityLinks(string $entity, $addLabel = FALSE, array $excludeActions = NULL): array {
+    $apiParams = [
       'checkPermissions' => FALSE,
       'entityTitle' => $addLabel,
       'select' => ['ui_action', 'entity', 'text', 'icon', 'target'],
-    ]);
+    ];
+    if ($excludeActions) {
+      $apiParams['where'][] = ['ui_action', 'NOT IN', $excludeActions];
+    }
+    $links = (array) civicrm_api4($entity, 'getLinks', $apiParams);
     $styles = [
       'delete' => 'danger',
       'add' => 'primary',

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -227,6 +227,12 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertCount(1, $result[1]['columns'][1]['links']);
     $this->assertCount(1, $result[2]['columns'][0]['links']);
     $this->assertCount(1, $result[2]['columns'][1]['links']);
+    $this->assertContains('View Group', array_column($result[0]['columns'][2]['links'], 'text'));
+    $this->assertContains('Update Group', array_column($result[0]['columns'][2]['links'], 'text'));
+    $this->assertContains('Delete Group', array_column($result[0]['columns'][2]['links'], 'text'));
+    // Add and browse links should not be shown in rows
+    $this->assertNotContains('Add Group', array_column($result[0]['columns'][2]['links'], 'text'));
+    $this->assertNotContains('Browse Group', array_column($result[0]['columns'][2]['links'], 'text'));
     // No contact links in 1st row since the group is empty
     $this->assertNotContains('View Contact', array_column($result[0]['columns'][2]['links'], 'text'));
     $this->assertNotContains('Delete Contact', array_column($result[0]['columns'][2]['links'], 'text'));
@@ -234,6 +240,9 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertContains('Delete Contact', array_column($result[1]['columns'][2]['links'], 'text'));
     $this->assertContains('View Contact', array_column($result[2]['columns'][2]['links'], 'text'));
     $this->assertContains('Delete Contact', array_column($result[2]['columns'][2]['links'], 'text'));
+    // Add and browse links should not be shown in rows
+    $this->assertNotContains('Add Contact', array_column($result[1]['columns'][2]['links'], 'text'));
+    $this->assertNotContains('Browse Contact', array_column($result[2]['columns'][2]['links'], 'text'));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Removes some links that shouldn't be there in the default search display.

Before
----------------------------------------
1. Click "New Search" in search kit (the default search for contacts is fine).
2. Click the "Search" button.
3. Notice the dropdown of links for each row contains an "Add contact" link that shouldn't be there.

After
----------------------------------------
Errant "Add" and "Browse" links back to being hidden.

Technical Details
----------------------------------------
The action filtering regressed in 5.70 when switching search displays to use the GetLinks api action.
This fixes the filtering & makes it more efficient by passing the filter to the api.