### PR TITLE
Upgrader Tests - Suppress PHP 8.3 warning that blocks test-suite

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveTwentyFive.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwentyFive.php
@@ -37,7 +37,7 @@ class CRM_Upgrade_Incremental_php_FiveTwentyFive extends CRM_Upgrade_Incremental
     $reports = CRM_Core_DAO::executeQuery("SELECT id FROM civicrm_report_instance WHERE form_values like '%relative%'");
     while ($reports->fetch()) {
       $report = civicrm_api3('ReportInstance', 'getsingle', ['id' => $reports->id]);
-      $reportFormValues = unserialize($report['form_values']);
+      $reportFormValues = @unserialize($report['form_values']);
       foreach ($reportFormValues as $index => $value) {
         if (strpos($index, '_relative') !== FALSE) {
           $date_fields[] = str_replace('_relative', '', $index);

--- a/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
@@ -656,7 +656,7 @@ class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
     ]);
     CRM_Upgrade_Incremental_php_FiveTwentyFive::convertReportsJcalendarToDatePicker();
     $reportGet = $this->callAPISuccess('ReportInstance', 'getsingle', ['id' => $report['id']]);
-    $formValues = unserialize($reportGet['form_values']);
+    $formValues = @unserialize($reportGet['form_values']);
     $this->assertEquals('1991-11-01 00:00:00', $formValues['receive_date_from']);
   }
 


### PR DESCRIPTION
This is the easiest of the suggestions in

https://stackoverflow.com/questions/10152904/how-to-repair-a-serialized-string-which-has-been-corrupted-by-an-incorrect-byte

The test fail

CRM_Upgrade_Incremental_BaseTest::testReportFormConvertDatePicker unserialize(): Extra data starting at offset 2492 of 4996 bytes

/home/homer/buildkit/build/build-4/web/sites/all/modules/civicrm/CRM/Upgrade/Incremental/php/FiveTwentyFive.php:40 /home/homer/buildkit/build/build-4/web/sites/all/modules/civicrm/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php:657 /home/homer/buildkit/build/build-4/web/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:289 /home/homer/buildkit/extern/phpunit9/phpunit9.phar:2307

only affects php 8.3 & seems mostly like noise as we still check the actual expected change.
