### PR TITLE
dev/core#5243 Leverage getTemplateDir() returning a reference for performance

### DIFF
--- a/mixin/smarty-v2@1/mixin.php
+++ b/mixin/smarty-v2@1/mixin.php
@@ -4,7 +4,7 @@
  * Auto-register "templates/" folder.
  *
  * @mixinName smarty-v2
- * @mixinVersion 1.0.2
+ * @mixinVersion 1.0.3
  * @since 5.59
  *
  * @deprecated - it turns out that the mixin is not version specific so the 'smarty'
@@ -31,13 +31,22 @@ return function ($mixInfo, $bootCache) {
     }
     // getTemplateDir returns string or array by reference
     $templateRef = $smarty->getTemplateDir();
-    // Dereference and normalize as array
-    $templateDirs = (array) $templateRef;
-    // Add the dir if not already present
-    if (!in_array($dir, $templateDirs, TRUE)) {
-      array_unshift($templateDirs, $dir);
-      $smarty->setTemplateDir($templateDirs);
+    if (!is_array($templateRef)) {
+      // Dereference and normalize as array
+      $templateDirs = (array) $templateRef;
+      // Add the dir if not already present
+      if (!in_array($dir . '/', $templateDirs, TRUE)) {
+        array_unshift($templateDirs, $dir);
+        $smarty->setTemplateDir($templateDirs);
+      }
     }
+    else {
+      // Add the dir if not already present
+      if (!in_array($dir . '/', $templateRef, TRUE)) {
+        array_unshift($templateRef, $dir);
+      }
+    }
+
   };
 
   // Let's figure out what environment we're in -- so that we know the best way to call $register().

--- a/mixin/smarty@1/mixin.php
+++ b/mixin/smarty@1/mixin.php
@@ -4,7 +4,7 @@
  * Auto-register "templates/" folder.
  *
  * @mixinName smarty
- * @mixinVersion 1.0.2
+ * @mixinVersion 1.0.3
  * @since 5.71
  *
  * @param CRM_Extension_MixInfo $mixInfo
@@ -27,13 +27,22 @@ return function ($mixInfo, $bootCache) {
     }
     // getTemplateDir returns string or array by reference
     $templateRef = $smarty->getTemplateDir();
-    // Dereference and normalize as array
-    $templateDirs = (array) $templateRef;
-    // Add the dir if not already present
-    if (!in_array($dir, $templateDirs, TRUE)) {
-      array_unshift($templateDirs, $dir);
-      $smarty->setTemplateDir($templateDirs);
+    if (!is_array($templateRef)) {
+      // Dereference and normalize as array
+      $templateDirs = (array) $templateRef;
+      // Add the dir if not already present
+      if (!in_array($dir . '/', $templateDirs, TRUE)) {
+        array_unshift($templateDirs, $dir);
+        $smarty->setTemplateDir($templateDirs);
+      }
     }
+    else {
+      // Add the dir if not already present
+      if (!in_array($dir . '/', $templateRef, TRUE)) {
+        array_unshift($templateRef, $dir);
+      }
+    }
+
   };
 
   // Let's figure out what environment we're in -- so that we know the best way to call $register().


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5243 Leverage getTemplateDir() returning a reference for performance

Before
----------------------------------------
The repeating of `getTemplateDir()` + `setTemplateDir()` results in the list of template dirs being constantly compiled

After
----------------------------------------
The smarty-2-like use of `array_shift` does not trigger the cache clearing 

Technical Details
----------------------------------------
`getTemplateDirs()` seems to be correctly kept up to date but perhaps there are issues around symlinks? This is the second faster option tried so far https://lab.civicrm.org/dev/core/-/issues/5243#note_164881

Comments
----------------------------------------
