### PR TITLE
Add some noise if people use getVar to access internal properties

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2134,8 +2134,12 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    */
   public function getVar($name) {
     try {
-      if (!empty(ReflectionUtils::getCodeDocs((new ReflectionProperty($this, $name)), 'Property')['deprecated'])) {
+      $property = ReflectionUtils::getCodeDocs((new ReflectionProperty($this, $name)), 'Property');
+      if (!empty($property['deprecated'])) {
         CRM_Core_Error::deprecatedWarning('deprecated property accessed :' . $name);
+      }
+      if (!empty($property['internal'])) {
+        CRM_Core_Error::deprecatedWarning('internal property accessed (this property could change without warning):' . $name);
       }
     }
     catch (\ReflectionException $e) {


### PR DESCRIPTION
Overview
----------------------------------------
Add some noise if people use getVar to access internal properties

Before
----------------------------------------
`getVar()` only has a todo to warn about the risks of accessing properties marked internal

After
----------------------------------------
Some noise

Technical Details
----------------------------------------
Chances are there are no cases where getVar is used for internal properties but ....

Comments
----------------------------------------
