### PR TITLE
Use apiv4 to getFields for participant import

### DIFF
--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -260,6 +260,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
    * Set up field metadata.
    *
    * @return void
+   * @throws \CRM_Core_Exception
    */
   protected function setFieldMetadata(): void {
     if (empty($this->importableFieldsMetadata)) {
@@ -274,22 +275,13 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
             'options' => FALSE,
           ],
         ],
-        CRM_Event_DAO_Participant::import(),
+        $this->getImportFieldsForEntity('Participant'),
         CRM_Core_BAO_CustomField::getFieldsForImport('Participant'),
         $this->getContactMatchingFields()
       );
 
-      $fields['participant_contact_id']['title'] .= ' (match to contact)';
-      $fields['participant_contact_id']['html']['label'] = $fields['participant_contact_id']['title'];
-      foreach ($fields as $index => $field) {
-        if (isset($field['name']) && $field['name'] !== $index) {
-          // undo unique names - participant is the primary
-          // entity and no others have conflicting unique names
-          // if we ever added them the should have unique names - v4api style
-          $fields[$field['name']] = $field;
-          unset($fields[$index]);
-        }
-      }
+      $fields['contact_id']['title'] .= ' (match to contact)';
+      $fields['contact_id']['html']['label'] = $fields['contact_id']['title'];
       $this->importableFieldsMetadata = $fields;
     }
   }

--- a/Civi/Test/EntityTrait.php
+++ b/Civi/Test/EntityTrait.php
@@ -11,6 +11,8 @@
 
 namespace Civi\Test;
 
+use Civi\Core\Exception\DBQueryException;
+
 /**
  * Helper for tracking entities created in tests.
  */
@@ -57,6 +59,9 @@ trait EntityTrait {
     try {
       $result = \civicrm_api4($entity, 'create', ['values' => $values, 'checkPermissions' => FALSE])->single();
       $this->setTestEntityID($entity, $result['id'], $identifier);
+    }
+    catch (DBQueryException $e) {
+      $this->fail('sql error when trying to create ' . $entity . ' : ' . "\n" . $e->getUserInfo());
     }
     catch (\CRM_Core_Exception $e) {
       $this->fail('Failed to create ' . $entity . ' : ' . $e->getMessage());


### PR DESCRIPTION
Overview
----------------------------------------
Use apiv4 to getFields for participant import

Before
----------------------------------------
Uses importableFields & then works from there to get something that looks like apiv4 getfields output

![image](https://github.com/civicrm/civicrm-core/assets/336308/d77f8ccc-8ee5-49ce-82cc-06f569e774ea)


After
----------------------------------------
Uses apiv4 - no change in output - same number of fields

![image](https://github.com/civicrm/civicrm-core/assets/336308/eb204339-4921-4fae-9187-30b9e260cde3)


Technical Details
----------------------------------------
@colemanw I used the newly exposed `usage` but couldn't get it to work in the `where` - also, I wonder if custom fields should have usage for import set to TRUE where they are not is_view?

Comments
----------------------------------------
