### PR TITLE
Fix duplicate key so all SearchTest cases run correctly

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/SearchTest.php
@@ -615,7 +615,7 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
         'expected_qill' => "Recurring Contribution Status = 'Cancelled'",
       ],
       // Case 4: Search for contributions with is_template = 1
-      'in_progress_search' => [
+      'is_template_search' => [
         'form_value' => ['contribution_is_template' => 1],
         'expected_count' => 1,
         'expected_contact' => ['Mr. Joe Miller II'],


### PR DESCRIPTION
Overview
----------------------------------------
Fix duplicate key so all SearchTest cases run correctly.

Before
----------------------------------------
The `in_progress_search` key was declared twice, and so the first test case using that key was not run.

After
----------------------------------------
Unique keys are used, and so all the test cases run.


Comments
----------------------------------------
I think there is an argument for removing the key's to stop this happening again, but for now have just changed the single problematic key.
