### PR TITLE
dev/core#4955 Use addPluginsDir for registering plugins

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -125,20 +125,16 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
       if (!file_exists($customPluginsDir)) {
         $customPluginsDir = NULL;
       }
+      if ($customPluginsDir) {
+        $this->addPluginsDir($customPluginsDir);
+      }
     }
 
     $pkgsDir = Civi::paths()->getVariable('civicrm.packages', 'path');
     // smarty3/4 have the define, fall back to smarty2. smarty5 deprecates plugins_dir - TBD.
     $smartyPluginsDir = defined('SMARTY_PLUGINS_DIR') ? SMARTY_PLUGINS_DIR : ($pkgsDir . DIRECTORY_SEPARATOR . 'Smarty' . DIRECTORY_SEPARATOR . 'plugins');
     $corePluginsDir = __DIR__ . DIRECTORY_SEPARATOR . 'Smarty' . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR;
-
-    if ($customPluginsDir) {
-      $this->plugins_dir = [$customPluginsDir, $smartyPluginsDir, $corePluginsDir];
-    }
-    else {
-      $this->plugins_dir = [$smartyPluginsDir, $corePluginsDir];
-    }
-
+    $this->addPluginsDir($corePluginsDir);
     $this->compile_check = $this->isCheckSmartyIsCompiled();
 
     // add the session and the config here


### PR DESCRIPTION
This is deprecated but 'ok-ish' on Smarty5 & should work with the others.

It does not allow smarty functions to be inserted via the customPhpDir in a way that overrides core smarty functions - we don't know of any usage of this & the setting is discouraged to adding to change log / an upgrade notice for anyone with the setting in play might be called for

Requires
https://github.com/civicrm/civicrm-packages/pull/398

Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
