### PR TITLE
Fix for issue dev/#5037: Standalone install in another language

### DIFF
--- a/setup/src/Setup/UI/SetupController.php
+++ b/setup/src/Setup/UI/SetupController.php
@@ -140,8 +140,10 @@ class SetupController implements SetupControllerInterface {
 
     global $civicrm_paths;
     foreach ($model->paths as $pathVar => $pathValues) {
-      foreach (['url', 'path'] as $aspectName => $aspectValue) {
-        $civicrm_paths[$pathVar][$aspectName] = $aspectValue;
+      foreach ($pathValues as $aspectName => $aspectValue) {
+        if (in_array($aspectName, ['url', 'path'])) {
+          $civicrm_paths[$pathVar][$aspectName] = $aspectValue;
+        }
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------

Fixes an issue in the installer user interface (for standalone) after selecting a different language.

Before
----------------------------------------

When installing CiviCRM Standalone through the user interface and one selects a different language an fatal error did appear. 

After
----------------------------------------

When installing CiviCRM Standalone through the user interface and one selects a different language the setup continues and CiviCRM is installed in the selected language. 

Technical Details
----------------------------------------

The issue was caused by not propagating the correct `cms.root` path.

Comments
----------------------------------------

Good to know is that the installer downloads the translation files after selected the right language.  So no need to download those before installing. 
After this PR is merged the installation documentation for standalone in a different language needs an update.

See https://lab.civicrm.org/dev/core/-/issues/5037
