### PR TITLE
`hook_civicrm_links` - don't pass `objectId` by-reference

### DIFF
--- a/CRM/Contact/Page/View/UserDashBoard.php
+++ b/CRM/Contact/Page/View/UserDashBoard.php
@@ -240,7 +240,7 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
     // call the hook so we can modify it
     CRM_Utils_Hook::links('view.contact.userDashBoard',
       'Contact',
-      CRM_Core_DAO::$_nullObject,
+      NULL,
       self::$_links
     );
     return self::$_links;

--- a/CRM/Core/Block.php
+++ b/CRM/Core/Block.php
@@ -399,7 +399,7 @@ class CRM_Core_Block {
     // Hook that enables extensions to add user-defined links
     CRM_Utils_Hook::links('create.new.shortcuts',
       NULL,
-      CRM_Core_DAO::$_nullObject,
+      NULL,
       $values
     );
 

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -438,7 +438,7 @@ abstract class CRM_Utils_Hook {
    * @return null
    *   the return value is ignored
    */
-  public static function links($op, $objectName, &$objectId, &$links, &$mask = NULL, &$values = []) {
+  public static function links($op, $objectName, $objectId, &$links, &$mask = NULL, &$values = []) {
     return self::singleton()->invoke(['op', 'objectName', 'objectId', 'links', 'mask', 'values'], $op, $objectName, $objectId, $links, $mask, $values, 'civicrm_links');
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Removes an unnecessary and potentially bug-inviting pass-by-reference.


Comments
----------------------------------------
There is no reasonable use-case for using this hook to change the id of an entity. Attempting to do so would surely break things in unpredictable ways.
Also, this param is not documented as by-ref in the [hook documentation](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_links/).