### PR TITLE
Use usage to determine which contact fields can be imported for contribution import

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -2352,15 +2352,17 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   protected function getAllContactFields(string $prefix = 'Contact.'): array {
     $allContactFields = (array) Contact::getFields()
       ->addWhere('readonly', '=', FALSE)
-      ->addWhere('type', 'IN', ['Field', 'Custom'])
+      ->addWhere('usage', 'CONTAINS', 'import')
       ->addWhere('fk_entity', 'IS EMPTY')
+      ->setAction('save')
       ->addOrderBy('title')
       ->execute()->indexBy('name');
 
     $contactTypeFields['Individual'] = (array) Contact::getFields()
       ->addWhere('readonly', '=', FALSE)
-      ->addWhere('type', 'IN', ['Field', 'Custom'])
+      ->addWhere('usage', 'CONTAINS', 'import')
       ->addWhere('fk_entity', 'IS EMPTY')
+      ->setAction('save')
       ->setSelect(['name'])
       ->addValue('contact_type', 'Individual')
       ->addOrderBy('title')
@@ -2368,8 +2370,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
 
     $contactTypeFields['Organization'] = (array) Contact::getFields()
       ->addWhere('readonly', '=', FALSE)
-      ->addWhere('type', 'IN', ['Field', 'Custom'])
+      ->addWhere('usage', 'CONTAINS', 'import')
       ->addWhere('fk_entity', 'IS EMPTY')
+      ->setAction('save')
       ->setSelect(['name'])
       ->addValue('contact_type', 'Organization')
       ->addOrderBy('title')
@@ -2377,8 +2380,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
 
     $contactTypeFields['Household'] = (array) Contact::getFields()
       ->addWhere('readonly', '=', FALSE)
-      ->addWhere('type', 'IN', ['Field', 'Custom'])
+      ->addWhere('usage', 'CONTAINS', 'import')
       ->addWhere('fk_entity', 'IS EMPTY')
+      ->setAction('save')
       ->setSelect(['name'])
       ->addOrderBy('title')
       ->execute()->indexBy('name');
@@ -2400,7 +2404,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
 
     $addressFields = (array) Address::getFields()
       ->addWhere('readonly', '=', FALSE)
-      ->addWhere('type', 'IN', ['Field', 'Custom'])
+      ->addWhere('usage', 'CONTAINS', 'import')
+      ->addWhere('fk_entity', 'IS EMPTY')
+      ->setAction('save')
       ->addOrderBy('title')
       // Exclude these fields to keep it simpler for now - we just map to primary
       ->addWhere('name', 'NOT IN', ['id', 'location_type_id', 'master_id'])
@@ -2415,7 +2421,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
 
     $phoneFields = (array) Phone::getFields()
       ->addWhere('readonly', '=', FALSE)
-      ->addWhere('type', 'IN', ['Field', 'Custom'])
+      ->addWhere('usage', 'CONTAINS', 'import')
+      ->addWhere('fk_entity', 'IS EMPTY')
+      ->setAction('save')
       // Exclude these fields to keep it simpler for now - we just map to primary
       ->addWhere('name', 'NOT IN', ['id', 'location_type_id', 'phone_type_id'])
       ->addOrderBy('title')
@@ -2429,7 +2437,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
 
     $emailFields = (array) Email::getFields()
       ->addWhere('readonly', '=', FALSE)
-      ->addWhere('type', 'IN', ['Field', 'Custom'])
+      ->addWhere('usage', 'CONTAINS', 'import')
+      ->addWhere('fk_entity', 'IS EMPTY')
+      ->setAction('save')
       // Exclude these fields to keep it simpler for now - we just map to primary
       ->addWhere('name', 'NOT IN', ['id', 'location_type_id'])
       ->addOrderBy('title')


### PR DESCRIPTION
Overview
----------------------------------------
Use usage to determine which contact fields can be imported for contribution import


This updates the getFields retrieval to filter on the usage being set to import rather than on the field type. This is more correct and also supports adding additional fields through extensions - ie the Deduper extension adds 'full_name' as a field for 'create/update' and when this is provided it uses a library to split it into parts it a somewhat correct way. Being able to access this via import is helpful for users who have data in this format.

Before
----------------------------------------
We added usage to the schema but didn't do much with it - 

After
----------------------------------------
With the schema being more hookable now we should respect it rather than relying on proxies. 
Also it is possible (which was the use case [here](https://github.com/eileenmcnaughton/deduper/commit/643fd6bfd5f264e2b9d2a5f0a413d976fe594191)) to add 'calculated' fields via the api & make them importable. 

Technical Details
----------------------------------------

Currently this function is only called via the Contribution.import and most of the fields are filtered out if civiimport is not enabled.

Note that there are some fields that are no longer available to import via the contribution import with this patch
- addressee_id
- is_deleted
- email_greeting_id
- postal_greeting_id
- preferred_mail_format

These do not have the usage of 'import' in the schema and I think they should have always been filtered out in this context.

I went back & forth on
- also filtering readonly = false (should be implicit in the usage IMHO)
- leaving `fk_entity` is null - I went for no change 
- setting the action to 'save' - I think this makes sense as these are importable fields & I don't want to have to make my create/update only field also apply to get which it seems to default to (rather than 'action_unspecified'

Comments
----------------------------------------
