### PR TITLE
SearchKit - Fix SearchSegment state/province

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/searchSegment/crmSearchAdminSegment.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchSegment/crmSearchAdminSegment.component.js
@@ -10,7 +10,8 @@
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this,
         originalEntity,
-        originalField;
+        originalField,
+        meta = {};
 
       this.entitySelect = searchMeta.getPrimaryAndSecondaryEntitySelect();
 
@@ -56,6 +57,20 @@
           ctrl.addItem(true);
         }
       };
+
+      this.getOptionKey = function(expr) {
+        let arg = getFirstArgFromExpr(expr);
+        return arg.suffix ? arg.suffix.slice(1) : 'id';
+      };
+
+      // Gets the first arg of type "field"
+      function getFirstArgFromExpr(expr) {
+        if (!(expr in meta)) {
+          var args = searchMeta.parseExpr(expr).args;
+          meta[expr] = _.findWhere(args, {type: 'field'});
+        }
+        return meta[expr] || {};
+      }
 
       function getDefaultField() {
         var item = _.findLast(ctrl.segment.items, function(item) {

--- a/ext/search_kit/ang/crmSearchAdmin/searchSegment/crmSearchAdminSegment.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchSegment/crmSearchAdminSegment.html
@@ -34,7 +34,7 @@
             <td>
               <div ng-repeat="condition in item.when" class="form-inline">
                 <input class="form-control" ng-model="condition[0]" crm-ui-select="{data: $ctrl.selectFields, allowClear: false}" >
-                <crm-search-condition clause="condition" field="$ctrl.getField(condition[0])" offset="1" option-key="'name'" class="form-group"></crm-search-condition>
+                <crm-search-condition clause="condition" field="$ctrl.getField(condition[0])" offset="1" option-key="$ctrl.getOptionKey(condition[0])" class="form-group"></crm-search-condition>
                 <a class="crm-hover-button" ng-if="$index" ng-click="item.when.splice($index, 1)">
                   <i class="crm-i fa-times" aria-hidden="true"></i>
                 </a>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5121](https://lab.civicrm.org/dev/core/-/issues/5121)

Before
----------------------------------------
State/Province doesn't work as a search segment.

After
----------------------------------------
Works

Comments
----------------------------------------
Broken search segments using state/province will need to be recreated after applying this patch (but they were broken anyway).