### PR TITLE
(dev/core#4462) Afform - Add support for page-level authentication links

### DIFF
--- a/CRM/Utils/GuzzleMiddleware.php
+++ b/CRM/Utils/GuzzleMiddleware.php
@@ -227,7 +227,7 @@ class CRM_Utils_GuzzleMiddleware {
 
     $curlFmt = new class() extends \GuzzleHttp\MessageFormatter {
 
-      public function format(RequestInterface $request, ResponseInterface $response = NULL, \Exception $error = NULL) {
+      public function format(RequestInterface $request, ?ResponseInterface $response = NULL, ?\Throwable $error = NULL): string {
         $cmd = '$ curl';
         if ($request->getMethod() !== 'GET') {
           $cmd .= ' -X ' . escapeshellarg($request->getMethod());

--- a/ext/afform/core/CRM/Afform/Utils.php
+++ b/ext/afform/core/CRM/Afform/Utils.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use CRM_Afform_ExtensionUtil as E;
+
+/**
+ *
+ */
+class CRM_Afform_Utils {
+
+  /**
+   * Get a list of authentication options for `afform_mail_auth_token`.
+   *
+   * @return array
+   *   Array (string $machineName => string $label).
+   */
+  public static function getMailAuthOptions(): array {
+    return [
+      'session' => E::ts('Session-level authentication'),
+      'page' => E::ts('Page-level authentication'),
+    ];
+  }
+
+}

--- a/ext/afform/core/Civi/Afform/PageTokenCredential.php
+++ b/ext/afform/core/Civi/Afform/PageTokenCredential.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Civi\Afform;
+
+use Civi\Authx\CheckCredentialEvent;
+use Civi\Core\Service\AutoService;
+use Civi\Crypto\Exception\CryptoException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Allow Afform-based pages to accept page-level access token
+ *
+ * Example:
+ * - Create a JWT with `[scope => afform, afform => MY_FORM_NAME, sub=>cid:123]`.
+ *   This is defined to support "Afform.prefill" and "Afform.submit" on behalf of contact #123.
+ * - Navigate to `civicrm/my-form?_aff=Bearer+MY_JWT`
+ * - Within the page-view, each AJAX call sets `X-Civi-Auth: MY_JWT`.
+ *
+ * @service civi.afform.page_token
+ */
+class PageTokenCredential extends AutoService implements EventSubscriberInterface {
+
+  public static function getSubscribedEvents(): array {
+    $events = [];
+    $events['&civi.invoke.auth'][] = ['onInvoke', 105];
+    $events['civi.authx.checkCredential'][] = ['afformPageToken', -400];
+    return $events;
+  }
+
+  /**
+   * If you visit a top-level page like "civicrm/my-custom-form?_aff=XXX", then
+   * all embedded AJAX calls should "_authx=XXX".
+   *
+   * @param array $path
+   * @return void
+   */
+  public function onInvoke(array $path) {
+    $token = $_REQUEST['_aff'] ?? NULL;
+
+    if (empty($token)) {
+      return;
+    }
+    if (!preg_match(';^[a-zA-Z0-9\.\-_ ]+$;', $token)) {
+      throw new \CRM_Core_Exception("Malformed page token");
+    }
+
+    \CRM_Core_Region::instance('page-header')->add([
+      'callback' => function() use ($token) {
+        $ajaxSetup = [
+          'headers' => ['X-Civi-Auth' => $token],
+
+          // Sending cookies is counter-productive. For same-origin AJAX, there doesn't seem to be an opt-out.
+          // The main mitigating factor is that AuthX calls useFakeSession() for our use-case.
+          // 'xhrFields' => ['withCredentials' => FALSE],
+          // 'crossDomain' => TRUE,
+        ];
+        $script = sprintf('CRM.$.ajaxSetup(%s);', json_encode($ajaxSetup));
+        return "<script type='text/javascript'>\n$script\n</script>";
+      },
+    ]);
+  }
+
+  /**
+   * If we get a JWT with `[scope=>afform, afformName=>xyz]`, then setup
+   * the current fake-session to allow limited page-views.
+   *
+   * @param \Civi\Authx\CheckCredentialEvent $check
+   *
+   * @return void
+   */
+  public function afformPageToken(CheckCredentialEvent $check) {
+    if ($check->credFormat === 'Bearer') {
+      try {
+        $claims = \Civi::service('crypto.jwt')->decode($check->credValue);
+        $scopes = isset($claims['scope']) ? explode(' ', $claims['scope']) : [];
+        if (!in_array('afform', $scopes)) {
+          // This is not an afform JWT. Proceed to check any other token sources.
+          return;
+        }
+        if (empty($claims['sub']) || substr($claims['sub'], 0, 4) !== 'cid:') {
+          $check->reject('Malformed JWT. Must specify the contact ID.');
+        }
+        else {
+          $contactId = substr($claims['sub'], 4);
+          if ($this->checkAllowedRoute($check->getRequestPath(), $claims)) {
+            $check->accept(['contactId' => $contactId, 'credType' => 'jwt', 'jwt' => $claims]);
+          }
+          else {
+            $check->reject('JWT specifies a different form or route');
+          }
+        }
+      }
+      catch (CryptoException $e) {
+        if (strpos($e->getMessage(), 'Expired token') !== FALSE) {
+          $check->reject('Expired token');
+        }
+
+        // Not a valid AuthX JWT. Proceed to check any other token sources.
+      }
+    }
+
+  }
+
+  /**
+   * When processing CRM_Core_Invoke, check to see if our token allows us to handle this request.
+   *
+   * @param string $route
+   * @param array $jwt
+   * @return bool
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function checkAllowedRoute(string $route, array $jwt): bool {
+    $allowedForm = $jwt['afform'];
+
+    $ajaxRoutes = $this->getAllowedRoutes();
+    foreach ($ajaxRoutes as $regex => $routeInfo) {
+      if (preg_match($regex, $route)) {
+        $parsed = json_decode(\CRM_Utils_Request::retrieve('params', 'String'), 1);
+        if (empty($parsed)) {
+          \Civi::log()->warning("Malformed request. Routes matching $regex must submit params as JSON field.");
+          return FALSE;
+        }
+
+        $extraFields = array_diff(array_keys($parsed), $routeInfo['allowFields']);
+        if (!empty($extraFields)) {
+          \Civi::log()->warning("Malformed request. Routes matching $regex only support these input fields: " . json_encode($routeInfo['allowFields']));
+          return FALSE;
+        }
+
+        $actualForm = $parsed[$routeInfo['nameField']] ?? NULL;
+        if ($actualForm !== $allowedForm) {
+          \Civi::log()->warning("Malformed request. Requested form ($actualForm) does not match allowed name ($allowedForm).");
+          return FALSE;
+        }
+
+        return TRUE;
+      }
+    }
+
+    // Actually, we may not need this? aiming for model where top page-request auth is irrelevant to subrequests...
+    $allowedFormRoute = \Civi\Api4\Afform::get(FALSE)->addWhere('name', '=', $allowedForm)
+      ->addSelect('name', 'server_route')
+      ->execute()
+      ->single();
+    if ($allowedFormRoute['server_route'] === $route) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * @return array[]
+   */
+  protected function getAllowedRoutes(): array {
+    return [
+      // ';civicrm/path/to/some/page;' => [
+      //
+      //    // All the fields that are allowed for this API call.
+      //    // N.B. Fields like "chain" are NOT allowed.
+      //    'allowFields' => ['field_1', 'field_2', ...]
+      //
+      //    // The specific field which identifies the target form. Must match our page-token.
+      //    'nameField' => 'field_1',
+      //
+      // ],
+
+      ';^civicrm/ajax/api4/Afform/prefill$;' => [
+        'allowFields' => ['name', 'args'],
+        'nameField' => 'name',
+      ],
+      ';^civicrm/ajax/api4/Afform/submit$;' => [
+        'allowFields' => ['name', 'args', 'values'],
+        'nameField' => 'name',
+      ],
+      ';^civicrm/ajax/api4/Afform/submitFile$;' => [
+        'allowFields' => ['name'], /* FIXME */
+        'nameField' => 'name',
+      ],
+      ';^civicrm/ajax/api4/\w+/autocomplete$;' => [
+        'allowFields' => ['formName'], /* FIXME */
+        'nameField' => 'formName',
+      ],
+    ];
+  }
+
+}

--- a/ext/afform/core/Civi/Afform/PageTokenCredential.php
+++ b/ext/afform/core/Civi/Afform/PageTokenCredential.php
@@ -77,6 +77,9 @@ class PageTokenCredential extends AutoService implements EventSubscriberInterfac
           // This is not an afform JWT. Proceed to check any other token sources.
           return;
         }
+        if (empty($claims['exp'])) {
+          $check->reject('Malformed JWT. Must specify an expiration time.');
+        }
         if (empty($claims['sub']) || substr($claims['sub'], 0, 4) !== 'cid:') {
           $check->reject('Malformed JWT. Must specify the contact ID.');
         }

--- a/ext/afform/core/Civi/Afform/PageTokenCredential.php
+++ b/ext/afform/core/Civi/Afform/PageTokenCredential.php
@@ -179,7 +179,7 @@ class PageTokenCredential extends AutoService implements EventSubscriberInterfac
         'nameField' => 'name',
       ],
       ';^civicrm/ajax/api4/\w+/autocomplete$;' => [
-        'allowFields' => ['formName'], /* FIXME */
+        'allowFields' => ['fieldName', 'filters', 'formName', 'input', 'page', 'values'],
         'nameField' => 'formName',
       ],
     ];

--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -40,6 +40,8 @@
     <mixin>smarty@1.0.0</mixin>
     <mixin>entity-types-php@2.0.0</mixin>
     <mixin>menu-xml@1.0.0</mixin>
+    <mixin>setting-php@1.0.0</mixin>
+    <mixin>setting-admin@1.0.1</mixin>
   </mixins>
   <upgrader>CiviMix\Schema\Afform\AutomaticUpgrader</upgrader>
 </extension>

--- a/ext/afform/core/settings/Afform.setting.php
+++ b/ext/afform/core/settings/Afform.setting.php
@@ -1,0 +1,27 @@
+<?php
+use CRM_Afform_ExtensionUtil as E;
+
+return [
+  'afform_mail_auth_token' => [
+    'group_name' => 'Afform Preferences',
+    'group' => 'afform',
+    'name' => 'afform_mail_auth_token',
+    'type' => 'String',
+    'html_type' => 'select',
+    'html_attributes' => [
+      'class' => 'crm-select2',
+    ],
+    'pseudoconstant' => [
+      'callback' => 'CRM_Afform_Utils::getMailAuthOptions',
+    ],
+    // Traditional default. Might be nice to change, but need to tend to upgrade process.
+    'default' => 'session',
+    'add' => '4.7',
+    'title' => E::ts('Mail Authentication Tokens'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => E::ts('How do authenticated email hyperlinks work?'),
+    'help_text' => NULL,
+    'settings_pages' => ['afform' => ['weight' => 10]],
+  ],
+];

--- a/ext/afform/mock/ang/mockPublicForm.aff.html
+++ b/ext/afform/mock/ang/mockPublicForm.aff.html
@@ -1,14 +1,8 @@
 <!-- This example is entirely public; anonymous users may use it to submit a `Contact`, but they cannot view or modify data. -->
 <af-form ctrl="afform">
-  <af-entity data="{contact_type: 'Individual', source: 'Hello'}" url-autofill="1" security="FBAC" actions="{create: true, update: false}" type="Contact" name="me" label="Myself" />
-  <fieldset af-fieldset="me">
-    <legend class="af-text">Individual 1</legend>
-    <div class="af-container">
-      <div class="af-container af-layout-inline">
-        <af-field name="first_name" />
-        <af-field name="last_name" />
-      </div>
-    </div>
+  <af-entity data="{contact_type: 'Individual', source: 'Mock Public Form'}" type="Contact" name="me" label="Myself" actions="{create: true, update: true}" security="FBAC" url-autofill="0" autofill="user" />
+  <fieldset af-fieldset="me" class="af-container" af-title="Myself">
+    <afblock-name-individual></afblock-name-individual>
   </fieldset>
   <button class="af-button btn-primary" crm-icon="fa-check" ng-click="afform.submit()">Submit</button>
 </af-form>

--- a/ext/afform/mock/ang/mockPublicForm.aff.php
+++ b/ext/afform/mock/ang/mockPublicForm.aff.php
@@ -3,6 +3,8 @@ return [
   'type' => 'form',
   'title' => ts('My public form'),
   'server_route' => 'civicrm/mock-public-form',
+  'is_public' => TRUE,
   'permission' => '*always allow*',
   'is_token' => TRUE,
+  'create_submission' => FALSE,
 ];

--- a/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormBrowserTest.php
+++ b/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormBrowserTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace E2E\AfformMock;
+
+use Civi;
+
+/**
+ * Perform some tests against `mockPublicForm.aff.html`.
+ *
+ * This test uses Chrome and checks more high-level behaviors. For lower-level checks,
+ * see MockPublicFormTest.
+ *
+ * @group e2e
+ */
+class MockPublicFormBrowserTest extends Civi\Test\MinkBase {
+
+  protected $formName = 'mockPublicForm';
+
+  public static function setUpBeforeClass(): void {
+    \Civi\Test::e2e()
+      ->install(['org.civicrm.afform', 'org.civicrm.afform-mock'])
+      ->apply();
+  }
+
+  protected function setUp(): void {
+    parent::setUp();
+  }
+
+  protected function tearDown(): void {
+    parent::tearDown();
+    Civi::settings()->revert('afform_mail_auth_token');
+  }
+
+  /**
+   * Create a contact with middle name "Donald". Use the custom form to change the middle
+   * name to "Donny".
+   *
+   * @return void
+   * @throws \Behat\Mink\Exception\ElementNotFoundException
+   * @throws \CRM_Core_Exception
+   */
+  public function testUpdateMiddleName() {
+    Civi::settings()->set('afform_mail_auth_token', 'page');
+
+    $donny = $this->initializeTheodoreKerabatsos();
+    $this->assertEquals('Donald', $this->getContact($donny)['middle_name'], 'Middle name has original value');
+
+    $session = $this->mink->getSession();
+    $url = $this->renderToken('{afform.mockPublicFormUrl}', $donny);
+    $this->visit($url);
+
+    // Goal: Wait for the fields to be populated. But how...?
+    // $session->wait(5000, 'document.querySelectorAll("input#middle-name-1").length > 0');
+    // $session->wait(5000, '!!document.querySelectorAll("input#first-name-0").length && !!document.querySelectorAll("input#first-name-0")[0].value');
+    // $session->wait(5000, '!!document.querySelectorAll("input#middle-name-1").length && document.querySelectorAll("input#middle-name-1")[0].value.length > 0');
+    // $session->wait(5000, 'CRM.$(\'#middle-name-1:contains("Donald")\').length > 0');
+    // $session->wait(5000, 'window.CRM.$(\'#middle-name-1:contains("Donald")\').length > 0');
+    $session->wait(2000); /* FIXME: Cannot get wait-condition to be meaningfully used */
+
+    $middleName = $this->assertSession()->elementExists('css', 'input#middle-name-1');
+    $this->assertEquals('Donald', $middleName->getValue());
+    $middleName->setValue('Donny');
+
+    $submit = $this->assertSession()->elementExists('css', 'button.af-button.btn-primary');
+    $submit->click();
+
+    // Goal: Wait for the "Saved" status message. But how...?
+    // $session->wait(5000, 'document.querySelectorAll(".crm-status-box-msg").length > 0');
+    // $session->wait(5000, 'CRM.$(\'.crm-status-box-msg:contains("Saved")\').length > 1');
+    $session->wait(2000); /* FIXME: Cannot get wait-condition to be meaningfully used */
+
+    $this->assertEquals('Donny', $this->getContact($donny)['middle_name'], 'Middle name has been updated');
+  }
+
+  protected function renderToken(string $token, int $cid): string {
+    $tp = new \Civi\Token\TokenProcessor(\Civi::dispatcher(), []);
+    $tp->addRow()->context('contactId', $cid);
+    $tp->addMessage('example', $token, 'text/plain');
+    $tp->evaluate();
+    return $tp->getRow(0)->render('example');
+  }
+
+  protected function initializeTheodoreKerabatsos(): int {
+    $record = [
+      'contact_type' => 'Individual',
+      'first_name' => 'Theodore',
+      'middle_name' => 'Donald',
+      'last_name' => 'Kerabatsos',
+      'external_identifier' => __CLASS__,
+    ];
+    $contact = \Civi\Api4\Contact::save(FALSE)
+      ->setRecords([$record])
+      ->setMatch(['external_identifier'])
+      ->execute();
+    return $contact[0]['id'];
+  }
+
+  /**
+   * @param int $contactId
+   * @return string
+   * @throws \CRM_Core_Exception
+   */
+  protected function getContact(int $contactId): array {
+    return Civi\Api4\Contact::get(FALSE)
+      ->addWhere('id', '=', $contactId)
+      ->addSelect('id', 'first_name', 'middle_name', 'last_name')
+      ->execute()
+      ->single();
+  }
+
+}

--- a/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormTest.php
+++ b/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormTest.php
@@ -70,9 +70,7 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
    * The email token `{afform.mockPublicFormUrl}` should evaluate to an authenticated URL.
    */
   public function testAuthenticatedUrlToken_Plain() {
-    if (!function_exists('authx_civicrm_config')) {
-      $this->fail('Cannot test without authx');
-    }
+    $this->assertTrue(function_exists('authx_civicrm_config'), 'Cannot test without authx');
 
     $lebowski = $this->getLebowskiCID();
     $text = $this->renderTokens($lebowski, 'Please go to {afform.mockPublicFormUrl}', 'text/plain');
@@ -89,9 +87,7 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
    * The email token `{afform.mockPublicFormUrl}` should evaluate to an authenticated URL.
    */
   public function testAuthenticatedUrlToken_Html() {
-    if (!function_exists('authx_civicrm_config')) {
-      $this->fail('Cannot test without authx');
-    }
+    $this->assertTrue(function_exists('authx_civicrm_config'), 'Cannot test without authx');
 
     $lebowski = $this->getLebowskiCID();
     $html = $this->renderTokens($lebowski, 'Please go to <a href="{afform.mockPublicFormUrl}">my form</a>', 'text/html');
@@ -109,9 +105,7 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
    * The email token `{afform.mockPublicFormLink}` should evaluate to an authenticated URL.
    */
   public function testAuthenticatedLinkToken_Html() {
-    if (!function_exists('authx_civicrm_config')) {
-      $this->fail('Cannot test without authx');
-    }
+    $this->assertTrue(function_exists('authx_civicrm_config'), 'Cannot test without authx');
 
     $lebowski = $this->getLebowskiCID();
     $html = $this->renderTokens($lebowski, 'Please go to {afform.mockPublicFormLink}', 'text/html');

--- a/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormTest.php
+++ b/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormTest.php
@@ -2,6 +2,7 @@
 
 namespace E2E\AfformMock;
 
+use Civi;
 use CRM_Core_DAO;
 
 /**
@@ -16,6 +17,11 @@ use CRM_Core_DAO;
 class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
 
   protected $formName = 'mockPublicForm';
+
+  protected function setUp(): void {
+    parent::setUp();
+    Civi::settings()->revert('afform_mail_auth_token');
+  }
 
   public function testGetPage() {
     $r = $this->createGuzzle()->get('civicrm/mock-public-form');

--- a/ext/authx/Civi/Authx/Authenticator.php
+++ b/ext/authx/Civi/Authx/Authenticator.php
@@ -125,6 +125,7 @@ class Authenticator extends AutoService implements HookInterface {
       'cred' => $details['cred'] ?? NULL,
       'siteKey' => $details['siteKey'] ?? NULL,
       'useSession' => $details['useSession'] ?? FALSE,
+      'requestPath' => empty($e->args) ? '*' : implode('/', $e->args),
     ]);
 
     if (isset($tgt->cred)) {
@@ -161,6 +162,7 @@ class Authenticator extends AutoService implements HookInterface {
       'cred' => $details['cred'] ?? NULL,
       'siteKey' => $details['siteKey'] ?? NULL,
       'useSession' => $details['useSession'] ?? FALSE,
+      'requestPath' => $details['requestPath'] ?? '*',
     ]);
 
     if ($principal = $this->checkCredential($tgt)) {
@@ -186,7 +188,7 @@ class Authenticator extends AutoService implements HookInterface {
     // 1. Accept the cred, which stops event propagation and further checks;
     // 2. Reject the cred, which stops event propagation and further checks;
     // 3. Neither accept nor reject, letting the event continue on to the next.
-    $checkEvent = new CheckCredentialEvent($tgt->cred);
+    $checkEvent = new CheckCredentialEvent($tgt->cred, $tgt->requestPath);
     \Civi::dispatcher()->dispatch('civi.authx.checkCredential', $checkEvent);
 
     if ($checkEvent->getRejection()) {
@@ -344,6 +346,12 @@ class AuthenticatorTarget {
   public $flow;
 
   /**
+   * @var string|null
+   *   Ex: 'civicrm/dashboard'
+   */
+  public $requestPath;
+
+  /**
    * @var bool
    */
   public $useSession;
@@ -396,7 +404,13 @@ class AuthenticatorTarget {
    * @return $this
    */
   public static function create($args = []) {
-    return (new static())->set($args);
+    $tgt = (new static())->set($args);
+    if ($tgt->useSession || $tgt->requestPath === NULL) {
+      // If requesting access to a session (or using anything that isn't specifically tied
+      // to an HTTP route), then we are effectively asking for any/all routes.
+      $tgt->requestPath = '*';
+    }
+    return $tgt;
   }
 
   /**
@@ -470,6 +484,7 @@ class AuthenticatorTarget {
       // omit: cred
       // omit: siteKey
       'flow' => $this->flow,
+      'requestPath' => $this->requestPath,
       'credType' => $this->credType,
       'jwt' => $this->jwt,
       'useSession' => $this->useSession,

--- a/ext/authx/Civi/Authx/CheckCredentialEvent.php
+++ b/ext/authx/Civi/Authx/CheckCredentialEvent.php
@@ -32,6 +32,16 @@ class CheckCredentialEvent extends \Civi\Core\Event\GenericHookEvent {
   public $credValue;
 
   /**
+   * @var string
+   *   Ex: 'civicrm/dashboard' or '*'
+   *
+   *   This identifies the path(s) that the requestor wants to access.
+   *   For a stateless HTTP request, that's a specific path.
+   *   For stateful HTTP session or CLI pipe, that's a wildcard.
+   */
+  protected $requestPath;
+
+  /**
    * Authenticated principal.
    *
    * @var array|null
@@ -49,9 +59,16 @@ class CheckCredentialEvent extends \Civi\Core\Event\GenericHookEvent {
   /**
    * @param string $cred
    *   Ex: 'Basic ABCD1234' or 'Bearer ABCD1234'
+   * @param string $requestPath
+   *   Ex: 'civicrm/dashboard' or '*'
+   *
+   *   This identifies the path(s) that the requestor wants to access.
+   *   For a stateless HTTP request, that's a specific path.
+   *   For stateful HTTP session or CLI pipe, that's a wildcard.
    */
-  public function __construct(string $cred) {
+  public function __construct(string $cred, string $requestPath) {
     [$this->credFormat, $this->credValue] = explode(' ', $cred, 2);
+    $this->requestPath = $requestPath;
   }
 
   /**
@@ -121,6 +138,14 @@ class CheckCredentialEvent extends \Civi\Core\Event\GenericHookEvent {
 
   public function getRejection(): ?string {
     return $this->rejection;
+  }
+
+  /**
+   * @return string
+   *   Ex: 'civicrm/dashboard'
+   */
+  public function getRequestPath(): string {
+    return $this->requestPath;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

When you create a custom form and enable email-token support, it will generate authenticated hyperlinks with *session-level authentication* (clicking the link logs you into a session). However, *page-level authentication* (granting access to one specific page) is also useful.

For more discussion about the differences, see: https://lab.civicrm.org/dev/core/-/issues/4462. (That issue is focused more on email-driven workflows. However, the same mechanism can also be incorporated into cross-site workflows -- where a remote site wants to grant limited access to display a specific form for a specific user.)

Before
----------------------------------------

* Sending an email with a token like `{afform.myFormUrl}` will always generate a URL with a session-level authentication token, e.g.

    ```
    https://example.com/civicrm/my-form?_authx=GENERAL_LOGIN_TOKEN&_authxSes=1
    ```

After
----------------------------------------

* There is a setting ("Administer > System Settings > Form Core") which determines whether to prefer page-level authentication or session-level authentication.
* Sending an email with a token like `{afform.myFormUrl}` will generate a URL with a token. The token will look like either:

    ```
    https://example.com/civicrm/my-form?_authx=GENERAL_LOGIN_TOKEN&_authxSes=1
    ```

   or

    ```
    https://example.com/civicrm/my-form?_aff=LIMITED_PAGE_TOKEN
    ```

Comments
----------------------------------------

* Testing
    * Probably needs more interactive testing. I've been focused mostly on phpunit.
    * This includes some end-to-end tests using both Guzzle and Mink/Chrome.
    * I couldn't get the Mink/Chrome tests to implement "wait-until-condition" behavior. I included several comments about some of the attempted formulations, but none of them seemed to work. (*Well, the test might pass - but only have after waiting until the full timeout. So they'd idle longer than necessary*) For the moment, it's just using a static `wait(2000)`. Maybe someone with more Mink experience (like @demeritcowboy) can figure a better technique?
* Approach
    * This only targets Afform.
    * In Afform, all authenticated requests go through REST/APIv4. Civi's REST (when using authx) has support for processing narrow requests (*i.e. stateless; no cookie; fake session*). Also, you can propagate credentials using a single mechanism (jQuery's `$.ajaxSetup()`). 
    * In other kinds of forms (eg QuickForm), there's a mix of GETs, POST-backs, adhoc AJAX, and redirects. Making a generic mechanism for this would be tougher.