### PR TITLE
core/-/issues/5050 Message Templates: Membership Receipt, On-line and Contribution Receipt, On-line - both include userText ("Receipt Message") which is not used for these workflows.

### DIFF
--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -21,9 +21,7 @@
   <tr>
    <td>
      {assign var="greeting" value="{contact.email_greeting_display}"}{if $greeting}<p>{$greeting},</p>{/if}
-     {if $userText}
-       <p>{$userText}</p>
-     {elseif {contribution.contribution_page_id.receipt_text|boolean}}
+     {if {contribution.contribution_page_id.receipt_text|boolean}}
        <p>{contribution.contribution_page_id.receipt_text}</p>
      {/if}
 

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -21,9 +21,7 @@
   <tr>
    <td>
      {assign var="greeting" value="{contact.email_greeting_display}"}{if $greeting}<p>{$greeting},</p>{/if}
-     {if $userText}
-       <p>{$userText}</p>
-     {elseif {contribution.contribution_page_id.receipt_text|boolean}}
+     {if {contribution.contribution_page_id.receipt_text|boolean}}
        <p>{contribution.contribution_page_id.receipt_text}</p>
      {/if}
     {if {contribution.balance_amount|boolean} && {contribution.is_pay_later|boolean}}


### PR DESCRIPTION
Overview
----------------------------------------
Message Templates: Membership Receipt, On-line and Contribution Receipt, On-line - both include userText ("Receipt Message”) which is not used for these workflows. The userText ("Receipt Message") is only used when recording a Contribution, off-line.

userText ("Receipt Message") is not set for the following workflows:

- Membership, Off-line
- Membership, On-line
- Contribution, On-line

To summarise when a Receipt Message is set or available:

- Membership, Off-line - When the user sets the Receipt Message field
- Membership, On-line - On the related Contribution Page
- Contribution, Off-line - No ability to set a Receipt Message, field is not available
- Contribution, On-line - On the related Contribution Page

See https://lab.civicrm.org/dev/core/-/issues/5050

Before
----------------------------------------
Extra logic is included the message templates, which is not required.

After
----------------------------------------
Logic removed.

Technical Details
----------------------------------------

Comments
----------------------------------------
Would really prefer that tokens in the message templates themselves have the logic defined in code to determine what value to output, rather than this logic being defined in the message template. Making the message template more complex and harder to maintain.

Agileware Ref: CIVICRM-2226