### PR TITLE
Fix for dev/core#5367

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -301,7 +301,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         $count = CRM_Utils_Array::value('count', $customOption[$optionKey], '');
         $max_value = CRM_Utils_Array::value('max_value', $customOption[$optionKey], '');
         $taxAmount = $customOption[$optionKey]['tax_amount'] ?? NULL;
-        if (isset($taxAmount) && $displayOpt && $invoicing) {
+        if (isset($taxAmount) && $taxAmount && $displayOpt && $invoicing) {
           $qf->assign('displayOpt', $displayOpt);
           $qf->assign('taxTerm', $taxTerm);
           $qf->assign('invoicing', $invoicing);


### PR DESCRIPTION
Reference https://lab.civicrm.org/dev/core/-/issues/5367:
"includes Sales Tax of $0.00" apears for text/numeric price fields that don't use a Sales Tax financial type

Overview
----------------------------------------
Per issue, this text didn't used to appear, but now it does. (See screenshots and version history mentioned in OP issue.)

Before
----------------------------------------
Screenshot from 5.77.alpha1:
![master](https://github.com/user-attachments/assets/fc7140ed-efb8-44b9-960a-048c121112c2)


After
----------------------------------------
Screenshot from 5.77.alpha1:
![pr](https://github.com/user-attachments/assets/fc88ea77-7632-4d02-bb4c-712eec187527)

