### PR TITLE
Searchkit - towards scheduled emails of searchkit results - part 1 - allow returning the results as a string

### DIFF
--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDownloadTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDownloadTest.php
@@ -99,18 +99,8 @@ class SearchDownloadTest extends \PHPUnit\Framework\TestCase implements Headless
 
   /**
    * Test downloading CSV format.
-   *
-   * Must run in separate process to capture direct output to browser
-   *
-   * @runInSeparateProcess
-   * @preserveGlobalState disabled
    */
   public function testDownloadCSV() {
-    $this->markTestIncomplete('Unable to get this test working in separate process, probably due to being in an extension');
-
-    // Re-enable because this test has to run in a separate process
-    \CRM_Extension_System::singleton()->getManager()->install('org.civicrm.search_kit');
-
     $lastName = uniqid(__FUNCTION__);
     $sampleData = [
       ['first_name' => 'One', 'last_name' => $lastName],
@@ -123,6 +113,7 @@ class SearchDownloadTest extends \PHPUnit\Framework\TestCase implements Headless
     $params = [
       'checkPermissions' => FALSE,
       'format' => 'csv',
+      'disposition' => 'inline',
       'savedSearch' => [
         'api_entity' => 'Contact',
         'api_params' => [
@@ -162,15 +153,10 @@ class SearchDownloadTest extends \PHPUnit\Framework\TestCase implements Headless
     foreach ($sampleData as $row) {
       $expectedOut .= '\s+' . preg_quote('"' . $row['first_name'] . ' ' . $lastName . '"');
     }
-    $this->expectOutputRegex('#' . $expectedOut . '#');
+    $expectedOut = '#' . $expectedOut . '#';
 
-    try {
-      civicrm_api4('SearchDisplay', 'download', $params);
-      $this->fail();
-    }
-    catch (\CRM_Core_Exception_PrematureExitException $e) {
-      // All good, we expected the api to exit
-    }
+    $result = civicrm_api4('SearchDisplay', 'download', $params);
+    $this->assertMatchesRegularExpression($expectedOut, $result[0]);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Currently except for format=array it sends it to the browser. It would be nice to have it returnable as a binary string. This will facilitate a scheduled job like civireport's mail_report.

Before
----------------------------------------
Awkward to get the results as a string which could be easily then passed on to mail functions as an attachment. Have to use ob_start which is sometimes tricky with output headers, or redirect to a temp file.

After
----------------------------------------
Results can be returned as a string.
Resurrected unit test.

Technical Details
----------------------------------------
I waffled over using the word "disposition". It's consistent with how browser/mail headers do it, and the existing getContentDisposition function, but it's not super-intuitive unless you stare at mail headers for your day job that attachment means browser download and inline means string.

It also feels like this could be more oo-ey instead of `switch` and `if`, but I was just trying to get something working.

Comments
----------------------------------------
To test this you could do something like:
1. Make a searchkit and a search display. Use a simple label so that the generated `name` will be the same and you don't have to guess or go to api explorer.
2. `cv ev --user=admin '$r = \Civi\Api4\SearchDisplay::download()->setFormat("csv")->setDisposition("inline")->setDisplay("the_display_name")->setSavedSearch("the_search_name")->execute(); var_export($r->first());'`
3. It should output the csv as a string.

Next step would be a scheduled job.