### PR TITLE
CRM_Utils_JS - Improve encoding of object keys

### DIFF
--- a/tests/phpunit/CRM/Utils/JSTest.php
+++ b/tests/phpunit/CRM/Utils/JSTest.php
@@ -251,8 +251,8 @@ class CRM_Utils_JSTest extends CiviUnitTestCase {
         "{a: 'Apple', b: 'Banana', c: [0, -2, 3.15]}",
       ],
       [
-        ['a' => ['foo', 'bar'], 'b' => ["'a'" => ['foo/bar&', 'bar(foo)'], 'b' => ['a' => ["fo\\'oo", '"bar"'], 'b' => []]]],
-        "{a: ['foo', 'bar'], b: {\"'a'\": ['foo/bar&', 'bar(foo)'], b: {a: ['fo\\\\\\'oo', '\"bar\"'], b: {}}}}",
+        ['a.b-c' => ['foo', 'bar'], 'b' => ["'a'" => ['foo/bar&', 'bar(foo)'], 'b' => ["'a'" => ["fo\\'oo", '"bar"'], 'b' => []]]],
+        "{'a.b-c': ['foo', 'bar'], b: {'\'a\'': ['foo/bar&', 'bar(foo)'], b: {'\'a\'': ['fo\\\\\\'oo', '\"bar\"'], b: {}}}}",
       ],
       [TRUE, 'true'],
       [' ', "' '"],
@@ -313,12 +313,12 @@ class CRM_Utils_JSTest extends CiviUnitTestCase {
       [
         '{status: /^http:\/\/civicrm\.com/.test(url) ? \'good\' : \'bad\' , \'foo\&\': getFoo("Some \"quoted\" thing"), "ba\'[(r": function() {return "bar"}}',
         ['status' => '/^http:\/\/civicrm\.com/.test(url) ? \'good\' : \'bad\'', 'foo&' => 'getFoo("Some \"quoted\" thing")', "ba'[(r" => 'function() {return "bar"}'],
-        '{status: /^http:\/\/civicrm\.com/.test(url) ? \'good\' : \'bad\', "foo&": getFoo("Some \"quoted\" thing"), "ba\'[(r": function() {return "bar"}}',
+        '{status: /^http:\/\/civicrm\.com/.test(url) ? \'good\' : \'bad\', \'foo&\': getFoo("Some \"quoted\" thing"), \'ba\\\'[(r\': function() {return "bar"}}',
       ],
       [
         '{"some\"key": typeof foo === \'number\' ? true : false , "O\'Really?": ",((,", \'A"quote"\': 1 + 1 , "\\\\&\\/" : 0}',
         ['some"key' => 'typeof foo === \'number\' ? true : false', "O'Really?" => '",((,"', 'A"quote"' => '1 + 1', '\\&/' => '0'],
-        '{\'some"key\': typeof foo === \'number\' ? true : false, "O\'Really?": ",((,", \'A"quote"\': 1 + 1, "\\\\&/": 0}',
+        '{\'some"key\': typeof foo === \'number\' ? true : false, \'O\\\'Really?\': ",((,", \'A"quote"\': 1 + 1, \'\\\\&/\': 0}',
       ],
       [
         '[foo ? 1 : 2 , 3 ,  function() {return 1 + 1;}, /^http:\/\/civicrm\.com/.test(url) ? \'good\' : \'bad\' , 3.14   ]',


### PR DESCRIPTION
Overview
----------------------------------------
Originally this was to fix https://lab.civicrm.org/dev/core/-/issues/4977 but that turned out to have a different root cause (see https://github.com/civicrm/civicrm-core/pull/29400). But this still stands as a general improvement to our js encode/decode algorithm.

Before
--------
Object keys and values were being encoded differently, even if they are both strings.

After
------
Uses same encoding method for both; gives more consistent results.

Technical Details
----------------------------------------
CRM_Utils_JS would normally put single quotes (or no quotes) around keys in an object, but was falling back to double-quotes if the string had any non-word characters (like a dot). Custom field names include a dot, so this was putting double quotes into the js string which was breaking out of the quoted html attribute.

Why the html attribute was not getting correctly encoded is another question...
**Update:** the regression was actually caused by 0ae1b99e9efd9ad04d208ce8f021814c832e2639