### PR TITLE
dev/core#5118 Add support for trailing conditional bracket

### DIFF
--- a/tests/phpunit/CRM/Contact/BAO/IndividualTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/IndividualTest.php
@@ -128,7 +128,11 @@ class CRM_Contact_BAO_IndividualTest extends CiviUnitTestCase {
   public static function displayFormatCases(): array {
     return [
       'Nick name with tilde' => ['{contact.first_name}{ }{contact.last_name}{ ~ }{contact.nick_name}', 'Michael Jackson ~ Mick'],
-      'Empty nick name' => ['{contact.first_name}{ }{contact.last_name}{ ~ }{contact.nick_name}', 'Michael Jackson', ['nick_name' => '']],
+      'Nick name with tilde, empty nick' => ['{contact.first_name}{ }{contact.last_name}{ ~ }{contact.nick_name}', 'Michael Jackson', ['nick_name' => '']],
+      'Nick name surrounding brackets' => ['{contact.first_name}{ }{ (}{contact.nick_name}{) }{contact.last_name}', 'Michael (Mick) Jackson'],
+      'Nick name surrounding brackets, empty nick' => ['{contact.first_name}{ }{ (}{contact.nick_name}{) }{contact.last_name}', 'Michael Jackson', ['nick_name' => '']],
+      'Nick name surrounding brackets at end' => ['{contact.first_name}{ }{contact.last_name}{ (}{contact.nick_name}{)}', 'Michael Jackson (Mick)'],
+      'Nick name surrounding brackets at end, empty nick' => ['{contact.first_name}{ }{contact.last_name}{ (}{contact.nick_name}{)}', 'Michael Jackson', ['nick_name' => '']],
       'No Nick Name but Prefix' => ['{contact.individual_prefix}{ }{contact.first_name}{ }{contact.middle_name}{ }{contact.last_name}{ }{contact.individual_suffix}{ ~ }{contact.nick_name}', 'Mr. Michael Jackson Jr.', ['nick_name' => '']],
     ];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Add support for trailing conditional bracket in tokens - eg
 `{contact.first_name}{ }{contact.last_name}{ (}{contact.nick_name}{)}`

Alternative to PR #29954 

Before
----------------------------------------

After
----------------------------------------


Technical Details
----------------------------------------
This replaces all the code evaluating `{ }` and its variants in tokens. Hopefully this is easier to comprehend.

Additional test cases have been added but would be good to add more from real world cases.

Comments
----------------------------------------

