### PR TITLE
dev/core#5405 - Domain Org form - remove old code that doesn't do anything and smarty doesn't like

### DIFF
--- a/templates/CRM/Contact/Form/Domain.tpl
+++ b/templates/CRM/Contact/Form/Domain.tpl
@@ -55,10 +55,3 @@
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 {/if}
 </div>
-
-{* phone_2 a email_2 only included in form if CiviMail enabled. *}
-{if array_search('CiviMail', $config->enableComponents)}
-    <script type="text/javascript">
-    cj('a#addEmail,a#addPhone').hide();
-    </script>
-{/if}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5405

Before
----------------------------------------
1. Admin - communications - Org Address
2. Crash

After
----------------------------------------


Technical Details
----------------------------------------
The "need" for this code was made unnecessary by https://github.com/civicrm/civicrm-core/commit/db255f7f6fdc20323507dd378cabb8e92e49427f. This form used to include the whole email/phone block form. Now it's just the needed fields, so there is no field this code is trying to act on anymore.

Comments
----------------------------------------

