### PR TITLE
Stop burying the lead

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
@@ -11,48 +11,16 @@
 
 <div class="crm-block crm-form-block crm-event-manage-eventinfo-form-block">
   <table class="form-layout-compressed">
-    {if !empty($form.template_id)}
-      <tr class="crm-event-manage-eventinfo-form-block-template_id">
-        <td class="label">{$form.template_id.label} {help id="id-select-template" isTemplate=$isTemplate}</td>
-        <td>{$form.template_id.html}</td>
-      </tr>
-    {/if}
+    <tr class="crm-event-manage-eventinfo-form-block-title">
+      <td class="label">{$form.title.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='title' id=$eventID}{/if}</td>
+      <td>{$form.title.html}</td>
+    </tr>
     {if !empty($form.template_title)}
       <tr class="crm-event-manage-eventinfo-form-block-template_title">
         <td class="label">{$form.template_title.label} {help id="id-template-title"}{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='template_title' id=$eventID}{/if}</td>
         <td>{$form.template_title.html}</td>
       </tr>
     {/if}
-    <tr class="crm-event-manage-eventinfo-form-block-event_type_id">
-      <td class="label">{$form.event_type_id.label}</td>
-      <td>{$form.event_type_id.html}</td>
-    </tr>
-
-    {* CRM-7362 --add campaign *}
-    {include file="CRM/Campaign/Form/addCampaignToComponent.tpl"
-    campaignTrClass="crm-event-manage-eventinfo-form-block-campaign_id"}
-
-    <tr class="crm-event-manage-eventinfo-form-block-default_role_id">
-      <td class="label">{$form.default_role_id.label} {help id="id-participant-role"}</td>
-      <td>{$form.default_role_id.html}
-      </td>
-    </tr>
-    <tr class="crm-event-manage-eventinfo-form-block-participant_listing_id">
-      <td class="label">{$form.participant_listing_id.label} {help id="id-listing" isTemplate=$isTemplate action=$action entityId=$eventID}</td>
-      <td>{$form.participant_listing_id.html}</td>
-    </tr>
-    <tr class="crm-event-manage-eventinfo-form-block-title">
-      <td class="label">{$form.title.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='title' id=$eventID}{/if}</td>
-      <td>{$form.title.html}</td>
-    </tr>
-    <tr class="crm-event-manage-eventinfo-form-block-summary">
-      <td class="label">{$form.summary.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='summary' id=$eventID}{/if}</td>
-      <td>{$form.summary.html}</td>
-    </tr>
-    <tr class="crm-event-manage-eventinfo-form-block-description">
-      <td class="label">{$form.description.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='description' id=$eventID}{/if}</td>
-      <td>{$form.description.html}</td>
-    </tr>
     {if !$isTemplate}
       <tr class="crm-event-manage-eventinfo-form-block-start_date">
         <td class="label">{$form.start_date.label}</td>
@@ -63,6 +31,38 @@
         <td>{$form.end_date.html}</td>
       </tr>
     {/if}
+    {if !empty($form.template_id)}
+      <tr class="crm-event-manage-eventinfo-form-block-template_id">
+        <td class="label">{$form.template_id.label} {help id="id-select-template" isTemplate=$isTemplate}</td>
+        <td>{$form.template_id.html}</td>
+      </tr>
+    {/if}
+    <tr class="crm-event-manage-eventinfo-form-block-event_type_id">
+      <td class="label">{$form.event_type_id.label}</td>
+      <td>{$form.event_type_id.html}</td>
+    </tr>
+
+    <tr class="crm-event-manage-eventinfo-form-block-default_role_id">
+      <td class="label">{$form.default_role_id.label} {help id="id-participant-role"}</td>
+      <td>{$form.default_role_id.html}
+      </td>
+    </tr>
+    {* CRM-7362 --add campaign *}
+    {include file="CRM/Campaign/Form/addCampaignToComponent.tpl"
+    campaignTrClass="crm-event-manage-eventinfo-form-block-campaign_id"}
+
+    <tr class="crm-event-manage-eventinfo-form-block-summary">
+      <td class="label">{$form.summary.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='summary' id=$eventID}{/if}</td>
+      <td>{$form.summary.html}</td>
+    </tr>
+    <tr class="crm-event-manage-eventinfo-form-block-description">
+      <td class="label">{$form.description.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='description' id=$eventID}{/if}</td>
+      <td>{$form.description.html}</td>
+    </tr>
+    <tr class="crm-event-manage-eventinfo-form-block-participant_listing_id">
+      <td class="label">{$form.participant_listing_id.label} {help id="id-listing" isTemplate=$isTemplate action=$action entityId=$eventID}</td>
+      <td>{$form.participant_listing_id.html}</td>
+    </tr>
     <tr class="crm-event-manage-eventinfo-form-block-max_participants">
       <td class="label">{$form.max_participants.label} {help id="id-max_participants" waitlist=$waitlist}</td>
       <td>


### PR DESCRIPTION
Overview
----------------------------------------
Re-order field display on ManageEvent Info screen

I've been configuring a few event forms & find it kinda hard to find the most important fields - which I've kinda defined as the required fields - in particular the Event Title feels to me like the MOST important field - and it is number 5 after 'Participant Listing'

Also the start & end dates are important to have up front because start date is a required field & cos they are so easily misconfigured  & the misconfiguration can block registrations that putting them in front of people's eyes seems helpful

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/6b637b8d-0255-4f4a-8f18-d70626942c97)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/2a96122c-a983-4f69-8c57-5f447fad73a3)

Technical Details
----------------------------------------


Comments
----------------------------------------
I was tempted to bring up max participants too - but then that can lead into waitlist & such like