### PR TITLE
Allow getting log filename after pear log 1.14 update

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -696,8 +696,9 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * the file exists.
    *
    * @param string $prefix
+   * @return string The full path to the file.
    */
-  protected static function generateLogFileName($prefix) {
+  public static function generateLogFileName($prefix): string {
     if (!isset(\Civi::$statics[__CLASS__]['logger_file' . $prefix])) {
       $config = CRM_Core_Config::singleton();
 
@@ -731,6 +732,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       }
       \Civi::$statics[__CLASS__]['logger_file' . $prefix] = $fileName;
     }
+    return \Civi::$statics[__CLASS__]['logger_file' . $prefix];
   }
 
   /**

--- a/tests/phpunit/CRM/Core/ErrorTest.php
+++ b/tests/phpunit/CRM/Core/ErrorTest.php
@@ -105,11 +105,14 @@ class CRM_Core_ErrorTest extends CiviUnitTestCase {
     $log = CRM_Core_Error::createDebugLogger('my-test');
     $log->log('Mary had a little lamb');
     $log->log('Little lamb');
+    $fileName = CRM_Core_Error::generateLogFileName('my-test');
     $config = CRM_Core_Config::singleton();
-    $fileContents = file_get_contents($config->configAndLogDir . 'CiviCRM.' . CIVICRM_DOMAIN_ID . '.' . 'my-test.' . CRM_Core_Error::generateLogFileHash($config) . '.log');
-    // The 5 here is a bit arbitrary - on my local the date part is 15 chars (Mar 29 05:29:16) - but we are just checking that
-    // there are chars for the date at the start.
-    $this->assertTrue(strpos($fileContents, '[info] Mary had a little lamb') > 10);
+    $this->assertEquals($config->configAndLogDir . 'CiviCRM.' . CIVICRM_DOMAIN_ID . '.' . 'my-test.' . CRM_Core_Error::generateLogFileHash($config) . '.log', $fileName);
+    $fileContents = file_get_contents($fileName);
+    // Date format should be ISO
+    $this->assertMatchesRegularExpression('/^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d[+-]\d\d\d\d$/', substr($fileContents, 0, 24));
+    // Check the text starts at the expected position
+    $this->assertEquals(26, strpos($fileContents, '[info] Mary had a little lamb'));
     $this->assertStringContainsString('[info] Little lamb', $fileContents);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Followup to https://github.com/civicrm/civicrm-core/pull/30484/files#r1647984172

Before
----------------------------------------
In earlier versions of pear/log, you could access $log->_filename.

After
----------------------------------------
Make existing function in CRM_Core_Error public.

Technical Details
----------------------------------------
The hash function is already public. Doesn't seem like this would cause harm.

Comments
----------------------------------------
Also reinstates/updates the test
