### PR TITLE
Afform - Fix autofill-current-user

### DIFF
--- a/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
+++ b/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
@@ -102,8 +102,8 @@ class ContactAutofill extends AbstractBehavior implements EventSubscriberInterfa
       $id = $event->getEntityId();
       $autoFillMode = $entity['autofill'] ?? '';
       $relatedContact = $entity['autofill-relationship'] ?? NULL;
-      // Autofill with current user, but only if this is an "entire form" prefill (no entity-specific args)
-      if (!$id && $autoFillMode === 'user' && !$event->getApiRequest()->getArgs()) {
+      // Autofill with current user, but only if this is an "entire form" prefill
+      if (!$id && $autoFillMode === 'user' && $event->getApiRequest()->getFillMode() === 'form') {
         $id = \CRM_Core_Session::getLoggedInContactID();
         if ($id) {
           $event->getApiRequest()->loadEntity($entity, [['id' => $id]]);

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -54,16 +54,19 @@
           params.args[selectedEntity] = {};
           params.args[selectedEntity][selectedIndex] = {};
           if (joinEntity) {
+            params.fillMode = 'join';
             params.args[selectedEntity][selectedIndex].joins = {};
             params.args[selectedEntity][selectedIndex].joins[joinEntity] = {};
             params.args[selectedEntity][selectedIndex].joins[joinEntity][joinIndex] = {};
             params.args[selectedEntity][selectedIndex].joins[joinEntity][joinIndex][selectedField] = selectedId;
           } else {
+            params.fillMode = 'entity';
             params.args[selectedEntity][selectedIndex][selectedField] = selectedId;
           }
         }
         // Prefill entire form
         else {
+          params.fillMode = 'form';
           args = _.assign({}, $scope.$parent.routeParams || {}, $scope.$parent.options || {});
           _.each(schema, function (entity, entityName) {
             if (args[entityName] && typeof args[entityName] === 'string') {

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformContactUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformContactUsageTest.php
@@ -92,6 +92,9 @@ EOHTML;
     // Autofill form with current user. See `Civi\Afform\Behavior\ContactAutofill`
     $prefill = Afform::prefill()
       ->setName($this->formName)
+      ->setFillMode('form')
+      // This should be ignored and not mess up the prefill
+      ->setArgs(['dummy_distraction' => ['id' => 1]])
       ->execute()
       ->indexBy('name');
     $this->assertEquals('Logged In', $prefill['me']['values'][0]['fields']['first_name']);
@@ -238,6 +241,7 @@ EOHTML;
     try {
       Afform::prefill()
         ->setName($this->formName)
+        ->setFillMode('form')
         ->setArgs([])
         ->execute()
         ->indexBy('name');
@@ -552,7 +556,10 @@ EOHTML;
       ->execute();
 
     // Autofilling form works because limit hasn't been reached
-    Afform::prefill()->setName($this->formName)->execute();
+    Afform::prefill()
+      ->setName($this->formName)
+      ->setFillMode('form')
+      ->execute();
 
     // Last time
     Afform::submit()
@@ -571,7 +578,10 @@ EOHTML;
 
     // Prefilling and submitting are no longer allowed.
     try {
-      Afform::prefill()->setName($this->formName)->execute();
+      Afform::prefill()
+        ->setName($this->formName)
+        ->setFillMode('entity')
+        ->execute();
       $this->fail();
     }
     catch (\Civi\API\Exception\UnauthorizedException $e) {

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformEventUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformEventUsageTest.php
@@ -55,6 +55,7 @@ EOHTML;
     // Prefill from template
     $prefill = Afform::prefill()
       ->setName($this->formName)
+      ->setFillMode('entity')
       ->setArgs(['Event1' => [['template_id' => $eventTemplate['id']]]])
       ->execute()->single();
     $this->assertSame('Test Me', $prefill['values'][0]['fields']['title']);
@@ -67,6 +68,7 @@ EOHTML;
     // Prefill just the locBlock
     $prefill = Afform::prefill()
       ->setName($this->formName)
+      ->setFillMode('join')
       ->setArgs(['Event1' => [['joins' => ['LocBlock' => [['id' => $locBlock2['id']]]]]]])
       ->execute()->single();
     $this->assertSame('2@te.st', $prefill['values'][0]['joins']['LocBlock'][0]['email_id.email']);

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformGroupSubscriptionUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformGroupSubscriptionUsageTest.php
@@ -80,6 +80,7 @@ EOHTML;
     // Prefill - afform will show group checkbox checked
     $prefill = Afform::prefill()
       ->setName($this->formName)
+      ->setFillMode('form')
       ->setArgs(['Individual1' => $cid])
       ->execute()
       ->indexBy('name');

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformPrefillUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformPrefillUsageTest.php
@@ -60,6 +60,7 @@ EOHTML;
 
     $prefill = Afform::prefill()
       ->setName($this->formName)
+      ->setFillMode('entity')
       ->setArgs(['Individual1' => $cid])
       ->execute()
       ->indexBy('name');
@@ -87,6 +88,7 @@ EOHTML;
     // Prefill a specific contact for the af-repeat entity
     $prefill = Afform::prefill()
       ->setName($this->formName)
+      ->setFillMode('entity')
       ->setArgs(['Individual1' => [1 => $cid[3]]])
       ->execute()
       ->indexBy('name');
@@ -99,6 +101,7 @@ EOHTML;
     // Form entity has `max="3"` so a forth contact (index 3) is out-of-bounds
     $prefill = Afform::prefill()
       ->setName($this->formName)
+      ->setFillMode('entity')
       ->setArgs(['Individual1' => [3 => $cid[0]]])
       ->execute();
     $this->assertTrue(empty($prefill['Individual1']['values']));
@@ -155,6 +158,7 @@ EOHTML;
 
     $prefill = Afform::prefill()
       ->setName($this->formName)
+      ->setFillMode('entity')
       ->setArgs(['Individual1' => $cid])
       ->execute()
       ->indexBy('name');
@@ -226,6 +230,7 @@ EOHTML;
 
     $prefill = Afform::prefill()
       ->setName($this->formName)
+      ->setFillMode('form')
       ->execute()
       ->indexBy('name');
 
@@ -284,6 +289,7 @@ EOHTML;
 
     $prefill = Afform::prefill()
       ->setName($this->formName)
+      ->setFillMode('entity')
       ->setArgs(['Individual1' => $cid])
       ->execute()
       ->indexBy('name');

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformRelationshipUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformRelationshipUsageTest.php
@@ -187,6 +187,7 @@ EOHTML;
 
     $prefill = Afform::prefill(FALSE)
       ->setName($this->formName)
+      ->setFillMode('entity')
       ->setArgs(['Organization1' => $contact[3]])
       ->execute()
       ->indexBy('name');


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug in autofill-current-user, where any argument in the url would break the functionality.

Before
----------------------------------------
1. Create a form with at least one Individual, "Autofill: Current User"
2. Visit the form and put any argument in the url like `/civicrm/my-form#?foo=bar`
3. Autofill doesn't work

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
So this reinstates a param that I've been waffling on. It was added in 12308f3 then deleted in e2c263c but it turns out to be useful in this context, and also helps optimize the loading of joins, so let's keep it.