### PR TITLE
Add initial unit test to Unsubscribe form & stop passing value to function that discards it

### DIFF
--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -77,7 +77,7 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
     $this->assign('email', $email);
     $this->_email = $email;
 
-    $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing($job_id, $queue_id, $hash, TRUE);
+    $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing(NULL, $queue_id, $hash, TRUE);
     $this->assign('groups', $groups ?? []);
     $groupExist = NULL;
     foreach ($groups as $value) {
@@ -119,7 +119,7 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
     CRM_Core_Session::singleton()->pushUserContext($confirmURL);
 
     // Email address verified
-    $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing($this->_job_id, $this->_queue_id, $this->_hash);
+    $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing(NULL, $this->_queue_id, $this->_hash);
 
     if (!empty($groups)) {
       CRM_Mailing_Event_BAO_MailingEventUnsubscribe::send_unsub_response($this->_queue_id, $groups, FALSE, $this->_job_id);

--- a/Civi/Test/MailingTestTrait.php
+++ b/Civi/Test/MailingTestTrait.php
@@ -15,10 +15,11 @@ trait MailingTestTrait {
    * Helper function to create new mailing.
    *
    * @param array $params
+   * @param string $identifier
    *
    * @return int
    */
-  public function createMailing($params = []) {
+  public function createMailing(array $params = [], string $identifier = 'default'): int {
     $params = array_merge([
       'subject' => 'maild' . rand(),
       'body_text' => 'bdkfhdskfhduew{domain.address}{action.optOutUrl}',
@@ -27,7 +28,8 @@ trait MailingTestTrait {
     ], $params);
 
     $result = $this->callAPISuccess('Mailing', 'create', $params);
-    return $result['id'];
+    $this->ids['Mailing'][$identifier] = (int) $result['id'];
+    return (int) $result['id'];
   }
 
   /**

--- a/tests/phpunit/CRM/Mailing/Form/UnsubscribeTest.php
+++ b/tests/phpunit/CRM/Mailing/Form/UnsubscribeTest.php
@@ -8,6 +8,9 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
  */
+
+use Civi\Api4\Email;
+
 /**
  * Test class for CRM_Mailing_Form_Unsubscribe.
  * @group headless
@@ -15,11 +18,34 @@
 class CRM_Mailing_Form_UnsubscribeTest extends CiviUnitTestCase {
 
   public function testSubmit(): void {
+    $this->sendMailing();
     $this->getTestForm('CRM_Mailing_Form_Unsubscribe', [], [
       'jid' => 1,
-
+      'qid' => $this->ids['MailingEventQueue']['default'],
+      'h' => 'abc',
     ])
-    ->processForm();
+      ->processForm();
+  }
+
+  /**
+   * @return void
+   * @throws \CRM_Core_Exception
+   */
+  public function sendMailing(): void {
+    $params = [
+      'contact_id' => $this->individualCreate(),
+      'group_id' => $this->groupCreate(['name' => 'Test group 2', 'title' => 'group title 2']),
+    ];
+    $this->createTestEntity('GroupContact', $params);
+    $email = Email::get()
+      ->addWhere('id', '=', $params['contact_id'])
+      ->execute()->first();
+    $this->createTestEntity('MailingEventQueue', [
+      'mailing_id' => $this->createMailing(),
+      'hash' => 'abc',
+      'contact_id' => $params['contact_id'],
+      'email_id' => $email['id'],
+    ]);
   }
 
 }

--- a/tests/phpunit/CRM/Mailing/Form/UnsubscribeTest.php
+++ b/tests/phpunit/CRM/Mailing/Form/UnsubscribeTest.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+/**
+ * Test class for CRM_Mailing_Form_Unsubscribe.
+ * @group headless
+ */
+class CRM_Mailing_Form_UnsubscribeTest extends CiviUnitTestCase {
+
+  public function testSubmit(): void {
+    $this->getTestForm('CRM_Mailing_Form_Unsubscribe', [], [
+      'jid' => 1,
+
+    ])
+    ->processForm();
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
The non-test change is the same as 
https://github.com/civicrm/civicrm-core/pull/30865


Before
----------------------------------------
After
----------------------------------------

Technical Details
----------------------------------------

Comments
----------------------------------------
