### PR TITLE
relabel searchkit tabs

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -43,17 +43,17 @@
       },
       {
         key: 'fields',
-        title: ts('Select Fields'),
+        title: ts('Field Transformations'),
         icon: 'fa-columns',
       },
       {
         key: 'settings',
-        title: ts('Configure Settings'),
+        title: ts('Save Options'),
         icon: 'fa-gears',
       },
       {
         key: 'query',
-        title: ts('Query Info'),
+        title: ts('Debug Info'),
         icon: 'fa-info-circle',
       },
     ];

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
@@ -41,12 +41,12 @@
 
       // Add callbacks for pre & post run
       this.onPreRun.push(function(apiCalls) {
-        // So the raw SQL can be shown in the "Query Info" tab
+        // So the raw SQL can be shown in the "Debug Info" tab
         apiCalls.run[2].debug = true;
       });
 
       this.onPostRun.push(function(apiResults) {
-        // Add debug output (e.g. raw SQL) to the "Query Info" tab
+        // Add debug output (e.g. raw SQL) to the "Debug Info" tab
         ctrl.debug.sql = apiResults.run.debug.sql;
         ctrl.debug.timeIndex = apiResults.run.debug.timeIndex;
       });


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5099

The recent addition of tabs to SK's UI makes sense, but the labels are ambiguous and trip up users.

Before
----------------------------------------
Ambiguous label names.

After
----------------------------------------
Slightly less ambiguous names.


Comments
----------------------------------------
Yes, this is bikeshedding bait.  That is by design.  My only criterium here was "better in than out", but I'd rather we not change them a second time (unless we're reorganizing the tabs' contents).  So enter the tab naming contest!