### PR TITLE
Remove deprecated misspelled event

### DIFF
--- a/CRM/Core/Block.php
+++ b/CRM/Core/Block.php
@@ -392,16 +392,6 @@ class CRM_Core_Block {
 
     $values = [];
 
-    // Deprecated hook with typo.  Please don't use this!
-    CRM_Utils_Hook::links('create.new.shorcuts',
-      NULL,
-      CRM_Core_DAO::$_nullObject,
-      $values
-    );
-    if ($values) {
-      CRM_Core_Error::deprecatedWarning('hook_civicrm_links "create.new.shorcuts" deprecated in favor of "create.new.shortcuts"');
-    }
-
     foreach ($shortCuts as $key => $short) {
       $values[$key] = self::setShortCutValues($short);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Removes long-deprecated event with spelling error.

Technical Details
----------------------------------------
'shorcuts' was misspelled and has been documented as deprecated since 2018, with noisy notices for the past 2 years since 79ba796ca945fb347e97098467c94c65b7d20349

Comments
------------
Only one use found in `universe` so I submitted a MR: https://lab.civicrm.org/extensions/grant_program
FYI @JoeMurray 