### PR TITLE
Fix dev/core#4924 - Notes column breaks some reports.

### DIFF
--- a/CRM/Core/BAO/Note.php
+++ b/CRM/Core/BAO/Note.php
@@ -536,7 +536,14 @@ WHERE participant.contact_id = %1 AND  note.entity_table = 'civicrm_participant'
     if ($relatedClauses) {
       // Nested array will be joined with OR
       $clauses['entity_table'] = [$relatedClauses];
+      // Fix dev/core#4924 : Allow inclusion of rows that have no Note.
+      // This is a workaround specifically for CiviReport, which erroneously
+      // adds this clause to the WHERE instead of the JOIN. If that problem
+      // were solved in CiviReport, this could be removed.
+      // @see CRM_Report_Form::buildPermissionClause
+      $clauses['entity_table'][0][] = 'IS NULL';
     }
+
     // Enforce note privacy setting
     if (!CRM_Core_Permission::check('view all notes', $userId)) {
       // It was ok to have $userId = NULL for the permission check but must be an int for the query


### PR DESCRIPTION
Overview
----------------------------------------
Reference original ticket https://lab.civicrm.org/dev/core/-/issues/4924

Summary: At least 3 reports which reference the `civicrm_note` table will incorrectly exclude from report results any entity which does not have a Note, if the report configuration actually references that table.

E.g. Contribution Report (Detail): Enable the "Contribution Note" column for display, and run the report. Observe that any contribution which does **not** have a Contribution Note value is **excluded** from the report results.

Before
----------------------------------------
Merely enabling the "Contribution Note" display column (or other entity-related Note column, depending on the report) will cause the report to show fewer rows, without making any changes to filter criteria.

After
----------------------------------------
All rows are displayed in results as called for in the filter criteria, whether they have a Note or not.

Technical Details
----------------------------------------
When the Note column is enabled for display (or any time the civicrm_note table is used in the report, though I'm not sure if there's any way to do that other than to enable the column), the report SQL uses a LEFT JOIN to reference the table, but it also includes a WHERE clause like this:

```
WHERE 
  (
    contact_civireport.is_deleted = 0
  ) 
  AND (1) 
  AND (
    contribution_civireport.contribution_status_id IN (1)
  ) 
  AND (
    (
      note_civireport.entity_table = 'civicrm_relationship' 
      OR note_civireport.entity_table = 'civicrm_contact' 
      OR note_civireport.entity_table = 'civicrm_participant' 
      OR note_civireport.entity_table = 'civicrm_contribution' 
      OR note_civireport.entity_table = 'civicrm_note'
    )
  )
```
All of those `note_civireport.entity_table = 'X'` where criteria are effectively turning the LEFT JOIN into an INNER JOIN.

This PR simply has the effect of adding an 'OR note_civireport.entity_table is null` to that WHERE clause, thus allowing the query to include records that have no note.

Background
----------------------------------------

This appears to have been introduced In 5.67.0, with the method `CRM_Core_BAO_Note::addSelectWhereClause` (See [diff for those commits](https://github.com/civicrm/civicrm-core/compare/d887fb183cd2ec2e6d20d3ef575fc577e9fad453..8ad23a073215ad851ec4f7e4ab9b74808d7426a6#diff-cfdfc014d707d21f9bba097eb6c678872a164d608603b2f314d3fa37b2a76bc8), from d887fb183cd2ec2e6d20d3ef575fc577e9fad453 to 8ad23a073215ad851ec4f7e4ab9b74808d7426a6 )

Not perfect
----------------------------------------
Naturally the better way would be to move these criteria into the LEFT JOIN instead of the WHERE clause, but _come awn main_.