### PR TITLE
dev/core#5321 - When deleting a group it doesn't display the group title in the confirmation popup

### DIFF
--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -302,7 +302,7 @@ WHERE  title = %1
     $updateNestingCache = FALSE;
     if ($this->_action & CRM_Core_Action::DELETE) {
       CRM_Contact_BAO_Group::discard($this->_id);
-      CRM_Core_Session::setStatus(ts("The Group '%1' has been deleted.", [1 => $this->_title]), ts('Group Deleted'), 'success');
+      CRM_Core_Session::setStatus(ts("The Group '%1' has been deleted.", [1 => $this->_groupValues['frontend_title']]), ts('Group Deleted'), 'success');
       $updateNestingCache = TRUE;
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------

This aims to resolve issue 5321 https://lab.civicrm.org/dev/core/-/issues/5321

Before
----------------------------------------

Deleting a group gives a confirmation message like this: 
![image](https://github.com/civicrm/civicrm-core/assets/10037367/0fe685f7-47ac-4c3a-8cde-70ecdbb2cc4e)
where the groups is called 'Confirm Group Delete'.

After
----------------------------------------

The confirmation message has the group name in it: 
![image](https://github.com/civicrm/civicrm-core/assets/10037367/f8d27720-1614-475e-8abe-36e8f091cafc)

Technical Details
----------------------------------------

Line 305 of `<Drupal root>/vendor/civicrm/civicrm-core/CRM/Group/Form/Edit.php`
used `$this->_title]` in an attempt to get the group name. That is the title of the delete confirmation form.
It now uses  `$this->_groupValues['frontend_title']` which holds the name of the group just deleted.

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
