### PR TITLE
Fold getting `$payableItems` back into `getPayableItems()`

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -645,24 +645,26 @@ class CRM_Financial_BAO_Payment {
    *
    * @throws \CRM_Core_Exception
    */
-  protected static function createFinancialItem($lineItem, $trxn_date, $contactID, $currency): array {
+  protected static function createFinancialItem(array $lineItem, string $trxn_date, int $contactID, string $currency): array {
     $financialAccount = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
       $lineItem['financial_type_id'],
       'Income Account Is'
     );
-    $itemParams = [
-      'transaction_date' => $trxn_date,
-      'contact_id' => $contactID,
-      'currency' => $currency,
-      'amount' => $lineItem['line_total'],
-      'description' => $lineItem['label'],
-      'status_id' => 'Unpaid',
-      'financial_account_id' => $financialAccount,
-      'entity_table' => 'civicrm_line_item',
-      'entity_id' => $lineItem['id'],
-    ];
 
-    civicrm_api3('FinancialItem', 'create', $itemParams);
+    FinancialItem::create(FALSE)
+      ->setValues([
+        'transaction_date' => $trxn_date,
+        'contact_id' => $contactID,
+        'currency' => $currency,
+        'amount' => $lineItem['line_total'],
+        'description' => $lineItem['label'],
+        'status_id' => 'Unpaid',
+        'financial_account_id' => $financialAccount,
+        'entity_table' => 'civicrm_line_item',
+        'entity_id' => $lineItem['id'],
+      ])
+      ->execute();
+
     return LineItem::get(FALSE)
       ->addSelect('*', 'financial_item.status_id:name', 'financial_item.id', 'financial_item.financial_account_id', 'financial_item_id.currency', 'financial_item.financial_account_id.is_tax', 'financial_item.entity_id', 'financial_item.amount')
       ->addJoin(

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -518,8 +518,6 @@ class CRM_Financial_BAO_Payment {
       $ratio = 0;
     }
     foreach ($lineItems as $lineItemID => $lineItem) {
-      // Ideally id would be set deeper but for now just add in here.
-      $lineItems[$lineItemID]['id'] = $lineItemID;
       $lineItems[$lineItemID]['paid'] = self::getAmountOfLineItemPaid($lineItemID);
       $lineItems[$lineItemID]['balance'] = $lineItem['line_total'] - $lineItems[$lineItemID]['paid'];
       if (!empty($lineItemOverrides)) {


### PR DESCRIPTION
Overview
----------------------------------------
Fold getting `$payableItems` back into `getPayableItems()`

Before
----------------------------------------
Payable items array partially determined in `getpayableItems()` but then re-worked in the calling function

After
----------------------------------------

This ensure that all the work to get the payable items is done in the function of that name & the calling function is only responsible for creating them based on the output of `getPayableItems()`

Technical Details
----------------------------------------
good test cover, part of a series of PRs to clean up the determination of payable items to be in only 1 place

Comments
----------------------------------------
