### PR TITLE
Add some noise to legacy callers of tokenValues, tokens

### DIFF
--- a/CRM/Contact/Tokens.php
+++ b/CRM/Contact/Tokens.php
@@ -260,7 +260,8 @@ class CRM_Contact_Tokens extends CRM_Core_EntityTokens {
         [$row->context['contactId']],
         empty($row->context['mailingJobId']) ? NULL : $row->context['mailingJobId'],
         $messageTokens,
-        $row->context['controller']
+        $row->context['controller'],
+        TRUE
       );
       foreach ($this->getHookTokens() as $category => $hookToken) {
         if (!empty($messageTokens[$category])) {
@@ -752,7 +753,7 @@ class CRM_Contact_Tokens extends CRM_Core_EntityTokens {
       return Civi::$statics[__CLASS__]['hook_tokens'];
     }
     $tokens = [];
-    \CRM_Utils_Hook::tokens($tokens);
+    \CRM_Utils_Hook::tokens($tokens, TRUE);
     Civi::$statics[__CLASS__]['hook_tokens'] = $tokens;
     return $tokens;
   }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -935,10 +935,21 @@ abstract class CRM_Utils_Hook {
    * @param array $tokens
    *   The list of tokens that can be used for the contact.
    *
+   * @param bool $squashDeprecation
+   *    Suppress the deprecation message - this should ONLY EVER BE CALLED
+   *    from the backward compatibilty adapter in `evaluateLegacyHookTokens`.
+   *    We are deprecating both this function, and the implementation of the hook
+   *    but for now we ensure that the hook is still rendered for
+   *    sites that implement it, via the TokenProcessor methodology
+   *    https://docs.civicrm.org/dev/en/latest/framework/token/#compose-batch
+   *
    * @return null
    */
-  public static function tokens(&$tokens) {
+  public static function tokens(&$tokens, bool $squashDeprecation = FALSE) {
     $null = NULL;
+    if (!$squashDeprecation) {
+      CRM_Core_Error::deprecatedFunctionWarning('call the token processor');
+    }
     return self::singleton()->invoke(['tokens'], $tokens,
       $null, $null, $null, $null, $null, 'civicrm_tokens'
     );
@@ -968,25 +979,36 @@ abstract class CRM_Utils_Hook {
    *   The array to store the token values indexed by contactIDs.
    * @param array $contactIDs
    *   An array of contactIDs.
-   * @param int $jobID
+   * @param null $jobID
    *   The jobID if this is associated with a CiviMail mailing.
    * @param array $tokens
    *   The list of tokens associated with the content.
-   * @param string $className
+   * @param null $className
    *   The top level className from where the hook is invoked.
-   *
-   * @deprecated since 5.71 will be removed sometime after all core uses are fully removed.
+   * @param bool $squashDeprecation
+   *   Suppress the deprecation message - this should ONLY EVER BE CALLED
+   *   from the backward compatibilty adapter in `evaluateLegacyHookTokens`.
+   *   We are deprecating both this function, and the implementation of the hook
+   *   but for now we ensure that the hook is still rendered for
+   *   sites that implement it, via the TokenProcessor methodology
+   *   https://docs.civicrm.org/dev/en/latest/framework/token/#compose-batch
    *
    * @return null
+   * @deprecated since 5.71 will be removed sometime after all core uses are fully removed.
+   *
    */
   public static function tokenValues(
     &$details,
     $contactIDs,
     $jobID = NULL,
     $tokens = [],
-    $className = NULL
+    $className = NULL,
+    $squashDeprecation = FALSE
   ) {
     $null = NULL;
+    if (!$squashDeprecation) {
+      CRM_Core_Error::deprecatedFunctionWarning('call the token processor');
+    }
     return self::singleton()
       ->invoke(['details', 'contactIDs', 'jobID', 'tokens', 'className'], $details, $contactIDs, $jobID, $tokens, $className, $null, 'civicrm_tokenValues');
   }


### PR DESCRIPTION
Overview
----------------------------------------
Add some noise to legacy callers of tokenValues, tokens

Before
----------------------------------------
The only core callers of this hook are
- some functions that themselves have noisy deprecation already AND
- the token processor compatibility layer 
![image](https://github.com/user-attachments/assets/44b14c59-08f6-400d-a361-2ef698032895)


After
----------------------------------------
A special parameter has been added for the token compatibility layer to call the hook without a deprecation notice but any other callers will get one

Technical Details
----------------------------------------
Of course people could add the parameter from their own code - but they would not then later be able to complain if the hook vanishes without notice....

I would have liked to also add notices for implementers of the hook but unfortunately the `afform` hook implemention is using this hook INSTEAD of the token processor caller https://github.com/civicrm/civicrm-core/pull/30924


Comments
----------------------------------------
