### PR TITLE
[REF] After editing schedule job it should redirect back to job list page

### DIFF
--- a/CRM/Admin/Form/Job.php
+++ b/CRM/Admin/Form/Job.php
@@ -275,6 +275,7 @@ class CRM_Admin_Form_Job extends CRM_Admin_Form {
       CRM_Core_Session::setStatus($msg, ts('Warning: Update Greeting job enabled'), 'alert');
     }
 
+    CRM_Utils_System::redirect($redirectUrl);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Right now after editing a scheduled job it redirects to just civicrm/admin/job without the reset=1 parameter


Before
----------------------------------------
Stays on the edit form.
After
----------------------------------------
Redirects to the job list page

Comments
----------------------------------------
ping @seamuslee001 @colemanw  @demeritcowboy 


