### PR TITLE
entity id in rows

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
@@ -1,4 +1,4 @@
-<tr ng-repeat="(rowIndex, row) in $ctrl.results">
+<tr ng-repeat="(rowIndex, row) in $ctrl.results" data-entity-id="{{:: row.key }}">
   <td ng-if=":: $ctrl.hasExtraFirstColumn()" class="{{:: row.cssClass }}">
     <span ng-if=":: $ctrl.settings.draggable" class="crm-draggable" title="{{:: ts('Drag to reposition') }}">
       <i class="crm-i fa-arrows-v"></i>


### PR DESCRIPTION
Overview
----------------------------------------
Adds an `entity-id` attribute when one exists to SK result rows.

Before
----------------------------------------
No `entity-id`.

After
----------------------------------------
Yes `entity-id`.


Comments
----------------------------------------
Even when `entity-id` isn't rendered (e.g. when aggregating), the `ng-attr-entity-id` is still present.  Is that due to a debug mode or something?  I used `ngAttr` because I thought it would be less verbose, but it's more verbose.