### PR TITLE
standalone: remove unused css vars, tweak standalone-specific css to use Riverlea vars

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -4004,17 +4004,8 @@ span.crm-status-icon {
 
 /* Standalone-only styles. A minimal set to make it usable out-of-the-box. */
 html.crm-standalone body {
-  --sa-font-family: sans-serif;
-  --roundness: 3px;
-  --error-colour: #a00;
-  --warning-colour: #fbb862;
-  --success-colour: #86c66c;
-  --label-colour: #464354;
-  --background-colour: rgb(242,242,237);
-  --box-padding: 1.6rem;
-  --box-background: #fff;
   margin: 0;
   padding: 0;
-  font-family: var(--sa-font-family);
-  background-color: var(--background-colour);
+  font-family: var(--crm-font, sans-serif);
+  background-color: var(--crm-c-page-background, #f8f8f8);
 }


### PR DESCRIPTION
As raised at https://lab.civicrm.org/extensions/riverlea/-/issues/26#note_168528

This removes some variable that are not used, and where vars are referenced, they belong to Riverlea