### PR TITLE
Add getVersion() to CRM_Core_Smarty

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -73,6 +73,13 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
   private static $UNDEFINED_VALUE;
 
   /**
+   * @return mixed
+   */
+  protected static function getSmartyLoadPath() {
+    return CRM_Utils_Constant::value('CIVICRM_SMARTY_AUTOLOAD_PATH') ?: CRM_Utils_Constant::value('CIVICRM_SMARTY3_AUTOLOAD_PATH');
+  }
+
+  /**
    * @throws \CRM_Core_Exception
    * @throws \SmartyException
    */
@@ -517,6 +524,18 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
       ]);
     }
     return $value;
+  }
+
+  public function getVersion (): int {
+    $path = $this->getSmartyLoadPath();
+    if (str_contains($path, 'smarty3')) {
+      return 3;
+    }
+    if (str_contains($path, 'smarty4')) {
+      return 4;
+    }
+    // 5 is handled by overriding this function.
+    return 2;
   }
 
 }

--- a/CRM/Core/SmartyCompatibility.php
+++ b/CRM/Core/SmartyCompatibility.php
@@ -36,13 +36,10 @@
  * other similar PEAR packages. doubt it
  */
 if (!class_exists('Smarty')) {
-  if (defined('CIVICRM_SMARTY_AUTOLOAD_PATH')) {
+  $path = CRM_Utils_Constant::value('CIVICRM_SMARTY_AUTOLOAD_PATH') ?: CRM_Utils_Constant::value('CIVICRM_SMARTY3_AUTOLOAD_PATH');
+  if ($path) {
     // Specify the smarty version to load.
-    require_once CIVICRM_SMARTY_AUTOLOAD_PATH;
-  }
-  elseif (defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
-    // older version of the above constant.
-    require_once CIVICRM_SMARTY3_AUTOLOAD_PATH;
+    require_once $path;
   }
   else {
     require_once 'Smarty/Smarty.class.php';


### PR DESCRIPTION


Overview
----------------------------------------
Add getVersion() to CRM_Core_Smarty

Before
----------------------------------------
No consistent way to determine the smarty version

After
----------------------------------------
added

Technical Details
----------------------------------------
This is to support Smarty 5 fixes in
https://github.com/civicrm/civicrm-core/pull/30278 but I spun it off for clarity.

I looked to use the same functin for both path retrievals but the load thing is function so I just standardised the logic (note we have a variant of the constant use in production)

Comments
----------------------------------------
