### PR TITLE
SearchKit - Fix saving search displays with 'Bypass Permissions'

### DIFF
--- a/ext/search_kit/CRM/Search/BAO/SearchDisplay.php
+++ b/ext/search_kit/CRM/Search/BAO/SearchDisplay.php
@@ -49,7 +49,7 @@ class CRM_Search_BAO_SearchDisplay extends CRM_Search_DAO_SearchDisplay implemen
     }
 
     // Ensure only super-admins may update SavedSearches linked to displays with `acl_bypass`
-    elseif ($recordType === 'SavedSearch' && $e->getActionName() === 'update') {
+    if ($recordType === 'SavedSearch' && $e->getActionName() === 'update' && !CRM_Core_Permission::check('all CiviCRM permissions and ACLs', $userCID)) {
       $id = (int) $e->getRecord()['id'];
       $sql = "SELECT COUNT(id) FROM civicrm_search_display WHERE acl_bypass = 1 AND saved_search_id = $id";
       if (CRM_Core_DAO::singleValueQuery($sql)) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression in which super-admins are incorrectly denied permission to edit search displays with 'Bypass Permissions'

Before
----------------------------------------
Saved searches with a display set to 'Bypass Permissions' are supposed to be only editable by super-admins, however permission was incorrectly being denied even for those with 'all CiviCRM permissions and ACLs' permission.

After
----------------------------------------
Editing is correctly allowed for users with 'all CiviCRM permissions and ACLs' permission.