### PR TITLE
dev/core#5130 - Don't load smarty2's own plugins if running smarty3/4

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -128,14 +128,15 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
     }
 
     $pkgsDir = Civi::paths()->getVariable('civicrm.packages', 'path');
-    $smartyDir = $pkgsDir . DIRECTORY_SEPARATOR . 'Smarty' . DIRECTORY_SEPARATOR;
-    $pluginsDir = __DIR__ . DIRECTORY_SEPARATOR . 'Smarty' . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR;
+    // smarty3/4 have the define, fall back to smarty2. smarty5 deprecates plugins_dir - TBD.
+    $smartyPluginsDir = defined('SMARTY_PLUGINS_DIR') ? SMARTY_PLUGINS_DIR : ($pkgsDir . DIRECTORY_SEPARATOR . 'Smarty' . DIRECTORY_SEPARATOR . 'plugins');
+    $corePluginsDir = __DIR__ . DIRECTORY_SEPARATOR . 'Smarty' . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR;
 
     if ($customPluginsDir) {
-      $this->plugins_dir = [$customPluginsDir, $smartyDir . 'plugins', $pluginsDir];
+      $this->plugins_dir = [$customPluginsDir, $smartyPluginsDir, $corePluginsDir];
     }
     else {
-      $this->plugins_dir = [$smartyDir . 'plugins', $pluginsDir];
+      $this->plugins_dir = [$smartyPluginsDir, $corePluginsDir];
     }
 
     $this->compile_check = $this->isCheckSmartyIsCompiled();


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5130

Before
----------------------------------------
You get a crash if you use something like `|date_format` in a message template when using smarty3/4

After
----------------------------------------


Technical Details
----------------------------------------
For smarty3/4 use the constant that smarty defines. For smarty2 which doesn't have that do what it did before.
For smarty5 do what it was doing before this PR but it will need future attention because it deprecates the pluginsdir concept and I think wants you to write a smarty extension.

The renaming of pluginsDir to corePluginsDir is not a functional change. I was confused at first by the two references to the literal 'Smarty' that are actually different things, so clarified that it means core plugins which is always 'Smarty', but otherwise is the same as before.

Comments
----------------------------------------
A quick cli way to test this is update civicrm.settings.php to use smarty4 and then clear cache and put this in a file and run with `cv -vvv scr`:

```php
<?php
$x = CRM_Core_Smarty::singleton();
$x->assign('d', '2024-04-05 10:11');
echo $x->fetch('string:{$d|date_format:"%m/%d/%Y"}');
```

It will error before the PR with a stacktrace showing that it's loading smarty2 date_format, and output the right thing after.