### PR TITLE
smarty don't crash

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -391,10 +391,6 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
         $this->clearAssign($key);
       }
       else {
-        if (method_exists($this, 'clearAssign')) {
-          $this->clearAssign();
-          return $this;
-        }
         $this->clear_assign($key);
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
This was a line that was merged recently but (a) it doesn't make sense because of the lines above, and (b) crashes because clearAssign needs a param passed in.

Note you won't be able to reproduce the crash anymore, because the lines above it were just merged a few minutes ago, and it wasn't crashing until [the packages PR](https://github.com/civicrm/civicrm-packages/pull/384) was merged about an hour ago.

@eileenmcnaughton @colemanw 