### PR TITLE
don't create duplicate contacts when sending test emails

### DIFF
--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -671,13 +671,9 @@ function civicrm_api3_mailing_send_test($params) {
   $testEmailParams['emails'] = array_key_exists('test_email', $testEmailParams) ? explode(',', strtolower($testEmailParams['test_email'] ?? '')) : NULL;
   if (!empty($params['test_email'])) {
     $query = CRM_Utils_SQL_Select::from('civicrm_email e')
-      ->select(['e.id', 'e.contact_id', 'e.email'])
+      ->select(['e.id', 'e.contact_id', 'e.email', 'e.on_hold', 'c.is_opt_out', 'c.do_not_email', 'c.is_deceased'])
       ->join('c', 'INNER JOIN civicrm_contact c ON e.contact_id = c.id')
       ->where('e.email IN (@emails)', ['@emails' => $testEmailParams['emails']])
-      ->where('e.on_hold = 0')
-      ->where('c.is_opt_out = 0')
-      ->where('c.do_not_email = 0')
-      ->where('c.is_deceased = 0')
       ->where('c.is_deleted = 0')
       ->groupBy('e.id')
       ->orderBy(['e.is_bulkmail DESC', 'e.is_primary DESC'])
@@ -689,16 +685,22 @@ function civicrm_api3_mailing_send_test($params) {
       $emailDetail[strtolower($dao->email)] = [
         'contact_id' => $dao->contact_id,
         'email_id' => $dao->id,
+        'is_opt_out' => $dao->is_opt_out,
+        'do_not_email' => $dao->do_not_email,
+        'is_deceased' => $dao->is_deceased,
       ];
     }
-    foreach ($testEmailParams['emails'] as $key => $email) {
+    foreach ($testEmailParams['emails'] as $email) {
       $email = trim($email);
       $contactId = $emailId = NULL;
       if (array_key_exists($email, $emailDetail)) {
+        if ($emailDetail[$email]['is_opt_out'] || $emailDetail[$email]['do_not_email'] || $emailDetail[$email]['is_deceased']) {
+          continue;
+        }
         $emailId = $emailDetail[$email]['email_id'];
         $contactId = $emailDetail[$email]['contact_id'];
       }
-      if (!$contactId && CRM_Core_Permission::check('add contacts')) {
+      elseif (!$contactId && CRM_Core_Permission::check('add contacts')) {
         //create new contact.
         $contact   = civicrm_api3('Contact', 'create',
           [

--- a/ext/civi_mail/ang/crmMailing/services.js
+++ b/ext/civi_mail/ang/crmMailing/services.js
@@ -545,7 +545,7 @@
             .then(function (deliveryInfos) {
               var count = Object.keys(deliveryInfos).length;
               if (count === 0) {
-                CRM.alert(ts('Could not identify any recipients. Perhaps your test group is empty, or you tried sending to contacts that do not exist and you have no permission to add contacts.'));
+                CRM.alert(ts('Could not identify any recipients. Perhaps your test group is empty, all contacts are set to deceased/opt out/do_not_email, or you tried sending to contacts that do not exist and you have no permission to add contacts.'));
               }
             })
           ;

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -460,10 +460,16 @@ class api_v3_MailingTest extends CiviUnitTestCase {
       'first_name' => 'Alice',
       'last_name' => 'Person',
     ]);
+    $contactIDs['bob'] = $this->individualCreate([
+      'email' => 'bob@example.org',
+      'first_name' => 'Bob',
+      'last_name' => 'Person',
+      'do_not_email' => 1,
+    ]);
 
     $mail = $this->callAPISuccess('mailing', 'create', $this->_params);
 
-    $params = ['mailing_id' => $mail['id'], 'test_email' => 'ALicE@example.org', 'test_group' => NULL];
+    $params = ['mailing_id' => $mail['id'], 'test_email' => 'ALicE@example.org,bob@example.org', 'test_group' => NULL];
     // Per https://lab.civicrm.org/dev/core/issues/229 ensure this is not passed through!
     // Per https://lab.civicrm.org/dev/mail/issues/32 test non-lowercase email
     $params['id'] = $mail['id'];


### PR DESCRIPTION
Overview
----------------------------------------
Sending test emails to contacts who have an email but shouldn't receive email (by virtual of having the "do not mail", "opt out", or "is deceased" flags) creates a duplicate contact.

You can replicate this by sending a test email to a contact with one of the above flags set.

Before
----------------------------------------
Duplicate contacts created.

After
----------------------------------------
No duplicate created.  "No recipients found" warning is updated to account for this scenario.