### PR TITLE
[Smarty Gencode] Fixes on clearAllAssign

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -134,12 +134,12 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
   /**
    * Build the form object.
    */
-  public function buildQuickForm() {
+  public function buildQuickForm(): void {
     $this->preventAjaxSubmit();
     $this->assign('isAdmin', CRM_Core_Permission::check('administer CiviCRM'));
 
     $this->add('select', 'from_email_address', ts('From'), $this->_fromEmails, TRUE, ['class' => 'crm-select2 huge']);
-    if ($this->_selectedOutput != 'email') {
+    if ($this->_selectedOutput !== 'email') {
       $this->addElement('radio', 'output', NULL, ts('Email Invoice'), 'email_invoice');
       $this->addElement('radio', 'output', NULL, ts('PDF Invoice'), 'pdf_invoice');
       $this->addRule('output', ts('Selection required'), 'required');
@@ -162,7 +162,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
     $this->addButtons([
       [
         'type' => 'upload',
-        'name' => $this->_selectedOutput == 'email' ? ts('Send Email') : ts('Process Invoice(s)'),
+        'name' => $this->_selectedOutput === 'email' ? ts('Send Email') : ts('Process Invoice(s)'),
         'isDefault' => TRUE,
       ],
       [

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -282,7 +282,17 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
     }
   }
 
+  /**
+   * @deprecated call clearAllAssign().
+   *
+   * @return void
+   */
   public function clearTemplateVars() {
+    if (method_exists($this, 'clearAllAssign')) {
+      $this->clearAllAssign();
+      return;
+    }
+
     foreach (array_keys($this->_tpl_vars) as $key) {
       if ($key == 'config' || $key == 'session') {
         continue;


### PR DESCRIPTION
This is no longer needed before calling the message template as the variables should be handled in there
