### PR TITLE
(dev/core#5276) Extension.download API - Restore classloader (after you destroy it...)

### DIFF
--- a/api/v3/Extension.php
+++ b/api/v3/Extension.php
@@ -242,6 +242,7 @@ function civicrm_api3_extension_download($params) {
   }
   CRM_Extension_System::singleton()->getCache()->flush();
   CRM_Extension_System::singleton(TRUE);
+  CRM_Extension_System::singleton()->getClassLoader()->register();
   if ($params['install']) {
     CRM_Extension_System::singleton()->getManager()->install([$params['key']]);
   }


### PR DESCRIPTION
Overview
----------------------------------------

Alternative to #30380 -- but perhaps a bit more conservative.

