### PR TITLE
Guard against missing saved search class during smart group cache rebuild

### DIFF
--- a/ext/legacycustomsearches/legacycustomsearches.php
+++ b/ext/legacycustomsearches/legacycustomsearches.php
@@ -53,9 +53,11 @@ function legacycustomsearches_civicrm_buildGroupContactCache(array $savedSearch,
   $addSelect = "$groupID AS group_id";
   $ssParams = CRM_Contact_BAO_SavedSearch::getFormValues($savedSearchID);
 
-  $customSearchClass = $ssParams['customSearchClass'];
+  // A lack of customSearchClass key probably indicates a deeper problem, but shouldn't hold up the system
+  $customSearchClass = $ssParams['customSearchClass'] ?? NULL;
+
   // check if there is a special function - formatSavedSearchFields defined in the custom search form
-  if (method_exists($customSearchClass, 'formatSavedSearchFields')) {
+  if ($customSearchClass && method_exists($customSearchClass, 'formatSavedSearchFields')) {
     $customSearchClass::formatSavedSearchFields($ssParams);
   }
 


### PR DESCRIPTION
See [dev/core#5143](https://lab.civicrm.org/dev/core/-/issues/5143)

Overview
----------------------------------------
Turns a fatal error during smart group cache build into an exception, allowing scheduled jobs execution to continue

Before
----------------------------------------
`legacycustomsearches_civicrm_buildGroupContactCache` assumes the saved search parameters include a 'customSearchClass' key.
When this is not present throws a warning when assigning it to `$customSearchClass`, then a fatal error when calling `method_exists` on that variable (which is implicitly null).
This stops whatever is happening dead, e.g. cron runs.

After
----------------------------------------
- Explicitly assign null when 'customSearchClass' does not exist, avoiding the warning
- Skip check for method on the empty class variable
- Throws an exception later in the process, but this is caught by the scheduled job and logged.
- Cron will continue even when a problematic smart group is encountered

Technical Details
----------------------------------------
Just adding guards to avoid a fatal error.  No contract changes.

Comments
----------------------------------------
Not sure if this counts as a new regression, but should apply to rc without trouble if it does.