### PR TITLE
dev/core#3381 Fix currency display on total fees

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -266,12 +266,13 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     }
     $this->_availableRegistrations = $this->get('availableRegistrations');
     $this->_participantIDS = $this->get('participantIDs');
+
     // Required for currency formatting in the JS layer
     // this is a temporary fix intended to resolve a regression quickly
     // And assigning moneyFormat for js layer formatting
     // will only work until that is done.
     // https://github.com/civicrm/civicrm-core/pull/19151
-    $this->assign('moneyFormat', CRM_Utils_Money::format(1234.56));
+    $this->assign('moneyFormat', CRM_Utils_Money::format(1234.56, $this->getCurrency()));
 
     //check if participant allow to walk registration wizard.
     $this->_allowConfirmation = $this->get('allowConfirmation');


### PR DESCRIPTION
Before
----------------------------------------
Currency symbol is incorrect for additional participants on events.

![image](https://github.com/civicrm/civicrm-core/assets/5212601/205a691e-4e0c-43d6-9025-a1d0cce75ac3)

After
----------------------------------------
Currency symbol is correct

![image](https://github.com/civicrm/civicrm-core/assets/5212601/5fcc0864-205c-4a84-bbdf-a30f442a8574)

Technical Details
----------------------------------------
This feels dirty, but it's a copy-paste of the fix which exists in the main registration page. I've kept the comments so we can trace it through if needed.