### PR TITLE
SearchKit - Set column autosize for spreadsheet downloads

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
@@ -180,6 +180,7 @@ class Download extends AbstractRunAction {
     // Header row
     foreach (array_values($columns) as $index => $col) {
       $sheet->setCellValueByColumnAndRow($index + 1, 1, $col['label']);
+      $sheet->getColumnDimensionByColumn($index)->setAutoSize(TRUE);
     }
 
     foreach ($rows as $rowNum => $data) {


### PR DESCRIPTION
Overview
----------------------------------------
It's very annoying to download a spreadsheet in a SearchKit and having to resize columns to comfortably view the content.

Similar to how https://civicrm.org/extensions/export-native-excel does it

Before
----------------------------------------
All columns have the same default size.

After
----------------------------------------
Columns are self-adjusted to their content.