### PR TITLE
(dev/core#2994) IFrame Connector - Add support for Backdrop

### DIFF
--- a/ext/iframe/Civi/Iframe/EntryPoint/Backdrop.php
+++ b/ext/iframe/Civi/Iframe/EntryPoint/Backdrop.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Civi\Iframe\EntryPoint;
+
+//TEMPLATE:START
+
+/**
+ * Begin processing of an embedded page-view on Backdrop
+ */
+class Backdrop {
+
+  public static function main(): void {
+
+    define('CIVICRM_IFRAME', 1);
+    define('BACKDROP_ROOT', getcwd());
+
+    // Do not accept cookies.
+    // The whole issue is that browsers disagree on cookie-handling for embedded iframe content.
+    // (Ex: Safari 16 doesn't send cookies; but Firefox 118 does.)
+    // This means that `iframe.php` has the same cookie-less behavior for all browsers/users/tools.
+    foreach (array_keys($_COOKIE) as $cookie) {
+      unset($_COOKIE[$cookie]);
+    }
+
+    $GLOBALS['civicrm_url_defaults'][]['scheme'] = 'iframe';
+
+    require_once BACKDROP_ROOT . '/core/includes/bootstrap.inc';
+    \backdrop_bootstrap(BACKDROP_BOOTSTRAP_FULL);
+    $GLOBALS['config']['x_frame_options'] = '';
+    \civicrm_initialize();
+
+    \Civi::service('iframe.router')->invoke([
+      'route' => trim($_SERVER['PATH_INFO'], '/'),
+    ]);
+  }
+
+}
+
+//TEMPLATE:END


### PR DESCRIPTION
Overview
----------------------------------------

Follow-up to #29496 which adds an adapter for Backdrop. 

See also: https://lab.civicrm.org/dev/core/-/issues/2994

Before
----------------------------------------

If you enable `iframe` on Backdrop, then you get this notification:

<img width="1178" alt="Screenshot 2024-04-09 at 11 13 37 PM" src="https://github.com/civicrm/civicrm-core/assets/1336047/e0391b7a-6aa4-4e4f-85ce-664379f2e56b">

After
----------------------------------------

If you enable `iframe` on Backdrop, then you can proceed with regular installation of the connector:

<img width="1179" alt="Screenshot 2024-04-09 at 11 16 09 PM" src="https://github.com/civicrm/civicrm-core/assets/1336047/04361865-2d7c-40cf-a47a-5cd1e7af78df">

See #29496 for instructions on usage/process.