### PR TITLE
Swap assign_by_ref to assign in search templates

### DIFF
--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -430,7 +430,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
 
         // set the group title
         $groupValues = ['id' => $this->_groupID, 'title' => $this->_group[$this->_groupID]];
-        $this->assign_by_ref('group', $groupValues);
+        $this->assign('group', $groupValues);
 
         // also set ssID if this is a saved search
         $ssID = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Group', $this->_groupID, 'saved_search_id');
@@ -471,7 +471,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
       $this->setTitle(ts('Add to Group: %1', [1 => $this->_group[$this->_amtgID]]));
       // also set the group title and freeze the action task with Add Members to Group
       $groupValues = ['id' => $this->_amtgID, 'title' => $this->_group[$this->_amtgID]];
-      $this->assign_by_ref('group', $groupValues);
+      $this->assign('group', $groupValues);
       $this->add('xbutton', $this->_actionButtonName, ts('Add Contacts to %1', [1 => $this->_group[$this->_amtgID]]),
         [
           'type' => 'submit',
@@ -495,7 +495,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
       $selectedContactIds = array_keys($selectedContactIdsArr[$qfKeyParam]);
     }
 
-    $this->assign_by_ref('selectedContactIds', $selectedContactIds);
+    $this->assign('selectedContactIds', $selectedContactIds);
 
     $rows = $this->get('rows');
 

--- a/CRM/Core/Selector/Controller.php
+++ b/CRM/Core/Selector/Controller.php
@@ -319,8 +319,8 @@ class CRM_Core_Selector_Controller {
       }
       else {
         // assign to template and display them.
-        self::$_template->assign_by_ref('rows', $rows);
-        self::$_template->assign_by_ref('columnHeaders', $columnHeaders);
+        self::$_template->assign('rows', $rows);
+        self::$_template->assign('columnHeaders', $columnHeaders);
       }
     }
     else {
@@ -359,11 +359,11 @@ class CRM_Core_Selector_Controller {
         $this->_store->set("{$this->_prefix}summary", $summary);
       }
       else {
-        self::$_template->assign_by_ref("{$this->_prefix}pager", $this->_pager);
-        self::$_template->assign_by_ref("{$this->_prefix}sort", $this->_sort);
+        self::$_template->assign("{$this->_prefix}pager", $this->_pager);
+        self::$_template->assign("{$this->_prefix}sort", $this->_sort);
 
-        self::$_template->assign_by_ref("{$this->_prefix}columnHeaders", $finalColumnHeaders);
-        self::$_template->assign_by_ref("{$this->_prefix}rows", $rows);
+        self::$_template->assign("{$this->_prefix}columnHeaders", $finalColumnHeaders);
+        self::$_template->assign("{$this->_prefix}rows", $rows);
         self::$_template->assign("{$this->_prefix}rowsEmpty", !$rows);
         self::$_template->assign("{$this->_prefix}qill", $qill);
         self::$_template->assign("{$this->_prefix}summary", $summary);
@@ -450,7 +450,7 @@ class CRM_Core_Selector_Controller {
    * @return void
    */
   public function moveFromSessionToTemplate() {
-    self::$_template->assign_by_ref("{$this->_prefix}pager", $this->_pager);
+    self::$_template->assign("{$this->_prefix}pager", $this->_pager);
 
     $rows = $this->_store->get("{$this->_prefix}rows");
 
@@ -464,7 +464,7 @@ class CRM_Core_Selector_Controller {
       );
     }
 
-    self::$_template->assign_by_ref("{$this->_prefix}sort", $this->_sort);
+    self::$_template->assign("{$this->_prefix}sort", $this->_sort);
     $columnHeaders = (array) $this->_store->get("{$this->_prefix}columnHeaders");
     foreach ($columnHeaders as $index => $columnHeader) {
       // Fill out the keys to avoid e-notices.


### PR DESCRIPTION
Overview
----------------------------------------
Swap assign_by_ref to assign in search templates

Before
----------------------------------------
We have a history of using `assign_by_ref`for reasons that seem to relate to perceived performance in php4. The function is bad & removed in Smarty5

After
---------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
