### PR TITLE
Afform - Fix missing labels

### DIFF
--- a/ext/afform/core/ang/af/afField.html
+++ b/ext/afform/core/ang/af/afField.html
@@ -1,4 +1,4 @@
-<label class="crm-af-field-label" ng-if=":: $ctrl.defn.label && $ctrl.defn.input_type != 'CheckBox' && $ctrl.defn.data_type != 'Boolean'" for="{{:: fieldId }}">
+<label class="crm-af-field-label" ng-if=":: $ctrl.defn.label && !($ctrl.defn.input_type == 'CheckBox' && $ctrl.defn.data_type == 'Boolean')" for="{{:: fieldId }}">
   {{:: $ctrl.defn.label }}
   <span class="crm-marker" title="{{:: ts('Required') }}" ng-if=":: $ctrl.defn.required">*</span>
 </label>


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the logic so that labels are only hidden for single boolean checkboxes, previously it had been erroneously hiding labels for all checkboxes and boolean fields.

This is a regression due to https://github.com/civicrm/civicrm-core/pull/30706