### PR TITLE
Convert accordions under ext

### DIFF
--- a/ext/civigrant/templates/CRM/Grant/Form/Search.tpl
+++ b/ext/civigrant/templates/CRM/Grant/Form/Search.tpl
@@ -9,10 +9,10 @@
 *}
 
 <div class="crm-block crm-form-block crm-search-form-block">
-  <div class="crm-accordion-wrapper crm-member_search_form-accordion {if $rows}collapsed{/if}">
-   <div class="crm-accordion-header crm-master-accordion-header">
+  <details class="crm-accordion-light crm-member_search_form-accordion" {if $rows}{else}open{/if}>
+   <summary>
       {ts}Edit Search Criteria{/ts}
-    </div><!-- /.crm-accordion-header -->
+    </summary>
   <div class="crm-accordion-body">
       {strip}
         <div class="help">
@@ -30,7 +30,7 @@
         </table>
         {/strip}
     </div><!-- /.crm-accordion-body -->
-  </div><!-- /.crm-accordion-wrapper -->
+  </details>
 </div><!-- /.crm-form-block -->
 
 <div class="crm-content-block">

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom.tpl
@@ -11,10 +11,10 @@
    custom search .php file. If you want a different layout, clone and customize this file and point to new file using
    templateFile() function.*}
 <div class="crm-block crm-form-block crm-contact-custom-search-form-block">
-<div class="crm-accordion-wrapper crm-custom_search_form-accordion {if $rows}collapsed{/if}">
-    <div class="crm-accordion-header crm-master-accordion-header">
+<details class="crm-accordion-light crm-custom_search_form-accordion" {if $rows}{else}open{/if}>
+    <summary>
       {ts}Edit Search Criteria{/ts}
-    </div><!-- /.crm-accordion-header -->
+    </summary>
     <div class="crm-accordion-body">
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
         <table class="form-layout-compressed">
@@ -28,7 +28,7 @@
         </table>
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
     </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 </div><!-- /.crm-form-block -->
 
 {if $rowsEmpty || $rows}

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/ActivitySearch.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/ActivitySearch.tpl
@@ -9,10 +9,10 @@
 *}
 {* Template for "Sample" custom search component. *}
 <div class="crm-form-block crm-search-form-block">
-  <div class="crm-accordion-wrapper crm-activity_search-accordion {if $rows}collapsed{/if}">
-    <div class="crm-accordion-header crm-master-accordion-header">
+  <details class="crm-accordion-light crm-activity_search-accordion" {if $rows}{else}open{/if}>
+    <summary>
       {ts}Edit Search Criteria{/ts}
-    </div><!-- /.crm-accordion-header -->
+    </summary>
     <div class="crm-accordion-body">
       <div id="searchForm" class="crm-block crm-form-block crm-contact-custom-search-activity-search-form-block">
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
@@ -28,7 +28,7 @@
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
       </div>
     </div><!-- /.crm-accordion-body -->
-  </div><!-- /.crm-accordion-wrapper -->
+  </details>
 </div><!-- /.crm-form-block -->
 
 {if $rowsEmpty || $rows}

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/ContribSYBNT.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/ContribSYBNT.tpl
@@ -11,10 +11,10 @@
    custom search .php file. If you want a different layout, clone and customize this file and point to new file using
    templateFile() function.*}
 <div class="crm-block crm-form-block crm-contact-custom-search-form-block">
-<div class="crm-accordion-wrapper crm-custom_search_form-accordion {if $rows}collapsed{/if}">
-    <div class="crm-accordion-header crm-master-accordion-header">
+<details class="crm-accordion-light crm-custom_search_form-accordion" {if $rows}{else}open{/if}>
+    <summary>
       {ts}Edit Search Criteria{/ts}
-    </div><!-- /.crm-accordion-header -->
+    </summary>
     <div class="crm-accordion-body">
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
         <table class="form-layout-compressed">
@@ -57,7 +57,7 @@
         </table>
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
     </div><!-- /.crm-accordion-body -->
-    </div><!-- /.crm-accordion-wrapper -->
+    </details>
     </div><!-- /.crm-form-block -->
 
 {if $rowsEmpty || $rows}

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/ContributionAggregate.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/ContributionAggregate.tpl
@@ -8,10 +8,10 @@
  +--------------------------------------------------------------------+
 *}
 <div class="crm-block crm-form-block crm-contact-custom-search-form-block">
-<div class="crm-accordion-wrapper crm-custom_search_form-accordion {if $rows}collapsed{/if}">
-    <div class="crm-accordion-header crm-master-accordion-header">
+<details class="crm-accordion-light crm-custom_search_form-accordion" {if $rows}{else}open{/if}>
+    <summary>
       {ts}Edit Search Criteria{/ts}
-    </div><!-- /.crm-accordion-header -->
+    </summary>
     <div class="crm-accordion-body">
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
         <table class="form-layout-compressed">
@@ -37,7 +37,7 @@
         </table>
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
     </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 </div><!-- /.crm-form-block -->
 
 {if $rowsEmpty || $rows}

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/EventDetails.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/EventDetails.tpl
@@ -11,10 +11,10 @@
 {assign var="showBlock" value="'searchForm'"}
 {assign var="hideBlock" value="'searchForm_show','searchForm_hide'"}
 <div class="crm-block crm-form-block crm-search-form-block">
-  <div class="crm-accordion-wrapper crm-eventDetails_search-accordion {if $rows}collapsed{/if}">
-    <div class="crm-accordion-header crm-master-accordion-header">
+  <details class="crm-accordion-light crm-eventDetails_search-accordion" {if $rows}{else}open{/if}>
+    <summary>
       {ts}Edit Search Criteria{/ts}
-    </div><!-- /.crm-accordion-header -->
+    </summary>
     <div class="crm-accordion-body">
       <div id="searchForm" class="crm-block crm-form-block crm-contact-custom-search-eventDetails-form-block">
           <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
@@ -43,7 +43,7 @@
           <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
       </div>
     </div>
-  </div>
+  </details>
 
 {if $rowsEmpty}
     {include file="CRM/Contact/Form/Search/Custom/EmptyResults.tpl"}

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/MultipleValuesCriteria.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/MultipleValuesCriteria.tpl
@@ -14,10 +14,10 @@
 
 {strip}
 <div class="crm-block crm-form-block crm-basic-criteria-form-block">
-    <div class="crm-accordion-wrapper crm-case_search-accordion {if $rows}collapsed{/if}">
-     <div class="crm-accordion-header crm-master-accordion-header">
+    <details class="crm-accordion-light crm-case_search-accordion" {if $rows}{else}open{/if}>
+     <summary>
         {$editTitle}
-    </div><!-- /.crm-accordion-header -->
+    </summary>
     <div class="crm-accordion-body">
         <div class="crm-section sort_name-section">
           <div class="label">
@@ -88,6 +88,6 @@
 
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>
     </div><!-- /.crm-accordion-body -->
-    </div><!-- /.crm-accordion-wrapper -->
+    </details>
 </div><!-- /.crm-form-block -->
 {/strip}

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/Proximity.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/Proximity.tpl
@@ -11,10 +11,10 @@
    custom search .php file. If you want a different layout, clone and customize this file and point to new file using
    templateFile() function.*}
 <div class="crm-block crm-form-block crm-contact-custom-search-form-block">
-<div class="crm-accordion-wrapper crm-custom_search_form-accordion {if $rows}collapsed{/if}">
-    <div class="crm-accordion-header crm-master-accordion-header">
+<details class="crm-accordion-light crm-custom_search_form-accordion" {if $rows}{else}open{/if}>
+    <summary>
       {ts}Edit Search Criteria{/ts}
-    </div><!-- /.crm-accordion-header -->
+    </summary>
     <div class="crm-accordion-body">
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
         <table class="form-layout-compressed">
@@ -35,7 +35,7 @@
         </table>
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
     </div><!-- /.crm-accordion-body -->
-</div><!-- /.crm-accordion-wrapper -->
+</details>
 </div><!-- /.crm-form-block -->
 
 {if $rowsEmpty || $rows}

--- a/ext/oauth-client/templates/CRM/OAuth/Page/Return.tpl
+++ b/ext/oauth-client/templates/CRM/OAuth/Page/Return.tpl
@@ -1,8 +1,8 @@
 {if $error}
-    <div class="crm-accordion-wrapper">
-        <div class="crm-accordion-header">
+    <details class="crm-accordion-bold" open>
+        <summary>
             {ts}OAuth Error Details{/ts}
-        </div>
+        </summary>
         <div class="crm-accordion-body">
             <ul>
                 <li><strong>{ts}Error type:{/ts}</strong> {$error.error|escape:'html'}</li>
@@ -12,30 +12,30 @@
                 <li><strong>{ts}Error URI:{/ts}</strong> <code>{$error.error_uri|escape:'html'}</code></li>
             </ul>
         </div>
-    </div>
+    </details>
 {else}
     <p>{ts}An OAuth token was created!{/ts}</p>
     <p>{ts}There is no clear "next step", so this may be a new integration. Please update the integration to define a next step via "hook_civicrm_oauthReturn" or "landingUrl".{/ts}</p>
 {/if}
 
 {if $stateJson}
-    <div class="crm-accordion-wrapper collapsed">
-        <div class="crm-accordion-header">
+    <details class="crm-accordion-bold">
+        <summary>
             {ts}OAuth State{/ts}
-        </div>
+        </summary>
         <div class="crm-accordion-body">
             <pre>{$stateJson}</pre>
         </div>
-    </div>
+    </details>
 {/if}
 
 {if $tokenJson}
-    <div class="crm-accordion-wrapper collapsed">
-        <div class="crm-accordion-header">
+    <details class="crm-accordion-bold">
+        <summary>
             {ts}OAuth Token{/ts}
-        </div>
+        </summary>
         <div class="crm-accordion-body">
             <pre>{$tokenJson}</pre>
         </div>
-    </div>
+    </details>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Converts the accordions under `civicrm/ext` to use the new `<details><summary>` accessible pattern.

Before
----------------------------------------
Old format 

After
----------------------------------------
New format

Things to test:

- [ ] ext/civigrant/templates/CRM/Grant/Form/Search.tpl
- [ ] ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom.tpl
- [ ] ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/ActivitySearch.tpl
- [ ] ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/ContribSYBNT.tpl
- [ ] ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/ContributionAggregate.tpl
- [ ] ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/EventDetails.tpl
- [ ] ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/MultipleValuesCriteria.tpl
- [ ] ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/Proximity.tpl
- [ ] ext/oauth-client/templates/CRM/OAuth/Page/Return.tpl

Technical Details
----------------------------------------
This continues the work in #29448 - same changes applied to files under `civicrm/ext`

Comments
----------------------------------------
This includes `legacycustomsearches` which are legacy(!) but the changes are simple and help to eliminate the old pattern.
