### PR TITLE
dev/core#5100 Record other amount as unit price not quantity

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -981,7 +981,8 @@ class CRM_Financial_BAO_Order {
         $lineItem['tax_amount'] = round($lineItem['line_total_inclusive'] - $lineItem['line_total'], 2);
         // Make sure they still add up to each other afer the rounding.
         $lineItem['line_total'] = $lineItem['line_total_inclusive'] - $lineItem['tax_amount'];
-        $lineItem['unit_price'] = $lineItem['line_total'] / $lineItem['qty'];
+        $lineItem['qty'] = 1;
+        $lineItem['unit_price'] = $lineItem['line_total'];
 
       }
       elseif ($taxRate) {


### PR DESCRIPTION
Overview
----------------------------------------
If you create a contribution pages that allows other amounts the amount in that field is recorded in the quantity field of the line item rather than the unit price.

See https://lab.civicrm.org/dev/core/-/issues/5100

Before
----------------------------------------
Amount is recorded in quantity field. Unit price is $1.00.

![image](https://github.com/civicrm/civicrm-core/assets/13518928/ab213e1a-643d-43c3-96ae-0220043d07ac)


After
----------------------------------------
Quantity is 1. Amount is recorded in unit price.

![image](https://github.com/civicrm/civicrm-core/assets/13518928/d537ce2c-83dd-4e05-aa57-cf4cf77542ce)

Comments
----------------------------------------

This is a partial backport of #29717 to fix this specific issue. This isn't a full backport of #29717 because that also fixes dev/core#5079 which was introduced in CiviCRM 5.70 so the rest of the patch won't apply to 5.69.

Not sure if this is the right way to do this, but it would be good to get this in the next ESR point release if possible.
