### PR TITLE
avoid passing null to strnatcmp deprecation notice

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -532,7 +532,9 @@ class CRM_Utils_Array {
     $fields = (array) $field;
     uasort($array, function ($a, $b) use ($fields) {
       foreach ($fields as $f) {
-        $v = strnatcmp($a[$f], $b[$f]);
+        $f1 = $a[$f] ?? '';
+        $f2 = $b[$f] ?? '';
+        $v = strnatcmp($f1, $f2);
         if ($v !== 0) {
           return $v;
         }


### PR DESCRIPTION
Overview
----------------------------------------
Passing NULL to `strnatcmp` is deprecated.

Before
----------------------------------------
Before I would get notices like the following:

> [PHP Deprecation] strnatcmp(): Passing null to parameter #1 ($string1) of type string is deprecated at /var/www/powerbase/sites/all/modules/civicrm/CRM/Utils/Array.php:535

After
----------------------------------------
Now no notices!


Comments
----------------------------------------
I am not sure where this is being called, but I'm not sure it matters. It seems easy to call this function with a null value so seems good to fix it here.
