### PR TITLE
dev/core#5252 Loosen default purification of defaults

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -823,7 +823,15 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $exclude = $this->getFieldsToExcludeFromPurification();
     foreach ($defaults as $index => $default) {
       if (!in_array($index, $exclude, TRUE) && is_string($default) && !is_numeric($default)) {
+        $hasEncodedAmp = str_contains('&amp;', $default);
+        $hasEncodedQuote = str_contains('&quot;', $default);
         $defaults[$index] = CRM_Utils_String::purifyHTML($default);
+        if (!$hasEncodedAmp) {
+          $defaults[$index] = str_replace('&amp;', '&', $defaults[$index]);
+        }
+        if (!$hasEncodedQuote) {
+          $defaults[$index] = str_replace('&quot;', '"', $defaults[$index]);
+        }
       }
     }
     $this->setDefaults($defaults);


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5252 Loosen default purification of defaults

Before
----------------------------------------
We purify the defaults to ensure we are not loading up script but we are replacing the common values `&` and `"`

After
----------------------------------------
Specifically do not replace those

Technical Details
----------------------------------------

Comments
----------------------------------------
