### PR TITLE
Updating php-weasyprint to latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
     "symfony/dependency-injection": "~4.4 || ~6.0",
     "symfony/event-dispatcher": "~4.4 || ~6.0",
     "symfony/filesystem": "~4.4 || ~6.0",
-    "symfony/process": "~4.4 || ~6.0",
+    "symfony/process": "~4.4 || ~5.0 || ~6.0",
     "symfony/var-dumper": "~4.4 || ~5.1 || ~6.0",
     "symfony/service-contracts": "~2.2 || ~3.1",
     "psr/log": "~1.0 || ~2.0 || ~3.0",
@@ -103,7 +103,7 @@
     "soundasleep/html2text": "^2.1",
     "psr/container": "~1.0 || ~2.0",
     "ext-fileinfo": "*",
-    "pontedilana/php-weasyprint": "^0.13.0",
+    "pontedilana/php-weasyprint": "^1",
     "knplabs/knp-snappy": "^1.4"
   },
   "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "142449f17c1a3e6d486d398c274352f8",
+    "content-hash": "20d2acf6ea0edb0c877aaa7f371614ab",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -2941,22 +2941,22 @@
         },
         {
             "name": "pontedilana/php-weasyprint",
-            "version": "0.13.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pontedilana/php-weasyprint.git",
-                "reference": "3ceba9644240e775d3d44e1bcee90b930769a17f"
+                "reference": "62c8704834e7d2a3688318ec15bf0e87b3061de9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pontedilana/php-weasyprint/zipball/3ceba9644240e775d3d44e1bcee90b930769a17f",
-                "reference": "3ceba9644240e775d3d44e1bcee90b930769a17f",
+                "url": "https://api.github.com/repos/pontedilana/php-weasyprint/zipball/62c8704834e7d2a3688318ec15bf0e87b3061de9",
+                "reference": "62c8704834e7d2a3688318ec15bf0e87b3061de9",
                 "shasum": ""
             },
             "require": {
-                "php": "7.4.* || 8.0.* || 8.1.* || 8.2.*",
+                "php": "7.4.* || 8.0.* || 8.1.* || 8.2.* || 8.3.*",
                 "psr/log": "^1.1 || ^2.0 || ^3.0",
-                "symfony/process": "^4.4 || ^5.4 || ^6.0"
+                "symfony/process": "^5.4 || ^6.2  || ^7"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.4",
@@ -2989,9 +2989,19 @@
             ],
             "support": {
                 "issues": "https://github.com/pontedilana/php-weasyprint/issues",
-                "source": "https://github.com/pontedilana/php-weasyprint/tree/0.13.0"
+                "source": "https://github.com/pontedilana/php-weasyprint/tree/1.4.0"
             },
-            "time": "2023-01-16T09:42:22+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/endelwar",
+                    "type": "github"
+                },
+                {
+                    "url": "https://ko-fi.com/endelwar",
+                    "type": "ko_fi"
+                }
+            ],
+            "time": "2023-11-20T08:58:59+00:00"
         },
         {
             "name": "psr/container",
@@ -3208,16 +3218,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
-                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
                 "shasum": ""
             },
             "require": {
@@ -3241,7 +3251,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for logging libraries",
@@ -3252,9 +3262,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.3"
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
             },
-            "time": "2020-03-23T09:12:05+00:00"
+            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -4437,16 +4447,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.27.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936"
+                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
                 "shasum": ""
             },
             "require": {
@@ -4454,9 +4464,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -4500,7 +4507,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -4516,7 +4523,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
@@ -4678,20 +4685,20 @@
         },
         {
             "name": "symfony/process",
-            "version": "v4.4.41",
+            "version": "v5.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "9eedd60225506d56e42210a70c21bb80ca8456ce"
+                "reference": "4fdf34004f149cc20b2f51d7d119aa500caad975"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/9eedd60225506d56e42210a70c21bb80ca8456ce",
-                "reference": "9eedd60225506d56e42210a70c21bb80ca8456ce",
+                "url": "https://api.github.com/repos/symfony/process/zipball/4fdf34004f149cc20b2f51d7d119aa500caad975",
+                "reference": "4fdf34004f149cc20b2f51d7d119aa500caad975",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1.3",
+                "php": ">=7.2.5",
                 "symfony/polyfill-php80": "^1.16"
             },
             "type": "library",
@@ -4720,7 +4727,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v4.4.41"
+                "source": "https://github.com/symfony/process/tree/v5.4.36"
             },
             "funding": [
                 {
@@ -4736,7 +4743,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-04T10:19:07+00:00"
+            "time": "2024-02-12T15:49:53+00:00"
         },
         {
             "name": "symfony/service-contracts",

--- a/tests/phpunit/CRM/Core/ComposerConfigTest.php
+++ b/tests/phpunit/CRM/Core/ComposerConfigTest.php
@@ -26,7 +26,7 @@ class CRM_Core_ComposerConfigTest extends \PHPUnit\Framework\TestCase {
       'symfony/event-dispatcher' => '/^v4\.4\./',
       'symfony/filesystem' => '/^v4\.4\./',
       'symfony/finder' => '/^v4\.4\./',
-      'symfony/process' => '/^v4\.4\./',
+      'symfony/process' => '/^v5\.4\./',
     ];
 
     $lockFile = Civi::paths()->getPath('[civicrm.root]/composer.lock');


### PR DESCRIPTION
Overview
----------------------------------------
Can't install civicrm 5.71.1 on php 8.3

Technical Details
----------------------------------------
Php-WeasyPrint is locked at 0.13 version which works only till php 8.2 version so the installation fails, we should go to latest version i.e. 1.3.0 so that it works with php 8.3

