### PR TITLE
[REF] Set outer tr of a custom field row to be a radiogroup role for …

### DIFF
--- a/templates/CRM/Custom/Form/Edit/CustomField.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomField.tpl
@@ -20,8 +20,8 @@
     <td>{$formElement.html}</td>
   </tr>
 {elseif $element.options_per_line}
-  <tr class="custom_field-row {$element.element_name}-row">
-    <td class="label">{$formElement.label}{if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$element.label}{/if}</td>
+  <tr class="custom_field-row {$element.element_name}-row" {if $element.html_type === "Radio"}role="radiogroup" aria-labelledby="{$element.element_name}_group"{/if}>
+    <td class="label" {if $element.html_type === "Radio"}id="{$element.element_name}_group"{/if}>{$formElement.label}{if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$element.label}{/if}</td>
     <td class="html-adjust">
 
       <div class="crm-multiple-checkbox-radio-options crm-options-per-line" style="--crm-opts-per-line:{$element.options_per_line};">
@@ -40,8 +40,8 @@
     </td>
   </tr>
 {else}
-  <tr class="custom_field-row {$element.element_name}-row">
-    <td class="label">{$formElement.label}
+  <tr class="custom_field-row {$element.element_name}-row" {if $element.html_type === "Radio"}role="radiogroup" aria-labelledby="{$element.element_name}_group"{/if}>
+    <td class="label" {if $element.html_type === "Radio"}id="{$element.element_name}_group"{/if}>{$formElement.label}
       {if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$element.label}{/if}
     </td>
     <td class="html-adjust">

--- a/templates/CRM/Custom/Form/Edit/CustomField.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomField.tpl
@@ -21,7 +21,7 @@
   </tr>
 {elseif $element.options_per_line}
   <tr class="custom_field-row {$element.element_name}-row" {if $element.html_type === "Radio"}role="radiogroup" aria-labelledby="{$element.element_name}_group"{/if}>
-    <td class="label" {if $element.html_type === "Radio"}id="{$element.element_name}_group"{/if}>{$formElement.label}{if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$element.label}{/if}</td>
+    <td class="label">{if $element.html_type === "Radio"}<span id="{$element.element_name}_group">{$element.label}</span>{else}{$formElement.label}{/if}{if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$element.label}{/if}</td>
     <td class="html-adjust">
 
       <div class="crm-multiple-checkbox-radio-options crm-options-per-line" style="--crm-opts-per-line:{$element.options_per_line};">
@@ -41,7 +41,7 @@
   </tr>
 {else}
   <tr class="custom_field-row {$element.element_name}-row" {if $element.html_type === "Radio"}role="radiogroup" aria-labelledby="{$element.element_name}_group"{/if}>
-    <td class="label" {if $element.html_type === "Radio"}id="{$element.element_name}_group"{/if}>{$formElement.label}
+    <td class="label">{if $element.html_type === "Radio"}<span id="{$element.element_name}_group">{$element.label}</span>{else}{$formElement.label}{/if}
       {if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$element.label}{/if}
     </td>
     <td class="html-adjust">


### PR DESCRIPTION
…aria reasons to improve accessibility

Overview
----------------------------------------
This sets the outer tr to be the role of radio group and sets the label to have an id so that the radiogroup label is outputted to screen readers etc

Before
----------------------------------------
No role on tr

After
----------------------------------------
tr is classified as a radio group if custom field is radio

Technical Details
----------------------------------------
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/radiogroup_role

ping @monishdeb @JoeMurray 