### PR TITLE
Call browse directly rather than forcing through run

### DIFF
--- a/CRM/Contact/Page/View/CustomData.php
+++ b/CRM/Contact/Page/View/CustomData.php
@@ -91,16 +91,16 @@ class CRM_Contact_Page_View_CustomData extends CRM_Core_Page {
 
         $this->assign('displayStyle', 'tableOriented');
         // here the multi custom data listing code will go
-        $multiRecordFieldListing = TRUE;
         $page = new CRM_Profile_Page_MultipleRecordFieldsListing();
-        $page->set('contactId', $this->_contactId);
-        $page->set('customGroupId', $this->_groupId);
+        $page->_contactId = $this->_contactId;
+        $page->_customGroupId = $this->_groupId;
         $page->set('action', CRM_Core_Action::BROWSE);
-        $page->set('multiRecordFieldListing', $multiRecordFieldListing);
-        $page->set('pageViewType', 'customDataView');
-        $page->set('contactType', $ctype);
+        $page->_pageViewType = 'customDataView';
+        $page->_contactType = $ctype;
         $page->_headersOnly = TRUE;
-        $page->run();
+        // assign vars to templates
+        $this->assign('action', CRM_Core_Action::BROWSE);
+        $page->browse();
       }
       else {
         //Custom Groups Inline


### PR DESCRIPTION
Going through run() means a few variables are set one way rather than another but ultimate does nothing but confuse. The whole form is very overloaded so baby-steps

This is accessed to view the custom data tab

![image](https://github.com/civicrm/civicrm-core/assets/336308/5816775b-c5d1-466d-a7eb-c17212ac2733)
