### PR TITLE
[REF] AllCoreTables - Make internal function private

### DIFF
--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -59,7 +59,7 @@ class CRM_Core_DAO_AllCoreTables {
   }
 
   /**
-   * (Quasi-Private) Do not call externally (except for unit-testing)
+   * Add entity type to cached array.
    *
    * @param string $briefName
    * @param string $className
@@ -67,7 +67,7 @@ class CRM_Core_DAO_AllCoreTables {
    * @param string $fields_callback
    * @param string $links_callback
    */
-  public static function registerEntityType($briefName, $className, $tableName, $fields_callback = NULL, $links_callback = NULL) {
+  private static function registerEntityType($briefName, $className, $tableName, $fields_callback = NULL, $links_callback = NULL) {
     Civi::$statics[__CLASS__]['tables'][$tableName] = $briefName;
     Civi::$statics[__CLASS__]['classes'][$className] = $briefName;
     Civi::$statics[__CLASS__]['entities'][$briefName] = [

--- a/tests/phpunit/CRM/Dedupe/BAO/RuleGroupTest.php
+++ b/tests/phpunit/CRM/Dedupe/BAO/RuleGroupTest.php
@@ -247,7 +247,14 @@ class CRM_Dedupe_BAO_RuleGroupTest extends CiviUnitTestCase {
    */
   public function testHookDupeQueryMatch(): void {
     $this->hookClass->setHook('civicrm_dupeQuery', [$this, 'hook_civicrm_dupeQuery']);
-    \CRM_Core_DAO_AllCoreTables::registerEntityType('TestEntity', 'CRM_Dedupe_DAO_TestEntity', 'civicrm_dedupe_test_table');
+    $this->hookClass->setHook('civicrm_entityTypes', function (array &$entityTypes) {
+      $entityTypes['TestEntity'] = [
+        'name' => 'TestEntity',
+        'class' => 'CRM_Dedupe_DAO_TestEntity',
+        'table' => 'civicrm_dedupe_test_table',
+      ];
+    });
+    \CRM_Core_DAO_AllCoreTables::flush();
     $this->apiKernel = \Civi::service('civi_api_kernel');
     $this->adhocProvider = new \Civi\API\Provider\AdhocProvider(3, 'TestEntity');
     $this->apiKernel->registerApiProvider($this->adhocProvider);

--- a/tests/phpunit/Civi/API/Subscriber/DynamicFKAuthorizationTest.php
+++ b/tests/phpunit/Civi/API/Subscriber/DynamicFKAuthorizationTest.php
@@ -31,7 +31,25 @@ class DynamicFKAuthorizationTest extends \CiviUnitTestCase {
   protected function setUp(): void {
     parent::setUp();
 
-    \CRM_Core_DAO_AllCoreTables::registerEntityType('FakeFile', 'CRM_Fake_DAO_FakeFile', 'fake_file');
+    $this->hookClass->setHook('civicrm_entityTypes', function (array &$entityTypes) {
+      $entityTypes['FakeFile'] = [
+        'name' => 'FakeFile',
+        'class' => 'CRM_Fake_DAO_FakeFile',
+        'table' => 'fake_file',
+      ];
+      $entityTypes['Widget'] = [
+        'name' => 'Widget',
+        'class' => 'CRM_Fake_DAO_Widget',
+        'table' => 'fake_widget',
+      ];
+      $entityTypes['Forbidden'] = [
+        'name' => 'Forbidden',
+        'class' => 'CRM_Fake_DAO_Forbidden',
+        'table' => 'fake_forbidden',
+      ];
+    });
+    \CRM_Core_DAO_AllCoreTables::flush();
+
     $fileProvider = new StaticProvider(
       3,
       'FakeFile',
@@ -43,7 +61,6 @@ class DynamicFKAuthorizationTest extends \CiviUnitTestCase {
       ]
     );
 
-    \CRM_Core_DAO_AllCoreTables::registerEntityType('Widget', 'CRM_Fake_DAO_Widget', 'fake_widget');
     $widgetProvider = new StaticProvider(3, 'Widget',
       ['id', 'title'],
       [],
@@ -52,7 +69,6 @@ class DynamicFKAuthorizationTest extends \CiviUnitTestCase {
       ]
     );
 
-    \CRM_Core_DAO_AllCoreTables::registerEntityType('Forbidden', 'CRM_Fake_DAO_Forbidden', 'fake_forbidden');
     $forbiddenProvider = new StaticProvider(
       3,
       'Forbidden',

--- a/tests/phpunit/Civi/API/Subscriber/WhitelistSubscriberTest.php
+++ b/tests/phpunit/Civi/API/Subscriber/WhitelistSubscriberTest.php
@@ -351,15 +351,26 @@ class WhitelistSubscriberTest extends \CiviUnitTestCase {
   public function testEach($apiRequest, $rules, $expectSuccess) {
     $recs = $this->getFixtures();
 
-    // FIXME: It would be more realistic to use hook_civicrm_entityTypes() instead of calling this internal function.
-    \CRM_Core_DAO_AllCoreTables::registerEntityType('Widget', 'CRM_Fake_DAO_Widget', 'fake_widget');
+    $this->hookClass->setHook('civicrm_entityTypes', function (array &$entityTypes) {
+      $entityTypes['Widget'] = [
+        'name' => 'Widget',
+        'class' => 'CRM_Fake_DAO_Widget',
+        'table' => 'fake_widget',
+      ];
+      $entityTypes['Sprocket'] = [
+        'name' => 'Sprocket',
+        'class' => 'CRM_Fake_DAO_Sprocket',
+        'table' => 'fake_sprocket',
+      ];
+    });
+    \CRM_Core_DAO_AllCoreTables::flush();
+
     $widgetProvider = new \Civi\API\Provider\StaticProvider(3, 'Widget',
       ['id', 'widget_type', 'provider', 'title'],
       [],
       $recs['widget']
     );
 
-    \CRM_Core_DAO_AllCoreTables::registerEntityType('Sprocket', 'CRM_Fake_DAO_Sprocket', 'fake_sprocket');
     $sprocketProvider = new \Civi\API\Provider\StaticProvider(
       3,
       'Sprocket',


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a `fixme` in the unit tests to use public hook instead of internal function. This allows the internal function to be private which makes future refactoring possible.