### PR TITLE
dev/core#5007 Fix failure to assign default membership to quick config price set

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -242,7 +242,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
     $memtypeID = NULL;
     if ($this->_priceSetId) {
-      if ($this->isMembershipPriceSet()) {
+      if ($this->getFormContext() === 'membership') {
         $selectedCurrentMemTypes = [];
         foreach ($this->_priceSet['fields'] as $key => $val) {
           foreach ($val['options'] as $keys => $values) {
@@ -926,6 +926,9 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         $errors["price_{$otherAmount}"] = ts('Amount is required field.');
       }
 
+      // @todo - this should probably be $this->getFormContext() === 'membership'
+      // which would make it apply to quick config & non quick config.
+      // See https://lab.civicrm.org/dev/core/-/issues/3314
       if ($self->isMembershipPriceSet() && !empty($check) && $membershipIsActive) {
         $priceFieldIDS = [];
         $priceFieldMemTypes = [];


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5007 Fix failure to assign default membership to quick config price set

Before
----------------------------------------
With a quick config membership the existing membership type is not selected as the default on renewal

After
----------------------------------------
It is


Technical Details
----------------------------------------
The default setting  code was using a function that checked not just if it was being used for membership context but also if it was quick config - this removes that check

There is some related code that I commented as probably meriting the same change to fix https://lab.civicrm.org/dev/core/-/issues/3314 - we could do that change in master -depending on @MegaphoneJon's interest in testing it.

Comments
----------------------------------------
