### PR TITLE
Fix PHP warning when event has no end date

### DIFF
--- a/templates/CRM/Event/Form/Selector.tpl
+++ b/templates/CRM/Event/Form/Selector.tpl
@@ -60,7 +60,7 @@
     <td class="right nowrap crm-participant-participant_fee_amount">{if array_key_exists('participant_fee_amount', $row)}{$row.participant_fee_amount|crmMoney:$row.participant_fee_currency}{/if}</td>
     <td class="crm-participant-participant_register_date">{$row.participant_register_date|truncate:10:''|crmDate}</td>
     <td class="crm-participant-event_start_date">{$row.event_start_date|truncate:10:''|crmDate}
-      {if $row.event_end_date && $row.event_end_date|crmDate:"%Y%m%d" NEQ $row.event_start_date|crmDate:"%Y%m%d"}
+      {if array_key_exists('event_end_date', $row) && $row.event_end_date|crmDate:"%Y%m%d" NEQ $row.event_start_date|crmDate:"%Y%m%d"}
         <br/>- {$row.event_end_date|truncate:10:''|crmDate}
       {/if}
     </td>


### PR DESCRIPTION
Overview
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/5212601/d6819690-4c80-4ace-9afb-415fff34af89)

Before
----------------------------------------
PHP warnings on participant listings for events with no end date

After
----------------------------------------
No warnings.
