### PR TITLE
Drupal10 clearResourceCache: check if hasContainer, avoid cv fatal

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -999,7 +999,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     // and the fallback to drupal_flush_css_js. Still need the class_exists.
     try {
       // Sometimes metadata gets cleared while the cms isn't bootstrapped.
-      if (class_exists('\Drupal')) {
+      if (class_exists('\Drupal') && \Drupal::hasContainer()) {
         \Drupal::service('asset.query_string')->reset();
         $cleared = TRUE;
       }


### PR DESCRIPTION
Overview
----------------------------------------

When running `cv upgrade:db` on Drupal 9/10, we would sometimes get a fatal error about an uninitialized Drupal container.

Before
----------------------------------------

Fatal

After
----------------------------------------

No fatal.

Technical Details
----------------------------------------

This pattern is used elsewhere in the same file, so I figure it should be safe.

Probably also means that the Drupal cache is not flushed on CiviCRM upgrades from the CLI, which could lead to some confusion about CSS/JS, but .. :shrug: 
