### PR TITLE
Add help text for civi admins regarding from email

### DIFF
--- a/templates/CRM/Contact/Form/Task/Help/Email/id-from_email.hlp
+++ b/templates/CRM/Contact/Form/Task/Help/Email/id-from_email.hlp
@@ -5,6 +5,9 @@
 {crmSetting var="allow_mail_from_logged_in_contact" name="allow_mail_from_logged_in_contact"}
 {if $allow_mail_from_logged_in_contact}
   <p>{ts}By default, CiviCRM uses the primary email address of the logged in user as the FROM address when sending emails to contacts. However, users with Administer CiviCRM permission can configure one or more general email addresses that can be selected as an alternative. EXAMPLE: "Client Services" &lt;clientservices@example.org&gt;{/ts}</p>
+  {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM')}
+    <p>{ts 1=$smtpUrl}Go to <a href='%1'>Settings - Outbound Mail</a> to disable the usage of the logged in contact's email address as the from email{/ts}</p>
+  {/if}
 {else}
   <p>{ts}CiviCRM is currently configured to only use the defined From Email addresses. If you wish to be able to use the email address of the logged in user as the From Address you will need to set the setting "Allow mail from logged in contact" setting. Users with Administer CiviCRM can set this setting in the SMTP settings.{/ts}<p>
     {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM')}


### PR DESCRIPTION
Update help text on the send email screen to tell civi admins where to disable the usage of the logged in contact's email address. This help text exists if logged in contacts are not allowed to send emails from their email address but not if they are.



