### PR TITLE
Fix crash flushing when a managed record is removed after the entity it manages has been deleted

### DIFF
--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -375,7 +375,10 @@ class CRM_Core_ManagedEntities {
         break;
 
       case 'unused':
-        if (CRM_Core_BAO_Managed::isApi4ManagedType($item['entity_type'])) {
+        if (!$item['entity_id']) {
+          $getRefCount = [];
+        }
+        elseif (CRM_Core_BAO_Managed::isApi4ManagedType($item['entity_type'])) {
           $getRefCount = CoreUtil::getRefCount($item['entity_type'], $item['entity_id']);
         }
         else {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes crash when flushing if a managed record is removed when the entity it is managing has been deleted.

Added a test that demonstrates crash on master, passes with patch.