### PR TITLE
Fix just-merged rebase error

### DIFF
--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -211,7 +211,7 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
         if (!empty($blockVal['master_id'])) {
           $idValue = $blockVal['master_id'];
         }
-        $defaults['address'][$blockId]['custom'] = $this->addBlockCustomData($entity, $idValue);
+        $defaults['address'][$blockId]['custom'] = $this->addBlockCustomData('Address', $idValue);
       }
       // reset template variable since that won't be of any use, and could be misleading
       $this->assign("dnc_viewCustomData", NULL);


### PR DESCRIPTION
Overview
----------------------------------------
Fix just-merged rebase error

Before
----------------------------------------
A cherry-picked patch that was just merged had `$entity` not `Address` - this was an error from rebasing as `$entity` is not defined

![image](https://github.com/user-attachments/assets/ca737fd4-0b3d-4183-8bdc-4bddc201a7be)

After
----------------------------------------
fixed

Technical Details
----------------------------------------

Comments
----------------------------------------
