### PR TITLE
[REF] Only load map if we have a geocoded address in the event

### DIFF
--- a/templates/CRM/Event/Page/EventInfo.tpl
+++ b/templates/CRM/Event/Page/EventInfo.tpl
@@ -137,8 +137,7 @@
         {/if}
 
       {if ($event.is_map && $config->mapProvider &&
-          array_key_exists('address', $location)  && (is_numeric($location.address.1.geo_code_1) ||
-          ($location.address.1.city AND $location.address.1.state_province)))}
+          array_key_exists('address', $location)  && (is_numeric($location.address.1.geo_code_1)))}
           <div class="crm-section event_map-section">
               <div class="content">
                     {assign var=showDirectly value="1"}


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix something that I find confusing. In the Event Info page we try loading the map if the event is marked as is map, if we have a mapping provider, and if either the address is geocoded or we have a city and state.  However looking at the templates for the [Google Map](https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/Contact/Form/Task/Map/Google.tpl#L45) and [OSM](https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/Contact/Form/Task/Map/OpenStreetMaps.tpl#L83) they are dealing with only geocoded address

Before
----------------------------------------
Non geocoded address can cause a blank space and possible javascript errors

After
----------------------------------------
Map is not tried to load

Technical Details
----------------------------------------
note the smarty variable in GMap and OSM is the plural locations not location and the Event locations variable is assigned with address data https://github.com/civicrm/civicrm-core/blob/master/CRM/Event/Page/EventInfo.php#L168 only when 
https://github.com/civicrm/civicrm-core/blob/master/CRM/Event/BAO/Event.php#L673 we have a geocoded address as per this function 

@eileenmcnaughton @demeritcowboy thoughts?