### PR TITLE
Stop returning unused array, remove unused function

### DIFF
--- a/CRM/Contact/Form/Task/Label.php
+++ b/CRM/Contact/Form/Task/Label.php
@@ -303,7 +303,7 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
         $row['preferred_communication_method'] = implode(', ', $temp);
       }
       $row['id'] = $id;
-      $formatted = CRM_Utils_Address::formatMailingLabel($row, 'mailing_format', FALSE, TRUE, $tokenFields);
+      $formatted = CRM_Utils_Address::formatMailingLabel($row);
       $rows[$id] = [$formatted];
     }
 

--- a/CRM/Contact/Form/Task/LabelCommon.php
+++ b/CRM/Contact/Form/Task/LabelCommon.php
@@ -160,10 +160,6 @@ class CRM_Contact_Form_Task_LabelCommon {
         // If location type is not primary, $contact contains
         // one more array as "$contact[$locName] = array( values... )"
 
-        if (!CRM_Contact_Form_Task_Label::tokenIsFound($contact, $mailingFormatProperties, $tokenFields)) {
-          continue;
-        }
-
         unset($contact[$locName]);
 
         if (!empty($contact['county_id'])) {
@@ -203,9 +199,6 @@ class CRM_Contact_Form_Task_LabelCommon {
         }
       }
       else {
-        if (!CRM_Contact_Form_Task_Label::tokenIsFound($contact, $mailingFormatProperties, $tokenFields)) {
-          continue;
-        }
 
         if (!empty($contact['addressee_display'])) {
           $contact['addressee_display'] = trim($contact['addressee_display']);

--- a/CRM/Contact/Form/Task/LabelCommon.php
+++ b/CRM/Contact/Form/Task/LabelCommon.php
@@ -141,9 +141,6 @@ class CRM_Contact_Form_Task_LabelCommon {
     // except it also handles multiple locations
     [$details] = CRM_Contact_BAO_Query::apiQuery($params, $returnProperties, NULL, NULL, 0, $numberofContacts);
 
-    // $details is an array of [ contactID => contactDetails ]
-    $tokenFields = CRM_Contact_Form_Task_LabelCommon::getTokenData($details);
-
     foreach ($contactIDs as $value) {
       foreach ($custom as $cfID) {
         if (isset($details[$value]["custom_{$cfID}"])) {
@@ -224,7 +221,7 @@ class CRM_Contact_Form_Task_LabelCommon {
       }
     }
     // sigh couldn't extract out tokenfields yet
-    return [$rows, $tokenFields];
+    return [$rows];
   }
 
   /**
@@ -244,35 +241,6 @@ class CRM_Contact_Form_Task_LabelCommon {
       $addressReturnProperties['postal_code_suffix'] = 1;
     }
     return $addressReturnProperties;
-  }
-
-  /**
-   * Get token list from mailing format & contacts
-   * @param array $contacts
-   * @return array
-   */
-  public static function getTokenData(&$contacts) {
-    $mailingFormat = Civi::settings()->get('mailing_format');
-    $tokens = $tokenFields = [];
-    $messageToken = CRM_Utils_Token::getTokens($mailingFormat);
-
-    // also get all token values
-    CRM_Utils_Hook::tokenValues($contacts,
-      array_keys($contacts),
-      NULL,
-      $messageToken,
-      'CRM_Contact_Form_Task_LabelCommon'
-    );
-
-    CRM_Utils_Hook::tokens($tokens);
-
-    foreach ($tokens as $category => $catTokens) {
-      foreach ($catTokens as $token => $tokenName) {
-        $tokenFields[] = $token;
-      }
-    }
-    return $tokenFields;
-
   }
 
   /**

--- a/CRM/Member/Form/Task/Label.php
+++ b/CRM/Member/Form/Task/Label.php
@@ -81,7 +81,7 @@ class CRM_Member_Form_Task_Label extends CRM_Member_Form_Task {
     // so no-one is tempted to refer to this again after relevant values are extracted
     unset($formValues);
 
-    [$rows, $tokenFields] = CRM_Contact_Form_Task_LabelCommon::getRows($this->_contactIds, $locationTypeID, $respectDoNotMail, $mergeSameAddress, $mergeSameHousehold);
+    [$rows] = CRM_Contact_Form_Task_LabelCommon::getRows($this->_contactIds, $locationTypeID, $respectDoNotMail, $mergeSameAddress, $mergeSameHousehold);
 
     if ($mergeSameAddress) {
       CRM_Core_BAO_Address::mergeSameAddress($rows);

--- a/CRM/Member/Form/Task/Label.php
+++ b/CRM/Member/Form/Task/Label.php
@@ -102,7 +102,7 @@ class CRM_Member_Form_Task_Label extends CRM_Member_Form_Task {
         $row['preferred_communication_method'] = implode(', ', $temp);
       }
       $row['id'] = $id;
-      $formatted = CRM_Utils_Address::formatMailingLabel($row, 'mailing_format', FALSE, TRUE, $tokenFields);
+      $formatted = CRM_Utils_Address::formatMailingLabel($row);
       $rows[$id] = [$formatted];
     }
     if ($isPerMembership) {


### PR DESCRIPTION
Overview
----------------------------------------
Stop returning unused array as it is no longer passed here https://github.com/civicrm/civicrm-core/pull/30851, remove now-unused function

Before
----------------------------------------
A universe search shows that function `getRows()` only has one core caller.  That function is the only caller for `getTokenData()`

![image](https://github.com/user-attachments/assets/b47a828c-02a3-4581-830c-1585229b3a89)
![image](https://github.com/user-attachments/assets/9a710e6b-d66b-4d85-b954-b285251570b7)



After
----------------------------------------
both functions are removed

Technical Details
----------------------------------------
While we might give `getTokenData()` a deprecated cooling off period normally it is itself calling hooks and functions that we are working to deprecate & remove so keeping it around makes the job of cleaning up the rest of the code harder as we keep hitting this false positive when searching as to whether those functions are still called. Since there are no universe uses and I think it would be hard to argue this as a supported function I've gone full removal

Comments
----------------------------------------
