### PR TITLE
Align price field loading with other forms to address notice

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1193,8 +1193,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    */
   public function buildEventFeeForm($form) {
     //as when call come from register.php
-    $financialTypes = CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'create');
-
     if (!$form->_eventId) {
       $form->_eventId = CRM_Utils_Request::retrieve('eventId', 'Positive', $form);
     }
@@ -1268,13 +1266,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         $form->addElement('checkbox', 'record_contribution', ts('Record Payment?'), NULL,
           ['onclick' => "return showHideByValue('record_contribution','','payment_information','table-row','radio',false);"]
         );
-        // Check permissions for financial type first
-        if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()) {
-          CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($financialTypes, $form->_action);
-        }
-        else {
-          $financialTypes = CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'create');
-        }
+        $financialTypes = CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'create');
 
         $form->add('select', 'financial_type_id',
           ts('Financial Type'),

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -52,6 +52,8 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    * The values for the contribution db object.
    *
    * @var array
+   *
+   * @deprecated use $this->getPriceFieldMetadata()
    */
   public $_values;
 
@@ -796,6 +798,9 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    * Process the form submission.
    */
   public function postProcess() {
+    if ($this->getPriceSetID()) {
+      $this->getOrder()->setPriceSelectionFromUnfilteredInput($this->getSubmittedValues());
+    }
     $statusMsg = $this->submit($this->getSubmittedValues());
     CRM_Core_Session::setStatus($statusMsg, ts('Saved'), 'success');
     $session = CRM_Core_Session::singleton();
@@ -1188,6 +1193,8 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    */
   public function buildEventFeeForm($form) {
     //as when call come from register.php
+    $financialTypes = CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'create');
+
     if (!$form->_eventId) {
       $form->_eventId = CRM_Utils_Request::retrieve('eventId', 'Positive', $form);
     }
@@ -1213,7 +1220,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       //retrieve custom information
       $this->_values = [];
       $this->_values['line_items'] = CRM_Price_BAO_LineItem::getLineItems($this->_id, 'participant');
-      self::initEventFee($form, $this->getPriceSetID());
+      $this->initEventFee($this->getPriceSetID());
       if ($form->_context === 'standalone' || $form->_context === 'participant') {
         $discountedEvent = CRM_Core_BAO_Discount::getOptionGroup($event['id'], 'civicrm_event');
         if (is_array($discountedEvent)) {
@@ -1355,21 +1362,32 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    *
    * @internal function has had several recent signature changes & is expected to be eventually removed.
    */
-  private static function initEventFee($form, $priceSetId): void {
+  private function initEventFee($priceSetId): void {
     if (!$priceSetId) {
       CRM_Core_Error::deprecatedWarning('this should not be reachable');
       return;
     }
+    $this->_priceSet = $this->getOrder()->getPriceSetMetadata();
+    $this->_priceSet['fields'] = $this->order->getPriceFieldsMetadata();
+    $this->_values['fee'] = $this->getPriceFieldMetaData();
+    $this->set('priceSet', $this->_priceSet);
+  }
 
-    $priceSet = CRM_Price_BAO_PriceSet::getSetDetail($priceSetId, NULL, FALSE);
-    $form->_priceSet = $priceSet[$priceSetId] ?? NULL;
-    $form->_values['fee'] = $form->_priceSet['fields'] ?? NULL;
-    $form->set('priceSet', $form->_priceSet);
-
-    $eventFee = $form->_values['fee'] ?? NULL;
-    if (!is_array($eventFee) || empty($eventFee)) {
-      $form->_values['fee'] = [];
-    }
+  /**
+   * Get price field metadata.
+   *
+   * The returned value is an array of arrays where each array
+   * is an id-keyed price field and an 'options' key has been added to that
+   * arry for any options.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @return array
+   */
+  public function getPriceFieldMetaData(): array {
+    return $this->order->getPriceFieldsMetadata();
   }
 
   /**
@@ -1405,9 +1423,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       if (!isset($lineItem[0])) {
         $lineItem[0] = [];
       }
-      CRM_Price_BAO_PriceSet::processAmount($this->_values['fee'],
-        $params, $lineItem[0]
-      );
       //CRM-11529 for quick config backoffice transactions
       //when financial_type_id is passed in form, update the
       //lineitems with the financial type selected in form
@@ -1419,16 +1434,9 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         }
       }
 
-      $params['fee_level'] = $params['amount_level'];
-      if ($this->isQuickConfig() && !empty($params['total_amount']) &&
-        $params['status_id'] != array_search('Partially paid', $participantStatus)
-      ) {
-        $params['fee_amount'] = $params['total_amount'];
-      }
-      else {
-        //fix for CRM-3086
-        $params['fee_amount'] = $params['amount'];
-      }
+      $params['fee_level'] = $this->getOrder()->getAmountLevel();
+      $params['fee_amount'] = $this->getOrder()->getTotalAmount();
+      $params['amount'] = $this->getOrder()->getTotalAmount();
     }
 
     return $params;
@@ -2038,7 +2046,6 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
         $this->submittableMoneyFields[] = 'price_' . $priceField['id'];
       }
     }
-    $this->order->setPriceSelectionFromUnfilteredInput($this->getSubmittedValues());
   }
 
   /**
@@ -2071,15 +2078,11 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
    * change again.
    */
   private function buildAmount(): void {
-    $feeFields = $this->_values['fee'] ?? NULL;
-    //its time to call the hook.
-    CRM_Utils_Hook::buildAmount('event', $this, $feeFields);
-
     //build the priceset fields.
     // This is probably not required now - normally loaded from event ....
     $this->add('hidden', 'priceSetId', $this->getPriceSetID());
 
-    foreach ($feeFields as $field) {
+    foreach ($this->getPriceFieldMetaData() as $field) {
       // public AND admin visibility fields are included for back-office registration and back-office change selections
       $fieldId = $field['id'];
       $elementName = 'price_' . $fieldId;
@@ -2106,7 +2109,6 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
         );
       }
     }
-    $this->_priceSet['id'] ??= $this->getPriceSetID();
     $this->assign('priceSet', $this->_priceSet);
   }
 

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1262,13 +1262,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           ['class' => "crm-select2"]
         );
       }
-      if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()
-        && empty($form->_values['fee'])
-        && ($_REQUEST['snippet'] ?? NULL) == CRM_Core_Smarty::PRINT_NOFORM
-      ) {
-        CRM_Core_Session::setStatus(ts('You do not have all the permissions needed for this page.'), 'Permission Denied', 'error');
-        return FALSE;
-      }
 
       CRM_Core_Payment_Form::buildPaymentForm($form, $form->_paymentProcessor, FALSE, TRUE, self::getDefaultPaymentInstrumentId());
       if (!$form->_mode) {
@@ -1356,7 +1349,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
   /**
    * Initiate event fee.
    *
-   * @param self $form
    * @param int|null $priceSetId
    *   ID of the price set in use.
    *

--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -210,6 +210,14 @@ function financialacls_civicrm_buildAmount($component, $form, &$feeBlock) {
       unset($feeBlock[$key]);
     }
   }
+  if (is_a($form, 'CRM_Event_Form_Participant')
+    && empty($feeBlock)
+    && ($_REQUEST['snippet'] ?? NULL) == CRM_Core_Smarty::PRINT_NOFORM
+  ) {
+    CRM_Core_Session::setStatus(ts('You do not have all the permissions needed for this page.'), 'Permission Denied', 'error');
+    return FALSE;
+  }
+
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
Align price field loading with other forms to address notice

Before
----------------------------------------
Price fields loaded both the legacy way & the way that is consistent with other forms. Notice on old way, hooks called twice

After
----------------------------------------
I also moved the related  financialacl hook code to the the extension - the output is kinda messed up before & after
Before

![image](https://github.com/civicrm/civicrm-core/assets/336308/da69a317-b7f3-498e-8a1e-83cd700df286)

After
![image](https://github.com/civicrm/civicrm-core/assets/336308/3190e9da-e242-4f55-bf7b-fd7157954092)

After in non-pop up mode 
![image](https://github.com/civicrm/civicrm-core/assets/336308/4bfb9f3a-d30a-405e-a294-27af50af0276)


but I don't think you could make the argument that we should not move the code to the extension based on before being so much better

Technical Details
----------------------------------------

Comments
----------------------------------------
