### PR TITLE
Increment min recommended & recommended php versions

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -28,14 +28,14 @@ class CRM_Upgrade_Incremental_General {
    * The point release will be dropped in recommendations unless it's .1 or
    * higher.
    */
-  const RECOMMENDED_PHP_VER = '8.1.0';
+  const RECOMMENDED_PHP_VER = '8.3.0';
 
   /**
    * The minimum recommended PHP version.
    *
    * A site running an earlier version will be told to upgrade.
    */
-  const MIN_RECOMMENDED_PHP_VER = '8.0.0';
+  const MIN_RECOMMENDED_PHP_VER = '8.1.0';
 
   /**
    * The minimum PHP version required to install Civi.


### PR DESCRIPTION
Overview
----------------------------------------
Increment min recommended & recommended php versions

Before
----------------------------------------
We were not warning that php 8.0 is EOL and we are still recommending 8.1 even though we support up to 8.3 and it doesn't make sense to suggest an earlier version

After
----------------------------------------
Messages to 8.0 users, recommend 8.3

Technical Details
----------------------------------------

Comments
----------------------------------------
