### PR TITLE
[NFC] Clean up comments in civicrm.settings.php

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -34,23 +34,23 @@ global $civicrm_root, $civicrm_setting, $civicrm_paths;
 /**
  * Content Management System (CMS) Host:
  *
- * CiviCRM can be hosted in either Drupal 6 or 7, Joomla or WordPress.
+ * CiviCRM can be hosted in Backdrop, Drupal 7+, Joomla or WordPress.
  *
  * Settings for Backdrop CMS:
  *      define('CIVICRM_UF', 'Backdrop');
  *
- * Settings for Drupal 7.x:
+ * Settings for Drupal 7:
  *      define('CIVICRM_UF', 'Drupal');
  *
- * Settings for Joomla 1.7.x - 2.5.x:
+ * Settings for Drupal 8+:
+ *      define('CIVICRM_UF', 'Drupal8');
+ *
+ * Settings for Joomla:
  *      define('CIVICRM_UF', 'Joomla');
  *
- * Settings for WordPress 3.3.x:
+ * Settings for WordPress:
  *      define('CIVICRM_UF', 'WordPress');
  *
- * You may have issues with images in CiviCRM. If this is the case, be sure
- * to update the CiviCRM Resource URL field to your CiviCRM root directory
- * (Administer::System Settings::Resource URLs).
  */
 if (!defined('CIVICRM_UF')) {
   if (getenv('CIVICRM_UF')) {
@@ -83,20 +83,11 @@ if (!defined('CIVICRM_UF_DSN') && CIVICRM_UF !== 'UnitTests') {
  * Database URL format:
  *      define('CIVICRM_DSN', 'mysql://crm_db_username:crm_db_password@db_server/crm_database?new_link=true');
  *
+ * Your CMS and CiviCRM can share the same database, or can be installed into separate databases.
+ * See https://docs.civicrm.org/installation/en/latest/general/requirements/#mysql-connection.
+ *
  * See https://docs.civicrm.org/installation/en/latest/general/mysql_tls/#dsn-settings for how to append
  * ssl options to the Database URL.
- *
- * Drupal and CiviCRM can share the same database, or can be installed into separate databases.
- * Backdrop CMS and CiviCRM can also share the same database, or can be installed into separate databases.
- *
- * EXAMPLE: Drupal/Backdrop and CiviCRM running in the same database...
- *      DB Name = cms, DB User = cms
- *      define('CIVICRM_DSN', 'mysql://cms:YOUR_PASSWORD@localhost/cms?new_link=true');
- *
- * EXAMPLE: Drupal/Backdrop and CiviCRM running in separate databases...
- *      CMS DB Name = cms, DB User = cms
- *      CiviCRM DB Name = civicrm, CiviCRM DB User = civicrm
- *      define('CIVICRM_DSN', 'mysql://civicrm:YOUR_PASSWORD@localhost/civicrm?new_link=true');
  *
  * If your username, password, server or DB name contain a single quote or backslash, escape those characters
  * with a backslash: \' and \\, respectively.
@@ -155,7 +146,7 @@ if (!defined('CIVICRM_LOGGING_DSN')) {
  * the CIVICRM_TEMPLATE_COMPILEDIR would be:
  *      define('CIVICRM_TEMPLATE_COMPILEDIR', '/var/www/htdocs/drupal/sites/default/files/civicrm/templates_c/');
  *
- * EXAMPLE - Backdrop CMS:
+ * EXAMPLE - Backdrop:
  * If the path to the Backdrop home directory is /var/www/htdocs/backdrop
  * the $civicrm_root setting would be:
  *      $civicrm_root = '/var/www/htdocs/backdrop/modules/civicrm/';
@@ -163,7 +154,7 @@ if (!defined('CIVICRM_LOGGING_DSN')) {
  * the CIVICRM_TEMPLATE_COMPILEDIR would be:
  *      define('CIVICRM_TEMPLATE_COMPILEDIR', '/var/www/htdocs/backdrop/files/civicrm/templates_c/');
  *
- * EXAMPLE - Joomla Installations:
+ * EXAMPLE - Joomla:
  * If the path to the Joomla home directory is /var/www/htdocs/joomla
  * the $civicrm_root setting would be:
  *      $civicrm_root = '/var/www/htdocs/joomla/administrator/components/com_civicrm/civicrm/';
@@ -171,7 +162,7 @@ if (!defined('CIVICRM_LOGGING_DSN')) {
  * the CIVICRM_TEMPLATE_COMPILEDIR would be:
  *      define('CIVICRM_TEMPLATE_COMPILEDIR', '/var/www/htdocs/joomla/media/civicrm/templates_c/');
  *
- * EXAMPLE - WordPress Installations:
+ * EXAMPLE - WordPress:
  * If the path to the WordPress home directory is /var/www/htdocs/wordpress and the path to the plugin directory is /var/www/htdocs/wordpress/wp-content/plugins
  * the $civicrm_root setting would be:
  *      $civicrm_root = '/var/www/htdocs/wordpress/wp-content/plugins/civicrm/civicrm/';
@@ -219,27 +210,19 @@ if (!defined('CIVICRM_TEMPLATE_COMPILEDIR')) {
 /**
  * Site URLs:
  *
- * This section defines absolute and relative URLs to access the host CMS (Backdrop, Drupal, or Joomla) resources.
+ * This section defines absolute and relative URLs to access the host CMS resources.
  *
  * IMPORTANT: Trailing slashes should be used on all URL settings.
  *
  *
- * EXAMPLE - Drupal Installations:
- * If your site's home url is http://www.example.com/drupal/
- * these variables would be set as below. Modify as needed for your install.
+ * EXAMPLE - Drupal, Backdrop, WordPress:
+ * If your site's home url is http://www.example.com/mysite/:
  *
- * CIVICRM_UF_BASEURL - home URL for your site:
- *      define('CIVICRM_UF_BASEURL', 'http://www.example.com/drupal/');
+ * The CIVICRM_UF_BASEURL would be:
+ *      define('CIVICRM_UF_BASEURL', 'http://www.example.com/mysite/');
  *
- * EXAMPLE - Backdrop CMS Installations:
- * If your site's home url is http://www.example.com/backdrop/
- * these variables would be set as below. Modify as needed for your install.
- *
- * CIVICRM_UF_BASEURL - home URL for your site:
- *      define('CIVICRM_UF_BASEURL', 'http://www.example.com/backdrop/');
- *
- * EXAMPLE - Joomla Installations:
- * If your site's home url is http://www.example.com/joomla/
+ * EXAMPLE - Joomla:
+ * If your site's home url is http://www.example.com/joomla/:
  *
  * CIVICRM_UF_BASEURL - home URL for your site:
  * Administration site:
@@ -340,9 +323,7 @@ if (!defined('CIVICRM_SMARTY_AUTOLOAD_PATH') && getenv('CIVICRM_SMARTY_AUTOLOAD_
  // $civicrm_setting['domain']['communityMessagesUrl'] = 'https://alert.civicrm.org/alert?prot=1&ver={ver}&uf={uf}&sid={sid}&lang={lang}&co={co}&optout=offers,asks';
 
 /**
- * If you are using any CiviCRM script in the bin directory that
- * requires authentication, then you also need to set this key.
- * We recommend using a 16-32 bit alphanumeric/punctuation key.
+ * Set a 16-32 bit alphanumeric/punctuation key.
  * More info at https://docs.civicrm.org/sysadmin/en/latest/setup/site-key/
  */
 if (!defined('CIVICRM_SITE_KEY')) {
@@ -455,7 +436,7 @@ if (!defined('CIVICRM_DOMAIN_ID')) {
  * set the following constant.  You should only set this once you have your cache
  * server up and working, because CiviCRM will not start up if your server is
  * unavailable on the host and port that you specify. By default CiviCRM will use
- * an in-memory array cache
+ * an in-memory array cache.
  *
  * To use the php extension memcache  use a value of 'Memcache'
  * To use the php extension memcached use a value of 'Memcached'
@@ -527,7 +508,7 @@ if (!defined('CIVICRM_PSR16_STRICT')) {
 }
 
 /**
- * If you have multilingual site and you are using the "inherit CMS language"
+ * If you have a multilingual site and you are using the "inherit CMS language"
  * configuration option, but wish to, for example, use fr_CA instead of the
  * default fr_FR (for French), set one or more of the constants below to an
  * appropriate regional value.
@@ -563,7 +544,7 @@ if (!defined('CIVICRM_PSR16_STRICT')) {
 /**
  * Define how many times to retry a transaction when the DB hits a deadlock
  * (ie. the database is locked by another transaction). This is an
- * advanced setting intended for high-traffic databases & experienced developers/ admins.
+ * advanced setting intended for high-traffic databases & experienced developers/admins.
  */
 define('CIVICRM_DEADLOCK_RETRIES', 3);
 
@@ -635,7 +616,7 @@ if (!defined('CIVICRM_CLEANURL')) {
   elseif (function_exists('config_get') && config_get('system.core', 'clean_url') != 0) {
     define('CIVICRM_CLEANURL', 1);
   }
-  elseif(function_exists('get_option') && get_option('permalink_structure') != '') {
+  elseif (function_exists('get_option') && get_option('permalink_structure') != '') {
     define('CIVICRM_CLEANURL', 1);
   }
   else {
@@ -643,7 +624,9 @@ if (!defined('CIVICRM_CLEANURL')) {
   }
 }
 
-// make sure the memory_limit is at least 64 MB
+/**
+ * Make sure the memory_limit is at least 128 MB.
+ */
 $memLimitString = trim(ini_get('memory_limit'));
 $memLimitUnit   = strtolower(substr($memLimitString, -1));
 $memLimit       = (int) $memLimitString;


### PR DESCRIPTION
Overview
----------------------------------------
As experienced Civi devs, we rarely look at the comments in `civicrm.settings.php`.  But they are out of date and inconsistent.  For an admin who installs Civi for the first time, this is often the first code they look at, and it should make a good first impression.

Comments
----------------------------------------
This is bikeshedding bait.  If folks have a non-critical objection to some part of this, but agree that this is better in than out, let's note it as such in the comments.
