### PR TITLE
SpecFormatter: Use number field for data type `Money`

### DIFF
--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -154,6 +154,15 @@ class SpecFormatter {
     if ($inputType == 'Date' && !empty($inputAttrs['format_type'])) {
       self::setLegacyDateFormat($inputAttrs);
     }
+    $dataTypeName = $fieldSpec->getDataType();
+    // Number input for numeric fields
+    if ($inputType === 'Text' && in_array($dataTypeName, ['Integer', 'Float', 'Money'], TRUE)) {
+      $inputType = 'Number';
+    }
+    if ($inputType === 'Number') {
+      // Todo: make 'step' configurable for the custom field
+      $inputAttrs['step'] ??= $dataTypeName === 'Integer' ? 1 : 'any';
+    }
     if ($inputType == 'Text' && !empty($data['maxlength'])) {
       $inputAttrs['maxlength'] = (int) $data['maxlength'];
     }

--- a/tests/phpunit/api/v4/Custom/CustomFieldGetFieldsTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomFieldGetFieldsTest.php
@@ -59,17 +59,17 @@ class CustomFieldGetFieldsTest extends Api4TestBase {
         [
           'name' => 'int',
           'data_type' => 'Int',
-          'html_type' => 'Text',
+          'html_type' => 'Number',
         ],
         [
           'name' => 'float',
           'data_type' => 'Float',
-          'html_type' => 'Text',
+          'html_type' => 'Number',
         ],
         [
           'name' => 'money',
           'data_type' => 'Money',
-          'html_type' => 'Text',
+          'html_type' => 'Number',
         ],
         [
           'name' => 'memo',
@@ -179,16 +179,16 @@ class CustomFieldGetFieldsTest extends Api4TestBase {
     $field = $fields["$customGroupName.float"];
     $this->assertSame('Number', $field['input_type']);
     $this->assertSame('Float', $field['data_type']);
-    $this->assertSame(.01, $field['input_attrs']['step']);
+    $this->assertSame('any', $field['input_attrs']['step']);
     $this->assertFalse($field['options']);
     $this->assertNull($field['operators']);
     $this->assertNull($field['serialize']);
 
     // Check money field
     $field = $fields["$customGroupName.money"];
-    $this->assertSame('Text', $field['input_type']);
+    $this->assertSame('Number', $field['input_type']);
     $this->assertSame('Money', $field['data_type']);
-    $this->assertArrayNotHasKey('step', $field['input_attrs']);
+    $this->assertSame('any', $field['input_attrs']['step']);
     $this->assertFalse($field['options']);
     $this->assertNull($field['operators']);
     $this->assertNull($field['serialize']);


### PR DESCRIPTION
Overview
----------------------------------------
Use a HTML number input field if field data type is `Money` (i.e. the corresponding integer). It is also ensured that `step` is set, even if the given HTML input was already `Number`.

Before
----------------------------------------
A HTML number input field is used for fields with data type `Integer` and `Float`, but not for `Money`.

The `step` is set to `1` for integers and `.01` for floats, but only if the given HTML type is `Text` and not if it is already `Number`.

After
----------------------------------------
A HTML number input field is used for data type `Money`, too.

The `step` is set even if the given HTML type is already `Number`.

Comments
----------------------------------------
Maybe for the `step` the database could be checked, too.
