### PR TITLE
Undefined array key "tax_amount" on backend participant form

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -780,10 +780,10 @@ WHERE  id IN (" . implode(',', array_keys($priceFields)) . ')';
     }
 
     $invoicing = Civi::settings()->get('invoicing');
-    $taxAmount = $opt['tax_amount'] ?? NULL;
+    $taxAmount = $opt['tax_amount'] ?? 0;
     if ($isDisplayAmounts) {
       $optionLabel = !empty($optionLabel) ? $optionLabel . '<span class="crm-price-amount-label-separator">&nbsp;-&nbsp;</span>' : '';
-      if ($opt['tax_amount'] && $invoicing) {
+      if ($taxAmount && $invoicing) {
         $optionLabel = $optionLabel . self::getTaxLabel($opt, $valueFieldName);
       }
       else {


### PR DESCRIPTION
Overview
----------------------------------------
Addresses also the 4th test fail and many others at https://github.com/civicrm/civicrm-core/pull/30068#issuecomment-2080107953

Before
----------------------------------------
1. Don't have tax and invoicing enabled at civicontribute component settings.
2. Register a participant in the backend.
3. Errors about undefined array key tax_amount.

After
----------------------------------------


Technical Details
----------------------------------------
There's already a recognition in line 783 that sometimes there is no tax field, but then it doesn't use the computed variable on line 786 and tries to access the field anyway.

Comments
----------------------------------------

