### PR TITLE
FormBuilder: afform date field required attribute

### DIFF
--- a/ext/afform/core/ang/af/fields/Date.html
+++ b/ext/afform/core/ang/af/fields/Date.html
@@ -1,4 +1,4 @@
-<input ng-if=":: !$ctrl.defn.search_range" class="form-control" crm-ui-datepicker=":: $ctrl.defn.input_attrs" id="{{:: fieldId }}" ng-model="getSetValue" ng-model-options="{getterSetter: true}" title="{{:: ts('Search Range')}}" />
+<input ng-if=":: !$ctrl.defn.search_range" class="form-control" ng-required="$ctrl.defn.required" crm-ui-datepicker=":: $ctrl.defn.input_attrs" id="{{:: fieldId }}" ng-model="getSetValue" ng-model-options="{getterSetter: true}" title="{{:: ts('Search Range')}}" />
 <div ng-if=":: $ctrl.defn.search_range" class="form-inline">
   <input class="form-control" ng-required="$ctrl.defn.required" crm-ui-datepicker=":: $ctrl.inputAttrs[1]" id="{{:: fieldId }}1" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]['>=']"/>
   <span class="af-field-range-sep">-</span>


### PR DESCRIPTION
Overview
----------------------------------------
It seems that `ng-required="$ctrl.defn.required"` was missed in the main date input element for afform Date field.

Before
----------------------------------------
Afform date field did not have required attribute.

After
----------------------------------------
Added afform date field required attribute.

Technical Details (Steps to replicate)
----------------------------------------
1. Make a submission form in form builder.
2. Use Individual entity.
3. We can use basic inputs such as first name, last name, birth date, and gender.
4. Make them all required.
5. When filling the fields in its page, leave out birth date. 
6. It will still submit even if birth date is a required field in afform settings.

Comments
----------------------------------------
CiviCRM: 5.75.1 - 5.76.2
WordPress: 6.6.1
App: Fresh Install (to replicate in clean application)

Question
-----------------------------------------
How should validation error be handled so it can be put in the form or a popup or anything else to identify what was wrong? Just asking for suggestions. Thanks.
Edit: Assuming there is the afform validation hook. But just asking how it could be handled in frontend as well.
