### PR TITLE
Update CRM_Core_Smarty::escape not to call smarty function

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -541,7 +541,8 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
       }
     }
 
-    $value = smarty_modifier_escape($string, $esc_type, $char_set);
+    $string = mb_convert_encoding($string, 'UTF-8', $char_set);
+    $value = htmlentities($string, ENT_QUOTES, 'UTF-8');
     if ($value !== $string) {
       Civi::log('smarty')->debug('smarty escaping original {original}, escaped {escaped} type {type} charset {charset}', [
         'original' => $string,


### PR DESCRIPTION

Overview
----------------------------------------
Update CRM_Core_Smarty::escape not to call smarty function

This function call appears to do pretty much this in different smarty versions but doing it directly avoids smarty conflicts

This is part of resuscitating efforts to enable smarty escape by default - but targetting Smarty5 now

Before
----------------------------------------
If you attempt to enable smarty escaping by default for any smarty version other than 2 it gets it's knickers in a knot about what the native smarty function should call

After
----------------------------------------
We call what the native smarty function would call internally 

Technical Details
----------------------------------------
This won't be functional in Smarty3+ without further patches - I will open a PR in packages that gets it to load with Smarty5

Comments
----------------------------------------
Will not enable without https://github.com/civicrm/civicrm-packages/pull/409
