### PR TITLE
dev/core#5258 - Crash in smarty 5 if you have the fulltext block enabled

### DIFF
--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText.php
@@ -304,6 +304,8 @@ WHERE      t.table_name = 'Activity' AND
     $form->applyFilter('__ALL__', 'trim');
     $form->add('text', 'text', ts('Find'), NULL, TRUE);
 
+    $form->assign('hasAllACLs', CRM_Core_Permission::giveMeAllACLs());
+
     // also add a select box to allow the search to be constrained
     $tables = ['' => ts('All tables')];
     /** @var CRM_Contact_Form_Search_Custom_FullText_AbstractPartialQuery $partialQuery */

--- a/templates/CRM/Block/FullTextSearch.tpl
+++ b/templates/CRM/Block/FullTextSearch.tpl
@@ -28,7 +28,7 @@
     <input type="hidden" name="qfKey" value="{crmKey name='CRM_Legacycustomsearches_Controller_Search' addSequence=1}" />
   </div>
   <select class="form-select" id="fulltext_table" name="fulltext_table">
-{if call_user_func(array('CRM_Core_Permission','giveMeAllACLs'))}
+{if $hasAllACLs}
       <option value="">{ts}All{/ts}</option>
       <option value="Contact">{ts}Contacts{/ts}</option>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5258

Before
----------------------------------------
Crash

After
----------------------------------------


Technical Details
----------------------------------------
Same as https://github.com/civicrm/civicrm-core/pull/30325

Comments
----------------------------------------

