### PR TITLE
ensure single checkbox profile fields work

### DIFF
--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -123,13 +123,23 @@
             {elseif $field.html_type eq 'File' && $viewOnlyFileValues}
               {$viewOnlyFileValues.$profileFieldName}
             {elseif $field.html_type eq 'Radio' or $field.html_type eq 'CheckBox'}
-              <div class="crm-multiple-checkbox-radio-options" >
+              {if array_key_exists('options_per_line', $field) && $field.options_per_line == 0}
+                <div class="crm-multiple-checkbox-radio-options" >
                 {foreach name=outer key=key item=item from=$formElement}
-                  {if is_array($item) && array_key_exists('html', $item)}
-                    <div class="crm-option-label-pair" >{$formElement.$key.html}</div>
+                    {if is_array($item) && array_key_exists('html', $item)}
+                      <div class="crm-option-label-pair" >{$formElement.$key.html}</div>
+                    {/if}
+                {/foreach}
+                </div>
+              {else}
+                <div class="crm-checkbox-radio-option" >
+                {foreach name=outer key=key item=item from=$formElement}
+                  {if $key == 'html'}
+                    <div class="crm-option-label-pair" >{$item}</div>
                   {/if}
                 {/foreach}
-              </div>
+                </div>
+              {/if}
               {* Include the edit options list for admins *}
               {if $formElement.html|strstr:"crm-option-edit-link"}
                 {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@":"$1"}


### PR DESCRIPTION
Overview
----------------------------------------
Ensure that a single checkbox (yes/no field) is properly displayed in an event profile.

Before
----------------------------------------
If you add the "Do not SMS" field to a profile and then use the profile for an event registration, the label is displayed but the checkbox is not displayed.

![image](https://github.com/user-attachments/assets/4d31e252-64ae-4b8f-ba17-605de5c183cb)


After
----------------------------------------

Both label and checkbox are displayed

Technical Details
----------------------------------------

This might be a regression caused by the [work on improving multi-checkbox displays](https://lab.civicrm.org/dev/core/-/issues/4985). But maybe it didn't work before then? I'm not sure.

Comments
----------------------------------------

From what I could tell from trial and error, if there is only one option (aka a yes/no field like "Do not SMS"), then $item is a regular value and does not have an 'html' element. 

Also - the scenario where `array_key_exists('options_per_line', $field) && $field.options_per_line != 0` is handled higher up. These changes are designed to apply when there is just one option OR when there are multiple options for $option_per_line is set to 0.