### PR TITLE
avoid deprecation notice if header is null

### DIFF
--- a/CRM/Report/Utils/Report.php
+++ b/CRM/Report/Utils/Report.php
@@ -236,7 +236,8 @@ WHERE  inst.report_id = %1";
     // Replace internal header names with friendly ones, where available.
     foreach ($columnHeaders as $header) {
       if (isset($form->_columnHeaders[$header])) {
-        $headers[] = '"' . html_entity_decode(strip_tags($form->_columnHeaders[$header]['title'])) . '"';
+        $title = $form->_columnHeaders[$header]['title'] ?? '';
+        $headers[] = '"' . html_entity_decode(strip_tags($title)) . '"';
       }
     }
     // Add the headers.


### PR DESCRIPTION
Overview
----------------------------------------
I'm getting errors like the following:

> [PHP Deprecation] strip_tags(): Passing null to parameter #1 ($string) of type string is deprecated at /var/www/powerbase/sites/all/modules/civicrm/CRM/Report/Utils/Report.php:239


Before
----------------------------------------

When `$form->_columnHeaders[$header]` is defined but `$form->_columnHeaders[$header]['title']` is not defined or null, then we end up passing NULL to the `strip_tags` function, which expects a string.

After
----------------------------------------

By coalescing `$form->_columnHeaders[$header]['title']` to a empty string when NULL, we avoid this error. 

