### PR TITLE
[Php8.2] Fix relationship form to use preferred php8.2 compliant methods

### DIFF
--- a/templates/CRM/Contact/Form/Relationship.tpl
+++ b/templates/CRM/Contact/Form/Relationship.tpl
@@ -62,7 +62,7 @@
   {/if}
   {if ($action EQ 1) OR ($action EQ 2)}
     {*include custom data js file *}
-    {include file="CRM/common/customData.tpl"}
+    {include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='Relationship' cid=false}
     <script type="text/javascript">
       {literal}
       CRM.$(function($) {


### PR DESCRIPTION
Overview
----------------------------------------
[php8.2] Apply custom data handling improvements to grant form

This removes a smarty notice, reduces php8.2 undefined proprty issues and fixes a problem with validation of numbers with thousand separators and is in line with similar fixes to the participant form & group form & membership & open fixes for MemberRenewal, Pledge & FinancialAccount forms

Before
----------------------------------------
Php8.x issues

After
----------------------------------------
above brought into line with other forms

Technical Details
----------------------------------------
Note that for testing installing https://github.com/eileenmcnaughton/testdata creates a swag of custom fields & greatly reduces the time to set up for testing

This is the same change as some closed PRs for participant form & membership form & manage event form & also

https://github.com/civicrm/civicrm-core/pull/29228
https://github.com/civicrm/civicrm-core/pull/29241
https://github.com/civicrm/civicrm-core/pull/29592
https://github.com/civicrm/civicrm-core/pull/29652
https://github.com/civicrm/civicrm-core/pull/29655
https://github.com/civicrm/civicrm-core/pull/29657
https://github.com/civicrm/civicrm-core/pull/29651

Comments
----------------------------------------
