### PR TITLE
dev/core#224 Fix participant mail to include additional participant data on pay later

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2405,16 +2405,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       ];
       $values['location'] = CRM_Core_BAO_Location::getValues($locationParams);
 
-      $ufJoinParams = [
-        'entity_table' => 'civicrm_event',
-        'entity_id' => $eventID,
-        'module' => 'CiviEvent',
-      ];
-
-      [$custom_pre_id, $custom_post_ids] = CRM_Core_BAO_UFJoin::getUFGroupIds($ufJoinParams);
-
-      $values['custom_pre_id'] = $custom_pre_id;
-      $values['custom_post_id'] = $custom_post_ids;
       //for tasks 'Change Participant Status' and 'Update multiple Contributions' case
       //and cases involving status updation through ipn
       // whatever that means!

--- a/CRM/Core/WorkflowMessage/ProfileTrait.php
+++ b/CRM/Core/WorkflowMessage/ProfileTrait.php
@@ -1,0 +1,206 @@
+<?php
+
+use Civi\Api4\UFGroup;
+use Civi\Api4\UFJoin;
+
+/**
+ * Trait for participant workflow classes.
+ *
+ * @method string getNote()
+ */
+trait CRM_Core_WorkflowMessage_ProfileTrait {
+
+  /**
+   * The profiles array is not currently assigned / used but might
+   * be saner than the ones that are.
+   *
+   * @var array
+   */
+  protected $profiles;
+
+  /**
+   * The note, if any, from the session.
+   *
+   * As multiple notes can be attached to a participant records we only want
+   * to render a note as part of the profile if the user entered it in the form submission.
+   *
+   * @var string
+   */
+  protected string $note = '';
+
+  /**
+   * @var array
+   *
+   * @scope tplParams as customPre
+   */
+  public $profilesPreForm;
+
+  /**
+   * @var array
+   *
+   * @scope tplParams as customPost
+   */
+  public $profilesPostForm;
+
+  /**
+   * @var array
+   *
+   * @scope tplParams as customPre_grouptitle
+   */
+  public $profileTitlesPreForm;
+
+  /**
+   * @var array
+   *
+   * @scope tplParams as customPost_grouptitle
+   */
+  public $profileTitlesPostForm;
+
+  /**
+   * @var array
+   *
+   * @scope tplParams as customProfile
+   */
+  public $profilesAdditionalParticipants;
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function getProfiles(): array {
+    if (!isset($this->profiles)) {
+      if ($this->getEventID()) {
+        $joins = (array) UFJoin::get(FALSE)
+          ->addWhere('entity_table', '=', 'civicrm_event')
+          ->addWhere('entity_id', '=', $this->getEventID())
+          ->addWhere('is_active', '=', TRUE)
+          ->addSelect('module', 'weight', 'uf_group_id')
+          ->addOrderBy('weight')
+          ->execute();
+        $profiles = UFGroup::get(FALSE)
+          ->addWhere('id', 'IN', CRM_Utils_Array::collect('uf_group_id', $joins))
+          ->execute()->indexBy('id');
+        foreach ($joins as $join) {
+          // The thing we want to order by is on the join not the profile
+          // hence we iterate the joins.
+          $profile = $profiles[$join['uf_group_id']];
+          $profile['placement'] = $join['weight'] === 1 ? 'pre' : 'post';
+          $profile['is_additional_participant'] = $join['module'] === 'CiviEvent_Additional';
+          if ($join['module'] === 'CiviEvent') {
+            $profile['participant_id'] = $this->getParticipantID();
+            try {
+              $fields = CRM_Event_BAO_Event::getProfileDisplay([$profile['id']],
+                $this->getParticipant()['contact_id'] ?? 0,
+                $this->getParticipantID(),
+                $this->getNote(),
+              );
+            }
+            catch (CRM_Core_Exception $e) {
+              // This could be false if the person does not have permission. This came up in
+              // the SelfSvcTransfer workflow via test testTransferAnonymous & it seems OK
+              // to not include profile data in this scenario ... probably.
+              $fields = [];
+            }
+            $profile['fields'] = $fields ? $fields[0] : [];
+          }
+          elseif ($profile['is_additional_participant']) {
+            foreach ($this->getParticipants() as $participant) {
+              // Only show the other participants for the primary participant.
+              if ($this->getIsPrimary() && !$participant['is_primary']) {
+                if (!isset($profile['fields'])) {
+                  $profile['fields'] = [];
+                }
+                $fields = CRM_Event_BAO_Event::getProfileDisplay([$profile['id']],
+                  $participant['contact']['id'],
+                  $participant['id'],
+                  $this->getNote()
+                );
+                $profile['fields'][] = $fields ? $fields[0] : [];
+
+              }
+            }
+          }
+
+          $this->profiles[] = $profile;
+        }
+      }
+    }
+    return $this->profiles;
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function getProfilesPreForm(): array {
+    $profiles = [];
+    foreach ($this->getProfilesByPlacement('pre') as $profile) {
+      $profiles[] = $profile['fields'];
+    }
+    return $profiles;
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function getProfileTitlesPreForm(): array {
+    $titles = [];
+    foreach ($this->getProfilesByPlacement('pre') as $profile) {
+      $titles[] = $profile['frontend_title'];
+    }
+    return $titles;
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function getProfileTitlesPostForm(): array {
+    $titles = [];
+    foreach ($this->getProfilesByPlacement('post') as $profile) {
+      $titles[] = $profile['frontend_title'];
+    }
+    return $titles;
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function getProfilesPostForm(): array {
+    $profiles = [];
+    foreach ($this->getProfilesByPlacement('post') as $profile) {
+      $profiles[] = $profile['fields'];
+    }
+    return $profiles;
+  }
+
+  public function getProfilesAdditionalParticipants(): array {
+    $profiles = [];
+    foreach ($this->getProfiles() as $profile) {
+      if ($profile['is_additional_participant'] && !empty($profile['fields'])) {
+        foreach ($profile['fields'] as $participantIndex => $fields) {
+          $profiles['profile'][$participantIndex][$profile['id']] = $profile['fields'][$participantIndex];
+        }
+        $profiles['title'][$profile['id']] = $profile['title'];
+      }
+    }
+    return $profiles;
+  }
+
+  /**
+   * @param string $placement
+   *   pre or post.
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  private function getProfilesByPlacement(string $placement): array {
+    $profiles = [];
+    foreach ($this->getProfiles() as $profile) {
+      if (!empty($profile['participant_id']) && $profile['participant_id'] === $this->getParticipantID()) {
+        if ($profile['placement'] === $placement) {
+          $profiles[] = $profile;
+        }
+      }
+    }
+    return $profiles;
+  }
+
+}

--- a/CRM/Core/WorkflowMessage/ProfileTrait.php
+++ b/CRM/Core/WorkflowMessage/ProfileTrait.php
@@ -109,11 +109,19 @@ trait CRM_Core_WorkflowMessage_ProfileTrait {
                 if (!isset($profile['fields'])) {
                   $profile['fields'] = [];
                 }
-                $fields = CRM_Event_BAO_Event::getProfileDisplay([$profile['id']],
-                  $participant['contact']['id'],
-                  $participant['id'],
-                  $this->getNote()
-                );
+                try {
+                  $fields = CRM_Event_BAO_Event::getProfileDisplay([$profile['id']],
+                    $participant['contact']['id'],
+                    $participant['id'],
+                    $this->getNote()
+                  );
+                }
+                catch (CRM_Core_Exception $e) {
+                  // This could be false if the person does not have permission. This came up in
+                  // the SelfSvcTransfer workflow via test testTransferAnonymous & it seems OK
+                  // to not include profile data in this scenario ... probably.
+                  $fields = [];
+                }
                 $profile['fields'][] = $fields ? $fields[0] : [];
 
               }

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1074,7 +1074,7 @@ WHERE civicrm_event.is_active = 1
     ];
 
     //get the params submitted by participant.
-    $participantParams = CRM_Utils_Array::value($participantId, $values['params'], []);
+    $participantParams = $values['params'][$participantId] ?? [];
 
     if (!$returnMessageText) {
       //send notification email if field values are set (CRM-1941)
@@ -1115,55 +1115,10 @@ WHERE civicrm_event.is_active = 1
       $notifyEmail = CRM_Utils_Array::valueByRegexKey('/^email-/', $participantParams) ?? $email;
       //send email only when email is present
       if (isset($notifyEmail) || $returnMessageText) {
-        $preProfileID = $values['custom_pre_id'] ?? NULL;
-        $postProfileID = $values['custom_post_id'] ?? NULL;
-
-        if (!empty($values['params']['additionalParticipant'])) {
-          $preProfileID = CRM_Utils_Array::value('additional_custom_pre_id', $values, $preProfileID);
-          $postProfileID = CRM_Utils_Array::value('additional_custom_post_id', $values, $postProfileID);
-        }
-
-        $profilePre = self::buildCustomDisplay($preProfileID,
-          'customPre',
-          $contactID,
-          $template,
-          $participantId,
-          $isTest,
-          TRUE,
-          $participantParams
-        );
-
-        $profilePost = self::buildCustomDisplay($postProfileID,
-          'customPost',
-          $contactID,
-          $template,
-          $participantId,
-          $isTest,
-          TRUE,
-          $participantParams
-        );
-
-        // @todo - the goal is that all params available to the message template are explicitly defined here rather than
-        // 'in a smattering of places'. Note that leakage can happen between mailings when not explicitly defined.
-        if ($postProfileID) {
-          $customPostTitles = empty($profilePost[1]) ? NULL : [];
-          foreach ($postProfileID as $offset => $id) {
-            $customPostTitles[$offset] = CRM_Core_BAO_UFGroup::getFrontEndTitle((int) $id);
-          }
-        }
-        else {
-          $customPostTitles = NULL;
-        }
         $tplParams = array_merge($values, $participantParams, [
           'email' => $notifyEmail,
           'confirm_email_text' => $values['event']['confirm_email_text'] ?? NULL,
           'isShowLocation' => $values['event']['is_show_location'] ?? NULL,
-          'customPre' => $profilePre[0],
-          'customPre_grouptitle' => empty($profilePre[1]) ? NULL : [CRM_Core_BAO_UFGroup::getFrontEndTitle((int) $preProfileID)],
-          'customPost' => $profilePost[0],
-          'customPost_grouptitle' => $customPostTitles,
-          'participantID' => $participantId,
-          'contactID' => $contactID,
           'credit_card_number' => CRM_Utils_System::mungeCreditCard(CRM_Utils_Array::value('credit_card_number', $participantParams)),
           'credit_card_exp_date' => CRM_Utils_Date::mysqlToIso(CRM_Utils_Date::format(CRM_Utils_Array::value('credit_card_exp_date', $participantParams))),
           'selfcancelxfer_time' => abs($values['event']['selfcancelxfer_time']),
@@ -1174,10 +1129,12 @@ WHERE civicrm_event.is_active = 1
         // CRM-13890 : NOTE wait list condition need to be given so that
         // wait list message is shown properly in email i.e. WRT online event registration template
         if (empty($tplParams['participant_status']) && empty($values['params']['isOnWaitlist'])) {
+          // @todo - this is no longer used in the core template - deprecate & remove
           $statusId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $participantId, 'status_id', 'id', TRUE);
           $tplParams['participant_status'] = CRM_Event_PseudoConstant::participantStatus($statusId, NULL, 'label');
         }
         //CRM-15754 - if participant_status contains status ID
+        // @todo - this is no longer used in the core template - deprecate & remove
         elseif (!empty($tplParams['participant_status']) && CRM_Utils_Rule::integer($tplParams['participant_status'])) {
           $tplParams['participant_status'] = CRM_Event_PseudoConstant::participantStatus($tplParams['participant_status'], NULL, 'label');
         }
@@ -1191,6 +1148,7 @@ WHERE civicrm_event.is_active = 1
             'participantID' => (int) $participantId,
             'eventID' => (int) $values['event']['id'],
             'contactID' => (int) $contactID,
+            'note' => $participantParams['note'] ?? '',
           ],
         ];
 
@@ -1293,7 +1251,7 @@ WHERE civicrm_event.is_active = 1
 
     $groups = $participantParams['group'] ?? NULL;
     $note = $participantParams['note'] ?? NULL;
-    $displayValues = self::getProfileDisplay($profileIds, $cid, $participantId, $isTest, $groups, $note);
+    $displayValues = self::getProfileDisplay($profileIds, $cid, $participantId, $note, $groups, $isTest);
 
     $groupTitles = UFGroup::get(FALSE)
       ->addWhere('id', 'IN', $profileIds)
@@ -2312,7 +2270,7 @@ WHERE  ce.loc_block_id = $locBlockId";
    * @throws \CRM_Core_Exception
    * @throws \Civi\Core\Exception\DBQueryException
    */
-  public static function getProfileDisplay(array $profileIds, int $cid, int $participantId, bool $isTest = FALSE, ?array $groups = NULL, ?string $note = NULL): ?array {
+  public static function getProfileDisplay(array $profileIds, int $cid, int $participantId, ?string $note = NULL, ?array $groups = NULL, bool $isTest = FALSE): ?array {
     foreach ($profileIds as $gid) {
       if (CRM_Core_BAO_UFGroup::filterUFGroups($gid, $cid)) {
         $values = [];

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -2349,8 +2349,8 @@ WHERE  ce.loc_block_id = $locBlockId";
         //dev/event#10
         //If the event profile includes a note field and the submitted value of
         //that field is "", then remove the old note returned by getValues.
-        if ($note === '') {
-          $noteKeyPos = array_search('note', array_keys($fields));
+        if ($note === '' && array_key_exists('note', $fields)) {
+          $noteKeyPos = array_search('note', array_keys($fields), TRUE);
           $valuesKeys = array_keys($values);
           $values[$valuesKeys[$noteKeyPos]] = "";
         }

--- a/CRM/Event/WorkflowMessage/EventOfflineReceipt.php
+++ b/CRM/Event/WorkflowMessage/EventOfflineReceipt.php
@@ -80,7 +80,7 @@ class CRM_Event_WorkflowMessage_EventOfflineReceipt extends GenericWorkflowMessa
    * @throws \CRM_Core_Exception
    */
   protected function getFieldsToLoadForParticipant(): array {
-    $fields = ['registered_by_id', 'role_id', 'event_id', 'event_id.event_type_id'];
+    $fields = ['registered_by_id', 'role_id', 'event_id', 'event_id.event_type_id', 'contact_id'];
     // Request the relevant custom fields. This list is
     // restricted by view-ability but we don't have the information
     // at this point to filter by the finer tuned entity extends information

--- a/CRM/Event/WorkflowMessage/ParticipantTrait.php
+++ b/CRM/Event/WorkflowMessage/ParticipantTrait.php
@@ -334,6 +334,9 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
           // If the only tax rate charged is 0% then no tax breakdown is returned.
           $participant['tax_rate_breakdown'] = [];
         }
+        if (!isset($participant['line_items'])) {
+          $participant['line_items'] = [];
+        }
         $count++;
       }
       $this->participants = $participants;

--- a/CRM/Event/WorkflowMessage/ParticipantTrait.php
+++ b/CRM/Event/WorkflowMessage/ParticipantTrait.php
@@ -12,6 +12,8 @@ use Civi\Api4\Participant;
 trait CRM_Event_WorkflowMessage_ParticipantTrait {
 
   use CRM_Contribute_WorkflowMessage_ContributionTrait;
+  use CRM_Core_WorkflowMessage_ProfileTrait;
+
   /**
    * @var int
    *
@@ -247,7 +249,7 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
    * Get the participant fields we need to load.
    */
   protected function getFieldsToLoadForParticipant(): array {
-    return ['registered_by_id'];
+    return ['registered_by_id', 'contact_id'];
   }
 
   /**
@@ -286,7 +288,7 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
       if ($this->isCiviContributeEnabled()) {
         foreach ($this->getLineItems() as $lineItem) {
           if ($lineItem['entity_table'] === 'civicrm_participant') {
-            $participantID = $lineItem['entity_id'];
+            $participantID = (int) $lineItem['entity_id'];
           }
           else {
             // It is not clear if this could ever be true - testing the CiviCRM event
@@ -318,6 +320,7 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
       $count = 1;
       foreach ($participants as $participantID => &$participant) {
         $participant['id'] = $participantID;
+        $participant['is_primary'] = $this->getParticipantID() === $participantID;
         $participant['index'] = $count;
         $participant['contact'] = $this->getParticipantContact($participantID);
         foreach ($participant['tax_rate_breakdown'] ?? [] as $rate => $details) {

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -311,7 +311,7 @@ class CRM_Utils_Mail {
       if ($logCount < 3) {
         // Only record the first 3 times since there might be different messages but after 3 chances are
         // it's just bulk run of the same..
-        CRM_Core_Error::deprecatedWarning('email output affected by undefined php properties:' . (CRM_Utils_Constant::value('CIVICRM_UF') === 'UnitTests' ? CRM_Utils_String::purifyHTML($htmlMessage) : ''));
+        CRM_Core_Error::deprecatedWarning('email output affected by undefined php properties:' . (CRM_Utils_Constant::value('CIVICRM_UF') === 'UnitTests' ? CRM_Utils_String::purifyHTML($htmlMessage) . CRM_Utils_String::purifyHTML($textMessage) : ''));
         $logCount++;
         \Civi::$statics[__CLASS__][__FUNCTION__]['count'] = $logCount;
       }

--- a/Civi/Test/EventTestTrait.php
+++ b/Civi/Test/EventTestTrait.php
@@ -260,13 +260,27 @@ trait EventTestTrait {
     $profiles = [
       ['name' => '_pre', 'title' => 'Event Pre Profile', 'weight' => 1, 'fields' => ['email']],
       ['name' => '_post', 'title' => 'Event Post Profile', 'weight' => 2, 'fields' => ['first_name', 'last_name']],
-      ['name' => '_post_post', 'title' => 'Event Post Post Profile', 'weight' => 3, 'fields' => ['job_title']],
     ];
     foreach ($profiles as $profile) {
       $this->createEventProfile($profile, $identifier);
       if ($this->getEventValue('is_multiple_registrations', $identifier)) {
         $this->createEventProfile($profile, $identifier, TRUE);
       }
+    }
+    $sharedProfile = ['name' => '_post_post', 'title' => 'Event Post Post Profile', 'weight' => 3, 'fields' => ['job_title']];
+    $this->createEventProfile($sharedProfile, $identifier);
+    if ($this->getEventValue('is_multiple_registrations', $identifier)) {
+      // For this one use the same profile but 2 UFJoins - to provide variation.
+      // e.g. we hit a bug where behaviour was different if the profiles for
+      // additional were the same uf group or different ones.
+      $profileName = $identifier . '_post_post';
+      $this->setTestEntity('UFJoin', UFJoin::create(FALSE)->setValues([
+        'module' => 'CiviEvent_Additional',
+        'entity_table' => 'civicrm_event',
+        'uf_group_id:name' => $profileName,
+        'weight' => $profile['weight'],
+        'entity_id' => $this->getEventID($identifier),
+      ])->execute()->first(), $profileName . '_' . $identifier);
     }
   }
 

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -260,8 +260,9 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
 
     $this->assertStringContainsString('Dear Participant1', $mailSent[2]);
     $this->assertStringContainsString('job_title	oracle', $mailSent[2]);
-    // Note the delayed version does not add the additional participant profiles
-    // This could be fixed at some point so no assertions added.
+    $this->assertStringContainsString('job_title	wizard', $mailSent[2]);
+    $this->assertStringContainsString('job_title	seer', $mailSent[2]);
+    $this->assertStringNotContainsString('Participant 4', $mailSent[2]);
 
     $this->assertStringContainsString('Dear Participant2', $mailSent[0]);
     $this->assertStringNotContainsString('job_title	oracle', $mailSent[0]);
@@ -489,7 +490,6 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
    * email reflects the submitted value
    *
    * @throws \CRM_Core_Exception
-   * @throws \Exception
    */
   public function testNoteSubmission(): void {
     // Create an event with an attached profile containing a note

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -329,11 +329,37 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
   /**
    * Test stock template for multiple participant.
    *
-   * The goal is to ensure no leakage.
+   * The goal is to ensure the profile details for all are
+   * on the first contact and the relevant contact are
+   * on the other 2.
    *
    * @throws \CRM_Core_Exception
    */
   public function testMailMultipleParticipant(): void {
+    $this->createScenarioMultipleParticipantPendingFreeEvent();
+    $mailSent = $this->sentMail;
+    // The second and 3rd emails have the job title for their participant,
+    // but not the others
+    $this->assertStringContainsString('job_title	wizard', $mailSent[1]['body']);
+    $this->assertStringContainsString('job_title	seer', $mailSent[2]['body']);
+    $this->assertStringNotContainsString('job_title	oracle', $mailSent[1]['body']);
+    $this->assertStringNotContainsString('job_title	oracle', $mailSent[2]['body']);
+
+    // The first participant, has the title for all 3.
+    $this->assertStringContainsString('job_title	oracle', $mailSent[0]['body']);
+    $this->assertStringContainsString('job_title	seer', $mailSent[0]['body']);
+    $this->assertStringContainsString('job_title	wizard', $mailSent[0]['body']);
+
+  }
+
+  /**
+   * Test stock template for multiple participant.
+   *
+   * The goal is to ensure no leakage.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testMailParticipant(): void {
     $this->createScenarioMultipleParticipantPendingWithTax();
     $mailSent = $this->sentMail;
     // amounts paid = [300, 100, 200];


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to https://github.com/civicrm/civicrm-core/pull/30358

 https://lab.civicrm.org/dev/core/-/issues/224

Before
----------------------------------------
When a participant record is completed via pay later, or a receipt is otherwise sent for a multiple participant event registration after the fact the additional participant profiles are not included


After
----------------------------------------
The additional participant data is included, all profile data now comes from the Workflow Message layer for this receipt

Technical Details
----------------------------------------

Comments
----------------------------------------
