### PR TITLE
dev/core#5106 - Fix visibility of afforms & saved searches for disabled components

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -985,13 +985,22 @@ class CRM_Core_Permission {
       return [$permissionName];
     }
     try {
-      $impliedPermissions = self::basicPermissions(TRUE, TRUE)[$permissionName]['implied_by'] ?? [];
+      $permission = self::basicPermissions(TRUE, TRUE)[$permissionName] ?? NULL;
+      $impliedPermissions = array_merge([$permissionName], $permission['implied_by'] ?? []);
+      // Permission for a disabled component: always deny
+      if (!empty($permission['disabled'])) {
+        return [self::ALWAYS_DENY_PERMISSION];
+      }
+      // If it's a CiviCRM permission, then it's also implied by the master permission
+      elseif ($permission) {
+        $impliedPermissions[] = 'all CiviCRM permissions and ACLs';
+      }
     }
     // This could happen early in the boot-cycle or during upgrade
     catch (RuntimeException $e) {
-      $impliedPermissions = [];
+      $impliedPermissions = [$permissionName, 'all CiviCRM permissions and ACLs'];
     }
-    return array_merge([$permissionName, 'all CiviCRM permissions and ACLs'], $impliedPermissions);
+    return $impliedPermissions;
   }
 
   /**

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1815,10 +1815,10 @@ class CRM_Core_Permission {
         $info = $component->getInfo();
         foreach ($perms as $name => $perm) {
           $perm['label'] = $info['translatedName'] . ': ' . $perm['label'];
-          $permissions[$name] = $perm;
           if (!$component->isEnabled()) {
             $perm['disabled'] = TRUE;
           }
+          $permissions[$name] = $perm;
         }
       }
     }

--- a/CRM/Utils/System/UnitTests.php
+++ b/CRM/Utils/System/UnitTests.php
@@ -192,4 +192,12 @@ class CRM_Utils_System_UnitTests extends CRM_Utils_System_Base {
     throw new Exception("Method not implemented: getLoginURL");
   }
 
+  /**
+   * @inheritdoc
+   */
+  public function mailingWorkflowIsEnabled():bool {
+    $enableWorkflow = Civi::settings()->get('civimail_workflow');
+    return (bool) $enableWorkflow;
+  }
+
 }

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -169,7 +169,7 @@ function afform_civicrm_tabset($tabsetName, &$tabs, $context) {
   }
   $existingTabs = array_combine(array_keys($tabs), array_column($tabs, 'id'));
   $contactTypes = array_merge((array) ($context['contact_type'] ?? []), $context['contact_sub_type'] ?? []);
-  $afforms = Civi\Api4\Afform::get(FALSE)
+  $afforms = Civi\Api4\Afform::get()
     ->addSelect('name', 'title', 'icon', 'module_name', 'directive_name', 'summary_contact_type', 'summary_weight')
     ->addWhere('placement', 'CONTAINS', 'contact_summary_tab')
     ->addOrderBy('title')
@@ -213,7 +213,7 @@ function afform_civicrm_pageRun(&$page) {
   if (!in_array(get_class($page), ['CRM_Contact_Page_View_Summary', 'CRM_Contact_Page_View_Print'])) {
     return;
   }
-  $afforms = Civi\Api4\Afform::get(FALSE)
+  $afforms = Civi\Api4\Afform::get()
     ->addSelect('name', 'title', 'icon', 'module_name', 'directive_name', 'summary_contact_type')
     ->addWhere('placement', 'CONTAINS', 'contact_summary_block')
     ->addOrderBy('summary_weight')
@@ -257,7 +257,7 @@ function afform_civicrm_pageRun(&$page) {
  * @link https://github.com/civicrm/org.civicrm.contactlayout
  */
 function afform_civicrm_contactSummaryBlocks(&$blocks) {
-  $afforms = \Civi\Api4\Afform::get(FALSE)
+  $afforms = \Civi\Api4\Afform::get()
     ->setSelect(['name', 'title', 'directive_name', 'module_name', 'type', 'type:icon', 'type:label', 'summary_contact_type'])
     ->addWhere('placement', 'CONTAINS', 'contact_summary_block')
     ->addOrderBy('title')

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Assigned_Financial_Accounts.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Assigned_Financial_Accounts.mgd.php
@@ -1,6 +1,11 @@
 <?php
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
 
+// Temporary check can be removed when moving this file to the civi_contribute extension.
+if (!CRM_Core_Component::isEnabled('CiviContribute')) {
+  return [];
+}
+
 return [
   [
     'name' => 'SavedSearch_Administer_Assigned_Financial_Accounts',

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Financial_Accounts.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Financial_Accounts.mgd.php
@@ -1,6 +1,11 @@
 <?php
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
 
+// Temporary check can be removed when moving this file to the civi_contribute extension.
+if (!CRM_Core_Component::isEnabled('CiviContribute')) {
+  return [];
+}
+
 return [
   [
     'name' => 'SavedSearch_Administer_Financial_Accounts',

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Financial_Types.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Financial_Types.mgd.php
@@ -1,6 +1,11 @@
 <?php
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
 
+// Temporary check can be removed when moving this file to the civi_contribute extension.
+if (!CRM_Core_Component::isEnabled('CiviContribute')) {
+  return [];
+}
+
 return [
   [
     'name' => 'SavedSearch_Administer_Financial_Types',

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Payment_Processors.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Payment_Processors.mgd.php
@@ -1,6 +1,11 @@
 <?php
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
 
+// Temporary check can be removed when moving this file to the civi_contribute extension.
+if (!CRM_Core_Component::isEnabled('CiviContribute')) {
+  return [];
+}
+
 return [
   [
     'name' => 'SavedSearch_Administer_Payment_Processors',

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Events.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Events.mgd.php
@@ -1,6 +1,11 @@
 <?php
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
 
+// Temporary check can be removed when moving this file to the civi_event extension.
+if (!CRM_Core_Component::isEnabled('CiviEvent')) {
+  return [];
+}
+
 return [
   [
     'name' => 'SavedSearch_Contact_Summary_Events',

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Membership_Type.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Membership_Type.mgd.php
@@ -1,6 +1,11 @@
 <?php
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
 
+// Temporary check can be removed when moving this file to the civi_member extension.
+if (!CRM_Core_Component::isEnabled('CiviMember')) {
+  return [];
+}
+
 return [
   [
     'name' => 'SavedSearch_Contact_Summary_Membership_Type',

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Memberships.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Memberships.mgd.php
@@ -1,6 +1,11 @@
 <?php
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
 
+// Temporary check can be removed when moving this file to the civi_member extension.
+if (!CRM_Core_Component::isEnabled('CiviMember')) {
+  return [];
+}
+
 return [
   [
     'name' => 'SavedSearch_Contact_Summary_Memberships',

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Contribution_Pages.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Contribution_Pages.mgd.php
@@ -1,6 +1,11 @@
 <?php
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
 
+// Temporary check can be removed when moving this file to the civi_contribute extension.
+if (!CRM_Core_Component::isEnabled('CiviContribute')) {
+  return [];
+}
+
 return [
   [
     'name' => 'SavedSearch_Manage_Contribution_Pages',

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Mail_Accounts.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Mail_Accounts.mgd.php
@@ -1,6 +1,10 @@
 <?php
-
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
+
+// Temporary check can be removed when moving this file to the civi_mail extension.
+if (!CRM_Core_Component::isEnabled('CiviMail')) {
+  return [];
+}
 
 // This SearchDisplay shows an editable-in-place field for Enabled? for all rows, including the bounce processing mail account, which cannot actually be disabled (you can change it to No, but it won't actually be disabled). So this is FIXME for when we can set rows to edit-in-place conditionally.
 return [

--- a/tests/phpunit/api/v3/MultilingualTest.php
+++ b/tests/phpunit/api/v3/MultilingualTest.php
@@ -26,6 +26,7 @@ class api_v3_MultilingualTest extends CiviUnitTestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    CRM_Core_BAO_ConfigSetting::enableAllComponents();
     $this->useTransaction(TRUE);
   }
 

--- a/tests/phpunit/api/v4/Entity/GroupTest.php
+++ b/tests/phpunit/api/v4/Entity/GroupTest.php
@@ -88,6 +88,8 @@ class GroupTest extends Api4TestBase {
   }
 
   public function testCreate(): void {
+    \Civi::settings()->set('civimail_workflow', TRUE);
+    \CRM_Core_BAO_ConfigSetting::enableAllComponents();
     $this->createLoggedInUser();
     \CRM_Core_Config::singleton()->userPermissionClass->permissions = [
       'access CiviCRM',


### PR DESCRIPTION
Overview
----------------------------------------
Fixes crash when enabling AdminUI extension without all components enabled.

Before
----------------------------------------
See description in https://lab.civicrm.org/dev/core/-/issues/5106

After
----------------------------------------
Works with or without all components enabled.

Technical Details
----------------------------------------
This takes a multi-pronged approach to the problem, since the tab consists of a search display *and* an afform, I fixed both, using different approaches:

- Added a conditional component check to the saved searches.
- Fixed permission checks to the afforms so that a permission to a disabled component (e.g. "Access CiviMember") would always be denied, even for super-admins).
- Fixed a bug in the permission system which misreported disabled components as enabled
- Fixed Afform-core to actually check permissions when loading contact summary tabs