### PR TITLE
dev/core#5090 Fix display of multiple autoselect custom fields

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1265,7 +1265,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
               }
               else {
                 if ($field['html_type'] === 'Autocomplete-Select') {
-                  $checkedValue = array_filter(explode(CRM_Core_DAO::VALUE_SEPARATOR, $value));
+                  $checkedValue = array_filter((array) \CRM_Utils_Array::explodePadded($value));
                   $defaults[$elementName] = implode(',', $checkedValue);
                   continue;
                 }

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1264,6 +1264,11 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
                 }
               }
               else {
+                if ($field['html_type'] === 'Autocomplete-Select') {
+                  $checkedValue = array_filter(explode(CRM_Core_DAO::VALUE_SEPARATOR, $value));
+                  $defaults[$elementName] = implode(',', $checkedValue);
+                  continue;
+                }
                 // Values may be "array strings" or actual arrays. Handle both.
                 if (is_array($value) && count($value)) {
                   CRM_Utils_Array::formatArrayKeys($value);
@@ -1274,7 +1279,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
                 }
                 foreach ($customOption as $val) {
                   if (in_array($val['value'], $checkedValue)) {
-                    if ($field['html_type'] == 'CheckBox') {
+                    if ($field['html_type'] === 'CheckBox') {
                       $defaults[$elementName][$val['value']] = 1;
                     }
                     else {


### PR DESCRIPTION



Overview
----------------------------------------
dev/core#5090 Fix display of multiple autoselect custom fields

This is a regression in the sense that the bug has always existed in the Custom Data loaded by ajax - but the event form newly loads it's custom data that way


Before
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/5090

Note the [test data](https://github.com/eileenmcnaughton/testdata) will create the relevant field

After
----------------------------------------
Saved custom data loads

![image](https://github.com/civicrm/civicrm-core/assets/336308/faecf5de-5059-4631-8162-d08927cb96c4)


Technical Details
----------------------------------------
@colemanw  - that function is a nightmare!! Is it really still that complicated?

Comments
----------------------------------------
