### PR TITLE
return empty array from getSelectedIDs

### DIFF
--- a/CRM/Contribute/Form/Task/TaskTrait.php
+++ b/CRM/Contribute/Form/Task/TaskTrait.php
@@ -122,7 +122,6 @@ trait CRM_Contribute_Form_Task_TaskTrait {
     $ids = $this->getSelectedIDs($this->getSearchFormValues());
     if (!$ids) {
       $result = $this->getSearchQueryResults();
-      $ids = [];
       while ($result->fetch()) {
         $ids[] = $result->contribution_id;
       }

--- a/CRM/Core/Form/Task.php
+++ b/CRM/Core/Form/Task.php
@@ -115,13 +115,11 @@ abstract class CRM_Core_Form_Task extends CRM_Core_Form {
   }
 
   /**
-   * Get the ids the user has selected or FALSE if selection has not been used.
+   * Get the ids the user has selected or an empty array if selection has not been used.
    *
    * @param array $values
-   *
-   * @return array|bool
    */
-  public function getSelectedIDs(array $values) {
+  public function getSelectedIDs(array $values): array {
     if ($values['radio_ts'] === 'ts_sel') {
       $ids = [];
       foreach ($values as $name => $value) {
@@ -131,7 +129,7 @@ abstract class CRM_Core_Form_Task extends CRM_Core_Form {
       }
       return $ids;
     }
-    return FALSE;
+    return [];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
When you select a search task and have selected "All X Contacts", `getSelectedIDs()` returns `FALSE` because no contacts were selected.  That's fine, but everywhere that code is called expects an array or you get this:

```
Deprecated function: Automatic conversion of false to array is deprecated in CRM_Grant_Form_Task::preProcessCommon() (line 67 of /home/jon/local/civicrm-buildkit/build/dmaster/web/sites/all/modules/civicrm/ext/civigrant/CRM/Grant/Form/Task.php).
```

The exception is contribution searches, since they explicit declare `$ids` as an empty array.  I started to fix all the other places where `getSelectedIDs()` is called, but looking at them all, it seems like it's better to change `getSelectedIDs()` itself.

Before
----------------------------------------
Deprecated function notices.

After
----------------------------------------
Less noise.
