### PR TITLE
dompdf - Configure default "font_dir" for Standalone

### DIFF
--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -290,7 +290,7 @@ class CRM_Utils_PDF_Utils {
     foreach (['font_dir', 'chroot', 'log_output_file'] as $setting) {
       $value = \Civi::settings()->get("dompdf_$setting");
       if (isset($value)) {
-        $settings[$setting] = $value;
+        $settings[$setting] = Civi::paths()->getPath($value);
       }
     }
 

--- a/setup/plugins/init/Standalone.civi-setup.php
+++ b/setup/plugins/init/Standalone.civi-setup.php
@@ -97,6 +97,7 @@ function _standalone_setup_scheme(): string {
     $model->paths['civicrm.l10n']['path'] = $privatePath . '/l10n';
     $model->mandatorySettings['customFileUploadDir'] = '[cms.root]/private/attachment';
     $model->mandatorySettings['uploadDir'] = '[cms.root]/private/tmp';
+    $model->mandatorySettings['dompdf_font_dir'] = '[cms.root]/private';
 
     // public directories
     $model->paths['civicrm.files']['path'] = $appRootPath . '/public';


### PR DESCRIPTION
Overview
-------------

This initializes the setting `dompdf_font_dir` for Standalone... in the same way that other settings are initialized. This allows various headless tests to run successfully on Standalone.

cc @demeritcowboy @ufundo  - I've never needed to customize this folder, so I don't have a strong sense if this is a good or bad location. (Maybe something else is better?) But generally, the style of folder-layouts in "Standalone" tries to be more thoughtful about the split between `public/` and `private/`.

Before
------

* Various unit-tests involving PDFs fail if they run on Standalone. Ex: * `api_v3_JobTest::testMailReportForPdf` * `CRM_Activity_Form_Task_PDFTest::testCreateDocumentUnknownTokens` * `CRM_Contribute_Form_Task_PDFLetterCommonTest::testGroupedThankYous`
* `dompdf_font_dir` must be an absolute path.
* On Standalone, the default value of `dompdf_font_dir` is invalid.

After
-----

* Those unit-tests pass on Staandalone.
* `dompdf_font_dir` may be absolute, or it may use path-variables (like `[civicrm.private]` or `[cms.root]`).
* On Standalone, the default value of `dompdf_font_dir` is valid.

Comments
--------

The existing setting `dompdf_font_dir` has this behavior:

* If it's set (and writeable), then CRM_Utils_PDF_Utils will initialize subdir `font_cache`.
* If it's unset (or unwriteable), then CRM_Utils_PDF_Utils will go to `[civicrm.files]/upload/font_cache`.

This fails when running on standalone because `[civicrm.files]/upload` doesn't exist. That folder has already been redirected elsewhere.

The general style by which Standalone has redirected folders is to pre-initialize them in `Standalone.civi-setup.php`.

The patch has the effect of moving `dompdf_font_dir` to a valid place on new installations Standalone; and leaving it alone for all other deployments.

