### PR TITLE
dev/financial#224: Empty tax term on front end donation form

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1338,10 +1338,9 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     if (empty($this->getExistingContributionID())) {
       return;
     }
-    // @todo - all this stuff is likely obsolete.
-    if ($taxAmount = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $this->_ccid, 'tax_amount')) {
-      $this->assign('taxAmount', $taxAmount);
-    }
+
+    $this->assign('taxAmount', $this->getContributionValue('tax_amount'));
+    $this->assign('taxTerm', Civi::settings()->get('tax_term'));
 
     $lineItems = $this->getExistingContributionLineItems();
     $this->assign('lineItem', [$this->getPriceSetID() => $lineItems]);


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate: 
1. Enable Tax and Invoicing
2. Update a existing or add a financial type to have liability financial account with 10% tax
3. Then use the financial type to new or existing membership type say Membership - General ($100)
4. Configure a contribution page with quick-config membership types. 
5. Set contribution page to Pay Later
6. Make a pay later contribution.
7. Go to user dashboard and click `Pay Now` against the pending donation. 

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/75b9f443-c33b-4e38-afce-3e1419790163)


After
----------------------------------------
<img width="1006" alt="Screenshot 2024-09-05 at 09 33 09" src="https://github.com/user-attachments/assets/f5cd54f2-5f75-431d-9079-4b7524c679d7">


Comments
----------------------------------------
ping @eileenmcnaughton @JoeMurray 