### PR TITLE
don't crash when sending event receipts for orgs

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -2342,18 +2342,10 @@ WHERE  ce.loc_block_id = $locBlockId";
   }
 
   /**
-   * @param array $profileIds
-   * @param int $cid
-   * @param int $participantId
-   * @param bool $isTest Probably not required, even when true.
-   * @param array|null $groups group values from session
-   * @param string|null $note note values from session
-   *
-   * @return array
    * @throws \CRM_Core_Exception
    * @throws \Civi\Core\Exception\DBQueryException
    */
-  public static function getProfileDisplay(array $profileIds, int $cid, int $participantId, bool $isTest = FALSE, ?array $groups = NULL, ?string $note = NULL): array {
+  public static function getProfileDisplay(array $profileIds, int $cid, int $participantId, bool $isTest = FALSE, ?array $groups = NULL, ?string $note = NULL): ?array {
     foreach ($profileIds as $gid) {
       if (CRM_Core_BAO_UFGroup::filterUFGroups($gid, $cid)) {
         $values = [];


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/5349

Before
----------------------------------------
Crash when sending event receipts to organizations in most common configurations (including all 3 events in demo data).

After
----------------------------------------
No crash.

Technical Details
----------------------------------------
See lab.c.o.

Comments
----------------------------------------
This only occurs in 5.76+.
