### PR TITLE
SearchDisplay: format footer aggregate values same as column values

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -87,6 +87,14 @@ class Run extends AbstractRunAction {
             $tally[$col['key']] = $dao->$alias ?? NULL;
           }
         }
+        $formatFunctions = ['AVG', 'GROUP_FIRST', 'GROUP_LAST', 'MIN', 'MAX', 'SUM'];
+        foreach ($settings['columns'] as $col) {
+          $key = $col['key'];
+          if (array_key_exists($key, $tally) && in_array($col['tally']['fn'], $formatFunctions)) {
+            $dataType = $this->getSelectExpression($key)['dataType'] ?? NULL;
+            $tally[$key] = $this->formatViewValue($key, $tally[$key], $tally, $dataType);
+          }
+        }
         $result[] = $tally;
         return;
 


### PR DESCRIPTION
Overview
----------------------------------------
When a SearchDisplay footer contains an average/first/last/min/max/sum of a monetary column, format that aggregate value as money.

Before
----------------------------------------
Aggregate value was presented as an unformatted integer.

After
----------------------------------------
Aggregate value is formatted.

Technical Details
----------------------------------------
Some code borrowed from [AbstractRunAction](https://github.com/civicrm/civicrm-core/blob/6281d10e3766a21a5a96d89899101f22f1716764/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php#L229).

Comments
----------------------------------------
LIST aggregates aren't handled yet.
