### PR TITLE
dev/core#5212 Fix handling of non membership checkbox line items when…

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2924,7 +2924,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       if (empty($lineItem['membership_type_id']) && $this->isSeparateMembershipPayment()) {
         continue;
       }
-      $lineItemSplit[$lineItem['membership_type_id'] ?: $defaultMembershipTypeID][$lineItem['price_field_id']] = $lineItem;
+      $lineItemSplit[$lineItem['membership_type_id'] ?: $defaultMembershipTypeID]['price_field_value_' . $lineItem['price_field_value_id']] = $lineItem;
     }
     return $lineItemSplit[$membershipTypeID];
   }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2879,6 +2879,11 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       'label' => 'Goat Breed',
       'html_type' => 'Radio',
     ]);
+    $addOnPriceField = $this->callAPISuccess('price_field', 'create', [
+      'price_set_id' => $priceSetID,
+      'label' => 'Goat Addons',
+      'html_type' => 'CheckBox',
+    ]);
     $priceFieldValue = $this->callAPISuccess('price_field_value', 'create', [
       'price_set_id' => $priceSetID,
       'price_field_id' => $priceField['id'],
@@ -2913,9 +2918,24 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       'is_separate_payment' => FALSE,
     ])->execute();
     $this->_ids['price_field_value']['cont'] = $priceFieldValue['id'];
-
+    $strawPriceFieldValue = $this->callAPISuccess('price_field_value', 'create', [
+      'price_set_id' => $priceSetID,
+      'price_field_id' => $addOnPriceField['id'],
+      'label' => 'Straw',
+      'amount' => 5,
+      'financial_type_id' => 'Donation',
+    ]);
+    $this->_ids['price_field_value']['straw'] = $strawPriceFieldValue['id'];
+    $feedPriceFieldValue = $this->callAPISuccess('price_field_value', 'create', [
+      'price_set_id' => $priceSetID,
+      'price_field_id' => $addOnPriceField['id'],
+      'label' => 'Feed',
+      'amount' => 30,
+      'financial_type_id' => 'Donation',
+    ]);
+    $this->_ids['price_field_value']['feed'] = $feedPriceFieldValue['id'];
     $this->_ids['contribution_page'] = $contributionPageID;
-    $this->_ids['price_field'] = [$priceField['id']];
+    $this->_ids['price_field'] = [$priceField['id'], $addOnPriceField['id']];
   }
 
   /**

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -617,6 +617,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       'price_' . $this->_ids['price_field'][0] => $this->_ids['price_field_value']['cont'],
       'price_' . $this->_ids['price_field']['org1'] => $this->_ids['price_field_value']['org1'],
       'price_' . $this->_ids['price_field']['org2'] => $this->_ids['price_field_value']['org2'],
+      'price_' . $this->_ids['price_field'][1] => [$this->_ids['price_field_value']['straw'] => 1, $this->_ids['price_field_value']['feed'] => 1],
       'id' => $this->getContributionPageID(),
       'billing_first_name' => 'Billy',
       'billing_middle_name' => 'Goat',
@@ -646,7 +647,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     ]);
     $this->assertEquals(2, $membershipPayments['count']);
     $lines = $this->validateTripleLines($contribution['id'], $preExistingMembershipID);
-    $this->assertEquals($preExistingMembershipID + 2, $lines[2]['entity_id']);
+    $this->assertEquals($preExistingMembershipID + 2, $lines[4]['entity_id']);
 
     $this->callAPISuccessGetSingle('MembershipPayment', ['contribution_id' => $contribution['id'], 'membership_id' => $preExistingMembershipID + 1]);
     $membership = $this->callAPISuccessGetSingle('membership', ['id' => $preExistingMembershipID + 1]);
@@ -1426,12 +1427,12 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       'sequential' => 1,
       'contribution_id' => $id,
     ])['values'];
-    $this->assertCount(3, $lines);
+    $this->assertCount(5, $lines);
     $this->assertEquals('civicrm_membership', $lines[1]['entity_table']);
     $this->assertEquals($preExistingMembershipID + 1, $lines[1]['entity_id']);
     $this->assertEquals('civicrm_contribution', $lines[0]['entity_table']);
     $this->assertEquals($id, $lines[0]['entity_id']);
-    $this->assertEquals('civicrm_membership', $lines[2]['entity_table']);
+    $this->assertEquals('civicrm_membership', $lines[4]['entity_table']);
     return $lines;
   }
 


### PR DESCRIPTION
… processing with membership signup

Overview
----------------------------------------
This aims to fix a situation where by not all selected checkboxes in a price set are processed when those checkboxes are used for things like membership extras

Before
----------------------------------------
Not all checkbox lineitems are saved

After
----------------------------------------
All lineitems are correctly saved now

@eileenmcnaughton 