### PR TITLE
Standalone installation UI: matches confirmation page fonts & panel with pre-install page

### DIFF
--- a/setup/res/finished.Standalone.php
+++ b/setup/res/finished.Standalone.php
@@ -1,7 +1,7 @@
 <?php \Civi\Setup::assertRunning(); ?>
-<h1><?php echo ts('CiviCRM Installed'); ?></h1>
-<div style="padding: 1em;">
-  <p style="background-color: #0C0; border: 1px #070 solid; color: white;">
+<div class="civicrm-setup-body complete">
+  <h1><?php echo ts('CiviCRM Installed'); ?></h1>
+  <p class="good">
     <?php echo ts("CiviCRM has been successfully installed"); ?>
   </p>
   <ul>

--- a/setup/res/template.css
+++ b/setup/res/template.css
@@ -63,7 +63,8 @@ body {
 
 /* Header End */
 
-.civicrm-setup-body #All {
+.civicrm-setup-body #All,
+.civicrm-setup-body.complete {
   font-family: Arial, sans-serif;
   width: auto;
   margin: 0.5em auto;


### PR DESCRIPTION
Overview
----------------------------------------
The pre-installation and installation confirmed screen on Standalone both load the same css file, but don't match fonts or panel - the user jumps from sans-serif pre-installation to serif post. 

This PR adds container classes that provide that, removes inline css and applies a pre-existing class to the confirmation notice.

Before
----------------------------------------
pre-installation:

<img width="1306" alt="image" src="https://github.com/user-attachments/assets/ca2aa4ca-5bb6-4082-afd5-16c8ad8064bd">

post-installation:

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/fac51c3a-696d-4a88-862d-729d1bf6d723">

After
----------------------------------------
![image](https://github.com/user-attachments/assets/d288c8e1-db26-47fc-b0a3-1aa5e2d69554)

Comments
----------------------------------------
Have avoided changing any other CSS – this is designed as a quick fix. There are confirmation screen templates for WordPress, Backdrop and Drupal - the changes here could be re-applied to them if they have a similar issue with