### PR TITLE
avoid deprecation errors 

### DIFF
--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -80,9 +80,9 @@ class CRM_Utils_Mail_EmailProcessor {
   private static function _process($civiMail, $dao, $is_create_activities) {
     // 0 = activities; 1 = bounce;
     $isBounceProcessing = $dao->is_default;
-    $targetFields = array_filter(explode(',', $dao->activity_targets));
-    $assigneeFields = array_filter(explode(",", $dao->activity_assignees));
-    $sourceFields = array_filter(explode(",", $dao->activity_source));
+    $targetFields = array_filter(explode(',', (string) $dao->activity_targets));
+    $assigneeFields = array_filter(explode(",", (string) $dao->activity_assignees));
+    $sourceFields = array_filter(explode(",", (string) $dao->activity_source));
     // create an array of all of to, from, cc, bcc that are in use for this Mail Account, so we don't create contacts for emails we aren't adding to the activity.
     $emailFields = array_merge($targetFields, $assigneeFields, $sourceFields);
     $createContact = !($dao->is_contact_creation_disabled_if_no_match) && !$isBounceProcessing;


### PR DESCRIPTION
Overview
----------------------------------------

There are deprecation notices when running via php 8.1

Before
----------------------------------------

When running `cv api job.execute` with php version 8.1, I get:

[PHP Deprecation] explode(): Passing null to parameter #2 ($string) of type string is deprecated at /var/www/powerbase/sites/all/modules/civicrm/CRM/Utils/Mail/EmailProcessor.php:83


After
----------------------------------------

Wonderful silence.

Technical Details
----------------------------------------

I discovered this problem on a brand new installation with no real data. 

