### PR TITLE
Standalone install - check upload directory is writable

### DIFF
--- a/setup/plugins/installFiles/StandaloneCivicrmFilesPath.civi-setup.php
+++ b/setup/plugins/installFiles/StandaloneCivicrmFilesPath.civi-setup.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @file
+ *
+ * Validate and create the civicrm.files folder.
+ */
+
+if (!defined('CIVI_SETUP')) {
+  exit("Installation plugins must only be loaded by the installer.\n");
+}
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setup.checkRequirements', function (\Civi\Setup\Event\CheckRequirementsEvent $e) {
+    \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'checkRequirements'));
+    $m = $e->getModel();
+
+    $civicrmFilesDirectory = $m->paths['civicrm.files']['path'] ?? '';
+
+    if (!$civicrmFilesDirectory) {
+      $e->addError('system', 'civicrmFilesPath', 'The civicrm.files directory path is undefined.');
+    }
+    else {
+      $e->addInfo('system', 'civicrmFilesPath', sprintf('The civicrm.files directory path is defined ("%s").', $civicrmFilesDirectory));
+    }
+
+    if ($civicrmFilesDirectory && !file_exists($civicrmFilesDirectory) && !\Civi\Setup\FileUtil::isCreateable($civicrmFilesDirectory)) {
+      $e->addError('system', 'civicrmFilesPathWritable', sprintf('The civicrm files dir "%s" does not exist and cannot be created. Ensure it exists or the parent folder is writable.', $civicrmFilesDirectory));
+    }
+    elseif ($civicrmFilesDirectory && !file_exists($civicrmFilesDirectory)) {
+      $e->addInfo('system', 'civicrmFilesPathWritable', sprintf('The civicrm files dir "%s" can be created.', $civicrmFilesDirectory));
+    }
+  });
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setup.installFiles', function (\Civi\Setup\Event\InstallFilesEvent $e) {
+    \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'installFiles'));
+    $m = $e->getModel();
+
+    $civicrmFilesDirectory = $m->paths['civicrm.files']['path'] ?? '';
+
+    if ($civicrmFilesDirectory && !file_exists($civicrmFilesDirectory)) {
+      Civi\Setup::log()->info('[StandaloneCivicrmFilesPath.civi-setup.php] mkdir "{path}"', [
+        'path' => $civicrmFilesDirectory,
+      ]);
+      mkdir($civicrmFilesDirectory, 0777, TRUE);
+      \Civi\Setup\FileUtil::makeWebWriteable($civicrmFilesDirectory);
+    }
+  });


### PR DESCRIPTION
Before
----------------------------------------
Installing Standalone using [the composer starter template method](https://docs.civicrm.org/installation/en/latest/standalone/#download) fails unexpectedly if the `civicrm.files` directory doesn't exist or isn't writeable.


After
----------------------------------------
We check the directory is writeable before starting the installer (in the same way as we do already for `templates_c`).


Technical Details
----------------------------------------
I've added this as Standalone specific, but is there any reason we don't do this for other CMSes?

It's particularly relevant for Standalone because the warning that the directory isn't writeable causes a crash before we have installed the SessionHandler. See https://lab.civicrm.org/dev/core/-/issues/4988