### PR TITLE
Smarty - Don't hard-code reference to Smarty version

### DIFF
--- a/CRM/Core/CodeGen/Util/Smarty.php
+++ b/CRM/Core/CodeGen/Util/Smarty.php
@@ -47,8 +47,11 @@ class CRM_Core_CodeGen_Util_Smarty {
    */
   public function createSmarty(): Smarty {
     $base = dirname(__DIR__, 4);
-    $pkgs = file_exists(dirname($base) . "/civicrm-packages") ? dirname($base) . "/civicrm-packages" : "$base/packages";
-    require_once $pkgs . '/smarty5/Smarty.php';
+    if (!class_exists('Smarty', FALSE)) {
+      // Prefer Smarty v5; but if we get here in some scenario with another Smarty, use that.
+      $pkgs = file_exists(dirname($base) . "/civicrm-packages") ? dirname($base) . "/civicrm-packages" : "$base/packages";
+      require_once $pkgs . '/smarty5/Smarty.php';
+    }
     $smarty = new Smarty();
     $smarty->setTemplateDir("$base/xml/templates");
     // Doesn't seem to work very well.... since I still need require_once below

--- a/setup/src/Setup/SmartyUtil.php
+++ b/setup/src/Setup/SmartyUtil.php
@@ -10,9 +10,11 @@ class SmartyUtil {
    * @throws \SmartyException
    */
   public static function createSmarty($srcPath) {
-    $packagePath = PackageUtil::getPath($srcPath);
-    require_once $packagePath . '/smarty5/Smarty.php';
-
+    if (!class_exists('Smarty', FALSE)) {
+      // Prefer Smarty v5; but if we get here in some scenario with another Smarty, use that.
+      $packagePath = PackageUtil::getPath($srcPath);
+      require_once $packagePath . '/smarty5/Smarty.php';
+    }
     $smarty = new \Smarty();
     $smarty->setTemplateDir(implode(DIRECTORY_SEPARATOR, [$srcPath, 'xml', 'templates']));
     $pluginsDirectory = $smarty->addPluginsDir([


### PR DESCRIPTION
Overview
----------------------------------------

While trying to investigate test-failures, I found that I couldn't run some E2E tests in isolation.

Before
----------------------------------------

```
[php82:~/bknix/build/s4/web/core]$ phpunit9 tests/phpunit/E2E/Core/LocalizedDataTest.php 
PHPUnit 9.6.20 by Sebastian Bergmann and contributors.


Fatal error: Cannot redeclare smarty_ucfirst_ascii() (previously declared in /home/totten/bknix/build/s4/web/core/packages/smarty4/vendor/smarty/smarty/libs/functions.php:23) in /home/totten/bknix/build/s4/web/core/packages/smarty5/vendor/smarty/smarty/src/functions.php on line 21
```

After
----------------------------------------

Same test can run.
