### PR TITLE
PHP 8.4 - Fix warnings about NULL-able parameters

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -804,7 +804,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
    * @param array $conditions
    * @inheritDoc
    */
-  public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
+  public function addSelectWhereClause(?string $entityName = NULL, ?int $userId = NULL, array $conditions = []): array {
     $clauses = [];
     $permittedActivityTypeIDs = self::getPermittedActivityTypes();
     if (!empty($conditions['activity_type_id'])) {
@@ -2731,7 +2731,7 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
    *   Id of the activity.
    * @throws CRM_Core_Exception
    */
-  public static function getEntityIcon(string $entityName, int $entityId = NULL): ?string {
+  public static function getEntityIcon(string $entityName, ?int $entityId = NULL): ?string {
     $default = parent::getEntityIcon($entityName);
     if (!$entityId) {
       return $default;

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -3030,7 +3030,7 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
    * @param array $conditions
    * @inheritDoc
    */
-  public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
+  public function addSelectWhereClause(?string $entityName = NULL, ?int $userId = NULL, array $conditions = []): array {
     $administerCases = CRM_Core_Permission::check('administer CiviCase', $userId);
     $viewMyCases = CRM_Core_Permission::check('access my cases and activities', $userId);
     $viewAllCases = CRM_Core_Permission::check('access all cases and activities', $userId);
@@ -3063,7 +3063,7 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
     return $clauses;
   }
 
-  private static function getAccessMyCasesClause(int $userId = NULL): string {
+  private static function getAccessMyCasesClause(?int $userId = NULL): string {
     $user = $userId ?? (int) CRM_Core_Session::getLoggedInContactID();
     return "IN (
       SELECT r.case_id FROM civicrm_relationship r, civicrm_case_contact cc WHERE r.is_active = 1 AND cc.case_id = r.case_id AND (

--- a/CRM/Case/BAO/CaseContact.php
+++ b/CRM/Case/BAO/CaseContact.php
@@ -76,7 +76,7 @@ class CRM_Case_BAO_CaseContact extends CRM_Case_DAO_CaseContact implements \Civi
    * @param array $conditions
    * @inheritDoc
    */
-  public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
+  public function addSelectWhereClause(?string $entityName = NULL, ?int $userId = NULL, array $conditions = []): array {
     return [
       // Reuse case acls
       'case_id' => CRM_Utils_SQL::mergeSubquery('Case'),

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3401,7 +3401,7 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
    * @param array $conditions
    * @inheritDoc
    */
-  public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
+  public function addSelectWhereClause(?string $entityName = NULL, ?int $userId = NULL, array $conditions = []): array {
     // We always return an array with these keys, even if they are empty,
     // because this tells the query builder that we have considered these fields for acls
     $clauses = [
@@ -3622,11 +3622,11 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
    *
    * @param string $entityName
    *   Always "Contact".
-   * @param int $entityId
+   * @param int|null $entityId
    *   Id of the contact.
    * @throws CRM_Core_Exception
    */
-  public static function getEntityIcon(string $entityName, int $entityId = NULL): ?string {
+  public static function getEntityIcon(string $entityName, ?int $entityId = NULL): ?string {
     $default = parent::getEntityIcon($entityName);
     if (!$entityId) {
       return $default;

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -317,7 +317,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group implements HookInterfa
    * @param array $conditions
    * @inheritDoc
    */
-  public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
+  public function addSelectWhereClause(?string $entityName = NULL, ?int $userId = NULL, array $conditions = []): array {
     $clauses = [];
     if (!CRM_Core_Permission::check([['edit all contacts', 'view all contacts']])) {
       $allowedGroups = CRM_Core_Permission::group(NULL, FALSE);

--- a/CRM/Contact/BAO/RelationshipCache.php
+++ b/CRM/Contact/BAO/RelationshipCache.php
@@ -161,7 +161,7 @@ class CRM_Contact_BAO_RelationshipCache extends CRM_Contact_DAO_RelationshipCach
    * @param array $conditions
    * @return array
    */
-  public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
+  public function addSelectWhereClause(?string $entityName = NULL, ?int $userId = NULL, array $conditions = []): array {
     // Permission for this entity depends on access to the two related contacts.
     $contactClause = CRM_Utils_SQL::mergeSubquery('Contact');
     $clauses = [

--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -680,7 +680,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
    * @param array $conditions
    * @inheritDoc
    */
-  public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
+  public function addSelectWhereClause(?string $entityName = NULL, ?int $userId = NULL, array $conditions = []): array {
     $clauses['contribution_id'] = CRM_Utils_SQL::mergeSubquery('Contribution');
     CRM_Utils_Hook::selectWhereClause($this, $clauses, $userId, $conditions);
     return $clauses;

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -41,7 +41,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
    * @return array|null
    *   Result includes all custom fields in addition to group info.
    */
-  public static function getGroup(array $filter, int $permissionType = NULL, int $userId = NULL): ?array {
+  public static function getGroup(array $filter, ?int $permissionType = NULL, ?int $userId = NULL): ?array {
     $allGroups = self::getAll([], $permissionType, $userId);
     if (isset($filter['id']) && count($filter) === 1) {
       return $allGroups[$filter['id']] ?? NULL;
@@ -69,7 +69,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
    *   User contact id for permission check (defaults to current user)
    * @return array[]
    */
-  public static function getAll(array $filters = [], int $permissionType = NULL, int $userId = NULL): array {
+  public static function getAll(array $filters = [], ?int $permissionType = NULL, ?int $userId = NULL): array {
     $allGroups = self::loadAll();
     if (isset($permissionType)) {
       if (!in_array($permissionType, [CRM_Core_Permission::EDIT, CRM_Core_Permission::VIEW], TRUE)) {
@@ -2022,11 +2022,11 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
   /**
    * Loads pseudoconstant option values for the `extends_entity_column_id` field.
    *
-   * @param string $fieldName
+   * @param string|null $fieldName
    * @param array $params
    * @return array
    */
-  public static function getExtendsEntityColumnIdOptions(string $fieldName = NULL, array $params = []) {
+  public static function getExtendsEntityColumnIdOptions(?string $fieldName = NULL, array $params = []) {
     $props = $params['values'] ?? [];
     $ogId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'custom_data_type', 'id', 'name');
     $optionValues = CRM_Core_BAO_OptionValue::getOptionValuesArray($ogId);

--- a/CRM/Core/BAO/CustomValue.php
+++ b/CRM/Core/BAO/CustomValue.php
@@ -219,7 +219,7 @@ class CRM_Core_BAO_CustomValue extends CRM_Core_DAO implements \Civi\Core\HookIn
    * @param array $conditions
    * @return array
    */
-  public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
+  public function addSelectWhereClause(?string $entityName = NULL, ?int $userId = NULL, array $conditions = []): array {
     // Some legacy code omits $entityName, in which case fall-back on 'Contact' which until 2023
     // was the only type of entity that could be extended by multi-record custom groups.
     $groupName = \Civi\Api4\Utils\CoreUtil::getCustomGroupName((string) $entityName);

--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -820,7 +820,7 @@ HEREDOC;
    * @param array $conditions
    * @inheritDoc
    */
-  public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
+  public function addSelectWhereClause(?string $entityName = NULL, ?int $userId = NULL, array $conditions = []): array {
     // TODO: This seemded like a good idea... piggybacking off the ACL clause of EntityFile
     // however that's too restrictive because entityFile ACLs are limited to just attachments,
     // so this would prevent access to other file fields (e.g. custom fields)

--- a/CRM/Core/BAO/Note.php
+++ b/CRM/Core/BAO/Note.php
@@ -533,7 +533,7 @@ WHERE participant.contact_id = %1 AND  note.entity_table = 'civicrm_participant'
     }
   }
 
-  public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
+  public function addSelectWhereClause(?string $entityName = NULL, ?int $userId = NULL, array $conditions = []): array {
     $clauses = [];
     $relatedClauses = self::getDynamicFkAclClauses('entity_table', 'entity_id', $conditions['entity_table'] ?? NULL);
     if ($relatedClauses) {

--- a/CRM/Core/BAO/UFJoin.php
+++ b/CRM/Core/BAO/UFJoin.php
@@ -183,7 +183,7 @@ class CRM_Core_BAO_UFJoin extends CRM_Core_DAO_UFJoin {
    * @param array $conditions
    * @return array
    */
-  public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
+  public function addSelectWhereClause(?string $entityName = NULL, ?int $userId = NULL, array $conditions = []): array {
     $clauses = [];
     CRM_Utils_Hook::selectWhereClause($this, $clauses, $userId, $conditions);
     return $clauses;

--- a/CRM/Core/BAO/UFMatch.php
+++ b/CRM/Core/BAO/UFMatch.php
@@ -620,7 +620,7 @@ AND    domain_id    = %4
    * @param array $conditions
    * @inheritDoc
    */
-  public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
+  public function addSelectWhereClause(?string $entityName = NULL, ?int $userId = NULL, array $conditions = []): array {
     // Prevent default behavior of joining ACLs onto the contact_id field.
     $clauses = [];
     CRM_Utils_Hook::selectWhereClause($this, $clauses, $userId, $conditions);

--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -156,7 +156,7 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements HookInterface
    * @param array $conditions
    * @inheritDoc
    */
-  public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
+  public function addSelectWhereClause(?string $entityName = NULL, ?int $userId = NULL, array $conditions = []): array {
     $clauses = [];
     if (!\CRM_Core_Permission::check('administer queues', $userId)) {
       // It was ok to have $userId = NULL for the permission check but must be an int for the query

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -3179,7 +3179,7 @@ SELECT contact_id
    *   Can be used for optimization/deduping of clauses.
    * @return array
    */
-  public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
+  public function addSelectWhereClause(?string $entityName = NULL, ?int $userId = NULL, array $conditions = []): array {
     $clauses = [];
     $fields = $this::getSupportedFields();
     foreach ($fields as $fieldName => $field) {
@@ -3467,11 +3467,11 @@ SELECT contact_id
    * @param string $entityName
    *   Short name of the entity. This may seem redundant because the entity name can usually be inferred
    *   from the BAO class being called, but not always. Some virtual entities share a BAO class.
-   * @param int $entityId
+   * @param int|null $entityId
    *   Id of the entity.
    * @throws CRM_Core_Exception
    */
-  public static function getEntityIcon(string $entityName, int $entityId = NULL): ?string {
+  public static function getEntityIcon(string $entityName, ?int $entityId = NULL): ?string {
     // By default, just return the icon representing this entity. If there's more complex lookup to do,
     // the BAO for this entity should override this method.
     return static::$_icon;

--- a/CRM/Core/DAO/Base.php
+++ b/CRM/Core/DAO/Base.php
@@ -81,7 +81,7 @@ abstract class CRM_Core_DAO_Base extends CRM_Core_DAO {
   /**
    * @inheritDoc
    */
-  public static function getEntityIcon(string $entityName, int $entityId = NULL): ?string {
+  public static function getEntityIcon(string $entityName, ?int $entityId = NULL): ?string {
     return static::getEntityInfo()['icon'] ?? NULL;
   }
 

--- a/CRM/Core/Exception/PrematureExitException.php
+++ b/CRM/Core/Exception/PrematureExitException.php
@@ -40,9 +40,9 @@ class CRM_Core_Exception_PrematureExitException extends RuntimeException {
    * @param string $message [optional] The Exception message to throw.
    * @param array $errorData
    * @param int $error_code
-   * @param throwable $previous [optional] The previous throwable used for the exception chaining.
+   * @param Throwable|null $previous [optional] The previous throwable used for the exception chaining.
    */
-  public function __construct($message = "", $errorData = [], $error_code = 0, throwable $previous = NULL) {
+  public function __construct($message = "", $errorData = [], $error_code = 0, ?Throwable $previous = NULL) {
     parent::__construct($message, $error_code, $previous);
     $this->errorData = $errorData + ['error_code' => $error_code];
   }

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2909,10 +2909,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * This is like a save point :-). The next status bounce will
    * return the browser to this url unless another is added.
    *
-   * @param string $path
+   * @param string|null $path
    *   Path string e.g. `civicrm/foo/bar?reset=1`, defaults to current path.
    */
-  protected function pushUrlToUserContext(string $path = NULL): void {
+  protected function pushUrlToUserContext(?string $path = NULL): void {
     $url = CRM_Utils_System::url($path ?: CRM_Utils_System::currentPath() . '?reset=1',
       '', FALSE, NULL, FALSE);
     CRM_Core_Session::singleton()->pushUserContext($url);

--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -46,7 +46,7 @@ class CRM_Core_ManagedEntities {
    * Perform an asynchronous reconciliation when the transaction ends.
    * @param array|null $modules
    */
-  public static function scheduleReconciliation(array $modules = NULL) {
+  public static function scheduleReconciliation(?array $modules = NULL) {
     CRM_Core_Transaction::addCallback(
       CRM_Core_Transaction::PHASE_POST_COMMIT,
       function ($modules) {

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -103,12 +103,12 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
   /**
    * Get or set the single instance of CRM_Core_Resources.
    *
-   * @param CRM_Core_Resources $instance
+   * @param CRM_Core_Resources|null $instance
    *   New copy of the manager.
    *
    * @return CRM_Core_Resources
    */
-  public static function singleton(CRM_Core_Resources $instance = NULL) {
+  public static function singleton(?CRM_Core_Resources $instance = NULL) {
     if ($instance !== NULL) {
       self::$_singleton = $instance;
     }

--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -169,7 +169,7 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
    *
    * @internal
    */
-  protected function getEventTokenValues(int $eventID = NULL): array {
+  protected function getEventTokenValues(?int $eventID = NULL): array {
     if (!$eventID) {
       return [];
     }

--- a/CRM/Extension/Container/Basic.php
+++ b/CRM/Extension/Container/Basic.php
@@ -88,14 +88,14 @@ class CRM_Extension_Container_Basic implements CRM_Extension_Container_Interface
    *   Local path to the container.
    * @param string $baseUrl
    *   Public URL of the container.
-   * @param CRM_Utils_Cache_Interface $cache
+   * @param CRM_Utils_Cache_Interface|null $cache
    *   Cache in which to store extension metadata.
    * @param string $cacheKey
    *   Unique name for this container.
    * @param int|null $maxDepth
    *   Maximum number of subdirectories to search.
    */
-  public function __construct($baseDir, $baseUrl, CRM_Utils_Cache_Interface $cache = NULL, $cacheKey = NULL, ?int $maxDepth = NULL) {
+  public function __construct($baseDir, $baseUrl, ?CRM_Utils_Cache_Interface $cache = NULL, $cacheKey = NULL, ?int $maxDepth = NULL) {
     $this->cache = $cache;
     $this->cacheKey = $cacheKey;
     $this->baseDir = rtrim($baseDir, '/');

--- a/CRM/Extension/Container/Collection.php
+++ b/CRM/Extension/Container/Collection.php
@@ -64,12 +64,12 @@ class CRM_Extension_Container_Collection implements CRM_Extension_Container_Inte
    * @param array $containers
    *   Array($name => CRM_Extension_Container_Interface) in order from highest
    *   priority (winners) to lowest priority (losers).
-   * @param CRM_Utils_Cache_Interface $cache
+   * @param CRM_Utils_Cache_Interface|null $cache
    *   Cache in which to store extension metadata.
    * @param string $cacheKey
    *   Unique name for this container.
    */
-  public function __construct($containers, CRM_Utils_Cache_Interface $cache = NULL, $cacheKey = NULL) {
+  public function __construct($containers, ?CRM_Utils_Cache_Interface $cache = NULL, $cacheKey = NULL) {
     $this->containers = $containers;
     $this->cache = $cache;
     $this->cacheKey = $cacheKey;

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -73,13 +73,13 @@ class CRM_Extension_Mapper {
   protected $upgraders = [];
 
   /**
-   * @param CRM_Extension_Container_Interface $container
-   * @param CRM_Utils_Cache_Interface $cache
+   * @param CRM_Extension_Container_Interface|null $container
+   * @param CRM_Utils_Cache_Interface|null $cache
    * @param null $cacheKey
    * @param null $civicrmPath
    * @param null $civicrmUrl
    */
-  public function __construct(CRM_Extension_Container_Interface $container, CRM_Utils_Cache_Interface $cache = NULL, $cacheKey = NULL, $civicrmPath = NULL, $civicrmUrl = NULL) {
+  public function __construct(CRM_Extension_Container_Interface $container, ?CRM_Utils_Cache_Interface $cache = NULL, $cacheKey = NULL, $civicrmPath = NULL, $civicrmUrl = NULL) {
     $this->container = $container;
     $this->cache = $cache;
     $this->cacheKey = $cacheKey;

--- a/CRM/Extension/MixinScanner.php
+++ b/CRM/Extension/MixinScanner.php
@@ -59,7 +59,7 @@ class CRM_Extension_MixinScanner {
    *   Enabling this may slow-down scanning a bit, and it has no benefit when for on-demand loaders.
    *   However, if the loader is cached, then it may make for smaller, more portable cache-file.
    */
-  public function __construct(?\CRM_Extension_Mapper $mapper = NULL, \CRM_Extension_Manager $manager = NULL, $relativize = TRUE) {
+  public function __construct(?\CRM_Extension_Mapper $mapper = NULL, ?\CRM_Extension_Manager $manager = NULL, $relativize = TRUE) {
     $this->mapper = $mapper ?: CRM_Extension_System::singleton()->getMapper();
     $this->manager = $manager ?: CRM_Extension_System::singleton()->getManager();
     if ($relativize) {

--- a/CRM/Extension/Upgrader/Base.php
+++ b/CRM/Extension/Upgrader/Base.php
@@ -155,7 +155,7 @@ class CRM_Extension_Upgrader_Base implements CRM_Extension_Upgrader_Interface {
   /**
    * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
    */
-  public function onUpgrade($op, CRM_Queue_Queue $queue = NULL) {
+  public function onUpgrade($op, ?CRM_Queue_Queue $queue = NULL) {
     switch ($op) {
       case 'check':
         return [$this->hasPendingRevisions()];

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -1215,7 +1215,7 @@ WHERE li.contribution_id = %1";
    * @param array $conditions
    * @inheritDoc
    */
-  public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
+  public function addSelectWhereClause(?string $entityName = NULL, ?int $userId = NULL, array $conditions = []): array {
     $clauses['contribution_id'] = CRM_Utils_SQL::mergeSubquery('Contribution');
     CRM_Utils_Hook::selectWhereClause($this, $clauses, $userId, $conditions);
     return $clauses;

--- a/CRM/Queue/BAO/Queue.php
+++ b/CRM/Queue/BAO/Queue.php
@@ -20,7 +20,7 @@
  */
 class CRM_Queue_BAO_Queue extends CRM_Queue_DAO_Queue implements \Civi\Core\HookInterface {
 
-  public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
+  public function addSelectWhereClause(?string $entityName = NULL, ?int $userId = NULL, array $conditions = []): array {
     $clauses = [];
     if (!\CRM_Core_Permission::check('administer queues')) {
       $cid = (int) CRM_Core_Session::getLoggedInContactID();

--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -290,7 +290,7 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance implem
    *
    * @inheritDoc
    */
-  public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
+  public function addSelectWhereClause(?string $entityName = NULL, ?int $userId = NULL, array $conditions = []): array {
     $permissions = CRM_Core_DAO::executeQuery('SELECT DISTINCT permission FROM civicrm_report_instance');
     $validPermissions = [];
     while ($permissions->fetch()) {

--- a/CRM/Upgrade/Incremental/php/TimezoneRevertTrait.php
+++ b/CRM/Upgrade/Incremental/php/TimezoneRevertTrait.php
@@ -111,10 +111,10 @@ trait CRM_Upgrade_Incremental_php_TimezoneRevertTrait {
    *
    * But some records may have changed. `convertModifiedEvents()` will address those.
    *
-   * @param \CRM_Queue_TaskContext $ctx
+   * @param \CRM_Queue_TaskContext|null $ctx
    * @return bool
    */
-  public static function revertEventDates(CRM_Queue_TaskContext $ctx = NULL): bool {
+  public static function revertEventDates(?CRM_Queue_TaskContext $ctx = NULL): bool {
     // We only run if the field is timestamp, so don't need to check about that.
 
     // The original 5.47.alpha1 upgrade was executed with SQL helpers in CRM_Utils_File, which use
@@ -153,10 +153,10 @@ trait CRM_Upgrade_Incremental_php_TimezoneRevertTrait {
    * By default, this will borrow the current user (sysadmin)'s timezone as the representative skewTz.
    * This can be overridden with env-var `CIVICRM_TZ_SKEW`.
    *
-   * @param \CRM_Queue_TaskContext $ctx
+   * @param \CRM_Queue_TaskContext|null $ctx
    * @return bool
    */
-  public static function convertModifiedEvents(CRM_Queue_TaskContext $ctx = NULL): bool {
+  public static function convertModifiedEvents(?CRM_Queue_TaskContext $ctx = NULL): bool {
     $skewTz = self::pickSkewTz();
     $mysqlTz = '+0:00';
     $restoreMysqlTz = static::swapTz($mysqlTz);

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -648,7 +648,7 @@ abstract class CRM_Utils_Hook {
    * @param array $conditions
    *   Values from WHERE or ON clause
    */
-  public static function selectWhereClause($entity, array &$clauses, int $userId = NULL, array $conditions = []): void {
+  public static function selectWhereClause($entity, array &$clauses, ?int $userId = NULL, array $conditions = []): void {
     $entityName = is_object($entity) ? CRM_Core_DAO_AllCoreTables::getEntityNameForClass(get_class($entity)) : $entity;
     $null = NULL;
     $userId ??= (int) CRM_Core_Session::getLoggedInContactID();
@@ -1680,7 +1680,7 @@ abstract class CRM_Utils_Hook {
    *
    * @return mixed
    */
-  public static function emailProcessor($type, &$params, $mail, &$result, $action = NULL, int $mailSettingId = NULL) {
+  public static function emailProcessor($type, &$params, $mail, &$result, $action = NULL, ?int $mailSettingId = NULL) {
     $null = NULL;
     return self::singleton()
       ->invoke(['type', 'params', 'mail', 'result', 'action', 'mailSettingId'], $type, $params, $mail, $result, $action, $mailSettingId, 'civicrm_emailProcessor');
@@ -2196,7 +2196,7 @@ abstract class CRM_Utils_Hook {
    *   TRUE, if $op is 'check' and upgrades are pending.
    *   FALSE, if $op is 'check' and upgrades are not pending.
    */
-  public static function upgrade($op, CRM_Queue_Queue $queue = NULL) {
+  public static function upgrade($op, ?CRM_Queue_Queue $queue = NULL) {
     $null = NULL;
     return self::singleton()->invoke(['op', 'queue'], $op, $queue,
       $null, $null, $null, $null,

--- a/Civi/API/Exception/NotImplementedException.php
+++ b/Civi/API/Exception/NotImplementedException.php
@@ -17,7 +17,7 @@ class NotImplementedException extends \CRM_Core_Exception {
    * @param \Exception|null $previous
    *   A previous exception which caused this new exception.
    */
-  public function __construct($message, $extraParams = [], \Exception $previous = NULL) {
+  public function __construct($message, $extraParams = [], ?\Exception $previous = NULL) {
     parent::__construct($message, \CRM_Core_Exception::NOT_IMPLEMENTED, $extraParams, $previous);
   }
 

--- a/Civi/API/Exception/UnauthorizedException.php
+++ b/Civi/API/Exception/UnauthorizedException.php
@@ -17,7 +17,7 @@ class UnauthorizedException extends \CRM_Core_Exception {
    * @param \Exception|null $previous
    *   A previous exception which caused this new exception.
    */
-  public function __construct($message, $extraParams = [], \Exception $previous = NULL) {
+  public function __construct($message, $extraParams = [], ?\Exception $previous = NULL) {
     parent::__construct($message, \CRM_Core_Exception::UNAUTHORIZED, $extraParams, $previous);
   }
 

--- a/Civi/Angular/Manager.php
+++ b/Civi/Angular/Manager.php
@@ -38,7 +38,7 @@ class Manager {
    *   The resource manager.
    * @param $cache
    */
-  public function __construct($res, \CRM_Utils_Cache_Interface $cache = NULL) {
+  public function __construct($res, ?\CRM_Utils_Cache_Interface $cache = NULL) {
     $this->res = $res;
     $this->cache = $cache ?: new \CRM_Utils_Cache_ArrayCache([]);
   }

--- a/Civi/Api4/Event/ValidateValuesEvent.php
+++ b/Civi/Api4/Event/ValidateValuesEvent.php
@@ -127,7 +127,7 @@ class ValidateValuesEvent extends GenericHookEvent {
    * @param string|null $message
    * @return $this
    */
-  public function addError($recordKey, $field, string $name, string $message = NULL): self {
+  public function addError($recordKey, $field, string $name, ?string $message = NULL): self {
     $this->errors[] = [
       'record' => $recordKey,
       'fields' => (array) $field,

--- a/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
+++ b/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
@@ -107,11 +107,11 @@ trait ArrayQueryActionTrait {
   /**
    * @param array $row
    * @param array $condition
-   * @param int $index
+   * @param int|null $index
    * @return bool
    * @throws \Civi\API\Exception\NotImplementedException
    */
-  public static function filterCompare(array $row, array $condition, int $index = NULL): bool {
+  public static function filterCompare(array $row, array $condition, ?int $index = NULL): bool {
     $value = $row[$condition[0]] ?? NULL;
     $operator = $condition[1];
     $expected = $condition[2] ?? NULL;

--- a/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
+++ b/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
@@ -58,7 +58,7 @@ trait SavedSearchInspectorTrait {
    * @throws UnauthorizedException
    * @throws \CRM_Core_Exception
    */
-  protected function loadSavedSearch(int $id = NULL) {
+  protected function loadSavedSearch(?int $id = NULL) {
     if ($id || is_string($this->savedSearch)) {
       $this->savedSearch = SavedSearch::get(FALSE)
         ->addWhere($id ? 'id' : 'name', '=', $id ?: $this->savedSearch)

--- a/Civi/Api4/Service/Schema/Joinable/Joinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/Joinable.php
@@ -299,7 +299,7 @@ class Joinable {
    * @param string|null $deprecatedBy
    * @return $this
    */
-  public function setDeprecatedBy(string $deprecatedBy = NULL) {
+  public function setDeprecatedBy(?string $deprecatedBy = NULL) {
     $this->deprecatedBy = $deprecatedBy ?? $this->alias . '_id';
     return $this;
   }

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -20,7 +20,7 @@ class SpecFormatter {
   /**
    * Convert array from BAO::fields() or CustomGroup::getAll() into a FieldSpec object
    */
-  public static function arrayToField(array $data, string $entityName, array $customGroup = NULL): FieldSpec {
+  public static function arrayToField(array $data, string $entityName, ?array $customGroup = NULL): FieldSpec {
     $dataTypeName = self::getDataType($data);
 
     $hasDefault = isset($data['default']) && $data['default'] !== '';

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -239,7 +239,7 @@ class CoreUtil {
    * @return bool|null
    * @throws \CRM_Core_Exception
    */
-  public static function checkAccessRecord(AbstractAction $apiRequest, array $record, int $userID = NULL): ?bool {
+  public static function checkAccessRecord(AbstractAction $apiRequest, array $record, ?int $userID = NULL): ?bool {
     $userID ??= \CRM_Core_Session::getLoggedInContactID() ?? 0;
     $idField = self::getIdFieldName($apiRequest->getEntityName());
 

--- a/Civi/Import/DataSource/DataSourceTrait.php
+++ b/Civi/Import/DataSource/DataSourceTrait.php
@@ -42,7 +42,7 @@ trait DataSourceTrait {
    *
    * @param int|null $userJobID
    */
-  public function __construct(int $userJobID = NULL) {
+  public function __construct(?int $userJobID = NULL) {
     if ($userJobID) {
       $this->setUserJobID($userJobID);
     }

--- a/Civi/Schema/EntityMetadataInterface.php
+++ b/Civi/Schema/EntityMetadataInterface.php
@@ -17,6 +17,6 @@ interface EntityMetadataInterface {
 
   public function getFields(): array;
 
-  public function getOptions(string $fieldName, array $values = NULL): ?array;
+  public function getOptions(string $fieldName, ?array $values = NULL): ?array;
 
 }

--- a/Civi/Schema/EntityProvider.php
+++ b/Civi/Schema/EntityProvider.php
@@ -44,7 +44,7 @@ final class EntityProvider {
     return $this->getFields()[$fieldName] ?? NULL;
   }
 
-  public function getOptions(string $fieldName, array $values = NULL): ?array {
+  public function getOptions(string $fieldName, ?array $values = NULL): ?array {
     return $this->getMetaProvider()->getOptions($fieldName, $values);
   }
 

--- a/Civi/Schema/LegacySqlEntityMetadata.php
+++ b/Civi/Schema/LegacySqlEntityMetadata.php
@@ -186,7 +186,7 @@ class LegacySqlEntityMetadata extends EntityMetadataBase {
     return $usage;
   }
 
-  public function getOptions(string $fieldName, array $values = NULL): ?array {
+  public function getOptions(string $fieldName, ?array $values = NULL): ?array {
     // TODO: Implement getOptions() method.
   }
 

--- a/Civi/Schema/SqlEntityMetadata.php
+++ b/Civi/Schema/SqlEntityMetadata.php
@@ -40,7 +40,7 @@ class SqlEntityMetadata extends EntityMetadataBase {
     return $this->getEntity()['getFields']();
   }
 
-  public function getOptions(string $fieldName, array $values = NULL): ?array {
+  public function getOptions(string $fieldName, ?array $values = NULL): ?array {
     // TODO: Implement getOptions() method.
   }
 

--- a/Civi/WorkflowMessage/Traits/FinalHelperTrait.php
+++ b/Civi/WorkflowMessage/Traits/FinalHelperTrait.php
@@ -28,7 +28,7 @@ trait FinalHelperTrait {
    * @see \Civi\WorkflowMessage\WorkflowMessageInterface::export()
    * @see \Civi\WorkflowMessage\Traits\ReflectiveWorkflowTrait::export()
    */
-  abstract public function export(string $format = NULL): ?array;
+  abstract public function export(?string $format = NULL): ?array;
 
   /**
    * @see \Civi\WorkflowMessage\WorkflowMessageInterface::validate()

--- a/Civi/WorkflowMessage/Traits/ReflectiveWorkflowTrait.php
+++ b/Civi/WorkflowMessage/Traits/ReflectiveWorkflowTrait.php
@@ -111,7 +111,7 @@ trait ReflectiveWorkflowTrait {
    * @inheritDoc
    * @see \Civi\WorkflowMessage\WorkflowMessageInterface::export()
    */
-  public function export(string $format = NULL): ?array {
+  public function export(?string $format = NULL): ?array {
     switch ($format) {
       case 'modelProps':
       case 'envelope':

--- a/Civi/WorkflowMessage/Traits/TemplateTrait.php
+++ b/Civi/WorkflowMessage/Traits/TemplateTrait.php
@@ -82,7 +82,7 @@ trait TemplateTrait {
    * @throws \CRM_Core_Exception
    * @internal
    */
-  private static function loadTemplate(string $workflowName, bool $isTest, int $messageTemplateID = NULL, $groupName = NULL, ?array $messageTemplateOverride = NULL, ?string $language = NULL): array {
+  private static function loadTemplate(string $workflowName, bool $isTest, ?int $messageTemplateID = NULL, $groupName = NULL, ?array $messageTemplateOverride = NULL, ?string $language = NULL): array {
     $base = ['msg_subject' => NULL, 'msg_text' => NULL, 'msg_html' => NULL, 'pdf_format_id' => NULL];
     if (!$workflowName && !$messageTemplateID && !$messageTemplateOverride) {
       throw new CRM_Core_Exception(ts("Message template not specified. No option value, ID, or template content."));

--- a/Civi/WorkflowMessage/WorkflowMessageInterface.php
+++ b/Civi/WorkflowMessage/WorkflowMessageInterface.php
@@ -26,14 +26,14 @@ interface WorkflowMessageInterface {
   public function getFields(): array;
 
   /**
-   * @param string $format
+   * @param string|null $format
    *   Ex: 'tplParams', 'tokenContext', 'modelProps', 'envelope'
    * @return array|null
    *   A list of field-values that are used in the given format, keyed by their name in that format.
    *   If the implementation does not understand a specific format, return NULL.
    * @see \Civi\WorkflowMessage\Traits\ReflectiveWorkflowTrait::export()
    */
-  public function export(string $format = NULL): ?array;
+  public function export(?string $format = NULL): ?array;
 
   /**
    * Import values from some scope.

--- a/ext/oauth-client/CRM/OAuth/BAO/OAuthContactToken.php
+++ b/ext/oauth-client/CRM/OAuth/BAO/OAuthContactToken.php
@@ -101,7 +101,7 @@ class CRM_OAuth_BAO_OAuthContactToken extends CRM_OAuth_DAO_OAuthContactToken im
    * @param array $conditions
    * @inheritDoc
    */
-  public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
+  public function addSelectWhereClause(?string $entityName = NULL, ?int $userId = NULL, array $conditions = []): array {
     $clauses = [];
     $loggedInContactID = CRM_Core_Session::getLoggedInContactID();
 

--- a/ext/standaloneusers/CRM/Standaloneusers/BAO/User.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/BAO/User.php
@@ -104,7 +104,7 @@ class CRM_Standaloneusers_BAO_User extends CRM_Standaloneusers_DAO_User implemen
     return $timeZones;
   }
 
-  public function addSelectWhereClause(string $entityName = NULL, int $userId = NULL, array $conditions = []): array {
+  public function addSelectWhereClause(?string $entityName = NULL, ?int $userId = NULL, array $conditions = []): array {
     $clauses = [];
 
     // ↓ The following is copied from parent::addSelectWhereClause(). Is it needed? :shrug:

--- a/tests/extensions/shimmy/shimmy.php
+++ b/tests/extensions/shimmy/shimmy.php
@@ -64,7 +64,7 @@ function shimmy_civicrm_disable() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
-function shimmy_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
+function shimmy_civicrm_upgrade($op, ?CRM_Queue_Queue $queue = NULL) {
   return _shimmy_civix_civicrm_upgrade($op, $queue);
 }
 

--- a/tests/phpunit/CRM/Activity/Selector/SearchTest.php
+++ b/tests/phpunit/CRM/Activity/Selector/SearchTest.php
@@ -112,7 +112,7 @@ class CRM_Activity_Selector_SearchTest extends CiviUnitTestCase {
    *
    * @noinspection PhpUnusedParameterInspection
    */
-  public static function linkHook(string $op, string $objectName, int &$objectId, array &$links, int &$mask = NULL, array $values = []): void {
+  public static function linkHook(string $op, string $objectName, int &$objectId, array &$links, ?int &$mask = NULL, array $values = []): void {
     if ($values['activity_type_id']) {
       $links = [];
     }

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -1911,7 +1911,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  protected function runImport(array $originalValues, int $onDuplicateAction, int $expectedResult, ?array $fieldMapping = [], array $fields = NULL, int $ruleGroupId = NULL): void {
+  protected function runImport(array $originalValues, int $onDuplicateAction, int $expectedResult, ?array $fieldMapping = [], ?array $fields = NULL, ?int $ruleGroupId = NULL): void {
     $values = array_values($originalValues);
     // Stand in for row number.
     $values[] = 1;

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -666,7 +666,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
    * @return array
    *   ['year' => int, 'month' => int]
    */
-  private function getYearAndMonthFromOffset(int $offset, int $year = NULL, int $month = NULL): array {
+  private function getYearAndMonthFromOffset(int $offset, ?int $year = NULL, ?int $month = NULL): array {
     $dateInfo = [
       'year' => $year ?? (int) date('Y'),
       'month' => ($month ?? (int) date('m')) + $offset,

--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -353,7 +353,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function submitPayment(float $amount, string $mode = NULL, bool $isEmailReceipt = FALSE): void {
+  public function submitPayment(float $amount, ?string $mode = NULL, bool $isEmailReceipt = FALSE): void {
     $submitParams = [
       'contact_id' => $this->ids['Contact']['order'] ?? $this->_individualId,
       'total_amount' => $amount,

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -759,7 +759,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  protected function runImport(array $originalValues, int $onDuplicateAction, array $mappings = [], array $fields = NULL): void {
+  protected function runImport(array $originalValues, int $onDuplicateAction, array $mappings = [], ?array $fields = NULL): void {
     if (!$fields) {
       $fields = array_keys($originalValues);
     }

--- a/tests/phpunit/CRM/Extension/Container/BasicTest.php
+++ b/tests/phpunit/CRM/Extension/Container/BasicTest.php
@@ -85,13 +85,13 @@ class CRM_Extension_Container_BasicTest extends CiviUnitTestCase {
   }
 
   /**
-   * @param CRM_Utils_Cache_Interface $cache
+   * @param CRM_Utils_Cache_Interface|null $cache
    * @param null $cacheKey
    * @param string $appendPathGarbage
    *
    * @return array
    */
-  public function _createContainer(CRM_Utils_Cache_Interface $cache = NULL, $cacheKey = NULL, $appendPathGarbage = '') {
+  public function _createContainer(?CRM_Utils_Cache_Interface $cache = NULL, $cacheKey = NULL, $appendPathGarbage = '') {
     $basedir = rtrim($this->createTempDir('ext-'), '/');
     mkdir("$basedir/foo");
     mkdir("$basedir/foo/bar");

--- a/tests/phpunit/CRM/Extension/Container/CollectionTest.php
+++ b/tests/phpunit/CRM/Extension/Container/CollectionTest.php
@@ -80,12 +80,12 @@ class CRM_Extension_Container_CollectionTest extends CiviUnitTestCase {
   }
 
   /**
-   * @param CRM_Utils_Cache_Interface $cache
+   * @param CRM_Utils_Cache_Interface|null $cache
    * @param null $cacheKey
    *
    * @return CRM_Extension_Container_Collection
    */
-  public function _createContainer(CRM_Utils_Cache_Interface $cache = NULL, $cacheKey = NULL) {
+  public function _createContainer(?CRM_Utils_Cache_Interface $cache = NULL, $cacheKey = NULL) {
     $containers = [];
     $containers['a'] = new CRM_Extension_Container_Static([
       'test.foo' => [

--- a/tests/phpunit/CRM/Extension/MapperTest.php
+++ b/tests/phpunit/CRM/Extension/MapperTest.php
@@ -126,13 +126,13 @@ class CRM_Extension_MapperTest extends CiviUnitTestCase {
   }
 
   /**
-   * @param CRM_Utils_Cache_Interface $cache
+   * @param CRM_Utils_Cache_Interface|null $cache
    * @param null $cacheKey
    * @param string $appendPathGarbage
    *
    * @return array
    */
-  public function _createContainer(CRM_Utils_Cache_Interface $cache = NULL, $cacheKey = NULL, $appendPathGarbage = '') {
+  public function _createContainer(?CRM_Utils_Cache_Interface $cache = NULL, $cacheKey = NULL, $appendPathGarbage = '') {
     /*
     $container = new CRM_Extension_Container_Static(array(
     'test.foo.bar' => array(

--- a/tests/phpunit/CRM/Utils/Mail/EmailProcessorInboundTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/EmailProcessorInboundTest.php
@@ -140,7 +140,7 @@ class CRM_Utils_Mail_EmailProcessorInboundTest extends CiviUnitTestCase {
   /**
    * hook implementation for testHookEmailProcessor
    */
-  public function hookImplForEmailProcessor($type, &$params, $mail, &$result, $action = NULL, int $mailSettingId = NULL) {
+  public function hookImplForEmailProcessor($type, &$params, $mail, &$result, $action = NULL, ?int $mailSettingId = NULL) {
     $this->assertEquals($this->mailSettingsId, $mailSettingId);
     if ($type !== 'activity') {
       return;

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1311,7 +1311,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * @return int
    *   $id of created UF Join
    */
-  public function ufjoinCreate(array $params = NULL): int {
+  public function ufjoinCreate(?array $params = NULL): int {
     if ($params === NULL) {
       $params = [
         'is_active' => 1,

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -4766,7 +4766,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    * @throws \Civi\API\Exception\UnauthorizedException
    */
-  protected function validateContactField(string $fieldName, $expected, ?int $contactID, array $criteria = NULL): void {
+  protected function validateContactField(string $fieldName, $expected, ?int $contactID, ?array $criteria = NULL): void {
     $api = Contact::get()->addSelect($fieldName);
     if ($criteria) {
       $api->setWhere([$criteria]);


### PR DESCRIPTION
Overview
----------------------------------------

This fixes many instances of a new warning in PHP 8.4.  The warnings typically look like:

```
Deprecated: SomeClass::someFunction(): Implicitly marking parameter
$someParameter as nullable is deprecated, the explicit nullable type must be used
instead in path/to/SomeClass.php on line 189
```

Technical Details
----------------------------------------

Consider these function signatures:

```php
function a($param) {}                 // Anything goes
function b(string $param) {}          // MUST be string.
function c(?string $param) {}         // MAY be string or null
function d(?string $param = NULL) {}  // MAY be string or null, with default null
function e(string $param = NULL) {}   // MAY be string or null, with default null
```

If you've learned about the meaning of `?` (*so you correctly understood the first 4 examples*), then the last example is confusing/contradictory.

The last example is now deprecated:

* Before PHP 8.4, `e()` was treated the same as `d()`. The `$param` was *implicitly* nullable.
* After PHP 8.4, it emits a deprecation warning.

Here's a random weblink discussing the change in more detail: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

