### PR TITLE
No properties

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1,4 +1,5 @@
-<?php
+<?php /** @noinspection PhpUndefinedFieldInspection */
+
 /*
  +--------------------------------------------------------------------+
  | Copyright CiviCRM LLC. All rights reserved.                        |


### PR DESCRIPTION
This would mean we don't have to completely disable our IDE interaction with Civi & we could still pick up bugs that affect classes other than BAO/DAO classes... I don't like it - but I'd rather accept loss of bug-finding in BAO/DAO than on all files