### PR TITLE
(dev/core#5386) Fix translation for relationship types on Membership …

### DIFF
--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -260,7 +260,7 @@ END AS 'relType'
         // comment is a qualifier for the relationship - now just job_title
         $select = "
 SELECT r.id, c.id as cid, c.display_name as name, c.job_title as comment,
-       rt.name_x_y as relation, r.start_date, r.end_date,
+       rt.label_x_y as relation, r.start_date, r.end_date,
        m.id as mid, ms.is_current_member, ms.label as status
   FROM civicrm_relationship r
   LEFT JOIN civicrm_relationship_type rt ON rt.id = r.relationship_type_id


### PR DESCRIPTION
…View page

Overview
----------------------------------------
Fix translation for relationship types on Membership View page. This is a display issue.

Before
----------------------------------------
Relationship types on membership view page are displayed in English.

After
----------------------------------------
Relationship types on membership view page are translated and show proper labels as do they elsewhere in CiviCRM.