### PR TITLE
Fix notice error when previewing profile from contribution page

### DIFF
--- a/templates/CRM/UF/Form/Preview.tpl
+++ b/templates/CRM/UF/Form/Preview.tpl
@@ -15,21 +15,22 @@
 {include file="CRM/common/info.tpl" infoType="no-popup profile-preview-msg" infoMessage=" "}
 <div class="crm-form-block">
 
-{if ! empty( $fields )}
-  {if $viewOnly}
-  {* wrap in crm-container div so crm styles are used *}
-    <div id="crm-container-inner" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
-      {strip}
-        {include file="CRM/UF/Form/Block.tpl" prefix=false mode=false hideFieldset=false}
-      {/strip}
-    </div> {* end crm-container div *}
-  {else}
-    {capture assign=infoMessage}{ts}This CiviCRM profile field is view only.{/ts}{/capture}
-  {include file="CRM/common/info.tpl"}
+  {if ! empty( $fields )}
+    {if $viewOnly}
+      {* wrap in crm-container div so crm styles are used *}
+      <div id="crm-container-inner" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
+        {strip}
+          {include file="CRM/UF/Form/Block.tpl" prefix=false mode=false hideFieldset=false}
+        {/strip}
+      </div> {* end crm-container div *}
+    {else}
+      {capture assign=infoMessage}{ts}This CiviCRM profile field is view only.{/ts}{/capture}
+      {include file="CRM/common/info.tpl"}
+    {/if}
+  {/if} {* fields array is not empty *}
+  {if array_key_exists('buttons', $form)}
+    <div class="crm-submit-buttons">
+      {include file="CRM/common/formButtons.tpl" location=''}
+    </div>
   {/if}
-{/if} {* fields array is not empty *}
-
-  <div class="crm-submit-buttons">
-  {include file="CRM/common/formButtons.tpl" location=''}
-  </div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix this notice error

```
Warning: Undefined array key "buttons" in include() (line 38 of /sites/default/files/civicrm/templates_c/en_US/%%ED/ED7/ED78F5CC%%formButtons.tpl.php)
#1 sites/default/files/civicrm/templates_c/en_US/%%ED/ED7/ED78F5CC%%formButtons.tpl.php(38): _drupal_error_handler()
#3 sites/default/files/civicrm/templates_c/en_US/%%8A/8A0/8A0573CD%%Preview.tpl.php(39): Smarty->_smarty_include()
```

Before
----------------------------------------
Smarty Error triggered when clicking the Preview button inline or after clicking edit profile in the popup when on a Manage Contribution Page / Manage Event Page admin section

After
----------------------------------------
No Notice

Technical Details
----------------------------------------
In these two inline preview modes we don't output any buttons when rendering the profile and this should stop the notice by putting an if around the include and always assigning the buttons key

@eileenmcnaughton @demeritcowboy @colemanw 