### PR TITLE
[php8.2] Apply custom data handling improvements to grant form

### DIFF
--- a/ext/civigrant/CRM/Grant/Form/Grant.php
+++ b/ext/civigrant/CRM/Grant/Form/Grant.php
@@ -14,13 +14,14 @@
  *
  */
 class CRM_Grant_Form_Grant extends CRM_Core_Form {
+  use CRM_Custom_Form_CustomDataTrait;
 
   /**
    * The id of the grant when ACTION is update or delete.
    *
-   * @var int
+   * @var int|null
    */
-  protected $_id;
+  protected ?int $_id;
 
   /**
    * The id of the contact associated with this contribution.
@@ -45,9 +46,8 @@ class CRM_Grant_Form_Grant extends CRM_Core_Form {
    */
   public function preProcess() {
 
-    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
     $this->_grantType = NULL;
-    if ($this->_id) {
+    if ($this->getGrantID()) {
       $this->_grantType = CRM_Core_DAO::getFieldValue('CRM_Grant_DAO_Grant', $this->_id, 'grant_type_id');
       $this->_contactID = CRM_Core_DAO::getFieldValue('CRM_Grant_DAO_Grant', $this->_id, 'contact_id');
     }
@@ -80,16 +80,29 @@ class CRM_Grant_Form_Grant extends CRM_Core_Form {
       }
     }
 
-    // when custom data is included in this page
-    if (!empty($_POST['hidden_custom'])) {
-      $grantTypeId = empty($_POST['grant_type_id']) ? NULL : $_POST['grant_type_id'];
-      $this->set('type', 'Grant');
-      $this->set('subType', $grantTypeId);
-      $this->set('entityId', $this->_id);
-      CRM_Custom_Form_CustomData::preProcess($this, NULL, $grantTypeId, 1, 'Grant', $this->_id);
-      CRM_Custom_Form_CustomData::buildQuickForm($this);
-      CRM_Custom_Form_CustomData::setDefaultValues($this);
+    if ($this->isSubmitted()) {
+      // The custom data fields are added to the form by an ajax form.
+      // However, if they are not present in the element index they will
+      // not be available from `$this->getSubmittedValue()` in post process.
+      // We do not have to set defaults or otherwise render - just add to the element index.
+      $this->addCustomDataFieldsToForm('Grant', array_filter([
+        'id' => $this->getGrantID(),
+        'grant_type_id' => $this->getSubmittedValue('grant_type_id'),
+      ]));
     }
+  }
+
+  /**
+   * @api supported for external use.
+   *
+   * @return int|null
+   * @throws \CRM_Core_Exception
+   */
+  public function getGrantID(): ?int {
+    if (!isset($this->_id)) {
+      $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    }
+    return $this->_id;
   }
 
   /**
@@ -156,8 +169,7 @@ class CRM_Grant_Form_Grant extends CRM_Core_Form {
     $attributes = CRM_Core_DAO::getAttribute('CRM_Grant_DAO_Grant');
     $this->addSelect('grant_type_id', ['placeholder' => ts('- select type -'), 'onChange' => "CRM.buildCustomData( 'Grant', this.value );"], TRUE);
 
-    //need to assign custom data type and subtype to the template
-    $this->assign('customDataType', 'Grant');
+    //need to assign custom data subtype to the template
     $this->assign('customDataSubType', $this->_grantType);
     $this->assign('entityID', $this->_id);
 
@@ -243,7 +255,7 @@ class CRM_Grant_Form_Grant extends CRM_Core_Form {
     $params['contact_id'] = $this->_contactID;
 
     // build custom data array
-    $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
+    $params['custom'] = CRM_Core_BAO_CustomField::postProcess($this->getSubmittedValues(),
       $this->_id,
       'Grant'
     );

--- a/ext/civigrant/templates/CRM/Grant/Form/Grant.tpl
+++ b/ext/civigrant/templates/CRM/Grant/Form/Grant.tpl
@@ -75,7 +75,7 @@
       </tr>
   </table>
 
-  {include file="CRM/common/customDataBlock.tpl"}
+  {include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='Grant' cid=false}
 
   <div class="crm-grant-form-block-attachment">
     {include file="CRM/Form/attachment.tpl"}


### PR DESCRIPTION
Overview
----------------------------------------
[php8.2] Apply custom data handling improvements to grant form

This removes a smarty notice, reduces php8.2 undefined proprty issues and fixes a problem with validation of numbers with thousand separators and is in line with similar fixes to the participant form & group form & membership & open fixes for MemberRenewal, Pledge & FinancialAccount forms

Before
----------------------------------------
Smarty notice, more php8.x issues, issues handling numbers over 1000 (if there is a thousand separator in play)

After
----------------------------------------
above brought into line with other forms

Technical Details
----------------------------------------
Note that for testing installing https://github.com/eileenmcnaughton/testdata creates a swag of custom fields & greatly reduces the time to set up for testing

This is the same change as some closed PRs for participant form & membership form & manage event form & also

https://github.com/civicrm/civicrm-core/pull/29228
https://github.com/civicrm/civicrm-core/pull/29241
https://github.com/civicrm/civicrm-core/pull/29592
https://github.com/civicrm/civicrm-core/pull/29652
https://github.com/civicrm/civicrm-core/pull/29655
https://github.com/civicrm/civicrm-core/pull/29657
https://github.com/civicrm/civicrm-core/pull/29651

Comments
----------------------------------------
