### PR TITLE
Fixed not of the type Float when a number has comma

### DIFF
--- a/CRM/Contact/Form/CustomData.php
+++ b/CRM/Contact/Form/CustomData.php
@@ -367,8 +367,7 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
    */
   public function postProcess() {
     // Get the form values and groupTree
-    //CRM-18183
-    $params = $this->controller->exportValues($this->_name);
+    $params = $this->getSubmittedValues();
 
     CRM_Core_BAO_CustomValueTable::postProcess($params,
       'civicrm_contact',


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5408

Before
----------------------------------------
![before](https://github.com/user-attachments/assets/cb03b5a0-919a-4ca2-84f8-e7c5cf1a4b14)


After
----------------------------------------
![after](https://github.com/user-attachments/assets/48c1d729-726e-475c-8dc1-643d0b3552ba)
