### PR TITLE
Determine instance more transparently

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -1496,6 +1496,10 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       CRM_Contact_Form_Edit_OpenID::buildQuickForm($this);
       return;
     }
+    if ($name === 'Email') {
+      CRM_Contact_Form_Edit_Email::buildQuickForm($this, $this->get('Email_Block_Count') ?: 1);
+      return;
+    }
     CRM_Core_Error::deprecatedWarning('unused?');
     $this->buildBlock($name);
   }

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -345,16 +345,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
   }
 
   private function preProcessLocation() {
-    $blockName = CRM_Utils_Request::retrieve('block', 'String');
-    $additionalblockCount = CRM_Utils_Request::retrieve('count', 'Positive');
-
     $this->assign('addBlock', FALSE);
-    if ($blockName && $additionalblockCount) {
-      $this->assign('addBlock', TRUE);
-      $this->assign('blockName', $blockName);
-      $this->assign('blockId', $additionalblockCount);
-      $this->set($blockName . '_Block_Count', $additionalblockCount);
-    }
 
     $this->assign('className', 'CRM_Contact_Form_Contact');
 
@@ -737,7 +728,16 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
   public function buildQuickForm() {
     //load form for child blocks
     if ($this->isAjaxMode()) {
-      $this->buildLocationBlock($this->getAjaxBlockName());
+      $blockName = CRM_Utils_Request::retrieve('block', 'String');
+      $additionalblockCount = CRM_Utils_Request::retrieve('count', 'Positive');
+
+      $this->assign('addBlock', FALSE);
+      if ($blockName && $additionalblockCount) {
+        $this->assign('addBlock', TRUE);
+        $this->assign('blockName', $blockName);
+        $this->assign('blockId', $additionalblockCount);
+      }
+      $this->buildLocationBlock($this->getAjaxBlockName(), $additionalblockCount);
       return;
     }
 
@@ -924,8 +924,6 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
         }
         switch ($blockName) {
           case 'Email':
-            // setDefaults uses this to tell which instance
-            $this->set('Email_Block_Count', $instance);
             CRM_Contact_Form_Edit_Email::buildQuickForm($this, $instance);
             // Only display the signature fields if this contact has a CMS account
             // because they can only send email if they have access to the CRM
@@ -942,8 +940,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
             break;
 
           default:
-            $this->set($blockName . '_Block_Count', $instance);
-            $this->buildLocationBlock($blockName);
+            $this->buildLocationBlock($blockName, $instance);
         }
       }
     }
@@ -1471,33 +1468,33 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     return $this->_contactId ? (int) $this->_contactId : NULL;
   }
 
-  private function buildLocationBlock(string $name): void {
+  private function buildLocationBlock(string $name, int $instance): void {
     if ($name === 'Address') {
-      CRM_Contact_Form_Edit_Address::buildQuickForm($this);
+      CRM_Contact_Form_Edit_Address::buildQuickForm($this, $instance);
       return;
     }
     if ($name === 'Phone') {
-      CRM_Contact_Form_Edit_Phone::buildQuickForm($this);
+      CRM_Contact_Form_Edit_Phone::buildQuickForm($this, $instance);
       return;
     }
     if ($name === 'IM') {
-      CRM_Contact_Form_Edit_IM::buildQuickForm($this);
+      CRM_Contact_Form_Edit_IM::buildQuickForm($this, $instance);
       return;
     }
     if ($name === 'Website') {
-      CRM_Contact_Form_Edit_Website::buildQuickForm($this);
+      CRM_Contact_Form_Edit_Website::buildQuickForm($this, $instance);
       return;
     }
     if ($name === 'IM') {
-      CRM_Contact_Form_Edit_IM::buildQuickForm($this);
+      CRM_Contact_Form_Edit_IM::buildQuickForm($this, $instance);
       return;
     }
     if ($name === 'OpenID') {
-      CRM_Contact_Form_Edit_OpenID::buildQuickForm($this);
+      CRM_Contact_Form_Edit_OpenID::buildQuickForm($this, $instance);
       return;
     }
     if ($name === 'Email') {
-      CRM_Contact_Form_Edit_Email::buildQuickForm($this, $this->get('Email_Block_Count') ?: 1);
+      CRM_Contact_Form_Edit_Email::buildQuickForm($this, $instance);
       return;
     }
     CRM_Core_Error::deprecatedWarning('unused?');


### PR DESCRIPTION
Overview
----------------------------------------
This makes is easier to see where block instance is coming from & harder to accidentally break it

Before
----------------------------------------
- it's not obvious that a key part of `preProcessLocation` is really only applicable with the form is being loaded in ajax mode
- it's really hard to trace back where `instance` is coming from when passed to `      CRM_Contact_Form_Edit_Address::buildQuickForm($this, $instance);`

After
----------------------------------------
The portion that only relates to loading the form in ajax mode is moved there, the instance is consistently passed in rather than 'shimmied around'

Technical Details
----------------------------------------
I have long been confused by this code & a previous attempt went wrong -     https://github.com/civicrm/civicrm-core/pull/30196
   
I dug in again & have determined that what I missed last time was the preProcessLocation()    was setting the block from the url, specifically in ajax mode. This updates it    to determine the block from the url in the part of the form that    does a form build specifically in the context of the form being used    in ajax-load (that in itself is a bit of an anti-pattern, but it can live to fight another day

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
