### PR TITLE
Set error response code before starting error response

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -451,6 +451,9 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       $content = self::formatHtmlException($exception) . $content;
     }
 
+    // set the response code before starting the request
+    http_response_code(500);
+
     echo CRM_Utils_System::theme($content);
     $exit = CRM_Utils_System::shouldExitAfterFatal();
 


### PR DESCRIPTION
Overview
----------------------------------------
Set the http_response_code before output is started, so that it makes it into the request.

Fixes [ErrorTest.testErrorStatus](https://test.civicrm.org/job/CiviCRM-E2E-Matrix/BKPROF=min,BLDTYPE=standalone-clean,CIVIVER=master,label=bknix-tmp/lastCompletedBuild/testReport/(root)/E2E_Core_ErrorTest/testErrorStatus_with_data_set__frontend_fatal_/) fails 

Before
----------------------------------------
Error page content is output in `CRM_Core_Error::handleUnhandledException` before the http_response_code is set in `onCiviExit` - which means the response code never makes it into the request.

After
----------------------------------------
Set the response code before we output any content.

Technical Details
----------------------------------------
I'm not sure how this work in the CMSes... maybe some kind of output buffering?
