### PR TITLE
dev/core#5125 Standalone cms permissions are civi permissions

### DIFF
--- a/CRM/Core/Permission/Backdrop.php
+++ b/CRM/Core/Permission/Backdrop.php
@@ -105,7 +105,7 @@ class CRM_Core_Permission_Backdrop extends CRM_Core_Permission_DrupalBase {
     // We want to list *only* Backdrop perms, so we'll *skip* Civi perms.
     $allCorePerms = \CRM_Core_Permission::basicPermissions(TRUE);
 
-    $permissions = [];
+    $permissions = parent::getAvailablePermissions();
     $modules = system_get_info('module');
     foreach ($modules as $moduleName => $module) {
       $prefix = isset($module['name']) ? ($module['name'] . ': ') : '';

--- a/CRM/Core/Permission/Base.php
+++ b/CRM/Core/Permission/Base.php
@@ -308,7 +308,21 @@ class CRM_Core_Permission_Base {
    * @see \CRM_Core_Permission_Base::translatePermission()
    */
   public function getAvailablePermissions() {
-    return [];
+    // These "synthetic" permissions are translated to the relevant CMS permissions in CRM/Core/Permission/*.php
+    // using the `translatePermission()` mechanism.
+    // EXCEPT in Standalone, where they are not needed
+    return [
+      'cms:view user account' => [
+        'title' => ts('CMS') . ': ' . ts('View user accounts'),
+        'description' => ts('View user accounts. (Synthetic permission - adapts to local CMS)'),
+        'is_synthetic' => TRUE,
+      ],
+      'cms:administer users' => [
+        'title' => ts('CMS') . ': ' . ts('Administer user accounts'),
+        'description' => ts('Administer user accounts. (Synthetic permission - adapts to local CMS)'),
+        'is_synthetic' => TRUE,
+      ],
+    ];
   }
 
   /**

--- a/CRM/Core/Permission/Drupal.php
+++ b/CRM/Core/Permission/Drupal.php
@@ -104,7 +104,7 @@ class CRM_Core_Permission_Drupal extends CRM_Core_Permission_DrupalBase {
     // We want to list *only* Drupal perms, so we'll *skip* Civi perms.
     $allCorePerms = \CRM_Core_Permission::basicPermissions(TRUE);
 
-    $permissions = [];
+    $permissions = parent::getAvailablePermissions();
     $modules = system_get_info('module');
     foreach ($modules as $moduleName => $module) {
       $prefix = isset($module['name']) ? ($module['name'] . ': ') : '';

--- a/CRM/Core/Permission/Drupal8.php
+++ b/CRM/Core/Permission/Drupal8.php
@@ -61,7 +61,7 @@ class CRM_Core_Permission_Drupal8 extends CRM_Core_Permission_DrupalBase {
     $dperms = \Drupal::service('user.permissions')->getPermissions();
     $modules = \Drupal::service('extension.list.module')->getAllInstalledInfo();
 
-    $permissions = [];
+    $permissions = parent::getAvailablePermissions();
     foreach ($dperms as $permName => $dperm) {
       if (isset($allCorePerms[$permName])) {
         continue;

--- a/CRM/Core/Permission/List.php
+++ b/CRM/Core/Permission/List.php
@@ -54,28 +54,15 @@ class CRM_Core_Permission_List {
     $config = \CRM_Core_Config::singleton();
 
     $ufPerms = $config->userPermissionClass->getAvailablePermissions();
+
     foreach ($ufPerms as $permName => $cmsPerm) {
       $e->permissions[$permName] = [
         'group' => 'cms',
         'title' => $cmsPerm['title'] ?? $permName,
         'description' => $cmsPerm['description'] ?? NULL,
+        'is_synthetic' => $cmsPerm['is_synthetic'] ?? FALSE,
       ];
     }
-
-    // There are a handful of special permissions defined in CRM/Core/Permission/*.php
-    // using the `translatePermission()` mechanism.
-    $e->permissions['cms:view user account'] = [
-      'group' => 'cms',
-      'title' => ts('CMS') . ': ' . ts('View user accounts'),
-      'description' => ts('View user accounts. (Synthetic permission - adapts to local CMS)'),
-      'is_synthetic' => TRUE,
-    ];
-    $e->permissions['cms:administer users'] = [
-      'group' => 'cms',
-      'title' => ts('CMS') . ': ' . ts('Administer user accounts'),
-      'description' => ts('Administer user accounts. (Synthetic permission - adapts to local CMS)'),
-      'is_synthetic' => TRUE,
-    ];
   }
 
   /**

--- a/CRM/Core/Permission/Standalone.php
+++ b/CRM/Core/Permission/Standalone.php
@@ -59,14 +59,6 @@ class CRM_Core_Permission_Standalone extends CRM_Core_Permission_Base {
    *   true if yes, else false
    */
   public function check($str, $userId = NULL) {
-    // These core-defined synthetic permissions (which cannot be applied by our Role UI):
-    // cms:administer users
-    // cms:view user account
-    // need mapping to our concrete permissions (which can be applied to Roles) with the same names:
-    $str = $this->translatePermission($str, 'Standalone', [
-      'view user account' => 'view user account',
-      'administer users' => 'administer users',
-    ]);
     return \Civi\Standalone\Security::singleton()->checkPermission($str, $userId);
   }
 

--- a/CRM/Core/Permission/Standalone.php
+++ b/CRM/Core/Permission/Standalone.php
@@ -34,6 +34,17 @@ class CRM_Core_Permission_Standalone extends CRM_Core_Permission_Base {
   public $permissions = NULL;
 
   /**
+   * @inheritdoc
+   * on Standalone we don't want to add any "synthetic" cms permissions
+   * because we have concrete equivalents, provided by e.g. standaloneusers extension
+   * so we override the base class to suppress the synthetic ones
+   *
+   */
+  public function getAvailablePermissions() {
+    return [];
+  }
+
+  /**
    * Given a permission string, check for access requirements.
    *
    * Note this differs from CRM_Core_Permission::check() which handles

--- a/CRM/Core/Permission/WordPress.php
+++ b/CRM/Core/Permission/WordPress.php
@@ -103,7 +103,7 @@ class CRM_Core_Permission_WordPress extends CRM_Core_Permission_Base {
       $wpCaps = array_unique(array_merge(array_keys($wpRole['capabilities']), $wpCaps));
     }
 
-    $permissions = [];
+    $permissions = parent::getAvailablePermissions();
     foreach ($wpCaps as $wpCap) {
       if (!in_array($wpCap, $mungedCorePerms)) {
         $permissions["WordPress:$wpCap"] = [

--- a/ext/standaloneusers/standaloneusers.php
+++ b/ext/standaloneusers/standaloneusers.php
@@ -82,7 +82,7 @@ function standaloneusers_civicrm_permission(&$permissions) {
   // provide expected cms: permissions.
   $permissions['cms:administer users'] = [
     'label' => E::ts('CiviCRM Standalone Users: Administer user accounts'),
-    'implies' => ['cms: view user account'],
+    'implies' => ['cms:view user account'],
   ];
   $permissions['cms:view user account'] = [
     'label' => E::ts('CiviCRM Standalone Users: View user accounts'),

--- a/ext/standaloneusers/standaloneusers.php
+++ b/ext/standaloneusers/standaloneusers.php
@@ -77,14 +77,14 @@ function standaloneusers_civicrm_enable() {
  */
 function standaloneusers_civicrm_permission(&$permissions) {
   $permissions['access password resets'] = [
-    'label' => E::ts('Allow users to access the reset password system'),
+    'label' => E::ts('CiviCRM Standalone Users: Allow users to access the reset password system'),
   ];
-  // Concrete implementations of synthetic cms: permissions.
-  $permissions['administer users'] = [
-    'label' => E::ts('Administer user accounts'),
-    'implies' => ['view user account'],
+  // provide expected cms: permissions.
+  $permissions['cms:administer users'] = [
+    'label' => E::ts('CiviCRM Standalone Users: Administer user accounts'),
+    'implies' => ['cms: view user account'],
   ];
-  $permissions['view user account'] = [
-    'label' => E::ts('View user accounts'),
+  $permissions['cms:view user account'] = [
+    'label' => E::ts('CiviCRM Standalone Users: View user accounts'),
   ];
 }

--- a/ext/standaloneusers/tests/phpunit/Civi/Api4/Action/UserTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Api4/Action/UserTest.php
@@ -284,11 +284,11 @@ class UserTest extends \PHPUnit\Framework\TestCase implements EndToEndInterface,
             'view own manual batches',
             'access all custom data',
             'access contact reference fields',
-            // Standalone-defined permissions that have the same name as the cms: prefixed synthetic ones
-            // 'administer users',
-            'view user account',
-            // The admninister CiviCRM data implicitly sets other permissions as well.
-            // Such as, edit message templates and admnister dedupe rules.
+            // Standalone-defined permissions that stand in for the synthetic ones on CMSes
+            // 'cms: administer users',
+            'cms: view user account',
+            // The administer CiviCRM data implicitly sets other permissions as well.
+            // Such as, edit message templates and administer dedupe rules.
             'administer CiviCRM Data',
           ],
         ],

--- a/setup/plugins/init/StandaloneUsers.civi-setup.php
+++ b/setup/plugins/init/StandaloneUsers.civi-setup.php
@@ -141,9 +141,10 @@ if (!defined('CIVI_SETUP')) {
             'view own manual batches',
             'access all custom data',
             'access contact reference fields',
-            // Standalone-defined permissions that have the same name as the cms: prefixed synthetic ones
-            'administer users',
-            'view user account',
+            // standaloneusers provides concrete permissions in place of
+            // the synthetic ones on other UF
+            'cms:administer users',
+            'cms:view user account',
             // The admninister CiviCRM data implicitly sets other permissions as well.
             // Such as, edit message templates and admnister dedupe rules.
             'administer CiviCRM Data',


### PR DESCRIPTION
Overview
----------------------------------------
A [recent change](https://github.com/civicrm/civicrm-core/pull/29828/commits/1268e879666b5096de44c951d2fbbc49e8135ecf#diff-410497db8c86f6ba1a897c533db8f391a25d2cee7b12852bb743b2dbed82d86aR994) means CMS permissions are no longer implied by `all CiviCRM permissions and ACLs`. This makes sense in UF-land, but in Standalone, the CMS permissions **are** CiviCRM permissions, so you expect the implication to hold.

Before
----------------------------------------
- `all CiviCRM permissions and ACLs` doesn't imply cms permissions.
- Standalone admin user doesn't automatically get implied permission to administer users in Standalone.

After
----------------------------------------
In Standalone, `cms:administer users` is like any other CiviCRM permission, so it does get implied by `all CiviCRM permissions and ACLs`. There are no "CMS-specific" permissions.

On other UFs, everything is the same as before (though `cms: administer users` and `cms:view user account` are sourced from `CRM_Core_Permission_Base::getAvailablePermissions` rather than `CRM_Core_Permission_List`).

Technical Details
----------------------------------------
This changes the way the expected `cms:view user account` and `cms:administer users` are implemented in Standalone. Before: standaloneusers adds new concrete permissions `administer users` and `view user account`, 'cms:administer users' and 'cms:view user account' are translated into these. 
After: standaloneusers provides `cms:administer users` and `cms:view user account` concretely directly, and there are no synthetic ones.
Feels simpler to me, less potential for "do I need the prefix or not?" confusion.

Comments
----------------------------------------
I don't _think_ anything should be getting in between `CRM_Core_Permission_List` and `userPermissionClass->getAvailablePermissions` which could be affected by the move?

I did notice a few references to unprefixed `administer users` in some Profile code... which was a bit surprising for me, don't know how/if they work/are relevant.
