### PR TITLE
dev/core#5126 - SearchKit - Munge array keys for smarty rewrite inste…

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -307,19 +307,8 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     $hasSmarty = strpos($column['rewrite'], '{') !== FALSE;
     $output = $this->replaceTokens($column['rewrite'], $data, 'view');
     if ($hasSmarty) {
-      $vars = [];
-      // Convert dots to nested arrays which are more Smarty-friendly
-      foreach ($data as $key => $value) {
-        $parent = &$vars;
-        $keys = array_map('CRM_Utils_String::munge', explode('.', $key));
-        while (count($keys) > 1) {
-          $level = array_shift($keys);
-          $parent[$level] = $parent[$level] ?? [];
-          $parent = &$parent[$level];
-        }
-        $level = array_shift($keys);
-        $parent[$level] = $value;
-      }
+      // Convert dots & other weird characters to underscores
+      $vars = \CRM_Utils_Array::rekey($data, fn($key) => \CRM_Utils_String::munge($key));
       $smarty = \CRM_Core_Smarty::singleton();
       $output = $smarty->fetchWith("string:$output", $vars);
     }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -615,7 +615,7 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
               'key' => 'Contact_Email_contact_id_01.email',
               'label' => 'Email',
               'type' => 'field',
-              'rewrite' => '{if $Contact_Email_contact_id_01.email}{$Contact_Email_contact_id_01.email} ({$Contact_Email_contact_id_01.location_type_id_label}){/if}',
+              'rewrite' => '{if $Contact_Email_contact_id_01_email}{$Contact_Email_contact_id_01_email} ({$Contact_Email_contact_id_01_location_type_id_label}){/if}',
             ],
           ],
           'sort' => [


### PR DESCRIPTION
Overview
----------------------------------------
For discussion: Here's a potential fix for https://lab.civicrm.org/dev/core/-/issues/5126

Before
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/22592 caused a regression that crashes some search displays. One way or another we need to fix that...

After
---------
This changes the smarty-rewrite syntax for accessing variables with a dot in them.

Technical Details
----------------------------------------
The bug doesn't seem to be fixable without breaking something or other, and this is the simplest fix.