### PR TITLE
Theming - Allow manipulation of Angular CSS

### DIFF
--- a/Civi/Angular/AngularLoader.php
+++ b/Civi/Angular/AngularLoader.php
@@ -183,8 +183,8 @@ class AngularLoader {
         $res->addScriptFile('civicrm', 'ang/resetLocationProviderHashPrefix.js', 101, $this->getRegion(), FALSE);
       }
       foreach ($moduleNames as $moduleName) {
-        foreach ($this->angular->getResources($moduleName, 'css', 'cacheUrl') as $url) {
-          $res->addStyleUrl($url, self::DEFAULT_MODULE_WEIGHT + (++$headOffset), $this->getRegion());
+        foreach ($this->angular->getResources($moduleName, 'css', 'relUrl') as $relUrl) {
+          $res->addStyleFile($relUrl['ext'], $relUrl['file'], self::DEFAULT_MODULE_WEIGHT + (++$headOffset), $this->getRegion());
         }
         foreach ($this->angular->getResources($moduleName, 'js', 'cacheUrl') as $url) {
           $res->addScriptUrl($url, self::DEFAULT_MODULE_WEIGHT + (++$headOffset), $this->getRegion());
@@ -205,8 +205,8 @@ class AngularLoader {
       //$aggStyleUrl = \Civi::service('asset_builder')->getUrl('angular-modules.css', $assetParams);
       //$res->addStyleUrl($aggStyleUrl, 120, $this->getRegion());
 
-      foreach ($this->angular->getResources($moduleNames, 'css', 'cacheUrl') as $url) {
-        $res->addStyleUrl($url, self::DEFAULT_MODULE_WEIGHT + (++$headOffset), $this->getRegion());
+      foreach ($this->angular->getResources($moduleNames, 'css', 'relUrl') as $relUrl) {
+        $res->addStyleFile($relUrl['ext'], $relUrl['file'], self::DEFAULT_MODULE_WEIGHT + (++$headOffset), $this->getRegion());
       }
     }
     // Add bundles

--- a/Civi/Angular/Manager.php
+++ b/Civi/Angular/Manager.php
@@ -362,6 +362,10 @@ class Manager {
               $result[] = $this->res->getUrl($module['ext'], $file, TRUE);
               break;
 
+            case 'relUrl':
+              $result[] = ['ext' => $module['ext'], 'file' => $file];
+              break;
+
             case 'path-assetBuilder':
               $assetName = parse_url($file, PHP_URL_HOST) . parse_url($file, PHP_URL_PATH);
               $assetParams = [];


### PR DESCRIPTION
Overview
----------------------------------------

The [Theming subsystem](https://docs.civicrm.org/dev/en/latest/framework/theme/#advanced) allows themes to do things like:

* Override a CSS file (by creating an eponymous CSS file)
* Exclude a CSS file (by declaring the `excludes` list in `hook_civicrm_themes`)

This was originally implemented when all screens used QuickForm. We now also have screens implemented as Angular modules. They have declarations like:

```php
// FILE: ang/api4Explorer.ang.php 
return [
  ...
  'css' => [
    'css/api4-explorer.css',
  ],
  ...
];
```

As a themer, you would expect the CSS overrides to work the same way for QuickForm pages and Angular pages.

Steps to Reproduce
----------------------------------------

* Take an existing theme
* Add a file `css/api4-explorer.css`. Fill it with dummy content.
* Open "APIv4 Explorer"
* View the source. Find where includes `api4-explorer.css`.

Before
----------------------------------------

* Overrides and exclusions for Angular CSS are quietly ignored.
* The example `api4-explorer.css` is loaded from `civicrm-core`.

After
----------------------------------------

* Overrides and exclusions for Angular CSS work.
* The example `api4-explorer.css` is loaded from your theme.