### PR TITLE
Stop calling run when loading multipleParticipantListing

### DIFF
--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -485,11 +485,15 @@ class CRM_Profile_Form extends CRM_Core_Form {
           $page = new CRM_Profile_Page_MultipleRecordFieldsListing();
           $cs = $this->get('cs');
           $page->set('pageCheckSum', $cs);
-          $page->set('contactId', $this->_id);
-          $page->set('profileId', $this->_gid);
+          $page->_contactId = $this->_id;
+          $page->setProfileID($this->_gid);
           $page->set('action', CRM_Core_Action::BROWSE);
-          $page->set('multiRecordFieldListing', $multiRecordFieldListing);
-          $page->run();
+          $action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, FALSE);
+          // assign vars to templates
+          $page->assign('action', $action);
+          $page->_pageViewType = 'profileDataView';
+
+          $page->browse();
         }
       }
 

--- a/CRM/Profile/Page/MultipleRecordFieldsListing.php
+++ b/CRM/Profile/Page/MultipleRecordFieldsListing.php
@@ -27,6 +27,13 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
 
   protected $_profileId = NULL;
 
+  /**
+   * @param int $profileId
+   */
+  public function setProfileID(int $profileId): void {
+    $this->_profileId = $profileId;
+  }
+
   public $_contactId = NULL;
 
   public $_customGroupTitle = NULL;


### PR DESCRIPTION
This is accessed when trying a profile with a mutliple record field is used in edit mode (note the red stuff is unchanged - it's just there cos it's a feature)

![image](https://github.com/civicrm/civicrm-core/assets/336308/daa70739-2397-439e-bc4b-0f3962b1c1bd)