### PR TITLE
Add ability to edit email custom data to Email inline edit

### DIFF
--- a/CRM/Contact/Form/Edit/BlockCustomDataTrait.php
+++ b/CRM/Contact/Form/Edit/BlockCustomDataTrait.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * Form helper class to add custom data fields to location blocks.
+ *
+ * @internal not supported for use outside core - if you do use it ensure your
+ * code has adequate unit test cover.
+ */
+trait CRM_Contact_Form_Edit_BlockCustomDataTrait {
+
+  /**
+   * @var array
+   */
+  protected array $customFieldBlocks = [];
+
+  /**
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\NotImplementedException
+   */
+  protected function addCustomDataFieldBlock(string $entity, int $blockNumber, array $filters = []): void {
+    if (CRM_Core_Smarty::singleton()->getVersion() < 5) {
+      // Apiv4 custom fields do not work with Smarty 2. By the time there is any
+      // real uptake here we should have migrated fully to Smarty 5 so for now, do now harm.
+      $this->assign('custom_fields_' . strtolower($entity), []);
+      return;
+    }
+    $fields = (array) civicrm_api4($entity, 'getFields', [
+      'action' => 'create',
+      'values' => $filters,
+      'where' => [
+        ['type', '=', 'Custom'],
+        ['readonly', '=', FALSE],
+      ],
+      'checkPermissions' => TRUE,
+    ])->indexBy('custom_field_id');
+    foreach ($fields as $field) {
+      $elementName = strtolower($entity) . "[$blockNumber][{$field['name']}]";
+      CRM_Core_BAO_CustomField::addQuickFormElement($this, $elementName, $field['custom_field_id'], $field['required']);
+      if ($field['input_type'] === 'File') {
+        $this->registerFileField([$elementName]);
+      }
+      $this->customFieldBlocks[$blockNumber][$field['name']] = $field;
+    }
+    $this->assign('custom_fields_' . strtolower($entity), $this->customFieldBlocks);
+  }
+
+}

--- a/CRM/Contact/Form/Edit/EmailBlockTrait.php
+++ b/CRM/Contact/Form/Edit/EmailBlockTrait.php
@@ -1,0 +1,161 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+use Civi\Api4\Email;
+use Civi\Api4\Generic\Result;
+
+/**
+ * Form helper trait for including emails in forms.
+ *
+ * @internal not supported for use outside core - if you do use it ensure your
+ *  code has adequate unit test cover.
+ */
+trait CRM_Contact_Form_Edit_EmailBlockTrait {
+
+  /**
+   * @var \Civi\Api4\Generic\Result
+   */
+  private Result $existingEmails;
+
+  /**
+   * @return \Civi\Api4\Generic\Result
+   * @throws CRM_Core_Exception
+   */
+  public function getExistingEmails() : Result {
+    if (!isset($this->existingEmails)) {
+      $this->existingEmails = Email::get()
+        ->addOrderBy('is_primary', 'DESC')
+        ->addWhere('contact_id', '=', $this->getContactID())
+        ->execute();
+    }
+    return $this->existingEmails;
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  protected function addEmailBlockFields(int $blockNumber): void {
+    $this->addEmailBlockNonContactFields($blockNumber);
+    $this->addEmailBlockContactFields($blockNumber);
+  }
+
+  /**
+   * Add the email block fields that are not contact-specific.
+   *
+   * This is used, for example, by the Event Location form which is not interested in 'is_primary', 'is_bulkmail' etc.
+   * @throws \CRM_Core_Exception
+   */
+  protected function addEmailBlockNonContactFields(int $blockNumber): void {
+    $this->addField("email[$blockNumber][email]", [
+      'entity' => 'email',
+      'aria-label' => ts('Email %1', [1 => $blockNumber]),
+      'label' => ts('Email %1', [1 => $blockNumber]),
+    ]);
+    $this->addRule("email[$blockNumber][email]", ts('Email is not valid.'), 'email');
+  }
+
+  /**
+   * Add the email block fields that are contact-specific.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function addEmailBlockContactFields(int $blockNumber): void {
+    //Block type
+    $this->addField("email[$blockNumber][location_type_id]", ['entity' => 'email', 'placeholder' => NULL, 'class' => 'eight', 'option_url' => NULL]);
+
+    //TODO: Refactor on_hold field to select.
+    $multipleBulk = CRM_Core_BAO_Email::isMultipleBulkMail();
+
+    //On-hold select
+    if ($multipleBulk) {
+      $holdOptions = [
+        0 => ts('- select -'),
+        1 => ts('On Hold Bounce'),
+        2 => ts('On Hold Opt Out'),
+      ];
+      $this->addElement('select', "email[$blockNumber][on_hold]", '', $holdOptions);
+    }
+    else {
+      $this->addField("email[$blockNumber][on_hold]", ['entity' => 'email', 'type' => 'advcheckbox', 'aria-label' => ts('On Hold for Email %1?', [1 => $blockNumber])]);
+    }
+
+    //Bulkmail checkbox
+    $this->assign('multipleBulk', $multipleBulk);
+    $js = [
+      'id' => 'Email_' . $blockNumber . '_IsBulkmail',
+      'aria-label' => ts('Bulk Mailing for Email %1?', [1 => $blockNumber]),
+      'onChange' => "if (CRM.$(this).is(':checked')) {
+          CRM.$('.crm-email-bulkmail input').not(this).prop('checked', false);
+        } else {alert('boo')}",
+    ];
+
+    $this->addElement('advcheckbox', "email[$blockNumber][is_bulkmail]", NULL, '', $js);
+
+    //is_Primary radio
+    $js = [
+      'id' => 'Email_' . $blockNumber . '_IsPrimary',
+      'aria-label' => ts('Email %1 is primary?', [1 => $blockNumber]),
+      'class' => 'crm-email-is_primary',
+      'onChange' => "if (CRM.$(this).is(':checked')) {
+          CRM.$('.crm-email-is_primary').not(this).prop('checked', false);
+        }",
+    ];
+    $this->addElement('radio', "email[$blockNumber][is_primary]", '', '', '1', $js);
+  }
+
+  /**
+   * @throws UnauthorizedException
+   * @throws CRM_Core_Exception
+   */
+  public function saveEmails(array $emails): void {
+    $existingEmails = (array) $this->getExistingEmails()->indexBy('id');
+    foreach ($emails as $index => $email) {
+      $id = $email['id'] ?? NULL;
+      $dataExists = !CRM_Utils_System::isNull($email['email']);
+      if (!$dataExists) {
+        unset($emails[$index]);
+        continue;
+      }
+      if (!array_key_exists('contact_id', $email)) {
+        $emails[$index]['contact_id'] = $this->getContactID();
+      }
+      if ($id) {
+        if (array_key_exists($id, $existingEmails)) {
+          // We unset this here because we are going to delete any existing
+          // emails that were not in the incoming array.
+          unset($existingEmails[$id]);
+        }
+        else {
+          // The id is not valid, this becomes a create.
+          unset($email['id']);
+        }
+      }
+    }
+    if ($emails) {
+      Email::save()
+        ->setRecords($emails)
+        ->execute();
+    }
+
+    if (!empty($existingEmails)) {
+      Email::delete()->addWhere('id', 'IN', array_keys($existingEmails))
+        ->execute();
+    }
+
+  }
+
+}

--- a/CRM/Contact/Form/Edit/EmailBlockTrait.php
+++ b/CRM/Contact/Form/Edit/EmailBlockTrait.php
@@ -25,6 +25,7 @@ use Civi\Api4\Generic\Result;
  *  code has adequate unit test cover.
  */
 trait CRM_Contact_Form_Edit_EmailBlockTrait {
+  use CRM_Contact_Form_Edit_BlockCustomDataTrait;
 
   /**
    * @var \Civi\Api4\Generic\Result
@@ -38,6 +39,7 @@ trait CRM_Contact_Form_Edit_EmailBlockTrait {
   public function getExistingEmails() : Result {
     if (!isset($this->existingEmails)) {
       $this->existingEmails = Email::get()
+        ->addSelect('*', 'custom.*')
         ->addOrderBy('is_primary', 'DESC')
         ->addWhere('contact_id', '=', $this->getContactID())
         ->execute();
@@ -115,6 +117,7 @@ trait CRM_Contact_Form_Edit_EmailBlockTrait {
         }",
     ];
     $this->addElement('radio', "email[$blockNumber][is_primary]", '', '', '1', $js);
+    $this->addCustomDataFieldBlock('Email', $blockNumber);
   }
 
   /**

--- a/CRM/Contact/Form/Inline.php
+++ b/CRM/Contact/Form/Inline.php
@@ -88,7 +88,7 @@ abstract class CRM_Contact_Form_Inline extends CRM_Core_Form {
    * @noinspection PhpUnhandledExceptionInspection
    * @noinspection PhpDocMissingThrowsInspection
    */
-  public function getContactID(): int {
+  public function getContactID(): ?int {
     if (!isset($this->_contactId)) {
       $this->_contactId = (int) CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
     }

--- a/templates/CRM/Contact/Form/Inline/BlockCustomData.tpl
+++ b/templates/CRM/Contact/Form/Inline/BlockCustomData.tpl
@@ -1,0 +1,23 @@
+{*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+*}
+{* This file provides the template for inline editing of custom data attached to a block
+ - ie email & in the future phone, maybe im, website & openID although those
+ may not rise to the top of anyone's to-do *}
+{if array_key_exists($blockId, $customFields)}
+  {foreach item='custom_field' from=$customFields[$blockId] key='custom_field_name'}
+    <tr class="crm-block-entity-{$entity}-{$blockId} {if $blockId gt $actualBlockCount}hiddenElement{/if}">
+      <td colspan="5">{$form[$entity][$blockId][$custom_field_name]['label']}</td>
+    </tr>
+    <tr class="crm-block-entity-{$entity}-{$blockId} {if $blockId gt $actualBlockCount}hiddenElement{/if}">
+      <td colspan="5">{$form[$entity][$blockId][$custom_field_name]['html']}</td>
+    </tr>
+  {/foreach}
+{/if}
+

--- a/templates/CRM/Contact/Form/Inline/Email.tpl
+++ b/templates/CRM/Contact/Form/Inline/Email.tpl
@@ -32,13 +32,15 @@
   </tr>
   {section name='i' start=1 loop=$totalBlocks}
     {assign var='blockId' value=$smarty.section.i.index}
-    <tr id="Email_Block_{$blockId}" {if $blockId gt $actualBlockCount}class="hiddenElement"{/if}>
+    <tr data-entity='email' data-block-number={$blockId} id="Email_Block_{$blockId}" {if $blockId gt $actualBlockCount}class="hiddenElement"{/if}>
       <td>{$form.email.$blockId.email.html|crmAddClass:email}&nbsp;{$form.email.$blockId.location_type_id.html}</td>
       <td align="center">{$form.email.$blockId.on_hold.html}</td>
       <td align="center" {if !$multipleBulk}class="crm-email-bulkmail"{/if}>{$form.email.$blockId.is_bulkmail.html}</td>
       <td align="center" class="crm-email-is_primary">{$form.email.$blockId.is_primary.1.html}</td>
       <td><a title="{ts}Delete Email{/ts}" class="crm-delete-inline crm-hover-button" href="#"><span class="icon delete-icon"></span></a></td>
     </tr>
+    {include file="CRM/Contact/Form/Inline/BlockCustomData.tpl" entity=email customFields=$custom_fields_email blockId=$blockId actualBlockCount=$actualBlockCount}
+
   {/section}
 </table>
 

--- a/templates/CRM/Contact/Page/View/Summary.js
+++ b/templates/CRM/Contact/Page/View/Summary.js
@@ -250,6 +250,11 @@
         var row = $(this).closest('tr');
         var form = $(this).closest('form');
         row.hide();
+        var blockNumber = row.data('block-number');
+        if (blockNumber) {
+          $('.crm-block-entity-' + row.data('entity') + '-' + blockNumber).addClass('hiddenElement');
+          $('input', '.crm-block-entity-' + row.data('entity') + '-' + blockNumber).val('');
+        }
         $('input', row).val('');
         //if the primary is checked for deleted block
         //unset and set first as primary
@@ -284,6 +289,11 @@
         var form = $(this).closest('form');
         var row = $('tr[class="hiddenElement"]:first', form);
         row.removeClass('hiddenElement');
+        var blockNumber = row.data('block-number');
+        if (blockNumber) {
+          $('.crm-block-entity-' + row.data('entity') + '-' + blockNumber).removeClass('hiddenElement');
+        }
+
         $('input:focus', form).blur();
         $('input:first', row).focus();
         if ($('tr[class="hiddenElement"]').length < 1) {


### PR DESCRIPTION
Overview
----------------------------------------
Add ability to edit email custom data to Email inline edit

(includes the change in https://github.com/civicrm/civicrm-core/pull/30840)

Before
----------------------------------------
Some time back we added support for Custom Data on 'any' entity. Since then we have added UI editing support for some entities (MembershipType, FinancialAccount, FinancialTransaction, RelationshipType etc) and have a general principle that ideally this would be standard. 

On the location entities we have support for Custom Fields on Addresses, only.

After
----------------------------------------
Support for Custom fields in the edit pane (not view as yet) of the Inline Email trait - code written ready to be generalised to phone (& other location entities if I get keen) and to other forms with Email on it.

![image](https://github.com/user-attachments/assets/67f2c799-fcc4-401e-9609-dc09fea11794)

Technical Details
----------------------------------------
The new functionality requires Smarty5. It uses Apiv4 and the approach is not possible with Smarty2. It likely works with Smarty3 & 4 but given that this will take some time to phase in and pre-Smarty5 is being phased out at the same time it feels like the easiest / best approach is to limit ourselves to 1 smarty version.

Comments
----------------------------------------
To easily create the custom fields grab 
`git clone  https://github.com/eileenmcnaughton/testdata.git`
