### PR TITLE
dev/core#4821 - APIv4: Allow custom field to reference value in bridge joins

### DIFF
--- a/CRM/Core/Reference/Basic.php
+++ b/CRM/Core/Reference/Basic.php
@@ -42,6 +42,9 @@ class CRM_Core_Reference_Basic implements CRM_Core_Reference_Interface {
   }
 
   /**
+   * CRM_Core_Reference_Basic returns NULL.
+   * CRM_Core_Reference_Dynamic returns the name of the dynamic column e.g. "entity_table".
+   *
    * @return string|null
    */
   public function getTypeColumn() {

--- a/CRM/Core/Reference/Dynamic.php
+++ b/CRM/Core/Reference/Dynamic.php
@@ -18,8 +18,12 @@ class CRM_Core_Reference_Dynamic extends CRM_Core_Reference_Basic {
   }
 
   /**
+   * Returns a list of all allowed values for $this->refTypeColumn
+   *
    * @return array
-   *   [table_name => EntityName]
+   *   [option_value => EntityName]
+   *   Keys are the value stored in $this->refTypeColumn,
+   *   Values are the name of the corresponding entity.
    */
   public function getTargetEntities(): array {
     $targetEntities = [];

--- a/Civi/Api4/Service/Schema/Joinable/ExtraJoinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/ExtraJoinable.php
@@ -22,10 +22,11 @@ class ExtraJoinable extends Joinable {
    *
    * @param string $baseTableAlias
    * @param string $targetTableAlias
+   * @param array|null $openJoin
    *
    * @return array
    */
-  public function getConditionsForJoin(string $baseTableAlias, string $targetTableAlias) {
+  public function getConditionsForJoin(string $baseTableAlias, string $targetTableAlias, ?array $openJoin) {
     $conditions = [];
     $this->addExtraJoinConditions($conditions, $baseTableAlias, $targetTableAlias);
     return $conditions;

--- a/Civi/Api4/Service/Schema/Joinable/Joinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/Joinable.php
@@ -99,16 +99,25 @@ class Joinable {
    *
    * @param string $baseTableAlias
    * @param string $targetTableAlias
+   * @param array|null $openJoin
    *
    * @return array
    */
-  public function getConditionsForJoin(string $baseTableAlias, string $targetTableAlias) {
+  public function getConditionsForJoin(string $baseTableAlias, string $targetTableAlias, ?array $openJoin) {
     $conditions = [];
+    $baseColumn = $this->baseColumn;
+    // Joining within a bridge, use the bridge table key instead,
+    // because the custom fields are joined first and the base entity might not be added yet.
+    if (!empty($openJoin['bridgeKey']) && $baseTableAlias === $openJoin['alias']) {
+      $conditions = $openJoin['bridgeCondition'];
+      $baseTableAlias = $openJoin['bridgeAlias'];
+      $baseColumn = $openJoin['bridgeKey'];
+    }
     if ($this->baseColumn && $this->targetColumn) {
       $conditions[] = sprintf(
         '`%s`.`%s` =  `%s`.`%s`',
         $baseTableAlias,
-        $this->baseColumn,
+        $baseColumn,
         $targetTableAlias,
         $this->targetColumn
       );


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/4821

Before
----------------------------------------
SQL error when trying to compare a field value in the on condition of a custom field.

After
----------------------------------------
Query works correctly.

Technical Details
----------------------------------------
When part of a bridge join there are two ways to get at the `id` of the joined entity. E.g. when joining Activity through ActivityContact, you could access the Activity id field either via `civicrm_activity.id` or via `civicrm_activity_contact.activity_id`. Custom fields were trying to join using the normal way of `civicrm_activity.id` but that fails if the custom field is getting joined prior to the activity table join. So instead of joining custom fields the normal way, they need to be joined to the bridge table.

Also includes follow-up to b36782187bc7d798681af955eec8b6b159a26e69 which adds metadata about these joins so the values are discoverable and not always assumed to match the name of the entity table (usually they do, but they don't have to).