### PR TITLE
Fix crash on membership view for related memberships

### DIFF
--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -180,7 +180,7 @@ class CRM_Member_Form_MembershipView extends CRM_Core_Form {
       // should be moved to the php layer - with financialacls using hooks.
       $this->assign('noACL', !CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus());
 
-      $membershipType = \Civi\Api4\Membership::get(FALSE)
+      $membershipType = \Civi\Api4\MembershipType::get(FALSE)
         ->addSelect('relationship_direction', 'relationship_type_id')
         ->addWhere('id', '=', $values['membership_type_id'])
         ->execute()
@@ -226,7 +226,7 @@ SELECT relationship_type_id,
   WHEN  contact_id_b = {$values['owner_contact_id']} AND contact_id_a = {$values['contact_id']} THEN 'a_b'
 END AS 'relType'
   FROM civicrm_relationship
- WHERE relationship_type_id IN ({$membershipType['relationship_type_id']})";
+ WHERE relationship_type_id IN (" . implode(',', $membershipType['relationship_type_id']) . ")";
         $dao = CRM_Core_DAO::executeQuery($sql);
         $values['relationship'] = NULL;
         while ($dao->fetch()) {
@@ -280,7 +280,7 @@ SELECT r.id, c.id as cid, c.display_name as name, c.job_title as comment,
         $query .= " ORDER BY is_current_member DESC";
         $dao = CRM_Core_DAO::executeQuery($query);
         $related = [];
-        $relatedRemaining = CRM_Utils_Array::value('max_related', $values, PHP_INT_MAX);
+        $relatedRemaining = $values['max_related'] ?? PHP_INT_MAX;
         $rowElememts = [
           'id',
           'cid',


### PR DESCRIPTION
Overview
----------------------------------------
Came up while reviewing https://github.com/civicrm/civicrm-core/pull/30838
Should backport to 5.76

Before
----------------------------------------
1. Set up a membership type with related memberships.
2. Add a membership so that it creates a related one.
3. View the membership.
4. Crash

After
----------------------------------------


Technical Details
----------------------------------------
From https://github.com/civicrm/civicrm-core/commit/b2637afc916afff1c40c54fa7691b62c4d874d24

Comments
----------------------------------------

