### PR TITLE
(dev/core#5010) Add fields to mailing details report

### DIFF
--- a/CRM/Report/Form/Mailing/Detail.php
+++ b/CRM/Report/Form/Mailing/Detail.php
@@ -131,6 +131,10 @@ class CRM_Report_Form_Mailing_Detail extends CRM_Report_Form {
           'title' => ts('Delivery Status'),
           'default' => TRUE,
         ],
+        'time_stamp' => [
+          'title' => ts('Delivery Date'),
+          'default' => TRUE,
+        ],
       ],
       'filters' => [
         'delivery_status' => [
@@ -143,6 +147,12 @@ class CRM_Report_Form_Mailing_Detail extends CRM_Report_Form {
             'successful' => 'Successful',
             'bounced' => 'Bounced',
           ],
+        ],
+        'time_stamp' => [
+          'name' => 'time_stamp',
+          'title' => ts('Delivery Date'),
+          'operatorType' => CRM_Report_Form::OP_DATE,
+          'type' => CRM_Utils_Type::T_DATE,
         ],
       ],
       'grouping' => 'mailing-fields',


### PR DESCRIPTION
Overview
----------------------------------------
Expose time stamp fields to mailing details report to show when the mailing was delivered.

Before
----------------------------------------
No filter/column present for delivery time stamp.

After
----------------------------------------
Voila!