### PR TITLE
Switch Smartyv2 mixin to Smarty mixin

### DIFF
--- a/ext/afform/admin/info.xml
+++ b/ext/afform/admin/info.xml
@@ -37,7 +37,7 @@
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>mgd-php@1.0.0</mixin>
     <mixin>afform-entity-php@1.0.0</mixin>
-    <mixin>smarty-v2@1.0.1</mixin>
+    <mixin>smarty@1.0.0</mixin>
   </mixins>
   <upgrader>CRM_AfformAdmin_Upgrader</upgrader>
 </extension>

--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -37,7 +37,7 @@
     <mixin>ang-php@1.0.0</mixin>
     <mixin>mgd-php@1.0.0</mixin>
     <mixin>scan-classes@1.0.0</mixin>
-    <mixin>smarty-v2@1.0.1</mixin>
+    <mixin>smarty@1.0.0</mixin>
     <mixin>entity-types-php@1.0.0</mixin>
     <mixin>menu-xml@1.0.0</mixin>
   </mixins>

--- a/ext/civicrm_search_ui/info.xml
+++ b/ext/civicrm_search_ui/info.xml
@@ -37,7 +37,7 @@
   <mixins>
     <mixin>mgd-php@1.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
-    <mixin>smarty-v2@1.0.1</mixin>
+    <mixin>smarty@1.0.0</mixin>
   </mixins>
   <upgrader>CRM_CivicrmSearchUi_Upgrader</upgrader>
 </extension>

--- a/ext/civigrant/info.xml
+++ b/ext/civigrant/info.xml
@@ -32,7 +32,7 @@
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>mgd-php@1.0.0</mixin>
     <mixin>afform-entity-php@1.0.0</mixin>
-    <mixin>smarty-v2@1.0.1</mixin>
+    <mixin>smarty@1.0.0</mixin>
     <mixin>entity-types-php@1.0.0</mixin>
     <mixin>scan-classes@1.0.0</mixin>
   </mixins>

--- a/ext/civiimport/info.xml
+++ b/ext/civiimport/info.xml
@@ -39,6 +39,6 @@
     <mixin>scan-classes@1.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
     <mixin>ang-php@1.0.0</mixin>
-    <mixin>smarty-v2@1.0.1</mixin>
+    <mixin>smarty@1.0.0</mixin>
   </mixins>
 </extension>

--- a/ext/ckeditor4/info.xml
+++ b/ext/ckeditor4/info.xml
@@ -27,7 +27,7 @@
   </classloader>
   <mixins>
     <mixin>menu-xml@1.0.0</mixin>
-    <mixin>smarty-v2@1.0.1</mixin>
+    <mixin>smarty@1.0.0</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Ckeditor4</namespace>

--- a/ext/eventcart/info.xml
+++ b/ext/eventcart/info.xml
@@ -28,7 +28,7 @@
   <mixins>
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
-    <mixin>smarty-v2@1.0.1</mixin>
+    <mixin>smarty@1.0.0</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Event/Cart</namespace>

--- a/ext/legacycustomsearches/info.xml
+++ b/ext/legacycustomsearches/info.xml
@@ -28,7 +28,7 @@
   <mixins>
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>mgd-php@1.0.0</mixin>
-    <mixin>smarty-v2@1.0.1</mixin>
+    <mixin>smarty@1.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
   </mixins>
   <civix>

--- a/ext/message_admin/info.xml
+++ b/ext/message_admin/info.xml
@@ -31,7 +31,7 @@
   <mixins>
     <mixin>ang-php@1.0.0</mixin>
     <mixin>menu-xml@1.0.0</mixin>
-    <mixin>smarty-v2@1.0.1</mixin>
+    <mixin>smarty@1.0.0</mixin>
   </mixins>
   <civix>
     <namespace>CRM/MessageAdmin</namespace>

--- a/ext/oauth-client/info.xml
+++ b/ext/oauth-client/info.xml
@@ -33,7 +33,7 @@
     <mixin>ang-php@1.0.0</mixin>
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
-    <mixin>smarty-v2@1.0.1</mixin>
+    <mixin>smarty@1.0.0</mixin>
     <mixin>entity-types-php@1.0.0</mixin>
   </mixins>
   <civix>

--- a/ext/recaptcha/info.xml
+++ b/ext/recaptcha/info.xml
@@ -30,7 +30,7 @@
     <mixin>setting-php@1.0.0</mixin>
     <mixin>ang-php@1.0.0</mixin>
     <mixin>scan-classes@1.0.0</mixin>
-    <mixin>smarty-v2@1.0.1</mixin>
+    <mixin>smarty@1.0.0</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Recaptcha</namespace>

--- a/ext/search_kit/info.xml
+++ b/ext/search_kit/info.xml
@@ -35,7 +35,7 @@
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>mgd-php@1.0.0</mixin>
     <mixin>entity-types-php@1.0.0</mixin>
-    <mixin>smarty-v2@1.0.1</mixin>
+    <mixin>smarty@1.0.0</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Search</namespace>

--- a/ext/standaloneusers/info.xml
+++ b/ext/standaloneusers/info.xml
@@ -41,7 +41,7 @@
     <mixin>ang-php@1.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
     <mixin>menu-xml@1.0.0</mixin>
-    <mixin>smarty-v2@1.0.1</mixin>
+    <mixin>smarty@1.0.0</mixin>
     <mixin>entity-types-php@1.0.0</mixin>
     <mixin>afform-entity-php@1.0.0</mixin>
   </mixins>


### PR DESCRIPTION


Overview
----------------------------------------
Switch Smartyv2 mixin to Smarty mixin

This is aesthetic only - the 2 mixins are the same but calling it v2 is misleading as it applies to all versions

Before
----------------------------------------
Core extensions include `  <mixin>smarty-v2@1.0.1</mixin>`

After
----------------------------------------
Core extensions include ` <mixin>smarty@1.0.0</mixin>`

Technical Details
----------------------------------------


Comments
----------------------------------------
