### PR TITLE
PHP8.2 Fix Financial Account form to load custom data via ajax

### DIFF
--- a/templates/CRM/Financial/Form/FinancialAccount.tpl
+++ b/templates/CRM/Financial/Form/FinancialAccount.tpl
@@ -76,7 +76,7 @@
     </tr>
   </table>
   <details id="financial_account_custom_field_extension_section" class="crm-accordion-wrapper crm-financial-account-panel" open>
-  {include file="CRM/Custom/Form/CustomData.tpl"}
+    {include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='FinancialAccount' customDataSubType=false cid=false}
   </details>
 {/if}
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="botttom"}</div>


### PR DESCRIPTION
Overview
----------------------------------------
Fix Financial Account form to load custom data via ajax

Before
----------------------------------------
Uses non-php8.x compliant function

After
----------------------------------------
uses ajax

Technical Details
----------------------------------------
I also fixed for localised money - ie & as separator

![image](https://github.com/civicrm/civicrm-core/assets/336308/834283e9-1374-4b4d-9b0c-b9da34090c2a)

Comments
----------------------------------------
