### PR TITLE
SearchKit - Include unconditional style rules in table header

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -74,6 +74,26 @@
         }
       };
 
+      // Get header classes for each column
+      this.getHeaderClass = function (column) {
+        let headerClasses = [];
+        if (ctrl.isSortable(column)) {
+          headerClasses.push('crm-sortable-col');
+        }
+        if (column.alignment) {
+          headerClasses.push(column.alignment);
+        }
+        // Include unconditional css rules
+        if (column.cssRules) {
+          column.cssRules.forEach(function (cssRule) {
+            if (cssRule.length === 1) {
+              headerClasses.push(cssRule[0]);
+            }
+          });
+        }
+        return headerClasses.join(' ');
+      };
+
     }
   });
 

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -12,7 +12,7 @@
         <th ng-class="{'crm-search-result-select': $ctrl.settings.actions}" ng-include="'~/crmSearchDisplayTable/crmSearchDisplayTaskHeader.html'" ng-if=":: $ctrl.hasExtraFirstColumn()">
           <span class="sr-only">{{:: ts('Bulk row actions')}}</span>
         </th>
-        <th ng-repeat="col in $ctrl.settings.columns" ng-click="$ctrl.setSort(col, $event)" class="{{:: $ctrl.isSortable(col) ? 'crm-sortable-col' : ''}} {{:: col.alignment }}" title="{{:: $ctrl.isSortable(col) ? ts('Click to sort results (shift-click to sort by multiple).') : '' }}">
+        <th ng-repeat="col in $ctrl.settings.columns" ng-click="$ctrl.setSort(col, $event)" class="{{:: $ctrl.getHeaderClass(col) }}" title="{{:: $ctrl.isSortable(col) ? ts('Click to sort results (shift-click to sort by multiple).') : '' }}">
           <i ng-if=":: $ctrl.isSortable(col)" class="crm-i crm-search-table-column-sort-icon {{ $ctrl.getSort(col) }}"></i>
           <span class="crm-search-display-table-column-label">{{:: col.label }}</span>
         </th>


### PR DESCRIPTION
Overview
----------------------------------------
Style rules with no conditions attached can be included in the header cell as well as the table body.

Before
----------------------------------------
No css rules were included in the table header. 

After
----------------------------------------
In this example, the 2nd column has an unconditional rule and the 3rd column has a conditional rule:
![image](https://github.com/user-attachments/assets/5d6ed1bb-af4d-43db-bed7-6711862594f6)
