### PR TITLE
Assign highlighted fields as json

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -185,7 +185,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
             $highlightedRelFields[$key][] = $k;
           }
         }
-        $this->assign('highlightedRelFields', $highlightedRelFields);
+        $this->assign('highlightedRelFields', json_encode($highlightedRelFields));
         $sel2[$key] = $this->_formattedFieldNames[$relatedContactType];
 
         if (!empty($relatedContactSubType)) {

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -69,7 +69,7 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     $this->addExpectedSmartyVariables(['highlightedRelFields', 'initHideBoxes']);
     $this->assign('columnNames', $this->getColumnHeaders());
     $this->assign('showColumnNames', $this->getSubmittedValue('skipColumnHeader') || $this->getSubmittedValue('dataSource') !== 'CRM_Import_DataSource');
-    $this->assign('highlightedFields', $this->getHighlightedFields());
+    $this->assign('highlightedFields', json_encode($this->getHighlightedFields()));
     $this->assign('dataValues', array_values($this->getDataRows([], 2)));
     $this->_mapperFields = $this->getAvailableFields();
     $fieldMappings = $this->getFieldMappings();

--- a/templates/CRM/common/highLightImport.tpl
+++ b/templates/CRM/common/highLightImport.tpl
@@ -10,12 +10,13 @@
 {* Highlight the required field during import (included within a <script>)*}
 {literal}
 CRM.$(function($) {
-  var highlightedFields = ["{/literal}{'","'|implode:$highlightedFields}{literal}"];
+  var highlightedFields = {/literal}{$highlightedFields}{literal};
   $.each(highlightedFields, function() {
+    // This addition of color by css appears to have stopped working along the way although the append works.
     $('select[id^="mapper"][id$="_0"] option[value='+ this + ']').append(' *').css({"color":"#FF0000"});
   });
   {/literal}{if $highlightedRelFields}{literal}
-  var highlightedRelFields = {/literal}{$highlightedRelFields|@json_encode}{literal};
+  var highlightedRelFields = {/literal}{$highlightedRelFields}{literal};
   function highlight() {
     var select, fields = highlightedRelFields[$(this).val()];
     if (fields) {


### PR DESCRIPTION

Overview
----------------------------------------
Assign highlighted fields as json

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/6e14a78a-5a56-462e-bc25-2a8766b60fcc)

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/f7cc3a54-052b-4b2b-aac0-475416b73567)

Technical Details
----------------------------------------
The import map field screen with Smarty5 doesn't like the use of implode here because Smarty has settled on 'join' as the preferred
alias https://www.php.net/manual/en/function.join.php (probably seen as more user friendly to template developers).

I also don't like the use of join here - because it's really hard to read the line of code it is used in. Hence I switched to assigning json at the php layer instead.

Note that the attempt to add colour seems broken & when I checked on 5.70 it seems to be not working there either - this makes that no better of worse

Comments
----------------------------------------
