### PR TITLE
dev/core#3682 Add message_header site token on install

### DIFF
--- a/sql/civicrm_data/civicrm_site_token.sqldata.php
+++ b/sql/civicrm_data/civicrm_site_token.sqldata.php
@@ -5,7 +5,7 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_site_token')
     [
       'label' => ts('Message Header'),
       'name' => 'message_header',
-      'body_html' => '<div></div>',
+      'body_html' => '<div><!-- ' . ts('This content comes from the site message header token') . '--></div>',
       'body_text' => ts('Sample Header for TEXT formatted content.'),
       'is_reserved' => 1,
     ],

--- a/sql/civicrm_data/civicrm_site_token.sqldata.php
+++ b/sql/civicrm_data/civicrm_site_token.sqldata.php
@@ -1,0 +1,16 @@
+<?php
+
+return CRM_Core_CodeGen_SqlData::create('civicrm_site_token')
+  ->addValues([
+    [
+      'label' => ts('Message Header'),
+      'name' => 'message_header',
+      'body_html' => '<div></div>',
+      'body_text' => ts('Sample Header for TEXT formatted content.'),
+      'is_reserved' => 1,
+    ],
+  ])
+  ->addDefaults([
+    'is_active' => 1,
+    'domain_id' => 1,
+  ]);

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -346,7 +346,8 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends AbstractMappingTest {
       campaign_id = {contribution.campaign_id}
       campaign name = {contribution.campaign_id:name}
       campaign label = {contribution.campaign_id:label}
-      receipt text = {contribution.contribution_page_id.receipt_text}';
+      receipt text = {contribution.contribution_page_id.receipt_text}
+      message_header = {site.message_header}';
 
     $this->schedule->save();
     $this->callAPISuccess('job', 'send_reminder', []);
@@ -376,6 +377,7 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends AbstractMappingTest {
       'campaign name = big_campaign',
       'campaign label = Campaign',
       'receipt text = Thank you!',
+      'header = <div><!-- This content comes from the site message header token--></div>',
     ];
     $this->mut->checkMailLog($expected);
 
@@ -472,6 +474,7 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends AbstractMappingTest {
         'address_id.id' => 'Address ID',
         'address_id.name' => 'Billing Address Name',
         'address_id.display' => 'Billing Address',
+        'header' => 'Message Header',
       ], $comparison);
   }
 

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -959,6 +959,7 @@ emo
       '{contact.checksum}' => 'Checksum',
       '{contact.id}' => 'Contact ID',
       '{important_stuff.favourite_emoticon}' => 'Best coolest emoticon',
+      '{site.message_header}' => 'Message Header',
     ];
   }
 
@@ -1336,6 +1337,7 @@ custom_3 |01/20/2021 12:00AM
 checksum |cs=' . $checksum . '
 id |' . $tokenData['contact_id'] . '
 t_stuff.favourite_emoticon |
+sage_header |<div><!-- This content comes from the site message header token--></div>
 ';
   }
 

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -952,6 +952,7 @@ United States', $tokenProcessor->getRow(0)->render('message'));
       '{domain.state_province_id:label}' => 'Domain (Organization) State',
       '{domain.country_id:label}' => 'Domain (Organization) Country',
       '{domain.empowered_by_civicrm_image_url}' => 'Empowered By CiviCRM Image',
+      '{site.message_header}' => 'Message Header',
     ];
   }
 

--- a/xml/templates/civicrm_data.tpl
+++ b/xml/templates/civicrm_data.tpl
@@ -183,3 +183,4 @@ VALUES ( @fieldID, 'contribution_amount', 'Contribution Amount', '1', '1', '0', 
 {crmSqlData file="sql/civicrm_data/civicrm_extension.sqldata.php"}
 {crmSqlData file="sql/civicrm_data/civicrm_option_group/soft_credit_type.sqldata.php"}
 {crmSqlData file="sql/civicrm_data/civicrm_option_group/recent_items_providers.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_site_token.sqldata.php"}


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#3682 Add message_header site token on install

This is one of the outstanding steps in

https://lab.civicrm.org/dev/core/-/issues/3682

Before
----------------------------------------
no blank entry created on install

After
----------------------------------------
it's created

Technical Details
----------------------------------------
It's important to do this as we create it as is_reserved=1 & it can't be deleted (unlike ad hoc ones)

Comments
----------------------------------------
