### PR TITLE
[REF] Fix empty table header on extra first column in table display

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -10,6 +10,7 @@
     <thead>
       <tr>
         <th ng-class="{'crm-search-result-select': $ctrl.settings.actions}" ng-include="'~/crmSearchDisplayTable/crmSearchDisplayTaskHeader.html'" ng-if=":: $ctrl.hasExtraFirstColumn()">
+          <span class="sr-only">{{:: ts('Bulk row actions')}}</span>
         </th>
         <th ng-repeat="col in $ctrl.settings.columns" ng-click="$ctrl.setSort(col, $event)" class="{{:: $ctrl.isSortable(col) ? 'crm-sortable-col' : ''}} {{:: col.alignment }}" title="{{:: $ctrl.isSortable(col) ? ts('Click to sort results (shift-click to sort by multiple).') : '' }}">
           <i ng-if=":: $ctrl.isSortable(col)" class="crm-i crm-search-table-column-sort-icon {{ $ctrl.getSort(col) }}"></i>


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix an accessibility issue with missing table header when there is an extra first column

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/60f4ba8b-e2c9-4c27-bf01-136bb3dbad6a)


After
----------------------------------------
Issue fixed

@colemanw @vingle @monishdeb 
