### PR TITLE
update PermissionTest for Standalone case

### DIFF
--- a/tests/phpunit/E2E/Api4/PermissionTest.php
+++ b/tests/phpunit/E2E/Api4/PermissionTest.php
@@ -23,6 +23,8 @@ class PermissionTest extends \CiviEndToEndTestCase {
       'Drupal' => 'Drupal:post comments',
       'Drupal8' => 'Drupal:post comments',
       'WordPress' => 'WordPress:list_users',
+      // note this should exist on Standalone as a core permission - it is not in the CMS group
+      'Standalone' => 'cms:administer users',
     ];
 
     $perms = \civicrm_api4('Permission', 'get')->indexBy('name');
@@ -46,8 +48,12 @@ class PermissionTest extends \CiviEndToEndTestCase {
 
     $groups = array_unique(\CRM_Utils_Array::collect('group', $perms->getArrayCopy()));
     $this->assertTrue(in_array('civicrm', $groups), 'There should be at least one permission in the "civicrm" group.');
-    $this->assertTrue(in_array('cms', $groups), 'There should be at least one permission in the "cms" group.');
     $this->assertTrue(in_array('const', $groups), 'There should be at least one permission in the "const" group.');
+
+    // in Standalone no permissions are "cms" permissions
+    if (CIVICRM_UF !== 'Standalone') {
+      $this->assertTrue(in_array('cms', $groups), 'There should be at least one permission in the "cms" group.');
+    }
 
     if (isset($smokeTest[CIVICRM_UF])) {
       $smokeTestPerm = $smokeTest[CIVICRM_UF];


### PR DESCRIPTION
Overview
----------------------------------------
PermissionTest.testGet fails for Standalone, because there are rightly no permissions in the cms group.

Add a Standalone case to the smoke test whilst I was at it.