### PR TITLE
Copy function back to only calling class

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -331,7 +331,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
             CRM_Custom_Form_CustomData::preProcess($this, NULL, $contactSubType,
               $i, $this->_contactType, $this->_contactId, NULL, FALSE
             );
-            CRM_Contact_Form_Edit_CustomData::buildQuickForm($this);
+            $this->buildCustomData();
           }
         }
       }
@@ -1541,7 +1541,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       return;
     }
     if ($name === 'CustomData') {
-      CRM_Contact_Form_Edit_CustomData::buildQuickForm($this);
+      $this->buildCustomData();
       return;
     }
     if ($name === 'CommunicationPreferences') {
@@ -1562,6 +1562,36 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     // and any extensions doing magic are buyer-beware.
     $className = 'CRM_Contact_Form_Edit_' . $name;
     $className::buildQuickForm($this);
+  }
+
+  /**
+   * Build the form object elements for CustomData object.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  private function buildCustomData(): void {
+    $customValueCount = $this->_submitValues['hidden_custom_group_count'] ?? NULL;
+    if (is_array($customValueCount)) {
+      if (array_key_exists(0, $customValueCount)) {
+        unset($customValueCount[0]);
+      }
+      $this->_customValueCount = $customValueCount;
+      $this->assign('customValueCount', $customValueCount);
+    }
+
+    $this->addElement('hidden', 'hidden_custom', 1);
+    $this->addElement('hidden', "hidden_custom_group_count[{$this->_groupID}]", $this->_groupCount);
+    CRM_Core_BAO_CustomGroup::buildQuickForm($this, $this->_groupTree);
+
+    //build custom data.
+    if (!empty($_POST["hidden_custom"]) && !empty($_POST['contact_sub_type'])) {
+      $contactSubType = $_POST['contact_sub_type'];
+    }
+    else {
+      $contactSubType = $this->_values['contact_sub_type'] ?? NULL;
+    }
+    $this->assign('contactType', $this->_contactType);
+    $this->assign('contactSubType', $contactSubType);
   }
 
   /**

--- a/CRM/Contact/Form/Edit/CustomData.php
+++ b/CRM/Contact/Form/Edit/CustomData.php
@@ -46,10 +46,13 @@ class CRM_Contact_Form_Edit_CustomData {
   /**
    * Build the form object elements for CustomData object.
    *
+   * @deprecated since 5.73 will be removed around 5.85
+   *
    * @param CRM_Core_Form $form
    *   Reference to the form object.
    */
   public static function buildQuickForm(&$form) {
+    CRM_Core_Error::deprecatedFunctionWarning('take a copy?');
     $customValueCount = $form->_submitValues['hidden_custom_group_count'] ?? NULL;
     if (is_array($customValueCount)) {
       if (array_key_exists(0, $customValueCount)) {


### PR DESCRIPTION


Overview
----------------------------------------

Copy function back to only calling class

This function is called from the contact form & not otherwise. Copying it back & slightly consolidating reduces complexity & saves us from passing the form

Before
----------------------------------------
Function is called from 2 places on the main contact form & nowhere else

After
----------------------------------------
Function copied to be private on the calling form, the few lines from the function it calls internally are copied in

Technical Details
----------------------------------------

Comments
----------------------------------------
