### PR TITLE
Pass parameters to dedupe fill table

### DIFF
--- a/CRM/Dedupe/BAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/BAO/DedupeRuleGroup.php
@@ -22,8 +22,11 @@
 class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
 
   /**
-   * Ids of the contacts to limit the SQL queries (whole-database queries otherwise)
    * @var array
+   *
+   * Ids of the contacts to limit the SQL queries (whole-database queries otherwise)
+   *
+   * @internal
    */
   public $contactIds = [];
 
@@ -33,6 +36,7 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
    * @param array $contactIds
    */
   public function setContactIds($contactIds) {
+    CRM_Core_Error::deprecatedWarning('unused');
     $this->contactIds = $contactIds;
   }
 
@@ -44,7 +48,13 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
 
   /**
    * If there are no rules in rule group.
+   *
    * @var bool
+   *
+   * @deprecated this was introduced in https://github.com/civicrm/civicrm-svn/commit/15136b07013b3477d601ebe5f7aa4f99f801beda
+   * as an awkward way to avoid fatalling on an invalid rule set with no rules.
+   *
+   * Passing around a property is a bad way to do that check & we will work to remove.
    */
   public $noRules = FALSE;
 
@@ -410,14 +420,25 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
   }
 
   /**
+   * Fill the dedupe finder table.
+   *
+   * @internal do not access from outside core.
+   *
+   * @param int $id
+   * @param array $contactIDs
+   * @param array $params
+   *
    * @return void
    * @throws \Civi\Core\Exception\DBQueryException
    */
-  public function fillTable(): void {
+  public function fillTable(int $id, array $contactIDs, array $params): void {
+    $this->contactIds = $contactIDs;
+    $this->params = $params;
+    $this->id = $id;
     // get the list of queries handy
     $tableQueries = $this->tableQuery();
 
-    if ($this->params && !$this->noRules) {
+    if ($params && !empty($tableQueries)) {
       $this->temporaryTables['dedupe'] = CRM_Utils_SQL_TempTable::build()
         ->setCategory('dedupe')
         ->createWithColumns("id1 int, weight int, UNIQUE UI_id1 (id1)")->getName();

--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -41,12 +41,11 @@ class CRM_Dedupe_Finder {
   public static function dupes($rgid, $cids = [], $checkPermissions = TRUE) {
     $rgBao = new CRM_Dedupe_BAO_DedupeRuleGroup();
     $rgBao->id = $rgid;
-    $rgBao->contactIds = $cids;
     if (!$rgBao->find(TRUE)) {
       throw new CRM_Core_Exception('Dedupe rule not found for selected contacts');
     }
 
-    $rgBao->fillTable();
+    $rgBao->fillTable($rgid, $cids, []);
     $dao = CRM_Core_DAO::executeQuery($rgBao->thresholdQuery($checkPermissions));
     $dupes = [];
     while ($dao->fetch()) {
@@ -120,8 +119,8 @@ class CRM_Dedupe_Finder {
       $orig = $params['civicrm_phone']['phone_numeric'];
       $params['civicrm_phone']['phone_numeric'] = preg_replace('/[^\d]/', '', $orig);
     }
-    $rgBao->params = $params;
-    $rgBao->fillTable();
+
+    $rgBao->fillTable($rgBao->id, [], $params);
 
     $dao = CRM_Core_DAO::executeQuery($rgBao->thresholdQuery($checkPermission));
     $dupes = [];


### PR DESCRIPTION
Overview
----------------------------------------
Pass parameters to dedupe fill table

Before
----------------------------------------
Function uses confusing way to pass parameters - it sets the properties before calling the function, rather than passing them in. 

On digging it seems like the properties are then used in `thresholdQuery` which is also called from the same calling function & would logicaly also take `$params` as a parameter but that is out of scope of this change

Function is not called from elsewhere in universe
![image](https://github.com/civicrm/civicrm-core/assets/336308/cffd4eb5-ae0c-4d37-bffd-510db5dadfc9)


After
----------------------------------------
The parameters are passed in

Technical Details
----------------------------------------
I also set up id to be an integer input - moving towards this being a static function to reflect how it is called

Comments
----------------------------------------
