### PR TITLE
dev/core#5288 Fix broken links in sched reminders

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -56,6 +56,13 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
   }
 
   /**
+   * @return array
+   */
+  protected function getFieldsToExcludeFromPurification(): array {
+    return ['body_html', 'html_message'];
+  }
+
+  /**
    * Because `CRM_Mailing_BAO_Mailing::commonCompose` uses different fieldNames than `CRM_Core_DAO_ActionSchedule`.
    * @var array
    */


### PR DESCRIPTION
Overview
----------------------------------------
Fix broken links in sched reminders

Before
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/5288

After
----------------------------------------
Tokens are fixed in emails.

Technical Details
----------------------------------------
Same treatment as message templates - https://github.com/civicrm/civicrm-core/pull/30081

