### PR TITLE
Specify rounding mode when rendering Monetary entity tokens

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -17,6 +17,7 @@ use Civi\Token\TokenRow;
 use Civi\ActionSchedule\Event\MailingQueryEvent;
 use Civi\Token\TokenProcessor;
 use Brick\Money\Money;
+use Brick\Math\RoundingMode;
 
 /**
  * Class CRM_Core_EntityTokens
@@ -126,7 +127,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
       }
 
       return $row->format('text/plain')->tokens($entity, $field,
-        Money::of($fieldValue, $currency));
+        Money::of($fieldValue, $currency, NULL, RoundingMode::HALF_UP));
 
     }
     if ($this->isDateField($field)) {


### PR DESCRIPTION
Specify rounding mode when rendering Monetary entity tokens, avoids RoundingModeException

Overview
----------------------------------------
Found when investigating why Schedule Reminders would not send.
Rendering Monetary tokens was failing due to no rounding mode being set.

Before
----------------------------------------
Formatting Money amounts is attempted in token rendering without rounding mode specified.  If rounding is required, Brick will instead throw an exception, because it needs to be told how to round.

The conditions under which this is required are not especially clear, however it's probably a result of implementing Tax.

After
----------------------------------------
Specifies a rounding mode when rendering monetary amounts for tokens.  Does not throw an exception when it needs to round.

Technical Details
----------------------------------------
One line change... I also reviewed other places where `Brick\Money\Money::of` is in use and found most other places are already specifying HALF_UP as the rounding mode, which makes sense.

