### PR TITLE
Add support for saving custom data on option values

### DIFF
--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -179,6 +179,12 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue implements \Civi
       $optionValue->find(TRUE);
       self::updateOptionDefaults($params['option_group_id'], $optionValue->id, $optionValue, $groupName);
     }
+    if (!empty($params['custom']) &&
+      is_array($params['custom'])
+    ) {
+      CRM_Core_BAO_CustomValueTable::store($params['custom'], 'civicrm_option_value', $optionValue->id, $op);
+    }
+
     Civi::cache('metadata')->flush();
     CRM_Core_PseudoConstant::flush();
 

--- a/templates/CRM/Admin/Form/Options.tpl
+++ b/templates/CRM/Admin/Form/Options.tpl
@@ -156,6 +156,11 @@
              <td>{$form.contact_type_id.html}</td>
            </tr>
         {/if}
+        <tr class="crm-admin-options-form-block-custom_data">
+          <td colspan="2">
+            {include file="CRM/common/customDataBlock.tpl" customDataType='OptionValue' cid=false}
+          </td>
+        </tr>
     </table>
   {/if}
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>


### PR DESCRIPTION
Overview
----------------------------------------
This adds support for saving Custom Data on Option values

Before
----------------------------------------
Cannot save Custom Data on Option Values

After
----------------------------------------
Can save custom data on option values e.g. Activity Types

Note you will still need to add OptionValue into the cg_extends option group to fully make this work

ping @eileenmcnaughton @JoeMurray 