### PR TITLE
smtp outbound fails with mysterious message if message body is blank

### DIFF
--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -205,7 +205,7 @@ class CRM_Utils_Mail {
 
     if (is_object($mailer)) {
       try {
-        $result = $mailer->send($to, $headers, $message);
+        $result = $mailer->send($to, $headers, $message ?? '');
       }
       catch (Exception $e) {
         \Civi::log()->error('Mailing error: ' . $e->getMessage());


### PR DESCRIPTION
Overview
----------------------------------------
https://civicrm.stackexchange.com/questions/47964/mailing-error-expected-a-string-or-file-resource

Before
----------------------------------------
1. Use smtp for outbound email.
2. Send an email to a contact and leave the body blank.
3. The user just sees "mail failed". In the log all it says is "Expected a string or file resource".

After
----------------------------------------


Technical Details
----------------------------------------
Briefly Mail_mime generates null for the message when there is no body, and then this ultimately gets passed on to net_smtp which [doesn't like null](https://github.com/pear/Net_SMTP/blob/5d7ba854d75a7c207d8581de1cc6fd2895ae2518/Net/SMTP.php#L1510).

While sending a blank email is odd, it's not illegal.

Comments
----------------------------------------
This isn't recent. Same fail in 5.65, and likely for a long time.