### PR TITLE
dev/core#5251 Expect payment_processor_id to be passed in, if needed

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2260,17 +2260,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $this->find(TRUE);
     }
 
-    $paymentProcessorID = $input['payment_processor_id'] ?? $ids['paymentProcessor'] ?? NULL;
+    $paymentProcessorID = $input['payment_processor_id'] ?? NULL;
 
-    if (!isset($input['payment_processor_id']) && !$paymentProcessorID && $this->contribution_page_id) {
-      $paymentProcessorID = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_ContributionPage',
-        $this->contribution_page_id,
-        'payment_processor'
-      );
-      if ($paymentProcessorID) {
-        $intentionalEnotice = $CRM16923AnUnreliableMethodHasBeenUserToDeterminePaymentProcessorFromContributionPage;
-      }
-    }
     $ids['contributionType'] = $this->financial_type_id;
     $ids['financialType'] = $this->financial_type_id;
     if ($this->contribution_page_id) {

--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -202,7 +202,7 @@ AND    {$this->_componentClause}";
       $input['trxn_date'] = $contribution->trxn_date ?? NULL;
       $input['receipt_update'] = $params['receipt_update'];
       $input['contribution_status_id'] = $contribution->contribution_status_id;
-      $input['paymentProcessor'] = empty($contribution->trxn_id) ? NULL :
+      $input['payment_processor_id'] = empty($contribution->trxn_id) ? NULL :
         CRM_Core_DAO::singleValueQuery("SELECT payment_processor_id
           FROM civicrm_financial_trxn
           WHERE trxn_id = %1


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5251 Expect payment_processor_id to be passed in, if needed

Before
----------------------------------------
Inconsistent passing in of payment processor ID, leads to e-notice

After
----------------------------------------
Expect the functions that call `sendMail()` to pass in the payment processor ID (in a consistent way). This should already be the case in callers on `sendconfirmation` and if not looking it up from the contribution page is as bad today as it ever was...given the field may have more than 1 value.

 it looks like it was never working in `sendPdf` anyway as it was setting `$input['paymentProcessor'] but needed to set either `$ids['paymentProcessor']` OR `$input['payment_processor_id']`

Technical Details
----------------------------------------


Comments
----------------------------------------
