### PR TITLE
Fix broken Import Participants menu entry

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSeventyFive.php
+++ b/CRM/Upgrade/Incremental/php/FiveSeventyFive.php
@@ -75,6 +75,23 @@ class CRM_Upgrade_Incremental_php_FiveSeventyFive extends CRM_Upgrade_Incrementa
     $this->addTask(ts('Disable financial ACL extension if unused'), 'disableFinancialAcl');
   }
 
+  /**
+   * Upgrade step; adds tasks including 'runSql'.
+   *
+   * @param string $rev
+   *   The version number matching this function name
+   */
+  public function upgrade_5_75_1($rev): void {
+    $this->addTask(ts('Update the Import Participant menu item'), 'updateImportParticipantMenu');
+  }
+
+  public static function updateImportParticipantMenu($rev): bool {
+    CRM_Core_DAO::executeQuery('UPDATE civicrm_navigation SET url = %1 WHERE url = %2', [
+      1 => ['civicrm/import/participant?reset=1', 'String'],
+      2 => ['civicrm/event/import?reset=1', 'String'],
+    ]);
+  }
+
   public static function disableFinancialAcl($rev): bool {
     $setting = CRM_Core_DAO::singleValueQuery('SELECT value FROM civicrm_setting WHERE name = "acl_financial_type"');
     if ($setting) {


### PR DESCRIPTION
Overview
----------------------------------------

- Install CiviCRM 5.74, then upgrade to CiviCRM 5.75
- then go to Events > Import Participants

It leads back to the Event Dashboard, instead of the Import Participants screen.

This only affects installations that upgraded from 5.74 or earlier.

Before
----------------------------------------

wrong URL

After
----------------------------------------

good URL

Technical Details
----------------------------------------

In  #30044, some tidy was made to the import code. It renamed the URL from `civicrm/event/import?reset=1` to `civicrm/import/participant?reset=1`.

However, it was missing an upgrader function for existing sites.

Comments
----------------------------------------

Based on a bug report by @Stoob 

This PR is against 5.75 (stable) because while it's technically a really minor issue, it's a very confusing bug to admins.

:question:  Should I duplicate this code for the RC and master? (it feels overkill to abstract and clutter a parent class with the equivalent of a one-off  one-liner)