### PR TITLE
dev/core#5291 Fix php comparison bug

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -78,6 +78,10 @@ abstract class CRM_Utils_System_Base {
    *   or equal 0 if not in print mode.
    */
   public static function getContentTemplate($print = 0): string {
+    if ($print === CRM_Core_Smarty::PRINT_JSON) {
+      return 'CRM/common/snippet.tpl';
+    }
+
     switch ($print) {
       case 0:
         // Not a print context.


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#5291 Fix php comparison bug causing extra header/footer rendering

Affects me, not others
This seems to be
https://stackoverflow.com/questions/8146433/is-php-switch-statement-bug

My php version is 7.4 - maybe it's a php version thing & that's why others do not have it?


Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/24eaec7f-97a4-458b-8e4d-f6d5efc99f2e)

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/677937f4-a993-4fc2-8a38-059253c9dfd4)


Technical Details
----------------------------------------

Comments
----------------------------------------

