### PR TITLE
Stop setting relatedObjects['pledge_payment'] as it is not used

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2295,20 +2295,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $paymentProcessorID = $this->_relatedObjects['contributionRecur']->payment_processor_id;
     }
 
-    if (!empty($ids['pledge_payment'])) {
-      foreach ($ids['pledge_payment'] as $key => $paymentID) {
-        if (empty($paymentID)) {
-          continue;
-        }
-        $payment = new CRM_Pledge_BAO_PledgePayment();
-        $payment->id = $paymentID;
-        if (!$payment->find(TRUE)) {
-          throw new CRM_Core_Exception("Could not find pledge payment record: " . $paymentID);
-        }
-        $this->_relatedObjects['pledge_payment'][] = $payment;
-      }
-    }
-
     // These are probably no longer accessed from anywhere
     $query = "
       SELECT membership_id


### PR DESCRIPTION
Overview
----------------------------------------
Stop setting relatedObjects['pledge_payment'] as it is not used

Before
----------------------------------------
Set, not used

![image](https://github.com/civicrm/civicrm-core/assets/336308/89f0a504-9953-4b12-bbd8-9059a7c76ea1)

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
