### PR TITLE
Add mailSettingId parameter to emailProcessor hook

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1675,13 +1675,15 @@ abstract class CRM_Utils_Hook {
    * @param array &$result the result returned by the api call
    * @param string $action
    *   (optional ) the requested action to be performed if the types was 'mailing'.
+   * @param int|null $mailSettingId
+   *   The MailSetting ID the email relates to
    *
    * @return mixed
    */
-  public static function emailProcessor($type, &$params, $mail, &$result, $action = NULL) {
+  public static function emailProcessor($type, &$params, $mail, &$result, $action = NULL, int $mailSettingId = NULL) {
     $null = NULL;
     return self::singleton()
-      ->invoke(['type', 'params', 'mail', 'result', 'action'], $type, $params, $mail, $result, $action, $null, 'civicrm_emailProcessor');
+      ->invoke(['type', 'params', 'mail', 'result', 'action', 'mailSettingId'], $type, $params, $mail, $result, $action, $mailSettingId, 'civicrm_emailProcessor');
   }
 
   /**

--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -211,7 +211,7 @@ class CRM_Utils_Mail_EmailProcessor {
 
             $result = civicrm_api3('Activity', 'create', $activityParams);
             $matches = TRUE;
-            CRM_Utils_Hook::emailProcessor('activity', $activityParams, $mail, $result);
+            CRM_Utils_Hook::emailProcessor('activity', $activityParams, $mail, $result, NULL, $dao->id);
             echo "Processed as Activity: {$mail->subject}\n";
           }
           catch (Exception $e) {
@@ -337,7 +337,7 @@ class CRM_Utils_Mail_EmailProcessor {
             echo "Failed Processing: {$mail->subject}, Action: $action, Job ID: $job, Queue ID: $queue, Hash: $hash. Reason: {$result['error_message']}\n";
           }
           else {
-            CRM_Utils_Hook::emailProcessor('mailing', $activityParams, $mail, $result, $action);
+            CRM_Utils_Hook::emailProcessor('mailing', $activityParams, $mail, $result, $action, $dao->id);
           }
         }
 

--- a/tests/phpunit/CRM/Utils/Mail/EmailProcessorInboundTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/EmailProcessorInboundTest.php
@@ -140,7 +140,8 @@ class CRM_Utils_Mail_EmailProcessorInboundTest extends CiviUnitTestCase {
   /**
    * hook implementation for testHookEmailProcessor
    */
-  public function hookImplForEmailProcessor($type, &$params, $mail, &$result, $action = NULL) {
+  public function hookImplForEmailProcessor($type, &$params, $mail, &$result, $action = NULL, int $mailSettingId = NULL) {
+    $this->assertEquals($this->mailSettingsId, $mailSettingId);
     if ($type !== 'activity') {
       return;
     }


### PR DESCRIPTION
Overview
----------------------------------------
This adds a new `$mailSettingId` parameter to the `emailProcessor` hook.

The emailProcessor hook is called after inbound emails are processed and provides parameters related to the email and result/created entity.

However, as far as I can tell there is currently no way to figure out which mail setting (mail account) the email relates to - the created entities themselves don't include a FK to the mail setting, and the mail object itself does not help either since it doesn't give us access to the (trusted) mail envelope which would contain the canonical From/To header.

Before
----------------------------------------
No way to determine the mail setting/account an inbound email relates to.

After
----------------------------------------
mailSettingId is provided to any hook listeners.


Comments
----------------------------------------
TODO: doc update
