### PR TITLE
use read only session for checking standalone locale in boot

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -92,7 +92,7 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
           // since it is defined in an extension, and we need the session
           // initialized before calling applyLocale.
           $sess = \CRM_Core_Session::singleton();
-          $sess->initialize();
+          $sess->initialize(TRUE);
           if ($sess->getLoggedInContactID()) {
             // Apply user's timezone.
             if (is_callable([self::$_singleton->userSystem, 'setMySQLTimeZone'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Standalone is starting new sessions at this boot in config boot when it needn't/shouldn't.

It's just trying to check the locale timezone, so I think it should be fine to use the readOnly flag, which then avoids calling `sessionStart`.

This change stops a new session session being started in [these StatelessFlowsTests](https://test.civicrm.org/job/CiviCRM-E2E-Matrix/BKPROF=min,BLDTYPE=standalone-clean,CIVIVER=master,label=bknix-tmp/lastCompletedBuild/testReport/(root)/Civi_Authx_StatelessFlowsTest/testStatelessContactOnly_with_data_set__4/)  so we no longer get the Set-Cookie header, which seems an improvement. I'm hoping it might help with https://lab.civicrm.org/dev/core/-/issues/5069

~~The tests still fail - but I think this is a secondary issue with UF_Match missing from the test. ( It [fails this check here](https://github.com/civicrm/civicrm-core/blob/dcb2a73055bb0510ecfdd1a5d8336904d628f070/ext/authx/Civi/Authx/Authenticator.php#L266). I think this may be due to how the test boots. The `civicrm_uf_match` table seems to be empty at the point it fails. )~~
