### PR TITLE
Alternate to part of 30382 - replace tpl php call to permission::check

### DIFF
--- a/CRM/Contribute/Page/UserDashboard.php
+++ b/CRM/Contribute/Page/UserDashboard.php
@@ -140,6 +140,7 @@ class CRM_Contribute_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBo
    */
   public function run() {
     $this->assign('isIncludeInvoiceLinks', $this->isIncludeInvoiceLinks());
+    $this->assign('canViewMyInvoicesOrAccessCiviContribute', CRM_Core_Permission::check([['view my invoices', 'access CiviContribute']]));
     parent::preProcess();
     $this->listContribution();
   }

--- a/templates/CRM/Contribute/Page/UserDashboard.tpl
+++ b/templates/CRM/Contribute/Page/UserDashboard.tpl
@@ -46,7 +46,7 @@
                             {assign var='id' value=$row.id}
                             {assign var='contact_id' value=$row.contact_id}
                             {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id"}
-                            {if call_user_func(array('CRM_Core_Permission','check'), 'view my invoices') OR call_user_func(array('CRM_Core_Permission','check'), 'access CiviContribute')}
+                            {if $canViewMyInvoicesOrAccessCiviContribute}
                                 <a class="button no-popup nowrap"
                                    href="{crmURL p='civicrm/contribute/invoice' q=$urlParams}">
                                     <i class="crm-i fa-download" aria-hidden="true"></i>


### PR DESCRIPTION
Overview
----------------------------------------
Alternate to part of 30382

Before
----------------------------------------
call to php function from tpl

After
----------------------------------------
assign to smarty var from php

Technical Details
----------------------------------------
Bonus: If you had lots of contributions previously it would make 2 calls to check() for each one that always return the same thing. Now it just makes one at the start. Although this block is a bit weird anyway and as per the code comment should probably work differently.

Comments
----------------------------------------

