### PR TITLE
Follow up fix on setDefaultValues fix

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -434,7 +434,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     // set defaults for blocks ( custom data, address, communication preference, notes, tags and groups )
     foreach ($this->_editOptions as $name => $label) {
       if (!in_array($name, ['Address', 'Notes'])) {
-        $this->setBlockDefaults($name, $defaults);
+        $this->setBlockDefaults($defaults, $name);
       }
     }
 
@@ -1589,18 +1589,19 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
   }
 
   /**
-   * @param $name
-   * @param $defaults
+   * @param array $defaults
+   *
+   * @param string $name
    *
    * @return void
    */
-  private function setBlockDefaults($name, $defaults): void {
+  private function setBlockDefaults(array &$defaults, string $name): void {
     if ($name === 'TagsAndGroups') {
       CRM_Contact_Form_Edit_TagsAndGroups::setDefaultValues($this, $defaults);
       return;
     }
     if ($name === 'CustomData') {
-      CRM_Contact_Form_Edit_CustomData::setDefaultValues($this, $defaults);
+      CRM_Core_BAO_CustomGroup::setDefaults($this->_groupTree, $defaults, FALSE, FALSE, $this->getAction());
       return;
     }
     if ($name === 'CommunicationPreferences') {

--- a/CRM/Contact/Form/Edit/CustomData.php
+++ b/CRM/Contact/Form/Edit/CustomData.php
@@ -76,11 +76,13 @@ class CRM_Contact_Form_Edit_CustomData {
    * Set default values for the form. Note that in edit/view mode
    * the default values are retrieved from the database
    *
+   * @deprecated since 5.73 will be removed around 5.85
    *
    * @param CRM_Core_Form $form
    * @param array $defaults
    */
   public static function setDefaultValues(&$form, &$defaults) {
+    CRM_Core_Error::deprecatedFunctionWarning('take a copy?');
     $defaults += CRM_Custom_Form_CustomData::setDefaultValues($form);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This recent change missed making the defaults parameter a reference https://github.com/civicrm/civicrm-core/pull/29674/files#diff-b2123bc442ae801eae669e45656cf5b142e871fa611b733a3dbcec6658ddd7e1R437

In addition it doesn't make much sense to have the custom data functions on another class that calls a one liner on yet another class - it adds complexity for no reason


Before
----------------------------------------
opps didn't pass by ref in just merged fix

After
----------------------------------------
fixed

![image](https://github.com/civicrm/civicrm-core/assets/336308/2ca2f475-d0ef-4e7a-be19-5f180048bca3)


Technical Details
----------------------------------------

Comments
----------------------------------------
