### PR TITLE
Sort by register_date Contact Summary Events tab with Admin UI

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Events.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Events.mgd.php
@@ -76,7 +76,12 @@ return [
         'type' => 'table',
         'settings' => [
           'description' => NULL,
-          'sort' => [],
+          'sort' => [
+            [
+              'register_date',
+              'DESC',
+            ],
+          ],
           'limit' => 50,
           'pager' => [
             'show_count' => TRUE,


### PR DESCRIPTION
Represents a regression, introduced here https://github.com/civicrm/civicrm-core/pull/29570 compared to the no-adminUI event contact tab.