### PR TITLE
change standaloneusers session lifetime setting units to minutes

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -588,7 +588,8 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
       $session_cookie_name = 'SESSCIVISO';
     }
 
-    $session_max_lifetime = Civi::settings()->get('standaloneusers_session_max_lifetime') ?? 1440;
+    // session lifetime in seconds (default = 24 minutes)
+    $session_max_lifetime = (Civi::settings()->get('standaloneusers_session_max_lifetime') ?? 24) * 60;
 
     session_start([
       'cookie_httponly'  => 1,

--- a/ext/standaloneusers/Civi/Standalone/SessionHandler.php
+++ b/ext/standaloneusers/Civi/Standalone/SessionHandler.php
@@ -145,7 +145,7 @@ class SessionHandler implements SessionHandlerInterface, SessionIdInterface, Ses
     $this->data = $session['data'];
     $maxLifetime = \Civi::settings()->get('standaloneusers_session_max_lifetime');
 
-    return strtotime($session['last_accessed']) >= strtotime("-$maxLifetime seconds");
+    return strtotime($session['last_accessed']) >= strtotime("-$maxLifetime minutes");
   }
 
   /**

--- a/ext/standaloneusers/settings/standaloneusers.setting.php
+++ b/ext/standaloneusers/settings/standaloneusers.setting.php
@@ -6,9 +6,9 @@ return [
     'group'       => 'standaloneusers',
     'type'        => 'Integer',
     'title'       => ts('Maxiumum Session Lifetime'),
-    'description' => ts('Duration (in seconds) until a user session expires'),
+    'description' => ts('Duration (in minutes) until a user session expires'),
     // 24 days (= Drupal default)
-    'default'     => 24 * 24 * 60 * 60,
+    'default'     => 24 * 24 * 60,
     'html_type'   => 'text',
     'is_domain'   => 1,
     'is_contact'  => 0,


### PR DESCRIPTION
Overview
----------------------------------------
Change the underlying units of this setting from seconds to minutes to make the UI more human-friendly.

Comments
----------------------------------------
Lose the ability to set sub-minute accuracy - though can't see a use case for this.

No upgrader - existing sites will suddenly have 60 times longer session timeout.

However Standalone is still in preview, so no real sites should have values. (There's only been a UI to set this setting for a few days on `master`).
