### PR TITLE
Move participant validation out of registration forms into the Participant BAO

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -219,6 +219,8 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant implements \Ci
 
   /**
    * @internal
+   *     Do not call this from outside core code. It is expected to change multiple times in the course of refactoring
+   *     participant validation out of the QuickForm layer. Eventually, there will be an API action for validation.
    */
   public static function getAvailableSpaces(int $eventId, bool $includeWaitlist = TRUE): int {
     $availableSpaces = self::eventFull(
@@ -792,6 +794,8 @@ WHERE  civicrm_participant.id = {$participantId}
    * @throws \Civi\API\Exception\UnauthorizedException
    *
    * @internal
+   *    Do not call this from outside core code. It is expected to change multiple times in the course of refactoring
+   *    participant validation out of the QuickForm layer. Eventually, there will be an API action for validation.
    */
   public static function getExistingParticipants(
     int $contactId,
@@ -892,6 +896,8 @@ WHERE  civicrm_participant.id = {$participantId}
    * @throws \CRM_Core_Exception
    *
    * @internal
+   *    Do not call this from outside core code. It is expected to change multiple times in the course of refactoring
+   *    participant validation out of the QuickForm layer. Eventually, there will be an API action for validation.
    */
   public static function validateExistingRegistration(
     int $contactId,
@@ -951,6 +957,8 @@ WHERE  civicrm_participant.id = {$participantId}
    *   A list of validation error messages, possibly keyed by affected participant properties/field names.
    *
    * @internal
+   *    Do not call this from outside core code. It is expected to change multiple times in the course of refactoring
+   *    participant validation out of the QuickForm layer. Eventually, there will be an API action for validation.
    */
   public static function validateAvailableSpaces(
     array $values,
@@ -994,6 +1002,8 @@ WHERE  civicrm_participant.id = {$participantId}
    * @throws \CRM_Core_Exception
    *
    * @internal
+   *   Do not call this from outside core code. It is expected to change multiple times in the course of refactoring
+   *   participant validation out of the QuickForm layer. Eventually, there will be an API action for validation.
    */
   public static function validateEvent(int $eventId): array {
     $event = \Civi\Api4\Event::get(FALSE)
@@ -1053,6 +1063,8 @@ WHERE  civicrm_participant.id = {$participantId}
    *   A list of validation error messages, possibly keyed by affected participant properties/field names.
    *
    * @internal
+   *     Do not call this from outside core code. It is expected to change multiple times in the course of refactoring
+   *     participant validation out of the QuickForm layer. Eventually, there will be an API action for validation.
    */
   public static function validateEventRegistration(
     array $values,

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -863,13 +863,13 @@ WHERE  civicrm_participant.id = {$participantId}
         'default_role_id',
         'allow_same_participant_emails'
       )
-      ->addWhere('id')
+      ->addWhere('id', '=', $eventId)
       ->execute()
       ->single();
     $excludeStatus = 'admin' === $context ? ['Cancelled'] : [];
     $participantRoleIds = 'public' === $context ? [$participantRoleId ?? $event['default_role_id']] : [];
     $existingParticipants = CRM_Event_BAO_Participant::getExistingParticipants(
-      $contactID,
+      $contactId,
       $eventId,
       TRUE,
       TRUE,

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -997,7 +997,6 @@ WHERE  civicrm_participant.id = {$participantId}
    */
   public static function validateEvent(int $eventId): array {
     $event = \Civi\Api4\Event::get(FALSE)
-      ->addSelect('has_waitlist', 'max_participants')
       ->addWhere('id', '=', $eventId)
       ->execute()
       ->single();

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -837,53 +837,6 @@ WHERE  civicrm_participant.id = {$participantId}
   }
 
   /**
-   * Checks whether a participant for a given event and contact exists.
-   * Can be used during validation of new event registrations to check for duplicates.
-   *
-   * @param int $contactId
-   *    The contact ID of participants to find.
-   * @param int $eventId
-   *    The event ID of participants to find.
-   * @param bool $onlyCounted
-   *    Whether to only consider registrations with a status with "is_counted".
-   * @param bool $includeOnWaitlist
-   *    Whether to consider registrations with status "On waitlist" when restricing to "is_counted".
-   * @param array $excludeStatus
-   *    A list of registration status to not consider (e.g. for ignoring cancelled registrations).
-   * @param array $filterRoleIds
-   *    A list of participant role IDs to filter for. Registrations with other roles will not be considered.
-   * @param bool $includeTest
-   *    Whether to include test participants.
-   *
-   * @return bool
-   * @throws \CRM_Core_Exception
-   * @throws \Civi\API\Exception\UnauthorizedException
-   *
-   * @internal
-   */
-  public static function exists(
-    int $contactId,
-    int $eventId,
-    bool $onlyCounted = TRUE,
-    bool $includeOnWaitlist = TRUE,
-    array $excludeStatus = ['Cancelled'],
-    array $filterRoleIds = [],
-    bool $includeTest = FALSE
-  ) {
-    return count(
-        self::getExistingParticipants(
-          $contactId,
-          $eventId,
-          $onlyCounted,
-          $includeOnWaitlist,
-          $excludeStatus,
-          $filterRoleIds,
-          $includeTest
-        )
-      ) > 0;
-  }
-
-  /**
    * @param int $contactId
    * @param int $eventId
    * @param string $context

--- a/CRM/Event/Form/EventFormTrait.php
+++ b/CRM/Event/Form/EventFormTrait.php
@@ -115,11 +115,10 @@ trait CRM_Event_Form_EventFormTrait {
    * @throws \CRM_Core_Exception
    */
   protected function getAvailableSpaces(): int {
-    $availableSpaces = CRM_Event_BAO_Participant::eventFull($this->getEventID(),
-      TRUE,
+    return CRM_Event_BAO_Participant::getAvailableSpaces(
+      $this->getEventID(),
       $this->getEventValue('has_waitlist')
     );
-    return is_numeric($availableSpaces) ? (int) $availableSpaces : 0;
   }
 
   /**

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -777,21 +777,9 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
       $eventId = $values['event_id'] ?? NULL;
 
-      $event = new CRM_Event_DAO_Event();
-      $event->id = $eventId;
-      $event->find(TRUE);
+      $errorMsg += CRM_Event_BAO_Participant::validateExistingRegistration($contactId, $eventId, 'admin');
 
-      if (!$event->allow_same_participant_emails && !empty($contactId) && !empty($eventId)) {
-        $cancelledStatusID = CRM_Core_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'status_id', 'Cancelled');
-        $dupeCheck = new CRM_Event_BAO_Participant();
-        $dupeCheck->contact_id = $contactId;
-        $dupeCheck->event_id = $eventId;
-        $dupeCheck->whereAdd("status_id != {$cancelledStatusID} ");
-        $dupeCheck->find(TRUE);
-        if (!empty($dupeCheck->id)) {
-          $errorMsg['event_id'] = ts('This contact has already been assigned to this event.');
-        }
-      }
+      // TODO: No check for available spaces?
     }
     return empty($errorMsg) ? TRUE : $errorMsg;
   }

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1667,41 +1667,11 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    *
    */
   protected function checkValidEvent(): void {
-    // is the event active (enabled)?
-    if (!$this->_values['event']['is_active']) {
-      // Form is inactive, redirect to the list of events
-      $urlList = CRM_Utils_System::url('civicrm/event/list', FALSE, NULL, FALSE, TRUE);
-      CRM_Core_Error::statusBounce(ts('The event you requested is currently unavailable (contact the site administrator for assistance).'), $urlList);
-    }
-
-    // is online registration is enabled?
-    if (!$this->_values['event']['is_online_registration']) {
-      CRM_Core_Error::statusBounce(ts('Online registration is not currently available for this event (contact the site administrator for assistance).'), $this->getInfoPageUrl());
-    }
-
-    // is this an event template ?
-    if (!empty($this->_values['event']['is_template'])) {
-      CRM_Core_Error::statusBounce(ts('Event templates are not meant to be registered.'), $this->getInfoPageUrl());
-    }
-
-    $now = date('YmdHis');
-    $startDate = CRM_Utils_Date::processDate($this->_values['event']['registration_start_date'] ?? NULL);
-
-    if ($startDate && ($startDate >= $now)) {
-      CRM_Core_Error::statusBounce(ts('Registration for this event begins on %1',
-        [1 => CRM_Utils_Date::customFormat($this->_values['event']['registration_start_date'] ?? NULL)]),
-        $this->getInfoPageUrl(),
-        ts('Sorry'));
-    }
-
-    $regEndDate = CRM_Utils_Date::processDate($this->_values['event']['registration_end_date'] ?? NULL);
-    $eventEndDate = CRM_Utils_Date::processDate($this->_values['event']['event_end_date'] ?? NULL);
-    if (($regEndDate && ($regEndDate < $now)) || (empty($regEndDate) && !empty($eventEndDate) && ($eventEndDate < $now))) {
-      $endDate = CRM_Utils_Date::customFormat($this->_values['event']['registration_end_date'] ?? NULL);
-      if (empty($regEndDate)) {
-        $endDate = CRM_Utils_Date::customFormat($this->_values['event']['event_end_date'] ?? NULL);
-      }
-      CRM_Core_Error::statusBounce(ts('Registration for this event ended on %1', [1 => $endDate]), $this->getInfoPageUrl(), ts('Sorry'));
+    foreach (CRM_Event_BAO_Participant::validateEvent($this->getEventID()) as $error) {
+      CRM_Core_Error::statusBounce(
+        $error,
+        $this->_values['event']['is_active'] ? $this->getInfoPageUrl() : CRM_Utils_System::url('civicrm/event/list', FALSE, NULL, FALSE, TRUE),
+      );
     }
   }
 

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -556,8 +556,9 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       self::checkRegistration($fields, $form);
     }
 
+    $spacesAvailable = $form->getEventValue('available_spaces');
     if (!$form->_allowConfirmation) {
-      $errors += CRM_Event_BAO_Participant::validateAvailableSpaces($fields);
+      $errors += CRM_Event_BAO_Participant::validateAvailableSpaces($fields + ['event_id' => $form->getEventID()]);
     }
 
     $numberAdditionalParticipants = $fields['additional_participants'] ?? 0;
@@ -964,7 +965,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       $errors = CRM_Event_BAO_Participant::validateExistingRegistration(
         $contactID,
         $form->_values['event']['id'],
-        NULL,
+        'public',
         $isAdditional
       );
       $status = reset($errors);

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -555,19 +555,12 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     if (!$form->_skipDupeRegistrationCheck) {
       self::checkRegistration($fields, $form);
     }
-    $spacesAvailable = $form->getEventValue('available_spaces');
-    //check for availability of registrations.
-    if ($form->getEventValue('max_participants') !== NULL
-      && !$form->_allowConfirmation
-      && !empty($fields['additional_participants'])
-      && empty($fields['bypass_payment']) &&
-      ((int) $fields['additional_participants']) >= $spacesAvailable
-    ) {
-      $errors['additional_participants'] = ts("There is only enough space left on this event for %1 participant(s).", [1 => $spacesAvailable]);
+
+    if (!$form->_allowConfirmation) {
+      $errors += CRM_Event_BAO_Participant::validateAvailableSpaces($fields);
     }
 
     $numberAdditionalParticipants = $fields['additional_participants'] ?? 0;
-
     if ($numberAdditionalParticipants && !CRM_Utils_Rule::positiveInteger($fields['additional_participants'])) {
       $errors['additional_participants'] = ts('Please enter a whole number for Number of additional people.');
     }
@@ -954,7 +947,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
    * @param bool $isAdditional
    *   Treat isAdditional participants a bit differently.
    *
-   * @return int
+   * @return bool|void
    */
   public static function checkRegistration($fields, $form, $isAdditional = FALSE) {
     // CRM-3907, skip check for preview registrations
@@ -968,58 +961,41 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     $contactID = self::getRegistrationContactID($fields, $form, $isAdditional);
 
     if ($contactID) {
-      $participant = new CRM_Event_BAO_Participant();
-      $participant->contact_id = $contactID;
-      $participant->event_id = $form->_values['event']['id'];
-      if (!empty($fields['participant_role']) && is_numeric($fields['participant_role'])) {
-        $participant->role_id = $fields['participant_role'];
-      }
-      else {
-        $participant->role_id = $form->_values['event']['default_role_id'];
-      }
-      $participant->is_test = 0;
-      $participant->find();
-      // Event#30 - Anyone whose status type has `is_counted` OR is on the waitlist should be considered as registered.
-      $statusTypes = CRM_Event_PseudoConstant::participantStatus(NULL, 'is_counted = 1') + CRM_Event_PseudoConstant::participantStatus(NULL, "name = 'On waitlist'");
-      while ($participant->fetch()) {
-        if (array_key_exists($participant->status_id, $statusTypes)) {
-          if (!$isAdditional && !$form->_values['event']['allow_same_participant_emails']) {
-            $registerUrl = CRM_Utils_System::url('civicrm/event/register',
-              "reset=1&id={$form->_values['event']['id']}&cid=0"
-            );
-            if ($form->_pcpId) {
-              $registerUrl .= '&pcpId=' . $form->_pcpId;
-            }
-            $registrationType = (CRM_Event_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'participant_status_id', 'On waitlist') == $participant->status_id) ? 'waitlisted' : 'registered';
-            if ($registrationType == 'waitlisted') {
-              $status = ts("It looks like you are already waitlisted for this event. If you want to change your registration, or you feel that you've received this message in error, please contact the site administrator.");
-            }
-            else {
-              $status = ts("It looks like you are already registered for this event. If you want to change your registration, or you feel that you've received this message in error, please contact the site administrator.");
-            }
-            $status .= ' ' . ts('You can also <a href="%1">register another participant</a>.', [1 => $registerUrl]);
-            CRM_Core_Session::singleton()->setStatus($status, '', 'alert');
-            // @todo - pass cid=0 in the url & remove noFullMsg here.
-            $url = CRM_Utils_System::url('civicrm/event/info',
-              "reset=1&id={$form->_values['event']['id']}&noFullMsg=true"
-            );
-            if ($form->_action & CRM_Core_Action::PREVIEW) {
-              $url .= '&action=preview';
-            }
-
-            if ($form->_pcpId) {
-              $url .= '&pcpId=' . $form->_pcpId;
-            }
-
-            CRM_Utils_System::redirect($url);
+      $errors = CRM_Event_BAO_Participant::validateExistingRegistration(
+        $contactID,
+        $form->_values['event']['id'],
+        NULL,
+        $isAdditional
+      );
+      $status = reset($errors);
+      if (is_string($status)) {
+        if (!$isAdditional) {
+          $registerUrl = CRM_Utils_System::url('civicrm/event/register',
+            "reset=1&id={$form->_values['event']['id']}&cid=0"
+          );
+          if ($form->_pcpId) {
+            $registerUrl .= '&pcpId=' . $form->_pcpId;
           }
-
-          if ($isAdditional) {
-            $status = ts("It looks like this participant is already registered for this event. If you want to change your registration, or you feel that you've received this message in error, please contact the site administrator.");
-            CRM_Core_Session::singleton()->setStatus($status, '', 'alert');
-            return $participant->id;
-          }
+          $status .= ' ' . ts('You can also <a href="%1">register another participant</a>.', [1 => $registerUrl]);
         }
+
+        CRM_Core_Session::singleton()->setStatus($status, '', 'alert');
+
+        if (!$isAdditional) {
+          // @todo - pass cid=0 in the url & remove noFullMsg here.
+          $url = CRM_Utils_System::url('civicrm/event/info',
+            "reset=1&id={$form->_values['event']['id']}&noFullMsg=true"
+          );
+          if ($form->_action & CRM_Core_Action::PREVIEW) {
+            $url .= '&action=preview';
+          }
+          if ($form->_pcpId) {
+            $url .= '&pcpId=' . $form->_pcpId;
+          }
+          CRM_Utils_System::redirect($url);
+        }
+
+        return TRUE;
       }
     }
   }

--- a/CRM/Event/Form/Task/Register.php
+++ b/CRM/Event/Form/Task/Register.php
@@ -117,7 +117,7 @@ class CRM_Event_Form_Task_Register extends CRM_Event_Form_Participant {
       foreach ($this->_contactIds as $k => $dupeCheckContactId) {
         // Eliminate contacts that have already been assigned to this event.
         if (
-          CRM_Event_BAO_Participant::exists(
+          count(CRM_Event_BAO_Participant::getExistingParticipants(
             $dupeCheckContactId,
             $event_id,
             FALSE,
@@ -125,7 +125,7 @@ class CRM_Event_Form_Task_Register extends CRM_Event_Form_Participant {
             [],
             [],
             TRUE
-          )
+          )) > 0
         ) {
           $duplicateContacts++;
           if (!$allowSameParticipantEmails) {

--- a/CRM/Event/Form/Task/Register.php
+++ b/CRM/Event/Form/Task/Register.php
@@ -116,7 +116,17 @@ class CRM_Event_Form_Task_Register extends CRM_Event_Form_Participant {
       $duplicateContacts = 0;
       foreach ($this->_contactIds as $k => $dupeCheckContactId) {
         // Eliminate contacts that have already been assigned to this event.
-        if (!empty($this->getExistingParticipantRecords($dupeCheckContactId))) {
+        if (
+          CRM_Event_BAO_Participant::exists(
+            $dupeCheckContactId,
+            $event_id,
+            FALSE,
+            TRUE,
+            [],
+            [],
+            TRUE
+          )
+        ) {
           $duplicateContacts++;
           if (!$allowSameParticipantEmails) {
             unset($this->_contactIds[$k]);

--- a/tests/phpunit/CRM/Event/Form/Registration/RegisterTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/RegisterTest.php
@@ -120,9 +120,9 @@ class CRM_Event_Form_Registration_RegisterTest extends CiviUnitTestCase {
         'is_active' => 'The event you requested is currently unavailable (contact the site administrator for assistance).',
         'is_online_registration' => 'Online registration is not currently available for this event (contact the site administrator for assistance).',
         'is_template' => 'Event templates are not meant to be registered.',
-        'registration_start_date' => 'Registration for this event begins on ' . CRM_Utils_Date::customFormat(date('Ymd000000', strtotime('+ 1 day'))),
-        'registration_end_date' => 'Registration for this event ended on ' . CRM_Utils_Date::customFormat(date('Ymd000000', strtotime('- 1 day'))),
-        'event_end_date' => 'Registration for this event ended on ' . CRM_Utils_Date::customFormat(date('Ymd000000', strtotime('- 1 day'))),
+        'registration_start_date' => 'Registration for this event begins on ' . CRM_Utils_Date::customFormat(date('YmdH0000', strtotime('+ 1 day'))),
+        'registration_end_date' => 'Registration for this event ended on ' . CRM_Utils_Date::customFormat(date('YmdH0000', strtotime('- 1 day'))),
+        'event_end_date' => 'Registration for this event ended on ' . CRM_Utils_Date::customFormat(date('YmdHi', strtotime('- 1 day'))),
       ] as $parameter => $errorMessage) {
         $check = ($parameter === 'is_template');
         if (isset($formValues[$parameter]) && $formValues[$parameter] === $check) {
@@ -138,7 +138,7 @@ class CRM_Event_Form_Registration_RegisterTest extends CiviUnitTestCase {
     }
   }
 
-  public static function eventDataProvider(): array {
+  public function eventDataProvider(): array {
     return [
       'inactive_event' => [
         'form_values' => ['is_active' => FALSE],
@@ -150,13 +150,13 @@ class CRM_Event_Form_Registration_RegisterTest extends CiviUnitTestCase {
         'form_values' => ['is_template' => TRUE],
       ],
       'start_date_in_future' => [
-        'form_values' => ['registration_start_date' => date('Ymd000000', strtotime('+ 1 day'))],
+        'form_values' => ['registration_start_date' => date('YmdH0000', strtotime('+ 1 day'))],
       ],
       'registration_end_date_in_past' => [
-        'form_values' => ['registration_end_date' => date('Ymd000000', strtotime('- 1 day'))],
+        'form_values' => ['registration_end_date' => date('YmdH0000', strtotime('- 1 day'))],
       ],
       'event_end_date_in_past' => [
-        'form_values' => ['event_end_date' => date('Ymd000000', strtotime('- 1 day'))],
+        'form_values' => ['event_end_date' => date('YmdH0000', strtotime('- 1 day'))],
       ],
     ];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Validating event registrations implies checking for
* "readiness" of the event for registration (status, registration period, etc.)
* existing participants for the registering contact(s)
* available spaces
* available price options

All of this has been done in the form classes individually. This PR tries to refactor those parts out into the Participant BAO class and eventually using the API in the form layer for validation.

The aim is to have a central entry point for validation that an API or form validation will be able to call. As the PR evolves, all the individual steps will be moved into semantically grouped static methods on the Participant BAO which will then be called from the "central" validation method.

Status:
* [x] Validating the event
* [x] Validating existing participants
* [x] Validating available spaces
* [ ] Validating available price options (follow-up PR)
* [x] Tests (@monishdeb)
  - https://github.com/civicrm/civicrm-core/pull/31234 


Before
----------------------------------------
Different event registration and participant forms did this validation on their own (with differing criteria!), there was no central point of checking for existing participants that could've been reliably called from elsewhere.

After
----------------------------------------
Central validation method on the BAO to be calles by the API eventually, plus "sub"-methods for validating each aspect of an event registration.

Technical Details
----------------------------------------
Some of the new methods have a fairly extensive signature, which I'm not sure is necessary and which I'd like to be discussed, hence this PR being a draft for now. The calls I added (replacing individual queries) had differing criteria for checking for existing participants, which I tried to retain semantically.

Since there are different contexts for validation (basically "admin" and "public"), validation will have to be able to behave differently in each case. There might be additions necessary for more actions on event registrations to validate (e.g. self-service transfer/cancel).

Comments
----------------------------------------
Shouldn't we rely on `is_counted` only and not bother with `On waitlist` or `Cancelled` status separately? This would make the signatures of the new methods cleaner. And if you configure `On waitlist` or `Cancelled` to be counted, the current assumptions don't really fit anymore …

Also, why does `\CRM_Event_Form_Registration_Register::checkRegistration()` take roles into account and other forms don't?

Also, I'm quite sure the checks in `\CRM_Event_Form_Participant::formRule()` and `\CRM_Event_Form_Task_Register::postProcess()` should not include test participants, as their current implementations do, and they don't care for `is_counted` or other status-related attributes at all.

Lastly, did I miss any more checks that can be replaced by the new method?

@colemanw, @JoeMurray, @eileenmcnaughton happy to hear your thoughts!