### PR TITLE
dev/core#5449 set NOINDEX on non-public event registration pages

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -403,6 +403,12 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $this->_isBillingAddressRequiredForPayLater = $this->_values['event']['is_billing_required'] ?? NULL;
       $this->assign('isBillingAddressRequiredForPayLater', $this->_isBillingAddressRequiredForPayLater);
     }
+
+    // set the noindex metatag for non-public events
+    if ($values['event']['is_public'] == 0) {
+      CRM_Utils_System::addHTMLHead('<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">');
+    }
+
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
non-public event registration pages are still indexed by search engines
this pr adds a no-index to registration pages for non-public events
Gitlab issue: https://lab.civicrm.org/dev/core/-/issues/5449

Before
----------------------------------------
non-public event registration pages are still indexed by search engines

After
----------------------------------------
non-public event registration pages get a NOINDEX metatag in the html header

Comments
----------------------------------------
A while ago https://issues.civicrm.org/jira/browse/CRM-21639 already added NOINDEX for the event info pages (https://github.com/civicrm/civicrm-core/pull/11496 & https://github.com/civicrm/civicrm-core/pull/11498) But this was not done fior the event registration pages. This pr add the same metatag to the event registration pages if the event is a non-pubkic event