### PR TITLE
[REF] Fix potential smarty notice if location is empty

### DIFF
--- a/templates/CRM/Contact/Form/Task/Map/Google.tpl
+++ b/templates/CRM/Contact/Form/Task/Map/Google.tpl
@@ -47,7 +47,7 @@
     {if $location.image && ( $location.marker_class neq 'Event' )}
        image = '{$location.image}';
     {else}
-                 {if $location.marker_class eq 'Individual'}
+       {if $location.marker_class eq 'Individual'}
            image = "{$config->resourceBase}i/contact_ind.gif";
        {/if}
        {if $location.marker_class eq 'Household'}
@@ -67,8 +67,6 @@
         {if count($locations) gt 1}
             map.fitBounds(bounds);
             map.setMapTypeId(google.maps.MapTypeId.TERRAIN);
-        {elseif $location.marker_class eq 'Event' || $location.marker_class eq 'Individual'|| $location.marker_class eq 'Household' || $location.marker_class eq 'Organization'}
-            map.setZoom({$defaultZoom});
         {else}
             map.setZoom({$defaultZoom});
         {/if}

--- a/templates/CRM/Contact/Form/Task/Map/OpenStreetMaps.tpl
+++ b/templates/CRM/Contact/Form/Task/Map/OpenStreetMaps.tpl
@@ -121,8 +121,6 @@
         map.setCenter(bounds.getCenterLonLat());
         {if count($locations) gt 1}
             map.zoomToExtent(bounds);
-        {elseif $location.marker_class eq 'Event' || $location.marker_class eq 'Individual'|| $location.marker_class eq 'Household' || $location.marker_class eq 'Organization'}
-            map.zoomTo({$defaultZoom});
         {else}
             map.zoomTo({$defaultZoom});
         {/if}


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix a potential smarty issue where by if you have an event with an address but that address has not been geocoded you can end up with a smarty notice about missing marker_class 

Before
----------------------------------------
Smarty notice error on missing marker_class

After
----------------------------------------
Notice error is gone

Technical Details
----------------------------------------
In event info we call the Mapping provider template here https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/Event/Page/EventInfo.tpl#L145 if we have a geocoded address or if the address has city and state set. However the locations smarty variable that is set https://github.com/civicrm/civicrm-core/blob/master/CRM/Event/Page/EventInfo.php#L170 only contains geocoded addresses https://github.com/civicrm/civicrm-core/blob/master/CRM/Event/BAO/Event.php#L696

The other thing is that this else if doesn't make sense as `$location` is meant to be one of the array values from `$locations`  but by the time we reach these lines we are already out of the foreach loop. It seems to me that the purpose is that if we have multiple mappable locations (search task) we want to zoom the map to show all markers otherwise zoom to the default zoom

ping @eileenmcnaughton @demeritcowboy 
