### PR TITLE
Fix a few more smarty:nodefaults to use nofilter

### DIFF
--- a/templates/CRM/Event/Page/ManageEvent.tpl
+++ b/templates/CRM/Event/Page/ManageEvent.tpl
@@ -119,10 +119,10 @@
               </span>
             </div>
             <div class="crm-event-links">
-              {$row.eventlinks|smarty:nodefaults|replace:'xx':$row.id}
+              {$row.eventlinks|replace:'xx':$row.id nofilter}
             </div>
             <div class="crm-event-more">
-              {$row.action|smarty:nodefaults|replace:'xx':$row.id}
+              {$row.action|replace:'xx':$row.id nofilter}
             </div>
           </td>
           <td class="crm-event-start_date hiddenElement">{$row.start_date|crmDate}</td>

--- a/templates/CRM/Event/Page/Tab.tpl
+++ b/templates/CRM/Event/Page/Tab.tpl
@@ -17,8 +17,8 @@
 
     <div class="help">
         <p>{ts 1=$displayName}This page lists all event registrations for %1 since inception.{/ts}
-        {capture assign="link"}class="action-item" href="{$newEventURL|smarty:nodefaults}"{/capture}
-        {if $permission EQ 'edit'}{ts 1=$link|smarty:nodefaults}Click <a %1>Add Event Registration</a> to register this contact for an event.{/ts}{/if}
+        {capture assign="link"}class="action-item" href="{$newEventURL nofilter}"{/capture}
+        {if $permission EQ 'edit'}{ts 1=$link nofilter}Click <a %1>Add Event Registration</a> to register this contact for an event.{/ts}{/if}
         {if $accessContribution and $newCredit}
             {capture assign=newCreditURL}{crmURL p="civicrm/contact/view/participant" q="reset=1&action=add&cid=`$contactId`&context=participant&mode=live"}{/capture}
             {capture assign="link"}class="action-item" href="{$newCreditURL|smarty:nodefaults}"{/capture}

--- a/templates/CRM/UF/Form/Field.tpl
+++ b/templates/CRM/UF/Form/Field.tpl
@@ -17,7 +17,7 @@
   <table class="form-layout-compressed">
     <tr class="crm-uf-field-form-block-field_name">
       <td class="label">{$form.field_name.label} {help id='field_name_0'}</td>
-      <td>{$form.field_name.html|smarty:nodefaults}<br />
+      <td>{$form.field_name.html nofilter}<br />
         <span class="description">&nbsp;{ts}Select the type of CiviCRM record and the field you want to include in this Profile.{/ts}</span></td>
     </tr>
     <tr class="crm-uf-field-form-block-label">
@@ -69,7 +69,7 @@
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>
 
-{$initHideBoxes|smarty:nodefaults}
+{$initHideBoxes nofilter}
 
 {literal}
 <script type="text/javascript">

--- a/templates/CRM/UF/Page/Field.tpl
+++ b/templates/CRM/UF/Page/Field.tpl
@@ -43,7 +43,7 @@
                 <td class="crm-editable crmf-is_searchable" data-type="boolean">{if $row.is_searchable eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
                 <td class="crm-editable crmf-in_selector" data-type="boolean">{if $row.in_selector eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
                 {/if}
-                <td class="nowrap">{$row.weight|smarty:nodefaults}</td>
+                <td class="nowrap">{$row.weight nofilter}</td>
                 <td class="crm-editable crmf-is_required" data-type="boolean">{if $row.is_required eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
                 <td class="crm-editable crmf-is_view" data-type="boolean">{if $row.is_view eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
                 <td>{if $row.is_reserved     eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>

--- a/templates/CRM/common/showHide.tpl
+++ b/templates/CRM/common/showHide.tpl
@@ -9,8 +9,8 @@
 *}
 {* This included tpl hides and displays the appropriate blocks as directed by the php code which assigns showBlocks and hideBlocks arrays. *}
  <script type="text/javascript">
-    var showBlocks = new Array({$showBlocks|smarty:nodefaults});
-    var hideBlocks = new Array({$hideBlocks|smarty:nodefaults});
+    var showBlocks = new Array({$showBlocks nofilter});
+    var hideBlocks = new Array({$hideBlocks nofilter});
 
     on_load_init_blocks( showBlocks, hideBlocks{if $elemType and $elemType EQ 'table-row'}, 'table-row'{/if} );
  </script>


### PR DESCRIPTION
Overview
----------------------------------------
Fix a few more smarty:nodefaults to use nofilter

Before
----------------------------------------
use of Smarty2 style nofilter

After
----------------------------------------
Smarty5 style

Technical Details
----------------------------------------
I've been trying to figure out what is different over & above a find & replace focussing on a couple of screens & it seems to be the placement in these ones

   -          {$row.eventlinks|smarty:nodefaults|replace:'xx':$row.id}
    +          {$row.eventlinks|replace:'xx':$row.id nofilter} 

Other than that I think a basic replace will work

Comments
----------------------------------------
