### PR TITLE
dev/core#5123 Membership dashboard not shown (fix in api4)

### DIFF
--- a/Civi/Api4/Service/Schema/Joinable/Joinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/Joinable.php
@@ -313,17 +313,18 @@ class Joinable {
 
   public function getEntityFields(): array {
     $entityFields = [];
-    /** @var \Civi\Api4\Service\Spec\SpecGatherer $gatherer */
-    $gatherer = \Civi::container()->get('spec_gatherer');
-    $allFields = $gatherer->getAllFields($this->entity, 'get');
-    foreach ($allFields as $field) {
-      if ($field['table_name'] === $this->targetTable) {
-        // Serialized fields require a specialized join
-        if ($this->serialize) {
-          $field['serialize'] = \CRM_Core_DAO::SERIALIZE_SEPARATOR_TRIMMED;
-          $field['sql_renderer'] = ['Civi\Api4\Query\Api4SelectQuery', 'renderSerializedJoin'];
+    if (!empty($this->entity)) {
+      $gatherer = \Civi::container()->get('spec_gatherer');
+      $allFields = $gatherer->getAllFields($this->entity, 'get');
+      foreach ($allFields as $field) {
+        if ($field['table_name'] === $this->targetTable) {
+          // Serialized fields require a specialized join
+          if ($this->serialize) {
+            $field['serialize'] = \CRM_Core_DAO::SERIALIZE_SEPARATOR_TRIMMED;
+            $field['sql_renderer'] = ['Civi\Api4\Query\Api4SelectQuery', 'renderSerializedJoin'];
+          }
+          $entityFields[] = $field;
         }
-        $entityFields[] = $field;
       }
     }
     return $entityFields;


### PR DESCRIPTION
Overview
----------------------------------------

When Civi Contribute is disabled, the membership dashboard is not shown. This PR fixes an issue in the Api4 functionality so that it fails with a nicer error message. 

There is also another PR which checks whether Civi Contribute is installed (https://github.com/civicrm/civicrm-core/pull/29882)

Before
----------------------------------------

When Civi Contribute is disabled clicking the Memberships --> Dashboards it gives an error.

![2024-04-04_12-56](https://github.com/civicrm/civicrm-core/assets/4126292/ef288026-89a5-47e7-9d87-5d719fe71ae4)

After
----------------------------------------

When Civi Contribute is disabled clicking the Memberships --> Dashboards it gives a nicer error message

![2024-04-04_14-20](https://github.com/civicrm/civicrm-core/assets/4126292/14ce8110-b8d4-4862-929e-9135f9d7d732)


Comments
----------------------------------------

See as well this related issue: https://lab.civicrm.org/dev/core/-/issues/5123
