### PR TITLE
Extension Upgrades - More distinction between default task titles

### DIFF
--- a/CRM/Extension/Upgrader/RevisionsTrait.php
+++ b/CRM/Extension/Upgrader/RevisionsTrait.php
@@ -60,15 +60,19 @@ trait CRM_Extension_Upgrader_RevisionsTrait {
     $currentRevision = $this->getCurrentRevision();
     foreach ($this->getRevisions() as $revision) {
       if ($revision > $currentRevision) {
-        $title = ts('Upgrade %1 to revision %2', [
+        $titleA = ts('Upgrade %1 to revision %2 (main)', [
+          1 => $this->getExtensionKey(),
+          2 => $revision,
+        ]);
+        $titleB = ts('Upgrade %1 to revision %2 (set revision)', [
           1 => $this->getExtensionKey(),
           2 => $revision,
         ]);
 
         // note: don't use addTask() because it sets weight=-1
 
-        $this->appendTask($title, 'upgrade_' . $revision);
-        $this->appendTask($title, 'setCurrentRevision', $revision);
+        $this->appendTask($titleA, 'upgrade_' . $revision);
+        $this->appendTask($titleB, 'setCurrentRevision', $revision);
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------

Following https://github.com/civicrm/cv/pull/200, you can now get verbose output about the progress of extension database-upgrades.

This is a small tweak to make the output (slightly) less confusing.


Before
----------------------------------------

It looks like it's running the same thing twice:

<img width="399" alt="Screenshot 2024-06-27 at 3 54 35 PM" src="https://github.com/civicrm/civicrm-core/assets/1336047/368643c9-9b32-4af8-972a-47c545012d24">


After
----------------------------------------

Each step looks more distinctive:

<img width="491" alt="Screenshot 2024-06-27 at 3 52 30 PM" src="https://github.com/civicrm/civicrm-core/assets/1336047/5b4c938c-e9f6-45dd-8b61-1fde20ce6035">

Is it a distinction without a difference? Gibberish upgraded to gibberish? Maybe. But if the distinction exists, then it should at least be clear.