### PR TITLE
[Update Subscription Form] Align UpdateSubscription to more recent practices

### DIFF
--- a/CRM/Contribute/Form/ContributionRecur.php
+++ b/CRM/Contribute/Form/ContributionRecur.php
@@ -14,6 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
+use Civi\Api4\Membership;
 
 /**
  * Shared parent class for recurring contribution forms.
@@ -39,7 +40,7 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
    *
    * @var int
    *
-   * @internal
+   * @deprecated
    */
   protected $_crid = NULL;
 
@@ -53,16 +54,16 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
    *
    * @internal
    */
-  protected $contributionRecurID = NULL;
+  protected int $contributionRecurID;
 
   /**
    * Membership ID.
    *
-   * @var int
+   * @var int|null
    *
    * @internal
    */
-  protected $_mid;
+  protected ?int $_mid;
 
   /**
    * Payment processor object.
@@ -188,15 +189,17 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
    * @return int
    */
   public function getContributionRecurID(): int {
-    $id = CRM_Utils_Request::retrieve('crid', 'Integer', $this, FALSE);
-    if (!$id && $this->getContributionID()) {
-      $id = $this->getContributionValue('contribution_recur_id');
+    if (!isset($this->contributionRecurID)) {
+      $id = CRM_Utils_Request::retrieve('crid', 'Integer', $this, FALSE);
+      if (!$id && $this->getContributionID()) {
+        $id = $this->getContributionValue('contribution_recur_id');
+      }
+      if (!$id) {
+        $id = $this->getMembershipValue('contribution_recur_id');
+      }
+      $this->contributionRecurID = $this->_crid = $id;
     }
-    if (!$id) {
-      $id = $this->getMembershipValue('contribution_recur_id');
-    }
-    $this->contributionRecurID = $this->_crid = $id;
-    return (int) $id;
+    return (int) $this->contributionRecurID;
   }
 
   /**
@@ -216,15 +219,37 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
   /**
    * Get the membership ID.
    *
+   * @return int
+   * @throws \CRM_Core_Exception
+   *
    * @api This function will not change in a minor release and is supported for
    * use outside of core. This annotation / external support for properties
    * is only given where there is specific test cover.
    *
-   * @return int
    */
   protected function getMembershipID(): ?int {
-    $this->_mid = CRM_Utils_Request::retrieve('mid', 'Integer', $this, FALSE);
-    return $this->_mid ? (int) $this->_mid : NULL;
+    $membershipID = CRM_Utils_Request::retrieve('mid', 'Integer', $this);
+    if (!isset($this->contributionRecurID)) {
+      // This is being called before the contribution recur ID is set - return quickly to avoid a loop.
+      return $membershipID ? (int) $membershipID : NULL;
+    }
+    if (!isset($this->_mid)) {
+      $this->_mid = NULL;
+      if (!$this->isDefined('Membership')) {
+        $membership = Membership::get(FALSE)
+          ->addWhere('contribution_recur_id', '=', $this->getContributionRecurID())
+          ->execute()->first();
+        if ($membershipID && (!$membership || ($membership['id'] !== $membershipID))) {
+          // this feels unreachable
+          throw new CRM_Core_Exception(ts('invalid membership ID'));
+        }
+        if ($membership) {
+          $this->define('Membership', 'Membership', $membership);
+          $this->_mid = $membership['id'];
+        }
+      }
+    }
+    return $this->_mid;
   }
 
   /**

--- a/CRM/Contribute/Form/ContributionRecur.php
+++ b/CRM/Contribute/Form/ContributionRecur.php
@@ -29,6 +29,8 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
    * Contribution ID.
    *
    * @var int
+   *
+   * @internal
    */
   protected $_coid = NULL;
 

--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -40,16 +40,16 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Contribute_Form_Contribution
       $this->_paymentProcessor['object'] = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->_coid, 'contribute', 'obj');
     }
 
-    if ($this->_mid) {
-      $this->_paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->_mid, 'membership', 'info');
-      $this->_paymentProcessor['object'] = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->_mid, 'membership', 'obj');
+    if ($this->getMembershipID()) {
+      $this->_paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->getMembershipID(), 'membership', 'info');
+      $this->_paymentProcessor['object'] = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->getMembershipID(), 'membership', 'obj');
       $membershipTypes = CRM_Member_PseudoConstant::membershipType();
-      $membershipTypeId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $this->_mid, 'membership_type_id');
+      $membershipTypeId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $this->getMembershipID(), 'membership_type_id');
       $this->assign('membershipType', CRM_Utils_Array::value($membershipTypeId, $membershipTypes));
       $this->_mode = 'auto_renew';
     }
 
-    if ((!$this->_crid && !$this->_coid && !$this->_mid) || (!$this->getSubscriptionDetails())) {
+    if ((!$this->_crid && !$this->_coid && !$this->getMembershipID()) || (!$this->getSubscriptionDetails())) {
       throw new CRM_Core_Exception('Required information missing.');
     }
 

--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -63,23 +63,13 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
       CRM_Core_Error::statusBounce(ts('Required information missing.'));
     }
 
-    if ($this->getSubscriptionDetails()->membership_id && $this->getSubscriptionDetails()->auto_renew) {
-      // Add Membership details to form
-      $membership = civicrm_api3('Membership', 'get', [
-        'contribution_recur_id' => $this->contributionRecurID,
-      ]);
-      if (!empty($membership['count'])) {
-        $membershipDetails = reset($membership['values']);
-        $values['membership_id'] = $membershipDetails['id'];
-        $values['membership_name'] = $membershipDetails['membership_name'];
-      }
-      $this->assign('recurMembership', $values);
-      $this->assign('contactId', $this->getSubscriptionContactID());
-    }
+    $this->assign('contactId', $this->getSubscriptionContactID());
+    $this->assign('membershipID', $this->getMembershipID());
+    $this->assign('membershipName', $this->getMembershipValue('name'));
 
     $this->assign('self_service', $this->isSelfService());
-    $this->assign('recur_frequency_interval', $this->getSubscriptionDetails()->frequency_interval);
-    $this->assign('recur_frequency_unit', $this->getSubscriptionDetails()->frequency_unit);
+    $this->assign('recur_frequency_interval', $this->getContributionRecurValue('frequency_interval'));
+    $this->assign('recur_frequency_unit', $this->getContributionRecurValue('frequency_unit'));
 
     $this->editableScheduleFields = $this->getPaymentProcessorObject()->getEditableRecurringScheduleFields();
 
@@ -175,7 +165,7 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
       CRM_Campaign_BAO_Campaign::addCampaign($this, $this->getSubscriptionDetails()->campaign_id);
     }
 
-    if (CRM_Contribute_BAO_ContributionRecur::supportsFinancialTypeChange($this->contributionRecurID)) {
+    if (CRM_Contribute_BAO_ContributionRecur::supportsFinancialTypeChange($this->getContributionRecurID())) {
       $this->addEntityRef('financial_type_id', ts('Financial Type'), ['entity' => 'FinancialType'], !$this->isSelfService());
     }
 

--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -58,15 +58,7 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
     parent::preProcess();
     $this->setAction(CRM_Core_Action::UPDATE);
 
-    if ($this->_coid) {
-      $this->_paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->_coid, 'contribute', 'info');
-      $this->contributionRecurID = $this->getSubscriptionDetails()->recur_id;
-    }
-    elseif ($this->contributionRecurID) {
-      $this->_coid = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $this->contributionRecurID, 'id', 'contribution_recur_id');
-    }
-
-    if (!$this->contributionRecurID || !$this->getSubscriptionDetails()) {
+    if (!$this->getSubscriptionDetails()) {
       CRM_Core_Error::statusBounce(ts('Required information missing.'));
     }
 
@@ -149,7 +141,7 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
   public function buildQuickForm() {
     // CRM-16398: If current recurring contribution got > 1 lineitems then make amount field readonly
     $amtAttr = ['size' => 20];
-    $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($this->_coid);
+    $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($this->getContributionID());
     if (count($lineItems) > 1) {
       $amtAttr += ['readonly' => TRUE];
     }

--- a/templates/CRM/Contribute/Form/UpdateSubscription.tpl
+++ b/templates/CRM/Contribute/Form/UpdateSubscription.tpl
@@ -48,7 +48,7 @@
   </table>
 
   {if !$self_service}
-    {include file="CRM/common/customDataBlock.tpl"}
+    {include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='ContributionRecur' customDataSubType=false entityID=$pledgeID cid=false}
   {/if}
 
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>

--- a/templates/CRM/Contribute/Form/UpdateSubscription.tpl
+++ b/templates/CRM/Contribute/Form/UpdateSubscription.tpl
@@ -11,9 +11,9 @@
   {if $changeHelpText}
     <div class="help">
       {$changeHelpText}
-      {if $recurMembership}
+      {if $membershipID}
         <br/><strong> {ts}WARNING: This recurring contribution is linked to membership:{/ts}
-        <a class="crm-hover-button" href='{crmURL p="civicrm/contact/view/membership" q="action=view&reset=1&cid=`$contactId`&id=`$recurMembership.membership_id`&context=membership&selectedChild=member"}'>{$recurMembership.membership_name}</a>
+        <a class="crm-hover-button" href='{crmURL p="civicrm/contact/view/membership" q="action=view&reset=1&cid=`$contactId`&id=`$membershipID`&context=membership&selectedChild=member"}'>{$membershipName|escape}</a>
         </strong>
       {/if}
     </div>
@@ -27,7 +27,7 @@
   <table class="form-layout">
     <tr>
       <td class="label">{$form.amount.label}</td>
-      <td>{$form.currency.html|crmAddClass:eight}&nbsp;{$form.amount.html|crmAddClass:eight} ({ts}every{/ts} {$recur_frequency_interval} {$recur_frequency_unit})</td>
+      <td>{$form.currency.html|crmAddClass:eight}&nbsp;{$form.amount.html|crmAddClass:eight} ({ts}every{/ts} {$recur_frequency_interval|escape} {$recur_frequency_unit|escape})</td>
     </tr>
     {if array_key_exists('installments', $form)}
       <tr>
@@ -48,7 +48,7 @@
   </table>
 
   {if !$self_service}
-    {include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='ContributionRecur' customDataSubType=false entityID=$pledgeID cid=false}
+    {include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='ContributionRecur' customDataSubType=false entityID=$contributionRecurID cid=false}
   {/if}
 
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>


### PR DESCRIPTION
Overview
----------------------------------------
This attempts to address https://github.com/civicrm/civicrm-core/pull/28617/files#diff-c683b948c8375b8bcc28cea8d54c2210bf8e94e8229b151666c94db370970b36L77-R105 of the stale cleanup by by @mattwire by using some of the techniques we have worked on in the meantime 

Before
----------------------------------------
notices

After
----------------------------------------
The goal is that `getMembershipID()` should be reliable & `getMembershipValue()` should be adequate to retrieve an assign a value - since this uses apiv4 rather than BAO values we need to ensure db escaping (also best practice)

Technical Details
----------------------------------------
This also applies the way of handling custom data we have been working on in similar PRs to use the preferred function at hte php level & ensure the parameters are passed at the tpl level  https://github.com/civicrm/civicrm-core/pulls?q=is%3Apr+is%3Aopen+php8.2

Comments
----------------------------------------
I haven't given this a proper spin yet