### PR TITLE
Fold function back into only caller

### DIFF
--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -711,6 +711,7 @@ WHERE  id = %1";
    * @deprecated since 5.68. Will be removed around 5.80.
    */
   public static function buildPriceSet(&$form, $component = NULL, $validFieldsOnly = TRUE) {
+    CRM_Core_Error::deprecatedWarning('internal function');
     $priceSetId = $form->get('priceSetId');
     if (!$priceSetId) {
       return;


### PR DESCRIPTION
Overview
----------------------------------------
Fold function back into only caller

Before
----------------------------------------
This form is the only remaining user of the function - it was already deprecated

After
----------------------------------------
 this adds noisy deprecation & takes a copy for the Membership_Form

Technical Details
----------------------------------------
I'll do a bit more tidy up to address notices affecting https://github.com/civicrm/civicrm-core/pull/29889 - but this is a precursor in that it gets the code to a location where it can be edited without touching code that at least has the appearance of being shared code

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
