### PR TITLE
Fix New Member receipt setting for non-English

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1259,8 +1259,12 @@ DESC limit 1");
     $contributionId = $this->ids['Contribution'] ?? CRM_Member_BAO_Membership::getMembershipContributionId($this->getMembershipID());
     $membershipIds = $this->_membershipIDs;
     if ($this->getSubmittedValue('send_receipt') && $contributionId && !empty($membershipIds)) {
-      $contributionDetails = CRM_Contribute_BAO_Contribution::getContributionDetails(CRM_Export_Form_Select::MEMBER_EXPORT, $this->_membershipIDs);
-      if ($contributionDetails[$this->getMembershipID()]['contribution_status'] === 'Completed') {
+      $contributionStatus = \Civi\Api4\Contribution::get(FALSE)
+        ->addSelect('contribution_status_id:name')
+        ->addWhere('id', '=', $contributionId)
+        ->execute()
+        ->first();
+      if ($contributionStatus['contribution_status_id:name'] === 'Completed') {
         $formValues['contact_id'] = $this->_contactID;
         $formValues['contribution_id'] = $contributionId;
         // receipt_text_signup is no longer used in receipts from 5.47


### PR DESCRIPTION
Overview
----------------------------------------

- Go to the list of option values, then "contribution status" (under Administer > Customize Screens > Option Lists, then find the "contribution status" option group)
- Change the label of the status "Completed" to something else, ex: "Terminé"

Then go to a contact record:

- New membership
- Select a membership
- Check the box "send a receipt" at the bottom of the form.

The email will not be sent. It will save fine, but not send an email. When it sends an email, the notification also says "an email has been sent"

I suspect many people did not notice that this was broken because it's a very subtle bug.

Before
----------------------------------------

No membership receipt email sent when the admin UI is in non-English, with non-English contribution statuses. 

After
----------------------------------------

Email sent.

Technical Details
----------------------------------------

- The old code used the Option Value label instead of the name, so if the label was translated, no receipt was sent.
- `CRM_Contribute_BAO_Contribution::getContributionDetails()` is a hot mess, and now, only 1 other place uses it (data export).