### PR TITLE
dev/core#5208 - Undo change that prevents editing multiple emails on a contact

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -924,6 +924,8 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
         }
         switch ($blockName) {
           case 'Email':
+            // setDefaults uses this to tell which instance
+            $this->set('Email_Block_Count', $instance);
             CRM_Contact_Form_Edit_Email::buildQuickForm($this, $instance);
             // Only display the signature fields if this contact has a CMS account
             // because they can only send email if they have access to the CRM

--- a/CRM/Contact/Form/Edit/Email.php
+++ b/CRM/Contact/Form/Edit/Email.php
@@ -25,12 +25,21 @@ class CRM_Contact_Form_Edit_Email {
    *
    * @param CRM_Core_Form $form
    *   Reference to the form object.
-   * @param int $blockId
+   * @param int $blockCount
    *   Block number to build.
    * @param bool $blockEdit
    *   Is it block edit.
    */
-  public static function buildQuickForm($form, int $blockId, $blockEdit = FALSE): void {
+  public static function buildQuickForm(&$form, $blockCount = NULL, $blockEdit = FALSE) {
+    // passing this via the session is AWFUL. we need to fix this
+    if (!$blockCount) {
+      CRM_Core_Error::deprecatedWarning('pass in blockCount');
+      $blockId = ($form->get('Email_Block_Count')) ? $form->get('Email_Block_Count') : 1;
+    }
+    else {
+      $blockId = $blockCount;
+    }
+
     $form->applyFilter('__ALL__', 'trim');
 
     //Email box

--- a/CRM/Contact/Form/Location.php
+++ b/CRM/Contact/Form/Location.php
@@ -54,6 +54,8 @@ class CRM_Contact_Form_Location {
         }
         switch ($blockName) {
           case 'Email':
+            // setDefaults uses this to tell which instance
+            $form->set('Email_Block_Count', $instance);
             CRM_Contact_Form_Edit_Email::buildQuickForm($form, $instance);
             // Only display the signature fields if this contact has a CMS account
             // because they can only send email if they have access to the CRM


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5208

Before
----------------------------------------
1. Add button doesn't work to add a second email when editing contact.
2. If it had multiple emails before, then when editing a contact you can only see the first email, and saving deletes the others.

After
----------------------------------------


Technical Details
----------------------------------------
For 5.74/5.73 I'd propose just a straight revert. It seems to fix it. Could look at something more in master+

Comments
----------------------------------------

