### PR TITLE
ext/* - Update civix templates for newer entities

### DIFF
--- a/ext/afform/core/afform.civix.php
+++ b/ext/afform/core/afform.civix.php
@@ -79,17 +79,32 @@ class CRM_Afform_ExtensionUtil {
    * @return \CiviMix\Schema\SchemaHelperInterface
    */
   public static function schema() {
-    return $GLOBALS['CiviMixSchema5']->getHelper(static::LONG_NAME);
+    if (!isset($GLOBALS['CiviMixSchema'])) {
+      pathload()->loadPackage('civimix-schema@5', TRUE);
+    }
+    return $GLOBALS['CiviMixSchema']->getHelper(static::LONG_NAME);
   }
 
 }
 
 use CRM_Afform_ExtensionUtil as E;
 
-pathload()->addSearchDir(__DIR__ . '/mixin/lib');
 spl_autoload_register('_afform_civix_class_loader', TRUE, TRUE);
 
 function _afform_civix_class_loader($class) {
+  if ($class === 'CRM_Afform_DAO_Base') {
+    if (version_compare(CRM_Utils_System::version(), '5.74.beta', '>=')) {
+      class_alias('CRM_Core_DAO_Base', 'CRM_Afform_DAO_Base');
+      // ^^ Materialize concrete names -- encourage IDE's to pick up on this association.
+    }
+    else {
+      $realClass = 'CiviMix\\Schema\\Afform\\DAO';
+      class_alias($realClass, $class);
+      // ^^ Abstract names -- discourage IDE's from picking up on this association.
+    }
+    return;
+  }
+
   // This allows us to tap-in to the installation process (without incurring real file-reads on typical requests).
   if (strpos($class, 'CiviMix\\Schema\\Afform\\') === 0) {
     // civimix-schema@5 is designed for backported use in download/activation workflows,

--- a/ext/civigrant/info.xml
+++ b/ext/civigrant/info.xml
@@ -27,7 +27,7 @@
     <psr0 prefix="CRM_" path="."/>
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
-  <upgrader>CiviMix\Schema\CiviGrant\AutomaticUpgrader</upgrader>
+  <upgrader>CiviMix\Schema\Civigrant\AutomaticUpgrader</upgrader>
   <mixins>
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>mgd-php@1.0.0</mixin>

--- a/ext/eventcart/eventcart.civix.php
+++ b/ext/eventcart/eventcart.civix.php
@@ -79,19 +79,34 @@ class CRM_Event_Cart_ExtensionUtil {
    * @return \CiviMix\Schema\SchemaHelperInterface
    */
   public static function schema() {
-    return $GLOBALS['CiviMixSchema5']->getHelper(static::LONG_NAME);
+    if (!isset($GLOBALS['CiviMixSchema'])) {
+      pathload()->loadPackage('civimix-schema@5', TRUE);
+    }
+    return $GLOBALS['CiviMixSchema']->getHelper(static::LONG_NAME);
   }
 
 }
 
 use CRM_Event_Cart_ExtensionUtil as E;
 
-pathload()->addSearchDir(__DIR__ . '/mixin/lib');
 spl_autoload_register('_eventcart_civix_class_loader', TRUE, TRUE);
 
 function _eventcart_civix_class_loader($class) {
+  if ($class === 'CRM_Event_Cart_DAO_Base') {
+    if (version_compare(CRM_Utils_System::version(), '5.74.beta', '>=')) {
+      class_alias('CRM_Core_DAO_Base', 'CRM_Event_Cart_DAO_Base');
+      // ^^ Materialize concrete names -- encourage IDE's to pick up on this association.
+    }
+    else {
+      $realClass = 'CiviMix\\Schema\\Eventcart\\DAO';
+      class_alias($realClass, $class);
+      // ^^ Abstract names -- discourage IDE's from picking up on this association.
+    }
+    return;
+  }
+
   // This allows us to tap-in to the installation process (without incurring real file-reads on typical requests).
-  if (strpos($class, 'CiviMix\\Schema\\EventCart\\') === 0) {
+  if (strpos($class, 'CiviMix\\Schema\\Eventcart\\') === 0) {
     // civimix-schema@5 is designed for backported use in download/activation workflows,
     // where new revisions may become dynamically available.
     pathload()->loadPackage('civimix-schema@5', TRUE);

--- a/ext/eventcart/info.xml
+++ b/ext/eventcart/info.xml
@@ -36,5 +36,5 @@
     <namespace>CRM/Event/Cart</namespace>
     <format>23.02.1</format>
   </civix>
-  <upgrader>CiviMix\Schema\EventCart\AutomaticUpgrader</upgrader>
+  <upgrader>CiviMix\Schema\Eventcart\AutomaticUpgrader</upgrader>
 </extension>

--- a/ext/search_kit/search_kit.civix.php
+++ b/ext/search_kit/search_kit.civix.php
@@ -79,17 +79,32 @@ class CRM_Search_ExtensionUtil {
    * @return \CiviMix\Schema\SchemaHelperInterface
    */
   public static function schema() {
-    return $GLOBALS['CiviMixSchema5']->getHelper(static::LONG_NAME);
+    if (!isset($GLOBALS['CiviMixSchema'])) {
+      pathload()->loadPackage('civimix-schema@5', TRUE);
+    }
+    return $GLOBALS['CiviMixSchema']->getHelper(static::LONG_NAME);
   }
 
 }
 
 use CRM_Search_ExtensionUtil as E;
 
-pathload()->addSearchDir(__DIR__ . '/mixin/lib');
 spl_autoload_register('_search_kit_civix_class_loader', TRUE, TRUE);
 
 function _search_kit_civix_class_loader($class) {
+  if ($class === 'CRM_Search_DAO_Base') {
+    if (version_compare(CRM_Utils_System::version(), '5.74.beta', '>=')) {
+      class_alias('CRM_Core_DAO_Base', 'CRM_Search_DAO_Base');
+      // ^^ Materialize concrete names -- encourage IDE's to pick up on this association.
+    }
+    else {
+      $realClass = 'CiviMix\\Schema\\SearchKit\\DAO';
+      class_alias($realClass, $class);
+      // ^^ Abstract names -- discourage IDE's from picking up on this association.
+    }
+    return;
+  }
+
   // This allows us to tap-in to the installation process (without incurring real file-reads on typical requests).
   if (strpos($class, 'CiviMix\\Schema\\SearchKit\\') === 0) {
     // civimix-schema@5 is designed for backported use in download/activation workflows,

--- a/ext/standaloneusers/standaloneusers.civix.php
+++ b/ext/standaloneusers/standaloneusers.civix.php
@@ -79,18 +79,32 @@ class CRM_Standaloneusers_ExtensionUtil {
    * @return \CiviMix\Schema\SchemaHelperInterface
    */
   public static function schema() {
-    return $GLOBALS['CiviMixSchema5']->getHelper(static::LONG_NAME);
+    if (!isset($GLOBALS['CiviMixSchema'])) {
+      pathload()->loadPackage('civimix-schema@5', TRUE);
+    }
+    return $GLOBALS['CiviMixSchema']->getHelper(static::LONG_NAME);
   }
 
 }
 
 use CRM_Standaloneusers_ExtensionUtil as E;
 
-($GLOBALS['_PathLoad'][0] ?? require __DIR__ . '/mixin/lib/pathload-0.php');
-pathload()->addSearchDir(__DIR__ . '/mixin/lib');
 spl_autoload_register('_standaloneusers_civix_class_loader', TRUE, TRUE);
 
 function _standaloneusers_civix_class_loader($class) {
+  if ($class === 'CRM_Standaloneusers_DAO_Base') {
+    if (version_compare(CRM_Utils_System::version(), '5.74.beta', '>=')) {
+      class_alias('CRM_Core_DAO_Base', 'CRM_Standaloneusers_DAO_Base');
+      // ^^ Materialize concrete names -- encourage IDE's to pick up on this association.
+    }
+    else {
+      $realClass = 'CiviMix\\Schema\\Standaloneusers\\DAO';
+      class_alias($realClass, $class);
+      // ^^ Abstract names -- discourage IDE's from picking up on this association.
+    }
+    return;
+  }
+
   // This allows us to tap-in to the installation process (without incurring real file-reads on typical requests).
   if (strpos($class, 'CiviMix\\Schema\\Standaloneusers\\') === 0) {
     // civimix-schema@5 is designed for backported use in download/activation workflows,


### PR DESCRIPTION
Overview
--------

The boilerplate code in here is based on an older draft of civix templates. This is based on a more recent draft.

Changes
------

* `E::schema()` should return a schema object if you're using the final/published version of `civimix-schema5`. (Old snippet was unpublished draft.) You can see the problem/resolution by running this command:

    ```
    cv ev 'echo CRM_Search_ExtensionUtil::schema()->generateInstallSql();'
    ```

* Since these are core exts, they don't include their own copies of `mixin/lib/civimix-schema@5` - so that's not added to pathload's search.
* Define the new `CRM_XXXX_DAO_Base` alias

Comments
----------------------------------------

I haven't done any `r-run` yet. Let's see what Jenkins says first.