### PR TITLE
Regression fix (master) , custom data not saved on edit case activity

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -427,34 +427,32 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
     }
 
     // format activity custom data
-    if (!empty($params['hidden_custom'])) {
-      if ($this->_activityId) {
-        // retrieve and include the custom data of old Activity
-        $oldActivity = civicrm_api3('Activity', 'getsingle', ['id' => $this->_activityId]);
-        $params = array_merge($oldActivity, $params);
+    if ($this->_activityId) {
+      // retrieve and include the custom data of old Activity
+      $oldActivity = civicrm_api3('Activity', 'getsingle', ['id' => $this->_activityId]);
+      $params = array_merge($oldActivity, $params);
 
-        // unset custom fields-id from params since we want custom
-        // fields to be saved for new activity.
-        foreach ($params as $key => $value) {
-          $match = [];
-          if (preg_match('/^(custom_\d+_)(\d+)$/', $key, $match)) {
-            $params[$match[1] . '-1'] = $params[$key];
+      // unset custom fields-id from params since we want custom
+      // fields to be saved for new activity.
+      foreach ($params as $key => $value) {
+        $match = [];
+        if (preg_match('/^(custom_\d+_)(\d+)$/', $key, $match)) {
+          $params[$match[1] . '-1'] = $params[$key];
 
-            // for autocomplete transfer hidden value instead of label
-            if ($params[$key] && isset($params[$key . '_id'])) {
-              $params[$match[1] . '-1_id'] = $params[$key . '_id'];
-              unset($params[$key . '_id']);
-            }
-            unset($params[$key]);
+          // for autocomplete transfer hidden value instead of label
+          if ($params[$key] && isset($params[$key . '_id'])) {
+            $params[$match[1] . '-1_id'] = $params[$key . '_id'];
+            unset($params[$key . '_id']);
           }
+          unset($params[$key]);
         }
       }
-
-      $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
-        $this->_activityId,
-        'Activity'
-      );
     }
+
+    $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
+      $this->_activityId,
+      'Activity'
+    );
 
     // assigning formatted value
     if (!empty($params['assignee_contact_id'])) {
@@ -471,7 +469,7 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
       }
 
       // @todo This is called newActParams because it USED TO create new activity revisions. But at the moment just changing the part that is broken.
-      // hidden_custom is always 1, so see above where $params gets merged with the existing activity data every time, including the activity id.
+      // $params gets merged with the existing activity data every time, including the activity id.
       $newActParams = $params;
 
       // add target contact values in update mode


### PR DESCRIPTION

Overview
----------------------------------------
Regression fix, custom data not saved on edit case activity

This patch is here by itself & also combined in https://github.com/civicrm/civicrm-core/pull/29799 as it was discovered in the context of testing that PR

Before
----------------------------------------
Master only regression - custom data not saved when editing fields attached to an activity on a case - this is hit when the testData extension is installed & a Case is opened & then an attempt is made to edit the attached custom field

After
----------------------------------------
saved

Technical Details
----------------------------------------
We have gone from hidden_custom to being always true in PostProcess to never true
- so we just remove the conditional for it
- 
Comments
----------------------------------------
Can be most easily reproduced with https://github.com/eileenmcnaughton/testdata installed