### PR TITLE
Fix Smarty Notices on Event confirm & thank you pages

### DIFF
--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -220,6 +220,8 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
    */
   public function buildQuickForm() {
     $this->assignToTemplate();
+    // This use of the ts function uses the legacy interpolation of the button name to avoid translations having to be re-done.
+    $this->assign('verifyText', !$this->_totalAmount ? ts('Click <strong>%1</strong> to complete your registration.', [1 => ts('Register')]) : $this->getPaymentProcessorObject()->getText('eventContinueText', []));
 
     if ($this->_values['event']['is_monetary'] &&
       (isset($this->_params[0]['amount']) && is_numeric($this->_params[0]['amount'])) &&
@@ -241,9 +243,6 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       $this->assign('amounts', $amountArray);
       $this->assign('totalAmount', $this->_totalAmount);
       $this->set('totalAmount', $this->_totalAmount);
-      // This use of the ts function uses the legacy interpolation of the button name to avoid translations having to be re-done.
-      $this->assign('verifyText', !$this->_totalAmount ? ts('Click <strong>%1</strong> to complete your registration.', [1 => ts('Register')]) : $this->getPaymentProcessorObject()->getText('eventContinueText', []));
-
       $showPaymentOnConfirm = (in_array($this->_eventId, \Civi::settings()->get('event_show_payment_on_confirm')) || in_array('all', \Civi::settings()->get('event_show_payment_on_confirm')));
       $this->assign('showPaymentOnConfirm', $showPaymentOnConfirm);
       if ($showPaymentOnConfirm) {

--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -180,9 +180,9 @@
       {include file="CRM/common/formButtons.tpl" location="bottom"}
     </div>
 
-    {if $event.confirm_footer_text}
+    {if array_key_exists('confirm_footer_text', $event) && $event.confirm_footer_text}
         <div id="footer_text" class="crm-section event_confirm_footer-section">
-            <p>{$event.confirm_footer_text}</p>
+            <p>{$event.confirm_footer_text|purify}</p>
         </div>
     {/if}
 </div>

--- a/templates/CRM/Event/Form/Registration/EventInfoBlock.tpl
+++ b/templates/CRM/Event/Form/Registration/EventInfoBlock.tpl
@@ -21,7 +21,7 @@
   <tr><td>{ts}When{/ts}</td>
       <td width="90%">
         {$event.event_start_date|crmDate}
-        {if $event.event_end_date}{ts}through{/ts}
+        {if array_key_exists('event_end_date', $event) && $event.event_end_date}{ts}through{/ts}
             {* Only show end time if end date = start date *}
             {if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}
               {$event.event_end_date|crmDate:0:1}
@@ -33,7 +33,7 @@
   </tr>
 
   {if $isShowLocation}
-    {if $location.address.1}
+    {if array_key_exists(1, $location.address) && $location.address.1}
       <tr><td>{ts}Location{/ts}</td>
           <td>
             {$location.address.1.display|nl2br}
@@ -48,7 +48,7 @@
     {/if}
   {/if}{*End of isShowLocation condition*}
 
-  {if $location.phone.1.phone || $location.email.1.email}
+  {if array_key_exists(1, $location.phone) || array(1, $location.email)}
     <tr><td>{ts}Contact{/ts}</td>
         <td>
         {* loop on any phones and emails for this event *}

--- a/templates/CRM/Event/Form/Registration/ThankYou.tpl
+++ b/templates/CRM/Event/Form/Registration/ThankYou.tpl
@@ -186,9 +186,9 @@
       {/crmRegion}
     {/if}
 
-    {if $event.thankyou_footer_text}
+    {if array_key_exists('thankyou_footer_text', $event) && $event.thankyou_footer_text}
         <div id="footer_text" class="crm-section event_thankyou_footer-section">
-            <p>{$event.thankyou_footer_text}</p>
+            <p>{$event.thankyou_footer_text|purify}</p>
         </div>
     {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix Smarty Notices on Event confirm & thank you pages

Before
----------------------------------------
Red notices

After
----------------------------------------
Gone

Technical Details
----------------------------------------

Comments
----------------------------------------
@demeritcowboy I don't know if you have appetite to do this one too but it is the last of the notices that I saw in the event flow & along with https://github.com/civicrm/civicrm-core/pull/29222 is close to the last of the notices in the event forms (the remiaining form is ChangeParticipantFeeSelection)