### PR TITLE
Can't save an empty Contact Reference

### DIFF
--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -119,10 +119,6 @@ class CRM_Core_BAO_CustomValueTable {
               break;
 
             case 'ContactReference':
-              if ($value == NULL || $value === '' || $value === $VS . $VS) {
-                $type = 'Timestamp';
-                $value = NULL;
-              }
               if ($serialize) {
                 $type = 'String';
                 // Validate the string contains only integers and value-separators
@@ -130,6 +126,10 @@ class CRM_Core_BAO_CustomValueTable {
                 if (str_replace($validChars, '', $value)) {
                   throw new CRM_Core_Exception('Contact ID must be of type Integer');
                 }
+              }
+              elseif ($value == NULL || $value === '') {
+                $type = 'Timestamp';
+                $value = NULL;
               }
               else {
                 $type = 'Integer';


### PR DESCRIPTION
Overview
----------------------------------------
This is a master-only regression from #30728.  Empty contact reference fields can no longer be saved.

Before
----------------------------------------
Empty contact reference fields can no longer be saved.

After
----------------------------------------
Empty contact reference fields can be saved.

Technical Details
----------------------------------------
An `elseif` was changed to an `if`.  I rearranged the `if` statements to ensure that the original intent of #30728 was kept.