### PR TITLE
fix reference to dashboard contact

### DIFF
--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -60,6 +60,9 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
 
       $params = [
         'select' => ['*', 'dashboard_contact.*'],
+        'join' => [
+          ['DashboardContact AS dashboard_contact', 'LEFT'],
+        ],
         'where' => [
           ['domain_id', '=', 'current_domain'],
         ],


### PR DESCRIPTION
Overview
----------------------------------------
This API call references `dashboard_contact.*`, which doesn't exist because there's no join..

Before
----------------------------------------
Seems ok.

After
----------------------------------------
Seems ok.

Comments
----------------------------------------
This wasn't causing an issue for me, and there's been no change to this file in 9 months, so maybe not anyone else either.  It was just throwing an exception I caught during other troubleshooting and it looked easy enough to address.
