### PR TITLE
Fix PHP warnings on contribute confirm when membership is not enabled

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -519,6 +519,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         $this->assign('autoRenewOption', 2);
       }
     }
+    $this->assign('membershipBlock', FALSE);
     if (CRM_Core_Component::isEnabled('CiviMember') && empty($this->_ccid)) {
       if (isset($params['selectMembership']) &&
         $params['selectMembership'] !== 'no_thanks'
@@ -527,9 +528,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           $this->_membershipContactID,
           $params['selectMembership']
         );
-      }
-      else {
-        $this->assign('membershipBlock', FALSE);
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
If the CiviMember component is not enabled, then confirm.php doesn't set 'membershipblock' to FALSE, so it is undefined when the template tries to access it (regardless of whether CiviMember is enabled).

Steps to recreate:
- On an installation with CiviMember disabled, navigate to a contribution page 'confirm' screen
- PHP warnings:

```
Warning: Undefined array key "membershipBlock" in include() (line 8 of /.../files/civicrm/templates_c/en_GB/%%0B/0BB/0BBEE922%%MembershipBlock.tpl.php).
Warning: Undefined array key "membershipBlock" in include() (line 43 of /.../files/civicrm/templates_c/en_GB/%%A8/A8D/A8DCF2A7%%Confirm.tpl.php).
```

Suggested fix is to always set the variable to 'FALSE' and then allow the existing code to override it if needed.
