### PR TITLE
Fix Smarty noticed when contribution tab opened outside of ajax

### DIFF
--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -269,15 +269,12 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
   private function addRecurringContributionsBlock() {
     [$activeContributions, $activeContributionsCount] = $this->getActiveRecurringContributions();
     [$inactiveRecurringContributions, $inactiveContributionsCount] = $this->getInactiveRecurringContributions();
-
-    if (!empty($activeContributions) || !empty($inactiveRecurringContributions)) {
-      // assign vars to templates
-      $this->assign('action', $this->_action);
-      $this->assign('activeRecurRows', $activeContributions);
-      $this->assign('contributionRecurCount', $activeContributionsCount + $inactiveContributionsCount);
-      $this->assign('inactiveRecurRows', $inactiveRecurringContributions);
-      $this->assign('recur', TRUE);
-    }
+    // assign vars to templates
+    $this->assign('action', $this->_action);
+    $this->assign('activeRecurRows', $activeContributions);
+    $this->assign('contributionRecurCount', $activeContributionsCount + $inactiveContributionsCount);
+    $this->assign('inactiveRecurRows', $inactiveRecurringContributions);
+    $this->assign('recur', !empty($activeContributions) || !empty($inactiveRecurringContributions));
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Fix Smarty noticed when contribution tab opened outside of ajax & the contact has no recurring contributions

Before
----------------------------------------
More red

![image](https://github.com/civicrm/civicrm-core/assets/336308/8c97f8e6-f148-4503-9b3b-186241a200d3)

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/4a7fd872-6acb-4b23-8a6d-ab87674b626a)


Technical Details
----------------------------------------
This isn't all of them but is a bunch. Didn't seem to make the failure to load that caused me to look better or worse

Comments
----------------------------------------
