### PR TITLE
Contact Summary address: make accordion more accessible

### DIFF
--- a/templates/CRM/Contact/Page/Inline/Address.tpl
+++ b/templates/CRM/Contact/Page/Inline/Address.tpl
@@ -47,7 +47,7 @@
     {foreach from=$add.custom item=customGroup key=cgId} {* start of outer foreach *}
       {assign var="isAddressCustomPresent" value=1}
       {foreach from=$customGroup item=customValue key=cvId}
-        <details id="address_custom_{$cgId}_{$locationIndex}" class="crm-address-custom-{$cgId}-{$locationIndex}-accordion" {if $customValue.collapse_display}{else}open{/if}>
+        <details id="address_custom_{$cgId}_{$locationIndex}" class="crm-address-custom-{$cgId}-{$locationIndex}-accordion crm-accordion-light" {if $customValue.collapse_display}{else}open{/if}>
           <summary class="collapsible-title">
             {$customValue.title}
           </summary>

--- a/templates/CRM/Contact/Page/Inline/Address.tpl
+++ b/templates/CRM/Contact/Page/Inline/Address.tpl
@@ -47,25 +47,23 @@
     {foreach from=$add.custom item=customGroup key=cgId} {* start of outer foreach *}
       {assign var="isAddressCustomPresent" value=1}
       {foreach from=$customGroup item=customValue key=cvId}
-        <div id="address_custom_{$cgId}_{$locationIndex}"
-        class="crm-collapsible crm-address-custom-{$cgId}-{$locationIndex}-accordion
-        {if $customValue.collapse_display}collapsed{/if}">
-        <div class="collapsible-title">
-          {$customValue.title}
-        </div>
-        <div class="crm-summary-block">
-          {foreach from=$customValue.fields item=customField key=cfId}
-          <div class="crm-summary-row">
-            <div class="crm-label">
-              {$customField.field_title}
+        <details id="address_custom_{$cgId}_{$locationIndex}" class="crm-address-custom-{$cgId}-{$locationIndex}-accordion" {if $customValue.collapse_display}{else}open{/if}>
+          <summary>
+            {$customValue.title}
+          </summary>
+          <div class="crm-summary-block">
+            {foreach from=$customValue.fields item=customField key=cfId}
+            <div class="crm-summary-row">
+              <div class="crm-label">
+                {$customField.field_title}
+              </div>
+              <div class="crm-content">
+                {$customField.field_value}
+              </div>
             </div>
-            <div class="crm-content">
-              {$customField.field_value}
-            </div>
+            {/foreach}
           </div>
-          {/foreach}
-          </div>
-        </div>
+        </details>
       {/foreach}
     {/foreach} {* end of outer custom group foreach *}
     <!-- end custom data -->

--- a/templates/CRM/Contact/Page/Inline/Address.tpl
+++ b/templates/CRM/Contact/Page/Inline/Address.tpl
@@ -48,7 +48,7 @@
       {assign var="isAddressCustomPresent" value=1}
       {foreach from=$customGroup item=customValue key=cvId}
         <details id="address_custom_{$cgId}_{$locationIndex}" class="crm-address-custom-{$cgId}-{$locationIndex}-accordion" {if $customValue.collapse_display}{else}open{/if}>
-          <summary>
+          <summary class="collapsible-title">
             {$customValue.title}
           </summary>
           <div class="crm-summary-block">


### PR DESCRIPTION
Overview
----------------------------------------
Toward [user-interface#60](https://lab.civicrm.org/dev/user-interface/-/issues/60) / [core#3294](https://lab.civicrm.org/dev/core/-/issues/3294) -- replaces the [last remaining instance of .crm-collapsible](https://lab.civicrm.org/dev/user-interface/-/issues/67#note_160008), a less-accessible accordion pattern, with `<details><summary>`

Before
----------------------------------------
`.crm-collapsible` plus JS controls

After
----------------------------------------
`<details><summary>`, with css class to play well with existing JS