### PR TITLE
dev/core#5219 Remove "Additional Group for Export" option

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -101,15 +101,6 @@ class CRM_Export_BAO_Export {
       $exportParams['postal_mailing_export']['postal_mailing_export'] == 1
     );
 
-    if (!$selectAll && $componentTable && !empty($exportParams['additional_group'])) {
-      // If an Additional Group is selected, then all contacts in that group are
-      // added to the export set (filtering out duplicates).
-      // Really - the calling function could do this ... just saying
-      // @todo take a whip to the calling function.
-      CRM_Core_DAO::executeQuery("
-INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_contact gc WHERE gc.group_id = {$exportParams['additional_group']} ON DUPLICATE KEY UPDATE {$componentTable}.contact_id = gc.contact_id"
-      );
-    }
     // rectify params to what proximity search expects if there is a value for prox_distance
     // CRM-7021
     // @todo - move this back to the calling functions

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -187,11 +187,6 @@ FROM   {$this->_componentTable}
     if ($this->_exportMode == self::CONTACT_EXPORT) {
       $this->addRadio('mergeOption', ts('Merge Options'), $mergeOptions, [], '<br/>', FALSE, $mergeOptionsJS);
       $this->addGroup($postalMailing, 'postal_mailing_export', ts('Postal Mailing Export'), '<br/>');
-
-      $this->addElement('select', 'additional_group', ts('Additional Group for Export'),
-        ['' => ts('- select group -')] + CRM_Core_PseudoConstant::nestedGroup(),
-        ['class' => 'crm-select2 huge']
-      );
     }
 
     $this->buildMapping();

--- a/templates/CRM/Export/Form/Select.tpl
+++ b/templates/CRM/Export/Form/Select.tpl
@@ -72,11 +72,6 @@
         &nbsp;{$form.postal_mailing_export.html}
         {ts}Exclude contacts with "do not mail" privacy, no street address, or who are deceased.{/ts}
     </div>
-    <br/>
-    <div class="label crm-label-additionalGroup">{$form.additional_group.label}</div>
-    <div class="content crm-content-additionalGroup">
-        &nbsp;{$form.additional_group.html}
-    </div>
   <div class="clear"></div>
   </div>
   {/if}

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -1184,7 +1184,6 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
         'addressee' => '2',
         'addressee_other' => 'random string {contact.display_name}',
         'mergeOption' => '1',
-        'additional_group' => '',
         'mapping' => '',
       ],
     ]);


### PR DESCRIPTION
Overview
----------------------------------------
When exporting, there is a barely used option Additional Group for Export which cause a DB: Error if we choose the fields to export. This seems to be broken for a long time.

As this doesn't seems to be used much and it's quite easy to choose multiple group to export, I propose to simply remove the option.

Before
----------------------------------------
The option is there:

![Screenshot_2024-05-16_at_10-31-02_Find_Contacts_CiviCRM_Sandbox_on_Drupal](https://github.com/civicrm/civicrm-core/assets/372004/a3ac88c1-c509-4180-853f-6c287b3615ae)


After
----------------------------------------
No more option:

![Screenshot 2024-06-07 at 15-06-50 Find Contacts ‹ samuel dev501 symbiodev xyz — WordPress](https://github.com/civicrm/civicrm-core/assets/372004/43f53bf8-5a39-47f9-a574-9363332f9e47)

