### PR TITLE
Fix mis-allocation of is_primary when Primary and Billing emails on profiles on an event

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2167,9 +2167,22 @@ ORDER BY civicrm_email.is_primary DESC";
           }
         }
         elseif ($fieldName == 'email') {
+          // This bit of code ensures is_primary is set.
+          // It probably dates back to when the BAO
+          // could not be relied upon to manage
+          // that at least one email had is_primary
+          // & would ideally be removed.
           $data['email'][$loc]['email'] = $value;
           if (empty($contactID)) {
-            $data['email'][$loc]['is_primary'] = 1;
+            $hasPrimary = FALSE;
+            foreach ($data['email'] ?? [] as $email) {
+              if (!empty($email['is_primary'])) {
+                $hasPrimary = TRUE;
+              }
+            }
+            if (!$hasPrimary) {
+              $data['email'][$loc]['is_primary'] = 1;
+            }
           }
         }
         elseif ($fieldName == 'im') {


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5330

This is a follow on to https://github.com/civicrm/civicrm-core/pull/30609

Before
----------------------------------------
In the described (gitlab/ prior PR) circumstances the billing email winds up with the primary flag

After
----------------------------------------
the primary email winds up with the primary flag

Technical Details
----------------------------------------
I only tested when the billing email is second - I suspect that it would work in the other order as both would have the primary flag & the later one would 'win' - but if it doesn't then it's out of scope on this PR as would be unchanged by this patch

Comments
----------------------------------------
