### PR TITLE
Settings form tidy-ups (apiv3-v4,  `CRM_Utils_Array::value()`, save integers as integers)

### DIFF
--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -197,15 +197,15 @@ trait CRM_Admin_Form_SettingTrait {
             $props['html_type'],
             $setting,
             $props['title'],
-            ($options !== NULL) ? $options : CRM_Utils_Array::value('html_attributes', $props, []),
-            ($options !== NULL) ? CRM_Utils_Array::value('html_attributes', $props, []) : NULL
+            ($options !== NULL) ? $options : $props['html_attributes'] ?? [],
+            ($options !== NULL) ? $props['html_attributes'] ?? [] : NULL
           );
         }
         elseif ($add === 'addSelect') {
-          $this->addElement('select', $setting, $props['title'], $options, CRM_Utils_Array::value('html_attributes', $props));
+          $this->addElement('select', $setting, $props['title'], $options, $props['html_attributes'] ?? NULL);
         }
         elseif ($add === 'addCheckBox') {
-          $this->addCheckBox($setting, '', $options, NULL, CRM_Utils_Array::value('html_attributes', $props), NULL, NULL, ['&nbsp;&nbsp;']);
+          $this->addCheckBox($setting, '', $options, NULL, $props['html_attributes'] ?? NULL, NULL, NULL, ['&nbsp;&nbsp;']);
         }
         elseif ($add === 'addCheckBoxes') {
           $newOptions = array_flip($options);
@@ -232,7 +232,7 @@ trait CRM_Admin_Form_SettingTrait {
           $this->$add($setting, $props['title'], $props['entity_reference_options']);
         }
         elseif ($add === 'addYesNo' && ($props['type'] === 'Boolean')) {
-          $this->addRadio($setting, $props['title'], [1 => ts('Yes'), 0 => ts('No')], CRM_Utils_Array::value('html_attributes', $props), '&nbsp;&nbsp;');
+          $this->addRadio($setting, $props['title'], [1 => ts('Yes'), 0 => ts('No')], $props['html_attributes'] ?? NULL, '&nbsp;&nbsp;');
         }
         elseif ($add === 'add') {
           $this->add($props['html_type'], $setting, $props['title'], $options, FALSE, $props['html_extra'] ?? NULL);

--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -356,6 +356,15 @@ trait CRM_Admin_Form_SettingTrait {
         // This will be an array with one value.
         $settings[$setting] = (bool) reset($settings[$setting]);
       }
+      elseif ($settingMetaData['type'] === 'Integer') {
+        // QuickForm is pretty slack when it comes to types, cast to an integer.
+        if (is_numeric($settingValue)) {
+          $settings[$setting] = (int) $settingValue;
+        }
+        if (!$settingValue && empty($settingMetaData['is_required'])) {
+          $settings[$setting] = NULL;
+        }
+      }
     }
     Setting::set(FALSE)->setValues($settings)->execute();
   }

--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -14,6 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
+use Civi\Api4\Setting;
 
 /**
  * This trait allows us to consolidate Preferences & Settings forms.
@@ -356,7 +357,7 @@ trait CRM_Admin_Form_SettingTrait {
         $settings[$setting] = (bool) reset($settings[$setting]);
       }
     }
-    civicrm_api3('setting', 'create', $settings);
+    Setting::set(FALSE)->setValues($settings)->execute();
   }
 
   /**


### PR DESCRIPTION
This turned out to be unrelated to what I was looking at & to make no difference - but we should update this. 

This only behaviour change is that where a setting is defined as an Integer and is submitted as a number it is saved as an integer (or as NULL if empty) - because Quickform converts the integer options to strings this undoes that

Best merged straight after forking
