### PR TITLE
Unwind legacy flexmailer hack of specifying functions in a define

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -11,6 +11,7 @@
 use Civi\Api4\ActivityContact;
 use Civi\Api4\Mailing;
 use Civi\Api4\MailingJob;
+use Civi\FlexMailer\FlexMailer;
 
 /**
  *
@@ -172,7 +173,7 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
         $job->id = $result->id;
         $job->find(TRUE);
         $mailer = \Civi::service('pear_mail');
-        $isComplete = Civi\Core\Resolver::singleton()->call(CIVICRM_FLEXMAILER_HACK_DELIVER, [$job, $mailer, $testParams]);
+        $isComplete = FlexMailer::createAndRun($job, $mailer, $testParams);
       }
       elseif ($mode === 'sms') {
         $smsJob = new CRM_Mailing_BAO_SMSJob();

--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -82,10 +82,8 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
     ]);
     $enabledLanguages = CRM_Core_I18n::languages(TRUE);
     $isMultiLingual = (count($enabledLanguages) > 1);
-    // FlexMailer is a refactoring of CiviMail which provides new hooks/APIs/docs. If the sysadmin has opted to enable it, then use that instead of CiviMail.
-    $requiredTokens = defined('CIVICRM_FLEXMAILER_HACK_REQUIRED_TOKENS') ? Civi\Core\Resolver::singleton()
-      ->call(CIVICRM_FLEXMAILER_HACK_REQUIRED_TOKENS,
-        []) : CRM_Utils_Token::getRequiredTokens();
+    $requiredTokens = Civi\Core\Resolver::singleton()->call('call://civi_flexmailer_required_tokens/getRequiredTokens', []);
+
     $crmMailingSettings = [
       'templateTypes' => CRM_Mailing_BAO_Mailing::getTemplateTypes(),
       'civiMails' => [],

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -81,6 +81,7 @@ class CRM_Utils_Token {
    * @return array
    */
   public static function getRequiredTokens() {
+    CRM_Core_Error::deprecatedFunctionWarning('token processor');
     if (self::$_requiredTokens == NULL) {
       self::$_requiredTokens = [
         'domain.address' => ts("Domain address - displays your organization's postal address."),
@@ -106,8 +107,7 @@ class CRM_Utils_Token {
    *    else an array of the missing tokens
    */
   public static function requiredTokens(&$str) {
-    // FlexMailer is a refactoring of CiviMail which provides new hooks/APIs/docs. If the sysadmin has opted to enable it, then use that instead of CiviMail.
-    $requiredTokens = defined('CIVICRM_FLEXMAILER_HACK_REQUIRED_TOKENS') ? Civi\Core\Resolver::singleton()->call(CIVICRM_FLEXMAILER_HACK_REQUIRED_TOKENS, []) : CRM_Utils_Token::getRequiredTokens();
+    $requiredTokens = Civi\Core\Resolver::singleton()->call('call://civi_flexmailer_required_tokens/getRequiredTokens', []);
 
     $missing = [];
     foreach ($requiredTokens as $token => $value) {

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -41,11 +41,7 @@ function civicrm_api3_mailing_create($params) {
     && $params['scheduled_date'] !== 'null'
     // This might have been passed in as empty to prevent us validating, is set skip.
     && !isset($params['_evil_bao_validator_'])) {
-
-    // FlexMailer is a refactoring of CiviMail which provides new hooks/APIs/docs. If the sysadmin has opted to enable it, then use that instead of CiviMail.
-    $function = \CRM_Utils_Constant::value('CIVICRM_FLEXMAILER_HACK_SENDABLE', 'CRM_Mailing_BAO_Mailing::checkSendable');
-    $validationFunction = Civi\Core\Resolver::singleton()->get($function);
-    $errors = call_user_func($validationFunction, $params);
+    $errors = \Civi\FlexMailer\Validator::createAndRun($params);
     if (!empty($errors)) {
       $fields = implode(',', array_keys($errors));
       throw new CRM_Core_Exception("Mailing cannot be sent. There are missing or invalid fields ($fields).", 'cannot-send', $errors);

--- a/ext/flexmailer/flexmailer.php
+++ b/ext/flexmailer/flexmailer.php
@@ -1,15 +1,7 @@
 <?php
 
 /**
- * Civi v5.19 does not provide all the API's we would need to define
- * FlexMailer in an extension, but you can patch core to simulate them.
- * These define()s tell core to enable any such hacks (if available).
  */
-
-define('CIVICRM_FLEXMAILER_HACK_DELIVER', '\Civi\FlexMailer\FlexMailer::createAndRun');
-define('CIVICRM_FLEXMAILER_HACK_SENDABLE', '\Civi\FlexMailer\Validator::createAndRun');
-define('CIVICRM_FLEXMAILER_HACK_REQUIRED_TOKENS', 'call://civi_flexmailer_required_tokens/getRequiredTokens');
-
 require_once 'flexmailer.civix.php';
 
 use CRM_Flexmailer_ExtensionUtil as E;


### PR DESCRIPTION

Overview
----------------------------------------
Unwind legacy flexmailer hack of specifying functions in a define

These hacks allowed flexmailer to run as an optional extension but it is requried now. Ideally there would be better separation of concerns between the extension & core but this does not change that - it just makes it saner

Before
----------------------------------------
Back when Flexmailer was optional defines defined in the extension altered the function called in some cases. These days they are always defined & hence always called & the defines are just cruft

After
----------------------------------------
Functions called directly

Technical Details
----------------------------------------

Comments
----------------------------------------
