### PR TITLE
[REF] Allow System Admins to override the file permissions set by Pea…

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -660,6 +660,8 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     self::generateLogFileName($prefix);
     $log = Log::singleton('file', \Civi::$statics[__CLASS__]['logger_file' . $prefix], '', [
       'timeFormat' => 'Y-m-d H:i:sO',
+      'mode' => CRM_Utils_Constant::value('CIVICRM_LOG_FILE_PERMISSIONS', '0664'),
+      'dirmode' => CRM_Utils_Constant::value('CIVICRM_LOG_FILE_DIR_PERMISSIONS', '0775'),
     ]);
     return $log;
   }

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -387,6 +387,16 @@ if (!defined('CIVICRM_MAIL_SMARTY')) {
 // }
 
 /**
+ * If needed to modify the file nad directory permissions for any LogFiles / directories created by Pear/log package
+ */
+// if (!defined('CIVICRM_LOG_FILE_PERMISSIONS')) {
+//   define('CIVICRM_LOG_FILE_PERMISSIONS', '0664');
+// }
+// if (!defined('CIVICRM_LOG_FILE_DIR_PERMISSIONS')) {
+//   define('CIVICRM_LOG_FILE_DIR_PERMISSIONS', '775');
+// }
+
+/**
  * This setting will only work if CIVICRM_MAIL_LOG is defined.  Mail will be logged and then sent.
  */
 //if (!defined('CIVICRM_MAIL_LOG_AND_SEND')) {


### PR DESCRIPTION
…r Log package for ConfigAndLog Files

Overview
----------------------------------------
This aims to make advantage of the file permissions modes in Pear_Log configuration to allow system admins to override the permissions

Before
----------------------------------------
Log files always created with 0644 permissions

After
----------------------------------------
Log files maybe created with 0644 or other linux perms a System Admin wants

@eileenmcnaughton @demeritcowboy @totten 