### PR TITLE
[REF] Remove a few unused variables

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -209,18 +209,14 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
     $job = new CRM_Mailing_BAO_MailingJob();
 
     $mailing = new CRM_Mailing_BAO_Mailing();
-
-    $config = CRM_Core_Config::singleton();
-    $jobTable = CRM_Mailing_DAO_MailingJob::getTableName();
     $mailingTable = CRM_Mailing_DAO_Mailing::getTableName();
 
     $currentTime = date('YmdHis');
-    $mailingACL = CRM_Mailing_BAO_Mailing::mailingACL('m');
     $domainID = CRM_Core_Config::domainID();
 
     $query = "
                 SELECT   j.*
-                  FROM   $jobTable     j,
+                  FROM   civicrm_mailing_job     j,
                                  $mailingTable m
                  WHERE   m.id = j.mailing_id AND m.domain_id = {$domainID}
                    AND   j.is_test = 0


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Remove a few unused variables

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/c752310e-ae5f-467e-a3fa-dffc78ec6a7a)

After
----------------------------------------
poof

Technical Details
----------------------------------------
I left the mailing table for now cos I think it uses localization & the `query()` function doesn't work with that - which is what the point of the legacy `getTableName()` was

Comments
----------------------------------------
