### PR TITLE
Check parents key exists in GroupsCommon.tpl

### DIFF
--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -81,7 +81,6 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
    * @throws \CRM_Core_Exception
    */
   public function preProcess() {
-    $this->addOptionalQuickFormElement('parents');
     $this->addExpectedSmartyVariables([
       'parent_groups',
       'editSmartGroupURL',

--- a/templates/CRM/Group/Form/GroupsCommon.tpl
+++ b/templates/CRM/Group/Form/GroupsCommon.tpl
@@ -7,12 +7,14 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-<table class="form-layout-compressed">
-  <tr class="crm-group-form-block-parents">
-    <td class="label">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{$form.parents.label}</td>
-    <td>{$form.parents.html|crmAddClass:huge}</td>
-  </tr>
-</table>
+{if array_key_exists('parents', $form)}
+  <table class="form-layout-compressed">
+    <tr class="crm-group-form-block-parents">
+      <td class="label">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{$form.parents.label}</td>
+      <td>{$form.parents.html|crmAddClass:huge}</td>
+    </tr>
+  </table>
+{/if}
 {if array_key_exists('organization_id', $form)}
   <h3>{ts}Associated Organization{/ts} {help id="id-group-organization" file="CRM/Group/Page/Group.hlp"}</h3>
   <table class="form-layout-compressed">


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a Deprecation notice when adding a group for the first time.

Before
----------------------------------------
On a clean install (with no sample data), visiting the add groups screen will trigger a deprecation notice:
<img width="1211" alt="Screenshot 2024-08-24 at 19 06 09" src="https://github.com/user-attachments/assets/3beb365e-7116-403c-88d0-b4b4469baca6">

```
str_replace(): Passing null to parameter #3 ($subject) of type array\|string is deprecated
```

This is caused by the fact that in [`buildParentGroups`](https://github.com/civicrm/civicrm-core/blob/b7cba5370d76dbb821baa402e980dda8339c47fa/CRM/Group/Form/Edit.php#L361), there is a check that more than one group already exists before adding the field to the form: `if (count($parentGroupSelectValues) > 1)`. 

Therefore, when `{$form.parents.html|crmAddClass:huge}` is called within the template, `null` was being passed to `crmAddClass`, and `crmAddClass` was passing that `null` into `str_replace`.


After
----------------------------------------
`GroupsCommon.tpl` checks that `parents` exists on the form (in the same way that it already does a check on `organization_id`).


Comments
----------------------------------------
I wonder if `crmAddClass` should also cast `null` to `string` to avoid any deprecation notices when `crmAddClass` is accidentally applied to `null` values. But on the other hand, perhaps the deprecation notice is a helpful hint that the template needs some work...
