### PR TITLE
Stop passing some-weird-but-always-the-same params to getPositions

### DIFF
--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -104,11 +104,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
       }
 
       $cacheKey = CRM_Dedupe_Merger::getMergeCacheKeyString($this->_rgid, $gid, json_decode($this->criteria, TRUE), TRUE, $this->limit);
-
-      $join = CRM_Dedupe_Merger::getJoinOnDedupeTable();
-      $where = "de.id IS NULL";
-
-      $pos = CRM_Core_BAO_PrevNextCache::getPositions($cacheKey, $this->_cid, $this->_oid, $this->_mergeId, $join, $where, $flip);
+      $pos = CRM_Core_BAO_PrevNextCache::getPositions($cacheKey, $flip ? $this->_oid : $this->_cid, $flip ? $this->_cid : $this->_oid, $this->_mergeId);
 
       // get user info of main contact.
       $config = CRM_Core_Config::singleton();
@@ -339,10 +335,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
     elseif ($this->next && $this->_mergeId && empty($formValues['_qf_Merge_done'])) {
       $cacheKey = CRM_Dedupe_Merger::getMergeCacheKeyString($this->_rgid, $this->_gid, json_decode($this->criteria, TRUE), TRUE, $this->limit);
 
-      $join = CRM_Dedupe_Merger::getJoinOnDedupeTable();
-      $where = "de.id IS NULL";
-
-      $pos = CRM_Core_BAO_PrevNextCache::getPositions($cacheKey, NULL, NULL, $this->_mergeId, $join, $where);
+      $pos = CRM_Core_BAO_PrevNextCache::getPositions($cacheKey, NULL, NULL, $this->_mergeId);
 
       if (!empty($pos) &&
         $pos['next']['id1'] &&

--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -23,18 +23,26 @@ class CRM_Core_BAO_PrevNextCache extends CRM_Core_DAO_PrevNextCache {
   /**
    * Get the previous and next keys.
    *
+   * @internal as of Feb 2014 no universe usages other than defunct CiviHR
+   * code found.
+   *
    * @param string $cacheKey
    * @param int $id1
    * @param int $id2
-   * @param int $mergeId
-   * @param string $join
-   * @param string $where
+   * @param null $mergeId
+   * @param null $ignore
+   * @param null $ignore_more
    * @param bool $flip
    *
    * @return array
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\Core\Exception\DBQueryException
    */
-  public static function getPositions($cacheKey, $id1, $id2, &$mergeId = NULL, $join = NULL, $where = NULL, $flip = FALSE) {
+  public static function getPositions($cacheKey, $id1, $id2, &$mergeId = NULL, $ignore = NULL, $ignore_more = NULL, $flip = FALSE) {
+    $join = CRM_Dedupe_Merger::getJoinOnDedupeTable();
+    $where = "de.id IS NULL";
     if ($flip) {
+      CRM_Core_Error::deprecatedFunctionWarning('handle this outside the function');
       [$id1, $id2] = [$id2, $id1];
     }
 

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -204,7 +204,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
     $select = ['pn.is_selected' => 'is_selected'];
     $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($dao->id, $this->_groupId, [], TRUE, 0);
     $pnDupePairs = CRM_Core_BAO_PrevNextCache::retrieve($cacheKeyString, NULL, NULL, 0, 0, $select);
-    $this->assertEquals(count($foundDupes), count($pnDupePairs), 'Check number of dupe pairs in prev next cache.');
+    $this->assertCount(count($foundDupes), $pnDupePairs, 'Check number of dupe pairs in prev next cache.');
 
     // mark first two pairs as selected
     CRM_Core_DAO::singleValueQuery("UPDATE civicrm_prevnext_cache SET is_selected = 1 WHERE id IN ({$pnDupePairs[0]['prevnext_id']}, {$pnDupePairs[1]['prevnext_id']})");
@@ -408,8 +408,6 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
 
   /**
    * Test results are returned when criteria are passed in.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testGetMatchesCriteriaMatched(): void {
     $this->setupMatchData();


### PR DESCRIPTION


Overview
----------------------------------------
Stop passing some-weird-but-always-the-same params to getPositions

Before
----------------------------------------
`$join` and `$where` passed in, always have the same variables. `$flip` passed in in one case & has the effect of switching the order of 2 passed in variables

After
----------------------------------------
variables no longer passed, `$flip` is deprecated as a hypothetical caller would need to update their call

Technical Details
----------------------------------------
A universe search shows only these 2 callers + 2 copy & paste callers in Civi-HR. In all cases join & where have the same values so we don't need them

I put in a deprecation warning for the silly flip parameter

Comments
----------------------------------------