### PR TITLE
[REF] Ensure that CMS is booted prior to processing legacy PayPal IPN

### DIFF
--- a/extern/ipn.php
+++ b/extern/ipn.php
@@ -46,16 +46,6 @@ require_once '../civicrm.config.php';
 /* Cache the real UF, override it with the SOAP environment */
 
 CRM_Core_Config::singleton();
-$log = new CRM_Utils_SystemLogger();
-if (empty($_GET)) {
-  $log->alert('payment_notification processor_name=PayPal', $_REQUEST);
-  $paypalIPN = new CRM_Core_Payment_PayPalProIPN($_REQUEST);
-}
-else {
-  $log->alert('payment_notification PayPal_Standard', $_REQUEST);
-  $paypalIPN = new CRM_Core_Payment_PayPalIPN($_REQUEST);
-  // @todo upgrade standard per Pro
-}
 try {
   switch ($config->userFramework) {
     case 'Joomla':
@@ -68,6 +58,16 @@ try {
       CRM_Utils_System::loadBootStrap([], FALSE);
       break;
 
+  }
+  $log = new CRM_Utils_SystemLogger();
+  if (empty($_GET)) {
+    $log->alert('payment_notification processor_name=PayPal', $_REQUEST);
+    $paypalIPN = new CRM_Core_Payment_PayPalProIPN($_REQUEST);
+  }
+  else {
+    $log->alert('payment_notification PayPal_Standard', $_REQUEST);
+    $paypalIPN = new CRM_Core_Payment_PayPalIPN($_REQUEST);
+    // @todo upgrade standard per Pro
   }
   $paypalIPN->main();
 }


### PR DESCRIPTION
Overview
----------------------------------------
Recently the Australian Greens found that they had a recurring contribution that had been running for so long that it still relied on the extern/ipn.php route. When they switched from D7 to D9 this broke (many reasons but for the purpose of this PR) one problem was that in D9 you need to have booted the Drupal Container which is done as part of the bootstrap call here first before trying to record in the System Log table the IPN request

Before
----------------------------------------
Really old legacy IPNs cannot be processed on D9

After
----------------------------------------
Possibly can be without container errors

ping @eileenmcnaughton @MegaphoneJon @andrew-cormick-dockery @johntwyman