### PR TITLE
get any API param from the Api4Query class

### DIFF
--- a/Civi/Api4/Query/Api4Query.php
+++ b/Civi/Api4/Query/Api4Query.php
@@ -490,17 +490,24 @@ abstract class Api4Query {
   }
 
   /**
-   * @return \CRM_Utils_SQL_Select
-   */
-  public function getQuery() {
-    return $this->query;
-  }
-
-  /**
    * @return bool|string
    */
   public function getCheckPermissions() {
     return $this->api->getCheckPermissions();
+  }
+
+  /**
+   * @return mixed
+   */
+  public function getApiParam($param) {
+    return call_user_func([$this->api, 'get' . ucfirst($param)]);
+  }
+
+  /**
+   * @return \CRM_Utils_SQL_Select
+   */
+  public function getQuery() {
+    return $this->query;
   }
 
   /**


### PR DESCRIPTION
See https://lab.civicrm.org/dev/core/-/issues/5102

Note the diff looks weird as I re-orded the functions so that everything getting something from `$this->api` was consecutive.