### PR TITLE
dev/core#5407 - Multiselect custom field can't be blanked out

### DIFF
--- a/CRM/Custom/Form/CustomDataTrait.php
+++ b/CRM/Custom/Form/CustomDataTrait.php
@@ -126,7 +126,7 @@ trait CRM_Custom_Form_CustomDataTrait {
       // We can handle those here - although is that enough to handle blanking on
       // multiple field radios?
       $field = CRM_Core_BAO_CustomField::getField($id);
-      if ($field['html_type'] === 'Radio') {
+      if ($field['html_type'] === 'Radio' || $field['html_type'] === 'Select') {
         $group = CRM_Core_BAO_CustomGroup::getGroup(['id' => $field['custom_group_id']]);
         if (!$group['is_multiple']) {
           $instances[] = 'custom_' . $id;


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5407

Before
----------------------------------------
1. Create a custom field for _contributions_ of type integer that is widget type select and allow multiple (the field not the group). Yes it's pretty specific.
2. Create a contribution and pick one or more values for the field and save.
3. Edit it and try to remove all the values in the field and save.
4. Look at it and note the values are still there.

After
----------------------------------------


Technical Details
----------------------------------------
This is an unusual function so as per comments in the lab just doing a minimal fix that seems safe.

Comments
----------------------------------------

