### PR TITLE
Use Smarty5 by default on new installs

### DIFF
--- a/CRM/Utils/Check/Component/Smarty.php
+++ b/CRM/Utils/Check/Component/Smarty.php
@@ -26,18 +26,18 @@ class CRM_Utils_Check_Component_Smarty extends CRM_Utils_Check_Component {
   public function checkSmartyVersion(): array {
     $messages = [];
     if (!defined('CIVICRM_SMARTY_AUTOLOAD_PATH') && !defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
-      $smartyPath = \Civi::paths()->getPath('[civicrm.packages]/smarty4/vendor/autoload.php');
+      $smartyPath = \Civi::paths()->getPath('[civicrm.packages]/smarty5/Smarty.php');
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
         '<p>' . (ts('CiviCRM is updating a major library (<em>Smarty</em>) to improve performance and security and php 8.3 compatibility. The update is currently optional, but you should try it now.')) . '</p>'
         . '<p>' . (ts('To apply the update, add this statement to <code>civicrm.settings.php</code>:'))
         . sprintf("<pre>  define('CIVICRM_SMARTY_AUTOLOAD_PATH',\n    %s);</pre>", htmlentities(var_export($smartyPath, 1))) . '</p>'
-        . '<p>' . ('Some extensions may not work yet with Smarty v4. If you encounter problems, then simply remove the statement.') . '</p>'
-        . '<p>' . (ts('Upcoming versions will standardize on Smarty v4. CiviCRM <a %1>v5.69-ESR</a> will provide extended support for Smarty v2. To learn more and discuss, see the <a %2>Smarty transition page</a>.' . '</p>', [
+        . '<p>' . ('Some extensions may not work yet with Smarty v5. If you encounter problems, then simply remove the statement.') . '</p>'
+        . '<p>' . (ts('Upcoming versions will standardize on Smarty v5. CiviCRM <a %1>v5.81-ESR</a> will provide extended support for Smarty v2, v3, & v4. To learn more and discuss, see the <a %2>Smarty transition page</a>.' . '</p>', [
           1 => 'target="_blank" href="' . htmlentities('https://civicrm.org/esr') . '"',
           2 => 'target="_blank" href="' . htmlentities('https://civicrm.org/redirect/smarty-v3') . '"',
         ])),
-        ts('Smarty Update (v2 => v4)'),
+        ts('Smarty Update (v2 => v5)'),
         LogLevel::WARNING,
         'fa-lock'
       );

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -243,27 +243,13 @@ if (!defined('CIVICRM_UF_BASEURL')) {
  * the near future - this opt-in setting is transitional.
  */
 if (!defined('CIVICRM_SMARTY_AUTOLOAD_PATH') && getenv('CIVICRM_SMARTY_AUTOLOAD_PATH') === FALSE) {
-  // enable by default for dev & demo sites for now - will soon enable by default for all new installs.
-  if (CIVICRM_UF === 'UnitTests' || strpos(CIVICRM_UF_BASEURL, 'localhost') !== FALSE || strpos(CIVICRM_UF_BASEURL, 'demo.civicrm.org') !== FALSE
-    || strpos(CIVICRM_UF_BASEURL, 'http://build') !== FALSE
-  ) {
-    if (is_dir($civicrm_root . '/packages')) {
-      define('CIVICRM_SMARTY_AUTOLOAD_PATH', $civicrm_root . '/packages/smarty5/Smarty.php');
-    }
-    elseif (is_dir($civicrm_root . '/../civicrm-packages')) {
-      define('CIVICRM_SMARTY_AUTOLOAD_PATH', $civicrm_root . '/../civicrm-packages/smarty5/Smarty.php');
-    }
-  }
-}
-
-// If not set above we should default the Smarty version to Smarty4 which is our stable version.
-// This will not work for all composer-based installs @todo.
-if (!defined('CIVICRM_SMARTY_AUTOLOAD_PATH') && getenv('CIVICRM_SMARTY_AUTOLOAD_PATH') === FALSE) {
+  // If not set we should default the Smarty version to Smarty4 which is our stable version.
+  // This will not work for all composer-based installs @todo.
   if (is_dir($civicrm_root . '/packages')) {
-    define('CIVICRM_SMARTY_AUTOLOAD_PATH', $civicrm_root . '/packages/smarty4/vendor/autoload.php');
+    define('CIVICRM_SMARTY_AUTOLOAD_PATH', $civicrm_root . '/packages/smarty5/Smarty.php');
   }
   elseif (is_dir($civicrm_root . '/../civicrm-packages')) {
-    define('CIVICRM_SMARTY_AUTOLOAD_PATH', $civicrm_root . '/../civicrm-packages/smarty4/vendor/autoload.php');
+    define('CIVICRM_SMARTY_AUTOLOAD_PATH', $civicrm_root . '/../civicrm-packages/smarty5/Smarty.php');
   }
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
Use Smarty5 by default on new installs

Before
----------------------------------------
New installs were defaulting to Smarty4 which we gave Smarty5 a little longer to run on dev sites, unit tests and WMF production in case anything came up. It has been quiet for a couple of months now so time to switch over

After
----------------------------------------
New installs get Smarty5 

Technical Details
----------------------------------------
The next step is probably to fully remove Smarty 3 & just `str_replace` smarty3 to smarty4 on existing sites. For Smarty2 we would probably discontinue it after the next ESR is released.

Comments
----------------------------------------
