### PR TITLE
[REF] Fix empty headers in schedule reminders and dedupe rules page

### DIFF
--- a/templates/CRM/Admin/Page/Reminders.tpl
+++ b/templates/CRM/Admin/Page/Reminders.tpl
@@ -22,7 +22,7 @@
       <th >{ts}While{/ts}</th>
       <th >{ts}Repeat{/ts}</th>
       <th >{ts}Active?{/ts}</th>
-      <th ><span class="sr-only">{ts}Actions{/ts}</span></th>
+      <th id="nosort"><span class="sr-only">{ts}Actions{/ts}</span></th>
     </tr>
     </thead>
     {if $rows and is_array($rows)}

--- a/templates/CRM/Admin/Page/Reminders.tpl
+++ b/templates/CRM/Admin/Page/Reminders.tpl
@@ -22,8 +22,7 @@
       <th >{ts}While{/ts}</th>
       <th >{ts}Repeat{/ts}</th>
       <th >{ts}Active?{/ts}</th>
-      <th class="hiddenElement"></th>
-      <th ></th>
+      <th ><span class="sr-only">{ts}Actions{/ts}</span></th>
     </tr>
     </thead>
     {if $rows and is_array($rows)}
@@ -36,13 +35,10 @@
           <td class="crm-scheduleReminders-is_repeat">{if $row.is_repeat eq 1}{ts}Yes{/ts}{else}{ts}No{/ts}{/if}&nbsp;</td>
           <td id="row_{$row.id}_status" class="crm-scheduleReminders-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
-          <td class="hiddenElement"></td>
         </tr>
       {/foreach}
     {else}
-      <tr><td colspan="8">{ts}No Scheduled Reminders have been created.{/ts}</td></tr>
+      <tr><td colspan="7">{ts}No Scheduled Reminders have been created.{/ts}</td></tr>
     {/if}
   </table>
 {/strip}
-
-

--- a/templates/CRM/Contact/Page/DedupeRules.tpl
+++ b/templates/CRM/Contact/Page/DedupeRules.tpl
@@ -31,7 +31,7 @@
             <tr>
               <th>{ts 1=$contactTypes.$contactType}%1 Rules{/ts}</th>
               <th>{ts}Usage{/ts}</th>
-              <th></th>
+              <th id="nosort"><span class="sr-only">{ts}Actions{/ts}</span></th>
             </tr>
             </thead>
             {foreach from=$rows item=row}


### PR DESCRIPTION
Overview
----------------------------------------
Fix empty headers in schedule reminders and dedupe rules page

Before
----------------------------------------
Schedule reminder:
<img width="1400" alt="Screenshot 2024-07-23 at 12 49 15" src="https://github.com/user-attachments/assets/ce961689-1bc3-4bbf-8000-dcdc920659c4">

Dedupe Rules: 
<img width="1412" alt="Screenshot 2024-07-23 at 18 14 40" src="https://github.com/user-attachments/assets/31243f15-5961-4e91-8c05-9b235d3b945a">


After
----------------------------------------
Fixed

Technical Details
----------------------------------------
Continuation of https://github.com/civicrm/civicrm-core/pull/30696

Comments
----------------------------------------
ping @colemanw @eileenmcnaughton @seamuslee001 @JoeMurray
