### PR TITLE
Fix saving entity display with money calculated field

### DIFF
--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
@@ -184,6 +184,7 @@ class SKEntitySubscriber extends AutoService implements EventSubscriberInterface
         'String' => 'text',
         'Text' => 'text',
         'Timestamp' => 'datetime',
+        'Money' => 'decimal(20,2)',
       ];
       $type = $map[$expr['dataType']] ?? $type;
     }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5399

When you try to save an entity display in SearchKit, and there's a calculated field of type "Money", you get a crash.