### PR TITLE
don't send an extra receipt when completing pending contributions

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -2034,6 +2034,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         && 'Completed' === CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $this->getSubmittedValue('contribution_status_id'))) {
         // @todo make users use add payment form.
         civicrm_api3('Payment', 'create', [
+          'is_send_contribution_notification' => FALSE,
           'contribution_id' => $this->getContributionID(),
           'total_amount' => $this->getContributionValue('balance_amount'),
           'currency' => $this->getSubmittedValue('currency'),
@@ -2048,6 +2049,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $this->invoicingPostProcessHook($submittedValues, $action, $lineItem);
 
       //send receipt mail.
+      //FIXME: 'payment.create' could send a receipt.
       if ($contribution->id && !empty($formValues['is_email_receipt'])) {
         $formValues['contact_id'] = $this->_contactID;
         $formValues['contribution_id'] = $contribution->id;


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4970

Before
----------------------------------------
Extra receipt sent when completing a pending contribution.

After
----------------------------------------
Not anymore.

Technical Details
----------------------------------------
This occurred because of the move from `transitionComponents()` to `Payment.create`, and the fact that `Payment.create`'s spec says that `is_send_contribution_notification` defaults to `TRUE`.  So we explicitly set it FALSE.

Comments
----------------------------------------
It would be better to use this, then remove the code that sends the receipt:
```
'is_send_contribution_notification' => $formValues['is_email_receipt'] ?? FALSE,
```

However, it doesn't send the same template, this is a regression that should get fixed in 5.70, and there's not much time for testing.  I'm going with the minimal fix.