### PR TITLE
Swaps truncated old accordion pattern to new pattern

### DIFF
--- a/templates/CRM/Contact/Page/DedupeException.tpl
+++ b/templates/CRM/Contact/Page/DedupeException.tpl
@@ -8,26 +8,27 @@
  +--------------------------------------------------------------------+
 *}
 {include file="CRM/common/dedupe.tpl"}
-<div class="crm-accordion-header">
-  {ts}Filter Contacts{/ts}
-</div>
-<div class="crm-accordion-body">
-  <form method="get">
-    <table class="no-border form-layout-compressed" id="searchOptions" style="width:100%;">
-      <tr>
-        <td class="crm-contact-form-block-contact1">
-          <label for="search-contact1">{ts}Contact Name{/ts}</label><br />
-          <input class="crm-form-text" type="text" size="50" placeholder="{ts}Search Contacts{/ts}" value="{$searchcontact1}" id="search-contact1" search-column="0" />
-        </td>
-        <td class="crm-contact-form-block-search">
-          <label>&nbsp;</label><br />
-          <button type="submit" class="button crm-button filtercontacts"><span><i class="crm-i fa-search" aria-hidden="true"></i> {ts}Find Contacts{/ts}</span></button>
-        </td>
-      </tr>
-    </table>
-  </form>
-</div>
-
+<details class="crm-accordion-bold">
+  <summary>
+    {ts}Filter Contacts{/ts}
+  </summary>
+  <div class="crm-accordion-body">
+    <form method="get">
+      <table class="no-border form-layout-compressed" id="searchOptions" style="width:100%;">
+        <tr>
+          <td class="crm-contact-form-block-contact1">
+            <label for="search-contact1">{ts}Contact Name{/ts}</label><br />
+            <input class="crm-form-text" type="text" size="50" placeholder="{ts}Search Contacts{/ts}" value="{$searchcontact1}" id="search-contact1" search-column="0" />
+          </td>
+          <td class="crm-contact-form-block-search">
+            <label>&nbsp;</label><br />
+            <button type="submit" class="button crm-button filtercontacts"><span><i class="crm-i fa-search" aria-hidden="true"></i> {ts}Find Contacts{/ts}</span></button>
+          </td>
+        </tr>
+      </table>
+    </form>
+  </div>
+</details>
 
 <div class="crm-content-block crm-block">
   {include file="CRM/common/pager.tpl" location="top"}


### PR DESCRIPTION
This was originally in @aydun's PR #29448 but got pulled out early on because it was a mystery why the accordion lacked the `.crm-accordion-wrapper` div and if that was deliberate or an error.

What gave me pause with this is that the accordion functions, despite lacking the enclosing `.crm-accordion-wrapper` div - the `.collapsed` is applied to a further enclosing div: `<div id="crm-main-content-wrapper">`. But that's not in this template file, or in the referenced template file (`CRM/common/dedupe.tpl`). Maybe that doesn't matter - it seems to work with the change - but figured this needed its own issue to dble check

Before
----------------------------------------
(half) the old accordion markup pattern.

After
----------------------------------------
The new accordion markup pattern.

Comments
----------------------------------------
Despite the 21 line diff, the change here is the code is wrapped in a new `<details>` element, then the first div is made into a `<summary>` - everything else is the same.