### PR TITLE
Remove incorrectly placed ChangeCaseStatus class properties and convert one of them to a local var

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -50,6 +50,26 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
   public $_caseTypeDefinition;
 
   /**
+   * This is here to avoid php 8 warnings but it should be converted to
+   * some mechanism more local to ChangeCaseStatus. It also doesn't make sense
+   * that it's an array.
+   *
+   * @var array
+   * @internal
+   */
+  public $_oldCaseStatus;
+
+  /**
+   * This is here to avoid php 8 warnings but it should be converted to
+   * some mechanism more local to ChangeCaseStatus. It also doesn't make sense
+   * that it's an array.
+   *
+   * @var array
+   * @internal
+   */
+  public $_defaultCaseStatus;
+
+  /**
    * Build the form object.
    */
   public function preProcess() {

--- a/CRM/Case/Form/Activity/ChangeCaseStatus.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStatus.php
@@ -58,13 +58,13 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
   /**
    * @param CRM_Core_Form $form
    */
-  public static function buildQuickForm(&$form) {
+  public static function buildQuickForm($form) {
     $form->removeElement('status_id');
     $form->removeElement('priority_id');
 
     $caseTypes = [];
 
-    $form->_caseStatus = CRM_Case_PseudoConstant::caseStatus();
+    $statusLabels = CRM_Case_PseudoConstant::caseStatus();
     $statusNames = CRM_Case_PseudoConstant::caseStatus('name');
 
     // Limit case statuses to allowed types for these case(s)
@@ -75,9 +75,9 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
     $caseTypes = civicrm_api3('CaseType', 'get', ['id' => ['IN' => $caseTypes]]);
     foreach ($caseTypes['values'] as $ct) {
       if (!empty($ct['definition']['statuses'])) {
-        foreach ($form->_caseStatus as $id => $label) {
+        foreach ($statusLabels as $id => $label) {
           if (!in_array($statusNames[$id], $ct['definition']['statuses'])) {
-            unset($form->_caseStatus[$id]);
+            unset($statusLabels[$id]);
           }
         }
       }
@@ -88,12 +88,12 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
     }
 
     foreach ($form->_defaultCaseStatus as $keydefault => $valdefault) {
-      if (!array_key_exists($valdefault, $form->_caseStatus)) {
-        $form->_caseStatus[$valdefault] = CRM_Core_PseudoConstant::getLabel('CRM_Case_BAO_Case', 'status_id', $valdefault);
+      if (!array_key_exists($valdefault, $statusLabels)) {
+        $statusLabels[$valdefault] = CRM_Core_PseudoConstant::getLabel('CRM_Case_BAO_Case', 'status_id', $valdefault);
       }
     }
     $element = $form->add('select', 'case_status_id', ts('Case Status'),
-      $form->_caseStatus, TRUE
+      $statusLabels, TRUE
     );
     // check if the case status id passed in url is a valid one, set as default and freeze
     if (CRM_Utils_Request::retrieve('case_status_id', 'Positive', $form)) {
@@ -191,11 +191,15 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
     $params['priority_id'] = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'priority_id', 'Normal');
     $activity->priority_id = $params['priority_id'];
 
+    // Note here we don't need to do the filtering that happens in buildForm.
+    // All we want is the label for a given id so we can put it in the subject.
+    $statusLabels = CRM_Case_PseudoConstant::caseStatus();
     foreach ($form->_oldCaseStatus as $statusval) {
+      // @todo we store all old statuses but then we only use the first one.
       if ($activity->subject == 'null') {
         $activity->subject = ts('Case status changed from %1 to %2', [
-          1 => $form->_caseStatus[$statusval] ?? NULL,
-          2 => $form->_caseStatus[$params['case_status_id']] ?? NULL,
+          1 => $statusLabels[$statusval] ?? NULL,
+          2 => $statusLabels[$params['case_status_id']] ?? NULL,
         ]);
         $activity->save();
       }

--- a/CRM/Case/Form/Activity/ChangeCaseStatus.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStatus.php
@@ -50,6 +50,7 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
   public static function setDefaultValues(&$form) {
     $defaults = [];
     // Retrieve current case status
+    // @todo this var is created as an array below, but the form field is single-valued. See also comment about _oldCaseStatus in endPostProcess.
     $defaults['case_status_id'] = $form->_defaultCaseStatus;
 
     return $defaults;

--- a/CRM/Case/Form/Activity/ChangeCaseStatus.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStatus.php
@@ -20,12 +20,6 @@
  */
 class CRM_Case_Form_Activity_ChangeCaseStatus {
 
-  public $_caseId;
-
-  public $_defaultCaseStatus;
-
-  public $_oldCaseStatus;
-
   /**
    * @param CRM_Core_Form $form
    *
@@ -64,7 +58,7 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
   /**
    * @param CRM_Core_Form $form
    */
-  public static function buildQuickForm($form) {
+  public static function buildQuickForm(&$form) {
     $form->removeElement('status_id');
     $form->removeElement('priority_id');
 

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -758,7 +758,7 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
     $closedStatus = $closedStatusResult['values'][$closedStatusResult['id']]['value'];
 
     // Go thru the motions to change case status
-    $form = new CRM_Case_Form_Activity_ChangeCaseStatus();
+    $form = new CRM_Case_Form_Activity();
     $form->_caseId = [$case1->id];
     $form->_oldCaseStatus = [$case1->status_id];
     $params = [


### PR DESCRIPTION
Overview
----------------------------------------
Class properties on wrong class. Test using wrong class.

Before
----------------------------------------
Class properties on wrong class. Test using wrong class.

After
----------------------------------------
One of the variables converted to a local variable.

Technical Details
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/29227, a misleading test caused the addition of class variables to the wrong class to deal with a php 8.2 warning. For the moment I've done the minimal change to that test - the 8.2 test fail will come back but will be pointing at the right place.

To deal with the "oldCaseStatus" variable, I'm tempted to just declare it on CRM_Case_Form_Activity since it's more complicated.

Comments
----------------------------------------
To r-run this, mostly what you're looking for is that the subject line of a change case status activity is created correctly.