### PR TITLE
dev/core#5238 Filter loaded fields to be of the custom group type 'tab'

### DIFF
--- a/CRM/Custom/Form/CustomDataTrait.php
+++ b/CRM/Custom/Form/CustomDataTrait.php
@@ -59,14 +59,13 @@ trait CRM_Custom_Form_CustomDataTrait {
       ],
       'checkPermissions' => TRUE,
     ])->indexBy('custom_field_id');
-
+    $fieldFilters = ['style' => 'Inline'];
     if ($entity === 'Contact') {
       // Ideally this would not be contact specific but the function being
       // called here does not handle the filters as received.
-      $fieldFilters = [
+      $fieldFilters += [
         'extends' => [$entity, $filters['contact_type']],
         'is_multiple' => TRUE,
-        'style' => 'Inline',
       ];
       if (!empty($filters['contact_sub_type'])) {
         $fieldFilters['extends_entity_column_value'] = [NULL, $filters['contact_sub_type']];


### PR DESCRIPTION
Overview
----------------------------------------
Filter loaded fields to be of the custom group type 'tab'

Before
----------------------------------------
The UI only supports setting the CustomGroup.style to 'tab' for the Contact entity - but Systopia have been doing this for the Event entity. We have a regression that affects Systopia as we are only filtering tab fields out from the 'known fields' for Contact based on the assumption only contact will have them

After
----------------------------------------
We filter for all - in practice this is a null op except for the very specific Systopia scenario 

Technical Details
----------------------------------------
For more information see https://lab.civicrm.org/dev/core/-/issues/5238


Comments
----------------------------------------
@jofranz maybe you want to check this out