### PR TITLE
Add str_starts_with modifier to Smarty

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -173,6 +173,7 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
     $this->registerPlugin('modifier', 'json_encode', 'json_encode');
     $this->registerPlugin('modifier', 'count', 'count');
     $this->registerPlugin('modifier', 'implode', 'implode');
+    $this->registerPlugin('modifier', 'str_starts_with', 'str_starts_with');
 
     $this->assign('crmPermissions', new CRM_Core_Smarty_Permissions());
 

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1599,10 +1599,11 @@ WHERE civicrm_event.is_active = 1
             $idx = $detailName . '_id';
             $values[$index] = $params[$idx];
           }
-          elseif ($fieldName == 'im') {
+          elseif ($fieldName === 'im') {
             $providerName = NULL;
             if ($providerId = $detailName . '-provider_id') {
-              $providerName = $imProviders[$params[$providerId]] ?? NULL;
+              $inputProvider = $params[$providerId] ?? '';
+              $providerName = $imProviders[$inputProvider] ?? NULL;
             }
             if ($providerName) {
               $values[$index] = $params[$detailName] . " (" . $providerName . ")";
@@ -1611,7 +1612,7 @@ WHERE civicrm_event.is_active = 1
               $values[$index] = $params[$detailName];
             }
           }
-          elseif ($fieldName == 'phone') {
+          elseif ($fieldName === 'phone') {
             $phoneExtField = str_replace('phone', 'phone_ext', $detailName);
             if (isset($params[$phoneExtField])) {
               $values[$index] = $params[$detailName] . " (" . $params[$phoneExtField] . ")";

--- a/templates/CRM/Event/Form/Registration/ThankYou.tpl
+++ b/templates/CRM/Event/Form/Registration/ThankYou.tpl
@@ -13,10 +13,10 @@
 
 <div class="crm-event-id-{$event.id} crm-block crm-event-thankyou-form-block">
     {* Don't use "normal" thank-you message for Waitlist and Approval Required registrations - since it will probably not make sense for those situations. dgg *}
-    {if $event.thankyou_text AND (not $isOnWaitlist AND not $isRequireApproval)}
+    {if array_key_exists('thankyou_text', $event) AND (not $isOnWaitlist AND not $isRequireApproval)}
         <div id="intro_text" class="crm-section event_thankyou_text-section">
             <p>
-            {$event.thankyou_text}
+            {$event.thankyou_text|purify}
             </p>
         </div>
     {/if}

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -60,7 +60,7 @@
         <div class="content">
           {if $profileFieldName|str_starts_with:'im-'}
             {assign var="provider" value=profileFieldNamen|cat:"-provider_id"}
-            {$form.$provider.html}&nbsp;
+            {if array_key_exists($provider, $form)}{$form.$provider.html}{/if}&nbsp;
           {/if}
 
           {if $profileFieldName eq 'email_greeting' or  $profileFieldName eq 'postal_greeting' or $profileFieldName eq 'addressee'}
@@ -118,7 +118,7 @@
           {elseif $profileFieldName|str_starts_with:'phone'}
             {assign var="phone_ext_field" value=$profileFieldName|replace:'phone':'phone_ext'}
             {$formElement.html}
-            {if $form.$phone_ext_field.html}
+            {if array_key_exists($phone_ext_field, $form)}
               &nbsp;{$form.$phone_ext_field.html}
             {/if}
           {else}

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -58,7 +58,7 @@
           {$formElement.label}
         </div>
         <div class="content">
-          {if $profileFieldName|substr:0:3 eq 'im-'}
+          {if $profileFieldName|str_starts_with:'im-'}
             {assign var="provider" value=profileFieldNamen|cat:"-provider_id"}
             {$form.$provider.html}&nbsp;
           {/if}
@@ -115,7 +115,7 @@
                 </div>
               </div>
             {/if}
-          {elseif $profileFieldName|substr:0:5 eq 'phone'}
+          {elseif $profileFieldName|str_starts_with:'phone'}
             {assign var="phone_ext_field" value=$profileFieldName|replace:'phone':'phone_ext'}
             {$formElement.html}
             {if $form.$phone_ext_field.html}


### PR DESCRIPTION

Overview
----------------------------------------
Add str_starts_with modifier to Smarty

Using str_starts_with like this  will work on Smarty2 / 3 already but needs this to work on Smarty4 / Smarty5 without notices

Before
----------------------------------------
We use `|substr` in a handful of  places in the template layer in core & contact layout editor. It is used in this way in all cases... (ie looking for str_starts_with). In Smarty4 all php functions must be registered or notices will appear

After
----------------------------------------
You can tell it's working cos we get brand new notices when we display the form with phone & im

![image](https://github.com/civicrm/civicrm-core/assets/336308/885a808f-98d8-48df-a083-ebcf3d40722f)


Technical Details
----------------------------------------
@colemanw definitely prefers str_starts_with over substr....

Comments
----------------------------------------
