### PR TITLE
dev/core#5123: Membership Dashboard not shown

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1655,12 +1655,18 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
    * @throws \CRM_Core_Exception
    */
   public static function isSubscriptionCancelled(int $membershipID): bool {
-    // Check permissions set to false 'in case' - ideally would check permissions are
-    // correct & remove.
-    return (bool) Membership::get(FALSE)
-      ->addWhere('id', '=', $membershipID)
-      ->addWhere('contribution_recur_id.contribution_status_id:name', '=', 'Cancelled')
-      ->selectRowCount()->execute()->count();
+    $isCiviContributeEnabled = CRM_Extension_System::singleton()
+      ->getManager()
+      ->isEnabled('civi_contribute');
+    if ($isCiviContributeEnabled) {
+      // Check permissions set to false 'in case' - ideally would check permissions are
+      // correct & remove.
+      return (bool) Membership::get(FALSE)
+        ->addWhere('id', '=', $membershipID)
+        ->addWhere('contribution_recur_id.contribution_status_id:name', '=', 'Cancelled')
+        ->selectRowCount()->execute()->count();
+    }
+    return FALSE;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

When clicking on Memberships --> Dashboard the screen shows an error when Civi Contribute is disabled

Before
----------------------------------------

When Civi Contribute is disabled clicking the Memberships --> Dashboards it gives an error.

![2024-04-04_12-56](https://github.com/civicrm/civicrm-core/assets/4126292/edde295c-3855-478c-8e59-c685d7258546)


After
----------------------------------------

Error is gone

Technical Details
----------------------------------------

Behind the screen the membership checks whether a contribution recur is cancelled for a membership. The contribution recur api does not exists when Civi Contribute is disabled. 

Comments
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/5123
