### PR TITLE
[Survey] 5.71 regression - survey forms missing type hints

### DIFF
--- a/CRM/Campaign/Form/Survey/Main.php
+++ b/CRM/Campaign/Form/Survey/Main.php
@@ -98,7 +98,7 @@ class CRM_Campaign_Form_Survey_Main extends CRM_Campaign_Form_Survey {
   /**
    * Build the form object.
    */
-  public function buildQuickForm() {
+  public function buildQuickForm(): void {
     $this->add('text', 'title', ts('Title'), CRM_Core_DAO::getAttribute('CRM_Campaign_DAO_Survey', 'title'), TRUE);
 
     // Activity Type id

--- a/CRM/Campaign/Form/Survey/Questions.php
+++ b/CRM/Campaign/Form/Survey/Questions.php
@@ -47,7 +47,7 @@ class CRM_Campaign_Form_Survey_Questions extends CRM_Campaign_Form_Survey {
   /**
    * Build the form object.
    */
-  public function buildQuickForm() {
+  public function buildQuickForm(): void {
     $subTypeId = CRM_Core_DAO::getFieldValue('CRM_Campaign_DAO_Survey', $this->_surveyId, 'activity_type_id');
     if (!self::autoCreateCustomGroup($subTypeId)) {
       // everything

--- a/CRM/Campaign/Form/Survey/Results.php
+++ b/CRM/Campaign/Form/Survey/Results.php
@@ -83,7 +83,7 @@ class CRM_Campaign_Form_Survey_Results extends CRM_Campaign_Form_Survey {
   /**
    * Build the form object.
    */
-  public function buildQuickForm() {
+  public function buildQuickForm(): void {
     $optionGroups = CRM_Campaign_BAO_Survey::getResultSets();
 
     if (empty($optionGroups)) {


### PR DESCRIPTION
In 5.71 a type hint was added here
https://github.com/civicrm/civicrm-core/commit/7479e9a4ae0c74faef53ac91b12fc43799db325a#diff-7e9517680f0eb471c450e432cc4e871269e4a95604c847c9a4a861cee9944621R211 but it turns out these forms extend the form with the added hint

![image](https://github.com/civicrm/civicrm-core/assets/336308/0e1e38eb-eb74-48f9-94ac-f45a40b50916)

