### PR TITLE
dev/core#5330 Fix accordian hiding fields

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/Registration.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.tpl
@@ -195,8 +195,8 @@
 
 {*Confirmation Block*}
 <details id="confirm" {if !$defaultsEmpty}open{/if}>
-  <summary class="collapsible-title">{ts}Confirmation Screen{/ts}</summary>
-  <div id="confirm_screen_settings" class="crm-accordion-body">
+  <summary>{ts}Confirmation Screen{/ts}</summary>
+  <div class="crm-accordion-body">
     {if !$is_monetary}
     <table class="form-layout-compressed">
       <tr class="crm-event-manage-registration-form-block-is_confirm_enabled">
@@ -254,7 +254,7 @@
 
 {* Confirmation Email Block *}
 <details id="mail" {if !$defaultsEmpty}open{/if}>
-  <summary class="collapsible-title">{ts}Confirmation Email{/ts}</summary>
+  <summary >{ts}Confirmation Email{/ts}</summary>
   <div class="crm-accordion-wrapper">
     <table class="form-layout-compressed">
       <tr class="crm-event-manage-registration-form-block-is_email_confirm">


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5330 Fix accordian hiding fields on Confirmation

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/2444d6ae-f9c2-4060-af94-5acc8d32c6bb)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/01b65869-7c54-4535-aa0e-8c2d150ec4ba)


Technical Details
----------------------------------------
getting rid of the `id` did it but I also removed ` 'collapsible-title'` since it seemed to make no difference (good or bad) but is deprecated per https://lab.civicrm.org/dev/core/-/issues/5330#note_166690

Comments
----------------------------------------

@vingle 
