### PR TITLE
Further clean up on notices, parameter assignment in ParticipantView

### DIFF
--- a/templates/CRM/Event/Form/ParticipantView.tpl
+++ b/templates/CRM/Event/Form/ParticipantView.tpl
@@ -12,14 +12,14 @@
     <div class="action-link">
         <div class="crm-submit-buttons">
             {if call_user_func(array('CRM_Core_Permission','check'), 'edit event participants')}
-         {assign var='editUrlParams' value="reset=1&id=$id&cid=$contact_id&action=update&context=$context&selectedChild=event"}
+         {assign var='editUrlParams' value="reset=1&id=$participantId&cid=$contactId&action=update&context=$context&selectedChild=event"}
          {if ( $context eq 'fulltext' || $context eq 'search' ) && $searchKey}
-         {assign var='editUrlParams' value="reset=1&id=$id&cid=$contact_id&action=update&context=$context&selectedChild=event&key=$searchKey"}
+         {assign var='editUrlParams' value="reset=1&id=$participantId&cid=$contactId&action=update&context=$context&selectedChild=event&key=$searchKey"}
          {/if}
              <a class="button" href="{crmURL p='civicrm/contact/view/participant' q=$editUrlParams}" accesskey="e"><span><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Edit{/ts}</span></a>
           {/if}
           {if call_user_func(array('CRM_Core_Permission','check'), 'delete in CiviEvent')}
-            <a class="button" href="{crmURL p='civicrm/participant/delete' q="reset=1&id=$id"}"><span><i class="crm-i fa-trash" aria-hidden="true"></i> {ts}Delete{/ts}</span></a>
+            <a class="button" href="{crmURL p='civicrm/participant/delete' q="reset=1&id=$participantId"}"><span><i class="crm-i fa-trash" aria-hidden="true"></i> {ts}Delete{/ts}</span></a>
           {/if}
 
         </div>
@@ -28,16 +28,16 @@
     <tr class="crm-event-participantview-form-block-displayName">
       <td class="label">{ts}Participant Name{/ts}</td>
       <td>
-        <strong><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$contact_id"}" title="{ts}View contact record{/ts}">{$displayName|escape}</a></strong>
+        <strong><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$contactId"}" title="{ts}View contact record{/ts}">{$displayName|escape}</a></strong>
         <div>
-            <a class="action-item crm-hover-button" href="{crmURL p='civicrm/event/badge' q="reset=1&context=view&id=$id&cid=$contact_id"}"><i class="crm-i fa-print" aria-hidden="true"></i> {ts}Print Name Badge{/ts}</a>
+            <a class="action-item crm-hover-button" href="{crmURL p='civicrm/event/badge' q="reset=1&context=view&id=$participantId&cid=$contactId"}"><i class="crm-i fa-print" aria-hidden="true"></i> {ts}Print Name Badge{/ts}</a>
         </div>
       </td>
   </tr>
   {if $participant_registered_by_id} {* Display primary participant *}
       <tr class="crm-event-participantview-form-block-registeredBy">
           <td class="label">{ts}Registered By{/ts}</td>
-          <td><a href="{crmURL p='civicrm/contact/view/participant' q="reset=1&id=$participant_registered_by_id&cid=$registered_by_contact_id&action=view"}" title="{ts}view primary participant{/ts}">{$registered_by_display_name}</a></td>
+          <td><a href="{crmURL p='civicrm/contact/view/participant' q="reset=1&id=$participant_registered_by_id&cid=$registered_by_contact_id&action=view"}" title="{ts}view primary participant{/ts}">{$registered_by_display_name|escape}</a></td>
       </tr>
   {/if}
   {if $additionalParticipants} {* Display others registered by this participant *}
@@ -52,7 +52,7 @@
   {/if}
     <tr class="crm-event-participantview-form-block-event">
       <td class="label">{ts}Event{/ts}</td><td>
-        <a href="{crmURL p='civicrm/event/manage/settings' q="action=update&reset=1&id=$event_id"}" title="{ts}Configure this event{/ts}">{$event}</a>
+        <a href="{crmURL p='civicrm/event/manage/settings' q="action=update&reset=1&id=$event_id"}" title="{ts}Configure this event{/ts}">{$event|escape}</a>
       </td>
   </tr>
 
@@ -71,7 +71,7 @@
       <td>{$register_date|crmDate}&nbsp;</td>
   </tr>
     <tr class="crm-event-participantview-form-block-status">
-      <td class="label">{ts}Status{/ts}</td><td>{$status}&nbsp;
+      <td class="label">{ts}Status{/ts}</td><td>{$status|escape}&nbsp;
       {if $transferName}
         {ts}(Transferred to <a href="{crmURL p='civicrm/contact/view/participant' q="action=view&reset=1&id=$pid&cid=$transferId"}" title="{ts}View this Participant{/ts}">{$transferName|escape}</a>){/ts}
       {/if}
@@ -112,7 +112,7 @@
     {/if}
     {foreach from=$note item="rec"}
       {if $rec}
-            <tr><td class="label">{ts}Note{/ts}</td><td>{$rec|nl2br}</td></tr>
+            <tr><td class="label">{ts}Note{/ts}</td><td>{$rec|escape|nl2br}</td></tr>
       {/if}
     {/foreach}
     </table>
@@ -121,14 +121,14 @@
     {/if}
     {include file="CRM/Custom/Page/CustomDataView.tpl"}
     {if $accessContribution and $rows.0.contribution_id}
-        {include file="CRM/Contribute/Form/Selector.tpl" context="Search"}
+        {include file="CRM/Contribute/Form/Selector.tpl" context="Search" single=true}
     {/if}
     <div class="crm-submit-buttons">
       {if call_user_func(array('CRM_Core_Permission','check'), 'edit event participants')}
         <a class="button" href="{crmURL p='civicrm/contact/view/participant' q=$editUrlParams}" accesskey="e"><span><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Edit{/ts}</span></a>
       {/if}
       {if call_user_func(array('CRM_Core_Permission','check'), 'delete in CiviEvent')}
-        <a class="button" href="{crmURL p='civicrm/participant/delete' q="reset=1&id=$id"}"><span><i class="crm-i fa-trash" aria-hidden="true"></i> {ts}Delete{/ts}</span></a>
+        <a class="button" href="{crmURL p='civicrm/participant/delete' q="reset=1&id=$participantId"}"><span><i class="crm-i fa-trash" aria-hidden="true"></i> {ts}Delete{/ts}</span></a>
       {/if}
       {include file="CRM/common/formButtons.tpl" location="bottom"}
     </div>


### PR DESCRIPTION
Overview
----------------------------------------
Further clean up on notices, parameter assignment in ParticipantView

Before
----------------------------------------
- Still 2 notices on ParticipantView

- the way values are assigned to the template is by adding them to an array & then assigning - this is REALLY confusing & hard to track down where they are coming from
- mix of id & participantId used in the template= confusion
- mix of contactId & contact_id used in the template  = confusion

After
----------------------------------------
Above fixes, escaping added to address some values being fetch via apiv4 now

Technical Details
----------------------------------------
@demeritcowboy this addresses the last notice & the pain in my head

Comments
----------------------------------------
