### PR TITLE
dev/core#5437 Use Search Views with QuickSearch-initiated Advanced Search

### DIFF
--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -766,7 +766,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
 
     //get the button name
     $buttonName = $this->controller->getButtonName();
-    $this->_formValues['uf_group_id'] ??= $this->get('uf_group_id');
+    $this->_formValues['uf_group_id'] ??= $this->get('uf_group_id') ?: CRM_Core_Config::singleton()->defaultSearchProfileID;
 
     if (isset($this->_componentMode) && empty($this->_formValues['component_mode'])) {
       $this->_formValues['component_mode'] = $this->_componentMode;


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5437

If you use QuickSearch, but press "Enter" instead of selecting a contact, the QuickSearch is used as the basis for an Advanced Search.
Advanced Searches are supposed to respect the default search profile set in Administer >> Customize Data and Screens >> Search Preferences.
My client assures me that in the past, this worked on QuickSearch-initiated Advanced Searches, but it doesn't at present, and hasn't at least as far back as 5.74.

Before
----------------------------------------
Search preference for default search view isn't respected.

After
----------------------------------------
Default search view is respected.