### PR TITLE
More accordion classname cleanup

### DIFF
--- a/ext/oembed/ang/crmOembedSharing/main.html
+++ b/ext/oembed/ang/crmOembedSharing/main.html
@@ -1,7 +1,7 @@
 <div id="bootstrap-theme" class="crm-container crm-oembed-sharing">
 
-  <details class="crm-accordion-wrapper crm-oembed-sharing-accordion">
-    <summary class="crm-accordion-header">
+  <details class="crm-accordion-bold crm-oembed-sharing-accordion">
+    <summary>
       {{::ts('Cross-Site Sharing')}}
     </summary>
     <div class="crm-accordion-body">

--- a/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
+++ b/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
@@ -95,16 +95,16 @@ CRM.$(function($) {
       {include file="CRM/Contact/Form/Search/Criteria/DisplaySettings.tpl"}
     </div>
   </details>
-  <details class="crm-accordion-wrapper crm-search_criteria_basic-accordion" open>
-    <summary class="crm-accordion-header">
+  <details class="crm-accordion-bold crm-search_criteria_basic-accordion" open>
+    <summary>
       {ts}Search Settings{/ts}
     </summary>
     <div class="crm-accordion-body">
       {include file="CRM/Contact/Form/Search/Criteria/SearchSettings.tpl"}
     </div>
   </details>
-  <details class="crm-accordion-wrapper crm-search_criteria_basic-accordion" open>
-    <summary class="crm-accordion-header">
+  <details class="crm-accordion-bold crm-search_criteria_basic-accordion" open>
+    <summary>
       {ts}Basic Criteria{/ts}
     </summary>
     <div class="crm-accordion-body">
@@ -112,8 +112,8 @@ CRM.$(function($) {
     </div>
   </details>
   {foreach from=$allPanes key=paneName item=paneValue}
-    <details class="crm-accordion-wrapper crm-ajax-accordion crm-{$paneValue.id}-accordion {if $paneValue.open eq 'true' || array_key_exists($paneName, $openedPanes)} {else}collapsed{/if}">
-      <summary class="crm-accordion-header" id="{$paneValue.id}">
+    <details class="crm-accordion-bold crm-ajax-accordion crm-{$paneValue.id}-accordion {if $paneValue.open eq 'true' || array_key_exists($paneName, $openedPanes)} {else}collapsed{/if}">
+      <summary id="{$paneValue.id}">
         {$paneName}
       </summary>
     <div class="crm-accordion-body {$paneValue.id}"></div>

--- a/templates/CRM/Dashlet/Page/Blog.tpl
+++ b/templates/CRM/Dashlet/Page/Blog.tpl
@@ -16,7 +16,7 @@
   #civicrm-news-feed .crm-news-feed-unread .crm-news-feed-item-title {
     font-weight: bold;
   }
-  #civicrm-news-feed details:not([open]) .crm-accordion-header {
+  #civicrm-news-feed details:not([open]) summary {
     text-overflow: ellipsis;
     text-wrap: none;
     white-space: nowrap;
@@ -46,8 +46,8 @@
   {foreach from=$feeds item="channel"}
     <div id="civicrm-news-feed-{$channel.name}">
     {foreach from=$channel.items item=article}
-      <details class="crm-accordion-wrapper">
-        <summary class="crm-accordion-header">
+      <details class="crm-accordion-bold">
+        <summary>
           <span class="crm-news-feed-item-title">{$article.title|smarty:nodefaults|purify}</span>
           <span class="crm-news-feed-item-preview"> - {if function_exists('mb_substr')}{$article.description|smarty:nodefaults|strip_tags|mb_substr:0:150}{else}{$article.description|smarty:nodefaults|strip_tags}{/if}</span>
         </summary>


### PR DESCRIPTION
Replaces #29702 

Overview
----------------------------------------
Removes more instances of the old accordion classnames `crm-accordion-wrapper` and `crm-accordion-header` which were mostly removed in #29448. Also tweaks one line of inline CSS to reflect the change.

Before
----------------------------------------
`<details class="crm-accordion-header"><summary class="crm-accordion-header">` in use.

After
----------------------------------------
`<details class="crm-accordion-bold"><summary>` used.
No visual change

Comments
----------------------------------------
Two of these were missed by me in #29600, one is a new instance added last week. 