### PR TITLE
dev/core#5152 dev/core#5152 Fix customDataBlock to convert false to 'false'

### DIFF
--- a/templates/CRM/common/customDataBlock.tpl
+++ b/templates/CRM/common/customDataBlock.tpl
@@ -3,6 +3,13 @@
   <div id="customData_{$customDataType}" class="crm-customData-block"></div>
   {*include custom data js file*}
   {include file="CRM/common/customData.tpl"}
+  {* convert falsey values to NULL so that the default of 'false' works lower down (it's a string not a bool lower down) *}
+  {if !$customDataSubType}
+    {assign value=null var=customDataSubType}
+  {/if}
+  {if !$cid}
+    {assign value=null var=cid}
+  {/if}
   {literal}
   <script type="text/javascript">
     CRM.$(function($) {


### PR DESCRIPTION
We need smarty to print a string to the js to get valid js.

This is leading to js causing both https://lab.civicrm.org/dev/core/-/issues/5152 and https://lab.civicrm.org/dev/core/-/issues/5173