### PR TITLE
Financial ACLs shouldn't restrict financial accounts by relationship type

### DIFF
--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -85,6 +85,9 @@ function financialacls_civicrm_pre($op, $objectName, $id, &$params) {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_selectWhereClause
  */
 function financialacls_civicrm_selectWhereClause($entity, &$clauses) {
+  if (CRM_Core_Permission::check([['all CiviCRM permissions and ACLs', 'administer CiviCRM Financial Types']])) {
+    return;
+  }
 
   switch ($entity) {
     case 'LineItem':
@@ -128,7 +131,6 @@ function _financialacls_civicrm_get_accounts_clause(): string {
       $clause = '= 0';
       Civi::$statics['financial_acls'][__FUNCTION__][CRM_Core_Session::getLoggedInContactID()] = &$clause;
       $accounts = (array) EntityFinancialAccount::get()
-        ->addWhere('account_relationship:name', '=', 'Income Account is')
         ->addWhere('entity_table', '=', 'civicrm_financial_type')
         ->addSelect('entity_id', 'financial_account_id')
         ->addJoin('FinancialType AS financial_type', 'LEFT', [

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialAccountTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialAccountTest.php
@@ -21,9 +21,12 @@ class FinancialAccountTest extends BaseTestClass {
     $this->setupLoggedInUserWithLimitedFinancialTypeAccess();
     $financialAccounts = FinancialAccount::get(FALSE)->execute();
     $this->assertCount(14, $financialAccounts);
-    $restrictedAccounts = FinancialAccount::get()->execute();
-    $this->assertCount(1, $restrictedAccounts);
+    $restrictedAccounts = FinancialAccount::get()->addOrderBy('id')->execute();
+    $this->assertCount(4, $restrictedAccounts);
     $this->assertEquals('Donation', $restrictedAccounts[0]['name']);
+    $this->assertEquals('Banking Fees', $restrictedAccounts[1]['name']);
+    $this->assertEquals('Accounts Receivable', $restrictedAccounts[2]['name']);
+    $this->assertEquals('Premiums', $restrictedAccounts[3]['name']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Financial ACLs restrict viewing financial accounts to those with a relationship of "Income Account is".  This is true even for super-admins.

So if you want to make an API call to get all, say, Expense accounts, you can't.

To replicate:
* Run this API call on a demo site (as super-admin) with Financial ACLs disabled:
```php
$financialAccounts = \Civi\Api4\FinancialAccount::get(FALSE)->execute();
```
Enable Financial ACLs and run again, still as super-admin.  

Before
----------------------------------------
Get 4 results.

After
----------------------------------------
Get 9 results.

Comments
----------------------------------------
Advanced mathematicians might notice that 9 != 14.  There are some accounts that, by default, aren't tied to any financial type. IMO those should also be returned, but I'm not sure if that's as clear-cut.  Would appreciate feedback from those with deep knowledge (e.g. @JoeMurray) to see if there's any reason why, e.g., "Premiums Inventory" or "Discounts" account types shouldn't appear in an API call when Financial ACLs are enabled.