### PR TITLE
Angular Datepicker - Default to +-100 year range

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -82,17 +82,21 @@
           ngModel.$render = function () {
             element.val(ngModel.$viewValue).change();
           };
+          let settings = angular.copy(scope.crmUiDatepicker || {});
+          // Set defaults to be non-restrictive
+          settings.start_date_years = settings.start_date_years || 100;
+          settings.end_date_years = settings.end_date_years || 100;
 
           element
-            .crmDatepicker(scope.crmUiDatepicker)
+            .crmDatepicker(settings)
             .on('change', function() {
               // Because change gets triggered from the $render function we could be either inside or outside the $digest cycle
               $timeout(function() {
-                var requiredLength = 19;
-                if (scope.crmUiDatepicker && scope.crmUiDatepicker.time === false) {
+                let requiredLength = 19;
+                if (settings.time === false) {
                   requiredLength = 10;
                 }
-                if (scope.crmUiDatepicker && scope.crmUiDatepicker.date === false) {
+                if (settings.date === false) {
                   requiredLength = 8;
                 }
                 ngModel.$setValidity('incompleteDateTime', !(element.val().length && element.val().length !== requiredLength));

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/date.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/date.html
@@ -10,7 +10,7 @@
   <div class="form-group" ng-switch="$ctrl.dateType">
 
     <div class="form-group" ng-switch-when="fixed">
-      <input class="form-control" crm-ui-datepicker="{time: $ctrl.field.data_type === 'Timestamp', start_date_years: 100, end_date_years: 100}" ng-model="$ctrl.value" ng-required="!$ctrl.field.nullable" ng-if="!$ctrl.isMulti()">
+      <input class="form-control" crm-ui-datepicker="{time: $ctrl.field.data_type === 'Timestamp'}" ng-model="$ctrl.value" ng-required="!$ctrl.field.nullable" ng-if="!$ctrl.isMulti()">
       <input class="form-control" crm-multi-select-date ng-model="$ctrl.value" ng-required="!$ctrl.field.nullable" ng-if="$ctrl.isMulti()">
     </div>
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes datepicker widgets to be less restrictive in FormBuilder.

Before
----------------------------------------
Previously the default was +0 -10 years, which does not give a very wide selection of dates.

After
----------------------------------------
A 200-year range is selectable.

Comments
----------------------------------------
This basically moves the default added by #27935 one layer down into the widget itself, since the problem presents in more than just that one place.