### PR TITLE
SMS form test - fix to test the function actually being used

### DIFF
--- a/CRM/Contact/Form/Task/SMSCommon.php
+++ b/CRM/Contact/Form/Task/SMSCommon.php
@@ -77,6 +77,7 @@ class CRM_Contact_Form_Task_SMSCommon {
    * @deprecated since 5.71 will be removed around 5.77.
    */
   public static function buildQuickForm(&$form) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative supported for non-core use');
 
     $toArray = [];
 
@@ -290,7 +291,7 @@ class CRM_Contact_Form_Task_SMSCommon {
    */
   public static function formRule($fields, $dontCare, $self) {
     $errors = [];
-
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative supported for non-core use');
     $template = CRM_Core_Smarty::singleton();
 
     if (empty($fields['sms_text_message'])) {

--- a/CRM/Contact/Form/Task/SMSTrait.php
+++ b/CRM/Contact/Form/Task/SMSTrait.php
@@ -74,7 +74,7 @@ trait CRM_Contact_Form_Task_SMSTrait {
 
     // when form is submitted recompute contactIds
     $allToSMS = [];
-    if ($to->getValue()) {
+    if ($this->getSubmittedValue('to')) {
       $allToPhone = explode(',', $to->getValue());
 
       $form->_contactIds = [];
@@ -235,9 +235,17 @@ trait CRM_Contact_Form_Task_SMSTrait {
     // format contact details array to handle multiple sms from same contact
     $formattedContactDetails = [];
     $tempPhones = [];
-
-    foreach ($form->_contactIds as $key => $contactId) {
-      $phone = $form->_toContactPhone[$key];
+    $phonesToSendTo = explode(',', $this->getSubmittedValue('to'));
+    $contactIds = $phones = [];
+    foreach ($phonesToSendTo as $phone) {
+      list($contactId, $phone) = explode('::', $phone);
+      if ($contactId) {
+        $contactIds[] = $contactId;
+        $phones[] = $phone;
+      }
+    }
+    foreach ($contactIds as $key => $contactId) {
+      $phone = $phones[$key];
 
       if ($phone) {
         $phoneKey = "{$contactId}::{$phone}";

--- a/CRM/Contact/Form/Task/SMSTrait.php
+++ b/CRM/Contact/Form/Task/SMSTrait.php
@@ -28,6 +28,12 @@ trait CRM_Contact_Form_Task_SMSTrait {
     $this->postProcessSms();
   }
 
+  /**
+   */
+  protected function filterContactIDs(): void {
+    // Activity sub class does this.
+  }
+
   protected function bounceOnNoActiveProviders(): void {
     $providersCount = CRM_SMS_BAO_Provider::activeProviderCount();
     if (!$providersCount) {
@@ -83,48 +89,7 @@ trait CRM_Contact_Form_Task_SMSTrait {
     }
 
     //get the group of contacts as per selected by user in case of Find Activities
-    if (!empty($form->_activityHolderIds)) {
-      $extendTargetContacts = 0;
-      $invalidActivity = 0;
-      $validActivities = 0;
-      foreach ($form->_activityHolderIds as $key => $id) {
-        //valid activity check
-        if (CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity', $id, 'subject', 'id') !== $this->getActivityName()) {
-          $invalidActivity++;
-          continue;
-        }
-
-        $activityContacts = CRM_Activity_BAO_ActivityContact::buildOptions('record_type_id', 'validate');
-        $targetID = CRM_Utils_Array::key('Activity Targets', $activityContacts);
-        //target contacts limit check
-        $ids = array_keys(CRM_Activity_BAO_ActivityContact::getNames($id, $targetID));
-
-        if (count($ids) > 1) {
-          $extendTargetContacts++;
-          continue;
-        }
-        $validActivities++;
-        $form->_contactIds = empty($form->_contactIds) ? $ids : array_unique(array_merge($form->_contactIds, $ids));
-      }
-
-      if (!$validActivities) {
-        $errorMess = "";
-        if ($extendTargetContacts) {
-          $errorMess = ts('One selected activity consists of more than one target contact.', [
-            'count' => $extendTargetContacts,
-            'plural' => '%count selected activities consist of more than one target contact.',
-          ]);
-        }
-        if ($invalidActivity) {
-          $errorMess = ($errorMess ? ' ' : '');
-          $errorMess .= ts('The selected activity is invalid.', [
-            'count' => $invalidActivity,
-            'plural' => '%count selected activities are invalid.',
-          ]);
-        }
-        CRM_Core_Error::statusBounce(ts("%1: SMS Reply will not be sent.", [1 => $errorMess]));
-      }
-    }
+    $this->filterContactIDs();
 
     if (is_array($form->_contactIds) && !empty($form->_contactIds) && $toSetDefault) {
       $form->_contactDetails = civicrm_api3('Contact', 'get', [
@@ -203,8 +168,8 @@ trait CRM_Contact_Form_Task_SMSTrait {
     }
 
     //activity related variables
-    $form->assign('invalidActivity', $invalidActivity ?? NULL);
-    $form->assign('extendTargetContacts', $extendTargetContacts ?? NULL);
+    $form->addExpectedSmartyVariable('invalidActivity');
+    $form->addExpectedSmartyVariable('extendTargetContacts');
 
     $form->assign('toContact', json_encode($toArray));
     $form->assign('suppressedSms', $suppressedSms);

--- a/Civi/Test/FormWrapper.php
+++ b/Civi/Test/FormWrapper.php
@@ -79,6 +79,15 @@ class FormWrapper {
     return $this->templateVariables;
   }
 
+  /**
+   * Get a variable assigned to the template.
+   *
+   * @return mixed
+   */
+  public function getTemplateVariable($string) {
+    return $this->templateVariables[$string];
+  }
+
   private $redirects;
 
   private $mailSpoolID;
@@ -154,9 +163,11 @@ class FormWrapper {
    * @return $this
    */
   public function addSubsequentForm(string $formName, array $formValues = []): FormWrapper {
-    /* @var \CRM_Core_Form */
+    /* @var \CRM_Core_Form $form */
     $form = new $formName();
     $form->controller = $this->form->controller;
+    $form->_submitValues = $formValues;
+    $form->controller->addPage($form);
     $_SESSION['_' . $this->form->controller->_name . '_container']['values'][$form->getName()] = $formValues;
     $this->subsequentForms[$form->getName()] = $form;
     return $this;
@@ -339,6 +350,11 @@ class FormWrapper {
         $_SESSION['_' . $this->form->controller->_name . '_container']['values']['MapField'] = $formValues;
         $_SESSION['_' . $this->form->controller->_name . '_container']['values']['Preview'] = $formValues;
         return;
+
+      case $class === 'CRM_Contact_Form_Search_Basic':
+        $this->form->controller = new \CRM_Contact_Controller_Search('Basic', TRUE, \CRM_Core_Action::BASIC);
+        $this->form->setAction(\CRM_Core_Action::BASIC);
+        break;
 
       case strpos($class, 'Search') !== FALSE:
         $this->form->controller = new \CRM_Contact_Controller_Search();

--- a/tests/phpunit/CRM/Contact/Form/Task/SMSCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/SMSCommonTest.php
@@ -9,11 +9,15 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Test\FormTrait;
+
 /**
  * Test class for CRM_Contact_Form_Task_SMSCommon.
  * @group headless
  */
 class CRM_Contact_Form_Task_SMSCommonTest extends CiviUnitTestCase {
+
+  use FormTrait;
 
   /**
    * Set up SMS recipients.
@@ -97,12 +101,29 @@ class CRM_Contact_Form_Task_SMSCommonTest extends CiviUnitTestCase {
    * Test to ensure SMS Activity QuickForm displays the right phone numbers.
    */
   public function testQuickFormMobileNumbersDisplay(): void {
-    /** @var CRM_Activity_Form_Task_SMS $form */
-    $form = $this->getFormObject('CRM_Contact_Form_Task_SMS');
-    $form->_contactIds = array_values($this->ids['Contact']);
-    $form->_single = FALSE;
-    CRM_Contact_Form_Task_SMSCommon::buildQuickForm($form);
-    $contacts = json_decode($form->getTemplateVars('toContact'));
+    $this->createLoggedInUser();
+    $this->createTestEntity('OptionValue', ['option_group_id:name' => 'sms_provider_name', 'name' => 'dummy sms', 'label' => 'Dummy']);
+    CRM_Core_DAO::executeQuery('INSERT INTO civicrm_sms_provider (name,title, api_type, api_params) VALUES ("SMS", "SMS", 1, "1=2")');
+    $form = $this->getTestForm('CRM_Contact_Form_Search_Basic', [
+      'radio_ts' => 'ts_all',
+      'to' => implode(',', [
+        $this->ids['Contact']['first'] . '::' . 1111111111,
+        $this->ids['Contact']['second'] . '::' . 2222222222,
+        $this->ids['Contact']['third'] . '::' . 3333333333,
+      ]),
+    ], ['action' => 1])
+      ->addSubsequentForm('CRM_Contact_Form_Task_SMS', [
+        'sms_provider_id' => 1,
+        'to' => implode(',', [
+          $this->ids['Contact']['first'] . '::' . 1111111111,
+          $this->ids['Contact']['second'] . '::' . 2222222222,
+          $this->ids['Contact']['third'] . '::' . 3333333333,
+        ]),
+        'activity_subject' => 'Your SMS Reminder',
+        'sms_text_message' => 'Do not forget',
+      ]);
+    $form->processForm();
+    $contacts = json_decode($form->getTemplateVariable('toContact'));
     $smsRecipientsActual = [];
 
     $phoneNumbers = [


### PR DESCRIPTION
Overview
----------------------------------------
SMS form test - fix to test the function actually being used


Before
----------------------------------------
The forms were moved to call a new `Trait` & `SMSCommon` was deprecated - but the test was still calling it

After
----------------------------------------
Test fixed to call the full form flow

Technical Details
----------------------------------------


Incorporates https://github.com/civicrm/civicrm-core/pull/29431

Comments
----------------------------------------