### PR TITLE
Afform - Fix console error in conditional rule

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiCondition.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiCondition.component.js
@@ -13,6 +13,7 @@
     controller: function ($scope) {
       var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
         ctrl = this;
+      let conditionValue;
       this.operators = [
         {
           "key": "==",
@@ -55,8 +56,14 @@
         }
       }
 
+      // Getter for ng-model.
+      // Returns a reference to avoid infinite loops in ngModel.watch
       function getValue() {
-        return JSON.parse(ctrl.clause[1 + ctrl.offset]);
+        let newVal = JSON.parse(ctrl.clause[1 + ctrl.offset]);
+        if (!angular.equals(newVal, conditionValue)) {
+          conditionValue = newVal;
+        }
+        return conditionValue;
       }
 
       function setValue(val) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix console errors when configuring Afform conditional rules.

Before
----------------------------------------
Error appears when adding a condition based on a multi-select (e.g. 'If contact_sub_type = [Student]')

![image](https://github.com/civicrm/civicrm-core/assets/2874912/55766a31-d8c4-4762-8710-dfb23c36ec4a)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/2874912/e9ea3c9e-a4d7-4c7e-a4b8-b591551e58e4)


Technical Details
----------------------------------------
Angular === Anger