### PR TITLE
dev/core#5320 [REF] Respond with a 400 for Event Registration and Info pages to reduce log overload from bots

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -14,6 +14,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use GuzzleHttp\Psr7\Response;
+
 /**
  * This class generates form components for processing Event.
  */
@@ -56,7 +58,14 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    */
   public function getEventID(): int {
     if (!$this->_eventId) {
-      $this->_eventId = (int) CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
+      try {
+        $this->_eventId = (int) CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
+      }
+      catch (CRM_Core_Exception $e) {
+        CRM_Utils_System::sendResponse(
+          new Response(400, [], ts('Missing Event ID'))
+        );
+      }
       // this is the first time we are hitting this, so check for permissions here
       if (!CRM_Core_Permission::event(CRM_Core_Permission::EDIT, $this->_eventId, 'register for events')) {
         CRM_Core_Error::statusBounce(ts('You do not have permission to register for this event'), $this->getInfoPageUrl());

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -14,8 +14,6 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-use GuzzleHttp\Psr7\Response;
-
 /**
  * This class generates form components for processing Event.
  */
@@ -62,9 +60,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
         $this->_eventId = (int) CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
       }
       catch (CRM_Core_Exception $e) {
-        CRM_Utils_System::sendResponse(
-          new Response(400, [], ts('Missing Event ID'))
-        );
+        CRM_Utils_System::sendInvalidRequestResponse(ts('Missing Event ID'));
       }
       // this is the first time we are hitting this, so check for permissions here
       if (!CRM_Core_Permission::event(CRM_Core_Permission::EDIT, $this->_eventId, 'register for events')) {

--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -15,6 +15,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use GuzzleHttp\Psr7\Response;
+
 /**
  * Event Info Page - Summary about the event
  */
@@ -342,7 +344,14 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
    */
   public function getEventID(): int {
     if (!isset($this->_id)) {
-      $id = CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
+      try {
+        $id = CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
+      }
+      catch (CRM_Core_Exception $e) {
+        CRM_Utils_System::sendResponse(
+          new Response(400, [], ts('Missing Event ID'))
+        );
+      }
       $this->_id = $id;
     }
     return (int) $this->_id;

--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -15,8 +15,6 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-use GuzzleHttp\Psr7\Response;
-
 /**
  * Event Info Page - Summary about the event
  */
@@ -348,9 +346,7 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
         $id = CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
       }
       catch (CRM_Core_Exception $e) {
-        CRM_Utils_System::sendResponse(
-          new Response(400, [], ts('Missing Event ID'))
-        );
+        CRM_Utils_System::sendInvalidRequestResponse(ts('Missing Event ID'));
       }
       $this->_id = $id;
     }

--- a/CRM/Event/StateMachine/Registration.php
+++ b/CRM/Event/StateMachine/Registration.php
@@ -9,8 +9,6 @@
  +--------------------------------------------------------------------+
  */
 
-use GuzzleHttp\Psr7\Response;
-
 /**
  * State machine for managing different states of the EventWizard process.
  */
@@ -30,9 +28,7 @@ class CRM_Event_StateMachine_Registration extends CRM_Core_StateMachine {
       $id = CRM_Utils_Request::retrieve('id', 'Positive', $controller, TRUE);
     }
     catch (CRM_Core_Exception $e) {
-      CRM_Utils_System::sendResponse(
-        new Response(400, [], ts('Missing Event ID'))
-      );
+      CRM_Utils_System::sendInvalidRequestResponse(ts('Missing Event ID'));
     }
     $is_monetary = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $id, 'is_monetary');
     $is_confirm_enabled = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $id, 'is_confirm_enabled');

--- a/CRM/Event/StateMachine/Registration.php
+++ b/CRM/Event/StateMachine/Registration.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use GuzzleHttp\Psr7\Response;
+
 /**
  * State machine for managing different states of the EventWizard process.
  */
@@ -24,7 +26,14 @@ class CRM_Event_StateMachine_Registration extends CRM_Core_StateMachine {
    */
   public function __construct($controller, $action = CRM_Core_Action::NONE) {
     parent::__construct($controller, $action);
-    $id = CRM_Utils_Request::retrieve('id', 'Positive', $controller, TRUE);
+    try {
+      $id = CRM_Utils_Request::retrieve('id', 'Positive', $controller, TRUE);
+    }
+    catch (CRM_Core_Exception $e) {
+      CRM_Utils_System::sendResponse(
+        new Response(400, [], ts('Missing Event ID'))
+      );
+    }
     $is_monetary = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $id, 'is_monetary');
     $is_confirm_enabled = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $id, 'is_confirm_enabled');
 

--- a/CRM/Mailing/Form/Optout.php
+++ b/CRM/Mailing/Form/Optout.php
@@ -50,17 +50,13 @@ class CRM_Mailing_Form_Optout extends CRM_Core_Form {
     $this->_hash = $hash = CRM_Utils_Request::retrieve('h', 'String', $this);
 
     if (!$job_id || !$queue_id || !$hash) {
-      CRM_Utils_System::sendResponse(
-        new \GuzzleHttp\Psr7\Response(400, [], ts("Invalid request: missing parameters"))
-      );
+      CRM_Utils_System::sendInvalidRequestResponse(ts("Invalid request: missing parameters"));
     }
 
     // verify that the three numbers above match
     $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
     if (!$q) {
-      CRM_Utils_System::sendResponse(
-        new \GuzzleHttp\Psr7\Response(400, [], ts("Invalid request: bad parameters"))
-      );
+      CRM_Utils_System::sendInvalidRequestResponse(ts("Invalid request: bad parameters"));
     }
 
     [$displayName, $email] = CRM_Mailing_Event_BAO_MailingEventQueue::getContactInfo($queue_id);

--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -51,17 +51,13 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
     $isConfirm = CRM_Utils_Request::retrieveValue('confirm', 'Boolean', FALSE, FALSE, 'GET');
 
     if (!$job_id || !$queue_id || !$hash) {
-      CRM_Utils_System::sendResponse(
-        new \GuzzleHttp\Psr7\Response(400, [], ts("Invalid request: missing parameters"))
-      );
+      CRM_Utils_System::sendInvalidRequestResponse(ts("Invalid request: missing parameters"));
     }
 
     // verify that the three numbers above match
     $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
     if (!$q) {
-      CRM_Utils_System::sendResponse(
-        new \GuzzleHttp\Psr7\Response(400, [], ts("Invalid request: bad parameters"))
-      );
+      CRM_Utils_System::sendInvalidRequestResponse(ts("Invalid request: bad parameters"));
     }
 
     [$displayName, $email] = CRM_Mailing_Event_BAO_MailingEventQueue::getContactInfo($queue_id);

--- a/CRM/Mailing/Page/Open.php
+++ b/CRM/Mailing/Page/Open.php
@@ -36,9 +36,7 @@ class CRM_Mailing_Page_Open extends CRM_Core_Page {
       $queue_id = CRM_Utils_Request::retrieveValue('q', 'Positive', NULL, FALSE, 'GET');
     }
     if (!$queue_id) {
-      CRM_Utils_System::sendResponse(
-        new \GuzzleHttp\Psr7\Response(400, [], ts("Missing input parameters"))
-      );
+      CRM_Utils_System::sendInvalidRequestResponse(ts("Missing input parameters"));
     }
 
     CRM_Mailing_Event_BAO_MailingEventOpened::open($queue_id);

--- a/CRM/Mailing/Page/Unsubscribe.php
+++ b/CRM/Mailing/Page/Unsubscribe.php
@@ -50,9 +50,7 @@ class CRM_Mailing_Page_Unsubscribe extends CRM_Core_Page {
 
     $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queueId, $hash);
     if (!$q) {
-      CRM_Utils_System::sendResponse(
-        new \GuzzleHttp\Psr7\Response(400, [], ts("Invalid request: bad parameters"))
-      );
+      CRM_Utils_System::sendInvalidRequestResponse(ts("Invalid request: bad parameters"));
     }
 
     $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing($jobId, $queueId, $hash);
@@ -60,9 +58,7 @@ class CRM_Mailing_Page_Unsubscribe extends CRM_Core_Page {
       CRM_Mailing_Event_BAO_MailingEventUnsubscribe::send_unsub_response($queueId, $groups, FALSE, $jobId);
     }
 
-    CRM_Utils_System::sendResponse(
-      new \GuzzleHttp\Psr7\Response(200, [], 'OK')
-    );
+    CRM_Utils_System::sendOkRequestResponse();
   }
 
 }

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -15,6 +15,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use GuzzleHttp\Psr7\Response;
+
 /**
  * System wide utilities.
  *
@@ -1962,6 +1964,19 @@ class CRM_Utils_System {
    */
   public static function prePostRedirect() {
     CRM_Core_Config::singleton()->userSystem->prePostRedirect();
+  }
+
+  /**
+   * Send an Invalid Request response
+   *
+   * @param string $responseMessage Response Message
+   */
+  public static function sendInvalidRequestResponse(string $responseMessage): void {
+    self::sendResponse(new Response(400, [], $responseMessage));
+  }
+
+  public static function sendOkRequestResponse(string $message = 'OK'): void {
+    self::sendResponse(new Response(200, [], $message));
   }
 
 }


### PR DESCRIPTION
…ation and Event Info pages when id param doesn't exist or has a non int value

Overview
----------------------------------------
This modifies the return to be instead of a CRM_Core_Exception/500 being returned a 400 error is returned instead because the parameter is invalid

Before
----------------------------------------
500 fatal error is returned if a parameter of like `id=x` is passed to the Event info or manage Event page

After
----------------------------------------
400 error is returned instead

