### PR TITLE
Dedupe finder field wrangler - de-nest groupTree results

### DIFF
--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -345,11 +345,6 @@ class CRM_Dedupe_Finder {
       }
     }
 
-    if (str_contains($entityType, "'")) {
-      // Handle really weird legacy input format
-      $entityType = explode(',', str_replace([' ', "'"], '', $entityType));
-    }
-
     $filters = [
       'extends' => $entityType,
       'is_active' => TRUE,
@@ -378,11 +373,6 @@ class CRM_Dedupe_Finder {
           $value = CRM_Utils_Array::implodePadded($value);
         }
         $group[$key] = (string) $value;
-      }
-      // CRM-5507 - Hard to know what this was supposed to do but this faithfully recreates
-      // whatever it was doing before the refactor, which was probably broken anyway.
-      if (!empty($subTypes[0])) {
-        $group['subtype'] = self::validateSubTypeByEntity(CRM_Utils_Array::first((array) $filters['extends']), $subTypes[0]);
       }
     }
     $groupTree = $customGroups;


### PR DESCRIPTION
Overview
----------------------------------------
Dedupe finder field wrangler - de-nest groupTree results

Before
----------------------------------------
The groupTree is layered up by group ID & then an array of fields - each time the function handles the fields it iterates through them to get to these layers

After
-----------------------------------
`$customFields is flattened at the start - handling is simplified, formatting of unused fields is removed

Technical Details
----------------------------------------
Note that this cleanup fixed https://github.com/civicrm/civicrm-core/pull/29554 - I think there was some oddness around the wrangling causing an actual bug that got fixed in the cleanup

Comments
----------------------------------------
