### PR TITLE
APIv4 - Fetch all options when matching pseudoconstants.

### DIFF
--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -303,7 +303,9 @@ class FormattingUtil {
     // Use BAO::buildOptions if possible
     if ($baoName) {
       $fieldName = empty($field['custom_field_id']) ? $field['name'] : 'custom_' . $field['custom_field_id'];
-      $options = $baoName::buildOptions($fieldName, $context, self::filterByPath($values, $fieldPath, $field['name']));
+      $entityValues = self::filterByPath($values, $fieldPath, $field['name']);
+      $entityValues['check_permissions'] = FALSE;
+      $options = $baoName::buildOptions($fieldName, $context, $entityValues);
     }
     // Fallback for option lists that exist in the api but not the BAO
     if (!isset($options) || $options === FALSE) {


### PR DESCRIPTION
Overview
----------------------------------------
When performing a match we want to fetch all options not a filtered list.
Fixes https://lab.civicrm.org/dev/core/-/issues/4997

