### PR TITLE
dev/core#5276 - Don't crash when installing extension after download

### DIFF
--- a/CRM/Extension/System.php
+++ b/CRM/Extension/System.php
@@ -199,6 +199,7 @@ class CRM_Extension_System {
   public function getClassLoader() {
     if ($this->classLoader === NULL) {
       $this->classLoader = new CRM_Extension_ClassLoader($this->getMapper(), $this->getFullContainer(), $this->getManager());
+      $this->classLoader->register();
     }
     return $this->classLoader;
   }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5276

Before
----------------------------------------
If the extension files don't already exist in the filesystem when civi does whatever it does early in the lifecycle, you get a crash when it then tries to install after downloading. You can see it by just installing an extension from the Add New tab in the UI, or by doing `cv api3 Extension.download install=1 key=the_extension_key`

After
----------------------------------------


Technical Details
----------------------------------------
In https://github.com/civicrm/civicrm-core/commit/c10bd1d51eeda73e5445432b9d7bb51f05d7c it now calls preinstall, but  this happens at a time when $loader is null, so it just skips loading the extension [here](https://github.com/civicrm/civicrm-core/blob/a5b15beea5df43cdcfe4ec7bf33a9c166a1c3269/CRM/Extension/ClassLoader.php#L145), so it can't find the extension's upgrader class when it hits [here](https://github.com/civicrm/civicrm-core/blob/c10bd1d51eeda73e5445432b9d7bb51f05d7cb5f/CRM/Extension/Manager/Module.php#L74).

Comments
----------------------------------------
Classloading is a little bit mysterious to me sometimes so I'm not sure this is the optimal fix.
