### PR TITLE
ScheduledReminders - Fix hiding irrelevant fields

### DIFF
--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -210,7 +210,7 @@
                     $field.toggleClass('required', fieldSpec.required);
                     $field.removeClass('loading');
                     // Show field and update option list if applicable
-                    if (fieldSpec.options) {
+                    if (fieldSpec.options && fieldSpec.options.length) {
                       fieldSpec.options.forEach(function(option) {
                         option.text = option.label;
                         delete(option.label);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes display bug on Scheduled Reminders form.

Before
----------------------------------------
1. Click on "New Scheduled Reminder"
2. Notice that "Select Role" and "Manual Recipients" fields are displayed even when they are not relevant.

After
----------------------------------------
Fields are shown/hidden appropriately.