### PR TITLE
Api4 - Set 'usage' property for custom fields

### DIFF
--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -55,6 +55,11 @@ class SpecFormatter {
         $field->setSuffixes($suffixes);
       }
       $field->setReadonly($data['is_view']);
+      $usage = ['export', 'duplicate_matching', 'token'];
+      if (empty($data['is_view'])) {
+        $usage[] = 'import';
+      }
+      $field->setUsage($usage);
     }
     // Core field
     else {

--- a/tests/phpunit/api/v4/Custom/BasicCustomFieldTest.php
+++ b/tests/phpunit/api/v4/Custom/BasicCustomFieldTest.php
@@ -149,6 +149,7 @@ class BasicCustomFieldTest extends CustomTestBase {
         ->addValue('custom_group_id', '$id')
         ->addValue('html_type', 'Text')
         ->addValue('is_required', TRUE)
+        ->addValue('is_view', TRUE)
         ->addValue('data_type', 'String'))
       ->execute();
 
@@ -163,6 +164,8 @@ class BasicCustomFieldTest extends CustomTestBase {
     $this->assertFalse($fields['MyContactFields_._Food']['required']);
     // But the api will report is_required as not nullable
     $this->assertFalse($fields['MyContactFields_._Food']['nullable']);
+    $this->assertEquals(['export', 'duplicate_matching', 'token', 'import'], $fields['MyContactFields._Food']['usage']);
+    $this->assertEquals(['export', 'duplicate_matching', 'token'], $fields['MyContactFields_._Food']['usage']);
 
     $contactId1 = $this->createTestRecord('Contact', [
       'first_name' => 'Johann',


### PR DESCRIPTION
Overview
----------------------------------------
Sets property for custom fields in APIv4 to be equivalent to core fields.