### PR TITLE
SearchKit - Fix `str_starts_with()` error on php74

### DIFF
--- a/ext/search_kit/info.xml
+++ b/ext/search_kit/info.xml
@@ -28,7 +28,7 @@
     <psr0 prefix="CRM_" path="."/>
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
-  <upgrader>CiviMix\Schema\Search\AutomaticUpgrader</upgrader>
+  <upgrader>CiviMix\Schema\SearchKit\AutomaticUpgrader</upgrader>
   <mixins>
     <mixin>ang-php@1.0.0</mixin>
     <mixin>scan-classes@1.0.0</mixin>

--- a/ext/search_kit/search_kit.civix.php
+++ b/ext/search_kit/search_kit.civix.php
@@ -86,13 +86,12 @@ class CRM_Search_ExtensionUtil {
 
 use CRM_Search_ExtensionUtil as E;
 
-($GLOBALS['_PathLoad'][0] ?? require __DIR__ . '/mixin/lib/pathload-0.php');
 pathload()->addSearchDir(__DIR__ . '/mixin/lib');
 spl_autoload_register('_search_kit_civix_class_loader', TRUE, TRUE);
 
 function _search_kit_civix_class_loader($class) {
   // This allows us to tap-in to the installation process (without incurring real file-reads on typical requests).
-  if (str_starts_with($class, 'CiviMix\\Schema\\Search\\')) {
+  if (strpos($class, 'CiviMix\\Schema\\SearchKit\\') === 0) {
     // civimix-schema@5 is designed for backported use in download/activation workflows,
     // where new revisions may become dynamically available.
     pathload()->loadPackage('civimix-schema@5', TRUE);


### PR DESCRIPTION
Overview
----------------------------------------

Follow-up to #30007. Fix error regarding `str_starts_with()` when running on dmaster and PHP 7.4.

Before
----------------------------------------

Navigate to... basically any web-page. See the error:

```
Error message
Error: Class 'Symfony\Polyfill\Php80\Php80' not found in str_starts_with() (line 32 of /home/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/vendor/symfony/polyfill-php80/bootstrap.php).
```

After
----------------------------------------

Works

Comments
----------------------------------------

SearchKit is an early-adopter of upcoming changes in civix. This particular code was previously discussed at https://github.com/totten/civix/pull/331#discussion_r1573039679. Generally, this PR just brings the early-update for SK into closer alignment with current civix drafts.