### PR TITLE
Ext - Specify COLLATE when creating tables

### DIFF
--- a/ext/afform/core/sql/auto_install.sql
+++ b/ext/afform/core/sql/auto_install.sql
@@ -43,4 +43,4 @@ CREATE TABLE `civicrm_afform_submission` (
   PRIMARY KEY (`id`),
   CONSTRAINT FK_civicrm_afform_submission_contact_id FOREIGN KEY (`contact_id`) REFERENCES `civicrm_contact`(`id`) ON DELETE SET NULL
 )
-ENGINE=InnoDB ROW_FORMAT=DYNAMIC;
+ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;

--- a/ext/civigrant/sql/auto_install.sql
+++ b/ext/civigrant/sql/auto_install.sql
@@ -55,4 +55,4 @@ CREATE TABLE `civicrm_grant` (
   CONSTRAINT FK_civicrm_grant_contact_id FOREIGN KEY (`contact_id`) REFERENCES `civicrm_contact`(`id`) ON DELETE CASCADE,
   CONSTRAINT FK_civicrm_grant_financial_type_id FOREIGN KEY (`financial_type_id`) REFERENCES `civicrm_financial_type`(`id`) ON DELETE SET NULL
 )
-ENGINE=InnoDB;
+ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;

--- a/ext/oauth-client/sql/auto_install.sql
+++ b/ext/oauth-client/sql/auto_install.sql
@@ -47,7 +47,7 @@ CREATE TABLE `civicrm_oauth_client` (
   INDEX `UI_provider`(provider),
   INDEX `UI_guid`(guid)
 )
-ENGINE=InnoDB;
+ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 -- /*******************************************************
 -- *
@@ -76,7 +76,7 @@ CREATE TABLE `civicrm_oauth_contact_token` (
   CONSTRAINT FK_civicrm_oauth_contact_token_client_id FOREIGN KEY (`client_id`) REFERENCES `civicrm_oauth_client`(`id`) ON DELETE CASCADE,
   CONSTRAINT FK_civicrm_oauth_contact_token_contact_id FOREIGN KEY (`contact_id`) REFERENCES `civicrm_contact`(`id`) ON DELETE CASCADE
 )
-ENGINE=InnoDB;
+ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 -- /*******************************************************
 -- *
@@ -103,4 +103,4 @@ CREATE TABLE `civicrm_oauth_systoken` (
   INDEX `UI_tag`(tag),
   CONSTRAINT FK_civicrm_oauth_systoken_client_id FOREIGN KEY (`client_id`) REFERENCES `civicrm_oauth_client`(`id`) ON DELETE CASCADE
 )
-ENGINE=InnoDB;
+ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;

--- a/ext/oauth-client/sql/upgrade_0001.sql
+++ b/ext/oauth-client/sql/upgrade_0001.sql
@@ -70,4 +70,4 @@ CREATE TABLE `civicrm_oauth_contact_token` (
   )
 
 ,          CONSTRAINT FK_civicrm_oauth_contact_token_client_id FOREIGN KEY (`client_id`) REFERENCES `civicrm_oauth_client`(`id`) ON DELETE CASCADE,          CONSTRAINT FK_civicrm_oauth_contact_token_contact_id FOREIGN KEY (`contact_id`) REFERENCES `civicrm_contact`(`id`) ON DELETE CASCADE
-)  ENGINE=InnoDB  ;
+)  ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;

--- a/ext/search_kit/sql/auto_install.sql
+++ b/ext/search_kit/sql/auto_install.sql
@@ -46,7 +46,7 @@ CREATE TABLE `civicrm_search_display` (
   UNIQUE INDEX `UI_saved_search__id_name`(saved_search_id, name),
   CONSTRAINT FK_civicrm_search_display_saved_search_id FOREIGN KEY (`saved_search_id`) REFERENCES `civicrm_saved_search`(`id`) ON DELETE CASCADE
 )
-ENGINE=InnoDB ROW_FORMAT=DYNAMIC;
+ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 -- /*******************************************************
 -- *
@@ -65,4 +65,4 @@ CREATE TABLE `civicrm_search_segment` (
   PRIMARY KEY (`id`),
   UNIQUE INDEX `UI_name`(name)
 )
-ENGINE=InnoDB ROW_FORMAT=DYNAMIC;
+ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;

--- a/ext/standaloneusers/sql/auto_install.sql
+++ b/ext/standaloneusers/sql/auto_install.sql
@@ -44,7 +44,7 @@ CREATE TABLE `civicrm_role` (
   `is_active` tinyint NOT NULL DEFAULT 1 COMMENT 'Only active roles grant permissions',
   PRIMARY KEY (`id`)
 )
-ENGINE=InnoDB;
+ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 -- /*******************************************************
 -- *
@@ -61,7 +61,7 @@ CREATE TABLE `civicrm_session` (
   PRIMARY KEY (`id`),
   UNIQUE INDEX `index_session_id`(session_id)
 )
-ENGINE=InnoDB;
+ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 -- /*******************************************************
 -- *
@@ -93,7 +93,7 @@ CREATE TABLE `civicrm_uf_match` (
   CONSTRAINT FK_civicrm_uf_match_domain_id FOREIGN KEY (`domain_id`) REFERENCES `civicrm_domain`(`id`),
   CONSTRAINT FK_civicrm_uf_match_contact_id FOREIGN KEY (`contact_id`) REFERENCES `civicrm_contact`(`id`) ON DELETE SET NULL
 )
-ENGINE=InnoDB;
+ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 -- /*******************************************************
 -- *
@@ -110,4 +110,4 @@ CREATE TABLE `civicrm_user_role` (
   CONSTRAINT FK_civicrm_user_role_user_id FOREIGN KEY (`user_id`) REFERENCES `civicrm_uf_match`(`id`) ON DELETE CASCADE,
   CONSTRAINT FK_civicrm_user_role_role_id FOREIGN KEY (`role_id`) REFERENCES `civicrm_role`(`id`) ON DELETE CASCADE
 )
-ENGINE=InnoDB;
+ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;

--- a/ext/standaloneusers/sql/upgrade_5691.sql
+++ b/ext/standaloneusers/sql/upgrade_5691.sql
@@ -6,4 +6,4 @@ CREATE TABLE `civicrm_session` (
   PRIMARY KEY (`id`),
   UNIQUE INDEX `index_session_id`(session_id)
 )
-ENGINE=InnoDB;
+ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;


### PR DESCRIPTION
Overview
----------------------------------------
This uses the new syntax generated by https://github.com/totten/civix/pull/329

Before
----------------------------------------
Possible inconsistencies between core tables and core/ext tables.

After
----------------------------------------
Consistent.