### PR TITLE
Fix rendering default value of autocomplete fields

### DIFF
--- a/CRM/Core/Form/Renderer.php
+++ b/CRM/Core/Form/Renderer.php
@@ -190,6 +190,9 @@ class CRM_Core_Form_Renderer extends HTML_QuickForm_Renderer_ArraySmarty {
     elseif (strpos($class, 'crm-form-entityref') !== FALSE) {
       self::preProcessEntityRef($element);
     }
+    elseif (str_contains($class, 'crm-form-autocomplete')) {
+      self::preProcessAutocomplete($element);
+    }
     elseif (strpos($class, 'crm-form-contact-reference') !== FALSE) {
       self::preprocessContactReference($element);
     }
@@ -243,6 +246,16 @@ class CRM_Core_Form_Renderer extends HTML_QuickForm_Renderer_ArraySmarty {
       require SMARTY_DIR . '/plugins/function.eval.php';
     }
     return smarty_function_eval(['var' => $tplSource], $this->_tpl);
+  }
+
+  /**
+   * @param HTML_QuickForm_element $field
+   */
+  private static function preProcessAutocomplete($field) {
+    $val = $field->getValue();
+    if (is_array($val)) {
+      $field->setValue(implode(',', $val));
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This resolves https://lab.civicrm.org/dev/core/-/issues/5216 and possibly other regressions for similar fields.

Before
----------------------------------------
Multiselect Autocomplete fields do not display a value after saving.

After
----------------------------------------
Fixed.