### PR TITLE
(dev/core#5183) Search Tasks - Actions incorrectly apply to all records in database

### DIFF
--- a/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
+++ b/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
@@ -17,7 +17,7 @@ CRM.$(function($) {
   $('.crm-ajax-accordion').on('click', 'summary:not(.active)', function() {
     loadPanes($(this).attr('id'));
   });
-  $('.crm-ajax-accordion[open] summary').each(function() {
+  $('.crm-ajax-accordion:not(.collapsed) summary').each(function() {
     loadPanes($(this).attr('id'));
   });
   $('.crm-ajax-accordion').on('click', '.crm-close-accordion', function() {


### PR DESCRIPTION
# Overview

For steps to reproduce, see https://lab.civicrm.org/dev/core/-/issues/5183 and https://lab.civicrm.org/dev/core/-/issues/5169

This appears to have regressed from an update to `AdvancedCritera.tpl` in a342352e1de92ff513a58e18146e80d7068f4100.

Longer discussion/diagnostic thread: https://chat.civicrm.org/civicrm/pl/44ft1ojh8p89j8oky3matqpa9o

# Comparison (General)

* __Circa 5.71__: If you use a Search Task and apply it to all matching records, it actually does that.
* __Circa 5.72-stable/5.73-rc__: If you use a Search Task and apply it to all matching records, it actually applies the action to all records in the database. The search-criteria are ignored
* __With 5.73+patch__: If you use a Search Task and apply it to all matching records, it actually does that.

# Comparison (Technical Details)

* __Circa 5.71__: When you view search-results, there are collapsed panes which define the search-criteria. These panes are quietly prefetched.
* __Circa 5.72__: The search-criteria panes are not fetched. So the search-criteria are not available to be propagated to the next step.
* __Crica 5.73+patch__: Search-criteria panes are once again prefetched

