### PR TITLE
[REF] Fix empty label accessibility issue on report elements

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1475,7 +1475,7 @@ class CRM_Report_Form extends CRM_Core_Form {
           default:
             // default type is string
             $this->addElement('select', "{$fieldName}_op", ts('Operator:'), $operations,
-              ['onchange' => "return showHideMaxMinVal( '$fieldName', this.value );"]
+              ['onchange' => "return showHideMaxMinVal( '$fieldName', this.value );", 'title' => ts('%1 Filter Operator', [1 => $field['title']])]
             );
             // we need text box for value input
             $this->add('text', "{$fieldName}_value", NULL, ['class' => 'huge']);
@@ -1692,8 +1692,8 @@ class CRM_Report_Form extends CRM_Core_Form {
           'ASC' => ts('Ascending'),
           'DESC' => ts('Descending'),
         ]);
-        $this->addElement('checkbox', "order_bys[{$i}][section]", ts('Order by Section'), FALSE, ['id' => "order_by_section_$i"]);
-        $this->addElement('checkbox', "order_bys[{$i}][pageBreak]", ts('Page Break'), FALSE, ['id' => "order_by_pagebreak_$i"]);
+        $this->addElement('checkbox', "order_bys[{$i}][section]", ts('Order by Section'), FALSE, ['id' => "order_by_section_$i", 'title' => ts('Order by Section %1', [1 => $i])]);
+        $this->addElement('checkbox', "order_bys[{$i}][pageBreak]", ts('Page Break'), FALSE, ['id' => "order_by_pagebreak_$i", 'title' => ts('Page Break %1', [1 => $i])]);
       }
     }
   }
@@ -1720,7 +1720,7 @@ class CRM_Report_Form extends CRM_Core_Form {
       $this->addElement('select', 'groups', ts('Group'),
         ['' => ts('Add Contacts to Group')] +
         CRM_Core_PseudoConstant::nestedGroup(),
-        ['class' => 'crm-select2 crm-action-menu fa-plus huge']
+        ['class' => 'crm-select2 crm-action-menu fa-plus huge', 'title' => ts('Add Contacts to Group')]
       );
       $this->assign('group', TRUE);
     }

--- a/CRM/Report/Form/Instance.php
+++ b/CRM/Report/Form/Instance.php
@@ -125,6 +125,7 @@ class CRM_Report_Form_Instance {
           'size' => 5,
           'style' => 'width:240px',
           'class' => 'advmultiselect',
+          'title' => ts('ACL Group/Role'),
         ]
       );
       $grouprole->setButtonAttributes('add', ['value' => ts('Add >>')]);

--- a/templates/CRM/Report/Form/Tabs/Filters.tpl
+++ b/templates/CRM/Report/Form/Tabs/Filters.tpl
@@ -37,7 +37,12 @@
                     <td class="label report-contents">{if !empty($field.title)}{$field.title}{/if}</td>
                     <td class="report-contents">{$form.$fieldOp.html}</td>
                     <td>
-                      <span id="{$filterVal}_cell">{$form.$filterVal.label}&nbsp;{$form.$filterVal.html}</span>
+                      <span id="{$filterVal}_cell">
+                        <label class="sr-only" for="{$form.$filterVal.id}">
+                          {if !empty($field.title)}{$field.title}{else}{$field.name}{/if} filter value
+                        </label>
+                        {$form.$filterVal.label}&nbsp;{$form.$filterVal.html}
+                      </span>
                       <span id="{$filterMin}_max_cell">
                         {if array_key_exists($filterMin, $form) && $form.$filterMin}{$form.$filterMin.label}&nbsp;{$form.$filterMin.html}&nbsp;&nbsp;{/if}
                         {if array_key_exists($filterMax, $form) && $form.$filterMax}{$form.$filterMax.label}&nbsp;{$form.$filterMax.html}{/if}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes accessibility issues on report elements.
Before
----------------------------------------
1. Empty form label on report text element:
<img width="904" alt="Screenshot 2024-07-17 at 11 04 45" src="https://github.com/user-attachments/assets/c55907d0-b773-4f3d-8c3d-b5ebe7ff6a5b">

2. Empty form label in page break and group by:
<img width="893" alt="Screenshot 2024-07-17 at 11 07 16" src="https://github.com/user-attachments/assets/3bb910a4-19cd-4964-b7f0-bb5480eeb961">

3. Empty form label on actions and add contact to group widgets:
<img width="752" alt="Screenshot 2024-07-17 at 11 08 26" src="https://github.com/user-attachments/assets/785d53c7-dfbe-4087-8cf6-b86660b09b32">


After
----------------------------------------
Fixed them all

Technical Details
----------------------------------------
Dependent on https://github.com/colemanw/select2/pull/5

Comments
----------------------------------------
ping @seamuslee001 @colemanw 