### PR TITLE
Add diff view to Message Admin

### DIFF
--- a/ang/crmMonaco.js
+++ b/ang/crmMonaco.js
@@ -13,7 +13,6 @@
         this.editor = null; // Filled in by link().
       },
       link: function($scope, $el, $attr, controllers) {
-        // console.log('crmMonaco: attrs: ', $attr);
         var ngModel = controllers[0], crmMonaco = controllers[1];
         var heightPct = 0.70;
         var editor;
@@ -28,8 +27,6 @@
           if ($attr.crmMonaco) {
             angular.extend(options, $parse($attr.crmMonaco)($scope));
           }
-          let originalMessage = $parse($attr.crmMonacoOriginal)($scope);
-          // console.log('crm monaco received: orig: ', originalMessage);
           angular.extend(options, {
             value: ngModel.$modelValue,
             minimap: {
@@ -53,39 +50,54 @@
 
           var editorEl = $el.find('.crm-monaco-container');
           editorEl.css({height: Math.round(heightPct * $(window).height())});
-          // editor = monaco.editor.create(editorEl[0], options);
+          let originalMessage = $parse($attr.crmMonacoOriginal)($scope);
+          if (originalMessage) {
+            var originalModel = monaco.editor.createModel(originalMessage);
+            // var modifiedModel = monaco.editor.createModel('');
+            var modifiedModel = monaco.editor.createModel(ngModel.$modelValue);
+            // ^^^ This looks like it works on first load,
+            // but it's not following ngModel contract -- need to sort the listeners below.
 
-          var originalModel = monaco.editor.createModel(originalMessage);
-          // var modifiedModel = monaco.editor.createModel('');
-          var modifiedModel = monaco.editor.createModel(ngModel.$modelValue);
-          // ^^^ This looks like it works on first load,
-          // but it's not following ngModel contract -- need to sort the listeners below.
+            options.renderSideBySide = false;
+            options.enableSplitViewResizing = false;
+            editor = monaco.editor.createDiffEditor(editorEl[0], options);
+            editor.setModel({ original: originalModel, modified: modifiedModel });
 
-          options.renderSideBySide = false;
-          options.enableSplitViewResizing = false;
-          editor = monaco.editor.createDiffEditor(editorEl[0], options);
-          editor.setModel({original: originalModel, modified: modifiedModel});
+            // Important -- how to propagate changes back to angular
+            editor.getModifiedEditor().onDidChangeModelContent(_.debounce(function () {
+              $scope.$apply(function () {
+                ngModel.$setViewValue(modifiedModel.getValue());
+              });
+            }, 150));
 
-          // Important -- how to propagate changes back to angular
-          // modifiedModel.onDidChangeModelContent(_.debounce(function () {
-          //   $scope.$apply(function () {
-          //     // ngModel.$setViewValue(editor.getValue());
-          //     ngModel.$setViewValue(modifiedModel.getValue());
-          //   });
-          // }, 150));
+            ngModel.$render = function () {
+              //   console.log('update modifiedModemodifiedEditorl content ' + new Date());
+              if (editor) {
+                editor.getModifiedEditor().setValue(ngModel.$modelValue);
+              }
+              // FIXME: else: retry?
+            };
 
-          // ngModel.$render = function() {
-          //   console.log('update modifiedModel content ' + new Date());
-          //   if (editor) {
-          //     // editor.setValue(ngModel.$modelValue);
-          //     modifiedModel.setValue(ngModel.$modelValue);
-          //   }
-          //   // FIXME: else: retry?
-          // };
+          }
+          else {
+            editor = monaco.editor.create(editorEl[0], options);
 
+            editor.onDidChangeModelContent(_.debounce(function () {
+              $scope.$apply(function () {
+                ngModel.$setViewValue(editor.getValue());
+              });
+            }, 150));
+
+            ngModel.$render = function() {
+              if (editor) {
+                editor.setValue(ngModel.$modelValue);
+              }
+              // FIXME: else: retry?
+            };
+          }
           if ($attr.ngDisabled) {
-            $scope.$watch($parse($attr.ngDisabled), function(disabled){
-              editor.updateOptions({readOnly: disabled});
+            $scope.$watch($parse($attr.ngDisabled), function (disabled) {
+              editor.updateOptions({ readOnly: disabled });
             });
           }
 

--- a/ang/crmMonaco.js
+++ b/ang/crmMonaco.js
@@ -13,6 +13,7 @@
         this.editor = null; // Filled in by link().
       },
       link: function($scope, $el, $attr, controllers) {
+        // console.log('crmMonaco: attrs: ', $attr);
         var ngModel = controllers[0], crmMonaco = controllers[1];
         var heightPct = 0.70;
         var editor;
@@ -27,6 +28,8 @@
           if ($attr.crmMonaco) {
             angular.extend(options, $parse($attr.crmMonaco)($scope));
           }
+          let originalMessage = $parse($attr.crmMonacoOriginal)($scope);
+          // console.log('crm monaco received: orig: ', originalMessage);
           angular.extend(options, {
             value: ngModel.$modelValue,
             minimap: {
@@ -50,20 +53,35 @@
 
           var editorEl = $el.find('.crm-monaco-container');
           editorEl.css({height: Math.round(heightPct * $(window).height())});
-          editor = monaco.editor.create(editorEl[0], options);
+          // editor = monaco.editor.create(editorEl[0], options);
 
-          editor.onDidChangeModelContent(_.debounce(function () {
-            $scope.$apply(function () {
-              ngModel.$setViewValue(editor.getValue());
-            });
-          }, 150));
+          var originalModel = monaco.editor.createModel(originalMessage);
+          // var modifiedModel = monaco.editor.createModel('');
+          var modifiedModel = monaco.editor.createModel(ngModel.$modelValue);
+          // ^^^ This looks like it works on first load,
+          // but it's not following ngModel contract -- need to sort the listeners below.
 
-          ngModel.$render = function() {
-            if (editor) {
-              editor.setValue(ngModel.$modelValue);
-            }
-            // FIXME: else: retry?
-          };
+          options.renderSideBySide = false;
+          options.enableSplitViewResizing = false;
+          editor = monaco.editor.createDiffEditor(editorEl[0], options);
+          editor.setModel({original: originalModel, modified: modifiedModel});
+
+          // Important -- how to propagate changes back to angular
+          // modifiedModel.onDidChangeModelContent(_.debounce(function () {
+          //   $scope.$apply(function () {
+          //     // ngModel.$setViewValue(editor.getValue());
+          //     ngModel.$setViewValue(modifiedModel.getValue());
+          //   });
+          // }, 150));
+
+          // ngModel.$render = function() {
+          //   console.log('update modifiedModel content ' + new Date());
+          //   if (editor) {
+          //     // editor.setValue(ngModel.$modelValue);
+          //     modifiedModel.setValue(ngModel.$modelValue);
+          //   }
+          //   // FIXME: else: retry?
+          // };
 
           if ($attr.ngDisabled) {
             $scope.$watch($parse($attr.ngDisabled), function(disabled){

--- a/ext/message_admin/ang/crmMsgadm/Edit.html
+++ b/ext/message_admin/ang/crmMsgadm/Edit.html
@@ -67,7 +67,7 @@
         </ul>
       </div>
       <div class="panel-body" ng-hide="$ctrl.loading">
-        <crm-msgadm-edit-content msgtpl="$ctrl.records[$ctrl.tab]" token-list="$ctrl.tokenList" disabled="$ctrl.tab==='original'"></crm-msgadm-edit-content>
+        <crm-msgadm-edit-content msgtpl="$ctrl.records[$ctrl.tab]" original="$ctrl.records.original" token-list="$ctrl.tokenList" disabled="$ctrl.tab==='original'"></crm-msgadm-edit-content>
       </div>
     </div>
 

--- a/ext/message_admin/ang/crmMsgadm/EditContent.html
+++ b/ext/message_admin/ang/crmMsgadm/EditContent.html
@@ -51,9 +51,11 @@
       <div class="clearfix"></div>
     </div>
     <div class="panel-body" uib-collapse="!accordions.msg_html">
+      <div crm-ui-debug="$ctrl"></div>
       <div ng-model="$ctrl.msgtpl.msg_html"
            crm-monaco="$ctrl.monacoOptions({language: 'html', crmHeightPct: 0.5})"
            crm-monaco-insert-rx="insert:msg_html"
+           crm-monaco-original="$ctrl.original.msg_html"
            ng-disabled="$ctrl.isDisabled()"
       ></div>
     </div>

--- a/ext/message_admin/ang/crmMsgadm/EditContent.html
+++ b/ext/message_admin/ang/crmMsgadm/EditContent.html
@@ -33,11 +33,11 @@
         <i class="crm-i fa-caret-{{ accordions.msg_html ? 'down' : 'right' }}"></i>
         {{:: ts('HTML Content') }}
       </a>
-      <div class="btn-group btn-group-xs pull-right" role="toolbar" aria-label="{{::ts('HTML Content: Toolbar')}}" ng-show="accordions.msg_html">
-        <button type="button" class="btn btn-secondary" ng-show="!$ctrl.isDisabled()" title="{{::ts('Show diff')}}" ng-click="$ctrl.openFull(ts('HTML Content'), 'msg_html', {language: 'html'}, true)">
+      <div class=" pull-right" role="toolbar" aria-label="{{::ts('HTML Content: Toolbar')}}" ng-show="accordions.msg_html">
+        <button type="button" class="btn btn-primary" ng-show="!$ctrl.isDisabled()" title="{{::ts('Show diff')}}" ng-click="$ctrl.openFull(ts('HTML Content'), 'msg_html', {language: 'html'}, true)">
           {{::ts('Show diff')}}
         </button>
-        <button type="button" class="btn btn-secondary" title="{{::ts('Open preview')}}" ng-click="$ctrl.openPreview({formatName: 'msg_html'})">
+        <button type="button" class="btn btn-primary" title="{{::ts('Open preview')}}" ng-click="$ctrl.openPreview({formatName: 'msg_html'})">
           <i class="crm-i fa-eye"> {{::ts('Open preview')}}</i>
         </button>
         <button type="button" class="btn btn-secondary" title="{{::ts('Open large editor')}}" ng-click="$ctrl.openFull(ts('HTML Content'), 'msg_html', {language: 'html'})">

--- a/ext/message_admin/ang/crmMsgadm/EditContent.html
+++ b/ext/message_admin/ang/crmMsgadm/EditContent.html
@@ -34,11 +34,14 @@
         {{:: ts('HTML Content') }}
       </a>
       <div class="btn-group btn-group-xs pull-right" role="toolbar" aria-label="{{::ts('HTML Content: Toolbar')}}" ng-show="accordions.msg_html">
-        <button type="button" class="btn btn-secondary" title="{{::ts('Open large editor')}}" ng-click="$ctrl.openFull(ts('HTML Content'), 'msg_html', {language: 'html'})">
-          <i class="crm-i fa-expand"></i>
+        <button type="button" class="btn btn-secondary" ng-show="!$ctrl.isDisabled()" title="{{::ts('Show diff')}}" ng-click="$ctrl.openFull(ts('HTML Content'), 'msg_html', {language: 'html'}, true)">
+          {{::ts('Show diff')}}
         </button>
         <button type="button" class="btn btn-secondary" title="{{::ts('Open preview')}}" ng-click="$ctrl.openPreview({formatName: 'msg_html'})">
-          <i class="crm-i fa-eye"></i>
+          <i class="crm-i fa-eye"> {{::ts('Open preview')}}</i>
+        </button>
+        <button type="button" class="btn btn-secondary" title="{{::ts('Open large editor')}}" ng-click="$ctrl.openFull(ts('HTML Content'), 'msg_html', {language: 'html'})">
+          <i class="crm-i fa-expand"></i>
         </button>
       </div>
       <input class="form-control pull-right crm-action-menu fa-code"
@@ -55,7 +58,6 @@
       <div ng-model="$ctrl.msgtpl.msg_html"
            crm-monaco="$ctrl.monacoOptions({language: 'html', crmHeightPct: 0.5})"
            crm-monaco-insert-rx="insert:msg_html"
-           crm-monaco-original="$ctrl.original.msg_html"
            ng-disabled="$ctrl.isDisabled()"
       ></div>
     </div>

--- a/ext/message_admin/ang/crmMsgadm/EditContent.html
+++ b/ext/message_admin/ang/crmMsgadm/EditContent.html
@@ -54,7 +54,6 @@
       <div class="clearfix"></div>
     </div>
     <div class="panel-body" uib-collapse="!accordions.msg_html">
-      <div crm-ui-debug="$ctrl"></div>
       <div ng-model="$ctrl.msgtpl.msg_html"
            crm-monaco="$ctrl.monacoOptions({language: 'html', crmHeightPct: 0.5})"
            crm-monaco-insert-rx="insert:msg_html"

--- a/ext/message_admin/ang/crmMsgadm/EditContent.js
+++ b/ext/message_admin/ang/crmMsgadm/EditContent.js
@@ -25,7 +25,7 @@
         }, opts);
       };
 
-      $ctrl.openFull = function(title, fld, monacoOptions) {
+      $ctrl.openFull = function(title, fld, monacoOptions, isDiff = false) {
         var model = {
           title: title,
           monacoOptions: $ctrl.monacoOptions(angular.extend({crmHeightPct: 0.80}, monacoOptions)),
@@ -34,7 +34,8 @@
           },
           record: $ctrl.msgtpl,
           field: fld,
-          tokenList: $ctrl.tokenList
+          tokenList: $ctrl.tokenList,
+          original: isDiff ? $ctrl.original[fld]: ''
         };
         var options = CRM.utils.adjustDialogDefaults({
           // show: {effect: 'slideDown'},

--- a/ext/message_admin/ang/crmMsgadm/EditContent.js
+++ b/ext/message_admin/ang/crmMsgadm/EditContent.js
@@ -4,6 +4,7 @@
       onPreview: '&',
       tokenList: '<',
       disabled: '<',
+      original: '=',
       msgtpl: '='
     },
     templateUrl: '~/crmMsgadm/EditContent.html',

--- a/ext/message_admin/ang/crmMsgadm/ExpandedEdit.html
+++ b/ext/message_admin/ang/crmMsgadm/ExpandedEdit.html
@@ -36,6 +36,7 @@
     <div ng-model="model.record[model.field]"
          crm-monaco="model.monacoOptions"
          crm-monaco-insert-rx="insert:expanded"
+         crm-monaco-original="model.original"
     ></div>
   </form>
 


### PR DESCRIPTION
Overview
----------------------------------------
Add diff view to Message Admin


Before
----------------------------------------
Really hard to see what has changed in Message Templates. BetterMsgTpl has a bunch of features, including using monaco-editor to render a diff. I don't think we want to bring all those features into core but not being able to see the diff is a real missing feature

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/2b91ca76-749d-4cb2-88be-8477cf8f9610)

![image](https://github.com/civicrm/civicrm-core/assets/336308/3c918fd4-5b28-41d4-bf2c-24475ecd76d0)


Technical Details
----------------------------------------
This is actually an editable diff viewer that Monaco provides but in discussion with @twomice it seems to make sense to downplay that aspect as it is likely to cause confusion - although this is nice

![image](https://github.com/civicrm/civicrm-core/assets/336308/57de2821-db6a-46e0-8666-7fb06d3bd23d)

Comments
----------------------------------------
