### PR TITLE
support content-type of application/json on AJAX requests

### DIFF
--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -323,6 +323,10 @@ class CRM_Utils_REST {
         ]);
       }
     }
+    // Handle POST requests of content-type application/json.
+    elseif (array_key_exists('json', $requestParams) && is_array($requestParams['json'])) {
+      $params = $requestParams['json'];
+    }
     foreach ($requestParams as $n => $v) {
       if (!array_key_exists($n, $skipVars)) {
         $params[$n] = $v;

--- a/CRM/Utils/Request.php
+++ b/CRM/Utils/Request.php
@@ -133,6 +133,16 @@ class CRM_Utils_Request {
     foreach (($method ?? []) as $key => $value) {
       if (str_contains($key, 'amp;')) {
         $method[str_replace('amp;', '', $key)] = $method[$key];
+        if ($method === '$_POST' && $_SERVER['CONTENT_TYPE'] === 'application/json') {
+          static $post = NULL;
+          if (!isset($post)) {
+            $rawPost = file_get_contents('php://input');
+            $post = json_decode($rawPost, TRUE) ?? [];
+          }
+          if (isset($post[$name])) {
+            return $post[$name];
+          }
+        }
         if (isset($method[$name])) {
           return $method[$name];
         }
@@ -166,6 +176,11 @@ class CRM_Utils_Request {
     }
     if ($_POST) {
       $result = array_merge($result, $_POST);
+    }
+    if ($_SERVER['REQUEST_METHOD'] === 'POST' && $_SERVER['CONTENT_TYPE'] === 'application/json') {
+      $rawPost = file_get_contents('php://input');
+      $jsonPost = json_decode($rawPost, TRUE) ?? [];
+      $result = array_merge($result, $jsonPost);
     }
     return $result;
   }


### PR DESCRIPTION
Overview
----------------------------------------
This is https://github.com/civicrm/civicrm-core/pull/29886, but I've addressed Coleman's concern by fixing the non-deprecated function as well.

I force-pushed my change and tried reopening that PR, but apparently you have to reopen before force-pushing or not at all.

Before
----------------------------------------
Can't submit JSON-formatted POST requests.

After
----------------------------------------
You can.

Technical Details
----------------------------------------
While I don't love the static variable, my profiling of Civi shows that we lose a ridiculous amount of time to serializing/deserializing data (including JSON), even though it uses internal functions. So we only decode the POST request once.

I didn't think this necessary on the deprecated function because it seems far less likely to get called multiple times (it retrieves all values, not just one) but I could be swayed to add it to both (or leave it off of both).