### PR TITLE
[REF] Add Getter function for formComponent protected var in Contribu…

### DIFF
--- a/CRM/Report/Form/Contact/Detail.php
+++ b/CRM/Report/Form/Contact/Detail.php
@@ -998,4 +998,8 @@ HERESQL;
     ];
   }
 
+  public function getFormComponent(): array {
+    return $this->_formComponent ?? [];
+  }
+
 }


### PR DESCRIPTION
…teDetail report

Overview
----------------------------------------
This adds a getter for the _formComponent var which was made private from public https://github.com/civicrm/civicrm-core/commit/15707f0c40ec6c550451eef44e7861515cf316f1 this broke the Activity Type ACL extension here https://lab.civicrm.org/extensions/activitytypeacl/-/blob/master/activitytypeacl.php?ref_type=heads#L318 This adds a getter so that the extension can be fixed up

Before
----------------------------------------
var is private and no way to access it from extension

After
----------------------------------------
Getter function available
 
@JoeMurray @Edzelopez @eileenmcnaughton @monishdeb @MegaphoneJon 