### PR TITLE
[NFC] Don't flush someone else's ob

### DIFF
--- a/tests/phpunit/CRM/Core/Smarty/plugins/HtxtTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/HtxtTest.php
@@ -60,7 +60,6 @@ class CRM_Core_Smarty_plugins_HtxtTest extends CiviUnitTestCase {
       $this->fail("That should have thrown an error. Are you working on a better parsing rule?");
     }
     catch (Throwable $t) {
-      ob_end_flush();
       $this->assertTrue(str_contains($t->getMessage(), 'Invalid {htxt} tag'));
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
It's risky to flush someone else's ob.
Interpret that however you want.

Before
----------------------------------------
I'm hoping https://github.com/civicrm/civicrm-core/pull/29425 will make this test show up as a fail. I've been seeing it in another environment.

After
----------------------------------------


Technical Details
----------------------------------------
I'm not sure if this line was added to solve some problem at the time, but the test doesn't start its own output buffer. Even if there is another one somewhere, it shouldn't be flushed here. It doesn't seem needed locally.

Comments
----------------------------------------

