### PR TITLE
php 8.2 fix ChangeCaseStartDate

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -70,6 +70,12 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
   public $_defaultCaseStatus;
 
   /**
+   * @var int
+   * Used by ChangeCaseStartDate. See getter/setter below.
+   */
+  private $openCaseActivityId;
+
+  /**
    * Build the form object.
    */
   public function preProcess() {
@@ -816,6 +822,24 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
       }
     }
     return $bounceMessage;
+  }
+
+  /**
+   * Getter used by ChangeCaseStartDate
+   * @return int|null
+   * @internal
+   */
+  public function getOpenCaseActivityId(): ?int {
+    return $this->openCaseActivityId;
+  }
+
+  /**
+   * Setter used by ChangeCaseStartDate
+   * @param int $id
+   * @internal
+   */
+  public function setOpenCaseActivityId(int $id): void {
+    $this->openCaseActivityId = $id;
   }
 
 }

--- a/CRM/Case/Form/Activity/ChangeCaseStartDate.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStartDate.php
@@ -58,7 +58,7 @@ class CRM_Case_Form_Activity_ChangeCaseStartDate {
       $openCaseInfo = current($openCaseInfo);
 
       // store activity id for updating it later
-      $form->openCaseActivityId = $openCaseInfo['id'];
+      $form->setOpenCaseActivityId($openCaseInfo['id']);
 
       $defaults['start_date'] = $openCaseInfo['activity_date'];
     }
@@ -164,10 +164,10 @@ class CRM_Case_Form_Activity_ChangeCaseStartDate {
 
     // 2.5 Update open case activity date
     // @todo Since revisioning code has been removed this can be refactored more
-    if ($form->openCaseActivityId) {
+    if ($form->getOpenCaseActivityId()) {
 
       $abao = new CRM_Activity_BAO_Activity();
-      $oldParams = ['id' => $form->openCaseActivityId];
+      $oldParams = ['id' => $form->getOpenCaseActivityId()];
       $oldActivityDefaults = [];
       $oldActivity = $abao->retrieve($oldParams, $oldActivityDefaults);
 


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
```
CRM_Case_Form_ChangeStartDateTest::testChangeCaseStartDate
Creation of dynamic property CRM_Case_Form_Activity::$openCaseActivityId is deprecated

/home/homer/buildkit/build/build-2/web/sites/all/modules/civicrm/CRM/Case/Form/Activity/ChangeCaseStartDate.php:61
/home/homer/buildkit/build/build-2/web/sites/all/modules/civicrm/CRM/Activity/Form/Activity.php:575
/home/homer/buildkit/build/build-2/web/sites/all/modules/civicrm/CRM/Case/Form/Activity.php:206
/home/homer/buildkit/build/build-2/web/sites/all/modules/civicrm/CRM/Core/Form.php:776
/home/homer/buildkit/build/build-2/web/sites/all/modules/civicrm/tests/phpunit/CRM/Case/Form/ChangeStartDateTest.php:41
/home/homer/buildkit/build/build-2/web/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:247
/home/homer/buildkit/extern/phpunit9/phpunit9.phar:2307
```

After
----------------------------------------
There is a separate problem coming from https://github.com/civicrm/civicrm-core/pull/29448 but will deal with in a different PR.

Technical Details
----------------------------------------


Comments
----------------------------------------
I checked universe and nothing uses this var so I think ok to make private and mark the getter/setter as internal.
