### PR TITLE
fix using REGEXP with contact ID

### DIFF
--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -126,7 +126,8 @@ class FormattingUtil {
     }
 
     // Special handling for 'current_user' and user lookups
-    if ($fk === 'Contact' && isset($value) && !is_numeric($value)) {
+    $exactMatch = [NULL, '=', '!=', '<>', 'IN', 'NOT IN'];
+    if ($fk === 'Contact' && isset($value) && !is_numeric($value) && in_array($operator, $exactMatch, TRUE)) {
       $value = \_civicrm_api3_resolve_contactID($value);
       if ('unknown-user' === $value) {
         throw new \CRM_Core_Exception("\"{$fieldSpec['name']}\" \"{$value}\" cannot be resolved to a contact ID", 2002, ['error_field' => $fieldSpec['name'], "type" => "integer"]);

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -318,6 +318,13 @@ class ContactGetTest extends Api4TestBase implements TransactionalInterface {
     $this->assertArrayHasKey($meg['id'], (array) $result);
     $this->assertArrayHasKey($jess['id'], (array) $result);
     $this->assertArrayHasKey($amy['id'], (array) $result);
+
+    // Check that punctuation in REGEXP isn't munged away.
+    $findByIDs = '^(' . $jane['id'] . '|' . $meg['id'] . '|' . $jess['id'] . '|' . $amy['id'] . ')$';
+    $result = Contact::get(FALSE)
+      ->addWhere('id', 'REGEXP', $findByIDs)
+      ->execute();
+    $this->assertCount(4, $result);
   }
 
   public function testGetRelatedWithSubType(): void {


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5431

It's not currently possible to use a REGEXP search on contact IDs.

Before
----------------------------------------
The query below returns all contacts.  That `REGEXP` is `^[1|2|3|4|5]$`.
![Selection_023](https://github.com/user-attachments/assets/dcba8c51-2753-4fea-a1ca-45ec85506b37)


After
----------------------------------------
The query only returns contact IDs corresponding to the `REGEXP`.

Technical Details
----------------------------------------
The "current user" or "username:user" handling picked up all non-numeric values for contact IDs and returned `NULL` if they weren't matching one of the special cases.