### PR TITLE
Standalone installer - fix admin not getting admin role

### DIFF
--- a/setup/plugins/init/StandaloneUsers.civi-setup.php
+++ b/setup/plugins/init/StandaloneUsers.civi-setup.php
@@ -179,9 +179,9 @@ if (!defined('CIVI_SETUP')) {
     $userID = \CRM_Core_BAO_CMSUser::create($params, 'email');
 
     // Assign 'admin' role to user
-    \Civi\Api4\User::update(FALSE)
-      ->addWhere('id', '=', $userID)
-      ->addValue('roles:name', ['admin'])
+    \Civi\Api4\UserRole::create(FALSE)
+      ->addValue('user_id', $userID)
+      ->addValue('role_id', $roles['admin']['id'])
       ->execute();
 
     $message = "Created new user \"{$e->getModel()->extras['adminUser']}\" (user ID #$userID, contact ID #$contactID) with 'admin' role and ";


### PR DESCRIPTION
Before
----------------------------------------
In the standaloneusers install plugin, the admin user and admin role are created successfully, but the admin role isn't assigned to the admin user, so the user has no permissions.

When you try to log in after install you hit a redirect loop.

After
----------------------------------------
The role is assigned and install works.

Technical Details
----------------------------------------
Previously the installer was using an update API call to set the `roles:name` field on the User record. This field is a calculated one (based on the `civicrm_user_role` bridge table), so there's some magic involved in making it work. The same call does seem to work post-install... so I'm wondering if there is something around the fieldspec magic that is not quite ready at this point in the installer.

I've changed to create the UserRole record explicitly using the UserRole api for now, which I hope is always going to be safer.