### PR TITLE
Standalone - Separate HTML templates for frontend and backend UIs

### DIFF
--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -765,20 +765,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
    * @return string
    */
   public function getTemplateFile() {
-    if ($this->_print) {
-      if ($this->_print == CRM_Core_Smarty::PRINT_PAGE) {
-        return 'CRM/common/print.tpl';
-      }
-      elseif ($this->_print === 'xls' || $this->_print === 'doc') {
-        return 'CRM/Contact/Form/Task/Excel.tpl';
-      }
-      else {
-        return 'CRM/common/snippet.tpl';
-      }
-    }
-    else {
-      return CRM_Utils_System::getContentTemplate($this->_print);
-    }
+    return CRM_Utils_System::getContentTemplate($this->_print);
   }
 
   /**

--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -777,8 +777,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
       }
     }
     else {
-      $config = CRM_Core_Config::singleton();
-      return 'CRM/common/' . strtolower($config->userFramework) . '.tpl';
+      return CRM_Utils_System::getContentTemplate($this->_print);
     }
   }
 

--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -270,7 +270,7 @@ class CRM_Core_Page {
       CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'js/crm.livePage.js', 1, 'html-header');
     }
 
-    $content = self::$_template->fetch('CRM/common/' . strtolower($config->userFramework) . '.tpl');
+    $content = self::$_template->fetch(CRM_Utils_System::getContentTemplate());
 
     // Render page header
     if (!defined('CIVICRM_UF_HEAD') && $region = CRM_Core_Region::instance('html-header', FALSE)) {

--- a/CRM/Core/Selector/Controller.php
+++ b/CRM/Core/Selector/Controller.php
@@ -114,7 +114,7 @@ class CRM_Core_Selector_Controller {
    *   Should match a CRM_Core_Smarty::PRINT_* constant,
    *   or equal 0 if not in print mode
    */
-  protected $_print = FALSE;
+  protected $_print = 0;
 
   /**
    * The storage object (typically a form or a page)

--- a/CRM/Core/Selector/Controller.php
+++ b/CRM/Core/Selector/Controller.php
@@ -486,13 +486,8 @@ class CRM_Core_Selector_Controller {
     }
 
     self::$_template->assign('tplFile', $this->_object->getHookedTemplateFileName());
-    if ($this->_print) {
-      $content = self::$_template->fetch('CRM/common/print.tpl');
-    }
-    else {
-      $config = CRM_Core_Config::singleton();
-      $content = self::$_template->fetch('CRM/common/' . strtolower($config->userFramework) . '.tpl');
-    }
+    $contentTpl = CRM_Utils_System::getContentTemplate($this->_print);
+    $content = self::$_template->fetch($contentTpl);
     echo CRM_Utils_System::theme($content, $this->_print);
   }
 

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -24,7 +24,7 @@
  *
  * @method static void getCMSPermissionsUrlParams() Immediately stop script execution and display a 401 "Access Denied" page.
  * @method static mixed permissionDenied() Show access denied screen.
- * @method static string getContentTemplate(bool $print) Get the template path to render whole content.
+ * @method static string getContentTemplate(int|string $print = 0) Get the template path to render whole content.
  * @method static mixed logout() Log out the current user.
  * @method static mixed updateCategories() Clear CMS caches related to the user registration/profile forms.
  * @method static void appendBreadCrumb(array $breadCrumbs) Append an additional breadcrumb link to the existing breadcrumbs.

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -24,6 +24,7 @@
  *
  * @method static void getCMSPermissionsUrlParams() Immediately stop script execution and display a 401 "Access Denied" page.
  * @method static mixed permissionDenied() Show access denied screen.
+ * @method static string getContentTemplate(bool $print) Get the template path to render whole content.
  * @method static mixed logout() Log out the current user.
  * @method static mixed updateCategories() Clear CMS caches related to the user registration/profile forms.
  * @method static void appendBreadCrumb(array $breadCrumbs) Append an additional breadcrumb link to the existing breadcrumbs.

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -72,13 +72,28 @@ abstract class CRM_Utils_System_Base {
    * Returns the Smarty template path to the main template that renders the content.
    *
    * In CMS contexts, this goes inside their theme, but Standalone needs to render the full HTML page.
+   *
+   * @var int|string $print
+   *   Should match a CRM_Core_Smarty::PRINT_* constant,
+   *   or equal 0 if not in print mode.
    */
-  public static function getContentTemplate(bool $print = FALSE, bool $frontEnd = FALSE): string {
-    if ($print) {
-      return 'CRM/common/print.tpl';
+  public static function getContentTemplate($print = 0): string {
+    switch ($print) {
+      case 0:
+        // Not a print context.
+        $config = CRM_Core_Config::singleton();
+        return 'CRM/common/' . strtolower($config->userFramework) . '.tpl';
+
+      case CRM_Core_Smarty::PRINT_PAGE:
+        return 'CRM/common/print.tpl';
+
+      case 'xls':
+      case 'doc':
+        return 'CRM/Contact/Form/Task/Excel.tpl';
+
+      default:
+        return 'CRM/common/print.tpl';
     }
-    $config = CRM_Core_Config::singleton();
-    return 'CRM/common/' . strtolower($config->userFramework) . '.tpl';
   }
 
   /**

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -69,6 +69,19 @@ abstract class CRM_Utils_System_Base {
   abstract public function loadBootStrap($params = [], $loadUser = TRUE, $throwError = TRUE, $realPath = NULL);
 
   /**
+   * Returns the Smarty template path to the main template that renders the content.
+   *
+   * In CMS contexts, this goes inside their theme, but Standalone needs to render the full HTML page.
+   */
+  public static function getContentTemplate(bool $print = FALSE, bool $frontEnd = FALSE): string {
+    if ($print) {
+      return 'CRM/common/print.tpl';
+    }
+    $config = CRM_Core_Config::singleton();
+    return 'CRM/common/' . strtolower($config->userFramework) . '.tpl';
+  }
+
+  /**
    * Append an additional breadcrumb tag to the existing breadcrumb.
    *
    * @param array $breadCrumbs

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -92,7 +92,7 @@ abstract class CRM_Utils_System_Base {
         return 'CRM/Contact/Form/Task/Excel.tpl';
 
       default:
-        return 'CRM/common/print.tpl';
+        return 'CRM/common/snippet.tpl';
     }
   }
 

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -253,9 +253,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
     if ($print) {
       return 'CRM/common/print.tpl';
     }
-    $isPublic = \CRM_Core_Smarty::singleton()->getTemplateVars('urlIsPublic');
-    // Alternative:
-    // $isPublic = ($_GET['q'] ?? '') ? CRM_Core_Menu::isPublicRoute($_GET['q']) : FALSE;
+    $isPublic = CRM_Utils_System::isFrontEndPage();
     return $isPublic ? 'CRM/common/standalone-frontend.tpl' : 'CRM/common/standalone.tpl';
   }
 
@@ -384,6 +382,10 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
       return $civicrm_paths['cms.root']['path'];
     }
     throw new \RuntimeException("Standalone requires the path is set for now. Set \$civicrm_paths['cms.root']['path'] in civicrm.settings.php to the webroot.");
+  }
+
+  public function isFrontEndPage() {
+    return CRM_Core_Menu::isPublicRoute(CRM_Utils_System::currentPath() ?? '');
   }
 
   /**

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -247,6 +247,20 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
 
   /**
    * @inheritDoc
+   *
+   */
+  public static function getContentTemplate(bool $print = FALSE, bool $frontEnd = FALSE): string {
+    if ($print) {
+      return 'CRM/common/print.tpl';
+    }
+    $isPublic = \CRM_Core_Smarty::singleton()->getTemplateVars('urlIsPublic');
+    // Alternative:
+    // $isPublic = ($_GET['q'] ?? '') ? CRM_Core_Menu::isPublicRoute($_GET['q']) : FALSE;
+    return $isPublic ? 'CRM/common/standalone-frontend.tpl' : 'CRM/common/standalone.tpl';
+  }
+
+  /**
+   * @inheritDoc
    */
   public function theme(&$content, $print = FALSE, $maintenance = FALSE) {
 

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -248,13 +248,17 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    *
+   * Standalone offers different HTML templates for front and back-end routes.
+   *
    */
-  public static function getContentTemplate(bool $print = FALSE, bool $frontEnd = FALSE): string {
+  public static function getContentTemplate($print = 0): string {
     if ($print) {
-      return 'CRM/common/print.tpl';
+      return parent::getContentTemplate($print);
     }
-    $isPublic = CRM_Utils_System::isFrontEndPage();
-    return $isPublic ? 'CRM/common/standalone-frontend.tpl' : 'CRM/common/standalone.tpl';
+    else {
+      $isPublic = CRM_Utils_System::isFrontEndPage();
+      return $isPublic ? 'CRM/common/standalone-frontend.tpl' : 'CRM/common/standalone.tpl';
+    }
   }
 
   /**

--- a/templates/CRM/common/standalone-frontend.tpl
+++ b/templates/CRM/common/standalone-frontend.tpl
@@ -1,0 +1,67 @@
+<!DOCTYPE html >
+<html lang="{$config->lcMessages|substr:0:2}" class="crm-standalone crm-public" >
+ <head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" type="image/png" href="{$config->resourceBase}i/logo_lg.png" >
+
+  {* @todo crmRegion below should replace this, but not working? *}
+  {if isset($pageHTMLHead)}
+    {foreach from=$pageHTMLHead item=i}
+      {$i}
+    {/foreach}
+  {/if}
+
+  {crmRegion name='html-header'}
+  {/crmRegion}
+
+  <title>{if isset($docTitle)}{$docTitle}{else}CiviCRM{/if}</title>
+</head>
+<body>
+  {if $config->debug}
+  {include file="CRM/common/debug.tpl"}
+  {/if}
+
+  <div id="crm-container" class="crm-container standalone-page-padding" lang="{$config->lcMessages|substr:0:2}" xml:lang="{$config->lcMessages|substr:0:2}">
+    {if $breadcrumb}
+      <nav aria-label="{ts}Breadcrumb{/ts}" class="breadcrumb"><ol>
+        <li><a href="/civicrm/dashboard?reset=1" >{ts}Home{/ts}</a></li>
+        {foreach from=$breadcrumb item=crumb key=key}
+          <li><a href="{$crumb.url}">{$crumb.title}</a></li>
+        {/foreach}
+      </ol></nav>
+    {/if}
+
+    {if $standaloneErrors}
+      <div class="standalone-errors">
+        <ul>{$standaloneErrors}</ul>
+      </div>
+    {/if}
+
+    {if $pageTitle}
+      <div class="crm-page-title-wrapper">
+        <h1 class="crm-page-title">{$pageTitle}</h1>
+      </div>
+    {/if}
+
+    {crmRegion name='page-header'}
+    {/crmRegion}
+
+    <div class="clear"></div>
+
+    <div id="crm-main-content-wrapper">
+      {crmRegion name='page-body'}
+        {if isset($isForm) and $isForm and isset($formTpl)}
+          {include file="CRM/Form/$formTpl.tpl"}
+        {else}
+          {include file=$tplFile}
+        {/if}
+      {/crmRegion}
+    </div>
+
+    {crmRegion name='page-footer'}
+      {include file="CRM/common/publicFooter.tpl"}
+    {/crmRegion}
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Overview
----------------------------------------

This adds an HTML template for public-facing pages, e.g. Event registrations, unsubscribe etc.

Before
----------------------------------------

Only one HTML template, used for all pages

After
----------------------------------------

standalone-frontend.tpl is used for frontend pages.

Technical Details
----------------------------------------

- Until standalone, this wasn't necessary; the CMS would deal with the `<html>` level anyway. So the codebase to-date had assumed just to bring in a single template with the name of the UF.
- I centralised identifying the template to use into a `CRM_Utils_System` method, and implemented the current code on `CRM_Utils_System_Base` for all the CMSes, and standalone's on `CRM_Utils_System_Standalone`.
- Currently there are only very minor differences in the standalone-frontend.tpl, including adding `crm-public` on the `<html>` element (really just so I could see it was working...) and removing some bits that are definitely not for front-end use.
- The purpose of this is to allow people to make their own themed front end pages.

