### PR TITLE
Fix deprecation notice

### DIFF
--- a/CRM/Admin/Page/Extensions.php
+++ b/CRM/Admin/Page/Extensions.php
@@ -270,7 +270,7 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
       );
       if (isset($localExtensionRows[$info->key])) {
         if (array_key_exists('version', $localExtensionRows[$info->key])) {
-          if (version_compare($localExtensionRows[$info->key]['version'], $info->version, '<')) {
+          if (version_compare($localExtensionRows[$info->key]['version'] ?? '', $info->version, '<')) {
             $row['upgradelink'] = $mapper->getUpgradeLink($remoteExtensions[$info->key], $localExtensionRows[$info->key]);
           }
         }

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -553,7 +553,7 @@ class CRM_Extension_Mapper {
    * @return string
    */
   public function getUpgradeLink($remoteExtensionInfo, $localExtensionInfo) {
-    if (!empty($remoteExtensionInfo) && version_compare($localExtensionInfo['version'], $remoteExtensionInfo->version, '<')) {
+    if (!empty($remoteExtensionInfo) && version_compare($localExtensionInfo['version'] ?? '', $remoteExtensionInfo->version, '<')) {
       return ts('Version %1 is installed. <a %2>Upgrade to version %3</a>.', [
         1 => $localExtensionInfo['version'],
         2 => 'href="' . CRM_Utils_System::url('civicrm/admin/extensions', "action=update&id={$localExtensionInfo['key']}&key={$localExtensionInfo['key']}") . '"',


### PR DESCRIPTION
If null pass empty string as version instead of NULL to avoid notice.

Overview
----------------------------------------
Use null coalescing to avoid passing a NULL where it is not wanted.

I assume this is going to break rather badly at some point in the future. I think this would avoid the case of having missing extensions causing the extension page to white screen the site. 

Before
----------------------------------------
When loading the extension page under certain conditions you could get a:

`Deprecated function: version_compare(): Passing null to parameter #1 ($version1) of type string is deprecated in CRM_Admin_Page_Extensions->formatRemoteExtensionRows() `

and 

` Deprecated function: version_compare(): Passing null to parameter #1 ($version1) of type string is deprecated in CRM_Extension_Mapper->getUpgradeLink()`

I encountered when an extension was 'missing' from the filesystem. I assume this could be encountered in other circumstances - malformed info.xml potentially.

After
----------------------------------------
Still some errors about various stuff (missing extensions) and related deprecations in templates_c !!! but these two are gone!




