### PR TITLE
php8.2 Remove non-compliant code replaced by jquery validation

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -294,6 +294,11 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address implements Civi\Core\Hoo
 
     $config = CRM_Core_Config::singleton();
     foreach ($params as $name => $value) {
+      if (is_array($value) && str_starts_with($name, 'custom_')) {
+        // This could be a custom field of type file. We want to unset these as they could
+        // give false positives.
+        unset($value['error'], $value['size']);
+      }
       if (in_array($name, [
         'is_primary',
         'location_type_id',


### PR DESCRIPTION

Overview
----------------------------------------
php8.2 Remove non-compliant code replaced by jquery validation

Before
----------------------------------------
Noticey code sets property that is not reached

After
----------------------------------------
Code removed

This code is called from the contact form & the inline address form. It sets up information about required custom fields to be enforced in the form rule.

However, on testing I found that the form rule is not reached in either form because jquery validation prevents form submission

![image](https://github.com/civicrm/civicrm-core/assets/336308/954e4fb1-32c9-41ee-89d5-494c9c1a2446)

![image](https://github.com/civicrm/civicrm-core/assets/336308/c464381f-b404-4963-9d64-a737fd14a311)



Technical Details
----------------------------------------

Comments
----------------------------------------
