### PR TITLE
[REF] Fix link when copying a mass SMS to not create a new mailing an…

### DIFF
--- a/CRM/Mailing/Selector/Browse.php
+++ b/CRM/Mailing/Selector/Browse.php
@@ -366,8 +366,11 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
         $actionMask = NULL;
         if ($row['sms_provider_id']) {
           $actionLinks[CRM_Core_Action::PREVIEW]['url'] = 'civicrm/sms/send';
+          $actionLinks[CRM_Core_Action::PREVIEW]['title'] = ts('Continue SMS');
+          $actionLinks[CRM_Core_Action::UPDATE]['url'] = 'civicrm/sms/send';
+          $actionLinks[CRM_Core_Action::UPDATE]['title'] = ts('Copy SMS');
+          $actionLinks[CRM_Core_Action::VIEW]['title'] = ts('View SMS Report');
         }
-
         if (!($row['status'] === 'Not scheduled') && !$row['sms_provider_id']) {
           if ($allAccess || $showCreateLinks) {
             $actionMask = CRM_Core_Action::VIEW;


### PR DESCRIPTION
…d fix some strings to be clearer your dealing with SMS when looking at the List of Sent Mass SMSes

Overview
----------------------------------------
This fixes the Copy link to go to the correct endpoint for SMS if we are on the list of sent SMSes

Before
----------------------------------------
Copying an SMS creates a new Mass Mailing

After
----------------------------------------
Copying an SMS creates a new mass SMS

@eileenmcnaughton @johntwyman @colemanw 