### PR TITLE
[REF][PHP8.2] Fix deprecated property on CRM_Contact_Page_View_Log

### DIFF
--- a/CRM/Contact/Page/View/Log.php
+++ b/CRM/Contact/Page/View/Log.php
@@ -17,6 +17,12 @@
 class CRM_Contact_Page_View_Log extends CRM_Core_Page {
 
   /**
+   * @var int
+   * @internal
+   */
+  public $_contactId;
+
+  /**
    * Called when action is browse.
    *
    * @return null


### PR DESCRIPTION
Overview
----------------------------------------
Fixes yet another dynamic property, which were deprecated in PHP 8.2.

Before
----------------------------------------
Visiting the change log tab on a contact record triggered a deprecation notice.

After
----------------------------------------
`_contactId` declared. I've made it `public`, just in case any extensions are using it, but to be honest I'm probably playing it a bit too safe there.