### PR TITLE
Order Complete Event (and implement listener for updateMembershipBasedOnCompletionOfContribution)

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -21,6 +21,7 @@ use Civi\Api4\MembershipLog;
 use Civi\Api4\PaymentProcessor;
 use Civi\Api4\UFJoin;
 use Civi\Core\Event\PostEvent;
+use Civi\Order\Event\OrderCompleteEvent;
 
 /**
  *
@@ -3661,8 +3662,10 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     }
 
     if ($contributionParams['contribution_status_id'] === $completedContributionStatusID && !$disableActionsOnCompleteOrder) {
-      $dateTodayForDatesCalculations = $input['trxn_date'] ?? date('YmdHis');
-      \Civi::dispatcher()->dispatch('civi.order.complete', new \Civi\Order\Event\OrderCompleteEvent($contributionID, $dateTodayForDatesCalculations));
+      $orderCompleteEventParams = [
+        'effective_date' => $input['trxn_date'] ?? date('YmdHis'),
+      ];
+      \Civi::dispatcher()->dispatch('civi.order.complete', new OrderCompleteEvent($contributionID, $orderCompleteEventParams));
     }
 
     $participantPayments = civicrm_api3('ParticipantPayment', 'get', ['contribution_id' => $contributionID, 'return' => 'participant_id', 'sequential' => 1])['values'];

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -949,6 +949,8 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
    * @deprecated
    */
   protected static function getRelatedMemberships(int $contributionID): array {
+    CRM_Core_Error::deprecatedWarning('getRelatedMemberships is only used by updateMembershipBasedOnCompletionOfContribution which has been moved to \Civi\Membership\OrderCompleteSubscriber and will be removed from CRM_Contribute_BAO_Contribution');
+
     $membershipIDs = array_keys((array) LineItem::get(FALSE)
       ->addWhere('contribution_id', '=', $contributionID)
       ->addWhere('entity_table', '=', 'civicrm_membership')
@@ -3994,6 +3996,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @deprecated
    */
   public static function updateMembershipBasedOnCompletionOfContribution($contributionID, $changeDate) {
+    CRM_Core_Error::deprecatedWarning('updateMembershipBasedOnCompletionOfContribution has been moved to \Civi\Membership\OrderCompleteSubscriber and will be removed from CRM_Contribute_BAO_Contribution');
+
     $memberships = self::getRelatedMemberships((int) $contributionID);
     foreach ($memberships as $membership) {
       $membershipParams = [

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -945,6 +945,8 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
    *
    * @return array
    * @throws \CRM_Core_Exception
+   *
+   * @deprecated
    */
   protected static function getRelatedMemberships(int $contributionID): array {
     $membershipIDs = array_keys((array) LineItem::get(FALSE)
@@ -3657,10 +3659,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     }
 
     if ($contributionParams['contribution_status_id'] === $completedContributionStatusID && !$disableActionsOnCompleteOrder) {
-      self::updateMembershipBasedOnCompletionOfContribution(
-        $contributionID,
-        $input['trxn_date'] ?? date('YmdHis')
-      );
+      $dateTodayForDatesCalculations = $input['trxn_date'] ?? date('YmdHis');
+      \Civi::dispatcher()->dispatch('civi.order.complete', new \Civi\Order\Event\OrderCompleteEvent($contributionID, $dateTodayForDatesCalculations));
     }
 
     $participantPayments = civicrm_api3('ParticipantPayment', 'get', ['contribution_id' => $contributionID, 'return' => 'participant_id', 'sequential' => 1])['values'];
@@ -3990,6 +3990,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    *   If provided, specify an alternative date to use as "today" calculation of membership dates
    *
    * @throws \CRM_Core_Exception
+   *
+   * @deprecated
    */
   public static function updateMembershipBasedOnCompletionOfContribution($contributionID, $changeDate) {
     $memberships = self::getRelatedMemberships((int) $contributionID);

--- a/Civi/Membership/OrderCompleteSubscriber.php
+++ b/Civi/Membership/OrderCompleteSubscriber.php
@@ -1,6 +1,9 @@
 <?php
 namespace Civi\Membership;
 
+use Civi\Api4\Activity;
+use Civi\Api4\LineItem;
+use Civi\Api4\MembershipLog;
 use Civi\Core\Service\AutoService;
 use Civi\Core\Service\IsActiveTrait;
 use Civi\Order\Event\OrderCompleteEvent;
@@ -32,8 +35,6 @@ class OrderCompleteSubscriber extends AutoService implements EventSubscriberInte
    *   so you should check if there is actually a membership to update.
    *
    * @param \Civi\Order\Event\OrderCompleteEvent $event
-   *
-   * @throws \CRM_Core_Exception
    */
   public function onOrderComplete(OrderCompleteEvent $event): void {
     if (!$this->isActive()) {
@@ -41,11 +42,175 @@ class OrderCompleteSubscriber extends AutoService implements EventSubscriberInte
     }
 
     try {
-      \CRM_Contribute_BAO_Contribution::updateMembershipBasedOnCompletionOfContribution($event->contributionID, $event->dateTodayForDatesCalculations);
+      self::updateMembershipBasedOnCompletionOfContribution($event->contributionID, $event->dateTodayForDatesCalculations);
     }
     catch (\Exception $e) {
       \Civi::log()->error('civi_membership_order_complete: Error updating membership for contributionID: ' . $event->contributionID . ': ' . $e->getMessage());
     }
+  }
+
+  /**
+   * Update the memberships associated with a contribution if it has been completed.
+   *
+   * Note that the way in which $memberships are loaded as objects is pretty messy & I think we could just
+   * load them in this function. Code clean up would compensate for any minor performance implication.
+   *
+   * @param int $contributionID
+   *   The Contribution ID that was Completed
+   * @param string $changeDate
+   *   If provided, specify an alternative date to use as "today" calculation of membership dates
+   *
+   * @throws \CRM_Core_Exception
+   */
+  private static function updateMembershipBasedOnCompletionOfContribution(int $contributionID, string $changeDate) {
+
+    $memberships = self::getRelatedMemberships($contributionID);
+    if (empty($memberships)) {
+      return;
+    }
+
+    foreach ($memberships as $membership) {
+      $membershipParams = [
+        'id' => $membership['id'],
+        'contact_id' => $membership['contact_id'],
+        'is_test' => $membership['is_test'],
+        'membership_type_id' => $membership['membership_type_id'],
+        'membership_activity_status' => 'Completed',
+      ];
+
+      $currentMembership = \CRM_Member_BAO_Membership::getContactMembership($membershipParams['contact_id'],
+        $membershipParams['membership_type_id'],
+        $membershipParams['is_test'],
+        $membershipParams['id']
+      );
+
+      // CRM-8141 update the membership type with the value recorded in log when membership created/renewed
+      // this picks up membership type changes during renewals
+      $preChangeMembership = MembershipLog::get(FALSE)
+        ->addSelect('membership_type_id')
+        ->addWhere('membership_id', '=', $membershipParams['id'])
+        ->addOrderBy('id', 'DESC')
+        ->execute()
+        ->first();
+      if (!empty($preChangeMembership) && !empty($preChangeMembership['membership_type_id'])) {
+        $membershipParams['membership_type_id'] = $preChangeMembership['membership_type_id'];
+      }
+      if (empty($membership['end_date']) || (int) $membership['status_id'] !== \CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Pending')) {
+        // Passing num_terms to the api triggers date calculations, but for pending memberships these may be already calculated.
+        // sigh - they should  be  consistent but removing the end date check causes test failures & maybe UI too?
+        // The api assumes num_terms is a special sauce for 'is_renewal' so we need to not pass it when updating a pending to completed.
+        // ... except testCompleteTransactionMembershipPriceSetTwoTerms hits this line so the above is obviously not true....
+        $lineItem = LineItem::get(FALSE)
+          ->addSelect('membership_num_terms')
+          ->addJoin('PriceFieldValue AS price_field_value', 'LEFT')
+          ->addWhere('contribution_id', '=', $contributionID)
+          ->addWhere('price_field_value.membership_type_id', '=', $membershipParams['membership_type_id'])
+          ->execute()
+          ->first();
+        // default of 1 is precautionary
+        $membershipParams['num_terms'] = empty($lineItem['membership_num_terms']) ? 1 : $lineItem['membership_num_terms'];
+      }
+      // @todo remove all this stuff in favour of letting the api call further down handle in
+      // (it is a duplication of what the api does).
+      $dates = [];
+      if ($currentMembership) {
+        /*
+         * Fixed FOR CRM-4433
+         * In BAO/Membership.php(renewMembership function), we skip the extend membership date and status
+         * when Contribution mode is notify and membership is for renewal
+         */
+        // Test cover for this is in testRepeattransactionRenewMembershipOldMembership
+        // Be afraid.
+        \CRM_Member_BAO_Membership::fixMembershipStatusBeforeRenew($currentMembership, $changeDate);
+
+        // @todo - we should pass membership_type_id instead of null here but not
+        // adding as not sure of testing
+        $dates = \CRM_Member_BAO_MembershipType::getRenewalDatesForMembershipType($membershipParams['id'],
+          $changeDate, NULL, $membershipParams['num_terms']
+        );
+        $dates['join_date'] = $currentMembership['join_date'];
+      }
+      if ('Pending' === \CRM_Core_PseudoConstant::getName('CRM_Member_BAO_Membership', 'status_id', $membership['status_id'])) {
+        $membershipParams['skipStatusCal'] = '';
+      }
+      else {
+        //get the status for membership.
+        $calcStatus = \CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($dates['start_date'] ?? NULL,
+          $dates['end_date'] ?? NULL,
+          $dates['join_date'] ?? NULL,
+          'now',
+          TRUE,
+          $membershipParams['membership_type_id'],
+          $membershipParams
+        );
+
+        unset($dates['end_date']);
+        $membershipParams['status_id'] = $calcStatus['id'] ?? 'New';
+      }
+      //we might be renewing membership,
+      //so make status override false.
+      $membershipParams['is_override'] = FALSE;
+      $membershipParams['status_override_end_date'] = 'null';
+      $membership = civicrm_api3('Membership', 'create', $membershipParams);
+      $membership = $membership['values'][$membership['id']];
+      // Update activity to Completed.
+      // Perhaps this should be in Membership::create? Test cover in
+      // api_v3_ContributionTest.testPendingToCompleteContribution.
+      $priorMembershipStatus = $memberships[$membership['id']]['status_id'] ?? NULL;
+      Activity::update(FALSE)->setValues([
+        'status_id:name' => 'Completed',
+        'subject' => ts('Status changed from %1 to %2'), [
+          1 => \CRM_Core_PseudoConstant::getLabel('CRM_Member_BAO_Membership', 'status_id', $priorMembershipStatus),
+          2 => \CRM_Core_PseudoConstant::getLabel('CRM_Member_BAO_Membership', 'status_id', $membership['status_id']),
+        ],
+
+      ])->addWhere('source_record_id', '=', $membership['id'])
+        ->addWhere('status_id:name', '=', 'Scheduled')
+        ->addWhere('activity_type_id:name', 'IN', ['Membership Signup', 'Membership Renewal'])
+        ->execute();
+    }
+  }
+
+  /**
+   * Get memberships related to the contribution.
+   *
+   * @param int $contributionID
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  private static function getRelatedMemberships(int $contributionID): array {
+    $membershipIDs = array_keys((array) LineItem::get(FALSE)
+      ->addWhere('contribution_id', '=', $contributionID)
+      ->addWhere('entity_table', '=', 'civicrm_membership')
+      ->addSelect('entity_id')
+      ->execute()->indexBy('entity_id'));
+
+    $doubleCheckParams = [
+      'return' => 'membership_id',
+      'contribution_id' => $contributionID,
+    ];
+    if (!empty($membershipIDs)) {
+      $doubleCheckParams['membership_id'] = ['NOT IN' => $membershipIDs];
+    }
+    $membershipPayments = civicrm_api3('MembershipPayment', 'get', $doubleCheckParams)['values'];
+    if (!empty($membershipPayments)) {
+      $membershipIDs = [];
+      \CRM_Core_Error::deprecatedWarning('Not having valid line items for membership payments is invalid.');
+      foreach ($membershipPayments as $membershipPayment) {
+        $membershipIDs[] = $membershipPayment['membership_id'];
+      }
+    }
+    if (empty($membershipIDs)) {
+      return [];
+    }
+    // We could combine this with the MembershipPayment.get - we'd
+    // need to re-wrangle the params (here or in the calling function)
+    // as they would then me membership.contact_id, membership.is_test etc
+    return civicrm_api3('Membership', 'get', [
+      'id' => ['IN' => $membershipIDs],
+      'return' => ['id', 'contact_id', 'membership_type_id', 'is_test', 'status_id', 'end_date'],
+    ])['values'];
   }
 
 }

--- a/Civi/Membership/OrderCompleteSubscriber.php
+++ b/Civi/Membership/OrderCompleteSubscriber.php
@@ -1,0 +1,51 @@
+<?php
+namespace Civi\Membership;
+
+use Civi\Core\Service\AutoService;
+use Civi\Core\Service\IsActiveTrait;
+use Civi\Order\Event\OrderCompleteEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class OrderCompleteSubscriber
+ * @package Civi\Membership
+ * @service civi_membership_order_complete
+ *
+ * This class provides the default behaviour for updating memberships on completion of contribution (On "Order Complete")
+ */
+class OrderCompleteSubscriber extends AutoService implements EventSubscriberInterface {
+
+  use IsActiveTrait;
+
+  /**
+   * @inheritDoc
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      'civi.order.complete' => ['onOrderComplete', 0],
+    ];
+  }
+
+  /**
+   * Default handler for Membership on "Order Complete"
+   * Note that the "civi.order.complete" will trigger for all "Completed orders"
+   *   so you should check if there is actually a membership to update.
+   *
+   * @param \Civi\Order\Event\OrderCompleteEvent $event
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function onOrderComplete(OrderCompleteEvent $event): void {
+    if (!$this->isActive()) {
+      return;
+    }
+
+    try {
+      \CRM_Contribute_BAO_Contribution::updateMembershipBasedOnCompletionOfContribution($event->contributionID, $event->dateTodayForDatesCalculations);
+    }
+    catch (\Exception $e) {
+      \Civi::log()->error('civi_membership_order_complete: Error updating membership for contributionID: ' . $event->contributionID . ': ' . $e->getMessage());
+    }
+  }
+
+}

--- a/Civi/Membership/OrderCompleteSubscriber.php
+++ b/Civi/Membership/OrderCompleteSubscriber.php
@@ -42,7 +42,7 @@ class OrderCompleteSubscriber extends AutoService implements EventSubscriberInte
     }
 
     try {
-      self::updateMembershipBasedOnCompletionOfContribution($event->contributionID, $event->dateTodayForDatesCalculations);
+      self::updateMembershipBasedOnCompletionOfContribution($event->contributionID, $event->params['effective_date'] ?? NULL);
     }
     catch (\Exception $e) {
       \Civi::log()->error('civi_membership_order_complete: Error updating membership for contributionID: ' . $event->contributionID . ': ' . $e->getMessage());
@@ -57,12 +57,14 @@ class OrderCompleteSubscriber extends AutoService implements EventSubscriberInte
    *
    * @param int $contributionID
    *   The Contribution ID that was Completed
-   * @param string $changeDate
+   * @param string|null $changeDate
    *   If provided, specify an alternative date to use as "today" calculation of membership dates
    *
+   * @return void
    * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
-  private static function updateMembershipBasedOnCompletionOfContribution(int $contributionID, string $changeDate) {
+  private static function updateMembershipBasedOnCompletionOfContribution(int $contributionID, ?string $changeDate) {
 
     $memberships = self::getRelatedMemberships($contributionID);
     if (empty($memberships)) {

--- a/Civi/Order/Event/OrderCompleteEvent.php
+++ b/Civi/Order/Event/OrderCompleteEvent.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Order\Event;
+
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * Class OrderCompleteEvent
+ *
+ * @package Civi\Order\Event
+ */
+class OrderCompleteEvent extends GenericHookEvent {
+
+  /**
+   * The Contribution ID that was Completed
+   *
+   * @var int
+   */
+  public int $contributionID;
+
+  /**
+   * If provided, specify an alternative date to use as "today" calculation of membership dates
+   *
+   * @var string
+   */
+  public string $dateTodayForDatesCalculations;
+
+  /**
+   * Class constructor
+   *
+   * @param int $contributionID
+   * @param string $dateTodayForDatesCalculations
+   */
+  public function __construct(int $contributionID, string $dateTodayForDatesCalculations) {
+    $this->contributionID = $contributionID;
+    $this->dateTodayForDatesCalculations = $dateTodayForDatesCalculations;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getHookValues() {
+    return [$this->contributionID, $this->dateTodayForDatesCalculations];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
See #28607 for proof of concept and discussion around this solution.

An "Order Complete" event allows us to perform actions on order complete (eg. what `CRM_Contribute_BAO_Contribution::updateMembershipBasedOnCompletionOfContribution()` currently does for Membership).

Before
----------------------------------------
Membership dates/status are updated on completion of contribution. No way to override/change.

After
----------------------------------------
- Membership dates/status are updated on completion of contribution via `civi.order.complete` event.
- Now possible to add additional functionality by intercepting a listener for the `civi.order.complete` event - eg. a custom extension that creates a "Dispatch Order" activity or changes a case status.
- Also possible to remove existing listeners so we can alter/disable default behaviour.

Technical Details
----------------------------------------
- Implements a new event, listener and subscriber `civi.order.completed`.
- Moves call to `CRM_Contribute_BAO_Contribution::updateMembershipBasedOnCompletionOfContribution()` to a new subscriber class.
- Implements a service named `civi_membership_order_complete` so you can disable it if you want to implement your own. For example: https://lab.civicrm.org/extensions/stripeimport/-/commit/199c4777348a15826f3f160fa54a70dd0313b521

```
    if (\Civi\Core\Container::singleton()->has('civi_membership_order_complete')) {
      \Civi::service('civi_membership_order_complete')->setActive(FALSE);
      \Civi::log()->info('Stripeimport: Disabled Civi\Membership\OrderCompleteSubscriber::onOrderComplete listener');
    }
    else {
      \Civi::log()->debug('civi_membership_order_complete service not found. Did you apply https://github.com/civicrm/civicrm-core/pull/30085?');
    }
```

Comments
----------------------------------------
This copies `IsActiveTrait` from FlexMailer to Civi\Core\Service. We should remove the FlexMailer one in a follow-up PR.