### PR TITLE
dev/core#5457 FormBuilder: afform recaptcha2 error on submit

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -562,6 +562,12 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
           $idData['joins'] = $this->combineValuesAndIds($val['joins'] ?? [], $idData['joins'] ?? [], TRUE);
         }
         // $item = array_merge($isJoin ? $val : ($val['fields'] ?? []), $idData);
+        // if (!is_array($val) && !is_null($val)) {
+        //   $val = [$val];
+        // }
+        if ($idx === "recaptcha2") {
+          $val = [$val];
+        }
         $item = array_merge(($val ?? []), $idData);
         $combined[$name][$idx] = $item;
       }


### PR DESCRIPTION
Overview
----------------------------------------
_Afform with recaptcha triggers an error as the value is string and not array._

 https://lab.civicrm.org/dev/core/-/issues/5457

Before
----------------------------------------
_Recaptcha2 value in `AbstractProcessor->combineValuesAndIds(...)` is string and could not be merged into an array._
```
PHP Fatal error:  Uncaught TypeError: array_merge(): Argument #1 must be of type array, string given in .../.../wp-content/plugins/civicrm/civicrm/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php:435.
Stack trace:
#0 .../.../wp-content/plugins/civicrm/civicrm/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php(435): array_merge('03AFcWeA6NwbyYH...', Array)
```

```
{
  "extra": {
    "recaptcha2": "03AFcWeA6iydaMQiDluT..." -> this is a long string
  },
  "Individual1": [
    {
      "fields": {
        "first_name": "Copper",
        "last_name": "Field"
      },
      "joins": {
        "Address": [
          {
            "location_type_id": 0,
            "country_id": 0,
            "street_address": "Test Address1",
            "city": "...",
            "state_province_id": "...",
            "postal_code": "..."
          }
        ]
      }
    }
  ],
  "Activity1": [
    {
      "fields": {
        "details": "<p>Test<\/p>"
      }
    }
  ]
}

```

After
----------------------------------------
_Wrap into array._

Technical Details
----------------------------------------
* __Browser:__ _Firefox 130.0_
* __CiviCRM:__ _5.77.0_
* __PHP:__ _8.3.10_
* __CMS:__ _WordPress 6.6.2_

Comments
----------------------------------------
_The commit includes commented alternate solution. As I am not sure if there will be other fields that could have a string value instead._
