### PR TITLE
Fix joomla 3 regression from #27834 for Select2 drop down options in …

### DIFF
--- a/css/joomla.css
+++ b/css/joomla.css
@@ -45,13 +45,13 @@ body.admin.com_civicrm.layout-default .crm-dashlet {
 body.admin.com_civicrm .crm-container.ui-dialog {
   z-index: 100000;
 }
-body.admin.com_civicrm.layout-default .ui-widget-overlay {
+body.admin.com_civicrm .ui-widget-overlay {
   z-index: 100001;
 }
-body.admin.com_civicrm.layout-default .select2-drop {
+body.admin.com_civicrm .select2-drop {
   z-index: 100002;
 }
-body.admin.com_civicrm.layout-default .modal-dialog {
+body.admin.com_civicrm .modal-dialog {
   max-width: inherit;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
…a modal

Overview
----------------------------------------
On a client site we found after upgrading to 5.74.4 select2 dropdowns were hidden in modal due to the z-index issues. the patch here https://github.com/civicrm/civicrm-core/pull/29821 didn't seem to solve it as there is no layout-default class on our j3 site

@vingle can you check this?