### PR TITLE
Api4 - Use EntityRepository for metadata instead of legacy DAOs

### DIFF
--- a/Civi/Api4/Generic/Traits/EntityBridge.php
+++ b/Civi/Api4/Generic/Traits/EntityBridge.php
@@ -28,11 +28,10 @@ trait EntityBridge {
   public static function getInfo() {
     $info = parent::getInfo();
     $bridgeFields = [];
-    if (!empty($info['dao'])) {
-      foreach (($info['dao'])::fields() as $field) {
-        if (!empty($field['FKClassName']) || $field['name'] === 'entity_id') {
-          $bridgeFields[] = $field['name'];
-        }
+    $entity = \Civi::entity(self::getEntityName());
+    foreach ($entity->getFields() as $fieldName => $field) {
+      if (!empty($field['entity_reference'])) {
+        $bridgeFields[] = $fieldName;
       }
     }
     if (count($bridgeFields) === 2) {

--- a/Civi/Api4/Query/SqlExpression.php
+++ b/Civi/Api4/Query/SqlExpression.php
@@ -210,6 +210,13 @@ abstract class SqlExpression {
   }
 
   /**
+   * Get value serialization method if any.
+   */
+  public function getSerialize(): ?int {
+    return NULL;
+  }
+
+  /**
    * @return string
    */
   abstract public static function getTitle(): string;

--- a/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
@@ -62,7 +62,7 @@ class SqlFunctionGROUP_CONCAT extends SqlFunction {
   public function formatOutputValue(?string &$dataType, array &$values, string $key): void {
     $exprArgs = $this->getArgs();
     // By default, values are split into an array and formatted according to the field's dataType
-    if (isset($exprArgs[2]['expr'][0]->expr) && $exprArgs[2]['expr'][0]->expr === \CRM_Core_DAO::VALUE_SEPARATOR) {
+    if ($this->getSerialize()) {
       $values[$key] = explode(\CRM_Core_DAO::VALUE_SEPARATOR, $values[$key]);
       // If the first expression is a SqlFunction/SqlEquation, allow it to control the dataType
       if (method_exists($exprArgs[0]['expr'][0], 'formatOutputValue')) {
@@ -86,6 +86,14 @@ class SqlFunctionGROUP_CONCAT extends SqlFunction {
     else {
       $dataType = 'String';
     }
+  }
+
+  public function getSerialize(): ?int {
+    $exprArgs = $this->getArgs();
+    if (($exprArgs[2]['expr'][0]->expr ?? NULL) === \CRM_Core_DAO::VALUE_SEPARATOR) {
+      return \CRM_Core_DAO::SERIALIZE_SEPARATOR_TRIMMED;
+    }
+    return NULL;
   }
 
   /**

--- a/Civi/Schema/EntityProvider.php
+++ b/Civi/Schema/EntityProvider.php
@@ -40,6 +40,22 @@ final class EntityProvider {
     return $this->getMetaProvider()->getFields();
   }
 
+  public function getSupportedFields(): array {
+    $fields = $this->getMetaProvider()->getFields();
+    if ($this->getMeta('module') === 'civicrm') {
+      // Exclude fields yet not added by pending upgrades
+      $dbVer = \CRM_Core_BAO_Domain::version();
+      $fields = array_filter($fields, function($field) use ($dbVer) {
+        $add = $field['add'] ?? '1.0.0';
+        if (substr_count($add, '.') < 2) {
+          $add .= '.alpha1';
+        }
+        return version_compare($dbVer, $add, '>=');
+      });
+    }
+    return $fields;
+  }
+
   public function getField(string $fieldName): ?array {
     return $this->getFields()[$fieldName] ?? NULL;
   }

--- a/Civi/Schema/LegacySqlEntityMetadata.php
+++ b/Civi/Schema/LegacySqlEntityMetadata.php
@@ -58,7 +58,7 @@ class LegacySqlEntityMetadata extends EntityMetadataBase {
     foreach ($this->getClassName()::fields() as $uniqueName => $legacyField) {
       $fieldName = $legacyField['name'];
       $field = [
-        'title' => $legacyField['title'],
+        'title' => $legacyField['title'] ?? $fieldName,
         'sql_type' => $this->getSqlType($legacyField),
         'input_type' => $legacyField['html']['type'] ?? NULL,
         'description' => $legacyField['description'] ?? NULL,

--- a/ext/civiimport/Civi/Api4/Import/ImportSpecProvider.php
+++ b/ext/civiimport/Civi/Api4/Import/ImportSpecProvider.php
@@ -41,6 +41,35 @@ class ImportSpecProvider extends AutoService implements SpecProviderInterface {
       // table is deleted - & hence we get an error.
       return;
     }
+    // Common fields
+    $field = new FieldSpec('_id', $spec->getEntity(), 'Int');
+    $field->setTitle(E::ts('Import row ID'));
+    $field->setType('Field');
+    $field->setInputType('Number');
+    $field->setReadonly(TRUE);
+    $field->setNullable(FALSE);
+    $field->setColumnName('_id');
+    $spec->addFieldSpec($field);
+
+    $field = new FieldSpec('_status', $spec->getEntity(), 'String');
+    $field->setTitle(E::ts('Import row status'));
+    $field->setType('Field');
+    $field->setInputType('Text');
+    $field->setReadonly(TRUE);
+    $field->setRequired(TRUE);
+    $field->setNullable(FALSE);
+    $field->setColumnName('_status');
+    $spec->addFieldSpec($field);
+
+    $field = new FieldSpec('_status_message', $spec->getEntity(), 'String');
+    $field->setTitle(E::ts('Import row message'));
+    $field->setType('Field');
+    $field->setInputType('Text');
+    $field->setReadonly(TRUE);
+    $field->setNullable(TRUE);
+    $field->setColumnName('_status_message');
+    $spec->addFieldSpec($field);
+
     $userJobType = $this->getJobType($spec);
     foreach ($columns as $column) {
       $isInternalField = strpos($column['name'], '_') === 0;

--- a/ext/civiimport/Civi/BAO/Import.php
+++ b/ext/civiimport/Civi/BAO/Import.php
@@ -62,54 +62,6 @@ class Import extends CRM_Core_DAO {
   }
 
   /**
-   * Returns fields generic to all imports, indexed by name.
-   *
-   * This function could arguably go, leaving it to the `ImportSpecProvider`
-   * which adds all the other fields. But it does have the nice side effect of
-   * putting these three fields first in a natural sort.
-   *
-   * @param bool $checkPermissions
-   *   Filter by field permissions.
-   * @return array
-   */
-  public static function getSupportedFields($checkPermissions = FALSE): array {
-    return [
-      '_id' => [
-        'type' => 'Field',
-        'required' => FALSE,
-        'nullable' => FALSE,
-        'readonly' => TRUE,
-        'name' => '_id',
-        'title' => E::ts('Import row ID'),
-        'data_type' => 'Integer',
-        'input_type' => 'Number',
-        'column_name' => '_id',
-      ],
-      '_status' => [
-        'type' => 'Field',
-        'required' => TRUE,
-        // We should add a requeue action or just define an option group but for now..
-        'readonly' => TRUE,
-        'nullable' => FALSE,
-        'name' => '_status',
-        'title' => E::ts('Row status'),
-        'data_type' => 'String',
-        'column_name' => '_status_message',
-      ],
-      '_status_message' => [
-        'type' => 'Field',
-        'nullable' => TRUE,
-        'readonly' => TRUE,
-        'name' => '_status_message',
-        'title' => E::ts('Row import message'),
-        'description' => '',
-        'data_type' => 'String',
-        'column_name' => '_status_message',
-      ],
-    ];
-  }
-
-  /**
    * Over-ride the parent to prevent a NULL return.
    *
    * Metadata otherwise handled in `table()`, `writeRecord` and `ImportSpecProvider`

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
@@ -126,7 +126,7 @@ class SKEntitySubscriber extends AutoService implements EventSubscriberInterface
 
   /**
    * @param array $column
-   * @param array{fields: array, expr: SqlExpression, dataType: string} $expr
+   * @param array{fields: array, expr: \Civi\Api4\Query\SqlExpression, dataType: string} $expr
    * @return array
    */
   private function formatFieldSpec(array $column, array $expr): array {
@@ -140,8 +140,10 @@ class SKEntitySubscriber extends AutoService implements EventSubscriberInterface
       'suffixes' => $suffix ? ['id', $suffix] : NULL,
       'options' => FALSE,
     ];
+    $field = \CRM_Utils_Array::first($expr['fields']);
+    $spec['original_field_name'] = $field['name'] ?? NULL;
+    $spec['original_field_entity'] = $field['entity'] ?? NULL;
     if ($expr['expr']->getType() === 'SqlField') {
-      $field = \CRM_Utils_Array::first($expr['fields']);
       // An entity id counts as a FK
       if (!$field['fk_entity'] && $field['name'] === CoreUtil::getIdFieldName($field['entity'])) {
         $spec['entity_reference'] = [
@@ -152,22 +154,34 @@ class SKEntitySubscriber extends AutoService implements EventSubscriberInterface
       else {
         $originalField = \Civi::entity($field['entity'])->getField($field['name']);
         $spec['input_type'] = $originalField['input_type'] ?? NULL;
+        $spec['serialize'] = $originalField['serialize'] ?? NULL;
         $spec['entity_reference'] = $originalField['entity_reference'] ?? NULL;
       }
-      $spec['original_field_name'] = $field['name'];
-      $spec['original_field_entity'] = $field['entity'];
       if ($suffix) {
         // Options will be looked up by SKEntitySpecProvider::getOptionsForSKEntityField
         $spec['options'] = TRUE;
       }
     }
     elseif ($expr['expr']->getType() === 'SqlFunction') {
+      // For functions that have options, e.g. SqlFunctionDAYOFWEEK
       if ($suffix) {
         $spec['options'] = CoreUtil::formatOptionList($expr['expr']::getOptions(), $spec['suffixes']);
         $spec['input_type'] = 'Select';
       }
+      // For field options that pass through the function, e.g. SqlFunctionGROUP_CONCAT
+      elseif (!empty($field['suffixes']) && $spec['data_type'] === $field['data_type']) {
+        $spec['input_type'] = 'Select';
+        $spec['options'] = TRUE;
+        $spec['suffixes'] = $field['suffixes'];
+      }
       else {
         $spec['input_type'] = $this->getInputTypeFromDataType($spec['data_type']);
+      }
+      if ($expr['expr']->getSerialize()) {
+        $spec['serialize'] = $expr['expr']->getSerialize();
+      }
+      elseif ($spec['data_type'] === $field['data_type']) {
+        $spec['serialize'] = $field['serialize'] ?? NULL;
       }
     }
     return $spec;
@@ -175,21 +189,23 @@ class SKEntitySubscriber extends AutoService implements EventSubscriberInterface
 
   /**
    * @param array $column
-   * @param array{fields: array, expr: SqlExpression, dataType: string} $expr
+   * @param array{fields: array, expr: \Civi\Api4\Query\SqlExpression, dataType: string} $expr
    * @return array
    */
   private function formatSQLSpec(array $column, array $expr): array {
-    // Try to use the exact sql column type as the original field
     $field = \CRM_Utils_Array::first($expr['fields']);
-    if (!empty($field['column_name']) && !empty($field['table_name'])) {
+    // Store serialized values as text
+    if ($expr['expr']->getSerialize()) {
+      $type = 'text';
+    }
+    // Try to use the exact sql column type as the original field
+    elseif (!empty($field['column_name']) && !empty($field['table_name']) && $field['data_type'] === $expr['dataType']) {
       $columns = \CRM_Core_DAO::executeQuery("DESCRIBE `{$field['table_name']}`")
         ->fetchMap('Field', 'Type');
       $type = $columns[$field['column_name']] ?? NULL;
     }
-    // If we can't get the exact data type from the column, take an educated guess
-    if (empty($type) ||
-      ($expr['expr']->getType() !== 'SqlField' && $field['data_type'] !== $expr['dataType'])
-    ) {
+    // If we can't get the data type from the column, take an educated guess
+    if (empty($type)) {
       $map = [
         'Array' => 'text',
         'Boolean' => 'tinyint',
@@ -211,8 +227,7 @@ class SKEntitySubscriber extends AutoService implements EventSubscriberInterface
     // Add FK indexes
     if ($expr['expr']->getType() === 'SqlField' && !empty($field['fk_entity'])) {
       $defn['fk_table_name'] = CoreUtil::getTableName($field['fk_entity']);
-      // FIXME look up fk_field_name from schema, don't assume it's always "id"
-      $defn['fk_field_name'] = 'id';
+      $defn['fk_field_name'] = $field['fk_column'];
       $defn['fk_attributes'] = ' ON DELETE SET NULL';
     }
     return $defn;
@@ -230,6 +245,7 @@ class SKEntitySubscriber extends AutoService implements EventSubscriberInterface
 
   private function getInputTypeFromDataType(string $dataType): ?string {
     $dataTypeToInputType = [
+      'Array' => 'Text',
       'Boolean' => 'Radio',
       'Date' => 'Date',
       'Float' => 'Number',

--- a/ext/search_kit/Civi/Api4/Service/Spec/Provider/SKEntitySpecProvider.php
+++ b/ext/search_kit/Civi/Api4/Service/Spec/Provider/SKEntitySpecProvider.php
@@ -12,7 +12,6 @@
 
 namespace Civi\Api4\Service\Spec\Provider;
 
-use Civi\Api4\Service\Spec\FieldSpec;
 use Civi\Api4\Service\Spec\Provider\Generic\SpecProviderInterface;
 use Civi\Api4\Service\Spec\RequestSpec;
 use Civi\Core\Service\AutoService;
@@ -34,24 +33,12 @@ class SKEntitySpecProvider extends AutoService implements SpecProviderInterface 
       if ($entityDisplay['entityName'] !== $entityName) {
         continue;
       }
-      // Primary key field
-      $field = new FieldSpec('_row', $entityName, 'Int');
-      $field->setTitle(E::ts('Row'));
-      $field->setLabel(E::ts('Row'));
-      $field->setType('Field');
-      $field->setDescription('Search result row number');
-      $field->setColumnName('_row');
-      $spec->addFieldSpec($field);
-
       foreach ($entityDisplay['settings']['columns'] as $column) {
-        $field = new FieldSpec($column['spec']['name'], $entityName, $column['spec']['data_type']);
-        $field->setTitle($column['label']);
-        $field->setLabel($column['label']);
-        $field->setType('Field');
-        $field->setFkEntity($column['spec']['fk_entity']);
-        $field->setColumnName($column['spec']['name']);
-        $field->setSuffixes($column['spec']['suffixes']);
+        // Add pseudoconstant options
+        // TODO: This could probably be handled in SkEntityMetaProvider
         if (!empty($column['spec']['options'])) {
+          $field = $spec->getFieldByName($column['spec']['name']);
+          $field->setSuffixes($column['spec']['suffixes']);
           if (is_array($column['spec']['options'])) {
             $field->setOptions($column['spec']['options']);
           }
@@ -59,7 +46,6 @@ class SKEntitySpecProvider extends AutoService implements SpecProviderInterface 
             $field->setOptionsCallback([__CLASS__, 'getOptionsForSKEntityField'], $column['spec']);
           }
         }
-        $spec->addFieldSpec($field);
       }
     }
   }

--- a/ext/search_kit/Civi/Schema/SkEntityMetaProvider.php
+++ b/ext/search_kit/Civi/Schema/SkEntityMetaProvider.php
@@ -47,13 +47,10 @@ class SkEntityMetaProvider extends SqlEntityMetadata {
       $field = [
         'title' => $column['label'],
         'data_type' => $column['spec']['data_type'],
+        'entity_reference' => $column['spec']['entity_reference'] ?? NULL,
+        'input_type' => $column['spec']['input_type'] ?? NULL,
         'usage' => [],
       ];
-      if (!empty($column['spec']['fk_entity'])) {
-        $field['entity_reference'] = [
-          'entity' => $column['spec']['fk_entity'],
-        ];
-      }
       $fields[$column['spec']['name']] = $field;
     }
     return $fields;

--- a/ext/search_kit/Civi/Schema/SkEntityMetaProvider.php
+++ b/ext/search_kit/Civi/Schema/SkEntityMetaProvider.php
@@ -49,6 +49,7 @@ class SkEntityMetaProvider extends SqlEntityMetadata {
         'data_type' => $column['spec']['data_type'],
         'entity_reference' => $column['spec']['entity_reference'] ?? NULL,
         'input_type' => $column['spec']['input_type'] ?? NULL,
+        'serialize' => $column['spec']['serialize'] ?? NULL,
         'usage' => [],
       ];
       $fields[$column['spec']['name']] = $field;

--- a/ext/search_kit/Civi/Schema/SkEntityMetaProvider.php
+++ b/ext/search_kit/Civi/Schema/SkEntityMetaProvider.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Civi\Schema;
+
+use CRM_Search_ExtensionUtil as E;
+
+class SkEntityMetaProvider extends SqlEntityMetadata {
+
+  private $displayInfo;
+
+  public function getProperty(string $propertyName) {
+    $staticProps = [
+      'primary_keys' => ['_row'],
+      'log' => FALSE,
+      'icon' => 'fa-search-plus',
+      'paths' => [],
+    ];
+    if (isset($staticProps[$propertyName])) {
+      return $staticProps[$propertyName];
+    }
+    $display = $this->getDisplayInfo();
+    $displayProps = [
+      'name' => $display['entityName'],
+      'title' => $display['label'],
+      'title_plural' => $display['label'],
+      'description' => $display['settings']['description'] ?? NULL,
+      'table' => $display['tableName'],
+    ];
+    return $displayProps[$propertyName] ?? NULL;
+  }
+
+  public function getFields(): array {
+    $entityDisplay = $this->getDisplayInfo();
+    $fields = [
+      '_row' => [
+        'title' => E::ts('Case ID'),
+        'sql_type' => 'int unsigned',
+        'input_type' => 'Number',
+        'required' => TRUE,
+        'description' => E::ts('Search result row number'),
+        'usage' => [],
+        'primary_key' => TRUE,
+        'auto_increment' => TRUE,
+      ],
+    ];
+    foreach ($entityDisplay['settings']['columns'] as $column) {
+      $field = [
+        'title' => $column['label'],
+        'data_type' => $column['spec']['data_type'],
+        'usage' => [],
+      ];
+      if (!empty($column['spec']['fk_entity'])) {
+        $field['entity_reference'] = [
+          'entity' => $column['spec']['fk_entity'],
+        ];
+      }
+      $fields[$column['spec']['name']] = $field;
+    }
+    return $fields;
+  }
+
+  private function getDisplayInfo(): array {
+    // Load and cache display (substr is used to strip the `SK_` prefix)
+    $this->displayInfo ??= _getSearchKitEntityDisplays(substr($this->entityName, 3))[0];
+    return $this->displayInfo;
+  }
+
+}

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -279,10 +279,14 @@ class Admin {
   public static function getJoins(array $allowedEntities):array {
     $joins = [];
     foreach ($allowedEntities as $entity) {
-      $isMultiValueCustomEntity = in_array('CustomValue', $entity['type'], TRUE);
+      $isVirtualEntity = (bool) array_intersect(['CustomValue', 'SavedSearch'], $entity['type']);
 
-      // Normal DAO entities (excludes multi-value custom field entities)
-      if (!empty($entity['dao']) && !$isMultiValueCustomEntity) {
+      // Normal DAO entities (excludes virtual entities)
+      // FIXME: At this point DAO entities have enough metadata that using getReferenceColumns()
+      // is no longer necessary and they could be handled the same as virtual entities.
+      // So this entire block could, in theory, be removed in favor of the foreach loop below.
+      // Just need a solid before/after comparison to ensure the output stays stable.
+      if (!empty($entity['dao']) && !$isVirtualEntity) {
         /** @var \CRM_Core_DAO $daoClass */
         $daoClass = $entity['dao'];
         $references = $daoClass::getReferenceColumns();
@@ -392,9 +396,12 @@ class Admin {
         }
       }
 
-      // Custom EntityRef joins
+      // This handles joins for custom fields and virtual entities which don't have a DAO.
       foreach ($entity['fields'] as $field) {
-        if (($field['type'] === 'Custom' || $isMultiValueCustomEntity) && $field['fk_entity'] && $field['input_type'] === 'EntityRef') {
+        // FIXME: See comment above: this loop should be able to handle every entity.
+        // Above block could be removed and the first part of this conditional
+        // `($field['type'] === 'Custom' || $isVirtualEntity)` can be removed.
+        if (($field['type'] === 'Custom' || $isVirtualEntity) && $field['fk_entity'] && $field['input_type'] === 'EntityRef') {
           $entityRefJoins = self::getEntityRefJoins($entity, $field);
           foreach ($entityRefJoins as $joinEntity => $joinInfo) {
             $joins[$joinEntity][] = $joinInfo;
@@ -434,7 +441,7 @@ class Admin {
       $alias = "{$field['fk_entity']}_{$entity['name']}_$bareFieldName";
       $joins[$field['fk_entity']] = [
         'label' => $entity['title_plural'],
-        'description' => $entity['description'],
+        'description' => $entity['description'] ?? '',
         'entity' => $entity['name'],
         'conditions' => self::getJoinConditions('id', "$alias.{$field['name']}"),
         'defaults' => [],

--- a/ext/search_kit/search_kit.php
+++ b/ext/search_kit/search_kit.php
@@ -90,6 +90,7 @@ function search_kit_civicrm_entityTypes(array &$entityTypes): void {
       'name' => $display['entityName'],
       'class' => \Civi\BAO\SK_Entity::class,
       'table' => $display['tableName'],
+      'metaProvider' => \Civi\Schema\SkEntityMetaProvider::class,
     ];
   }
 }
@@ -110,12 +111,15 @@ function _getSearchKitDisplayTableName(string $displayName): string {
  * @return array
  * @throws CRM_Core_Exception
  */
-function _getSearchKitEntityDisplays(): array {
+function _getSearchKitEntityDisplays($name = NULL): array {
   $displays = [];
   // Can't use the API to fetch search displays because this is called by pre-boot hooks
   $select = CRM_Utils_SQL_Select::from('civicrm_search_display')
     ->where('type = "entity"')
     ->select(['id', 'name', 'label', 'settings']);
+  if ($name) {
+    $select->where('name = @name', ['@name' => $name]);
+  }
   try {
     $display = CRM_Core_DAO::executeQuery($select->toSQL());
     while ($display->fetch()) {

--- a/tests/phpunit/api/v4/Action/GetFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetFieldsTest.php
@@ -246,6 +246,7 @@ class GetFieldsTest extends Api4TestBase implements TransactionalInterface {
   public function testDynamicFks(): void {
     $tagFields = EntityTag::getFields(FALSE)
       ->execute()->indexBy('name');
+    $this->assertEquals('Tag', $tagFields['tag_id']['fk_entity']);
     $this->assertEmpty($tagFields['entity_id']['fk_entity']);
     $this->assertEquals('Activity', $tagFields['entity_id']['dfk_entities']['civicrm_activity']);
     $this->assertEquals('entity_table', $tagFields['entity_id']['input_attrs']['control_field']);

--- a/tests/phpunit/api/v4/Spec/SpecFormatterTest.php
+++ b/tests/phpunit/api/v4/Spec/SpecFormatterTest.php
@@ -28,20 +28,6 @@ use api\v4\Api4TestBase;
  */
 class SpecFormatterTest extends Api4TestBase {
 
-  /**
-   * @dataProvider arrayFieldSpecProvider
-   *
-   * @param array $fieldData
-   * @param string $expectedName
-   * @param string $expectedType
-   */
-  public function testArrayToField($fieldData, $expectedName, $expectedType) {
-    $field = SpecFormatter::arrayToField($fieldData, 'TestEntity');
-
-    $this->assertEquals($expectedName, $field->getName());
-    $this->assertEquals($expectedType, $field->getDataType());
-  }
-
   public function testCustomFieldWillBeReturned(): void {
     $customFieldId = 3333;
     $name = 'MyFancyField';
@@ -72,34 +58,6 @@ class SpecFormatterTest extends Api4TestBase {
     $this->assertEquals('Select', $field->getInputType());
     $this->assertEquals('civicrm_value_my_group', $field->getTableName());
     $this->assertTrue($field->getInputAttrs()['multiple']);
-  }
-
-  /**
-   * @return array
-   */
-  public function arrayFieldSpecProvider() {
-    return [
-      [
-        [
-          'name' => 'Foo',
-          'title' => 'Bar',
-          'type' => \CRM_Utils_Type::T_STRING,
-        ],
-        'Foo',
-        'String',
-      ],
-      [
-        [
-          'name' => 'MyField',
-          'title' => 'Bar',
-          'type' => \CRM_Utils_Type::T_STRING,
-          // this should take precedence
-          'data_type' => 'Boolean',
-        ],
-        'MyField',
-        'Boolean',
-      ],
-    ];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This replaces #28527 & allows joins to be performed on Entity-type displays in SearchKit.

Before
----------------------------------------
When creating a display of type DB Entity, the resulting entity can be searched on but cannot be joined to other entities.

After
----------------------------------------
Now it can.

Technical Details
----------------------------------------
With this change, APIv4 now reads field metadata directly from the EntityRepository instead of from the DAO. So for all modern entities (using `CRM_Core_DAO_Base`), this removes an extra conversion step. For legacy entities (from extensions with generated DAO files) it adds a conversion step, but they are still supported. For generated entities (CiviImport_Entity, SK_Entity, ECK_Entity), we should standardize on declaring fields via entityRepository.