### PR TITLE
regen - node 16 deprecated in github actions

### DIFF
--- a/.github/workflows/regen.yml
+++ b/.github/workflows/regen.yml
@@ -117,7 +117,7 @@ jobs:
           git commit -m "regenerate civicrm_generated" sql/civicrm_generated.mysql
           git remote add mine https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY.git
           git push mine
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ success() }}
         with:
           name: the_file_you_requested


### PR DESCRIPTION
Overview
----------------------------------------
node 16 deprecated in github actions

Before
----------------------------------------
If you scroll to the bottom at e.g. https://github.com/demeritcowboy/civicrm-core/actions/runs/8731898330, you'll see `Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`

After
----------------------------------------
Same change as was made e.g. here for webform: https://github.com/colemanw/webform_civicrm/commit/40aa70937ea5638b276dcdfcb0c437018ac207ae

Technical Details
----------------------------------------
`3 => 4`

Comments
----------------------------------------

