### PR TITLE
distmaker - Add `iframe` and `oembed` (5.73-rc)

### DIFF
--- a/distmaker/core-ext.txt
+++ b/distmaker/core-ext.txt
@@ -17,8 +17,10 @@ ewaysingle
 financialacls
 flexmailer
 greenwich
+iframe
 message_admin
 oauth-client
+oembed
 payflowpro
 recaptcha
 search_kit


### PR DESCRIPTION
Overview
----------------------------------------

These extensions were added in 5.72 as hidden extensions (*meaning that they're hidden from web UI -- you can only enable them via API/CLI*). But they weren't declared in `distmaker`, so their availability is inconsistent.

Before
----------------------------------------

* Git-based builds and composer-based builds include `ext/iframe` and `ext/oembed` (*as hidden extensions*). 
* But tar-based builds don't include them.
 
After
----------------------------------------

* Git-based, composer-based, and tar-based builds all include `iframe` and `oembed` (*as hidden extensions*).