### PR TITLE
dev/core#5168 Do not block people from confirming free event registrations

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -594,7 +594,11 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     }
 
     //don't allow to register w/ waiting if enough spaces available.
-    if (!empty($fields['bypass_payment']) && $form->_allowConfirmation) {
+    // @todo - this might not be working too well cos bypass_payment is working over time here.
+    // it will always be true if there is no payment on the form & it's a bit hard
+    // to determine if this is and we don't want people trying to confirm registration to be blocked here
+    /// see https://lab.civicrm.org/dev/core/-/issues/5168
+    if ($form->getPriceSetID() && !empty($fields['bypass_payment']) && $form->_allowConfirmation) {
       if ($spacesAvailable === 0 ||
         (empty($fields['priceSetId']) && CRM_Utils_Array::value('additional_participants', $fields) < $spacesAvailable)
       ) {


### PR DESCRIPTION
Overview
----------------------------------------
It tooks some figuring out how to replicate this but I got there - report is https://civicrm.stackexchange.com/questions/47780/people-approved-for-events-cant-register/47781?noredirect=1#comment57499_47781

The 2 key things to configure are

1) must use a FREE event, no price set of any kind
2) enable approval - by enabling the participant statuses

![image](https://github.com/civicrm/civicrm-core/assets/336308/2422f6a7-565b-4d4a-8c72-63f9f023c65e)

and require participant approval
![image](https://github.com/civicrm/civicrm-core/assets/336308/8b0c15ed-fb66-4d8b-bf25-eec657787bd9)


The registrant must register & then be altered to be Pending from Approval

The link they are sent looks like this (you can probably exclude the checksum if logged in)

https://dmaster.localhost:32353/civicrm/event/confirm?reset=1&participantId=68&cs=66766070edbdb0357c07b798b9cda429_1714720902_5049.6547222222

The error occurs when submitting the Register form (the second form you hit)

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/821804d0-fee7-409b-b4d7-effa4213120f)

After
----------------------------------------
registration succeeds

Technical Details
----------------------------------------
The issue was a lot of functionality is hanging off 'bypass_payment' & it's all a bit jumbled. This ensures the specific rule causing issues is not hit on free events. I don't quite know what would happen with the opposite - ie a free event where the user is trying to join the wait list - it hurts my head - but I suspect it wasn't exactly working a dream before & carving out a path for this legitimate flow feels like the priority

Comments
----------------------------------------
