### PR TITLE
Fix regression from #27902 disabled options showing

### DIFF
--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -667,6 +667,7 @@ WHERE  id = %1";
         ->execute()->first();
       $data['fields'] = (array) PriceField::get(FALSE)
         ->addWhere('price_set_id', '=', $priceSetID)
+        ->addWhere('is_active', '=', TRUE)
         ->addSelect('*', 'visibility_id:name')
         ->addOrderBy('weight', 'ASC')
         ->execute()->indexBy('id');
@@ -681,6 +682,7 @@ WHERE  id = %1";
       }
       $options = PriceFieldValue::get(FALSE)
         ->addWhere('price_field_id', 'IN', array_keys($data['fields']))
+        ->addWhere('is_active', '=', TRUE)
         ->setSelect($select)
         ->addOrderBy('weight', 'ASC')
         ->execute();


### PR DESCRIPTION
Overview
----------------------------------------
Disabled priceset options (fields, fieldvalues) showing on contribution page.

Before
----------------------------------------
Disabled priceset options showing on contribution page.

After
----------------------------------------
Disabled priceset options not showing on contribution page.

Technical Details
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/27902 we switched from `CRM_Price_BAO_PriceSet::getSetDetail()` to `CRM_Price_BAO_PriceSet::getCachedPriceSetDetail()`. The old function filtered by `is_active=1` but the new function did not.

Comments
----------------------------------------
Regression in 5.68
