### PR TITLE
Annotate CRM_Core_PseudoConstant::get as @deprecated

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2870,7 +2870,7 @@ SELECT contact_id
   /**
    * Legacy field options getter.
    *
-   * @deprecated in favor of `EntityProvider::getOptions()`
+   * @deprecated in favor of `Civi::entity()->getOptions()`
    *
    * Overriding this function is no longer recommended as a way to customize options.
    * Instead, option lists can be customized by either:

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -106,14 +106,9 @@ class CRM_Core_PseudoConstant {
   private static $accountOptionValues;
 
   /**
-   * Low-level option getter, rarely accessed directly.
-   * NOTE: Rather than calling this function directly use CRM_*_BAO_*::buildOptions()
-   * @see https://docs.civicrm.org/dev/en/latest/framework/pseudoconstant/
+   * Legacy option getter.
    *
-   * NOTE: If someone undertakes a refactoring of this, please consider the use-case of
-   * the Setting.getoptions API. There is no DAO/field, but it would be nice to use the
-   * same 'pseudoconstant' struct in *.settings.php. This means loosening the coupling
-   * between $field lookup and the $pseudoconstant evaluation.
+   * @deprecated in favor of `Civi::entity()->getOptions()`
    *
    * @param string $daoName
    * @param string $fieldName


### PR DESCRIPTION
Overview
----------------------------------------
Just a docblock change to mark old functions as `@deprecated`