### PR TITLE
Add Ken Zalewski to list of CiviCRM contributors

### DIFF
--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -937,6 +937,10 @@
   name        : Kurund Jalmi
   organization: Third Sector Design
 
+- github      : kzalewski
+  name        : Ken Zalewski
+  organization: New York State Senate
+
 - github      : lalgwebdev
   name        : Tony Maynard-Smith
 


### PR DESCRIPTION

Overview
----------------------------------------
See title

Before
----------------------------------------
The Senate has actually been contributing to the CiviCRM project since 2010.  Until now, all of our contributions have funneled through Brian Shaughnessy.  After 14 years of working with CiviCRM and the core team, I figured it was time to start making direct contributions to the codebase.

After
----------------------------------------
Only time will tell.

Technical Details
----------------------------------------
Just a textual change to a Yaml file.

Comments
----------------------------------------
Thank you to the many developers, designers, and technical writers who have contributed to this project over the years.  CiviCRM is a core part of our constituent services at the New York Senate.