### PR TITLE
[PHP8.4] Don't implicitly mark params as null

### DIFF
--- a/ext/afform/core/Civi/Afform/Event/AfformEventEntityTrait.php
+++ b/ext/afform/core/Civi/Afform/Event/AfformEventEntityTrait.php
@@ -90,7 +90,7 @@ trait AfformEventEntityTrait {
    * @param string|null $entityName
    * @return array
    */
-  public function getEntityIds(string $entityName = NULL): array {
+  public function getEntityIds(?string $entityName = NULL): array {
     $entityName = $entityName ?: $this->entityName;
     $apiEntity = $this->getFormDataModel()->getEntity($entityName)['type'];
     $idField = CoreUtil::getIdFieldName($apiEntity);

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -355,10 +355,10 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    *
    * @param array[] $styleRules
    * @param array $data
-   * @param int $index
+   * @param int|null $index
    * @return array
    */
-  protected function getCssStyles(array $styleRules, array $data, int $index = NULL) {
+  protected function getCssStyles(array $styleRules, array $data, ?int $index = NULL) {
     $classes = [];
     foreach ($styleRules as $clause) {
       $cssClass = $clause[0] ?? '';
@@ -558,7 +558,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    * @return array|null
    * @throws \CRM_Core_Exception
    */
-  protected function formatLink(array $link, array $data, bool $allowMultiple = FALSE, string $text = NULL, $index = 0): ?array {
+  protected function formatLink(array $link, array $data, bool $allowMultiple = FALSE, ?string $text = NULL, $index = 0): ?array {
     $useApi = (!empty($link['entity']) && !empty($link['action']));
     if (isset($index)) {
       foreach ($data as $key => $value) {

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -476,7 +476,7 @@ class Admin {
    * @param string|null $dynamicCol
    * @return array[]
    */
-  private static function getJoinConditions(string $nearCol, string $farCol, string $dynamicValue = NULL, string $dynamicCol = NULL):array {
+  private static function getJoinConditions(string $nearCol, string $farCol, ?string $dynamicValue = NULL, ?string $dynamicCol = NULL):array {
     $conditions = [
       [
         $nearCol,

--- a/mixin/lib/civimix-schema/src/DAO.php
+++ b/mixin/lib/civimix-schema/src/DAO.php
@@ -81,7 +81,7 @@ return new class() extends \CRM_Core_DAO {
   /**
    * @inheritDoc
    */
-  public static function getEntityIcon(string $entityName, int $entityId = NULL): ?string {
+  public static function getEntityIcon(string $entityName, ?int $entityId = NULL): ?string {
     return static::getEntityInfo()['icon'] ?? NULL;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
In PHP 8.4 Implicitly marking parameters as nullable is going to be deprecated.

Most of these were already caught by https://github.com/civicrm/civicrm-core/pull/30806, but this handles a few more instances.

See also https://stitcher.io/blog/new-in-php-84#implicit-nullable-types-deprecation
