### PR TITLE
Switch to using new crmPermission block

### DIFF
--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -243,7 +243,7 @@
       <a href="{crmURL p='civicrm/activity/add' q=$urlParams}" class="edit button" title="{ts}Edit{/ts}"><span><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Edit{/ts}</span></a>
     {/if}
 
-    {crmPermission permission='delete activities'}
+    {crmPermission has='delete activities'}
       {assign var='urlParams' value="reset=1&atype=$atype&action=delete&reset=1&id=$entityID&cid=$contactId&context=$context"}
       {if ($context eq 'fulltext' || $context eq 'search') && $searchKey}
         {assign var='urlParams' value="reset=1&atype=$atype&action=delete&reset=1&id=$entityID&cid=$contactId&context=$context&key=$searchKey"}

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -243,13 +243,13 @@
       <a href="{crmURL p='civicrm/activity/add' q=$urlParams}" class="edit button" title="{ts}Edit{/ts}"><span><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Edit{/ts}</span></a>
     {/if}
 
-    {if call_user_func(array('CRM_Core_Permission','check'), 'delete activities')}
+    {crmPermission permission='delete activities'}
       {assign var='urlParams' value="reset=1&atype=$atype&action=delete&reset=1&id=$entityID&cid=$contactId&context=$context"}
       {if ($context eq 'fulltext' || $context eq 'search') && $searchKey}
         {assign var='urlParams' value="reset=1&atype=$atype&action=delete&reset=1&id=$entityID&cid=$contactId&context=$context&key=$searchKey"}
       {/if}
       <a href="{crmURL p='civicrm/contact/view/activity' q=$urlParams}" class="delete button" title="{ts}Delete{/ts}"><span><i class="crm-i fa-trash" aria-hidden="true"></i> {ts}Delete{/ts}</span></a>
-    {/if}
+    {/crmPermission}
   {/if}
   {if $action eq 4 and $context != 'case' and call_user_func(array('CRM_Case_BAO_Case','checkPermission'), $activityId, 'File On Case', $atype)}
     <a href="#" onclick="fileOnCase('file', {$activityId}, null, this); return false;" class="cancel button" title="{ts}File On Case{/ts}"><span><i class="crm-i fa-clipboard" aria-hidden="true"></i> {ts}File on Case{/ts}</span></a>


### PR DESCRIPTION
Overview
----------------------------------------
Switch to using new crmPermission block

Before
----------------------------------------
deprecated use of `call_user_func_array` in the tpl file

After
----------------------------------------
Use of new `crmPermission` block

Technical Details
----------------------------------------

Before we fully go down this path I want to question which signature we prefer...

1) Current
```
{crmPermission permission='access CiviCRM' not='access CiviCRM Event'}
  blah
{/crmPermssion}
```

Or more matching
```
{crmPermission has='access CiviCRM' has_not='access CiviCRM Event'}
  blah
{/crmPermssion}
```


Or suggested by @colemanw just now
```
{crmPermission has='access CiviCRM' not='access CiviCRM Event'}
  blah
{/crmPermssion}
```


Comments
----------------------------------------
@mattwire @demeritcowboy @seamuslee001 @colemanw @totten - get your bikes out