### PR TITLE
[ext/financialacls] Add constraint for `contribution_id` in SQL clause for unavailable financial types

### DIFF
--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -96,7 +96,7 @@ function financialacls_civicrm_selectWhereClause($entity, &$clauses) {
       if ($entity === 'Contribution') {
         $unavailableTypes = _financialacls_civicrm_get_inaccessible_financial_types();
         if (!empty($unavailableTypes)) {
-          $clauses['id'][] = 'NOT IN (SELECT contribution_id FROM civicrm_line_item WHERE financial_type_id IN (' . implode(',', $unavailableTypes) . '))';
+          $clauses['id'][] = 'NOT IN (SELECT contribution_id FROM civicrm_line_item WHERE contribution_id IS NOT NULL AND financial_type_id IN (' . implode(',', $unavailableTypes) . '))';
         }
       }
       break;


### PR DESCRIPTION
Overview
----------------------------------------
the *Financial ACLs* Core extension adds SQL constraints for queries produced by the API for filtering out contributions the user does not have permission for. When using in a `JOIN`, the clause checking for `civicrm_line_item.financial_type_id NOT IN (…)` causes no results when there are line items without a contribution ID (`NULL`), filtering out valid results.

This PR adds a constraint for `civicrm_line_item.contribution_id IS NOT NULL` to include valid results.

Note: The query is being created by an APIv4 call with a `JOIN` to `Contribution`.

Before
----------------------------------------
[*CiviSEPA*](https://github.com/project60/org.project60.sepa) has SEPA mandate entities that are linked to a contribution and should thus only show mandates connected with permissioned contributions.
In this example, the user does not have permission to view financial types `1`-`10`, but does have permission for `11`.
This query does not return records associated with a permissioned contribution when there are line items in the DB with `civicrm_line_item.contribution_id = NULL` (i.e. line items for other entities like memberships):

```sql
SELECT
  `a`.`id` AS `id`,
  `contribution`.`id` AS `contribution.id`,
  …
FROM civicrm_sdd_mandate a
INNER JOIN (`civicrm_contribution` `contribution`)
  ON

  # Added by financialacls:
  (
      `contribution`.`financial_type_id` IS NULL
      OR `contribution`.`financial_type_id` IN (11)
  )
  AND
  `contribution`.`id` NOT IN (
      SELECT contribution_id
      FROM civicrm_line_item
      WHERE financial_type_id IN (1,2,3,4,5,6,7,8,9,10)
  )
  # End financialacls

  AND `a`.`entity_table` = "civicrm_contribution"
  AND `a`.`entity_id` = `contribution`.`id`
  
WHERE(`a`.`contact_id` = "123")
  AND (`a`.`type` = "OOFF");

```

After
----------------------------------------
This condition:
```sql
  `contribution`.`id` NOT IN (
      SELECT contribution_id
      FROM civicrm_line_item
      WHERE financial_type_id IN (1,2,3,4,5,6,7,8,9,10)
  )
```
is being added a constraint for requiring contribution IDs in line items to compare with and now looks like this:
```sql
`contribution`.`id` NOT IN (
  SELECT contribution_id
  FROM civicrm_line_item
  WHERE
    contribution_id IS NOT NULL
    AND financial_type_id IN (1,2,3,4,5,6,7,8,9,10)
)
```