### PR TITLE
Remove some unreachable code

### DIFF
--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -206,14 +206,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
       }
     }
 
-    // check that event id is not an template
-    if (!empty($params['event_id'])) {
-      $isTemplate = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $params['event_id'], 'is_template');
-      if (!empty($isTemplate)) {
-        throw new CRM_Core_Exception(ts('Event templates are not meant to be registered.'));
-      }
-    }
-
     $result = [];
     if ($checkDuplicate) {
       if (CRM_Event_BAO_Participant::checkDuplicate($params, $result)) {

--- a/Civi/Test/EventTestTrait.php
+++ b/Civi/Test/EventTestTrait.php
@@ -186,6 +186,9 @@ trait EventTestTrait {
    */
   public function eventCreate(array $params = [], string $identifier = 'event'): array {
     try {
+      if ($params['is_template'] ?? NULL && empty($params['template_title'])) {
+        $params['template_title'] = 'template event';
+      }
       $event = Event::create(FALSE)->setValues($params)->execute()->first();
       $this->setTestEntity('Event', $event, $identifier);
       $this->addProfilesToEvent($identifier);

--- a/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
@@ -170,6 +170,36 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that we cannot import to a template event.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testImportToTemplateEvent() :void {
+    // When setting up for the test make sure the IDs match those in the csv.
+    $this->assertEquals(1, $this->eventCreatePaid(['is_template' => TRUE])['id']);
+    $this->assertEquals(3, $this->individualCreate());
+    $this->importCSV('participant_with_event_id.csv', [
+      ['name' => 'event_id'],
+      ['name' => 'do_not_import'],
+      ['name' => 'contact_id'],
+      ['name' => 'fee_amount'],
+      ['name' => 'do_not_import'],
+      ['name' => 'fee_level'],
+      ['name' => 'is_pay_later'],
+      ['name' => 'role_id'],
+      ['name' => 'source'],
+      ['name' => 'status_id'],
+      ['name' => 'register_date'],
+      ['name' => 'do_not_import'],
+      ['name' => 'do_not_import'],
+    ]);
+    $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
+    $row = $dataSource->getRow();
+    $this->assertEquals('ERROR', $row['_status']);
+    $this->assertEquals('Missing required fields: Event ID', $row['_status_message']);
+  }
+
+  /**
    * Test that imports work generally.
    *
    * @throws \CRM_Core_Exception

--- a/tests/phpunit/CRM/Event/Import/Parser/data/participant_with_event_id.csv
+++ b/tests/phpunit/CRM/Event/Import/Parser/data/participant_with_event_id.csv
@@ -1,0 +1,2 @@
+Event ID,Campaign ID,Contact ID,Fee Amount,Fee Currency,Fee level,Is Pay Later,Participant Role,Participant Source,Participant Status,Register date,Do not import,Color
+1,Soccer Cup,3,5000.55,USD,High,No,"Attendee, Volunteer",Phoned up,Registered,2022-12-07,,"Purple, Mauve"


### PR DESCRIPTION
I added a test to check what is happening here & an attempt to import to a template event fails well before the chunk of removed code. Perhaps the message could be better but this does not change that - it just ensures that at least the import cannot be done & removes some unused code
