### PR TITLE
SearchKit - Format footer tally values according to data type

### DIFF
--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -168,8 +168,8 @@ abstract class SqlFunction extends SqlExpression {
    * @param string $output
    * @return string
    */
-  protected function renderExpression(string $output): string {
-    return $this->getName() . "($output)";
+  public static function renderExpression(string $output): string {
+    return static::getName() . "($output)";
   }
 
   /**

--- a/Civi/Api4/Query/SqlFunctionDAYSTOANNIV.php
+++ b/Civi/Api4/Query/SqlFunctionDAYSTOANNIV.php
@@ -46,7 +46,7 @@ class SqlFunctionDAYSTOANNIV extends SqlFunction {
   /**
    * @inheritDoc
    */
-  protected function renderExpression(string $output): string {
+  public static function renderExpression(string $output): string {
     $anniversarySql = \CRM_Utils_Date::getAnniversarySql($output);
     return "DATEDIFF($anniversarySql, CURDATE())";
   }

--- a/Civi/Api4/Query/SqlFunctionGROUP_FIRST.php
+++ b/Civi/Api4/Query/SqlFunctionGROUP_FIRST.php
@@ -58,7 +58,7 @@ class SqlFunctionGROUP_FIRST extends SqlFunction {
    * @param string $output
    * @return string
    */
-  protected function renderExpression(string $output): string {
+  public static function renderExpression(string $output): string {
     $sep = \CRM_Core_DAO::VALUE_SEPARATOR;
     return "SUBSTRING_INDEX(GROUP_CONCAT($output SEPARATOR '$sep'), '$sep', 1)";
   }

--- a/Civi/Api4/Query/SqlFunctionNEXTANNIV.php
+++ b/Civi/Api4/Query/SqlFunctionNEXTANNIV.php
@@ -46,7 +46,7 @@ class SqlFunctionNEXTANNIV extends SqlFunction {
   /**
    * @inheritDoc
    */
-  protected function renderExpression(string $output): string {
+  public static function renderExpression(string $output): string {
     return \CRM_Utils_Date::getAnniversarySql($output);
   }
 

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -1166,8 +1166,8 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    */
   protected function formatViewValue($key, $rawValue, $data, $dataType, $format = NULL) {
     if (is_array($rawValue)) {
-      return array_map(function($val) use ($key, $data, $dataType) {
-        return $this->formatViewValue($key, $val, $data, $dataType);
+      return array_map(function($val) use ($key, $data, $dataType, $format) {
+        return $this->formatViewValue($key, $val, $data, $dataType, $format);
       }, $rawValue);
     }
 

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTally.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTally.html
@@ -7,7 +7,7 @@
     <div ng-if="!$ctrl.tally" class="crm-search-loading-placeholder"></div>
     <div ng-if="$ctrl.tally">
       {{:: col.tally.label }}
-      {{ $ctrl.tally[col.key] }}
+      {{ $ctrl.isArray($ctrl.tally[col.key]) ? $ctrl.tally[col.key].join(', ') : $ctrl.tally[col.key] }}
     </div>
   </td>
 </tr>

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -1977,6 +1977,122 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals('$250.00', $result[3]['columns'][0]['val']);
   }
 
+  public function testTally(): void {
+    \Civi::settings()->set('dateformatshortdate', '%m/%d/%Y');
+    $contacts = $this->saveTestRecords('Individual', [
+      'records' => [
+        ['first_name' => 'A', 'last_name' => 'A'],
+        ['first_name' => 'B', 'last_name' => 'B'],
+        ['first_name' => 'C', 'last_name' => 'C'],
+      ],
+    ]);
+
+    $contributions = $this->saveTestRecords('Contribution', [
+      'records' => [
+        ['total_amount' => 100, 'contact_id' => $contacts[0]['id'], 'receive_date' => '2024-02-02'],
+        ['total_amount' => 200, 'contact_id' => $contacts[0]['id'], 'receive_date' => '2021-02-02'],
+        ['total_amount' => 300, 'contact_id' => $contacts[1]['id'], 'receive_date' => '2022-02-02'],
+        ['total_amount' => 400, 'contact_id' => $contacts[2]['id'], 'receive_date' => '2023-02-02'],
+      ],
+    ]);
+
+    $this->createTestRecord('SavedSearch', [
+      'name' => __FUNCTION__,
+      'label' => __FUNCTION__,
+      'api_entity' => 'Contribution',
+      'api_params' => [
+        'version' => 4,
+        'select' => [
+          'COUNT(id) AS COUNT_id',
+          'GROUP_CONCAT(DISTINCT contact_id.sort_name) AS GROUP_CONCAT_contact_id_sort_name',
+          'SUM(total_amount) AS SUM_total_amount',
+          'GROUP_FIRST(receive_date ORDER BY receive_date ASC) AS GROUP_FIRST_receive_date',
+        ],
+        'orderBy' => [],
+        'where' => [
+          ['id', 'IN', $contributions->column('id')],
+        ],
+        'groupBy' => [
+          'contact_id',
+        ],
+        'join' => [],
+        'having' => [],
+      ],
+    ]);
+
+    $this->createTestRecord('SearchDisplay', [
+      'name' => __FUNCTION__,
+      'label' => __FUNCTION__,
+      'saved_search_id.name' => __FUNCTION__,
+      'type' => 'table',
+      'settings' => [
+        'description' => NULL,
+        'sort' => [],
+        'limit' => 50,
+        'pager' => [],
+        'placeholder' => 5,
+        'columns' => [
+          [
+            'type' => 'field',
+            'key' => 'COUNT_id',
+            'label' => '(Count) Contribution ID',
+            'sortable' => TRUE,
+            'tally' => [
+              'fn' => 'SUM',
+            ],
+          ],
+          [
+            'type' => 'field',
+            'key' => 'GROUP_CONCAT_contact_id_sort_name',
+            'label' => '(List) Contact Sort Name',
+            'sortable' => TRUE,
+            'tally' => [
+              'fn' => 'GROUP_CONCAT',
+            ],
+          ],
+          [
+            'type' => 'field',
+            'key' => 'SUM_total_amount',
+            'label' => '(Sum) Total Amount',
+            'sortable' => TRUE,
+            'tally' => [
+              'fn' => 'SUM',
+            ],
+          ],
+          [
+            'type' => 'field',
+            'key' => 'GROUP_FIRST_receive_date',
+            'label' => 'First Contribution Date',
+            'sortable' => TRUE,
+            'tally' => [
+              'fn' => 'GROUP_FIRST',
+            ],
+            'format' => 'dateformatshortdate',
+          ],
+        ],
+        'actions' => TRUE,
+        'classes' => [
+          'table',
+          'table-striped',
+        ],
+        'tally' => [
+          'label' => 'Total',
+        ],
+      ],
+    ]);
+
+    $tally = SearchDisplay::run(FALSE)
+      ->setReturn('tally')
+      ->setDisplay(__FUNCTION__)
+      ->setSavedSearch(__FUNCTION__)
+      ->execute()->single();
+
+    $this->assertSame('4', $tally['COUNT_id']);
+    $this->assertEquals(['A, A', 'B, B', 'C, C'], $tally['GROUP_CONCAT_contact_id_sort_name']);
+    $this->assertSame('$1,000.00', $tally['SUM_total_amount']);
+    $this->assertSame('02/02/2021', $tally['GROUP_FIRST_receive_date']);
+  }
+
   public function testContributionTotalCountWithTestAndTemplateContributions():void {
     // Add a source here for the where below, as if we use id, we get the test and template contributions
     $contributions = $this->saveTestRecords('Contribution', [


### PR DESCRIPTION
Overview
----------------------------------------
When a SearchDisplay footer contains an average/first/last/min/max/sum of a monetary column, format that aggregate value as money.

Before
----------------------------------------
Aggregate value was presented as an unformatted integer.

After
----------------------------------------
Aggregate value is formatted.

Comments
------------
This is a reviewer's version of #30738