### PR TITLE
dev/core#4965 Afform: check we know the contact type to be able to check we have a contact name

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -247,7 +247,10 @@ class Submit extends AbstractProcessor {
       if (!empty($contact['fields']['id'])) {
         continue;
       }
-      if (empty($contact['fields']) || \CRM_Contact_BAO_Contact::hasName($contact['fields'])) {
+      if (
+        in_array($contact['fields']['contact_type'] ?? '', ['Individual', 'Household', 'Organization'])
+        && \CRM_Contact_BAO_Contact::hasName($contact['fields'])
+       ) {
         continue;
       }
       foreach ($contact['joins']['Email'] ?? [] as $email) {


### PR DESCRIPTION
Prevents a crash in questionable use case of contact without explicit contact_type, set out here https://lab.civicrm.org/dev/core/-/issues/4965

The `is_empty($contact['fields])` seems weird at any rate -- has an effect like "if the fields are null, dont set them to null".