### PR TITLE
Call hooks when recording a trackable URL open

### DIFF
--- a/CRM/Mailing/Event/BAO/MailingEventTrackableURLOpen.php
+++ b/CRM/Mailing/Event/BAO/MailingEventTrackableURLOpen.php
@@ -84,11 +84,11 @@ class CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen extends CRM_Mailing_Eve
       return $search->url;
     }
 
-    $open = new CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen();
-    $open->event_queue_id = $queue_id;
-    $open->trackable_url_id = $url_id;
-    $open->time_stamp = date('YmdHis');
-    $open->save();
+    self::writeRecord([
+      'event_queue_id' => $queue_id,
+      'trackable_url_id' => $url_id,
+      'time_stamp' => date('YmdHis'),
+    ]);
 
     return $search->url;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Following [recent discussion regarding if MailingEvents should call hooks](https://chat.civicrm.org/civicrm/pl/by68686xbidh3bae65s9e8mmoo), this PR ensures the Trackable URL Open mailing event calls hooks.

Before
----------------------------------------
Trackable URL opens do not call CiviCRM's hook functions framework.

After
----------------------------------------
Trackable URL opens call CiviCRM's hook functions framework.

Technical Details
----------------------------------------
The PR [follows the pattern @eileenmcnaughton used for MailingEvent_Opened](https://github.com/civicrm/civicrm-core/pull/29887). 

Testing
----------------------------------------
I've tested this locally by using a very simple logger extension that contains this code:
```
function localdev_civicrm_post($op, $objectName, $objectId, $objectRef): void {
  \Drupal::logger('localdev')->debug('Object: %obj, Op: %op', ['%obj' => $objectName, '%op' => $op]);
}
```

This has captured a _create_ operation involving an object named _MailingEventTrackableURLOpen_.

I've also confirmed that CiviMail Mailing reports are still correctly counting/reporting click-throughs.