### PR TITLE
Disable FollowSymLinks by default in Standalone .htaccess

### DIFF
--- a/setup/res/htaccess.txt
+++ b/setup/res/htaccess.txt
@@ -16,8 +16,9 @@
 # Don't show directory listings for URLs which map to a directory.
 Options -Indexes
 
-# Follow symbolic links in this directory.
-Options +FollowSymLinks
+# Uncomment if you need to follow symbolic links within your Standalone install
+# (Disabled by default as some webhosts may not allow this)
+# Options +FollowSymLinks
 
 # Make CiviCRM handle any 404 errors.
 ErrorDocument 404 /index.php


### PR DESCRIPTION
This may not be allowed on some webhosts, and shouldn't be needed in a "default" install.

Alternatively we could add an instruction to the docs about checking whether this is enabled and commenting out if needed. But this seems simpler to me.

Does anyone know why "FollowSymLinks" might be needed out of the box?
