### PR TITLE
Suppress last php8.2 test fail for PR tests

### DIFF
--- a/tests/phpunit/CRM/Contact/Form/IndividualTest.php
+++ b/tests/phpunit/CRM/Contact/Form/IndividualTest.php
@@ -14,6 +14,9 @@ class CRM_Contact_Form_IndividualTest extends CiviUnitTestCase {
    * notices or errors. For example to make it fail change the spelling of a
    * variable in the form so it has a typo, and then this test will throw an
    * exception.
+   *
+   * @group ornery
+   *   Suppress for PR tests while this does not pass pn php8.2.
    */
   public function testOpeningNewIndividualForm(): void {
     $_REQUEST['reset'] = 1;
@@ -38,6 +41,9 @@ class CRM_Contact_Form_IndividualTest extends CiviUnitTestCase {
    * This is the same as testOpeningNewIndividualForm but with a custom field
    * defined. It maybe doesn't need to be a separate test but might make it
    * easier to track down problems if one fails but not the other.
+   *
+   * @group ornery
+   *  Suppress for PR tests while this does not pass pn php8.2.
    */
   public function testOpeningNewIndividualFormWithCustomField(): void {
     $custom_group = $this->customGroupCreate([]);


### PR DESCRIPTION
This is as we discussed - ie get PR testing on php8.2 & suppress the one outstanding fail