### PR TITLE
[REF] DAO - Outside parties should use `getTableName()` instead of `$_tableName`

### DIFF
--- a/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
@@ -459,7 +459,7 @@ WHERE  email = %2
   ) {
     $dao = new CRM_Core_DAO();
 
-    $unsub = self::$_tableName;
+    $unsub = self::getTableName();
     $queueObject = new CRM_Mailing_Event_BAO_MailingEventQueue();
     $queue = $queueObject->getTableName();
     $mailingObject = new CRM_Mailing_BAO_Mailing();
@@ -533,7 +533,7 @@ WHERE  email = %2
 
     $dao = new CRM_Core_DAO();
 
-    $unsub = self::$_tableName;
+    $unsub = self::getTableName();
     $queueObject = new CRM_Mailing_Event_BAO_MailingEventQueue();
     $queue = $queueObject->getTableName();
     $mailingObject = new CRM_Mailing_BAO_Mailing();

--- a/ext/standaloneusers/CRM/Standaloneusers/BAO/Session.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/BAO/Session.php
@@ -10,7 +10,7 @@ class CRM_Standaloneusers_BAO_Session extends CRM_Standaloneusers_DAO_Session {
    * @return void
    */
   public static function deleteExpired($db, $expiration_date) {
-    $table_name = self::$_tableName;
+    $table_name = self::getTableName();
     $stmt = $db->prepare("DELETE FROM $table_name WHERE last_accessed < ?");
     $db->execute($stmt, $expiration_date);
   }
@@ -23,7 +23,7 @@ class CRM_Standaloneusers_BAO_Session extends CRM_Standaloneusers_DAO_Session {
    * @return void
    */
   public static function destroy($db, $session_id) {
-    $table_name = self::$_tableName;
+    $table_name = self::getTableName();
     $stmt = $db->prepare("DELETE FROM $table_name WHERE session_id = ?");
     $db->execute($stmt, $session_id);
   }
@@ -36,7 +36,7 @@ class CRM_Standaloneusers_BAO_Session extends CRM_Standaloneusers_DAO_Session {
    * @return string
    */
   public static function read($db, $session_id) {
-    $table_name = self::$_tableName;
+    $table_name = self::getTableName();
     $stmt = $db->prepare("SELECT * FROM $table_name WHERE session_id = ? FOR UPDATE");
 
     return $db->execute($stmt, $session_id)->fetchRow(DB_FETCHMODE_ASSOC);
@@ -51,7 +51,7 @@ class CRM_Standaloneusers_BAO_Session extends CRM_Standaloneusers_DAO_Session {
    * @return void
    */
   public static function write($db, $session_id, $data = NULL) {
-    $table_name = self::$_tableName;
+    $table_name = self::getTableName();
 
     if (is_null($data)) {
       $stmt = $db->prepare("


### PR DESCRIPTION
Overview
----------------------------------------
This is a small piece of code cleanup peeled off of #29991.