### PR TITLE
dev/core#5258 - Crash on Manage Case in smarty 5

### DIFF
--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -239,6 +239,8 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
       return;
     }
 
+    $this->assign('hasAllACLs', CRM_Core_Permission::giveMeAllACLs());
+
     $allowedRelationshipTypes = CRM_Contact_BAO_Relationship::getContactRelationshipType($this->_contactID);
     $relationshipTypeMetadata = CRM_Contact_Form_Relationship::getRelationshipTypeMetadata($allowedRelationshipTypes);
 

--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -118,7 +118,7 @@
           </span>
         {/if}
 
-        {if call_user_func(array('CRM_Core_Permission','giveMeAllACLs'))}
+        {if $hasAllACLs}
           <a class="action-item crm-hover-button medium-popup" href="{crmURL p='civicrm/contact/view/case/editClient' h=1 q="reset=1&action=update&id=$caseID&cid=$contactID"}"><i class="crm-i fa-user" aria-hidden="true"></i> {ts}Assign to Another Client{/ts}</a>
         {/if}
       </p>


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5258

Before
----------------------------------------
Crash

After
----------------------------------------


Technical Details
----------------------------------------
It calls CRM_Core_Permission::giveMeAllACLs from within the tpl. Only one other place in core that I can see does this, but it's from a deprecated place, so doesn't seem worth trying to support from within tpls.

Comments
----------------------------------------

