### PR TITLE
dev/core#5355 - Afform: prevent errors and show warning when field is missing

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiConditionalDialog.ctrl.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiConditionalDialog.ctrl.js
@@ -36,9 +36,12 @@
       _.each(ctrl.editor.getEntities(), function(entity) {
         var entityFields = ctrl.editor.getEntityFields(entity.name),
           items = _.transform(entityFields.fields, function(items, field) {
-            var key = entity.name + "[0][fields][" + field.name + "]";
-            ctrl.fieldDefns[key] = field;
-            items.push({id: key, text: field.label});
+            // Conditional in case field is missing
+            if (field) {
+              var key = entity.name + "[0][fields][" + field.name + "]";
+              ctrl.fieldDefns[key] = field;
+              items.push({id: key, text: field.label});
+            }
           });
         _.each(entityFields.joins, function(join) {
           items.push({

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -203,14 +203,18 @@
       }
 
       // Returns a value from either the local field defn or the base defn
-      $scope.getProp = function(propName) {
-        var path = propName.split('.'),
-          item = path.pop(),
-          localDefn = drillDown(ctrl.node.defn || {}, path);
+      $scope.getProp = function(propName, defaultValue) {
+        const path = propName.split('.');
+        const item = path.pop();
+        const localDefn = drillDown(ctrl.node.defn || {}, path);
         if (typeof localDefn[item] !== 'undefined') {
           return localDefn[item];
         }
-        return drillDown(ctrl.getDefn(), path)[item];
+        const fieldDefn = drillDown(ctrl.getDefn(), path);
+        if (typeof fieldDefn[item] !== 'undefined') {
+          return fieldDefn[item];
+        }
+        return defaultValue;
       };
 
       // Checks for a value in either the local field defn or the base defn

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.html
@@ -17,7 +17,7 @@
   <div class="af-gui-field-help" ng-if="propIsset('help_pre')">
     <span crm-ui-editable ng-model="getSet('help_pre')" ng-model-options="{getterSetter: true}" default-value="$ctrl.getDefn().help_pre">{{ getProp('help_pre') }}</span>
   </div>
-  <div class="af-gui-field-input af-gui-field-input-type-{{ getProp('input_type').toLowerCase() }}" ng-include="'~/afGuiEditor/inputType/' + getProp('input_type') + '.html'"></div>
+  <div class="af-gui-field-input af-gui-field-input-type-{{ getProp('input_type').toLowerCase() }}" ng-include="'~/afGuiEditor/inputType/' + getProp('input_type', 'Missing') + '.html'"></div>
   <div class="af-gui-field-help" ng-if="propIsset('help_post')">
     <span crm-ui-editable ng-model="getSet('help_post')" ng-model-options="{getterSetter: true}" default-value="$ctrl.getDefn().help_post">{{ getProp('help_post') }}</span>
   </div>

--- a/ext/afform/admin/ang/afGuiEditor/inputType/Missing.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/Missing.html
@@ -1,0 +1,3 @@
+<div class="form-inline">
+  <span class="crm-error">{{:: ts('Error: missing field "%1"', {1: $ctrl.node.name}) }}</span>
+</div>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/5355

Before
--------
Console errors, no visible warning when editing a form with disabled custom fields.

After
---------
![image](https://github.com/user-attachments/assets/7d86cd59-3917-4a58-b413-5eba90bce452)
