### PR TITLE
Afform - Permit > 1 block per contact (email, phone, etc)

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
@@ -159,7 +159,7 @@
       // Note that if a block contains no fields it can be used repeatedly, so this will always return false for those.
       $scope.blockInUse = function(block) {
         if (block['af-join']) {
-          return check(ctrl.editor.layout['#children'], {'af-join': block['af-join']});
+          return check(ctrl.editor.layout['#children'], (item) => item['af-join'] === block['af-join'] && !(item.data && item.data.location_type_id));
         }
         var fieldsInBlock = _.pluck(afGui.findRecursive(afGui.meta.blocks[block['#tag']].layout, {'#tag': 'af-field'}), 'name');
         return check(ctrl.editor.layout['#children'], function(item) {

--- a/ext/afform/core/Civi/Afform/FormDataModel.php
+++ b/ext/afform/core/Civi/Afform/FormDataModel.php
@@ -179,7 +179,17 @@ class FormDataModel {
         }
       }
       elseif ($entity && !empty($node['af-join'])) {
-        $this->entities[$entity]['joins'][$node['af-join']] = AHQ::getProps($node);
+        $joinProps = AHQ::getProps($node);
+        // If the join is declared > once, merge data
+        $existingJoin = $this->entities[$entity]['joins'][$node['af-join']] ?? [];
+        if (!empty($existingJoin['data']) && !empty($joinProps['data'])) {
+          foreach ($joinProps['data'] as $key => $value) {
+            if (!empty($existingJoin['data'][$key]) && $existingJoin['data'][$key] !== $value) {
+              $joinProps['data'][$key] = array_unique(array_merge((array) $existingJoin['data'][$key], (array) $value));
+            }
+          }
+        }
+        $this->entities[$entity]['joins'][$node['af-join']] = $joinProps;
         $this->parseFields($node['#children'] ?? [], $entity, $node['af-join'], NULL, $afIfConditions);
       }
       elseif (!empty($node['#children'])) {

--- a/ext/afform/core/ang/af/afFieldset.directive.js
+++ b/ext/afform/core/ang/af/afFieldset.directive.js
@@ -13,8 +13,9 @@
         self.afFormCtrl = ctrls[1];
       },
       controller: function($scope, $element) {
-        var ctrl = this,
-          localData = [];
+        let ctrl = this;
+        let localData = [];
+        let joinOffsets = {};
 
         this.getData = function() {
           return ctrl.afFormCtrl ? ctrl.afFormCtrl.getData(ctrl.modelName) : localData;
@@ -40,6 +41,11 @@
         };
         this.getFormName = function() {
           return ctrl.afFormCtrl ? ctrl.afFormCtrl.getFormMeta().name : $scope.meta.name;
+        };
+
+        this.getJoinOffset = function(joinEntity) {
+          joinOffsets[joinEntity] = joinEntity in joinOffsets ? joinOffsets[joinEntity] + 1 : 0;
+          return joinOffsets[joinEntity];
         };
 
         // If `storeValue` setting is enabled, field values are cached in localStorage

--- a/ext/afform/core/ang/af/afJoin.directive.js
+++ b/ext/afform/core/ang/af/afJoin.directive.js
@@ -12,6 +12,8 @@
           var self = ctrls[0];
           self.afFieldset = ctrls[1];
           self.repeatItem = ctrls[2];
+          // Used when there is > 1 block per entity
+          self.offset = self.afFieldset.getJoinOffset($attr.afJoin);
         },
         controller: function($scope) {
           var self = this;
@@ -39,10 +41,10 @@
           };
           this.getFieldData = function() {
             var data = this.getData();
-            if (!data.length) {
-              data.push({});
+            if (!data[this.offset]) {
+              data[this.offset] = {};
             }
-            return data[0];
+            return data[this.offset];
           };
         }
       };


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/3433

Before
----------------------------------------
Only one block allowed per contact.

After
----------------------------------------
Multiples allowed (each one must specify a location type)

