### PR TITLE
use id not name to update User roles magic field in test

### DIFF
--- a/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
@@ -101,7 +101,7 @@ class SecurityTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
 
     // Give our user this role only.
     \Civi\Api4\User::update(FALSE)
-      ->addValue('roles:name', ['demo_role'])
+      ->addValue('roles', [$roleID])
       ->addWhere('id', '=', $userID)
       ->execute();
 


### PR DESCRIPTION
Overview
----------------------------------------
Using the option :name suffix with the magic field doesn't seem to work (any more?) 

Comments
----------------------------------------
This might have been the better fix for https://github.com/civicrm/civicrm-core/pull/30136 . I thought the magic field wasn't ready during the install phase, but seems to be the suffix bit that no longer works (if it ever did?). 

That would explain why the use in Afforms is unaffected (they are always passing the entity ID).
