### PR TITLE
News Dashlet - Fix styling of unread items

### DIFF
--- a/templates/CRM/Dashlet/Page/Blog.tpl
+++ b/templates/CRM/Dashlet/Page/Blog.tpl
@@ -16,18 +16,18 @@
   #civicrm-news-feed .crm-news-feed-unread .crm-news-feed-item-title {
     font-weight: bold;
   }
-  #civicrm-news-feed .collapsed .crm-accordion-header {
+  #civicrm-news-feed details:not([open]) .crm-accordion-header {
     text-overflow: ellipsis;
     text-wrap: none;
     white-space: nowrap;
     overflow: hidden;
   }
   #civicrm-news-feed .crm-news-feed-item-preview {
-    color: #8d8d8d;
-    display: none;
-  }
-  #civicrm-news-feed .collapsed .crm-news-feed-item-preview {
     display: inline;
+    color: #8d8d8d;
+  }
+  #civicrm-news-feed details[open] .crm-news-feed-item-preview {
+    display: none;
   }
   #civicrm-news-feed .crm-news-feed-item-link {
     margin-bottom: 0;
@@ -88,7 +88,7 @@
             if ($.inArray(itemKey, opened[key]) < 0) {
               $(this).addClass('crm-news-feed-unread');
               ++count;
-              $(this).one('crmAccordion:open', function () {
+              $(this).one('click', function () {
                 $(this).removeClass('crm-news-feed-unread');
                 $('em', $tab).text(--count || '');
                 opened[key].push(itemKey);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes style regression from 71111877c8f7516b84f739ba8418603d5e0935ba which caused unread items to lose their bold appearance, and the collapsed summaries to disappear.

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/2874912/0d15c3c8-ddab-4d0d-b9d6-f85945003744)

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/2874912/9e227c5a-a843-4ca0-8740-61c1963124b6)


Technical Details
----------------------------------------
Adjusts css to target the new disclosure element markup, and removes dependence on the deprecated `crmAccordion:open` event.