### PR TITLE
(dev/core#4919) Prefer new versions of PHPGitIgnore / DownloadsPlugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
     "cweagans/composer-patches": "~1.0",
     "pear/log": "1.13.3",
     "adrienrn/php-mimetyper": "0.2.2",
-    "civicrm/composer-downloads-plugin": "^3.0",
+    "civicrm/composer-downloads-plugin": "^3.0 || ^4.0",
     "league/csv": "~9.7.4",
     "league/oauth2-client": "^2.4",
     "league/oauth2-google": "^3.0 || ^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c59a1388833927af758b5d9d808f3130",
+    "content-hash": "a3f068b38533a169fed7ecd60558d674",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -5509,5 +5509,5 @@
     "platform-overrides": {
         "php": "7.4.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -326,27 +326,27 @@
         },
         {
             "name": "civicrm/composer-downloads-plugin",
-            "version": "v3.0.1",
+            "version": "v4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/civicrm/composer-downloads-plugin.git",
-                "reference": "3aabb6d259a86158d01829fc2c62a2afb9618877"
+                "reference": "7af08ca4a78607ac2bad3215c05a10390da9c673"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/civicrm/composer-downloads-plugin/zipball/3aabb6d259a86158d01829fc2c62a2afb9618877",
-                "reference": "3aabb6d259a86158d01829fc2c62a2afb9618877",
+                "url": "https://api.github.com/repos/civicrm/composer-downloads-plugin/zipball/7af08ca4a78607ac2bad3215c05a10390da9c673",
+                "reference": "7af08ca4a78607ac2bad3215c05a10390da9c673",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.1 || ^2.0",
-                "php": ">=5.6",
-                "togos/gitignore": "~1.1.1"
+                "civicrm/gitignore": "~1.2.0",
+                "composer-plugin-api": "^2.0",
+                "php": ">=7.2"
             },
             "require-dev": {
-                "composer/composer": "~1.0 || ~2.0",
+                "composer/composer": "~2.0",
                 "friendsofphp/php-cs-fixer": "^2.3",
-                "phpunit/phpunit": "^5.7",
+                "phpunit/phpunit": "^8.5 || ^9.5",
                 "totten/process-helper": "^1.0.1"
             },
             "type": "composer-plugin",
@@ -374,9 +374,48 @@
             ],
             "description": "Composer plugin for downloading additional files within any composer package.",
             "support": {
-                "source": "https://github.com/civicrm/composer-downloads-plugin/tree/v3.0.1"
+                "source": "https://github.com/civicrm/composer-downloads-plugin/tree/v4.0.0"
             },
-            "time": "2020-11-02T05:26:23+00:00"
+            "time": "2024-04-09T20:34:36+00:00"
+        },
+        {
+            "name": "civicrm/gitignore",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/civicrm/PHPGitIgnore.git",
+                "reference": "7491782ee89c4e14bbcc9b30bebb90389054cb2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/civicrm/PHPGitIgnore/zipball/7491782ee89c4e14bbcc9b30bebb90389054cb2e",
+                "reference": "7491782ee89c4e14bbcc9b30bebb90389054cb2e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "replace": {
+                "togos/gitignore": "1.*"
+            },
+            "require-dev": {
+                "togos/simpler-test": "1.1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "TOGoS_GitIgnore_": "src/main/php/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Parser for .gitignore (and sparse-checkout, and anything else using the same format) files",
+            "support": {
+                "source": "https://github.com/civicrm/PHPGitIgnore/tree/1.2.0"
+            },
+            "time": "2024-04-09T07:07:33+00:00"
         },
         {
             "name": "cweagans/composer-patches",
@@ -4984,43 +5023,6 @@
                 }
             ],
             "time": "2021-12-31T08:39:24+00:00"
-        },
-        {
-            "name": "togos/gitignore",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/TOGoS/PHPGitIgnore.git",
-                "reference": "32bc0830e4123f670adcbf5ddda5bef362f4f4d4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/TOGoS/PHPGitIgnore/zipball/32bc0830e4123f670adcbf5ddda5bef362f4f4d4",
-                "reference": "32bc0830e4123f670adcbf5ddda5bef362f4f4d4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2"
-            },
-            "require-dev": {
-                "togos/simpler-test": "1.1.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "TOGoS_GitIgnore_": "src/main/php/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Parser for .gitignore (and sparse-checkout, and anything else using the same format) files",
-            "support": {
-                "issues": "https://github.com/TOGoS/PHPGitIgnore/issues",
-                "source": "https://github.com/TOGoS/PHPGitIgnore/tree/master"
-            },
-            "time": "2019-04-19T19:16:58+00:00"
         },
         {
             "name": "totten/ca-config",


### PR DESCRIPTION
Overview
----------------------------------------

When running `composer install` on PHP 8.2+, one is likely to see repeated warnings, e.g.:

```
Deprecation Notice: Creation of dynamic property TOGoS_GitIgnore_FileFinder::$ruleset is deprecated in /home/homer/buildkit/build/build-1/web/sites/all/modules/civicrm/vendor/togos/gitignore/src/main/php/TOGoS/GitIgnore/FileFinder.php:7
Deprecation Notice: Creation of dynamic property TOGoS_GitIgnore_FileFinder::$invertRulesetResult is deprecated in /home/homer/buildkit/build/build-1/web/sites/all/modules/civicrm/vendor/togos/gitignore/src/main/php/TOGoS/GitIgnore/FileFinder.php:8
Deprecation Notice: Creation of dynamic property TOGoS_GitIgnore_FileFinder::$defaultResult is deprecated in /home/homer/buildkit/build/build-1/web/sites/all/modules/civicrm/vendor/togos/gitignore/src/main/php/TOGoS/GitIgnore/FileFinder.php:9
```

This update allows Drupal 8/9/10-style sites to get a new version of the package which resolves the warnings, and it switches the 

See also: https://lab.civicrm.org/dev/core/-/issues/4919 and https://lab.civicrm.org/dev/core/-/issues/3833

ping @demeritcowboy 

Before
----------------------------------------

* `civicrm-core` requires `composer-downloads-plugin` v3, which uses `TOGoS/gitignore`. But this package is unmaintained.

After
----------------------------------------

* `civicrm-core` requires `composer-downloads-plugin` v3 or v4. The latter switches to a fork `civicrm/gitignore` and addresses the PHP warnings.

Comments
----------------------------------------

I'm a bit ambivalent about how exactly to target this change (e.g. v3 vs v4; json vs lock; master vs rc vs stable). The relaxed constraint (`^3.0 || ^4.0`) is more accurate and more compatible in edge-cases. A stricter constraint (`^4.0`) would do a better job of coaxing typical deployments to get the PHP 8.2 fixes. This feels sort of middle-of-the-road. But if there are some strong opinions pointing another way, then that's fine.