### PR TITLE
Begone bad index

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSeventyFive.php
+++ b/CRM/Upgrade/Incremental/php/FiveSeventyFive.php
@@ -71,6 +71,8 @@ class CRM_Upgrade_Incremental_php_FiveSeventyFive extends CRM_Upgrade_Incrementa
     $this->addTask('Replace receive_date smarty token in online membership template',
       'updateMessageToken', 'membership_online_receipt', '$receive_date', 'contribution.receive_date', $rev
     );
+
+    CRM_Core_BAO_SchemaHandler::dropIndexIfExists('civicrm_line_item', 'UI_line_item_value');
   }
 
 }

--- a/schema/Price/LineItem.entityType.php
+++ b/schema/Price/LineItem.entityType.php
@@ -12,19 +12,6 @@ return [
     'add' => '1.7',
     'label_field' => 'label',
   ],
-  'getIndices' => fn() => [
-    'UI_line_item_value' => [
-      'fields' => [
-        'entity_id' => TRUE,
-        'entity_table' => TRUE,
-        'contribution_id' => TRUE,
-        'price_field_value_id' => TRUE,
-        'price_field_id' => TRUE,
-      ],
-      'unique' => TRUE,
-      'add' => '3.3',
-    ],
-  ],
   'getFields' => fn() => [
     'id' => [
       'title' => ts('Line Item ID'),

--- a/xml/schema/Price/LineItem.xml
+++ b/xml/schema/Price/LineItem.xml
@@ -144,18 +144,6 @@
     <add>3.2</add>
 
   </field>
-   <index>
-    <name>UI_line_item_value</name>
-    <fieldName>entity_id</fieldName>
-    <fieldName>entity_table</fieldName>
-    <fieldName>contribution_id</fieldName>
-    <fieldName>price_field_value_id</fieldName>
-    <fieldName>price_field_id</fieldName>
-    <unique>true</unique>
-    <add>3.3</add>
-    <change>4.5</change>
-    <!-- Add contribution_id to unique index in 4.5  -->
-  </index>
   <field>
     <name>price_field_value_id</name>
     <title>Option ID</title>


### PR DESCRIPTION
Overview
----------------------------------------
Removes the unique invoice ID preventing a contribution from having 2 line items with the same price field value

Before
----------------------------------------
The index on the civicrm_line_item table prevents us from adding 2 line items with the same price field value on the same contribution

After
----------------------------------------
It is now permitted

Technical Details
----------------------------------------
In discussion with @mattwire @bjendres @jensschuppe @sluc23 @JoeMurray @seamuslee001 we agreed that this index did not meet 'modern' usage as in many cases integrations want to provide basic details like description, amount etc ad hoc and this was not originally envisaged when the index was added

Comments
----------------------------------------
