### PR TITLE
serialize custom fields when appropriate

### DIFF
--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -381,6 +381,10 @@ class CRM_Core_BAO_CustomValueTable {
           $cvParam['type'] = 'Timestamp';
         }
 
+        // Some form-layer forms (including FB) will pass a scalar for a serialized value, trust the data model over the form.
+        if ($cvParam['serialize'] !== 0 && !is_array($cvParam['value'])) {
+          $cvParam['value'] = CRM_Core_DAO::serializeField($cvParam['value'], $cvParam['serialize']);
+        }
         if (!empty($customValue['id'])) {
           $cvParam['id'] = $customValue['id'];
         }


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/5360.

Comments
----------------------------------------
I feel like I'm correct that we should be normalizing data passed in from our form layers, but this only addresses custom fields.  Is it necessary to handle this elsewhere so it affects core fields?  Perhaps in the API4 layer?
