### PR TITLE
dev/core#4964 careful where we splice in reference ids in afform

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -349,10 +349,12 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
       foreach ($record['fields'] as $field => $value) {
         if (array_intersect($entityNames, (array) $value) && $this->getEntityField($entityType, $field)['input_type'] === 'EntityRef') {
           if (is_array($value)) {
-            foreach ($value as $i => $val) {
+            foreach ($value as $val) {
               if (in_array($val, $entityNames, TRUE)) {
                 $refIds = array_filter(array_column($this->_entityIds[$val], 'id'));
-                array_splice($records[$key]['fields'][$field], $i, 1, $refIds);
+                // replace the reference element in the field value array with found id(s)
+                $refPosition = array_search($val, $records[$key]['fields'][$field]);
+                array_splice($records[$key]['fields'][$field], $refPosition, 1, $refIds);
               }
             }
           }


### PR DESCRIPTION
Fix for unexpected behaviour if some of the reference IDs are missing - example of impact here https://lab.civicrm.org/dev/core/-/issues/4964

In general seems dangerous to rely on the $i index from the foreach loop given we're editing the array as we go - so check the position to splice right before we do it.