### PR TITLE
dev/core#5190 Smarty3/4 compatibility

### DIFF
--- a/templates/CRM/Admin/Form/Preferences/Address.hlp
+++ b/templates/CRM/Admin/Form/Preferences/Address.hlp
@@ -15,7 +15,7 @@
 <p>{ts}Configure mailing labels for your site using tokens, which are replaced by contact field values when the labels are generated. Place your cursor within the Mailing Labels box where you want to the token to be inserted. Then click the "Insert Tokens" link to see a list of available tokens (including custom fields). Insert the token by clicking the desired token name.{/ts}</p>
 <ul>
   <li>{ts}Address field values are taken from the contact's <strong>primary</strong> location.{/ts}</li>
-  <li>{ts 1=&#123;contact.state_province&#125; 2=&#123;contact.state_province_name&#125;}Use the %1 token for state/province abbreviation or %2 for full state/province name.{/ts}</li>
+  <li>{ts 1="&#123;contact.state_province&#125;" 2="&#123;contact.state_province_name&#125;"}Use the %1 token for state/province abbreviation or %2 for full state/province name.{/ts}</li>
   <li>{ts}Add spaces or punctuation to layout by surrounding them with brackets.{/ts}
     <ul><li>{ts}EXAMPLE:{/ts} {literal}{, }{/literal}</li></ul></li>
   <li>{ts}If you want to include the county in your mailing labels, the <strong>County</strong> checkbox must be checked in the Address Editing section on this screen, and county names must be added to the civicrm_county table in your database.{/ts}</li>

--- a/templates/CRM/Admin/Form/Preferences/Address.tpl
+++ b/templates/CRM/Admin/Form/Preferences/Address.tpl
@@ -62,7 +62,7 @@
              <tr class="crm-preferences-address-form-block-description">
                 <td colspan="2">
                   <span class="description">
-                      {ts 1=https://www.usps.com/business/web-tools-apis/welcome.htm}CiviCRM includes an optional plugin for interfacing with the United States Postal Services (USPS) Address Standardization web service. You must register to use the USPS service at <a href='%1' target='_blank'>%1</a>. If you are approved, they will provide you with a User ID and the URL for the service.{/ts}
+                      {ts 1="https://www.usps.com/business/web-tools-apis/welcome.htm"}CiviCRM includes an optional plugin for interfacing with the United States Postal Services (USPS) Address Standardization web service. You must register to use the USPS service at <a href='%1' target='_blank'>%1</a>. If you are approved, they will provide you with a User ID and the URL for the service.{/ts}
                       {ts}Plugins for other address standardization services may be available from 3rd party developers. If installed, they will be included in the drop-down below.{/ts}
                   </span>
               </td>


### PR DESCRIPTION
port of https://github.com/civicrm/civicrm-core/pull/29968/ - in 5.74 but this has been reported as a regression against 5.73 so let's port. (it's a bit on the edge of the definition of regression as it involves Smarty3/4 but we don't need to litigate that)