### PR TITLE
Ensure CKEditor config screen loads with Smarty 5

### DIFF
--- a/ext/ckeditor4/templates/CRM/Ckeditor4/Form/CKEditorConfig.tpl
+++ b/ext/ckeditor4/templates/CRM/Ckeditor4/Form/CKEditorConfig.tpl
@@ -66,7 +66,7 @@
       <label for="skin">{ts}Skin{/ts}</label>
       <select id="skin" name="config_skin" class="crm-select2 eight config-param">
         {foreach from=$skins item='s'}
-          <option value="{$s}" {if $s == $skin}selected{/if}>{$s|ucfirst}</option>
+          <option value="{$s}" {if $s == $skin}selected{/if}>{$s|capitalize}</option>
         {/foreach}
       </select>
       &nbsp;&nbsp;


### PR DESCRIPTION
Overview
----------------------------------------
Ensure CKEditor config screen loads with Smarty 5

Before
----------------------------------------
Fatal crash (easily replicable by going to https://dmaster.demo.civicrm.org/civicrm/admin/ckeditor?reset=1)

<img width="1440" alt="Screenshot 2024-08-30 at 21 51 52" src="https://github.com/user-attachments/assets/3cf9fd54-7e39-47ea-81c0-cd7b46034e0f">


After
----------------------------------------
Page loads as expected
