### PR TITLE
Add custom fields for email to the event manage location form

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/Location.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Location.tpl
@@ -53,10 +53,12 @@
     <tr>
       <td>{$form.email.1.email.label}</td>
       <td>{$form.email.1.email.html|crmAddClass:email}</td>
+      {include file="CRM/Contact/Form/Inline/BlockCustomData.tpl" entity=email customFields=$custom_fields_email blockId=1 actualBlockCount=2}
     </tr>
     <tr>
       <td>{$form.email.2.email.label}</td>
       <td>{$form.email.2.email.html|crmAddClass:email}</td>
+      {include file="CRM/Contact/Form/Inline/BlockCustomData.tpl" entity=email customFields=$custom_fields_email blockId=2 actualBlockCount=2}
     </tr>
     <tr>
       <td>{$form.phone.1.phone.label}</td>

--- a/tests/phpunit/CRM/Event/Form/ManageEvent/LocationTest.php
+++ b/tests/phpunit/CRM/Event/Form/ManageEvent/LocationTest.php
@@ -21,7 +21,6 @@ class CRM_Event_Form_ManageEvent_LocationTest extends CiviUnitTestCase {
    * Test the right emails exist after submitting the location form twice.
    *
    * @throws \CRM_Core_Exception
-   * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function testSubmit(): void {
     $eventID = (int) $this->eventCreateUnpaid()['id'];


### PR DESCRIPTION
Overview
----------------------------------------
Add custom fields for email to the event manage location form

Before
----------------------------------------
Support for custom fields on emails added to contact inline view / edit tab on summary but not present on Manage Location (even though address is)

After
----------------------------------------
Now it's here

![image](https://github.com/user-attachments/assets/33d8049b-644a-40b0-8dd4-27238fea495b)


Technical Details
----------------------------------------
It's a bit fugly - but so are the address custom fields. There is no known use case for these fields here but I feel like if we don't push through & get consistency now it will be harder later.

In addition I set up a new trait when I added the fields to the other - which is intended to replace     `CRM_Contact_Form_Edit_Email::buildQuickForm();`

& hence completing the replacement will be less confusing  (there are a couple more oustanding places)

Comments
----------------------------------------
