### PR TITLE
Move 'Manage Custom Searches' menu item to extension

### DIFF
--- a/CRM/Core/xml/Menu/Admin.xml
+++ b/CRM/Core/xml/Menu/Admin.xml
@@ -252,14 +252,6 @@
      <weight>105</weight>
   </item>
   <item>
-     <path>civicrm/admin/options/custom_search</path>
-     <title>Manage Custom Searches</title>
-     <desc>Developers and accidental techies with a bit of PHP and SQL knowledge can create new search forms to handle specific search and reporting needs which aren't covered by the built-in Advanced Search and Search Builder features.</desc>
-     <page_callback>CRM_Admin_Page_Options</page_callback>
-     <adminGroup>Customize Data and Screens</adminGroup>
-     <weight>110</weight>
-  </item>
-  <item>
      <path>civicrm/admin/domain</path>
      <title>Organization Address and Contact Info</title>
      <desc>Configure primary contact name, email, return-path and address information. This information is used by CiviMail to identify the sending organization.</desc>

--- a/ext/legacycustomsearches/xml/Menu/Search.xml
+++ b/ext/legacycustomsearches/xml/Menu/Search.xml
@@ -16,4 +16,12 @@
     <page_type>1</page_type>
     <weight>16</weight>
   </item>
+  <item>
+    <path>civicrm/admin/options/custom_search</path>
+    <title>Manage Custom Searches</title>
+    <desc>Developers and accidental techies with a bit of PHP and SQL knowledge can create new search forms to handle specific search and reporting needs which aren't covered by the built-in Advanced Search and Search Builder features.</desc>
+    <page_callback>CRM_Admin_Page_Options</page_callback>
+    <adminGroup>Customize Data and Screens</adminGroup>
+    <weight>110</weight>
+ </item>
 </menu>


### PR DESCRIPTION
Overview
----------------------------------------
Move 'Manage Custom Searches' menu item to extension

Before
----------------------------------------
'Manage Custom Searches' shows up in 'Administer', and in the CiviCRM menu, even if the `legacycustomsearches` extension is not enabled:

<img width="1033" alt="Screenshot 2024-09-07 at 12 07 04" src="https://github.com/user-attachments/assets/c4027612-951a-4b3d-82d3-e66236939b75">

<img width="476" alt="Screenshot 2024-09-07 at 12 07 28" src="https://github.com/user-attachments/assets/1ada33fb-28f7-4147-a835-62a8a0b5a8e0">

The actual edit screen contains a 'Run' button which doesn't do anything if the extension is not enabled:

<img width="1060" alt="Screenshot 2024-09-07 at 12 08 11" src="https://github.com/user-attachments/assets/67a21eb9-273e-4190-a52f-5428f5e7f0ef">

After
----------------------------------------
There is no change if the extension is enabled.

However, if the extension is not enabled, the 'Manage Custom Searches' link is no longer shown:
<img width="1034" alt="Screenshot 2024-09-07 at 12 09 23" src="https://github.com/user-attachments/assets/52a1f3d7-2943-4327-a5e5-22e6d6a14551">

Comments
----------------------------------------
The 'Manage Custom Searches' screen is handled by `CRM_Admin_Page_Options`, and so the screen is still accessible if you know the URL, despite not being shown in the menu.
