### PR TITLE
Use name instead of label in conditionals

### DIFF
--- a/ext/afform/admin/managed/FormSubmissionSavedSearch.mgd.php
+++ b/ext/afform/admin/managed/FormSubmissionSavedSearch.mgd.php
@@ -122,7 +122,7 @@ return [
                   'text' => E::ts('Process'),
                   'style' => 'default',
                   'condition' => [
-                    'status_id:label',
+                    'status_id:name',
                     '=',
                     'Pending',
                   ],

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Assigned_Financial_Accounts.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Assigned_Financial_Accounts.mgd.php
@@ -142,7 +142,7 @@ return [
                   'text' => E::ts('Delete'),
                   'style' => 'danger',
                   'condition' => [
-                    'account_relationship:label',
+                    'account_relationship:name',
                     '!=',
                     'Accounts Receivable Account is',
                   ],


### PR DESCRIPTION
Overview
----------------------------------------
Fixes conditions that would break in non-English.

Before
----------------------------------------
2 search displays have a conditional link that compares labels with names. This will break in another language or when using word-replacements.

After
----------------------------------------
Correct comparison used.