### PR TITLE
distmaker - Rename root-folder for civicrm-X.Y.Z-standalone.tar.gz

### DIFF
--- a/distmaker/dists/standalone.sh
+++ b/distmaker/dists/standalone.sh
@@ -11,22 +11,22 @@ else
 fi
 . "$P/common.sh"
 
-SRC=$DM_SOURCEDIR
-TRG=$DM_TMPDIR/civicrm
+SRC="$DM_SOURCEDIR"
+TRG="$DM_TMPDIR/civicrm-standalone"
 
 # copy all the stuff
-dm_reset_dirs "$TRG" "$TRG/civicrm/web/core"
-dm_install_core "$SRC" "$TRG/civicrm/web/core"
-dm_install_coreext "$SRC" "$TRG/civicrm/web/core" $(dm_core_exts)
-dm_install_packages "$SRC/packages" "$TRG/civicrm/web/core/packages"
-dm_install_vendor "$SRC/vendor" "$TRG/civicrm/web/core/vendor"
-dm_install_bower "$SRC/bower_components" "$TRG/civicrm/web/core/bower_components"
-dm_install_cvext com.iatspayments.civicrm "$TRG/civicrm/web/core/ext/iatspayments"
-$SRC/tools/standalone/bin/scaffold $TRG/civicrm/web
+dm_reset_dirs "$TRG" "$TRG/core"
+dm_install_core "$SRC" "$TRG/core"
+dm_install_coreext "$SRC" "$TRG/core" $(dm_core_exts)
+dm_install_packages "$SRC/packages" "$TRG/core/packages"
+dm_install_vendor "$SRC/vendor" "$TRG/core/vendor"
+dm_install_bower "$SRC/bower_components" "$TRG/core/bower_components"
+dm_install_cvext com.iatspayments.civicrm "$TRG/core/ext/iatspayments"
+"$SRC/tools/standalone/bin/scaffold" "$TRG"
 
 # gen tarball
-cd $TRG/civicrm
-tar czf $DM_TARGETDIR/civicrm-$DM_VERSION-standalone.tar.gz web
+cd "$DM_TMPDIR"
+tar czf "$DM_TARGETDIR/civicrm-$DM_VERSION-standalone.tar.gz" civicrm-standalone
 
 # clean up
 rm -rf $TRG


### PR DESCRIPTION
Overview
----------------------------------------

Update the structure within `civicrm-X.Y.Z-standalone.tar.gz` to be less surprising. Follow-up to #30835 (cc @ufundo @michaelmcandrew).

Before
----------------------------------------

When you extract the tarball, it creates a folder named `./web`.

```bash
tar xzf civicrm-X.Y.Z-standalone.tar.gz
ls ./web
```
```
civicrm.standalone.php  core  ext  index.php  private  public
```

After
----------------------------------------

When you extract the tarball, it creates a folder named `./civicrm-standalone`.

```bash
tar xzf civicrm-X.Y.Z-standalone.tar.gz
ls ./civicrm-standalone
```
```
civicrm.standalone.php  core  ext  index.php  private  public
```


Comments
----------------------------------------

I ran distmaker locally before+after patch. Confirmed that the contents are the same (only the base folder changes):

```
[php82:/tmp]$ tar xzf BEFORE-civicrm-5.78.alpha1-standalone.tar.gz 
[php82:/tmp]$ tar xzf AFTER-civicrm-5.78.alpha1-standalone.tar.gz 
[php82:/tmp]$ diff -ru web civicrm-standalone

[php82:/tmp]$ 
```

Additionally, flagging the PR as `run-distmaker` so civibot will do its own trial run of `distmaker`.

I know we little discussion of pro/con for different names (`./civicrm` vs `./civicrm-standalone`). All options are each reasonable, with different leans. I'm breaking the tie in favor of `civicrm-standalone`...