### PR TITLE
Tell me which entity when silently ignoring it on form submission

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -352,7 +352,7 @@ class Submit extends AbstractProcessor {
       catch (\CRM_Core_Exception $e) {
         // What to do here? Sometimes we should silently ignore errors, e.g. an optional entity
         // intentionally left blank. Other times it's a real error the user should know about.
-        \Civi::log('afform')->debug("Silently ignoring exception in Afform processGenericEntity call: " . $e->getMessage());
+        \Civi::log('afform')->debug('Silently ignoring exception in Afform processGenericEntity call for "' . $event->getEntityName() . '". Message: ' . $e->getMessage());
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Slightly more helpful "silent" exception message when a parameter is missing on form submission.

Before
----------------------------------------
Guess which entity actually has a missing parameter:

`Silently ignoring exception in Afform processGenericEntity call: One of parameters (value: user_contact_id) is not of the type Integer`

After
----------------------------------------
Don't need to guess anymore:

`Silently ignoring exception in Afform processGenericEntity call for "Individual1". Message: One of parameters (value: user_contact_id) is not of the type Integer`

Technical Details
----------------------------------------
Just adds the entity name into the message since we already have it available in the function.

Comments
----------------------------------------

