### PR TITLE
reenable status messages in standalone page template

### DIFF
--- a/templates/CRM/common/standalone.tpl
+++ b/templates/CRM/common/standalone.tpl
@@ -50,7 +50,7 @@
     <div class="clear"></div>
 
     <div id="crm-main-content-wrapper">
-      {* include file="CRM/common/status.tpl" @todo FIXME *}
+      {include file="CRM/common/status.tpl"}
       {crmRegion name='page-body'}
         {if isset($isForm) and $isForm and isset($formTpl)}
           {include file="CRM/Form/$formTpl.tpl"}


### PR DESCRIPTION
Overview
----------------------------------------
Reenable status messages in Standalone

Before
----------------------------------------
The status messages template was commented out in the standalone page template. You didn't get any status messages.

After
----------------------------------------
Status messages appear as expected

Comments
----------------------------------------
There was a "FIXME" comment in the template - though no specific note about what was broken. It was in a big "Standalone POC" commit from @mlutfy  June 2022. I'm guessing maybe before there was any session handling? 

@mlutfy @artfulrobot do you have any memory if there was anything else that needed fixing about the status messages?