### PR TITLE
dev/core#3787 Restore ability to use > & < in sql query imports

### DIFF
--- a/CRM/Import/DataSource/SQL.php
+++ b/CRM/Import/DataSource/SQL.php
@@ -79,7 +79,7 @@ class CRM_Import_DataSource_SQL extends CRM_Import_DataSource {
   public function initialize(): void {
     $table = CRM_Utils_SQL_TempTable::build()->setDurable();
     $tableName = $table->getName();
-    $table->createWithQuery($this->getSubmittedValue('sqlQuery'));
+    $table->createWithQuery($this->restoreOperators($this->getSubmittedValue('sqlQuery')));
 
     // Get the names of the fields to be imported.
     $columnsResult = CRM_Core_DAO::executeQuery(
@@ -106,6 +106,17 @@ class CRM_Import_DataSource_SQL extends CRM_Import_DataSource {
       'column_headers' => $columnNames,
       'number_of_columns' => count($columnNames),
     ]);
+  }
+
+  /**
+   * Restore greater than & equal operators that the form html_encoded.
+   *
+   * @param string $string
+   *
+   * @return string
+   */
+  public function restoreOperators(string $string): string {
+    return str_replace(['&lt;', '&gt;'], ['<', '>'], $string);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#3787 Restore ability to use > & < in sql query imports

Before
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/3787 for details

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
This is a regression but @seamuslee001 reported it over a year ago so targettng master

Comments
----------------------------------------
