### PR TITLE
Fatal Errors - Fix display of error icon (FontAwesome 6)

### DIFF
--- a/templates/CRM/common/fatal.tpl
+++ b/templates/CRM/common/fatal.tpl
@@ -19,7 +19,7 @@
   <style type="text/css" media="screen">
     @import url({$config->resourceBase}css/civicrm.css);
     @import url({$config->resourceBase}css/crm-i.css);
-    @import url({$config->resourceBase}bower_components/font-awesome/css/font-awesome.min.css);
+    @import url({$config->resourceBase}bower_components/font-awesome/css/all.min.css);
   </style>
 </head>
 <body>
@@ -29,7 +29,7 @@
   <style type="text/css" media="screen">
     @import url({$config->resourceBase}css/civicrm.css);
     @import url({$config->resourceBase}css/crm-i.css);
-    @import url({$config->resourceBase}bower_components/font-awesome/css/font-awesome.min.css);
+    @import url({$config->resourceBase}bower_components/font-awesome/css/all.min.css);
   </style>
 {/if}
 <div class="messages status no-popup">  <i class="crm-i fa-exclamation-triangle crm-i-red" aria-hidden="true"></i>


### PR DESCRIPTION
Overview
------------

Fix missing icons when displaying a "fatal error" page.

Follow-up to 5.77.alpha's https://github.com/civicrm/civicrm-core/pull/30779 (cc @ufundo @herbdool)

Before
---------

No alert icon. Instead, browser console HTTP error.

> ![Screenshot from 2024-09-04 00-25-08](https://github.com/user-attachments/assets/b8a33a9f-365f-4848-8231-7faf7ca2cc15)

After
------

Well... the page still crashed (*it is an error page...*)... But at least the alert icon works! :smile: 

> ![Screenshot from 2024-09-04 00-22-03](https://github.com/user-attachments/assets/aeeda153-dd2b-4bc9-9535-9c5fbd634cc7)


Comments
-------------

The fix is for 5.77-rc. We'll need to make sure to merge-forward to master.