### PR TITLE
In debug mode or on dev builds, make smarty annoying again

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -209,6 +209,11 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
 
     if ($config->debug || str_contains(CIVICRM_UF_BASEURL, 'localhost') || CRM_Utils_Constant::value('CIVICRM_UF') === 'UnitTests') {
       $this->error_reporting = E_ALL;
+      // In smarty 3+ warn about unassigned vars like it used to. It has the
+      // most effect in smarty 5. The property doesn't exist in smarty 2.
+      if ($this->getVersion() >= 3) {
+        $this->error_unassigned = TRUE;
+      }
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Everybody likes php warnings.

Before
----------------------------------------
In smarty5, it doesn't display some warnings that it does in older versions.

After
----------------------------------------
Annoying, but that's the point of the warnings.

Technical Details
----------------------------------------
Only with debugging enabled or on dev sites.

Comments
----------------------------------------
I have mixed feelings. We don't really need MORE red error boxes than we already have, but these go missing in smarty5 without the setting.