### PR TITLE
dev/core#4985 Modernise checkbox/radio CSS, markup

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3321,18 +3321,24 @@ span.crm-select-item-color {
   left: 23px;
 }
 /* Checkbox/radio fields with n-per-line. See https://lab.civicrm.org/dev/core/-/issues/4985 */
-.crm-container .crm-options-per-line {
+.crm-container .crm-multiple-checkbox-radio-options {
   --gap: 1em;
   --checkbox-width: 2em;
   display: flex;
   flex-wrap: wrap;
   gap: var(--gap);
 }
-.crm-container .crm-options-per-line .crm-option-label-pair {
-  flex: 0 0 calc((100% - (var(--crm-opts-per-line) - 1) * var(--gap)) / var(--crm-opts-per-line));
+/* Override more general styling */
+.crm-container .crm-multiple-checkbox-radio-options :where(input.crm-form-radio, input.crm-form-checkbox) + label {
+  margin-left: 0;
+}
+.crm-container .crm-multiple-checkbox-radio-options .crm-option-label-pair {
   display: grid;
   grid-template-columns: var(--checkbox-width) 1fr;
   align-items: baseline;
+}
+.crm-container .crm-multiple-checkbox-radio-options.crm-options-per-line .crm-option-label-pair {
+  flex: 0 0 calc((100% - (var(--crm-opts-per-line) - 1) * var(--gap)) / var(--crm-opts-per-line));
 }
 
 /* classes related to batch entry operation */

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -270,7 +270,7 @@ input.crm-form-entityref {
   border-top: 1px solid #696969;
 }
 
-/* Size the verticle heights in crm-containers by class. */
+/* Size the vertical heights in crm-containers by class. */
 .crm-container .ht-one {
   height: 1em;
 }
@@ -3262,7 +3262,7 @@ span.crm-select-item-color {
   width: 93%;
 }
 
-/* Checkbox gropus */
+/* Checkbox groups */
 .crm-container ul.crm-checkbox-list {
   list-style: none;
   margin: 0;
@@ -3319,6 +3319,20 @@ span.crm-select-item-color {
 }
 .crm-container ul.crm-checkbox-list.crm-sortable-list li input {
   left: 23px;
+}
+/* Checkbox/radio fields with n-per-line. See https://lab.civicrm.org/dev/core/-/issues/4985 */
+.crm-container .crm-options-per-line {
+  --gap: 1em;
+  --checkbox-width: 2em;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap);
+}
+.crm-container .crm-options-per-line .crm-option-label-pair {
+  flex: 0 0 calc((100% - (var(--crm-opts-per-line) - 1) * var(--gap)) / var(--crm-opts-per-line));
+  display: grid;
+  grid-template-columns: var(--checkbox-width) 1fr;
+  align-items: baseline;
 }
 
 /* classes related to batch entry operation */
@@ -3974,6 +3988,7 @@ span.crm-status-icon {
 .dedupe-rules-dialog label > * {
   margin-left: 30px;
 }
+
 
 /* Standalone-only styles. A minimal set to make it usable out-of-the-box. */
 html.crm-standalone body {

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3329,7 +3329,8 @@ span.crm-select-item-color {
   gap: var(--gap);
 }
 /* Override more general styling */
-.crm-container .crm-multiple-checkbox-radio-options :where(input.crm-form-radio, input.crm-form-checkbox) + label {
+.crm-container .crm-multiple-checkbox-radio-options :where(input.crm-form-radio,
+input.crm-form-checkbox) + label {
   margin-left: 0;
 }
 .crm-container .crm-multiple-checkbox-radio-options .crm-option-label-pair {

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -26,29 +26,18 @@
     {if array_key_exists('options_per_line', $field) && $field.options_per_line != 0}
       <div class="crm-section editrow_{$profileFieldName}-section form-item" id="editrow-{$rowIdentifier}">
         <div class="label option-label">{$formElement.label}</div>
-        <div class="content 3">
-
-          {assign var="count" value=1}
-          {strip}
-            <table class="form-layout-compressed">
-              <tr>
-                {* sort by fails for option per line. Added a variable to iterate through the element array*}
-                {foreach name=outer key=key item=item from=$formElement}
-                  {* There are both numeric and non-numeric keys mixed in here, where the non-numeric are metadata that aren't arrays with html members. *}
-                  {if is_array($item) && array_key_exists('html', $item)}
-                <td class="labels font-light">{$formElement.$key.html}</td>
-                {if $count == $field.options_per_line}
-              </tr>
-              <tr>
-                {assign var="count" value=1}
-                {else}
-                {assign var="count" value=$count+1}
-                {/if}
-                {/if}
-                {/foreach}
-              </tr>
-            </table>
-          {/strip}
+        <div class="content">
+          <div class="crm-options-per-line" style="--crm-opts-per-line:{$field.options_per_line};">
+            {foreach name=outer key=key item=item from=$formElement}
+              {if is_array($item) && array_key_exists('html', $item)}
+                <div class="crm-option-label-pair" >{$formElement.$key.html}</div>
+              {/if}
+            {/foreach}
+          </div>
+          {* Include the edit options list for admins *}
+          {if $formElement.html|strstr:"crm-option-edit-link"}
+            {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@":"$1"}
+          {/if}
         </div>
         <div class="clear"></div>
       </div>
@@ -133,6 +122,16 @@
               {/if}
             {elseif $field.html_type eq 'File' && $viewOnlyFileValues}
               {$viewOnlyFileValues.$profileFieldName}
+            {elseif $field.html_type eq 'Radio' or $field.html_type eq 'CheckBox'}
+              {foreach name=outer key=key item=item from=$formElement}
+                {if is_array($item) && array_key_exists('html', $item)}
+                  <div class="crm-option-label-pair" >{$formElement.$key.html}</div>
+                {/if}
+              {/foreach}
+              {* Include the edit options list for admins *}
+              {if $formElement.html|strstr:"crm-option-edit-link"}
+                {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@":"$1"}
+              {/if}
             {else}
               {$formElement.html}
             {/if}

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -27,7 +27,7 @@
       <div class="crm-section editrow_{$profileFieldName}-section form-item" id="editrow-{$rowIdentifier}">
         <div class="label option-label">{$formElement.label}</div>
         <div class="content">
-          <div class="crm-options-per-line" style="--crm-opts-per-line:{$field.options_per_line};">
+          <div class="crm-multiple-checkbox-radio-options crm-options-per-line" style="--crm-opts-per-line:{$field.options_per_line};">
             {foreach name=outer key=key item=item from=$formElement}
               {if is_array($item) && array_key_exists('html', $item)}
                 <div class="crm-option-label-pair" >{$formElement.$key.html}</div>
@@ -123,11 +123,13 @@
             {elseif $field.html_type eq 'File' && $viewOnlyFileValues}
               {$viewOnlyFileValues.$profileFieldName}
             {elseif $field.html_type eq 'Radio' or $field.html_type eq 'CheckBox'}
-              {foreach name=outer key=key item=item from=$formElement}
-                {if is_array($item) && array_key_exists('html', $item)}
-                  <div class="crm-option-label-pair" >{$formElement.$key.html}</div>
-                {/if}
-              {/foreach}
+              <div class="crm-multiple-checkbox-radio-options" >
+                {foreach name=outer key=key item=item from=$formElement}
+                  {if is_array($item) && array_key_exists('html', $item)}
+                    <div class="crm-option-label-pair" >{$formElement.$key.html}</div>
+                  {/if}
+                {/foreach}
+              </div>
               {* Include the edit options list for admins *}
               {if $formElement.html|strstr:"crm-option-edit-link"}
                 {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@":"$1"}


### PR DESCRIPTION
See https://lab.civicrm.org/dev/core/-/issues/4985

Provides a fix for checkboxes unaligned when n-per-line presentation option is used. Also fixes that this was previously not responsive.

See extensive discussions in link above.

Reviewers:

- I think this works for checkboxes and radios with and without n-per-line options.
- I have brought in the little wrench icon for admins to edit the options, too.
- I applied the markup changes to the case where there are no n-per-line; for consistency's sake. I kept those inline but applied the same classes + styling.
- Please check it works with various different configuration options. I *think* it should; I've tried to copy the CSS in the [mock up tool I made](https://artfulrobot.uk/lil/civi-issue-4985/).

Ping @samuelsov @vingle and @eileenmcnaughton though I think you might have only gotten involved to chivvy the process along?
