### PR TITLE
CRM_Admin_Form_MessageTemplates - Fix disabling user message templates via the edit form

### DIFF
--- a/CRM/Admin/Form/MessageTemplates.php
+++ b/CRM/Admin/Form/MessageTemplates.php
@@ -207,7 +207,7 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Core_Form {
       ] + CRM_Core_BAO_PdfFormat::getList(TRUE), FALSE
     );
 
-    $this->add('checkbox', 'is_active', ts('Enabled?'));
+    $this->add('advcheckbox', 'is_active', ts('Enabled?'));
     $this->addFormRule([__CLASS__, 'formRule'], $this);
 
     if ($this->_action & CRM_Core_Action::VIEW) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes behaviour of the "Enabled?" checkbox when editing a user message template.

Before
----------------------------------------
If a message template is enabled, unchecking the box does nothing when you submit the form.

After
----------------------------------------
Unchecking the box disables the message template when the form is submitted.

Technical Details
----------------------------------------
In the `CRM_Admin_Form_MessageTemplates::postProcess()` method:
- When the box is checked, `is_active` is present in `$params` when the submitted values are fetched
- When the box is unchecked, `is_active` is missing so it doesn't get updated in the db
- I added a line to default to `FALSE` when it is missing

