### PR TITLE
Make `civicrm_queue.name` & `civicrm_queue.name` field longer

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSeventySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveSeventySeven.php
@@ -29,6 +29,8 @@ class CRM_Upgrade_Incremental_php_FiveSeventySeven extends CRM_Upgrade_Increment
    */
   public function upgrade_5_77_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask('Alter Queue.name length', 'alterColumn', 'civicrm_queue', 'name', "varchar(128)  NOT NULL COMMENT 'Name of the queue'", FALSE);
+    $this->addTask('Alter QueueItem.queue_name length', 'alterColumn', 'civicrm_queue_item', 'queue_name', "varchar(128) NOT NULL COMMENT 'Name of the queue which includes this item'", FALSE);
   }
 
 }

--- a/schema/Queue/Queue.entityType.php
+++ b/schema/Queue/Queue.entityType.php
@@ -31,7 +31,7 @@ return [
     ],
     'name' => [
       'title' => ts('Name'),
-      'sql_type' => 'varchar(64)',
+      'sql_type' => 'varchar(128)',
       'input_type' => 'Text',
       'required' => TRUE,
       'description' => ts('Name of the queue'),

--- a/schema/Queue/QueueItem.entityType.php
+++ b/schema/Queue/QueueItem.entityType.php
@@ -30,7 +30,7 @@ return [
     ],
     'queue_name' => [
       'title' => ts('Queue Name'),
-      'sql_type' => 'varchar(64)',
+      'sql_type' => 'varchar(128)',
       'input_type' => 'Text',
       'required' => TRUE,
       'description' => ts('Name of the queue which includes this item'),


### PR DESCRIPTION
Overview
----------------------------------------
Make queue_name field longer

Before
----------------------------------------
The dedupe UI screen fails to do a batch job when loaded using criteria - eg.

https://my-site/civicrm/contact/dedupefind?reset=1&action=update&rgid=13&gid=&limit=1000&criteria=%7B%22contact%22%3A%7B%22last_name%22%3A%22Otten%22%7D%7D

![image](https://github.com/user-attachments/assets/4039ff5f-e19a-4cd0-b74c-1a390a913745)

![image](https://github.com/user-attachments/assets/6e5b993a-fa3f-4dc1-96e4-b1d11c9e182a)



After
----------------------------------------
Queue Name adjusted to reflect the fact we already insert names longer than 64 char (67 in this case)

Technical Details
----------------------------------------
This is probably an older regression

Comments
----------------------------------------
