### PR TITLE
Fixes to Accordion CSS, following recent PRs

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2194,6 +2194,10 @@ div.crm-master-accordion-header a.helpicon {
 
 /* Specific types of headers */
 
+.crm-container details {
+  margin: 0.25rem 0;
+}
+
 .crm-container summary { /* default summary setting*/
   display: list-item;
   list-style: none;
@@ -2321,7 +2325,7 @@ div.crm-master-accordion-header a.helpicon {
 /* Accordion bodies */
 
 .crm-container .crm-accordion-wrapper .crm-accordion-body,
-.crm-container details.crm-accordion-bold > .crm-accordion-body {
+.crm-container details.crm-accordion-bold .crm-accordion-body {
   border-radius: 0 0 4px 4px;
   border: 1px solid #70716b;
   border-top: 0;

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2325,7 +2325,7 @@ div.crm-master-accordion-header a.helpicon {
 /* Accordion bodies */
 
 .crm-container .crm-accordion-wrapper .crm-accordion-body,
-.crm-container details.crm-accordion-bold .crm-accordion-body {
+.crm-container details.crm-accordion-bold > .crm-accordion-body {
   border-radius: 0 0 4px 4px;
   border: 1px solid #70716b;
   border-top: 0;

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2321,7 +2321,7 @@ div.crm-master-accordion-header a.helpicon {
 /* Accordion bodies */
 
 .crm-container .crm-accordion-wrapper .crm-accordion-body,
-.crm-container details.crm-accordion-bold .crm-accordion-body {
+.crm-container details.crm-accordion-bold > .crm-accordion-body {
   border-radius: 0 0 4px 4px;
   border: 1px solid #70716b;
   border-top: 0;


### PR DESCRIPTION
Overview
----------------------------------------
Addresses two visual issues with the accordion upgrades in #29448 & #29533: 
1. the `.crm-accordion-bold` border is inherited by a nested `.crm-accordion-light` accordion, which shouldn't have a border, as raised here: https://github.com/civicrm/civicrm-core/pull/29533#issuecomment-1971933843. This forces the border onto direct descendants only
2. multiple accordions together have no space between them.
 
Before
----------------------------------------
<img width="1441" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/15cd1078-8979-4653-93e6-26b8b09542c6">

After
----------------------------------------
<img width="1443" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/ce488d18-2aef-444b-b113-6edf488e1d87">

Technical Details
----------------------------------------
The padding around accordions impacts all new accordions, but makes them look closer to the Civi's old handling of multiple accordions.

With the new accordion pattern:
<img width="1439" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/8fede5e3-d291-488a-9952-3cc7dbe14859">

With the old accordion pattern:
<img width="1445" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/15fafcc6-7cad-4618-bdd6-2f2b7799547d">

With the new pattern, and this PR's css:
<img width="1436" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/3ac2f13d-c6fc-45be-b3ac-693ba03a0232">
