### PR TITLE
dev/core#5053 Afform - Add support for saving event location

### DIFF
--- a/Civi/Api4/Action/LocBlock/Create.php
+++ b/Civi/Api4/Action/LocBlock/Create.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\LocBlock;
+
+/**
+ * @inheritDoc
+ */
+class Create extends \Civi\Api4\Generic\DAOCreateAction {
+  use LocBlockSaveTrait;
+
+}

--- a/Civi/Api4/Action/LocBlock/LocBlockSaveTrait.php
+++ b/Civi/Api4/Action/LocBlock/LocBlockSaveTrait.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\LocBlock;
+
+use Civi\Api4\LocBlock;
+use Civi\Api4\Utils\CoreUtil;
+
+/**
+ * Code shared by LocBlock create/update/save actions
+ */
+trait LocBlockSaveTrait {
+
+  /**
+   * @param array $items
+   * @return array
+   */
+  protected function write(array $items) {
+    foreach ($items as &$item) {
+      self::saveLocations($item);
+    }
+    $saved = parent::write($items);
+    return $saved;
+  }
+
+  /**
+   * @param array $params
+   */
+  protected function saveLocations(array &$params) {
+    if (!empty($params['id'])) {
+      $locBlock = LocBlock::get(FALSE)
+        ->addWhere('id', '=', $params['id'])
+        ->execute()->first();
+    }
+    foreach (['Address', 'Email', 'Phone', 'IM'] as $joinEntity) {
+      foreach (['', '_2'] as $suffix) {
+        $joinField = strtolower($joinEntity) . $suffix . '_id';
+        $item = \CRM_Utils_Array::filterByPrefix($params, "$joinField.");
+        $entityId = $params[$joinField] ?? $locBlock[$joinField] ?? NULL;
+        if ($item) {
+          $labelField = CoreUtil::getInfoItem($joinEntity, 'label_field');
+          // If NULL was given for the main field (e.g. `email`) then delete the record IF it's not in use
+          if (!empty($params['id']) && $entityId && $labelField && array_key_exists($labelField, $item) && ($item[$labelField] === NULL || $item[$labelField] === '')) {
+            $referenceCount = CoreUtil::getRefCountTotal($joinEntity, $entityId);
+            if ($referenceCount <= 1) {
+              civicrm_api4($joinEntity, 'delete', [
+                'checkPermissions' => FALSE,
+                'where' => [
+                  ['id', '=', $entityId],
+                ],
+              ]);
+            }
+          }
+          else {
+            $item['contact_id'] = '';
+            if ($entityId) {
+              $item['id'] = $entityId;
+            }
+            $saved = civicrm_api4($joinEntity, 'save', [
+              'checkPermissions' => FALSE,
+              'records' => [$item],
+            ])->first();
+            $params[$joinField] = $saved['id'] ?? NULL;
+          }
+        }
+      }
+    }
+  }
+
+  protected function resolveFKValues(array &$record): void {
+    // Override parent function with noop to prevent spurious matching
+  }
+
+}

--- a/Civi/Api4/Action/LocBlock/Save.php
+++ b/Civi/Api4/Action/LocBlock/Save.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\LocBlock;
+
+/**
+ * @inheritDoc
+ */
+class Save extends \Civi\Api4\Generic\DAOSaveAction {
+  use LocBlockSaveTrait;
+
+}

--- a/Civi/Api4/Action/LocBlock/Update.php
+++ b/Civi/Api4/Action/LocBlock/Update.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\LocBlock;
+
+/**
+ * @inheritDoc
+ */
+class Update extends \Civi\Api4\Generic\DAOUpdateAction {
+  use LocBlockSaveTrait;
+
+}

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -189,7 +189,7 @@ trait DAOActionTrait {
    *
    * @param array $record
    */
-  private function resolveFKValues(array &$record): void {
+  protected function resolveFKValues(array &$record): void {
     // Resolve domain id first
     uksort($record, function($a, $b) {
       return substr($a, 0, 9) == 'domain_id' ? -1 : 1;

--- a/Civi/Api4/LocBlock.php
+++ b/Civi/Api4/LocBlock.php
@@ -16,6 +16,7 @@ namespace Civi\Api4;
  * Links addresses, emails & phones to Events.
  *
  * @searchable secondary
+ * @searchFields address_id.street_address,address_id.city,email_id.email
  * @since 5.31
  * @package Civi\Api4
  */

--- a/Civi/Api4/LocBlock.php
+++ b/Civi/Api4/LocBlock.php
@@ -21,4 +21,31 @@ namespace Civi\Api4;
  */
 class LocBlock extends Generic\DAOEntity {
 
+  /**
+   * @param bool $checkPermissions
+   * @return Action\LocBlock\Create
+   */
+  public static function create($checkPermissions = TRUE) {
+    return (new Action\LocBlock\Create('LocBlock', __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return Action\LocBlock\Update
+   */
+  public static function update($checkPermissions = TRUE) {
+    return (new Action\LocBlock\Update('LocBlock', __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return Action\LocBlock\Save
+   */
+  public static function save($checkPermissions = TRUE) {
+    return (new Action\LocBlock\Save('LocBlock', __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
 }

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -327,6 +327,22 @@ class CoreUtil {
   }
 
   /**
+   * Gets total number of references
+   *
+   * @param string $entityName
+   * @param $entityId
+   * @return int
+   * @throws NotImplementedException
+   */
+  public static function getRefCountTotal(string $entityName, $entityId): int {
+    $total = 0;
+    foreach ((array) self::getRefCount($entityName, $entityId) as $ref) {
+      $total += $ref['count'] ?? 0;
+    }
+    return $total;
+  }
+
+  /**
    * @return array
    */
   public static function getSearchableOptions(): array {

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -117,6 +117,29 @@ class AfformAdminMeta {
         }
       }
     }
+    // Add LocBlock joins
+    if ($params['action'] === 'create' && $entityName === 'LocBlock') {
+      $joinParams = $params;
+      // Exclude fields that don't apply to locBlocks
+      $joinParams['where'][] = ['name', 'NOT IN', ['id', 'is_primary', 'is_billing', 'location_type_id', 'contact_id']];
+      foreach (['Address', 'Email', 'Phone', 'IM'] as $joinEntity) {
+        $joinEntityFields = (array) civicrm_api4($joinEntity, 'getFields', $joinParams);
+        $joinEntityLabel = CoreUtil::getInfoItem($joinEntity, 'title');
+        foreach ([1 => '', 2 => '_2'] as $number => $suffix) {
+          $joinField = strtolower($joinEntity) . $suffix . '_id';
+          foreach ($joinEntityFields as $joinEntityField) {
+            if (strtolower($joinEntity) === $joinEntityField['name']) {
+              $joinEntityField['label'] .= " $number";
+            }
+            else {
+              $joinEntityField['label'] = "$joinEntityLabel $number {$joinEntityField['label']}";
+            }
+            $joinEntityField['name'] = "$joinField." . $joinEntityField['name'];
+            $fields[] = $joinEntityField;
+          }
+        }
+      }
+    }
     // Index by name
     $fields = array_column($fields, NULL, 'name');
     $idField = CoreUtil::getIdFieldName($entityName);

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -99,6 +99,13 @@ class AfformAdminMeta {
       }
       $params['values']['state_province_id'] = \Civi::settings()->get('defaultContactStateProvince');
     }
+    // Exclude LocBlock fields that will be replaced by joins (see below)
+    if ($params['action'] === 'create' && $entityName === 'LocBlock') {
+      $joinParams = $params;
+      // Omit the fk fields (email_id, email_2_id, phone_id, etc)
+      // As we'll add their joined fields below
+      $params['where'][] = ['fk_entity', 'IS NULL'];
+    }
     $fields = (array) civicrm_api4($entityName, 'getFields', $params);
     // Add implicit joins to search fields
     if ($params['action'] === 'get') {
@@ -117,14 +124,14 @@ class AfformAdminMeta {
         }
       }
     }
-    // Add LocBlock joins
+    // Add LocBlock joins (e.g. `email_id.email`, `address_id.street_address`)
     if ($params['action'] === 'create' && $entityName === 'LocBlock') {
-      $joinParams = $params;
       // Exclude fields that don't apply to locBlocks
       $joinParams['where'][] = ['name', 'NOT IN', ['id', 'is_primary', 'is_billing', 'location_type_id', 'contact_id']];
       foreach (['Address', 'Email', 'Phone', 'IM'] as $joinEntity) {
         $joinEntityFields = (array) civicrm_api4($joinEntity, 'getFields', $joinParams);
         $joinEntityLabel = CoreUtil::getInfoItem($joinEntity, 'title');
+        // LocBlock entity includes every join twice (e.g. `email_2_id.email`, `address_2_id.street_address`)
         foreach ([1 => '', 2 => '_2'] as $number => $suffix) {
           $joinField = strtolower($joinEntity) . $suffix . '_id';
           foreach ($joinEntityFields as $joinEntityField) {

--- a/ext/afform/admin/afformEntities/LocBlock.php
+++ b/ext/afform/admin/afformEntities/LocBlock.php
@@ -1,0 +1,5 @@
+<?php
+return [
+  'type' => 'join',
+  'repeat_max' => 1,
+];

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
@@ -108,11 +108,13 @@
               }
               item['af-join'] = block.join_entity;
               item['#children'] = [{"#tag": directive}];
-              item['af-repeat'] = ts('Add');
-              item['af-copy'] = ts('Copy');
-              item.min = '1';
-              if (typeof joinEntity.repeat_max === 'number') {
-                item.max = '' + joinEntity.repeat_max;
+              if (joinEntity.repeat_max !== 1) {
+                item['af-repeat'] = ts('Add');
+                item['af-copy'] = ts('Copy');
+                item.min = '1';
+                if (typeof joinEntity.repeat_max === 'number') {
+                  item.max = '' + joinEntity.repeat_max;
+                }
               }
             }
             $scope.blockList.push(item);

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
@@ -117,7 +117,7 @@
       };
 
       $scope.isRepeatable = function() {
-        return ctrl.join ||
+        return (ctrl.join && $scope.getRepeatMax() !== 1) ||
           (block.directive && afGui.meta.blocks[block.directive].repeat) ||
           (ctrl.node['af-fieldset'] && ctrl.editor.getEntityDefn(ctrl.editor.getEntity(ctrl.node['af-fieldset'])) !== false);
       };

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
@@ -7,7 +7,7 @@
     </select>
     <button type="button" class="btn btn-default btn-xs" ng-if="block && !block.layout" ng-click="saveBlock()" title="{{:: ts('Save block') }}">{{:: ts('Save...') }}</button>
     <div class="btn-group pull-right" title="">
-      <af-gui-container-multi-toggle ng-if="!ctrl.loading && ($ctrl.join || $ctrl.node['af-repeat'])" entity="$ctrl.getFieldEntityType()" class="btn-group"></af-gui-container-multi-toggle>
+      <af-gui-container-multi-toggle ng-if="!ctrl.loading && ($ctrl.join || $ctrl.node['af-repeat']) && isRepeatable()" entity="$ctrl.getFieldEntityType()" class="btn-group"></af-gui-container-multi-toggle>
       <div class="btn-group" af-gui-menu>
         <button type="button" class="btn btn-default btn-xs dropdown-toggle af-gui-add-element-button" data-toggle="dropdown" title="{{:: ts('Configure') }}">
           <span><i class="crm-i fa-gear"></i></span>

--- a/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
+++ b/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
@@ -106,7 +106,7 @@ class ContactAutofill extends AbstractBehavior implements EventSubscriberInterfa
       if (!$id && $autoFillMode === 'user' && !$event->getApiRequest()->getArgs()) {
         $id = \CRM_Core_Session::getLoggedInContactID();
         if ($id) {
-          $event->getApiRequest()->loadEntity($entity, [$id]);
+          $event->getApiRequest()->loadEntity($entity, [['id' => $id]]);
         }
       }
       // Autofill by relationship
@@ -123,8 +123,12 @@ class ContactAutofill extends AbstractBehavior implements EventSubscriberInterfa
             ->addWhere('far_contact_id', '=', $relatedContact)
             ->addWhere('near_contact_id.is_deleted', '=', FALSE)
             ->addWhere('is_current', '=', TRUE)
-            ->execute()->column('near_contact_id');
-          $event->getApiRequest()->loadEntity($entity, $relations);
+            ->execute();
+          $relatedIds = [];
+          foreach ($relations as $relation) {
+            $relatedIds[] = ['id' => $relation['near_contact_id']];
+          }
+          $event->getApiRequest()->loadEntity($entity, $relatedIds);
         }
       }
     }

--- a/ext/afform/core/Civi/Afform/Behavior/GroupSubscription.php
+++ b/ext/afform/core/Civi/Afform/Behavior/GroupSubscription.php
@@ -91,7 +91,7 @@ class GroupSubscription extends AbstractBehavior implements EventSubscriberInter
       $cid = $event->getEntityIds($contact)[0] ?? NULL;
     }
     if ($cid) {
-      $event->getApiRequest()->loadEntity($subscriptionEntity, [$cid]);
+      $event->getApiRequest()->loadEntity($subscriptionEntity, [['contact_id' => $cid]]);
     }
   }
 

--- a/ext/afform/core/Civi/Api4/Action/Afform/Prefill.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Prefill.php
@@ -2,54 +2,20 @@
 
 namespace Civi\Api4\Action\Afform;
 
-use Civi\Api4\Utils\CoreUtil;
-
 /**
  * Class Prefill
  *
- * @method $this setMatchField(bool $matchField)
- * @method bool getMatchField()
  * @package Civi\Api4\Action\Afform
  */
 class Prefill extends AbstractProcessor {
-
-  /**
-   * Name of the field being matched (typically 'id')
-   * @var string
-   */
-  protected $matchField;
 
   protected function processForm() {
     $entityValues = $this->_entityValues;
     foreach ($entityValues as $afformEntityName => &$valueSets) {
       $afformEntity = $this->_formDataModel->getEntity($afformEntityName);
-      if ($this->matchField) {
-        $this->handleMatchField($afformEntity['type'], $valueSets);
-      }
       $this->formatViewValues($afformEntity, $valueSets);
     }
     return \CRM_Utils_Array::makeNonAssociative($entityValues, 'name', 'values');
-  }
-
-  /**
-   * Set entity values based on an existing record.
-   *
-   * This is used for e.g. Event.template_id,
-   * based on 'autofill' => 'create' metadata in APIv4 getFields.
-   *
-   * @param string $entityType
-   * @param array $valueSets
-   */
-  private function handleMatchField(string $entityType, array &$valueSets): void {
-    $matchFieldDefn = $this->_formDataModel->getField($entityType, $this->matchField, 'create');
-    // @see EventCreationSpecProvider for the `template_id` declaration which includes this 'autofill' = 'create' flag.
-    if (($matchFieldDefn['input_attrs']['autofill'] ?? NULL) === 'create') {
-      $idField = CoreUtil::getIdFieldName($entityType);
-      foreach ($valueSets as &$valueSet) {
-        $valueSet['fields'][$this->matchField] = $valueSet['fields'][$idField];
-        unset($valueSet['fields'][$idField]);
-      }
-    }
   }
 
   private function formatViewValues(array $afformEntity, array &$valueSets): void {

--- a/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
+++ b/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
@@ -77,6 +77,7 @@ class AfformAutocompleteSubscriber extends AutoService implements EventSubscribe
     $formDataModel = new FormDataModel($afform['layout']);
     [$entityName, $joinEntity] = array_pad(explode('+', $entityName), 2, NULL);
     $entity = $formDataModel->getEntity($entityName);
+    $isId = FALSE;
 
     // If no model entity, it's a search display
     if (!$entity) {
@@ -88,7 +89,6 @@ class AfformAutocompleteSubscriber extends AutoService implements EventSubscribe
     // If using a join (e.g. Contact -> Email)
     elseif ($joinEntity) {
       $apiEntity = $joinEntity;
-      $isId = FALSE;
       $formField = $entity['joins'][$joinEntity]['fields'][$fieldName]['defn'] ?? [];
     }
     else {

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -251,10 +251,12 @@
       // ngChange callback from Existing entity field
       ctrl.onSelectEntity = function() {
         if (ctrl.defn.input_attrs && ctrl.defn.input_attrs.autofill) {
-          var val = $scope.getSetSelect();
-          var entity = ctrl.afFieldset.modelName;
-          var index = ctrl.getEntityIndex();
-          ctrl.afFieldset.afFormCtrl.loadData(entity, index, val, ctrl.defn.name);
+          const val = $scope.getSetSelect();
+          const entity = ctrl.afFieldset.modelName;
+          const entityIndex = ctrl.getEntityIndex();
+          const joinEntity = ctrl.afJoin ? ctrl.afJoin.entity : null;
+          const joinIndex = ctrl.afJoin && $scope.dataProvider.repeatIndex || null;
+          ctrl.afFieldset.afFormCtrl.loadData(entity, entityIndex, val, ctrl.defn.name, joinEntity, joinIndex);
         }
       };
 

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -255,7 +255,7 @@
           const entity = ctrl.afFieldset.modelName;
           const entityIndex = ctrl.getEntityIndex();
           const joinEntity = ctrl.afJoin ? ctrl.afJoin.entity : null;
-          const joinIndex = ctrl.afJoin && $scope.dataProvider.repeatIndex || null;
+          const joinIndex = ctrl.afJoin && $scope.dataProvider.repeatIndex || 0;
           ctrl.afFieldset.afFormCtrl.loadData(entity, entityIndex, val, ctrl.defn.name, joinEntity, joinIndex);
         }
       };
@@ -272,9 +272,15 @@
       };
 
       ctrl.getAutocompleteParams = function() {
+        let fieldName = ctrl.afFieldset.getName();
+        // Append join name which will be unpacked by AfformAutocompleteSubscriber::processAfformAutocomplete
+        if (ctrl.afJoin) {
+          fieldName += '+' + ctrl.afJoin.entity;
+        }
+        fieldName += ':' + ctrl.fieldName;
         return {
           formName: 'afform:' + ctrl.afFieldset.getFormName(),
-          fieldName: ctrl.afFieldset.getName() + ':' + ctrl.fieldName,
+          fieldName: fieldName,
           values: $scope.dataProvider.getFieldData()
         };
       };

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -45,15 +45,22 @@
       // With no arguments this will prefill the entire form based on url args
       // and also check if the form is open for submissions.
       // With selectedEntity, selectedIndex & selectedId provided this will prefill a single entity
-      this.loadData = function(selectedEntity, selectedIndex, selectedId, selectedField) {
+      this.loadData = function(selectedEntity, selectedIndex, selectedId, selectedField, joinEntity, joinIndex) {
         let toLoad = true;
         const params = {name: ctrl.getFormMeta().name, args: {}};
         // Load single entity
         if (selectedEntity) {
           toLoad = !!selectedId;
-          params.matchField = selectedField;
           params.args[selectedEntity] = {};
-          params.args[selectedEntity][selectedIndex] = selectedId;
+          params.args[selectedEntity][selectedIndex] = {};
+          if (joinEntity) {
+            params.args[selectedEntity][selectedIndex].joins = {};
+            params.args[selectedEntity][selectedIndex].joins[joinEntity] = {};
+            params.args[selectedEntity][selectedIndex].joins[joinEntity][joinIndex] = {};
+            params.args[selectedEntity][selectedIndex].joins[joinEntity][joinIndex][selectedField] = selectedId;
+          } else {
+            params.args[selectedEntity][selectedIndex][selectedField] = selectedId;
+          }
         }
         // Prefill entire form
         else {

--- a/ext/afform/core/ang/afblockEventLocBlock.aff.html
+++ b/ext/afform/core/ang/afblockEventLocBlock.aff.html
@@ -1,3 +1,4 @@
+<af-field name="id" />
 <div class="af-container">
   <af-field name="email_id.email" />
   <af-field name="phone_id.phone" />

--- a/ext/afform/core/ang/afblockEventLocBlock.aff.html
+++ b/ext/afform/core/ang/afblockEventLocBlock.aff.html
@@ -1,0 +1,11 @@
+<div class="af-container">
+  <af-field name="email_id.email" />
+  <af-field name="phone_id.phone" />
+  <af-field name="address_id.street_address" />
+</div>
+<div class="af-container af-layout-inline">
+  <af-field name="address_id.city" />
+  <af-field name="address_id.state_province_id" />
+  <af-field name="address_id.country_id" />
+  <af-field name="address_id.postal_code" />
+</div>

--- a/ext/afform/core/ang/afblockEventLocBlock.aff.php
+++ b/ext/afform/core/ang/afblockEventLocBlock.aff.php
@@ -1,0 +1,7 @@
+<?php
+return [
+  'title' => ts('Event Location'),
+  'type' => 'block',
+  'entity_type' => 'Event',
+  'join_entity' => 'LocBlock',
+];

--- a/ext/afform/core/tests/phpunit/Civi/Afform/AfformMetadataTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/AfformMetadataTest.php
@@ -24,12 +24,27 @@ class AfformMetadataTest extends \PHPUnit\Framework\TestCase implements Headless
     $this->assertTrue($fields['placement']['options']);
   }
 
-  public function testGetEntityFields():void {
+  public function testGetIndividualFields():void {
     $individualFields = \Civi\AfformAdmin\AfformAdminMeta::getFields('Individual');
 
-    // Ensure the "Existing" contact field exists
+    // Ensure the "Existing Contact" `id` field exists
     $this->assertEquals('Existing Individual', $individualFields['id']['label']);
     $this->assertEquals('EntityRef', $individualFields['id']['input_type']);
+  }
+
+  public function testGetLocBlockFields():void {
+    $fields = \Civi\AfformAdmin\AfformAdminMeta::getFields('LocBlock');
+
+    // Ensure the "Existing" `id` field exists
+    $this->assertEquals('Existing Location', $fields['id']['label']);
+    $this->assertEquals('EntityRef', $fields['id']['input_type']);
+    // FK fields should not be included
+    $this->assertArrayNotHasKey('email_id', $fields);
+    $this->assertArrayNotHasKey('email_2_id', $fields);
+    // 1st and 2nd join fields should exist
+    $this->assertEquals('Text', $fields['address_id.street_address']['input_type']);
+    $this->assertEquals('Text', $fields['address_2_id.street_address']['input_type']);
+
   }
 
 }

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformAutocompleteUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformAutocompleteUsageTest.php
@@ -16,6 +16,13 @@ use Civi\Api4\SavedSearch;
  */
 class AfformAutocompleteUsageTest extends AfformUsageTestCase {
 
+  public function tearDown(): void {
+    CustomGroup::delete(FALSE)
+      ->addWhere('id', '>', 0)
+      ->execute();
+    parent::tearDown();
+  }
+
   /**
    * Ensure that Afform restricts autocomplete results when it's set to use a SavedSearch
    */

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformCustomFieldUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformCustomFieldUsageTest.php
@@ -13,6 +13,12 @@ use Civi\Api4\CustomGroup;
  */
 class AfformCustomFieldUsageTest extends AfformUsageTestCase {
 
+  public function tearDown(): void {
+    parent::tearDown();
+    CustomField::delete(FALSE)->addWhere('id', '>', '0')->execute();
+    CustomGroup::delete(FALSE)->addWhere('id', '>', '0')->execute();
+  }
+
   public static function setUpBeforeClass(): void {
     parent::setUpBeforeClass();
 

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformGroupSubscriptionUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformGroupSubscriptionUsageTest.php
@@ -13,7 +13,7 @@ use Civi\Test\TransactionalInterface;
 class AfformGroupSubscriptionUsageTest extends AfformUsageTestCase implements TransactionalInterface {
 
   /**
-   * Tests creating a relationship between multiple contacts
+   * Tests subscribing and unsubscribing to groups
    */
   public function testGroupSubscription(): void {
     $groupName = __FUNCTION__;

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformUsageTestCase.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformUsageTestCase.php
@@ -2,6 +2,7 @@
 namespace api\v4\Afform;
 
 use Civi\Api4\Afform;
+use Civi\Api4\CustomGroup;
 
 /**
  * Test case for Afform.prefill and Afform.submit.
@@ -27,6 +28,9 @@ abstract class AfformUsageTestCase extends AfformTestCase {
   public function tearDown(): void {
     Afform::revert(FALSE)
       ->addWhere('name', '=', $this->formName)
+      ->execute();
+    CustomGroup::delete(FALSE)
+      ->addWhere('id', '>', 0)
       ->execute();
     parent::tearDown();
   }

--- a/tests/phpunit/api/v4/Entity/LocBlockTest.php
+++ b/tests/phpunit/api/v4/Entity/LocBlockTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Entity;
+
+use api\v4\Api4TestBase;
+use Civi\Api4\Email;
+use Civi\Api4\LocBlock;
+
+/**
+ * @group headless
+ */
+class LocBlockTest extends Api4TestBase {
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function testSaveWithJoins(): void {
+    $locBlock1 = LocBlock::create(FALSE)
+      ->addValue('email_id.email', 'first@e.mail')
+      ->addValue('email_2_id.email', 'second@e.mail')
+      ->execute()->first();
+
+    $locBlock = LocBlock::get(FALSE)
+      ->addWhere('id', '=', $locBlock1['id'])
+      ->addSelect('email_id', 'email_2_id', 'email_id.email', 'email_2_id.email')
+      ->execute()->first();
+    $this->assertEquals('first@e.mail', $locBlock['email_id.email']);
+    $this->assertEquals('second@e.mail', $locBlock['email_2_id.email']);
+    $this->assertEquals($locBlock1['email_id'], $locBlock['email_id']);
+    $this->assertEquals($locBlock1['email_2_id'], $locBlock['email_2_id']);
+
+    // Share an email with the 1st block
+    $locBlock2 = LocBlock::create(FALSE)
+      ->addValue('email_id', $locBlock1['email_id'])
+      ->addValue('email_2_id.email', 'third@e.mail')
+      ->execute()->first();
+
+    LocBlock::update(FALSE)
+      ->addWhere('id', '=', $locBlock1['id'])
+      ->addValue('email_id.email', '')
+      ->addValue('email_2_id.email', '')
+      ->execute();
+
+    $email1 = Email::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('id', 'IN', [$locBlock1['email_id'], $locBlock1['email_2_id']])
+      ->execute()->column('id');
+
+    $this->assertEquals([$locBlock1['email_id']], (array) $email1);
+  }
+
+}

--- a/tools/extensions/phpstorm/Civi/PhpStorm/Api4Generator.php
+++ b/tools/extensions/phpstorm/Civi/PhpStorm/Api4Generator.php
@@ -54,6 +54,7 @@ class Api4Generator extends AutoService implements EventSubscriberInterface {
     $builder->addExpectedArguments('\Civi\Api4\Utils\CoreUtil::getTableName()', 0, 'api4Entities');
     $builder->addExpectedArguments('\Civi\Api4\Utils\CoreUtil::getCustomGroupExtends()', 0, 'api4Entities');
     $builder->addExpectedArguments('\Civi\Api4\Utils\CoreUtil::getRefCount()', 0, 'api4Entities');
+    $builder->addExpectedArguments('\Civi\Api4\Utils\CoreUtil::getRefCountTotal()', 0, 'api4Entities');
     $builder->addExpectedArguments('\Civi\Api4\Utils\CoreUtil::isType()', 0, 'api4Entities');
     $builder->addExpectedArguments('\Civi\Api4\Utils\CoreUtil::isType()', 1, 'api4EntityTypes');
     $builder->addExpectedArguments('\Civi\Api4\Utils\CoreUtil::checkAccessDelegated()', 0, 'api4Entities');


### PR DESCRIPTION
Overview
----------------------------------------
Fulfills feature request from https://lab.civicrm.org/dev/core/-/issues/5053

Before
------
Not possible to save email/phone/address when creating an event via Afform

After
------
Support added for those fields, in the form of a block.