### PR TITLE
SearchKit - Support field comparisons in HAVING clause

### DIFF
--- a/Civi/Api4/Generic/Traits/GroupAndHavingParamTrait.php
+++ b/Civi/Api4/Generic/Traits/GroupAndHavingParamTrait.php
@@ -52,14 +52,15 @@ trait GroupAndHavingParamTrait {
    * @param string $expr
    * @param string $op
    * @param mixed $value
+   * @param bool $isExpression
    * @return $this
    * @throws \CRM_Core_Exception
    */
-  public function addHaving(string $expr, string $op, $value = NULL) {
+  public function addHaving(string $expr, string $op, $value = NULL, bool $isExpression = FALSE) {
     if (!in_array($op, CoreUtil::getOperators())) {
       throw new \CRM_Core_Exception('Unsupported operator');
     }
-    $this->having[] = [$expr, $op, $value];
+    $this->having[] = [$expr, $op, $value, $isExpression];
     return $this;
   }
 

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -22,6 +22,7 @@ namespace api\v4\Action;
 use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
 use Civi\Api4\Email;
+use Civi\Api4\Individual;
 use Civi\Api4\Relationship;
 use Civi\Test\TransactionalInterface;
 
@@ -411,6 +412,23 @@ class ContactGetTest extends Api4TestBase implements TransactionalInterface {
       ->addClause('OR', ['first_name', '=', '🚂'], ['last_name', '=', '🚂'])
       ->setCheckPermissions(FALSE)
       ->execute();
+  }
+
+  public function testCompareWithHaving(): void {
+    $same = $this->createTestRecord('Individual', [
+      'first_name' => 'Hi 😁',
+      'last_name' => 'Hi 😁',
+    ]);
+    $diff = $this->createTestRecord('Individual', [
+      'first_name' => 'Hi 😁',
+      'last_name' => 'Hi ☹️',
+    ]);
+    $result = Individual::get(FALSE)
+      ->addWhere('first_name', '=', 'Hi 😁')
+      ->addHaving('first_name', '=', 'last_name', TRUE)
+      ->execute()->indexBy('id')->column('first_name');
+    $this->assertEquals('Hi 😁', $result[$same['id']]);
+    $this->assertArrayNotHasKey($diff['id'], $result);
   }
 
   public function testAge(): void {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes broken field-comparison feature in SearchKit. It works for WHERE, but was not working for HAVING.

Before
----------------------------------------
This does not work (will return no results):
![image](https://github.com/civicrm/civicrm-core/assets/2874912/363b68db-4ebf-485b-a0c9-ab70836e3edc)


After
----------------------------------------
Works - above example will show all contacts whose first name equals their last name.

Technical Details
------
This fixes APIv4 to allow HAVING to refer to a column instead of a scalar value.
