### PR TITLE
AllCoreTables - Handle tableless and classless entities without crashing

### DIFF
--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -43,7 +43,12 @@ class CRM_Core_DAO_AllCoreTables {
    *   [EntityName => [table => table_name, class => CRM_DAO_ClassName]][]
    */
   public static function getEntities(): array {
-    return EntityRepository::getEntities();
+    $allEntities = EntityRepository::getEntities();
+    // Filter out entities without a table
+    $tables = EntityRepository::getTableIndex();
+    // Filter out entities without a class
+    $classes = EntityRepository::getClassIndex();
+    return array_intersect_key($allEntities, array_flip($tables), array_flip($classes));
   }
 
   /**
@@ -166,7 +171,8 @@ class CRM_Core_DAO_AllCoreTables {
    *   [EntityName => CRM_DAO_ClassName]
    */
   public static function daoToClass() {
-    return array_combine(array_keys(self::getEntities()), array_column(self::getEntities(), 'class'));
+    $entities = self::getEntities();
+    return array_combine(array_keys($entities), array_column($entities, 'class'));
   }
 
   /**

--- a/Civi/Schema/EntityRepository.php
+++ b/Civi/Schema/EntityRepository.php
@@ -70,8 +70,8 @@ class EntityRepository {
     // Extensions should be online when we're called.
     \CRM_Utils_Hook::entityTypes($entityTypes);
     self::$entities = array_column($entityTypes, NULL, 'name');
-    self::$tableIndex = array_column($entityTypes, 'name', 'table');
-    self::$classIndex = array_column($entityTypes, 'name', 'class');
+    self::$tableIndex = array_column(array_filter($entityTypes, fn($entityType) => !empty($entityType['table'])), 'name', 'table');
+    self::$classIndex = array_column(array_filter($entityTypes, fn($entityType) => !empty($entityType['class'])), 'name', 'class');
   }
 
   private static function loadCoreEntities(): array {

--- a/mixin/lib/civimix-schema/src/SqlGenerator.php
+++ b/mixin/lib/civimix-schema/src/SqlGenerator.php
@@ -48,7 +48,8 @@ return new class() {
   }
 
   public function __construct(array $entities = [], ?callable $findExternalTable = NULL) {
-    $this->entities = $entities;
+    // Filter out entities without a sql table (e.g. Afform)
+    $this->entities = array_filter($entities, fn($entity) => !empty($entity['table']));
     $this->findExternalTable = $findExternalTable ?: function() {
       return NULL;
     };


### PR DESCRIPTION
Overview
----------------------------------------
As we expand the capabilities of EntityFramework v2 to handle tableless and classless entities. This ensures backward compatibility.

Technical Details
----------------------------------------
Without these changes, [adding a tableless entity like Afform](https://github.com/civicrm/civicrm-core/pull/31072) causes a bunch of test failures. With these changes, tests pass.