### PR TITLE
dev/user-interface#60 Add backward-compat to crmAccordionToggle function

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -1172,20 +1172,10 @@ if (!CRM.vars) CRM.vars = {};
       $('table.crm-ajax-table', e.target).each(function() {
         var
           $table = $(this),
-          script = CRM.config.resourceBase + 'js/jquery/jquery.crmAjaxTable.js',
-          $accordion = $table.closest('.crm-accordion-wrapper.collapsed, .crm-collapsible.collapsed');
-        // For tables hidden by collapsed accordions, wait.
-        if ($accordion.length) {
-          $accordion.one('crmAccordion:open', function() {
-            CRM.loadScript(script).done(function() {
-              $table.crmAjaxTable();
-            });
-          });
-        } else {
-          CRM.loadScript(script).done(function() {
-            $table.crmAjaxTable();
-          });
-        }
+          script = CRM.config.resourceBase + 'js/jquery/jquery.crmAjaxTable.js';
+        CRM.loadScript(script).done(function() {
+          $table.crmAjaxTable();
+        });
       });
       if ($("input:radio[name=radio_ts]").length == 1) {
         $("input:radio[name=radio_ts]").prop("checked", true);
@@ -1713,15 +1703,13 @@ if (!CRM.vars) CRM.vars = {};
       })
       // Handle accordions
       .on('click.crmAccordions', 'div.crm-accordion-header, fieldset.crm-accordion-header, .crm-collapsible .collapsible-title', function (e) {
-        var action = 'open';
         if ($(this).parent().hasClass('collapsed')) {
           $(this).next().css('display', 'none').slideDown(200);
         }
         else {
           $(this).next().css('display', 'block').slideUp(200);
-          action = 'close';
         }
-        $(this).parent().toggleClass('collapsed').trigger('crmAccordion:' + action);
+        $(this).parent().toggleClass('collapsed');
         e.preventDefault();
       });
 
@@ -1740,15 +1728,13 @@ if (!CRM.vars) CRM.vars = {};
         this.open = !this.open;
         return;
       }
-      var action = 'open';
       if ($(this).hasClass('collapsed')) {
         $('.crm-accordion-body', this).first().css('display', 'none').slideDown(speed);
       }
       else {
         $('.crm-accordion-body', this).first().css('display', 'block').slideUp(speed);
-        action = 'close';
       }
-      $(this).toggleClass('collapsed').trigger('crmAccordion:' + action);
+      $(this).toggleClass('collapsed');
     });
   };
 

--- a/js/Common.js
+++ b/js/Common.js
@@ -1730,10 +1730,16 @@ if (!CRM.vars) CRM.vars = {};
 
   /**
    * Collapse or expand an accordion
+   * @deprecated
    * @param speed
    */
   $.fn.crmAccordionToggle = function (speed) {
     $(this).each(function () {
+      // Backward-compat, for when this older function is used on a newer <details> element
+      if ($(this).is('details')) {
+        this.open = !this.open;
+        return;
+      }
       var action = 'open';
       if ($(this).hasClass('collapsed')) {
         $('.crm-accordion-body', this).first().css('display', 'none').slideDown(speed);


### PR DESCRIPTION
Overview
----------------------------------------
Makes older function work on new accordion markup, remove some unnecessarily complex handling for accordions & datatables.

Technical Details
---------
While providing backward-compat javascript support for our accordion => disclosure element upgrades, this also reverts 
16f4d319ef04e192a8836b2486f7de9dd7808046 to remove the unnecessary complexity of the 'crmAccordion:open' jQuery event.