### PR TITLE
Fix Cache Issue In Schema Difference Calculation For Log Tables

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -427,8 +427,10 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
    *   name of the relevant table.
    * @param array $cols
    *   Mixed array of columns to add or null (to check for the missing columns).
+   * @param bool $resetTableCache
+   *   Refresh the cache for table before calculating the differences with log table.
    */
-  public function fixSchemaDifferencesFor(string $table, array $cols = []): void {
+  public function fixSchemaDifferencesFor(string $table, array $cols = [], bool $resetTableCache = FALSE): void {
     if (!in_array($table, $this->tables, TRUE)) {
       // Create the table if the log table does not exist and
       // the table is in 'this->tables'. This latter array
@@ -441,13 +443,17 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
       return;
     }
 
+    if ($resetTableCache) {
+      $this->resetSchemaCacheForTable($table);
+    }
+    $this->resetSchemaCacheForTable("log_$table");
+
     if (empty($cols)) {
       $cols = $this->columnsWithDiffSpecs($table, "log_$table");
     }
 
     // If a column that already exists on logging table is being added, we
     // should treat it as a modification.
-    $this->resetSchemaCacheForTable("log_$table");
     $logTableSchema = $this->columnSpecsOf("log_$table");
     if (!empty($cols['ADD'])) {
       foreach ($cols['ADD'] as $colKey => $col) {

--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -391,7 +391,7 @@ class CRM_Upgrade_Incremental_Base {
       }
       $schema = new CRM_Logging_Schema();
       if ($schema->isEnabled()) {
-        $schema->fixSchemaDifferencesFor($table);
+        $schema->fixSchemaDifferencesFor($table, [], TRUE);
       }
     }
     if ($locales && $triggerRebuild) {
@@ -613,7 +613,7 @@ class CRM_Upgrade_Incremental_Base {
     }
     $schema = new CRM_Logging_Schema();
     if ($schema->isEnabled()) {
-      $schema->fixSchemaDifferencesFor($table);
+      $schema->fixSchemaDifferencesFor($table, [], TRUE);
     }
     $locales = CRM_Core_I18n::getMultilingual();
     if ($locales) {
@@ -720,7 +720,7 @@ class CRM_Upgrade_Incremental_Base {
     }
     $schema = new CRM_Logging_Schema();
     if ($schema->isEnabled()) {
-      $schema->fixSchemaDifferencesFor($table);
+      $schema->fixSchemaDifferencesFor($table, [], TRUE);
     }
     if ($locales) {
       CRM_Core_I18n_Schema::rebuildMultilingualSchema($locales, NULL, TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
This pr solves a very specific caching issue related to calculation of schema difference between a table and its log table during the upgrades that includes multiple changes to the same table.

Technical Details
----------------------------------------
While upgrading from version 5.51.3 to 5.75.0 we change the columns **post_URL** and **cancel_URL**  [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Upgrade/Incremental/sql/5.64.alpha1.mysql.tpl#L15) for table **civicrm_uf_group** and later in the upgrade process we make changes to same table again [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Upgrade/Incremental/php/FiveSeventyOne.php#L41) and this time civi also tries to sync log tables [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Upgrade/Incremental/Base.php#L723) if logging is enabled. 

During this sync when civi is trying to find differences between **civicrm_uf_group** table and **log_civicrm_uf_group** table there appears to be an issue that in cache for **civicrm_uf_group** there exists both columns **post_URL** (old column name) and **post_url** (new column name) as well. And since **post_URL** does not exist in **log_civicrm_uf_group**  it appears in the differences as a new column.

When civi tries to find the spec of this new column [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Logging/Schema.php#L517) from database there appears to be none due to which [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Logging/Schema.php#L467) it forms an incomplete query and thus results in an error. Same issue happens for **cancel_URL** column as well.

This pr adds an ability to refresh the table cache during schema difference calculations during the upgrades.
