### PR TITLE
Fix broken user account profile tab in drupal 10

### DIFF
--- a/CRM/Core/Permission/Drupal8.php
+++ b/CRM/Core/Permission/Drupal8.php
@@ -33,6 +33,7 @@ class CRM_Core_Permission_Drupal8 extends CRM_Core_Permission_DrupalBase {
   public function check($str, $userId = NULL) {
     $str = $this->translatePermission($str, 'Drupal', [
       'view user account' => 'access user profiles',
+      'administer users' => 'administer users',
     ]);
 
     if ($str == CRM_Core_Permission::ALWAYS_DENY_PERMISSION) {


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/drupal/-/issues/196

Before
----------------------------------------
Edit a user account in drupal 10 and click on the Name and Address tab. Screen fills with php gibberish and the profile fields are all missing.

After
----------------------------------------


Technical Details
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/29946 the change in CRM/Profile/Form.php causes this. I'm not familiar with the cms prefix and didn't know it existed. I've added the same thing that's in drupal 7 but is this what needs to be done since it doesn't feel right? @ufundo 

Comments
----------------------------------------

