### PR TITLE
add CaseRole pseudo bridge entity

### DIFF
--- a/ext/civi_case/CRM/Case/BAO/CaseRole.php
+++ b/ext/civi_case/CRM/Case/BAO/CaseRole.php
@@ -1,0 +1,7 @@
+<?php
+
+use CRM_Case_ExtensionUtil as E;
+
+class CRM_Case_BAO_CaseRole extends CRM_Contact_BAO_Relationship {
+
+}

--- a/ext/civi_case/CRM/Case/DAO/CaseRole.php
+++ b/ext/civi_case/CRM/Case/DAO/CaseRole.php
@@ -1,0 +1,7 @@
+<?php
+
+use CRM_Case_ExtensionUtil as E;
+
+class CRM_Case_DAO_CaseRole extends CRM_Contact_DAO_Relationship {
+
+}

--- a/ext/civi_case/Civi/Api4/CaseRole.php
+++ b/ext/civi_case/Civi/Api4/CaseRole.php
@@ -11,17 +11,21 @@
 namespace Civi\Api4;
 
 /**
- * RelationshipCache - readonly table to facilitate joining and finding contacts by relationship.
+ * CaseRoleCache - API wrapper on Relationship entity to facilitate joining and finding contacts with a role on a case
  *
  * @searchable secondary
- * @searchFields near_contact_id.sort_name,near_relation:label,far_contact_id.sort_name
+ * @searchFields contact_a_id.sort_name,relationship_type_id:label,case_id.subject
  * @see \Civi\Api4\Relationship
- * @ui_join_filters near_relation
- * @since 5.29
+ * @ui_join_filters relationship_type_id,is_active
+ * @since 5.72
  * @package Civi\Api4
  */
-class RelationshipCache extends Generic\AbstractEntity {
+class CaseRole extends Generic\AbstractEntity {
   use Generic\Traits\EntityBridge;
+
+  protected static function getEntityTitle(bool $plural = FALSE): string {
+    return $plural ? ts('Case Roles') : ts('Case Role');
+  }
 
   /**
    * @param bool $checkPermissions
@@ -42,34 +46,23 @@ class RelationshipCache extends Generic\AbstractEntity {
   }
 
   /**
-   * @param bool $checkPermissions
-   * @return Action\RelationshipCache\Rebuild
-   */
-  public static function rebuild($checkPermissions = TRUE) {
-    return (new Action\RelationshipCache\Rebuild(__CLASS__, __FUNCTION__))
-      ->setCheckPermissions($checkPermissions);
-  }
-
-  /**
    * @return array
    */
   public static function getInfo() {
     $info = parent::getInfo();
-    $info['bridge_title'] = ts('Relationship');
+    $info['bridge_title'] = ts('Case Roles');
     $info['bridge'] = [
-      'near_contact_id' => [
-        'to' => 'far_contact_id',
-        'label' => ts('Related Contacts'),
-        'description' => ts('One or more related contacts'),
+      'contact_id_b' => [
+        'to' => 'case_id',
+        'label' => ts('Contact Roles'),
+        'description' => ts('Contacts with a role in the this case'),
       ],
     ];
-    if (\CRM_Core_Component::isEnabled('CiviCase')) {
-      $info['bridge']['case_id'] = [
-        'to' => 'far_contact_id',
-        'label' => ts('Case Roles Cache (deprecated)'),
-        'description' => ts('Cases in which this contact has a role'),
-      ];
-    }
+    $info['bridge']['case_id'] = [
+      'to' => 'contact_id_b',
+      'label' => ts('Case Roles'),
+      'description' => ts('Cases in which this contact has a role'),
+    ];
     return $info;
   }
 

--- a/ext/civi_case/info.xml
+++ b/ext/civi_case/info.xml
@@ -30,6 +30,7 @@
   <mixins>
     <mixin>ang-php@1.0.0</mixin>
     <mixin>scan-classes@1.0.0</mixin>
+    <mixin>entity-types-php@1.0.0</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Case</namespace>

--- a/ext/civi_case/xml/schema/CRM/Case/CaseRole.entityType.php
+++ b/ext/civi_case/xml/schema/CRM/Case/CaseRole.entityType.php
@@ -1,0 +1,10 @@
+<?php
+// This file declares a new entity type. For more details, see "hook_civicrm_entityTypes" at:
+// https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
+return [
+  [
+    'name' => 'CaseRole',
+    'class' => 'CRM_Case_DAO_CaseRole',
+    'table' => 'civicrm_relationship',
+  ],
+];

--- a/ext/search_kit/tests/phpunit/Civi/Search/AdminTest.php
+++ b/ext/search_kit/tests/phpunit/Civi/Search/AdminTest.php
@@ -64,8 +64,8 @@ class AdminTest extends Api4TestBase {
     );
 
     $relationshipCacheJoins = $joins['RelationshipCache'];
-    $this->assertCount(4, $relationshipCacheJoins);
-    $this->assertEquals(['RelationshipType', 'Contact', 'Contact', 'Case'], array_column($relationshipCacheJoins, 'entity'));
+    $this->assertCount(5, $relationshipCacheJoins);
+    $this->assertEquals(['CaseRole', 'RelationshipType', 'Contact', 'Contact', 'Case'], array_column($relationshipCacheJoins, 'entity'));
 
     $eventParticipantJoins = \CRM_Utils_Array::findAll($joins['Event'], [
       'entity' => 'Participant',


### PR DESCRIPTION
Overview
----------------------------------------
This adds a "pseudo" entity on top of Relationship to expose specifically the Case <=> Contact relationships.

This makes it possible to bridge from Cases to Contacts in both directions in SearchKit.

Currently a join is exposed using the RelationshipCache entity - but it only works from Contacts => Cases. I _think_ it's not necessary to use the RelationshipCache for the Case relationships anyway, because they aren't symmetric (you dont have to check for the contact in both contact_a and contact_b slots - its always contact_b)

Before
----------------------------------------
Not possible to bridge from Cases to Contacts with a role on that Case in SearchKit.

After
----------------------------------------
Is possible to bridge from Cases to Contacts with a role on that Case

Technical Details
----------------------------------------
I feel like there may be a neater implementation exclusively at the API level (ie without creating a BAO entity) . I tried this first I couldn't work out how to pass all possible methods/params through in a way that was neat/safe/efficient.

