### PR TITLE
WIP: Fix for https://lab.civicrm.org/dev/core/-/issues/5095

### DIFF
--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -546,7 +546,7 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
           str_contains($clause, 'civicrm_employer_contact_target_employer') ||
           str_contains($clause, 'civicrm_address_')
         ) {
-          $this->_selectClauses[$key] = "GROUP_CONCAT(DISTINCT $clause SEPARATOR ';') as $clause";
+          $this->_selectClauses[$key] = "GROUP_CONCAT(DISTINCT $clause ORDER BY civicrm_contact_contact_source, civicrm_contact_contact_assignee, civicrm_contact_contact_target SEPARATOR ';') as $clause";
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Reference original issue: https://lab.civicrm.org/dev/core/-/issues/5095 : 
"CRM_Report_Form_Activity: links to target / assigned contacts are often incorrect"

Before
----------------------------------------
Links often point to wrong contact.

After
----------------------------------------
Links point to the correct contact(s).
Sorting of names within each column is maintained, based on contact.sort_name.

Technical Details
----------------------------------------
Sure, it would be nice to do as the code comments in this file suggest (in several places):

```
      // @todo - fix up the way the tables are declared in construct & remove this.
```
But that seems more effort that it's worth at this point.
