### PR TITLE
core#4849 Shorten all Event iCal descriptions to match Add event to Google Calendar

### DIFF
--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -182,7 +182,10 @@ function civicrm_api3_mailing_clone($params) {
   while ($dao->fetch()) {
     // CRM-11431; account for multi-lingual
     $entity = (substr($dao->entity_table, 0, 15) == 'civicrm_mailing') ? 'mailings' : 'groups';
-    $newParams[$entity][strtolower($dao->group_type)][] = $dao->entity_id;
+    $group_type = strtolower($dao->group_type);
+    if (!in_array($dao->entity_id, $newParams[$entity][$group_type])) {
+      $newParams[$entity][$group_type][] = $dao->entity_id;
+    }
   }
 
   return civicrm_api3('Mailing', 'create', $newParams);


### PR DESCRIPTION
Overview
----------------------------------------
See [issue #4849](https://lab.civicrm.org/dev/core/-/issues/4849)

Before
----------------------------------------
iCal events have long descriptions

After
----------------------------------------
iCal events are shortened with a link to the event

