### PR TITLE
[REF] Get rid of hidden submit button no longer used in report

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -244,7 +244,6 @@ class CRM_Report_Form extends CRM_Core_Form {
 
   protected $_instanceButtonName = NULL;
   protected $_createNewButtonName = NULL;
-  protected $_groupButtonName = NULL;
   protected $_chartButtonName = NULL;
   protected $_csvSupported = TRUE;
   protected $_add2groupSupported = TRUE;
@@ -767,7 +766,6 @@ class CRM_Report_Form extends CRM_Core_Form {
 
     $this->_instanceButtonName = $this->getButtonName('submit', 'save');
     $this->_createNewButtonName = $this->getButtonName('submit', 'next');
-    $this->_groupButtonName = $this->getButtonName('submit', 'group');
     $this->_chartButtonName = $this->getButtonName('submit', 'chart');
   }
 
@@ -1724,11 +1722,6 @@ class CRM_Report_Form extends CRM_Core_Form {
       );
       $this->assign('group', TRUE);
     }
-
-    $this->addElement('xbutton', $this->_groupButtonName, '', [
-      'type' => 'submit',
-      'style' => 'display: none;',
-    ]);
 
     $this->addChartOptions();
     $showResultsLabel = $this->getResultsLabel();


### PR DESCRIPTION
Overview
----------------------------------------
Get rid of hidden submit button no longer used in report. Earlier this button was jointly works with Add Contacts to Group action but now this button is no longer used and hidden. This trigger a accessibility issue shown under before section.

Before
----------------------------------------
<img width="1337" alt="Screenshot 2024-07-17 at 09 58 29" src="https://github.com/user-attachments/assets/16d18d2a-5dea-4af0-8074-776d39f0b423">


After
----------------------------------------
Fixed


Comments
----------------------------------------
ping @colemanw @seamuslee001 