### PR TITLE
dev/core#5338 Fix participant import regression

### DIFF
--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -84,8 +84,8 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
         if (!$this->isUpdateExisting()) {
           throw new CRM_Core_Exception(ts('% record found and update not selected', [1 => 'Participant']));
         }
-        $newParticipant = CRM_Event_BAO_Participant::create($formatted);
-        $this->setImportStatus($rowNumber, 'IMPORTED', '', $newParticipant->id);
+        $newParticipant = civicrm_api3('Participant', 'create', $formatted);
+        $this->setImportStatus($rowNumber, 'IMPORTED', '', $newParticipant['id']);
         return;
       }
 

--- a/tests/phpunit/CRM/Event/Import/Parser/data/cancel_participant.csv
+++ b/tests/phpunit/CRM/Event/Import/Parser/data/cancel_participant.csv
@@ -1,3 +1,3 @@
-id,Status
-1,Cancelled
-2,Cancelled
+id,Status,Yes-no-field
+1,Cancelled,yes
+2,Cancelled,no


### PR DESCRIPTION


Overview
----------------------------------------
dev/core#5338 Fix participant import regression 
This specifically affects custom data when combined with an update to an existing participant record

https://lab.civicrm.org/dev/core/-/issues/5338

Before
----------------------------------------
When importing a custom field WITH participant ID specified the custom field was not imported

After
----------------------------------------
fixed, test added

Technical Details
----------------------------------------
this issue was specifically in the with-id flow because that flow was using the BAO action which relied on the custom field being pre-formatted. Now all paths use the api

Comments
----------------------------------------
