### PR TITLE
[NFC] Resurrect searchkit download test

### DIFF
--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDownloadTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDownloadTest.php
@@ -99,18 +99,8 @@ class SearchDownloadTest extends \PHPUnit\Framework\TestCase implements Headless
 
   /**
    * Test downloading CSV format.
-   *
-   * Must run in separate process to capture direct output to browser
-   *
-   * @runInSeparateProcess
-   * @preserveGlobalState disabled
    */
   public function testDownloadCSV() {
-    $this->markTestIncomplete('Unable to get this test working in separate process, probably due to being in an extension');
-
-    // Re-enable because this test has to run in a separate process
-    \CRM_Extension_System::singleton()->getManager()->install('org.civicrm.search_kit');
-
     $lastName = uniqid(__FUNCTION__);
     $sampleData = [
       ['first_name' => 'One', 'last_name' => $lastName],
@@ -162,14 +152,16 @@ class SearchDownloadTest extends \PHPUnit\Framework\TestCase implements Headless
     foreach ($sampleData as $row) {
       $expectedOut .= '\s+' . preg_quote('"' . $row['first_name'] . ' ' . $lastName . '"');
     }
-    $this->expectOutputRegex('#' . $expectedOut . '#');
+    $expectedOut = '#' . $expectedOut . '#';
 
     try {
+      ob_start();
       civicrm_api4('SearchDisplay', 'download', $params);
+      ob_end_clean();
       $this->fail();
     }
     catch (\CRM_Core_Exception_PrematureExitException $e) {
-      // All good, we expected the api to exit
+      $this->assertMatchesRegularExpression($expectedOut, ob_get_clean());
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
I don't remember exactly what we tried in https://github.com/civicrm/civicrm-core/pull/21328, but maybe this will work now.

Before
----------------------------------------


After
----------------------------------------
Test

Technical Details
----------------------------------------


Comments
----------------------------------------
What originally spurred this was that I wanted to get at the download output programatically, and then realized that wasn't really what I wanted anyway, but in looking into it came across this.