### PR TITLE
Allow json parameter definition for scheduled jobs

### DIFF
--- a/CRM/Core/BAO/Job.php
+++ b/CRM/Core/BAO/Job.php
@@ -126,6 +126,14 @@ class CRM_Core_BAO_Job extends CRM_Core_DAO_Job {
    */
   public static function parseParameters(?string $parameters): array {
     $parameters = trim($parameters ?? '');
+    if (!empty($parameters) && $parameters[0] === '{') {
+      try {
+        return json_decode($parameters, TRUE, 512, JSON_THROW_ON_ERROR);
+      }
+      catch (JsonException $e) {
+        throw new CRM_Core_Exception('Job parameters error: ' . $e->getMessage() . '. Parameters: ' . print_r($parameters, TRUE));
+      }
+    }
     $result = ['version' => 3];
     $lines = $parameters ? explode("\n", $parameters) : [];
 

--- a/CRM/Core/JobManager.php
+++ b/CRM/Core/JobManager.php
@@ -32,8 +32,18 @@ class CRM_Core_JobManager {
    */
   public $currentJob = NULL;
 
+  /**
+   * @var array
+   *
+   * @fixme How are these set? What do they do?
+   */
   public $singleRunParams = [];
 
+  /**
+   * @var string|null
+   *
+   * @fixme Looks like this is only used by "singleRun"
+   */
   public $_source = NULL;
 
   /**
@@ -124,7 +134,7 @@ class CRM_Core_JobManager {
     try {
       $result = civicrm_api($job->api_entity, $job->api_action, $params);
     }
-    catch (Exception$e) {
+    catch (Exception $e) {
       $this->logEntry('Error while executing ' . $job->name . ': ' . $e->getMessage());
       $result = $e;
     }
@@ -191,7 +201,7 @@ class CRM_Core_JobManager {
    * @param $entity
    * @param $job
    * @param array $params
-   * @param null $source
+   * @param string|null $source
    */
   public function setSingleRunParams($entity, $job, $params, $source = NULL) {
     $this->_source = $source;


### PR DESCRIPTION
Overview
----------------------------------------
Proof of concept to allow scheduled job parameters to be specified as JSON.

Before
----------------------------------------
Can only specify as name=value pairs separated by \n. Means you can't use any of the other operators eg. "IN".

After
----------------------------------------
Can specify as JSON. Means that you can use any API params.

Technical Details
----------------------------------------
Parser checks first if it looks like json (has a `{` as the first character) and decodes. Falls back to standard parsing if not.

Comments
----------------------------------------
@mlutfy Here is a proof of concept for JSON params for scheduled jobs as discussed in https://github.com/civicrm/civicrm-core/pull/29353

Simple example of usage:
```
return [
  [
    'name' => 'job_payflowpro_importlatestrecurpayments',
    'entity' => 'Job',
    'cleanup' => 'always',
    'update' => 'unmodified',
    'params' => [
      'values' => [
        'is_active' => FALSE,
        'name' => 'PayflowPro: Import latest recur Payments',
        'description' => E::ts('Get the latest payments using PayflowPro API for each recurring payment and record/update in CiviCRM.'),
        'run_frequency' => 'Daily',
        'api_entity' => 'PayflowPro',
        'api_action' => 'importLatestRecurPayments',
        'parameters' => '{"version":4,"paymentProcessorID":7}',
      ],
      'match' => [
        'name',
      ],
    ],
  ],
];
```
