### PR TITLE
Fix a couple of smarty notices when viewing the big map on events by …

### DIFF
--- a/CRM/Contact/Form/Task/Map.php
+++ b/CRM/Contact/Form/Task/Map.php
@@ -47,6 +47,7 @@ class CRM_Contact_Form_Task_Map extends CRM_Contact_Form_Task {
       $this, FALSE
     );
     $this->assign('profileGID', $profileGID);
+    $this->assign('showDirectly', FALSE);
     $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     $type = 'Contact';

--- a/CRM/Contact/Form/Task/Map/Event.php
+++ b/CRM/Contact/Form/Task/Map/Event.php
@@ -31,6 +31,8 @@ class CRM_Contact_Form_Task_Map_Event extends CRM_Contact_Form_Task_Map {
       $this, FALSE
     );
     $type = 'Event';
+    $this->assign('profileGID');
+    $this->assign('showDirectly', FALSE);
     self::createMapXML($ids, $lid, $this, TRUE, $type);
     $this->assign('single', FALSE);
     $this->assign('skipLocationType', TRUE);


### PR DESCRIPTION
…always assigning variables to smarty

Overview
----------------------------------------
This aims to fix a couple of smarty notices when viewing a large map such as a contact search task result or from the event info page on urls like `/civicrm/contact/map/event?eid=9895&reset=1` 

Before
----------------------------------------
Notices

After
----------------------------------------
Less notices

@demeritcowboy @eileenmcnaughton 