### PR TITLE
[not mergeable] Remove use of legacy afform tokens 

### DIFF
--- a/ext/afform/core/Civi/Afform/Tokens.php
+++ b/ext/afform/core/Civi/Afform/Tokens.php
@@ -34,8 +34,6 @@ class Tokens extends AutoService implements EventSubscriberInterface {
 
     return [
       'hook_civicrm_alterMailContent' => 'applyCkeditorWorkaround',
-      'hook_civicrm_tokens' => 'hook_civicrm_tokens',
-      'hook_civicrm_tokenValues' => 'hook_civicrm_tokenValues',
       'civi.token.list' => 'listTokens',
       'civi.token.eval' => 'evaluateTokens',
     ];
@@ -52,61 +50,6 @@ class Tokens extends AutoService implements EventSubscriberInterface {
       if (is_string($e->content[$field])) {
         $e->content[$field] = preg_replace(';https?://(\{afform.*Url\});', '$1', $e->content[$field]);
       }
-    }
-  }
-
-  /**
-   * Expose tokens for use in UI.
-   *
-   * @param \Civi\Core\Event\GenericHookEvent $e
-   * @see \CRM_Utils_Hook::tokens()
-   */
-  public static function hook_civicrm_tokens(GenericHookEvent $e) {
-    $tokenForms = static::getTokenForms();
-    foreach ($tokenForms as $tokenName => $afform) {
-      $e->tokens['afform']["afform.{$tokenName}Url"] = E::ts('%1 (URL)', [1 => $afform['title'] ?? $afform['name']]);
-      $e->tokens['afform']["afform.{$tokenName}Link"] = E::ts('%1 (Full Hyperlink)', [1 => $afform['title'] ?? $afform['name']]);
-    }
-  }
-
-  /**
-   * Substitute any tokens of the form `{afform.myFormUrl}` or `{afform.myFormLink}` with actual values.
-   *
-   * @param \Civi\Core\Event\GenericHookEvent $e
-   * @see \CRM_Utils_Hook::tokenValues()
-   */
-  public static function hook_civicrm_tokenValues(GenericHookEvent $e) {
-    try {
-      // Depending on the caller, $tokens['afform'] might be ['fooUrl'] or ['fooUrl'=>1]. Because... why not!
-      $activeAfformTokens = array_merge(array_keys($e->tokens['afform'] ?? []), array_values($e->tokens['afform'] ?? []));
-
-      $tokenForms = static::getTokenForms();
-      foreach ($tokenForms as $formName => $afform) {
-        if (!array_intersect($activeAfformTokens, ["{$formName}Url", "{$formName}Link"])) {
-          continue;
-        }
-
-        if (empty($afform['server_route'])) {
-          continue;
-        }
-
-        if (!is_array($e->contactIDs)) {
-          $url = self::createUrl($afform, $e->contactIDs);
-          $e->details["afform.{$formName}Url"] = $url;
-          $e->details["afform.{$formName}Link"] = sprintf('<a href="%s">%s</a>', htmlentities($url), htmlentities($afform['title'] ?? $afform['name']));
-        }
-        else {
-          foreach ($e->contactIDs as $cid) {
-            $url = self::createUrl($afform, $cid);
-            $e->details[$cid]["afform.{$formName}Url"] = $url;
-            $e->details[$cid]["afform.{$formName}Link"] = sprintf('<a href="%s">%s</a>', htmlentities($url), htmlentities($afform['title'] ?? $afform['name']));
-          }
-        }
-      }
-    }
-    catch (CryptoException $ex) {
-      \Civi::log()->warning(__CLASS__ . ' cannot generate tokens due to a crypto exception.',
-        ['exception' => $ex]);
     }
   }
 
@@ -188,38 +131,6 @@ class Tokens extends AutoService implements EventSubscriberInterface {
       \Civi::$statics[__CLASS__]['tokenForms'] = $tokenForms;
     }
     return \Civi::$statics[__CLASS__]['tokenForms'];
-  }
-
-  /**
-   * Generate an authenticated URL for viewing this form.
-   *
-   * @param array $afform
-   * @param int $contactId
-   *
-   * @return string
-   * @throws \Civi\Crypto\Exception\CryptoException
-   */
-  public static function createUrl($afform, $contactId): string {
-    $expires = \CRM_Utils_Time::time() +
-      (\Civi::settings()->get('checksum_timeout') * 24 * 60 * 60);
-
-    /** @var \Civi\Crypto\CryptoJwt $jwt */
-    $jwt = \Civi::service('crypto.jwt');
-
-    $bearerToken = "Bearer " . $jwt->encode([
-      'exp' => $expires,
-      'sub' => "cid:" . $contactId,
-      'scope' => 'authx',
-    ]);
-
-    $url = \CRM_Utils_System::url($afform['server_route'],
-      ['_authx' => $bearerToken, '_authxSes' => 1],
-      TRUE,
-      NULL,
-      FALSE,
-      $afform['is_public'] ?? TRUE
-    );
-    return $url;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Remove legacy implementation of tokens hook

When afform tokens were added they were added both the old way - it should go - but this shows what tests call it


Before
----------------------------------------
![image](https://github.com/user-attachments/assets/d4922ca0-b483-4cdb-8f51-4543fc154032)
![image](https://github.com/user-attachments/assets/e25884a6-ce1d-4464-96de-a7af7cb64a3a)


After
----------------------------------------
poof

Technical Details
----------------------------------------
I thought that these tokens were added after the token processor was written & this was done for backward compatibility but it seems that it might not be & it will probably fail over at 
https://github.com/civicrm/civicrm-core/commit/b7edd04eb0dbcae4419f7073faea923a4140579b#diff-c23344233be023c79713512b55552d6e52ed0bbc194768ef4b906a7d32c50cf4R69




Comments
----------------------------------------
_Anything else you would like the reviewer to note_
