### PR TITLE
AllCoreTables - allow multiple entities per table when filtering out …

### DIFF
--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -44,11 +44,9 @@ class CRM_Core_DAO_AllCoreTables {
    */
   public static function getEntities(): array {
     $allEntities = EntityRepository::getEntities();
-    // Filter out entities without a table
-    $tables = EntityRepository::getTableIndex();
-    // Filter out entities without a class
-    $classes = EntityRepository::getClassIndex();
-    return array_intersect_key($allEntities, array_flip($tables), array_flip($classes));
+    // Filter out entities without a table or class
+
+    return array_filter($allEntities, fn($entity) => (!empty($entity['table']) && !empty($entity['class'])));
   }
 
   /**


### PR DESCRIPTION
…tableless entities.

Overview
--------------------------------------
Fix Standalone crash since https://github.com/civicrm/civicrm-core/commit/d3e1ce86fb40494c2f8381c76ce3d6685c5232ac

Before
----------------------------------------
- Standalone crashes, because UFMatch gets filtered from the entities in this function, because it's not included in the tableIndex, because User has taken its place.

After
----------------------------------------
- Standalone works again
- Possible performance impact?

Technical Details
----------------------------------------
It looks like there are a few functions around `EntityRepository` / `AllCoreTables` that look like they assume you can do a map from table to entity. Maybe they aren't needed in the long run?

A similar situation might arise with Individual/Household/Organisation in `civicrm_contact` .