### PR TITLE
set label for autocomplete on financial account

### DIFF
--- a/schema/Financial/FinancialAccount.entityType.php
+++ b/schema/Financial/FinancialAccount.entityType.php
@@ -10,6 +10,7 @@ return [
     'description' => ts('Financial Accounts'),
     'log' => TRUE,
     'add' => '3.2',
+    'label_field' => 'name',
   ],
   'getPaths' => fn() => [
     'add' => 'civicrm/admin/financial/financialAccount/edit?action=add&reset=1',


### PR DESCRIPTION
Overview
----------------------------------------
The label field wasn't set for the FinancialAccount entity type, so autocomplete wasn't working.

To replicate:
```
$results = \Civi\Api4\FinancialAccount::autocomplete(TRUE)
  ->setInput('bank')
  ->execute();
```

Before
----------------------------------------
Returns nothing.

After
----------------------------------------
Returns financial accounts with "bank" in the name, like "Banking Fees".