### PR TITLE
EntityMetadata - Add ACL checks to getOptions

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -3293,23 +3293,21 @@ SELECT contact_id
    *
    * With acls from related entities + additional clauses from hook_civicrm_selectWhereClause
    *
-   * DO NOT OVERRIDE THIS FUNCTION
-   *
-   * @TODO: ADD `final` keyword to function signature
-   *
    * @param string|null $tableAlias
    * @param string|null $entityName
    * @param array $conditions
    *   Values from WHERE or ON clause
-   * @return array
+   * @param int|null $userId
+   *
+   * @return string[]
    */
-  public static function getSelectWhereClause($tableAlias = NULL, $entityName = NULL, $conditions = []) {
+  final public static function getSelectWhereClause(?string $tableAlias = NULL, ?string $entityName = NULL, array $conditions = [], ?int $userId = NULL) {
     $bao = new static();
     $tableAlias ??= $bao->tableName();
     $entityName ??= CRM_Core_DAO_AllCoreTables::getEntityNameForClass(get_class($bao));
     $finalClauses = [];
     $fields = static::getSupportedFields();
-    $selectWhereClauses = $bao->addSelectWhereClause($entityName, NULL, $conditions);
+    $selectWhereClauses = $bao->addSelectWhereClause($entityName, $userId, $conditions);
     foreach ($selectWhereClauses as $fieldName => $fieldClauses) {
       $finalClauses[$fieldName] = NULL;
       if ($fieldClauses) {

--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -53,10 +53,13 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
     ];
     $field['pseudoconstant']['condition'] = (array) ($field['pseudoconstant']['condition'] ?? []);
     if (!empty($field['pseudoconstant']['condition_provider'])) {
-      $this->getConditionFromProvider($fieldName, $field, $hookParams);
+      $this->addOptionConditionsFromProvider($fieldName, $field, $hookParams);
+    }
+    if ($checkPermissions && !empty($field['pseudoconstant']['table'])) {
+      $this->addOptionConditionsFromACL($field, $userId);
     }
     if (!empty($field['pseudoconstant']['option_group_name'])) {
-      $this->getOptionGroupParams($field);
+      $this->addOptionGroupParams($field);
     }
     if (!empty($field['pseudoconstant']['callback'])) {
       $callbackValues = call_user_func(Resolver::singleton()->get($field['pseudoconstant']['callback']), $fieldName, $hookParams);
@@ -78,7 +81,21 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
     return isset($options) ? array_values($options) : NULL;
   }
 
-  private function getConditionFromProvider(string $fieldName, array &$field, array $hookParams) {
+  private function addOptionConditionsFromACL(array &$field, ?int $userId): void {
+    $entity = \Civi::table($field['pseudoconstant']['table']);
+    $dao = $entity->getMeta('class');
+    if ($dao) {
+      $bao = \CRM_Core_DAO_AllCoreTables::getBAOClassName($dao);
+      $conditions = $bao::getSelectWhereClause($field['pseudoconstant']['table'], $entity->getMeta('name'), [], $userId);
+      foreach ($conditions as $condition) {
+        if ($condition) {
+          $field['pseudoconstant']['condition'][] = $condition;
+        }
+      }
+    }
+  }
+
+  private function addOptionConditionsFromProvider(string $fieldName, array &$field, array $hookParams) {
     $fragment = \CRM_Utils_SQL_Select::fragment();
     $callback = Resolver::singleton()->get($field['pseudoconstant']['condition_provider']);
     $callback($fieldName, $fragment, $hookParams);
@@ -88,7 +105,7 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
     unset($field['pseudoconstant']['condition_provider']);
   }
 
-  private function getOptionGroupParams(array &$field) {
+  private function addOptionGroupParams(array &$field) {
     $groupName = $field['pseudoconstant']['option_group_name'];
     $groupId = (int) \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', $groupName, 'id', 'name');
 

--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -158,8 +158,10 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
       $options = [];
       $fields = $entity->getFields();
       $select = \CRM_Utils_SQL_Select::from($pseudoconstant['table']);
+      // Ensure key_column, name_column and label_column are set
       $idCol = $pseudoconstant['key_column'] ?? $entity->getMeta('primary_key');
       $pseudoconstant['name_column'] ??= (isset($fields['name']) ? 'name' : $idCol);
+      $pseudoconstant['label_column'] ??= $pseudoconstant['name_column'];
       $select->select(["$idCol AS id"]);
       foreach (\Civi\Api4\Utils\FormattingUtil::$pseudoConstantSuffixes as $prop) {
         if (!empty($pseudoconstant["{$prop}_column"])) {

--- a/tests/phpunit/Civi/Entity/GetOptionsTest.php
+++ b/tests/phpunit/Civi/Entity/GetOptionsTest.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Entity;
+
+use Civi\Core\HookInterface;
+use Civi\Test\Api4TestTrait;
+use Civi\Test\HeadlessInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test the core Entity->getOptions functionality
+ * @group headless
+ */
+class GetOptionsTest extends TestCase implements HeadlessInterface, HookInterface {
+
+  use Api4TestTrait;
+
+  protected static $hookEntity;
+  protected static $hookCondition = [];
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->apply();
+  }
+
+  public function setUp(): void {
+    parent::setUp();
+    self::$hookEntity = NULL;
+    self::$hookCondition = [];
+  }
+
+  public function testAclHookOptions(): void {
+    $this->saveTestRecords('LocationType', [
+      'records' => [['name' => 'Restricted']],
+      'match' => ['name'],
+    ]);
+
+    $address = \Civi::entity('Address');
+
+    // Get options with permission check
+    $locationTypes = array_column($address->getOptions('location_type_id', [], TRUE, TRUE), 'name');
+    $this->assertContains('Restricted', $locationTypes);
+
+    // Add ACL restriction
+    self::$hookEntity = 'LocationType';
+    self::$hookCondition = [
+      'name' => ['!= "Restricted"'],
+    ];
+
+    // Get options with permission check
+    $locationTypes = array_column($address->getOptions('location_type_id', [], TRUE, TRUE), 'name');
+    $this->assertNotContains('Restricted', $locationTypes);
+
+    // Get options without permission check
+    $locationTypes = array_column($address->getOptions('location_type_id'), 'name');
+    $this->assertContains('Restricted', $locationTypes);
+  }
+
+  /**
+   * @implements \CRM_Utils_Hook::selectWhereClause()
+   */
+  public static function hook_civicrm_selectWhereClause($entity, &$clauses) {
+    if ($entity == self::$hookEntity) {
+      foreach (self::$hookCondition as $field => $clause) {
+        $clauses[$field] = array_merge(($clauses[$field] ?? []), $clause);
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This builds on #30986 with more consistent permission enforcement.

Before
----------------------------------------
Traditionally, `CRM_Core_PseudoConstant` was pretty inconsistent about checking permissions & enforcing ACLs.

After
----------------------------------------
The new core `Entity->getOptions` consistently and predictably enforces ACLs when `$checkPermissions` is true.