### PR TITLE
Fix BackOffice Membership forms getPriceSetID() to be standard

### DIFF
--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -551,20 +551,21 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
   }
 
   /**
-   * Get the selected price set id.
+   * Get the price set ID.
    *
-   * @param array $params
-   *   Parameters submitted to the form.
+   * @api Supported for external use.
    *
    * @return int
    */
-  protected function getPriceSetID(array $params): int {
-    $priceSetID = $params['price_set_id'] ?? NULL;
-    if (!$priceSetID) {
-      $priceSetDetails = $this->getPriceSetDetails($params);
-      return (int) key($priceSetDetails);
+  public function getPriceSetID(): int {
+    $this->_priceSetId = $this->getSubmittedValue('price_set_id') ?? NULL;
+    if (!$this->_priceSetId) {
+      $priceSet = CRM_Price_BAO_PriceSet::getDefaultPriceSet('membership');
+      $priceSet = reset($priceSet);
+      $priceSetDetails = CRM_Price_BAO_PriceSet::getSetDetail($priceSet['setID']);
+      $this->_priceSetId = key($priceSetDetails);
     }
-    return (int) $priceSetID;
+    return (int) $this->_priceSetId;
   }
 
   /**
@@ -577,7 +578,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    */
   protected function setPriceSetParameters(array $formValues): array {
     // process price set and get total amount and line items.
-    $this->_priceSetId = $this->getPriceSetID($formValues);
+    $this->getPriceSetID();
     $this->ensurePriceParamsAreSet($formValues);
     $priceSetDetails = $this->getPriceSetDetails($formValues);
     $this->_priceSet = $priceSetDetails[$this->_priceSetId];

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -594,7 +594,7 @@ DESC limit 1");
   public static function formRule($params, $files, $self) {
     $errors = [];
 
-    $priceSetId = $self->getPriceSetID($params);
+    $priceSetId = $self->getPriceSetID();
     $priceSetDetails = $self->getPriceSetDetails($params);
 
     $selectedMemberships = self::getSelectedMemberships($priceSetDetails[$priceSetId], $params);

--- a/ext/contributioncancelactions/tests/phpunit/CancelTest.php
+++ b/ext/contributioncancelactions/tests/phpunit/CancelTest.php
@@ -4,6 +4,7 @@ use Civi\Api4\Activity;
 use Civi\Api4\Contribution;
 use Civi\Test\Api3TestTrait;
 use Civi\Test\CiviEnvBuilder;
+use Civi\Test\FormTrait;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
@@ -35,6 +36,7 @@ class CancelTest extends TestCase implements HeadlessInterface, HookInterface, T
 
   use Api3TestTrait;
   use ContactTestTrait;
+  use FormTrait;
 
   /**
    * Created ids.
@@ -271,17 +273,13 @@ class CancelTest extends TestCase implements HeadlessInterface, HookInterface, T
     $this->createLoggedInUser();
     $formValues = [
       'contact_id' => $this->ids['contact'][0],
+      'financial_type_id' => 1,
       'contribution_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Cancelled'),
     ];
-    $form = new CRM_Contribute_Form_Contribution();
-    $_SERVER['REQUEST_METHOD'] = 'GET';
-    $form->controller = new CRM_Core_Controller();
-    $form->controller->setStateMachine(new CRM_Core_StateMachine($form->controller));
-    $_SESSION['_' . $form->controller->_name . '_container']['values']['Contribution'] = $formValues;
-    $_REQUEST['action'] = 'update';
-    $_REQUEST['id'] = $this->ids['Contribution'][0];
-    $form->buildForm();
-    $form->postProcess();
+    $this->getTestForm('CRM_Contribute_Form_Contribution', $formValues, [
+      'action' => 'update',
+      'id' => $this->ids['Contribution'][0],
+    ])->processForm();
 
     $contribution = Contribution::get()
       ->addWhere('id', '=', $this->ids['Contribution'][0])

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -388,6 +388,7 @@ London,',
       $event = $this->eventCreateUnpaid($eventParams);
     }
     $submittedValues['event_id'] = $event['id'];
+    $submittedValues['_qf_default'] = 'Builder:refresh';
     $submittedValues['receipt_text'] = 'Contact the Development Department if you need to make any changes to your registration.';
     return $this->getTestForm('CRM_Event_Form_Participant', $submittedValues, ['cid' => $submittedValues['contact_id']])->processForm(FormWrapper::BUILT);
   }
@@ -403,7 +404,7 @@ London,',
    */
   protected function submitForm(array $eventParams = [], array $submittedValues = [], bool $isQuickConfig = FALSE): EventFormParticipant {
     $form = $this->getForm($eventParams, $submittedValues, $isQuickConfig);
-    $form->postProcess();
+    $form->processForm();
     return $form;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix BackOffice Membership forms getPriceSetID() to be standard

Before
----------------------------------------
We have been encouraging people to switch from accessing 'any property or method they can find' to ones designated as supported for external use. One of these is `getPriceSetID()` but on the back office membership form this function is non-standard and non-public

After
----------------------------------------
The methods are standard & public

Technical Details
----------------------------------------
The function is called both from a `postProcess()` and from a `formRule()` function - we have hit a couple of gotchas sharing some between these which I have also addressed.

We now recommend the use of `getSubmittedValue()` and `getSubmittedValues()` to retrieve the data the user has submitted. These functions do a bit of extra handing around money & also permit forms in multi-form flows to access the submitted values even through the values were submitted on a different form in the flow.

However, the values aren't loaded into the QuickForm array until validate has been run - so up until that point we need to access the `submitValue()` function - the contents of which differ in that that they are basically raw post & not yet validated. 

But all that is a lot to know - a developer calling `getSubmittedValue()` wants to get the value the user submitted with an appropriate level of processing without having to do something different at different points of the submission. I did add an extra `purify` in there cos it seemed like good practice & I'd rather remove it later than add it later but I don't see it having any real impact in the way this is currently used.

Comments
----------------------------------------
