### PR TITLE
[NFC] SettingsStyleTest - better warnings when missing keys

### DIFF
--- a/tests/phpunit/Civi/Core/SettingsStyleTest.php
+++ b/tests/phpunit/Civi/Core/SettingsStyleTest.php
@@ -29,16 +29,20 @@ class SettingsStyleTest extends \CiviUnitTestCase {
     $all = SettingsMetadata::getMetadata();
     $this->assertTrue(count($all) > 10);
     foreach ($all as $key => $spec) {
-      $assert($key, preg_match(';^\d+\.\d+(\.\d+)?$;', $spec['add'] ?? NULL), 'Should have well-formed \"add\" property');
-      $assert($key, !($spec['is_domain'] && $spec['is_contact']), 'Cannot be both is_domain and is_contact');
-      $assert($key, $key === $spec['name'], 'Should have matching name');
+      $add = $spec['add'] ?? 'UNKNOWN';
+      $assert($key, preg_match(';^\d+\.\d+(\.\d+)?$;', $add), 'Should have well-formed \"add\" property');
+      $isDomain = $spec['is_domain'] ?? NULL;
+      $isContact = $spec['is_contact'] ?? NULL;
+      $assert($key, !($isDomain && $isContact), 'Cannot be both is_domain and is_contact');
+      $name = $spec['name'] ?? NULL;
+      $assert($key, $key === $name, 'Should have matching name');
       $type = $spec['type'] ?? 'UNKNOWN';
       $assert($key, in_array($type, $validTypes), 'Should have known type. Found: ' . $type);
       if (version_compare($spec['add'], '5.53', '>=')) {
         $assert($key, preg_match(';^[a-z0-9]+(_[a-z0-9]+)+$;', $key), 'In 5.53+, names should use snake_case with a group/subsystem prefix.');
       }
       else {
-        $assert($key, preg_match(';^[a-z][a-zA-Z0-9_]+$;', $key), 'In 4.1-5.52, names should snake_case or lowerCamelCase.');
+        $assert($key, preg_match(';^[a-z][a-zA-Z0-9_]+$;', $key), 'In 4.1-5.52, names should use snake_case or lowerCamelCase.');
       }
     }
     $this->assertEquals([], $errors);


### PR DESCRIPTION
Overview
----------------------------------------
Improve null-coalescing for a test

Before
----------------------------------------
PHP 8.3 throws cryptic warnings when meta keys the test is trying to check are missing, e.g.:
```
Civi\Core\SettingsStyleTest::testConformance
preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated

/home/homer/buildkit/build/build-2/web/sites/all/modules/civicrm/tests/phpunit/Civi/Core/SettingsStyleTest.php:32
/home/homer/buildkit/build/build-2/web/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:289
/home/homer/buildkit/extern/phpunit9/phpunit9.phar:2307
```



After
----------------------------------------
You get the actual error text from the test, which is more informative.