### PR TITLE
SMS form cleanup Stop passing contactIds into previously shared function

### DIFF
--- a/CRM/Contact/Form/Task/SMSTrait.php
+++ b/CRM/Contact/Form/Task/SMSTrait.php
@@ -266,12 +266,8 @@ trait CRM_Contact_Form_Task_SMSTrait {
       }
     }
 
-    $contactIds = array_keys($form->_contactDetails);
-    $allContactIds = array_keys($form->_allContactDetails);
-
     [$sent, $countSuccess] = $this->sendSMS($formattedContactDetails,
-      $thisValues,
-      $contactIds
+      $thisValues
     );
 
     if ($countSuccess > 0) {
@@ -295,6 +291,8 @@ trait CRM_Contact_Form_Task_SMSTrait {
       ]), 'info');
     }
     else {
+      $contactIds = array_keys($form->_contactDetails);
+      $allContactIds = array_keys($form->_allContactDetails);
       //Display the name and number of contacts for those sms is not sent.
       $smsNotSent = array_diff_assoc($allContactIds, $contactIds);
 
@@ -324,36 +322,14 @@ trait CRM_Contact_Form_Task_SMSTrait {
    *
    * @param array $contactDetails
    * @param array $activityParams
-   * @param array $contactIds
    *
    * @return array(bool $sent, int $activityId, int $success)
    * @throws CRM_Core_Exception
    */
   protected function sendSMS(
-    &$contactDetails,
-    &$activityParams,
-    &$contactIds = NULL
+    $contactDetails,
+    $activityParams
   ) {
-
-    if (!isset($contactDetails) && !isset($contactIds)) {
-      throw new CRM_Core_Exception('You must specify either $contactDetails or $contactIds');
-    }
-    // Populate $contactDetails and $contactIds if only one is set
-    if (is_array($contactIds) && !empty($contactIds) && empty($contactDetails)) {
-      foreach ($contactIds as $id) {
-        try {
-          $contactDetails[] = civicrm_api3('Contact', 'getsingle', ['contact_id' => $id]);
-        }
-        catch (Exception $e) {
-          // Contact Id doesn't exist
-        }
-      }
-    }
-    elseif (is_array($contactDetails) && !empty($contactDetails) && empty($contactIds)) {
-      foreach ($contactDetails as $contact) {
-        $contactIds[] = $contact['contact_id'];
-      }
-    }
 
     $text = &$activityParams['sms_text_message'];
 


### PR DESCRIPTION


Overview
----------------------------------------
SMS form cleanup Stop passing contactIds into previously shared function

Before
----------------------------------------
`contactIds` passed by reference into sendSMS where it is used to populate `contactDetails` if if is empty - but since `contactIds` is derived from contactDetails in the calling function that's not a thing

After
----------------------------------------
Removed

Technical Details
----------------------------------------
The handling for contactIds OR contactDetails to be passed into the SMS function  was added at some point in the past for a non-core usage of the original function used to send SMS. That function is now unused in core - I took a copy back to this form in order to strip the function back to the inputs & outputs that make sense

Neither of the other 2 parameters are used again from the original function & hence do not need to be passed as references

Comments
----------------------------------------
