### PR TITLE
Tell-a-friend fixes to Manage event

### DIFF
--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -481,9 +481,6 @@ WHERE      e.id = %1
       if (!$dao->is_monetary) {
         $tabs['fee']['valid'] = FALSE;
       }
-      if (!$dao->is_active) {
-        $tabs['friend']['valid'] = FALSE;
-      }
       if (!$dao->is_pcp) {
         $tabs['pcp']['valid'] = FALSE;
       }

--- a/CRM/Event/Form/ManageEvent/TabHeader.php
+++ b/CRM/Event/Form/ManageEvent/TabHeader.php
@@ -85,10 +85,6 @@ class CRM_Event_Form_ManageEvent_TabHeader {
       $tabs['reminder'] = ['title' => ts('Schedule Reminders'), 'class' => 'livePage'] + $default;
     }
 
-    // @todo Move to hook_civicrm_tabset()
-    if (function_exists('tellafriend_civicrm_config')) {
-      $tabs['friend'] = ['title' => ts('Tell a Friend')] + $default;
-    }
     $tabs['pcp'] = ['title' => ts('Personal Campaigns')] + $default;
     $tabs['repeat'] = ['title' => ts('Repeat')] + $default;
 

--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -182,14 +182,6 @@ class CRM_Event_Page_ManageEvent extends CRM_Core_Page {
             'field' => 'reminder',
           ];
       }
-      if (!function_exists('tellafriend_civicrm_config')) {
-        self::$_tabLinks[$cacheKey]['friend']
-          = [
-            'title' => ts('Tell a Friend'),
-            'url' => 'civicrm/event/manage/friend',
-            'field' => 'friend',
-          ];
-      }
       self::$_tabLinks[$cacheKey]['pcp']
         = [
           'title' => ts('Personal Campaign Pages'),

--- a/ext/tellafriend/tellafriend.php
+++ b/ext/tellafriend/tellafriend.php
@@ -43,17 +43,19 @@ function tellafriend_civicrm_tabset($tabsetName, &$tabs, $context) {
   if (!empty($context['urlParams'])) {
     return;
   }
-  if ($tabsetName == 'civicrm/event/manage' || $tabsetName == 'civicrm/admin/contribute') {
+  if ($tabsetName === 'civicrm/event/manage' || $tabsetName === 'civicrm/admin/contribute') {
     $default = [
       'link' => NULL,
-      'valid' => FALSE,
-      'active' => FALSE,
+      'valid' => TRUE,
+      'active' => TRUE,
       'current' => FALSE,
       'class' => FALSE,
       'extra' => FALSE,
       'template' => FALSE,
       'count' => FALSE,
       'icon' => FALSE,
+      'url' => $tabsetName === 'civicrm/event/manage' ? 'civicrm/event/manage/friend' : '',
+      'field' => 'friend',
     ];
     $tabs['friend'] = ['title' => ts('Tell a Friend')] + $default;
   }


### PR DESCRIPTION
Overview
----------------------------------------
I found that with the extension disabled there were notices & then when I enabled it the tab was broken - this works for me in terms of manage event & manage contribution seemed unchanged by this PR in local testing

Before
----------------------------------------
With the extension enabled

![image](https://github.com/user-attachments/assets/da267017-4267-4818-9ff9-fb15250729a0)

![image](https://github.com/user-attachments/assets/f1fb4b4d-0457-4203-bcf5-5e0e97bdaf22)

and disabled

![image](https://github.com/user-attachments/assets/e083faec-edda-4269-9d87-64cc6e416fab)
![image](https://github.com/user-attachments/assets/d8a1c126-d631-414e-9fc7-3c57e0c72657)


After
----------------------------------------
![image](https://github.com/user-attachments/assets/e9c4de0f-ab8c-49b9-bb08-714738d7399b)

And disabled

![image](https://github.com/user-attachments/assets/af28bc91-c985-4b22-92df-d89891fd5885)


Technical Details
----------------------------------------

Comments
----------------------------------------
