### PR TITLE
Type safety in Standalone currentPath

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -197,9 +197,9 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    *   the current menu path
    */
   public static function currentPath() {
-    $path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
-    $path = trim($path, '/');
-    return $path;
+    $path = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH);
+
+    return $path ? trim($path, '/') : NULL;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://test.civicrm.org/job/CiviCRM-Test-QLow/14847/testReport/(root)/E2E_Core_PathUrlTest/testUrl_FrontBackCurrent/ ( errors because REQUEST_URI not set in CLI environments )

Technical Details
----------------------------------------
`parse_url` can return null or false with unexpected input - this returns null for any falsey values
