### PR TITLE
Smarty 3/4 - Fix prepending extension template directories

### DIFF
--- a/mixin/smarty-v2@1/mixin.php
+++ b/mixin/smarty-v2@1/mixin.php
@@ -4,7 +4,7 @@
  * Auto-register "templates/" folder.
  *
  * @mixinName smarty-v2
- * @mixinVersion 1.0.1
+ * @mixinVersion 1.0.2
  * @since 5.59
  *
  * @deprecated - it turns out that the mixin is not version specific so the 'smarty'
@@ -23,9 +23,21 @@ return function ($mixInfo, $bootCache) {
   }
 
   $register = function() use ($dir) {
-    // This implementation has a theoretical edge-case bug on older versions of CiviCRM where a template could
-    // be registered more than once.
-    CRM_Core_Smarty::singleton()->addTemplateDir($dir);
+    $smarty = CRM_Core_Smarty::singleton();
+    // Smarty2 compatibility
+    if (isset($smarty->_version) && version_compare($smarty->_version, 3, '<')) {
+      $smarty->addTemplateDir($dir);
+      return;
+    }
+    // getTemplateDir returns string or array by reference
+    $templateRef = $smarty->getTemplateDir();
+    // Dereference and normalize as array
+    $templateDirs = (array) $templateRef;
+    // Add the dir if not already present
+    if (!in_array($dir, $templateDirs, TRUE)) {
+      array_unshift($templateDirs, $dir);
+      $smarty->setTemplateDir($templateDirs);
+    }
   };
 
   // Let's figure out what environment we're in -- so that we know the best way to call $register().


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://github.com/civicrm/org.civicrm.contactlayout/issues/143

Before
----------------------------------------
Extensions would prepend their directories under smarty2, but smarty3 & 4 would append them, breaking template overrides.

After
----------------------------------------
Smarty 2,3&4 all prepend template directories

Technical Details
----------------------------------------
~~It was a bit tough to wrangle the same behavior out of all 3 versions, but resorting to lowest-common-denominator getter/setter functions works well.~~

Note: I ended up adding a special case for Smarty2 since it doesn't have getter/setter functions (at least not on older versions of Civi, which we still support via mixin shims). So this PR no longer depends on https://github.com/civicrm/civicrm-packages/pull/397
