### PR TITLE
[REF] DAO - Consolidate redundant functions keys() and getPrimaryKey()

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -43,13 +43,6 @@ class CRM_Core_DAO extends DB_DataObject {
   public static $_primaryKey = ['id'];
 
   /**
-   * @return string[]
-   */
-  protected function getPrimaryKey(): array {
-    return static::$_primaryKey;
-  }
-
-  /**
    * @return string
    */
   protected function getFirstPrimaryKey(): string {
@@ -58,7 +51,7 @@ class CRM_Core_DAO extends DB_DataObject {
     // keys (which we support in codegen if not many other places) we return 'id'
     // simply because that is what we historically did & we don't want to 'just change'
     // it & break those extensions without doing the work to create an alternative.
-    return count($this->getPrimaryKey()) > 1 ? 'id' : $this->getPrimaryKey()[0];
+    return count($this->keys()) > 1 ? 'id' : $this->keys()[0];
   }
 
   /**
@@ -525,31 +518,24 @@ class CRM_Core_DAO extends DB_DataObject {
   }
 
   /**
-   * Defines the default key as 'id'.
+   * Returns primary keys (usually ['id'])
    *
-   * @return array
+   * @return string[]
    */
   public function keys() {
-    static $keys;
-    if (!isset($keys)) {
-      $keys = ['id'];
-    }
-    return $keys;
+    return static::$_primaryKey;
   }
 
   /**
    * Tells DB_DataObject which keys use autoincrement.
    * 'id' is autoincrementing by default.
    *
+   * FIXME: this should return all autoincrement keys not just the first.
    *
    * @return array
    */
   public function sequenceKey() {
-    static $sequenceKeys;
-    if (!isset($sequenceKeys)) {
-      $sequenceKeys = [$this->getFirstPrimaryKey(), TRUE];
-    }
-    return $sequenceKeys;
+    return [$this->getFirstPrimaryKey(), TRUE];
   }
 
   /**

--- a/ext/civiimport/Civi/BAO/Import.php
+++ b/ext/civiimport/Civi/BAO/Import.php
@@ -62,13 +62,6 @@ class Import extends CRM_Core_DAO {
   }
 
   /**
-   * @return string[]
-   */
-  protected function getPrimaryKey(): array {
-    return self::$_primaryKey;
-  }
-
-  /**
    * Returns fields generic to all imports, indexed by name.
    *
    * This function could arguably go, leaving it to the `ImportSpecProvider`
@@ -283,26 +276,6 @@ class Import extends CRM_Core_DAO {
    */
   private static function getAllFields(string $tableName): array {
     return array_merge(self::getFieldsForTable($tableName), self::getSupportedFields());
-  }
-
-  /**
-   * Defines the default key as 'id'.
-   *
-   * @return array
-   */
-  public function keys() {
-    return ['_id'];
-  }
-
-  /**
-   * Tells DB_DataObject which keys use autoincrement.
-   * 'id' is autoincrementing by default.
-   *
-   *
-   * @return array
-   */
-  public function sequenceKey() {
-    return ['_id', TRUE];
   }
 
 }

--- a/ext/search_kit/Civi/BAO/SK_Entity.php
+++ b/ext/search_kit/Civi/BAO/SK_Entity.php
@@ -51,23 +51,4 @@ class SK_Entity extends CRM_Core_DAO {
     return TRUE;
   }
 
-  /**
-   * Defines the primary key(s).
-   *
-   * @return array
-   */
-  public function keys() {
-    return ['_row'];
-  }
-
-  /**
-   * Tells DB_DataObject which keys use autoincrement.
-   * Overrides the default 'id'.
-   *
-   * @return array
-   */
-  public function sequenceKey() {
-    return ['_row', TRUE];
-  }
-
 }


### PR DESCRIPTION
Overview
----------------------------------------
Followup to 615f874077783f799c64d091c0e8882d8e615579 
Towards [dev/core#4999](https://lab.civicrm.org/dev/core/-/issues/4999)

Technical Details
----------------------------------------
The `getPrimaryKey()` function was added recently and the older one was hobbled by not returning the declared `$_primaryKey`. Fortunately the new function was protected so could be safely removed while fixing `keys()` to do the right thing.

Comments
------
Also removes some useless static caching; it's already a static class variable it doesn't need to be statically cached again.