### PR TITLE
Resolve Issue with Payment Allocation to Contribution Line Item 

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -609,6 +609,16 @@ class CRM_Financial_BAO_Payment {
         $paid += $entityFinancialTrxn['amount'];
       }
     }
+
+    $lineItem = \Civi\Api4\LineItem::get(FALSE)
+      ->addWhere('id', '=', $lineItemID)
+      ->execute()
+      ->first();
+    if (!empty($lineItem['tax_amount']) && $paid > 0) {
+      $total = floatval($lineItem['line_total']);
+      $tax = floatval($lineItem['tax_amount']);
+      $paid = ($total * $paid) / ($tax + $total);
+    }
     return (float) $paid;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This pull request addresses an issue where incorrect amounts were allocated to contribution line items during payment processing. 

Considering the contribution entity table provided:

| Line   | Price | Quantity | Subtotal exc Tax | Tax  | Tax total | Total inc Tax |
|--------|-------|----------|------------------|------|-----------|---------------|
| Line 1 | 100   | 1        | 100              | 0%   | 0         | 100           |
| Line 2 | 200   | 1        | 200              | 0%   | 0         | 200           |
| Line 3 | 300   | 1        | 300              | 20%  | 60        | 360           |
| Total  |       |          |                  |      |           | 660           |

Before
----------------------------------------

Before this PR, the following EntityFinancialTrxn was created:

|            | Subtotal exc Tax | Payment 1 (200) | Payment 2 (200)  | Payment 3 (200) |
|------------|-------------------|-----------------------------------------------|-----------------------------------------------|-----------------------------------------------|
| Line 1     | 100               | 30.30                                         | 30.30                                         | 30.30                                         |
| Line 2     | 200               | 60.61                                         | 60.60                                         | 60.60                                         |
| **Line 3**     | **300**               | **90.91**                                         | **83.00**                                         | **69.02**                                         |
| Tax line 1 | 0                 | 0.00                                          | 0.00                                          | 0.00                                          |
| Tax line 2 | 0                 | 0.00                                          | 0.00                                          | 0.00                                          |
| Tax line 3 | 60                | 18.18                                         | 18.18                                         | 18.18                                         |
| Total      | 660               | 200.00                                        | 192.08                                        | 178.10                                        |


From this table, it's evident that incorrect amounts are assigned to line item 3 following the initial payment.

After
----------------------------------------

After this PR, the following EntityFinancialTrxn is created:

|            | Subtotal exc Tax | Payment 1 (200) | Payment 2 (200) | Payment 3 (200) |
|------------|-------------------|-----------------------------------------------|-----------------------------------------------|-----------------------------------------------|
| Line 1     | 100               | 30.30                                         | 30.30                                         | 30.30                                         |
| Line 2     | 200               | 60.61                                         | 60.61                                         | 60.61                                         |
| **Line 3**     | **300**               | **90.91**                                         | **90.91**                                         | **90.91**                                         |
| Tax line 1 | 0                 | 0.00                                          | 0.00                                          | 0.00                                          |
| Tax line 2 | 0                 | 0.00                                          | 0.00                                          | 0.00                                          |
| Tax line 3 | 60                | 18.18                                         | 18.18                                         | 18.18                                         |
| Total      | 660               | 200.00                                        | 200.00                                        | 200.00                                        |

Line Item 3 now receives the accurate allocation with subsequent payments.

Replication Step
----------------------------------------
- Create a pending contribution with a tax line item (maybe 100 + tax 20)
- Make the first partial payment (maybe 60) - Check that the EntityFinancialTrxns created for the payment has the correct total
- Make the second partial payment (maybe 30) - Check that the EntityFinancialTrxns created for the payment has an incorrect total



