### PR TITLE
Provide Grant tokens & by extension tokens for any entity by declaring some metadata

### DIFF
--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -91,6 +91,15 @@ class CRM_Core_DAO_AllCoreTables {
   }
 
   /**
+   * Get the declared token classes.
+   * @return string[]
+   *   [table_name => token class]
+   */
+  public static function tokenClasses() {
+    return array_column(self::getEntities(), 'token_class', 'name');
+  }
+
+  /**
    * @return array
    *   List of indices.
    */

--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -363,9 +363,13 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
    * @return bool
    */
   public function checkActive(TokenProcessor $processor) {
+    $isEntityEnabled = in_array($this->getApiEntityName(), array_keys(\Civi::service('action_object_provider')->getEntities()));
+    if (!$isEntityEnabled) {
+      return FALSE;
+    }
     return ((!empty($processor->context['actionMapping'])
         // This makes the 'schema context compulsory - which feels accidental
-      && $processor->context['actionMapping']->getEntityName()) || in_array($this->getEntityIDField(), $processor->context['schema'])) && in_array($this->getApiEntityName(), array_keys(\Civi::service('action_object_provider')->getEntities()));
+      && $processor->context['actionMapping']->getEntityName()) || in_array($this->getEntityIDField(), $processor->context['schema']));
   }
 
   /**

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -345,6 +345,7 @@ class Container {
       'Civi\Token\TokenCompatSubscriber',
       []
     ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
+
     $container->setDefinition("crm_mailing_action_tokens", new Definition(
       'CRM_Mailing_ActionTokens',
       []
@@ -389,6 +390,16 @@ class Container {
       'CRM_Core_DomainTokens',
       []
     ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
+
+    // For each DAO that supports tokens by declaring the token class...
+    $entities = \CRM_Core_DAO_AllCoreTables::tokenClasses();
+    foreach ($entities as $entity => $class) {
+      $container->setDefinition('crm_entity_token_' . strtolower($entity), new Definition(
+        $class,
+        [$entity]
+      ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
+    }
+
     $container->setDefinition('crm_token_tidy', new Definition(
       '\Civi\Token\TidySubscriber',
       []

--- a/Civi/Token/GenericEntityTokens.php
+++ b/Civi/Token/GenericEntityTokens.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Token;
+
+class GenericEntityTokens extends \CRM_Core_EntityTokens {
+
+  /**
+   * @var string
+   */
+  private string $apiEntityName;
+
+  /**
+   * Class constructor.
+   */
+  public function __construct($entity) {
+    $this->apiEntityName = $entity;
+    parent::__construct();
+  }
+
+  /**
+   * Get the entity name for api v4 calls.
+   *
+   * @return string
+   */
+  protected function getApiEntityName(): string {
+    return $this->apiEntityName;
+  }
+
+}

--- a/ext/civigrant/schema/Grant.entityType.php
+++ b/ext/civigrant/schema/Grant.entityType.php
@@ -5,6 +5,7 @@ return [
   'name' => 'Grant',
   'table' => 'civicrm_grant',
   'class' => 'CRM_Grant_DAO_Grant',
+  'token_class' => 'Civi\Token\GenericEntityTokens',
   'getInfo' => fn() => [
     'title' => E::ts('Grant'),
     'title_plural' => E::ts('Grants'),
@@ -45,7 +46,7 @@ return [
       'usage' => [
         'import',
         'export',
-        'duplicate_matching',
+        'token',
       ],
       'primary_key' => TRUE,
       'auto_increment' => TRUE,
@@ -60,6 +61,7 @@ return [
       'unique_name' => 'grant_contact_id',
       'usage' => [
         'export',
+        'import',
       ],
       'input_attrs' => [
         'label' => E::ts('Contact'),
@@ -80,7 +82,7 @@ return [
       'usage' => [
         'import',
         'export',
-        'duplicate_matching',
+        'token',
       ],
       'input_attrs' => [
         'format_type' => 'activityDate',
@@ -96,7 +98,7 @@ return [
       'usage' => [
         'import',
         'export',
-        'duplicate_matching',
+        'token',
       ],
       'input_attrs' => [
         'format_type' => 'activityDate',
@@ -112,7 +114,7 @@ return [
       'usage' => [
         'import',
         'export',
-        'duplicate_matching',
+        'token',
       ],
       'input_attrs' => [
         'format_type' => 'activityDate',
@@ -127,7 +129,7 @@ return [
       'usage' => [
         'import',
         'export',
-        'duplicate_matching',
+        'token',
       ],
       'input_attrs' => [
         'format_type' => 'activityDate',
@@ -144,7 +146,7 @@ return [
       'usage' => [
         'import',
         'export',
-        'duplicate_matching',
+        'token',
       ],
     ],
     'grant_type_id' => [
@@ -156,6 +158,7 @@ return [
       'add' => '1.8',
       'usage' => [
         'export',
+        'token',
       ],
       'pseudoconstant' => [
         'option_group_name' => 'grant_type',
@@ -171,7 +174,7 @@ return [
       'usage' => [
         'import',
         'export',
-        'duplicate_matching',
+        'token',
       ],
     ],
     'amount_requested' => [
@@ -180,6 +183,11 @@ return [
       'input_type' => 'Text',
       'description' => E::ts('Requested grant amount, in original currency (optional).'),
       'add' => '1.8',
+      'usage' => [
+        'import',
+        'export',
+        'token',
+      ],
     ],
     'amount_granted' => [
       'title' => E::ts('Amount granted'),
@@ -190,7 +198,7 @@ return [
       'usage' => [
         'import',
         'export',
-        'duplicate_matching',
+        'token',
       ],
     ],
     'currency' => [
@@ -210,6 +218,11 @@ return [
         'name_column' => 'name',
         'abbr_column' => 'symbol',
       ],
+      'usage' => [
+        'import',
+        'export',
+        'token',
+      ],
     ],
     'rationale' => [
       'title' => E::ts('Grant Rationale'),
@@ -220,7 +233,7 @@ return [
       'usage' => [
         'import',
         'export',
-        'duplicate_matching',
+        'token',
       ],
       'input_attrs' => [
         'rows' => 4,
@@ -237,7 +250,8 @@ return [
       'unique_name' => 'grant_status_id',
       'usage' => [
         'import',
-        'duplicate_matching',
+        'export',
+        'token',
       ],
       'pseudoconstant' => [
         'option_group_name' => 'grant_status',
@@ -252,6 +266,11 @@ return [
       'default' => NULL,
       'input_attrs' => [
         'label' => E::ts('Financial Type'),
+      ],
+      'usage' => [
+        'import',
+        'export',
+        'token',
       ],
       'pseudoconstant' => [
         'table' => 'civicrm_financial_type',

--- a/ext/civigrant/tests/phpunit/Civi/TokenTest.php
+++ b/ext/civigrant/tests/phpunit/Civi/TokenTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi;
+
+use Civi\Test\EntityTrait;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+use Civi\Token\TokenProcessor;
+use PHPUnit\Framework\TestCase;
+
+/**
+ *  Test APIv3 civicrm_grant* functions
+ *
+ * @package CiviCRM_APIv3
+ * @subpackage API_Grant
+ * @group headless
+ */
+class TokenTest extends TestCase implements HeadlessInterface, TransactionalInterface {
+
+  use EntityTrait;
+
+  /**
+   * @throws \CRM_Extension_Exception_ParseException
+   */
+  public function setUpHeadless(): Test\CiviEnvBuilder {
+    return Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function testTokens(): void {
+    $this->createTestEntity('OptionValue', [
+      'option_group_id:name' => 'grant_type',
+      'value' => 1,
+      'name' => 'community_grant',
+      'label' => 'Community Grant',
+    ]);
+    $this->createTestEntity('Grant', [
+      'contact_id' => $this->createTestEntity('Contact', ['contact_type' => 'organization', 'organization_name' => 'The Firm'])['id'],
+      'application_received_date' => '2024-05-07',
+      'decision_date' => '2024-06-07',
+      'amount_total' => '500.00',
+      'status_id' => 1,
+      'rationale' => 'Just Because',
+      'currency' => 'USD',
+      'grant_type_id:name' => 'community_grant',
+    ]);
+    $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), ['schema' => ['grantId']]);
+    $tokens = $tokenProcessor->listTokens();
+    $this->assertEquals('Grant Report Due Date', $tokens['{grant.grant_due_date}']);
+    $tokenProcessor->addMessage('html', '{grant.application_received_date} {grant.status_id:label} {grant.rationale}', 'text/html');
+    $tokenProcessor->addRow(['grantId' => $this->ids['Grant']['default']]);
+    $tokenProcessor->evaluate();
+    $row = $tokenProcessor->getRow(0);
+    $this->assertEquals('May 7th, 2024 Submitted Just Because', $text = $row->render('html'));
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------


Provide Grant tokens & by extension tokens for any entity by declaring some metadata 

This specifically adds tokens for CiviGrant but more generally adds a mechanism to allow any entity to add generic tokens by inserting some values in the entity definition and is part of an effort to lower the bar to have entity features for custom & core enitities

Before
----------------------------------------
No tokens for CiviGrant, fairly hard to add tokens for 'random' entities

After
----------------------------------------
Tokens can be added for random entities by defining the `token_class` in the `entityType` file & more specifically setting it to the `Civi/Token/GenericEntityTokens.php` class 

Technical Details
----------------------------------------
The mechanism to determine the `DAO`s that define the class is still to be done - there is a placeholder ATM

Comments
----------------------------------------
