### PR TITLE
APIv4: Automatically add 'OR IS NULL' to 'NOT CONTAINS'

### DIFF
--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -204,15 +204,15 @@ class ContactGetTest extends Api4TestBase implements TransactionalInterface {
     $last_name = uniqid(__FUNCTION__);
 
     $alice = Contact::create()
-      ->setValues(['first_name' => 'Alice', 'last_name' => $last_name])
+      ->setValues(['first_name' => 'Alice', 'middle_name' => 'Angela', 'last_name' => $last_name])
       ->execute()->first();
 
     $alex = Contact::create()
-      ->setValues(['first_name' => 'Alex', 'last_name' => $last_name])
+      ->setValues(['first_name' => 'Alex', 'middle_name' => 'Zed', 'last_name' => $last_name])
       ->execute()->first();
 
     $jane = Contact::create()
-      ->setValues(['first_name' => 'Jane', 'last_name' => $last_name])
+      ->setValues(['first_name' => 'Jane', 'middle_name' => 'Z', 'last_name' => $last_name])
       ->execute()->first();
 
     $holly = Contact::create()
@@ -287,6 +287,36 @@ class ContactGetTest extends Api4TestBase implements TransactionalInterface {
     $this->assertArrayHasKey($alice['id'], (array) $result);
     $this->assertArrayHasKey($alex['id'], (array) $result);
     $this->assertArrayHasKey($jane['id'], (array) $result);
+
+    $result = Contact::get(FALSE)
+      ->addWhere('last_name', '=', $last_name)
+      ->addWhere('middle_name', 'CONTAINS', 'A')
+      ->execute()->indexBy('id');
+    $this->assertCount(1, $result);
+    $this->assertArrayHasKey($alice['id'], (array) $result);
+
+    $result = Contact::get(FALSE)
+      ->addWhere('last_name', '=', $last_name)
+      ->addWhere('middle_name', 'NOT CONTAINS', 'Z')
+      ->execute()->indexBy('id');
+    $this->assertCount(5, $result);
+    $this->assertArrayHasKey($alice['id'], (array) $result);
+    $this->assertArrayHasKey($holly['id'], (array) $result);
+    $this->assertArrayHasKey($meg['id'], (array) $result);
+    $this->assertArrayHasKey($jess['id'], (array) $result);
+    $this->assertArrayHasKey($amy['id'], (array) $result);
+
+    $result = Contact::get(FALSE)
+      ->addWhere('last_name', '=', $last_name)
+      ->addWhere('middle_name', 'NOT CONTAINS', 'Zed')
+      ->execute()->indexBy('id');
+    $this->assertCount(6, $result);
+    $this->assertArrayHasKey($alice['id'], (array) $result);
+    $this->assertArrayHasKey($jane['id'], (array) $result);
+    $this->assertArrayHasKey($holly['id'], (array) $result);
+    $this->assertArrayHasKey($meg['id'], (array) $result);
+    $this->assertArrayHasKey($jess['id'], (array) $result);
+    $this->assertArrayHasKey($amy['id'], (array) $result);
   }
 
   public function testGetRelatedWithSubType(): void {


### PR DESCRIPTION
Overview
----------------------------------------
In APIv4 'NOT CONTAINS', automatically add a 'OR IS NULL' since we just want to know that a particular value is not present but don't care whether the field has any other value or is empty.

Before
----------------------------------------

1. On standard sample data, for one contact, set "Most Important Issue" to "Education" and on another contact set "Environment"
2. Create a SearchKit on Contacts with a `WHERE` of `Constituent Information:Most Important Issue` `Contains` `Education`
3. Confirm results include those in 1.
4. Change to `Doesn't Contain`
5. Note only the contact with "Environment" is shown - not all the other records with no value set for "Most Important Issue"


After
----------------------------------------
All contacts without 'Education' as the 'Most Important Issue' are returned.

Technical Details
----------------------------------------
Not sure whether there is a better way to implement this.

Comments
----------------------------------------
This can be worked around in SK by adding an 'OR' group with 'IS EMPTY' but this is cumbersome.
