### PR TITLE
dev/core#5280 Fix bug switching between member type & price set on back-office membership

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -602,16 +602,17 @@
       if (!priceSetId) {
         priceSetId = cj("#price_set_id").val();
       }
-        var fname = '#priceset';
+
         if ( !priceSetId ) {
         cj('#membership_type_id_1').val(0);
         CRM.buildCustomData('Membership', null);
 
         // hide price set fields.
-        cj( fname ).hide( );
+        cj('#priceset').empty();
 
         // show/hide price set amount and total amount.
         cj( "#mem_type_id").show( );
+
         var choose = "{/literal}{ts escape='js'}Choose price set{/ts}{literal}";
         cj("#price_set_id option[value='']").html( choose );
         cj( "#totalAmountORPriceSet" ).show( );
@@ -635,7 +636,7 @@
         async: false
       }).responseText;
 
-      cj( fname ).show( ).html( response );
+      cj('#priceset').show( ).html( response );
       // freeze total amount text field.
 
       cj( "#totalAmountORPriceSet" ).hide( );


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5280 Fix bug switching between member type & price set on back-office membership

Before
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/5280 - be sure to make the field in the price set required + select & to open in pop-up mode

After
----------------------------------------
Saves

Technical Details
----------------------------------------
The price set field was being left behind & jquery validate was enforcing it.

I don't think this is a regression

Comments
----------------------------------------
