### PR TITLE
Installation UI: Aligns header block, matches h1 colour.

### DIFF
--- a/setup/res/template.css
+++ b/setup/res/template.css
@@ -1,71 +1,11 @@
 body {
   background: #eee;
 }
-/* Header */
-.civicrm-setup-header {
-  height: 300px;
-  width: 100%;
-  display: block;
-}
-
-.civicrm-setup-header .title {
-  width: 25%;
-  position: absolute;
-  overflow: hidden;
-  float: left;
-  margin-left: 10%;
-  margin-top: 50px;
-  margin-right: 20%;
-  display: inline-flex;
-}
-
-.civicrm-setup-header h1 {
-  line-height: 35px;
-  color: #ddd;
-  position: relative;
-  left: 400px;
-  -webkit-animation: slide 1s forwards;
-  -webkit-animation-delay: 0.5s;
-  animation: slide 1s forwards;
-  animation-delay: 0.5s;
-}
-
-@-webkit-keyframes slide {
-  100% {
-    left: 0;
-    color: #555;
-  }
-}
-
-@keyframes slide {
-  100% {
-    left: 0;
-    color: #555;
-  }
-}
-
-.civicrm-setup-header hr {
-  border-bottom: 2px solid #fff;
-  border-top: 2px solid #ddd;
-}
-
-.civicrm-setup-body .civicrm-logo {
-  float: right;
-  width: 30%;
-  display: grid;
-  margin-top: 50px;
-  margin-right: 10%;
-}
-
-.civicrm-setup-body .civicrm-logo img {
-  width: 100%;
-}
-
-/* Header End */
 
 .civicrm-setup-body #All,
 .civicrm-setup-body.complete {
-  font-family: Arial, sans-serif;
+  font-family: sans-serif;
+  line-height: 1.2;
   width: auto;
   margin: 0.5em auto;
   padding: 1em;
@@ -78,6 +18,52 @@ body {
 .civicrm-setup-body form {
   margin: 3%;
 }
+
+/* Header */
+.civicrm-setup-header {
+  width: 100%;
+  display: flex;
+  gap: 2rem;
+}
+
+.civicrm-setup-header > * {
+  flex: 1;
+}
+
+.civicrm-setup-header h1 {
+  margin: 0;
+  color: #fff;
+  position: relative;
+  left: -40px;
+  -webkit-animation: slide 1s forwards;
+  -webkit-animation-delay: 0.25s;
+  animation: slide 1s forwards;
+  animation-delay: 0.25s;
+}
+
+@-webkit-keyframes slide {
+  100% {
+    left: 0;
+    color: #000;
+  }
+}
+
+@keyframes slide {
+  100% {
+    left: 0;
+    color: #000;
+  }
+}
+
+.civicrm-setup-header hr {
+  border: 0;
+}
+
+.civicrm-setup-body .civicrm-logo img {
+  width: 100%;
+}
+
+/* Header End */
 
 .civicrm-setup-body h2 {
   display: inline-block;
@@ -305,11 +291,6 @@ body {
 }
 
 @media only screen and (max-width: 635px) {
-  .civicrm-setup-header .title {
-    width: 45%;
-    margin-left: 5%;
-    margin-top: 30px;
-  }
 
   .civicrm-setup-body .settingsTable {
     display: block;
@@ -317,6 +298,9 @@ body {
     white-space: nowrap;
     width: 95%;
     margin: 10px 2% 10px 2%;
+  }
+  .civicrm-setup-header {
+    flex-direction: column-reverse;
   }
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
The header on the installation screen used in Standalone, WordPress and others uses % positioning which creates variable alignment. This swaps to Flexbox to create consistent positioning, and a responsive fall back for small screens. 

Before
----------------------------------------
Desktop:

<img width="1306" alt="image" src="https://github.com/user-attachments/assets/fe196f58-8c16-4221-9007-4c7312a793d5">

Tablet:

<img width="1122" alt="image" src="https://github.com/user-attachments/assets/7246965a-cc98-4840-a5d1-405ce308fb60">

Mobile:

<img width="488" alt="image" src="https://github.com/user-attachments/assets/b216d151-6882-4b14-b2d3-78bb7a05032c">

After
----------------------------------------
<img width="1331" alt="image" src="https://github.com/user-attachments/assets/aeed3d04-986e-48c3-8e9a-97358cbbe48a">
<img width="773" alt="image" src="https://github.com/user-attachments/assets/59922e2d-63d9-417d-b5bf-9c8d2076a8f2">
<img width="528" alt="image" src="https://github.com/user-attachments/assets/0f9e927b-fc76-48e3-a3e9-fb8769e58f1e">

Technical Details
----------------------------------------
The animation on the title text is adjusted to accommodate this (it's a smaller slide in from the other direction), with the h1 colour matching the rest of the text.

Comments
----------------------------------------
I did my best to avoid changing any other css / design, beyond removing the horizontal rule and changing 'font-family: Arial, sans-serif' to 'font-family: sans-serif' to give neater OS integration. @JGaunt – I really don't want to step on your work here, so please feel free to push back!