### PR TITLE
dev/core#5273 - Fix incorrect alert on custom data form

### DIFF
--- a/templates/CRM/Custom/Form/Group.tpl
+++ b/templates/CRM/Custom/Form/Group.tpl
@@ -203,7 +203,7 @@ CRM.$(function($) {
 
   // When saving the form after removing sub-types
   $('.crm-warnDataLoss', $form).on('click', function() {
-    var submittedSubtypes = $('[name=extends_entity_column_value]', $form).val();
+    var submittedSubtypes = $('[name=extends_entity_column_value]', $form).val().split(',');
 
     var warning = false;
     $.each(defaultSubtypes, function(index, subtype) {


### PR DESCRIPTION
Overview
----------------------------------------
Altering custom fields used for subtypes throws up false or incorrect warning

Before
----------------------------------------
To replicate:

- Create a custom set `Used for` = Individual; Subtype = Parent, Staff
- Add a field to this set.
- Add a custom value for any parent contact.
- Open the edit form of the custom set, and save the form without making any change to the subtype.
- Eventhough no subtype is removed, the form gives an alert on save.

After
----------------------------------------
Fixed.

Comments
----------------------------------------
Gitlab: https://lab.civicrm.org/dev/core/-/issues/5273


