### PR TITLE
[REF] Remove Foreign Key Constraints on cache tables

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixFour.php
+++ b/CRM/Upgrade/Incremental/php/SixFour.php
@@ -30,6 +30,14 @@ class CRM_Upgrade_Incremental_php_SixFour extends CRM_Upgrade_Incremental_Base {
   public function upgrade_6_4_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Rename multisite_is_enabled setting', 'renameMultisiteSetting');
+    $this->addTask('Remove Foreign Key References from cache tables', 'removeForeignKeyReferencesCacheTables');
+  }
+
+  public static function removeForeignKeyReferencesCacheTables(): bool {
+    CRM_Core_BAO_SchemaHandler::safeRemoveFK('civicrm_group_contact_cache', 'FK_civicrm_group_contact_cache_contact_id');
+    CRM_Core_BAO_SchemaHandler::safeRemoveFK('civicrm_group_contact_cache', 'FK_civicrm_group_contact_cache_group_id');
+    CRM_Core_BAO_SchemaHandler::safeRemoveFK('civicrm_acl_cache', 'FK_civicrm_acl_cache_acl_id');
+    return TRUE;
   }
 
   public static function renameMultisiteSetting(): bool {

--- a/schema/ACL/ACLCache.entityType.php
+++ b/schema/ACL/ACLCache.entityType.php
@@ -66,11 +66,6 @@ return [
         'key_column' => 'id',
         'label_column' => 'name',
       ],
-      'entity_reference' => [
-        'entity' => 'ACL',
-        'key' => 'id',
-        'on_delete' => 'CASCADE',
-      ],
     ],
     'modified_date' => [
       'title' => ts('Cache Modified Date'),

--- a/schema/Contact/GroupContactCache.entityType.php
+++ b/schema/Contact/GroupContactCache.entityType.php
@@ -46,11 +46,6 @@ return [
         'key_column' => 'id',
         'label_column' => 'title',
       ],
-      'entity_reference' => [
-        'entity' => 'Group',
-        'key' => 'id',
-        'on_delete' => 'CASCADE',
-      ],
     ],
     'contact_id' => [
       'title' => ts('Contact ID'),
@@ -61,11 +56,6 @@ return [
       'add' => '2.1',
       'input_attrs' => [
         'label' => ts('Contact'),
-      ],
-      'entity_reference' => [
-        'entity' => 'Contact',
-        'key' => 'id',
-        'on_delete' => 'CASCADE',
       ],
     ],
   ],


### PR DESCRIPTION
Overview
----------------------------------------
This aims to remove the last foreign key constraints on some cache tables. Having data that references deleted records shouldn't be a bad thing and shouldn't cause issue

Before
----------------------------------------
FKs exist

After
----------------------------------------
FKs are gone

ping @eileenmcnaughton @colemanw @mattwire @johntwyman 