### PR TITLE
dev/user-interface#60 - CaseType - Switch collapsible markup to summary/details

### DIFF
--- a/ext/civi_case/ang/crmCaseType/caseTypeDetails.html
+++ b/ext/civi_case/ang/crmCaseType/caseTypeDetails.html
@@ -41,8 +41,8 @@ The original form used table layout; don't know if we have an alternative, CSS-b
     <div crm-ui-field="{title: ts('Enabled?')}">
       <input name="is_active" type="checkbox" ng-model="caseType.is_active" ng-true-value="'1'" ng-false-value="'0'"/>
     </div>
-    <fieldset class="crm-collapsible">
-      <legend class="collapsible-title">{{:: ts('Activity assignment settings') }}</legend>
+    <details class="crm-accordion-light" open>
+      <summary>{{:: ts('Activity assignment settings') }}</summary>
       <div>
         <div crm-ui-field="{name: 'caseTypeDetailForm.activityAsgmtGrps', title: ts('Restrict to Groups'), help: hs('activityAsgmtGrps')}">
           <input
@@ -62,6 +62,6 @@ The original form used table layout; don't know if we have an alternative, CSS-b
           />
         </div>
       </div>
-    </fieldset>
+    </details>
   </div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
This removes a `crm-collapsible` class which is deprecated & replaces it with summary/details.

Before
----------------------------------------
Collapsible fieldset, open by default.

![image](https://github.com/civicrm/civicrm-core/assets/2874912/afe5e621-f477-4eb8-bef0-77175941c361)

After
----------------------------------------
Summary/details, open by default.

![image](https://github.com/civicrm/civicrm-core/assets/2874912/63e82ef4-040b-496b-bf39-9b32db1bbc73)

Comments
----------------------------------------
Now that I think about it, this is probably overkill because the collapsibility is so useless on this screen. Why don't we just remove it.
See https://github.com/civicrm/civicrm-core/pull/29446 for a better alternative to this PR.