### PR TITLE
dev/core#5389 : Line total displayed incorrectly in GST receipts

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -980,8 +980,6 @@ class CRM_Financial_BAO_Order {
       // requires it for line retrieval but we want to fix that as it
       // should not be required at that point.
       $this->setPriceSetIDFromSelectedField($lineItem['price_field_id']);
-      // Set any pre-calculation to zero as we will calculate.
-      $lineItem['tax_amount'] = 0;
       if ($this->isOverrideLineItemFinancialType($lineItem['financial_type_id']) !== FALSE) {
         $lineItem['financial_type_id'] = $this->getOverrideFinancialTypeID();
       }
@@ -990,7 +988,7 @@ class CRM_Financial_BAO_Order {
         $this->addTotalsToLineBasedOnOverrideTotal((int) $lineItem['financial_type_id'], $lineItem);
       }
       elseif ($taxRate) {
-        $lineItem['tax_amount'] = ($taxRate / 100) * $lineItem['line_total'];
+        $lineItem['tax_amount'] = $lineItem['tax_amount'] ?? (($taxRate / 100) * $lineItem['line_total']);
       }
       $lineItem['membership_type_id'] ??= NULL;
       if ($lineItem['membership_type_id']) {
@@ -1014,9 +1012,9 @@ class CRM_Financial_BAO_Order {
 
       }
       elseif ($taxRate) {
-        $lineItem['tax_amount'] = ($taxRate / 100) * $lineItem['line_total'];
+        $lineItem['tax_amount'] = $lineItem['tax_amount'] ?? (($taxRate / 100) * $lineItem['line_total']);
       }
-      $lineItem['line_total_inclusive'] = $lineItem['line_total_inclusive'] ?? ($lineItem['line_total'] + $lineItem['tax_amount']);
+      $lineItem['line_total_inclusive'] = $lineItem['line_total_inclusive'] ?? ($lineItem['line_total'] + ($lineItem['tax_amount'] ?? 0));
     }
     return $lineItems;
   }


### PR DESCRIPTION
Overview
----------------------------------------
To replicate

- Enable Tax and create FT to add 15% GST on the amount.
- Create a membership type using the above FT and set the Minimum Fee = `169.565217391`, so that after 15% GST - the total amount is calculated as $195
- Visit a contact and add a membership with above type.
- Navigate to Contribution tab.
- Download a pdf receipt for this contribution, the value for `{$line.line_total_inclusive|crmMoney:'{contribution.currency}'}` incorrectly displays an additional .01 in the receipt.

Before
----------------------------------------
[before.pdf](https://github.com/user-attachments/files/16639439/before.pdf)


After
----------------------------------------
[latest.pdf](https://github.com/user-attachments/files/16639441/latest.pdf)


Technical Details
----------------------------------------
I went with the first suggestion in the ticket description `Skip the recalculation if tax_amount is already present?` 


ping @eileenmcnaughton @jitendrapurohit @JoeMurray 