### PR TITLE
API4: Abstract resolveContactID and ensure that formatCustomField receives a valid contact ID

### DIFF
--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -118,6 +118,9 @@ trait DAOActionTrait {
 
     foreach ($items as &$item) {
       $entityId = $item[$idField] ?? NULL;
+      if (CoreUtil::isContact($this->getEntityName())) {
+        $entityId = FormattingUtil::resolveContactID($idField, $entityId);
+      }
       FormattingUtil::formatWriteParams($item, $this->entityFields());
       $this->formatCustomParams($item, $entityId);
 
@@ -264,13 +267,8 @@ trait DAOActionTrait {
 
       // Match contact id to strings like "user_contact_id"
       // FIXME handle arrays for multi-value contact reference fields, etc.
-      if (in_array($field['data_type'], ['ContactReference', 'EntityReference']) && is_string($value) && !is_numeric($value)) {
-        // FIXME decouple from v3 API
-        require_once 'api/v3/utils.php';
-        $value = \_civicrm_api3_resolve_contactID($value);
-        if ('unknown-user' === $value) {
-          throw new \CRM_Core_Exception("\"{$field['name']}\" \"{$value}\" cannot be resolved to a contact ID", 2002, ['error_field' => $field['name'], "type" => "integer"]);
-        }
+      if (in_array($field['data_type'], ['ContactReference', 'EntityReference']) && is_string($value)) {
+        $value = FormattingUtil::resolveContactID($field['name'], $value);
       }
 
       \CRM_Core_BAO_CustomField::formatCustomField(


### PR DESCRIPTION
Overview
----------------------------------------
In some situations "user_contact_id" string makes it all the way through to DB query and you get "DB Error: field doesn't exist" error.

Before
----------------------------------------
Crash and custom fields not saved and maybe entity not saved either.

After
----------------------------------------
Saved.

Technical Details
----------------------------------------
Since the changes in https://github.com/civicrm/civicrm-core/pull/29246 "Contact" is not always "Contact". It might also be "Individual", "Organization" etc.

Comments
----------------------------------------
Found this by building a formbuilder with an "Individual" and multi-select checkboxes custom field for that individual.