### PR TITLE
(php83) UnitTests - Fix warning

### DIFF
--- a/CRM/Utils/System/UnitTests.php
+++ b/CRM/Utils/System/UnitTests.php
@@ -46,6 +46,19 @@ class CRM_Utils_System_UnitTests extends CRM_Utils_System_Base {
   }
 
   /**
+   * Send an HTTP Response base on PSR HTTP RespnseInterface response.
+   *
+   * @param \Psr\Http\Message\ResponseInterface $response
+   */
+  public function sendResponse(\Psr\Http\Message\ResponseInterface $response) {
+    // We'll if the simple version passes. If not, then we might need to enable `setHttpHeader()`.
+    // foreach ($response->getHeaders() as $name => $values) {
+    //   CRM_Utils_System::setHttpHeader($name, implode(', ', (array) $values));
+    // }
+    CRM_Utils_System::civiExit(0, ['response' => $response]);
+  }
+
+  /**
    * @param string $name
    * @param string $value
    */


### PR DESCRIPTION
Overview
------------

This fixes a warning when running tests on PHP 8.3

Scenario
--------

A test like `FlexMailerSystemTest::testHttpUnsubscribe()` emits a local-only HTTP response while executing (via `CRM_Utils_Sysmem::sendResponse()`).

Before
-------

`sendResponse()` goes through the motions of calling `http_response_code()` and similar methods. That's important for regular web-requests, but for headless testing, it's kinda pointless. (You're not actually processing a regular HTTP request.)

On PHP 8.3, it leads to a warning like:

http_response_code(): Cannot set response code - headers already sent (output started at phar:///home/homer/buildkit/extern/phpunit9/phpunit9.phar/phpunit/Util/Printer.php:82)

After
-----

Within the context of headless tests, it skips the exta call. `FlexMailerSystemTest::testHttpUnsubscribe()`  passes.
