### PR TITLE
Remove broken code from DedupeFinder

### DIFF
--- a/CRM/Dedupe/BAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/BAO/DedupeRuleGroup.php
@@ -399,10 +399,10 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
    * @param array $contactIDs
    * @param array $params
    *
-   * @return void
+   * @return bool
    * @throws \Civi\Core\Exception\DBQueryException
    */
-  public function fillTable(int $id, array $contactIDs, array $params): void {
+  public function fillTable(int $id, array $contactIDs, array $params): bool {
     $this->contactIds = $contactIDs;
     $this->params = $params;
     $this->id = $id;
@@ -414,11 +414,15 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
     // if there are no rules in this rule group
     // add an empty query fulfilling the pattern
     if (!$tableQueries) {
-      // Yeah not too sure why but ....,
+      // Just for the hook.... (which is deprecated).
       $this->noRules = TRUE;
     }
+    CRM_Utils_Hook::dupeQuery($this, 'table', $tableQueries);
+    if (empty($tableQueries)) {
+      return FALSE;
+    }
 
-    if ($params && !empty($tableQueries)) {
+    if ($params) {
       $this->temporaryTables['dedupe'] = CRM_Utils_SQL_TempTable::build()
         ->setCategory('dedupe')
         ->createWithColumns("id1 int, weight int, UNIQUE UI_id1 (id1)")->getName();
@@ -442,8 +446,6 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
     }
     $patternColumn = '/t1.(\w+)/';
     $exclWeightSum = [];
-
-    CRM_Utils_Hook::dupeQuery($this, 'table', $tableQueries);
 
     while (!empty($tableQueries)) {
       [$isInclusive, $isDie] = self::isQuerySetInclusive($tableQueries, $this->threshold, $exclWeightSum);
@@ -519,6 +521,7 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
         break;
       }
     }
+    return TRUE;
   }
 
   /**
@@ -606,7 +609,7 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
     $this->_aclFrom = '';
     $aclWhere = '';
 
-    if ($this->params && !$this->noRules) {
+    if ($this->params) {
       if ($checkPermission) {
         [$this->_aclFrom, $aclWhere] = CRM_Contact_BAO_Contact_Permission::cacheClause('civicrm_contact');
         $aclWhere = $aclWhere ? "AND {$aclWhere}" : '';

--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -45,7 +45,9 @@ class CRM_Dedupe_Finder {
       throw new CRM_Core_Exception('Dedupe rule not found for selected contacts');
     }
 
-    $rgBao->fillTable($rgid, $cids, []);
+    if (!$rgBao->fillTable($rgid, $cids, [])) {
+      return [];
+    }
     $dao = CRM_Core_DAO::executeQuery($rgBao->thresholdQuery($checkPermissions));
     $dupes = [];
     while ($dao->fetch()) {
@@ -120,7 +122,9 @@ class CRM_Dedupe_Finder {
       $params['civicrm_phone']['phone_numeric'] = preg_replace('/[^\d]/', '', $orig);
     }
 
-    $rgBao->fillTable($rgBao->id, [], $params);
+    if (!$rgBao->fillTable($rgBao->id, [], $params)) {
+      return [];
+    }
 
     $dao = CRM_Core_DAO::executeQuery($rgBao->thresholdQuery($checkPermission));
     $dupes = [];


### PR DESCRIPTION
Overview
----------------------------------------
Remove broken code from DedupeFinder. I've stared at this code & tried to understand the point of `$this->noRules` so many times over the years - today I went down the rabbit hole - and shot the rabbit - but not the white one that likes me to feed it - that one doesn't live in a hole

Before
----------------------------------------
Code that was written to implement an early return falls through to another code path, creating & dropping a temp table & doing an empty select from that table. If it DID happen to find something in that table it would still not work as the select would retrieve the field as `id1` but the retrieval code is looking for `id`

After
----------------------------------------
We no longer do the extra 3 queries. & do the early return that was clearly always intended when no parameters match the rule

Technical Details
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/336308/9afae1d8-bd14-4f0f-b022-5028fa20434f)


There are 2 code flows that go through the dedupe finder code

- dedupe by params = search in the DB for existing contacts matching the incoming critieria
- dedupe without params = search in the DB for existing contacts that match each other (possibly with a filter applied to restrict the number of contacts count).
- 
If the dedupes by parameters code is followed there is an early exit in the code for when no applicable rules are found. e.g when the only passed in param is `nick_name` but the rule fields are first & last name.

However, at some point this early exit became a fall-through to the query used to find duplicate pairs - ie it creates a temporary table, tries to populate that temporary table & then drops it. 

It turns out that when it doesn't find the table queries & sets `$this->noRules = TRUE` the threshold query ALSO goes down the dedupe without params function and IF in some kooky way it DID find something that had been pushed into that table it would generate sql that retrieves the field as [`->id1`](https://github.com/civicrm/civicrm-core/blob/5569fe76c6ffcdd486a7cc3f3888dc32afa32d41/CRM/Dedupe/BAO/DedupeRuleGroup.php#L628) rather than `id` as would be required to make this work. SInce it never finds anything that brokenness is not hit.

https://github.com/civicrm/civicrm-core/blob/5569fe76c6ffcdd486a7cc3f3888dc32afa32d41/CRM/Dedupe/Finder.php#L129-L133

Given that the [code expectation has always been that the caller would modify `$tableQueries`](https://lab.civicrm.org/documentation/docs/dev/-/blob/master/docs/hooks/hook_civicrm_dupeQuery.md) it's reasonable to expect the hook to do just that -  so this moves the hook call to right after `tableQueries` is generated & early returns if it is not populated - skipping the 3 NULL queries.

Note that we have never found universe usages of this hook except in the `supportedFields` context & added noisy deprecation earlier this year https://github.com/civicrm/civicrm-core/blob/7787a3df767c7a5bcd3448e975333042bfad92c3/CRM/Utils/Hook.php#L1638-L1640

Comments
----------------------------------------

