### PR TITLE
[php8.2] Fix MembershipType + other entityFormTrait uses for php8.2

### DIFF
--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -15,6 +15,7 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 trait CRM_Core_Form_EntityFormTrait {
+  use CRM_Custom_Form_CustomDataTrait;
 
   /**
    * The id of the object being edited / created.
@@ -174,9 +175,24 @@ trait CRM_Core_Form_EntityFormTrait {
     }
      */
 
-    $customisableEntities = CRM_Core_SelectValues::customGroupExtends();
-    if (isset($customisableEntities[$this->getDefaultEntity()])) {
-      CRM_Custom_Form_CustomData::addToForm($this, $this->getEntitySubTypeId());
+    if ($this->isSubmitted()) {
+      $customisableEntities = CRM_Core_SelectValues::customGroupExtends();
+      if (isset($customisableEntities[$this->getDefaultEntity()])) {
+        if ($this->getEntitySubTypeId()) {
+          // Supporting entity subtypes form the EntityFormTrait is not
+          // used in core & is likely not used anywhere / was a good idea that
+          // didn't fully happen. If anyone is winding up here they should override
+          // the entire addCustomDataToForm function - e.g like the backoffice membership
+          // forms do
+          // @todo - add some noisy deprecation at some point.
+          CRM_Custom_Form_CustomData::addToForm($this, $this->getEntitySubTypeId());
+        }
+        else {
+          $this->addCustomDataFieldsToForm($this->getDefaultEntity(), array_filter([
+            'id' => $this->getEntityId(),
+          ]));
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
[php8.2] Fix MembershipType + other entityFormTrait uses for php8.2

Before
----------------------------------------
Membership Type form calls (indirectly) crufty old function that will cause php8.2 warnings

After
----------------------------------------
Uses new preferred function that doesn't mostly do stuff that has nothing to do with any of it's callers

Technical Details
----------------------------------------


Comments
----------------------------------------

