### PR TITLE
SearchKit - Refresh entity list after saving a DB entity display

### DIFF
--- a/ext/search_kit/CRM/Search/Page/AJAX.php
+++ b/ext/search_kit/CRM/Search/Page/AJAX.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use CRM_Search_ExtensionUtil as E;
+
+/**
+ * Ajax callback used to reload admin settings when they may have changed.
+ */
+class CRM_Search_Page_AJAX extends CRM_Core_Page {
+
+  public function run() {
+    $response = \Civi\Search\Admin::getAdminSettings();
+    CRM_Utils_JSON::output($response);
+  }
+
+}

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.component.js
@@ -114,6 +114,10 @@
               ts('Saved'),
               'success'
             );
+            // Refresh admin settings (if a db entity was saved the list of entities will be changed)
+            fetch(CRM.url('civicrm/ajax/admin/search'))
+              .then(response => response.json())
+              .then(data => CRM.crmSearchAdmin = data);
             dialogService.close('crmSearchAdminImport');
           }, function(error) {
             ctrl.running = false;

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.decorator.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.decorator.js
@@ -30,9 +30,14 @@
         crmApi4('SK_' + display.name, 'refresh', {}, 0).then(function(result) {
           display._refresh_date = CRM.utils.formatDate(result.refresh_date, null, true);
         });
+        // Job was a separate api call, add its result back in to the model
         if (apiResults['job_' + display.name]) {
           display._job = apiResults['job_' + display.name];
         }
+        // Refresh admin settings to reflect any new/updated entity + joins
+        fetch(CRM.url('civicrm/ajax/admin/search'))
+          .then(response => response.json())
+          .then(data => CRM.crmSearchAdmin = data);
       }
     });
     return $delegate;

--- a/ext/search_kit/xml/Menu/search_kit.xml
+++ b/ext/search_kit/xml/Menu/search_kit.xml
@@ -10,4 +10,9 @@
     <page_callback>CRM_Search_Page_Admin</page_callback>
     <access_arguments>administer CiviCRM data;administer search_kit</access_arguments>
   </item>
+  <item>
+    <path>civicrm/ajax/admin/search</path>
+    <page_callback>CRM_Search_Page_AJAX</page_callback>
+    <access_arguments>administer CiviCRM data;administer search_kit</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
Overview
----------------------------------------
This adds a live-update feature so a newly saved db entity can be used immediately without a page refresh.

Addresses this review comment: https://github.com/civicrm/civicrm-core/pull/30671#issuecomment-2289980782