### PR TITLE
Intro text on event confirm is actually html

### DIFF
--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -35,7 +35,7 @@
 
     {if $confirm_text}
         <div id="intro_text" class="crm-section event_confirm_text-section">
-          <p>{$confirm_text|escape}</p>
+          <p>{$confirm_text|purify}</p>
         </div>
     {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
html tags appear

Before
----------------------------------------
Add something to the intro text on an event config online registration tab
html tags appear when viewing the confirmation page

After
----------------------------------------
evil is still (mostly) suppressed

Technical Details
----------------------------------------


Comments
----------------------------------------
https://civicrm.stackexchange.com/questions/47774/html-in-confirmation-screen-introductory-text
