### PR TITLE
[NFC] Deprecated class name for abstract classes in phpunit

### DIFF
--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/FlexMailerSystemTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/FlexMailerSystemTest.php
@@ -20,13 +20,13 @@ namespace Civi\FlexMailer;
 use Civi\Core\Event\GenericHookEvent;
 
 // For compat w/v4.6 phpunit
-require_once 'tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php';
+require_once 'tests/phpunit/CRM/Mailing/MailingSystemTestBase.php';
 
 /**
  * Class FlexMailerSystemTest
  *
  * MailingSystemTest checks that overall composition and delivery of
- * CiviMail blasts works. It extends CRM_Mailing_BaseMailingSystemTest
+ * CiviMail blasts works. It extends CRM_Mailing_MailingSystemTestBase
  * which provides the general test scenarios -- but this variation
  * checks that certain internal events/hooks fire.
  *
@@ -35,7 +35,7 @@ require_once 'tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php';
  * @group civimail
  * @see CRM_Mailing_MailingSystemTest
  */
-class FlexMailerSystemTest extends \CRM_Mailing_BaseMailingSystemTest {
+class FlexMailerSystemTest extends \CRM_Mailing_MailingSystemTestBase {
 
   private $counts;
 

--- a/tests/phpunit/CRM/Mailing/MailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/MailingSystemTest.php
@@ -27,7 +27,7 @@
  * away from supporting.
  *
  * MailingSystemTest checks that overall composition and delivery of
- * CiviMail blasts works. It extends CRM_Mailing_BaseMailingSystemTest
+ * CiviMail blasts works. It extends CRM_Mailing_MailingSystemTestBase
  * which provides the general test scenarios -- but this variation
  * checks that certain internal events/hooks fire.
  *
@@ -37,7 +37,7 @@
  * @group civimail
  * @see \Civi\FlexMailer\FlexMailerSystemTest
  */
-class CRM_Mailing_MailingSystemTest extends CRM_Mailing_BaseMailingSystemTest {
+class CRM_Mailing_MailingSystemTest extends CRM_Mailing_MailingSystemTestBase {
 
   private $counts;
 

--- a/tests/phpunit/CRM/Mailing/MailingSystemTestBase.php
+++ b/tests/phpunit/CRM/Mailing/MailingSystemTestBase.php
@@ -26,7 +26,7 @@ use GuzzleHttp\Psr7\Request;
  * @see \Civi\FlexMailer\FlexMailerSystemTest
  * @see CRM_Mailing_MailingSystemTest
  */
-abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
+abstract class CRM_Mailing_MailingSystemTestBase extends CiviUnitTestCase {
   protected $_apiversion = 3;
 
   public $defaultParams = [];

--- a/tests/phpunit/CRM/Mailing/MultilingualSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/MultilingualSystemTest.php
@@ -271,7 +271,7 @@ class CRM_Mailing_MultilingualSystemTest extends CiviUnitTestCase {
   }
 
   /**
-   * (FIXME) De-duplicate BaseMailingSystemTest::createContactsInGroup and MultilingualSystemTest::createContactsInGroup
+   * (FIXME) De-duplicate MailingSystemTestBase::createContactsInGroup and MultilingualSystemTest::createContactsInGroup
    * This should probably be in a trait.
    *
    * Create contacts in group.


### PR DESCRIPTION
Overview
----------------------------------------
Warning:       Abstract test case classes with "Test" suffix are deprecated (CRM_Mailing_BaseMailingSystemTest)