### PR TITLE
Extension System: use settings instead of the config var

### DIFF
--- a/CRM/Extension/System.php
+++ b/CRM/Extension/System.php
@@ -86,10 +86,10 @@ class CRM_Extension_System {
   public function __construct($parameters = []) {
     $config = CRM_Core_Config::singleton();
     $parameters['maxDepth'] = CRM_Utils_Array::value('maxDepth', $parameters, \Civi::settings()->get('ext_max_depth'));
-    $parameters['extensionsDir'] = CRM_Utils_Array::value('extensionsDir', $parameters, $config->extensionsDir);
-    $parameters['extensionsURL'] = CRM_Utils_Array::value('extensionsURL', $parameters, $config->extensionsURL);
-    $parameters['resourceBase'] = CRM_Utils_Array::value('resourceBase', $parameters, $config->resourceBase);
-    $parameters['uploadDir'] = CRM_Utils_Array::value('uploadDir', $parameters, $config->uploadDir);
+    $parameters['extensionsDir'] = CRM_Utils_Array::value('extensionsDir', $parameters, \Civi::settings()->get('extensionsDir'));
+    $parameters['extensionsURL'] = CRM_Utils_Array::value('extensionsURL', $parameters, \Civi::settings()->get('extensionsURL'));
+    $parameters['resourceBase'] = CRM_Utils_Array::value('resourceBase', $parameters, \Civi::settings()->get('resourceBase'));
+    $parameters['uploadDir'] = CRM_Utils_Array::value('uploadDir', $parameters, \Civi::settings()->get('uploadDir'));
     $parameters['userFrameworkBaseURL'] = CRM_Utils_Array::value('userFrameworkBaseURL', $parameters, $config->userFrameworkBaseURL);
     if (!array_key_exists('civicrm_root', $parameters)) {
       $parameters['civicrm_root'] = $GLOBALS['civicrm_root'];


### PR DESCRIPTION
Overview
----------------------------------------

I was running into odd undefined properties on an install, and noticed that this function is already using a mix of settings and config. Switching them all to settings made the problem go away.

Before
----------------------------------------

Site-specific extensions were not detected (in `[civicrm.files]/ext`), and I had this warning in the logs:

```
PHP Warning:  Undefined property: CRM_Core_Config::$extensionsDir in [...]/wp-content/plugins/civicrm/civicrm/CRM/Extension/System.php on line 89
```

The site where this happened did seem to be experience some sort of glitch. Initially, the client complained they could not login because the default currency setting had been lost. Re-creating that setting fixed that problem, but then I noticed that client-specific extensions were not loading.

Oddly, only the `Dir` settings were having issues (`extensionsDir`, `uploadDir`), and also the site had lost its default currency setting. Everything else was OK. Despite deleting settings in the DB and re-creating, the `extensionsDir` setting didn't fix itself (but the default currency setting was OK once I set it back).

After
----------------------------------------

No warning, all working as expected.

Comments
----------------------------------------

`$config` is hard to debug.

I would have liked to get rid of `$config->userFrameworkBaseURL` too, but I don't think there is an alternative for that?