### PR TITLE
Always restore error handler when extension download glitches, a.k.a. avoid intermittent test fails

### DIFF
--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -224,7 +224,9 @@ class CRM_Extension_Browser {
     catch (GuzzleException $e) {
       throw new CRM_Extension_Exception(ts('The CiviCRM public extensions directory at %1 could not be contacted - please check your webserver can make external HTTP requests', [1 => $this->getRepositoryUrl()]), 'connection_error');
     }
-    restore_error_handler();
+    finally {
+      restore_error_handler();
+    }
 
     if ($response->getStatusCode() !== 200) {
       throw new CRM_Extension_Exception(ts('The CiviCRM public extensions directory at %1 could not be contacted - please check your webserver can make external HTTP requests', [1 => $this->getRepositoryUrl()]), 'connection_error');


### PR DESCRIPTION
Overview
----------------------------------------
Lately there's been a common intermittent fail where the error message is misleading and what's really happened is that it glitched connecting to lab.civicrm.org.

Before
----------------------------------------
error about "error handler is not the same as when it started"

After
----------------------------------------


Technical Details
----------------------------------------
When the exception is thrown it never resets the error handler.
If you're wondering, yes the finally block still executes even when an exception is thrown in the catch.

Comments
----------------------------------------
