### PR TITLE
dev/core#3381 [online-event]  Fix wrong currency for online event[s

### DIFF
--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -50,20 +50,20 @@
           <div class="crm-section no-label amount-item-section">
                     {foreach from=$amounts item=amount key=level}
               <div class="content">
-                  {$amount.amount|crmMoney}&nbsp;&nbsp;{$amount.label}
+                  {$amount.amount|crmMoney:$currency}&nbsp;&nbsp;{$amount.label}
               </div>
                   <div class="clear"></div>
                     {/foreach}
             </div>
                 {if $totalTaxAmount}
                   <div class="crm-section no-label total-amount-section">
-                  <div class="content bold">{ts}Total {$taxTerm} Amount{/ts}:&nbsp;&nbsp;{$totalTaxAmount|crmMoney}</div>
+                  <div class="content bold">{ts}Total {$taxTerm} Amount{/ts}:&nbsp;&nbsp;{$totalTaxAmount|crmMoney:$currency}</div>
                   <div class="clear"></div>
                   </div>
                 {/if}
                 {if $totalAmount}
                 <div class="crm-section no-label total-amount-section">
-                    <div class="content bold">{ts}Total Amount{/ts}:&nbsp;&nbsp;{$totalAmount|crmMoney}</div>
+                    <div class="content bold">{ts}Total Amount{/ts}:&nbsp;&nbsp;{$totalAmount|crmMoney:$currency}</div>
                     <div class="clear"></div>
                   </div>
                 {/if}

--- a/templates/CRM/Event/Form/Registration/ThankYou.tpl
+++ b/templates/CRM/Event/Form/Registration/ThankYou.tpl
@@ -86,18 +86,18 @@
               <div class="crm-section no-label amount-item-section">
                     {foreach from=$finalAmount item=amount key=level}
                   <div class="content">
-                      {$amount.amount|crmMoney}&nbsp;&nbsp;{$amount.label}
+                      {$amount.amount|crmMoney:$currency}&nbsp;&nbsp;{$amount.label}
                   </div>
                   <div class="clear"></div>
                     {/foreach}
                 </div>
                 {if $totalTaxAmount}
-                  <div class="content bold">{ts}Tax Total{/ts}:&nbsp;&nbsp;{$totalTaxAmount|crmMoney}</div>
+                  <div class="content bold">{ts}Tax Total{/ts}:&nbsp;&nbsp;{$totalTaxAmount|crmMoney:$currency}</div>
                   <div class="clear"></div>
                 {/if}
                 {if $totalAmount}
                  <div class="crm-section no-label total-amount-section">
-                    <div class="content bold">{ts}Total Amount{/ts}:&nbsp;&nbsp;{$totalAmount|crmMoney}</div>
+                    <div class="content bold">{ts}Total Amount{/ts}:&nbsp;&nbsp;{$totalAmount|crmMoney:$currency}</div>
                     <div class="clear"></div>
                   </div>
 


### PR DESCRIPTION
Overview
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/3381 if your event has a non-default currency it may not show correctly in some or all places on Confirm.tpl & ThankYou.tpl 

Before
----------------------------------------
currency formatting inconsistent

After
----------------------------------------
more? fully? consistent

Technical Details
----------------------------------------

Comments
----------------------------------------
