### PR TITLE
dev/core#4120 MultiLingual - Fix inconsistent handling of table names

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -232,7 +232,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       $op = empty($records[$index]['id']) ? 'create' : 'edit';
       // Theoretically a custom field could have custom fields! Trippy...
       if (!empty($records[$index]['custom']) && is_array($records[$index]['custom'])) {
-        CRM_Core_BAO_CustomValueTable::store($records[$index]['custom'], static::$_tableName, $customField->id, $op);
+        CRM_Core_BAO_CustomValueTable::store($records[$index]['custom'], static::getTableName(), $customField->id, $op);
       }
       CRM_Utils_Hook::post($op, 'CustomField', $customField->id, $customField);
     }

--- a/CRM/Upgrade/Incremental/php/FiveSeventyTwo.php
+++ b/CRM/Upgrade/Incremental/php/FiveSeventyTwo.php
@@ -29,6 +29,22 @@ class CRM_Upgrade_Incremental_php_FiveSeventyTwo extends CRM_Upgrade_Incremental
    */
   public function upgrade_5_72_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask('Remove localized suffixes from civicrm_mailing_group.entity_table', 'fixMailingGroupEntityTable');
+  }
+
+  /**
+   * Remove unwanted dbLocale suffixes from values in civicrm_mailing_group.entity_table.
+   *
+   * @see https://github.com/civicrm/civicrm-core/pull/29366
+   *
+   * @return bool
+   */
+  public static function fixMailingGroupEntityTable(): bool {
+    $updateQuery = 'UPDATE civicrm_mailing_group SET entity_table = "civicrm_mailing" WHERE entity_table LIKE "civicrm_mailing_%"';
+    CRM_Core_DAO::executeQuery($updateQuery, [], TRUE, NULL, FALSE, FALSE);
+    $updateQuery = 'UPDATE civicrm_mailing_group SET entity_table = "civicrm_group" WHERE entity_table LIKE "civicrm_group_%"';
+    CRM_Core_DAO::executeQuery($updateQuery, [], TRUE, NULL, FALSE, FALSE);
+    return TRUE;
   }
 
 }

--- a/CRM/Utils/SQL/Insert.php
+++ b/CRM/Utils/SQL/Insert.php
@@ -65,7 +65,7 @@ class CRM_Utils_SQL_Insert {
    * @throws \CRM_Core_Exception
    */
   public static function dao(CRM_Core_DAO $dao) {
-    $table = CRM_Core_DAO::getLocaleTableName($dao->getTableName());
+    $table = $dao::getLocaleTableName();
     $row = [];
     foreach ((array) $dao as $key => $value) {
       if ($value === 'null') {

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -161,7 +161,7 @@ abstract class AbstractEntity {
       $info['icon'] = $dao::$_icon;
       $info['label_field'] = $dao::$_labelField;
       $info['dao'] = $dao;
-      $info['table_name'] = $dao::$_tableName;
+      $info['table_name'] = $dao::getTableName();
       $info['icon_field'] = (array) ($dao::fields()['icon']['name'] ?? NULL);
       if (method_exists($dao, 'indices')) {
         foreach (\CRM_Utils_Array::findAll($dao::indices(FALSE), ['unique' => TRUE, 'localizable' => FALSE]) as $index) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/4120 and other potential problems with multilingual handling of table names.

What started as cleanup toward https://lab.civicrm.org/dev/core/-/issues/4999 has morphed into fixing problematic behavior in multi-lingual sites.

Background
-------------
In multi-lingual installs, some tables get a locale suffix appended to them (well, the table doesn't, it's actually a SQL View but that's not an important detail for the purposes of this PR). The important thing to know is that a multi-lingual site needs queries to be written like `SELECT FROM civicrm_activity_ES_es` instead of `SELECT FROM civicrm_activity`.

But *you* don't have to write it like that, because `CRM_Core_DAO::executeQuery()` will automatically convert the latter query into the former using a rather scary regex (see `CRM_Core_I18n_Schema::rewriteQuery()` or, if you want to sleep well tonight, don't.).

So in almost every way the localized table suffix is invisible to developers. They don't need to think about it 99% of the time. Meanwhile, the  canonical (non-suffixed) table name is passed around all over the place, e.g.
- for matching `className` to `table_name` and vice-versa in e.g. `CoreUtil::getTableName()`
- for insertion into an 'entity_table' field value (e.g. in civicrm_log)
- for the `entity_table` of a custom field value operation
- for uniquely identifying an entity e.g. by `CRM_Core_DAO_AllCoreTables`
- & many more places throughout our codebase that expect to be passed a canonical table name & can't cope with a localized one

So it's important to keep the localized & canonical table names separate:
- Use localized name within a query (and you only need to think about this if you're not calling `CRM_Core_DAO::executeQuery()`)
- Use canonical name everywhere else.

Before
----------------------------------------
That separation was not always happening correctly, probably due to developer miscommunication over the years and people generally not understanding the how the multilingual schema works (see background, above). And the DAO functions for getting an entity's table name were not helping whatsoever. The DAO had two getters for table name and they were both localized, even though many calling functions were not expecting or able to cope with a localized value.

- `getTableName()` returned localized value whether you want it or not
- `getLocaleTableName()` was not a real getter, just a transformer
- If you want the non-localized table name you had to access the static class variable e.g. `CRM_Activity_DAO_Activity::$_tableName`

After
----------------------------------------
- `getTableName()` returns the non-localized canonical value, which is what most callers expect.
- `getLocaleTableName()` is now a real getter & returns the localized value (still works as a transformer with backward-compat param maintained, but it's much more useful as a getter).
- Any code directly accessing `::$_tableName` switched to use `::getTableName()`

Technical Details
----------------------------------------
As noted above, passing localized table names into functions that don't expect it can have bad consequences. One such example is that the `civicrm_mailing_group.entity_table` field has reportedly been corrupted with localized values (like all `entity_table` fields in CiviCRM it was designed to hold the canonical table name which is used to match to an entity). This PR ought to fix any more of those values being inserted, and I've added an upgrader script to remove existing localized values.