### PR TITLE
[REF] Use standard DeleteMessage functionality from EntityFormTrait f…

### DIFF
--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -23,6 +23,8 @@ use Civi\Api4\OptionValue;
  */
 class CRM_Admin_Form_Options extends CRM_Admin_Form {
 
+  use CRM_Core_Form_EntityFormTrait;
+
   /**
    * The option group name.
    *
@@ -47,6 +49,13 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
    * @var bool
    */
   public $submitOnce = TRUE;
+
+  /**
+   * Explicitly declare the entity api name.
+   */
+  public function getDefaultEntity() {
+    return 'OptionValue';
+  }
 
   /**
    * Pre-process
@@ -98,7 +107,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
 
     $session->pushUserContext(CRM_Utils_System::url($url, $params));
     $this->assign('id', $this->_id);
-
+    $this->setDeleteMessage(ts('WARNING: Deleting this option will result in the loss of all %1 related records which use the option.', [1 => $this->_gLabel]) . ts('This may mean the loss of a substantial amount of data, and the action cannot be undone.') . ts('Do you want to continue?'));
     if ($this->_id && CRM_Core_OptionGroup::isDomainOptionGroup($this->_gName)) {
       $domainID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionValue', $this->_id, 'domain_id', 'id');
       if (CRM_Core_Config::domainID() != $domainID) {
@@ -156,6 +165,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
     $this->setPageTitle(ts('%1 Option', [1 => $this->_gLabel]));
 
     if ($this->_action & CRM_Core_Action::DELETE) {
+      $this->buildDeleteForm();
       return;
     }
 

--- a/templates/CRM/Admin/Form/Options.tpl
+++ b/templates/CRM/Admin/Form/Options.tpl
@@ -12,7 +12,7 @@
   {if $action eq 8}
     <div class="messages status no-popup">
       {icon icon="fa-info-circle"}{/icon}
-      {ts 1=$gLabel}WARNING: Deleting this option will result in the loss of all %1 related records which use the option.{/ts} {ts}This may mean the loss of a substantial amount of data, and the action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
+      {$deleteMessage|escape}
     </div>
   {else}
     <table class="form-layout-compressed">


### PR DESCRIPTION
…or OptionValues

Overview
----------------------------------------
This modifies the OptionValue Edit/Delete form to use the standard DeleteMessage functionality in the entity form trait

Before
----------------------------------------
Delete message hard coded in tpl

After
----------------------------------------
Hooks can modify delete message if needed and uses more generic functionality

ping @eileenmcnaughton @JoeMurray