### PR TITLE
[WIP] core/issues#5354 : Add Membership.Validate APIv4 action

### DIFF
--- a/Civi/Api4/Generic/ValidateAction.php
+++ b/Civi/Api4/Generic/ValidateAction.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Generic;
+
+use Civi\Api4\Event\ValidateValuesEvent;
+
+/**
+ * Base class for all `Validate` api actions.
+ *
+ * @method $this setValues(array $values) Set all field values from an array of key => value pairs.
+ * @method array getValues() Get field values.
+ *
+ * @package Civi\Api4\Generic
+ */
+class ValidateAction extends AbstractAction {
+
+  use Traits\GetSetValueTrait;
+
+  /**
+   * Run the api Action.
+   *
+   * @param \Civi\Api4\Generic\Result $result
+   *
+   */
+  public function _run(Result $result): void {
+    $e = new ValidateValuesEvent($this, [$this->getValues()], new \CRM_Utils_LazyArray(function () {
+      return [['old' => NULL, 'new' => $this->getValues()]];
+    }));
+
+    $this->onValidateValues($e);
+    \Civi::dispatcher()->dispatch('civi.api4.validate', $e);
+    if (!empty($e->errors)) {
+      $result[] = $e->errors;
+    }
+  }
+
+  protected function onValidateValues(ValidateValuesEvent $e) {
+    foreach ($e->records as $recordKey => $record) {
+      $unmatched = $this->checkRequiredFields($record);
+      if ($unmatched) {
+        $e->addError($recordKey, $unmatched, 'mandatory_missing', "Mandatory values missing from Api4 {$this->getEntityName()}::{$this->getActionName()}: " . implode(", ", $unmatched));
+      }
+    }
+  }
+
+}

--- a/ext/civi_member/Civi/Api4/Action/Membership/Validate.php
+++ b/ext/civi_member/Civi/Api4/Action/Membership/Validate.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Membership;
+
+use Civi\Api4\Generic\ValidateAction;
+use Civi\Api4\Event\ValidateValuesEvent;
+
+/**
+ * Validate membership parameters before creating/updating Memberships.
+ */
+class Validate extends ValidateAction {
+
+  protected function onValidateValues(ValidateValuesEvent $e) {
+    foreach ($e->records as $recordKey => $record) {
+      parent::onValidateValues($e);
+
+      if (empty($record['status_id'])) {
+        $e->addError($recordKey, 'status_id', 'empty_status_id', ts('There is no valid Membership Status available for selected membership dates.'));
+      }
+
+      if (!empty($record['join_date'])) {
+        if (!empty($record['membership_type_id']) && !empty($record['start_date'])) {
+          $membershipDetails = \CRM_Member_BAO_MembershipType::getMembershipType($record['membership_type_id']);
+          if ($record['start_date'] && ($membershipDetails['period_type'] ?? NULL) === 'rolling') {
+            if ($record['start_date'] < $record['join_date']) {
+              $e->addError($recordKey, 'start_date', 'incorrect_start_date', 'Start date must be the same or later than Member since.');
+            }
+          }
+        }
+        if (!empty($record['end_date'])) {
+          if ($membershipDetails['duration_unit'] === 'lifetime') {
+            // Check if status is NOT cancelled or similar. For lifetime memberships, there is no automated
+            // process to update status based on end-date. The user must change the status now.
+            $result = civicrm_api3('MembershipStatus', 'get', [
+              'sequential' => 1,
+              'is_current_member' => 0,
+            ]);
+            $tmp_statuses = $result['values'];
+            $status_ids = [];
+            foreach ($tmp_statuses as $cur_stat) {
+              $status_ids[] = $cur_stat['id'];
+            }
+
+            if (empty($record['status_id']) || in_array($record['status_id'], $status_ids) == FALSE) {
+              $e->addError($recordKey, 'status_id', 'lifetime_membership_error', ts('A current lifetime membership cannot have an end date. You can either remove the end date or change the status to a non-current status like Cancelled, Expired, or Deceased.'));
+            }
+            if (!empty($record['is_override']) && !\CRM_Member_StatusOverrideTypes::isPermanent($record['is_override'])) {
+              $e->addError($recordKey, 'is_override', 'lifetime_membership_error', ts('Because you set an End Date for a lifetime membership, This must be set to "Override Permanently"'));
+            }
+          }
+          else {
+            if (!$record['start_date']) {
+              $e->addError($recordKey, 'start_date', 'empty_start_date', ts('Start date must be set if end date is set.'));
+            }
+            if ($record['end_date'] < $record['start_date']) {
+              $e->addError($recordKey, 'end_date', 'incorrect_end_date', ts('End date must be the same or later than start date.'));
+            }
+          }
+        }
+      }
+
+      if (!empty($record['is_override']) && \CRM_Member_StatusOverrideTypes::isUntilDate($record['is_override'])) {
+        if (empty($record['status_override_end_date'])) {
+          $e->addError($recordKey, 'status_override_end_date', 'empty_status_override_end_date', ts('Please enter the Membership override end date.'));
+        }
+      }
+      if (empty($record['join_date'])) {
+        $e->addError($recordKey, 'join_date', 'empty_join_date', ts('Please enter the Member Since.'));
+      }
+      if (!empty($record['is_override']) && CRM_Member_StatusOverrideTypes::isOverridden($record['is_override']) && empty($record['status_id'])) {
+        $e->addError($recordKey, 'status_id', 'empty_status_id', ts('Please enter the Membership status.'));
+      }
+    }
+  }
+
+}

--- a/ext/civi_member/Civi/Api4/Membership.php
+++ b/ext/civi_member/Civi/Api4/Membership.php
@@ -10,6 +10,8 @@
  */
 namespace Civi\Api4;
 
+use Civi\Api4\Action\Membership\Validate;
+
 /**
  * Membership entity.
  *
@@ -19,5 +21,14 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class Membership extends Generic\DAOEntity {
+
+  /**
+   * @param bool $checkPermissions
+   * @return Civi\Api4\Action\Membership\Validate
+   */
+  public static function validate($checkPermissions = TRUE) {
+    return (new Validate(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Remaining 
- [x] Replace the formrule validation code with the Membership.validate Apiv4 call           
- [ ] Add unit tests to reproduce different validation failures by using Membership.validate()

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
List of errors from the back office formRule https://docs.google.com/spreadsheets/d/1Ul-VSnw50_b1_xdd9mY2wtMSXK3HDLCesLJIdt9F66s/edit?usp=sharing