### PR TITLE
Make string nullable on civicrm_translation

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSeventySix.php
+++ b/CRM/Upgrade/Incremental/php/FiveSeventySix.php
@@ -32,6 +32,9 @@ class CRM_Upgrade_Incremental_php_FiveSeventySix extends CRM_Upgrade_Incremental
     $this->addTask('Add start_date to civicrm_mailing table', 'addColumn', 'civicrm_mailing', 'start_date', "timestamp NULL DEFAULT NULL COMMENT 'date on which this mailing was started.'");
     $this->addTask('Add end_date to civicrm_mailing table', 'addColumn', 'civicrm_mailing', 'end_date', "timestamp NULL DEFAULT NULL COMMENT 'date on which this mailing was completed.'");
     $this->addTask('Add status to civicrm_mailing table', 'addColumn', 'civicrm_mailing', 'status', "varchar(12) DEFAULT NULL COMMENT 'The status of this Mailing'");
+    $this->addTask('Alter translation to make string non-required', 'alterColumn', 'civicrm_translation', 'string',
+      "longtext NULL COMMENT 'Translated string'"
+    );
   }
 
 }

--- a/schema/Core/Translation.entityType.php
+++ b/schema/Core/Translation.entityType.php
@@ -95,7 +95,7 @@ return [
       'title' => ts('Translated String'),
       'sql_type' => 'longtext',
       'input_type' => 'TextArea',
-      'required' => TRUE,
+      'required' => FALSE,
       'description' => ts('Translated string'),
       'add' => '5.39',
     ],


### PR DESCRIPTION
Overview
----------------------------------------
Make string nullable on civicrm_translation

Before
----------------------------------------
Not possible to save an empty translation string - e.g if you go to Message Admin and add a translation with the body_text being empty

After
----------------------------------------
Can be saved

Technical Details
----------------------------------------
Being able to save an empty translation is important as it allows you to fall back to the relevant html rather than the untranslated text version - also it fixes the problem where it won't save at all right now as the text is empty unless you make it otherwise on our message templates

Comments
----------------------------------------
