### PR TITLE
Update CRM_Core_Resources::isAjaxMode to handle more ajax paths

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -506,7 +506,7 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
    *   is this page request an ajax snippet?
    */
   public static function isAjaxMode() {
-    if (in_array(CRM_Utils_Array::value('snippet', $_REQUEST), [
+    if (in_array($_REQUEST['snippet'] ?? '', [
       CRM_Core_Smarty::PRINT_SNIPPET,
       CRM_Core_Smarty::PRINT_NOFORM,
       CRM_Core_Smarty::PRINT_JSON,
@@ -514,8 +514,9 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
     ) {
       return TRUE;
     }
-    [$arg0, $arg1] = array_pad(explode('/', (CRM_Utils_System::currentPath() ?? '')), 2, '');
-    return ($arg0 === 'civicrm' && in_array($arg1, ['ajax', 'angularprofiles', 'asset']));
+    $path = explode('/', (CRM_Utils_System::currentPath() ?? ''));
+    [$arg0, $arg1] = array_pad($path, 2, '');
+    return ($arg0 === 'civicrm' && (in_array($arg1, ['angularprofiles', 'asset']) || in_array('ajax', $path, TRUE)));
   }
 
   /**

--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -388,6 +388,7 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
   public function ajaxModeData(): array {
     return [
       [['q' => 'civicrm/ajax/foo'], TRUE],
+      [['q' => 'civicrm/case/ajax/foo'], TRUE],
       [['q' => 'civicrm/angularprofiles/template'], TRUE],
       [['q' => 'civicrm/asset/builder'], TRUE],
       [['q' => 'civicrm/test/page'], FALSE],


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug I noticed in the code that detects whether a path uses ajax.

Technical Details
----------------------------------------
The function assumed paths that have ajax as the 2nd argument (like `civicrm/ajax/rest`, but there are others like `civicrm/case/ajax/details` that have it as the 3rd.