### PR TITLE
Fix failure to render Custom Data on RelationshipType form

### DIFF
--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -174,7 +174,10 @@ trait CRM_Core_Form_EntityFormTrait {
     ]));
     }
      */
-
+    $this->assign('customDataType', $this->getDefaultEntity());
+    $this->assign('customDataSubType', $this->getEntitySubTypeId());
+    $this->assign('entityID', $this->getEntityId());
+    $this->assign('cid', NULL);
     if ($this->isSubmitted()) {
       $customisableEntities = CRM_Core_SelectValues::customGroupExtends();
       if (isset($customisableEntities[$this->getDefaultEntity()])) {

--- a/CRM/Custom/Form/CustomData.php
+++ b/CRM/Custom/Form/CustomData.php
@@ -72,11 +72,6 @@ class CRM_Custom_Form_CustomData {
         self::setDefaultValues($form);
       }
     }
-    // need to assign custom data type and subtype to the template
-    $form->assign('customDataType', $entityName);
-    $form->assign('customDataSubType', $entitySubType);
-    $form->assign('entityID', $entityID);
-    $form->assign('cid', $contact_id);
   }
 
   /**


### PR DESCRIPTION


Overview
----------------------------------------
Fix failure to render Custom Data on RelationshipType form

This addresses https://github.com/eileenmcnaughton/org.wikimedia.relationshipblock/issues/41 where the generic template used by RelationShip Type no longer has enough information to render the Custom Fields

Before
----------------------------------------
With the RelationshipType block extension enabled the custom fields it creates no longer show on the edit relationship screen

After
----------------------------------------
The fields are back

![image](https://github.com/civicrm/civicrm-core/assets/336308/c42ed11c-1b30-465c-b2f5-bcdc29984179)


Technical Details
----------------------------------------


Comments
----------------------------------------
