### PR TITLE
Replace a few more assign_by_ref with assign (Smarty)

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/Widget.php
+++ b/CRM/Contribute/Form/ContributionPage/Widget.php
@@ -210,8 +210,8 @@ class CRM_Contribute_Form_ContributionPage_Widget extends CRM_Contribute_Form_Co
       );
     }
 
-    $this->assign_by_ref('fields', $this->_fields);
-    $this->assign_by_ref('colorFields', $this->_colorFields);
+    $this->assign('fields', $this->_fields);
+    $this->assign('colorFields', $this->_colorFields);
 
     $this->_refreshButtonName = $this->getButtonName('refresh');
     $this->addElement('xbutton',

--- a/CRM/Contribute/Form/Task/Status.php
+++ b/CRM/Contribute/Form/Task/Status.php
@@ -127,7 +127,7 @@ AND    co.id IN ( $contribIDs )";
       $this->_rows[] = $row;
     }
 
-    $this->assign_by_ref('rows', $this->_rows);
+    $this->assign('rows', $this->_rows);
     $this->setDefaults($defaults);
     $this->addButtons([
       [

--- a/CRM/Contribute/Page/ContributionPage.php
+++ b/CRM/Contribute/Page/ContributionPage.php
@@ -674,7 +674,7 @@ WHERE $whereClause";
     $params['total'] = CRM_Core_DAO::singleValueQuery($query, $whereParams);
 
     $this->_pager = new CRM_Utils_Pager($params);
-    $this->assign_by_ref('pager', $this->_pager);
+    $this->assign('pager', $this->_pager);
   }
 
   /**

--- a/CRM/Event/Form/ManageEvent/TabHeader.php
+++ b/CRM/Event/Form/ManageEvent/TabHeader.php
@@ -37,7 +37,7 @@ class CRM_Event_Form_ManageEvent_TabHeader {
       $tabs = self::process($form);
       $form->set('tabHeader', $tabs);
     }
-    $form->assign_by_ref('tabHeader', $tabs);
+    $form->assign('tabHeader', $tabs);
     CRM_Core_Resources::singleton()
       ->addScriptFile('civicrm', 'templates/CRM/common/TabHeader.js', 1, 'html-header')
       ->addSetting([

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -428,7 +428,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       );
       $this->set('availableRegistrations', $this->_availableRegistrations);
     }
-    $this->assign_by_ref('paymentProcessor', $this->_paymentProcessor);
+    $this->assign('paymentProcessor', $this->_paymentProcessor);
 
     // check if this is a paypal auto return and redirect accordingly
     if (CRM_Core_Payment::paypalRedirect($this->_paymentProcessor)) {

--- a/CRM/Event/Form/Task/AddToGroup.php
+++ b/CRM/Event/Form/Task/AddToGroup.php
@@ -115,7 +115,7 @@ class CRM_Event_Form_Task_AddToGroup extends CRM_Event_Form_Task {
 
       // also set the group title
       $groupValues = ['id' => $this->_id, 'title' => $this->_title];
-      $this->assign_by_ref('group', $groupValues);
+      $this->assign('group', $groupValues);
     }
 
     // Set dynamic page title for 'Add Members Group (confirm)'

--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -588,7 +588,7 @@ SELECT count(id)
     $params['total'] = CRM_Core_DAO::singleValueQuery($query, $whereParams);
 
     $this->_pager = new CRM_Utils_Pager($params);
-    $this->assign_by_ref('pager', $this->_pager);
+    $this->assign('pager', $this->_pager);
   }
 
   /**


### PR DESCRIPTION


Overview
----------------------------------------
Replace a few more assign_by_ref with assign (Smarty)

Before
----------------------------------------
`$smarty->assign_by_ref()`

After
----------------------------------------
`$smarty->assign()`

Technical Details
----------------------------------------
assign_by_ref is removed from smarty by v5 & we have yet to see it used in CiviCRM in a way that does not work the same with assign I believe there was a perception it performed better under php4

Comments
----------------------------------------
