### PR TITLE
Align membership online receipt with contribution online receipt

### DIFF
--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -21,9 +21,11 @@
   <tr>
    <td>
      {assign var="greeting" value="{contact.email_greeting_display}"}{if $greeting}<p>{$greeting},</p>{/if}
-    {if $userText}
-     <p>{$userText}</p>
-    {/if}
+     {if $userText}
+       <p>{$userText}</p>
+     {elseif {contribution.contribution_page_id.receipt_text|boolean}}
+       <p>{contribution.contribution_page_id.receipt_text}</p>
+     {/if}
     {if {contribution.balance_amount|boolean} && {contribution.is_pay_later|boolean}}
       <p>{contribution.contribution_page_id.pay_later_receipt}</p>
     {/if}


### PR DESCRIPTION
Overview
----------------------------------------
We updated the contribution online receipt to have both `$userText` and the token

![image](https://github.com/civicrm/civicrm-core/assets/336308/567a599f-6b6d-4479-b6b0-c9339bf6ecc7)

This does the same to membership online receipt