### PR TITLE
Change button type to upload to upload files

### DIFF
--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -383,6 +383,20 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
     //need to assign subtype to the template
     $this->assign('customDataSubType', $this->_gid);
     $this->assign('entityID', $this->_id);
+
+    if (($this->_action & CRM_Core_Action::ADD) || ($this->_action & CRM_Core_Action::UPDATE)) {
+      $this->addButtons([
+        [
+          'type' => 'upload',
+          'name' => ts('Save'),
+          'isDefault' => TRUE,
+        ],
+        [
+          'type' => 'cancel',
+          'name' => ts('Cancel'),
+        ],
+      ]);
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
If we have a custom set for OptionValue with a file custom field, the file is not uploaded because the button is not type upload.

Before
----------------------------------------
File not saved for the custom field

After
----------------------------------------
File saved for the custom field