### PR TITLE
Finish making DedupeRule sql() static

### DIFF
--- a/CRM/Dedupe/BAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/BAO/DedupeRuleGroup.php
@@ -245,7 +245,7 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
       $queries = [];
       while ($bao->fetch()) {
         // Skipping empty rules? Empty rules shouldn't exist; why check?
-        if ($query = $bao->sql($this->params, $this->contactIds, [
+        if ($query = CRM_Dedupe_BAO_DedupeRule::sql($this->params, $this->contactIds, [
           'id' => (int) $bao->id,
           'rule_table' => $bao->rule_table,
           'rule_length' => $bao->rule_length,


### PR DESCRIPTION


Overview
----------------------------------------
Finish making DedupeRule sql() static

This is to make it cleaner to move to the class where it makes sense

I did a universe search on the whole class & marked all the functions internal
- although one of the functions I don't plan to touch is called from CiviHR & some test code in an even older extension via the deprecated CRM_Dedupe_BAO_Rule class. In the case of the non-Civi-HR function the results are used for var_dump() only....

Before
----------------------------------------
functions non-static

After
----------------------------------------
static

Technical Details
----------------------------------------

Comments
----------------------------------------
