### PR TITLE
[PHP8.x] Ensure value is a string (not NULL) before passing to trim

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1032,11 +1032,11 @@ SELECT is_primary,
     $uniqueAddress = [];
     foreach (array_keys($rows) as $rowID) {
       // load complete address as array key
-      $address = trim($rows[$rowID]['street_address'])
-        . trim($rows[$rowID]['city'])
-        . trim($rows[$rowID]['state_province'])
-        . trim($rows[$rowID]['postal_code'])
-        . trim($rows[$rowID]['country']);
+      $address = trim((string) $rows[$rowID]['street_address'])
+        . trim((string) $rows[$rowID]['city'])
+        . trim((string) $rows[$rowID]['state_province'])
+        . trim((string) $rows[$rowID]['postal_code'])
+        . trim((string) $rows[$rowID]['country']);
       if (isset($rows[$rowID]['last_name'])) {
         $name = $rows[$rowID]['last_name'];
       }


### PR DESCRIPTION
Overview
----------------------------------------
[PHP8.x] Ensure value is a string (not NULL) before passing to trim

Before
----------------------------------------
Value that may be a string or may be NULL passed to a string function

After
----------------------------------------
value is always a string

Technical Details
----------------------------------------
I'm in the process of writing the first test cover for this code & it borks on this

Comments
----------------------------------------
