### PR TITLE
php8.2 Update Case form to handle both Activity & Case custom data with standard ajax methods

### DIFF
--- a/CRM/Case/Form/Activity/OpenCase.php
+++ b/CRM/Case/Form/Activity/OpenCase.php
@@ -31,8 +31,8 @@ class CRM_Case_Form_Activity_OpenCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public static function preProcess(&$form) {
-    if ($form->_context == 'caseActivity') {
+  public static function preProcess(&$form): void {
+    if ($form->_context === 'caseActivity') {
       $contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $form);
       $atype = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Change Case Start Date');
       $caseId = CRM_Utils_Array::first($form->_caseId);
@@ -74,7 +74,7 @@ class CRM_Case_Form_Activity_OpenCase {
    */
   public static function setDefaultValues(&$form) {
     $defaults = [];
-    if ($form->_context == 'caseActivity') {
+    if ($form->_context === 'caseActivity') {
       return $defaults;
     }
 
@@ -249,8 +249,8 @@ class CRM_Case_Form_Activity_OpenCase {
    *
    * @throws \Exception
    */
-  public static function endPostProcess(&$form, &$params) {
-    if ($form->_context == 'caseActivity') {
+  public static function endPostProcess($form, &$params): void {
+    if ($form->_context === 'caseActivity') {
       return;
     }
 

--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -230,7 +230,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
     }
     // Used for loading custom data fields
     $this->assign('activityTypeID', $this->_activityTypeId);
-    $this->assign('caseTypeID', $this->getSubmittedValue('case_type_id') ?: $this->getCaseValue('campaign_type_id'));
+    $this->assign('caseTypeID', $this->getSubmittedValue('case_type_id') ?: $this->getCaseValue('case_type_id'));
   }
 
   /**

--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -85,6 +85,21 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
   public $submitOnce = TRUE;
 
   /**
+   * @var float|int|mixed|string|null
+   *
+   * This is inconsistently set & likely to be replaced by a local variable or getter.
+   */
+  public $_contactID;
+
+  /**
+   * @var float|int|mixed|string|null
+   * @deprecated
+   *
+   * This is inconsistently set & likely to be replaced by a local variable or getter.
+   */
+  public $_caseStatusId;
+
+  /**
    * Explicitly declare the entity api name.
    */
   public function getDefaultEntity() {
@@ -189,7 +204,16 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
     $this->_currentUserId = CRM_Core_Session::getLoggedInContactID();
 
     $className = "CRM_Case_Form_Activity_{$this->_activityTypeFile}";
-    $className::preProcess($this);
+    switch ($className) {
+      // @todo flesh out this switch. Sure we hate switches but it's better than
+      // than the default below for code tracing purposes.
+      case 'CRM_Case_Form_Activity_OpenCase':
+        CRM_Case_Form_Activity_OpenCase::preProcess($this);
+        break;
+
+      default:
+        $className::preProcess($this);
+    }
 
     if ($this->isSubmitted()) {
       // The custom data fields are added to the form by an ajax form.

--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -337,25 +337,6 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
   }
 
   /**
-   * Wrapper for unit testing the post process submit function.
-   *
-   * @param $params
-   * @param $activityTypeFile
-   * @param $contactId
-   * @param $context
-   * @return CRM_Case_BAO_Case
-   */
-  public function testSubmit($params, $activityTypeFile, $contactId, $context = "case") {
-    $this->controller = new CRM_Core_Controller();
-
-    $this->_activityTypeFile = $activityTypeFile;
-    $this->_currentUserId = $contactId;
-    $this->_context = $context;
-
-    return $this->submit($params);
-  }
-
-  /**
    * Submit the form with given params.
    *
    * @param $params

--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -177,8 +177,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
     }
     $this->assign('clientName', isset($this->_currentlyViewedContactId) ? $contact->display_name : NULL);
 
-    $session = CRM_Core_Session::singleton();
-    $this->_currentUserId = $session->get('userID');
+    $this->_currentUserId = CRM_Core_Session::getLoggedInContactID();
 
     //Add activity custom data is included in this page
     CRM_Custom_Form_CustomData::preProcess($this, NULL, $this->_activityTypeId, 1, 'Activity');

--- a/CRM/Case/Form/CaseFormTrait.php
+++ b/CRM/Case/Form/CaseFormTrait.php
@@ -1,0 +1,51 @@
+<?php
+
+use Civi\API\EntityLookupTrait;
+
+/**
+ * Trait implements functions to retrieve activity related values.
+ */
+trait CRM_Case_Form_CaseFormTrait {
+
+  use EntityLookupTrait;
+
+  /**
+   * Get the value for a field relating to the Case.
+   *
+   * All values returned in apiv4 format. Escaping may be required.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @param string $fieldName
+   *
+   * @return mixed
+   * @throws \CRM_Core_Exception
+   */
+  public function getCaseValue(string $fieldName) {
+    if ($this->isDefined('Case')) {
+      return $this->lookup('Case', $fieldName);
+    }
+    $id = $this->getCaseID();
+    if ($id) {
+      $this->define('Case', 'Case', ['id' => $id]);
+      return $this->lookup('Case', $fieldName);
+    }
+    return NULL;
+  }
+
+  /**
+   * Get the selected Case ID.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function getCaseID(): ?int {
+    throw new CRM_Core_Exception('`getCaseID` must be implemented');
+  }
+
+}

--- a/CRM/Custom/Form/CustomDataTrait.php
+++ b/CRM/Custom/Form/CustomDataTrait.php
@@ -95,7 +95,12 @@ trait CRM_Custom_Form_CustomDataTrait {
     }
     $qf = $this->get('qfKey');
     $this->assign('qfKey', $qf);
-    Civi::cache('customData')->set($qf, $formValues);
+    // We cached the POSTed values so that they can be reloaded
+    // if the form fails to submit. Note that we may be combining the
+    // values with those stored by other custom field entities on the
+    // form.
+    $defaultValues = (array) Civi::cache('customData')->get($qf);
+    Civi::cache('customData')->set($qf, $formValues + $defaultValues);
   }
 
   /**

--- a/templates/CRM/Case/Form/Case.tpl
+++ b/templates/CRM/Case/Form/Case.tpl
@@ -58,11 +58,11 @@
 
 {* custom data group *}
 {* This shows ACTIVITY custom fields, as opposed to CASE custom fields, so is not a duplicate of the other custom data block below. *}
-{if $groupTree}
-    <tr>
-       <td colspan="2">{include file="CRM/Custom/Form/CustomData.tpl" skipTitle=0}</td>
-    </tr>
-{/if}
+<tr class="crm-activity-form-block-custom_data">
+  <td colspan="2">
+    {include file="CRM/common/customDataBlock.tpl" customDataType='Activity' customDataSubType=$activityTypeID cid=false}
+  </td>
+</tr>
 
 {if !empty($form.activity_subject.html)}
     <tr class="crm-case-form-block-activity_subject">

--- a/templates/CRM/Case/Form/Case.tpl
+++ b/templates/CRM/Case/Form/Case.tpl
@@ -97,7 +97,7 @@
 {* This shows CASE custom fields, as opposed to ACTIVITY custom fields, so is not a duplicate of the other custom data block above. *}
 <tr class="crm-case-form-block-custom_data">
     <td colspan="2">
-      {include file="CRM/common/customDataBlock.tpl" customDataType='Case'}
+      {include file="CRM/common/customDataBlock.tpl" customDataType='Case' customDataSubType=$caseTypeID cid=false}
     </td>
 </tr>
 

--- a/templates/CRM/Contact/Form/Contact.tpl
+++ b/templates/CRM/Contact/Form/Contact.tpl
@@ -78,7 +78,7 @@
 
     {foreach from = $editOptions item = "title" key="name"}
       {if $name eq 'CustomData'}
-        <div id='customData'>{include file="CRM/Contact/Form/Edit/CustomData.tpl" isSingleRecordEdit=false skipTitle=false}</div>
+        <div id='customData_{$contactType}'>{include file="CRM/Contact/Form/Edit/CustomData.tpl" isSingleRecordEdit=false skipTitle=false}</div>
       {else}
         {include file="CRM/Contact/Form/Edit/$name.tpl"}
       {/if}

--- a/templates/CRM/Contact/Form/CustomData.tpl
+++ b/templates/CRM/Contact/Form/CustomData.tpl
@@ -14,7 +14,7 @@
      <div class="crm-submit-buttons">{$form.buttons.html}</div>
    {/if}
 {else}
-    <div id="customData_{$contact_type}"></div>
+    <div id="customData_{$contact_type}" class="crm-customData-block"></div>
     <div class="crm-submit-buttons">{$form.buttons.html}</div>
 
     {*include custom data js file*}

--- a/templates/CRM/Contact/Form/CustomData.tpl
+++ b/templates/CRM/Contact/Form/CustomData.tpl
@@ -14,7 +14,7 @@
      <div class="crm-submit-buttons">{$form.buttons.html}</div>
    {/if}
 {else}
-    <div id="customData"></div>
+    <div id="customData_{$contact_type}"></div>
     <div class="crm-submit-buttons">{$form.buttons.html}</div>
 
     {*include custom data js file*}
@@ -45,4 +45,3 @@
   {/if}
   {include file="CRM/Form/attachmentjs.tpl"}
 {/if}
-

--- a/templates/CRM/Contact/Form/Edit/CustomData.tpl
+++ b/templates/CRM/Contact/Form/Edit/CustomData.tpl
@@ -18,7 +18,7 @@
     <summary>
       {$cd_edit.title}
     </summary>
-    <div id="customData_{$contactType}{$group_id}" class="crm-accordion-body">
+    <div id="customData_{$contactType}{$group_id}" class="crm-accordion-body crm-customData-block">
       {include file="CRM/Custom/Form/Edit/CustomData.tpl" customDataEntity=''}
       {include file="CRM/Form/attachmentjs.tpl"}
     </div>

--- a/templates/CRM/Contact/Form/Edit/CustomData.tpl
+++ b/templates/CRM/Contact/Form/Edit/CustomData.tpl
@@ -18,7 +18,7 @@
     <summary>
       {$cd_edit.title}
     </summary>
-    <div id="customData{$group_id}" class="crm-accordion-body">
+    <div id="customData_{$contactType}{$group_id}" class="crm-accordion-body">
       {include file="CRM/Custom/Form/Edit/CustomData.tpl" customDataEntity=''}
       {include file="CRM/Form/attachmentjs.tpl"}
     </div>

--- a/templates/CRM/Contact/Form/Relationship.tpl
+++ b/templates/CRM/Contact/Form/Relationship.tpl
@@ -56,7 +56,7 @@
           <td>{$form.is_active.html}</td>
         </tr>
       </table>
-      <div id="customData_Relationship"></div>
+      <div id="customData_Relationship" class="crm-customData-block"></div>
       <div class="spacer"></div>
     </div>
   {/if}

--- a/templates/CRM/Contact/Form/Relationship.tpl
+++ b/templates/CRM/Contact/Form/Relationship.tpl
@@ -56,7 +56,7 @@
           <td>{$form.is_active.html}</td>
         </tr>
       </table>
-      <div id="customData"></div>
+      <div id="customData_Relationship"></div>
       <div class="spacer"></div>
     </div>
   {/if}

--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -114,10 +114,10 @@
         </fieldset>
 
         <div class="crm-participant-form-block-customData">
-          <div id="customData" class="crm-customData-block"></div>  {* Participant Custom data *}
-          <div id="customData{$eventNameCustomDataTypeID}" class="crm-customData-block"></div> {* Event Custom Data *}
-          <div id="customData{$roleCustomDataTypeID}" class="crm-customData-block"></div> {* Role Custom Data *}
-          <div id="customData{$eventTypeCustomDataTypeID}" class="crm-customData-block"></div> {* Role Custom Data *}
+          <div id="customData_Participant" class="crm-customData-block"></div>  {* Participant Custom data *}
+          <div id="customData_Participant{$eventNameCustomDataTypeID}" class="crm-customData-block"></div> {* Event Custom Data *}
+          <div id="customData_Participant{$roleCustomDataTypeID}" class="crm-customData-block"></div> {* Role Custom Data *}
+          <div id="customData_Participant{$eventTypeCustomDataTypeID}" class="crm-customData-block"></div> {* Role Custom Data *}
         </div>
       {/if}
 

--- a/templates/CRM/common/customData.tpl
+++ b/templates/CRM/common/customData.tpl
@@ -13,7 +13,7 @@
     CRM.buildCustomData = function (type, subType, subName, cgCount, groupID, isMultiple, onlySubtype, cid) {
       var dataUrl = CRM.url('civicrm/custom', {type: type}),
         prevCount = 1,
-        fname = '#customData',
+        fname = '#customData_' + type,
         storage = {};
 
       if (subType) {
@@ -26,10 +26,10 @@
 
       if (subName) {
         dataUrl += '&subName=' + subName;
-        $('#customData' + subName).show();
+        $('#customData_' + type + subName).show();
       }
       else {
-        $('#customData').show();
+        $('#customData_' + type).show();
       }
       if (groupID) {
         dataUrl += '&groupID=' + groupID;

--- a/templates/CRM/common/customDataBlock.tpl
+++ b/templates/CRM/common/customDataBlock.tpl
@@ -1,6 +1,6 @@
 
 {if !empty($customDataType)}
-  <div id="customData"></div>
+  <div id="customData_{$customDataType}"></div>
   {*include custom data js file*}
   {include file="CRM/common/customData.tpl"}
   {literal}

--- a/templates/CRM/common/customDataBlock.tpl
+++ b/templates/CRM/common/customDataBlock.tpl
@@ -1,6 +1,6 @@
 
 {if !empty($customDataType)}
-  <div id="customData_{$customDataType}" class="crm-custom-data-container"></div>
+  <div id="customData_{$customDataType}" class="crm-customData-block"></div>
   {*include custom data js file*}
   {include file="CRM/common/customData.tpl"}
   {literal}

--- a/templates/CRM/common/customDataBlock.tpl
+++ b/templates/CRM/common/customDataBlock.tpl
@@ -1,6 +1,6 @@
 
 {if !empty($customDataType)}
-  <div id="customData_{$customDataType}"></div>
+  <div id="customData_{$customDataType}" class="crm-custom-data-container"></div>
   {*include custom data js file*}
   {include file="CRM/common/customData.tpl"}
   {literal}

--- a/tests/phpunit/CRM/Activity/Form/ActivityViewTest.php
+++ b/tests/phpunit/CRM/Activity/Form/ActivityViewTest.php
@@ -63,7 +63,6 @@ class CRM_Activity_Form_ActivityViewTest extends CiviUnitTestCase {
    * Test that the smarty template for ActivityView contains what we expect
    * after preProcess().
    *
-   * @throws \CRM_Core_Exception
    */
   public function testActivityViewPreProcess(): void {
     // create activity


### PR DESCRIPTION
Overview
----------------------------------------
Builds on #29798 to fully remove calls to complex legacy non-php8.2 compliant method of adding Custom Data to Case form
 
Can be most easily tested with https://github.com/eileenmcnaughton/testdata installed

Before
----------------------------------------
Case data loaded by Ajax, Activity form loaded using another method which we have mostly removed

After
----------------------------------------
Both loaded by ajax


Technical Details
----------------------------------------
Needed some tpl level tweaks to allow more than one customData type per page

Comments
----------------------------------------
Release notes should highlight that the id of the custom data blocks is now namespaced by entity - to allow more than 1 per form - but we ensured they all had the class `crm-customData-block` for jquery purposes 