### PR TITLE
api3 job.process_membership: allow passing a comma-separated list of exclude_membership_status_ids

### DIFF
--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -460,7 +460,7 @@ function civicrm_api3_job_process_membership($params) {
 
   // We need to pass this through as a simple array of membership status IDs as values.
   if (!empty($params['exclude_membership_status_ids'])) {
-    is_array($params['exclude_membership_status_ids']) ?: $params['exclude_membership_status_ids'] = [$params['exclude_membership_status_ids']];
+    is_array($params['exclude_membership_status_ids']) ?: $params['exclude_membership_status_ids'] = explode(',', $params['exclude_membership_status_ids']);
   }
   if (!empty($params['exclude_membership_status_ids']['IN'])) {
     $params['exclude_membership_status_ids'] = $params['exclude_membership_status_ids']['IN'];
@@ -487,7 +487,7 @@ function _civicrm_api3_job_process_membership_spec(&$params) {
   $params['only_active_membership_types']['type'] = CRM_Utils_Type::T_BOOLEAN;
   $params['exclude_membership_status_ids']['title'] = 'Exclude membership status IDs from calculations';
   $params['exclude_membership_status_ids']['description'] = 'Default: Exclude Pending, Cancelled, Expired. Deceased will always be excluded';
-  $params['exclude_membership_status_ids']['type'] = CRM_Utils_Type::T_INT;
+  $params['exclude_membership_status_ids']['type'] = CRM_Utils_Type::T_STRING;
   $params['exclude_membership_status_ids']['pseudoconstant'] = [
     'table' => 'civicrm_membership_status',
     'keyColumn' => 'id',


### PR DESCRIPTION
Overview
----------------------------------------

The api3 call `job.process_membership` supports passing a param called `exclude_membership_status_ids`, but when used from the Scheduled Jobs or from the CLI, it only supports 1 ID, not a list of comma-separated IDs.

Before
----------------------------------------

This fails:

```
cv api job.process_membership runInNonProductionEnvironment=TRUE  exclude_membership_status_ids=5,6,7
```

After
----------------------------------------

It works as intended.


Comments
----------------------------------------

If merged, I'll updated the docs: https://docs.civicrm.org/user/en/latest/initial-set-up/scheduled-jobs/#job_process_membership

I had a request to support setting all Expired members to Archived after a certain number of years. It was not possible because Expired is ignored by default (alternatively I could have updated them to a pre-expired status, but I don't why not support this).