### PR TITLE
"View Contact" - Stop trying to read undefined oplock_ts in templates

### DIFF
--- a/templates/CRM/Contact/Form/Inline/Address.tpl
+++ b/templates/CRM/Contact/Form/Inline/Address.tpl
@@ -8,7 +8,6 @@
  +--------------------------------------------------------------------+
 *}
 {* This file builds html for address block inline edit *}
-{$form.oplock_ts.html}
   <table class="form-layout crm-edit-address-form crm-inline-edit-form">
     <tr>
       <td>

--- a/templates/CRM/Contact/Form/Inline/CommunicationPreferences.tpl
+++ b/templates/CRM/Contact/Form/Inline/CommunicationPreferences.tpl
@@ -9,7 +9,6 @@
 *}
 {* This file provides the plugin for the communication preferences in all the three types of contact *}
 {* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller *}
-{$form.oplock_ts.html}
 
  <div class="crm-inline-edit-form">
     <div class="crm-inline-button">

--- a/templates/CRM/Contact/Form/Inline/ContactInfo.tpl
+++ b/templates/CRM/Contact/Form/Inline/ContactInfo.tpl
@@ -7,7 +7,6 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{$form.oplock_ts.html}
 <div class="crm-inline-edit-form">
   <div class="crm-inline-button">
     {include file="CRM/common/formButtons.tpl" location=''}

--- a/templates/CRM/Contact/Form/Inline/ContactName.tpl
+++ b/templates/CRM/Contact/Form/Inline/ContactName.tpl
@@ -8,7 +8,6 @@
  +--------------------------------------------------------------------+
 *}
 {* This file builds html for Contact Display Name inline edit *}
-{$form.oplock_ts.html}
 <div class="crm-inline-edit-form">
   <div class="crm-inline-button">
     {include file="CRM/common/formButtons.tpl" location=''}

--- a/templates/CRM/Contact/Form/Inline/CustomData.tpl
+++ b/templates/CRM/Contact/Form/Inline/CustomData.tpl
@@ -8,7 +8,6 @@
  +--------------------------------------------------------------------+
 *}
 
-{$form.oplock_ts.html}
 <div class="crm-inline-edit-form">
   <div class="crm-inline-button">
     {include file="CRM/common/formButtons.tpl" location=''}

--- a/templates/CRM/Contact/Form/Inline/Demographics.tpl
+++ b/templates/CRM/Contact/Form/Inline/Demographics.tpl
@@ -7,7 +7,6 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{$form.oplock_ts.html}
 <div class="crm-inline-edit-form">
   <div class="crm-inline-button">
     {include file="CRM/common/formButtons.tpl" location=''}

--- a/templates/CRM/Contact/Form/Inline/Email.tpl
+++ b/templates/CRM/Contact/Form/Inline/Email.tpl
@@ -8,7 +8,6 @@
  +--------------------------------------------------------------------+
 *}
 {* This file provides the template for inline editing of emails *}
-{$form.oplock_ts.html}
 <table class="crm-inline-edit-form">
   <tr>
     <td colspan="5">

--- a/templates/CRM/Contact/Form/Inline/IM.tpl
+++ b/templates/CRM/Contact/Form/Inline/IM.tpl
@@ -8,7 +8,6 @@
  +--------------------------------------------------------------------+
 *}
 {* This file provides the template for inline editing of ims *}
-{$form.oplock_ts.html}
 <table class="crm-inline-edit-form">
     <tr>
       <td colspan="5">

--- a/templates/CRM/Contact/Form/Inline/OpenID.tpl
+++ b/templates/CRM/Contact/Form/Inline/OpenID.tpl
@@ -8,7 +8,6 @@
  +--------------------------------------------------------------------+
 *}
 {* This file provides the template for inline editing of openids *}
-{$form.oplock_ts.html}
 <table class="crm-inline-edit-form">
   <tr>
     <td colspan="4">

--- a/templates/CRM/Contact/Form/Inline/Phone.tpl
+++ b/templates/CRM/Contact/Form/Inline/Phone.tpl
@@ -8,7 +8,6 @@
  +--------------------------------------------------------------------+
 *}
 {* This file provides the template for inline editing of phones *}
-{$form.oplock_ts.html}
 <table class="crm-inline-edit-form">
     <tr>
       <td colspan="5">

--- a/templates/CRM/Contact/Form/Inline/Website.tpl
+++ b/templates/CRM/Contact/Form/Inline/Website.tpl
@@ -8,7 +8,6 @@
  +--------------------------------------------------------------------+
 *}
 {* This file provides the template for inline editing of websites *}
-{$form.oplock_ts.html}
 <table class="crm-inline-edit-form">
     <tr>
       <td colspan="5">


### PR DESCRIPTION
Overview
----------------------------------------
Stop trying to read undefined oplock_ts in templates.

_This change feels wrong, but I'm fairly sure it's right..._

Before
----------------------------------------
When opening any of the inline edit forms on the contact summary screen, some Smarty notices would appear in the logs:

```
[25-Aug-2024 09:11:00 UTC] PHP Warning:  Undefined array key "oplock_ts" in /Users/bradleytaylor/Local Sites/cividev3/app/public/wp-content/uploads/civicrm/templates_c/en_GB/4b/71/b8/4b71b8d0888e0c9debb967c4330d8ec4d874e869_0.file_Address.tpl.php on line 38
[25-Aug-2024 09:11:00 UTC] PHP Warning:  Trying to access array offset on null in /Users/bradleytaylor/Local Sites/cividev3/app/public/wp-content/uploads/civicrm/templates_c/en_GB/4b/71/b8/4b71b8d0888e0c9debb967c4330d8ec4d874e869_0.file_Address.tpl.php on line 38
```

After
----------------------------------------
No such notices (but the oplock functionality still works as expected).

Technical Details
----------------------------------------
In `CRM_Contact_Form_Inline_Lock`, the oplock field is added as so:

```
$form->addElement('hidden', 'oplock_ts', $timestamps['modified_date'], ['id' => 'oplock_ts']);
```

So I think the references to `{$form.oplock_ts.html}` expected the hidden field to be output at that point in the template. However, hidden fields are not output one-by-one, but are instead automatically included in `civicrm/templates/CRM/Form/body.tpl`:
```
{if !empty($form.hidden)}
  <div>{$form.hidden}</div>
{/if}
```

This is old code, and so I guess it's just never been noticed before that the `oplock_ts` field was being output correctly, even without it needing to be explicitly included in the individual form templates.

I've tested that the lock warnings are still shown as expected following this change, and the forms still correctly include the oplock field:
```
<input id="oplock_ts" name="oplock_ts" type="hidden" value="2024-08-25 09:10:58">
```

Therefore, there is no change to functionality with this change.