### PR TITLE
Remove Civi/ActionSchedule/Mapping workaround

### DIFF
--- a/Civi/ActionSchedule/Mapping.php
+++ b/Civi/ActionSchedule/Mapping.php
@@ -1,4 +1,0 @@
-<?php
-
-// Empty file to ensure the old one is overwritten on Joomla! installs.
-// It otherwise causes Declaration of Civi\\ActionSchedule\\Mapping::getValueHeader() must be compatible with Civi\\ActionSchedule\\MappingInterface::getValueHeader():

--- a/deleted-files-list.json
+++ b/deleted-files-list.json
@@ -485,6 +485,7 @@
     "CRM/Utils/Tree.php",
     "CRM/Widget/*",
     "Civi/API/Subscriber/XDebugSubscriber.php",
+    "Civi/ActionSchedule/Mapping.php",
     "Civi/Api4/Action/Campaign/*",
     "Civi/Api4/Action/CiviCase/*",
     "Civi/Api4/Action/Contact/GetFields.php",


### PR DESCRIPTION
Overview
----------------------------------------
Remove workaround no longer needed and is causing new problems.

Before
----------------------------------------
Class

After
----------------------------------------
No Class

Technical Details
----------------------------------------
This was added in https://github.com/civicrm/civicrm-core/pull/27591 but is an awkward workaround for joomla, and another workaround was taken in https://github.com/civicrm/civicrm-core/pull/28653 that no longer needs this workaround.

Comments
----------------------------------------
The problem is that in an even stricter testing environment in drupal 11 using symfony debugclassloader, the civi class scanning fails because this file is in the autoloader's sights but does not contain the expected class declaration.