### PR TITLE
HTML Purification - Allow "figcaption" and "figure" html tags

### DIFF
--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -638,10 +638,15 @@ class CRM_Utils_String {
       $config = HTMLPurifier_Config::createDefault();
       $config->set('Core.Encoding', 'UTF-8');
       $config->set('Attr.AllowedFrameTargets', ['_blank', '_self', '_parent', '_top']);
-
       // Disable the cache entirely
       $config->set('Cache.DefinitionImpl', NULL);
-
+      $config->set('HTML.DefinitionID', 'enduser-customize.html tutorial');
+      $config->set('HTML.DefinitionRev', 1);
+      $def = $config->maybeGetRawHTMLDefinition();
+      if (!empty($def)) {
+        $def->addElement('figcaption', 'Block', 'Flow', 'Common');
+        $def->addElement('figure', 'Block', 'Optional: (figcaption, Flow) | (Flow, figcaption) | Flow', 'Common');
+      }
       $_filter = new HTMLPurifier($config);
     }
 


### PR DESCRIPTION
… to support CKEditor5

Overview
----------------------------------------
When using CKEditor 5 and I think the elfinder is needed but you might be able to do this with the embeded image. If you have an image inserted as a "block" and you go to resize it say to 50% or something a <figure> html tag is added / updated with a style tag of the max width around it as per https://github.com/ckeditor/ckeditor5/issues/10856#issuecomment-1567101834. HTML Purifier strips this out because it isn't a supported entity. This PR adds support into HTML Purifier for these html tags to fix a regression from the default purifying of quickform defaults

Before
----------------------------------------
Images may appear larger in editor and on pages like the event info because <figure> tag has been removed by html purifier

After
----------------------------------------
<figure> tag remains and images are correct size as per selected scale

@eileenmcnaughton @totten @demeritcowboy 