### PR TITLE
Remove unreachable code

### DIFF
--- a/CRM/Contact/Form/Task/Label.php
+++ b/CRM/Contact/Form/Task/Label.php
@@ -238,34 +238,6 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
         foreach ($contact as $field => $fieldValue) {
           $rows[$value][$field] = $fieldValue;
         }
-
-        $valuesothers = [];
-        $paramsothers = ['contact_id' => $value];
-        $valuesothers = CRM_Core_BAO_Location::getValues($paramsothers, $valuesothers);
-        if (!empty($fv['location_type_id'])) {
-          foreach ($valuesothers as $vals) {
-            if (($vals['location_type_id'] ?? NULL) ==
-              ($fv['location_type_id'] ?? NULL)
-            ) {
-              foreach ($vals as $k => $v) {
-                if (in_array($k, [
-                  'email',
-                  'phone',
-                  'im',
-                  'openid',
-                ])) {
-                  if ($k === 'im') {
-                    $rows[$value][$k] = $v['1']['name'];
-                  }
-                  else {
-                    $rows[$value][$k] = $v['1'][$k];
-                  }
-                  $rows[$value][$k . '_id'] = $v['1']['id'];
-                }
-              }
-            }
-          }
-        }
       }
       else {
         if (!self::tokenIsFound($contact, $mailingFormatProperties, $tokenFields)) {


### PR DESCRIPTION
Overview
----------------------------------------
Remove unreachable code (this is also in https://github.com/civicrm/civicrm-core/pull/30862 which is where the test I wrote to step through this code is)

Before
----------------------------------------
This very confusing if is actually unreachable
![image](https://github.com/user-attachments/assets/3182f76e-1477-4ae9-854c-e17f38cfbfd1)


After
----------------------------------------
poof

Technical Details
----------------------------------------
I wrote a test (going up separately) so that I could step through this code & see what it was trying to do - but the upshot is that `$vals` never has a key `location_type_id` because is is an array or arrays, each one numerically indexed. Each array is an entity's values

The arrays come from `Location::getValues()` which returns an array of blocks like this - ie any 'location_type_id' would be a layer down.

![image](https://github.com/user-attachments/assets/9095b9dd-4736-4a67-a074-80cbff0092a6)


Comments
----------------------------------------
