### PR TITLE
Afform - Server side conditional evaluation

### DIFF
--- a/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
+++ b/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
@@ -119,6 +119,10 @@ trait ArrayQueryActionTrait {
     if (isset($index) && is_array($value) && $operator !== 'IN' && $operator !== 'NOT IN') {
       $value = $value[$index] ?? NULL;
     }
+    return self::compareValues($value, $operator, $expected);
+  }
+
+  public static function compareValues($value, string $operator, $expected): bool {
     switch ($operator) {
       case '=':
       case '!=':

--- a/ext/afform/core/Civi/Afform/FormDataModel.php
+++ b/ext/afform/core/Civi/Afform/FormDataModel.php
@@ -144,20 +144,28 @@ class FormDataModel {
    * @param string $entity
    * @param string $join
    * @param string $searchDisplay
+   * @param array $afIfConditions
    */
-  protected function parseFields($nodes, $entity = NULL, $join = NULL, $searchDisplay = NULL) {
+  protected function parseFields($nodes, $entity = NULL, $join = NULL, $searchDisplay = NULL, $afIfConditions = []) {
     foreach ($nodes as $node) {
       if (!is_array($node) || !isset($node['#tag'])) {
         continue;
       }
-      elseif (isset($node['af-fieldset'])) {
+      if (!empty($node['af-if'])) {
+        $conditional = substr($node['af-if'], 1, -1);
+        $afIfConditions[] = json_decode(html_entity_decode($conditional));
+      }
+      if ($node['#tag'] === 'af-field' && $afIfConditions) {
+        $node['af-if'] = $afIfConditions;
+      }
+      if (isset($node['af-fieldset'])) {
         $entity = $node['af-fieldset'] ?? NULL;
         $searchDisplay = $entity ? NULL : $this->findSearchDisplay($node);
         if ($entity && isset($node['af-repeat'])) {
           $this->entities[$entity]['min'] = $node['min'] ?? 0;
           $this->entities[$entity]['max'] = $node['max'] ?? NULL;
         }
-        $this->parseFields($node['#children'] ?? [], $node['af-fieldset'], $join, $searchDisplay);
+        $this->parseFields($node['#children'] ?? [], $node['af-fieldset'], $join, $searchDisplay, $afIfConditions);
       }
       elseif ($searchDisplay && $node['#tag'] === 'af-field') {
         $this->searchDisplays[$searchDisplay]['fields'][$node['name']] = AHQ::getProps($node);
@@ -172,10 +180,10 @@ class FormDataModel {
       }
       elseif ($entity && !empty($node['af-join'])) {
         $this->entities[$entity]['joins'][$node['af-join']] = AHQ::getProps($node);
-        $this->parseFields($node['#children'] ?? [], $entity, $node['af-join']);
+        $this->parseFields($node['#children'] ?? [], $entity, $node['af-join'], NULL, $afIfConditions);
       }
       elseif (!empty($node['#children'])) {
-        $this->parseFields($node['#children'], $entity, $join, $searchDisplay);
+        $this->parseFields($node['#children'], $entity, $join, $searchDisplay, $afIfConditions);
       }
       // Recurse into embedded blocks
       if (isset($this->blocks[$node['#tag']])) {
@@ -183,7 +191,7 @@ class FormDataModel {
           $this->blocks[$node['#tag']] = Afform::get(FALSE)->setSelect(['name', 'layout'])->addWhere('name', '=', $this->blocks[$node['#tag']]['name'])->execute()->first();
         }
         if (!empty($this->blocks[$node['#tag']]['layout'])) {
-          $this->parseFields($this->blocks[$node['#tag']]['layout'], $entity, $join, $searchDisplay);
+          $this->parseFields($this->blocks[$node['#tag']]['layout'], $entity, $join, $searchDisplay, $afIfConditions);
         }
       }
     }

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -175,15 +175,17 @@
 
           case 'CONTAINS':
           case 'NOT CONTAINS':
-            if (typeof val1 === 'string' || Array.isArray(val1)) {
-              return val1.includes(val2);
+            if (Array.isArray(val1)) {
+              return val1.includes(val2) === yes;
+            } else if (typeof val1 === 'string' && typeof val2 === 'string') {
+              return val1.toLowerCase().includes(val2.toLowerCase()) === yes;
             }
             return !yes;
 
           case 'IN':
           case 'NOT IN':
             if (Array.isArray(val2)) {
-              return val2.includes(val1);
+              return val2.includes(val1) === yes;
             }
             return !yes;
 

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformConditionalUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformConditionalUsageTest.php
@@ -1,0 +1,142 @@
+<?php
+namespace api\v4\Afform;
+
+use Civi\Api4\Afform;
+
+/**
+ * Test case for Afform with autocomplete.
+ *
+ * @group headless
+ */
+class AfformConditionalUsageTest extends AfformUsageTestCase {
+
+  /**
+   * Required field based on text input
+   */
+  public function testConditionalRequiredFieldTextInput(): void {
+    $layout = <<<EOHTML
+<af-form ctrl="afform">
+  <af-entity data="{source: 'TestConditionals'}" type="Individual" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="RBAC" />
+  <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
+    <af-field name="first_name" />
+    <af-field name="last_name" af-if="([[&amp;quot;OR&amp;quot;,[[&amp;quot;Individual1[0][fields][first_name]&amp;quot;,&amp;quot;=&amp;quot;,&amp;quot;\&amp;quot;A\&amp;quot;&amp;quot;],[&amp;quot;Individual1[0][fields][first_name]&amp;quot;,&amp;quot;CONTAINS&amp;quot;,&amp;quot;\&amp;quot;BC\&amp;quot;&amp;quot;]]]])" defn="{required: true, input_attrs: {}}" />
+  </fieldset>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()" ng-if="afform.showSubmitButton">Submit</button>
+</af-form>
+EOHTML;
+    $this->useValues([
+      'layout' => $layout,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+    ]);
+
+    // Conditional rule is that last_name is required
+    // IF first_name = A (case-sensitive) OR first_name CONTAINS "bc" (case-insensitive)
+
+    // Conditional field shown: this will fail validation
+    $submission = [
+      ['fields' => ['first_name' => 'A', 'last_name' => '']],
+    ];
+    try {
+      Afform::submit()
+        ->setName($this->formName)
+        ->setValues(['Individual1' => $submission])
+        ->execute();
+    }
+    catch (\CRM_Core_Exception $e) {
+    }
+    $this->assertStringContainsString('Validation Error', $e->getMessage());
+
+    // Conditional field shown: this will fail validation
+    $submission = [
+      ['fields' => ['first_name' => 'ebcd', 'last_name' => '']],
+    ];
+    try {
+      Afform::submit()
+        ->setName($this->formName)
+        ->setValues(['Individual1' => $submission])
+        ->execute();
+    }
+    catch (\CRM_Core_Exception $e) {
+    }
+    $this->assertStringContainsString('Validation Error', $e->getMessage());
+
+    // Conditional field hidden: this will pass validation
+    $submission = [
+      ['fields' => ['first_name' => 'a', 'last_name' => '']],
+    ];
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues(['Individual1' => $submission])
+      ->execute();
+
+    $this->assertGreaterThan(0, $result[0]['Individual1'][0]['id']);
+  }
+
+  /**
+   * Required field based on boolean input
+   */
+  public function testConditionalRequiredFieldBoolInput(): void {
+    $layout = <<<EOHTML
+<af-form ctrl="afform">
+  <af-entity data="{source: 'TestConditionals'}" type="Individual" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="RBAC" />
+  <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
+    <af-field name="first_name" />
+    <af-field name="last_name" />
+    <af-field name="do_not_email" />
+    <div af-join="Email" data="{is_primary: true}" af-if="([[&amp;quot;Individual1[0][fields][do_not_email]&amp;quot;,&amp;quot;=&amp;quot;,&amp;quot;false&amp;quot;]])">
+      <div class="af-container af-layout-inline">
+        <af-field name="email" defn="{required: true, input_attrs: {}}" />
+      </div>
+    </div>
+  </fieldset>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()" ng-if="afform.showSubmitButton">Submit</button>
+</af-form>
+EOHTML;
+    $this->useValues([
+      'layout' => $layout,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+    ]);
+
+    // Conditional rule is that email is required if no_not_email is FALSE
+
+    // Conditional field shown: this will fail validation
+    $submission = [
+      [
+        'fields' => ['first_name' => 'A', 'last_name' => 'A', 'do_not_email' => FALSE],
+        'joins' => [
+          'Email' => [
+            ['email' => ''],
+          ],
+        ],
+      ],
+    ];
+    try {
+      Afform::submit()
+        ->setName($this->formName)
+        ->setValues(['Individual1' => $submission])
+        ->execute();
+    }
+    catch (\CRM_Core_Exception $e) {
+    }
+    $this->assertStringContainsString('Validation Error', $e->getMessage());
+
+    // Conditional field hidden: this will pass validation
+    $submission = [
+      [
+        'fields' => ['first_name' => 'A', 'last_name' => 'A', 'do_not_email' => TRUE],
+        'joins' => [
+          'Email' => [
+            ['email' => ''],
+          ],
+        ],
+      ],
+    ];
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues(['Individual1' => $submission])
+      ->execute();
+
+    $this->assertGreaterThan(0, $result[0]['Individual1'][0]['id']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/5182.  If you have a required field on an FB form that's conditionally hidden, it passes client-side "required field" validation but fails it server-side.

Before
----------------------------------------
Silent failure, not all data saved.

After
----------------------------------------
Hidden required fields are un-required server side as well as client-side.

Comments
----------------------------------------
This extends @MegaphoneJon's work from https://github.com/civicrm/civicrm-core/pull/30094 with support for all operators, and server-side unit tests. TODO: client-side unit tests.