### PR TITLE
A11y: Fix info button contrast ratio

### DIFF
--- a/ext/greenwich/scss/_greenwich.scss
+++ b/ext/greenwich/scss/_greenwich.scss
@@ -159,7 +159,7 @@ $btn-success-color: rgb(255, 255, 255);
 $btn-success-bg: $brand-success;
 $btn-success-border: $btn-success-bg;
 
-$btn-info-color: rgb(255, 255, 255);
+$btn-info-color: rgb(0, 0, 0);
 $btn-info-bg: $brand-info;
 $btn-info-border: $btn-info-bg;
 


### PR DESCRIPTION
White text on light blue background has a 1.26 contrast ratio, failing WCAG 2.0. Black text is 16.56 and passes.

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/1175967/6a731858-106b-47ee-a456-e099a910d601)

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/1175967/a94c8228-1b56-422c-9f1c-f740289d227d)

Comments
----------------------------------------
Swapped for black rather than a shade of blue, as that seemed the simplest, least opinionated fix.