### PR TITLE
dev/core#5289 Fix participant fee amount not updated when no -contribution

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1559,10 +1559,11 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       'note' => $this->getSubmittedValue('note'),
       'is_test' => $this->isTest(),
     ];
-    if (!$this->getParticipantID()) {
-      // For new registrations fill in fee detail. For existing
-      // registrations we are not doing anything on this form that would require
-      // these fields to change.
+    if (!$this->getParticipantID() || !$this->getContributionID()) {
+      // For new registrations, or existing ones with no contribution,
+      // fill in fee detail. For existing
+      // registrations with a contribution the user will have the option to
+      // change the fees via a different form.
       $order = $this->getOrder();
       if ($order) {
         $participantParams['fee_level'] = $order->getAmountLevel();

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -128,6 +128,8 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
       $sum += $financialItem['amount'];
     }
     $this->assertEquals(100, $sum);
+    $participant = $this->callAPISuccessGetSingle('Participant', []);
+    $this->assertEquals(100, $participant['participant_fee_amount']);
 
     $priceSetID = $this->ids['PriceSet']['PaidEvent'];
     $eventFeeBlock = CRM_Price_BAO_PriceSet::getSetDetail($priceSetID)[$priceSetID]['fields'];
@@ -152,6 +154,40 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
       $sum += $financialItem['amount'];
     }
     $this->assertEquals(1550.55, $sum);
+  }
+
+  /**
+   * Test fee_amount altered while changed in a pending state.
+   *
+   * See https://lab.civicrm.org/dev/core/-/issues/5289
+   *
+   * @throws \Exception
+   */
+  public function testSubmitNoContributionPlusPriceChange(): void {
+    $this->eventCreatePaid([], ['is_quick_config' => TRUE]);
+    $params = [
+      'register_date' => date('Ymd'),
+      'record_contribution' => FALSE,
+      'priceSetId' => $this->getPriceSetID('PaidEvent'),
+      $this->getPriceFieldKey() => $this->ids['PriceFieldValue']['PaidEvent_student'],
+      'send_receipt' => FALSE,
+      'role_id' => [0 => CRM_Core_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'role_id', 'Attendee')],
+      'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'status_id', 'Pending from pay later'),
+      'source' => 'I wrote this',
+      'event_id' => $this->getEventID(),
+      'contact_id' => $this->individualCreate(),
+      '_qf_default' => '',
+    ];
+    $this->getTestForm('CRM_Event_Form_Participant', $params)->processForm();
+
+    $participant = $this->callAPISuccessGetSingle('Participant', []);
+    $this->assertEquals(100, $participant['participant_fee_amount']);
+
+    $params[$this->getPriceFieldKey()] = $this->ids['PriceFieldValue']['PaidEvent_standard'];
+    $this->getTestForm('CRM_Event_Form_Participant', $params, ['id' => $participant['id']])->processForm();
+
+    $participant = $this->callAPISuccessGetSingle('Participant', ['id' => $participant['id']]);
+    $this->assertEquals(300, $participant['participant_fee_amount']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5289 Fix participant fee amount not updated when no -contribution

https://lab.civicrm.org/dev/core/-/issues/5289

Before
----------------------------------------
Once a  participant record has been created WITH a  contribution recorded it is not possible to change the amount on the back office participant form - the Change Fee Selection must be launched but because , sigh, that's how it is, it IS possible to alter the amount on the Participant form if a contribution has not been recorded (insert rant). We have a regression where in this second scenario the `fee_amount` field on the record in `civicrm_participant` is not updated


After
----------------------------------------
Now it is updated

Technical Details
----------------------------------------

Comments
----------------------------------------
