### PR TITLE
dev/core#3769 Change default font family to sans-serif in print.css

### DIFF
--- a/css/print.css
+++ b/css/print.css
@@ -20,7 +20,7 @@ table.form-layout th {
 }
 #crm-container {
   overflow: visible !important;
-  font-family: DejaVu Sans, serif;
+  font-family: DejaVu Sans, sans-serif;
   margin: 0px 10px 0px 10px;
 }
 


### PR DESCRIPTION
The font family is set as DejaVu Sans but the fallback is `serif`. It would make more sense for this to be `sans-serif`.
