### PR TITLE
[php8.2] Fix Survey configuration forms for  custom data for php8.2

### DIFF
--- a/CRM/Campaign/Form/Survey.php
+++ b/CRM/Campaign/Form/Survey.php
@@ -19,11 +19,14 @@
  * This class generates form components for processing a survey.
  */
 class CRM_Campaign_Form_Survey extends CRM_Core_Form {
+  use CRM_Custom_Form_CustomDataTrait;
 
   /**
    * The id of the object being edited.
    *
    * @var int
+   *
+   * @internal
    */
   protected $_surveyId;
 
@@ -51,12 +54,17 @@ class CRM_Campaign_Form_Survey extends CRM_Core_Form {
   /**
    * Get the entity id being edited.
    *
+   * @internal
+   *
    * @return int|null
    */
   public function getEntityId() {
     return $this->_surveyId;
   }
 
+  /**
+   * @throws \CRM_Core_Exception
+   */
   public function preProcess() {
     // Multistep form doesn't play well with popups
     $this->preventAjaxSubmit();
@@ -66,9 +74,7 @@ class CRM_Campaign_Form_Survey extends CRM_Core_Form {
     }
 
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'add', 'REQUEST');
-    $this->_surveyId = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE);
-
-    if ($this->_surveyId) {
+    if ($this->getSurveyID()) {
       $this->_single = TRUE;
 
       $params = ['id' => $this->_surveyId];
@@ -79,10 +85,17 @@ class CRM_Campaign_Form_Survey extends CRM_Core_Form {
     }
 
     $this->assign('action', $this->_action);
-    $this->assign('surveyId', $this->_surveyId);
+    $this->assign('surveyId', $this->getSurveyID());
 
-    // Add custom data to form
-    CRM_Custom_Form_CustomData::addToForm($this);
+    if ($this->isSubmitted()) {
+      // The custom data fields are added to the form by an ajax form.
+      // However, if they are not present in the element index they will
+      // not be available from `$this->getSubmittedValue()` in post process.
+      // We do not have to set defaults or otherwise render - just add to the element index.
+      $this->addCustomDataFieldsToForm('Survey', array_filter([
+        'id' => $this->getSurveyID(),
+      ]));
+    }
 
     // CRM-11480, CRM-11682
     // Preload libraries required by the "Questions" tab
@@ -91,6 +104,21 @@ class CRM_Campaign_Form_Survey extends CRM_Core_Form {
     CRM_UF_Page_ProfileEditor::registerSchemas(['IndividualModel', 'ActivityModel']);
 
     $this->build();
+  }
+
+  /**
+   * Get the survey ID.
+   *
+   * @api supported for external use.
+   *
+   * @return int|null
+   * @throws \CRM_Core_Exception
+   */
+  public function getSurveyID(): ?int {
+    if (!isset($this->_surveyId)) {
+      $this->_surveyId = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    }
+    return $this->_surveyId;
   }
 
   /**
@@ -144,10 +172,11 @@ class CRM_Campaign_Form_Survey extends CRM_Core_Form {
   /**
    *
    * @return array
+   * @throws \CRM_Core_Exception
    */
   private function processSurveyForm() {
     $form = $this;
-    if ($form->getVar('_surveyId') <= 0) {
+    if ($this->getSurveyID() <= 0) {
       return NULL;
     }
 
@@ -175,8 +204,8 @@ class CRM_Campaign_Form_Survey extends CRM_Core_Form {
       ],
     ];
 
-    $surveyID = $form->getVar('_surveyId');
-    $class = $form->getVar('_name');
+    $surveyID = $this->getSurveyID();
+    $class = $this->_name;
     $class = CRM_Utils_String::getClassName($class);
     $class = strtolower($class);
 

--- a/CRM/Campaign/Form/Survey/Main.php
+++ b/CRM/Campaign/Form/Survey/Main.php
@@ -50,8 +50,15 @@ class CRM_Campaign_Form_Survey_Main extends CRM_Campaign_Form_Survey {
       $this->setTitle(ts('Configure Survey') . ' - ' . $this->_surveyTitle);
     }
 
-    // Add custom data to form
-    CRM_Custom_Form_CustomData::addToForm($this);
+    if ($this->isSubmitted()) {
+      // The custom data fields are added to the form by an ajax form.
+      // However, if they are not present in the element index they will
+      // not be available from `$this->getSubmittedValue()` in post process.
+      // We do not have to set defaults or otherwise render - just add to the element index.
+      $this->addCustomDataFieldsToForm('Survey', array_filter([
+        'id' => $this->getSurveyID(),
+      ]));
+    }
 
     if ($this->_name != 'Petition') {
       $url = CRM_Utils_System::url('civicrm/campaign', 'reset=1&subPage=survey');
@@ -158,7 +165,7 @@ class CRM_Campaign_Form_Survey_Main extends CRM_Campaign_Form_Survey {
     $params['is_active'] ??= 0;
     $params['is_default'] ??= 0;
 
-    $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params, $this->getEntityId(), $this->getDefaultEntity());
+    $params['custom'] = CRM_Core_BAO_CustomField::postProcess($this->getSubmittedValues(), $this->getSurveyID(), 'Survey');
 
     $survey = CRM_Campaign_BAO_Survey::create($params);
     $this->_surveyId = $survey->id;

--- a/templates/CRM/Campaign/Form/Petition.tpl
+++ b/templates/CRM/Campaign/Form/Petition.tpl
@@ -94,7 +94,7 @@
         </td>
       </tr>
     </table>
-    {include file="CRM/common/customDataBlock.tpl"}
+    {include file="CRM/common/customDataBlock.tpl"  groupID='' customDataType='Survey' customDataSubType=false entityID=$surveyId cid=false}
   {/if}
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>

--- a/templates/CRM/Campaign/Form/Survey/Main.tpl
+++ b/templates/CRM/Campaign/Form/Survey/Main.tpl
@@ -52,7 +52,7 @@
    </tr>
    <tr class="crm-campaign-form-block-custom_data">
        <td colspan="2">
-         {include file="CRM/common/customDataBlock.tpl"}
+         {include file="CRM/common/customDataBlock.tpl" groupID='' entityID=$surveyId customDataType='Survey' customDataSubType=false cid=false}
        </td>
    </tr>
   </table>


### PR DESCRIPTION
Overview
----------------------------------------
[php8.2] Apply custom data handling improvements to survey configuration forms

This removes a smarty notice, reduces php8.2 undefined proprty issues and fixes a problem with validation of numbers with thousand separators and is in line with similar fixes to the participant form & group form & membership & open fixes for MemberRenewal, Pledge & FinancialAccount forms

Before
----------------------------------------
Php8.x issues

After
----------------------------------------
above brought into line with other forms

Technical Details
----------------------------------------
Note that for testing installing https://github.com/eileenmcnaughton/testdata creates a swag of custom fields & greatly reduces the time to set up for testing

This is the same change as some closed PRs for participant form & membership form & manage event form & also

https://github.com/civicrm/civicrm-core/pull/29228
https://github.com/civicrm/civicrm-core/pull/29241
https://github.com/civicrm/civicrm-core/pull/29592
https://github.com/civicrm/civicrm-core/pull/29652
https://github.com/civicrm/civicrm-core/pull/29655
https://github.com/civicrm/civicrm-core/pull/29657
https://github.com/civicrm/civicrm-core/pull/29651

Comments
----------------------------------------
