### PR TITLE
Update participant import to work on updates (with participant ID)

### DIFF
--- a/CRM/Event/Import/Form/MapField.php
+++ b/CRM/Event/Import/Form/MapField.php
@@ -50,11 +50,6 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
         unset($this->_mapperFields[$value]);
       }
     }
-    elseif (
-      $this->getSubmittedValue('onDuplicate') == CRM_Import_Parser::DUPLICATE_SKIP
-      || $this->getSubmittedValue('onDuplicate') == CRM_Import_Parser::DUPLICATE_NOCHECK) {
-      unset($this->_mapperFields['participant_id']);
-    }
   }
 
   /**
@@ -82,9 +77,7 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
    *   list of errors to be posted back to the form
    */
   public static function formRule($fields, $files, $self) {
-    $errors = [];
-    // define so we avoid notices below
-    $errors['_qf_default'] = '';
+    $requiredError = [];
 
     if (!array_key_exists('savedMapping', $fields)) {
       $importKeys = [];
@@ -98,24 +91,26 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
       ];
 
       $contactFieldsBelowWeightMessage = self::validateRequiredContactMatchFields($self->getContactType(), $importKeys);
-
+      if (in_array('id', $importKeys)) {
+        // ID is the only field we need, if present.
+        $requiredFields = [];
+      }
       foreach ($requiredFields as $field => $title) {
         if (!in_array($field, $importKeys)) {
           if ($field === 'contact_id') {
-            if (!$contactFieldsBelowWeightMessage || in_array('external_identifier', $importKeys) ||
-              in_array('participant_id', $importKeys)
+            if (!$contactFieldsBelowWeightMessage || in_array('external_identifier', $importKeys)
             ) {
               continue;
             }
             if ($self->isUpdateExisting()) {
-              $errors['_qf_default'] .= ts('Missing required field: Provide Participant ID') . '<br />';
+              $requiredError[] = ts('Missing required field: Provide Participant ID') . '<br />';
             }
             else {
-              $errors['_qf_default'] .= ts('Missing required contact matching fields.') . " $contactFieldsBelowWeightMessage " . ' ' . ts('Or Provide Contact ID or External ID.') . '<br />';
+              $requiredError[] = ts('Missing required contact matching fields.') . " $contactFieldsBelowWeightMessage " . ' ' . ts('Or Provide Contact ID or External ID.') . '<br />';
             }
           }
           elseif (!in_array('event_title', $importKeys)) {
-            $errors['_qf_default'] .= ts('Missing required field: Provide %1 or %2',
+            $requiredError[] = ts('Missing required field: Provide %1 or %2',
                 [1 => $title, 2 => 'Event Title']
               ) . '<br />';
           }
@@ -123,11 +118,7 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
       }
     }
 
-    if (empty($errors['_qf_default'])) {
-      unset($errors['_qf_default']);
-    }
-
-    return empty($errors) ? TRUE : $errors;
+    return empty($requiredError) ? TRUE : ['_qf_default' => implode('<br', $requiredError)];
   }
 
   /**

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -210,7 +210,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
       $participant = new CRM_Event_BAO_Participant();
       $participant->id = $params['id'];
       if (!$participant->find(TRUE)) {
-        return civicrm_api3_create_error(ts('Participant  id is not valid'));
+        throw new CRM_Core_Exception(ts('Participant  id is not valid'));
       }
     }
 
@@ -219,7 +219,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
       $contact = new CRM_Contact_BAO_Contact();
       $contact->id = $params['contact_id'];
       if (!$contact->find(TRUE)) {
-        return civicrm_api3_create_error(ts('Contact id is not valid'));
+        throw new CRM_Core_Exception(ts('Contact id is not valid'));
       }
     }
 
@@ -227,7 +227,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
     if (!empty($params['event_id'])) {
       $isTemplate = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $params['event_id'], 'is_template');
       if (!empty($isTemplate)) {
-        return civicrm_api3_create_error(ts('Event templates are not meant to be registered.'));
+        throw new CRM_Core_Exception(ts('Event templates are not meant to be registered.'));
       }
     }
 
@@ -249,7 +249,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
         );
       }
     }
-    return TRUE;
   }
 
   /**

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -78,15 +78,14 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
 
       if (!empty($params['id'])) {
         $this->checkEntityExists('Participant', $params['id']);
-      }
-      if ($this->isUpdateExisting()) {
-        if (!empty($params['id'])) {
-          //@todo calling api functions directly is not supported
-          $this->deprecated_participant_check_params($formatted);
-          $newParticipant = CRM_Event_BAO_Participant::create($formatted);
-          $this->setImportStatus($rowNumber, 'IMPORTED', '', $newParticipant->id);
-          return;
+        if (!$this->isUpdateExisting()) {
+          throw new CRM_Core_Exception(ts('% record found and update not selected', [1 => 'Participant']));
         }
+        //@todo calling api functions directly is not supported
+        $this->deprecated_participant_check_params($formatted);
+        $newParticipant = CRM_Event_BAO_Participant::create($formatted);
+        $this->setImportStatus($rowNumber, 'IMPORTED', '', $newParticipant->id);
+        return;
       }
 
       if (empty($params['contact_id'])) {

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1600,7 +1600,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     }
     if ($dataType === 'Integer') {
       // We have resolved the options now so any remaining ones should be integers.
-      return CRM_Utils_Rule::numeric($importedValue) ? $importedValue : 'invalid_import_value';
+      return CRM_Utils_Rule::numeric($importedValue) ? (int) $importedValue : 'invalid_import_value';
     }
     return $importedValue;
   }
@@ -2226,6 +2226,21 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     }
 
     return $matchIDs;
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  protected function checkEntityExists(string $entity, int $id) {
+    try {
+      civicrm_api4($entity, 'get', ['where' => [['id', '=', $id]], 'select' => ['id']])->single();
+    }
+    catch (CRM_Core_Exception $e) {
+      throw new CRM_Core_Exception(ts('%1 record not found for id %2', [
+        1 => $entity,
+        2 => $id,
+      ]));
+    }
   }
 
   /**

--- a/tests/phpunit/CRM/Event/Import/Parser/data/cancel_participant.csv
+++ b/tests/phpunit/CRM/Event/Import/Parser/data/cancel_participant.csv
@@ -1,0 +1,3 @@
+id,Status
+1,Cancelled
+2,Cancelled


### PR DESCRIPTION
Overview
----------------------------------------
Update participant import to work on updates (with participant ID)

Before
----------------------------------------
This must have broken in 5.51 when the field got renamed to 'id' from 'participant_id' but code was not adusted

After
----------------------------------------
works & has test

Technical Details
----------------------------------------

Comments
----------------------------------------
