### PR TITLE
show distinct contacts when reserving for a survey

### DIFF
--- a/CRM/Campaign/Selector/Search.php
+++ b/CRM/Campaign/Selector/Search.php
@@ -146,10 +146,31 @@ class CRM_Campaign_Selector_Search extends CRM_Core_Selector_Base implements CRM
     // type of selector
     $this->_action = $action;
 
-    $this->_query = new CRM_Contact_BAO_Query($this->_queryParams,
-      NULL, NULL, FALSE, FALSE,
-      CRM_Contact_BAO_Query::MODE_CAMPAIGN,
-      TRUE
+    $params = $this->_queryParams;
+    $returnProperties = NULL;
+    $fields = NULL;
+    $includeContactIds = FALSE;
+    $strict = FALSE;
+    $mode = CRM_Contact_BAO_Query::MODE_CAMPAIGN;
+    $skipPermission = TRUE;
+    $searchDescendentGroups = TRUE;
+    $smartGroupCache = TRUE;
+    $displayRelationshipType = NULL;
+    $operator = 'AND';
+    $apiEntity = NULL;
+    // This is flipped from the default of NULL. When primaryLocationOnly is NULL
+    // it will be based on the value of the 'searchPrimaryDetailsOnly' setting, which is often
+    // set to FALSE so you can search for non-primary location fields in advanced search. But,
+    // when reserving people for a survey, we only want each person listed once, not once for
+    // every combination of location types they have for email, phone, and address.
+    $primaryLocationOnly = TRUE;
+
+    $this->_query = new CRM_Contact_BAO_Query(
+      $params, $returnProperties, $fields,
+      $includeContactIds, $strict, $mode,
+      $skipPermission, $searchDescendentGroups,
+      $smartGroupCache, $displayRelationshipType,
+      $operator, $apiEntity, $primaryLocationOnly
     );
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Depending on the "searchPrimaryDetailsOnly" setting (which controls whether or not you can search for non primary location fields), you might end up with a confusing number of results when trying to reserve people for a survey when using CiviCampaign.


Before
----------------------------------------
If:

 * searchPrimaryDetailsOnly is set to no (`Advanced Search -> Customize Data and Screens -> Search Preferences`),
 * You have a contact with more than one email, address or phone number
 * You create a survey
 * You reserve respondents (`Campigns -> Reserve Respondents`)
 
Then, you will  see something like this when trying to reserve someone to be Interviewed using CiviCampaign. Note: there is only one respondent listed multiple times with each address, email and phone:

![many](https://github.com/civicrm/civicrm-core/assets/4511942/8a9203b1-df07-4751-acf7-9174f19ebef4)


After
----------------------------------------

You should only see one row for each unique respondent:

![just-one](https://github.com/civicrm/civicrm-core/assets/4511942/c5322794-87d7-40f6-b503-f262bd9e1fe7)


Comments
----------------------------------------
I also spelled out the very long list of arguments to `CRM_Contact_BAO_Query` to try to make it clearer what is happening.
