### PR TITLE
dev/core#5438 - dedupe help bubble broken on contact import

### DIFF
--- a/templates/CRM/Import/Form/DataSource.tpl
+++ b/templates/CRM/Import/Form/DataSource.tpl
@@ -70,13 +70,13 @@
       {if array_key_exists('onDuplicate', $form)}
         <tr class="crm-import-uploadfile-from-block-onDuplicate">
           <td class="label">{$form.onDuplicate.label}</td>
-          <td>{$form.onDuplicate.html} {help id="dupes"}</td>
+          <td>{$form.onDuplicate.html} {help id="dupes" file="CRM/Contact/Import/Form/DataSource.hlp"}</td>
         </tr>
       {/if}
       {if array_key_exists('dedupe_rule_id', $form)}
         <tr class="crm-import-datasource-form-block-dedupe">
           <td class="label">{$form.dedupe_rule_id.label}</td>
-          <td><span id="contact-dedupe_rule_id">{$form.dedupe_rule_id.html}</span> {help id='id-dedupe_rule'}</td>
+          <td><span id="contact-dedupe_rule_id">{$form.dedupe_rule_id.html}</span> {help id='id-dedupe_rule' file="CRM/Contact/Import/Form/DataSource.hlp"}</td>
         </tr>
       {/if}
       {if array_key_exists('multipleCustomData', $form)}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5438

Before
----------------------------------------
1. Click the bubble. It gives an error about can't find it.

After
----------------------------------------
1. Click the bubble. Text appears.

Technical Details
----------------------------------------
I fixed this same bubble about a year ago so something probably related to smarty changes since then has borked it again.

Comments
----------------------------------------

