### PR TITLE
php 8.x fix - cast potential NULL to a string before passing to a string function

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -261,7 +261,7 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
         if (!empty($entityData)) {
           $softCreditTypeID = (int) $entityData['soft_credit']['soft_credit_type_id'];
         }
-        $fieldName = $this->isQuickFormMode ? str_replace('.', '__', $fieldMapping['name']) : $fieldMapping['name'];
+        $fieldName = $this->isQuickFormMode ? str_replace('.', '__', (string) $fieldMapping['name']) : $fieldMapping['name'];
         $defaults["mapper[$rowNumber]"] = [$fieldName, $softCreditTypeID];
       }
     }


### PR DESCRIPTION

Overview
----------------------------------------
php 8.x fix - cast potential NULL to a string before passing to a string function

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/b5be3696-f2bf-4a7c-babe-daf5882d39d8)

After
----------------------------------------
![image](https://github.com/user-attachments/assets/ad9052c3-821f-4f1c-8959-6c0a28749021)

Technical Details
----------------------------------------
This is a bit of a configuration edge case - ie the row in civicrm_mapping_field would have a NULL value - but not a problematic one, other than this notice

Comments
----------------------------------------
