### PR TITLE
Fix master-only regression on import fields

### DIFF
--- a/CRM/Dedupe/BAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/BAO/DedupeRuleGroup.php
@@ -123,6 +123,12 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
             $fields[$ctype][$cg['table_name']][$cf['column_name']] = $cg['title'] . ' : ' . $cf['label'];
           }
         }
+        // Set field names to historical names for test.
+        // temporary fix to move the real fix to a different PR.
+        $fields[$ctype]['civicrm_address']['state_province_id'] = ts('State');
+        $fields[$ctype]['civicrm_address']['country_id'] = ts('Country');
+        $fields[$ctype]['civicrm_address']['county_id'] = ts('County');
+        $fields[$ctype]['civicrm_address']['master_id'] = ts('Master Address ID');
       }
       //Does this have to run outside of cache?
       CRM_Utils_Hook::dupeQuery(NULL, 'supportedFields', $fields);

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -2405,7 +2405,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     $addressFields = (array) Address::getFields()
       ->addWhere('readonly', '=', FALSE)
       ->addWhere('usage', 'CONTAINS', 'import')
-      ->addWhere('fk_entity', 'IS EMPTY')
       ->setAction('save')
       ->addOrderBy('title')
       // Exclude these fields to keep it simpler for now - we just map to primary
@@ -2422,7 +2421,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     $phoneFields = (array) Phone::getFields()
       ->addWhere('readonly', '=', FALSE)
       ->addWhere('usage', 'CONTAINS', 'import')
-      ->addWhere('fk_entity', 'IS EMPTY')
       ->setAction('save')
       // Exclude these fields to keep it simpler for now - we just map to primary
       ->addWhere('name', 'NOT IN', ['id', 'location_type_id', 'phone_type_id'])
@@ -2438,7 +2436,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     $emailFields = (array) Email::getFields()
       ->addWhere('readonly', '=', FALSE)
       ->addWhere('usage', 'CONTAINS', 'import')
-      ->addWhere('fk_entity', 'IS EMPTY')
       ->setAction('save')
       // Exclude these fields to keep it simpler for now - we just map to primary
       ->addWhere('name', 'NOT IN', ['id', 'location_type_id'])

--- a/schema/Core/Address.entityType.php
+++ b/schema/Core/Address.entityType.php
@@ -237,6 +237,9 @@ return [
       'input_type' => 'ChainSelect',
       'description' => ts('Which County does this address belong to.'),
       'add' => '1.1',
+      'usage' => [
+        'import',
+      ],
       'input_attrs' => [
         'control_field' => 'state_province_id',
         'label' => ts('County'),
@@ -263,6 +266,9 @@ return [
       'input_type' => 'ChainSelect',
       'description' => ts('Which State_Province does this address belong to.'),
       'add' => '1.1',
+      'usage' => [
+        'import',
+      ],
       'localize_context' => 'province',
       'input_attrs' => [
         'control_field' => 'country_id',
@@ -328,6 +334,9 @@ return [
       'input_type' => 'Select',
       'description' => ts('Which Country does this address belong to.'),
       'add' => '1.1',
+      'usage' => [
+        'import',
+      ],
       'localize_context' => 'country',
       'input_attrs' => [
         'label' => ts('Country'),


### PR DESCRIPTION
Overview
----------------------------------------
Fix master-only regression on import fields

Before
----------------------------------------
State & Country & Location Type ID no longer show as importable fields in the contribution import

After
----------------------------------------
They're back

Technical Details
----------------------------------------
This undoes a change I made very recently here https://github.com/civicrm/civicrm-core/pull/30930/files#diff-a2daa0eb4d93f084aa2ad66b42fd4a351f38c8f230a0895870c7da8c520ab6dcR2408 - I was confused about hot the filter on fk_entity fit & first removed that filter for all entities & then put it back - but put it back for the ones that did not originally have it.

We DO want to be able to specify the contact's State, Country etc when importing contributions

Comments
----------------------------------------
