### PR TITLE
call buildamount hook

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1998,6 +1998,9 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       }
     }
 
+    //its time to call the hook.
+    CRM_Utils_Hook::buildAmount('event', $form, $feeFields);
+
     //reset required if participant is skipped.
     $button = substr($form->controller->getButtonName(), -4);
     if ($required && $button === 'skip') {
@@ -2095,6 +2098,8 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
         $form->addRule('amount', ts('Fee Level is a required field.'), 'required');
       }
     }
+
+    $this->setPriceFieldMetaData($feeFields);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
CiviDiscount stopped working since 5.71

Ref: https://lab.civicrm.org/extensions/cividiscount/-/issues/308

Regression from: https://github.com/civicrm/civicrm-core/pull/29219/files#diff-dcb99c146eb90c35dfb3a56e963fe84c57faca51fbaf9f611ca0a7922c8f509cL1763

Before
----------------------------------------
Discounts not applied on event

After
----------------------------------------
Discounts applied