### PR TITLE
Copy payment_instrument_id when creating template contribution

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -412,7 +412,7 @@ LEFT  JOIN civicrm_membership_payment mp  ON ( mp.contribution_id = con.id )
 
     // Retrieve the most recently added contribution
     $mostRecentContribution = Contribution::get(FALSE)
-      ->addSelect('custom.*', 'id', 'contact_id', 'campaign_id', 'financial_type_id', 'currency', 'source', 'amount_level', 'address_id', 'on_behalf', 'source_contact_id', 'tax_amount', 'contribution_page_id', 'total_amount', 'is_test')
+      ->addSelect('custom.*', 'id', 'contact_id', 'campaign_id', 'financial_type_id', 'payment_instrument_id', 'currency', 'source', 'amount_level', 'address_id', 'on_behalf', 'source_contact_id', 'tax_amount', 'contribution_page_id', 'total_amount', 'is_test')
       ->addWhere('contribution_recur_id', '=', $id)
       ->addWhere('is_template', '=', 0)
       // we need this line otherwise the is test contribution don't work.


### PR DESCRIPTION
Overview
----------------------------------------
 Otherwise it gets set incorrectly to the default `payment_instrument_id`.

This was found when using CiviRules and triggering on a membership end date. Using a condition of "payment instrument is one of: stripe" was incorrectly triggering when template contribution was the "latest" contribution. It turned out that template contribution had the default `payment_instrument_id` set instead of matching existing contributions.

This can occur, for example, when you made a change to the pricing and have not yet received the next payment at the new amount. And you won't have a payment yet so can't look at the how it was actually paid... Think of "payment_instrument_id" here as the "how do we expect this contribution to be paid?".

Before
----------------------------------------
Payment instrument ID not copied when creating template contribution.

After
----------------------------------------
Payment instrument ID copied when creating template contribution.

Technical Details
----------------------------------------
Add `payment_instrument_id` to `addSelect()` when creating template contribution.

Comments
----------------------------------------
