### PR TITLE
Deprecate dupeQuery hook

### DIFF
--- a/CRM/Dedupe/BAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/BAO/DedupeRuleGroup.php
@@ -120,7 +120,7 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
         }
       }
       //Does this have to run outside of cache?
-      CRM_Utils_Hook::dupeQuery(CRM_Core_DAO::$_nullObject, 'supportedFields', $fields);
+      CRM_Utils_Hook::dupeQuery(NULL, 'supportedFields', $fields);
       Civi::$statics[__CLASS__]['supportedFields'] = $fields;
     }
 

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1627,15 +1627,17 @@ abstract class CRM_Utils_Hook {
    *   Type of queries e.g table / threshold.
    * @param array $query
    *   Set of queries.
-   *
-   * @return mixed
    */
   public static function dupeQuery($obj, $type, &$query) {
     $null = NULL;
-    return self::singleton()->invoke(['obj', 'type', 'query'], $obj, $type, $query,
+    $original = $query;
+    self::singleton()->invoke(['obj', 'type', 'query'], $obj, $type, $query,
       $null, $null, $null,
       'civicrm_dupeQuery'
     );
+    if ($original !== $query) {
+      CRM_Core_Error::deprecatedWarning('hook_civicrm_dupeQuery is deprecated.');
+    }
   }
 
   /**

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1619,6 +1619,8 @@ abstract class CRM_Utils_Hook {
   /**
    * This hook allows modification of the queries constructed from dupe rules.
    *
+   * @deprecated since 5.72
+   *
    * @param string $obj
    *   Object of rulegroup class.
    * @param string $type


### PR DESCRIPTION

Overview
----------------------------------------
Deprecte dupeQuery hook

Before
----------------------------------------
hook unused in universe & pretty fugly but no active discouragement

After
----------------------------------------
Marked deprecated - will do the same in docs

Technical Details
----------------------------------------
I did a universe search & found no usages - this hook feels to me like one of those things that got added cos it seemed like a good idea but was never really the right thing in the right place & not that useful. Let's deprecated it here & in the docs
& not encourage people to use it

Comments
----------------------------------------
