### PR TITLE
fix getCancelUrls

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1241,8 +1241,11 @@ abstract class CRM_Core_Payment {
     }
 
     if ($this->_component == 'event') {
-      $eventID = Participant::get(FALSE)->addWhere('id', '=', $participantID)
-        ->addSelect('event_id')->execute()->single()['event_id'];
+      $eventID = NULL;
+      if ($participantID) {
+        $eventID = Participant::get(FALSE)->addWhere('id', '=', $participantID)
+          ->addSelect('event_id')->execute()->single()['event_id'];
+      }
       return CRM_Utils_System::url($this->getBaseReturnUrl(), [
         'reset' => 1,
         'cc' => 'fail',


### PR DESCRIPTION
Overview
----------------------------------------
A recent change to getCancelUrl() causes a crash when you use an event with PayPal Express or Stripe Checkout.  You can test this by attempting to pay for an event using Stripe Checkout.

Before
----------------------------------------
```
$Fatal Error Details = array:3 [
  "message" => "Expected to find one Participant record, but there were zero."
  "code" => null
  "exception" => CRM_Core_Exception {#4321
    -errorData: array:1 [
      "error_code" => 0
    ]
    #cause: null
    -_trace: null
    #message: "Expected to find one Participant record, but there were zero."
    #code: 0
    #file: "/var/www/mysite.org/web/sites/all/modules/civicrm/CRM/Utils/Array.php"
    #line: 1245
    trace: {
      /var/www/mysite.org/web/sites/all/modules/civicrm/CRM/Utils/Array.php:1245 {
        CRM_Utils_Array::single(iterable $items, string $recordTypeLabel = 'record')
        › if ($result === NULL) {
        ›   throw new \CRM_Core_Exception("Expected to find one {$recordTypeLabel}, but there were zero.");
        › }
      }
      /var/www/mysite.org/web/sites/all/modules/civicrm/Civi/Api4/Generic/Result.php:90 { …}
      /var/www/mysite.org/web/sites/all/modules/civicrm/CRM/Core/Payment.php:1239 { …}
      /var/www/mysite.org/web/sites/all/civicrm-custom/extensions/com.drastikbydesign.stripe/CRM/Core/Payment/StripeCheckout.php:155 { …}
      /var/www/mysite.org/web/sites/all/modules/civicrm/CRM/Event/Form/Registration/Confirm.php:1230 { …}
      /var/www/mysite.org/web/sites/all/modules/civicrm/CRM/Event/Form/Registration/Confirm.php:771 { …}
      /var/www/mysite.org/web/sites/all/modules/civicrm/CRM/Core/Form.php:646 { …}
      /var/www/mysite.org/web/sites/all/modules/civicrm/CRM/Core/StateMachine.php:144 { …}
      /var/www/mysite.org/web/sites/all/modules/civicrm/CRM/Core/QuickForm/Action/Next.php:43 { …}
      /var/www/mysite.org/web/sites/all/modules/civicrm/packages/HTML/QuickForm/Controller.php:203 { …}
      /var/www/mysite.org/web/sites/all/modules/civicrm/packages/HTML/QuickForm/Page.php:103 { …}
      /var/www/mysite.org/web/sites/all/modules/civicrm/CRM/Core/Controller.php:355 { …}
      /var/www/mysite.org/web/sites/all/modules/civicrm/CRM/Core/Invoke.php:325 { …}
      /var/www/mysite.org/web/sites/all/modules/civicrm/CRM/Core/Invoke.php:69 { …}
      /var/www/mysite.org/web/sites/all/modules/civicrm/CRM/Core/Invoke.php:36 { …}
      /var/www/mysite.org/web/sites/all/modules/civicrm/drupal/civicrm.module:470 { …}
      /var/www/mysite.org/web/includes/menu.inc:527 { …}
      /var/www/mysite.org/web/index.php:21 { …}
    }
  }
]
```

After
----------------------------------------
No crash.

Comments
----------------------------------------
This is a recent regression (5.74 but backported to 5.73)
