### PR TITLE
DAO - Fix isComponentEnabled function, mark deprecated

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -3577,12 +3577,15 @@ SELECT contact_id
 
   /**
    * Check if component is enabled for this DAO class
-   *
+   * @deprecated
    * @return bool
    */
   public static function isComponentEnabled(): bool {
-    $daoName = static::class;
-    return !defined("$daoName::COMPONENT") || CRM_Core_Component::isEnabled($daoName::COMPONENT);
+    $entityName = CRM_Core_DAO_AllCoreTables::getEntityNameForClass(static::class);
+    if (!$entityName) {
+      return FALSE;
+    }
+    return \Civi\Api4\Utils\CoreUtil::entityExists($entityName);
   }
 
   /**


### PR DESCRIPTION
Port https://github.com/civicrm/civicrm-core/pull/30636

The issue was reported in 5.75 - see https://civicrm.stackexchange.com/questions/48320/errors-like-missing-case-type-defintion-and-invalid-case-type-name-on-upgrad

Fixes dev/core#5337
Components are no longer tracked in the DAO, this is a workaround but also marking the function @deprecated because we could just as easily do without it.