### PR TITLE
Fix dev/core#4959 - Handle extra whitespace in scheduled job params

### DIFF
--- a/CRM/Core/BAO/Job.php
+++ b/CRM/Core/BAO/Job.php
@@ -125,6 +125,7 @@ class CRM_Core_BAO_Job extends CRM_Core_DAO_Job {
    * @throws CRM_Core_Exception
    */
   public static function parseParameters(?string $parameters): array {
+    $parameters = trim($parameters ?? '');
     $result = ['version' => 3];
     $lines = $parameters ? explode("\n", $parameters) : [];
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/4959

Before
----------------------------------------
Extra newlines in scheduled job parameters (textarea) cause errors.

After
----------------------------------------
No errors.

Technical Details
----------------------------------------
This regressed with ebe5df9f657d4c57dcad17384f70156476c2f086