### PR TITLE
[php8.2] apply php8.2 clean up to contribution form custom data

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -358,22 +358,6 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
   }
 
   /**
-   * @param string $type
-   *   Eg 'Contribution'.
-   * @param string $subType
-   * @param int $entityId
-   */
-  public function applyCustomData($type, $subType, $entityId) {
-    $this->set('type', $type);
-    $this->set('subType', $subType);
-    $this->set('entityId', $entityId);
-
-    CRM_Custom_Form_CustomData::preProcess($this, NULL, $subType, 1, $type, $entityId);
-    CRM_Custom_Form_CustomData::buildQuickForm($this);
-    CRM_Custom_Form_CustomData::setDefaultValues($this);
-  }
-
-  /**
    * @return array
    *   Array of valid processors. The array resembles the DB table but also has 'object' as a key
    * @throws Exception

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -20,6 +20,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
   use CRM_Contact_Form_ContactFormTrait;
   use CRM_Contribute_Form_ContributeFormTrait;
   use CRM_Financial_Form_PaymentProcessorFormTrait;
+  use CRM_Custom_Form_CustomDataTrait;
 
   /**
    * The id of the contribution that we are processing.
@@ -302,9 +303,15 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     }
     $this->assign('is_template', $this->_values['is_template']);
 
-    // when custom data is included in this page
-    if (!empty($_POST['hidden_custom'])) {
-      $this->applyCustomData('Contribution', $this->getFinancialTypeID(), $this->_id);
+    if ($this->isSubmitted()) {
+      // The custom data fields are added to the form by an ajax form.
+      // However, if they are not present in the element index they will
+      // not be available from `$this->getSubmittedValue()` in post process.
+      // We do not have to set defaults or otherwise render - just add to the element index.
+      $this->addCustomDataFieldsToForm('Contribution', array_filter([
+        'id' => $this->getContributionID(),
+        'financial_type_id' => $this->getFinancialTypeID(),
+      ]));
     }
 
     $this->_lineItems = [];
@@ -687,8 +694,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     $this->applyFilter('__ALL__', 'trim');
 
-    //need to assign custom data type and subtype to the template
-    $this->assign('customDataType', 'Contribution');
+    //need to assign custom data subtype to the template for initial custom data load
     $this->assign('customDataSubType', $this->getFinancialTypeID());
     $this->assign('entityID', $this->getContributionID());
     $this->assign('email', $this->getContactValue('email_primary.email'));

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -316,9 +316,8 @@
     <!-- end of PCP -->
 
     {if !$payNow}
-      {include file="CRM/common/customDataBlock.tpl" cid=$contactId}
+      {include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='Contribution' cid=$contactId}
     {/if}
-
     {literal}
       <script type="text/javascript">
         CRM.$(function($) {


### PR DESCRIPTION
Overview
----------------------------------------
[php8.2] Apply custom data handling improvements to grant form

This removes a smarty notice, reduces php8.2 undefined proprty issues and fixes a problem with validation of numbers with thousand separators and is in line with similar fixes to the participant form & group form & membership & open fixes for MemberRenewal, Pledge & FinancialAccount forms

Before
----------------------------------------
Php8.x issues

After
----------------------------------------
above brought into line with other forms

Technical Details
----------------------------------------
Note that for testing installing https://github.com/eileenmcnaughton/testdata creates a swag of custom fields & greatly reduces the time to set up for testing

This is the same change as some closed PRs for participant form & membership form & manage event form & also

https://github.com/civicrm/civicrm-core/pull/29228
https://github.com/civicrm/civicrm-core/pull/29241
https://github.com/civicrm/civicrm-core/pull/29592
https://github.com/civicrm/civicrm-core/pull/29652
https://github.com/civicrm/civicrm-core/pull/29655
https://github.com/civicrm/civicrm-core/pull/29657
https://github.com/civicrm/civicrm-core/pull/29651

Comments
----------------------------------------
