### PR TITLE
APIv4 - Ensure dataType of option id matches dataType of field

### DIFF
--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -316,6 +316,7 @@ class BasicGetFieldsAction extends BasicGetAction {
           'Date' => ts('Date'),
           'Float' => ts('Float'),
           'Integer' => ts('Integer'),
+          'Money' => ts('Money'),
           'String' => ts('String'),
           'Text' => ts('Text'),
           'Timestamp' => ts('Timestamp'),

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -176,7 +176,7 @@ class SpecFormatter {
       $options = FALSE;
     }
     else {
-      $options = \CRM_Utils_Array::makeNonAssociative($optionLabels, 'id', 'label');
+      $options = self::formatOptionList($field, $optionLabels);
       if (is_array($returnFormat) && $options) {
         self::addOptionProps($options, $field, $bao, $fieldName, $values, $returnFormat);
       }
@@ -189,6 +189,28 @@ class SpecFormatter {
         'label' => ts('Current Domain'),
         'icon' => 'fa-sign-in',
       ]);
+    }
+    return $options;
+  }
+
+  private static function formatOptionList(array $field, array $optionLabels) {
+    $options = \CRM_Utils_Array::makeNonAssociative($optionLabels, 'id', 'label');
+    foreach ($options as &$option) {
+      switch ($field['data_type']) {
+        case 'String':
+        case 'Text':
+          $option['id'] = (string) $option['id'];
+          break;
+
+        case 'Float':
+        case 'Money':
+          $option['id'] = (float) $option['id'];
+          break;
+
+        case 'Integer':
+          $option['id'] = (int) $option['id'];
+          break;
+      }
     }
     return $options;
   }

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -180,21 +180,21 @@
             } else if (typeof val1 === 'string' && typeof val2 === 'string') {
               return val1.toLowerCase().includes(val2.toLowerCase()) === yes;
             }
-            return !yes;
+            return angular.equals(val1, val2) === yes;
 
           case 'IN':
           case 'NOT IN':
             if (Array.isArray(val2)) {
               return val2.includes(val1) === yes;
             }
-            return !yes;
+            return angular.equals(val1, val2) === yes;
 
           case 'LIKE':
           case 'NOT LIKE':
             if (typeof val1 === 'string' && typeof val2 === 'string') {
               return likeCompare(val1, val2) === yes;
             }
-            return !yes;
+            return angular.equals(val1, val2) === yes;
         }
       }
 

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -165,23 +165,6 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test calling GetTree for a custom field that extends a non numerical Event Type.
-   */
-  public function testGetTreeEventSubTypeAlphabetical(): void {
-    $eventType = $this->callAPISuccess('OptionValue', 'Create', ['option_group_id' => 'event_type', 'value' => '99_ish', 'name' => 'Meeting_99', 'label' => 'Meeting 99']);
-    $customGroup = $this->CustomGroupCreate(['extends' => 'Event', 'extends_entity_column_value' => ['99_ish']]);
-    $customField = $this->customFieldCreate(['custom_group_id' => $customGroup['id']]);
-    $result1 = CRM_Core_BAO_CustomGroup::getTree('Event', NULL, NULL, NULL, CRM_Core_DAO::VALUE_SEPARATOR . 'meeting_99' . CRM_Core_DAO::VALUE_SEPARATOR);
-    $this->assertEquals('Custom Field', $result1[$customGroup['id']]['fields'][$customField['id']]['label']);
-    $result1 = CRM_Core_BAO_CustomGroup::getTree('Event', NULL, NULL, NULL, ['99_ish']);
-    $this->assertEquals('Custom Field', $result1[$customGroup['id']]['fields'][$customField['id']]['label']);
-    $result1 = CRM_Core_BAO_CustomGroup::getTree('Event', NULL, NULL, NULL, ['99_ISH']);
-    $this->assertEquals('Custom Field', $result1[$customGroup['id']]['fields'][$customField['id']]['label']);
-    $this->customGroupDelete($customGroup['id']);
-    $this->callAPISuccess('OptionValue', 'delete', ['id' => $eventType['id']]);
-  }
-
-  /**
    * Test calling getTree with contact subtype data.
    *
    * Note that the function seems to support a range of formats so 3 are tested. Yay for

--- a/tests/phpunit/api/v4/Custom/PseudoconstantTest.php
+++ b/tests/phpunit/api/v4/Custom/PseudoconstantTest.php
@@ -149,7 +149,8 @@ class PseudoconstantTest extends CustomTestBase {
   public function testCustomOptions(): void {
     $technicolor = [
       ['id' => 'r', 'name' => 'red', 'label' => 'RED', 'color' => '#ff0000', 'description' => 'Red color', 'icon' => 'fa-red'],
-      ['id' => 'g', 'name' => 'green', 'label' => 'GREEN', 'color' => '#00ff00', 'description' => 'Green color', 'icon' => 'fa-green'],
+      // String '2' gets checked below via `assertSame` to ensure it doesn't get cast to int
+      ['id' => '2', 'name' => 'green', 'label' => 'GREEN', 'color' => '#00ff00', 'description' => 'Green color', 'icon' => 'fa-green'],
       ['id' => 'b', 'name' => 'blue', 'label' => 'BLUE', 'color' => '#0000ff', 'description' => 'Blue color', 'icon' => 'fa-blue'],
     ];
 
@@ -175,7 +176,7 @@ class PseudoconstantTest extends CustomTestBase {
 
     foreach ($technicolor as $index => $option) {
       foreach ($option as $prop => $val) {
-        $this->assertEquals($val, $fields['myPseudoconstantTest.Multicolor']['options'][$index][$prop]);
+        $this->assertSame($val, $fields['myPseudoconstantTest.Multicolor']['options'][$index][$prop]);
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
While investigating https://lab.civicrm.org/dev/core/-/issues/5360 I unearthed a related issue - sometimes conditional comparisons fail because the dataType of the option value doesn't match the dataType of the field.
This ensures they always match, and improves Afform conditional comparisons.

Before
----------------------------------------
Mismatch

After
----------------------------------------
Match

Technical Details
-----------------
PHP is a sloppy language when it comes to variable data types. If you ask it "which one is a number, 2 or '2'?" it will say "yes". It doesn't help that in the OptionValue table we store mostly numeric values in a varchar column, as strings. Javascript is much more strict, and doesn't consider "2" to be a number, so we get a mismatch when comparing options with field values.
This cleans up the return value of APIv4 GetFields so that fields with a numeric data type will return all option values as numeric, and vice-versa for string-type fields.