### PR TITLE
Remove function that no longer does much of anything

### DIFF
--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -76,12 +76,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
         $formatValues[$key] = $field;
       }
 
-      $formatError = $this->formatValues($formatted, $formatValues);
-
-      if ($formatError) {
-        throw new CRM_Core_Exception($formatError['error_message']);
-      }
-
       if ($this->isUpdateExisting()) {
         if (!empty($formatValues['participant_id'])) {
           $dao = new CRM_Event_BAO_Participant();
@@ -188,29 +182,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
       return;
     }
     $this->setImportStatus($rowNumber, 'IMPORTED', '', $newParticipant['id']);
-  }
-
-  /**
-   * Format values
-   *
-   * @todo lots of tidy up needed here - very old function relocated.
-   *
-   * @param array $values
-   * @param array $params
-   *
-   * @return array|null
-   */
-  protected function formatValues(&$values, $params) {
-    $fields = CRM_Event_DAO_Participant::fields();
-    _civicrm_api3_store_values($fields, $params, $values);
-
-    $customFields = CRM_Core_BAO_CustomField::getFields('Participant', FALSE, FALSE, NULL, NULL, FALSE, FALSE, FALSE);
-
-    if (array_key_exists('participant_note', $params)) {
-      $values['participant_note'] = $params['participant_note'];
-    }
-
-    return NULL;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Remove function that no longer does much of anything

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/d9ec7c14-1f7d-4e56-81b8-f142e3eea7fd)


After
----------------------------------------
The code can go altogether - note we don't need to keep the bit about setting participant_note because `$values` is called `$formatValues` in the calling function - & is already populated from `$params`

![image](https://github.com/civicrm/civicrm-core/assets/336308/a6e75cba-2b42-4bcb-8920-6446b0acac51)


Technical Details
----------------------------------------

Comments
----------------------------------------
