### PR TITLE
[REF] Ensure that schedule reminder listing is only avaliable to logg…

### DIFF
--- a/CRM/Core/xml/Menu/Admin.xml
+++ b/CRM/Core/xml/Menu/Admin.xml
@@ -298,7 +298,6 @@
      <title>Schedule Reminders</title>
      <desc>Schedule Reminders.</desc>
      <page_callback>CRM_Admin_Page_ScheduleReminders</page_callback>
-     <access_callback>1</access_callback>
      <access_arguments>administer CiviCRM data</access_arguments>
      <adminGroup>Communications</adminGroup>
      <weight>40</weight>
@@ -307,7 +306,6 @@
      <path>civicrm/admin/scheduleReminders/edit</path>
      <title>Schedule Reminders</title>
      <page_callback>CRM_Admin_Form_ScheduleReminders</page_callback>
-     <access_callback>1</access_callback>
      <access_arguments>administer CiviCRM data;edit all events</access_arguments>
   </item>
   <item>


### PR DESCRIPTION
…ed in users

Overview
----------------------------------------
This aims to fix a bug that is specific to Drupal 10 but seems awefully silly IMO. The schedule Reminders Listing is available publicly in Drupal 10 but so far not seen on other CMSes

Before
----------------------------------------
Url can be visited by Anon users

After
----------------------------------------
Url Can't be visited as Anon

Technical Details
----------------------------------------
Based on my interpretation of this https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Permission.php#L539 we by-pass the access_arguments completely if access_callback is 1. For Drupal 10 that relies on the menu route this means essentially public access.  In @colemanw's recent work he removed a Permission Check status bounce on the listing https://github.com/civicrm/civicrm-core/commit/dc742067004cb2e47bed3d55387e2ed3fbfd72b6#diff-7d3110fd59b9d3b7dbefb079dfa354453b08961fda778561fb4691e99427d0faL75 which I think might have been there preventing this from showing up. 

I haven't checked if this has any impact on ACLed event administrators usage of the Reminders Tab in Manage Event 

ping @JoeMurray @eileenmcnaughton @stesi561 
