### PR TITLE
Remove calls to get_template_vars, template_exists

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -1296,7 +1296,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     if ($this->_contactSubType) {
       $templateFile = "CRM/Contact/Form/Edit/SubType/{$this->_contactSubType}.tpl";
       $template = CRM_Core_Form::getTemplate();
-      if ($template->template_exists($templateFile)) {
+      if ($template->templateExists($templateFile)) {
         return $templateFile;
       }
     }

--- a/CRM/Core/Smarty/plugins/block.localize.php
+++ b/CRM/Core/Smarty/plugins/block.localize.php
@@ -38,13 +38,13 @@ function smarty_block_localize($params, $text, $smarty, &$repeat) {
     // For opening tag text is always null
     return '';
   }
-  $multiLingual = method_exists($smarty, 'get_template_vars') ? $smarty->get_template_vars('multilingual') : $smarty->getTemplateVars('multilingual');
+  $multiLingual = $smarty->getTemplateVars('multilingual');
   if (!$multiLingual) {
     return $text;
   }
 
   $lines = [];
-  $locales = (array) (method_exists($smarty, 'get_template_vars') ? $smarty->get_template_vars('locales') : $smarty->getTemplateVars('locales'));
+  $locales = (array) $smarty->getTemplateVars('locales');
   foreach ($locales as $locale) {
     $line = $text;
     if (isset($params['field'])) {

--- a/CRM/Core/Smarty/plugins/block.ts.php
+++ b/CRM/Core/Smarty/plugins/block.ts.php
@@ -37,14 +37,7 @@
  */
 function smarty_block_ts($params, $text, &$smarty, &$repeat) {
   if (!$repeat) {
-    $extensionKey = '';
-    if (method_exists($smarty, 'getTemplateVars')) {
-      $extensionKey = $smarty->getTemplateVars('extensionKey');
-    }
-    else {
-      // Transitional support for Smarty2 still being used in GenCode.
-      $extensionKey = $smarty->get_template_vars('extensionKey');
-    }
+    $extensionKey = $smarty->getTemplateVars('extensionKey');
     if (!isset($params['domain']) && $extensionKey) {
       $params['domain'] = is_array($extensionKey) ? $extensionKey : [$extensionKey, NULL];
     }

--- a/CRM/Core/SmartyCompatibility.php
+++ b/CRM/Core/SmartyCompatibility.php
@@ -139,7 +139,7 @@ class CRM_Core_SmartyCompatibility extends Smarty {
   /**
    * Returns an array containing template variables
    *
-   * @deprecated
+   * @deprecated since 5.69 will be removed around 5.79
    *
    * @param string $name
    *


### PR DESCRIPTION
Overview
----------------------------------------
Remove calls to get_template_vars, deprecate more noisily

Before
----------------------------------------
A couple of places called by gencode still handling possibility Smarty2 is loaded directly & that `getTemplateVars()` might not be available - but we since hacked Smarty2 so it IS always available

After
----------------------------------------
Hacks removed, noisy deprecation added

Technical Details
----------------------------------------

Comments
----------------------------------------
