### PR TITLE
enable quick search using nickname if configured

### DIFF
--- a/Civi/Api4/Service/Autocomplete/ContactAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/ContactAutocompleteProvider.php
@@ -95,20 +95,29 @@ class ContactAutocompleteProvider extends \Civi\Core\Service\AutoService impleme
         7 => 'address_primary.country_id:label',
         8 => 'address_primary.postal_code',
       ];
+      $filterFields = [];
       // If doing a search by a field other than the default,
       // add that field to the main column
       if (!empty($e->context['filters'])) {
-        $filterField = array_keys($e->context['filters'])[0];
+        $filterFields[] = array_keys($e->context['filters'])[0];
       }
-      elseif (\Civi::settings()->get('includeEmailInName')) {
-        $filterField = 'email_primary.email';
+      else {
+        if (\Civi::settings()->get('includeEmailInName')) {
+          $filterFields[] = 'email_primary.email';
+        }
+        if (\Civi::settings()->get('includeNickNameInName')) {
+          $filterFields[] = 'nick_name';
+        }
       }
-      // Search on name + filter/email
-      if (!empty($filterField)) {
-        $column['key'] = $filterField;
-        $column['rewrite'] = "[sort_name] :: [$filterField]";
+      if (!empty($filterFields)) {
+        // Take the first one as the key.
+        $column['key'] = $filterFields[0];
         $column['empty_value'] = '[sort_name]';
-        $autocompleteOptionsMap = array_diff($autocompleteOptionsMap, [$filterField]);
+        $column['rewrite'] = "[sort_name]";
+        foreach ($filterFields as $filterField) {
+          $column['rewrite'] .= " :: [$filterField]";
+          $autocompleteOptionsMap = array_diff($autocompleteOptionsMap, [$filterField]);
+        }
       }
       // No filter & email search disabled: search on name only
       else {


### PR DESCRIPTION
Overview
----------------------------------------

Allow quick searching by contact nick name if enabled.

Before
----------------------------------------
The quick search field in the top right corner allows you to search by "name/email". 

In addition, in `Administer -> Customize Data and Screens -> Search Options` there is an option called: "Include Nickname" with the description "If enabled, nicknames are automatically included when users search by Name."

However, even if that option is enabled, searching by nick name does not work via quick search.

After
----------------------------------------

With this change, the "Include Nickname" setting is respected when doing a quick search.

Comments
----------------------------------------
There was a bit of guesswork in this commit - so happy to make changes or do it differently based on feedback.
