### PR TITLE
Default Smarty version on new installs to 4

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -272,6 +272,17 @@ if (!defined('CIVICRM_SMARTY_AUTOLOAD_PATH')) {
   }
 }
 
+// If not set above we should default the Smarty version to Smarty4 which is our stable version.
+// This will not work for all composer-based installs @todo.
+if (!defined('CIVICRM_SMARTY_AUTOLOAD_PATH')) {
+  if (is_dir($civicrm_root . '/packages')) {
+    define('CIVICRM_SMARTY_AUTOLOAD_PATH', $civicrm_root . '/packages/smarty4/vendor/autoload.php');
+  }
+  elseif (is_dir($civicrm_root . '/../civicrm-packages')) {
+    define('CIVICRM_SMARTY_AUTOLOAD_PATH', $civicrm_root . '/../civicrm-packages/smarty4/vendor/autoload.php');
+  }
+}
+
 /**
  * Define any CiviCRM Settings Overrides per https://docs.civicrm.org/sysadmin/en/latest/customize/settings/
  *


### PR DESCRIPTION
We don't want people installing & then straight away getting messages to get off Smarty2


Note this doesn't quite get us there as it is not covering composer installs - now I'm second guessing whether we require the full path though as the Smarty2 version doesn't have it
