### PR TITLE
dev/core#5230 Switch confirm_text on backoffice event to html

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1319,7 +1319,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
     $form->add('select', 'from_email_address', ts('Receipt From'), $form->getAvailableFromEmails()['from_email_id']);
 
-    $form->add('textarea', 'receipt_text', ts('Confirmation Message'));
+    $form->add('wysiwyg', 'receipt_text', ts('Confirmation Message'));
 
     // Retrieve the name and email of the contact - form will be the TO for receipt email ( only if context is not standalone)
     if ($form->_context !== 'standalone') {
@@ -1821,7 +1821,7 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
         'PDFFilename' => ts('confirmation') . '.pdf',
         'modelProps' => [
           'participantID' => $participantID,
-          'userEnteredText' => $this->getSubmittedValue('receipt_text'),
+          'userEnteredHTML' => $this->getSubmittedValue('receipt_text'),
           'eventID' => $params['event_id'],
           'contributionID' => $contributionID,
         ],


### PR DESCRIPTION


Overview
----------------------------------------
dev/core#5230 Switch confirm_text on backoffice event to html
https://lab.civicrm.org/dev/core/-/issues/5230

Before
----------------------------------------
The field civicrm_event.confirm_text is now an html field. However, it is also used to populate the back office field for receipt text, which is not an html field. This causes mis-formatting

After
----------------------------------------
The back-office field is converted to html

Technical Details
----------------------------------------


Comments
----------------------------------------
