### PR TITLE
Deprecate a couple of backward compatibility Smarty functions

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -72,6 +72,10 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
    */
   private static $UNDEFINED_VALUE;
 
+  /**
+   * @throws \CRM_Core_Exception
+   * @throws \SmartyException
+   */
   private function initialize() {
     $config = CRM_Core_Config::singleton();
 
@@ -160,12 +164,12 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
       // contribution dashboard from RecentlyViewed.tpl
       require_once 'Smarty/plugins/modifier.escape.php';
       if (!isset($this->_plugins['modifier']['escape'])) {
-        $this->register_modifier('escape', ['CRM_Core_Smarty', 'escape']);
+        $this->registerPlugin('modifier', 'escape', ['CRM_Core_Smarty', 'escape']);
       }
       $this->default_modifiers[] = 'escape:"htmlall"';
     }
-    $this->load_filter('pre', 'resetExtScope');
-    $this->load_filter('pre', 'htxtFilter');
+    $this->loadFilter('pre', 'resetExtScope');
+    $this->loadFilter('pre', 'htxtFilter');
     $this->registerPlugin('modifier', 'json_encode', 'json_encode');
     $this->registerPlugin('modifier', 'count', 'count');
     $this->registerPlugin('modifier', 'implode', 'implode');

--- a/CRM/Core/SmartyCompatibility.php
+++ b/CRM/Core/SmartyCompatibility.php
@@ -71,6 +71,7 @@ class CRM_Core_SmartyCompatibility extends Smarty {
    * @throws \SmartyException
    */
   public function load_filter($type, $name) {
+    CRM_Core_Error::deprecatedWarning('loadFilter');
     if (method_exists(get_parent_class(), 'load_filter')) {
       parent::load_filter($type, $name);
       return;
@@ -91,6 +92,7 @@ class CRM_Core_SmartyCompatibility extends Smarty {
       parent::register_modifier($modifier, $modifier_impl);
       return;
     }
+    CRM_Core_Error::deprecatedWarning('registerPlugin');
     parent::registerPlugin('modifier', $modifier, $modifier_impl);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Deprecate a couple of backward compatibility Smarty functions

Before
----------------------------------------
We were using backward compatibilty Smarty functions`load_filter` & `register_modifier`  in core

After
----------------------------------------
Switched to the new function names, added deprecation notice

Technical Details
----------------------------------------
These are not really used in extensions 

Comments
----------------------------------------
