### PR TITLE
[REF] AllCoreTables - Cleanup comments, rename functions for consistency

### DIFF
--- a/CRM/Admin/Form.php
+++ b/CRM/Admin/Form.php
@@ -74,7 +74,7 @@ class CRM_Admin_Form extends CRM_Core_Form {
     $this->_BAOName = $this->get('BAOName');
     // Otherwise, look it up from the api entity name
     if (!$this->_BAOName) {
-      $this->_BAOName = CRM_Core_DAO_AllCoreTables::getBAOClassName(CRM_Core_DAO_AllCoreTables::getFullName($this->getDefaultEntity()));
+      $this->_BAOName = CRM_Core_DAO_AllCoreTables::getBAOClassName(CRM_Core_DAO_AllCoreTables::getDAONameForEntity($this->getDefaultEntity()));
     }
     $this->retrieveValues();
     $this->setPageTitle($this->_BAOName::getEntityTitle());

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3367,7 +3367,7 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
       !empty($event->object->is_primary) &&
       !empty($event->object->contact_id)
     ) {
-      $daoClass = CRM_Core_DAO_AllCoreTables::getFullName($event->entity);
+      $daoClass = CRM_Core_DAO_AllCoreTables::getDAONameForEntity($event->entity);
       $dao = new $daoClass();
       $dao->contact_id = $event->object->contact_id;
       $dao->is_primary = 1;

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -370,7 +370,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
    */
   public static function validateCustomGroupName(CRM_Core_DAO_CustomGroup $group) {
     $extends = in_array($group->extends, CRM_Contact_BAO_ContactType::basicTypes(TRUE)) ? 'Contact' : $group->extends;
-    $extendsDAO = CRM_Core_DAO_AllCoreTables::getFullName($extends);
+    $extendsDAO = CRM_Core_DAO_AllCoreTables::getDAONameForEntity($extends);
     if ($extendsDAO) {
       $fields = array_column($extendsDAO::fields(), 'name');
       if (in_array($group->name, $fields)) {

--- a/CRM/Core/BAO/EntityTag.php
+++ b/CRM/Core/BAO/EntityTag.php
@@ -457,7 +457,7 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag implements \Civi\Cor
       $options = [];
       foreach (self::buildOptions($fieldName) as $tableName => $label) {
         $bao = CRM_Core_DAO_AllCoreTables::getClassForTable($tableName);
-        $apiName = CRM_Core_DAO_AllCoreTables::getBriefName($bao);
+        $apiName = CRM_Core_DAO_AllCoreTables::getEntityNameForClass($bao);
         $options[$tableName] = $apiName;
       }
     }
@@ -484,7 +484,7 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag implements \Civi\Cor
     }
     // This is probably fairly mild in terms of helping performance - a case could be made to check if tags
     // exist before deleting (further down) as delete is a locking action.
-    $entity = CRM_Core_DAO_AllCoreTables::getBriefName(get_class($event->object));
+    $entity = CRM_Core_DAO_AllCoreTables::getEntityNameForClass(get_class($event->object));
     if ($entity && !isset(Civi::$statics[__CLASS__]['tagged_entities'][$entity])) {
       $tableName = CRM_Core_DAO_AllCoreTables::getTableForEntityName($entity);
       $used_for = CRM_Core_OptionGroup::values('tag_used_for');

--- a/CRM/Core/BAO/RecurringEntity.php
+++ b/CRM/Core/BAO/RecurringEntity.php
@@ -561,7 +561,7 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity implemen
       CRM_Core_BAO_RecurringEntity::quickAdd($object->id, $newObject->id, $entityTable);
     }
 
-    CRM_Utils_Hook::copy(CRM_Core_DAO_AllCoreTables::getBriefName($daoName), $newObject);
+    CRM_Utils_Hook::copy(CRM_Core_DAO_AllCoreTables::getEntityNameForClass($daoName), $newObject);
     return $newObject;
   }
 

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -153,7 +153,7 @@ class CRM_Core_DAO extends DB_DataObject {
   public static function getEntityTitle() {
     $className = static::class;
     CRM_Core_Error::deprecatedWarning("$className needs to be regenerated. Missing getEntityTitle method.");
-    return CRM_Core_DAO_AllCoreTables::getBriefName($className);
+    return CRM_Core_DAO_AllCoreTables::getEntityNameForClass($className);
   }
 
   /**
@@ -1017,7 +1017,7 @@ class CRM_Core_DAO extends DB_DataObject {
     if ($className === 'CRM_Core_DAO') {
       throw new CRM_Core_Exception('Function writeRecord must be called on a subclass of CRM_Core_DAO');
     }
-    $entityName = CRM_Core_DAO_AllCoreTables::getBriefName($className);
+    $entityName = CRM_Core_DAO_AllCoreTables::getEntityNameForClass($className);
 
     // For legacy reasons, empty values would sometimes be passed around as the string 'null'.
     // The DAO treats 'null' the same as '', and an empty string makes a lot more sense!
@@ -1086,7 +1086,7 @@ class CRM_Core_DAO extends DB_DataObject {
     if ($className === 'CRM_Core_DAO') {
       throw new CRM_Core_Exception('Function deleteRecord must be called on a subclass of CRM_Core_DAO');
     }
-    $entityName = CRM_Core_DAO_AllCoreTables::getBriefName($className);
+    $entityName = CRM_Core_DAO_AllCoreTables::getEntityNameForClass($className);
     if (empty($record[$idField])) {
       throw new CRM_Core_Exception("Cannot delete {$entityName} with no $idField.");
     }
@@ -2054,7 +2054,7 @@ LIKE %1
       if (!$blockCopyofCustomValues) {
         $newObject->copyCustomFields($object->id, $newObject->id);
       }
-      CRM_Utils_Hook::post('create', CRM_Core_DAO_AllCoreTables::getBriefName($daoName), $newObject->id, $newObject);
+      CRM_Utils_Hook::post('create', CRM_Core_DAO_AllCoreTables::getEntityNameForClass($daoName), $newObject->id, $newObject);
     }
 
     return $newObject;
@@ -2136,7 +2136,7 @@ LIKE %1
    * @param string $parentOperation
    */
   public function copyCustomFields($entityID, $newEntityID, $parentOperation = NULL) {
-    $entity = CRM_Core_DAO_AllCoreTables::getBriefName(get_class($this));
+    $entity = CRM_Core_DAO_AllCoreTables::getEntityNameForClass(get_class($this));
     $tableName = CRM_Core_DAO_AllCoreTables::getTableForClass(get_class($this));
     // Obtain custom values for the old entity.
     $customParams = $htmlType = [];
@@ -3293,7 +3293,7 @@ SELECT contact_id
   public static function getSelectWhereClause($tableAlias = NULL, $entityName = NULL, $conditions = []) {
     $bao = new static();
     $tableAlias ??= $bao->tableName();
-    $entityName ??= CRM_Core_DAO_AllCoreTables::getBriefName(get_class($bao));
+    $entityName ??= CRM_Core_DAO_AllCoreTables::getEntityNameForClass(get_class($bao));
     $finalClauses = [];
     $fields = static::getSupportedFields();
     $selectWhereClauses = $bao->addSelectWhereClause($entityName, NULL, $conditions);

--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -306,7 +306,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
    * @internal function will likely be protected soon.
    */
   protected function getPseudoValue(string $realField, string $pseudoKey, $fieldValue): string {
-    $bao = CRM_Core_DAO_AllCoreTables::getFullName($this->getMetadataForField($realField)['entity']);
+    $bao = CRM_Core_DAO_AllCoreTables::getDAONameForEntity($this->getMetadataForField($realField)['entity']);
     if ($pseudoKey === 'name') {
       // There is a theoretical possibility fieldValue could be an array but
       // specifically for preferred communication type - but real world usage

--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -184,7 +184,7 @@ trait CRM_Core_Form_EntityFormTrait {
     $this->assign('entityFields', $this->entityFields);
     $this->assign('entityID', $this->getEntityId());
     $this->assign('entityInClassFormat', strtolower(str_replace('_', '-', $this->getDefaultEntity())));
-    $this->assign('entityTable', CRM_Core_DAO_AllCoreTables::getTableForClass(CRM_Core_DAO_AllCoreTables::getFullName($this->getDefaultEntity())));
+    $this->assign('entityTable', CRM_Core_DAO_AllCoreTables::getTableForClass(CRM_Core_DAO_AllCoreTables::getDAONameForEntity($this->getDefaultEntity())));
     $this->addCustomDataToForm();
     $this->addFormButtons();
 

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -152,7 +152,7 @@ class CRM_Core_PseudoConstant {
       'condition' => [],
       'values' => [],
     ];
-    $entity = CRM_Core_DAO_AllCoreTables::getBriefName($daoName);
+    $entity = CRM_Core_DAO_AllCoreTables::getEntityNameForClass($daoName);
 
     // Custom fields are not in the schema
     if (strpos($fieldName, 'custom_') === 0 && is_numeric($fieldName[7])) {

--- a/CRM/Dedupe/MergeHandler.php
+++ b/CRM/Dedupe/MergeHandler.php
@@ -448,7 +448,7 @@ class CRM_Dedupe_MergeHandler {
     foreach ($blocksDAO as $blockDAOs) {
       if (!empty($blockDAOs['update'])) {
         foreach ($blockDAOs['update'] as $blockDAO) {
-          $entity = CRM_Core_DAO_AllCoreTables::getBriefName(get_class($blockDAO));
+          $entity = CRM_Core_DAO_AllCoreTables::getEntityNameForClass(get_class($blockDAO));
           $values = ['checkPermissions' => FALSE];
           foreach ($blockDAO->fields() as $field) {
             if (isset($blockDAO->{$field['name']})) {
@@ -460,7 +460,7 @@ class CRM_Dedupe_MergeHandler {
       }
       if (!empty($blockDAOs['delete'])) {
         foreach ($blockDAOs['delete'] as $blockDAO) {
-          $entity = CRM_Core_DAO_AllCoreTables::getBriefName(get_class($blockDAO));
+          $entity = CRM_Core_DAO_AllCoreTables::getEntityNameForClass(get_class($blockDAO));
           civicrm_api4($entity, 'delete', ['where' => [['id', '=', $blockDAO->id]], 'checkPermissions' => FALSE]);
         }
       }

--- a/CRM/Export/Controller/Standalone.php
+++ b/CRM/Export/Controller/Standalone.php
@@ -49,7 +49,7 @@ class CRM_Export_Controller_Standalone extends CRM_Core_Controller {
 
     // add all the actions
     $this->addActions();
-    $dao = CRM_Core_DAO_AllCoreTables::getFullName($entity);
+    $dao = CRM_Core_DAO_AllCoreTables::getDAONameForEntity($entity);
     CRM_Utils_System::setTitle(ts('Export %1', [1 => $dao::getEntityTitle(TRUE)]));
   }
 

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -649,7 +649,7 @@ abstract class CRM_Utils_Hook {
    *   Values from WHERE or ON clause
    */
   public static function selectWhereClause($entity, array &$clauses, int $userId = NULL, array $conditions = []): void {
-    $entityName = is_object($entity) ? CRM_Core_DAO_AllCoreTables::getBriefName(get_class($entity)) : $entity;
+    $entityName = is_object($entity) ? CRM_Core_DAO_AllCoreTables::getEntityNameForClass(get_class($entity)) : $entity;
     $null = NULL;
     $userId ??= (int) CRM_Core_Session::getLoggedInContactID();
     self::singleton()->invoke(['entity', 'clauses', 'userId', 'conditions'],

--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -264,7 +264,7 @@ class CRM_Utils_Recent {
    */
   private static function getIcon($entityType, $entityId) {
     $icon = NULL;
-    $daoClass = CRM_Core_DAO_AllCoreTables::getFullName($entityType);
+    $daoClass = CRM_Core_DAO_AllCoreTables::getDAONameForEntity($entityType);
     if ($daoClass) {
       $icon = CRM_Core_DAO_AllCoreTables::getBAOClassName($daoClass)::getEntityIcon($entityType, $entityId);
     }

--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -57,7 +57,7 @@ class CRM_Utils_SQL {
    * @return array
    */
   public static function mergeSubquery($entityName, $joinColumn = 'id') {
-    $baoName = CRM_Core_DAO_AllCoreTables::getBAOClassName(CRM_Core_DAO_AllCoreTables::getFullName($entityName));
+    $baoName = CRM_Core_DAO_AllCoreTables::getBAOClassName(CRM_Core_DAO_AllCoreTables::getDAONameForEntity($entityName));
     $bao = new $baoName();
     $fields = $bao::getSupportedFields();
     $mergeClauses = $subClauses = [];

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1880,7 +1880,7 @@ class CRM_Utils_System {
       $action = strtolower($action);
     }
 
-    $daoClass = isset($crudLinkSpec['entity']) ? CRM_Core_DAO_AllCoreTables::getFullName($crudLinkSpec['entity']) : CRM_Core_DAO_AllCoreTables::getClassForTable($crudLinkSpec['entity_table']);
+    $daoClass = isset($crudLinkSpec['entity']) ? CRM_Core_DAO_AllCoreTables::getDAONameForEntity($crudLinkSpec['entity']) : CRM_Core_DAO_AllCoreTables::getClassForTable($crudLinkSpec['entity_table']);
     $paths = $daoClass ? $daoClass::getEntityPaths() : [];
     $path = $paths[$action] ?? NULL;
     if (!$path) {

--- a/Civi/API/SelectQuery.php
+++ b/Civi/API/SelectQuery.php
@@ -267,7 +267,7 @@ abstract class SelectQuery {
       $entityTable = $this->where[$entityTableParam] ?? NULL;
       if ($entityTable && is_string($entityTable) && \CRM_Core_DAO_AllCoreTables::getClassForTable($entityTable)) {
         $fkField['FKClassName'] = \CRM_Core_DAO_AllCoreTables::getClassForTable($entityTable);
-        $fkField['FKApiName'] = \CRM_Core_DAO_AllCoreTables::getBriefName($fkField['FKClassName']);
+        $fkField['FKApiName'] = \CRM_Core_DAO_AllCoreTables::getEntityNameForClass($fkField['FKClassName']);
       }
     }
     if (!empty($fkField['pseudoconstant']['optionGroupName'])) {

--- a/Civi/API/Subscriber/DynamicFKAuthorization.php
+++ b/Civi/API/Subscriber/DynamicFKAuthorization.php
@@ -282,7 +282,7 @@ class DynamicFKAuthorization implements EventSubscriberInterface {
     if ($this->allowedDelegates === NULL || in_array($entityTable, $this->allowedDelegates)) {
       $className = \CRM_Core_DAO_AllCoreTables::getClassForTable($entityTable);
       if ($className) {
-        $entityName = \CRM_Core_DAO_AllCoreTables::getBriefName($className);
+        $entityName = \CRM_Core_DAO_AllCoreTables::getEntityNameForClass($className);
         if ($entityName) {
           return $entityName;
         }

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -130,7 +130,7 @@ abstract class AbstractEntity {
    * @return \CRM_Core_DAO|string|null
    */
   protected static function getDaoName(): ?string {
-    return \CRM_Core_DAO_AllCoreTables::getFullName(static::getEntityName());
+    return \CRM_Core_DAO_AllCoreTables::getDAONameForEntity(static::getEntityName());
   }
 
   /**

--- a/Civi/Api4/Provider/CustomEntityProvider.php
+++ b/Civi/Api4/Provider/CustomEntityProvider.php
@@ -44,7 +44,7 @@ class CustomEntityProvider extends AutoService implements EventSubscriberInterfa
       $entityName = 'Custom_' . $customGroup['name'];
       $baseEntity = CRM_Core_BAO_CustomGroup::getEntityFromExtends($customGroup['extends']);
       // Lookup base entity info using DAO methods not CoreUtil to avoid early-bootstrap issues
-      $baseEntityDao = \CRM_Core_DAO_AllCoreTables::getFullName($baseEntity);
+      $baseEntityDao = \CRM_Core_DAO_AllCoreTables::getDAONameForEntity($baseEntity);
       $baseEntityTitle = $baseEntityDao ? $baseEntityDao::getEntityTitle(TRUE) : $baseEntity;
       $e->entities[$entityName] = [
         'name' => $entityName,

--- a/Civi/Api4/Service/Spec/Provider/CustomValueSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/CustomValueSpecProvider.php
@@ -42,7 +42,7 @@ class CustomValueSpecProvider extends \Civi\Core\Service\AutoService implements 
     $groupName = CoreUtil::getCustomGroupName($spec->getEntity());
     $baseEntity = \CRM_Core_BAO_CustomGroup::getEntityForGroup($groupName);
     // Lookup base entity info using DAO methods not CoreUtil to avoid early-bootstrap issues
-    $baseEntityDao = \CRM_Core_DAO_AllCoreTables::getFullName($baseEntity);
+    $baseEntityDao = \CRM_Core_DAO_AllCoreTables::getDAONameForEntity($baseEntity);
     $baseEntityTitle = $baseEntityDao ? $baseEntityDao::getEntityTitle() : $baseEntity;
 
     $entityField = new FieldSpec('entity_id', $spec->getEntity(), 'Integer');

--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -191,7 +191,7 @@ class SpecGatherer extends AutoService implements EventSubscriberInterface {
           $DAOField['html']['controlField'] = $entityTableColumn;
           // If we have a value for entity_table then this field can pretend to be a single FK too.
           if ($spec->hasValue($entityTableColumn) && $DAOField['DFKEntities']) {
-            $DAOField['FKClassName'] = \CRM_Core_DAO_AllCoreTables::getFullName($DAOField['DFKEntities'][$spec->getValue($entityTableColumn)]);
+            $DAOField['FKClassName'] = \CRM_Core_DAO_AllCoreTables::getDAONameForEntity($DAOField['DFKEntities'][$spec->getValue($entityTableColumn)]);
           }
           break;
         }

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -39,7 +39,7 @@ class CoreUtil {
       $dao = \Civi\Api4\CustomValue::getInfo()['dao'];
     }
     else {
-      $dao = AllCoreTables::getFullName($entityName);
+      $dao = AllCoreTables::getDAONameForEntity($entityName);
     }
     if (!$dao && self::isContact($entityName)) {
       $dao = 'CRM_Contact_DAO_Contact';
@@ -56,7 +56,7 @@ class CoreUtil {
    * @return string|null
    */
   public static function getApiNameFromBAO($baoClassName): ?string {
-    $briefName = AllCoreTables::getBriefName($baoClassName);
+    $briefName = AllCoreTables::getEntityNameForClass($baoClassName);
     return $briefName && self::getApiClass($briefName) ? $briefName : NULL;
   }
 

--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -420,7 +420,7 @@ trait Api3TestTrait {
         unset($v3Params['option_group_id']);
       }
       if (isset($field['pseudoconstant'], $v3Params[$name]) && $field['type'] === \CRM_Utils_Type::T_INT && !is_numeric($v3Params[$name]) && is_string($v3Params[$name])) {
-        $v3Params[$name] = \CRM_Core_PseudoConstant::getKey(\CRM_Core_DAO_AllCoreTables::getFullName($v4Entity), $name, $v3Params[$name]);
+        $v3Params[$name] = \CRM_Core_PseudoConstant::getKey(\CRM_Core_DAO_AllCoreTables::getDAONameForEntity($v4Entity), $name, $v3Params[$name]);
       }
     }
 

--- a/Civi/Test/EntityExample.php
+++ b/Civi/Test/EntityExample.php
@@ -42,7 +42,7 @@ abstract class EntityExample implements ExampleDataInterface {
   }
 
   protected function dao(): string {
-    return \CRM_Core_DAO_AllCoreTables::getFullName($this->entityName);
+    return \CRM_Core_DAO_AllCoreTables::getDAONameForEntity($this->entityName);
   }
 
   protected function bao(): string {

--- a/api/api.php
+++ b/api/api.php
@@ -302,5 +302,5 @@ function _civicrm_api_get_entity_name_from_camel($entity) {
  * @return string
  */
 function _civicrm_api_get_entity_name_from_dao($bao) {
-  return CRM_Core_DAO_AllCoreTables::getBriefName(get_class($bao));
+  return CRM_Core_DAO_AllCoreTables::getEntityNameForClass(get_class($bao));
 }

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -337,7 +337,7 @@ function _civicrm_api3_get_DAO($name) {
     $name = strtoupper($name);
   }
 
-  $dao = CRM_Core_DAO_AllCoreTables::getFullName($name);
+  $dao = CRM_Core_DAO_AllCoreTables::getDAONameForEntity($name);
   if ($dao || !$name) {
     return $dao;
   }
@@ -1233,7 +1233,7 @@ function formatCheckBoxField(&$checkboxFieldValue, $customFieldLabel, $entity) {
  * @return array
  */
 function _civicrm_api3_basic_get($bao_name, $params, $returnAsSuccess = TRUE, $entity = "", $sql = NULL, $uniqueFields = FALSE) {
-  $entity = $entity ?: CRM_Core_DAO_AllCoreTables::getBriefName($bao_name);
+  $entity = $entity ?: CRM_Core_DAO_AllCoreTables::getEntityNameForClass($bao_name);
   $options = _civicrm_api3_get_options_from_params($params);
 
   // Skip query if table doesn't exist yet due to pending upgrade
@@ -1329,7 +1329,7 @@ function _civicrm_api3_basic_create($bao_name, &$params, $entity = NULL) {
       $alreadyHandled[] = 'Tag';
       $alreadyHandled[] = 'Website';
       if (!in_array($entity, $alreadyHandled)) {
-        CRM_Core_BAO_CustomValueTable::store($params['custom'], CRM_Core_DAO_AllCoreTables::getTableForClass(CRM_Core_DAO_AllCoreTables::getFullName($entity)), $bao->id);
+        CRM_Core_BAO_CustomValueTable::store($params['custom'], CRM_Core_DAO_AllCoreTables::getTableForClass(CRM_Core_DAO_AllCoreTables::getDAONameForEntity($entity)), $bao->id);
       }
     }
     $values = [];
@@ -1945,7 +1945,7 @@ function _civicrm_api_get_fields($entity, $unique = FALSE, &$params = []) {
   // Translate FKClassName to the corresponding api
   foreach ($fields as $name => &$field) {
     if (!empty($field['FKClassName'])) {
-      $FKApi = CRM_Core_DAO_AllCoreTables::getBriefName($field['FKClassName']);
+      $FKApi = CRM_Core_DAO_AllCoreTables::getEntityNameForClass($field['FKClassName']);
       if ($FKApi) {
         $field['FKApiName'] = $FKApi;
       }

--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -58,7 +58,7 @@ function financialacls_civicrm_pre($op, $objectName, $id, &$params) {
   }
   if (in_array($objectName, ['LineItem', 'Product'], TRUE) && !empty($params['check_permissions'])) {
     if (empty($params['financial_type_id']) && !empty($params['id'])) {
-      $dao = CRM_Core_DAO_AllCoreTables::getFullName($objectName);
+      $dao = CRM_Core_DAO_AllCoreTables::getDAONameForEntity($objectName);
       $params['financial_type_id'] = CRM_Core_DAO::getFieldValue($dao, $params['id'], 'financial_type_id');
     }
     $operationMap = ['delete' => CRM_Core_Action::DELETE, 'edit' => CRM_Core_Action::UPDATE, 'create' => CRM_Core_Action::ADD];

--- a/tests/phpunit/CRM/Core/DAO/AllCoreTablesTest.php
+++ b/tests/phpunit/CRM/Core/DAO/AllCoreTablesTest.php
@@ -216,14 +216,14 @@ class CRM_Core_DAO_AllCoreTablesTest extends CiviUnitTestCase {
   }
 
   public function testGetBriefName(): void {
-    $this->assertEquals('Contact', CRM_Core_DAO_AllCoreTables::getBriefName('CRM_Contact_BAO_Contact'));
-    $this->assertEquals('Contact', CRM_Core_DAO_AllCoreTables::getBriefName('CRM_Contact_DAO_Contact'));
-    $this->assertNull(CRM_Core_DAO_AllCoreTables::getBriefName('CRM_Core_DAO_XqZy'));
+    $this->assertEquals('Contact', CRM_Core_DAO_AllCoreTables::getEntityNameForClass('CRM_Contact_BAO_Contact'));
+    $this->assertEquals('Contact', CRM_Core_DAO_AllCoreTables::getEntityNameForClass('CRM_Contact_DAO_Contact'));
+    $this->assertNull(CRM_Core_DAO_AllCoreTables::getEntityNameForClass('CRM_Core_DAO_XqZy'));
   }
 
   public function testGetFullName(): void {
-    $this->assertEquals('CRM_Contact_DAO_Contact', CRM_Core_DAO_AllCoreTables::getFullName('Contact'));
-    $this->assertNull(CRM_Core_DAO_AllCoreTables::getFullName('XqZy'));
+    $this->assertEquals('CRM_Contact_DAO_Contact', CRM_Core_DAO_AllCoreTables::getDAONameForEntity('Contact'));
+    $this->assertNull(CRM_Core_DAO_AllCoreTables::getDAONameForEntity('XqZy'));
   }
 
   public function testGetEntityNameForTable(): void {


### PR DESCRIPTION
Overview
----------------------------------------
Renames a few functions in `CRM_Core_DAO_AllCoreTables` for clarity & consistency.

Technical Details
----------------------------------------
These functions are all pretty internal, but if any extension is using them I gave a long (24 month) noisy deprecation period.
