### PR TITLE
Fix failure to handle localised money, notice on batch membership form

### DIFF
--- a/templates/CRM/Batch/Form/Entry.tpl
+++ b/templates/CRM/Batch/Form/Entry.tpl
@@ -112,7 +112,7 @@
       </div>
     {/section}
   </div>
-  <div class="crm-submit-buttons">{if $fields}{$form._qf_Batch_refresh.html}{/if} &nbsp; {$form.buttons.html}</div>
+  <div class="crm-submit-buttons">{if $fields && array_key_exists('_qf_Batch_refresh', $form) && is_array($form._qf_Batch_refresh)}{$form._qf_Batch_refresh.html}{/if} &nbsp; {$form.buttons.html}</div>
 </div>
 {literal}
 <script type="text/javascript">


### PR DESCRIPTION
Overview
----------------------------------------
Fix failure to handle localised money, notice on batch membership form

Before
----------------------------------------
Using the batch entry form to enter memberships the total_amount is mangled is not handled if it is using non-English currency separators

After
----------------------------------------
Input passed through cleanMoney - successfull processing of an amount > 1000

Other notices fixes

![image](https://github.com/civicrm/civicrm-core/assets/336308/e609bee6-8d66-4745-aa05-1569229b8b53)

Technical Details
----------------------------------------
I was trying to replicate https://lab.civicrm.org/dev/core/-/issues/4089 but did not find that & suspect is if fixed