### PR TITLE
[REF][PHP8.2] Declare parentID property

### DIFF
--- a/CRM/Admin/Form/ContactType.php
+++ b/CRM/Admin/Form/ContactType.php
@@ -21,6 +21,11 @@
 class CRM_Admin_Form_ContactType extends CRM_Admin_Form {
 
   /**
+   * @var int|null
+   */
+  protected $parentId;
+
+  /**
    * Explicitly declare the entity api name.
    */
   public function getDefaultEntity() {
@@ -51,9 +56,9 @@ class CRM_Admin_Form_ContactType extends CRM_Admin_Form {
       $contactTypeName = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_ContactType', $this->_id, 'name');
       $this->assign('contactTypeName', $contactTypeName);
 
-      $this->_parentId = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_ContactType', $this->_id, 'parent_id');
+      $this->parentId = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_ContactType', $this->_id, 'parent_id');
       // Freeze Enabled field for built-in contact types (parent_id is NULL for these)
-      if (is_null($this->_parentId)) {
+      if (is_null($this->parentId)) {
         $enabled->freeze();
       }
     }
@@ -131,7 +136,7 @@ class CRM_Admin_Form_ContactType extends CRM_Admin_Form {
     if ($this->_action & CRM_Core_Action::UPDATE) {
       $params['id'] = $this->_id;
       // Force Enabled = true for built-in contact types to fix problems caused by CRM-6471 (parent_id is NULL for these types)
-      if (is_null($this->_parentId)) {
+      if (is_null($this->parentId)) {
         $params['is_active'] = 1;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a deprecation when editing contact types:

```
Creation of dynamic property CRM_Admin_Form_ContactType::$_parentId is deprecated
```

Before
----------------------------------------
Editing a contact type triggers a deprecation notice.

After
----------------------------------------
No deprecation notice.

Technical Details
----------------------------------------
This property is only used to ensure parent contact types are always enabled. As such I judged it was safe enough to make `protected`.