### PR TITLE
Load Smarty4 instead of Smarty3 where upgraded off Smarty2

### DIFF
--- a/CRM/Core/SmartyCompatibility.php
+++ b/CRM/Core/SmartyCompatibility.php
@@ -37,7 +37,11 @@
  * @return string|null
  */
 function crm_smarty_compatibility_get_path() {
-  return CRM_Utils_Constant::value('CIVICRM_SMARTY_AUTOLOAD_PATH') ?: CRM_Utils_Constant::value('CIVICRM_SMARTY3_AUTOLOAD_PATH');
+  $path = CRM_Utils_Constant::value('CIVICRM_SMARTY_AUTOLOAD_PATH') ?: CRM_Utils_Constant::value('CIVICRM_SMARTY3_AUTOLOAD_PATH');
+  if ($path) {
+    $path = str_replace('smarty3', 'smarty4', $path);
+  }
+  return $path;
 }
 
 /**


### PR DESCRIPTION

Overview
----------------------------------------
Smarty3 where upgraded off Smarty2

This switches anyone who has updated to Smarty3 onto Smarty4 - they are equivalent except for php8.x support & the recommendation by Smarty that Smarty3 is updated so we don't want to make users take action for this change. We will be able to remove Smarty3 from packages

Before
----------------------------------------
Sites that have code in the path to Smarty3 get Smarty3

After
----------------------------------------
Sites that have code in the path to Smarty3 get Smarty4

Technical Details
----------------------------------------
The only differences we have identified are that php compatibility is fixed in Smarty4 & it is getting security updates

Comments
----------------------------------------
