### PR TITLE
dev/user-interface#72 remove html that got superceded

### DIFF
--- a/templates/CRM/Financial/Form/FinancialAccount.tpl
+++ b/templates/CRM/Financial/Form/FinancialAccount.tpl
@@ -75,9 +75,7 @@
       </td>
     </tr>
   </table>
-  <details id="financial_account_custom_field_extension_section" class="crm-accordion-wrapper crm-financial-account-panel" open>
-    {include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='FinancialAccount' customDataSubType=false cid=false}
-  </details>
+  {include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='FinancialAccount' customDataSubType=false cid=false}
 {/if}
-  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="botttom"}</div>
+<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="botttom"}</div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/user-interface/-/issues/72

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/8660e250-5e73-4e9b-bd64-b292da311bac)

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/24a06f1a-b98a-4bbc-adc2-601fe2d36400)

Technical Details
----------------------------------------
The change to the include happened about the same time as the markup change & made the latter un-required

Comments
----------------------------------------
