### PR TITLE
Stop calling complex function to just add a field

### DIFF
--- a/CRM/Contact/Form/Domain.php
+++ b/CRM/Contact/Form/Domain.php
@@ -120,7 +120,14 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
     //build location blocks.
     $this->assign('addressSequence', CRM_Core_BAO_Address::addressSequence());
     CRM_Contact_Form_Edit_Address::buildQuickForm($this, 1);
-    CRM_Contact_Form_Edit_Email::buildQuickForm($this, 1);
+
+    //Email box
+    $this->addField("email[1][email]", [
+      'entity' => 'email',
+      'aria-label' => ts('Email %1', [1 => 1]),
+      'label' => ts('Email %1', [1 => 1]),
+    ]);
+    $this->addRule("email[1][email]", ts('Email is not valid.'), 'email');
     CRM_Contact_Form_Edit_Phone::buildQuickForm($this, 1);
 
     $this->addButtons([


### PR DESCRIPTION


Overview
----------------------------------------
Stop calling complex function to just add a field

Before
----------------------------------------
The function to add the email address to the form has code to add the email field and then a bunch of code that is bypassed when called from the Domain contact form.

This copies back the small amount of code that form is getting from the shared code, thus reducing complexity & improving php8.2 compliance

After
----------------------------------------
The few lines copied back - still saves on r-run

Technical Details
----------------------------------------

Comments
----------------------------------------
