### PR TITLE
SearchKit - Move search tasks to their respective component-extensions

### DIFF
--- a/ext/civi_contribute/Civi/Api4/Service/ContributionTasksProvider.php
+++ b/ext/civi_contribute/Civi/Api4/Service/ContributionTasksProvider.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service;
+
+use CRM_Contribute_ExtensionUtil as E;
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * @service
+ * @internal
+ */
+class ContributionTasksProvider extends \Civi\Core\Service\AutoSubscriber {
+
+  public static function getSubscribedEvents(): array {
+    return [
+      'hook_civicrm_searchKitTasks' => 'addContributionTasks',
+    ];
+  }
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $event
+   */
+  public function addContributionTasks(GenericHookEvent $event): void {
+    // FIXME: CRM_Contribute_Task::tasks() should respect `$this->checkPermissions`
+    foreach (\CRM_Contribute_Task::tasks() as $id => $task) {
+      if (!empty($task['url'])) {
+        $path = explode('?', $task['url'], 2)[0];
+        $menu = \CRM_Core_Menu::get($path);
+        $key = $menu ? \CRM_Core_Key::get($menu['page_callback'], TRUE) : '';
+
+        $event->tasks['Contribution']['contribution.' . $id] = [
+          'title' => $task['title'],
+          'icon' => $task['icon'] ?? 'fa-gear',
+          'crmPopup' => [
+            'path' => "'{$task['url']}'",
+            'data' => "{id: ids.join(','), qfKey: '$key'}",
+          ],
+        ];
+      }
+    }
+  }
+
+}

--- a/ext/civi_mail/Civi/Api4/Service/MailTasksProvider.php
+++ b/ext/civi_mail/Civi/Api4/Service/MailTasksProvider.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service;
+
+use CRM_Mailing_ExtensionUtil as E;
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * @service
+ * @internal
+ */
+class MailTasksProvider extends \Civi\Core\Service\AutoSubscriber {
+
+  public static function getSubscribedEvents(): array {
+    return [
+      'hook_civicrm_searchKitTasks' => 'addMailTasks',
+    ];
+  }
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $event
+   */
+  public function addMailTasks(GenericHookEvent $event): void {
+    if (
+        \CRM_Core_Permission::access('CiviMail') || !$event->checkPermissions ||
+        (\CRM_Mailing_Info::workflowEnabled() && \CRM_Core_Permission::check('create mailings'))
+      ) {
+      $event->tasks['Contact']['contact.mailing'] = [
+        'title' => E::ts('Email - schedule/send via CiviMail'),
+        'uiDialog' => ['templateUrl' => '~/crmSearchTasks/crmSearchTaskMailing.html'],
+        'icon' => 'fa-paper-plane',
+      ];
+    }
+  }
+
+}

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -195,36 +195,6 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
           ],
         ];
       }
-      if (\CRM_Core_Component::isEnabled('CiviMail') && (
-        \CRM_Core_Permission::access('CiviMail') || !$this->checkPermissions ||
-        (\CRM_Mailing_Info::workflowEnabled() && \CRM_Core_Permission::check('create mailings'))
-      )) {
-        $tasks[$entity['name']]['contact.mailing'] = [
-          'title' => E::ts('Email - schedule/send via CiviMail'),
-          'uiDialog' => ['templateUrl' => '~/crmSearchTasks/crmSearchTaskMailing.html'],
-          'icon' => 'fa-paper-plane',
-        ];
-      }
-    }
-
-    if ($entity['name'] === 'Contribution') {
-      // FIXME: tasks() function always checks permissions, should respect `$this->checkPermissions`
-      foreach (\CRM_Contribute_Task::tasks() as $id => $task) {
-        if (!empty($task['url'])) {
-          $path = explode('?', $task['url'], 2)[0];
-          $menu = \CRM_Core_Menu::get($path);
-          $key = \CRM_Core_Key::get($menu['page_callback'], TRUE);
-
-          $tasks[$entity['name']]['contribution.' . $id] = [
-            'title' => $task['title'],
-            'icon' => $task['icon'] ?? 'fa-gear',
-            'crmPopup' => [
-              'path' => "'{$task['url']}'",
-              'data' => "{id: ids.join(','), qfKey: '$key'}",
-            ],
-          ];
-        }
-      }
     }
 
     // Call `hook_civicrm_searchKitTasks` which serves 3 purposes:


### PR DESCRIPTION
Overview
----------------------------------------
Moves some code into a better place.

Technical Details
----------------------------------------
This fixes some of the code under this fixme:
https://github.com/civicrm/civicrm-core/blob/05dd5142039298fb1d334df55c21ba9f3deceb7d/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php#L139-L140