### PR TITLE
Check workflow not deprecated workflow_id on showing message templates

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -193,7 +193,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implemen
       ->addWhere('is_sms', '=', $isSMS);
 
     if (!$all) {
-      $messageTemplates->addWhere('workflow_id', 'IS NULL');
+      $messageTemplates->addWhere('workflow_name', 'IS NULL');
     }
 
     $msgTpls = array_column((array) $messageTemplates->execute(), 'msg_title', 'id');


### PR DESCRIPTION
workflow_id is being phased out & is optional, even when workflow is set (although all core templates will have both if they have either)
