### PR TITLE
Deprecate not passing a name to getTemplateVars (page version)

### DIFF
--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -353,6 +353,7 @@ class CRM_Core_Page {
    * @return array
    */
   public function get_template_vars($name = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning('getTemplateVars');
     return $this->getTemplateVars($name);
   }
 
@@ -362,6 +363,9 @@ class CRM_Core_Page {
    * @param string|null $name
    */
   public function getTemplateVars($name = NULL) {
+    if (!$name) {
+      CRM_Core_Error::deprecatedWarning('not passing a variable name will give unexpected results on som smarty versions');
+    }
     return self::$_template->getTemplateVars($name);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Per https://github.com/civicrm/civicrm-core/pull/29961 - this provides warning about a construct that is unreliable on later Smarty

Before
----------------------------------------
No warning


After
----------------------------------------
Warning

Technical Details
----------------------------------------
@demeritcowboy it may be worth going a step further & hacking this into the pre-smarty-5 packages

Comments
----------------------------------------
