### PR TITLE
dev/core#5298 Update Monaco-editor to version 0.49.0

### DIFF
--- a/Civi/Angular/Page/Modules.php
+++ b/Civi/Angular/Page/Modules.php
@@ -113,7 +113,13 @@ class Modules extends \CRM_Core_Page {
   public function digestJs($files) {
     $scripts = [];
     foreach ($files as $file) {
-      $scripts[] = \CRM_Utils_JS::stripComments(file_get_contents($file));
+      $content = file_get_contents($file);
+      if (str_contains($file, 'monaco-editor')) {
+        $scripts[] = $content;
+      }
+      else {
+        $scripts[] = \CRM_Utils_JS::stripComments($content);
+      }
     }
     $scripts = \CRM_Utils_JS::dedupeClosures(
       $scripts,

--- a/ang/crmMonaco.js
+++ b/ang/crmMonaco.js
@@ -71,23 +71,6 @@
             });
           }
 
-          // FIXME: This makes vertical scrolling much better, but horizontal is still weird.
-          var origOverflow;
-          function bodyScrollSuspend() {
-            if (origOverflow !== undefined) return;
-            origOverflow = $('body').css('overflow');
-            $('body').css('overflow', 'hidden');
-          }
-          function bodyScrollRestore() {
-            if (origOverflow === undefined) return;
-            $('body').css('overflow', origOverflow);
-            origOverflow = undefined;
-          }
-          editorEl.on('mouseenter', bodyScrollSuspend);
-          editorEl.on('mouseleave', bodyScrollRestore);
-          editor.onDidFocusEditorWidget(bodyScrollSuspend);
-          editor.onDidBlurEditorWidget(bodyScrollRestore);
-
           crmMonaco.editor = editor;
 
           $scope.$on('$destroy', function () {

--- a/composer.json
+++ b/composer.json
@@ -218,7 +218,7 @@
         "ignore": [".*", "*.json", "*.md", "Makefile", "*/*"]
       },
       "monaco-editor": {
-        "url": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.25.2.tgz",
+        "url": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.49.0.tgz",
         "path": "bower_components/monaco-editor",
         "ignore": ["dev", "esm"]
       },


### PR DESCRIPTION


Overview
----------------------------------------
dev/core#5298 Update Monaco to laster 0.4 release (0.49)
This is in line with discussions on chat to target 5.75 so it will be in the ESR which is helpful for the bettermsgtpl extension


Before
----------------------------------------
version   0.25.2

After
----------------------------------------
version   0.49.0

Technical Details
----------------------------------------
this is used in core Message Admin and the bettermsgtpl by @konadave - in the latter @konadave has been shipping his own version (0.45) per https://chat.civicrm.org/civicrm/pl/o6yxwwfpo7fffynnh33n7pz5ty which would not be required if we got CiviCRM up to a more recent version

We hit some problems with 0.37.0 not running well through our custom minify so it is now excluded

https://github.com/microsoft/monaco-editor/blob/main/CHANGELOG.md#0370

Comments
----------------------------------------
