### PR TITLE
dev/core#2290 - Remove id from cache tables

### DIFF
--- a/CRM/ACL/BAO/Cache.php
+++ b/CRM/ACL/BAO/Cache.php
@@ -85,15 +85,19 @@ SELECT acl_id
    */
   protected static function store($id, &$cache) {
     foreach ($cache as $aclID => $data) {
-      $dao = new CRM_ACL_BAO_Cache();
-      if ($id) {
-        $dao->contact_id = $id;
-      }
-      $dao->acl_id = $aclID;
-
       $cache[$aclID] = 1;
 
-      $dao->save();
+      $params = [
+        1 => [$aclID, 'Integer'],
+      ];
+      if ($id) {
+        $query = "INSERT INTO civicrm_acl_cache (contact_id, acl_id) VALUES (%2, %1)";
+        $params[2] = [$id, 'Integer'];
+      }
+      else {
+        $query = "INSERT INTO civicrm_acl_cache (contact_id, acl_id) VALUES (NULL, %1)";
+      }
+      CRM_Core_DAO::executeQuery($query, $params);
     }
   }
 

--- a/CRM/ACL/BAO/Cache.php
+++ b/CRM/ACL/BAO/Cache.php
@@ -87,17 +87,18 @@ SELECT acl_id
     foreach ($cache as $aclID => $data) {
       $cache[$aclID] = 1;
 
-      $params = [
-        1 => [$aclID, 'Integer'],
-      ];
       if ($id) {
-        $query = "INSERT INTO civicrm_acl_cache (contact_id, acl_id) VALUES (%2, %1)";
-        $params[2] = [$id, 'Integer'];
+        CRM_Core_DAO::executeQuery("INSERT INTO civicrm_acl_cache (acl_id, contact_id) VALUES (%1, %2)", [
+          1  => [$aclID, 'Integer'],
+          2 => [$id, 'Integer'],
+        ]);
       }
       else {
-        $query = "INSERT INTO civicrm_acl_cache (contact_id, acl_id) VALUES (NULL, %1)";
+        // contact_id is null if the user is not logged in. Not sure why we need to insert a record for NULL though?
+        CRM_Core_DAO::executeQuery("INSERT INTO civicrm_acl_cache (acl_id, contact_id) VALUES (%1, NULL)", [
+          1  => [$aclID, 'Integer'],
+        ]);
       }
-      CRM_Core_DAO::executeQuery($query, $params);
     }
   }
 

--- a/CRM/Upgrade/Incremental/php/SixNine.php
+++ b/CRM/Upgrade/Incremental/php/SixNine.php
@@ -61,6 +61,12 @@ class CRM_Upgrade_Incremental_php_SixNine extends CRM_Upgrade_Incremental_Base {
         'label' => ts('Modified Date'),
       ],
     ]);
+
+    // dev/core#2290 - Remove id from cache tables
+    $tables = ['civicrm_cache', 'civicrm_acl_cache', 'civicrm_acl_contact_cache', 'civicrm_group_contact_cache'];
+    foreach ($tables as $table) {
+      $this->addTask("dev/core#2290 - Remove id column from '$table' table", 'dropColumn', $table, 'id');
+    }
   }
 
 }

--- a/schema/ACL/ACLCache.entityType.php
+++ b/schema/ACL/ACLCache.entityType.php
@@ -31,16 +31,6 @@ return [
     ],
   ],
   'getFields' => fn() => [
-    'id' => [
-      'title' => ts('Cache ID'),
-      'sql_type' => 'int unsigned',
-      'input_type' => 'Number',
-      'required' => TRUE,
-      'description' => ts('Unique table ID'),
-      'add' => '1.6',
-      'primary_key' => TRUE,
-      'auto_increment' => TRUE,
-    ],
     'contact_id' => [
       'title' => ts('Contact ID'),
       'sql_type' => 'int unsigned',

--- a/schema/Contact/ACLContactCache.entityType.php
+++ b/schema/Contact/ACLContactCache.entityType.php
@@ -23,16 +23,6 @@ return [
     ],
   ],
   'getFields' => fn() => [
-    'id' => [
-      'title' => ts('ACL Contact Cache ID'),
-      'sql_type' => 'int unsigned',
-      'input_type' => 'Number',
-      'required' => TRUE,
-      'description' => ts('primary key'),
-      'add' => '3.1',
-      'primary_key' => TRUE,
-      'auto_increment' => TRUE,
-    ],
     'user_id' => [
       'title' => ts('Contact ID'),
       'sql_type' => 'int unsigned',

--- a/schema/Contact/GroupContactCache.entityType.php
+++ b/schema/Contact/GroupContactCache.entityType.php
@@ -21,16 +21,6 @@ return [
     ],
   ],
   'getFields' => fn() => [
-    'id' => [
-      'title' => ts('Group Contact Cache ID'),
-      'sql_type' => 'int unsigned',
-      'input_type' => 'Number',
-      'required' => TRUE,
-      'description' => ts('primary key'),
-      'add' => '2.1',
-      'primary_key' => TRUE,
-      'auto_increment' => TRUE,
-    ],
     'group_id' => [
       'title' => ts('Group ID'),
       'sql_type' => 'int unsigned',

--- a/schema/Core/Cache.entityType.php
+++ b/schema/Core/Cache.entityType.php
@@ -27,16 +27,6 @@ return [
     ],
   ],
   'getFields' => fn() => [
-    'id' => [
-      'title' => ts('Cache ID'),
-      'sql_type' => 'int unsigned',
-      'input_type' => 'Number',
-      'required' => TRUE,
-      'description' => ts('Unique table ID'),
-      'add' => '2.1',
-      'primary_key' => TRUE,
-      'auto_increment' => TRUE,
-    ],
     'group_name' => [
       'title' => ts('Group Name'),
       'sql_type' => 'varchar(32)',

--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -605,37 +605,37 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
    * @throws CRM_Core_Exception
    */
   public function testUpdateTimestampWithBlankDate(): void {
-    // Arbitrarily using "Cache" since it has a desired type of timestamp field and is simple.
-    $dao = new CRM_Core_DAO_Cache();
+    // Arbitrarily using "ActionSchedule" since it has a desired type of timestamp field and is simple.
+    $dao = new CRM_Core_DAO_ActionSchedule();
     $fields = $dao->fields();
-    $this->assertSame(CRM_Utils_Type::T_TIMESTAMP, $fields['expired_date']['type'], 'Oh somebody changed the type, so this test might not be testing the right type of timestamp anymore. Might need to change the test to have it use a different field.');
-    $this->assertFalse(!empty($fields['expired_date']['required']), 'Oh somebody changed the REQUIRED setting, so this test might not be testing the right type of timestamp anymore. Might need to change the test to have it use a different field.');
+    $this->assertSame(CRM_Utils_Type::T_TIMESTAMP, $fields['action_schedule_effective_end_date']['type'], 'Oh somebody changed the type, so this test might not be testing the right type of timestamp anymore. Might need to change the test to have it use a different field.');
+    $this->assertFalse(!empty($fields['action_schedule_effective_end_date']['required']), 'Oh somebody changed the REQUIRED setting, so this test might not be testing the right type of timestamp anymore. Might need to change the test to have it use a different field.');
 
-    $dao->group_name = 'mytest';
-    $dao->path = 'mypath';
-    $dao->data = 'some data';
-    $dao->expired_date = '';
+    $dao->name = 'test_schedule_' . uniqid();
+    $dao->title = 'Test Schedule';
+    $dao->mapping_id = 'activity_type';
+    $dao->effective_end_date = '';
     $dao->save();
     $id = $dao->id;
 
     // Now retrieve it and update it with a blank timestamp.
-    $dao = new CRM_Core_DAO_Cache();
+    $dao = new CRM_Core_DAO_ActionSchedule();
     $dao->id = $id;
     $dao->find(TRUE);
     // sanity check we got the right one since otherwise checking null might falsely be true
-    $this->assertEquals('mytest', $dao->group_name);
-    $this->assertNull($dao->expired_date);
+    $this->assertEquals('Test Schedule', $dao->title);
+    $this->assertNull($dao->effective_end_date);
 
-    $dao->data = 'some updated data';
-    $dao->expired_date = '';
+    $dao->title = 'Updated Test Schedule';
+    $dao->effective_end_date = '';
     // would crash here on update
     $dao->save();
 
-    $dao = new CRM_Core_DAO_Cache();
+    $dao = new CRM_Core_DAO_ActionSchedule();
     $dao->id = $id;
     $dao->find(TRUE);
-    $this->assertEquals('some updated data', $dao->data);
-    $this->assertNull($dao->expired_date);
+    $this->assertEquals('Updated Test Schedule', $dao->title);
+    $this->assertNull($dao->effective_end_date);
   }
 
   public function testFillValues(): void {


### PR DESCRIPTION
Overview
----------------------------------------
Remove id from cache tables

Before
----------------------------------------
See discussion on gitlab - https://lab.civicrm.org/dev/core/-/issues/2290

After
----------------------------------------
No id column in cache tables.

Technical Details
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/10019 was merged which removed the dependency/usage of id column from the code.

This PR aims to remove it from database.

Comments
----------------------------------------
