### PR TITLE
StandaloneCivicrmFilesPath - Fix WP installation. Focus on Standalone

### DIFF
--- a/setup/plugins/installFiles/StandaloneCivicrmFilesPath.civi-setup.php
+++ b/setup/plugins/installFiles/StandaloneCivicrmFilesPath.civi-setup.php
@@ -14,6 +14,12 @@ if (!defined('CIVI_SETUP')) {
     \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'checkRequirements'));
     $m = $e->getModel();
 
+    if ($m->cms !== 'Standalone') {
+      // The installers on WP+J don't prepopulate $m->paths['civicrm.files'].
+      // TODO: Maybe they should? It would probably be good for all UF's to follow same codepaths for setting up the folder.
+      return;
+    }
+
     $civicrmFilesDirectory = $m->paths['civicrm.files']['path'] ?? '';
 
     if (!$civicrmFilesDirectory) {


### PR DESCRIPTION
Overview
----------------

This is a followup to 82418bf0cb03f46c6a8b2bb1438938acedfc27c3 which added an extra pre-installation check for handling `civicrm.files`.

Revision History
----------------

* `5.71` does not have `StandaloneCivicrmFilesPath`. Installation works normally on WordPress.
* `5.72.beta1` does have `StandaloneCivicrmFilesPath`. It was QA'd for Standalone usage. But it blocks web-based installation on WordPress. (It may also affect Joomla, but I haven't verified.)
* `5.72.beta{next}` (this patch) still includes `StandaloneCivicrmFilesPath`, but it only applies to Standalone.

Technical Details
----------------------------------------

A couple things to know about how it got here:

1. The `$m->paths` property was originally written as a supplement/override. (It replaces whatever default was historically in place for the local Civi-UF installation.) So it was an optional property. (D7/D9/BD/SA all seem to set it. But WP/J don't.)
2. In the nightly tests of Civi-WP, it appears that we still use the old install protocol (i.e. `mysql < sql/civicrm.mysql` -- rather than `Civi\Setup`). But all the other  install-paths for WordPress (`cv`, `wp-cli`, web UI) have been switched over to `Civi\Setup`.  So they are impacted.

So that's a couple things we should probably address in follow-ups.

However, given that it's release-time for 5.72, it seems safest to walk-back a little on the `StandaloneCivicrmFilesPath` guard. It'll appliy to `Standalone` (where it was intended+tested).