### PR TITLE
dev/wordpress#150 Do not require CiviEvent access to alter price sets

### DIFF
--- a/CRM/Core/xml/Menu/Admin.xml
+++ b/CRM/Core/xml/Menu/Admin.xml
@@ -688,7 +688,7 @@
      <title>Price Sets</title>
      <page_callback>CRM_Price_Page_Set</page_callback>
      <desc>Price sets allow you to offer multiple options with associated fees (e.g. pre-conference workshops, additional meals, etc.). Configure Price Sets for events which need more than a single set of fee levels.</desc>
-     <access_arguments>access CiviCRM,access CiviEvent</access_arguments>
+     <access_arguments>access CiviCRM</access_arguments>
      <adminGroup>Customize</adminGroup>
      <weight>380</weight>
   </item>
@@ -697,14 +697,14 @@
      <title>New Price Set</title>
      <page_callback>CRM_Price_Page_Set</page_callback>
      <desc>Price sets allow you to offer multiple options with associated fees (e.g. pre-conference workshops, additional meals, etc.). Configure Price Sets for events which need more than a single set of fee levels.</desc>
-     <access_arguments>access CiviCRM,access CiviEvent</access_arguments>
+     <access_arguments>access CiviCRM</access_arguments>
      <path_arguments>action=add</path_arguments>
   </item>
   <item>
      <path>civicrm/admin/price/edit</path>
      <title>Price Sets</title>
      <page_callback>CRM_Price_Page_Set</page_callback>
-     <access_arguments>access CiviCRM,access CiviEvent</access_arguments>
+     <access_arguments>access CiviCRM</access_arguments>
   </item>
   <item>
      <path>civicrm/admin/price/field</path>


### PR DESCRIPTION
Overview
----------------------------------------
dev/wordpress#150 Do not require CiviEvent access to alter price sets

Before
----------------------------------------
Access to the price set configuration requires 
- access CiviCRM
- access CiviEvent

After
----------------------------------------
Access to the price set configuration requires 
- access CiviCRM

Technical Details
----------------------------------------
The requirement for Access CiviEvent dates back to when we only permitted price sets for events (erm a decade ago) and doesn't make sense - especially as it goes awry if CiviEvent is disabled.

I do think the *right* permission would be 'adminster CiviCRM Data' but am not sure if we need to think through rolling that out as it might cause problems for sites to adapt. Regardless of whether we follow up with a tightening I think this makes sense

Comments
----------------------------------------
