### PR TITLE
Add nofilter to templates for avoiding default escaping

### DIFF
--- a/ext/afform/core/templates/afform/AfformAngularModule.tpl
+++ b/ext/afform/core/templates/afform/AfformAngularModule.tpl
@@ -8,8 +8,8 @@
 (function(angular, $, _) {
   angular.module('{/literal}{$afform.camel}{literal}', CRM.angRequires('{/literal}{$afform.camel}{literal}'));
   angular.module('{/literal}{$afform.camel}{literal}').directive('{/literal}{$afform.camel}{literal}', function(afCoreDirective) {
-    return afCoreDirective({/literal}{$afform.camel|json}, {$afform.meta|@json_encode}{literal}, {
-      templateUrl: {/literal}{$afform.templateUrl|json}{literal}
+    return afCoreDirective({/literal}{$afform.camel|json nofilter}, {$afform.meta|@json_encode nofilter}{literal}, {
+      templateUrl: {/literal}{$afform.templateUrl|json nofilter}{literal}
     });
   });
 })(angular, CRM.$, CRM._);

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -108,7 +108,7 @@
   {/if}
 
   <tr class="crm-activity-form-block-location">
-    <td class="label">{$form.location.label}</td><td class="view-value">{$form.location.html|crmAddClass:huge}</td>
+    <td class="label">{$form.location.label}</td><td class="view-value">{$form.location.html|crmAddClass:huge nofilter}</td>
   </tr>
   <tr class="crm-activity-form-block-activity_date_time">
     <td class="label">{$form.activity_date_time.label}</td>
@@ -263,7 +263,7 @@
     {literal}
     <script type="text/javascript">
       CRM.$(function($) {
-        var doNotNotifyAssigneeFor = {/literal}{$doNotNotifyAssigneeFor|@json_encode}{literal};
+        var doNotNotifyAssigneeFor = {/literal}{$doNotNotifyAssigneeFor|@json_encode nofilter}{literal};
         $('#activity_type_id').change(function() {
           if ($.inArray($(this).val(), doNotNotifyAssigneeFor) != -1) {
             $('#notify_assignee_msg').hide();

--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -170,8 +170,8 @@
         (function($, _) {
           $(function($) {
             const $form = $('form.{/literal}{$form.formClass}{literal}'),
-              controlFields = {/literal}{$controlFields|@json_encode}{literal},
-              recurringFrequencyOptions = {/literal}{$recurringFrequencyOptions|@json_encode}{literal};
+              controlFields = {/literal}{$controlFields|@json_encode nofilter}{literal},
+              recurringFrequencyOptions = {/literal}{$recurringFrequencyOptions|@json_encode nofilter}{literal};
 
             // Reload metadata when a controlField is changed
             $form.on('change', 'input', function() {

--- a/templates/CRM/Contact/Form/ShareAddress.tpl
+++ b/templates/CRM/Contact/Form/ShareAddress.tpl
@@ -38,7 +38,7 @@
 <script type="text/javascript">
   CRM.$(function($) {
     var blockNo = {/literal}{$blockId}{literal},
-      contactType = {/literal}{$contactType|@json_encode}{literal},
+      contactType = {/literal}{$contactType|@json_encode nofilter}{literal},
       $addRelationshipSection = $('#shared-address-' + blockNo + ' .shared-address-add-relationship'),
       $employerSection = $('#shared-address-' + blockNo + ' .shared-address-add-relationship .employer'),
       $employerLabel = $('#shared-address-' + blockNo + ' .shared-address-add-relationship label .addrel-employer'),

--- a/templates/CRM/Contact/Page/Inline/Address.tpl
+++ b/templates/CRM/Contact/Page/Inline/Address.tpl
@@ -39,7 +39,7 @@
           {if array_key_exists($locationIndex, $sharedAddresses) && !empty($sharedAddresses.$locationIndex.shared_address_display.name)}
             <strong>{ts 1=$sharedAddresses.$locationIndex.shared_address_display.name}Address belongs to %1{/ts}</strong><br />
           {/if}
-          {$add.display|smarty:nodefaults|purify|nl2br}
+          {$add.display|purify|nl2br nofilter}
         </div>
       </div>
 

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -59,7 +59,7 @@
       <table class="form-layout-compressed">
         <tr class="crm-contribution-form-block-contact_id">
           <td class="label">{$form.contact_id.label}</td>
-          <td>{$form.contact_id.html}</td>
+          <td>{$form.contact_id.html nofilter}</td>
         </tr>
         <tr class="crm-contribution-form-block-contribution_type_id crm-contribution-form-block-financial_type_id">
           <td class="label">{$form.financial_type_id.label}</td><td{$valueStyle}>{$form.financial_type_id.html}&nbsp;

--- a/templates/CRM/UF/Form/Field.tpl
+++ b/templates/CRM/UF/Form/Field.tpl
@@ -75,7 +75,7 @@
 <script type="text/javascript">
 
 CRM.$(function($) {
-  var otherModule = {/literal}{$otherModules|@json_encode}{literal};
+  var otherModule = {/literal}{$otherModules|@json_encode nofilter}{literal};
   if ( $.inArray( "Profile", otherModule ) > -1 && $.inArray( "Search Profile", otherModule ) == -1 ){
     $('#profile_visibility').show();
   }

--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -11,34 +11,34 @@
 {* This file should only contain strings and settings which rarely change *}
 (function($) {ldelim}
   // Config settings
-  CRM.config.userFramework = {$config->userFramework|@json_encode};
+  CRM.config.userFramework = {$config->userFramework|@json_encode nofilter};
   {* resourceBase: The URL of `civicrm-core` assets. Ends with "/". *}
-  CRM.config.resourceBase = {$config->userFrameworkResourceURL|@json_encode};
+  CRM.config.resourceBase = {$config->userFrameworkResourceURL|@json_encode nofilter};
   {* packageseBase: The URL of `civicrm-packages` assets. Ends with "/". *}
-  CRM.config.packagesBase = {capture assign=packagesBase}{crmResURL expr='[civicrm.packages]/'}{/capture}{$packagesBase|@json_encode};
-  CRM.config.lcMessages = {$lcMessages|@json_encode};
-  CRM.config.locale = {$locale|@json_encode};
-  CRM.config.cid = {$cid|@json_encode};
-  $.datepicker._defaults.dateFormat = CRM.config.dateInputFormat = {$dateInputFormat|@json_encode};
+  CRM.config.packagesBase = {capture assign=packagesBase}{crmResURL expr='[civicrm.packages]/'}{/capture}{$packagesBase|@json_encode nofilter};
+  CRM.config.lcMessages = {$lcMessages|@json_encode nofilter};
+  CRM.config.locale = {$locale|@json_encode nofilter};
+  CRM.config.cid = {$cid|@json_encode nofilter};
+  $.datepicker._defaults.dateFormat = CRM.config.dateInputFormat = {$dateInputFormat|@json_encode nofilter};
   CRM.config.timeIs24Hr = {if $timeInputFormat eq 2}true{else}false{/if};
-  CRM.config.ajaxPopupsEnabled = {$ajaxPopupsEnabled|@json_encode};
-  CRM.config.allowAlertAutodismissal = {$allowAlertAutodismissal|@json_encode};
-  CRM.config.resourceCacheCode = {$resourceCacheCode|@json_encode};
-  CRM.config.quickAdd = {$quickAdd|@json_encode};
+  CRM.config.ajaxPopupsEnabled = {$ajaxPopupsEnabled|@json_encode nofilter};
+  CRM.config.allowAlertAutodismissal = {$allowAlertAutodismissal|@json_encode nofilter};
+  CRM.config.resourceCacheCode = {$resourceCacheCode|@json_encode nofilter};
+  CRM.config.quickAdd = {$quickAdd|@json_encode nofilter};
 
   // Merge entityRef settings
-  CRM.config.entityRef = $.extend({ldelim}{rdelim}, {$entityRef|@json_encode}, CRM.config.entityRef || {ldelim}{rdelim});
+  CRM.config.entityRef = $.extend({ldelim}{rdelim}, {$entityRef|@json_encode nofilter}, CRM.config.entityRef || {ldelim}{rdelim});
 
   // Initialize CRM.url and CRM.formatMoney
   CRM.url({ldelim}back: '{crmURL p="civicrm/crmajax-placeholder-url-path" q="civicrm-placeholder-url-query=1" h=0 fb=1}', front: '{crmURL p="civicrm/crmajax-placeholder-url-path" q="civicrm-placeholder-url-query=1" h=0 fe=1}'{rdelim});
-  CRM.formatMoney('init', false, {$moneyFormat|@json_encode});
+  CRM.formatMoney('init', false, {$moneyFormat|@json_encode nofilter});
 
   // Localize select2
   $.fn.select2.defaults.formatNoMatches = "{ts escape='js'}None found.{/ts}";
   $.fn.select2.defaults.formatLoadMore = "{ts escape='js'}Loading...{/ts}";
   $.fn.select2.defaults.formatSearching = "{ts escape='js'}Searching...{/ts}";
   $.fn.select2.defaults.formatInputTooShort = function() {ldelim}
-    return ($(this).data('api-entity') === 'contact' || $(this).data('api-entity') === 'Contact') ? {$contactSearch|smarty:nodefaults} : {$otherSearch|smarty:nodefaults};
+    return ($(this).data('api-entity') === 'contact' || $(this).data('api-entity') === 'Contact') ? {$contactSearch nofilter} : {$otherSearch nofilter};
   {rdelim};
 
   // Localize jQuery UI
@@ -56,7 +56,7 @@
       "infoEmpty": "{ts escape='js'}Showing 0 to 0 of 0 entries{/ts}",
       "infoFiltered": "{ts escape='js' 1=_MAX_}(filtered from %1 total entries){/ts}",
       "infoPostFix": "",
-      "thousands": {$config->monetaryThousandSeparator|json_encode},
+      "thousands": {$config->monetaryThousandSeparator|json_encode nofilter},
       "lengthMenu": "{ts escape='js' 1=_MENU_}Show %1 entries{/ts}",
       "loadingRecords": " ",
       "processing": " ",


### PR DESCRIPTION

Overview
----------------------------------------
Add nofilter to templates for avoiding default escaping

Before
----------------------------------------
Tpl syntax we have added to support Smarty 2 is smarty:nodefaults  =this does not work with Smarty 5

After
----------------------------------------
both smarty2 & smarty 5 seem happy with the `nofilter` syntax.

This is the documented method for Smarty5 & not documented for Smarty2 but appears to work on both. However there are some js errors on Smarty2 - since they go away when we turn off default escaping & supporting default escaping on Smarty2 is no longer a goal I have not dug into them - it's enough that it works when default escaping is off

https://smarty-php.github.io/smarty/stable/programmers/api-variables/variable-escape-html/

Technical Details
----------------------------------------

It is not possible to enable default escaping on Smarty 3 or 4 & there are no production uses on Smarty2 so the goal is to make this viable for Smarty5 without causing any of the others to break when the markup is adjusted - adding `nofilter` seems to do this & it makes sense to remove smarty:nodefaults when we do. This PR is incomplete but it seems that we could do a mass update where smarty::nodefaults is used to use the nofilter syntax & if this approach is agreed I can follow up with that

*Smarty5 seems to require `nofilter` to be declared it when json_decode is invoked but Smarty2 did not.*



Comments
----------------------------------------

