### PR TITLE
Warn when disabling/deleting groups which feature in smart group criteria 

### DIFF
--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -241,23 +241,21 @@ class CRM_Admin_Page_AJAX {
 
         case 'CRM_Contact_BAO_Group':
           $ret['content'] = ts('Are you sure you want to disable this Group?');
-          $smartGroupsReferencingThisGroup = CRM_Contact_BAO_Group::getSmartGroupsUsingGroup($recordID);
-          if (!empty($smartGroupsReferencingThisGroup)) {
-            $ret['content'] .= '<br /><br /><strong>';
-            $ret['content'] .= ts('WARNING this Group is currently referenced by %1 group/s',
-                                  [1 => count($smartGroupsReferencingThisGroup)]);
-            $ret['content'] .= '</strong><ul>';
-
-            foreach ($smartGroupsReferencingThisGroup as $group_id => $group_title) {
-              $ret['content'] .= '<li>' . ts('Group id: %1 title: %2 ', [
-                1 => $group_id,
-                2 => $group_title,
+          $sgContent = '';
+          $sgReferencingThisGroup = CRM_Contact_BAO_SavedSearch::getSmartGroupsUsingGroup($recordID);
+          if (!empty($sgReferencingThisGroup)) {
+            $sgContent .= '<br /><br /><strong>' . ts('WARNING - This Group is currently referenced by %1 smart group(s).', [
+              1 => count($sgReferencingThisGroup),
+            ]) . '</strong><ul>';
+            foreach ($sgReferencingThisGroup as $gid => $group) {
+              $sgContent .= '<li>' . ts('%1 <a class="action-item crm-hover-button" href="%2" target="_blank">Edit Smart Group Criteria</a>', [
+                1 => $group['title'],
+                2 => $group['editSearchURL'],
               ]) . '</li>';
             }
-            $ret['content'] .= '</ul>';
-            $ret['content'] .= ts('Disabling this group will cause these groups to no longer restrict members based on membership in this group. Please edit and remove this group as a criteria from these smart groups.') . '<br /><br />';
+            $sgContent .= '</ul>' . ts('Disabling this group will cause these groups to no longer restrict members based on membership in this group. Please edit and remove this group as a criteria from these smart groups.');
           }
-          $ret['content'] .= '<br /><br /><strong>' . ts('WARNING - Disabling this group will disable all the child groups associated if any.') . '</strong>';
+          $ret['content'] .= $sgContent . '<br /><br /><strong>' . ts('WARNING - Disabling this group will disable all the child groups associated if any.') . '</strong>';
           break;
 
         case 'CRM_Core_BAO_OptionGroup':

--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -241,6 +241,22 @@ class CRM_Admin_Page_AJAX {
 
         case 'CRM_Contact_BAO_Group':
           $ret['content'] = ts('Are you sure you want to disable this Group?');
+          $smartGroupsReferencingThisGroup = CRM_Contact_BAO_Group::getSmartGroupsUsingGroup($recordID);
+          if (!empty($smartGroupsReferencingThisGroup)) {
+            $ret['content'] .= '<br /><br /><strong>';
+            $ret['content'] .= ts('WARNING this Group is currently referenced by %1 group/s',
+                                  [1 => count($smartGroupsReferencingThisGroup)]);
+            $ret['content'] .= '</strong><ul>';
+
+            foreach ($smartGroupsReferencingThisGroup as $group_id => $group_title) {
+              $ret['content'] .= '<li>' . ts('Group id: %1 title: %2 ', [
+                1 => $group_id,
+                2 => $group_title,
+              ]) . '</li>';
+            }
+            $ret['content'] .= '</ul>';
+            $ret['content'] .= ts('Disabling this group will cause these groups to no longer restrict members based on membership in this group. Please edit and remove this group as a criteria from these smart groups.') . '<br /><br />';
+          }
           $ret['content'] .= '<br /><br /><strong>' . ts('WARNING - Disabling this group will disable all the child groups associated if any.') . '</strong>';
           break;
 

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1443,39 +1443,6 @@ WHERE {$whereClause}";
   }
 
   /**
-   * Gets all smart groups that filter based on groupID.
-   *
-   * @param int $groupID
-   *     Group Id to search for.
-   * @return array
-   */
-  public static function getSmartGroupsUsingGroup(int $groupID) {
-    $savedSearches = Group::get(FALSE)
-      ->addSelect('id', 'title', 'saved_search_id', 'saved_search_id.form_values')
-      ->addWhere('saved_search_id', 'IS NOT NULL')
-      ->setLimit(0)
-      ->execute();
-    $failingSmartGroups = [];
-    foreach ($savedSearches as $savedSearch) {
-      // Filter out arrays in Form Values which are group searchs.
-      $groupSearches = array_filter(
-        $savedSearch['saved_search_id.form_values'],
-        function($v) {
-          return ($v[0] == 'group');
-        }
-      );
-      // Check each group search for valid groups.
-      $failingGroups = [];
-      foreach ($groupSearches as $groupSearch) {
-        if (!empty($groupSearch[2]['IN']) && in_array($groupID, $groupSearch[2]['IN'])) {
-          $failingSmartGroups[$savedSearch['id']] = $savedSearch['title'];
-        }
-      }
-    }
-    return $failingSmartGroups;
-  }
-
-  /**
    * Check write access.
    * @see \Civi\Api4\Utils\CoreUtil::checkAccessRecord
    */

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -378,4 +378,40 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
       ->column('title_plural');
   }
 
+  /**
+   * Gets all smart groups that filter based on groupID.
+   *
+   * @param int $groupID
+   *     Group Id to search for.
+   * @return array
+   */
+  public static function getSmartGroupsUsingGroup(int $groupID) {
+    $groups = \Civi\Api4\Group::get(FALSE)
+      ->addSelect('id', 'title', 'saved_search_id', 'saved_search_id.form_values')
+      ->addWhere('saved_search_id', 'IS NOT NULL')
+      ->addWhere('saved_search_id.form_values', 'CONTAINS', 'group')
+      ->setLimit(0)
+      ->execute();
+    $smartGroups = [];
+    foreach ($groups as $group) {
+      // Filter out arrays in Form Values which are group searchs.
+      $groupSearches = array_filter(
+        $group['saved_search_id.form_values'],
+        function($v) {
+          return ($v[0] == 'group');
+        }
+      );
+      // Check each group search for valid groups.
+      foreach ($groupSearches as $groupSearch) {
+        if (!empty($groupSearch[2]) && in_array($groupID, $groupSearch[2])) {
+          $smartGroups[$group['id']] = [
+            'title' => $group['title'],
+            'editSearchURL' => self::getEditSearchUrl($group['saved_search_id']),
+          ];
+        }
+      }
+    }
+    return $smartGroups;
+  }
+
 }

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -125,8 +125,7 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
           }
         }
         $this->assign('count', $count ?? NULL);
-        $smartGroupsUsingThisGroup = CRM_Contact_BAO_Group::getSmartGroupsUsingGroup($this->_id);
-        $this->assign('smartGroupsUsingThisGroup', $smartGroupsUsingThisGroup);
+        $this->assign('smartGroupsUsingThisGroup', CRM_Contact_BAO_SavedSearch::getSmartGroupsUsingGroup($this->_id));
         $this->setTitle(ts('Confirm Group Delete'));
       }
       if ($this->_groupValues['is_reserved'] == 1 && !CRM_Core_Permission::check('administer reserved groups')) {

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -125,6 +125,8 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
           }
         }
         $this->assign('count', $count ?? NULL);
+        $smartGroupsUsingThisGroup = CRM_Contact_BAO_Group::getSmartGroupsUsingGroup($this->_id);
+        $this->assign('smartGroupsUsingThisGroup', $smartGroupsUsingThisGroup);
         $this->setTitle(ts('Confirm Group Delete'));
       }
       if ($this->_groupValues['is_reserved'] == 1 && !CRM_Core_Permission::check('administer reserved groups')) {

--- a/templates/CRM/Group/Form/Delete.tpl
+++ b/templates/CRM/Group/Form/Delete.tpl
@@ -17,6 +17,15 @@
     {if $count !== NULL}
         {ts count=$count plural='This group currently has %count members in it.'}This group currently has one member in it.{/ts}
     {/if}
+
+    {if $smartGroupsUsingThisGroup}
+    <p>Deleting this group will mean the following Smart Groups will no longer restrict based on membership in this group - as they do currently. Please edit and resave these smart groups to remove reference to this group before deleting.</p>
+    <ul>
+    {foreach from=$smartGroupsUsingThisGroup item=v key=k}
+         <li>{$v} <a href='civicrm/group/search?force=1&context=smog&gid={$k}&component_mode=1'>Edit Group</a></li>
+    {/foreach}
+    </ul>
+    {/if}
     {ts}Deleting this group will NOT delete the member contact records. However, all contact subscription information and history for this group will be deleted.{/ts} {ts}If this group is used in CiviCRM profiles, those fields will be reset.{/ts} {ts}This action cannot be undone.{/ts}
     </div>
 

--- a/templates/CRM/Group/Form/Delete.tpl
+++ b/templates/CRM/Group/Form/Delete.tpl
@@ -18,15 +18,19 @@
         {ts count=$count plural='This group currently has %count members in it.'}This group currently has one member in it.{/ts}
     {/if}
 
-    {if $smartGroupsUsingThisGroup}
-    <p>Deleting this group will mean the following Smart Groups will no longer restrict based on membership in this group - as they do currently. Please edit and resave these smart groups to remove reference to this group before deleting.</p>
-    <ul>
-    {foreach from=$smartGroupsUsingThisGroup item=v key=k}
-         <li>{$v} <a href='civicrm/group/search?force=1&context=smog&gid={$k}&component_mode=1'>Edit Group</a></li>
-    {/foreach}
-    </ul>
-    {/if}
     {ts}Deleting this group will NOT delete the member contact records. However, all contact subscription information and history for this group will be deleted.{/ts} {ts}If this group is used in CiviCRM profiles, those fields will be reset.{/ts} {ts}This action cannot be undone.{/ts}
+
+    {if $smartGroupsUsingThisGroup}
+      <p><strong>{ts 1=$smartGroupsUsingThisGroup|count}WARNING - This Group is currently referenced by %1 smart group(s).{/ts}</strong></p>
+      <p>{ts}Deleting this group will mean the following Smart Groups will no longer restrict based on membership in this group - as they do currently. Please edit and resave these smart groups to remove reference to this group before deleting.{/ts}</p>
+      <ul>
+      {foreach from=$smartGroupsUsingThisGroup item=group key=k}
+        <li>
+          {ts 1=$group.editSearchURL 2=$group.title}%2 <a class='action-item crm-hover-button' href="%1" target="_blank">Edit Smart Group Criteria</a>{/ts}
+        </li>
+      {/foreach}
+      </ul>
+    {/if}
     </div>
 
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>


### PR DESCRIPTION
Overview
----------------------------------------
Resubmission of Luke's PR https://github.com/civicrm/civicrm-core/pull/26088 with rebase + additional fixes.

Before
----------------------------------------
It's not obvious when disabling or deleting a group that a smart group built from this group will act unpredictably.

There are warnings about what happens when you disable a group but no reference to dependent smart groups and no indication of which smart groups are involved.

After
----------------------------------------
Adds a warning when user disables/deletes a group listing which groups are potentially problematic.

**Disable Alert**

![image](https://github.com/civicrm/civicrm-core/assets/5929648/449aa4b3-65fe-43e9-9b8e-61a6de375f03)

**Delete Form Alert**

![image](https://github.com/civicrm/civicrm-core/assets/5929648/73638fa4-fe64-41f6-9af6-b35df01b1f8a)
