### PR TITLE
dev/core#5210 Add deceased date to contact reports

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4911,6 +4911,10 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
         'title' => ts('Age'),
         'dbAlias' => 'TIMESTAMPDIFF(YEAR, contact_civireport.birth_date, CURDATE())',
       ],
+      'is_deceased' => [],
+      'deceased_date' => [
+        'title' => ts('Deceased Date'),
+      ],
       'job_title' => [
         'title' => ts('Contact Job title'),
       ],
@@ -4926,7 +4930,6 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       'do_not_sms' => [],
       'do_not_trade' => [],
       'is_opt_out' => [],
-      'is_deceased' => [],
       'preferred_language' => [],
       'employer_id' => [
         'title' => ts('Current Employer'),


### PR DESCRIPTION
Overview
----------------------------------------
Deceased date is missing in the contact reports

https://lab.civicrm.org/dev/core/-/issues/5210

Before
----------------------------------------
![Screenshot 2024-05-14 181544](https://github.com/civicrm/civicrm-core/assets/3455173/4f8e65d2-8ebb-4b65-bfce-da0a23b7bbc8)


After
----------------------------------------
Voila!!!