### PR TITLE
Remove deprecated handling for invalid value

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -746,12 +746,12 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
    *
    * Call this via the api, not directly.
    *
-   * @param \CRM_Contact_BAO_Contact $contact
+   * @param \CRM_Contact_DAO_Contact $contact
    *
    * @return bool
    * @throws \CRM_Core_Exception
    */
-  protected static function contactTrash($contact): bool {
+  protected static function contactTrash(CRM_Contact_DAO_Contact $contact): bool {
     $updateParams = [
       'id' => $contact->id,
       'is_deleted' => 1,

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -868,12 +868,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
    *
    * @throws \CRM_Core_Exception
    */
-  public static function deleteContact($id, $restore = FALSE, $skipUndelete = FALSE, $checkPermissions = TRUE) {
-
-    if (!$id || !is_numeric($id)) {
-      CRM_Core_Error::deprecatedFunctionWarning('calling delete contact without a valid contact ID is deprecated.');
-      return FALSE;
-    }
+  public static function deleteContact(int $id, bool $restore = FALSE, bool $skipUndelete = FALSE, bool $checkPermissions = TRUE): bool {
     // If trash is disabled in system settings then we always skip
     if (!Civi::settings()->get('contact_undelete')) {
       $skipUndelete = TRUE;

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -1112,7 +1112,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     foreach ($backtrace as $backtraceLine) {
       $miniBacktrace[] = ($backtraceLine['class'] ?? '') . '::' . ($backtraceLine['function'] ?? '');
     }
-    Civi::log()->warning($message . "\n" . implode("\n", $miniBacktrace), ['civi.tag' => 'deprecated']);
+    Civi::log('deprecated')->warning($message . "\n" . implode("\n", $miniBacktrace), ['civi.tag' => 'deprecated']);
     trigger_error($message, E_USER_DEPRECATED);
   }
 


### PR DESCRIPTION
This deprecation notice is precautionary & we have no reports of it being hit since it was added in 2020 - time to clean it up'

I also added a typeHint on `contactTrash()`, a protected function with only 1 caller