### PR TITLE
Message templates admin page crashes with smarty 5

### DIFF
--- a/CRM/Admin/Page/MessageTemplates.php
+++ b/CRM/Admin/Page/MessageTemplates.php
@@ -285,6 +285,7 @@ class CRM_Admin_Page_MessageTemplates extends CRM_Core_Page_Basic {
     $this->assign('canEditSystemTemplates', CRM_Core_Permission::check('edit system workflow message templates'));
     $this->assign('canEditMessageTemplates', CRM_Core_Permission::check('edit message templates'));
     $this->assign('canEditUserDrivenMessageTemplates', CRM_Core_Permission::check('edit user-driven message templates'));
+    $this->assign('isCiviMailEnabled', CRM_Core_Component::isEnabled('CiviMail'));
     Civi::resources()
       ->addScriptFile('civicrm', 'templates/CRM/common/TabHeader.js', 1, 'html-header')
       ->addSetting([

--- a/templates/CRM/Admin/Page/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Page/MessageTemplates.tpl
@@ -95,7 +95,7 @@
           {if $type eq 'userTemplates'}
             {capture assign=schedRemURL}{crmURL p='civicrm/admin/scheduleReminders' q="reset=1"}{/capture}
             {ts 1=$schedRemURL}Message templates allow you to easily create similar emails or letters on a recurring basis. Messages used for membership renewal reminders, as well as event and activity related reminders should be created via <a href="%1">Schedule Reminders</a>.{/ts}
-            {if array_search('CiviMail', $config->enableComponents)}
+            {if $isCiviMailEnabled}
               {capture assign=automatedMsgURL}{crmURL p='civicrm/admin/component' q="reset=1"}{/capture}
               {ts 1=$automatedMsgURL}You can also use message templates for CiviMail (bulk email) content. However, subscribe, unsubscribe and opt-out messages are configured at <a href="%1">Administer > CiviMail > Headers, Footers and Automated Messages</a>.{/ts}
             {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Addresses the first test fail [here](https://github.com/civicrm/civicrm-core/pull/30068#issuecomment-2080107953) which is using smarty 4, and also you can see this on any site with smarty 5.

Before
----------------------------------------
1. You can see it on dmaster.demo if you disable the message admin extension. Just visit the message templates admin page.

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------
I considered just making it unconditional, given that if you click the help bubble it mentions civimail unconditionally, but there is a little more specific info here so just converted it to an assign.
