### PR TITLE
Add test for groups assigned to unsubscribe, minor clean up

### DIFF
--- a/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
@@ -230,7 +230,7 @@ WHERE  email = %2
      * how a UNION would work.
      */
     $groupsCachedSQL = "
-            SELECT      grp.id as group_id,
+            SELECT      grp.id as id,
                         grp.title as title,
                         grp.frontend_title as frontend_title,
                         grp.frontend_description as frontend_description,
@@ -246,7 +246,7 @@ WHERE  email = %2
                         ) GROUP BY grp.id";
 
     $groupsAddedSQL = "
-            SELECT      grp.id as group_id,
+            SELECT      grp.id as id,
                         grp.title as title,
                         grp.frontend_title as frontend_title,
                         grp.frontend_description as frontend_description,
@@ -266,30 +266,19 @@ WHERE  email = %2
     ];
     $doCached = CRM_Core_DAO::executeQuery($groupsCachedSQL, $groupsParams);
     $doAdded = CRM_Core_DAO::executeQuery($groupsAddedSQL, $groupsParams);
-
+    $allGroups = $doAdded->fetchAll() + $doCached->fetchAll();
     if ($return) {
       $returnGroups = [];
-      while ($doCached->fetch()) {
-        $returnGroups[$doCached->group_id] = [
-          'title' => !empty($doCached->frontend_title) ? $doCached->frontend_title : $doCached->title,
-          'description' => !empty($doCached->frontend_description) ? $doCached->frontend_description : $doCached->description,
-        ];
-      }
-      while ($doAdded->fetch()) {
-        $returnGroups[$doAdded->group_id] = [
-          'title' => $doAdded->frontend_title,
-          'description' => $doAdded->frontend_description,
+      foreach ($allGroups as $group) {
+        $returnGroups[$group['id']] = [
+          'title' => $group['frontend_title'],
+          'description' => $group['frontend_description'],
         ];
       }
       return $returnGroups;
     }
-    else {
-      while ($doCached->fetch()) {
-        $groups[$doCached->group_id] = $doCached->frontend_title;
-      }
-      while ($doAdded->fetch()) {
-        $groups[$doAdded->group_id] = $doAdded->frontend_title;
-      }
+    foreach ($allGroups as $group) {
+      $groups[$group['id']] = $group['frontend_title'];
     }
     $transaction = new CRM_Core_Transaction();
     $contacts = [$contact_id];

--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -77,7 +77,7 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
     $this->assign('email', $email);
     $this->_email = $email;
 
-    $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing($job_id, $queue_id, $hash, TRUE);
+    $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing(NULL, $queue_id, $hash, TRUE);
     $this->assign('groups', $groups ?? []);
     $groupExist = NULL;
     foreach ($groups as $value) {
@@ -119,7 +119,7 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
     CRM_Core_Session::singleton()->pushUserContext($confirmURL);
 
     // Email address verified
-    $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing($this->_job_id, $this->_queue_id, $this->_hash);
+    $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing(NULL, $this->_queue_id, $this->_hash);
 
     if (!empty($groups)) {
       CRM_Mailing_Event_BAO_MailingEventUnsubscribe::send_unsub_response($this->_queue_id, $groups, FALSE, $this->_job_id);

--- a/Civi/Test/FormTrait.php
+++ b/Civi/Test/FormTrait.php
@@ -148,6 +148,10 @@ trait FormTrait {
     }
   }
 
+  protected function assertTemplateVariable($name, $expected): void {
+    $this->assertEquals($expected, $this->form->getTemplateVariable($name));
+  }
+
   /**
    * Retrieve a deprecated property, ensuring a deprecation notice is thrown.
    *

--- a/Civi/Test/MailingTestTrait.php
+++ b/Civi/Test/MailingTestTrait.php
@@ -15,10 +15,11 @@ trait MailingTestTrait {
    * Helper function to create new mailing.
    *
    * @param array $params
+   * @param string $identifier
    *
    * @return int
    */
-  public function createMailing($params = []) {
+  public function createMailing(array $params = [], string $identifier = 'default'): int {
     $params = array_merge([
       'subject' => 'maild' . rand(),
       'body_text' => 'bdkfhdskfhduew{domain.address}{action.optOutUrl}',
@@ -27,7 +28,8 @@ trait MailingTestTrait {
     ], $params);
 
     $result = $this->callAPISuccess('Mailing', 'create', $params);
-    return $result['id'];
+    $this->ids['Mailing'][$identifier] = (int) $result['id'];
+    return (int) $result['id'];
   }
 
   /**

--- a/tests/phpunit/CRM/Mailing/Form/UnsubscribeTest.php
+++ b/tests/phpunit/CRM/Mailing/Form/UnsubscribeTest.php
@@ -8,6 +8,9 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
  */
+
+use Civi\Api4\Email;
+
 /**
  * Test class for CRM_Mailing_Form_Unsubscribe.
  * @group headless
@@ -15,11 +18,34 @@
 class CRM_Mailing_Form_UnsubscribeTest extends CiviUnitTestCase {
 
   public function testSubmit(): void {
+    $this->sendMailing();
     $this->getTestForm('CRM_Mailing_Form_Unsubscribe', [], [
       'jid' => 1,
-
+      'qid' => $this->ids['MailingEventQueue']['default'],
+      'h' => 'abc',
     ])
-    ->processForm();
+      ->processForm();
+  }
+
+  /**
+   * @return void
+   * @throws \CRM_Core_Exception
+   */
+  public function sendMailing(): void {
+    $params = [
+      'contact_id' => $this->individualCreate(),
+      'group_id' => $this->groupCreate(['name' => 'Test group 2', 'title' => 'group title 2']),
+    ];
+    $this->createTestEntity('GroupContact', $params);
+    $email = Email::get()
+      ->addWhere('id', '=', $params['contact_id'])
+      ->execute()->first();
+    $this->createTestEntity('MailingEventQueue', [
+      'mailing_id' => $this->createMailing(),
+      'hash' => 'abc',
+      'contact_id' => $params['contact_id'],
+      'email_id' => $email['id'],
+    ]);
   }
 
 }

--- a/tests/phpunit/CRM/Mailing/Form/UnsubscribeTest.php
+++ b/tests/phpunit/CRM/Mailing/Form/UnsubscribeTest.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+/**
+ * Test class for CRM_Mailing_Form_Unsubscribe.
+ * @group headless
+ */
+class CRM_Mailing_Form_UnsubscribeTest extends CiviUnitTestCase {
+
+  public function testSubmit(): void {
+    $this->getTestForm('CRM_Mailing_Form_Unsubscribe', [], [
+      'jid' => 1,
+
+    ])
+    ->processForm();
+  }
+
+}

--- a/tests/phpunit/CRM/Mailing/Form/UnsubscribeTest.php
+++ b/tests/phpunit/CRM/Mailing/Form/UnsubscribeTest.php
@@ -17,26 +17,48 @@ use Civi\Api4\Email;
  */
 class CRM_Mailing_Form_UnsubscribeTest extends CiviUnitTestCase {
 
+  /**
+   * Submit the unsubscribe form.
+   *
+   * @return void
+   * @throws \CRM_Core_Exception
+   */
   public function testSubmit(): void {
-    $this->sendMailing();
+    $this->setupMailing();
     $this->getTestForm('CRM_Mailing_Form_Unsubscribe', [], [
       'jid' => 1,
       'qid' => $this->ids['MailingEventQueue']['default'],
       'h' => 'abc',
     ])
       ->processForm();
+    $this->assertTemplateVariable('groups', [$this->ids['Group']['group'] => ['title' => 'Public group name', 'description' => ''], $this->ids['Group']['smart_group'] => ['title' => 'Public group name', 'description' => '']]);
   }
 
   /**
+   * Set up a 'sent' mailing with 2 attached groups which the contact is part of.
+   *
+   * One group is a smarty group of all individuals.
+   *
    * @return void
    * @throws \CRM_Core_Exception
    */
-  public function sendMailing(): void {
+  public function setupMailing(): void {
+
+    $savedSearch = $this->createTestEntity('SavedSearch', [
+      'api_entity' => 'Contact',
+      'api_params' => [
+        'version' => 4,
+        'select' => ['id'],
+        'where' => [['contact_type', '=', 'Individual']],
+      ],
+    ]);
+
     $params = [
       'contact_id' => $this->individualCreate(),
       'group_id' => $this->groupCreate(['name' => 'Test group 2', 'title' => 'group title 2']),
     ];
     $this->createTestEntity('GroupContact', $params);
+
     $email = Email::get()
       ->addWhere('id', '=', $params['contact_id'])
       ->execute()->first();
@@ -45,6 +67,18 @@ class CRM_Mailing_Form_UnsubscribeTest extends CiviUnitTestCase {
       'hash' => 'abc',
       'contact_id' => $params['contact_id'],
       'email_id' => $email['id'],
+    ]);
+    $this->createTestEntity('MailingGroup', [
+      'mailing_id' => $this->ids['Mailing']['default'],
+      'entity_table' => 'civicrm_group',
+      'entity_id' => $params['group_id'],
+      'group_type' => 'Base',
+    ]);
+    $this->createTestEntity('MailingGroup', [
+      'mailing_id' => $this->ids['Mailing']['default'],
+      'entity_table' => 'civicrm_group',
+      'entity_id' => $this->groupCreate(['saved_search_id' => $savedSearch['id']], 'smart_group'),
+      'group_type' => 'Include',
     ]);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Add test for groups assigned to unsubscribe, minor clean up

Before
----------------------------------------
Lack of test cover - 2 separate ways the `dao` is iterated

After
----------------------------------------
The `dao` is converted into an array once - that array is still iterated in 2 different ways - but we can extract the generation of it next & deprecate one of those ways (2 core callers)

Technical Details
----------------------------------------

Comments
----------------------------------------
