### PR TITLE
dev/core#5330 Fix regression on profile emails for free events

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1771,7 +1771,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
         CRM_Event_Form_Registration_Confirm::fixLocationFields($value, $fields, $this);
         //for free event or additional participant, dont create billing email address.
-        if (empty($value['is_primary']) || !$this->_values['event']['is_monetary']) {
+        if (empty($value['is_primary'])) {
           unset($value["email-{$this->_bltID}"]);
         }
 

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -1028,7 +1028,10 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     $fields['email-Primary'] = 1;
 
     //if its pay later or additional participant set email address as primary.
-    if ((!empty($params['is_pay_later']) || empty($params['is_primary']) ||
+    // Note that it seems this function may have been broken and then
+    // accidentally started working - causing https://lab.civicrm.org/dev/core/-/issues/5330 was
+    // I can't see what changed...
+    if (empty($params['email-Primary']) && (!empty($params['is_pay_later']) || empty($params['is_primary']) ||
         !$form->_values['event']['is_monetary'] ||
         $form->_allowWaitlist ||
         $form->_requireApproval


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5330

dev/core#5330 Fix regression on profile emails for free events

Before
----------------------------------------
When a free event is configured with the profiles described in https://lab.civicrm.org/dev/core/-/issues/5330 the primary email is discarded in favour of the billing address

After
----------------------------------------
It is kept

Technical Details
----------------------------------------
Although this was reported as a regression from 5.70 I did not determine a mechanism - for some reason the `if` started working but the only relevant commit I found did not seem to have caused it https://github.com/civicrm/civicrm-core/commit/19e9a4fcdf7c850eaf141df0ac0abb6569e0ca22#diff-967d81007b3b773e9204a716773928529873c94f82bb21952845f1f1fdcd0255R1049

Comments
----------------------------------------
