### PR TITLE
Add line item information to values returned by apiv4 Order.create

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -1474,8 +1474,10 @@ class CRM_Financial_BAO_Order {
     $contributionValues['amount_level'] = $this->getAmountLevel();
     $contributionValues['contribution_status_id:name'] = 'Pending';
     $contributionValues['line_item'] = [$this->getLineItems()];
-    return Contribution::create()
+    $result = Contribution::create()
       ->setValues($contributionValues)->execute();
+    $result[0]['line_item'] = $contributionValues['line_item'][0];
+    return $result;
   }
 
   /**

--- a/tests/phpunit/CRM/Financial/BAO/OrderTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/OrderTest.php
@@ -80,6 +80,10 @@ class CRM_Financial_BAO_OrderTest extends CiviUnitTestCase {
       ])
       ->addLineItem([
         'price_field_value_id' => $this->ids['PriceFieldValue']['membership_first'],
+        // Because the price field value relates to a membership type
+        // the entity_id is understood to be a membership ID.
+        // All provided values prefixed by entity_id will be passed to
+        // the membership.create api.
         'entity_id.join_date' => '2006-01-21',
         'entity_id.start_date' => '2006-01-21',
         'entity_id.end_date' => '2006-12-21',
@@ -122,13 +126,22 @@ class CRM_Financial_BAO_OrderTest extends CiviUnitTestCase {
         'financial_type_id:name' => 'Member Dues',
       ])
       ->addLineItem([
+        // As this price field value has a membership type ID attached
+        // a membership will be created in response to this.
+        // All other values will be loaded from the price field value,
+        // with the contact_id defaulting to that of the contribution (above).
         'price_field_value_id' => $this->ids['PriceFieldValue']['membership_first'],
       ])
       ->addLineItem([
+        // The amount, financial type will come from the price field value record.
+        // Note this price field value is not in the same price set as the above one.
         'price_field_value_id' => $this->ids['PriceFieldValue']['hundred'],
       ])
       ->addLineItem([
         // This will assume the order financial type & quantity = 1,
+        // The price field value will be that of the default line item
+        // (generally ID = 1) which is the 'generic' one.
+        // Note that it is not part of either the above price sets.
         'line_total' => 500,
         'description' => 'Some extra dosh',
       ])

--- a/tests/phpunit/CRM/Financial/BAO/OrderTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/OrderTest.php
@@ -36,7 +36,7 @@ class CRM_Financial_BAO_OrderTest extends CiviUnitTestCase {
   public function testCreateOrderParticipantAndDonation(): void {
     $this->eventCreatePaid();
     $this->individualCreate();
-    Order::create()
+    $order = Order::create()
       ->setContributionValues([
         'contact_id' => $this->ids['Contact']['individual_0'],
         'financial_type_id' => 1,
@@ -48,7 +48,8 @@ class CRM_Financial_BAO_OrderTest extends CiviUnitTestCase {
         'financial_type_id' => 3,
         'price_field_value_id' => $this->ids['PriceFieldValue']['PaidEvent_student_early'],
       ])
-      ->execute();
+      ->execute()->single();
+    $this->assertCount(1, $order['line_item']);
     $contribution = Contribution::get(FALSE)
       ->addWhere('contact_id', '=', $this->ids['Contact']['individual_0'])
       ->execute()->single();
@@ -114,7 +115,7 @@ class CRM_Financial_BAO_OrderTest extends CiviUnitTestCase {
     $this->setUpMembershipPriceSet();
     $this->setUpGenericPriceSet();
 
-    Order::create()
+    $order = Order::create()
       ->setContributionValues([
         'contact_id' => $this->individualCreate(),
         'receive_date' => '2010-01-20',
@@ -132,6 +133,8 @@ class CRM_Financial_BAO_OrderTest extends CiviUnitTestCase {
         'description' => 'Some extra dosh',
       ])
       ->execute()->first();
+    $this->assertCount(3, $order['line_item']);
+    $this->assertEquals('civicrm_membership', $order['line_item'][0]['entity_table']);
     $contribution = Contribution::get(FALSE)
       ->addWhere('contact_id', '=', $this->ids['Contact']['individual_0'])
       ->execute()->single();


### PR DESCRIPTION
Overview
----------------------------------------
Add line item information to values returned by apiv4 Order

Before
----------------------------------------
No line item / entity information returned

After
----------------------------------------
The details that are know to the code within the order api are returned - this is effectively everything but the line item ID as the rest is generated in the function

![image](https://github.com/civicrm/civicrm-core/assets/336308/fa4aaddb-a97c-413b-9470-fc46f6c72259)


Technical Details
----------------------------------------
This is the main part missing to give v4 Order api parity with v3

We *could* look up the line item ID but it feels like it would be more of an edge case to require it and it adds a looking

@mattwire @artfulrobot @seamuslee001 @monishdeb 


Comments
----------------------------------------
I also added some commentary to the unit tests as I screenshotted them for the dev-digets