### PR TITLE
Move logic from tpl to php layer (extension page)

### DIFF
--- a/CRM/Admin/Page/Extensions.php
+++ b/CRM/Admin/Page/Extensions.php
@@ -361,6 +361,7 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
       'comments' => FALSE,
     ];
     $info = array_merge($defaultKeys, $info);
+    $info['is_stable'] = $info['develStage'] === 'stable' && !preg_match(";(alpha|beta|dev);", $info['version']);
     foreach ($info['authors'] as &$author) {
       $author = array_merge(['homepage' => ''], $author);
     }

--- a/templates/CRM/Admin/Page/Extensions/Main.tpl
+++ b/templates/CRM/Admin/Page/Extensions/Main.tpl
@@ -31,7 +31,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
           </td>
           <td class="crm-extensions-status">{$row.statusLabel} </td>
           <td class="crm-extensions-version">{$row.version|escape}
-            {if (!empty($row.develStage) and $row.develStage != 'stable') or preg_match(";(alpha|beta|dev);", $row.version)}
+            {if !$row.is_stable}
               {icon icon="fa-flask crm-extensions-stage"}{ts}This is a pre-release version. For more details, see the expanded description.{/ts}{/icon}
             {else}
               {icon icon="fa-check-circle crm-extensions-stage"}{ts}This is a stable release version.{/ts}{/icon}


### PR DESCRIPTION

Overview
----------------------------------------
Move logic from tpl to php layer (extension page)

Before
----------------------------------------
Smarty 4 & 5 don't much like using random functions in smarty -you have to register them or remove them - in this case Smarty is right - this is not really a tpl level thing


After
----------------------------------------
still does the alpha / stable thing

![image](https://github.com/civicrm/civicrm-core/assets/336308/d520293a-539a-4aa5-9461-072095c38dcc)


Technical Details
----------------------------------------

Comments
----------------------------------------
