### PR TITLE
dev/core#5314 Fix participant register action from search to set `fee_amount`

### DIFF
--- a/CRM/Event/Form/Task/Register.php
+++ b/CRM/Event/Form/Task/Register.php
@@ -150,6 +150,9 @@ class CRM_Event_Form_Task_Register extends CRM_Event_Form_Participant {
       // will be created below.
       $this->_contactIds = array_values($this->_contactIds);
     }
+    if ($this->getPriceSetID()) {
+      $this->getOrder()->setPriceSelectionFromUnfilteredInput($this->getSubmittedValues());
+    }
     $statusMsg = $this->submit($params);
     CRM_Core_Session::setStatus($statusMsg, ts('Saved'), 'success');
   }


### PR DESCRIPTION


Overview
----------------------------------------
dev/core#5314 Fix participant register action from search to set `fee_amount`

Before
----------------------------------------
As described in https://lab.civicrm.org/dev/core/-/issues/5314 `fee_amount` is correct when the edit participant form is used, but not when the register participant from search is used

After
----------------------------------------
It's set

Technical Details
----------------------------------------
The loading of the order object is outside the shared code - I think that's OK as long as both do it as we are seeing forms as responsible for loading their own order object & moving away from sharing code between these 2 forms - but they both need to load it

Comments
----------------------------------------
