### PR TITLE
Fix handling on Contribution token on unpaid event 

### DIFF
--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -183,6 +183,9 @@ class TokenRow {
    */
   public function customToken($entity, $customFieldID, $entityID) {
     $customFieldName = 'custom_' . $customFieldID;
+    if (empty($entityID)) {
+      return $this->format('text/html')->tokens($entity, $customFieldName, '');
+    }
     $record = civicrm_api3($entity, 'getSingle', [
       'return' => $customFieldName,
       'id' => $entityID,

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -26,6 +26,8 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
   use CRMTraits_Custom_CustomDataTrait;
 
   public function tearDown(): void {
+    $this->cleanupCustomGroups();
+    $this->quickCleanup(['civicrm_custom_group', 'civicrm_custom_field']);
     $this->quickCleanUpFinancialEntities();
     $this->revertTemplateToReservedTemplate();
     parent::tearDown();
@@ -87,6 +89,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
     $this->createCustomGroupWithFieldOfType(['extends' => 'Contribution']);
     MessageTemplate::update()
       ->addWhere('is_default', '=', TRUE)
+      ->addWhere('is_reserved', '=', FALSE)
       ->addWhere('workflow_name', '=', 'event_offline_receipt')
       ->setValues(['msg_subject' => 'hey {contribution.' . $this->getCustomFieldName() . '}you'])
       ->execute();

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2595,7 +2595,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       INNER JOIN civicrm_msg_template m2
         ON m2.workflow_name = m.workflow_name AND m2.is_reserved = 1
         AND m.is_default = 1
-      SET m.msg_html = m2.msg_html, m.msg_text = m2.msg_text
+      SET m.msg_html = m2.msg_html, m.msg_text = m2.msg_text, m.msg_subject = m2.msg_subject
     ');
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix handling on Contribution token on unpaid event 


This is a port of @pradpnayak's patch from https://github.com/civicrm/civicrm-core/pull/30633 

Before
----------------------------------------
Fatal error when processing an event registration with 
1) receipt enabled
2) paid event processing disabled
3) a contribution token in the template

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
Per the original patch - there is no attempt to `getsingle` for the entity if the id is NULL or ''

Comments
----------------------------------------
