### PR TITLE
skip custom word replacements check during installer

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -782,7 +782,7 @@ class CRM_Core_I18n {
    *   Ex: $stringTable['enabled']['wildcardMatch']['foo'] = 'bar';
    */
   private function getWordReplacements() {
-    if (isset(Civi\Test::$statics['testPreInstall'])) {
+    if (defined('CIVI_SETUP') || isset(Civi\Test::$statics['testPreInstall'])) {
       return [];
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Pulling this out of https://github.com/civicrm/civicrm-core/pull/30132 because I think it is a straight up bug in the installer with the new global `ts` function.

Before
----------------------------------------
Standalone web installer can't load - get `DB_DataObject Error: No database name / dsn found anywhere` because translating strings in the installer is trying to lookup word replacements from the database, but we aren't installed yet.


After
----------------------------------------
Installer loads nicely.