### PR TITLE
Remove unused variables

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -240,12 +240,11 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $this->_defaults["billing_state_province_id-{$this->_bltID}"] = $config->defaultContactStateProvince;
     }
 
-    $memtypeID = NULL;
     if ($this->_priceSetId) {
       if ($this->getFormContext() === 'membership') {
         $existingMembershipTypeID = $this->getRenewableMembershipValue('membership_type_id');
         $selectedCurrentMemTypes = [];
-        foreach ($this->_priceSet['fields'] as $key => $val) {
+        foreach ($this->_priceSet['fields'] as $val) {
           foreach ($val['options'] as $keys => $priceFieldOption) {
             $opMemTypeId = $priceFieldOption['membership_type_id'] ?? NULL;
             $priceFieldName = 'price_' . $priceFieldOption['price_field_id'];
@@ -262,12 +261,10 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
               && !in_array($opMemTypeId, $selectedCurrentMemTypes)
             ) {
               CRM_Price_BAO_PriceSet::setDefaultPriceSetField($priceFieldName, $keys, $val['html_type'], $this->_defaults);
-              $memtypeID = $selectedCurrentMemTypes[] = $priceFieldOption['membership_type_id'];
             }
             elseif (!empty($priceFieldOption['is_default']) && (!isset($this->_defaults[$priceFieldName]) ||
               ($val['html_type'] === 'CheckBox' && !isset($this->_defaults[$priceFieldName][$keys])))) {
               CRM_Price_BAO_PriceSet::setDefaultPriceSetField($priceFieldName, $keys, $val['html_type'], $this->_defaults);
-              $memtypeID = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $this->_defaults[$priceFieldName], 'membership_type_id');
             }
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused variables

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/55559f90-6bd2-4336-8e41-135560327509)


After
----------------------------------------
where did they go?

Technical Details
----------------------------------------
They are unused so they should go - also they might be causing a bug - see 
https://github.com/civicrm/civicrm-core/pull/29653

The variable was used until recently but this cleanup was missed

Comments
----------------------------------------
