### PR TITLE
Ref clean up contact lookup handling in Participant import

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1823,4 +1823,21 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     return \Civi::$statics[$cacheString];
   }
 
+  /**
+   * Get the metadata field for which importable fields does not key the actual field name.
+   *
+   * @return string[]
+   */
+  protected function getOddlyMappedMetadataFields(): array {
+    return [
+      'country_id' => 'country',
+      'state_province_id' => 'state_province',
+      'county_id' => 'county',
+      'email_greeting_id' => 'email_greeting',
+      'postal_greeting_id' => 'postal_greeting',
+      'addressee_id' => 'addressee',
+      'source' => 'contact_source',
+    ];
+  }
+
 }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1777,15 +1777,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    * @return string[]
    */
   protected function getOddlyMappedMetadataFields(): array {
-    return [
-      'country_id' => 'country',
-      'state_province_id' => 'state_province',
-      'county_id' => 'county',
-      'email_greeting_id' => 'email_greeting',
-      'postal_greeting_id' => 'postal_greeting',
-      'addressee_id' => 'addressee',
-      'source' => 'contact_source',
-    ];
+    return [];
   }
 
   /**
@@ -1902,16 +1894,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
       }
       if ($mappedField['name']) {
         $fieldSpec = $this->getFieldMetadata($mappedField['name']);
-
         $entity = $fieldSpec['entity_instance'] ?? $fieldSpec['entity'] ?? $fieldSpec['extends'] ?? NULL;
         if ($this->isUpdatedForEntityRowParsing && $entity) {
           // Split values into arrays by entity.
-          if (!isset($params[$entity])) {
-            $params[$entity] = [];
-            if ($entity === 'Contact') {
-              $params[$entity]['contact_type'] = $this->getContactTypeForEntity($entity) ?: $this->getContactType();
-            }
-          }
           // Apiv4 name is currently only set for contact, & only in cases where it would
           // be used for the dedupe rule (ie Membership import).
           $params[$entity][$fieldSpec['apiv4_name'] ?? $fieldSpec['name']] = $this->getTransformedFieldValue($mappedField['name'], $values[$i]);
@@ -2144,10 +2129,12 @@ abstract class CRM_Import_Parser implements UserJobInterface {
 
   /**
    * @throws \CRM_Core_Exception
+   *
+   * @return array
    */
-  protected function checkEntityExists(string $entity, int $id) {
+  protected function checkEntityExists(string $entity, int $id): array {
     try {
-      civicrm_api4($entity, 'get', ['where' => [['id', '=', $id]], 'select' => ['id']])->single();
+      return civicrm_api4($entity, 'get', ['where' => [['id', '=', $id]]])->single();
     }
     catch (CRM_Core_Exception $e) {
       throw new CRM_Core_Exception(ts('%1 record not found for id %2', [

--- a/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
@@ -3,7 +3,8 @@
 /**
  *  File for the Participant import class
  */
-
+use Civi\Api4\DedupeRule;
+use Civi\Api4\DedupeRuleGroup;
 use Civi\Api4\Participant;
 use Civi\Api4\UserJob;
 
@@ -15,6 +16,7 @@ use Civi\Api4\UserJob;
 class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
 
   use CRMTraits_Custom_CustomDataTrait;
+  use CRMTraits_Import_ParserTrait;
 
   protected $entity = 'Participant';
 
@@ -40,6 +42,13 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
       'civicrm_uf_field',
       'civicrm_uf_group',
     ], TRUE);
+    DedupeRule::delete()
+      ->addWhere('rule_table', '!=', 'civicrm_email')
+      ->addWhere('dedupe_rule_group_id.name', '=', 'IndividualUnsupervised')->execute();
+    DedupeRuleGroup::update(FALSE)
+      ->addWhere('name', '=', 'IndividualUnsupervised')
+      ->setValues(['is_reserved' => TRUE])
+      ->execute();
     parent::tearDown();
   }
 
@@ -204,7 +213,7 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
     $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
     $row = $dataSource->getRow();
     $this->assertEquals('ERROR', $row['_status']);
-    $this->assertEquals('Missing required fields: Event ID', $row['_status_message']);
+    $this->assertEquals('Missing required fields: Participant ID OR Event ID', $row['_status_message']);
   }
 
   /**
@@ -246,6 +255,41 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
     $this->assertEquals(['Attendee', 'Volunteer'], $result['participant_role']);
     $this->assertEquals(0, $result['participant_is_pay_later']);
     $this->assertEquals(['P', 'M'], array_keys($result[$this->getCustomFieldName('checkbox')]));
+  }
+
+  /**
+   * Test import parser match a contact using the dedupe rule with a custom field.
+   *
+   * It should match the created contact based on first name & custom field.
+   */
+  public function testImportWithCustomDedupeRule(): void {
+    $this->eventCreateUnpaid(['title' => 'Rain-forest Cup Youth Soccer Tournament']);
+    $this->addToDedupeRule();
+    // Setting this rule to not reserved is a bit artificial, although it does happen
+    // in the wild. The goal is to demonstrate that when we expose arbitrary dedupe
+    // rules it works, plus to ensure the code tidy up does not go backwards.
+    // We are already testing what was previously tested - ie contact_id,
+    // external_identifier or email, (email is the limit of the reserved
+    // un-supervised rule).
+    DedupeRuleGroup::update(FALSE)
+      ->addWhere('id', '=', $this->ids['DedupeRule']['unsupervised'])
+      ->setValues(['is_reserved' => FALSE])
+      ->execute();
+
+    $this->individualCreate([$this->getCustomFieldName() => 'secret code', 'first_name' => 'Bob', 'last_name' => 'Smith'], 'bob');
+    $this->importCSV('participant_with_dedupe_match.csv', [
+      ['name' => 'event_id'],
+      ['name' => 'first_name'],
+      ['name' => 'last_name'],
+      ['name' => $this->getCustomFieldName()],
+      ['name' => 'role_id'],
+      ['name' => 'status_id'],
+      ['name' => 'register_date'],
+    ]);
+    $participant = Participant::get(FALSE)
+      ->addWhere('contact_id', '=', $this->ids['Contact']['bob'])
+      ->execute()->first();
+    $this->assertEquals($this->ids['Event']['event'], $participant['event_id']);
   }
 
   /**

--- a/tests/phpunit/CRM/Event/Import/Parser/data/participant_with_dedupe_match.csv
+++ b/tests/phpunit/CRM/Event/Import/Parser/data/participant_with_dedupe_match.csv
@@ -1,0 +1,2 @@
+Event Title,First Name,Last Name,CustomField,Participant Role,Status,Register date
+Rain-forest Cup Youth Soccer Tournament,Bob,Wood,secret code,Attendee,Registered,2022-12-07


### PR DESCRIPTION
Overview
----------------------------------------
Ref clean up contact lookup handling in Participant import


Before
----------------------------------------
Participant import (and membership import) are using some particularly old & fugly code to look up the contact being imported to

After
----------------------------------------
The code is much more aligned with the contribution import 

Technical Details
----------------------------------------
Prior to this change matching was possible & tested on 
- contact ID
- contact external identifier
- contact email

The change focuses on adding test cover for something largely not currently possible in the UI - matching based on 'any' dedupe rule. The import is currently hard-coded to the Individual Unsupervised rule which is a reserved rule that only checks email. 

It you remove the `is_reserved` flag (not possible via the UI but known to happen in the wild) then the Unsupervised rule will allow any field to be used. In order to put the matching through it's paces the test does this.

This is working towards standardisation in the import classes with a view to switch all to apiv4 & add the extra civi-import functionality (e.g create / update contacts while importing) to all import classes

Comments
----------------------------------------

