### PR TITLE
add missing cms: prefix to permission check

### DIFF
--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -808,7 +808,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
       // if we are a admin OR the same user OR acl-user with access to the profile
       // or we have checksum access to this contact (i.e. the user without a login) - CRM-5909
       if (
-        CRM_Core_Permission::check('administer users') ||
+        CRM_Core_Permission::check('cms:administer users') ||
         $this->_id == $this->_currentUserID ||
         $this->_isPermissionedChecksum ||
         in_array(

--- a/CRM/Profile/Page/Dynamic.php
+++ b/CRM/Profile/Page/Dynamic.php
@@ -201,7 +201,7 @@ class CRM_Profile_Page_Dynamic extends CRM_Core_Page {
 
       $this->_isPermissionedChecksum = $allowPermission = FALSE;
       $permissionType = CRM_Core_Permission::VIEW;
-      if (CRM_Core_Permission::check('administer users') || CRM_Core_Permission::check('view all contacts') || CRM_Contact_BAO_Contact_Permission::allow($this->_id)) {
+      if (CRM_Core_Permission::check('cms:administer users') || CRM_Core_Permission::check('view all contacts') || CRM_Contact_BAO_Contact_Permission::allow($this->_id)) {
         $allowPermission = TRUE;
       }
       if ($this->_id != $userID) {


### PR DESCRIPTION
Overview
----------------------------------------
These permissions checks in Profile code seem to be missing the `cms: ` prefix they should have now.

Before
----------------------------------------
Checking a permission that no longer actually exists. Probably no one notices that the checks always fail because they are unusual cases.

After
----------------------------------------
Use the standardised naming for the cms permissions that's used everywhere else. If you have `cms: administer users` and not `view all contacts` you get some more power on a Profile page?

Comments
----------------------------------------
Found in course of https://github.com/civicrm/civicrm-core/pull/29896
