### PR TITLE
ensure civisms adds SMS delivery activity

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1279,38 +1279,43 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       }
       $mailing->copyValues($params);
     }
-
     $errors = [];
-    foreach (['subject', 'name', 'from_name', 'from_email'] as $field) {
-      if (empty($mailing->{$field})) {
-        $errors[$field] = ts('Field "%1" is required.', [
-          1 => $field,
-        ]);
+    if ($mailing->sms_provider_id) {
+      if (empty($mailing->body_text)) {
+        $errors['body'] = ts('Field "body_text" is required.');
       }
     }
-    if (empty($mailing->body_html) && empty($mailing->body_text)) {
-      $errors['body'] = ts('Field "body_html" or "body_text" is required.');
-    }
-
-    if (!Civi::settings()->get('disable_mandatory_tokens_check')) {
-      $header = $mailing->header_id && $mailing->header_id !== 'null' ? CRM_Mailing_BAO_MailingComponent::findById($mailing->header_id) : NULL;
-      $footer = $mailing->footer_id && $mailing->footer_id !== 'null' ? CRM_Mailing_BAO_MailingComponent::findById($mailing->footer_id) : NULL;
-      foreach (['body_html', 'body_text'] as $field) {
+    else {
+      foreach (['subject', 'name', 'from_name', 'from_email'] as $field) {
         if (empty($mailing->{$field})) {
-          continue;
+          $errors[$field] = ts('Field "%1" is required.', [
+            1 => $field,
+          ]);
         }
-        $str = ($header ? $header->{$field} : '') . $mailing->{$field} . ($footer ? $footer->{$field} : '');
-        $err = CRM_Utils_Token::requiredTokens($str);
-        if ($err !== TRUE) {
-          foreach ($err as $token => $desc) {
-            $errors["{$field}:{$token}"] = ts('This message is missing a required token - {%1}: %2',
-              [1 => $token, 2 => $desc]
-            );
+      }
+      if (empty($mailing->body_html) && empty($mailing->body_text)) {
+        $errors['body'] = ts('Field "body_html" or "body_text" is required.');
+      }
+
+      if (!Civi::settings()->get('disable_mandatory_tokens_check')) {
+        $header = $mailing->header_id && $mailing->header_id !== 'null' ? CRM_Mailing_BAO_MailingComponent::findById($mailing->header_id) : NULL;
+        $footer = $mailing->footer_id && $mailing->footer_id !== 'null' ? CRM_Mailing_BAO_MailingComponent::findById($mailing->footer_id) : NULL;
+        foreach (['body_html', 'body_text'] as $field) {
+          if (empty($mailing->{$field})) {
+            continue;
+          }
+          $str = ($header ? $header->{$field} : '') . $mailing->{$field} . ($footer ? $footer->{$field} : '');
+          $err = CRM_Utils_Token::requiredTokens($str);
+          if ($err !== TRUE) {
+            foreach ($err as $token => $desc) {
+              $errors["{$field}:{$token}"] = ts('This message is missing a required token - {%1}: %2',
+                [1 => $token, 2 => $desc]
+              );
+            }
           }
         }
       }
     }
-
     return $errors;
   }
 

--- a/CRM/Mailing/BAO/SMSJob.php
+++ b/CRM/Mailing/BAO/SMSJob.php
@@ -158,7 +158,7 @@ class CRM_Mailing_BAO_SMSJob extends CRM_Mailing_BAO_MailingJob {
       ];
       CRM_Utils_Hook::alterMailParams($mailParams, 'civimail');
       $body = $mailParams['text'];
-      $headers = ['To' => $field['phone']];
+      $headers = ['To' => $field['phone'], 'contact_id' => $contact['id']];
 
       try {
         $result = $mailer->send($headers['To'], $headers, $body, $this->id);

--- a/CRM/Mailing/Service/ListUnsubscribe.php
+++ b/CRM/Mailing/Service/ListUnsubscribe.php
@@ -34,6 +34,10 @@ class CRM_Mailing_Service_ListUnsubscribe extends \Civi\Core\Service\AutoService
     // This code is a little ugly because it anticipates serving both code-paths.
     // But the BAO path should be properly killed. Doing so will allow you cleanup this code more.
 
+    // SMS messages don't have List-Unsubscribe, so bail early.
+    if (!array_key_exists('List-Unsubscribe', $params)) {
+      return;
+    }
     if (!in_array($context, ['civimail', 'flexmailer'])) {
       return;
     }

--- a/tests/phpunit/CRM/Contact/Form/Task/SMSCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/SMSCommonTest.php
@@ -10,6 +10,7 @@
  */
 
 use Civi\Test\FormTrait;
+
 require_once 'CiviTest/CiviTestSMSProvider.php';
 
 /**

--- a/tests/phpunit/CRM/Contact/Form/Task/SMSCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/SMSCommonTest.php
@@ -10,6 +10,7 @@
  */
 
 use Civi\Test\FormTrait;
+require_once 'CiviTest/CiviTestSMSProvider.php';
 
 /**
  * Test class for CRM_Contact_Form_Task_SMSCommon.
@@ -99,7 +100,16 @@ class CRM_Contact_Form_Task_SMSCommonTest extends CiviUnitTestCase {
   public function testQuickFormMobileNumbersDisplay(): void {
     $this->createLoggedInUser();
     $this->createTestEntity('OptionValue', ['option_group_id:name' => 'sms_provider_name', 'name' => 'dummy sms', 'label' => 'Dummy']);
-    CRM_Core_DAO::executeQuery('INSERT INTO civicrm_sms_provider (name,title, api_type, api_params) VALUES ("SMS", "SMS", 1, "1=2")');
+    $sms_provider = $this->callAPISuccess('SmsProvider', 'create', [
+      'sequential' => 1,
+      'name' => 'CiviTestSMSProvider',
+      'title' => "Test",
+      'username' => "Test",
+      'password' => "Test",
+      'api_type' => 1,
+      'is_active' => 1,
+      'api_params' => 'From=+1234567890',
+    ]);
     $form = $this->getTestForm('CRM_Contact_Form_Search_Basic', [
       'radio_ts' => 'ts_all',
       'to' => implode(',', [

--- a/tests/phpunit/CiviTest/CiviTestSMSProvider.php
+++ b/tests/phpunit/CiviTest/CiviTestSMSProvider.php
@@ -46,6 +46,8 @@ class CiviTestSMSProvider extends CRM_SMS_Provider {
 
   public function send($recipients, $header, $message, $dncID = NULL) {
     $this->sentMessage = $message;
+    $sid = substr(str_shuffle('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'), 0, 16);
+    $this->createActivity($sid, $message, $header, $dncID);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Ensure sending an SMS message via CiviMail results in a "SMS delivery" activity being created that is with the contact that was sent the SMS message.

Before
----------------------------------------
An SMS delivery activity is created for every SMS message sent, but the "With/Target" contact is left blank.

After
----------------------------------------
Now, after sending an SMS message via CiviMail, the "SMS delivery" activity is with the contact that was sent the message. 

Technical Details
----------------------------------------
I think this is a regression from 2a55af8e4b2d450e919a3a0aef9c3cb33071477c.

Comments
----------------------------------------
It seems that we have never had a test that actually runs the sms_process job, so I made a few fixes to make it possible to test and fixed another error preventing it from working (the list unsubscribe business).
