### PR TITLE
SearchKit Conditional punctuation

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -340,9 +340,10 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    * @return string
    */
   protected function rewrite(string $rewrite, array $data, string $format = 'view'): string {
-    // Cheap str_contains to skip Smarty processing if not needed
-    $hasSmarty = str_contains($rewrite, '{');
     $output = $this->replaceTokens($rewrite, $data, $format);
+    $output = \Civi\Token\TokenCompatSubscriber::renderConditionalPunctuation($output);
+    // Cheap str_contains to skip Smarty processing if not needed
+    $hasSmarty = str_contains($output, '{');
     if ($hasSmarty) {
       $vars = [];
       $nestedIds = [];

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -915,6 +915,61 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
   }
 
   /**
+   * Test conditional punctuation in rewrite syntax.
+   */
+  public function testRunWithConditionalPunctuation() {
+    $lastName = uniqid(__FUNCTION__);
+    $sampleData = [
+      ['first_name' => 'Alpha', 'middle_name' => 'Middle', 'last_name' => $lastName, 'nick_name' => 'Al'],
+      ['first_name' => 'Beta', 'last_name' => $lastName],
+    ];
+    Contact::save(FALSE)->setRecords($sampleData)->execute();
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'Contact',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['id', 'first_name', 'middle_name', 'last_name', 'nick_name'],
+          'where' => [['last_name', '=', $lastName]],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => 'testDisplayPunctuation',
+        'settings' => [
+          'limit' => 20,
+          'pager' => TRUE,
+          'columns' => [
+            [
+              'key' => 'first_name',
+              'label' => 'Full Name',
+              'type' => 'field',
+              'rewrite' => '[first_name]{ }[middle_name]{ }[last_name]',
+            ],
+            [
+              'key' => 'nick_name',
+              'label' => 'Name & Nickname',
+              'type' => 'field',
+              'rewrite' => '[first_name]{ (}[nick_name]{)}',
+            ],
+          ],
+          'sort' => [
+            ['id', 'ASC'],
+          ],
+        ],
+      ],
+    ];
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertEquals("Alpha Middle $lastName", $result[0]['columns'][0]['val']);
+    $this->assertEquals("Beta $lastName", $result[1]['columns'][0]['val']);
+    $this->assertEquals("Alpha (Al)", $result[0]['columns'][1]['val']);
+    $this->assertEquals("Beta", $result[1]['columns'][1]['val']);
+  }
+
+  /**
    * Test running a searchDisplay as a restricted user.
    */
   public function testDisplayACLCheck() {

--- a/tests/phpunit/Civi/Token/TokenCompatSubscriberTest.php
+++ b/tests/phpunit/Civi/Token/TokenCompatSubscriberTest.php
@@ -1,0 +1,36 @@
+<?php
+namespace Civi\Token;
+
+use CiviUnitTestCase;
+
+/**
+ * @group headless
+ */
+class TokenCompatSubscriberTest extends CiviUnitTestCase {
+
+  /**
+   * Test conditional punctuation rendering.
+   *
+   * @dataProvider conditionalPunctuationDataProvider
+   */
+  public function testRenderConditionalPunctuation(string $input, string $expected): void {
+    $this->assertEquals($expected, TokenCompatSubscriber::renderConditionalPunctuation($input));
+  }
+
+  public function conditionalPunctuationDataProvider(): array {
+    return [
+      'simple space separation' => ['John{ }Smith', 'John Smith'],
+      'leading space removal' => ['{ }Smith', 'Smith'],
+      'trailing space removal' => ['John{ }', 'John'],
+      'comma space separation' => ['San Francisco{, }CA', 'San Francisco, CA'],
+      'trailing comma space removal' => ['San Francisco{, }', 'San Francisco'],
+      'leading comma space removal' => ['{, }CA', 'CA'],
+      'parentheses paired' => ['John{ (}Johnny{) }Smith', 'John (Johnny) Smith'],
+      'parentheses paired removed when missing inner' => ['John{ (}{) }Smith', 'JohnSmith'],
+      'address block style' => ['123 Main St{, }{ }Suite 100', '123 Main St, Suite 100'],
+      'multiple adjacent curlies' => ['John{ }{, }Smith', 'John, Smith'],
+      'empty input' => ['', ''],
+    ];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Enable conditional punctuation in SearchKit 'rewrite' functionality.

Examples:
-  a rewrite of `[first_name]{ }{ (}[nick_name]{) }[last_name]` produces `First (Nick) Last` when `nick_name` exists or otherwise `First Last` (ie _not_ `First () Last`)
- a rewrite of `[street_address]{, }[supplemental_address_1]{, }[supplemental_address_2]{, }[city]{, }[state]` avoids double commas where parts of the address are blank. 

Before
----------------------------------------
Using conditional punctuation results in no results since it is treated as invalid Smarty.

After
----------------------------------------
Works

Technical Details
----------------------------------------


Comments
----------------------------------------
Might be a better code location for `renderConditionalPunctuation()` than in `TokenCompatSubscriber`
