### PR TITLE
Fix auto-respond to use token processor.

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -892,9 +892,9 @@ ORDER BY   civicrm_email.is_bulkmail DESC
    *   Array of message headers to update, in-out.
    * @param string $prefix
    *   Prefix for the message ID, use same prefixes as verp.
-   *                                wherever possible
-   * @param string $job_id
-   *   Job ID component of the generated message ID.
+   *   wherever possible
+   * @param null $theVoid
+   *   Stare into the abyss.
    * @param string $event_queue_id
    *   Event Queue ID component of the generated message ID.
    * @param string $hash
@@ -902,7 +902,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
    *
    * @return void
    */
-  public static function addMessageIdHeader(&$headers, $prefix, $job_id, $event_queue_id, $hash) {
+  public static function addMessageIdHeader(&$headers, $prefix, $theVoid, $event_queue_id, $hash): void {
     $config = CRM_Core_Config::singleton();
     $localpart = CRM_Core_BAO_MailSettings::defaultLocalpart();
     $emailDomain = CRM_Core_BAO_MailSettings::defaultDomain();

--- a/CRM/Mailing/Event/BAO/MailingEventReply.php
+++ b/CRM/Mailing/Event/BAO/MailingEventReply.php
@@ -200,7 +200,6 @@ class CRM_Mailing_Event_BAO_MailingEventReply extends CRM_Mailing_Event_DAO_Mail
     $eq = CRM_Core_DAO::executeQuery(
       'SELECT
                   email.email as email,
-                  queue.job_id as job_id,
                   queue.hash as hash
         FROM civicrm_contact contact
         INNER JOIN  civicrm_mailing_event_queue queue ON queue.contact_id = contact.id
@@ -243,7 +242,7 @@ class CRM_Mailing_Event_BAO_MailingEventReply extends CRM_Mailing_Event_DAO_Mail
       $params['text'] = $tokenProcessor->getRow(0)->render('body_text');
     }
 
-    CRM_Mailing_BAO_Mailing::addMessageIdHeader($params, 'a', $eq->job_id, $queue_id, $eq->hash);
+    CRM_Mailing_BAO_Mailing::addMessageIdHeader($params, 'a', NULL, $queue_id, $eq->hash);
     if (CRM_Core_BAO_MailSettings::includeMessageId()) {
       $params['messageId'] = $params['Message-ID'];
     }

--- a/tests/phpunit/CRM/Mailing/MailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/MailingSystemTest.php
@@ -154,7 +154,7 @@ class CRM_Mailing_MailingSystemTest extends CRM_Mailing_MailingSystemTestBase {
   }
 
   /**
-   * @throws \CRM_Core_Exception
+   * Test the auto-respond email, including token presence.
    */
   public function testMailingReplyAutoRespond(): void {
     // Because our parent class marks the _groupID as private, we can't use that :-(


### PR DESCRIPTION

Overview
----------------------------------------
Fix auto-respond to use token processor.

Before
----------------------------------------
rendered by legacy methods

After
----------------------------------------
rendered by token processor

Technical Details
----------------------------------------
This is well covered in the commented test.

Note that I have implemented the expectation that the text version will be left to the send() function to populate if empty

Comments
----------------------------------------
I also stopped passing a value to job_id

![image](https://github.com/civicrm/civicrm-core/assets/336308/d7320950-6a54-4373-b29c-c3f7d6c3ed9c)
