### PR TITLE
dev/core#5435 Strip hex char before template assign

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -714,7 +714,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     $this->assign('currencyID', $this->_params['currencyID'] ?? NULL);
     $this->assign('credit_card_type', $this->_params['credit_card_type'] ?? NULL);
     $this->assign('trxn_id', $this->_params['trxn_id'] ?? NULL);
-    $this->assign('amount_level', $this->order->getAmountLevel());
+    $this->assign('amount_level', str_replace(CRM_Core_DAO::VALUE_SEPARATOR, '', $this->order->getAmountLevel()));
     $this->assign('amount', $this->getMainContributionAmount() > 0 ? CRM_Utils_Money::format($this->getMainContributionAmount(), NULL, NULL, TRUE) : NULL);
 
     $isRecurEnabled = isset($this->_values['is_recur']) && !empty($this->_paymentProcessor['is_recur']);


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5435 Strip hex char before template assign

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/e47b8a04-0780-4607-8c91-b544e1b6f3bc)


After
----------------------------------------

![image](https://github.com/user-attachments/assets/91786d41-6971-441a-a25f-a59601a79431)

Technical Details
----------------------------------------
Only affects quick config. This is safe because it only affects what is assigned to the template, not other uses of the order function

Comments
----------------------------------------
