### PR TITLE
[php8] undeclared var on new individual on-the-fly popup

### DIFF
--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -158,6 +158,8 @@ class CRM_Profile_Form extends CRM_Core_Form {
 
   protected $_customGroupId = NULL;
 
+  protected $_mail;
+
   protected $_currentUserID = NULL;
   protected $_session = NULL;
 


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
1. In a contact field that allows making new contacts on the fly, click New Individual.
2. The popup has a warning about `_mail`

After
----------------------------------------

Technical Details
----------------------------------------


Comments
----------------------------------------

