### PR TITLE
Fix reversed membership status change in activity following #30493

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2070,23 +2070,23 @@ WHERE {$whereClause}";
         'membership_id' => $dao2->membership_id,
         'ignore_admin_only' => TRUE,
       ]);
-      $statusId = $newStatus['id'] ?? NULL;
+      $newStatusId = $newStatus['id'] ?? NULL;
 
       // process only when status change.
-      if ($statusId &&
-        $statusId != $dao2->status_id
+      if ($newStatusId &&
+        $newStatusId != $dao2->status_id
       ) {
         // Update the status on the membership.
         self::writeRecord([
           'id' => $dao2->membership_id,
-          'status_id' => $statusId,
+          'status_id' => $newStatusId,
         ]);
 
         self::createRelatedMemberships(['action' => CRM_Core_Action::UPDATE], $dao2);
         // Now create the "Change Membership Status" activity
         $allStatusLabels = CRM_Member_BAO_Membership::buildOptions('status_id', 'get');
         $changedByContactID = CRM_Core_Session::getLoggedInContactID() ?? $dao2->contact_id;
-        self::createChangeMembershipStatusActivity($dao2, $allStatusLabels[$statusId], $allStatusLabels[$dao2->status_id], $changedByContactID);
+        self::createChangeMembershipStatusActivity($dao2, $allStatusLabels[$dao2->status_id], $allStatusLabels[$newStatusId], $changedByContactID);
         $updateCount++;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Membership status change activities were being created with the status back to front when created via CRON job. Eg. "Status changed from Grace to Current" instead of "Status changed from Current to Grace".

Before
----------------------------------------
Activity subject wrong when job.process_membership run.

After
----------------------------------------
Activity subject correct when job.process_membership run.

Technical Details
----------------------------------------
Renamed a variable so it's clearer next time...

Comments
----------------------------------------
This is a regression in 5.76 so we should backport there as well.