### PR TITLE
Remove use of createAPIError (gets swallowed in php8.x

### DIFF
--- a/CRM/Mailing/MailStore/Localdir.php
+++ b/CRM/Mailing/MailStore/Localdir.php
@@ -108,7 +108,7 @@ class CRM_Mailing_MailStore_Localdir extends CRM_Mailing_MailStore {
       $mail = $parser->parseMail($set);
 
       if (!$mail) {
-        return CRM_Core_Error::createAPIError(ts('%1 could not be parsed',
+        throw new CRM_Core_Exception(ts('%1 could not be parsed',
           [1 => $file]
         ));
       }


### PR DESCRIPTION
This is called with the modeException so it throws an exception - but with NULL for the data - which should be an int.

It winds up in a deprecation loop & the error is lost

This is hard to hit but if you delete the file after it has been identified it is hit. Since it's in CRM code one of our errors makes sense
