### PR TITLE
Add ability to define a pseudo row in imports

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -144,7 +144,10 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
         continue;
       }
       $fieldSpec = $this->getFieldMetadata($mappedField['name']);
-      $fieldValue = $values[$i];
+      $columnHeader = $this->getUserJob()['metadata']['DataSource']['column_headers'][$i] ?? '';
+      // If there is no column header we are dealing with an added value mapping, do not use
+      // the database value as it will be for (e.g.) `_status`
+      $fieldValue = $columnHeader ? $values[$i] : '';
       if ($fieldValue === '' && isset($mappedField['default_value'])) {
         $fieldValue = $mappedField['default_value'];
       }

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -597,7 +597,21 @@ class CRM_Import_Forms extends CRM_Core_Form {
    */
   protected function getDataRows($statuses = [], int $limit = 0): array {
     $statuses = (array) $statuses;
-    return $this->getDataSourceObject()->setLimit($limit)->setStatuses($statuses)->getRows();
+    $rows = $this->getDataSourceObject()->setLimit($limit)->setStatuses($statuses)->getRows();
+    $headers = $this->getColumnHeaders();
+    $mappings = $this->getUserJob()['metadata']['import_mappings'] ?? [];
+    foreach ($rows as &$row) {
+      foreach ($headers as $index => $header) {
+        if (!$header) {
+          // Our rows are sequential lists of the values in the database table but the database
+          // table has some non-mapping related rows (`_status`, `_statusMessage` etc)
+          // and our mappings have some virtual rows, which do not have headers
+          // so, we populate our virtual values here.
+          $row[$index] = $mappings[$index]['default_value'] ?? '';
+        }
+      }
+    }
+    return $rows;
   }
 
   /**

--- a/ext/civiimport/ang/crmCiviimport.js
+++ b/ext/civiimport/ang/crmCiviimport.js
@@ -243,6 +243,26 @@
         });
 
         /**
+         * Add another row to the mapping.
+         *
+         * This row will use a default value and be the same for all rows imported.
+         *
+         * @type {$scope.addRow}
+         */
+        $scope.addRow = (function () {
+          $scope.data.importMappings.push({'header' : '', 'selectedField' : undefined});
+          $scope.userJob.metadata.DataSource.column_headers.push('');
+        });
+
+        $scope.alterRow = (function (index, row) {
+          if (row.header === '' && row.selectedField === '') {
+            // Deleting a mapped row.
+            $scope.data.importMappings.splice(index, 1);
+            $scope.userJob.metadata.DataSource.column_headers.splice(index, 1);
+          }
+        });
+
+        /**
          * Save the user job configuration on save.
          *
          * We add two arrays to the 'metadata' key. This is in the format returned from `Parser->getFieldMappings()`

--- a/ext/civiimport/ang/crmCiviimport/Import.html
+++ b/ext/civiimport/ang/crmCiviimport/Import.html
@@ -81,13 +81,13 @@
       <tr ng-repeat="(index, row) in data.importMappings">
         <td ng-if="data.showColumnNames" >{{ row['header'] }}</td>
         <td ng-repeat="(rowNumber, rowValues) in data.rows" class="odd-row">
-          <span ng-repeat="rowValue in rowValues track by $index"><span ng-if="index == $index">{{ rowValue }}</span></span>
+          <span ng-repeat="rowValue in rowValues track by $index"><span ng-if="index == $index && row['header']">{{ rowValue }}</span></span>
         </td>
         <td class="even-row">
           <div>
             <div>
               <label>
-                <input id='mapper[{{index}}][0]' name='mapper[{{index}}][0]' class="big" crm-ui-select='{data: getFields, allowClear: true, placeholder: "do not import"}' ng-model="row['selectedField']" />
+                <input ng-change="alterRow(index, row)" id='mapper[{{index}}][0]' name='mapper[{{index}}][0]' class="big" crm-ui-select='{data: getFields, allowClear: true, placeholder: "do not import"}' ng-model="row['selectedField']" />
               </label>
             </div>
           </div>
@@ -103,6 +103,7 @@
         </td>
       </tr>
     </table>
+    <button ng-click="addRow()" type="button" class="crm-button"><i aria-hidden="true" class="crm-i fa-plus"></i>{{:: ts('Add Row') }}</button>
   </div>
 
 </div>


### PR DESCRIPTION


Overview
----------------------------------------
Add ability to define a pseudo row in imports

This adds the ability to add an additional row to the mapping that will allow a default value to be set, which will then apply to all imported rows

Before
----------------------------------------
It's necessary to add another column to a csv in order to specify a value to applied to the whole row

After
----------------------------------------
It can be defined in the mapping

The last 2 rows in this screen shot have been added through 'add row'

![image](https://github.com/civicrm/civicrm-core/assets/336308/a8096ec7-2520-4be7-8229-aa7e0a6efb3f)


Technical Details
----------------------------------------

Comments
----------------------------------------
This is really helpful when it is saved into the import template and can cut down on training as the person loading up the files does not need to understand the mechanics
