### PR TITLE
APIv4 Explorer - Accept action-parameters of type "float"

### DIFF
--- a/Civi/Api4/Event/Subscriber/ValidateFieldsSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/ValidateFieldsSubscriber.php
@@ -87,6 +87,12 @@ class ValidateFieldsSubscriber extends Generic\AbstractPrepareSubscriber {
           }
           break;
 
+        case 'float':
+          if (\CRM_Utils_Rule::numeric($value)) {
+            return TRUE;
+          }
+          break;
+
         case 'mixed':
           return TRUE;
 

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -88,9 +88,9 @@
           <label for="api4-param-action">action<span class="crm-marker" ng-if="::availableParams.action.required"> *</span></label>
           <input class="form-control" crm-ui-select="{data: actions, allowClear: true, placeholder: 'None'}" id="api4-param-action" ng-model="params.action"/>
         </div>
-        <div class="api4-input form-inline" ng-mouseenter="help(name, param)" ng-mouseleave="help()" ng-repeat="(name, param) in ::getGenericParams(['string', 'int'])">
+        <div class="api4-input form-inline" ng-mouseenter="help(name, param)" ng-mouseleave="help()" ng-repeat="(name, param) in ::getGenericParams(['string', 'int', 'float'])">
           <label for="api4-param-{{:: name }}">{{:: name }}<span class="crm-marker" ng-if="::param.required"> *</span></label>
-          <input class="form-control" ng-if="::!param.options" type="{{:: param.type[0] === 'int' && param.type.length === 1 ? 'number' : 'text' }}" id="api4-param-{{:: name }}" ng-model="params[name]"/>
+          <input class="form-control" ng-if="::!param.options" type="{{:: (param.type[0] === 'int' || param.type[0] === 'float') && param.type.length === 1 ? 'number' : 'text' }}" id="api4-param-{{:: name }}" ng-model="params[name]"/>
           <select class="form-control" ng-if="::param.options" ng-options="o for o in ::param.options" id="api4-param-{{:: name }}" ng-model="params[name]"></select>
           <a href class="crm-hover-button" title="Clear" ng-click="clearParam(name)" ng-show="!!params[name]"><i class="crm-i fa-times" aria-hidden="true"></i></a>
         </div>


### PR DESCRIPTION
Overview
----------------------------------------

Suppose you have an APIv4 action. You declare a property with a decimal value, such as:

```php
class Foo extends AbstractAction {

  /**
   * @var float
   */
  protected $decimal;

}
```

The APIv4 Explorer should be able to process this property.

ping @patrick-civilisten

Before
----------------------------------------

Field is hidden.

After
----------------------------------------

Field appears. It's rendered as an HTML `number` .

<img width="670" alt="Screenshot 2024-03-02 at 12 51 42 PM" src="https://github.com/civicrm/civicrm-core/assets/1336047/4a3ad9c6-e4d1-4959-8733-72aa93cc0ba5">

Comments
----------------------------------------

Aside: When testing, I noticed a pre-existing quirk with any number-style fields in APIv4 Explorer -- if you enter a malformed number, then the Explorer won't complain. It silently ignores the value and lets you call the API without it. But in context (dev tool), it's not a hard-block and it's pre-existing.

Regardless of the web UI, I played a bit with sending malformed numbers directly to APIv4, and it properly complained.