### PR TITLE
Move add function on ContributionRecur to hook

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -29,8 +29,12 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
    *
    * @return object
    *   activity contact object
+   *
+   * @deprecated since 5.76 will be removed around 5.90.
+   * Non-core users should all use the api.
    */
   public static function create(&$params) {
+    CRM_Core_Error::deprecatedFunctionWarning('writeRecord');
     return self::add($params);
   }
 
@@ -46,49 +50,31 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
    *
    * @return \CRM_Contribute_BAO_ContributionRecur
    * @throws \CRM_Core_Exception
-   * @todo move hook calls / extended logic to create - requires changing calls
-   *   to call create not add
+   * @deprecated since 5.76 will be removed around 5.96.
+   * Non-core users should all use the api. As of writing there
+   * are some core users.
    */
   public static function add(&$params) {
-    if (!empty($params['id'])) {
-      CRM_Utils_Hook::pre('edit', 'ContributionRecur', $params['id'], $params);
-    }
-    else {
-      CRM_Utils_Hook::pre('create', 'ContributionRecur', NULL, $params);
-    }
+    return self::writeRecord($params);
+  }
 
-    // make sure we're not creating a new recurring contribution with the same transaction ID
-    // or invoice ID as an existing recurring contribution
-    $duplicates = [];
-    if (self::checkDuplicate($params, $duplicates)) {
-      throw new CRM_Core_Exception('Found matching recurring contribution(s): ' . implode(', ', $duplicates));
+  /**
+   * Event fired before modifying an IM.
+   * @param \Civi\Core\Event\PreEvent $event
+   */
+  public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
+    if (in_array($event->action, ['create', 'edit'])) {
+      // make sure we're not creating a new recurring contribution with the same transaction ID
+      // or invoice ID as an existing recurring contribution
+      $duplicates = [];
+      if (self::checkDuplicate($event->params, $duplicates)) {
+        throw new CRM_Core_Exception('Found matching recurring contribution(s): ' . implode(', ', $duplicates));
+      }
+      if ($event->action === 'create' && empty($event->params['currency'])) {
+        // set currency for CRM-1496
+        $event->params['currency'] = \Civi::settings()->get('defaultCurrency');
+      }
     }
-
-    $recurring = new CRM_Contribute_BAO_ContributionRecur();
-    $recurring->copyValues($params);
-    $recurring->id = $params['id'] ?? NULL;
-
-    // set currency for CRM-1496
-    if (empty($params['id']) && !isset($recurring->currency)) {
-      $config = CRM_Core_Config::singleton();
-      $recurring->currency = $config->defaultCurrency;
-    }
-    $recurring->save();
-
-    if (!empty($params['id'])) {
-      CRM_Utils_Hook::post('edit', 'ContributionRecur', $recurring->id, $recurring);
-    }
-    else {
-      CRM_Utils_Hook::post('create', 'ContributionRecur', $recurring->id, $recurring);
-    }
-
-    if (!empty($params['custom']) &&
-      is_array($params['custom'])
-    ) {
-      CRM_Core_BAO_CustomValueTable::store($params['custom'], 'civicrm_contribution_recur', $recurring->id);
-    }
-
-    return $recurring;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Move add funciton on ContributionRecur to hook

Before
----------------------------------------
This `BAO` still has a custom add function

After
----------------------------------------
In line with the changes @colemanw has been making the `BAO_ContributionRecur` implements a `pre` hook to massage incoming values and does the main work through `writeRecord`

Technical Details
----------------------------------------
I wrote a test - https://github.com/civicrm/civicrm-core/pull/30635- but am putting it up separately as it picks up on a discussion we have in Charleston about the location of tests like this & might take more discussion.

There were no core callers of the `create()` function so I added noisy deprecation. For `add` there are so the deprecation is not noisy. I put longer on the indicative removal date for `add` for this reason

Comments
----------------------------------------
