### PR TITLE
 dev/core#5029 somewhat fix save template on sms trait

### DIFF
--- a/CRM/Contact/Form/Task/SMSTrait.php
+++ b/CRM/Contact/Form/Task/SMSTrait.php
@@ -16,6 +16,7 @@
  */
 use Civi\Api4\Activity;
 use Civi\API\EntityLookupTrait;
+use Civi\Api4\MessageTemplate;
 use Civi\Api4\Phone;
 use Civi\Token\TokenProcessor;
 
@@ -229,21 +230,20 @@ trait CRM_Contact_Form_Task_SMSTrait {
     // process message template
     if (!empty($thisValues['SMSsaveTemplate']) || !empty($thisValues['SMSupdateTemplate'])) {
       $messageTemplate = [
-        'msg_text' => $thisValues['sms_text_message'],
+        'msg_text' => $this->getSubmittedValue('sms_text_message'),
         'is_active' => TRUE,
         'is_sms' => TRUE,
       ];
 
       if (!empty($thisValues['SMSsaveTemplate'])) {
-        $messageTemplate['msg_title'] = $thisValues['SMSsaveTemplateName'];
-        CRM_Core_BAO_MessageTemplate::add($messageTemplate);
+        $messageTemplate['msg_title'] = $this->getSubmittedValue('SMSsaveTemplateName');
       }
 
-      if (!empty($thisValues['SMStemplate']) && !empty($thisValues['SMSupdateTemplate'])) {
-        $messageTemplate['id'] = $thisValues['SMStemplate'];
+      if ($this->getSubmittedValue('SMStemplate') && $this->getSubmittedValue('SMSupdateTemplate')) {
+        $messageTemplate['id'] = $this->getSubmittedValue('SMStemplate');
         unset($messageTemplate['msg_title']);
-        CRM_Core_BAO_MessageTemplate::add($messageTemplate);
       }
+      MessageTemplate::save()->addRecord($messageTemplate)->execute();
     }
 
     $phonesToSendTo = explode(',', $this->getSubmittedValue('to'));

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2564,9 +2564,11 @@ LEFT JOIN civicrm_mailing_group g ON g.mailing_id   = m.id
           ['onChange' => "selectValue( this.value, '{$prefix}');", 'class' => 'crm-select2 huge']
         );
       }
-      $form->add('checkbox', "{$prefix}updateTemplate", ts('Update Template'), NULL);
-      $form->add('checkbox', "{$prefix}saveTemplate", ts('Save As New Template'), ['onclick' => "showSaveDetails(this, '{$prefix}');"]);
-      $form->add('text', "{$prefix}saveTemplateName", ts('Template Title'));
+      if (\CRM_Core_Permission::check('edit message templates')) {
+        $form->add('checkbox', "{$prefix}updateTemplate", ts('Update Template'), NULL);
+        $form->add('checkbox', "{$prefix}saveTemplate", ts('Save As New Template'), ['onclick' => "showSaveDetails(this, '{$prefix}');"]);
+        $form->add('text', "{$prefix}saveTemplateName", ts('Template Title'));
+      }
     }
 
     // I'm not sure this is ever called.

--- a/templates/CRM/Contact/Form/Task/EmailCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/EmailCommon.tpl
@@ -40,20 +40,21 @@
     </div>
   </div>
 </details>
-<div id="editMessageDetails" class="section">
-  {if call_user_func(array('CRM_Core_Permission','check'), 'edit message templates')}
-      <div id="updateDetails" class="section" >
-    {$form.updateTemplate.html}&nbsp;{$form.updateTemplate.label}
-      </div>
-      <div class="section">
-    {$form.saveTemplate.html}&nbsp;{$form.saveTemplate.label}
-      </div>
-  {/if}
+
+<div id="editMessageDetails">
+  <div id="updateDetails" >
+    {if array_key_exists('updateTemplate', $form)}{$form.updateTemplate.html}&nbsp;{$form.updateTemplate.label}{/if}
+  </div>
+  <div>
+    {if array_key_exists('saveTemplate', $form)}{$form.saveTemplate.html}&nbsp;{$form.saveTemplate.label}{/if}
+  </div>
 </div>
 
 <div id="saveDetails" class="section">
-   <div class="label">{$form.saveTemplateName.label}</div>
-   <div class="content">{$form.saveTemplateName.html|crmAddClass:huge}</div>
+  {if array_key_exists('saveTemplateName', $form)}
+    <div class="label">{$form.saveTemplateName.label}</div>
+    <div class="content">{$form.saveTemplateName.html|crmAddClass:huge}</div>
+  {/if}
 </div>
 
 {if !$noAttach}

--- a/templates/CRM/Mailing/Form/InsertTokens.tpl
+++ b/templates/CRM/Mailing/Form/InsertTokens.tpl
@@ -25,7 +25,13 @@ var isMailing    = false;
   text_message = "mailing_format";
   isMailing = false;
   {/literal}
-{elseif $form.formClass eq 'CRM_SMS_Form_Upload' || $form.formClass eq 'CRM_Contact_Form_Task_SMS'}
+{elseif $form.formClass eq 'CRM_Contact_Form_Task_SMS'}
+  {literal}
+    prefix = "SMS";
+    text_message = "sms_text_message";
+    isMailing = true;
+  {/literal}
+{elseif $form.formClass eq 'CRM_SMS_Form_Upload'}
   {literal}
   prefix = "SMS";
   text_message = "sms_text_message";
@@ -74,7 +80,8 @@ function showSaveUpdateChkBox(prefix) {
     document.getElementById(prefix + "saveDetails").style.display = "none";
     return;
   }
-  if (document.getElementById(prefix + "template") == null) {
+
+  if (cj('#' + prefix + "template").val() === '') {
     if (document.getElementsByName(prefix + "saveTemplate")[0].checked){
       document.getElementById(prefix + "saveDetails").style.display = "block";
       document.getElementById(prefix + "editMessageDetails").style.display = "block";
@@ -93,7 +100,7 @@ function showSaveUpdateChkBox(prefix) {
   else if ( document.getElementsByName(prefix + "saveTemplate")[0].checked &&
     document.getElementsByName(prefix + "updateTemplate")[0].checked ){
     document.getElementById(prefix + "editMessageDetails").style.display = "block";
-    document.getElementById(pefix + "saveDetails").style.display = "block";
+    document.getElementById(prefix + "saveDetails").style.display = "block";
   }
   else if ( document.getElementsByName(prefix + "saveTemplate")[0].checked == false &&
       document.getElementsByName(prefix + "updateTemplate")[0].checked ) {
@@ -102,31 +109,34 @@ function showSaveUpdateChkBox(prefix) {
   }
   else {
     document.getElementById(prefix + "saveDetails").style.display = "none";
-    document.getElementById(prefix + "updateDetails").style.display = "none";
+    if (cj('#' + prefix + "template").val() === '') {
+      document.getElementById(prefix + "updateDetails").style.display = "none";
+    }
+    else {
+      document.getElementById(prefix + "updateDetails").style.display = "block";
+    }
   }
 }
 
 function selectValue( val, prefix) {
+  console.log('here');
   if (manageTemplateFieldsExists(prefix)) {
     document.getElementsByName(prefix + "saveTemplate")[0].checked = false;
     document.getElementsByName(prefix + "updateTemplate")[0].checked = false;
     showSaveUpdateChkBox(prefix);
   }
   if ( !val ) {
-    if (document.getElementById("subject").length) {
-      document.getElementById("subject").value ="";
+    // The SMS form has activity_subject not subject which is not
+    // cleared by this as subject is not present. It's unclear if that
+    // is deliberate or not but this does not error if the field is not present.
+    cj('#subject').val('');
+    if (prefix === 'SMS') {
+      document.getElementById("sms_text_message").value ="";
+      return;
     }
-    if (document.getElementById("subject").length) {
-      document.getElementById("subject").value ="";
-    }
+
     if ( !isPDF ) {
-      if (prefix == 'SMS') {
-        document.getElementById("sms_text_message").value ="";
-        return;
-      }
-      else {
-        document.getElementById("text_message").value ="";
-      }
+      document.getElementById("text_message").value ="";
     }
     else {
       cj('.crm-html_email-accordion').show();

--- a/templates/CRM/Mailing/Form/InsertTokens.tpl
+++ b/templates/CRM/Mailing/Form/InsertTokens.tpl
@@ -119,7 +119,6 @@ function showSaveUpdateChkBox(prefix) {
 }
 
 function selectValue( val, prefix) {
-  console.log('here');
   if (manageTemplateFieldsExists(prefix)) {
     document.getElementsByName(prefix + "saveTemplate")[0].checked = false;
     document.getElementsByName(prefix + "updateTemplate")[0].checked = false;


### PR DESCRIPTION



Overview
----------------------------------------
This at least ensures it is possible to update the template & also fixes the notice & at least one js error

It still seems a little funky but I think it is closer to right & the gap is not on not doing enough hiding rather than not showing what is needed.

I also fixed the save to use the api & pulled in https://github.com/civicrm/civicrm-core/pull/29505 and https://github.com/civicrm/civicrm-core/pull/29578 because I allowed the permissions to be FALSE on save so wanted this protection.

Note I am targetting the just-cut 5.72 rc as the SMS form has been substantially re-written in 5.72 so my goal was to resolve the other known issues in 5.72 rather than spread changes to this form over more than one release


Before
----------------------------------------
- the update template box never shows 
- smarty notice
- js error when clearing the selected template (because the subject field does not exist)

After
----------------------------------------
Above fixed - still doesn't seem to hide the update box when it should - but that feels like the lesser evil

Technical Details
----------------------------------------
@demeritcowboy this is the issue you reported + a bit more. Note that the form has been re-written since you last looked - the "to" box now uses apiv4 ajax so keep you eye out for anything else odd


Comments
----------------------------------------
