### PR TITLE
Remove cancerous unreachable code

### DIFF
--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -99,13 +99,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
               throw new CRM_Core_Exception($newParticipant['error_message']);
             }
             $newParticipant = CRM_Event_BAO_Participant::create($formatted, $ids);
-            if (!empty($formatted['fee_level'])) {
-              $otherParams = [
-                'fee_label' => $formatted['fee_level'],
-                'event_id' => $newParticipant->event_id,
-              ];
-              CRM_Price_BAO_LineItem::syncLineItems($newParticipant->id, 'civicrm_participant', $newParticipant->fee_amount, $otherParams);
-            }
             $this->setImportStatus($rowNumber, 'IMPORTED', '', $newParticipant->id);
             return;
           }

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -428,61 +428,6 @@ WHERE li.contribution_id = %1";
   }
 
   /**
-   * @param int $entityId
-   * @param string $entityTable
-   * @param $amount
-   * @param array $otherParams
-   */
-  public static function syncLineItems($entityId, $entityTable, $amount, $otherParams = NULL) {
-    if (!$entityId || CRM_Utils_System::isNull($amount)) {
-      return;
-    }
-
-    $from = " civicrm_line_item li
-      LEFT JOIN   civicrm_price_field pf ON pf.id = li.price_field_id
-      LEFT JOIN   civicrm_price_set ps ON ps.id = pf.price_set_id ";
-
-    $set = " li.unit_price = %3,
-      li.line_total = %3 ";
-
-    $where = " li.entity_id = %1 AND
-      li.entity_table = %2 ";
-
-    $params = [
-      1 => [$entityId, 'Integer'],
-      2 => [$entityTable, 'String'],
-      3 => [$amount, 'Float'],
-    ];
-
-    if ($entityTable == 'civicrm_contribution') {
-      $entityName = 'default_contribution_amount';
-      $where .= " AND ps.name = %4 ";
-      $params[4] = [$entityName, 'String'];
-    }
-    elseif ($entityTable == 'civicrm_participant') {
-      $from .= "
-        LEFT JOIN civicrm_price_set_entity cpse ON cpse.price_set_id = ps.id
-        LEFT JOIN civicrm_price_field_value cpfv ON cpfv.price_field_id = pf.id and cpfv.label = %4 ";
-      $set .= " ,li.label = %4,
-        li.price_field_value_id = cpfv.id ";
-      $where .= " AND cpse.entity_table = 'civicrm_event' AND cpse.entity_id = %5 ";
-      $amount = empty($amount) ? 0 : $amount;
-      $params += [
-        4 => [$otherParams['fee_label'], 'String'],
-        5 => [$otherParams['event_id'], 'String'],
-      ];
-    }
-
-    $query = "
-      UPDATE $from
-      SET    $set
-      WHERE  $where
-      ";
-
-    CRM_Core_DAO::executeQuery($query, $params);
-  }
-
-  /**
    * Build line items array.
    *
    * @param array $params


### PR DESCRIPTION
Overview
----------------------------------------
Remove dubious unreachable code

Before
----------------------------------------
The removed code is not reachable & has not been for a couple of years because in 5.51 the field name changed from `participant_id` to `id` without this code being adjusted to cope. I'm looking to fix that code but since this line of code has not been missed in that time AND it appears to be doing something actively wrong - ie updating the line items without updating the related financial items - I think it's best to remove this code before it becomes reachable again

After
----------------------------------------
poof

Technical Details
----------------------------------------
I originally looked to move this - see https://github.com/civicrm/civicrm-core/pull/30037/files  - but the more I think about it the more sure I am that this function would actively introduce bad data & hence it's best to get rid of it while it's unreachable


Comments
----------------------------------------
no universe usages