### PR TITLE
dev/core#5245 - FormBuilder: Don't put date options into the form markup

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -65,7 +65,6 @@
         if (ctrl.fieldDefn.operators && ctrl.fieldDefn.operators.length) {
           this.searchOperators = _.pick(this.searchOperators, ctrl.fieldDefn.operators);
         }
-        setDateOptions();
       };
 
       this.getFkEntity = function() {
@@ -155,6 +154,10 @@
           }
           return entityRefOptions;
         }
+        if (_.includes(['Date', 'Timestamp'], $scope.getProp('data_type'))) {
+          ctrl.node.defn = ctrl.node.defn || {};
+          return $scope.getProp('search_range') ? CRM.afGuiEditor.dateRanges : CRM.afGuiEditor.dateRanges.slice(1);
+        }
         return ctrl.getDefn().options || (ctrl.getDefn().data_type === 'Boolean' ? yesNo : null);
       };
 
@@ -243,7 +246,6 @@
         if (ctrl.hasDefaultValue) {
           $scope.toggleDefaultValue();
         }
-        setDateOptions();
       };
 
       $scope.toggleAttr = function(attr) {
@@ -261,14 +263,6 @@
 
       function setFieldDefn() {
         ctrl.fieldDefn = angular.extend({}, ctrl.getDefn(), ctrl.node.defn);
-      }
-
-      function setDateOptions() {
-        if (_.includes(['Date', 'Timestamp'], $scope.getProp('data_type'))) {
-          ctrl.node.defn = ctrl.node.defn || {};
-          ctrl.node.defn.options = $scope.getProp('search_range') ? CRM.afGuiEditor.dateRanges : CRM.afGuiEditor.dateRanges.slice(1);
-          setFieldDefn();
-        }
       }
 
       $scope.toggleDefaultValue = function() {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug in https://lab.civicrm.org/dev/core/-/issues/5245

Technical Details
----------------------------------------
Inserting a date field into a form was resulting in a large amount of markup and errors during editing.

This removes the unnecessary markup, as the options can be referenced instead of inserted.