### PR TITLE
dev/core#5233 Clear cache before passing custom field data to hooks

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2013,6 +2013,9 @@ WHERE  id IN ( %1, %2 )
     $transaction = new CRM_Core_Transaction();
     $params = self::prepareCreate($params);
 
+    // Clear caches before passing the data to hooks.
+    Civi::cache('metadata')->clear();
+
     $customField = new CRM_Core_DAO_CustomField();
     $customField->copyValues($params);
     $customField->save();


### PR DESCRIPTION
Overview
----------------------------------------
Fix fatal error on creating custom fields

Before
----------------------------------------
Creating custom field returns a fatal error if hook calls getoptions() for the entity.

To replicate:
- Create an extension with the following hook code.
```
function myextension_civicrm_postSave_civicrm_custom_field($dao) {
  $entity = 'Activity';  // Code to retrieve entity. Eg. Activity.
  civicrm_api3($entity, 'getoptions', [
    'field' => "custom_" . $dao->id,
  ]);
}
```
- Create a custom group with entity = Activity.
- Create a custom field of type Dropdown with options => Save => Error

>TypeError: CRM_Core_BAO_CustomField::getFieldOptions(): Argument #3 ($dataType) must be of type string, null given, called in /vendor/civicrm/civicrm-core/CRM/Core/BAO/CustomField.php on line 297 in CRM_Core_BAO_CustomField::getFieldOptions() (line 2696 of /vendor/civicrm/civicrm-core/CRM/Core/BAO/CustomField.php).

If `getoptions` is replaced with api4 getfields()->setLoadOptions(TRUE), it still fails to return the field options.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Custom group information is [loaded into the cache](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/BAO/CustomGroup.php#L140) during [buildform()](https://github.com/civicrm/civicrm-core/blob/master/CRM/Custom/Form/Field.php#L197).

- When a custom field is saved to the database, this cache is not invalidated.
- The extension attempts to retrieve the list of options for this field, using getoptions api.
- An error occurs because loadAll() returns the cached array, which does not include the newly added field from the form submission.
- The fix in this PR clears the cache before invoking the extension hooks, ensuring the latest field information is included.

Comments
----------------------------------------

Gitlab - https://lab.civicrm.org/dev/core/-/issues/5233