### PR TITLE
Afform - typo when getting options from SavedSearch entity

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/GetOptions.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/GetOptions.php
@@ -71,7 +71,7 @@ class GetOptions extends AbstractProcessor {
         ->addSelect('api_entity', 'api_params')
         ->execute()->single();
       // If field is not prefixed with a join, it's from the main entity
-      $entity = $savedSearch['api__entity'];
+      $entity = $savedSearch['api_entity'];
       // Check to see if field belongs to a join
       foreach ($savedSearch['api_params']['join'] ?? [] as $join) {
         [$joinEntity, $joinAlias] = array_pad(explode(' AS ', $join[0]), 2, '');


### PR DESCRIPTION
Overview
----------------------------------------
Fix a typo that crashes chain select filters on saved searches.

Example form:

- Create a saved search of Cases

- Create a Search Afform and add filters for Case Type and Case Status. Make the Case Status a chain-select based on the Case Type (because Case Types can define available statuses)

```
<div af-fieldset="">
  <af-field name="case_type_id" defn="{input_attrs: {multiple: false}}" />
  <af-field name="status_id" defn="{input_type: 'ChainSelect', input_attrs: {multiple: true, control_field: 'case_type_id'}}" />

  <crm-search-display-table search-name="Case_Search_by_Standalone_Admin" display-name=""></crm-search-display-table>
</div>
```

- Open the form and select a Case Type.

Before
----------------------------------------
The Case Status selector crashes based on failed Afform/getOptions AJAX call for the Case Status

After
----------------------------------------
It crashes because the Case BAO can't handle being passed an array of possible case_type_id values, which is an improvement...

TODO
---------------------------------------
Add test
Find a non-case example where the chain select actually works!