### PR TITLE
[NFC] Make tests fail when any error handlers don't clean themselves up

### DIFF
--- a/tests/phpunit/api/v3/ExtensionTest.php
+++ b/tests/phpunit/api/v3/ExtensionTest.php
@@ -25,11 +25,13 @@ class api_v3_ExtensionTest extends CiviUnitTestCase {
   use \Civi\Test\GuzzleTestTrait;
 
   public function setUp(): void {
+    parent::setUp();
     Civi::settings()->set('ext_repo_url', 'http://localhost:9999/fake-repo');
   }
 
   public function tearDown(): void {
     Civi::settings()->revert('ext_repo_url');
+    parent::tearDown();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Followup to https://github.com/civicrm/civicrm-core/pull/30068 / https://github.com/civicrm/civicrm-core/pull/30077

Assuming this doesn't find anything (the previous PRs were specific to the smarty error handler), one way to test it is just make a test like

```php
  public function testSomething() {
    set_error_handler(function($errno, $errstr, $errfile, $errline) {
      fwrite(STDERR, "hello\n");
    });
    $this->assertTrue(1 == 1);
  }
```