### PR TITLE
Loosen weasyprint constraint to allow drupal 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,7 +103,7 @@
     "soundasleep/html2text": "^2.1",
     "psr/container": "~1.0 || ~2.0",
     "ext-fileinfo": "*",
-    "pontedilana/php-weasyprint": "^1",
+    "pontedilana/php-weasyprint": "^0.13.0 || ^1",
     "knplabs/knp-snappy": "^1.4"
   },
   "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20d2acf6ea0edb0c877aaa7f371614ab",
+    "content-hash": "c59a1388833927af758b5d9d808f3130",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",


### PR DESCRIPTION
Overview
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/29697 weasyprint was updated to 1.x, but this unintentionally prevents updating civi on drupal 9.

Before
----------------------------------------
composer something something meaningless to humans error message

After
----------------------------------------
ok

Technical Details
----------------------------------------
symfony/process in drupal 9 has to be 4.x. Weasyprint 1.x requires 5.x. So also allow weasyprint 0.13.0 which is what it was before.

The lock file is unchanged except the hash, so this doesn't change anything for tarballs.

Comments
----------------------------------------
Technically drupal 9 is EOL but civi still officially supports it. It can be more difficult depending on how many other modules/extensions you have to go from drupal 9 to 10 than it was from 8 to 9 because it requires php 8.1.

This is a bit difficult to test because of chicken/egg. It's possible to:
1. `git clone https://github.com/civicrm/civicrm-core.git` into some folder somewhere and apply this PR to it.
2. Then because composer is annoying, you'll also need to git clone https://github.com/civicrm/civicrm-drupal-8.git somewhere and edit its composer.json to require civicrm-core:dev-master because it won't recognize the repo in 1 properly. Well, it does, but it also doesn't.
3. Then download drupal 9, `composer create-project drupal/recommended-project:^9 some-path`, but then before downloading civi update composer.json like this:
```
"repositories": [
        {
            "type": "path",
            "url": "/path/to/civicrm-core",
            "options": {
                "symlink": false
            }
        },
        {
            "type": "path",
            "url": "/path/to/civicrm-drupal-8",
            "options": {
                "symlink": false
            }
        },
        {
            "type": "composer",
            "url": "https://packages.drupal.org/8"
        },
        {
          "type": "composer",
          "url": "https://packagist.org"
        }
    ],
```
4. Then do the civi composer download as normal, specifying dev-master for the version.