### PR TITLE
Regression - Fix missing getLinks action in SKEntity

### DIFF
--- a/ext/search_kit/Civi/Api4/SKEntity.php
+++ b/ext/search_kit/Civi/Api4/SKEntity.php
@@ -64,6 +64,16 @@ class SKEntity {
 
   /**
    * @param string $displayEntity
+   * @param bool $checkPermissions
+   * @return \Civi\Api4\Action\GetLinks
+   */
+  public static function getLinks(string $displayEntity, bool $checkPermissions = TRUE): Action\GetLinks {
+    return (new Action\GetLinks('SK_' . $displayEntity, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param string $displayEntity
    * @return \Civi\Api4\Generic\CheckAccessAction
    * @throws \CRM_Core_Exception
    */


### PR DESCRIPTION
Backports #29589 

Fixes a fatal error encountered when creating a SearchDisplay of type "DB Entity".