### PR TITLE
APIv4 - Add type hints to FieldSpec functions

### DIFF
--- a/Civi/Api4/Service/Spec/FieldSpec.php
+++ b/Civi/Api4/Service/Spec/FieldSpec.php
@@ -124,7 +124,7 @@ class FieldSpec {
    *
    * @return $this
    */
-  public function setEntity($entity) {
+  public function setEntity(string $entity) {
     $this->entity = $entity;
 
     return $this;
@@ -133,14 +133,14 @@ class FieldSpec {
   /**
    * @return string
    */
-  public function getEntity() {
+  public function getEntity(): ?string {
     return $this->entity;
   }
 
   /**
    * @return bool
    */
-  public function getNullable() {
+  public function getNullable(): bool {
     return $this->nullable;
   }
 
@@ -158,7 +158,7 @@ class FieldSpec {
   /**
    * @return bool
    */
-  public function isRequired() {
+  public function isRequired(): bool {
     return $this->required;
   }
 
@@ -167,7 +167,7 @@ class FieldSpec {
    *
    * @return $this
    */
-  public function setRequired($required) {
+  public function setRequired(bool $required) {
     $this->required = $required;
 
     return $this;
@@ -176,16 +176,16 @@ class FieldSpec {
   /**
    * @return string
    */
-  public function getRequiredIf() {
+  public function getRequiredIf(): ?string {
     return $this->requiredIf;
   }
 
   /**
-   * @param string $requiredIf
+   * @param string|null $requiredIf
    *
    * @return $this
    */
-  public function setRequiredIf($requiredIf) {
+  public function setRequiredIf(?string $requiredIf) {
     $this->requiredIf = $requiredIf;
 
     return $this;
@@ -244,8 +244,8 @@ class FieldSpec {
    * @param bool $readonly
    * @return $this
    */
-  public function setReadonly($readonly) {
-    $this->readonly = (bool) $readonly;
+  public function setReadonly(bool $readonly) {
+    $this->readonly = $readonly;
 
     return $this;
   }
@@ -254,8 +254,8 @@ class FieldSpec {
    * @param bool $deprecated
    * @return $this
    */
-  public function setDeprecated($deprecated) {
-    $this->deprecated = (bool) $deprecated;
+  public function setDeprecated(bool $deprecated) {
+    $this->deprecated = $deprecated;
 
     return $this;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Improves APIv4 code with some php7 type hints.