### PR TITLE
Backdrop - Fix MockPublicFormTest.  Ensure session is committed during redirect.

### DIFF
--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -917,6 +917,21 @@ AND    u.status = 1
   }
 
   /**
+   * Commit the session before exiting.
+   * Similar to drupal_exit().
+   */
+  public function onCiviExit() {
+    if (function_exists('module_invoke_all')) {
+      if (!defined('MAINTENANCE_MODE') || MAINTENANCE_MODE != 'update') {
+        module_invoke_all('exit');
+      }
+      if (!defined('_CIVICRM_FAKE_SESSION')) {
+        backdrop_session_commit();
+      }
+    }
+  }
+
+  /**
    * @inheritDoc
    */
   public function clearResourceCache() {


### PR DESCRIPTION
Overview
--------

This fixes a failing test. The failure does indicate a buggy behavior.

The fix fills-in a missing method `CRM_Utils_System_Backdrop::onCiviExit()`. The method is nearly identical to the one in `CRM_Utils_System_Drupal`.

Use-Case
--------

The test case `MockPublicFormTest` shows the problem. It currently [fails on Backdrop](https://test.civicrm.org/job/CiviCRM-Test-QLow/53750/). You can run locally as:

```bash
cd ext/afform/mock
phpunit9 --stderr tests/phpunit/E2E/AfformMock/MockPublicFormTest.php
```

In this test, we generate an email with an authenticated link to a form, eg

```
https://example.com/civicrm/my-form?_authx=...&_authxSes=1
```

When one clicks the link, it authenticates the token and stores the contact ID in the session.

Finally, it issues a redirect to reload `civicrm/my-form` with a clean URL.

Before
------

Within PHP, it stores the contact ID in `CRM_Core_Session`... but that data is NOT written persistently. The user is not meaningfully authenticated.

After
-----

It stores the data in `CRM_Core_Session`... and actually writes it persistently.
