### PR TITLE
Afform - Allow 'Current Date' as a value option for date fields

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor.css
+++ b/ext/afform/admin/ang/afGuiEditor.css
@@ -216,6 +216,7 @@ body.af-gui-dragging {
 #afGuiEditor af-gui-container,
 #afGuiEditor af-gui-markup,
 #afGuiEditor af-gui-field,
+#afGuiEditor .af-gui-block-label,
 #afGuiEditor af-gui-edit-options {
   display: block;
 }

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
@@ -202,6 +202,10 @@
         }
       };
 
+      this.getFieldId = function(fieldName) {
+        return _.kebabCase(ctrl.entity.name + '-' + fieldName);
+      };
+
       this.$onInit = function() {
         // When a new block is saved, update the list
         this.meta = afGui.meta;

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.html
@@ -1,12 +1,28 @@
-<div class="af-gui-columns crm-flex-box" ng-if="!$ctrl.entity.loading">
+<form class="af-gui-columns crm-flex-box" ng-if="!$ctrl.entity.loading">
   <fieldset class="af-gui-entity-values" ng-if="$ctrl.editor.getAfform().type !== 'block'">
     <legend>{{:: ts('Values:') }}</legend>
-    <div class="form-inline" ng-if="getMeta().fields[fieldName]" ng-repeat="(fieldName, value) in $ctrl.entity.data">
-      <label>{{ getMeta().fields[fieldName].label }}:</label><br />
-      <input class="form-control" af-gui-field-value="getField($ctrl.getEntityType(), fieldName)" ng-model="$ctrl.entity.data[fieldName]" />
-      <a href ng-click="removeValue($ctrl.entity, fieldName)">
-        <i class="crm-i fa-times"></i>
-      </a>
+    <div ng-if="getMeta().fields[fieldName]" ng-repeat="(fieldName, value) in $ctrl.entity.data">
+      <label class="af-gui-block-label" for="{{ $ctrl.getFieldId(fieldName) }}">{{:: getMeta().fields[fieldName].label }}:</label>
+      <label class="af-gui-block-label" ng-if="getField($ctrl.getEntityType(), fieldName)['input_type'] === 'Date'">
+        <input type="radio" name="{{:: fieldName + 'now' }}" ng-click="$ctrl.entity.data[fieldName] = 'now'" ng-checked="$ctrl.entity.data[fieldName] === 'now'">
+        {{:: ts('Current Date') }}
+      </label>
+      <div class="form-inline">
+        <input type="radio" ng-if="getField($ctrl.getEntityType(), fieldName)['input_type'] === 'Date'" name="{{:: fieldName + 'now' }}" ng-click="$ctrl.entity.data[fieldName] = ''" ng-checked="$ctrl.entity.data[fieldName] !== 'now'">
+        <input disabled
+               class="form-control"
+               placeholder="{{:: ts('Pick Date') }}"
+               ng-if="getField($ctrl.getEntityType(), fieldName)['input_type'] === 'Date' && $ctrl.entity.data[fieldName] === 'now'">
+        <input required
+               ng-if="getField($ctrl.getEntityType(), fieldName)['input_type'] !== 'Date' || $ctrl.entity.data[fieldName] !== 'now'"
+               id="{{ $ctrl.getFieldId(fieldName) }}"
+               class="form-control"
+               af-gui-field-value="getField($ctrl.getEntityType(), fieldName)"
+               ng-model="$ctrl.entity.data[fieldName]" />
+        <a href ng-click="removeValue($ctrl.entity, fieldName)">
+          <i class="crm-i fa-times"></i>
+        </a>
+      </div>
     </div>
     <hr />
     <div class="form-inline">
@@ -48,7 +64,7 @@
       </div>
     </div>
   </fieldset>
-</div>
+</form>
 
 <a ng-if="!$ctrl.entity.loading && $ctrl.editor.allowEntityConfig" href ng-click="$ctrl.editor.removeEntity($ctrl.entity.name)" class="btn btn-sm btn-danger-outline af-gui-remove-entity" title="{{ ts('Remove %1', {1: getMeta().label}) }}">
   <i class="crm-i fa-trash"></i>


### PR DESCRIPTION
Overview
----------------------------------------
Allows "now" as a pre-defined value for date fields.

Before
----------------------------------------
Datepicker in "Values" was actually broken.

After
----------------------------------------
Now it works *and* permits "Current Date" as an option.

![image](https://github.com/civicrm/civicrm-core/assets/2874912/a4b0072f-ddca-4c6e-bf61-2f66f4a4c3a4)
