### PR TITLE
SearchKit - Improve appearance and usability of pager

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/Pager.html
+++ b/ext/search_kit/ang/crmSearchDisplay/Pager.html
@@ -6,17 +6,15 @@
   <div ng-if="!$ctrl.settings.pager.hide_single || ($ctrl.rowCount > $ctrl.limit)" class="text-center crm-flex-2">
     <ul uib-pagination
         class="pagination"
-        boundary-links="true"
+        boundary-link-numbers="true"
         total-items="$ctrl.rowCount"
         ng-model="$ctrl.page"
         ng-change="$ctrl.getResultsPronto()"
         items-per-page="$ctrl.limit"
-        max-size="6"
+        max-size="5"
         force-ellipses="true"
-        previous-text="&lsaquo;"
-        next-text="&rsaquo;"
-        first-text="&laquo;"
-        last-text="&raquo;"
+        previous-text="⬅"
+        next-text="⮕"
     ></ul>
   </div>
   <div>


### PR DESCRIPTION
Overview
----------------------------------------
Tweak pager settings. Makes it easier to see the number of pages, and clearer how to skip forward.

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/6cf553d4-f55a-4447-ac5f-58c231578d91)



After
----------------------------------------
![image](https://github.com/user-attachments/assets/4dea0717-c167-42d1-8366-31631f37e042)

