### PR TITLE
Don't clear the smarty debugging var

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -293,11 +293,15 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
   /**
    * Clear template variables, except session or config.
    *
+   * Also the debugging variable because during test runs initialize() is only
+   * called once at the start but the var gets indirectly accessed by a couple
+   * tests that test forms.
+   *
    * @return void
    */
   public function clearTemplateVars(): void {
     foreach (array_keys($this->getTemplateVars()) as $key) {
-      if ($key === 'config' || $key === 'session') {
+      if ($key === 'config' || $key === 'session' || $key === 'debugging') {
         continue;
       }
       $this->clearAssign($key);


### PR DESCRIPTION
Overview
----------------------------------------
This causes problems in unit tests because smarty is a static singleton, so if the vars get cleared in between tests then this causes an undefined array key when running on some form tests.

Before
----------------------------------------
If your site url is localhost, you'll see the test fails if you run the crm suite. If it's not named localhost, like in the PR test runs here, you can make the change I was going to make here https://github.com/civicrm/civicrm-core/pull/28795/files, and then you can see there it generates some test fails.

Note to see the fails you need to have it run at least one test first that includes a call to somewhere in civi that calls clearTemplateVars. Just running a single test won't show it.

After
----------------------------------------


Technical Details
----------------------------------------
I debated where to handle this. Since the cause is a call to clearTemplateVars, it makes some sense to put it there. In normal UI usage this shouldn't make a difference since the static is reset as usual when you navigate. In cli usage, it's not even clear what you would want this variable to do for you, since it does things like pop up the smarty debug window, or other things which you can get at in better ways via code if it's cli.

Comments
----------------------------------------

