### PR TITLE
fix scheduled reminders changed from relative to absolute dates

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -330,10 +330,10 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
 
     // Absolute or relative date
     if ($values['absolute_or_relative_date'] === 'absolute') {
-      $values['start_action_offset'] = $values['start_action_unit'] = $values['start_action_condition'] = $values['start_action_date'] = NULL;
+      $values['start_action_offset'] = $values['start_action_unit'] = $values['start_action_condition'] = $values['start_action_date'] = '';
     }
     else {
-      $values['absolute_date'] = NULL;
+      $values['absolute_date'] = '';
     }
 
     // Convert values for the fields added by CRM_Mailing_BAO_Mailing::commonCompose


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/5357

Overview
----------------------------------------
If you set up a Scheduled Reminder with a relative date (e.g. "3 days after event ends"), then change it to an absolute date (e.g. "12/22/2025") then the relative date is still used for calculating when the reminder goes out.

Reproduction steps
----------------------------------------
* Create a scheduled reminder with a relative date that is in the past (e.g. 1 day after an event that ended last week.
* Change it to an absolute date in the future.
* Run the "Send Scheduled Reminders" job.

Current behaviour
----------------------------------------
Reminder is sent.

Expected behaviour
----------------------------------------
Reminder shouldn't send until the absolute date is reached.

Comments
----------------------------------------
There is code in the `postProcess` to see if the date is absolute or relative - then `NULL`s the value that wasn't selected.  However, `writeRecord()` treats `NULL` as "ignore".  I'm *speculating* this regressed when this was converted to `writeRecord()`.  Setting them to empty strings fixes the behavior.

If this *is* due to `writeRecord()`, it seems like something we need to be especially careful about when converting.

I'm going to file this against master because this has been broken for about a year.

It's easy to see the changes by looking at the database:

```sql
select id, name, title, recipient, start_action_offset, start_action_unit, start_action_condition, start_action_date, absolute_date, is_active from civicrm_action_schedule;
```