### PR TITLE
Replace a few more assign_by_ref with assign (Smarty)

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3366,7 +3366,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
    */
   public function doTemplateAssignment(&$rows) {
     $this->assign('columnHeaders', $this->_columnHeaders);
-    $this->assign_by_ref('rows', $rows);
+    $this->assign('rows', $rows);
     $this->assign('statistics', $this->statistics($rows));
   }
 
@@ -3762,7 +3762,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
       }
 
       $pager = new CRM_Utils_Pager($params);
-      $this->assign_by_ref('pager', $pager);
+      $this->assign('pager', $pager);
       $this->ajaxResponse['totalRows'] = $this->_rowsFound;
     }
   }

--- a/CRM/Report/Form/Contact/Detail.php
+++ b/CRM/Report/Form/Contact/Detail.php
@@ -843,8 +843,8 @@ HERESQL;
         unset($this->_columnHeadersComponent[$componentTitle][$id_header], $this->_columnHeadersComponent[$componentTitle][$contact_header]);
       }
 
-      $this->assign_by_ref('columnHeadersComponent', $this->_columnHeadersComponent);
-      $this->assign_by_ref('componentRows', $componentRows);
+      $this->assign('columnHeadersComponent', $this->_columnHeadersComponent);
+      $this->assign('componentRows', $componentRows);
     }
 
     $this->doTemplateAssignment($rows);

--- a/CRM/Report/Form/Event/Income.php
+++ b/CRM/Report/Form/Event/Income.php
@@ -76,7 +76,7 @@ class CRM_Report_Form_Event_Income extends CRM_Report_Form {
       $eventSummary[$eventDAO->event_id][ts('Registered Participant')] = "{$eventDAO->participant} (" . implode(', ', $this->getActiveParticipantStatuses()) . ")";
       $currency[$eventDAO->event_id] = $eventDAO->currency;
     }
-    $this->assign_by_ref('summary', $eventSummary);
+    $this->assign('summary', $eventSummary);
 
     $activeParticipantClause = " AND civicrm_participant.status_id IN ( " . implode(',', array_keys($this->getActiveParticipantStatuses())) . " ) ";
     //Total Participant Registerd for the Event
@@ -198,7 +198,7 @@ class CRM_Report_Form_Event_Income extends CRM_Report_Form {
     }
     $rows[ts('Payment Method')] = $instrumentRows;
 
-    $this->assign_by_ref('rows', $rows);
+    $this->assign('rows', $rows);
     if (!$this->_setVariable) {
       $this->_params['id_value'] = NULL;
     }
@@ -254,7 +254,7 @@ class CRM_Report_Form_Event_Income extends CRM_Report_Form {
     ];
 
     $pager = new CRM_Utils_Pager($params);
-    $this->assign_by_ref('pager', $pager);
+    $this->assign('pager', $pager);
   }
 
   /**

--- a/CRM/Report/Form/Membership/Summary.php
+++ b/CRM/Report/Form/Membership/Summary.php
@@ -314,8 +314,8 @@ LEFT  JOIN civicrm_contribution  {$this->_aliases['civicrm_contribution']}
     }
     $this->formatDisplay($rows);
 
-    $this->assign_by_ref('columnHeaders', $this->_columnHeaders);
-    $this->assign_by_ref('rows', $rows);
+    $this->assign('columnHeaders', $this->_columnHeaders);
+    $this->assign('rows', $rows);
     $this->assign('statistics', $this->statistics($rows));
 
     if (!empty($this->_params['charts'])) {

--- a/CRM/SMS/Form/Schedule.php
+++ b/CRM/SMS/Form/Schedule.php
@@ -86,7 +86,7 @@ class CRM_SMS_Form_Schedule extends CRM_Core_Form {
     $preview = [];
     $preview['type'] = CRM_Core_DAO::getFieldValue('CRM_Mailing_DAO_Mailing', $this->_mailingID, 'body_html') ? 'html' : 'text';
     $preview['viewURL'] = CRM_Utils_System::url('civicrm/mailing/view', "reset=1&id={$this->_mailingID}");
-    $this->assign_by_ref('preview', $preview);
+    $this->assign('preview', $preview);
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Replace a few more assign_by_ref with assign (Smarty)

Before
----------------------------------------
`$smarty->assign_by_ref()`

After
----------------------------------------
`$smarty->assign()`

Technical Details
----------------------------------------
assign_by_ref is removed from smarty by v5 & we have yet to see it used in CiviCRM in a way that does not work the same with assign I believe there was a perception it performed better under php4

Comments
----------------------------------------
