### PR TITLE
Remove some legacy code that is not relevant in this previously shared function

### DIFF
--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -345,11 +345,6 @@ class CRM_Dedupe_Finder {
       }
     }
 
-    if (str_contains($entityType, "'")) {
-      // Handle really weird legacy input format
-      $entityType = explode(',', str_replace([' ', "'"], '', $entityType));
-    }
-
     $filters = [
       'extends' => $entityType,
       'is_active' => TRUE,
@@ -378,11 +373,6 @@ class CRM_Dedupe_Finder {
           $value = CRM_Utils_Array::implodePadded($value);
         }
         $group[$key] = (string) $value;
-      }
-      // CRM-5507 - Hard to know what this was supposed to do but this faithfully recreates
-      // whatever it was doing before the refactor, which was probably broken anyway.
-      if (!empty($subTypes[0])) {
-        $group['subtype'] = self::validateSubTypeByEntity(CRM_Utils_Array::first((array) $filters['extends']), $subTypes[0]);
       }
     }
     $groupTree = $customGroups;


### PR DESCRIPTION


Overview
----------------------------------------
Remove some legacy code that is not relevant in this separated function

Before
----------------------------------------
The function never uses the 'subtype' key & it could possibly cause a regression not removing it as I removed a protection against non-numeric values thinking 'info' was the only one

The other bit of code is for handling entityType being in a weird format - but I think we can be pretty confident that is not relevant here

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
