### PR TITLE
Premium Products: allow key=val format for product options

### DIFF
--- a/CRM/Contribute/BAO/Premium.php
+++ b/CRM/Contribute/BAO/Premium.php
@@ -130,12 +130,8 @@ class CRM_Contribute_BAO_Premium extends CRM_Contribute_DAO_Premium {
             CRM_Core_DAO::storeValues($productDAO, $products[$productDAO->id]);
           }
         }
-        $options = $temp = [];
-        $temp = explode(',', $productDAO->options);
-        foreach ($temp as $value) {
-          $options[trim($value)] = trim($value);
-        }
-        if ($temp[0] != '') {
+        $options = self::parseProductOptions($productDAO->options);
+        if (!empty($options)) {
           $form->addElement('select', 'options_' . $productDAO->id, NULL, $options);
         }
       }
@@ -244,6 +240,27 @@ class CRM_Contribute_BAO_Premium extends CRM_Contribute_DAO_Premium {
       self::$productInfo = [$products, $options];
     }
     return self::$productInfo;
+  }
+
+  /**
+   * Convert key=val options into an array while keeping
+   * compatibility for values only.
+   */
+  public static function parseProductOptions($string) : array {
+    $options = [];
+    $temp = explode(',', $string);
+
+    foreach ($temp as $value) {
+      $parts = explode('=', $value, 2);
+      if (count($parts) == 2) {
+        $options[trim($parts[0])] = trim($parts[1]);
+      }
+      else {
+        $options[trim($value)] = trim($value);
+      }
+    }
+
+    return $options;
   }
 
 }

--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -40,11 +40,9 @@ class CRM_Contribute_Form_AdditionalInfo {
     while ($dao->fetch()) {
       $sel1[$dao->id] = $dao->name . " ( " . $dao->sku . " )";
       $min_amount[$dao->id] = $dao->min_contribution;
-      $options = explode(',', $dao->options);
-      foreach ($options as $k => $v) {
-        $options[$k] = trim($v);
-      }
-      if ($options[0] != '') {
+      $options = CRM_Contribute_BAO_Premium::parseProductOptions($dao->options);
+      if (!empty($options)) {
+        $options = ['' => ts('- select -')] + $options;
         $sel2[$dao->id] = $options;
       }
       $form->assign('premiums', TRUE);
@@ -189,7 +187,7 @@ class CRM_Contribute_Form_AdditionalInfo {
     CRM_Contribute_BAO_Product::retrieve($premiumParams, $productDetails);
     $dao->financial_type_id = $productDetails['financial_type_id'] ?? NULL;
     if (!empty($options[$selectedProductID])) {
-      $dao->product_option = $options[$selectedProductID][$selectedProductOptionID];
+      $dao->product_option = $selectedProductOptionID;
     }
 
     // This IF condition codeblock does the following:

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -497,9 +497,13 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     if (empty($defaults['payment_instrument_id'])) {
       $defaults['payment_instrument_id'] = $this->getDefaultPaymentInstrumentId();
     }
-    $this->assign('is_test', !empty($defaults['is_test']));
 
+    $this->assign('is_test', !empty($defaults['is_test']));
+    $this->assign('email', $this->userEmail);
+    $this->assign('is_pay_later', !empty($defaults['is_pay_later']));
+    $this->assign('contribution_status_id', $defaults['contribution_status_id'] ?? NULL);
     $this->assign('showOption', TRUE);
+
     // For Premium section.
     if ($this->_premiumID) {
       $this->assign('showOption', FALSE);
@@ -507,9 +511,8 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       if (!$options) {
         $this->assign('showOption', TRUE);
       }
-      $options_key = CRM_Utils_Array::key($this->_productDAO->product_option, $options);
-      if ($options_key) {
-        $defaults['product_name'] = [$this->_productDAO->product_id, trim($options_key)];
+      if ($this->_productDAO->product_option) {
+        $defaults['product_name'] = [$this->_productDAO->product_id, $this->_productDAO->product_option];
       }
       else {
         $defaults['product_name'] = [$this->_productDAO->product_id];
@@ -519,9 +522,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       }
     }
 
-    $this->assign('is_pay_later', !empty($defaults['is_pay_later']));
-
-    $this->assign('contribution_status_id', $defaults['contribution_status_id'] ?? NULL);
     if (!empty($defaults['contribution_status_id']) && in_array(
         CRM_Contribute_PseudoConstant::contributionStatus($defaults['contribution_status_id'], 'name'),
         // Historically not 'Cancelled' hence not using CRM_Contribute_BAO_Contribution::isContributionStatusNegative.

--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -160,8 +160,16 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
       $productDAO->id = $productID;
       $productDAO->find(TRUE);
 
+      // If the option has a key/val that are not identical, display as "label (key)"
+      // where the "key" is somewhat assumed to be the SKU of the option
+      $options = CRM_Contribute_BAO_Premium::parseProductOptions($productDAO->options);
+      $option_key = $option_label = $dao->product_option;
+      if ($option_key && !empty($options[$option_key]) && $options[$option_key] != $option_key) {
+        $option_label = $options[$option_key] . ' (' . $option_key . ')';
+      }
+
       $this->assign('premium', $productDAO->name);
-      $this->assign('option', $dao->product_option);
+      $this->assign('option', $option_label);
       $this->assign('fulfilled', $dao->fulfilled_date);
     }
 

--- a/templates/CRM/Contribute/Form/ContributionView.tpl
+++ b/templates/CRM/Contribute/Form/ContributionView.tpl
@@ -231,7 +231,7 @@
         <td class="label">{ts}Option{/ts}</td>
         <td>{$option}</td>
         <td class="label">{ts}Fulfilled{/ts}</td>
-        <td>{$fulfilled|truncate:10:''|crmDate}</td>
+        <td>{if $fulfilled}{$fulfilled|truncate:10:''|crmDate}{else}{ts}No{/ts}{/if}</td>
       </table>
     </div>
   </details>

--- a/templates/CRM/Contribute/Form/ManagePremiums.tpl
+++ b/templates/CRM/Contribute/Form/ManagePremiums.tpl
@@ -94,7 +94,7 @@
     <tr class="crm-contribution-form-block-options">
        <td class="label">{$form.options.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_product' field='options' id=$productId}{/if}</td>
       <td class="html-adjust">{$form.options.html}<br />
-          <span class="description">{ts}Enter a comma-delimited list of color, size, etc. options for the product if applicable. Contributors will be presented a drop-down menu of these options when they select this product.{/ts}</span>
+          <span class="description">{ts}Enter a comma-delimited list of color, size, etc. options for the product if applicable. Contributors will be presented a drop-down menu of these options when they select this product.{/ts} {ts}You can also use the format key=label, where the key could be the SKU of the option, for example.{/ts}</span>
        </td>
     </tr>
     <tr class="crm-contribution-form-block-is_active">

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -77,7 +77,7 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
 
     $product1 = $this->callAPISuccess('Product', 'create', [
       'name' => 'Smurf',
-      'options' => 'brainy smurf, clumsy smurf, papa smurf',
+      'options' => 'brainy smurf, clumsy smurf, papa smurf, skusmurf=SKU Smurf',
     ]);
 
     $this->products[] = $product1['values'][$product1['id']];
@@ -720,7 +720,7 @@ Receipt Date: ' . date('m/d/Y'),
       'contact_id' => $this->_individualId,
       'payment_instrument_id' => $this->getPaymentInstrumentID('Check'),
       'contribution_status_id' => 1,
-      'product_name' => [$this->products[0]['id'], 1],
+      'product_name' => [$this->products[0]['id'], 'clumsy smurf'],
       'fulfilled_date' => '',
       'is_email_receipt' => TRUE,
       'from_email_address' => 'test@test.com',
@@ -739,6 +739,32 @@ Receipt Date: ' . date('m/d/Y'),
   /**
    * Test functions involving premiums.
    */
+  public function testPremiumUpdateWithSKUkey(): void {
+    $this->submitContributionForm([
+      'total_amount' => 50,
+      'financial_type_id' => 1,
+      'contact_id' => $this->_individualId,
+      'payment_instrument_id' => $this->getPaymentInstrumentID('Check'),
+      'contribution_status_id' => 1,
+      'product_name' => [$this->products[0]['id'], 'skusmurf'],
+      'fulfilled_date' => '',
+      'is_email_receipt' => TRUE,
+      'from_email_address' => 'test@test.com',
+      'hidden_Premium' => 1,
+    ]);
+    $contributionProduct = $this->callAPISuccess('contribution_product', 'getsingle', []);
+    $this->assertEquals('skusmurf', $contributionProduct['product_option']);
+    $this->assertMailSentContainingStrings([
+      'Premium Information',
+      'Smurf',
+      'SKU Smurf',
+    ]);
+    $this->assertMailSentContainingStrings(['Smurf', 'SKU Smurf']);
+  }
+
+  /**
+   * Test functions involving premiums.
+   */
   public function testPremiumUpdateCreditCard(): void {
     $form = $this->submitContributionForm([
       'total_amount' => 50,
@@ -746,7 +772,7 @@ Receipt Date: ' . date('m/d/Y'),
       'contact_id' => $this->_individualId,
       'payment_instrument_id' => $this->getPaymentInstrumentID('Check'),
       'contribution_status_id' => 1,
-      'product_name' => [$this->products[0]['id'], 1],
+      'product_name' => [$this->products[0]['id'], 'clumsy smurf'],
       'fulfilled_date' => '',
       'is_email_receipt' => TRUE,
       'from_email_address' => 'test@test.com',


### PR DESCRIPTION
Overview
----------------------------------------

Adds support for formatting premium/product options as key=value. Makes it easier to manage products where the options might have their own SKU. It also displays the option SKU on ContributionView.

Another small change was to display "Fulfilled : No" when there is no fulfillment date.

Before
----------------------------------------

Product options can have only a label. This is not super useful for inventory management.

For example, if I have t-shirts that have S/M/L, each of those options have their own SKU. In reports, I would see only "S", "M", "L". I cannot put the SKU there, because the string is user-facing (when selecting the option).

After
----------------------------------------

Products can have a key=label, so the user sees "M" but my inventory reports see "SHIRT-2024-M".

Also changes the "Fulfilled" display, to show "No" when not fulfilled, because at a glance, one doesn't know that a date will be displayed here, so it gives the impression that the order was fulfilled:

![image](https://github.com/civicrm/civicrm-core/assets/254741/321595e5-1e22-4fd9-9f11-7d687ee3e999)

![image](https://github.com/civicrm/civicrm-core/assets/254741/2fa9c0f2-d926-40cc-af24-2712d657ca48)

Comments
----------------------------------------

I considered moving options to either an OptionValue, or to a separate entity altogether, but my inner voice said it would be very overkill, and I'm pretty sure no one uses this feature, because it's very awkward to use.

There is one drawback, but it is opt-in: in a report of Contributions (or when using SearchKit), we will see the option SKU instead of the label. Fetching the label will not easy in searchkit. However, 1) I think most people will want the SKU, and 2) this behaviour is opt-in, if people previously only had a "label", then it works like before.

These changes came from the Tor Project Association, where they had been using lots of messy custom fields to manage perks/premiums for donations, presumably as a workaround for this limitation.