### PR TITLE
Stop passing value to unused function within tests

### DIFF
--- a/tests/phpunit/CRM/Mailing/MultilingualSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/MultilingualSystemTest.php
@@ -227,7 +227,7 @@ class CRM_Mailing_MultilingualSystemTest extends CiviUnitTestCase {
 
     // Now test unsubscribe groups.
     $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing(
-      $matches[1],
+      NULL,
       $matches[2],
       $matches[3],
       TRUE
@@ -249,7 +249,7 @@ class CRM_Mailing_MultilingualSystemTest extends CiviUnitTestCase {
       $dbLocale = '_fr_FR';
       // Now test unsubscribe groups.
       $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing(
-        $matches[1],
+        NULL,
         $matches[2],
         $matches[3],
         TRUE

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -752,15 +752,15 @@ class api_v3_MailingTest extends CiviUnitTestCase {
     $hash = CRM_Core_DAO::getFieldValue('CRM_Mailing_Event_DAO_MailingEventQueue', $jobId, 'hash', 'job_id');
     $queueId = CRM_Core_DAO::getFieldValue('CRM_Mailing_Event_DAO_MailingEventQueue', $jobId, 'id', 'job_id');
     // This gets the list of groups to unsubscribe but does NOT actually unsubcribe from groups (because return=TRUE)
-    $beforeUnsubscribeGroups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing($jobId, $queueId, $hash, TRUE);
+    $beforeUnsubscribeGroups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing(NULL, $queueId, $hash, TRUE);
     // Assert that there are two groups in the unsubscribe list.
     $this->assertCount(2, $beforeUnsubscribeGroups);
     $this->assertArrayHasKey($groupID3, $beforeUnsubscribeGroups);
     $this->assertArrayHasKey($groupID4, $beforeUnsubscribeGroups);
     // Do the actual unsubscribe
-    CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing($jobId, $queueId, $hash, FALSE);
+    CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing(NULL, $queueId, $hash, FALSE);
     // Assert that there are now no groups in the unsubscribe list.
-    $afterUnsubscribeGroups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing($jobId, $queueId, $hash, TRUE);
+    $afterUnsubscribeGroups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing(NULL, $queueId, $hash, TRUE);
     $this->assertCount(0, $afterUnsubscribeGroups);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Stop passing value to unused function within tests

Before
----------------------------------------
Variable passed but....

![image](https://github.com/user-attachments/assets/a535560e-27a3-4129-ae09-ed7daeae7865)

After
----------------------------------------
null passed

Technical Details
----------------------------------------
this is also in forms but probably the tests part is an easy merge cos in the forms it might also be possible to stop setting the variable

Comments
----------------------------------------
