### PR TITLE
dev/core#4993 block Sync CMS Users form and functionality on Standalone

### DIFF
--- a/CRM/Admin/Form/CMSUser.php
+++ b/CRM/Admin/Form/CMSUser.php
@@ -26,6 +26,15 @@ class CRM_Admin_Form_CMSUser extends CRM_Core_Form {
   public $submitOnce = TRUE;
 
   /**
+   * Disable on Standalone
+   */
+  public function preProcess() {
+    if (!\CRM_Utils_System::allowSynchronizeUsers()) {
+      \CRM_Core_Error::statusBounce(ts('This framework doesn\'t allow for syncing CMS users.'));
+    }
+  }
+
+  /**
    * Build the form object.
    */
   public function buildQuickForm() {
@@ -47,7 +56,7 @@ class CRM_Admin_Form_CMSUser extends CRM_Core_Form {
    * Process the form submission.
    */
   public function postProcess() {
-    $result = CRM_Utils_System::synchronizeUsers();
+    $result = CRM_Utils_System::synchronizeUsersIfAllowed();
 
     $status = ts('Checked one user record.',
         [

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -525,6 +525,17 @@ class CRM_Extension_Manager {
   }
 
   /**
+   * Check if a given extension is installed and enabled
+   *
+   * @param $key
+   *
+   * @return bool
+   */
+  public function isEnabled($key) {
+    return ($this->getStatus($key) === self::STATUS_INSTALLED);
+  }
+
+  /**
    * Check if a given extension is incompatible with this version of CiviCRM
    *
    * @param $key

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -967,6 +967,27 @@ abstract class CRM_Utils_System_Base {
   }
 
   /**
+   * Whether to allow access to CMS user sync action
+   * @return bool
+   */
+  public function allowSynchronizeUsers() {
+    return TRUE;
+  }
+
+  /**
+   * Run CMS user sync if allowed, otherwise just returns empty array
+   * @return array
+   */
+  public function synchronizeUsersIfAllowed() {
+    if ($this->allowSynchronizeUsers()) {
+      return $this->synchronizeUsers();
+    }
+    else {
+      return [];
+    }
+  }
+
+  /**
    * Send an HTTP Response base on PSR HTTP RespnseInterface response.
    *
    * @param \Psr\Http\Message\ResponseInterface $response

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -420,10 +420,12 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
   }
 
   /**
-   * @inheritDoc
+   * CMS User Sync doesn't make sense when using standaloneusers
+   * (but leave open the door for other user extensions, which might have a sync method)
+   * @return bool
    */
-  public function synchronizeUsers() {
-    return Security::singleton()->synchronizeUsers();
+  public function allowSynchronizeUsers() {
+    return !\CRM_Extension_System::singleton()->getManager()->isEnabled('standaloneusers');
   }
 
   /**

--- a/ext/authx/tests/phpunit/Civi/Authx/AbstractFlowsTest.php
+++ b/ext/authx/tests/phpunit/Civi/Authx/AbstractFlowsTest.php
@@ -32,7 +32,7 @@ class AbstractFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndI
       ->installMe(__DIR__)
       ->callback(
         function() {
-          \CRM_Utils_System::synchronizeUsers();
+          \CRM_Utils_System::synchronizeUsersIfAllowed();
         },
         'synchronizeUsers'
       )

--- a/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
@@ -1,6 +1,7 @@
 <?php
 use CRM_Standaloneusers_ExtensionUtil as E;
 use Civi\Api4\MessageTemplate;
+use Civi\Api4\Navigation;
 
 /**
  * Collection of upgrade steps.
@@ -99,18 +100,28 @@ class CRM_Standaloneusers_Upgrader extends CRM_Extension_Upgrader_Base {
   // }
 
   /**
-   * Example: Run a simple query when a module is enabled.
+   * On enable:
+   * - disable the user sync menu item
    */
-  // public function enable() {
-  //  CRM_Core_DAO::executeQuery('UPDATE foo SET is_active = 1 WHERE bar = "whiz"');
-  // }
+  public function enable() {
+    // standaloneusers is incompatible with user sync, so disable this nav menu item
+    Navigation::update(FALSE)
+      ->addWhere('url', '=', 'civicrm/admin/synchUser?reset=1')
+      ->addValue('is_active', FALSE)
+      ->execute();
+  }
 
   /**
-   * Example: Run a simple query when a module is disabled.
+   * On disable:
+   * - re-enable the user sync menu item
    */
-  // public function disable() {
-  //   CRM_Core_DAO::executeQuery('UPDATE foo SET is_active = 0 WHERE bar = "whiz"');
-  // }
+  public function disable() {
+    // reinstate user sync menu item
+    Navigation::update(FALSE)
+      ->addWhere('url', '=', 'civicrm/admin/synchUser?reset=1')
+      ->addValue('is_active', TRUE)
+      ->execute();
+  }
 
   /**
    * Example: Run a couple simple queries.

--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -280,21 +280,6 @@ class Security {
   }
 
   /**
-   * Since our User entity contains a FK to a contact, it's not possible for a User to exist without a contact.
-   *
-   * @todo review this (what if contact is deleted?)
-   */
-  public function synchronizeUsers() {
-
-    $userCount = \Civi\Api4\User::get(FALSE)->selectRowCount()->execute()->countMatched();
-    return [
-      'contactCount' => $userCount,
-      'contactMatching' => $userCount,
-      'contactCreated' => 0,
-    ];
-  }
-
-  /**
    * High level function to encrypt password using the site-default mechanism.
    */
   public function hashPassword(string $plaintext): string {

--- a/tests/phpunit/CiviTest/CiviEndToEndTestCase.php
+++ b/tests/phpunit/CiviTest/CiviEndToEndTestCase.php
@@ -17,7 +17,7 @@ class CiviEndToEndTestCase extends PHPUnit\Framework\TestCase implements \Civi\T
       'name' => $GLOBALS['_CV']['ADMIN_USER'],
       'pass' => $GLOBALS['_CV']['ADMIN_PASS'],
     ]);
-    CRM_Utils_System::synchronizeUsers();
+    CRM_Utils_System::synchronizeUsersIfAllowed();
 
     parent::setUpBeforeClass();
   }

--- a/tests/phpunit/E2E/Cache/CacheTestCase.php
+++ b/tests/phpunit/E2E/Cache/CacheTestCase.php
@@ -24,7 +24,7 @@ abstract class E2E_Cache_CacheTestCase extends CiviSimpleCacheTest implements \C
       'name' => $GLOBALS['_CV']['ADMIN_USER'],
       'pass' => $GLOBALS['_CV']['ADMIN_PASS'],
     ]);
-    CRM_Utils_System::synchronizeUsers();
+    \CRM_Utils_System::synchronizeUsersIfAllowed();
 
     parent::setUpBeforeClass();
   }

--- a/tests/phpunit/E2E/Extern/AuthxRestTest.php
+++ b/tests/phpunit/E2E/Extern/AuthxRestTest.php
@@ -22,7 +22,7 @@ class E2E_Extern_AuthxRestTest extends E2E_Extern_BaseRestTest {
       ->install(['authx'])
       ->callback(
         function() {
-          \CRM_Utils_System::synchronizeUsers();
+          \CRM_Utils_System::synchronizeUsersIfAllowed();
         },
         'synchronizeUsers'
       )


### PR DESCRIPTION
Overview
----------------------------------------
Block CMS user sync form when using Standaloneusers extension, because it doesn't do anything. And the most secure code is no code.

There was a note about the case when the contact of a user was deleted -- but deleting a contact with a user attached is prevented with https://github.com/civicrm/civicrm-core/pull/29026
