### PR TITLE
Uncaught SyntaxError: missing ) after argument list with Catalan localization

### DIFF
--- a/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
@@ -190,7 +190,7 @@ function showBindFormatChkBox()
         document.getElementById("bindFormat").style.display = "block";
     } else if ( formatExists && document.getElementById("saveTemplate") != null && document.getElementById("saveTemplate").checked ) {
         document.getElementById("bindFormat").style.display = "block";
-        var yes = confirm( '{/literal}{$useThisPageFormat}{literal}' );
+        var yes = confirm( "{/literal}{$useThisPageFormat}{literal}" );
         if ( yes ) {
             document.getElementById("bind_format").checked = true;
         }
@@ -312,7 +312,7 @@ function showSaveDetails(chkbox)  {
         document.getElementById("saveTemplateName").disabled = false;
         if ( formatSelected && ! templateSelected ) {
             document.getElementById("bindFormat").style.display = "block";
-            var yes = confirm( '{/literal}{$useSelectedPageFormat}{literal}' );
+            var yes = confirm( "{/literal}{$useSelectedPageFormat}{literal}" );
             if ( yes ) {
                 document.getElementById("bind_format").checked = true;
             }


### PR DESCRIPTION
Catalan translation for `Should the new template always use the selected Page Format?` have an apostrophe char that conflicts in this JS code:

```
var yes = confirm( 'La nova plantilla hauria d'utilitzar sempre el format de pàgina seleccionat?' );
```

This causes the following error in the console: `Uncaught SyntaxError: missing ) after argument list`