### PR TITLE
Stop calculating optionsCountDetails in non-unshared function on participantFeeSelection

### DIFF
--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -725,39 +725,20 @@ SELECT  id, html_type
     $form->_values['fee'] = $form->_priceSet['fields'] ?? NULL;
 
     //get the price set fields participant count.
-    //get option count info.
-    $form->_priceSet['optionsCountTotal'] = CRM_Price_BAO_PriceSet::getPricesetCount($priceSetId);
-    if ($form->_priceSet['optionsCountTotal']) {
-      $optionsCountDetails = [];
-      if (!empty($form->_priceSet['fields'])) {
-        foreach ($form->_priceSet['fields'] as $field) {
-          foreach ($field['options'] as $option) {
-            $count = $option['count'] ?? 0;
-            $optionsCountDetails['fields'][$field['id']]['options'][$option['id']] = $count;
-          }
-        }
-      }
-      $form->_priceSet['optionsCountDetails'] = $optionsCountDetails;
-    }
-
     //get option max value info.
     $optionsMaxValueTotal = 0;
-    $optionsMaxValueDetails = [];
 
     if (!empty($form->_priceSet['fields'])) {
       foreach ($form->_priceSet['fields'] as $field) {
         foreach ($field['options'] as $option) {
           $maxVal = $option['max_value'] ?? 0;
-          $optionsMaxValueDetails['fields'][$field['id']]['options'][$option['id']] = $maxVal;
           $optionsMaxValueTotal += $maxVal;
         }
       }
     }
 
     $form->_priceSet['optionsMaxValueTotal'] = $optionsMaxValueTotal;
-    if ($optionsMaxValueTotal) {
-      $form->_priceSet['optionsMaxValueDetails'] = $optionsMaxValueDetails;
-    }
+
     $form->set('priceSet', $form->_priceSet);
 
     $eventFee = $form->_values['fee'] ?? NULL;


### PR DESCRIPTION

Overview
----------------------------------------
Stop calculating optionsCountDetails & related properties for calculating how many additional participants can register in on-line form flow, in non-unshared function on participantFeeSelection

The value is used in the form it used to share with but not in this  back office form

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/74300745-51c0-4c66-bddb-d132121438b7)

![image](https://github.com/civicrm/civicrm-core/assets/336308/47936f37-cdc8-4f0d-9771-53fc2c85e677)

![image](https://github.com/civicrm/civicrm-core/assets/336308/a42fa873-f1e4-423c-82db-580a59b64af1)


After
----------------------------------------
poof

Technical Details
----------------------------------------
This is what you get when you don't share...

Comments
----------------------------------------
