### PR TITLE
Remove (unreachable) call to clearAssign

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -300,12 +300,7 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
       if ($key === 'config' || $key === 'session') {
         continue;
       }
-      if (method_exists($this, 'clearAssign')) {
-        $this->clearAssign($key);
-      }
-      else {
-        $this->clear_assign($key);
-      }
+      $this->clearAssign($key);
     }
   }
 

--- a/CRM/Core/SmartyCompatibility.php
+++ b/CRM/Core/SmartyCompatibility.php
@@ -179,7 +179,6 @@ class CRM_Core_SmartyCompatibility extends Smarty {
    * @return mixed|null|void
    */
   public function clear_assign($tpl_var) {
-    CRM_Core_Error::deprecatedFunctionWarning('clearAssign');
     if (method_exists(get_parent_class(), 'clear_assign')) {
       parent::clear_assign($tpl_var);
       return;

--- a/CRM/Core/SmartyCompatibility.php
+++ b/CRM/Core/SmartyCompatibility.php
@@ -179,6 +179,7 @@ class CRM_Core_SmartyCompatibility extends Smarty {
    * @return mixed|null|void
    */
   public function clear_assign($tpl_var) {
+    CRM_Core_Error::deprecatedFunctionWarning('clearAssign');
     if (method_exists(get_parent_class(), 'clear_assign')) {
       parent::clear_assign($tpl_var);
       return;


### PR DESCRIPTION

Overview
----------------------------------------
Remove (unreachable) call to clearAssign

Before
----------------------------------------
We have backwards compatibility handling from before we hacked `clearAssign()` into smarty 2

After
----------------------------------------
poof

Technical Details
----------------------------------------


Comments
----------------------------------------
