### PR TITLE
Fix membership status updating when using in-place edit

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -243,6 +243,13 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
       $memTypeDetails = CRM_Member_BAO_MembershipType::getMembershipType($params['membership_type_id']);
       $isLifeTime = $memTypeDetails['duration_unit'] === 'lifetime' ? TRUE : FALSE;
     }
+    if (!empty($params['id']) && !isset($params['skipStatusCal'])) {
+      // Don't calculate status on existing membership - expect API use to pass them in or leave unchanged.
+      // API3 does this. In-place edit (ie. API4 did not and we ended up updating membership status every time
+      // we did an in-place edit on an unrelated field (eg. source, customfield).
+      $params['skipStatusCal'] = 1;
+    }
+
     // always calculate status if is_override/skipStatusCal is not true.
     // giving respect to is_override during import.  CRM-4012
 


### PR DESCRIPTION
Overview
----------------------------------------
When doing an in-place edit on a membership field (using searchkit) the membership status calculations are re-run (causing eg. a Pending membership to change to "New" when it should not).

Before
----------------------------------------
Membership status calculations run when editing unrelated field (eg. source / customfield on membership).

After
----------------------------------------
Membership status calculations not run when updating membership fields.

Technical Details
----------------------------------------
API3 checks if we are updating and `skipStatusCal` is not set. If so it sets `skipStatusCal` = TRUE which prevents status calculations from running. But in-place edit (ie. API4 membership update) calls `CRM_Member_BAO_Membership::create()` directly and bypasses this check.
Solution is to perform the same check at this lower level (and we should probably remove the check from API3?). Pending verification if we have any test failures.

Comments
----------------------------------------
I ran some tests using in-place edit (status did not change), recording a payment on a Pending Contribution (membership status changed correctly from Pending to New).
