### PR TITLE
ActivityTest - Update to pass on Standalone

### DIFF
--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -1713,7 +1713,7 @@ $textValue
     // Check the smarty doesn't mess stuff up.
     $text = 'text:' . '{contact.display_name} {$contact.first_name}';
 
-    $filepath = Civi::paths()->getPath('[civicrm.files]/custom');
+    $filepath = CRM_Core_Config::singleton()->customFileUploadDir;
     $fileName = 'test_email_create.txt';
     $fileUri = "{$filepath}/{$fileName}";
     // Create a file.
@@ -1778,7 +1778,7 @@ $textValue
     $html = __FUNCTION__ . ' html';
     $text = __FUNCTION__ . ' text';
 
-    $filepath = Civi::paths()->getPath('[civicrm.files]/custom');
+    $filepath = CRM_Core_Config::singleton()->customFileUploadDir;
     $fileName = 'test_email_create.txt';
     $fileUri = "{$filepath}/{$fileName}";
     // Create a file.


### PR DESCRIPTION
Before
------

If you run this test on Standalone, it fails: like so

```
CRM_Activity_BAO_ActivityTest::testSendEmailWillReplaceTokensUniquelyForEachContact3
Exception: CRM_Core_Exception: "rename(/home/homer/buildkit/build/build-1/web/public/custom/test_email_create.txt,
/home/homer/buildkit/build/build-1/web/private/attachment//test_email_create.txt): No such file or directory"
 #0 /home/homer/buildkit/build/build-1/web/core/CRM/Contact/Form/Task/EmailTrait.php(867): civicrm_api3("Activity", "create", (Array:9))
 #1 /home/homer/buildkit/build/build-1/web/core/CRM/Contact/Form/Task/EmailTrait.php(788): CRM_Contact_Form_Task_Email->createEmailActivity(6, "subject:Mr. Joe Red II", "html:Mr. Joe Red II", "text:Mr. Joe Red II {$contact.first_name}", "", 1, (Array:1), NULL)
...
```

After
-----

Passes

Comments
--------

The key difference between D7 and SA is that [SA installer changes the names of the folder](https://github.com/civicrm/civicrm-core/blob/master/setup/plugins/init/Standalone.civi-setup.php#L98).

The underlying scenario is a bit weird -- it seems that `rename()` puts the file into the same place where it already is. Which is weird. But I don't fully understand the context of the test.

Reflexively speaking... if the purpose is to create an example file and put it through the same paces as
day-to-day workflows, then you'd probably need to put the sample file somewhere
else (like sys_get_temp_dir()).

In any event, I believe this revision makes standalone-test behave the same way as Drupal-test.

