### PR TITLE
dev/core#5118 Add support for trailing conditional bracket [wip - regex not quite right]

### DIFF
--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -88,8 +88,14 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
     // {contact.address_primary.city}{, }{contact.address_primary.state_province_id:label}{ }{contact.address_primary.postal_code}
     // Where state_province is not present. No perfect solution here but we
     // do want to keep the comma in this case.
+    // e.g String is Michael{ }Jackson{ (}Mick{)}
     $e->string = preg_replace('/\\\\|{(\s*([,`~()\-*|])*\s*)?}}*({\s})/', '$1', $e->string);
+    // e.g. String is Michael{ }Jackson{ (}Mick{)}
     $e->string = preg_replace('/\\\\|{(\s*(\s|,|`|~|\(|\)|-|\*|\|)*\s*)?\}}*(?=[^{\s])/', '$1', $e->string);
+    // e.g. String is Michael Jackson (Mick{)}
+    // Specific regex for handling a closing bracket at the end of line `{)}` where there is a closing bracket present
+    $e->string = preg_replace('/\([^{]*{(\s*\)+\s*)}$/', '$1', $e->string);
+    // String is Michael Jackson (Mick)
     // Now do a another pass, removing any remaining instances (which will get rid of any that were not
     // followed by something).
     $e->string = preg_replace('/\\\\|' . '\{(\s*(\s|,|`|~|\(|\)|-|\*|\|)*\s?)?\}/', '', $e->string);

--- a/tests/phpunit/CRM/Contact/BAO/IndividualTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/IndividualTest.php
@@ -128,6 +128,8 @@ class CRM_Contact_BAO_IndividualTest extends CiviUnitTestCase {
   public static function displayFormatCases(): array {
     return [
       'Nick name with tilde' => ['{contact.first_name}{ }{contact.last_name}{ ~ }{contact.nick_name}', 'Michael Jackson ~ Mick'],
+      'Nick name surrounding brackets' => ['{contact.first_name}{ (}{contact.nick_name}{) }{ }{contact.last_name}', 'Michael (Mick) Jackson'],
+      'Nick name surrounding brackets at end' => ['{contact.first_name}{ }{contact.last_name}{ (}{contact.nick_name}{)}', 'Michael Jackson (Mick)'],
       'Empty nick name' => ['{contact.first_name}{ }{contact.last_name}{ ~ }{contact.nick_name}', 'Michael Jackson', ['nick_name' => '']],
       'No Nick Name but Prefix' => ['{contact.individual_prefix}{ }{contact.first_name}{ }{contact.middle_name}{ }{contact.last_name}{ }{contact.individual_suffix}{ ~ }{contact.nick_name}', 'Mr. Michael Jackson Jr.', ['nick_name' => '']],
     ];


### PR DESCRIPTION
Overview
----------------------------------------
Add support for trailing conditional bracket in tokens - eg * {contact.first_name}{ }{contact.last_name}{ (}{contact.nick_name}{)}*

Before
----------------------------------------


After
----------------------------------------

Technical Details
----------------------------------------

Comments
----------------------------------------
