### PR TITLE
Drupal 10 - Fix breadcrumbs with id tokens

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -188,6 +188,15 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   public function appendBreadCrumb($breadcrumbs) {
     $civicrmPageState = \Drupal::service('civicrm.page_state');
     foreach ($breadcrumbs as $breadcrumb) {
+      if (stripos($breadcrumb['url'], 'id%%')) {
+        $args = ['cid', 'mid'];
+        foreach ($args as $a) {
+          $val = CRM_Utils_Request::retrieve($a, 'Positive');
+          if ($val) {
+            $breadcrumb['url'] = str_ireplace("%%{$a}%%", $val, $breadcrumb['url']);
+          }
+        }
+      }
       $civicrmPageState->addBreadcrumb($breadcrumb['title'], $breadcrumb['url']);
     }
   }
@@ -296,6 +305,8 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
         'fragment' => $fragment,
         'absolute' => $absolute,
       ])->toString();
+      // Decode %% for better readability, e.g., %%cid%%.
+      $url = str_replace('%25%25', '%%', $url);
     }
     catch (Exception $e) {
       \Drupal::logger('civicrm')->error($e->getMessage());


### PR DESCRIPTION
Overview
----------------------------------------
Fix breadcrumbs with id tokens

Before
----------------------------------------
Breadcrumbs with eg `%%cid%%` in the url is not evaluated. It used to work in drupal 7.

Afftected Pages are View Participant, Manage Case screen, etc.

To replicate: 

- Visit Participant View page on d10 demo site - https://d10-master.demo.civicrm.org/civicrm/contact/view/participant?reset=1&id=31&cid=89&action=view
- Hover on the `Contact Summary` breadcrumb. The value for cid is not replaced.
![CiviCRM  Contact Summary](https://github.com/civicrm/civicrm-core/assets/5929648/5c3e74e3-9a22-4d2c-9955-8ce897f5fc4d)
- Clicking on this link takes you to the dashboard instead of the contact summary page.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
CiviCRM stores the encoded URL in the database, eg, in `civicrm_menu`.  While it [decodes the slashes](https://git.drupalcode.org/project/drupal/-/blob/11.x/core/lib/Drupal/Component/Utility/UrlHelper.php?ref_type=heads#L58) from the query string, it does not handle `%%`, probably because it is specific to CiviCRM. If this change appears to be a bit riskier, perhaps will move the line to `appendBreadcrumb()`.

Comments
----------------------------------------
Requires menu rebuild after the patch.