### PR TITLE
always treat saved groups as an array

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -403,7 +403,7 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
       );
       // Check each group search for valid groups.
       foreach ($groupSearches as $groupSearch) {
-        if (!empty($groupSearch[2]) && in_array($groupID, $groupSearch[2])) {
+        if (!empty($groupSearch[2]) && in_array($groupID, (array) $groupSearch[2])) {
           $smartGroups[$group['id']] = [
             'title' => $group['title'],
             'editSearchURL' => self::getEditSearchUrl($group['saved_search_id']),


### PR DESCRIPTION
Overview
----------------------------------------
It seems that old smart groups that contained a single group were saved differently than they are now.  This causes an error if you have such a group and you try to delete any group.

Before
----------------------------------------
If you search for a group, and save the results as a smart group, your saved search ID form values will be saved as something like this:
```
Array
(
    [0] => Array
        (
            [0] => entryURL
            [1] => =
            [2] => http://dmaster.localhost/civicrm/contact/search/advanced?reset=1
            [3] => 0
            [4] => 0
        )

    [1] => Array
        (
            [0] => group
            [1] => =
            [2] => Array
                (
                    [IN] => Array
                        (
                            [0] => 3
                        )

                )

            [3] => 0
            [4] => 0
        )

    [2] => Array
        (
            [0] => group_search_selected
            [1] => =
            [2] => group
            [3] => 0
            [4] => 0
        )

    [3] => Array
        (
            [0] => privacy_operator
            [1] => =
            [2] => OR
            [3] => 0
            [4] => 0
        )

    [4] => Array
        (
            [0] => privacy_toggle
            [1] => =
            [2] => 1
            [3] => 0
            [4] => 0
        )

)
```

Most importantly - $array[1][2] is an array.

However, this same smart group created in 2019 would look like this:
```
Array
(
    [0] => Array
        (
            [0] => entryURL
            [1] => LIKE
            [2] => https://mysite.org/wp-admin/admin.php?page=CiviCRM&amp;q=civicrm%2Fcontact%2Fsearch%2Fadvanced&amp;page=CiviCRM&amp;reset=1
            [3] => 0
            [4] => 0
        )

    [1] => Array
        (
            [0] => group
            [1] => =
            [2] => 217
            [3] => 0
            [4] => 0
        )

    [2] => Array
        (
            [0] => group_contact_status
            [1] => IN
            [2] => Array
                (
                    [Added] => 1
                )

            [3] => 0
            [4] => 0
        )

)
```

Here, $array[1][2] is a string.

If you have a group saved like this from 2019, and you try to delete any group (not just this one), you get this error:
```
PHP Fatal error:  Uncaught TypeError: in_array(): Argument #2 ($haystack) must be of type array, string given in /var/www/mysite.org/web/wp-content/plugins/civicrm/civicrm/CRM/Contact/BAO/SavedSearch.php:406"
```

After
----------------------------------------
We always cast that value to an array.