### PR TITLE
Use upper not strtoupper in Smarty as that is supported going forwards

### DIFF
--- a/xml/templates/dao.tpl
+++ b/xml/templates/dao.tpl
@@ -140,7 +140,7 @@ class {$table.className} extends CRM_Core_DAO {ldelim}
                                                                       'description'     => {$tsFunctionName}('{$field.comment|crmEscapeSingleQuotes}'),
 {/if}
 {if $field.required}
-                                        'required'  => {$field.required|strtoupper},
+                                        'required'  => {$field.required|upper},
 {/if} {* field.required *}
 {if isset($field.length)}
                       'maxlength' => {$field.length},


### PR DESCRIPTION
Overview
----------------------------------------
We either have to register strtoupper or use the supported one .. https://www.smarty.net/docs/en/language.modifier.upper.tpl
