### PR TITLE
Fix Test createCase to use full form flow rather than a hack-flow

### DIFF
--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -177,8 +177,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
     }
     $this->assign('clientName', isset($this->_currentlyViewedContactId) ? $contact->display_name : NULL);
 
-    $session = CRM_Core_Session::singleton();
-    $this->_currentUserId = $session->get('userID');
+    $this->_currentUserId = CRM_Core_Session::getLoggedInContactID();
 
     //Add activity custom data is included in this page
     CRM_Custom_Form_CustomData::preProcess($this, NULL, $this->_activityTypeId, 1, 'Activity');


### PR DESCRIPTION
Overview
----------------------------------------
Fix Test createCase to use full form flow rather than a hack-flow

Before
----------------------------------------
calls `testSubmit()`

After
----------------------------------------
uses preferred helper approach

Technical Details
----------------------------------------

Comments
----------------------------------------
Looks like this is not mergeable on it's own as it exposes php8.2 non-compliance to the test suite & we need all of https://github.com/civicrm/civicrm-core/pull/29799 to get that working
