### PR TITLE
dev/core#5082 Ensure that urls are correctly formatted if mailing url…

### DIFF
--- a/CRM/Mailing/BAO/MailingTrackableURL.php
+++ b/CRM/Mailing/BAO/MailingTrackableURL.php
@@ -141,7 +141,7 @@ class CRM_Mailing_BAO_MailingTrackableURL extends CRM_Mailing_DAO_MailingTrackab
     // Append the tokenised bits and the fragment.
     if ($tokenised_params) {
       // We know the URL will already have the '?'
-      $data .= '&' . implode('&', $tokenised_params);
+      $data .= (str_contains($data, '?') ? '&' : '?') . implode('&', $tokenised_params);
     }
     if (!empty($parsed[3])) {
       $data .= $parsed[3];

--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ClickTrackerTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ClickTrackerTest.php
@@ -151,4 +151,15 @@ class ClickTrackerTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
     $this->assertEquals('<p><a href="http://example.com/extern?u=1&amp;qid=1" rel=\'nofollow\'>See This</a></p>', $result);
   }
 
+  public function testTraditionalViewMailingTokenFormat(): void {
+    $filter = new HtmlClickTracker();
+    $msg = '<p><a href="http://civicrm.org/civicrm/mailing/view?id={mailing.key}&{contact.checksum}&cid={contact.contact_id}">View online</a></p>';
+    \runkit7_method_rename('\CRM_Mailing_BAO_MailingTrackableURL', 'getBasicTrackerURL', 'new_getBasicTrackerURL');
+    \runkit7_method_rename('\CRM_Mailing_BAO_MailingTrackableURL', 'orig_getBasicTrackerURL', 'getBasicTrackerURL');
+    $result = $filter->filterContent($msg, 1, 1);
+    \runkit7_method_rename('\CRM_Mailing_BAO_MailingTrackableURL', 'getBasicTrackerURL', 'orig_getBasicTrackerURL');
+    \runkit7_method_rename('\CRM_Mailing_BAO_MailingTrackableURL', 'new_getBasicTrackerURL', 'getBasicTrackerURL');
+    $this->assertEquals('<p><a href="http://civicrm.org/civicrm/mailing/view?id={mailing.key}&amp;{contact.checksum}&amp;cid={contact.contact_id}" rel=\'nofollow\'>View online</a></p>', $result);
+  }
+
 }


### PR DESCRIPTION
… is not converted to trackable format and there are no static params only token ones

Overview
----------------------------------------
This fixes a bug where a url like http://civicrm.org/civicrm/mailing/view?id={mailing.key}&{contact.checksum}&cid={contact.contact_id} as being converted to http://civicrm.org/civicrm/mailing/view&id={mailing.key}&{contact.checksum}&cid={contact.contact_id}

Before
----------------------------------------
Url mangled

After
----------------------------------------
url not mangled

ping @totten @eileenmcnaughton @agileware-justin 