### PR TITLE
Fix dev/core#5139 incorrect Date Preferences link

### DIFF
--- a/CRM/Core/xml/Menu/Admin.xml
+++ b/CRM/Core/xml/Menu/Admin.xml
@@ -234,8 +234,6 @@
      <path>civicrm/admin/setting/preferences/date/edit</path>
      <title>Date Preferences</title>
      <page_callback>CRM_Admin_Form_PreferencesDate</page_callback>
-     <adminGroup>Customize Data and Screens</adminGroup>
-     <weight>97</weight>
   </item>
   <item>
      <path>civicrm/admin/menu</path>
@@ -599,8 +597,10 @@
   </item>
   <item>
      <path>civicrm/admin/setting/preferences/date</path>
-     <title>View Date Preferences</title>
+     <title>Date Preferences</title>
      <page_callback>CRM_Admin_Page_PreferencesDate</page_callback>
+     <adminGroup>Customize Data and Screens</adminGroup>
+     <weight>97</weight>
   </item>
 
   <item>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/5139

Bug introduced in 270c76a6

Before
----------------------------------------
Incorrect link from "Administer" screen to "Date Preferences".

After
----------------------------------------
Fixed.