### PR TITLE
Pseudoconstant - Improve currency dropdowns & use non-deprecated functions

### DIFF
--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -92,17 +92,11 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
     $this->addElement('select', 'contact_default_language', ts('Default Language for users'),
       CRM_Admin_Form_Setting_Localization::getDefaultLanguageOptions());
 
-    $includeCurrency = &$this->addElement('advmultiselect', 'currencyLimit',
-      ts('Available Currencies') . ' ', self::getCurrencySymbols(),
-      [
-        'size' => 5,
-        'style' => 'width:150px',
-        'class' => 'advmultiselect',
-      ]
+    $this->add('select2', 'currencyLimit', ts('Available Currencies'),
+      Civi::entity('Contribution')->getOptions('currency'),
+      FALSE,
+      ['placeholder' => ts('- default currency only -'), 'multiple' => TRUE, 'class' => 'huge']
     );
-
-    $includeCurrency->setButtonAttributes('add', ['value' => ts('Add >>')]);
-    $includeCurrency->setButtonAttributes('remove', ['value' => ts('<< Remove')]);
 
     $this->addFormRule(['CRM_Admin_Form_Setting_Localization', 'formRule']);
 
@@ -213,13 +207,11 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
     $config = CRM_Core_Config::singleton();
     // save enabled currencies and default currency in option group 'currencies_enabled'
     // CRM-1496
-    if (empty($values['currencyLimit'])) {
-      $values['currencyLimit'] = [$values['defaultCurrency']];
+    $currencyLimit = $values['currencyLimit'] ? explode(',', $values['currencyLimit']) : [];
+    if (!in_array($values['defaultCurrency'], $values['currencyLimit'])) {
+      $currencyLimit[] = $values['defaultCurrency'];
     }
-    elseif (!in_array($values['defaultCurrency'], $values['currencyLimit'])) {
-      $values['currencyLimit'][] = $values['defaultCurrency'];
-    }
-    self::updateEnabledCurrencies($values['currencyLimit'], $values['defaultCurrency']);
+    self::updateEnabledCurrencies($currencyLimit, $values['defaultCurrency']);
     // unset currencyLimit so we dont store there
     unset($values['currencyLimit']);
 
@@ -254,7 +246,7 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
     // get labels for all the currencies
     $options = [];
 
-    $currencySymbols = CRM_Admin_Form_Setting_Localization::getCurrencySymbols();
+    $currencySymbols = self::getCurrencySymbols();
     foreach ($currencies as $i => $currency) {
       $options[] = [
         'label' => $currencySymbols[$currency],
@@ -321,10 +313,7 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
    *   Array('USD' => 'USD ($)').
    */
   public static function getCurrencySymbols() {
-    $symbols = CRM_Core_PseudoConstant::get('CRM_Contribute_DAO_Contribution', 'currency', [
-      'labelColumn' => 'symbol',
-      'orderColumn' => TRUE,
-    ]);
+    $symbols = CRM_Contribute_DAO_Contribution::buildOptions('currency', 'abbreviate');
     $_currencySymbols = [];
     foreach ($symbols as $key => $value) {
       $_currencySymbols[$key] = "$key";

--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -918,13 +918,11 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
     $form->addRule('contribution_amount_high', ts('Please enter a valid money value (e.g. %1).', [1 => CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency('99.99')]), 'money');
 
     // Adding select option for curreny type -- CRM-4711
-    $form->add('select', 'contribution_currency_type',
+    $form->add('select2', 'contribution_currency_type',
       ts('Currency Type'),
-      [
-        '' => ts('- any -'),
-      ] +
-      CRM_Core_PseudoConstant::get('CRM_Contribute_DAO_Contribution', 'currency', ['labelColumn' => 'name']),
-      FALSE, ['class' => 'crm-select2']
+      Civi::entity('Contribution')->getOptions('currency', [], FALSE, TRUE),
+      FALSE,
+      ['placeholder' => ts('- any -')]
     );
 
     // CRM-13848

--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -73,10 +73,8 @@ class CRM_Utils_Money {
     }
 
     if (!self::$_currencySymbols) {
-      self::$_currencySymbols = CRM_Core_PseudoConstant::get('CRM_Contribute_DAO_Contribution', 'currency', [
-        'keyColumn' => 'name',
-        'labelColumn' => 'symbol',
-      ]);
+      self::$_currencySymbols = CRM_Contribute_DAO_Contribution::buildOptions('currency', 'abbreviate');
+
     }
 
     // ensure $currency is a valid currency code

--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -531,13 +531,7 @@ class CRM_Utils_Rule {
     $config = CRM_Core_Config::singleton();
 
     //CRM-14868
-    $currencySymbols = CRM_Core_PseudoConstant::get(
-      'CRM_Contribute_DAO_Contribution',
-      'currency', [
-        'keyColumn' => 'name',
-        'labelColumn' => 'symbol',
-      ]
-    );
+    $currencySymbols = CRM_Contribute_DAO_Contribution::buildOptions('currency', 'abbreviate');
     $value = str_replace($currencySymbols, '', $value);
 
     if ($config->monetaryThousandSeparator) {

--- a/ext/civigrant/CRM/Report/Form/Grant/Statistics.php
+++ b/ext/civigrant/CRM/Report/Form/Grant/Statistics.php
@@ -514,8 +514,7 @@ SELECT COUNT({$this->_aliases['civicrm_grant']}.id) as count ,
       return;
     }
 
-    $currencies = CRM_Core_PseudoConstant::get('CRM_Grant_DAO_Grant', 'currency', ['labelColumn' => 'name']);
-    $currency = $currencies[$values['civicrm_grant_currency']];
+    $currency = CRM_Core_PseudoConstant::getName('CRM_Grant_DAO_Grant', 'currency', $values['civicrm_grant_currency']);
 
     if (!$customData) {
       if (!isset($grantStatistics['value'][$fieldValue]['currency'][$currency])

--- a/ext/civigrant/schema/Grant.entityType.php
+++ b/ext/civigrant/schema/Grant.entityType.php
@@ -218,6 +218,7 @@ return [
         'label_column' => 'full_name',
         'name_column' => 'name',
         'abbr_column' => 'symbol',
+        'description_column' => 'IFNULL(CONCAT(name, " (", symbol, ")"), name)',
       ],
       'usage' => [
         'import',

--- a/schema/Contribute/Contribution.entityType.php
+++ b/schema/Contribute/Contribution.entityType.php
@@ -318,6 +318,7 @@ return [
         'label_column' => 'full_name',
         'name_column' => 'name',
         'abbr_column' => 'symbol',
+        'description_column' => 'IFNULL(CONCAT(name, " (", symbol, ")"), name)',
       ],
     ],
     'cancel_date' => [

--- a/schema/Contribute/ContributionPage.entityType.php
+++ b/schema/Contribute/ContributionPage.entityType.php
@@ -463,6 +463,7 @@ return [
         'label_column' => 'full_name',
         'name_column' => 'name',
         'abbr_column' => 'symbol',
+        'description_column' => 'IFNULL(CONCAT(name, " (", symbol, ")"), name)',
       ],
     ],
     'campaign_id' => [

--- a/schema/Contribute/ContributionRecur.entityType.php
+++ b/schema/Contribute/ContributionRecur.entityType.php
@@ -88,6 +88,7 @@ return [
         'label_column' => 'full_name',
         'name_column' => 'name',
         'abbr_column' => 'symbol',
+        'description_column' => 'IFNULL(CONCAT(name, " (", symbol, ")"), name)',
       ],
     ],
     'frequency_unit' => [

--- a/schema/Contribute/ContributionSoft.entityType.php
+++ b/schema/Contribute/ContributionSoft.entityType.php
@@ -100,6 +100,7 @@ return [
         'label_column' => 'full_name',
         'name_column' => 'name',
         'abbr_column' => 'symbol',
+        'description_column' => 'IFNULL(CONCAT(name, " (", symbol, ")"), name)',
       ],
     ],
     'pcp_id' => [

--- a/schema/Contribute/Product.entityType.php
+++ b/schema/Contribute/Product.entityType.php
@@ -106,6 +106,7 @@ return [
         'label_column' => 'full_name',
         'name_column' => 'name',
         'abbr_column' => 'symbol',
+        'description_column' => 'IFNULL(CONCAT(name, " (", symbol, ")"), name)',
       ],
     ],
     'financial_type_id' => [

--- a/schema/Event/Event.entityType.php
+++ b/schema/Event/Event.entityType.php
@@ -730,6 +730,7 @@ return [
         'label_column' => 'full_name',
         'name_column' => 'name',
         'abbr_column' => 'symbol',
+        'description_column' => 'IFNULL(CONCAT(name, " (", symbol, ")"), name)',
       ],
     ],
     'campaign_id' => [

--- a/schema/Event/Participant.entityType.php
+++ b/schema/Event/Participant.entityType.php
@@ -286,6 +286,7 @@ return [
         'label_column' => 'full_name',
         'name_column' => 'name',
         'abbr_column' => 'symbol',
+        'description_column' => 'IFNULL(CONCAT(name, " (", symbol, ")"), name)',
       ],
     ],
     'campaign_id' => [

--- a/schema/Financial/FinancialItem.entityType.php
+++ b/schema/Financial/FinancialItem.entityType.php
@@ -109,6 +109,7 @@ return [
         'label_column' => 'full_name',
         'name_column' => 'name',
         'abbr_column' => 'symbol',
+        'description_column' => 'IFNULL(CONCAT(name, " (", symbol, ")"), name)',
       ],
     ],
     'financial_account_id' => [

--- a/schema/Financial/FinancialTrxn.entityType.php
+++ b/schema/Financial/FinancialTrxn.entityType.php
@@ -130,6 +130,7 @@ return [
         'label_column' => 'full_name',
         'name_column' => 'name',
         'abbr_column' => 'symbol',
+        'description_column' => 'IFNULL(CONCAT(name, " (", symbol, ")"), name)',
       ],
     ],
     'is_payment' => [

--- a/schema/PCP/PCP.entityType.php
+++ b/schema/PCP/PCP.entityType.php
@@ -153,6 +153,7 @@ return [
         'label_column' => 'full_name',
         'name_column' => 'name',
         'abbr_column' => 'symbol',
+        'description_column' => 'IFNULL(CONCAT(name, " (", symbol, ")"), name)',
       ],
     ],
     'is_active' => [

--- a/schema/Pledge/Pledge.entityType.php
+++ b/schema/Pledge/Pledge.entityType.php
@@ -140,6 +140,7 @@ return [
         'label_column' => 'full_name',
         'name_column' => 'name',
         'abbr_column' => 'symbol',
+        'description_column' => 'IFNULL(CONCAT(name, " (", symbol, ")"), name)',
       ],
     ],
     'frequency_unit' => [

--- a/schema/Pledge/PledgePayment.entityType.php
+++ b/schema/Pledge/PledgePayment.entityType.php
@@ -113,6 +113,7 @@ return [
         'label_column' => 'full_name',
         'name_column' => 'name',
         'abbr_column' => 'symbol',
+        'description_column' => 'IFNULL(CONCAT(name, " (", symbol, ")"), name)',
       ],
     ],
     'scheduled_date' => [


### PR DESCRIPTION
Overview
----------------------------------------
Makes currency selectors nicer & updates code to avoid deprecated function calls.

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/62d6337f-357d-4e55-a60c-553cc7e3d63f)

![image](https://github.com/user-attachments/assets/8a1bd291-6b51-4283-a928-01d4d224196b)


After
----------------------------------------
![image](https://github.com/user-attachments/assets/1d087f0e-bbd2-4163-bbe5-205b0e94e1d9)

![image](https://github.com/user-attachments/assets/2d207219-6c2c-438b-b305-848e9bae07cb)
