### PR TITLE
dev/core#5344 Fix Grant extension interfering with Contribution Search

### DIFF
--- a/ext/civigrant/schema/Grant.entityType.php
+++ b/ext/civigrant/schema/Grant.entityType.php
@@ -206,6 +206,7 @@ return [
       'sql_type' => 'varchar(3)',
       'input_type' => 'Select',
       'required' => TRUE,
+      'unique_name' => 'grant_currency',
       'description' => E::ts('3 character string, value from config setting or input via user.'),
       'add' => '3.2',
       'input_attrs' => [
@@ -263,6 +264,7 @@ return [
       'input_type' => 'Select',
       'description' => E::ts('FK to Financial Type.'),
       'add' => '4.3',
+      'unique_name' => 'grant_financial_type_id',
       'default' => NULL,
       'input_attrs' => [
         'label' => E::ts('Financial Type'),

--- a/ext/civigrant/tests/phpunit/api/v3/GrantTest.php
+++ b/ext/civigrant/tests/phpunit/api/v3/GrantTest.php
@@ -13,6 +13,9 @@ use Civi\Test;
 use Civi\Test\Api3TestTrait;
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\ContactTestTrait;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  *  Test APIv3 civicrm_grant* functions
@@ -21,15 +24,15 @@ use Civi\Test\ContactTestTrait;
  * @subpackage API_Grant
  * @group headless
  */
-class api_v3_GrantTest extends \PHPUnit\Framework\TestCase implements \Civi\Test\HeadlessInterface, \Civi\Test\TransactionalInterface {
+class api_v3_GrantTest extends TestCase implements HeadlessInterface, TransactionalInterface {
   use Api3TestTrait;
   use ContactTestTrait;
   use Test\EntityTrait;
 
   protected $_apiversion = 3;
-  protected $params;
+  protected array $params;
   protected $ids = [];
-  protected $_entity = 'Grant';
+  protected string $_entity = 'Grant';
 
   /**
    * @throws \CRM_Extension_Exception_ParseException
@@ -158,7 +161,7 @@ class api_v3_GrantTest extends \PHPUnit\Framework\TestCase implements \Civi\Test
     $this->assertGreaterThanOrEqual(1, $result['count']);
   }
 
-  public function testGrantGetDoesNotInterfereWithContributionGet() {
+  public function testGrantGetDoesNotInterfereWithContributionGet(): void {
     $this->individualCreate();
     $this->createTestEntity('Contribution', [
       'contact_id' => $this->individualCreate(),


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5344 Fix Grant extension interfering with Contribution Search

Before
----------------------------------------
In 5.76+ doing a `Contribuiton.get` with CiviGrant enabled does not correctly retrieve currency

After
----------------------------------------
Fixed, tested

Technical Details
----------------------------------------
In the course of adding token `usage` over at https://github.com/civicrm/civicrm-core/commit/26d486b632ceeb8f1d607d8351a8e9fe99026a64#diff-f3e4adae0b28e70fd27fb8574132907b6dd7b3c010a0c39b9a2195630627d71aR221 the `export` usage was added too - which winds up adding `currency` from the grant table to the query object queries

In thinking about this I feel there were 2 options

1) re-remove the usage
2) make it work

I'm not terribly wedded to 'make it work' - it might not even be actually accessible from anywhere but I landed on adding a unique key to 'make it work' (not clash in the advanced search / contribution search context) because it feels like there might be a reasonable case to re-add the usage later on & it would break again & possibly cause havoc. Given that the fields previously did not have export / import/ query-object search usage it is 'safe' to add the unique key I believe

Comments
----------------------------------------
