### PR TITLE
'Total amount' on some event registrations is showing wrong amounts

### DIFF
--- a/CRM/Event/Form/ParticipantView.php
+++ b/CRM/Event/Form/ParticipantView.php
@@ -106,8 +106,6 @@ class CRM_Event_Form_ParticipantView extends CRM_Core_Form {
     $lineItem = CRM_Price_BAO_LineItem::getLineItems($participantID);
     $this->assign('lineItem', [$lineItem]);
 
-    $this->assign('totalAmount', $this->getParticipantValue('fee_amount'));
-
     // Assign registered_by contact ID and display_name if participant was registered by someone else (CRM-4859)
     $this->assign('registered_by_display_name', $this->getParticipantValue('registered_by_id.contact_id.display_name'));
     $this->assign('registered_by_contact_id', $this->getParticipantValue('registered_by_id.contact_id'));
@@ -167,15 +165,17 @@ class CRM_Event_Form_ParticipantView extends CRM_Core_Form {
     $displayName = CRM_Contact_BAO_Contact::displayName($values[$participantID]['contact_id']);
 
     $participantCount = [];
-    $totalTaxAmount = 0;
+    $totalTaxAmount = $totalAmount = 0;
     foreach ($lineItem as $k => $v) {
       if (CRM_Utils_Array::value('participant_count', $lineItem[$k]) > 0) {
         $participantCount[] = $lineItem[$k]['participant_count'];
       }
       $totalTaxAmount = $v['tax_amount'] + $totalTaxAmount;
+      $totalAmount += $v['line_total'];
     }
     $this->assign('currency', $this->getParticipantValue('fee_currency'));
     $this->assign('totalTaxAmount', $totalTaxAmount ?? NULL);
+    $this->assign('totalAmount', $totalAmount);
     $this->assign('pricesetFieldsCount', $participantCount);
     $this->assign('displayName', $displayName);
     // omitting contactImage from title for now since the summary overlay css doesn't work outside of our crm-container


### PR DESCRIPTION
Overview
----------------------------------------
['Total amount' on some event registrations is showing wrong amounts - Issue Link](https://lab.civicrm.org/dev/core/-/issues/5244)

Before
----------------------------------------
![Screenshot from 2024-05-29 15-07-58](https://github.com/civicrm/civicrm-core/assets/171150220/983528a7-989d-4be5-b2c0-2cd7687c58a2)

After
----------------------------------------
![Screenshot from 2024-05-29 15-07-13](https://github.com/civicrm/civicrm-core/assets/171150220/8649c543-fc0a-45b2-b56c-c6a07f8a9317)


