### PR TITLE
dev/core#5421 Fix 404 error when posting to google.com//recaptcha/api/siteverify

### DIFF
--- a/ext/recaptcha/lib/recaptcha/recaptchalib.php
+++ b/ext/recaptcha/lib/recaptcha/recaptchalib.php
@@ -67,7 +67,7 @@ function _recaptcha_qsencode ($data) {
 function _recaptcha_http_post($host, $path, $data) {
   $client = new Client();
   try {
-    $response = $client->request('POST', $host . '/' . $path, ['query' => $data, 'timeout' => \Civi::settings()->get('http_timeout')]);
+    $response = $client->request('POST', $host . $path, ['query' => $data, 'timeout' => \Civi::settings()->get('http_timeout')]);
   }
   catch (Exception $e) {
     return '';
@@ -144,7 +144,7 @@ function recaptcha_check_answer ($privkey, $remoteip, $response, $extra_params =
     return $recaptcha_response;
   }
 
-  $validationResponse = _recaptcha_http_post(RECAPTCHA_VERIFY_SERVER, "/recaptcha/api/siteverify",
+  $validationResponse = _recaptcha_http_post(RECAPTCHA_VERIFY_SERVER, '/recaptcha/api/siteverify',
           [
             'secret' => $privkey,
             'remoteip' => $remoteip,


### PR DESCRIPTION
Overview
----------------------------------------
Recaptcha v2 failing validation due to Google returning 404 when POST is sent to the siteverify end point.

This line is the issue - an extra backslash is added to the URL.
`$response = $client->request('POST', $host . '/' . $path`

Which results in the POST URL: https://www.google.com//recaptcha/api/siteverify

**google.com responds with HTTP Response: 404 and recaptcha validation will always fail regardless of the submission**

Can be fixed by changing this line to: `$response = $client->request('POST', $host . $path`

Which changes the POST URL: https://www.google.com/recaptcha/api/siteverify

**google.com responds with HTTP Response: 200 and recaptcha validation is then performed correctly**

Before
----------------------------------------
google.com responds with HTTP Response: 404 and recaptcha validation will always fail regardless of the submission

After
----------------------------------------
google.com responds with HTTP Response: 200 and recaptcha validation is then performed correctly

Technical Details
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5421

Comments
----------------------------------------
This code has not changed for a long time, suspect it's caused by Google being stricter or something else perhaps, Guzzle.

Agileware Ref: CIVICRM-2268