### PR TITLE
avoid divide-by-zero when validating 'other amount' on contribution pages

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -995,7 +995,7 @@ class CRM_Financial_BAO_Order {
       if ($this->getOverrideTotalAmount() !== FALSE) {
         $this->addTotalsToLineBasedOnOverrideTotal((int) $lineItem['financial_type_id'], $lineItem);
       }
-      elseif ($this->getPriceFieldMetadata($lineItem['price_field_id'])['name'] === 'other_amount') {
+      elseif ($this->getPriceFieldMetadata($lineItem['price_field_id'])['name'] === 'other_amount' && $lineItem['line_total']) {
         // Other amount is a front end user entered form. It is reasonable to think it would be tax inclusive.
         $lineItem['line_total_inclusive'] = $lineItem['line_total'];
         $lineItem['line_total'] = $lineItem['line_total_inclusive'] / (1 + ($lineItem['tax_rate'] / 100));


### PR DESCRIPTION
Overview
----------------------------------------
A proposed fix for https://lab.civicrm.org/dev/core/-/issues/5079, and an alternate to https://github.com/civicrm/civicrm-core/pull/29717.

Before
----------------------------------------
Submitting alpha characters in "Other Amount" gives a divide-by-zero error.

After
----------------------------------------
Fails validation.

Technical Details
----------------------------------------
This works because `getLine()` a few lines above will return zero here.  But a code comment says `getLine()` is getting phased out so maybe this needs to be handled higher up?