### PR TITLE
Hides billing block if total amount is 0

### DIFF
--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -92,7 +92,9 @@
         </div>
       </fieldset>
     {/if}
-        {include file='CRM/Core/BillingBlockWrapper.tpl'}
+    {if $totalAmount > 0}
+      {include file='CRM/Core/BillingBlockWrapper.tpl'}
+    {/if}
     {literal}<script>function calculateTotalFee() { return {/literal}{$totalAmount}{literal} }</script>{/literal}
     </div>
     {/if}


### PR DESCRIPTION
Overview
----------------------------------------
On event registration confirmation form the Billing Block still renders even when no payment is required. i.e. the total is 0. This can be confusing for users

Adds if statement around include for Billing Block: if the total amount is 0 then don't show the block
