### PR TITLE
Enable CiviImport by default

### DIFF
--- a/ext/afform/mock/ang/mockBespoke.ang.php
+++ b/ext/afform/mock/ang/mockBespoke.ang.php
@@ -23,5 +23,4 @@ return [
       1 => 'crmUtil',
       2 => 'ngRoute',
     ],
-  'settings' => [],
 ];

--- a/ext/civiimport/ang/crmCiviimport.ang.php
+++ b/ext/civiimport/ang/crmCiviimport.ang.php
@@ -20,5 +20,4 @@ return [
     'ngRoute',
     'api4',
   ],
-  'settings' => [],
 ];

--- a/ext/message_admin/ang/crmMsgadm.ang.php
+++ b/ext/message_admin/ang/crmMsgadm.ang.php
@@ -30,7 +30,6 @@ return [
     'api4',
     'ui.bootstrap',
   ],
-  'settings' => [],
   'basePages' => [],
   'permissions' => [
     'edit message templates',

--- a/ext/oauth-client/ang/oauthUtil.ang.php
+++ b/ext/oauth-client/ang/oauthUtil.ang.php
@@ -11,7 +11,6 @@ return [
   // 'css' => ['ang/oauthUtil.css'],
   // 'partials' => ['ang/oauthUtil'],
   // 'requires' => ['crmUi', 'crmUtil'],
-  'settings' => [],
   'settingsFactory' => ['CRM_OAuth_Angular', 'getSettings'],
   'exports' => [
     'oauth-util-import' => 'A',

--- a/ext/oembed/ang/crmOembedSharing.ang.php
+++ b/ext/oembed/ang/crmOembedSharing.ang.php
@@ -14,7 +14,6 @@ return [
     'ang/crmOembedSharing',
   ],
   'requires' => ['crmUi', 'crmUtil'],
-  'settings' => [],
   'basePages' => [],
   'bundles' => ['bootstrap3'],
   'exports' => [

--- a/sql/civicrm_data/civicrm_extension.sqldata.php
+++ b/sql/civicrm_data/civicrm_extension.sqldata.php
@@ -65,4 +65,8 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_extension', 'INSERT IGNORE INTO
       'full_name' => 'civi_report',
       'name' => 'CiviReport',
     ],
+    [
+      'full_name' => 'civiimport',
+      'name' => 'Civi-Import',
+    ],
   ]);

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -56,7 +56,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
   protected function setUp(): void {
     parent::setUp();
     $originalExtensions = array_column(CRM_Extension_System::singleton()->getMapper()->getActiveModuleFiles(), 'fullName');
-    $this->assertEquals([], array_intersect($originalExtensions, $this->toggleExtensions), 'These extensions may be enabled and disabled during the test. The start-state and end-state should be the same. It appears that we have an unexpected start-state. Perhaps another test left us with a weird start-state?');
+    $this->assertEquals(['civiimport'], array_values(array_intersect($originalExtensions, $this->toggleExtensions)), 'These extensions may be enabled and disabled during the test. The start-state and end-state should be the same. It appears that we have an unexpected start-state. Perhaps another test left us with a weird start-state?');
     $this->enableBackgroundQueueOriginalValue = Civi::settings()->get('enableBackgroundQueue');
   }
 
@@ -73,8 +73,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ->addWhere('rule_table', '!=', 'civicrm_email')
       ->addWhere('dedupe_rule_group_id.name', '=', 'IndividualUnsupervised')->execute();
     foreach ($this->toggleExtensions as $ext) {
-      CRM_Extension_System::singleton()->getManager()->disable([$ext]);
-      CRM_Extension_System::singleton()->getManager()->uninstall([$ext]);
+      CRM_Extension_System::singleton()->getManager()->install([$ext]);
     }
     Civi::settings()->set('enableBackgroundQueue', $this->enableBackgroundQueueOriginalValue);
     parent::tearDown();


### PR DESCRIPTION
I thought we had done this but only on buildkit not here it seems - came up when looking  at documentation