### PR TITLE
dev/core#5388 don't create a logging table for SearchKit entities

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -161,6 +161,9 @@ AND    TABLE_NAME LIKE 'civicrm_%'
     // Don't log sessions
     $this->tables = preg_grep('/^civicrm_session/', $this->tables, PREG_GREP_INVERT);
 
+    // Don't log entity tables.
+    $this->tables = preg_grep('/^civicrm_sk_/', $this->tables, PREG_GREP_INVERT);
+
     // do not log civicrm_mailing_recipients table, CRM-16193
     $this->tables = array_diff($this->tables, ['civicrm_mailing_recipients']);
     $this->logTableSpec = array_fill_keys($this->tables, []);


### PR DESCRIPTION
Overview
----------------------------------------
A "missing log tables" warning appears when you create a SearchKit display of type Entity.

Before
----------------------------------------
"Missing log tables" warning.

After
----------------------------------------
No warning.

Comments
----------------------------------------
This table's closest analogy is `civicrm_group_contact_cache`, and like that table, it gets regenerated frequently.
