### PR TITLE
Case custom fields no longer appearing on print report

### DIFF
--- a/CRM/Case/XMLProcessor/Report.php
+++ b/CRM/Case/XMLProcessor/Report.php
@@ -959,7 +959,7 @@ LIMIT  1
 
     // Retrieve custom values for cases.
     $customValues = CRM_Core_BAO_CustomValueTable::getEntityValues($caseID, 'Case');
-    $extends = ['case'];
+    $extends = ['Case'];
     $groupTree = CRM_Core_BAO_CustomGroup::getGroupDetail(NULL, NULL, $extends);
     $caseCustomFields = [];
     foreach ($groupTree as $gid => $group_values) {


### PR DESCRIPTION
Overview
----------------------------------------
https://civicrm.stackexchange.com/questions/48034/custom-data-fields-not-showing-on-case-print-report

Before
----------------------------------------
1. Create a custom field for CASES
2. Create a case and put something in the custom field.
3. Visit the Print Report link on manage case.
4. The custom field group doesn't show.

After
----------------------------------------
It does.

Technical Details
----------------------------------------
It's from https://github.com/civicrm/civicrm-core/commit/269181b62f5774b0374 in 5.71

Comments
----------------------------------------

