### PR TITLE
CryptoJwt - Fix detection of firebase/php-jwt APIs

### DIFF
--- a/Civi/Crypto/CryptoJwt.php
+++ b/Civi/Crypto/CryptoJwt.php
@@ -60,12 +60,9 @@ class CryptoJwt {
    * @throws CryptoException
    */
   public function decode($token, $keyTag = 'SIGN') {
-    // Version 6.x+ has 2 parameters, earlier versions had 3
-    $reflection = new \ReflectionMethod('Firebase\JWT\JWT::decode');
-    $useKeyObj = ($reflection->getNumberOfParameters() === 2) ?? FALSE;
-
-    // Composer\InstalledVersions returns 0 if the library has been replaced using "replace" in composer.json
-    // $useKeyObj = version_compare(\Composer\InstalledVersions::getVersion('firebase/php-jwt'), '6', '>=');
+    // TODO: Circa mid-2024, make a hard-requirement on firebase/php-jwt v5.5+.
+    // Then we can remove this guard and simplify the `$keysByAlg` stuff.
+    $useKeyObj = class_exists(Key::class);
     if (!$useKeyObj) {
       \CRM_Core_Error::deprecatedWarning('Using deprecated version of firebase/php-jwt. Upgrade to 6.x+.');
     }


### PR DESCRIPTION
Overview
----------------------------------------

5.70's #28971 introduced a different check for detecting firebase/php-jwt APIs. It distinguishes Firbase JWT [v5.x](https://github.com/firebase/php-jwt/blob/v5.5.1/src/JWT.php#L83) from [v6.0](https://github.com/firebase/php-jwt/blob/v6.0.0/src/JWT.php#L85) -- but then it misinterprets [v6.6+](https://github.com/firebase/php-jwt/blob/v6.6.0/src/JWT.php#L99) and crashes.

(ping @seamuslee001 @mattwire)


Before
----------------------------------------

If you have `firebase/php-jwt` v6.6+, then it chooses the wrong behavior and gives it the v5.x-style call. This leads to errors like:

```
Error: Cannot pass parameter 3 by reference in Civi\Crypto\CryptoJwt->decode() (line 92 of /Users/totten/bknix/build/build-0/vendor/civicrm/civicrm-core/Civi/Crypto/CryptoJwt.php)

#0 /Users/totten/bknix/build/build-0/vendor/civicrm/civicrm-core/ext/authx/Civi/Authx/CheckCredential.php(96): Civi\Crypto\CryptoJwt->decode('')
#1 [internal function]: Civi\Authx\CheckCredential->bearerJwt(Object(Civi\Authx\CheckCredentialEvent), 'civi.authx.chec...', Object(Civi\Core\UnoptimizedEventDispatcher))
```

After
----------------------------------------

That works.

Technical Details
----------------------------------------

The reason why the test from 28971 doesn't work is that the method signature has been moving around:

* https://github.com/firebase/php-jwt/blob/v5.4.0/src/JWT.php#L79
* https://github.com/firebase/php-jwt/blob/v5.5.0/src/JWT.php#L82
* https://github.com/firebase/php-jwt/blob/v6.0.0/src/JWT.php#L85
* https://github.com/firebase/php-jwt/blob/v6.6.0/src/JWT.php#L99
