### PR TITLE
Authx - Fix stateful logins on D9/D10

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -653,6 +653,21 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   }
 
   /**
+   * Commit the session before exiting.
+   * Similar to drupal_exit().
+   */
+  public function onCiviExit() {
+    if (class_exists('Drupal')) {
+      if (!defined('_CIVICRM_FAKE_SESSION')) {
+        $session = \Drupal::service('session');
+        if (!$session->isEmpty()) {
+          $session->save();
+        }
+      }
+    }
+  }
+
+  /**
    * @inheritDoc
    */
   public function setMessage($message) {


### PR DESCRIPTION
Steps to reproduce (phpunit)
------------------

Run the unit-test `Civi\Authx\StatefulFlowsTest` on D9/D10.

```
cd vendor/civicrm/civicrm-core/ext/authx
phpunit9 --debug --group e2e
```

Steps to reproduce (manual)
------------------

* Enable "authx"
* In "Authentication" settings, double-check that "Auto-login" allows JWT credentials
* Generate a login URL for `admin`.

    ```
    $ cv url -LU admin civicrm/dashboard
    "http://d10.127.0.0.1.nip.io:8001/civicrm/dashboard?_authxSes=1&_authx=Bearer+eyJ0..."
* Open the URL

Before
------

* Unit tests fail
* Login link doesn't work

After
-----

* Unit test succeeds
* Login link works

Technical Details
------------------

These tests work on D7/BD. They used to work on D8. They don't currently work on D9/D10 because session-management is a bit different.

* The basic problem -- authx tells Drupal to update the session, which it does (sort of). Except it doesn't actually save the session. In D9/D10, this is handled by a later-stage -- but it doesn't work with Civi's REST-y controllers because they all build on `civiExit()`.
* In D7, I guess there's a similar problem -- which is solved by having `CRM_Utils_System_Drupal::onCiviExit()` call `drupal_session_commit()`. But that doesn't exist in D9/D10.
* This patch essentially ports the logic from `Drupal::onCiviExit()` to `Drupal10::onCiviExit()`.

I did local `r-run` on D10. Haven't actually tried D9 yet. 

Comments
--------------

This is one of the final TODO's from https://lab.civicrm.org/dev/drupal/-/issues/189. It's also an annoyance when using `run-extended-tests`. And it will be an annoyance for PR tests on `civicrm-drupal-8.git` whenever enable `phpunit-core-exts` over there.