### PR TITLE
[REF] Remove purify calls for labelfrom quickform which are not needed

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -495,7 +495,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         $check = [];
         foreach ($customOption as $opId => $opt) {
           $priceOptionText = self::buildPriceOptionText($opt, $field->is_display_amounts, $valueFieldName);
-          $check[$opId] = &$qf->createElement('checkbox', $opt['id'], NULL, $priceOptionText['label'],
+          $check[$opId] = &$qf->createElement('checkbox', $opt['id'], NULL, CRM_Utils_String::purifyHTML($priceOptionText['label']),
             [
               'price' => json_encode([$opt['id'], $priceOptionText['priceVal']]),
               'data-amount' => $opt[$valueFieldName],

--- a/templates/CRM/Price/Form/Field.tpl
+++ b/templates/CRM/Price/Form/Field.tpl
@@ -81,12 +81,12 @@
 <div class="crm-block crm-form-block crm-price-field-form-block">
   <table class="form-layout">
     <tr class="crm-price-field-form-block-label">
-      <td class="label">{$form.label.label|smarty:nodefaults|purify}</td>
+      <td class="label">{$form.label.label|smarty:nodefaults}</td>
       <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_price_field' field='label' id=$fid}{/if}{$form.label.html}
       </td>
     </tr>
     <tr class="crm-price-field-form-block-html_type">
-      <td class="label">{$form.html_type.label|smarty:nodefaults|purify}</td>
+      <td class="label">{$form.html_type.label|smarty:nodefaults}</td>
       <td>{$form.html_type.html}
       </td>
     </tr>
@@ -103,7 +103,7 @@
   <div id="price-block" {if $action eq 2 && $form.html_type.value.0 eq 'Text'} class="show-block" {else} class="hiddenElement" {/if}>
     <table class="form-layout">
       <tr class="crm-price-field-form-block-price">
-        <td class="label">{$form.price.label|smarty:nodefaults|purify} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></td>
+        <td class="label">{$form.price.label|smarty:nodefaults} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></td>
         <td>{$form.price.html}
         {if $action neq 4}
           <br /><span class="description">{ts}Unit price.{/ts}</span> {help id="id-negative"}
@@ -111,25 +111,25 @@
         </td>
       </tr>
       <tr class="crm-price-field-form-block-non-deductible-amount">
-        <td class="label">{$form.non_deductible_amount.label|smarty:nodefaults|purify}</td>
+        <td class="label">{$form.non_deductible_amount.label|smarty:nodefaults}</td>
         <td>{$form.non_deductible_amount.html}</td>
       </tr>
     {if $useForEvent}
       <tr class="crm-price-field-form-block-count">
-        <td class="label">{$form.count.label|smarty:nodefaults|purify}</td>
+        <td class="label">{$form.count.label|smarty:nodefaults}</td>
         <td>{$form.count.html}<br />
           <span class="description">{ts}Enter a value here if you want to increment the number of registered participants per unit against the maximum number of participants allowed for this event.{/ts}</span>
           {help id="id-participant-count"}
         </td>
       </tr>
       <tr class="crm-price-field-form-block-max_value">
-        <td class="label">{$form.max_value.label|smarty:nodefaults|purify}</td>
+        <td class="label">{$form.max_value.label|smarty:nodefaults}</td>
         <td>{$form.max_value.html}
         </td>
       </tr>
     {/if}
       <tr class="crm-price-field-form-block-financial_type">
-        <td class="label">{$form.financial_type_id.label|smarty:nodefaults|purify}<span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></td></td>
+        <td class="label">{$form.financial_type_id.label|smarty:nodefaults}<span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></td></td>
         <td>
         {if !$financialType}
           {capture assign=ftUrl}{crmURL p='civicrm/admin/financial/financialType' q="reset=1"}{/capture}
@@ -169,7 +169,7 @@
     </tr>
 
     <tr class="crm-price-field-form-block-help_pre">
-      <td class="label">{$form.help_pre.label|smarty:nodefaults|purify}</td>
+      <td class="label">{$form.help_pre.label|smarty:nodefaults}</td>
       <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_price_field' field='help_pre' id=$fid}{/if}{$form.help_pre.html|crmAddClass:huge}&nbsp;
       {if $action neq 4}
         <div class="description">{ts}Explanatory text displayed to users at the beginning of this field.{/ts}</div>
@@ -178,7 +178,7 @@
     </tr>
 
     <tr class="crm-price-field-form-block-help_post">
-      <td class="label">{$form.help_post.label|smarty:nodefaults|purify}</td>
+      <td class="label">{$form.help_post.label|smarty:nodefaults}</td>
       <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_price_field' field='help_post' id=$fid}{/if}{$form.help_post.html|crmAddClass:huge}&nbsp;
       {if $action neq 4}
         <div class="description">{ts}Explanatory text displayed to users below this field.{/ts}</div>

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -32,7 +32,7 @@
             <div class="crm-section {$element.name|escape}-section crm-price-field-id-{$field_id}">
             {if ($element.html_type eq 'CheckBox' || $element.html_type == 'Radio') && $element.options_per_line}
               {assign var="element_name" value="price_`$field_id`"}
-              <div class="label">{$form.$element_name.label|purify}</div>
+              <div class="label">{$form.$element_name.label}</div>
               <div class="content {$element.name|escape}-content">
                 {assign var="elementCount" value="0"}
                 {assign var="optionCount" value="0"}
@@ -60,7 +60,7 @@
 
                 {assign var="element_name" value="price_"|cat:$field_id}
 
-                <div class="label">{$form.$element_name.label|purify}</div>
+                <div class="label">{$form.$element_name.label}</div>
                 <div class="content {$element.name|escape}-content">
                   {$form.$element_name.html}
                   {if $element.html_type eq 'Text'}
@@ -101,7 +101,7 @@
                   <div class='label'></div>
                   <div class='content' id="auto_renew_section">
                     {if $form.auto_renew}
-                      {$form.auto_renew.html}&nbsp;{$form.auto_renew.label|smarty:nodefaults|purify}
+                      {$form.auto_renew.html}&nbsp;{$form.auto_renew.label}
                     {/if}
                   </div>
                   <div class='content' id="force_renew" style='display: none'>{ts}Membership will renew automatically.{/ts}</div>


### PR DESCRIPTION
Overview
----------------------------------------
This removes the purify modify from various .label which is quickform label. This ensures that <label> tag and the for attribute are retained which are stripped by the purify HTML

Before
----------------------------------------
label tag removed by purify HTML

After
----------------------------------------
Label tag retained

Technical Details
----------------------------------------
The label parameter is generated by code rather than in general user input. In the one place which relates to checkboxes I have replaced the original  purify with something more appropriate. 

ping @eileenmcnaughton 