### PR TITLE
Event Info: copy the checksum to the registerURL

### DIFF
--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -249,10 +249,16 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
       $this->getEventID(), 'register for events'
     );
     if ($hasPermission && $this->isAvailableForOnlineRegistration()) {
+      // Copy over the checksum, if one was present
+      $checksum_query = CRM_Utils_Request::retrieveValue('cs', 'String');
+      if ($checksum_query) {
+        $checksum_query = '&cs=' . $checksum_query . '&cid=' . CRM_Utils_Request::retrieveValue('cid', 'Positive');
+      }
+
       // we always generate urls for the front end in joomla
       $action_query = $action === CRM_Core_Action::PREVIEW ? "&action=$action" : '';
       $url = CRM_Utils_System::url('civicrm/event/register',
-        "id={$this->_id}&reset=1{$action_query}",
+        "id={$this->_id}&reset=1{$action_query}{$checksum_query}",
         FALSE, NULL, TRUE,
         TRUE
       );


### PR DESCRIPTION
Overview
----------------------------------------

Say an admin sends a mailing with a link to an Event Info page, and includes a checksum in the link, users will lose the benefits of that checksum when they click on the "register now" button on that page.

To reproduce:

- Create an Event
- Send a mailing with a link such as `https://crm.example.org/civicrm/event/info?reset=1&id=1&{contact.checksum}&cid={contact.id}`  (or save some trouble, and use "Generate PDF Letter" from a contact's record)
- Use that link in a private tab

Sure, we can remind admins that they should `civicrm/event/register`, but CiviCRM should not make people feel stupid.

Before
----------------------------------------

Clicking on "Register Now" results on a loss of state, so the user has to fill in their name/email/etc.

After
----------------------------------------

Clicking on "Register Now" works as expected: people are authenticated to the form.

Technical Details
----------------------------------------

Using `retrieveValue` perhaps isn't the most fancy way to do this?
