### PR TITLE
dev/core#4988 Standalone - use regular php session during install

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -553,8 +553,12 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    * Start a new session.
    */
   public function sessionStart() {
-    $session_handler = new SessionHandler();
-    session_set_save_handler($session_handler);
+    // during installation we can't use the session handler from the extension yet
+    // so we fall back to a default php session
+    if (!defined('CIVI_SETUP')) {
+      $session_handler = new SessionHandler();
+      session_set_save_handler($session_handler);
+    }
 
     $session_max_lifetime = Civi::settings()->get('standaloneusers_session_max_lifetime') ?? 1440;
 

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -553,11 +553,17 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    * Start a new session.
    */
   public function sessionStart() {
-    // during installation we can't use the session handler from the extension yet
-    // so we fall back to a default php session
-    if (!defined('CIVI_SETUP')) {
+    if (defined('CIVI_SETUP')) {
+      // during installation we can't use the session
+      // handler from the extension yet so we just
+      // use a default php session
+      // use a different cookie name to avoid any nasty clash
+      $session_cookie_name = 'SESSCIVISOINSTALL';
+    }
+    else {
       $session_handler = new SessionHandler();
       session_set_save_handler($session_handler);
+      $session_cookie_name = 'SESSCIVISO';
     }
 
     $session_max_lifetime = Civi::settings()->get('standaloneusers_session_max_lifetime') ?? 1440;
@@ -566,7 +572,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
       'cookie_httponly'  => 1,
       'cookie_secure'    => !empty($_SERVER['HTTPS']),
       'gc_maxlifetime'   => $session_max_lifetime,
-      'name'             => 'SESSCIVISO',
+      'name'             => $session_cookie_name,
       'use_cookies'      => 1,
       'use_only_cookies' => 1,
       'use_strict_mode'  => 1,


### PR DESCRIPTION
Before
----------------------------------------
Installing Standalone through the web UI crashes because the installer wants to initialise a session before the SessionHandler provided by Standaloneusers extension is available.

After
----------------------------------------
Use the default php session handler during install.

Technical Details
----------------------------------------
This just opts out of the custom SessionHandler based on `CIVI_SETUP` being set - other parameters to the `session_start` call ( in particular the custom session cookie name ) are retained.

Questions:
- is there any risk to the opt-out based on `CIVI_SETUP`? could anything bad happen if CIVI_SETUP is set when it shouldn't be?
- when exactly does the transfer over to the "proper" `standaloneusers` session happen? will anything important from the session be lost at this point? e.g. notices from the install phase?

An alternative solution is to hook in early to enable the `standaloneusers` extension: https://github.com/civicrm/civicrm-core/pull/29362