### PR TITLE
incorrect amount is passed to the payment processor when tax is inclusive

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1183,6 +1183,12 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       // Line total inclusive should really be always set but this is a safe fall back.
       $amount += $lineItem['line_total_inclusive'] ?? ($lineItem['line_total'] + $lineItem['tax_amount']);
     }
+
+    // format the amount to prevent potential rounding errors
+    if (!empty($this->_params['currencyID'])) {
+      $amount = Civi::format()->moneyNumber($amount, CRM_Utils_Money::getCurrencyObject($this->_params['currencyID']));
+    }
+
     return $amount;
   }
 

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1186,7 +1186,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
     // format the amount to prevent potential rounding errors
     if (!empty($this->_params['currencyID'])) {
-      $amount = Civi::format()->moneyNumber($amount, CRM_Utils_Money::getCurrencyObject($this->_params['currencyID']));
+      $amount = (float) Civi::format()->moneyNumber($amount, CRM_Utils_Money::getCurrencyObject($this->_params['currencyID']));
     }
 
     return $amount;

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -1010,7 +1010,7 @@ class CRM_Financial_BAO_Order {
 
       }
       elseif ($taxRate) {
-        $lineItem['tax_amount'] = ($taxRate / 100) * $lineItem['line_total'];
+        $lineItem['tax_amount'] = round(($taxRate / 100) * $lineItem['line_total'], 2);
       }
       $lineItem['line_total_inclusive'] = $lineItem['line_total_inclusive'] ?? ($lineItem['line_total'] + $lineItem['tax_amount']);
     }

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -1010,7 +1010,7 @@ class CRM_Financial_BAO_Order {
 
       }
       elseif ($taxRate) {
-        $lineItem['tax_amount'] = round(($taxRate / 100) * $lineItem['line_total'], 2);
+        $lineItem['tax_amount'] = ($taxRate / 100) * $lineItem['line_total'];
       }
       $lineItem['line_total_inclusive'] = $lineItem['line_total_inclusive'] ?? ($lineItem['line_total'] + $lineItem['tax_amount']);
     }


### PR DESCRIPTION
Overview
----------------------------------------
There are cases where amount is incorrectly sent to the payment processor because we are not rounding the amount 

Before
----------------------------------------

Line item:
```php
$lineItem = Array
(
    [price_field_id] => xx
    [price_field_value_id] => xx
    [label] => Supporter
    [field_title] => Membership
    [description] =>
    [qty] => 1
    [unit_price] => 31.67
    [line_total] => 31.67
    [participant_count] => 0
    [max_value] =>
    [membership_type_id] => 1
    [membership_num_terms] => 1
    [auto_renew] => 1
    [html_type] => Radio
    [financial_type_id] => 20
    [tax_amount] => 6.334
    [non_deductible_amount] => 0
    [tax_rate] => 20.00000000
    [entity_table] => civicrm_membership
    [title] => Membership - Artist
    [line_total_inclusive] => 38.004
)
```

Amount passed to the payment processor:  `38.004`

After
----------------------------------------

```php
$lineItem = Array
(
    [price_field_id] => xx
    [price_field_value_id] => xx
    [label] => Supporter
    [field_title] => Membership
    [description] =>
    [qty] => 1
    [unit_price] => 31.67
    [line_total] => 31.67
    [participant_count] => 0
    [max_value] =>
    [membership_type_id] => 1
    [membership_num_terms] => 1
    [auto_renew] => 1
    [html_type] => Radio
    [financial_type_id] => 20
    [tax_amount] => 6.33
    [non_deductible_amount] => 0
    [tax_rate] => 20.00000000
    [entity_table] => civicrm_membership
    [title] => Membership - Artist
    [line_total_inclusive] => 38
```

Amount passed to the payment processor:  `38`

