### PR TITLE
Drop binding current domain settings bag to CRM_Core_Config on boot

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -103,9 +103,6 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
         ]);
         self::$_singleton->authenticate();
 
-        // Extreme backward compat: $config binds to active domain at moment of setup.
-        self::$_singleton->getSettings();
-
         self::$_singleton->handleFirstRun();
       }
     }


### PR DESCRIPTION
Curiosity will probably cause some failed tests.

But this was ["extremely backward" 9 years ago](https://github.com/civicrm/civicrm-core/commit/23bb9c85dfd571bf91309ece5c02dc16c8b709cb#diff-dc1c0506257784ef60b0b3f296a5e64c633c0a19d47dbd87885eb21852836fd6), so I couldn't help myself... 