### PR TITLE
Use html5purify library

### DIFF
--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -635,18 +635,11 @@ class CRM_Utils_String {
   public static function purifyHTML($string) {
     static $_filter = NULL;
     if (!$_filter) {
-      $config = HTMLPurifier_Config::createDefault();
+      $config = HTMLPurifier_HTML5Config::createDefault();
       $config->set('Core.Encoding', 'UTF-8');
       $config->set('Attr.AllowedFrameTargets', ['_blank', '_self', '_parent', '_top']);
       // Disable the cache entirely
       $config->set('Cache.DefinitionImpl', NULL);
-      $config->set('HTML.DefinitionID', 'enduser-customize.html tutorial');
-      $config->set('HTML.DefinitionRev', 1);
-      $def = $config->maybeGetRawHTMLDefinition();
-      if (!empty($def)) {
-        $def->addElement('figcaption', 'Block', 'Flow', 'Common');
-        $def->addElement('figure', 'Block', 'Optional: (figcaption, Flow) | (Flow, figcaption) | Flow', 'Common');
-      }
       $_filter = new HTMLPurifier($config);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,8 @@
     "behat/mink": "^1.10",
     "dmore/chrome-mink-driver": "^2.9",
     "pontedilana/php-weasyprint": "^0.13.0 || ^1",
-    "knplabs/knp-snappy": "^1.4"
+    "knplabs/knp-snappy": "^1.4",
+    "xemlock/htmlpurifier-html5": "^0.1.11"
   },
   "scripts": {
     "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a8980b3d6c076d374e5eb265c6560c02",
+    "content-hash": "1f911a9b456d442b7e814df8c29ad6b9",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -5703,6 +5703,61 @@
                 "source": "https://github.com/TYPO3/phar-stream-wrapper/tree/master"
             },
             "time": "2019-12-10T11:53:27+00:00"
+        },
+        {
+            "name": "xemlock/htmlpurifier-html5",
+            "version": "v0.1.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/xemlock/htmlpurifier-html5.git",
+                "reference": "f0d563f9fd4a82a3d759043483f9a94c0d8c2255"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/xemlock/htmlpurifier-html5/zipball/f0d563f9fd4a82a3d759043483f9a94c0d8c2255",
+                "reference": "f0d563f9fd4a82a3d759043483f9a94c0d8c2255",
+                "shasum": ""
+            },
+            "require": {
+                "ezyang/htmlpurifier": "^4.8",
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^1.1|^2.1",
+                "phpunit/phpunit": ">=4.7 <8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "library/HTMLPurifier/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "xemlock",
+                    "email": "xemlock@gmail.com"
+                }
+            ],
+            "description": "HTML5 element definitions for HTML Purifier",
+            "keywords": [
+                "HTML5",
+                "Purifier",
+                "html",
+                "htmlpurifier",
+                "security",
+                "tidy",
+                "validator",
+                "xss"
+            ],
+            "support": {
+                "issues": "https://github.com/xemlock/htmlpurifier-html5/issues",
+                "source": "https://github.com/xemlock/htmlpurifier-html5/tree/master"
+            },
+            "time": "2019-08-07T17:19:21+00:00"
         },
         {
             "name": "xkerman/restricted-unserialize",

--- a/tests/phpunit/CRM/Activity/Form/ActivityViewTest.php
+++ b/tests/phpunit/CRM/Activity/Form/ActivityViewTest.php
@@ -195,7 +195,7 @@ and has two consecutive lines.
 And one blank line.
 ENDDETAILS
         ],
-        '<span class="crm-frozen-field">This is text only<br />and has two consecutive lines.<br /><br />And one blank line.</span>',
+        '<span class="crm-frozen-field">This is text only<br>and has two consecutive lines.<br><br>And one blank line.</span>',
       ],
 
       'bulkemail-text' => [
@@ -210,7 +210,7 @@ And one blank line.
 ENDDETAILS
         ],
         // Note this is the summary of the actual bulk mailing text. The above details are a bit irrelevant for what we're testing here.
-        '<td class="label nowrap">Text Message</td><td>This<br />address<br /><br />is not ours:...<br />',
+        '<td class="label nowrap">Text Message</td><td>This<br>address<br><br>is not ours:...<br>',
       ],
 
       'email-text' => [
@@ -224,7 +224,7 @@ and has two consecutive lines.
 And one blank line.
 ENDDETAILS
         ],
-        '<td class="view-value report">                   This is text only<br />and has two consecutive lines.<br /><br />And one blank line.',
+        '<td class="view-value report">                   This is text only<br>and has two consecutive lines.<br><br>And one blank line.',
       ],
 
       'inbound-text' => [
@@ -238,7 +238,7 @@ and has two consecutive lines.
 And one blank line.
 ENDDETAILS
         ],
-        '<span class="crm-frozen-field">This is text only<br />and has two consecutive lines.<br /><br />And one blank line.</span>',
+        '<span class="crm-frozen-field">This is text only<br>and has two consecutive lines.<br><br>And one blank line.</span>',
       ],
 
       // Now html only
@@ -270,7 +270,7 @@ ENDDETAILS
 ENDDETAILS
         ],
         // Note this is the summary of the actual bulk mailing text. The above details are a bit irrelevant for what we're testing here.
-        '<td class="label nowrap">Text Message</td><td>This<br />address<br /><br />is not ours:...<br />',
+        '<td class="label nowrap">Text Message</td><td>This<br>address<br><br>is not ours:...<br>',
       ],
 
       'email-html' => [
@@ -316,14 +316,14 @@ and has two consecutive lines.
 
 And one blank line.
 -ALTERNATIVE ITEM 1-
-<p>This is mixed<br />
+<p>This is mixed<br>
 and has two consecutive lines.</p>
 
 <p>And one blank line.</p>
 -ALTERNATIVE END-
 ENDDETAILS
         ],
-        'This is mixed<br />and has two consecutive lines.<br /><br />And one blank line.',
+        'This is mixed<br>and has two consecutive lines.<br><br>And one blank line.',
       ],
 
       'bulkemail-mixed-text' => [
@@ -337,7 +337,7 @@ and has two consecutive lines.
 
 And one blank line.
 -ALTERNATIVE ITEM 1-
-<p>This is mixed<br />
+<p>This is mixed<br>
 and has two consecutive lines.</p>
 
 <p>And one blank line.</p>
@@ -345,7 +345,7 @@ and has two consecutive lines.</p>
 ENDDETAILS
         ],
         // Note this is the summary of the actual bulk mailing text. The above details are a bit irrelevant for what we're testing here.
-        '<td class="label nowrap">Text Message</td><td>This<br />address<br /><br />is not ours:...<br />',
+        '<td class="label nowrap">Text Message</td><td>This<br>address<br><br>is not ours:...<br>',
       ],
 
       'email-mixed-text' => [
@@ -359,14 +359,14 @@ and has two consecutive lines.
 
 And one blank line.
 -ALTERNATIVE ITEM 1-
-<p>This is mixed<br />
+<p>This is mixed<br>
 and has two consecutive lines.</p>
 
 <p>And one blank line.</p>
 -ALTERNATIVE END-
 ENDDETAILS
         ],
-        '<td class="view-value report">                   <br />This is mixed<br />and has two consecutive lines.<br /><br />And one blank line.<br />',
+        '<td class="view-value report">                   <br>This is mixed<br>and has two consecutive lines.<br><br>And one blank line.<br>',
       ],
 
       'inbound-mixed-text' => [
@@ -380,14 +380,14 @@ and has two consecutive lines.
 
 And one blank line.
 -ALTERNATIVE ITEM 1-
-<p>This is mixed<br />
+<p>This is mixed<br>
 and has two consecutive lines.</p>
 
 <p>And one blank line.</p>
 -ALTERNATIVE END-
 ENDDETAILS
         ],
-        '<td class="view-value">       <br />This is mixed<br />and has two consecutive lines.<br /><br />And one blank line.<br />',
+        '<td class="view-value">       <br>This is mixed<br>and has two consecutive lines.<br><br>And one blank line.<br>',
       ],
 
       // Now mixed with html first
@@ -397,7 +397,7 @@ ENDDETAILS
           'url' => 'civicrm/activity?atype=%%atype%%&action=view&reset=1&id=%%id%%&cid=%%cid%%&context=activity',
           'details' => <<<'ENDDETAILS'
 -ALTERNATIVE ITEM 0-
-<p>This is mixed<br />
+<p>This is mixed<br>
 and has two consecutive lines.</p>
 
 <p>And one blank line.</p>
@@ -409,7 +409,7 @@ And one blank line.
 -ALTERNATIVE END-
 ENDDETAILS
         ],
-        '<td class="view-value">       <p>This is mixed<br />and has two consecutive lines.</p><p>And one blank line.</p>',
+        '<td class="view-value">       <p>This is mixed<br>and has two consecutive lines.</p><p>And one blank line.</p>',
       ],
 
       'bulkemail-mixed-html' => [
@@ -418,7 +418,7 @@ ENDDETAILS
           'url' => 'civicrm/activity/view?atype=%%atype%%&action=view&reset=1&id=%%id%%&cid=%%cid%%&context=activity',
           'details' => <<<'ENDDETAILS'
 -ALTERNATIVE ITEM 0-
-<p>This is mixed<br />
+<p>This is mixed<br>
 and has two consecutive lines.</p>
 
 <p>And one blank line.</p>
@@ -431,7 +431,7 @@ And one blank line.
 ENDDETAILS
         ],
         // Note this is the summary of the actual bulk mailing text. The above details are a bit irrelevant for what we're testing here.
-        '<td class="label nowrap">Text Message</td><td>This<br />address<br /><br />is not ours:...<br />',
+        '<td class="label nowrap">Text Message</td><td>This<br>address<br><br>is not ours:...<br>',
       ],
 
       'email-mixed-html' => [
@@ -440,7 +440,7 @@ ENDDETAILS
           'url' => 'civicrm/activity/view?atype=%%atype%%&action=view&reset=1&id=%%id%%&cid=%%cid%%&context=activity',
           'details' => <<<'ENDDETAILS'
 -ALTERNATIVE ITEM 0-
-<p>This is mixed<br />
+<p>This is mixed<br>
 and has two consecutive lines.</p>
 
 <p>And one blank line.</p>
@@ -452,7 +452,7 @@ And one blank line.
 -ALTERNATIVE END-
 ENDDETAILS
         ],
-        '<p>This is mixed<br />and has two consecutive lines.</p><p>And one blank line.</p>',
+        '<p>This is mixed<br>and has two consecutive lines.</p><p>And one blank line.</p>',
       ],
 
       'inbound-mixed-html' => [
@@ -461,7 +461,7 @@ ENDDETAILS
           'url' => 'civicrm/contact/view/activity?atype=%%atype%%&action=view&reset=1&id=%%id%%&cid=%%cid%%&context=activity',
           'details' => <<<'ENDDETAILS'
 -ALTERNATIVE ITEM 0-
-<p>This is mixed<br />
+<p>This is mixed<br>
 and has two consecutive lines.</p>
 
 <p>And one blank line.</p>
@@ -473,7 +473,7 @@ And one blank line.
 -ALTERNATIVE END-
 ENDDETAILS
         ],
-        '<p>This is mixed<br />and has two consecutive lines.</p><p>And one blank line.</p>',
+        '<p>This is mixed<br>and has two consecutive lines.</p><p>And one blank line.</p>',
       ],
     ];
 
@@ -501,10 +501,10 @@ ENDDETAILS
       $newData['case-' . $key][0]['url'] = 'civicrm/case/activity/view?reset=1&aid=%%id%%&cid=%%cid%%&caseid=%%caseid%%';
     }
     $newData['case-meeting-text'][0]['skip'] = FALSE;
-    $newData['case-meeting-text'][1] = 'This is text only<br />and has two consecutive lines.<br /><br />And one blank line.';
-    $newData['case-bulkemail-text'][1] = 'This is text only<br />and has two consecutive lines.<br /><br />And one blank line.';
-    $newData['case-email-text'][1] = 'This is text only<br />and has two consecutive lines.<br /><br />And one blank line.';
-    $newData['case-inbound-text'][1] = 'This is text only<br />and has two consecutive lines.<br /><br />And one blank line.';
+    $newData['case-meeting-text'][1] = 'This is text only<br>and has two consecutive lines.<br><br>And one blank line.';
+    $newData['case-bulkemail-text'][1] = 'This is text only<br>and has two consecutive lines.<br><br>And one blank line.';
+    $newData['case-email-text'][1] = 'This is text only<br>and has two consecutive lines.<br><br>And one blank line.';
+    $newData['case-inbound-text'][1] = 'This is text only<br>and has two consecutive lines.<br><br>And one blank line.';
 
     $newData['case-meeting-html'][1] = "<p>This is html only</p><p>And it usually looks like this.</p><p>With p's and newlines between the p's.</p>";
     $newData['case-bulkemail-html'][1] = "<p>This is html only</p><p>And it usually looks like this.</p><p>With p's and newlines between the p's.</p>";
@@ -512,15 +512,15 @@ ENDDETAILS
     $newData['case-inbound-html'][1] = "<p>This is html only</p><p>And it usually looks like this.</p><p>With p's and newlines between the p's.</p>";
 
     $newData['case-meeting-mixed-text'][0]['skip'] = FALSE;
-    $newData['case-meeting-mixed-text'][1] = 'This is mixed<br />and has two consecutive lines.<br /><br />And one blank line.';
-    $newData['case-bulkemail-mixed-text'][1] = 'This is mixed<br />and has two consecutive lines.<br /><br />And one blank line.';
-    $newData['case-email-mixed-text'][1] = 'This is mixed<br />and has two consecutive lines.<br /><br />And one blank line.';
-    $newData['case-inbound-mixed-text'][1] = 'This is mixed<br />and has two consecutive lines.<br /><br />And one blank line.';
+    $newData['case-meeting-mixed-text'][1] = 'This is mixed<br>and has two consecutive lines.<br><br>And one blank line.';
+    $newData['case-bulkemail-mixed-text'][1] = 'This is mixed<br>and has two consecutive lines.<br><br>And one blank line.';
+    $newData['case-email-mixed-text'][1] = 'This is mixed<br>and has two consecutive lines.<br><br>And one blank line.';
+    $newData['case-inbound-mixed-text'][1] = 'This is mixed<br>and has two consecutive lines.<br><br>And one blank line.';
 
-    $newData['case-meeting-mixed-html'][1] = '<p>This is mixed<br />and has two consecutive lines.</p><p>And one blank line.</p>';
-    $newData['case-bulkemail-mixed-html'][1] = '<p>This is mixed<br />and has two consecutive lines.</p><p>And one blank line.</p>';
-    $newData['case-email-mixed-html'][1] = '<p>This is mixed<br />and has two consecutive lines.</p><p>And one blank line.</p>';
-    $newData['case-inbound-mixed-html'][1] = '<p>This is mixed<br />and has two consecutive lines.</p><p>And one blank line.</p>';
+    $newData['case-meeting-mixed-html'][1] = '<p>This is mixed<br>and has two consecutive lines.</p><p>And one blank line.</p>';
+    $newData['case-bulkemail-mixed-html'][1] = '<p>This is mixed<br>and has two consecutive lines.</p><p>And one blank line.</p>';
+    $newData['case-email-mixed-html'][1] = '<p>This is mixed<br>and has two consecutive lines.</p><p>And one blank line.</p>';
+    $newData['case-inbound-mixed-html'][1] = '<p>This is mixed<br>and has two consecutive lines.</p><p>And one blank line.</p>';
 
     return $newData;
   }

--- a/tests/phpunit/CRM/Contact/Form/Task/EmailTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/EmailTest.php
@@ -117,7 +117,7 @@ class CRM_Contact_Form_Task_EmailTest extends CiviUnitTestCase {
     $form->isSearchContext = FALSE;
     $form->buildForm();
     $this->assertEquals([
-      'html_message' => '<br /><br />--<p>This is a test Signature</p>',
+      'html_message' => '<br><br>--<p>This is a test Signature</p>',
       'text_message' => '
 
 --

--- a/tests/phpunit/CRM/Contribute/Form/Task/EmailTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/EmailTest.php
@@ -67,7 +67,7 @@ class CRM_Contribute_Form_Task_EmailTest extends CiviUnitTestCase {
     ]);
     $form->set('cid', $contact1 . ',' . $contact2);
     $form->buildForm();
-    $this->assertEquals('<br /><br />--Benny, Benny', $form->_defaultValues['html_message']);
+    $this->assertEquals('<br><br>--Benny, Benny', $form->_defaultValues['html_message']);
     $form->postProcess();
     $mut->assertSubjects(['Mr. Anthony Anderson II $999.00', 'Mr. Elton Anderson II $100.00']);
     $mut->checkAllMailLog([


### PR DESCRIPTION
Overview
----------------------------------------
The standard HTML purify library does not support HTML5 tags. Since HTML5 was released in 2008 and recommended in 2014 we should probably think about supporting it in CiviCRM.

This PR adds the following library: https://github.com/xemlock/htmlpurifier-html5
which adds support for HTML5 tags including `<audio>` and `<figcaption>/<figure>` (as added here: https://github.com/civicrm/civicrm-core/pull/30584)

Before
----------------------------------------
HTML5 tags stripped from display.

After
----------------------------------------
HTML5 tags allowed.

Technical Details
----------------------------------------


Comments
----------------------------------------
I was trying to get a custom field containing a link to an audio file (mp3) to display via a searchkit display. Unfortunately angular still seems to be stripping the audio tag out just before it is displayed but it does reach the browser with this PR. See https://chat.civicrm.org/civicrm/pl/a8sainff5jn33eduzfgksaap3c for unresolved discussion about that.