### PR TITLE
Fix notice on Membership form custom data loading

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -205,7 +205,7 @@
             {$form.receipt_text.html|crmAddClass:huge}</td>
         </tr>
       </table>
-      {include file="CRM/common/customDataBlock.tpl"}
+      {include file="CRM/common/customDataBlock.tpl" cid=false}
       {if $accessContribution and $action eq 2 and $rows.0.contribution_id}
         <details class="crm-accordion-bold" open>
           <summary>{ts}Related Contributions{/ts}</summary>


### PR DESCRIPTION
Overview
----------------------------------------
Fix notice on Membership form custom data loading

Before
----------------------------------------
notice on cid not set

![image](https://github.com/civicrm/civicrm-core/assets/336308/cd16cff0-d0f3-41b7-ad65-0bfbaef51ee2)


After
----------------------------------------
gone

Technical Details
----------------------------------------
cid is generally null when customDataBlock is called - the exception being activity data


Comments
----------------------------------------
