### PR TITLE
ScheduledCommunications - Unit test + api fixes

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -2500,16 +2500,16 @@ class CRM_Utils_Date {
    * Sql expression to calculate the upcoming anniversary of a given date.
    *
    * The IF() accounts for the possibility that the date has already passed, & so skips to next year.
-   * The IFNULL() conditions account for leap year: if the date is Feb 29, and it's not currently a leap year, the first DATE() will return NULL so the second subtracts a day.
+   * The INTERVAL() functions correctly handle leap years.
    *
    * @param string $dateColumn
    * @return string
    */
   public static function getAnniversarySql(string $dateColumn): string {
     return "IF(
-      CONCAT(YEAR(CURDATE()), DATE_FORMAT($dateColumn, '-%m-%d')) < CURDATE(),
-      IFNULL(DATE(CONCAT(YEAR(CURDATE()) + 1, DATE_FORMAT($dateColumn, '-%m-%d'))), DATE(CONCAT(YEAR(CURDATE()) + 1, DATE_FORMAT(DATE_SUB($dateColumn, INTERVAL 1 DAY), '-%m-%d')))),
-      IFNULL(DATE(CONCAT(YEAR(CURDATE()), DATE_FORMAT($dateColumn, '-%m-%d'))), DATE(CONCAT(YEAR(CURDATE()), DATE_FORMAT(DATE_SUB($dateColumn, INTERVAL 1 DAY), '-%m-%d'))))
+      DATE_ADD($dateColumn, INTERVAL(YEAR(CURDATE()) - YEAR($dateColumn)) YEAR) < CURDATE(),
+      DATE_ADD($dateColumn, INTERVAL(1 + YEAR(CURDATE()) - YEAR($dateColumn)) YEAR),
+      DATE_ADD($dateColumn, INTERVAL(YEAR(CURDATE()) - YEAR($dateColumn)) YEAR)
     )";
   }
 

--- a/ext/scheduled_communications/Civi/Search/ActionMapping.php
+++ b/ext/scheduled_communications/Civi/Search/ActionMapping.php
@@ -42,7 +42,7 @@ class ActionMapping extends \Civi\ActionSchedule\MappingBase {
 
   public function getEntityTable(\CRM_Core_DAO_ActionSchedule $actionSchedule): string {
     $this->loadSavedSearch($actionSchedule->entity_value);
-    return \CRM_Core_DAO_AllCoreTables::getTableForEntityName($this->savedSearch['api_entity']);
+    return CoreUtil::getTableName($this->savedSearch['api_entity']);
   }
 
   public function modifyApiSpec(\Civi\Api4\Service\Spec\RequestSpec $spec) {
@@ -67,7 +67,7 @@ class ActionMapping extends \Civi\ActionSchedule\MappingBase {
       ->addWhere('is_current', '=', TRUE)
       // Limit to searches that have something to do with contacts
       // FIXME: Matching `api_params LIKE %contact%` is a cheap trick with no real understanding of the appropriateness of the SavedSearch for use as a Scheduled Reminder.
-      ->addClause('OR', ['api_entity', '=', 'Contact'], ['api_params', 'LIKE', '%contact%'])
+      ->addClause('OR', ['api_entity', 'IN', ['Contact', 'Individual', 'Household', 'Organization']], ['api_params', 'LIKE', '%contact%'])
       ->execute()->getArrayCopy();
   }
 
@@ -172,7 +172,7 @@ class ActionMapping extends \Civi\ActionSchedule\MappingBase {
       $sqlSelect['casDateField'] = "'" . \CRM_Utils_Type::escape($schedule->absolute_date, 'String') . "'";
     }
     else {
-      $sqlSelect['casDateField'] = SqlExpression::convert($schedule->start_action_date)->render($apiQuery);
+      $sqlSelect['casDateField'] = $this->getSelectExpression($schedule->start_action_date)['expr']->render($apiQuery);
     }
     return $sqlSelect;
   }

--- a/ext/scheduled_communications/phpunit.xml.dist
+++ b/ext/scheduled_communications/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" cacheResult="false" bootstrap="tests/phpunit/bootstrap.php">
+  <testsuites>
+    <testsuite name="ScheduledCommunications Tests">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/ext/scheduled_communications/tests/phpunit/Civi/ScheduledCommunications/SendTest.php
+++ b/ext/scheduled_communications/tests/phpunit/Civi/ScheduledCommunications/SendTest.php
@@ -1,0 +1,117 @@
+<?php
+namespace Civi\ScheduledCommunications;
+
+use CRM_ScheduledCommunications_ExtensionUtil as E;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class SendTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  use \Civi\Test\Api4TestTrait;
+
+  /**
+   * @var CiviMailUtils
+   */
+  public $mut;
+
+  /**
+   * Setup for tests.
+   */
+  public function setUp(): void {
+    parent::setUp();
+
+    $this->mut = new \CiviMailUtils($this, TRUE);
+  }
+
+  public function setUpHeadless(): CiviEnvBuilder {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function testBirthdayMessage():void {
+    $lastName = uniqid();
+    $sampleContacts = [
+      ['first_name' => 'A', 'last_name' => $lastName, 'email_primary.email' => "a@$lastName", 'birth_date' => '2020-02-29'],
+      ['first_name' => 'B', 'last_name' => $lastName, 'email_primary.email' => "b@$lastName", 'birth_date' => '2019-02-19'],
+      ['first_name' => 'C', 'last_name' => $lastName, 'email_primary.email' => "c@$lastName", 'birth_date' => '2018-02-09', 'is_deceased' => TRUE],
+    ];
+    $this->saveTestRecords('Individual', [
+      'records' => $sampleContacts,
+    ]);
+    $savedSearch = $this->createTestRecord('SavedSearch', [
+      'label' => __FUNCTION__,
+      'api_entity' => 'Individual',
+      'api_params' => [
+        'version' => 4,
+        'select' => ['id', 'first_name', 'last_name', 'NEXTANNIV(birth_date) AS upcoming_birthday'],
+        'where' => [['last_name', '=', $lastName]],
+      ],
+    ]);
+    $actionSchedule = $this->createTestRecord('ActionSchedule', [
+      'title' => __FUNCTION__,
+      'mapping_id:name' => 'saved_search',
+      'entity_value' => $savedSearch['id'],
+      'entity_status' => 'id',
+      'start_action_offset' => 1,
+      'start_action_unit' => 'day',
+      'start_action_condition' => 'before',
+      'start_action_date' => 'upcoming_birthday',
+      'body_html' => '<p>Your birthday is tomorrow!</p>',
+      'subject' => 'Happy birthday {contact.first_name}!',
+    ]);
+    $this->assertCronRuns([
+      [
+        // No birthdays tomorrow
+        'time' => '2025-04-02 04:00:00',
+        'recipients' => [],
+        'subjects' => [],
+      ],
+      [
+        'time' => '2025-02-18 04:00:00',
+        'recipients' => [["b@$lastName"]],
+        'subjects' => ['Happy birthday B!'],
+      ],
+      [
+        'time' => '2025-02-08 04:00:00',
+        'recipients' => [],
+        'subjects' => [],
+      ],
+      [
+        // On a non-leap-year, birthday is the 28th
+        'time' => '2025-02-27 04:00:00',
+        'recipients' => [["a@$lastName"]],
+        'subjects' => ['Happy birthday A!'],
+      ],
+    ]);
+  }
+
+  /**
+   * Run a series of cron jobs and make an assertion about email deliveries.
+   *
+   * @param array $cronRuns
+   *   array specifying when to run cron and what messages to expect; each item is an array with keys:
+   *   - time: string, e.g. '2012-06-15 21:00:01'
+   *   - recipients: array(array(string)), list of email addresses which should receive messages
+   *
+   * @throws \CRM_Core_Exception
+   * @noinspection DisconnectedForeachInstructionInspection
+   */
+  public function assertCronRuns(array $cronRuns): void {
+    foreach ($cronRuns as $cronRun) {
+      \CRM_Utils_Time::setTime($cronRun['time']);
+      civicrm_api3('job', 'send_reminder');
+      $this->mut->assertRecipients($cronRun['recipients']);
+      if (array_key_exists('subjects', $cronRun)) {
+        $this->mut->assertSubjects($cronRun['subjects']);
+      }
+      $this->mut->clearMessages();
+    }
+  }
+
+}

--- a/ext/scheduled_communications/tests/phpunit/bootstrap.php
+++ b/ext/scheduled_communications/tests/phpunit/bootstrap.php
@@ -1,0 +1,65 @@
+<?php
+
+ini_set('memory_limit', '2G');
+
+// phpcs:disable
+eval(cv('php:boot --level=classloader', 'phpcode'));
+// phpcs:enable
+// Allow autoloading of PHPUnit helper classes in this extension.
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->add('CRM_', [__DIR__ . '/../..', __DIR__]);
+$loader->addPsr4('Civi\\', [__DIR__ . '/../../Civi', __DIR__ . '/Civi']);
+$loader->add('api_', [__DIR__ . '/../..', __DIR__]);
+$loader->addPsr4('api\\', [__DIR__ . '/../../api', __DIR__ . '/api']);
+
+$loader->register();
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return mixed
+ *   Response output (if the command executed normally).
+ *   For 'raw' or 'phpcode', this will be a string. For 'json', it could be any JSON value.
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv(string $cmd, string $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => STDERR];
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv('CV_OUTPUT=json');
+
+  // Execute `cv` in the original folder. This is a work-around for
+  // phpunit/codeception, which seem to manipulate PWD.
+  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== '/*BEGINPHP*/' || substr(trim($result), -10) !== '/*ENDPHP*/') {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}


### PR DESCRIPTION
Overview
----------------------------------------
This adds the word's first unit test for the ScheduledCommunications extension, which instantly surfaced some bugs.

Technical Details
----------------------------------------
Bugs fixed in this PR:
- Fixes getAnniversarySql to correctly handle leap years ([again](https://github.com/civicrm/civicrm-core/pull/30338))
- Fixes Search/ActionMapping when using sql functions
- Fixes Search/ActionMapping to handle Individual/Household/Organization api4 entities

Comments
----------------------------------------
Putting up for 5.75 so this goes in the same version as #30338 which only partially fixed the leap-year problems.
