### PR TITLE
dev/core#5014 don't show premiums unless premiums are active

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -928,6 +928,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       ->addSelect('product_id')
       ->addSelect('premiums_id.*')
       ->addWhere('product_id.is_active', '=', TRUE)
+      ->addWhere('premiums_id.premiums_active', '=', TRUE)
       ->addWhere('premiums_id.entity_id', '=', $this->getContributionPageID())
       ->addWhere('premiums_id.entity_table', '=', 'civicrm_contribution_page')
       ->addOrderBy('weight')


### PR DESCRIPTION
Overview
----------------------------------------
If a contribution page has premiums defined, they display on the page even if premiums are turned off.

To replicate, go to contribution page 1 on a demo site and uncheck **Premium Section enabled**. 

lab.c.o: https://lab.civicrm.org/dev/core/-/issues/5014

Before
----------------------------------------
Premiums are still there.

After
----------------------------------------
Premiums are gone.

Comments
----------------------------------------
This regressed in 5.69 when the old `buildPremiumsBlock()` was deprecated.
