### PR TITLE
Add deprecation to class comment

### DIFF
--- a/CRM/Custom/Form/CustomData.php
+++ b/CRM/Custom/Form/CustomData.php
@@ -16,7 +16,9 @@
  */
 
 /**
- * this class builds custom data
+ * Deprecated class no longer used in core.
+ *
+ * @deprecated since 5.72 will be removed around 5.92
  */
 class CRM_Custom_Form_CustomData {
 


### PR DESCRIPTION
I left a fairly long deprecation period as the functions do not have active deprecation warnings - php8.2 warnings will likely be enough & hopefully people can replace with form builder rather than another iteration of this
