### PR TITLE
Add validate.tpl to customDataBlock, minor cleanup

### DIFF
--- a/templates/CRM/common/customDataBlock.tpl
+++ b/templates/CRM/common/customDataBlock.tpl
@@ -1,19 +1,17 @@
+
 {if !empty($customDataType)}
   <div id="customData"></div>
   {*include custom data js file*}
   {include file="CRM/common/customData.tpl"}
-  {assign var='cid' value=$cid|default:'false'}
   {literal}
   <script type="text/javascript">
     CRM.$(function($) {
       {/literal}
-      {if !empty($customDataSubType)}
-        CRM.buildCustomData('{$customDataType}', {$customDataSubType}, false, false, false, false, false, {$cid});
-      {else}
-        CRM.buildCustomData('{$customDataType}', false, false, false, false, false, false, {$cid});
-      {/if}
-      {literal}
+      CRM.buildCustomData('{$customDataType}', {$customDataSubType|default:"false"}, false, false, false, false, false, {$cid|default:"false"});
+    {literal}
     });
   </script>
   {/literal}
 {/if}
+{* jQuery validate *}
+{include file="CRM/Form/validate.tpl"}


### PR DESCRIPTION
Overview
----------------------------------------
Add validate.tpl to customDataBlock, minor cleanup

Before
----------------------------------------
validate.tpl inconsistently added to the custom data form & hence I have 2 conflicting PRs that add it - see https://github.com/civicrm/civicrm-core/pull/29751 & https://github.com/civicrm/civicrm-core/pull/29799

After
----------------------------------------
Added. Also note minor clean up - we have had to declare cid everywhere this function is called because the use of default doesn't effectively bypass notices. `$customDataSubType` is always declared or false now so the use of default there is a bit of overkill but...

Technical Details
----------------------------------------

Comments
----------------------------------------
