### PR TITLE
Afform - Form fails to render if parent nav-item has its own URL

### DIFF
--- a/ext/afform/core/CRM/Afform/Page/AfformBase.php
+++ b/ext/afform/core/CRM/Afform/Page/AfformBase.php
@@ -33,8 +33,8 @@ class CRM_Afform_Page_AfformBase extends CRM_Core_Page {
           ->execute()->first();
         if (!empty($navParent['url'])) {
           CRM_Utils_System::resetBreadCrumb();
-          CRM_Utils_System::appendBreadCrumb([['title' => E::ts('CiviCRM'), 'url' => Civi::url('civicrm')]]);
-          CRM_Utils_System::appendBreadCrumb([['title' => $navParent['label'], 'url' => Civi::url($navParent['url'])]]);
+          CRM_Utils_System::appendBreadCrumb([['title' => E::ts('CiviCRM'), 'url' => Civi::url('current://civicrm')]]);
+          CRM_Utils_System::appendBreadCrumb([['title' => $navParent['label'], 'url' => Civi::url('current://' . $navParent['url'])]]);
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
I'm getting a crash in the breadcrumb builder for an afform on D10 , 5.72.2  because these urls don't have a scheme. 

Looking at the implementation in \Civi\Core\Url it seems having an opening `/` is the signal to trigger the default `current://` scheme.

Need to check if there's something weird about my afform/drupal that is triggering this...