### PR TITLE
Register native php functions that we use as smarty plugins

### DIFF
--- a/CRM/Core/CodeGen/Util/Smarty.php
+++ b/CRM/Core/CodeGen/Util/Smarty.php
@@ -69,6 +69,11 @@ class CRM_Core_CodeGen_Util_Smarty {
 
     require_once 'CRM/Core/Smarty/plugins/modifier.crmCountCharacters.php';
     $smarty->registerPlugin('modifier', 'crmCountCharacters', 'smarty_modifier_crmCountCharacters');
+
+    $smarty->registerPlugin('modifier', 'json_encode', 'json_encode');
+    $smarty->registerPlugin('modifier', 'count', 'count');
+    $smarty->registerPlugin('modifier', 'implode', 'implode');
+
     return $smarty;
   }
 

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -166,6 +166,9 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
     }
     $this->load_filter('pre', 'resetExtScope');
     $this->load_filter('pre', 'htxtFilter');
+    $this->registerPlugin('modifier', 'json_encode', 'json_encode');
+    $this->registerPlugin('modifier', 'count', 'count');
+    $this->registerPlugin('modifier', 'implode', 'implode');
 
     $this->assign('crmPermissions', new CRM_Core_Smarty_Permissions());
 

--- a/setup/src/Setup/SmartyUtil.php
+++ b/setup/src/Setup/SmartyUtil.php
@@ -33,6 +33,9 @@ class SmartyUtil {
     require_once 'CRM/Core/Smarty/plugins/modifier.crmCountCharacters.php';
     $smarty->registerPlugin('modifier', 'crmCountCharacters', 'smarty_modifier_crmCountCharacters');
     require_once implode(DIRECTORY_SEPARATOR, [$srcPath, 'CRM', 'Core', 'CodeGen', 'Util', 'MessageTemplates.php']);
+    $smarty->registerPlugin('modifier', 'json_encode', 'json_encode');
+    $smarty->registerPlugin('modifier', 'count', 'count');
+    $smarty->registerPlugin('modifier', 'implode', 'implode');
     \CRM_Core_CodeGen_Util_MessageTemplates::assignSmartyVariables($smarty);
     return $smarty;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Register json_encode as a smarty plugin

Before
----------------------------------------
The main practical difference between Smarty 3 & 4 is that using unregistered php functions is deprecated

The main practical difference between Smarty 4 & 5 is that using unregistered php functions fails & assign_by_ref fails

When I switch to Smarty4 I get notices about json_encode not being registered

After
----------------------------------------
notices gone, still works if I switch back to Smarty 2

Technical Details
----------------------------------------
See
https://stackoverflow.com/questions/77170834/why-will-smarty-remove-support-for-using-php-functions-as-modifiers

This is where we use it

![image](https://github.com/civicrm/civicrm-core/assets/336308/dc9f15a0-283c-4fd2-ae72-b9b35794b7c4)


Comments
----------------------------------------
