### PR TITLE
AngularJS - Fix multi-select fields when value contains a comma

### DIFF
--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -82,7 +82,7 @@
         </fieldset>
         <div class="api4-input form-inline" ng-mouseenter="help('fields', availableParams.fields)" ng-mouseleave="help()" ng-if="::availableParams.fields">
           <label for="api4-param-fields">fields<span class="crm-marker" ng-if="::availableParams.fields.required"> *</span></label>
-          <input class="form-control" ng-list crm-ui-select="::{data: fields, multiple: true}" id="api4-param-fields" ng-model="params.fields" style="width: 85%;"/>
+          <input class="form-control" ng-list="" crm-ui-select="::{data: fields, multiple: true, separator: '\u0001'}" id="api4-param-fields" ng-model="params.fields" style="width: 85%;"/>
         </div>
         <div class="api4-input form-inline" ng-mouseenter="help('action', availableParams.action)" ng-mouseleave="help()"ng-if="::availableParams.action">
           <label for="api4-param-action">action<span class="crm-marker" ng-if="::availableParams.action.required"> *</span></label>

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -1275,16 +1275,17 @@
           } else if (_.includes(['=', '!=', '<>', 'IN', 'NOT IN'], op) && (field.fk_entity || field.options || dataType === 'Boolean')) {
            if (field.options) {
               var id = field.pseudoconstant || 'id';
-              $el.addClass('loading').attr('placeholder', ts('- select -')).crmSelect2({multiple: multi, data: [{id: '', text: ''}]});
+              $el.addClass('loading').attr('placeholder', ts('- select -')).crmSelect2({multiple: multi, separator: "\u0001", data: [{id: '', text: ''}]});
               loadFieldOptions(field.entity || entity).then(function(data) {
                 var options = _.transform(data[field.name].options, function(options, opt) {
                   options.push({id: opt[id], text: opt.label, description: opt.description, color: opt.color, icon: opt.icon});
                 }, []);
-                $el.removeClass('loading').crmSelect2({data: options, multiple: multi});
+                $el.removeClass('loading').crmSelect2({data: options, multiple: multi, separator: "\u0001"});
               });
             } else if (field.fk_entity) {
               $el.crmAutocomplete(field.fk_entity, {fieldName: field.entity + '.' + field.name, key: field.id_field || null}, {
                 multiple: multi,
+                separator: "\u0001",
                 static: field.fk_entity === 'Contact' ? ['user_contact_id'] : [],
                 minimumInputLength: field.fk_entity === 'Contact' ? 1 : 0
               });
@@ -1323,7 +1324,7 @@
           var list = [];
 
           if (viewValue) {
-            _.each(viewValue.split(','), function(value) {
+            _.each(viewValue.split("\u0001"), function(value) {
               if (value) list.push(_.trim(value));
             });
           }

--- a/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
@@ -56,6 +56,7 @@
               var params = field.entity && field.name ? {fieldName: field.entity + '.' + field.name} : {filters: filters};
               $el.crmAutocomplete(field.fk_entity, params, {
                 multiple: multi,
+                separator: '\u0001',
                 "static": options,
                 minimumInputLength: options.length ? 1 : 0
               });
@@ -63,9 +64,9 @@
               options = _.transform(field.options, function(options, val) {
                 options.push({id: val.id, text: val.label});
               }, []);
-              $el.select2({data: options, multiple: multi});
+              $el.select2({data: options, multiple: multi, separator: '\u0001'});
             } else if (dataType === 'Boolean') {
-              $el.attr('placeholder', ts('- select -')).crmSelect2({allowClear: false, multiple: multi, placeholder: ts('- select -'), data: [
+              $el.attr('placeholder', ts('- select -')).crmSelect2({allowClear: false, multiple: multi, separator: '\u0001', placeholder: ts('- select -'), data: [
                   {id: '1', text: ts('Yes')},
                   {id: '0', text: ts('No')}
                 ]});
@@ -95,7 +96,7 @@
           var list = [];
 
           if (viewValue) {
-            _.each(viewValue.split(','), function(value) {
+            _.each(viewValue.split("\u0001"), function(value) {
               if (value) list.push(_.trim(value));
             });
           }

--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -23,7 +23,7 @@
       {{:: ts('Permission') }}
     </label>
     <div class="form-inline" >
-      <input ng-model="editor.afform.permission" class="form-control" id="af_config_form_permission" crm-ui-select="{data: editor.meta.permissions, multiple: true}" ng-list >
+      <input ng-model="editor.afform.permission" class="form-control" id="af_config_form_permission" crm-ui-select="{data: editor.meta.permissions, multiple: true, separator: '\u0001'}" ng-list="" >
       <select ng-model="editor.afform.permission_operator" class="form-control" id="af_config_form_permission_operator" >
         <option value="AND">{{:: ts('And') }}</option>
         <option value="OR">{{:: ts('Or') }}</option>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -40,7 +40,7 @@
 </li>
 <li ng-if="$ctrl.fieldDefn.input_type === 'EntityRef'" title="{{:: ts('Allow a new entity to be created via quick-add popup') }}">
   <div href ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
-    <input crm-ui-select="{data: $ctrl.quickAddLinks, multiple: true, placeholder: ts('Quick Add')}" ng-model="getSet('input_attrs.quickAdd')" ng-model-options="{getterSetter: true}" ng-list class="form-control">
+    <input crm-ui-select="{data: $ctrl.quickAddLinks, multiple: true, separator: '\u0001', placeholder: ts('Quick Add')}" ng-model="getSet('input_attrs.quickAdd')" ng-model-options="{getterSetter: true}" ng-list="" class="form-control">
   </div>
 </li>
 <li ng-if="$ctrl.fieldDefn.input_type === 'EntityRef'">

--- a/ext/afform/core/ang/af/fields/Select.html
+++ b/ext/afform/core/ang/af/fields/Select.html
@@ -1,6 +1,6 @@
 <div class="{{:: $ctrl.defn.search_range ? 'form-inline' : 'form-group' }}">
   <input class="form-control" ng-required="$ctrl.defn.required" id="{{:: fieldId }}" ng-if="!$ctrl.isMultiple()" crm-ui-select="{data: select2Options, placeholder: $ctrl.defn.input_attrs.placeholder}" ng-model="getSetSelect" ng-model-options="{getterSetter: true}" >
-  <input class="form-control" ng-required="$ctrl.defn.required" id="{{:: fieldId }}" ng-if="$ctrl.isMultiple()" ng-list crm-ui-select="{data: select2Options, multiple: true, placeholder: $ctrl.defn.input_attrs.placeholder}" ng-model="getSetSelect" ng-model-options="{getterSetter: true}" >
+  <input class="form-control" ng-required="$ctrl.defn.required" id="{{:: fieldId }}" ng-if="$ctrl.isMultiple()" ng-list="" crm-ui-select="{data: select2Options, multiple: true, separator: '\u0001', placeholder: $ctrl.defn.input_attrs.placeholder}" ng-model="getSetSelect" ng-model-options="{getterSetter: true}" >
   <input class="form-control" ng-required="$ctrl.defn.required" ng-if=":: $ctrl.defn.search_range && !$ctrl.defn.is_date" id="{{:: fieldId }}2" crm-ui-select="{data: select2Options, placeholder: $ctrl.defn.input_attrs.placeholder2 || $ctrl.defn.input_attrs.placeholder}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]['<=']" >
   <div ng-if="$ctrl.defn.search_range && $ctrl.defn.is_date && getSetSelect() === '{}'" class="form-group" ng-include="'~/af/fields/Date.html'"></div>
 </div>

--- a/ext/civi_case/ang/crmCaseType/rolesTable.html
+++ b/ext/civi_case/ang/crmCaseType/rolesTable.html
@@ -18,8 +18,8 @@ Required vars: caseType
 	    <td>{{relType.displayLabel}}</td>
 	    <td><input type="checkbox" ng-model="relType.creator" ng-true-value="'1'" ng-false-value="'0'"></td>
 	    <td><input type="radio" ng-model="relType.manager" value="1" ng-change="onManagerChange(relType)"></td>
-	    <td><input ng-list class="big"
-				crm-entityref="{entity: 'Group', api: {id_field: 'name', params: {is_hidden: 0, is_active: 1}}, select: {allowClear: true, multiple: true, placeholder: ts('Select Group')}}"
+	    <td><input ng-list="" class="big"
+				crm-entityref="{entity: 'Group', api: {id_field: 'name', params: {is_hidden: 0, is_active: 1}}, select: {allowClear: true, multiple: true, separator: '\u0001', placeholder: ts('Select Group')}}"
 				ng-model="relType.groups"
 			/></td>
 	    <td>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/select.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/select.html
@@ -5,5 +5,5 @@
   <input class="form-control" ng-model="$ctrl.value" crm-ui-select="{data: $ctrl.getFieldOptions, allowClear: $ctrl.field.nullable, placeholder: $ctrl.field.nullable ? ts('None') : ts('Select')}">
 </div>
 <div class="form-group" ng-if="$ctrl.isMulti() && $ctrl.field.options !== true">
-  <input class="form-control" ng-model="$ctrl.value" crm-ui-select="{data: $ctrl.getFieldOptions, multiple: true}" ng-list >
+  <input class="form-control" ng-model="$ctrl.value" crm-ui-select="{data: $ctrl.getFieldOptions, multiple: true, separator: '\u0001'}" ng-list="" >
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/3695

Before
----------------------------------------
Values containing a comma character break multi-selects. See [reproduction steps](https://lab.civicrm.org/dev/core/-/issues/3695).

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Both `ng-list` and Select2 default to ',' as the separator character but allow you to change it. I went with the same character we use to separate values in the DB.

Comments
--------
I fixed this in all the places I could find that use this multiselect pattern in our AngularJS code.