### PR TITLE
Update pear/log to 1.14.4

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -659,7 +659,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
   public static function createDebugLogger($prefix = '') {
     self::generateLogFileName($prefix);
     $log = Log::singleton('file', \Civi::$statics[__CLASS__]['logger_file' . $prefix], '', [
-      'timeFormat' => '%Y-%m-%d %H:%M:%S%z',
+      'timeFormat' => 'Y-m-d H:i:sO',
     ]);
     if (is_callable([$log, 'setLocale'])) {
       $log->setLocale(CRM_Core_I18n::getLocale());

--- a/Civi/API/LogObserver.php
+++ b/Civi/API/LogObserver.php
@@ -22,7 +22,7 @@ class LogObserver extends \Log_observer {
    * @see \Log::_announce
    * @param array $event
    */
-  public function notify($event) {
+  public function notify(array $event): void {
     $levels = \CRM_Core_Error_Log::getMap();
     $event['level'] = array_search($event['priority'], $levels);
     // Extract [civi.tag] from message string

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
     "guzzlehttp/guzzle": "^6.3 || ^7.3",
     "psr/simple-cache": "~1.0.1",
     "cweagans/composer-patches": "~1.0",
-    "pear/log": "1.13.3",
+    "pear/log": "1.14.4",
     "adrienrn/php-mimetyper": "0.2.2",
     "civicrm/composer-downloads-plugin": "^3.0 || ^4.0",
     "league/csv": "~9.7.4",
@@ -273,9 +273,6 @@
       },
       "pear/db": {
         "Apply CiviCRM Customisations for the pear:db package": "https://raw.githubusercontent.com/civicrm/civicrm-core/2ad420c394/tools/scripts/composer/pear_db_civicrm_changes.patch"
-      },
-      "pear/log": {
-        "Apply patch for php8.1": "https://gist.githubusercontent.com/totten/d99d47dd9d19a5cb02858954a5577609/raw/0e5e4628a475219c2aec6af76e69894cdec42a55/pear-log-locale.patch"
       },
       "pear/mail": {
         "Apply CiviCRM Customisations for CRM-1367 and CRM-5946": "https://raw.githubusercontent.com/civicrm/civicrm-core/36319938a5bf26c1e7e2110a26a65db6a5979268/tools/scripts/composer/patches/pear-mail.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c4bdb6ccb696800cb62baee531ac90c9",
+    "content-hash": "82c851239f3688eb1cf51016d874821b",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -2108,24 +2108,25 @@
         },
         {
             "name": "pear/log",
-            "version": "1.13.3",
+            "version": "1.14.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/Log.git",
-                "reference": "21af0be11669194d72d88b5ee9d5f176dc75d9a3"
+                "reference": "f1ce70cfc8ee30af93c313f4e6444a7abe6aea03"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/Log/zipball/21af0be11669194d72d88b5ee9d5f176dc75d9a3",
-                "reference": "21af0be11669194d72d88b5ee9d5f176dc75d9a3",
+                "url": "https://api.github.com/repos/pear/Log/zipball/f1ce70cfc8ee30af93c313f4e6444a7abe6aea03",
+                "reference": "f1ce70cfc8ee30af93c313f4e6444a7abe6aea03",
                 "shasum": ""
             },
             "require": {
                 "pear/pear_exception": "1.0.1 || 1.0.2",
-                "php": ">5.2"
+                "php": ">=7.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "*"
+                "phpunit/phpunit": "*",
+                "rector/rector": "*"
             },
             "suggest": {
                 "pear/db": "Install optionally via your project's composer.json"
@@ -2164,7 +2165,7 @@
                 "issues": "https://github.com/pear/Log/issues",
                 "source": "https://github.com/pear/Log"
             },
-            "time": "2021-05-04T23:51:30+00:00"
+            "time": "2024-02-20T21:00:10+00:00"
         },
         {
             "name": "pear/mail",

--- a/tests/phpunit/CRM/Core/ErrorTest.php
+++ b/tests/phpunit/CRM/Core/ErrorTest.php
@@ -106,8 +106,7 @@ class CRM_Core_ErrorTest extends CiviUnitTestCase {
     $log->log('Mary had a little lamb');
     $log->log('Little lamb');
     $config = CRM_Core_Config::singleton();
-    $fileContents = file_get_contents($log->_filename);
-    $this->assertEquals($config->configAndLogDir . 'CiviCRM.' . CIVICRM_DOMAIN_ID . '.' . 'my-test.' . CRM_Core_Error::generateLogFileHash($config) . '.log', $log->_filename);
+    $fileContents = file_get_contents($config->configAndLogDir . 'CiviCRM.' . CIVICRM_DOMAIN_ID . '.' . 'my-test.' . CRM_Core_Error::generateLogFileHash($config) . '.log');
     // The 5 here is a bit arbitrary - on my local the date part is 15 chars (Mar 29 05:29:16) - but we are just checking that
     // there are chars for the date at the start.
     $this->assertTrue(strpos($fileContents, '[info] Mary had a little lamb') > 10);


### PR DESCRIPTION
Overview
----------------------------------------
Attempt to resurrect https://github.com/civicrm/civicrm-core/pull/29235

Before
----------------------------------------
pear version 1.13.3

After
----------------------------------------
pear 1.14.3

Technical Details
----------------------------------------
This was attempted on the first PR & some upstream update was done - but this kinda got a bit messed up on the other PR & I think it failed tests so lessee

I removed our patch on this as it created duplicate copies of the functions - but not sure if there is stuff in it that is still needed - will check in with @demeritcowboy once tests pass

UPDATE seeing 2 issues locally
- deprecations
- 
PHP Warning:  Using strftime-style formatting is deprecated in /srv/civi-sites/dmaster/web/sites/all/modules/civicrm/vendor/pear/log/Log.php on line 831
PHP Warning:  Using strftime-style formatting is deprecated in /srv/civi-sites/dmaster/web/sites/all/modules/civicrm/vendor/pear/log/Log.php on line 831
PHP Warning:  Using strftime-style formatting is deprecate

-error
Failure in api call for System check:  Undefined property: Log_file::$_filename
#0 /srv/civi-sites/dmaster/web/sites/all/modules/civicrm/CRM/Utils/Check/Component/Security.php(63): PHPUnit\Util\ErrorHandler->__invoke()
#1 /srv/civi-sites/dmaster/web/sites/all/modules/civicrm/CRM/Utils/Check/Component.php(76):

Comments
----------------------------------------
