### PR TITLE
dev/core#4389 Display ID field on imports for all modes

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -389,13 +389,10 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     $highlightedFields = $entityFields[$this->getContactType()];
     $highlightedFields[] = 'email';
     $highlightedFields[] = 'external_identifier';
-    if (!$this->isSkipDuplicates()) {
-      $highlightedFields[] = 'id';
-    }
-    $customFields = CRM_Core_BAO_CustomField::getFields($this->getContactType());
-    foreach ($customFields as $key => $attr) {
-      if (!empty($attr['is_required'])) {
-        $highlightedFields[] = "custom_$key";
+    $highlightedFields[] = 'id';
+    foreach ($this->getFields() as $key => $details) {
+      if (!empty($details['custom_field_id']) && !empty($details['is_required'])) {
+        $highlightedFields[] = $key;
       }
     }
     return $highlightedFields;

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -732,10 +732,6 @@ class CRM_Import_Forms extends CRM_Core_Form {
   protected function getAvailableFields(): array {
     $return = [];
     foreach ($this->getFields() as $name => $field) {
-      if ($name === 'id' && $this->isSkipDuplicates()) {
-        // Duplicates are being skipped so id matching is not available.
-        continue;
-      }
       if (($field['entity'] ?? '') === 'Contact' && $this->isFilterContactFields() && empty($field['match_rule'])) {
         // Filter out metadata that is intended for create & update - this is not available in the quick-form
         // but is now loaded in the Parser for the LexIM variant.


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#4389 Display ID field on imports for all modes

The case was reasonably made in
https://lab.civicrm.org/dev/core/-/issues/4389
that it is less rather than more clear to exclude it.

I also updated the follow lines to use already-loaded metadata rather than load yet more

Before
----------------------------------------
contact ID is not an available field in 'skip' mode

After
----------------------------------------
Now it is

Technical Details
----------------------------------------

Comments
----------------------------------------
issue was logged by @aydun 