### PR TITLE
Fix edit message templates permission on PDFLetter

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2564,9 +2564,11 @@ LEFT JOIN civicrm_mailing_group g ON g.mailing_id   = m.id
           ['onChange' => "selectValue( this.value, '{$prefix}');", 'class' => 'crm-select2 huge']
         );
       }
-      $form->add('checkbox', "{$prefix}updateTemplate", ts('Update Template'), NULL);
-      $form->add('checkbox', "{$prefix}saveTemplate", ts('Save As New Template'), ['onclick' => "showSaveDetails(this, '{$prefix}');"]);
-      $form->add('text', "{$prefix}saveTemplateName", ts('Template Title'));
+      if (\CRM_Core_Permission::check('edit message templates')) {
+        $form->add('checkbox', "{$prefix}updateTemplate", ts('Update Template'), NULL);
+        $form->add('checkbox', "{$prefix}saveTemplate", ts('Save As New Template'), ['onclick' => "showSaveDetails(this, '{$prefix}');"]);
+        $form->add('text', "{$prefix}saveTemplateName", ts('Template Title'));
+      }
     }
 
     // I'm not sure this is ever called.

--- a/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
@@ -111,8 +111,10 @@
 </div>
 
 <div id="saveDetails" class="section">
+  {if call_user_func(array('CRM_Core_Permission','check'), 'edit message templates')}
     <div class="label">{$form.saveTemplateName.label}</div>
     <div class="content">{$form.saveTemplateName.html|crmAddClass:huge}</div>
+  {/if}
 </div>
 
   </div><!-- /.crm-accordion-body -->

--- a/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
@@ -100,21 +100,17 @@
     </div>
 
 <div id="editMessageDetails">
-  {if call_user_func(array('CRM_Core_Permission','check'), 'edit message templates')}
     <div id="updateDetails" >
         {$form.updateTemplate.html}&nbsp;{$form.updateTemplate.label}
     </div>
     <div>
         {$form.saveTemplate.html}&nbsp;{$form.saveTemplate.label}
     </div>
-  {/if}
 </div>
 
 <div id="saveDetails" class="section">
-  {if call_user_func(array('CRM_Core_Permission','check'), 'edit message templates')}
     <div class="label">{$form.saveTemplateName.label}</div>
     <div class="content">{$form.saveTemplateName.html|crmAddClass:huge}</div>
-  {/if}
 </div>
 
   </div><!-- /.crm-accordion-body -->

--- a/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
@@ -100,12 +100,14 @@
     </div>
 
 <div id="editMessageDetails">
+  {if call_user_func(array('CRM_Core_Permission','check'), 'edit message templates')}
     <div id="updateDetails" >
         {$form.updateTemplate.html}&nbsp;{$form.updateTemplate.label}
     </div>
     <div>
         {$form.saveTemplate.html}&nbsp;{$form.saveTemplate.label}
     </div>
+  {/if}
 </div>
 
 <div id="saveDetails" class="section">


### PR DESCRIPTION
Overview
----------------------------------------
Users without the `CiviCRM: edit message templates permision`, can update Templates via the Print/Merge Document.

After
----------------------------------------
The checkbox that let you Update a Template shouldn't appear if the User doesn't have the `CiviCRM: edit message templates permision`.

Technical Details
----------------------------------------
Shouldn't the `<div>` in [L106](https://github.com/civicrm/civicrm-core/blob/24fa95e2c6cfed0d1988ab3f26e4e56a96f2f363/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl#L106) also have the class `section` as in [EmailCommon L48](https://github.com/civicrm/civicrm-core/blob/24fa95e2c6cfed0d1988ab3f26e4e56a96f2f363/templates/CRM/Contact/Form/Task/EmailCommon.tpl#L48)?

Comments
----------------------------------------
See [Issue #5021](https://lab.civicrm.org/dev/core/-/issues/5021)
