### PR TITLE
add field name to SearchKit cells, primarily for testing

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
@@ -5,7 +5,7 @@
     </span>
     <input ng-if=":: $ctrl.settings.actions" type="checkbox" ng-checked="$ctrl.isRowSelected(row)" ng-click="$ctrl.toggleRow(row, $event)" ng-disabled="!!$ctrl.loadingAllRows">
   </td>
-  <td ng-repeat="(colIndex, colData) in row.columns" ng-include="'~/crmSearchDisplay/colType/' + $ctrl.settings.columns[colIndex].type + '.html'" title="{{:: colData.title }}" class="crm-search-col-type-{{:: $ctrl.settings.columns[colIndex].type }} {{:: row.cssClass }} {{:: colData.cssClass }}">
+  <td ng-repeat="(colIndex, colData) in row.columns" ng-include="'~/crmSearchDisplay/colType/' + $ctrl.settings.columns[colIndex].type + '.html'" title="{{:: colData.title }}" class="crm-search-col-type-{{:: $ctrl.settings.columns[colIndex].type }} {{:: row.cssClass }} {{:: colData.cssClass }}" data-field-name="{{:: colData.edit.value_key }}">
   </td>
 </tr>
 <tr ng-if="$ctrl.rowCount === 0">


### PR DESCRIPTION
Overview
----------------------------------------
This is a companion to #29582.  That placed entity IDs in rows, this places field names in columns.

Before
----------------------------------------
SK table display cell markup looked like this:
```php
<td ng-repeat="(colIndex, colData) in row.columns" ng-include="'~/crmSearchDisplay/colType/' + $ctrl.settings.columns[colIndex].type + '.html'" title="" class="crm-search-col-type-field  ">
```

After
----------------------------------------
Looks like this (`data-field-name` added at end):
```php
<td ng-repeat="(colIndex, colData) in row.columns" ng-include="'~/crmSearchDisplay/colType/' + $ctrl.settings.columns[colIndex].type + '.html'" title="" class="crm-search-col-type-field  " data-field-name="is_active">
```

Comments
----------------------------------------
Without this, it's very difficult (and brittle) to target cells in a SK table display, making interactive testing difficult as well.
