### PR TITLE
Fix some pesky warnings about undefined stuff

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -900,6 +900,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup implements \Civi\Core\Ho
         $controller->run();
 
         $template = CRM_Core_Smarty::singleton();
+        $template->ensureVariablesAreAssigned(['activeComponent']);
 
         // Hide CRM error messages if they are set by the CMS.
         if (!empty($_POST)) {

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -148,7 +148,7 @@
               {elseif $n|substr:0:5 eq 'phone'}
                 {assign var="phone_ext_field" value=$n|replace:'phone':'phone_ext'}
                 {$form.$n.html}
-                {if $form.$phone_ext_field.html}
+                {if array_key_exists($phone_ext_field, $form)}
                 &nbsp;{$form.$phone_ext_field.html}
                 {/if}
               {else}


### PR DESCRIPTION
Overview
----------------------------------------
Spotted on a Drupal profile edit page and on add page where a heap of warnings.

  occurred on the CiviCRM profile having a phone field (but not an extension). 

And activeComponent was not being set in this case so it was causing issues.

Before
----------------------------------------

Warnings polluted the screen!

After
----------------------------------------

No warnings!

Technical Details
----------------------------------------

I believe for the activeComponent one we want to run the following logic if it is not set. However perhaps a wiser head than me can comment on that.

in the compiled template we get `$this->_tpl_vars['activeComponent'] != 'CiviCRM'`  which causes the warning, because activeComponent wasn't set.

Comments
----------------------------------------

Warnings were seen on a D10 site via Add new user and edit user.
Would need to ensure you had a CiviCRM profile with a phone field set to show. Make sure it doesn't have the extension.
