### PR TITLE
Match event breadcrumb label to context

### DIFF
--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -181,13 +181,14 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
     // Set Done button URL and breadcrumb. Templates go back to Manage Templates,
     // otherwise go to Manage Event for new event or ManageEventEdit if event if exists.
     if (!$this->_isTemplate) {
-      $breadCrumb = ['title' => ts('Manage Events')];
       if ($this->_id) {
+        $breadCrumb = ['title' => ts('Configure Event')];
         $breadCrumb['url'] = CRM_Utils_System::url(CRM_Utils_System::currentPath(),
           "action=update&reset=1&id={$this->_id}"
         );
       }
       else {
+        $breadCrumb = ['title' => ts('Manage Events')];
         $breadCrumb['url'] = CRM_Utils_System::url('civicrm/event/manage',
           'reset=1'
         );


### PR DESCRIPTION
Overview
----------------------------------------
Small change to match the text in the event breadcrumb label to its context. Fixes minor issue raised by [this question on SE](https://civicrm.stackexchange.com/questions/46513/save-done-button).