### PR TITLE
Add descriptions to schema entities which were set to 'FIXME'

### DIFF
--- a/ext/eventcart/schema/Cart.entityType.php
+++ b/ext/eventcart/schema/Cart.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Cart'),
     'title_plural' => ts('Carts'),
-    'description' => ts('FIXME'),
+    'description' => ts('Event Carts'),
   ],
   'getFields' => fn() => [
     'id' => [

--- a/ext/eventcart/schema/EventInCart.entityType.php
+++ b/ext/eventcart/schema/EventInCart.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Event In Cart'),
     'title_plural' => ts('Event In Carts'),
-    'description' => ts('FIXME'),
+    'description' => ts('Events in Cart'),
   ],
   'getFields' => fn() => [
     'id' => [

--- a/schema/Contribute/ContributionProduct.entityType.php
+++ b/schema/Contribute/ContributionProduct.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Contribution Product'),
     'title_plural' => ts('Contribution Products'),
-    'description' => ts('FIXME'),
+    'description' => ts('Products for Contributions'),
     'log' => TRUE,
     'add' => '1.4',
   ],

--- a/schema/Contribute/ContributionRecur.entityType.php
+++ b/schema/Contribute/ContributionRecur.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Recurring Contribution'),
     'title_plural' => ts('Recurring Contributions'),
-    'description' => ts('FIXME'),
+    'description' => ts('Table of Recurring Contributions'),
     'log' => TRUE,
     'add' => '1.6',
   ],

--- a/schema/Contribute/ContributionSoft.entityType.php
+++ b/schema/Contribute/ContributionSoft.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Contribution Soft Credit'),
     'title_plural' => ts('Contribution Soft Credits'),
-    'description' => ts('FIXME'),
+    'description' => ts('Soft Credits for Contributions'),
     'log' => TRUE,
     'add' => '2.2',
   ],

--- a/schema/Core/AddressFormat.entityType.php
+++ b/schema/Core/AddressFormat.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Address Format'),
     'title_plural' => ts('Address Formats'),
-    'description' => ts('FIXME'),
+    'description' => ts('Table of different address formats'),
     'add' => '3.2',
   ],
   'getFields' => fn() => [

--- a/schema/Core/Component.entityType.php
+++ b/schema/Core/Component.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Component'),
     'title_plural' => ts('Components'),
-    'description' => ts('FIXME'),
+    'description' => ts('Table of Core Components (deprecated - use core extensions instead)'),
     'add' => '2.0',
   ],
   'getFields' => fn() => [

--- a/schema/Core/County.entityType.php
+++ b/schema/Core/County.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('County'),
     'title_plural' => ts('Counties'),
-    'description' => ts('FIXME'),
+    'description' => ts('Table that contains a list of counties (if populated)'),
     'add' => '1.1',
     'label_field' => 'name',
   ],

--- a/schema/Core/Extension.entityType.php
+++ b/schema/Core/Extension.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Extension'),
     'title_plural' => ts('Extensions'),
-    'description' => ts('FIXME'),
+    'description' => ts('Table of extensions'),
     'log' => FALSE,
     'add' => '4.2',
     'label_field' => 'label',

--- a/schema/Core/LocationType.entityType.php
+++ b/schema/Core/LocationType.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Location Type'),
     'title_plural' => ts('Location Types'),
-    'description' => ts('FIXME'),
+    'description' => ts('Location types that are available for address, email, phone etc.'),
     'log' => TRUE,
     'add' => '1.1',
     'label_field' => 'display_name',

--- a/schema/Core/OptionGroup.entityType.php
+++ b/schema/Core/OptionGroup.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Option Group'),
     'title_plural' => ts('Option Groups'),
-    'description' => ts('FIXME'),
+    'description' => ts('Table of option groups'),
     'log' => TRUE,
     'add' => '1.5',
     'label_field' => 'title',

--- a/schema/Core/OptionValue.entityType.php
+++ b/schema/Core/OptionValue.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Option Value'),
     'title_plural' => ts('Option Values'),
-    'description' => ts('FIXME'),
+    'description' => ts('Table of Option Values'),
     'log' => TRUE,
     'add' => '1.5',
     'label_field' => 'label',

--- a/schema/Core/RecurringEntity.entityType.php
+++ b/schema/Core/RecurringEntity.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Recurring Entity'),
     'title_plural' => ts('Recurring Entities'),
-    'description' => ts('FIXME'),
+    'description' => ts('Recurring entities (used by repeating activities and events)'),
     'log' => TRUE,
     'add' => '4.6',
   ],

--- a/schema/Core/StateProvince.entityType.php
+++ b/schema/Core/StateProvince.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('State/Province'),
     'title_plural' => ts('States/Provinces'),
-    'description' => ts('FIXME'),
+    'description' => ts('Table containing a list of states/provinces for all countries'),
     'add' => '1.1',
     'label_field' => 'name',
   ],

--- a/schema/Core/SystemLog.entityType.php
+++ b/schema/Core/SystemLog.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('System Log'),
     'title_plural' => ts('System Logs'),
-    'description' => ts('FIXME'),
+    'description' => ts('System log table that contains a record of various events (eg. incoming IPN requests)'),
     'add' => '4.5',
   ],
   'getFields' => fn() => [

--- a/schema/Core/Timezone.entityType.php
+++ b/schema/Core/Timezone.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Timezone'),
     'title_plural' => ts('Timezones'),
-    'description' => ts('FIXME'),
+    'description' => ts('Table containing a list of known timezones'),
     'add' => '1.8',
   ],
   'getFields' => fn() => [

--- a/schema/Core/WorldRegion.entityType.php
+++ b/schema/Core/WorldRegion.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('World Region'),
     'title_plural' => ts('World Regions'),
-    'description' => ts('FIXME'),
+    'description' => ts('List of World Regions'),
     'add' => '1.8',
   ],
   'getFields' => fn() => [

--- a/schema/Cxn/Cxn.entityType.php
+++ b/schema/Cxn/Cxn.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Cxn'),
     'title_plural' => ts('Cxns'),
-    'description' => ts('FIXME'),
+    'description' => ts('Connections - this is no longer used and is not visible in the UI.'),
     'add' => '4.6',
   ],
   'getIndices' => fn() => [

--- a/schema/Event/ParticipantPayment.entityType.php
+++ b/schema/Event/ParticipantPayment.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Participant Payment'),
     'title_plural' => ts('Participant Payments'),
-    'description' => ts('FIXME'),
+    'description' => ts('Participant payments table (deprecated - use lineitems)'),
     'log' => TRUE,
     'add' => '1.7',
   ],

--- a/schema/Financial/Currency.entityType.php
+++ b/schema/Financial/Currency.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Currency'),
     'title_plural' => ts('Currencies'),
-    'description' => ts('FIXME'),
+    'description' => ts('List of currencies'),
     'log' => TRUE,
     'add' => '1.7',
   ],

--- a/schema/Financial/EntityFinancialTrxn.entityType.php
+++ b/schema/Financial/EntityFinancialTrxn.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Entity Financial Trxn'),
     'title_plural' => ts('Entity Financial Trxns'),
-    'description' => ts('FIXME'),
+    'description' => ts('Mapping table for FinancialTrxn to FinancialItem and Contribution'),
     'add' => '3.2',
   ],
   'getIndices' => fn() => [

--- a/schema/Financial/FinancialAccount.entityType.php
+++ b/schema/Financial/FinancialAccount.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Financial Account'),
     'title_plural' => ts('Financial Accounts'),
-    'description' => ts('FIXME'),
+    'description' => ts('Financial Accounts'),
     'log' => TRUE,
     'add' => '3.2',
   ],

--- a/schema/Financial/FinancialTrxn.entityType.php
+++ b/schema/Financial/FinancialTrxn.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Financial Trxn'),
     'title_plural' => ts('Financial Trxns'),
-    'description' => ts('FIXME'),
+    'description' => ts('Table containing Financial Transactions (including Payments)'),
     'log' => TRUE,
     'add' => '1.3',
   ],

--- a/schema/Financial/PaymentProcessor.entityType.php
+++ b/schema/Financial/PaymentProcessor.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Payment Processor'),
     'title_plural' => ts('Payment Processors'),
-    'description' => ts('FIXME'),
+    'description' => ts('Table containing list of defined payment processors'),
     'add' => '1.8',
     'label_field' => 'title',
   ],

--- a/schema/Financial/PaymentProcessorType.entityType.php
+++ b/schema/Financial/PaymentProcessorType.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Payment Processor Type'),
     'title_plural' => ts('Payment Processor Types'),
-    'description' => ts('FIXME'),
+    'description' => ts('Table containing list of defined Payment Processor types'),
     'add' => '1.8',
     'label_field' => 'title',
   ],

--- a/schema/Friend/Friend.entityType.php
+++ b/schema/Friend/Friend.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Friend'),
     'title_plural' => ts('Friends'),
-    'description' => ts('FIXME'),
+    'description' => ts('Tell a Friend (deprecated - moved to extension)'),
     'add' => '2.0',
     'label_field' => 'title',
   ],

--- a/schema/PCP/PCP.entityType.php
+++ b/schema/PCP/PCP.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Personal Campaign Page'),
     'title_plural' => ts('Personal Campaign Pages'),
-    'description' => ts('FIXME'),
+    'description' => ts('Table containing list of Personal Campaign Pages'),
     'log' => TRUE,
     'add' => '2.2',
     'label_field' => 'title',

--- a/schema/Pledge/PledgeBlock.entityType.php
+++ b/schema/Pledge/PledgeBlock.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Pledge Block'),
     'title_plural' => ts('Pledge Blocks'),
-    'description' => ts('FIXME'),
+    'description' => ts('Table containing Pledge blocks'),
     'log' => TRUE,
     'add' => '2.1',
   ],

--- a/schema/Price/LineItem.entityType.php
+++ b/schema/Price/LineItem.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Line Item'),
     'title_plural' => ts('Line Items'),
-    'description' => ts('FIXME'),
+    'description' => ts('Line Items for Contributions'),
     'log' => TRUE,
     'add' => '1.7',
     'label_field' => 'label',

--- a/schema/Price/PriceField.entityType.php
+++ b/schema/Price/PriceField.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Price Field'),
     'title_plural' => ts('Price Fields'),
-    'description' => ts('FIXME'),
+    'description' => ts('Price fields (can be part of a PriceSet and can contain multiple PriceFieldValue)'),
     'log' => TRUE,
     'add' => '1.8',
     'label_field' => 'label',

--- a/schema/Price/PriceFieldValue.entityType.php
+++ b/schema/Price/PriceFieldValue.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Price Field Value'),
     'title_plural' => ts('Price Field Values'),
-    'description' => ts('FIXME'),
+    'description' => ts('Provides multiple options for a PriceField'),
     'add' => '3.3',
     'label_field' => 'label',
   ],

--- a/schema/Price/PriceSet.entityType.php
+++ b/schema/Price/PriceSet.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Price Set'),
     'title_plural' => ts('Price Sets'),
-    'description' => ts('FIXME'),
+    'description' => ts('A set of Price Fields'),
     'log' => TRUE,
     'add' => '1.8',
     'label_field' => 'title',

--- a/schema/Price/PriceSetEntity.entityType.php
+++ b/schema/Price/PriceSetEntity.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Price Set Entity'),
     'title_plural' => ts('Price Set Entities'),
-    'description' => ts('FIXME'),
+    'description' => ts('Price Set Entities'),
     'log' => TRUE,
     'add' => '1.8',
   ],


### PR DESCRIPTION
Overview
----------------------------------------
These descriptions (sometimes) surface in eg. the SearchKit entity picker:
![image](https://github.com/civicrm/civicrm-core/assets/2052161/acdf2f10-9098-4bdf-8f20-22c1aad28aa5)


Before
----------------------------------------
User sees "FIXME".

After
----------------------------------------
User sees something more useful

Technical Details
----------------------------------------


Comments
----------------------------------------
Many of the descriptions I've added are rather simplistic and could probably be improved. But still better than "FIXME" in my opinion..
