### PR TITLE
[php8] undeclared vars on new contribution

### DIFF
--- a/CRM/Financial/Form/Payment.php
+++ b/CRM/Financial/Form/Payment.php
@@ -24,6 +24,17 @@ class CRM_Financial_Form_Payment extends CRM_Core_Form {
   public $_values = [];
 
   /**
+   * @var int
+   * Billing type ID
+   */
+  protected $_bltID;
+
+  /**
+   * @var array
+   */
+  public $_paymentFields;
+
+  /**
    * @var array
    */
   public $_paymentProcessor;


### PR DESCRIPTION
Overview
----------------------------------------
undeclared vars

Before
----------------------------------------
Go to new contribution.
Undeclared vars.

After
----------------------------------------
Declared vars

Technical Details
----------------------------------------
It's a little hard to see these because it happens during ajax so is hidden. One way to see it is with the loudnotices extension. Or you can see in preprocess it calls $this->assignBillingType(); and CRM_Core_Payment_ProcessorForm::preProcess($this); which is where these vars are getting accessed.

Comments
----------------------------------------

