### PR TITLE
Fix override on pending memberships

### DIFF
--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -254,9 +254,9 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
 
       if (!empty($defaults['is_override'])) {
         $defaults['is_override'] = CRM_Member_StatusOverrideTypes::PERMANENT;
-      }
-      if (!empty($defaults['status_override_end_date'])) {
-        $defaults['is_override'] = CRM_Member_StatusOverrideTypes::UNTIL_DATE;
+        if (!empty($defaults['status_override_end_date'])) {
+          $defaults['is_override'] = CRM_Member_StatusOverrideTypes::UNTIL_DATE;
+        }
       }
     }
 

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1219,6 +1219,7 @@ DESC limit 1");
         // If we are recording a contribution we *do* want to trigger a recalculation of membership status so it can go from Pending->New/Current
         // So here we check if status_id is empty, default (ie. status in database) is pending and that we are not recording a contribution -
         //   If all those are true then we skip the status calculation and explicitly set the pending status (to avoid a DB constraint status_id=0).
+        // Test cover in `CRM_Member_Form_MembershipTest::testOverrideSubmit()`.
         $isPaymentPending = FALSE;
         if ($this->getMembershipID()) {
           $contributionId = CRM_Member_BAO_Membership::getMembershipContributionId($this->getMembershipID());

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1219,10 +1219,22 @@ DESC limit 1");
         // If we are recording a contribution we *do* want to trigger a recalculation of membership status so it can go from Pending->New/Current
         // So here we check if status_id is empty, default (ie. status in database) is pending and that we are not recording a contribution -
         //   If all those are true then we skip the status calculation and explicitly set the pending status (to avoid a DB constraint status_id=0).
+        $isPaymentPending = FALSE;
+        if ($this->getMembershipID()) {
+          $contributionId = CRM_Member_BAO_Membership::getMembershipContributionId($this->getMembershipID());
+          if ($contributionId) {
+            $isPaymentPending = \Civi\Api4\Contribution::get(FALSE)
+              ->addSelect('contribution_status_id:name')
+              ->addWhere('id', '=', $contributionId)
+              ->execute()
+              ->first()['contribution_status_id:name'] === 'Pending';
+          }
+        }
         if (empty($membershipParams['status_id'])
           && !empty($this->_defaultValues['status_id'])
           && !$this->getSubmittedValue('record_contribution')
           && (int) $this->_defaultValues['status_id'] === $pendingMembershipStatusId
+          && $isPaymentPending
         ) {
           $membershipParams['status_id'] = $this->_defaultValues['status_id'];
         }

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1141,6 +1141,37 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test if membership is updated after override flag
+   * on pending membership is removed.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testOverrideSubmit(): void {
+    $pendingStatusId = CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Pending');
+    $params = $this->getBaseSubmitParams();
+    unset($params['auto_renew'], $params['is_recur']);
+    $params['is_override'] = 1;
+    $params['status_id'] = $pendingStatusId;
+
+    $form = $this->getForm($params);
+    $this->createLoggedInUser();
+    $form->_mode = FALSE;
+    $form->_contactID = $this->_individualId;
+    $form->testSubmit($params);
+    $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_individualId]);
+    $this->assertEquals(CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Pending'), $membership['status_id']);
+
+    // Disable "Override" and let the form save recalculate the status.
+    $form->_defaultValues['status_id'] = $pendingStatusId;
+    $params['is_override'] = 0;
+    unset($params['status_id']);
+    $form->testSubmit($params);
+    $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_individualId]);
+    // Membership should be updated to New.
+    $this->assertEquals(CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'New'), $membership['status_id']);
+  }
+
+  /**
    * Test the submit function of the membership form.
    *
    * @throws \CRM_Core_Exception


### PR DESCRIPTION
Overview
----------------------------------------
Fix status recalculation if override flag is removed from pending membership.

Before
----------------------------------------
If a pending membership is updated from Override Permanently to No override, the status remains the same.

To replicate:

- Contact summary page => Open `Add Membership` form.
- Select `Status Override?` = Override Permanently.
- Dont record any contribution.
- Save.

Ensure pending membership is created for the contact.

- Edit the membership created above.
-  Select `Status Override?` = No.
- Save the form.
- **Current Result** - Membership status remains Pending.
- **Expected Result** - Membership status should be recalculated and updated to New.

After
----------------------------------------
Membership status is updated to New if is_override flag is removed.

Technical Details
----------------------------------------
@mattwire This is a result of https://github.com/civicrm/civicrm-core/pull/25385, merged ~9 months ago so not sure if this can be tagged as regression.

I think the aim of that PR was to **not** recalculate the status if the related payment of the membership is pending? I've just added that explicitly to the list of conditions. Please let me know your usecase isn't affected.

Comments
----------------------------------------
Has test