### PR TITLE
Add filters to membership type sk on contact membership tab

### DIFF
--- a/ext/civicrm_admin_ui/ang/afformTabMember.aff.html
+++ b/ext/civicrm_admin_ui/ang/afformTabMember.aff.html
@@ -12,5 +12,5 @@
   <hr />
 </div>
 <div af-fieldset="" af-title="Membership Types">
-  <crm-search-display-table search-name="Contact_Summary_Membership_Type" display-name="Contact_Summary_Membership_Type"></crm-search-display-table>
+  <crm-search-display-table search-name="Contact_Summary_Membership_Type" display-name="Contact_Summary_Membership_Type" filters="{member_of_contact_id: options.contact_id, 'is_active': true}"></crm-search-display-table>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Followup PR for https://github.com/civicrm/civicrm-core/pull/28810 to fix membership type SK.

Before
----------------------------------------
Membership Type SK displays membership types for all organisation contacts.

After
----------------------------------------
Displays for only organisations stored for membership type.

Technical Details
----------------------------------------
Adds filters to form builder 

Comments
----------------------------------------
ping @colemanw 