### PR TITLE
dev/core#5142 Smarty5 Pass variable name in when retrieving a template variable

### DIFF
--- a/CRM/Core/Smarty/plugins/block.edit.php
+++ b/CRM/Core/Smarty/plugins/block.edit.php
@@ -38,7 +38,7 @@
  */
 function smarty_block_edit($params, $text, &$smarty, &$repeat) {
   if (!$repeat) {
-    $action = $smarty->getTemplateVars()['action'];
+    $action = (int) $smarty->getTemplateVars('action');
     return ($action & 3) ? $text : NULL;
   }
 }

--- a/CRM/Core/Smarty/plugins/function.help.php
+++ b/CRM/Core/Smarty/plugins/function.help.php
@@ -34,12 +34,12 @@
  *   the help html to be inserted
  */
 function smarty_function_help($params, $smarty) {
-  if (!isset($params['id']) || !isset($smarty->getTemplateVars()['config'])) {
+  if (!isset($params['id']) || !($smarty->getTemplateVars('config'))) {
     return NULL;
   }
 
-  if (empty($params['file']) && isset($smarty->getTemplateVars()['tplFile'])) {
-    $params['file'] = $smarty->getTemplateVars()['tplFile'];
+  if (empty($params['file']) && $smarty->getTemplateVars('tplFile')) {
+    $params['file'] = $smarty->getTemplateVars('tplFile');
   }
   elseif (empty($params['file'])) {
     return NULL;

--- a/tests/phpunit/CRM/Core/SmartyTest.php
+++ b/tests/phpunit/CRM/Core/SmartyTest.php
@@ -39,7 +39,7 @@ class CRM_Core_SmartyTest extends CiviUnitTestCase {
   public function testFetchWith_CleanNull(): void {
     $smarty = CRM_Core_Smarty::singleton();
     $smarty->assign('my_variable', NULL);
-    $this->assertEquals(NULL, $smarty->getTemplateVars()['my_variable']);
+    $this->assertEquals(NULL, $smarty->getTemplateVars('my_variable'));
 
     $tpl = 'eval:({$my_variable})';
     $this->assertEquals('()', $smarty->fetchWith($tpl, []));
@@ -48,7 +48,7 @@ class CRM_Core_SmartyTest extends CiviUnitTestCase {
     ]));
 
     // Assert global state
-    $this->assertEquals(NULL, $smarty->getTemplateVars()['my_variable']);
+    $this->assertEquals(NULL, $smarty->getTemplateVars('my_variable'));
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Smarty5 Pass variable name in when retrieving a template variable

Before
----------------------------------------
If you don't pass in the value name the returned array holds an array of smarty variable objects in Smarty5


After
----------------------------------------
the specific value is returned

Technical Details
----------------------------------------
per analysis by @demeritcowboy 

Comments
----------------------------------------
