### PR TITLE
[NFC] CRM_Contact_Page_View: Remove unused dashboardURL variable

### DIFF
--- a/CRM/Contact/Page/View.php
+++ b/CRM/Contact/Page/View.php
@@ -341,13 +341,6 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
     }
     $obj->assign('userRecordUrl', $userRecordUrl);
 
-    if (CRM_Core_Permission::check('access Contact Dashboard')) {
-      $dashboardURL = CRM_Utils_System::url('civicrm/user',
-        "reset=1&id={$cid}"
-      );
-      $obj->assign('dashboardURL', $dashboardURL);
-    }
-
     // See if other modules want to add links to the activtity bar
     $hookLinks = [];
     CRM_Utils_Hook::links('view.contact.activity',


### PR DESCRIPTION
Overview
----------------------------------------

While poking around for #30967, I stumbled on this code, and could not figure out where it was used.

The code has been since 2007, but the template using the variable was removed before 2013 (git migration).