### PR TITLE
(dev/translation#85) CiviMail/CiviCase - Fix string loading (5.72-stable)

### DIFF
--- a/ext/civi_case/ang/crmCaseType.js
+++ b/ext/civi_case/ang/crmCaseType.js
@@ -244,7 +244,7 @@
 
     (function init () {
 
-      ts = $scope.ts = CRM.ts(null);
+      ts = $scope.ts = CRM.ts('civi_case');
       $scope.hs = crmUiHelp({file: 'CRM/Case/CaseType'});
       $scope.locks = { caseTypeName: true, activitySetName: true };
       $scope.workflows = { timeline: 'Timeline', sequence: 'Sequence' };
@@ -715,7 +715,7 @@
   });
 
   crmCaseType.controller('CaseTypeListCtrl', function($scope, crmApi, caseTypes) {
-    var ts = $scope.ts = CRM.ts(null);
+    var ts = $scope.ts = CRM.ts('civi_case');
 
     $scope.caseTypes = caseTypes.values;
     $scope.toggleCaseType = function (caseType) {

--- a/ext/civi_mail/ang/crmMailing/BlockPreview.js
+++ b/ext/civi_mail/ang/crmMailing/BlockPreview.js
@@ -10,7 +10,7 @@
           scope.mailing = newValue;
         });
         scope.crmMailingConst = CRM.crmMailing;
-        scope.ts = CRM.ts(null);
+        scope.ts = CRM.ts('civi_mail');
         scope.hs = crmUiHelp({file: 'CRM/Mailing/MailingUI'});
         scope.testContact = {email: CRM.crmMailing.defaultTestEmail};
         scope.testGroup = {gid: null};

--- a/ext/civi_mail/ang/crmMailing/BlockReview.js
+++ b/ext/civi_mail/ang/crmMailing/BlockReview.js
@@ -15,7 +15,7 @@
           scope.attachments = newValue;
         });
         scope.crmMailingConst = CRM.crmMailing;
-        scope.ts = CRM.ts(null);
+        scope.ts = CRM.ts('civi_mail');
         scope.previewMailing = function previewMailing(mailing, mode) {
           return crmMailingPreviewMgr.preview(mailing, mode);
         };

--- a/ext/civi_mail/ang/crmMailing/EditMailingCtrl.js
+++ b/ext/civi_mail/ang/crmMailing/EditMailingCtrl.js
@@ -9,7 +9,7 @@
     $scope.checkPerm = CRM.checkPerm;
     $scope.mailingFields = mailingFields;
 
-    var ts = $scope.ts = CRM.ts(null);
+    var ts = $scope.ts = CRM.ts('civi_mail');
     $scope.hs = crmUiHelp({file: 'CRM/Mailing/MailingUI'});
     var block = $scope.block = crmBlocker();
     var myAutosave = null;

--- a/ext/civi_mail/ang/crmMailing/EditRecipCtrl.js
+++ b/ext/civi_mail/ang/crmMailing/EditRecipCtrl.js
@@ -11,7 +11,7 @@
     var SETTING_DEBOUNCE_MS = 5000;
     var RECIPIENTS_PREVIEW_LIMIT = 50;
 
-    var ts = $scope.ts = CRM.ts();
+    var ts = $scope.ts = CRM.ts('civi_mail');
 
     $scope.recipients = null;
     $scope.outdated = null;

--- a/ext/civi_mail/ang/crmMailing/EditRecipOptionsDialogCtrl.js
+++ b/ext/civi_mail/ang/crmMailing/EditRecipOptionsDialogCtrl.js
@@ -5,7 +5,7 @@
   //   - "mailing" (APIv3 mailing object)
   //   - "fields" (list of fields)
   angular.module('crmMailing').controller('EditRecipOptionsDialogCtrl', function EditRecipOptionsDialogCtrl($scope, crmUiHelp) {
-    $scope.ts = CRM.ts(null);
+    $scope.ts = CRM.ts('civi_mail');
     $scope.hs = crmUiHelp({file: 'CRM/Mailing/MailingUI'});
   });
 

--- a/ext/civi_mail/ang/crmMailing/EmailAddrCtrl.js
+++ b/ext/civi_mail/ang/crmMailing/EmailAddrCtrl.js
@@ -1,7 +1,7 @@
 (function(angular, $, _) {
 
   angular.module('crmMailing').controller('EmailAddrCtrl', function EmailAddrCtrl($scope, crmFromAddresses, crmUiAlert) {
-    var ts = CRM.ts(null);
+    var ts = CRM.ts('civi_mail');
 
     function changeAlert(winnerField, loserField) {
       crmUiAlert({

--- a/ext/civi_mail/ang/crmMailing/EmailBodyCtrl.js
+++ b/ext/civi_mail/ang/crmMailing/EmailBodyCtrl.js
@@ -2,7 +2,7 @@
 
   var lastEmailTokenAlert = null;
   angular.module('crmMailing').controller('EmailBodyCtrl', function EmailBodyCtrl($scope, crmMailingMgr, crmUiAlert, $timeout) {
-    var ts = CRM.ts(null);
+    var ts = CRM.ts('civi_mail');
 
     // ex: if (!hasAllTokens(myMailing, 'body_text)) alert('Oh noes!');
     $scope.hasAllTokens = function hasAllTokens(mailing, field) {

--- a/ext/civi_mail/ang/crmMailing/MsgTemplateCtrl.js
+++ b/ext/civi_mail/ang/crmMailing/MsgTemplateCtrl.js
@@ -2,7 +2,7 @@
 
   // Controller for the in-place msg-template management
   angular.module('crmMailing').controller('MsgTemplateCtrl', function MsgTemplateCtrl($scope, crmMsgTemplates, dialogService) {
-    var ts = $scope.ts = CRM.ts(null);
+    var ts = $scope.ts = CRM.ts('civi_mail');
     $scope.crmMsgTemplates = crmMsgTemplates;
     $scope.checkPerm = CRM.checkPerm;
     // @return Promise MessageTemplate (per APIv3)

--- a/ext/civi_mail/ang/crmMailing/PreviewComponentCtrl.js
+++ b/ext/civi_mail/ang/crmMailing/PreviewComponentCtrl.js
@@ -3,7 +3,7 @@
   // Controller for the "Preview Mailing Component" segment
   // which displays header/footer/auto-responder
   angular.module('crmMailing').controller('PreviewComponentCtrl', function PreviewComponentCtrl($scope, dialogService) {
-    var ts = $scope.ts = CRM.ts(null);
+    var ts = $scope.ts = CRM.ts('civi_mail');
 
     $scope.previewComponent = function previewComponent(title, componentId) {
       var component = _.where(CRM.crmMailing.headerfooterList, {id: "" + componentId});

--- a/ext/civi_mail/ang/crmMailing/PreviewComponentDialogCtrl.js
+++ b/ext/civi_mail/ang/crmMailing/PreviewComponentDialogCtrl.js
@@ -7,7 +7,7 @@
   //   - "body_html"
   //   - "body_text"
   angular.module('crmMailing').controller('PreviewComponentDialogCtrl', function PreviewComponentDialogCtrl($scope) {
-    $scope.ts = CRM.ts(null);
+    $scope.ts = CRM.ts('civi_mail');
   });
 
 })(angular, CRM.$, CRM._);

--- a/ext/civi_mail/ang/crmMailing/PreviewMailingDialogCtrl.js
+++ b/ext/civi_mail/ang/crmMailing/PreviewMailingDialogCtrl.js
@@ -6,7 +6,7 @@
   //   - "body_html"
   //   - "body_text"
   angular.module('crmMailing').controller('PreviewMailingDialogCtrl', function PreviewMailingDialogCtrl($scope) {
-    $scope.ts = CRM.ts(null);
+    $scope.ts = CRM.ts('civi_mail');
   });
 
 })(angular, CRM.$, CRM._);

--- a/ext/civi_mail/ang/crmMailing/PreviewRecipCtrl.js
+++ b/ext/civi_mail/ang/crmMailing/PreviewRecipCtrl.js
@@ -4,7 +4,7 @@
   // Note: Expects $scope.model to be an object with properties:
   //   - recipients: array of contacts
   angular.module('crmMailing').controller('PreviewRecipCtrl', function($scope) {
-    $scope.ts = CRM.ts(null);
+    $scope.ts = CRM.ts('civi_mail');
   });
 
 })(angular, CRM.$, CRM._);

--- a/ext/civi_mail/ang/crmMailing/SaveMsgTemplateDialogCtrl.js
+++ b/ext/civi_mail/ang/crmMailing/SaveMsgTemplateDialogCtrl.js
@@ -9,7 +9,7 @@
   //       - "msg_text": string
   //       - "msg_html": string
   angular.module('crmMailing').controller('SaveMsgTemplateDialogCtrl', function SaveMsgTemplateDialogCtrl($scope, crmMsgTemplates, dialogService) {
-    var ts = $scope.ts = CRM.ts(null);
+    var ts = $scope.ts = CRM.ts('civi_mail');
     $scope.saveOpt = {mode: '', newTitle: ''};
     $scope.selected = null;
 

--- a/ext/civi_mail/ang/crmMailing/services.js
+++ b/ext/civi_mail/ang/crmMailing/services.js
@@ -639,7 +639,7 @@
             scope.mailing = newValue;
           });
           scope.crmMailingConst = CRM.crmMailing;
-          scope.ts = CRM.ts(null);
+          scope.ts = CRM.ts('civi_mail');
           scope.hs = crmUiHelp({file: 'CRM/Mailing/MailingUI'});
           scope.checkPerm = CRM.checkPerm;
           scope[directiveName] = attr[directiveName] ? scope.$parent.$eval(attr[directiveName]) : {};

--- a/ext/civi_mail/ang/crmMailingAB/BlockMailing.js
+++ b/ext/civi_mail/ang/crmMailingAB/BlockMailing.js
@@ -19,7 +19,7 @@
           scope.abtest = model(scope.$parent);
           scope.crmMailingConst = CRM.crmMailing;
           scope.crmMailingABCriteria = crmMailingABCriteria;
-          scope.ts = CRM.ts(null);
+          scope.ts = CRM.ts('civi_mail');
           scope.hs = crmUiHelp({file: 'CRM/Mailing/MailingUI'});
 
           var fieldsModel = $parse(attr[directiveName]);

--- a/ext/civi_mail/ang/crmMailingAB/BlockSetup.js
+++ b/ext/civi_mail/ang/crmMailingAB/BlockSetup.js
@@ -19,7 +19,7 @@
           scope.abtest = model(scope.$parent);
           scope.crmMailingConst = CRM.crmMailing;
           scope.crmMailingABCriteria = crmMailingABCriteria;
-          scope.ts = CRM.ts(null);
+          scope.ts = CRM.ts('civi_mail');
           scope.hs = crmUiHelp({file: 'CRM/Mailing/MailingUI'});
 
           var fieldsModel = $parse(attr[directiveName]);

--- a/ext/civi_mail/ang/crmMailingAB/EditCtrl.js
+++ b/ext/civi_mail/ang/crmMailingAB/EditCtrl.js
@@ -2,7 +2,7 @@
 
   angular.module('crmMailingAB').controller('CrmMailingABEditCtrl', function($scope, abtest, crmMailingABCriteria, crmMailingMgr, crmMailingPreviewMgr, crmStatus, $q, $location, crmBlocker, $interval, $timeout, CrmAutosaveCtrl, dialogService, mailingFields) {
     $scope.abtest = abtest;
-    var ts = $scope.ts = CRM.ts(null);
+    var ts = $scope.ts = CRM.ts('civi_mail');
     var block = $scope.block = crmBlocker();
     $scope.crmUrl = CRM.url;
     var myAutosave = null;

--- a/ext/civi_mail/ang/crmMailingAB/ListCtrl.js
+++ b/ext/civi_mail/ang/crmMailingAB/ListCtrl.js
@@ -1,7 +1,7 @@
 (function(angular, $, _) {
 
   angular.module('crmMailingAB').controller('CrmMailingABListCtrl', function($scope, mailingABList, crmMailingABCriteria, crmMailingABStatus, fields) {
-    var ts = $scope.ts = CRM.ts(null);
+    var ts = $scope.ts = CRM.ts('civi_mail');
     $scope.mailingABList = _.values(mailingABList.values);
     $scope.crmMailingABCriteria = crmMailingABCriteria;
     $scope.crmMailingABStatus = crmMailingABStatus;

--- a/ext/civi_mail/ang/crmMailingAB/ReportCtrl.js
+++ b/ext/civi_mail/ang/crmMailingAB/ReportCtrl.js
@@ -1,7 +1,7 @@
 (function(angular, $, _) {
 
   angular.module('crmMailingAB').controller('CrmMailingABReportCtrl', function($scope, crmApi, crmMailingStats) {
-    var ts = $scope.ts = CRM.ts(null);
+    var ts = $scope.ts = CRM.ts('civi_mail');
 
     var CrmMailingABReportCnt = 1, activeMailings = null;
     $scope.getActiveMailings = function() {

--- a/ext/civi_mail/ang/crmMailingAB/Slider.js
+++ b/ext/civi_mail/ang/crmMailingAB/Slider.js
@@ -12,7 +12,7 @@
         var sliderTests = $('.slider-test', element);
         var sliderWin = $('.slider-win', element);
 
-        scope.ts = CRM.ts(null);
+        scope.ts = CRM.ts('civi_mail');
         scope.testValue = 0;
         scope.winValue = 100;
 

--- a/ext/civi_mail/ang/crmMailingAB/WinnerDialogCtrl.js
+++ b/ext/civi_mail/ang/crmMailingAB/WinnerDialogCtrl.js
@@ -1,7 +1,7 @@
 (function(angular, $, _) {
 
   angular.module('crmMailingAB').controller('CrmMailingABWinnerDialogCtrl', function($scope, $timeout, dialogService, crmMailingMgr, crmStatus) {
-    var ts = $scope.ts = CRM.ts(null);
+    var ts = $scope.ts = CRM.ts('civi_mail');
     var abtest = $scope.abtest = $scope.model.abtest;
     var mailingName = $scope.model.mailingName;
 


### PR DESCRIPTION
Overview
----------------------------------------

When opening CiviMail UI in a non-English locale, it does not display translated strings.

Reported in https://lab.civicrm.org/dev/translation/-/issues/85. Problem begins in 5.69. See also: #28042

ping @colemanw @mlutfy 

Before/After
----------------------------------------

* __5.68__:
    * When CiviMail strings are sent to they client, they are categorized as part of the default domain. 
    * You can use  `CRM.ts(null)` to lookup strings in the default domain.
* __5.69__:
    * CiviMail UI moved into an quasi-extension (`civi_mail`). When CiviMail strings are sent to they client, they are categorized as part of the `civi_mail` domain.
    * If you use `CRM.ts(null)`, then it will not find the string.
* __Patch__: 
    * CiviMail UI will search for strings from the `civi_mail` domain.
    * It calls `CRM.ts('civi_mail')` - which does work.

Comments
----------------------------------------

* This is currently targetted at `5.72`. When we branch for 5.73-rc, we should either change the target here or open a second PR.
* I don't know if it's somehow better or worse to have these strings in the default-domain vs `civi_mail`-domain. However, updating the UI seems to fix it for me.
* #28042 touched a lot of other Angular modules, which all use `ts()`. I wouldn't be surprised if they need similar updates.
