### PR TITLE
EntityTag - Remove unneeded legacy formatting of entity_table options

### DIFF
--- a/CRM/Core/BAO/EntityTag.php
+++ b/CRM/Core/BAO/EntityTag.php
@@ -451,17 +451,6 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag implements \Civi\Cor
     }
 
     $options = CRM_Core_PseudoConstant::get(__CLASS__, $fieldName, $params, $context);
-
-    // Special formatting for validate/match context
-    if ($fieldName == 'entity_table' && in_array($context, ['validate', 'match'])) {
-      $options = [];
-      foreach (self::buildOptions($fieldName) as $tableName => $label) {
-        $bao = CRM_Core_DAO_AllCoreTables::getClassForTable($tableName);
-        $apiName = CRM_Core_DAO_AllCoreTables::getEntityNameForClass($bao);
-        $options[$tableName] = $apiName;
-      }
-    }
-
     return $options;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Removes old workaround for a problem that's been fixed.

Technical Details
----------------------------------------
This conversion was needed originally because the option group had weird values, but that was fixed in a6d0f90f8da1d21cd87e62f56d9bf4dc8f05d1ef.

This is covered by tests for Api3 & Api4, including this one which was added at the same time as this workaround. If it passes, we're good.

https://github.com/civicrm/civicrm-core/blob/9df1541a8e0c1520f1879ea75cf171b13af08a91/tests/phpunit/api/v3/EntityTagTest.php#L309-L333