### PR TITLE
Make getContributionID public on AbstractEditPayment

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -170,13 +170,15 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
   protected $contributionID;
 
   /**
-   * Get the contribution id that has been created or is being edited.
+   * Get the contribution ID.
    *
-   * @internal - not supported for outside core.
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
    *
    * @return int|null
    */
-  protected function getContributionID(): ?int {
+  public function getContributionID(): ?int {
     return $this->contributionID;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Make getContributionID public on AbstractEditPayment

Before
----------------------------------------
We have the same function many places & have been making it `public` & api supported but this one is protected

After
----------------------------------------
It's out there

Technical Details
----------------------------------------

Comments
----------------------------------------
