### PR TITLE
dev/core#5242, dev/core#5109 - Option 1 - Smarty - Don't trigger an error on error, instead trigger an error

### DIFF
--- a/CRM/Core/Smarty/plugins/function.crmAPI.php
+++ b/CRM/Core/Smarty/plugins/function.crmAPI.php
@@ -25,7 +25,7 @@ function smarty_function_crmAPI($params, &$smarty) {
   CRM_Core_Smarty_UserContentPolicy::assertTagAllowed('crmAPI');
 
   if (!array_key_exists('entity', $params)) {
-    $smarty->trigger_error("assign: missing 'entity' parameter");
+    trigger_error('crmAPI: missing &#039;entity&#039; parameter', E_USER_ERROR);
     return "crmAPI: missing 'entity' parameter";
   }
   $entity = $params['entity'];
@@ -37,7 +37,7 @@ function smarty_function_crmAPI($params, &$smarty) {
     $result = civicrm_api3($entity, $action, $params);
   }
   catch (Exception $e) {
-    $smarty->trigger_error('{crmAPI} ' . $e->getMessage());
+    trigger_error('{crmAPI} ' . htmlentities($e->getMessage()), E_USER_ERROR);
     return NULL;
   }
 

--- a/CRM/Core/Smarty/plugins/function.crmSetting.php
+++ b/CRM/Core/Smarty/plugins/function.crmSetting.php
@@ -32,7 +32,7 @@ function smarty_function_crmSetting($params, &$smarty) {
     $result = civicrm_api3('setting', 'getvalue', $params);
   }
   catch (Exception $e) {
-    $smarty->trigger_error('{crmAPI} ' . $e->getMessage());
+    trigger_error('{crmSetting} ' . htmlentities($e->getMessage()), E_USER_ERROR);
     return NULL;
   }
 

--- a/CRM/Core/Smarty/plugins/function.isValueChange.php
+++ b/CRM/Core/Smarty/plugins/function.isValueChange.php
@@ -39,7 +39,7 @@ function smarty_function_isValueChange($params, &$smarty) {
   static $values = [];
 
   if (empty($params['key'])) {
-    $smarty->trigger_error("Missing required parameter, 'key', in isValueChange plugin.");
+    trigger_error('Missing required parameter, &#039;key&#039;, in isValueChange plugin.', E_USER_ERROR);
     return NULL;
   }
 

--- a/CRM/Core/Smarty/plugins/function.simpleActivityContacts.php
+++ b/CRM/Core/Smarty/plugins/function.simpleActivityContacts.php
@@ -24,7 +24,7 @@
  */
 function smarty_function_simpleActivityContacts($params, &$smarty) {
   if (empty($params['activity_id'])) {
-    $smarty->trigger_error('assign: missing \'activity_id\' parameter');
+    trigger_error('simpleActivityContacts: missing &#039;activity_id&#039; parameter', E_USER_ERROR);
   }
   if (!isset($params['target_var'])) {
     $params['target_var'] = 'target';


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5242

Before
----------------------------------------
If an error happens during some crm smarty plugins, it causes a crash, instead of an error.

You can reproduce it in smarty 4/5 with something like `cv ev '$s = CRM_Core_Smarty::singleton(); echo $s->fetch("eval:{crmSetting kwyjibo=ape}");'` - you get a fatal Call to undefined method instead of a logged but recoverable error.

After
----------------------------------------
A good error

Technical Details
----------------------------------------
`$smarty->trigger_error` kind of exists in smarty 3, but is no different than trigger_error, and doesn't exist in 4 and 5.
Our smarty 2 version has some custom stuff hacked in.

Comments
----------------------------------------
This is option 1 which is the simplest, but doesn't have our custom stuff. I tried making a compatibility function but it wasn't working and my head doesn't have the bandwidth for it at the moment. Also a universe search suggests there's only one extension using the dispatched event (already pinged on the lab ticket).