### PR TITLE
Use old, unused, code on advanced setting form (Profiles)

### DIFF
--- a/CRM/UF/Form/AdvanceSetting.php
+++ b/CRM/UF/Form/AdvanceSetting.php
@@ -59,13 +59,6 @@ class CRM_UF_Form_AdvanceSetting extends CRM_UF_Form_Group {
     $config = CRM_Core_Config::singleton();
     $form->addElement('advcheckbox', 'is_uf_link', ts('Include %1 user account information links in search results?', [1 => $config->userFramework]));
 
-    // want to create cms user
-    $session = CRM_Core_Session::singleton();
-    $cmsId = FALSE;
-    if ($form->_cId = $session->get('userID')) {
-      $form->_cmsId = TRUE;
-    }
-
     $form->addRadio('is_cms_user', ts('%1 user account registration option?', [1 => $config->userFramework]), [ts('No account create option'), ts('Give option, but not required'), ts('Account creation required')]);
 
     // options for including Proximity Search in the profile search form


### PR DESCRIPTION
Overview
----------------------------------------
Use old, unused, code on advanced setting form (Profiles)

Before
----------------------------------------
When editing the settings for a profile, dynamic property deprecation notices are thrown (PHP 8.2+):

<img width="1282" alt="Screenshot 2024-08-31 at 17 24 21" src="https://github.com/user-attachments/assets/532ccd6e-6f9e-45d9-baf0-bd2a4fdb0118">

After
----------------------------------------
The code which is using these dynamic properties is removed, therefore the deprecation notices they no longer occur.

Technical Details
----------------------------------------
An alternative, perhaps safer, option would have been to keep the code in place, and instead define the properties. However, I'm almost certain this code is not used:

1. No commit have changed code referencing `_cmsId` since the import from SVN 12 years ago (as per `git log -S _cmsId`)
2. The code doesn't really make sense - it feels like it was probably initially designed for when the form is submitted, rather than a configuration screen
3. `$form` in this case refers to `CRM_UF_Form_Group`, which appears to never have `_cId` set (I've looked though all the parent classes, traits etc and see no reference to `_cId`)

So in conclusion, I think this code removal is safe.