### PR TITLE
dev/core#5199 Add support for html encoded quotes in tokens

### DIFF
--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -1193,7 +1193,7 @@ Attendees will need to install the [TeleFoo](http://telefoo.example.com) app.';
    *
    * @return \Civi\Token\TokenProcessor
    */
-  protected function getTokenProcessor(array $override): TokenProcessor {
+  protected function getTokenProcessor(array $override = []): TokenProcessor {
     return new TokenProcessor(\Civi::dispatcher(), array_merge([
       'controller' => __CLASS__,
     ], $override));
@@ -1219,6 +1219,23 @@ Attendees will need to install the [TeleFoo](http://telefoo.example.com) app.';
     $tokenProcessor->addMessage('text', $text, 'text/' . ($isHtml ? 'html' : 'plain'));
     $tokenProcessor->evaluate();
     return $tokenProcessor->getRow(0)->render('text');
+  }
+
+  public function testQuotedTokens(): void {
+    $quoteOptions = [
+      '"',
+      '&lquote;',
+      '&rquote;',
+      '&quot;',
+      '&#8221;',
+      '&#8220;',
+      '&#x22;',
+    ];
+    Civi::settings()->set('dateformatFull', '%B %E%f, %Y');
+    foreach ($quoteOptions as $quote) {
+      $date = CRM_Utils_Date::customFormat(date('Y-m-d H:i:s'), '%B %E%f, %Y');
+      $this->assertEquals($date, $this->renderText([], '{domain.now|crmDate:' . $quote . 'Full' . $quote . '}'), 'render with quote type :' . $quote);
+    }
   }
 
 }


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#5199

This addresses
https://lab.civicrm.org/dev/core/-/issues/5199
by handling the possibility of the html formatted text being

{domain.now|crmDate:&quot;Full&quot;}

this is what is passed in via the ODT method


Before
----------------------------------------
`{domain.now|crmDate:&quot;Full&quot;} ` crashes

After
----------------------------------------
`{domain.now|crmDate:&quot;Full&quot;}` works along with 
variants like
```
      '&lquote\;',
      '&rquote\;',
      '&quot\;',
      '&#8221\;',
      '&#8220\;',
      '&#x22\;'
```

Technical Details
----------------------------------------
more discussion on gitlab

Comments
----------------------------------------
