### PR TITLE
Eliminate unnecessary calculations and conversions when setting the minDate and maxDate

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -2065,12 +2065,12 @@ class CRM_Utils_Date {
       $extra['date'] = $field['date_format'];
       $extra['time'] = $field['time_format'];
     }
-    $thisYear = date('Y');
+    $todayMD = date('-m-d');
     if (isset($field['start_date_years'])) {
-      $extra['minDate'] = date('Y-m-d', strtotime((-1 * ($thisYear - $field['start_date_years'])) . ' years'));
+      $extra['minDate'] = $field['start_date_years'] . $todayMD;
     }
     if (isset($field['end_date_years'])) {
-      $extra['maxDate'] = date('Y-m-d', strtotime((-1 * ($thisYear - $field['end_date_years'])) . ' years'));
+      $extra['maxDate'] = $field['end_date_years'] . $todayMD;
     }
     return $extra;
   }


### PR DESCRIPTION
Overview
----------------------------------------
This PR is simply an optimization to the setting of the date picker minDate and maxDate variables.  This eliminates two of the three calls to `date()` and it eliminates both of the calls to `strtotime()`.

Before
----------------------------------------
Prior to this optimization, the minDate was being calculated by subtracting the minYear from the current year to get the year offset, then converting that year offset to a string.  The string is then fed into `strtotime()` to calculate the Unix timestamp of the minimum date.  That Unix timestamp is then converted to YYYY-MM-DD format.  A similar calculation was performed for the maxDate.

After
----------------------------------------
Since the minYear and maxYear are already known, there is no need to convert them to year offsets, only to convert them back to YYYY-MM-DD dates.  This optimization uses the minYear and maxYear as is, and appends the current month and day as "-MM-DD".

Technical Details
----------------------------------------
This is a simple and straightforward optimization.

Comments
----------------------------------------
n/a