### PR TITLE
Switch our default dev & demo smarty version from 3 to 4

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -264,10 +264,10 @@ if (!defined('CIVICRM_SMARTY_AUTOLOAD_PATH')) {
   // enable by default for dev & demo sites for now - will soon enable by default for all new installs.
   if (strpos(CIVICRM_UF_BASEURL, 'localhost') !== FALSE || strpos(CIVICRM_UF_BASEURL, 'demo.civicrm.org') !== FALSE) {
     if (is_dir($civicrm_root . '/packages')) {
-      define('CIVICRM_SMARTY_AUTOLOAD_PATH', $civicrm_root . '/packages/smarty3/vendor/autoload.php');
+      define('CIVICRM_SMARTY_AUTOLOAD_PATH', $civicrm_root . '/packages/smarty4/vendor/autoload.php');
     }
     elseif (is_dir($civicrm_root . '/../civicrm-packages')) {
-      define('CIVICRM_SMARTY_AUTOLOAD_PATH', $civicrm_root . '/../civicrm-packages/smarty3/vendor/autoload.php');
+      define('CIVICRM_SMARTY_AUTOLOAD_PATH', $civicrm_root . '/../civicrm-packages/smarty4/vendor/autoload.php');
     }
   }
 }


### PR DESCRIPTION

Overview
----------------------------------------
Switch our default dev & demo smarty version from 3 to 4

This is what our tests are running on now & is now our preferred option


Before
----------------------------------------
sites at local host of demo urls set up with smarty 3

After
----------------------------------------
set up with Smarty4

Technical Details
----------------------------------------

Comments
----------------------------------------
