### PR TITLE
Fix for `TypeError: array_key_exists(): Argument #2 ($array) must be …

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -845,11 +845,11 @@ class CRM_Core_DAO extends DB_DataObject {
     $primaryKey = $this->getFirstPrimaryKey();
     foreach ($this->fields() as $uniqueName => $field) {
       $dbName = $field['name'];
-      if (array_key_exists($dbName, $params)) {
+      if (is_array($params) && array_key_exists($dbName, $params)) {
         $value = $params[$dbName];
         $exists = TRUE;
       }
-      elseif (array_key_exists($uniqueName, $params)) {
+      elseif (is_array($params) && array_key_exists($uniqueName, $params)) {
         $value = $params[$uniqueName];
         $exists = TRUE;
       }


### PR DESCRIPTION
…of type array, null given a CRM_Core_DAO->copyValues()

I have not been able to identify the exact source of the error, but the fact is that after a series of updates, from Core to 5.71.1, Drupal modules, CiviCRM extensions and from PHP 8.0 to 8.1 for users with ACL permissions I get this error

`TypeError: array_key_exists(): Argument #2 ($array) must be of type array, null given a CRM_Core_DAO->copyValues()`

These users can practically do nothing.

This PR prevents the fatal error and restores normal operation for these users.