### PR TITLE
Pass variables into validatePriceSet rather than getting from the form

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1249,19 +1249,18 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    * User should select at least one price field option.
    *
    * @param array $params
+   * @param array $feeBlock
+   * @param int $priceSetId
+   * @param array $priceSetDetails
    *
    * @return array
    */
-  protected function validatePriceSet($params) {
+  protected static function validatePriceSet(array $params, $feeBlock, $priceSetId, $priceSetDetails) {
     $errors = [];
     $hasOptMaxValue = FALSE;
     if (!is_array($params) || empty($params)) {
       return $errors;
     }
-    $form = $this;
-
-    $priceSetId = $form->get('priceSetId');
-    $priceSetDetails = $form->get('priceSet');
     if (
       !$priceSetId ||
       !is_array($priceSetDetails) ||
@@ -1285,7 +1284,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $hasOptCount = TRUE;
       $optionsCountDetails = $priceSetDetails['optionsCountDetails']['fields'];
     }
-    $feeBlock = $form->_feeBlock;
 
     if (empty($feeBlock)) {
       $feeBlock = $priceSetDetails['fields'];

--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -502,7 +502,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
         $totalParticipants = self::getParticipantCount($self, $allParticipantParams);
 
         //validate price field params.
-        $priceSetErrors = $self->validatePriceSet($allParticipantParams);
+        $priceSetErrors = $self->validatePriceSet($allParticipantParams, $self->_feeBlock, $self->get('priceSetId'), $self->get('priceSet'));
         $errors = array_merge($errors, CRM_Utils_Array::value($addParticipantNum, $priceSetErrors, []));
 
         if (!$self->_allowConfirmation &&

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -353,7 +353,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       if (!empty($form->_priceSetId) &&
         !$form->_requireApproval && !$form->_allowWaitlist
       ) {
-        $errors = $form->validatePriceSet($form->_params);
+        $errors = $form->validatePriceSet($form->_params, $form->_params, $form->_priceSetId, $form->get('priceSet'));
         if (!empty($errors)) {
           CRM_Core_Session::setStatus(ts('You have been returned to the start of the registration process and any sold out events have been removed from your selections. You will not be able to continue until you review your booking and select different events if you wish.'), ts('Unfortunately some of your options have now sold out for one or more participants.'), 'error');
           CRM_Core_Session::setStatus(ts('Please note that the options which are marked or selected are sold out for participant being viewed.'), ts('Sold out:'), 'error');

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -702,7 +702,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       //format params.
       $formatted = self::formatPriceSetParams($form, $fields);
       $ppParams = [$formatted];
-      $priceSetErrors = $form->validatePriceSet($ppParams);
+      $priceSetErrors = $form->validatePriceSet($ppParams, $form->_feeBlock, $fields['priceSetId'], $form->get('priceSet'));
       $primaryParticipantCount = self::getParticipantCount($form, $ppParams);
 
       //get price set fields errors in.


### PR DESCRIPTION
Overview
----------------------------------------
Pass variables into validatePriceSet rather than getting from the form

Before
----------------------------------------
The function `validatePriceSet` requires calling functions to ensure things are set on the form

After
----------------------------------------
The form can pass in the variables from where it sees fit


Technical Details
----------------------------------------
Supports follow up removal of undefined properties because functions are setting `_feeBlock` just so this function can access them

Comments
----------------------------------------
