### PR TITLE
SearchKit - Add entity_permission setting for entity displays

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.component.js
@@ -11,9 +11,12 @@
       parent: '^crmSearchAdminDisplay'
     },
     templateUrl: '~/crmSearchAdmin/displays/searchAdminDisplayEntity.html',
-    controller: function($scope, crmApi4) {
+    controller: function($scope, crmApi4, crmUiHelp) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
+      $scope.hs = crmUiHelp({file: 'CRM/Search/Help/DisplayTypeEntity'});
+
+      this.permissions = CRM.crmSearchAdmin.permissions;
 
       this.$onInit = function () {
         ctrl.jobFrequency = CRM.crmSearchAdmin.jobFrequency;
@@ -39,6 +42,14 @@
           ctrl.display._job = defaultJobParams();
         }
         ctrl.parent.initColumns({label: true});
+      };
+
+      this.onChangeEntityPermission = function() {
+        if (ctrl.display.settings.entity_permission.length > 1) {
+          ctrl.display.settings.entity_permission_operator = ctrl.display.settings.entity_permission_operator || 'AND';
+        } else {
+          delete ctrl.display.settings.entity_permission_operator;
+        }
       };
 
       function defaultJobParams() {

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.html
@@ -8,7 +8,7 @@
 <div class="form-inline">
   <label for="crm-search-admin-display-api">{{:: ts('API Name') }} <span class="crm-marker">*</span></label>
   <div class="input-group">
-    <span class="input-group-addon" id="basic-addon1">SK_</span>
+    <span class="input-group-addon">SK_</span>
     <input id="crm-search-admin-display-api" type="text" class="form-control" ng-model="$ctrl.display.name" required />
   </div>
 </div>
@@ -26,6 +26,15 @@
   </div>
   <select class="form-control" ng-if="$ctrl.display._job.is_active" ng-model="$ctrl.display._job.run_frequency">
     <option ng-repeat="opt in $ctrl.jobFrequency" value="{{:: opt.id }}">{{:: opt.label }}</option>
+  </select>
+</div>
+<div class="form-inline">
+  <label for="display_entity_permission">{{:: ts('API Permission') }}</label>
+  <a crm-ui-help="hs({id: 'entity_permission', title: ts('API Permission')})"></a>
+  <input id="display_entity_permission" class="form-control" crm-ui-select="{data: $ctrl.permissions, multiple: true, placeholder: ts('administer CiviCRM')}" ng-model="$ctrl.display.settings.entity_permission" ng-list ng-change="$ctrl.onChangeEntityPermission()">
+  <select ng-if="$ctrl.display.settings.entity_permission.length > 1" title="{{:: ts('Permission operator') }}" ng-model="$ctrl.display.settings.entity_permission_operator">
+    <option value="AND">{{:: ts('And') }}</option>
+    <option value="OR">{{:: ts('Or') }}</option>
   </select>
 </div>
 <fieldset ng-include="'~/crmSearchAdmin/crmSearchAdminDisplaySort.html'"></fieldset>

--- a/ext/search_kit/templates/CRM/Search/Help/DisplayTypeEntity.hlp
+++ b/ext/search_kit/templates/CRM/Search/Help/DisplayTypeEntity.hlp
@@ -1,0 +1,4 @@
+{htxt id="entity_permission"}
+  <p>{ts}Set the permission level needed to view this entity.{/ts}</p>
+  <p>{ts}Users without this permission will not be able to see this entity in SearchKit.{/ts}</p>
+{/htxt}


### PR DESCRIPTION
Overview
----------------------------------------
![image](https://github.com/user-attachments/assets/42a4ed0b-d0c4-463d-92f0-eb213e63c385)


Before
----------------------------------------
All searchKit entities had 'administer CiviCRM' as their permission level (it wasn't declared, that's just the default).

After
----------------------------------------
The permissions are configurable.