### PR TITLE
[REF] Ensure that gName is always asigned to page template

### DIFF
--- a/CRM/Admin/Page/Options.php
+++ b/CRM/Admin/Page/Options.php
@@ -83,6 +83,8 @@ class CRM_Admin_Page_Options extends CRM_Core_Page_Basic {
     }
     // If we don't have a group we will browse all groups
     if (!self::$_gName) {
+      // Ensure that gName is assigned to the template to prevent smarty notice.
+      $this->assign('gName');
       return;
     }
     $this->set('gName', self::$_gName);


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix the following notice found on Administer -> System Settings -> Option Groups

![image](https://github.com/civicrm/civicrm-core/assets/6799125/d82f79aa-fae8-42a4-9604-dbad49583c60)

Before
----------------------------------------
Notice shows

After
----------------------------------------
No Notice

ping @eileenmcnaughton 