### PR TITLE
Fix handling on Contribution token on unpaid event

### DIFF
--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -183,6 +183,9 @@ class TokenRow {
    */
   public function customToken($entity, $customFieldID, $entityID) {
     $customFieldName = 'custom_' . $customFieldID;
+    if (empty($entityID)) {
+      return $this->format('text/html')->tokens($entity, $customFieldName, '');
+    }
     $record = civicrm_api3($entity, 'getSingle', [
       'return' => $customFieldName,
       'id' => $entityID,


### PR DESCRIPTION
Overview
----------------------------------------
If the event online receipt message template has a contribution custom field token, the event registration fails with an error
<img width="800" alt="Screenshot 2024-07-09 at 00 04 40" src="https://github.com/civicrm/civicrm-core/assets/2053075/15cfa4db-87a0-4dd7-9e70-acc111b4daf7">

Steps to replicate:
1. Create custom field for contribution
2. Add contribution token to [Events - Registration Confirmation and Receipt (on-line)](https://dmaster.demo.civicrm.org/civicrm/admin/messageTemplates?reset=1#/edit?id=31)

````
<tr>
  <td style="padding-bottom: 16px;">Payment Description:</td>
  <td style="padding-bottom: 16px;">{contribution.custom_6}</td>
 </tr>
````
3. Create a Event with Paid Event set to No and confirmation email to yes.
4. Try to register for the event online.

**Backtace**
```
2024-07-08 23:48:03+0100  [debug] $eeror = #0 /var/sites/drupal10/vendor/civicrm/civicrm-core/api/api.php(138): CRM_Core_Error::backtrace("eeror", 1)
#1 /var/sites/drupal10/vendor/civicrm/civicrm-core/Civi/Token/TokenRow.php(188): civicrm_api3("contribution", "getSingle", (Array:3))
#2 /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/EntityTokens.php(120): Civi\Token\TokenRow->customToken("contribution", "136", NULL)
#3 /var/sites/drupal10/vendor/civicrm/civicrm-core/Civi/Token/AbstractTokenSubscriber.php(146): CRM_Core_EntityTokens->evaluateToken(Object(Civi\Token\TokenRow), "contribution", "custom_136", (Array:0))
#4 /var/sites/drupal10/vendor/symfony/event-dispatcher/EventDispatcher.php(220): Civi\Token\AbstractTokenSubscriber->evaluateTokens(Object(Civi\Token\Event\TokenValueEvent), "civi.token.eval", Object(Civi\Core\UnoptimizedEventDispatcher))
#5 /var/sites/drupal10/vendor/symfony/event-dispatcher/EventDispatcher.php(56): Symfony\Component\EventDispatcher\EventDispatcher->callListeners((Array:20), "civi.token.eval", Object(Civi\Token\Event\TokenValueEvent))
#6 /var/sites/drupal10/vendor/civicrm/civicrm-core/Civi/Core/CiviEventDispatcher.php(263): Symfony\Component\EventDispatcher\EventDispatcher->dispatch(Object(Civi\Token\Event\TokenValueEvent), "civi.token.eval")
#7 /var/sites/drupal10/vendor/civicrm/civicrm-core/Civi/Token/TokenProcessor.php(354): Civi\Core\CiviEventDispatcher->dispatch("civi.token.eval", Object(Civi\Token\Event\TokenValueEvent))
#8 /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/TokenSmarty.php(64): Civi\Token\TokenProcessor->evaluate()
#9 /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/BAO/MessageTemplate.php(374): CRM_Core_TokenSmarty::render((Array:3), (Array:13), (Array:55))
#10 /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/BAO/MessageTemplate.php(422): CRM_Core_BAO_MessageTemplate::renderTemplateRaw((Array:18))
#11 /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Event/BAO/Event.php(1254): CRM_Core_BAO_MessageTemplate::sendTemplate((Array:12))
#12 /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Event/Form/Registration.php(1681): CRM_Event_BAO_Event::sendMail(2, (Array:7), 2553, FALSE)
#13 /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Event/Form/Registration.php(1613): CRM_Event_Form_Registration->sendMails((Array:1), 2553, (Array:0))
#14 /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Event/Form/Registration/Register.php(1165): CRM_Event_Form_Registration->processRegistration((Array:1))
#15 /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/Form.php(641): CRM_Event_Form_Registration_Register->postProcess()
#16 /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/QuickForm/Action/Upload.php(153): CRM_Core_Form->mainProcess()
#17 /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/QuickForm/Action/Upload.php(120): CRM_Core_QuickForm_Action_Upload->realPerform(Object(CRM_Event_Form_Registration_Register), "upload")
#18 /var/sites/drupal10/vendor/civicrm/civicrm-packages/HTML/QuickForm/Controller.php(203): CRM_Core_QuickForm_Action_Upload->perform(Object(CRM_Event_Form_Registration_Register), "upload")
#19 /var/sites/drupal10/vendor/civicrm/civicrm-packages/HTML/QuickForm/Page.php(103): HTML_QuickForm_Controller->handle(Object(CRM_Event_Form_Registration_Register), "upload")
#20 /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/Controller.php(355): HTML_QuickForm_Page->handle("upload")
#21 /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php(322): CRM_Core_Controller->run((Array:3), NULL)
#22 /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php(69): CRM_Core_Invoke::runItem((Array:18))
#23 /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php(36): CRM_Core_Invoke::_invoke((Array:3))
#24 /var/sites/drupal10/web/modules/contrib/civicrm/src/Civicrm.php(88): CRM_Core_Invoke::invoke((Array:3))
#25 /var/sites/drupal10/web/modules/contrib/civicrm/src/Controller/CivicrmController.php(83): Drupal\civicrm\Civicrm->invoke((Array:3))
#26 [internal function](): Drupal\civicrm\Controller\CivicrmController->main((Array:3), "")
#27 /var/sites/drupal10/web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(123): call_user_func_array((Array:2), (Array:2))
#28 /var/sites/drupal10/web/core/lib/Drupal/Core/Render/Renderer.php(627): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#29 /var/sites/drupal10/web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(124): Drupal\Core\Render\Renderer->executeInRenderContext(Object(Drupal\Core\Render\RenderContext), Object(Closure))
#30 /var/sites/drupal10/web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(97): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext((Array:2), (Array:2))
#31 /var/sites/drupal10/vendor/symfony/http-kernel/HttpKernel.php(181): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#32 /var/sites/drupal10/vendor/symfony/http-kernel/HttpKernel.php(76): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#33 /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/Session.php(58): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#34 /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/KernelPreHandle.php(48): Drupal\Core\StackMiddleware\Session->handle(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#35 /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/ContentLength.php(28): Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#36 /var/sites/drupal10/web/core/modules/big_pipe/src/StackMiddleware/ContentLength.php(32): Drupal\Core\StackMiddleware\ContentLength->handle(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#37 /var/sites/drupal10/web/core/modules/page_cache/src/StackMiddleware/PageCache.php(106): Drupal\big_pipe\StackMiddleware\ContentLength->handle(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#38 /var/sites/drupal10/web/core/modules/page_cache/src/StackMiddleware/PageCache.php(85): Drupal\page_cache\StackMiddleware\PageCache->pass(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#39 /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/ReverseProxyMiddleware.php(48): Drupal\page_cache\StackMiddleware\PageCache->handle(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#40 /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/NegotiationMiddleware.php(51): Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#41 /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/AjaxPageState.php(36): Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#42 /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/StackedHttpKernel.php(51): Drupal\Core\StackMiddleware\AjaxPageState->handle(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#43 /var/sites/drupal10/web/core/lib/Drupal/Core/DrupalKernel.php(704): Drupal\Core\StackMiddleware\StackedHttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#44 /var/sites/drupal10/web/index.php(19): Drupal\Core\DrupalKernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#45 {main}


2024-07-08 23:48:03+0100  [error] 
$Fatal Error Details = array:3 [
  "message" => "Expected one Contribution but found 25"
  "code" => null
  "exception" => CRM_Core_Exception {#14287
    #message: "Expected one Contribution but found 25"
    #code: 0
    #file: "/var/sites/drupal10/vendor/civicrm/civicrm-core/api/api.php"
    #line: 139
    #cause: null
    -_trace: null
    -errorData: array:4 [
      "count" => 25
      "is_error" => 1
      "error_message" => "Expected one Contribution but found 25"
      "error_code" => "undefined"
    ]
    trace: {
      /var/sites/drupal10/vendor/civicrm/civicrm-core/api/api.php:139 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-core/Civi/Token/TokenRow.php:188 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/EntityTokens.php:120 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-core/Civi/Token/AbstractTokenSubscriber.php:146 { …}
      /var/sites/drupal10/vendor/symfony/event-dispatcher/EventDispatcher.php:220 { …}
      /var/sites/drupal10/vendor/symfony/event-dispatcher/EventDispatcher.php:56 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-core/Civi/Core/CiviEventDispatcher.php:263 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-core/Civi/Token/TokenProcessor.php:354 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/TokenSmarty.php:64 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/BAO/MessageTemplate.php:374 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/BAO/MessageTemplate.php:422 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Event/BAO/Event.php:1254 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Event/Form/Registration.php:1681 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Event/Form/Registration.php:1613 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Event/Form/Registration/Register.php:1165 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/Form.php:641 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/QuickForm/Action/Upload.php:153 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/QuickForm/Action/Upload.php:120 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-packages/HTML/QuickForm/Controller.php:203 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-packages/HTML/QuickForm/Page.php:103 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/Controller.php:355 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php:322 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php:69 { …}
      /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php:36 { …}
      /var/sites/drupal10/web/modules/contrib/civicrm/src/Civicrm.php:88 {
        Drupal\civicrm\Civicrm->invoke($args)
        › ob_start();
        › $content = \CRM_Core_Invoke::invoke($args);
        › $output = ob_get_clean();
      }
      /var/sites/drupal10/web/modules/contrib/civicrm/src/Controller/CivicrmController.php:83 { …}
      Drupal\civicrm\Controller\CivicrmController->main() {}
      /var/sites/drupal10/web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php:123 { …}
      /var/sites/drupal10/web/core/lib/Drupal/Core/Render/Renderer.php:627 { …}
      /var/sites/drupal10/web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php:124 { …}
      /var/sites/drupal10/web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php:97 { …}
      /var/sites/drupal10/vendor/symfony/http-kernel/HttpKernel.php:181 { …}
      /var/sites/drupal10/vendor/symfony/http-kernel/HttpKernel.php:76 { …}
      /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/Session.php:58 { …}
      /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/KernelPreHandle.php:48 { …}
      /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/ContentLength.php:28 { …}
      /var/sites/drupal10/web/core/modules/big_pipe/src/StackMiddleware/ContentLength.php:32 { …}
      /var/sites/drupal10/web/core/modules/page_cache/src/StackMiddleware/PageCache.php:106 { …}
      /var/sites/drupal10/web/core/modules/page_cache/src/StackMiddleware/PageCache.php:85 { …}
      /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/ReverseProxyMiddleware.php:48 { …}
      /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/NegotiationMiddleware.php:51 { …}
      /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/AjaxPageState.php:36 { …}
      /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/StackedHttpKernel.php:51 { …}
      /var/sites/drupal10/web/core/lib/Drupal/Core/DrupalKernel.php:704 { …}
      /var/sites/drupal10/web/index.php:19 { …}
    }
  }
]


2024-07-08 23:48:03+0100  [debug] $backTrace = #0 /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/Error.php(443): CRM_Core_Error::backtrace("backTrace", TRUE)
#1 /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php(39): CRM_Core_Error::handleUnhandledException(Object(CRM_Core_Exception))
#2 /var/sites/drupal10/web/modules/contrib/civicrm/src/Civicrm.php(88): CRM_Core_Invoke::invoke((Array:3))
#3 /var/sites/drupal10/web/modules/contrib/civicrm/src/Controller/CivicrmController.php(83): Drupal\civicrm\Civicrm->invoke((Array:3))
#4 [internal function](): Drupal\civicrm\Controller\CivicrmController->main((Array:3), "")
#5 /var/sites/drupal10/web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(123): call_user_func_array((Array:2), (Array:2))
#6 /var/sites/drupal10/web/core/lib/Drupal/Core/Render/Renderer.php(627): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#7 /var/sites/drupal10/web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(124): Drupal\Core\Render\Renderer->executeInRenderContext(Object(Drupal\Core\Render\RenderContext), Object(Closure))
#8 /var/sites/drupal10/web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(97): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext((Array:2), (Array:2))
#9 /var/sites/drupal10/vendor/symfony/http-kernel/HttpKernel.php(181): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#10 /var/sites/drupal10/vendor/symfony/http-kernel/HttpKernel.php(76): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#11 /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/Session.php(58): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#12 /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/KernelPreHandle.php(48): Drupal\Core\StackMiddleware\Session->handle(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#13 /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/ContentLength.php(28): Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#14 /var/sites/drupal10/web/core/modules/big_pipe/src/StackMiddleware/ContentLength.php(32): Drupal\Core\StackMiddleware\ContentLength->handle(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#15 /var/sites/drupal10/web/core/modules/page_cache/src/StackMiddleware/PageCache.php(106): Drupal\big_pipe\StackMiddleware\ContentLength->handle(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#16 /var/sites/drupal10/web/core/modules/page_cache/src/StackMiddleware/PageCache.php(85): Drupal\page_cache\StackMiddleware\PageCache->pass(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#17 /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/ReverseProxyMiddleware.php(48): Drupal\page_cache\StackMiddleware\PageCache->handle(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#18 /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/NegotiationMiddleware.php(51): Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#19 /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/AjaxPageState.php(36): Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#20 /var/sites/drupal10/web/core/lib/Drupal/Core/StackMiddleware/StackedHttpKernel.php(51): Drupal\Core\StackMiddleware\AjaxPageState->handle(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#21 /var/sites/drupal10/web/core/lib/Drupal/Core/DrupalKernel.php(704): Drupal\Core\StackMiddleware\StackedHttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, TRUE)
#22 /var/sites/drupal10/web/index.php(19): Drupal\Core\DrupalKernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#

```

