### PR TITLE
Permissions - Allow hooks/extensions to declare implied permissions 

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -591,6 +591,14 @@ class CRM_Core_Permission {
     $permissions = self::getCoreAndComponentPermissions();
     $module_permissions = CRM_Core_Config::singleton()->userPermissionClass->getAllModulePermissions();
     $allPermissions = array_merge($permissions, $module_permissions);
+    // Propagate implied_by permissions to their parents
+    foreach ($allPermissions as $name => $permission) {
+      foreach ($permission['implied_by'] ?? [] as $parent) {
+        if (isset($allPermissions[$parent])) {
+          $allPermissions[$parent]['implies'][] = $name;
+        }
+      }
+    }
     // Propagate implied permissions to their children
     foreach ($allPermissions as $name => $permission) {
       if (!empty($permission['implies'])) {

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -714,6 +714,7 @@ class CRM_Core_Permission {
         'implies' => [
           'administer CiviCRM system',
           'administer CiviCRM data',
+          'access CiviCRM',
         ],
       ],
       'skip IDS check' => [

--- a/CRM/Core/Permission/Base.php
+++ b/CRM/Core/Permission/Base.php
@@ -410,6 +410,8 @@ class CRM_Core_Permission_Base {
         'label' => $defn['label'] ?? $defn[0],
         'description' => $defn['description'] ?? $defn[1] ?? NULL,
         'disabled' => $defn['disabled'] ?? NULL,
+        'implies' => $defn['implies'] ?? NULL,
+        'implied_by' => $defn['implied_by'] ?? NULL,
       ];
       $permissions[$name] = array_filter($permission, fn($item) => isset($item));
     }

--- a/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
+++ b/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
@@ -372,7 +372,7 @@ trait SavedSearchInspectorTrait {
   protected function checkPermissionToLoadSearch() {
     if (
       (is_array($this->savedSearch) || (isset($this->display) && is_array($this->display))) && $this->checkPermissions &&
-      !\CRM_Core_Permission::check([['administer CiviCRM data', 'administer search_kit']])
+      !\CRM_Core_Permission::check('administer search_kit')
     ) {
       throw new UnauthorizedException('Access denied');
     }

--- a/ext/afform/admin/ang/afAdminFormSubmissionList.aff.php
+++ b/ext/afform/admin/ang/afAdminFormSubmissionList.aff.php
@@ -5,6 +5,5 @@ return [
   'type' => 'system',
   'title' => E::ts('Submissions'),
   'server_route' => 'civicrm/admin/afform/submissions',
-  'permission' => ["administer CiviCRM", "administer afform"],
-  'permission_operator' => 'OR',
+  'permission' => ['administer afform'],
 ];

--- a/ext/afform/admin/managed/Navigation_afform_admin.mgd.php
+++ b/ext/afform/admin/managed/Navigation_afform_admin.mgd.php
@@ -13,10 +13,8 @@ return [
         'name' => 'afform_admin',
         'label' => E::ts('FormBuilder'),
         'permission' => [
-          'administer CiviCRM',
           'administer afform',
         ],
-        'permission_operator' => 'OR',
         'parent_id.name' => 'Customize Data and Screens',
         'weight' => 1,
         'url' => 'civicrm/admin/afform',

--- a/ext/afform/admin/xml/Menu/afform_admin.xml
+++ b/ext/afform/admin/xml/Menu/afform_admin.xml
@@ -3,6 +3,6 @@
   <item>
     <path>civicrm/admin/afform</path>
     <page_callback>CRM_AfformAdmin_Page_Base</page_callback>
-    <access_arguments>administer CiviCRM;administer afform</access_arguments>
+    <access_arguments>administer afform</access_arguments>
   </item>
 </menu>

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -350,7 +350,7 @@ class Afform extends Generic\AbstractEntity {
   public static function permissions() {
     return [
       'meta' => ['access CiviCRM'],
-      'default' => [['administer CiviCRM', 'administer afform']],
+      'default' => ['administer afform'],
       // These all check form-level permissions
       'get' => [],
       'getOptions' => [],

--- a/ext/afform/core/Civi/Api4/AfformBehavior.php
+++ b/ext/afform/core/Civi/Api4/AfformBehavior.php
@@ -28,7 +28,7 @@ class AfformBehavior extends Generic\AbstractEntity {
   public static function permissions() {
     return [
       'meta' => ['access CiviCRM'],
-      'get' => [['administer CiviCRM', 'administer afform']],
+      'get' => ['administer afform'],
     ];
   }
 

--- a/ext/afform/core/Civi/Api4/AfformSubmission.php
+++ b/ext/afform/core/Civi/Api4/AfformSubmission.php
@@ -18,7 +18,7 @@ class AfformSubmission extends Generic\DAOEntity {
   public static function permissions() {
     return [
       'meta' => ['access CiviCRM'],
-      'default' => [['administer CiviCRM', 'administer afform']],
+      'default' => ['administer afform'],
     ];
   }
 

--- a/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
+++ b/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
@@ -132,7 +132,7 @@ class AfformAutocompleteSubscriber extends AutoService implements EventSubscribe
    * @param \Civi\Api4\Generic\AutocompleteAction $apiRequest
    */
   private function processAfformAdminAutocomplete(string $fieldName, AutocompleteAction $apiRequest):void {
-    if (!\CRM_Core_Permission::check([['administer CiviCRM', 'administer afform']])) {
+    if (!\CRM_Core_Permission::check('administer afform')) {
       return;
     }
     switch ($fieldName) {

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -434,6 +434,7 @@ function afform_civicrm_permission(&$permissions) {
   $permissions['administer afform'] = [
     'label' => E::ts('FormBuilder: edit and delete forms'),
     'description' => E::ts('Allows non-admin users to create, update and delete forms'),
+    'implied_by' => ['administer CiviCRM'],
   ];
 }
 

--- a/ext/search_kit/CRM/Search/BAO/SearchDisplay.php
+++ b/ext/search_kit/CRM/Search/BAO/SearchDisplay.php
@@ -32,7 +32,7 @@ class CRM_Search_BAO_SearchDisplay extends CRM_Search_DAO_SearchDisplay implemen
         return;
       }
       // Must be at least a SearchKit administrator
-      if (!CRM_Core_Permission::check([['administer CiviCRM data', 'administer search_kit']], $userCID)) {
+      if (!CRM_Core_Permission::check('administer search_kit', $userCID)) {
         $e->setAuthorized(FALSE);
         return;
       }

--- a/ext/search_kit/Civi/Api4/SKEntity.php
+++ b/ext/search_kit/Civi/Api4/SKEntity.php
@@ -87,8 +87,8 @@ class SKEntity {
   public static function permissions(): array {
     return [
       'meta' => ['access CiviCRM'],
-      'refresh' => [['administer CiviCRM data', 'administer search_kit']],
-      'getRefreshDate' => [['administer CiviCRM data', 'administer search_kit']],
+      'refresh' => ['administer search_kit'],
+      'getRefreshDate' => ['administer search_kit'],
     ];
   }
 

--- a/ext/search_kit/Civi/Api4/SearchDisplay.php
+++ b/ext/search_kit/Civi/Api4/SearchDisplay.php
@@ -52,7 +52,7 @@ class SearchDisplay extends Generic\DAOEntity {
 
   public static function permissions() {
     $permissions = parent::permissions();
-    $permissions['default'] = [['administer CiviCRM data', 'administer search_kit']];
+    $permissions['default'] = ['administer search_kit'];
     // Anyone with access to CiviCRM can view search displays (but not necessarily the results)
     $permissions['get'] = $permissions['getDefault'] = ['access CiviCRM'];
     // Anyone with access to CiviCRM can do search tasks (but not necessarily all of them)

--- a/ext/search_kit/Civi/Api4/SearchSegment.php
+++ b/ext/search_kit/Civi/Api4/SearchSegment.php
@@ -12,7 +12,7 @@ class SearchSegment extends Generic\DAOEntity {
 
   public static function permissions() {
     $permissions = parent::permissions();
-    $permissions['default'] = [['administer CiviCRM data', 'administer search_kit']];
+    $permissions['default'] = ['administer search_kit'];
     return $permissions;
   }
 

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -23,7 +23,7 @@
     $scope.hs = crmUiHelp({file: 'CRM/Search/Help/Compose'});
 
     this.afformEnabled = 'org.civicrm.afform' in CRM.crmSearchAdmin.modules;
-    this.afformAdminEnabled = (CRM.checkPerm('administer CiviCRM') || CRM.checkPerm('administer afform')) &&
+    this.afformAdminEnabled = CRM.checkPerm('administer afform') &&
       'org.civicrm.afform_admin' in CRM.crmSearchAdmin.modules;
     this.displayTypes = _.indexBy(CRM.crmSearchAdmin.displayTypes, 'id');
     this.searchDisplayPath = CRM.url('civicrm/search');

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -18,7 +18,7 @@
       this.searchDisplayPath = CRM.url('civicrm/search');
       this.afformPath = CRM.url('civicrm/admin/afform');
       this.afformEnabled = 'org.civicrm.afform' in CRM.crmSearchAdmin.modules;
-      this.afformAdminEnabled = (CRM.checkPerm('administer CiviCRM') || CRM.checkPerm('administer afform')) &&
+      this.afformAdminEnabled = CRM.checkPerm('administer afform') &&
         'org.civicrm.afform_admin' in CRM.crmSearchAdmin.modules;
       const scheduledCommunicationsEnabled = 'scheduled_communications' in CRM.crmSearchAdmin.modules;
 

--- a/ext/search_kit/managed/Navigation_search_kit.mgd.php
+++ b/ext/search_kit/managed/Navigation_search_kit.mgd.php
@@ -15,7 +15,6 @@ return [
         'url' => 'civicrm/admin/search',
         'icon' => 'crm-i fa-search-plus',
         'permission' => [
-          'administer CiviCRM data',
           'administer search_kit',
         ],
         'permission_operator' => 'OR',

--- a/ext/search_kit/search_kit.php
+++ b/ext/search_kit/search_kit.php
@@ -22,6 +22,7 @@ function search_kit_civicrm_permission(&$permissions) {
   $permissions['administer search_kit'] = [
     'label' => E::ts('SearchKit: edit and delete searches'),
     'description' => E::ts('Gives non-admin users access to the SearchKit UI to create, update and delete searches and displays'),
+    'implied_by' => ['administer CiviCRM data'],
   ];
 }
 

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -1060,7 +1060,7 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     }
     $this->assertStringContainsString('failed', $error);
 
-    $config->userPermissionClass->permissions = ['access CiviCRM', 'administer search_kit'];
+    $config->userPermissionClass->permissions = ['administer CiviCRM'];
 
     // Admins can edit the search and the display
     SavedSearch::update()->addWhere('name', '=', $searchName)


### PR DESCRIPTION
Overview
----------------------------------------
This builds on #29174 by enabling extensions to take advantage of implied permissions.

Before
----------------------------------------
Only core could set the "implies" property of a permission.

After
----------------------------------------
Extensions can do it too!

This implements the feature in SearchKit and Afform, which makes permission checks simpler for both.