### PR TITLE
Display Tax only if its configured for the financial type

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -811,16 +811,21 @@ WHERE  id IN (" . implode(',', array_keys($priceFields)) . ')';
   public static function getTaxLabel($opt, $valueFieldName, $currency = NULL) {
     $taxTerm = Civi::settings()->get('tax_term');
     $displayOpt = Civi::settings()->get('tax_display_settings');
+    $taxRates = CRM_Core_PseudoConstant::getTaxRates();
     if ($displayOpt === 'Do_not_show') {
       $label = CRM_Utils_Money::format($opt[$valueFieldName] + $opt['tax_amount'], $currency);
     }
     elseif ($displayOpt === 'Inclusive') {
       $label = CRM_Utils_Money::format($opt[$valueFieldName] + $opt['tax_amount'], $currency);
-      $label .= '<span class="crm-price-amount-tax"> ' . ts('(includes %1 of %2)', [1 => $taxTerm, 2 => CRM_Utils_Money::format($opt['tax_amount'], $currency)]) . '</span>';
+      if (array_key_exists($opt['financial_type_id'], $taxRates)) {
+        $label .= '<span class="crm-price-amount-tax"> ' . ts('(includes %1 of %2)', [1 => $taxTerm, 2 => CRM_Utils_Money::format($opt['tax_amount'], $currency)]) . '</span>';
+      }
     }
     else {
       $label = CRM_Utils_Money::format($opt[$valueFieldName], $currency);
-      $label .= '<span class="crm-price-amount-tax"> + ' . CRM_Utils_Money::format($opt['tax_amount'], $currency) . ' ' . $taxTerm . '</span>';
+      if (array_key_exists($opt['financial_type_id'], $taxRates)) {
+        $label .= '<span class="crm-price-amount-tax"> + ' . CRM_Utils_Money::format($opt['tax_amount'], $currency) . ' ' . $taxTerm . '</span>';
+      }
     }
 
     return $label;


### PR DESCRIPTION
Overview
----------------------------------------
Display Tax only if its configured for the financial type.

Before
----------------------------------------
Replicated on dmaster -

- Visit https://dmaster.demo.civicrm.org/civicrm/contribute/transact?reset=1&id=1
- Enable Tax & Invoicing from https://dmaster.demo.civicrm.org/civicrm/admin/setting/preferences/contribute?reset=1
- Revisit the above donation page 

![image](https://github.com/civicrm/civicrm-core/assets/5929648/098e0a39-6539-4851-b790-2ebda6562822)


After
----------------------------------------
Display Tax label only if it applies on the financial type.

Technical Details
----------------------------------------
This was working in 5.65 and 5.66 as far as i can test. So it seems it regressed after 5.67 or later version.

Comments
----------------------------------------
@eileenmcnaughton Thoughts please.