### PR TITLE
[Smarty-gencode] Switch createSmarty to use functions that work on v2,v3,v4

### DIFF
--- a/CRM/Core/CodeGen/Util/Smarty.php
+++ b/CRM/Core/CodeGen/Util/Smarty.php
@@ -43,6 +43,7 @@ class CRM_Core_CodeGen_Util_Smarty {
    * Create a Smarty instance.
    *
    * @return \Smarty
+   * @throws \SmartyException
    */
   public function createSmarty() {
     $base = dirname(dirname(dirname(dirname(__DIR__))));
@@ -50,16 +51,25 @@ class CRM_Core_CodeGen_Util_Smarty {
 
     require_once 'Smarty/Smarty.class.php';
     $smarty = new Smarty();
-    $smarty->template_dir = "$base/xml/templates";
-    $smarty->plugins_dir = ["$pkgs/Smarty/plugins", "$base/CRM/Core/Smarty/plugins"];
-    $smarty->compile_dir = $this->getCompileDir();
-    $smarty->clear_all_cache();
+    $smarty->setTemplateDir("$base/xml/templates");
+    $pluginsDirectory = $smarty->getPluginsDir();
+    $pluginsDirectory[] = "$base/CRM/Core/Smarty/plugins";
+    // Doesn't seem to work very well.... since I still need require_once below
+    $smarty->setPluginsDir($pluginsDirectory);
+    $smarty->setCompileDir($this->getCompileDir());
+    $smarty->clearAllCache();
 
     // CRM-5308 / CRM-3507 - we need {localize} to work in the templates
-
     require_once 'CRM/Core/Smarty/plugins/block.localize.php';
-    $smarty->register_block('localize', 'smarty_block_localize');
-    $smarty->assign('gencodeXmlDir', dirname(dirname(dirname(dirname(__DIR__)))) . '/xml');
+    $smarty->registerPlugin('block', 'localize', 'smarty_block_localize');
+
+    // Use our special replace rather than Smarty's to avoid conflicts while we
+    // transition from Smarty2.
+    require_once 'CRM/Core/Smarty/plugins/modifier.crmEscapeSingleQuotes.php';
+    $smarty->registerPlugin('modifier', 'crmEscapeSingleQuotes', 'smarty_modifier_crmEscapeSingleQuotes');
+
+    require_once 'CRM/Core/Smarty/plugins/modifier.crmCountCharacters.php';
+    $smarty->registerPlugin('modifier', 'crmCountCharacters', 'smarty_modifier_crmCountCharacters');
     return $smarty;
   }
 

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -385,6 +385,10 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
         $this->assign($key, $value);
       }
       else {
+        if (method_exists($this, 'clearAssign')) {
+          $this->clearAssign();
+          return $this;
+        }
         $this->clear_assign($key);
       }
     }

--- a/CRM/Core/Smarty/plugins/function.crmSqlData.php
+++ b/CRM/Core/Smarty/plugins/function.crmSqlData.php
@@ -27,7 +27,10 @@
  * @internal
  */
 function smarty_function_crmSqlData($params, &$smarty) {
-  if ($smarty->security) {
+  if ((property_exists($smarty, 'security_policy') && $smarty->security_policy)
+    // security is the Smarty v2 property.
+  || (property_exists($smarty, 'security') && $smarty->security)
+  ) {
     throw new \CRM_Core_Exception("crmSqlData not allowed in secure mode");
     // In theory, there's nothing actually wrong with running in secure more. We just don't need it.
     // If that changes, then be sure to double-check that the file-name sanitization is good.

--- a/CRM/Core/Smarty/plugins/modifier.crmEscapeSingleQuotes.php
+++ b/CRM/Core/Smarty/plugins/modifier.crmEscapeSingleQuotes.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Smarty plugin
+ * @package Smarty
+ * @subpackage plugins
+ */
+
+/**
+ * Smarty escape single quotes.
+ *
+ * This is hopefully a transitional plugin to get us past conflicts while
+ * we migrate from Smarty2 to Smarty 3. Potentially after that we can use
+ * {$field.comment|replace:"'":"\'"} again...
+ *
+ * @internal - may disappear again!!!
+ * @param string $string
+ *
+ * @return string
+ */
+function smarty_modifier_crmEscapeSingleQuotes($string) {
+  return str_replace("'", "\'", $string);
+}

--- a/CRM/Core/SmartyCompatibility.php
+++ b/CRM/Core/SmartyCompatibility.php
@@ -94,18 +94,10 @@ class CRM_Core_SmartyCompatibility extends Smarty {
     parent::registerPlugin('modifier', $modifier, $modifier_impl);
   }
 
-  public function registerPlugin($type, $name, $callback, $cacheable = TRUE, $cache_attr = NULL) {
-    if (method_exists(get_parent_class(), 'registerPlugin')) {
-      parent::registerPlugin($type, $name, $callback, $cacheable = TRUE, $cache_attr = NULL);
-      return;
-    }
-    if ($type === 'modifier') {
-      parent::register_modifier($name, $callback);
-    }
-  }
-
   /**
    * Registers a resource to fetch a template
+   *
+   * @deprecated
    *
    * @param string $type name of resource
    * @param array $functions array of functions to handle resource
@@ -125,6 +117,8 @@ class CRM_Core_SmartyCompatibility extends Smarty {
   /**
    * Registers custom function to be used in templates
    *
+   * @deprecated
+   *
    * @param string $function the name of the template function
    * @param string $function_impl the name of the PHP function to register
    * @param bool $cacheable
@@ -142,6 +136,8 @@ class CRM_Core_SmartyCompatibility extends Smarty {
 
   /**
    * Returns an array containing template variables
+   *
+   * @deprecated
    *
    * @param string $name
    *

--- a/setup/src/Setup/SmartyUtil.php
+++ b/setup/src/Setup/SmartyUtil.php
@@ -7,6 +7,7 @@ class SmartyUtil {
    * Create a Smarty instance.
    *
    * @return \Smarty
+   * @throws \SmartyException
    */
   public static function createSmarty($srcPath) {
     require_once 'CRM/Core/I18n.php';
@@ -15,18 +16,24 @@ class SmartyUtil {
     require_once $packagePath . DIRECTORY_SEPARATOR . 'Smarty' . DIRECTORY_SEPARATOR . 'Smarty.class.php';
 
     $smarty = new \Smarty();
-    $smarty->template_dir = implode(DIRECTORY_SEPARATOR, [$srcPath, 'xml', 'templates']);
-    $smarty->plugins_dir = [
-      implode(DIRECTORY_SEPARATOR, [$packagePath, 'Smarty', 'plugins']),
-      implode(DIRECTORY_SEPARATOR, [$srcPath, 'CRM', 'Core', 'Smarty', 'plugins']),
-    ];
-    $smarty->compile_dir = \Civi\Setup\FileUtil::createTempDir('templates_c');
-    $smarty->clear_all_cache();
+    $smarty->setTemplateDir(implode(DIRECTORY_SEPARATOR, [$srcPath, 'xml', 'templates']));
+    $pluginsDirectory = $smarty->getPluginsDir();
+    $pluginsDirectory[] = implode(DIRECTORY_SEPARATOR, [$srcPath, 'CRM', 'Core', 'Smarty', 'plugins']);
+    // Doesn't seem to work very well.... since I still need require_once below
+    $smarty->setPluginsDir($pluginsDirectory);
+    $smarty->setCompileDir(\Civi\Setup\FileUtil::createTempDir('templates_c'));
+    $smarty->clearAllCache();
+
+    require_once 'CRM/Core/Smarty/plugins/modifier.crmEscapeSingleQuotes.php';
+    $smarty->registerPlugin('modifier', 'crmEscapeSingleQuotes', 'smarty_modifier_crmEscapeSingleQuotes');
 
     // CRM-5308 / CRM-3507 - we need {localize} to work in the templates
     require_once implode(DIRECTORY_SEPARATOR, [$srcPath, 'CRM', 'Core', 'Smarty', 'plugins', 'block.localize.php']);
-    $smarty->register_block('localize', 'smarty_block_localize');
-    $smarty->assign('gencodeXmlDir', "$srcPath/xml");
+    $smarty->registerPlugin('block', 'localize', 'smarty_block_localize');
+    require_once 'CRM/Core/Smarty/plugins/modifier.crmCountCharacters.php';
+    $smarty->registerPlugin('modifier', 'crmCountCharacters', 'smarty_modifier_crmCountCharacters');
+    require_once implode(DIRECTORY_SEPARATOR, [$srcPath, 'CRM', 'Core', 'CodeGen', 'Util', 'MessageTemplates.php']);
+    \CRM_Core_CodeGen_Util_MessageTemplates::assignSmartyVariables($smarty);
     return $smarty;
   }
 

--- a/tests/phpunit/CRM/Core/Smarty/plugins/CrmRSSPubDateTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/CrmRSSPubDateTest.php
@@ -30,10 +30,10 @@ class CRM_Core_Smarty_plugins_CrmRSSPubDateTest extends CiviUnitTestCase {
    * @param string $input
    * @param string $expected
    */
-  public function testRSSPubDate(string $input, string $expected) {
+  public function testRSSPubDate(string $input, string $expected): void {
     $smarty = CRM_Core_Smarty::singleton();
     $smarty->assign('the_date', $input);
-    $actual = $smarty->fetch('string:{$the_date|crmRSSPubDate}');
+    $actual = CRM_Utils_String::parseOneOffStringThroughSmarty('{$the_date|crmRSSPubDate}');
     $this->assertEquals($expected, $actual);
   }
 
@@ -60,16 +60,19 @@ class CRM_Core_Smarty_plugins_CrmRSSPubDateTest extends CiviUnitTestCase {
    * Test that invalid inputs return "today"'s date.
    *
    * @dataProvider dateListBad
+   *
    * @param mixed $input
    * @param string $expected
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testRSSPubDateBad($input, string $expected) {
+  public function testRSSPubDateBad($input, string $expected): void {
     putenv('TIME_FUNC=frozen');
     CRM_Utils_Time::setTime(self::FIXED_DATE);
 
     $smarty = CRM_Core_Smarty::singleton();
     $smarty->assign('the_date', $input);
-    $actual = $smarty->fetch('string:{$the_date|crmRSSPubDate}');
+    $actual = CRM_Utils_String::parseOneOffStringThroughSmarty('{$the_date|crmRSSPubDate}');
     $this->assertEquals($expected, $actual);
   }
 

--- a/tests/phpunit/CRM/Core/Smarty/plugins/HtxtTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/HtxtTest.php
@@ -6,20 +6,10 @@
  */
 class CRM_Core_Smarty_plugins_HtxtTest extends CiviUnitTestCase {
 
-  public function setUp(): void {
-    parent::setUp();
-    $this->useTransaction();
-    require_once 'CRM/Core/Smarty.php';
-
-    // Templates should normally be file names, but for unit-testing it's handy to use "string:" notation
-    require_once 'CRM/Core/Smarty/resources/String.php';
-    civicrm_smarty_register_string_resource();
-  }
-
   /**
    * @return array
    */
-  public function supportedCases() {
+  public function supportedCases(): array {
     $cases = [];
     $cases[] = ['yum yum apple_pie!', '{htxt id="apple_pie"}yum yum apple_pie!{/htxt}', ['id' => 'apple_pie']];
     $cases[] = ['yum yum Apple-Pie!', '{htxt id=\'Apple-Pie\'}yum yum Apple-Pie!{/htxt}', ['id' => 'Apple-Pie']];
@@ -32,7 +22,7 @@ class CRM_Core_Smarty_plugins_HtxtTest extends CiviUnitTestCase {
     return $cases;
   }
 
-  public function unsupportedCases() {
+  public function unsupportedCases(): array {
     $cases = [];
     $cases[] = ['{htxt id=$dynamic.zx["$f{b}"]}not supported{/htxt}', []];
     $cases[] = ['{htxt id=\'dragonfruit"}not supported{/htxt}', []];
@@ -47,11 +37,11 @@ class CRM_Core_Smarty_plugins_HtxtTest extends CiviUnitTestCase {
    * @param string $input
    * @param array $vars
    */
-  public function testSupported(string $expected, string $input, array $vars) {
+  public function testSupported(string $expected, string $input, array $vars): void {
     $smarty = CRM_Core_Smarty::singleton();
     $smarty->pushScope($vars);
     try {
-      $actual = $smarty->fetch('string:' . $input);
+      $actual = CRM_Utils_String::parseOneOffStringThroughSmarty($input);
       $this->assertEquals($expected, $actual, "Process input=[$input]");
     }
     finally {
@@ -62,12 +52,11 @@ class CRM_Core_Smarty_plugins_HtxtTest extends CiviUnitTestCase {
   /**
    * @dataProvider unsupportedCases
    * @param string $input
-   * @param array $vars
    */
-  public function testUnsupported(string $input, array $vars) {
+  public function testUnsupported(string $input): void {
     $smarty = CRM_Core_Smarty::singleton();
     try {
-      $smarty->fetch('string:' . $input);
+      CRM_Utils_String::parseOneOffStringThroughSmarty($input);
       $this->fail("That should have thrown an error. Are you working on a better parsing rule?");
     }
     catch (Throwable $t) {

--- a/xml/templates/dao.tpl
+++ b/xml/templates/dao.tpl
@@ -111,7 +111,7 @@ class {$table.className} extends CRM_Core_DAO {ldelim}
   * @return string
   */
   public static function getEntityDescription() {ldelim}
-    return {$tsFunctionName}('{$table.description|replace:"'":"\'"}');
+    return {$tsFunctionName}('{$table.description|crmEscapeSingleQuotes}');
   {rdelim}
 {/if}
 
@@ -137,7 +137,7 @@ class {$table.className} extends CRM_Core_DAO {ldelim}
                                                                       'title'     => {$tsFunctionName}('{$field.title}'),
 {/if}
 {if $field.comment}
-                                                                      'description'     => {$tsFunctionName}('{$field.comment|replace:"'":"\'"}'),
+                                                                      'description'     => {$tsFunctionName}('{$field.comment|crmEscapeSingleQuotes}'),
 {/if}
 {if $field.required}
                                         'required'  => {$field.required|strtoupper},


### PR DESCRIPTION
this is a partial of the work to switch Smarty over but I'm expecting it to work against the current v2 as well as v3/v4 which should ease some of @demeritcowboy's pain.

To actually switch it is necessary to change the require once but my experience is the tests have been loading both versions at different times so I've had to have shims to cope with that possibility