### PR TITLE
Fix PHP Notice in Contact Import Parser

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -388,7 +388,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
           foreach ($customOption as $customValue) {
             $val = $customValue['value'] ?? NULL;
             $label = strtolower($customValue['label'] ?? '');
-            $value = strtolower(trim($formatted[$key]));
+            $value = strtolower(trim($formatted[$key] ?? ''));
             if (($value == $label) || ($value == strtolower($val))) {
               $params[$key] = $formatted[$key] = $val;
             }


### PR DESCRIPTION
e.g.
coworker[3112893]: [PHP Notice] Undefined index: custom_348 at sites/all/modules/civicrm/CRM/Contact/Import/Parser/Contact.php:391

Overview
----------------------------------------
Fixes an e-notice when importing a contact with custom fields

Before
----------------------------------------
notices in coworker log

After
----------------------------------------
No notices in coworker log

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
