### PR TITLE
Updates SMS form to use api based widget to select phones rather than the hacky one-off ajax

### DIFF
--- a/CRM/Core/Form/Task.php
+++ b/CRM/Core/Form/Task.php
@@ -391,7 +391,10 @@ SELECT contact_id
    * @return array
    */
   protected function getContactIDs(): array {
-    return $this->_contactIds ?? [];
+    if (!isset($this->_contactIds)) {
+      $this->setContactIDs();
+    }
+    return $this->_contactIds;
   }
 
 }

--- a/CRM/Core/xml/Menu/Contact.xml
+++ b/CRM/Core/xml/Menu/Contact.xml
@@ -255,11 +255,6 @@
      <access_callback>1</access_callback>
 </item>
 <item>
-     <path>civicrm/ajax/checkphone</path>
-     <page_callback>CRM_Contact_Page_AJAX::getContactPhone</page_callback>
-     <access_callback>1</access_callback>
-</item>
-<item>
      <path>civicrm/ajax/subtype</path>
      <page_callback>CRM_Contact_Page_AJAX::buildSubTypes</page_callback>
      <access_arguments>access CiviCRM</access_arguments>

--- a/templates/CRM/Contact/Form/Task/SMS.tpl
+++ b/templates/CRM/Contact/Form/Task/SMS.tpl
@@ -30,7 +30,7 @@
        <td>{$form.sms_provider_id.html} {help id ="id-provider" file="CRM/Contact/Form/Task/SMS.hlp"}</td>
     </tr>
     <tr class="crm-contactsms-form-block-recipient">
-       <td class="label">{if $single eq false}{ts}Recipient(s){/ts}{else}{$form.to.label}{/if}</td>
+       <td class="label">{$form.to.label}</td>
        <td>{$form.to.html}
     <div class="spacer"></div>
       </td>
@@ -69,31 +69,3 @@
 {/if}
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>
-<script type="text/javascript">
-
-{if $toContact}
-    toContact  = {$toContact};
-{/if}
-
-{literal}
-CRM.$(function($){
-  var sourceDataUrl = "{/literal}{crmURL p='civicrm/ajax/checkphone' h=0}{literal}";
-  function phoneSelect(el){
-    $(el).data('api-entity', 'contact').crmSelect2({
-      minimumInputLength: 1,
-      multiple: true,
-      ajax: {
-        url: sourceDataUrl,
-        data: function(term) {
-          return { name: term, id: 1};
-        },
-        results: function(response) {
-          return { results: response };
-        }
-      }
-    }).select2('data', toContact);
-  }
-  phoneSelect('#to');
-});
-</script>
-{/literal}

--- a/tests/phpunit/CRM/Contact/Form/Task/SMSCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/SMSCommonTest.php
@@ -31,69 +31,63 @@ class CRM_Contact_Form_Task_SMSCommonTest extends CiviUnitTestCase {
       'first_name' => 'First',
       'last_name' => 'Person',
       'do_not_sms' => 0,
-      'phone' => [
-        1 => [
-          'phone_type_id' => $mobile_type_id,
-          'location_type_id' => 1,
-          'phone' => '1111111111',
-        ],
-      ],
+    ], 'first');
+    $this->createTestEntity('Phone', [
+      'phone_type_id' => $mobile_type_id,
+      'location_type_id' => 1,
+      'phone' => '1111111111',
+      'contact_id' => $this->ids['Contact']['first'],
     ], 'first');
     $this->individualCreate([
       'first_name' => 'Second',
       'last_name' => 'Person',
       'do_not_sms' => 0,
-      'phone' => [
-        1 => [
-          'phone_type_id' => $phone_type_id,
-          'location_type_id' => 1,
-          'phone' => '9999999999',
-          'is_primary' => 1,
-        ],
-        2 => [
-          'phone_type_id' => $mobile_type_id,
-          'location_type_id' => 1,
-          'phone' => '2222222222',
-        ],
-      ],
+    ], 'second');
+    $this->createTestEntity('Phone', [
+      'phone_type_id' => $phone_type_id,
+      'location_type_id' => 1,
+      'phone' => '9999999999',
+      'contact_id' => $this->ids['Contact']['second'],
+    ], 'second_phone');
+    $this->createTestEntity('Phone', [
+      'phone_type_id' => $mobile_type_id,
+      'location_type_id' => 1,
+      'phone' => '2222222222',
+      'contact_id' => $this->ids['Contact']['second'],
     ], 'second');
     $this->individualCreate([
       'first_name' => 'Third',
       'last_name' => 'Person',
       'do_not_sms' => 0,
-      'phone' => [
-        1 => [
-          'phone_type_id' => $mobile_type_id,
-          'location_type_id' => 1,
-          'phone' => '3333333333',
-          'is_primary' => 0,
-        ],
-      ],
+    ], 'third');
+    $this->createTestEntity('Phone', [
+      'phone_type_id' => $mobile_type_id,
+      'location_type_id' => 1,
+      'phone' => '3333333333',
+      'contact_id' => $this->ids['Contact']['third'],
     ], 'third');
     $this->individualCreate([
       'first_name' => 'Fourth',
       'last_name' => 'Person',
       'do_not_sms' => 1,
-      'phone' => [
-        1 => [
-          'phone_type_id' => $mobile_type_id,
-          'location_type_id' => 1,
-          'phone' => '4444444444',
-        ],
-      ],
+    ], 'fourth');
+    $this->createTestEntity('Phone', [
+      'phone_type_id' => $mobile_type_id,
+      'location_type_id' => 1,
+      'phone' => '4444444444',
+      'contact_id' => $this->ids['Contact']['fourth'],
     ], 'fourth');
     $this->individualCreate([
       'first_name' => 'Fifth',
       'last_name' => 'Person',
       'do_not_sms' => 0,
       'is_deceased' => 1,
-      'phone' => [
-        1 => [
-          'phone_type_id' => $mobile_type_id,
-          'location_type_id' => 1,
-          'phone' => '5555555555',
-        ],
-      ],
+    ], 'fifth');
+    $this->createTestEntity('Phone', [
+      'phone_type_id' => $mobile_type_id,
+      'location_type_id' => 1,
+      'phone' => '5555555555',
+      'contact_id' => $this->ids['Contact']['fifth'],
     ], 'fifth');
   }
 
@@ -109,55 +103,24 @@ class CRM_Contact_Form_Task_SMSCommonTest extends CiviUnitTestCase {
     $form = $this->getTestForm('CRM_Contact_Form_Search_Basic', [
       'radio_ts' => 'ts_all',
       'to' => implode(',', [
-        $this->ids['Contact']['first'] . '::' . 1111111111,
-        $this->ids['Contact']['second'] . '::' . 2222222222,
-        $this->ids['Contact']['third'] . '::' . 3333333333,
+        $this->ids['Phone']['first'],
+        $this->ids['Phone']['second'],
+        $this->ids['Phone']['third'],
       ]),
     ], ['action' => 1])
       ->addSubsequentForm('CRM_Contact_Form_Task_SMS', [
         'sms_provider_id' => 1,
         'to' => implode(',', [
-          $this->ids['Contact']['first'] . '::' . 1111111111,
-          $this->ids['Contact']['second'] . '::' . 2222222222,
-          $this->ids['Contact']['third'] . '::' . 3333333333,
+          $this->ids['Phone']['first'],
+          $this->ids['Phone']['second'],
+          $this->ids['Phone']['third'],
         ]),
         'activity_subject' => 'Your SMS Reminder',
         'sms_text_message' => 'Do not forget',
       ]);
     $form->processForm();
-    $contacts = json_decode($form->getTemplateVariable('toContact'));
-    $smsRecipientsActual = [];
-
-    $phoneNumbers = [
-      $this->ids['Contact']['first'] => 1111111111,
-      $this->ids['Contact']['second'] => 2222222222,
-      $this->ids['Contact']['third'] => 3333333333,
-    ];
-
-    foreach ($contacts as $contact) {
-      $id = $contact->id;
-      $ret = preg_match('/^([0-9]+)::([0-9]+)/', $id, $matches);
-      // id is in the format: contact_id::phone_number, e.g.: 5::2222222222
-      $this->assertEquals(1, $ret, 'Failed to extract the mobile number and contact id.');
-      $contact_id = $matches[1];
-      $phone_number = $matches[2];
-      // Check if we are supposed to send an SMS to this contact.
-      if (array_key_exists($contact_id, $phoneNumbers)) {
-        // We are supposed to send an SMS to this contact, now make sure we have the right phone number.
-        $this->assertEquals($phone_number, $phoneNumbers[$contact_id], "Returned incorrect mobile number in SMS send quick form.");
-        $smsRecipientsActual[] = $contact_id;
-      }
-      else {
-        // We are not supposed to send this contact an email.
-        $this->fail("We should not be sending an SMS to contact_id: $contact_id.");
-      }
-    }
-
-    // Make sure we sent to all the contacts.
-    sort($smsRecipientsActual);
-    $smsRecipientsIntended = array_keys($phoneNumbers);
-    sort($smsRecipientsIntended);
-    $this->assertEquals($smsRecipientsIntended, $smsRecipientsActual, 'We did not send an SMS to all the contacts.');
+    $activities = $this->callAPISuccess('Activity', 'get', ['sequential' => 1])['values'];
+    $this->assertEquals('Your SMS Reminder', $activities[0]['subject']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

Updates SMS form to use api based widget to select phones rather than the hacky one-off ajax

Before
----------------------------------------
Crazy code, non 8.2 compliant, uses one off widget. Validation is dubious

After
----------------------------------------
Uses @colemanw's new autocomplete method

![image](https://github.com/civicrm/civicrm-core/assets/336308/f96c9971-2719-4b0c-9d8d-db611f52a5d0)

![image](https://github.com/civicrm/civicrm-core/assets/336308/00faa25b-d29d-4535-a278-24f1c4cfc04e)

sends to the 18 + my extra selected one
![image](https://github.com/civicrm/civicrm-core/assets/336308/5d64b70d-5e78-4bed-a60a-78f649a4a020)


Technical Details
----------------------------------------
Note that this needs to be tested under admin not demo if you want to avoid having to set permissions & generally best done with https://github.com/mattwire/io.3sd.dummysms

Comments
----------------------------------------