### PR TITLE
CRM_Utils_Cache_Tiered - Fix test failure on Standalone

### DIFF
--- a/CRM/Utils/Cache/Tiered.php
+++ b/CRM/Utils/Cache/Tiered.php
@@ -164,6 +164,9 @@ class CRM_Utils_Cache_Tiered implements CRM_Utils_Cache_Interface {
       return $this->maxTimeouts[$tierNum];
     }
     else {
+      if ($ttl instanceof \DateInterval) {
+        $ttl = date_add(new DateTime(), $ttl)->getTimestamp() - time();
+      }
       return min($this->maxTimeouts[$tierNum], $ttl);
     }
   }


### PR DESCRIPTION
Overview
----------

The corresponding test, `E2E_Cache_TieredTest`, delivers inconsistent results -- depending on UF.  (Passes on D7; fails on Standalone).  This fixes the behavior.

Before
------

Fails on Standalone ([example](https://test.civicrm.org/job/CiviCRM-Test-QLow/7106/testReport/(root)/E2E_Cache_TieredTest/testSetTtl/))

After
-----

Passes on Standalone

Technical Details
-----------------

* When trying to determine the effective TTL of a cache-hierarchy, it compares the TTL's of each cache-layer.
* Those TTL's can be expressed as `int` (*seconds to live*) or `DateTimeInterval`.
* The comparison operation (`min($a, $b)`) is ill-defined for `DateTimeInterval`.
* This fix normalizes the TTL so that comparisons use consistent `int`.
* I'm not entirely certain why it was passing in D7. I suspect it has to do with the varying policies re:PHP warnings/notices when running E2E tests (e.g. D7 hides the problem, but Standalone presents it).