### PR TITLE
A11y: Fix info button contrast ratio

### DIFF
--- a/ext/greenwich/scss/_greenwich.scss
+++ b/ext/greenwich/scss/_greenwich.scss
@@ -159,7 +159,7 @@ $btn-success-color: rgb(255, 255, 255);
 $btn-success-bg: $brand-success;
 $btn-success-border: $btn-success-bg;
 
-$btn-info-color: rgb(255, 255, 255);
+$btn-info-color: rgb(0, 0, 0);
 $btn-info-bg: $brand-info;
 $btn-info-border: $btn-info-bg;
 

--- a/templates/CRM/Member/Page/MembershipType.tpl
+++ b/templates/CRM/Member/Page/MembershipType.tpl
@@ -10,7 +10,7 @@
 
 {capture assign=reminderLink}{crmURL p='civicrm/admin/scheduleReminders' q='reset=1'}{/capture}
 <div class="help">
-  <p>{icon icon="fa-info-circle"}{/icon}{ts}Membership types are used to categorize memberships. You can define an unlimited number of types. Each type incorporates a 'name' (Gold Member, Honor Society Member...), a description, a minimum fee (can be $0), and a duration (can be 'lifetime'). Each member type is specifically linked to the membership entity (organization) - e.g. Bay Area Chapter.{/ts} {docURL page="user/membership/defining-memberships/"}</p>
+  <p>{icon icon="fa-info-circle"}{/icon} {ts}Membership types are used to categorize memberships. You can define an unlimited number of types. Each type incorporates a 'name' (Gold Member, Honor Society Member...), a description, a minimum fee (can be $0), and a duration (can be 'lifetime'). Each member type is specifically linked to the membership entity (organization) - e.g. Bay Area Chapter.{/ts} {docURL page="user/membership/defining-memberships/"}</p>
   <p>{ts 1=$reminderLink}Configure membership renewal reminders using <a href="%1">Schedule Reminders</a>.{/ts} {docURL page="user/email/scheduled-reminders"}</p>
 </div>
 
@@ -64,7 +64,7 @@
 {else}
   {if $action ne 1}
   <div class="messages status no-popup">
-    <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
+    {icon icon="fa-info-circle"}{/icon} 
     {capture assign=crmURL}{crmURL p='civicrm/admin/member/membershipType/add' q="action=add&reset=1"}{/capture}{ts 1=$crmURL}There are no membership types entered. You can <a href='%1'>add one</a>.{/ts}
   </div>
   {/if}


### PR DESCRIPTION
White text on light blue background has a 1.26 contrast ratio, failing WCAG 2.0. Black text is 16.56 and passes.

Before
----------------------------------------
<img width="324" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/6415073c-1e4b-408f-8579-b9a0f1d67367">

After
----------------------------------------
<img width="322" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/4dc37834-ea1f-484c-a296-0888ca2e3914">

Comments
----------------------------------------
Swapped for black rather than a shade of blue, as that's the simplest, least opinionated fix.