### PR TITLE
Don't enable Smarty5 by default in UnitTests context

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -260,13 +260,16 @@ if (!defined('CIVICRM_UF_BASEURL')) {
  * the near future - this opt-in setting is transitional.
  */
 if (!defined('CIVICRM_SMARTY_AUTOLOAD_PATH') && getenv('CIVICRM_SMARTY_AUTOLOAD_PATH') === FALSE) {
-  // enable by default for dev & demo sites for now - will soon enable by default for all new installs.
-  if (strpos(CIVICRM_UF_BASEURL, 'localhost') !== FALSE || strpos(CIVICRM_UF_BASEURL, 'demo.civicrm.org') !== FALSE) {
-    if (is_dir($civicrm_root . '/packages')) {
-      define('CIVICRM_SMARTY_AUTOLOAD_PATH', $civicrm_root . '/packages/smarty5/Smarty.php');
-    }
-    elseif (is_dir($civicrm_root . '/../civicrm-packages')) {
-      define('CIVICRM_SMARTY_AUTOLOAD_PATH', $civicrm_root . '/../civicrm-packages/smarty5/Smarty.php');
+  // don't enable by default for testing, until we make the test environment compatible
+  if (CIVICRM_UF !== 'UnitTests') {
+    // enable by default for non-test dev & demo sites for now - will soon enable by default for all new installs.
+    if (strpos(CIVICRM_UF_BASEURL, 'localhost') !== FALSE || strpos(CIVICRM_UF_BASEURL, 'demo.civicrm.org') !== FALSE) {
+      if (is_dir($civicrm_root . '/packages')) {
+        define('CIVICRM_SMARTY_AUTOLOAD_PATH', $civicrm_root . '/packages/smarty5/Smarty.php');
+      }
+      elseif (is_dir($civicrm_root . '/../civicrm-packages')) {
+        define('CIVICRM_SMARTY_AUTOLOAD_PATH', $civicrm_root . '/../civicrm-packages/smarty5/Smarty.php');
+      }
     }
   }
 }


### PR DESCRIPTION
Overview
----------------------------------------
Smarty5 currently breaks PHPUnit tests. Let's not load it by default when running tests.

Before
----------------------------------------
In `civicrm.settings.php`, Smarty 5 is loaded by default in dev & demo sites.

After
----------------------------------------
In `civicrm.settings.php`, Smarty 5 is loaded by default in dev & demo sites EXCEPT in the unit test context.