### PR TITLE
Update Smarty3 check to refer to Smarty4

### DIFF
--- a/CRM/Utils/Check/Component/Smarty.php
+++ b/CRM/Utils/Check/Component/Smarty.php
@@ -23,25 +23,21 @@ class CRM_Utils_Check_Component_Smarty extends CRM_Utils_Check_Component {
    *
    * @return CRM_Utils_Check_Message[]
    */
-  public function checkSmarty3(): array {
-    $p = function($text) {
-      return '<p>' . $text . '</p>';
-    };
-
+  public function checkSmartyVersion(): array {
     $messages = [];
     if (!defined('CIVICRM_SMARTY_AUTOLOAD_PATH') && !defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
-      $smartyPath = \Civi::paths()->getPath('[civicrm.packages]/smarty3/vendor/autoload.php');
+      $smartyPath = \Civi::paths()->getPath('[civicrm.packages]/smarty4/vendor/autoload.php');
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        $p(ts('CiviCRM is updating a major library (<em>Smarty</em>) to improve performance and security. In CiviCRM v5.69, the update is optional, but you should try it now.'))
-        . $p(ts('To apply the update, add this statement to <code>civicrm.settings.php</code>:'))
-        . sprintf("<pre>  define('CIVICRM_SMARTY_AUTOLOAD_PATH',\n    %s);</pre>", htmlentities(var_export($smartyPath, 1)))
-        . $p('Some extensions may not work yet with Smarty v3. If you encounter problems, then simply remove the statement.')
-        . $p(ts('Upcoming versions will standardize on Smarty v3. CiviCRM <a %1>v5.69-ESR</a> will provide extended support for Smarty v2. To learn more and discuss, see the <a %2>Smarty transition page</a>.', [
+        '<p>' . (ts('CiviCRM is updating a major library (<em>Smarty</em>) to improve performance and security and php 8.3 compatibility. The update is currently optional, but you should try it now.')) . '</p>'
+        . '<p>' . (ts('To apply the update, add this statement to <code>civicrm.settings.php</code>:'))
+        . sprintf("<pre>  define('CIVICRM_SMARTY_AUTOLOAD_PATH',\n    %s);</pre>", htmlentities(var_export($smartyPath, 1))) . '</p>'
+        . '<p>' . ('Some extensions may not work yet with Smarty v4. If you encounter problems, then simply remove the statement.') . '</p>'
+        . '<p>' . (ts('Upcoming versions will standardize on Smarty v4. CiviCRM <a %1>v5.69-ESR</a> will provide extended support for Smarty v2. To learn more and discuss, see the <a %2>Smarty transition page</a>.' . '</p>', [
           1 => 'target="_blank" href="' . htmlentities('https://civicrm.org/esr') . '"',
           2 => 'target="_blank" href="' . htmlentities('https://civicrm.org/redirect/smarty-v3') . '"',
         ])),
-        ts('Smarty Update (v2 => v3)'),
+        ts('Smarty Update (v2 => v4)'),
         LogLevel::WARNING,
         'fa-lock'
       );


### PR DESCRIPTION
Overview
----------------------------------------
Update Smarty3 check to refer to Smarty4

Before
----------------------------------------
Check refers to Smarty 3

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/879f163e-5ef9-4833-a67a-4eefb93d6994)


Technical Details
----------------------------------------
@demeritcowboy 

Comments
----------------------------------------
