### PR TITLE
Trigger search kit refresh for non-popup form submits

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -60,7 +60,7 @@
         }
 
         // Popup forms in this display or surrounding Afform trigger a refresh
-        $element.closest('form').on('crmPopupFormSuccess', function() {
+        $element.closest('form').on('crmPopupFormSuccess crmFormSuccess', function() {
           ctrl.rowCount = null;
           ctrl.getResultsPronto();
         });

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -171,11 +171,7 @@
             // If there are no results on initial load, open an "autoOpen" toolbar link
             ctrl.toolbar.forEach((link) => {
               if (link.autoOpen && requestId === 1 && !ctrl.results.length) {
-                CRM.loadForm(link.url)
-                  .on('crmFormSuccess', () => {
-                    ctrl.rowCount = null;
-                    ctrl.getResultsPronto();
-                  });
+                CRM.loadForm(link.url);
               }
             });
           }

--- a/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
@@ -61,7 +61,12 @@
           var path = $rootScope.$eval(task.crmPopup.path, data),
             query = task.crmPopup.query && $rootScope.$eval(task.crmPopup.query, data);
           CRM.loadForm(CRM.url(path, query, 'back'), {post: task.crmPopup.data && $rootScope.$eval(task.crmPopup.data, data)})
-            .on('crmFormSuccess', mngr.refreshAfterTask);
+            .on('crmFormSuccess', (e) => {
+                // refreshAfterTask emits its own
+                // crmPopupFormSuccess event
+                e.stopPropagation();
+                mngr.refreshAfterTask();
+            });
         }
         else if (task.redirect) {
           var redirectPath = $rootScope.$eval(task.redirect.path, data),


### PR DESCRIPTION
Overview
----------------------------------------
I would like a non-popup afform on the same page as a search kit to trigger refreshes.

Before
----------------------------------------
Search Kits only listen for pop up form success events to refresh

After
----------------------------------------
Search Kits listen for pop up and regular form success events in the same way

Technical Details
----------------------------------------
A common `<form>` parent provides the scoping for the listener, so relevant forms and displays should be grouped using `<form>`.
