### PR TITLE
Fixes Joomla regression in #27834 that hides select2 dropdown options when used in modal

### DIFF
--- a/css/joomla.css
+++ b/css/joomla.css
@@ -42,7 +42,10 @@ body.admin.com_civicrm .crm-container.ui-dialog {
   z-index: 100000;
 }
 body.admin.com_civicrm.layout-default .ui-widget-overlay {
-  z-index: 1;
+  z-index: 100001;
+}
+body.admin.com_civicrm.layout-default .select2-drop {
+  z-index: 100002;
 }
 body.admin.com_civicrm.layout-default .modal-dialog {
   max-width: inherit;


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a PR introduced in https://github.com/civicrm/civicrm-core/pull/27834. In that PR, the z-index of modals had been increased to ensure they sat above menu elements (as illustrated by the screengrabs on that page). However, select2 dropdowns are given a lower z-index, which means they are hidden behind modals, if the select2 select list is in a modal. This PR fixes that.

Before
----------------------------------------
Select2 dropdowns in modals are hidden (e.g. on a 'send email' popup).

<img width="567" alt="image" src="https://github.com/vingle/civicrm-core/assets/1175967/4cde7c9a-0f74-42ca-82a3-60c717b8c642">

After
----------------------------------------
They aren't.

Technical details
----------------------------------------
Am aware chasing z-indexes ever-higher isn't particularly elegant, but these seems the simplest way to respond to JQueryUI and Select2's use of z-indexes.