### PR TITLE
support 'current user' as value in FB

### DIFF
--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -264,7 +264,7 @@ trait DAOActionTrait {
 
       // Match contact id to strings like "user_contact_id"
       // FIXME handle arrays for multi-value contact reference fields, etc.
-      if ($field['data_type'] === 'ContactReference' && is_string($value) && !is_numeric($value)) {
+      if (in_array($field['data_type'], ['ContactReference', 'EntityReference']) && is_string($value) && !is_numeric($value)) {
         // FIXME decouple from v3 API
         require_once 'api/v3/utils.php';
         $value = \_civicrm_api3_resolve_contactID($value);


### PR DESCRIPTION
Overview
----------------------------------------
If you set a value on a FB form to "Select Current User", the value isn't saved.

In the attached screenshot, I've enabled CiviGrant and created a custom field for Grants of type EntityReference (to contacts) .  When I choose "Select Current User" nothing happens.

![Selection_2245](https://github.com/civicrm/civicrm-core/assets/1796012/ad921c62-2961-479f-a1a4-c3bb828024af)

Before
----------------------------------------
Value not saved.

After
----------------------------------------
Value is saved.

Comments
----------------------------------------
I expected the fix to be in `Civi\Api4\Utils\FormattingUtil::formatInputValue()` because that's how API4 handles this, but that function isn't called on these fields, this one is.