### PR TITLE
Remove do-nothing call to old function

### DIFF
--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -84,8 +84,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
         if (!$this->isUpdateExisting()) {
           throw new CRM_Core_Exception(ts('% record found and update not selected', [1 => 'Participant']));
         }
-        //@todo calling api functions directly is not supported
-        $this->deprecated_participant_check_params($formatted);
         $newParticipant = CRM_Event_BAO_Participant::create($formatted);
         $this->setImportStatus($rowNumber, 'IMPORTED', '', $newParticipant->id);
         return;


### PR DESCRIPTION
Overview
----------------------------------------
Remove do-nothing call to old function

Before
----------------------------------------
Calling ` $this->deprecated_participant_check_params()` without passing true as the second parameter does nothing

![image](https://github.com/civicrm/civicrm-core/assets/336308/be452a56-1ce1-40ab-a955-ca5c6bc04678)

After
----------------------------------------
Stopped doing it

Technical Details
----------------------------------------

Comments
----------------------------------------
