### PR TITLE
avoid openlayers error: string literal contains an unescaped line break

### DIFF
--- a/CRM/Contact/BAO/Contact/Location.php
+++ b/CRM/Contact/BAO/Contact/Location.php
@@ -141,7 +141,9 @@ AND civicrm_contact.id IN $idString ";
       CRM_Utils_String::append($address, '<br /> ',
         [$dao->country]
       );
-      $location['address'] = addslashes($address);
+      // OpenLayers throws an error if they get an unexpected line break in the
+      // address.
+      $location['address'] = addslashes(str_replace(["\n", "\r"], ' ', $address));
       $location['displayAddress'] = str_replace('<br />', ', ', addslashes($address));
       $location['url'] = CRM_Utils_System::url('civicrm/contact/view', 'reset=1&cid=' . $dao->contact_id);
       $location['location_type'] = $dao->location_type;


### PR DESCRIPTION
Overview
----------------------------------------
When searching for contacts and choosing the "Map Contacts" action, no map is displayed if a contact has a line break in their address. This merge request ensures no line breaks are present before attempting to display the map to avoid this confusing error. 

Before
----------------------------------------

No map is displayed to the user if they attempt to map a contact with a line break in an address field. Instead, the screen is blank. If you view the console error, you will see the error "string literal contains an unescaped line break"

After
----------------------------------------
The map is displayed!


Comments
----------------------------------------
This corrects a data error, so it may not be the right fix? We could instead show an error to the user. It seems like something should be done because getting a blank screen is just confusing. I'm not 100% sure how the bad data gets in, but I assume it's an import - where it's easy to accidentally import an address line with a line break in it.
