### PR TITLE
standalone: minor fixes

### DIFF
--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -320,9 +320,9 @@ class Security {
       ^
       \$([a-z0-9-]{1,32})  # Match 1 algorithm identifier
       (\$v=[0-9+])?        # Match 2 optional version
-      (\$[a-z0-9-]{1,32}=[a-zA-Z0-9/+.-]*(?:,[a-z0-9-]{1,32}=[a-zA-Z0-9/+.-]*)*)? # 3: optional parameters
-      \$([a-zA-Z0-9/+.-]+) # Match 4 salt
-      \$([a-zA-Z0-9/+]+)   # Match 5 B64 encoded hash
+      (\$[a-z0-9-]{1,32}=[a-zA-Z0-9\/+.-]*(?:,[a-z0-9-]{1,32}=[a-zA-Z0-9\/+.-]*)*)? # 3: optional parameters
+      \$([a-zA-Z0-9\/+.-]+) # Match 4 salt
+      \$([a-zA-Z0-9\/+]+)   # Match 5 B64 encoded hash
       $/x', $storedHashedPassword, $matches)) {
 
       Civi::log()->warning("Denying access to user whose stored password is not in a format we can parse.");

--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -23,11 +23,11 @@ class Security {
   const PASSWORD_RESET_SCOPE = 'pw_reset';
 
   /**
-   * @return static
+   * @return Security
    */
   public static function singleton() {
     if (!isset(\Civi::$statics[__METHOD__])) {
-      \Civi::$statics[__METHOD__] = new static();
+      \Civi::$statics[__METHOD__] = new Security();
     }
     return \Civi::$statics[__METHOD__];
   }


### PR DESCRIPTION
Should fix the important bits of 
https://lab.civicrm.org/dev/core/-/issues/4998

- the regex delimiter character must be escaped, even when within a `[]`. 
- The standalone Security class's singleton method now uses concrete `new Security()` not `new static()` 