### PR TITLE
Partially convert recur updateOnNewPayment to API4

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -263,8 +263,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
     if (empty($params['contribution_recur_id']) && empty($params['prevContribution']->contribution_recur_id)) {
       return FALSE;
     }
-    $contributionStatus = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
-    if ($params['prevContribution']->contribution_status_id == array_search('Pending', $contributionStatus)) {
+    if ($params['prevContribution']->contribution_status_id == CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending')) {
       return TRUE;
     }
     return FALSE;


### PR DESCRIPTION
Overview
----------------------------------------
Simplify the code in `CRM_Contribution_BAO_ContributionRecur::updateOnNewPayment()`

Before
----------------------------------------
Using API3 and deprecated functions.

After
----------------------------------------
Replace deprecated functions and partially switch to API4

Technical Details
----------------------------------------


Comments
----------------------------------------
The api3 update call could be converted fairly easily in a follow up PR.
