### PR TITLE
(dev/core#4984) Display issue on membership view for relationships

### DIFF
--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -251,8 +251,8 @@ END AS 'relType'
         // split the relations in 2 arrays based on direction
         $relTypeId = explode(CRM_Core_DAO::VALUE_SEPARATOR, $membershipType['relationship_type_id']);
         $relDirection = explode(CRM_Core_DAO::VALUE_SEPARATOR, $membershipType['relationship_direction']);
-        foreach ($relTypeId as $rid) {
-          $relTypeDir[substr($relDirection[0], 0, 1)][] = $rid;
+        foreach ($relTypeId as $x => $rid) {
+          $relTypeDir[substr($relDirection[$x], 0, 1)][] = $rid;
         }
         // build query in 2 parts with a UNION if necessary
         // _x and _y are replaced with _a and _b first, then vice-versa


### PR DESCRIPTION
Overview
----------------------------------------
## Steps to replicate :

* Create a membership type configured with a relationship in both directions.
 [
![Screenshot 2024-02-08 204424](https://github.com/civicrm/civicrm-core/assets/3455173/854c4761-f2b7-4baa-b554-7fb3202c17cc)
](url)

* Create a relationship between contacts that have this relationship "Shares home"
* Create a primary membership on one of them.
* On membership view screen of primary membership, we can't see the related contact


Before
----------------------------------------
![Screenshot 2024-02-08 205130](https://github.com/civicrm/civicrm-core/assets/3455173/e180e6c8-e653-45cf-b746-c979954dba4d)


After
----------------------------------------

![Screenshot 2024-02-08 205008](https://github.com/civicrm/civicrm-core/assets/3455173/ea4d3100-ba1c-4e90-b9b2-13cac43d682d)

Comments
-------------------------------
It is not possible to delete related memberships on the screen (as no related contact is listed) even though the membership is transferred via these relationship types.

