### PR TITLE
Add details to contact_id field after it's name has been changed

### DIFF
--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -315,8 +315,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
         $this->getContactMatchingFields()
       );
 
-      $fields['participant_contact_id']['title'] .= ' (match to contact)';
-      $fields['participant_contact_id']['html']['label'] = $fields['participant_contact_id']['title'];
       foreach ($fields as $index => $field) {
         if (isset($field['name']) && $field['name'] !== $index) {
           // undo unique names - participant is the primary
@@ -326,6 +324,8 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
           unset($fields[$index]);
         }
       }
+      $fields['contact_id']['title'] .= ' (match to contact)';
+      $fields['contact_id']['html']['label'] = $fields['contact_id']['title'];
       $this->importableFieldsMetadata = $fields;
     }
   }


### PR DESCRIPTION
By adding these values to the key participant_contact_id it gives the impression that field is used - but in fact it is renamed to contact_id in the code between where it was & where it is moved to

