### PR TITLE
Remove call to silly non-php8.2 compliant function

### DIFF
--- a/CRM/Contact/Form/Task/EmailCommon.php
+++ b/CRM/Contact/Form/Task/EmailCommon.php
@@ -25,8 +25,13 @@ class CRM_Contact_Form_Task_EmailCommon {
   /**
    * Pre Process Form Addresses to be used in Quickform
    *
-   * @param CRM_Core_Form $form
+   * This doesn't really do much - use part should be transferred back to caller
+   * and noisy deprecation added.
+   *
+   * @param \CRM_Contribute_Form_Task_Invoice $form
    * @param bool $bounce determine if we want to throw a status bounce.
+   *
+   * @deprecated
    *
    * @throws \CRM_Core_Exception
    */


### PR DESCRIPTION
Overview
----------------------------------------
Remove call to silly non-php8.2 compliant function

Before
----------------------------------------
Non-compliant function doesn't do that much - but it does make php8.2 tests fail

After
----------------------------------------
Property no longer set, another test will pass

Technical Details
----------------------------------------

Comments
----------------------------------------
