### PR TITLE
Unshare the SMSCommon::preProcess function between the 

### DIFF
--- a/CRM/Activity/Form/Task/SMS.php
+++ b/CRM/Activity/Form/Task/SMS.php
@@ -41,7 +41,19 @@ class CRM_Activity_Form_Task_SMS extends CRM_Activity_Form_Task {
    */
   public function preProcess() {
     parent::preProcess();
-    CRM_Contact_Form_Task_SMSCommon::preProcessProvider($this);
+    $form = $this;
+    $this->bounceOnNoActiveProviders();
+    $activityCheck = 0;
+    foreach ($this->_activityHolderIds as $value) {
+      if (CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity', $value, 'subject', 'id') != CRM_Contact_Form_Task_SMSCommon::RECIEVED_SMS_ACTIVITY_SUBJECT) {
+        $activityCheck++;
+      }
+    }
+    if ($activityCheck == count($this->_activityHolderIds)) {
+      CRM_Core_Error::statusBounce(ts("The Reply SMS Could only be sent for activities with '%1' subject.",
+        [1 => CRM_Contact_Form_Task_SMSCommon::RECIEVED_SMS_ACTIVITY_SUBJECT]
+      ));
+    }
     $this->assign('single', $this->_single);
   }
 

--- a/CRM/Contact/Form/Task/SMS.php
+++ b/CRM/Contact/Form/Task/SMS.php
@@ -36,15 +36,20 @@ class CRM_Contact_Form_Task_SMS extends CRM_Contact_Form_Task {
    */
   public $_templates = NULL;
 
-  public function preProcess() {
+  /**
+   * @var float|int|mixed|string|null
+   */
+  public $_context;
+
+  public function preProcess(): void {
 
     $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this, FALSE);
 
-    CRM_Contact_Form_Task_SMSCommon::preProcessProvider($this);
-
-    if (!$cid && $this->_context != 'standalone') {
+    $this->_single = $this->_context !== 'search';
+    $this->bounceOnNoActiveProviders();
+    if (!$cid && $this->_context !== 'standalone') {
       parent::preProcess();
     }
 

--- a/CRM/Contact/Form/Task/SMSCommon.php
+++ b/CRM/Contact/Form/Task/SMSCommon.php
@@ -30,9 +30,12 @@ class CRM_Contact_Form_Task_SMSCommon {
   /**
    * Pre process the provider.
    *
+   * @deprecated since 5.71 will be removed around 5.77.
+   *
    * @param CRM_Core_Form $form
    */
   public static function preProcessProvider(&$form) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     $form->_single = FALSE;
     $className = CRM_Utils_System::getClassName($form);
 

--- a/CRM/Contact/Form/Task/SMSTrait.php
+++ b/CRM/Contact/Form/Task/SMSTrait.php
@@ -28,6 +28,13 @@ trait CRM_Contact_Form_Task_SMSTrait {
     CRM_Contact_Form_Task_SMSCommon::postProcess($this);
   }
 
+  protected function bounceOnNoActiveProviders(): void {
+    $providersCount = CRM_SMS_BAO_Provider::activeProviderCount();
+    if (!$providersCount) {
+      CRM_Core_Error::statusBounce(ts('There are no SMS providers configured, or no SMS providers are set active'));
+    }
+  }
+
   /**
    * List available tokens for this form.
    *


### PR DESCRIPTION


Overview
----------------------------------------
Unshare the SMSCommon::preProcess function between the 

Before
----------------------------------------
2 classes share the function but there is only 2 line it in that both classes call


After
----------------------------------------
separated

Technical Details
----------------------------------------

Comments
----------------------------------------
