### PR TITLE
Copy function back to one of the few remaining callers

### DIFF
--- a/CRM/Contact/Form/CustomData.php
+++ b/CRM/Contact/Form/CustomData.php
@@ -97,7 +97,7 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
       if (!empty($entityId)) {
         $subType = CRM_Contact_BAO_Contact::getContactSubType($entityId, ',');
       }
-      CRM_Custom_Form_CustomData::preProcess($this, NULL, $subType, NULL, CRM_Utils_Request::retrieve('type', 'String', $this), $entityId);
+      $this->preProcessCustomData(NULL, $subType, NULL, CRM_Utils_Request::retrieve('type', 'String', $this), $entityId);
       if ($this->_multiRecordDisplay) {
         $this->_groupID = CRM_Utils_Request::retrieve('groupID', 'Positive', $this);
         $this->_tableID = $this->_entityId;
@@ -143,10 +143,135 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
     // when custom data is included in this page
     if (!empty($_POST['hidden_custom'])) {
       for ($i = 1; $i <= $_POST['hidden_custom_group_count'][$this->_groupID]; $i++) {
-        CRM_Custom_Form_CustomData::preProcess($this, NULL, $this->_contactSubType, $i, $this->_contactType, $this->_tableID);
-        CRM_Custom_Form_CustomData::buildQuickForm($this);
-        CRM_Custom_Form_CustomData::setDefaultValues($this);
+        $this->preProcessCustomData(NULL, $this->_contactSubType, $i, $this->_contactType, $this->_tableID);
+        $this->addElement('hidden', 'hidden_custom', 1);
+        $this->addElement('hidden', "hidden_custom_group_count[{$this->_groupID}]", $this->_groupCount);
+        CRM_Core_BAO_CustomGroup::buildQuickForm($this, $this->_groupTree);
       }
+    }
+  }
+
+  /**
+   * Previously shared function
+   *
+   * @param null|string $extendsEntityColumn
+   *   Additional filter on the type of custom data to retrieve - e.g for
+   *   participant data this could be a value representing role.
+   * @param null|string $subType
+   * @param null|int $groupCount
+   * @param null $type
+   * @param null|int $entityID
+   * @param null $onlySubType
+   * @param bool $isLoadFromCache
+   *
+   * @throws \CRM_Core_Exception
+   *
+   * @deprecated see https://github.com/civicrm/civicrm-core/pull/29241 for preferred approach - basically
+   * 1) at the tpl layer use CRM/common/customDataBlock.tpl
+   * 2) to make the fields available for postProcess
+   * if ($this->isSubmitted()) {
+   *   $this->addCustomDataFieldsToForm('FinancialAccount');
+   * }
+   * 3) pass getSubmittedValues() to CRM_Core_BAO_CustomField::postProcess($this->getSubmittedValues(), $this->_id, 'FinancialAccount');
+   *  to ensure any money or number fields are handled for localisation
+   */
+  private function preProcessCustomData(
+    $extendsEntityColumn = NULL, $subType = NULL,
+    $groupCount = NULL, $type = NULL, $entityID = NULL, $onlySubType = NULL, $isLoadFromCache = TRUE
+  ) {
+    $form = $this;
+    if (!$type) {
+      CRM_Core_Error::deprecatedWarning('type should be passed in');
+      $type = CRM_Utils_Request::retrieve('type', 'String', $form);
+    }
+
+    if (!isset($subType)) {
+      $subType = CRM_Utils_Request::retrieve('subType', 'String', $form);
+    }
+    if ($subType === 'null') {
+      // Is this reachable?
+      $subType = NULL;
+    }
+    $extendsEntityColumn = $extendsEntityColumn ?: CRM_Utils_Request::retrieve('subName', 'String', $form);
+    if ($extendsEntityColumn === 'null') {
+      // Is this reachable?
+      $extendsEntityColumn = NULL;
+    }
+
+    if ($groupCount) {
+      $form->_groupCount = $groupCount;
+    }
+    else {
+      $form->_groupCount = CRM_Utils_Request::retrieve('cgcount', 'Positive', $form);
+    }
+
+    $form->assign('cgCount', $form->_groupCount);
+
+    //carry qf key, since this form is not inhereting core form.
+    if ($qfKey = CRM_Utils_Request::retrieve('qfKey', 'String')) {
+      $form->assign('qfKey', $qfKey);
+    }
+
+    if ($entityID) {
+      $form->_entityId = $entityID;
+    }
+    else {
+      $form->_entityId = CRM_Utils_Request::retrieve('entityID', 'Positive', $form);
+    }
+
+    $typeCheck = CRM_Utils_Request::retrieve('type', 'String');
+    $urlGroupId = CRM_Utils_Request::retrieve('groupID', 'Positive');
+    if (isset($typeCheck) && $urlGroupId) {
+      $form->_groupID = $urlGroupId;
+    }
+    else {
+      $form->_groupID = CRM_Utils_Request::retrieve('groupID', 'Positive', $form);
+    }
+
+    $gid = (isset($form->_groupID)) ? $form->_groupID : NULL;
+    if (!is_array($subType) && str_contains(($subType ?? ''), CRM_Core_DAO::VALUE_SEPARATOR)) {
+      CRM_Core_Error::deprecatedWarning('Using a CRM_Core_DAO::VALUE_SEPARATOR separated subType deprecated, use a comma-separated string instead.');
+      $subType = str_replace(CRM_Core_DAO::VALUE_SEPARATOR, ',', trim($subType, CRM_Core_DAO::VALUE_SEPARATOR));
+    }
+
+    $singleRecord = NULL;
+    if (!empty($form->_groupCount) && !empty($form->_multiRecordDisplay) && $form->_multiRecordDisplay == 'single') {
+      $singleRecord = $form->_groupCount;
+    }
+    $mode = CRM_Utils_Request::retrieve('mode', 'String', $form);
+    // when a new record is being added for multivalued custom fields.
+    if (isset($form->_groupCount) && $form->_groupCount == 0 && $mode == 'add' &&
+      !empty($form->_multiRecordDisplay) && $form->_multiRecordDisplay == 'single') {
+      $singleRecord = 'new';
+    }
+
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree($type,
+      NULL,
+      $form->_entityId,
+      $gid,
+      $subType,
+      $extendsEntityColumn,
+      $isLoadFromCache,
+      $onlySubType,
+      FALSE,
+      CRM_Core_Permission::EDIT,
+      $singleRecord
+    );
+
+    if (property_exists($form, '_customValueCount') && !empty($groupTree)) {
+      $form->_customValueCount = CRM_Core_BAO_CustomGroup::buildCustomDataView($form, $groupTree, TRUE, NULL, NULL, NULL, $form->_entityId);
+    }
+    // we should use simplified formatted groupTree
+    $groupTree = CRM_Core_BAO_CustomGroup::formatGroupTree($groupTree, $form->_groupCount, $form);
+
+    if (isset($form->_groupTree) && is_array($form->_groupTree)) {
+      $keys = array_keys($groupTree);
+      foreach ($keys as $key) {
+        $form->_groupTree[$key] = $groupTree[$key];
+      }
+    }
+    else {
+      $form->_groupTree = $groupTree;
     }
   }
 


### PR DESCRIPTION


Overview
----------------------------------------
Copy function back to one of the few remaining callers

Before
----------------------------------------
Deprecated function that is on it's way out is called statically

After
----------------------------------------
Copied back as a private function to support clean up. The `buildForm` is also copied in directly (only 3 lines)

Note the setDefaults line is removed because the output of the setDefaults is an array that is not used - no form actions are taken so it does nothing. It is being called once the form is submitted & hance setting defaults does nothing so this is copy & paste gone mad


Technical Details
----------------------------------------

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
