### PR TITLE
Drupal.civi-setup: setAuthorized if running via drush

### DIFF
--- a/setup/plugins/init/Drupal.civi-setup.php
+++ b/setup/plugins/init/Drupal.civi-setup.php
@@ -17,7 +17,7 @@ if (!defined('CIVI_SETUP')) {
     }
 
     \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'checkAuthorized'));
-    $e->setAuthorized(user_access('administer modules'));
+    $e->setAuthorized(\Civi\Setup\DrupalUtil::isDrush() || user_access('administer modules'));
   });
 
 \Civi\Setup::dispatcher()


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/drupal/-/issues/193

Running \Civi\Setup is unauthorized if run from Drush, because we might not have specified `-u admin` from the command line.

This aims to provide background-compatibility for people who still use Drush8 (ex: Aegir).

Before
----------------------------------------

\Civi\Setup refuses to run when called from drush.

After
----------------------------------------

OK

Comments
-----------------------

See https://lab.civicrm.org/dev/drupal/-/issues/193 - for other related PRs