### PR TITLE
Afform - enable autocomplete id filter on search forms

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -131,16 +131,18 @@ class AfformAdminMeta {
     }
     // Index by name
     $fields = array_column($fields, NULL, 'name');
-    if ($params['action'] === 'create') {
-      // Add existing entity field
-      $idField = CoreUtil::getIdFieldName($entityName);
+    $idField = CoreUtil::getIdFieldName($entityName);
+    // Convert ID field to existing entity field
+    if (isset($fields[$idField])) {
       $fields[$idField]['readonly'] = FALSE;
       $fields[$idField]['input_type'] = 'EntityRef';
       // Afform-only (so far) metadata tells the form to update an existing entity autofilled from this value
       $fields[$idField]['input_attrs']['autofill'] = 'update';
       $fields[$idField]['fk_entity'] = $entityName;
       $fields[$idField]['label'] = E::ts('Existing %1', [1 => CoreUtil::getInfoItem($entityName, 'title')]);
-      // Mix in alterations declared by afform entities
+    }
+    // Mix in alterations declared by afform entities
+    if ($params['action'] === 'create') {
       $afEntity = self::getMetadata()['entities'][$entityName] ?? [];
       if (!empty($afEntity['alterFields'])) {
         foreach ($afEntity['alterFields'] as $fieldName => $changes) {

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -178,7 +178,7 @@
             return defn.options || defn.data_type === 'Boolean';
 
           case 'Select':
-            return defn.options || defn.data_type === 'Boolean' || defn.input_type === 'EntityRef' || (defn.input_type === 'Date' && ctrl.isSearch());
+            return defn.options || defn.data_type === 'Boolean' || (defn.input_type === 'EntityRef' && !ctrl.isSearch()) || (defn.input_type === 'Date' && ctrl.isSearch());
 
           case 'Date':
             return defn.input_type === 'Date';

--- a/ext/afform/core/Civi/Afform/FormDataModel.php
+++ b/ext/afform/core/Civi/Afform/FormDataModel.php
@@ -234,7 +234,7 @@ class FormDataModel {
       return NULL;
     }
     // Id field for selecting existing entity
-    if ($action === 'create' && $field['name'] === CoreUtil::getIdFieldName($entityName)) {
+    if ($field['name'] === CoreUtil::getIdFieldName($entityName)) {
       $entityTitle = CoreUtil::getInfoItem($entityName, 'title');
       $field['input_type'] = 'EntityRef';
       $field['fk_entity'] = $entityName;


### PR DESCRIPTION
Overview
----------------------------------------
This permits the ID field to be used as an autocomplete on search forms.

Before
----------------------------------------
ID field could only be a numeric input on search forms.

After
----------------------------------------
By default it will be an autocomplete (but can still be changed back to a numeric input).
