### PR TITLE
dev/core#5104 Afform - improve relative date support

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -62,14 +62,26 @@
   </a>
 </li>
 <li ng-if="$ctrl.fieldDefn.input_type === 'Date' && $ctrl.hasDefaultValue">
-  <div ng-click="setDefaultDateType(); $event.stopPropagation(); $event.target.blur();" class="af-gui-field-select-in-dropdown form-inline">
-    <select class="form-control" ng-model="getSet('default_date_type')" ng-model-options="{getterSetter: true}">
+  <div ng-click="$event.stopPropagation();" class="af-gui-field-select-in-dropdown form-inline">
+    <select class="form-control" ng-model="$ctrl.defaultDateType" ng-model-options="{getterSetter: true}">
       <option value="fixed">{{:: ts('Pick Date') }}</option>
       <option value="now">{{:: ts('Now') }}</option>
+      <option value="relative">{{:: ts('Relative') }}</option>
     </select>
   </div>
 </li>
-<li ng-if="$ctrl.hasDefaultValue && $ctrl.defaultDateType !== 'now'">
+<li ng-if="$ctrl.hasDefaultValue && $ctrl.defaultDateType() === 'relative'">
+  <form ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown form-inline">
+    <label>{{ ts('Now') + ($ctrl.defaultDateOffset() < 0 ? '' : ' +') }}</label>
+    <input class="form-control" type="number" ng-model="$ctrl.defaultDateOffset" ng-model-options="{getterSetter: true}">
+    <select class="form-control" ng-model="$ctrl.defaultDateUnit" ng-model-options="{getterSetter: true}">
+      <option value="day">{{ $ctrl.defaultDatePlural() ? ts('Days') : ts('Day') }}</option>
+      <option value="week">{{ $ctrl.defaultDatePlural() ? ts('Weeks') : ts('Week') }}</option>
+      <option value="year">{{ $ctrl.defaultDatePlural() ? ts('Years') : ts('Year') }}</option>
+    </select>
+  </form>
+</li>
+<li ng-if="$ctrl.hasDefaultValue && $ctrl.defaultDateType() === 'fixed'">
   <form ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown form-inline">
     <input class="form-control" af-gui-field-value="$ctrl.fieldDefn" ng-model="getSet('afform_default')" ng-model-options="{getterSetter: true}" >
   </form>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -66,14 +66,6 @@
           this.searchOperators = _.pick(this.searchOperators, ctrl.fieldDefn.operators);
         }
         setDateOptions();
-
-        if (ctrl.getDefn().input_type == 'Date') {
-          if (!getSet('default_date_type')) {
-            ctrl.defaultDateType = getSet('default_date_type', 'fixed');
-          } else {
-            ctrl.defaultDateType = getSet("default_date_type");
-          }
-        }
       };
 
       this.getFkEntity = function() {
@@ -288,8 +280,50 @@
         }
       };
 
-      $scope.setDefaultDateType = function() {
-        ctrl.defaultDateType = getSet('default_date_type');
+      this.defaultDateType = function(newValue) {
+        if (arguments.length) {
+          if (newValue === 'relative') {
+            getSet('afform_default', 'now +0 day');
+          }
+          if (newValue === 'now') {
+            getSet('afform_default', 'now');
+          }
+          if (newValue === 'fixed') {
+            getSet('afform_default', '');
+          }
+        }
+        if (this.fieldDefn.input_type === 'Date') {
+          const defaultVal = getSet('afform_default');
+          if (defaultVal === 'now') {
+            return 'now';
+          }
+          else if (typeof defaultVal === 'string' && defaultVal.startsWith('now')) {
+            return 'relative';
+          }
+        }
+        return 'fixed';
+      };
+
+      this.defaultDateOffset = function(newValue) {
+        let defaultVals = getSet('afform_default').split(' ');
+        if (arguments.length) {
+          defaultVals[1] = newValue < 0 ? newValue : '+' + newValue;
+          getSet('afform_default', defaultVals.join(' '));
+        }
+        return parseInt(defaultVals[1], 10);
+      };
+
+      this.defaultDateUnit = function(newValue) {
+        let defaultVals = getSet('afform_default').split(' ');
+        if (arguments.length) {
+          defaultVals[2] = newValue;
+          getSet('afform_default', defaultVals.join(' '));
+        }
+        return defaultVals[2];
+      };
+
+      this.defaultDatePlural = function() {
+        return Math.abs(this.defaultDateOffset()) !== 1;
       };
 
       $scope.defaultValueContains = function(val) {

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -123,10 +123,6 @@
           else if (ctrl.afFieldset.getStoredValue(ctrl.fieldName) !== undefined) {
             setValue(ctrl.afFieldset.getStoredValue(ctrl.fieldName));
           }
-          else if ('default_date_type' in ctrl.defn && ctrl.defn.default_date_type === 'now') {
-            let currentDate = new Date();
-            setValue(currentDate.toISOString().split('T')[0]);
-          }
           // Set default value based on field defn
           else if ('afform_default' in ctrl.defn) {
             setValue(ctrl.defn.afform_default);
@@ -188,6 +184,9 @@
         // correct the value type
         value = correctValueType(value, ctrl.defn.data_type);
 
+        if (ctrl.defn.input_type === 'Date' && typeof value === 'string' && value.startsWith('now')) {
+          value = getRelativeDate(value);
+        }
         if (ctrl.defn.input_type === 'Number' && ctrl.defn.search_range) {
           if (!_.isPlainObject(value)) {
             value = {
@@ -346,6 +345,24 @@
         }
         return currentVal;
       };
+
+      function getRelativeDate(dateString) {
+        const parts = dateString.split(' ');
+        const baseDate = new Date();
+        let unit = parts[2] || 'day';
+        let offset = parseInt(parts[1] || '0', 10);
+
+        switch (unit) {
+          case 'week':
+            offset *= 7;
+            break;
+
+          case 'year':
+            offset *= 365;
+        }
+        let newDate = new Date(baseDate.getTime() + offset * 24 * 60 * 60 * 1000);
+        return newDate.toISOString().split('T')[0];
+      }
 
     }
   });


### PR DESCRIPTION
Overview
----------------------------------------
This fixes bugs in #28014 as well as the bug reported in https://lab.civicrm.org/dev/core/-/issues/5104 to make it possible to use relative dates in an Afform default value.

Before
----------------------------------------
The only relative date available was "now" and it was not selectable due to js errors.

After
----------------------------------------
Multiple relative date options (either now, or x days/weeks/~~months~~/years before/after now).

Technical Details
----------------------------------------
This takes a different approach to #28014 in that it re-uses the `afform_default` property rather than making a new property.