### PR TITLE
SearchKit - Add contact joins to the contactType pseudo-entities

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -401,6 +401,11 @@ class Admin {
         }
       }
     }
+    // Add contact joins to the contactType pseudo-entities
+    foreach (\CRM_Contact_BAO_ContactType::basicTypes() as $contactType) {
+      $joins += [$contactType => []];
+      $joins[$contactType] = array_merge($joins[$contactType], $joins['Contact']);
+    }
     return $joins;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes missing joins in SearchKit when selecting Individual, Organization or Household as the base entity.

Before
----------------------------------------
<img width="618" alt="Screenshot 2024-06-28 at 10 39 49 AM" src="https://github.com/civicrm/civicrm-core/assets/2874912/2b50924c-00c9-417f-b89f-ec9722b1e54d">



After
----------------------------------------

<img width="618" alt="Screenshot 2024-06-28 at 10 39 49 AM" src="https://github.com/civicrm/civicrm-core/assets/2874912/1f6a399f-be64-4d50-8376-2590aff8b110">
