### PR TITLE
Afform - Fix display value in select & autocomplete widgets

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
@@ -26,7 +26,7 @@
             if (typeof value === 'boolean') {
               return value ? '1' : '0';
             }
-            return value;
+            return '' + value;
           }
           ctrls.ngModel.$formatters.push(formatViewValue);
         }


### PR DESCRIPTION
Overview
----------------------------------------
See https://chat.civicrm.org/civicrm/pl/s6xtjegt7fdxzqy74cnd3o81zy

Before
--------
Set values in an activity for 'activity type', 'activity status'. Save and go back in the values are blank.

After
-------
Fixed