### PR TITLE
Follow up to #30415 - restrict permissions on Price Set Editing page

### DIFF
--- a/CRM/Core/xml/Menu/Admin.xml
+++ b/CRM/Core/xml/Menu/Admin.xml
@@ -686,7 +686,7 @@
      <title>Price Sets</title>
      <page_callback>CRM_Price_Page_Set</page_callback>
      <desc>Price sets allow you to offer multiple options with associated fees (e.g. pre-conference workshops, additional meals, etc.). Configure Price Sets for events which need more than a single set of fee levels.</desc>
-     <access_arguments>access CiviCRM</access_arguments>
+     <access_arguments>access CiviContribute;access CiviEvent</access_arguments>
      <adminGroup>Customize</adminGroup>
      <weight>380</weight>
   </item>


### PR DESCRIPTION
Overview
----------------------------------------

In #30415 we removed a requirement to restrict permission to editing a price set Access CiviEvent, leaving just access CiviCRM.

Since a price set will either be used on a Contribution page or an event page it makes more sense to require the same permissions as adding/editing an event or contribution page.

This tightens up the permissions using the ';' syntax documented https://docs.civicrm.org/dev/en/latest/framework/routing/#access_arguments which is in use elsewhere.

Before
Previously access to the price set configuration required

    access CiviCRM and  access CiviEvent

Then in #30415 this changed to just access CiviCRM with a note that ' do think the right permission would be 'adminster CiviCRM Data''


After
----------------------------------------
Access requires   access CiviCRM or  access CiviEvent


Comment
----------------------------------------
Relevant page to test is /civicrm/admin/price?reset=1