### PR TITLE
Fix dev/core#5278 - Missing page title on angular pages

### DIFF
--- a/templates/CRM/common/CMSPrint.tpl
+++ b/templates/CRM/common/CMSPrint.tpl
@@ -32,7 +32,7 @@
     {/if}
 {else}
     {if $pageTitle}
-      <div class="crm-title">
+      <div class="crm-title crm-page-title-wrapper">
         <h1 class="title">{if $isDeleted}
           <del>{/if}{$pageTitle}{if $isDeleted}</del>{/if}</h1>
       </div>

--- a/templates/CRM/common/joomla.tpl
+++ b/templates/CRM/common/joomla.tpl
@@ -25,7 +25,7 @@
     {/if}
 
     {if $pageTitle}
-      <div class="crm-title">
+      <div class="crm-title crm-page-title-wrapper">
         <h1 class="title">{if $isDeleted}<del>{/if}{$pageTitle}{if $isDeleted}</del>{/if}</h1>
       </div>
     {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes missing page title on CMSs other than D7.

Before
----------------------------------------
Angular pages such as FormBuilder forms display "CiviCRM" as the title on D9, WP & Joomla (although it works correctly on D7).

After
----------------------------------------
Correct title displayed.

Technical Details
-----
This regressed probably due to a combination of https://github.com/civicrm/civicrm-core/pull/28560 and https://github.com/civicrm/civicrm-core/pull/29694