### PR TITLE
Use addPluginsDir rather than non-public property

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -125,19 +125,16 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
       if (!file_exists($customPluginsDir)) {
         $customPluginsDir = NULL;
       }
+      if ($customPluginsDir) {
+        $this->addPluginsDir($customPluginsDir);
+      }
     }
 
     $pkgsDir = Civi::paths()->getVariable('civicrm.packages', 'path');
     // smarty3/4 have the define, fall back to smarty2. smarty5 deprecates plugins_dir - TBD.
     $smartyPluginsDir = defined('SMARTY_PLUGINS_DIR') ? SMARTY_PLUGINS_DIR : ($pkgsDir . DIRECTORY_SEPARATOR . 'Smarty' . DIRECTORY_SEPARATOR . 'plugins');
     $corePluginsDir = __DIR__ . DIRECTORY_SEPARATOR . 'Smarty' . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR;
-
-    if ($customPluginsDir) {
-      $this->plugins_dir = [$customPluginsDir, $smartyPluginsDir, $corePluginsDir];
-    }
-    else {
-      $this->plugins_dir = [$smartyPluginsDir, $corePluginsDir];
-    }
+    $this->addPluginsDir($corePluginsDir);
 
     $this->compile_check = $this->isCheckSmartyIsCompiled();
 


### PR DESCRIPTION
Overview
----------------------------------------
Use addPluginsDir rather than non-public property

requires https://github.com/civicrm/civicrm-packages/pull/398 & https://github.com/civicrm/civicrm-packages/pull/401

Before
----------------------------------------
accessing non-public property plugins_dir causes errors on Smarty5 in tests


After
----------------------------------------
consistent use of `addPluginsDir()` on all versions - also OK in extensions

Technical Details
----------------------------------------

Comments
----------------------------------------
