### PR TITLE
dev/user-interface#60 CaseType - Remove deprecated crm-collapsible class

### DIFF
--- a/ext/civi_case/ang/crmCaseType/caseTypeDetails.html
+++ b/ext/civi_case/ang/crmCaseType/caseTypeDetails.html
@@ -41,8 +41,8 @@ The original form used table layout; don't know if we have an alternative, CSS-b
     <div crm-ui-field="{title: ts('Enabled?')}">
       <input name="is_active" type="checkbox" ng-model="caseType.is_active" ng-true-value="'1'" ng-false-value="'0'"/>
     </div>
-    <fieldset class="crm-collapsible">
-      <legend class="collapsible-title">{{:: ts('Activity assignment settings') }}</legend>
+    <fieldset>
+      <legend>{{:: ts('Activity assignment settings') }}</legend>
       <div>
         <div crm-ui-field="{name: 'caseTypeDetailForm.activityAsgmtGrps', title: ts('Restrict to Groups'), help: hs('activityAsgmtGrps')}">
           <input


### PR DESCRIPTION
Overview
----------------------------------------
This removes a `crm-collapsible` class which is deprecated & not doing much.

Before
----------------------------------------
Fieldset is collapsible but open by default. Collapsibility is not terribly useful.

![image](https://github.com/civicrm/civicrm-core/assets/2874912/01c23488-c117-4883-af87-c2546b9d4486)

After
----------------------------------------
Just a regular fieldset.

![image](https://github.com/civicrm/civicrm-core/assets/2874912/15f15ccb-ffa9-4fe8-8aff-d6d1d3388e43)

Comments
----------------------------------------
Normally we would replace these with summary/details like #29445 but in this case the collapsibility was pretty useless and probably added by copy/paste. I see no reason to ever need to collapse that fieldset.