### PR TITLE
Move some CRM tests to use apiv4

### DIFF
--- a/tests/phpunit/CRM/ACL/ListTest.php
+++ b/tests/phpunit/CRM/ACL/ListTest.php
@@ -11,6 +11,13 @@
 class CRM_ACL_ListTest extends CiviUnitTestCase {
 
   /**
+   * API version in use.
+   *
+   * @var int
+   */
+  protected $_apiversion = 4;
+
+  /**
    * @var array
    */
   protected $allowedContactsACL = [];

--- a/tests/phpunit/CRM/Activity/BAO/ActivityAssignmentTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityAssignmentTest.php
@@ -18,23 +18,28 @@
 class CRM_Activity_BAO_ActivityAssignmentTest extends CiviUnitTestCase {
 
   /**
+   * API version in use.
+   *
+   * @var int
+   */
+  protected $_apiversion = 4;
+
+  /**
    *  Pass zero as an id and make sure no Assignees are retrieved.
    */
   public function testGetAssigneeNamesNoId(): void {
-    $activity = $this->activityCreate();
+    $this->activityCreate();
     $assignees = CRM_Activity_BAO_ActivityAssignment::getAssigneeNames(0);
-
-    $this->assertEquals(count($assignees), 0, '0 assignee names retrieved');
+    $this->assertCount(0, $assignees, '0 assignee names retrieved');
   }
 
   /**
    *  Pass Null as an id and make sure no Assignees are retrieved.
    */
   public function testGetAssigneeNamesNullId(): void {
-    $activity = $this->activityCreate();
+    $this->activityCreate();
     $assignees = CRM_Activity_BAO_ActivityAssignment::getAssigneeNames(NULL);
-
-    $this->assertEquals(count($assignees), 0, '0 assignee names retrieved');
+    $this->assertCount(0, $assignees, '0 assignee names retrieved');
   }
 
   /**
@@ -43,7 +48,7 @@ class CRM_Activity_BAO_ActivityAssignmentTest extends CiviUnitTestCase {
   public function testGetAssigneeNamesOneId(): void {
     $activity = $this->activityCreate();
     $assignees = CRM_Activity_BAO_ActivityAssignment::getAssigneeNames([$activity['id']]);
-    $this->assertEquals(count($assignees), 1, '1 assignee names retrieved');
+    $this->assertCount(1, $assignees, '1 assignee names retrieved');
   }
 
 }

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -8,11 +8,20 @@ use Civi\Api4\OptionValue;
  * @group headless
  */
 class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
+  /**
+   * API version in use.
+   *
+   * @var int
+   */
+  protected $_apiversion = 4;
 
   use Civi\Test\ACLPermissionTrait;
 
-  private $allowedContactsACL = [];
+  private array $allowedContactsACL = [];
 
+  /**
+   * @var int|null
+   */
   private $loggedInUserId = NULL;
 
   private $someContacts = [];
@@ -88,7 +97,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
       'activity_type_id',
       'subject', 'Database check on updated activity record.'
     );
-    $this->assertEquals($activityTypeId, 3, 'Verify activity type id is 3.');
+    $this->assertEquals(3, $activityTypeId, 'Verify activity type id is 3.');
 
     $this->contactDelete($contactId);
   }
@@ -167,12 +176,12 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
     $defaults = [];
     $activity = CRM_Activity_BAO_Activity::retrieve($params, $defaults);
 
-    $this->assertEquals($activity->subject, 'Scheduling Meeting', 'Verify activity subject is correct.');
-    $this->assertEquals($activity->activity_type_id, 2, 'Verify activity type id is correct.');
+    $this->assertEquals('Scheduling Meeting', $activity->subject, 'Verify activity subject is correct.');
+    $this->assertEquals(2, $activity->activity_type_id, 'Verify activity type id is correct.');
     $this->assertEquals($defaults['source_contact_id'], $contactId, 'Verify source contact id is correct.');
 
-    $this->assertEquals($defaults['subject'], 'Scheduling Meeting', 'Verify activity subject is correct.');
-    $this->assertEquals($defaults['activity_type_id'], 2, 'Verify activity type id is correct.');
+    $this->assertEquals('Scheduling Meeting', $defaults['subject'], 'Verify activity subject is correct.');
+    $this->assertEquals(2, $defaults['activity_type_id'], 'Verify activity type id is correct.');
 
     $this->assertEquals($defaults['target_contact'][0], $targetContactId, 'Verify target contact id is correct.');
 
@@ -186,7 +195,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function testTargetContactNotAvaliable(): void {
+  public function testTargetContactNotAvailable(): void {
     $contactId = $this->individualCreate();
     $params = [
       'first_name' => 'liz',
@@ -231,9 +240,9 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
    */
   public function testActivitySelectorNoTargets(): void {
     $contact_id = $this->individualCreate([], 0, TRUE);
-    $activity = $this->callAPISuccess('activity', 'create', [
+    $activity = $this->callAPISuccess('Activity', 'create', [
       'source_contact_id' => $contact_id,
-      'activity_type_id' => 'Meeting',
+      'activity_type_id:name' => 'Meeting',
       'subject' => 'Lonely Meeting',
       'details' => 'Here at this meeting all by myself and no other contacts.',
     ]);
@@ -473,7 +482,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
    * Test getActivities BAO method for getting count
    *
    */
-  public function testGetActivitiesCountforContactSummary(): void {
+  public function testGetActivitiesCountForContactSummary(): void {
     // Reset to default
     $this->setShowCaseActivitiesInCore(FALSE);
     $this->createTestActivities();
@@ -908,10 +917,10 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
           $this->assertEquals(3, $activities[3]['source_contact_id']);
           // @todo review inconsistency between 2 versions.
           // $this->assertEquals(TRUE, array_key_exists(3, $activities[8]['target_contact_name']));
-          $this->assertEquals(TRUE, array_key_exists(3, $activities[1]['assignee_contact_name']));
+          $this->assertTrue(array_key_exists(3, $activities[1]['assignee_contact_name']));
         }
         if ($caseName === 'exclude-all-activity_type') {
-          $this->assertEquals(0, count($activities));
+          $this->assertCount(0, $activities);
           $this->assertEquals(0, $activityCount);
         }
         if ($caseName === 'sort-by-subject') {
@@ -1054,7 +1063,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
       if ($caseName === 'todays-activity' || $caseName === 'todays-activity-filtered-by-range') {
         // Only one of the 4 activities today relates to contact id 1.
         $this->assertEquals(1, $activityCount);
-        $this->assertEquals(1, count($activities));
+        $this->assertCount(1, $activities);
         $this->assertEquals([7], array_keys($activities));
       }
       elseif ($caseName === 'last-week-activity') {
@@ -1164,7 +1173,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
     $params = [
       'source_contact_id' => $sourceContactID,
       'subject' => 'Scheduling Meeting',
-      'activity_type_id' => 'Meeting',
+      'activity_type_id:name' => 'Meeting',
       'assignee_contact_id' => [$assigneeContactId],
       'activity_date_time' => 'now',
     ];
@@ -1189,7 +1198,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
     ];
     $activity = $this->callAPISuccess('Activity', 'create', $params);
     // fetch domain info
-    $domainInfo = $this->callAPISuccess('Domain', 'getsingle', ['id' => CRM_Core_Config::domainID()]);
+    $domainInfo = $this->callAPISuccess('Domain', 'getsingle', ['version' => 3, 'id' => CRM_Core_Config::domainID()]);
 
     $formAddress = CRM_Case_BAO_Case::getReceiptFrom($activity['id']);
     if (!empty($domainInfo['from_email'])) {
@@ -1256,13 +1265,14 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
     $subject = __FUNCTION__ . ' subject';
     $html = __FUNCTION__ . ' html {contact.display_name} {case.case_type_id:label}';
     $text = __FUNCTION__ . ' text {contact.display_name} {case.case_type_id:label}';
-    $form = $this->getCaseEmailTaskForm($contactId, [
+    $this->getTestForm('CRM_Case_Form_Task_Email', [
+      'to' => $contactId . '::' . 'email@example.com',
+      'from_email_address' => 'from@example.com',
       'subject' => $subject,
       'html_message' => $html,
       'text_message' => $text,
-    ]);
-    $mut = new CiviMailUtils($this, TRUE);
-    $form->postProcess();
+    ], ['cid' => $contactId, 'caseid' => $this->getCaseID()])
+      ->processForm();
     $activity = Activity::get()
       ->addSelect('activity_type_id:label', 'subject', 'details')
       ->addWhere('activity_type_id:name', '=', 'Email')
@@ -1276,10 +1286,9 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
 ';
     $this->assertEquals($details, $activity['details'], 'Activity details do not match.');
     $this->assertEquals($subject, $activity['subject'], 'Activity subject do not match.');
-    $mut->checkMailLog([
+    $this->assertMailSentContainingStrings([
       'Mr. Anthony Anderson II Housing Support',
     ]);
-    $mut->stop();
   }
 
   /**
@@ -1325,23 +1334,28 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
    * assumes an email always has tokens in it.
    *
    * @throws \CRM_Core_Exception
-   * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function testSendEmailBasicWithoutAnyTokens(): void {
     $contactId = $this->individualCreate();
 
-    // create a logged in USER since the code references it for sendEmail user.
+    // create a logged-in USER since the code references it for sendEmail user.
     $this->createLoggedInUser();
     \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['view all contacts', 'access CiviCRM'];
 
     $subject = __FUNCTION__ . ' subject';
     $html = __FUNCTION__ . ' html';
     $text = __FUNCTION__ . ' text';
-    $form = $this->getContactEmailTaskForm($contactId, [
+    $_REQUEST['cid'] = $contactId;
+    // @todo use getTestForm instead like the rest of the class.
+    /** @var CRM_Contact_Form_Task_Email $form */
+    $form = $this->getFormObject('CRM_Contact_Form_Task_Email', [
+      'to' => $contactId . '::' . 'email@example.com',
+      'from_email_address' => 'from@example.com',
       'subject' => $subject,
       'html_message' => $html,
       'text_message' => $text,
     ]);
+    $form->buildForm();
     $mut = new CiviMailUtils($this, TRUE);
     $form->postProcess();
 
@@ -1387,22 +1401,24 @@ $text
     ];
 
     // Create a campaign.
-    $result = $this->civicrm_api('Campaign', 'create', [
-      'version' => $this->_apiversion,
-      'title' => __FUNCTION__ . ' campaign',
+    $result = $this->createTestEntity('Campaign', [
+      'name' => 'my_test',
+      'title' => 'campaign',
     ]);
     $campaign_id = $result['id'];
 
     $html = __FUNCTION__ . ' html';
     $text = __FUNCTION__ . ' text';
-    /** @var CRM_Activity_Form_Task_Email $form */
-    $form = $this->getCaseEmailTaskForm($contactId, [
+    $this->getTestForm('CRM_Case_Form_Task_Email', [
+      'to' => $contactId . '::' . 'email@example.com',
+      'from_email_address' => 'from@example.com',
       'subject' => '',
       'html_message' => $html,
       'text_message' => $text,
       'campaign_id' => $campaign_id,
-    ]);
-    $form->postProcess();
+    ], ['cid' => $contactId, 'caseid' => $this->getCaseID()])
+      ->processForm();
+
     $activity = Activity::get()
       ->addSelect('activity_type_id:label', 'subject', 'details', 'campaign_id')
       ->addWhere('activity_type_id:name', '=', 'Email')
@@ -1415,13 +1431,14 @@ $text
    */
   public function testSendSMSWithoutPermission(): void {
     $dummy = NULL;
+    $array = [];
     $session = CRM_Core_Session::singleton();
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
     $this->expectException(CRM_Core_Exception::class);
     $this->expectExceptionMessage('You do not have the \'send SMS\' permission');
     CRM_Activity_BAO_Activity::sendSMS(
-      $dummy,
-      $dummy,
+      $array,
+      $array,
       $dummy,
       $dummy,
       $session->get('userID')
@@ -1472,8 +1489,10 @@ $text
   }
 
   /**
-   * Test that when a numbe ris specified in the To Param of the SMS provider parameters that an SMS is sent
+   * Test that when a number is specified in the To Param of the SMS provider parameters that an SMS is sent
    * @see dev/core#273
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testSendSMSMobileInToProviderParamWithDoNotSMS(): void {
     $sent = $this->createSendSmsTest(FALSE, 2, TRUE, ['do_not_sms' => 1]);
@@ -1512,14 +1531,16 @@ $text
     // Create a contact
     $contactId = $this->individualCreate();
     if (!empty($additionalContactParams)) {
-      $this->callAPISuccess('contact', 'create', ['id' => $contactId] + $additionalContactParams);
+      $this->callAPISuccess('Contact', 'create', ['id' => $contactId] + $additionalContactParams);
     }
-    $contactsResult = $this->callApiSuccess('Contact', 'get', ['id' => $contactId, 'return' => ['id', 'phone_type_id', 'do_not_sms']]);
+    $contactsResult = $this->callApiSuccess('Contact', 'get', ['id' => $contactId, 'return' => ['id', 'phone_primary.phone_type_id', 'do_not_sms']]);
     $contactDetails = $contactsResult['values'];
-
+    $contactIds = [];
     // Get contactIds from contact details
-    foreach ($contactDetails as $contact) {
-      $contactIds[] = $contact['contact_id'];
+    foreach ($contactDetails as $index => $contact) {
+      $contactIds[] = $contact['id'];
+      $contactDetails[$index]['contact_id'] = $contact['id'];
+      $contactDetails[$index]['phone_type_id'] = $contact['phone_primary.phone_type_id'];
     }
 
     $activityParams['sms_text_message'] = 'text {contact.first_name}';
@@ -1573,12 +1594,11 @@ $text
   }
 
   /**
-   * @throws \CRM_Core_Exception
    */
   protected function createTestActivities(): void {
     $this->loadXMLDataSet(__DIR__ . '/activities_for_dashboard_count.xml');
     // Make changes to improve variation in php since the xml method is brittle & relies on option values being unchanged.
-    $this->callAPISuccess('Activity', 'create', ['id' => 12, 'activity_type_id' => 'Bulk Email']);
+    $this->callAPISuccess('Activity', 'create', ['id' => 12, 'activity_type_id:name' => 'Bulk Email']);
   }
 
   /**
@@ -1597,7 +1617,7 @@ $text
     // Create a contact and contactDetails array.
     $contactId = $this->individualCreate();
 
-    // create a logged in USER since the code references it for sendEmail user.
+    // create a logged-in USER since the code references it for sendEmail user.
     $this->createLoggedInUser();
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['view all contacts', 'access CiviCRM', 'access all cases and activities', 'administer CiviCase'];
 
@@ -1605,22 +1625,21 @@ $text
     $html = __FUNCTION__ . ' html {case.subject}';
     $text = __FUNCTION__ . ' text';
 
-    $mut = new CiviMailUtils($this, TRUE);
-    $form = $this->getCaseEmailTaskForm($contactId, [
+    $this->getTestForm('CRM_Case_Form_Task_Email', [
+      'to' => $contactId . '::' . 'email@example.com',
+      'from_email_address' => 'from@example.com',
       'subject' => $subject,
       'html_message' => $html,
       'text_message' => $text,
-      'to' => $contactId . '::' . 'email@example.com',
-    ]);
-    $form->postProcess();
+    ], ['cid' => $contactId, 'caseid' => $this->getCaseID()])
+      ->processForm();
     $activity = Activity::get()
       ->addSelect('id')
       ->addWhere('activity_type_id:name', '=', 'Email')
       ->execute()->first();
-    $activity = $this->callAPISuccess('Activity', 'getsingle', ['id' => $activity['id'], 'return' => ['case_id']]);
+    $activity = $this->callAPISuccess('Activity', 'getsingle', ['id' => $activity['id'], 'version' => 3, 'return' => ['case_id']]);
     $this->assertEquals($this->getCaseID(), $activity['case_id'][0], 'Activity case_id does not match.');
-    $mut->checkMailLog(['subject Case Subject']);
-    $mut->stop();
+    $this->assertMailSentContainingHeaderString('subject Case Subject');
   }
 
   /**
@@ -1646,20 +1665,17 @@ $text
     $html = __FUNCTION__ . ' html' . '{contact.display_name}';
     $text = __FUNCTION__ . ' text' . '{contact.display_name}';
 
-    /** @var CRM_Contact_Form_Task_Email $form */
-    $form = $this->getFormObject('CRM_Contact_Form_Task_Email', [
+    $this->getTestForm('CRM_Contact_Form_Task_Email', [
       'subject' => $subject,
       'html_message' => $html,
       'text_message' => $text,
       'campaign_id' => $campaign_id,
       'from_email_address' => 'from@example.com',
       'to' => $contactId1 . '::email@example.com,' . $contactId2 . '::email2@example.com',
-    ]);
-    $form->set('cid', $contactId1 . ',' . $contactId2);
-    $form->buildForm();
-    $form->postProcess();
+    ], ['cid' => $contactId1 . ',' . $contactId2])
+      ->processForm();
 
-    $result = $this->callAPISuccess('activity', 'get', ['campaign_id' => $campaign_id]);
+    $result = $this->callAPISuccess('Activity', 'get', ['campaign_id' => $campaign_id]);
     // An activity created for each of the two contacts
     $this->assertEquals(2, $result['count']);
     $id = 0;
@@ -1684,19 +1700,18 @@ $textValue
    * 3 recipients and an attachment.
    */
   public function testSendEmailWillReplaceTokensUniquelyForEachContact3(): void {
-    $contactId1 = $this->individualCreate(['last_name' => 'Red']);
-    $contactId2 = $this->individualCreate(['last_name' => 'Pink']);
-    $contactId3 = $this->individualCreate(['last_name' => 'Ochre']);
-
-    // create a logged in USER since the code references it for sendEmail user.
+    $contactId1 = $this->individualCreate(['last_name' => 'Red'], 1);
+    $contactId2 = $this->individualCreate(['last_name' => 'Pink'], 2);
+    $contactId3 = $this->individualCreate(['last_name' => 'Ochre'], 3);
+    $this->enableCiviCampaign();
+    // Create a logged-in USER since the code references it for sendEmail user.
     $this->createLoggedInUser();
-    $contact = $this->callAPISuccess('Contact', 'get', ['sequential' => 1, 'id' => ['IN' => [$contactId1, $contactId2, $contactId3]]]);
 
     // Add contact tokens in subject, html , text.
-    $subject = __FUNCTION__ . ' subject' . '{contact.display_name}';
-    $html = __FUNCTION__ . ' html' . '{contact.display_name}';
+    $subject = 'subject:' . '{contact.display_name}';
+    $html = 'html:' . '{contact.display_name}';
     // Check the smarty doesn't mess stuff up.
-    $text = ' text' . '{contact.display_name} {$contact.first_name}';
+    $text = 'text:' . '{contact.display_name} {$contact.first_name}';
 
     $filepath = Civi::paths()->getPath('[civicrm.files]/custom');
     $fileName = 'test_email_create.txt';
@@ -1704,15 +1719,15 @@ $textValue
     // Create a file.
     CRM_Utils_File::createFakeFile($filepath, 'aaaaaa', $fileName);
 
-    $form = $this->getFormObject('CRM_Contact_Form_Task_Email', [
+    $this->getTestForm('CRM_Contact_Form_Task_Email', [
       'subject' => $subject,
       'html_message' => $html,
       'text_message' => $text,
       'campaign_id' => $this->getCampaignID(),
       'from_email_address' => 'from@example.com',
-      'to' => $contactId1 . '::' . $contact['values'][0]['email'] . ','
-      . $contactId2 . '::' . $contact['values'][1]['email'] . ','
-      . $contactId3 . '::' . $contact['values'][2]['email'],
+      'to' => $contactId1 . '::anthony_anderson@civicrm.org,'
+      . $contactId2 . '::anthony_anderson@civicrm.org,'
+      . $contactId3 . '::anthony_anderson@civicrm.org',
       'attachFile_1' => [
         'uri' => $fileUri,
         'type' => 'text/plain',
@@ -1720,28 +1735,25 @@ $textValue
         'name' => $fileUri,
       ],
       'attachDesc_1' => '',
-    ]);
-    $form->set('cid', $contactId1 . ',' . $contactId2 . ',' . $contactId3);
-    $form->buildForm();
-    $form->postProcess();
+    ], ['cid' => $contactId1 . ',' . $contactId2 . ',' . $contactId3])
+      ->processForm();
 
     $result = $this->callAPISuccess('Activity', 'get', ['campaign_id' => $this->getCampaignID()]);
     // An activity created for each of the two contacts
     $this->assertEquals(3, $result['count']);
-    $id = 0;
     foreach ($result['values'] as $activity) {
-      $htmlValue = str_replace('{contact.display_name}', $contact['values'][$id]['display_name'], $html);
-      $textValue = str_replace('{contact.display_name}', $contact['values'][$id]['display_name'], $text);
-      $subjectValue = str_replace('{contact.display_name}', $contact['values'][$id]['display_name'], $subject);
+      $displayName = $this->callAPISuccessGetValue('Contact', ['id' => $this->ids['Contact'][$activity['id']], 'return' => 'display_name']);
+      $htmlValue = str_replace('{contact.display_name}', $displayName, $html);
+      $textValue = str_replace('{contact.display_name}', $displayName, $text);
+      $subjectValue = str_replace('{contact.display_name}', $displayName, $subject);
       $details = "-ALTERNATIVE ITEM 0-
 $htmlValue
 -ALTERNATIVE ITEM 1-
 $textValue
 -ALTERNATIVE END-
 ";
-      $this->assertEquals($activity['details'], $details, 'Activity details does not match.');
-      $this->assertEquals($activity['subject'], $subjectValue, 'Activity subject does not match.');
-      $id++;
+      $this->assertEquals($details, $activity['details'], 'Activity details does not match.');
+      $this->assertEquals($subjectValue, $activity['subject'], 'Activity subject does not match.');
     }
 
     unlink($fileUri);
@@ -1753,19 +1765,14 @@ $textValue
   public function testSendEmailDoesNotDuplicateAttachmentFileIDsForActivitiesCreated(): void {
     $contactId1 = $this->individualCreate(['last_name' => 'Red']);
     $contactId2 = $this->individualCreate(['last_name' => 'Pink']);
-
-    // create a logged in USER since the code references it for sendEmail user.
+    $this->enableCiviCampaign();
+    // create a logged-in USER since the code references it for sendEmail user.
     $this->createLoggedInUser();
-    $session = CRM_Core_Session::singleton();
-    $loggedInUser = $session->get('userID');
-    $contact = $this->callAPISuccess('Contact', 'get', ['sequential' => 1, 'id' => ['IN' => [$contactId1, $contactId2]]]);
-
-    // Create a campaign.
-    $result = $this->callAPISuccess('Campaign', 'create', [
-      'version' => $this->_apiversion,
-      'title' => __FUNCTION__ . ' campaign',
+    $contact = $this->callAPISuccess('Contact', 'get', [
+      'sequential' => 1,
+      'id' => ['IN' => [$contactId1, $contactId2]],
+      'return' => ['*', 'email_primary.email'],
     ]);
-    $campaign_id = $result['id'];
 
     $subject = __FUNCTION__ . ' subject';
     $html = __FUNCTION__ . ' html';
@@ -1777,14 +1784,14 @@ $textValue
     // Create a file.
     CRM_Utils_File::createFakeFile($filepath, 'Bananas do not bend themselves without a little help.', $fileName);
 
-    $form = $this->getFormObject('CRM_Contact_Form_Task_Email', [
+    $this->getTestForm('CRM_Contact_Form_Task_Email', [
       'subject' => $subject,
       'html_message' => $html,
       'text_message' => $text,
-      'campaign_id' => $campaign_id,
+      'campaign_id' => $this->getCampaignID(),
       'from_email_address' => 'from@example.com',
-      'to' => $contactId1 . '::' . $contact['values'][0]['email'] . ','
-      . $contactId2 . '::' . $contact['values'][1]['email'],
+      'to' => $contactId1 . '::' . $contact['values'][0]['email_primary.email'] . ','
+      . $contactId2 . '::' . $contact['values'][1]['email_primary.email'],
       'attachFile_1' => [
         'uri' => $fileUri,
         'type' => 'text/plain',
@@ -1792,12 +1799,10 @@ $textValue
         'name' => $fileUri,
       ],
       'attachDesc_1' => '',
-    ]);
-    $form->set('cid', $contactId1 . ',' . $contactId2);
-    $form->buildForm();
-    $form->postProcess();
+    ], ['cid' => $contactId1 . ',' . $contactId2])
+      ->processForm();
 
-    $result = $this->callAPISuccess('activity', 'get', ['campaign_id' => $campaign_id]);
+    $result = $this->callAPISuccess('Activity', 'get', ['campaign_id' => $this->getCampaignID()]);
     // An activity created for each of the two contacts, i.e two activities.
     $this->assertEquals(2, $result['count']);
     $activityIds = array_column($result['values'], 'id');
@@ -1805,6 +1810,7 @@ $textValue
       'return' => ['file_id'],
       'id' => ['IN' => $activityIds],
       'sequential' => 1,
+      'version' => 3,
     ]);
 
     // Verify that the that both activities are linked to the same File Id.
@@ -1819,8 +1825,7 @@ $textValue
    */
   protected function addCaseWithActivity() {
     // case is not enabled by default do that now.
-    $enableResult = CRM_Core_BAO_ConfigSetting::enableComponent('CiviCase');
-    $this->assertTrue($enableResult, 'Cannot enable CiviCase in line ' . __LINE__);
+    $this->assertTrue(CRM_Core_BAO_ConfigSetting::enableComponent('CiviCase'));
 
     // We need a minimal case setup.
     $case_type_id = civicrm_api3('CaseType', 'get', ['return' => 'id', 'name' => 'test_case_type'])['id'] ?? NULL;
@@ -1885,12 +1890,13 @@ $textValue
 
     // Create a scheduled 'Meeting' activity that belongs to this case, but is
     // assigned to contact #9
-    $activity_id = $this->callAPISuccess('Activity', 'create', [
+    $this->callAPISuccess('Activity', 'create', [
       'activity_type_id' => 'Meeting',
       'status_id' => 'Scheduled',
       'case_id' => $case_id,
       'source_contact_id' => 3,
       'assignee_id' => [9],
+      'version' => 3,
       'subject' => 'test meeting activity',
     ])['id'] ?? NULL;
   }
@@ -1917,8 +1923,7 @@ $textValue
    * @throws \CRM_Core_Exception
    */
   public function testTargetAssigneeVariations(array $do_first, array $do_second) {
-    // Originally wanted to put this in setUp() but it broke other tests.
-    $this->loggedInUserId = $this->createLoggedInUser();
+    $this->createLoggedInUser();
     for ($i = 1; $i <= 4; $i++) {
       $this->someContacts[$i] = $this->individualCreate([], $i - 1, TRUE);
     }
@@ -1926,7 +1931,7 @@ $textValue
     $params = [
       'activity_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Meeting'),
       'subject' => 'Test Meeting',
-      'source_contact_id' => $this->loggedInUserId,
+      'source_contact_id' => $this->ids['Contact']['logged_in'],
     ];
 
     // Create an activity first if specified.
@@ -2620,48 +2625,14 @@ $textValue
    *
    * @return int
    */
-  protected function getCampaignID() {
+  protected function getCampaignID(): int {
     if (!isset($this->ids['Campaign'][0])) {
-      $this->ids['Campaign'][0] = $this->callAPISuccess('Campaign', 'create', [
+      $this->createTestEntity('Campaign', [
         'title' => 'campaign',
-      ])['id'];
+        'name' => 'campaign',
+      ], 0)['id'];
     }
     return $this->ids['Campaign'][0];
-  }
-
-  /**
-   * @param int $contactId
-   * @param array $submittedValues
-   *
-   * @return \CRM_Case_Form_Task_Email
-   */
-  protected function getCaseEmailTaskForm(int $contactId, array $submittedValues): CRM_Case_Form_Task_Email {
-    $_REQUEST['cid'] = $contactId;
-    $_REQUEST['caseid'] = $this->getCaseID();
-    /** @var CRM_Case_Form_Task_Email $form */
-    $form = $this->getFormObject('CRM_Case_Form_Task_Email', array_merge([
-      'to' => $contactId . '::' . 'email@example.com',
-      'from_email_address' => 'from@example.com',
-    ], $submittedValues));
-    $form->buildForm();
-    return $form;
-  }
-
-  /**
-   * @param int $contactId
-   * @param array $submittedValues
-   *
-   * @return \CRM_Contact_Form_Task_Email
-   */
-  protected function getContactEmailTaskForm(int $contactId, array $submittedValues): CRM_Contact_Form_Task_Email {
-    $_REQUEST['cid'] = $contactId;
-    /** @var CRM_Contact_Form_Task_Email $form */
-    $form = $this->getFormObject('CRM_Contact_Form_Task_Email', array_merge([
-      'to' => $contactId . '::' . 'email@example.com',
-      'from_email_address' => 'from@example.com',
-    ], $submittedValues));
-    $form->buildForm();
-    return $form;
   }
 
 }

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTypeTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTypeTest.php
@@ -6,6 +6,13 @@
 class CRM_Activity_BAO_ActivityTypeTest extends CiviUnitTestCase {
 
   /**
+   * API version in use.
+   *
+   * @var int
+   */
+  protected $_apiversion = 4;
+
+  /**
    * Test ActivityType
    */
   public function testActivityType(): void {
@@ -16,7 +23,7 @@ class CRM_Activity_BAO_ActivityTypeTest extends CiviUnitTestCase {
       'is_active' => 1,
       'is_default' => 0,
     ];
-    $result = $this->callAPISuccess('option_value', 'create', $actParams);
+    $result = $this->callAPISuccess('OptionValue', 'create', $actParams);
 
     $activity_type_id = $result['values'][$result['id']]['value'];
 
@@ -24,8 +31,8 @@ class CRM_Activity_BAO_ActivityTypeTest extends CiviUnitTestCase {
     $activityTypeObj = new CRM_Activity_BAO_ActivityType($activity_type_id);
     $keyValuePair = $activityTypeObj->getActivityType();
 
-    $this->assertEquals($keyValuePair['machineName'], 'abc123');
-    $this->assertEquals($keyValuePair['displayLabel'], 'Write Unit Test');
+    $this->assertEquals('abc123', $keyValuePair['machineName']);
+    $this->assertEquals('Write Unit Test', $keyValuePair['displayLabel']);
 
     // cleanup
     $this->callAPISuccess('option_value', 'delete', ['id' => $result['id']]);

--- a/tests/phpunit/CRM/Activity/Form/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Form/ActivityTest.php
@@ -11,6 +11,13 @@ use Civi\Test\Invasive;
  */
 class CRM_Activity_Form_ActivityTest extends CiviUnitTestCase {
 
+  /**
+   * API version in use.
+   *
+   * @var int
+   */
+  protected $_apiversion = 4;
+
   use FormTrait;
 
   protected $assignee1;
@@ -190,6 +197,7 @@ class CRM_Activity_Form_ActivityTest extends CiviUnitTestCase {
       'entity_id' => $activity['id'],
       'entity_table' => 'civicrm_activity',
       'content' => 'delete me',
+      'version' => 3,
     ]);
     $this->assertNotEmpty($attachment['id']);
 

--- a/tests/phpunit/CRM/Activity/Form/ActivityViewTest.php
+++ b/tests/phpunit/CRM/Activity/Form/ActivityViewTest.php
@@ -6,6 +6,13 @@
 class CRM_Activity_Form_ActivityViewTest extends CiviUnitTestCase {
 
   /**
+   * API version in use.
+   *
+   * @var int
+   */
+  protected $_apiversion = 4;
+
+  /**
    * @var int
    */
   protected $source_contact_id;
@@ -69,7 +76,7 @@ class CRM_Activity_Form_ActivityViewTest extends CiviUnitTestCase {
     $activity = $this->activityCreate();
 
     // $activity doesn't contain everything we need, so do another get call
-    $activityMoreInfo = $this->callAPISuccess('activity', 'getsingle', ['id' => $activity['id']]);
+    $activityMoreInfo = $this->callAPISuccess('Activity', 'getsingle', ['id' => $activity['id'], 'version' => 3]);
 
     // do preProcess
     $activityViewForm = new CRM_Activity_Form_ActivityView();

--- a/tests/phpunit/CRM/Activity/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Activity/Form/SearchTest.php
@@ -7,6 +7,13 @@
 class CRM_Activity_Form_SearchTest extends CiviUnitTestCase {
 
   /**
+   * API version in use.
+   *
+   * @var int
+   */
+  protected $_apiversion = 4;
+
+  /**
    * @var int
    */
   protected $individualID;

--- a/tests/phpunit/CRM/Activity/Form/Task/PDFTest.php
+++ b/tests/phpunit/CRM/Activity/Form/Task/PDFTest.php
@@ -9,6 +9,13 @@ use Civi\Token\TokenProcessor;
 class CRM_Activity_Form_Task_PDFTest extends CiviUnitTestCase {
 
   /**
+   * API version in use.
+   *
+   * @var int
+   */
+  protected $_apiversion = 4;
+
+  /**
    * Set up for tests.
    */
   public function setUp(): void {

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1486,12 +1486,12 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * @return array
    *   ids of created objects
    */
-  public function entityCustomGroupWithSingleStringMultiSelectFieldCreate($function, $filename) {
+  public function entityCustomGroupWithSingleStringMultiSelectFieldCreate($function, $filename): array {
     $params = ['title' => $function];
     $entity = substr(basename($filename), 0, strlen(basename($filename)) - 8);
     $params['extends'] = $entity ?: 'Contact';
     $customGroup = $this->customGroupCreate($params);
-    $customField = $this->customFieldCreate(['custom_group_id' => $customGroup['id'], 'label' => $function, 'html_type' => 'Multi-Select', 'default_value' => 1]);
+    $customField = $this->customFieldCreate(['version' => 3, 'custom_group_id' => $customGroup['id'], 'label' => $function, 'html_type' => 'Multi-Select', 'default_value' => 1]);
     CRM_Core_PseudoConstant::flush();
     $options = [
       'defaultValue' => 'Default Value',
@@ -1500,7 +1500,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       'NULL' => 'NULL',
     ];
     $custom_field_params = ['sequential' => 1, 'id' => $customField['id']];
-    $custom_field_api_result = $this->callAPISuccess('custom_field', 'get', $custom_field_params);
+    $custom_field_api_result = $this->callAPISuccess('CustomField', 'get', $custom_field_params);
     $this->assertNotEmpty($custom_field_api_result['values'][0]['option_group_id']);
     $option_group_params = ['sequential' => 1, 'id' => $custom_field_api_result['values'][0]['option_group_id']];
     $option_group_result = $this->callAPISuccess('OptionGroup', 'get', $option_group_params);


### PR DESCRIPTION
Overview
----------------------------------------
Move some CRM tests to use apiv4

Before
----------------------------------------
We are calling apiv3 way too much in tests due to the convenience of helpers in the `apiv3testTrait` - there is no quick fix but at least passing v4 more often & fixing keys in the direction of v4 is the right direction

After
----------------------------------------
Some CRM_Activity tests  using 4 not 3

Technical Details
----------------------------------------

Comments
----------------------------------------
