### PR TITLE
Update import/participant url to match new standardised name

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.74.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.74.alpha1.mysql.tpl
@@ -1,1 +1,3 @@
 {* file to handle db changes in 5.74.alpha1 during upgrade *}
+UPDATE civicrm_navigation SET url = 'civicrm/import/participant?reset=1'
+WHERE url = 'civicrm/event/import?reset=1';


### PR DESCRIPTION


Overview
----------------------------------------
Update import/participant url to match new standardised name

https://github.com/civicrm/civicrm-core/pull/30044 changes the url for participant import to align with the other import urls. However, it doesn't update the navigation records on existing sites so this addresses that

Before
----------------------------------------
Old url in the menu except for rebuild sites - civicrm/event/import

After
----------------------------------------
new url civicrm/import/participant

Technical Details
----------------------------------------
the new url is consistent with other imports

Comments
----------------------------------------
