### PR TITLE
Civi\Test\MinkBase - Skip execution on D9

### DIFF
--- a/Civi/Test/MinkBase.php
+++ b/Civi/Test/MinkBase.php
@@ -18,6 +18,11 @@ abstract class MinkBase extends \CiviEndToEndTestCase {
 
   protected function setUp(): void {
     parent::setUp();
+
+    if (CIVICRM_UF === 'Drupal8' && version_compare(\CRM_Core_Config::singleton()->userSystem->getVersion(), '10', '<')) {
+      $this->markTestSkipped('Browser testing is currently unsupported on Civi-Drupal 9');
+    }
+
     // $this->failOnJavascriptConsoleErrors = TRUE; // Not implemented yet
     $this->mink = $this->createMink();
     $this->screenshotsEnabled = $_ENV['SCREENSHOTS'] ?? FALSE;


### PR DESCRIPTION
Overview
----------------------------------------

There appears to be a de-facto conflict between the versions of `phrity/websocket` and `psr/http-message` that composer selects on D9.

@demeritcowboy mentions Civi-D9 support is likely EOL in the near future, so it's not important to sort out new test-coverage there.

Before
----------------------------------------

Scheduled test jobs for `master` failing on `drupal9-clean` for `phpunit-core-exts`, eg [job 35479](https://test.civicrm.org/job/CiviCRM-Test-QLow/35479/console):

```
PHPUnit 9.6.5 by Sebastian Bergmann and contributors.


Fatal error: Declaration of WebSocket\Http\Message::withProtocolVersion(string $version): WebSocket\Http\Message 
must be compatible with Psr\Http\Message\MessageInterface::withProtocolVersion($version) 
in /home/homer/buildkit/build/build-3/vendor/phrity/websocket/lib/Http/Message.php on line 42
```

After
----------------------------------------

Skip new tests that don't run.


Comments
----------------------------------------

I haven't tested locally. We should fire [manual tests](https://test.civicrm.org/job/CiviCRM-Manual-Test/) on D9+D10 to confirm that it does/doesn't run as expected.

(Note: For reference, the new test doesn't actually pass on D10. But it's a [different issue](https://test.civicrm.org/job/CiviCRM-Test-QLow/35482/testReport/(root)/E2E_CivicrmAdminUi_ManageGroupsTest/testManageGroups/) that will need a different fix. We should see the test being on skipped on D9 -- and then failing on D10.)