### PR TITLE
Fix signature for pear/log update preparatory to upgrading pear

### DIFF
--- a/Civi/API/LogObserver.php
+++ b/Civi/API/LogObserver.php
@@ -22,7 +22,7 @@ class LogObserver extends \Log_observer {
    * @see \Log::_announce
    * @param array $event
    */
-  public function notify($event) {
+  public function notify(array $event): void {
     $levels = \CRM_Core_Error_Log::getMap();
     $event['level'] = array_search($event['priority'], $levels);
     // Extract [civi.tag] from message string


### PR DESCRIPTION
Overview
----------------------------------------
Fix signauture for pear/log update preparatory to upgrading pear

Before
----------------------------------------
Conflicts with later pear version

After
----------------------------------------
doesn't 

Technical Details
----------------------------------------
making child classes stricter should be backward compatible

Comments
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/30484 is in a bit of a mess, so breaking it down