### PR TITLE
dev/core#2357 Improve clarity on Dedupe rule names

### DIFF
--- a/sql/civicrm_data/civicrm_dedupe_rule/HouseholdSupervised.sqldata.php
+++ b/sql/civicrm_data/civicrm_dedupe_rule/HouseholdSupervised.sqldata.php
@@ -4,7 +4,7 @@ return CRM_Core_CodeGen_DedupeRule::create('HouseholdSupervised')
     'contact_type' => 'Household',
     'threshold' => 10,
     'used' => 'Supervised',
-    'title' => ts('Name or Email'),
+    'title' => ts('Household Name or Email'),
     'is_reserved' => 0,
   ])
   ->addValueTable(['rule_table', 'rule_field', 'rule_weight'], [

--- a/sql/civicrm_data/civicrm_dedupe_rule/IndividualGeneral.sqldata.php
+++ b/sql/civicrm_data/civicrm_dedupe_rule/IndividualGeneral.sqldata.php
@@ -5,7 +5,7 @@ return CRM_Core_CodeGen_DedupeRule::create('IndividualGeneral')
     'contact_type' => 'Individual',
     'threshold' => 15,
     'used' => 'General',
-    'title' => ts('Name and Address (reserved)'),
+    'title' => ts('First Name, Last Name and Street Address (reserved)'),
     'is_reserved' => 1,
   ])
   ->addValueTable(['rule_table', 'rule_field', 'rule_weight'], [

--- a/sql/civicrm_data/civicrm_dedupe_rule/IndividualSupervised.sqldata.php
+++ b/sql/civicrm_data/civicrm_dedupe_rule/IndividualSupervised.sqldata.php
@@ -5,7 +5,7 @@ return CRM_Core_CodeGen_DedupeRule::create('IndividualSupervised')
     'contact_type' => 'Individual',
     'threshold' => 20,
     'used' => 'Supervised',
-    'title' => ts('Name and Email (reserved)'),
+    'title' => ts('First Name, Last Name and Email (reserved)'),
     'is_reserved' => 1,
   ])
   ->addValueTable(['rule_table', 'rule_field', 'rule_weight'], [

--- a/sql/civicrm_data/civicrm_dedupe_rule/OrganizationSupervised.sqldata.php
+++ b/sql/civicrm_data/civicrm_dedupe_rule/OrganizationSupervised.sqldata.php
@@ -4,7 +4,7 @@ return CRM_Core_CodeGen_DedupeRule::create('OrganizationSupervised')
     'contact_type' => 'Organization',
     'threshold' => 10,
     'used' => 'Supervised',
-    'title' => ts('Name or Email'),
+    'title' => ts('Organization Name or Email'),
     'is_reserved' => 0,
   ])
   ->addValueTable(['rule_table', 'rule_field', 'rule_weight'], [


### PR DESCRIPTION

Overview
----------------------------------------
Item 1 on https://lab.civicrm.org/dev/core/-/issues/2357 is already done, 3 is an open question as to whether it should be done but this addresses 2

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/c2af0456-0ee5-4975-a878-2e2558937321)

After
----------------------------------------
Well nothing changes - until I re-run the famously conflicty regen....

Technical Details
----------------------------------------

Comments
----------------------------------------
@MegaphoneJon - I see you offered at some point to do this rename for all + some other stuff. I've just done this as a quick improvement that seems to have been requested more than once & wasn't going to delve into anything further - however if you still wanted to put this in an upgrade script (is_reserved = TRUE only) I would merge it