### PR TITLE
Add missing alias trxn_id to transactionID

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -81,6 +81,7 @@ class PropertyBag implements \ArrayAccess {
     'recurProcessorID'            => TRUE,
     'transactionID'               => TRUE,
     'transaction_id'              => 'transactionID',
+    'trxn_id'                     => 'transactionID',
     'trxnResultCode'              => TRUE,
     'isNotifyProcessorOnCancelRecur' => TRUE,
   ];


### PR DESCRIPTION
Overview
----------------------------------------
We defined `transactionID` as the "standard" param for payment propertyBag but only mapped `transaction_id`. But `trxn_id` is more common and matches the internal field name used in the database. This allows it to automatically map and `$propertyBag->getTransactionID()` will work if the value was supplied via `trxn_id`.

Before
----------------------------------------
Missing alias `trxn_id`

After
----------------------------------------
Mapped!

Technical Details
----------------------------------------


Comments
----------------------------------------
This is more likely to come up when implementing code for refunds since you usually need the original transaction ID (eg. see https://lab.civicrm.org/extensions/mjwshared/-/blob/master/CRM/Core/Payment/MJWTrait.php?ref_type=heads#L485) and (https://lab.civicrm.org/extensions/authnet/-/blob/master/CRM/Core/Payment/AuthorizeNetCommon.php?ref_type=heads#L309)
@artfulrobot 
