### PR TITLE
Allow deletion of orphan payment activities

### DIFF
--- a/CRM/Activity/Selector/Activity.php
+++ b/CRM/Activity/Selector/Activity.php
@@ -135,6 +135,12 @@ class CRM_Activity_Selector_Activity extends CRM_Core_Selector_Base implements C
           $url = 'civicrm/contact/view/participant';
           $qsView = "action=view&reset=1&id={$participantId}&cid=%%cid%%&context=%%cxt%%{$extraParams}";
         }
+        else {
+          // Allow deletion of orphan activities if the contribution/participant was probably deleted
+          $url = 'civicrm/activity';
+          $showView = $showDelete = TRUE;
+          $qsView = "atype={$activityTypeId}&action=view&reset=1&id=%%id%%&cid=%%cid%%&context=%%cxt%%{$extraParams}";
+        }
         break;
 
       case 'Membership Signup':


### PR DESCRIPTION
Overview
----------------------------------------

To reproduce:

- Create a pending contribution
- Do a partial payment
- Delete the contribution

An activity about the payment will linger under the "Activities" tab of the contact. It cannot be viewed nor deleted.

Before
----------------------------------------

Cannot delete the orphan activity.

After
----------------------------------------

Activity can be deleted.

Comments
----------------------------------------

Ideally we should delete the orphan activity, but that seemed like a riskier venture.