### PR TITLE
Core - Add annotations to DAO stubs

### DIFF
--- a/CRM/ACL/DAO/ACL.php
+++ b/CRM/ACL/DAO/ACL.php
@@ -7,6 +7,19 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $name
+ * @property bool|string $deny
+ * @property string $entity_table
+ * @property int|string|null $entity_id
+ * @property string $operation
+ * @property string|null $object_table
+ * @property int|string|null $object_id
+ * @property string|null $acl_table
+ * @property int|string|null $acl_id
+ * @property bool|string $is_active
+ * @property int|string $priority
  */
 class CRM_ACL_DAO_ACL extends CRM_Core_DAO_Base {
 }

--- a/CRM/ACL/DAO/ACLCache.php
+++ b/CRM/ACL/DAO/ACLCache.php
@@ -7,6 +7,11 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $contact_id
+ * @property int|string $acl_id
+ * @property string $modified_date
  */
 class CRM_ACL_DAO_ACLCache extends CRM_Core_DAO_Base {
 }

--- a/CRM/ACL/DAO/ACLEntityRole.php
+++ b/CRM/ACL/DAO/ACLEntityRole.php
@@ -7,6 +7,12 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $acl_role_id
+ * @property string $entity_table
+ * @property int|string $entity_id
+ * @property bool|string $is_active
  */
 class CRM_ACL_DAO_ACLEntityRole extends CRM_Core_DAO_Base {
 }

--- a/CRM/Activity/DAO/Activity.php
+++ b/CRM/Activity/DAO/Activity.php
@@ -7,6 +7,34 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $source_record_id
+ * @property int|string $activity_type_id
+ * @property string|null $subject
+ * @property string $activity_date_time
+ * @property int|string|null $duration
+ * @property string|null $location
+ * @property int|string|null $phone_id
+ * @property string|null $phone_number
+ * @property string|null $details
+ * @property int|string|null $status_id
+ * @property int|string|null $priority_id
+ * @property int|string|null $parent_id
+ * @property bool|string $is_test
+ * @property int|string|null $medium_id
+ * @property bool|string $is_auto
+ * @property int|string|null $relationship_id
+ * @property bool|string $is_current_revision
+ * @property int|string|null $original_id
+ * @property string|null $result
+ * @property bool|string $is_deleted
+ * @property int|string|null $campaign_id
+ * @property int|string|null $engagement_level
+ * @property int|string|null $weight
+ * @property bool|string $is_star
+ * @property string $created_date
+ * @property string $modified_date
  */
 class CRM_Activity_DAO_Activity extends CRM_Core_DAO_Base {
 }

--- a/CRM/Activity/DAO/ActivityContact.php
+++ b/CRM/Activity/DAO/ActivityContact.php
@@ -7,6 +7,11 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $activity_id
+ * @property int|string $contact_id
+ * @property int|string|null $record_type_id
  */
 class CRM_Activity_DAO_ActivityContact extends CRM_Core_DAO_Base {
 }

--- a/CRM/Batch/DAO/Batch.php
+++ b/CRM/Batch/DAO/Batch.php
@@ -7,6 +7,24 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $name
+ * @property string|null $title
+ * @property string|null $description
+ * @property int|string|null $created_id
+ * @property string|null $created_date
+ * @property int|string|null $modified_id
+ * @property string|null $modified_date
+ * @property int|string|null $saved_search_id
+ * @property int|string $status_id
+ * @property int|string|null $type_id
+ * @property int|string|null $mode_id
+ * @property float|string|null $total
+ * @property int|string|null $item_count
+ * @property int|string|null $payment_instrument_id
+ * @property string|null $exported_date
+ * @property string|null $data
  */
 class CRM_Batch_DAO_Batch extends CRM_Core_DAO_Base {
 }

--- a/CRM/Batch/DAO/EntityBatch.php
+++ b/CRM/Batch/DAO/EntityBatch.php
@@ -7,6 +7,11 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $entity_table
+ * @property int|string $entity_id
+ * @property int|string $batch_id
  */
 class CRM_Batch_DAO_EntityBatch extends CRM_Core_DAO_Base {
 }

--- a/CRM/Campaign/DAO/Campaign.php
+++ b/CRM/Campaign/DAO/Campaign.php
@@ -7,6 +7,24 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property string|null $title
+ * @property string|null $description
+ * @property string|null $start_date
+ * @property string|null $end_date
+ * @property int|string|null $campaign_type_id
+ * @property int|string|null $status_id
+ * @property string|null $external_identifier
+ * @property int|string|null $parent_id
+ * @property bool|string $is_active
+ * @property int|string|null $created_id
+ * @property string|null $created_date
+ * @property int|string|null $last_modified_id
+ * @property string|null $last_modified_date
+ * @property string|null $goal_general
+ * @property float|string|null $goal_revenue
  */
 class CRM_Campaign_DAO_Campaign extends CRM_Core_DAO_Base {
 }

--- a/CRM/Campaign/DAO/CampaignGroup.php
+++ b/CRM/Campaign/DAO/CampaignGroup.php
@@ -7,6 +7,12 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $campaign_id
+ * @property string|null $group_type
+ * @property string|null $entity_table
+ * @property int|string|null $entity_id
  */
 class CRM_Campaign_DAO_CampaignGroup extends CRM_Core_DAO_Base {
 }

--- a/CRM/Campaign/DAO/Survey.php
+++ b/CRM/Campaign/DAO/Survey.php
@@ -7,6 +7,26 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $title
+ * @property int|string|null $campaign_id
+ * @property int|string|null $activity_type_id
+ * @property string|null $instructions
+ * @property int|string|null $release_frequency
+ * @property int|string|null $max_number_of_contacts
+ * @property int|string|null $default_number_of_contacts
+ * @property bool|string $is_active
+ * @property bool|string $is_default
+ * @property int|string|null $created_id
+ * @property string|null $created_date
+ * @property int|string|null $last_modified_id
+ * @property string|null $last_modified_date
+ * @property int|string|null $result_id
+ * @property bool|string $bypass_confirm
+ * @property string|null $thankyou_title
+ * @property string|null $thankyou_text
+ * @property bool|string $is_share
  */
 class CRM_Campaign_DAO_Survey extends CRM_Core_DAO_Base {
 }

--- a/CRM/Case/DAO/Case.php
+++ b/CRM/Case/DAO/Case.php
@@ -7,6 +7,17 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $case_type_id
+ * @property string|null $subject
+ * @property string|null $start_date
+ * @property string|null $end_date
+ * @property string|null $details
+ * @property int|string $status_id
+ * @property bool|string $is_deleted
+ * @property string $created_date
+ * @property string $modified_date
  */
 class CRM_Case_DAO_Case extends CRM_Core_DAO_Base {
 }

--- a/CRM/Case/DAO/CaseActivity.php
+++ b/CRM/Case/DAO/CaseActivity.php
@@ -7,6 +7,10 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $case_id
+ * @property int|string $activity_id
  */
 class CRM_Case_DAO_CaseActivity extends CRM_Core_DAO_Base {
 }

--- a/CRM/Case/DAO/CaseContact.php
+++ b/CRM/Case/DAO/CaseContact.php
@@ -7,6 +7,10 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $case_id
+ * @property int|string $contact_id
  */
 class CRM_Case_DAO_CaseContact extends CRM_Core_DAO_Base {
 }

--- a/CRM/Case/DAO/CaseType.php
+++ b/CRM/Case/DAO/CaseType.php
@@ -7,6 +7,15 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property string $title
+ * @property string|null $description
+ * @property bool|string $is_active
+ * @property bool|string $is_reserved
+ * @property int|string $weight
+ * @property string|null $definition
  */
 class CRM_Case_DAO_CaseType extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contact/DAO/ACLContactCache.php
+++ b/CRM/Contact/DAO/ACLContactCache.php
@@ -7,6 +7,11 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $user_id
+ * @property int|string $contact_id
+ * @property string $operation
  */
 class CRM_Contact_DAO_ACLContactCache extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contact/DAO/Contact.php
+++ b/CRM/Contact/DAO/Contact.php
@@ -7,6 +7,59 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $contact_type
+ * @property string|null $external_identifier
+ * @property string|null $display_name
+ * @property string|null $organization_name
+ * @property string|null $contact_sub_type
+ * @property string|null $first_name
+ * @property string|null $middle_name
+ * @property string|null $last_name
+ * @property bool|string $do_not_email
+ * @property bool|string $do_not_phone
+ * @property bool|string $do_not_mail
+ * @property bool|string $do_not_sms
+ * @property bool|string $do_not_trade
+ * @property bool|string $is_opt_out
+ * @property string|null $legal_identifier
+ * @property string|null $sort_name
+ * @property string|null $nick_name
+ * @property string|null $legal_name
+ * @property string|null $image_URL
+ * @property string|null $preferred_communication_method
+ * @property string|null $preferred_language
+ * @property string|null $hash
+ * @property string|null $api_key
+ * @property string|null $source
+ * @property int|string|null $prefix_id
+ * @property int|string|null $suffix_id
+ * @property string|null $formal_title
+ * @property int|string|null $communication_style_id
+ * @property int|string|null $email_greeting_id
+ * @property string|null $email_greeting_custom
+ * @property string|null $email_greeting_display
+ * @property int|string|null $postal_greeting_id
+ * @property string|null $postal_greeting_custom
+ * @property string|null $postal_greeting_display
+ * @property int|string|null $addressee_id
+ * @property string|null $addressee_custom
+ * @property string|null $addressee_display
+ * @property string|null $job_title
+ * @property int|string|null $gender_id
+ * @property string|null $birth_date
+ * @property bool|string $is_deceased
+ * @property string|null $deceased_date
+ * @property string|null $household_name
+ * @property int|string|null $primary_contact_id
+ * @property string|null $sic_code
+ * @property string|null $user_unique_id
+ * @property int|string|null $employer_id
+ * @property bool|string $is_deleted
+ * @property string $created_date
+ * @property string $modified_date
+ * @property string|null $preferred_mail_format
  */
 class CRM_Contact_DAO_Contact extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contact/DAO/ContactType.php
+++ b/CRM/Contact/DAO/ContactType.php
@@ -7,6 +7,16 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property string|null $label
+ * @property string|null $description
+ * @property string|null $image_URL
+ * @property string|null $icon
+ * @property int|string|null $parent_id
+ * @property bool|string $is_active
+ * @property bool|string $is_reserved
  */
 class CRM_Contact_DAO_ContactType extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contact/DAO/DashboardContact.php
+++ b/CRM/Contact/DAO/DashboardContact.php
@@ -7,6 +7,13 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $dashboard_id
+ * @property int|string $contact_id
+ * @property int|string|null $column_no
+ * @property bool|string $is_active
+ * @property int|string|null $weight
  */
 class CRM_Contact_DAO_DashboardContact extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contact/DAO/Group.php
+++ b/CRM/Contact/DAO/Group.php
@@ -7,6 +7,30 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property string $title
+ * @property string|null $description
+ * @property string|null $source
+ * @property int|string|null $saved_search_id
+ * @property bool|string $is_active
+ * @property string|null $visibility
+ * @property string|null $where_clause
+ * @property string|null $select_tables
+ * @property string|null $where_tables
+ * @property string|null $group_type
+ * @property string $cache_date
+ * @property float|string $cache_fill_took
+ * @property string $refresh_date
+ * @property string|null $parents
+ * @property string|null $children
+ * @property bool|string $is_hidden
+ * @property bool|string $is_reserved
+ * @property int|string|null $created_id
+ * @property int|string|null $modified_id
+ * @property string $frontend_title
+ * @property string|null $frontend_description
  */
 class CRM_Contact_DAO_Group extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contact/DAO/GroupContact.php
+++ b/CRM/Contact/DAO/GroupContact.php
@@ -7,6 +7,13 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $group_id
+ * @property int|string $contact_id
+ * @property string|null $status
+ * @property int|string|null $location_id
+ * @property int|string|null $email_id
  */
 class CRM_Contact_DAO_GroupContact extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contact/DAO/GroupContactCache.php
+++ b/CRM/Contact/DAO/GroupContactCache.php
@@ -7,6 +7,10 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $group_id
+ * @property int|string $contact_id
  */
 class CRM_Contact_DAO_GroupContactCache extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contact/DAO/GroupNesting.php
+++ b/CRM/Contact/DAO/GroupNesting.php
@@ -7,6 +7,10 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $child_group_id
+ * @property int|string $parent_group_id
  */
 class CRM_Contact_DAO_GroupNesting extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contact/DAO/GroupOrganization.php
+++ b/CRM/Contact/DAO/GroupOrganization.php
@@ -7,6 +7,10 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $group_id
+ * @property int|string $organization_id
  */
 class CRM_Contact_DAO_GroupOrganization extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contact/DAO/Relationship.php
+++ b/CRM/Contact/DAO/Relationship.php
@@ -7,6 +7,20 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $contact_id_a
+ * @property int|string $contact_id_b
+ * @property int|string $relationship_type_id
+ * @property string|null $start_date
+ * @property string|null $end_date
+ * @property bool|string $is_active
+ * @property string|null $description
+ * @property int|string $is_permission_a_b
+ * @property int|string $is_permission_b_a
+ * @property int|string|null $case_id
+ * @property string $created_date
+ * @property string $modified_date
  */
 class CRM_Contact_DAO_Relationship extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contact/DAO/RelationshipCache.php
+++ b/CRM/Contact/DAO/RelationshipCache.php
@@ -7,6 +7,19 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $relationship_id
+ * @property int|string $relationship_type_id
+ * @property string $orientation
+ * @property int|string $near_contact_id
+ * @property string|null $near_relation
+ * @property int|string $far_contact_id
+ * @property string|null $far_relation
+ * @property bool|string $is_active
+ * @property string|null $start_date
+ * @property string|null $end_date
+ * @property int|string|null $case_id
  */
 class CRM_Contact_DAO_RelationshipCache extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contact/DAO/RelationshipType.php
+++ b/CRM/Contact/DAO/RelationshipType.php
@@ -7,6 +7,19 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $name_a_b
+ * @property string|null $label_a_b
+ * @property string|null $name_b_a
+ * @property string|null $label_b_a
+ * @property string|null $description
+ * @property string|null $contact_type_a
+ * @property string|null $contact_type_b
+ * @property string|null $contact_sub_type_a
+ * @property string|null $contact_sub_type_b
+ * @property bool|string $is_reserved
+ * @property bool|string $is_active
  */
 class CRM_Contact_DAO_RelationshipType extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contact/DAO/SavedSearch.php
+++ b/CRM/Contact/DAO/SavedSearch.php
@@ -7,6 +7,21 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $name
+ * @property string|null $label
+ * @property string|null $form_values
+ * @property int|string|null $mapping_id
+ * @property int|string|null $search_custom_id
+ * @property string|null $api_entity
+ * @property string|null $api_params
+ * @property int|string|null $created_id
+ * @property int|string|null $modified_id
+ * @property string $expires_date
+ * @property string $created_date
+ * @property string $modified_date
+ * @property string|null $description
  */
 class CRM_Contact_DAO_SavedSearch extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contact/DAO/SubscriptionHistory.php
+++ b/CRM/Contact/DAO/SubscriptionHistory.php
@@ -7,6 +7,14 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $contact_id
+ * @property int|string|null $group_id
+ * @property string $date
+ * @property string|null $method
+ * @property string|null $status
+ * @property string|null $tracking
  */
 class CRM_Contact_DAO_SubscriptionHistory extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contribute/DAO/Contribution.php
+++ b/CRM/Contribute/DAO/Contribution.php
@@ -7,6 +7,38 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $contact_id
+ * @property int|string|null $financial_type_id
+ * @property int|string|null $contribution_page_id
+ * @property int|string|null $payment_instrument_id
+ * @property string|null $receive_date
+ * @property float|string|null $non_deductible_amount
+ * @property float|string $total_amount
+ * @property float|string|null $fee_amount
+ * @property float|string|null $net_amount
+ * @property string|null $trxn_id
+ * @property string|null $invoice_id
+ * @property string|null $invoice_number
+ * @property string|null $currency
+ * @property string|null $cancel_date
+ * @property string|null $cancel_reason
+ * @property string|null $receipt_date
+ * @property string|null $thankyou_date
+ * @property string|null $source
+ * @property string|null $amount_level
+ * @property int|string|null $contribution_recur_id
+ * @property bool|string $is_test
+ * @property bool|string $is_pay_later
+ * @property int|string|null $contribution_status_id
+ * @property int|string|null $address_id
+ * @property string|null $check_number
+ * @property int|string|null $campaign_id
+ * @property string|null $creditnote_id
+ * @property float|string $tax_amount
+ * @property string|null $revenue_recognition_date
+ * @property bool|string $is_template
  */
 class CRM_Contribute_DAO_Contribution extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contribute/DAO/ContributionPage.php
+++ b/CRM/Contribute/DAO/ContributionPage.php
@@ -7,6 +7,54 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $title
+ * @property string $frontend_title
+ * @property string $name
+ * @property string|null $intro_text
+ * @property int|string|null $financial_type_id
+ * @property string|null $payment_processor
+ * @property bool|string $is_credit_card_only
+ * @property bool|string $is_monetary
+ * @property bool|string $is_recur
+ * @property bool|string $is_confirm_enabled
+ * @property string|null $recur_frequency_unit
+ * @property bool|string $is_recur_interval
+ * @property bool|string $is_recur_installments
+ * @property bool|string $adjust_recur_start_date
+ * @property bool|string $is_pay_later
+ * @property string|null $pay_later_text
+ * @property string|null $pay_later_receipt
+ * @property bool|string|null $is_partial_payment
+ * @property string|null $initial_amount_label
+ * @property string|null $initial_amount_help_text
+ * @property float|string|null $min_initial_amount
+ * @property bool|string $is_allow_other_amount
+ * @property int|string|null $default_amount_id
+ * @property float|string|null $min_amount
+ * @property float|string|null $max_amount
+ * @property float|string|null $goal_amount
+ * @property string|null $thankyou_title
+ * @property string|null $thankyou_text
+ * @property string|null $thankyou_footer
+ * @property bool|string $is_email_receipt
+ * @property string|null $receipt_from_name
+ * @property string|null $receipt_from_email
+ * @property string|null $cc_receipt
+ * @property string|null $bcc_receipt
+ * @property string|null $receipt_text
+ * @property bool|string $is_active
+ * @property string|null $footer_text
+ * @property bool|string $amount_block_is_active
+ * @property string|null $start_date
+ * @property string|null $end_date
+ * @property int|string|null $created_id
+ * @property string|null $created_date
+ * @property string|null $currency
+ * @property int|string|null $campaign_id
+ * @property bool|string $is_share
+ * @property bool|string $is_billing_required
  */
 class CRM_Contribute_DAO_ContributionPage extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contribute/DAO/ContributionProduct.php
+++ b/CRM/Contribute/DAO/ContributionProduct.php
@@ -7,6 +7,17 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $product_id
+ * @property int|string $contribution_id
+ * @property string|null $product_option
+ * @property int|string|null $quantity
+ * @property string|null $fulfilled_date
+ * @property string|null $start_date
+ * @property string|null $end_date
+ * @property string|null $comment
+ * @property int|string|null $financial_type_id
  */
 class CRM_Contribute_DAO_ContributionProduct extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contribute/DAO/ContributionRecur.php
+++ b/CRM/Contribute/DAO/ContributionRecur.php
@@ -7,6 +7,36 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $contact_id
+ * @property float|string $amount
+ * @property string|null $currency
+ * @property string|null $frequency_unit
+ * @property int|string $frequency_interval
+ * @property int|string|null $installments
+ * @property string $start_date
+ * @property string $create_date
+ * @property string|null $modified_date
+ * @property string|null $cancel_date
+ * @property string|null $cancel_reason
+ * @property string|null $end_date
+ * @property string|null $processor_id
+ * @property int|string|null $payment_token_id
+ * @property string|null $trxn_id
+ * @property string|null $invoice_id
+ * @property int|string|null $contribution_status_id
+ * @property bool|string $is_test
+ * @property int|string $cycle_day
+ * @property string|null $next_sched_contribution_date
+ * @property int|string|null $failure_count
+ * @property string|null $failure_retry_date
+ * @property bool|string $auto_renew
+ * @property int|string|null $payment_processor_id
+ * @property int|string|null $financial_type_id
+ * @property int|string|null $payment_instrument_id
+ * @property int|string|null $campaign_id
+ * @property bool|string $is_email_receipt
  */
 class CRM_Contribute_DAO_ContributionRecur extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contribute/DAO/ContributionSoft.php
+++ b/CRM/Contribute/DAO/ContributionSoft.php
@@ -7,6 +7,17 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $contribution_id
+ * @property int|string $contact_id
+ * @property float|string $amount
+ * @property string|null $currency
+ * @property int|string|null $pcp_id
+ * @property bool|string $pcp_display_in_roll
+ * @property string|null $pcp_roll_nickname
+ * @property string|null $pcp_personal_note
+ * @property int|string|null $soft_credit_type_id
  */
 class CRM_Contribute_DAO_ContributionSoft extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contribute/DAO/Premium.php
+++ b/CRM/Contribute/DAO/Premium.php
@@ -7,6 +7,18 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $entity_table
+ * @property int|string $entity_id
+ * @property bool|string $premiums_active
+ * @property string|null $premiums_intro_title
+ * @property string|null $premiums_intro_text
+ * @property string|null $premiums_contact_email
+ * @property string|null $premiums_contact_phone
+ * @property bool|string $premiums_display_min_contribution
+ * @property string|null $premiums_nothankyou_label
+ * @property int|string|null $premiums_nothankyou_position
  */
 class CRM_Contribute_DAO_Premium extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contribute/DAO/PremiumsProduct.php
+++ b/CRM/Contribute/DAO/PremiumsProduct.php
@@ -7,6 +7,12 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $premiums_id
+ * @property int|string $product_id
+ * @property int|string $weight
+ * @property int|string|null $financial_type_id
  */
 class CRM_Contribute_DAO_PremiumsProduct extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contribute/DAO/Product.php
+++ b/CRM/Contribute/DAO/Product.php
@@ -7,6 +7,26 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property string|null $description
+ * @property string|null $sku
+ * @property string|null $options
+ * @property string|null $image
+ * @property string|null $thumbnail
+ * @property float|string|null $price
+ * @property string|null $currency
+ * @property int|string|null $financial_type_id
+ * @property float|string|null $min_contribution
+ * @property float|string|null $cost
+ * @property bool|string $is_active
+ * @property string|null $period_type
+ * @property int|string|null $fixed_period_start_day
+ * @property string|null $duration_unit
+ * @property int|string|null $duration_interval
+ * @property string|null $frequency_unit
+ * @property int|string|null $frequency_interval
  */
 class CRM_Contribute_DAO_Product extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contribute/DAO/Widget.php
+++ b/CRM/Contribute/DAO/Widget.php
@@ -7,6 +7,24 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $contribution_page_id
+ * @property bool|string $is_active
+ * @property string|null $title
+ * @property string|null $url_logo
+ * @property string|null $button_title
+ * @property string|null $about
+ * @property string|null $url_homepage
+ * @property string|null $color_title
+ * @property string|null $color_button
+ * @property string|null $color_bar
+ * @property string|null $color_main_text
+ * @property string|null $color_main
+ * @property string|null $color_main_bg
+ * @property string|null $color_bg
+ * @property string|null $color_about_link
+ * @property string|null $color_homepage_link
  */
 class CRM_Contribute_DAO_Widget extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/ActionLog.php
+++ b/CRM/Core/DAO/ActionLog.php
@@ -7,6 +7,17 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $contact_id
+ * @property int|string $entity_id
+ * @property string|null $entity_table
+ * @property int|string $action_schedule_id
+ * @property string|null $action_date_time
+ * @property bool|string $is_error
+ * @property string|null $message
+ * @property int|string|null $repetition_number
+ * @property string|null $reference_date
  */
 class CRM_Core_DAO_ActionLog extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/ActionSchedule.php
+++ b/CRM/Core/DAO/ActionSchedule.php
@@ -7,6 +7,49 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property string|null $title
+ * @property string|null $recipient
+ * @property int|string|null $limit_to
+ * @property string|null $entity_value
+ * @property string|null $entity_status
+ * @property int|string|null $start_action_offset
+ * @property string|null $start_action_unit
+ * @property string|null $start_action_condition
+ * @property string|null $start_action_date
+ * @property bool|string $is_repeat
+ * @property string|null $repetition_frequency_unit
+ * @property int|string|null $repetition_frequency_interval
+ * @property string|null $end_frequency_unit
+ * @property int|string|null $end_frequency_interval
+ * @property string|null $end_action
+ * @property string|null $end_date
+ * @property bool|string $is_active
+ * @property string|null $recipient_manual
+ * @property string|null $recipient_listing
+ * @property string|null $body_text
+ * @property string|null $body_html
+ * @property string|null $sms_body_text
+ * @property string|null $subject
+ * @property bool|string $record_activity
+ * @property string|null $mapping_id
+ * @property int|string|null $group_id
+ * @property int|string|null $msg_template_id
+ * @property int|string|null $sms_template_id
+ * @property string|null $absolute_date
+ * @property string|null $from_name
+ * @property string|null $from_email
+ * @property string|null $mode
+ * @property int|string|null $sms_provider_id
+ * @property string|null $used_for
+ * @property string|null $filter_contact_language
+ * @property string|null $communication_language
+ * @property string $created_date
+ * @property string $modified_date
+ * @property string $effective_start_date
+ * @property string $effective_end_date
  */
 class CRM_Core_DAO_ActionSchedule extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Address.php
+++ b/CRM/Core/DAO/Address.php
@@ -7,6 +7,36 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $contact_id
+ * @property int|string|null $location_type_id
+ * @property bool|string $is_primary
+ * @property bool|string $is_billing
+ * @property string|null $street_address
+ * @property int|string|null $street_number
+ * @property string|null $street_number_suffix
+ * @property string|null $street_number_predirectional
+ * @property string|null $street_name
+ * @property string|null $street_type
+ * @property string|null $street_number_postdirectional
+ * @property string|null $street_unit
+ * @property string|null $supplemental_address_1
+ * @property string|null $supplemental_address_2
+ * @property string|null $supplemental_address_3
+ * @property string|null $city
+ * @property int|string|null $county_id
+ * @property int|string|null $state_province_id
+ * @property string|null $postal_code_suffix
+ * @property string|null $postal_code
+ * @property string|null $usps_adc
+ * @property int|string|null $country_id
+ * @property float|string|null $geo_code_1
+ * @property float|string|null $geo_code_2
+ * @property bool|string $manual_geo_code
+ * @property string|null $timezone
+ * @property string|null $name
+ * @property int|string|null $master_id
  */
 class CRM_Core_DAO_Address extends CRM_Core_DAO_Base {
 

--- a/CRM/Core/DAO/AddressFormat.php
+++ b/CRM/Core/DAO/AddressFormat.php
@@ -7,6 +7,9 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $format
  */
 class CRM_Core_DAO_AddressFormat extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Cache.php
+++ b/CRM/Core/DAO/Cache.php
@@ -7,6 +7,14 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $group_name
+ * @property string|null $path
+ * @property string|null $data
+ * @property int|string|null $component_id
+ * @property string|null $created_date
+ * @property string $expired_date
  */
 class CRM_Core_DAO_Cache extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Component.php
+++ b/CRM/Core/DAO/Component.php
@@ -7,6 +7,10 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property string|null $namespace
  */
 class CRM_Core_DAO_Component extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Country.php
+++ b/CRM/Core/DAO/Country.php
@@ -7,6 +7,17 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $name
+ * @property string|null $iso_code
+ * @property string|null $country_code
+ * @property int|string|null $address_format_id
+ * @property string|null $idd_prefix
+ * @property string|null $ndd_prefix
+ * @property int|string $region_id
+ * @property bool|string $is_province_abbreviated
+ * @property bool|string $is_active
  */
 class CRM_Core_DAO_Country extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/County.php
+++ b/CRM/Core/DAO/County.php
@@ -7,6 +7,12 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $name
+ * @property string|null $abbreviation
+ * @property int|string $state_province_id
+ * @property bool|string $is_active
  */
 class CRM_Core_DAO_County extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/CustomField.php
+++ b/CRM/Core/DAO/CustomField.php
@@ -7,6 +7,38 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $custom_group_id
+ * @property string|null $name
+ * @property string $label
+ * @property string $data_type
+ * @property string $html_type
+ * @property string|null $default_value
+ * @property bool|string $is_required
+ * @property bool|string $is_searchable
+ * @property bool|string $is_search_range
+ * @property int|string $weight
+ * @property string|null $help_pre
+ * @property string|null $help_post
+ * @property string|null $attributes
+ * @property bool|string|null $is_active
+ * @property bool|string $is_view
+ * @property int|string|null $options_per_line
+ * @property int|string|null $text_length
+ * @property int|string|null $start_date_years
+ * @property int|string|null $end_date_years
+ * @property string|null $date_format
+ * @property int|string|null $time_format
+ * @property int|string|null $note_columns
+ * @property int|string|null $note_rows
+ * @property string|null $column_name
+ * @property int|string|null $option_group_id
+ * @property int|string $serialize
+ * @property string|null $filter
+ * @property bool|string $in_selector
+ * @property string|null $fk_entity
+ * @property string $fk_entity_on_delete
  */
 class CRM_Core_DAO_CustomField extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/CustomGroup.php
+++ b/CRM/Core/DAO/CustomGroup.php
@@ -7,6 +7,29 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $name
+ * @property string $title
+ * @property string|null $extends
+ * @property int|string|null $extends_entity_column_id
+ * @property string|null $extends_entity_column_value
+ * @property string|null $style
+ * @property bool|string $collapse_display
+ * @property string|null $help_pre
+ * @property string|null $help_post
+ * @property int|string $weight
+ * @property bool|string $is_active
+ * @property string|null $table_name
+ * @property bool|string $is_multiple
+ * @property int|string|null $min_multiple
+ * @property int|string|null $max_multiple
+ * @property bool|string $collapse_adv_display
+ * @property int|string|null $created_id
+ * @property string|null $created_date
+ * @property bool|string $is_reserved
+ * @property bool|string $is_public
+ * @property string|null $icon
  */
 class CRM_Core_DAO_CustomGroup extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Dashboard.php
+++ b/CRM/Core/DAO/Dashboard.php
@@ -7,6 +7,19 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $domain_id
+ * @property string|null $name
+ * @property string|null $label
+ * @property string|null $url
+ * @property string|null $permission
+ * @property string|null $permission_operator
+ * @property string|null $fullscreen_url
+ * @property bool|string $is_active
+ * @property bool|string $is_reserved
+ * @property int|string $cache_minutes
+ * @property string|null $directive
  */
 class CRM_Core_DAO_Dashboard extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Discount.php
+++ b/CRM/Core/DAO/Discount.php
@@ -7,6 +7,13 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $entity_table
+ * @property int|string $entity_id
+ * @property int|string $price_set_id
+ * @property string|null $start_date
+ * @property string|null $end_date
  */
 class CRM_Core_DAO_Discount extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Domain.php
+++ b/CRM/Core/DAO/Domain.php
@@ -7,6 +7,14 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $name
+ * @property string|null $description
+ * @property string|null $version
+ * @property int|string|null $contact_id
+ * @property string|null $locales
+ * @property string|null $locale_custom_strings
  */
 class CRM_Core_DAO_Domain extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Email.php
+++ b/CRM/Core/DAO/Email.php
@@ -7,6 +7,19 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $contact_id
+ * @property int|string|null $location_type_id
+ * @property string|null $email
+ * @property bool|string $is_primary
+ * @property bool|string $is_billing
+ * @property int|string $on_hold
+ * @property bool|string $is_bulkmail
+ * @property string|null $hold_date
+ * @property string|null $reset_date
+ * @property string|null $signature_text
+ * @property string|null $signature_html
  */
 class CRM_Core_DAO_Email extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/EntityFile.php
+++ b/CRM/Core/DAO/EntityFile.php
@@ -7,6 +7,11 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $entity_table
+ * @property int|string $entity_id
+ * @property int|string $file_id
  */
 class CRM_Core_DAO_EntityFile extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/EntityTag.php
+++ b/CRM/Core/DAO/EntityTag.php
@@ -7,6 +7,11 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $entity_table
+ * @property int|string $entity_id
+ * @property int|string $tag_id
  */
 class CRM_Core_DAO_EntityTag extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Extension.php
+++ b/CRM/Core/DAO/Extension.php
@@ -7,6 +7,15 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $type
+ * @property string $full_name
+ * @property string|null $name
+ * @property string|null $label
+ * @property string|null $file
+ * @property string|null $schema_version
+ * @property bool|string|null $is_active
  */
 class CRM_Core_DAO_Extension extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/File.php
+++ b/CRM/Core/DAO/File.php
@@ -7,6 +7,15 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $file_type_id
+ * @property string|null $mime_type
+ * @property string|null $uri
+ * @property string|null $document
+ * @property string|null $description
+ * @property string|null $upload_date
+ * @property int|string|null $created_id
  */
 class CRM_Core_DAO_File extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/IM.php
+++ b/CRM/Core/DAO/IM.php
@@ -7,6 +7,14 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $contact_id
+ * @property int|string|null $location_type_id
+ * @property string|null $name
+ * @property int|string|null $provider_id
+ * @property bool|string $is_primary
+ * @property bool|string $is_billing
  */
 class CRM_Core_DAO_IM extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Job.php
+++ b/CRM/Core/DAO/Job.php
@@ -7,6 +7,19 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $domain_id
+ * @property string|null $run_frequency
+ * @property string $last_run
+ * @property string $last_run_end
+ * @property string $scheduled_run_date
+ * @property string|null $name
+ * @property string|null $description
+ * @property string|null $api_entity
+ * @property string|null $api_action
+ * @property string|null $parameters
+ * @property bool|string $is_active
  */
 class CRM_Core_DAO_Job extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/JobLog.php
+++ b/CRM/Core/DAO/JobLog.php
@@ -7,6 +7,15 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $domain_id
+ * @property string|null $run_time
+ * @property int|string|null $job_id
+ * @property string|null $name
+ * @property string|null $command
+ * @property string|null $description
+ * @property string|null $data
  */
 class CRM_Core_DAO_JobLog extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/LocBlock.php
+++ b/CRM/Core/DAO/LocBlock.php
@@ -7,6 +7,16 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $address_id
+ * @property int|string|null $email_id
+ * @property int|string|null $phone_id
+ * @property int|string|null $im_id
+ * @property int|string|null $address_2_id
+ * @property int|string|null $email_2_id
+ * @property int|string|null $phone_2_id
+ * @property int|string|null $im_2_id
  */
 class CRM_Core_DAO_LocBlock extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/LocationType.php
+++ b/CRM/Core/DAO/LocationType.php
@@ -7,6 +7,15 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property string $display_name
+ * @property string|null $vcard_name
+ * @property string|null $description
+ * @property bool|string $is_reserved
+ * @property bool|string $is_active
+ * @property bool|string $is_default
  */
 class CRM_Core_DAO_LocationType extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Log.php
+++ b/CRM/Core/DAO/Log.php
@@ -7,6 +7,13 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $entity_table
+ * @property int|string $entity_id
+ * @property string|null $data
+ * @property int|string|null $modified_id
+ * @property string|null $modified_date
  */
 class CRM_Core_DAO_Log extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/MailSettings.php
+++ b/CRM/Core/DAO/MailSettings.php
@@ -7,6 +7,30 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $domain_id
+ * @property string|null $name
+ * @property bool|string $is_default
+ * @property string|null $domain
+ * @property string|null $localpart
+ * @property string|null $return_path
+ * @property string|null $protocol
+ * @property string|null $server
+ * @property int|string|null $port
+ * @property string|null $username
+ * @property string|null $password
+ * @property bool|string $is_ssl
+ * @property string|null $source
+ * @property string|null $activity_status
+ * @property bool|string $is_non_case_email_skipped
+ * @property bool|string $is_contact_creation_disabled_if_no_match
+ * @property bool|string $is_active
+ * @property int|string|null $activity_type_id
+ * @property int|string|null $campaign_id
+ * @property string|null $activity_source
+ * @property string|null $activity_targets
+ * @property string|null $activity_assignees
  */
 class CRM_Core_DAO_MailSettings extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Managed.php
+++ b/CRM/Core/DAO/Managed.php
@@ -7,6 +7,14 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $module
+ * @property string $name
+ * @property string $entity_type
+ * @property int|string|null $entity_id
+ * @property string $cleanup
+ * @property string $entity_modified_date
  */
 class CRM_Core_DAO_Managed extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Mapping.php
+++ b/CRM/Core/DAO/Mapping.php
@@ -7,6 +7,11 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property string|null $description
+ * @property int|string|null $mapping_type_id
  */
 class CRM_Core_DAO_Mapping extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/MappingField.php
+++ b/CRM/Core/DAO/MappingField.php
@@ -7,6 +7,21 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $mapping_id
+ * @property string|null $name
+ * @property string|null $contact_type
+ * @property int|string $column_number
+ * @property int|string|null $location_type_id
+ * @property int|string|null $phone_type_id
+ * @property int|string|null $im_provider_id
+ * @property int|string|null $website_type_id
+ * @property int|string|null $relationship_type_id
+ * @property string|null $relationship_direction
+ * @property int|string|null $grouping
+ * @property string|null $operator
+ * @property string|null $value
  */
 class CRM_Core_DAO_MappingField extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Menu.php
+++ b/CRM/Core/DAO/Menu.php
@@ -7,6 +7,29 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $domain_id
+ * @property string|null $path
+ * @property string|null $path_arguments
+ * @property string|null $title
+ * @property string|null $access_callback
+ * @property string|null $access_arguments
+ * @property string|null $page_callback
+ * @property string|null $page_arguments
+ * @property string|null $breadcrumb
+ * @property string|null $return_url
+ * @property string|null $return_url_args
+ * @property int|string|null $component_id
+ * @property bool|string $is_active
+ * @property bool|string $is_public
+ * @property bool|string $is_exposed
+ * @property bool|string $is_ssl
+ * @property int|string $weight
+ * @property int|string $type
+ * @property int|string $page_type
+ * @property bool|string $skipBreadcrumb
+ * @property string|null $module_data
  */
 class CRM_Core_DAO_Menu extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/MessageTemplate.php
+++ b/CRM/Core/DAO/MessageTemplate.php
@@ -7,6 +7,19 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $msg_title
+ * @property string|null $msg_subject
+ * @property string|null $msg_text
+ * @property string|null $msg_html
+ * @property bool|string $is_active
+ * @property int|string|null $workflow_id
+ * @property string|null $workflow_name
+ * @property bool|string $is_default
+ * @property bool|string $is_reserved
+ * @property bool|string $is_sms
+ * @property int|string|null $pdf_format_id
  */
 class CRM_Core_DAO_MessageTemplate extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Navigation.php
+++ b/CRM/Core/DAO/Navigation.php
@@ -7,6 +7,19 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $domain_id
+ * @property string|null $label
+ * @property string|null $name
+ * @property string|null $url
+ * @property string $icon
+ * @property string|null $permission
+ * @property string|null $permission_operator
+ * @property int|string|null $parent_id
+ * @property bool|string $is_active
+ * @property int|string|null $has_separator
+ * @property int|string $weight
  */
 class CRM_Core_DAO_Navigation extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Note.php
+++ b/CRM/Core/DAO/Note.php
@@ -7,6 +7,17 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $entity_table
+ * @property int|string $entity_id
+ * @property string|null $note
+ * @property int|string|null $contact_id
+ * @property string|null $note_date
+ * @property string $created_date
+ * @property string|null $modified_date
+ * @property string|null $subject
+ * @property string $privacy
  */
 class CRM_Core_DAO_Note extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/OpenID.php
+++ b/CRM/Core/DAO/OpenID.php
@@ -7,6 +7,13 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $contact_id
+ * @property int|string|null $location_type_id
+ * @property string|null $openid
+ * @property bool|string $allowed_to_login
+ * @property bool|string $is_primary
  */
 class CRM_Core_DAO_OpenID extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/OptionGroup.php
+++ b/CRM/Core/DAO/OptionGroup.php
@@ -7,6 +7,16 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property string|null $title
+ * @property string|null $description
+ * @property string|null $data_type
+ * @property bool|string $is_reserved
+ * @property bool|string $is_active
+ * @property bool|string $is_locked
+ * @property string|null $option_value_fields
  */
 class CRM_Core_DAO_OptionGroup extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/OptionValue.php
+++ b/CRM/Core/DAO/OptionValue.php
@@ -7,6 +7,25 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $option_group_id
+ * @property string $label
+ * @property string $value
+ * @property string|null $name
+ * @property string|null $grouping
+ * @property int|string|null $filter
+ * @property bool|string|null $is_default
+ * @property int|string $weight
+ * @property string|null $description
+ * @property bool|string|null $is_optgroup
+ * @property bool|string|null $is_reserved
+ * @property bool|string|null $is_active
+ * @property int|string|null $component_id
+ * @property int|string|null $domain_id
+ * @property int|string|null $visibility_id
+ * @property string|null $icon
+ * @property string|null $color
  */
 class CRM_Core_DAO_OptionValue extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Phone.php
+++ b/CRM/Core/DAO/Phone.php
@@ -7,6 +7,17 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $contact_id
+ * @property int|string|null $location_type_id
+ * @property bool|string $is_primary
+ * @property bool|string $is_billing
+ * @property int|string|null $mobile_provider_id
+ * @property string|null $phone
+ * @property string|null $phone_ext
+ * @property string|null $phone_numeric
+ * @property int|string|null $phone_type_id
  */
 class CRM_Core_DAO_Phone extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/PreferencesDate.php
+++ b/CRM/Core/DAO/PreferencesDate.php
@@ -7,6 +7,14 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property string|null $description
+ * @property int|string $start
+ * @property int|string $end
+ * @property string|null $date_format
+ * @property string|null $time_format
  */
 class CRM_Core_DAO_PreferencesDate extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/PrevNextCache.php
+++ b/CRM/Core/DAO/PrevNextCache.php
@@ -7,6 +7,14 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $entity_table
+ * @property int|string $entity_id1
+ * @property int|string $entity_id2
+ * @property string|null $cachekey
+ * @property string|null $data
+ * @property bool|string $is_selected
  */
 class CRM_Core_DAO_PrevNextCache extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/PrintLabel.php
+++ b/CRM/Core/DAO/PrintLabel.php
@@ -7,6 +7,18 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $title
+ * @property string|null $name
+ * @property string|null $description
+ * @property string|null $label_format_name
+ * @property int|string|null $label_type_id
+ * @property string|null $data
+ * @property bool|string $is_default
+ * @property bool|string $is_active
+ * @property bool|string $is_reserved
+ * @property int|string|null $created_id
  */
 class CRM_Core_DAO_PrintLabel extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/RecurringEntity.php
+++ b/CRM/Core/DAO/RecurringEntity.php
@@ -7,6 +7,12 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $parent_id
+ * @property int|string|null $entity_id
+ * @property string $entity_table
+ * @property bool|string $mode
  */
 class CRM_Core_DAO_RecurringEntity extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Setting.php
+++ b/CRM/Core/DAO/Setting.php
@@ -7,6 +7,16 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $name
+ * @property string|null $value
+ * @property int|string|null $domain_id
+ * @property int|string|null $contact_id
+ * @property bool|string $is_domain
+ * @property int|string|null $component_id
+ * @property string|null $created_date
+ * @property int|string|null $created_id
  */
 class CRM_Core_DAO_Setting extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/StateProvince.php
+++ b/CRM/Core/DAO/StateProvince.php
@@ -7,6 +7,12 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $name
+ * @property string|null $abbreviation
+ * @property int|string $country_id
+ * @property bool|string $is_active
  */
 class CRM_Core_DAO_StateProvince extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/StatusPreference.php
+++ b/CRM/Core/DAO/StatusPreference.php
@@ -7,6 +7,15 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $domain_id
+ * @property string $name
+ * @property string|null $hush_until
+ * @property int|string|null $ignore_severity
+ * @property string|null $prefs
+ * @property string|null $check_info
+ * @property bool|string $is_active
  */
 class CRM_Core_DAO_StatusPreference extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/SystemLog.php
+++ b/CRM/Core/DAO/SystemLog.php
@@ -7,6 +7,14 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $message
+ * @property string|null $context
+ * @property string|null $level
+ * @property string|null $timestamp
+ * @property int|string|null $contact_id
+ * @property string|null $hostname
  */
 class CRM_Core_DAO_SystemLog extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Tag.php
+++ b/CRM/Core/DAO/Tag.php
@@ -7,6 +7,19 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property string $label
+ * @property string|null $description
+ * @property int|string|null $parent_id
+ * @property bool|string $is_selectable
+ * @property bool|string $is_reserved
+ * @property bool|string $is_tagset
+ * @property string|null $used_for
+ * @property int|string|null $created_id
+ * @property string|null $color
+ * @property string|null $created_date
  */
 class CRM_Core_DAO_Tag extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Timezone.php
+++ b/CRM/Core/DAO/Timezone.php
@@ -7,6 +7,13 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $name
+ * @property string|null $abbreviation
+ * @property string|null $gmt
+ * @property int|string|null $offset
+ * @property int|string $country_id
  */
 class CRM_Core_DAO_Timezone extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Translation.php
+++ b/CRM/Core/DAO/Translation.php
@@ -7,6 +7,14 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $entity_table
+ * @property string $entity_field
+ * @property int|string $entity_id
+ * @property string $language
+ * @property int|string $status_id
+ * @property string $string
  */
 class CRM_Core_DAO_Translation extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/UFField.php
+++ b/CRM/Core/DAO/UFField.php
@@ -7,6 +7,26 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $uf_group_id
+ * @property string $field_name
+ * @property bool|string $is_active
+ * @property bool|string $is_view
+ * @property bool|string $is_required
+ * @property int|string $weight
+ * @property string|null $help_post
+ * @property string|null $help_pre
+ * @property string|null $visibility
+ * @property bool|string $in_selector
+ * @property bool|string $is_searchable
+ * @property int|string|null $location_type_id
+ * @property int|string|null $phone_type_id
+ * @property int|string|null $website_type_id
+ * @property string $label
+ * @property string|null $field_type
+ * @property bool|string $is_reserved
+ * @property bool|string $is_multi_summary
  */
 class CRM_Core_DAO_UFField extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/UFGroup.php
+++ b/CRM/Core/DAO/UFGroup.php
@@ -7,6 +7,34 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property bool|string $is_active
+ * @property string|null $group_type
+ * @property string $title
+ * @property string $frontend_title
+ * @property string|null $description
+ * @property string|null $help_pre
+ * @property string|null $help_post
+ * @property int|string|null $limit_listings_group_id
+ * @property string|null $post_url
+ * @property int|string|null $add_to_group_id
+ * @property bool|string $add_captcha
+ * @property bool|string $is_map
+ * @property bool|string $is_edit_link
+ * @property bool|string $is_uf_link
+ * @property bool|string $is_update_dupe
+ * @property string|null $cancel_url
+ * @property bool|string $is_cms_user
+ * @property string|null $notify
+ * @property bool|string $is_reserved
+ * @property int|string|null $created_id
+ * @property string|null $created_date
+ * @property bool|string $is_proximity_search
+ * @property string|null $cancel_button_text
+ * @property string|null $submit_button_text
+ * @property bool|string $add_cancel_button
  */
 class CRM_Core_DAO_UFGroup extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/UFJoin.php
+++ b/CRM/Core/DAO/UFJoin.php
@@ -7,6 +7,15 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property bool|string $is_active
+ * @property string $module
+ * @property string|null $entity_table
+ * @property int|string|null $entity_id
+ * @property int|string $weight
+ * @property int|string $uf_group_id
+ * @property string|null $module_data
  */
 class CRM_Core_DAO_UFJoin extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/UFMatch.php
+++ b/CRM/Core/DAO/UFMatch.php
@@ -7,6 +7,13 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $domain_id
+ * @property int|string $uf_id
+ * @property string|null $uf_name
+ * @property int|string|null $contact_id
+ * @property string|null $language
  */
 class CRM_Core_DAO_UFMatch extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/UserJob.php
+++ b/CRM/Core/DAO/UserJob.php
@@ -7,6 +7,19 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $name
+ * @property int|string|null $created_id
+ * @property string $created_date
+ * @property string $start_date
+ * @property string $end_date
+ * @property string $expires_date
+ * @property int|string $status_id
+ * @property string $job_type
+ * @property int|string|null $queue_id
+ * @property string|null $metadata
+ * @property bool|string $is_template
  */
 class CRM_Core_DAO_UserJob extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Website.php
+++ b/CRM/Core/DAO/Website.php
@@ -7,6 +7,11 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $contact_id
+ * @property string|null $url
+ * @property int|string|null $website_type_id
  */
 class CRM_Core_DAO_Website extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/WordReplacement.php
+++ b/CRM/Core/DAO/WordReplacement.php
@@ -7,6 +7,13 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $find_word
+ * @property string|null $replace_word
+ * @property bool|string $is_active
+ * @property string|null $match_type
+ * @property int|string|null $domain_id
  */
 class CRM_Core_DAO_WordReplacement extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Worldregion.php
+++ b/CRM/Core/DAO/Worldregion.php
@@ -7,6 +7,9 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $name
  */
 class CRM_Core_DAO_Worldregion extends CRM_Core_DAO_Base {
 }

--- a/CRM/Cxn/DAO/Cxn.php
+++ b/CRM/Cxn/DAO/Cxn.php
@@ -7,6 +7,18 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $app_guid
+ * @property string|null $app_meta
+ * @property string|null $cxn_guid
+ * @property string|null $secret
+ * @property string|null $perm
+ * @property string|null $options
+ * @property bool|string $is_active
+ * @property string $created_date
+ * @property string $modified_date
+ * @property string $fetched_date
  */
 class CRM_Cxn_DAO_Cxn extends CRM_Core_DAO_Base {
 }

--- a/CRM/Dedupe/DAO/DedupeException.php
+++ b/CRM/Dedupe/DAO/DedupeException.php
@@ -7,6 +7,10 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $contact_id1
+ * @property int|string $contact_id2
  */
 class CRM_Dedupe_DAO_DedupeException extends CRM_Core_DAO_Base {
 }

--- a/CRM/Dedupe/DAO/DedupeRule.php
+++ b/CRM/Dedupe/DAO/DedupeRule.php
@@ -7,6 +7,13 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $dedupe_rule_group_id
+ * @property string $rule_table
+ * @property string $rule_field
+ * @property int|string|null $rule_length
+ * @property int|string $rule_weight
  */
 class CRM_Dedupe_DAO_DedupeRule extends CRM_Core_DAO_Base {
 }

--- a/CRM/Dedupe/DAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/DAO/DedupeRuleGroup.php
@@ -7,6 +7,14 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $contact_type
+ * @property int|string $threshold
+ * @property string $used
+ * @property string|null $name
+ * @property string|null $title
+ * @property bool|string $is_reserved
  */
 class CRM_Dedupe_DAO_DedupeRuleGroup extends CRM_Core_DAO_Base {
 }

--- a/CRM/Event/Cart/DAO/Cart.php
+++ b/CRM/Event/Cart/DAO/Cart.php
@@ -7,6 +7,10 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $user_id
+ * @property bool|string $completed
  */
 class CRM_Event_Cart_DAO_Cart extends CRM_Core_DAO_Base {
 }

--- a/CRM/Event/Cart/DAO/EventInCart.php
+++ b/CRM/Event/Cart/DAO/EventInCart.php
@@ -7,6 +7,10 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $event_id
+ * @property int|string|null $event_cart_id
  */
 class CRM_Event_Cart_DAO_EventInCart extends CRM_Core_DAO_Base {
 }

--- a/CRM/Event/DAO/Event.php
+++ b/CRM/Event/DAO/Event.php
@@ -7,6 +7,77 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $title
+ * @property string|null $summary
+ * @property string|null $description
+ * @property int|string|null $event_type_id
+ * @property int|string|null $participant_listing_id
+ * @property bool|string $is_public
+ * @property string|null $start_date
+ * @property string|null $end_date
+ * @property bool|string $is_online_registration
+ * @property string|null $registration_link_text
+ * @property string|null $registration_start_date
+ * @property string|null $registration_end_date
+ * @property int|string|null $max_participants
+ * @property string|null $event_full_text
+ * @property bool|string $is_monetary
+ * @property int|string|null $financial_type_id
+ * @property string|null $payment_processor
+ * @property bool|string $is_map
+ * @property bool|string $is_active
+ * @property string|null $fee_label
+ * @property bool|string $is_show_location
+ * @property int|string|null $loc_block_id
+ * @property int|string|null $default_role_id
+ * @property string|null $intro_text
+ * @property string|null $footer_text
+ * @property string|null $confirm_title
+ * @property string|null $confirm_text
+ * @property string|null $confirm_footer_text
+ * @property bool|string $is_email_confirm
+ * @property string|null $confirm_email_text
+ * @property string|null $confirm_from_name
+ * @property string|null $confirm_from_email
+ * @property string|null $cc_confirm
+ * @property string|null $bcc_confirm
+ * @property int|string|null $default_fee_id
+ * @property int|string|null $default_discount_fee_id
+ * @property string|null $thankyou_title
+ * @property string|null $thankyou_text
+ * @property string|null $thankyou_footer_text
+ * @property bool|string $is_pay_later
+ * @property string|null $pay_later_text
+ * @property string|null $pay_later_receipt
+ * @property bool|string $is_partial_payment
+ * @property string|null $initial_amount_label
+ * @property string|null $initial_amount_help_text
+ * @property float|string|null $min_initial_amount
+ * @property bool|string $is_multiple_registrations
+ * @property int|string|null $max_additional_participants
+ * @property bool|string $allow_same_participant_emails
+ * @property bool|string $has_waitlist
+ * @property bool|string $requires_approval
+ * @property int|string|null $expiration_time
+ * @property bool|string $allow_selfcancelxfer
+ * @property int|string $selfcancelxfer_time
+ * @property string|null $waitlist_text
+ * @property string|null $approval_req_text
+ * @property bool|string $is_template
+ * @property string|null $template_title
+ * @property int|string|null $created_id
+ * @property string|null $created_date
+ * @property string|null $currency
+ * @property int|string|null $campaign_id
+ * @property bool|string $is_share
+ * @property bool|string $is_confirm_enabled
+ * @property int|string|null $parent_event_id
+ * @property int|string|null $slot_label_id
+ * @property int|string|null $dedupe_rule_group_id
+ * @property bool|string $is_billing_required
+ * @property bool|string $is_show_calendar_links
  */
 class CRM_Event_DAO_Event extends CRM_Core_DAO_Base {
 }

--- a/CRM/Event/DAO/Participant.php
+++ b/CRM/Event/DAO/Participant.php
@@ -7,6 +7,27 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $contact_id
+ * @property int|string $event_id
+ * @property int|string $status_id
+ * @property string|null $role_id
+ * @property string|null $register_date
+ * @property string|null $source
+ * @property string|null $fee_level
+ * @property bool|string $is_test
+ * @property bool|string $is_pay_later
+ * @property float|string|null $fee_amount
+ * @property int|string|null $registered_by_id
+ * @property int|string|null $discount_id
+ * @property string|null $fee_currency
+ * @property int|string|null $campaign_id
+ * @property int|string|null $discount_amount
+ * @property int|string|null $cart_id
+ * @property int|string|null $must_wait
+ * @property int|string|null $transferred_to_contact_id
+ * @property int|string|null $created_id
  */
 class CRM_Event_DAO_Participant extends CRM_Core_DAO_Base {
 }

--- a/CRM/Event/DAO/ParticipantPayment.php
+++ b/CRM/Event/DAO/ParticipantPayment.php
@@ -7,6 +7,10 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $participant_id
+ * @property int|string $contribution_id
  */
 class CRM_Event_DAO_ParticipantPayment extends CRM_Core_DAO_Base {
 }

--- a/CRM/Event/DAO/ParticipantStatusType.php
+++ b/CRM/Event/DAO/ParticipantStatusType.php
@@ -7,6 +7,16 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $name
+ * @property string|null $label
+ * @property string|null $class
+ * @property bool|string $is_reserved
+ * @property bool|string $is_active
+ * @property bool|string $is_counted
+ * @property int|string $weight
+ * @property int|string|null $visibility_id
  */
 class CRM_Event_DAO_ParticipantStatusType extends CRM_Core_DAO_Base {
 }

--- a/CRM/Financial/DAO/Currency.php
+++ b/CRM/Financial/DAO/Currency.php
@@ -7,6 +7,12 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $name
+ * @property string|null $symbol
+ * @property string|null $numeric_code
+ * @property string|null $full_name
  */
 class CRM_Financial_DAO_Currency extends CRM_Core_DAO_Base {
 }

--- a/CRM/Financial/DAO/EntityFinancialAccount.php
+++ b/CRM/Financial/DAO/EntityFinancialAccount.php
@@ -7,6 +7,12 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $entity_table
+ * @property int|string $entity_id
+ * @property int|string $account_relationship
+ * @property int|string $financial_account_id
  */
 class CRM_Financial_DAO_EntityFinancialAccount extends CRM_Core_DAO_Base {
 }

--- a/CRM/Financial/DAO/EntityFinancialTrxn.php
+++ b/CRM/Financial/DAO/EntityFinancialTrxn.php
@@ -7,6 +7,12 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $entity_table
+ * @property int|string $entity_id
+ * @property int|string|null $financial_trxn_id
+ * @property float|string $amount
  */
 class CRM_Financial_DAO_EntityFinancialTrxn extends CRM_Core_DAO_Base {
 }

--- a/CRM/Financial/DAO/FinancialAccount.php
+++ b/CRM/Financial/DAO/FinancialAccount.php
@@ -7,6 +7,22 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property int|string|null $contact_id
+ * @property int|string $financial_account_type_id
+ * @property string|null $accounting_code
+ * @property string|null $account_type_code
+ * @property string|null $description
+ * @property int|string|null $parent_id
+ * @property bool|string $is_header_account
+ * @property bool|string $is_deductible
+ * @property bool|string $is_tax
+ * @property float|string|null $tax_rate
+ * @property bool|string $is_reserved
+ * @property bool|string $is_active
+ * @property bool|string $is_default
  */
 class CRM_Financial_DAO_FinancialAccount extends CRM_Core_DAO_Base {
 }

--- a/CRM/Financial/DAO/FinancialItem.php
+++ b/CRM/Financial/DAO/FinancialItem.php
@@ -7,6 +7,18 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $created_date
+ * @property string $transaction_date
+ * @property int|string $contact_id
+ * @property string|null $description
+ * @property float|string $amount
+ * @property string|null $currency
+ * @property int|string|null $financial_account_id
+ * @property int|string|null $status_id
+ * @property string|null $entity_table
+ * @property int|string|null $entity_id
  */
 class CRM_Financial_DAO_FinancialItem extends CRM_Core_DAO_Base {
 }

--- a/CRM/Financial/DAO/FinancialTrxn.php
+++ b/CRM/Financial/DAO/FinancialTrxn.php
@@ -7,6 +7,25 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $from_financial_account_id
+ * @property int|string|null $to_financial_account_id
+ * @property string|null $trxn_date
+ * @property float|string $total_amount
+ * @property float|string|null $fee_amount
+ * @property float|string|null $net_amount
+ * @property string|null $currency
+ * @property bool|string $is_payment
+ * @property string|null $trxn_id
+ * @property string|null $trxn_result_code
+ * @property int|string|null $status_id
+ * @property int|string|null $payment_processor_id
+ * @property int|string|null $payment_instrument_id
+ * @property int|string|null $card_type_id
+ * @property string|null $check_number
+ * @property string|null $pan_truncation
+ * @property string|null $order_reference
  */
 class CRM_Financial_DAO_FinancialTrxn extends CRM_Core_DAO_Base {
 }

--- a/CRM/Financial/DAO/FinancialType.php
+++ b/CRM/Financial/DAO/FinancialType.php
@@ -7,6 +7,13 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property string|null $description
+ * @property bool|string $is_deductible
+ * @property bool|string $is_reserved
+ * @property bool|string $is_active
  */
 class CRM_Financial_DAO_FinancialType extends CRM_Core_DAO_Base {
 }

--- a/CRM/Financial/DAO/PaymentProcessor.php
+++ b/CRM/Financial/DAO/PaymentProcessor.php
@@ -7,6 +7,31 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $domain_id
+ * @property string $name
+ * @property string $title
+ * @property string $frontend_title
+ * @property string|null $description
+ * @property int|string $payment_processor_type_id
+ * @property bool|string $is_active
+ * @property bool|string $is_default
+ * @property bool|string $is_test
+ * @property string|null $user_name
+ * @property string|null $password
+ * @property string|null $signature
+ * @property string|null $url_site
+ * @property string|null $url_api
+ * @property string|null $url_recur
+ * @property string|null $url_button
+ * @property string|null $subject
+ * @property string|null $class_name
+ * @property int|string $billing_mode
+ * @property bool|string $is_recur
+ * @property int|string|null $payment_type
+ * @property int|string|null $payment_instrument_id
+ * @property string|null $accepted_credit_cards
  */
 class CRM_Financial_DAO_PaymentProcessor extends CRM_Core_DAO_Base {
 }

--- a/CRM/Financial/DAO/PaymentProcessorType.php
+++ b/CRM/Financial/DAO/PaymentProcessorType.php
@@ -7,6 +7,30 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property string $title
+ * @property string|null $description
+ * @property bool|string $is_active
+ * @property bool|string $is_default
+ * @property string|null $user_name_label
+ * @property string|null $password_label
+ * @property string|null $signature_label
+ * @property string|null $subject_label
+ * @property string $class_name
+ * @property string|null $url_site_default
+ * @property string|null $url_api_default
+ * @property string|null $url_recur_default
+ * @property string|null $url_button_default
+ * @property string|null $url_site_test_default
+ * @property string|null $url_api_test_default
+ * @property string|null $url_recur_test_default
+ * @property string|null $url_button_test_default
+ * @property int|string $billing_mode
+ * @property bool|string $is_recur
+ * @property int|string|null $payment_type
+ * @property int|string|null $payment_instrument_id
  */
 class CRM_Financial_DAO_PaymentProcessorType extends CRM_Core_DAO_Base {
 }

--- a/CRM/Financial/DAO/PaymentToken.php
+++ b/CRM/Financial/DAO/PaymentToken.php
@@ -7,6 +7,20 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $contact_id
+ * @property int|string $payment_processor_id
+ * @property string $token
+ * @property string|null $created_date
+ * @property int|string|null $created_id
+ * @property string|null $expiry_date
+ * @property string|null $email
+ * @property string|null $billing_first_name
+ * @property string|null $billing_middle_name
+ * @property string|null $billing_last_name
+ * @property string|null $masked_account_number
+ * @property string|null $ip_address
  */
 class CRM_Financial_DAO_PaymentToken extends CRM_Core_DAO_Base {
 }

--- a/CRM/Friend/DAO/Friend.php
+++ b/CRM/Friend/DAO/Friend.php
@@ -7,6 +7,17 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $entity_table
+ * @property int|string $entity_id
+ * @property string|null $title
+ * @property string|null $intro
+ * @property string|null $suggested_message
+ * @property string|null $general_link
+ * @property string|null $thankyou_title
+ * @property string|null $thankyou_text
+ * @property bool|string $is_active
  */
 class CRM_Friend_DAO_Friend extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/DAO/BouncePattern.php
+++ b/CRM/Mailing/DAO/BouncePattern.php
@@ -7,6 +7,10 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $bounce_type_id
+ * @property string|null $pattern
  */
 class CRM_Mailing_DAO_BouncePattern extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/DAO/BounceType.php
+++ b/CRM/Mailing/DAO/BounceType.php
@@ -7,6 +7,11 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property string|null $description
+ * @property int|string $hold_threshold
  */
 class CRM_Mailing_DAO_BounceType extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/DAO/Mailing.php
+++ b/CRM/Mailing/DAO/Mailing.php
@@ -7,6 +7,50 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $domain_id
+ * @property int|string|null $header_id
+ * @property int|string|null $footer_id
+ * @property int|string|null $reply_id
+ * @property int|string|null $unsubscribe_id
+ * @property int|string|null $resubscribe_id
+ * @property int|string|null $optout_id
+ * @property string|null $name
+ * @property string|null $mailing_type
+ * @property string|null $from_name
+ * @property string|null $from_email
+ * @property string|null $replyto_email
+ * @property string $template_type
+ * @property string|null $template_options
+ * @property string|null $subject
+ * @property string|null $body_text
+ * @property string|null $body_html
+ * @property bool|string $url_tracking
+ * @property bool|string $forward_replies
+ * @property bool|string $auto_responder
+ * @property bool|string $open_tracking
+ * @property bool|string $is_completed
+ * @property int|string|null $msg_template_id
+ * @property bool|string $override_verp
+ * @property int|string|null $created_id
+ * @property string $created_date
+ * @property string $modified_date
+ * @property int|string|null $scheduled_id
+ * @property string $scheduled_date
+ * @property int|string|null $approver_id
+ * @property string $approval_date
+ * @property int|string|null $approval_status_id
+ * @property string|null $approval_note
+ * @property bool|string $is_archived
+ * @property string|null $visibility
+ * @property int|string|null $campaign_id
+ * @property bool|string $dedupe_email
+ * @property int|string|null $sms_provider_id
+ * @property string|null $hash
+ * @property int|string|null $location_type_id
+ * @property string|null $email_selection_method
+ * @property string|null $language
  */
 class CRM_Mailing_DAO_Mailing extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/DAO/MailingAB.php
+++ b/CRM/Mailing/DAO/MailingAB.php
@@ -7,6 +7,21 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $name
+ * @property string|null $status
+ * @property int|string|null $mailing_id_a
+ * @property int|string|null $mailing_id_b
+ * @property int|string|null $mailing_id_c
+ * @property int|string $domain_id
+ * @property string|null $testing_criteria
+ * @property string|null $winner_criteria
+ * @property string|null $specific_url
+ * @property string|null $declare_winning_time
+ * @property int|string|null $group_percentage
+ * @property int|string|null $created_id
+ * @property string $created_date
  */
 class CRM_Mailing_DAO_MailingAB extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/DAO/MailingComponent.php
+++ b/CRM/Mailing/DAO/MailingComponent.php
@@ -7,6 +7,15 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $name
+ * @property string|null $component_type
+ * @property string|null $subject
+ * @property string|null $body_html
+ * @property string|null $body_text
+ * @property bool|string $is_default
+ * @property bool|string $is_active
  */
 class CRM_Mailing_DAO_MailingComponent extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/DAO/MailingGroup.php
+++ b/CRM/Mailing/DAO/MailingGroup.php
@@ -7,6 +7,14 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $mailing_id
+ * @property string|null $group_type
+ * @property string $entity_table
+ * @property int|string $entity_id
+ * @property int|string|null $search_id
+ * @property string|null $search_args
  */
 class CRM_Mailing_DAO_MailingGroup extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/DAO/MailingJob.php
+++ b/CRM/Mailing/DAO/MailingJob.php
@@ -7,6 +7,18 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $mailing_id
+ * @property string $scheduled_date
+ * @property string $start_date
+ * @property string $end_date
+ * @property string|null $status
+ * @property bool|string $is_test
+ * @property string|null $job_type
+ * @property int|string|null $parent_id
+ * @property int|string|null $job_offset
+ * @property int|string|null $job_limit
  */
 class CRM_Mailing_DAO_MailingJob extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/DAO/MailingRecipients.php
+++ b/CRM/Mailing/DAO/MailingRecipients.php
@@ -7,6 +7,12 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $mailing_id
+ * @property int|string $contact_id
+ * @property int|string|null $email_id
+ * @property int|string|null $phone_id
  */
 class CRM_Mailing_DAO_MailingRecipients extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/DAO/MailingTrackableURL.php
+++ b/CRM/Mailing/DAO/MailingTrackableURL.php
@@ -7,6 +7,10 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $url
+ * @property int|string $mailing_id
  */
 class CRM_Mailing_DAO_MailingTrackableURL extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/DAO/Spool.php
+++ b/CRM/Mailing/DAO/Spool.php
@@ -7,6 +7,14 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $job_id
+ * @property string|null $recipient_email
+ * @property string|null $headers
+ * @property string|null $body
+ * @property string $added_at
+ * @property string $removed_at
  */
 class CRM_Mailing_DAO_Spool extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/Event/DAO/MailingEventBounce.php
+++ b/CRM/Mailing/Event/DAO/MailingEventBounce.php
@@ -7,6 +7,12 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $event_queue_id
+ * @property int|string|null $bounce_type_id
+ * @property string|null $bounce_reason
+ * @property string $time_stamp
  */
 class CRM_Mailing_Event_DAO_MailingEventBounce extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/Event/DAO/MailingEventConfirm.php
+++ b/CRM/Mailing/Event/DAO/MailingEventConfirm.php
@@ -7,6 +7,10 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $event_subscribe_id
+ * @property string $time_stamp
  */
 class CRM_Mailing_Event_DAO_MailingEventConfirm extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/Event/DAO/MailingEventDelivered.php
+++ b/CRM/Mailing/Event/DAO/MailingEventDelivered.php
@@ -7,6 +7,10 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $event_queue_id
+ * @property string $time_stamp
  */
 class CRM_Mailing_Event_DAO_MailingEventDelivered extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/Event/DAO/MailingEventForward.php
+++ b/CRM/Mailing/Event/DAO/MailingEventForward.php
@@ -7,6 +7,11 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $event_queue_id
+ * @property int|string|null $dest_queue_id
+ * @property string $time_stamp
  */
 class CRM_Mailing_Event_DAO_MailingEventForward extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/Event/DAO/MailingEventOpened.php
+++ b/CRM/Mailing/Event/DAO/MailingEventOpened.php
@@ -7,6 +7,10 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $event_queue_id
+ * @property string $time_stamp
  */
 class CRM_Mailing_Event_DAO_MailingEventOpened extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/Event/DAO/MailingEventQueue.php
+++ b/CRM/Mailing/Event/DAO/MailingEventQueue.php
@@ -7,6 +7,15 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $job_id
+ * @property int|string $mailing_id
+ * @property bool|string $is_test
+ * @property int|string|null $email_id
+ * @property int|string $contact_id
+ * @property string $hash
+ * @property int|string|null $phone_id
  */
 class CRM_Mailing_Event_DAO_MailingEventQueue extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/Event/DAO/MailingEventReply.php
+++ b/CRM/Mailing/Event/DAO/MailingEventReply.php
@@ -7,6 +7,10 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $event_queue_id
+ * @property string $time_stamp
  */
 class CRM_Mailing_Event_DAO_MailingEventReply extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/Event/DAO/MailingEventSubscribe.php
+++ b/CRM/Mailing/Event/DAO/MailingEventSubscribe.php
@@ -7,6 +7,12 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $group_id
+ * @property int|string $contact_id
+ * @property string $hash
+ * @property string $time_stamp
  */
 class CRM_Mailing_Event_DAO_MailingEventSubscribe extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/Event/DAO/MailingEventTrackableURLOpen.php
+++ b/CRM/Mailing/Event/DAO/MailingEventTrackableURLOpen.php
@@ -7,6 +7,11 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $event_queue_id
+ * @property int|string $trackable_url_id
+ * @property string $time_stamp
  */
 class CRM_Mailing_Event_DAO_MailingEventTrackableURLOpen extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/Event/DAO/MailingEventUnsubscribe.php
+++ b/CRM/Mailing/Event/DAO/MailingEventUnsubscribe.php
@@ -7,6 +7,11 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $event_queue_id
+ * @property bool|string $org_unsubscribe
+ * @property string $time_stamp
  */
 class CRM_Mailing_Event_DAO_MailingEventUnsubscribe extends CRM_Core_DAO_Base {
 }

--- a/CRM/Member/DAO/Membership.php
+++ b/CRM/Member/DAO/Membership.php
@@ -7,6 +7,23 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $contact_id
+ * @property int|string $membership_type_id
+ * @property string|null $join_date
+ * @property string|null $start_date
+ * @property string|null $end_date
+ * @property string|null $source
+ * @property int|string $status_id
+ * @property bool|string $is_override
+ * @property string|null $status_override_end_date
+ * @property int|string|null $owner_membership_id
+ * @property int|string|null $max_related
+ * @property bool|string $is_test
+ * @property bool|string $is_pay_later
+ * @property int|string|null $contribution_recur_id
+ * @property int|string|null $campaign_id
  */
 class CRM_Member_DAO_Membership extends CRM_Core_DAO_Base {
 }

--- a/CRM/Member/DAO/MembershipBlock.php
+++ b/CRM/Member/DAO/MembershipBlock.php
@@ -7,6 +7,20 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $entity_table
+ * @property int|string $entity_id
+ * @property string|null $membership_types
+ * @property int|string|null $membership_type_default
+ * @property bool|string $display_min_fee
+ * @property bool|string $is_separate_payment
+ * @property string|null $new_title
+ * @property string|null $new_text
+ * @property string|null $renewal_title
+ * @property string|null $renewal_text
+ * @property bool|string $is_required
+ * @property bool|string $is_active
  */
 class CRM_Member_DAO_MembershipBlock extends CRM_Core_DAO_Base {
 }

--- a/CRM/Member/DAO/MembershipLog.php
+++ b/CRM/Member/DAO/MembershipLog.php
@@ -7,6 +7,16 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $membership_id
+ * @property int|string $status_id
+ * @property string|null $start_date
+ * @property string|null $end_date
+ * @property int|string|null $modified_id
+ * @property string|null $modified_date
+ * @property int|string|null $membership_type_id
+ * @property int|string|null $max_related
  */
 class CRM_Member_DAO_MembershipLog extends CRM_Core_DAO_Base {
 }

--- a/CRM/Member/DAO/MembershipPayment.php
+++ b/CRM/Member/DAO/MembershipPayment.php
@@ -7,6 +7,10 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $membership_id
+ * @property int|string|null $contribution_id
  */
 class CRM_Member_DAO_MembershipPayment extends CRM_Core_DAO_Base {
 }

--- a/CRM/Member/DAO/MembershipStatus.php
+++ b/CRM/Member/DAO/MembershipStatus.php
@@ -7,6 +7,22 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property string|null $label
+ * @property string|null $start_event
+ * @property string|null $start_event_adjust_unit
+ * @property int|string|null $start_event_adjust_interval
+ * @property string|null $end_event
+ * @property string|null $end_event_adjust_unit
+ * @property int|string|null $end_event_adjust_interval
+ * @property bool|string $is_current_member
+ * @property bool|string $is_admin
+ * @property int|string|null $weight
+ * @property bool|string $is_default
+ * @property bool|string $is_active
+ * @property bool|string $is_reserved
  */
 class CRM_Member_DAO_MembershipStatus extends CRM_Core_DAO_Base {
 }

--- a/CRM/Member/DAO/MembershipType.php
+++ b/CRM/Member/DAO/MembershipType.php
@@ -7,6 +7,28 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $domain_id
+ * @property string $name
+ * @property string|null $description
+ * @property int|string $member_of_contact_id
+ * @property int|string $financial_type_id
+ * @property float|string|null $minimum_fee
+ * @property string $duration_unit
+ * @property int|string|null $duration_interval
+ * @property string $period_type
+ * @property int|string|null $fixed_period_start_day
+ * @property int|string|null $fixed_period_rollover_day
+ * @property string|null $relationship_type_id
+ * @property string|null $relationship_direction
+ * @property int|string|null $max_related
+ * @property string|null $visibility
+ * @property int|string|null $weight
+ * @property string|null $receipt_text_signup
+ * @property string|null $receipt_text_renewal
+ * @property int|string|null $auto_renew
+ * @property bool|string|null $is_active
  */
 class CRM_Member_DAO_MembershipType extends CRM_Core_DAO_Base {
 }

--- a/CRM/PCP/DAO/PCP.php
+++ b/CRM/PCP/DAO/PCP.php
@@ -7,6 +7,23 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $contact_id
+ * @property int|string $status_id
+ * @property string|null $title
+ * @property string|null $intro_text
+ * @property string|null $page_text
+ * @property string|null $donate_link_text
+ * @property int|string $page_id
+ * @property string|null $page_type
+ * @property int|string $pcp_block_id
+ * @property int|string|null $is_thermometer
+ * @property int|string|null $is_honor_roll
+ * @property float|string|null $goal_amount
+ * @property string|null $currency
+ * @property bool|string $is_active
+ * @property bool|string $is_notify
  */
 class CRM_PCP_DAO_PCP extends CRM_Core_DAO_Base {
 }

--- a/CRM/PCP/DAO/PCPBlock.php
+++ b/CRM/PCP/DAO/PCPBlock.php
@@ -7,6 +7,20 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $entity_table
+ * @property int|string $entity_id
+ * @property string $target_entity_type
+ * @property int|string $target_entity_id
+ * @property int|string|null $supporter_profile_id
+ * @property int|string|null $owner_notify_id
+ * @property bool|string $is_approval_needed
+ * @property bool|string $is_tellfriend_enabled
+ * @property int|string|null $tellfriend_limit
+ * @property string|null $link_text
+ * @property bool|string $is_active
+ * @property string|null $notify_email
  */
 class CRM_PCP_DAO_PCPBlock extends CRM_Core_DAO_Base {
 }

--- a/CRM/Pledge/DAO/Pledge.php
+++ b/CRM/Pledge/DAO/Pledge.php
@@ -7,6 +7,30 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $contact_id
+ * @property int|string|null $financial_type_id
+ * @property int|string|null $contribution_page_id
+ * @property float|string $amount
+ * @property float|string $original_installment_amount
+ * @property string|null $currency
+ * @property string $frequency_unit
+ * @property int|string $frequency_interval
+ * @property int|string $frequency_day
+ * @property int|string $installments
+ * @property string $start_date
+ * @property string $create_date
+ * @property string|null $acknowledge_date
+ * @property string|null $modified_date
+ * @property string|null $cancel_date
+ * @property string|null $end_date
+ * @property int|string|null $max_reminders
+ * @property int|string|null $initial_reminder_day
+ * @property int|string|null $additional_reminder_day
+ * @property int|string $status_id
+ * @property bool|string $is_test
+ * @property int|string|null $campaign_id
  */
 class CRM_Pledge_DAO_Pledge extends CRM_Core_DAO_Base {
 }

--- a/CRM/Pledge/DAO/PledgeBlock.php
+++ b/CRM/Pledge/DAO/PledgeBlock.php
@@ -7,6 +7,18 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $entity_table
+ * @property int|string $entity_id
+ * @property string|null $pledge_frequency_unit
+ * @property bool|string $is_pledge_interval
+ * @property int|string|null $max_reminders
+ * @property int|string|null $initial_reminder_day
+ * @property int|string|null $additional_reminder_day
+ * @property string|null $pledge_start_date
+ * @property bool|string $is_pledge_start_date_visible
+ * @property bool|string $is_pledge_start_date_editable
  */
 class CRM_Pledge_DAO_PledgeBlock extends CRM_Core_DAO_Base {
 }

--- a/CRM/Pledge/DAO/PledgePayment.php
+++ b/CRM/Pledge/DAO/PledgePayment.php
@@ -7,6 +7,17 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $pledge_id
+ * @property int|string|null $contribution_id
+ * @property float|string $scheduled_amount
+ * @property float|string|null $actual_amount
+ * @property string|null $currency
+ * @property string $scheduled_date
+ * @property string|null $reminder_date
+ * @property int|string|null $reminder_count
+ * @property int|string|null $status_id
  */
 class CRM_Pledge_DAO_PledgePayment extends CRM_Core_DAO_Base {
 }

--- a/CRM/Price/DAO/LineItem.php
+++ b/CRM/Price/DAO/LineItem.php
@@ -7,6 +7,22 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $entity_table
+ * @property int|string $entity_id
+ * @property int|string|null $contribution_id
+ * @property int|string|null $price_field_id
+ * @property string|null $label
+ * @property float|string $qty
+ * @property float|string $unit_price
+ * @property float|string $line_total
+ * @property int|string|null $participant_count
+ * @property int|string|null $price_field_value_id
+ * @property int|string|null $financial_type_id
+ * @property float|string $non_deductible_amount
+ * @property float|string $tax_amount
+ * @property int|string|null $membership_num_terms
  */
 class CRM_Price_DAO_LineItem extends CRM_Core_DAO_Base {
 }

--- a/CRM/Price/DAO/PriceField.php
+++ b/CRM/Price/DAO/PriceField.php
@@ -7,6 +7,24 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $price_set_id
+ * @property string $name
+ * @property string $label
+ * @property string $html_type
+ * @property bool|string $is_enter_qty
+ * @property string|null $help_pre
+ * @property string|null $help_post
+ * @property int|string|null $weight
+ * @property bool|string $is_display_amounts
+ * @property int|string|null $options_per_line
+ * @property bool|string $is_active
+ * @property bool|string $is_required
+ * @property string|null $active_on
+ * @property string|null $expire_on
+ * @property string|null $javascript
+ * @property int|string|null $visibility_id
  */
 class CRM_Price_DAO_PriceField extends CRM_Core_DAO_Base {
 }

--- a/CRM/Price/DAO/PriceFieldValue.php
+++ b/CRM/Price/DAO/PriceFieldValue.php
@@ -7,6 +7,25 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $price_field_id
+ * @property string|null $name
+ * @property string|null $label
+ * @property string|null $description
+ * @property string|null $help_pre
+ * @property string|null $help_post
+ * @property float|string $amount
+ * @property int|string|null $count
+ * @property int|string|null $max_value
+ * @property int|string|null $weight
+ * @property int|string|null $membership_type_id
+ * @property int|string|null $membership_num_terms
+ * @property bool|string $is_default
+ * @property bool|string $is_active
+ * @property int|string|null $financial_type_id
+ * @property float|string $non_deductible_amount
+ * @property int|string|null $visibility_id
  */
 class CRM_Price_DAO_PriceFieldValue extends CRM_Core_DAO_Base {
 }

--- a/CRM/Price/DAO/PriceSet.php
+++ b/CRM/Price/DAO/PriceSet.php
@@ -7,6 +7,20 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $domain_id
+ * @property string $name
+ * @property string $title
+ * @property bool|string $is_active
+ * @property string|null $help_pre
+ * @property string|null $help_post
+ * @property string|null $javascript
+ * @property string $extends
+ * @property int|string|null $financial_type_id
+ * @property bool|string $is_quick_config
+ * @property bool|string $is_reserved
+ * @property float|string|null $min_amount
  */
 class CRM_Price_DAO_PriceSet extends CRM_Core_DAO_Base {
 }

--- a/CRM/Price/DAO/PriceSetEntity.php
+++ b/CRM/Price/DAO/PriceSetEntity.php
@@ -7,6 +7,11 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $entity_table
+ * @property int|string $entity_id
+ * @property int|string $price_set_id
  */
 class CRM_Price_DAO_PriceSetEntity extends CRM_Core_DAO_Base {
 }

--- a/CRM/Queue/DAO/Queue.php
+++ b/CRM/Queue/DAO/Queue.php
@@ -7,6 +7,18 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property string $type
+ * @property string $runner
+ * @property int|string $batch_limit
+ * @property int|string $lease_time
+ * @property int|string $retry_limit
+ * @property int|string $retry_interval
+ * @property string $status
+ * @property string $error
+ * @property bool|string $is_template
  */
 class CRM_Queue_DAO_Queue extends CRM_Core_DAO_Base {
 }

--- a/CRM/Queue/DAO/QueueItem.php
+++ b/CRM/Queue/DAO/QueueItem.php
@@ -7,6 +7,14 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $queue_name
+ * @property int|string $weight
+ * @property string $submit_time
+ * @property string $release_time
+ * @property int|string $run_count
+ * @property string|null $data
  */
 class CRM_Queue_DAO_QueueItem extends CRM_Core_DAO_Base {
 }

--- a/CRM/Report/DAO/ReportInstance.php
+++ b/CRM/Report/DAO/ReportInstance.php
@@ -7,6 +7,28 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $domain_id
+ * @property string|null $title
+ * @property string $report_id
+ * @property string|null $name
+ * @property string|null $args
+ * @property string|null $description
+ * @property string|null $permission
+ * @property string|null $grouprole
+ * @property string|null $form_values
+ * @property bool|string $is_active
+ * @property int|string|null $created_id
+ * @property int|string|null $owner_id
+ * @property string|null $email_subject
+ * @property string|null $email_to
+ * @property string|null $email_cc
+ * @property string|null $header
+ * @property string|null $footer
+ * @property int|string|null $navigation_id
+ * @property int|string|null $drilldown_id
+ * @property bool|string $is_reserved
  */
 class CRM_Report_DAO_ReportInstance extends CRM_Core_DAO_Base {
 }

--- a/CRM/SMS/DAO/SmsProvider.php
+++ b/CRM/SMS/DAO/SmsProvider.php
@@ -7,6 +7,18 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $name
+ * @property string|null $title
+ * @property string|null $username
+ * @property string|null $password
+ * @property int|string $api_type
+ * @property string|null $api_url
+ * @property string|null $api_params
+ * @property bool|string $is_default
+ * @property bool|string $is_active
+ * @property int|string|null $domain_id
  */
 class CRM_SMS_DAO_SmsProvider extends CRM_Core_DAO_Base {
 }

--- a/xml/templates/dao_stub.tpl
+++ b/xml/templates/dao_stub.tpl
@@ -6,6 +6,10 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+{foreach from=$table.fields item=field}
+ * @property {$field.phpType}{if $field.phpNullable}|null{/if} ${$field.name}
+{/foreach}
  */
 class {$table.className} extends CRM_Core_DAO_Base {ldelim}
 


### PR DESCRIPTION
Overview
----------------------------------------
Adds annotations so IDEs can understand legacy code that uses DAOs as objects.

Comments
--------------
Note that running the script to regenerate DAOs requires un-disabling the generation and switching to the alternate `dao_stub.tpl` with this temp patch (not committed):

```diff
diff --git a/CRM/Core/CodeGen/DAO.php b/CRM/Core/CodeGen/DAO.php
index 9865d9e5f8..93cbbe1175 100644
--- a/CRM/Core/CodeGen/DAO.php
+++ b/CRM/Core/CodeGen/DAO.php
@@ -80,7 +80,7 @@ class CRM_Core_CodeGen_DAO extends CRM_Core_CodeGen_BaseTask {
 
     $template = $this->getTemplate();
     $template->assign('genCodeChecksum', $this->getTableChecksum());
-    $template->run('dao.tpl', $this->getAbsFileName());
+    $template->run('dao_stub.tpl', $this->getAbsFileName());
   }
 
   /**
diff --git a/CRM/Core/CodeGen/Main.php b/CRM/Core/CodeGen/Main.php
index 2e092d44ea..b3df7e0922 100644
--- a/CRM/Core/CodeGen/Main.php
+++ b/CRM/Core/CodeGen/Main.php
@@ -144,11 +144,11 @@ Alternatively you can get a version of CiviCRM that matches your PHP version
 
     $tasks = [];
     $tasks[] = new CRM_Core_CodeGen_Config($this);
-    // $tasks[] = new CRM_Core_CodeGen_Reflection($this);
+    $tasks[] = new CRM_Core_CodeGen_Reflection($this);
     $tasks[] = new CRM_Core_CodeGen_PhpSchema($this);
-    //  foreach (array_keys($this->tables) as $name) {
-    //    $tasks[] = new CRM_Core_CodeGen_DAO($this, $name);
-    //  }
+    foreach (array_keys($this->tables) as $name) {
+      $tasks[] = new CRM_Core_CodeGen_DAO($this, $name);
+    }
     $tasks[] = new CRM_Core_CodeGen_I18n($this);
     return $tasks;
   }
```