### PR TITLE
Sets name value with required form field value title

### DIFF
--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -128,8 +128,12 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
    * @throws \CRM_Core_Exception
    */
   public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event): void {
+    if ($event->action === 'edit') {
+      // Supply defaults for `name`
+      $event->params['name'] = $event->params['title'];
+    }
     if ($event->action === 'create') {
-      // Supply defaults for `title` and `frontend_title`
+      // Supply defaults for `name` and `frontend_title`
       if (!isset($event->params['name'])) {
         $event->params['name'] = $event->params['title'];
       }

--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -130,8 +130,8 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
   public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event): void {
     if ($event->action === 'create') {
       // Supply defaults for `title` and `frontend_title`
-      if (!isset($event->params['title'])) {
-        $event->params['title'] = $event->params['name'];
+      if (!isset($event->params['name'])) {
+        $event->params['name'] = $event->params['title'];
       }
       if (!isset($event->params['frontend_title'])) {
         $event->params['frontend_title'] = $event->params['title'];


### PR DESCRIPTION
Overview
----------------------------------------
When creating a new payment processor the the backend title is being munged and saved as the name value. I believe this is because of the following change
https://github.com/civicrm/civicrm-core/commit/df3b3799337a18ef22e059681ca36784d66f0f1b

This merge request aims to set the name field in the pre process hook for payment processors

This is an open issue in Gitlab:
https://lab.civicrm.org/dev/core/-/issues/5063

Before
----------------------------------------
Before this change, the name field is not submitted results in name field being guessed and saved by CiviCRM:
![image](https://github.com/user-attachments/assets/538919bc-7da7-4e0b-9350-a86d074f8c2a)

After
----------------------------------------
After settings the name value with the title form field:
![image](https://github.com/user-attachments/assets/5d8db33b-bdf5-401f-9f7a-022c97824e46)

