### PR TITLE
dev/core#1735 Advanced Search et al: ignore the is_searchable as a criteria for displaying a custom field

### DIFF
--- a/CRM/Case/XMLProcessor/Report.php
+++ b/CRM/Case/XMLProcessor/Report.php
@@ -959,8 +959,7 @@ LIMIT  1
 
     // Retrieve custom values for cases.
     $customValues = CRM_Core_BAO_CustomValueTable::getEntityValues($caseID, 'Case');
-    $extends = ['Case'];
-    $groupTree = CRM_Core_BAO_CustomGroup::getGroupDetail(NULL, NULL, $extends);
+    $groupTree = CRM_Core_BAO_CustomGroup::getAll(['extends' => ['Case']]);
     $caseCustomFields = [];
     foreach ($groupTree as $gid => $group_values) {
       foreach ($group_values['fields'] as $id => $field_values) {

--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -85,9 +85,7 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
       CRM_Contact_BAO_ContactType::basicTypes(),
       CRM_Contact_BAO_ContactType::subTypes()
     );
-    $groupDetails = CRM_Core_BAO_CustomGroup::getGroupDetail(NULL, TRUE,
-      $extends
-    );
+    $groupDetails = CRM_Core_BAO_CustomGroup::getAll(['extends' => $extends]);
     // if no searchable fields unset panel
     if (empty($groupDetails)) {
       unset($paneNames[ts('Custom Fields')]);

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -607,10 +607,7 @@ class CRM_Contact_Form_Search_Criteria {
       CRM_Contact_BAO_ContactType::basicTypes(),
       CRM_Contact_BAO_ContactType::subTypes()
     );
-    $groupDetails = CRM_Core_BAO_CustomGroup::getGroupDetail(NULL, TRUE,
-      $extends
-    );
-
+    $groupDetails = CRM_Core_BAO_CustomGroup::getAll(['extends' => $extends]);
     $form->assign('groupTree', $groupDetails);
 
     foreach ($groupDetails as $key => $group) {

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -648,8 +648,7 @@ LEFT  JOIN civicrm_membership_payment mp  ON ( mp.contribution_id = con.id )
       }
 
       // copy custom data
-      $extends = ['Contribution'];
-      $groupTree = CRM_Core_BAO_CustomGroup::getGroupDetail(NULL, NULL, $extends);
+      $groupTree = CRM_Core_BAO_CustomGroup::getAll(['extends' => ['Contribution']]);
       if ($groupTree) {
         foreach ($groupTree as $groupID => $group) {
           $table[$groupTree[$groupID]['table_name']] = ['entity_id'];

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -938,6 +938,18 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
   }
 
   /**
+   * Get custom group details for a group. Legacy function for backwards compatibility.
+   * @deprecated Legacy function
+   *
+   * @see CRM_Core_BAO_CustomGroup::getAll()
+   * for a better alternative.
+   */
+  public static function &getGroupDetail($groupId = NULL, $searchable = FALSE, &$extends = NULL, $inSelector = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning('getCustomGroupDetail');
+    return self::getCustomGroupDetail($groupId, $extends, $inSelector);
+  }
+
+  /**
    * @deprecated Legacy function
    *
    * @see CRM_Core_BAO_CustomGroup::getAll()
@@ -945,8 +957,6 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
    *
    * @param int $groupId
    *   Group id whose details are needed.
-   * @param bool $searchable
-   *   Is this field searchable.
    * @param array $extends
    *   Which table does it extend if any.
    * @param bool $inSelector
@@ -954,16 +964,13 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
    * @return array
    *   array consisting of all group and field details
    */
-  public static function &getGroupDetail($groupId = NULL, $searchable = NULL, &$extends = NULL, $inSelector = NULL) {
+  public static function &getCustomGroupDetail($groupId = NULL, $extends = NULL, $inSelector = NULL) {
     $groupFilters = [
       'is_active' => TRUE,
     ];
     $fieldFilters = [];
     if ($groupId) {
       $groupFilters['id'] = $groupId;
-    }
-    if ($searchable) {
-      $fieldFilters['is_searchable'] = TRUE;
     }
     if ($inSelector) {
       $groupFilters['is_multiple'] = TRUE;

--- a/CRM/Core/BAO/Query.php
+++ b/CRM/Core/BAO/Query.php
@@ -21,7 +21,7 @@ class CRM_Core_BAO_Query {
    * @param array $extends
    */
   public static function addCustomFormFields(&$form, $extends) {
-    $groupDetails = CRM_Core_BAO_CustomGroup::getGroupDetail(NULL, TRUE, $extends);
+    $groupDetails = CRM_Core_BAO_CustomGroup::getAll(['extends' => $extends]);
     if ($groupDetails) {
       foreach ($groupDetails as $group) {
         if (empty($group['fields'])) {

--- a/CRM/Custom/Form/Preview.php
+++ b/CRM/Custom/Form/Preview.php
@@ -77,7 +77,7 @@ class CRM_Custom_Form_Preview extends CRM_Core_Form {
     // Group preview
     else {
       $this->_groupId = CRM_Utils_Request::retrieve('gid', 'Positive', $this, TRUE);
-      $groupTree = CRM_Core_BAO_CustomGroup::getGroupDetail($this->_groupId);
+      $groupTree = CRM_Core_BAO_CustomGroup::getCustomGroupDetail($this->_groupId);
       $this->_groupTree = CRM_Core_BAO_CustomGroup::formatGroupTree($groupTree, TRUE, $this);
       $this->assign('preview_type', 'group');
     }

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -175,9 +175,7 @@ class CRM_Event_BAO_Event extends CRM_Event_DAO_Event implements \Civi\Core\Hook
    */
   public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
     if ($event->action === 'delete' && $event->id) {
-
-      $extends = ['Event'];
-      $groupTree = CRM_Core_BAO_CustomGroup::getGroupDetail(NULL, NULL, $extends);
+      $groupTree = CRM_Core_BAO_CustomGroup::getAll(['extends' => ['Event']]);
       // @todo is this custom field loop necessary? The cascade delete on the
       // db foreign key should do it already.
       foreach ($groupTree as $values) {

--- a/CRM/Profile/Page/MultipleRecordFieldsListing.php
+++ b/CRM/Profile/Page/MultipleRecordFieldsListing.php
@@ -200,7 +200,7 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
       }
       $this->assign('reachedMax', $reached);
       // custom group info : this consists of the field title of group fields
-      $groupDetail = CRM_Core_BAO_CustomGroup::getGroupDetail($customGroupId, NULL, CRM_Core_DAO::$_nullObject, TRUE);
+      $groupDetail = CRM_Core_BAO_CustomGroup::getCustomGroupDetail($customGroupId, NULL, TRUE);
       // field ids of fields in_selector for the custom group id provided
       $fieldIDs = array_keys($groupDetail[$customGroupId]['fields']);
       // field labels for headers

--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -215,7 +215,7 @@ return [
     'title' => ts('Quicksearch options'),
     'is_domain' => '1',
     'is_contact' => 0,
-    'description' => ts("Which fields can be searched on in the menubar quicksearch box? Don't see your custom field here? Make sure it is marked as Searchable."),
+    'description' => ts("Which fields can be searched on in the menubar quicksearch box?"),
     'help_text' => NULL,
     'settings_pages' => ['search' => ['weight' => 90]],
   ],

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -252,9 +252,9 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test getGroupDetail().
+   * Test getCustomGroupDetail().
    */
-  public function testGetGroupDetail(): void {
+  public function testGetCustomGroupDetail(): void {
     $customGroupTitle = 'My Custom Group';
     $groupParams = [
       'title' => $customGroupTitle,
@@ -291,10 +291,10 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     $customField2 = $this->customFieldCreate($field2Params + ['custom_group_id' => $customGroupId]);
     $field2Id = $customField2['id'];
 
-    $emptyTree = CRM_Core_BAO_CustomGroup::getGroupDetail(99);
+    $emptyTree = CRM_Core_BAO_CustomGroup::getCustomGroupDetail(99);
     $this->assertCount(0, $emptyTree, 'Check that no custom Group matches id=99');
 
-    $groupTree = CRM_Core_BAO_CustomGroup::getGroupDetail($customGroupId);
+    $groupTree = CRM_Core_BAO_CustomGroup::getCustomGroupDetail($customGroupId);
     $this->assertCount(1, $groupTree);
     $this->assertCount(2, $groupTree[$customGroupId]['fields']);
     //check values of custom group
@@ -302,12 +302,6 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     //check values of custom fields
     $this->assertAttributesEquals($field1Params, $groupTree[$customGroupId]['fields'][$field1Id]);
     $this->assertAttributesEquals($field2Params, $groupTree[$customGroupId]['fields'][$field2Id]);
-
-    $searchableTree = CRM_Core_BAO_CustomGroup::getGroupDetail($customGroupId, TRUE);
-    $this->assertCount(1, $searchableTree[$customGroupId]['fields']);
-    $this->assertAttributesEquals($groupParams, $searchableTree[$customGroupId]);
-    // only searchable field should be returned
-    $this->assertAttributesEquals($field2Params, $searchableTree[$customGroupId]['fields'][$field2Id]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

Related to https://lab.civicrm.org/dev/core/-/issues/1735

Displays custom fields in old Search forms, regardless of the `is_searchable` setting, which is being renamed to "Optimized for Search" c.f.  #30188 and #30186.

Also provides an alternative getCustomGroupDetail() function without the $searchable argument, and removes the pass-by-ref on  `$extends`, in an attempt to de-uglify some other code. Also replaces some calls by getAll().

Before
----------------------------------------

Custom Fields are only available in Advanced Search if the option "is searchable" (now "optimized for search") is checked. Many people forgot to check this box and would be confused.

After
----------------------------------------

All fields are displayed.

Comments
----------------------------------------

I didn't test much of this, only Advanced Search. I'm hoping the tests will blow up.