### PR TITLE
EventCart - Move 'Pending in cart' status to extension

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/SortableEntitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/SortableEntitySpecProvider.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\RequestSpec;
+use Civi\Api4\Utils\CoreUtil;
+
+/**
+ * @service
+ * @internal
+ */
+class SortableEntitySpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
+
+  /**
+   * Generic create spec function applies to all SortableEntity types.
+   * Disables required 'weight' field because that's auto-managed.
+   *
+   * @param \Civi\Api4\Service\Spec\RequestSpec $spec
+   */
+  public function modifySpec(RequestSpec $spec): void {
+    $weightFieldName = CoreUtil::getInfoItem($spec->getEntity(), 'order_by');
+    $weightField = $spec->getFieldByName($weightFieldName);
+    $weightField->setRequired(FALSE);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function applies($entity, $action) {
+    return $action === 'create' && CoreUtil::isType($entity, 'SortableEntity');
+  }
+
+}

--- a/ext/eventcart/managed/ParticipantStatusType_Pending_in_cart.mgd.php
+++ b/ext/eventcart/managed/ParticipantStatusType_Pending_in_cart.mgd.php
@@ -1,0 +1,24 @@
+<?php
+use CRM_Event_Cart_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'ParticipantStatusType_Pending_in_cart',
+    'entity' => 'ParticipantStatusType',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Pending in cart',
+        'label' => E::ts('Pending in cart'),
+        'class' => 'Pending',
+        'is_reserved' => TRUE,
+        'visibility_id:name' => 'admin',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+];

--- a/sql/civicrm_data/civicrm_participant_status_type.sqldata.php
+++ b/sql/civicrm_data/civicrm_participant_status_type.sqldata.php
@@ -99,13 +99,6 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_participant_status_type')
       'weight' => 12,
     ],
     [
-      'name' => 'Pending in cart',
-      'label' => ts('Pending in cart'),
-      'class' => 'Pending',
-      'is_counted' => 0,
-      'weight' => 13,
-    ],
-    [
       'name' => 'Partially paid',
       'label' => ts('Partially paid'),
       'class' => 'Positive',


### PR DESCRIPTION
Overview
----------------------------------------
Moves a participant status type out of core and into the extension where it belongs.

Comments
-------------
I was really trying to get rid of this hack:

https://github.com/civicrm/civicrm-core/blob/19a5745c09f693c66ffb0047f55f61e7e9072e0b/CRM/Event/BAO/Participant.php#L1760-L1766

But I got stuck on the fact that the extension cannot be disabled in the UI, which means the managed entity won't auto enable/disable the record, which means we still need the hack.

@eileenmcnaughton I think the next step for event cart is to make the extension visible in the UI, and remove the `enable_cart` setting, per 

https://github.com/civicrm/civicrm-core/blob/85c643be0ac3341dd3a05ae5740f88676adbf21a/ext/eventcart/README.md#L7-L11
