### PR TITLE
dev/core#5112 5.71 regression fix display of custom groups with no searchale fields

### DIFF
--- a/CRM/Core/BAO/Query.php
+++ b/CRM/Core/BAO/Query.php
@@ -24,6 +24,12 @@ class CRM_Core_BAO_Query {
     $groupDetails = CRM_Core_BAO_CustomGroup::getGroupDetail(NULL, TRUE, $extends);
     if ($groupDetails) {
       foreach ($groupDetails as $group) {
+        if (empty($group['fields'])) {
+          // if there are no searchable fields in the custom group remove it
+          // from the details to avoid empty accordians per
+          // https://lab.civicrm.org/dev/core/-/issues/5112
+          unset($groupDetails[$group['id']]);
+        }
         foreach ($group['fields'] as $field) {
           $fieldId = $field['id'];
           $elementName = 'custom_' . $fieldId;


### PR DESCRIPTION


Overview
----------------------------------------
This addresses a 5.71 regression where an empty accordian started showing for 'eligible' custom groups with no searchable custom fields on search forms

Warning - if testing beware caching

Before
----------------------------------------
If you have a custom field group that extends (e.g) Case but there are no searchable fields in it an empty accordian is displayed

After
----------------------------------------
The accordian is suppressed

Technical Details
----------------------------------------
Although it affects 5.71 the requirement for a custom group with no searchable fields to replicate means this hasn't been reported 'in the wild'

Comments
----------------------------------------