### PR TITLE
Fold preProcess function from Custom data form back to only caller

### DIFF
--- a/CRM/Contact/Form/Edit/CustomData.php
+++ b/CRM/Contact/Form/Edit/CustomData.php
@@ -23,11 +23,14 @@ class CRM_Contact_Form_Edit_CustomData {
   /**
    * Build all the data structures needed to build the form.
    *
+   * @deprecated since 5.73 will be removed around 5.85
+   *
    * @param CRM_Core_Form $form
    *
    * @throws \CRM_Core_Exception
    */
   public static function preProcess(&$form) {
+    CRM_Core_Error::deprecatedFunctionWarning('maybe take a copy?');
     $customDataType = CRM_Utils_Request::retrieve('type', 'String');
 
     if ($customDataType) {


### PR DESCRIPTION
Overview
----------------------------------------
Fold preProcess function from Custom data form back to only caller

Before
----------------------------------------
The function is not in fact shared - it has only 1 called but is a static function on another form

After
----------------------------------------
Copied back, deprecated

Technical Details
----------------------------------------

Comments
----------------------------------------
