### PR TITLE
Api4 - Handle EMPTY operators correctly with boolean fields

### DIFF
--- a/Civi/Api4/Query/Api4Query.php
+++ b/Civi/Api4/Query/Api4Query.php
@@ -406,7 +406,7 @@ abstract class Api4Query {
       // If field is not a string or number, this will pass through and use IS NULL/IS NOT NULL
       $operator = str_replace('EMPTY', 'NULL', $operator);
       // For strings & numbers, create an OR grouping of empty value OR null
-      if (in_array($field['data_type'] ?? NULL, ['String', 'Integer', 'Float'], TRUE)) {
+      if (in_array($field['data_type'] ?? NULL, ['String', 'Integer', 'Float', 'Boolean'], TRUE)) {
         $emptyVal = $field['data_type'] === 'String' ? '""' : '0';
         $isEmptyClause = $operator === 'IS NULL' ? "= $emptyVal OR" : "<> $emptyVal AND";
         return "($fieldAlias $isEmptyClause $fieldAlias $operator)";

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -80,7 +80,9 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
         'api_params' => [
           'version' => 4,
           'select' => ['id', 'first_name', 'middle_name', 'last_name', 'contact_sub_type:label', 'is_deceased'],
-          'where' => [],
+          'where' => [
+            ['do_not_email', 'IS EMPTY'],
+          ],
         ],
       ],
       'display' => [


### PR DESCRIPTION
Overview
----------------------------------------
Fixes SearchKit bug when using EMPTY operator with boolean fields.

Before
----------------------------------------
Search for contacts where "Do not mail" IS EMPTY. No results returned.

After
----------------------------------------
Correct results returned.