### PR TITLE
dev/core#5207 Add event_id in the cancel url for paypalStd (& similar)

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -9,6 +9,7 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Participant;
 use Civi\Payment\System;
 use Civi\Payment\Exception\PaymentProcessorException;
 use Civi\Payment\PropertyBag;
@@ -1240,9 +1241,12 @@ abstract class CRM_Core_Payment {
     }
 
     if ($this->_component == 'event') {
+      $eventID = Participant::get(FALSE)->addWhere('id', '=', $participantID)
+        ->addSelect('event_id')->execute()->single()['event_id'];
       return CRM_Utils_System::url($this->getBaseReturnUrl(), [
         'reset' => 1,
         'cc' => 'fail',
+        'id' => $eventID,
         'participantId' => $participantID,
       ],
         TRUE, NULL, FALSE


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5207 Add event_id in the cancel url for paypalStd (& similar)

Before
----------------------------------------

See https://lab.civicrm.org/dev/core/-/issues/5207

After
----------------------------------------
Event ID is in the cancel URL

Technical Details
----------------------------------------
Per the gitlab I can't quite see how this could have regressed. I think this will fix it but it's a bit tricky to test for most people so I'm hoping @pradpnayak will confirm

Comments
----------------------------------------
