### PR TITLE
Regression - Fix missing getLinks action in SKEntity

### DIFF
--- a/ext/search_kit/Civi/Api4/SKEntity.php
+++ b/ext/search_kit/Civi/Api4/SKEntity.php
@@ -64,6 +64,16 @@ class SKEntity {
 
   /**
    * @param string $displayEntity
+   * @param bool $checkPermissions
+   * @return \Civi\Api4\Action\GetLinks
+   */
+  public static function getLinks(string $displayEntity, bool $checkPermissions = TRUE): Action\GetLinks {
+    return (new Action\GetLinks('SK_' . $displayEntity, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param string $displayEntity
    * @return \Civi\Api4\Generic\CheckAccessAction
    * @throws \CRM_Core_Exception
    */


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a fatal error encountered when creating a SearchDisplay of type "DB Entity".

Technical Details
---------
This appears as a regression in 5.70.0 because that version starts to actually use the new `getLinks` api. It was added a few versions before but not really used.