### PR TITLE
[REF] Fix Contribution Detail Report add to Group when using custom f…

### DIFF
--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -882,8 +882,7 @@ WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribu
       foreach (array_merge($sectionAliases, $this->_selectAliases) as $alias) {
         $ifnulls[] = "ifnull($alias, '') as $alias";
       }
-      $this->_select = "SELECT " . implode(", ", $ifnulls);
-      $this->_select = CRM_Contact_BAO_Query::appendAnyValueToSelect($ifnulls, $sectionAliases);
+      $select = CRM_Contact_BAO_Query::appendAnyValueToSelect($ifnulls, $sectionAliases);
 
       /* Group (un-limited) report by all aliases and get counts. This might
        * be done more efficiently when the contents of $sql are known, ie. by
@@ -899,7 +898,7 @@ WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribu
         $showsumcontribs = TRUE;
       }
 
-      $query = $this->_select .
+      $query = $select .
         "$addtotals, count(*) as ct from {$this->temporaryTables['civireport_contribution_detail_temp3']['name']} group by " .
         implode(", ", $sectionAliases);
       // initialize array of total counts
@@ -1051,6 +1050,20 @@ WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribu
       $joinType JOIN civicrm_contribution_soft {$this->_aliases['civicrm_contribution_soft']}
       ON {$this->_aliases['civicrm_contribution_soft']}.contribution_id = {$this->_aliases['civicrm_contribution']}.id
    ";
+  }
+
+  /**
+   * End post processing.
+   *
+   * @param array|null $rows
+   */
+  public function endPostProcess(&$rows = NULL) {
+    $this->groupConcatTested = FALSE;
+    $this->orderBy();
+    $this->groupConcatTested = TRUE;
+    $this->optimisedForOnlyFullGroupBy = FALSE;
+    parent::endPostProcess($rows);
+    $this->optimisedForOnlyFullGroupBy = TRUE;
   }
 
 }


### PR DESCRIPTION
…ield as a section header

Overview
----------------------------------------
This aims to fix a bug where by using a Custom field e.g. Marital Status as a section header in the order bys on the report when using the add to group function

Before
----------------------------------------
Add to group function creates db error

After
----------------------------------------
No DB Error

ping @demeritcowboy @andrew-cormick-dockery 