### PR TITLE
(NFC) gitignore - Don't care about .composer-downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *.bak
 .use-civicrm-setup
+.composer-downloads
 /ext/*
 !/ext/afform
 !/ext/standaloneusers


### PR DESCRIPTION
Overview
----------------------------------------

This is an internal tracking file for `composer` (`composer-downloads-plugin`). Never needs to be committed.

