### PR TITLE
[php8.2] Fix Campaign form custom data for php8,2

### DIFF
--- a/templates/CRM/Campaign/Form/Campaign.tpl
+++ b/templates/CRM/Campaign/Form/Campaign.tpl
@@ -69,7 +69,7 @@
   </tr>
   </table>
 
-  {include file="CRM/common/customDataBlock.tpl" cid=false}
+  {include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='Campaign' cid=false}
 
 {/if}
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>


### PR DESCRIPTION
Overview
----------------------------------------
[php8.2] Apply custom data handling improvements to campaign form

This removes a smarty notice, reduces php8.2 undefined property issues and fixes a problem with validation of numbers with thousand separators and is in line with similar fixes to the participant form & group form & membership & open fixes for MemberRenewal, Pledge & FinancialAccount forms

Before
----------------------------------------
Php8.x issues

After
----------------------------------------
above brought into line with other forms

Technical Details
----------------------------------------
Note that for testing installing https://github.com/eileenmcnaughton/testdata creates a swag of custom fields & greatly reduces the time to set up for testing

This is the same change as some closed PRs for participant form & membership form & manage event form & also

https://github.com/civicrm/civicrm-core/pull/29228
https://github.com/civicrm/civicrm-core/pull/29241
https://github.com/civicrm/civicrm-core/pull/29592
https://github.com/civicrm/civicrm-core/pull/29652
https://github.com/civicrm/civicrm-core/pull/29655
https://github.com/civicrm/civicrm-core/pull/29657
https://github.com/civicrm/civicrm-core/pull/29651

Comments
----------------------------------------
