### PR TITLE
dev/core#5126 - Fix searchKit crash with smarty rewrite

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -315,10 +315,20 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         while (count($keys) > 1) {
           $level = array_shift($keys);
           $parent[$level] = $parent[$level] ?? [];
+          if (is_scalar($parent[$level])) {
+            $parent[$level] = [
+              'id' => $parent[$level],
+            ];
+          }
           $parent = &$parent[$level];
         }
         $level = array_shift($keys);
-        $parent[$level] = $value;
+        if (isset($parent[$level]) && is_array($parent[$level])) {
+          $parent[$level]['id'] = $value;
+        }
+        else {
+          $parent[$level] = $value;
+        }
       }
       $smarty = \CRM_Core_Smarty::singleton();
       $output = $smarty->fetchWith("string:$output", $vars);

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -639,6 +639,49 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     }
     catch (\Exception $e) {
     }
+
+    // Start with email as base entity and use implicit join
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'Email',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['id', 'email', 'contact_id', 'contact_id.first_name', 'contact_id.last_name', 'contact_id.nick_name'],
+          'where' => [['contact_id.last_name', '=', $lastName]],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => 'testDisplay',
+        'settings' => [
+          'limit' => 20,
+          'pager' => TRUE,
+          'columns' => [
+            [
+              'key' => 'contact_id',
+              'label' => 'Contact ID',
+              'type' => 'field',
+              'rewrite' => '#{$contact_id.id}',
+            ],
+            [
+              'key' => 'first_name',
+              'label' => 'Name',
+              'type' => 'field',
+              'rewrite' => '{if $contact_id.nick_name}{$contact_id.nick_name}{else}[contact_id.first_name]{/if} {$contact_id.last_name}',
+            ],
+          ],
+          'sort' => [
+            ['id', 'ASC'],
+          ],
+        ],
+      ],
+    ];
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertEquals('#' . $contacts[0]['id'], $result[0]['columns'][0]['val']);
+    $this->assertEquals("Uno $lastName", $result[0]['columns'][1]['val']);
   }
 
   /**

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -664,7 +664,7 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
               'key' => 'contact_id',
               'label' => 'Contact ID',
               'type' => 'field',
-              'rewrite' => '#{$contact_id.id}',
+              'rewrite' => '#{$contact_id.id} is #{$contact_id}',
             ],
             [
               'key' => 'first_name',
@@ -680,7 +680,7 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
       ],
     ];
     $result = civicrm_api4('SearchDisplay', 'run', $params);
-    $this->assertEquals('#' . $contacts[0]['id'], $result[0]['columns'][0]['val']);
+    $this->assertEquals("#{$contacts[0]['id']} is #{$contacts[0]['id']}", $result[0]['columns'][0]['val']);
     $this->assertEquals("Uno $lastName", $result[0]['columns'][1]['val']);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
For discussion: Here's a potential fix for https://lab.civicrm.org/dev/core/-/issues/5126
This is an alternative to #29996

Before
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/22592 caused a regression that crashes some search displays.

After
---------
This prevents collisions between scalar values and arrays in the smarty tokens.

Technical Details
----------------------------------------
The problem was that with a select clause like `[contact_id, contact_id.first_name]`, etc. The smarty rewrite code was attempting to nest `first_name` within `contact_id` as an array, but it was already a scalar value.

This fudges the values so that scalar ids get nested within an array if part of a join.
So `contact_id` becomes `contact_id.id` in smarty.

It rewrites any tokens to use the new nesting.