### PR TITLE
dev/core#4048 Add check for expected array being NULL

### DIFF
--- a/CRM/Member/BAO/MembershipBlock.php
+++ b/CRM/Member/BAO/MembershipBlock.php
@@ -69,7 +69,7 @@ class CRM_Member_BAO_MembershipBlock extends CRM_Member_DAO_MembershipBlock impl
         $autoRenewOption = (int) $autoRenewOption;
         $membershipBlocks = MembershipBlock::get(FALSE)->execute();
         foreach ($membershipBlocks as $membershipBlock) {
-          if (array_key_exists($event->id, $membershipBlock['membership_types'])
+          if ($membershipBlock['membership_types'] && array_key_exists($event->id, $membershipBlock['membership_types'])
             && ((int) $membershipBlock['membership_types'][$event->id]) !== $autoRenewOption
           ) {
             $membershipBlock['membership_types'][$event->id] = $autoRenewOption;


### PR DESCRIPTION


Overview
----------------------------------------
dev/core#4048 Add check for expected array being NULL

Before
----------------------------------------
We have a report of an error affecting php 8.x where the second value is NULL not an array

After
----------------------------------------
We check if is truthy before the array comparison

Technical Details
----------------------------------------
Not too sure why this happens but it feels like this check is probably safe & we might as well - see https://lab.civicrm.org/dev/core/-/issues/4048#note_164825

Comments
----------------------------------------
