### PR TITLE
SchemaHandler - Get table names from canonical sources instead of string-fu guesswork

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -785,7 +785,7 @@ MODIFY      {$columnName} varchar( $length )
    *
    * @return bool
    */
-  public static function migrateUtf8mb4($revert = FALSE, $patterns = ['civicrm\_%'], $databaseList = NULL) {
+  public static function migrateUtf8mb4($revert = FALSE, $patterns = [], $databaseList = NULL) {
     $newCharSet = $revert ? 'utf8' : 'utf8mb4';
     $newCollation = $revert ? 'utf8_unicode_ci' : 'utf8mb4_unicode_ci';
     $newBinaryCollation = $revert ? 'utf8_bin' : 'utf8mb4_bin';
@@ -795,6 +795,8 @@ MODIFY      {$columnName} varchar( $length )
 
     $tableNameLikePatterns = [];
     $logTableNameLikePatterns = [];
+
+    $patterns = $patterns ?: CRM_Core_DAO::getTableNames();
 
     foreach ($patterns as $pattern) {
       $pattern = CRM_Utils_Type::escape($pattern, 'String');

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1158,26 +1158,23 @@ class CRM_Core_DAO extends DB_DataObject {
   }
 
   /**
-   * Gets the names of all the tables in the schema.
+   * Gets the names of all enabled schema tables.
+   *
+   * - Includes tables from core, components & enabled extensions.
+   * - Excludes log tables, temp tables, and missing/disabled extensions.
    *
    * @return array
    *
    * @throws \CRM_Core_Exception
    */
   public static function getTableNames(): array {
-    $dao = CRM_Core_DAO::executeQuery(
-      "SELECT TABLE_NAME
-       FROM information_schema.TABLES
-       WHERE TABLE_SCHEMA = DATABASE()
-         AND TABLE_NAME LIKE 'civicrm_%'
-         AND TABLE_NAME NOT LIKE '%_tmp%'
-      ");
+    // CRM_Core_DAO_AllCoreTables returns all tables with a dao (core + extensions)
+    $daoTables = array_column(CRM_Core_DAO_AllCoreTables::getEntities(), 'table');
 
-    $values = [];
-    while ($dao->fetch()) {
-      $values[] = $dao->TABLE_NAME;
-    }
-    return $values;
+    // Include custom value tables
+    $customTables = array_column(CRM_Core_BAO_CustomGroup::getAll(), 'table_name');
+
+    return array_merge($daoTables, $customTables);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Makes our schema handler more thorough when checking table collations & outputting db prefixes.

Before
----------------------------------------
Any table starting with `civicrm_` is picked up. This excludes cividiscount_, civirule_, etc.

After
----------------------------------------
All registered tables are picked up.
