### PR TITLE
Afform - Fix new test-failures on php74

### DIFF
--- a/ext/afform/core/Civi/Afform/Utils.php
+++ b/ext/afform/core/Civi/Afform/Utils.php
@@ -40,7 +40,7 @@ class Utils {
       foreach ($entityValues[$entityName] as $record) {
         foreach ($record['fields'] as $fieldName => $fieldValue) {
           foreach ((array) $fieldValue as $value) {
-            if (array_key_exists($value, $formEntities) && $value !== $entityName) {
+            if (!is_bool($value) && array_key_exists($value, $formEntities) && $value !== $entityName) {
               $references[$value] = $value;
             }
           }


### PR DESCRIPTION
Overview
----------------------------------------

CiviCRM 5.77-rc adds new test-coverage (`api\v4\Afform\AfformConditionalUsageTest` and `api\v4\Afform\AfformGroupSubscriptionUsageTest`). This fixes a warning which cause these tests to fail on php74.

cc @colemanw

Before
----------------------------------------

* Tests pass on php82
* Tests fail on php74 (Example: https://test.civicrm.org/job/CiviCRM-Test-QLow/58510/testReport/)

After
----------------------------------------

* Tests pass on php82 and php74

Technical Details
----------------------------------------

This message is a common theme among the new failures:

```
array_key_exists(): The first argument should be either a string or an integer

/home/homer/buildkit/build/build-2/web/sites/all/modules/civicrm/ext/afform/core/Civi/Afform/Utils.php:43
/home/homer/buildkit/build/build-2/web/sites/all/modules/civicrm/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php:522
```

* The problem arises when processing a submitted field `$value` like [`do_not_email => TRUE` or `do_not_email => FALSE`](https://github.com/civicrm/civicrm-core/blob/36f93f0e5c5c356148cd8353cb87912e36c16a5b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformConditionalUsageTest.php#L105). 
* `getEntityWeights()` uses the *values* as array-keys. php8x fully supports setting `$array[TRUE]` or `$array[FALSE]`, so it doesn't mind -- but those keys are misleading on PHP 7, so it complains.
* I don't fully understand the data-structure being scanned. But it loosely seems to be about finding/collating/prioritizing foreign-keys. And `TRUE`/`FALSE` don't indicate a foreign-key (either as an entity-name or an entity-id)... so I don't see how they'd be relevant to the scan.