### PR TITLE
smarty5 - implode is deprecated

### DIFF
--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -470,6 +470,10 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
         ];
         $tagSetTags[$tag['tag_id.parent_id']]['items'][] = $tag['tag_id.label'];
       }
+      // Add a displayable string version of the items
+      foreach ($tagSetTags as $tagIndex => $tagData) {
+        $tagSetTags[$tagIndex]['itemsStr'] = implode(', ', $tagData['items']);
+      }
     }
     $this->assign('tagSetTags', $tagSetTags);
     CRM_Core_Form_Tag::buildQuickForm($this, $parentNames, 'civicrm_case', $this->_caseID, FALSE, TRUE);

--- a/CRM/Tag/Page/Tag.php
+++ b/CRM/Tag/Page/Tag.php
@@ -47,6 +47,7 @@ class CRM_Tag_Page_Tag extends CRM_Core_Page {
     foreach ($result['values'] as $id => $tagset) {
       $used = explode(',', CRM_Utils_Array::value('used_for', $tagset, ''));
       $tagset['used_for_label'] = array_values(array_intersect_key($usedFor, array_flip($used)));
+      $tagset['used_for_label_str'] = implode(', ', $tagset['used_for_label']);
       if (isset($tagset['created_id.display_name'])) {
         $tagset['display_name'] = $tagset['created_id.display_name'];
       }
@@ -55,6 +56,7 @@ class CRM_Tag_Page_Tag extends CRM_Core_Page {
     }
 
     $this->assign('usedFor', $usedFor);
+    $this->assign('usedForStr', implode(', ', $usedFor));
     $this->assign('tagsets', $tagsets);
 
     return parent::run();

--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -279,7 +279,7 @@
    {foreach from=$tagSetTags item=displayTagset}
      <p class="crm-block crm-content-block crm-case-caseview-display-tagset">
        &nbsp;&nbsp;<strong>{$displayTagset.label}:</strong>
-       {', '|implode:$displayTagset.items|escape}
+       {$displayTagset.itemsStr|escape}
      </p>
    {/foreach}
 

--- a/templates/CRM/Tag/Page/Tag.tpl
+++ b/templates/CRM/Tag/Page/Tag.tpl
@@ -9,7 +9,7 @@
 *}
 <div class="crm-content-block">
   <div class="help">
-    {ts 1=', '|implode:$usedFor}Tags are a convenient way to categorize data (%1).{/ts}
+    {ts 1=$usedForStr}Tags are a convenient way to categorize data (%1).{/ts}
     {crmPermission has='administer Tagsets'}
       <br />
       {ts}Create predefined tags in the main tree, or click the <strong>+</strong> to add a set for free tagging.{/ts}
@@ -23,7 +23,7 @@
         <a href="#tree"><i class="crm-i fa-tags" aria-hidden="true"></i> {ts}Tag Tree{/ts}</a>
       </li>
       {foreach from=$tagsets item=set}
-        <li class="ui-corner-all crm-tab-button {if ($set.is_reserved)}is-reserved{/if}" title="{ts 1=', '|implode:$set.used_for_label}Tag Set for %1{/ts}">
+        <li class="ui-corner-all crm-tab-button {if ($set.is_reserved)}is-reserved{/if}" title="{ts 1=$set.used_for_label_str}Tag Set for %1{/ts}">
           <a href="#tagset-{$set.id}">{$set.label}</a>
         </li>
       {/foreach}


### PR DESCRIPTION
Overview
----------------------------------------
Implode modifier is deprecated in smarty 5

Alternate to https://github.com/civicrm/civicrm-core/pull/30932 because can't just use the replacement if need to work with smarty 4 too.

Before
----------------------------------------
1. Create a tagset (not a bare tag) for cases.
2. Error message: `Deprecated: Using implode is deprecated. Use join using the array first, separator second`
3. On manage case add one or more of the tagset tags to the case.
4. More error messages: `Deprecated: Using implode is deprecated. Use join using the array first, separator second`

After
----------------------------------------


Technical Details
----------------------------------------
Reason given at https://github.com/smarty-php/smarty/issues/939#issuecomment-1963078637

Comments
----------------------------------------
There are other instances this just fixes one that was also coming up in some of my tests.
