### PR TITLE
(dev/core#4999) mixin - Fix PHP syntax for backportability

### DIFF
--- a/mixin/lib/civimix-schema/src/SqlGenerator.php
+++ b/mixin/lib/civimix-schema/src/SqlGenerator.php
@@ -9,13 +9,16 @@
  +--------------------------------------------------------------------+
  */
 
-return new class([], fn()=>NULL) {
+return new class() {
 
   /**
    * @var array
    */
-  private array $entities;
+  private $entities;
 
+  /**
+   * @var callable
+   */
   private $findExternalTable;
 
   /**
@@ -40,13 +43,15 @@ return new class([], fn()=>NULL) {
       $entities[$entity['name']] = $entity;
     }
 
-    $findExternalTable = $isolated ? (fn($entity) => NULL) : (['CRM_Core_DAO_AllCoreTables', 'getTableForEntityName']);
+    $findExternalTable = $isolated ? NULL : (['CRM_Core_DAO_AllCoreTables', 'getTableForEntityName']);
     return new static($entities, $findExternalTable);
   }
 
-  public function __construct(array $entities, callable $findExternalTable) {
+  public function __construct(array $entities = [], ?callable $findExternalTable = NULL) {
     $this->entities = $entities;
-    $this->findExternalTable = $findExternalTable;
+    $this->findExternalTable = $findExternalTable ?: function() {
+      return NULL;
+    };
   }
 
   public function getEntities(): array {


### PR DESCRIPTION
Overview
----------------------------------------

Files in `./mixin` folder should be backportable. Fix a PHP syntax issue.

Follow-up to #29472

Before
----------------------------------------

PHP 7.3:

```
  syntax error, unexpected '=>' (T_DOUBLE_ARROW), expecting ')'  

  syntax error, unexpected 'array' (T_ARRAY), expecting function (T_FUNCTION) or const (T_CONST) in mixin/lib/civimix-schema/src/SqlGenerator.php on line 17
```

After
----------------------------------------

PHP 7.3:

<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Sleeping_furry_cat_%28Unsplash%29.jpg/319px-Sleeping_furry_cat_%28Unsplash%29.jpg">
