### PR TITLE
Fix event management performance when there are lots of events.

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -2120,14 +2120,13 @@ WHERE  ce.loc_block_id = $locBlockId";
 
     $allEvents = [];
     $createdEvents = [];
-    if ($eventResult = civicrm_api4('Event', 'get', $params)) {
-      $contactId = CRM_Core_Session::getLoggedInContactID();
-      foreach ($eventResult as $eventDetail) {
-        $eventId = $eventDetail['id'];
-        $allEvents[$eventId] = $eventId;
-        if (isset($eventDetail['created_id']) && $contactId == $eventDetail['created_id']) {
-          $createdEvents[$eventId] = $eventId;
-        }
+    $eventResult = civicrm_api4('Event', 'get', $params);
+    $contactId = CRM_Core_Session::getLoggedInContactID();
+    foreach ($eventResult as $eventDetail) {
+      $eventId = $eventDetail['id'];
+      $allEvents[$eventId] = $eventId;
+      if (isset($eventDetail['created_id']) && $contactId == $eventDetail['created_id']) {
+        $createdEvents[$eventId] = $eventId;
       }
     }
     return [$allEvents, $createdEvents];

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -2112,20 +2112,18 @@ WHERE  ce.loc_block_id = $locBlockId";
    */
   private static function checkPermissionGetInfo($eventId = NULL) {
     $params = [
-      'check_permissions' => 1,
-      'return' => 'id, created_id',
-      'options' => ['limit' => 0],
+      'select' => ['id', 'created_id'],
     ];
     if ($eventId) {
-      $params['id'] = $eventId;
+      $params['where'] = [['id', '=', $eventId]];
     }
 
     $allEvents = [];
     $createdEvents = [];
-    $eventResult = civicrm_api3('Event', 'get', $params);
-    if ($eventResult['count'] > 0) {
+    if ($eventResult = civicrm_api4('Event', 'get', $params)) {
       $contactId = CRM_Core_Session::getLoggedInContactID();
-      foreach ($eventResult['values'] as $eventId => $eventDetail) {
+      foreach ($eventResult as $eventDetail) {
+        $eventId = $eventDetail['id'];
         $allEvents[$eventId] = $eventId;
         if (isset($eventDetail['created_id']) && $contactId == $eventDetail['created_id']) {
           $createdEvents[$eventId] = $eventId;


### PR DESCRIPTION
Overview
----------------------------------------
When there are lots of events the event management page gets slow. Switching to API v4 appears to fix the bottleneck. We had a site with hundreds of events where this was happening.
