### PR TITLE
Slow down deprecation of function

### DIFF
--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -338,10 +338,9 @@ class CRM_Core_DAO_AllCoreTables {
   }
 
   /**
-   * @deprecated in 5.72 will be removed in 5.96
+   * @deprecated in 5.72 will be removed in 5.102
    */
   public static function getBriefName($className): ?string {
-    CRM_Core_Error::deprecatedFunctionWarning('CRM_Core_DAO_AllCoreTables::getEntityNameForClass');
     return self::getEntityNameForClass((string) $className);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
The cross over between this being deprecated & there being a new option is a bit on the short side, given that it is very commonly used. I'm taking out the deprecation notice for 5.74 after discussing with Johannes F & after also having had to do a bit of a juggle on our site to upgrade from 5.70 to 5.74 with some need to juggle code to manage CI

Before
----------------------------------------
Noisy deprecation in `getBriefName()`

After
----------------------------------------
Quiet deprecation

Technical Details
----------------------------------------
This is a function with heavy usage in extensions & it's fairly cheap to keep in core as it just calls the new function

Comments
----------------------------------------
@colemanw FYI - we can put this back in a few releases once (e.g)  LTS users are no longer completely missing the new function to save tooo much function_exists code