### PR TITLE
Post split code cleanup

### DIFF
--- a/CRM/Contact/Form/CustomData.php
+++ b/CRM/Contact/Form/CustomData.php
@@ -97,7 +97,7 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
       if (!empty($entityId)) {
         $subType = CRM_Contact_BAO_Contact::getContactSubType($entityId, ',');
       }
-      $this->preProcessCustomData(NULL, $subType, NULL, CRM_Utils_Request::retrieve('type', 'String', $this), $entityId);
+      $this->preProcessCustomData(NULL, CRM_Utils_Request::retrieve('type', 'String', $this), $entityId);
       if ($this->_multiRecordDisplay) {
         $this->_groupID = CRM_Utils_Request::retrieve('groupID', 'Positive', $this);
         $this->_tableID = $this->_entityId;
@@ -143,7 +143,7 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
     // when custom data is included in this page
     if (!empty($_POST['hidden_custom'])) {
       for ($i = 1; $i <= $_POST['hidden_custom_group_count'][$this->_groupID]; $i++) {
-        $this->preProcessCustomData(NULL, $this->_contactSubType, $i, $this->_contactType, $this->_tableID);
+        $this->preProcessCustomData($i, $this->_contactType, $this->_tableID);
         $this->addElement('hidden', 'hidden_custom', 1);
         $this->addElement('hidden', "hidden_custom_group_count[{$this->_groupID}]", $this->_groupCount);
         CRM_Core_BAO_CustomGroup::buildQuickForm($this, $this->_groupTree);
@@ -154,18 +154,11 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
   /**
    * Previously shared function
    *
-   * @param null|string $extendsEntityColumn
-   *   Additional filter on the type of custom data to retrieve - e.g for
-   *   participant data this could be a value representing role.
-   * @param null|string $subType
    * @param null|int $groupCount
    * @param null $type
    * @param null|int $entityID
-   * @param null $onlySubType
-   * @param bool $isLoadFromCache
    *
    * @throws \CRM_Core_Exception
-   *
    * @deprecated see https://github.com/civicrm/civicrm-core/pull/29241 for preferred approach - basically
    * 1) at the tpl layer use CRM/common/customDataBlock.tpl
    * 2) to make the fields available for postProcess
@@ -175,24 +168,10 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
    * 3) pass getSubmittedValues() to CRM_Core_BAO_CustomField::postProcess($this->getSubmittedValues(), $this->_id, 'FinancialAccount');
    *  to ensure any money or number fields are handled for localisation
    */
-  private function preProcessCustomData(
-    $extendsEntityColumn = NULL, $subType = NULL,
-    $groupCount = NULL, $type = NULL, $entityID = NULL, $onlySubType = NULL, $isLoadFromCache = TRUE
-  ) {
+  private function preProcessCustomData($groupCount = NULL, $type = NULL, $entityID = NULL) {
     $form = $this;
-    if (!$type) {
-      CRM_Core_Error::deprecatedWarning('type should be passed in');
-      $type = CRM_Utils_Request::retrieve('type', 'String', $form);
-    }
 
-    if (!isset($subType)) {
-      $subType = CRM_Utils_Request::retrieve('subType', 'String', $form);
-    }
-    if ($subType === 'null') {
-      // Is this reachable?
-      $subType = NULL;
-    }
-    $extendsEntityColumn = $extendsEntityColumn ?: CRM_Utils_Request::retrieve('subName', 'String', $form);
+    $extendsEntityColumn = CRM_Utils_Request::retrieve('subName', 'String', $form);
     if ($extendsEntityColumn === 'null') {
       // Is this reachable?
       $extendsEntityColumn = NULL;
@@ -229,10 +208,6 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
     }
 
     $gid = (isset($form->_groupID)) ? $form->_groupID : NULL;
-    if (!is_array($subType) && str_contains(($subType ?? ''), CRM_Core_DAO::VALUE_SEPARATOR)) {
-      CRM_Core_Error::deprecatedWarning('Using a CRM_Core_DAO::VALUE_SEPARATOR separated subType deprecated, use a comma-separated string instead.');
-      $subType = str_replace(CRM_Core_DAO::VALUE_SEPARATOR, ',', trim($subType, CRM_Core_DAO::VALUE_SEPARATOR));
-    }
 
     $singleRecord = NULL;
     if (!empty($form->_groupCount) && !empty($form->_multiRecordDisplay) && $form->_multiRecordDisplay == 'single') {
@@ -249,10 +224,10 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
       NULL,
       $form->_entityId,
       $gid,
-      $subType,
+      CRM_Contact_BAO_Contact::getContactSubType($entityID),
       $extendsEntityColumn,
-      $isLoadFromCache,
-      $onlySubType,
+      TRUE,
+      NULL,
       FALSE,
       CRM_Core_Permission::EDIT,
       $singleRecord


### PR DESCRIPTION


Overview
----------------------------------------
Post split code cleanup

Before
----------------------------------------
SubType is determined the same way in both places that pass it in so instead of passing it in look it up in the function

Some parameters are never passed in or always the same

After
----------------------------------------
Remove extraneous params

Technical Details
----------------------------------------

Comments
----------------------------------------
