### PR TITLE
followup to 30484 - calling pear log setLocale doesn't do anything anymore

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -661,9 +661,6 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     $log = Log::singleton('file', \Civi::$statics[__CLASS__]['logger_file' . $prefix], '', [
       'timeFormat' => 'Y-m-d H:i:sO',
     ]);
-    if (is_callable([$log, 'setLocale'])) {
-      $log->setLocale(CRM_Core_I18n::getLocale());
-    }
     return $log;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Followup to https://github.com/civicrm/civicrm-core/pull/30484

Before
----------------------------------------
in the previous version we had a patch that implemented setLocale

After
----------------------------------------
current version of pear log has no concept of locale-dependency, and we don't use the patch anymore. So this function doesn't even exist.

Technical Details
----------------------------------------


Comments
----------------------------------------

