### PR TITLE
dev/core#5422 Fix no full message showing up for logged in registered users

### DIFF
--- a/CRM/Event/Form/Registration/ParticipantConfirm.php
+++ b/CRM/Event/Form/Registration/ParticipantConfirm.php
@@ -199,6 +199,8 @@ class CRM_Event_Form_Registration_ParticipantConfirm extends CRM_Event_Form_Regi
 
       $this->postProcessHook();
       CRM_Core_Session::setStatus($statusMessage);
+      // The noFullMsg here is about suppressing the event full message as the person
+      // is potentially just being bounced to that screen.
       CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/event/info',
           "reset=1&id={$this->_eventId}&noFullMsg=1",
           FALSE, NULL, FALSE, TRUE

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -984,6 +984,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
             }
             $status .= ' ' . ts('You can also <a href="%1">register another participant</a>.', [1 => $registerUrl]);
             CRM_Core_Session::singleton()->setStatus($status, '', 'alert');
+            // @todo - pass cid=0 in the url & remove noFullMsg here.
             $url = CRM_Utils_System::url('civicrm/event/info',
               "reset=1&id={$form->_values['event']['id']}&noFullMsg=true"
             );

--- a/CRM/Event/Form/SelfSvcUpdate.php
+++ b/CRM/Event/Form/SelfSvcUpdate.php
@@ -317,6 +317,8 @@ class CRM_Event_Form_SelfSvcUpdate extends CRM_Core_Form {
     if (!empty($this->isBackoffice)) {
       return;
     }
+    // The noFullMsg here is about suppressing the event full message as the person
+    // is potentially just being bounced to that screen.
     $url = CRM_Utils_System::url('civicrm/event/info', "reset=1&id={$this->_event_id}&noFullMsg=true");
     CRM_Utils_System::redirect($url);
   }

--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -49,9 +49,6 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
     $this->assign('iCal', CRM_Event_BAO_Event::getICalLinks($this->_id));
     $this->assign('isShowICalIconsInline', TRUE);
 
-    // Sometimes we want to suppress the Event Full msg
-    $noFullMsg = CRM_Utils_Request::retrieve('noFullMsg', 'String', $this, FALSE, 'false');
-
     //retrieve event information
     $params = ['id' => $this->_id];
     $values = ['event' => NULL];
@@ -271,17 +268,25 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
     $this->assign('registerClosed', !empty($values['event']['is_online_registration']) && !$isEventOpenForRegistration && CRM_Core_Permission::check('register for events'));
     $this->assign('allowRegistration', $allowRegistration);
 
-    $session = CRM_Core_Session::singleton();
-    $params = [
-      'contact_id' => $session->get('userID'),
-      'event_id' => $values['event']['id'] ?? NULL,
-      'role_id' => $values['event']['default_role_id'] ?? NULL,
-    ];
-
-    if (($this->isEventFull() && $noFullMsg === 'false') || CRM_Event_BAO_Event::checkRegistration($params)) {
-      $statusMessage = $this->getEventValue('event_full_text');
-      if (CRM_Event_BAO_Event::checkRegistration($params)) {
-        if ($noFullMsg == 'false') {
+    $isAlreadyRegistered = $this->isAlreadyRegistered();
+    // noFullMsg was originally passed in to suppress the message about the event being full. The intent
+    // was originally such that when you were sending the user back to the info page after registering
+    // they would not be told it was full. Along the way it got overloaded to encompass
+    // the scenario where the user is potentially trying to register another user & hence became very confusing.
+    // We could probably make this make more sense by
+    // 1) always passing cid in the url if the person is being redirected to register another person
+    // and using that rather than the logged in use to check for existing registrations
+    // 2) using a more positive 'you are registered' message rather than making it
+    // sound like a mistake.
+    // 3) using the normal button to pass cid=0 information rather than a link.
+    $noFullMsg = CRM_Utils_Request::retrieve('noFullMsg', 'String', $this, FALSE, 'false');
+    $isSuppressEventFullMessage = $noFullMsg !== 'false';
+    $statusMessage = ($this->isEventFull() && !$isSuppressEventFullMessage && !$isAlreadyRegistered) ? $this->getEventValue('event_full_text') : '';
+    if (($this->isEventFull() && $noFullMsg === 'false') || $isAlreadyRegistered) {
+      if ($isAlreadyRegistered) {
+        // @todo - this usage of `$isSuppressEventFullMessage` is where the historical mis-use makes it
+        // confusing - better use of cid in the url would help.
+        if (!$isSuppressEventFullMessage) {
           if ($values['event']['allow_same_participant_emails']) {
             $statusMessage = ts('It looks like you are already registered for this event.  You may proceed if you want to create an additional registration.');
           }
@@ -375,6 +380,21 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
       return (int) CRM_Price_BAO_PriceSet::getFor('civicrm_event', $this->getEventID());
     }
     return NULL;
+  }
+
+  /**
+   * @return bool
+   * @throws \CRM_Core_Exception
+   */
+  public function isAlreadyRegistered(): bool {
+    $params = [
+      // @todo - instead of just checking logged in user check for cid=0 or an integer
+      // in the url. (For zero there should be no check).
+      'contact_id' => CRM_Core_Session::getLoggedInContactID(),
+      'event_id' => $this->getEventID(),
+      'role_id' => $this->getEventValue('default_role_id'),
+    ];
+    return CRM_Event_BAO_Event::checkRegistration($params);
   }
 
 }

--- a/Civi/Test/PageTrait.php
+++ b/Civi/Test/PageTrait.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Test;
+
+use Civi\Civi\Test\PageWrapper;
+
+/**
+ * Trait for writing tests interacting with QuickForm Pages.
+ */
+trait PageTrait {
+  /**
+   * @var \Civi\Civi\Test\PageWrapper
+   */
+  private PageWrapper $page;
+
+  public function getTestPage(string $pageName, array $urlParameters = []): PageWrapper {
+    $this->page = new PageWrapper($pageName, $urlParameters);
+    return $this->page;
+  }
+
+  /**
+   * Assert that the status set does not contain the given string..
+   *
+   * @param string $string
+   */
+  protected function assertOutputNotContainsString(string $string): void {
+    $this->assertStringNotContainsString($string, $this->page->getOutput());
+  }
+
+}

--- a/Civi/Test/PageWrapper.php
+++ b/Civi/Test/PageWrapper.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Civi\Test;
+
+use Civi\Api4\Utils\ReflectionUtils;
+
+class PageWrapper {
+
+  /**
+   * @var \CRM_Core_Page
+   */
+  private \CRM_Core_Page $page;
+
+  private array $statusMessage;
+
+  /**
+   * @var false|string
+   */
+  private string $output;
+
+  /**
+   * @param string $class
+   * @param array $urlParameters
+   */
+  public function __construct(string $class, array $urlParameters = []) {
+    $_GET = $urlParameters;
+    $this->page = new $class();
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+    $_REQUEST = array_merge($_REQUEST, $urlParameters);
+  }
+
+  public function run(): void {
+    ob_start();
+    $this->page->run();
+    $this->output = ob_get_clean();
+  }
+
+  public function getOutput(): string {
+    return $this->output;
+  }
+
+}

--- a/Civi/Test/PageWrapper.php
+++ b/Civi/Test/PageWrapper.php
@@ -11,8 +11,6 @@
 
 namespace Civi\Civi\Test;
 
-use Civi\Api4\Utils\ReflectionUtils;
-
 class PageWrapper {
 
   /**

--- a/Civi/Test/PageWrapper.php
+++ b/Civi/Test/PageWrapper.php
@@ -37,6 +37,10 @@ class PageWrapper {
   }
 
   public function run(): void {
+    // Ensure the system checks do not run in this context.
+    // The `checkAngularModuleSettings()` check is specifically likely
+    // to cause crashes but also there are other tests for the checks.
+    \CRM_Core_Session::singleton()->timer('check_CRM_Utils_Check', 86400);
     ob_start();
     $this->page->run();
     $this->output = ob_get_clean();

--- a/tests/phpunit/CRM/Event/Form/ManageEvent/EventInfoTest.php
+++ b/tests/phpunit/CRM/Event/Form/ManageEvent/EventInfoTest.php
@@ -7,7 +7,7 @@ class CRM_Event_Form_ManageEvent_EventInfoTest extends CiviUnitTestCase {
    *
    * @return array
    */
-  private function getCorrectFormFields() {
+  private function getCorrectFormFields(): array {
     return [
       'title' => 'A test event',
       'event_type_id' => 1,
@@ -50,7 +50,8 @@ class CRM_Event_Form_ManageEvent_EventInfoTest extends CiviUnitTestCase {
   }
 
   /**
-   * dataprovider to test both regular events and event templates
+   * Data Provider to test both regular events and event templates.
+   *
    * @return array
    */
   public function isTemplateProvider(): array {

--- a/tests/phpunit/CRM/Event/Page/EventInfoTest.php
+++ b/tests/phpunit/CRM/Event/Page/EventInfoTest.php
@@ -5,7 +5,6 @@ use Civi\Test\EventTestTrait;
 class CRM_Event_Page_EventInfoTest extends CiviUnitTestCase {
   use EventTestTrait;
 
-
   public function tearDown(): void {
     $this->quickCleanUpFinancialEntities();
     parent::tearDown();

--- a/tests/phpunit/CRM/Event/Page/EventInfoTest.php
+++ b/tests/phpunit/CRM/Event/Page/EventInfoTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Civi\Test\EventTestTrait;
+
+class CRM_Event_Page_EventInfoTest extends CiviUnitTestCase {
+  use EventTestTrait;
+
+
+  public function tearDown(): void {
+    $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
+  }
+
+  public function testFullMessage(): void {
+    $this->eventCreateUnpaid(['max_participants' => 1]);
+    $this->createTestEntity('Participant', [
+      'event_id' => $this->getEventID(),
+      'contact_id' => $this->createLoggedInUser(),
+    ]);
+    $page = $this->getTestPage('CRM_Event_Page_EventInfo', [
+      'id' => $this->getEventID(),
+      'contact_id' => $this->getLoggedInUser(),
+      'noFullMsg' => TRUE,
+    ]);
+    $page->run();
+    $this->assertOutputNotContainsString('Sorry! We are already full');
+  }
+
+}

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -55,6 +55,7 @@ use Civi\Test\FormTrait;
 use Civi\Test\GenericAssertionsTrait;
 use Civi\Test\LocaleTestTrait;
 use Civi\Test\MailingTestTrait;
+use Civi\Test\PageTrait;
 use League\Csv\Reader;
 
 /**
@@ -91,6 +92,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   use MailingTestTrait;
   use LocaleTestTrait;
   use FormTrait;
+  use PageTrait;
 
   /**
    * API version in use.
@@ -2146,7 +2148,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * @return int|null
    */
   public function getLoggedInUser(): ?int {
-    return CRM_Core_Session::singleton()->get('userID') ?: NULL;
+    return CRM_Core_Session::getLoggedInContactID();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5422 Fix no full message showing up for logged in registered users

Before
----------------------------------------
A logged in user who returns to the event info page will see the event full message - regardless of whether it is full

After
----------------------------------------
The logged in user should not see the event full message - although if the url does not have `&noFullMsg=true` in it they should see 

![image](https://github.com/user-attachments/assets/09346a0b-607d-4c0d-8873-bb485fbf1caa)

Technical Details
----------------------------------------
This appears to have regressed around the end of last year/ beginning of this - recent enough to target the rc but I don't think a port to stable is required right before the rc goes stable. However, as it was right before the rc is cut I added a lot of code comments point towards my thoughts about the 'right  fix' (stop overloading the `noFullMsg` url parameter for the `cid=0` / register someone else scenario

Comments
----------------------------------------
