### PR TITLE
Implement locale-based value formatting for query results

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -2295,9 +2295,9 @@ LIMIT $offset, $limit
    * @param string $fieldName Field name
    *
    * @return mixed|string
-   *  Returns formatted value or mysql value if field isn't localizable.
+   *   Returns formatted value or mysql value if field isn't localizable.
    */
-  protected function formatLocal(mixed $value, string $fieldName): mixed {
+  protected function formatLocal($value, string $fieldName) {
     $fieldMetaData = $this->getMetaDataForField($fieldName);
 
     if (!isset($fieldMetaData['type']) || empty($value)) {

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -2304,11 +2304,11 @@ LIMIT $offset, $limit
       return $value;
     }
     $fieldType = $fieldMetaData['type'];
-    $isDate = ($fieldType & (CRM_Utils_Type::T_DATE | CRM_Utils_Type::T_TIME | CRM_Utils_Type::T_TIMESTAMP )) != 0 ;
-    if ( $isDate ) {
-        $formatType = $fieldMetaData['html']['formatType'] ?? NULL;
+    $isDate = ($fieldType & (CRM_Utils_Type::T_DATE | CRM_Utils_Type::T_TIME | CRM_Utils_Type::T_TIMESTAMP)) != 0;
+    if ($isDate) {
+      $formatType = $fieldMetaData['html']['formatType'] ?? NULL;
       $formattedValue = CRM_Utils_Date::setDateDefaults($value, $formatType);
-      if ( !($formatType & CRM_Utils_Type::T_TIMESTAMP) ) {
+      if (!($formatType & CRM_Utils_Type::T_TIMESTAMP)) {
         if (!($fieldType & CRM_Utils_Type::T_DATE)) {
           unset($formattedValue[0]);
         }
@@ -2316,16 +2316,12 @@ LIMIT $offset, $limit
           unset($formattedValue[1]);
         }
       }
-      $x = implode(' ', $formattedValue);
       return implode(' ', $formattedValue);
     }
-
     if ($fieldType == CRM_Utils_Type::T_MONEY) {
-      $x = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($value);
-        return CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($value);
+      return CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($value);
     }
-        return $value;
-
+    return $value;
   }
 
   /**

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -2308,7 +2308,7 @@ LIMIT $offset, $limit
     if ($isDate) {
       $formatType = $fieldMetaData['html']['formatType'] ?? NULL;
       $formattedValue = CRM_Utils_Date::setDateDefaults($value, $formatType);
-      if (!($formatType & CRM_Utils_Type::T_TIMESTAMP)) {
+      if (!($fieldType & CRM_Utils_Type::T_TIMESTAMP)) {
         if (!($fieldType & CRM_Utils_Type::T_DATE)) {
           unset($formattedValue[0]);
         }


### PR DESCRIPTION
Overview
----------------------------------------
Added a new method, formatLocal, to the ExportProcessor class in order to convert the mysql value to a localized version based on the field type and current locale. This method is now called when previewing and exporting data.



Before
----------------------------------------
Currency and date(time) values were exported as unaltered database values.

After
----------------------------------------
Exported values now respect the configured locale.

Technical Details
----------------------------------------
I have removed the 'map' function to make the code compatible with PHP 7.3.

