### PR TITLE
Pass values into DedupeRule->sql() rather than hybrid object

### DIFF
--- a/CRM/Dedupe/BAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/BAO/DedupeRuleGroup.php
@@ -244,11 +244,15 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
       // tailored to respect the param and contactId options provided.
       $queries = [];
       while ($bao->fetch()) {
-        $bao->contactIds = $this->contactIds;
-        $bao->params = $this->params;
-
         // Skipping empty rules? Empty rules shouldn't exist; why check?
-        if ($query = $bao->sql()) {
+        if ($query = $bao->sql($this->params, $this->contactIds, [
+          'id' => (int) $bao->id,
+          'rule_table' => $bao->rule_table,
+          'rule_length' => $bao->rule_length,
+          'rule_field' => $bao->rule_field,
+          'rule_weight' => $bao->rule_weight,
+          'dedupe_rule_group_id' => $bao->dedupe_rule_group_id,
+        ])) {
           $queries["{$bao->rule_table}.{$bao->rule_field}.{$bao->rule_weight}"] = $query;
         }
       }


### PR DESCRIPTION


Overview
----------------------------------------
Pass values into DedupeRule->sql() rather than hybrid object

Before
----------------------------------------
Most of the properties accessed from `sql()` are straight from the db find but it also passes a couple of other properties by setting them on the class

After
----------------------------------------
This fixes so the values the function needs are clearly passed in

Technical Details
----------------------------------------
It doesn't really make sense for this query calculation function to be on a different class I kinda get what they were thinking but the way our BAOs are half a collection of static functions but occassionally get serious about being an object but then like extra properties set without explanation does us no favours. In this case it would be most sane if all the query calculation was on the same class (probably a new one but for now just looking at one of the existing ones). To do that we need to get clearer about the input the sql() function needs - this switches it most of the way to being static-ready & move-ready by passing in the values as arrays rather than setting them as properties

Comments
----------------------------------------
