### PR TITLE
OAuth - Add permission implications

### DIFF
--- a/ext/oauth-client/CRM/OAuth/BAO/OAuthContactToken.php
+++ b/ext/oauth-client/CRM/OAuth/BAO/OAuthContactToken.php
@@ -58,7 +58,7 @@ class CRM_OAuth_BAO_OAuthContactToken extends CRM_OAuth_DAO_OAuthContactToken im
       if (!CRM_Contact_BAO_Contact_Permission::allow($cid, CRM_Core_Permission::EDIT, $userId)) {
         throw new \Civi\API\Exception\UnauthorizedException('Access denied to contact');
       }
-      if (!CRM_Core_Permission::check([['manage all OAuth contact tokens', 'manage my OAuth contact tokens']], $userId)) {
+      if (!CRM_Core_Permission::check('manage my OAuth contact tokens', $userId)) {
         throw new \Civi\API\Exception\UnauthorizedException('Access denied to OAuthContactToken');
       }
       if (

--- a/ext/oauth-client/Civi/Api4/OAuthContactToken.php
+++ b/ext/oauth-client/Civi/Api4/OAuthContactToken.php
@@ -15,12 +15,7 @@ class OAuthContactToken extends Generic\DAOEntity {
   public static function permissions(): array {
     return [
       'meta' => ['access CiviCRM'],
-      'default' => [
-        [
-          'manage my OAuth contact tokens',
-          'manage all OAuth contact tokens',
-        ],
-      ],
+      'default' => ['manage my OAuth contact tokens'],
     ];
   }
 

--- a/ext/oauth-client/oauth_client.php
+++ b/ext/oauth-client/oauth_client.php
@@ -41,6 +41,7 @@ function oauth_client_civicrm_permission(&$permissions) {
   $permissions['manage all OAuth contact tokens'] = [
     'label' => $prefix . ts('manage all OAuth contact tokens'),
     'description' => ts("Manage OAuth tokens for all contacts"),
+    'implies' => ['manage my OAuth contact tokens'],
   ];
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
This adds a logical relationship between the 2 permissions declared by OAuth.

Technical Details
----------------------------------------
According to the runtime logic (and common sense), 'manage my' is always granted to those with 'manage all'. So this codifies that implication.