### PR TITLE
Fix List-Unsubscribe warning in logs

### DIFF
--- a/ext/flexmailer/src/API/MailingPreview.php
+++ b/ext/flexmailer/src/API/MailingPreview.php
@@ -52,6 +52,7 @@ class MailingPreview {
     };
     $job->mailing_id = $mailing->id ?: NULL;
     $job->status = 'Complete';
+    $job->find(TRUE);
 
     $flexMailer = new FlexMailer([
       'is_preview' => TRUE,


### PR DESCRIPTION
Overview
----------------------------------------
Fix List-Unsubscribe warning in logs

Before
----------------------------------------
CiviCRM error log is filled with the following warning message

> [warning] Failed to set final value of List-Unsubscribe

To replicate: View the mailing on the browser and then check civi logs.

After
----------------------------------------
Fixed.


Comments
----------------------------------------
Related SE - [Warning: Failed to set final value of List-Unsubscribe](https://civicrm.stackexchange.com/questions/47630/warning-failed-to-set-final-value-of-list-unsubscribe)