### PR TITLE
dev/core#5079 Handle money localization before anything else in formRule

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -998,11 +998,12 @@ class CRM_Financial_BAO_Order {
       elseif ($this->getPriceFieldMetadata($lineItem['price_field_id'])['name'] === 'other_amount') {
         // Other amount is a front end user entered form. It is reasonable to think it would be tax inclusive.
         $lineItem['line_total_inclusive'] = $lineItem['line_total'];
-        $lineItem['line_total'] = $lineItem['line_total_inclusive'] / (1 + ($lineItem['tax_rate'] / 100));
+        $lineItem['line_total'] = $lineItem['line_total_inclusive'] ? $lineItem['line_total_inclusive'] / (1 + ($lineItem['tax_rate'] / 100)) : 0;
         $lineItem['tax_amount'] = round($lineItem['line_total_inclusive'] - $lineItem['line_total'], 2);
         // Make sure they still add up to each other afer the rounding.
         $lineItem['line_total'] = $lineItem['line_total_inclusive'] - $lineItem['tax_amount'];
-        $lineItem['unit_price'] = $lineItem['line_total'] / $lineItem['qty'];
+        $lineItem['qty'] = 1;
+        $lineItem['unit_price'] = $lineItem['line_total'];
 
       }
       elseif ($taxRate) {


### PR DESCRIPTION
Overview
---------------------------------------

dev/core#5079 Handle money localization before anything else in formRule

Before
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/5079

After
----------------------------------------
Localized & non-numeric values are handled in the Contribution Main formRule function

Technical Details
----------------------------------------
This ensures the values are passed through the de-localization functions before any more handling is done

Comments
----------------------------------------
@MegaphoneJon 