### PR TITLE
Register trim as a  smarty plugin

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -170,10 +170,15 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
     }
     $this->loadFilter('pre', 'resetExtScope');
     $this->loadFilter('pre', 'htxtFilter');
+    // In theory json_encode, count & implode no longer need to
+    // be added as they are now more natively supported in smarty4, smarty5
     $this->registerPlugin('modifier', 'json_encode', 'json_encode');
     $this->registerPlugin('modifier', 'count', 'count');
     $this->registerPlugin('modifier', 'implode', 'implode');
+    // We use str_starts_with to check if a field is (e.g 'phone_' in profile presentation.
     $this->registerPlugin('modifier', 'str_starts_with', 'str_starts_with');
+    // Trim is used on the extensions page.
+    $this->registerPlugin('modifier', 'trim', 'trim');
 
     $this->assign('crmPermissions', new CRM_Core_Smarty_Permissions());
 


### PR DESCRIPTION
Overview
---------------------------------------
Register trim as a plugin

Before
----------------------------------------
deprecation notices on the manage extensions page

After
----------------------------------------
gone

Technical Details
----------------------------------------
@demeritcowboy @colemanw I put this up mostly to highlight that there are 2 ways to address the deprecation notices like the one in https://github.com/civicrm/civicrm-core/pull/29755 - 

1) use a different modifier
2) declare the modifier like this

I have gone back & forwards on whether we should do 1 or 2 in this case since it seems kinda harmless to register trim but it's also an annoying usage both cos it's plain fugly & probably should be done in the php layer & because we want to kill off that page anyway

Comments
----------------------------------------
