### PR TITLE
Scheduled Reminder listing will not load at all if any Scheduled Reminder exists which refers to a deleted Membership Type

### DIFF
--- a/CRM/Member/ActionMapping.php
+++ b/CRM/Member/ActionMapping.php
@@ -47,7 +47,7 @@ class CRM_Member_ActionMapping extends \Civi\ActionSchedule\MappingBase {
   }
 
   public function getStatusLabels(?array $entityValue): array {
-    foreach ($entityValue ?? [] as $membershipType) {
+    foreach (array_filter($entityValue ?? []) as $membershipType) {
       if (\CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType', $membershipType, 'auto_renew')) {
         return \CRM_Core_OptionGroup::values('auto_renew_options');
       }


### PR DESCRIPTION
Overview
----------------------------------------
Scheduled Reminder listing will not load at all if any Scheduled Reminder exists which refers to a deleted Membership Type

Before
----------------------------------------
Scheduled Reminder listing will not load. Bad UX after a user purges old membership types.

After
----------------------------------------
Scheduled Reminder listing will loads.

Technical Details
----------------------------------------
Membership Type being checked is NULL and throws an exception in getFieldValue, causing the Scheduled Reminder listing to not load.

This only applies to the pre-SearchKit Scheduled Reminder listing.

Comments
----------------------------------------
Agileware Ref: CIVICRM-2212