### PR TITLE
Remove deprecated hook_civicrm_customFieldOptions

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2731,7 +2731,6 @@ WHERE      f.id IN ($ids)";
       elseif ($dataType === 'Boolean') {
         $options = $context === 'validate' ? [0, 1] : CRM_Core_SelectValues::boolean();
       }
-      CRM_Utils_Hook::customFieldOptions($id, $options);
       CRM_Utils_Hook::fieldOptions($entity, "custom_{$id}", $options, ['context' => $context]);
       $cache->set($cacheKey, $options);
     }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1054,32 +1054,6 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
-   * This hook is called when CiviCRM needs to edit/display a custom field with options
-   *
-   * @deprecated in favor of hook_civicrm_fieldOptions
-   *
-   * @param int $customFieldID
-   *   The custom field ID.
-   * @param array $options
-   *   The current set of options for that custom field.
-   *   You can add/remove existing options.
-   *   Important: This array may contain meta-data about the field that is needed elsewhere, so it is important
-   *              to be careful to not overwrite the array.
-   *   Only add/edit/remove the specific field options you intend to affect.
-   * @param bool $detailedFormat
-   *   If true, the options are in an ID => array ( 'id' => ID, 'label' => label, 'value' => value ) format
-   *
-   * @return mixed
-   */
-  public static function customFieldOptions($customFieldID, &$options, $detailedFormat = FALSE) {
-    $null = NULL;
-    return self::singleton()->invoke(['customFieldID', 'options', 'detailedFormat'], $customFieldID, $options, $detailedFormat,
-      $null, $null, $null,
-      'civicrm_customFieldOptions'
-    );
-  }
-
-  /**
    * Hook for modifying field options
    *
    * @param string $entity


### PR DESCRIPTION
Overview
----------------------------------------
Removes a redundant hook that's been deprecated for 9 years, with no uses found in `universe`.