### PR TITLE
(dev/core#5217) URL Generation - Revise relativization protocol for multisite

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -155,22 +155,24 @@ abstract class CRM_Utils_System_Base {
    *   Ex: 'civicrm/event/info'
    * @param string|null $query
    *   Ex: 'id=100&msg=Hello+world'
+   * @param string $preferFormat
+   *   'absolute' or 'relative'
    * @return string|null
    *   Absolute URL, or NULL if scheme is unsupported.
    *   Ex: 'https://subdomain.example.com/index.php?q=civicrm/event/info&id=100&msg=Hello+world'
    */
-  public function getRouteUrl(string $scheme, string $path, ?string $query): ?string {
+  public function getRouteUrl(string $scheme, string $path, ?string $query, string $preferFormat = 'absolute'): ?string {
     switch ($scheme) {
       case 'frontend':
-        return $this->url($path, $query, TRUE, NULL, TRUE, FALSE, FALSE);
+        return $this->url($path, $query, $preferFormat !== 'relative', NULL, TRUE, FALSE, FALSE);
 
       case 'service':
         // The original `url()` didn't have an analog for "service://". But "frontend" is probably the closer bet?
         // Or maybe getNotifyUrl() makes sense?
-        return $this->url($path, $query, TRUE, NULL, TRUE, FALSE, FALSE);
+        return $this->url($path, $query, $preferFormat !== 'relative', NULL, TRUE, FALSE, FALSE);
 
       case 'backend':
-        return $this->url($path, $query, TRUE, NULL, FALSE, TRUE, FALSE);
+        return $this->url($path, $query, $preferFormat !== 'relative', NULL, FALSE, TRUE, FALSE);
 
       // If the UF defines other major UI/URL conventions, then you might hypothetically handle
       // additional schemes.

--- a/Civi/Core/Url.php
+++ b/Civi/Core/Url.php
@@ -660,7 +660,7 @@ final class Url implements \JsonSerializable {
 
       // Handle 'frontend', 'backend', 'service', and any extras.
       default:
-        $result = $userSystem->getRouteUrl($scheme, $this->getPath(), $this->getQuery());
+        $result = $userSystem->getRouteUrl($scheme, $this->getPath(), $this->getQuery(), $preferFormat);
         if ($result === NULL) {
           $event = GenericHookEvent::create(['url' => $this, 'result' => &$result]);
           \Civi::dispatcher()->dispatch('civi.url.render.' . $scheme, $event);


### PR DESCRIPTION
Overview
--------

When computing a URL to a route, you can request relative or absolute formulations

```php
Civi::url('frontend://civicrm/foo', 'a')
Civi::url('frontend://civicrm/foo', 'r')
```

On multisite deployments (Drupal-style; split URLs, one database), the behavior of "relative" form regressed. This brings it more in-line with past behavior.

(See also: https://lab.civicrm.org/dev/core/-/issues/5217)

Before+After
============

For `Civi::url()`, there are different schemes/URL-providers. This specifically changes the implementation of the *route* provider.

* Circa 5.71 (and earlier), `$userSystem->url()` would choose both the relative and absolute renditions of `civicrm/foo`.

* Circa 5.72 (86d289a1b9 + 59af62f8b3d), `$userSystem->url()` chooses the absolute rendition.  Then a generic step in `Civi::url()` makes it relative.

* With this patch,  `$userSystem->url()` again chooses the relative and absolute renditions.

Comments
========

* For my local testing, I used D7 site (`dmaster.127.0.0.1.nip.io:8001`) with one manually-configured HTTP alias (`alias.127.0.0.1.nip.io:8001`).

* This PR is kind of fixing one symptom of a deeper problem.

* The solution here basically brings the behavior in-line with prior versions -- so it fixes a regression (and is less likely to be regressive).

* This leaves the deeper issue for another day.  The deeper issue is that absolute URLs always point to the primary/default domain -- never to the alias domain.

    * This likely is bad for some edge-cases (eg involving OAuthClient or redirect-based payment processors) and good for others (eg involving email-blasts).

    * The most common effect should be asymptomatic.  When you "View Source" on an alias-domain, you see that JS/CSS assets are split arbitrarily among primary-domain and alias-domain.

    * Finding the ideal line feels like a longer/squishier topic. But I'm putting some notes on the Gitlab issue.

* What happens when someone uses  `Civi::url('civicrm/foo')->setPreferFormat('inVAliD')`?  Works like before. It decides absolute/relative based on whether `$preferFormat` matches string `'relative'`.