### PR TITLE
SearchKit - Show 'label' for autocomplete displays

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayAutocomplete.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayAutocomplete.html
@@ -1,4 +1,7 @@
-
+<div class="form-inline">
+  <label for="crm-search-admin-display-label">{{:: ts('Label') }} <span class="crm-marker">*</span></label>
+  <input id="crm-search-admin-display-label" type="text" class="form-control" ng-model="$ctrl.display.label" required placeholder="{{:: ts('Untitled') }}"/>
+</div>
 <fieldset ng-include="'~/crmSearchAdmin/crmSearchAdminDisplaySort.html'"></fieldset>
 
 <fieldset class="crm-search-admin-edit-columns-wrapper">


### PR DESCRIPTION
Overview
----------------------------------------
Technically, the label of an autocomplete doesn't matter because it won't be shown to end-users (it's not the label of the *field* the autocomplete will be used for). But it's still useful for back-end organization of things. So this exposes it.
