### PR TITLE
Standalone login screen: tidies padding, input height, label margin, fixes duplicate semi-colon

### DIFF
--- a/ext/standaloneusers/css/standalone.css
+++ b/ext/standaloneusers/css/standalone.css
@@ -19,7 +19,7 @@ html.crm-standalone  nav.breadcrumb>ol {
   background-color: white;
   border: none;
   border-radius: 3px;
-  padding: 1rem 3vw;;
+  padding: 2rem;
 }
 .standalone-auth-form img.crm-logo {
   width: 100%;
@@ -32,10 +32,13 @@ html.crm-standalone  nav.breadcrumb>ol {
 }
 .standalone-auth-form label {
   display: block;
+  margin-bottom: 0.25rem;
 }
 .standalone-auth-form input {
   box-sizing: border-box;
   width: 100%;
+  height: 2rem;
+  padding: 0.5rem;
 }
 .standalone-auth-form .login-or-forgot {
   display: grid;


### PR DESCRIPTION
Overview
----------------------------------------
This login screen was originally created a long time ago on a laptop during the Antwerp sprint, and the '3vw' unit for padding the login box looks odd at large & small screens. Have swapped that for something normal, and while at it made the input box and label bottom margin (which looks worse on some themes) a tiny bit easier on the eye. Also removed a duplicate semi-colon.

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/79c35544-d56d-433b-a2dd-9cc6ae876868)

After
----------------------------------------
![image](https://github.com/user-attachments/assets/4142b159-61af-4596-b581-91c0c7f9590b)

Technical Details
----------------------------------------
Have tested this against default Greenwich, and with RiverLea: Minetta, Walbank and Hackney. 

Comment
----------------------------------------
This is a purely visual change, no functional changes.
