### PR TITLE
REF: Replace deprecate getMembershipTypeDetails with API4

### DIFF
--- a/api/v3/Membership.php
+++ b/api/v3/Membership.php
@@ -252,13 +252,13 @@ function _civicrm_api3_membership_relationsship_get_customv2behaviour(&$params, 
   $relationships = [];
   foreach ($membershipValues as $membershipId => $values) {
     // populate the membership type name for the membership type id
-    $membershipType = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($values['membership_type_id']) ?? [];
+    $membershipType = CRM_Member_BAO_MembershipType::getMembershipType($values['membership_type_id']) ?? [];
 
     if (!empty($membershipType)) {
       $membershipValues[$membershipId]['membership_name'] = $membershipType['name'];
 
       if (!empty($membershipType['relationship_type_id'])) {
-        $relationships[$membershipType['relationship_type_id']] = $membershipId;
+        $relationships[reset($membershipType['relationship_type_id'])] = $membershipId;
       }
     }
 

--- a/tests/phpunit/CRM/Member/BAO/MembershipTypeTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTypeTest.php
@@ -182,7 +182,12 @@ class CRM_Member_BAO_MembershipTypeTest extends CiviUnitTestCase {
    */
   public function testGetMembershipTypeDetails(): void {
     $membershipTypeID = $this->createGeneralMembershipType();
-    $result = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($membershipTypeID);
+    $result = MembershipType::get(FALSE)
+      ->addSelect('id', 'name', 'duration_unit')
+      ->addWhere('id', '=', $membershipTypeID)
+      ->addWhere('is_active', '=', TRUE)
+      ->execute()
+      ->first();
 
     $this->assertEquals('General', $result['name'], 'Verify membership type details.');
     $this->assertEquals('year', $result['duration_unit'], 'Verify membership types details.');


### PR DESCRIPTION
Overview
----------------------------------------
Replaces some instances of deprecated function `CRM_Member_BAO_MembershipType::getMembershipTypeDetails` with API4.

Before
----------------------------------------
Deprecated in use

After
----------------------------------------
Less deprecated in use.

Technical Details
----------------------------------------


Comments
----------------------------------------
Originally the deprecated function suggested using another function but that seems pointless when we can easily retrieve through API4.
