### PR TITLE
SMS Trait - add support for Autocomplete subscriber, notice fix

### DIFF
--- a/CRM/Activity/Form/Task/SMS.php
+++ b/CRM/Activity/Form/Task/SMS.php
@@ -61,8 +61,6 @@ class CRM_Activity_Form_Task_SMS extends CRM_Activity_Form_Task {
    * Build the form object.
    */
   public function buildQuickForm() {
-    // Enable form element.
-    $this->assign('SMSTask', TRUE);
     CRM_Contact_Form_Task_SMSCommon::buildQuickForm($this);
   }
 

--- a/CRM/Activity/Form/Task/SMS.php
+++ b/CRM/Activity/Form/Task/SMS.php
@@ -61,7 +61,7 @@ class CRM_Activity_Form_Task_SMS extends CRM_Activity_Form_Task {
    * Build the form object.
    */
   public function buildQuickForm() {
-    CRM_Contact_Form_Task_SMSCommon::buildQuickForm($this);
+    $this->buildSmsForm();
   }
 
 }

--- a/CRM/Activity/Form/Task/SMS.php
+++ b/CRM/Activity/Form/Task/SMS.php
@@ -64,4 +64,17 @@ class CRM_Activity_Form_Task_SMS extends CRM_Activity_Form_Task {
     $this->buildSmsForm();
   }
 
+  /**
+   * Get the relevant activity name.
+   *
+   * This is likely to be further refactored/ clarified.
+   *
+   * @internal
+   *
+   * @return string
+   */
+  protected function getActivityName() {
+    return 'SMS Received';
+  }
+
 }

--- a/CRM/Contact/Form/Task/SMS.php
+++ b/CRM/Contact/Form/Task/SMS.php
@@ -63,7 +63,7 @@ class CRM_Contact_Form_Task_SMS extends CRM_Contact_Form_Task {
   public function buildQuickForm() {
     //enable form element
     $this->assign('suppressForm', FALSE);
-    CRM_Contact_Form_Task_SMSCommon::buildQuickForm($this);
+    $this->buildSmsForm();
   }
 
 }

--- a/CRM/Contact/Form/Task/SMS.php
+++ b/CRM/Contact/Form/Task/SMS.php
@@ -63,7 +63,6 @@ class CRM_Contact_Form_Task_SMS extends CRM_Contact_Form_Task {
   public function buildQuickForm() {
     //enable form element
     $this->assign('suppressForm', FALSE);
-    $this->assign('SMSTask', TRUE);
     CRM_Contact_Form_Task_SMSCommon::buildQuickForm($this);
   }
 

--- a/CRM/Contact/Form/Task/SMSCommon.php
+++ b/CRM/Contact/Form/Task/SMSCommon.php
@@ -17,6 +17,8 @@
 
 /**
  * This class provides the common functionality for sending sms to one or a group of contact ids.
+ *
+ * @deprecated since 5.71 will be removed around 5.77.
  */
 class CRM_Contact_Form_Task_SMSCommon {
   const RECIEVED_SMS_ACTIVITY_SUBJECT = "SMS Received";
@@ -71,6 +73,8 @@ class CRM_Contact_Form_Task_SMSCommon {
    * Build the form object.
    *
    * @param CRM_Core_Form $form
+   *
+   * @deprecated since 5.71 will be removed around 5.77.
    */
   public static function buildQuickForm(&$form) {
 
@@ -105,7 +109,7 @@ class CRM_Contact_Form_Task_SMSCommon {
 
       $form->_contactIds = [];
       foreach ($allToPhone as $value) {
-        list($contactId, $phone) = explode('::', $value);
+        [$contactId, $phone] = explode('::', $value);
         if ($contactId) {
           $form->_contactIds[] = $contactId;
           $form->_toContactPhone[] = $phone;
@@ -314,9 +318,11 @@ class CRM_Contact_Form_Task_SMSCommon {
    * Process the form after the input has been submitted and validated.
    *
    * @param CRM_Core_Form $form
+   *
+   * @deprecated since 5.71 will be removed around 5.77.
    */
   public static function postProcess(&$form) {
-
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative supported for non-core use');
     $thisValues = $form->controller->exportValues($form->getName());
 
     $fromSmsProviderId = $thisValues['sms_provider_id'];
@@ -367,7 +373,7 @@ class CRM_Contact_Form_Task_SMSCommon {
     $contactIds = array_keys($form->_contactDetails);
     $allContactIds = array_keys($form->_allContactDetails);
 
-    list($sent, $activityId, $countSuccess) = CRM_Activity_BAO_Activity::sendSMS($formattedContactDetails,
+    [$sent, $activityId, $countSuccess] = CRM_Activity_BAO_Activity::sendSMS($formattedContactDetails,
       $thisValues,
       $smsParams,
       $contactIds

--- a/CRM/Contact/Form/Task/SMSTrait.php
+++ b/CRM/Contact/Form/Task/SMSTrait.php
@@ -25,7 +25,7 @@ trait CRM_Contact_Form_Task_SMSTrait {
    * Process the form after the input has been submitted and validated.
    */
   public function postProcess() {
-    CRM_Contact_Form_Task_SMSCommon::postProcess($this);
+    $this->postProcessSms();
   }
 
   protected function bounceOnNoActiveProviders(): void {
@@ -33,6 +33,348 @@ trait CRM_Contact_Form_Task_SMSTrait {
     if (!$providersCount) {
       CRM_Core_Error::statusBounce(ts('There are no SMS providers configured, or no SMS providers are set active'));
     }
+  }
+
+  /**
+   * Build the SMS Form
+   *
+   * @internal - highly likely to change!
+   */
+  protected function buildSmsForm() {
+    $form = $this;
+    $toArray = [];
+
+    $providers = CRM_SMS_BAO_Provider::getProviders(NULL, NULL, TRUE, 'is_default desc');
+
+    $providerSelect = [];
+    foreach ($providers as $provider) {
+      $providerSelect[$provider['id']] = $provider['title'];
+    }
+    $suppressedSms = 0;
+    //here we are getting logged in user id as array but we need target contact id. CRM-5988
+    $cid = $form->get('cid');
+
+    if ($cid) {
+      $form->_contactIds = [$cid];
+    }
+
+    $to = $form->add('text', 'to', ts('To'), ['class' => 'huge'], TRUE);
+    $form->add('text', 'activity_subject', ts('Name The SMS'), ['class' => 'huge'], TRUE);
+
+    $toSetDefault = TRUE;
+    if (property_exists($form, '_context') && $form->_context == 'standalone') {
+      $toSetDefault = FALSE;
+    }
+
+    // when form is submitted recompute contactIds
+    $allToSMS = [];
+    if ($to->getValue()) {
+      $allToPhone = explode(',', $to->getValue());
+
+      $form->_contactIds = [];
+      foreach ($allToPhone as $value) {
+        list($contactId, $phone) = explode('::', $value);
+        if ($contactId) {
+          $form->_contactIds[] = $contactId;
+          $form->_toContactPhone[] = $phone;
+        }
+      }
+      $toSetDefault = TRUE;
+    }
+
+    //get the group of contacts as per selected by user in case of Find Activities
+    if (!empty($form->_activityHolderIds)) {
+      $extendTargetContacts = 0;
+      $invalidActivity = 0;
+      $validActivities = 0;
+      foreach ($form->_activityHolderIds as $key => $id) {
+        //valid activity check
+        if (CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity', $id, 'subject', 'id') != self::RECIEVED_SMS_ACTIVITY_SUBJECT) {
+          $invalidActivity++;
+          continue;
+        }
+
+        $activityContacts = CRM_Activity_BAO_ActivityContact::buildOptions('record_type_id', 'validate');
+        $targetID = CRM_Utils_Array::key('Activity Targets', $activityContacts);
+        //target contacts limit check
+        $ids = array_keys(CRM_Activity_BAO_ActivityContact::getNames($id, $targetID));
+
+        if (count($ids) > 1) {
+          $extendTargetContacts++;
+          continue;
+        }
+        $validActivities++;
+        $form->_contactIds = empty($form->_contactIds) ? $ids : array_unique(array_merge($form->_contactIds, $ids));
+      }
+
+      if (!$validActivities) {
+        $errorMess = "";
+        if ($extendTargetContacts) {
+          $errorMess = ts('One selected activity consists of more than one target contact.', [
+            'count' => $extendTargetContacts,
+            'plural' => '%count selected activities consist of more than one target contact.',
+          ]);
+        }
+        if ($invalidActivity) {
+          $errorMess = ($errorMess ? ' ' : '');
+          $errorMess .= ts('The selected activity is invalid.', [
+            'count' => $invalidActivity,
+            'plural' => '%count selected activities are invalid.',
+          ]);
+        }
+        CRM_Core_Error::statusBounce(ts("%1: SMS Reply will not be sent.", [1 => $errorMess]));
+      }
+    }
+
+    if (is_array($form->_contactIds) && !empty($form->_contactIds) && $toSetDefault) {
+      $form->_contactDetails = civicrm_api3('Contact', 'get', [
+        'id' => ['IN' => $form->_contactIds],
+        'return' => ['sort_name', 'phone', 'do_not_sms', 'is_deceased', 'display_name'],
+        'options' => ['limit' => 0],
+      ])['values'];
+
+      // make a copy of all contact details
+      $form->_allContactDetails = $form->_contactDetails;
+
+      foreach ($form->_contactIds as $key => $contactId) {
+        $mobilePhone = NULL;
+        $contactDetails = $form->_contactDetails[$contactId];
+
+        //to check if the phone type is "Mobile"
+        $phoneTypes = CRM_Core_OptionGroup::values('phone_type', TRUE, FALSE, FALSE, NULL, 'name');
+
+        if (CRM_Utils_System::getClassName($form) == 'CRM_Activity_Form_Task_SMS') {
+          //to check for "if the contact id belongs to a specified activity type"
+          // @todo use the api instead - function is deprecated.
+          $actDetails = CRM_Activity_BAO_Activity::getContactActivity($contactId);
+          if (self::RECIEVED_SMS_ACTIVITY_SUBJECT !=
+            CRM_Utils_Array::retrieveValueRecursive($actDetails, 'subject')
+          ) {
+            $suppressedSms++;
+            unset($form->_contactDetails[$contactId]);
+            continue;
+          }
+        }
+
+        // No phone, No SMS or Deceased: then we suppress it.
+        if (empty($contactDetails['phone']) || $contactDetails['do_not_sms'] || !empty($contactDetails['is_deceased'])) {
+          $suppressedSms++;
+          unset($form->_contactDetails[$contactId]);
+          continue;
+        }
+        elseif ($contactDetails['phone_type_id'] != ($phoneTypes['Mobile'] ?? NULL)) {
+          //if phone is not primary check if non-primary phone is "Mobile"
+          $filter = ['do_not_sms' => 0];
+          $contactPhones = CRM_Core_BAO_Phone::allPhones($contactId, FALSE, 'Mobile', $filter);
+          if (count($contactPhones) > 0) {
+            $mobilePhone = CRM_Utils_Array::retrieveValueRecursive($contactPhones, 'phone');
+            $form->_contactDetails[$contactId]['phone_id'] = CRM_Utils_Array::retrieveValueRecursive($contactPhones, 'id');
+            $form->_contactDetails[$contactId]['phone'] = $mobilePhone;
+            $form->_contactDetails[$contactId]['phone_type_id'] = $phoneTypes['Mobile'] ?? NULL;
+          }
+          else {
+            $suppressedSms++;
+            unset($form->_contactDetails[$contactId]);
+            continue;
+          }
+        }
+
+        if (isset($mobilePhone)) {
+          $phone = $mobilePhone;
+        }
+        elseif (empty($form->_toContactPhone)) {
+          $phone = $contactDetails['phone'];
+        }
+        else {
+          $phone = $form->_toContactPhone[$key] ?? NULL;
+        }
+
+        if ($phone) {
+          $toArray[] = [
+            'text' => '"' . $contactDetails['sort_name'] . '" (' . $phone . ')',
+            'id' => "$contactId::{$phone}",
+          ];
+        }
+      }
+
+      if (empty($toArray)) {
+        CRM_Core_Error::statusBounce(ts('Selected contact(s) do not have a valid Phone, or communication preferences specify DO NOT SMS, or they are deceased'));
+      }
+    }
+
+    //activity related variables
+    $form->assign('invalidActivity', $invalidActivity ?? NULL);
+    $form->assign('extendTargetContacts', $extendTargetContacts ?? NULL);
+
+    $form->assign('toContact', json_encode($toArray));
+    $form->assign('suppressedSms', $suppressedSms);
+    $form->assign('totalSelectedContacts', count($form->_contactIds));
+
+    $form->add('select', 'sms_provider_id', ts('From'), $providerSelect, TRUE);
+
+    CRM_Mailing_BAO_Mailing::commonCompose($form);
+
+    if ($form->_single) {
+      // also fix the user context stack
+      if ($form->_context) {
+        $url = CRM_Utils_System::url('civicrm/dashboard', 'reset=1');
+      }
+      else {
+        $url = CRM_Utils_System::url('civicrm/contact/view',
+          "&show=1&action=browse&cid={$form->_contactIds[0]}&selectedChild=activity"
+        );
+      }
+
+      $session = CRM_Core_Session::singleton();
+      $session->replaceUserContext($url);
+      $form->addDefaultButtons(ts('Send SMS'), 'upload', 'cancel');
+    }
+    else {
+      $form->addDefaultButtons(ts('Send SMS'), 'upload');
+    }
+
+    $form->addFormRule([__CLASS__, 'formRuleSms'], $form);
+  }
+
+  /**
+   * Process the sms form after the input has been submitted and validated.
+   *
+   * @internal likely to change.
+   */
+  protected function postProcessSms() {
+    $form = $this;
+    $thisValues = $form->controller->exportValues($form->getName());
+
+    $fromSmsProviderId = $thisValues['sms_provider_id'];
+
+    // process message template
+    if (!empty($thisValues['SMSsaveTemplate']) || !empty($thisValues['SMSupdateTemplate'])) {
+      $messageTemplate = [
+        'msg_text' => $thisValues['sms_text_message'],
+        'is_active' => TRUE,
+        'is_sms' => TRUE,
+      ];
+
+      if (!empty($thisValues['SMSsaveTemplate'])) {
+        $messageTemplate['msg_title'] = $thisValues['SMSsaveTemplateName'];
+        CRM_Core_BAO_MessageTemplate::add($messageTemplate);
+      }
+
+      if (!empty($thisValues['SMStemplate']) && !empty($thisValues['SMSupdateTemplate'])) {
+        $messageTemplate['id'] = $thisValues['SMStemplate'];
+        unset($messageTemplate['msg_title']);
+        CRM_Core_BAO_MessageTemplate::add($messageTemplate);
+      }
+    }
+
+    // format contact details array to handle multiple sms from same contact
+    $formattedContactDetails = [];
+    $tempPhones = [];
+
+    foreach ($form->_contactIds as $key => $contactId) {
+      $phone = $form->_toContactPhone[$key];
+
+      if ($phone) {
+        $phoneKey = "{$contactId}::{$phone}";
+        if (!in_array($phoneKey, $tempPhones)) {
+          $tempPhones[] = $phoneKey;
+          if (!empty($form->_contactDetails[$contactId])) {
+            $formattedContactDetails[] = $form->_contactDetails[$contactId];
+          }
+        }
+      }
+    }
+
+    // $smsParams carries all the arguments provided on form (or via hooks), to the provider->send() method
+    // this gives flexibity to the users / implementors to add their own args via hooks specific to their sms providers
+    $smsParams = $thisValues;
+    unset($smsParams['sms_text_message']);
+    $smsParams['provider_id'] = $fromSmsProviderId;
+    $contactIds = array_keys($form->_contactDetails);
+    $allContactIds = array_keys($form->_allContactDetails);
+
+    [$sent, $activityId, $countSuccess] = CRM_Activity_BAO_Activity::sendSMS($formattedContactDetails,
+      $thisValues,
+      $smsParams,
+      $contactIds
+    );
+
+    if ($countSuccess > 0) {
+      CRM_Core_Session::setStatus(ts('One message was sent successfully.', [
+        'plural' => '%count messages were sent successfully.',
+        'count' => $countSuccess,
+      ]), ts('Message Sent', ['plural' => 'Messages Sent', 'count' => $countSuccess]), 'success');
+    }
+
+    if (is_array($sent)) {
+      // At least one PEAR_Error object was generated.
+      // Display the error messages to the user.
+      $status = '<ul>';
+      foreach ($sent as $errMsg) {
+        $status .= '<li>' . $errMsg . '</li>';
+      }
+      $status .= '</ul>';
+      CRM_Core_Session::setStatus($status, ts('One Message Not Sent', [
+        'count' => count($sent),
+        'plural' => '%count Messages Not Sent',
+      ]), 'info');
+    }
+    else {
+      //Display the name and number of contacts for those sms is not sent.
+      $smsNotSent = array_diff_assoc($allContactIds, $contactIds);
+
+      if (!empty($smsNotSent)) {
+        $not_sent = [];
+        foreach ($smsNotSent as $index => $contactId) {
+          $displayName = $form->_allContactDetails[$contactId]['display_name'];
+          $phone = $form->_allContactDetails[$contactId]['phone'];
+          $contactViewUrl = CRM_Utils_System::url('civicrm/contact/view', "reset=1&cid=$contactId");
+          $not_sent[] = "<a href='$contactViewUrl' title='$phone'>$displayName</a>";
+        }
+        $status = '(' . ts('because no phone number on file or communication preferences specify DO NOT SMS or Contact is deceased');
+        if (CRM_Utils_System::getClassName($form) == 'CRM_Activity_Form_Task_SMS') {
+          $status .= ' ' . ts("or the contact is not part of the activity '%1'", [1 => self::RECIEVED_SMS_ACTIVITY_SUBJECT]);
+        }
+        $status .= ')<ul><li>' . implode('</li><li>', $not_sent) . '</li></ul>';
+        CRM_Core_Session::setStatus($status, ts('One Message Not Sent', [
+          'count' => count($smsNotSent),
+          'plural' => '%count Messages Not Sent',
+        ]), 'info');
+      }
+    }
+  }
+
+  /**
+   * Form rule.
+   *
+   * @param array $fields
+   *   The input form values.
+   *
+   * @return bool|array
+   *   true if no errors, else array of errors
+   */
+  public static function formRuleSms($fields) {
+    $errors = [];
+
+    if (empty($fields['sms_text_message'])) {
+      $errors['sms_text_message'] = ts('Please provide Text message.');
+    }
+    else {
+      if (!empty($fields['sms_text_message'])) {
+        $messageCheck = $fields['sms_text_message'] ?? NULL;
+        $messageCheck = str_replace("\r\n", "\n", $messageCheck);
+        if ($messageCheck && (strlen($messageCheck) > CRM_SMS_Provider::MAX_SMS_CHAR)) {
+          $errors['sms_text_message'] = ts("You can configure the SMS message body up to %1 characters", [1 => CRM_SMS_Provider::MAX_SMS_CHAR]);
+        }
+      }
+    }
+
+    //Added for CRM-1393
+    if (!empty($fields['SMSsaveTemplate']) && empty($fields['SMSsaveTemplateName'])) {
+      $errors['SMSsaveTemplateName'] = ts("Enter name to save message template");
+    }
+
+    return empty($errors) ? TRUE : $errors;
   }
 
   /**

--- a/CRM/Contact/Form/Task/SMSTrait.php
+++ b/CRM/Contact/Form/Task/SMSTrait.php
@@ -89,7 +89,7 @@ trait CRM_Contact_Form_Task_SMSTrait {
       $validActivities = 0;
       foreach ($form->_activityHolderIds as $key => $id) {
         //valid activity check
-        if (CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity', $id, 'subject', 'id') != self::RECIEVED_SMS_ACTIVITY_SUBJECT) {
+        if (CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity', $id, 'subject', 'id') !== $this->getActivityName()) {
           $invalidActivity++;
           continue;
         }
@@ -147,7 +147,7 @@ trait CRM_Contact_Form_Task_SMSTrait {
           //to check for "if the contact id belongs to a specified activity type"
           // @todo use the api instead - function is deprecated.
           $actDetails = CRM_Activity_BAO_Activity::getContactActivity($contactId);
-          if (self::RECIEVED_SMS_ACTIVITY_SUBJECT !=
+          if ($this->getActivityName() !==
             CRM_Utils_Array::retrieveValueRecursive($actDetails, 'subject')
           ) {
             $suppressedSms++;
@@ -333,7 +333,7 @@ trait CRM_Contact_Form_Task_SMSTrait {
         }
         $status = '(' . ts('because no phone number on file or communication preferences specify DO NOT SMS or Contact is deceased');
         if (CRM_Utils_System::getClassName($form) == 'CRM_Activity_Form_Task_SMS') {
-          $status .= ' ' . ts("or the contact is not part of the activity '%1'", [1 => self::RECIEVED_SMS_ACTIVITY_SUBJECT]);
+          $status .= ' ' . ts("or the contact is not part of the activity '%1'", [1 => $this->getActivityName()]);
         }
         $status .= ')<ul><li>' . implode('</li><li>', $not_sent) . '</li></ul>';
         CRM_Core_Session::setStatus($status, ts('One Message Not Sent', [

--- a/CRM/Core/BAO/Phone.php
+++ b/CRM/Core/BAO/Phone.php
@@ -246,7 +246,8 @@ ORDER BY ph.is_primary DESC, phone_id ASC ";
    * @param \Civi\Core\Event\GenericHookEvent $e
    */
   public static function on_civi_search_autocompleteDefault(\Civi\Core\Event\GenericHookEvent $e) {
-    if (!str_contains($e->formName, '_Form_Task_SMS') || !is_array($e->savedSearch) || $e->savedSearch['api_entity'] !== 'Phone') {
+    $formName = $e->formName ?? '';
+    if (!str_contains($formName, '_Form_Task_SMS') || !is_array($e->savedSearch) || $e->savedSearch['api_entity'] !== 'Phone') {
       return;
     }
     $e->savedSearch['api_params'] = [

--- a/CRM/Core/BAO/Phone.php
+++ b/CRM/Core/BAO/Phone.php
@@ -240,4 +240,36 @@ ORDER BY ph.is_primary DESC, phone_id ASC ";
     return (bool) self::deleteRecord(['id' => $id]);
   }
 
+  /**
+   * Customize search criteria for SMS autocompletes
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   */
+  public static function on_civi_search_autocompleteDefault(\Civi\Core\Event\GenericHookEvent $e) {
+    if (!str_contains($e->formName, '_Form_Task_SMS') || !is_array($e->savedSearch) || $e->savedSearch['api_entity'] !== 'Phone') {
+      return;
+    }
+    $e->savedSearch['api_params'] = [
+      'version' => 4,
+      'select' => [
+        'id',
+        'phone',
+        'phone_numeric',
+        'phone_type_id:label',
+        'location_type_id:label',
+        'contact_id.sort_name',
+      ],
+      'orderBy' => [],
+      'where' => [
+        ['phone_type_id:name', '=', 'Mobile'],
+        ['contact_id.is_deleted', '=', FALSE],
+        ['contact_id.is_deceased', '=', FALSE],
+        ['contact_id.do_not_sms', '=', FALSE],
+      ],
+      'groupBy' => [],
+      'join' => [],
+      'having' => [],
+    ];
+  }
+
 }

--- a/Civi/Api4/Service/Autocomplete/PhoneAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/PhoneAutocompleteProvider.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Autocomplete;
+
+use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\HookInterface;
+
+/**
+ * @service
+ * @internal
+ */
+class PhoneAutocompleteProvider extends \Civi\Core\Service\AutoService implements HookInterface {
+
+  /**
+   * Provide default SearchDisplay for Phone autocompletes
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   */
+  public static function on_civi_search_defaultDisplay(GenericHookEvent $e) {
+    if ($e->display['settings'] || $e->display['type'] !== 'autocomplete' || $e->savedSearch['api_entity'] !== 'Phone') {
+      return;
+    }
+    $e->display['settings'] = [
+      'sort' => [
+        ['contact_id.sort_name', 'ASC'],
+        ['phone_numeric', 'ASC'],
+      ],
+      'columns' => [
+        [
+          'type' => 'field',
+          'key' => 'contact_id.sort_name',
+          'rewrite' => '[contact_id.sort_name]: [phone]',
+          'empty_value' => '[phone]',
+        ],
+        [
+          'type' => 'field',
+          'key' => 'location_type_id:label',
+          'rewrite' => '[location_type_id:label] ([phone_type_id:label])',
+        ],
+      ],
+    ];
+  }
+
+}

--- a/templates/CRM/Contact/Form/Task/SMS.tpl
+++ b/templates/CRM/Contact/Form/Task/SMS.tpl
@@ -40,7 +40,7 @@
    </tr>
 
 
-{if $SMSTask}
+{if array_key_exists('SMStemplate', $form)}
     <tr class="crm-contactPhone-form-block-template">
         <td class="label">{$form.SMStemplate.label}</td>
         <td>{$form.SMStemplate.html}</td>


### PR DESCRIPTION
Overview
----------------------------------------
SMS Trait - add support for Autocomplete subscriber, notice fix

This just pulls out the Smarty notice fix, the function moves & the registration for the phone autocomplete widget from https://github.com/civicrm/civicrm-core/pull/29413 because there is still a bit to work through in there & these fixes can be added by themselves

Before
----------------------------------------
@colemanw's autocomplete support not in core, notice on SMSTemplate 
![image](https://github.com/civicrm/civicrm-core/assets/336308/30a1c39f-b986-401d-8a06-0bbe4c39a686)

Functions not in the trait

After
---------------------------------------
Above chunks done

Technical Details
----------------------------------------

@colemanw I think this will simplify working through the remaining parts

Comments
----------------------------------------
