### PR TITLE
dev/core#4985 Modernise checkbox/radio CSS, markup for backend

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -1685,15 +1685,18 @@ if (!CRM.vars) CRM.vars = {};
       // Handle clear button for form elements
       .on('click', 'a.crm-clear-link', function() {
         $(this).css({visibility: 'hidden'}).siblings('.crm-form-radio:checked').prop('checked', false).trigger('change', ['crmClear']);
+        $(this).css({visibility: 'hidden'}).siblings('.crm-multiple-checkbox-radio-options').find('.crm-form-radio:checked').prop('checked', false).trigger('change', ['crmClear']);
         $(this).siblings('input:text').val('').trigger('change', ['crmClear']);
         return false;
       })
       .on('change keyup', 'input.crm-form-radio:checked, input[allowclear=1]', function(e, context) {
         if (context !== 'crmClear' && ($(this).is(':checked') || ($(this).is('[allowclear=1]') && $(this).val()))) {
           $(this).siblings('.crm-clear-link').css({visibility: ''});
+          $(this).parents('.crm-multiple-checkbox-radio-options').siblings('.crm-clear-link').css({visibility: ''});
         }
         if (context !== 'crmClear' && $(this).is('[allowclear=1]') && $(this).val() === '') {
           $(this).siblings('.crm-clear-link').css({visibility: 'hidden'});
+          $(this).parents('.crm-multiple-checkbox-radio-options').siblings('.crm-clear-link').css({visibility: 'hidden'});
         }
       })
 

--- a/js/Common.js
+++ b/js/Common.js
@@ -1685,18 +1685,18 @@ if (!CRM.vars) CRM.vars = {};
       // Handle clear button for form elements
       .on('click', 'a.crm-clear-link', function() {
         $(this).css({visibility: 'hidden'}).siblings('.crm-form-radio:checked').prop('checked', false).trigger('change', ['crmClear']);
-        $(this).css({visibility: 'hidden'}).siblings('.crm-multiple-checkbox-radio-options').find('.crm-form-radio:checked').prop('checked', false).trigger('change', ['crmClear']);
+        $(this).siblings('.crm-multiple-checkbox-radio-options').find('.crm-form-radio:checked').prop('checked', false).trigger('change', ['crmClear']);
         $(this).siblings('input:text').val('').trigger('change', ['crmClear']);
         return false;
       })
       .on('change keyup', 'input.crm-form-radio:checked, input[allowclear=1]', function(e, context) {
         if (context !== 'crmClear' && ($(this).is(':checked') || ($(this).is('[allowclear=1]') && $(this).val()))) {
           $(this).siblings('.crm-clear-link').css({visibility: ''});
-          $(this).parents('.crm-multiple-checkbox-radio-options').siblings('.crm-clear-link').css({visibility: ''});
+          $(this).closest('.crm-multiple-checkbox-radio-options').siblings('.crm-clear-link').css({visibility: ''});
         }
         if (context !== 'crmClear' && $(this).is('[allowclear=1]') && $(this).val() === '') {
           $(this).siblings('.crm-clear-link').css({visibility: 'hidden'});
-          $(this).parents('.crm-multiple-checkbox-radio-options').siblings('.crm-clear-link').css({visibility: 'hidden'});
+          $(this).closest('.crm-multiple-checkbox-radio-options').siblings('.crm-clear-link').css({visibility: 'hidden'});
         }
       })
 

--- a/templates/CRM/Custom/Form/Edit/CustomField.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomField.tpl
@@ -23,24 +23,23 @@
   <tr class="custom_field-row {$element.element_name}-row">
     <td class="label">{$formElement.label}{if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$element.label}{/if}</td>
     <td class="html-adjust">
-      {assign var="count" value=1}
-      {foreach name=outer key=key item=item from=$formElement}
-        {if is_array($item) && array_key_exists('html', $item)}
-          {$item.html}
-          {if $count == $element.options_per_line}
-            <br />
-            {assign var="count" value=1}
-          {else}
-            {assign var="count" value=$count+1}
-          {/if}
-        {else}
-          {* Skip because this isn't one of the numeric keyed elements that are the options to display, it's non-numeric keys like the field label and metadata. *}
-        {/if}
-      {/foreach}
 
-      {if $element.html_type == 'Radio' and $element.is_required == 0}
-        <a href="#" class="crm-hover-button crm-clear-link" title="{ts}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
-      {/if}
+      <div class="content">
+        <div class="crm-multiple-checkbox-radio-options crm-options-per-line" style="--crm-opts-per-line:{$element.options_per_line};">
+          {foreach name=outer key=key item=item from=$formElement}
+            {if is_array($item) && array_key_exists('html', $item)}
+              <div class="crm-option-label-pair" >{$formElement.$key.html}</div>
+            {/if}
+          {/foreach}
+        </div>
+
+        {* Include the edit options list for admins *}
+        {if $formElement.html|strstr:"crm-option-edit-link"}
+          {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@":"$1"}
+        {/if}
+      </div>
+      <div class="clear"></div>
+
     </td>
   </tr>
 {else}

--- a/templates/CRM/Custom/Form/Edit/CustomField.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomField.tpl
@@ -24,21 +24,18 @@
     <td class="label">{$formElement.label}{if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$element.label}{/if}</td>
     <td class="html-adjust">
 
-      <div class="content">
-        <div class="crm-multiple-checkbox-radio-options crm-options-per-line" style="--crm-opts-per-line:{$element.options_per_line};">
-          {foreach name=outer key=key item=item from=$formElement}
-            {if is_array($item) && array_key_exists('html', $item)}
-              <div class="crm-option-label-pair" >{$formElement.$key.html}</div>
-            {/if}
-          {/foreach}
-        </div>
-
-        {* Include the edit options list for admins *}
-        {if $formElement.html|strstr:"crm-option-edit-link"}
-          {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@":"$1"}
-        {/if}
+      <div class="crm-multiple-checkbox-radio-options crm-options-per-line" style="--crm-opts-per-line:{$element.options_per_line};">
+        {foreach name=outer key=key item=item from=$formElement}
+          {if is_array($item) && array_key_exists('html', $item)}
+            <div class="crm-option-label-pair" >{$formElement.$key.html}</div>
+          {/if}
+        {/foreach}
       </div>
-      <div class="clear"></div>
+
+      {* Include the edit options list for admins *}
+      {if $formElement.html|strstr:"crm-option-edit-link"}
+        {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@":"$1"}
+      {/if}
 
     </td>
   </tr>


### PR DESCRIPTION
Overview
----------------------------------------
Follow-up for https://github.com/civicrm/civicrm-core/pull/30162

This is the backend part

Technical Details
----------------------------------------
Same code as https://github.com/civicrm/civicrm-core/pull/30162 for backend custom fields.

I had to update the clear button javascript as it's not a direct sibling of the radio buttons anymore.

Comments
----------------------------------------
Oddly enough, I removed the `crm-clear-link` from the template as it seems to be already added in `CRM/Core/Form/Renderer.php`. Not sure if there is a use case where it's needed but if we keep the code, the clear button is there twice.
