### PR TITLE
Afform - Fix url default for comma-separated values

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -185,6 +185,10 @@
 
       // Set default value; ensure data type matches input type
       function setValue(value) {
+        // For values passed from the url, split
+        if (typeof value === 'string' && ctrl.isMultiple()) {
+          value = value.split(',');
+        }
         // correct the value type
         if (ctrl.defn.input_type !== 'DisplayOnly') {
           value = correctValueType(value, ctrl.defn.data_type);
@@ -212,9 +216,6 @@
             '>=': ('' + value).split('-')[0],
             '<=': ('' + value).split('-')[1] || '',
           };
-        }
-        else if (_.isString(value) && ctrl.isMultiple()) {
-          value = value.split(',');
         }
         $scope.getSetValue(value);
       }


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to #30169

Before
-------
1. Create a search for Events, add to a form, and expose the event "Type" field as a filter.
2. Visit the form and enter comma-separated values to prefill the field, e.g. `/civicrm/eventtest#?event_type_id=5,3,4`
3. Field is not autofilled.

After
-----
Autofill works.