### PR TITLE
dev/core#5370 Fix Civi-import import-mapping saving issues

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -190,23 +190,15 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
       $defaults["mapper[$i]"] = [];
       if ($this->getSubmittedValue('savedMapping')) {
         $fieldMapping = $fieldMappings[$i] ?? NULL;
-        if ($fieldMapping) {
-          if ($fieldMapping['name'] !== ts('do_not_import')) {
-            // $mapping contact_type is not really a contact type - the 'about this entity' data has been mangled
-            // into that field - see https://lab.civicrm.org/dev/core/-/issues/654
-            $softCreditTypeID = '';
-            $entityData = json_decode($fieldMapping['contact_type'] ?? '', TRUE);
-            if (!empty($entityData)) {
-              $softCreditTypeID = (int) $entityData['soft_credit']['soft_credit_type_id'];
-            }
-            $fieldName = $this->isQuickFormMode ? str_replace('.', '__', $fieldMapping['name']) : $fieldMapping['name'];
-            $defaults["mapper[$i]"] = [$fieldName, $softCreditTypeID];
-          }
-        }
+        $this->addMappingToDefaults($defaults, $fieldMapping, $i);
       }
       elseif ($this->getSubmittedValue('skipColumnHeader')) {
         $defaults["mapper[$i]"][0] = $this->guessMappingBasedOnColumns($columnHeader);
       }
+    }
+    $userDefinedMappings = array_diff_key($this->getFieldMappings(), $this->getColumnHeaders());
+    foreach ($userDefinedMappings as $index => $mapping) {
+      $this->addMappingToDefaults($defaults, $mapping, $index);
     }
 
     return $defaults;
@@ -248,6 +240,31 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
       return $rule['rule_message'];
     }
     return NULL;
+  }
+
+  /**
+   * Add the saved mapping to the defaults.
+   *
+   * @param array $defaults
+   * @param array $fieldMapping
+   * @param int $rowNumber
+   *
+   * @return void
+   */
+  public function addMappingToDefaults(array &$defaults, array $fieldMapping, int $rowNumber): void {
+    if ($fieldMapping) {
+      if ($fieldMapping['name'] !== ts('do_not_import')) {
+        // $mapping contact_type is not really a contact type - the 'about this entity' data has been mangled
+        // into that field - see https://lab.civicrm.org/dev/core/-/issues/654
+        $softCreditTypeID = '';
+        $entityData = json_decode($fieldMapping['contact_type'] ?? '', TRUE);
+        if (!empty($entityData)) {
+          $softCreditTypeID = (int) $entityData['soft_credit']['soft_credit_type_id'];
+        }
+        $fieldName = $this->isQuickFormMode ? str_replace('.', '__', $fieldMapping['name']) : $fieldMapping['name'];
+        $defaults["mapper[$rowNumber]"] = [$fieldName, $softCreditTypeID];
+      }
+    }
   }
 
   /**

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -565,7 +565,16 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * @throws \CRM_Core_Exception
    */
   protected function getColumnHeaders(): array {
-    return $this->getDataSourceObject()->getColumnHeaders();
+    $headers = $this->getDataSourceObject()->getColumnHeaders();
+    $mappedFields = $this->getUserJob()['metadata']['import_mappings'] ?? [];
+    if (!empty($mappedFields) && count($mappedFields) > count($headers)) {
+      // The user has mapped one or more non-database fields, add those in.
+      $userMappedFields = array_diff_key($mappedFields, $headers);
+      foreach ($userMappedFields as $field) {
+        $headers[] = '';
+      }
+    }
+    return $headers;
   }
 
   /**
@@ -963,6 +972,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
       'entityMetadata' => $this->getFieldOptions(),
       'dedupeRules' => $parser->getAllDedupeRules(),
       'userJob' => $this->getUserJob(),
+      'columnHeaders' => $this->getColumnHeaders(),
     ]);
   }
 

--- a/ext/civiimport/ang/crmCiviimport.js
+++ b/ext/civiimport/ang/crmCiviimport.js
@@ -277,6 +277,7 @@
          * @type {$scope.save}
          */
         $scope.save = (function ($event) {
+          $event.preventDefault();
           $scope.userJob.metadata.entity_configuration = {};
           $scope.userJob.metadata.import_mappings = [];
           _.each($scope.entitySelection, function (entity) {
@@ -300,7 +301,16 @@
               entity_data: entityConfig
             });
           });
-          crmApi4('UserJob', 'save', {records: [$scope.userJob]});
+          crmApi4('UserJob', 'save', {records: [$scope.userJob]})
+            .then(function(result) {
+              // Only post the form if the save succeeds.
+              document.getElementById("MapField").submit();
+            },
+            function(failure) {
+              // @todo add more error handling - for now, at least we waited...
+              document.getElementById("MapField").submit();
+            }
+          );
         });
 
         $scope.load();

--- a/ext/civiimport/ang/crmCiviimport.js
+++ b/ext/civiimport/ang/crmCiviimport.js
@@ -33,7 +33,8 @@
           $scope.data.dedupeRules = CRM.vars.crmImportUi.dedupeRules;
           // Used for select contact type select-options.
           $scope.data.contactTypes = CRM.vars.crmImportUi.contactTypes;
-
+          // The headers from the data-source + any previously added user-defined rows.
+          $scope.data.columnHeaders = CRM.vars.crmImportUi.columnHeaders;
           $scope.data.entities = {};
           // Available entities is entityMetadata mapped to a form-friendly format
           $scope.entitySelection = [];
@@ -72,7 +73,7 @@
           function buildImportMappings() {
             $scope.data.importMappings = [];
             var importMappings = $scope.userJob.metadata.import_mappings;
-            _.each($scope.userJob.metadata.DataSource.column_headers, function (header, index) {
+            _.each($scope.data.columnHeaders, function (header, index) {
               var fieldName = $scope.data.defaults['mapper[' + index + ']'][0];
               if (Boolean(fieldName)) {
                 fieldName = fieldName.replace('__', '.');


### PR DESCRIPTION
Overview
----------------------------------------
This addresses 2 issues with saving mappings with Civi-import.

1) timing issue - if the js layer does not complete before the php layer then the soft credit details of the mapping are not correctly saved. This would have been a problem all along but either the js action got a bit faster or php a bit slower cos it appears fairly consistent now.
2) The new 5.76 feature of allowing user mappings is not correctly saving them


Before
----------------------------------------
- Go to a plain new dmaster site
- using the [csv @alifrumin provided](https://lab.civicrm.org/-/project/70/uploads/f3347372d45fdb315cc129ea40c700d9/demodata.csv) 
do an contribution to organization import
![image](https://github.com/user-attachments/assets/3c12d4f6-bb41-4052-a056-e326b896599d)
- configure the import with the add row feature & include individual soft credit fields (saving the mapping)
![image](https://github.com/user-attachments/assets/157b5420-d0ba-487e-b790-325c4a5c3ed6)

- see not all fields are remembered
![image](https://github.com/user-attachments/assets/5e2f6ca5-a58d-4199-8c90-e79cf4682b7e)

Try re-using the import template
![image](https://github.com/user-attachments/assets/da41e669-afce-4aa8-bb9c-53555a7942ab)
- entity configuration & the rest of the mappings are forgotten
- 
![image](https://github.com/user-attachments/assets/78c13c6b-cee5-4cb1-b3bf-0ca0725016f9)


After
----------------------------------------
The above is fixed - screenshots from the demo site from this PR

![image](https://github.com/user-attachments/assets/b143282b-6523-417f-8249-31fe6be55ee8)

![image](https://github.com/user-attachments/assets/85c3c91a-81fd-432e-9752-6f53d7e2181d)

Successful reload of the template

![image](https://github.com/user-attachments/assets/8bbbc981-112f-4574-955b-1f7e6fe96443)


Technical Details
----------------------------------------

Comments
----------------------------------------
