### PR TITLE
dev/core#5246 - Allow form builder to toggle time input on date/time fields

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -6,6 +6,12 @@
     </select>
   </div>
 </li>
+<li ng-if="$ctrl.fieldDefn.input_type === 'Date' && $ctrl.getDefn().input_attrs.time">
+  <a href ng-click="toggleAttr('input_attrs.time'); $event.stopPropagation(); $event.target.blur();" title="{{:: ts('Input date + time') }}">
+    <i class="crm-i fa-{{ getProp('input_attrs.time') ? 'check-' : '' }}square-o"></i>
+    {{:: ts('Show Time') }}
+  </a>
+</li>
 <li ng-if="$ctrl.fieldDefn.input_type === 'Number' && $ctrl.fieldDefn.data_type === 'Float'">
   <div href ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
     <label>{{:: ts('Decimal places:') }}</label>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -260,7 +260,7 @@
       }
 
       function setFieldDefn() {
-        ctrl.fieldDefn = angular.extend({}, ctrl.getDefn(), ctrl.node.defn);
+        ctrl.fieldDefn = angular.merge({}, ctrl.getDefn(), ctrl.node.defn);
       }
 
       function setDateOptions() {


### PR DESCRIPTION
Overview
----------------------------------------
Sometimes you only want the date. This allows the widget to be customized as date-only. Fixes https://lab.civicrm.org/dev/core/-/issues/5246

Before
----------------------------------------
Date/time fields were always rendered with both inputs.

After
----------------------------------------
![image](https://github.com/user-attachments/assets/f56ebf6d-f8cb-49c3-9780-cd05b472b627)

Comments
------------
Depends on #30689 to work correctly.
