### PR TITLE
[NFC] Remove unused variable

### DIFF
--- a/CRM/Badge/BAO/Badge.php
+++ b/CRM/Badge/BAO/Badge.php
@@ -365,6 +365,8 @@ class CRM_Badge_BAO_Badge {
       $y = $this->pdf->GetY();
     }
 
+    $imgRes = 300;
+
     if ($img) {
       [$w, $h] = self::getImageProperties($img, 300, $w, $h);
       $this->pdf->Image($img, $x, $y, $w, $h, '', '', '', FALSE, 72, '', FALSE,


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused variable

Before
----------------------------------------
`$imgRes` is defined within `printImage()`, but not used.

It appears it was intended to be used as the second argument to `getImageProperties` (3 lines further down), but instead the 300 is hardcoded.

After
----------------------------------------
Unused variable removed.
