### PR TITLE
Resolve issue with Payment allocation for Sales Item

### DIFF
--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -397,11 +397,11 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
    * @throws \Civi\Core\Exception\DBQueryException
    */
   public function testAddPaymentMissingFinancialItems(): void {
-    $contribution = $this->callAPISuccess('Contribution', 'create', [
+    $contribution = $this->createTestEntity('Contribution', [
       'total_amount' => 50,
-      'financial_type_id' => 'Donation',
+      'financial_type_id:name' => 'Donation',
       'contact_id' => $this->individualCreate(),
-      'contribution_status_id' => 'Pending',
+      'contribution_status_id:name' => 'Pending',
     ]);
     CRM_Core_DAO::executeQuery('DELETE FROM civicrm_financial_item');
     $this->callAPISuccess('Payment', 'create', ['contribution_id' => $contribution['id'], 'payment_instrument_id' => 'Check', 'total_amount' => 5]);


### PR DESCRIPTION
Overview
----------------------------------------
This addresses the same issue as https://github.com/civicrm/civicrm-core/pull/29823 & includes the test that @omarabuhussein wrote there. However, the code has been refactored in the interim so that the handling is all done in one place rather than in the various places that legacy code left it in.

Before
----------------------------------------
The EntityFinancialTrxn for the sales tax is wrong

After
----------------------------------------
Corrected

Technical Details
----------------------------------------
@omarabuhussein I have attributed this to you since you wrote the test - which is actually the most important part of it - however, you need to be happy with it!

It fixes the issue covered in your test but leaves out of scope a couple of things in your PR relating to rounding and allocating unallocated items - I am unsure if those changes are correct but we can look at them as a follow up

Comments
----------------------------------------

