### PR TITLE
Revert "Add deprecation notice to hook_civicrm_links used by search forms"

### DIFF
--- a/CRM/Core/Action.php
+++ b/CRM/Core/Action.php
@@ -309,11 +309,7 @@ class CRM_Core_Action {
     }
 
     if ($op && $objectName && $objectId) {
-      $oldLinks = $seqLinks;
       CRM_Utils_Hook::links($op, $objectName, $objectId, $seqLinks, $mask, $values);
-      if ($oldLinks !== $seqLinks) {
-        Civi::log()->warning('Tabular screens that call hook_civicrm_links are being replaced by SearchKit. See https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_links/#notes', ['civi.tag' => 'deprecated']);
-      }
     }
 
     $url = [];


### PR DESCRIPTION
Reverts civicrm/civicrm-core#29765

This notice is more annoying than useful. See https://lab.civicrm.org/dev/core/-/issues/5096#note_169100

FYI @eileenmcnaughton 