### PR TITLE
Afform - use contact-type-specific API entities 

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -43,19 +43,11 @@ class AfformAdminMeta {
   }
 
   /**
-   * Get info about an api entity, with special handling for contact types
+   * Get info about an api entity
    * @param string $entityName
    * @return array|null
    */
   public static function getApiEntity(string $entityName) {
-    $contactTypes = \CRM_Contact_BAO_ContactType::basicTypeInfo();
-    if (isset($contactTypes[$entityName])) {
-      return [
-        'entity' => 'Contact',
-        'contact_type' => $entityName,
-        'label' => $contactTypes[$entityName]['label'],
-      ];
-    }
     $info = \Civi\Api4\Entity::get(FALSE)
       ->addWhere('name', '=', $entityName)
       ->execute()->first();
@@ -99,10 +91,6 @@ class AfformAdminMeta {
       'select' => ['name', 'label', 'input_type', 'input_attrs', 'required', 'options', 'help_pre', 'help_post', 'serialize', 'data_type', 'entity', 'fk_entity', 'readonly', 'operators'],
       'where' => [['deprecated', '=', FALSE], ['input_type', 'IS NOT NULL']],
     ];
-    if (in_array($entityName, \CRM_Contact_BAO_ContactType::basicTypes(TRUE), TRUE)) {
-      $params['values']['contact_type'] = $entityName;
-      $entityName = 'Contact';
-    }
     if ($entityName === 'Address') {
       // The stateProvince option list is waaay too long unless country limits are set
       if (!\Civi::settings()->get('provinceLimit')) {

--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -98,14 +98,7 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
     $scanBlocks = function($layout) use (&$scanBlocks, &$info, &$entities, $allAfforms) {
       // Find declared af-entity tags
       foreach (\CRM_Utils_Array::findAll($layout, ['#tag' => 'af-entity']) as $afEntity) {
-        // Convert "Contact" to "Individual", "Organization" or "Household"
-        if ($afEntity['type'] === 'Contact' && !empty($afEntity['data'])) {
-          $data = \CRM_Utils_JS::decode($afEntity['data']);
-          $entities[] = $data['contact_type'] ?? $afEntity['type'];
-        }
-        else {
-          $entities[] = $afEntity['type'];
-        }
+        $entities[] = $afEntity['type'];
       }
       $joins = array_column(\CRM_Utils_Array::findAll($layout, 'af-join'), 'af-join');
       $entities = array_unique(array_merge($entities, $joins));
@@ -142,10 +135,6 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
       }
       else {
         $scanBlocks($info['definition']['layout']);
-      }
-
-      if (array_intersect($entities, \CRM_Contact_BAO_ContactType::basicTypes(TRUE))) {
-        $entities[] = 'Contact';
       }
 
       // The full contents of blocks used on the form have been loaded. Get basic info about others relevant to these entities.
@@ -213,12 +202,6 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
       $this->loadAvailableBlocks($entities, $info, [['join_entity', 'IS NULL']]);
     }
 
-    // Optimization - since contact fields are a combination of these three,
-    // we'll combine them client-side rather than sending them via ajax.
-    elseif (array_intersect($entities, \CRM_Contact_BAO_ContactType::basicTypes(TRUE))) {
-      $entities = array_diff($entities, ['Contact']);
-    }
-
     foreach (array_diff($entities, $this->skipEntities) as $entity) {
       $info['entities'][$entity] = AfformAdminMeta::getApiEntity($entity);
       $info['fields'][$entity] = AfformAdminMeta::getFields($entity, ['action' => $getFieldsMode]);
@@ -261,6 +244,10 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
     $entities = array_diff($entities, $this->skipEntities);
     if (!$this->skipEntities) {
       $entities[] = '*';
+    }
+    // A block of type "Contact" also applies to "Individual", "Organization" & "Household".
+    if (array_intersect($entities, \CRM_Contact_BAO_ContactType::basicTypes())) {
+      $entities[] = 'Contact';
     }
     if ($entities) {
       $blockInfo = Afform::get($this->checkPermissions)

--- a/ext/afform/admin/afformEntities/Household.php
+++ b/ext/afform/admin/afformEntities/Household.php
@@ -3,7 +3,6 @@ return [
   'type' => 'primary',
   'defaults' => "{
     data: {
-      contact_type: 'Household',
       source: afform.title
     }
   }",

--- a/ext/afform/admin/afformEntities/Individual.php
+++ b/ext/afform/admin/afformEntities/Individual.php
@@ -3,7 +3,6 @@ return [
   'type' => 'primary',
   'defaults' => "{
     data: {
-      contact_type: 'Individual',
       source: afform.title
     }
   }",

--- a/ext/afform/admin/afformEntities/Organization.php
+++ b/ext/afform/admin/afformEntities/Organization.php
@@ -3,7 +3,6 @@ return [
   'type' => 'primary',
   'defaults' => "{
     data: {
-      contact_type: 'Organization',
       source: afform.title
     }
   }",

--- a/ext/afform/admin/ang/afGuiEditor.js
+++ b/ext/afform/admin/ang/afGuiEditor.js
@@ -127,15 +127,6 @@
               CRM.afGuiEditor.entities[entityName].fields = fields;
             }
           });
-          // Optimization - since contact fields are a combination of these three,
-          // the server doesn't send contact fields if sending contact-type fields
-          if ('Individual' in data.fields || 'Household' in data.fields || 'Organization' in data.fields) {
-            CRM.afGuiEditor.entities.Contact.fields = _.assign({},
-              (CRM.afGuiEditor.entities.Individual || {}).fields,
-              (CRM.afGuiEditor.entities.Household || {}).fields,
-              (CRM.afGuiEditor.entities.Organization || {}).fields
-            );
-          }
           _.each(data.search_displays, function(display) {
             CRM.afGuiEditor.searchDisplays[display['saved_search_id.name'] + (display.name ? '.' + display.name : '')] = display;
           });

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -303,9 +303,6 @@
       };
 
       this.getEntityDefn = function(entity) {
-        if (entity.type === 'Contact' && entity.data && entity.data.contact_type) {
-          return editor.meta.entities[entity.data.contact_type];
-        }
         return editor.meta.entities[entity.type];
       };
 

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
@@ -19,7 +19,7 @@
       $scope.elementTitles = [];
 
       this.getEntityType = function() {
-        return (ctrl.entity.type === 'Contact' && ctrl.entity.data) ? ctrl.entity.data.contact_type || 'Contact' : ctrl.entity.type;
+        return ctrl.entity.type;
       };
 
       $scope.getMeta = function() {
@@ -90,7 +90,9 @@
         $scope.blockTitles.length = 0;
         _.each(afGui.meta.blocks, function(block, directive) {
           if ((!search || _.contains(directive, search) || _.contains(block.name.toLowerCase(), search) || _.contains(block.title.toLowerCase(), search)) &&
-            (block.entity_type === '*' || block.entity_type === ctrl.entity.type || (ctrl.entity.type === 'Contact' && block.entity_type === ctrl.entity.data.contact_type)) &&
+            // A block of type "*" applies to everything. A block of type "Contact" also applies to "Individual", "Organization" & "Household".
+            (block.entity_type === '*' || block.entity_type === ctrl.entity.type || (block.entity_type === 'Contact' && ['Individual', 'Household', 'Organization'].includes(ctrl.entity.type))) &&
+            // Prevent recursion
             block.name !== ctrl.editor.getAfform().name
           ) {
             var item = {"#tag": block.join_entity ? "div" : directive};

--- a/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
@@ -38,12 +38,12 @@
               // Static options for choosing current user or other entities on the form
               options = [];
               filters = (field.input_attrs && field.input_attrs.filter) || {};
-              if (field.fk_entity === 'Contact' && (!filters.contact_type || filters.contact_type === 'Individual')) {
+              if (field.fk_entity === 'Individual' || (field.fk_entity === 'Contact' && (!filters.contact_type || filters.contact_type === 'Individual'))) {
                 options.push('user_contact_id');
               }
-              _.each(ctrl.editor ? ctrl.editor.getEntities({type: field.fk_entity}) : [], function(entity) {
+              _.each(ctrl.editor ? ctrl.editor.getEntities() : [], function(entity) {
+                let filtersMatch = (entity.type === field.fk_entity) || (field.fk_entity === 'Contact' && ['Individual', 'Household', 'Organization'].includes(entity.type));
                 // Check if field filters match entity data (e.g. contact_type)
-                var filtersMatch = true;
                 _.each(filters, function(value, key) {
                   if (entity.data && entity.data[key] && entity.data[key] != value) {
                     filtersMatch = false;

--- a/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
+++ b/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
@@ -4,6 +4,7 @@ namespace Civi\Afform\Behavior;
 use Civi\Afform\AbstractBehavior;
 use Civi\Afform\Event\AfformEntitySortEvent;
 use Civi\Afform\Event\AfformPrefillEvent;
+use Civi\Api4\Utils\CoreUtil;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use CRM_Afform_ExtensionUtil as E;
 
@@ -96,7 +97,7 @@ class ContactAutofill extends AbstractBehavior implements EventSubscriberInterfa
   }
 
   public static function onAfformPrefill(AfformPrefillEvent $event): void {
-    if ($event->getEntityType() === 'Contact') {
+    if (CoreUtil::isContact($event->getEntityType())) {
       $entity = $event->getEntity();
       $id = $event->getEntityId();
       $autoFillMode = $entity['autofill'] ?? '';

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -269,7 +269,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
    */
   protected static function getJoinWhereClause(FormDataModel $formDataModel, string $mainEntityName, string $joinEntityType, $mainEntityId) {
     $entity = $formDataModel->getEntity($mainEntityName);
-    $mainEntityType = $entity['type'];
+    $mainEntityType = CoreUtil::isContact($entity['type']) ? 'Contact' : $entity['type'];
     $params = [];
 
     // Add data as clauses e.g. `is_primary: true`

--- a/ext/afform/core/tests/phpunit/Civi/Afform/AfformGetTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/AfformGetTest.php
@@ -87,8 +87,8 @@ class AfformGetTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
           '#children' => [
             [
               '#tag' => 'af-entity',
-              'data' => "{contact_type: 'Individual', source: 'This isn\\'t \"quotes\"'}",
-              'type' => 'Contact',
+              'data' => "{source: 'This isn\\'t \"quotes\"'}",
+              'type' => 'Individual',
               'name' => 'Individual1',
             ],
           ],
@@ -102,7 +102,7 @@ class AfformGetTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
       ->execute()->single()['layout'];
 
     $expected = <<<HTML
-data="{contact_type: 'Individual', source: 'This isn\'t &quot;quotes&quot;'}"
+data="{source: 'This isn\'t &quot;quotes&quot;'}"
 HTML;
 
     $this->assertStringContainsString($expected, $html);
@@ -142,6 +142,36 @@ HTML;
       ->execute()->single();
 
     $this->assertEquals(['foo.foo-bar', 'foo.bar-food'], $result['search_displays']);
+  }
+
+  public function testGetLayoutWithLegacyContactTypeConversion() {
+    Afform::create(FALSE)
+      ->addValue('name', $this->formName)
+      ->addValue('title', 'Test Form')
+      ->addValue('layout', <<<'AFFORM'
+        <af-form>
+          <af-entity type="Contact" data="{'contact_type': 'Organization' num: 1}"></af-entity>
+          <af-entity data="{thing: 2 contact_type: 'Household'}" type="Contact"></af-entity>
+          <af-entity data="{contact_type: 'Individual'}" type='Contact'></af-entity>
+          <fieldset>Hello</fieldset>
+        </af-form>
+        AFFORM
+      )->execute();
+
+    $entity = Afform::get(FALSE)
+      ->addWhere('name', '=', $this->formName)
+      ->setFormatWhitespace(TRUE)
+      ->execute()->single()['layout'][0]['#children'];
+
+    // Legacy contact_type should have been converted to entity type
+    $this->assertEquals('Organization', $entity[0]['type']);
+    $this->assertCount(1, $entity[0]['data']);
+    $this->assertEquals(1, $entity[0]['data']['num']);
+    $this->assertEquals('Household', $entity[1]['type']);
+    $this->assertCount(1, $entity[1]['data']);
+    $this->assertEquals(2, $entity[1]['data']['thing']);
+    $this->assertEquals('Individual', $entity[2]['type']);
+    $this->assertCount(0, $entity[2]['data']);
   }
 
 }

--- a/ext/afform/core/tests/phpunit/Civi/Afform/AfformMetadataTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/AfformMetadataTest.php
@@ -28,7 +28,7 @@ class AfformMetadataTest extends \PHPUnit\Framework\TestCase implements Headless
     $individualFields = \Civi\AfformAdmin\AfformAdminMeta::getFields('Individual');
 
     // Ensure the "Existing" contact field exists
-    $this->assertEquals('Existing Contact', $individualFields['id']['label']);
+    $this->assertEquals('Existing Individual', $individualFields['id']['label']);
     $this->assertEquals('EntityRef', $individualFields['id']['input_type']);
   }
 

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformContactUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformContactUsageTest.php
@@ -16,7 +16,7 @@ class AfformContactUsageTest extends AfformUsageTestCase {
     parent::setUpBeforeClass();
     self::$layouts['aboutMe'] = <<<EOHTML
 <af-form ctrl="modelListCtrl">
-  <af-entity type="Contact" data="{contact_type: 'Individual'}" name="me" label="Myself" url-autofill="1" autofill="user" />
+  <af-entity type="Individual" data="{}" name="me" label="Myself" url-autofill="1" autofill="user" />
   <fieldset af-fieldset="me">
       <af-field name="first_name" />
       <af-field name="last_name" />

--- a/ext/afform/mock/tests/phpunit/api/v4/formatExamples/entity-security.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/formatExamples/entity-security.php
@@ -1,9 +1,9 @@
 <?php
 
 return [
-  'html' => '<af-form ctrl="afform"><af-entity security="FBAC" type="Contact" name="me" data="{contact_type: \'Individual\', source: \'Hello\'}" actions="{create: 1, update: 0}" /></af-form>',
+  'html' => '<af-form ctrl="afform"><af-entity security="FBAC" type="Individual" name="me" data="{source: \'Hello\'}" actions="{create: 1, update: 0}" /></af-form>',
   'pretty' => '<af-form ctrl="afform">
-  <af-entity security="FBAC" type="Contact" name="me" data="{contact_type: \'Individual\', source: \'Hello\'}" actions="{create: 1, update: 0}" />
+  <af-entity security="FBAC" type="Individual" name="me" data="{source: \'Hello\'}" actions="{create: 1, update: 0}" />
 </af-form>
 ',
   'stripped' => [
@@ -14,9 +14,9 @@ return [
         [
           '#tag' => 'af-entity',
           'security' => 'FBAC',
-          'type' => 'Contact',
+          'type' => 'Individual',
           'name' => 'me',
-          'data' => '{contact_type: \'Individual\', source: \'Hello\'}',
+          'data' => '{source: \'Hello\'}',
           'actions' => '{create: 1, update: 0}',
         ],
       ],
@@ -30,9 +30,9 @@ return [
         [
           '#tag' => 'af-entity',
           'security' => 'FBAC',
-          'type' => 'Contact',
+          'type' => 'Individual',
           'name' => 'me',
-          'data' => '{contact_type: \'Individual\', source: \'Hello\'}',
+          'data' => '{source: \'Hello\'}',
           'actions' => '{create: 1, update: 0}',
         ],
       ],
@@ -46,9 +46,9 @@ return [
         [
           '#tag' => 'af-entity',
           'security' => 'FBAC',
-          'type' => 'Contact',
+          'type' => 'Individual',
           'name' => 'me',
-          'data' => ['contact_type' => 'Individual', 'source' => 'Hello'],
+          'data' => ['source' => 'Hello'],
           'actions' => ['create' => 1, 'update' => 0],
         ],
       ],


### PR DESCRIPTION
Overview
----------------------------------------
Makes Afform code more internally consistent. Now that we have [contact-type-specific API entities](https://github.com/civicrm/civicrm-core/pull/27659), a lot of workarounds for not having them can be removed.

Before
----------------------------------------
Mismatch between Afform entity type (e.g. Individual) and API entity type (Contact).

After
----------------------------------------
Afform entities match API entities Individual, Household, Organization.

Technical Details
----------------------------------------
Adds a backward-compatibility layer to convert existing forms to the new format on-the fly. As soon as a form is read into memory it will be in the new format.
This means that fetching and re-saving an Afform in the old format with the api (or with the GUI Editor) will write it in the new format. Forms in the old format will continue to work indefinitely as they will be converted every time they are read from disk.
