### PR TITLE
Membership renewal form: Clarify "Date renewal entered"

### DIFF
--- a/templates/CRM/Member/Form/MembershipRenewal.tpl
+++ b/templates/CRM/Member/Form/MembershipRenewal.tpl
@@ -42,9 +42,6 @@
     {/if}
   {/if}
   <div class="crm-block crm-form-block crm-member-membershiprenew-form-block">
-    <div id="help" class="description">
-      {ts}Renewing will add the normal membership period to the End Date of the previous period for members whose status is Current or Grace. For Expired memberships, renewing will create a membership period commencing from the 'Date Renewal Entered'. This date can be adjusted including being set to the day after the previous End Date - if continuous membership is required.{/ts}
-    </div>
     <div>{include file="CRM/common/formButtons.tpl" location="top"}</div>
     <table class="form-layout">
       <tr class="crm-member-membershiprenew-form-block-contact-id">
@@ -74,15 +71,14 @@
         <td class="label">{ts}Membership Expiration Date{/ts}</td>
         <td class="html-adjust">&nbsp;{$endDate|crmDate}</td>
       </tr>
+      {if isset($form.renewal_date)}
       <tr class="crm-member-membershiprenew-form-block-renewal_date">
         <td class="label">{$form.renewal_date.label}</td>
-        <td>{$form.renewal_date.html}
-          <div id="defaultNumTerms" class="crm-member-membershiprenew-form-block-default-num_terms description">
-            {ts}Renewal extends Membership Expiration Date by one membership period{/ts}
-            &nbsp;<a id="changeTermsLink" href='#' onclick='changeNumTerms(); return false;'>{ts}change{/ts}</a>
-          </div>
+        <td>{$form.renewal_date.html}<br/>
+          <span class="description">{ts}If empty the previous End Date will be used{/ts}</span>
         </td>
       </tr>
+      {/if}
       <tr id="changeNumTerms" class="crm-member-membershiprenew-form-block-change-num_terms">
         <td class="label">{$form.num_terms.label}</td>
         <td>{$form.num_terms.html|crmAddClass:two} {ts}membership periods{/ts}</td>
@@ -172,7 +168,6 @@
   <script type="text/javascript">
     CRM.$(function($) {
       $('#membershipOrgType').hide();
-      $('#changeNumTerms').hide();
     });
 
     function checkPayment() {
@@ -193,11 +188,6 @@
     function adjustMembershipOrgType() {
       cj('#membershipOrgType').show();
       cj('#changeMembershipOrgType').hide();
-    }
-
-    function changeNumTerms() {
-      cj('#changeNumTerms').show();
-      cj('#defaultNumTerms').hide();
     }
 
     CRM.$(function($) {


### PR DESCRIPTION
Overview
----------------------------------------
It was not very clear how the "Date renewal entered" field worked on the form and in fact it worked differently depending on whether the membership was expired or current.

The PR makes the following two changes to make it easier to understand and easier to use:

- Rename 'Date renewal entered' to 'Renewal date'.
- Hide 'Renewal date' field for current memberships as it does nothing.
- Allow the 'Renewal date' field to be empty for non-current memberships - this allows membership renewal to happen based on existing dates without having to explicity specify. Otherwise you had to check what the existing membership date was and enter the end date + 1 day into the box if you wanted it to renew without a gap. If you left it blank you could not submit the form.
- Simplify description for 'Renewal date' field.
- Always show 'Extend Membership by periods' field. That way it is simpler and clearer.

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/ab26d246-3f90-4382-956d-16cae12c0d3d)


After
----------------------------------------
Expired:
![image](https://github.com/user-attachments/assets/b016920c-52cf-4732-be1f-5c4422927e2a)

Current:
![image](https://github.com/user-attachments/assets/37ea3c4f-59f5-4e3d-b7cb-c26174111438)


Technical Details
----------------------------------------
The underlying code supports a blank renewal date as it uses the existing membership dates. It seems silly to force the user to enter a date when it can be calculated.

The form hides "Extend membership by" but this seems unnecessary and adds complexity (js) to the form. It also, in my opinion, makes the form a bit more confusing by not being visible. It has a default value and is required so let's just display the default value.
Moved the description from the top of the form to the relevant membership date fields and clarified what actually happens for a current and for an expired membership.


Comments
----------------------------------------
Partial from #30105