### PR TITLE
Fix smarty error on the manage event pcp tab

### DIFF
--- a/templates/CRM/PCP/Form/Event.tpl
+++ b/templates/CRM/PCP/Form/Event.tpl
@@ -17,4 +17,4 @@
 <div class="help">
 {ts}Allow constituents to create their own personal fundraising pages linked to this event.{/ts} {help id="id-pcp_intro_help"}
 </div>
-{include file="CRM/PCP/Form/PCP.tpl" context="event" pageId=`$eventId`}
+{include file="CRM/PCP/Form/PCP.tpl" context="event" pageId=$eventId}


### PR DESCRIPTION
Overview
----------------------------------------
Fix smarty error on the manage event pcp tab

Before
----------------------------------------
tab doesn't load

After
----------------------------------------
it does

Technical Details
----------------------------------------
I feel sure we have done this fix to this file before?

Comments
----------------------------------------
