### PR TITLE
Manage Premiums: remove the tiny thumbnail

### DIFF
--- a/CRM/Contribute/Form/ManagePremiums.php
+++ b/CRM/Contribute/Form/ManagePremiums.php
@@ -41,16 +41,12 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
       $tempDefaults = Product::get()->addSelect('*', 'custom.*')->addWhere('id', '=', $this->_id)->execute()->first();
       if (isset($tempDefaults['image']) && isset($tempDefaults['thumbnail'])) {
         $defaults['imageUrl'] = $tempDefaults['image'];
-        $defaults['thumbnailUrl'] = $tempDefaults['thumbnail'];
         $defaults['imageOption'] = 'thumbnail';
-        // assign thumbnailUrl to template so we can display current image in update mode
-        $this->assign('thumbnailUrl', $defaults['thumbnailUrl']);
       }
       else {
         $defaults['imageOption'] = 'noImage';
       }
       if (isset($tempDefaults['thumbnail']) && isset($tempDefaults['image'])) {
-        $this->assign('thumbURL', $tempDefaults['thumbnail']);
         $this->assign('imageURL', $tempDefaults['image']);
       }
       if (isset($tempDefaults['period_type'])) {
@@ -127,14 +123,11 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
     $image['noImage'] = ts('Do not display an image');
     $imageJS['noImage'] = ['onclick' => 'add_upload_file_block(\'noImage\');', 'class' => 'required'];
 
-    $this->addRadio('imageOption', ts('Premium Image'), $image, [], NULL, FALSE, $imageJS);
+    $this->addRadio('imageOption', ts('Image'), $image, [], NULL, FALSE, $imageJS);
     $this->addRule('imageOption', ts('Please select an option for the premium image.'), 'required');
 
     $this->addElement('text', 'imageUrl', ts('Image URL'));
-    $this->addElement('text', 'thumbnailUrl', ts('Thumbnail URL'));
-
     $this->add('file', 'uploadFile', ts('Image File Name'), ['onChange' => 'CRM.$("input[name=imageOption][value=image]").prop("checked", true);']);
-
     $this->add('text', 'price', ts('Market Value'), CRM_Core_DAO::getAttribute('CRM_Contribute_DAO_Product', 'price'), TRUE);
     $this->addRule('price', ts('Please enter the Market Value for this product.'), 'money');
 
@@ -235,9 +228,6 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
     if (($params['imageOption'] ?? NULL) == 'thumbnail') {
       if (!$params['imageUrl']) {
         $errors['imageUrl'] = ts('Image URL is Required');
-      }
-      if (!$params['thumbnailUrl']) {
-        $errors['thumbnailUrl'] = ts('Thumbnail URL is Required');
       }
     }
 
@@ -348,7 +338,6 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
       'image' => '',
       'thumbnail' => '',
       'imageUrl' => '',
-      'thumbnailUrl' => '',
     ];
     $params = array_merge($defaults, $params);
 
@@ -357,11 +346,9 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
       $imageFile = $params['uploadFile']['name'];
       try {
         $params['image'] = CRM_Utils_File::resizeImage($imageFile, 200, 200, "_full");
-        $params['thumbnail'] = CRM_Utils_File::resizeImage($imageFile, 50, 50, "_thumb");
       }
       catch (CRM_Core_Exception $e) {
         $params['image'] = self::_defaultImage();
-        $params['thumbnail'] = self::_defaultThumbnail();
         $msg = ts('The product has been configured to use a default image.');
         CRM_Core_Session::setStatus($e->getMessage() . " $msg", ts('Notice'), 'alert');
       }
@@ -370,13 +357,11 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
     // User is specifying existing URLs for the images
     elseif ($params['imageOption'] == 'thumbnail') {
       $params['image'] = $params['imageUrl'];
-      $params['thumbnail'] = $params['thumbnailUrl'];
     }
 
     // User wants a default image
     elseif ($params['imageOption'] == 'default_image') {
       $params['image'] = self::_defaultImage();
-      $params['thumbnail'] = self::_defaultThumbnail();
     }
   }
 
@@ -387,15 +372,6 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
   protected static function _defaultImage() {
     $config = CRM_Core_Config::singleton();
     return $config->resourceBase . 'i/contribute/default_premium.jpg';
-  }
-
-  /**
-   * Returns the path to the default premium thumbnail
-   * @return string
-   */
-  protected static function _defaultThumbnail() {
-    $config = CRM_Core_Config::singleton();
-    return $config->resourceBase . 'i/contribute/default_premium_thumb.jpg';
   }
 
 }

--- a/templates/CRM/Contribute/Form/ManagePremiums.tpl
+++ b/templates/CRM/Contribute/Form/ManagePremiums.tpl
@@ -38,27 +38,36 @@
      <span class="description">{ts}Optional product SKU or code. If used, this value will be included in contributor receipts.{/ts}</span>
   </td>
      </tr>
-     <tr class="crm-contribution-form-block-imageOption" >
-        <td class="label">{$form.imageOption.label}</td>
+     <tr class="crm-contribution-form-block-imageOption">
+      <td class="label">{$form.imageOption.label}</td>
       <td>
-      <fieldset><div class="description">
-        <p>{ts}You can give this premium a picture that will be displayed on the contribution page. Both a 50 x 50 pixel thumbnail image and a 200 x 200 pixel larger image will be displayed. Images must be in GIF, JPEG, or PNG format.{/ts}</p>
-        <p>{ts}You can upload an image from your computer OR enter a URL for an image already on the Web. If you chose to upload an image file, a 'thumbnail' version will be automatically created for you. If you don't have an image available at this time, you may also choose to display a 'No Image Available' icon by selecting the 'default image'.{/ts}</p>
-                  </div>
+        {if $imageURL}
+          <img src="{$imageURL}" alt="{ts escape="htmlattribute"}Current Image{/ts}"/>
+        {/if}
+        <div class="description">
+          <p>{ts}You can give this premium a picture that will be displayed on the contribution page. The image displayed will be resized to a maximum of 200x200 pixels. Images must be in GIF, JPEG, or PNG format.{/ts}</p>
+        </div>
   <table class="form-layout-compressed">
-    {if !empty($thumbnailUrl)}<tr class="odd-row"><td class="describe-image" colspan="2"><strong>{ts}Current Image Thumbnail{/ts}</strong><br /><img src="{$thumbnailUrl}" /></td></tr>{/if}
-    <tr class="crm-contribution-form-block-imageOption"><td>{$form.imageOption.image.html}</td><td>{$form.uploadFile.html}</td></tr>
-  <tr class="crm-contribution-form-block-imageOption-thumbnail"><td colspan="2">{$form.imageOption.thumbnail.html}</td></tr>
+    <tr class="crm-contribution-form-block-imageOption">
+      <td colspan="2">{$form.imageOption.image.html}</td>
+    </tr>
+    <tr id="uploadFileRow" class="hiddenElement">
+      <td class="label"><label for="uploadFile">{ts}File{/ts}</label></td>
+      <td>{$form.uploadFile.html}</td>
+    </tr>
+    <tr class="crm-contribution-form-block-imageOption-thumbnail">
+      <td colspan="2">{$form.imageOption.thumbnail.html}</td>
+    </tr>
     <tr id="imageURL"{if $action neq 2} class="hiddenElement"{/if}>
-        <td class="label">{$form.imageUrl.label}</td><td>{$form.imageUrl.html|crmAddClass:huge}</td>
+      <td class="label">{$form.imageUrl.label}</td><td>{$form.imageUrl.html|crmAddClass:huge}</td>
     </tr>
-    <tr id="thumbnailURL"{if $action neq 2} class="hiddenElement"{/if}>
-        <td class="label">{$form.thumbnailUrl.label}</td><td>{$form.thumbnailUrl.html|crmAddClass:huge}</td>
+    <tr>
+      <td colspan="2">{$form.imageOption.default_image.html}</td>
     </tr>
-  <tr><td colspan="2">{$form.imageOption.default_image.html}</td></tr>
-  <tr><td colspan="2">{$form.imageOption.noImage.html}</td></tr>
+    <tr>
+      <td colspan="2">{$form.imageOption.noImage.html}</td>
+    </tr>
   </table>
-        </fieldset>
         </td>
     </tr>
     <tr class="crm-contribution-form-block-min_contribution">
@@ -144,21 +153,19 @@
 
 <script type="text/javascript">
 {literal}
-
 function add_upload_file_block(parms) {
-  if (parms =='thumbnail') {
-
-          document.getElementById("imageURL").style.display="table-row";
-        document.getElementById("thumbnailURL").style.display="table-row";
-
-  } else {
-
-        document.getElementById("imageURL").style.display="none";
-        document.getElementById("thumbnailURL").style.display="none";
-
+  if (parms == 'thumbnail') {
+    document.getElementById("imageURL").style.display = "table-row";
+    document.getElementById("uploadFileRow").style.display = "none";
+  }
+  else if (parms == 'image') {
+    document.getElementById("uploadFileRow").style.display = "table-row";
+    document.getElementById("imageURL").style.display = "none";
+  }
+  else {
+    document.getElementById("imageURL").style.display = "none";
   }
 }
-
 {/literal}
 </script>
 


### PR DESCRIPTION
Overview
----------------------------------------

Minor improvements to the Manage Premium form, notably by removing the tiny thumbnail.

Before
----------------------------------------

Tiny thumbnail:

![image](https://github.com/user-attachments/assets/381141bc-07b0-4403-af85-57dd5b46d460)

After
----------------------------------------

Displays the 200x200 image:

![image](https://github.com/user-attachments/assets/d3071a25-ce42-420b-a67f-2276ba659acb)

(and other minor tweaks)

Comments
-----------------------------

Based on feedback by the Tor Project org.