### PR TITLE
Extra squiggly bracket appearing on event thankyou page

### DIFF
--- a/templates/CRM/Price/Page/LineItem.tpl
+++ b/templates/CRM/Price/Page/LineItem.tpl
@@ -109,7 +109,7 @@
         {assign var="lineItemCount" value=0}
 
         {foreach from=$pcount item=p_count}
-          {assign var="intPCount" value=$p_count.participant_count|string_format:"%d"}}
+          {assign var="intPCount" value=$p_count.participant_count|string_format:"%d"}
           {assign var="lineItemCount" value=$lineItemCount+$intPCount}
         {/foreach}
         {if $lineItemCount < 1}


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
<img width="348" alt="untitled3" src="https://github.com/civicrm/civicrm-core/assets/2967821/f6223024-3f7f-4b93-893d-a9ea00f18000">


After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------
In 5.71
