### PR TITLE
Fully switch unit tests over to Smarty5

### DIFF
--- a/CRM/Core/CodeGen/Util/MessageTemplates.php
+++ b/CRM/Core/CodeGen/Util/MessageTemplates.php
@@ -248,18 +248,12 @@ class CRM_Core_CodeGen_Util_MessageTemplates {
    * @return string
    */
   protected static function getDirectory($smarty) {
-    if (method_exists($smarty, 'getTemplateDir')) {
-      $directories = $smarty->getTemplateDir();
-    }
-    else {
-      $directories = (array) $smarty->template_dir;
-    }
+    $directories = $smarty->getTemplateDir();
     foreach ($directories as $directory) {
       if (file_exists($directory . '/message_templates/')) {
         return $directory . '/message_templates/';
       }
     }
-
     return $directory . '/message_templates/';
   }
 

--- a/CRM/Core/CodeGen/Util/Smarty.php
+++ b/CRM/Core/CodeGen/Util/Smarty.php
@@ -48,27 +48,13 @@ class CRM_Core_CodeGen_Util_Smarty {
   public function createSmarty(): Smarty {
     $base = dirname(__DIR__, 4);
     $pkgs = file_exists(dirname($base) . "/civicrm-packages") ? dirname($base) . "/civicrm-packages" : "$base/packages";
-    require_once $pkgs . '/smarty4/vendor/autoload.php';
+    require_once $pkgs . '/smarty5/Smarty.php';
     $smarty = new Smarty();
     $smarty->setTemplateDir("$base/xml/templates");
-    $pluginsDirectory = $smarty->getPluginsDir();
-    $pluginsDirectory[] = "$base/CRM/Core/Smarty/plugins";
     // Doesn't seem to work very well.... since I still need require_once below
-    $smarty->setPluginsDir($pluginsDirectory);
+    $smarty->addPluginsDir(["$base/CRM/Core/Smarty/plugins"]);
     $smarty->setCompileDir($this->getCompileDir());
     $smarty->clearAllCache();
-
-    // CRM-5308 / CRM-3507 - we need {localize} to work in the templates
-    require_once 'CRM/Core/Smarty/plugins/block.localize.php';
-    $smarty->registerPlugin('block', 'localize', 'smarty_block_localize');
-
-    // Use our special replace rather than Smarty's to avoid conflicts while we
-    // transition from Smarty2.
-    require_once 'CRM/Core/Smarty/plugins/modifier.crmEscapeSingleQuotes.php';
-    $smarty->registerPlugin('modifier', 'crmEscapeSingleQuotes', 'smarty_modifier_crmEscapeSingleQuotes');
-
-    require_once 'CRM/Core/Smarty/plugins/modifier.crmCountCharacters.php';
-    $smarty->registerPlugin('modifier', 'crmCountCharacters', 'smarty_modifier_crmCountCharacters');
 
     $smarty->registerPlugin('modifier', 'json_encode', 'json_encode');
     $smarty->registerPlugin('modifier', 'count', 'count');

--- a/setup/src/Setup/SmartyUtil.php
+++ b/setup/src/Setup/SmartyUtil.php
@@ -11,25 +11,15 @@ class SmartyUtil {
    */
   public static function createSmarty($srcPath) {
     $packagePath = PackageUtil::getPath($srcPath);
-    require_once $packagePath . '/smarty4/vendor/autoload.php';
+    require_once $packagePath . '/smarty5/Smarty.php';
 
     $smarty = new \Smarty();
     $smarty->setTemplateDir(implode(DIRECTORY_SEPARATOR, [$srcPath, 'xml', 'templates']));
-    $pluginsDirectory = $smarty->getPluginsDir();
-    $pluginsDirectory[] = implode(DIRECTORY_SEPARATOR, [$srcPath, 'CRM', 'Core', 'Smarty', 'plugins']);
-    // Doesn't seem to work very well.... since I still need require_once below
-    $smarty->setPluginsDir($pluginsDirectory);
+    $pluginsDirectory = $smarty->addPluginsDir([
+      implode(DIRECTORY_SEPARATOR, [$srcPath, 'CRM', 'Core', 'Smarty', 'plugins']),
+    ]);
     $smarty->setCompileDir(\Civi\Setup\FileUtil::createTempDir('templates_c'));
     $smarty->clearAllCache();
-
-    require_once 'CRM/Core/Smarty/plugins/modifier.crmEscapeSingleQuotes.php';
-    $smarty->registerPlugin('modifier', 'crmEscapeSingleQuotes', 'smarty_modifier_crmEscapeSingleQuotes');
-
-    // CRM-5308 / CRM-3507 - we need {localize} to work in the templates
-    require_once implode(DIRECTORY_SEPARATOR, [$srcPath, 'CRM', 'Core', 'Smarty', 'plugins', 'block.localize.php']);
-    $smarty->registerPlugin('block', 'localize', 'smarty_block_localize');
-    require_once 'CRM/Core/Smarty/plugins/modifier.crmCountCharacters.php';
-    $smarty->registerPlugin('modifier', 'crmCountCharacters', 'smarty_modifier_crmCountCharacters');
     require_once implode(DIRECTORY_SEPARATOR, [$srcPath, 'CRM', 'Core', 'CodeGen', 'Util', 'MessageTemplates.php']);
     $smarty->registerPlugin('modifier', 'json_encode', 'json_encode');
     $smarty->registerPlugin('modifier', 'count', 'count');

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -261,7 +261,9 @@ if (!defined('CIVICRM_UF_BASEURL')) {
  */
 if (!defined('CIVICRM_SMARTY_AUTOLOAD_PATH') && getenv('CIVICRM_SMARTY_AUTOLOAD_PATH') === FALSE) {
   // enable by default for dev & demo sites for now - will soon enable by default for all new installs.
-  if (strpos(CIVICRM_UF_BASEURL, 'localhost') !== FALSE || strpos(CIVICRM_UF_BASEURL, 'demo.civicrm.org') !== FALSE) {
+  if (CIVICRM_UF === 'UnitTests' || strpos(CIVICRM_UF_BASEURL, 'localhost') !== FALSE || strpos(CIVICRM_UF_BASEURL, 'demo.civicrm.org') !== FALSE
+    || strpos(CIVICRM_UF_BASEURL, 'http://build') !== FALSE
+  ) {
     if (is_dir($civicrm_root . '/packages')) {
       define('CIVICRM_SMARTY_AUTOLOAD_PATH', $civicrm_root . '/packages/smarty5/Smarty.php');
     }


### PR DESCRIPTION
Overview
----------------------------------------
We are still running Gencode using Smarty4 - which conflicts with Smarty5 in the unit test context - this fixes to fully use Smarty5

Before
----------------------------------------
Potential mix of Smarty4 & Smarty5

After
----------------------------------------
Smarty5

Technical Details
----------------------------------------
Alternative to https://github.com/civicrm/civicrm-core/pull/30640

Comments
----------------------------------------
