### PR TITLE
dev/core#5271 - Fix javascripty bubble popups no longer working

### DIFF
--- a/templates/CRM/common/footer.tpl
+++ b/templates/CRM/common/footer.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{crmPermission permission='access CiviCRM'}
+{crmPermission has='access CiviCRM'}
   {include file="CRM/common/accesskeys.tpl"}
   {if $contactId}
     {include file="CRM/common/contactFooter.tpl"}
@@ -19,7 +19,7 @@
       <a href="{crmURL p='civicrm/a/#/status'}">{$footer_status_message}</a>
     </span>&nbsp;
     {else}
-      {crmPermission permission='administer CiviCRM'}
+      {crmPermission has='administer CiviCRM'}
     <span class="status crm-status-none">
       <a href="{crmURL p='civicrm/a/#/status'}">{ts}System Status{/ts}</a>
     </span>&nbsp;


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5271

Before
----------------------------------------
Bubble popups show inline with yellow background, old-school.

After
----------------------------------------
javascript bubble popup

Technical Details
----------------------------------------
crmPermission attribute names were changed but existing usage wasn't

Comments
----------------------------------------

