### PR TITLE
dev/core#5393 Add custom data display for emails, fix address for empty fields

### DIFF
--- a/CRM/Contact/Page/Inline/Address.php
+++ b/CRM/Contact/Page/Inline/Address.php
@@ -20,6 +20,8 @@
  */
 class CRM_Contact_Page_Inline_Address extends CRM_Core_Page {
 
+  use CRM_Custom_Page_CustomDataTrait;
+
   /**
    * Run the page.
    *
@@ -66,12 +68,7 @@ class CRM_Contact_Page_Inline_Address extends CRM_Core_Page {
         $idValue = $currentAddressBlock['address'][$locBlockNo]['master_id'];
       }
 
-      // add custom data of type address
-      $groupTree = CRM_Core_BAO_CustomGroup::getTree('Address', NULL, $idValue);
-
-      // we setting the prefix to dnc_ below so that we don't overwrite smarty's grouptree var.
-      $currentAddressBlock['address'][$locBlockNo]['custom'] = CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, FALSE, NULL, "dnc_");
-      $this->assign("dnc_viewCustomData", NULL);
+      $currentAddressBlock['address'][$locBlockNo]['custom'] = $this->getCustomDataFieldsForEntityDisplay('Address', $idValue);
 
       $this->assign('add', $currentAddressBlock['address'][$locBlockNo]);
       $this->assign('sharedAddresses', $sharedAddresses);

--- a/CRM/Contact/Page/Inline/Email.php
+++ b/CRM/Contact/Page/Inline/Email.php
@@ -20,6 +20,8 @@
  */
 class CRM_Contact_Page_Inline_Email extends CRM_Core_Page {
 
+  use CRM_Custom_Page_CustomDataTrait;
+
   /**
    * Run the page.
    *
@@ -36,6 +38,7 @@ class CRM_Contact_Page_Inline_Email extends CRM_Core_Page {
     if (!empty($emails)) {
       foreach ($emails as &$value) {
         $value['location_type'] = $locationTypes[$value['location_type_id']];
+        $value['custom'] = $this->getCustomDataFieldsForEntityDisplay('Email', $value['id']);
       }
     }
 

--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -19,6 +19,7 @@
  * Main page for viewing contact.
  */
 class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
+  use CRM_Custom_Page_CustomDataTrait;
 
   /**
    * Contents of contact_view_options setting.
@@ -185,11 +186,13 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
 
     CRM_Contact_BAO_Contact::getValues(['id' => $this->_contactId], $defaults);
     $defaults['im'] = $this->getLocationValues($this->_contactId, 'IM');
-    $defaults['email'] = $this->getLocationValues($this->_contactId, 'Email');
+    $emails = $this->getLocationValues($this->_contactId, 'Email');
+    foreach ($emails as $blockId => $email) {
+      $emails[$blockId]['custom'] = $this->addBlockCustomData('Email', $email['id']);
+    }
+    $this->assign('email', $emails);
     $defaults['openid'] = $this->getLocationValues($this->_contactId, 'OpenID');
     $defaults['phone'] = $this->getLocationValues($this->_contactId, 'Phone');
-    // This microformat magic is still required...
-    $defaults['address'] = CRM_Core_BAO_Address::getValues(['contact_id' => $this->_contactId], TRUE);
     $defaults['website'] = $this->getLocationValues($this->_contactId, 'Website');
     // Copy employer fields to the current_employer keys.
     if (($defaults['contact_type'] === 'Individual') && !empty($defaults['employer_id']) && !empty($defaults['organization_name'])) {
@@ -201,21 +204,19 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
     $mailingBackend = Civi::settings()->get('mailing_backend');
     $this->assign('mailingOutboundOption', $mailingBackend['outBound_option']);
 
-    if (!empty($defaults['address'])) {
-      foreach ($defaults['address'] as & $val) {
-        CRM_Utils_Array::lookupValue($val, 'location_type', CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id', ['labelColumn' => 'display_name']), FALSE);
-      }
+    // This microformat magic is still required...
+    $addresses = (array) CRM_Core_BAO_Address::getValues(['contact_id' => $this->_contactId], TRUE);
+    foreach ($addresses as $blockId => &$blockVal) {
+      // Does this do anything?
+      CRM_Utils_Array::lookupValue($blockVal, 'location_type', CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id', ['labelColumn' => 'display_name']), FALSE);
 
-      foreach ($defaults['address'] as $blockId => $blockVal) {
-        $idValue = $blockVal['id'];
-        if (!empty($blockVal['master_id'])) {
-          $idValue = $blockVal['master_id'];
-        }
-        $defaults['address'][$blockId]['custom'] = $this->addBlockCustomData('Address', $idValue);
+      $idValue = $blockVal['id'];
+      if (!empty($blockVal['master_id'])) {
+        $idValue = $blockVal['master_id'];
       }
-      // reset template variable since that won't be of any use, and could be misleading
-      $this->assign("dnc_viewCustomData", NULL);
+      $addresses[$blockId]['custom'] = $this->addBlockCustomData('Address', $idValue);
     }
+    $this->assign('address', $addresses);
 
     $defaults['gender_display'] = CRM_Core_PseudoConstant::getLabel('CRM_Contact_DAO_Contact', 'gender_id', $defaults['gender_id'] ?? NULL);
 
@@ -255,8 +256,8 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
 
     // get contact name of shared contact names
     $sharedAddresses = [];
-    $shareAddressContactNames = CRM_Contact_BAO_Contact_Utils::getAddressShareContactNames($defaults['address']);
-    foreach ($defaults['address'] as $key => $addressValue) {
+    $shareAddressContactNames = CRM_Contact_BAO_Contact_Utils::getAddressShareContactNames($addresses);
+    foreach ($addresses as $key => $addressValue) {
       if (!empty($addressValue['master_id']) &&
         !$shareAddressContactNames[$addressValue['master_id']]['is_deleted']
       ) {
@@ -267,7 +268,9 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
       }
     }
     $this->assign('sharedAddresses', $sharedAddresses);
-
+    // @todo - stop assigning defaults - assign variables individually
+    // rather than adding to defaults for transparency - this is some old
+    // copy & paste.
     $this->assign($defaults);
 
     // FIXME: when we sort out TZ isssues with DATETIME/TIMESTAMP, we can skip next query
@@ -514,17 +517,15 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
   }
 
   /**
-   * @param $idValue
-   * @param $entity
+   * @param string $entityType
+   *
+   * @param int $entityID
    *
    * @return array
    * @throws \CRM_Core_Exception
    */
-  private function addBlockCustomData($entity, $idValue): array {
-    $groupTree = CRM_Core_BAO_CustomGroup::getTree($entity, NULL, $idValue, NULL, [],
-      NULL, TRUE, NULL, FALSE, CRM_Core_Permission::VIEW);
-    // we setting the prefix to dnc_ below so that we don't overwrite smarty's grouptree var.
-    return CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, FALSE, NULL, "dnc_");
+  private function addBlockCustomData(string $entityType, int $entityID): array {
+    return $this->getCustomDataFieldsForEntityDisplay($entityType, $entityID);
   }
 
 }

--- a/CRM/Custom/Page/CustomDataTrait.php
+++ b/CRM/Custom/Page/CustomDataTrait.php
@@ -1,0 +1,88 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This trait supports adding custom data to pages.
+ *
+ * @internal this is not supported for use outside of core and there is no guarantee the
+ * function signature or behaviour won't change. It you use if from outside core
+ * be sure to use unit tests in your non-core use.
+ */
+trait CRM_Custom_Page_CustomDataTrait {
+
+  /**
+   * Get the custom values for the entity ready to be displayed on the form.
+   *
+   * @param string $entity
+   * @param int $id
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   *
+   */
+  protected function getCustomDataFieldsForEntityDisplay(string $entity, int $id): array {
+    $values = civicrm_api4($entity, 'get', [
+      'select' => [
+        'custom.*',
+      ],
+      'where' => [
+        ['id', '=', $id],
+      ],
+      'checkPermissions' => TRUE,
+    ])->single();
+    $formValues = [];
+    // We have api style field names not IDs so can't use the BAO function AFAIK.
+    $fields = civicrm_api4($entity, 'getfields', [
+      'where' => [
+        ['name', 'IN', array_keys($values)],
+      ],
+      'checkPermissions' => TRUE,
+    ])->indexBy('name');
+    foreach ($values as $name => $value) {
+      if ($name === 'id') {
+        continue;
+      }
+      // https://lab.civicrm.org/dev/core/-/issues/5393
+      // Early filter on empty values.
+      if ($value !== NULL && $value !== []) {
+        $spec = CRM_Core_BAO_CustomField::getField($fields[$name]['custom_field_id']);
+        if (!isset($formValues[$spec['custom_group_id']])) {
+          $formValues[$spec['custom_group_id']] = [
+            'title' => $spec['custom_group']['title'],
+            'name' => $spec['custom_group']['name'],
+            'collapse_display' => $spec['custom_group']['collapse_display'],
+            'fields' => [],
+          ];
+        }
+        $displayValue = CRM_Core_BAO_CustomField::displayValue($value, $spec['id'], $id);
+        // https://lab.civicrm.org/dev/core/-/issues/5393
+        // Final filter on empty values.
+        if ($displayValue !== '') {
+          $formValues[$spec['custom_group_id']]['fields'][$spec['id']][] = [
+            // This `field_` prefixing feels a bit awkward but is consistent with similar pages.
+            'field_value' => CRM_Core_BAO_CustomField::displayValue($value, $spec['id'], $id),
+            'field_title' => $spec['label'],
+            'field_input_type' => $spec['html_type'],
+            'field_data_type' => $spec['data_type'],
+          ];
+        }
+      }
+    }
+    return $formValues;
+  }
+
+}

--- a/templates/CRM/Contact/Page/Inline/Address.tpl
+++ b/templates/CRM/Contact/Page/Inline/Address.tpl
@@ -42,7 +42,7 @@
           {$add.display|purify|nl2br nofilter}
         </div>
       </div>
-    {include file="CRM/Contact/Page/Inline/BlockCustomData.tpl" entity='address' customFields=$add.custom identifier=$locationIndex}
+    {include file="CRM/Contact/Page/Inline/BlockCustomData.tpl" entity='address' customGroups=$add.custom identifier=$locationIndex}
     {/if}
   </div>
 </div>

--- a/templates/CRM/Contact/Page/Inline/BlockCustomData.tpl
+++ b/templates/CRM/Contact/Page/Inline/BlockCustomData.tpl
@@ -8,25 +8,24 @@
  +--------------------------------------------------------------------+
 *}
 {* template adding block-specific custom data *}
-{foreach from=$customFields item=customGroup key=cgId} {* start of outer foreach *}
-  {foreach from=$customGroup item=customValue key=cvId}
-    <details id="{$entity}_custom_{$cgId}_{$identifier}" class="crm-{$entity}-custom-{$cgId}-{$identifier}-accordion crm-accordion-light" {if $customValue.collapse_display}{else}open{/if}>
+{foreach from=$customGroups item=customGroup key=customGroupID} {* start of customGroup foreach *}
+  {if (!empty($customGroup.fields))}
+    <details id="{$entity}_custom_{$customGroupID}_{$identifier}" class="crm-{$entity}-custom-{$customGroupID}-{$identifier}-accordion crm-accordion-light" {if $customGroup.collapse_display}{else}open{/if}>
       <summary class="collapsible-title">
-        {$customValue.title}
+        {$customGroup.title}
       </summary>
       <div class="crm-summary-block">
-        {foreach from=$customValue.fields item=customField key=cfId}
-          <div class="crm-summary-row">
-            <div class="crm-label">
-              {$customField.field_title}
+        {foreach from=$customGroup.fields item=customField}
+          {* We only expect one value in this loop because as of writing only single fields custom groups are supported
+          for the entities that use this -address, email~ *}
+          {foreach from=$customField item=instance}
+            <div class="crm-summary-row">
+            {include file="CRM/Contact/Page/Inline/CustomDataFieldInstance.tpl" instance=$instance}
             </div>
-            <div class="crm-content">
-              {$customField.field_value}
-            </div>
-          </div>
+          {/foreach}
         {/foreach}
       </div>
     </details>
-  {/foreach}
+  {/if}
 {/foreach} {* end of outer custom group foreach *}
 <!-- end custom data -->

--- a/templates/CRM/Contact/Page/Inline/CustomDataFieldInstance.tpl
+++ b/templates/CRM/Contact/Page/Inline/CustomDataFieldInstance.tpl
@@ -1,0 +1,24 @@
+{*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+*}
+{* template adding custom field instances. *}
+<div class="crm-label">
+  {$instance.field_title}
+</div>
+<div class="crm-content crm-custom_data">
+  {if $instance.field_input_type === 'RichTextEditor' || $instance.field_input_type === 'Link'}
+    {$instance.field_value|purify nofilter}
+  {else}
+    {* This would be too strict for some types - eg. contact reference.
+    Fortunately the Address custom data is currently not creating links for them
+    as it should so we can address when we fix that.
+    *}
+    {$instance.field_value|escape:html nofilter}
+  {/if}
+</div>

--- a/templates/CRM/Contact/Page/Inline/Email.tpl
+++ b/templates/CRM/Contact/Page/Inline/Email.tpl
@@ -57,6 +57,7 @@
         <strong>{ts}Signature Text{/ts}</strong><br />{if !empty($item.signature_text)}{$item.signature_text|nl2br}{/if}</div>
       </div>
     </div>
+      {include file="CRM/Contact/Page/Inline/BlockCustomData.tpl" entity='email' customGroups=$item.custom identifier=$blockId}
     {/if}
   {/foreach}
   </div>


### PR DESCRIPTION
Overview
----------------------------------------
Add custom data display for emails, fix address for empty fields.

We have had support for custom fields on Addresses for some time but not on other location entities - ie Email, Phone, IM, Website. In 5.78 there is edit support added for email custom fields - but that data is not yet visible on the contact summary.

In addition we recently agreed to suppress empty custom fields in this context - ie https://lab.civicrm.org/dev/core/-/issues/5393

This adds support to view custom fields for email blocks on the contact summary in a way that should be easily extendable to other location blocks (phone seems worth doing, unsure about the others)

Before
----------------------------------------
Custom fields on emails can be edited but not seen, Custom fields on address entities show empty fields

After
----------------------------------------
![image](https://github.com/user-attachments/assets/e8399f8f-1f57-4282-9ae6-e3e8aba7b7bf)

![image](https://github.com/user-attachments/assets/ea3c0cd7-2f73-4177-8c40-07b2e414278e)


Technical Details
----------------------------------------
- With the greater use of apiv4 I added a couple of escapes

I used the [`testData`](https://github.com/eileenmcnaughton/testdata.git) extension to test & hit some pre-exisitng issues

These are long-standing but usage is low on these things

- the extension doesn't quite nail all the custom fields on install & needs Managed.reconcile to be run again
- the heading size  of the sections is a bit OTT
- some non-required custom field types crash if you try to save them without putting in data - I think it was the contact reference & the state country fields
- attempts to save file custom fields results in nothing happening
- the contact reference custom fields are not displaying as links

Comments
----------------------------------------
@colemanw - I ditched those awful old functions & replaced with https://github.com/civicrm/civicrm-core/pull/30981/files#diff-9a67357eae4879bbc109707f971477093a5aaede8e072ca40085d00c18be9c84R37 - but there were a couple of places where I wondered if there was a better way within the new code.