### PR TITLE
[php8.2] Share Custom data fixes from Membership form to renewal

### DIFF
--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -20,7 +20,7 @@
  *
  */
 class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
-
+  use CRM_Custom_Form_CustomDataTrait;
   use CRM_Core_Form_EntityFormTrait;
 
   /**
@@ -604,6 +604,23 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    */
   private function isQuickConfig(): bool {
     return $this->_priceSetId && CRM_Price_BAO_PriceSet::isQuickConfig($this->_priceSetId);
+  }
+
+  /**
+   * Overriding this entity trait function as the function does not
+   * at this stage use the CustomDataTrait which works better with php8.2.
+   */
+  public function addCustomDataToForm() {
+    if ($this->isSubmitted()) {
+      // The custom data fields are added to the form by an ajax form.
+      // However, if they are not present in the element index they will
+      // not be available from `$this->getSubmittedValue()` in post process.
+      // We do not have to set defaults or otherwise render - just add to the element index.
+      $this->addCustomDataFieldsToForm('Membership', array_filter([
+        'id' => $this->getMembershipID(),
+        'membership_type_id' => $this->getSubmittedValue('membership_type_id'),
+      ]));
+    }
   }
 
   /**

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -21,7 +21,6 @@ use Civi\Api4\ContributionRecur;
  * This class generates form components for offline membership form.
  */
 class CRM_Member_Form_Membership extends CRM_Member_Form {
-  use CRM_Custom_Form_CustomDataTrait;
 
   /**
    * If this is set (to 'test' or 'live') then the payment processor will be shown on the form to take a payment.
@@ -73,23 +72,6 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       . ts('Consider modifying the membership status instead if you want to maintain an audit trail and avoid losing payment data. You can set the status to Cancelled by editing the membership and clicking the Status Override checkbox.')
       . '</p><p>'
       . ts("Click 'Delete' if you want to continue.") . '</p>';
-  }
-
-  /**
-   * Overriding this entity trait function as the function does not
-   * at this stage use the CustomDataTrait which works better with php8.2.
-   */
-  public function addCustomDataToForm() {
-    if ($this->isSubmitted()) {
-      // The custom data fields are added to the form by an ajax form.
-      // However, if they are not present in the element index they will
-      // not be available from `$this->getSubmittedValue()` in post process.
-      // We do not have to set defaults or otherwise render - just add to the element index.
-      $this->addCustomDataFieldsToForm('Membership', array_filter([
-        'id' => $this->getMembershipID(),
-        'membership_type_id' => $this->getSubmittedValue('membership_type_id'),
-      ]));
-    }
   }
 
   /**

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -165,13 +165,6 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       }
     }
 
-    // when custom data is included in this page
-    if (!empty($_POST['hidden_custom'])) {
-      CRM_Custom_Form_CustomData::preProcess($this, NULL, $this->_memType, 1, 'Membership', $this->_id);
-      CRM_Custom_Form_CustomData::buildQuickForm($this);
-      CRM_Custom_Form_CustomData::setDefaultValues($this);
-    }
-
     $this->setTitle(ts('Renew Membership'));
 
     parent::preProcess();
@@ -240,6 +233,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
   public function buildQuickForm() {
 
     parent::buildQuickForm();
+    $this->addCustomDataToForm();
 
     $defaults = parent::setDefaultValues();
     $this->assign('customDataType', 'Membership');
@@ -499,7 +493,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     $this->_params['total_amount'] = CRM_Utils_Array::value('total_amount', $this->_params,
       CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType', $this->_memType, 'minimum_fee')
     );
-    $customFieldsFormatted = CRM_Core_BAO_CustomField::postProcess($this->_params,
+    $customFieldsFormatted = CRM_Core_BAO_CustomField::postProcess($this->getSubmittedValues(),
       $this->getMembershipID(),
       'Membership'
     );

--- a/templates/CRM/Member/Form/MembershipCommon.tpl
+++ b/templates/CRM/Member/Form/MembershipCommon.tpl
@@ -3,7 +3,7 @@
     <table>
       <tr class="crm-{$formClass}-form-block-contribution-contact">
         <td class="label">{$form.is_different_contribution_contact.label}</td>
-        <td>{$form.is_different_contribution_contact.html}&nbsp;&nbsp;{help id="id-contribution_contact"}</td>
+        <td>{$form.is_different_contribution_contact.html}&nbsp;&nbsp;{help id="id-contribution_contact" file="CRM/Member/Page/Tab.hlp"}</td>
       </tr>
       <tr id="record-different-contact">
         <td>&nbsp;</td>

--- a/templates/CRM/Member/Form/MembershipRenewal.tpl
+++ b/templates/CRM/Member/Form/MembershipRenewal.tpl
@@ -122,7 +122,7 @@
       </table>
     {/if}
 
-    {include file="CRM/common/customDataBlock.tpl"}
+    {include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='Membership' cid=false}
 
     <div>{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 


### PR DESCRIPTION
Overview
----------------------------------------
Share Custom data fixes from Membership form to renewal

This fixes handling on money amounts like 1,000.9 and addresses php8.x issues as well as consolidating code.

Before
----------------------------------------
Php 8.2 issues with the form, hangs on validation fail

After
----------------------------------------
Consolidated code

Technical Details
----------------------------------------
Note that for testing installing https://github.com/eileenmcnaughton/testdata creates a swag of custom fields

This is the same change as some closed PRs & also

https://github.com/civicrm/civicrm-core/pull/29228
https://github.com/civicrm/civicrm-core/pull/29241

Comments
----------------------------------------
