### PR TITLE
Run successful scheduled jobs first

### DIFF
--- a/CRM/Admin/Page/Job.php
+++ b/CRM/Admin/Page/Job.php
@@ -162,9 +162,8 @@ class CRM_Admin_Page_Job extends CRM_Core_Page_Basic {
       }
     }
 
-    $sj = new CRM_Core_JobManager();
     $rows = [];
-    foreach ($sj->jobs as $job) {
+    foreach ($this->getJobs() as $job) {
       $action = array_sum(array_keys($this->links()));
 
       // update enable/disable links.
@@ -191,6 +190,29 @@ class CRM_Admin_Page_Job extends CRM_Core_Page_Basic {
       $rows[] = get_object_vars($job);
     }
     $this->assign('rows', $rows);
+  }
+
+  /**
+   * Retrieves the list of jobs from the database,
+   * populates class param.
+   *
+   * @fixme: Copied from JobManager. We should replace with API
+   *
+   * @return array
+   *   ($id => CRM_Core_ScheduledJob)
+   */
+  private function getJobs(): array {
+    $jobs = [];
+    $dao = new CRM_Core_DAO_Job();
+    $dao->orderBy('name');
+    $dao->domain_id = CRM_Core_Config::domainID();
+    $dao->find();
+    while ($dao->fetch()) {
+      $temp = ['class' => NULL, 'parameters' => NULL, 'last_run' => NULL];
+      CRM_Core_DAO::storeValues($dao, $temp);
+      $jobs[$dao->id] = new CRM_Core_ScheduledJob($temp);
+    }
+    return $jobs;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
If you have a job that crashes but it runs before other jobs it will prevent all those other jobs from running as well. In #29587 we introduced "last_run_end" parameter so we can now see when a job last successfully completed as well as when it started.

This PR changes the query that selects the jobs to run so that they are ordered by ones that completed successfully first. This means that any job that is crashing will get pushed to the bottom of the queue and will still try to run but only after the other jobs have run.
This means that a failing job will still be reported as failing but will not cause other problems. For example, if your accounting system scheduled job crashes you don't want membership status updates to fail as well..


Before
----------------------------------------
Jobs run in "name" order.

After
----------------------------------------
Jobs with `last_run_end` set run first. Then jobs without `last_run_end` will run. Still sorted by "name".

Technical Details
----------------------------------------
We get the list of jobs with `last_run_end` set, then the list of jobs that it is not set. Then we merge them sequentially and run them all.

Comments
----------------------------------------
Needed a bit of wrangling to go from DAO objects to API4 etc. Could be cleaned up further in the future.