### PR TITLE
[php8.x] Minor cleanup in priceSetOptionsCount

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -504,7 +504,7 @@ SELECT  event.event_full_text,
     SELECT  line.id as lineId,
             line.entity_id as entity_id,
             line.qty,
-            value.id as valueId,
+            value.id as price_field_value_id,
             value.count,
             field.html_type
       FROM  civicrm_line_item line
@@ -520,14 +520,13 @@ INNER JOIN  civicrm_price_field field       ON ( value.price_field_id = field.id
 
     $lineItem = CRM_Core_DAO::executeQuery($sql, [1 => [$eventId, 'Positive']]);
     while ($lineItem->fetch()) {
-      $count = $lineItem->count;
-      if (!$count) {
-        $count = 1;
-      }
-      if ($lineItem->html_type == 'Text') {
+      $id = (int) $lineItem->price_field_value_id;
+      $optionsCount[$id] ??= 0;
+      $count = $lineItem->count ?: 1;
+      if ($lineItem->html_type === 'Text') {
         $count *= $lineItem->qty;
       }
-      $optionsCount[$lineItem->valueId] = $count + ($optionsCount[$lineItem->valueId] ?? 0);
+      $optionsCount[$id] += $count;
     }
 
     return $optionsCount;


### PR DESCRIPTION
Mostly it was to cast the id index to an int  - but then I spotted that there was a case_sensitive field name in the sql, which seemed like bad practice
