### PR TITLE
dev/core#5459 - Fix one of the bad timestamp columns from the schema changes

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSeventyEight.php
+++ b/CRM/Upgrade/Incremental/php/FiveSeventyEight.php
@@ -52,4 +52,14 @@ class CRM_Upgrade_Incremental_php_FiveSeventyEight extends CRM_Upgrade_Increment
     }
   }
 
+  /**
+   * Upgrade step; adds tasks including 'runSql'.
+   *
+   * @param string $rev
+   *   The version number matching this function name
+   */
+  public function upgrade_5_78_beta1($rev): void {
+    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+  }
+
 }

--- a/CRM/Upgrade/Incremental/sql/5.78.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.78.beta1.mysql.tpl
@@ -1,0 +1,5 @@
+UPDATE `civicrm_job_log` jl
+  LEFT JOIN `civicrm_job` j ON j.id = jl.job_id
+  SET jl.`run_time` = COALESCE(j.`last_run_end`, j.`last_run`, current_timestamp())
+  WHERE jl.`run_time` IS NULL;
+ALTER TABLE `civicrm_job_log` MODIFY COLUMN `run_time` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp() COMMENT 'Log entry date';

--- a/schema/Core/JobLog.entityType.php
+++ b/schema/Core/JobLog.entityType.php
@@ -47,6 +47,8 @@ return [
       'sql_type' => 'timestamp',
       'input_type' => NULL,
       'description' => ts('Log entry date'),
+      'required' => TRUE,
+      'default' => 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
       'add' => '4.1',
     ],
     'job_id' => [


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5459

Before
----------------------------------------
civicrm_job_log.run_time gets created wrong => times when viewing the job log are all blank.

After
----------------------------------------
right definition, although the filling of the null column is not precise, but I need to fill it with something before changing to not null. I don't know that it's worth the effort to try to figure out an algorithm to match the right times for the start of a job and the end of a job, given that it's been displaying blank for both.

Technical Details
----------------------------------------
mysql timestamps are whack
It used to rely on the fact that if you don't specify anything, the first timestamp column is autocreated as not null default current_timestamp. Now you have to specify because of changes in how the schema is generated.

Comments
----------------------------------------
Backport to 5.77 will need the usual trickiness since 5.77.1 doesn't exist yet so the upgrade script there will fail tests

There are more timestamp columns broken like this. If people agree with this approach I'll put up another PR for those.