### PR TITLE
  [php8.2] apply php8.2 clean up to activity form custom data

### DIFF
--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -173,7 +173,7 @@
       {if $action eq 4}
         {include file="CRM/Custom/Page/CustomDataView.tpl"}
       {else}
-        {include file="CRM/common/customDataBlock.tpl"}
+        {include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='Activity'}
       {/if}
     </td>
   </tr>

--- a/templates/CRM/Case/Form/Activity.tpl
+++ b/templates/CRM/Case/Form/Activity.tpl
@@ -139,7 +139,7 @@
               </tr>
               {/if}
               <tr>
-                <td colspan="2">{include file="CRM/common/customDataBlock.tpl"}</td>
+                <td colspan="2">{include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='Activity'}</td>
               </tr>
               {if NOT $activityTypeFile}
                 <tr class="crm-case-activity-form-block-details">

--- a/templates/CRM/Case/Form/Case.tpl
+++ b/templates/CRM/Case/Form/Case.tpl
@@ -97,7 +97,7 @@
 {* This shows CASE custom fields, as opposed to ACTIVITY custom fields, so is not a duplicate of the other custom data block above. *}
 <tr class="crm-case-form-block-custom_data">
     <td colspan="2">
-      {include file="CRM/common/customDataBlock.tpl"}
+      {include file="CRM/common/customDataBlock.tpl" customDataType='Case'}
     </td>
 </tr>
 


### PR DESCRIPTION
Overview
----------------------------------------
[php8.2] Apply custom data handling improvements to grant form

This removes a smarty notice, reduces php8.2 undefined proprty issues and fixes a problem with validation of numbers with thousand separators and is in line with similar fixes to the participant form & group form & membership & open fixes for MemberRenewal, Pledge & FinancialAccount forms

Before
----------------------------------------
Php8.x issues

After
----------------------------------------
above brought into line with other forms

Technical Details
----------------------------------------
Note that for testing installing https://github.com/eileenmcnaughton/testdata creates a swag of custom fields & greatly reduces the time to set up for testing

This is the same change as some closed PRs for participant form & membership form & manage event form & also

https://github.com/civicrm/civicrm-core/pull/29228
https://github.com/civicrm/civicrm-core/pull/29241
https://github.com/civicrm/civicrm-core/pull/29592
https://github.com/civicrm/civicrm-core/pull/29652
https://github.com/civicrm/civicrm-core/pull/29655
https://github.com/civicrm/civicrm-core/pull/29657
https://github.com/civicrm/civicrm-core/pull/29651

Comments
----------------------------------------
