### PR TITLE
Fix issue with permissions on membership creation activity

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -163,11 +163,13 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
       }
 
       foreach (['Membership Signup', 'Membership Renewal'] as $activityType) {
-        $activityParams['id'] = civicrm_api3('Activity', 'Get', [
-          'source_record_id' => $membership->id,
-          'activity_type_id' => $activityType,
-          'status_id' => 'Scheduled',
-        ])['id'] ?? NULL;
+        $activityParams['id'] = \Civi\Api4\Activity::get(FALSE)
+          ->addSelect('id')
+          ->addWhere('source_record_id', '=', $membership->id)
+          ->addWhere('activity_type_id:name', '=', $activityType)
+          ->addWhere('status_id:name', '=', 'Scheduled')
+          ->execute()
+          ->first()['id'] ?? NULL;
         // 1. Update Schedule Membership Signup/Renwal activity to completed on successful payment of pending membership
         // 2. OR Create renewal activity scheduled if its membership renewal will be paid later
         if (!empty($params['membership_activity_status']) && (!empty($activityParams['id']) || $activityType == 'Membership Renewal')) {


### PR DESCRIPTION
Overview
----------------------------------------
This replaces an API3 call with an API4 call.

Does it fix a bug?  Yes, but I can't replicate it, so let's just say I'm doing a slight modernization and leave it there.  But I've found that if someone creates a membership via contribution page when logged in, the original code works fine.  But if they access the page via a checksum, the API3 code returns `NULL` instead of the activity ID.  This causes a) the Membership Signup activity to not have the statuses populated, b) a Membership Renewal activity is created, despite this being a new membership.  But not on dmaster.

This is also a regression, but I think it's about 6 months old, looking at the client site's data.

Before
----------------------------------------
API3 older code.

After
----------------------------------------
API4 shinier code.

Comments
----------------------------------------
I've noticed lately that there is a much larger performance hit than I'd expect with API4 `get` actions when we don't limit the number of fields.  I don't think it's a SQL thing, I think it's just the cost of copying large arrays from function to function. While that's not applicable here, I think it's a good habit to get into to use `addSelect()` wherever it makes sense.