### PR TITLE
fix 'Authorization Failed' on API4TestTrait

### DIFF
--- a/Civi/Test/Api4TestTrait.php
+++ b/Civi/Test/Api4TestTrait.php
@@ -124,6 +124,7 @@ trait Api4TestTrait {
         ['readonly', 'IS EMPTY'],
       ],
       'orderBy' => ['required' => 'DESC'],
+      'checkPermissions' => FALSE,
     ], 'name');
 
     $extraValues = [];


### PR DESCRIPTION
Overview
----------------------------------------
API4TestTrait correctly sets permission checks to `FALSE` when saving records.  However, if it needs to look up which fields are required, it fails.

Before
----------------------------------------
`Authorization failed` error when running in the context of a user.

After
----------------------------------------
API4TestTrait can create records.

Comments
----------------------------------------
This hasn't been caught previously because most tests don't run in a user context.  It's coming up in E2E testing though.
