### PR TITLE
Split code from quasi-shared code in order to be able to clean it up

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1161,6 +1161,12 @@ WHERE entity_id =%1 AND entity_table = %2";
    * @param array $contactIds
    * @param int $sourceContactId This is the source contact Id
    *
+   * @deprecated since 5.71.
+   *
+   * This function has no core usage. There is some non-core usage. At some point
+   * we should add a suitable api & noisily deprecate this / set an tentative
+   * removal date.
+   *
    * @return array(bool $sent, int $activityId, int $success)
    * @throws CRM_Core_Exception
    */


### PR DESCRIPTION
Overview 
========================
Split code from quasi-shared code in order to be able to clean it up

Before
=============================
The core SMS forms call an underlying function which has a confusing signature & is not really suitable to the form's needs, causing the form to be more complex than it need to be

After
=================================
The form has it's own copy, allowing the form to be cleaned up - ie it will be able to only generate & pass the needed arrays & we can remove all the pass-by-ref that is making it tough

Soft deprecation added to the underlying function

Technical details
========================================
    
That previously-shared function does not have other core uses but it is  is being used externally as a pseudo-api. We should have a real api. Adding that is out of scope but I kept the deprecation pretty soft to reflect that.

