### PR TITLE
(REF) CRM_Core_Invoke - Cleanup old experiment circa Symfony 2

### DIFF
--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -59,31 +59,12 @@ class CRM_Core_Invoke {
       ini_set('display_errors', 0);
     }
 
-    if (!defined('CIVICRM_SYMFONY_PATH')) {
-      // Traditional Civi invocation path
-      // may exit
-      self::hackMenuRebuild($args);
-      self::init($args);
-      Civi::dispatcher()->dispatch('civi.invoke.auth', \Civi\Core\Event\GenericHookEvent::create(['args' => $args]));
-      $item = self::getItem($args);
-      return self::runItem($item);
-    }
-    else {
-      // Symfony-based invocation path
-      require_once CIVICRM_SYMFONY_PATH . '/app/bootstrap.php.cache';
-      require_once CIVICRM_SYMFONY_PATH . '/app/AppKernel.php';
-      $kernel = new AppKernel('dev', TRUE);
-      $kernel->loadClassCache();
-      $response = $kernel->handle(Symfony\Component\HttpFoundation\Request::createFromGlobals());
-      if (preg_match(':^text/html:', $response->headers->get('Content-Type'))) {
-        // let the CMS handle the trappings
-        return $response->getContent();
-      }
-      else {
-        $response->send();
-        exit();
-      }
-    }
+    self::hackMenuRebuild($args);
+    self::init($args);
+    Civi::dispatcher()->dispatch('civi.invoke.auth', \Civi\Core\Event\GenericHookEvent::create(['args' => $args]));
+    $item = self::getItem($args);
+    return self::runItem($item);
+    // NOTE: runItem() may return HTML, or it may call print+exit.
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

The `_invoke()` implementation has an optional code-path that specifically involves Symfony `AppKernel`. This is left-over from an ancient experiment trying to bring Symfony 2 (*full-stack*) into cross-CMS usage. We eventually pivoted to using Symfony Components (*piece-wise*). So this code-path is effectively dead.

Some of the code talks about `Request`/`Response` objects, and IMHO `CRM_Core_Invoke` should have support for these. (*They are pretty standard for modern PHP.*)

However, the S2 `AppKernel` stuff is distracting. Better to remove the dead branch, get a clearer view, and then add live code with `Request`/`Respose` support.
