### PR TITLE
[REF] Fix schema version number to be correct one

### DIFF
--- a/schema/Mailing/Mailing.entityType.php
+++ b/schema/Mailing/Mailing.entityType.php
@@ -398,7 +398,7 @@ return [
         'formatType' => 'activityDateTime',
       ],
       'readonly' => TRUE,
-      'add' => 5.75,
+      'add' => 5.76,
     ],
     'end_date' => [
       'sql_type' => 'timestamp',
@@ -418,7 +418,7 @@ return [
         'formatType' => 'activityDateTime',
       ],
       'readonly' => TRUE,
-      'add' => 5.75,
+      'add' => 5.76,
     ],
     'status' => [
       'title' => ts('Mailing Status'),
@@ -441,7 +441,7 @@ return [
         'callback' => 'CRM_Core_SelectValues::getMailingJobStatus',
       ],
       'readonly' => TRUE,
-      'add' => 5.75,
+      'add' => 5.76,
     ],
     'approver_id' => [
       'title' => ts('Approved By Contact ID'),


### PR DESCRIPTION
Overview
----------------------------------------
These fields were only added last week so the correct version is 5.76 not 75 https://github.com/civicrm/civicrm-core/commit/bd1c609ec2b92e521d82899888611bc384e43da3

@eileenmcnaughton @demeritcowboy @colemanw 