### PR TITLE
fix broken status check after update to pear log 1.14

### DIFF
--- a/CRM/Utils/Check/Component/Security.php
+++ b/CRM/Utils/Check/Component/Security.php
@@ -59,8 +59,8 @@ class CRM_Utils_Check_Component_Security extends CRM_Utils_Check_Component {
 
     $config = CRM_Core_Config::singleton();
 
-    $log = CRM_Core_Error::createDebugLogger();
-    $log_filename = str_replace('\\', '/', $log->_filename ?? '');
+    CRM_Core_Error::createDebugLogger();
+    $log_filename = str_replace('\\', '/', CRM_Core_Error::generateLogFileName(''));
 
     $filePathMarker = $this->getFilePathMarker();
 


### PR DESCRIPTION
Overview
----------------------------------------
pear log no longer allows access to the filename

Before
----------------------------------------
property doesn't exist anymore

After
----------------------------------------
use new function

Technical Details
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/30484

Comments
----------------------------------------
