### PR TITLE
if no clicks, display 0 rather than empty string

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2822,8 +2822,8 @@ ORDER BY civicrm_mailing.id DESC";
       //CRM-12814
       $clicks = $clickCounts[$values['mailing_id']] ?? 0;
       $opens = $openCounts[$values['mailing_id']] ?? 0;
-      $mailing['openstats'] = "Opens: {$opens}" .
-        "<br />Clicks: {$clicks}";
+      $mailing['openstats'] = ts('Opens: %1', [1 => $opens]) . '<br />' .
+        ts('Clicks: %1', [1 => $clicks]);
 
       $actionLinks = [
         CRM_Core_Action::VIEW => [

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2820,10 +2820,10 @@ ORDER BY civicrm_mailing.id DESC";
         "mid={$values['mailing_id']}&reset=1&cid={$params['contact_id']}&event=queue&context=mailing");
       $mailing['start_date'] = CRM_Utils_Date::customFormat($values['start_date']);
       //CRM-12814
-      $mailing['openstats'] = "Opens: " .
-        CRM_Utils_Array::value($values['mailing_id'], $openCounts, 0) .
-        "<br />Clicks: " .
-        $clickCounts[$values['mailing_id']] ?? 0;
+      $clicks = $clickCounts[$values['mailing_id']] ?? 0;
+      $opens = $openCounts[$values['mailing_id']] ?? 0;
+      $mailing['openstats'] = "Opens: {$opens}" .
+        "<br />Clicks: {$clicks}";
 
       $actionLinks = [
         CRM_Core_Action::VIEW => [


### PR DESCRIPTION
Overview
----------------------------------------
The display of clicks in the Mailings tab shows an empty string instead of 0.

Before
----------------------------------------

Confusing - looks like the display of clicks is broken:

![empty-clicks](https://github.com/civicrm/civicrm-core/assets/4511942/a578bb7e-ddf7-4c9f-bfc8-4e4edee43c74)

After
----------------------------------------
Now, clicks display properly as zero:

![zero-clicks](https://github.com/civicrm/civicrm-core/assets/4511942/50115d30-fcc3-4478-9489-3f295107410f)


Technical Details
----------------------------------------

I love the NULL coalesce operator! Unfortunately, it only seems to work when assigning variables, not when appending. At least I think that is what is going wrong? 

Comments
----------------------------------------

I also opted to make consistent the collection of both clicks and opens just so it's more readable. I think the coalesce operator is our preferred method rather than using `CRM_Utils_Array::value`?