### PR TITLE
APIv4 - Add SqlFunctionNEXTANNIV, fix leap-year handling

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -2496,4 +2496,21 @@ class CRM_Utils_Date {
     return '(' . implode('|', $months) . ')';
   }
 
+  /**
+   * Sql expression to calculate the upcoming anniversary of a given date.
+   *
+   * The IF() accounts for the possibility that the date has already passed, & so skips to next year.
+   * The IFNULL() conditions account for leap year: if the date is Feb 29, and it's not currently a leap year, the first DATE() will return NULL so the second subtracts a day.
+   *
+   * @param string $dateColumn
+   * @return string
+   */
+  public static function getAnniversarySql(string $dateColumn): string {
+    return "IF(
+      CONCAT(YEAR(CURDATE()), DATE_FORMAT($dateColumn, '-%m-%d')) < CURDATE(),
+      IFNULL(DATE(CONCAT(YEAR(CURDATE()) + 1, DATE_FORMAT($dateColumn, '-%m-%d'))), DATE(CONCAT(YEAR(CURDATE()) + 1, DATE_FORMAT(DATE_SUB($dateColumn, INTERVAL 1 DAY), '-%m-%d')))),
+      IFNULL(DATE(CONCAT(YEAR(CURDATE()), DATE_FORMAT($dateColumn, '-%m-%d'))), DATE(CONCAT(YEAR(CURDATE()), DATE_FORMAT(DATE_SUB($dateColumn, INTERVAL 1 DAY), '-%m-%d'))))
+    )";
+  }
+
 }

--- a/Civi/Api4/Query/SqlFunctionNEXTANNIV.php
+++ b/Civi/Api4/Query/SqlFunctionNEXTANNIV.php
@@ -14,11 +14,11 @@ namespace Civi\Api4\Query;
 /**
  * Sql function
  */
-class SqlFunctionDAYSTOANNIV extends SqlFunction {
+class SqlFunctionNEXTANNIV extends SqlFunction {
 
   protected static $category = self::CATEGORY_DATE;
 
-  protected static $dataType = 'Integer';
+  protected static $dataType = 'Date';
 
   protected static function params(): array {
     return [
@@ -33,22 +33,21 @@ class SqlFunctionDAYSTOANNIV extends SqlFunction {
    * @return string
    */
   public static function getTitle(): string {
-    return ts('Days to Anniversary');
+    return ts('Next Anniversary');
   }
 
   /**
    * @return string
    */
   public static function getDescription(): string {
-    return ts('Number of days until the next anniversary of this date.');
+    return ts('Date of next anniversary of this date.');
   }
 
   /**
    * @inheritDoc
    */
   protected function renderExpression(string $output): string {
-    $anniversarySql = \CRM_Utils_Date::getAnniversarySql($output);
-    return "DATEDIFF($anniversarySql, CURDATE())";
+    return \CRM_Utils_Date::getAnniversarySql($output);
   }
 
 }

--- a/Civi/Api4/Service/Spec/Provider/ContactGetSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ContactGetSpecProvider.php
@@ -207,14 +207,8 @@ class ContactGetSpecProvider extends \Civi\Core\Service\AutoService implements G
    * @return string
    */
   public static function calculateBirthday(array $field): string {
-    return "DATEDIFF(
-        IF(
-            DATE(CONCAT(YEAR(CURDATE()), '-', MONTH({$field['sql_name']}), '-', DAY({$field['sql_name']}))) < CURDATE(),
-            CONCAT(YEAR(CURDATE()) + 1, '-', MONTH({$field['sql_name']}), '-', DAY({$field['sql_name']})),
-            CONCAT(YEAR(CURDATE()), '-', MONTH({$field['sql_name']}), '-', DAY({$field['sql_name']}))
-        ),
-        CURDATE()
-    )";
+    $anniversarySql = \CRM_Utils_Date::getAnniversarySql($field['sql_name']);
+    return "DATEDIFF($anniversarySql, CURDATE())";
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Even leap-year babies deserve a birthday party once in a while.

Before
----------------------------------------
Leap years were not being handled correctly in existing functions that calculate anniversaries. The days-to-next-anniversary function would return null for Feb 29th.

After
----------------------------------------
This fixes those and adds a new function to return the next upcoming anniversary date. Useful for scheduled communications.
