### PR TITLE
prevent grant dashboard URLs leading to data loss

### DIFF
--- a/ext/civigrant/CRM/Grant/BAO/Query.php
+++ b/ext/civigrant/CRM/Grant/BAO/Query.php
@@ -304,6 +304,7 @@ class CRM_Grant_BAO_Query extends CRM_Contact_BAO_Query_Interface {
       'grant_decision_date',
       'grant_money_transfer_date',
       'grant_due_date',
+      'grant_status_id',
     ];
     $metadata = civicrm_api3('Grant', 'getfields', [])['values'];
     return array_intersect_key($metadata, array_flip($fields));

--- a/ext/civigrant/CRM/Grant/Form/Search.php
+++ b/ext/civigrant/CRM/Grant/Form/Search.php
@@ -221,12 +221,6 @@ class CRM_Grant_Form_Search extends CRM_Core_Form_Search {
       return;
     }
 
-    $status = CRM_Utils_Request::retrieve('status', 'String');
-    if ($status) {
-      $this->_formValues['grant_status_id'] = $status;
-      $this->_defaults['grant_status_id'] = $status;
-    }
-
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
 
     if ($cid) {

--- a/ext/civigrant/templates/CRM/Grant/Page/DashBoard.tpl
+++ b/ext/civigrant/templates/CRM/Grant/Page/DashBoard.tpl
@@ -30,8 +30,8 @@ You have {$grantSummary.total_grants} grant(s) registered in your database.
 
 {foreach from=$grantSummary.per_status item=status key=id}
 <tr>
-    <td><a href="{crmURL p="civicrm/grant/search" q="reset=1&status=`$id`&force=1"}">{$status.label}</a></td>
-    <td><a href="{crmURL p="civicrm/grant/search" q="reset=1&status=`$id`&force=1"}">{$status.total}</a></td>
+    <td><a href="{crmURL p="civicrm/grant/search" q="reset=1&grant_status_id=`$id`&force=1"}">{$status.label}</a></td>
+    <td><a href="{crmURL p="civicrm/grant/search" q="reset=1&grant_status_id=`$id`&force=1"}">{$status.total}</a></td>
 </tr>
 {/foreach}
 <tr class="columnfooter">


### PR DESCRIPTION
Overview
----------------------------------------
The grant dashboard has a bug that leads to the "Action" selected from its searches applying to all grants.

To replicate:
* Enable CiviGrant.
* Create at least two grants. Ensure they have different status IDs.
* Click on a link in the grant summary (see screenshot) to select one of the statuses.
* Select all records and then select **Delete Grants** as your action.
![Selection_2346](https://github.com/user-attachments/assets/f038c03c-65b5-4c62-b64d-6a19ce8d9293)

Before
----------------------------------------
Only grants with that status are deleted.

After
----------------------------------------
All your grants are deleted.

Technical Details
----------------------------------------
There was some code specifically for handling status from the dashboard.  I moved to using standard URL filtering via getting the entity metadata.

Comments
----------------------------------------
I considered not ripping out the old code on the grounds that someone somewhere had a link in a Google doc or something that used the `status` argument.  I decided that was pretty unlikely but could be convinced to put it back in.
