### PR TITLE
Enforce unique label+domain_id for site tokens

### DIFF
--- a/schema/Core/SiteToken.entityType.php
+++ b/schema/Core/SiteToken.entityType.php
@@ -22,6 +22,14 @@ return [
       'unique' => TRUE,
       'add' => '5.76',
     ],
+    'UI_label_domain_id' => [
+      'fields' => [
+        'label' => TRUE,
+        'domain_id' => TRUE,
+      ],
+      'unique' => TRUE,
+      'add' => '5.76',
+    ],
   ],
   'getPaths' => fn() => [
     'add' => 'civicrm/admin/sitetoken/edit?action=add&reset=1',


### PR DESCRIPTION
As Allan pointed out in this comment
https://github.com/civicrm/civicrm-core/pull/30451#issuecomment-2184316807 the drop down token list would be loopy if we permit multiple uses of the same label
