### PR TITLE
Additional Payments form: Use submitted trxn_id if payment result doesn't exist

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -335,7 +335,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       'pan_truncation' => substr((string) $this->getSubmittedValue('credit_card_number'), -4),
       'trxn_result_code' => $paymentResult['trxn_result_code'] ?? NULL,
       'payment_instrument_id' => $this->getSubmittedValue('payment_instrument_id'),
-      'trxn_id' => $paymentResult['trxn_id'] ?? NULL,
+      'trxn_id' => $paymentResult['trxn_id'] ?? ($this->getSubmittedValue('trxn_id') ?? NULL),
       'trxn_date' => $this->getSubmittedValue('trxn_date'),
       // This form sends payment notification only, for historical reasons.
       'is_send_contribution_notification' => FALSE,


### PR DESCRIPTION
Overview
----------------------------------------
Respect the Transaction ID submitted on the Additional Payment form for manual transactions.

Before
----------------------------------------
When adding a payment using CRM_Contribute_Form_AdditionalPayment, for example when clicking on the Record Payment link on an existing contribution on a contact's Contributions tab, the Transaction ID was not saved.

After
----------------------------------------
The transaction ID is now saved.

Technical Details
----------------------------------------
The parameters passed to the Payment API's create used the transaction ID from the result of processCreditCard. But for a manual payment where there's a transaction ID entered, that result won't exist, and the submitted transaction ID is never referenced.
This fix uses the result from processCreditCard if it exists, and the submitted value or NULL otherwise.

Comments
----------------------------------------
Tested this by adding an event to a contact with a partial payment, then going to the Contributions tab, expanding the contribution, clicking Record Payment and adding a Transaction ID there.
