### PR TITLE
FIx show-hide notices on event confirm

### DIFF
--- a/CRM/Core/ShowHideBlocks.php
+++ b/CRM/Core/ShowHideBlocks.php
@@ -82,8 +82,8 @@ class CRM_Core_ShowHideBlocks {
 
     $template = CRM_Core_Smarty::singleton();
     $template->ensureVariablesAreAssigned(['elemType']);
-    $template->assign_by_ref('hideBlocks', $hide);
-    $template->assign_by_ref('showBlocks', $show);
+    $template->assign('hideBlocks', $hide);
+    $template->assign('showBlocks', $show);
   }
 
   /**

--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -186,4 +186,3 @@
         </div>
     {/if}
 </div>
-{include file="CRM/common/showHide.tpl"}


### PR DESCRIPTION
Overview
----------------------------------------
FIx show-hide notices on event confirm, drop deprecated assign_by_ref - removed in Smarty5

Before
----------------------------------------
lots of notices

After
----------------------------------------
Gone


Technical Details
----------------------------------------
The php layer only invokes this from back office forms (those Field & Group entries are admin forms ) - the inclusion looks like copy & paste or other legacy behaviour

![image](https://github.com/civicrm/civicrm-core/assets/336308/bc794375-07b2-4b7f-823d-d1bb628839e6)

Comments
----------------------------------------
