### PR TITLE
Similar to 30189 - customgroup::getGroupDetail is case-sensitive now

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -176,8 +176,10 @@ class CRM_Event_BAO_Event extends CRM_Event_DAO_Event implements \Civi\Core\Hook
   public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
     if ($event->action === 'delete' && $event->id) {
 
-      $extends = ['event'];
+      $extends = ['Event'];
       $groupTree = CRM_Core_BAO_CustomGroup::getGroupDetail(NULL, NULL, $extends);
+      // @todo is this custom field loop necessary? The cascade delete on the
+      // db foreign key should do it already.
       foreach ($groupTree as $values) {
         $query = "DELETE FROM %1 WHERE entity_id = %2";
         CRM_Core_DAO::executeQuery($query, [


### PR DESCRIPTION
Overview
----------------------------------------
This is the same as #30189, except in this case maybe the whole loop can go? Are there some installs that wouldn't have the db constraint?