### PR TITLE
Add test check on imported multple fields

### DIFF
--- a/tests/phpunit/CRM/Custom/Import/Parser/ApiTest.php
+++ b/tests/phpunit/CRM/Custom/Import/Parser/ApiTest.php
@@ -4,6 +4,8 @@
  * File for the CRM_Custom_Import_Parser_ContributionTest class.
  */
 
+use Civi\Api4\CustomValue;
+
 /**
  *  Test Contribution import parser.
  *
@@ -42,6 +44,11 @@ class CRM_Custom_Import_Parser_ApiTest extends CiviUnitTestCase {
     $this->assertEquals('ERROR', $row['_status']);
     $row = $dataSource->getRow();
     $this->assertEquals('IMPORTED', $row['_status'], $row['_status_message']);
+    $values = CustomValue::get('level', FALSE)
+      ->addWhere('entity_id', '=', $row['the_contact_id'])->execute();
+    $this->assertEquals(['R'], $values[0]['Pick_Color']);
+    $this->assertEquals(['R'], $values[1]['Pick_Color']);
+    $this->assertEquals(['R', 'Y'], $values[2]['Pick_Color']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Add test check on imported multple fields

Before
----------------------------------------
Tobias advised that the custom field import is not working for single values -but the test covers single values

https://github.com/civicrm/civicrm-core/pull/29116/files#diff-b0a832d42a7b0d28fe5892d808ff55514a5e832e3c895290a62de52bdc2b5e6aL2

I thought maybe it wasn't erroring but not importing so I extended the test to check

After
----------------------------------------
They are importing but test covers that now

Technical Details
----------------------------------------

Comments
----------------------------------------
