### PR TITLE
[php8.x] Clean up max value functionality

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -894,6 +894,28 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
   }
 
   /**
+   * Get the array of price field value IDs on the form that 'count' as
+   * full.
+   *
+   * The criteria for full is slightly confusing as it has an exclusion around
+   * select fields if they are the default - or something...
+   *
+   * @param array $field
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  protected function getOptionFullPriceFieldValues(array $field): array {
+    $optionFullIds = [];
+    foreach ($field['options'] ?? [] as &$option) {
+      if ($this->isOptionFullID($option, $field)) {
+        $optionFullIds[$option['id']] = $option['id'];
+      }
+    }
+    return $optionFullIds;
+  }
+
+  /**
    * Is the option a 'full ID'.
    *
    * It is not clear why this is different to the is_full calculation
@@ -1036,17 +1058,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    * @return array
    */
   protected function addOptionFullInformation(array $field): array {
-
-    if (!is_array($field['options'])) {
-      // Is this reachable
-      return $field;
-    }
-    $optionFullIds = [];
-    foreach ($field['options'] as &$option) {
-      if ($this->isOptionFullID($option, $field)) {
-        $optionFullIds[$option['id']] = $option['id'];
-      }
-    }
+    $optionFullIds = $this->getOptionFullPriceFieldValues($field);
 
     //finally get option ids in.
     $field['option_full_ids'] = $optionFullIds;

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1053,19 +1053,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
   }
 
   /**
-   * @param array $field
-   *
-   * @return array
-   */
-  protected function addOptionFullInformation(array $field): array {
-    $optionFullIds = $this->getOptionFullPriceFieldValues($field);
-
-    //finally get option ids in.
-    $field['option_full_ids'] = $optionFullIds;
-    return $field;
-  }
-
-  /**
    * Calculate the total participant count as per params.
    *
    * @param array $params
@@ -1998,8 +1985,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     //build the priceset fields.
     if ($priceSetID) {
 
-      //format price set fields across option full.
-      $this->formatPriceFieldsForFull($feeFields);
       // This is probably not required now - normally loaded from event ....
       $form->add('hidden', 'priceSetId', $priceSetID);
 
@@ -2038,7 +2023,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
             }
           }
 
-          $optionFullIds = CRM_Utils_Array::value('option_full_ids', $field, []);
+          $optionFullIds = $this->getOptionFullPriceFieldValues($field);
 
           //soft suppress required rule when option is full.
           if (!empty($optionFullIds) && (count($options) == count($optionFullIds))) {
@@ -2090,26 +2075,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     }
     // @todo this is temporary while we stop calling it from other places
     $this->_feeBlock = $feeFields;
-  }
-
-  /**
-   *
-   */
-  protected function formatPriceFieldsForFull(&$feeBlock): void {
-    $form = $this;
-    $priceSet = $form->get('priceSet');
-    $priceSetId = $form->get('priceSetId');
-    if (!$priceSetId ||
-      !is_array($priceSet) ||
-      empty($priceSet)
-      || !$this->isMaxValueValidationRequired()
-    ) {
-      return;
-    }
-
-    foreach ($feeBlock as &$field) {
-      $field = $this->addOptionFullInformation($field);
-    }
   }
 
   /**

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1458,13 +1458,12 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    * User should select at least one price field option.
    *
    * @param array $params
-   * @param array $feeBlock
    * @param int $priceSetId
    * @param array $priceSetDetails
    *
    * @return array
    */
-  protected function validatePriceSet(array $params, $feeBlock, $priceSetId, $priceSetDetails) {
+  protected function validatePriceSet(array $params, $priceSetId, $priceSetDetails) {
     $errors = [];
     $hasOptMaxValue = FALSE;
     if (!is_array($params) || empty($params)) {
@@ -1493,10 +1492,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $optionsCountDetails = $priceSetDetails['optionsCountDetails']['fields'];
     }
 
-    if (empty($feeBlock)) {
-      $feeBlock = $priceSetDetails['fields'];
-    }
-
     $optionMaxValues = $fieldSelected = [];
     foreach ($params as $pNum => $values) {
       if (!is_array($values) || $values == 'skip') {
@@ -1509,7 +1504,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
         }
         $priceFieldId = substr($valKey, 6);
         $noneOptionValueSelected = FALSE;
-        if (!$feeBlock[$priceFieldId]['is_required'] && $value == 0) {
+        if (!$this->getPriceFieldMetaData()[$priceFieldId]['is_required'] && $value == 0) {
           $noneOptionValueSelected = TRUE;
         }
 
@@ -1527,7 +1522,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
         }
 
         foreach ($value as $optId => $optVal) {
-          if (($feeBlock[$priceFieldId]['html_type'] ?? NULL) === 'Text') {
+          if (($this->getPriceFieldMetaData()[$priceFieldId]['html_type'] ?? NULL) === 'Text') {
             $currentMaxValue = $optVal;
           }
           else {
@@ -1555,7 +1550,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
     //validate for option max value.
     foreach ($optionMaxValues as $fieldId => $values) {
-      $options = $feeBlock[$fieldId]['options'] ?? [];
       foreach ($values as $optId => $total) {
         $optMax = $optionsMaxValueDetails[$fieldId]['options'][$optId];
         $opDbCount = $this->getUsedSeatsCount($optId);
@@ -2073,8 +2067,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
         $form->addRule('amount', ts('Fee Level is a required field.'), 'required');
       }
     }
-    // @todo this is temporary while we stop calling it from other places
-    $this->_feeBlock = $feeFields;
   }
 
   /**

--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -144,7 +144,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
           continue;
         }
 
-        $optionsFull = CRM_Utils_Array::value('option_full_ids', $val, []);
+        $optionsFull = $this->getOptionFullPriceFieldValues($val);
         foreach ($val['options'] as $keys => $values) {
           if ($values['is_default'] && !in_array($keys, $optionsFull)) {
             if ($val['html_type'] === 'CheckBox') {

--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -139,7 +139,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
       }
     }
     if ($this->_priceSetId) {
-      foreach ($this->_feeBlock as $key => $val) {
+      foreach ($this->getPriceFieldMetaData() as $key => $val) {
         if (empty($val['options'])) {
           continue;
         }
@@ -501,7 +501,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
         $totalParticipants = $self->getParticipantCount($allParticipantParams);
 
         //validate price field params.
-        $priceSetErrors = $self->validatePriceSet($allParticipantParams, $self->_feeBlock, $self->get('priceSetId'), $self->get('priceSet'));
+        $priceSetErrors = $self->validatePriceSet($allParticipantParams, $self->get('priceSetId'), $self->get('priceSet'));
         $errors = array_merge($errors, CRM_Utils_Array::value($addParticipantNum, $priceSetErrors, []));
 
         if (!$self->_allowConfirmation &&

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -347,7 +347,6 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       }
     }
     if ($form->getEventValue('is_monetary')) {
-      $form->formatPriceFieldsForFull($form->_values['fee']);
 
       if (!empty($form->_priceSetId) &&
         !$form->_requireApproval && !$form->_allowWaitlist

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -351,7 +351,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       if (!empty($form->_priceSetId) &&
         !$form->_requireApproval && !$form->_allowWaitlist
       ) {
-        $errors = $form->validatePriceSet($form->_params, $form->_values['fee'], $form->_priceSetId, $form->get('priceSet'));
+        $errors = $form->validatePriceSet($form->_params, $form->_priceSetId, $form->get('priceSet'));
         if (!empty($errors)) {
           CRM_Core_Session::setStatus(ts('You have been returned to the start of the registration process and any sold out events have been removed from your selections. You will not be able to continue until you review your booking and select different events if you wish.'), ts('Unfortunately some of your options have now sold out for one or more participants.'), 'error');
           CRM_Core_Session::setStatus(ts('Please note that the options which are marked or selected are sold out for participant being viewed.'), ts('Sold out:'), 'error');

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -308,8 +308,8 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
             break;
           }
           else {
-            if ($values['is_default'] && empty($values['is_full'])) {
-              if ($val['html_type'] == 'CheckBox') {
+            if ($values['is_default'] && !$this->getIsOptionFull($values)) {
+              if ($val['html_type'] === 'CheckBox') {
                 $this->_defaults["price_{$key}"][$keys] = 1;
               }
               else {

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -292,8 +292,8 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       $this->_defaults['participant_role']
         = $this->_defaults['participant_role_id'] = $this->_values['event']['default_role_id'];
     }
-    if ($this->_priceSetId && !empty($this->_feeBlock)) {
-      foreach ($this->_feeBlock as $key => $val) {
+    if ($this->_priceSetId) {
+      foreach ($this->getPriceFieldMetaData() as $key => $val) {
         if (empty($val['options'])) {
           continue;
         }
@@ -607,7 +607,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       //format params.
       $formatted = self::formatPriceSetParams($form, $fields);
       $ppParams = [$formatted];
-      $priceSetErrors = $form->validatePriceSet($ppParams, $form->_feeBlock, $fields['priceSetId'], $form->get('priceSet'));
+      $priceSetErrors = $form->validatePriceSet($ppParams, $fields['priceSetId'], $form->get('priceSet'));
       $primaryParticipantCount = $form->getParticipantCount($ppParams);
 
       //get price set fields errors in.

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -297,7 +297,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         if (empty($val['options'])) {
           continue;
         }
-        $optionFullIds = CRM_Utils_Array::value('option_full_ids', $val, []);
+        $optionFullIds = $this->getOptionFullPriceFieldValues($val);
         foreach ($val['options'] as $keys => $values) {
           $priceFieldName = 'price_' . $values['price_field_id'];
           $priceFieldValue = CRM_Price_BAO_PriceSet::getPriceFieldValueFromURL($this, $priceFieldName);


### PR DESCRIPTION
Overview
----------------------------------------
Clean up max_value functionality

Before
----------------------------------------
We have multiple stores of price field metadata - one of them has been augmented with some extra info with no transparency

After
----------------------------------------
The augmented data is called as it is used - note it is used to deal with the situation where a price field value is configured with a 'max_value' to ensure that that max_value cannot be exceeded within the order - in this case the participant count for couple is set to 2 and the max_value is set to 2 - on the additional participant page it is greyed out

![image](https://github.com/civicrm/civicrm-core/assets/336308/70fb64d8-a7d7-4b28-b20d-ac06e2b8f935)


Technical Details
----------------------------------------
It might duplicate some queries but I don't think that will move the needle performance wise - that is offset by the fact that it took me days to figure out what this code does & it is more transparent now

Comments
----------------------------------------
