### PR TITLE
fixes for group subscription confirmation

### DIFF
--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -466,8 +466,7 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact implemen
         LEFT JOIN civicrm_subscription_history
           ON ( civicrm_group_contact.contact_id = civicrm_subscription_history.contact_id
           AND civicrm_subscription_history.group_id = {$groupID} )";
-      $where = "AND civicrm_subscription_history.method ='Email'";
-      $orderBy = "ORDER BY civicrm_subscription_history.id DESC";
+      $orderBy = "ORDER BY civicrm_subscription_history.id DESC LIMIT 1";
     }
     $query = "
 SELECT    *
@@ -475,7 +474,6 @@ SELECT    *
           $leftJoin
   WHERE civicrm_group_contact.contact_id = %1
   AND civicrm_group_contact.group_id = %2
-          $where
           $orderBy
 ";
 


### PR DESCRIPTION
Overview
----------------------------------------

Cannot confirm group subscription via double opt in if contact was previously part of same group.


Current behavior
----------------------------------------
When some one signs up using double opt-in method, following entry is added to subscription history table.
```
group_id = X
method = ''
Status = Pending
```
After confirmation of subscription via email, new entry is added.

```
group_id = X
method = 'Email'
Status = Added
```

If user later on unsubscribes to the group following entry is added

```
group_id = X
method = ''
Status = Removed
```

If user resubscribes to the group again

```
group_id = X
method = ''
Status = Pending
```

Now during the confirmation there is a check to prevent duplicate email sending. The query includes following in where clause

```
AND civicrm_subscription_history.method ='Email'"
```

which is always true hence confirmation is never completed.

Proposed changes
----------------------------------------------------

- Always check the last entry status for the group to determine if confirmation is needed.
