### PR TITLE
Fix missing opening <p> tag

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -78,13 +78,14 @@
           {if !empty($auto_renew)} {* Auto-renew membership confirmation *}
             {crmRegion name="contribution-confirm-recur-membership"}
               <br/>
-              <strong>
-                {if $autoRenewOption == 1}
-                  {ts 1=$frequency_interval 2=$frequency_unit}I want this membership to be renewed automatically every %1 %2(s).{/ts}
-                {elseif $autoRenewOption == 2}
-                  {ts 1=$frequency_interval 2=$frequency_unit}This membership will be renewed automatically every %1 %2(s).{/ts}
-                {/if}
-              </strong>
+              <p>
+                <strong>
+                  {if $autoRenewOption == 1}
+                    {ts 1=$frequency_interval 2=$frequency_unit}I want this membership to be renewed automatically every %1 %2(s).{/ts}
+                  {elseif $autoRenewOption == 2}
+                    {ts 1=$frequency_interval 2=$frequency_unit}This membership will be renewed automatically every %1 %2(s).{/ts}
+                  {/if}
+                </strong>
               </p>
               <div class="description crm-auto-renew-cancel-info">
                 ({ts}Your initial membership fee will be processed once you complete the confirmation step. You will be able to cancel the auto-renewal option by visiting the web page link that will be included in your receipt.{/ts}


### PR DESCRIPTION
Overview
----------------------------------------
Membership auto-renewal confirmation page has been missing an opening `<p>` for ages.

Before
----------------------------------------
No opening pee, invalid markup, Chrome auto-corrects it:

![broken-pee](https://github.com/civicrm/civicrm-core/assets/5212601/94e157c1-a8cd-45ec-8865-eccf6b636a48)


After
----------------------------------------
An opening pee, valid HTML, much rejoicing.

