### PR TITLE
use `getAddressColumns` instead of `addAddressFields` in `ContributionDetail` report

### DIFF
--- a/CRM/Report/Form/Member/ContributionDetail.php
+++ b/CRM/Report/Form/Member/ContributionDetail.php
@@ -368,7 +368,7 @@ class CRM_Report_Form_Member_ContributionDetail extends CRM_Report_Form {
           ],
         ],
       ],
-    ] + $this->addAddressFields(FALSE);
+    ] + $this->getAddressColumns(['group_bys' => FALSE]);
 
     $this->_groupFilter = TRUE;
     $this->_tagFilter = TRUE;


### PR DESCRIPTION
`ContributionDetail` report was still using the deprecated function `addAddressFields`. 

So I replaced it with  `getAddressColumns`. 

I copied the `$options` parameter (`['group_bys' => FALSE]`)  from `Contact_Summary` report: I'm not sure if it is correct.

I realised this because I could not use `alterStateProvinceID` and `alterCountryID` functions.