### PR TITLE
dev/core#4950 - Disable SearchUI version of ContactSummary Activity tab

### DIFF
--- a/ext/civicrm_admin_ui/ang/afsearchTabActivity.aff.php
+++ b/ext/civicrm_admin_ui/ang/afsearchTabActivity.aff.php
@@ -4,7 +4,8 @@ return [
   'type' => 'search',
   'title' => ts('Activities'),
   'description' => '',
-  'contact_summary' => 'tab',
+  // Disabled temporarily for https://lab.civicrm.org/dev/core/-/issues/4950
+  // 'placement' => ['contact_summary_tab'],
   'summary_weight' => 70,
   'icon' => 'fa-tasks',
   'permission' => [


### PR DESCRIPTION
Overview
----------------------------------------
This temporarily disables the new tab while we assess query performance problems.
See https://lab.civicrm.org/dev/core/-/issues/4950

Before
----------------------------------------
Slow query in new version of tab for some sites.

After
----------------------------------------
New tab reverted in favor of old tab, for now.

Comments
----------------------------------------
Note: commented out code uses the new 'placement' option which is preferred over the legacy 'contact_summary' flag.

