### PR TITLE
"DB Error: syntax error" on membership reminder when contribution statuses are translated

### DIFF
--- a/CRM/Member/ActionMapping.php
+++ b/CRM/Member/ActionMapping.php
@@ -95,14 +95,12 @@ class CRM_Member_ActionMapping extends \Civi\ActionSchedule\MappingBase {
       $query['casDateField'] = 'e.' . $query['casDateField'];
     }
 
-    $recurStatuses = \Civi\Api4\ContributionRecur::getFields(FALSE)
-      ->setLoadOptions(TRUE)
-      ->addWhere('name', '=', 'contribution_status_id')
-      ->addSelect('options')
-      ->execute()
-      ->first()['options'];
     // Exclude the renewals that are cancelled or failed.
-    $nonRenewStatusIds = array_keys(array_intersect($recurStatuses, ['Cancelled', 'Failed']));
+    $nonRenewStatusIds = [
+      CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionRecur', 'contribution_status_id', 'Cancelled'),
+      CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionRecur', 'contribution_status_id', 'Failed'),
+    ];
+
     // FIXME: Numbers should be constants.
     if (in_array(2, $selectedStatuses)) {
       //auto-renew memberships


### PR DESCRIPTION
Overview
----------------------------------------
`DB Error: syntax error` on membership reminder when contribution statuses 'Cancelled' and 'Failed' are translated.

Introduced by https://github.com/civicrm/civicrm-core/pull/26563/files

Before
----------------------------------------
When sending a membership reminder and the label for statuses 'Cancelled', 'Failed' are modified or translated, the query generated gives a syntax error (nothing in the `NOT IN`) :
```sql
INSERT INTO civicrm_action_log (contact_id, entity_id, entity_table, action_schedule_id, reference_date)
SELECT e.contact_id as contact_id, e.id as entity_id, "civicrm_membership" as entity_table, 1 as action_schedule_id, e.end_date as reference_date
FROM civicrm_membership e
INNER JOIN civicrm_contribution_recur cr on e.contribution_recur_id = cr.id
LEFT JOIN civicrm_membership cm ON cm.id = e.owner_membership_id
LEFT JOIN civicrm_relationship rela ON rela.contact_id_a = e.contact_id AND rela.contact_id_b = cm.contact_id AND rela.is_permission_a_b = 1
LEFT JOIN civicrm_relationship relb ON relb.contact_id_a = cm.contact_id AND relb.contact_id_b = e.contact_id AND relb.is_permission_b_a = 1
INNER JOIN civicrm_contact c ON c.id = e.contact_id AND c.is_deleted = 0 AND c.is_deceased = 0 
LEFT JOIN civicrm_action_log reminder ON reminder.contact_id = e.contact_id AND
reminder.entity_id          = e.id AND
reminder.entity_table       = 'civicrm_membership' AND
reminder.action_schedule_id = 1 AND
reminder.reference_date = e.end_date
WHERE (cr.contribution_status_id NOT IN ())
  AND (e.membership_type_id IN ("2", "1", "3"))
  AND (e.is_override = 0)
  AND (!( e.owner_membership_id IS NOT NULL AND rela.id IS NULL and relb.id IS NULL ))
  AND (e.status_id IN (1, 2, 3, 4))
  AND (reminder.id IS NULL)
  AND ('20240621102648' >= DATE_SUB(e.end_date, INTERVAL 15 day))
  AND (DATE_SUB(20240621102648, INTERVAL 1 DAY ) <= DATE_SUB(e.end_date, INTERVAL 15 day));
```

After
----------------------------------------
No more sql `Syntax error`

Comments
----------------------------------------
This is a typical label vs name issue. Is there no easier way in CiviCRM to get a list of field options ids by name ?

