### PR TITLE
Api4 - Backport new param in Result::column()

### DIFF
--- a/Civi/Api4/Generic/Result.php
+++ b/Civi/Api4/Generic/Result.php
@@ -189,11 +189,12 @@ class Result extends \ArrayObject implements \JsonSerializable {
   /**
    * Reduce each result to one field
    *
-   * @param $name
+   * @param string $columnName
+   * @param string|null $indexBy
    * @return array
    */
-  public function column($name): array {
-    return array_column($this->getArrayCopy(), $name, $this->indexedBy);
+  public function column($columnName, $indexBy = NULL): array {
+    return array_column($this->getArrayCopy(), $columnName, $indexBy ?? $this->indexedBy);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This backports the api change from #30736 to 5.76

Comments
----------------------------------------
IMO api improvements like this should get backported to prevent conflicts - if a security patch or regression needed backporting & relied on this change, or if an extension started using this new signature, this would improve compatibility. 
