### PR TITLE
dev/core#3035 Add New Extension: Display all stable extensions (not just reviewed ones)

### DIFF
--- a/CRM/Admin/Page/Extensions.php
+++ b/CRM/Admin/Page/Extensions.php
@@ -91,10 +91,10 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
           'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::DELETE),
         ],
         CRM_Core_Action::UPDATE => [
-          'name' => ts('Download'),
+          'name' => ts('Install'),
           'url' => 'civicrm/admin/extensions',
           'qs' => 'action=update&id=%%id%%&key=%%key%%',
-          'title' => ts('Download Extension'),
+          'title' => ts('Install Extension'),
           'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::UPDATE),
         ],
       ];
@@ -358,10 +358,22 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
       'downloadUrl' => FALSE,
       'compatibility' => FALSE,
       'develStage' => FALSE,
+      'ready' => '',
+      'usage' => '',
       'comments' => FALSE,
+    ];
+    $support = [
+      'alpha' => ts('Alpha'),
+      'beta' => ts('Beta'),
+      'stable' => ts('Stable'),
+      'reviewed' => ts('Reviewed'),
     ];
     $info = array_merge($defaultKeys, $info);
     $info['is_stable'] = $info['develStage'] === 'stable' && !preg_match(";(alpha|beta|dev);", $info['version']);
+    $info['develStage_formatted'] = $support[$info['develStage']] ?? $info['develStage'];
+    if ($info['ready'] == 'ready') {
+      $info['develStage_formatted'] = $support['reviewed'];
+    }
     foreach ($info['authors'] as &$author) {
       $author = array_merge(['homepage' => ''], $author);
     }

--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -21,15 +21,6 @@ use GuzzleHttp\Exception\GuzzleException;
 class CRM_Extension_Browser {
 
   /**
-   * An URL for public extensions repository.
-   *
-   * Note: This default is now handled through setting/*.php.
-   *
-   * @deprecated
-   */
-  const DEFAULT_EXTENSIONS_REPOSITORY = 'https://civicrm.org/extdir/ver={ver}|cms={uf}';
-
-  /**
    * Relative path below remote repository URL for single extensions file.
    */
   const SINGLE_FILE_PATH = '/single';

--- a/CRM/Extension/Info.php
+++ b/CRM/Extension/Info.php
@@ -123,6 +123,18 @@ class CRM_Extension_Info {
   public $develStage;
 
   /**
+   * @var string|null
+   *   Ex: 'ready', 'not_ready'
+   */
+  public $ready;
+
+  /**
+   * @var int|null
+   *   Ex: 1234
+   */
+  public $usage;
+
+  /**
    * Full URL of the zipball for this extension/version.
    *
    * This property is (usually) only provided on the feed of new/available extensions.

--- a/css/admin.css
+++ b/css/admin.css
@@ -51,11 +51,13 @@
   margin-left: 5px;
 }
 
-.crm-container .crm-extensions-stage.fa-flask {
+.crm-container .crm-extensions-stage.fa-flask,
+.crm-container .crm-extensions-stage.fa-warning {
   color: #eba12d;
 }
 
-.crm-container .crm-extensions-stage.fa-check-circle {
+.crm-container .crm-extensions-stage.fa-check-circle,
+.crm-container .crm-extensions-stage.fa-trophy {
   color: #00994d;
 }
 

--- a/templates/CRM/Admin/Page/ExtensionDetails.tpl
+++ b/templates/CRM/Admin/Page/ExtensionDetails.tpl
@@ -1,9 +1,4 @@
 <table class="crm-info-panel">
-    {if $extension.urls}
-        {foreach from=$extension.urls key=label item=url}
-            <tr><td class="label">{$label|escape}</td><td><a href="{$url|escape}">{$url|escape}</a></td></tr>
-        {/foreach}
-    {/if}
     <tr>
         <td class="label">{ts}Author{/ts}</td>
         <td>
@@ -17,25 +12,37 @@
           {/foreach}
         </td>
     </tr>
-    {if $extension.comments}
     <tr>
-      <td class="label">{ts}Comments{/ts}</td><td>{$extension.comments|escape}</td>
+      <td class="label">
+        {ts}Version{/ts}</td><td>{$extension.version|escape}
+        {if $extension.ready == 'ready'}
+          {icon icon="fa-trophy crm-extensions-stage"}{ts}This extension has been reviewed by the community.{/ts}{/icon}
+        {elseif $extension.develStage == 'stable' && $extension.ready == 'not_ready'}
+          {icon icon="fa-warning crm-extensions-stage"}{ts}This extension has not been reviewed by the community. Proceed with caution.{/ts}{/icon}
+        {/if}
+      </td>
+    </tr>
+    {if $extension.develStage}
+    <tr>
+      <td class="label">{ts}Stability{/ts}</td>
+      <td>
+        {if $extension.ready == 'ready'}
+          {ts}This extension has been reviewed by the community.{/ts}
+        {elseif $extension.develStage == 'stable' && $extension.ready == 'not_ready'}
+          <div class="crm-error alert alert-danger">{ts}This extension has not been reviewed by the community.{/ts} {ts}Please proceed with caution.{/ts} {ts}The number of active installs, the date of the latest release and the CiviCRM version compatibility should be good indicators. If a support link is listed below, it should point to the list of known issues.{/ts} {docURL page="dev/extensions/lifecycle"}</div>
+        {else}
+          {$extension.develStage_formatted|escape}
+        {/if}
+      </td>
     </tr>
     {/if}
-    <tr>
-      <td class="label">{ts}Version{/ts}</td><td>{$extension.version|escape}</td>
-    </tr>
     <tr>
       <td class="label">{ts}Released on{/ts}</td><td>{$extension.releaseDate|escape}</td>
     </tr>
     <tr>
-      <td class="label">{ts}License{/ts}</td><td>{$extension.license|escape}</td>
+      <td class="label">{ts}Active Installs{/ts}</td><td>{$extension.usage}</td>
     </tr>
-    {if $extension.develStage}
-    <tr>
-      <td class="label">{ts}Development stage{/ts}</td><td>{$extension.develStage|escape}</td>
-    </tr>
-    {/if}
+    {if !empty($extension.requires)}
     <tr>
         <td class="label">{ts}Requires{/ts}</td>
         <td>
@@ -51,6 +58,7 @@
             {/foreach}
         </td>
     </tr>
+    {/if}
     <tr>
         <td class="label">{ts}Compatible with{/ts}</td>
         <td>
@@ -62,8 +70,18 @@
         </td>
     </tr>
     <tr>
-      <td class="label">{ts}Local path{/ts}</td><td>{if !empty($extension.path)}{$extension.path|escape}{/if}</td>
+      <td class="label">{ts}License{/ts}</td><td>{$extension.license|escape}</td>
     </tr>
+    {if !empty($extension.path)}
+      <tr>
+        <td class="label">{ts}Local path{/ts}</td><td>{$extension.path|escape}</td>
+      </tr>
+    {/if}
+    {if $extension.urls}
+        {foreach from=$extension.urls key=label item=url}
+            <tr><td class="label">{$label|escape}</td><td><a href="{$url|escape}">{$url|escape}</a></td></tr>
+        {/foreach}
+    {/if}
     {if $extension.downloadUrl}
     <tr>
       <td class="label">{ts}Download location{/ts}</td><td>{$extension.downloadUrl|escape}</td>

--- a/templates/CRM/Admin/Page/Extensions/About.tpl
+++ b/templates/CRM/Admin/Page/Extensions/About.tpl
@@ -1,6 +1,6 @@
 <div class="messages help">
     {capture assign='adminURL'}{crmURL p='civicrm/admin/setting/path' q="reset=1&civicrmDestination=$destination"}{/capture}
-    <p>{ts 1=$adminURL 2="https://civicrm.org/extensions"}CiviCRM extensions allow you to install additional features for your site. This page will automatically list the available "native" extensions from the <a href="%2" target="_blank">CiviCRM.org extensions directory</a> which are compatible with this version of CiviCRM. If you install Custom Searches, Reports or Payment Processor extensions - these will automatically be available on the corresponding menus and screens.{/ts}</p>
+    <p>{ts 1=$adminURL 2="https://civicrm.org/extensions"}CiviCRM extensions allow you to install additional features for your site. This page lists the stable and reviewed extensions from the <a href="%2" target="_blank">CiviCRM.org extensions directory</a> which are compatible with this version of CiviCRM.{/ts} {ts}Reviewed extensions have gone through a manual review and met certain criteria in the hope that they are actively maintained and keep working in the future.{/ts} {docURL page="dev/extensions/lifecycle"}</p>
     {if $config->userFramework != "Standalone"}
       {ts 1=$config->userFramework|replace:'6':'' 2="https://civicrm.org/extensions"}<p>You may also want to check the directory for <a href="%2/%1" target="_blank">native %1 modules</a> that may be useful for you (CMS-specific modules are not listed here).{/ts}</p>
     {/if}

--- a/templates/CRM/Admin/Page/Extensions/AddNew.tpl
+++ b/templates/CRM/Admin/Page/Extensions/AddNew.tpl
@@ -9,9 +9,8 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
     <table id="extensions-addnew-table" class="display">
       <thead>
         <tr>
-          <th>{ts}Extension name (key){/ts}</th>
-          <th>{ts}Version{/ts}</th>
-          <th>{ts}Type{/ts}</th>
+          <th>{ts}Extension{/ts}</th>
+          <th id="nosort">{ts}Version{/ts}</th>
           <th></th>
         </tr>
       </thead>
@@ -20,7 +19,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
         {if array_key_exists($extKey, $localExtensionRows)}
           {continue}
         {/if}
-        <tr id="addnew-row_{$row.file}" class="crm-extensions crm-extensions_{$row.file}">
+        <tr id="addnew-row_{$row.file}" class="crm-extensions crm-extensions_{$row.file} {cycle values="odd-row,even-row"}">
           <td class="crm-extensions-label">
             <details class="crm-accordion-light">
               <summary><strong>{$row.label|escape}</strong>
@@ -28,8 +27,13 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
                 {include file="CRM/Admin/Page/ExtensionDetails.tpl" extension=$row}
             </details>
           </td>
-          <td class="crm-extensions-version">{$row.version|escape}</td>
-          <td class="crm-extensions-description">{$row.type|capitalize}</td>
+          <td class="crm-extensions-version right">{$row.version|escape}
+            {if $row.ready == 'ready'}
+              {icon icon="fa-trophy crm-extensions-stage"}{ts}This extension has been reviewed by the community.{/ts}{/icon}
+            {else}
+              {icon icon="fa-warning crm-extensions-stage"}{ts}This extension has not been reviewed by the community. Proceed with caution.{/ts}{/icon}
+            {/if}
+          </td>
           <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}

--- a/templates/CRM/Admin/Page/Extensions/Main.tpl
+++ b/templates/CRM/Admin/Page/Extensions/Main.tpl
@@ -9,7 +9,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
     <table id="extensions" class="display">
       <thead>
         <tr>
-          <th>{ts}Name{/ts}</th>
+          <th>{ts}Extension{/ts}</th>
           <th>{ts}Status{/ts}</th>
           <th>{ts}Version{/ts}</th>
           <th></th>
@@ -30,7 +30,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
             </details>
           </td>
           <td class="crm-extensions-status">{$row.statusLabel} </td>
-          <td class="crm-extensions-version">{$row.version|escape}
+          <td class="crm-extensions-version right">{$row.version|escape}
             {if !$row.is_stable}
               {icon icon="fa-flask crm-extensions-stage"}{ts}This is a pre-release version. For more details, see the expanded description.{/ts}{/icon}
             {else}


### PR DESCRIPTION
Overview
----------------------------------------

Gitlab: https://lab.civicrm.org/dev/core/-/issues/3035

This proposes that, as of CiviCRM 5.79 (master), the in-app Extension Browser (add new) displays all stable extensions, not just the ~~stable~~ reviewed ones.

There are also a few small changes:

- Extensions tab:
  - Renamed the header "Name" to "Extension" (to be the same as on the "Add New" tab)
- Add New tab:
  - Removed "Type" column (was always "module")
  - Added "Stability" column (alpha, beta, stable, reviewed)
  - "Download" action renamed to "Install" ("download" is a technicality, the actual action is "install")
  - Removed jsortable, so that the sort order is more predictable (same as on civicrm.org) - I'm on the fence on this, maybe people want to sort alphabetically if they don't know that their browser has a search function?
- When displaying the details (uncollapse the fieldset)
  - Added row for the number of installs (usage)
  - Re-order a few items in a way that felt more intuitive to me

It also fixes the issue reported in dev/core#3035, which is that non-reviewed extensions did not display that an upgrade was available.

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/991d8267-12c5-4c4a-9395-8b961a7f3991)

After
----------------------------------------

(the visual is a bit different because this is from Standalone, not Drupal7)

![image](https://github.com/user-attachments/assets/7d56a2fb-2ed4-4d10-9d90-46d9e635302b)

and also non-reviewed extensions have upgrade notifications:

![image](https://github.com/user-attachments/assets/dbb96bf3-647c-4e4a-b030-0aba9c47f3ae)

Technical Details
----------------------------------------

I did some changes in the `extdir` module on civicrm.org, so that starting from CiviCRM 5.79, it lists all extensions by default, but does not change the behaviour for older versions of CiviCRM (because they do not display the "reviewed" status, scary messages, etc). Here are the changes, and they are live: https://lab.civicrm.org/marketing/civicrm-website/-/commit/c6ccc013a98ffb385db7d8e714bbe34f5f9e295c

The stability/popularity sorting is done by civicrm.org. Because of how things are stored in XML, it's a bit of a mess to handle client-side.

**Important:** the extdir is significantly slower and can sometimes timeout (more than 10 seconds?). It gets cached by civicrm.org, but still, that will definitely need to be improved.