### PR TITLE
 Ensure currency is set on back office participant form

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -963,6 +963,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       $paymentParams['amount'] = $this->order->getTotalAmount();
       try {
         $paymentParams['invoiceID'] = $this->getInvoiceID();
+        $paymentParams['currency'] = $this->getCurrency();
         $result = $payment->doPayment($paymentParams);
       }
       catch (\Civi\Payment\Exception\PaymentProcessorException $e) {


### PR DESCRIPTION
Should help with
https://civicrm.stackexchange.com/questions/46412/error-property-currency-has-not-been-set-when-using-submit-credit-card-eve

since property bag hardens it to a fatal error ....
