### PR TITLE
Use pan_truncation where present on form

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -332,7 +332,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       'contribution_id' => $this->getContributionID(),
       'payment_processor_id' => $this->getPaymentProcessorID(),
       'card_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_FinancialTrxn', 'card_type_id', $this->getSubmittedValue('credit_card_type')),
-      'pan_truncation' => substr((string) $this->getSubmittedValue('credit_card_number'), -4),
+      'pan_truncation' => $this->getSubmittedValue('pan_truncation') ?: substr((string) $this->getSubmittedValue('credit_card_number'), -4),
       'trxn_result_code' => $paymentResult['trxn_result_code'] ?? NULL,
       'payment_instrument_id' => $this->getSubmittedValue('payment_instrument_id'),
       'trxn_id' => $paymentResult['trxn_id'] ?? ($this->getSubmittedValue('trxn_id') ?? NULL),


### PR DESCRIPTION
Overview
----------------------------------------
See https://chat.civicrm.org/civicrm/pl/tgq7b5hw8pbbib57d1ob6anbkh - appears to have regressed in 5.71

Before
----------------------------------------
Pan transaction not saved

After
----------------------------------------
if is saved

Technical Details
----------------------------------------
The report on chat also mentions custom fields -but I can't see custom fields on that form at all - or any code that would render them. I tested adding fields on 5.70 that added fields to the financial_trxn table & they did not appear

Comments
----------------------------------------
