### PR TITLE
Add new crmPermission Smarty block

### DIFF
--- a/CRM/Core/Smarty/plugins/block.crmPermission.php
+++ b/CRM/Core/Smarty/plugins/block.crmPermission.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * Show block conditionally, based on the permission
+ *
+ * /**
+ * @param array $params
+ *  Array containing the permission/s to check and optional contact ID.
+ * @param CRM_Core_Smarty $smarty
+ *   The Smarty object.
+ * @param bool $repeat
+ *   Repeat is true for the opening tag, false for the closing tag
+ *
+ * @return string
+ *   The content in the black, if allowed.
+ * @noinspection PhpUnused
+ */
+function smarty_block_crmPermission($params, $content, &$smarty, &$repeat) {
+  if (!$repeat) {
+    if (CRM_Core_Permission::check($params['permission'], $params['contact_id'] ?? NULL)) {
+      return $content;
+    }
+  }
+  return '';
+}

--- a/templates/CRM/common/footer.tpl
+++ b/templates/CRM/common/footer.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if call_user_func(array('CRM_Core_Permission','check'), 'access CiviCRM')}
+{crmPermission permission='access CiviCRM'}
   {include file="CRM/common/accesskeys.tpl"}
   {if $contactId}
     {include file="CRM/common/contactFooter.tpl"}
@@ -18,13 +18,15 @@
     <span class="status{if $footer_status_severity gt 3} crm-error{elseif $footer_status_severity gt 2} crm-warning{else} crm-ok{/if}">
       <a href="{crmURL p='civicrm/a/#/status'}">{$footer_status_message}</a>
     </span>&nbsp;
-    {elseif call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM')}
+    {else}
+      {crmPermission permission='administer CiviCRM'}
     <span class="status crm-status-none">
       <a href="{crmURL p='civicrm/a/#/status'}">{ts}System Status{/ts}</a>
     </span>&nbsp;
+      {/crmPermission}
     {/if}
     {crmVersion assign=version}
     {ts 1='href="http://www.gnu.org/licenses/agpl-3.0.html" rel="external" target="_blank"' 2='href="https://civicrm.org/" rel="external" target="_blank"' 3=$version}Powered by <a %2>CiviCRM</a> %3, free and open source <a %1>AGPLv3</a> software.{/ts}<br/>
   </div>
   {include file="CRM/common/notifications.tpl"}
-{/if}
+{/crmPermission}


### PR DESCRIPTION
Overview
----------------------------------------
Add new crmPermission Smarty block

Before
----------------------------------------
Our existing method of handling permissions in templates is kinda gross and with the Smarty5 move to only permit registered functions it's not really right to be registering `call_user_func` (although we need to short term in a limited way) - https://github.com/civicrm/civicrm-core/pull/30278 

```
 {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM')}
      stuff
    {/if}
```

After
----------------------------------------
```
    {crmPermission permission='administer CiviCRM'}
      stuff
    {/crmPermission}
```

Technical Details
----------------------------------------

Comments
----------------------------------------
