### PR TITLE
MailingTrackableURL: allow tracking civicrm/mailing/view

### DIFF
--- a/CRM/Mailing/BAO/MailingTrackableURL.php
+++ b/CRM/Mailing/BAO/MailingTrackableURL.php
@@ -50,7 +50,7 @@ class CRM_Mailing_BAO_MailingTrackableURL extends CRM_Mailing_DAO_MailingTrackab
     // let's not replace possible image URLs, CiviMail URLs or internal anchor URLs
     if (preg_match('/\.(png|jpg|jpeg|gif|css)[\'"]?$/i', $url)
       or substr_count($url, 'civicrm/extern/')
-      or substr_count($url, 'civicrm/mailing/')
+      or substr_count($url, 'civicrm/mailing/url')
       or ($url[0] === '#')
     ) {
       // let's not cache these, so they don't get &qid= appended to them


### PR DESCRIPTION
Overview
----------------------------------------

As odd as it may seem, mailing/view (online) is an interesting metric, and also, a mailing might include links to another archived mailing.

This exclusion seems to go back to https://issues.civicrm.org/jira/browse/CRM-1151 in 2008, and the original intent was to avoid having "open.php" in the stats.

Before
----------------------------------------

No stats for click-throughs on `civicrm/mailing/view` links.

After
----------------------------------------

CiviCRM keeps tracking stats on those links.