### PR TITLE
[NFC] Fix registration confirmtest

### DIFF
--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -387,7 +387,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
         'first_name' => 'Bruce',
         'last_name' => 'Wayne',
         'email-Primary' => 'bruce@gotham.com',
-        'price_' . $priceField['id'] => '',
+        'price_' . $priceField['id'] => 0,
         'priceSetId' => $priceField['values'][$priceField['id']]['price_set_id'],
         'payment_processor_id' => $paymentProcessorID,
         'button' => '_qf_Register_upload',


### PR DESCRIPTION
Overview
----------------------------------------
Addresses the third test fail at https://github.com/civicrm/civicrm-core/pull/30068#issuecomment-2080107953

Before
----------------------------------------
If you configure an event with a price set, with a non-required text price field of value 100, and then leave the price field box blank, you get an error in the UI of "SELECT at least one OPTION FROM EVENT Fee(s)" because you hit this line: https://github.com/civicrm/civicrm-core/blob/ee104600baa3babaa01076e37c72154884431306/CRM/Event/Form/Registration.php#L1550

The test _should_ be failing because the above is what the test tries to do, but because of the tooling issue in the other PR it ignores the error.

After
----------------------------------------
The test does the same thing you need to do in the UI: Enter a 0 in the box.

Technical Details
----------------------------------------


Comments
----------------------------------------

