### PR TITLE
dev/core#4988 enable standaloneusers extension early in Standalone install

### DIFF
--- a/setup/plugins/init/StandaloneUsers.civi-setup.php
+++ b/setup/plugins/init/StandaloneUsers.civi-setup.php
@@ -3,6 +3,8 @@
  * @file
  *
  * On "Standalone" UF, default policy is to enable `standaloneusers` and create user with admin role.
+ *
+ * Note: we need to enable 'standaloneusers' early, because it provides the session handler
  */
 
 if (!defined('CIVI_SETUP')) {
@@ -31,6 +33,17 @@ if (!defined('CIVI_SETUP')) {
     $e->getModel()->extras['adminPassWasSpecified'] = !empty($e->getModel()->extras['adminPass']);
     $e->getModel()->extras = array_merge($defaults, $e->getModel()->extras);
   });
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setup.installDatabase', function (\Civi\Setup\Event\InstallDatabaseEvent $e) {
+    if ($e->getModel()->cms !== 'Standalone') {
+      return;
+    }
+    Civi\Setup::log()->info('Enabling Standaloneusers extension early');
+    \civicrm_api3('Extension', 'enable', array(
+      'keys' => ['standaloneusers'],
+    ));
+  }, \Civi\Setup::PRIORITY_MAIN - 150);
 
 \Civi\Setup::dispatcher()
   ->addListener('civi.setup.installDatabase', function (\Civi\Setup\Event\InstallDatabaseEvent $e) {


### PR DESCRIPTION
Before
----------------------------------------
Installing Standalone through the web ui fails because we don't have the SessionHandler from standaloneusers early enough.

After
----------------------------------------
Hook in earlier to enable this extension specifically.

Technical Details
----------------------------------------
This resolves the main path issue that the installer tries to start a session in `BootstrapCivi.civi-setup.php` [here](https://github.com/civicrm/civicrm-core/blob/eacd1f4206fab41f0cf14bcbd80b5f7187b42bea/setup/plugins/installDatabase/BootstrapCivi.civi-setup.php#L27) at `\Civi\Setup::PRIORITY_MAIN - 200` .

However you can have a problem earlier if warnings are generated about directories, which [`CRM_Core_Config_MagicMerge` then tries to put in the session](https://github.com/civicrm/civicrm-core/blob/eacd1f4206fab41f0cf14bcbd80b5f7187b42bea/CRM/Core/Config/MagicMerge.php#L243), which then causes a crash.

In particular I hit this one: https://github.com/civicrm/civicrm-core/pull/29354

Comments
----------------------------------------
Alternative approach just using regular PHP session instead during the whole install https://github.com/civicrm/civicrm-core/pull/29352
