### PR TITLE
Afform - Fix FK selects of form entities

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
@@ -109,6 +109,13 @@
         function getDataType() {
           if (ctrl.field) {
             dataType = ctrl.field.data_type;
+            // FK Entities can use a mix of numeric & string values (see `"static": options` above)
+            if (ctrl.field.fk_entity) {
+              dataType = 'String';
+            }
+          }
+          else {
+            dataType = null;
           }
         }
 

--- a/ext/afform/admin/ang/afGuiEditor/behaviors/autofillRelationshipBehaviorForm.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/behaviors/autofillRelationshipBehaviorForm.component.js
@@ -22,18 +22,15 @@
       // Initialize or rebuild form field
       this.$onChanges = function(changes) {
         if (changes.selectedType) {
-          var selectedType = _.find(ctrl.relTypes, {name: ctrl.selectedType});
-          if (!ctrl.relatedContactField || ctrl.relatedContactField.input_attrs.filter.contact_type !== selectedType.contact_type) {
+          let selectedType = _.find(ctrl.relTypes, {name: ctrl.selectedType});
+          let contactType = selectedType.contact_type || 'Contact';
+          if (!ctrl.relatedContactField || ctrl.relatedContactField.fk_entity !== contactType) {
             // Replacing the variable with a new object will trigger the afGuiFieldValue to refresh
             ctrl.relatedContactField = {
               input_type: 'EntityRef',
               data_type: 'Integer',
-              fk_entity: 'Contact',
-              input_attrs: {filter: {}}
+              fk_entity: contactType,
             };
-            if (selectedType.contact_type) {
-              ctrl.relatedContactField.input_attrs.filter.contact_type = selectedType.contact_type;
-            }
           }
         }
       };


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug from https://chat.civicrm.org/civicrm/pl/pngpnbatopddzrczesqysmz61o

Technical Details
-------
This is a regression caused by afde330ff

Forcing the data to match an integer doesn't work for FK fields because of the way Afform oveloads those values with string references to other form entities (e.g. 'Individual1') or 'user_contact_id'.