### PR TITLE
[REF] Fix Screen reader accessibility of attachment fields

### DIFF
--- a/templates/CRM/Form/attachment.tpl
+++ b/templates/CRM/Form/attachment.tpl
@@ -45,7 +45,7 @@
         {/if}
         <tr>
           <td class="label">{$form.attachFile_1.label}</td>
-          <td>{$form.attachFile_1.html}&nbsp;{$form.attachDesc_1.html}<a href="#" class="crm-hover-button crm-clear-attachment" style="visibility: hidden;" title="{ts}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
+          <td>{$form.attachFile_1.html}&nbsp;<label for="attachDesc_1" class="sr-only">{ts}File 1 description{/ts}</label>{$form.attachDesc_1.html}<a href="#" class="crm-hover-button crm-clear-attachment" style="visibility: hidden;" title="{ts}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
             <div class="description">{if $maxAttachments GT 1} {ts 1=$maxAttachments}You can have a maximum of %1 attachment(s).{/ts}{/if} {ts 1=$config->maxFileSize}Each file must be less than %1M in size. You can also add a short description.{/ts}</div>
           </td>
         </tr>
@@ -65,8 +65,8 @@
           {assign var=tagElement value="tag_"|cat:$index}
             <tr class="attachment-fieldset solid-border-top"><td colspan="2"></td></tr>
             <tr>
-                <td class="label">{$form.attachFile_1.label}</td>
-                <td>{$form.$attachName.html}&nbsp;{$form.$attachDesc.html}<a href="#" class="crm-hover-button crm-clear-attachment" style="visibility: hidden;" title="{ts}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a></td>
+                <td class="label">{ts}Attach File{/ts}</td>
+                <td><label class="sr-only" for="{$attachName}">{ts 1=$index}Attach File %1{/ts}</label>{$form.$attachName.html}&nbsp;<label for="{$attachDesc}" class="sr-only">{ts 1=$index}File %1 description{/ts}</label>{$form.$attachDesc.html}<a href="#" class="crm-hover-button crm-clear-attachment" style="visibility: hidden;" title="{ts}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a></td>
             </tr>
             {if $form.$tagElement}
             <tr>


### PR DESCRIPTION
Overview
----------------------------------------
This ensures that each file field correctly has a label assigned to it for screen readers and the description field is also properly labelled

Before
----------------------------------------
Labels incorrectly referencing attachfile_1 and no label on description fields

After
----------------------------------------
labels fixed

@monishdeb @eileenmcnaughton @colemanw @JoeMurray 