### PR TITLE
civicrm_menu.is_ssl

### DIFF
--- a/CRM/Contribute/xml/Menu/Contribute.xml
+++ b/CRM/Contribute/xml/Menu/Contribute.xml
@@ -32,7 +32,6 @@
     <page_callback>CRM_Contribute_Controller_Contribution</page_callback>
     <access_arguments>make online contributions</access_arguments>
     <weight>0</weight>
-    <is_ssl>true</is_ssl>
     <is_public>true</is_public>
   </item>
   <item>

--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -160,7 +160,7 @@ class CRM_Core_Menu {
             $value = [[$value], 'and'];
           }
         }
-        elseif ($key == 'is_public' || $key == 'is_ssl') {
+        elseif ($key == 'is_public') {
           $value = ($value == 'true' || $value == 1) ? 1 : 0;
         }
         $menu[$path][$key] = $value;
@@ -210,7 +210,6 @@ class CRM_Core_Menu {
       'access_arguments',
       'page_callback',
       'page_arguments',
-      'is_ssl',
     ];
     $fieldsPresent = [];
     foreach ($fieldsToPropagate as $field) {

--- a/CRM/Core/xml/Menu/Admin.xml
+++ b/CRM/Core/xml/Menu/Admin.xml
@@ -664,7 +664,6 @@
      <access_arguments>administer CiviCRM system,administer CiviCRM data,access CiviCRM</access_arguments>
      <page_type>1</page_type>
      <page_callback>CRM_Admin_Page_Admin</page_callback>
-     <is_ssl>true</is_ssl>
      <weight>9000</weight>
   </item>
   <item>

--- a/CRM/Core/xml/Menu/Contact.xml
+++ b/CRM/Core/xml/Menu/Contact.xml
@@ -8,7 +8,6 @@
      <access_arguments>access CiviCRM</access_arguments>
      <page_callback>CRM_Contact_Page_DashBoard</page_callback>
      <page_arguments>null</page_arguments>
-     <is_ssl>false</is_ssl>
      <weight>0</weight>
   </item>
   <item>

--- a/CRM/Event/xml/Menu/Event.xml
+++ b/CRM/Event/xml/Menu/Event.xml
@@ -31,7 +31,6 @@
      <page_callback>CRM_Event_Controller_Registration</page_callback>
      <access_callback>1</access_callback>
      <is_public>true</is_public>
-     <is_ssl>true</is_ssl>
   </item>
   <item>
      <path>civicrm/event/confirm</path>
@@ -39,7 +38,6 @@
      <page_callback>CRM_Event_Form_Registration_ParticipantConfirm</page_callback>
      <access_callback>1</access_callback>
      <is_public>true</is_public>
-     <is_ssl>true</is_ssl>
   </item>
   <item>
      <path>civicrm/event/ical</path>
@@ -150,7 +148,6 @@
      <page_callback>CRM_Event_Page_ManageEvent</page_callback>
      <access_arguments>access CiviEvent</access_arguments>
      <page_type>1</page_type>
-     <is_ssl>true</is_ssl>
      <weight>820</weight>
   </item>
   <item>
@@ -164,7 +161,6 @@
      <title>Event Info and Settings</title>
      <page_callback>CRM_Event_Form_ManageEvent_EventInfo</page_callback>
      <access_arguments>access CiviEvent</access_arguments>
-     <is_ssl>true</is_ssl>
      <weight>910</weight>
   </item>
   <item>
@@ -172,7 +168,6 @@
      <title>Event Location</title>
      <page_callback>CRM_Event_Form_ManageEvent_Location</page_callback>
      <access_arguments>access CiviEvent</access_arguments>
-     <is_ssl>true</is_ssl>
      <weight>930</weight>
   </item>
   <item>
@@ -180,7 +175,6 @@
      <title>Event Fees</title>
      <page_callback>CRM_Event_Form_ManageEvent_Fee</page_callback>
      <access_arguments>access CiviEvent</access_arguments>
-     <is_ssl>true</is_ssl>
      <weight>920</weight>
   </item>
   <item>
@@ -188,7 +182,6 @@
      <title>Event Online Registration</title>
      <page_callback>CRM_Event_Form_ManageEvent_Registration</page_callback>
      <access_arguments>access CiviEvent</access_arguments>
-     <is_ssl>true</is_ssl>
      <weight>930</weight>
   </item>
   <item>
@@ -196,7 +189,6 @@
      <title>Tell a Friend</title>
      <page_callback>CRM_Friend_Form_Event</page_callback>
      <access_arguments>access CiviEvent</access_arguments>
-     <is_ssl>true</is_ssl>
      <weight>940</weight>
   </item>
   <item>
@@ -204,7 +196,6 @@
      <title>Schedule Reminders</title>
      <page_callback>CRM_Event_Form_ManageEvent_ScheduleReminders</page_callback>
      <access_arguments>access CiviEvent</access_arguments>
-     <is_ssl>true</is_ssl>
      <weight>950</weight>
   </item>
   <item>
@@ -212,7 +203,6 @@
      <title>Repeat Event</title>
      <page_callback>CRM_Event_Form_ManageEvent_Repeat</page_callback>
      <access_arguments>access CiviEvent</access_arguments>
-     <is_ssl>true</is_ssl>
      <weight>960</weight>
   </item>
   <item>

--- a/CRM/Upgrade/Incremental/php/FiveFortyNine/Core.bool.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortyNine/Core.bool.php
@@ -60,7 +60,6 @@ return [
     'is_active' => "DEFAULT 1 COMMENT 'Is this menu item active?'",
     'is_public' => "DEFAULT 0 COMMENT 'Is this menu accessible to the public?'",
     'is_exposed' => "DEFAULT 1 COMMENT 'Is this menu exposed to the navigation system?'",
-    'is_ssl' => "DEFAULT 1 COMMENT 'Should this menu be exposed via SSL if enabled?'",
     'skipBreadcrumb' => "DEFAULT 0 COMMENT 'skip this url being exposed to breadcrumb'",
   ],
   'civicrm_msg_template' => [

--- a/ext/eventcart/xml/Menu/Eventcart.xml
+++ b/ext/eventcart/xml/Menu/Eventcart.xml
@@ -19,7 +19,6 @@
     <page_callback>CRM_Event_Cart_Page_AddToCart</page_callback>
     <access_callback>1</access_callback>
     <is_public>true</is_public>
-    <is_ssl>false</is_ssl>
   </item>
   <item>
     <path>civicrm/event/cart_checkout</path>
@@ -27,7 +26,6 @@
     <page_callback>CRM_Event_Cart_Controller_Checkout</page_callback>
     <access_callback>1</access_callback>
     <is_public>true</is_public>
-    <is_ssl>true</is_ssl>
   </item>
   <item>
     <path>civicrm/event/remove_from_cart</path>
@@ -35,7 +33,6 @@
     <page_callback>CRM_Event_Cart_Page_RemoveFromCart</page_callback>
     <access_callback>1</access_callback>
     <is_public>true</is_public>
-    <is_ssl>false</is_ssl>
   </item>
   <item>
     <path>civicrm/event/view_cart</path>
@@ -43,7 +40,6 @@
     <page_callback>CRM_Event_Cart_Page_ViewCart</page_callback>
     <access_callback>1</access_callback>
     <is_public>true</is_public>
-    <is_ssl>false</is_ssl>
   </item>
   <item>
     <path>civicrm/admin/options/conference_slot</path>
@@ -59,7 +55,6 @@
     <title>Conference Slots</title>
     <page_callback>CRM_Event_Form_ManageEvent_Conference</page_callback>
     <access_arguments>access CiviEvent</access_arguments>
-    <is_ssl>true</is_ssl>
     <weight>950</weight>
   </item>
 </menu>

--- a/xml/schema/Core/Menu.xml
+++ b/xml/schema/Core/Menu.xml
@@ -183,15 +183,6 @@
     <add>2.1</add>
   </field>
   <field>
-    <name>is_ssl</name>
-    <title>Use SSL?</title>
-    <type>boolean</type>
-    <default>1</default>
-    <required>true</required>
-    <comment>Should this menu be exposed via SSL if enabled?</comment>
-    <add>2.1</add>
-  </field>
-  <field>
     <name>weight</name>
     <title>Order</title>
     <type>int</type>


### PR DESCRIPTION
Overview
----------------------------------------
I'm pretty sure this parameter is no longer required.

Before
----------------------------------------

After
----------------------------------------

Technical Details
----------------------------------------

Comments
----------------------------------------
@eileenmcnaughton @colemanw @totten thoughts? There might be a couple of other fields in civicrm_menu that we could drop as well like `page_type` and `is_exposed` but I've not looked into that.

Note that this might want an upgrader to drop the column if agreed we should remove.