### PR TITLE
Add SiteToken entity to the schema

### DIFF
--- a/CRM/Core/DAO/SiteToken.php
+++ b/CRM/Core/DAO/SiteToken.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * Placeholder class retained for legacy compatibility.
+ *
+ * @property int $id
+ * @property int $domain_id
+ * @property string $name
+ * @property string $body_html
+ * @property string $body_text
+ * @property bool $is_active
+ * @property bool $is_reserved
+ * @property int $created_id
+ * @property int $modified_id
+ * @property string $modified_date
+ */
+class CRM_Core_DAO_SiteToken extends CRM_Core_DAO_Base {
+}

--- a/CRM/Upgrade/Incremental/php/FiveSeventySix.php
+++ b/CRM/Upgrade/Incremental/php/FiveSeventySix.php
@@ -35,6 +35,26 @@ class CRM_Upgrade_Incremental_php_FiveSeventySix extends CRM_Upgrade_Incremental
     $this->addTask('Alter translation to make string non-required', 'alterColumn', 'civicrm_translation', 'string',
       "longtext NULL COMMENT 'Translated string'"
     );
+    $this->addTask('Install SiteToken entity', 'createEntityTable', '5.76.alpha1.SiteToken.entityType.php');
+    $this->addTask(ts('Create index %1', [1 => 'civicrm_site_token.UI_name_domain_id']), 'addIndex', 'civicrm_site_token', [['name', 'domain_id']], 'UI');
+    $this->addTask('Create "message header" token', 'create_mesage_header_token');
+  }
+
+  public static function create_mesage_header_token() {
+    $query = CRM_Core_DAO::executeQuery('SELECT id FROM civicrm_domain');
+    $domains = $query->fetchAll();
+    foreach ($domains as $domain) {
+      CRM_Core_DAO::executeQuery(
+        "INSERT IGNORE INTO civicrm_site_token (domain_id, name, label, body_html, body_text, is_reserved, is_active)
+      VALUES(
+       " . $domain['id'] . ",
+       'message_header',
+       '" . ts('Message Header') . "',
+     '<!-- " . ts('This is the %1 token HTML content.', [1 => '{site.message_header}']) . " -->',
+      '', 1, 1)"
+      );
+    }
+    return TRUE;
   }
 
 }

--- a/CRM/Upgrade/Incremental/schema/5.76.alpha1.SiteToken.entityType.php
+++ b/CRM/Upgrade/Incremental/schema/5.76.alpha1.SiteToken.entityType.php
@@ -1,0 +1,169 @@
+<?php
+
+return [
+  'name' => 'SiteToken',
+  'table' => 'civicrm_site_token',
+  'class' => 'CRM_Core_DAO_SiteToken',
+  // @todo - uncomment token class when the class is added.
+  //'token_class' => 'CRM_Core_SiteTokens',
+  'getInfo' => fn() => [
+    'title' => ts('Site Token'),
+    'title_plural' => ts('Site Tokens'),
+    'description' => ts('Site-wide tokens.'),
+    'add' => 5.76,
+    'log' => TRUE,
+    'icon' => 'fa-code',
+  ],
+  'getIndices' => fn() => [
+    'UI_name_domain_id' => [
+      'fields' => [
+        'name' => TRUE,
+        'domain_id' => TRUE,
+      ],
+      'unique' => TRUE,
+      'add' => '5.76',
+    ],
+  ],
+  'getPaths' => fn() => [
+    'add' => 'civicrm/admin/sitetoken/edit?action=add&reset=1',
+    'update' => 'civicrm/admin/sitetoken/edit#?SiteToken1=[id]',
+    'browse' => 'civicrm/admin/sitetoken?action=browse&reset=1',
+  ],
+  'getFields' => fn() => [
+    'id' => [
+      'title' => ts('Site Token ID'),
+      'sql_type' => 'int unsigned',
+      'input_type' => 'Number',
+      'required' => TRUE,
+      'primary_key' => TRUE,
+      'auto_increment' => TRUE,
+    ],
+    'domain_id' => [
+      'title' => ts('Domain'),
+      'sql_type' => 'int unsigned',
+      'input_type' => 'EntityRef',
+      'required' => TRUE,
+      'entity_reference' => [
+        'entity' => 'Domain',
+        'key' => 'id',
+        'on_delete' => 'CASCADE',
+      ],
+      'pseudoconstant' => [
+        'table' => 'civicrm_domain',
+        'key_column' => 'id',
+        'label_column' => 'name',
+      ],
+    ],
+    'name' => [
+      'title' => ts('Token Name'),
+      'sql_type' => 'varchar(64)',
+      'input_type' => 'Text',
+      'required' => TRUE,
+      'description' => ts('Token string, e.g. {site.[name]}'),
+      'input_attrs' => [
+        'maxlength' => 64,
+      ],
+    ],
+    'label' => [
+      'title' => ts('Token Label'),
+      'sql_type' => 'varchar(255)',
+      'input_type' => 'Text',
+      'required' => TRUE,
+      'description' => ts('User-visible label in token UI'),
+      'input_attrs' => [
+        'label' => ts('Label'),
+        'maxlength' => 255,
+      ],
+    ],
+    'body_html' => [
+      'title' => ts('Token Value (HTML)'),
+      'sql_type' => 'text',
+      'input_type' => 'TextArea',
+      'description' => ts('Value of the token in html format.'),
+      'input_attrs' => [
+        'rows' => 8,
+        'cols' => 80,
+      ],
+    ],
+    'body_text' => [
+      'title' => ts('Token Value (Text)'),
+      'sql_type' => 'text',
+      'input_type' => 'TextArea',
+      'description' => ts('Value of the token in text format.'),
+      'input_attrs' => [
+        'rows' => 8,
+        'cols' => 80,
+        'label' => ts('Body in Text Format'),
+      ],
+    ],
+    'is_active' => [
+      'title' => ts('Token Is Active?'),
+      'sql_type' => 'boolean',
+      'input_type' => 'CheckBox',
+      'required' => TRUE,
+      'description' => ts('Is this token active?'),
+      'default' => TRUE,
+      'input_attrs' => [
+        'label' => ts('Enabled'),
+      ],
+    ],
+    'is_reserved' => [
+      'title' => ts('Token Is Reserved?'),
+      'sql_type' => 'boolean',
+      'input_type' => 'CheckBox',
+      'required' => TRUE,
+      'description' => ts('Is this token reserved?'),
+      'default' => FALSE,
+      'input_attrs' => [
+        'label' => ts('Reserved'),
+      ],
+    ],
+    'created_id' => [
+      'title' => ts('Created By Contact ID'),
+      'sql_type' => 'int unsigned',
+      'input_type' => 'EntityRef',
+      'description' => ts('Contact responsible for creating this token'),
+      'add' => '5.76',
+      'input_attrs' => [
+        'label' => ts('Created By'),
+      ],
+      'entity_reference' => [
+        'entity' => 'Contact',
+        'key' => 'id',
+        'on_delete' => 'SET NULL',
+      ],
+    ],
+    'modified_id' => [
+      'title' => ts('Modified By Contact ID'),
+      'sql_type' => 'int unsigned',
+      'input_type' => NULL,
+      'readonly' => TRUE,
+      'description' => ts('FK to contact table.'),
+      'add' => '5.76',
+      'input_attrs' => [
+        'label' => ts('Modified By'),
+      ],
+      'entity_reference' => [
+        'entity' => 'Contact',
+        'key' => 'id',
+        'on_delete' => 'SET NULL',
+      ],
+    ],
+    'modified_date' => [
+      'title' => ts('Modified Date'),
+      'sql_type' => 'timestamp',
+      'input_type' => 'Select Date',
+      'readonly' => TRUE,
+      'description' => ts('When the token was created or modified or deleted.'),
+      'add' => '4.7',
+      'unique_name' => 'site_token_modified_date',
+      'default' => 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
+      'usage' => [
+        'export',
+      ],
+      'input_attrs' => [
+        'label' => ts('Modified Date'),
+      ],
+    ],
+  ],
+];

--- a/schema/Core/SiteToken.entityType.php
+++ b/schema/Core/SiteToken.entityType.php
@@ -1,0 +1,169 @@
+<?php
+
+return [
+  'name' => 'SiteToken',
+  'table' => 'civicrm_site_token',
+  'class' => 'CRM_Core_DAO_SiteToken',
+  // @todo - uncomment token class when the class is added.
+  //'token_class' => 'CRM_Core_SiteTokens',
+  'getInfo' => fn() => [
+    'title' => ts('Site Token'),
+    'title_plural' => ts('Site Tokens'),
+    'description' => ts('Site-wide tokens.'),
+    'add' => 5.76,
+    'log' => TRUE,
+    'icon' => 'fa-code',
+  ],
+  'getIndices' => fn() => [
+    'UI_name_domain_id' => [
+      'fields' => [
+        'name' => TRUE,
+        'domain_id' => TRUE,
+      ],
+      'unique' => TRUE,
+      'add' => '5.76',
+    ],
+  ],
+  'getPaths' => fn() => [
+    'add' => 'civicrm/admin/sitetoken/edit?action=add&reset=1',
+    'update' => 'civicrm/admin/sitetoken/edit#?SiteToken1=[id]',
+    'browse' => 'civicrm/admin/sitetoken?action=browse&reset=1',
+  ],
+  'getFields' => fn() => [
+    'id' => [
+      'title' => ts('Site Token ID'),
+      'sql_type' => 'int unsigned',
+      'input_type' => 'Number',
+      'required' => TRUE,
+      'primary_key' => TRUE,
+      'auto_increment' => TRUE,
+    ],
+    'domain_id' => [
+      'title' => ts('Domain'),
+      'sql_type' => 'int unsigned',
+      'input_type' => 'EntityRef',
+      'required' => TRUE,
+      'entity_reference' => [
+        'entity' => 'Domain',
+        'key' => 'id',
+        'on_delete' => 'CASCADE',
+      ],
+      'pseudoconstant' => [
+        'table' => 'civicrm_domain',
+        'key_column' => 'id',
+        'label_column' => 'name',
+      ],
+    ],
+    'name' => [
+      'title' => ts('Token Name'),
+      'sql_type' => 'varchar(64)',
+      'input_type' => 'Text',
+      'required' => TRUE,
+      'description' => ts('Token string, e.g. {site.[name]}'),
+      'input_attrs' => [
+        'maxlength' => 64,
+      ],
+    ],
+    'label' => [
+      'title' => ts('Token Label'),
+      'sql_type' => 'varchar(255)',
+      'input_type' => 'Text',
+      'required' => TRUE,
+      'description' => ts('User-visible label in token UI'),
+      'input_attrs' => [
+        'label' => ts('Label'),
+        'maxlength' => 255,
+      ],
+    ],
+    'body_html' => [
+      'title' => ts('Token Value (HTML)'),
+      'sql_type' => 'text',
+      'input_type' => 'TextArea',
+      'description' => ts('Value of the token in html format.'),
+      'input_attrs' => [
+        'rows' => 8,
+        'cols' => 80,
+      ],
+    ],
+    'body_text' => [
+      'title' => ts('Token Value (Text)'),
+      'sql_type' => 'text',
+      'input_type' => 'TextArea',
+      'description' => ts('Value of the token in text format.'),
+      'input_attrs' => [
+        'rows' => 8,
+        'cols' => 80,
+        'label' => ts('Body in Text Format'),
+      ],
+    ],
+    'is_active' => [
+      'title' => ts('Token Is Active?'),
+      'sql_type' => 'boolean',
+      'input_type' => 'CheckBox',
+      'required' => TRUE,
+      'description' => ts('Is this token active?'),
+      'default' => TRUE,
+      'input_attrs' => [
+        'label' => ts('Enabled'),
+      ],
+    ],
+    'is_reserved' => [
+      'title' => ts('Token Is Reserved?'),
+      'sql_type' => 'boolean',
+      'input_type' => 'CheckBox',
+      'required' => TRUE,
+      'description' => ts('Is this token reserved?'),
+      'default' => FALSE,
+      'input_attrs' => [
+        'label' => ts('Reserved'),
+      ],
+    ],
+    'created_id' => [
+      'title' => ts('Created By Contact ID'),
+      'sql_type' => 'int unsigned',
+      'input_type' => 'EntityRef',
+      'description' => ts('Contact responsible for creating this token'),
+      'add' => '5.76',
+      'input_attrs' => [
+        'label' => ts('Created By'),
+      ],
+      'entity_reference' => [
+        'entity' => 'Contact',
+        'key' => 'id',
+        'on_delete' => 'SET NULL',
+      ],
+    ],
+    'modified_id' => [
+      'title' => ts('Modified By Contact ID'),
+      'sql_type' => 'int unsigned',
+      'input_type' => NULL,
+      'readonly' => TRUE,
+      'description' => ts('FK to contact table.'),
+      'add' => '5.76',
+      'input_attrs' => [
+        'label' => ts('Modified By'),
+      ],
+      'entity_reference' => [
+        'entity' => 'Contact',
+        'key' => 'id',
+        'on_delete' => 'SET NULL',
+      ],
+    ],
+    'modified_date' => [
+      'title' => ts('Modified Date'),
+      'sql_type' => 'timestamp',
+      'input_type' => 'Select Date',
+      'readonly' => TRUE,
+      'description' => ts('When the token was created or modified or deleted.'),
+      'add' => '4.7',
+      'unique_name' => 'site_token_modified_date',
+      'default' => 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
+      'usage' => [
+        'export',
+      ],
+      'input_attrs' => [
+        'label' => ts('Modified Date'),
+      ],
+    ],
+  ],
+];

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -1567,6 +1567,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
         0 => 'created_id',
       ],
       'civicrm_saved_search' => ['created_id', 'modified_id'],
+      'civicrm_site_token' => ['created_id', 'modified_id'],
       'civicrm_relationship' => [
         0 => 'contact_id_a',
         1 => 'contact_id_b',


### PR DESCRIPTION
Overview
----------------------------------------
This contains the schema declaration & updates from https://github.com/civicrm/civicrm-core/pull/30451 with some fixes. The upgrade is a notoriously hard part of a change like this - both because of tricksiness & because it always goes stale. 

The version is rebased over 2 open PRs to avoid conflict https://github.com/civicrm/civicrm-core/pull/30517 & https://github.com/civicrm/civicrm-core/pull/30516

Before
----------------------------------------
Schema to support #30451 not added - a fight lies ahead

After
----------------------------------------
Code added to declare the new schema & add the new table

Technical Details
----------------------------------------
I made a couple of changes - notably
1) avoiding the API in the upgrader - that is best practice for the upgrader
2) adding a unique name/domain_id index & using INSERT INTO to avoid duplicates if run more than once
3) I added the token_class declaration following the (just merged) new way, but commented it out for now
4) fixed it to add 1 record per domain

Comments
----------------------------------------
