### PR TITLE
add download link to existing data for afform File questions

### DIFF
--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -97,7 +97,8 @@ class CRM_Core_BAO_CustomValueTable {
               $entityFileDAO->file_id = $field['file_id'];
               $entityFileDAO->find(TRUE);
 
-              $entityFileDAO->entity_table = $field['table_name'];
+              // some older callers dont pass the entity table here, so we have to fetch it based on the Entity listed in 'extends'
+              $entityFileDAO->entity_table = $field['entity_table'] ?? \Civi\Schema\EntityRepository::getEntity($field['extends'])['table'];
               $entityFileDAO->entity_id = $field['entity_id'];
               $entityFileDAO->file_id = $field['file_id'];
               $entityFileDAO->save();

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2119,38 +2119,12 @@ LIKE %1
     $entity = CRM_Core_DAO_AllCoreTables::getEntityNameForClass(get_class($this));
     $tableName = CRM_Core_DAO_AllCoreTables::getTableForClass(get_class($this));
     // Obtain custom values for the old entity.
-    $customParams = $htmlType = [];
-    $customValues = CRM_Core_BAO_CustomValueTable::getEntityValues($entityID, $entity);
+    $customParams = [];
+    $customValues = CRM_Core_BAO_CustomValueTable::getEntityValues($entityID, $entity) ?: [];
 
     // If custom values present, we copy them
-    if (!empty($customValues)) {
-      // Get Field ID's and identify File type attributes, to handle file copying.
-      $fieldIds = implode(', ', array_keys($customValues));
-      $sql = "SELECT id FROM civicrm_custom_field WHERE html_type = 'File' AND id IN ( {$fieldIds} )";
-      $result = CRM_Core_DAO::executeQuery($sql);
-
-      // Build array of File type fields
-      while ($result->fetch()) {
-        $htmlType[] = $result->id;
-      }
-
-      // Build params array of custom values
-      foreach ($customValues as $field => $value) {
-        if ($value !== NULL) {
-          // Handle File type attributes
-          if (in_array($field, $htmlType)) {
-            $fileValues = CRM_Core_BAO_File::path($value, $entityID);
-            $customParams["custom_{$field}_-1"] = [
-              'name' => CRM_Utils_File::duplicate($fileValues[0]),
-              'type' => $fileValues[1],
-            ];
-          }
-          // Handle other types
-          else {
-            $customParams["custom_{$field}_-1"] = $value;
-          }
-        }
-      }
+    foreach ($customValues as $field => $value) {
+      $customParams["custom_{$field}_-1"] = $value;
 
       // Save Custom Fields for new Entity.
       CRM_Core_BAO_CustomValueTable::postProcess($customParams, $tableName, $newEntityID, $entity, $parentOperation ?? 'create');

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -322,8 +322,10 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
       foreach ($result as &$item) {
         if (!empty($item[$fieldName])) {
           $fileInfo = File::get(FALSE)
-            ->addSelect('file_name', 'icon')
+            ->addSelect('file_name', 'icon', 'url')
             ->addWhere('id', '=', $item[$fieldName])
+            // entity join is required to get hashed url
+            ->addJoin($entityName, 'LEFT', 'EntityFile')
             ->execute()->first();
           $item[$fieldName] = $fileInfo;
         }

--- a/ext/afform/core/ang/af/fields/File.html
+++ b/ext/afform/core/ang/af/fields/File.html
@@ -1,6 +1,8 @@
 <span ng-if="dataProvider.getFieldData()[$ctrl.fieldName].file_name">
-  <i class="crm-i {{ dataProvider.getFieldData()[$ctrl.fieldName].icon }}"></i>
-  {{ dataProvider.getFieldData()[$ctrl.fieldName].file_name }}
+  <a target="_blank" href="{{ dataProvider.getFieldData()[$ctrl.fieldName].url }}">
+     <i class="crm-i {{ dataProvider.getFieldData()[$ctrl.fieldName].icon }}"></i>
+     {{ dataProvider.getFieldData()[$ctrl.fieldName].file_name }}
+  </a>
   <a class="crm-hover-button" title="{{:: ts('Replace') }}" ng-click="dataProvider.getFieldData()[$ctrl.fieldName].file_name = null">
     <i class="crm-i fa-times" aria-hidden="true"></i>
   </a>

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -289,7 +289,7 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
     ]);
 
     // Create two files to attach to the new case
-    $filepath = Civi::paths()->getPath('[civicrm.files]/custom');
+    $filepath = Civi::paths()->getPath(\CRM_Core_Config::singleton()->customFileUploadDir);
 
     CRM_Utils_File::createFakeFile($filepath, 'Bananas do not bend themselves without a little help.', 'i_bend_bananas.txt');
     $fileA = $this->callAPISuccess('File', 'create', ['uri' => "$filepath/i_bend_bananas.txt"]);

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -311,7 +311,7 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
 
     $entityFiles = new CRM_Core_DAO_EntityFile();
     $entityFiles->entity_id = $newCase[0];
-    $entityFiles->entity_table = $customGroup['table_name'];
+    $entityFiles->entity_table = 'civicrm_case';
     $entityFiles->find();
 
     $totalEntityFiles = 0;


### PR DESCRIPTION
Overview
----------------------------------------
Adds a file download link to existing answers to Afform File fields.

I've split out the EntityFile change into https://github.com/civicrm/civicrm-core/pull/31017 - so this should follow that.

Before
----------------------------------------
At the moment there's no way that I can see to get an uploaded file back out when submitted through an afform?

After
----------------------------------------
There's a download link when existing answers are pre-filled.

