### PR TITLE
Possible fix for export test on php8.3

### DIFF
--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -184,7 +184,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'componentClause' => 'civicrm_contribution.id IN ( ' . implode(',', $this->contributionIDs) . ')',
     ]);
 
-    $this->assertEquals(array_merge($this->getBasicHeaderDefinition(FALSE), $this->getContributeHeaderDefinition()), $this->csv->getHeader());
+    $this->assertEquals(array_values(array_merge($this->getBasicHeaderDefinition(FALSE), $this->getContributeHeaderDefinition())), $this->csv->getHeader());
     $this->assertCount(3, $this->csv);
     $row = $this->csv->fetchOne();
     $this->assertEquals(95, $row['Net Amount']);
@@ -1856,7 +1856,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     $this->setupBaseExportData($exportMode);
     $this->doExportTest(['selectAll' => TRUE, 'exportMode' => $exportMode, 'ids' => [1]]);
     $this->assertEquals($expected, $this->processor->getSQLColumns());
-    $this->assertEquals($expectedHeaders, $this->processor->getHeaderRows());
+    $this->assertEquals(array_values($expectedHeaders), $this->processor->getHeaderRows());
   }
 
   /**


### PR DESCRIPTION
The issue seems to be about gaps in the array numbers so perhaps this does it? https://test.civicrm.org/job/CiviCRM-Core-Edge/CIVIVER=master,label=bknix-tmp-edge/lastCompletedBuild/testReport/(root)/CRM_Export_BAO_ExportTest/testExportComponentsContributionSoftCredits/
