### PR TITLE
Standalone - ensure id value is an int for comparison check when changing password

### DIFF
--- a/ext/standaloneusers/Civi/Api4/Action/User/WriteTrait.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/WriteTrait.php
@@ -103,7 +103,7 @@ trait WriteTrait {
         throw new UnauthorizedException("Unauthorized");
       }
       else {
-        $changingOtherUser = intval($values['id'] ?? FALSE) !== $loggedInUserID;
+        $changingOtherUser = intval($values['id'] ?? 0) !== $loggedInUserID;
         if ($changingOtherUser && !$hasAdminPermission) {
           throw new UnauthorizedException("You are not permitted to change other users' accounts.");
         }

--- a/ext/standaloneusers/Civi/Api4/Action/User/WriteTrait.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/WriteTrait.php
@@ -103,7 +103,7 @@ trait WriteTrait {
         throw new UnauthorizedException("Unauthorized");
       }
       else {
-        $changingOtherUser = ($values['id'] ?? FALSE) !== $loggedInUserID;
+        $changingOtherUser = intval($values['id'] ?? FALSE) !== $loggedInUserID;
         if ($changingOtherUser && !$hasAdminPermission) {
           throw new UnauthorizedException("You are not permitted to change other users' accounts.");
         }


### PR DESCRIPTION
Before
----------------------------------------
When changing password through the UI, the `id` value comes through from the JS as a string, and fails this comparison check. This stops non-admin users changing their own password.

After
----------------------------------------
Get the intval before comparing. Non-admins can change their password.


Comments
----------------------------------------
For some reason I'm getting `hasAdminPermission` is false even when I am the admin on master, which is how I noticed this in the first place. I think that's relatively recently broken. Will investigate separately.