### PR TITLE
Smarty have nots

### DIFF
--- a/CRM/Core/Smarty/plugins/block.crmPermission.php
+++ b/CRM/Core/Smarty/plugins/block.crmPermission.php
@@ -32,15 +32,15 @@
  */
 function smarty_block_crmPermission($params, $content, &$smarty, &$repeat) {
   if (!$repeat) {
-    if (empty($params['permission']) && empty($params['not'])) {
+    if (empty($params['has']) && empty($params['not'])) {
       // This would be due to developer error - better to return nothing to make it more visible.
       return '';
     }
-    $hasPermission = empty($params['permission']) || CRM_Core_Permission::check($params['permission'], $params['contact_id'] ?? NULL);
+    $hasPermission = empty($params['has']) || CRM_Core_Permission::check($params['has'], $params['contact_id'] ?? NULL);
     if (!$hasPermission) {
       return '';
     }
-    if (empty($params['not']) || !CRM_Core_Permission::check($params['permission'], $params['contact_id'] ?? NULL)) {
+    if (empty($params['not']) || !CRM_Core_Permission::check($params['not'], $params['contact_id'] ?? NULL)) {
       return $content;
     }
   }

--- a/tests/phpunit/CRM/Core/Smarty/plugins/CrmPermissionTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/CrmPermissionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Class CRM_Core_Smarty_plugins_CrmMoneyTest
+ * @group headless
+ * @group locale
+ */
+class CRM_Core_Smarty_plugins_CrmPermissionTest extends CiviUnitTestCase {
+
+  /**
+   * @dataProvider permissionCases
+   *
+   * @param string $input
+   *
+   * @param string $expected
+   * @param bool $isAdmin
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testPermission(string $input, string $expected, bool $isAdmin) {
+    if ($isAdmin) {
+      \CRM_Core_Config::singleton()->userPermissionClass->permissions = [
+        'access CiviCRM',
+        'administer CiviCRM',
+      ];
+    }
+    else {
+      \CRM_Core_Config::singleton()->userPermissionClass->permissions = [
+        'access CiviCRM',
+      ];
+    }
+    $actual = CRM_Utils_String::parseOneOffStringThroughSmarty($input);
+    $this->assertEquals($expected, $actual, "Process input=[$input]");
+  }
+
+  /**
+   * Get variations on permission configuration.
+   *
+   * @return array[]
+   */
+  public function permissionCases(): array {
+    return [
+      'has_allowed' => ['{crmPermission has="administer CiviCRM"}boom{/crmPermission}', 'boom', TRUE],
+      'has_blocked' => ['{crmPermission has="administer CiviCRM"}boom{/crmPermission}', '', FALSE],
+      'not_has_allowed' => ['{crmPermission not="administer CiviCRM"}boom{/crmPermission}', '', TRUE],
+      'not_has_blocked' => ['{crmPermission not="administer CiviCRM"}boom{/crmPermission}', 'boom', FALSE],
+      'has_and_not_allowed' => ['{crmPermission has="access CiviCRM" not="administer CiviCRM"}boom{/crmPermission}', 'boom', FALSE],
+      'has_and_not_blocked' => ['{crmPermission has="access CiviCRM" not="administer CiviCRM"}boom{/crmPermission}', '', TRUE],
+      'has_not_and_has_allowed' => ['{crmPermission has="administer CiviCRM" not="access CiviEvent"}boom{/crmPermission}', 'boom', TRUE],
+      'has_not_and_has_blocked' => ['{crmPermission has="administer CiviCRM" not="access CiviEvent"}boom{/crmPermission}', '', FALSE],
+    ];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes new `{crmPermission}` to use the option from preferred by @totten & @colemanw - although @demeritcowboy is waving the flag of disent

Before
----------------------------------------
```
{crmPermission permission='access CiviCRM' not='access CiviCRM Event'}
  blah
{/crmPermssion}

```

After
----------------------------------------
```
{crmPermission has='access CiviCRM' not='access CiviCRM Event'}
  blah
{/crmPermssion}
```

Technical Details
----------------------------------------
To @demeritcowboy concern  - I think we found an `if-else` that is hard to solve without supporting has & not in the same block

Comments
----------------------------------------
