### PR TITLE
distmaker - Stop trying to bundle SQL files

### DIFF
--- a/distmaker/distmaker.sh
+++ b/distmaker/distmaker.sh
@@ -255,6 +255,9 @@ if [ -z "$DM_KEEP_DEPS" ]; then
   dm_generate_vendor "$DM_SOURCEDIR"
 fi
 
+cd "$DM_SOURCEDIR/xml"
+"${DM_PHP:-php}" GenCode.php schema/Schema.xml "$DM_VERSION" "$GENCODE_CMS"
+
 cd $ORIGPWD
 
 if [ "$L10NPACK" = 1 ]; then

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -120,10 +120,7 @@ function dm_install_core() {
   dm_install_files "$repo" "$to" composer.json composer.lock package.json Civi.php functions.php README.md release-notes.md extension-compatibility.json deleted-files-list.json guzzle_php81_shim.php
 
   mkdir -p "$to/sql"
-  pushd "$repo" >> /dev/null
-    dm_install_files "$repo" "$to" sql/civicrm*.mysql sql/case_sample*.mysql
-    ## TODO: for master, remove counties.US.SQL.gz
-  popd >> /dev/null
+  dm_install_files "$repo/sql" "$to/sql" civicrm_drop.mysql civicrm_generated.mysql civicrm_navigation.mysql
 
   if [ -d $to/bin ] ; then
     rm -f $to/bin/setup.sh
@@ -132,7 +129,6 @@ function dm_install_core() {
   fi
 
   set +e
-  rm -rf $to/sql/civicrm_*.??_??.mysql
   rm -rf $to/mixin/*/example
   set -e
 }


### PR DESCRIPTION
Overview
----------------------------------------

SQL schema should generally be created on-the-fly using `schema/*.php` -- making the `*.mysql` files obsolete.

(Follow-up to 9d4682697bb93c880a513e5e1cbfe596697ba11d from #30022.)

Before
----------------------------------------

Distmaker will try to include pre-generated SQL files.

However, depending on how `distmaker` is run, you may not have any SQL files... because  9d4682697bb93c880a513e5e1cbfe596697ba11d stopped `distmaker` from trying to make its own copies.

After
----------------------------------------

Distmaker doesn't try to include these SQL files.

Comments
----------------------------------------

* I have not tested the resulting zip/tar files. That seems like the important thing to do...
* Generally, my impression is that we have two main areas the SQL files might still be used:
    * In CI/civibuild, the Civi-WP tests use them. (*Should non-issue after [buildkit#854](https://github.com/civicrm/civicrm-buildkit/pull/854)*) But they should be generated on-the-fly for the active branch. We don't need them in tarballs. 
    * ~~In Drush-Backdrop, it might still use them.~~ (*Should be non-issue after [civicrm-backdrop#182](https://github.com/civicrm/civicrm-backdrop/pull/182)*)