### PR TITLE
Exclude activity details (i.e. HTML content) from purification for "Create Document" task

### DIFF
--- a/CRM/Contact/Form/Task/PDF.php
+++ b/CRM/Contact/Form/Task/PDF.php
@@ -105,6 +105,17 @@ class CRM_Contact_Form_Task_PDF extends CRM_Contact_Form_Task {
   }
 
   /**
+   * {@inheritDoc}
+   */
+  protected function getFieldsToExcludeFromPurification(): array {
+    return [
+      'details',
+      'activity_details',
+      'html_message',
+    ];
+  }
+
+  /**
    * Build the form object.
    *
    * @throws \CRM_Core_Exception


### PR DESCRIPTION
Overview
----------------------------------------

- Introduced with `5.72` in #29532 (682ca196deba8e78d35e9a3363a026ff61e59513), all Core forms have purification applied to their default values. This causes HTML in things to be rendered with *Smarty* be purified, essentially removing styling etc.
- [dev/core#5176](https://lab.civicrm.org/dev/core/-/issues/5176) and #30081 fixed that for message template forms
- This PR fixes that for the "Create Document" task form, which, for already created documents, allows to re-compose it via the "Edit" button in the activities list.

Before
----------------------------------------
When "editing" an activity of the type "Create Document", the form is actually the "Create Document" form with default values from the activity (the `details` field containing the message body). However, that field's content gets purified when it shouldn't.

After
----------------------------------------
Relevant default values (`details`, `activity_details`, `html_message`) are excluded from purification.

Technical Details
----------------------------------------
Not sure if all three are necessary, but they all contain the `details` field's value, so keeping them in sync seems correct to me.

Comments
----------------------------------------
This might affect more forms - this is just one scenario we came across.
