### PR TITLE
Improved reading comprehension - fix full text search

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -233,6 +233,7 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
       ['CRM_Campaign_BAO_Campaign', 'isComponentEnabled'],
       ['CRM_Case_BAO_Case', 'checkPermission'],
       ['CRM_Core_Permission', 'check'],
+      ['CRM_Core_Permission', 'access'],
     ];
     if (!in_array($callable, $permitted)) {
       if (CRM_Core_Smarty::singleton()->getVersion() === 5) {


### PR DESCRIPTION
Overview
----------------------------------------
Improved reading comprehension - fix full text search

Before
----------------------------------------
Full text search crash

After
----------------------------------------
Fix

Technical Details
----------------------------------------
` ['CRM_Core_Permission', 'check'],` looks like ` ['CRM_Core_Permission', 'access'],` but on careful re-reading not all the words are actually the same

Comments
----------------------------------------
@demeritcowboy 