### PR TITLE
Dont crash if we can't start a session when a file path doesnt exist

### DIFF
--- a/CRM/Core/Config/MagicMerge.php
+++ b/CRM/Core/Config/MagicMerge.php
@@ -240,10 +240,19 @@ class CRM_Core_Config_MagicMerge {
           $value = CRM_Utils_File::addTrailingSlash($value);
           if (isset($this->map[$k][2]) && in_array('mkdir', $this->map[$k][2])) {
             if (!is_dir($value) && !CRM_Utils_File::createDir($value, FALSE)) {
-              CRM_Core_Session::setStatus(ts('Failed to make directory (%1) at "%2". Please update the settings or file permissions.', [
+              // we want to warn the user about this error
+              // ideally we show a browser alert
+              // but this might not be possible if the session handler isn't up yet, so fallback to just printing it (sorry)
+              $alertMessage = ts('Failed to make directory (%1) at "%2". Please update the settings or file permissions.', [
                 1 => $k,
                 2 => $value,
-              ]));
+              ]);
+              try {
+                CRM_Core_Session::setStatus($alertMessage);
+              }
+              catch (\Error $e) {
+                echo $alertMessage;
+              }
             }
           }
           if (isset($this->map[$k][2]) && in_array('restrict', $this->map[$k][2])) {


### PR DESCRIPTION
Before
----------------------------------------
`CRM_Core_Config_MagicMerge` tries to put warnings about file path issues into the session. 

If a situation arises where the warnings are the root cause of not being able to init the session, the system crashes. Users get an error about not being able to start the session (but no immediate indication this is because of the file path issues).

After
----------------------------------------
If there's an error with putting the warnings into the session, we print them to the screen and then continue.

The user gets the warning, which is more useful to them. They may get subsequent warnings.

Technical details
----------------------------------------
Potentially this would be good behaviour generally, and could live in `CRM_Core_Session::setStatus` - but felt a bit safer to restrict to these specific warnings (which have a specific relevant example with Standalone).

Comments
----------------------------------------
For an example:

On a Standalone install, remove your custom extensions directory and make its parent directory unwriteable so the server can't recreate it ( e.g. `mv web/upload/ext web/upload/ext.moved && chmod a-w web/upload`). You get a crash about not having the Standalone SessionHandler (because the Standaloneusers extension that manages sessions can't be initialised, in turn because the Extension system can't boot up, because the config loading crashes at this point).