### PR TITLE
[REF] Fix some smarty notices on Event Pages

### DIFF
--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -236,8 +236,8 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
         "reset=1&id={$this->_id}",
         FALSE, NULL, TRUE, TRUE
       );
-      $this->assign('participantListingURL', $participantListingURL);
     }
+    $this->assign('participantListingURL', $participantListingURL ?? NULL);
 
     $hasWaitingList = $values['event']['has_waitlist'] ?? NULL;
     $isEventOpenForRegistration = CRM_Event_BAO_Event::validRegistrationRequest($values['event'], $this->_id);

--- a/templates/CRM/Event/Form/Registration/ThankYou.tpl
+++ b/templates/CRM/Event/Form/Registration/ThankYou.tpl
@@ -81,7 +81,7 @@
                 {$event.fee_label}
             </div>
             {if $lineItem}
-                {include file="CRM/Price/Page/LineItem.tpl" context="Event"}
+                {include file="CRM/Price/Page/LineItem.tpl" context="Event" displayLineItemFinancialType=false getTaxDetails=$totalTaxAmount hookDiscount=''}
             {elseif $amount || $amount == 0}
               <div class="crm-section no-label amount-item-section">
                     {foreach from=$finalAmount item=amount key=level}

--- a/templates/CRM/Event/Page/EventInfo.tpl
+++ b/templates/CRM/Event/Page/EventInfo.tpl
@@ -142,7 +142,7 @@
           <div class="crm-section event_map-section">
               <div class="content">
                     {assign var=showDirectly value="1"}
-                    {include file="CRM/Contact/Form/Task/Map/`$config->mapProvider`.tpl" fields=$showDirectly}
+                    {include file="CRM/Contact/Form/Task/Map/`$config->mapProvider`.tpl" fields=$showDirectly profileGID=false}
                     <a href="{$mapURL}" title="{ts}Show large map{/ts}">{ts}Show large map{/ts}</a>
               </div>
               <div class="clear"></div>


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix some smarty notices about undefined variables

Before
----------------------------------------
Smarty Notices

After
----------------------------------------
Less notices

note for the Map this is the variable we are working with https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/Contact/Form/Task/Map/Google.tpl#L33C31-L33C42

For the LineItem one it is basically the same as confirm https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/Event/Form/Registration/Confirm.tpl#L48 but assigning a hookDiscount (which might be wrong not sure)

@eileenmcnaughton @demeritcowboy 