### PR TITLE
Pass Source and Account ID to PayPal when processing Additional Payments

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -391,13 +391,20 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     if ($paymentParams['amount'] > 0.0) {
       if (!empty($this->contributionID)) {
         if (empty($paymentParams['description'])) {
-        $paymentParams['description'] = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $this->_contributionId, 'source');
+          $paymentParams['description'] = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $this->_contributionId, 'source');
         }
-        if (empty($paymentParams['contributionType_accounting_code'])) {
+
+        if (empty($paymentParams['financial_type_id'])) {
           $financialTypeID = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $this->_contributionId, 'financial_type_id');
-          $paymentParams['contributionType_accounting_code'] = CRM_Financial_BAO_FinancialAccount::getAccountingCode($financialTypeID);
+          $paymentParams['financial_type_id'] = CRM_Financial_BAO_FinancialAccount::getAccountingCode($financialTypeID);
+        }
+
+        if (empty($paymentParams['contributionType_accounting_code'])) {
+          // anticipate standardizing on 'financial_type_id' but until the payment processor code is updated, we need to set this param
+          $paymentParams['contributionType_accounting_code'] = $paymentParams['financial_type_id'];
         }
       }
+
       try {
         // Re-retrieve the payment processor in case the form changed it, CRM-7179
         $payment = \Civi\Payment\System::singleton()->getById($this->getPaymentProcessorID());

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -389,6 +389,15 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     ]);
 
     if ($paymentParams['amount'] > 0.0) {
+      if (!empty($this->contributionID)) {
+        if (empty($paymentParams['description'])) {
+        $paymentParams['description'] = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $this->_contributionId, 'source');
+        }
+        if (empty($paymentParams['contributionType_accounting_code'])) {
+          $financialTypeID = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $this->_contributionId, 'financial_type_id');
+          $paymentParams['contributionType_accounting_code'] = CRM_Financial_BAO_FinancialAccount::getAccountingCode($financialTypeID);
+        }
+      }
       try {
         // Re-retrieve the payment processor in case the form changed it, CRM-7179
         $payment = \Civi\Payment\System::singleton()->getById($this->getPaymentProcessorID());


### PR DESCRIPTION
Overview
----------------------------------------
When the back-office payment form (`CRM_Contribute_Form_AdditionalPayment`) was disentangled from the ContributionPage circa 2019, some important parameters to `doPayment()` were lost: the contribution-source and the financial account code.

Before
----------------------------------------
PayPal PayFlowPro is missing the "Item Title" (Contribution Source), and "Comment 1" (financial account code) when processed on the back-office form. This form is loaded for search-actions, and the Contribution Tab.

After
----------------------------------------
If, empty, and if a Contribution ID is present, the Contribution Source and accounting code are retrieved from the Contribution and passed to the payment processor.


Comments
----------------------------------------
I do not think this PR is comprehensive enough. It does not address new Contributions from the back-office, which I suspect use the same form. On the chance there are other unknown effected cases and code-paths, I think a solution in the Payment Processor component would be more appropriate. 

I do not know if the different PayPal processors are similar enough to have this issue resolved by this PR. If they all use the payment params, 'description', and 'contributionType_accounting_code', the same way, then they are.

I leave it to someone more familiar with the payment processors to decide if this should be merged as a slight improvement, or if it should be adapted to handle all cases and all payment processors better.
