### PR TITLE
Convert accordions to accessible style

### DIFF
--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -208,7 +208,7 @@
             $('.crm-accordion-body', $form).each( function() {
               //open tab if form rule throws error
               if ( $(this).children( ).find('span.crm-error').text( ).length > 0 ) {
-                $(this).parent('.collapsed').crmAccordionToggle();
+                $(this).parent('details:not([open])').crmAccordionToggle();
               }
             });
             function toggleMultiActivityCheckbox() {

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -208,7 +208,7 @@
             $('.crm-accordion-body', $form).each( function() {
               //open tab if form rule throws error
               if ( $(this).children( ).find('span.crm-error').text( ).length > 0 ) {
-                $(this).parent('details:not([open])').crmAccordionToggle();
+                $(this).parent('details').prop('open', true);
               }
             });
             function toggleMultiActivityCheckbox() {

--- a/templates/CRM/Activity/Form/FollowUp.tpl
+++ b/templates/CRM/Activity/Form/FollowUp.tpl
@@ -1,7 +1,7 @@
-<div id="follow-up" class="crm-accordion-wrapper collapsed">
-  <div class="crm-accordion-header">
+<details id="follow-up" class="crm-accordion-bold">
+  <summary>
      {ts}Schedule Follow-up{/ts}
-  </div><!-- /.crm-accordion-header -->
+  </summary>
   <div class="crm-accordion-body">
     <table class="form-layout-compressed">
       <tr class="crm-{$type}activity-form-block-followup_activity_type_id">
@@ -27,5 +27,5 @@
       </tr>
     </table>
   </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
      

--- a/templates/CRM/Activity/Form/FollowUp.tpl
+++ b/templates/CRM/Activity/Form/FollowUp.tpl
@@ -26,6 +26,6 @@
         </td>
       </tr>
     </table>
-  </div><!-- /.crm-accordion-body -->
+  </div>
 </details>
      

--- a/templates/CRM/Activity/Form/Search.tpl
+++ b/templates/CRM/Activity/Form/Search.tpl
@@ -13,7 +13,6 @@
     <summary class="crm-accordion-header crm-master-accordion-header">
       {ts}Edit Search Criteria{/ts}
     </summary>
-    <!-- /.crm-accordion-header -->
     <div class="crm-accordion-body">
       <div id="searchForm" class="form-item">
         {strip}

--- a/templates/CRM/Activity/Selector/Selector.tpl
+++ b/templates/CRM/Activity/Selector/Selector.tpl
@@ -8,10 +8,10 @@
  +--------------------------------------------------------------------+
 *}
 <div class="crm-activity-selector-{$context}">
-  <div class="crm-accordion-wrapper crm-search_filters-accordion">
-    <div class="crm-accordion-header">
+  <details class="crm-accordion-bold crm-search_filters-accordion" open>
+    <summary>
     {ts}Filter by Activity{/ts}
-    </div><!-- /.crm-accordion-header -->
+    </summary>
     <div class="crm-accordion-body">
       <form><!-- form element is here to fool the datepicker widget -->
       <table class="no-border form-layout-compressed activity-search-options">
@@ -30,7 +30,7 @@
       </table>
       </form>
     </div><!-- /.crm-accordion-body -->
-  </div><!-- /.crm-accordion-wrapper -->
+  </details>
   <table class="contact-activity-selector-{$context} crm-ajax-table" style="width: 100%;">
     <thead>
     <tr>

--- a/templates/CRM/Activity/Selector/Selector.tpl
+++ b/templates/CRM/Activity/Selector/Selector.tpl
@@ -29,7 +29,7 @@
         </tr>
       </table>
       </form>
-    </div><!-- /.crm-accordion-body -->
+    </div>
   </details>
   <table class="contact-activity-selector-{$context} crm-ajax-table" style="width: 100%;">
     <thead>

--- a/templates/CRM/Admin/Form/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Form/MessageTemplates.tpl
@@ -79,7 +79,7 @@
           <div class='html'>
             {$form.msg_html.html|crmAddClass:huge}
           </div>
-        </div><!-- /.crm-accordion-body -->
+        </div>
       </details>
 
       <details id="msg_text_section" class="crm-accordion-bold crm-plaint_text_email-accordion " open>
@@ -96,7 +96,7 @@
           <div class='text'>
             {$form.msg_text.html|crmAddClass:huge}
           </div>
-        </div><!-- /.crm-accordion-body -->
+        </div>
       </details>
 
       <details id="pdf_format" class="crm-accordion-bold crm-html_email-accordion " open>
@@ -110,7 +110,7 @@
             {help id="id-msg-template" file="CRM/Contact/Form/Task/PDFLetterCommon.hlp"}
             <div class="description">{ts}Page format to use when creating PDF files using this template.{/ts}</div>
           </div>
-        </div><!-- /.crm-accordion-body -->
+        </div>
       </details>
 
       {if !$isWorkflow}

--- a/templates/CRM/Admin/Form/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Form/MessageTemplates.tpl
@@ -65,11 +65,11 @@
         <tr>
       </table>
 
-      <div id="msg_html_section" class="crm-accordion-wrapper crm-html_email-accordion ">
-        <div class="crm-accordion-header">
+      <details id="msg_html_section" class="crm-accordion-bold crm-html_email-accordion " open>
+        <summary>
           {ts}HTML Format{/ts}
           {help id="id-message-text" file="CRM/Contact/Form/Task/Email.hlp"}
-        </div><!-- /.crm-accordion-header -->
+        </summary>
         <div class="crm-accordion-body">
           <div class="helpIcon" id="helphtml">
             <input class="crm-token-selector big" data-field="msg_html" />
@@ -80,13 +80,13 @@
             {$form.msg_html.html|crmAddClass:huge}
           </div>
         </div><!-- /.crm-accordion-body -->
-      </div><!-- /.crm-accordion-wrapper -->
+      </details>
 
-      <div id="msg_text_section" class="crm-accordion-wrapper crm-plaint_text_email-accordion ">
-        <div class="crm-accordion-header">
+      <details id="msg_text_section" class="crm-accordion-bold crm-plaint_text_email-accordion " open>
+        <summary>
           {ts}Optional Plain-Text Format{/ts}
           {help id="id-message-plain" file="CRM/Contact/Form/Task/Email.hlp"}
-        </div><!-- /.crm-accordion-header -->
+        </summary>
         <div class="crm-accordion-body">
           <div class="helpIcon" id="helptext">
             <input class="crm-token-selector big" data-field="msg_text" />
@@ -97,12 +97,12 @@
             {$form.msg_text.html|crmAddClass:huge}
           </div>
         </div><!-- /.crm-accordion-body -->
-      </div><!-- /.crm-accordion-wrapper -->
+      </details>
 
-      <div id="pdf_format" class="crm-accordion-wrapper crm-html_email-accordion ">
-        <div class="crm-accordion-header">
+      <details id="pdf_format" class="crm-accordion-bold crm-html_email-accordion " open>
+        <summary>
           {$form.pdf_format_id.label}
-        </div><!-- /.crm-accordion-header -->
+        </summary>
         <div class="crm-accordion-body">
           <div class="spacer"></div>
           <div class='html'>
@@ -111,7 +111,7 @@
             <div class="description">{ts}Page format to use when creating PDF files using this template.{/ts}</div>
           </div>
         </div><!-- /.crm-accordion-body -->
-      </div><!-- /.crm-accordion-wrapper -->
+      </details>
 
       {if !$isWorkflow}
         <table class="form-layout-compressed">

--- a/templates/CRM/Campaign/Form/Gotv.tpl
+++ b/templates/CRM/Campaign/Form/Gotv.tpl
@@ -100,7 +100,7 @@
 
       //collapse the search form.
       var searchFormName = '#search_form_' + {/literal}'{$searchVoterFor}'{literal};
-      CRM.$( searchFormName + '.crm-accordion-wrapper:not(.collapsed)').crmAccordionToggle();
+      CRM.$( searchFormName + 'details').prop('open', false);
     }, 'html' );
   }
 

--- a/templates/CRM/Campaign/Form/Search/Common.tpl
+++ b/templates/CRM/Campaign/Form/Search/Common.tpl
@@ -14,10 +14,10 @@
 {if $searchVoterFor}
   {assign var='searchForm' value="search_form_$searchVoterFor"}
 {/if}
-  <div id="{$searchForm}" class="crm-accordion-wrapper crm-contribution_search_form-accordion {if $rows}collapsed{/if}">
-    <div class="crm-accordion-header {if !$votingTab} crm-master-accordion-header{/if}">
+  <details id="{$searchForm}" class="{if !$votingTab} crm-accordion-light{else}crm-accordion-bold{/if} crm-contribution_search_form-accordion" {if $rows}{else}open{/if}>
+    <summary>
     {ts}Edit Search Criteria{/ts}
-    </div><!-- /.crm-accordion-header -->
+    </summary>
 
     <div class="crm-accordion-body">
     {strip}
@@ -142,7 +142,7 @@
     {/strip}
 
     </div>
-  </div>
+  </details>
 </div>
 
 {literal}

--- a/templates/CRM/Campaign/Form/Survey/Results.tpl
+++ b/templates/CRM/Campaign/Form/Survey/Results.tpl
@@ -20,8 +20,8 @@
     {* Create Report *}
     <tr id='showoption'>
       <td colspan="2">
-        <div id="new-group" class="crm-accordion-wrapper">
-          <div class="crm-accordion-header">{ts}Create Report{/ts}</div>
+        <details id="new-group" class="crm-accordion-bold" open>
+          <summary>{ts}Create Report{/ts}</summary>
           <div class="crm-accordion-body">
             <table class="form-layout-compressed">
               <tr>
@@ -34,7 +34,7 @@
               </tr>
             </table>
           </div>
-        </div>
+        </details>
       </td>
     </tr>
   </table>

--- a/templates/CRM/Campaign/Form/Task/Reserve.tpl
+++ b/templates/CRM/Campaign/Form/Task/Reserve.tpl
@@ -57,7 +57,7 @@
   function setDefaultGroup() {
     var invalidGroupName = {/literal}'{$invalidGroupName}'{literal};
     if (invalidGroupName) {
-       cj("#new-group.collapsed").crmAccordionToggle();
+       cj("#new-group").prop('open', true);
     } else {
        cj("#newGroupName").val('');
        cj("#newGroupDesc").val('');

--- a/templates/CRM/Campaign/Form/Task/Reserve.tpl
+++ b/templates/CRM/Campaign/Form/Task/Reserve.tpl
@@ -16,8 +16,8 @@
   {include file="CRM/Contact/Form/Task.tpl"}
 
   {* New Group *}
-  <div id="new-group" class="crm-accordion-wrapper collapsed">
-    <div class="crm-accordion-header">{ts}Add respondent(s) to a new group{/ts}</div>
+  <details id="new-group" class="crm-accordion-bold">
+    <summary>{ts}Add respondent(s) to a new group{/ts}</summary>
     <div class="crm-accordion-body">
             <table class="form-layout-compressed">
              <tr>
@@ -30,11 +30,11 @@
              </tr>
             </table>
     </div>
-  </div>
+  </details>
 
   {* Existing Group *}
-  <div class="crm-accordion-wrapper crm-existing_group-accordion {if $hasExistingGroups} {else}collapsed{/if}">
-    <div class="crm-accordion-header">{ts}Add respondent(s) to existing group(s){/ts}</div>
+  <details class="crm-accordion-bold crm-existing_group-accordion" {if $hasExistingGroups}open{/if}>
+    <summary>{ts}Add respondent(s) to existing group(s){/ts}</summary>
     <div class="crm-accordion-body">
       <table class="form-layout-compressed">
         <tr>
@@ -43,7 +43,7 @@
         </tr>
       </table>
     </div>
-  </div>
+  </details>
 
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>

--- a/templates/CRM/Case/Form/Activity.tpl
+++ b/templates/CRM/Case/Form/Activity.tpl
@@ -41,10 +41,10 @@
       {* Added Activity Details accordion tab *}
       <tr class="crm-case-activity-form-block-activity-details">
         <td colspan="2">
-          <div id="activity-details" class="crm-accordion-wrapper collapsed">
-            <div class="crm-accordion-header">
+          <details id="activity-details" class="crm-accordion-bold">
+            <summary>
               {ts}Activity Details{/ts}
-            </div><!-- /.crm-accordion-header -->
+            </summary>
             <div class="crm-accordion-body">
     {else}
       <tr class="crm-case-activity-form-block-activity-details">
@@ -161,7 +161,7 @@
         || $activityTypeFile EQ 'ChangeCaseType'
         || $activityTypeFile EQ 'ChangeCaseStartDate'}
           </div><!-- /.crm-accordion-body -->
-        </div><!-- /.crm-accordion-wrapper -->
+        </details>
         {* End of Activity Details accordion tab *}
       {/if}
       </td>
@@ -172,10 +172,10 @@
     {if $searchRows} {* We have got case role rows to display for "Send Copy To" feature *}
       <tr class="crm-case-activity-form-block-send_copy">
         <td colspan="2">
-          <div id="sendcopy" class="crm-accordion-wrapper collapsed">
-            <div class="crm-accordion-header">
+          <details id="sendcopy" class="crm-accordion-bold">
+            <summary>
               {ts}Send a Copy{/ts}
-            </div><!-- /.crm-accordion-header -->
+            </summary>
             <div id="sendcopy-body" class="crm-accordion-body">
 
               <div class="description">{ts}Email a complete copy of this activity record to other people involved with the case. Click the top left box to select all.{/ts}</div>
@@ -202,7 +202,7 @@
                 </table>
               {/strip}
             </div><!-- /.crm-accordion-body -->
-          </div><!-- /.crm-accordion-wrapper -->
+          </details>
         </td>
       </tr>
     {/if}

--- a/templates/CRM/Case/Form/Activity.tpl
+++ b/templates/CRM/Case/Form/Activity.tpl
@@ -268,10 +268,10 @@
   {if $action neq 8 and $action neq 32768 and empty($activityTypeFile)}
   <script type="text/javascript">
     {if $searchRows}
-      cj('#sendcopy').crmAccordionToggle();
+      cj('#sendcopy').prop('open', function(i, val) {return !val;});
     {/if}
 
-    cj('#follow-up').crmAccordionToggle();
+    cj('#follow-up').prop('open', function(i, val) {return !val;});
   </script>
   {/if}
 

--- a/templates/CRM/Case/Form/Activity.tpl
+++ b/templates/CRM/Case/Form/Activity.tpl
@@ -160,7 +160,7 @@
         {if $activityTypeFile EQ 'ChangeCaseStatus'
         || $activityTypeFile EQ 'ChangeCaseType'
         || $activityTypeFile EQ 'ChangeCaseStartDate'}
-          </div><!-- /.crm-accordion-body -->
+          </div>
         </details>
         {* End of Activity Details accordion tab *}
       {/if}
@@ -201,7 +201,7 @@
                   {/foreach}
                 </table>
               {/strip}
-            </div><!-- /.crm-accordion-body -->
+            </div>
           </details>
         </td>
       </tr>

--- a/templates/CRM/Case/Form/CaseFilter.tpl
+++ b/templates/CRM/Case/Form/CaseFilter.tpl
@@ -29,7 +29,7 @@
           {/if}
         </tr>
       </table>
-    </div><!-- /.crm-accordion-body -->
+    </div>
   </details>
 </div>
 <div class="spacer"></div>

--- a/templates/CRM/Case/Form/CaseFilter.tpl
+++ b/templates/CRM/Case/Form/CaseFilter.tpl
@@ -8,10 +8,10 @@
  +--------------------------------------------------------------------+
 *}
 <div class="crm-case-filter-{$list}">
-  <div class="crm-accordion-wrapper crm-search_filters-accordion">
-    <div class="crm-accordion-header">
+  <details class="crm-accordion-bold crm-search_filters-accordion" open>
+    <summary>
     {ts}Filter by Case{/ts}</a>
-    </div><!-- /.crm-accordion-header -->
+    </summary>
     <div class="crm-accordion-body">
       <table class="no-border form-layout-compressed case-search-options-{$list}">
         <tr>
@@ -30,6 +30,6 @@
         </tr>
       </table>
     </div><!-- /.crm-accordion-body -->
-  </div><!-- /.crm-accordion-wrapper -->
+  </details>
 </div>
 <div class="spacer"></div>

--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -128,10 +128,10 @@
   <div class="clear"></div>
   {include file="CRM/Case/Page/CustomDataView.tpl"}
 
-  <div class="crm-accordion-wrapper collapsed crm-case-roles-block">
-    <div class="crm-accordion-header">
+  <details class="crm-accordion-bold crm-case-roles-block">
+    <summary>
       {ts}Roles{/ts}
-    </div><!-- /.crm-accordion-header -->
+    </summary>
     <div class="crm-accordion-body">
 
       {if $hasAccessToAllCases}
@@ -186,13 +186,13 @@
       </div>
 
    </div><!-- /.crm-accordion-body -->
-  </div><!-- /.crm-accordion-wrapper -->
+  </details>
 
   {if $hasAccessToAllCases}
-  <div class="crm-accordion-wrapper collapsed crm-case-other-relationships-block">
-    <div class="crm-accordion-header">
+  <details class="crm-accordion-bold crm-case-other-relationships-block">
+    <summary>
       {ts}Other Relationships{/ts}
-    </div><!-- /.crm-accordion-header -->
+    </summary>
     <div class="crm-accordion-body">
       <div class="crm-submit-buttons">
         {crmButton p='civicrm/contact/view/rel' q="action=add&reset=1&cid=`$contactId`&caseID=`$caseID`" icon="plus-circle"}{ts}Add client relationship{/ts}{/crmButton}
@@ -253,17 +253,17 @@
   {/if}
 
   </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 
 {/if} {* other relationship section ends *}
 {include file="CRM/Case/Form/ActivityToCase.tpl"}
 
 {* pane to display / edit regular tags or tagsets for cases *}
 {if $showTags}
-<div id="casetags" class="crm-accordion-wrapper  crm-case-tags-block">
- <div class="crm-accordion-header">
+<details id="casetags" class="crm-accordion-bold  crm-case-tags-block" open>
+ <summary>
   {ts}Case Tags{/ts}
- </div><!-- /.crm-accordion-header -->
+ </summary>
  <div class="crm-accordion-body">
   {if $tags}
     <p class="crm-block crm-content-block crm-case-caseview-display-tags">
@@ -296,7 +296,7 @@
   </div>
 
  </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 
 <div id="manageTagsDialog" class="hiddenElement">
   <div class="label">{$form.case_tag.label}</div>

--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -185,7 +185,7 @@
         {ts}Are you sure you want to end this relationship?{/ts}
       </div>
 
-   </div><!-- /.crm-accordion-body -->
+   </div>
   </details>
 
   {if $hasAccessToAllCases}
@@ -252,7 +252,7 @@
     {/literal}
   {/if}
 
-  </div><!-- /.crm-accordion-body -->
+  </div>
 </details>
 
 {/if} {* other relationship section ends *}
@@ -295,7 +295,7 @@
     </a>
   </div>
 
- </div><!-- /.crm-accordion-body -->
+ </div>
 </details>
 
 <div id="manageTagsDialog" class="hiddenElement">

--- a/templates/CRM/Case/Form/Search.tpl
+++ b/templates/CRM/Case/Form/Search.tpl
@@ -13,10 +13,10 @@
 {else}
 
 <div class="crm-block crm-form-block crm-case-search-form-block">
-<div class="crm-accordion-wrapper crm-case_search-accordion {if $rows}collapsed{/if}">
- <div class="crm-accordion-header crm-master-accordion-header">
+<details class="crm-accordion-light crm-case_search-accordion" {if $rows}{else}open{/if}>
+ <summary>
             {ts}Edit Search Criteria{/ts}
-</div><!-- /.crm-accordion-header -->
+</summary>
  <div class="crm-accordion-body">
         {strip}
             <table class="form-layout">
@@ -34,7 +34,7 @@
             </table>
         {/strip}
 </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 </div><!-- /.crm-form-block -->
     {if $rowsEmpty || $rows}
 <div class="crm-content-block">

--- a/templates/CRM/Case/Form/Search.tpl
+++ b/templates/CRM/Case/Form/Search.tpl
@@ -33,7 +33,7 @@
             </tr>
             </table>
         {/strip}
-</div><!-- /.crm-accordion-body -->
+</div>
 </details>
 </div><!-- /.crm-form-block -->
     {if $rowsEmpty || $rows}

--- a/templates/CRM/Case/Page/CustomDataView.tpl
+++ b/templates/CRM/Case/Page/CustomDataView.tpl
@@ -11,10 +11,10 @@
 {foreach from=$viewCustomData item=customValues key=customGroupId}
   {foreach from=$customValues item=cd_edit key=cvID}
     {assign var='index' value=$groupId|cat:"_$cvID"}
-  <div id="{$cd_edit.name}" class="crm-accordion-wrapper {if $cd_edit.collapse_display neq 0}collapsed{/if}">
-    <div class="crm-accordion-header">
+  <details id="{$cd_edit.name}" class="crm-accordion-bold" {if $cd_edit.collapse_display neq 0}{else}open{/if}>
+    <summary>
       {$cd_edit.title}
-    </div>
+    </summary>
     <div class="crm-accordion-body">
       {if !empty($cd_edit.fields)}
         <table class="crm-info-panel">
@@ -47,7 +47,7 @@
       <br/>
       <div class="clear"></div>
     </div>
-  </div>
+  </details>
 
   {/foreach}
 {/foreach}

--- a/templates/CRM/Contact/Form/Contact.tpl
+++ b/templates/CRM/Contact/Form/Contact.tpl
@@ -73,7 +73,7 @@
           {/if}
           <div class="spacer"></div>
         </div>
-      </div><!-- /.crm-accordion-body -->
+      </div>
     </details>
 
     {foreach from = $editOptions item = "title" key="name"}

--- a/templates/CRM/Contact/Form/Contact.tpl
+++ b/templates/CRM/Contact/Form/Contact.tpl
@@ -106,15 +106,15 @@
       }
       //open tab if form rule throws error
       if ( $(this).children().find('span.crm-error').text().length > 0 ) {
-        $(this).parents('.collapsed').crmAccordionToggle();
+        $(this).parents('details:not([open])').crmAccordionToggle();
       }
     });
     if (action === 2) {
-      $('.crm-accordion-wrapper').not('.crm-accordion-wrapper .crm-accordion-wrapper').each(function() {
+      $('details').not('details details').each(function() {
         highlightTabs(this);
       });
       $('#crm-container').on('change click', '.crm-accordion-body :input, .crm-accordion-body a', function() {
-        highlightTabs($(this).parents('.crm-accordion-wrapper'));
+        highlightTabs($(this).parents('details'));
       });
     }
     function highlightTabs(tab) {
@@ -125,7 +125,7 @@
             case 'checkbox':
             case 'radio':
               if($(this).is(':checked') && !$(this).is('[id$=IsPrimary],[id$=IsBilling]')) {
-                $('.crm-accordion-header:first', tab).addClass('active');
+                $('summary:first', tab).addClass('active');
                 return false;
               }
               break;
@@ -133,7 +133,7 @@
             case 'text':
             case 'textarea':
               if($(this).val()) {
-                $('.crm-accordion-header:first', tab).addClass('active');
+                $('summary:first', tab).addClass('active');
                 return false;
               }
               break;
@@ -141,19 +141,19 @@
             case 'select-one':
             case 'select-multiple':
               if($(this).val() && $('option[value=""]', this).length > 0) {
-                $('.crm-accordion-header:first', tab).addClass('active');
+                $('summary:first', tab).addClass('active');
                 return false;
               }
               break;
 
             case 'file':
               if($(this).next().html()) {
-                $('.crm-accordion-header:first', tab).addClass('active');
+                $('summary:first', tab).addClass('active');
                 return false;
               }
               break;
           }
-          $('.crm-accordion-header:first', tab).removeClass('active');
+          $('summary:first', tab).removeClass('active');
       });
     }
 
@@ -161,11 +161,11 @@
       if( $(this).attr('href') == '#expand') {
         var message = {/literal}"{ts escape='js'}Collapse all tabs{/ts}"{literal};
         $(this).attr('href', '#collapse');
-        $('.crm-accordion-wrapper.collapsed').crmAccordionToggle();
+        $('.crm-form-block details:not([open])').crmAccordionToggle();
       }
       else {
         var message = {/literal}"{ts escape='js'}Expand all tabs{/ts}"{literal};
-        $('.crm-accordion-wrapper:not(.collapsed)').crmAccordionToggle();
+        $('.crm-form-block details[open]').crmAccordionToggle();
         $(this).attr('href', '#expand');
       }
       $(this).html(message);

--- a/templates/CRM/Contact/Form/Contact.tpl
+++ b/templates/CRM/Contact/Form/Contact.tpl
@@ -106,7 +106,7 @@
       }
       //open tab if form rule throws error
       if ( $(this).children().find('span.crm-error').text().length > 0 ) {
-        $(this).parents('details:not([open])').crmAccordionToggle();
+        $(this).parents('details').prop('open', true);
       }
     });
     if (action === 2) {
@@ -161,11 +161,11 @@
       if( $(this).attr('href') == '#expand') {
         var message = {/literal}"{ts escape='js'}Collapse all tabs{/ts}"{literal};
         $(this).attr('href', '#collapse');
-        $('.crm-form-block details:not([open])').crmAccordionToggle();
+        $('.crm-form-block details').prop('open', true);
       }
       else {
         var message = {/literal}"{ts escape='js'}Expand all tabs{/ts}"{literal};
-        $('.crm-form-block details[open]').crmAccordionToggle();
+        $('.crm-form-block details').prop('open', false);
         $(this).attr('href', '#expand');
       }
       $(this).html(message);

--- a/templates/CRM/Contact/Form/Contact.tpl
+++ b/templates/CRM/Contact/Form/Contact.tpl
@@ -23,10 +23,10 @@
     {include file="CRM/common/formButtons.tpl" location="top"}
     </div>
 
-    <div class="crm-accordion-wrapper crm-contactDetails-accordion">
-      <div class="crm-accordion-header">
+    <details class="crm-accordion-bold crm-contactDetails-accordion" open>
+      <summary>
         {ts}Contact Details{/ts}
-      </div><!-- /.crm-accordion-header -->
+      </summary>
       <div class="crm-accordion-body" id="contactDetails">
         <div id="contactDetails">
           <div class="crm-section contact_basic_information-section">
@@ -74,7 +74,7 @@
           <div class="spacer"></div>
         </div>
       </div><!-- /.crm-accordion-body -->
-    </div><!-- /.crm-accordion-wrapper -->
+    </details>
 
     {foreach from = $editOptions item = "title" key="name"}
       {if $name eq 'CustomData'}

--- a/templates/CRM/Contact/Form/Edit/Address.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address.tpl
@@ -71,7 +71,7 @@
 
 {if $className eq 'CRM_Contact_Form_Contact' && $title}
 </div>
- </div><!-- /.crm-accordion-body -->
+ </div>
 </details>
 {/if}
 {literal}

--- a/templates/CRM/Contact/Form/Edit/Address.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address.tpl
@@ -12,10 +12,10 @@
 {* @var $blockId Contains the current address block id, and assigned in the  CRM/Contact/Form/Location.php file *}
 
 {if $className eq 'CRM_Contact_Form_Contact' && $title}
-<div id="addressBlockId" class="crm-accordion-wrapper crm-address-accordion collapsed">
- <div class="crm-accordion-header">
+<details id="addressBlockId" class="crm-accordion-bold crm-address-accordion">
+ <summary>
     {$title}
- </div><!-- /.crm-accordion-header -->
+ </summary>
  <div class="crm-accordion-body" id="addressBlock">
 {/if}
 
@@ -72,7 +72,7 @@
 {if $className eq 'CRM_Contact_Form_Contact' && $title}
 </div>
  </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 {/if}
 {literal}
 <script type="text/javascript">

--- a/templates/CRM/Contact/Form/Edit/CommunicationPreferences.tpl
+++ b/templates/CRM/Contact/Form/Edit/CommunicationPreferences.tpl
@@ -106,6 +106,6 @@
           <td>{$form.is_opt_out.html} {$form.is_opt_out.label} {help id="id-optOut" file="CRM/Contact/Form/Contact.hlp"}</td>
         </tr>
     </table>
- </div><!-- /.crm-accordion-body -->
+ </div>
 </details>
 {include file="CRM/Contact/Form/Edit/CommunicationPreferences.js.tpl"}

--- a/templates/CRM/Contact/Form/Edit/CommunicationPreferences.tpl
+++ b/templates/CRM/Contact/Form/Edit/CommunicationPreferences.tpl
@@ -10,10 +10,10 @@
 {* This file provides the plugin for the communication preferences in all the three types of contact *}
 {* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller *}
 
-<div class="crm-accordion-wrapper crm-commPrefs-accordion collapsed">
- <div class="crm-accordion-header">
+<details class="crm-accordion-bold crm-commPrefs-accordion">
+ <summary>
     {$title}
-  </div><!-- /.crm-accordion-header -->
+  </summary>
 <div id="commPrefs" class="crm-accordion-body">
     <table class="form-layout-compressed" >
         {if array_key_exists('communication_style_id', $form)}
@@ -107,5 +107,5 @@
         </tr>
     </table>
  </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 {include file="CRM/Contact/Form/Edit/CommunicationPreferences.js.tpl"}

--- a/templates/CRM/Contact/Form/Edit/CustomData.tpl
+++ b/templates/CRM/Contact/Form/Edit/CustomData.tpl
@@ -13,11 +13,9 @@
     {assign var=tableID value=$cd_edit.table_id}
     {assign var=divName value=$group_id|cat:"_$tableID"}
     <div></div>
-    <div
-     class="crm-accordion-wrapper crm-custom-accordion {if $cd_edit.collapse_display and !$skipTitle}collapsed{/if}">
+    <div class="crm-accordion-wrapper crm-custom-accordion {if $cd_edit.collapse_display and !$skipTitle}collapsed{/if}">
   {else}
-    <div id="{$cd_edit.name}"
-       class="crm-accordion-wrapper crm-custom-accordion {if $cd_edit.collapse_display}collapsed{/if}">
+    <div id="{$cd_edit.name}" class="crm-accordion-wrapper crm-custom-accordion {if $cd_edit.collapse_display}collapsed{/if}">
   {/if}
     <div class="crm-accordion-header">
       {$cd_edit.title}

--- a/templates/CRM/Contact/Form/Edit/CustomData.tpl
+++ b/templates/CRM/Contact/Form/Edit/CustomData.tpl
@@ -13,20 +13,19 @@
     {assign var=tableID value=$cd_edit.table_id}
     {assign var=divName value=$group_id|cat:"_$tableID"}
     <div></div>
-    <div class="crm-accordion-wrapper crm-custom-accordion {if $cd_edit.collapse_display and !$skipTitle}collapsed{/if}">
+    <details class="crm-accordion-bold crm-custom-accordion" {if $cd_edit.collapse_display and !$skipTitle}{else}open{/if}>
   {else}
-    <div id="{$cd_edit.name}" class="crm-accordion-wrapper crm-custom-accordion {if $cd_edit.collapse_display}collapsed{/if}">
+    <details id="{$cd_edit.name}" class="crm-accordion-bold crm-custom-accordion" {if $cd_edit.collapse_display}{else}open{/if}>
   {/if}
-    <div class="crm-accordion-header">
+    <summary>
       {$cd_edit.title}
-    </div>
+    </summary>
     <div id="customData{$group_id}" class="crm-accordion-body">
       {include file="CRM/Custom/Form/Edit/CustomData.tpl" customDataEntity=''}
       {include file="CRM/Form/attachmentjs.tpl"}
     </div>
     <!-- crm-accordion-body-->
-  </div>
-  <!-- crm-accordion-wrapper -->
+  </details>
   <div id="custom_group_{$group_id}_{$cgCount}"></div>
   {/foreach}
 

--- a/templates/CRM/Contact/Form/Edit/Demographics.tpl
+++ b/templates/CRM/Contact/Form/Edit/Demographics.tpl
@@ -31,7 +31,7 @@
        <span class="label">{$form.deceased_date.label}</span>
        <span class="fields">{$form.deceased_date.html}</span>
   </div>
- </div><!-- /.crm-accordion-body -->
+ </div>
 </details>
 
 {literal}

--- a/templates/CRM/Contact/Form/Edit/Demographics.tpl
+++ b/templates/CRM/Contact/Form/Edit/Demographics.tpl
@@ -7,10 +7,10 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-<div class="crm-accordion-wrapper crm-demographics-accordion collapsed">
- <div class="crm-accordion-header">
+<details class="crm-accordion-bold crm-demographics-accordion">
+ <summary>
     {$title}
-  </div><!-- /.crm-accordion-header -->
+  </summary>
   <div id="demographics" class="crm-accordion-body">
   <div class="form-item">
         <span class="label">{$form.gender_id.label}</span>
@@ -32,7 +32,7 @@
        <span class="fields">{$form.deceased_date.html}</span>
   </div>
  </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 
 {literal}
 <script type="text/javascript">

--- a/templates/CRM/Contact/Form/Edit/Notes.tpl
+++ b/templates/CRM/Contact/Form/Edit/Notes.tpl
@@ -24,5 +24,5 @@
        </td>
      </tr>
    </table>
- </div><!-- /.crm-accordion-body -->
+ </div>
 </details>

--- a/templates/CRM/Contact/Form/Edit/Notes.tpl
+++ b/templates/CRM/Contact/Form/Edit/Notes.tpl
@@ -7,11 +7,11 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-<div class="crm-accordion-wrapper crm-notesBlock-accordion collapsed">
- <div class="crm-accordion-header">
+<details class="crm-accordion-bold crm-notesBlock-accordion">
+ <summary>
 
     {$title}
-  </div><!-- /.crm-accordion-header -->
+  </summary>
   <div class="crm-accordion-body" id="notesBlock">
    <table class="form-layout-compressed">
      <tr>
@@ -25,4 +25,4 @@
      </tr>
    </table>
  </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>

--- a/templates/CRM/Contact/Form/Edit/TagsAndGroups.tpl
+++ b/templates/CRM/Contact/Form/Edit/TagsAndGroups.tpl
@@ -8,8 +8,8 @@
  +--------------------------------------------------------------------+
 *}
 {if $title}
-<div class="crm-accordion-wrapper crm-tagGroup-accordion collapsed">
-  <div class="crm-accordion-header">{$title}</div>
+<details class="crm-accordion-bold crm-tagGroup-accordion">
+  <summary>{$title}</summary>
   <div class="crm-accordion-body" id="tagGroup">
 {/if}
     <table class="form-layout-compressed{if $context EQ 'profile'} crm-profile-tagsandgroups{/if}">
@@ -49,5 +49,5 @@
     </table>
 {if $title}
   </div>
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 {/if}

--- a/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
+++ b/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
@@ -13,11 +13,11 @@
 CRM.$(function($) {
   // Bind first click of accordion header to load crm-accordion-body with snippet
   // everything else is taken care of by crmAccordions()
-  $('.crm-search_criteria_basic-accordion .crm-accordion-header').addClass('active');
-  $('.crm-ajax-accordion').on('click', '.crm-accordion-header:not(.active)', function() {
+  $('.crm-search_criteria_basic-accordion summary').addClass('active');
+  $('.crm-ajax-accordion').on('click', 'summary:not(.active)', function() {
     loadPanes($(this).attr('id'));
   });
-  $('.crm-ajax-accordion:not(.collapsed) .crm-accordion-header').each(function() {
+  $('.crm-ajax-accordion[open] summary').each(function() {
     loadPanes($(this).attr('id'));
   });
   $('.crm-ajax-accordion').on('click', '.crm-close-accordion', function() {
@@ -46,7 +46,7 @@ CRM.$(function($) {
     $('#task').val('');
     var mode = modes[$('#component_mode').val()] || null;
     if (mode) {
-      $('.crm-' + mode + '-accordion.collapsed').crmAccordionToggle();
+      $('.crm-' + mode + '-accordion:not([open])').prop('open', true);
       loadPanes(mode);
     }
     if ('related_contact' === modes[$('#component_mode').val()]) {

--- a/templates/CRM/Contact/Form/Search/BasicCriteria.tpl
+++ b/templates/CRM/Contact/Form/Search/BasicCriteria.tpl
@@ -79,7 +79,7 @@
             </div>
         {/if}
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
-    </div><!-- /.crm-accordion-body -->
+    </div>
     </details>
 </div><!-- /.crm-form-block -->
 {/strip}

--- a/templates/CRM/Contact/Form/Search/BasicCriteria.tpl
+++ b/templates/CRM/Contact/Form/Search/BasicCriteria.tpl
@@ -20,10 +20,10 @@
 
 {strip}
 <div class="crm-block crm-form-block crm-basic-criteria-form-block">
-    <div class="crm-accordion-wrapper crm-case_search-accordion {if $rows}collapsed{/if}">
-     <div class="crm-accordion-header crm-master-accordion-header">
+    <details class="crm-accordion-light crm-case_search-accordion" {if $rows}{else}open{/if}>
+     <summary>
         {$editTitle}
-    </div><!-- /.crm-accordion-header -->
+    </summary>
     <div class="crm-accordion-body">
         <div class="crm-section sort_name-section">
           <div class="label">
@@ -80,6 +80,6 @@
         {/if}
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
     </div><!-- /.crm-accordion-body -->
-    </div><!-- /.crm-accordion-wrapper -->
+    </details>
 </div><!-- /.crm-form-block -->
 {/strip}

--- a/templates/CRM/Contact/Form/Search/Builder.tpl
+++ b/templates/CRM/Contact/Form/Search/Builder.tpl
@@ -27,7 +27,7 @@
           {$form.buttons.html}
         </div>
       </div>
-    </div><!-- /.crm-accordion-body -->
+    </div>
   </details>
 </div><!-- /.crm-form-block -->
 {if $rowsEmpty || $rows}

--- a/templates/CRM/Contact/Form/Search/Builder.tpl
+++ b/templates/CRM/Contact/Form/Search/Builder.tpl
@@ -14,10 +14,10 @@
   {ts 1="href='$skUrl'"}Search Builder is a legacy part of CiviCRM. It is recommended to <a %1>use SearchKit instead</a>.{/ts}
 </div>
 <div class="crm-form-block crm-search-form-block">
-  <div class="crm-accordion-wrapper crm-search_builder-accordion {if $rows and !$showSearchForm}collapsed{/if}">
-    <div class="crm-accordion-header crm-master-accordion-header">
+  <details class="crm-accordion-light crm-search_builder-accordion" {if $rows and !$showSearchForm}{else}open{/if}>
+    <summary>
       {ts}Search Criteria{/ts} {help id='builder-intro'}
-    </div>
+    </summary>
     <div class="crm-accordion-body">
       <div id="searchForm">
         {* Table for adding search criteria. *}
@@ -28,7 +28,7 @@
         </div>
       </div>
     </div><!-- /.crm-accordion-body -->
-  </div><!-- /.crm-accordion-wrapper -->
+  </details>
 </div><!-- /.crm-form-block -->
 {if $rowsEmpty || $rows}
 <div class="crm-content-block">

--- a/templates/CRM/Contact/Form/Task/EmailCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/EmailCommon.tpl
@@ -9,11 +9,11 @@
 *}
 {*common template for compose mail*}
 
-<div class="crm-accordion-wrapper crm-html_email-accordion ">
-<div class="crm-accordion-header">
+<details class="crm-accordion-bold crm-html_email-accordion " open>
+<summary>
     {ts}HTML Format{/ts}
     {help id="id-message-text" file="CRM/Contact/Form/Task/Email.hlp"}
-</div><!-- /.crm-accordion-header -->
+</summary>
  <div class="crm-accordion-body">
   <div class="helpIcon" id="helphtml">
     <input class="crm-token-selector big" data-field="html_message" />
@@ -24,12 +24,12 @@
       {$form.html_message.html}<br />
     </div>
   </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 
-<div class="crm-accordion-wrapper crm-plaint_text_email-accordion collapsed">
-<div class="crm-accordion-header">
+<details class="crm-accordion-bold crm-plaint_text_email-accordion">
+<summary>
   {ts}Plain-Text Format{/ts}
-  </div><!-- /.crm-accordion-header -->
+  </summary>
  <div class="crm-accordion-body">
    <div class="helpIcon" id="helptext">
      <input class="crm-token-selector big" data-field="text_message" />
@@ -39,7 +39,7 @@
       {$form.text_message.html}<br />
     </div>
   </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 <div id="editMessageDetails" class="section">
   {if call_user_func(array('CRM_Core_Permission','check'), 'edit message templates')}
       <div id="updateDetails" class="section" >

--- a/templates/CRM/Contact/Form/Task/EmailCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/EmailCommon.tpl
@@ -23,7 +23,7 @@
     <div class='html'>
       {$form.html_message.html}<br />
     </div>
-  </div><!-- /.crm-accordion-body -->
+  </div>
 </details>
 
 <details class="crm-accordion-bold crm-plaint_text_email-accordion">
@@ -38,7 +38,7 @@
     <div class='text'>
       {$form.text_message.html}<br />
     </div>
-  </div><!-- /.crm-accordion-body -->
+  </div>
 </details>
 <div id="editMessageDetails" class="section">
   {if call_user_func(array('CRM_Core_Permission','check'), 'edit message templates')}

--- a/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
@@ -82,7 +82,7 @@
   </summary>
   <div class="crm-accordion-body">
     <div id='document-preview'></div>
-  </div><!-- /.crm-accordion-body -->
+  </div>
 </details>
 
 <details class="crm-accordion-bold crm-html_email-accordion " open>
@@ -115,7 +115,7 @@
   {/if}
 </div>
 
-  </div><!-- /.crm-accordion-body -->
+  </div>
 </details>
 
 <table class="form-layout-compressed">

--- a/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
@@ -32,10 +32,10 @@
 </table>
 {/if}
 
-<div class="crm-accordion-wrapper collapsed crm-pdf-format-accordion">
-    <div class="crm-accordion-header">
+<details class="crm-accordion-bold crm-pdf-format-accordion">
+    <summary>
       {ts}Page Format:{/ts} <span class="pdf-format-header-label"></span>
-    </div>
+    </summary>
     <div class="crm-accordion-body">
       <div class="crm-block crm-form-block">
     <table class="form-layout-compressed">
@@ -74,21 +74,21 @@
         <div id="updateFormat" style="display: none">{$form.update_format.html}&nbsp;{$form.update_format.label}</div>
       </div>
   </div>
-</div>
+</details>
 
-<div class="crm-accordion-wrapper crm-document-accordion ">
-  <div class="crm-accordion-header">
+<details class="crm-accordion-bold crm-document-accordion " open>
+  <summary>
     {ts}Preview Document{/ts}
-  </div><!-- /.crm-accordion-header -->
+  </summary>
   <div class="crm-accordion-body">
     <div id='document-preview'></div>
   </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 
-<div class="crm-accordion-wrapper crm-html_email-accordion ">
-<div class="crm-accordion-header">
+<details class="crm-accordion-bold crm-html_email-accordion " open>
+<summary>
     {$form.html_message.label}
-</div><!-- /.crm-accordion-header -->
+</summary>
  <div class="crm-accordion-body">
    <div class="helpIcon" id="helphtml">
      <input class="crm-token-selector big" data-field="html_message" />
@@ -116,7 +116,7 @@
 </div>
 
   </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 
 <table class="form-layout-compressed">
   <tr>

--- a/templates/CRM/Contact/Form/Task/SMSCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/SMSCommon.tpl
@@ -9,10 +9,10 @@
 *}
 {*common template for compose sms*}
 
-<div class="crm-accordion-wrapper crm-plaint_text_sms-accordion ">
-<div class="crm-accordion-header">
+<details class="crm-accordion-bold crm-plaint_text_sms-accordion " open>
+<summary>
   {$form.sms_text_message.label}
-  </div><!-- /.crm-accordion-header -->
+  </summary>
  <div class="crm-accordion-body">
  <div><span id="char-count-message"></span> <span id="char-count-help">{help id="id-count-text" tplFile=$tplFile file="CRM/Contact/Form/Task/SMS.hlp"}</span></div>
    <div class="helpIcon" id="helptext">
@@ -23,8 +23,7 @@
   {$form.sms_text_message.html}<br />
     </div>
   </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
-
+</details>
 <div id="SMSeditMessageDetails" class="section">
   <div id="SMSupdateDetails" class="section" >
     {if array_key_exists('SMSupdateTemplate', $form)}{$form.SMSupdateTemplate.html}&nbsp;{$form.SMSupdateTemplate.label}{/if}

--- a/templates/CRM/Contact/Form/Task/SMSCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/SMSCommon.tpl
@@ -22,7 +22,7 @@
     <div class='text'>
   {$form.sms_text_message.html}<br />
     </div>
-  </div><!-- /.crm-accordion-body -->
+  </div>
 </details>
 <div id="SMSeditMessageDetails" class="section">
   <div id="SMSupdateDetails" class="section" >

--- a/templates/CRM/Contact/Import/Form/Preview.tpl
+++ b/templates/CRM/Contact/Import/Form/Preview.tpl
@@ -138,17 +138,3 @@
    {include file="CRM/common/formButtons.tpl" location="bottom"}
 </div>
 </div>
-
-{literal}
-<script type="text/javascript">
-
-if (cj("#newGroupName").val()) {
-  cj("#new-group.collapsed").crmAccordionToggle();
-}
-
-if (cj("#newTagName").val()) {
-  cj("#new-tag.collapsed").crmAccordionToggle();
-}
-
-</script>
-{/literal}

--- a/templates/CRM/Contact/Import/Form/Preview.tpl
+++ b/templates/CRM/Contact/Import/Form/Preview.tpl
@@ -75,7 +75,7 @@
                <td>{$form.newGroupType.html}</td>
              </tr>
             </table>
- </div><!-- /.crm-accordion-body -->
+ </div>
 </details>
 
 
@@ -90,7 +90,7 @@
         <div class="form-item">
         <table><tr><td style="width: 14em;"></td><td>{$form.groups.html}</td></tr></table>
         </div>
- </div><!-- /.crm-accordion-body -->
+ </div>
 </details>
 
     {* Tag options *}
@@ -113,7 +113,7 @@
            </tr>
         </table>
     </div>
- </div><!-- /.crm-accordion-body -->
+ </div>
 </details>
     {* Existing Tag Imported Contact *}
 
@@ -130,7 +130,7 @@
             </td>
           </tr>
         </table>
- </div><!-- /.crm-accordion-body -->
+ </div>
 </details>
 </div> {* End of preview-info div. We hide this on form submit. *}
 

--- a/templates/CRM/Contact/Import/Form/Preview.tpl
+++ b/templates/CRM/Contact/Import/Form/Preview.tpl
@@ -56,10 +56,10 @@
 
  {* Group options *}
  {* New Group *}
-<div id="new-group" class="crm-accordion-wrapper collapsed">
- <div class="crm-accordion-header">
+<details id="new-group" class="crm-accordion-bold">
+ <summary>
     {ts}Add imported records to a new group{/ts}
- </div><!-- /.crm-accordion-header -->
+ </summary>
  <div class="crm-accordion-body">
             <table class="form-layout-compressed">
              <tr>
@@ -76,29 +76,29 @@
              </tr>
             </table>
  </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 
 
       {* Existing Group *}
 
-<div id="existing-groups" class="crm-accordion-wrapper crm-existing_group-accordion {if !empty($form.groups)} {else}collapsed{/if}">
- <div class="crm-accordion-header">
+<details id="existing-groups" class="crm-accordion-bold crm-existing_group-accordion" {if !empty($form.groups)}open{/if}>
+ <summary>
   {$form.groups.label}
- </div><!-- /.crm-accordion-header -->
+ </summary>
  <div class="crm-accordion-body">
 
         <div class="form-item">
         <table><tr><td style="width: 14em;"></td><td>{$form.groups.html}</td></tr></table>
         </div>
  </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 
     {* Tag options *}
     {* New Tag *}
-<div id="new-tag" class="crm-accordion-wrapper collapsed">
- <div class="crm-accordion-header">
+<details id="new-tag" class="crm-accordion-bold">
+ <summary>
   {ts}Create a new tag and assign it to imported records{/ts}
- </div><!-- /.crm-accordion-header -->
+ </summary>
  <div class="crm-accordion-body">
 
   <div class="form-item">
@@ -114,13 +114,13 @@
         </table>
     </div>
  </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
     {* Existing Tag Imported Contact *}
 
-<div id="existing-tags" class="crm-accordion-wrapper collapsed">
- <div class="crm-accordion-header">
+<details id="existing-tags" class="crm-accordion-bold">
+ <summary>
   {ts}Tag imported records{/ts}
-</div><!-- /.crm-accordion-header -->
+</summary>
  <div class="crm-accordion-body">
 
         <table class="form-layout-compressed">
@@ -131,7 +131,7 @@
           </tr>
         </table>
  </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 </div> {* End of preview-info div. We hide this on form submit. *}
 
 <div class="crm-submit-buttons">

--- a/templates/CRM/Contact/Page/DedupeFind.tpl
+++ b/templates/CRM/Contact/Page/DedupeFind.tpl
@@ -52,7 +52,7 @@
           </td>
         </tr>
       </table>
-    </div><!-- /.crm-accordion-body -->
+    </div>
   </details>
   <div>
     {ts}Show / Hide columns:{/ts}

--- a/templates/CRM/Contact/Page/DedupeFind.tpl
+++ b/templates/CRM/Contact/Page/DedupeFind.tpl
@@ -9,10 +9,10 @@
 *}
 {if $action eq 2 || $action eq 16}
 <div class="form-item">
-  <div class="crm-accordion-wrapper crm-search_filters-accordion">
-    <div class="crm-accordion-header">
+  <details class="crm-accordion-bold crm-search_filters-accordion" open>
+    <summary>
     {ts}Filter Contacts{/ts}</a>
-    </div><!-- /.crm-accordion-header -->
+    </summary>
     <div class="crm-accordion-body">
       <table class="no-border form-layout-compressed" id="searchOptions" style="width:100%;">
         <tr>
@@ -53,7 +53,7 @@
         </tr>
       </table>
     </div><!-- /.crm-accordion-body -->
-  </div><!-- /.crm-accordion-wrapper -->
+  </details>
   <div>
     {ts}Show / Hide columns:{/ts}
     <input type='checkbox' id='steet-address' class='toggle-vis' data-column-main="7" data-column-dupe="8" >

--- a/templates/CRM/Contact/Page/View/GroupContact.tpl
+++ b/templates/CRM/Contact/Page/View/GroupContact.tpl
@@ -183,8 +183,8 @@
       }
     }
     // bind first click of accordion header to load crm-accordion-body with snippet
-    $('.view-contact-groups .crm-ajax-accordion.collapsed .crm-accordion-header').one('click', loadPanes);
-    $('.view-contact-groups .crm-ajax-accordion:not(.collapsed) .crm-accordion-header').each(loadPanes);
+    $('.view-contact-groups .crm-ajax-accordion:not([open]) summary').one('click', loadPanes);
+    $('.view-contact-groups .crm-ajax-accordion[open] summary').each(loadPanes);
     // Handle enable/delete links
     var that;
     function refresh() {

--- a/templates/CRM/Contact/Page/View/GroupContact.tpl
+++ b/templates/CRM/Contact/Page/View/GroupContact.tpl
@@ -69,7 +69,6 @@
         <div class="crm-accordion-body">
           <div class="crm-contact_smartgroup" style="min-height: 3em;"></div>
         </div>
-        <!-- /.crm-accordion-body -->
       </details>
     </div>
   {/if}

--- a/templates/CRM/Contact/Page/View/GroupContact.tpl
+++ b/templates/CRM/Contact/Page/View/GroupContact.tpl
@@ -62,17 +62,15 @@
   {if $contactSmartGroupSettings neq 3}
     <div class="spacer" style="height: 1.5em;"></div>
     <div class="accordion ui-accordion ui-widget ui-helper-reset">
-      <div class="crm-accordion-wrapper crm-ajax-accordion crm-smartgroup-accordion {if $contactSmartGroupSettings eq 1}collapsed{/if}">
-        <div class="crm-accordion-header" id="crm-contact_smartgroup" contact_id="{$contactId}">
+      <details class="crm-accordion-bold crm-ajax-accordion crm-smartgroup-accordion" {if $contactSmartGroupSettings eq 1}{else}open{/if}>
+        <summary  id="crm-contact_smartgroup" contact_id="{$contactId}">
           {ts}Smart Groups{/ts}
-        </div>
-        <!-- /.crm-accordion-header -->
+        </summary>
         <div class="crm-accordion-body">
           <div class="crm-contact_smartgroup" style="min-height: 3em;"></div>
         </div>
         <!-- /.crm-accordion-body -->
-      </div>
-      <!-- /.crm-accordion-wrapper -->
+      </details>
     </div>
   {/if}
 

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -75,11 +75,11 @@
     </tr>
    </table>
 
-    <div class="crm-accordion-wrapper crm-accordion_title-accordion crm-accordion-processed" id="paymentDetails_Information">
+    <details class="crm-accordion-bold crm-accordion_title-accordion crm-accordion-processed" id="paymentDetails_Information" open>
       {if !$contributionMode}
-      <div class="crm-accordion-header">
+      <summary>
         {if $paymentType EQ 'refund'}{ts}Refund Details{/ts}{else}{ts}Payment Details{/ts}{/if}
-      </div>
+      </summary>
       <div class="crm-accordion-body">
         <table class="form-layout-compressed" >
           <tr class="crm-payment-form-block-trxn_date">
@@ -103,7 +103,7 @@
       </div>
       {/if}
       {include file='CRM/Core/BillingBlockWrapper.tpl' currency=false}
-    </div>
+    </details>
 
     {literal}
     <script type="text/javascript">

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -329,10 +329,10 @@
           // bind first click of accordion header to load crm-accordion-body with snippet
           // everything else taken care of by cj().crm-accordions()
           cj('#adjust-option-type').hide();
-          cj('.crm-ajax-accordion .crm-accordion-header').one('click', function() {
+          cj('.crm-ajax-accordion summary').one('click', function() {
             loadPanes(cj(this).attr('id'));
           });
-          cj('.crm-ajax-accordion:not(.collapsed) .crm-accordion-header').each(function(index) {
+          cj('.crm-ajax-accordion[open] summary').each(function(index) {
             loadPanes(cj(this).attr('id'));
           });
         });

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -402,17 +402,15 @@
         {/if}
       </script>
 
-      <div class="accordion ui-accordion ui-widget ui-helper-reset">
-        {* Additional Detail / Honoree Information / Premium Information *}
-        {foreach from=$allPanes key=paneName item=paneValue}
-          <details class="crm-accordion-bold crm-ajax-accordion crm-{$paneValue.id}-accordion" {if $paneValue.open neq 'true'}{else}open{/if}>
-            <summary  id="{$paneValue.id}">{$paneName}</summary>
-            <div class="crm-accordion-body">
-              <div class="{$paneValue.id}"></div>
-            </div><!-- /.crm-accordion-body -->
-          </details>
-        {/foreach}
-      </div>
+      {* Additional Detail / Honoree Information / Premium Information *}
+      {foreach from=$allPanes key=paneName item=paneValue}
+        <details class="crm-accordion-bold crm-ajax-accordion crm-{$paneValue.id}-accordion" {if $paneValue.open neq 'true'}{else}open{/if}>
+          <summary  id="{$paneValue.id}">{$paneName}</summary>
+          <div class="crm-accordion-body">
+            <div class="{$paneValue.id}"></div>
+          </div><!-- /.crm-accordion-body -->
+        </details>
+      {/foreach}
     {/if}
     {if $billing_address}
       <fieldset>

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -408,7 +408,7 @@
           <summary  id="{$paneValue.id}">{$paneName}</summary>
           <div class="crm-accordion-body">
             <div class="{$paneValue.id}"></div>
-          </div><!-- /.crm-accordion-body -->
+          </div>
         </details>
       {/foreach}
     {/if}

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -258,10 +258,10 @@
 
     <!-- start of soft credit -->
     {if !$payNow}
-      <div class="crm-accordion-wrapper crm-accordion_title-accordion crm-accordion-processed {if $noSoftCredit}collapsed{/if}" id="softCredit">
-        <div class="crm-accordion-header">
+      <details class="crm-accordion-bold crm-accordion_title-accordion crm-accordion-processed" id="softCredit" {if $noSoftCredit}{else}open{/if}>
+        <summary>
           {ts}Soft Credit{/ts}&nbsp;{help id="id-soft_credit"}
-        </div>
+        </summary>
         <div class="crm-accordion-body">
           <table class="form-layout-compressed">
             <tr class="crm-contribution-form-block-soft_credit_to">
@@ -271,16 +271,16 @@
             </tr>
           </table>
         </div>
-      </div>
+      </details>
     {/if}
     <!-- end of soft credit -->
 
     <!-- start of PCP -->
     {if array_key_exists('pcp_made_through_id', $form) && !$payNow}
-      <div class="crm-accordion-wrapper crm-accordion_title-accordion crm-accordion-processed {if $noPCP}collapsed{/if}" id="pcp">
-        <div class="crm-accordion-header">
+      <details class="crm-accordion-bold crm-accordion_title-accordion crm-accordion-processed" id="pcp" {if $noPCP}{else}open{/if}>
+        <summary>
           {ts}Personal Campaign Page{/ts}&nbsp;{help id="id-pcp"}
-        </div>
+        </summary>
         <div class="crm-accordion-body">
           <table class="form-layout-compressed">
             <tr class="crm-contribution-pcp-block crm-contribution-form-block-pcp_made_through_id">
@@ -310,7 +310,7 @@
             </tr>
           </table>
         </div>
-      </div>
+      </details>
       {include file="CRM/Contribute/Form/PCP.js.tpl"}
     {/if}
     <!-- end of PCP -->
@@ -405,12 +405,12 @@
       <div class="accordion ui-accordion ui-widget ui-helper-reset">
         {* Additional Detail / Honoree Information / Premium Information *}
         {foreach from=$allPanes key=paneName item=paneValue}
-          <div class="crm-accordion-wrapper crm-ajax-accordion crm-{$paneValue.id}-accordion {if $paneValue.open neq 'true'}collapsed{/if}">
-            <div class="crm-accordion-header" id="{$paneValue.id}">{$paneName}</div>
+          <details class="crm-accordion-bold crm-ajax-accordion crm-{$paneValue.id}-accordion" {if $paneValue.open neq 'true'}{else}open{/if}>
+            <summary  id="{$paneValue.id}">{$paneName}</summary>
             <div class="crm-accordion-body">
               <div class="{$paneValue.id}"></div>
             </div><!-- /.crm-accordion-body -->
-          </div><!-- /.crm-accordion-wrapper -->
+          </details>
         {/foreach}
       </div>
     {/if}

--- a/templates/CRM/Contribute/Form/ContributionPage/Premium.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Premium.tpl
@@ -103,7 +103,6 @@
           </tr>
         </table>
       </div>
-      <!-- /.crm-accordion-body -->
     </details>
 
     {* include premium product templates *}

--- a/templates/CRM/Contribute/Form/ContributionPage/Premium.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Premium.tpl
@@ -21,10 +21,10 @@
   </table>
 
   <div id="premiumSettings">
-    <div class="crm-accordion-wrapper crm-premium-settings-accordion collapsed">
-      <div class="crm-accordion-header">
+    <details class="crm-accordion-bold crm-premium-settings-accordion">
+      <summary>
         {ts}Premiums Settings{/ts}
-      </div>
+      </summary>
       <div class="crm-accordion-body">
         <table class="form-layout-compressed">
           <tr class="crm-contribution-contributionpage-premium-form-block-premiums_intro_title">
@@ -104,8 +104,7 @@
         </table>
       </div>
       <!-- /.crm-accordion-body -->
-    </div>
-    <!-- /.crm-accordion-wrapper -->
+    </details>
 
     {* include premium product templates *}
     {include file="CRM/Contribute/Page/Premium.tpl"}

--- a/templates/CRM/Contribute/Form/ContributionPage/Widget.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Widget.tpl
@@ -79,10 +79,10 @@
         </div>
 
 
-        <div class="crm-accordion-wrapper collapsed crm-case-roles-block">
-         <div class="crm-accordion-header">
+        <details class="crm-accordion-bold crm-case-roles-block">
+         <summary>
           {ts}Edit Widget Colors{/ts}
-         </div><!-- /.crm-accordion-header -->
+         </summary>
          <div class="crm-accordion-body">
             <table class="form-layout-compressed">
             {foreach from=$colorFields item=field key=fieldName}
@@ -90,7 +90,7 @@
             {/foreach}
             </table>
          </div><!-- /.crm-accordion-body -->
-        </div><!-- /.crm-accordion-wrapper -->
+        </details>
 
     </div>
 

--- a/templates/CRM/Contribute/Form/ContributionPage/Widget.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Widget.tpl
@@ -89,7 +89,7 @@
               <tr><td class="label">{$form.$fieldName.label}<span class="crm-marker"> *</span></td><td>{$form.$fieldName.html}</td></tr>
             {/foreach}
             </table>
-         </div><!-- /.crm-accordion-body -->
+         </div>
         </details>
 
     </div>

--- a/templates/CRM/Contribute/Form/ContributionView.tpl
+++ b/templates/CRM/Contribute/Form/ContributionView.tpl
@@ -194,10 +194,10 @@
 </table>
 
 {if $softContributions && count($softContributions)} {* We show soft credit name with PCP section if contribution is linked to a PCP. *}
-  <div class="crm-accordion-wrapper crm-soft-credit-pane">
-    <div class="crm-accordion-header">
+  <details class="crm-accordion-bold crm-soft-credit-pane" open>
+    <summary>
       {ts}Soft Credit{/ts}
-    </div>
+    </summary>
     <div class="crm-accordion-body">
       <table class="crm-info-panel crm-soft-credit-listing">
         {foreach from=$softContributions item="softCont"}
@@ -216,14 +216,14 @@
         {/foreach}
       </table>
     </div>
-  </div>
+  </details>
 {/if}
 
 {if $premium}
-  <div class="crm-accordion-wrapper ">
-    <div class="crm-accordion-header">
+  <details class="crm-accordion-bold " open>
+    <summary>
       {ts}Premium Information{/ts}
-    </div>
+    </summary>
     <div class="crm-accordion-body">
       <table class="crm-info-panel">
         <td class="label">{ts}Premium{/ts}</td>
@@ -234,14 +234,14 @@
         <td>{$fulfilled|truncate:10:''|crmDate}</td>
       </table>
     </div>
-  </div>
+  </details>
 {/if}
 
 {if $pcp_id}
-  <div id='PCPView' class="crm-accordion-wrapper ">
-    <div class="crm-accordion-header">
+  <details id='PCPView' class="crm-accordion-bold " open>
+    <summary>
       {ts}Personal Campaign Page Contribution Information{/ts}
-    </div>
+    </summary>
     <div class="crm-accordion-body">
       <table class="crm-info-panel">
         <tr>
@@ -273,7 +273,7 @@
         {/if}
       </table>
     </div>
-  </div>
+  </details>
 {/if}
 
 {include file="CRM/Custom/Page/CustomDataView.tpl"}

--- a/templates/CRM/Contribute/Form/Search.tpl
+++ b/templates/CRM/Contribute/Form/Search.tpl
@@ -11,10 +11,10 @@
 {assign var="showBlock" value="'searchForm'"}
 {assign var="hideBlock" value="'searchForm_show'"}
 <div class="crm-block crm-form-block crm-contribution-search-form-block">
-  <div class="crm-accordion-wrapper crm-contribution_search_form-accordion {if $rows}collapsed{/if}">
-      <div class="crm-accordion-header crm-master-accordion-header">
+  <details class="crm-accordion-light crm-contribution_search_form-accordion" {if $rows}{else}open{/if}>
+      <summary>
           {ts}Edit Search Criteria{/ts}
-       </div><!-- /.crm-accordion-header -->
+       </summary>
       <div class="crm-accordion-body">
         {strip}
           <table class="form-layout">
@@ -26,7 +26,7 @@
             </table>
         {/strip}
       </div><!-- /.crm-accordion-body -->
-    </div><!-- /.crm-accordion-wrapper -->
+    </details>
 </div><!-- /.crm-form-block -->
 {if $rowsEmpty || $rows}
 <div class="crm-content-block">

--- a/templates/CRM/Contribute/Form/Search.tpl
+++ b/templates/CRM/Contribute/Form/Search.tpl
@@ -25,7 +25,7 @@
             </tr>
             </table>
         {/strip}
-      </div><!-- /.crm-accordion-body -->
+      </div>
     </details>
 </div><!-- /.crm-form-block -->
 {if $rowsEmpty || $rows}

--- a/templates/CRM/Contribute/Form/Search/ContributionRecur.tpl
+++ b/templates/CRM/Contribute/Form/Search/ContributionRecur.tpl
@@ -78,7 +78,6 @@
       {/if}
     </table>
   </div>
-<!-- /.crm-accordion-body -->
 </details>
 
 

--- a/templates/CRM/Contribute/Form/Search/ContributionRecur.tpl
+++ b/templates/CRM/Contribute/Form/Search/ContributionRecur.tpl
@@ -8,8 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 
-<div class="crm-accordion-wrapper crm-contactDetails-accordion
-   {if empty($contribution_recur_pane_open)} collapsed{/if}" id="contribution_recur">
+<div class="crm-accordion-wrapper crm-contactDetails-accordion {if empty($contribution_recur_pane_open)} collapsed{/if}" id="contribution_recur">
   <div class="crm-accordion-header">
     {ts}Recurring Contributions{/ts}
   </div>

--- a/templates/CRM/Contribute/Form/Search/ContributionRecur.tpl
+++ b/templates/CRM/Contribute/Form/Search/ContributionRecur.tpl
@@ -8,10 +8,10 @@
  +--------------------------------------------------------------------+
 *}
 
-<div class="crm-accordion-wrapper crm-contactDetails-accordion {if empty($contribution_recur_pane_open)} collapsed{/if}" id="contribution_recur">
-  <div class="crm-accordion-header">
+<details class="crm-accordion-bold crm-contactDetails-accordion" id="contribution_recur" {if empty($contribution_recur_pane_open)}{else}open{/if}>
+  <summary>
     {ts}Recurring Contributions{/ts}
-  </div>
+  </summary>
   <div class="crm-accordion-body">
     <table class="form-layout-compressed">
       <tr>
@@ -79,6 +79,6 @@
     </table>
   </div>
 <!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 
 

--- a/templates/CRM/Contribute/Form/Task/PDFLetter.tpl
+++ b/templates/CRM/Contribute/Form/Task/PDFLetter.tpl
@@ -40,7 +40,7 @@
         <td>{$form.from_email_address.html}</td>
       </tr>
     </table>
-  </div><!-- /.crm-accordion-body -->
+  </div>
 </details>
 
 {include file="CRM/Contact/Form/Task/PDFLetterCommon.tpl"}

--- a/templates/CRM/Contribute/Form/Task/PDFLetter.tpl
+++ b/templates/CRM/Contribute/Form/Task/PDFLetter.tpl
@@ -13,10 +13,10 @@
     <div class="messages status no-popup">{include file="CRM/Contribute/Form/Task.tpl"}</div>
 {/if}
 
-<div class="crm-accordion-wrapper crm-html_email-accordion ">
-  <div class="crm-accordion-header">
+<details class="crm-accordion-bold crm-html_email-accordion " open>
+  <summary>
     {$form.more_options_header.html}
-  </div><!-- /.crm-accordion-header -->
+  </summary>
   <div class="crm-accordion-body">
     <table class="form-layout-compressed">
       <tr><td class="label-left">{$form.thankyou_update.html} {$form.thankyou_update.label}</td><td></td></tr>
@@ -41,7 +41,7 @@
       </tr>
     </table>
   </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 
 {include file="CRM/Contact/Form/Task/PDFLetterCommon.tpl"}
 

--- a/templates/CRM/Contribute/Page/ContributionRecurPayments.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecurPayments.tpl
@@ -1,6 +1,6 @@
 {if $contributionsCount > 0}
-  <div class="crm-accordion-wrapper">
-    <div class="crm-accordion-header">{ts}Related Contributions{/ts}</div>
+  <details class="crm-accordion-bold" open>
+    <summary>{ts}Related Contributions{/ts}</summary>
     <div class="crm-accordion-body">
       <table class="crm-contact-contributions">
         <thead>
@@ -33,7 +33,7 @@
         {/literal}
       </script>
     </div>
-  </div>
+  </details>
 {else}
   <div class="messages status no-popup">
     {icon icon="fa-info-circle"}{/icon}

--- a/templates/CRM/Core/Form/RecurringEntity.tpl
+++ b/templates/CRM/Core/Form/RecurringEntity.tpl
@@ -8,10 +8,10 @@
  +--------------------------------------------------------------------+
 *}
 
-<div class="crm-core-form-recurringentity-block crm-accordion-wrapper{if $recurringFormIsEmbedded && !$scheduleReminderId} collapsed{/if}" id="recurring-entity-block">
-  <div class="crm-accordion-header">
+<details class="crm-core-form-recurringentity-block crm-accordion-bold" id="recurring-entity-block" {if $recurringFormIsEmbedded && !$scheduleReminderId}{else}open{/if}>
+  <summary>
     {ts 1=$recurringEntityType}Repeat %1{/ts}
-  </div>
+  </summary>
   <div class="crm-accordion-body">
     <table class="form-layout-compressed">
       <tr class="crm-core-form-recurringentity-block-repetition_frequency">
@@ -60,7 +60,7 @@
       </div>
     {/if}
   </div>
-</div>
+</details>
 {literal}
 <script type="text/javascript">
 (function (_) {

--- a/templates/CRM/Custom/Form/CustomData.tpl
+++ b/templates/CRM/Custom/Form/CustomData.tpl
@@ -21,16 +21,16 @@
         {include file="CRM/Custom/Form/Edit/CustomData.tpl" customDataEntity=''}
       </div>
     {else}
-     <div class="custom-group custom-group-{$cd_edit.name} crm-accordion-wrapper crm-custom-accordion {if $cd_edit.collapse_display and empty($skipTitle)}collapsed{/if}">
+     <details class="custom-group custom-group-{$cd_edit.name} crm-accordion-bold crm-custom-accordion" {if $cd_edit.collapse_display and empty($skipTitle)}{else}open{/if}>
       {if empty($skipTitle)}
-      <div class="crm-accordion-header">
+      <summary>
         {$cd_edit.title}
-       </div><!-- /.crm-accordion-header -->
+       </summary>
       {/if}
       <div class="crm-accordion-body">
         {include file="CRM/Custom/Form/Edit/CustomData.tpl" customDataEntity=''}
       </div>
-     </div>
+     </details>
     {/if}
     {if $cgCount}
       <div id="custom_group_{$group_id}_{$cgCount}"></div>

--- a/templates/CRM/Custom/Form/Search.tpl
+++ b/templates/CRM/Custom/Form/Search.tpl
@@ -10,10 +10,10 @@
 {if $groupTree}
 {foreach from=$groupTree item=cd_edit key=group_id}
 
-  <div class="crm-accordion-wrapper crm-contactDetails-accordion {if $form.formName eq 'Advanced' AND $cd_edit.collapse_adv_display eq 1}collapsed{/if}" id="{$cd_edit.name}" >
-    <div class="crm-accordion-header">
+  <details class="crm-accordion-bold crm-contactDetails-accordion" id="{$cd_edit.name}"  {if $form.formName eq 'Advanced' AND $cd_edit.collapse_adv_display eq 1}{else}open{/if}>
+    <summary>
         {$cd_edit.title}
-    </div>
+    </summary>
     <div class="crm-accordion-body">
     <table class="form-layout-compressed">
     {foreach from=$cd_edit.fields item=element key=field_id}
@@ -49,7 +49,7 @@
       {/foreach}
      </table>
     </div><!-- /.crm-accordion-body -->
-  </div><!-- /.crm-accordion-wrapper -->
+  </details>
 
 {/foreach}
   {if !empty($add_multivalue_js)}

--- a/templates/CRM/Custom/Form/Search.tpl
+++ b/templates/CRM/Custom/Form/Search.tpl
@@ -48,7 +48,7 @@
           </tr>
       {/foreach}
      </table>
-    </div><!-- /.crm-accordion-body -->
+    </div>
   </details>
 
 {/foreach}

--- a/templates/CRM/Custom/Page/CustomDataView.tpl
+++ b/templates/CRM/Custom/Page/CustomDataView.tpl
@@ -31,11 +31,11 @@
       {assign var="showEdit" value=0}
       <tr>
         <td id="{$cd_edit.name}_{$index}" class="section-shown form-item">
-          <div class="crm-accordion-wrapper{if !empty($cd_edit.collapse_display) && empty($skipTitle)} collapsed{/if}">
+          <details class="crm-accordion-bold" {if !empty($cd_edit.collapse_display) && empty($skipTitle)}{else}open{/if}>
             {if !$skipTitle}
-              <div class="crm-accordion-header">
+              <summary>
                 {$cd_edit.title}
-              </div>
+              </summary>
             {/if}
             <div class="crm-accordion-body">
               {if $groupId and $cvID and $editPermission and $cd_edit.editable}
@@ -83,7 +83,7 @@
             </div>
             <!-- end of body -->
             <div class="clear"></div>
-          </div>
+          </details>
           <!-- end of main accordion -->
         </td>
       </tr>

--- a/templates/CRM/Event/Form/ManageEvent/Repeat.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Repeat.tpl
@@ -10,8 +10,8 @@
 <div class="crm-block crm-form-block crm-event-manage-repeat-form-block">
 {include file="CRM/Core/Form/RecurringEntity.tpl" recurringFormIsEmbedded=false}
 {if $rows}
-<div class="crm-block crm-manage-events crm-accordion-wrapper">
-  <div class="crm-accordion-header">{ts}Connected Repeating Events{/ts}</div>
+<details class="crm-block crm-manage-events crm-accordion-bold" open>
+  <summary>{ts}Connected Repeating Events{/ts}</summary>
   <div class="crm-accordion-body">
   {strip}
   {include file="CRM/common/jsortable.tpl"}
@@ -57,6 +57,6 @@
     </table>
   {/strip}
   </div>
-</div>
+</details>
 {/if}
 </div>

--- a/templates/CRM/Event/Form/Search.tpl
+++ b/templates/CRM/Event/Form/Search.tpl
@@ -11,10 +11,10 @@
 {assign var="showBlock" value="'searchForm'"}
 {assign var="hideBlock" value="'searchForm_show'"}
 <div class="crm-block crm-form-block crm-event-search-form-block">
-<div class="crm-accordion-wrapper crm-advanced_search_form-accordion {if !empty($ssID) or $rows}collapsed{/if}">
- <div class="crm-accordion-header crm-master-accordion-header">
+<details class="crm-accordion-light crm-advanced_search_form-accordion" {if !empty($ssID) or $rows}{else}open{/if}>
+ <summary>
         {ts}Edit Search Criteria{/ts}
-  </div>
+  </summary>
  <div class="crm-accordion-body">
 <div id="searchForm">
     {strip}
@@ -30,7 +30,7 @@
     {/strip}
 </div>
 </div>
-</div>
+</details>
 </div>
 {if $rowsEmpty|| $rows}
 <div class="crm-block crm-content-block">

--- a/templates/CRM/Event/Form/SearchEvent.tpl
+++ b/templates/CRM/Event/Form/SearchEvent.tpl
@@ -7,10 +7,10 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-  <div class="crm-accordion-wrapper crm-block crm-form-block crm-event-searchevent-form-block">
-    <div class="crm-accordion-header">
+  <details class="crm-accordion-bold crm-block crm-form-block crm-event-searchevent-form-block" open>
+    <summary>
       {ts}Find Events{/ts}
-    </div>
+    </summary>
     <div class="crm-accordion-body">
   <table class="form-layout">
     <tr class="crm-event-searchevent-form-block-title">
@@ -47,7 +47,7 @@
     <td class="right">{include file="CRM/common/formButtons.tpl" location=''}</td>
   </table>
     </div>
-  </div>
+  </details>
 
 {include file="CRM/common/showHide.tpl"}
 

--- a/templates/CRM/Financial/Form/BatchTransaction.tpl
+++ b/templates/CRM/Financial/Form/BatchTransaction.tpl
@@ -10,10 +10,10 @@
 {* this template is used for batch transaction screen, assign/remove transactions to batch  *}
 {if in_array($batchStatus, array('Open', 'Reopened'))}
 <div class="crm-form-block crm-search-form-block">
-  <div class="crm-accordion-wrapper crm-batch_transaction_search-accordion collapsed">
-    <div class="crm-accordion-header crm-master-accordion-header">
+  <details class="crm-accordion-light crm-batch_transaction_search-accordion">
+    <summary>
       {ts}Edit Search Criteria{/ts}
-    </div>
+    </summary>
     <div class="crm-accordion-body">
       <div id="searchForm" class="crm-block crm-form-block crm-contact-custom-search-activity-search-form-block">
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
@@ -46,7 +46,7 @@
 	<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
       </div>
     </div>
-  </div>
+  </details>
 </div>
 {if in_array($batchStatus, array('Open', 'Reopened'))}
 <div class="form-layout-compressed">{$form.trans_assign.html}&nbsp;{$form.submit.html}</div><br/>

--- a/templates/CRM/Financial/Form/BatchTransaction.tpl
+++ b/templates/CRM/Financial/Form/BatchTransaction.tpl
@@ -81,7 +81,7 @@
 <script type="text/javascript">
 CRM.$(function($) {
   CRM.$('#_qf_BatchTransaction_submit-top, #_qf_BatchTransaction_submit-bottom').click(function() {
-    CRM.$('.crm-batch_transaction_search-accordion:not(.collapsed)').crmAccordionToggle();
+    CRM.$('.crm-batch_transaction_search-accordion[open]').prop('open', false);
   });
   var batchStatus = {/literal}{$statusID}{literal};
   {/literal}{if $validStatus}{literal}

--- a/templates/CRM/Financial/Form/FinancialAccount.tpl
+++ b/templates/CRM/Financial/Form/FinancialAccount.tpl
@@ -75,9 +75,9 @@
       </td>
     </tr>
   </table>
-  <div id="financial_account_custom_field_extension_section" class="crm-accordion-wrapper crm-financial-account-panel">
+  <details id="financial_account_custom_field_extension_section" class="crm-accordion-wrapper crm-financial-account-panel" open>
   {include file="CRM/Custom/Form/CustomData.tpl"}
-  </div>
+  </details>
 {/if}
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="botttom"}</div>
 </div>

--- a/templates/CRM/Financial/Form/Search.tpl
+++ b/templates/CRM/Financial/Form/Search.tpl
@@ -14,10 +14,10 @@
   <a accesskey="N" href="{crmURL p='civicrm/financial/batch' q="reset=1&action=add&context=$batchStatus"}" id="newBatch" class="button"><span><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}New Accounting Batch{/ts}</span></a>
 </div>
 <div class="crm-form-block crm-search-form-block">
-  <div class="crm-accordion-wrapper crm-activity_search-accordion">
-    <div class="crm-accordion-header">
+  <details class="crm-accordion-bold crm-activity_search-accordion" open>
+    <summary>
       {ts}Filter Results{/ts}
-    </div>
+    </summary>
     <div class="crm-accordion-body">
       <div id="financial-search-form" class="crm-block crm-form-block">
         <table class="form-layout-compressed">
@@ -33,7 +33,7 @@
         </table>
       </div>
     </div>
-  </div>
+  </details>
 </div>
 {if !empty($form.batch_update)}<div class="form-layout-compressed">{$form.batch_update.html}&nbsp;{$form.submit.html}</div><br/>{/if}
 <table id="crm-batch-selector-{$batchStatus}" class="row-highlight">

--- a/templates/CRM/Form/attachment.tpl
+++ b/templates/CRM/Form/attachment.tpl
@@ -109,7 +109,7 @@
       {/if}
       </table>
     </div>
-  </div><!-- /.crm-accordion-body -->
+  </div>
   </details>
     {literal}
     <script type="text/javascript">

--- a/templates/CRM/Form/attachment.tpl
+++ b/templates/CRM/Form/attachment.tpl
@@ -32,10 +32,10 @@
     {else}
       {capture assign=attachTitle}{ts}Attachment(s){/ts}{/capture}
     {/if}
-    <div class="crm-accordion-wrapper {if (!$context || $context NEQ 'pcpCampaign') AND !$currentAttachmentInfo}collapsed{/if}">
-     <div class="crm-accordion-header">
+    <details class="crm-accordion-bold" {if (!$context || $context NEQ 'pcpCampaign') AND !$currentAttachmentInfo}{else}open{/if}>
+     <summary>
       {$attachTitle}
-     </div><!-- /.crm-accordion-header -->
+     </summary>
     <div class="crm-accordion-body">
     <div id="attachments">
       <table class="form-layout-compressed">
@@ -110,7 +110,7 @@
       </table>
     </div>
   </div><!-- /.crm-accordion-body -->
-  </div><!-- /.crm-accordion-wrapper -->
+  </details>
     {literal}
     <script type="text/javascript">
       CRM.$(function($) {

--- a/templates/CRM/Group/Form/Search.tpl
+++ b/templates/CRM/Group/Form/Search.tpl
@@ -8,10 +8,10 @@
  +--------------------------------------------------------------------+
 *}
 <div class="crm-block crm-form-block crm-group-search-form-block">
-  <div class="crm-accordion-wrapper crm-search_builder-accordion">
-    <div class="crm-accordion-header crm-master-accordion-header">
+  <details class="crm-accordion-light crm-search_builder-accordion" open>
+    <summary>
       {ts}Find Groups{/ts}
-    </div>
+    </summary>
     <div class="crm-accordion-body">
       <div id="searchForm">
         <table class="form-layout">
@@ -63,7 +63,7 @@
         </table>
       </div>
     </div>
-  </div>
+  </details>
 <div class="css_right">
   <a class="crm-hover-button action-item" href="{crmURL q="reset=1&update_smart_groups=1"}">{ts}Update Smart Group Counts{/ts}</a> {help id="update_smart_groups"}
 </div>

--- a/templates/CRM/Mailing/Form/Approve.tpl
+++ b/templates/CRM/Mailing/Form/Approve.tpl
@@ -24,10 +24,10 @@
 </table>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>
 
-<div class="crm-accordion-wrapper crm-plain_text_email-accordion collapsed">
-    <div class="crm-accordion-header">
+<details class="crm-accordion-bold crm-plain_text_email-accordion">
+    <summary>
         {ts}Preview Mailing{/ts}
-    </div><!-- /.crm-accordion-header -->
+    </summary>
     <div class="crm-accordion-body">
         <table class="form-layout">
           <tr class="crm-mailing-test-form-block-subject"><td class="label">{ts}Subject:{/ts}</td><td>{$preview.subject}</td></tr>
@@ -39,6 +39,6 @@
           {/if}
         </table>
     </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 
 </div>

--- a/templates/CRM/Mailing/Form/Approve.tpl
+++ b/templates/CRM/Mailing/Form/Approve.tpl
@@ -38,7 +38,7 @@
     <tr><td class="label">{if $preview.type eq 'html'}{ts}Mailing HTML:{/ts}{else}{ts}Mailing Text:{/ts}{/if}</td><td><iframe height="300" src="{$preview.viewURL}" width="80%"><a href="{$preview.viewURL}" onclick="window.open(this.href); return false;">{ts}Mailing Text:{/ts}</a></iframe></td></tr>
           {/if}
         </table>
-    </div><!-- /.crm-accordion-body -->
+    </div>
 </details>
 
 </div>

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -207,8 +207,8 @@
       </table>
       {include file="CRM/common/customDataBlock.tpl"}
       {if $accessContribution and $action eq 2 and $rows.0.contribution_id}
-        <div class="crm-accordion-wrapper">
-          <div class="crm-accordion-header">{ts}Related Contributions{/ts}</div>
+        <details class="crm-accordion-bold" open>
+          <summary>{ts}Related Contributions{/ts}</summary>
           <div class="crm-accordion-body">
             {include file="CRM/Contribute/Form/Selector.tpl" context="Search"}
             <script type="text/javascript">
@@ -236,13 +236,13 @@
             </script>
             <div id="membership-recurring-contributions"></div>
           </div>
-        </div>
+        </details>
       {/if}
       {if $softCredit}
-        <div class="crm-accordion-wrapper">
-          <div class="crm-accordion-header">{ts}Related Soft Contributions{/ts}</div>
+        <details class="crm-accordion-bold" open>
+          <summary>{ts}Related Soft Contributions{/ts}</summary>
           <div class="crm-accordion-body">{include file="CRM/Contribute/Page/ContributionSoft.tpl" context="membership"}</div>
-       </div>
+       </details>
       {/if}
     {/if}
 

--- a/templates/CRM/Member/Form/MembershipView.tpl
+++ b/templates/CRM/Member/Form/MembershipView.tpl
@@ -64,10 +64,10 @@
     {include file="CRM/Custom/Page/CustomDataView.tpl"}
 
     {if $accessContribution}
-      <div class="crm-accordion-wrapper">
-        <div class="crm-accordion-header">
+      <details class="crm-accordion-bold" open>
+        <summary>
           {ts}Related Contributions and Recurring Contributions{/ts}
-        </div>
+        </summary>
         <div class="crm-accordion-body">
           {if $rows.0.contribution_id}
             {include file="CRM/Contribute/Form/Selector.tpl" context="Search"}
@@ -97,14 +97,14 @@
           </script>
           <div id="membership-recurring-contributions"></div>
         </div>
-      </div>
+      </details>
     {/if}
 
     {if $softCredit}
-        <div class="crm-accordion-wrapper">
-            <div class="crm-accordion-header">{ts}Related Soft Contributions{/ts}</div>
+        <details class="crm-accordion-bold" open>
+            <summary>{ts}Related Soft Contributions{/ts}</summary>
             <div class="crm-accordion-body">{include file="CRM/Contribute/Page/ContributionSoft.tpl" context="membership"}</div>
-        </div>
+        </details>
     {/if}
 
     {if $has_related}

--- a/templates/CRM/Member/Form/Search.tpl
+++ b/templates/CRM/Member/Form/Search.tpl
@@ -8,10 +8,10 @@
  +--------------------------------------------------------------------+
 *}
 <div class="crm-form-block crm-search-form-block">
-  <div class="crm-accordion-wrapper crm-member_search_form-accordion {if $rows}collapsed{/if}">
-   <div class="crm-accordion-header crm-master-accordion-header">
+  <details class="crm-accordion-light crm-member_search_form-accordion" {if $rows}{else}open{/if}>
+   <summary>
       {ts}Edit Search Criteria{/ts}
-    </div><!-- /.crm-accordion-header -->
+    </summary>
   <div class="crm-accordion-body">
   {strip}
        <table class="form-layout">
@@ -24,7 +24,7 @@
       </table>
   {/strip}
    </div><!-- /.crm-accordion-body -->
-  </div><!-- /.crm-accordion-wrapper -->
+  </details>
 </div><!-- /.crm-form-block -->
 <div class="crm-content-block">
   {if $rowsEmpty}

--- a/templates/CRM/Member/Form/Search.tpl
+++ b/templates/CRM/Member/Form/Search.tpl
@@ -23,7 +23,7 @@
           </tr>
       </table>
   {/strip}
-   </div><!-- /.crm-accordion-body -->
+   </div>
   </details>
 </div><!-- /.crm-form-block -->
 <div class="crm-content-block">

--- a/templates/CRM/Pledge/Form/Pledge.tpl
+++ b/templates/CRM/Pledge/Form/Pledge.tpl
@@ -179,7 +179,7 @@
   </summary>
  <div class="crm-accordion-body">
        <div class="{$paneValue.id}"></div>
- </div><!-- /.crm-accordion-body -->
+ </div>
 </details>
 
 {/foreach}

--- a/templates/CRM/Pledge/Form/Pledge.tpl
+++ b/templates/CRM/Pledge/Form/Pledge.tpl
@@ -134,13 +134,13 @@
   // bind first click of accordion header to load crm-accordion-body with snippet
   // everything else taken care of by $().crm-accordions()
   CRM.$(function($) {
-    $('.crm-ajax-accordion .crm-accordion-header').one('click', function() {
+    $('.crm-ajax-accordion summary').one('click', function() {
       loadPanes($(this).attr('id'));
     });
     $('#currency').on('change', function() {
       replaceCurrency($('#currency option:selected').text());
     });
-    $('.crm-ajax-accordion:not(.collapsed) .crm-accordion-header').each(function(index) {
+    $('.crm-ajax-accordion[open] summary').each(function(index) {
       loadPanes($(this).attr('id'));
     });
 

--- a/templates/CRM/Pledge/Form/Pledge.tpl
+++ b/templates/CRM/Pledge/Form/Pledge.tpl
@@ -173,14 +173,14 @@
 
 <div class="accordion ui-accordion ui-widget ui-helper-reset">
 {foreach from=$allPanes key=paneName item=paneValue}
-<div class="crm-accordion-wrapper crm-ajax-accordion crm-{$paneValue.id}-accordion {if $paneValue.open neq 'true'}collapsed{/if}">
-<div class="crm-accordion-header" id="{$paneValue.id}">
+<details class="crm-accordion-bold crm-ajax-accordion crm-{$paneValue.id}-accordion" {if $paneValue.open neq 'true'}{else}open{/if}>
+<summary  id="{$paneValue.id}">
         {$paneName}
-  </div><!-- /.crm-accordion-header -->
+  </summary>
  <div class="crm-accordion-body">
        <div class="{$paneValue.id}"></div>
  </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 
 {/foreach}
 </div>

--- a/templates/CRM/Pledge/Form/Search.tpl
+++ b/templates/CRM/Pledge/Form/Search.tpl
@@ -9,10 +9,10 @@
 *}
 {* Search form and results for Event Participants *}
 <div class="crm-form-block crm-search-form-block">
-<div class="crm-accordion-wrapper crm-advanced_search_form-accordion {if $rowsEmpty or $rows}collapsed{/if}">
- <div class="crm-accordion-header crm-master-accordion-header">
+<details class="crm-accordion-light crm-advanced_search_form-accordion" {if $rowsEmpty or $rows}{else}open{/if}>
+ <summary>
         {ts}Edit Search Criteria{/ts}
- </div><!-- /.crm-accordion-header -->
+ </summary>
  <div class="crm-accordion-body">
 
 <div id="searchForm">
@@ -28,7 +28,7 @@
     {/strip}
   </div>
 </div>
-</div>
+</details>
 </div>
 
 {if $rowsEmpty || $rows}

--- a/templates/CRM/Profile/Form/Search.tpl
+++ b/templates/CRM/Profile/Form/Search.tpl
@@ -9,10 +9,10 @@
 *}
 {if ! empty($fields)}
   {if $groupId}
-  <div class="crm-accordion-wrapper crm-group-{$groupId}-accordion {if $rows}collapsed{/if}">
-    <div class="crm-accordion-header crm-master-accordion-header">
+  <details class="crm-accordion-light crm-group-{$groupId}-accordion" {if $rows}{else}open{/if}>
+    <summary>
       {ts}Edit Search Criteria{/ts}
-    </div>
+    </summary>
   <div class="crm-accordion-body">
     {else}
   <div>
@@ -84,7 +84,7 @@
   {/if}
   {if $groupId}
   </div><!-- /.crm-accordion-body -->
-  </div><!-- /.crm-accordion-wrapper -->
+  </details>
   {/if}
 
 {elseif $statusMessage}

--- a/templates/CRM/Profile/Form/Search.tpl
+++ b/templates/CRM/Profile/Form/Search.tpl
@@ -83,7 +83,7 @@
   </div>
   {/if}
   {if $groupId}
-  </div><!-- /.crm-accordion-body -->
+  </div>
   </details>
   {/if}
 

--- a/templates/CRM/Profile/Form/Search.tpl
+++ b/templates/CRM/Profile/Form/Search.tpl
@@ -79,6 +79,10 @@
   </table>
 
   {if $groupId}
+  {else}
+  </div>
+  {/if}
+  {if $groupId}
   </div><!-- /.crm-accordion-body -->
   </div><!-- /.crm-accordion-wrapper -->
   {/if}

--- a/templates/CRM/Report/Form/Tabs/FieldSelection.tpl
+++ b/templates/CRM/Report/Form/Tabs/FieldSelection.tpl
@@ -13,10 +13,10 @@
       {assign  var="count" value=0}
       {* Wrap custom field sets in collapsed accordion pane. *}
       {if !empty($grpFields.use_accordian_for_field_selection)}
-        <div class="crm-accordion-wrapper crm-accordion collapsed">
-        <div class="crm-accordion-header">
+        <details class="crm-accordion-bold crm-accordion">
+        <summary>
           {$grpFields.group_title}
-        </div><!-- /.crm-accordion-header -->
+        </summary>
         <div class="crm-accordion-body">
       {/if}
       <table class="criteria-group">
@@ -35,7 +35,7 @@
       </table>
       {if !empty($grpFields.use_accordian_for_field_selection)}
         </div><!-- /.crm-accordion-body -->
-        </div><!-- /.crm-accordion-wrapper -->
+        </details>
       {/if}
     {/foreach}
   </div>

--- a/templates/CRM/Report/Form/Tabs/FieldSelection.tpl
+++ b/templates/CRM/Report/Form/Tabs/FieldSelection.tpl
@@ -34,7 +34,7 @@
         </tr>
       </table>
       {if !empty($grpFields.use_accordian_for_field_selection)}
-        </div><!-- /.crm-accordion-body -->
+        </div>
         </details>
       {/if}
     {/foreach}

--- a/templates/CRM/Report/Form/Tabs/Filters.tpl
+++ b/templates/CRM/Report/Form/Tabs/Filters.tpl
@@ -49,7 +49,7 @@
         {/foreach}
         </table>
         {if $filterGroup.use_accordion_for_field_selection}
-            </div><!-- /.crm-accordion-body -->
+            </div>
           </details>
         {/if}
       {/foreach}

--- a/templates/CRM/Report/Form/Tabs/Filters.tpl
+++ b/templates/CRM/Report/Form/Tabs/Filters.tpl
@@ -14,10 +14,10 @@
       {foreach from=$filterGroups item=filterGroup}
         {* Wrap custom field sets in collapsed accordion pane. *}
         {if $filterGroup.use_accordion_for_field_selection}
-          <div class="crm-accordion-wrapper crm-accordion collapsed">
-            <div class="crm-accordion-header">
+          <details class="crm-accordion-bold crm-accordion">
+            <summary>
               {$filterGroup.group_title}
-            </div><!-- /.crm-accordion-header -->
+            </summary>
             <div class="crm-accordion-body">
         {/if}
         <table class="report-layout">
@@ -50,7 +50,7 @@
         </table>
         {if $filterGroup.use_accordion_for_field_selection}
             </div><!-- /.crm-accordion-body -->
-          </div><!-- /.crm-accordion-wrapper -->
+          </details>
         {/if}
       {/foreach}
   </div>

--- a/templates/CRM/Report/Page/InstanceList.tpl
+++ b/templates/CRM/Report/Page/InstanceList.tpl
@@ -20,10 +20,10 @@
     <div class="crm-block crm-form-block crm-report-instanceList-form-block">
       {counter start=0 skip=1 print=false}
       {foreach from=$list item=rows key=report}
-        <div class="crm-accordion-wrapper crm-accordion_{$report}-accordion ">
-          <div class="crm-accordion-header">
+        <details class="crm-accordion-bold crm-accordion_{$report}-accordion " open>
+          <summary>
             {if $title}{$title}{elseif $report EQ 'Contribute'}{ts}Contribution Reports{/ts}{else}{ts 1=$report}%1 Reports{/ts}{/if}</a>
-          </div><!-- /.crm-accordion-header -->
+          </summary>
           <div class="crm-accordion-body">
             <div id="{$report}" class="boxBlock">
               <table class="report-layout">
@@ -48,7 +48,7 @@
               </table>
             </div>
           </div>
-        </div>
+        </details>
       {/foreach}
     </div>
 

--- a/templates/CRM/Report/Page/TemplateList.tpl
+++ b/templates/CRM/Report/Page/TemplateList.tpl
@@ -41,7 +41,7 @@
                 {/foreach}
               </table>
             </div>
-          </div><!-- /.crm-accordion-body -->
+          </div>
         </details>
       {/foreach}
     {else}

--- a/templates/CRM/Report/Page/TemplateList.tpl
+++ b/templates/CRM/Report/Page/TemplateList.tpl
@@ -17,10 +17,10 @@
     {if $list}
       {counter start=0 skip=1 print=false}
       {foreach from=$list item=rows key=report}
-        <div class="crm-accordion-wrapper crm-accordion_{$report}-accordion ">
-          <div class="crm-accordion-header">
+        <details class="crm-accordion-bold crm-accordion_{$report}-accordion " open>
+          <summary>
             {if $report}{if $report EQ 'Contribute'}{ts}Contribution{/ts}{else}{$report}{/if}{else}{ts}Contact{/ts}{/if} Report Templates
-          </div><!-- /.crm-accordion-header -->
+          </summary>
           <div class="crm-accordion-body">
             <div id="{$report}" class="boxBlock">
               <table class="report-layout">
@@ -42,7 +42,7 @@
               </table>
             </div>
           </div><!-- /.crm-accordion-body -->
-        </div><!-- /.crm-accordion-wrapper -->
+        </details>
       {/foreach}
     {else}
       <div class="messages status no-popup">

--- a/templates/CRM/SMS/Form/Group.tpl
+++ b/templates/CRM/SMS/Form/Group.tpl
@@ -23,10 +23,10 @@
 
 
 <div id="id-additional" class="form-item">
-<div class="crm-accordion-wrapper ">
- <div class="crm-accordion-header">
+<details class="crm-accordion-bold " open>
+ <summary>
 {ts}Mailing Recipients{/ts}
- </div><!-- /.crm-accordion-header -->
+ </summary>
  <div class="crm-accordion-body">
   {strip}
 
@@ -47,7 +47,7 @@
 
   {/strip}
  </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>
 </div>

--- a/templates/CRM/SMS/Form/Group.tpl
+++ b/templates/CRM/SMS/Form/Group.tpl
@@ -46,7 +46,7 @@
   </table>
 
   {/strip}
- </div><!-- /.crm-accordion-body -->
+ </div>
 </details>
 
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>

--- a/templates/CRM/SMS/Form/Schedule.tpl
+++ b/templates/CRM/SMS/Form/Schedule.tpl
@@ -38,7 +38,7 @@
     <tr><td class="label">{if $preview.type eq 'html'}{ts}SMS HTML:{/ts}{else}{ts}SMS Text:{/ts}{/if}</td><td><iframe height="300" src="{$preview.viewURL}" width="80%"><a href="{$preview.viewURL}" onclick="window.open(this.href); return false;">{ts}SMS Text:{/ts}</a></iframe></td></tr>
           {/if}
         </table>
-    </div><!-- /.crm-accordion-body -->
+    </div>
 </details>
 {/if}
 

--- a/templates/CRM/SMS/Form/Schedule.tpl
+++ b/templates/CRM/SMS/Form/Schedule.tpl
@@ -27,10 +27,10 @@
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>
 
 {if $preview}
-<div class="crm-accordion-wrapper crm-plain_text_sms-accordion collapsed">
-    <div class="crm-accordion-header">
+<details class="crm-accordion-bold crm-plain_text_sms-accordion">
+    <summary>
         {ts}Preview SMS{/ts}
-    </div><!-- /.crm-accordion-header -->
+    </summary>
     <div class="crm-accordion-body">
         <table class="form-layout">
 
@@ -39,7 +39,7 @@
           {/if}
         </table>
     </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 {/if}
 
 </div>

--- a/templates/CRM/UF/Form/AdvanceSetting.tpl
+++ b/templates/CRM/UF/Form/AdvanceSetting.tpl
@@ -86,7 +86,7 @@
         </tr>
     </table>
     </div><!-- / .crm-block -->
-  </div><!-- /.crm-accordion-body -->
+  </div>
 </details>
 {literal}
   <script type="text/javascript">

--- a/templates/CRM/UF/Form/AdvanceSetting.tpl
+++ b/templates/CRM/UF/Form/AdvanceSetting.tpl
@@ -7,10 +7,10 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-<div class="crm-accordion-wrapper collapsed">
- <div class="crm-accordion-header">
+<details class="crm-accordion-bold">
+ <summary>
     {ts}Advanced Settings{/ts}
-  </div><!-- /.crm-accordion-header -->
+  </summary>
   <div class="crm-accordion-body">
   <div class="crm-block crm-form-block crm-uf-advancesetting-form-block">
     <table class="form-layout">
@@ -87,7 +87,7 @@
     </table>
     </div><!-- / .crm-block -->
   </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 {literal}
   <script type="text/javascript">
   CRM.$(function($) {

--- a/templates/CRM/common/additionalBlocks.tpl
+++ b/templates/CRM/common/additionalBlocks.tpl
@@ -156,7 +156,7 @@ function clearFirstBlock( blockName , blockId ) {
     cj("#" + element +" input, " + "#" + element + " select").each(function () {
         cj(this).val('');
     });
-    cj("#addressBlockId:not(.collapsed)").crmAccordionToggle();
+    cj("#addressBlockId[open]").prop('open', false);
     cj("#addressBlockId .active").removeClass('active');
 }
 

--- a/templates/CRM/common/fatal.tpl
+++ b/templates/CRM/common/fatal.tpl
@@ -40,10 +40,10 @@
         <div class="crm-section crm-error-message">{$error.message|escape}</div>
     {/if}
     {if (!empty($code) || !empty($mysql_code) || !empty($errorDetails)) AND $config->debug}
-        <div class="crm-accordion-wrapper collapsed crm-fatal-error-details-block">
-         <div class="crm-accordion-header" onclick="toggle(this);";>
+        <details class="crm-accordion-bold crm-fatal-error-details-block">
+         <summary  onclick="toggle(this);";>
           {ts}Error Details{/ts}
-         </div><!-- /.crm-accordion-header -->
+         </summary>
          <div class="crm-accordion-body">
             {if !empty($code)}
                 <div class="crm-section">{ts}Error Code:{/ts} {$code|purify}</div>
@@ -55,7 +55,7 @@
                 <div class="crm-section">{ts}Additional Details:{/ts} {$errorDetails|purify}</div>
             {/if}
          </div><!-- /.crm-accordion-body -->
-        </div><!-- /.crm-accordion-wrapper -->
+        </details>
     {/if}
     <p><a href="{$config->userFrameworkBaseURL}" title="{ts}Main Menu{/ts}">{ts}Return to home page.{/ts}</a></p>
 </div>

--- a/templates/CRM/common/fatal.tpl
+++ b/templates/CRM/common/fatal.tpl
@@ -41,7 +41,7 @@
     {/if}
     {if (!empty($code) || !empty($mysql_code) || !empty($errorDetails)) AND $config->debug}
         <details class="crm-accordion-bold crm-fatal-error-details-block">
-         <summary  onclick="toggle(this);";>
+         <summary>
           {ts}Error Details{/ts}
          </summary>
          <div class="crm-accordion-body">
@@ -60,19 +60,6 @@
     <p><a href="{$config->userFrameworkBaseURL}" title="{ts}Main Menu{/ts}">{ts}Return to home page.{/ts}</a></p>
 </div>
 </div> {* end crm-container div *}
-{literal}
-<script language="JavaScript">
-function toggle( element ) {
-    var parent = element.parentNode;
-    var className = parent.className;
-    if ( className  == 'crm-accordion-wrapper collapsed crm-fatal-error-details-block') {
-        parent.className = 'crm-accordion-wrapper  crm-fatal-error-details-block';
-    } else {
-        parent.className = 'crm-accordion-wrapper collapsed crm-fatal-error-details-block';
-    }
-}
-</script>
-{/literal}
 {if $config->userFramework != 'WordPress'}
 </body>
 </html>

--- a/templates/CRM/common/fatal.tpl
+++ b/templates/CRM/common/fatal.tpl
@@ -54,7 +54,7 @@
             {if !empty($errorDetails)}
                 <div class="crm-section">{ts}Additional Details:{/ts} {$errorDetails|purify}</div>
             {/if}
-         </div><!-- /.crm-accordion-body -->
+         </div>
         </details>
     {/if}
     <p><a href="{$config->userFrameworkBaseURL}" title="{ts}Main Menu{/ts}">{ts}Return to home page.{/ts}</a></p>

--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -115,6 +115,7 @@
     if ($('#crm-notification-container').length) {
       $.each(validator.errorList, function(k, error) {
         $(error.element).parents('.crm-custom-accordion.collapsed').crmAccordionToggle();
+        $(error.element).parents('.crm-custom-accordion').prop('open', true);
         $(error.element).crmError(error.message);
       });
     }


### PR DESCRIPTION
Overview
----------------------------------------
Convert more accordions to `details`/`summary`

Before
----------------------------------------
Old style

After
----------------------------------------
New style

Technical Details
----------------------------------------
Some of these files have a `details` with a smarty conditional. In the old construct, accordions were open by default unless the `collapsed` class was included.  In the new, they are closed by default unless the `open` keyword is added. In some cases the presence of `collapsed` is determined by a smarty conditional.

This conditional needs to be preserved, but the logic reversed.  For ease of conversion, this PR does not attempt to negate the condition but uses the (inelegant but simple and existing) device of moving `open` to the other side of a smarty `{else}` - in some cases adding an `{else}`, removing it in others.  So `{if somecondition}collapsed{/if}` becomes `{if somecondition}{else}open{/if}` and `{if somecondition}{else}collapsed{/if}`becomes `{if somecondition}open{/if}`

This also changes the classes, removing `.crm-accordion-wrapper`, `.crm-accordion-header` and `.crm-master-accordion-header` and instead using `.crm-accordion-light` and `.crm-accordion-bold`  See [#29447#issuecomment-1959072462](https://github.com/civicrm/civicrm-core/pull/29447#issuecomment-1959072462) for details

Comments
----------------------------------------
~~Most of the non-conditional ones are in #29447  I'll rebase those out of here once those are merged. So focus on the last commit.~~
Change of plan: since the reviews are all on this PR, and the complications are in the js I have closed #29447 and we will use this as the consolidated PR.
