### PR TITLE
Replace assign_by_ref with assign

### DIFF
--- a/CRM/Contact/Page/View/UserDashBoard/GroupContact.php
+++ b/CRM/Contact/Page/View/UserDashBoard/GroupContact.php
@@ -53,9 +53,9 @@ class CRM_Contact_Page_View_UserDashBoard_GroupContact extends CRM_Contact_Page_
     );
 
     $this->assign('groupCount', $count);
-    $this->assign_by_ref('groupIn', $in);
-    $this->assign_by_ref('groupPending', $pending);
-    $this->assign_by_ref('groupOut', $out);
+    $this->assign('groupIn', $in);
+    $this->assign('groupPending', $pending);
+    $this->assign('groupOut', $out);
   }
 
   /**

--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -430,7 +430,7 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
 
     // this required to show billing block
     // @todo remove this assignment the billing block is now designed to be always included but will not show fieldsets unless those sets of fields are assigned
-    $this->assign_by_ref('paymentProcessor', $this->_paymentProcessor);
+    $this->assign('paymentProcessor', $this->_paymentProcessor);
   }
 
   /**

--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -239,6 +239,8 @@ class CRM_Contribute_Form_AdditionalInfo {
    * @param int $contactID
    * @param int $contributionID
    * @param int $contributionNoteID
+   *
+   * @throws \CRM_Core_Exception
    */
   public static function processNote($params, $contactID, $contributionID, $contributionNoteID = NULL) {
     if (CRM_Utils_System::isNull($params['note']) && $contributionNoteID) {
@@ -322,7 +324,7 @@ class CRM_Contribute_Form_AdditionalInfo {
     if (!empty($params['payment_instrument_id'])) {
       $paymentInstrument = CRM_Contribute_PseudoConstant::paymentInstrument();
       $params['paidBy'] = $paymentInstrument[$params['payment_instrument_id']];
-      if ($params['paidBy'] != 'Check' && isset($params['check_number'])) {
+      if ($params['paidBy'] !== 'Check' && isset($params['check_number'])) {
         unset($params['check_number']);
       }
     }
@@ -421,7 +423,7 @@ class CRM_Contribute_Form_AdditionalInfo {
       $form->assign('customGroup', $customGroup);
     }
 
-    $form->assign_by_ref('formValues', $params);
+    $form->assign('formValues', $params);
     list($contributorDisplayName,
       $contributorEmail
       ) = CRM_Contact_BAO_Contact_Location::getEmailDetails($params['contact_id']);

--- a/CRM/Contribute/Form/ContributionPage/TabHeader.php
+++ b/CRM/Contribute/Form/ContributionPage/TabHeader.php
@@ -31,7 +31,7 @@ class CRM_Contribute_Form_ContributionPage_TabHeader {
       $tabs = self::process($form);
       $form->set('tabHeader', $tabs);
     }
-    $form->assign_by_ref('tabHeader', $tabs);
+    $form->assign('tabHeader', $tabs);
     CRM_Core_Resources::singleton()
       ->addScriptFile('civicrm', 'templates/CRM/common/TabHeader.js', 1, 'html-header')
       ->addSetting([

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -199,9 +199,9 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       }
     }
 
-    $template->assign_by_ref('error', $error);
+    $template->assign('error', $error);
     $errorDetails = CRM_Core_Error::debug('', $error, FALSE);
-    $template->assign_by_ref('errorDetails', $errorDetails);
+    $template->assign('errorDetails', $errorDetails);
 
     CRM_Core_Error::debug_var('Fatal Error Details', $error, TRUE, TRUE, '', PEAR_LOG_ERR);
     CRM_Core_Error::backtrace('backTrace', TRUE);


### PR DESCRIPTION

Overview
----------------------------------------
Replace assign_by_ref with assign

Before
----------------------------------------
`$smarty->assign_by_ref()`

After
----------------------------------------
`$smarty->assign()`

Technical Details
----------------------------------------
This continues the effort to replace assign_by_ref which smarty5 discontinues with assign

Note that we have never found a case where assign_by_ref is used in a way that would not work with assign & in fact in smarty3 we actually convert it to assign anyway


Comments
----------------------------------------
