### PR TITLE
find financial acl warning amongst other messages

### DIFF
--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialTypeTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialTypeTest.php
@@ -29,8 +29,11 @@ class FinancialTypeTest extends BaseTestClass {
       'name' => 'your test',
       'id' => $type['id'],
     ]);
-    $status = CRM_Core_Session::singleton()->getStatus(TRUE);
-    $this->assertEquals('Changing the name', substr($status[0]['text'], 0, 17));
+    $statusMessages = CRM_Core_Session::singleton()->getStatus(TRUE);
+    $financialTypeMessages = array_filter($statusMessages, function ($msg) {
+        return strpos($msg['text'], 'Changing the name of a Financial Type') === 0;
+    });
+    $this->assertEquals(1, count($financialTypeMessages));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

Fixes https://test.civicrm.org/job/CiviCRM-Test-QLow/14843/testReport/(root)/Civi_Financialacls_FinancialTypeTest/testChangeFinancialTypeName/

Test was checking the first status message, but there might be other unrelated messages in the status inbox.