### PR TITLE
Remove function with noisy deprecation since 2022: replaceCaseTokens

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1389,28 +1389,6 @@ class CRM_Utils_Token {
   }
 
   /**
-   * @deprecated
-   *
-   * @param int $caseId
-   * @param string $str
-   * @param array $knownTokens
-   * @param bool $escapeSmarty
-   * @return string
-   * @throws \CRM_Core_Exception
-   */
-  public static function replaceCaseTokens($caseId, $str, $knownTokens = NULL, $escapeSmarty = FALSE): string {
-    CRM_Core_Error::deprecatedFunctionWarning('token processor');
-    if (strpos($str, '{case.') === FALSE) {
-      return $str;
-    }
-    if (!$knownTokens) {
-      $knownTokens = self::getTokens($str);
-    }
-    $case = civicrm_api3('case', 'getsingle', ['id' => $caseId]);
-    return self::replaceEntityTokens('case', $case, $str, $knownTokens, $escapeSmarty);
-  }
-
-  /**
    * Generic function for formatting token replacement for an api field
    *
    * @deprecated


### PR DESCRIPTION
Overview
----------------------------------------
Remove function with noisy deprecation since 2022: replaceCaseTokens

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/e7ef9e03-b7b8-4266-8787-cf299be4e5e7)

The only universe caller is in a function which only runs on civi versions before 5.43 to provide backward compatibility

![image](https://github.com/user-attachments/assets/4f9653db-ce8c-403f-b1dd-b0a6e46eb285)


![image](https://github.com/user-attachments/assets/0c6bb01c-388f-4d7c-8925-9bbd8dd92742)


After
----------------------------------------
poof


Technical Details
----------------------------------------

Comments
----------------------------------------
