### PR TITLE
[NFC] Use correct syntax for writing to arrays

### DIFF
--- a/CRM/Event/BAO/ParticipantStatusType.php
+++ b/CRM/Event/BAO/ParticipantStatusType.php
@@ -194,13 +194,13 @@ LEFT JOIN  civicrm_event event ON ( event.id = participant.event_id )
               if (is_array($results['updatedParticipantIds']) && !empty($results['updatedParticipantIds'])) {
                 foreach ($results['updatedParticipantIds'] as $processedId) {
                   $expiredParticipantCount += 1;
-                  $returnMessages[] .= "<br />Status updated to: Expired";
+                  $returnMessages[] = "<br />Status updated to: Expired";
 
                   //mailed participants.
                   if (is_array($results['mailedParticipants']) &&
                     array_key_exists($processedId, $results['mailedParticipants'])
                   ) {
-                    $returnMessages[] .= "<br />Expiration Mail sent to: {$results['mailedParticipants'][$processedId]}";
+                    $returnMessages[] = "<br />Expiration Mail sent to: {$results['mailedParticipants'][$processedId]}";
                   }
                 }
               }
@@ -266,16 +266,16 @@ LEFT JOIN  civicrm_event event ON ( event.id = participant.event_id )
                     foreach ($results['updatedParticipantIds'] as $processedId) {
                       if ($values['requires_approval']) {
                         $waitingApprovalCount += 1;
-                        $returnMessages[] .= "<br /><br />- status updated to: Awaiting approval";
-                        $returnMessages[] .= "<br />Will send you Confirmation Mail when registration gets approved.";
+                        $returnMessages[] = "<br /><br />- status updated to: Awaiting approval";
+                        $returnMessages[] = "<br />Will send you Confirmation Mail when registration gets approved.";
                       }
                       else {
                         $waitingConfirmCount += 1;
-                        $returnMessages[] .= "<br /><br />- status updated to: Pending from waitlist";
+                        $returnMessages[] = "<br /><br />- status updated to: Pending from waitlist";
                         if (is_array($results['mailedParticipants']) &&
                           array_key_exists($processedId, $results['mailedParticipants'])
                         ) {
-                          $returnMessages[] .= "<br />Confirmation Mail sent to: {$results['mailedParticipants'][$processedId]}";
+                          $returnMessages[] = "<br />Confirmation Mail sent to: {$results['mailedParticipants'][$processedId]}";
                         }
                       }
                     }
@@ -297,12 +297,12 @@ LEFT JOIN  civicrm_event event ON ( event.id = participant.event_id )
       //cron 2 ends.
     }
 
-    $returnMessages[] .= "<br /><br />Number of Expired registration(s) = {$expiredParticipantCount}";
-    $returnMessages[] .= "<br />Number of registration(s) require approval =  {$waitingApprovalCount}";
-    $returnMessages[] .= "<br />Number of registration changed to Pending from waitlist = {$waitingConfirmCount}<br /><br />";
+    $returnMessages[] = "<br /><br />Number of Expired registration(s) = {$expiredParticipantCount}";
+    $returnMessages[] = "<br />Number of registration(s) require approval =  {$waitingApprovalCount}";
+    $returnMessages[] = "<br />Number of registration changed to Pending from waitlist = {$waitingConfirmCount}<br /><br />";
     if (!empty($fullEvents)) {
       foreach ($fullEvents as $eventId => $title) {
-        $returnMessages[] .= "Full Event : {$title}<br />";
+        $returnMessages[] = "Full Event : {$title}<br />";
       }
     }
 

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -491,7 +491,7 @@ class CRM_Utils_File {
     if ($dh = opendir($path)) {
       while (FALSE !== ($elem = readdir($dh))) {
         if (substr($elem, -(strlen($ext) + 1)) == '.' . $ext) {
-          $files[] .= $path . $elem;
+          $files[] = $path . $elem;
         }
       }
       closedir($dh);

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -721,7 +721,7 @@ emo
       $tokenLines[] = trim($tokenName, '{}') . ':' . $tokenName;
     }
     foreach (array_keys($tokenData) as $key) {
-      $tokenLines[] .= "contact.$key:{contact.$key}";
+      $tokenLines[] = "contact.$key:{contact.$key}";
     }
     $tokenLines = array_unique($tokenLines);
     sort($tokenLines);


### PR DESCRIPTION
Overview
----------------------------------------
A tool I use (specifically PHPStan) is giving me this warning for the 12 lines I've changed:

```
Cannot use [] for reading. 
```

This changes the 12 lines to a more valid syntax.

Before
----------------------------------------
We had code like:

```
$returnMessages[] .= "<br />Status updated to: Expired";
```

This does work in current PHP versions, but is a bit odd and isn't specifically documented as being an allowed way of writing to an array. When you do `.=` you are concatonating to an existing value, but here there is no existing value as we've created a new array item with the `[]`. Mixing these constructs is confusing.

After
----------------------------------------
We now follow the structure:

```
$returnMessages[] = "<br />Status updated to: Expired";
```

Technical Details
----------------------------------------
This won't have any functional change, but keeps the code cleaner, and less likely to cause confusion.