### PR TITLE
dompdf - Abide by configurable path to "upload" dir

### DIFF
--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -290,7 +290,7 @@ class CRM_Utils_PDF_Utils {
     foreach (['font_dir', 'chroot', 'log_output_file'] as $setting) {
       $value = \Civi::settings()->get("dompdf_$setting");
       if (isset($value)) {
-        $settings[$setting] = $value;
+        $settings[$setting] = Civi::paths()->getPath($value);
       }
     }
 

--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -315,7 +315,7 @@ class CRM_Utils_PDF_Utils {
       $cacheDir = $settings['font_dir'] . DIRECTORY_SEPARATOR . 'font_cache';
     }
     else {
-      $cacheDir = Civi::paths()->getPath('[civicrm.files]/upload/font_cache');
+      $cacheDir = CRM_Core_Config::singleton()->uploadDir . '/font_cache';
     }
     // Try to create dir if it doesn't exist or return empty string
     if ((!is_dir($cacheDir)) && (!mkdir($cacheDir))) {


### PR DESCRIPTION
Overview
-------------

This changes the calculation for the "getCacheDir()".  On most systems, it should behave the same.  However, on some systems (such as Standalone) the "upload" dir has been renamed -- and the old formula pointed to the wrong place.

With this revision, it abides by the local configuration.

(This is an alternative to #31005. ping @demeritcowboy @ufundo)

Before
------

* Various unit-tests involving PDFs fail if they run on Standalone. Ex:
    * `api_v3_JobTest::testMailReportForPdf`
    * `CRM_Activity_Form_Task_PDFTest::testCreateDocumentUnknownTokens`
    * `CRM_Contribute_Form_Task_PDFLetterCommonTest::testGroupedThankYous`
* On Standalone, the default value of `getCacheDir` is invalid.

After
-----

* Those unit-tests pass on Standalone.
* On Standalone, the default value of `getCacheDir` is valid.

Comment
-------

The problem for "Standalone" is that `[civicrm.files]/upload` was renamed to `[civicrm.private]/tmp` (*which is more apropos*), but `getCacheDir()` was hard-coded to the other convention.  This formula should work with either.
