### PR TITLE
Api4 - More efficient array_column function

### DIFF
--- a/CRM/Campaign/BAO/Query.php
+++ b/CRM/Campaign/BAO/Query.php
@@ -478,7 +478,7 @@ INNER JOIN  civicrm_custom_group grp on fld.custom_group_id = grp.id
             ->addSelect('label', 'filter')
             ->addWhere('option_group_id', '=', $optionGroupId)
             ->execute()
-            ->indexBy('label')->column('filter');
+            ->column('filter', 'label');
         }
         if ($surveyId &&
           !empty($recontactInterval) &&

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -374,8 +374,7 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
       ->addSelect('name', 'title_plural')
       ->addOrderBy('title_plural')
       ->execute()
-      ->indexBy('name')
-      ->column('title_plural');
+      ->column('title_plural', 'name');
   }
 
   /**

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -2234,7 +2234,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $deductible = FinancialType::get(TRUE)
         ->addSelect('is_deductible')
         ->addWhere('id', 'IN', [$toType, $fromType])
-        ->execute()->indexBy('id')->column('is_deductible');
+        ->execute()->column('is_deductible', 'id');
       if ($deductible[$fromType] == FALSE && $deductible[$toType] == TRUE) {
         CRM_Core_Session::setStatus(ts("You've changed the financial type for this %1 contribution from non-tax deductible to tax deductible, but the non-deductible amount of %2 has not been changed. This could prevent a tax receipt from being issued correctly. You may want to edit the non-deductible amount.",
           [1 => Civi::format()->money($submittedValues['total_amount']), 2 => Civi::format()->money($submittedValues['non_deductible_amount'])]),

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -461,7 +461,7 @@ FROM civicrm_action_schedule cas
         ->addWhere('do_not_email', '=', FALSE)
         ->addWhere('email_primary.on_hold', '=', FALSE)
         ->execute();
-      Civi::$statics[__CLASS__]['email'][$cacheKey] = $emails->indexBy('id')->column('email_primary.email');
+      Civi::$statics[__CLASS__]['email'][$cacheKey] = $emails->column('email_primary.email', 'id');
     }
     return Civi::$statics[__CLASS__]['email'][$cacheKey];
   }

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1910,7 +1910,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
         ->addWhere('option_group_id:name', '=', 'cg_extend_objects')
         ->addWhere('grouping', 'IS NOT EMPTY')
         ->addWhere('is_active', '=', TRUE)
-        ->execute()->indexBy('value')->column('grouping');
+        ->execute()->column('grouping', 'value');
 
       foreach ($extendObjs as $entityName => $grouping) {
         try {

--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -162,7 +162,7 @@ class CRM_Core_ManagedEntities {
       'action' => 'create',
       'where' => $condition,
     ]);
-    $defaultValues = $getFields->indexBy('name')->column('default_value');
+    $defaultValues = $getFields->column('default_value', 'name');
     $item['params']['values'] += $defaultValues;
   }
 

--- a/CRM/Event/ActionMapping/ByTemplate.php
+++ b/CRM/Event/ActionMapping/ByTemplate.php
@@ -32,8 +32,7 @@ class CRM_Event_ActionMapping_ByTemplate extends CRM_Event_ActionMapping {
       ->addWhere('is_template', '=', TRUE)
       ->addWhere('is_active', '=', TRUE)
       ->execute()
-      ->indexBy('id')
-      ->column('template_title');
+      ->column('template_title', 'id');
   }
 
 }

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -330,8 +330,7 @@ WHERE  ( civicrm_event.is_template  = 0 )";
         ->addSelect('id', 'title')
         ->addWhere('is_active', '=', TRUE)
         ->execute()
-        ->indexBy('id')
-        ->column('title');
+        ->column('title', 'id');
     }
     return $options;
   }

--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -124,8 +124,7 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
         ->addWhere('is_template', '=', TRUE)
         ->addWhere('is_active', '=', TRUE)
         ->execute()
-        ->indexBy('id')
-        ->column('template_title');
+        ->column('template_title', 'id');
       if (CRM_Utils_System::isNull($eventTemplates) && !$this->_isTemplate) {
         $url = CRM_Utils_System::url('civicrm/admin/eventTemplate', ['reset' => 1]);
         CRM_Core_Session::setStatus(ts('If you find that you are creating multiple events with similar settings, you may want to use the <a href="%1">Event Templates</a> feature to streamline your workflow.', [1 => $url]), ts('Tip'), 'info');

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1573,8 +1573,7 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
     try {
       $membershipTypes = MembershipType::get(TRUE)
         ->execute()
-        ->indexBy('id')
-        ->column('name');
+        ->column('name', 'id');
       $addWhere = " AND membership_type_id IN (0)";
       if (!empty($membershipTypes)) {
         $addWhere = " AND membership_type_id IN (" . implode(',', array_keys($membershipTypes)) . ")";

--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -52,8 +52,7 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
     $links = self::links('all', $this->_isPaymentProcessor, $this->_accessContribution);
     $membershipTypes = \Civi\Api4\MembershipType::get(TRUE)
       ->execute()
-      ->indexBy('id')
-      ->column('name');
+      ->column('name', 'id');
     $addWhere = "membership_type_id IN (0)";
     if (!empty($membershipTypes)) {
       $addWhere = "membership_type_id IN (" . implode(',', array_keys($membershipTypes)) . ")";

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -773,7 +773,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       ->addWhere('key', 'LIKE', 'civi_%')
       ->addWhere('status', '=', 'installed')
       ->execute()
-      ->indexBy('key')->column('status');
+      ->column('status', 'key');
     if (empty($setting) || empty($exts)) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,

--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -380,8 +380,7 @@ class CRM_Utils_Recent {
       ->addWhere('is_active', '=', TRUE)
       ->addOrderBy('weight', 'ASC')
       ->execute()
-      ->indexBy('value')
-      ->column('label');
+      ->column('label', 'value');
   }
 
 }

--- a/Civi/Api4/Generic/Result.php
+++ b/Civi/Api4/Generic/Result.php
@@ -189,11 +189,12 @@ class Result extends \ArrayObject implements \JsonSerializable {
   /**
    * Reduce each result to one field
    *
-   * @param $name
+   * @param string $columnName
+   * @param string|null $indexBy
    * @return array
    */
-  public function column($name): array {
-    return array_column($this->getArrayCopy(), $name, $this->indexedBy);
+  public function column($columnName, $indexBy = NULL): array {
+    return array_column($this->getArrayCopy(), $columnName, $indexBy ?? $this->indexedBy);
   }
 
   /**

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -226,7 +226,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
       'action' => 'create',
       'select' => ['name'],
       'where' => [['name', 'IN', array_keys($entityFields)], ['fk_entity', '=', 'File']],
-    ])->indexBy('name')->column('name');
+    ])->column('name', 'name');
   }
 
   /**

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformAutocompleteUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformAutocompleteUsageTest.php
@@ -65,7 +65,7 @@ EOHTML;
     $contacts = Contact::save(FALSE)
       ->setRecords($sampleContacts)
       ->addDefault('last_name', $lastName)
-      ->execute()->indexBy('first_name')->column('id');
+      ->execute()->column('id', 'first_name');
 
     $result = Contact::autocomplete()
       ->setFormName('afform:' . $this->formName)
@@ -129,7 +129,7 @@ EOHTML;
 
     $contacts = Contact::save(FALSE)
       ->setRecords($sampleData)
-      ->execute()->indexBy('first_name')->column('id');
+      ->execute()->column('id', 'first_name');
 
     // Place contacts A & B in the group, but not contact C
     $group = Group::create(FALSE)
@@ -228,7 +228,7 @@ EOHTML;
 
     $contacts = Contact::save(FALSE)
       ->setRecords($sampleData)
-      ->execute()->indexBy('first_name')->column('id');
+      ->execute()->column('id', 'first_name');
 
     CustomGroup::create(FALSE)
       ->addValue('title', 'test_address_fields')

--- a/ext/search_kit/CRM/Search/BAO/SearchSegment.php
+++ b/ext/search_kit/CRM/Search/BAO/SearchSegment.php
@@ -24,8 +24,7 @@ class CRM_Search_BAO_SearchSegment extends CRM_Search_DAO_SearchSegment {
       ->addOrderBy('title_plural')
       ->addWhere('type', 'CONTAINS', 'DAOEntity')
       ->execute()
-      ->indexBy('name')
-      ->column('title_plural');
+      ->column('title_plural', 'name');
   }
 
 }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -841,7 +841,7 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     ];
     $sampleData = Contact::save(FALSE)
       ->setRecords($sampleData)->execute()
-      ->indexBy('first_name')->column('id');
+      ->column('id', 'first_name');
 
     // Create logged-in user
     UFMatch::delete(FALSE)

--- a/ext/standaloneusers/tests/phpunit/Civi/Api4/Action/UserTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Api4/Action/UserTest.php
@@ -544,7 +544,7 @@ class UserTest extends \PHPUnit\Framework\TestCase implements EndToEndInterface,
 
     $updatedUser = User::get(FALSE)
       ->addWhere('id', 'IN', [$this->nonAdminUserID, $this->adminUserID, $newUserID])
-      ->execute()->indexBy('id')->column('username');
+      ->execute()->column('username', 'id');
     $this->assertEquals([
       $this->nonAdminUserID => 'nonadmin2',
       $this->adminUserID => 'admin2',

--- a/tests/phpunit/CRM/Case/WorkflowMessage/CaseActivityTest.php
+++ b/tests/phpunit/CRM/Case/WorkflowMessage/CaseActivityTest.php
@@ -28,8 +28,7 @@ class CRM_Case_WorkflowMessage_CaseActivityTest extends CiviUnitTestCase {
       ->setSelect(['name', 'data'])
       ->addWhere('name', 'IN', ['workflow/case_activity_test/CaseAdhocExample', 'workflow/case_activity_test/CaseModelExample'])
       ->execute()
-      ->indexBy('name')
-      ->column('data');
+      ->column('data', 'name');
     $byAdhoc = WorkflowMessage::create('case_activity_test', $examples['workflow/case_activity_test/CaseAdhocExample']);
     $byClass = new CRM_Case_WorkflowMessage_CaseActivityTestWorkflow($examples['workflow/case_activity_test/CaseModelExample']);
     $this->assertSameWorkflowMessage($byClass, $byAdhoc, 'Compare byClass and byAdhoc: ');
@@ -41,7 +40,7 @@ class CRM_Case_WorkflowMessage_CaseActivityTest extends CiviUnitTestCase {
    * To see this, we take all the example data and use it with diff constructors.
    */
   public function testConstructorEquivalence(): void {
-    $examples = $this->findExamples()->execute()->indexBy('name')->column('data');
+    $examples = $this->findExamples()->execute()->column('data', 'name');
     $this->assertTrue(count($examples) >= 1, 'Must have at least one example data-set');
     foreach ($examples as $example) {
       $this->assertConstructorEquivalence($example);

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -426,7 +426,7 @@ class ContactGetTest extends Api4TestBase implements TransactionalInterface {
     $result = Individual::get(FALSE)
       ->addWhere('first_name', '=', 'Hi 😁')
       ->addHaving('first_name', '=', 'last_name', TRUE)
-      ->execute()->indexBy('id')->column('first_name');
+      ->execute()->column('first_name', 'id');
     $this->assertEquals('Hi 😁', $result[$same['id']]);
     $this->assertArrayNotHasKey($diff['id'], $result);
   }

--- a/tests/phpunit/api/v4/Custom/BasicCustomFieldTest.php
+++ b/tests/phpunit/api/v4/Custom/BasicCustomFieldTest.php
@@ -457,7 +457,7 @@ class BasicCustomFieldTest extends CustomTestBase {
       return CustomField::get(FALSE)
         ->addWhere('custom_group_id.name', '=', $groupName)
         ->addOrderBy('weight')
-        ->execute()->indexBy('name')->column('weight');
+        ->execute()->column('weight', 'name');
     };
 
     // Create 2 custom groups. Control group is to ensure updating one doesn't affect the other

--- a/tests/phpunit/api/v4/Custom/CustomEntityReferenceTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomEntityReferenceTest.php
@@ -108,7 +108,7 @@ class CustomEntityReferenceTest extends CustomTestBase {
         ['contact_type' => 'Individual'],
         ['contact_type' => 'Household'],
       ],
-    ])->indexBy('contact_type')->column('id');
+    ])->column('id', 'contact_type');
     // Autocomplete by id
     $result = (array) Organization::autocomplete(FALSE)
       ->setFieldName("Contact.EntityRefFields.TestOrgRef")

--- a/tests/phpunit/api/v4/Entity/MembershipTest.php
+++ b/tests/phpunit/api/v4/Entity/MembershipTest.php
@@ -37,7 +37,7 @@ class MembershipTest extends Api4TestBase implements TransactionalInterface {
       return MembershipType::get(FALSE)
         ->addWhere('domain_id.name', '=', $domain)
         ->addOrderBy('weight')
-        ->execute()->indexBy('name')->column('weight');
+        ->execute()->column('weight', 'name');
     };
 
     // Create 2 domains. Control domain is to ensure updating one doesn't affect the other

--- a/tests/phpunit/api/v4/Entity/OptionValueTest.php
+++ b/tests/phpunit/api/v4/Entity/OptionValueTest.php
@@ -60,7 +60,7 @@ class OptionValueTest extends Api4TestBase implements TransactionalInterface {
       return OptionValue::get(FALSE)
         ->addWhere('option_group_id.name', '=', $groupName)
         ->addOrderBy('weight')
-        ->execute()->indexBy('value')->column('weight');
+        ->execute()->column('weight', 'value');
     };
 
     // Create 2 option groups. Control group is to ensure updating one doesn't affect the other

--- a/tests/phpunit/api/v4/Entity/SettingTest.php
+++ b/tests/phpunit/api/v4/Entity/SettingTest.php
@@ -34,7 +34,7 @@ class SettingTest extends Api4TestBase implements TransactionalInterface {
     $setting = Setting::get()->addSelect('menubar_position')->setCheckPermissions(FALSE)->execute()->first();
     $this->assertEquals('above-crm-container', $setting['value']);
 
-    $setting = Setting::revert()->addSelect('menubar_position')->setCheckPermissions(FALSE)->execute()->indexBy('name')->column('value');
+    $setting = Setting::revert()->addSelect('menubar_position')->setCheckPermissions(FALSE)->execute()->column('value', 'name');
     $this->assertEquals(['menubar_position' => 'over-cms-menu'], $setting);
     $setting = civicrm_api4('Setting', 'get', ['select' => ['menubar_position'], 'checkPermissions' => FALSE], 0);
     $this->assertEquals('over-cms-menu', $setting['value']);


### PR DESCRIPTION
Overview
----------------------------------------
This adds a 2nd argument to Result::column(), which is more efficient than calling Result::indexBy() separately.

If nothing else this should make tests run slightly faster.