### PR TITLE
Add option to enable payment on confirmation for all multi-participant events

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -323,7 +323,10 @@ WHERE  ( civicrm_event.is_template  = 0 )";
    * @return array
    */
   public static function getEventsForSelect2() {
-    $options = ['all' => ts('- all -')];
+    $options = [
+      'all' => ts('- all -'),
+      'multiparticipant' => ts('- All multi-participant events -'),
+    ];
     // Check that CiviEvent is enabled before calling the api
     if (class_exists('\Civi\Api4\Event')) {
       $options += \Civi\Api4\Event::get(FALSE)

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -286,7 +286,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     //get the additional participant ids.
     $this->_additionalParticipantIds = $this->get('additionalParticipantIds');
 
-    $this->showPaymentOnConfirm = (in_array($this->_eventId, \Civi::settings()->get('event_show_payment_on_confirm')) || in_array('all', \Civi::settings()->get('event_show_payment_on_confirm')));
+    $this->showPaymentOnConfirm = $this->isShowPaymentOnConfirm();
     $this->assign('showPaymentOnConfirm', $this->showPaymentOnConfirm);
     $priceSetID = $this->getPriceSetID();
     if ($priceSetID) {
@@ -2123,6 +2123,21 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       }
     }
     return FALSE;
+  }
+
+  /**
+   * Is this event configured to show the payment processors on the confirmation form?
+   *
+   * @return bool
+   */
+  protected function isShowPaymentOnConfirm(): bool {
+    $showPaymentOnConfirm = (
+      in_array($this->getEventID(), \Civi::settings()->get('event_show_payment_on_confirm')) ||
+      in_array('all', \Civi::settings()->get('event_show_payment_on_confirm')) ||
+      (in_array('multiparticipant', \Civi::settings()->get('event_show_payment_on_confirm')) && $this->getEventValue('is_multiple_registrations'))
+    );
+
+    return $showPaymentOnConfirm;
   }
 
 }

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -1378,17 +1378,4 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     return $amountArray;
   }
 
-  /**
-   * Is this event configured to show the payment processors on the confirmation form?
-   *
-   * @return bool
-   */
-  private function isShowPaymentOnConfirm(): bool {
-    $showPaymentOnConfirm = (in_array(
-      $this->getEventID(),
-      \Civi::settings()->get('event_show_payment_on_confirm')) || in_array('all', \Civi::settings()->get('event_show_payment_on_confirm'))
-    );
-    return $showPaymentOnConfirm;
-  }
-
 }


### PR DESCRIPTION
Overview
----------------------------------------
This adds an additional option to the "Show Event Payment on Confirm?" setting that moves the payment to the confirmation page on event registration.

Before
----------------------------------------
Can select "all" or individual events.

After
----------------------------------------
Can select "all" , "all multi-participant", or individual events.

Technical Details
----------------------------------------
Extracts isShowPaymentOnConfirm from one more place and adds the option.

Comments
----------------------------------------

