### PR TITLE
[REF] Do not add arrays consisting of just the auto renew as options …

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -675,12 +675,15 @@ class CRM_Financial_BAO_Order {
       $metadata[$index]['supports_auto_renew'] = FALSE;
       if ($this->isExcludeExpiredFields && !$priceField['is_active']) {
         unset($metadata[$index]);
+        continue;
       }
       if ($this->isExcludeExpiredFields && !empty($priceField['active_on']) && time() < strtotime($priceField['active_on'])) {
         unset($metadata[$index]);
+        continue;
       }
       elseif ($this->isExcludeExpiredFields && !empty($priceField['expire_on']) && strtotime($priceField['expire_on']) < time()) {
         unset($metadata[$index]);
+        continue;
       }
       elseif (!empty($priceField['options'])) {
         foreach ($priceField['options'] as $optionID => $option) {


### PR DESCRIPTION
…for disabled fields

Overview
----------------------------------------
When loading up a front end contribution form disabled price fields can still be included in the array but with the only key in the options being the auto renew key

Before
----------------------------------------
Price set metadata array polluted by keys not needed

After
----------------------------------------
Price set metadata array correctly built