### PR TITLE
(dev/core#5434) Installer - Automatically synchronize contacts<=>users

### DIFF
--- a/setup/plugins/blocks/sync-users.civi-setup.php
+++ b/setup/plugins/blocks/sync-users.civi-setup.php
@@ -1,0 +1,37 @@
+<?php
+if (!defined('CIVI_SETUP')) {
+  exit("Installation plugins must only be loaded by the installer.\n");
+}
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setup.init', function (\Civi\Setup\Event\InitEvent $e) {
+    \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'init'));
+
+    if (!$e->getModel()->syncUsers) {
+      $e->getModel()->syncUsers = TRUE;
+    }
+
+  }, \Civi\Setup::PRIORITY_START);
+
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setupui.boot', function (\Civi\Setup\UI\Event\UIBootEvent $e) {
+    \Civi\Setup::log()->info(sprintf('[%s] Register blocks', basename(__FILE__)));
+
+    /**
+     * @var \Civi\Setup\UI\SetupController $ctrl
+     */
+    $ctrl = $e->getCtrl();
+
+    $ctrl->blocks['sync-users'] = array(
+      'is_active' => ($e->getModel()->cms !== 'Standalone'),
+      'file' => __DIR__ . DIRECTORY_SEPARATOR . 'sync-users.tpl.php',
+      'class' => 'if-no-errors',
+      'weight' => 55,
+    );
+
+    if ($e->getMethod() === 'POST') {
+      $e->getModel()->syncUsers = !empty($e->getField('syncUsers'));
+    }
+
+  }, \Civi\Setup::PRIORITY_PREPARE);

--- a/setup/plugins/blocks/sync-users.tpl.php
+++ b/setup/plugins/blocks/sync-users.tpl.php
@@ -1,0 +1,17 @@
+<?php if (!defined('CIVI_SETUP')): exit("Installation plugins must only be loaded by the installer.\n");
+endif; ?>
+
+<h2><?php echo ts('Users'); ?></h2>
+
+<p>
+  <label for="syncUsers"><span>Synchronize all existing users:</span><input id="syncUsers" type="checkbox" name="civisetup[syncUsers]" value=1 <?php echo $model->syncUsers ? "checked='checked'" : ""; ?> /></label> <br />
+  <span class="advancedTip">
+  <?php $cmsTitle = ($model->cms === 'Drupal8') ? 'Drupal' : $model->cms; ?>
+  <?php echo ts("To help manage communication preferences, each <em>%1 User record</em> should be internally linked to a <em>CiviCRM Contact record</em>.", [1 => $cmsTitle]); ?><br />
+  </span>
+</p>
+
+<p class="tip">
+  <strong><?php echo ts('Tip'); ?></strong>:
+  <?php echo ts('You may skip this and run synchronization at any time in the future.'); ?>
+</p>

--- a/setup/plugins/installDatabase/SyncUsers.civi-setup.php
+++ b/setup/plugins/installDatabase/SyncUsers.civi-setup.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @file
+ *
+ * When CiviCRM is colocated with a CMS, we may synchronize users<=>contacts.
+ */
+
+if (!defined('CIVI_SETUP')) {
+  exit("Installation plugins must only be loaded by the installer.\n");
+}
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setup.installDatabase', function (\Civi\Setup\Event\InstallDatabaseEvent $e) {
+    if ($e->getModel()->cms === 'Standalone' || !$e->getModel()->syncUsers) {
+      return;
+    }
+
+    \Civi\Setup::log()->info(sprintf('[%s] Synchronize CMS users', basename(__FILE__)));
+    CRM_Utils_System::synchronizeUsers();
+  }, \Civi\Setup::PRIORITY_LATE - 60);

--- a/setup/src/Setup/Model.php
+++ b/setup/src/Setup/Model.php
@@ -38,6 +38,8 @@ namespace Civi\Setup;
  * @property string|NULL $lang
  *   The language of the default dataset.
  *   Ex: 'fr_FR'.
+ * @property bool $syncUsers
+ *   Whether to automatically create `Contact` records for each pre-existing CMS `User`
  * @property bool $loadGenerated
  *   UNSUPPORTED: Load example dataset (in lieu of the standard dataset).
  *   This was copied-in from the previous installer code, but it should probably be
@@ -133,6 +135,11 @@ class Model {
     $this->addField(array(
       'description' => 'Load example data',
       'name' => 'loadGenerated',
+      'type' => 'bool',
+    ));
+    $this->addField(array(
+      'description' => 'Load users',
+      'name' => 'syncUsers',
       'type' => 'bool',
     ));
     $this->addField(array(


### PR DESCRIPTION
Overview
----------------------------------------

Simplify installation process -- and reduce test-failures -- by implementing https://lab.civicrm.org/dev/core/-/issues/5434

(*~~Depends on #31045 which is currently included with the PR~~ - Merged*)

Before
------
    
* The "Installation Guide" tells the site-builder to manually synchronize users.
* Some civibuild configurations explicitly add a step to synchronize users - but others neglect to. This leads to some surprising E2E test failures.
    * (Esp: `ManageGroupsTest` emits `"@user:admin" cannot be resolved to a contact ID`... on `backdrop-clean` and `drupal10-dev`... because the `admin` user wasn't sync'd.)

After
-----
    
* By default, the installer will automatically call `synchronizeUsers()`.
* For web-based installation, there's a description of this action - and an option to opt-out.
 
    ![Screenshot from 2024-09-04 02-15-54](https://github.com/user-attachments/assets/76577c1d-7ee4-426a-9680-d2cac74e443a)


* For CLI-based installation, you can opt-out with the extra argument:
    
    ```
    cv core:install -m syncUsers=0
    ```

* After this goes out, we can simplify "Installation Guide" (et al).