### PR TITLE
Remove unused properties

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -30,10 +30,6 @@ use Civi\UserJob\UserJobInterface;
  * supported.
  */
 abstract class CRM_Import_Parser implements UserJobInterface {
-  /**
-   * Settings
-   */
-  const MAX_WARNINGS = 25, DEFAULT_TIMEOUT = 30;
 
   /**
    * Return codes
@@ -41,21 +37,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   const VALID = 1, WARNING = 2, ERROR = 4, CONFLICT = 8, STOP = 16, DUPLICATE = 32, MULTIPLE_DUPE = 64, NO_MATCH = 128, UNPARSED_ADDRESS_WARNING = 256;
 
   /**
-   * Parser modes
-   */
-  const MODE_MAPFIELD = 1, MODE_PREVIEW = 2, MODE_SUMMARY = 4, MODE_IMPORT = 8;
-
-  /**
    * Codes for duplicate record handling
    */
   const DUPLICATE_SKIP = 1, DUPLICATE_UPDATE = 4, DUPLICATE_FILL = 8, DUPLICATE_NOCHECK = 16;
-
-  /**
-   * Contact types
-   *
-   * @deprecated
-   */
-  const CONTACT_INDIVIDUAL = 'Individual', CONTACT_HOUSEHOLD = 'Household', CONTACT_ORGANIZATION = 'Organization';
 
   /**
    * User job id.
@@ -224,61 +208,10 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   }
 
   /**
-   * Total number of non empty lines
-   * @var int
-   */
-  protected $_totalCount;
-
-  /**
-   * Running total number of valid lines
-   * @var int
-   */
-  protected $_validCount;
-
-  /**
-   * Running total number of invalid rows
-   * @var int
-   */
-  protected $_invalidRowCount;
-
-  /**
    * Array of error lines, bounded by MAX_ERROR
    * @var array
    */
   protected $_errors;
-
-  /**
-   * Total number of duplicate (from database) lines
-   * @var int
-   */
-  protected $_duplicateCount;
-
-  /**
-   * Array of duplicate lines
-   * @var array
-   */
-  protected $_duplicates;
-
-  /**
-   * Maximum number of warnings to store
-   * @var int
-   */
-  protected $_maxWarningCount = self::MAX_WARNINGS;
-
-  /**
-   * Array of warning lines, bounded by MAX_WARNING
-   * @var array
-   */
-  protected $_warnings;
-
-  /**
-   * TO BE REMOVED.
-   *
-   * Array of all the fields that could potentially be part
-   * of this import process
-   * @var array
-   */
-  private $_fields;
 
   private $dedupeRules = [];
 
@@ -405,13 +338,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   protected function isFillDuplicates(): bool {
     return ((int) $this->getSubmittedValue('onDuplicate')) === CRM_Import_Parser::DUPLICATE_FILL;
   }
-
-  /**
-   * Cache of preview rows
-   *
-   * @var array
-   */
-  protected $_rows;
 
   /**
    * Contact type


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused properties

Before
----------------------------------------
We stopped using properties when re-working imports a while back but they are still defined

![image](https://github.com/civicrm/civicrm-core/assets/336308/6711e670-7b21-42a8-bf05-8f9f05f3f8a9)

![image](https://github.com/civicrm/civicrm-core/assets/336308/71f39fe7-9809-499f-8447-098b9a010e87)

![image](https://github.com/civicrm/civicrm-core/assets/336308/8545d0eb-942f-4325-9941-30f1d8c1c80d)


![image](https://github.com/civicrm/civicrm-core/assets/336308/865539ff-6e43-4b34-a709-f40e04be219c)


![image](https://github.com/civicrm/civicrm-core/assets/336308/f03618e9-a194-4089-8d8f-9a4155422940)

![image](https://github.com/civicrm/civicrm-core/assets/336308/b8ff6fb4-88a3-4eec-9b14-543371033b69)



After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
