### PR TITLE
Afform Admin: allow multi-select default values on more input types

### DIFF
--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -205,6 +205,9 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
     foreach (array_diff($entities, $this->skipEntities) as $entity) {
       $info['entities'][$entity] = AfformAdminMeta::getApiEntity($entity);
       $info['fields'][$entity] = AfformAdminMeta::getFields($entity, ['action' => $getFieldsMode]);
+      foreach ($info['fields'][$entity] as $key => $field) {
+        $info['fields'][$entity][$key]['original_input_type'] = $field['input_type'];
+      }
       $behaviors = AfformBehavior::get(FALSE)
         ->addWhere('entities', 'CONTAINS', $entity)
         ->execute();

--- a/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
@@ -51,6 +51,10 @@
           } else if (inputType) {
             multi = (dataType !== 'Boolean' &&
               (inputType === 'CheckBox' || (field.input_attrs && field.input_attrs.multiple)));
+            // Hidden fields are multi-select if the original input type is.
+            if (inputType === 'Hidden') {
+              multi = _.contains(['CheckBox', 'Radio', 'Select'], field.original_input_type);
+            }
           } else {
             multi = field.serialize || dataType === 'Array';
           }


### PR DESCRIPTION
Overview
----------------------------------------
The scenarios in which you can select multiple default values for an afform search filter is too strict.

For instance - if you want to display contributions with a status of "Failed" or "Cancelled".  You can do this if you add a filter and change the input type to "Checkboxes", but not if it's set to "Select" or "Hidden", both of which are valid configurations.

Before
----------------------------------------
Can't set multiple default values on any input type but checkboxes (unless the field is itself a multi-select):
![Selection_2354](https://github.com/user-attachments/assets/616de384-ecf7-4796-adf6-7ebe74498d71)

After
----------------------------------------
You can.

Comments
----------------------------------------
I debated whether to remove the "is not boolean" setting - but I can see a scenario where you want to display all values by default, but allow the user to unset one value or the other.
