### PR TITLE
Add check for whether SMARTY_DIR is defined

### DIFF
--- a/CRM/Core/Form/Renderer.php
+++ b/CRM/Core/Form/Renderer.php
@@ -233,7 +233,7 @@ class CRM_Core_Form_Renderer extends HTML_QuickForm_Renderer_ArraySmarty {
   public function _tplFetch($tplSource) {
     // Smarty3 does not have this function defined so the parent fails.
     // Adding this is preparatory to smarty 3....
-    if (!function_exists('smarty_function_eval') && !file_exists(SMARTY_DIR . '/plugins/function.eval.php')) {
+    if (!function_exists('smarty_function_eval') && (!defined('SMARTY_DIR') || !file_exists(SMARTY_DIR . '/plugins/function.eval.php'))) {
       $smarty = $this->_tpl;
       $smarty->assign('var', $tplSource);
       return $smarty->fetch("eval:$tplSource");

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -1042,7 +1042,7 @@ class CRM_Utils_String {
     // is invalid in Windows, causing failure.
     // Adding this is preparatory to smarty 3. The original PR failed some
     // tests so we check for the function.
-    if (!function_exists('smarty_function_eval') && !file_exists(SMARTY_DIR . '/plugins/function.eval.php')) {
+    if (!function_exists('smarty_function_eval') && (!defined('SMARTY_DIR') || !file_exists(SMARTY_DIR . '/plugins/function.eval.php'))) {
       try {
         $templateString = (string) $smarty->fetch('eval:' . $templateString);
       }


### PR DESCRIPTION
In Smarty5 it is not defined so will give a notice without this patch.

If is correct for Smarty5 to go down the Smarty3+ path in this if so behaviour is unchanged here
