### PR TITLE
[REF] Make lineItem field optional in processAmount

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -995,7 +995,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       // @todo - processAmount is to be deprectated - can we use getTotalAmount or
       // a function of self->order here?
       CRM_Price_BAO_PriceSet::processAmount($self->_values['fee'],
-        $fields, $lineItem
+        $fields
       );
 
       $minAmt = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $fields['priceSetId'], 'min_amount');

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -566,10 +566,7 @@ WHERE li.contribution_id = %1";
     $feeBlock
   ) {
     $entityTable = 'civicrm_' . $entity;
-    $newLineItems = [];
-    CRM_Price_BAO_PriceSet::processAmount($feeBlock,
-      $params, $newLineItems
-    );
+    CRM_Price_BAO_PriceSet::processAmount($feeBlock, $params);
     // initialize empty Lineitem instance to call protected helper functions
     $lineItemObj = new CRM_Price_BAO_LineItem();
 

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -569,7 +569,7 @@ WHERE  id = %1";
    * @todo $priceSetID is a pseudoparam for permit override - we should stop passing it where we
    * don't specifically need it & find a better way where we do.
    */
-  public static function processAmount($fields, &$params, &$lineItem, $priceSetID = NULL) {
+  public static function processAmount($fields, &$params, &$lineItem = [], $priceSetID = NULL) {
     // using price set
     foreach ($fields as $id => $field) {
       if (empty($params["price_{$id}"]) ||


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Make lineItem field optional in processAmount

Before
----------------------------------------
Some callers of `processAmount()` are creating a variable to pass to `processAmount()` as `$lineItem` by reference but never use it

After
----------------------------------------
The parameter is optional & 2 callers have been updated not to pass it in

Technical Details
----------------------------------------

Comments
----------------------------------------
