### PR TITLE
distmaker - My eyes! My eyes are bleeding! Make it stop!

### DIFF
--- a/distmaker/distmaker.sh
+++ b/distmaker/distmaker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -v
+#!/usr/bin/env bash
 set -e
 
 # This is distmaker script for CiviCRM

--- a/distmaker/distmaker.sh
+++ b/distmaker/distmaker.sh
@@ -93,7 +93,7 @@ check_conf()
 
   if [ -z $DM_SOURCEDIR ] ; then
     DM_SOURCEDIR="$THIS_DIR/..";
-    echo "Setting source dir to $DM_SOURCEDIR";
+    dm_note "Setting source dir to $DM_SOURCEDIR";
   fi
 
   if [ -z $DM_TMPDIR ] && [ -e $TMPDIR ] ; then
@@ -149,67 +149,67 @@ check_conf
 case $1 in
   # L10N PHP5
   l10n)
-  echo; echo "Generating L10N module"; echo;
+  dm_note "Enable CiviCRM L10N"
   L10NPACK=1
   ;;
 
   # BACKDROP PHP5
   Backdrop)
-  echo; echo "Generating Backdrop PHP5 module"; echo;
+  dm_note "Enable CiviCRM-Backdrop"
   BPACK=1
   ;;
 
   # DRUPAL7 PHP5
   d5|Drupal)
-  echo; echo "Generating Drupal7 PHP5 module"; echo;
+  dm_note "Enable CiviCRM-Drupal 7"
   D5PACK=1
   ;;
 
   # Drupal 7 - Output to directory
   d7_dir)
-  echo; echo "Generating Drupal7 Directory"; echo;
+  dm_note "Enable CiviCRM-Drupal 7 (directory)"
   D7DIR=1
   ;;
 
   # DRUPAL7 PHP5 StarterKit package
   sk)
-  echo; echo "Generating Drupal7 PHP5 starter kit minimal module"; echo;
+  dm_note "Enable CiviCRM-Drupal 7 (StarterKit version)"
   SKPACK=1
   ;;
 
   # JOOMLA PHP5
   j5|Joomla)
-  echo; echo "Generating Joomla PHP5 module"; echo;
+  dm_note "Enable CiviCRM-Joomla"
   J5PACK=1
   ;;
 
   # WORDPRESS PHP5
   wp5|WordPress)
-  echo; echo "Generating Wordpress PHP5 module"; echo;
+  dm_note "Enable CiviCRM-Wordpress"
   WP5PACK=1
   ;;
 
   # STANDALONE
   standalone|Standalone)
-  echo; echo "Generating CiviCRM Standalone"; echo;
+  dm_note "Enable CiviCRM (Standalone)"
   STANDALONEPACK=1
   ;;
 
   ## PATCHSET export
   patchset)
-  echo; echo "Generating patchset"; echo;
+  dm_note "Enable CiviCRM (Patchset)"
   PATCHPACK=1
   ;;
 
   # REPO REPORT PHP5
   report)
-  echo; echo "Generating repo report module"; echo;
+  dm_note "Enable repo report"
   REPOREPORT=1
   ;;
 
   # ALL
   all)
-  echo; echo "Generating all the tarballs we've got (not the directories). "; echo;
+  dm_note "Enable all the tarballs we've got (not the directories). "
   BPACK=1
   D5PACK=1
   J5PACK=1
@@ -229,6 +229,7 @@ case $1 in
 
 esac
 
+dm_title "Update source"
 ## Make sure we have the right branch or tag
 dm_git_checkout "$DM_SOURCEDIR" "$DM_REF_CORE"
 dm_git_checkout "$DM_PACKAGESDIR" "$DM_REF_PACKAGES"
@@ -257,58 +258,58 @@ fi
 cd $ORIGPWD
 
 if [ "$L10NPACK" = 1 ]; then
-  echo; echo "Packaging for L10N"; echo;
+  dm_title "Build CiviCRM-L10N"
   bash $P/dists/l10n.sh
 fi
 
 if [ "$BPACK" = 1 ]; then
-  echo; echo "Packaging for Backdrop, PHP5 version"; echo;
+  dm_title "Build CiviCRM-Backdrop"
   dm_git_checkout "$DM_SOURCEDIR/backdrop" "$DM_REF_BACKDROP"
   bash $P/dists/backdrop_php5.sh
 fi
 
 if [ "$D5PACK" = 1 ]; then
-  echo; echo "Packaging for Drupal7, PHP5 version"; echo;
+  dm_title "Build CiviCRM-Drupal 7"
   dm_git_checkout "$DM_SOURCEDIR/drupal" "$DM_REF_DRUPAL"
   bash $P/dists/drupal_php5.sh
 fi
 
 if [ "$D7DIR" = 1 ]; then
-  echo; echo "Packaging for Drupal7, Directory not tarball, PHP5 version"; echo;
+  dm_title "Build CiviCRM-Drupal 7 (directory)"
   dm_git_checkout "$DM_SOURCEDIR/drupal" "$DM_REF_DRUPAL"
   bash $P/dists/drupal7_dir_php5.sh
 fi
 
 if [ "$SKPACK" = 1 ]; then
-  echo; echo "Packaging for Drupal7, PHP5 StarterKit version"; echo;
+  dm_title "Build CiviCRM-Drupal 7 (StarterKit version)"
   dm_git_checkout "$DM_SOURCEDIR/drupal" "$DM_REF_DRUPAL"
   bash $P/dists/drupal_sk_php5.sh
 fi
 
 if [ "$J5PACK" = 1 ]; then
-  echo; echo "Packaging for Joomla, PHP5 version"; echo;
+  dm_title "Build CiviCRM-Joomla"
   dm_git_checkout "$DM_SOURCEDIR/joomla" "$DM_REF_JOOMLA"
   bash $P/dists/joomla_php5.sh
 fi
 
 if [ "$WP5PACK" = 1 ]; then
-  echo; echo "Packaging for Wordpress, PHP5 version"; echo;
+  dm_title "Build CiviCRM-Wordpress"
   dm_git_checkout "$DM_SOURCEDIR/WordPress" "$DM_REF_WORDPRESS"
   bash $P/dists/wordpress_php5.sh
 fi
 
 if [ "$STANDALONEPACK" = 1 ]; then
-  echo; echo "Packaging for CiviCRM Standalone"; echo;
+  dm_title "Build CiviCRM (Standalone)"
   bash $P/dists/standalone.sh
 fi
 
 if [ "$PATCHPACK" = 1 ]; then
-  echo; echo "Packaging for patchset tarball"; echo;
+  dm_title "Build CiviCRM (Patchset)"
   bash $P/dists/patchset.sh
 fi
 
 if [ "$REPOREPORT" = 1 ]; then
-  echo; echo "Preparing repository report"; echo;
+  dm_title "Prepare repository report"
   env \
     L10NPACK="$L10NPACK" \
     BPACK="$BPACK" \
@@ -322,4 +323,4 @@ if [ "$REPOREPORT" = 1 ]; then
 fi
 
 unset DM_SOURCEDIR DM_GENFILESDIR DM_TARGETDIR DM_TMPDIR DM_PHP DM_RSYNC DM_VERSION DM_ZIP
-echo;echo "DISTMAKER Done.";echo;
+dm_title "DISTMAKER Done."

--- a/distmaker/dists/backdrop_php5.sh
+++ b/distmaker/dists/backdrop_php5.sh
@@ -14,7 +14,7 @@ fi
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
 
-# copy all the stuff
+dm_h1 "Prepare files (civicrm-*-backdrop.tar.gz)"
 dm_reset_dirs "$TRG"
 cp $SRC/backdrop/civicrm.config.php.backdrop $TRG/civicrm.config.php
 dm_generate_version "$TRG/civicrm-version.php" Backdrop
@@ -26,10 +26,10 @@ dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_drupal "$SRC/backdrop" "$TRG/backdrop"
 dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
 
-# gen tarball
+dm_h1 "Generate archive (civicrm-*-backdrop.tar.gz)"
 cd $TRG/..
 dm_assert_no_symlinks civicrm
 tar czf $DM_TARGETDIR/civicrm-$DM_VERSION-backdrop.tar.gz civicrm
 
-# clean up
+dm_h1 "Clean up"
 rm -rf $TRG

--- a/distmaker/dists/backdrop_php5.sh
+++ b/distmaker/dists/backdrop_php5.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 P=`dirname $0`
 CFFILE=$P/../distmaker.conf

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -1,8 +1,23 @@
 #!/bin/bash
 
+function dm_h1() {
+  echo
+  echo "# $@"
+}
+
+function dm_h2() {
+  echo
+  echo "## $@"
+}
+
+function dm_note() {
+  echo "### $@"
+}
+
 ## Delete/create a dir
 ## usage: dm_reset_dirs <path1> <path2> ...
 function dm_reset_dirs() {
+  dm_h2 "dm_reset_dirs: $@"
   for d in "$@" ; do
     [ -d "$d" ] && rm -rf "$d"
   done
@@ -30,6 +45,8 @@ function dm_assert_no_symlinks() {
 ## Copy files from one dir into another dir
 ## usage: dm_install_dir <from-dir> <to-dir>
 function dm_install_dir() {
+  dm_note "dm_install_dir: $@"
+
   local from="$1"
   local to="$2"
 
@@ -42,6 +59,8 @@ function dm_install_dir() {
 ## Copy listed files
 ## usage: dm_install_files <from-dir> <to-dir> <file1> <file2>...
 function dm_install_files() {
+  dm_note "dm_install_files: $@"
+
   local from="$1"
   shift
   local to="$1"
@@ -54,6 +73,7 @@ function dm_install_files() {
 
 ## usage: dm_remove_files <directory> <file1> <file2>...
 function dm_remove_files() {
+  dm_note "dm_remove_files: $@"
   local tgt="$1"
   shift
 
@@ -64,6 +84,8 @@ function dm_remove_files() {
 
 ## Copy all bower dependencies
 function dm_install_bower() {
+  dm_h2 "dm_install_bower: $@"
+
   local repo="$1"
   local to="$2"
 
@@ -79,6 +101,8 @@ function dm_install_bower() {
 ## Copy all core files
 ## usage: dm_install_core <core_repo_path> <to_path>
 function dm_install_core() {
+  dm_h2 "dm_install_core: $@"
+
   local repo="$1"
   local to="$2"
 
@@ -110,6 +134,8 @@ function dm_install_core() {
 ## Copy built-in extensions
 ## usage: dm_install_core <core_repo_path> <to_path> <ext-dirs...>
 function dm_install_coreext() {
+  dm_h2 "dm_install_coreext: $@"
+
   local repo="$1"
   local to="$2"
   shift
@@ -130,6 +156,8 @@ function dm_core_exts() {
 ## Copy all packages
 ## usage: dm_install_packages <packages_repo_path> <to_path>
 function dm_install_packages() {
+  dm_h2 "dm_install_packages: $@"
+
   local repo="$1"
   local to="$2"
 
@@ -150,6 +178,8 @@ function dm_install_packages() {
 ## Copy Drupal-integration module
 ## usage: dm_install_drupal <drupal_repo_path> <to_path>
 function dm_install_drupal() {
+  dm_h2 "dm_install_drupal: $@"
+
   local repo="$1"
   local to="$2"
   dm_install_dir "$repo" "$to"
@@ -170,6 +200,8 @@ function dm_install_drupal() {
 ## Copy Joomla-integration module
 ## usage: dm_install_joomla <joomla_repo_path> <to_path>
 function dm_install_joomla() {
+  dm_h2 "dm_install_joomla: $@"
+
   local repo="$1"
   local to="$2"
   dm_install_dir "$repo" "$to"
@@ -188,6 +220,8 @@ function dm_install_joomla() {
 
 ## usage: dm_install_l10n <l10n_repo_path> <to_path>
 function dm_install_l10n() {
+  dm_h2 "dm_install_l10n: $@"
+
   local repo="$1"
   local to="$2"
   dm_install_dir "$repo" "$to"
@@ -196,6 +230,8 @@ function dm_install_l10n() {
 ## Copy composer's "vendor" folder
 ## usage: dm_install_vendor <from_path> <to_path>
 function dm_install_vendor() {
+  dm_h2 "dm_install_vendor: $@"
+
   local repo="$1"
   local to="$2"
 
@@ -213,6 +249,8 @@ function dm_install_vendor() {
 
 ##  usage: dm_install_wordpress <wp_repo_path> <to_path>
 function dm_install_wordpress() {
+  dm_h2 "dm_install_wordpress: $@"
+
   local repo="$1"
   local to="$2"
 
@@ -236,6 +274,8 @@ function dm_install_wordpress() {
 ## Generate the composer "vendor" folder
 ## usage: dm_generate_vendor <repo_path>
 function dm_generate_vendor() {
+  dm_h2 "dm_generate_vendor: $@"
+
   local repo="$1"
   pushd "$repo"
     ${DM_COMPOSER:-composer} install
@@ -245,6 +285,8 @@ function dm_generate_vendor() {
 ## Generate civicrm-version.php
 ## usage: dm_generate_version <file> <ufname>
 function dm_generate_version() {
+  dm_h2 "dm_generate_version: $@"
+
   local to="$1"
   local ufname="$2"
 
@@ -266,6 +308,7 @@ function dm_git_checkout() {
     echo "Skip git checkout ($1 => $2)"
     return
   fi
+  dm_note "dm_git_checkout: $@"
   pushd "$1"
     git checkout .
     git checkout "$2"
@@ -278,6 +321,7 @@ function dm_install_cvext() {
   if [ -n "$DM_SKIP_EXT" ]; then
     return
   fi
+  dm_h2 "dm_install_cvext: $@"
   # cv dl -b '@https://civicrm.org/extdir/ver=4.7.25|cms=Drupal/com.iatspayments.civicrm.xml' --destination=$PWD/iatspayments
   cv dl -b "@https://civicrm.org/extdir/ver=$DM_VERSION|cms=Drupal/$1.xml" --to="$2"
 }
@@ -302,6 +346,7 @@ function dm_export_patches() {
 ## usage: dm_preg_edit <search-pattern> <replacement-pattern> <file>
 ## example: '/version = \([0-9]*\.x-\)[1-9.]*/' 'version = \1$DM_VERSION'
 function dm_preg_edit() {
+  dm_note "dm_preg_edit: $3"
   env RPAT="$1" RREPL="$2" RFILE="$3" \
     php -r '$c = file_get_contents(getenv("RFILE")); $c = preg_replace(getenv("RPAT"), getenv("RREPL"), $c); file_put_contents(getenv("RFILE"), $c);'
 }

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+function dm_title() {
+  echo
+  echo "====[[ $@ ]]===="
+  echo
+}
+
 function dm_h1() {
   echo
   echo "# $@"

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -350,3 +350,9 @@ function dm_preg_edit() {
   env RPAT="$1" RREPL="$2" RFILE="$3" \
     php -r '$c = file_get_contents(getenv("RFILE")); $c = preg_replace(getenv("RPAT"), getenv("RREPL"), $c); file_put_contents(getenv("RFILE"), $c);'
 }
+
+## Wrapper for 'zip' cli
+function dm_zip() {
+  dm_note "dm_zip: $@"
+  ${DM_ZIP:-zip} -q -r -9 "$@"
+}

--- a/distmaker/dists/drupal7_dir_php5.sh
+++ b/distmaker/dists/drupal7_dir_php5.sh
@@ -21,7 +21,7 @@ if [ -z $DM_DRUPALDIR ] ; then
   DM_DRUPALDIR="$SRC/drupal"
 fi
 
-# copy all the stuff
+dm_h1 "Prepare files (civicrm-*-drupal dir)"
 dm_reset_dirs "$TRG"
 cp $DM_DRUPALDIR/civicrm.config.php.drupal $TRG/civicrm.config.php
 dm_generate_version "$TRG/civicrm-version.php" Drupal
@@ -33,10 +33,10 @@ dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_drupal "$DM_DRUPALDIR" "$TRG/drupal"
 dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
 
-# gen tarball
+dm_h1 "Generate archive (civicrm-*-drupal dir)"
 cd $TRG
 rm -r $DM_OUTPUTDIR/*
 mv * $DM_OUTPUTDIR
 
-# clean up
+dm_h1 "Clean up"
 rm -rf $TRG

--- a/distmaker/dists/drupal7_dir_php5.sh
+++ b/distmaker/dists/drupal7_dir_php5.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 P=`dirname $0`
 CFFILE=$P/../distmaker.conf

--- a/distmaker/dists/drupal_php5.sh
+++ b/distmaker/dists/drupal_php5.sh
@@ -14,7 +14,7 @@ fi
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
 
-# copy all the stuff
+dm_h1 "Prepare files (civicrm-*-drupal.tar.gz)"
 dm_reset_dirs "$TRG"
 cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php
 dm_generate_version "$TRG/civicrm-version.php" Drupal
@@ -26,10 +26,10 @@ dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_drupal "$SRC/drupal" "$TRG/drupal"
 dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
 
-# gen tarball
+dm_h1 "Generate archive (civicrm-*-drupal.tar.gz)"
 cd $TRG/..
 dm_assert_no_symlinks civicrm
 tar czf $DM_TARGETDIR/civicrm-$DM_VERSION-drupal.tar.gz civicrm
 
-# clean up
+dm_h1 "Cleanup"
 rm -rf $TRG

--- a/distmaker/dists/drupal_php5.sh
+++ b/distmaker/dists/drupal_php5.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 P=`dirname $0`
 CFFILE=$P/../distmaker.conf

--- a/distmaker/dists/drupal_sk_php5.sh
+++ b/distmaker/dists/drupal_sk_php5.sh
@@ -14,7 +14,7 @@ fi
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
 
-# copy all the stuff
+dm_h1 "Prepare files (civicrm-*-starterkit.tgz)"
 dm_reset_dirs "$TRG"
 cp $SRC/drupal/civicrm.config.php.drupal $TRG/civicrm.config.php
 dm_generate_version "$TRG/civicrm-version.php" Drupal
@@ -26,6 +26,7 @@ dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_drupal "$SRC/drupal" "$TRG/drupal"
 dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
 
+dm_h1 "Prune packages"
 # delete packages that distributions on Drupal.org repalce if present
 # also delete stuff that we dont really use and should not be included
 rm -rf $TRG/packages/dompdf
@@ -34,10 +35,10 @@ rm -rf $TRG/packages/jquery
 rm -rf $TRG/packages/ckeditor
 rm -rf $TRG/packages/tinymce
 
-# gen tarball
+dm_h1 "Generate archive (civicrm-*-starterkit.tgz)"
 cd $TRG/..
 dm_assert_no_symlinks civicrm
 tar czf $DM_TARGETDIR/civicrm-$DM_VERSION-starterkit.tgz civicrm
 
-# clean up
+dm_h1 "Clean up"
 rm -rf $TRG

--- a/distmaker/dists/drupal_sk_php5.sh
+++ b/distmaker/dists/drupal_sk_php5.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 P=`dirname $0`
 CFFILE=$P/../distmaker.conf

--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -14,7 +14,7 @@ fi
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
 
-# copy all the rest of the stuff
+dm_h1 "Prepare files (civicrm-*-joomla.zip)"
 dm_reset_dirs "$TRG" "$DM_TMPDIR/com_civicrm"
 cp $SRC/civicrm.config.php $TRG
 dm_generate_version "$TRG/civicrm-version.php" Joomla

--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -40,14 +40,14 @@ cd $DM_TMPDIR;
 if [ -z "$DM_SKIP_ALT" ]; then
   cp -R -p civicrm com_civicrm/admin/civicrm
   ${DM_PHP:-php} $DM_SOURCEDIR/distmaker/utils/joomlaxml.php $DM_SOURCEDIR com_civicrm $DM_VERSION alt
-  ${DM_ZIP:-zip} -q -r -9 $DM_TARGETDIR/civicrm-$DM_VERSION-joomla-alt.zip com_civicrm
+  dm_zip $DM_TARGETDIR/civicrm-$DM_VERSION-joomla-alt.zip com_civicrm
   rm -rf com_civicrm/admin/civicrm
 fi
 
 # generate zip version of civicrm.xml
 ${DM_PHP:-php} $DM_SOURCEDIR/distmaker/utils/joomlaxml.php $DM_SOURCEDIR com_civicrm $DM_VERSION zip
-${DM_ZIP:-zip} -q -r -9 com_civicrm/admin/civicrm.zip civicrm
-${DM_ZIP:-zip} -q -r -9 $DM_TARGETDIR/civicrm-$DM_VERSION-joomla.zip com_civicrm -x 'com_civicrm/admin/civicrm'
+dm_zip com_civicrm/admin/civicrm.zip civicrm
+dm_zip $DM_TARGETDIR/civicrm-$DM_VERSION-joomla.zip com_civicrm -x 'com_civicrm/admin/civicrm'
 
 # clean up
 rm -rf com_civicrm

--- a/distmaker/dists/l10n.sh
+++ b/distmaker/dists/l10n.sh
@@ -14,7 +14,7 @@ fi
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
 
-# copy all the stuff
+dm_h1 "Prepare files (civicrm-*-l10n.tar.gz)"
 dm_reset_dirs "$TRG"
 dm_install_l10n "$SRC/l10n" "$TRG/l10n"
 
@@ -23,9 +23,9 @@ for F in $SRC/sql/civicrm_*.??_??.mysql; do
 	cp $F $TRG/sql
 done
 
-# gen tarball
+dm_h1 "Generate archive (civicrm-*-l10n.tar.gz)"
 cd $TRG/..
 tar czf $DM_TARGETDIR/civicrm-$DM_VERSION-l10n.tar.gz --exclude '*.po' --exclude pot civicrm
 
-# clean up
+dm_h1 "Clean up"
 rm -rf $TRG

--- a/distmaker/dists/l10n.sh
+++ b/distmaker/dists/l10n.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 P=`dirname $0`
 CFFILE=$P/../distmaker.conf

--- a/distmaker/dists/patchset.sh
+++ b/distmaker/dists/patchset.sh
@@ -11,6 +11,7 @@ else
 fi
 . "$P/common.sh"
 
+dm_h1 "Identify scope of patches"
 DM_MAJMIN=$(echo "$DM_VERSION" | cut -f1,2 -d\. )
 REFTAG=$(grep -h "^${DM_MAJMIN}:" "$P/../patchset-baselines.txt" | cut -f2 -d: )
 if [ -z "$REFTAG" ]; then
@@ -21,7 +22,7 @@ fi
 SRC="$DM_SOURCEDIR"
 TRG="$DM_TMPDIR/civicrm-$DM_VERSION"
 
-# export patch files for each repo
+dm_h1 "Export patch files for each repo"
 dm_reset_dirs "$TRG"
 mkdir -p "$TRG"/civicrm-{core,drupal-7,drupal-8,backdrop,packages,joomla,wordpress}
 dm_export_patches "$SRC"            "$TRG/civicrm-core"       $REFTAG..$DM_REF_CORE
@@ -37,9 +38,9 @@ else
 fi
 
 
-# gen tarball
+dm_h1 "Generate archive (civicrm-*-patchset.tar.gz)"
 cd "$DM_TMPDIR"
 tar czf $DM_TARGETDIR/civicrm-$DM_VERSION-patchset.tar.gz civicrm-$DM_VERSION
 
-# clean up
+dm_h1 "Clean up"
 rm -rf $TRG

--- a/distmaker/dists/patchset.sh
+++ b/distmaker/dists/patchset.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 P=`dirname $0`
 CFFILE=$P/../distmaker.conf

--- a/distmaker/dists/repo-report.sh
+++ b/distmaker/dists/repo-report.sh
@@ -14,7 +14,7 @@ fi
 SRC=$DM_SOURCEDIR
 REPORT="$DM_TARGETDIR/civicrm-$DM_VERSION.json"
 
-dm_note "repo-report"
+dm_h1 "Generate repo report"
 env \
   DM_VERSION="$DM_VERSION" \
   DM_SOURCEDIR="$DM_SOURCEDIR" \

--- a/distmaker/dists/repo-report.sh
+++ b/distmaker/dists/repo-report.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 P=`dirname $0`
 CFFILE=$P/../distmaker.conf
@@ -14,6 +14,7 @@ fi
 SRC=$DM_SOURCEDIR
 REPORT="$DM_TARGETDIR/civicrm-$DM_VERSION.json"
 
+dm_note "repo-report"
 env \
   DM_VERSION="$DM_VERSION" \
   DM_SOURCEDIR="$DM_SOURCEDIR" \

--- a/distmaker/dists/standalone.sh
+++ b/distmaker/dists/standalone.sh
@@ -11,22 +11,22 @@ else
 fi
 . "$P/common.sh"
 
-SRC=$DM_SOURCEDIR
-TRG=$DM_TMPDIR/civicrm
+SRC="$DM_SOURCEDIR"
+TRG="$DM_TMPDIR/civicrm-standalone"
 
 # copy all the stuff
-dm_reset_dirs "$TRG" "$TRG/civicrm/web/core"
-dm_install_core "$SRC" "$TRG/civicrm/web/core"
-dm_install_coreext "$SRC" "$TRG/civicrm/web/core" $(dm_core_exts)
-dm_install_packages "$SRC/packages" "$TRG/civicrm/web/core/packages"
-dm_install_vendor "$SRC/vendor" "$TRG/civicrm/web/core/vendor"
-dm_install_bower "$SRC/bower_components" "$TRG/civicrm/web/core/bower_components"
-dm_install_cvext com.iatspayments.civicrm "$TRG/civicrm/web/core/ext/iatspayments"
-$SRC/tools/standalone/bin/scaffold $TRG/civicrm/web
+dm_reset_dirs "$TRG" "$TRG/core"
+dm_install_core "$SRC" "$TRG/core"
+dm_install_coreext "$SRC" "$TRG/core" $(dm_core_exts)
+dm_install_packages "$SRC/packages" "$TRG/core/packages"
+dm_install_vendor "$SRC/vendor" "$TRG/core/vendor"
+dm_install_bower "$SRC/bower_components" "$TRG/core/bower_components"
+dm_install_cvext com.iatspayments.civicrm "$TRG/core/ext/iatspayments"
+"$SRC/tools/standalone/bin/scaffold" "$TRG"
 
 # gen tarball
-cd $TRG/civicrm
-tar czf $DM_TARGETDIR/civicrm-$DM_VERSION-standalone.tar.gz web
+cd "$DM_TMPDIR"
+tar czf "$DM_TARGETDIR/civicrm-$DM_VERSION-standalone.tar.gz" civicrm-standalone
 
 # clean up
 rm -rf $TRG

--- a/distmaker/dists/standalone.sh
+++ b/distmaker/dists/standalone.sh
@@ -14,7 +14,7 @@ fi
 SRC="$DM_SOURCEDIR"
 TRG="$DM_TMPDIR/civicrm-standalone"
 
-# copy all the stuff
+dm_h1 "Prepare files (civicrm-*-standalone.tar.gz)"
 dm_reset_dirs "$TRG" "$TRG/core"
 dm_install_core "$SRC" "$TRG/core"
 dm_install_coreext "$SRC" "$TRG/core" $(dm_core_exts)
@@ -24,9 +24,9 @@ dm_install_bower "$SRC/bower_components" "$TRG/core/bower_components"
 dm_install_cvext com.iatspayments.civicrm "$TRG/core/ext/iatspayments"
 "$SRC/tools/standalone/bin/scaffold" "$TRG"
 
-# gen tarball
+dm_h1 "Generate archive (civicrm-*-standalone.tar.gz)"
 cd "$DM_TMPDIR"
 tar czf "$DM_TARGETDIR/civicrm-$DM_VERSION-standalone.tar.gz" civicrm-standalone
 
-# clean up
+dm_h1 "Clean up"
 rm -rf $TRG

--- a/distmaker/dists/standalone.sh
+++ b/distmaker/dists/standalone.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 P=`dirname $0`
 CFFILE=$P/../distmaker.conf

--- a/distmaker/dists/wordpress_php5.sh
+++ b/distmaker/dists/wordpress_php5.sh
@@ -14,7 +14,7 @@ fi
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
 
-# copy all the stuff
+dm_h1 "Prepare files (civicrm-*-wordpress.zip)"
 dm_reset_dirs "$TRG" "$TRG/civicrm/civicrm"
 cp $SRC/WordPress/civicrm.config.php.wordpress $TRG/civicrm/civicrm/civicrm.config.php
 dm_generate_version "$TRG/civicrm/civicrm/civicrm-version.php" Wordpress
@@ -26,15 +26,16 @@ dm_install_bower "$SRC/bower_components" "$TRG/civicrm/civicrm/bower_components"
 dm_install_wordpress "$SRC/WordPress" "$TRG/civicrm"
 dm_install_cvext com.iatspayments.civicrm "$TRG/civicrm/civicrm/ext/iatspayments"
 
-# gen tarball
+dm_h1 "Generate archive (civicrm-*-wordpress.zip)"
 cd $TRG
 ${DM_ZIP:-zip} -r -9 $DM_TARGETDIR/civicrm-$DM_VERSION-wordpress.zip *
 
-# gen wporg tarball
+dm_h1 "Generate archive (civicrm-*-wporg.zip)"
+
 touch "$TRG/civicrm/civicrm/.use-civicrm-setup"
 cp "$TRG/civicrm/civicrm/setup/plugins/blocks/opt-in.disabled.php" "$TRG/civicrm/civicrm/setup/plugins/blocks/opt-in.civi-setup.php"
 cd "$TRG"
 ${DM_ZIP:-zip} -r -9 $DM_TARGETDIR/civicrm-$DM_VERSION-wporg.zip *
 
-# clean up
+dm_h1 "Clean up"
 rm -rf $TRG

--- a/distmaker/dists/wordpress_php5.sh
+++ b/distmaker/dists/wordpress_php5.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 P=`dirname $0`
 CFFILE=$P/../distmaker.conf

--- a/distmaker/dists/wordpress_php5.sh
+++ b/distmaker/dists/wordpress_php5.sh
@@ -28,14 +28,14 @@ dm_install_cvext com.iatspayments.civicrm "$TRG/civicrm/civicrm/ext/iatspayments
 
 dm_h1 "Generate archive (civicrm-*-wordpress.zip)"
 cd $TRG
-${DM_ZIP:-zip} -r -9 $DM_TARGETDIR/civicrm-$DM_VERSION-wordpress.zip *
+dm_zip $DM_TARGETDIR/civicrm-$DM_VERSION-wordpress.zip *
 
 dm_h1 "Generate archive (civicrm-*-wporg.zip)"
 
 touch "$TRG/civicrm/civicrm/.use-civicrm-setup"
 cp "$TRG/civicrm/civicrm/setup/plugins/blocks/opt-in.disabled.php" "$TRG/civicrm/civicrm/setup/plugins/blocks/opt-in.civi-setup.php"
 cd "$TRG"
-${DM_ZIP:-zip} -r -9 $DM_TARGETDIR/civicrm-$DM_VERSION-wporg.zip *
+dm_zip $DM_TARGETDIR/civicrm-$DM_VERSION-wporg.zip *
 
 dm_h1 "Clean up"
 rm -rf $TRG


### PR DESCRIPTION
Overview
----------------------------------------

Reduce the amount of output generated by distmaker.

Before
----------------------------------------

When you run distmaker, the output is so long that it is impossible to comprehend. There are a few reasons:

* It literally prints out a copy of its own source code
* It prints a debug statement for every single line of shell
* In some cases, it prints the entire list of files that appear in a release-artifact. And it reports how much compression is achieved on each individual file. (The archives are generally ~20,000 files.)

Taken together, the overall output of `distmaker.sh all` exceeds 4 megabytes (almost 50,000 lines of text).

After
----------------------------------------

When you run distmaker, it prints some general information about which steps are running. But it doesn't print such detailed logs.

The output is only 50 kilobytes (about 400 lines).

Comments
----------------------------------------

* This incidentally includes #30904. While the PR's don't particularly depend each other, they would have merge-conflicts within `standalone.sh` (because they touch nearby lines).
* I'm flagging this PR as `run-distmaker` in case you want to see that distmaker still works.
* I did local runs of `distmaker` (before and after) then compared the contents of the archives. There were no substantive differences.
