### PR TITLE
Put the extended entity's table in entity_table for EntityFile records for File type Custom Fields

### DIFF
--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -97,7 +97,8 @@ class CRM_Core_BAO_CustomValueTable {
               $entityFileDAO->file_id = $field['file_id'];
               $entityFileDAO->find(TRUE);
 
-              $entityFileDAO->entity_table = $field['table_name'];
+              // some older callers dont pass the entity table here, so we have to fetch it based on the Entity listed in 'extends'
+              $entityFileDAO->entity_table = $field['entity_table'] ?? \Civi\Schema\EntityRepository::getEntity($field['extends'])['table'];
               $entityFileDAO->entity_id = $field['entity_id'];
               $entityFileDAO->file_id = $field['file_id'];
               $entityFileDAO->save();

--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -856,6 +856,7 @@ HEREDOC;
   public static function getEntityTables(): array {
     return [
       'civicrm_activity' => ts('Activity'),
+      'civicrm_contact' => ts('Contact'),
       'civicrm_case' => ts('Case'),
       'civicrm_note' => ts('Note'),
     ];

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2119,38 +2119,12 @@ LIKE %1
     $entity = CRM_Core_DAO_AllCoreTables::getEntityNameForClass(get_class($this));
     $tableName = CRM_Core_DAO_AllCoreTables::getTableForClass(get_class($this));
     // Obtain custom values for the old entity.
-    $customParams = $htmlType = [];
-    $customValues = CRM_Core_BAO_CustomValueTable::getEntityValues($entityID, $entity);
+    $customParams = [];
+    $customValues = CRM_Core_BAO_CustomValueTable::getEntityValues($entityID, $entity) ?: [];
 
     // If custom values present, we copy them
-    if (!empty($customValues)) {
-      // Get Field ID's and identify File type attributes, to handle file copying.
-      $fieldIds = implode(', ', array_keys($customValues));
-      $sql = "SELECT id FROM civicrm_custom_field WHERE html_type = 'File' AND id IN ( {$fieldIds} )";
-      $result = CRM_Core_DAO::executeQuery($sql);
-
-      // Build array of File type fields
-      while ($result->fetch()) {
-        $htmlType[] = $result->id;
-      }
-
-      // Build params array of custom values
-      foreach ($customValues as $field => $value) {
-        if ($value !== NULL) {
-          // Handle File type attributes
-          if (in_array($field, $htmlType)) {
-            $fileValues = CRM_Core_BAO_File::path($value, $entityID);
-            $customParams["custom_{$field}_-1"] = [
-              'name' => CRM_Utils_File::duplicate($fileValues[0]),
-              'type' => $fileValues[1],
-            ];
-          }
-          // Handle other types
-          else {
-            $customParams["custom_{$field}_-1"] = $value;
-          }
-        }
-      }
+    foreach ($customValues as $field => $value) {
+      $customParams["custom_{$field}_-1"] = $value;
 
       // Save Custom Fields for new Entity.
       CRM_Core_BAO_CustomValueTable::postProcess($customParams, $tableName, $newEntityID, $entity, $parentOperation ?? 'create');

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -289,7 +289,7 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
     ]);
 
     // Create two files to attach to the new case
-    $filepath = Civi::paths()->getPath('[civicrm.files]/custom');
+    $filepath = Civi::paths()->getPath(\CRM_Core_Config::singleton()->customFileUploadDir);
 
     CRM_Utils_File::createFakeFile($filepath, 'Bananas do not bend themselves without a little help.', 'i_bend_bananas.txt');
     $fileA = $this->callAPISuccess('File', 'create', ['uri' => "$filepath/i_bend_bananas.txt"]);

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -311,7 +311,7 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
 
     $entityFiles = new CRM_Core_DAO_EntityFile();
     $entityFiles->entity_id = $newCase[0];
-    $entityFiles->entity_table = $customGroup['table_name'];
+    $entityFiles->entity_table = 'civicrm_case';
     $entityFiles->find();
 
     $totalEntityFiles = 0;

--- a/tests/phpunit/api/v4/Custom/CustomFileTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomFileTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Custom;
+
+use Civi\Api4\Contact;
+use Civi\Api4\CustomField;
+use Civi\Api4\CustomGroup;
+use Civi\Api4\File;
+use Civi\Api4\EntityFile;
+
+/**
+ * @group headless
+ */
+class CustomFileTest extends CustomTestBase {
+
+  public function testCustomFileField(): void {
+    $customGroup = CustomGroup::create(FALSE)
+      ->addValue('title', 'FilingCabinet')
+      ->addValue('extends', 'Individual')
+      ->execute()
+      ->single();
+
+    CustomField::create(FALSE)
+      ->addValue('label', 'Passport')
+      ->addValue('custom_group_id', $customGroup['id'])
+      ->addValue('data_type', 'File')
+      ->addValue('html_type', 'File')
+      ->execute();
+
+    CustomField::create(FALSE)
+      ->addValue('label', 'Permit')
+      ->addValue('custom_group_id', $customGroup['id'])
+      ->addValue('data_type', 'File')
+      ->addValue('html_type', 'File')
+      ->execute();
+
+    // file path for custom file uploads
+    $filepath = \Civi::paths()->getPath(\CRM_Core_Config::singleton()->customFileUploadDir);
+
+    \CRM_Utils_File::createFakeFile($filepath, 'Name: Franz. Birthplace: Prague', 'passport.txt');
+    $passport = File::create(FALSE)
+      ->addValue('uri', "$filepath/passport.txt")
+      ->execute()
+      ->single();
+
+    $franz = Contact::save(FALSE)
+      ->addRecord([
+        'first_name' => 'Franz',
+        'last_name' => 'Kafka',
+        'contact_type' => 'Individual',
+        'FilingCabinet.Passport' => $passport['id'],
+      ])
+      ->execute()
+      ->single();
+
+    \CRM_Utils_File::createFakeFile($filepath, 'Name: Franz. Work permit', 'permit.txt');
+    $permit = File::create(FALSE)
+      ->addValue('uri', "$filepath/permit.txt")
+      ->execute()
+      ->single();
+
+    Contact::update(FALSE)
+      ->addWhere('id', '=', $franz['id'])
+      ->addValue('FilingCabinet.Permit', $permit['id'])
+      ->execute();
+
+    // check the fields on the contact work
+    $contactGet = Contact::get(FALSE)
+      ->addWhere('id', '=', $franz['id'])
+      ->addSelect('FilingCabinet.Passport')
+      ->addSelect('FilingCabinet.Permit')
+      ->execute()
+      ->single();
+
+    $this->assertEquals($passport['id'], $contactGet['FilingCabinet.Passport']);
+    $this->assertEquals($permit['id'], $contactGet['FilingCabinet.Permit']);
+
+    $entityFileRecords = EntityFile::get(FALSE)
+      ->addWhere('entity_table', '=', 'civicrm_contact')
+      ->addWhere('entity_id', '=', $franz['id'])
+      ->execute();
+
+    $this->assertEquals($entityFileRecords->count(), 2);
+
+    // get the file info
+    // note: entity join is required to get hashed url
+    $fileInfo = File::get(FALSE)
+      ->addSelect('file_name', 'url')
+      ->addWhere('id', '=', $passport['id'])
+      ->addJoin('Contact', 'LEFT', 'EntityFile')
+      ->execute()
+      ->single();
+
+    // url contains a checksum
+    $this->assertStringContainsString('&fcs=', $fileInfo['url']);
+    $this->assertEquals($fileInfo['file_name'], 'passport.txt');
+
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Update EntityFile behaviour, to pave the way for https://github.com/civicrm/civicrm-core/pull/30241

Before
----------------------------------------
- the EntityFile record for a file saved to a custom field has the parent entity id in `entity_id`, but has the custom value table name in `entity_table`
- joins to EntityFile don't work for Custom Fields

After
----------------------------------------
- the EntityFile record for a file saved to a custom field has the parent entity id in `entity_id`, and the corresponding table this id refers to `entity_table`
- joins to EntityFile work as expected for file custom fields, which enables e.g. linking uploaded files in Afforms https://github.com/civicrm/civicrm-core/pull/30241

Technical Details
----------------------------------------
This behaviour goes back to the beginning of time, and I fear there may be some weird workarounds out there in the world. One in `CRM_Core_DAO::copyCustomFields` got flagged by a case test.
