### PR TITLE
CiviCampaign - Fix function signature incompatibility crash in Survey form

### DIFF
--- a/CRM/Campaign/Form/Survey/Main.php
+++ b/CRM/Campaign/Form/Survey/Main.php
@@ -98,7 +98,7 @@ class CRM_Campaign_Form_Survey_Main extends CRM_Campaign_Form_Survey {
   /**
    * Build the form object.
    */
-  public function buildQuickForm() {
+  public function buildQuickForm(): void {
     $this->add('text', 'title', ts('Title'), CRM_Core_DAO::getAttribute('CRM_Campaign_DAO_Survey', 'title'), TRUE);
 
     // Activity Type id

--- a/CRM/Campaign/Form/Survey/Questions.php
+++ b/CRM/Campaign/Form/Survey/Questions.php
@@ -47,7 +47,7 @@ class CRM_Campaign_Form_Survey_Questions extends CRM_Campaign_Form_Survey {
   /**
    * Build the form object.
    */
-  public function buildQuickForm() {
+  public function buildQuickForm(): void {
     $subTypeId = CRM_Core_DAO::getFieldValue('CRM_Campaign_DAO_Survey', $this->_surveyId, 'activity_type_id');
     if (!self::autoCreateCustomGroup($subTypeId)) {
       // everything

--- a/CRM/Campaign/Form/Survey/Results.php
+++ b/CRM/Campaign/Form/Survey/Results.php
@@ -83,7 +83,7 @@ class CRM_Campaign_Form_Survey_Results extends CRM_Campaign_Form_Survey {
   /**
    * Build the form object.
    */
-  public function buildQuickForm() {
+  public function buildQuickForm(): void {
     $optionGroups = CRM_Campaign_BAO_Survey::getResultSets();
 
     if (empty($optionGroups)) {


### PR DESCRIPTION
Fixes regression from 7479e9a4ae0c74faef53ac91b12fc43799db325a 
`Fatal error: Declaration of CRM_Campaign_Form_Survey_Main::buildQuickForm() must be compatible with CRM_Campaign_Form_Survey::buildQuickForm(): void`
