### PR TITLE
allow standalone's alternative access denied wording in afform test

### DIFF
--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformRoutingTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformRoutingTest.php
@@ -84,7 +84,7 @@ class AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \Civi\Tes
   private function assertNotAuthorized(\Psr\Http\Message\ResponseInterface $result, string $directive) {
     $contents = $result->getBody()->getContents();
     $this->assertEquals(403, $result->getStatusCode());
-    $this->assertMatchesRegularExpression(';You are not authorized to access;', $contents);
+    $this->assertMatchesRegularExpression(';(You are not authorized to access|You do not have permission to access);', $contents);
     $this->assertDoesNotMatchRegularExpression(';' . preg_quote("<$directive>", ';') . ';', $contents);
   }
 
@@ -96,7 +96,7 @@ class AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \Civi\Tes
   private function assertOpensPage(\Psr\Http\Message\ResponseInterface $result, string $directive) {
     $contents = $result->getBody()->getContents();
     $this->assertEquals(200, $result->getStatusCode());
-    $this->assertDoesNotMatchRegularExpression(';You are not authorized to access;', $contents);
+    $this->assertDoesNotMatchRegularExpression(';(You are not authorized to access|You do not have permission to access);', $contents);
     $this->assertMatchesRegularExpression(';' . preg_quote("<$directive>", ';') . ';', $contents);
   }
 


### PR DESCRIPTION
Before
----------------------------------------
Afform E2E tests currently require a specific wording on access denied, but standalone uses a slightly different one, so a couple of tests fail: https://test.civicrm.org/job/CiviCRM-Manual-Test/136/

After
----------------------------------------
Tests check for one of two wordings, pass on standalone too