### PR TITLE
Allow override of Smarty version via env variable

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -260,7 +260,7 @@ if (!defined('CIVICRM_UF_BASEURL')) {
  * un-comment the line describing the path. Note that this will become always enabled in
  * the near future - this opt-in setting is transitional.
  */
-if (!defined('CIVICRM_SMARTY_AUTOLOAD_PATH')) {
+if (!defined('CIVICRM_SMARTY_AUTOLOAD_PATH') && getenv('CIVICRM_SMARTY_AUTOLOAD_PATH') === FALSE) {
   // enable by default for dev & demo sites for now - will soon enable by default for all new installs.
   if (strpos(CIVICRM_UF_BASEURL, 'localhost') !== FALSE || strpos(CIVICRM_UF_BASEURL, 'demo.civicrm.org') !== FALSE) {
     if (is_dir($civicrm_root . '/packages')) {


### PR DESCRIPTION


Overview
----------------------------------------
Allow override of Smarty version via env variable
This allows scripts to be run with different versions of Smarty for comparison

Before
----------------------------------------
Not possible to override the Smarty version at run-time


After
----------------------------------------
possible -e.g on a Site configured for Smarty4 a specific script could call Smarty2 using
`
 env CIVICRM_SMARTY_AUTOLOAD_PATH= 
`

For example I am switching between Smarty versions using 

`env PHP_IDE_CONFIG=serverName=wmff CIVICRM_SMARTY_AUTOLOAD_PATH=  LOG_THRESHOLD=500 drush -v @wmff thank-you-send-test
`

vs 
`
env PHP_IDE_CONFIG=serverName=wmff CIVICRM_SMARTY_AUTOLOAD_PATH=/srv/civi-sites/wmff/drupal/sites/all/modules/civicrm/packages/smarty4/vendor/autoload.php  LOG_THRESHOLD=500 drush -v @wmff thank-you-send-test 
`

vs

`
env PHP_IDE_CONFIG=serverName=wmff CIVICRM_SMARTY_AUTOLOAD_PATH=/srv/civi-sites/wmff/drupal/sites/all/modules/civicrm/packages/smarty5/Smarty.php  LOG_THRESHOLD=500 drush -v @wmff thank-you-send-test 
`
to try to track down some caching issue

Technical Details
----------------------------------------
I've done this against 5.74 as all our Smarty5 work is on 5.74

Comments
----------------------------------------
