### PR TITLE
missing literal

### DIFF
--- a/templates/CRM/Case/Form/Activity.tpl
+++ b/templates/CRM/Case/Form/Activity.tpl
@@ -268,10 +268,14 @@
   {if $action neq 8 and $action neq 32768 and empty($activityTypeFile)}
   <script type="text/javascript">
     {if $searchRows}
+      {literal}
       cj('#sendcopy').prop('open', function(i, val) {return !val;});
+      {/literal}
     {/if}
 
+    {literal}
     cj('#follow-up').prop('open', function(i, val) {return !val;});
+    {/literal}
   </script>
   {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
Missing literal tag causes invalid smarty.

Before
----------------------------------------
Creating any case activity gives `CRM\Case\Form\Activity.tpl line 271]: syntax error: unrecognized tag &#039;return&#039;`

After
----------------------------------------


Technical Details
----------------------------------------
In https://github.com/civicrm/civicrm-core/commit/a342352e1de92ff513a58e18146e80d7068f4100#diff-4b53b8fb3025c1aed49b1a0d2ff7c70664b20e6eead6000f8d03d1aa03406069 it added some squiggly brackets into some js code but without a `literal` tag around it.

Comments
----------------------------------------

