### PR TITLE
Fix smarty notice when editing a participant with no contribution (unpaid)

### DIFF
--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -121,7 +121,7 @@
         </div>
       {/if}
 
-      {if $action eq 2 and $accessContribution and $rows.0.contribution_id}
+      {if $action eq 2 and $accessContribution and array_key_exists(0, $rows) &&  $rows.0.contribution_id}
       {include file="CRM/Contribute/Form/Selector.tpl" context="Search"}
       {/if}
 


### PR DESCRIPTION

Overview
----------------------------------------
Fix smarty notice when viewing a participant with no contribution (unpaid)

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/98fc318f-a8ba-4279-b136-9a475ebd1df8)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/4401bc49-e52c-40bf-a485-69e92d126962)


Technical Details
----------------------------------------


Comments
----------------------------------------
