### PR TITLE
'All financial ACLs' permissions

### DIFF
--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -277,12 +277,19 @@ function financialacls_civicrm_permission(&$permissions) {
     'edit' => E::ts('edit'),
     'delete' => E::ts('delete'),
   ];
+  foreach ($actions as $action => $action_ts) {
+    $permissions[$action . ' contributions of all types'] = [
+      'label' => E::ts("CiviCRM: %1 contributions of all types", [1 => $action_ts]),
+      'description' => E::ts('%1 contributions of all types', [1 => $action_ts]),
+    ];
+  }
   $financialTypes = \CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'validate');
-  foreach ($financialTypes as $id => $type) {
+  foreach ($financialTypes as $type) {
     foreach ($actions as $action => $action_ts) {
       $permissions[$action . ' contributions of type ' . $type] = [
         'label' => E::ts("CiviCRM: %1 contributions of type %2", [1 => $action_ts, 2 => $type]),
         'description' => E::ts('%1 contributions of type %2', [1 => $action_ts, 2 => $type]),
+        'implied_by' => [$action . ' contributions of all types'],
       ];
     }
   }

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/ContributionTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/ContributionTest.php
@@ -127,4 +127,30 @@ class ContributionTest extends BaseTestClass {
     ]);
   }
 
+  public function testSuperPermissions(): void {
+    // With no financial ACLs.
+    $this->setPermissions([
+      'access CiviCRM',
+      'access CiviContribute',
+      'edit contributions',
+      'view all contacts',
+    ]);
+    $this->createLoggedInUser();
+    $visibleFTs = \CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'search');
+    $this->assertEquals(count($visibleFTs), 0);
+
+    // With financial ACLs.
+    $permissions = array_merge(\CRM_Core_Config::singleton()->userPermissionClass->permissions, [
+      'view contributions of all types',
+      'delete contributions of all types',
+      'add contributions of all types',
+      'edit contributions of all types',
+    ]);
+    $this->setPermissions($permissions);
+    // Clear pseudoconstant lookup cache.
+    unset(\Civi::$statics['CRM_Core_PseudoConstant']);
+    $visibleFTs = \CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'search');
+    $this->assertEquals(count($visibleFTs), 4);
+  }
+
 }

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialTypeTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialTypeTest.php
@@ -46,7 +46,7 @@ class FinancialTypeTest extends BaseTestClass {
       'delete' => ts('delete'),
     ];
     $financialTypes = \CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'validate');
-    foreach ($financialTypes as $id => $type) {
+    foreach ($financialTypes as $type) {
       foreach ($actions as $action => $action_ts) {
         $this->assertEquals(
           [
@@ -55,6 +55,7 @@ class FinancialTypeTest extends BaseTestClass {
               2 => $type,
             ]),
             'description' => ts('%1 contributions of type %2', [1 => $action_ts, 2 => $type]),
+            'implied_by' => [ts('%1 contributions of all types', [1 => $action_ts])],
           ],
           $permissions[$action . ' contributions of type ' . $type]
         );


### PR DESCRIPTION
Overview
----------------------------------------
With Financial ACLs enabled, each financial type must be granted manually.  When a large (and frequently changed) number of financial types exists, this causes a lot of administrative overhead.  This can be avoided by granting admin privileges, but that's not always appropriate.

This PR adds "View/Add/Edit/Delete contributions of all types" permissions.

Before
----------------------------------------
Permissions must be added individually.

After
----------------------------------------
A permission that allows a user to act as if financial ACLs were not enabled for them (without being an admin).

Comments
----------------------------------------
This takes advantage of the new-in-5.74 ability to pass implied permissions from an extension.
