### PR TITLE
[REF] Replace create with writeRecord in Group

### DIFF
--- a/CRM/Campaign/Form/Task/Reserve.php
+++ b/CRM/Campaign/Form/Task/Reserve.php
@@ -308,7 +308,7 @@ class CRM_Campaign_Form_Task_Reserve extends CRM_Campaign_Form_Task {
         'description' => $newGroupDesc,
         'is_active' => TRUE,
       ];
-      $group = CRM_Contact_BAO_Group::create($grpParams);
+      $group = CRM_Contact_BAO_Group::writeRecord($grpParams);
       $groups[] = $newGroupId = $group->id;
     }
 

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -337,196 +337,8 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group implements HookInterfa
    *   The new group BAO (if created)
    */
   public static function create(&$params) {
-
-    // only check if we need to remove parents if a params was provided
-    $parentsParamProvided = array_key_exists('parents', $params);
-
-    $params += [
-      'group_type' => NULL,
-      'parents' => NULL,
-    ];
-
-    // Fill title and frontend_title if not supplied
-    if (empty($params['id']) && empty($params['title'])) {
-      $params['title'] = $params['frontend_title'] ?? $params['name'];
-    }
-    if (empty($params['id']) && empty($params['frontend_title'])) {
-      $params['frontend_title'] = $params['title'];
-    }
-    $hook = empty($params['id']) ? 'create' : 'edit';
-    CRM_Utils_Hook::pre($hook, 'Group', $params['id'] ?? NULL, $params);
-
-    // If title isn't specified, retrieve it because we use it later, e.g.
-    // for RecentItems. But note we use array_key_exists not isset or empty
-    // since otherwise there would be no way to blank out an existing title.
-    // I'm not sure what the use-case is for that, but you're allowed to do it
-    // currently.
-    if (!empty($params['id']) && !array_key_exists('title', $params)) {
-      try {
-        $groupTitle = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Group', $params['id'], 'title', 'id');
-        $params['title'] = $groupTitle;
-      }
-      catch (CRM_Core_Exception $groupTitleException) {
-        // don't set title
-      }
-    }
-
-    if (!empty($params['id'])) {
-      // dev/core#287 Disable child groups if all parents are disabled.
-      $allChildGroupIds = self::getChildGroupIds($params['id']);
-      foreach ($allChildGroupIds as $childKey => $childValue) {
-        $parentIds = CRM_Contact_BAO_GroupNesting::getParentGroupIds($childValue);
-        $activeParentsCount = civicrm_api3('Group', 'getcount', [
-          'id' => ['IN' => $parentIds],
-          'is_active' => 1,
-        ]);
-        if (count($parentIds) >= 1 && $activeParentsCount <= 1) {
-          self::setIsActive($childValue, (int) ($params['is_active'] ?? 1));
-        }
-      }
-
-      // get current parents for removal if not in the list anymore
-      $parents = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Group', $params['id'], 'parents');
-      $currentParentGroupIDs = $parents ? explode(',', $parents) : [];
-    }
-
-    // form the name only if missing: CRM-627
-    $nameParam = $params['name'] ?? NULL;
-    // If we were calling writeRecord it would handle this, but we need
-    // to migrate the other bits of magic.
-    if (!$nameParam && empty($params['id'])) {
-      $params['name'] = CRM_Utils_String::titleToVar($params['title']);
-    }
-
-    if ($parentsParamProvided) {
-      $params['parents'] = CRM_Utils_Array::convertCheckboxFormatToArray((array) $params['parents']);
-      // failsafe: forbid adding itself as parent
-      if (!empty($params['id']) && ($key = array_search($params['id'], $params['parents'])) !== FALSE) {
-        unset($params['parents'][$key]);
-      }
-    }
-
-    // convert params if array type
-    if (!CRM_Utils_System::isNull($params['group_type'])) {
-      $params['group_type'] = CRM_Utils_Array::convertCheckboxFormatToArray((array) $params['group_type']);
-    }
-
-    $session = CRM_Core_Session::singleton();
-    $cid = $session->get('userID');
-    // this action is add
-    if ($cid && empty($params['id'])) {
-      $params['created_id'] = $cid;
-    }
-    // this action is update
-    if ($cid && !empty($params['id'])) {
-      $params['modified_id'] = $cid;
-    }
-
-    // CRM-19068.
-    // Validate parents parameter when creating group.
-    if (!CRM_Utils_System::isNull($params['parents'])) {
-      $parents = is_array($params['parents']) ? array_keys($params['parents']) : (array) $params['parents'];
-      foreach ($parents as $parent) {
-        CRM_Utils_Type::validate($parent, 'Integer');
-      }
-    }
-    $group = new CRM_Contact_BAO_Group();
-    $group->copyValues($params);
-
-    if (empty($params['id']) && !$nameParam) {
-      $group->name .= "_tmp";
-    }
-    $group->save();
-
-    if (!$group->id) {
-      return NULL;
-    }
-
-    // Enforce unique name by appending id
-    if (empty($params['id']) && !$nameParam) {
-      $group->name = substr($group->name, 0, -4) . "_{$group->id}";
-    }
-
-    $group->save();
-
-    // add custom field values
-    if (!empty($params['custom'])) {
-      CRM_Core_BAO_CustomValueTable::store($params['custom'], 'civicrm_group', $group->id);
-    }
-
-    // Process group nesting
-    // first deal with removed parents
-    if ($parentsParamProvided && !empty($currentParentGroupIDs)) {
-      foreach ($currentParentGroupIDs as $parentGroupId) {
-        // no more parents or not in the new list, let's remove
-        if (empty($params['parents']) || !in_array($parentGroupId, $params['parents'])) {
-          CRM_Contact_BAO_GroupNesting::remove($parentGroupId, $params['id']);
-        }
-      }
-    }
-
-    // then add missing parents
-    if (!CRM_Utils_System::isNull($params['parents'])) {
-      foreach ($params['parents'] as $parentId) {
-        if ($parentId && !CRM_Contact_BAO_GroupNesting::isParentChild($parentId, $group->id)) {
-          CRM_Contact_BAO_GroupNesting::add($parentId, $group->id);
-        }
-      }
-    }
-
-    // refresh cache if parents param was provided
-    if ($parentsParamProvided || !empty($params['parents'])) {
-      CRM_Contact_BAO_GroupNestingCache::update();
-    }
-
-    // update group contact cache for all parent groups
-    $parentIds = CRM_Contact_BAO_GroupNesting::getParentGroupIds($group->id);
-    foreach ($parentIds as $parentId) {
-      CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache($parentId);
-    }
-
-    if (!empty($params['organization_id'])) {
-      if ($params['organization_id'] == 'null') {
-        $groupOrganization = [];
-        CRM_Contact_BAO_GroupOrganization::retrieve($group->id, $groupOrganization);
-        if (!empty($groupOrganization['group_organization'])) {
-          CRM_Contact_BAO_GroupOrganization::deleteGroupOrganization($groupOrganization['group_organization']);
-        }
-      }
-      else {
-        // dev/core#382 Keeping the id here can cause db errors as it tries to update the wrong record in the Organization table
-        $groupOrg = [
-          'group_id' => $group->id,
-          'organization_id' => $params['organization_id'],
-        ];
-        CRM_Contact_BAO_GroupOrganization::add($groupOrg);
-      }
-    }
-
-    self::flushCaches();
-    CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache($group->id);
-
-    CRM_Utils_Hook::post($hook, 'Group', $group->id, $group);
-
-    $recentOther = [];
-    if (CRM_Core_Permission::check('edit groups')) {
-      $recentOther['editUrl'] = CRM_Utils_System::url('civicrm/group/edit', 'reset=1&action=update&id=' . $group->id);
-      // currently same permission we are using for delete a group
-      $recentOther['deleteUrl'] = CRM_Utils_System::url('civicrm/group/edit', 'reset=1&action=delete&id=' . $group->id);
-    }
-
-    // add the recently added group (unless hidden: CRM-6432)
-    if (!$group->is_hidden) {
-      CRM_Utils_Recent::add($group->title,
-        CRM_Utils_System::url('civicrm/group/search', 'reset=1&force=1&context=smog&gid=' . $group->id),
-        $group->id,
-        'Group',
-        NULL,
-        NULL,
-        $recentOther
-      );
-    }
-    return $group;
+    CRM_Core_Error::deprecatedFunctionWarning('writeRecord');
+    return self::writeRecord($params);
   }
 
   /**
@@ -1462,6 +1274,190 @@ WHERE {$whereClause}";
       }
       else {
         $e->setAuthorized(CRM_Core_Permission::check(['access CiviCRM', 'edit groups'], $userID));
+      }
+    }
+  }
+
+  /**
+   * Callback for hook_civicrm_post().
+   * @param \Civi\Core\Event\PostEvent $event
+   */
+  public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $event) {
+    /** @var CRM_Contact_DAO_Group $contactType */
+    $group = $event->object;
+    $params = $event->params;
+    if (empty($params['id']) && substr($params['name'], -4) == '_tmp') {
+      $group->name = substr($group->name, 0, -4) . "_{$group->id}";
+    }
+    // in order to avoid race condition passing $hook = FALSE
+    $group->save(FALSE);
+
+
+    // Process group nesting
+    // first deal with removed parents
+    if (array_key_exists('parents', $params) && !empty($params['current_parents'])) {
+      foreach ($params['current_parents'] as $parentGroupId) {
+        // no more parents or not in the new list, let's remove
+        if (empty($params['parents']) || !in_array($parentGroupId, $params['parents'])) {
+          CRM_Contact_BAO_GroupNesting::remove($parentGroupId, $params['id']);
+        }
+      }
+    }
+
+    // then add missing parents
+    if (!CRM_Utils_System::isNull($params['parents'])) {
+      foreach ($params['parents'] as $parentId) {
+        if ($parentId && !CRM_Contact_BAO_GroupNesting::isParentChild($parentId, $group->id)) {
+          CRM_Contact_BAO_GroupNesting::add($parentId, $group->id);
+        }
+      }
+    }
+
+    // refresh cache if parents param was provided
+    if (array_key_exists('parents', $params) || !empty($params['parents'])) {
+     CRM_Contact_BAO_GroupNestingCache::update();
+    }
+
+    // update group contact cache for all parent groups
+    $parentIds = CRM_Contact_BAO_GroupNesting::getParentGroupIds($group->id);
+    foreach ($parentIds as $parentId) {
+      CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache($parentId);
+    }
+
+    if (!empty($params['organization_id'])) {
+      if ($params['organization_id'] == 'null') {
+        $groupOrganization = [];
+        CRM_Contact_BAO_GroupOrganization::retrieve($group->id, $groupOrganization);
+        if (!empty($groupOrganization['group_organization'])) {
+          CRM_Contact_BAO_GroupOrganization::deleteGroupOrganization($groupOrganization['group_organization']);
+        }
+      }
+      else {
+        // dev/core#382 Keeping the id here can cause db errors as it tries to update the wrong record in the Organization table
+        $groupOrg = [
+          'group_id' => $group->id,
+          'organization_id' => $params['organization_id'],
+        ];
+        CRM_Contact_BAO_GroupOrganization::add($groupOrg);
+      }
+    }
+
+    self::flushCaches();
+    CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache($group->id);
+
+    $recentOther = [];
+    if (CRM_Core_Permission::check('edit groups')) {
+      $recentOther['editUrl'] = CRM_Utils_System::url('civicrm/group/edit', 'reset=1&action=update&id=' . $group->id);
+      // currently same permission we are using for delete a group
+      $recentOther['deleteUrl'] = CRM_Utils_System::url('civicrm/group/edit', 'reset=1&action=delete&id=' . $group->id);
+    }
+
+    // add the recently added group (unless hidden: CRM-6432)
+    if (!$group->is_hidden) {
+      CRM_Utils_Recent::add($group->title,
+        CRM_Utils_System::url('civicrm/group/search', 'reset=1&force=1&context=smog&gid=' . $group->id),
+        $group->id,
+        'Group',
+        NULL,
+        NULL,
+        $recentOther
+      );
+    }
+  }
+
+  /**
+   * Callback for hook_civicrm_pre().
+   * @param \Civi\Core\Event\PreEvent $event
+   * @throws CRM_Core_Exception
+   */
+  public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event): void {
+    if (in_array($event->action, ['create', 'edit'])) {
+      // convert params if array type
+      if (!CRM_Utils_System::isNull($event->params['group_type']) || is_array($event->params['group_type'])) {
+        $event->params['group_type'] = CRM_Utils_Array::convertCheckboxFormatToArray((array) $event->params['group_type']);
+      }
+
+      $cid = CRM_Core_Session::singleton()->get('userID');
+
+      // CRM-19068.
+      // Validate parents parameter when creating group.
+      if (!CRM_Utils_System::isNull($event->params['parents'])) {
+        $parents = is_array($event->params['parents']) ? array_keys($event->params['parents']) : (array) $event->params['parents'];
+        foreach ($parents as $parent) {
+          CRM_Utils_Type::validate($parent, 'Integer');
+        }
+      }
+
+      $event->params += [
+        'group_type' => NULL,
+        'parents' => NULL,
+      ];
+    }
+
+    if ($event->action === 'create') {
+      if (empty($event->params['title'])) {
+        $event->params['title'] = $event->params['frontend_title'] ?? $event->params['name'];
+      }
+      if (empty($event->params['frontend_title'])) {
+        $event->params['frontend_title'] = $event->params['title'] ?? $event->params['name'];
+      }
+
+      // form the name only if missing: CRM-627
+      // If we were calling writeRecord it would handle this, but we need
+      // to migrate the other bits of magic.
+      if (empty($event->params['name']) && !empty($event->params['title'])) {
+        $event->params['name'] = CRM_Utils_String::titleToVar($event->params['title']) . "_tmp";
+      }
+
+      // this action is add
+      if ($cid) {
+        $event->params['created_id'] = $cid;
+      }
+    }
+    elseif ($event->action === 'edit') {
+      if ($cid) {
+        $event->params['modified_id'] = $cid;
+      }
+
+      // If title isn't specified, retrieve it because we use it later, e.g.
+      // for RecentItems. But note we use array_key_exists not isset or empty
+      // since otherwise there would be no way to blank out an existing title.
+      // I'm not sure what the use-case is for that, but you're allowed to do it
+      // currently.
+      if (!array_key_exists('title', $event->params)) {
+        try {
+          $event->params['title'] = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Group', $event->params['id'], 'title', 'id');
+        }
+        catch (CRM_Core_Exception $groupTitleException) {
+          // don't set title
+        }
+      }
+
+      // dev/core#287 Disable child groups if all parents are disabled.
+      $allChildGroupIds = self::getChildGroupIds($event->params['id']);
+      foreach ($allChildGroupIds as $childKey => $childValue) {
+        $parentIds = CRM_Contact_BAO_GroupNesting::getParentGroupIds($childValue);
+        $activeParentsCount = civicrm_api3('Group', 'getcount', [
+          'id' => ['IN' => $parentIds],
+          'is_active' => 1,
+        ]);
+        if (count($parentIds) >= 1 && $activeParentsCount <= 1) {
+          self::setIsActive($childValue, (int) ($event->params['is_active'] ?? 1));
+        }
+      }
+
+      // get current parents for removal if not in the list anymore
+      $parents = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Group', $event->params['id'], 'parents');
+      if (!empty($parents)) {
+        $event->params['current_parents'] = $parents ? explode(',', $parents) : [];
+      }
+
+      if (!empty($event->params['parents'])) {
+        $event->params['parents'] = CRM_Utils_Array::convertCheckboxFormatToArray((array) $event->params['parents']);
+        // failsafe: forbid adding itself as parent
+        if (($key = array_search($$event->params['id'], $event->params['parents'])) !== FALSE) {
+          unset($event->params['parents'][$key]);
+        }
       }
     }
   }

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1237,7 +1237,7 @@ WHERE {$whereClause}";
    * @return int
    */
   public static function filterActiveGroups($parentArray) {
-    if (count($parentArray) > 1) {
+    if (count($parentArray) >= 1) {
       $result = civicrm_api3('Group', 'get', [
         'id' => ['IN' => $parentArray],
         'is_active' => TRUE,
@@ -1287,7 +1287,7 @@ WHERE {$whereClause}";
     $group = $event->object;
     if (in_array($event->action, ['create', 'edit'])) {
       $params = $event->params;
-      if (empty($params['id']) && !empty($params['name']) && substr($params['name'], -4) == '_tmp') {
+      if ($params['name_empty']) {
         $group->name = substr($group->name, 0, -4) . "_{$group->id}";
 
         // in order to avoid race condition passing $hook = FALSE
@@ -1376,6 +1376,7 @@ WHERE {$whereClause}";
     if (in_array($event->action, ['create', 'edit'])) {
       $event->params += [
         'parents_param_provided' => array_key_exists('parents', $event->params),
+        'name_empty' => ($event->action == 'create' && empty($event->params['name'])),
         'group_type' => NULL,
         'parents' => NULL,
       ];

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -459,7 +459,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
           'group_type' => ['2' => 1],
         ];
 
-        $group = CRM_Contact_BAO_Group::create($groupParams);
+        $group = CRM_Contact_BAO_Group::writeRecord($groupParams);
         $grpID = $group->id;
 
         CRM_Contact_BAO_GroupContact::addContactsToGroup($this->_contactIds, $group->id);
@@ -471,7 +471,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
           'title' => $newGroupTitle,
           'group_type' => ['2' => 1],
         ];
-        CRM_Contact_BAO_Group::create($groupParams);
+        CRM_Contact_BAO_Group::writeRecord($groupParams);
       }
 
       // note at this point its a static group

--- a/CRM/Contact/Form/Task/AddToGroup.php
+++ b/CRM/Contact/Form/Task/AddToGroup.php
@@ -191,7 +191,7 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
       $groupParams['is_active'] = 1;
       $groupParams['custom'] = CRM_Core_BAO_CustomField::postProcess($this->getSubmittedValues(), $this->_id, 'Group');
 
-      $createdGroup = CRM_Contact_BAO_Group::create($groupParams);
+      $createdGroup = CRM_Contact_BAO_Group::writeRecord($groupParams);
       $groupID = $createdGroup->id;
       $groupName = $groupParams['title'];
     }

--- a/CRM/Contact/Form/Task/SaveSearch.php
+++ b/CRM/Contact/Form/Task/SaveSearch.php
@@ -216,7 +216,7 @@ class CRM_Contact_Form_Task_SaveSearch extends CRM_Contact_Form_Task {
 
     $params['custom'] = CRM_Core_BAO_CustomField::postProcess($this->getSubmittedValues(), $this->_id, 'Group');
 
-    $group = CRM_Contact_BAO_Group::create($params);
+    $group = CRM_Contact_BAO_Group::writeRecord($params);
 
     // Update mapping with the name and description of the group.
     if ($mappingId && $group) {

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1045,9 +1045,10 @@ class CRM_Core_DAO extends DB_DataObject {
       return $value === 'null' ? '' : $value;
     }, $record);
 
-    self::addDefaultFallbackValues($entityName, $record);
-
     \CRM_Utils_Hook::pre($op, $entityName, $record[$idField] ?? NULL, $record);
+
+    //Reason to call after pre hook is to accept any label/title/frontend_title modification
+    self::addDefaultFallbackValues($entityName, $record);
     $fields = static::getSupportedFields();
     $instance = new static();
     // Ensure fields exist before attempting to write to them

--- a/CRM/Event/Form/Task/AddToGroup.php
+++ b/CRM/Event/Form/Task/AddToGroup.php
@@ -203,7 +203,7 @@ class CRM_Event_Form_Task_AddToGroup extends CRM_Event_Form_Task {
       }
       $groupParams['is_active'] = 1;
 
-      $createdGroup = CRM_Contact_BAO_Group::create($groupParams);
+      $createdGroup = CRM_Contact_BAO_Group::writeRecord($groupParams);
       $groupID = $createdGroup->id;
       $groupName = $groupParams['title'];
     }

--- a/CRM/Event/Form/Task/SaveSearch.php
+++ b/CRM/Event/Form/Task/SaveSearch.php
@@ -116,7 +116,7 @@ class CRM_Event_Form_Task_SaveSearch extends CRM_Event_Form_Task {
     if ($this->_id) {
       $params['id'] = CRM_Contact_BAO_SavedSearch::getName($this->_id, 'id');
     }
-    $group = CRM_Contact_BAO_Group::create($params);
+    $group = CRM_Contact_BAO_Group::writeRecord($params);
   }
 
 }

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -332,7 +332,7 @@ WHERE  title = %1
         $params['organization_id'] = empty($params['organization_id']) ? 'null' : $params['organization_id'];
       }
 
-      $group = CRM_Contact_BAO_Group::create($params);
+      $group = CRM_Contact_BAO_Group::writeRecord($params);
       // Set the entity id so it is available to postProcess hook consumers
       $this->setEntityId($group->id);
 

--- a/schema/Contact/Group.entityType.php
+++ b/schema/Contact/Group.entityType.php
@@ -72,6 +72,7 @@ return [
       'sql_type' => 'varchar(255)',
       'input_type' => 'Text',
       'required' => TRUE,
+      'default_fallback' => ['frontend_title', 'name'],
       'localizable' => TRUE,
       'description' => ts('Name of Group.'),
       'add' => '1.1',

--- a/tests/phpunit/CRM/Contact/BAO/GroupContactCacheTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupContactCacheTest.php
@@ -498,7 +498,7 @@ class CRM_Contact_BAO_GroupContactCacheTest extends CiviUnitTestCase {
     $ssParams = ['form_values' => $params['formValues'], 'is_active' => 1];
     $savedSearch = CRM_Contact_BAO_SavedSearch::create($ssParams);
     $params['saved_search_id'] = $savedSearch->id;
-    return CRM_Contact_BAO_Group::create($params);
+    return CRM_Contact_BAO_Group::writeRecord($params);
   }
 
 }

--- a/tests/phpunit/CRM/Contact/BAO/GroupTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupTest.php
@@ -42,7 +42,7 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
       'is_active' => 1,
     ];
 
-    $group = CRM_Contact_BAO_Group::create($params);
+    $group = CRM_Contact_BAO_Group::writeRecord($params);
 
     $this->assertDBCompareValues(
       'CRM_Contact_DAO_Group',
@@ -67,7 +67,7 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
       'visibility' => 'User and User Admin Only',
       'is_active' => 1,
     ];
-    $group1 = CRM_Contact_BAO_Group::create($params);
+    $group1 = CRM_Contact_BAO_Group::writeRecord($params);
 
     $params = array_merge($params, [
       'name' => 'parent group b',
@@ -76,7 +76,7 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
       // disable
       'is_active' => 0,
     ]);
-    $group2 = CRM_Contact_BAO_Group::create($params);
+    $group2 = CRM_Contact_BAO_Group::writeRecord($params);
 
     $params = array_merge($params, [
       'name' => 'parent group c',
@@ -87,7 +87,7 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
         $group2->id => 1,
       ],
     ]);
-    $group3 = CRM_Contact_BAO_Group::create($params);
+    $group3 = CRM_Contact_BAO_Group::writeRecord($params);
 
     $params = [
       $group1->id => 1,
@@ -117,7 +117,7 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
       // mailing group
       'group_type' => ['2' => 1],
     ];
-    $group1 = CRM_Contact_BAO_Group::create($params);
+    $group1 = CRM_Contact_BAO_Group::writeRecord($params);
 
     $params = [
       'name' => 'group b',
@@ -126,7 +126,7 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
       'visibility' => 'User and User Admin Only',
       'is_active' => 1,
     ];
-    $group2 = CRM_Contact_BAO_Group::create($params);
+    $group2 = CRM_Contact_BAO_Group::writeRecord($params);
 
     $params = [
       'name' => 'group c',
@@ -139,7 +139,7 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
       ],
       'group_type' => ['2' => 1],
     ];
-    $group3 = CRM_Contact_BAO_Group::create($params);
+    $group3 = CRM_Contact_BAO_Group::writeRecord($params);
 
     unset(Civi::$statics['CRM_Core_Permission_Base']);
     // Check with no group type restriction
@@ -269,7 +269,7 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
       'visibility' => 'User and User Admin Only',
       'is_active' => 1,
     ];
-    $group1 = CRM_Contact_BAO_Group::create($params);
+    $group1 = CRM_Contact_BAO_Group::writeRecord($params);
 
     $domain1 = $this->callAPISuccess('Domain', 'get', ['id' => 1]);
     $params2 = [
@@ -280,7 +280,7 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
       'is_active' => 1,
       'organization_id' => $domain1['values'][1]['contact_id'],
     ];
-    $group2 = CRM_Contact_BAO_Group::create($params2);
+    $group2 = CRM_Contact_BAO_Group::writeRecord($params2);
 
     $domain2 = $this->callAPISuccess('Domain', 'get', ['id' => 2]);
     $params3 = [
@@ -291,9 +291,9 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
       'is_active' => 1,
       'organization_id' => $domain2['values'][2]['contact_id'],
     ];
-    $group3 = CRM_Contact_BAO_Group::create($params3);
+    $group3 = CRM_Contact_BAO_Group::writeRecord($params3);
     $params2['id'] = $group2->id;
-    $testUpdate = CRM_Contact_BAO_Group::create($params2);
+    $testUpdate = CRM_Contact_BAO_Group::writeRecord($params2);
   }
 
   /**
@@ -346,14 +346,14 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
       'visibility' => 'User and User Admin Only',
       'is_active' => 1,
     ];
-    $group = CRM_Contact_BAO_Group::create($params);
+    $group = CRM_Contact_BAO_Group::writeRecord($params);
 
     // Update the group with just id and description.
     $newParams = [
       'id' => $group->id,
       'description' => 'The first group',
     ];
-    CRM_Contact_BAO_Group::create($newParams);
+    CRM_Contact_BAO_Group::writeRecord($newParams);
 
     // Check it against original array, except description.
     $result = $this->callAPISuccess('Group', 'getsingle', ['id' => $group->id]);

--- a/tests/phpunit/CRM/Mailing/MultilingualSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/MultilingualSystemTest.php
@@ -124,10 +124,17 @@ class CRM_Mailing_MultilingualSystemTest extends CiviUnitTestCase {
     }
 
     // Because our parent class marks the _groupID as private, we can't use that :-(
-    $group_1 = $this->groupCreate([
-      'name' => 'Test Group 1108.1',
+    $group_1 = $this->createTestEntity('Group', [
       'title' => 'Test Group 1108.1',
-    ]);
+      'frontend_title' => 'Public group name',
+      'description' => 'New Test Group Created',
+      'is_active' => 1,
+      'visibility' => 'Public Pages',
+      'group_type' => [
+        '1' => 1,
+        '2' => 1,
+      ],
+    ], 'group')['id'];
     $this->createContactsInGroup(2, $group_1);
 
     // Also _mut is private to the parent, so we have to make our own:
@@ -153,11 +160,17 @@ class CRM_Mailing_MultilingualSystemTest extends CiviUnitTestCase {
     $this->assertEquals(2, count($allMessages));
 
     // We need a new group
-    $group_2 = $this->groupCreate([
-      'name'  => 'Test Group 1108.2',
+    $group_2 = $this->createTestEntity('Group', [
       'title' => 'Test Group 1108.2',
-    ]);
-
+      'frontend_title' => 'Public group name',
+      'description' => 'New Test Group Created',
+      'is_active' => 1,
+      'visibility' => 'Public Pages',
+      'group_type' => [
+        '1' => 1,
+        '2' => 1,
+      ],
+    ], 'group')['id'];
     // Now create the 2nd mailing to the recipients of the first,
     // excluding our new albeit empty group.
     $mailingParams = [
@@ -188,10 +201,17 @@ class CRM_Mailing_MultilingualSystemTest extends CiviUnitTestCase {
     ));
 
     // Create a group that has nothing to do with this mailing.
-    $group_3 = $this->groupCreate([
-      'name' => 'Test Group 1108.3',
+    $group_3 = $this->createTestEntity('Group', [
       'title' => 'Test Group 1108.3',
-    ]);
+      'frontend_title' => 'Public group name',
+      'description' => 'New Test Group Created',
+      'is_active' => 1,
+      'visibility' => 'Public Pages',
+      'group_type' => [
+        '1' => 1,
+        '2' => 1,
+      ],
+    ], 'group')['id'];
     // Add contacts from group 1 to group 3.
     $gcQuery = new CRM_Contact_BAO_GroupContact();
     $gcQuery->group_id = $group_1;

--- a/tests/phpunit/api/v4/Entity/GroupTest.php
+++ b/tests/phpunit/api/v4/Entity/GroupTest.php
@@ -31,8 +31,8 @@ class GroupTest extends Api4TestBase {
   public function testGetFields(): void {
     $fields = Group::getFields(FALSE)
       ->execute()->indexBy('name');
-
-    $this->assertTrue($fields['title']['required']);
+    $this->assertFalse($fields['title']['required']);
+    $this->assertSame('empty($values.frontend_title) && empty($values.name)', $fields['title']['required_if']);
     $this->assertFalse($fields['frontend_title']['required']);
     $this->assertSame('empty($values.title)', $fields['frontend_title']['required_if']);
   }


### PR DESCRIPTION
Overview
----------------------------------------
In order to keep BAO CRUD fns cleaner and central to,  this patch move all the Create logics (that includes updating related entities, defaulting columns like frontend_title, name etc, rebuilding cache if parent groups are added/updated etc. ) onto pre and post hook. And so that we can avoid using deprecated CRM_Contact_BAO_Group::create and use DAO::writeRecord instead. 

Before
----------------------------------------
`CRM_Contact_BAO_Group::create` with additional logics before and after writing record. 

After
----------------------------------------
Move all the additional logics on to pre/post hook and call `writeRecord` for ...... obviously writing record only. 


Comments
----------------------------------------
ping @colemanw @eileenmcnaughton @seamuslee001 