### PR TITLE
Regression: Custom field file type not saved on entity

### DIFF
--- a/CRM/Custom/Form/CustomDataTrait.php
+++ b/CRM/Custom/Form/CustomDataTrait.php
@@ -112,7 +112,7 @@ trait CRM_Custom_Form_CustomDataTrait {
    */
   private function getInstancesOfField($id): array {
     $instances = [];
-    foreach ($_POST as $key => $value) {
+    foreach (array_merge($_POST, ($_FILES ?? [])) as $key => $value) {
       if (preg_match('/^custom_' . $id . '_?(-?\d+)?$/', $key)) {
         $instances[] = $key;
       }


### PR DESCRIPTION
Overview
----------------------------------------
https://civicrm.stackexchange.com/questions/48039/attachment-not-saved-for-contribution

Steps to recreate:

Create a custom field of Type file on a Contribution entity
Add Contribution with the file added to the custom field

The file is not saved for the Contribution

Regression from: https://github.com/civicrm/civicrm-core/pull/29708/files

Before
----------------------------------------
Files not saved for custom field type file

After
----------------------------------------
Files not saved for custom field type file


Technical Details
----------------------------------------
$_POST do not contain files related field, its available in $_FILES 
