### PR TITLE
(dev/core#5250) "Send Letter" - Crashes while rendering help widget

### DIFF
--- a/templates/CRM/Contribute/Form/Task/PDFLetter.tpl
+++ b/templates/CRM/Contribute/Form/Task/PDFLetter.tpl
@@ -36,7 +36,7 @@
         <td>{$form.email_options.html}</td>
       </tr>
       <tr>
-        <td class="label-left">{$form.from_email_address.label}  {help id="id-from_email" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
+        <td class="label-left">{$form.from_email_address.label}  {help id="id-from_email" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp" title=$form.from_email_address.label}</td>
         <td>{$form.from_email_address.html}</td>
       </tr>
     </table>


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/5250

Technical Details
----------------------------------------

Crash occurs while rendering the title of the help widget. As of 5.73 (#29851), the Smarty context for evaluating the title is more restrictive. This only matters when the help-text involves some less-commons expressions (like `call_user_func`). The explicit title does not require evaluation in the restricted mode.