### PR TITLE
Don't crash if we are recording a contribution, outbound email is disabled and we try to send a receipt

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -931,8 +931,13 @@ trait CRM_Contact_Form_Task_EmailTrait {
       'attachments' => $attachments,
     ];
 
-    if (!CRM_Utils_Mail::send($mailParams)) {
-      return FALSE;
+    try {
+      if (!CRM_Utils_Mail::send($mailParams)) {
+        return FALSE;
+      }
+    }
+    catch (\Exception $e) {
+      CRM_Core_Error::statusBounce($e->getMessage());
     }
 
     // add activity target record for every mail that is send

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3700,11 +3700,16 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     }
 
     if (self::isEmailReceipt($input, $contributionID, $recurringContributionID)) {
-      civicrm_api3('Contribution', 'sendconfirmation', [
-        'id' => $contributionID,
-        'payment_processor_id' => $paymentProcessorId,
-      ]);
-      \Civi::log()->info("Contribution {$contributionParams['id']} Receipt sent");
+      try {
+        civicrm_api3('Contribution', 'sendconfirmation', [
+          'id' => $contributionID,
+          'payment_processor_id' => $paymentProcessorId,
+        ]);
+        \Civi::log()->info("Contribution {$contributionParams['id']} Receipt sent");
+      }
+      catch (Exception $e) {
+        \Civi::log()->warning("Contribution {$contributionParams['id']} Failed to send receipt: " . $e->getMessage());
+      }
     }
 
     return $contributionResult;

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -99,12 +99,12 @@ class CRM_Utils_Mail {
     }
     elseif ($mailingInfo['outBound_option'] == CRM_Mailing_Config::OUTBOUND_OPTION_DISABLED) {
       Civi::log()->info(ts('Outbound mail has been disabled. Click <a href=\'%1\'>Administer >> System Setting >> Outbound Email</a> to set the OutBound Email.', [1 => CRM_Utils_System::url('civicrm/admin/setting/smtp', 'reset=1')]));
-      CRM_Core_Error::statusBounce(ts('Outbound mail has been disabled. Click <a href=\'%1\'>Administer >> System Setting >> Outbound Email</a> to set the OutBound Email.', [1 => CRM_Utils_System::url('civicrm/admin/setting/smtp', 'reset=1')]));
+      throw new CRM_Core_Exception(ts('Outbound mail has been disabled. Click <a href=\'%1\'>Administer >> System Setting >> Outbound Email</a> to set the OutBound Email.', [1 => CRM_Utils_System::url('civicrm/admin/setting/smtp', 'reset=1')]));
     }
     else {
       Civi::log()->error(ts('There is no valid SMTP server Setting Or SendMail path setting. Click <a href=\'%1\'>Administer >> System Setting >> Outbound Email</a> to set the OutBound Email.', [1 => CRM_Utils_System::url('civicrm/admin/setting/smtp', 'reset=1')]));
       CRM_Core_Error::debug_var('mailing_info', $mailingInfo);
-      CRM_Core_Error::statusBounce(ts('There is no valid SMTP server Setting Or sendMail path setting. Click <a href=\'%1\'>Administer >> System Setting >> Outbound Email</a> to set the OutBound Email.', [1 => CRM_Utils_System::url('civicrm/admin/setting/smtp', 'reset=1')]));
+      throw new CRM_Core_Exception(ts('There is no valid SMTP server Setting Or sendMail path setting. Click <a href=\'%1\'>Administer >> System Setting >> Outbound Email</a> to set the OutBound Email.', [1 => CRM_Utils_System::url('civicrm/admin/setting/smtp', 'reset=1')]));
     }
     return $mailer;
   }

--- a/tests/phpunit/api/v3/JobProcessMailingTest.php
+++ b/tests/phpunit/api/v3/JobProcessMailingTest.php
@@ -283,11 +283,11 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
       $this->fail('should not be reachable');
     }
     catch (\CRM_Core_Exception $e) {
-      $this->assertEquals('civiExit called', $e->getMessage());
+      $this->assertEquals('Outbound mail has been disabled', substr($e->getMessage(), 0, 31));
       $statuses = CRM_Core_Session::singleton()->getStatus();
       $hasExpectedMessage = FALSE;
       foreach ($statuses as $status) {
-        if (str_contains($status['text'], 'Outbound mail has been disabled')) {
+        if (str_contains($status['text'], 'Outbound emails have been disabled')) {
           $hasExpectedMessage = TRUE;
           break;
         }


### PR DESCRIPTION
Overview
----------------------------------------
Set "Outbound Email" to disabled.

Then:
Trigger `CRM_Contribute_BAO_Contribution::completeOrder()` eg. by recording a payment on a contribution that completes an order and you request a receipt (ie. set `is_send_email_receipt` to TRUE on API3 Payment.create which is the default..).

Before
----------------------------------------
Crash, it all falls over.

After
----------------------------------------
You get a helpful message in the logs:
`[warning] Contribution 615632 Failed to send receipt: Outbound mail has been disabled. Click [Administer >> System Setting >> Outbound Email](https://[removed.org]/civicrm/admin/setting/smtp?reset=1) to set the OutBound Email.`
and it all continues to process (except for sending the receipt, obviously, as email is disabled).

Technical Details
----------------------------------------
Why on earth we have `statusBounce()` right down in CRM_Utils_Mail we'll never know. And even better, only if you select certain options. Otherwise it'll do something sensible, like, throw an exception.

But even if you throw an exception we don't catch it and it goes all the way back up the stack. So we wrap a try/catch around the send email bit since it seems pretty reasonable to allow an email to fail and still record the fact that you've got some money properly (technically it does record a contribution but then fails with any other bits, eg custom fields and post processing).


Comments
----------------------------------------
Why do I always fall down the rabbit holes?
