### PR TITLE
Stop using intval in smarty

### DIFF
--- a/templates/CRM/Contact/Form/Contact.tpl
+++ b/templates/CRM/Contact/Form/Contact.tpl
@@ -92,8 +92,8 @@
   <script type="text/javascript" >
   CRM.$(function($) {
     var $form = $("form.{/literal}{$form.formClass}{literal}"),
-      action = {/literal}{$action|intval}{literal},
-      cid = {/literal}{$contactId|intval}{literal},
+      action = {/literal}{$action|string_format:"%d"}{literal},
+      cid = {/literal}{$contactId|string_format:"%d"}{literal},
       _ = CRM._;
 
     $('.crm-accordion-body').each( function() {

--- a/templates/CRM/Price/Page/LineItem.tpl
+++ b/templates/CRM/Price/Page/LineItem.tpl
@@ -109,7 +109,7 @@
         {assign var="lineItemCount" value=0}
 
         {foreach from=$pcount item=p_count}
-          {assign var="intPCount" value=$p_count.participant_count|intval}
+          {assign var="intPCount" value=$p_count.participant_count|string_format:"%d"}}
           {assign var="lineItemCount" value=$lineItemCount+$intPCount}
         {/foreach}
         {if $lineItemCount < 1}


### PR DESCRIPTION

Overview
----------------------------------------
In Smarty5 we have to register our php functions if we want to use them. Ihave been trying to find Smarty equivalents in the first instance & in this case my testing shows that this works just as well - if you go to New Individual `$contactId `is NULL so it's easy to check it casts OK to 0

Before
----------------------------------------
Use of intval causes notices on Smarty4 & won't work on Smarty5

After
----------------------------------------
Switched to smarty-native `string_format:"%d"`

Technical Details
----------------------------------------

Comments
----------------------------------------
We could register intval but at this stage I think we should only register things that we can't do otherwise