### PR TITLE
dev/core#4999 - [REF] Add DAO::getExtensionName() and DAO:: getTableAddVersion()

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1355,13 +1355,25 @@ class CRM_Core_DAO extends DB_DataObject {
    * @return bool
    * @throws CRM_Core_Exception
    */
-  public static function tableHasBeenAdded() {
+  public static function tableHasBeenAdded(): bool {
     if (CRM_Utils_System::version() === CRM_Core_BAO_Domain::version()) {
       return TRUE;
     }
     $daoExt = static::getExtensionName();
-    $daoVersion = defined(static::class . '::TABLE_ADDED') ? constant(static::class . '::TABLE_ADDED') : '1.0';
-    return !($daoExt === 'civicrm' && version_compare(CRM_Core_BAO_Domain::version(), $daoVersion, '<'));
+    if ($daoExt !== 'civicrm') {
+      // FIXME: Check extension tables
+      return TRUE;
+    }
+    $daoVersion = static::getTableAddVersion();
+    return !(version_compare(CRM_Core_BAO_Domain::version(), $daoVersion, '<'));
+  }
+
+  /**
+   * @return string
+   *   Version in which table was added
+   */
+  protected static function getTableAddVersion(): string {
+    return defined(static::class . '::TABLE_ADDED') ? constant(static::class . '::TABLE_ADDED') : '1.0';
   }
 
   /**

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -614,7 +614,7 @@ class CRM_Core_DAO extends DB_DataObject {
 
     // Exclude fields yet not added by pending upgrades
     $dbVer = \CRM_Core_BAO_Domain::version();
-    $daoExt = defined(static::class . '::EXT') ? constant(static::class . '::EXT') : NULL;
+    $daoExt = static::getExtensionName();
     if ($fields && $daoExt === 'civicrm' && version_compare($dbVer, \CRM_Utils_System::version()) < 0) {
       $fields = array_filter($fields, function($field) use ($dbVer) {
         $add = $field['add'] ?? '1.0.0';
@@ -633,6 +633,14 @@ class CRM_Core_DAO extends DB_DataObject {
     }
 
     return $fields;
+  }
+
+  /**
+   * Get name of extension in which this DAO is defined.
+   * @return string|null
+   */
+  public static function getExtensionName(): ?string {
+    return defined(static::class . '::EXT') ? constant(static::class . '::EXT') : NULL;
   }
 
   /**
@@ -1351,7 +1359,7 @@ class CRM_Core_DAO extends DB_DataObject {
     if (CRM_Utils_System::version() === CRM_Core_BAO_Domain::version()) {
       return TRUE;
     }
-    $daoExt = defined(static::class . '::EXT') ? constant(static::class . '::EXT') : NULL;
+    $daoExt = static::getExtensionName();
     $daoVersion = defined(static::class . '::TABLE_ADDED') ? constant(static::class . '::TABLE_ADDED') : '1.0';
     return !($daoExt === 'civicrm' && version_compare(CRM_Core_BAO_Domain::version(), $daoVersion, '<'));
   }


### PR DESCRIPTION
Overview
----------------------------------------
Adds a couple getter functions to the DAO.
Small refactor toward [dev/core#4999](https://lab.civicrm.org/dev/core/-/issues/4999)

Before
----------------------------------------
No getter functions, only weird ways to get at this data.

After
----------------------------------------
Normal getters are simpler to use and more importantly to [dev/core#4999](https://lab.civicrm.org/dev/core/-/issues/4999), can be overridden by classes that need to fetch that info by other means (e.g. from xml files).