### PR TITLE
[WIP] why doesn't this fail in jenkins

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -244,9 +244,9 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
    * @throws \CRM_Core_Exception
    */
   public function handleSmartyError(int $errorNumber, string $errorMessage): void {
+    restore_error_handler();
     $event = new SmartyErrorEvent($errorNumber, $errorMessage);
     \Civi::dispatcher()->dispatch('civi.smarty.error', $event);
-    restore_error_handler();
     throw new \CRM_Core_Exception('Message was not parsed due to invalid smarty syntax : ' . $errorMessage);
   }
 

--- a/CRM/Import/Controller.php
+++ b/CRM/Import/Controller.php
@@ -41,6 +41,14 @@ class CRM_Import_Controller extends CRM_Core_Controller {
       $this->entity = $arguments['entity'];
     }
     else {
+      if (CRM_Utils_System::currentPath() === NULL) {
+        fwrite(STDERR, 'error reporting is ' . error_reporting() . "\n");
+        $old_error_handler = set_error_handler(function($errno, $errstr, $errfile, $errline) {
+          restore_error_handler();
+          throw new \ErrorException($errstr);
+        });
+        fwrite(STDERR, 'old error handler is ' . ($old_error_handler === NULL ? 'null' : print_r($old_error_handler, TRUE)) . "\n");
+      }
       $pathArguments = explode('/', CRM_Utils_System::currentPath());
       unset($pathArguments[0], $pathArguments[1]);
       $this->entity = CRM_Utils_String::convertStringToCamel(implode('_', $pathArguments));

--- a/CRM/Import/Controller.php
+++ b/CRM/Import/Controller.php
@@ -44,9 +44,9 @@ class CRM_Import_Controller extends CRM_Core_Controller {
       if (CRM_Utils_System::currentPath() === NULL) {
         fwrite(STDERR, 'error reporting is ' . error_reporting() . "\n");
         $old_error_handler = set_error_handler(function($errno, $errstr, $errfile, $errline) {
-          restore_error_handler();
-          throw new \ErrorException($errstr);
+          //throw new \ErrorException($errstr);
         });
+        restore_error_handler();
         fwrite(STDERR, 'old error handler is ' . ($old_error_handler === NULL ? 'null' : print_r($old_error_handler, TRUE)) . "\n");
       }
       $pathArguments = explode('/', CRM_Utils_System::currentPath());

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -1047,6 +1047,8 @@ class CRM_Utils_String {
         $templateString = (string) $smarty->fetch('eval:' . $templateString);
       }
       catch (SmartyCompilerException $e) {
+        fwrite(STDERR, "you are here\n");
+        restore_error_handler();
         \Civi::log('smarty')->info('parsing smarty template {template}', [
           'template' => $templateString,
         ]);

--- a/tests/phpunit/CRM/Core/Smarty/plugins/HtxtTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/HtxtTest.php
@@ -60,6 +60,7 @@ class CRM_Core_Smarty_plugins_HtxtTest extends CiviUnitTestCase {
       $this->fail("That should have thrown an error. Are you working on a better parsing rule?");
     }
     catch (Throwable $t) {
+      fwrite(STDERR, get_class($t) . "\n");
       $this->assertTrue(str_contains($t->getMessage(), 'Invalid {htxt} tag'));
     }
   }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -495,6 +495,12 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * @noinspection PhpUnhandledExceptionInspection
    */
   protected function tearDown(): void {
+    $old_error_handler = set_error_handler(function($errno, $errstr, $errfile, $errline) {});
+    restore_error_handler();
+    if (is_array($old_error_handler) && (($old_error_handler[1] ?? '') == 'handleSmartyError')) {
+      fwrite(STDERR, 'test ' . get_class($this) . '::' . $this->getName() . " has ended with smarty as the error handler.\n");
+      restore_error_handler();
+    }
     $this->_apiversion = 3;
     $this->resetLabels();
     $this->frozenTime = NULL;


### PR DESCRIPTION
Overview
----------------------------------------
This has been failing for a few days for me, likely from https://github.com/civicrm/civicrm-core/pull/30044, and you can see it in the jenkins log that it notices it, but it doesn't fail: e.g. https://test.civicrm.org/job/CiviCRM-Core-Matrix-PR/10460/BKPROF=dfl,SUITES=phpunit-crm,label=bknix-tmp/consoleText. Why?

```
ok 1806 - CRM_Custom_Import_Parser_ApiTest::testImport
# Deprecated: explode(): Passing null to parameter 2 ($string) of type string is deprecated in /home/homer/buildkit/build/build-3/web/sites/all/modules/civicrm/CRM/Import/Controller.php on line 44
# 
# Deprecated: explode(): Passing null to parameter 2 ($string) of type string is deprecated in /home/homer/buildkit/build/build-3/web/sites/all/modules/civicrm/CRM/Import/Controller.php on line 44
# 
# Deprecated: explode(): Passing null to parameter 2 ($string) of type string is deprecated in /home/homer/buildkit/build/build-3/web/sites/all/modules/civicrm/CRM/Import/Controller.php on line 44
```