### PR TITLE
dev/user-interface#54 Move Contact Delete under the Actions menu

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2992,6 +2992,20 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
       ];
     }
 
+    if (CRM_Core_Permission::check('delete contacts')) {
+      $menu['otherActions']['delete'] = [
+        'title' => ts('Delete'),
+        'description' => ts('Delete Contact'),
+        'weight' => 90,
+        'ref' => 'crm-contact-delete',
+        'key' => 'delete',
+        'tab' => 'delete',
+        'class' => 'delete',
+        'href' => CRM_Utils_System::url('civicrm/contact/view/delete', "reset=1&delete=1&id=$contactId"),
+        'icon' => 'crm-i fa-trash',
+      ];
+    }
+
     $uid = CRM_Core_BAO_UFMatch::getUFId($contactId);
     if ($uid) {
       $menu['otherActions']['user-record'] = [

--- a/templates/CRM/Contact/Page/View/Summary.tpl
+++ b/templates/CRM/Contact/Page/View/Summary.tpl
@@ -66,14 +66,6 @@
           {/if}
         {/crmPermission}
 
-        {crmPermission has='delete contacts'}
-          <li class="crm-contact-delete">
-            {crmButton p='civicrm/contact/view/delete' q="reset=1&delete=1&cid=$contactId" class="delete" icon="trash"}
-              {ts}Delete Contact{/ts}
-            {/crmButton}
-          </li>
-        {/crmPermission}
-
         {* Previous and Next contact navigation when accessing contact summary from search results. *}
         {if $nextPrevError}
           <li class="crm-next-action">


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/user-interface/-/issues/54

The "Delete Contact" takes a lot of central space on the View Contact screen, for something that should not be used so often. It'

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/6559fa37-4802-4f54-9477-7cda0cf8f16a)


After
----------------------------------------

![image](https://github.com/user-attachments/assets/0bc43071-c39d-4f5c-863d-3c97d316c120)

Comments
----------------------------------------

From the issue ui54:

> "+1 agree that this would be a much appreciated improvement" -KevinC

> "Cue much swearing." -out of context, partial quote from Andew W

> "Overall, if the goal is to reduce accidental deletions and streamline the interface, moving the delete option to the Actions menu is a reasonable approach." -ChatGPT (actual quote, but it's a joke, of course)

I'll blog about it, and will update admin docs, if this is merged. It might confuse a few old-time power-users.

Old  (closed) PR: #26903