### PR TITLE
dev/core#5335 - Only show pcp section on online receipt if there is a pcp

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2715,20 +2715,21 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $softDAO = new CRM_Contribute_DAO_ContributionSoft();
       $softDAO->contribution_id = $this->id;
       if ($softDAO->find(TRUE)) {
-        $pcpParams['pcpBlock'] = TRUE;
         $pcpParams['pcp_display_in_roll'] = $softDAO->pcp_display_in_roll;
         $pcpParams['pcp_roll_nickname'] = $softDAO->pcp_roll_nickname;
         $pcpParams['pcp_personal_note'] = $softDAO->pcp_personal_note;
 
         //assign the pcp page title for email subject
-        $pcpDAO = new CRM_PCP_DAO_PCP();
-        $pcpDAO->id = $softDAO->pcp_id;
-        if ($pcpDAO->find(TRUE)) {
-          $pcpParams['title'] = $pcpDAO->title;
+        if ($softDAO->pcp_id) {
+          $pcpDAO = new CRM_PCP_DAO_PCP();
+          $pcpDAO->id = $softDAO->pcp_id;
+          if ($pcpDAO->find(TRUE)) {
+            $pcpParams['title'] = $pcpDAO->title;
 
-          // do not display PCP block in receipt if not enabled for the PCP poge
-          if (empty($pcpDAO->is_honor_roll)) {
-            $pcpParams['pcpBlock'] = FALSE;
+            // Only display PCP block in receipt if enabled for the PCP page
+            if (!empty($pcpDAO->is_honor_roll)) {
+              $pcpParams['pcpBlock'] = TRUE;
+            }
           }
         }
       }

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -321,17 +321,20 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
       'Anderson',
       'Email Address',
       'anthony_anderson@civicrm.org',
-      'Honor',
       'This membership will be automatically renewed every',
       'Dear Anthony',
       'Thanks for your auto renew membership sign-up',
       'In Memory of',
     ]);
+    $mails = $mut->getAllMessages();
+    foreach ($mails as $mail) {
+      $mut->checkMailForStrings([], ['Honor'], '', $mail);
+    }
     $mut->clearMessages();
     $this->_contactID = $this->individualCreate(['first_name' => 'Antonia', 'prefix_id' => 'Mrs.', 'email' => 'antonia_anderson@civicrm.org']);
 
-    // Note, the second contribution is not in honor of anyone and the
-    // receipt should not mention honor at all.
+    // Note, the second contribution is not in memory of anyone and the
+    // receipt should not mention memory at all.
     $this->setupMembershipRecurringPaymentProcessorTransaction(['is_email_receipt' => TRUE], ['invoice_id' => '345']);
     $IPN = new CRM_Core_Payment_AuthorizeNetIPN($this->getRecurTransaction(['x_trans_id' => 'hers']));
     $IPN->main();


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5335

Before
----------------------------------------
To reproduce you can set up an online contribution page but it's easier to see the problem like so:
1. Create a contribution in the backend for someone with an email.
2. Make a soft credit on it.
3. Save.
4. On the person's contributions tab click on More at the far right and choose Send Receipt. This will use the online template.
5. Send the email.
6. Notice the email contains a Personal Campaign Pages section and says "Display in honor roll: No". This happens even if there are no pcp pages or config at all in the system.

After
----------------------------------------
Better.

Technical Details
----------------------------------------
The logic is backwards. See ticket.
Also when pcp_id is null the find() would pick up the first arbitrary pcp page when there is one. null doesn't mean none it means wildcard.

Comments
----------------------------------------
Slightly easier to review with whitespace hidden.
