### PR TITLE
ensure we get correct resourceurl in backdrop

### DIFF
--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -805,6 +805,34 @@ AND    u.status = 1
   }
 
   /**
+   * @inheritdoc
+   */
+  public function getCiviSourceStorage():array {
+    global $civicrm_root;
+    $config = CRM_Core_Config::singleton();
+
+    // Don't use $config->userFrameworkBaseURL; it has garbage on it.
+    // More generally, we shouldn't be using $config here.
+    if (!defined('CIVICRM_UF_BASEURL')) {
+      throw new RuntimeException('Undefined constant: CIVICRM_UF_BASEURL');
+    }
+    $baseURL = CRM_Utils_File::addTrailingSlash(CIVICRM_UF_BASEURL, '/');
+    if (CRM_Utils_System::isSSL()) {
+      $baseURL = str_replace('http://', 'https://', $baseURL);
+    }
+
+    $cmsPath = $config->userSystem->cmsRootPath();
+    $userFrameworkResourceURL = $baseURL . str_replace("$cmsPath/", '',
+      str_replace('\\', '/', $civicrm_root)
+    );
+
+    return [
+      'url' => CRM_Utils_File::addTrailingSlash($userFrameworkResourceURL, '/'),
+      'path' => CRM_Utils_File::addTrailingSlash($civicrm_root),
+    ];
+  }
+
+  /**
    * Wrapper for og_membership creation.
    *
    * @param int $ogID


### PR DESCRIPTION
Overview
----------------------------------------
In backdrop, civicrm should be in /modules/civicrm. There is no need for the complicated Drupal code that checks if you are installed in /sites/all/modules or sites/default/modules.

Furthermore, the Drupal code breaks if you are installed in /home/sites/web/modules/civicrm (because the presence of a directory called "sites" throws things off). That's a different bug that should be addressed separately.

Before
----------------------------------------

If your web root has "sites" in it, Backdrop will fail to set the correct resourceUrl.

After
----------------------------------------

The correct resourceUrl is found.


