### PR TITLE
[REF] Fix empty headers in option group, custom field, group and profile pages

### DIFF
--- a/templates/CRM/Admin/Page/Options.tpl
+++ b/templates/CRM/Admin/Page/Options.tpl
@@ -69,7 +69,7 @@
          <thead>
          <tr>
             {if $hasIcons}
-              <th></th>
+              <th><span class="sr-only">{ts}Icons{/ts}</span></th>
             {/if}
             {if $showComponent}
                 <th>{ts}Component{/ts}</th>
@@ -102,7 +102,7 @@
             {if $showIsDefault}<th>{ts}Default{/ts}</th>{/if}
             <th>{ts}Reserved{/ts}</th>
             <th>{ts}Enabled?{/ts}</th>
-            <th></th>
+            <th><span class="sr-only">{ts}Actions{/ts}</span></th>
           </tr>
           </thead>
           <tbody>

--- a/templates/CRM/Custom/Page/Field.tpl
+++ b/templates/CRM/Custom/Page/Field.tpl
@@ -24,7 +24,7 @@
             <th>{ts}Req?{/ts}</th>
             <th>{ts}Searchable?{/ts}</th>
             <th>{ts}Enabled?{/ts}</th>
-            <th></th>
+            <th><span class="sr-only">{ts}Actions{/ts}</span></th>
         </tr>
         </thead>
         <tbody>

--- a/templates/CRM/Custom/Page/Group.tpl
+++ b/templates/CRM/Custom/Page/Group.tpl
@@ -28,7 +28,7 @@
             <th>{ts}Type{/ts}</th>
             <th>{ts}Order{/ts}</th>
             <th>{ts}Style{/ts}</th>
-            <th></th>
+            <th><span class="sr-only">{ts}Actions{/ts}</span></th>
           </tr>
         </thead>
         <tbody>

--- a/templates/CRM/Custom/Page/Option.tpl
+++ b/templates/CRM/Custom/Page/Option.tpl
@@ -30,7 +30,7 @@
             <th class='crm-custom_option-default_value'>{ts}Default{/ts}</th>
             <th class='crm-custom_option-is_active'>{ts}Enabled?{/ts}</th>
             <th class='crm-custom_option-links'>&nbsp;</th>
-            <th class='hiddenElement'>&nbsp;</th>
+            <th class='hiddenElement'><span class="sr-only">{ts}Actions{/ts}</span></th>
           </tr>
         </thead>
       </table>

--- a/templates/CRM/UF/Page/Group.tpl
+++ b/templates/CRM/UF/Page/Group.tpl
@@ -63,7 +63,7 @@
                   <th>{ts}Type{/ts}</th>
                   <th>{ts}ID{/ts}</th>
                   <th id="nosort">{ts}Used For{/ts}</th>
-                  <th></th>
+                  <th><span class="sr-only">{ts}Actions{/ts}</span></th>
                 </tr>
               </thead>
               <tbody>
@@ -108,7 +108,7 @@
                   <th>{ts}Type{/ts}</th>
                   <th>{ts}ID{/ts}</th>
                   <th id="nosort">{ts}Used For{/ts}</th>
-                  <th></th>
+                  <th><span class="sr-only">{ts}Actions{/ts}</span></th>
                 </tr>
               </thead>
               <tbody>


### PR DESCRIPTION
Overview
----------------------------------------
Fix empty headers in option group, custom field, group and profile pages

Before
----------------------------------------
<img width="1113" alt="Screenshot 2024-07-17 at 11 46 02" src="https://github.com/user-attachments/assets/21e872da-47fa-4fe6-8e28-c0906b3241ca">


After
----------------------------------------
Fixed

Comments
----------------------------------------
ping @colemanw @eileenmcnaughton @seamuslee001 @JoeMurray 