### PR TITLE
APIv3 - Move legacy Api3 code out of the BAO and into Api3

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -323,22 +323,6 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
   }
 
   /**
-   * @inheritDoc
-   */
-  public static function buildOptions($fieldName, $context = NULL, $props = []) {
-    $options = parent::buildOptions($fieldName, $context, $props);
-    // This provides legacy support for APIv3, allowing no-longer-existent html types
-    if ($fieldName == 'html_type' && isset($props['version']) && $props['version'] == 3) {
-      $options['Multi-Select'] = 'Multi-Select';
-      $options['Select Country'] = 'Select Country';
-      $options['Multi-Select Country'] = 'Multi-Select Country';
-      $options['Select State/Province'] = 'Select State/Province';
-      $options['Multi-Select State/Province'] = 'Multi-Select State/Province';
-    }
-    return $options;
-  }
-
-  /**
    * Crufty function makes getting custom fields unnecessarily difficult.
    * @deprecated since 5.71
    * @see CRM_Core_BAO_CustomGroup::getAll

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -2069,18 +2069,6 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
   }
 
   /**
-   * @inheritDoc
-   */
-  public static function buildOptions($fieldName, $context = NULL, $props = []) {
-    // Legacy support for APIv3 which also needs the ParticipantEventName etc pseudo-selectors
-    if ($fieldName === 'extends' && ($props['version'] ?? NULL) == 3) {
-      $options = CRM_Core_SelectValues::customGroupExtends();
-      return CRM_Core_PseudoConstant::formatArrayOptions($context, $options);
-    }
-    return parent::buildOptions($fieldName, $context, $props);
-  }
-
-  /**
    * Returns TRUE if this is a multivalued group which has reached the max for a given entity.
    *
    * @param int $customGroupId

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -1507,7 +1507,7 @@ WHERE  id = %1
    *   List of options, each as a record of id+name+label.
    *   Ex: [['id' => 123, 'name' => 'foo_bar', 'label' => 'Foo Bar']]
    */
-  public static function formatArrayOptions($context, array &$options) {
+  public static function formatArrayOptions(?string $context, array $options): array {
     // Already flat; return keys/values according to context
     if (!isset($options[0]) || !is_array($options[0])) {
       // For validate context, machine names are expected in place of labels.

--- a/api/v3/CustomField.php
+++ b/api/v3/CustomField.php
@@ -338,3 +338,22 @@ function civicrm_api3_custom_field_setvalue($params) {
   }
   return $result;
 }
+
+function civicrm_api3_custom_field_getoptions($params) {
+  $result = civicrm_api3_generic_getoptions(['entity' => 'CustomField', 'params' => $params]);
+  // This provides legacy support for APIv3, allowing no-longer-existent html types
+  if ($params['field'] === 'html_type') {
+    $extras = [
+      'Multi-Select' => 'Multi-Select',
+      'Select Country' => 'Select Country',
+      'Multi-Select Country' => 'Multi-Select Country',
+      'Select State/Province' => 'Select State/Province',
+      'Multi-Select State/Province' => 'Multi-Select State/Province',
+    ];
+    if (!empty($params['sequential'])) {
+      $extras = CRM_Utils_Array::makeNonAssociative($extras);
+    }
+    $result['values'] = array_merge($result['values'], $extras);
+  }
+  return $result;
+}

--- a/api/v3/CustomGroup.php
+++ b/api/v3/CustomGroup.php
@@ -120,3 +120,17 @@ function civicrm_api3_custom_group_setvalue($params) {
   }
   return $result;
 }
+
+function civicrm_api3_custom_group_getoptions($params) {
+  $result = civicrm_api3_generic_getoptions(['entity' => 'CustomGroup', 'params' => $params]);
+  // This provides legacy support for APIv3, which also needs the ParticipantEventName etc pseudo-selectors
+  if ($params['field'] === 'extends') {
+    $options = CRM_Core_SelectValues::customGroupExtends();
+    $options = CRM_Core_PseudoConstant::formatArrayOptions($params['context'] ?? NULL, $options);
+    if (!empty($params['sequential'])) {
+      $options = CRM_Utils_Array::makeNonAssociative($options);
+    }
+    $result['values'] = $options;
+  }
+  return $result;
+}


### PR DESCRIPTION
Overview
----------------------------------------
This is a small chunk pulled out of #30986 because it stands alone & moves code to a better spot.

Before
----------------------------------------
Api3 code in the BAO.

After
----------------------------------------
Api3 code in the API.

Technical Details
----------------------------------------
Also fixes signature of `CRM_Core_PseudoConstant::formatArrayOptions` which was passing `$options` by reference unnecessarily.
