### PR TITLE
dev/core#4753 Afform - Fix boolean options

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -17,11 +17,8 @@
         ctrl = this,
         // Prefix used for SearchKit explicit joins
         namePrefix = '',
-        boolOptions = [{id: true, label: ts('Yes')}, {id: false, label: ts('No')}],
-        // Used to store chain select options loaded on-the-fly
-        chainSelectOptions = null,
-        // Only used for is_primary radio button
-        noOptions = [{id: true, label: ''}];
+        // Either defn.options or chain select options loaded on-the-fly
+        fieldOptions = null;
 
       // Attributes for each of the low & high date fields when using search_range
       this.inputAttrs = [];
@@ -41,13 +38,20 @@
           this.search_operator = this.defn.search_operator;
         }
 
+        fieldOptions = this.defn.options || null;
+
         // Ensure boolean options are truly boolean
-        if (this.defn.data_type === 'Boolean' && this.defn.options) {
-          this.defn.options.forEach((option) => option.id = !!option.id);
+        if (this.defn.data_type === 'Boolean') {
+          if (fieldOptions) {
+            fieldOptions.forEach((option) => option.id = !!option.id);
+          } else {
+            fieldOptions = [{id: true, label: ts('Yes')}, {id: false, label: ts('No')}];
+          }
         }
 
         // is_primary field - watch others in this afRepeat block to ensure only one is selected
         if (ctrl.fieldName === 'is_primary' && 'repeatIndex' in $scope.dataProvider) {
+          fieldOptions = [{id: true, label: ''}];
           $scope.$watch('dataProvider.afRepeat.getEntityController().getData()', function (items, prev) {
             var index = $scope.dataProvider.repeatIndex;
             // Set first item to primary if there isn't a primary
@@ -91,11 +95,11 @@
               crmApi4('Afform', 'getOptions', params)
                 .then(function(data) {
                   $('input[crm-ui-select]', $element).removeClass('loading').prop('disabled', !data.length);
-                  chainSelectOptions = data;
+                  fieldOptions = data;
                   validateValue();
                 });
             } else {
-              chainSelectOptions = null;
+              fieldOptions = null;
               validateValue();
             }
           }, true);
@@ -265,7 +269,7 @@
       };
 
       $scope.getOptions = function () {
-        return chainSelectOptions || ctrl.defn.options || (ctrl.fieldName === 'is_primary' && ctrl.defn.input_type === 'Radio' ? noOptions : boolOptions);
+        return fieldOptions;
       };
 
       $scope.select2Options = function() {

--- a/ext/afform/core/ang/af/fields/CheckBox.html
+++ b/ext/afform/core/ang/af/fields/CheckBox.html
@@ -1,5 +1,5 @@
 <ul class="crm-checkbox-list" id="{{ fieldId }}" ng-if="$ctrl.isMultiple()">
-  <li ng-repeat="opt in $ctrl.defn.options track by opt.id" >
+  <li ng-repeat="opt in getOptions() track by opt.id" >
     <input type="checkbox" checklist-model="dataProvider.getFieldData()[$ctrl.fieldName]" ng-required="$ctrl.defn.required && !dataProvider.getFieldData()[$ctrl.fieldName].length" id="{{ fieldId + opt.id }}" checklist-value="opt.id" />
     <label for="{{ fieldId + opt.id }}">{{:: opt.label }}</label>
   </li>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes default values in yes/no radio fields in FormBuilder.

See steps to reproduce in https://lab.civicrm.org/dev/core/-/issues/4753

Technical Details
----------------------------------------
The previous code was taking care to cast option values to true/false for boolean fields, but this was then undone by the two-way binding on the field. By breaking the binding we can update the values in a way that won't be undone by the Angular bindings.