### PR TITLE
Update the handling of Case custom fields on Case form to use php8.2 happy pattern

### DIFF
--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -337,25 +337,6 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
   }
 
   /**
-   * Wrapper for unit testing the post process submit function.
-   *
-   * @param $params
-   * @param $activityTypeFile
-   * @param $contactId
-   * @param $context
-   * @return CRM_Case_BAO_Case
-   */
-  public function testSubmit($params, $activityTypeFile, $contactId, $context = "case") {
-    $this->controller = new CRM_Core_Controller();
-
-    $this->_activityTypeFile = $activityTypeFile;
-    $this->_currentUserId = $contactId;
-    $this->_context = $context;
-
-    return $this->submit($params);
-  }
-
-  /**
    * Submit the form with given params.
    *
    * @param $params

--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -177,8 +177,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
     }
     $this->assign('clientName', isset($this->_currentlyViewedContactId) ? $contact->display_name : NULL);
 
-    $session = CRM_Core_Session::singleton();
-    $this->_currentUserId = $session->get('userID');
+    $this->_currentUserId = CRM_Core_Session::getLoggedInContactID();
 
     //Add activity custom data is included in this page
     CRM_Custom_Form_CustomData::preProcess($this, NULL, $this->_activityTypeId, 1, 'Activity');

--- a/CRM/Case/Form/CaseFormTrait.php
+++ b/CRM/Case/Form/CaseFormTrait.php
@@ -1,0 +1,51 @@
+<?php
+
+use Civi\API\EntityLookupTrait;
+
+/**
+ * Trait implements functions to retrieve activity related values.
+ */
+trait CRM_Case_Form_CaseFormTrait {
+
+  use EntityLookupTrait;
+
+  /**
+   * Get the value for a field relating to the Case.
+   *
+   * All values returned in apiv4 format. Escaping may be required.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @param string $fieldName
+   *
+   * @return mixed
+   * @throws \CRM_Core_Exception
+   */
+  public function getCaseValue(string $fieldName) {
+    if ($this->isDefined('Case')) {
+      return $this->lookup('Case', $fieldName);
+    }
+    $id = $this->getCaseID();
+    if ($id) {
+      $this->define('Case', 'Case', ['id' => $id]);
+      return $this->lookup('Case', $fieldName);
+    }
+    return NULL;
+  }
+
+  /**
+   * Get the selected Case ID.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function getCaseID(): ?int {
+    throw new CRM_Core_Exception('`getCaseID` must be implemented');
+  }
+
+}

--- a/templates/CRM/Case/Form/Case.tpl
+++ b/templates/CRM/Case/Form/Case.tpl
@@ -97,7 +97,7 @@
 {* This shows CASE custom fields, as opposed to ACTIVITY custom fields, so is not a duplicate of the other custom data block above. *}
 <tr class="crm-case-form-block-custom_data">
     <td colspan="2">
-      {include file="CRM/common/customDataBlock.tpl" customDataType='Case'}
+      {include file="CRM/common/customDataBlock.tpl" customDataType='Case' customDataSubType=$caseTypeID cid=false}
     </td>
 </tr>
 

--- a/templates/CRM/common/customDataBlock.tpl
+++ b/templates/CRM/common/customDataBlock.tpl
@@ -17,3 +17,5 @@
   </script>
   {/literal}
 {/if}
+{* jQuery validate *}
+{include file="CRM/Form/validate.tpl"}

--- a/tests/phpunit/CRM/Activity/Form/ActivityViewTest.php
+++ b/tests/phpunit/CRM/Activity/Form/ActivityViewTest.php
@@ -63,7 +63,6 @@ class CRM_Activity_Form_ActivityViewTest extends CiviUnitTestCase {
    * Test that the smarty template for ActivityView contains what we expect
    * after preProcess().
    *
-   * @throws \CRM_Core_Exception
    */
   public function testActivityViewPreProcess(): void {
     // create activity


### PR DESCRIPTION


Overview
----------------------------------------
Update the handling of Case custom fields on Case form to use php8.2 happy pattern

Before
----------------------------------------
Complex php8.2 notice causing code used to load the case custom fields is inconsistent with the other places the data is loaded this way

After
----------------------------------------
Methodology aligned

Technical Details
----------------------------------------
There are 2 sets of custom fields on the Case form - Case & Activity

The former is loaded by ajax so this brings the way that is done inline with the other places that load custom fields by ajax

Comments
----------------------------------------
Note the addition of `validate.tpl` to the CustomData form is also in the Open PR to address campaign custom data loading