### PR TITLE
Enable message admin by default on new installs

### DIFF
--- a/ext/message_admin/info.xml
+++ b/ext/message_admin/info.xml
@@ -20,9 +20,6 @@
   <compatibility>
     <ver>5.76</ver>
   </compatibility>
-  <requires>
-    <ext>org.civicrm.afform</ext>
-  </requires>
   <comments/>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/sql/civicrm_data/civicrm_extension.sqldata.php
+++ b/sql/civicrm_data/civicrm_extension.sqldata.php
@@ -69,4 +69,8 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_extension', 'INSERT IGNORE INTO
       'full_name' => 'civiimport',
       'name' => 'Civi-Import',
     ],
+    [
+      'full_name' => 'message_admin',
+      'name' => 'Message Administration',
+    ],
   ]);

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -88,6 +88,8 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
     parent::setUp();
     $this->enableCiviCampaign();
     $this->toBeImplemented['get'] = [
+      // Not apiv3.
+      'Afform',
       // CxnApp.get exists but relies on remote data outside our control; QA w/UtilsTest::testBasicArrayGet
       'CxnApp',
       'Profile',


### PR DESCRIPTION
Overview
----------------------------------------
Enable message admin by default on new installs




Before
----------------------------------------
Message Admin enabled by default on demo sites but not new installs

After
----------------------------------------

Message Admin enabled by default on demo sites and new installs

Technical Details
----------------------------------------
Now that we have the missing revert functionality we can do this  & in time remove the alternative

Comments
----------------------------------------
