### PR TITLE
Run tests on Smarty4 instead of 3

### DIFF
--- a/CRM/Core/CodeGen/Util/Smarty.php
+++ b/CRM/Core/CodeGen/Util/Smarty.php
@@ -48,7 +48,7 @@ class CRM_Core_CodeGen_Util_Smarty {
   public function createSmarty(): Smarty {
     $base = dirname(__DIR__, 4);
     $pkgs = file_exists(dirname($base) . "/civicrm-packages") ? dirname($base) . "/civicrm-packages" : "$base/packages";
-    require_once $pkgs . '/smarty3/vendor/autoload.php';
+    require_once $pkgs . '/smarty4/vendor/autoload.php';
     $smarty = new Smarty();
     $smarty->setTemplateDir("$base/xml/templates");
     $pluginsDirectory = $smarty->getPluginsDir();

--- a/setup/src/Setup/SmartyUtil.php
+++ b/setup/src/Setup/SmartyUtil.php
@@ -13,7 +13,7 @@ class SmartyUtil {
     require_once 'CRM/Core/I18n.php';
 
     $packagePath = PackageUtil::getPath($srcPath);
-    require_once $packagePath . '/smarty3/vendor/autoload.php';
+    require_once $packagePath . '/smarty4/vendor/autoload.php';
 
     $smarty = new \Smarty();
     $smarty->setTemplateDir(implode(DIRECTORY_SEPARATOR, [$srcPath, 'xml', 'templates']));

--- a/xml/templates/dao.tpl
+++ b/xml/templates/dao.tpl
@@ -56,7 +56,7 @@ class {$table.className} extends CRM_Core_DAO {ldelim}
        *
        * @var bool
        */
-      public static $_log = {$table.log|strtoupper};
+      public static $_log = {$table.log|upper};
       {if $table.paths}
      /**
       * Paths for accessing this entity in the UI.
@@ -202,7 +202,7 @@ class {$table.className} extends CRM_Core_DAO {ldelim}
                       'component' => '{$field.component}',
 {/if}
 {if $field.serialize}
-  'serialize' => self::SERIALIZE_{$field.serialize|strtoupper},
+  'serialize' => self::SERIALIZE_{$field.serialize|upper},
 {/if}
 {if $field.uniqueTitle}
   'unique_title' => {$tsFunctionName}('{$field.uniqueTitle}'),


### PR DESCRIPTION
Overview
----------------------------------------
Run tests on Smarty4 instead of 3

Before
----------------------------------------
We finally got them onto v3

After
----------------------------------------
We push on to v4

Technical Details
----------------------------------------
From my digging /testing  there are no issues in Smarty4 that we have not already solved for v3 so I'm expecting this to pass now the packages patch is merged & then we can switch the 'encouraged version' from v3 to v4 & basically let Smarty rest there for a few months

Comments
----------------------------------------
