### PR TITLE
dev/core#5307 - Error when deleting groups

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -396,6 +396,7 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
     foreach ($groups as $group) {
       // Filter out arrays in Form Values which are group searchs.
       if (is_array($group['saved_search_id.form_values'])) {
+        $groupSearches = [];
         $groupSearches = array_filter(
           $group['saved_search_id.form_values'],
           function($v) {

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -395,12 +395,14 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
     $smartGroups = [];
     foreach ($groups as $group) {
       // Filter out arrays in Form Values which are group searchs.
-      $groupSearches = array_filter(
-        $group['saved_search_id.form_values'],
-        function($v) {
-          return ($v[0] == 'group');
-        }
-      );
+      if (is_array($group['saved_search_id.form_values'])) {
+        $groupSearches = array_filter(
+          $group['saved_search_id.form_values'],
+          function($v) {
+            return ($v[0] == 'group');
+          }
+        );
+      }
       // Check each group search for valid groups.
       foreach ($groupSearches as $groupSearch) {
         if (!empty($groupSearch[2]) && in_array($groupID, (array) $groupSearch[2])) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/5307
This enables one to delete groups.

Before
----------------------------------------
When deleting a group you got: 
![image](https://github.com/civicrm/civicrm-core/assets/10037367/88c61787-2163-4ec1-b3c0-1105b391629b)
instead of the group being deleted.

After
----------------------------------------
You get:
![image](https://github.com/civicrm/civicrm-core/assets/10037367/180cc29d-8a4c-4754-8a40-723d658cfcc0)
Followed by a confirmation message.

Technical Details
----------------------------------------
Before attempting an array_filter we check that the argument is an array.

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
