### PR TITLE
[php8.2] Clean up the 2 forms that support Group-extending custom data for notices, php8.2 compliance

### DIFF
--- a/CRM/Contact/Form/Task/AddToGroup.php
+++ b/CRM/Contact/Form/Task/AddToGroup.php
@@ -22,6 +22,7 @@
  * addition of contacts to groups.
  */
 class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
+  use CRM_Custom_Form_CustomDataTrait;
 
   /**
    * The context that we are working on
@@ -52,9 +53,13 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
     parent::preProcess();
 
     $this->_context = $this->get('context');
-    $this->_id = $this->get('amtgID');
 
-    CRM_Custom_Form_CustomData::preProcess($this, NULL, NULL, 1, 'Group', $this->_id);
+    $this->assign('entityID', $this->getGroupID());
+  }
+
+  public function getGroupID(): ?int {
+    $this->_id = $this->get('amtgID');
+    return $this->_id ? (int) $this->_id : NULL;
   }
 
   /**
@@ -117,8 +122,9 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
     }
     else {
       $this->setTitle(ts('Add Contacts to A Group'));
-      //build custom data
-      CRM_Custom_Form_CustomData::buildQuickForm($this);
+    }
+    if ($this->isSubmitted()) {
+      $this->addCustomDataFieldsToForm('Group');
     }
 
     $this->addDefaultButtons(ts('Add to Group'));
@@ -139,7 +145,6 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
     }
 
     $defaults['group_option'] = 0;
-    $defaults += CRM_Custom_Form_CustomData::setDefaultValues($this);
     return $defaults;
   }
 
@@ -155,7 +160,7 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
    *
    * @param array $params
    *
-   * @return array
+   * @return array|true
    *   list of errors to be posted back to the form
    */
   public static function formRule($params) {
@@ -174,7 +179,7 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
   /**
    * Process the form after the input has been submitted and validated.
    */
-  public function postProcess() {
+  public function postProcess(): void {
     $params = $this->controller->exportValues();
     $groupOption = $params['group_option'] ?? NULL;
     if ($groupOption) {
@@ -184,7 +189,7 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
       $groupParams['visibility'] = 'User and User Admin Only';
       $groupParams['group_type'] = array_keys($params['group_type'] ?? []);
       $groupParams['is_active'] = 1;
-      $groupParams['custom'] = CRM_Core_BAO_CustomField::postProcess($params, $this->_id, 'Group');
+      $groupParams['custom'] = CRM_Core_BAO_CustomField::postProcess($this->getSubmittedValues(), $this->_id, 'Group');
 
       $createdGroup = CRM_Contact_BAO_Group::create($groupParams);
       $groupID = $createdGroup->id;
@@ -196,7 +201,7 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
       $groupName = $group[$groupID];
     }
 
-    list($total, $added, $notAdded) = CRM_Contact_BAO_GroupContact::addContactsToGroup($this->_contactIds, $groupID);
+    [$total, $added, $notAdded] = CRM_Contact_BAO_GroupContact::addContactsToGroup($this->_contactIds, $groupID);
 
     $status = [
       ts('%count contact added to group', [

--- a/CRM/Contact/Form/Task/SaveSearch.php
+++ b/CRM/Contact/Form/Task/SaveSearch.php
@@ -21,6 +21,7 @@
  * Saved Searches are used for saving frequently used queries
  */
 class CRM_Contact_Form_Task_SaveSearch extends CRM_Contact_Form_Task {
+  use CRM_Custom_Form_CustomDataTrait;
 
   /**
    * Saved search id if any.
@@ -51,12 +52,7 @@ class CRM_Contact_Form_Task_SaveSearch extends CRM_Contact_Form_Task {
     }
 
     // Get Task name
-    $modeValue = CRM_Contact_Form_Search::getModeValue(CRM_Utils_Array::value('component_mode', $values, CRM_Contact_BAO_Query::MODE_CONTACTS));
-    $className = $modeValue['taskClassName'];
     $this->_task = $values['task'] ?? NULL;
-
-    // Add group custom data
-    CRM_Custom_Form_CustomData::preProcess($this, NULL, NULL, 1, 'Group');
   }
 
   /**
@@ -65,12 +61,17 @@ class CRM_Contact_Form_Task_SaveSearch extends CRM_Contact_Form_Task {
    * It consists of
    *    - displaying the QILL (query in local language)
    *    - displaying elements for saving the search
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function buildQuickForm() {
+  public function buildQuickForm(): void {
     // @todo sync this more with CRM_Group_Form_Edit.
     $query = new CRM_Contact_BAO_Query($this->get('queryParams'));
     $this->assign('qill', $query->qill());
 
+    if ($this->isSubmitted()) {
+      $this->addCustomDataFieldsToForm('Group');
+    }
     // Values from the search form
     $formValues = $this->controller->exportValues();
 
@@ -107,9 +108,6 @@ class CRM_Contact_Form_Task_SaveSearch extends CRM_Contact_Form_Task {
     //CRM-14190
     CRM_Group_Form_Edit::buildParentGroups($this);
     CRM_Group_Form_Edit::buildGroupOrganizations($this);
-
-    // Build custom data
-    CRM_Custom_Form_CustomData::buildQuickForm($this);
 
     // get the group id for the saved search
     $groupID = NULL;
@@ -216,7 +214,7 @@ class CRM_Contact_Form_Task_SaveSearch extends CRM_Contact_Form_Task {
       $params['id'] = CRM_Contact_BAO_SavedSearch::getName($this->_id, 'id');
     }
 
-    $params['custom'] = CRM_Core_BAO_CustomField::postProcess($formValues, $this->_id, 'Group');
+    $params['custom'] = CRM_Core_BAO_CustomField::postProcess($this->getSubmittedValues(), $this->_id, 'Group');
 
     $group = CRM_Contact_BAO_Group::create($params);
 
@@ -250,7 +248,6 @@ class CRM_Contact_Form_Task_SaveSearch extends CRM_Contact_Form_Task {
     if (empty($defaults['parents'])) {
       $defaults['parents'] = CRM_Core_BAO_Domain::getGroupId();
     }
-    $defaults += CRM_Custom_Form_CustomData::setDefaultValues($this);
     return $defaults;
   }
 

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -21,6 +21,7 @@
 class CRM_Group_Form_Edit extends CRM_Core_Form {
 
   use CRM_Core_Form_EntityFormTrait;
+  use CRM_Custom_Form_CustomDataTrait;
 
   /**
    * The group object, if an id is present
@@ -44,13 +45,6 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
   protected $_groupValues;
 
   /**
-   * What blocks should we show and hide.
-   *
-   * @var CRM_Core_ShowHideBlocks
-   */
-  protected $_showHide;
-
-  /**
    * The civicrm_group_organization table id
    *
    * @var int
@@ -60,7 +54,7 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
   /**
    * Set entity fields to be assigned to the form.
    */
-  protected function setEntityFields() {
+  protected function setEntityFields(): void {
     $this->entityFields = [
       'frontend_title' => ['name' => 'frontend_title', 'required' => TRUE],
       'frontend_description' => ['name' => 'frontend_description'],
@@ -159,9 +153,6 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
       $session->pushUserContext(CRM_Utils_System::url('civicrm/group', 'reset=1'));
     }
     $this->addExpectedSmartyVariables(['freezeMailingList', 'hideMailingList']);
-
-    //build custom data
-    CRM_Custom_Form_CustomData::preProcess($this, NULL, NULL, 1, 'Group', $this->_id);
   }
 
   /**
@@ -201,14 +192,11 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
       }
     }
 
-    $parentGroupIds = explode(',', $this->_groupValues['parents']);
+    $parentGroupIds = explode(',', ($this->_groupValues['parents'] ?? ''));
     $defaults['parents'] = $parentGroupIds;
     if (empty($defaults['parents'])) {
       $defaults['parents'] = CRM_Core_BAO_Domain::getGroupId();
     }
-
-    // custom data set defaults
-    $defaults += CRM_Custom_Form_CustomData::setDefaultValues($this);
     return $defaults;
   }
 
@@ -216,7 +204,7 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
    * Build the form object.
    */
   public function buildQuickForm() {
-    self::buildQuickEntityForm();
+    $this->buildQuickEntityForm();
     if ($this->_action & CRM_Core_Action::DELETE) {
       return;
     }
@@ -253,8 +241,9 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
     }
     $this->addElement('checkbox', 'is_active', ts('Is active?'));
 
-    //build custom data
-    CRM_Custom_Form_CustomData::buildQuickForm($this);
+    if ($this->isSubmitted()) {
+      $this->addCustomDataFieldsToForm('Group');
+    }
 
     $options = [
       'selfObj' => $this,
@@ -271,7 +260,7 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
    * @param array $fileParams
    * @param array $options
    *
-   * @return array
+   * @return array|true
    *   list of errors to be posted back to the form
    */
   public static function formRule($fields, $fileParams, $options) {
@@ -333,7 +322,7 @@ WHERE  title = %1
 
       $params['is_reserved'] ??= FALSE;
       $params['is_active'] ??= FALSE;
-      $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
+      $params['custom'] = CRM_Core_BAO_CustomField::postProcess($this->getSubmittedValues(),
         $this->_id,
         'Group'
       );
@@ -421,7 +410,7 @@ WHERE  title = %1
    *
    * @param CRM_Core_Form $form
    */
-  public static function buildGroupOrganizations(&$form) {
+  public static function buildGroupOrganizations($form) {
     if (CRM_Core_Permission::check('administer Multiple Organizations') && CRM_Core_Permission::isMultisiteEnabled()) {
       //group organization Element
       $props = ['api' => ['params' => ['contact_type' => 'Organization']]];

--- a/Civi/Test/FormWrapper.php
+++ b/Civi/Test/FormWrapper.php
@@ -340,6 +340,9 @@ class FormWrapper {
 
       case strpos($class, 'Search') !== FALSE:
         $this->form->controller = new \CRM_Contact_Controller_Search();
+        if ($class === 'CRM_Contact_Form_Search_Basic') {
+          $this->form->setAction(\CRM_Core_Action::BASIC);
+        }
         break;
 
       case strpos($class, '_Form_') !== FALSE:

--- a/templates/CRM/Contact/Form/Task/AddToGroup.tpl
+++ b/templates/CRM/Contact/Form/Task/AddToGroup.tpl
@@ -40,7 +40,7 @@
                 </tr>
                 {/if}
                 <tr>
-                  <td colspan=2>{include file="CRM/Custom/Form/CustomData.tpl"}</td>
+                  <td colspan=2>{include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='Group' customDataSubType=false cid=false}</td>
                 </tr>
                 </table>
             </td>
@@ -52,7 +52,6 @@
 </table>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>
-{include file="CRM/common/showHide.tpl"}
 
 {if !$form.group_id.value}
 {literal}

--- a/templates/CRM/Contact/Form/Task/SaveSearch.tpl
+++ b/templates/CRM/Contact/Form/Task/SaveSearch.tpl
@@ -40,7 +40,7 @@
         <td>{$form.group_type.html}</td>
       </tr>
       <tr>
-        <td colspan=2>{include file="CRM/Custom/Form/CustomData.tpl"}</td>
+        <td colspan=2>{include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='Group' customDataSubType=false cid=false}</td>
       </tr>
     {/if}
   </table>

--- a/templates/CRM/Group/Form/Edit.tpl
+++ b/templates/CRM/Group/Form/Edit.tpl
@@ -85,7 +85,7 @@
 
 
     <tr>
-      <td colspan=2>{include file="CRM/Custom/Form/CustomData.tpl"}</td>
+      <td colspan=2>{include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='Group' customDataSubType=false cid=false}</td>
     </tr>
   </table>
 


### PR DESCRIPTION
Overview
----------------------------------------
Clean up the 2 forms that support Group-extending custom data for notices, php8.2 compliance

Before
----------------------------------------
Forms use complex, non php8.2 compliant function to add the group custom data to the forms, various notices

After
----------------------------------------
Ajax method used to load the custom data, unlike the removed functions it has a clear contract 

Technical Details
----------------------------------------
I'm pretty sure the noticey show-hide was another round of copy & paste. I tackled both these forms together because although only one is blocking our test suite they both required the same field to be configured. In addition the slight change in postProcess should handle money formatting

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
