### PR TITLE
Deprecate `$ids` parameter on Note::create (noisily)

### DIFF
--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -253,13 +253,12 @@ class CRM_Contribute_Form_AdditionalInfo {
       'note' => $params['note'],
       'entity_id' => $contributionID,
       'contact_id' => $contactID,
+      'id' => $contributionNoteID,
     ];
-    $noteID = [];
     if ($contributionNoteID) {
-      $noteID = ["id" => $contributionNoteID];
       $noteParams['note'] = $noteParams['note'] ?: "null";
     }
-    CRM_Core_BAO_Note::add($noteParams, $noteID);
+    CRM_Core_BAO_Note::add($noteParams);
   }
 
   /**

--- a/CRM/Core/BAO/Note.php
+++ b/CRM/Core/BAO/Note.php
@@ -112,6 +112,9 @@ class CRM_Core_BAO_Note extends CRM_Core_DAO_Note implements \Civi\Core\HookInte
    * @throws \CRM_Core_Exception
    */
   public static function add(&$params, $ids = []) {
+    if (!empty($ids)) {
+      CRM_Core_Error::deprecatedWarning('ids is deprecated');
+    }
     $dataExists = self::dataExists($params);
     if (!$dataExists) {
       return NULL;

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -219,13 +219,9 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant implements \Ci
           'entity_table' => 'civicrm_participant',
           'note' => $noteValue,
           'entity_id' => $participant->id,
-          'contact_id' => $id,
+          'id' => $noteId,
         ];
-        $noteIDs = [];
-        if ($noteId) {
-          $noteIDs['id'] = $noteId;
-        }
-        CRM_Core_BAO_Note::add($noteParams, $noteIDs);
+        CRM_Core_BAO_Note::add($noteParams);
       }
       elseif ($noteId && $hasNoteField) {
         CRM_Core_BAO_Note::deleteRecord(['id' => $noteId]);


### PR DESCRIPTION
Overview
----------------------------------------
Deprecate `$ids` parameter on Note::create (noisily)

Before
----------------------------------------
Still passed in 2 places in core 
![image](https://github.com/user-attachments/assets/8a00fa3a-0a8f-455b-aa8f-8dd0ee18bb9f)


After
----------------------------------------
No longer passed, noisy deprecation

Technical Details
----------------------------------------
 I was able to identify test cover for the main path in
     CRM_Event_BAO_ParticipantTest.testCreate
    
    and step through it to be sure of the parameters. Note that
    if contact_id is not set it is populated with the loggedInContactID,
    falling back to the note contact ID in the Note::create
    function so doing that in the Participant::create
    function is redundant so I removed it




Comments
----------------------------------------
pre-existing test cover confirmed 
![image](https://github.com/user-attachments/assets/247991a4-917b-4b56-a85c-ac01622be3cd)
