### PR TITLE
Test for clean up of ContributionRecur.add function

### DIFF
--- a/ext/civi_contribute/phpunit.xml.dist
+++ b/ext/civi_contribute/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" cacheResult="false" bootstrap="tests/phpunit/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <testsuites>
+    <testsuite name="civi_contribute Tests">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/ext/civi_contribute/tests/phpunit/Civi/Entity/ContributionRecurTest.php
+++ b/ext/civi_contribute/tests/phpunit/Civi/Entity/ContributionRecurTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Civi\Entity;
+
+use Civi\Api4\ContributionRecur;
+use Civi\Test;
+use Civi\Test\EntityTrait;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * FIXME - Add test description.
+ *
+ * Tips:
+ *  - With HookInterface, you may implement CiviCRM hooks directly in the test class.
+ *    Simply create corresponding functions (e.g. "hook_civicrm_post(...)" or similar).
+ *  - With TransactionalInterface, any data changes made by setUp() or test****() functions will
+ *    rollback automatically -- as long as you don't manipulate schema or truncate tables.
+ *    If this test needs to manipulate schema or truncate tables, then either:
+ *       a. Do all that using setupHeadless() and Civi\Test.
+ *       b. Disable TransactionalInterface, and handle all setup/teardown yourself.
+ *
+ * @group headless
+ */
+class ContributionRecurTest extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  use EntityTrait;
+
+  /**
+   * Setup used when HeadlessInterface is implemented.
+   *
+   * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+   *
+   * @link https://github.com/civicrm/org.civicrm.testapalooza/blob/master/civi-test.md
+   *
+   * @return \Civi\Test\CiviEnvBuilder
+   *
+   * @throws \CRM_Extension_Exception_ParseException
+   */
+  public function setUpHeadless(): CiviEnvBuilder {
+    return Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function testDuplicateCheck(): void {
+    $values = [
+      'contact_id' => $this->createTestEntity('Contact', ['first_name' => 'Bob', 'contact_type' => 'Individual'])['id'],
+      'trxn_id' => 'abc',
+      'amount' => 20,
+    ];
+    ContributionRecur::create(FALSE)
+      ->setValues($values)
+      ->execute();
+    try {
+      ContributionRecur::create(FALSE)
+        ->setValues($values)
+        ->execute();
+    }
+    catch (\CRM_Core_Exception $e) {
+      $this->assertEquals('Found matching recurring contribution(s): 1', $e->getMessage());
+      return;
+    }
+    $this->fail('We should have had an exception');
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function testCurrencyFill(): void {
+    $values = [
+      'contact_id' => $this->createTestEntity('Contact', ['first_name' => 'Bob', 'contact_type' => 'Individual'])['id'],
+      'trxn_id' => 'abc',
+      'amount' => 20,
+    ];
+    $recur = ContributionRecur::create(FALSE)
+      ->setValues($values)
+      ->execute()->first();
+    $this->assertEquals('USD', $recur['currency']);
+  }
+
+}

--- a/ext/civi_contribute/tests/phpunit/bootstrap.php
+++ b/ext/civi_contribute/tests/phpunit/bootstrap.php
@@ -1,0 +1,65 @@
+<?php
+
+ini_set('memory_limit', '2G');
+
+// phpcs:disable
+eval(cv('php:boot --level=classloader', 'phpcode'));
+// phpcs:enable
+// Allow autoloading of PHPUnit helper classes in this extension.
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->add('CRM_', [__DIR__ . '/../..', __DIR__]);
+$loader->addPsr4('Civi\\', [__DIR__ . '/../../Civi', __DIR__ . '/Civi']);
+$loader->add('api_', [__DIR__ . '/../..', __DIR__]);
+$loader->addPsr4('api\\', [__DIR__ . '/../../api', __DIR__ . '/api']);
+
+$loader->register();
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return mixed
+ *   Response output (if the command executed normally).
+ *   For 'raw' or 'phpcode', this will be a string. For 'json', it could be any JSON value.
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv(string $cmd, string $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => STDERR];
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv('CV_OUTPUT=json');
+
+  // Execute `cv` in the original folder. This is a work-around for
+  // phpunit/codeception, which seem to manipulate PWD.
+  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== '/*BEGINPHP*/' || substr(trim($result), -10) !== '/*ENDPHP*/') {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}


### PR DESCRIPTION
Overview
----------------------------------------
Test for clean up of ContributionRecur.add function

This is the test I wrote for https://github.com/civicrm/civicrm-core/pull/30634

Before
----------------------------------------
There is no test

After
----------------------------------------
There is one

Technical Details
----------------------------------------
I've put this test in a separate PR because it builds on a [discussion we had in South Carolina](https://chat.civicrm.org/civicrm/pl/rxuaa5afuin58mfokfiiaz8w3a) (primarily with @colemanw ) about having a location to test entity funcitonality that is accessible via various layers (apiv3, v4, BAO) but does not 'belong' to any of them.

We talked about establishing a `\Civi\Entity` namespace rather than continuing to build out apiv3 & now apiv4 test suites (except where the functionality relates to the apiv3 layer).

When I came to do this it made more sense to add the test to the core-extension.

I was a little frustrated by the fact the handy `individualCreate()` function is specifically apiv3 & would like to think about changing that (non-blocking on this PR) 

Comments
----------------------------------------
