### PR TITLE
Avoid extra calls to Smarty::getTemplateDir

### DIFF
--- a/mixin/smarty-v2@1/mixin.php
+++ b/mixin/smarty-v2@1/mixin.php
@@ -4,7 +4,7 @@
  * Auto-register "templates/" folder.
  *
  * @mixinName smarty-v2
- * @mixinVersion 1.0.2
+ * @mixinVersion 1.0.3
  * @since 5.59
  *
  * @deprecated - it turns out that the mixin is not version specific so the 'smarty'
@@ -29,14 +29,19 @@ return function ($mixInfo, $bootCache) {
       $smarty->addTemplateDir($dir);
       return;
     }
-    // getTemplateDir returns string or array by reference
-    $templateRef = $smarty->getTemplateDir();
-    // Dereference and normalize as array
-    $templateDirs = (array) $templateRef;
-    // Add the dir if not already present
-    if (!in_array($dir, $templateDirs, TRUE)) {
-      array_unshift($templateDirs, $dir);
-      $smarty->setTemplateDir($templateDirs);
+    // Avoid calling getTemplateDir on Smarty 3+ when we know we
+    // have already registered the directory
+    if (empty(Civi::$statics[__FUNCTION__][$dir])) {
+      // getTemplateDir returns string or array by reference
+      $templateRef = $smarty->getTemplateDir();
+      // Dereference and normalize as array
+      $templateDirs = (array) $templateRef;
+      // Add the dir if not already present
+      if (!in_array($dir, $templateDirs, TRUE)) {
+        array_unshift($templateDirs, $dir);
+        $smarty->setTemplateDir($templateDirs);
+      }
+      Civi::$statics[__FUNCTION__][$dir] = true;
     }
   };
 

--- a/mixin/smarty@1/mixin.php
+++ b/mixin/smarty@1/mixin.php
@@ -4,7 +4,7 @@
  * Auto-register "templates/" folder.
  *
  * @mixinName smarty
- * @mixinVersion 1.0.2
+ * @mixinVersion 1.0.3
  * @since 5.71
  *
  * @param CRM_Extension_MixInfo $mixInfo
@@ -25,14 +25,19 @@ return function ($mixInfo, $bootCache) {
       $smarty->addTemplateDir($dir);
       return;
     }
-    // getTemplateDir returns string or array by reference
-    $templateRef = $smarty->getTemplateDir();
-    // Dereference and normalize as array
-    $templateDirs = (array) $templateRef;
-    // Add the dir if not already present
-    if (!in_array($dir, $templateDirs, TRUE)) {
-      array_unshift($templateDirs, $dir);
-      $smarty->setTemplateDir($templateDirs);
+    // Avoid calling getTemplateDir on Smarty 3+ when we know we
+    // have already registered the directory
+    if (empty(Civi::$statics[__FUNCTION__][$dir])) {
+      // getTemplateDir returns string or array by reference
+      $templateRef = $smarty->getTemplateDir();
+      // Dereference and normalize as array
+      $templateDirs = (array) $templateRef;
+      // Add the dir if not already present
+      if (!in_array($dir, $templateDirs, TRUE)) {
+        array_unshift($templateDirs, $dir);
+        $smarty->setTemplateDir($templateDirs);
+      }
+      Civi::$statics[__FUNCTION__][$dir] = true;
     }
   };
 


### PR DESCRIPTION
They end up doing lots of redundant path normalization. Make sure we only register each directory once per process, even if we are resetting the Config singleton multiple times (e.g. for locale swapping).

Overview
----------------------------------------
Stop slowdowns caused by lots of redundant calls to internal smarty functions.

Before
----------------------------------------
We noticed long-running processes with template rendering would slow down over time, to the point where rendering a single email would take 10 sec. This happened when using Smarty 3 or 5, but not with Smarty 2.

After
----------------------------------------
Long-running processes with rendering do not slow down.

Technical Details
----------------------------------------
Profiling showed most of the time in the Smarty::_realpath function, called from Smarty::_normalizeTemplateConfig. It turns out just calling getTemplateDir triggers this over and over again. We are switching locales during the long-running process to render different language emails, so the config hooks are running and re-registering template directories.
