### PR TITLE
dev/core#5107 fix smarty syntax error that is bad in Smarty3+

### DIFF
--- a/templates/CRM/Contribute/Form/ContributionPage/Premium.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Premium.tpl
@@ -141,5 +141,5 @@
   {/literal}
 </script>
 {/crmRegion}
-{crmRegion name="contribute-form-contributionpage-premium-post}
+{crmRegion name="contribute-form-contributionpage-premium-post"}
 {/crmRegion}


### PR DESCRIPTION
Smarty2 let us get away with this but 3 ,4 , 5 don't

https://lab.civicrm.org/dev/core/-/issues/5107