### PR TITLE
Remove wrangling of unused variable

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1402,9 +1402,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    * @throws \CRM_Core_Exception
    */
   protected function preparePaidEventProcessing($params): array {
-    $participantStatus = CRM_Event_PseudoConstant::participantStatus();
-    $lineItem = [];
-
     if ($this->isPaymentOnExistingContribution()) {
       //re-enter the values for UPDATE mode
       $params['fee_level'] = $params['amount_level'] = $this->getParticipantValue('fee_level');
@@ -1413,20 +1410,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     else {
       //lets carry currency, CRM-4453
       $params['fee_currency'] = $this->getCurrency();
-      if (!isset($lineItem[0])) {
-        $lineItem[0] = [];
-      }
-      //CRM-11529 for quick config backoffice transactions
-      //when financial_type_id is passed in form, update the
-      //lineitems with the financial type selected in form
-      $submittedFinancialType = $params['financial_type_id'] ?? NULL;
-      $isPaymentRecorded = $this->getSubmittedValue('record_contribution');
-      if ($isPaymentRecorded && $this->isQuickConfig() && $submittedFinancialType) {
-        foreach ($lineItem[0] as &$values) {
-          $values['financial_type_id'] = $submittedFinancialType;
-        }
-      }
-
       $params['fee_level'] = $this->getOrder()->getAmountLevel();
       $params['fee_amount'] = $this->getOrder()->getTotalAmount();
       $params['amount'] = $this->getOrder()->getTotalAmount();


### PR DESCRIPTION
Overview
----------------------------------------
Remove wrangling of unused variable

Before
----------------------------------------
The `$lineItem` variable gets a lot of wrangling - but it is never returned as the `getOrder()` section below uses the `BAO_Order` object now

![image](https://github.com/civicrm/civicrm-core/assets/336308/62449fda-c5fa-4cf7-811d-2a6dd3ce558b)
![image](https://github.com/civicrm/civicrm-core/assets/336308/d14b2663-fb76-468a-804d-6127d51e755f)


After
----------------------------------------
gone

Technical Details
----------------------------------------

Comments
----------------------------------------
