### PR TITLE
asofDate gets used as constructor to DateTime which wants a string

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5504,7 +5504,7 @@ civicrm_relationship.start_date > {$today}
 
     $asofDateValues = $this->getWhereValues("{$fieldName}_asof_date", $grouping);
     // will be treated as current day
-    $asofDate = NULL;
+    $asofDate = '';
     if ($asofDateValues) {
       $asofDate = CRM_Utils_Date::processDate($asofDateValues[2]);
       $asofDateFormat = CRM_Utils_Date::customFormat(substr($asofDate, 0, 8));


### PR DESCRIPTION
Overview
----------------------------------------

The `$asofDate` variable defaults to NULL. This variable is later passed to the `calcDateFromAge` function, which in turn feeds it to the `DateTime` constructor.

But, the `DateTime` constructor wants a string, so we can errors.

By updating the default value of the date used to calculate age to be an empty string instead of NULL, it works without errors.

Before
----------------------------------------

I get errors like the following:

[PHP Deprecation] DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated at /var/www/powerbase/sites/all/modules/civicrm/CRM/Contact/BAO/Query.php:5582

After
----------------------------------------

No errors!


Comments
----------------------------------------

The calcDateFromAge function does not seem to be called from anywhere else in the code base. It might be called from extensions which might suggest we should convert from NULL to string in that function but that could happen later if needed.
