### PR TITLE
dev/core#5185 Fix smart group error with deleted custom fields

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4764,9 +4764,8 @@ civicrm_relationship.start_date > {$today}
       return FALSE;
     }
     try {
-      $customFieldData = CRM_Core_BAO_CustomField::getFieldObject($customFieldID);
-      $customFieldDataType = $customFieldData->data_type;
-      if ('Date' == $customFieldDataType) {
+      $customFieldData = CRM_Core_BAO_CustomField::getField($customFieldID);
+      if ($customFieldData && 'Date' == $customFieldData['data_type']) {
         return TRUE;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fix smart group error with deleted custom fields

Before
----------------------------------------
A Smart Group with deleted custom date field in form values resulted in a fatal error, which in our case, halted the cron from running.

To replicate
- Create a smart group with custom date field as a criteria.
- Delete the custom field.
- Visit the group contact page - `/civicrm/group/search?reset=1&force=1&context=smog&gid=<gid>` => Error.
<details>
<summary>Backtrace</summary>

```
TypeError: array_key_exists(): Argument #2 ($array) must be of type array, null given in CRM_Core_DAO->copyValues() (line 848 of .../vendor/civicrm/civicrm-core/CRM/Core/DAO.php)
#0 .../vendor/civicrm/civicrm-core/CRM/Core/BAO/CustomField.php(566): CRM_Core_DAO->copyValues()
#1 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/Query.php(4774): CRM_Core_BAO_CustomField::getFieldObject()
#2 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/SavedSearch.php(131): CRM_Contact_BAO_Query::isCustomDateField()
#3 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/GroupContactCache.php(567): CRM_Contact_BAO_SavedSearch::getFormValues()
#4 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/GroupContactCache.php(795): CRM_Contact_BAO_GroupContactCache::getQueryObjectSQL()
#5 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/GroupContactCache.php(632): CRM_Contact_BAO_GroupContactCache::insertGroupContactsIntoTempTable()
#6 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/GroupContactCache.php(374): CRM_Contact_BAO_GroupContactCache::buildGroupContactTempTable()
#7 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/Query.php(3173): CRM_Contact_BAO_GroupContactCache::load()
#8 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/Query.php(3074): CRM_Contact_BAO_Query->addGroupContactCache()
#9 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/Query.php(1836): CRM_Contact_BAO_Query->group()
#10 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/Query.php(2074): CRM_Contact_BAO_Query->whereClauseSingle()
#11 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/Query.php(575): CRM_Contact_BAO_Query->whereClause()
#12 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/Query.php(524): CRM_Contact_BAO_Query->initialize()
#13 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/GroupContactCache.php(601): CRM_Contact_BAO_Query->__construct()
#14 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/GroupContactCache.php(795): CRM_Contact_BAO_GroupContactCache::getQueryObjectSQL()
#15 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/GroupContactCache.php(632): CRM_Contact_BAO_GroupContactCache::insertGroupContactsIntoTempTable()
#16 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/GroupContactCache.php(374): CRM_Contact_BAO_GroupContactCache::buildGroupContactTempTable()
#17 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/Query.php(3173): CRM_Contact_BAO_GroupContactCache::load()
#18 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/Query.php(3074): CRM_Contact_BAO_Query->addGroupContactCache()
#19 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/Query.php(1836): CRM_Contact_BAO_Query->group()
#20 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/Query.php(2074): CRM_Contact_BAO_Query->whereClauseSingle()
#21 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/Query.php(575): CRM_Contact_BAO_Query->whereClause()
#22 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/Query.php(524): CRM_Contact_BAO_Query->initialize()
#23 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/GroupContactCache.php(601): CRM_Contact_BAO_Query->__construct()
#24 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/GroupContactCache.php(795): CRM_Contact_BAO_GroupContactCache::getQueryObjectSQL()
#25 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/GroupContactCache.php(632): CRM_Contact_BAO_GroupContactCache::insertGroupContactsIntoTempTable()
#26 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/GroupContactCache.php(374): CRM_Contact_BAO_GroupContactCache::buildGroupContactTempTable()
#27 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/Query.php(3173): CRM_Contact_BAO_GroupContactCache::load()
#28 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/Query.php(3074): CRM_Contact_BAO_Query->addGroupContactCache()
#29 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/Query.php(1836): CRM_Contact_BAO_Query->group()
#30 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/Query.php(2074): CRM_Contact_BAO_Query->whereClauseSingle()
#31 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/Query.php(575): CRM_Contact_BAO_Query->whereClause()
#32 .../vendor/civicrm/civicrm-core/CRM/Contact/BAO/Query.php(524): CRM_Contact_BAO_Query->initialize()
#33 .../vendor/civicrm/civicrm-core/CRM/Contact/Selector.php(224): CRM_Contact_BAO_Query->__construct()
#34 .../vendor/civicrm/civicrm-core/CRM/Contact/Form/Search.php(704): CRM_Contact_Selector->__construct()
#35 .../vendor/civicrm/civicrm-core/CRM/Contact/Form/Search/Advanced.php(50): CRM_Contact_Form_Search->preProcess()
#36 .../vendor/civicrm/civicrm-core/CRM/Core/Form.php(753): CRM_Contact_Form_Search_Advanced->preProcess()
#37 .../vendor/civicrm/civicrm-core/CRM/Core/QuickForm/Action/Display.php(76): CRM_Core_Form->buildForm()
#38 .../vendor/civicrm/civicrm-packages/HTML/QuickForm/Controller.php(203): CRM_Core_QuickForm_Action_Display->perform()
#39 .../vendor/civicrm/civicrm-packages/HTML/QuickForm/Page.php(103): HTML_QuickForm_Controller->handle()
#40 .../vendor/civicrm/civicrm-core/CRM/Core/Controller.php(355): HTML_QuickForm_Page->handle()
#41 .../vendor/civicrm/civicrm-core/CRM/Core/Invoke.php(325): CRM_Core_Controller->run()
#42 .../vendor/civicrm/civicrm-core/CRM/Core/Invoke.php(69): CRM_Core_Invoke::runItem()
#43 .../vendor/civicrm/civicrm-core/CRM/Core/Invoke.php(36): CRM_Core_Invoke::_invoke()
#44 .../web/modules/contrib/civicrm/src/Civicrm.php(88): CRM_Core_Invoke::invoke()
#45 .../web/modules/contrib/civicrm/src/Controller/CivicrmController.php(83): Drupal\civicrm\Civicrm->invoke()
#46 [internal function]: Drupal\civicrm\Controller\CivicrmController->main()
#47 .../web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(123): call_user_func_array()
#48 .../web/core/lib/Drupal/Core/Render/Renderer.php(580): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#49 .../web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(124): Drupal\Core\Render\Renderer->executeInRenderContext()
#50 .../web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(97): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext()
#51 .../vendor/symfony/http-kernel/HttpKernel.php(169): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#52 .../vendor/symfony/http-kernel/HttpKernel.php(81): Symfony\Component\HttpKernel\HttpKernel->handleRaw()
#53 .../web/modules/contrib/redirect_after_login/src/RedirectMiddleware.php(46): Symfony\Component\HttpKernel\HttpKernel->handle()
#54 .../web/modules/contrib/simple_oauth/src/HttpMiddleware/BasicAuthSwap.php(68): Drupal\redirect_after_login\RedirectMiddleware->handle()
#55 .../web/core/lib/Drupal/Core/StackMiddleware/Session.php(58): Drupal\simple_oauth\HttpMiddleware\BasicAuthSwap->handle()
#56 .../web/core/lib/Drupal/Core/StackMiddleware/KernelPreHandle.php(48): Drupal\Core\StackMiddleware\Session->handle()
#57 .../web/core/modules/page_cache/src/StackMiddleware/PageCache.php(106): Drupal\Core\StackMiddleware\KernelPreHandle->handle()
#58 .../web/core/modules/page_cache/src/StackMiddleware/PageCache.php(85): Drupal\page_cache\StackMiddleware\PageCache->pass()
#59 .../web/modules/contrib/webform_product/src/RedirectMiddleware.php(42): Drupal\page_cache\StackMiddleware\PageCache->handle()
#60 .../web/core/lib/Drupal/Core/StackMiddleware/ReverseProxyMiddleware.php(48): Drupal\webform_product\RedirectMiddleware->handle()
#61 .../web/core/lib/Drupal/Core/StackMiddleware/NegotiationMiddleware.php(51): Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle()
#62 .../vendor/stack/builder/src/Stack/StackedHttpKernel.php(23): Drupal\Core\StackMiddleware\NegotiationMiddleware->handle()
#63 .../web/core/lib/Drupal/Core/DrupalKernel.php(718): Stack\StackedHttpKernel->handle()
#64 .../web/index.php(19): Drupal\Core\DrupalKernel->handle()
#65 {main}
```
</details>


This was caused after we upgraded civicrm  possibly relates to this PR https://github.com/civicrm/civicrm-core/pull/29032/files#diff-c3c751ad9f31137a69214a8c0dcedd2fc3788f00431497be6c087d9fe5ca2687R564 was merged.

___(Update/Clarification)___: The problem can happen _even if the smart-group and the custom-field are unrelated_ to each other, and it only happens if the smart-group was created via traditional search (e.g. "Advanced Search" not "Search Kit"). It arises because the "Advanced Search: Create smart group" stores a snapshot of `formValues`, which may include empty references to unrelated fields.

After
----------------------------------------
Fixed. 

Technical Details
----------------------------------------
Replaces the deprecated `getFieldObject()` with `getField()`

