### PR TITLE
dev/core#4224 - CiviCampaign - Add form validate for external_id

### DIFF
--- a/CRM/Campaign/Form/Campaign.php
+++ b/CRM/Campaign/Form/Campaign.php
@@ -288,6 +288,22 @@ class CRM_Campaign_Form_Campaign extends CRM_Core_Form {
       $errors[$validateDates['key']] = $validateDates['message'];
     }
 
+    // Validate that external_identifier is unique
+    if (isset($fields['external_identifier'])) {
+      $campaign = \Civi\Api4\Campaign::get(FALSE)
+        ->addWhere('external_identifier', '=', $fields['external_identifier']);
+
+      // when updating do not include the current campaign
+      if ($fields['id'] != '' && is_numeric($fields['id'])) {
+        $campaign->addWhere('id', '<>', $fields['id']);
+      }
+
+      $result = $campaign->execute()->first();
+      if (isset($result)) {
+        $errors['external_identifier'] = ts('External ID already exists.');
+      }
+    }
+
     return empty($errors) ? TRUE : $errors;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
The field external_identifier from CiviCampaign has a unique key constraint in the database. This also has to be checked during the validation of the form.

https://lab.civicrm.org/dev/core/-/issues/4224

Before
----------------------------------------
- Install git master of civicm-core
- enable CiviCampaign
- Add a new Campaign "Test 1" with the external id "23"
- Add a new Campaign "Test 2" with the external id "23"

This hangs without a message for the user. After a page reload you see "DB Error: already exists" and the form input of "Test 2" is lost.

After
----------------------------------------
With the added form validation you get a form error when you try to use an external ID which is already taken by another campaign.

Technical Details
----------------------------------------
For the case that you edit a campaign the validation excludes the current campaign from the query that searches for the external id. So it is still possible to edit a campaign and keep the same external_id.

Comments
----------------------------------------
This is my first pr, I am quite new to civi - so please note if there is anything that can be improved.
