### PR TITLE
dev/core#5432 Fix missing delete message on options form

### DIFF
--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -114,7 +114,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
 
     $session->pushUserContext(CRM_Utils_System::url($url, $params));
     $this->assign('id', $this->_id);
-    $this->setDeleteMessage(ts('WARNING: Deleting this option will result in the loss of all %1 related records which use the option.', [1 => $this->_gLabel]) . ts('This may mean the loss of a substantial amount of data, and the action cannot be undone.') . ts('Do you want to continue?'));
+    $this->setDeleteMessage();
     if ($this->_id && CRM_Core_OptionGroup::isDomainOptionGroup($this->_gName)) {
       $domainID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionValue', $this->_id, 'domain_id', 'id');
       if (CRM_Core_Config::domainID() != $domainID) {
@@ -131,6 +131,13 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
         'option_group_id' => $this->_gid,
       ]));
     }
+  }
+
+  /**
+   * Get the form-specific delete message.
+   */
+  public function setDeleteMessage(): void {
+    $this->deleteMessage = ts('WARNING: Deleting this option will result in the loss of all %1 related records which use the option.', [1 => $this->_gLabel]) . ts('This may mean the loss of a substantial amount of data, and the action cannot be undone.') . ts('Do you want to continue?');
   }
 
   /**

--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -137,7 +137,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
    * Get the form-specific delete message.
    */
   public function setDeleteMessage(): void {
-    $this->deleteMessage = ts('WARNING: Deleting this option will result in the loss of all %1 related records which use the option.', [1 => $this->_gLabel]) . ts('This may mean the loss of a substantial amount of data, and the action cannot be undone.') . ts('Do you want to continue?');
+    $this->deleteMessage = ts('WARNING: Deleting this option will result in the loss of all %1 related records which use the option.', [1 => $this->_gLabel]) . ' ' . ts('This may mean the loss of a substantial amount of data, and the action cannot be undone.') . ' ' . ts('Do you want to continue?');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5432 Fix missing delete message on options form

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/a3c09574-c813-45ff-86ff-49c0d5db3c29)

After
----------------------------------------
![image](https://github.com/user-attachments/assets/1ebc045c-39b1-42cd-b31d-6dd304778ceb)

Technical Details
----------------------------------------
As @braders pointed out this regressed in https://github.com/civicrm/civicrm-core/pull/29930 - which was included in 5.74

Comments
----------------------------------------
