### PR TITLE
Check for group array with IN clause on the delete form

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -403,7 +403,8 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
       );
       // Check each group search for valid groups.
       foreach ($groupSearches as $groupSearch) {
-        if (!empty($groupSearch[2]) && in_array($groupID, (array) $groupSearch[2])) {
+        $groupFormValues = (array) ($groupSearch[2]['IN'] ?? $groupSearch[2] ?? []);
+        if (!empty($groupFormValues) && in_array($groupID, $groupFormValues)) {
           $smartGroups[$group['id']] = [
             'title' => $group['title'],
             'editSearchURL' => self::getEditSearchUrl($group['saved_search_id']),

--- a/templates/CRM/Group/Form/Delete.tpl
+++ b/templates/CRM/Group/Form/Delete.tpl
@@ -21,7 +21,7 @@
     {ts}Deleting this group will NOT delete the member contact records. However, all contact subscription information and history for this group will be deleted.{/ts} {ts}If this group is used in CiviCRM profiles, those fields will be reset.{/ts} {ts}This action cannot be undone.{/ts}
 
     {if $smartGroupsUsingThisGroup}
-      <p><strong>{ts 1=$smartGroupsUsingThisGroup|count}WARNING - This Group is currently referenced by %1 smart group(s).{/ts}</strong></p>
+      <p><strong>{ts 1=$smartGroupsUsingThisGroup|@count}WARNING - This Group is currently referenced by %1 smart group(s).{/ts}</strong></p>
       <p>{ts}Deleting this group will mean the following Smart Groups will no longer restrict based on membership in this group - as they do currently. Please edit and resave these smart groups to remove reference to this group before deleting.{/ts}</p>
       <ul>
       {foreach from=$smartGroupsUsingThisGroup item=group key=k}


### PR DESCRIPTION
Overview
----------------------------------------
Similar to https://github.com/civicrm/civicrm-core/pull/30391 with more detailed checking for group params.

Before
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/30391 on different possible params for smart groups. 

Form values with params like 

```
       [1] => Array
        (
            [0] => group
            [1] => =
            [2] => Array
                (
                    [IN] => Array
                        (
                            [0] => 3
                        )

                )

            [3] => 0
            [4] => 0
        )

```

is not checked with the current if clause.

Also fixes a the count display on template.

After
----------------------------------------
if clause checks for group ids present inside 'IN'.


