### PR TITLE
dev/core#5253 Fix double display of custom data

### DIFF
--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -182,7 +182,9 @@
 
         function buildRoleCustomData() {
           var roleId = $('select[name^=role_id]', $form).val() || [];
-          CRM.buildCustomData('Participant', roleId.join(), {/literal}{$roleCustomDataTypeID}{literal});
+          // If -1 is passed this will avoid https://lab.civicrm.org/dev/core/-/issues/5253
+          // as it is not a valid role ID but it is not 'empty'
+          CRM.buildCustomData('Participant', roleId.join() || -1, {/literal}{$roleCustomDataTypeID}{literal});
         }
 
         //build fee block


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5253 Fix double display of custom data

Before
----------------------------------------
Double load of custom data when role is empty

url looks like

https://dmaster.localhost:32353/civicrm/custom?type=Participant&subName=1&entityID=51


After
----------------------------------------
Fixed

url looks like 


https://dmaster.localhost:32353/civicrm/custom?type=Participant&subType=1&subName=1&entityID=51

Technical Details
----------------------------------------
We were passing js variable that resolved to 'any' rather than 'none' when role was unset

Comments
----------------------------------------
