### PR TITLE
Remove the Participant Role from Event confirmations

### DIFF
--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -119,20 +119,6 @@
     </div>
     {/if}
 
-    {if $event.participant_role neq 'Attendee' and $defaultRole}
-        <div class="crm-group participant_role-group">
-            <div class="header-dark">
-                {ts}Participant Role{/ts}
-            </div>
-            <div class="crm-section no-label participant_role-section">
-                <div class="content">
-                    {$event.participant_role}
-                </div>
-              <div class="clear"></div>
-            </div>
-        </div>
-    {/if}
-
     {include file="CRM/Event/Form/Registration/DisplayProfile.tpl"}
 
     {if $billingName or $address}

--- a/templates/CRM/Event/Form/Registration/ThankYou.tpl
+++ b/templates/CRM/Event/Form/Registration/ThankYou.tpl
@@ -139,20 +139,6 @@
         </div>
     {/if}
 
-    {if $event.participant_role neq 'Attendee' and $defaultRole}
-        <div class="crm-group participant_role-group">
-            <div class="header-dark">
-                {ts}Participant Role{/ts}
-            </div>
-            <div class="crm-section no-label participant_role-section">
-                <div class="content">
-                    {$event.participant_role}
-                </div>
-            <div class="clear"></div>
-          </div>
-        </div>
-    {/if}
-
     {include file="CRM/Event/Form/Registration/DisplayProfile.tpl"}
     {if $billingName or $address}
         <div class="crm-group billing_name_address-group">

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -46,7 +46,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
   }
 
   public function testSubmitDualRole(): void {
-    $email = $this->getForm([], [
+    $this->getForm([], [
       'status_id' => 1,
       'register_date' => date('Ymd'),
       'send_receipt' => 1,
@@ -55,8 +55,13 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
         CRM_Core_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'role_id', 'Volunteer'),
         CRM_Core_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'role_id', 'Speaker'),
       ],
-    ])->postProcess()->getFirstMailBody();
-    $this->assertStringContainsString('Volunteer, Speaker', $email);
+    ])->postProcess();
+    $participant = \Civi\Api4\Participant::get()
+      ->addSelect('role_id:name')
+      ->addOrderBy('id', 'DESC')
+      ->execute()
+      ->first();
+    $this->assertEqualsCanonicalizing(['Volunteer', 'Speaker'], $participant['role_id:name']);
   }
 
   public function testSubmitWithCustomData(): void {

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -56,17 +56,6 @@
       </td>
      </tr>
 
-     {if "{participant.role_id:label}" neq 'Attendee'}
-      <tr>
-       <td {$labelStyle}>
-        {ts}Participant Role{/ts}
-       </td>
-       <td {$valueStyle}>
-         {participant.role_id:label}
-       </td>
-      </tr>
-     {/if}
-
      {if {event.is_show_location|boolean}}
       <tr>
        <td colspan="2" {$valueStyle}>

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -66,17 +66,6 @@
           </td>
         </tr>
 
-        {if "{participant.role_id:label}" neq 'Attendee'}
-          <tr>
-            <td {$labelStyle}>
-              {ts}Participant Role{/ts}
-            </td>
-            <td {$valueStyle}>
-              {participant.role_id:label}
-            </td>
-          </tr>
-        {/if}
-
         {if {event.is_show_location|boolean}}
           <tr>
             <td colspan="2" {$valueStyle}>

--- a/xml/templates/message_templates/participant_cancelled_html.tpl
+++ b/xml/templates/message_templates/participant_cancelled_html.tpl
@@ -38,14 +38,6 @@
        {event.start_date|crmDate:"%A"} {event.start_date|crmDate}{if {event.end_date|boolean}}-{if '{event.end_date|crmDate:"%Y%m%d"}' === '{event.start_date|crmDate:"%Y%m%d"}'}{event.end_date|crmDate:"Time"}{else}{event.end_date|crmDate:"%A"} {event.end_date|crmDate}{/if}{/if}
       </td>
      </tr>
-     <tr>
-      <td {$labelStyle}>
-       {ts}Participant Role{/ts}:
-      </td>
-      <td {$valueStyle}>
-       {participant.role_id:label}
-      </td>
-     </tr>
     {if {event.is_show_location|boolean}}
         <tr>
           <td colspan="2" {$valueStyle}>

--- a/xml/templates/message_templates/participant_confirm_html.tpl
+++ b/xml/templates/message_templates/participant_confirm_html.tpl
@@ -56,14 +56,6 @@
        {event.start_date|crmDate:"%A"} {event.start_date|crmDate}{if {event.end_date|boolean}}-{if '{event.end_date|crmDate:"%Y%m%d"}' === '{event.start_date|crmDate:"%Y%m%d"}'}{event.end_date|crmDate:"Time"}{else}{event.end_date|crmDate:"%A"} {event.end_date|crmDate}{/if}{/if}
       </td>
      </tr>
-     <tr>
-      <td {$labelStyle}>
-       {ts}Participant Role{/ts}:
-      </td>
-      <td {$valueStyle}>
-        {participant.role_id:label}
-      </td>
-     </tr>
      {if {event.is_show_location|boolean}}
         <tr>
           <td colspan="2" {$valueStyle}>

--- a/xml/templates/message_templates/participant_expired_html.tpl
+++ b/xml/templates/message_templates/participant_expired_html.tpl
@@ -41,15 +41,6 @@ or want to inquire about reinstating your registration for this event.{/ts}</p>
        {event.start_date|crmDate:"%A"} {event.start_date|crmDate}{if {event.end_date|boolean}}-{if '{event.end_date|crmDate:"%Y%m%d"}' === '{event.start_date|crmDate:"%Y%m%d"}'}{event.end_date|crmDate:"Time"}{else}{event.end_date|crmDate:"%A"} {event.end_date|crmDate}{/if}{/if}
       </td>
      </tr>
-     <tr>
-      <td {$labelStyle}>
-       {ts}Participant Role{/ts}:
-      </td>
-      <td {$valueStyle}>
-        {participant.role_id:label}
-      </td>
-     </tr>
-
     {if {event.is_show_location|boolean}}
         <tr>
           <td colspan="2" {$valueStyle}>

--- a/xml/templates/message_templates/participant_transferred_html.tpl
+++ b/xml/templates/message_templates/participant_transferred_html.tpl
@@ -38,15 +38,6 @@
        {event.start_date|crmDate:"%A"} {event.start_date|crmDate}{if {event.end_date|boolean}}-{if '{event.end_date|crmDate:"%Y%m%d"}' === '{event.start_date|crmDate:"%Y%m%d"}'}{event.end_date|crmDate:"Time"}{else}{event.end_date|crmDate:"%A"} {event.end_date|crmDate}{/if}{/if}
       </td>
      </tr>
-     <tr>
-      <td {$labelStyle}>
-       {ts}Participant Role{/ts}:
-      </td>
-      <td {$valueStyle}>
-       {participant.role_id:label}
-      </td>
-     </tr>
-
      {if {event.is_show_location|boolean}}
         <tr>
           <td colspan="2" {$valueStyle}>

--- a/xml/templates/message_templates/payment_or_refund_notification_html.tpl
+++ b/xml/templates/message_templates/payment_or_refund_notification_html.tpl
@@ -180,17 +180,6 @@
         </td>
       </tr>
 
-      {if {participant.role_id|boolean}}
-      <tr>
-        <td {$labelStyle}>
-          {ts}Participant Role{/ts}
-        </td>
-        <td {$valueStyle}>
-         {participant.role_id:label}
-        </td>
-      </tr>
-      {/if}
-
       {if {event.is_show_location|boolean}}
             <tr>
               <td colspan="2" {$valueStyle}>


### PR DESCRIPTION
For most forms and emails, the Participant Role is not something that the user selects, and is usually not relevant to them. CiviCRM is being overly pedantic with this information, which is probably not relevant to 90% of people, and I don't think we should annoy them because 10% need it.

Also, it didn't support translation most of the time, because it uses the label instead of the name (and I didn't feel it was worth fixing). In any case, people might not use "Attendant" but rather some custom option, and then CiviCRM would behave differently for some obscure reason.

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/690afef6-503d-49bd-8d66-8011229f0fc7)

After
----------------------------------------

Less clutter.

Comments
----------------------------------------

I didn't test the Upgrade step.

cc @jusfreeman (not sure why, but am trying to think of people who use more obscure features of CiviCRM)