### PR TITLE
dev/core#5187 - Fix smart group alert for deleted custom fields

### DIFF
--- a/CRM/Utils/Check/Component/Schema.php
+++ b/CRM/Utils/Check/Component/Schema.php
@@ -123,9 +123,9 @@ class CRM_Utils_Check_Component_Schema extends CRM_Utils_Check_Component {
       if (empty($group['form_values'])) {
         continue;
       }
-      foreach ($group['form_values'] as $formValues) {
-        if (isset($formValues[0]) && (strpos($formValues[0], 'custom_') === 0)) {
-          [, $customFieldID] = explode('_', $formValues[0]);
+      foreach ($group['form_values'] as $key => $val) {
+        if (str_starts_with($key, 'custom_')) {
+          [, $customFieldID] = explode('_', $key);
           if (!in_array((int) $customFieldID, $customFieldIds, TRUE)) {
             $problematicSG[CRM_Contact_BAO_SavedSearch::getName($group['id'], 'id')] = [
               'title' => CRM_Contact_BAO_SavedSearch::getName($group['id'], 'title'),


### PR DESCRIPTION
Overview
----------------------------------------
Fix smart group alert for deleted custom fields

Before
----------------------------------------
An alert was added if smart group form values included any deleted custom fields at https://github.com/civicrm/civicrm-core/pull/16267

This is no longer working.

After
----------------------------------------
Displayed now

<img width="1384" alt="image" src="https://github.com/civicrm/civicrm-core/assets/5929648/80f54206-1944-44c4-8bad-cb9ca98f8985">


Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/-/issues/5187