### PR TITLE
Fix test to call actual function

### DIFF
--- a/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
+++ b/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
@@ -81,8 +81,8 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
         'email-1' => $emails[$i][0],
         'email-2' => $emails[$i][1],
       ];
-      $dedupeParams = CRM_Dedupe_Finder::formatParams($fields, 'Individual');
-      $dedupeResults = CRM_Dedupe_Finder::dupesByParams($dedupeParams, 'Individual');
+      $dedupeResults = CRM_Contact_BAO_Contact::getDuplicateContacts($fields, 'Individual');
+
       $this->assertCount(1, $dedupeResults);
     }
   }


### PR DESCRIPTION
These 2 functions make up CRM_Contact_BAO_Contact::getDuplicateContacts and are only called from there - it makes sense to call the full function rather than the constituent functions - especially as they have a single caller & could reasonably have their imputs & outputs adjusted without change to the behaviour by the actually tested function
