### PR TITLE
dev/core#5333 - Fix submit value for num terms field

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1856,7 +1856,7 @@ DESC limit 1");
     // be called on ADD
     foreach ($this->order->getMembershipLineItems() as $membershipLineItem) {
       if ($this->getAction() === CRM_Core_Action::ADD && $this->isQuickConfig()) {
-        $memTypeNumTerms = $this->getSubmittedValue('num_terms');
+        $memTypeNumTerms = $this->getSubmittedValue('num_terms') ?: 1;
       }
       else {
         // The submitted value is hidden when a price set is selected so


### PR DESCRIPTION
Overview
----------------------------------------
Fix submission of num terms field on backend membership form

Before
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/5333

- Visit https://dmaster.demo.civicrm.org/civicrm/contact/view?reset=1&cid=204&selectedChild=member
- Open `Submit Credit Card Membership` form (in a new window to see error)
- Clear `Number of terms` field

![image](https://github.com/civicrm/civicrm-core/assets/5929648/f72a3344-4094-463d-9691-92c62443446a)

- Save the form

![image](https://github.com/civicrm/civicrm-core/assets/5929648/1b3a09f9-924d-43c7-9ecb-7bad8da40c14)

In our case, the number of terms field was cleared automatically for some reason if CC details was autofilled using lastpass. 

Possible fix is to improve the handling of this error, maybe, adding a default 1 for the field at https://github.com/civicrm/civicrm-core/blob/master/CRM/Member/Form/Membership.php#L1859


After
----------------------------------------
Fixed

