### PR TITLE
avoid errors when data_type is null

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -290,7 +290,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       $this->find(TRUE);
     }
     $id = (int) $this->id;
-    $dataType = $this->data_type;
+    $dataType = (string) $this->data_type;
     $optionGroupID = $this->option_group_id ? (int) $this->option_group_id : NULL;
     $entity = $this->getEntity();
 


### PR DESCRIPTION
Overview
----------------------------------------
When data_type is NULL, we get a hard error in php 8.2 because `getFieldOptions` wants it to be a string.

Before
----------------------------------------
If a field's data type is somehow set to NULL, we get an error.

After
----------------------------------------
No errors.

Comments
----------------------------------------
This only happened on one site we maintain - maybe it is just bad data and this is not worth it? Not sure. 
