### PR TITLE
[REF] AllCoreTables - Simplify array lookups & transformations

### DIFF
--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -169,11 +169,13 @@ class CRM_Core_DAO_AllCoreTables {
   }
 
   /**
+   * @deprecated in 5.72 will be removed in 5.90
    * @return array
    *   Mapping from table-names to class-names.
    *   Ex: $result['civicrm_contact'] == 'CRM_Contact_DAO_Contact'.
    */
   public static function getCoreTables() {
+    CRM_Core_Error::deprecatedFunctionWarning('CRM_Core_DAO_AllCoreTables::tables');
     return self::tables();
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Simplifies code, saves memory, deprecates an unused function.
Preliminary cleanup for [dev/core#4999](https://lab.civicrm.org/dev/core/-/issues/4999).

Before
----------------------------------------
Caches the same data 3 times in 3 different arrays.

After
----------------------------------------
Consolidates it to a single array, because calling `array_column()` really isn't hard.

Comments
------------
This will make further changes easier if we decide to cache this data in a different way, now there's only one thing to store & retrieve.

Also deprecates an unused function.