### PR TITLE
(dev/core#5235) Add deprecation for use of $mem_type_id in receipts

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1760,6 +1760,7 @@ class CRM_Utils_Token {
           '$mem_end_date' => 'membership.end_date',
           '$mem_join_date' => 'membership.join_date',
           '$membership_name' => 'membership.membership_type_id:name',
+          '$mem_type_id' => 'membership.membership_type_id',
           '$mem_status' => 'membership.membership_status_id:name',
           '$receive_date' => 'contribution.receive_date',
           '$currency' => 'contribution.currency',


### PR DESCRIPTION
Overview
----------------------------------------
Add deprecation for use of $mem_type_id in receipts

In general we are pushing people to use tokens in receipts & stop using Smarty Variables where a token can be used. We have a status check telling people to do that for various membership tokens and this adds the less-used `$mem_type_id` to that list