### PR TITLE
dev/core#5309 Allow mb_substr via Smarty

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -193,6 +193,7 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
       'str_starts_with',
       // Trim is used on the extensions page.
       'trim',
+      'mb_substr',
       'is_numeric',
       'array_key_exists',
       'strstr',


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#5309 Allow mb_substr via Smarty

Before
----------------------------------------
`mb_substr` now allowed in Smarty5

After
----------------------------------------
Now it is

Technical Details
----------------------------------------
I like Dave's idea of trying to get them to call mb_substr when available when substr is called but for now this quick-fix is sane

Comments
----------------------------------------
