### PR TITLE
Refactor Standalone-specific steps in CRM_Core_Config into a userSystem function

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -84,21 +84,13 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
       $errorScope = CRM_Core_TemporaryErrorScope::create(['CRM_Core_Error', 'simpleHandler']);
 
       self::$_singleton = new CRM_Core_Config();
+
       \Civi\Core\Container::boot($loadFromDB);
+
       if ($loadFromDB && self::$_singleton->dsn) {
+        self::$_singleton->userSystem->postContainerBoot();
+
         $domain = \CRM_Core_BAO_Domain::getDomain();
-        if (CIVICRM_UF === 'Standalone') {
-          // Standalone's session cannot be initialized until CiviCRM is booted,
-          // since it is defined in an extension, and we need the session
-          // initialized before calling applyLocale.
-          $sess = \CRM_Core_Session::singleton();
-          $sess->initialize();
-          // Apply timezone for this session (will use logged in user's timezone if set)
-          $sessionTime = self::$_singleton->userSystem->getTimeZoneString();
-          date_default_timezone_set($sessionTime);
-          // setMySQLTimeZone uses getTimeZoneString internally
-          self::$_singleton->userSystem->setMySQLTimeZone();
-        }
         \CRM_Core_BAO_ConfigSetting::applyLocale(\Civi::settings($domain->id), $domain->locales);
 
         unset($errorScope);

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1250,4 +1250,11 @@ abstract class CRM_Utils_System_Base {
     return $profile;
   }
 
+  /**
+   * Hook for further system boot once the main CiviCRM
+   * Container is up (only used in Standalone currently)
+   */
+  public function postContainerBoot(): void {
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Based on top of changes in https://github.com/civicrm/civicrm-core/pull/30887 - that should be merged first.

@demeritcowboy suggested the if (CIVICRM_UF === 'Standalone') check might be necessary because of being very early boot. But I think it _should_ be possible to use a userSystem method after the `\Civi\Core\Container::boot` call

Before
----------------------------------------
- an if (CIVICRM_UF === 'Standalone') block in the middle of CRM_Core_Config

After
----------------------------------------
- a call to a new userSystem function `postContainerBoot` which is empty in the base, and implemented in Standalone

Technical Details
----------------------------------------
I've moved the call above `getDomain` because I don't think one relies on the other. :crossed_fingers: 

Comments
----------------------------------------
I toyed with whether it belongs outside of the `if ($loadFromDB .. ` bit - or should be passed the value of the conditional as a $doWeHaveTheDB - but thought keep it simple for now.

It feels a lot neater than having multiple `self::$_singleton->userSystem->x` calls inside a block where you know what the user system is.

My local Standalone system seems to run fine through UI and a few `cv` calls. Install also works fine.