### PR TITLE
Remove deprecated function

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4625,53 +4625,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
   }
 
   /**
-   * Do not use - unused in core.
-   *
-   * Function to replace contribution tokens.
-   *
-   * @param array $contributionIds
-   *
-   * @param string $subject
-   *
-   * @param array $subjectToken
-   *
-   * @param string $text
-   *
-   * @param string $html
-   *
-   * @param array $messageToken
-   *
-   * @param bool $escapeSmarty
-   *
-   * @deprecated
-   *
-   * @return array
-   * @throws \CRM_Core_Exception
-   */
-  public static function replaceContributionTokens(
-    $contributionIds,
-    $subject,
-    $subjectToken,
-    $text,
-    $html,
-    $messageToken,
-    $escapeSmarty
-  ) {
-    CRM_Core_Error::deprecatedFunctionWarning('use the TokenProcessor');
-    if (empty($contributionIds)) {
-      return [];
-    }
-    $contributionDetails = [];
-    foreach ($contributionIds as $id) {
-      $result = self::getContributionTokenValues($id, $messageToken);
-      $contributionDetails[$result['values'][$result['id']]['contact_id']]['subject'] = CRM_Utils_Token::replaceContributionTokens($subject, $result, FALSE, $subjectToken, FALSE, $escapeSmarty);
-      $contributionDetails[$result['values'][$result['id']]['contact_id']]['text'] = CRM_Utils_Token::replaceContributionTokens($text, $result, FALSE, $messageToken, FALSE, $escapeSmarty);
-      $contributionDetails[$result['values'][$result['id']]['contact_id']]['html'] = CRM_Utils_Token::replaceContributionTokens($html, $result, FALSE, $messageToken, FALSE, $escapeSmarty);
-    }
-    return $contributionDetails;
-  }
-
-  /**
    * Do not use - still called from CRM_Contribute_Form_Task_PDFLetter
    *
    * This needs to be refactored out of use & deprecated out of existence.


### PR DESCRIPTION
Overview
----------------------------------------
Remove deprecated function - function deprecated in 2022

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/6c9fe28b-5e8c-4912-9dd2-0c2d48e95344)


After
----------------------------------------
poof 


Technical Details
----------------------------------------
Function is called from 2 places outside of core.


![image](https://github.com/civicrm/civicrm-core/assets/336308/c3d7ecb9-467d-4b89-8ed5-7446430d6a44)

 The first usage is ONLY called on older CIviCRM versions as part of in-extension compatibility handling. However the invoiceHelper extension by @mlutfy calls this function so need BGM's input here - note that the extension 
- adds a cc field (that could be in core)
- improves token support - I think this is the addition of a payment url token which I think fits in a category of url tokens that might also go in core - probably supported by the api



Comments
----------------------------------------
