### PR TITLE
SearchKit: Allow selecting arbitary results page

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/Pager.html
+++ b/ext/search_kit/ang/crmSearchDisplay/Pager.html
@@ -12,6 +12,7 @@
         ng-change="$ctrl.getResultsPronto()"
         items-per-page="$ctrl.limit"
         max-size="6"
+        num-pages="$ctrl.numPages"
         force-ellipses="true"
         previous-text="&lsaquo;"
         next-text="&rsaquo;"
@@ -25,6 +26,12 @@
         {{:: ts('Page Size') }}
       </label>
       <input class="form-control" id="crm-search-results-page-size" type="number" ng-model="$ctrl.limit" min="10" step="10">
+    </div>
+    <div class="form-inline text-right" ng-if="$ctrl.rowCount > $ctrl.limit">
+      <label for="crm-search-results-page-number" >
+        {{:: ts('Page') }}
+      </label>
+      <input class="form-control" id="crm-search-results-page-number" type="number" ng-model="$ctrl.page" ng-change="$ctrl.getResultsPronto()"> of {{ $ctrl.numPages }}
     </div>
   </div>
 </div>

--- a/ext/search_kit/css/crmSearchDisplay.css
+++ b/ext/search_kit/css/crmSearchDisplay.css
@@ -16,7 +16,8 @@
   border-color: #8a1f11;
 }
 
-#bootstrap-theme #crm-search-results-page-size {
+#bootstrap-theme #crm-search-results-page-size,
+#bootstrap-theme #crm-search-results-page-number {
   width: 60px;
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5428
Legacy search methods allow you to specify going directly to a particular page of search results.  SearchKit does not.

Before
----------------------------------------
Going to page 50 of 100 is a chore.

After
----------------------------------------
This:
![Selection_021](https://github.com/user-attachments/assets/7db6f3c7-6706-4da5-b4f4-cd6695ddafb6)

Comments
----------------------------------------
I'm not very good at CSS, so follow-up PRs to improve the layout are welcome.