### PR TITLE
[php8] Undeclared vars on manage events

### DIFF
--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -43,6 +43,10 @@ class CRM_Event_Page_ManageEvent extends CRM_Core_Page {
 
   protected $_isTemplate = FALSE;
 
+  protected $_searchResult;
+
+  protected $_force;
+
   /**
    * Get action Links.
    *

--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -301,6 +301,7 @@ class CRM_Event_Page_ManageEvent extends CRM_Core_Page {
     );
     $this->_searchResult = CRM_Utils_Request::retrieve('searchResult', 'Boolean', $this);
 
+    // @todo Does $this->_force get used somewhere deeper down? It doesn't seem used in whereClause()?
     $whereClause = $this->whereClause($params, FALSE, $this->_force);
 
     if (CRM_Core_Config::singleton()->includeAlphabeticalPager) {


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
Go to manage events.
Undeclared vars _searchResult and _force

After
----------------------------------------


Technical Details
----------------------------------------
It's a little hard to tell if these could be treated as local vars instead.
Also I'm not sure that force=1 actually works in the url - I couldn't get it to work.

Comments
----------------------------------------
