### PR TITLE
dev/core#5343 Fix failure to load membership custom data on initial load

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -224,7 +224,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     }
 
     $this->assign('customDataType', 'Membership');
-    $this->assign('customDataSubType', $this->_memType);
+    $this->assign('customDataSubType', $this->getMembershipValue('membership_type_id'));
 
     $this->setPageTitle(ts('Membership'));
   }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5343 Fix failure to load membership custom data on initial load

Before
----------------------------------------
As described in https://lab.civicrm.org/dev/core/-/issues/5343

After
----------------------------------------
Loads on initial load

Technical Details
----------------------------------------
The membership type was not assigned

Comments
----------------------------------------
