### PR TITLE
Advanced Search accordion, updates class name for lighter accordion

### DIFF
--- a/templates/CRM/Contact/Form/Search/Advanced.tpl
+++ b/templates/CRM/Contact/Form/Search/Advanced.tpl
@@ -13,8 +13,8 @@
 
   {include file="CRM/Contact/Form/Search/Intro.tpl"}
 
-  <details class="crm-advanced_search_form-accordion" {if !$rows}open{/if} >
-    <summary class="crm-master-accordion-header">
+  <details class="crm-accordion-light crm-advanced_search_form-accordion" {if !$rows}open{/if} >
+    <summary>
       {if !empty($savedSearch)}
         {ts 1=$savedSearch.name}Edit %1 Smart Group Criteria{/ts}
       {elseif !empty($ssID) or $rows}


### PR DESCRIPTION
The advanced search page is two template files - both adopted a combination of the new `<details>` accordion pattern with the old classnames during the Dec23 sprint. The other template file was fixed in #29704, this one was missed because it only appears on a search for `.crm-master-accordion-header` and the visual impact in Greenwich is tiny (in other themes it stands out more).

Before
----------------------------------------
Old classname. Barely noticeable via the bold text:
<img width="365" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/1b12b88b-31b0-4076-aea3-8c4a8d4889a6">

After
----------------------------------------
New classname. Text follows same appearance as other lighter style accordions.
<img width="300" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/1204197d-344e-40ed-af08-f652f384fbef">

Comments
----------------------------------------
I missed this in that last PR, sorry - the visual difference is tiny, but from a theming perspective this change should mean all of the old css accordion classnames aren't being used any more by core.