### PR TITLE
[REF] Accessiblity fix - empty form label on new organization form

### DIFF
--- a/CRM/Contact/Form/Edit/Organization.php
+++ b/CRM/Contact/Form/Edit/Organization.php
@@ -36,18 +36,18 @@ class CRM_Contact_Form_Edit_Organization {
 
     if (!$inlineEditMode || $inlineEditMode == 1) {
       // Organization_name
-      $form->addField('organization_name');
+      $form->addField('organization_name', ['title' => ts('Organization Name')]);
     }
 
     if (!$inlineEditMode || $inlineEditMode == 2) {
       // legal_name
-      $form->addField('legal_name');
+      $form->addField('legal_name', ['title' => ts('Legal Name')]);
 
       // nick_name
-      $form->addField('nick_name');
+      $form->addField('nick_name', ['title' => ts('Nickname')]);
 
       // sic_code
-      $form->addField('sic_code');
+      $form->addField('sic_code', ['title' => ts('SIC Code')]);
       $form->addField('contact_source');
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Add title to missing input text element on 'New Organization' form, to fix the missing label accessibility issues. 

Before
----------------------------------------
<img width="1412" alt="Screenshot 2024-07-22 at 17 04 20" src="https://github.com/user-attachments/assets/3e33a0a1-5baf-436a-a273-9550f250a272">


After
----------------------------------------
Fixed

Technical Details
----------------------------------------
@eileenmcnaughton as we removed the label element by adding 'smarty:nodefaults|purify' to the labels which purify the content as label text [here](https://github.com/civicrm/civicrm-core/pull/27951/files#diff-cc96b1968541d31e2480d6375d5119cf4f27d24313ffe70476d104ae73880b13R15) This caused a accessibility issue shown in the before section. In order to solve this I have added title attribute to the input text elements. 

Comments
----------------------------------------
ping @eileenmcnaughton @colemanw @seamuslee001 
