### PR TITLE
[REF] CRM_Utils_System timezone setting refactor / cleanup

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -749,16 +749,40 @@ abstract class CRM_Utils_System_Base {
   }
 
   /**
-   * Set timezone in mysql so that timestamp fields show the correct time.
+   * Set MySQL timezone so that timestamp fields show the correct time.
+   *
+   * @param ?string $timeZone
+   *    Timezone string - if none provided will be fetched from system
    */
-  public function setMySQLTimeZone() {
-    $timeZoneOffset = $this->getTimeZoneOffset();
+  public function setMySQLTimeZone(?string $timeZone = NULL) {
+    $timeZone = $timeZone ?? $this->getTimeZoneString();
+    $timeZoneOffset = \CRM_Utils_Time::getTimeZoneOffsetFromString($timeZone);
     if ($timeZoneOffset) {
       $sql = "SET time_zone = '$timeZoneOffset'";
       CRM_Core_DAO::executeQuery($sql);
     }
   }
 
+  /**
+   * Set PHP timezone
+   *
+   * @param ?string $timeZone
+   *    Timezone string - if none provided will be fetched from system
+   */
+  public function setPhpTimeZone(?string $timeZone = NULL) {
+    $timeZone = $timeZone ?? $this->getTimeZoneString();
+    date_default_timezone_set($timeZone);
+  }
+
+  /**
+   * Set system timezone (both PHP + MySQL)
+   */
+  public function setTimeZone(?string $timeZone = NULL) {
+    $timeZone = $timeZone ?? $this->getTimeZoneString();
+
+    $this->setPhpTimeZone($timeZone);
+    $this->setMySQLTimeZone($timeZone);
+  }
 
   /**
    * Get timezone from CMS as a string.

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -759,48 +759,23 @@ abstract class CRM_Utils_System_Base {
     }
   }
 
-  /**
-   * Get timezone from CMS.
-   *
-   * @return string|false|null
-   */
-  public function getTimeZoneOffset() {
-    $timezone = $this->getTimeZoneString();
-    if ($timezone) {
-      if ($timezone == 'UTC' || $timezone == 'Etc/UTC') {
-        // CRM-17072 Let's short-circuit all the zero handling & return it here!
-        return '+00:00';
-      }
-      $tzObj = new DateTimeZone($timezone);
-      $dateTime = new DateTime("now", $tzObj);
-      $tz = $tzObj->getOffset($dateTime);
-
-      if ($tz === 0) {
-        // CRM-21422
-        return '+00:00';
-      }
-
-      if (empty($tz)) {
-        return FALSE;
-      }
-
-      $timeZoneOffset = sprintf("%02d:%02d", $tz / 3600, abs(($tz / 60) % 60));
-
-      if ($timeZoneOffset > 0) {
-        $timeZoneOffset = '+' . $timeZoneOffset;
-      }
-      return $timeZoneOffset;
-    }
-    return NULL;
-  }
 
   /**
-   * Get timezone as a string.
+   * Get timezone from CMS as a string.
    * @return string
    *   Timezone string e.g. 'America/Los_Angeles'
    */
   public function getTimeZoneString() {
     return date_default_timezone_get();
+  }
+
+  /**
+   * Get timezone offset from CMS
+   *
+   * @return string|false|null
+   */
+  public function getTimeZoneOffset() {
+    return \CRM_Utils_Time::getTimeZoneOffsetFromString($this->getTimeZoneString());
   }
 
   /**

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -651,8 +651,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     $config = JFactory::getConfig();
     $timezone = $config->get('offset');
     if ($timezone) {
-      date_default_timezone_set($timezone);
-      CRM_Core_Config::singleton()->userSystem->setMySQLTimeZone();
+      $this->setTimeZone($timezone);
     }
     if (version_compare(JVERSION, '4.0', '>=')) {
       // Boot the DI container

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -620,9 +620,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
     // to use a fake session instead for this install bit.
     // Maybe they could get moved up here
     if (class_exists(\Civi\Standalone\Security::class)) {
-      $sessionTime = $this->getTimeZoneString();
-      date_default_timezone_set($sessionTime);
-      $this->setMySQLTimeZone();
+      $this->setTimeZone();
     }
   }
 

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -728,8 +728,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     // Match CiviCRM timezone to WordPress site timezone.
     $wpSiteTimezone = $this->getTimeZoneString();
     if ($wpSiteTimezone) {
-      date_default_timezone_set($wpSiteTimezone);
-      CRM_Core_Config::singleton()->userSystem->setMySQLTimeZone();
+      $this->setTimeZone($wpSiteTimezone);
     }
 
     // Make sure pluggable WordPress functions are available.

--- a/CRM/Utils/Time.php
+++ b/CRM/Utils/Time.php
@@ -200,4 +200,38 @@ class CRM_Utils_Time {
     return (abs($diff) <= $threshold);
   }
 
+  /**
+   * Get timezone offset from a timezone string
+   *
+   * @return string|false|null
+   */
+  public static function getTimeZoneOffsetFromString(string $timezone) {
+    if ($timezone) {
+      if ($timezone == 'UTC' || $timezone == 'Etc/UTC') {
+        // CRM-17072 Let's short-circuit all the zero handling & return it here!
+        return '+00:00';
+      }
+      $tzObj = new DateTimeZone($timezone);
+      $dateTime = new DateTime("now", $tzObj);
+      $tz = $tzObj->getOffset($dateTime);
+
+      if ($tz === 0) {
+        // CRM-21422
+        return '+00:00';
+      }
+
+      if (empty($tz)) {
+        return FALSE;
+      }
+
+      $timeZoneOffset = sprintf("%02d:%02d", $tz / 3600, abs(($tz / 60) % 60));
+
+      if ($timeZoneOffset > 0) {
+        $timeZoneOffset = '+' . $timeZoneOffset;
+      }
+      return $timeZoneOffset;
+    }
+    return NULL;
+  }
+
 }


### PR DESCRIPTION
Note: based on https://github.com/civicrm/civicrm-core/pull/30901 - should be NFC after that is merged.

Overview
----------------------------------------
- Use a common code path to set PHP and MySQL timezones together. 
- Move timezone string => offset conversion out of the System class, to a Util function


Comments
----------------------------------------
We have a system check that complains if these two things are different, so it makes sense that if you're setting one you should set the other.