### PR TITLE
dev/core/-/issues/2915 Replace 'Expose Publicly' with 'Public Pages' which is less offensive for some demographics

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -369,8 +369,8 @@ class CRM_Core_SelectValues {
   public static function ufVisibility() {
     return [
       'User and User Admin Only' => ts('User and User Admin Only'),
-      'Public Pages' => ts('Expose Publicly'),
-      'Public Pages and Listings' => ts('Expose Publicly and for Listings'),
+      'Public Pages' => ts('Public Pages'),
+      'Public Pages and Listings' => ts('Public Pages and Listings'),
     ];
   }
 

--- a/js/model/crm.uf.js
+++ b/js/model/crm.uf.js
@@ -8,8 +8,8 @@
 
   var VISIBILITY = [
     {val: 'User and User Admin Only', label: ts('User and User Admin Only'), isInSelectorAllowed: false},
-    {val: 'Public Pages', label: ts('Expose Publicly'), isInSelectorAllowed: true},
-    {val: 'Public Pages and Listings', label: ts('Expose Publicly and for Listings'), isInSelectorAllowed: true}
+    {val: 'Public Pages', label: ts('Public Pages'), isInSelectorAllowed: true},
+    {val: 'Public Pages and Listings', label: ts('Public Pages and Listings'), isInSelectorAllowed: true}
   ];
 
   var LOCATION_TYPES = _.map(CRM.PseudoConstant.locationType, function(value, key) {

--- a/templates/CRM/UF/Form/Field.hlp
+++ b/templates/CRM/UF/Form/Field.hlp
@@ -57,10 +57,10 @@
 {/htxt}
 {htxt id='visibility'}
   <p>
-    {ts}Is this field hidden from public search ('User and User Admin Only'), or is it visible to the public and potentially searchable in the Profile Search form ('Expose Publicly' or 'Expose Publicly and for Listings')?  ('User and User Admin Only') fields can still be used for Edit and Create mode.{/ts}
+    {ts}Is this field hidden from public search ('User and User Admin Only'), or is it visible to the public and potentially searchable in the Profile Search form ('Public Pages' or 'Public Pages and Listings')?  ('User and User Admin Only') fields can still be used for Edit and Create mode.{/ts}
   </p>
   <p>
-    {ts}When visibility is 'Expose Publicly and for Listings', users can also click the field value when viewing a contact in order to locate other contacts with the same value(s) (i.e. other contacts who live in Poland).{/ts}
+    {ts}When visibility is 'Public Pages and Listings', users can also click the field value when viewing a contact in order to locate other contacts with the same value(s) (i.e. other contacts who live in Poland).{/ts}
   </p>
 {/htxt}
 

--- a/tests/phpunit/CRM/Core/PseudoConstantTest.php
+++ b/tests/phpunit/CRM/Core/PseudoConstantTest.php
@@ -390,7 +390,7 @@ class CRM_Core_PseudoConstantTest extends CiviUnitTestCase {
         ],
         [
           'fieldName' => 'visibility',
-          'sample' => 'Expose Publicly',
+          'sample' => 'Public Pages',
         ],
       ],
       'CRM_Core_DAO_UFJoin' => [


### PR DESCRIPTION
Overview
----------------------------------------
Fix inconsistent use of 'Expose Publicly' to consistently use 'Public Pages'.

'Public Pages' is less offensive for some demographics than 'Expose Publicly' which has also been noted by our users more than once. See related proposal https://lab.civicrm.org/dev/core/-/issues/2915

This also aligns the Group listing with the updated SearchKit Group Listing which does use the consistent terminology of 'Public Pages'.

Before
----------------------------------------
"Expose Publicly" is shown in the Group listing (pre Searchkit / AdminUI) and then differently on the Group Settings page, displaying the same option as "Public Pages", this inconsistency is confusing.

The code internally uses the terminology "Public Pages" which is then replaced on the front-end with "Expose Publicly".

![image](https://github.com/civicrm/civicrm-core/assets/58866555/275c1e90-612c-4c19-abce-383fff9b5f9c)

![image](https://github.com/civicrm/civicrm-core/assets/58866555/6b8290a2-11bc-4654-993d-87737b6e9503)

![image](https://github.com/civicrm/civicrm-core/assets/58866555/a263358f-ae0c-44e8-9ade-5b1341bf80e1)

![image](https://github.com/civicrm/civicrm-core/assets/58866555/28c86870-1277-49e4-a9cd-f5efd5b7ff9d)

After
----------------------------------------
Consistent use of terminology, "Public Pages".

![image](https://github.com/civicrm/civicrm-core/assets/58866555/761926a2-0691-4dce-bcef-0670217b2dea)

![image](https://github.com/civicrm/civicrm-core/assets/58866555/43bdc53d-7bb7-4b6e-b191-e7a319b23974)

Technical Details
----------------------------------------

Comments
----------------------------------------
Agileware Ref: CIVICRM-1870
