### PR TITLE
[ref] Clarify job object

### DIFF
--- a/tests/phpunit/api/v3/JobProcessMailingTest.php
+++ b/tests/phpunit/api/v3/JobProcessMailingTest.php
@@ -530,10 +530,8 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
    * @dataProvider getBooleanDataProvider
    *
    * @param bool $isBulk
-   *
-   * @throws \CRM_Core_Exception
    */
-  public function testBatchActivityTargets($isBulk): void {
+  public function testBatchActivityTargets(bool $isBulk): void {
     $loggedInUserId = $this->createLoggedInUser();
 
     \Civi::settings()->set('mailerBatchLimit', 2);
@@ -546,7 +544,7 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
 
     $this->createContactsInGroup(6, $this->_groupID);
     $mailing = $this->callAPISuccess('mailing', 'create', $this->_params + ['scheduled_id' => $loggedInUserId]);
-    $this->callAPISuccess('job', 'process_mailing', []);
+    $this->callAPISuccess('Job', 'process_mailing', []);
     $bulkEmailActivity = $this->callAPISuccess('Activity', 'getsingle', [
       'source_record_id' => $mailing['id'],
       'activity_type_id' => 'Bulk Email',


### PR DESCRIPTION
Overview
----------------------------------------
Clarify job object

Before
----------------------------------------
The `job` object is mixed in with the query results which is confusing. In addition it uses the `query()` function which is more prone to memory leaks 

After
----------------------------------------
The use of  the query result is separated from the job object. This does require one extra query but it's a cheap one in the scheme of the processing that is happening here & seems worth the trade off.

Technical Details
----------------------------------------
The `deliver` functions used to be called as class functions on the job object but we ditched that as confusing quite a while back

Comments
----------------------------------------
