### PR TITLE
Allow Exceptions to propagate.

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4763,13 +4763,9 @@ civicrm_relationship.start_date > {$today}
     if (($customFieldID = CRM_Core_BAO_CustomField::getKeyID($fieldName)) == FALSE) {
       return FALSE;
     }
-    try {
-      $customFieldData = CRM_Core_BAO_CustomField::getField($customFieldID);
-      if ($customFieldData && 'Date' == $customFieldData['data_type']) {
-        return TRUE;
-      }
-    }
-    catch (Exception $e) {
+    $customFieldData = CRM_Core_BAO_CustomField::getField($customFieldID);
+    if ($customFieldData && 'Date' == $customFieldData['data_type']) {
+      return TRUE;
     }
     return FALSE;
   }


### PR DESCRIPTION
Follow up for https://github.com/civicrm/civicrm-core/pull/30104 where on review it was suggested we should remove the empty catch.

Overview
----------------------------------------
Removes a try/catch block.

Before
----------------------------------------
Exceptions were caught and False was returned.

After
----------------------------------------
Exceptions no longer caught.

Comments
----------------------------------------
Lets see if this triggers any errors in testing!
