### PR TITLE
regen.sh - Fix warnings on PHP 8.2

### DIFF
--- a/CRM/Core/CodeGen/GenerateData.php
+++ b/CRM/Core/CodeGen/GenerateData.php
@@ -1556,6 +1556,9 @@ VALUES
    * @return string
    */
   public static function repairDate($date) {
+    if ($date === NULL) {
+      return '';
+    }
     $dropArray = ['-' => '', ':' => '', ' ' => ''];
     return strtr($date, $dropArray);
   }

--- a/CRM/Core/CodeGen/GenerateData.php
+++ b/CRM/Core/CodeGen/GenerateData.php
@@ -277,6 +277,10 @@ class CRM_Core_CodeGen_GenerateData {
 
   private $deceasedContactIds = [];
 
+  private $time;
+
+  private $relTypes;
+
   /*********************************
    * private methods
    * *******************************


### PR DESCRIPTION
Overview
----------------------------------------

When running `regen.sh` on PHP 8.2, it generates some warnings. Noticed while testing 5.73's  #29997 (@demeritcowboy). This fixes those warnings.

Before
----------------------------------------

Warnings like:

```
Deprecated: Creation of dynamic property CRM_Core_CodeGen_GenerateData::$time is deprecated in /home/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/CodeGen/GenerateData.php on line 45

Deprecated: Creation of dynamic property CRM_Core_CodeGen_GenerateData::$relTypes is deprecated in /home/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/CodeGen/GenerateData.php on line 60

Deprecated: strtr(): Passing null to parameter #1 ($string) of type string is deprecated in /home/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/CodeGen/GenerateData.php on line 1563

Deprecated: strtr(): Passing null to parameter #1 ($string) of type string is deprecated in /home/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/CodeGen/GenerateData.php on line 1563
```

After
----------------------------------------

:speak_no_evil: 

Comments
----------------------------------------

I'd be equally fine with it being merged into `master` or `5.73-rc`. (A support script, it's relatively low-risk...) I suppose a warning technically isn't a regression or critical, so I submitted against `master`. However, the current branch should work just as well if you edit/retarget to `5.73`.