### PR TITLE
Update PEAR instantiation to deal with upcoming deprecation of strftime

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -659,7 +659,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
   public static function createDebugLogger($prefix = '') {
     self::generateLogFileName($prefix);
     $log = Log::singleton('file', \Civi::$statics[__CLASS__]['logger_file' . $prefix], '', [
-      'timeFormat' => '%Y-%m-%d %H:%M:%S%z',
+      'timeFormat' => 'Y-m-d H:i:sO',
     ]);
     if (is_callable([$log, 'setLocale'])) {
       $log->setLocale(CRM_Core_I18n::getLocale());


### PR DESCRIPTION
Overview
----------------------------------------
Update PEAR instantiation to deal with upcoming deprecation of strftime

Before
----------------------------------------
`strftime` formatted date string passed to `PEAR`

After
----------------------------------------
Format switched 

Technical Details
----------------------------------------
reflects deprecation of the `strtime` format in the PEAR package

Comments
----------------------------------------
pretty sure this is backward compatible but this is part of trying to clean up for https://github.com/civicrm/civicrm-core/pull/30484