### PR TITLE
Getter for log table names

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -776,6 +776,15 @@ WHERE  table_schema IN ('{$this->db}', '{$civiDB}')";
   }
 
   /**
+   * Return a list of log table names.
+   *
+   * @return array
+   */
+  public function getLogTableNames() {
+    return array_values($this->logs);
+  }
+
+  /**
    * Create a log table with schema mirroring the given table’s structure and seeding it with the given table’s contents.
    *
    * @param string $table

--- a/tests/phpunit/CRM/Logging/SchemaTest.php
+++ b/tests/phpunit/CRM/Logging/SchemaTest.php
@@ -441,6 +441,13 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     $this->assertStringNotContainsString('FOREIGN KEY', $dao->Create_Table);
   }
 
+  public function testGetLogTableNames(): void {
+    Civi::settings()->set('logging', TRUE);
+    $log_tables = (new CRM_Logging_Schema())->getLogTableNames();
+    $this->assertIsArray($log_tables);
+    $this->assertNotEmpty($log_tables);
+  }
+
   /**
    * Determine if we are running on MySQL 8 version 8.0.19 or later.
    *


### PR DESCRIPTION
Overview
----------------------------------------
We're doing some work around logging/auditing. In looking at new developments in this area we noticed there was no easy way to get a list of log table names. We think this is useful base functionality, adding a getter on an existing property.

Before
----------------------------------------
No way to get log table names easily.

After
----------------------------------------
Easy way to get log table names.

Technical Details
----------------------------------------
New method to get table names from existing private property, and a test.