### PR TITLE
Hooks on Cases

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -676,7 +676,7 @@ HERESQL;
     // Store the results in an array
     $cases = [];
     foreach ($result->fetchAll() as $case) {
-        $cases[$case['case_id']] = $case;
+      $cases[$case['case_id']] = $case;
     }
 
     // Allow extensions to modify the list of cases

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -678,7 +678,7 @@ HERESQL;
     foreach ($result->fetchAll() as $case) {
         $cases[$case['case_id']] = $case;
     }
-    
+
     // Allow extensions to modify the list of cases
     CRM_Utils_Hook::getCases($cases, $allCases, $params, $context);
 

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2607,6 +2607,40 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * This hook is called when cases are queried.
+   * 
+   * @param array $cases
+   * @param bool $allCases
+   * @param array $params
+   * @param string $context
+   * 
+   * @return mixed
+   */
+  public static function getCases(&$cases, $allCases, $params, $context) {
+    $null = NULL;
+    return self::singleton()->invoke(['query', 'type', 'userID', 'condition', 'limit', 'order'], $cases, $allCases, $params, $context, 
+      $null, $null,
+      'civicrm_getCases'
+    );
+  }
+
+  /**
+   * This hook is called when cases are queried.
+   * 
+   * @param int $totalCount
+   * @param string $type
+   * @param int $userID
+   * @param string $condition
+   */
+  public static function getCasesTotalCount(&$totalCount, $type, $userID, $condition) {
+    $null = NULL;
+    return self::singleton()->invoke(['totalCount', 'type', 'userID', 'condition'], $totalCount, $type, $userID, $condition, 
+      $null, $null,
+      'civicrm_getCasesTotalCount'
+    );
+  }
+
+  /**
    * This hook is called before a case merge (or a case reassign)
    *
    * @param int $mainContactId

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2608,17 +2608,17 @@ abstract class CRM_Utils_Hook {
 
   /**
    * This hook is called when cases are queried.
-   * 
+   *
    * @param array $cases
    * @param bool $allCases
    * @param array $params
    * @param string $context
-   * 
+   *
    * @return mixed
    */
   public static function getCases(&$cases, $allCases, $params, $context) {
     $null = NULL;
-    return self::singleton()->invoke(['query', 'type', 'userID', 'condition', 'limit', 'order'], $cases, $allCases, $params, $context, 
+    return self::singleton()->invoke(['query', 'type', 'userID', 'condition', 'limit', 'order'], $cases, $allCases, $params, $context,
       $null, $null,
       'civicrm_getCases'
     );
@@ -2626,7 +2626,7 @@ abstract class CRM_Utils_Hook {
 
   /**
    * This hook is called when cases are queried.
-   * 
+   *
    * @param int $totalCount
    * @param string $type
    * @param int $userID
@@ -2634,7 +2634,7 @@ abstract class CRM_Utils_Hook {
    */
   public static function getCasesTotalCount(&$totalCount, $type, $userID, $condition) {
     $null = NULL;
-    return self::singleton()->invoke(['totalCount', 'type', 'userID', 'condition'], $totalCount, $type, $userID, $condition, 
+    return self::singleton()->invoke(['totalCount', 'type', 'userID', 'condition'], $totalCount, $type, $userID, $condition,
       $null, $null,
       'civicrm_getCasesTotalCount'
     );


### PR DESCRIPTION
These hooks allow extensions to filter cases.

Typically, without usage of API4, extended behaviors such as hierarchical ACLs can't be effective. 
