### PR TITLE
support content-type of application/json on AJAX requests

### DIFF
--- a/CRM/Utils/Request.php
+++ b/CRM/Utils/Request.php
@@ -167,6 +167,11 @@ class CRM_Utils_Request {
     if ($_POST) {
       $result = array_merge($result, $_POST);
     }
+    if ($_SERVER['REQUEST_METHOD'] === 'POST' && $_SERVER['CONTENT_TYPE'] === 'application/json') {
+      $rawPost = file_get_contents('php://input');
+      $jsonPost = json_decode($rawPost, TRUE) ?? [];
+      $result = array_merge($result, $jsonPost);
+    }
     return $result;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
AJAX requests can't have a content-type of `application/json`.  That surprised me - I assumed API4 would use this all over the place, but it looks like there's a lot of passing JSON in the URL arguments.

Before
----------------------------------------
Can't send AJAX request of type `application-json` to `https://mysite.org/civicrm/ajax/rest` - though interestingly, the `https://mysite.org/wp-json` *does* accept JSON, presumably because it gets munged first by WP.

After
----------------------------------------
`application/json` accepted.

Technical Details
----------------------------------------
You need a [particular technique](https://www.geeksforgeeks.org/how-to-receive-json-post-with-php/) to read JSON from a POST request with PHP.