### PR TITLE
Add crm-i icon namespace class to font picker icon display

### DIFF
--- a/js/jquery/jquery.crmIconPicker.js
+++ b/js/jquery/jquery.crmIconPicker.js
@@ -72,7 +72,7 @@
           $.each(icons, function(i, icon) {
             if (!term.length || icon.replace(/-/g, '').indexOf(term) > -1) {
               var item = $('<a href="#" title="' + icon + '"/>').button({
-                icons: {primary: icon + ' ' + $style.val()}
+                icons: {primary: 'crm-i ' + icon + ' ' + $style.val()}
               });
               $place.append(item);
             }


### PR DESCRIPTION
Overview
----------------------------------------
FontAwesome4 icons are always loaded in core with an additional `crm-i` class - except here in the icon picker.

Lack of the namespace causes breakage when trying to load v4=>v6 shims in riverlea : https://lab.civicrm.org/extensions/riverlea/-/issues/28

I would assume also that if someone is using the namespace to load icons differently on Civi vs host CMS, they would be getting the CMS icon versions in the picker, and then they would display differently when actually displayed in Civi context menu/searchkit etc.
