### PR TITLE
dev/core#5274 crash on directory settings form

### DIFF
--- a/CRM/Admin/Form/Setting/Path.php
+++ b/CRM/Admin/Form/Setting/Path.php
@@ -36,7 +36,7 @@ class CRM_Admin_Form_Setting_Path extends CRM_Admin_Form_Setting {
     'customTemplateDir' => CRM_Core_BAO_Setting::DIRECTORY_PREFERENCES_NAME,
     'customPHPPathDir' => CRM_Core_BAO_Setting::DIRECTORY_PREFERENCES_NAME,
     'extensionsDir' => CRM_Core_BAO_Setting::DIRECTORY_PREFERENCES_NAME,
-    'ext_max_depth' => CRM_Core_BAO_Setting::EXT,
+    'ext_max_depth' => 'Extension Preferences',
   ];
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
A fix for https://lab.civicrm.org/dev/core/-/issues/5274

The `::EXT` constant is no longer set to "civicrm" after DAO updates. 

I don't know why it might have been intended to have this value here?


Before
---------------------------
Crash on accessing the page.

After
-----------------------------
On Standalone:
- the existing setting value prepopulates fine 
- Setting value is updated on form submit

Haven't tested on other UFs.

Thanks @artfulrobot for spotting! :bug: 