### PR TITLE
Less opinionated nav menu editor styling => dark mode compatible

### DIFF
--- a/CRM/Admin/Page/Navigation.php
+++ b/CRM/Admin/Page/Navigation.php
@@ -81,9 +81,11 @@ class CRM_Admin_Page_Navigation extends CRM_Core_Page_Basic {
     $this->assign('homeMenuId', $homeMenuId);
 
     // Add jstree support
-    CRM_Core_Resources::singleton()
-      ->addScriptFile('civicrm', 'bower_components/jstree/dist/jstree.min.js', 0, 'html-header')
-      ->addStyleFile('civicrm', 'bower_components/jstree/dist/themes/default/style.min.css');
+    Civi::resources()->addScriptFile('civicrm', 'bower_components/jstree/dist/jstree.min.js', 0, 'html-header');
+    Civi::resources()->addStyleFile('civicrm', 'bower_components/jstree/dist/themes/default/style.min.css');
+
+    // Add our styles
+    Civi::resources()->addStyleFile('civicrm', 'css/admin.css');
   }
 
 }

--- a/css/admin.css
+++ b/css/admin.css
@@ -61,9 +61,15 @@
 
 /* Navigation menu editor */
 .crm-container .navigation-tree {
- /* background-color: #ffffff; */
- height: auto; 
- border-collapse: separate;
+  height: auto;
+  border-collapse: separate;
+}
+/* reduce the default hover/clicked background colors to tints for more downstream compatibility */
+.crm-container .navigation-tree .jstree-hovered {
+  background: #ffffff50;
+}
+.crm-container .navigation-tree .jstree-clicked {
+  background: #beebff50;
 }
 
 @media screen and (min-width: 480px) {

--- a/css/admin.css
+++ b/css/admin.css
@@ -59,6 +59,13 @@
   color: #00994d;
 }
 
+/* Navigation menu editor */
+.crm-container .navigation-tree {
+ /* background-color: #ffffff; */
+ height: auto; 
+ border-collapse: separate;
+}
+
 @media screen and (min-width: 480px) {
   #crm-container .admin-section-items {
     column-count: 2;

--- a/css/admin.css
+++ b/css/admin.css
@@ -59,11 +59,7 @@
   color: #00994d;
 }
 
-/* Navigation menu editor */
-.crm-container .navigation-tree {
-  height: auto;
-  border-collapse: separate;
-}
+/* Navigation Menu Editor */
 /* reduce the default hover/clicked background colors to tints for more downstream compatibility */
 .crm-container .navigation-tree .jstree-hovered {
   background: #ffffff50;

--- a/templates/CRM/Admin/Page/Navigation.tpl
+++ b/templates/CRM/Admin/Page/Navigation.tpl
@@ -24,7 +24,7 @@
     </div>
     <div class="spacer"></div>
     <div style="padding-left: 48px;"><img src="{$config->resourceBase}i/logo_sm.png" /></div>
-    <div id="navigation-tree" class="navigation-tree" style="height:auto; border-collapse:separate; background-color:#FFFFFF;"></div>
+    <div id="navigation-tree" class="navigation-tree"></div>
     <div class="spacer"></div>
     <div>
       <a href="#" class="nav-reset crm-hover-button">


### PR DESCRIPTION

Before
----------------------------------------
- Navigation menu editor has inline styles which are hard to theme downstream
- Some fixed background colors which don't work with dark mode

Riverlea Hackney Brook Dark Mode:
![image](https://github.com/user-attachments/assets/d89a265f-b583-4956-b180-9864ec06036c)



After
----------------------------------------
- No fixed background color for the overall container
- Tints instead of block colors for hover and click styles on the individual items

Riverlea Hackney Brook Dark Mode:
[Screencast from 2024-08-23 14-38-08.webm](https://github.com/user-attachments/assets/5a9c921e-1ce8-4d03-9049-a4f45fe59ed2)

Standard Greenwich:
![image](https://github.com/user-attachments/assets/2f6314b5-44b5-4491-8729-2fa5d99a9234)


