### PR TITLE
Upgrade crash on mailing backfill

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSeventySix.php
+++ b/CRM/Upgrade/Incremental/php/FiveSeventySix.php
@@ -249,8 +249,8 @@ INNER JOIN
 as job
 ON job.mailing_id = m.id
 SET m.status = "Complete",
-    start_date = job.start_date,
-    end_date = job.end_date,
+    m.start_date = job.start_date,
+    m.end_date = job.end_date,
     is_completed = 1
 WHERE (m.status IS NULL OR m.status = "Draft")
    AND m.id BETWEEN %1 AND %2', [1 => [$startId, 'Integer'], 2 => [$endId, 'Integer']]);


### PR DESCRIPTION
Overview
----------------------------------------
Upgrade crash on mailing backfill.

Before
----------------------------------------
See https://civicrm.stackexchange.com/questions/48438/backfill-civicrm-mailing-unknown-error-when-upgrading-to-5-76-0/48439?noredirect=1#comment58384_48439
and
https://chat.civicrm.org/civicrm/pl/4c4cuwmrb3d7ig44guirabn4be

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------
I didn't run into this on earlier dev upgrades, but I doubt I had mailing jobs that matched on a dev site.