### PR TITLE
Fix contribution import to consider address fields for dedupe sufficiency

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -230,6 +230,11 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
       // not cope with a . the quick form layer will use a double underscore
       // as a stand in (the angular layer will not)
       $fieldName = str_replace('__', '.', $mapping[0]);
+      if (str_contains($fieldName, '.')) {
+        // If the field name contains a . - eg. address_primary.street_address
+        // we just want the part after the .
+        $fieldName = substr($fieldName, strpos($fieldName, '.') + 1);
+      }
       if ($fieldName === 'external_identifier' || $fieldName === 'contribution_contact_id' || $fieldName === 'contact__id') {
         // It is enough to have external identifier mapped.
         $weightSum = $threshold;


### PR DESCRIPTION
Overview
----------------------------------------
Fix contribution import to consider address fields for dedupe sufficiency

Before
----------------------------------------
When trying to import contributions with a dedupe rule requiring first_name + last_name + street_address the form rule rejects it on the basis of insufficient weight

After
---------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
