### PR TITLE
Update tests to orderBy amount rather than rely on id order

### DIFF
--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -11,6 +11,7 @@
 use Civi\Api4\Activity;
 use Civi\Api4\Contribution;
 use Civi\Api4\CustomField;
+use Civi\Api4\EntityFinancialTrxn;
 use Civi\Api4\FinancialTrxn;
 use Civi\Api4\PledgePayment;
 use Civi\Api4\Product;
@@ -928,6 +929,8 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
    * We pay $50, resulting in it being allocated as $45.45 payment & $4.55 tax. This is in equivalent proportions
    * to the original payment - ie. .0909 of the $110 is 10 & that * 50 is $4.54 (note the rounding seems wrong as it should be
    * saved un-rounded).
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testCreateProportionalFinancialEntriesViaPaymentCreate(): void {
     [$contribution, $financialAccount] = $this->createContributionWithTax([], FALSE);
@@ -941,16 +944,14 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
       'contribution_id' => $contribution['id'],
     ];
     $financialTrxn = $this->callAPISuccess('Payment', 'create', $params);
-    $eftParams = [
-      'entity_table' => 'civicrm_financial_item',
-      'financial_trxn_id' => $financialTrxn['id'],
-    ];
-    $entityFinancialTrxn = $this->callAPISuccess('EntityFinancialTrxn', 'Get', $eftParams);
-    $this->assertEquals(2, $entityFinancialTrxn['count'], 'Invalid count.');
-    $testAmount = [4.55, 45.45];
-    foreach ($entityFinancialTrxn['values'] as $value) {
-      $this->assertEquals(array_pop($testAmount), $value['amount'], 'Invalid amount stored in civicrm_entity_financial_trxn.');
-    }
+
+    $entityFinancialTrxns = EntityFinancialTrxn::get(FALSE)
+      ->addWhere('entity_table', '=', 'civicrm_financial_item')
+      ->addWhere('financial_trxn_id', '=', $financialTrxn['id'])
+      ->addOrderBy('amount')->execute();
+    $this->assertCount(2, $entityFinancialTrxns, '2 EntityFinancialTrxns should be created (one for tax).');
+    $this->assertEquals(4.55, $entityFinancialTrxns->first()['amount'], 'Incorrect tax amount in entity financial trxn');
+    $this->assertEquals(45.45, $entityFinancialTrxns->last()['amount'], 'Incorrect tax exclusive amount in entity financial trxn');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Update tests to orderBy amount rather than rely on id order

Before
----------------------------------------
Tests require items to be created in a certain order

After
----------------------------------------
Tests able to cope with us mixing it up

Technical Details
----------------------------------------

Comments
----------------------------------------
