### PR TITLE
dev/core#5141 - Fix non-selectable select2 in 'Clone Report' popup

### DIFF
--- a/CRM/Report/Form/Instance.php
+++ b/CRM/Report/Form/Instance.php
@@ -134,7 +134,7 @@ class CRM_Report_Form_Instance {
     // navigation field
     $parentMenu = CRM_Core_BAO_Navigation::getNavigationList();
 
-    $form->add('select', 'parent_id', ts('Parent Menu'), ['' => ts('- select -')] + $parentMenu, FALSE, ['class' => 'crm-select2 huge']);
+    $form->add('select', 'parent_id', ts('Parent Menu'), ['' => ts('- select -')] + $parentMenu);
 
     // For now we only providing drilldown for one primary detail report only. In future this could be multiple reports
     foreach ($form->_drilldownReport as $reportUrl => $drillLabel) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/5141

Before
----------------------------------------
Cannot select navigation in "Clone Report" popup.

After
----------------------------------------
Works.

Technical Details
----------------------------------------
This partially reverts 8eb6aa4.