### PR TITLE
dev/core#5356 dev/core#5379 Fix space comparison for multiple participants

### DIFF
--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -276,8 +276,8 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
         $realPayLater = $this->_params[0]['is_pay_later'] ?? NULL;
       }
 
-      //truly spaces are greater than required.
-      if (is_numeric($spaces) && $spaces >= ($processedCnt + $currentPageMaxCount)) {
+      //truly spaces are less than required.
+      if (is_numeric($spaces) && $spaces <= ($processedCnt + $currentPageMaxCount)) {
         if (CRM_Utils_Array::value('amount', $this->_params[0], 0) == 0 || $this->_requireApproval) {
           $this->_allowWaitlist = FALSE;
           $this->set('allowWaitlist', $this->_allowWaitlist);


### PR DESCRIPTION
Overview
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/5356 the notification for space limitations is incorrect for multiple participants

Before
----------------------------------------
Warnings about being over the limit occur when there are still spaces available

After
----------------------------------------
Warnings about being over the limit occur when there are not spaces available

Technical Details
----------------------------------------
I originally thought this must be a regression but the code just looks wrong and like it has been wrong for a long time. I am officially confused. Perhaps @JKingsnorth @MegaphoneJon @twomice can either 
a) reduce my confusion or b) send hard liquor

Comments
----------------------------------------
