### PR TITLE
dev/core#1735 Custom Fields: rename is_searchable label and help, always display range options

### DIFF
--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -423,9 +423,6 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
     );
     $this->addRule('weight', ts('is a numeric field'), 'numeric');
 
-    // is required ?
-    $this->add('advcheckbox', 'is_required', ts('Required?'));
-
     // checkbox / radio options per line
     $this->add('number', 'options_per_line', ts('Options Per Line'), ['min' => 0]);
     $this->addRule('options_per_line', ts('must be a numeric value'), 'numeric');
@@ -441,20 +438,11 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
       $attributes['help_post']
     );
 
-    // is active ?
-    $this->add('advcheckbox', 'is_active', ts('Active?'));
-
-    // is active ?
-    $this->add('advcheckbox', 'is_view', ts('View Only?'));
-
-    // is searchable ?
-    $this->addElement('advcheckbox',
-      'is_searchable',
-      ts('Is this Field Searchable?')
-    );
-
-    // is searchable by range?
-    $this->addRadio('is_search_range', ts('Search by Range?'), [ts('No'), ts('Yes')]);
+    $this->add('advcheckbox', 'is_required', ts('Required'));
+    $this->addElement('advcheckbox', 'is_searchable', ts('Optimize for Search'));
+    $this->addRadio('is_search_range', ts('Search by Range'), [ts('No'), ts('Yes')]);
+    $this->add('advcheckbox', 'is_active', ts('Active'));
+    $this->add('advcheckbox', 'is_view', ts('View Only'));
 
     $buttons = [
       [
@@ -851,9 +839,9 @@ AND    option_group_id = %2";
     $params = $this->controller->exportValues($this->_name);
     self::clearEmptyOptions($params);
 
-    //fix for 'is_search_range' field.
+    // Automatically disable 'is_search_range' if the field does not support it
     if (in_array($params['data_type'], ['Int', 'Float', 'Money', 'Date'])) {
-      if (empty($params['is_searchable']) || in_array($params['html_type'], ['Radio', 'Select'])) {
+      if (in_array($params['html_type'], ['Radio', 'Select'])) {
         $params['is_search_range'] = 0;
       }
     }

--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -155,7 +155,7 @@
       <td class="label">{$form.is_searchable.label}</td>
       <td class="html-adjust">{$form.is_searchable.html}
         {if $action neq 4}
-          <br /><span class="description">{ts}Can you search on this field in the Advanced and component search forms? Also determines whether you can include this field as a display column and / or filter in related detail reports.{/ts}</span>
+          <br /><span class="description">{ts}Adds a database index which helps speed up searches on this field significantly. However, it can require more storage and can slow down the system if the data is frequently updated.{/ts}</span>
         {/if}
       </td>
     </tr>
@@ -229,7 +229,7 @@
 
     function showSearchRange(dataType) {
       if (_.includes(['Date', 'Int', 'Float', 'Money'], dataType)) {
-        $("#searchByRange", $form).toggle($('#is_searchable', $form).is(':checked'));
+        $("#searchByRange", $form).show();
       } else {
         $("#searchByRange", $form).hide();
       }


### PR DESCRIPTION
Overview
----------------------------------------

Related to: https://lab.civicrm.org/dev/core/-/issues/1735

Updates the label and help text for the "Is Searchable?" option when creating a new Custom Field.

To reproduce:

- Go to a Custom Field Group
- Add or Edit a field

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/55462172-61a3-4103-ab2d-88c2355445ea)

After
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/54302a68-8fb5-4875-8b14-d8cc4c38ce08)

Technical Details
----------------------------------------

Related to #30186, which now always displays custom fields, regardless of this option. The same will be done for the Advanced Search. SearchKit already ignores this setting.

Based on changes proposed by @colemanw, @artfulrobot and @petednz