### PR TITLE
Joomla: fixes broken mobile menu and a small regression.

### DIFF
--- a/css/joomla.css
+++ b/css/joomla.css
@@ -11,8 +11,12 @@ body.admin.com_civicrm .crm-container .label {
   font-size: inherit;
   line-height: inherit;
 }
-body.admin.com_civicrm.layout-default #content {
+body.admin.com_civicrm.layout-default #content,
+body.admin.com_civicrm.layout-default #content > .row > .col-md-12 {
   padding: 0;
+}
+body.admin.com_civicrm.layout-default #content > .row {
+  margin-inline: 0;
 }
 body.admin.com_civicrm #crm-content {
   padding: 1rem;

--- a/css/menubar-joomla.css
+++ b/css/menubar-joomla.css
@@ -59,15 +59,13 @@ body.admin.com_civicrm.layout-default #crm-qsearch label {
 
 @media (max-width: $breakMin) {
 
-  body.com_civicrm.layout-default #header {
-    margin-bottom: $menubarHeight;
-  }
-
   body.admin.com_civicrm.layout-default #civicrm-menu-nav {
-    margin-top: calc($menubarHeight + 14px);
     background: #1b1b1b;
-    z-index: 1000;
     height: $menubarHeight;
     border-top: 1px solid #aaa;
+  }
+
+  body.admin.com_civicrm.layout-default .breadcrumb {
+    margin-top: 2.5rem;
   }
 }


### PR DESCRIPTION
While fixing a width regression from [the big Joomla css cleanup](https://github.com/civicrm/civicrm-core/pull/27834) (a little padding on the right of the screen if you scroll horizontally, which most people don't so easy to miss), I noticed that mobile menu display for Joomla 4 is quite broken. This pre-dates the css cleanup, tho I'm not sure when it started - or if the cause was a change to Joomla or Civi. This should fix it.

Before
----------------------------------------
The regression (visible when you scroll right):
<img width="939" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/f5a2bcaf-75a8-4fca-a5e8-d30d2fd4a941">

The broken mobile view:
<img width="690" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/12d81f7e-1a4a-4100-bc23-3110ccef1351">

After
----------------------------------------
Sidescroll is gone, and mobile menu is better:

<img width="691" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/472392b4-233f-4a28-a0e9-17b388422c84">

Technical Details
----------------------------------------
This should all be name-spaced to only target Joomla 4 +.

Comments
----------------------------------------
There's two different issues here in this one PR, but as there's not a flood of Joomla reviewers, should make review quicker.