### PR TITLE
Adding custom multi-value record leads to fatal "no valid value for tableId"

### DIFF
--- a/CRM/Contact/Form/CustomData.php
+++ b/CRM/Contact/Form/CustomData.php
@@ -83,7 +83,7 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
    * Gets session variables for table name, id of entity in table, type of entity and stores them.
    */
   public function preProcess() {
-    $this->_cdType = $_GET['type'] ?? NULL;
+    $this->_cdType = CRM_Utils_Request::retrieve('type', 'String', $this, FALSE, NULL);
     $this->_multiRecordDisplay = CRM_Utils_Request::retrieve('multiRecordDisplay', 'String', $this);
     $isBuildForm = $this->_cdType && $this->_multiRecordDisplay;
     $this->assign('cdType', (bool) $this->_cdType);


### PR DESCRIPTION
Overview
----------------------------------------
To reproduce:
- create a multiple record custom group with "Tab with table" display
![Screenshot 2024-08-02 at 09-50-02 Custom Field Groups CiviCRM Sandbox on Drupal](https://github.com/user-attachments/assets/55d54cc1-5c5d-4ccc-a28b-ec0cfbb942ed)
- in the contact, instead of adding a record using the popup, open in a new tab, the url is something like `https://dmaster.demo.civicrm.org/civicrm/contact/view/cd/edit?reset=1&type=Individual&groupID=4&entityID=204&cgcount=25&multiRecordDisplay=single&mode=add`
- when saving, fatal error


Before
----------------------------------------
![Screenshot 2024-08-02 at 09-49-34 Error](https://github.com/user-attachments/assets/9fa7c8ee-0701-44c4-bc85-b730a87eada0)

After
----------------------------------------
No more error.

Technical Details
----------------------------------------
For some reason, CRM_Contact_Form_CustomData::preProcess is called 2 times and the second time there is no `type` in the GET anymore. Using `CRM_Utils_Request::retrieve` works in both calls.
