### PR TITLE
Only run buildSubTypes ajax call if contact type is set

### DIFF
--- a/templates/CRM/Import/Form/DataSource.tpl
+++ b/templates/CRM/Import/Form/DataSource.tpl
@@ -145,9 +145,15 @@
 
     function buildSubTypes( )
     {
-      element = cj('input[name="contactType"]:checked').val( );
-      var postUrl = {/literal}"{crmURL p='civicrm/ajax/subtype' h=0}"{literal};
-      var param = 'parentId='+ element;
+      const element = cj('input[name="contactType"]:checked');
+      if (!element.length) {
+        // There are no contact fields on some import forms (e.g. import of activities)
+        return;
+      }
+
+      const elementVal = element.val( );
+      const postUrl = {/literal}"{crmURL p='civicrm/ajax/subtype' h=0}"{literal};
+      const param = 'parentId='+ elementVal;
       cj.ajax({ type: "POST", url: postUrl, data: param, async: false, dataType: 'json',
         success: function(subtype)
         {


### PR DESCRIPTION
Overview
----------------------------------------
Only run buildSubTypes ajax call if contact type is set.

Before
----------------------------------------
On import screens, an ajax call is made on page load (and on change of the selected parent type) to fetch the subtypes from the server.

However, on the "import activities" screen there is no contact type field, and so the ajax endpoint was being called with `parentId=undefined` causing PHP notices. 

After
----------------------------------------
The `buildSubTypes` does an early return (not performing the ajax call) if no parent ID can be found.

Technical Details
----------------------------------------
I assume we're happy that `const` is suitably supported by all browsers now? If not I'll change to `var`.