### PR TITLE
standalone: fix ACLs on Roles re core #4862

### DIFF
--- a/ext/standaloneusers/CRM/Standaloneusers/BAO/Role.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/BAO/Role.php
@@ -20,16 +20,38 @@ class CRM_Standaloneusers_BAO_Role extends CRM_Standaloneusers_DAO_Role implemen
   /**
    * Check access permission
    *
+   * Note that $e->getRecord() returns the data passed INTO the API, e.g. if it
+   * has a 'name' key, then the value is that passed into the API (e.g. for an
+   * update action), not the current value.
+   *
    * @param \Civi\Api4\Event\AuthorizeRecordEvent $e
    * @see \Civi\Api4\Utils\CoreUtil::checkAccessRecord
    */
   public static function self_civi_api4_authorizeRecord(AuthorizeRecordEvent $e): void {
     $record = $e->getRecord();
     $action = $e->getActionName();
-    // Prevent users from updating or deleting the admin and everyone roles
-    if (in_array($action, ['delete', 'update'], TRUE)) {
-      $name = $record['name'] ?? CRM_Core_DAO::getFieldValue(self::class, $record['id']);
-      if (in_array($name, ['admin', 'everyone'], TRUE)) {
+    if (!in_array($action, ['delete', 'update'], TRUE)) {
+      // We only care about these actions.
+      return;
+    }
+
+    // Load the role name from the record that is to be updated/deleted.
+    $storedRoleName = CRM_Core_DAO::getFieldValue(self::class, $record['id'], 'name');
+
+    // Protect the admin role: it must have access to everything.
+    if ($storedRoleName === 'admin') {
+      $e->setAuthorized(FALSE);
+      return;
+    }
+
+    // Protect the everyone role
+    if ($storedRoleName === 'everyone') {
+      if ($action === 'delete') {
+        // Do not allow deletion of the everyone role.
+        $e->setAuthorized(FALSE);
+      }
+      // Updates: Disallow changing name and is_active
+      if (array_intersect(['name', 'is_active'], array_keys($record))) {
         $e->setAuthorized(FALSE);
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------

Followup from https://github.com/civicrm/civicrm-core/pull/28451/files

Fixes https://lab.civicrm.org/dev/core/-/issues/4862

Can probably close https://lab.civicrm.org/dev/core/-/issues/4835


Before
----------------------------------------

Not possible to edit 'everyone' role - permissions fixed.

Possible to change admin role if you were cunning.


After
----------------------------------------

Added phpunit tests

- can change perms, label on everyone role
- cannot delete, or update name/`is_active` on everyone role
- cannot delete or update admin role.

