### PR TITLE
afform - fix - set default value for a select field by url

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -183,6 +183,9 @@
       function setValue(value) {
         // correct the value type
         if (ctrl.defn.input_type !== 'DisplayOnly') {
+          if (_.isString(value) && ctrl.isMultiple() && ctrl.defn.data_type === 'Integer'){
+            value = value.split(',');
+          }
           value = correctValueType(value, ctrl.defn.data_type);
         }
 
@@ -208,9 +211,6 @@
             '>=': ('' + value).split('-')[0],
             '<=': ('' + value).split('-')[1] || '',
           };
-        }
-        else if (_.isString(value) && ctrl.isMultiple()) {
-          value = value.split(',');
         }
         $scope.getSetValue(value);
       }


### PR DESCRIPTION
Overview
----------------------------------------
After updatinging to > ~5.65 it is not longer possible to set default values for a select field by url if a format like this is used: civicrm/forms/test#?event_type_id=1,2,3 Currently tested with 5.72.3.

Before
----------------------------------------
no default values set

After
----------------------------------------
working again

Technical Details
----------------------------------------
correctValueType returns for '1,2,3' alwayes NaN if we have the combination of isMultiple and data_type = Integer instead of an array of integers. This change moves the split befor correctValueType and it works again.