### PR TITLE
Fixes UI#73 - squashed DataTables inside ajax accordions

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2294,6 +2294,11 @@ div.crm-master-accordion-header a.helpicon {
   padding: 0 0.25rem; /* adds padding for nested accordions */
 }
 
+.crm-container details table.dataTable {
+  width: 100% !important; /* stops collapsed dataTables: dev/user-interface/-/issues/73 */
+  box-sizing: border-box;
+}
+
 /* Collapse icon */
 
 /* General icon settings for all collapsible things */


### PR DESCRIPTION
With the update of the accordion markup to details/summary, dataTables that are hidden by a collapsed accordion have their width set by JS as 0px, before the data is loaded, creating a a squashed table. This resolves that via CSS and is applied to any similar scenario (dataTable inside a `<details>` accordion).

Before
----------------------------------------
<img width="1475" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/f3bbcaf4-37ce-4633-8b9e-4ec266a6622d">

After
----------------------------------------
<img width="1471" alt="image" src="https://github.com/civicrm/civicrm-core/assets/1175967/faaf60bb-97b8-48cc-9645-18541c317bcc">

Technical Details
----------------------------------------
Border-box is needed to stop a 1px overlap on the right margin because civicrm.css doesn't have a border-box reset.

There are several other possible fixes here: remove dataTables, fix the JS, or [get the JS to set the table](https://lab.civicrm.org/dev/user-interface/-/issues/73#note_165992) at 100% width. Despite using an `!important` declaration, which should be avoided as much as possible, by putting the fix in the CSS this a) avoids JS inserting an inline css style into markup; b) makes it easier to handle this at theme level; and c) all these temporary fixes for outdated JS can be put in one place like a [fixes.css file](https://lab.civicrm.org/extensions/riverlea/-/commit/eb3436283dd64fd8dffd641d538dca3c5c0efb6a), so if dataTables was updated/removed, they could be removed too.

Comments
----------------------------------------
This fix is applied more widely than the scenario presented. Targeting `.crm-container .crm-case-caseview-form-block table` would be narrower in scope to only the bug initially raised. As this seems to be a problem with dataTables inside closed accordions, the selector here focuses on that - which may mean this fix impacts/fixes other displays than the one in the original issue.