### PR TITLE
CRM_Admin_Form_Setting_Url: use metadata for enableSSL, verifySSL fields

### DIFF
--- a/CRM/Admin/Form/Setting/Url.php
+++ b/CRM/Admin/Form/Setting/Url.php
@@ -32,6 +32,8 @@ class CRM_Admin_Form_Setting_Url extends CRM_Admin_Form_Setting {
     // @todo remove these, define any not yet defined in the setting metadata.
     'disable_core_css' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
     'defaultExternUrl' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
+    'enableSSL' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
+    'verifySSL' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
     'userFrameworkResourceURL' => CRM_Core_BAO_Setting::URL_PREFERENCES_NAME,
     'imageUploadURL' => CRM_Core_BAO_Setting::URL_PREFERENCES_NAME,
     'customCSSURL' => CRM_Core_BAO_Setting::URL_PREFERENCES_NAME,
@@ -43,15 +45,6 @@ class CRM_Admin_Form_Setting_Url extends CRM_Admin_Form_Setting {
    */
   public function buildQuickForm() {
     $this->setTitle(ts('Settings - Resource URLs'));
-    $settingFields = civicrm_api('setting', 'getfields', [
-      'version' => 3,
-    ]);
-
-    $this->addYesNo('enableSSL', ts('Force Secure URLs (SSL)'));
-    $this->addYesNo('verifySSL', ts('Verify SSL Certs'));
-    // FIXME: verifySSL should use $_settings instead of manually adding fields
-    $this->assign('verifySSL_description', $settingFields['values']['verifySSL']['description']);
-
     $this->addFormRule(['CRM_Admin_Form_Setting_Url', 'formRule']);
 
     parent::buildQuickForm();

--- a/templates/CRM/Admin/Form/Setting/Url.tpl
+++ b/templates/CRM/Admin/Form/Setting/Url.tpl
@@ -65,6 +65,7 @@
         </td>
         <td>
             {$form.enableSSL.html}
+            <p class="description font-red">{ts}{$settings_fields.enableSSL.description}{/ts}</p>
         </td>
     </tr>
     <tr class="crm-url-form-block-verifySSL">
@@ -73,7 +74,7 @@
         </td>
         <td>
             {$form.verifySSL.html}<br/>
-            <p class="description font-red">{ts}{$verifySSL_description}{/ts}</p>
+            <p class="description font-red">{ts}{$settings_fields.verifySSL.description}{/ts}</p>
         </td>
     </tr>
     <tr class="crm-url-form-block-defaultExternUrl">


### PR DESCRIPTION
Overview
----------------------------------------
In `CRM_Admin_Form_Setting_Url`, `enableSSL` and `verifySSL` fields are added manually, not through metadata like the rest. This causes them to show up on the "Settings - Resource URLs" screen (`/civicrm/admin/setting/url`) as changeable options even they are overridden in `civicrm.settings.php` and technically can't be adjusted.

This is confusing UX.

Before
----------------------------------------
![before](https://github.com/civicrm/civicrm-core/assets/51154903/98071fbb-aef2-4cc6-a78e-06a5a860dbdc)

After
----------------------------------------
Not overridden
![after](https://github.com/civicrm/civicrm-core/assets/51154903/7a61e9a0-03b0-4ded-896c-7da30fddfa25)

Overridden
![after_override](https://github.com/civicrm/civicrm-core/assets/51154903/1f7b3055-24a5-4c92-b241-d1e1d51ba65c)

Comments
---

Labels are changed, as that is in the meta, but help hasn't changed and there is now extra description for `enableSSL` to make it more clear what that option is doing.
