### PR TITLE
Copy small functions back to callers

### DIFF
--- a/CRM/Contact/Form/CustomData.php
+++ b/CRM/Contact/Form/CustomData.php
@@ -182,7 +182,10 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
           ]);
         }
       }
-      return CRM_Custom_Form_CustomData::buildQuickForm($this);
+      $this->addElement('hidden', 'hidden_custom', 1);
+      $this->addElement('hidden', "hidden_custom_group_count[{$this->_groupID}]", $this->_groupCount);
+      CRM_Core_BAO_CustomGroup::buildQuickForm($this, $this->_groupTree);
+      return;
     }
 
     //need to assign custom data type and subtype to the template
@@ -239,7 +242,8 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
         }
       }
       else {
-        $customDefaultValue = CRM_Custom_Form_CustomData::setDefaultValues($this);
+        $customDefaultValue = [];
+        CRM_Core_BAO_CustomGroup::setDefaults($this->_groupTree, $customDefaultValue, FALSE, FALSE, $this->get('action'));
       }
       return $customDefaultValue;
     }

--- a/CRM/Contact/Form/Edit/CustomData.php
+++ b/CRM/Contact/Form/Edit/CustomData.php
@@ -66,7 +66,9 @@ class CRM_Contact_Form_Edit_CustomData {
       $form->_customValueCount = $customValueCount;
       $form->assign('customValueCount', $customValueCount);
     }
-    CRM_Custom_Form_CustomData::buildQuickForm($form);
+    $form->addElement('hidden', 'hidden_custom', 1);
+    $form->addElement('hidden', "hidden_custom_group_count[{$form->_groupID}]", $form->_groupCount);
+    CRM_Core_BAO_CustomGroup::buildQuickForm($form, $form->_groupTree);
 
     //build custom data.
     $contactSubType = NULL;
@@ -91,7 +93,8 @@ class CRM_Contact_Form_Edit_CustomData {
    */
   public static function setDefaultValues(&$form, &$defaults) {
     CRM_Core_Error::deprecatedFunctionWarning('take a copy?');
-    $defaults += CRM_Custom_Form_CustomData::setDefaultValues($form);
+    CRM_Core_BAO_CustomGroup::setDefaults($form->_groupTree, $defaults, FALSE, FALSE, $form->get('action'));
+    return $defaults;
   }
 
 }

--- a/CRM/Contact/Form/Inline/CustomData.php
+++ b/CRM/Contact/Form/Inline/CustomData.php
@@ -54,7 +54,9 @@ class CRM_Contact_Form_Inline_CustomData extends CRM_Contact_Form_Inline {
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
-    CRM_Custom_Form_CustomData::buildQuickForm($this);
+    $this->addElement('hidden', 'hidden_custom', 1);
+    $this->addElement('hidden', "hidden_custom_group_count[{$this->_groupID}]", $this->_groupCount);
+    CRM_Core_BAO_CustomGroup::buildQuickForm($this, $this->_groupTree);
   }
 
   /**
@@ -63,7 +65,9 @@ class CRM_Contact_Form_Inline_CustomData extends CRM_Contact_Form_Inline {
    * @return array
    */
   public function setDefaultValues() {
-    return CRM_Custom_Form_CustomData::setDefaultValues($this);
+    $defaults = [];
+    CRM_Core_BAO_CustomGroup::setDefaults($this->_groupTree, $defaults, FALSE, FALSE, $this->get('action'));
+    return $defaults;
   }
 
   /**


### PR DESCRIPTION


Overview
----------------------------------------
Copy small functions back to callers

Before
----------------------------------------
These functions don't help us by sharing code because they are a) small
b) require variables to be passed by setting them as properties in once function to get them in the next

After
----------------------------------------
These forms now have their own copies

Technical Details
----------------------------------------

Comments
----------------------------------------
