### PR TITLE
Fix regen - resource cache is sometimes now cleared when cms is not bootstrapped

### DIFF
--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -916,7 +916,10 @@ AND    u.status = 1
    * @inheritDoc
    */
   public function clearResourceCache() {
-    _backdrop_flush_css_js();
+    // Sometimes metadata gets cleared while the cms isn't bootstrapped.
+    if (function_exists('_backdrop_flush_css_js')) {
+      _backdrop_flush_css_js();
+    }
   }
 
   /**

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -964,4 +964,27 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     return (bool) $enableWorkflow;
   }
 
+  /**
+   * @inheritDoc
+   */
+  public function clearResourceCache() {
+    $cleared = FALSE;
+    // @todo When only drupal 10.2+ is supported can remove the try catch
+    // and the fallback to drupal_flush_css_js. Still need the class_exists.
+    try {
+      // Sometimes metadata gets cleared while the cms isn't bootstrapped.
+      if (class_exists('\Drupal')) {
+        \Drupal::service('asset.query_string')->reset();
+        $cleared = TRUE;
+      }
+    }
+    catch (\Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException $e) {
+      // probably < drupal 10.2 - fall thru
+    }
+    // Sometimes metadata gets cleared while the cms isn't bootstrapped.
+    if (!$cleared && function_exists('_drupal_flush_css_js')) {
+      _drupal_flush_css_js();
+    }
+  }
+
 }

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -286,7 +286,10 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
    * @inheritDoc
    */
   public function clearResourceCache() {
-    _drupal_flush_css_js();
+    // Sometimes metadata gets cleared while the cms isn't bootstrapped.
+    if (function_exists('_drupal_flush_css_js')) {
+      _drupal_flush_css_js();
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Can't run regen.sh. Errors with call to undefined function _drupal_flush_css_js
Also a report of cv upgrade:db failing with same call.

Before
----------------------------------------
Crashy

After
----------------------------------------


Technical Details
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/28442 it now calls resource cache clear more, and this triggers drupal to clear its css/js query string cache buster. I don't fully understand the context of 28442 since I don't know what roles it means, but in the case of e.g. regen, the cms isn't bootstrapped during all steps because a new process has been spawned and it's not necessary, e.g. when generating various sample data, so the call to the function fails.

Wordpress/joomla don't do anything when this event happens - not sure if they have something equivalent and it _should_ do something, but out of scope - this PR doesn't change what those cmses do.

Comments
----------------------------------------
The drupal 8 complexity is because there's a deprecation in 10.2, so it falls back to the old way if it can't do the new way.

Here's a successful online run with this PR: https://github.com/demeritcowboy/civicrm-core/actions/runs/8731898330/job/23958029260
