### PR TITLE
Add empty check for logging schema variable

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -458,7 +458,7 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
     // If a column that already exists on logging table is being added, we
     // should treat it as a modification.
     $logTableSchema = $this->columnSpecsOf("log_$table");
-    if (!empty($cols['ADD'])) {
+    if (!empty($cols['ADD']) && !empty($logTableSchema)) {
       foreach ($cols['ADD'] as $colKey => $col) {
         if (array_key_exists($col, $logTableSchema)) {
           $cols['MODIFY'][] = $col;


### PR DESCRIPTION
Overview
----------------------------------------
Issue - https://lab.civicrm.org/dev/core/-/issues/5412

PR aims to fix civicrm issue with CRM_Logging_Schema -
`Error: TypeError: array_key_exists(): Argument #2 ($array) must be of type array, null given in CRM_Logging_Schema->fixSchemaDifferencesFor() (line 456 of /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/CRM/Logging/Schema.php).`

Technical Details
----------------------------------------

1. Added extra empty check for `$logTableSchema` variable to fix civicrm core issue.
