### PR TITLE
Remove brand names from website types

### DIFF
--- a/sql/civicrm_data/civicrm_option_group/website_type.sqldata.php
+++ b/sql/civicrm_data/civicrm_option_group/website_type.sqldata.php
@@ -3,9 +3,9 @@ return CRM_Core_CodeGen_OptionGroup::create('website_type', 'a/0045')
   ->addMetadata([
     'title' => ts('Website Type'),
   ])
-  ->addValueTable(['name', 'value'], [
-    ['Work', 1, 'is_default' => 1],
-    ['Main', 2],
-    ['Social', 3],
+  ->addValueTable(['label', 'name', 'value'], [
+    [ts('Work'), 'Work', 1, 'is_default' => 1],
+    [ts('Main'), 'Main', 2],
+    [ts('Social'), 'Social', 3],
   ])
   ->syncColumns('fill', ['value' => 'weight', 'name' => 'label']);

--- a/sql/civicrm_data/civicrm_option_group/website_type.sqldata.php
+++ b/sql/civicrm_data/civicrm_option_group/website_type.sqldata.php
@@ -6,13 +6,6 @@ return CRM_Core_CodeGen_OptionGroup::create('website_type', 'a/0045')
   ->addValueTable(['name', 'value'], [
     ['Work', 1, 'is_default' => 1],
     ['Main', 2],
-    ['Facebook', 3],
-    ['Instagram', 5],
-    ['LinkedIn', 6],
-    ['MySpace', 7],
-    ['Pinterest', 8],
-    ['SnapChat', 9],
-    ['Tumblr', 10],
-    ['Twitter', 11],
+    ['Social', 3],
   ])
   ->syncColumns('fill', ['value' => 'weight', 'name' => 'label']);

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -1612,7 +1612,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     $mobileTypeID = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Phone', 'phone_type_id', 'Mobile');
     $skypeTypeID = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_IM', 'provider_id', 'Skype');
     $mainWebsiteTypeID = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Website', 'website_type_id', 'Main');
-    $linkedInTypeID = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Website', 'website_type_id', 'LinkedIn');
+    $socialWebsiteTypeID = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Website', 'website_type_id', 'Social');
     $homeID = $locations['Home']['id'];
     $workID = $locations['Work']['id'];
     $mapper = [
@@ -1640,7 +1640,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       [$childKey, 'email', $homeID],
       [$childKey, 'signature_text', $homeID],
       [$childKey, 'im', $homeID, $skypeTypeID],
-      [$childKey, 'url', $linkedInTypeID],
+      [$childKey, 'url', $socialWebsiteTypeID],
       // Same location type, different phone typ in these phones
       [$childKey, 'phone', $homeID, $phoneTypeID],
       [$childKey, 'phone_ext', $homeID, $phoneTypeID],
@@ -1653,8 +1653,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       [$siblingKey, 'email', $homeID],
       [$siblingKey, 'signature_text', $homeID],
       [$siblingKey, 'im', $homeID, $skypeTypeID],
-      // The 2 is website_type_id (yes, small hard-coding cheat)
-      [$siblingKey, 'url', $linkedInTypeID],
+      [$siblingKey, 'url', $socialWebsiteTypeID],
       [$siblingKey, 'phone', $workID, $phoneTypeID],
       [$siblingKey, 'phone_ext', $workID, $phoneTypeID],
       [$employeeKey, 'organization_name'],
@@ -1665,7 +1664,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       [$employeeKey, 'supplemental_address_1', $homeID],
       [$employeeKey, 'do_not_import'],
       // Second website, different type.
-      [$employeeKey, 'url', $linkedInTypeID],
+      [$employeeKey, 'url', $socialWebsiteTypeID],
       ['openid'],
     ];
     $this->validateCSV($csv, $mapper);

--- a/tests/phpunit/CRM/Core/PseudoConstantTest.php
+++ b/tests/phpunit/CRM/Core/PseudoConstantTest.php
@@ -640,7 +640,7 @@ class CRM_Core_PseudoConstantTest extends CiviUnitTestCase {
       'CRM_Core_DAO_Website' => [
         [
           'fieldName' => 'website_type_id',
-          'sample' => 'Facebook',
+          'sample' => 'Social',
         ],
       ],
       'CRM_Core_DAO_WordReplacement' => [
@@ -656,7 +656,7 @@ class CRM_Core_PseudoConstantTest extends CiviUnitTestCase {
       'CRM_Core_DAO_MappingField' => [
         [
           'fieldName' => 'website_type_id',
-          'sample' => 'Facebook',
+          'sample' => 'Social',
         ],
         [
           'fieldName' => 'im_provider_id',


### PR DESCRIPTION
Overview
----------------------------------------
This is a strange list. As far as I can guess, it started reasonably enough with "Work" and "Main" types, then someone added "Facebook" and "MySpace" which are brands, not types (like Kleenex is to tissues). And then it spiraled out of control.

This pulls the list back to being about "types" not brands.