### PR TITLE
DAO - Fix isComponentEnabled function, mark deprecated

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -3577,12 +3577,15 @@ SELECT contact_id
 
   /**
    * Check if component is enabled for this DAO class
-   *
+   * @deprecated
    * @return bool
    */
   public static function isComponentEnabled(): bool {
-    $daoName = static::class;
-    return !defined("$daoName::COMPONENT") || CRM_Core_Component::isEnabled($daoName::COMPONENT);
+    $entityName = CRM_Core_DAO_AllCoreTables::getEntityNameForClass(static::class);
+    if (!$entityName) {
+      return FALSE;
+    }
+    return \Civi\Api4\Utils\CoreUtil::entityExists($entityName);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5337](https://lab.civicrm.org/dev/core/-/issues/5337)

Before
----------------------------------------
CiviCase system checks run unconditionally.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------

Components are no longer tracked in the DAO, this is a workaround but also marking the function @deprecated because we could just as easily do without it.