### PR TITLE
dev/core#5228 Add support for Payment custom fields

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -25,6 +25,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
   use CRM_Contact_Form_ContactFormTrait;
   use CRM_Contribute_Form_ContributeFormTrait;
   use CRM_Event_Form_EventFormTrait;
+  use CRM_Custom_Form_CustomDataTrait;
 
   /**
    * Id of the component entity
@@ -229,6 +230,13 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     $this->assign('displayName', $this->getContactValue('display_name'));
     $this->assign('component', $this->_component);
     $this->assign('email', $this->_contributorEmail);
+    if ($this->isSubmitted()) {
+      // The custom data fields are added to the form by an ajax form.
+      // However, if they are not present in the element index they will
+      // not be available from `$this->getSubmittedValue()` in post process.
+      // We do not have to set defaults or otherwise render - just add to the element index.
+      $this->addCustomDataFieldsToForm('FinancialTrxn');
+    }
 
     $js = NULL;
     // render backoffice payment fields only on offline mode
@@ -295,8 +303,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
    * @throws \CRM_Core_Exception
    */
   public function postProcess() {
-    $submittedValues = $this->controller->exportValues($this->_name);
-    $this->submit($submittedValues);
+    $this->submit($this->getSubmittedValues());
     $session = CRM_Core_Session::singleton();
     $session->replaceUserContext(CRM_Utils_System::url('civicrm/contact/view',
       "reset=1&cid={$this->_contactId}&selectedChild=" . $this->getParticipantID() ? 'participant' : 'contribute'
@@ -339,7 +346,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       'trxn_date' => $this->getSubmittedValue('trxn_date'),
       // This form sends payment notification only, for historical reasons.
       'is_send_contribution_notification' => FALSE,
-    ];
+    ] + $this->getSubmittedCustomFields();
     $paymentID = civicrm_api3('Payment', 'create', $trxnsData)['id'];
     $contributionAddressID = CRM_Contribute_BAO_Contribution::createAddress($this->getSubmittedValues());
     if ($contributionAddressID) {

--- a/CRM/Custom/Form/CustomDataTrait.php
+++ b/CRM/Custom/Form/CustomDataTrait.php
@@ -148,4 +148,22 @@ trait CRM_Custom_Form_CustomDataTrait {
     return is_string($this->getSubmitValue($elementName)) ? CRM_Utils_String::purifyHTML($this->getSubmitValue($elementName)) : $this->getSubmitValue($elementName);
   }
 
+  /**
+   * Get the submitted custom fields.
+   *
+   * This is returned apiv3 style but in future could take
+   * api version as a parameter.
+   *
+   * @return array
+   */
+  protected function getSubmittedCustomFields(): array {
+    $fields = [];
+    foreach ($this->getSubmittedValues() as $label => $field) {
+      if (CRM_Core_BAO_CustomField::getKeyID($label)) {
+        $fields[$label] = $field;
+      }
+    }
+    return $fields;
+  }
+
 }

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -57,6 +57,9 @@ class CRM_Financial_BAO_Payment {
     $paymentTrxnParams['is_payment'] = 1;
     // Really we should have a DB default.
     $paymentTrxnParams['fee_amount'] ??= 0;
+    if (!empty($params['custom'])) {
+      $paymentTrxnParams['custom'] = $params['custom'];
+    }
 
     if (isset($paymentTrxnParams['payment_processor_id']) && empty($paymentTrxnParams['payment_processor_id'])) {
       // Don't pass 0 - ie the Pay Later processor as it is  a pseudo-processor.

--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -133,6 +133,7 @@ function civicrm_api3_payment_create($params) {
       }
     }
   }
+  _civicrm_api3_format_params_for_create($params, 'FinancialTrxn');
   // Check if it is an update
   if (!empty($params['id'])) {
     $amount = $params['total_amount'];

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -105,6 +105,7 @@
       {include file='CRM/Core/BillingBlockWrapper.tpl' currency=false}
     </details>
 
+    {include file="CRM/common/customDataBlock.tpl" customDataType='FinancialTrxn'}
     {literal}
     <script type="text/javascript">
       CRM.$(function($) {

--- a/templates/CRM/Financial/Form/PaymentEdit.tpl
+++ b/templates/CRM/Financial/Form/PaymentEdit.tpl
@@ -22,6 +22,7 @@
      {/foreach}
    </div>
 {/crmRegion}
+{include file="CRM/common/customDataBlock.tpl" customDataType='FinancialTrxn' customDataSubType=false entityID=$id groupID='' cid=false}
 <div class="crm-submit-buttons">
   {include file="CRM/common/formButtons.tpl" location="bottom"}
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
[Remove unused properties, extra comment](https://lab.civicrm.org/dev/core/-/issues/5228)

Before
----------------------------------------
Core forms do not handle custom fields for Payments (Financial transactions) - an extension by @pradpnayak https://github.com/pradpnayak/financialtrxncustomfields does add them - but this fell over on a recent upgrade so moving them into core makes sense


After
----------------------------------------
If the option value is created we also see

![image](https://github.com/civicrm/civicrm-core/assets/336308/9dc17987-ff48-4115-8777-08ca6c5172f5)


Technical Details
----------------------------------------
In discussion with Coleman it seems odd not to put the option value for this & other entities we have form layer support for custom fields for into core - but there might be some upgrade script considerations

Also some tidy up eg

![image](https://github.com/civicrm/civicrm-core/assets/336308/f62d8271-2d2e-4dcf-a0ae-4714ff8e8374)

Comments
----------------------------------------
