### PR TITLE
[REF] AuthX - flatten already logged in cases

### DIFF
--- a/ext/authx/Civi/Authx/Authenticator.php
+++ b/ext/authx/Civi/Authx/Authenticator.php
@@ -251,6 +251,33 @@ class Authenticator extends AutoService implements HookInterface {
   }
 
   /**
+   * Check for a pre-existing login
+   *
+   * @param AuthenticatorTarget $tgt
+   * @return bool
+   */
+  protected function checkAlreadyLoggedIn(AuthenticatorTarget $tgt) {
+    if (!\CRM_Core_Session::getLoggedInContactID() && !$this->authxUf->getCurrentUserId()) {
+      return FALSE;
+    }
+
+    if (
+        \CRM_Core_Session::getLoggedInContactID()
+        && $this->authxUf->getCurrentUserId()
+        && ((string) \CRM_Core_Session::getLoggedInContactID() === (string) $tgt->contactId)
+        && ((string) $this->authxUf->getCurrentUserId() === (string) $tgt->userId)
+        ) {
+      return TRUE;
+    }
+
+    // This is plausible if you have a dev or admin experimenting.
+    // We should probably show a more useful page - e.g. ask if they want
+    // logout and/or suggest using private browser window.
+    $this->reject('Cannot login. A mismatched session is already active.');
+    // @see \Civi\Authx\AllFlowsTest::testStatefulStatelessOverlap()
+  }
+
+  /**
    * Update Civi and UF to recognize the authenticated user.
    *
    * @param AuthenticatorTarget $tgt
@@ -258,23 +285,10 @@ class Authenticator extends AutoService implements HookInterface {
    * @throws \Exception
    */
   protected function login(AuthenticatorTarget $tgt) {
-    $isSameValue = function($a, $b) {
-      return !empty($a) && (string) $a === (string) $b;
-    };
-
-    if (\CRM_Core_Session::getLoggedInContactID() || $this->authxUf->getCurrentUserId()) {
-      if ($isSameValue(\CRM_Core_Session::getLoggedInContactID(), $tgt->contactId)  && $isSameValue($this->authxUf->getCurrentUserId(), $tgt->userId)) {
-        // Already logged in. Post-condition met - but by unusual means.
-        \CRM_Core_Session::singleton()->set('authx', $tgt->createAlreadyLoggedIn());
-        return;
-      }
-      else {
-        // This is plausible if you have a dev or admin experimenting.
-        // We should probably show a more useful page - e.g. ask if they want
-        // logout and/or suggest using private browser window.
-        $this->reject('Cannot login. Session already active.');
-        // @see \Civi\Authx\AllFlowsTest::testStatefulStatelessOverlap()
-      }
+    if ($this->checkAlreadyLoggedIn($tgt)) {
+      // Already logged in. Post-condition met - but by unusual means.
+      \CRM_Core_Session::singleton()->set('authx', $tgt->createAlreadyLoggedIn());
+      return;
     }
 
     if (empty($tgt->contactId)) {

--- a/ext/authx/Civi/Authx/Authenticator.php
+++ b/ext/authx/Civi/Authx/Authenticator.php
@@ -257,15 +257,18 @@ class Authenticator extends AutoService implements HookInterface {
    * @return bool
    */
   protected function checkAlreadyLoggedIn(AuthenticatorTarget $tgt) {
-    if (!\CRM_Core_Session::getLoggedInContactID() && !$this->authxUf->getCurrentUserId()) {
+    $existingContact = \CRM_Core_Session::getLoggedInContactID();
+    $existingUser = $this->authxUf->getCurrentUserId();
+
+    if (!$existingContact && !$existingUser) {
       return FALSE;
     }
 
     if (
-        \CRM_Core_Session::getLoggedInContactID()
-        && $this->authxUf->getCurrentUserId()
-        && ((string) \CRM_Core_Session::getLoggedInContactID() === (string) $tgt->contactId)
-        && ((string) $this->authxUf->getCurrentUserId() === (string) $tgt->userId)
+        $existingContact
+        && $existingUser
+        && ((string) $existingContact === (string) $tgt->contactId)
+        && ((string) $existingUser === (string) $tgt->userId)
         ) {
       return TRUE;
     }

--- a/ext/authx/tests/phpunit/Civi/Authx/MixedFlowsTest.php
+++ b/ext/authx/tests/phpunit/Civi/Authx/MixedFlowsTest.php
@@ -48,7 +48,7 @@ class MixedFlowsTest extends AbstractFlowsTest {
     $response = $http->send($request);
     $this->assertFailedDueToProhibition($response);
     // The following assertion merely identifies current behavior. If you can get it working generally, then huzza.
-    $this->assertBodyRegexp(';Session already active;', $response);
+    $this->assertBodyRegexp(';A mismatched session is already active;', $response);
     // $this->assertMyContact($this->getLebowskiCID(), NULL, $response);
     // $this->assertNoCookies($response);
 


### PR DESCRIPTION
Overview
----------------------------------------
Attempt to flatten the existing code path logic, in order to make @aydun 's life easier trying to fix https://lab.civicrm.org/dev/core/-/issues/4463

Before
----------------------------------------
A locally defined function that includes checking a var is `!empty`, which is always passed values that are defined, inside a conditional where you already know one of them is truthy, inside a general conditional nest where it's hard to know whether you proceed or reject or complete.

After
----------------------------------------
-  helper function with specific cases for proceed and complete; falling back to reject if in doubt.
- Marginally more informative error message when rejecting