### PR TITLE
Fix dedupe rules to select available fields based on `usage` being `duplicate_matching`

### DIFF
--- a/CRM/Dedupe/BAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/BAO/DedupeRuleGroup.php
@@ -123,6 +123,12 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
             $fields[$ctype][$cg['table_name']][$cf['column_name']] = $cg['title'] . ' : ' . $cf['label'];
           }
         }
+        // Set field names to historical names for test.
+        // temporary fix to move the real fix to a different PR.
+        $fields[$ctype]['civicrm_address']['state_province_id'] = ts('State');
+        $fields[$ctype]['civicrm_address']['country_id'] = ts('Country');
+        $fields[$ctype]['civicrm_address']['county_id'] = ts('County');
+        $fields[$ctype]['civicrm_address']['master_id'] = ts('Master Address ID');
       }
       //Does this have to run outside of cache?
       CRM_Utils_Hook::dupeQuery(NULL, 'supportedFields', $fields);

--- a/CRM/Dedupe/BAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/BAO/DedupeRuleGroup.php
@@ -67,68 +67,53 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
    *   The requested contact type.
    *
    * @return array
-   *   a table-keyed array of field-keyed arrays holding supported fields' titles
+   *   a table-keyed array of field-keyed arrays holding supported fields'
+   *   titles
+   * @throws \CRM_Core_Exception
    */
-  public static function supportedFields($requestedType): array {
+  public static function supportedFields(string $requestedType): array {
     if (!isset(Civi::$statics[__CLASS__]['supportedFields'])) {
-      // this is needed, as we're piggy-backing importableFields() below
-      $replacements = [
-        'civicrm_country.name' => 'civicrm_address.country_id',
-        'civicrm_county.name' => 'civicrm_address.county_id',
-        'civicrm_state_province.name' => 'civicrm_address.state_province_id',
-        'civicrm_phone.phone' => 'civicrm_phone.phone_numeric',
-      ];
-      // the table names we support in dedupe rules - a filter for importableFields()
-      $supportedTables = [
-        'civicrm_address',
-        'civicrm_contact',
-        'civicrm_email',
-        'civicrm_im',
-        'civicrm_note',
-        'civicrm_openid',
-        'civicrm_phone',
-        'civicrm_website',
-      ];
+      $genericFields = $fields = [];
+      // We have a hard-coded list of entities - as we always have
+      // but if that were to get restrictive we could declare whether dedupe fields are supported
+      // in the entity metadata and maybe get rid of the hook at the end of this function?
+      foreach (['Address', 'Email', 'Phone', 'Website', 'OpenID', 'IM', 'Note'] as $entity) {
+        $entityFields = civicrm_api4($entity, 'getFields', [
+          'where' => [['usage', 'CONTAINS', 'duplicate_matching']],
+          'orderBy' => ['title'],
+          'checkPermissions' => FALSE,
+          // The action is a bit arguable - if not set it would default to 'get'.
+          // At the moment it makes no difference but if someone where to add a
+          // pseudo-field and set duplicate matching to 'true' then it would probably be a
+          // field used when creating/updating & de-duping while saving a contact - so
+          // save feels like a safer guess at future requirements than get.
+          'action' => 'save',
+        ], 'name');
+        foreach ($entityFields as $entityField) {
+          $genericFields[$entityField['table_name']][$entityField['column_name']] = $entityField['input_attrs']['label'] ?? $entityField['title'];
+        }
+      }
 
-      foreach (CRM_Contact_BAO_ContactType::basicTypes() as $ctype) {
+      foreach (CRM_Contact_BAO_ContactType::basicTypes() as $contactType) {
+        $fields[$contactType] = $genericFields;
+        $contactFields = civicrm_api4('Contact', 'getFields', [
+          'where' => [['usage', 'CONTAINS', 'duplicate_matching']],
+          'orderBy' => ['title'],
+          'values' => [
+            'contact_type' => $contactType,
+          ],
+          'checkPermissions' => FALSE,
+          // The action is a bit arguable - if not set it would default to 'get'.
+          // At the moment it makes no difference but if someone where to add a
+          // pseudo-field and set duplicate matching to 'true' then it would probably be a
+          // field used when creating/updating & de-duping while saving a contact - so
+          // save feels like a safer guess at future requirements than get.
+          'action' => 'save',
+        ], 'name');
         // take the table.field pairs and their titles from importableFields() if the table is supported
-        foreach (self::importableFields($ctype) as $iField) {
-          if (isset($iField['where'])) {
-            $where = $iField['where'];
-            if (isset($replacements[$where])) {
-              $where = $replacements[$where];
-            }
-            [$table, $field] = explode('.', $where);
-            if (!in_array($table, $supportedTables)) {
-              continue;
-            }
-            $fields[$ctype][$table][$field] = $iField['title'];
-          }
+        foreach ($contactFields as $entityField) {
+          $fields[$contactType][$entityField['table_name']][$entityField['column_name']] = $entityField['input_attrs']['label'] ?? $entityField['title'];
         }
-        // Note that most of the fields available come from 'importable fields' -
-        // I thought about making this field 'importable' but it felt like there might be unknown consequences
-        // so I opted for just adding it in & securing it with a unit test.
-        /// Example usage of sort_name - It is possible to alter sort name via hook so 2 organization names might differ as in
-        // Justice League vs The Justice League but these could have the same sort_name if 'the the'
-        // exension is installed (https://github.com/eileenmcnaughton/org.wikimedia.thethe)
-        $fields[$ctype]['civicrm_contact']['sort_name'] = ts('Sort Name');
-
-        $customGroups = CRM_Core_BAO_CustomGroup::getAll([
-          'extends' => $ctype,
-          'is_active' => TRUE,
-        ], CRM_Core_Permission::EDIT);
-        // add all custom data fields including those only for sub_types.
-        foreach ($customGroups as $cg) {
-          foreach ($cg['fields'] as $cf) {
-            $fields[$ctype][$cg['table_name']][$cf['column_name']] = $cg['title'] . ' : ' . $cf['label'];
-          }
-        }
-        // Set field names to historical names for test.
-        // temporary fix to move the real fix to a different PR.
-        $fields[$ctype]['civicrm_address']['state_province_id'] = ts('State');
-        $fields[$ctype]['civicrm_address']['country_id'] = ts('Country');
-        $fields[$ctype]['civicrm_address']['county_id'] = ts('County');
-        $fields[$ctype]['civicrm_address']['master_id'] = ts('Master Address ID');
       }
       //Does this have to run outside of cache?
       CRM_Utils_Hook::dupeQuery(NULL, 'supportedFields', $fields);
@@ -137,72 +122,6 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
 
     return Civi::$statics[__CLASS__]['supportedFields'][$requestedType] ?? [];
 
-  }
-
-  /**
-   * Combine all the importable fields from the lower levels object.
-   *
-   * @deprecated - copy of importableFields to unravel.
-   *
-   * The ordering is important, since currently we do not have a weight
-   * scheme. Adding weight is super important
-   *
-   * @param int|string $contactType contact Type
-   *
-   * @return array
-   *   array of importable Fields
-   */
-  private static function importableFields($contactType): array {
-
-    $fields = CRM_Contact_DAO_Contact::import();
-
-    $locationFields = array_merge(CRM_Core_DAO_Address::import(),
-      CRM_Core_DAO_Phone::import(),
-      CRM_Core_DAO_Email::import(),
-      CRM_Core_DAO_IM::import(TRUE),
-      CRM_Core_DAO_OpenID::import()
-    );
-
-    $locationFields = array_merge($locationFields,
-      CRM_Core_BAO_CustomField::getFieldsForImport('Address',
-        FALSE,
-        FALSE,
-        FALSE,
-        FALSE
-      )
-    );
-
-    foreach ($locationFields as $key => $field) {
-      $locationFields[$key]['hasLocationType'] = TRUE;
-    }
-
-    $fields = array_merge($fields, $locationFields);
-
-    $fields = array_merge($fields, CRM_Contact_DAO_Contact::import());
-    $fields = array_merge($fields, CRM_Core_DAO_Note::import());
-
-    //website fields
-    $fields = array_merge($fields, CRM_Core_DAO_Website::import());
-    $fields['url']['hasWebsiteType'] = TRUE;
-
-    $fields = array_merge($fields,
-      CRM_Core_BAO_CustomField::getFieldsForImport($contactType,
-        FALSE,
-        TRUE,
-        FALSE,
-        FALSE,
-        FALSE
-      )
-    );
-    // Unset the fields which are not related to their contact type.
-    foreach (CRM_Contact_DAO_Contact::import() as $name => $value) {
-      if (!empty($value['contactType']) && $value['contactType'] !== $contactType) {
-        unset($fields[$name]);
-      }
-    }
-
-    //Sorting fields in alphabetical order(CRM-1507)
-    return CRM_Utils_Array::crmArraySortByField($fields, 'title');
   }
 
   /**

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -2405,7 +2405,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     $addressFields = (array) Address::getFields()
       ->addWhere('readonly', '=', FALSE)
       ->addWhere('usage', 'CONTAINS', 'import')
-      ->addWhere('fk_entity', 'IS EMPTY')
       ->setAction('save')
       ->addOrderBy('title')
       // Exclude these fields to keep it simpler for now - we just map to primary
@@ -2422,7 +2421,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     $phoneFields = (array) Phone::getFields()
       ->addWhere('readonly', '=', FALSE)
       ->addWhere('usage', 'CONTAINS', 'import')
-      ->addWhere('fk_entity', 'IS EMPTY')
       ->setAction('save')
       // Exclude these fields to keep it simpler for now - we just map to primary
       ->addWhere('name', 'NOT IN', ['id', 'location_type_id', 'phone_type_id'])
@@ -2438,7 +2436,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     $emailFields = (array) Email::getFields()
       ->addWhere('readonly', '=', FALSE)
       ->addWhere('usage', 'CONTAINS', 'import')
-      ->addWhere('fk_entity', 'IS EMPTY')
       ->setAction('save')
       // Exclude these fields to keep it simpler for now - we just map to primary
       ->addWhere('name', 'NOT IN', ['id', 'location_type_id'])

--- a/schema/Contact/Contact.entityType.php
+++ b/schema/Contact/Contact.entityType.php
@@ -414,6 +414,7 @@ return [
       'description' => ts('Name used for sorting different contact types'),
       'add' => '1.1',
       'usage' => [
+        'duplicate_matching',
         'export',
       ],
       'input_attrs' => [

--- a/schema/Core/Address.entityType.php
+++ b/schema/Core/Address.entityType.php
@@ -237,6 +237,9 @@ return [
       'input_type' => 'ChainSelect',
       'description' => ts('Which County does this address belong to.'),
       'add' => '1.1',
+      'usage' => [
+        'import',
+      ],
       'input_attrs' => [
         'control_field' => 'state_province_id',
         'label' => ts('County'),
@@ -263,6 +266,9 @@ return [
       'input_type' => 'ChainSelect',
       'description' => ts('Which State_Province does this address belong to.'),
       'add' => '1.1',
+      'usage' => [
+        'import',
+      ],
       'localize_context' => 'province',
       'input_attrs' => [
         'control_field' => 'country_id',
@@ -328,6 +334,9 @@ return [
       'input_type' => 'Select',
       'description' => ts('Which Country does this address belong to.'),
       'add' => '1.1',
+      'usage' => [
+        'import',
+      ],
       'localize_context' => 'country',
       'input_attrs' => [
         'label' => ts('Country'),

--- a/schema/Core/Address.entityType.php
+++ b/schema/Core/Address.entityType.php
@@ -239,6 +239,7 @@ return [
       'add' => '1.1',
       'usage' => [
         'import',
+        'duplicate_matching',
       ],
       'input_attrs' => [
         'control_field' => 'state_province_id',
@@ -268,6 +269,7 @@ return [
       'add' => '1.1',
       'usage' => [
         'import',
+        'duplicate_matching',
       ],
       'localize_context' => 'province',
       'input_attrs' => [
@@ -336,6 +338,7 @@ return [
       'add' => '1.1',
       'usage' => [
         'import',
+        'duplicate_matching',
       ],
       'localize_context' => 'country',
       'input_attrs' => [

--- a/schema/Core/Phone.entityType.php
+++ b/schema/Core/Phone.entityType.php
@@ -121,7 +121,6 @@ return [
       'usage' => [
         'import',
         'export',
-        'duplicate_matching',
       ],
       'input_attrs' => [
         'label' => ts('Phone'),
@@ -149,8 +148,11 @@ return [
       'readonly' => TRUE,
       'description' => ts('Phone number stripped of all whitespace, letters, and punctuation.'),
       'add' => '4.3',
+      'usage' => [
+        'duplicate_matching',
+      ],
       'input_attrs' => [
-        'label' => ts('Numeric'),
+        'label' => ts('Phone (Numbers only)'),
       ],
     ],
     'phone_type_id' => [


### PR DESCRIPTION
Overview
----------------------------------------
Fix dedupe rules to select available fields based on `usage` being `duplicate_matching`

This follows on from a fix for the 'unrelated' import usage which wound up affecting this usage https://github.com/civicrm/civicrm-core/pull/30993 because this usage is not doing the right thing

Before
----------------------------------------
We have added a `usage` for the Dedupe use case to the schema - ie `duplicate_matching` but the code that determines the field that are available for import matching traditionally called `importableFields()` and got a list of the fields for `import` and then wrangled them. Previous work had severed the connection & the file has it's own copy of the function but it had no yet been refactored to use the `usage` metadata

After
----------------------------------------
Usage metadata now correctly used, additional test added for Address custom fields

Technical Details
----------------------------------------
This highlighted some discrepancies around labels as the tests failed without an adjustment - note the displayed label is the one designated for the html input label (falling back to title) - otherwise we get 'State Province ID' not 'State/Province'

Also note that the available fields for this usage were 'written' for the 'import' usage so some feel kinda inappropriate
- The label for master_id went from 'Master ID' to 'Master Address Belongs To'
- The label for state_province_id went from 'State' to 'State/Province'
- The label for 'image_URL' went from 'Image URL' to 'image' (I would argue we should consider removing this usage for image)
- The label for 'is_opt_out' went from 'No Bulk Emails (User Opt Out)' to 'Is Opt Out' (I would potentially remove the usage here too)
- The label for ''Signature Html'' went to ''Signature HTML' (I think the usage could go here)
- the label for 'sic_code' went from 'Sic Code' to 'SIC Code'

In the case of `phone_numeric` I felt this warranted a labeling change. Note that this field is very important in the dedupe context. I changed the input label from "numeric" to "Phone (Numbers only)" (it was previously being presented as just 'Phone' in the dedupe context

Comments
----------------------------------------
