### PR TITLE
Fix access to undeclared property on PEAR

### DIFF
--- a/CRM/Utils/Check/Component/Security.php
+++ b/CRM/Utils/Check/Component/Security.php
@@ -60,7 +60,7 @@ class CRM_Utils_Check_Component_Security extends CRM_Utils_Check_Component {
     $config = CRM_Core_Config::singleton();
 
     $log = CRM_Core_Error::createDebugLogger();
-    $log_filename = str_replace('\\', '/', isset($log->_filename) ? $log->_filename : '');
+    $log_filename = str_replace('\\', '/', $log->_filename ?? '');
 
     $filePathMarker = $this->getFilePathMarker();
 

--- a/CRM/Utils/Check/Component/Security.php
+++ b/CRM/Utils/Check/Component/Security.php
@@ -60,7 +60,7 @@ class CRM_Utils_Check_Component_Security extends CRM_Utils_Check_Component {
     $config = CRM_Core_Config::singleton();
 
     $log = CRM_Core_Error::createDebugLogger();
-    $log_filename = str_replace('\\', '/', $log->_filename);
+    $log_filename = str_replace('\\', '/', isset($log->_filename) ? $log->_filename : '');
 
     $filePathMarker = $this->getFilePathMarker();
 


### PR DESCRIPTION
It seems OK with this resolving to empty?

Overview
----------------------------------------
Fix access to undeclared property on PEAR

Before
----------------------------------------
In trying to upgrade PEAR - per https://github.com/civicrm/civicrm-core/pull/30484 we hit an issue with access to an undefined property

After
----------------------------------------
 - this is hit in a test & the test seems happy with an empty string here so just adding an isset test

Technical Details
----------------------------------------

Comments
----------------------------------------
