### PR TITLE
api3 Setting - pass NULL instead of "current_domain" to SettingsMetadata

### DIFF
--- a/api/v3/Setting.php
+++ b/api/v3/Setting.php
@@ -44,10 +44,14 @@ function civicrm_api3_setting_getfields($params) {
     //usage really easy
     $params['filters']['name'] = $params['name'];
   }
+  $domainID = $params['domain_id'] ?? NULL;
+  if ($domainID === 'current_domain') {
+    $domainID = NULL;
+  }
   $result = CRM_Core_BAO_Setting::getSettingSpecification(
     $params['component_id'] ?? NULL,
     $params['filters'] ?? [],
-    $params['domain_id'] ?? NULL,
+    $domainID,
     $params['profile'] ?? NULL
   );
   // find any supplemental information


### PR DESCRIPTION

Overview
----------------------------------------
Fix `CRM_Core_BAO_Setting::getSettingSpecification` passing an unexpected "magic" value to `Civi\Core\SettingsMetadata`

Before
----------------------------------------
If the api3 user doesn't specify `domain_id` param, it defaults to `current_domain` .

This is then passed to `CRM_Core_BAO_Setting::getSettingSpecification` which in passes to `Civi\Core\SettingsMetadata::getMetadata`, which doesn't look like it's expecting a string value.

The issue I can see is that it will generate a cacheString of `settingsMetadata_current_domain_`, which will then clash if called on two different domains. Seems bad. 

After
----------------------------------------
Check for `current_domain` value and pass `NULL`, which is what SettingsMetadata expects.

Hopefully no cache clashing.

Technical Details
----------------------------------------
I think `SettingsMetadata::getMetadata`'s `domainID` param _should_ have a strong `?int` type check, but wasn't brave enough to add it.