### PR TITLE
Afform - Fix incorrect html encoding when saving

### DIFF
--- a/ext/afform/core/CRM/Afform/ArrayHtml.php
+++ b/ext/afform/core/CRM/Afform/ArrayHtml.php
@@ -376,7 +376,10 @@ class CRM_Afform_ArrayHtml {
    * @return string
    */
   public function replaceUnicodeChars($markup) {
-    return htmlspecialchars_decode(htmlentities($markup, ENT_COMPAT, 'utf-8', FALSE));
+    $replace = [
+      ["\xc2\xa0", '&nbsp;'],
+    ];
+    return str_replace(array_column($replace, 0), array_column($replace, 1), $markup);
   }
 
   /**

--- a/ext/afform/core/tests/phpunit/Civi/Afform/AfformGetTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/AfformGetTest.php
@@ -75,6 +75,39 @@ class AfformGetTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
     $this->assertArrayNotHasKey('#children', $layout[0]['#children'][0]);
   }
 
+  public function testGetHtmlEncoding(): void {
+    Afform::create(FALSE)
+      ->setLayoutFormat('shallow')
+      ->addValue('name', $this->formName)
+      ->addValue('title', 'Test Form')
+      ->addValue('layout', [
+        [
+          '#tag' => 'af-form',
+          'ctrl' => 'afform',
+          '#children' => [
+            [
+              '#tag' => 'af-entity',
+              'data' => "{contact_type: 'Individual', source: 'This isn\\'t \"quotes\"'}",
+              'type' => 'Contact',
+              'name' => 'Individual1',
+            ],
+          ],
+        ],
+      ])
+      ->execute();
+
+    $html = Afform::get(FALSE)
+      ->addWhere('name', '=', $this->formName)
+      ->setLayoutFormat('html')
+      ->execute()->single()['layout'];
+
+    $expected = <<<HTML
+data="{contact_type: 'Individual', source: 'This isn\'t &quot;quotes&quot;'}"
+HTML;
+
+    $this->assertStringContainsString($expected, $html);
+  }
+
   public function testAfformAutocomplete(): void {
     // Use a numeric title to test that the "search by id" feature
     // doesn't kick in for Afforms (which don't have a numeric "id")


### PR DESCRIPTION
Overview
----------------------------------------
Fixes regression described in https://lab.civicrm.org/dev/core/-/issues/4977

Technical Details
----------------------------------------
This reverts 0ae1b99 AND 4a439e7.

- The problem with 4a439e7 is that function mode is [deprecated in php 8.2](https://www.php.net/manual/en/function.mb-convert-encoding.php#refsect1-function.mb-convert-encoding-changelog). 
- The problem with 0ae1b99 is that it was wrong and broke the html encoding of the file (FYI @seamuslee001).

So this takes us all the way back to the original version of the function, which actually worked fine for what it did. I guess anything fancier than a `str_replace()` was just asking for trouble...
