### PR TITLE
Clean up phone filtering in sms activity trait

### DIFF
--- a/CRM/Contact/Form/Task/SMSTrait.php
+++ b/CRM/Contact/Form/Task/SMSTrait.php
@@ -15,15 +15,26 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 use Civi\Api4\Activity;
+use Civi\API\EntityLookupTrait;
+use Civi\Api4\Phone;
 use Civi\Token\TokenProcessor;
 
 /**
  * This trait provides the common functionality for tasks that send sms.
  */
 trait CRM_Contact_Form_Task_SMSTrait {
+  use EntityLookupTrait;
+
+  /**
+   * The phones to be messaged.
+   * @var array
+   */
+  private array $phones;
 
   /**
    * Process the form after the input has been submitted and validated.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function postProcess() {
     $this->postProcessSms();
@@ -49,6 +60,30 @@ trait CRM_Contact_Form_Task_SMSTrait {
     return $smsProviderParams;
   }
 
+  /**
+   * Get phones to SMS.
+   *
+   * @internal
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  protected function getPhones(): array {
+    if (!isset($this->phones)) {
+      $this->phones = (array) Phone::get()
+        ->addWhere('contact_id', 'IN', $this->getContactIDs())
+        ->addWhere('contact_id.do_not_sms', '=', FALSE)
+        ->addWhere('contact_id.is_deceased', '=', FALSE)
+        ->addWhere('phone_numeric', '>', 0)
+        ->addWhere('phone_type_id:name', '=', 'Mobile')
+        ->addOrderBy('is_primary')
+        ->addSelect('id', 'contact_id', 'phone', 'phone_type_id:name', 'contact_id.sort_name', 'phone_type_id', 'contact_id.display_name')
+        ->execute()->indexBy('contact_id');
+    }
+    return $this->phones;
+  }
+
   protected function bounceOnNoActiveProviders(): void {
     $providersCount = CRM_SMS_BAO_Provider::activeProviderCount();
     if (!$providersCount) {
@@ -59,9 +94,10 @@ trait CRM_Contact_Form_Task_SMSTrait {
   /**
    * Build the SMS Form
    *
+   * @throws \CRM_Core_Exception
    * @internal - highly likely to change!
    */
-  protected function buildSmsForm() {
+  protected function buildSmsForm(): void {
     if (!CRM_Core_Permission::check('send SMS')) {
       throw new CRM_Core_Exception("You do not have the 'send SMS' permission");
     }
@@ -100,7 +136,6 @@ trait CRM_Contact_Form_Task_SMSTrait {
         [$contactId, $phone] = explode('::', $value);
         if ($contactId) {
           $form->_contactIds[] = $contactId;
-          $form->_toContactPhone[] = $phone;
         }
       }
       $toSetDefault = TRUE;
@@ -119,55 +154,30 @@ trait CRM_Contact_Form_Task_SMSTrait {
       // make a copy of all contact details
       $form->_allContactDetails = $form->_contactDetails;
 
-      foreach ($form->_contactIds as $key => $contactId) {
-        $mobilePhone = NULL;
-        $contactDetails = $form->_contactDetails[$contactId];
-
-        //to check if the phone type is "Mobile"
-        $phoneTypes = CRM_Core_OptionGroup::values('phone_type', TRUE, FALSE, FALSE, NULL, 'name');
-        if ($this->isInvalidRecipient($contactId)) {
+      $phoneNumbers = $this->getPhones();
+      $suppressedSms = count($this->getContactIDs()) - count($phoneNumbers);
+      foreach ($phoneNumbers as $phone) {
+        if ($this->isInvalidRecipient($phone['contact_id'])) {
           $suppressedSms++;
-          unset($form->_contactDetails[$contactId]);
           continue;
         }
-
-        // No phone, No SMS or Deceased: then we suppress it.
-        if (empty($contactDetails['phone']) || $contactDetails['do_not_sms'] || !empty($contactDetails['is_deceased'])) {
-          $suppressedSms++;
-          unset($form->_contactDetails[$contactId]);
-          continue;
-        }
-        elseif ($contactDetails['phone_type_id'] != ($phoneTypes['Mobile'] ?? NULL)) {
-          //if phone is not primary check if non-primary phone is "Mobile"
-          $filter = ['do_not_sms' => 0];
-          $contactPhones = CRM_Core_BAO_Phone::allPhones($contactId, FALSE, 'Mobile', $filter);
-          if (count($contactPhones) > 0) {
-            $mobilePhone = CRM_Utils_Array::retrieveValueRecursive($contactPhones, 'phone');
-            $form->_contactDetails[$contactId]['phone_id'] = CRM_Utils_Array::retrieveValueRecursive($contactPhones, 'id');
-            $form->_contactDetails[$contactId]['phone'] = $mobilePhone;
-            $form->_contactDetails[$contactId]['phone_type_id'] = $phoneTypes['Mobile'] ?? NULL;
-          }
-          else {
-            $suppressedSms++;
-            unset($form->_contactDetails[$contactId]);
-            continue;
-          }
-        }
-
-        if (isset($mobilePhone)) {
-          $phone = $mobilePhone;
-        }
-        elseif (empty($form->_toContactPhone)) {
-          $phone = $contactDetails['phone'];
-        }
-        else {
-          $phone = $form->_toContactPhone[$key] ?? NULL;
-        }
+        // We hope to refactor this array away but for now...
+        $form->_contactDetails[$phone['contact_id']] = [
+          'id' => $phone['contact_id'],
+          'contact_id' => $phone['contact_id'],
+          'sort_name' => $phone['contact_id.sort_name'],
+          'display_name' => $phone['contact_id.display_name'],
+          // Might need to be set later - we know it is false here.
+          'do_not_sms' => FALSE,
+          'phone_id' => $phone['id'],
+          'phone' => $phone['phone'],
+          'phone_type_id' => $phone['phone_type_id'],
+        ];
 
         if ($phone) {
           $toArray[] = [
-            'text' => '"' . $contactDetails['sort_name'] . '" (' . $phone . ')',
-            'id' => "$contactId::{$phone}",
+            'text' => CRM_Utils_String::purifyHTML('"' . $phone['contact_id.sort_name'] . '" (' . $phone['phone'] . ')'),
+            'id' => $phone['contact_id'] . '::' . CRM_Utils_String::purifyHTML($phone['phone']),
           ];
         }
       }
@@ -183,7 +193,7 @@ trait CRM_Contact_Form_Task_SMSTrait {
 
     $form->assign('toContact', json_encode($toArray));
     $form->assign('suppressedSms', $suppressedSms);
-    $form->assign('totalSelectedContacts', count($form->_contactIds));
+    $form->assign('totalSelectedContacts', count($this->getContactIDs()));
 
     $form->add('select', 'sms_provider_id', ts('From'), $providerSelect, TRUE);
 
@@ -215,6 +225,8 @@ trait CRM_Contact_Form_Task_SMSTrait {
    * Process the sms form after the input has been submitted and validated.
    *
    * @internal likely to change.
+   *
+   * @throws \CRM_Core_Exception
    */
   protected function postProcessSms(): void {
     $form = $this;
@@ -261,13 +273,11 @@ trait CRM_Contact_Form_Task_SMSTrait {
           $tempPhones[] = $phoneKey;
           if (!empty($form->_contactDetails[$contactId])) {
             $formattedContactDetails[] = $form->_contactDetails[$contactId];
+            $contactIds[] = $contactId;
           }
         }
       }
     }
-
-    $contactIds = array_keys($form->_contactDetails);
-    $allContactIds = array_keys($form->_allContactDetails);
 
     [$sent, $countSuccess] = $this->sendSMS($formattedContactDetails,
       $thisValues,
@@ -296,15 +306,14 @@ trait CRM_Contact_Form_Task_SMSTrait {
     }
     else {
       //Display the name and number of contacts for those sms is not sent.
-      $smsNotSent = array_diff_assoc($allContactIds, $contactIds);
+      $smsNotSent = array_diff_assoc($this->getContactIDs(), $contactIds);
 
       if (!empty($smsNotSent)) {
         $not_sent = [];
-        foreach ($smsNotSent as $index => $contactId) {
-          $displayName = $form->_allContactDetails[$contactId]['display_name'];
-          $phone = $form->_allContactDetails[$contactId]['phone'];
+        foreach ($smsNotSent as $contactId) {
+          $displayName = CRM_Utils_String::purifyHTML($this->getValueForContact($contactId, 'display_name'));
           $contactViewUrl = CRM_Utils_System::url('civicrm/contact/view', "reset=1&cid=$contactId");
-          $not_sent[] = "<a href='$contactViewUrl' title='$phone'>$displayName</a>";
+          $not_sent[] = "<a href='$contactViewUrl' title='$displayName'>$displayName</a>";
         }
         $status = '(' . ts('because no phone number on file or communication preferences specify DO NOT SMS or Contact is deceased');
         if (CRM_Utils_System::getClassName($form) == 'CRM_Activity_Form_Task_SMS') {
@@ -454,6 +463,25 @@ trait CRM_Contact_Form_Task_SMSTrait {
   protected function isInvalidRecipient($contactID): bool {
     //Overridden by the activity child class.
     return FALSE;
+  }
+
+  /**
+   * Get the specified value for the contact.
+   *
+   * Note do not rename to `getContactValue()` - that function
+   * is used on many forms and does not take $id as a parameter.
+   *
+   * @param int $contactID
+   * @param string $value
+   *
+   * @return mixed|null
+   * @throws \CRM_Core_Exception
+   */
+  protected function getValueForContact(int $contactID, $value) {
+    if (!$this->isDefined('Contact' . $contactID)) {
+      $this->define('Contact', 'Contact' . $contactID, ['id' => $contactID]);
+    }
+    return $this->lookup('Contact' . $contactID, $value);
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/Form/Task/SMSCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/SMSCommonTest.php
@@ -99,6 +99,8 @@ class CRM_Contact_Form_Task_SMSCommonTest extends CiviUnitTestCase {
 
   /**
    * Test to ensure SMS Activity QuickForm displays the right phone numbers.
+   *
+   * @throws \Civi\Core\Exception\DBQueryException
    */
   public function testQuickFormMobileNumbersDisplay(): void {
     $this->createLoggedInUser();


### PR DESCRIPTION
Overview
----------------------------------------
Clean up phone filtering in sms activity trait

Before
----------------------------------------
The form loads phones for all contacts & then filters out the ones who are deceased, have no phone, are not mobiles, or have specified no_sms - which a lot of tracking & wrangline

After
----------------------------------------
The values are filtered while being loaded, some reduction in php8.2 non-conformance, some increase in sanity

Technical Details
----------------------------------------


Comments
----------------------------------------
