### PR TITLE
dev/core#4026 Fix failure to save membership data on submit when membership type changed

### DIFF
--- a/CRM/Custom/Form/CustomDataTrait.php
+++ b/CRM/Custom/Form/CustomDataTrait.php
@@ -78,6 +78,7 @@ trait CRM_Custom_Form_CustomDataTrait {
       }
     }
 
+    $formValues = [];
     foreach ($fields as $field) {
       $suffix = $customGroupSuffixes[$field['table_name']];
       $elementName = 'custom_' . $field['custom_field_id'] . $suffix;
@@ -89,7 +90,13 @@ trait CRM_Custom_Form_CustomDataTrait {
       if ($field['input_type'] === 'File') {
         $this->registerFileField([$elementName]);
       }
+      // Get any values from the POST & cache them so that they can be retrieved from the
+      // CustomDataByType form.
+      $formValues[$elementName] = CRM_Utils_String::purifyHTML($this->getSubmitValue($elementName));
     }
+    $qf = $this->get('qfKey');
+    $this->assign('qfKey', $qf);
+    Civi::cache('customData')->set($qf, $formValues);
   }
 
 }

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -21,6 +21,7 @@ use Civi\Api4\ContributionRecur;
  * This class generates form components for offline membership form.
  */
 class CRM_Member_Form_Membership extends CRM_Member_Form {
+  use CRM_Custom_Form_CustomDataTrait;
 
   /**
    * If this is set (to 'test' or 'live') then the payment processor will be shown on the form to take a payment.
@@ -75,11 +76,21 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
   }
 
   /**
-   * Overriding this entity trait function as not yet tested.
-   *
-   * We continue to rely on legacy handling.
+   * Overriding this entity trait function as the function does not
+   * at this stage use the CustomDataTrait which works better with php8.2.
    */
-  public function addCustomDataToForm() {}
+  public function addCustomDataToForm() {
+    if ($this->isSubmitted()) {
+      // The custom data fields are added to the form by an ajax form.
+      // However, if they are not present in the element index they will
+      // not be available from `$this->getSubmittedValue()` in post process.
+      // We do not have to set defaults or otherwise render - just add to the element index.
+      $this->addCustomDataFieldsToForm('Membership', array_filter([
+        'id' => $this->getMembershipID(),
+        'membership_type_id' => $this->getSubmittedValue('membership_type_id'),
+      ]));
+    }
+  }
 
   /**
    * Overriding this entity trait function as not yet tested.
@@ -224,8 +235,9 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       }
     }
 
-    // Add custom data to form
-    CRM_Custom_Form_CustomData::addToForm($this, $this->_memType);
+    $this->assign('customDataType', 'Membership');
+    $this->assign('customDataSubType', $this->_memType);
+
     $this->setPageTitle(ts('Membership'));
   }
 
@@ -1485,7 +1497,7 @@ DESC limit 1");
    * @throws \CRM_Core_Exception
    */
   protected function emailMembershipReceipt($formValues) {
-    $customValues = $this->getCustomValuesForReceipt($formValues);
+    $customValues = $this->getCustomValuesForReceipt();
     $this->assign('customValues', $customValues);
     $this->assign('total_amount', $this->order->getTotalAmount());
     $this->assign('totalTaxAmount', $this->order->getTotalTaxAmount());
@@ -1511,35 +1523,46 @@ DESC limit 1");
   /**
    * Filter the custom values from the input parameters (for display in the email).
    *
-   * @todo figure out why the scary code this calls does & document.
+   * @todo move this to the WorkFlowMessageTrait.
    *
-   * @param array $formValues
    * @return array
    */
-  protected function getCustomValuesForReceipt($formValues): array {
-    $customFields = $customValues = [];
-    if (property_exists($this, '_groupTree')
-      && !empty($this->_groupTree)
-    ) {
-      foreach ($this->_groupTree as $groupID => $group) {
-        if ($groupID === 'info') {
-          continue;
-        }
-        foreach ($group['fields'] as $k => $field) {
-          $field['title'] = $field['label'];
-          $customFields["custom_{$k}"] = $field;
-        }
+  protected function getCustomValuesForReceipt(): array {
+    $customFieldValues = $this->getCustomFieldValues();
+    $customValues = [];
+    foreach ($customFieldValues as $customFieldString => $submittedValue) {
+      if ($submittedValue === NULL) {
+        // This would occur when the field is no longer appropriate - ie changing
+        // from a membership type with the field to one without it.
+        continue;
+      }
+      $customFieldID = (int) CRM_Core_BAO_CustomField::getKeyID($customFieldString);
+      $value = CRM_Core_BAO_CustomField::displayValue($this->getSubmittedValue($customFieldString), $customFieldID);
+      $customValues[CRM_Core_BAO_CustomField::getField($customFieldID)['label']] = $value;
+    }
+    return $customValues;
+  }
+
+  /**
+   * Get the custom fields tat are on the form with the submitted values.
+   *
+   * @internal I think it would be good to make this field
+   * available as an api supported method - maybe on the form custom data trait
+   * but I feel like we might want to talk about the format of the returned results
+   * (key-value vs array, custom field ID keys vs custom_, filters/ multiple functions
+   * with different formatting) so keeping private for now.
+   *
+   * @return array
+   */
+  private function getCustomFieldValues(): array {
+    $customFields = [];
+    foreach ($this->_elements as $element) {
+      $customFieldID = CRM_Core_BAO_CustomField::getKeyID($element->getName());
+      if ($customFieldID) {
+        $customFields[$element->getName()] = $this->getSubmittedValue($element->getName());
       }
     }
-
-    $members = [['member_id', '=', $this->getMembershipID(), 0, 0]];
-    // check whether its a test drive
-    if ($this->_mode === 'test') {
-      $members[] = ['member_test', '=', 1, 0, 0];
-    }
-
-    CRM_Core_BAO_UFGroup::getValues($formValues['contact_id'], $customFields, $customValues, FALSE, $members);
-    return $customValues;
+    return $customFields;
   }
 
   /**
@@ -1678,7 +1701,6 @@ DESC limit 1");
    * @throws \CRM_Core_Exception
    */
   protected function getFormMembershipParams(): array {
-    $submittedValues = $this->controller->exportValues($this->_name);
     return [
       'status_id' => $this->getSubmittedValue('status_id'),
       'source' => $this->getSubmittedValue('source') ?? $this->getContributionSource(),
@@ -1686,7 +1708,7 @@ DESC limit 1");
       'is_override' => $this->getSubmittedValue('is_override'),
       'status_override_end_date' => $this->getSubmittedValue('status_override_end_date'),
       'campaign_id' => $this->getSubmittedValue('campaign_id'),
-      'custom' => CRM_Core_BAO_CustomField::postProcess($submittedValues,
+      'custom' => CRM_Core_BAO_CustomField::postProcess($this->getSubmittedValues(),
         $this->_id,
         'Membership'
       ),

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -590,7 +590,7 @@
       showEmailOptions();
     }
 
-    var customDataType = {/literal}{$customDataType|@json_encode}{literal};
+    var customDataType = 'Membership';
 
     // load form during form rule.
     {/literal}{if $buildPriceSet}{literal}
@@ -605,7 +605,7 @@
         var fname = '#priceset';
         if ( !priceSetId ) {
         cj('#membership_type_id_1').val(0);
-        CRM.buildCustomData(customDataType, null);
+        CRM.buildCustomData('Membership', null);
 
         // hide price set fields.
         cj( fname ).hide( );
@@ -788,7 +788,7 @@
         subTypeNames = null;
       }
 
-      CRM.buildCustomData(customDataType, subTypeNames);
+      CRM.buildCustomData('Membership', subTypeNames);
     }
 
   function enableAmountSection( setContributionType ) {


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4026 Fix failure to save membership data on submit when membership type changed

This also fixes php8.2 issues with the form

Before
----------------------------------------
For full steps go to https://lab.civicrm.org/dev/core/-/issues/4026

In my testing I created 2 custom data groups extending membership, one extending the type 'student' and one extending the type ' and trying switching between the 2 membership types on edit - checking what was in the email receipt & what displayed when re-viewing - as per the reproduction steps the value did not update on the first save

After
----------------------------------------
fixed

Technical Details
----------------------------------------
There is already a WIP PR at https://github.com/civicrm/civicrm-core/pull/25215 by @braders  & in review @larssandergreen identified 2 issues on that PR which also needed to be addressed in this PR

- on reload the entered data did not appear - I put the patch for that on the rc as the participant form is affected in the rc https://github.com/civicrm/civicrm-core/pull/29356 (I will rebase out if merged)
- sub-type specific custom fields not saved on new register

Comments
----------------------------------------
I worked on this over https://github.com/civicrm/civicrm-core/pull/29348 which is in the PR but I expect that to be merged & then I can rebase out