### PR TITLE
BackOffice participant form - Fix failure to reload correct default when custom data subtype changes

### DIFF
--- a/CRM/Custom/Form/CustomDataTrait.php
+++ b/CRM/Custom/Form/CustomDataTrait.php
@@ -78,6 +78,7 @@ trait CRM_Custom_Form_CustomDataTrait {
       }
     }
 
+    $formValues = [];
     foreach ($fields as $field) {
       $suffix = $customGroupSuffixes[$field['table_name']];
       $elementName = 'custom_' . $field['custom_field_id'] . $suffix;
@@ -89,7 +90,14 @@ trait CRM_Custom_Form_CustomDataTrait {
       if ($field['input_type'] === 'File') {
         $this->registerFileField([$elementName]);
       }
+      // Get any values from the POST & cache them so that they can be retrieved from the
+      // CustomDataByType form in it's setDefaultValues() function - otherwise it cannot reload the
+      // values that were just entered if validation fails.
+      $formValues[$elementName] = is_string($this->getSubmitValue($elementName)) ? CRM_Utils_String::purifyHTML($this->getSubmitValue($elementName)) : $this->getSubmitValue($elementName);
     }
+    $qf = $this->get('qfKey');
+    $this->assign('qfKey', $qf);
+    Civi::cache('customData')->set($qf, $formValues);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix failure to reload correct default when custom data subtype changes

Before
----------------------------------------
-  Create a custom field set that extends participant restricted to a particular event
- Use the register participant link /civicrm/participant/add?reset=1&action=add&context=standalone - select that event type & enter the custom field data but leave participant empty, submit
- Validation will fail, but on reload the value you just entered will not be presented

After
----------------------------------------
The value is populated

Technical Details
----------------------------------------
@larssandergreen tested this fix by @braders  & identified it as an issue with it 
https://github.com/civicrm/civicrm-core/pull/25215

I addressed it & the other comment by @larssandergreen in my alternate fix https://github.com/civicrm/civicrm-core/pull/29355 but this one also affects participant form in 5.71 (only) so this is against the rc

Comments
----------------------------------------
