### PR TITLE
Stop calling assign_by_ref on smarty

### DIFF
--- a/CRM/Core/SmartyCompatibility.php
+++ b/CRM/Core/SmartyCompatibility.php
@@ -153,15 +153,13 @@ class CRM_Core_SmartyCompatibility extends Smarty {
    * @deprecated
    * @param string $tpl_var
    * @param mixed $value
-   *
-   * @return mixed|null|void
    */
   public function assign_by_ref($tpl_var, &$value) {
-    if (method_exists(get_parent_class(), 'assign_by_ref')) {
+    if (method_exists(parent::class, 'assign_by_ref')) {
       parent::assign_by_ref($tpl_var, $value);
       return;
     }
-    return parent::assignByRef($tpl_var, $value);
+    $this->assign($tpl_var, $value);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Stop calling assign_by_ref on smarty

Before
----------------------------------------
`assign_by_ref` is fully removed in Smarty5 & isn't really used that way anyway - but we are still calling it

After
----------------------------------------
it just calls `assign`

Technical Details
----------------------------------------


Comments
----------------------------------------

