### PR TITLE
[php8.x] [online-event] [test] Use Order object rather than passed parameter to figure out if price field values use participant count

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -651,12 +651,9 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    * @internal function has had several recent signature changes & is expected to be eventually removed.
    */
   private function initEventFee(): void {
-    $priceSetId = $this->getPriceSetID();
-
     //get the price set fields participant count.
     //get option count info.
-    $this->_priceSet['optionsCountTotal'] = CRM_Price_BAO_PriceSet::getPricesetCount($priceSetId);
-    if ($this->_priceSet['optionsCountTotal']) {
+    if ($this->getOrder()->isUseParticipantCount()) {
       $optionsCountDetails = [];
       if (!empty($this->_priceSet['fields'])) {
         foreach ($this->_priceSet['fields'] as $field) {
@@ -1070,13 +1067,11 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
     $priceSetId = $form->get('priceSetId');
     $addParticipantNum = substr($form->_name, 12);
-    $priceSetFields = $priceSetDetails = [];
+    $priceSetFields = [];
     $hasPriceFieldsCount = FALSE;
     if ($priceSetId) {
       $priceSetDetails = $form->get('priceSet');
-      if (isset($priceSetDetails['optionsCountTotal'])
-        && $priceSetDetails['optionsCountTotal']
-      ) {
+      if ($form->getOrder()->isUseParticipantCount()) {
         $hasPriceFieldsCount = TRUE;
         $priceSetFields = $priceSetDetails['optionsCountDetails']['fields'];
       }
@@ -1228,7 +1223,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     }
 
     $priceSetFields = $priceMaxFieldDetails = [];
-    if (!empty($priceSet['optionsCountTotal'])) {
+    if ($form->getOrder()->isUseParticipantCount()) {
       $priceSetFields = $priceSet['optionsCountDetails']['fields'];
     }
 
@@ -1484,10 +1479,8 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $hasOptMaxValue = TRUE;
       $optionsMaxValueDetails = $priceSetDetails['optionsMaxValueDetails']['fields'];
     }
-    if (
-      isset($priceSetDetails['optionsCountTotal'])
-      && $priceSetDetails['optionsCountTotal']
-    ) {
+
+    if ($this->getOrder()->isUseParticipantCount()) {
       $hasOptCount = TRUE;
       $optionsCountDetails = $priceSetDetails['optionsCountDetails']['fields'];
     }

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -822,6 +822,27 @@ class CRM_Financial_BAO_Order {
   }
 
   /**
+   * Is participant count being used.
+   *
+   * This would be true if at least one price field value
+   * has a count value that is not 0 or NULL. In this case
+   * the row value will be used for the participant.
+   *
+   * @return bool
+   * @throws \CRM_Core_Exception
+   */
+  public function isUseParticipantCount(): bool {
+    foreach ($this->getPriceFieldsMetadata() as $fieldMetadata) {
+      foreach ($fieldMetadata['options'] as $option) {
+        if (($option['count'] ?? 0) > 0) {
+          return TRUE;
+        }
+      }
+    }
+    return FALSE;
+  }
+
+  /**
    * Recalculate the line items.
    *
    * @return void

--- a/Civi/Test/FormWrapper.php
+++ b/Civi/Test/FormWrapper.php
@@ -200,6 +200,8 @@ class FormWrapper {
       foreach ($this->subsequentForms as $form) {
         $form->preProcess();
         $form->buildForm();
+        $form->validate();
+        $this->validation[$form->getName()] = $form->_errors;
         $form->postProcess();
       }
     }

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -89,30 +89,8 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
       'first_name' => 'k',
       'last_name' => 'p',
       'email-Primary' => 'demo@example.com',
-      'hidden_processor' => '1',
-      'credit_card_number' => '4111111111111111',
-      'cvv2' => '123',
-      'credit_card_exp_date' => [
-        'M' => '1',
-        'Y' => date('Y') + 1,
-      ],
-      'credit_card_type' => 'Visa',
-      'billing_first_name' => 'p',
-      'billing_middle_name' => '',
-      'billing_last_name' => 'p',
-      'billing_street_address-5' => 'p',
-      'billing_city-5' => 'p',
-      'billing_state_province_id-5' => '1061',
-      'billing_postal_code-5' => '7',
-      'billing_country_id-5' => '1228',
-      'priceSetId' => $this->getPriceSetID('PaidEvent'),
       'price_' . $this->getPriceFieldID('PaidEvent') => $this->ids['PriceFieldValue']['PaidEvent_standard'],
-      'payment_processor_id' => $paymentProcessorID,
-      'year' => '2019',
-      'month' => '1',
-      'billing_state_province-5' => 'AP',
-      'billing_country-5' => 'US',
-    ]);
+    ] + $this->getCreditCardParameters($paymentProcessorID));
     $this->callAPISuccessGetCount('Participant', [], 1);
     $contribution = $this->callAPISuccessGetSingle('Contribution', []);
     $this->assertEquals(300, $contribution['total_amount']);
@@ -620,10 +598,6 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
           'email-Primary' => 'bruce@gotham.com',
           'is_primary' => 1,
           'is_pay_later' => 0,
-          'campaign_id' => NULL,
-          'defaultRole' => 1,
-          'participant_role_id' => '1',
-          'button' => '_qf_Register_upload',
         ],
       ]
     );
@@ -648,6 +622,35 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
       $submittedValues,
       ['id' => $eventID])
       ->addSubsequentForm('CRM_Event_Form_Registration_Confirm');
+  }
+
+  /**
+   * @param int $paymentProcessorID
+   *
+   * @return array
+   */
+  public function getCreditCardParameters(int $paymentProcessorID): array {
+    return [
+      'credit_card_number' => '4111111111111111',
+      'cvv2' => '123',
+      'credit_card_exp_date' => [
+        'M' => '1',
+        'Y' => date('Y') + 1,
+      ],
+      'priceSetId' => $this->getPriceSetID('PaidEvent'),
+      'billing_state_province-5' => 'AP',
+      'billing_country-5' => 'US',
+      'credit_card_type' => 'Visa',
+      'billing_first_name' => 'p',
+      'billing_middle_name' => '',
+      'billing_last_name' => 'p',
+      'billing_street_address-5' => 'p',
+      'billing_city-5' => 'p',
+      'billing_state_province_id-5' => '1061',
+      'billing_postal_code-5' => '7',
+      'billing_country_id-5' => '1228',
+      'payment_processor_id' => $paymentProcessorID,
+    ];
   }
 
 }


### PR DESCRIPTION

Overview
----------------------------------------
User Order object rather than passed paramter to figure out if price field values use participant count

Before
----------------------------------------
We have multiple similar arrays with price metadata & need to pass the 'right' one to figure out if there are fields in the price set with count configured

After
----------------------------------------
Use a new function on `BAO_Order()`

Technical Details
----------------------------------------

Comments
----------------------------------------
