### PR TITLE
Fold functions that only support one form back into that form (survey)

### DIFF
--- a/CRM/Campaign/Form/Survey/TabHeader.php
+++ b/CRM/Campaign/Form/Survey/TabHeader.php
@@ -16,18 +16,21 @@
  */
 
 /**
- * Helper class to build navigation links
+ * @deprecated since 5.71 will be removed around 5.77
  */
 class CRM_Campaign_Form_Survey_TabHeader {
 
   /**
    * Build tab header.
    *
+   * @deprecated since 5.71 will be removed around 5.77
+   *
    * @param CRM_Core_Form $form
    *
    * @return array
    */
   public static function build(&$form) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     $tabs = $form->get('tabHeader');
     if (!$tabs || empty($_GET['reset'])) {
       $tabs = self::process($form);
@@ -48,8 +51,11 @@ class CRM_Campaign_Form_Survey_TabHeader {
    * @param CRM_Core_Form $form
    *
    * @return array
+   *
+   * @deprecated since 5.71 will be removed around 5.77
    */
   public static function process(&$form) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     if ($form->getVar('_surveyId') <= 0) {
       return NULL;
     }
@@ -110,8 +116,11 @@ class CRM_Campaign_Form_Survey_TabHeader {
 
   /**
    * @param CRM_Core_Form $form
+   *
+   * @deprecated since 5.71 will be removed around 5.77
    */
   public static function reset(&$form) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     $tabs = self::process($form);
     $form->set('tabHeader', $tabs);
   }
@@ -120,8 +129,11 @@ class CRM_Campaign_Form_Survey_TabHeader {
    * @param array $tabs
    *
    * @return int|string
+   *
+   * @deprecated since 5.71 will be removed around 5.77
    */
   public static function getCurrentTab($tabs) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     static $current = FALSE;
 
     if ($current) {
@@ -145,8 +157,11 @@ class CRM_Campaign_Form_Survey_TabHeader {
    * @param CRM_Core_Form $form
    *
    * @return int|string
+   *
+   * @deprecated since 5.71 will be removed around 5.77
    */
   public static function getNextTab(&$form) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     static $next = FALSE;
     if ($next) {
       return $next;


### PR DESCRIPTION
Overview
----------------------------------------

No other universe uses

![image](https://github.com/civicrm/civicrm-core/assets/336308/16e30d4d-c646-42fe-9df9-10d344c3102e)

Before
----------------------------------------
Functions are public & not clearly tied to the form


After
----------------------------------------
private on the relevant

Technical Details
----------------------------------------
There was a pretty strong case for just removing with no deprecation period - so I kept the deprecation to 6 months

Comments
----------------------------------------
