### PR TITLE
Fix master-only regression on saving event info when no custom data applies

### DIFF
--- a/CRM/Custom/Form/CustomDataTrait.php
+++ b/CRM/Custom/Form/CustomDataTrait.php
@@ -70,9 +70,11 @@ trait CRM_Custom_Form_CustomDataTrait {
           ]
         );
       }
-      $tables = CRM_Core_DAO::executeQuery(implode(' UNION ', $query));
-      while ($tables->fetch()) {
-        $customGroupSuffixes[$tables->table_name] = '_' . $tables->id;
+      if (!empty($query)) {
+        $tables = CRM_Core_DAO::executeQuery(implode(' UNION ', $query));
+        while ($tables->fetch()) {
+          $customGroupSuffixes[$tables->table_name] = '_' . $tables->id;
+        }
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix master-only regression on saving event info when no custom data applies

Before
----------------------------------------
Event Info not saving when there are no custom fields extending event

After
----------------------------------------
now it does

Technical Details
----------------------------------------
I didn't see this before as I had a tonne of custom data locally but after re-building my site I hit it

I'm pretty sure this is the same issue as @demeritcowboy reported in https://lab.civicrm.org/dev/core/-/issues/4968
and the reason why I couldn't replicate that would have been the same

Comments
----------------------------------------
