### PR TITLE
fixes incorrect display of tag field label in profiles

### DIFF
--- a/CRM/Contact/Form/Edit/TagsAndGroups.php
+++ b/CRM/Contact/Form/Edit/TagsAndGroups.php
@@ -137,7 +137,7 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
       $tags = CRM_Core_BAO_Tag::getColorTags('civicrm_contact');
 
       if (!empty($tags)) {
-        $form->add('select2', 'tag', ts('Tag(s)'), $tags, $isRequired, ['class' => 'huge', 'placeholder' => ts('- select -'), 'multiple' => TRUE]);
+        $form->add('select2', 'tag', $tagName, $tags, $isRequired, ['class' => 'huge', 'placeholder' => ts('- select -'), 'multiple' => TRUE]);
       }
 
       // build tag widget


### PR DESCRIPTION
Overview
----------------------------------------
1. Create a profile
2. Add a field Contacts > Tag(s)
3. Set a custom label for that field
4. Show the profile in Edit mode
5. Notice that the label of the field is "Tag(s)" and not what you set in step 3

Before
----------------------------------------
When displaying tags on a profile, the label is always Tag(s), regardless of the field label that is set.

After
----------------------------------------
The profile displays the field label.

Technical Details
----------------------------------------
The label of the select2 is set to ts('Tag(s)') instead of using the function argument $tagName.


