### PR TITLE
Replace a few more assign_by_ref with assign (Smarty)

### DIFF
--- a/CRM/Event/Page/ParticipantListing/NameStatusAndDate.php
+++ b/CRM/Event/Page/ParticipantListing/NameStatusAndDate.php
@@ -94,7 +94,7 @@ LIMIT    $offset, $rowCount";
       ];
       $rows[] = $row;
     }
-    $this->assign_by_ref('rows', $rows);
+    $this->assign('rows', $rows);
 
     return parent::run();
   }
@@ -124,7 +124,7 @@ SELECT count( civicrm_contact.id )
 
     $params['total'] = CRM_Core_DAO::singleValueQuery($query, $whereParams);
     $this->_pager = new CRM_Utils_Pager($params);
-    $this->assign_by_ref('pager', $this->_pager);
+    $this->assign('pager', $this->_pager);
   }
 
   /**
@@ -157,8 +157,8 @@ SELECT count( civicrm_contact.id )
       );
     }
     $sort = new CRM_Utils_Sort($headers, $sortID);
-    $this->assign_by_ref('headers', $headers);
-    $this->assign_by_ref('sort', $sort);
+    $this->assign('headers', $headers);
+    $this->assign('sort', $sort);
     $this->set(CRM_Utils_Sort::SORT_ID,
       $sort->getCurrentSortID()
     );

--- a/CRM/Event/Page/ParticipantListing/Simple.php
+++ b/CRM/Event/Page/ParticipantListing/Simple.php
@@ -87,7 +87,7 @@ LIMIT    $offset, $rowCount";
       ];
       $rows[] = $row;
     }
-    $this->assign_by_ref('rows', $rows);
+    $this->assign('rows', $rows);
 
     return parent::run();
   }
@@ -118,7 +118,7 @@ SELECT count( civicrm_contact.id )
 
     $params['total'] = CRM_Core_DAO::singleValueQuery($query, $whereParams);
     $this->_pager = new CRM_Utils_Pager($params);
-    $this->assign_by_ref('pager', $this->_pager);
+    $this->assign('pager', $this->_pager);
   }
 
   /**
@@ -148,8 +148,8 @@ SELECT count( civicrm_contact.id )
       );
     }
     $sort = new CRM_Utils_Sort($headers, $sortID);
-    $this->assign_by_ref('headers', $headers);
-    $this->assign_by_ref('sort', $sort);
+    $this->assign('headers', $headers);
+    $this->assign('sort', $sort);
     $this->set(CRM_Utils_Sort::SORT_ID,
       $sort->getCurrentSortID()
     );

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -369,7 +369,7 @@ WHERE  title = %1
         }
       }
     }
-    $form->assign_by_ref('parent_groups', $parentGroupElements);
+    $form->assign('parent_groups', $parentGroupElements);
 
     if (isset($form->_id)) {
       $potentialParentGroupIds = CRM_Contact_BAO_GroupNestingCache::getPotentialCandidates($form->_id, $groupNames);

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1167,7 +1167,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     if ($useSmarty) {
       $smarty = CRM_Core_Smarty::singleton();
       // also add the contact tokens to the template
-      $smarty->assign_by_ref('contact', $contact);
+      $smarty->assign('contact', $contact);
     }
 
     $mailParams = $headers;

--- a/CRM/Mailing/Form/Approve.php
+++ b/CRM/Mailing/Form/Approve.php
@@ -119,7 +119,7 @@ class CRM_Mailing_Form_Approve extends CRM_Core_Form {
     $preview['type'] = $this->_mailing->body_html ? 'html' : 'text';
     $preview['attachment'] = CRM_Core_BAO_File::attachmentInfo('civicrm_mailing', $this->_mailingID);
 
-    $this->assign_by_ref('preview', $preview);
+    $this->assign('preview', $preview);
   }
 
   /**

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -676,7 +676,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     }
     CRM_Core_BAO_UFGroup::getValues($this->_contactID, $customFields, $customValues, FALSE, $members);
 
-    $this->assign_by_ref('formValues', $this->_params);
+    $this->assign('formValues', $this->_params);
 
     $this->assign('membership_name', CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType',
       $membership->membership_type_id

--- a/CRM/Profile/Page/Dynamic.php
+++ b/CRM/Profile/Page/Dynamic.php
@@ -339,8 +339,8 @@ class CRM_Profile_Page_Dynamic extends CRM_Core_Page {
         ];
       }
 
-      $template->assign_by_ref('row', $values);
-      $template->assign_by_ref('profileFields', $profileFields);
+      $template->assign('row', $values);
+      $template->assign('profileFields', $profileFields);
     }
 
     $name = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFGroup', $this->_gid, 'name');


### PR DESCRIPTION

Overview
----------------------------------------
Replace a few more assign_by_ref with assign (Smarty)

Before
----------------------------------------
`$smarty->assign_by_ref()`

After
----------------------------------------
`$smarty->assign()`

Technical Details
----------------------------------------
assign_by_ref is removed from smarty by v5 & we have yet to see it used in CiviCRM in a way that does not work the same with assign I believe there was a perception it performed better under php4

Comments
----------------------------------------
