### PR TITLE
(dev/core#5243) mixin/smarty - Reduce expensive calls to `getTemplateDir()`/`setTemplateDir()`

### DIFF
--- a/mixin/smarty@1/mixin.php
+++ b/mixin/smarty@1/mixin.php
@@ -4,7 +4,7 @@
  * Auto-register "templates/" folder.
  *
  * @mixinName smarty
- * @mixinVersion 1.0.2
+ * @mixinVersion 1.0.3
  * @since 5.71
  *
  * @param CRM_Extension_MixInfo $mixInfo
@@ -18,20 +18,15 @@ return function ($mixInfo, $bootCache) {
     return;
   }
 
-  $register = function() use ($dir) {
+  $register = function($newDirs) {
     $smarty = CRM_Core_Smarty::singleton();
-    // Smarty2 compatibility
-    if (isset($smarty->_version) && version_compare($smarty->_version, 3, '<')) {
-      $smarty->addTemplateDir($dir);
-      return;
+    $v2 = isset($smarty->_version) && version_compare($smarty->_version, 3, '<');
+    $templateDirs = (array) ($v2 ? $smarty->template_dir : $smarty->getTemplateDir());
+    $templateDirs = array_merge($newDirs, $templateDirs);
+    if ($v2) {
+      $smarty->template_dir = $templateDirs;
     }
-    // getTemplateDir returns string or array by reference
-    $templateRef = $smarty->getTemplateDir();
-    // Dereference and normalize as array
-    $templateDirs = (array) $templateRef;
-    // Add the dir if not already present
-    if (!in_array($dir, $templateDirs, TRUE)) {
-      array_unshift($templateDirs, $dir);
+    else {
       $smarty->setTemplateDir($templateDirs);
     }
   };
@@ -41,7 +36,7 @@ return function ($mixInfo, $bootCache) {
   if (!empty($GLOBALS['_CIVIX_MIXIN_POLYFILL'])) {
     // Polyfill Loader (v<=5.45): We're already in the middle of firing `hook_config`.
     if ($mixInfo->isActive()) {
-      $register();
+      $register([$dir]);
     }
     return;
   }
@@ -49,14 +44,25 @@ return function ($mixInfo, $bootCache) {
   if (CRM_Extension_System::singleton()->getManager()->extensionIsBeingInstalledOrEnabled($mixInfo->longName)) {
     // New Install, Standard Loader: The extension has just been enabled, and we're now setting it up.
     // System has already booted. New templates may be needed for upcoming installation steps.
-    $register();
+    $register([$dir]);
     return;
   }
 
   // Typical Pageview, Standard Loader: Defer the actual registration for a moment -- to ensure that Smarty is online.
-  \Civi::dispatcher()->addListener('hook_civicrm_config', function() use ($mixInfo, $register) {
+  // We need to bundle-up all dirs -- Smarty 3/4/5 is inefficient with processing repeated calls to `getTemplateDir()`+`setTemplateDir()`
+  if (!isset(Civi::$statics[__FILE__]['event'])) {
+    Civi::$statics[__FILE__]['event'] = 'civi.smarty.addPaths.' . md5(__FILE__);
+    Civi::dispatcher()->addListener('hook_civicrm_config', function() use ($register) {
+      $dirs = [];
+      $event = \Civi\Core\Event\GenericHookEvent::create(['dirs' => &$dirs]);
+      Civi::dispatcher()->dispatch(Civi::$statics[__FILE__]['event'], $event);
+      $register($dirs);
+    });
+  }
+
+  Civi::dispatcher()->addListener(Civi::$statics[__FILE__]['event'], function($event) use ($mixInfo, $dir) {
     if ($mixInfo->isActive()) {
-      $register();
+      array_unshift($event->dirs, $dir);
     }
   });
 


### PR DESCRIPTION
Overview
----------------------------------------

Follow-up to #30148 to address https://lab.civicrm.org/dev/core/-/issues/5243 identified by @eileenmcnaughton. (This is one possible resolution - suggested by @totten.)

Before
----------------------------------------

* The `smarty` mixin registers `hook_civicrm_config` -- with one listener on behalf of each extension. On Smarty 3/4/5, this listener calls `getTemplateDir()`, prepends its own template-dir, and calls `setTemplateDir()`.

* Everytime an extension calls `getTemplateDir()`, it forces a full (re)normalization of the directory-list (*to sync-up with the prior addition*)... which examines all the directories that we're previously registered.

After
----------------------------------------

In effect, this is a refactoring that moves the per-extension listeners from `hook_civicrm_config` to an internal event (`civi.smarty-v2.addPaths.XXX`). Specifically:

* The `smarty` mixin registers for `civi.smarty-v2.addPaths.XXX(array &$dirs)` -- one listener on behalf of each extension. Each listener prepends/enqueues its own extension (`array_unshift($dirs, $dir)`).
* The `smarty` mixin registers a single listener for `hook_civicrm_config`. It serves as an adapter. It fires the internal event (`civi.smarty-v2.addPaths.XXX(array &$dirs)`), gets a list of all template dirs, and applies one update to `$smarty` (`getTemplateDir()` + `array_merge()` + `setTemplateDir()`).

* You only need to (re)normalize the directory-list one time.

