### PR TITLE
fixes for custom field: checkbox saving using fb

### DIFF
--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -259,7 +259,12 @@ trait DAOActionTrait {
 
       // Uglify checkbox values for the sake of CustomField::formatCustomField()
       if ($field['html_type'] === 'CheckBox' && is_array($value)) {
-        $value = array_fill_keys($value, TRUE);
+        if (empty($value)) {
+          $value = '';
+        }
+        else {
+          $value = array_fill_keys($value, TRUE);
+        }
       }
 
       // Match contact id to strings like "user_contact_id"


### PR DESCRIPTION
[Overview
----------------------------------------
- Create a custom field of type radio
- Include it in the FB form (check autofill)
- Save the data - works
- Save again - results in error.

Basically if there is existing data for custom field it fails to save the form.

Issue can be replicated in dmaster.

Before
----------------------------------------
![Screenshot from 2024-06-12 15-13-13](https://github.com/civicrm/civicrm-core/assets/151481/352352f4-d76c-49b8-9f98-32322c60bc94)
![Screenshot from 2024-06-12 15-13-39](https://github.com/civicrm/civicrm-core/assets/151481/51ee5005-84b6-4355-8036-491a3efa332e)


After
----------------------------------------
Works fine.

Technical Details
----------------------------------------
This might be a regression related to https://lab.civicrm.org/dev/core/-/issues/5103 and this PR, https://github.com/civicrm/civicrm-core/pull/29786/files](https://github.com/civicrm/civicrm-core/pull/30706)