### PR TITLE
dev/core#5363 - Fix Backdrop bee commands failing due to cms.root.path not resolving.

### DIFF
--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -657,6 +657,10 @@ AND    u.status = 1
       return $civicrm_paths['cms.root']['path'];
     }
 
+    if (defined('BACKDROP_ROOT')) {
+      return BACKDROP_ROOT;
+    }
+
     $cmsRoot = NULL;
     $valid = NULL;
 


### PR DESCRIPTION
In the `bee` cli tool context, the SCRIPT_FILENAME gets set to wherever the bee script is being executed. I've borrowed this change from the Drupal8 system cmsRootPath() implementation and it appears to be working well.

Fixes https://lab.civicrm.org/dev/core/-/issues/5363