### PR TITLE
useFakeSession during install on Standalone

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -91,6 +91,10 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
           // Standalone's session cannot be initialized until CiviCRM is booted,
           // since it is defined in an extension, and we need the session
           // initialized before calling applyLocale.
+          if (defined('CIVI_SETUP')) {
+            // during Standalone install the extension isn't ready yet so we need a fake session
+            \CRM_Core_Session::useFakeSession();
+          }
           $sess = \CRM_Core_Session::singleton();
           $sess->initialize();
           if ($sess->getLoggedInContactID()) {


### PR DESCRIPTION
Use a fake session during Standalone install, because we might not have the real session handler yet (because the extension that provides it hasn't been installed),

Before
-----
Standalone web installer crashes because of trying to start a session during the install, before standaloneusers extension is enabled to provide the session handler.

After
-----
Install completes successfully.


Technical details
-----
I tried @totten 's suggestion here https://github.com/civicrm/civicrm-core/pull/29362#issuecomment-1960554102 but it didn't seem to work. Because the Civi-bootstrap phase forces recreating the `CRM_Core_Config` singleton, the fakeness is lost.

I was also keen possible session creation during install by any pesky `CRM_Core_Session::setStatus` calls -- this doesn't work for that case because it's inside the `$loadFromDB` case, and at the beginning of the install we're not loading from DB.

The alternative that did cover this case is to put a check inside `CRM_Core_Session::singleton`, but this seems quite aggressive.  (Ie. https://github.com/civicrm/civicrm-core/pull/29488 )

After all this I'm thinking the initial approach of [using default PHP session handler](https://github.com/civicrm/civicrm-core/pull/29352)  might be the neatest way. For one thing it keeps the Standalone specific code inside `userSystem`, which seems desirable.