### PR TITLE
Fix incorrect CSS in contribution invoice template

### DIFF
--- a/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
@@ -75,7 +75,7 @@
       </tr>
       {foreach from=$lineItems item=line}
         <tr>
-          <td style="text-align:left;nowrap"><font size="1">
+          <td style="text-align:left;white-space: nowrap"><font size="1">
             {$line.title}
           </font></td>
           <td style="text-align:right;"><font size="1">{$line.qty}</font></td>


### PR DESCRIPTION
Overview
----------------------------------------
Invalid CSS. I'm guessing that 'white-space: ' was an accidental omission.

Introduced in #16680.