### PR TITLE
CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing: don't use addContactsToGroup to remove contacts from group

### DIFF
--- a/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
@@ -253,12 +253,7 @@ WHERE  email = %2
     foreach ($groups as $group_id => $group_name) {
       $notremoved = FALSE;
       if ($group_name) {
-        if (in_array($group_id, $baseGroupIds)) {
-          [$total, $removed, $notremoved] = CRM_Contact_BAO_GroupContact::addContactsToGroup($contacts, $group_id, 'Email', 'Removed');
-        }
-        else {
-          [$total, $removed, $notremoved] = CRM_Contact_BAO_GroupContact::removeContactsFromGroup($contacts, $group_id, 'Email');
-        }
+        [$total, $removed, $notremoved] = CRM_Contact_BAO_GroupContact::removeContactsFromGroup($contacts, $group_id, 'Email');
       }
       if ($notremoved) {
         unset($groups[$group_id]);


### PR DESCRIPTION
Overview
----------------------------------------
When unsubscribing from a mailing, `\CRM_Contact_BAO_GroupContact::addContactsToGroup()` with `$status = 'Removed'` removes the contact from the group but fires the pre and post hook with `op = 'create'` so downstream consumers (e.g. CiviRules) think the contact was _added_ to the group not _removed_.

Before
----------------------------------------
Post hook with `op = 'create'` is fired.

After
----------------------------------------
Post hook with `op = 'delete'` is fired.

Technical Details
----------------------------------------
I haven't found any reason, why was `addContactsToGroup` used for base groups and `removeContactsFromGroup` for others. They seem to do the same thing, just call the hook with different operation. It's untouched since import from SVN.
