### PR TITLE
dev/core#5237: improve caching of afform metadata

### DIFF
--- a/ext/afform/core/CRM/Afform/AfformScanner.php
+++ b/ext/afform/core/CRM/Afform/AfformScanner.php
@@ -140,6 +140,12 @@ class CRM_Afform_AfformScanner {
    * @see \Civi\Api4\Afform::getFields
    */
   public function getMeta(string $name, bool $getLayout = FALSE): ?array {
+    if ($this->isUseCachedPaths()) {
+      $cachedDefn = $this->cache->get('afform.meta.' . $name);
+      if ($cachedDefn !== NULL) {
+        return $cachedDefn;
+      }
+    }
     $defn = [];
     $mtime = NULL;
 
@@ -173,6 +179,9 @@ class CRM_Afform_AfformScanner {
     }
     $defn['name'] = $name;
     $defn['modified_date'] = date('Y-m-d H:i:s', $mtime);
+    if ($this->isUseCachedPaths()) {
+      $this->cache->set('afform.meta.' . $name, $defn);
+    }
     return $defn;
   }
 

--- a/ext/afform/core/CRM/Afform/AfformScanner.php
+++ b/ext/afform/core/CRM/Afform/AfformScanner.php
@@ -140,8 +140,12 @@ class CRM_Afform_AfformScanner {
    * @see \Civi\Api4\Afform::getFields
    */
   public function getMeta(string $name, bool $getLayout = FALSE): ?array {
+    $cacheKey = 'afform.meta.' . $name;
+    if ($getLayout) {
+      $cacheKey .= '.getLayout';
+    }
     if ($this->isUseCachedPaths()) {
-      $cachedDefn = $this->cache->get('afform.meta.' . $name);
+      $cachedDefn = $this->cache->get($cacheKey);
       if ($cachedDefn !== NULL) {
         return $cachedDefn;
       }
@@ -180,7 +184,7 @@ class CRM_Afform_AfformScanner {
     $defn['name'] = $name;
     $defn['modified_date'] = date('Y-m-d H:i:s', $mtime);
     if ($this->isUseCachedPaths()) {
-      $this->cache->set('afform.meta.' . $name, $defn);
+      $this->cache->set($cacheKey, $defn);
     }
     return $defn;
   }


### PR DESCRIPTION
Overview
----------------------------------------
The AFForm extension slows a site down. This is caused by the AFForm extension loading all meta data files.

The list of meta data files is cached by the contents it is not.

My proposal would be to cache also the content of the meta data file.

In my local environment with (a copy a large production database) the view contact timings went down from 4.36 seconds to 2.88 seconds when caching of the contents of the meta data file where enabled.

On a production site the timings of the view contact summary page went down from 7.39 seconds to 5.70 seconds.

See https://lab.civicrm.org/dev/core/-/issues/5237