### PR TITLE
[WIP] smarty5 - implode deprecated

### DIFF
--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -279,7 +279,7 @@
    {foreach from=$tagSetTags item=displayTagset}
      <p class="crm-block crm-content-block crm-case-caseview-display-tagset">
        &nbsp;&nbsp;<strong>{$displayTagset.label}:</strong>
-       {', '|implode:$displayTagset.items|escape}
+       {$displayTagset.items|join:', '|escape}
      </p>
    {/foreach}
 

--- a/templates/CRM/Tag/Page/Tag.tpl
+++ b/templates/CRM/Tag/Page/Tag.tpl
@@ -9,7 +9,7 @@
 *}
 <div class="crm-content-block">
   <div class="help">
-    {ts 1=', '|implode:$usedFor}Tags are a convenient way to categorize data (%1).{/ts}
+    {ts 1=$usedFor|join:', '}Tags are a convenient way to categorize data (%1).{/ts}
     {crmPermission has='administer Tagsets'}
       <br />
       {ts}Create predefined tags in the main tree, or click the <strong>+</strong> to add a set for free tagging.{/ts}
@@ -23,7 +23,7 @@
         <a href="#tree"><i class="crm-i fa-tags" aria-hidden="true"></i> {ts}Tag Tree{/ts}</a>
       </li>
       {foreach from=$tagsets item=set}
-        <li class="ui-corner-all crm-tab-button {if ($set.is_reserved)}is-reserved{/if}" title="{ts 1=', '|implode:$set.used_for_label}Tag Set for %1{/ts}">
+        <li class="ui-corner-all crm-tab-button {if ($set.is_reserved)}is-reserved{/if}" title="{ts 1=$set.used_for_label|join:', '}Tag Set for %1{/ts}">
           <a href="#tagset-{$set.id}">{$set.label}</a>
         </li>
       {/foreach}


### PR DESCRIPTION
Overview
----------------------------------------
Implode modifier is deprecated in smarty 5

Before
----------------------------------------
1. Create a tagset (not a bare tag) for cases.
2. Error message: `Deprecated: Using implode is deprecated. Use join using the array first, separator second`
3. On manage case add one or more of the tagset tags to the case.
4. More error messages: `Deprecated: Using implode is deprecated. Use join using the array first, separator second`

After
----------------------------------------


Technical Details
----------------------------------------
Reason given at https://github.com/smarty-php/smarty/issues/939#issuecomment-1963078637

Comments
----------------------------------------
There are other instances this just fixes one that was also coming up in some of my tests.
