### PR TITLE
Fix notices & php8.2 compatibility on Manage Event Info page

### DIFF
--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -18,6 +18,7 @@
  * This class generates form components for processing Event.
  */
 class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
+  use CRM_Event_Form_EventFormTrait;
 
   /**
    * The id of the event we are processing.
@@ -98,17 +99,12 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
       $this->assign('eventId', $this->_id);
       $this->_single = TRUE;
 
-      $eventInfo = \Civi\Api4\Event::get(FALSE)
-        ->addWhere('id', '=', $this->_id)
-        ->execute()
-        ->first();
-
       // its an update mode, do a permission check
       if (!CRM_Event_BAO_Event::checkPermission($this->_id, CRM_Core_Permission::EDIT)) {
         CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
       }
 
-      $participantListingID = $eventInfo['participant_listing_id'] ?? NULL;
+      $participantListingID = $this->getEventValue('participant_listing_id');
       if ($participantListingID) {
         $participantListingURL = CRM_Utils_System::url('civicrm/event/participant',
           "reset=1&id={$this->_id}",
@@ -117,14 +113,14 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
       }
       $this->assign('participantListingURL', $participantListingURL ?? NULL);
       $this->assign('participantListingID', $participantListingID);
-      $this->assign('isOnlineRegistration', CRM_Utils_Array::value('is_online_registration', $eventInfo));
+      $this->assign('isOnlineRegistration', $this->getEventValue('is_online_registration'));
 
       $this->assign('id', $this->_id);
     }
 
     // figure out whether we’re handling an event or an event template
     if ($this->_id) {
-      $this->_isTemplate = $eventInfo['is_template'] ?? NULL;
+      $this->_isTemplate = $this->getEventValue('is_template');
     }
     elseif ($this->_action & CRM_Core_Action::ADD) {
       $this->_isTemplate = CRM_Utils_Request::retrieve('is_template', 'Boolean', $this);
@@ -136,11 +132,11 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
     $title = NULL;
     if ($this->_id) {
       if ($this->_isTemplate) {
-        $title = ts('Edit Event Template') . ' - ' . ($eventInfo['template_title'] ?? '');
+        $title = ts('Edit Event Template') . ' - ' . ($this->getEventValue('template_title'));
       }
       else {
         $configureText = $this->_isRepeatingEvent ? ts('Configure Repeating Event') : ts('Configure Event');
-        $title = $configureText . ' - ' . ($eventInfo['title'] ?? '');
+        $title = $configureText . ' - ' . $this->getEventValue('title');
       }
     }
     elseif ($this->_action & CRM_Core_Action::ADD) {

--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -20,6 +20,7 @@ use Civi\Api4\Event;
  * This class generates form components for processing Event.
  */
 class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
+  use CRM_Custom_Form_CustomDataTrait;
 
   /**
    * Event type.
@@ -47,10 +48,6 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
       $this->set('subType', $_POST['event_type_id'] ?? '');
       $this->assign('customDataSubType', $_POST['event_type_id'] ?? '');
       $this->set('entityId', $entityID);
-
-      CRM_Custom_Form_CustomData::preProcess($this, NULL, $this->_eventType, 1, 'Event', $entityID);
-      CRM_Custom_Form_CustomData::buildQuickForm($this);
-      CRM_Custom_Form_CustomData::setDefaultValues($this);
     }
   }
 
@@ -188,6 +185,16 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     $this->addElement('checkbox', 'is_active', ts('Is this Event Active?'));
 
     $this->addFormRule(['CRM_Event_Form_ManageEvent_EventInfo', 'formRule']);
+    if ($this->isSubmitted()) {
+      // The custom data fields are added to the form by an ajax form.
+      // However, if they are not present in the element index they will
+      // not be available from `$this->getSubmittedValue()` in post process.
+      // We do not have to set defaults or otherwise render - just add to the element index.
+      $this->addCustomDataFieldsToForm('Event', array_filter([
+        'id' => $this->getEventID(),
+        'event_type_id' => $_POST['event_type_id'],
+      ]));
+    }
 
     parent::buildQuickForm();
   }

--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
@@ -124,7 +124,7 @@
       </tr>
     {/if}
   </table>
-  {include file="CRM/common/customDataBlock.tpl" entityID=$eventID}
+  {include file="CRM/common/customDataBlock.tpl" entityID=$eventID cid=false}
   <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>


### PR DESCRIPTION
Overview
----------------------------------------
Fix notices & php8.2 compatibility on Manage Event Info page

Before
----------------------------------------
Form calling complex non-php8.2 compliant function

After
----------------------------------------
Form calling simple function - as the fields are loaded by ajax

Technical Details
----------------------------------------
I tested with a type-specific field & it did save it OK.  I also fixed the parent to use the event trait

Comments
----------------------------------------
