### PR TITLE
Fix dedupe query wrangling to combine queries where 2 fields in the same table are always used together

### DIFF
--- a/CRM/Dedupe/BAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/BAO/DedupeRuleGroup.php
@@ -158,7 +158,7 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup impl
     }
 
     $optimizer = new CRM_Dedupe_FinderQueryOptimizer($id, $contactIDs, []);
-    $tableQueries = $optimizer->getRuleQueries();
+    $tableQueries = $optimizer->getOptimizedQueries();
     if (empty($tableQueries)) {
       return;
     }

--- a/CRM/Dedupe/FinderQueryOptimizer.php
+++ b/CRM/Dedupe/FinderQueryOptimizer.php
@@ -15,6 +15,7 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 use Civi\API\EntityLookupTrait;
+
 use Civi\Api4\DedupeRule;
 
 /**
@@ -28,9 +29,14 @@ class CRM_Dedupe_FinderQueryOptimizer {
   private array $queries = [];
 
   /**
-   * @var mixed
+   * Threshold weight for merge.
+   *
+   * This starts with an unreachable number and is set to the correct number
+   * provided there is a valid rule.
+   *
+   * @var int
    */
-  private int $threshold;
+  private int $threshold = 999999;
 
   private array $contactIDs = [];
 
@@ -213,7 +219,6 @@ class CRM_Dedupe_FinderQueryOptimizer {
    * @internal do not call from outside tested core code.
    *
    * @return array
-   * @throws \CRM_Core_Exception
    */
   public function getRuleQueries(): array {
     $queries = [];
@@ -221,6 +226,223 @@ class CRM_Dedupe_FinderQueryOptimizer {
       $queries[$rule['key']] = $rule['query'];
     }
     return $queries;
+  }
+
+  /**
+   * Get any fields that should be combined.
+   *
+   * For example if we always use first_name and last_name together then
+   * we combine these 2 queries.
+   *
+   * @return array
+   */
+  public function getCombinableQueries(): array {
+    $possibleCombinations = [];
+    $validQueryCombinations = $this->getValidCombinations();
+
+    // First we compile an array of all possible field combinations
+    // ie each set of fields that occurs together at least once.
+    foreach ($validQueryCombinations as $validQueryCombination) {
+      $fieldCombinations = $this->getPowerSet($validQueryCombination);
+      foreach ($fieldCombinations as $fieldCombination) {
+        if (count($fieldCombination) > 1) {
+          $possibleCombinations[implode(',', array_values($fieldCombination))] = $fieldCombination;
+        }
+      }
+    }
+    $combinedFields = [];
+    foreach ($possibleCombinations as $key => $possibleCombination) {
+      if (!$this->isCombinationAlwaysTogether(array_values($this->getValidCombinations()), $possibleCombination)) {
+        unset($possibleCombinations[$key]);
+      }
+    }
+    // Now prune any subsets.
+    foreach ($possibleCombinations as $key => $possibleCombination) {
+      $otherCombinations = $possibleCombinations;
+      unset($otherCombinations[$key]);
+      if (!$this->isCombinationAlreadyCovered($otherCombinations, $possibleCombination)) {
+        $combinedFields[] = $possibleCombination;
+      }
+    }
+
+    return $combinedFields;
+  }
+
+  /**
+   * Get queries with queries within the same table that MUST be combined combined.
+   *
+   * For example if both first_name and last_name are required to meet the threshold then
+   * use one query that includes both.
+   */
+  public function getOptimizedQueries(): array {
+    $queries = $this->queries;
+    // We want to combine cross-tables but looking to do that as a follow on since that will require some
+    // more work to figure out. For single table regex does get us there.
+    foreach ($this->getCombinableQueriesByTable() as $queryCombinations) {
+      foreach ($queryCombinations as $queryDetails) {
+        if (count($queryDetails) < 2) {
+          // We can't yet combine across tables so skip this one for now.
+          continue;
+        }
+        $comboQueries = ['field' => [], 'criteria' => [], 'weight' => 0, 'table' => '', 'query' => ''];
+        foreach ($queryDetails as $queryDetail) {
+          $comboQueries['table'] = $queryDetail['table'];
+          $comboQueries['weight'] += $queryDetail['weight'];
+          $comboQueries['field'][] = $queryDetail['field'];
+          $comboQueries['query'] = $queryDetail['query'];
+          $criteria = [];
+          // The part of the query that relates to the field is in double brackets like this.
+          // ((t1.first_name IS NOT NULL AND t2.first_name IS NOT NULL AND t1.first_name = t2.first_name AND t1.first_name <> '' AND t2.first_name <> ''))
+          preg_match('/\((\(.+?\))\)/m', $queryDetail['query'], $criteria);
+          $comboQueries['criteria'][] = $criteria[1];
+          unset($queries[$queryDetail['key']]);
+        }
+        $combinedKey = $comboQueries['table'] . '.' . implode('_', $comboQueries['field']) . '.' . $comboQueries['weight'];
+        $combinedQuery['query'] = preg_replace('/\((\(.+?\))\)/m', implode(' AND ', $comboQueries['criteria']), $comboQueries['query']);
+        $combinedQuery['query'] = preg_replace('/( \d+ weight )/m', ' ' . $comboQueries['weight'] . ' weight ', $combinedQuery['query']);
+        $combinedQuery['weight'] = $comboQueries['weight'];
+        $combinedQuery['key'] = $combinedKey;
+        $queries[$combinedKey] = $combinedQuery;
+      }
+    }
+    uasort($queries, [$this, 'sortWeightDescending']);
+    $tableQueryFormat = [];
+    foreach ($queries as $query) {
+      $tableQueryFormat[$query['key']] = $query['query'];
+    }
+    return $tableQueryFormat;
+  }
+
+  /**
+   * Get queries that are combinable, keyed by table.
+   *
+   * A combinable query is one where the fields must both / all be matches if any of them
+   * are. e.g. if first_name is only ever enough to meet the threshold if last_name
+   * is also a match.
+   *
+   * @return array
+   *   Combinable query. Within each combination queries are keyed
+   *   by table. eg. if the threshold can only be met if first_name, last_name & email
+   *   are all matches then it would return the following.
+   *
+   *   [
+   *     ['civicrm_email' => [['field_name' => 'email'...., ], 'civicrm_contact' => [['field_name' => 'first_name'....], ['field_name' => 'last_name'....]]],
+   *   ]
+   *
+   */
+  public function getCombinableQueriesByTable(): array {
+    $singleTableCombinableQueries = [];
+    foreach ($this->getCombinableQueries() as $index => $combo) {
+      foreach ($combo as $key) {
+        $query = $this->queries[$key];
+        $singleTableCombinableQueries[$index][$query['table']][$query['field']] = $query;
+      }
+    }
+    return $singleTableCombinableQueries;
+  }
+
+  private function sortWeightDescending($a, $b) {
+    return ($a['weight'] > $b['weight']) ? -1 : 1;
+  }
+
+  /**
+   * Is the field combination already covered by another one in the array.
+   *
+   * Each field combination represents 2 ore more fields that are always used
+   * together to fulfill the rule & hence can be combined. For example we have a
+   * rule where 12 points are required and first name & last name are both worth 5
+   * points and birth date and nick name are both worth 2 points then the threshold
+   * can only be met with BOTH first name & last name & hence we should combine their
+   * queries.
+   *
+   * This would be true if the combination is for 2 fields but the same combination
+   * is already present in the opposite order or within a array covering 3 fields.
+   * fields. We want to combine the greatest number of fields that are combinable
+   * (as that will minimise queries) so the 3 field array is better than the 2 field array.
+   *
+   * @param array $allCombinations
+   * @param array $combination
+   *
+   * @return bool
+   */
+  private function isCombinationAlreadyCovered(array $allCombinations, array $combination): bool {
+    foreach ($allCombinations as $otherCombination) {
+      $isAllFieldsFound = empty(array_diff($combination, $otherCombination));
+      $isSomeFieldsFound = !empty(array_intersect($combination, $otherCombination));
+      if ($isSomeFieldsFound && $isAllFieldsFound) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Is the given combination of fields always used together?
+   *
+   * For example if the only way to get to the threshold is to have
+   * both first_name & last_name and these 2 fields are being passed in here
+   * then this will return TRUE.
+   *
+   * @param array $allCombinations
+   * @param array $combination
+   *   e.g ['civicrm_contact.first_name.7', 'civicrm_contact.last_name.8']
+   *
+   * @return bool
+   */
+  private function isCombinationAlwaysTogether(array $allCombinations, array $combination): bool {
+    foreach ($allCombinations as $validCombination) {
+      $someCombinationFieldsUsed = !empty(array_intersect($combination, array_keys($validCombination)));
+      $allCombinationFieldsUsed = empty(array_diff($combination, array_keys($validCombination)));
+      if ($someCombinationFieldsUsed && !$allCombinationFieldsUsed) {
+        return FALSE;
+      }
+    }
+    return TRUE;
+  }
+
+  /**
+   * Get all combinations of the queries.
+   *
+   * This is taken from https://www.oreilly.com/library/view/php-cookbook/1565926811/ch04s25.html
+   * which assures us it is called a power set...
+   *
+   * @return array[]
+   */
+  private function getPowerSet($queries): array {
+    // initialize by adding the empty set. This is necessary for the logic of this function.
+    $results = [[]];
+    foreach (array_reverse(array_keys($queries)) as $element) {
+      foreach ($results as $combination) {
+        $results[] = array_merge([$element], $combination);
+      }
+    }
+    return $results;
+  }
+
+  /**
+   * @return array[]
+   */
+  public function getValidCombinations(): array {
+    $combinations = [];
+    foreach ($this->getPowerSet($this->queries) as $set) {
+      $combination = [];
+      foreach ($set as $queryKey) {
+        $combination[$queryKey] = $this->queries[$queryKey]['weight'];
+      }
+      if (array_sum($combination) >= $this->threshold) {
+        $combinations[] = $combination;
+      }
+    }
+    foreach ($combinations as $key => $combination) {
+      // Check if the combination was already enough without the last item.
+      // If so we discard it as that combination is already in the array (or has
+      // already been discorded on the same basis).
+      array_pop($combination);
+      if (array_sum($combination) >= $this->threshold) {
+        unset($combinations[$key]);
+      }
+    }
+    return $combinations;
   }
 
 }

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -253,6 +253,13 @@ if (!defined('CIVICRM_SMARTY_AUTOLOAD_PATH') && getenv('CIVICRM_SMARTY_AUTOLOAD_
   }
 }
 
+if (!defined('CIVICRM_DEDUPE_OPTIMIZER')) {
+  // This is a temporary define to allow us to phase in improved dedupe queries
+  // with some degree of caution. If you set this to TRUE
+  // then the queries used to dedupe contacts will be combined
+  // for better performance.
+  define('CIVICRM_DEDUPE_OPTIMIZER', FALSE);
+}
 /**
  * Define any CiviCRM Settings Overrides per https://docs.civicrm.org/sysadmin/en/latest/customize/settings/
  *

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -384,6 +384,7 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
     $this->renameLabels();
     $this->ensureMySQLMode(['IGNORE_SPACE', 'ERROR_FOR_DIVISION_BY_ZERO', 'STRICT_TRANS_TABLES']);
     putenv('CIVICRM_SMARTY_DEFAULT_ESCAPE=1');
+    putenv('CIVICRM_DEDUPE_OPTIMIZER=TRUE');
     $this->originalSettings = \Civi::settings()->exportValues();
 
     // There doesn't seem to be a better way to get the current error handler.
@@ -3568,8 +3569,8 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
   /**
    * @return array|int
    */
-  protected function createRuleGroup(): array {
-    return $this->createTestEntity('DedupeRuleGroup', [
+  protected function createRuleGroup($params = []): array {
+    return $this->createTestEntity('DedupeRuleGroup', $params + [
       'contact_type' => 'Individual',
       'threshold' => 8,
       'used' => 'General',


### PR DESCRIPTION
Overview
----------------------------------------
Fix dedupe query wrangling to combine queries where 2 fields in the same table are always used together, in the find-duplicates context (ie not when checking submitted fields for a possible match)

This reduced the time taken to find first_name + last_name + street_address matches for 5000 contacts from 1 hour ++ (I killed the query after an hour) to 170 seconds. While not part of this PR we were able to reduce by a further 120 seconds by adding a combined index on first_name + last_name.

I was able to further reduce the time taken (with or without the index) down to a couple of seconds when I tried to combine the 3rd, street_address field, into the same query but that was at the raw SQL level and I'm going to do more testing / digging / attempting to make that work as a follow up. This is how the 'reserved' queries work - although they do not respect the fields that are specified in the rule & have hard coded values. They can potentially be entirely removed once we can do it effectively based on query combining

In order to be cautious about how other sites might experience this I have made it off / behaviour unchanged in the first instance - with a behaviour change only if the site specifies

```define('CIVICRM_DEDUPE_OPTIMIZER', TRUE);```

This is only intended to be transitional / precautionary

Before
----------------------------------------
If a dedupe rule always requires 2 fields in the same table to be used they cause 2 separate queries -e g

Rule threshold 20
Rule fields

first-name = 9
last-name-9
postal_code=2
state=2 

In this scenario the threshold can only be met if BOTH first_name and last_name match - ie

first-name + last-name + postal_code
OR 

first-name + last-name + state

However, the 2 queries are done separately - which means that we have to process a lot more rows and our queries take longer and can stall

After
----------------------------------------
This patch has a mechanism to identify fields that are only meaningful when selected together and is able to combine the queries under certain conditions

1) we are dealing with a table-based dedupe not a parameter based dedupe
2) no hook has altered the calculated queries
3) a dedupe-specific php file is not in play - this is used for a couple of core dedupe rules & was at one point thought to be a good way to customise dedupe behaviour although there is no evidence of uptake
4) the fields being combined are in the same table.

Of these conditions 2 & 3 are by design - working around legacy ways to extend dedupe queries is hard-work & has hampered this effort for years but has been addressed here

for 1 I suspect the way the query works means that the consolidation may not work but mostly it has been excluded to minimise complexity

Addressing 4 is very much desirable and is on the 'next steps' plan but is a little tricksy


The relevant part of the resulting query looks like
```
SELECT id1, id2, weight FROM (SELECT t1.id id1, t2.id id2, 18 weight FROM civicrm_contact t1 INNER JOIN civicrm_contact t2 ON (t1.first_name IS NOT NULL AND t2.first_name IS NOT NULL AND t1.first_name = t2.first_name AND t1.first_name <> '' AND t2.first_name <> '') AND (t1.last_name IS NOT NULL AND t2.last_name IS NOT NULL AND t1.last_name = t2.last_name AND t1.last_name <> '' AND t2.last_name <> '') WHERE t1.contact_type = 'Individual' AND t2.contact_type = 'Individual' AND t1.id < t2.id AND t1.id IN (3,4,5,6,7,8,9)
        UNION SELECT t1.id id1, t2.id id2,18 weight FROM civicrm_contact t1 INNER JOIN civicrm_contact t2 ON (t1.first_name IS NOT NULL AND t2.first_name IS NOT NULL AND t1.first_name = t2.first_name AND t1.first_name <> '' AND t2.first_name <> '') AND (t1.last_name IS NOT NULL AND t2.last_name IS NOT NULL AND t1.last_name = t2.last_name AND t1.last_name <> '' AND t2.last_name <> '') WHERE t1.contact_type = 'Individual' AND t2.contact_type = 'Individual' AND t1.id < t2.id AND  t2.id IN (3,4,5,6,7,8,9)) subunion
```

Technical Details
----------------------------------------
There is existing test cover over this code from a number of code paths and it's quite extensive. I added 2 tests
1) to test the mechanism for figuring out which queries were candidates for combining 
2) to ensure we have a test for a query that would be combined except it falls afoul of 4 - the fields are in 2 tables. This is there to ensure we don't break the query by combining fields from 2 tables - for now we avoid that breakage by not trying the optimisation

Comments
----------------------------------------
