### PR TITLE
(WIP) Allow Case creator_id to be gotten through API4

### DIFF
--- a/ext/civi_case/Civi/Api4/Service/Spec/Provider/CaseGetSpecProvider.php
+++ b/ext/civi_case/Civi/Api4/Service/Spec/Provider/CaseGetSpecProvider.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Query\Api4SelectQuery;
+use Civi\Api4\Service\Spec\FieldSpec;
+use Civi\Api4\Service\Spec\RequestSpec;
+
+/**
+ * @service
+ * @internal
+ */
+class CaseGetSpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
+
+  /**
+   * @inheritDoc
+   */
+  public function modifySpec(RequestSpec $spec) {
+    $creator = new FieldSpec('creator_id', $spec->getEntity(), 'Integer');
+    $creator->setTitle(ts('Case Creator'));
+    $creator->setLabel(ts('Case Creator'));
+    $creator->setDescription('Contact who created the case.');
+    $creator->setFkEntity('Contact');
+    $creator->setSqlRenderer([__CLASS__, 'renderSqlForCaseCreator']);
+    $spec->addFieldSpec($creator);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function applies($entity, $action) {
+    return $entity === 'Case' && $action === 'get';
+  }
+
+  public static function renderSqlForCaseCreator(array $field, Api4SelectQuery $query): string {
+    $relationshipTypeDao = new \CRM_Contact_DAO_RelationshipType();
+    $relationshipTypeDao->find();
+    $relationshipTypes = $relationshipTypeDao->fetchAll();
+
+    $caseTypeDao = new \CRM_Case_DAO_CaseType();
+    $caseTypeDao->find();
+
+    while ($caseTypeDao->fetch()) {
+      $row = $caseTypeDao->toArray();
+      if (empty($row['definition'])) {
+        $xml = \CRM_Case_XMLRepository::singleton()->retrieveFile($row['name']);
+        $row['definition'] = $xml ? \CRM_Case_BAO_CaseType::convertXmlToDefinition($xml) : [];
+      }
+      else {
+        \CRM_Case_BAO_CaseType::formatOutputDefinition($row['definition'], $row);
+      }
+      foreach ($row['definition']['caseRoles'] ?? [] as $role) {
+        if (!empty($role['creator'])) {
+          $caseTypeId = $row['id'];
+          foreach ($relationshipTypes as $relationshipType) {
+            if ($relationshipType['name_a_b'] == $role['name']) {
+              $caseTypeMap[$caseTypeId]['relTypeId'] = $relationshipType['id'];
+              $caseTypeMap[$caseTypeId]['orientation'] = 'b_a';
+              break 2;
+            }
+            if ($relationshipType['name_b_a'] == $role['name']) {
+              $caseTypeMap[$caseTypeId]['relTypeId'] = $relationshipType['id'];
+              $caseTypeMap[$caseTypeId]['orientation'] = 'a_b';
+              break 2;
+            }
+          }
+        }
+      }
+    }
+
+    if (empty($caseTypeMap)) {
+      return 'NULL';
+    }
+
+    foreach ($caseTypeMap as $caseTypeId => $mapping) {
+      $idMap[] = "WHEN $caseTypeId THEN {$mapping['relTypeId']}";
+      $orientationMap[] = "WHEN $caseTypeId THEN '{$mapping['orientation']}'";
+    }
+
+    $caseIdSqlName = $query->getField('id')['sql_name'];
+
+    $separator = "\n                  ";
+    return "(SELECT `far_contact_id`
+              FROM `civicrm_relationship_cache`
+              WHERE `case_id` = $caseIdSqlName
+              AND `relationship_type_id` = (
+                  CASE `case_type_id`$separator" . implode($separator, $idMap) . "
+                  ELSE NULL END)
+              AND `orientation` = (
+                  CASE `case_type_id`$separator" . implode($separator, $orientationMap) . "
+                  ELSE NULL END)
+      LIMIT 1)";
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
The motivation of this PR was to make the "Creator ID" field functional in FormBuilder Case submission forms, in update mode as well as create mode.

Before
----------------------------------------
"Creator ID" field could be used in "create" mode, but the saved value would not prefill (load) in "update" mode.

After
----------------------------------------
Creator ID is prefilled in update mode. See below for caveats.

Technical Details
----------------------------------------
As I crafted this rather smelly bit of code, I realized there was simply no way to make it odor-free. That's because:

- It's all tied up with CiviCase's XML-based Case Type definition system, which may have been a clever idea at some point but has caused numerous headaches over the last decade plus. Case roles in particular have been hard to deal with --#15483 is just one example of the many hours that have been sunk into working around the problems in this system.
- `creator_id` appears to have been designed with one usage in mind: submitting a `CRM_Case_Form_Activity_OpenCase` (which is triggered when you use `CRM_Case_Form_Case` to create a new case). In that context, a single, required, `creator_id` is fine. It is used to create one (or more!) relationships between the "creator" contact and the case clients.
- Outside of the `CRM_Case_Form_Activity_OpenCase` context, a single integer is not necessarily sufficient to represent the "creator" of the case. Multiple case roles can be flagged "Assign to Creator", and multiple people can be in each of these roles.
- In fact, APIv3 [rejects](https://github.com/lemniscus/civicrm-core/blob/api4-casecreator-get/api/v3/Case.php#L64) `creator_id` in update actions.
- However, for whatever reason, `creator_id` was made a *required field* in APIv4. This means that it's required in FormBuilder. NB it was not required in APIv3.

This PR makes `creator_id` available in API4 `Case.Get`. It will return the ID of *one of the contacts* in a role flagged "Assign to Creator".

Comments
----------------------------------------
Despite the flaws, I think this PR is beneficial on the whole. We can address whether `creator_id` should be required or not separately. In the meantime, let's make the field work in FormBuilder, at least in a limited way.