### PR TITLE
dev/core#5241 - Don't drop tables during install

### DIFF
--- a/CRM/Core/CodeGen/PhpSchema.php
+++ b/CRM/Core/CodeGen/PhpSchema.php
@@ -54,7 +54,7 @@ class CRM_Core_CodeGen_PhpSchema extends CRM_Core_CodeGen_BaseTask {
   }
 
   public function generateCreateSql() {
-    return ['civicrm.mysql' => \Civi::schemaHelper()->generateUninstallSql() . \Civi::schemaHelper()->generateInstallSql()];
+    return ['civicrm.mysql' => \Civi::schemaHelper()->generateInstallSql()];
   }
 
   public function generateDropSql() {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/5241

Before
----------------------------------------
The installer automatically drops existing tables. If accidentally run on a live site, all data would be destroyed. This is like having a loaded gun pointed at your database all the time (don't worry, as long as nothing accidentally triggers it, you'll be fine!).

After
----------------------------------------
Installer only creates tables. If they already exist, it will give an error, but no data will be destroyed.

Technical Details
---------
I don't know if there are any legit circumstances where we need this functionality. Are there?