### PR TITLE
Noisily deprecate remaining assign_by_ref calls

### DIFF
--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -603,9 +603,12 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
    * @param string $var
    * @param mixed $value
    *   (reference) value of variable.
+   *
+   * @deprecated since 5.72 will be removed around 5.84
    */
   public function assign_by_ref($var, &$value) {
-    self::$_template->assign_by_ref($var, $value);
+    CRM_Core_Error::deprecatedFunctionWarning('assign');
+    self::$_template->assign($var, $value);
   }
 
   /**

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1396,9 +1396,12 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *   Name of variable.
    * @param mixed $value
    *   Value of variable.
+   *
+   * @deprecated since 5.72 will be removed around 5.84
    */
   public function assign_by_ref($var, &$value) {
-    self::$_template->assign_by_ref($var, $value);
+    CRM_Core_Error::deprecatedFunctionWarning('assign');
+    self::$_template->assign($var, $value);
   }
 
   /**

--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -323,9 +323,12 @@ class CRM_Core_Page {
    * @param string $var
    * @param mixed $value
    *   (reference) value of variable.
+   *
+   * @deprecated since 5.72 will be removed around 5.84
    */
   public function assign_by_ref($var, &$value) {
-    self::$_template->assign_by_ref($var, $value);
+    CRM_Core_Error::deprecatedFunctionWarning('assign');
+    self::$_template->assign($var, $value);
   }
 
   /**

--- a/CRM/Event/Selector/Search.php
+++ b/CRM/Event/Selector/Search.php
@@ -425,7 +425,7 @@ class CRM_Event_Selector_Search extends CRM_Core_Selector_Base implements CRM_Co
       }
       $rows[] = $row;
     }
-    CRM_Core_Selector_Controller::$_template->assign_by_ref('lineItems', $lineItems);
+    CRM_Core_Smarty::singleton()->assign('lineItems', $lineItems ?? []);
 
     return $rows;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Noisily deprecate remaining assign_by_ref calls

Before
----------------------------------------
Intermediary assign_by_ref functions no longer called but not clearly deprecated

After
----------------------------------------
Deprecation added

Technical Details
----------------------------------------

Comments
----------------------------------------
