### PR TITLE
dev/core#4367 Update apiv4 Order.create membership entity support

### DIFF
--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -99,6 +99,9 @@ function civicrm_api3_order_create(array $params): array {
           $lineItem['membership_type_id'] = CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'membership_type_id', $lineItems['params']['membership_type_id']);
         }
         $lineIndex = $index . '+' . $innerIndex;
+        if (!empty($lineItem['financial_type_id']) && !is_numeric($lineItem['financial_type_id'])) {
+          $lineItem['financial_type_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', $lineItem['financial_type_id']);
+        }
         $order->setLineItem($lineItem, $lineIndex);
         $order->addLineItemToEntityParameters($lineIndex, $index);
       }

--- a/ext/contributioncancelactions/tests/phpunit/CancelTest.php
+++ b/ext/contributioncancelactions/tests/phpunit/CancelTest.php
@@ -216,7 +216,7 @@ class CancelTest extends TestCase implements HeadlessInterface, HookInterface, T
   }
 
   /**
-   * Test that a cancel from paypal pro results in an order being cancelled.
+   * Test that a cancel from PayPal pro results in an order being cancelled.
    *
    * @throws \CRM_Core_Exception
    */
@@ -256,8 +256,7 @@ class CancelTest extends TestCase implements HeadlessInterface, HookInterface, T
    */
   public function testCancelOrderWithParticipantCancelled(): void {
     $this->markTestIncomplete('For unknown reasons this failed if run after the cancelled variation of this test');
-    $status = 'Cancelled';
-    $this->createAndUpdateContribution($status);
+    $this->createAndUpdateContribution('Cancelled');
   }
 
   /**

--- a/tests/phpunit/CRM/Financial/BAO/OrderTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/OrderTest.php
@@ -11,8 +11,10 @@
 
 use Civi\Api4\Contribution;
 use Civi\Api4\LineItem;
+use Civi\Api4\Membership;
 use Civi\Api4\Order;
 use Civi\Api4\Participant;
+use Civi\Api4\PriceSet;
 use Civi\Test\EventTestTrait;
 
 /**
@@ -60,6 +62,161 @@ class CRM_Financial_BAO_OrderTest extends CiviUnitTestCase {
       ->execute()->single();
     $this->assertEquals($this->ids['Contact']['individual_0'], $participant['contact_id']);
 
+  }
+
+  /**
+   * Test create order api for membership
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testCreateOrderForMembership(): void {
+    $this->setUpMembershipPriceSet();
+    $contribution = Order::create()
+      ->setContributionValues([
+        'contact_id' => $this->individualCreate(),
+        'receive_date' => '2010-01-20',
+        'financial_type_id:name' => 'Member Dues',
+      ])
+      ->addLineItem([
+        'price_field_value_id' => $this->ids['PriceFieldValue']['membership_first'],
+        'entity_id.join_date' => '2006-01-21',
+        'entity_id.start_date' => '2006-01-21',
+        'entity_id.end_date' => '2006-12-21',
+        'entity_id.source' => 'Payment',
+      ])
+      ->execute()->first();
+
+    $lineItem = LineItem::get()
+      ->addWhere('contribution_id', '=', $contribution['id'])
+      ->execute()->single();
+    $this->assertEquals('civicrm_membership', $lineItem['entity_table']);
+
+    // The line item links the membership to the contribution.
+    $this->assertEquals(1, $lineItem['membership_num_terms']);
+    $this->assertEquals(100, $lineItem['unit_price']);
+    $this->assertEquals(100, $lineItem['line_total']);
+    $this->assertEquals(1, $lineItem['qty']);
+
+    $membership = Membership::get()
+      ->addWhere('id', '=', $lineItem['entity_id'])
+      ->execute()->single();
+    $this->assertEquals('2006-12-21', $membership['end_date']);
+    // A membership payment should have been created for legacy compatibility.
+    $this->callAPISuccessGetSingle('MembershipPayment', ['membership_id' => $lineItem['entity_id'], 'contribution_id' => $contribution['id']]);
+  }
+
+  /**
+   * Test creating an order containing items from 2 price sets plus an ad hoc amount.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testCreateMixedPriceSetOrder(): void {
+    $this->setUpMembershipPriceSet();
+    $this->setUpGenericPriceSet();
+
+    Order::create()
+      ->setContributionValues([
+        'contact_id' => $this->individualCreate(),
+        'receive_date' => '2010-01-20',
+        'financial_type_id:name' => 'Member Dues',
+      ])
+      ->addLineItem([
+        'price_field_value_id' => $this->ids['PriceFieldValue']['membership_first'],
+      ])
+      ->addLineItem([
+        'price_field_value_id' => $this->ids['PriceFieldValue']['hundred'],
+      ])
+      ->addLineItem([
+        // This will assume the order financial type & quantity = 1,
+        'line_total' => 500,
+        'description' => 'Some extra dosh',
+      ])
+      ->execute()->first();
+    $contribution = Contribution::get(FALSE)
+      ->addWhere('contact_id', '=', $this->ids['Contact']['individual_0'])
+      ->execute()->single();
+    $this->assertEquals(700, $contribution['total_amount']);
+    $lineItem = (array) LineItem::get()
+      ->addWhere('contribution_id', '=', $contribution['id'])
+      ->addSelect('*', 'price_field_value_id.*', 'price_field_id.*')
+      ->execute();
+    $this->assertCount(3, $lineItem);
+    $firstItem = array_pop($lineItem);
+    $secondItem = array_pop($lineItem);
+    $thirdItem = array_pop($lineItem);
+    $this->assertEquals($this->getDefaultPriceSetID(), $firstItem['price_field_id.price_set_id']);
+    $this->assertEquals($this->ids['PriceSet']['generic'], $secondItem['price_field_id.price_set_id']);
+    $this->assertEquals($this->ids['PriceSet']['membership'], $thirdItem['price_field_id.price_set_id']);
+  }
+
+  public function setUpGenericPriceSet(): void {
+    $this->createTestEntity('PriceSet', [
+      'name' => 'generic_price_set',
+      'title' => 'generic price set',
+      'is_quick_config' => TRUE,
+      'extends' => 2,
+    ], 'generic')['id'];
+
+    $this->createTestEntity('PriceField', [
+      'price_set_id:name' => 'generic_price_set',
+      'name' => 'generic_price_set',
+      'label' => 'generic_price_set',
+      'html_type' => 'Radio',
+    ], 'generic');
+    $this->createTestEntity('PriceFieldValue', [
+      'price_field_id.name' => 'generic_price_set',
+      'name' => 'hundred',
+      'label' => 'Hundred',
+      'amount' => 100,
+      'financial_type_id:name' => 'Donation',
+    ], 'hundred');
+    $this->createTestEntity('PriceFieldValue', [
+      'price_field_id.name' => 'generic_price_set',
+      'name' => 'Thousand',
+      'label' => 'Thousand',
+      'amount' => 1000,
+      'financial_type_id:name' => 'Donation',
+    ], 'thousand');
+  }
+
+  /**
+   *
+   */
+  public function setUpMembershipPriceSet(): void {
+    $this->membershipTypeCreate(['name' => 'First'], 'first');
+    $this->membershipTypeCreate(['name' => 'Second'], 'second');
+    $this->createTestEntity('PriceSet', [
+      'name' => 'price_set',
+      'title' => 'membership price set',
+      'is_quick_config' => TRUE,
+      'extends' => 2,
+    ], 'membership')['id'];
+
+    $this->createTestEntity('PriceField', [
+      'price_set_id:name' => 'price_set',
+      'name' => 'membership_first',
+      'label' => 'Membership First',
+      'html_type' => 'Radio',
+    ], 'membership_first');
+    $this->createTestEntity('PriceFieldValue', [
+      'price_field_id.name' => 'membership_first',
+      'name' => 'membership_first',
+      'label' => 'Membership Type',
+      'amount' => 100,
+      'financial_type_id:name' => 'Member Dues',
+      'membership_type_id.name' => 'First',
+    ], 'membership_first');
+  }
+
+  /**
+   * @return int
+   * @throws \CRM_Core_Exception
+   */
+  public function getDefaultPriceSetID(): int {
+    return PriceSet::get(FALSE)
+      ->addWhere('name', '=', 'default_contribution_amount')
+      ->execute()
+      ->first()['id'];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Update Order.create membership entity support, add test & support for mixed price set line items

Before
----------------------------------------
Creating Membership entity through new apiv4 Order create api untested

After
----------------------------------------
tests added  - the second one adds 3 line items, 2 from different prices sets & the last is minimally described & uses the default price set

![image](https://github.com/civicrm/civicrm-core/assets/336308/4010d0b7-af83-4532-ba95-483be1f6ca61)


Technical Details
----------------------------------------
Minor fixes include
- moving handling for financial_type_id being text back into the v3 api (out of the shared code)
- look up financial_type_id, membership type ID, number of terms, when only price_field_value_id provided
- carry over contribution values if not provided and entity_id not provided (e.g contact_id)
- fix failure to return contribution result

Comments
----------------------------------------
