### PR TITLE
dev/core#5442 Avoid duplicate participant custom fields on edit

### DIFF
--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -98,6 +98,32 @@ class CRM_Custom_Form_Group extends CRM_Admin_Form {
       }
     }
 
+    // Ensure participant custom set that limits by role, title, or type
+    // includes at least one value.
+    if ($fields['extends'] == 'Participant') {
+      $entityColumnId = $fields['extends_entity_column_id'];
+      $entityColumnValue = $fields['extends_entity_column_value'];
+      if ($entityColumnId && empty($entityColumnValue)) {
+        $limitByColumnLabel = '';
+        switch ($entityColumnId) {
+          case 1:
+            $limitByColumnLabel = ts("Role");
+            break;
+
+          case 2:
+            $limitByColumnLabel = ts("Event Name");
+            break;
+
+          case 3:
+            $limitByColumnLabel = ts("Event Type");
+            break;
+
+          default:
+            $limitByColumnLabel = ts("Category");
+        }
+        $errors['extends_entity_column_value'] = ts("Please enter at least one %1.", [1 => $limitByColumnLabel]);
+      }
+    }
     return empty($errors) ? TRUE : $errors;
   }
 
@@ -181,7 +207,7 @@ class CRM_Custom_Form_Group extends CRM_Admin_Form {
 
     $this->add('select2', 'extends_entity_column_id', ts('Type'), $initialEntityColumnIdOptions, FALSE, ['placeholder' => ts('Any')]);
 
-    $this->add('select2', 'extends_entity_column_value', ts('Sub Type'), $initialEntityColumnValueOptions, FALSE, ['multiple' => TRUE, 'placeholder' => ts('Any')]);
+    $this->add('select2', 'extends_entity_column_value', ts('Sub Type'), $initialEntityColumnValueOptions, FALSE, ['multiple' => TRUE]);
 
     // help text
     $this->add('wysiwyg', 'help_pre', ts('Pre-form Help'), ['class' => 'collapsed']);


### PR DESCRIPTION
Overview
----------------------------------------

See https://lab.civicrm.org/dev/core/-/issues/5442

Custom participant fields appear twice when editing the participant record.

Before
----------------------------------------

If you:

- create a set of custom fields that extend the participant entity => Event Name and then, do not specify an event
- Add a field
- Register someone for an event
- Edit their registration record

Then the custom participant field you created will show up twice.

After
----------------------------------------
After fixing the javascript in the template, they only appear once.

Technical Details
----------------------------------------

When there is no event id, we pull in the participant custom fields that apply to all events. That's good.

But, if there is an event id, we again pull in participant custom fields that apply to the given event ID. However, this call includes custom fields that apply to all events as well as custom fields that apply to the given event ID, so any custom fields that apply to all events get pulled in twice.

The fix ensures that we only pull in custom fields once to avoid the duplicates.

@eileenmcnaughton  - It's _possible_ this is a regression from e7daf4a223a but I'm not sure how or why - it just seems like the most recent commit that is touching this code.