### PR TITLE
CaseActivity: Ignore case activity assignee contact id when activity type should not be notified.

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -600,7 +600,8 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
                 [$vval['actId']], TRUE, FALSE
               );
               $mailStatus .= ' ' . ts("A copy of the activity has also been sent to assignee contact(s).");
-            } else {
+            }
+            else {
               continue;
             }
           }

--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -600,6 +600,8 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
                 [$vval['actId']], TRUE, FALSE
               );
               $mailStatus .= ' ' . ts("A copy of the activity has also been sent to assignee contact(s).");
+            } else {
+              continue;
             }
           }
           //build an associative array with unique email addresses.


### PR DESCRIPTION
Overview
----------------------------------------
Ignore case activity assignee contact id when activity type is included in "Do not notify assignees for" settings.
- When creating a Case Activity that has the same Participant and Assignee, it will send a notification email to assignee even if activity type is included in "Do not notify assignees for" settings.

Before
----------------------------------------
It sends notification email to assignee even if activity type is included in "Do not notify assignees for" settings.

After
----------------------------------------
Should not send notification email to assignee when activity type is included in "Do not notify assignees for" settings.

Technical Details
----------------------------------------
CiviCRM: 5.75.0

Comments
----------------------------------------

