### PR TITLE
(dev/core#5276) Module::registerClassloader - Do what the name suggests

### DIFF
--- a/CRM/Extension/ClassLoader.php
+++ b/CRM/Extension/ClassLoader.php
@@ -65,6 +65,10 @@ class CRM_Extension_ClassLoader {
     $this->unregister();
   }
 
+  public function isRegistered(): bool {
+    return ($this->loader !== NULL);
+  }
+
   /**
    * Registers this instance as an autoloader.
    * @return CRM_Extension_ClassLoader

--- a/CRM/Extension/Manager/Module.php
+++ b/CRM/Extension/Manager/Module.php
@@ -138,6 +138,9 @@ class CRM_Extension_Manager_Module extends CRM_Extension_Manager_Base {
     }
 
     $classloader = CRM_Extension_System::singleton()->getClassLoader();
+    if (!$classloader->isRegistered()) {
+      $classloader->register();
+    }
     $classloader->installExtension($info, $extPath);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

Another stab at https://lab.civicrm.org/dev/core/-/issues/5276 using a narrower variant of @demeritcowboy's #30380

Before + After
--------------

* __5.74-stable (and earlier)__: When downloading an extension which declares an `<upgrader>`, it works.
    * (Internally, the upgrader-class loads because `hook_civicrm_install` configures class-loading -- as in the civix boilerplate.)
* __5.75-head__: When downloading an extension which declares an `<upgrader>`, the upgrader class fails to load.
    * (Internally, it fails because it tries to instantiate the upgrader before `hook_civicrm_install` has run.)
* __5.75+patch__: When downloading an extension which declares an `<upgrader>`, it works.
    * (Internally, the upgrader-class loads because `info.xml` uses `<classloader>` to configure class-loading -- as in the civix boilerplate.)

Technical Details
----------------------------------------

1. `Module::registerClassloader()` wasn't registering the module with the class-loader if the class-loader wasn't already registered.  👀  And if that makes sense to you, then 👏 🏆 😄 .

2. The before (`5.74-stable`) and after (`5.75+patch`) sound theoretically different. But in practice, after auditing `universe`, it seems to work out. The history/rollout of  `<classloader>` (via `civix@22.10.0`) and `<upgrader>` (via `civix@22.12.1`) means that any real-world extensions which use `<upgrader>` will also have the required `<classloader>`. More discussion about this in #30380.
