### PR TITLE
Remove mailing_backend_store, confusingly set when we switch the environment to Development

### DIFF
--- a/CRM/Admin/Page/Job.php
+++ b/CRM/Admin/Page/Job.php
@@ -143,7 +143,7 @@ class CRM_Admin_Page_Job extends CRM_Core_Page_Basic {
   public function browse() {
     // check if non-prod mode is enabled.
     if (CRM_Core_Config::environment() != 'Production') {
-      CRM_Core_Session::setStatus(ts('Execution of scheduled jobs has been turned off by default since this is a non-production environment. You can override this for particular jobs by adding runInNonProductionEnvironment=TRUE as a parameter. This will ignore email settings for this job and will send actual emails if this job is sending mails!'), ts('Non-production Environment'), 'warning', ['expires' => 0]);
+      CRM_Core_Session::setStatus(ts('Execution of scheduled jobs has been turned off by default since this is a non-production environment. You can override this for particular jobs by adding runInNonProductionEnvironment=TRUE as a parameter. Note: this will send emails if your <a %1>outbound email</a> is enabled.', [1 => 'href="' . CRM_Utils_System::url('civicrm/admin/setting/smtp', 'reset=1') . '"']), ts('Non-production Environment'), 'warning', ['expires' => 0]);
     }
     else {
       $cronError = Civi\Api4\System::check(FALSE)

--- a/CRM/Core/JobManager.php
+++ b/CRM/Core/JobManager.php
@@ -144,12 +144,6 @@ class CRM_Core_JobManager {
 
     // Save the job last run end date (if this doesn't get written we know the job crashed and was not caught (eg. OOM).
     $job->saveLastRunEnd();
-
-    //Disable outBound option after executing the job.
-    $environment = CRM_Core_Config::environment(NULL, TRUE);
-    if ($environment != 'Production' && !empty($job->apiParams['runInNonProductionEnvironment'])) {
-      Civi::settings()->set('mailing_backend', ['outBound_option' => CRM_Mailing_Config::OUTBOUND_OPTION_DISABLED]);
-    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

When we set the environment from Production to Staging or Development, the SMTP settings are copied from mailing_backend to mailing_backend_store. Then when a Scheduled Job is run with `runInNonProductionEnvironment=TRUE`, the setting is copied from _store back to mailing_backend, so that emails can be sent, if necessary. If the Job does not fatal, the settings are later on reset to what they were.

However, there is no way to set the backup SMTP settings and the admin is not informed about this. An admin may also want to execute a Scheduled Job and have the emails redirected to DB.

Conclusion: I hesitated between adding a complex UI to have "dev" and "production" SMTP settings, but I think that assuming that running a Job in runInNonProductionEnvironment does not necessarily imply that I want to send emails as production. So I recommend we remove this behaviour completely.

Before
----------------------------------------

SMTP settings are changed to some random hidden setting  when running a Scheduled Job with  `runInNonProductionEnvironment=TRUE` on a development environment.

After
----------------------------------------

SMTP settings are not changed when running a Scheduled Job with `runInNonProductionEnvironment=TRUE`.
