### PR TITLE
Allow 'Expires' placeholder text to be translated

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -87,21 +87,24 @@
           settings.start_date_years = settings.start_date_years || 100;
           settings.end_date_years = settings.end_date_years || 100;
 
-          element
-            .crmDatepicker(settings)
-            .on('change', function() {
-              // Because change gets triggered from the $render function we could be either inside or outside the $digest cycle
-              $timeout(function() {
-                let requiredLength = 19;
-                if (settings.time === false) {
-                  requiredLength = 10;
-                }
-                if (settings.date === false) {
-                  requiredLength = 8;
-                }
-                ngModel.$setValidity('incompleteDateTime', !(element.val().length && element.val().length !== requiredLength));
+          // Wait for interpolated elements like {{placeholder}} to render
+          $timeout(function() {
+            element
+              .crmDatepicker(settings)
+              .on('change', function () {
+                // Because change gets triggered from the $render function we could be either inside or outside the $digest cycle
+                $timeout(function() {
+                  let requiredLength = 19;
+                  if (settings.time === false) {
+                    requiredLength = 10;
+                  }
+                  if (settings.date === false) {
+                    requiredLength = 8;
+                  }
+                  ngModel.$setValidity('incompleteDateTime', !(element.val().length && element.val().length !== requiredLength));
+                });
               });
-            });
+          });
         }
       };
     })
@@ -658,6 +661,7 @@
               };
             });
           } else {
+            // Wait for interpolated elements like {{placeholder}} to render
             $timeout(init);
           }
         }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearch-settings.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearch-settings.html
@@ -3,7 +3,7 @@
   <label class="sr-only" for="expires_date">{{:: ts('Search Expiry Date') }}</label>
   <div class="input-group">
     <div class="input-group-addon"><i class="crm-i fa-calendar-times-o"></i></div>
-    <input id="expires_date" class="form-control" crm-ui-datepicker="{time: true}" ng-model="$ctrl.savedSearch.expires_date" placeholder="Expires">
+    <input id="expires_date" class="form-control" crm-ui-datepicker="{time: true}" ng-model="$ctrl.savedSearch.expires_date" placeholder="{{:: ts('Expires') }}">
   </div>
 </div>
 <crm-search-admin-tags tag-ids="$ctrl.savedSearch.tag_id" class="btn-group btn-group-sm"></crm-search-admin-tags>

--- a/tests/karma/unit/crmMailingRadioDateSpec.js
+++ b/tests/karma/unit/crmMailingRadioDateSpec.js
@@ -47,6 +47,7 @@ describe('crmMailingRadioDate', function() {
 
       model.the_date = '';
       $rootScope.$digest();
+      $timeout.flush();
       expect($rootScope.myForm.$valid).toBe(true);
       expect(element.find('.radio-now').prop('checked')).toBe(true);
       expect(element.find('.radio-at').prop('checked')).toBe(false);
@@ -130,14 +131,15 @@ describe('crmMailingRadioDate', function() {
 
       model.the_date = '';
       $rootScope.$digest();
+      $timeout.flush();
       expect($rootScope.myForm.$valid).toBe(true);
       expect(element.find('.radio-now').prop('checked')).toBe(true);
       expect(element.find('.radio-at').prop('checked')).toBe(false);
 
       element.find('.radio-now').click().trigger('click').trigger('change');
       element.find('.crm-form-date').datepicker('setDate', $.datepicker.parseDate('yy-mm-dd', '2014-01-03')).trigger('change');
-      $timeout.flush();
       $rootScope.$digest();
+      $timeout.flush();
       expect(model.the_date).toBe('2014-01-03');
       expect($rootScope.myForm.$valid).toBe(false);
       expect(element.find('.radio-now').prop('checked')).toBe(false);


### PR DESCRIPTION
Overview
----------------------------------------
Allow 'Expires' placeholder text to be translated.

Before
----------------------------------------
Text was hardcoded in English.

After
----------------------------------------
Text is passed through `ts()` function.