### PR TITLE
[REF] Fix showing Main Email field only hwen email doesn't exist in a…

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -340,7 +340,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     }
 
     $this->applyFilter('__ALL__', 'trim');
-    $this->assign('showMainEmail', empty($this->_ccid));
+    $this->assign('showMainEmail', (empty($this->_ccid) && $this->_emailExists === FALSE));
     if (empty($this->_ccid)) {
       if ($this->_emailExists == FALSE) {
         $this->add('text', "email-{$this->_bltID}",

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -354,7 +354,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     // current contribution page id
     $this->getContributionPageID();
     $this->_ccid = CRM_Utils_Request::retrieve('ccid', 'Positive', $this);
-    $this->_emailExists = $this->get('emailExists');
+    $this->_emailExists = $this->get('emailExists') ?? FALSE;
 
     $this->_contactID = $this->_membershipContactID = $this->getContactID();
 


### PR DESCRIPTION
… profile

Overview
----------------------------------------
This Fixes a regression whereby the form variable showMainEmail is being wrongly set to true when the email field exists in the profile. This is a regression from 5.70 specifically https://github.com/civicrm/civicrm-core/commit/ee88ac225f48bd4b7a1cba9740040941b1d049a4#diff-9319a4134599e85c273c3be5706ffb5d642b7659904fd644dd4273791467384aR345 where the showMainEmail was only true previously where ccid was empty AND emailExists is FALSE

Before
----------------------------------------
Email field potentially being shown twice

After
----------------------------------------
Email field shown correctly if no profile shows it