### PR TITLE
Call new 'civi.core.clearcache' event on CRM_Utils_System:flushCache()

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1525,6 +1525,11 @@ class CRM_Utils_System {
 
     CRM_Core_OptionGroup::flushAll();
     CRM_Utils_PseudoConstant::flushAll();
+
+    if (Civi\Core\Container::isContainerBooted()) {
+      Civi::dispatcher()->dispatch('civi.core.clearcache');
+    }
+
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Would be really useful to have a event when CiviCRM cache is cleared. Many extensions implement its own cache / logic that needs to be "cleared" when the CiviCRM cache is.

Before
----------------------------------------
No way to inject any custom code in extensions when CiviCRM cache is cleared.

After
----------------------------------------
New event `civi.core.clearcache` is dispatched in `CRM_Utils_System:flushCache()` method

Technical Details
----------------------------------------
I recall that this feature was requested and discussed at one point in the past, but not sure if this is part of the roadmap or the idea was abandoned for some reason.

Thoughts ?