### PR TITLE
Add deprecated warning if 'Completed' status passed into repeatTransaction

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1917,6 +1917,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
 
     if ($isCompleted) {
       // Ideally add deprecation notice here & only accept pending for repeattransaction.
+      CRM_Core_Error::deprecatedWarning('Only Pending status should be passed into repeatTransaction()');
       return self::completeOrder($input, NULL, $createContribution['id']);
     }
     return $createContribution;


### PR DESCRIPTION
Overview
----------------------------------------
Per comment already there. We still had various workflows using repeattransaction with "Completed" status. But now we don't! So flag as deprecated in case any third-party integrations are doing so.

Before
----------------------------------------
No deprecation warning

After
----------------------------------------
Deprecation warning

Technical Details
----------------------------------------


Comments
----------------------------------------

