### PR TITLE
[REF] Fix empty form label error on Groups Tab on Contact Summary

### DIFF
--- a/CRM/Contact/Form/GroupContact.php
+++ b/CRM/Contact/Form/GroupContact.php
@@ -113,7 +113,7 @@ class CRM_Contact_Form_GroupContact extends CRM_Core_Form {
       else {
         $msg = ts('Add to a group');
       }
-
+      $this->assign('groupLabel', $msg);
       $this->addField('group_id', ['class' => 'crm-action-menu fa-plus', 'placeholder' => $msg, 'options' => $groupSelect]);
 
       $this->addButtons([

--- a/templates/CRM/Contact/Form/GroupContact.tpl
+++ b/templates/CRM/Contact/Form/GroupContact.tpl
@@ -10,6 +10,6 @@
 {* this template is used for adding a contact to a group (from view context) *}
 
 <div class="form-item">
-    {if !empty($form.group_id)}{$form.group_id.html}{/if} {if !empty($form.buttons)}{$form.buttons.html}{/if}
+    {if !empty($form.group_id)}<label for="group_id" class="sr-only">{$groupLabel}</label>{$form.group_id.html}{/if} {if !empty($form.buttons)}{$form.buttons.html}{/if}
     {include file="CRM/Form/validate.tpl"}
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix this issue on the Groups tab on contact summary

![image](https://github.com/user-attachments/assets/c213c9de-7dac-4bbc-b358-0ec8cc83db17)


Before
----------------------------------------
No label in select2

After
----------------------------------------
Label

@monishdeb @colemanw @vingle 