### PR TITLE
Ornery++

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -255,7 +255,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     }
 
     if (CRM_Core_Component::isEnabled('CiviMail') &&
-      CRM_Core_BAO_MailSettings::defaultDomain() == "EXAMPLE.ORG"
+      CRM_Core_BAO_MailSettings::defaultDomain() === "EXAMPLE.ORG"
     ) {
       $message = new CRM_Utils_Check_Message(
         __FUNCTION__,

--- a/tests/phpunit/CRM/Mailing/MailingSystemTestBase.php
+++ b/tests/phpunit/CRM/Mailing/MailingSystemTestBase.php
@@ -18,6 +18,7 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\MailSettings;
 use GuzzleHttp\Psr7\Request;
 
 /**
@@ -41,7 +42,6 @@ abstract class CRM_Mailing_MailingSystemTestBase extends CiviUnitTestCase {
     parent::setUp();
     $this->useTransaction();
     CRM_Mailing_BAO_MailingJob::$mailsProcessed = 0;
-    CRM_Core_BAO_MailSettings::defaultDAO(TRUE);
 
     $this->_groupID = $this->groupCreate();
     $this->createContactsInGroup(2, $this->_groupID);
@@ -142,9 +142,11 @@ abstract class CRM_Mailing_MailingSystemTestBase extends CiviUnitTestCase {
     $this->assertEquals(2, $getMembers('Removed')->count());
   }
 
-  public function testHttpUnsubscribe_altVerp(): void {
-    CRM_Core_DAO::executeQuery('UPDATE civicrm_mail_settings SET localpart = "aeiou.aeiou-"');
-    CRM_Core_BAO_MailSettings::defaultDAO(TRUE);
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function testHttpUnsubscribeChangedVerpSeparator(): void {
+    MailSettings::update(FALSE)->setValues(['localpart' => "aeiou.aeiou-"])->addWhere('id', '>', 0)->execute();
 
     try {
       Civi::settings()->set('verpSeparator', '-');

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -838,6 +838,10 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
   }
 
   /**
+   * As the test is slow we mark it ornery to suppress in PR runs.
+   *
+   * @group ornery
+   *
    * @dataProvider custom_data_incl_non_std_entities_get
    *
    * @param string $entityName
@@ -1287,10 +1291,17 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
    *
    * limitations include the problem with avoiding loops when creating test objects -
    * hence FKs only set by createTestObject when required. e.g parent_id on campaign is not being followed through
-   * Currency - only seems to support US
-   * @param $entityName
+   * Currency - only seems to support US.
+   *
+   * As the test is slow we mark it ornery to suppress in PR runs.
+   *
+   * @param string $entityName
+   *
+   * @group ornery
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testCreateSingleValueAlter($entityName): void {
+  public function testCreateSingleValueAlter(string $entityName): void {
     if (in_array($entityName, $this->toBeImplemented['create'], TRUE)) {
       // $this->markTestIncomplete("civicrm_api3_{$Entity}_create to be implemented");
       return;

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -1095,6 +1095,10 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
   /**
    * Ensure that the "get" operation accepts limiting the #result records.
    *
+   * As the test is slow we mark it ornery to suppress in PR runs.
+   *
+   * @group ornery
+   *
    * @dataProvider entities_getSqlOperators
    *
    * @param string $entityName
@@ -1234,11 +1238,16 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
   /* ---- testing the _create ---- */
 
   /**
+   * As the test is slow we mark it ornery to suppress in PR runs.
+   *
+   * @group ornery
+   *
    * @dataProvider toBeSkipped_create
    * entities that don't need a create action
+   *
    * @param $Entity
    */
-  public function testNotImplemented_create($Entity) {
+  public function testNotImplementedCreate($Entity) {
     $result = civicrm_api($Entity, 'Create', ['version' => 3]);
     $this->assertEquals(1, $result['is_error']);
     $this->assertStringContainsString(strtolower("API ($Entity, Create) does not exist"), strtolower($result['error_message']));
@@ -1540,10 +1549,15 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
   }
 
   /**
+   *  As the test is slow we mark it ornery to suppress in PR runs.
+   *
+   * @group ornery
+   *
    * @dataProvider entities_delete
+   *
    * @param $Entity
    */
-  public function testEmptyParam_delete($Entity) {
+  public function testEmptyParamDelete($Entity) {
     if (in_array($Entity, $this->toBeImplemented['delete'])) {
       // $this->markTestIncomplete("civicrm_api3_{$Entity}_delete to be implemented");
       return;

--- a/tests/phpunit/api/v3/SystemCheckTest.php
+++ b/tests/phpunit/api/v3/SystemCheckTest.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\StatusPreference;
+
 /**
  * System.check API has many special test cases, so they have their own class.
  *
@@ -21,8 +23,14 @@
  */
 class api_v3_SystemCheckTest extends CiviUnitTestCase {
 
+  /**
+   * @throws \CRM_Core_Exception
+   */
   public function setUp(): void {
     parent::setUp();
+    CRM_Core_BAO_ConfigSetting::enableComponent('CiviMail');
+    StatusPreference::update(FALSE)->setValues(['is_active', '=', TRUE])
+      ->addWhere('is_active', '=', FALSE)->execute();
     $this->useTransaction(TRUE);
   }
 
@@ -35,7 +43,7 @@ class api_v3_SystemCheckTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function testSystemCheckBasic($version) {
+  public function testSystemCheckBasic(int $version): void {
     $this->_apiversion = $version;
     $this->runStatusCheck([], ['severity_id' => 3]);
   }
@@ -143,7 +151,7 @@ class api_v3_SystemCheckTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function testSystemCheckHushAboveSeverity($version) {
+  public function testSystemCheckHushAboveSeverity($version): void {
     $this->_apiversion = $version;
     $this->runStatusCheck([
       'name' => 'checkDefaultMailbox',
@@ -176,7 +184,7 @@ class api_v3_SystemCheckTest extends CiviUnitTestCase {
    * @dataProvider versionThreeAndFour
    * @throws \CRM_Core_Exception
    */
-  public function testSystemCheckHushBelowSeverity($version) {
+  public function testSystemCheckHushBelowSeverity(int $version): void {
     $this->_apiversion = $version;
     $this->runStatusCheck([
       'name' => 'checkDefaultMailbox',
@@ -193,7 +201,7 @@ class api_v3_SystemCheckTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  protected function runStatusCheck($params, $expected) {
+  protected function runStatusCheck(array $params, $expected): void {
     if (!empty($params)) {
       $this->callAPISuccess('StatusPreference', 'create', $params);
     }


### PR DESCRIPTION
Overview
----------------------------------------
This flags some particularly slow tests in the apiv3SyntaxConfirmanceTest so they do not run on PR runs. These tests used to be a good little canaries but have grown soft & fat as we improved our code & no longer have the stamina to run several times a day in a timely manner

Before
----------------------------------------
On PRs submitted about the same time
![image](https://github.com/civicrm/civicrm-core/assets/336308/9c7ddca5-7670-493c-84e2-cd40493d8ac9)

![image](https://github.com/civicrm/civicrm-core/assets/336308/ecb165dd-2d37-4c69-96dc-e00b5262b923)


After
----------------------------------------
On this PR apiv3 time taken

![image](https://github.com/civicrm/civicrm-core/assets/336308/28feb945-0373-4729-a14c-d518f5b5054c)

& with the second ornery 

![image](https://github.com/civicrm/civicrm-core/assets/336308/a84d52dc-e42d-467d-a230-b80e1924bd96)


Technical Details
----------------------------------------
There are a couple of other tests we could do this to but with this change the apiv3 tests are faster than the crm test so there might not be much to gain from further apiv3 test speed improvements

Comments
----------------------------------------
