### PR TITLE
fix for displaying submission data

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -153,14 +153,20 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
    */
   protected function prePopulateSubmissionData() {
     // if submission id is passed then get the data from submission
-    // we should prepopulate only pending submissions
-    $afformSubmissionData = \Civi\Api4\AfformSubmission::get(FALSE)
+    $afformSubmissionData = \Civi\Api4\AfformSubmission::get(TRUE)
       ->addSelect('data')
       ->addWhere('id', '=', $this->args['sid'])
       ->addWhere('afform_name', '=', $this->name)
       ->execute()->first();
 
-    $this->_entityValues = array_intersect_key($this->_formDataModel->getEntities(), $afformSubmissionData['data'] ?? []);
+    $this->_entityValues = $this->_formDataModel->getEntities();
+    foreach ($this->_entityValues as $entity => &$values) {
+      foreach ($afformSubmissionData['data'] as $e => $submission) {
+        if ($entity === $e) {
+          $values = $submission ?? [];
+        }
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
FB submission data is not displayed

Before
----------------------------------------
![Screenshot from 2024-09-04 14-46-56](https://github.com/user-attachments/assets/232b9242-919b-4413-a5da-1fc739a2d350)


After
----------------------------------------
![Screenshot from 2024-09-04 14-46-43](https://github.com/user-attachments/assets/50118184-b0f0-4edc-9002-80e21548a5ae)