### PR TITLE
Import - Use localized alternative to English-only headerPattern from field metadata

### DIFF
--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -850,15 +850,26 @@ class CRM_Import_Forms extends CRM_Core_Form {
   public function getHeaderPatterns(): array {
     $headerPatterns = [];
     foreach ($this->getFields() as $name => $field) {
-      if (empty($field['headerPattern']) || $field['headerPattern'] === '//') {
-        continue;
+      if (!empty($field['usage']['import']) && !empty($field['title'])) {
+        $patterns = [
+          $this->strToPattern($field['name']),
+          $this->strToPattern($field['title']),
+        ];
+        if (!empty($field['html']['label'])) {
+          $patterns[] = $this->strToPattern($field['html']['label']);
+        }
+        // Swap out dots for double underscores so as not to break the quick form js.
+        // We swap this back on postProcess.
+        $name = str_replace('.', '__', $name);
+        $headerPatterns[$name] = '/^' . implode('|', array_unique($patterns)) . '$/i';
       }
-      // Swap out dots for double underscores so as not to break the quick form js.
-      // We swap this back on postProcess.
-      $name = str_replace('.', '__', $name);
-      $headerPatterns[$name] = $field['headerPattern'];
     }
     return $headerPatterns;
+  }
+
+  private function strToPattern(string $str) {
+    $str = str_replace(['_', '-'], ' ', $str);
+    return strtolower(str_replace(' ', '[-_ ]?', preg_quote($str, '/')));
   }
 
   /**

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -522,11 +522,12 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   /**
    * Do this work on the form layer.
    *
-   * @deprecated
+   * @deprecated in 5.54 will be removed around 5.80
    *
    * @return array
    */
   public function getHeaderPatterns(): array {
+    CRM_Core_Error::deprecatedFunctionWarning('CRM_Import_Forms::getHeaderPatterns');
     $values = [];
     foreach ($this->importableFieldsMetadata as $name => $field) {
       if (isset($field['headerPattern'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Makes the import code better at guessing field headers in non-English languages.

Before
------
English-only matching rules to auto-guess the matching field based on header row in the imported spreadsheet.

After
----
Localized matching.

Technical Details
----------------------------------------
The 'headerPattern' key returned from `DAO::fields()` is only used in one place - import.
And while some of the patterns are quite clever, the only ever worked in English.

So this solution is not going to be quite as clever in English, but at least it will work in other languages.

Note that these headerPatterns are only used as suggestions - the user still gets to manually choose the field mapping (and until now, non-English users would always have to).

This will allow us to rip out the crufty headerPattern stuff from field metadata, which aside from this one place is unused in `universe` (except CiviHR which is abandoned).