### PR TITLE
Afform - Fix edit links permission for multiple users

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminInjector.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminInjector.php
@@ -38,59 +38,62 @@ class AfformAdminInjector extends AutoSubscriber {
     $changeSet = \Civi\Angular\ChangeSet::create('afformAdmin')
       ->alterHtml(';\\.aff\\.html$;', function($doc, $path) {
         try {
-          // If the user has "administer CiviCRM", inject gear menu with edit links
-          if (\CRM_Core_Permission::check('administer CiviCRM')) {
-            $afform = Afform::get()
-              ->addWhere('module_name', '=', basename($path, '.aff.html'))
-              ->addSelect('name', 'search_displays', 'title')
-              ->execute()->single();
-            // Create a link to edit the form, plus all embedded SavedSearches
-            $links = [
-              [
-                'url' => \CRM_Utils_System::url('civicrm/admin/afform', NULL, FALSE, "/edit/{$afform['name']}", TRUE, FALSE, TRUE),
-                'text' => E::ts('Edit %1 in FormBuilder', [1 => "<em>{$afform['title']}</em>"]),
-                'icon' => 'fa-pencil',
-              ],
-            ];
-            if ($afform['search_displays']) {
-              $searchNames = [];
-              foreach ($afform['search_displays'] as $searchAndDisplayName) {
-                $searchNames[] = explode('.', $searchAndDisplayName)[0];
-              }
-              $savedSearches = SavedSearch::get()
-                ->addWhere('name', 'IN', $searchNames)
-                ->addSelect('id', 'label')
-                ->execute();
-              foreach ($savedSearches as $savedSearch) {
-                $links[] = [
-                  'url' => \CRM_Utils_System::url('civicrm/admin/search', NULL, FALSE, "/edit/{$savedSearch['id']}", TRUE, FALSE, TRUE),
-                  'text' => E::ts('Edit %1 in SearchKit', [1 => "<em>{$savedSearch['label']}</em>"]),
-                  'icon' => 'fa-search-plus',
-                ];
-              }
+          // Inject gear menu with edit links which will be shown if the user has permission
+          $afform = Afform::get(FALSE)
+            ->addWhere('module_name', '=', basename($path, '.aff.html'))
+            ->addSelect('name', 'search_displays', 'title')
+            ->execute()->single();
+          // Create a link to edit the form, plus all embedded SavedSearches
+          $links = [
+            [
+              'url' => \CRM_Utils_System::url('civicrm/admin/afform', NULL, FALSE, "/edit/{$afform['name']}", TRUE, FALSE, TRUE),
+              'text' => E::ts('Edit %1 in FormBuilder', [1 => "<em>{$afform['title']}</em>"]),
+              'icon' => 'fa-pencil',
+              'permission' => 'administer afform',
+            ],
+          ];
+          if ($afform['search_displays']) {
+            $searchNames = [];
+            foreach ($afform['search_displays'] as $searchAndDisplayName) {
+              $searchNames[] = explode('.', $searchAndDisplayName)[0];
             }
-            $linksMarkup = '';
-            foreach ($links as $link) {
-              $linksMarkup .= <<<HTML
-                <li>
-                  <a href="{$link['url']}" target="_blank">
-                    <i class="crm-i fa-fw {$link['icon']}"></i> {$link['text']}
-                  </a>
-                </li>
-              HTML;
+            $savedSearches = SavedSearch::get(FALSE)
+              ->addWhere('name', 'IN', $searchNames)
+              ->addSelect('id', 'label', 'COUNT(permissioned_display.id) AS is_locked')
+              ->addGroupBy('id')
+              ->addJoin('SearchDisplay AS permissioned_display', 'LEFT', ['id', '=', 'permissioned_display.saved_search_id'], ['permissioned_display.acl_bypass', '=', TRUE])
+              ->execute();
+            foreach ($savedSearches as $savedSearch) {
+              $links[] = [
+                'url' => \CRM_Utils_System::url('civicrm/admin/search', NULL, FALSE, "/edit/{$savedSearch['id']}", TRUE, FALSE, TRUE),
+                'text' => E::ts('Edit %1 in SearchKit', [1 => "<em>{$savedSearch['label']}</em>"]),
+                'icon' => 'fa-search-plus',
+                // Saved Searches with "bypass_permission" displays are locked to non-super-admins
+                'permission' => $savedSearch['is_locked'] ? 'all CiviCRM permissions and ACLs' : 'administer search_kit',
+              ];
             }
-            $editMenu = <<<HTML
-              <div class="pull-right btn-group af-admin-edit-form-link">
-                <button type="button" class="btn dropdown-toggle btn-sm" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                  <i class="crm-i fa-gear"></i> <span class="caret"></span>
-                </button>
-                <ul class="dropdown-menu">$linksMarkup</ul>
-              </div>
-            HTML;
-            // Append link to end of afform markup so it has the highest z-index and is clickable.
-            // afCore.css will control placement at the top of the form.
-            pq($doc)->append($editMenu);
           }
+          $linksMarkup = '';
+          foreach ($links as $link) {
+            $linksMarkup .= <<<HTML
+              <li ng-if="checkPerm('{$link['permission']}')">
+                <a href="{$link['url']}" target="_blank">
+                  <i class="crm-i fa-fw {$link['icon']}"></i> {$link['text']}
+                </a>
+              </li>
+            HTML;
+          }
+          $editMenu = <<<HTML
+            <div class="pull-right btn-group af-admin-edit-form-link" ng-if="checkPerm('{$links[0]['permission']}')">
+              <button type="button" class="btn dropdown-toggle btn-sm" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <i class="crm-i fa-gear"></i> <span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu">$linksMarkup</ul>
+            </div>
+          HTML;
+          // Append link to end of afform markup so it has the highest z-index and is clickable.
+          // afCore.css will control placement at the top of the form.
+          pq($doc)->append($editMenu);
         }
         catch (\Exception $e) {
         }

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -334,6 +334,12 @@ function _afform_hook_civicrm_angularModules($e) {
       'exports' => [
         $afform['directive_name'] => 'E',
       ],
+      // Permissions needed for conditionally displaying edit-links
+      'permissions' => [
+        'administer afform',
+        'administer search_kit',
+        'all CiviCRM permissions and ACLs',
+      ],
     ];
   }
 

--- a/ext/afform/core/ang/afCore.js
+++ b/ext/afform/core/ang/afCore.js
@@ -16,6 +16,7 @@
           $scope.crmStatus = crmStatus;
           $scope.crmUiAlert = crmUiAlert;
           $scope.crmUrl = CRM.url;
+          $scope.checkPerm = CRM.checkPerm;
 
           $el.addClass('afform-directive');
 


### PR DESCRIPTION
Overview
----------------------------------------
Followup to https://github.com/civicrm/civicrm-core/pull/29922 this fixes a caching bug where links might be incorrectly shown/hidden to the wrong users.

Before
----------------------------------------
With asset-caching enabled, form edit links (the little gear icon when viewing the form) would be cached once and shown to all users regardless of their permission.

After
----------------------------------------
Links are shown appropriately for the permission level of each user.