### PR TITLE
[REF] Fix undefined constant on closed batches

### DIFF
--- a/CRM/Batch/BAO/Batch.php
+++ b/CRM/Batch/BAO/Batch.php
@@ -440,7 +440,7 @@ class CRM_Batch_BAO_Batch extends CRM_Batch_DAO_Batch implements \Civi\Core\Hook
           'url' => 'civicrm/financial/batch',
           'qs' => 'reset=1&action=update&id=%%id%%&context=1',
           'title' => ts('Edit Batch'),
-          'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::EDIT),
+          'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::UPDATE),
         ],
         'close' => [
           'name' => ts('Close'),


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a goofball in https://github.com/civicrm/civicrm-core/commit/63aa5eb0c5ff128e28708137cadbf92d6148500a as there is no CRM_Core_Action::EDIT but there is a CRM_Core_Action::UPDATE constant

Before
----------------------------------------
Undefined constant error

After
----------------------------------------
No Error

@eileenmcnaughton Note that based on the commit this only went out in 5.76