### PR TITLE
dev/core#5176 - Prevent broken message templates, loss of customizations

### DIFF
--- a/CRM/Admin/Form/MessageTemplates.php
+++ b/CRM/Admin/Form/MessageTemplates.php
@@ -334,4 +334,12 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Core_Form {
     }
   }
 
+  /**
+   * Override
+   * @return array
+   */
+  protected function getFieldsToExcludeFromPurification(): array {
+    return ['msg_html'];
+  }
+
 }

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -810,9 +810,19 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $this->_formBuilt = TRUE;
   }
 
+  /**
+   * Override this in a subclass to prevent fields intended to contain
+   * "raw html" from getting broken. E.g. system message templates
+   * @return array
+   */
+  protected function getFieldsToExcludeFromPurification(): array {
+    return [];
+  }
+
   public function setPurifiedDefaults($defaults) {
+    $exclude = $this->getFieldsToExcludeFromPurification();
     foreach ($defaults as $index => $default) {
-      if (is_string($default) && !is_numeric($default)) {
+      if (!in_array($index, $exclude, TRUE) && is_string($default) && !is_numeric($default)) {
         $defaults[$index] = CRM_Utils_String::purifyHTML($default);
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5176

Before
----------------------------------------
1. Go to edit a message template. It's more obvious for system message templates but also affects user templates.
2. Note the DOCTYPE and table elements are gone from the html version, among other things. They are still in the db at this point, but if you save then it removes them from the db too.

After
----------------------------------------


Technical Details
----------------------------------------
Broke in 5.72 with https://github.com/civicrm/civicrm-core/commit/682ca196deba8e78d35e9a3363a026ff61e59513

Comments
----------------------------------------
