### PR TITLE
Remove unreachable code.

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1225,7 +1225,10 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
   /**
    * @deprecated
-   *   This is used by CiviMail but will be made redundant by FlexMailer.
+   *
+   * @todo - this just does an sms has-body-text check now - it would be clearer just
+   * to do this in the sms function that calls this & remove it.
+   *
    * @param CRM_Mailing_DAO_Mailing|array $mailing
    *   The mailing which may or may not be sendable.
    * @return array
@@ -1242,41 +1245,8 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       $mailing->copyValues($params);
     }
     $errors = [];
-    if ($mailing->sms_provider_id) {
-      if (empty($mailing->body_text)) {
-        $errors['body'] = ts('Field "body_text" is required.');
-      }
-    }
-    else {
-      foreach (['subject', 'name', 'from_name', 'from_email'] as $field) {
-        if (empty($mailing->{$field})) {
-          $errors[$field] = ts('Field "%1" is required.', [
-            1 => $field,
-          ]);
-        }
-      }
-      if (empty($mailing->body_html) && empty($mailing->body_text)) {
-        $errors['body'] = ts('Field "body_html" or "body_text" is required.');
-      }
-
-      if (!Civi::settings()->get('disable_mandatory_tokens_check')) {
-        $header = $mailing->header_id && $mailing->header_id !== 'null' ? CRM_Mailing_BAO_MailingComponent::findById($mailing->header_id) : NULL;
-        $footer = $mailing->footer_id && $mailing->footer_id !== 'null' ? CRM_Mailing_BAO_MailingComponent::findById($mailing->footer_id) : NULL;
-        foreach (['body_html', 'body_text'] as $field) {
-          if (empty($mailing->{$field})) {
-            continue;
-          }
-          $str = ($header ? $header->{$field} : '') . $mailing->{$field} . ($footer ? $footer->{$field} : '');
-          $err = CRM_Utils_Token::requiredTokens($str);
-          if ($err !== TRUE) {
-            foreach ($err as $token => $desc) {
-              $errors["{$field}:{$token}"] = ts('This message is missing a required token - {%1}: %2',
-                [1 => $token, 2 => $desc]
-              );
-            }
-          }
-        }
-      }
+    if (empty($mailing->body_text)) {
+      $errors['body'] = ts('Field "body_text" is required.');
     }
     return $errors;
   }

--- a/ext/flexmailer/src/Listener/Abdicator.php
+++ b/ext/flexmailer/src/Listener/Abdicator.php
@@ -65,12 +65,15 @@ class Abdicator extends AutoService {
    * @param \Civi\FlexMailer\Event\CheckSendableEvent $e
    */
   public function onCheckSendable($e) {
-    if (self::isFlexmailPreferred($e->getMailing())) {
+    $mailing = $e->getMailing();
+    if (empty($mailing->sms_provider_id)) {
       // OK, we'll continue running.
       return;
     }
 
     $e->stopPropagation();
+    // @todo - just do the one tiny sms field check here & don't call the
+    // other function.
     $errors = \CRM_Mailing_BAO_Mailing::checkSendable($e->getMailing());
     if (is_array($errors)) {
       foreach ($errors as $key => $message) {


### PR DESCRIPTION


Overview
----------------------------------------
Remove unreachable code.


This is legacy complexity being removed


Before
----------------------------------------
This code is hard to follow back but ultimately this function is only called from Flexmailer Abdicater::onCheckSendable if sms_provider_id is not empty - so all the code that does not related to the sms_provider_id is unreachable.

After
----------------------------------------
This removes that code & makes the calling function clearer / easier to trace.

Technical Details
----------------------------------------
Comments
----------------------------------------
