### PR TITLE
standalone: prevent installer using secret admin pass. Fixes 5038

### DIFF
--- a/setup/plugins/blocks/admin.civi-setup.php
+++ b/setup/plugins/blocks/admin.civi-setup.php
@@ -27,6 +27,9 @@ if (!defined('CIVI_SETUP')) {
         $e->getModel()->extras['adminPassWasSpecified'] = TRUE;
         $e->getModel()->extras['adminPass'] = $e->getField('adminPass');
       }
+      if ($e->getField('adminEmail')) {
+        $e->getModel()->extras['adminEmail'] = $e->getField('adminEmail');
+      }
     }
 
   }, \Civi\Setup::PRIORITY_PREPARE);

--- a/setup/plugins/blocks/admin.tpl.php
+++ b/setup/plugins/blocks/admin.tpl.php
@@ -2,22 +2,28 @@
   exit("Installation plugins must only be loaded by the installer.\n");
 } ?>
 
-<h2><?php echo ts('Administrator'); ?></h2>
+<?php if (empty($reqs->getErrors())) : ?>
 
-<p style="margin-left: 2em">
+<h2><?php echo ts('Administrator Account'); ?></h2>
+
+<div class="civicrm-setup-field-wrapper">
   <label for="adminUser"><span><?php echo ts('Administrative User:'); ?></span></label>
   <input type="text" id="adminUser" name="civisetup[adminUser]" required value="<?php echo htmlentities($model->extras['adminUser'] ?? '') ?>">
-</p>
+</div>
 
-<p style="margin-left: 2em">
+<div class="civicrm-setup-field-wrapper">
   <label for="adminPass"><span><?php echo ts('Administrative Password:'); ?></span></label>
   <input type="password" id="adminPass" name="civisetup[adminPass]" required />
     <?php if (!empty($model->extras['adminPass'])) {
+      echo '<div>';
       echo ts('Suggestion: <code>%1</code>', [1 => $model->extras['adminPass']]);
+      echo '</div>';
 } ?>
-</p>
+</div>
 
-<p style="margin-left: 2em">
+<div class="civicrm-setup-field-wrapper">
   <label for="adminEmail"><span><?php echo ts('Administrative Email:'); ?></span></label>
   <input type="email" required id="adminEmail" name="civisetup[adminEmail]" value="<?php htmlspecialchars($model->extras['adminEmail'] ?? '');?>" />
-</p>
+</div>
+
+<?php endif;

--- a/setup/plugins/blocks/admin.tpl.php
+++ b/setup/plugins/blocks/admin.tpl.php
@@ -18,7 +18,7 @@
       echo '<div>';
       echo ts('Suggestion: <code>%1</code>', [1 => $model->extras['adminPass']]);
       echo '</div>';
-} ?>
+    } ?>
 </div>
 
 <div class="civicrm-setup-field-wrapper">

--- a/setup/plugins/blocks/admin.tpl.php
+++ b/setup/plugins/blocks/admin.tpl.php
@@ -1,14 +1,23 @@
-<?php if (!defined('CIVI_SETUP')): exit("Installation plugins must only be loaded by the installer.\n");
-endif; ?>
+<?php if (!defined('CIVI_SETUP')) {
+  exit("Installation plugins must only be loaded by the installer.\n");
+} ?>
 
 <h2><?php echo ts('Administrator'); ?></h2>
 
 <p style="margin-left: 2em">
   <label for="adminUser"><span><?php echo ts('Administrative User:'); ?></span></label>
-  <input type="text" id="adminUser" name="civisetup[adminUser]" value="<?php echo htmlentities($model->extras['adminUser'] ?? '') ?>">
+  <input type="text" id="adminUser" name="civisetup[adminUser]" required value="<?php echo htmlentities($model->extras['adminUser'] ?? '') ?>">
 </p>
 
 <p style="margin-left: 2em">
   <label for="adminPass"><span><?php echo ts('Administrative Password:'); ?></span></label>
-  <input type="password" id="adminPass" name="civisetup[adminPass]" value="<?php echo htmlentities($model->extras['adminPass'] ?? '') ?>">
+  <input type="password" id="adminPass" name="civisetup[adminPass]" required />
+    <?php if (!empty($model->extras['adminPass'])) {
+      echo ts('Suggestion: <code>%1</code>', [1 => $model->extras['adminPass']]);
+} ?>
+</p>
+
+<p style="margin-left: 2em">
+  <label for="adminEmail"><span><?php echo ts('Administrative Email:'); ?></span></label>
+  <input type="email" required id="adminEmail" name="civisetup[adminEmail]" value="<?php htmlspecialchars($model->extras['adminEmail'] ?? '');?>" />
 </p>

--- a/setup/plugins/blocks/database.tpl.php
+++ b/setup/plugins/blocks/database.tpl.php
@@ -1,24 +1,25 @@
-<?php if (!defined('CIVI_SETUP')): exit("Installation plugins must only be loaded by the installer.\n");
+<?php if (!defined('CIVI_SETUP')) :
+  exit("Installation plugins must only be loaded by the installer.\n");
 endif; ?>
 
 <h2><?php echo ts('Database'); ?></h2>
-
-<p style="margin-left: 2em">
+<div class="civicrm-setup-field-wrapper">
   <label for="server"><span><?php echo ts('Server:'); ?></span></label>
-  <input type="text" id="dbServer" name="civisetup[db][server]" value="<?php echo htmlentities($model->db['server'] ?? '') ?>">
-</p>
+  <input type="text" id="dbServer" name="civisetup[db][server]" value="<?php echo htmlentities($model->db['server'] ?? '') ?>" >
+</div>
 
-<p style="margin-left: 2em">
+<div class="civicrm-setup-field-wrapper">
   <label for="database"><span><?php echo ts('Database:'); ?></span></label>
   <input type="text" id="dbDatabase" name="civisetup[db][database]" value="<?php echo htmlentities($model->db['database'] ?? '') ?>">
-</p>
+</div>
 
-<p style="margin-left: 2em">
+<div class="civicrm-setup-field-wrapper">
   <label for="username"><span><?php echo ts('Username:'); ?></span></label>
   <input type="text" id="dbUsername" name="civisetup[db][username]" value="<?php echo htmlentities($model->db['username'] ?? '') ?>">
-</p>
+</div>
 
-<p style="margin-left: 2em">
+<div class="civicrm-setup-field-wrapper">
+
   <label for="password"><span><?php echo ts('Password:'); ?></span></label>
   <input type="password" id="dbPassword" name="civisetup[db][password]" value="<?php echo htmlentities($model->db['password'] ?? '') ?>">
-</p>
+</div>

--- a/setup/res/template.css
+++ b/setup/res/template.css
@@ -34,16 +34,15 @@ body {
   100% {
     left: 0;
     color: #555;
-}
+  }
 }
 
 @keyframes slide {
   100% {
     left: 0;
     color: #555;
+  }
 }
-}
-
 
 .civicrm-setup-header hr {
   border-bottom: 2px solid #fff;
@@ -61,7 +60,6 @@ body {
 .civicrm-setup-body .civicrm-logo img {
   width: 100%;
 }
-
 
 /* Header End */
 
@@ -81,7 +79,6 @@ body {
 }
 
 .civicrm-setup-body h2 {
-  margin-top: 0;
   display: inline-block;
 }
 
@@ -127,7 +124,7 @@ body {
   background: #ffb;
   padding: 0.5em;
   margin: 1em auto;
-  width: 50%
+  width: 50%;
 }
 
 .civicrm-setup-body .advancedTip {
@@ -163,7 +160,7 @@ body {
 
 .civicrm-setup-body .settingsTable {
   border-collapse: collapse;
-  margin: 2em
+  margin: 2em;
 }
 
 .civicrm-setup-body th,
@@ -263,7 +260,7 @@ body {
   text-align: center;
   margin: 2em 0.5em;
 }
-.civicrm-setup-body button[type=submit] {
+.civicrm-setup-body button[type="submit"] {
   padding: 15px 25px;
   background: #82c459;
   color: white;
@@ -273,19 +270,33 @@ body {
   border-radius: 5px;
   font-size: 20px;
 }
-.civicrm-setup-body button[type=submit]:hover {
+.civicrm-setup-body button[type="submit"]:hover {
   background: #60a237;
 }
-.civicrm-setup-body button[type=submit]:disabled {
+.civicrm-setup-body button[type="submit"]:disabled {
   background: #888;
   cursor: not-allowed;
 }
 
-.civicrm-setup-body .settingsTable input[type=text] {
+.civicrm-setup-body .settingsTable input[type="text"] {
   width: 80%;
 }
 
-
+.civicrm-setup-field-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  margin-bottom: 0.5em;
+  gap: 1em;
+}
+.civicrm-setup-field-wrapper > label {
+  flex: 0 0 25ch;
+}
+.civicrm-setup-field-wrapper > input {
+  flex: 0 0 25ch;
+}
+.civicrm-setup-field-wrapper > div {
+  flex: 0 0 auto;
+}
 
 @media only screen and (max-width: 801px) {
   .civicrm-setup-body .comp-box {
@@ -307,7 +318,6 @@ body {
     width: 95%;
     margin: 10px 2% 10px 2%;
   }
-
 }
 
 @media only screen and (max-width: 503px) {

--- a/setup/res/template.css
+++ b/setup/res/template.css
@@ -136,8 +136,7 @@ body {
   display: none;
 }
 
-.civicrm-setup-body .install-validate-bad {
-}
+/* .civicrm-setup-body .install-validate-bad { } */
 
 .civicrm-setup-body .reqTable {
   border-collapse: collapse;


### PR DESCRIPTION
re: https://lab.civicrm.org/dev/core/-/issues/5038

This PR does 3 things

1. It moves the auto-generated random password from a form value to a _suggestion_, so the password field is blank when you get the form.
2. It adds an email field for the admin account.
3. It only adds the fields to the HTML after there are no more database/system errors (previously it relied on CSS). It then uses HTML's `required` attribute to prevent the form submitting without data in these fields, thereby fixing 5038.

Screenshot of new screen:

![image](https://github.com/civicrm/civicrm-core/assets/870343/58660eed-ad8b-4290-8140-01cdcd6f9099)
