### PR TITLE
Copy shared function back to form as private function

### DIFF
--- a/CRM/Contact/Form/Inline/CustomData.php
+++ b/CRM/Contact/Form/Inline/CustomData.php
@@ -45,8 +45,132 @@ class CRM_Contact_Form_Inline_CustomData extends CRM_Contact_Form_Inline {
     $customRecId = CRM_Utils_Request::retrieve('customRecId', 'Positive', $this, FALSE, 1);
     $cgcount = CRM_Utils_Request::retrieve('cgcount', 'Positive', $this, FALSE, 1);
     $subType = CRM_Contact_BAO_Contact::getContactSubType($this->_contactId, ',');
-    CRM_Custom_Form_CustomData::preProcess($this, NULL, $subType, $cgcount,
+    $this->preProcessCustomData(NULL, $subType, $cgcount,
       $this->_contactType, $this->_contactId);
+  }
+
+  /**
+   *
+   * Previously shared function.
+   *
+   * @param null|string $extendsEntityColumn
+   *   Additional filter on the type of custom data to retrieve - e.g for
+   *   participant data this could be a value representing role.
+   * @param null|string $subType
+   * @param null|int $groupCount
+   * @param null $type
+   * @param null|int $entityID
+   * @param null $onlySubType
+   * @param bool $isLoadFromCache
+   *
+   * @throws \CRM_Core_Exception
+   *
+   * @deprecated see https://github.com/civicrm/civicrm-core/pull/29241 for preferred approach - basically
+   * 1) at the tpl layer use CRM/common/customDataBlock.tpl
+   * 2) to make the fields available for postProcess
+   * if ($this->isSubmitted()) {
+   *   $this->addCustomDataFieldsToForm('FinancialAccount');
+   * }
+   * 3) pass getSubmittedValues() to CRM_Core_BAO_CustomField::postProcess($this->getSubmittedValues(), $this->_id, 'FinancialAccount');
+   *  to ensure any money or number fields are handled for localisation
+   */
+  private function preProcessCustomData($extendsEntityColumn = NULL, $subType = NULL,
+    $groupCount = NULL, $type = NULL, $entityID = NULL, $onlySubType = NULL, $isLoadFromCache = TRUE
+  ) {
+    $form = $this;
+    if (!$type) {
+      CRM_Core_Error::deprecatedWarning('type should be passed in');
+      $type = CRM_Utils_Request::retrieve('type', 'String', $form);
+    }
+
+    if (!isset($subType)) {
+      $subType = CRM_Utils_Request::retrieve('subType', 'String', $form);
+    }
+    if ($subType === 'null') {
+      // Is this reachable?
+      $subType = NULL;
+    }
+    $extendsEntityColumn = $extendsEntityColumn ?: CRM_Utils_Request::retrieve('subName', 'String', $form);
+    if ($extendsEntityColumn === 'null') {
+      // Is this reachable?
+      $extendsEntityColumn = NULL;
+    }
+
+    if ($groupCount) {
+      $form->_groupCount = $groupCount;
+    }
+    else {
+      $form->_groupCount = CRM_Utils_Request::retrieve('cgcount', 'Positive', $form);
+    }
+
+    $form->assign('cgCount', $form->_groupCount);
+
+    //carry qf key, since this form is not inhereting core form.
+    if ($qfKey = CRM_Utils_Request::retrieve('qfKey', 'String')) {
+      $form->assign('qfKey', $qfKey);
+    }
+
+    if ($entityID) {
+      $form->_entityId = $entityID;
+    }
+    else {
+      $form->_entityId = CRM_Utils_Request::retrieve('entityID', 'Positive', $form);
+    }
+
+    $typeCheck = CRM_Utils_Request::retrieve('type', 'String');
+    $urlGroupId = CRM_Utils_Request::retrieve('groupID', 'Positive');
+    if (isset($typeCheck) && $urlGroupId) {
+      $form->_groupID = $urlGroupId;
+    }
+    else {
+      $form->_groupID = CRM_Utils_Request::retrieve('groupID', 'Positive', $form);
+    }
+
+    $gid = (isset($form->_groupID)) ? $form->_groupID : NULL;
+    if (!is_array($subType) && str_contains(($subType ?? ''), CRM_Core_DAO::VALUE_SEPARATOR)) {
+      CRM_Core_Error::deprecatedWarning('Using a CRM_Core_DAO::VALUE_SEPARATOR separated subType deprecated, use a comma-separated string instead.');
+      $subType = str_replace(CRM_Core_DAO::VALUE_SEPARATOR, ',', trim($subType, CRM_Core_DAO::VALUE_SEPARATOR));
+    }
+
+    $singleRecord = NULL;
+    if (!empty($form->_groupCount) && !empty($form->_multiRecordDisplay) && $form->_multiRecordDisplay == 'single') {
+      $singleRecord = $form->_groupCount;
+    }
+    $mode = CRM_Utils_Request::retrieve('mode', 'String', $form);
+    // when a new record is being added for multivalued custom fields.
+    if (isset($form->_groupCount) && $form->_groupCount == 0 && $mode == 'add' &&
+      !empty($form->_multiRecordDisplay) && $form->_multiRecordDisplay == 'single') {
+      $singleRecord = 'new';
+    }
+
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree($type,
+      NULL,
+      $form->_entityId,
+      $gid,
+      $subType,
+      $extendsEntityColumn,
+      $isLoadFromCache,
+      $onlySubType,
+      FALSE,
+      CRM_Core_Permission::EDIT,
+      $singleRecord
+    );
+
+    if (property_exists($form, '_customValueCount') && !empty($groupTree)) {
+      $form->_customValueCount = CRM_Core_BAO_CustomGroup::buildCustomDataView($form, $groupTree, TRUE, NULL, NULL, NULL, $form->_entityId);
+    }
+    // we should use simplified formatted groupTree
+    $groupTree = CRM_Core_BAO_CustomGroup::formatGroupTree($groupTree, $form->_groupCount, $form);
+
+    if (isset($form->_groupTree) && is_array($form->_groupTree)) {
+      $keys = array_keys($groupTree);
+      foreach ($keys as $key) {
+        $form->_groupTree[$key] = $groupTree[$key];
+      }
+    }
+    else {
+      $form->_groupTree = $groupTree;
+    }
   }
 
   /**

--- a/CRM/Contact/Form/Inline/CustomData.php
+++ b/CRM/Contact/Form/Inline/CustomData.php
@@ -132,17 +132,6 @@ class CRM_Contact_Form_Inline_CustomData extends CRM_Contact_Form_Inline {
       $subType = str_replace(CRM_Core_DAO::VALUE_SEPARATOR, ',', trim($subType, CRM_Core_DAO::VALUE_SEPARATOR));
     }
 
-    $singleRecord = NULL;
-    if (!empty($form->_groupCount) && !empty($form->_multiRecordDisplay) && $form->_multiRecordDisplay == 'single') {
-      $singleRecord = $form->_groupCount;
-    }
-    $mode = CRM_Utils_Request::retrieve('mode', 'String', $form);
-    // when a new record is being added for multivalued custom fields.
-    if (isset($form->_groupCount) && $form->_groupCount == 0 && $mode == 'add' &&
-      !empty($form->_multiRecordDisplay) && $form->_multiRecordDisplay == 'single') {
-      $singleRecord = 'new';
-    }
-
     $groupTree = CRM_Core_BAO_CustomGroup::getTree($type,
       NULL,
       $form->_entityId,
@@ -150,10 +139,7 @@ class CRM_Contact_Form_Inline_CustomData extends CRM_Contact_Form_Inline {
       $subType,
       $extendsEntityColumn,
       $isLoadFromCache,
-      $onlySubType,
-      FALSE,
-      CRM_Core_Permission::EDIT,
-      $singleRecord
+      $onlySubType
     );
 
     if (property_exists($form, '_customValueCount') && !empty($groupTree)) {


### PR DESCRIPTION
Overview
----------------------------------------
Copy shared function back to form as private function

Before
----------------------------------------
The last remaining real usage of this function is a nasty static function on a remote class

After
----------------------------------------
Copied back to permit cleanup

Technical Details
----------------------------------------

I also removed the handling for multipleRecord as it does not apply to this form

![image](https://github.com/civicrm/civicrm-core/assets/336308/128d4da0-3e60-417a-8fb2-dee9bcd23181)

Comments
----------------------------------------