### PR TITLE
dev/core#5071 Use first pricefield ID when inferring membership type

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -267,7 +267,6 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
             elseif (!empty($priceFieldOption['is_default']) && (!isset($this->_defaults[$priceFieldName]) ||
               ($val['html_type'] === 'CheckBox' && !isset($this->_defaults[$priceFieldName][$keys])))) {
               CRM_Price_BAO_PriceSet::setDefaultPriceSetField($priceFieldName, $keys, $val['html_type'], $this->_defaults);
-              $memtypeID = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $this->_defaults[$priceFieldName], 'membership_type_id');
             }
           }
         }


### PR DESCRIPTION
 Use first pricefield ID when inferring membership type ID from checkboxes

Overview
----------------------------------------
Prevents a crash on Contribution pages for membership sign up when you try to add a checkboxes price fields and assign a default that doesn't link to a membership type
See [dev/core#5071](https://lab.civicrm.org/dev/core/-/issues/5071)

Before
----------------------------------------
TypeError fatal when loading contribution pages as described, as it's trying to use an array to as an ID.

After
----------------------------------------
Uses the first key of the array as the relevant ID to load a membership type from the database

Comments
----------------------------------------
This code actually feels like a redundant way to confirm that the PriceFieldValue doesn't link to a membership type ID anyway, so a better solution might be to just remove the line causing the crash entirely.
