### PR TITLE
(NFC) afform_mock - Updates for PHPUnit 9.x

### DIFF
--- a/ext/afform/mock/phpunit.xml.dist
+++ b/ext/afform/mock/phpunit.xml.dist
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" cacheResult="false" bootstrap="tests/phpunit/bootstrap.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" cacheResult="false" bootstrap="tests/phpunit/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./</directory>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/ext/afform/mock/tests/phpunit/Civi/AfformMock/FormTestCase.php
+++ b/ext/afform/mock/tests/phpunit/Civi/AfformMock/FormTestCase.php
@@ -29,6 +29,12 @@ abstract class FormTestCase extends \PHPUnit\Framework\TestCase implements \Civi
 
   protected $formName = NULL;
 
+  public static function setUpBeforeClass(): void {
+    \Civi\Test::e2e()
+      ->install(['org.civicrm.afform', 'org.civicrm.afform-mock'])
+      ->apply();
+  }
+
   protected function setUp(): void {
     parent::setUp();
 
@@ -76,6 +82,9 @@ abstract class FormTestCase extends \PHPUnit\Framework\TestCase implements \Civi
   protected function getFormMeta(): array {
     $scanner = new \CRM_Afform_AfformScanner();
     $meta = $scanner->getMeta($this->getFormName());
+    if (empty($meta)) {
+      throw new \RuntimeException(sprintf("Failed to find metadata for form (%s)", $this->getFormName()));
+    }
     $scanner->addComputedFields($meta);
     return $meta;
   }

--- a/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormTest.php
+++ b/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormTest.php
@@ -1,12 +1,16 @@
 <?php
 
+namespace E2E\AfformMock;
+
+use CRM_Core_DAO;
+
 /**
  * @group e2e
  * @group ang
  */
 class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
 
-  const FILE = __FILE__;
+  protected $formName = 'mockPublicForm';
 
   public function testGetPage() {
     $r = $this->createGuzzle()->get('civicrm/mock-public-form');
@@ -28,14 +32,14 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
     $this->submit(['args' => [], 'values' => ['me' => $me]]);
 
     // Contact was created...
-    $contact = Civi\Api4\Contact::get(FALSE)->addWhere('first_name', '=', 'Firsty' . $r)->execute()->single();
+    $contact = \Civi\Api4\Contact::get(FALSE)->addWhere('first_name', '=', 'Firsty' . $r)->execute()->single();
     $this->assertEquals('Firsty' . $r, $contact['first_name']);
     $this->assertEquals('Lasty' . $r, $contact['last_name']);
     $this->assertTrue($contact['id'] > $initialMaxId);
   }
 
   public function testPublicEditDisallowed() {
-    $contact = Civi\Api4\Contact::create(FALSE)
+    $contact = \Civi\Api4\Contact::create(FALSE)
       ->setValues([
         'first_name' => 'FirstBegin',
         'last_name' => 'LastBegin',
@@ -54,7 +58,7 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
     $this->submit(['args' => [], 'values' => ['me' => $me]]);
 
     // Original contact hasn't changed
-    $get = Civi\Api4\Contact::get(FALSE)->addWhere('id', '=', $contact['id'])->execute()->single();
+    $get = \Civi\Api4\Contact::get(FALSE)->addWhere('id', '=', $contact['id'])->execute()->single();
     $this->assertEquals('FirstBegin', $get['first_name']);
     $this->assertEquals('LastBegin', $get['last_name']);
 


### PR DESCRIPTION
Overview
----------------------------------------

Small compatibility updates for pre-existing tests.

Before
----------------------------------------

* Console warnings about `phpunit.xml.dist`
* Tests for `mockPublicForm.aff.html` quietly ignored

After
----------------------------------------

* Warnings go away
* Test runs

Comments
----------------------------------------

The XML update is just the regular automated update.

It wa strange that I had trouble running the test for `mockPublicForm` locally -- obviously, it worked at some point. I think the underlying issue is that phpunit9 introduced different behaviors re:file naming and class naming.

Anyway, in theory, it just needed an extra XML directive to specify the formula (e.g. `<directory suffix=".test.php">./ang</directory>`). However, even with a suitable configuration, the usage is... flaky. `phpunit` (*no args*) would run the test; but `phpunit <FILENAME>` wouldn't; and `phpunit9 --testyaddayadda <FILENAME> ` would work.  Of course, `--testyaddayadda` is annoying.

So the file gets renamed. [#theNailThatSticksOutGetsHammeredDown](https://www.pinterest.com/pin/the-nail-that-sticks-out-gets-hammered-down-2024--735071970422465200/)
