### PR TITLE
allow read-only fields in FormBuilder

### DIFF
--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -109,6 +109,8 @@ class BasicGetFieldsAction extends BasicGetAction {
    *
    * Format option lists.
    *
+   * Configure read-only input fields based on the action.
+   *
    * In most cases it's not necessary to override this function, even if your entity is really weird.
    * Instead just override $this->fields and this function will respect that.
    *
@@ -143,6 +145,9 @@ class BasicGetFieldsAction extends BasicGetAction {
       }
       if (isset($defaults['options'])) {
         $this->formatOptionList($field);
+      }
+      if ($this->getAction() === 'create' && $field['readonly'] === TRUE) {
+        $field['input_type'] = 'DisplayOnly';
       }
       $field = array_diff_key($field, $internalProps);
     }
@@ -328,6 +333,7 @@ class BasicGetFieldsAction extends BasicGetAction {
           'ChainSelect' => ts('Chain-Select'),
           'CheckBox' => ts('Checkboxes'),
           'Date' => ts('Date Picker'),
+          'DisplayOnly' => ts('Display Only'),
           'Email' => ts('Email'),
           'EntityRef' => ts('Autocomplete Entity'),
           'File' => ts('File'),

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
@@ -68,9 +68,7 @@
 
         function filterFields(fields) {
           return _.transform(fields, function(fieldList, field) {
-            if (!field.readonly &&
-              (!search || _.contains(field.name, search) || _.contains(field.label.toLowerCase(), search))
-            ) {
+            if (!search || _.contains(field.name, search) || _.contains(field.label.toLowerCase(), search)) {
               fieldList.push(fieldDefaults(field));
             }
           }, []);

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -169,6 +169,16 @@
 
       function inputTypeCanBe(type) {
         var defn = ctrl.getDefn();
+        if (defn.readonly) {
+          switch (type) {
+            case 'DisplayOnly':
+            case 'Hidden':
+              return true;
+
+            default:
+              return false;
+          }
+        }
         if (defn.input_type === type) {
           return true;
         }


### PR DESCRIPTION
Overview
----------------------------------------
It's not currently possible to put a read-only field on a FormBuilder form.  This is a proof-of-concept for permitting their use.

Before
----------------------------------------
Can't put "Display Name" on a FormBuilder form.

After
----------------------------------------
You can.

Technical Details
----------------------------------------
I tried doing this by relying on the `readonly` property, but this proved tricky.  But I saw no reason not to have a "DisplayOnly" input type.

Comments
----------------------------------------
The new approach no longer requires changing metadata.
~~If this approach is accepted, then we will want to:~~
~~* Change the schema for a bunch of fields.~~
~~* Update the schema documentation (which also needs to be updated for the post-XML world).~~
