### PR TITLE
Ensure confirm hooks are called if confirmation page is disabled

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1315,8 +1315,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
     // build the confirm page
     $confirmForm = &$this->controller->_pages['Confirm'];
-    $confirmForm->preProcess();
-    $confirmForm->buildQuickForm();
+    $confirmForm->buildForm();
 
     // the confirmation page is valid
     $data = &$this->controller->container();


### PR DESCRIPTION
Overview
----------------------------------------
Ensure confirm hooks are called if confirmation page is disabled

Before
----------------------------------------
Confirmation form hooks are not called if confirm page is disabled on Contribution page.

After
----------------------------------------
Confirmation form hooks are called.

Technical Details
----------------------------------------
The line of code hasn't changed from a long time, but there's no way for extensions to update `$confirmForm` object before registering a payment.

This PR replaces the call of preProcess() & buildQuickForm() with a single buildForm() which also takes care of calling any related hooks for form updates.

