### PR TITLE
dev/core#5332 Prioritize format_locale to format money

### DIFF
--- a/Civi/Core/Locale.php
+++ b/Civi/Core/Locale.php
@@ -11,6 +11,8 @@
 
 namespace Civi\Core;
 
+use Civi;
+
 /**
  * Define a locale.
  *
@@ -156,7 +158,7 @@ class Locale {
     $locale->nominal = $tsLocale;
     $locale->ts = $tsLocale;
     $locale->db = $dbLocale ? ltrim($dbLocale, '_') : NULL;
-    $locale->moneyFormat = $tsLocale;
+    $locale->moneyFormat = Civi::settings()->get('format_locale') ?? $tsLocale;
     $locale->uf = \CRM_Utils_System::getUFLocale();
     return $locale;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Prioritize format_locale to format money

Before
----------------------------------------
- Visit `civicrm/admin/setting/localization?reset=1`
- Set Default Currency to NZD
- Set Formatting locale to `English (New Zealand)`
- View a contribution, the currency for all the amount is correctly set to $
- Send a receipt to a contact, the receipt still has `NZ$` displayed for the amount -

![image](https://github.com/civicrm/civicrm-core/assets/5929648/b98653cd-3472-47fa-b724-11d8640ab17b)

After
----------------------------------------
Fixed

![image](https://github.com/civicrm/civicrm-core/assets/5929648/d38c7174-f519-4ca1-9807-4cc25c06e0a5)

Technical Details
----------------------------------------
Prioritize format_locale to format money instead of the default locale.
