### PR TITLE
AngularJS - Fix log warning on upgrade UI

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -381,9 +381,11 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
     if (!self::isAjaxMode()) {
       $this->addBundle('coreResources');
       $this->addCoreStyles($region);
-      // This ensures that if a popup link requires AngularJS, it will always be available.
-      // Additional Ang modules required by popups will be loaded on-the-fly by Civi\Angular\AngularLoader
-      Civi::service('angularjs.loader')->addModules(['crmResource']);
+      if (!CRM_Core_Config::isUpgradeMode()) {
+        // This ensures that if a popup link requires AngularJS, it will always be available.
+        // Additional Ang modules required by popups will be loaded on-the-fly by Civi\Angular\AngularLoader
+        Civi::service('angularjs.loader')->addModules(['crmResource']);
+      }
     }
     return $this;
   }


### PR DESCRIPTION
Overview
----------------------------------------

When loading `civicrm/upgrade?reset=1`, there's a log message about `angular-modules.js`.

This is a follow-up to 5.69's 9bf181cfad2c22fbc9033abc0012ceef3547e71f (cc @colemanw).

Before
----------------------------------------

Install D7 w/5.63. Switch the code to 5.69 or newer. Open `civicrm/upgrade?reset=1`. Check the log. See:

```
2024-02-15 13:22:05-0800  [error] Unexpected error while rendering a file in the AssetBuilder: Unrecognized asset name: angular-modules.js
Array
(
    [exception] => Civi\Core\Exception\UnknownAssetException: "Unrecognized asset name: angular-modules.js"
#0 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/Core/AssetBuilder.php(198): Civi\Core\AssetBuilder->render("angular-modules.js", (Array:1))
#1 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/Core/AssetBuilder.php(136): Civi\Core\AssetBuilder->build("angular-modules.js", (Array:1))
#2 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/Angular/AngularLoader.php(200): Civi\Core\AssetBuilder->getUrl("angular-modules.js", (Array:1))
#3 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/Angular/AngularLoader.php(391): Civi\Angular\AngularLoader->loadAngularResources()
#4 [internal function](): Civi\Angular\AngularLoader->onRegionRender(Object(Civi\Core\Event\GenericHookEvent), "civi.region.render", Object(Civi\Core\UnoptimizedEventDispatcher))
#5 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/Core/Event/ServiceListener.php(53): call_user_func_array((Array:2), (Array:3))
#6 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/vendor/symfony/event-dispatcher/EventDispatcher.php(251): Civi\Core\Event\ServiceListener->__invoke(Object(Civi\Core\Event\GenericHookEvent), "civi.region.render", Object(Civi\Core\UnoptimizedEventDispatcher))
#7 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/vendor/symfony/event-dispatcher/EventDispatcher.php(73): Symfony\Component\EventDispatcher\EventDispatcher->callListeners((Array:4), "civi.region.render", Object(Civi\Core\Event\GenericHookEvent))
#8 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/Core/CiviEventDispatcher.php(263): Symfony\Component\EventDispatcher\EventDispatcher->dispatch(Object(Civi\Core\Event\GenericHookEvent), "civi.region.render")
#9 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/Region.php(64): Civi\Core\CiviEventDispatcher->dispatch("civi.region.render", Object(Civi\Core\Event\GenericHookEvent))
#10 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Utils/System/Drupal.php(907): CRM_Core_Region->render("")
#11 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Utils/System.php(203): CRM_Utils_System_Drupal->theme("  <div class=\"crm-container crm-upgrade-box-outer crm-upgrade-warning\">\n  ...", FALSE, TRUE)
#12 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Upgrade/Page/Upgrade.php(116): CRM_Utils_System::theme("  <div class=\"crm-container crm-upgrade-box-outer crm-upgrade-warning\">\n  ...", FALSE, TRUE)
#13 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Upgrade/Page/Upgrade.php(47): CRM_Upgrade_Page_Upgrade->runIntro()
#14 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/Invoke.php(323): CRM_Upgrade_Page_Upgrade->run((Array:2), NULL)
#15 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/Invoke.php(69): CRM_Core_Invoke::runItem((Array:17))
#16 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/Invoke.php(36): CRM_Core_Invoke::_invoke((Array:2))
#17 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/drupal/civicrm.module(470): CRM_Core_Invoke::invoke((Array:2))
#18 /Users/totten/bknix/build/dmaster/web/includes/menu.inc(527): civicrm_invoke("upgrade")
#19 /Users/totten/bknix/build/dmaster/web/index.php(24): menu_execute_active_handler()
#20 {main}

)
```

After
----------------------------------------

The same scenario gives a clean log.

