### PR TITLE
Prevent logging deprecations without E_USER_DEPRECATED flag

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -1099,6 +1099,10 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    *   optional description of old method (if not the calling method). eg. CRM_MyClass::myOldMethodToGetTheOptions()
    */
   public static function deprecatedFunctionWarning(string $newMethod, ?string $oldMethod = NULL): void {
+    if (!(error_reporting() & E_USER_DEPRECATED)) {
+      // Logging deprecations should be opt-in, it's useless to non-developers.
+      return;
+    }
     $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 4);
     if (!$oldMethod) {
       $callerFunction = $backtrace[1]['function'] ?? NULL;
@@ -1122,6 +1126,10 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * @param string $message
    */
   public static function deprecatedWarning($message) {
+    if (!(error_reporting() & E_USER_DEPRECATED)) {
+      // Logging deprecations should be opt-in, it's useless to non-developers.
+      return;
+    }
     // Even though the tag is no longer used within the log() function,
     // \Civi\API\LogObserver instances may still be monitoring it.
     $dbt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);


### PR DESCRIPTION
Overview
----------------------------------------
Currently extensions log a bunch of deprecation warnings into CiviCRM log files.  There may be some issues in core as well.

While this is surely useful for developers of those extensions, it's actually detrimental to end users in their production environment, as it produces large log files that it's hard to find relevant information in, leading to the question *Why are production sites logging this information?*.

Maybe not the best example but [dev/core#4846](https://lab.civicrm.org/dev/core/-/issues/4846) shows that it mostly causes confusion and delay.

This PR ties logging to the CiviCRM log to the E_USER_DEPRECATED error reporting level, so developers can still opt in to it easily, but it's not holding down admins of production sites from finding actual relevant information when something goes wrong that they could do something about.

Before
----------------------------------------
Lots of civicrm log file messages like:

> [warning] Deprecated function CRM_Mailing_BAO_MailingComponent::retrieve, use API. CRM_Core_Error::deprecatedFunctionWarning CRM_Mailing_BAO_MailingComponent::retrieve CRM_Mailing_Form_Component::setDefaultValues CRM_Core_Form::buildForm Array ( [civi.tag] => deprecated )

or:

> [warning] Permission 'CSV Import' should be declared with 'label' and 'description' keys. See https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/ Caller: CRM_Core_Permission::assembleBasicPermissions
> Array
> (
>    [civi.tag] => deprecated
> )

After
----------------------------------------
These messages are only shown if the PHP `error_reporting()` set includes `E_USER_DEPRECATED`
