### PR TITLE
Update registered Smarty modifiers (once packages PR merged)

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -170,9 +170,10 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
     }
     $this->loadFilter('pre', 'resetExtScope');
     $this->loadFilter('pre', 'htxtFilter');
-    $this->registerPlugin('modifier', 'json_encode', 'json_encode');
-    $this->registerPlugin('modifier', 'count', 'count');
-    $this->registerPlugin('modifier', 'implode', 'implode');
+    // This is used on the manage extensions page - we do plan on replacing it
+    // but perhaps no harm to add in trim anyway.
+    $this->registerPlugin('modifier', 'trim', 'trim');
+    // Smarty now supports substr natively but str_starts_with is kinda nicer.
     $this->registerPlugin('modifier', 'str_starts_with', 'str_starts_with');
 
     $this->assign('crmPermissions', new CRM_Core_Smarty_Permissions());


### PR DESCRIPTION
Overview
----------------------------------------
Update registered Smarty modifiers

Before
----------------------------------------
`trim` not registered as  a custom modifier, `json_encode` `count` and `implode` are 

After
----------------------------------------
The reverse is true

Technical Details
----------------------------------------
With https://github.com/civicrm/civicrm-packages/pull/392 merged we no longer need to register some native php functions as modifiers that have been made core in smarty

Conversely I have added trim as a modifier as that is hit on manage extensions page & I guess adding it is fairly harmless


Comments
----------------------------------------
Will not pass tests until the packges PR is merged