### PR TITLE
[NFC] Remove redundant deprecated checks for assertObjectHasAttribute

### DIFF
--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -52,8 +52,6 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
     $res = CRM_Core_DAO::executeQuery($query);
     $openCaseType = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Open Case');
     while ($res->fetch()) {
-      $message = 'Failed asserting that the case activity query has a activity_type_id property:';
-      $this->assertObjectHasAttribute('activity_type_id', $res, $message . PHP_EOL . print_r($res, TRUE));
       $message = 'Failed asserting that the latest activity from Case ID 1 was "Open Case":';
       $this->assertEquals($openCaseType, $res->activity_type_id, $message . PHP_EOL . print_r($res, TRUE));
     }

--- a/tests/phpunit/CRM/Core/BAO/NavigationTest.php
+++ b/tests/phpunit/CRM/Core/BAO/NavigationTest.php
@@ -29,7 +29,6 @@ class CRM_Core_BAO_NavigationTest extends CiviUnitTestCase {
     $url = 'civicrm/report/instance/1';
     $url_params = 'reset=1';
     $new_nav = CRM_Core_BAO_Navigation::getNavItemByUrl($url, $url_params);
-    $this->assertObjectHasAttribute('id', $new_nav);
     $this->assertNotNull($new_nav->id);
   }
 
@@ -110,7 +109,6 @@ class CRM_Core_BAO_NavigationTest extends CiviUnitTestCase {
     ];
     CRM_Core_BAO_Navigation::add($params);
     $new_nav = CRM_Core_BAO_Navigation::getNavItemByUrl($url, $url_params);
-    $this->assertObjectHasAttribute('id', $new_nav);
     $this->assertNotNull($new_nav->id);
     $new_nav->delete();
   }
@@ -138,7 +136,6 @@ class CRM_Core_BAO_NavigationTest extends CiviUnitTestCase {
     ];
     CRM_Core_BAO_Navigation::add($params);
     $new_nav = CRM_Core_BAO_Navigation::getNavItemByUrl($url, 'reset=1%');
-    $this->assertObjectHasAttribute('id', $new_nav);
     $this->assertNotNull($new_nav->id);
     $new_nav->delete();
   }


### PR DESCRIPTION
Overview
----------------------------------------
This function is deprecated in phpunit9, but in all the places it's used it seems redundant because the line after would check it implicitly.
I could replace it with assertObjectHasProperty instead, but that doesn't exist in phpunit8 in case that's still being used somewhere.