### PR TITLE
[REF] DAO - Make `getEntityIcon()` function more useful

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2774,18 +2774,22 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
    *
    * @param string $entityName
    *   Always "Activity".
-   * @param int $entityId
+   * @param int|null $entityId
    *   Id of the activity.
    * @throws CRM_Core_Exception
    */
-  public static function getEntityIcon(string $entityName, int $entityId): ?string {
+  public static function getEntityIcon(string $entityName, int $entityId = NULL): ?string {
+    $default = parent::getEntityIcon($entityName);
+    if (!$entityId) {
+      return $default;
+    }
     $field = Civi\Api4\Activity::getFields(FALSE)
       ->addWhere('name', '=', 'activity_type_id')
       ->setLoadOptions(['id', 'label', 'icon'])
       ->execute()->single();
     $activityTypes = array_column($field['options'], NULL, 'id');
     $activityType = CRM_Core_DAO::getFieldValue(parent::class, $entityId, 'activity_type_id');
-    return $activityTypes[$activityType]['icon'] ?? self::$_icon;
+    return $activityTypes[$activityType]['icon'] ?? $default;
   }
 
 }

--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2778,7 +2778,7 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
    *   Id of the activity.
    * @throws CRM_Core_Exception
    */
-  public static function getEntityIcon(string $entityName, int $entityId) {
+  public static function getEntityIcon(string $entityName, int $entityId): ?string {
     $field = Civi\Api4\Activity::getFields(FALSE)
       ->addWhere('name', '=', 'activity_type_id')
       ->setLoadOptions(['id', 'label', 'icon'])

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3637,7 +3637,11 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
    *   Id of the contact.
    * @throws CRM_Core_Exception
    */
-  public static function getEntityIcon(string $entityName, int $entityId): ?string {
+  public static function getEntityIcon(string $entityName, int $entityId = NULL): ?string {
+    $default = parent::getEntityIcon($entityName);
+    if (!$entityId) {
+      return $default;
+    }
     $contactTypes = CRM_Contact_BAO_ContactType::getAllContactTypes();
     $subTypes = CRM_Utils_Array::explodePadded(CRM_Core_DAO::getFieldValue(parent::class, $entityId, 'contact_sub_type'));
     foreach ((array) $subTypes as $subType) {
@@ -3647,7 +3651,7 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
     }
     // If no sub-type icon, lookup contact type
     $contactType = CRM_Core_DAO::getFieldValue(parent::class, $entityId, 'contact_type');
-    return $contactTypes[$contactType]['icon'] ?? self::$_icon;
+    return $contactTypes[$contactType]['icon'] ?? $default;
   }
 
 }

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3637,7 +3637,7 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
    *   Id of the contact.
    * @throws CRM_Core_Exception
    */
-  public static function getEntityIcon(string $entityName, int $entityId) {
+  public static function getEntityIcon(string $entityName, int $entityId): ?string {
     $contactTypes = CRM_Contact_BAO_ContactType::getAllContactTypes();
     $subTypes = CRM_Utils_Array::explodePadded(CRM_Core_DAO::getFieldValue(parent::class, $entityId, 'contact_sub_type'));
     foreach ((array) $subTypes as $subType) {

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -3467,10 +3467,7 @@ SELECT contact_id
    *   Id of the entity.
    * @throws CRM_Core_Exception
    */
-  public static function getEntityIcon(string $entityName, int $entityId): ?string {
-    if (static::class === 'CRM_Core_DAO' || static::class !== CRM_Core_DAO_AllCoreTables::getBAOClassName(static::class)) {
-      throw new CRM_Core_Exception('CRM_Core_DAO::getEntityIcon must be called on a BAO class e.g. CRM_Contact_BAO_Contact::getEntityIcon("Contact", 123).');
-    }
+  public static function getEntityIcon(string $entityName, int $entityId = NULL): ?string {
     // By default, just return the icon representing this entity. If there's more complex lookup to do,
     // the BAO for this entity should override this method.
     return static::$_icon;

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -3458,7 +3458,7 @@ SELECT contact_id
   /**
    * Overridable function to get icon for a particular entity.
    *
-   * Example: `CRM_Contact_BAO_Contact::getIcon('Contact', 123)`
+   * Example: `CRM_Contact_BAO_Contact::getEntityIcon('Contact', 123)`
    *
    * @param string $entityName
    *   Short name of the entity. This may seem redundant because the entity name can usually be inferred
@@ -3467,9 +3467,9 @@ SELECT contact_id
    *   Id of the entity.
    * @throws CRM_Core_Exception
    */
-  public static function getEntityIcon(string $entityName, int $entityId) {
+  public static function getEntityIcon(string $entityName, int $entityId): ?string {
     if (static::class === 'CRM_Core_DAO' || static::class !== CRM_Core_DAO_AllCoreTables::getBAOClassName(static::class)) {
-      throw new CRM_Core_Exception('CRM_Core_DAO::getIcon must be called on a BAO class e.g. CRM_Contact_BAO_Contact::getIcon("Contact", 123).');
+      throw new CRM_Core_Exception('CRM_Core_DAO::getEntityIcon must be called on a BAO class e.g. CRM_Contact_BAO_Contact::getEntityIcon("Contact", 123).');
     }
     // By default, just return the icon representing this entity. If there's more complex lookup to do,
     // the BAO for this entity should override this method.

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -158,7 +158,7 @@ abstract class AbstractEntity {
     if ($dao) {
       $info['paths'] = $dao::getEntityPaths();
       $info['primary_key'] = $dao::$_primaryKey;
-      $info['icon'] = $dao::$_icon;
+      $info['icon'] = $dao::getEntityIcon($entityName);
       $info['label_field'] = $dao::$_labelField;
       $info['dao'] = $dao;
       $info['table_name'] = $dao::getTableName();


### PR DESCRIPTION
Overview
----------------------------------------
Makes getter function work all the time, not just when passed an id.

Before
----------------------------------------
No general getter function for `DAO_*::$_icon`, which requires direct access to internal class variable.
`BAO:getEntityIcon()` only works when passed an id.

After
----------------------------------------
`BAO:getEntityIcon()` works as a getter function both for a specific entity, and also for the entity in-general.