### PR TITLE
MessageTemplate - Add Api4.revert action

### DIFF
--- a/CRM/Utils/API/HTMLInputCoder.php
+++ b/CRM/Utils/API/HTMLInputCoder.php
@@ -62,6 +62,8 @@ class CRM_Utils_API_HTMLInputCoder extends CRM_Utils_API_AbstractFieldCoder {
         'html_message',
         'body_html',
         'msg_html',
+        // MessageTemplate subject might contain the < character in a smarty tag
+        'msg_subject',
         'description',
         'intro',
         'thankyou_text',

--- a/Civi/Api4/Action/MessageTemplate/Revert.php
+++ b/Civi/Api4/Action/MessageTemplate/Revert.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\MessageTemplate;
+
+use Civi\Api4\Generic\Result;
+use Civi\Api4\MessageTemplate;
+
+/**
+ * Reverts a MessageTemplate subject and message to the contents of the master
+ */
+class Revert extends \Civi\Api4\Generic\BasicBatchAction {
+
+  protected function processBatch(Result $result, array $items) {
+    $revertable = MessageTemplate::get($this->getCheckPermissions())
+      ->addSelect('id', 'master_id', 'master_id.msg_subject', 'master_id.msg_html')
+      ->addWhere('id', 'IN', array_column($items, 'id'))
+      ->execute();
+    foreach ($revertable as $item) {
+      if (!empty($item['master_id'])) {
+        MessageTemplate::update(FALSE)
+          ->addWhere('id', '=', $item['id'])
+          ->addValue('msg_subject', $item['master_id.msg_subject'])
+          ->addValue('msg_html', $item['master_id.msg_html'])
+          ->execute();
+      }
+    }
+  }
+
+}

--- a/Civi/Api4/MessageTemplate.php
+++ b/Civi/Api4/MessageTemplate.php
@@ -20,4 +20,13 @@ namespace Civi\Api4;
  */
 class MessageTemplate extends Generic\DAOEntity {
 
+  /**
+   * @param bool $checkPermissions
+   * @return Action\MessageTemplate\Revert
+   */
+  public static function revert($checkPermissions = TRUE) {
+    return (new Action\MessageTemplate\Revert('MessageTemplate', __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
 }

--- a/tests/phpunit/api/v4/Entity/MessageTemplateTest.php
+++ b/tests/phpunit/api/v4/Entity/MessageTemplateTest.php
@@ -143,31 +143,32 @@ class MessageTemplateTest extends Api4TestBase implements TransactionalInterface
     \CRM_Core_Transaction::create(TRUE)->run(function(\CRM_Core_Transaction $tx) {
       $tx->rollback();
 
-      $messageTemplateID = MessageTemplate::get()
+      MessageTemplate::update(FALSE)
+        ->addWhere('workflow_name', '=', 'contribution_offline_receipt')
+        ->addValue('msg_html', '<p>Some test {if 1 > 2} markup{/if}</p>')
+        ->execute();
+
+      $originalTemplate = MessageTemplate::get()
         ->addWhere('is_default', '=', 1)
         ->addWhere('workflow_name', '=', 'contribution_offline_receipt')
-        ->addSelect('id')
-        ->execute()->first()['id'];
-      $messageTemplateIDReserved = MessageTemplate::get()
+        ->addSelect('id', 'msg_subject', 'msg_html', 'master_id', 'master_id.msg_subject')
+        ->execute()->first();
+      $messageTemplateID = $originalTemplate['id'];
+      $reservedTemplate = MessageTemplate::get()
         ->addWhere('is_reserved', '=', 1)
         ->addWhere('workflow_name', '=', 'contribution_offline_receipt')
-        ->addSelect('id')
-        ->execute()->first()['id'];
-      $msgTpl = MessageTemplate::get()
-        ->addSelect('msg_subject', 'master_id', 'master_id.msg_subject')
-        ->addWhere('id', '=', $messageTemplateID)
+        ->addSelect('id', 'msg_subject', 'msg_html')
         ->execute()->first();
-      // confirm subject is set
-      $this->assertNotNull($msgTpl['msg_subject']);
-      // message is unchanged from original so both of these should be null
-      $this->assertNull($msgTpl['master_id']);
-      $this->assertNull($msgTpl['master_id.msg_subject']);
+      $messageTemplateIDReserved = $reservedTemplate['id'];
+
+      $this->assertEquals('<p>Some test {if 1 > 2} markup{/if}</p>', $originalTemplate['msg_html']);
+      $this->assertNull($originalTemplate['master_id']);
+      $this->assertNull($originalTemplate['master_id.msg_subject']);
 
       MessageTemplate::update()
         ->addWhere('id', '=', $messageTemplateID)
         ->setValues([
           'msg_subject' => 'Hello world',
-          'msg_text' => 'Hello world',
           'msg_html' => '<p>Hello world</p>',
         ])
         ->execute();
@@ -176,13 +177,28 @@ class MessageTemplateTest extends Api4TestBase implements TransactionalInterface
         ->addWhere('id', '=', $messageTemplateID)
         ->execute()->first();
       // confirm subject is set
-      $this->assertNotNull($msgTpl['msg_subject']);
+      $this->assertEquals('Hello world', $msgTpl['msg_subject']);
       // message is changed so both of these should be set
       $this->assertEquals($msgTpl['master_id'], $messageTemplateIDReserved);
       $this->assertNotNull($msgTpl['master_id.msg_subject']);
       // these should be different
       $this->assertNotEquals($msgTpl['msg_subject'], $msgTpl['master_id.msg_subject']);
 
+      // Now revert it
+      MessageTemplate::revert(FALSE)
+        ->addWhere('id', '=', $messageTemplateID)
+        ->execute();
+
+      $msgTpl = MessageTemplate::get()
+        ->addSelect('msg_subject', 'msg_html', 'master_id', 'master_id.msg_subject')
+        ->addWhere('id', '=', $messageTemplateID)
+        ->execute()->first();
+      // confirm subject is reverted
+      $this->assertEquals($originalTemplate['msg_subject'], $msgTpl['msg_subject']);
+      $this->assertEquals($originalTemplate['msg_html'], $msgTpl['msg_html']);
+      // message is unchanged from original so both of these should be null
+      $this->assertNull($msgTpl['master_id']);
+      $this->assertNull($msgTpl['master_id.msg_subject']);
     });
   }
 

--- a/tests/phpunit/api/v4/Entity/MessageTemplateTest.php
+++ b/tests/phpunit/api/v4/Entity/MessageTemplateTest.php
@@ -145,7 +145,8 @@ class MessageTemplateTest extends Api4TestBase implements TransactionalInterface
 
       MessageTemplate::update(FALSE)
         ->addWhere('workflow_name', '=', 'contribution_offline_receipt')
-        ->addValue('msg_html', '<p>Some test {if 1 > 2} markup{/if}</p>')
+        ->addValue('msg_subject', 'Subject test {if 1 > 2} smarty{/if}')
+        ->addValue('msg_html', '<p>Body test {if 1 > 2} markup{/if}</p>')
         ->execute();
 
       $originalTemplate = MessageTemplate::get()
@@ -161,7 +162,8 @@ class MessageTemplateTest extends Api4TestBase implements TransactionalInterface
         ->execute()->first();
       $messageTemplateIDReserved = $reservedTemplate['id'];
 
-      $this->assertEquals('<p>Some test {if 1 > 2} markup{/if}</p>', $originalTemplate['msg_html']);
+      $this->assertEquals('Subject test {if 1 > 2} smarty{/if}', $originalTemplate['msg_subject']);
+      $this->assertEquals('<p>Body test {if 1 > 2} markup{/if}</p>', $originalTemplate['msg_html']);
       $this->assertNull($originalTemplate['master_id']);
       $this->assertNull($originalTemplate['master_id.msg_subject']);
 


### PR DESCRIPTION
Overview
----------------------------------------
Adds a new "revert" action to the MessageTemplate api.

Technical Details
--------
This uses the standard signature of other api entities with a "revert" action, although the behavior is a bit different due to the way MessageTemplates are structured.