### PR TITLE
Fix invalid date with STRICT SQL mode

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -278,7 +278,9 @@ WHERE  ( civicrm_event.is_template  = 0 )";
       $endDate = date('YmdHis');
       $query .= "
         AND ( `end_date` >= {$endDate} OR
-          end_date IS NULL AND start_date >= {$endDate}
+           (
+            ( end_date IS NULL OR end_date = STR_TO_DATE('', '%Y%m%d%H%i%s') ) AND start_date >= {$endDate}
+          )
         )";
     }
     elseif ($all == 2) {

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -278,9 +278,7 @@ WHERE  ( civicrm_event.is_template  = 0 )";
       $endDate = date('YmdHis');
       $query .= "
         AND ( `end_date` >= {$endDate} OR
-          (
-            ( end_date IS NULL OR end_date = '' ) AND start_date >= {$endDate}
-          )
+          end_date IS NULL AND start_date >= {$endDate}
         )";
     }
     elseif ($all == 2) {


### PR DESCRIPTION
`STRICT` SQL mode (including `NO_ZERO_DATES`, `NO_ZERO_IN_DATES`, without `ALLOW_INVALID_DATES`) fails to execute a query with this condition:
https://github.com/civicrm/civicrm-core/blob/6f28973ef2e264d63eae620359adcb2138f90509/CRM/Event/BAO/Event.php#L279-L284

due to the empty string not being a valid date value. The SQL error is:
```
nativecode=1525 ** Incorrect DATETIME value: ''
```
I could not get my MySQL 8 to run this query by changing the `sql_mode` variable, although the docs mention those options, also for *MariaDB*. But I think CiviCRM should not rely on them.

Also, I could not find any environment with the empty string as a value for the `end_date` column of the `civicrm_event` table, so I guess this comparison is just obsolete. If you have such values, you'd be better off converting them to `NULL` anyway.

I raised this issue in the chat previously: https://chat.civicrm.org/civicrm/pl/rzobsp9wrbrhdm6z8x6h9kyj6o, where @colemanw already confirmed my assumption that it's just bad SQL.