### PR TITLE
dev/core#5392 Standalone - set PHP timezone as well as MySQL timezone

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -93,12 +93,11 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
           // initialized before calling applyLocale.
           $sess = \CRM_Core_Session::singleton();
           $sess->initialize();
-          if ($sess->getLoggedInContactID()) {
-            // Apply user's timezone.
-            if (is_callable([self::$_singleton->userSystem, 'setMySQLTimeZone'])) {
-              self::$_singleton->userSystem->setMySQLTimeZone();
-            }
-          }
+          // Apply timezone for this session (will use logged in user's timezone if set)
+          $sessionTime = self::$_singleton->userSystem->getTimeZoneString();
+          date_default_timezone_set($sessionTime);
+          // setMySQLTimeZone uses getTimeZoneString internally
+          self::$_singleton->userSystem->setMySQLTimeZone();
         }
         \CRM_Core_BAO_ConfigSetting::applyLocale(\Civi::settings($domain->id), $domain->locales);
 

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -515,15 +515,19 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    * @inheritDoc
    */
   public function getTimeZoneString() {
-    $timezone = date_default_timezone_get();
+    // This method is called one time in the install, before we have Standaloneusers
+    // to check timezone against
+    if (!class_exists(\Civi\Standalone\Security::class)) {
+      return date_default_timezone_get();
+    }
     $userId = Security::singleton()->getLoggedInUfID();
     if ($userId) {
       $user = Security::singleton()->loadUserByID($userId);
       if ($user && !empty($user['timezone'])) {
-        $timezone = $user['timezone'];
+        return $user['timezone'];
       }
     }
-    return $timezone;
+    return date_default_timezone_get();
   }
 
   /**


### PR DESCRIPTION
[edit: narrowing this to the immediate Standalone fix] 

Overview
----------------------------------------
This is primarily in response to https://lab.civicrm.org/dev/core/-/issues/5392

~~But it looked like Wordpress and Joomla also want to set the php and mysql timezones together - so have tried to refactor into a shared code path~~ moving to separate PR

Before
----------------------------------------
~~There are separate system functions for setting MYSQL and PHP timezones. They are called together in Wordpress and Joomla bootstrap.~~

Standalone is only setting Mysql timezone when it loads, which leads to mismatch between Mysql and PHP timezones (see issue)

After
----------------------------------------
~~New function `userSystem->setTimezone` will do both together.~~

- Standalone sets PHP timezone as well as Mysql on load 
- set the time even if we don't have a logged in user (will then use the system default, which comes from the PHP timezone)
- times show consistently and correctly in UI and Mysql for me 
- removed a check on whether `userSystem->setMySQLTimeZone` is callable - we are booting and checking our UF is Standalone just above so this should be available (if it's not I think it should fail hard rather than silently)

Technical Details/Comments
----------------------------------------
It seems a bit weird to me that we could be setting the Mysql timezone to different things in different requests, based on different user's timezones.

Looking at the other system classes, it seems like only D7 is returning a user-specific timezone from `getTimeZoneString`.

I'm wondering if it would be simpler and safer for now to have a global setting for timezone, which looks more akin to Wordpress and D8.

If anything I would have thought it would make sense to set PHP timezone to current user time, and then use that to interpret any dates from mysql data in a canonical sitewide time? Though we currently have a status check that complains if these two are different.