### PR TITLE
Switch contribution search to use Smarty5 nofilter not older` smarty:nodefaults`

### DIFF
--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -35,7 +35,7 @@ trait CRM_Core_Form_EntityFormTrait {
    * Deletion message to be assigned to the form.
    *
    * Depending on the screen, the deletionMessage may be plain-text (`{$deletionMessage|escape}`)
-   * or HTML (`{$deletionMessage|smarty:nodefaults}`). Be sure your controller+template agree.
+   * or HTML (`{$deletionMessage nofilter}`). Be sure your controller+template agree.
    *
    * @var string
    */

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -464,7 +464,7 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
    * anything coming in with this be happening because of the default modifier.
    *
    * Also note the right way to opt a field OUT of escaping is
-   * ``{$fieldName|smarty:nodefaults}``
+   * ``{$fieldName nofilter}``
    * This should be used for fields with known html AND for fields where
    * we are doing empty or isset checks - as otherwise the value is passed for
    * escaping first so you still get an enotice for 'empty' or a fatal for 'isset'

--- a/templates/CRM/Contribute/Page/ContributionTotals.tpl
+++ b/templates/CRM/Contribute/Page/ContributionTotals.tpl
@@ -13,10 +13,10 @@
 
     {if !empty($annual.count)}
         <tr>
-            <th class="contriTotalLeft right">{ts}Current Fiscal Year-to-Date{/ts} &ndash; {$annual.amount|smarty:nodefaults}</th>
-            <th class="right"> &nbsp; {ts}# Completed Contributions{/ts} &ndash; {$annual.count|smarty:nodefaults}</th>
-            <th class="right contriTotalRight"> &nbsp; {ts}Avg Amount{/ts} &ndash; {$annual.avg|smarty:nodefaults}</th>
-            {if $contributionSummary.cancel.amount|smarty:nodefaults}
+            <th class="contriTotalLeft right">{ts}Current Fiscal Year-to-Date{/ts} &ndash; {$annual.amount nofilter}</th>
+            <th class="right"> &nbsp; {ts}# Completed Contributions{/ts} &ndash; {$annual.count nofilter}</th>
+            <th class="right contriTotalRight"> &nbsp; {ts}Avg Amount{/ts} &ndash; {$annual.avg nofilter}</th>
+            {if $contributionSummary.cancel.amount nofilter}
                 <td>&nbsp;</td>
             {/if}
         </tr>
@@ -25,16 +25,16 @@
     {if $contributionSummary}
       <tr>
           {if $contributionSummary.total.amount}
-            <th class="contriTotalLeft right">{ts}Total{/ts} &ndash; {$contributionSummary.total.amount|smarty:nodefaults}</th>
-            <th class="right"> &nbsp; {ts}# Completed{/ts} &ndash; {$contributionSummary.total.count|smarty:nodefaults}</th>
-            <th class="right contriTotalRight"> &nbsp; {ts}Avg{/ts} &ndash; {$contributionSummary.total.avg|smarty:nodefaults}</th>
+            <th class="contriTotalLeft right">{ts}Total{/ts} &ndash; {$contributionSummary.total.amount nofilter}</th>
+            <th class="right"> &nbsp; {ts}# Completed{/ts} &ndash; {$contributionSummary.total.count nofilter}</th>
+            <th class="right contriTotalRight"> &nbsp; {ts}Avg{/ts} &ndash; {$contributionSummary.total.avg nofilter}</th>
           {/if}
-          {if $contributionSummary.cancel.amount|smarty:nodefaults}
-            <th class="disabled right contriTotalRight"> &nbsp; {ts}Cancelled/Refunded{/ts} &ndash; {$contributionSummary.cancel.amount|smarty:nodefaults}</th>
+          {if $contributionSummary.cancel.amount nofilter}
+            <th class="disabled right contriTotalRight"> &nbsp; {ts}Cancelled/Refunded{/ts} &ndash; {$contributionSummary.cancel.amount nofilter}</th>
           {/if}
       </tr>
-      {if $contributionSummary.soft_credit.count|smarty:nodefaults}
-        {include file="CRM/Contribute/Page/ContributionSoftTotals.tpl" softCreditTotals=$contributionSummary.soft_credit|smarty:nodefaults}
+      {if $contributionSummary.soft_credit.count nofilter}
+        {include file="CRM/Contribute/Page/ContributionSoftTotals.tpl" softCreditTotals=$contributionSummary.soft_credit}
       {/if}
     {/if}
 

--- a/templates/CRM/Report/Form/Layout/Table.tpl
+++ b/templates/CRM/Report/Form/Layout/Table.tpl
@@ -44,7 +44,7 @@
         {if !$sections} {* section headers and sticky headers aren't playing nice yet *}
             <thead class="sticky">
             <tr>
-              {$tableHeader|smarty:nodefaults}
+              {$tableHeader nofilter}
             </tr>
         </thead>
         {/if}

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -199,7 +199,7 @@ if (!defined('CIVICRM_TEMPLATE_COMPILEDIR')) {
  * (see above).
  *
  * This tells smarty to pass all variables through the escape function
- * unless they are piped to smarty:nodefaults (eg. {$myScript|smarty:nodefaults}
+ * unless they are marked with nofilter (eg. {$myScript nofilter}
  * At this stage it should only be enabled on development sites.
  * @see https://github.com/civicrm/civicrm-core/pull/21935
  */

--- a/templates/CRM/common/displaySearchCriteria.tpl
+++ b/templates/CRM/common/displaySearchCriteria.tpl
@@ -36,7 +36,7 @@
     {else}
         {foreach from=$orClauses name=criteria item=item}
             <div class="qill">
-            {$item|escape}
+            {$item|escape nofilter}
             {if !$smarty.foreach.criteria.last}
                 {if !empty($operator)}
                   <span class="font-italic">...{$operator|escape}...</span>

--- a/templates/CRM/common/formButtons.tpl
+++ b/templates/CRM/common/formButtons.tpl
@@ -24,7 +24,7 @@
       {capture assign=linkname}name="{$linkButton.ref}"{/capture}
     {else}{capture assign=linkname}{if array_key_exists('name', $linkButton)}name="{$linkButton.name}"{/if}{/capture}
     {/if}
-    <a class="button{if array_key_exists('class', $linkButton)} {$linkButton.class}{/if}" {$linkname} href="{crmURL p=$linkButton.url q=$linkButton.qs}" {$accessKey} {if array_key_exists('extra', $linkButton)}{$linkButton.extra}>{/if}<span>{$icon|smarty:nodefaults}{$linkButton.title}</span></a>
+    <a class="button{if array_key_exists('class', $linkButton)} {$linkButton.class}{/if}" {$linkname} href="{crmURL p=$linkButton.url q=$linkButton.qs}" {$accessKey} {if array_key_exists('extra', $linkButton)}{$linkButton.extra}>{/if}<span>{$icon nofilter}{$linkButton.title}</span></a>
   {/foreach}
 {/if}
 {if $form}

--- a/templates/CRM/common/pager.tpl
+++ b/templates/CRM/common/pager.tpl
@@ -47,7 +47,7 @@
             numPages = {$pager->_response.numPages},
             currentPage = {$pager->_response.currentPage},
             perPageCount = {$pager->_perPage},
-            currentLocation = {$pager->_response.currentLocation|json_encode},
+            currentLocation = {$pager->_response.currentLocation|json_encode nofilter},
             spinning = null,
             refreshing = false;
           {literal}

--- a/templates/CRM/common/pager.tpl
+++ b/templates/CRM/common/pager.tpl
@@ -7,21 +7,21 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if $pager|smarty:nodefaults and $pager->_response|smarty:nodefaults}
+{if $pager && $pager->_response}
     {if $pager->_response.numPages > 1}
         <div class="crm-pager">
             <span class="element-right">
             {if $location eq 'top'}
-              {$pager->_response.titleTop|smarty:nodefaults}
+              {$pager->_response.titleTop nofilter}
             {else}
-              {$pager->_response.titleBottom|smarty:nodefaults}
+              {$pager->_response.titleBottom nofilter}
             {/if}
             </span>
           <span class="crm-pager-nav">
-          {$pager->_response.first|smarty:nodefaults}&nbsp;
-          {$pager->_response.back|smarty:nodefaults}&nbsp;
-          {$pager->_response.next|smarty:nodefaults}&nbsp;
-          {$pager->_response.last|smarty:nodefaults}&nbsp;
+          {$pager->_response.first nofilter}&nbsp;
+          {$pager->_response.back nofilter}&nbsp;
+          {$pager->_response.next nofilter}&nbsp;
+          {$pager->_response.last nofilter}&nbsp;
           {$pager->_response.status}
           </span>
 


### PR DESCRIPTION

Overview
----------------------------------------
Switch contribution search to use Smarty5 nofilter not older` smarty:nodefaults`

Before
----------------------------------------
Old `smarty;nofdefaults`

After
----------------------------------------
more recent `nofilter`

Technical Details
----------------------------------------
there are some non-string values I removed it from - these don't seem to work the same & were only there to reduce noise because there is transitional logging for when default filtering changes the value

Comments
----------------------------------------
this is when we have the define
`

define('CIVICRM_SMARTY_DEFAULT_ESCAPE', TRUE);
`

I just want to work through a few & check what gotchas there are & then I'll replace en masse once I'm confident