### PR TITLE
[REF] Accessiblity fix - empty form label on new individual form

### DIFF
--- a/CRM/Contact/Form/Edit/Email.php
+++ b/CRM/Contact/Form/Edit/Email.php
@@ -51,7 +51,7 @@ class CRM_Contact_Form_Edit_Email {
     $form->addRule("email[$blockId][email]", ts('Email is not valid.'), 'email');
     if (isset($form->_contactType) || $blockEdit) {
       //Block type
-      $form->addField("email[$blockId][location_type_id]", ['entity' => 'email', 'placeholder' => NULL, 'class' => 'eight', 'option_url' => NULL]);
+      $form->addField("email[$blockId][location_type_id]", ['entity' => 'email', 'placeholder' => NULL, 'class' => 'eight', 'option_url' => NULL, 'title' => ts('Email Location %1', [1 => $blockId]), 'type' => 'Select']);
 
       //TODO: Refactor on_hold field to select.
       $multipleBulk = CRM_Core_BAO_Email::isMultipleBulkMail();

--- a/CRM/Contact/Form/Edit/IM.php
+++ b/CRM/Contact/Form/Edit/IM.php
@@ -40,9 +40,9 @@ class CRM_Contact_Form_Edit_IM {
     $form->applyFilter('__ALL__', 'trim');
 
     //IM provider select
-    $form->addField("im[$blockId][provider_id]", ['entity' => 'im', 'class' => 'eight', 'placeholder' => NULL]);
+    $form->addField("im[$blockId][provider_id]", ['entity' => 'im', 'class' => 'eight', 'placeholder' => NULL, 'title' => ts('IM Type %1', [1 => $blockId])]);
     //Block type select
-    $form->addField("im[$blockId][location_type_id]", ['entity' => 'im', 'class' => 'eight', 'placeholder' => NULL, 'option_url' => NULL]);
+    $form->addField("im[$blockId][location_type_id]", ['entity' => 'im', 'class' => 'eight', 'placeholder' => NULL, 'option_url' => NULL, 'title' => ts('IM Location %1', [1 => $blockId])]);
 
     //IM box
     $form->addField("im[$blockId][name]", ['entity' => 'im', 'aria-label' => ts('Instant Messenger %1', [1 => $blockId])]);

--- a/CRM/Contact/Form/Edit/Phone.php
+++ b/CRM/Contact/Form/Edit/Phone.php
@@ -46,6 +46,7 @@ class CRM_Contact_Form_Edit_Phone {
       'entity' => 'phone',
       'class' => 'eight',
       'placeholder' => NULL,
+      'title' => ts('Phone Type %1', [1 => $blockId]),
     ]);
     //main phone number with crm_phone class
     $form->addField("phone[$blockId][phone]", [
@@ -66,6 +67,7 @@ class CRM_Contact_Form_Edit_Phone {
         'class' => 'eight',
         'placeholder' => NULL,
         'option_url' => NULL,
+        'title' => ts('Phone Location %1', [1 => $blockId]),
       ]);
 
       //is_Primary radio

--- a/CRM/Contact/Form/Edit/Website.php
+++ b/CRM/Contact/Form/Edit/Website.php
@@ -39,7 +39,7 @@ class CRM_Contact_Form_Edit_Website {
     $form->applyFilter('__ALL__', 'trim');
 
     //Website type select
-    $form->addField("website[$blockId][website_type_id]", ['entity' => 'website', 'class' => 'eight', 'placeholder' => NULL]);
+    $form->addField("website[$blockId][website_type_id]", ['entity' => 'website', 'class' => 'eight', 'placeholder' => NULL, 'title' => ts('Website Type %1', [1 => $blockId])]);
 
     //Website box
     $form->addField("website[$blockId][url]", ['entity' => 'website', 'aria-label' => ts('Website URL %1', [1 => $blockId])]);


### PR DESCRIPTION
Overview
----------------------------------------
This patch fixes the empty form label accessibility issues on new individual form. An empty form abel erlror is triggered when a <label> tag is present in your form and associated with an input (form field), but does not contain any text and this form has such element which doesn't have label text like email, phone location types, website type etc. 

Before
-------
<img width="1410" alt="Screenshot 2024-07-15 at 16 38 04" src="https://github.com/user-attachments/assets/4db0f1f0-4f21-4975-8e30-69fb1095f6d7">


After
-----
![cred1](https://github.com/user-attachments/assets/d46b8ef2-ac7d-49de-902a-833602e49b19)

Technical Details
----------------------------------------
It adds a title attribute to those element with missing label text, that is used by select2 improvement made in this PR https://github.com/colemanw/select2/pull/5 about utilizing title attribute as a label placeholder. 

Dependent on https://github.com/colemanw/select2/pull/5 

cc @seamuslee001 @colemanw 



