### PR TITLE
dev/core#5443 - Fix crash when using a saved import mapping with a file with more columns

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -189,7 +189,7 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
     foreach ($this->getColumnHeaders() as $i => $columnHeader) {
       $defaults["mapper[$i]"] = [];
       if ($this->getSubmittedValue('savedMapping')) {
-        $fieldMapping = $fieldMappings[$i] ?? NULL;
+        $fieldMapping = $fieldMappings[$i] ?? [];
         $this->addMappingToDefaults($defaults, $fieldMapping, $i);
       }
       elseif ($this->getSubmittedValue('skipColumnHeader')) {


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5443

Before
----------------------------------------
1. Do a contribution import and make a mapping and save the mapping.
2. Take a similar file but add a new column to the input file you didn't have before, like payment method.
3. Do a contribution import and load the saved mapping.
4. Crash with something something null array something line 193 of CRM\Contribute\Import\Form\MapField.php

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------

