### PR TITLE
[REF] Make datepicker element and actions accessible if label is defined but associated directly like in report filter

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1688,7 +1688,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       $label,
       $options,
       $required,
-      ['class' => 'crm-select2']
+      ['class' => 'crm-select2', 'title' => $label]
     );
     $attributes = ['formatType' => 'searchDate'];
     $extra = ['time' => $isDateTime];
@@ -2870,10 +2870,11 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       // This is appropriate as it is a pseudofield.
       $this->setConstants(['task' => '']);
       $this->assign('taskMetaData', $tasks);
-      $select = $this->add('select', 'task', NULL, ['' => ts('Actions')], FALSE, [
+      $select = $this->add('select', 'task', NULL, ['' => ts('Actions')], FALSE,
+      [
         'class' => 'crm-select2 crm-action-menu fa-check-circle-o huge crm-search-result-actions',
-      ]
-      );
+        'title' => ts('Actions'),
+      ]);
       foreach ($tasks as $key => $task) {
         $attributes = [];
         if (isset($task['data'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Make datepicker element and actions accessible if label is defined but associated directly like in report filter

Before
----------------------------------------
Empty label of Actions:
<img width="1254" alt="Screenshot 2024-07-17 at 10 17 01" src="https://github.com/user-attachments/assets/87c27a8d-ddaf-4d48-819c-afe585960f28">


Empty label of date filter:
<img width="1152" alt="Screenshot 2024-07-17 at 10 17 23" src="https://github.com/user-attachments/assets/06ed12d9-c36d-4992-96ce-1a7535d91d51">


After
----------------------------------------
Fixed

Dependent on https://github.com/colemanw/select2/pull/6
