### PR TITLE
Add test for api4 Product.get options unserialize

### DIFF
--- a/tests/phpunit/api/v4/Entity/ProductTest.php
+++ b/tests/phpunit/api/v4/Entity/ProductTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4\Entity;
+
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class ProductTest extends Api4TestBase implements TransactionalInterface {
+
+  /**
+   * Product options are serialized - make sure they are consistent between
+   * create/get calls
+   */
+  public function testProductOptions(): void {
+    $options = [
+      'T26-ONI-C01' => 'Small',
+      'T26-ONI-C02' => 'Medium',
+      'T26-ONI-C03' => 'Large',
+    ];
+
+    $p1 = $this->createTestRecord('Product', [
+      'name' => 'Tshirt',
+      'imageOption' => 'noImage',
+      'options' => $options,
+    ]);
+
+    $p2 = \Civi\Api4\Product::get(FALSE)
+      ->addSelect('options')
+      ->addWhere('id', '=', $p1['id'])
+      ->execute()
+      ->single();
+
+    $this->assertEquals($options, $p2['options']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

~~Follow-up to #29691, so that api4 Product.get can return a correctly formatted array of product attributes.~~ fixed in #31590.

This PR adds a test for the serialize/unserialize behaviour for a specific entity (#31590 has a test for the specific function, but not for an entity).

Before
----------------------------------------

Some testing.

After
----------------------------------------

More testing.

Comments
----------------------

(original comment, not relevant anymore)

@colemanw Any thoughts how the field should be named? Can I replace the existing `options`? or do I need to add a new field?