### PR TITLE
I got in a fight with AngerJS

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiCondition.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiCondition.html
@@ -2,5 +2,5 @@
   <option ng-repeat="(name, label) in $ctrl.getOperators()" value="{{:: name }}">{{:: label }}</option>
 </select>
 <div class="form-group" ng-if="$ctrl.operatorTakesInput()">
-  <input af-gui-field-value="$ctrl.field" ng-model="$ctrl.getSetValue" op="$ctrl.clause[$ctrl.offset]" ng-model-options="{getterSetter: true}" class="form-control"></input>
+  <input af-gui-field-value="$ctrl.field" ng-model="$ctrl.getSetValue" op="$ctrl.clause[$ctrl.offset]" ng-model-options="{getterSetter: true}" class="form-control">
 </div>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
@@ -13,17 +13,37 @@
         ngModel: 'ngModel',
         editor: '?^^afGuiEditor'
       },
+      link: {
+        post: function ngOptionsPreLink(scope, element, attr, ctrls) {
+
+          // Formatter for ngModel to convert value to a string for select2
+          // AngularJS provides its own formatter (`stringBasedInputType`) which simply casts the value to a string
+          // Formatters are applied in reverse-order so using postLink ensures this one comes last in the array & gets applied first
+          function formatViewValue(value) {
+            if (Array.isArray(value)) {
+              return value.join("\u0001");
+            }
+            if (typeof value === 'boolean') {
+              return value ? '1' : '0';
+            }
+            return value;
+          }
+          ctrls.ngModel.$formatters.push(formatViewValue);
+        }
+      },
       controller: function ($element, $timeout) {
         var ts = CRM.ts('org.civicrm.afform_admin'),
           ctrl = this,
+          dataType,
           multi;
 
         function makeWidget(field) {
           var options,
             filters,
             $el = $($element),
-            inputType = field.input_type,
-            dataType = field.data_type;
+            inputType = field.input_type;
+
+          getDataType();
 
           // Decide whether the input should be multivalued
           if (ctrl.op) {
@@ -86,6 +106,19 @@
           return $element.is('.select2-container + input');
         }
 
+        function getDataType() {
+          if (ctrl.field) {
+            dataType = ctrl.field.data_type;
+          }
+        }
+
+        function convertDataType(val) {
+          if (dataType === 'Integer') {
+            return +val;
+          }
+          return val;
+        }
+
         // Copied from ng-list but applied conditionally if field is multi-valued
         var parseFieldInput = function(viewValue) {
           // If the viewValue is invalid (say required but empty) it will be `undefined`
@@ -96,34 +129,24 @@
           }
 
           if (!multi || !isSelect2()) {
-            return viewValue;
+            return convertDataType(viewValue);
           }
 
           var list = [];
 
           if (viewValue) {
             _.each(viewValue.split("\u0001"), function(value) {
-              if (value) list.push(_.trim(value));
+              list.push(convertDataType(value));
             });
           }
 
           return list;
         };
 
-        var formatViewValue = function(value) {
-          if (Array.isArray(value)) {
-            return value.join(',');
-          }
-          if (typeof value === 'boolean') {
-            return value ? '1' : '0';
-          }
-          return value;
-        };
-
         this.$onInit = function() {
+          getDataType();
           // Copied from ng-list
           ctrl.ngModel.$parsers.push(parseFieldInput);
-          ctrl.ngModel.$formatters.push(formatViewValue);
 
           // Copied from ng-list
           ctrl.ngModel.$isEmpty = function(value) {

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -154,6 +154,13 @@
         });
       };
 
+      // When this field is removed by afIf, also remove its value from the data model.
+      $scope.$on('afIfDestroy', function() {
+        if (ctrl.defn.input_type !== 'DisplayOnly') {
+          delete $scope.dataProvider.getFieldData()[ctrl.fieldName];
+        }
+      });
+
       // correct the type for the value, make sure numbers are numbers and not string
       function correctValueType(value, dataType) {
         // let's skip type correction for null values

--- a/ext/afform/core/ang/af/afIf.directive.js
+++ b/ext/afform/core/ang/af/afIf.directive.js
@@ -38,6 +38,8 @@
               previousElements = null;
             }
             if (childScope) {
+              // Alert afFields that they are about to be destroyed
+              childScope.$broadcast('afIfDestroy');
               childScope.$destroy();
               childScope = null;
             }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the following bug: https://lab.civicrm.org/dev/core/-/issues/5105#note_167574
It was not easy.

Before
----------------------------------------
1. Create a field that is conditionally hidden by a field
2. Create a 3rd field that is conditionally hidden by the conditional field
3. Triggering the first field to be hidden does not cascade down to the 3rd field, and it remains visible.

After
----------------------------------------
Works.

Technical Details
-----------
In order to solve this problem I first had to fix another problem: integer values in the `af-if` directive were being cast to string which caused the clientside comparisons to fail. This is where I had a big fight with Angular, and eventually tracked the problem to a load-order issue, where AngularJS provides its own formatter (`stringBasedInputType`), which casts the value to a string and ruins the serialization of arrays. After much trial-and-error I figured out that formatters are applied in reverse-order, and for some reason the angular core formatter is added quite late. The only way I could find to add one even later was to use a postLink function in the directive.