### PR TITLE
(dev/translation#84) LocalizedDataTest - Reduce noise

### DIFF
--- a/tests/phpunit/E2E/Core/LocalizedDataTest.php
+++ b/tests/phpunit/E2E/Core/LocalizedDataTest.php
@@ -19,8 +19,6 @@ class LocalizedDataTest extends \CiviEndToEndTestCase {
    *
    * $ env CIVICRM_LOCALES=en_US,fr_FR,de_DE ./bin/setup.sh -g \
    *   && phpunit6 tests/phpunit/E2E/Core/LocalizedDataTest.php
-   *
-   * @group ornery
    */
   public function testLocalizedData(): void {
     $sqls = [
@@ -28,7 +26,7 @@ class LocalizedDataTest extends \CiviEndToEndTestCase {
       'fr_FR' => $this->getRenderedSql('fr_FR'),
     ];
     $pats = [
-      'de_DE' => '/new_organization.*Neue Organisation/i',
+      'de_DE' => '/new_individual.*Neue Person/i',
       'fr_FR' => '/new_organization.*Nouvelle organisation/i',
     ];
 


### PR DESCRIPTION
Overview
--------

For the past 2-3 months, this test has been complaining. Make it happy.

Technical Details
-----------------

The original problem is that several strings in `civicrm-core.git` were moved to different files. From l10n scanner/infra POV, this made it appear that the strings were no longer needed (even though they were needed) -- and eventually (circa February) they were dropped from l10n data.... which caused this smoke-test to start failing. So the test has been complaining for a couple months now.

The original structural issue (scanning) is actually fixed:

https://lab.civicrm.org/dev/translation/-/commit/7ceb439e22d18e72755a86d725e5b541a0471c68

Additionally, some locales/strings (like "New Organization" for "fr") have been re-instated. But other locales/strings (like "New Organization" for "de") still need to be re-instated (TBD).

This smoke-test is not a very useful measure for tracking re-instatements. (*The people who see this failure don't really manage the strings, and it really only speaks about 1-2 strings...*) For better tracking, there are Transifex coverage-stats (*which are more precise; and which appear to a more appropriate audience*).

Switching the test to slightly different strings means that we still have this as a smoke-test (to ensure that translation-behavior works) but without the noise about this one specific string.

