### PR TITLE
Remove extraneous `}` from generated link

### DIFF
--- a/CRM/Event/Form/ParticipantView.php
+++ b/CRM/Event/Form/ParticipantView.php
@@ -158,7 +158,7 @@ class CRM_Event_Form_ParticipantView extends CRM_Core_Form {
     }
     if (CRM_Core_Permission::check('delete in CiviEvent')) {
       $recentOther['deleteUrl'] = CRM_Utils_System::url('civicrm/participant/delete',
-        "reset=1&id={$values[$participantID]['id']}}"
+        "reset=1&id={$values[$participantID]['id']}"
       );
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove extraneous `}` from generated link - regression from late 2023

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/66171b59-dbf2-4aae-9100-24b0e4b323a8)

clicking on it fails

![image](https://github.com/civicrm/civicrm-core/assets/336308/cefa7f71-f544-49d3-97df-78cba2c61059)


After
----------------------------------------
extra `}` is gone but note that links created before this patch is applied need to age out as they are cached

Technical Details
----------------------------------------
This came up when I put the html in a validator

Comments
----------------------------------------
