### PR TITLE
Notice fixes on Contact Edit screen (with multiple contact fields & address fields - ie testData extension installed)

### DIFF
--- a/templates/CRM/Contact/Form/Contact.tpl
+++ b/templates/CRM/Contact/Form/Contact.tpl
@@ -78,7 +78,7 @@
 
     {foreach from = $editOptions item = "title" key="name"}
       {if $name eq 'CustomData'}
-        <div id='customData'>{include file="CRM/Contact/Form/Edit/CustomData.tpl" isSingleRecordEdit=false}</div>
+        <div id='customData'>{include file="CRM/Contact/Form/Edit/CustomData.tpl" isSingleRecordEdit=false skipTitle=false}</div>
       {else}
         {include file="CRM/Contact/Form/Edit/$name.tpl"}
       {/if}

--- a/templates/CRM/Contact/Form/Edit/Address/CustomData.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address/CustomData.tpl
@@ -15,7 +15,7 @@
             {$cd_edit.title}
         </summary>
         <div class="crm-accordion-body">
-        {include file="CRM/Custom/Form/Edit/CustomData.tpl" customDataEntity='address'}
+        {include file="CRM/Custom/Form/Edit/CustomData.tpl" customDataEntity='address' isSingleRecordEdit=false prefix=''}
         </div><!-- crm-accordion-body-->
     </details>
 

--- a/templates/CRM/Contact/Form/Edit/CustomData.tpl
+++ b/templates/CRM/Contact/Form/Edit/CustomData.tpl
@@ -10,8 +10,6 @@
 
 {foreach from=$groupTree item=cd_edit key=group_id}
   {if $cd_edit.is_multiple eq 1}
-    {assign var=tableID value=$cd_edit.table_id}
-    {assign var=divName value=$group_id|cat:"_$tableID"}
     <div></div>
     <details class="crm-accordion-bold crm-custom-accordion" {if $cd_edit.collapse_display and !$skipTitle}{else}open{/if}>
   {else}

--- a/templates/CRM/Custom/Form/Edit/CustomData.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomData.tpl
@@ -1,4 +1,4 @@
-{if !$isSingleRecordEdit && $cd_edit.is_multiple eq 1 and $cd_edit.table_id and $contactId and !$skipTitle and $cd_edit.style eq 'Inline'}
+{if !$isSingleRecordEdit && $cd_edit.is_multiple eq 1 and array_key_exists('table_id', $cd_edit) && $cd_edit.table_id and $contactId and !$skipTitle and $cd_edit.style eq 'Inline'}
   {assign var=tableID value=$cd_edit.table_id}
   <a href="#" class="crm-hover-button crm-custom-value-del" title="{ts 1=$cd_edit.title}Delete %1{/ts}"
      data-post='{ldelim}"valueID": "{$tableID}", "groupID": "{$group_id}", "contactId": "{$contactId}", "key": "{crmKey name='civicrm/ajax/customvalue'}"{rdelim}'>

--- a/templates/CRM/Custom/Form/Edit/CustomField.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomField.tpl
@@ -51,7 +51,7 @@
     <td class="html-adjust">
       {$formElement.html}&nbsp;
       {if $element.data_type eq 'File'}
-        {if $element.element_value.data}
+        {if array_key_exists('element_value', $element) && $element.element_value.data}
           <div class="crm-attachment-wrapper crm-entity" id="file_{$element.element_name}">
             <span class="html-adjust"><br/>&nbsp;{ts}Attached File{/ts}: &nbsp;
               {if $element.element_value.displayURL}


### PR DESCRIPTION
Overview
---------------------------------------
Notice fixes on Contact Edit screen (with multiple contact fields & address fields - ie testData extension installed)

Before
----------------------------------------
If you install the [testData](https://github.com/eileenmcnaughton/testdata)  extension then trying to create a new student shows a tonne of red

![image](https://github.com/civicrm/civicrm-core/assets/336308/cea42382-861b-4027-8aa5-6dd0f4476eed)



After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/f5540682-2cde-46d5-855d-3432d29d59bf)


Technical Details
----------------------------------------

Comments
----------------------------------------