### PR TITLE
CiviCase use APIv4 instead of SQL

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -455,6 +455,51 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
  * @return array
  */
 public static function getCaseActivities(string $type, int $userID, array $condition = [], ?string $limit = NULL, ?string $order = NULL) : array {
+  $params = self::getCaseActivityParams($type, $userID, $condition);
+  $params['select'] = [
+    'case_id',
+    'case_id.subject',
+    'case_contact.contact_id',
+    'case_contact.sort_name',
+    'case_contact.phone',
+    'case_contact.contact_type',
+    'case_contact.contact_sub_type',
+    'activity_id.activity_type_id',
+    'case_id.case_type_id',
+    'case_id.status_id',
+    'activity_id.status_id',
+    'case_id.start_date',
+    'relationship.label_a_b',
+    'relationship.label_b_a',
+    'activity_id.activity_date_time',
+    'activity_id.id',
+    'case_status.label',
+    'case_type.title',
+  ];
+    $cases = [];
+  $result = civicrm_api4('CaseActivity', 'get', $params);
+  foreach ($result as $case) {
+    $cases[$case['case_id']] = [
+      'case_id' => $case['case_id'],
+      'case_subject' => $case['case_id.subject'],
+      'contact_id' => $case['case_contact.contact_id'],
+      'sort_name' => $case['case_contact.sort_name'],
+      'phone' => $case['case_contact.phone'],
+      'contact_type' => $case['case_contact.contact_type'],
+      'contact_sub_type' => $case['case_contact.contact_sub_type'],
+      'activity_type_id' => $case['activity_id.activity_type_id'],
+      'case_type_id' => $case['case_id.case_type_id'],
+      'case_status_id' => $case['case_id.status_id'],
+      'status_id' => $case['activity_id.status_id'],
+      'case_start_date' => $case['case_id.start_date'],
+      'case_role' => $case['relationship.label_a_b'] ?? $case['relationship.label_b_a'],
+      'activity_date_time' => $case['activity_id.activity_date_time'],
+      'activity_id' => $case['activity_id.id'],
+      'case_status' => $case['case_status.label'],
+      'case_type' => $case['case_type.title'],
+    ];
+  }
+  return $cases;
 }
 
 /**
@@ -465,26 +510,50 @@ public static function getCaseActivities(string $type, int $userID, array $condi
  * @return int
  */
 public static function getCaseActivitiesCount(string $type, int $userID, array $condition = []) : int{
+  $params = self::getCaseActivityParams($type, $userID, $condition);
+  $params['select'] = [
+    'row_count',
+  ];
 
-      case 'recent':
-          $params['activity_id.activity_date_time'] = ['<' => 'now'];
-          break;
-
-      case 'any':
-          break;
-
-      default:
-          throw new Exception('Invalid type specified');
-  }
-
-  if ($condition) {
-      $params['where'] = $condition;
-  }
-
-  $result = civicrm_api4('CaseActivity', 'getcount', $params);
-
-  return $result['count'] ?? 0;
+  $result = civicrm_api4('CaseActivity', 'get', $params);
+  return $result->rowCount ?? 0;
 }
+
+/**
+ * @param string $type
+ * @param int $userID
+ * @param array $condition
+ * @return array
+ * 
+ */
+  public static function getCaseActivityParams(string $type, int $userID, array $condition = []) : array
+  {
+    $params = [];
+    $params['join'] = [
+      ['Relationship AS relationship', 'LEFT', ['case_id', '=', 'relationship.case_id']],
+      ['CaseContact AS case_contact', 'LEFT', ['case_id.id', '=', 'case_contact.case_id']],
+    ];
+    switch ($type) {
+        case 'upcoming':
+            $condition[] = ['activity_id.activity_date_time', '>' , date('Y-m-d')];
+            break;
+
+        case 'recent':
+            $condition[] = ['activity_id.activity_date_time', '<' , date('Y-m-d')];
+            break;
+
+        case 'any':
+            break;
+
+        default:
+            throw new Exception('Invalid type specified');
+    }
+
+    if ($condition) {
+        $params['where'] = $condition;
+    }
+    return $params;
+  }
 
   /**
    * @param string $type

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -706,7 +706,7 @@ HERESQL;
    * @param string $context
    * @param bool $getCount
    *
-   * @return array | int
+   * @return array|int
    *   Array of Cases
    */
   public static function getCases($allCases = TRUE, $params = [], $context = 'dashboard', $getCount = FALSE) {

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -759,7 +759,6 @@ HERESQL;
     }
     $casesList = self::getCaseActivities($type, $userID, $condition);
     $casesList['total'] = $totalCount;
-    
 
     $limit = '';
     if (!empty($params['rp'])) {
@@ -1650,7 +1649,6 @@ HERESQL;
         $activityInfo[$case->case_id]['type'] = $activityTypes[$case->activity_type_id] ?? NULL;
       }
     }
-
 
     return $activityInfo;
   }

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -751,7 +751,7 @@ HERESQL;
     foreach (['case_type_id', 'status_id'] as $column) {
       if (!empty($params[$column])) {
         // $condition[] = sprintf("civicrm_case.%s IN (%s)", $column, $params[$column]);
-        $condition[] = ['case_id' . $column, 'IN', $params[$column]];
+        $condition[] = ['case_id.' . $column, 'IN', $params[$column]];
       }
     }
     $totalCount = self::getCaseActivitiesCount($type, $userID, $condition);

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -512,6 +512,7 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
         'case_type' => $case['case_id.case_type_id:name'],
       ];
     }
+    throw new \Exception('test');
     return $cases;
   }
 
@@ -695,7 +696,7 @@ HERESQL;
     if ($limit) {
       $query .= $limit;
     }
-
+    throw new \Exception('test');
     return $query;
   }
 

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -751,6 +751,9 @@ HERESQL;
     foreach (['case_type_id', 'status_id'] as $column) {
       if (!empty($params[$column])) {
         // $condition[] = sprintf("civicrm_case.%s IN (%s)", $column, $params[$column]);
+        if(is_string($params[$column])){
+          $params[$column] = explode(',', $params[$column]);
+        }
         $condition[] = ['case_id.' . $column, 'IN', $params[$column]];
       }
     }

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -483,10 +483,10 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
       foreach ($result as $activity) {
         if ($activity['case_id'] === $case['case_id']) {
           if ($activity['relationship.contact_id_b'] == $userID) {
-              $roles[] = $activity['relationship_type.label_b_a'];
+            $roles[] = $activity['relationship_type.label_b_a'];
           }
           if ($activity['relationship.contact_id_a'] == $userID) {
-              $roles[] = $activity['relationship_type.label_a_b'];
+            $roles[] = $activity['relationship_type.label_a_b'];
           }
         }
       }
@@ -538,7 +538,7 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
    * @param string $type
    * @param int $userID
    * @param array $condition
-   * 
+   *
    * @return array
    */
   public static function getCaseActivityParams(string $type, int $userID, array $condition = []) : array {
@@ -550,23 +550,23 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
       ['RelationshipType AS relationship_type', 'LEFT', ['relationship.relationship_type_id', '=', 'relationship_type.id']],
     ];
     switch ($type) {
-        case 'upcoming':
-          $condition[] = ['activity_id.activity_date_time', '>' , date('Y-m-d')];
-          break;
+      case 'upcoming':
+        $condition[] = ['activity_id.activity_date_time', '>' , date('Y-m-d')];
+        break;
 
-        case 'recent':
-          $condition[] = ['activity_id.activity_date_time', '<' , date('Y-m-d')];
-          break;
+      case 'recent':
+        $condition[] = ['activity_id.activity_date_time', '<' , date('Y-m-d')];
+        break;
 
-        case 'any':
-          break;
+      case 'any':
+        break;
 
-        default:
-          throw new Exception('Invalid type specified');
+      default:
+        throw new Exception('Invalid type specified');
     }
 
     if ($condition) {
-        $params['where'] = $condition;
+      $params['where'] = $condition;
     }
     return $params;
   }
@@ -754,8 +754,8 @@ HERESQL;
     }
     $totalCount = self::getCaseActivitiesCount($type, $userID, $condition);
     if ($getCount) {
-        Civi::$statics[__CLASS__]['totalCount'][$type] = $totalCount;
-        return $totalCount;
+      Civi::$statics[__CLASS__]['totalCount'][$type] = $totalCount;
+      return $totalCount;
     }
     $casesList = self::getCaseActivities($type, $userID, $condition);
     $casesList['total'] = $totalCount;

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -448,58 +448,23 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
   /**
  * @param string $type
  * @param int $userID
- * @param string|null $condition
+ * @param array $condition
  * @param string|null $limit
  * @param string|null $order
  *
  * @return array
  */
-public static function getCaseActivities($type, $userID, $condition = NULL, $limit = NULL, $order = NULL) {
-  $params = [
-      'sequential' => 1,
-      'options' => ['limit' => $limit],
-      'activity_type' => 'caseActivity',
-  ];
-
-  switch ($type) {
-      case 'upcoming':
-          $params['activity_id.activity_date_time'] = ['>' => 'now'];
-          break;
-
-      case 'recent':
-          $params['activity_id.activity_date_time'] = ['<' => 'now'];
-          break;
-
-      case 'any':
-          break;
-
-      default:
-          throw new Exception('Invalid type specified');
-  }
-
-  if ($condition) {
-      $params['where'] = $condition;
-  }
-
-  return civicrm_api4('CaseActivity', 'get', $params)['values'] ?? [];
+public static function getCaseActivities(string $type, int $userID, array $condition = [], ?string $limit = NULL, ?string $order = NULL) : array {
 }
 
 /**
  * @param string $type
  * @param int $userID
- * @param string|null $condition
+ * @param array $condition
  *
  * @return int
  */
-public static function getCaseActivitiesCount($type, $userID, $condition = NULL) {
-  $params = [
-      'activity_type' => 'caseActivity',
-  ];
-
-  switch ($type) {
-      case 'upcoming':
-          $params['activity_id.activity_date_time'] = ['>' => 'now'];
-          break;
+public static function getCaseActivitiesCount(string $type, int $userID, array $condition = []) : int{
 
       case 'recent':
           $params['activity_id.activity_date_time'] = ['<' => 'now'];
@@ -660,7 +625,7 @@ HERESQL;
    *   Array of Cases
    */
   public static function getCases($allCases = TRUE, $params = [], $context = 'dashboard', $getCount = FALSE) {
-    $condition = NULL;
+    $condition = [];
     $casesList = [];
 
     // validate access for own cases.
@@ -682,23 +647,27 @@ HERESQL;
       $allCases = FALSE;
     }
 
-    $whereClauses = ['civicrm_case.is_deleted = 0 AND civicrm_contact.is_deleted <> 1'];
+    // $whereClauses = ['civicrm_case.is_deleted = 0 AND civicrm_contact.is_deleted <> 1'];
+    $condition[] = ['case_id.is_deleted', '<>', TRUE];
 
     if (!$allCases) {
-      $whereClauses[] = "(case_relationship.contact_id_b = {$userID} OR case_relationship.contact_id_a = {$userID})";
-      $whereClauses[] = 'case_relationship.is_active';
+      // $whereClauses[] = "(case_relationship.contact_id_b = {$userID} OR case_relationship.contact_id_a = {$userID})";
+      $condition[] = ['OR', [['relationship.contact_id_b', '=', $userID], ['relationship.contact_id_a', '=', $userID]]];
+      // $whereClauses[] = 'case_relationship.is_active';
+      $condition[] = ['relationship.is_active', '=', TRUE];
     }
     if (empty($params['status_id']) && $type == 'upcoming') {
-      $whereClauses[] = "civicrm_case.status_id != " . CRM_Core_PseudoConstant::getKey('CRM_Case_BAO_Case', 'case_status_id', 'Closed');
+      // $whereClauses[] = "civicrm_case.status_id != " . CRM_Core_PseudoConstant::getKey('CRM_Case_BAO_Case', 'case_status_id', 'Closed');
+      $status_id = CRM_Core_PseudoConstant::getKey('CRM_Case_BAO_Case', 'case_status_id', 'Closed');
+      $condition[] = ['case_id.status_id', '!=', $status_id];
     }
 
     foreach (['case_type_id', 'status_id'] as $column) {
       if (!empty($params[$column])) {
-        $whereClauses[] = sprintf("civicrm_case.%s IN (%s)", $column, $params[$column]);
+        // $condition[] = sprintf("civicrm_case.%s IN (%s)", $column, $params[$column]);
+        $condition[] = ['case_id' . $column, 'IN', $params[$column]];
       }
     }
-    $condition = implode(' AND ', $whereClauses);
-
     $totalCount = self::getCaseActivitiesCount($type, $userID, $condition);
     if ($getCount) {
         Civi::$statics[__CLASS__]['totalCount'][$type] = $totalCount;
@@ -1578,27 +1547,32 @@ HERESQL;
 
     $caseID = implode(',', $cases['case_id']);
     $contactID = implode(',', $cases['contact_id']);
+    $condition = [];
+    $condition[] = ['case_contact.id', 'IN', $contactID];
+    $condition[] = ['case.id', 'IN', $caseID];
+    $condition[] = ['case.is_deleted', '=', $cases['case_deleted']];
+//     $condition = " civicrm_case_contact.contact_id IN( {$contactID} )
+//  AND civicrm_case.id IN( {$caseID})
+//  AND civicrm_case.is_deleted     = {$cases['case_deleted']}";
 
-    $condition = " civicrm_case_contact.contact_id IN( {$contactID} )
- AND civicrm_case.id IN( {$caseID})
- AND civicrm_case.is_deleted     = {$cases['case_deleted']}";
-
-    $query = self::getCaseActivityQuery($type, $userID, $condition);
+    // $query = self::getCaseActivityQuery($type, $userID, $condition);
+    $cases = self::getCaseActivities($type, $userID, $condition);
     $activityTypes = CRM_Activity_BAO_Activity::buildOptions('activity_type_id');
-
-    $res = CRM_Core_DAO::executeQuery($query);
+    // $res = CRM_Core_DAO::executeQuery($query);
 
     $activityInfo = [];
-    while ($res->fetch()) {
+    // while ($res->fetch()) {
+    foreach ($cases as $case) {
       if ($type == 'upcoming') {
-        $activityInfo[$res->case_id]['date'] = $res->activity_date_time;
-        $activityInfo[$res->case_id]['type'] = $activityTypes[$res->activity_type_id] ?? NULL;
+        $activityInfo[$case->case_id]['date'] = $case->activity_date_time;
+        $activityInfo[$case->case_id]['type'] = $activityTypes[$case->activity_type_id] ?? NULL;
       }
       else {
-        $activityInfo[$res->case_id]['date'] = $res->activity_date_time;
-        $activityInfo[$res->case_id]['type'] = $activityTypes[$res->activity_type_id] ?? NULL;
+        $activityInfo[$case->case_id]['date'] = $case->activity_date_time;
+        $activityInfo[$case->case_id]['type'] = $activityTypes[$case->activity_type_id] ?? NULL;
       }
     }
+
 
     return $activityInfo;
   }

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -745,7 +745,7 @@ HERESQL;
 
     foreach (['case_type_id', 'status_id'] as $column) {
       if (!empty($params[$column])) {
-        if(is_string($params[$column])){
+        if (is_string($params[$column])) {
           $params[$column] = explode(',', $params[$column]);
         }
         $condition[] = ['case_id.' . $column, 'IN', $params[$column]];

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -538,8 +538,8 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
    * @param string $type
    * @param int $userID
    * @param array $condition
-   * @return array
    * 
+   * @return array
    */
   public static function getCaseActivityParams(string $type, int $userID, array $condition = []) : array {
     $params = [];

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -530,6 +530,7 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
     $params['groupBy'] = ['case_id'];
 
     $result = civicrm_api4('CaseActivity', 'get', $params);
+    throw new \Exception('test');
     return $result->rowCount ?? 0;
   }
 
@@ -578,6 +579,7 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
    * @return string
    */
   public static function getCaseActivityCountQuery($type, $userID, $condition = NULL) {
+    throw new \Exception('test');
     return sprintf(" SELECT COUNT(*) FROM (%s) temp ", self::getCaseActivityQuery($type, $userID, $condition));
   }
 

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -733,24 +733,19 @@ HERESQL;
       $allCases = FALSE;
     }
 
-    // $whereClauses = ['civicrm_case.is_deleted = 0 AND civicrm_contact.is_deleted <> 1'];
     $condition[] = ['case_id.is_deleted', '<>', TRUE];
 
     if (!$allCases) {
-      // $whereClauses[] = "(case_relationship.contact_id_b = {$userID} OR case_relationship.contact_id_a = {$userID})";
       $condition[] = ['OR', [['relationship.contact_id_b', '=', $userID], ['relationship.contact_id_a', '=', $userID]]];
-      // $whereClauses[] = 'case_relationship.is_active';
       $condition[] = ['relationship.is_active', '=', TRUE];
     }
     if (empty($params['status_id']) && $type == 'upcoming') {
-      // $whereClauses[] = "civicrm_case.status_id != " . CRM_Core_PseudoConstant::getKey('CRM_Case_BAO_Case', 'case_status_id', 'Closed');
       $status_id = CRM_Core_PseudoConstant::getKey('CRM_Case_BAO_Case', 'case_status_id', 'Closed');
       $condition[] = ['case_id.status_id', '!=', $status_id];
     }
 
     foreach (['case_type_id', 'status_id'] as $column) {
       if (!empty($params[$column])) {
-        // $condition[] = sprintf("civicrm_case.%s IN (%s)", $column, $params[$column]);
         if(is_string($params[$column])){
           $params[$column] = explode(',', $params[$column]);
         }
@@ -1634,25 +1629,17 @@ HERESQL;
   public static function getNextScheduledActivity($cases, $type = 'upcoming') {
     $userID = CRM_Core_Session::getLoggedInContactID();
 
-    // $caseID = implode(',', $cases['case_id']);
     $caseID = $cases['case_id'];
-    // $contactID = implode(',', $cases['contact_id']);
     $contactID = $cases['contact_id'];
     $condition = [];
     $condition[] = ['case_contact.id', 'IN', $contactID];
     $condition[] = ['case_id', 'IN', $caseID];
     $condition[] = ['case_id.is_deleted', '=', $cases['case_deleted']];
-//     $condition = " civicrm_case_contact.contact_id IN( {$contactID} )
-//  AND civicrm_case.id IN( {$caseID})
-//  AND civicrm_case.is_deleted     = {$cases['case_deleted']}";
 
-    // $query = self::getCaseActivityQuery($type, $userID, $condition);
     $cases = self::getCaseActivities($type, $userID, $condition);
     $activityTypes = CRM_Activity_BAO_Activity::buildOptions('activity_type_id');
-    // $res = CRM_Core_DAO::executeQuery($query);
 
     $activityInfo = [];
-    // while ($res->fetch()) {
     foreach ($cases as $case) {
       if ($type == 'upcoming') {
         $activityInfo[$case->case_id]['date'] = $case->activity_date_time;

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -444,7 +444,6 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
     return $caseArray;
   }
 
-
   /**
    * @param string $type
    * @param int $userID

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -460,43 +460,57 @@ public static function getCaseActivities(string $type, int $userID, array $condi
     'case_id',
     'case_id.subject',
     'case_contact.contact_id',
-    'case_contact.sort_name',
-    'case_contact.phone',
-    'case_contact.contact_type',
-    'case_contact.contact_sub_type',
+    'contact.sort_name',
+    'contact.phone_primary',
+    'contact.contact_type',
+    'contact.contact_sub_type',
     'activity_id.activity_type_id',
     'case_id.case_type_id',
     'case_id.status_id',
     'activity_id.status_id',
     'case_id.start_date',
-    'relationship.label_a_b',
-    'relationship.label_b_a',
+    'relationship.contact_id_b',
+    'relationship.contact_id_a',
+    'relationship_type.label_b_a',
     'activity_id.activity_date_time',
     'activity_id.id',
-    'case_status.label',
-    'case_type.title',
+    'case_id.status_id:label',
+    'case_id.case_type_id:name',
   ];
-    $cases = [];
+  $cases = [];
   $result = civicrm_api4('CaseActivity', 'get', $params);
   foreach ($result as $case) {
+    $roles = [];
+    foreach ($result as $activity) {
+      if ($activity['case_id'] === $case['case_id']) {
+          if ($activity['relationship.contact_id_b'] == $userID) {
+              $roles[] = $activity['relationship_type.label_b_a'];
+          }
+          if ($activity['relationship.contact_id_a'] == $userID) {
+              $roles[] = $activity['relationship_type.label_a_b'];
+          }
+      }
+    }
+    $uniqueRoles = array_unique($roles);
+    $role = implode(', ', $uniqueRoles);
     $cases[$case['case_id']] = [
       'case_id' => $case['case_id'],
       'case_subject' => $case['case_id.subject'],
       'contact_id' => $case['case_contact.contact_id'],
-      'sort_name' => $case['case_contact.sort_name'],
-      'phone' => $case['case_contact.phone'],
-      'contact_type' => $case['case_contact.contact_type'],
-      'contact_sub_type' => $case['case_contact.contact_sub_type'],
+      'sort_name' => $case['contact.sort_name'],
+      'phone' => $case['contact.phone_primary'],
+      'contact_type' => $case['contact.contact_type'],
+      'contact_sub_type' => $case['contact.contact_sub_type'],
       'activity_type_id' => $case['activity_id.activity_type_id'],
       'case_type_id' => $case['case_id.case_type_id'],
       'case_status_id' => $case['case_id.status_id'],
       'status_id' => $case['activity_id.status_id'],
       'case_start_date' => $case['case_id.start_date'],
-      'case_role' => $case['relationship.label_a_b'] ?? $case['relationship.label_b_a'],
+      'case_role' => $role,
       'activity_date_time' => $case['activity_id.activity_date_time'],
       'activity_id' => $case['activity_id.id'],
-      'case_status' => $case['case_status.label'],
-      'case_type' => $case['case_type.title'],
+      'case_status' => $case['case_id.status_id:label'],
+      'case_type' => $case['case_id.case_type_id:name'],
     ];
   }
   return $cases;
@@ -532,6 +546,8 @@ public static function getCaseActivitiesCount(string $type, int $userID, array $
     $params['join'] = [
       ['Relationship AS relationship', 'LEFT', ['case_id', '=', 'relationship.case_id']],
       ['CaseContact AS case_contact', 'LEFT', ['case_id.id', '=', 'case_contact.case_id']],
+      ['Contact AS contact', 'LEFT', ['case_contact.contact_id', '=', 'contact.id']],
+      ['RelationshipType AS relationship_type', 'LEFT', ['relationship.relationship_type_id', '=', 'relationship_type.id']],
     ];
     switch ($type) {
         case 'upcoming':

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -446,101 +446,101 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
 
 
   /**
- * @param string $type
- * @param int $userID
- * @param array $condition
- * @param string|null $limit
- * @param string|null $order
- *
- * @return array
- */
-public static function getCaseActivities(string $type, int $userID, array $condition = [], ?string $limit = NULL, ?string $order = NULL) : array {
-  $params = self::getCaseActivityParams($type, $userID, $condition);
-  $params['select'] = [
-    'case_id',
-    'case_id.subject',
-    'case_contact.contact_id',
-    'contact.sort_name',
-    'contact.phone_primary',
-    'contact.contact_type',
-    'contact.contact_sub_type',
-    'activity_id.activity_type_id',
-    'case_id.case_type_id',
-    'case_id.status_id',
-    'activity_id.status_id',
-    'case_id.start_date',
-    'relationship.contact_id_b',
-    'relationship.contact_id_a',
-    'relationship_type.label_b_a',
-    'activity_id.activity_date_time',
-    'activity_id.id',
-    'case_id.status_id:label',
-    'case_id.case_type_id:name',
-  ];
-  $cases = [];
-  $result = civicrm_api4('CaseActivity', 'get', $params);
-  foreach ($result as $case) {
-    $roles = [];
-    foreach ($result as $activity) {
-      if ($activity['case_id'] === $case['case_id']) {
-          if ($activity['relationship.contact_id_b'] == $userID) {
-              $roles[] = $activity['relationship_type.label_b_a'];
-          }
-          if ($activity['relationship.contact_id_a'] == $userID) {
-              $roles[] = $activity['relationship_type.label_a_b'];
-          }
-      }
-    }
-    $uniqueRoles = array_unique($roles);
-    $role = implode(', ', $uniqueRoles);
-    $cases[$case['case_id']] = [
-      'case_id' => $case['case_id'],
-      'case_subject' => $case['case_id.subject'],
-      'contact_id' => $case['case_contact.contact_id'],
-      'sort_name' => $case['contact.sort_name'],
-      'phone' => $case['contact.phone_primary'],
-      'contact_type' => $case['contact.contact_type'],
-      'contact_sub_type' => $case['contact.contact_sub_type'],
-      'activity_type_id' => $case['activity_id.activity_type_id'],
-      'case_type_id' => $case['case_id.case_type_id'],
-      'case_status_id' => $case['case_id.status_id'],
-      'status_id' => $case['activity_id.status_id'],
-      'case_start_date' => $case['case_id.start_date'],
-      'case_role' => $role,
-      'activity_date_time' => $case['activity_id.activity_date_time'],
-      'activity_id' => $case['activity_id.id'],
-      'case_status' => $case['case_id.status_id:label'],
-      'case_type' => $case['case_id.case_type_id:name'],
+   * @param string $type
+   * @param int $userID
+   * @param array $condition
+   * @param string|null $limit
+   * @param string|null $order
+   *
+   * @return array
+   */
+  public static function getCaseActivities(string $type, int $userID, array $condition = [], ?string $limit = NULL, ?string $order = NULL) : array {
+    $params = self::getCaseActivityParams($type, $userID, $condition);
+    $params['select'] = [
+      'case_id',
+      'case_id.subject',
+      'case_contact.contact_id',
+      'contact.sort_name',
+      'contact.phone_primary',
+      'contact.contact_type',
+      'contact.contact_sub_type',
+      'activity_id.activity_type_id',
+      'case_id.case_type_id',
+      'case_id.status_id',
+      'activity_id.status_id',
+      'case_id.start_date',
+      'relationship.contact_id_b',
+      'relationship.contact_id_a',
+      'relationship_type.label_b_a',
+      'activity_id.activity_date_time',
+      'activity_id.id',
+      'case_id.status_id:label',
+      'case_id.case_type_id:name',
     ];
+    $cases = [];
+    $result = civicrm_api4('CaseActivity', 'get', $params);
+    foreach ($result as $case) {
+      $roles = [];
+      foreach ($result as $activity) {
+        if ($activity['case_id'] === $case['case_id']) {
+            if ($activity['relationship.contact_id_b'] == $userID) {
+                $roles[] = $activity['relationship_type.label_b_a'];
+            }
+            if ($activity['relationship.contact_id_a'] == $userID) {
+                $roles[] = $activity['relationship_type.label_a_b'];
+            }
+        }
+      }
+      $uniqueRoles = array_unique($roles);
+      $role = implode(', ', $uniqueRoles);
+      $cases[$case['case_id']] = [
+        'case_id' => $case['case_id'],
+        'case_subject' => $case['case_id.subject'],
+        'contact_id' => $case['case_contact.contact_id'],
+        'sort_name' => $case['contact.sort_name'],
+        'phone' => $case['contact.phone_primary'],
+        'contact_type' => $case['contact.contact_type'],
+        'contact_sub_type' => $case['contact.contact_sub_type'],
+        'activity_type_id' => $case['activity_id.activity_type_id'],
+        'case_type_id' => $case['case_id.case_type_id'],
+        'case_status_id' => $case['case_id.status_id'],
+        'status_id' => $case['activity_id.status_id'],
+        'case_start_date' => $case['case_id.start_date'],
+        'case_role' => $role,
+        'activity_date_time' => $case['activity_id.activity_date_time'],
+        'activity_id' => $case['activity_id.id'],
+        'case_status' => $case['case_id.status_id:label'],
+        'case_type' => $case['case_id.case_type_id:name'],
+      ];
+    }
+    return $cases;
   }
-  return $cases;
-}
 
-/**
- * @param string $type
- * @param int $userID
- * @param array $condition
- *
- * @return int
- */
-public static function getCaseActivitiesCount(string $type, int $userID, array $condition = []) : int{
-  $params = self::getCaseActivityParams($type, $userID, $condition);
-  $params['select'] = [
-    'row_count',
-  ];
-  $params['groupBy'] = ['case_id'];
+  /**
+   * @param string $type
+   * @param int $userID
+   * @param array $condition
+   *
+   * @return int
+   */
+  public static function getCaseActivitiesCount(string $type, int $userID, array $condition = []) : int{
+    $params = self::getCaseActivityParams($type, $userID, $condition);
+    $params['select'] = [
+      'row_count',
+    ];
+    $params['groupBy'] = ['case_id'];
 
-  $result = civicrm_api4('CaseActivity', 'get', $params);
-  return $result->rowCount ?? 0;
-}
+    $result = civicrm_api4('CaseActivity', 'get', $params);
+    return $result->rowCount ?? 0;
+  }
 
-/**
- * @param string $type
- * @param int $userID
- * @param array $condition
- * @return array
- * 
- */
+  /**
+   * @param string $type
+   * @param int $userID
+   * @param array $condition
+   * @return array
+   * 
+   */
   public static function getCaseActivityParams(string $type, int $userID, array $condition = []) : array
   {
     $params = [];

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1634,12 +1634,14 @@ HERESQL;
   public static function getNextScheduledActivity($cases, $type = 'upcoming') {
     $userID = CRM_Core_Session::getLoggedInContactID();
 
-    $caseID = implode(',', $cases['case_id']);
-    $contactID = implode(',', $cases['contact_id']);
+    // $caseID = implode(',', $cases['case_id']);
+    $caseID = $cases['case_id'];
+    // $contactID = implode(',', $cases['contact_id']);
+    $contactID = $cases['contact_id'];
     $condition = [];
     $condition[] = ['case_contact.id', 'IN', $contactID];
-    $condition[] = ['case.id', 'IN', $caseID];
-    $condition[] = ['case.is_deleted', '=', $cases['case_deleted']];
+    $condition[] = ['case_id', 'IN', $caseID];
+    $condition[] = ['case_id.is_deleted', '=', $cases['case_deleted']];
 //     $condition = " civicrm_case_contact.contact_id IN( {$contactID} )
 //  AND civicrm_case.id IN( {$caseID})
 //  AND civicrm_case.is_deleted     = {$cases['case_deleted']}";

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -512,7 +512,6 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
         'case_type' => $case['case_id.case_type_id:name'],
       ];
     }
-    throw new \Exception('test');
     return $cases;
   }
 
@@ -531,7 +530,6 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
     $params['groupBy'] = ['case_id'];
 
     $result = civicrm_api4('CaseActivity', 'get', $params);
-    throw new \Exception('test');
     return $result->rowCount ?? 0;
   }
 
@@ -580,7 +578,6 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
    * @return string
    */
   public static function getCaseActivityCountQuery($type, $userID, $condition = NULL) {
-    throw new \Exception('test');
     return sprintf(" SELECT COUNT(*) FROM (%s) temp ", self::getCaseActivityQuery($type, $userID, $condition));
   }
 
@@ -696,7 +693,6 @@ HERESQL;
     if ($limit) {
       $query .= $limit;
     }
-    throw new \Exception('test');
     return $query;
   }
 

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -528,6 +528,7 @@ public static function getCaseActivitiesCount(string $type, int $userID, array $
   $params['select'] = [
     'row_count',
   ];
+  $params['groupBy'] = ['case_id'];
 
   $result = civicrm_api4('CaseActivity', 'get', $params);
   return $result->rowCount ?? 0;

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -483,12 +483,12 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
       $roles = [];
       foreach ($result as $activity) {
         if ($activity['case_id'] === $case['case_id']) {
-            if ($activity['relationship.contact_id_b'] == $userID) {
-                $roles[] = $activity['relationship_type.label_b_a'];
-            }
-            if ($activity['relationship.contact_id_a'] == $userID) {
-                $roles[] = $activity['relationship_type.label_a_b'];
-            }
+          if ($activity['relationship.contact_id_b'] == $userID) {
+              $roles[] = $activity['relationship_type.label_b_a'];
+          }
+          if ($activity['relationship.contact_id_a'] == $userID) {
+              $roles[] = $activity['relationship_type.label_a_b'];
+          }
         }
       }
       $uniqueRoles = array_unique($roles);

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -523,7 +523,7 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
    *
    * @return int
    */
-  public static function getCaseActivitiesCount(string $type, int $userID, array $condition = []) : int{
+  public static function getCaseActivitiesCount(string $type, int $userID, array $condition = []) : int {
     $params = self::getCaseActivityParams($type, $userID, $condition);
     $params['select'] = [
       'row_count',
@@ -541,8 +541,7 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
    * @return array
    * 
    */
-  public static function getCaseActivityParams(string $type, int $userID, array $condition = []) : array
-  {
+  public static function getCaseActivityParams(string $type, int $userID, array $condition = []) : array {
     $params = [];
     $params['join'] = [
       ['Relationship AS relationship', 'LEFT', ['case_id', '=', 'relationship.case_id']],
@@ -552,18 +551,18 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
     ];
     switch ($type) {
         case 'upcoming':
-            $condition[] = ['activity_id.activity_date_time', '>' , date('Y-m-d')];
-            break;
+          $condition[] = ['activity_id.activity_date_time', '>' , date('Y-m-d')];
+          break;
 
         case 'recent':
-            $condition[] = ['activity_id.activity_date_time', '<' , date('Y-m-d')];
-            break;
+          $condition[] = ['activity_id.activity_date_time', '<' , date('Y-m-d')];
+          break;
 
         case 'any':
-            break;
+          break;
 
         default:
-            throw new Exception('Invalid type specified');
+          throw new Exception('Invalid type specified');
     }
 
     if ($condition) {

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -48,7 +48,7 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
       'timeline' => "standard_timeline",
     ]);
 
-    $query = CRM_Case_BAO_Case::getCaseActivities('recent', $userID, [' civicrm_case.id IN( 1 )']);
+    $query = CRM_Case_BAO_Case::getCaseActivities('recent', $userID, [['case_id', 'IN', 1]]);
     $res = CRM_Core_DAO::executeQuery($query);
     $openCaseType = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Open Case');
     while ($res->fetch()) {

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -48,7 +48,7 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
       'timeline' => "standard_timeline",
     ]);
 
-    $query = CRM_Case_BAO_Case::getCaseActivities('recent', $userID, [['case_id', 'IN', 1]]);
+    $query = CRM_Case_BAO_Case::getCaseActivities('recent', $userID, [['case_id', 'IN', [1]]]);
     $res = CRM_Core_DAO::executeQuery($query);
     $openCaseType = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Open Case');
     while ($res->fetch()) {

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -48,7 +48,7 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
       'timeline' => "standard_timeline",
     ]);
 
-    $query = CRM_Case_BAO_Case::getCaseActivityQuery('recent', $userID, ' civicrm_case.id IN( 1 )');
+    $query = CRM_Case_BAO_Case::getCaseActivities('recent', $userID, [' civicrm_case.id IN( 1 )']);
     $res = CRM_Core_DAO::executeQuery($query);
     $openCaseType = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Open Case');
     while ($res->fetch()) {


### PR DESCRIPTION
Overview
----------------------------------------
As mentioned in [29419](https://github.com/civicrm/civicrm-core/pull/29419#issuecomment-2037278582), this PR make evolve `getCases()` to use api4 instead of SQL queries

Before
----------------------------------------
SQL queries used for `getCases()` and `getNextScheduledActivity()`

After
----------------------------------------
APIv4 queries used for `getCases()` and `getNextScheduledActivity()`

