### PR TITLE
AfformScanner - Allow altering search paths with internal event

### DIFF
--- a/ext/afform/core/CRM/Afform/AfformScanner.php
+++ b/ext/afform/core/CRM/Afform/AfformScanner.php
@@ -80,6 +80,9 @@ class CRM_Afform_AfformScanner {
       'module' => '',
     ];
 
+    $event = \Civi\Core\Event\GenericHookEvent::create(['paths' => &$basePaths]);
+    \Civi::dispatcher()->dispatch('civi.afform.searchPaths', $event);
+
     usort($basePaths, fn($a, $b) =>
       $a['weight'] === $b['weight']
         ? $a['module'] <=> $b['module']

--- a/ext/afform/core/CRM/Afform/AfformScanner.php
+++ b/ext/afform/core/CRM/Afform/AfformScanner.php
@@ -40,15 +40,16 @@ class CRM_Afform_AfformScanner {
    */
   public function findFilePaths(): array {
     if ($this->isUseCachedPaths()) {
-      $paths = $this->cache->get('afformAllPaths');
-      if ($paths !== NULL) {
-        return $paths;
+      $formPaths = $this->cache->get('afformAllPaths');
+      if ($formPaths !== NULL) {
+        return $formPaths;
       }
     }
 
+    // List of folders to search
     $basePaths = [];
-
-    $paths = [];
+    // List of specific forms that we found
+    $formPaths = [];
 
     $mapper = CRM_Extension_System::singleton()->getMapper();
     foreach ($mapper->getModules() as $module) {
@@ -84,14 +85,14 @@ class CRM_Afform_AfformScanner {
         ? $a['module'] <=> $b['module']
         : $a['weight'] <=> $b['weight']
     );
-    foreach ($basePaths as $folderPath) {
-      $this->appendFilePaths($paths, $folderPath['path'], $folderPath['module']);
+    foreach ($basePaths as $basePath) {
+      $this->appendFilePaths($formPaths, $basePath['path'], $basePath['module']);
     }
 
     if ($this->isUseCachedPaths()) {
-      $this->cache->set('afformAllPaths', $paths);
+      $this->cache->set('afformAllPaths', $formPaths);
     }
-    return $paths;
+    return $formPaths;
   }
 
   /**

--- a/ext/afform/core/CRM/Afform/AfformScanner.php
+++ b/ext/afform/core/CRM/Afform/AfformScanner.php
@@ -85,8 +85,8 @@ class CRM_Afform_AfformScanner {
 
     usort($basePaths, fn($a, $b) =>
       $a['weight'] === $b['weight']
-        ? $a['module'] <=> $b['module']
-        : $a['weight'] <=> $b['weight']
+        ? $b['module'] <=> $a['module']
+        : $b['weight'] <=> $a['weight']
     );
     foreach ($basePaths as $basePath) {
       $this->appendFilePaths($formPaths, $basePath['path'], $basePath['module']);

--- a/ext/afform/core/CRM/Afform/AfformScanner.php
+++ b/ext/afform/core/CRM/Afform/AfformScanner.php
@@ -261,8 +261,6 @@ class CRM_Afform_AfformScanner {
       $fileBase = preg_replace(self::FILE_REGEXP, '', $file);
       $name = basename($fileBase);
       $formPaths[$name][$module] = $fileBase;
-      // Local files get top priority
-      ksort($formPaths[$name]);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

This should make it possible to add/remove/prioritize Afform folders.

Quick demo for @eileenmcnaughton 

Example
----------------------------------------

```php
Civi::dispatcher()->addListener('&civi.afform.searchPaths', function(&$paths){
  $paths[] = [
    'weight' => 50,
    'path' => __DIR__ . '/new-ang',
    'module' => E::LONG_NAME,
  ];
});
```

Comments
----------------------------------------

I've only lightly tested. Process:

* Take an extension with some `ang/*.aff.html` files
* Move all of them to another folder (eg `new-ang`)
* Implement the event listener (as in the example)
* Run `cv ang:html:list`. Inspect the results.

Haven't done any UI-level testing.