### PR TITLE
[REF] Standardise is_bulk_mail select

### DIFF
--- a/CRM/Contact/Form/Edit/Email.php
+++ b/CRM/Contact/Form/Edit/Email.php
@@ -71,10 +71,14 @@ class CRM_Contact_Form_Edit_Email {
 
       //Bulkmail checkbox
       $form->assign('multipleBulk', $multipleBulk);
-      $js = ['id' => 'Email_' . $blockId . '_IsBulkmail', 'aria-label' => ts('Bulk Mailing for Email %1?', [1 => $blockId])];
-      if (!$blockEdit && !$multipleBulk) {
-        $js['onClick'] = 'singleSelect( this.id );';
-      }
+      $js = [
+        'id' => 'Email_' . $blockId . '_IsBulkmail',
+        'aria-label' => ts('Bulk Mailing for Email %1?', [1 => $blockId]),
+        'onChange' => "if (CRM.$(this).is(':checked')) {
+          CRM.$('.crm-email-bulkmail input').not(this).prop('checked', false);
+        }"
+      ];
+
       $form->addElement('advcheckbox', "email[$blockId][is_bulkmail]", NULL, '', $js);
 
       //is_Primary radio

--- a/CRM/Contact/Form/Edit/Email.php
+++ b/CRM/Contact/Form/Edit/Email.php
@@ -76,16 +76,20 @@ class CRM_Contact_Form_Edit_Email {
         'aria-label' => ts('Bulk Mailing for Email %1?', [1 => $blockId]),
         'onChange' => "if (CRM.$(this).is(':checked')) {
           CRM.$('.crm-email-bulkmail input').not(this).prop('checked', false);
-        }"
+        }",
       ];
 
       $form->addElement('advcheckbox', "email[$blockId][is_bulkmail]", NULL, '', $js);
 
       //is_Primary radio
-      $js = ['id' => 'Email_' . $blockId . '_IsPrimary', 'aria-label' => ts('Email %1 is primary?', [1 => $blockId])];
-      if (!$blockEdit) {
-        $js['onClick'] = 'singleSelect( this.id );';
-      }
+      $js = [
+        'id' => 'Email_' . $blockId . '_IsPrimary',
+        'aria-label' => ts('Email %1 is primary?', [1 => $blockId]),
+        'class' => 'crm-email-is_primary',
+        'onChange' => "if (CRM.$(this).is(':checked')) {
+          CRM.$('.crm-email-is_primary').not(this).prop('checked', false);
+        }",
+      ];
 
       $form->addElement('radio', "email[$blockId][is_primary]", '', '', '1', $js);
     }

--- a/templates/CRM/Contact/Form/Edit/Email.tpl
+++ b/templates/CRM/Contact/Form/Edit/Email.tpl
@@ -41,7 +41,7 @@
     {/if}
   </td>
   <td align="center">{$form.email.$blockId.on_hold.html}</td>
-  <td align="center" id="Email-Bulkmail-html">{$form.email.$blockId.is_bulkmail.html}</td>
+  <td align="center" id="Email-Bulkmail-html" {if !$multipleBulk}class="crm-email-bulkmail"{/if}>{$form.email.$blockId.is_bulkmail.html}</td>
   <td align="center" id="Email-Primary-html" {if $blockId eq 1}class="hiddenElement"{/if}>
     {$form.email.$blockId.is_primary.1.html}
   </td>

--- a/templates/CRM/Contact/Page/View/Summary.js
+++ b/templates/CRM/Contact/Page/View/Summary.js
@@ -243,12 +243,6 @@
           $('[class$=is_primary] input', $(this).closest('form')).not(this).prop('checked', false);
         }
       })
-      // make sure only one builk_mail radio is checked
-      .on('change', '.crm-email-bulkmail input', function(){
-        if ($(this).is(':checked')) {
-          $('.crm-email-bulkmail input').not(this).prop('checked', false);
-        }
-      })
       // handle delete link within blocks
       .on('click', '.crm-delete-inline', function(e) {
         var row = $(this).closest('tr');

--- a/templates/CRM/Contact/Page/View/Summary.js
+++ b/templates/CRM/Contact/Page/View/Summary.js
@@ -238,6 +238,8 @@
         return false;
       })
       // make sure only one is_primary radio is checked
+      // Note this is no longer required for the email block
+      // & similar changes to phone, address, im, openid would allow removal from them as well.
       .on('change', '[class$=is_primary] input', function() {
         if ($(this).is(':checked')) {
           $('[class$=is_primary] input', $(this).closest('form')).not(this).prop('checked', false);

--- a/templates/CRM/common/additionalBlocks.tpl
+++ b/templates/CRM/common/additionalBlocks.tpl
@@ -75,7 +75,7 @@ function buildAdditionalBlocks( blockName, className ) {
     }
 }
 
-//select single for is_primary.
+//select single for is_primary, although we are moving away from this - e.g on Email.
 function singleSelect( object ) {
     var element = object.split( '_', 3 );
 

--- a/templates/CRM/common/additionalBlocks.tpl
+++ b/templates/CRM/common/additionalBlocks.tpl
@@ -75,7 +75,7 @@ function buildAdditionalBlocks( blockName, className ) {
     }
 }
 
-//select single for is_bulk & is_primary
+//select single for is_primary.
 function singleSelect( object ) {
     var element = object.split( '_', 3 );
 


### PR DESCRIPTION
Overview
----------------------------------------
Standardise is_bulk_mail select

This fixes the js for is_bulk_mail select to be handled consistently on the 2 screens it is used on

The expected behaviour for the is_bulk_mail is that javascript should prevent the user from selecting more than one bulk email UNLESS this box is checked on Administer->CiviMail->ComponentSettings

![image](https://github.com/user-attachments/assets/fc5d2311-90eb-4222-aca5-67784ee56b6e)

Selecting one email on the inline edit should unselect any others
![image](https://github.com/user-attachments/assets/3303cf96-8339-43b7-b859-e0bfcb40fb0b)

Ditto on the main contact edit
![image](https://github.com/user-attachments/assets/202456f7-ae14-4d79-aee7-fa76771494f4)

If the box is unselected the behaviour should not occur

Follows on from 
https://github.com/civicrm/civicrm-core/pull/23082
https://github.com/civicrm/civicrm-core/pull/13019

Before
----------------------------------------
The above works - but the way in which it is done uses arcane magic. The shared email-form-building function between the 2 forms adds template-specific `js` to the one-click if the obtuse `$blockEdit` is passed in. It took some digging to understand why but essentially `$blockEdit` means 'this is this specific form' and that specific form already has js applied to it that handles the needed functionality based on applied classes. Otherwise the form must be 'the other one' which has a function included that can be called


After
----------------------------------------
The same class-based js is added in both cases and it is added via the 'on-click' as part of the field html. The class is added conditionally in the same way

Technical Details
----------------------------------------
This is part of some preliminary clean up towards supporting Custom fields on other location entities (currently only address is supported).

The function `CRM_Contact_Form_Edit_Email::buildQuickForm` has 4 callers

- Inline edit on contact summary as discussed / per screenshots above
- Full edit on contact summary as discussed / per screenshots above
- Event location edit - this only calls a very limited portion of the function & does not add the discussed field
- Deprecated `CRM_Contact_Form_Location` - this has one caller outside of core. Like Event location edit it only calls a very limited portion of the function & does not add the discussed field - I did log an issue with the extension to highlight the classes' planned removal https://github.com/agileware/au.com.agileware.eventmanagelocations/issues/2


Comments
----------------------------------------
@seamuslee001 you were involved with the earlier patches on this - I'm hoping you can take a look
