### PR TITLE
dev/core#5308 : APIv4 - Add Order.validate

### DIFF
--- a/Civi/Api4/Action/Order/Validate.php
+++ b/Civi/Api4/Action/Order/Validate.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Order;
+
+use Civi\Api4\Generic\ValidateAction;
+
+/**
+ * Validate Order parameters and related entities before creating an order.
+ */
+class Validate extends ValidateAction {}

--- a/Civi/Api4/Generic/ValidateAction.php
+++ b/Civi/Api4/Generic/ValidateAction.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Generic;
+
+use Civi\Api4\Event\ValidateValuesEvent;
+
+/**
+ * Base class for all `Validate` api actions.
+ *
+ * @method $this setValues(array $values) Set all field values from an array of key => value pairs.
+ * @method array getValues() Get field values.
+ *
+ * @package Civi\Api4\Generic
+ */
+class ValidateAction extends AbstractAction {
+
+  use Traits\GetSetValueTrait;
+
+  /**
+   * Run the api Action.
+   *
+   * @param \Civi\Api4\Generic\Result $result
+   *
+   */
+  public function _run(Result $result): void {
+    $e = new ValidateValuesEvent($this, [$this->getValues()], new \CRM_Utils_LazyArray(function () {
+      return [['old' => NULL, 'new' => $this->getValues()]];
+    }));
+
+    $this->onValidateValues($e);
+    \Civi::dispatcher()->dispatch('civi.api4.validate', $e);
+    if (!empty($e->errors)) {
+      $result[] = $e->errors;
+    }
+  }
+
+  protected function onValidateValues(ValidateValuesEvent $e) {
+    foreach ($e->records as $recordKey => $record) {
+      $unmatched = $this->checkRequiredFields($record);
+      if ($unmatched) {
+        $e->addError($recordKey, $unmatched, 'mandatory_missing', "Mandatory values missing from Api4 {$this->getEntityName()}::{$this->getActionName()}: " . implode(", ", $unmatched));
+      }
+    }
+  }
+
+}

--- a/Civi/Api4/Order.php
+++ b/Civi/Api4/Order.php
@@ -11,6 +11,7 @@
 namespace Civi\Api4;
 
 use Civi\Api4\Action\Order\Create;
+use Civi\Api4\Action\Order\Validate;
 use Civi\Api4\Generic\BasicGetFieldsAction;
 
 /**
@@ -42,6 +43,15 @@ class Order extends Generic\AbstractEntity {
     return (new Generic\BasicGetFieldsAction(__CLASS__, __FUNCTION__, function() {
       return [];
     }))->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return Civi\Api4\Action\Order\Validate
+   */
+  public static function validate($checkPermissions = TRUE) {
+    return (new Validate(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Add (skeletal) Order.validate APIv4 action. This adds the generic validate action that can be inherited by all entities for validating the parameters of an entity before doing CRUD operation.  

Ref - https://lab.civicrm.org/dev/core/-/issues/5308

Comments
----------------------------------------
ping @JoeMurray @eileenmcnaughton @colemanw @jensschuppe @seamuslee001 
