### PR TITLE
dev/core#1735 Reports: Expose all custom fields, not just the indexed ones

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2398,7 +2398,6 @@ INNER JOIN civicrm_custom_group cg ON cg.id = cf.custom_group_id
 WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
       cg.is_active = 1 AND
       cf.is_active = 1 AND
-      cf.is_searchable = 1 AND
       cf.data_type   NOT IN ('ContactReference', 'Date') AND
       cf.id IN (" . implode(",", $customFieldIds) . ")";
 
@@ -4029,8 +4028,7 @@ INNER  JOIN civicrm_custom_field cf ON cg.id = cf.custom_group_id
 WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
       {$customGroupWhere}
       cg.is_active = 1 AND
-      cf.is_active = 1 AND
-      cf.is_searchable = 1
+      cf.is_active = 1
 ORDER BY cg.weight, cf.weight";
     $customDAO = CRM_Core_DAO::executeQuery($sql);
 


### PR DESCRIPTION
Overview
----------------------------------------

Related to : https://lab.civicrm.org/dev/core/-/issues/1735

Reports only expose custom fields that have the "Is searchable?" option set. This option actually means "is the field indexed", and SearchKit ignores it.

Before
----------------------------------------

Only indexed custom fields are available in Reports.

After
----------------------------------------

All custom fields are available.

Comments
----------------------------------------

I plan to do the same for Advanced Search if all goes well.

Exposing this does mean that admins might shoot themselves in the foot, if they do heavy queries, but they have plenty of opportunities for shooting themselves in the foot, even if a field is indexed. So I don't think this should be our criteria for exposing a field or not.

I guess it could lead to more clutter in reports, but this means that people have too much clutter. We should not make it difficult for newbies and small users, just because there are data hoarders out there.