### PR TITLE
Ensure price from url is set as default

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -250,7 +250,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
             $opMemTypeId = $priceFieldOption['membership_type_id'] ?? NULL;
             $priceFieldName = 'price_' . $priceFieldOption['price_field_id'];
             $priceFieldValue = CRM_Price_BAO_PriceSet::getPriceFieldValueFromURL($this, $priceFieldName);
-            if (!empty($priceFieldValue) && !$existingMembershipTypeID) {
+            if (!empty($priceFieldValue)) {
               CRM_Price_BAO_PriceSet::setDefaultPriceSetField($priceFieldName, $priceFieldValue, $val['html_type'], $this->_defaults);
               // break here to prevent overwriting of default due to 'is_default'
               // option configuration or setting of current membership or


### PR DESCRIPTION
Overview
----------------------------------------
Specifying price field ID in URL is overriden by current membership type

Before
----------------------------------------
Since Civi 5.70, when a member (current or expired) visits the membership contribution page with the appropriate price field option indicated in the URL, it makes no difference - the auto-selected option is always the membership type they have/had last. 

After
----------------------------------------
The price_x from the URL is prioritized over the current membership present on the contact.

Technical Details
----------------------------------------
Seems to have regressed from https://github.com/civicrm/civicrm-core/pull/29190/files#diff-9319a4134599e85c273c3be5706ffb5d642b7659904fd644dd4273791467384aR252

thoughts? @eileenmcnaughton. 