### PR TITLE
Support alterEntityRefParams hook on addAutocomplete() function

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2385,6 +2385,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     }
     $props['class'] = ltrim(($props['class'] ?? '') . ' crm-form-autocomplete');
     $props['placeholder'] ??= self::selectOrAnyPlaceholder($props, $required);
+    CRM_Utils_Hook::alterEntityRefParams($props, get_class($this));
     $props['data-select-params'] = json_encode($props['select']);
     $props['data-api-params'] = json_encode($props['api']);
     $props['data-api-entity'] = $props['entity'];


### PR DESCRIPTION
Overview
----------------------------------------
In Civi 5.65 we were allowed to change the params of entity refs (any entityref and custom field type auto-complete). In the current version i.e 5.70 custom field auto-complete is switched to use API4 via CRM_Core_Form->addAutocomplete() which does not invoke the hook any more. This PR will provide hook to alter the params for the Auto-complete field.