### PR TITLE
Do not import multiple participants per line

### DIFF
--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -151,12 +151,15 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
 
         if (CRM_Core_Error::isAPIError($error, CRM_Core_Error::DUPLICATE_CONTACT)) {
           $matchedIDs = (array) $error['error_message']['params'];
-          if (count($matchedIDs) >= 1) {
+          if (count($matchedIDs) === 1) {
             foreach ($matchedIDs as $contactId) {
               $formatted['contact_id'] = $contactId;
               $formatted['version'] = 3;
               $newParticipant = $this->deprecated_create_participant_formatted($formatted);
             }
+          }
+          elseif ($matchedIDs > 1) {
+            throw new CRM_Core_Exception(ts('Record duplicates multiple contacts: ') . implode(',', $matchedIDs));
           }
         }
         else {


### PR DESCRIPTION


Overview
----------------------------------------
Do not import multiple participants per line

Before
----------------------------------------
If multiple contacts are found matching dedupe values in participant import then multiple participants are created

After
----------------------------------------
It rebels if there are multiple possible contacts matching the contribution row

Technical Details
----------------------------------------

@seamuslee001 can you sanity check me here? I'm finding the duplicate matching is fairly broken but I'm afraid that fixing it will be seen as a regression because this code is allows for creating a participant record for every found contact if multiple possible contacts are found. By contrast the contribution import creates an error on these, allowing people to fix it

Comments
----------------------------------------
