### PR TITLE
Add DAO entityID for sendSMSMessage() $smsProviderParams

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1321,7 +1321,7 @@ WHERE entity_id =%1 AND entity_table = %2";
     $recipient = $toPhoneNumber;
     $smsProviderParams['contact_id'] = $toID;
     $smsProviderParams['parent_activity_id'] = $activityID;
-    $smsProviderParams['dao_entity_id'] = $entityID;
+    $smsProviderParams['entity_id'] = $entityID;
 
     $providerObj = CRM_SMS_Provider::singleton(['provider_id' => $smsProviderParams['provider_id']]);
     $sendResult = $providerObj->send($recipient, $smsProviderParams, $tokenText, NULL, $sourceContactID);

--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1293,7 +1293,7 @@ WHERE entity_id =%1 AND entity_table = %2";
     $smsProviderParams,
     $activityID,
     $sourceContactID = NULL,
-    $entityID
+    $entityID = NULL
   ) {
     $toPhoneNumber = NULL;
     if ($smsProviderParams['To']) {

--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1282,6 +1282,7 @@ WHERE entity_id =%1 AND entity_table = %2";
    * @param int $activityID
    *   The activity ID that tracks the message.
    * @param int $sourceContactID
+   * @param int|null $entityID
    *
    * @return bool true on success
    * @throws CRM_Core_Exception
@@ -1291,7 +1292,8 @@ WHERE entity_id =%1 AND entity_table = %2";
     &$tokenText,
     $smsProviderParams,
     $activityID,
-    $sourceContactID = NULL
+    $sourceContactID = NULL,
+    $entityID
   ) {
     $toPhoneNumber = NULL;
     if ($smsProviderParams['To']) {
@@ -1319,6 +1321,7 @@ WHERE entity_id =%1 AND entity_table = %2";
     $recipient = $toPhoneNumber;
     $smsProviderParams['contact_id'] = $toID;
     $smsProviderParams['parent_activity_id'] = $activityID;
+    $smsProviderParams['dao_entity_id'] = $entityID;
 
     $providerObj = CRM_SMS_Provider::singleton(['provider_id' => $smsProviderParams['provider_id']]);
     $sendResult = $providerObj->send($recipient, $smsProviderParams, $tokenText, NULL, $sourceContactID);

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -386,7 +386,7 @@ FROM civicrm_action_schedule cas
         $swapLocale = empty($row->context['locale']) ? NULL : \CRM_Utils_AutoClean::swapLocale($row->context['locale']);
 
         if ($actionSchedule->mode === 'SMS' || $actionSchedule->mode === 'User_Preference') {
-          CRM_Utils_Array::extend($errors, self::sendReminderSms($tokenRow, $actionSchedule, $dao->contactID));
+          CRM_Utils_Array::extend($errors, self::sendReminderSms($tokenRow, $actionSchedule, $dao->contactID, $dao->entityID));
         }
 
         if ($actionSchedule->mode === 'Email' || $actionSchedule->mode === 'User_Preference') {
@@ -595,11 +595,12 @@ FROM civicrm_action_schedule cas
    * @param \Civi\Token\TokenRow $tokenRow
    * @param CRM_Core_DAO_ActionSchedule $schedule
    * @param int $toContactID
+   * @param int|null $entityID
    * @throws CRM_Core_Exception
    * @return array
    *   List of error messages.
    */
-  protected static function sendReminderSms($tokenRow, $schedule, $toContactID) {
+  protected static function sendReminderSms($tokenRow, $schedule, $toContactID, $entityID = NULL) {
     $toPhoneNumber = self::pickSmsPhoneNumber($toContactID);
     if (!$toPhoneNumber) {
       return ["sms_phone_missing" => "Couldn't find recipient's phone number."];
@@ -638,7 +639,8 @@ FROM civicrm_action_schedule cas
         $sms_body_text,
         $smsParams,
         $activity->id,
-        $userID
+        $userID,
+        $entityID
       );
     }
     catch (CRM_Core_Exception $e) {


### PR DESCRIPTION
Overview
----------------------------------------
When making a CaseActivity for a scheduled reminder, it would help if we can include entityID in $smsProviderParams to be able to trace which CaseActivity was related to a SMS delivery where `result = $apiMsgID` resides. With the added $smsProviderParams, we can use it that could help track whether an Inbound SMS is related to a CaseActivity from a scheduled reminder.

Before
----------------------------------------
Unable to track which CaseActivity a SMS delivery is related to.

After
----------------------------------------
Help track which CaseActivity a SMS delivery is related to using the DAO entityID

Comments
----------------------------------------
CiviCRM: 5.71.1
Here is a scenario:
Make CaseActivity, Scheduled Reminder Runs, `Outbound SMS` is created, `SMS delivery` is created, `Reminder Sent` is created.
We are looking into connecting `Inbound SMS` to the CaseActivity. Since we have `$apiMsgId` `result` in `Inbound SMS`, we can find out which `SMS delivery` it is connected, however, we cannot find out which CaseActivity it is connected. 

EntityID may not be the CaseActivity, but we devs can just query to check it.
