### PR TITLE
dev/core#5403 fix crash installing an extension that provides an EntityBridge

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -284,7 +284,6 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
   public function cleanupCaches($sessionReset = FALSE) {
     // cleanup templates_c directory
     $this->cleanup(1, FALSE);
-    UserJob::delete(FALSE)->addWhere('expires_date', '<', 'now')->execute();
     // clear all caches
     self::clearDBCache();
     // Avoid clearing QuickForm sessions unless explicitly requested
@@ -294,6 +293,10 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
     Civi::cache('metadata')->clear();
     CRM_Core_DAO_AllCoreTables::flush();
     CRM_Utils_System::flushCache();
+
+    // note this used to be earlier, but was crashing because of api4 instability
+    // during extension install
+    UserJob::delete(FALSE)->addWhere('expires_date', '<', 'now')->execute();
 
     if ($sessionReset) {
       $session = CRM_Core_Session::singleton();


### PR DESCRIPTION
Overview
----------------------------------------
Fix for https://lab.civicrm.org/dev/core/-/issues/5403 - alternative to https://github.com/civicrm/civicrm-core/pull/30912 


Before
---------------------------------------
- expired UserJobs are deleted early in a cache clear triggered using `rebuildMenuAndCaches`
- installing a new Standalone site crashes at the point it tries to install `standaloneusers`
- ~~_to be confirmed:_ installing any extension that provides an entity that uses the EntityBridge trait crashes~~
- installing [this demo extension](https://lab.civicrm.org/ufundo/wobbly_bridge) causes a similar crash on D7

After
--------------------------------------
- UserJobs are deleted near the end of the cache clear process
- no crashes


Technical details
--------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/5403#note_169033 for my theory of the crime :dagger: 
