### PR TITLE
Standalone - allow creating a homepage at `/civicrm/home`

### DIFF
--- a/Civi/Standalone/WebEntrypoint.php
+++ b/Civi/Standalone/WebEntrypoint.php
@@ -52,14 +52,20 @@ class WebEntrypoint {
 
     // Add CSS, JS, etc. that is required for this page.
     \CRM_Core_Resources::singleton()->addCoreResources();
+
     $parts = explode('?', $requestUri);
     $args = explode('/', $parts[0] ?? '');
     // Remove empty path segments, a//b becomes equivalent to a/b
     $args = array_values(array_filter($args));
     if (!$args) {
       // This is a request for the site's homepage. See if we have one.
-      $item = \CRM_Core_Invoke::getItem('/');
-      if (!$item) {
+
+      $homepage = \CRM_Core_Invoke::getItem('civicrm/home') ? '/civicrm/home' : NULL;
+
+      if ($homepage) {
+        \CRM_Utils_System::redirect($homepage);
+      }
+      else {
         // We have no public homepage, so send them to login.
         // This doesn't allow for /civicrm itself to be public,
         // but that's got to be a pretty edge case, right?!


### PR DESCRIPTION
Overview
----------------------------------------
Enable creating a Standalone homepage at `/civicrm/home`.


Before
----------------------------------------
- currently the Standalone web entrypoint looks for a homepage item with route `/`.
- however this doesn't work, if you create a Menu route (or Afform) with that route, it gets ignored because `CRM_Core_Invoke` [exits early for any routes that don't start `civicrm`](https://github.com/civicrm/civicrm-core/blob/349a670de5cff0d492f43b86301b213bfb8df53f/CRM/Core/Invoke.php#L54)

After
----------------------------------------
- looks for an item with route `/civicrm/home`.
- if it exists, redirect to that page
- You can create an afform with custom content and it can be displayed to anon users 

![image](https://github.com/user-attachments/assets/8e6bc306-3ee3-430e-b482-7e711201274a)


Technical Details
----------------------------------------
In the long run we will probably want to add a setting to choose between all known routes on the site.

It would be nice if we could display content at the actual `/` url rather than redirect -- but that would require patching `CRM_Core_Invoke`
