### PR TITLE
Remove calls to deprecated core function from event cart

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2499,6 +2499,9 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
   /**
    * Fetch the object and store the values in the values array.
    *
+   * @deprecated avoid this function, no planned removed at this stage as there
+   * are still core callers.
+   *
    * @param array $params
    *   Input parameters to find object.
    * @param array $values

--- a/ext/eventcart/CRM/Event/Cart/BAO/Cart.php
+++ b/ext/eventcart/CRM/Event/Cart/BAO/Cart.php
@@ -162,6 +162,7 @@ class CRM_Event_Cart_BAO_Cart extends CRM_Event_Cart_DAO_Cart {
     //return CRM_Event_Cart_BAO_EventInCart::find_all_by_params( array('main_conference_event_id'
     $all = [];
     foreach ($this->events_in_carts as $event_in_cart) {
+      /* @var \CRM_Event_Cart_BAO_EventInCart $event_in_cart */
       if (!$event_in_cart->is_child_event()) {
         $all[] = $event_in_cart;
       }
@@ -214,6 +215,7 @@ class CRM_Event_Cart_BAO_Cart extends CRM_Event_Cart_DAO_Cart {
   public function get_subparticipants($main_participant) {
     $subparticipants = [];
     foreach ($this->events_in_carts as $event_in_cart) {
+      /* @var \CRM_Event_Cart_BAO_EventInCart $event_in_cart */
       if ($event_in_cart->is_child_event($main_participant->event_id)) {
         foreach ($event_in_cart->participants as $participant) {
           if ($participant->contact_id == $main_participant->contact_id) {
@@ -229,7 +231,7 @@ class CRM_Event_Cart_BAO_Cart extends CRM_Event_Cart_DAO_Cart {
   /**
    * @param int $event_id
    *
-   * @return mixed
+   * @return \CRM_Event_Cart_BAO_EventInCart|null
    */
   public function get_event_in_cart_by_event_id($event_id) {
     return $this->events_in_carts[$event_id] ?? NULL;

--- a/ext/eventcart/CRM/Event/Cart/BAO/EventInCart.php
+++ b/ext/eventcart/CRM/Event/Cart/BAO/EventInCart.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Api4\Contact;
+
 /**
  * Class CRM_Event_Cart_BAO_EventInCart
  */
@@ -44,12 +46,11 @@ class CRM_Event_Cart_BAO_EventInCart extends CRM_Event_Cart_DAO_EventInCart impl
     $this->load_associations();
     $contacts_to_delete = [];
     foreach ($this->participants as $participant) {
-      $defaults = [];
-      $params = ['id' => $participant->contact_id];
-      $temporary_contact = CRM_Contact_BAO_Contact::retrieve($params, $defaults);
-
-      if ($temporary_contact->is_deleted) {
-        $contacts_to_delete[$temporary_contact->id] = 1;
+      // Selecting the already deleted ones because? But, it's how it has been....
+      if (Contact::get(FALSE)
+        ->addWhere('id', '=', $participant->contact_id)
+        ->addWhere('is_deleted', '=', TRUE)->execute()->first()) {
+        $contacts_to_delete[$participant->contact_id] = 1;
       }
       $participant->delete();
     }

--- a/ext/eventcart/CRM/Event/Cart/Form/Cart.php
+++ b/ext/eventcart/CRM/Event/Cart/Form/Cart.php
@@ -164,4 +164,42 @@ class CRM_Event_Cart_Form_Cart extends CRM_Core_Form {
     return $container['values'][$page_name];
   }
 
+  /**
+   *
+   * @deprecated copy of previously shared code.
+   *
+   * @param array $params
+   *   (reference ) an assoc array of name/value pairs.
+   * @param array $defaults
+   *   (reference ) an assoc array to hold the name / value pairs.
+   *                        in a hierarchical manner
+   * @param bool $microformat
+   *   For location in microformat.
+   *
+   * @return CRM_Contact_BAO_Contact
+   */
+  protected function retrieveContact(&$params, &$defaults = [], $microformat = FALSE) {
+    if (array_key_exists('contact_id', $params)) {
+      $params['id'] = $params['contact_id'];
+    }
+    elseif (array_key_exists('id', $params)) {
+      $params['contact_id'] = $params['id'];
+    }
+
+    $contact = new CRM_Contact_BAO_Contact();
+
+    $contact->copyValues($params);
+
+    if ($contact->find(TRUE)) {
+
+      CRM_Core_DAO::storeValues($contact, $values);
+      $contact->contact_id = $contact->id;
+    }
+
+    unset($params['id']);
+    $contact->email = $defaults['email'] = CRM_Core_BAO_Email::getValues(['contact_id' => $params['contact_id']]);
+    $contact->address = $defaults['address'] = CRM_Core_BAO_Address::getValues(['contact_id' => $params['contact_id']], $microformat);
+    return $contact;
+  }
+
 }

--- a/ext/eventcart/CRM/Event/Cart/Form/Checkout/ConferenceEvents.php
+++ b/ext/eventcart/CRM/Event/Cart/Form/Checkout/ConferenceEvents.php
@@ -116,6 +116,7 @@ EOS;
     $main_event_in_cart = $this->cart->get_event_in_cart_by_event_id($this->conference_event->id);
 
     foreach ($this->cart->events_in_carts as $event_in_cart) {
+      /* @var \CRM_Event_Cart_BAO_EventInCart $event_in_cart */
       if ($event_in_cart->event->parent_event_id == $this->conference_event->id) {
         $event_in_cart->remove_participant_by_contact_id($this->contact_id);
         if (empty($event_in_cart->participants)) {

--- a/ext/eventcart/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.php
+++ b/ext/eventcart/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.php
@@ -8,13 +8,6 @@ class CRM_Event_Cart_Form_Checkout_ParticipantsAndPrices extends CRM_Event_Cart_
   public $_values = NULL;
 
   /**
-   * Pre process function.
-   */
-  public function preProcess() {
-    parent::preProcess();
-  }
-
-  /**
    * Build quick form.
    */
   public function buildQuickForm() {
@@ -43,7 +36,7 @@ class CRM_Event_Cart_Form_Checkout_ParticipantsAndPrices extends CRM_Event_Cart_
 
     if ($this->getContactID()) {
       $params = ['id' => $this->getContactID()];
-      $contact = CRM_Contact_BAO_Contact::retrieve($params, $defaults);
+      $contact = $this->retrieveContact($params, $defaults);
       $contact_values = [];
       CRM_Core_DAO::storeValues($contact, $contact_values);
       $this->assign('contact', $contact_values);
@@ -195,7 +188,7 @@ class CRM_Event_Cart_Form_Checkout_ParticipantsAndPrices extends CRM_Event_Cart_
       ) {
         $defaults = [];
         $params = ['id' => $this->getContactID()];
-        $contact = CRM_Contact_BAO_Contact::retrieve($params, $defaults);
+        $contact = $this->retrieveContact($params, $defaults);
         $participant->contact_id = $this->getContactID();
         $participant->save();
         $participant->email = self::primary_email_from_contact($contact);
@@ -260,7 +253,7 @@ class CRM_Event_Cart_Form_Checkout_ParticipantsAndPrices extends CRM_Event_Cart_
         if ($participant->contact_id && $contact_id != $participant->contact_id) {
           $defaults = [];
           $params = ['id' => $participant->contact_id];
-          $temporary_contact = CRM_Contact_BAO_Contact::retrieve($params, $defaults);
+          $temporary_contact = $this->retrieveContact($params, $defaults);
 
           foreach ($this->cart->get_subparticipants($participant) as $subparticipant) {
             $subparticipant->contact_id = $contact_id;

--- a/ext/eventcart/CRM/Event/Cart/Form/Checkout/ThankYou.php
+++ b/ext/eventcart/CRM/Event/Cart/Form/Checkout/ThankYou.php
@@ -9,6 +9,7 @@ class CRM_Event_Cart_Form_Checkout_ThankYou extends CRM_Event_Cart_Form_Cart {
 
   public function buildLineItems() {
     foreach ($this->cart->events_in_carts as $event_in_cart) {
+      /* @var \CRM_Event_Cart_BAO_EventInCart $event_in_cart */
       $event_in_cart->load_location();
     }
     $line_items = $this->get('line_items');

--- a/ext/eventcart/CRM/Event/Cart/StateMachine/Checkout.php
+++ b/ext/eventcart/CRM/Event/Cart/StateMachine/Checkout.php
@@ -21,6 +21,7 @@ class CRM_Event_Cart_StateMachine_Checkout extends CRM_Core_StateMachine {
     $pages = [];
     $pages['CRM_Event_Cart_Form_Checkout_ParticipantsAndPrices'] = NULL;
     foreach ($cart->events_in_carts as $event_in_cart) {
+      /* @var \CRM_Event_Cart_BAO_EventInCart $event_in_cart */
       if ($event_in_cart->is_parent_event()) {
         foreach ($event_in_cart->participants as $participant) {
           $pages["CRM_Event_Cart_Form_Checkout_ConferenceEvents_{$event_in_cart->event_id}_{$participant->id}"] = [


### PR DESCRIPTION
Overview
----------------------------------------
Remove calls to deprecated core function from event cart

Before
----------------------------------------
Eventcard is thought to be unused - so we don't want to be making it hard to maintain a confusing core function because of it calling it -

After
----------------------------------------
 this takes a copy of the salient parts of `Contact:retrieve` into `eventcart` & calls that instead

Technical Details
----------------------------------------
Comments
----------------------------------------