### PR TITLE
SQL Escape - Reconcile CRM_Core_DAO::escapeString() and CRM_Core_I18n::escape()

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2298,6 +2298,9 @@ SELECT contact_id
     if ($string === NULL) {
       return '';
     }
+    if (isset($GLOBALS['CIVICRM_SQL_ESCAPER'])) {
+      return call_user_func($GLOBALS['CIVICRM_SQL_ESCAPER'], $string);
+    }
     static $_dao = NULL;
     if (!$_dao) {
       // If this is an atypical case (e.g. preparing .sql file before CiviCRM

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -24,16 +24,13 @@ class CRM_Core_I18n {
   const NONE = 'none', AUTO = 'auto';
 
   /**
-   * @var callable|null
-   *   A callback function which handles SQL string encoding.
-   *   Set NULL to use the default, CRM_Core_DAO::escapeString().
-   *   This is used by `ts(..., [escape=>sql])`.
+   * @var string
+   * @deprecated
+   *   This variable has 1-2 references in contrib, which -probably- aren't functionally
+   *   necessary. (Extensions don't load in pre-installation environments...)
+   *   But we'll keep the property stub just to prevent crashes.
    *
-   * This option is not intended for general consumption. It is only intended
-   * for certain pre-boot/pre-install contexts.
-   *
-   * You might ask, "Why on Earth does string-translation have an opinion on
-   * SQL escaping?" Good question!
+   *   Replaced by $GLOBALS['CIVICRM_SQL_ESCAPER'].
    */
   public static $SQL_ESCAPER = NULL;
 
@@ -47,12 +44,7 @@ class CRM_Core_I18n {
   protected static function escape($text, $mode) {
     switch ($mode) {
       case 'sql':
-        if (self::$SQL_ESCAPER == NULL) {
-          return CRM_Core_DAO::escapeString($text);
-        }
-        else {
-          return call_user_func(self::$SQL_ESCAPER, $text);
-        }
+        return CRM_Core_DAO::escapeString($text);
 
       case 'js':
         return substr(json_encode($text, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT), 1, -1);

--- a/CRM/Utils/SQL/EscapeStringTrait.php
+++ b/CRM/Utils/SQL/EscapeStringTrait.php
@@ -27,11 +27,11 @@ trait CRM_Utils_SQL_EscapeStringTrait {
       }
     }
 
-    if (CRM_Core_I18n::$SQL_ESCAPER == NULL) {
+    if (!isset($GLOBALS['CIVICRM_SQL_ESCAPER'])) {
       return '"' . CRM_Core_DAO::escapeString($value) . '"';
     }
     else {
-      return '"' . call_user_func(CRM_Core_I18n::$SQL_ESCAPER, $value) . '"';
+      return '"' . call_user_func($GLOBALS['CIVICRM_SQL_ESCAPER'], $value) . '"';
     }
 
   }

--- a/Civi/Test.php
+++ b/Civi/Test.php
@@ -31,15 +31,15 @@ class Test {
   public static function asPreInstall($callback) {
     $conn = \Civi\Test::pdo();
 
-    $oldEscaper = \CRM_Core_I18n::$SQL_ESCAPER;
+    $oldEscaper = $GLOBALS['CIVICRM_SQL_ESCAPER'] ?? NULL;
     \Civi\Test::$statics['testPreInstall'] = (\Civi\Test::$statics['testPreInstall'] ?? 0) + 1;
     try {
-      \CRM_Core_I18n::$SQL_ESCAPER = function ($text) use ($conn) {
+      $GLOBALS['CIVICRM_SQL_ESCAPER'] = function ($text) use ($conn) {
         return substr($conn->quote($text), 1, -1);
       };
       return $callback();
     } finally {
-      \CRM_Core_I18n::$SQL_ESCAPER = $oldEscaper;
+      $GLOBALS['CIVICRM_SQL_ESCAPER'] = $oldEscaper;
       \Civi\Test::$statics['testPreInstall']--;
       if (\Civi\Test::$statics['testPreInstall'] <= 0) {
         unset(\Civi\Test::$statics['testPreInstall']);

--- a/setup/plugins/installDatabase/BootstrapCivi.civi-setup.php
+++ b/setup/plugins/installDatabase/BootstrapCivi.civi-setup.php
@@ -21,7 +21,7 @@ if (!defined('CIVI_SETUP')) {
   ->addListener('civi.setup.installDatabase', function (\Civi\Setup\Event\InstallDatabaseEvent $e) {
     \Civi\Setup::log()->info(sprintf('[%s] Bootstrap CiviCRM', basename(__FILE__)));
 
-    \CRM_Core_I18n::$SQL_ESCAPER = NULL;
+    unset($GLOBALS['CIVICRM_SQL_ESCAPER']);
     unset(\Civi\Test::$statics['testPreInstall']);
 
     CRM_Core_Config::singleton(TRUE, TRUE);

--- a/setup/plugins/installDatabase/Preboot.civi-setup.php
+++ b/setup/plugins/installDatabase/Preboot.civi-setup.php
@@ -38,7 +38,7 @@ if (!defined('CIVI_SETUP')) {
     CRM_Core_ClassLoader::singleton()->register();
 
     $conn = \Civi\Setup\DbUtil::connect($e->getModel()->db);
-    \CRM_Core_I18n::$SQL_ESCAPER = function($text) use ($conn) {
+    $GLOBALS['CIVICRM_SQL_ESCAPER'] = function($text) use ($conn) {
       return $conn->escape_string($text);
     };
 


### PR DESCRIPTION
Overview
----------------------------------------

`CRM_Core_DAO` and `CRM_Core_I18n` both have SQL escaping functions.  This brings them into closer alignment.

It is a step toward #29472.

Before
----------------------------------------

The functions are similar and different:

* __Same__: For usual runtime work, both defer to `DB_DataObject`
* __Similar__: For pre-installation work (where `DB_DataObject` is not operational yet), both have an override/alternative escaper.
* __Different__: Within pre-installation environment, the override/alternative escape works differently:
    * For `CRM_Core_I18n`, it lets you define an alternative function (`CRM_Core_I18n::$SQL_ESCAPER`). This is usually the PDO escaper (which ensures that localized escaping works in a way suitable to that connection).
    * For `CRM_Core_DAO`, it checks the constant `CIVICRM_DSN` (*which is write-once -- if it has been set in any way, then you cannot use the alternative escaper*). It also uses a set heuristic escaping rules (without information about localization).

After
----------------------------------------

The functions are... more the same...:

* __Same__: For usual runtime work, both defer to `DB_DataObject`
* __Same__: For pre-installation work, you can set an alternative function as `$GLOBALS['CIVICRM_SQL_ESCAPER']`.

Or in other words:

* Rename `CRM_Core_I18n::$SQL_ESCAPER` to `$GLOBALS['CIVICRM_SQL_ESCAPER']`.
* Consolidate on `CRM_Core_DAO::escapeString()` as the ordinary way process an escape. (*The `CRM_Core_I18n::escape()` is thinner.*)

