### PR TITLE
(dev/core#5330) Manage Event - Fix radio button for "Confirmation Screen"

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/Registration.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.tpl
@@ -196,7 +196,7 @@
 {*Confirmation Block*}
 <details id="confirm" {if !$defaultsEmpty}open{/if}>
   <summary class="collapsible-title">{ts}Confirmation Screen{/ts}</summary>
-  <div id="confirm_screen_settings" class="crm-accordion-body">
+  <div class="crm-accordion-body">
     {if !$is_monetary}
     <table class="form-layout-compressed">
       <tr class="crm-event-manage-registration-form-block-is_confirm_enabled">
@@ -207,7 +207,7 @@
       </tr>
     </table>
     {/if}
-    <table class="form-layout-compressed">
+    <table class="form-layout-compressed" id="confirm_screen_settings">
       <tr class="crm-event-manage-registration-form-block-confirm_title">
         <td scope="row" class="label" width="20%">{$form.confirm_title.label} <span
             class="crm-marker">*</span> {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='confirm_title' id=$eventID}{/if}


### PR DESCRIPTION
Overview
--------

Under "Manage Event: Online Registration: Confirmation Screen", there's a radio button to enable/disable. The button misbehaves.

This is an off-shoot noticed while reproducing dev/core#5330.

ping @vingle @eileenmcnaughton 

Steps to Reproduce
--------

General procedure:

* Install demo data
* Edit the "Rain-forest" event
* In "Fees", use radio button todisable fees. (Free event)
* In "Online Registration", enable or disable the "Confirmation Screen"

Expected Behavior
-----------------

This is the behavior exhibited in 5.71 and earlier:

* For paid event, the confirmation screen is mandatory. So:
    * Under "Confirmation Screen", there is **no** radio button.
    * There are several text-boxes to configure title/text. They are always there.
* For free event, the confirmation screen is optional. So:
    * Under "Confirmation Screen", there **is** a radio button.
    * There are several text-boxes to configure title/text.
    * The text-boxes may be visible or hidden depending on the radio.

    <img width="518" alt="Screen Shot 2024-07-04 at 2 44 09 AM" src="https://github.com/civicrm/civicrm-core/assets/1336047/aaca401b-69f1-4576-b3fd-a1b4f5315509">

    or

    <img width="501" alt="Screen Shot 2024-07-06 at 4 33 08 PM" src="https://github.com/civicrm/civicrm-core/assets/1336047/e5b09a28-adb5-48d0-acf1-4d4b15418c4b">


Before
---------------

In 5.72 through 5.76-rc:

* For paid event: Same as expected behavior
* For free event: If you set the radio button to "No", then everything disappears.

<img width="524" alt="Screen Shot 2024-07-06 at 4 31 19 PM" src="https://github.com/civicrm/civicrm-core/assets/1336047/01e7c268-3cf8-455c-974a-0a86c519875e">

After
---------------

This patch restores the expected behavior.
