### PR TITLE
Afform - Fix 'Edit' links to always go to backend

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminInjector.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminInjector.php
@@ -47,7 +47,7 @@ class AfformAdminInjector extends AutoSubscriber {
             // Create a link to edit the form, plus all embedded SavedSearches
             $links = [
               [
-                'url' => \CRM_Utils_System::url('civicrm/admin/afform', NULL, FALSE, "/edit/{$afform['name']}", TRUE),
+                'url' => \CRM_Utils_System::url('civicrm/admin/afform', NULL, FALSE, "/edit/{$afform['name']}", TRUE, FALSE, TRUE),
                 'text' => E::ts('Edit %1 in FormBuilder', [1 => "<em>{$afform['title']}</em>"]),
                 'icon' => 'fa-pencil',
               ],
@@ -63,7 +63,7 @@ class AfformAdminInjector extends AutoSubscriber {
                 ->execute();
               foreach ($savedSearches as $savedSearch) {
                 $links[] = [
-                  'url' => \CRM_Utils_System::url('civicrm/admin/search', NULL, FALSE, "/edit/{$savedSearch['id']}", TRUE),
+                  'url' => \CRM_Utils_System::url('civicrm/admin/search', NULL, FALSE, "/edit/{$savedSearch['id']}", TRUE, FALSE, TRUE),
                   'text' => E::ts('Edit %1 in SearchKit', [1 => "<em>{$savedSearch['label']}</em>"]),
                   'icon' => 'fa-search-plus',
                 ];


### PR DESCRIPTION
Overview
----------------------------------------
Even when a form is displayed on the frontend of a website, the edit links should go to the backend.

See https://lab.civicrm.org/dev/core/-/issues/5131#note_162882