### PR TITLE
(REF) Drop references to `require_once "CRM/Core/I18n.php"`

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -28,8 +28,6 @@ if (!defined('DB_DSN_MODE')) {
 require_once 'PEAR.php';
 require_once 'DB/DataObject.php';
 
-require_once 'CRM/Core/I18n.php';
-
 /**
  * Class CRM_Core_DAO
  */

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -120,7 +120,6 @@ class CRM_Core_Invoke {
     $config = CRM_Core_Config::singleton();
 
     // also initialize the i18n framework
-    require_once 'CRM/Core/I18n.php';
     $i18n = CRM_Core_I18n::singleton();
   }
 

--- a/CRM/Queue/Menu.php
+++ b/CRM/Queue/Menu.php
@@ -17,8 +17,6 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-require_once 'CRM/Core/I18n.php';
-
 /**
  * Class CRM_Queue_Menu
  */

--- a/distmaker/utils/joomlaxml.php
+++ b/distmaker/utils/joomlaxml.php
@@ -60,7 +60,6 @@ function generateJoomlaConfig($version) {
 
   require_once 'CRM/Core/Permission.php';
   require_once 'CRM/Utils/String.php';
-  require_once 'CRM/Core/I18n.php';
   $permissions = CRM_Core_Permission::getCorePermissions();
 
   $crmFolderDir = $sourceCheckoutDir . DIRECTORY_SEPARATOR . 'CRM';

--- a/setup/src/Setup/SmartyUtil.php
+++ b/setup/src/Setup/SmartyUtil.php
@@ -10,8 +10,6 @@ class SmartyUtil {
    * @throws \SmartyException
    */
   public static function createSmarty($srcPath) {
-    require_once 'CRM/Core/I18n.php';
-
     $packagePath = PackageUtil::getPath($srcPath);
     require_once $packagePath . '/smarty4/vendor/autoload.php';
 

--- a/sql/GenerateGroups.php
+++ b/sql/GenerateGroups.php
@@ -23,7 +23,6 @@ require_once '../civicrm.config.php';
 
 require_once 'CRM/Core/Config.php';
 require_once 'CRM/Core/Error.php';
-require_once 'CRM/Core/I18n.php';
 
 require_once 'CRM/Contact/BAO/Group.php';
 

--- a/sql/GenerateMailing.php
+++ b/sql/GenerateMailing.php
@@ -24,7 +24,6 @@ require_once '../civicrm.config.php';
 
 require_once 'CRM/Core/Config.php';
 require_once 'CRM/Core/Error.php';
-require_once 'CRM/Core/I18n.php';
 
 require_once 'CRM/Mailing/BAO/Mailing.php';
 require_once 'CRM/Mailing/BAO/Job.php';


### PR DESCRIPTION
Overview
----------------------------------------

I believe these references exist because the callers wanted to ensure `ts()` was defined early. But with #30071, it will be universally loaded early (*whenever the classloader is setup*). So the references should be unnecessary.

(*This builds on #30071, which is not yet merged. It will look smaller after that.*)

Before
----------------------------------------

More boilerplate

After
----------------------------------------

Less boilerplate

Comments
----------------------------------------

* Some of the files (`sql/Generated**.php`) are funny. I did a local call to `regen.sh` in hopes that it might exercise them. It seemed to work.

* When the prior PR is merged and standard tests have passed, it might be prudent to add `run-extended-tests` on this.