### PR TITLE
Fix field length error while searching in Include / Exclude Search

### DIFF
--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Group.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Group.php
@@ -396,7 +396,7 @@ WHERE  gcc.group_id = {$ssGroup->id}
         }
       }
 
-      $this->_iGTable->createWithColumns("id int PRIMARY KEY AUTO_INCREMENT, contact_id int, group_names varchar(64)");
+      $this->_iGTable->createWithColumns("id int PRIMARY KEY AUTO_INCREMENT, contact_id int, group_names varchar(255)");
 
       if ($iGroups) {
         $includeGroup = "INSERT INTO {$this->_iGTableName} (contact_id, group_names)


### PR DESCRIPTION
Overview
----------------------------------------
In CRM group table field title has length VARCHAR(255), but while using "Include / Exclude Search" it will try to insert data longer than 64 characters to column limited to VARCHAR(64)

Before
----------------------------------------
Search in "Include / Exclude Search" throws error id group title is longer than 64 characters

After
----------------------------------------
Search in "Include / Exclude Search" works fine

Technical Details
----------------------------------------
PR includes only small change in field length from 64 to 255

Comments
----------------------------------------
https://github.com/civicrm/civicrm-core/blob/624bc8bb24e4e10143753d3a6c810575f1b722ad/CRM/Contact/DAO/Group.php#L345
