### PR TITLE
(dev/core#4267) Afform - Simplify registration of scanner service. Fix inconsistency.

### DIFF
--- a/ext/afform/core/CRM/Afform/AfformScanner.php
+++ b/ext/afform/core/CRM/Afform/AfformScanner.php
@@ -7,8 +7,10 @@
  * named `*.aff.*`. Each item is interpreted as a form instance.
  *
  * To reduce file-scanning, we keep a cache of file paths.
+ *
+ * @service afform_scanner
  */
-class CRM_Afform_AfformScanner {
+class CRM_Afform_AfformScanner extends \Civi\Core\Service\AutoService {
 
   const METADATA_JSON = 'aff.json';
 

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -25,17 +25,6 @@ function _afform_fields_filter($params) {
 }
 
 /**
- * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
- */
-function afform_civicrm_container($container) {
-  $container->addResource(new \Symfony\Component\Config\Resource\FileResource(__FILE__));
-  $container->setDefinition('afform_scanner', new \Symfony\Component\DependencyInjection\Definition(
-    'CRM_Afform_AfformScanner',
-    []
-  ))->setPublic(TRUE);
-}
-
-/**
  * Implements hook_civicrm_config().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config


### PR DESCRIPTION
Overview
---------

This is a twofer. For one, it simplifies code (removes boilerplate).

Additionally, it fixes a highly reproducible variation of the error `You have requested a non-existent service "afform_scanner"` (cc @eileenmcnaughton). It was observed while adding support for user-sync to the installer.

Use-Case
-------

* Update the installer to call `CRM_Utils_System::synchronizeUsers()`. (*There will be a separate PR to update the installer.*)

* Run the installer on Civi-Backdrop. 

* When it gets to this step, it tries to create `Contact`s and fill-in some computed fields (*like greetings*) -- which eventually leads to requests for services like `civi.afform.tokens` and `afform_scanner`.

Before
------

(1) The service `afform_scanner` is registered in an older way (`hook_civicrm_container`).

(2) The use-case fails with error:

`You have requested a non-existent service "afform_scanner".`

In exploring the backtrace for this exception, we find an oddity:

* The service `civi.afform.tokens` has been instantiated.
* It's trying to access the sibling service `afform_scanner`.
* But the second service is unknown/undeclared.

Both services are defined by `ext/afform/core/`. Why is one valid while the other invalid?

Part of the answer is that they have been declared in different ways.

* `civi.afform.tokens` declared via `@service`
* `afform_scanner` declared via `hook_civicrm_container`

(*Note: There's some great tracing for this kind of error by @demeritcowboy  on https://lab.civicrm.org/dev/core/-/issues/4267 which focuses on the internals of hook-dispatching. It may be that this edge-case is one where  `hook_civicrm_container` isn't dispatching in the expected way.*)

After
-----

(1) The service `afform_scanner` is registered in a newer way (`@service`) which is prettier. 

(2) The two services (`civi.afform.tokens` and `afform_scanner`) use the same registration method.  It's much harder to create edge-cases where they're mismatched (*one loaded, one missing*).

