### PR TITLE
Add getVersion() to CRM_Core_Smarty

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -519,4 +519,16 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
     return $value;
   }
 
+  public function getVersion (): int {
+    $path = crm_smarty_compatibility_get_path();
+    if (str_contains($path, 'smarty3')) {
+      return 3;
+    }
+    if (str_contains($path, 'smarty4')) {
+      return 4;
+    }
+    // 5 is handled by overriding this function.
+    return 2;
+  }
+
 }

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -527,7 +527,9 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
     if (str_contains($path, 'smarty4')) {
       return 4;
     }
-    // 5 is handled by overriding this function.
+    if (str_contains($path, 'smarty5')) {
+      return 5;
+    }
     return 2;
   }
 

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -520,7 +520,7 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
   }
 
   public function getVersion (): int {
-    $path = crm_smarty_compatibility_get_path();
+    $path = (string) crm_smarty_compatibility_get_path();
     if (str_contains($path, 'smarty3')) {
       return 3;
     }

--- a/CRM/Core/SmartyCompatibility.php
+++ b/CRM/Core/SmartyCompatibility.php
@@ -32,17 +32,23 @@
  */
 
 /**
+ * Get the path to load Smarty.
+ *
+ * @return string|null
+ */
+function crm_smarty_compatibility_get_path() {
+  return CRM_Utils_Constant::value('CIVICRM_SMARTY_AUTOLOAD_PATH') ?: CRM_Utils_Constant::value('CIVICRM_SMARTY3_AUTOLOAD_PATH');
+}
+
+/**
  * Fix for bug CRM-392. Not sure if this is the best fix or it will impact
  * other similar PEAR packages. doubt it
  */
 if (!class_exists('Smarty')) {
-  if (defined('CIVICRM_SMARTY_AUTOLOAD_PATH')) {
+  $path = crm_smarty_compatibility_get_path();
+  if ($path) {
     // Specify the smarty version to load.
-    require_once CIVICRM_SMARTY_AUTOLOAD_PATH;
-  }
-  elseif (defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
-    // older version of the above constant.
-    require_once CIVICRM_SMARTY3_AUTOLOAD_PATH;
+    require_once $path;
   }
   else {
     require_once 'Smarty/Smarty.class.php';


### PR DESCRIPTION
Alternate to https://github.com/civicrm/civicrm-core/pull/30283 - shares the function by putting it in the global namespace

This is to support Smarty 5 fixes in
https://github.com/civicrm/civicrm-core/pull/30278 but I spun it off for clarity.

I looked to use the same functin for both path retrievals but had to use the global name space to do so reliably

(note we have a variant of the constant use in production)

Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
