### PR TITLE
Wkhtml empty extra pdf page

### DIFF
--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -83,9 +83,9 @@ class CRM_Utils_PDF_Utils {
     // Add a special region for the HTML header of PDF files:
     $pdfHeaderRegion = CRM_Core_Region::instance('export-document-header', FALSE);
     $htmlHeader = ($pdfHeaderRegion) ? $pdfHeaderRegion->render('', FALSE) : '';
-
+// height: 0 is a work-a-round for a extra empty page with wkhtmltopdf
     $html = "
-<html>
+<html style="height:0;">
   <head>
     <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"/>
     <style>@page { margin: {$t}{$metric} {$r}{$metric} {$b}{$metric} {$l}{$metric};$css_page_size }</style>

--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -83,7 +83,7 @@ class CRM_Utils_PDF_Utils {
     // Add a special region for the HTML header of PDF files:
     $pdfHeaderRegion = CRM_Core_Region::instance('export-document-header', FALSE);
     $htmlHeader = ($pdfHeaderRegion) ? $pdfHeaderRegion->render('', FALSE) : '';
-// height: 0 is a work-a-round for a extra empty page with wkhtmltopdf
+// height: 0 is a work-a-round for an extra empty page with wkhtmltopdf
     $html = "
 <html style="height:0;">
   <head>


### PR DESCRIPTION
Overview
----------------------------------------
I found that html2pdf() always outputs an extra empty page.

Before
----------------------------------------
Your single page pdf has two pages

After
----------------------------------------
Your single page pdf is ready to mingle 

Technical Details
----------------------------------------
[This wkhtmltopdf issue](https://github.com/wkhtmltopdf/wkhtmltopdf/issues/3088) has a simple solution: add style="height: 0" to the html tag.

Comments
----------------------------------------
[Issue is here](https://lab.civicrm.org/dev/core/-/issues/5313#note_166493)
