### PR TITLE
dev/core#5069 initialise config/container safely in standalone

### DIFF
--- a/setup/res/index.php.txt
+++ b/setup/res/index.php.txt
@@ -3,6 +3,9 @@
 function invoke() {
   $requestUri = $_SERVER['REQUEST_URI'] ?? '';
 
+  // initialise config and boot container
+  \CRM_Core_Config::singleton();
+
   // Add CSS, JS, etc. that is required for this page.
   \CRM_Core_Resources::singleton()->addCoreResources();
   $parts = explode('?', $requestUri);


### PR DESCRIPTION
Overview
----------------------------------------
Adds an explicit call to initialise the CRM_Core_Config in Standalone's index.php

Before
----------------------------------------
There's some weird double booting going on, which causes an issue with duplicate listeners https://lab.civicrm.org/dev/core/-/issues/4994

After
----------------------------------------
It seems to boot nice and cleanly?

The [AuthX StatelessFlowsTest](https://test.civicrm.org/job/CiviCRM-E2E-Matrix/BKPROF=min,BLDTYPE=standalone-clean,CIVIVER=master,label=bknix-tmp/lastCompletedBuild/testReport/(root)/Civi_Authx_StatelessFlowsTest/) tests pass for me
