### PR TITLE
Civi::url() - Multiple fixes and test improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ packages/
 tests/output
 tests/phpunit/CiviTest/civicrm.settings.local.php
 tests/phpunit/CiviTest/truncate.xml
+tests/**/*.rtf.php
 tools/scripts/releaser/releaser.conf
 tools/tests/reports/logfile.tap
 tools/tests/reports/testdox.html

--- a/CRM/Core/Page/RemoteTestFunction.php
+++ b/CRM/Core/Page/RemoteTestFunction.php
@@ -1,0 +1,99 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * Handle requests for civicrm/dev/rtf
+ */
+class CRM_Core_Page_RemoteTestFunction extends CRM_Core_Page {
+
+  public function run() {
+    $result = static::handleJwt(CRM_Utils_Request::retrieve('t', 'String'));
+    if (is_string($result) || is_numeric($result)) {
+      echo $result;
+    }
+    elseif ($result instanceof \Psr\Http\Message\ResponseInterface) {
+      CRM_Utils_System::sendResponse($result);
+    }
+    else {
+      throw new \LogicException("Malformed response");
+    }
+  }
+
+  /**
+   * Decode a JWT token and call the requested RTF.
+   *
+   * @internal
+   * @param string $token
+   * @return \GuzzleHttp\Psr7\Response|string
+   */
+  public static function handleJwt(string $token) {
+    try {
+      /** @var \Civi\Crypto\CryptoJwt $jwt */
+      $jwt = Civi::service('crypto.jwt');
+      $claims = $jwt->decode($token);
+    }
+    catch (\Exception $e) {
+      $claims = [];
+    }
+
+    if (empty($claims['exp'])) {
+      throw new \LogicException("All JWT signatures must include an expiration time.");
+    }
+
+    if (empty($claims['civi.remote-test-function']->id)) {
+      return new Response(200, ['Content-Type' => 'text/plain'], 'Hello world');
+    }
+
+    $responseType = $claims['civi.remote-test-function']->{'response-type'} ?? NULL;
+    $responder = static::getResponders()[$responseType] ?? NULL;
+    if (!$responder) {
+      throw new \LogicException("Invalid response type");
+    }
+
+    // Ensure args use JSON-array rather than JSON-stdClass.
+    $args = json_decode(json_encode($claims['civi.remote-test-function']->args ?? []), TRUE);
+
+    $rtf = \Civi\Test\RemoteTestFunction::byId($claims['civi.remote-test-function']->id);
+    $result = $rtf->_run($args);
+    return $responder($result);
+  }
+
+  protected static function getResponders(): array {
+    return [
+      'application/json' => function ($data) {
+        return new Response(200, ['Content-Type' => 'application/json'], json_encode($data));
+      },
+      'application/php-serialized' => function ($data) {
+        return new Response(200, ['Content-Type' => 'application/php-serialized'], serialize($data));
+      },
+      'text/html' => function ($html) {
+        if (is_string($html)) {
+          return $html;
+        }
+        else {
+          throw new \LogicException("Expected output of type HTML. Received: " . gettype($html));
+        }
+      },
+      'psr7' => function ($data) {
+        if ($data instanceof \Psr\Http\Message\ResponseInterface) {
+          return $data;
+        }
+        else {
+          throw new \LogicException("Expected output of type \Psr\Http\Message\ResponseInterface. Received: " . gettype($data));
+        }
+      },
+    ];
+  }
+
+}

--- a/CRM/Core/xml/Menu/Misc.xml
+++ b/CRM/Core/xml/Menu/Misc.xml
@@ -187,6 +187,13 @@
     <access_arguments>*always allow*</access_arguments>
   </item>
   <item>
+    <path>civicrm/dev/rtf</path>
+    <page_callback>CRM_Core_Page_RemoteTestFunction</page_callback>
+    <title>Remote Test Function</title>
+    <is_public>true</is_public>
+    <access_arguments>*always allow*</access_arguments>
+  </item>
+  <item>
     <path>civicrm/profile-editor/schema</path>
     <page_callback>CRM_UF_Page_ProfileEditor::getSchemaJSON</page_callback>
     <title>ProfileEditor</title>

--- a/CRM/Utils/Url.php
+++ b/CRM/Utils/Url.php
@@ -59,6 +59,25 @@ class CRM_Utils_Url {
   }
 
   /**
+   * Convert to an absolute URL (if relative).
+   *
+   * @param string $value
+   * @param string|null $currentHostPort
+   *   The value of HTTP_HOST. (NULL means "lookup HTTP_HOST")
+   * @return string
+   *   Either the relative version of $value (if on the same HTTP_HOST), or else
+   *   the absolute version.
+   */
+  public static function toAbsolute(string $value, ?string $currentHostPort = NULL): string {
+    if ($value[0] === '/') {
+      $currentHostPort = $currentHostPort ?: $_SERVER['HTTP_HOST'] ?? NULL;
+      $scheme = CRM_Utils_System::isSSL() ? 'https' : 'http';
+      return $scheme . '://' . $currentHostPort . $value;
+    }
+    return $value;
+  }
+
+  /**
    * Parse an internal URL. Extract the CiviCRM route.
    *
    * @param string $pageUrl

--- a/Civi/Core/Url.php
+++ b/Civi/Core/Url.php
@@ -616,51 +616,52 @@ final class Url implements \JsonSerializable {
   public function __toString(): string {
     $userSystem = \CRM_Core_Config::singleton()->userSystem;
     $preferFormat = $this->getPreferFormat() ?: static::detectFormat();
-    $scheme = $this->getScheme();
+    $renderedPieces = $this->toRenderedPieces();
+    $scheme = $renderedPieces['scheme'];
 
     if ($scheme === NULL || $scheme === 'current') {
       $scheme = static::detectScheme();
     }
 
     if ($scheme === 'default') {
-      $scheme = \CRM_Core_Menu::isPublicRoute($this->getPath()) ? 'frontend' : 'backend';
+      $scheme = \CRM_Core_Menu::isPublicRoute($renderedPieces['path']) ? 'frontend' : 'backend';
     }
 
     // Goal: After this switch(), we should have the $scheme, $path, and $query combined.
     switch ($scheme) {
       case 'assetBuilder':
-        $assetName = $this->getPath();
+        $assetName = $renderedPieces['path'];
         $assetParams = [];
-        parse_str('' . $this->getQuery(), $assetParams);
+        parse_str('' . $renderedPieces['query'], $assetParams);
         $result = \Civi::service('asset_builder')->getUrl($assetName, $assetParams);
         break;
 
       case 'asset':
-        if (preg_match(';^\[([\w\.]+)\](.*)$;', $this->getPath(), $m)) {
+        if (preg_match(';^\[([\w\.]+)\](.*)$;', $renderedPieces['path'], $m)) {
           [, $var, $rest] = $m;
           $varValue = rtrim(\Civi::paths()->getVariable($var, 'url'), '/');
-          $result = $varValue . $rest . $this->composeQuery();
+          $result = $varValue . $rest . $this->composeQuery($renderedPieces['query']);
         }
         else {
-          throw new \RuntimeException("Malformed asset path: {$this->getPath()}");
+          throw new \RuntimeException("Malformed asset path: " . $renderedPieces['path']);
         }
         break;
 
       case 'ext':
-        $parts = explode('/', $this->getPath(), 2);
-        $result = \Civi::resources()->getUrl($parts[0], $parts[1] ?? NULL, FALSE) . $this->composeQuery();
+        $parts = explode('/', $renderedPieces['path'], 2);
+        $result = \Civi::resources()->getUrl($parts[0], $parts[1] ?? NULL, FALSE) . $this->composeQuery($renderedPieces['query']);
         break;
 
       case 'http':
       case 'https':
         $port = is_numeric($this->port) ? ":{$this->port}" : "";
         $path = $this->getPath();
-        $result = $this->getScheme() . '://' . $this->host . $port . $path . $this->composeQuery();
+        $result = $this->getScheme() . '://' . $this->host . $port . $path . $this->composeQuery($renderedPieces['query']);
         break;
 
       // Handle 'frontend', 'backend', 'service', and any extras.
       default:
-        $result = $userSystem->getRouteUrl($scheme, $this->getPath(), $this->getQuery());
+        $result = $userSystem->getRouteUrl($scheme, $renderedPieces['path'], $renderedPieces['query']);
         if ($result === NULL) {
           $event = GenericHookEvent::create(['url' => $this, 'result' => &$result]);
           \Civi::dispatcher()->dispatch('civi.url.render.' . $scheme, $event);
@@ -678,7 +679,7 @@ final class Url implements \JsonSerializable {
       $result = \Civi::resources()->addCacheCode($result);
     }
 
-    $result .= $this->composeFragment();
+    $result .= $this->composeFragment($renderedPieces['fragment'], $renderedPieces['fragmentQuery']);
 
     if ($preferFormat === 'relative') {
       $result = \CRM_Utils_Url::toRelative($result);
@@ -693,24 +694,20 @@ final class Url implements \JsonSerializable {
       $result = 'http:' . substr($result, 6);
     }
 
-    if ($this->vars !== NULL) {
-      // Replace variables
-      $result = preg_replace_callback('/\[(\w+)\]/', function($m) {
-        $var = $m[1];
-        if (isset($this->vars[$var])) {
-          return urlencode($this->vars[$var]);
-        }
-        if ($this->varsCallback !== NULL) {
-          $value = call_user_func($this->varsCallback, $var);
-          if ($value !== NULL) {
-            return urlencode($value);
-          }
-        }
-        return "[$var]";
-      }, $result);
-    }
-
     return $this->htmlEscape ? htmlentities($result) : $result;
+  }
+
+  /**
+   * @return array{scheme: ?string, path: ?string, query: ?string}
+   */
+  private function toRenderedPieces(): array {
+    return [
+      'scheme' => $this->replaceVars('scheme', $this->getScheme()),
+      'path' => $this->replaceVars('path', $this->getPath()),
+      'query' => $this->replaceVars('query', $this->getQuery()),
+      'fragment' => $this->replaceVars('fragment', $this->fragment),
+      'fragmentQuery' => $this->replaceVars('fragmentQuery', $this->fragmentQuery),
+    ];
   }
 
   #[\ReturnTypeWillChange]
@@ -718,13 +715,33 @@ final class Url implements \JsonSerializable {
     return $this->__toString();
   }
 
+  private function replaceVars(string $context, ?string $expr): ?string {
+    if ($expr === NULL || $this->vars === NULL) {
+      return $expr;
+    }
+    $result = preg_replace_callback('/\[(\w+)\]/', function($m) {
+      $var = $m[1];
+      if (isset($this->vars[$var])) {
+        return urlencode($this->vars[$var]);
+      }
+      if ($this->varsCallback !== NULL) {
+        $value = call_user_func($this->varsCallback, $var);
+        if ($value !== NULL) {
+          return urlencode($value);
+        }
+      }
+      return "[$var]";
+    }, $expr);
+    return $result;
+  }
+
   /**
    * @return string
    *   '' or '?foo=bar'
    */
-  private function composeQuery(): string {
-    if ($this->query !== NULL && $this->query !== '') {
-      return '?' . $this->query;
+  private function composeQuery(?string $query): string {
+    if ($query !== NULL && $query !== '') {
+      return '?' . $query;
     }
     else {
       return '';
@@ -735,12 +752,12 @@ final class Url implements \JsonSerializable {
    * @return string
    *   '' or '#foobar'
    */
-  private function composeFragment(): string {
-    $fragment = $this->fragment ?: '';
-    if ($this->fragmentQuery !== NULL && $this->fragmentQuery !== '') {
-      $fragment .= '?' . $this->fragmentQuery;
+  private function composeFragment(?string $baseFragment, ?string $fragmentQuery): string {
+    $fullFragment = $baseFragment ?: '';
+    if ($fragmentQuery !== NULL && $fragmentQuery !== '') {
+      $fullFragment .= '?' . $fragmentQuery;
     }
-    return ($fragment === '') ? '' : "#$fragment";
+    return ($fullFragment === '') ? '' : "#$fullFragment";
   }
 
   private static function detectFormat(): string {

--- a/Civi/Core/Url.php
+++ b/Civi/Core/Url.php
@@ -684,6 +684,9 @@ final class Url implements \JsonSerializable {
     if ($preferFormat === 'relative') {
       $result = \CRM_Utils_Url::toRelative($result);
     }
+    elseif ($preferFormat === 'absolute') {
+      $result = \CRM_Utils_Url::toAbsolute($result);
+    }
 
     // TODO decide if the current default is good enough for future
     $ssl = $this->getSsl() ?: \CRM_Utils_System::isSSL();

--- a/Civi/Test/RemoteTestFunction.php
+++ b/Civi/Test/RemoteTestFunction.php
@@ -1,0 +1,367 @@
+<?php
+
+namespace Civi\Test;
+
+use Civi\Schema\Traits\MagicGetterSetterTrait;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Laravel\SerializableClosure\Support\ReflectionClosure;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * RemoteTestFunctions may be used by tests to define (inline) code that will run on
+ * a remote server.
+ *
+ * @code
+ * // Register a function. Send a request and parse the response as PHP data.
+ * // Responses MUST be JSON-serializable data.
+ * $getBaseUrl = RemoteTestFunction::register('getBaseUrl', fn() => CIVICRM_UF_BASEURL);
+ * $data = $getBaseUrl->execute();
+ * @endCode
+ *
+ * @code
+ * // Register a function. Send HTTP call and inspect response.
+ * $getBaseUrl = RemoteTestFunction::register('getBaseUrl', fn() => CIVICRM_UF_BASEURL);
+ * $response = $getBaseUrl->httpRequest();
+ * assertEquals(200, $response->getStatusCode());
+ * @endCode
+ *
+ * TODO: Continue kicking-around method signatures. How best to distinguish functions which
+ *       are meant to return JSON data and functions which are meant as mini page-controllers?
+ *
+ * @method string getRequestMethod()
+ * @method $this setRequestMethod(string $method)
+ * @method string getRequestChannel()
+ * @method $this setRequestChannel(string $channel)
+ * @method string getResponseType()
+ * @method $this setResponseType(string $type)
+ * @method $this setResponseDecoder(callable $decoder)
+ * @method callable|null getResponseDecoder()
+ */
+class RemoteTestFunction {
+
+  use HttpTestTrait;
+  use MagicGetterSetterTrait;
+
+  // ---------------------------------------------------------------------------------------
+  // Static methods: Create and locate remote test functions.
+  // ---------------------------------------------------------------------------------------
+
+  /**
+   * Declare a remote-test-function.
+   *
+   * This is used by a test-class to prepare the server to execute some code.
+   *
+   * @param string $class
+   *   Who is creating this function.
+   * @param string $name
+   *   Name of the function. (Each test-function should be unique within its test-class.)
+   * @param \Closure $closure
+   *   Logic to execute. Should be a Closure. Must not have any `use()` properties.
+   *   The result should be a JSON-friendly array-tree.
+   *   Alternatively, it may emit a custom HTTP response via \CRM_Utils_System::sendResponse($result);
+   * @return \Civi\Test\RemoteTestFunction
+   */
+  public static function register(string $class, string $name, \Closure $closure): RemoteTestFunction {
+    $id = md5("{$class}::{$name}");
+    $instance = new static($class, $name, $id, self::getIndexPath($id), self::getCodePath($class, $name));
+    if (!class_exists($class)) {
+      throw new \RuntimeException("RemoteTestFunction: Invalid registration class");
+    }
+    $instance->save(new ReflectionClosure($closure));
+    return $instance;
+  }
+
+  /**
+   * Lookup the implementation of a remote-test-function.
+   *
+   * @param string $class
+   * @param string $name
+   * @return \Civi\Test\RemoteTestFunction|null
+   */
+  public static function byName(string $class, string $name): ?RemoteTestFunction {
+    $id = md5("{$class}::{$name}");
+    $instance = new static($class, $name, $id, self::getIndexPath($id), self::getCodePath($class, $name));
+    if (!file_exists($instance->codeFile)) {
+      throw new \RuntimeException("Cannot find RemoteTestFunction($class, $name)");
+    }
+    return $instance;
+  }
+
+  public static function byId(string $id): ?RemoteTestFunction {
+    $indexPath = self::getIndexPath($id);
+    if (!file_exists($indexPath)) {
+      throw new \RuntimeException("RemoteTestFunction: Invalid ID");
+    }
+    $about = json_decode(file_get_contents($indexPath), TRUE);
+    if ($about['id'] !== $id) {
+      throw new \RuntimeException("RemoteTestFunction: Mismatched ID. Stop trying to pull my leg.");
+    }
+    $instance = new static($about['class'], $about['name'], $about['id'], $indexPath, $about['codeFile']);
+    return $instance;
+  }
+
+  private static function assertTestEnvironment(): void {
+    if (!class_exists('PHPUnit\Framework\TestCase')) {
+      throw new \LogicException("RemoteTestFunction::save() can only run in the test framework.");
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Data model
+  // ---------------------------------------------------------------------------------------
+
+  /**
+   * Name of the test-class which defined the RTF.
+   *
+   * @var string
+   */
+  private string $class;
+
+  /**
+   * Logical name of the remote executable.
+   *
+   * This is often eponymous with the test-function but it may vary.
+   *
+   * @var string
+   */
+  private string $name;
+
+  /**
+   * @var string
+   */
+  private string $id;
+
+  /**
+   * Path to a file with local metadata about the RTF.
+   *
+   * @var string
+   */
+  private string $indexFile;
+
+  /**
+   * Path to a file with the minimal/extracted version of the RTF.
+   *
+   * @var string
+   */
+  private string $codeFile;
+
+  /**
+   * How to submit the request. One of: "POST", "GET", "LOCAL"
+   * @var string
+   */
+  protected string $requestMethod = 'POST';
+
+  protected string $responseType = 'application/json';
+
+  /**
+   * @var callable|null
+   */
+  protected $responseDecoder;
+
+  /**
+   * @var string
+   *   Either 'HTTP' or 'LOCAL'
+   */
+  protected string $requestChannel = 'HTTP';
+
+  // ---------------------------------------------------------------------------------------
+  // Primary APIs for calling remote test functions
+  // ---------------------------------------------------------------------------------------
+
+  /**
+   * Generate an HTTP request template.
+   *
+   * If you send this HTTP request, it will run the remote test-function.
+   *
+   * @param array $args
+   *   Data to pass through to the test function.
+   * @param string $method
+   * @return \Psr\Http\Message\RequestInterface
+   */
+  public function httpRequest(array $args = [], string $method = 'POST') {
+    $token = \Civi::service('crypto.jwt')->encode([
+      'civi.remote-test-function' => [
+        'id' => $this->id,
+        'args' => $args,
+        'response-type' => $this->getResponseType(),
+      ],
+      'exp' => \CRM_Utils_Time::strtotime('+2 hour'), /* Handy for debugging */
+    ]);
+    $url = \Civi::url('backend://civicrm/dev/rtf')->addQuery([
+      't' => $token,
+    ]);
+
+    return new Request($method, (string) $url);
+  }
+
+  /**
+   * Execute the method.
+   *
+   * This is intended for use with RTF's that simply return JSON data.
+   * If your RTF intends to emit some other response, then use httpRequest() and Guzzle Client.
+   *
+   * @param array $args
+   *   Data to pass through to the test function.
+   * @return mixed
+   */
+  public function execute(array $args = []) {
+    $request = $this->httpRequest($args, $this->requestMethod);
+    $client = $this->createClient();
+    $method = ($client instanceof \Psr\Http\Client\ClientInterface)
+      ? 'sendRequest' : 'send'; /* PSR-18 vs Guzzle 6 */
+    $response = $client->{$method}($request);
+    return call_user_func($this->createDecoder(), $response);
+  }
+
+  protected function createDecoder(): callable {
+    if ($this->responseDecoder !== NULL) {
+      return $this->responseDecoder;
+    }
+    switch ($this->responseType) {
+      case 'text/html':
+        return fn(ResponseInterface $r) => (string) $r->getBody();
+
+      case 'application/json':
+        return function(ResponseInterface $response) {
+          if ($response->getHeader('Content-type')[0] === 'application/json') {
+            $data = (string) $response->getBody();
+            return json_decode($data, TRUE);
+          }
+          else {
+            throw new \LogicException("RemoteTestFunction::execute(): Malformed response. Expected JSON. Use DEBUG=2 to inspect the full interaction, or use a custom httpRequest() to handle non-JSON response-types.");
+          }
+        };
+
+      default:
+        throw new \LogicException("RemoteTestFunction: No decoder available for $this->responseType");
+    }
+  }
+
+  /**
+   * @return \GuzzleHttp\Client|\Psr\Http\Client\ClientInterface
+   */
+  private function createClient() {
+    switch ($this->requestChannel) {
+      case 'HTTP':
+        return $this->createGuzzle();
+
+      case 'LOCAL':
+        return new class implements ClientInterface {
+
+          public function sendRequest(RequestInterface $request): ResponseInterface {
+            parse_str($request->getUri()->getQuery(), $query);
+            $result = \CRM_Core_Page_RemoteTestFunction::handleJwt($query['t']);
+            if (is_string($result)) {
+              $result = new Response(200, ['Content-Type' => 'text/html'], "<html><body>$result</body></html>");
+            }
+            return $result;
+          }
+
+        };
+
+      default:
+        throw new \LogicException("Unrecognized request channel: {$this->requestChannel}");
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------------------
+
+  /**
+   * @param string $class
+   * @param string $name
+   * @param string $id
+   * @param string $indexFile
+   * @param string $codeFile
+   */
+  private function __construct(string $class, string $name, string $id, string $indexFile, string $codeFile) {
+    // If the constant is missing, then your system is misconfigured.
+    // if (!\CRM_Utils_Constant::value('CIVICRM_REMOTE_TEST_FUNC')) {
+    //   throw new \RuntimeException("RemoteTestFunction can only be used if CIVICRM_REMOTE_TEST_FUNC is enabled.");
+    // }
+
+    $this->class = $class;
+    $this->name = $name;
+    $this->id = $id;
+    $this->indexFile = $indexFile;
+    $this->codeFile = $codeFile;
+  }
+
+  private function save(ReflectionClosure $refl): void {
+    self::assertTestEnvironment();
+
+    $upstreamTimestamp = max(filemtime($refl->getFileName()), filemtime(__FILE__));
+
+    if (!file_exists($this->indexFile) || filemtime($this->indexFile) < $upstreamTimestamp) {
+      $about = ['class' => $this->class, 'name' => $this->name, 'id' => $this->id, 'codeFile' => $this->codeFile];
+      $this->writeFile($this->indexFile, json_encode($about));
+    }
+
+    if (!file_exists($this->codeFile) || filemtime($this->codeFile) < $upstreamTimestamp) {
+      $this->writeFile($this->codeFile, $this->render($refl));
+    }
+  }
+
+  private function writeFile(string $path, string $content): void {
+    $parent = dirname($path);
+    if (!is_dir($parent)) {
+      if (!mkdir($parent, 0777, TRUE)) {
+        throw new \RuntimeException("RemoteTestFunction: Failed to storage ($parent)");
+      }
+    }
+
+    if (FALSE === file_put_contents($path, $content)) {
+      throw new \RuntimeException("RemoteTestFunction: Failed to write file ($path)");
+    }
+  }
+
+  public function _run($args = []) {
+    if ($this->codeFile === NULL || !file_exists($this->codeFile)) {
+      throw new \LogicException("Cannot load function for ({$this->class}::{$this->name}). Closure has not been extracted.");
+    }
+    if (!preg_match(';\.rtf\.php$;', $this->codeFile)) {
+      throw new \RuntimeException("Malformed filename ($this->codeFile) for ({$this->class}::{$this->name})");
+    }
+    $f = include $this->codeFile;
+    return $f(...$args);
+  }
+
+  private function render(ReflectionClosure $refl): string {
+    if (!empty($refl->getUseVariables())) {
+      throw new \LogicException(sprintf("Callback at %s::%d cannot used by %s. The \"use\" operator is unsupported.",
+        $refl->getFileName(), $refl->getStartLine(), __CLASS__
+      ));
+    }
+
+    // In practice, this would be inconvenient and not really add much.
+    // if (!$refl->isStatic()) {
+    //   throw new \LogicException(sprintf("Callback at %s::%d cannot used by %s. The function must be static.",
+    //     $refl->getFileName(), $refl->getStartLine(), __CLASS__
+    //   ));
+    // }
+
+    $message = sprintf("// This code is automatically extracted from %s.\n// Updates should be made in the main class.\n// You may wish to use this file for debugging.\n", $refl->getName());
+
+    return '<' . "?php\n\n$message\nreturn " . $refl->getCode() . ";\n";
+  }
+
+  /**
+   * The folder which stores information about test functions.
+   *
+   * @return string
+   */
+  private static function getIndexPath(string $id): string {
+    return implode(DIRECTORY_SEPARATOR, [dirname(__DIR__, 2), 'tests', 'tmp', $id . '.json']);
+  }
+
+  private static function getCodePath(string $className, string $name): string {
+    $class = new \ReflectionClass($className);
+    $base = preg_replace('/\.php/', '', $class->getFileName());
+    return $base . DIRECTORY_SEPARATOR . $name . '.rtf.php';
+  }
+
+}

--- a/composer.json
+++ b/composer.json
@@ -85,6 +85,7 @@
     "pear/log": "1.14.4",
     "adrienrn/php-mimetyper": "0.2.2",
     "civicrm/composer-downloads-plugin": "^3.0 || ^4.0",
+    "laravel/serializable-closure": "^1.3",
     "league/csv": "~9.7.4",
     "league/oauth2-client": "^2.4",
     "league/oauth2-google": "^3.0 || ^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "477e7288010997d1ceabc82ac51c4822",
+    "content-hash": "edea3fbf83b55cdd4926762fd6a2cfa7",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -1217,6 +1217,67 @@
                 "source": "https://github.com/KnpLabs/snappy/tree/v1.4.4"
             },
             "time": "2023-09-13T12:18:19+00:00"
+        },
+        {
+            "name": "laravel/serializable-closure",
+            "version": "v1.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/serializable-closure.git",
+                "reference": "61b87392d986dc49ad5ef64e75b1ff5fee24ef81"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/61b87392d986dc49ad5ef64e75b1ff5fee24ef81",
+                "reference": "61b87392d986dc49ad5ef64e75b1ff5fee24ef81",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3|^8.0"
+            },
+            "require-dev": {
+                "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
+                "nesbot/carbon": "^2.61|^3.0",
+                "pestphp/pest": "^1.21.3",
+                "phpstan/phpstan": "^1.8.2",
+                "symfony/var-dumper": "^5.4.11|^6.2.0|^7.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\SerializableClosure\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Nuno Maduro",
+                    "email": "nuno@laravel.com"
+                }
+            ],
+            "description": "Laravel Serializable Closure provides an easy and secure way to serialize closures in PHP.",
+            "keywords": [
+                "closure",
+                "laravel",
+                "serializable"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/serializable-closure/issues",
+                "source": "https://github.com/laravel/serializable-closure"
+            },
+            "time": "2024-08-02T07:48:17+00:00"
         },
         {
             "name": "league/csv",
@@ -5776,5 +5837,5 @@
     "platform-overrides": {
         "php": "7.4.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/tests/phpunit/E2E/Core/PathUrlTest.php
+++ b/tests/phpunit/E2E/Core/PathUrlTest.php
@@ -124,7 +124,7 @@ class PathUrlTest extends \CiviEndToEndTestCase {
 
     $this->assertNotEmpty($urlPatterns);
     foreach ($urlPatterns as $urlPattern) {
-      $this->assertRegExp($urlPattern[0], $urlPattern[1]);
+      $this->assertMatchesRegularExpression($urlPattern[0], $urlPattern[1]);
     }
   }
 

--- a/tests/phpunit/E2E/Core/UrlFacadeTest.php
+++ b/tests/phpunit/E2E/Core/UrlFacadeTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Civi\Core;
+namespace E2E\Core;
 
 use Civi;
+use Civi\Core\Url;
 
 /**
  * Test generation of URLs via `Civi::url()` (`Civi\Core\Url`).
@@ -11,9 +12,9 @@ use Civi;
  * There is also some coverage of the UF-specific parts in the E2E suite.
  *
  * @see \E2E\Core\PathUrlTest
- * @group headless
+ * @group e2e
  */
-class UrlTest extends \CiviUnitTestCase {
+class UrlFacadeTest extends \CiviEndToEndTestCase {
 
   public function setUp(): void {
     $parts = explode('/', CIVICRM_UF_BASEURL);
@@ -22,7 +23,6 @@ class UrlTest extends \CiviUnitTestCase {
     \CRM_Utils_GlobalStack::singleton()->push($tmpVars);
 
     parent::setUp();
-    $this->useTransaction();
   }
 
   protected function tearDown(): void {

--- a/tests/phpunit/E2E/Core/UrlFacadeTest.php
+++ b/tests/phpunit/E2E/Core/UrlFacadeTest.php
@@ -83,7 +83,7 @@ class UrlFacadeTest extends \CiviEndToEndTestCase {
       /** @var \Civi\Core\Url $url */
       [$expected, $url] = $example;
       $this->assertEquals($expected, $url->getPath(), sprintf("%s at %d should be have matching property", __FUNCTION__, $key));
-      $this->assertUrlComponentContains('path', $expected, $url, sprintf("%s at %d should be have matching output", __FUNCTION__, $key));
+      $this->assertUrlComponentContains('path', $expected, $url, sprintf('%s at %d: ', __FUNCTION__, $key));
     }
   }
 
@@ -105,7 +105,7 @@ class UrlFacadeTest extends \CiviEndToEndTestCase {
       /** @var \Civi\Core\Url $url */
       [$expected, $url] = $example;
       $this->assertEquals($expected, $url->getQuery(), sprintf("%s at %d should be have matching property", __FUNCTION__, $key));
-      $this->assertStringContainsString($expected, (string) $url, sprintf("%s at %d should be have matching output", __FUNCTION__, $key));
+      $this->assertUrlComponentContains('query', $expected, $url, sprintf('%s at %d: ', __FUNCTION__, $key));
     }
   }
 
@@ -235,7 +235,14 @@ class UrlFacadeTest extends \CiviEndToEndTestCase {
       $expectField = 'query';
       $expectValue = \CRM_Core_Config::singleton()->userFrameworkURLVar . '=' . urlencode($expectValue);
     }
-    $this->assertStringContainsString($expectValue, $parsedUrl[$expectField], $message . sprintf("Field \"%s\" should be have matching output. (Full URL: %s)", $expectField, $renderedUrl));
+    $actualValue = $parsedUrl[$expectField];
+    if ($expectField === 'query' && CIVICRM_UF === 'Drupal8') {
+      // These characters may be URL encoded -- even when they don't need to be. We'll accept either form.
+      $replace = ['%20' => '+', '%2F' => '/', '%5B' => '[', '%5D' => ']'];
+      $expectValue = strtr($expectValue, $replace);
+      $actualValue = strtr($actualValue, $replace);
+    }
+    $this->assertStringContainsString($expectValue, $actualValue, $message . sprintf("Field \"%s\" should contain \"%s\". (Full URL: %s)", $expectField, $expectValue, $renderedUrl));
   }
 
 }

--- a/tests/phpunit/E2E/Core/UrlFacadeTest.php
+++ b/tests/phpunit/E2E/Core/UrlFacadeTest.php
@@ -83,7 +83,7 @@ class UrlFacadeTest extends \CiviEndToEndTestCase {
       /** @var \Civi\Core\Url $url */
       [$expected, $url] = $example;
       $this->assertEquals($expected, $url->getPath(), sprintf("%s at %d should be have matching property", __FUNCTION__, $key));
-      $this->assertStringContainsString($expected, (string) $url, sprintf("%s at %d should be have matching output", __FUNCTION__, $key));
+      $this->assertUrlComponentContains('path', $expected, $url, sprintf("%s at %d should be have matching output", __FUNCTION__, $key));
     }
   }
 
@@ -155,27 +155,27 @@ class UrlFacadeTest extends \CiviEndToEndTestCase {
     $vars = ['hi' => 'hello world?', 'contact' => 123];
 
     $examples = [];
-    $examples[] = ['civicrm/admin/hello+world%3F', Civi::url('backend://civicrm/admin/[hi]?x=1')];
-    $examples[] = ['msg=hello+world%3F&id=123', Civi::url('backend://civicrm/admin?msg=[hi]&id=[contact]')];
-    $examples[] = ['a=123&b=456', Civi::url('backend://civicrm/admin?a=[1]&b=[2]')->addVars([1 => 123, 2 => 456])];
-    $examples[] = ['#/page?msg=hello+world%3F', Civi::url('backend://civicrm/a/#/page?msg=[hi]')];
-    $examples[] = ['a=hello+world%3F&b=Au+re%2Fvoir', Civi::url('frontend://civicrm/user?a=[hi]&b=[bye]')->addVars(['bye' => 'Au re/voir'])];
-    $examples[] = ['some_xyz=123', Civi::url('//civicrm/foo?some_[key]=123')->addVars(['key' => 'xyz'])];
+    $examples[] = ['path', 'civicrm/admin/hello+world%3F', Civi::url('backend://civicrm/admin/[hi]?x=1')];
+    $examples[] = ['query', 'msg=hello+world%3F&id=123', Civi::url('backend://civicrm/admin?msg=[hi]&id=[contact]')];
+    $examples[] = ['query', 'a=123&b=456', Civi::url('backend://civicrm/admin?a=[1]&b=[2]')->addVars([1 => 123, 2 => 456])];
+    $examples[] = ['fragment', '/page?msg=hello+world%3F', Civi::url('backend://civicrm/a/#/page?msg=[hi]')];
+    $examples[] = ['query', 'a=hello+world%3F&b=Au+re%2Fvoir', Civi::url('frontend://civicrm/user?a=[hi]&b=[bye]')->addVars(['bye' => 'Au re/voir'])];
+    $examples[] = ['query', 'some_xyz=123', Civi::url('//civicrm/foo?some_[key]=123')->addVars(['key' => 'xyz'])];
 
     // Unrecognized []'s are preserved as literals, which allows interop with deep form fields
-    $examples[] = ['some[key]=123', Civi::url('//civicrm/foo?some[key]=123')];
+    $examples[] = ['query', 'some[key]=123', Civi::url('//civicrm/foo?some[key]=123')];
 
     foreach ($examples as $key => $example) {
       /** @var \Civi\Core\Url $url */
-      [$expected, $url] = $example;
+      [$field, $expected, $url] = $example;
       $url->addVars($vars);
-      $this->assertStringContainsString($expected, (string) $url, sprintf("%s at %d should be have matching output", __FUNCTION__, $key));
+      $this->assertUrlComponentContains($field, $expected, $url, sprintf('%s at %d: ', __FUNCTION__, $key));
     }
   }
 
   public function testFunkyStartPoints(): void {
     $baseline = (string) \Civi::url('frontend://civicrm/event/info?id=1');
-    $this->assertStringContainsString('event/info', $baseline);
+    $this->assertUrlComponentContains('path', 'civicrm/event/info', $baseline);
 
     $alternatives = [
       // Start with nothing!
@@ -226,6 +226,16 @@ class UrlFacadeTest extends \CiviEndToEndTestCase {
     $this->assertEquals('https://example.com/dirty.jsp?q=foo', Civi::url('custom://foo')->__toString());
     $this->assertEquals('https://example.com/dirty.jsp?q=foo%2Fbar&x=1', Civi::url('custom://foo/bar?x=1')->__toString());
     $this->assertEquals('https://example.com/dirty.jsp?q=foo%2Fbar#whiz', Civi::url('custom://foo/bar#whiz')->__toString());
+  }
+
+  protected function assertUrlComponentContains($expectField, $expectValue, string $renderedUrl, string $message = ''): void {
+    $parsedUrl = parse_url($renderedUrl);
+    // if ($expectField === 'path' && !\CRM_Utils_Constant::value('CIVICRM_CLEANURL')) {
+    if ($expectField === 'path' && CIVICRM_UF === 'WordPress' && !str_contains($parsedUrl['path'], $expectValue)) {
+      $expectField = 'query';
+      $expectValue = \CRM_Core_Config::singleton()->userFrameworkURLVar . '=' . urlencode($expectValue);
+    }
+    $this->assertStringContainsString($expectValue, $parsedUrl[$expectField], $message . sprintf("Field \"%s\" should be have matching output. (Full URL: %s)", $expectField, $renderedUrl));
   }
 
 }

--- a/tests/phpunit/E2E/Extern/CliRunnerTest.php
+++ b/tests/phpunit/E2E/Extern/CliRunnerTest.php
@@ -132,12 +132,12 @@ class E2E_Extern_CliRunnerTest extends CiviEndToEndTestCase {
 
     $cv = $GLOBALS['_CV'];
     $this->assertEquals($cv['CIVI_CORE'], $this->callRunnerJson($r, '$GLOBALS[\'civicrm_root\']'));
-    $this->assertEquals($cv['CMS_URL'] . 'foo', $this->callRunnerJson($r, 'Civi::paths()->getUrl(\'[cms.root]/foo\')'));
+    $this->assertEquals($cv['CMS_URL'] . 'foo', $this->callRunnerJson($r, 'Civi::paths()->getUrl(\'[cms.root]/foo\', \'absolute\')'));
     $this->assertEquals($cv['CMS_ROOT'] . 'foo', $this->callRunnerJson($r, 'Civi::paths()->getPath(\'[cms.root]/foo\')'));
     $this->assertEquals($cv['CIVI_CORE'] . 'css/civicrm.css', $this->callRunnerJson($r, 'Civi::paths()->getPath(\'[civicrm.root]/css/civicrm.css\')'));
 
     $ufrUrl = $this->callRunnerJson($r, 'CRM_Core_Config::singleton()->userFrameworkResourceURL');
-    $crmUrl = $this->callRunnerJson($r, 'Civi::paths()->getUrl("[civicrm.root]/.")');
+    $crmUrl = $this->callRunnerJson($r, 'Civi::paths()->getUrl("[civicrm.root]/.", "absolute")');
     $this->assertEquals(rtrim($crmUrl, '/'), rtrim($ufrUrl, '/'));
   }
 
@@ -157,7 +157,7 @@ class E2E_Extern_CliRunnerTest extends CiviEndToEndTestCase {
   public function testPathUrlMatch($name, $r, $fileExpr) {
     $this->assertNotEmpty($this->findCommand($name), 'The command "$name" does not appear in the PATH.');
     $localPath = $this->callRunnerJson($r, "Civi::paths()->getPath('$fileExpr')");
-    $remoteUrl = $this->callRunnerJson($r, "Civi::paths()->getUrl('$fileExpr')");
+    $remoteUrl = $this->callRunnerJson($r, "Civi::paths()->getUrl('$fileExpr', 'absolute')");
     $this->assertFileExists($localPath);
     $localContent = file_get_contents($localPath);
     $this->assertNotEmpty($localContent);

--- a/tests/phpunit/E2E/Extern/WidgetTest.php
+++ b/tests/phpunit/E2E/Extern/WidgetTest.php
@@ -28,7 +28,7 @@ class E2E_Extern_WidgetTest extends CiviEndToEndTestCase {
   public function testWidget(): void {
     if (!in_array(CIVICRM_UF, ['Drupal8', 'Standalone'])) {
       // Skip the traditional tests for Drupal8+ and Standalone as these are unsupported.
-      $endpoints['traditional'] = CRM_Core_Resources::singleton()->getUrl('civicrm', 'extern/widget.php');
+      $endpoints['traditional'] = CRM_Utils_System::externUrl('extern/widget');
     }
     $endpoints['normal'] = CRM_Utils_System::url('civicrm/contribute/widget', NULL, TRUE, NULL, FALSE, TRUE);
     foreach ($endpoints as $key => $url) {


### PR DESCRIPTION
Overview
--------

The general aim of the PR is to fix bugs in `Civi::url()`. However, most the patchset is focused on expanding test-coverage for the same. This is somewhat sizable because test-coverage problems relate to the shape of the test-harness (*e.g. see notes about [5394](https://lab.civicrm.org/dev/core/-/issues/5394#example-use-case-1-e2ecorepathurltest)*).

Before+After
------

* Pre-existing test failure
    * _Before_: `E2E_Core_PathUrlTest::testUrl` fails on Backdrop.
    * _After_: Test passes (when combined with https://github.com/civicrm/cv/pull/215)
* Test harness limitations
    * _Before_: The end-to-end tests for `Civi::url()` run in the context of phpunit/cli. But the URL behaviors in  http/web-ui are often *slightly* different (due to variations in ENV/SERVER vars).
    * _After_: The end-to-end tests for `Civi::url()` evaluate in both contexts. We ensure both CLI and web-UI render similar URLs. To do this, the test uses `RemoteTestFunction`. (*In other words, the test writes a small PHP script and asks the web-server to run it.*)
* Absolute URLs
    * _Before_: Requests for `Civi::url()` to render absolute URLs do not always do so. For example, if   you run this on the Backdrop web UI, then it returns a relative URL:

        ```php
        Civi::url('ext://org.civicrm.search_kit/ang/crmSearchAdmin.module.js', 'a'));
        ```

        Deceptively, on some versions of CV/CLI, it does a render proper URL.

    * _After_: That expression returns an absolute URL in both web-UI and CLI (across
      multiple UFs). Tests cover both environments.
* Variable substitution on WordPress
    * _Before_: Path-variables are not encoded correctly (if using un-clean URLs).
    * _After_: Path-variables should be encoded correctly (with clean or unclean URLs)

Comments
--------

This replaces #30234 and goes much further. It addresses https://lab.civicrm.org/dev/core/-/issues/5394. It might contribute toward https://lab.civicrm.org/dev/core/-/issues/5217 (*certainly by improving test-coverage in the general area; possibly by fixing*), but this isn't tested/expected/focus-area.
