### PR TITLE
Fix regression on loading MembershipType edit form

### DIFF
--- a/CRM/Member/Form/MembershipType.php
+++ b/CRM/Member/Form/MembershipType.php
@@ -51,6 +51,7 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
       'financial_type_id' => [
         'name' => 'financial_type_id',
         'description' => ts('Select the financial type assigned to fees for this membership type (for example \'Membership Fees\'). This is required for all membership types - including free or complimentary memberships.'),
+        'required' => TRUE,
       ],
       'auto_renew' => [
         'name' => 'auto_renew',
@@ -76,13 +77,19 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
       'fixed_period_start_day' => [
         'name' => 'fixed_period_start_day',
         'description' => ts("Month and day on which a <strong>fixed</strong> period membership or subscription begins. Example: A fixed period membership with Start Day set to Jan 01 means that membership periods would be 1/1/06 - 12/31/06 for anyone signing up during 2006."),
+        // Not relying on auto-add until we have checked out the options function.
+        'not-auto-addable' => TRUE,
       ],
       'fixed_period_rollover_day' => [
         'name' => 'fixed_period_rollover_day',
         'description' => ts('Membership signups on or after this date cover the following calendar year as well. Example: If the rollover day is November 30, membership period for signups during December will cover the following year.'),
+        // Not relying on auto-add until we have checked out the options function.
+        'not-auto-addable' => TRUE,
       ],
       'relationship_type_id' => [
         'name' => 'relationship_type_id',
+        // Not relying on auto-add until we have checked out the options function.
+        'not-auto-addable' => TRUE,
       ],
       'max_related' => [
         'name' => 'max_related',
@@ -243,9 +250,6 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
     );
     $this->add('date', 'month_fixed_period_rollover_day', ts('Fixed Period Rollover Day'),
       CRM_Core_SelectValues::date(NULL, 'd'), FALSE
-    );
-    $this->add('select', 'financial_type_id', ts('Financial Type'),
-      ['' => ts('- select -')] + CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($financialTypes, $this->_action), TRUE, ['class' => 'crm-select2']
     );
 
     $relTypeInd = CRM_Contact_BAO_Relationship::getContactRelationshipType(NULL, NULL, NULL, NULL, TRUE);

--- a/schema/Member/MembershipType.entityType.php
+++ b/schema/Member/MembershipType.entityType.php
@@ -108,7 +108,7 @@ return [
     'financial_type_id' => [
       'title' => ts('Financial Type ID'),
       'sql_type' => 'int unsigned',
-      'input_type' => 'EntityRef',
+      'input_type' => 'Select',
       'required' => TRUE,
       'description' => ts('If membership is paid by a contribution - what financial type should be used. FK to civicrm_financial_type.id'),
       'add' => '4.3',


### PR DESCRIPTION
Overview
----------------------------------------
Fix regression on loading MembershipType edit form - I don't know what caused this & the similar one previously fixed - I'm guessing it relates to @colemanw DAO work but I can't see the mechanism

Before
----------------------------------------
Page does not load

![image](https://github.com/civicrm/civicrm-core/assets/336308/3c8c9918-29d6-4d9b-b1ed-789fec102145)


After
----------------------------------------
Page loads - sorta

Technical Details
----------------------------------------
This is not quite right yet but have put it up in the current state - we had a similar issue on the Payment Processor form that got fixed.

The form implements `CRM_Core_Form_EntityFormTrait` but it manually adds some fields. It turns out it was adding 'not-auto-addable' to any fields with no html type defined & these got filled in in the big DAO swapparoo, causing them to be added there & again.

I do wonder what other forms might be affected....

This is how it should look - from 5.74 

![image](https://github.com/civicrm/civicrm-core/assets/336308/72af76d2-8be0-4432-b1ff-95c47bedb90c)


Note that the financial_type_acl extension should be using a hook to alter the option list so we should be able to ignore it here

![image](https://github.com/civicrm/civicrm-core/assets/336308/ed5c63ab-3deb-4fc8-97d4-87c93d169c74)


Comments
----------------------------------------
