### PR TITLE
Fix clearAssign for php8.x

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -280,12 +280,17 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
     }
   }
 
-  public function clearTemplateVars() {
-    foreach (array_keys($this->_tpl_vars) as $key) {
-      if ($key == 'config' || $key == 'session') {
+  public function clearTemplateVars(): void {
+    foreach (array_keys($this->getTemplateVars()) as $key) {
+      if ($key === 'config' || $key === 'session') {
         continue;
       }
-      unset($this->_tpl_vars[$key]);
+      if (method_exists($this, 'clearAssign')) {
+        $this->clearAssign($key);
+      }
+      else {
+        $this->clear_assign($key);
+      }
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
In php8.x clear assign spits because of accessing unavailable properties - this fixes by calling functions

