### PR TITLE
Use smarty capitalize instead of ucfirst

### DIFF
--- a/templates/CRM/Contact/Form/Relationship.tpl
+++ b/templates/CRM/Contact/Form/Relationship.tpl
@@ -47,7 +47,7 @@
         <tr class="crm-relationship-form-block-is_permission_b_a">
           <td class="label"> </td>
           <td>
-            {ts 1=$contact_b|ucfirst 2=$display_name_a}Permission for <strong>%1</strong> to access information about <strong>%2</strong>{/ts}<br />
+            {ts 1=$contact_b|capitalize 2=$display_name_a}Permission for <strong>%1</strong> to access information about <strong>%2</strong>{/ts}<br />
             {$form.is_permission_b_a.html}
           </td>
         </tr>


### PR DESCRIPTION
Overview
----------------------------------------
Use smarty capitalize instead of ucfirst

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/ddd15d4a-4ce5-4fa4-840d-4ecca4a8dd98)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/9c9344ca-1022-4182-a7f4-29618ffe3d66)

Technical Details
----------------------------------------

Comments
----------------------------------------
