### PR TITLE
PayPalIPN: check the `custom` parameter of HTTP request is a valid JSON

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -43,7 +43,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
   public function __construct($inputData) {
     // CRM-19676
     $params = (!empty($inputData['custom'])) ?
-      array_merge($inputData, json_decode($inputData['custom'], TRUE)) :
+      array_merge($inputData, json_decode($inputData['custom'], TRUE) ?? []) :
       $inputData;
     $this->setInputParameters($params);
     parent::__construct();


### PR DESCRIPTION
In PayPal IPN request, if `custom` parameter of HTTP request is not a valid JSON, a PHP Exception is handled: 

```
array_merge(): Argument #2 must be of type array, null given" at ...vendor/civicrm/civicrm-core/CRM/Core/Payment/PayPalIPN.php line 47"
```
This happens when PayPal is not only used by CiviCRM, but also by other systems and the IPN is still sent to CRM.

This is why we should check that the `json_decode` function does not return null.