### PR TITLE
Display Preferences screen - use settings metadata as much as possible

### DIFF
--- a/CRM/Admin/Form/Preferences/Display.php
+++ b/CRM/Admin/Form/Preferences/Display.php
@@ -20,26 +20,7 @@
  */
 class CRM_Admin_Form_Preferences_Display extends CRM_Admin_Form_Preferences {
 
-  protected $_settings = [
-    'contact_view_options' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'contact_smart_group_display' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'contact_edit_options' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'advanced_search_options' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'user_dashboard_options' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'contact_ajax_check_similar' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'activity_assignee_notification' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'activity_assignee_notification_ics' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'do_not_notify_assignees_for' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'preserve_activity_tab_filter' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'editor_id' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'ajaxPopupsEnabled' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'display_name_format' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'sort_name_format' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'menubar_position' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'menubar_color' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'theme_backend' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'theme_frontend' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-  ];
+  protected array $_settings;
 
   /**
    * Build the form object.

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -1195,10 +1195,10 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => ts('Theme to use on frontend pages'),
-    'help_text' => ts('
-        The theme system allows you to change CiviCRM\'s appearance by replacing important CSS files.
-        On WordPress, Joomla, or a similar CMS, the frontend theme determines the appearance on user-facing screens, such as the "Event Registration" screen.
-    '),
+    'help_text' => implode('\n', [
+      ts('The theme system allows you to change CiviCRM\'s appearance by replacing important CSS files.'),
+      ts('On WordPress, Joomla, or a similar CMS, the frontend theme determines the appearance on user-facing screens, such as the "Event Registration" screen.'),
+    ]),
     'settings_pages' => ['display' => ['weight' => 920]],
   ],
   'theme_backend' => [
@@ -1220,10 +1220,10 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => ts('Theme to use on backend pages'),
-    'help_text' => ts('
-        The theme system allows you to change CiviCRM\'s appearance by replacing important CSS files.
-        The backend theme determines the appearance on administrative screens, such as the "Manage Event" screen.
-    '),
+    'help_text' => implode('\n', [
+      ts('The theme system allows you to change CiviCRM\'s appearance by replacing important CSS files.'),
+      ts('The backend theme determines the appearance on administrative screens, such as the "Manage Event" screen.'),
+    ]),
     'settings_pages' => ['display' => ['weight' => 900]],
   ],
   'http_timeout' => [

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -36,6 +36,7 @@ return [
     'description' => ts("Select the tabs that should be displayed when viewing a contact record. EXAMPLE: If your organization does not keep track of 'Relationships', then un-check this option to simplify the screen display. Tabs for Contributions, Pledges, Memberships, Events, Grants and Cases are also hidden if the corresponding component is not enabled. Go to Administer > System Settings > Enable Components to modify the components which are available for your site."),
     'help_text' => NULL,
     'serialize' => CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
+    'settings_pages' => ['display' => ['weight' => 100]],
   ],
   'contact_edit_options' => [
     'group_name' => 'CiviCRM Preferences',
@@ -54,6 +55,7 @@ return [
     'description' => ts('Select the sections that should be included when adding or editing a contact record. EXAMPLE: If your organization does not record Gender and Birth Date for individuals, then simplify the form by un-checking this option. Drag interface allows you to change the order of the panes displayed on contact add/edit screen.'),
     'help_text' => NULL,
     'serialize' => CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
+    'settings_pages' => ['display' => ['weight' => 140]],
   ],
   'advanced_search_options' => [
     'group_name' => 'CiviCRM Preferences',
@@ -71,6 +73,7 @@ return [
     'is_contact' => 0,
     'description' => ts('Select the sections that should be included in the Basic and Advanced Search forms. EXAMPLE: If you don\'t track Relationships - then you do not need this section included in the advanced search form. Simplify the form by un-checking this option.'),
     'serialize' => CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
+    'settings_pages' => ['display' => ['weight' => 160]],
   ],
   'user_dashboard_options' => [
     'group_name' => 'CiviCRM Preferences',
@@ -89,6 +92,7 @@ return [
     'description' => ts('Select the sections that should be included in the Contact Dashboard. EXAMPLE: If you don\'t want constituents to view their own contribution history, un-check that option.'),
     'help_text' => NULL,
     'serialize' => CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
+    'settings_pages' => ['display' => ['weight' => 420]],
   ],
   'address_options' => [
     'group_name' => 'CiviCRM Preferences',
@@ -148,6 +152,7 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => ts('Display name format for individual contact display names.'),
+    'settings_pages' => ['display' => ['weight' => 700]],
   ],
   'sort_name_format' => [
     'group_name' => 'CiviCRM Preferences',
@@ -161,6 +166,7 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => ts('Sort name format for individual contact display names.'),
+    'settings_pages' => ['display' => ['weight' => 720]],
   ],
   'remote_profile_submissions' => [
     'group_name' => 'CiviCRM Preferences',
@@ -200,7 +206,7 @@ return [
     'html_type' => 'select',
     'default' => 'CKEditor',
     'add' => '4.1',
-    'title' => ts('Wysiwig Editor'),
+    'title' => ts('Wysiwyg Editor'),
     'pseudoconstant' => [
       'optionGroupName' => 'wysiwyg_editor',
       'keyColumn' => 'name',
@@ -208,7 +214,8 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => NULL,
-    'help_text' => NULL,
+    'help_text' => ts('Choose which rich-text editor to use for editing HTML content in CiviCRM.'),
+    'settings_pages' => ['display' => ['weight' => 500]],
   ],
   'contact_ajax_check_similar' => [
     'group_name' => 'CiviCRM Preferences',
@@ -224,6 +231,7 @@ return [
     'description' => NULL,
     'help_text' => NULL,
     'options' => ['1' => ts('While Typing'), '0' => ts('When Saving'), '2' => ts('Never')],
+    'settings_pages' => ['display' => ['weight' => 200]],
   ],
   'ajaxPopupsEnabled' => [
     'group_name' => 'CiviCRM Preferences',
@@ -236,8 +244,9 @@ return [
     'title' => ts('Enable Popup Forms'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => NULL,
+    'description' => ts('If you disable this option, the CiviCRM interface will be limited to traditional browsing. Opening a form will refresh the page rather than opening a popup dialog.'),
     'help_text' => NULL,
+    'settings_pages' => ['display' => ['weight' => 600]],
   ],
   'enableBackgroundQueue' => [
     'group_name' => 'CiviCRM Preferences',
@@ -286,8 +295,9 @@ return [
     'title' => ts('Notify Activity Assignees'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => NULL,
+    'description' => ts('When enabled, contacts who are assigned activities will automatically receive an email notification with a copy of the activity.'),
     'help_text' => NULL,
+    'settings_pages' => ['display' => ['weight' => 300]],
   ],
   'activity_assignee_notification_ics' => [
     'group_name' => 'CiviCRM Preferences',
@@ -300,8 +310,9 @@ return [
     'title' => ts('Include ICal Invite to Activity Assignees'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => NULL,
+    'description' => ts('When enabled, activity assignee notification emails will also include an ical meeting invite.'),
     'help_text' => NULL,
+    'settings_pages' => ['display' => ['weight' => 340]],
   ],
   'contact_autocomplete_options' => [
     'group_name' => 'CiviCRM Preferences',
@@ -359,6 +370,7 @@ return [
     'pseudoconstant' => [
       'optionGroupName' => 'contact_smart_group_display',
     ],
+    'settings_pages' => ['display' => ['weight' => 120]],
   ],
   'smart_group_cache_refresh_mode' => [
     'group_name' => 'CiviCRM Preferences',
@@ -1089,6 +1101,7 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => ts('When enabled, any filter settings a user selects on the contact\'s Activity tab will be remembered as they visit other contacts.'),
+    'settings_pages' => ['display' => ['weight' => 400]],
   ],
   'do_not_notify_assignees_for' => [
     'group_name' => 'CiviCRM Preferences',
@@ -1110,6 +1123,7 @@ return [
       'optionGroupName' => 'activity_type',
     ],
     'quick_form_type' => 'Select',
+    'settings_pages' => ['display' => ['weight' => 320]],
   ],
   'menubar_position' => [
     'group_name' => 'CiviCRM Preferences',
@@ -1130,6 +1144,7 @@ return [
       'above-crm-container' => ts('Above content area'),
       'none' => ts('None - disable menu'),
     ],
+    'settings_pages' => ['display' => ['weight' => 800]],
   ],
   'menubar_color' => [
     'group_name' => 'CiviCRM Preferences',
@@ -1145,6 +1160,7 @@ return [
     'description' => ts('Color of the CiviCRM main menu.'),
     'help_text' => NULL,
     'validate_callback' => 'CRM_Utils_Color::normalize',
+    'settings_pages' => ['display' => ['weight' => 820]],
   ],
   'requestableMimeTypes' => [
     'group_name' => 'CiviCRM Preferences',
@@ -1179,7 +1195,11 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => ts('Theme to use on frontend pages'),
-    'help_text' => NULL,
+    'help_text' => ts('
+        The theme system allows you to change CiviCRM\'s appearance by replacing important CSS files.
+        On WordPress, Joomla, or a similar CMS, the frontend theme determines the appearance on user-facing screens, such as the "Event Registration" screen.
+    '),
+    'settings_pages' => ['display' => ['weight' => 920]],
   ],
   'theme_backend' => [
     'group_name' => 'CiviCRM Preferences',
@@ -1200,7 +1220,11 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => ts('Theme to use on backend pages'),
-    'help_text' => NULL,
+    'help_text' => ts('
+        The theme system allows you to change CiviCRM\'s appearance by replacing important CSS files.
+        The backend theme determines the appearance on administrative screens, such as the "Manage Event" screen.
+    '),
+    'settings_pages' => ['display' => ['weight' => 900]],
   ],
   'http_timeout' => [
     'group_name' => 'CiviCRM Preferences',

--- a/templates/CRM/Admin/Form/Preferences/Display.hlp
+++ b/templates/CRM/Admin/Form/Preferences/Display.hlp
@@ -7,10 +7,10 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{htxt id="editor_id-title"}
+{htxt id="editor-id-id-title"}
   {ts}WYSIWYG Editor{/ts}
 {/htxt}
-{htxt id="editor_id"}
+{htxt id="editor-id-id"}
   <p>
     {ts}A "WYSIWYG" (What You See Is What You Get) is a rich-text editor, like a mini word-processor, for editing HTML content in CiviCRM.{/ts}
   </p>
@@ -25,7 +25,7 @@
   {ts}Invoices / Credit Notes{/ts}
 {/htxt}
 {htxt id="id-invoices_id"}
-  {capture assign=invoiceURL}{crmURL p='civicrm/admin/setting/preferences/contribute' q="reset=1"}{/capture} 
+  {capture assign=invoiceURL}{crmURL p='civicrm/admin/setting/preferences/contribute' q="reset=1"}{/capture}
   {ts 1=$invoiceURL}In order to enable logged in users to download invoices and credit notes from the dashboard, please first enable CiviCRM invoicing functionality <a href='%1'>Administer > CiviContribute > CiviContribute Component Settings</a>{/ts}
 {/htxt}
 
@@ -36,26 +36,11 @@
     {ts}The theme system allows you to change CiviCRM's appearance by replacing important CSS files.{/ts}
   </p>
 {/capture}
-{capture assign=themeAdv}
-  {* TODO: Update when there is a page to link to:
-  <p>
-    {ts 1='http://fixme.example.com'}For more advanced theming options, consult the <a href="%1">theme documentation</a>.{/ts}
-  </p>
-  *}
-{/capture}
 
-{htxt id="theme-title"}
-  {ts}Theme{/ts}
-{/htxt}
-{htxt id="theme"}
-  {$themeDefn}
-  {$themeAdv}
-{/htxt}
-
-{htxt id="theme_backend-title"}
+{htxt id="theme-backend-id-title"}
   {ts}Backend Theme{/ts}
 {/htxt}
-{htxt id="theme_backend"}
+{htxt id="theme-backend-id"}
   {$themeDefn}
   <p>
     {ts}The backend theme determines the appearance on administrative screens, such as the "Manage Event" screen.{/ts}
@@ -63,10 +48,10 @@
   {$themeAdv}
 {/htxt}
 
-{htxt id="theme_frontend-title"}
+{htxt id="theme-frontend-id-title"}
   {ts}Frontend Theme{/ts}
 {/htxt}
-{htxt id="theme_frontend"}
+{htxt id="theme-frontend-id"}
   {$themeDefn}
   <p>
     {ts}On WordPress, Joomla, or a similar CMS, the frontend theme determines the appearance on user-facing screens, such as the "Event Registration" screen.{/ts}

--- a/templates/CRM/Admin/Form/Preferences/Display.tpl
+++ b/templates/CRM/Admin/Form/Preferences/Display.tpl
@@ -10,204 +10,102 @@
 {* this template is used for editing Site Preferences  *}
 <div class="crm-block crm-form-block crm-preferences-display-form-block">
   <table class="form-layout">
-    <tr class="crm-preferences-display-form-block-contact_view_options">
-      <td class="label">{$form.contact_view_options.label}</td>
-      <td><ul class="crm-checkbox-list"><li>{$form.contact_view_options.html}</li></ul></td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-description">
-      <td>&nbsp;</td>
-      <td class="description">
-        {capture assign=crmURL}{crmURL p='civicrm/admin/setting/component' q='action=add&reset=1'}{/capture}
-        {ts 1=$crmURL}Select the <strong>tabs</strong>
-          that should be displayed when viewing a contact record. EXAMPLE: If your organization does not keep track of
-          'Relationships', then un-check this option to simplify the screen display. Tabs for Contributions, Pledges,
-          Memberships, Events, Grants and Cases are also hidden if the corresponding component is not enabled. Go to
-          <a href="%1">Administer > System Settings > Enable Components</a>
-          to modify the components which are available for your site.{/ts}
-      </td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-contact_smart_group_display">
-      <td class="label">{$form.contact_smart_group_display.label}</td>
-      <td>{$form.contact_smart_group_display.html}</td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-description">
-      <td>&nbsp;</td>
-      <td class="description">
-        {$settings_fields.contact_smart_group_display.description}
-      </td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-contact_edit_options">
-      <td class="label">{$form.contact_edit_options.label}</td>
-      <td>
-        <table style="width:90%">
-          <tr>
-            <td style="width:30%">
-              <span class="label"><strong>{ts}Individual Name Fields{/ts}</strong></span>
-              <ul id="contactEditNameFields" class="crm-checkbox-list">
-                {foreach from=$nameFields item="title" key="opId"}
-                  <li id="preference-{$opId}-contactedit">
-                    {$form.contact_edit_options.$opId.html}
-                  </li>
-                {/foreach}
-              </ul>
-            </td>
-            <td style="width:30%">
-              <span class="label"><strong>{ts}Contact Details{/ts}</strong></span>
-              <ul id="contactEditBlocks" class="crm-checkbox-list crm-sortable-list">
-                {foreach from=$contactBlocks item="title" key="opId"}
-                  <li id="preference-{$opId}-contactedit">
-                    {$form.contact_edit_options.$opId.html}
-                  </li>
-                {/foreach}
-              </ul>
-            </td>
-            <td style="width:30%">
-              <span class="label"><strong>{ts}Other Panes{/ts}</strong></span>
-              <ul id="contactEditOptions"  class="crm-checkbox-list crm-sortable-list">
-                {foreach from=$editOptions item="title" key="opId"}
-                  <li id="preference-{$opId}-contactedit">
-                    {$form.contact_edit_options.$opId.html}
-                  </li>
-                {/foreach}
-              </ul>
-            </td>
-          </tr>
-        </table>
-      </td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-description">
-      <td>&nbsp;</td>
-      <td class="description">
-        {ts}Select the sections that should be included when adding or editing a contact record. EXAMPLE: If your organization does not record Gender and Birth Date for individuals, then simplify the form by un-checking this option. Drag interface allows you to change the order of the panes displayed on contact add/edit screen.{/ts}
-      </td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-advanced_search_options">
-      <td class="label">{$form.advanced_search_options.label}</td>
-      <td><ul class="crm-checkbox-list"><li>{$form.advanced_search_options.html}</li></ul></td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-description">
-      <td>&nbsp;</td>
-      <td class="description">
-        {ts}Select the sections that should be included in the Basic and Advanced Search forms. EXAMPLE: If you don't track Relationships - then you do not need this section included in the advanced search form. Simplify the form by un-checking this option.{/ts}
-      </td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-contact_ajax_check_similar">
-      <td class="label">{$form.contact_ajax_check_similar.label}</td>
-      <td>{$form.contact_ajax_check_similar.html}</td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-description">
-      <td>&nbsp;</td>
-      {capture assign=dedupeRules}href="{crmURL p='civicrm/contact/deduperules' q='reset=1'}"{/capture}
-      <td class="description">{ts 1=$dedupeRules}When enabled, checks for possible matches on the "New Contact" form using the Supervised <a %1>matching rule specified in your system</a>.{/ts}
-      </td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-activity_assignee_notification">
-      <td class="label"></td>
-      <td>{$form.activity_assignee_notification.html}</td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-description">
-      <td>&nbsp;</td>
-      <td class="description">
-        {ts}When enabled, contacts who are assigned activities will automatically receive an email notification with a copy of the activity.{/ts}
-      </td>
-    </tr>
-    <tr class="crm-preferences-display-form-activity_types">
-      <td class="label">{$form.do_not_notify_assignees_for.label}</td>
-      <td>{$form.do_not_notify_assignees_for.html}</td>
-    </tr>
-    <tr class="crm-preferences-display-form-activity_types">
-      <td>&nbsp;</td>
-      <td class="description">
-        {ts}These activity types will be excluded from automated email notifications to assignees.{/ts}
-      </td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-activity_assignee_notification_ics">
-      <td class="label"></td>
-      <td>{$form.activity_assignee_notification_ics.html}</td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-description">
-      <td>&nbsp;</td>
-      <td class="description">{ts}When enabled, the assignee notification sent out above will also include an ical meeting invite.{/ts}
-      </td>
-    </tr>
+    {foreach from=$settings_fields key="setting_name" item="fieldSpec"}
+      {assign var=fieldName value=$fieldSpec.name}
+      {* some exceptional cases use their own template *}
+      {if $fieldSpec.name eq 'contact_view_options'}
+        <tr class="crm-preferences-display-form-block-contact_view_options">
+          <td class="label">{$form.contact_view_options.label}</td>
+          <td>
+            <ul class="crm-checkbox-list">
+              <li>{$form.contact_view_options.html}</li>
+            </ul>
+            <div class="description">
+              {capture assign=crmURL}{crmURL p='civicrm/admin/setting/component' q='action=add&reset=1'}{/capture}
+              {ts 1=$crmURL}Select the <strong>tabs</strong>
+              that should be displayed when viewing a contact record. EXAMPLE: If your organization does not keep track of
+              'Relationships', then un-check this option to simplify the screen display. Tabs for Contributions, Pledges,
+              Memberships, Events, Grants and Cases are also hidden if the corresponding component is not enabled. Go to
+              <a href="%1">Administer > System Settings > Enable Components</a>
+              to modify the components which are available for your site.{/ts}
+            </div>
+          </td>
+        </tr>
+      {elseif $fieldSpec.name eq 'contact_edit_options'}
+        <tr class="crm-preferences-display-form-block-contact_edit_options">
+          <td class="label">{$form.contact_edit_options.label}</td>
+          <td>
+            <table style="width:90%">
+              <tr>
+                <td style="width:30%">
+                  <span class="label"><strong>{ts}Individual Name Fields{/ts}</strong></span>
+                  <ul id="contactEditNameFields" class="crm-checkbox-list">
+                    {foreach from=$nameFields item="title" key="opId"}
+                      <li id="preference-{$opId}-contactedit">
+                        {$form.contact_edit_options.$opId.html}
+                      </li>
+                    {/foreach}
+                  </ul>
+                </td>
+                <td style="width:30%">
+                  <span class="label"><strong>{ts}Contact Details{/ts}</strong></span>
+                  <ul id="contactEditBlocks" class="crm-checkbox-list crm-sortable-list">
+                    {foreach from=$contactBlocks item="title" key="opId"}
+                      <li id="preference-{$opId}-contactedit">
+                        {$form.contact_edit_options.$opId.html}
+                      </li>
+                    {/foreach}
+                  </ul>
+                </td>
+                <td style="width:30%">
+                  <span class="label"><strong>{ts}Other Panes{/ts}</strong></span>
+                  <ul id="contactEditOptions"  class="crm-checkbox-list crm-sortable-list">
+                    {foreach from=$editOptions item="title" key="opId"}
+                      <li id="preference-{$opId}-contactedit">
+                        {$form.contact_edit_options.$opId.html}
+                      </li>
+                    {/foreach}
+                  </ul>
+                </td>
+              </tr>
+            </table>
+            <div class="description">
+              {$fieldSpec.description}
+            </div>
+          </td>
+        </tr>
+      {elseif $fieldSpec.name eq 'contact_ajax_check_similar'}
+        <tr class="crm-preferences-display-form-block-contact_ajax_check_similar">
+          <td class="label">{$form.contact_ajax_check_similar.label}</td>
+          <td>
 
-    <tr class="crm-preferences-display-form-block-preserve_activity_tab_filter">
-      <td class="label"></td>
-      <td>{$form.preserve_activity_tab_filter.html}</td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-description">
-      <td>&nbsp;</td>
-      <td class="description">{$settings_fields.preserve_activity_tab_filter.description}</td>
-    </tr>
+            {$form.contact_ajax_check_similar.html}
 
-    <tr class="crm-preferences-display-form-block-user_dashboard_options">
-      <td class="label">{$form.user_dashboard_options.label}</td>
-      <td>
-        <ul class="crm-checkbox-list"><li>
-          {$form.user_dashboard_options.html}
-          <span style="position: absolute; right: 5px; bottom: 3px;"> {help id="id-invoices_id"}</span>
-        </li></ul>
-      </td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-description">
-      <td>&nbsp;</td>
-      <td class="description">
-        {$settings_fields.user_dashboard_options.description}
-      </td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-editor_id">
-      <td class="label">{$form.editor_id.label} {help id="editor_id"}</td>
-      <td>
-        {$form.editor_id.html}
-      </td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-ajaxPopupsEnabled">
-      <td class="label">{$form.ajaxPopupsEnabled.label}</td>
-      <td>{$form.ajaxPopupsEnabled.html}</td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-description">
-      <td>&nbsp;</td>
-      <td class="description">
-        {ts}If you disable this option, the CiviCRM interface will be limited to traditional browsing. Opening a form will refresh the page rather than opening a popup dialog.{/ts}
-      </td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-display_name_format">
-      <td class="label">{$form.display_name_format.label}</td>
-      <td>{$form.display_name_format.html}</td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-description">
-      <td>&nbsp;</td>
-      <td class="description">{$settings_fields.display_name_format.description}</td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-sort_name_format">
-      <td class="label">{$form.sort_name_format.label}</td>
-      <td>{$form.sort_name_format.html}</td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-description">
-      <td>&nbsp;</td>
-      <td class="description">{$settings_fields.sort_name_format.description}</td>
-    </tr>
-    <tr class="crm-preferences-display-form-block_menubar_position">
-      <td class="label">{$form.menubar_position.label}</td>
-      <td>
-        {$form.menubar_position.html}
-        <div class="description">{ts}Default position for the CiviCRM menubar.{/ts}</div>
-      </td>
-    </tr>
-    <tr class="crm-preferences-display-form-block_menubar_color">
-      <td class="label">{$form.menubar_color.label}</td>
-      <td>
-        {$form.menubar_color.html}
-      </td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-theme_backend">
-      <td class="label">{$form.theme_backend.label} {help id="theme_backend"}</td>
-      <td>{$form.theme_backend.html}</td>
-    </tr>
-    <tr class="crm-preferences-display-form-block-theme_frontend">
-      <td class="label">{$form.theme_frontend.label} {help id="theme_frontend"}</td>
-      <td>{$form.theme_frontend.html}</td>
-    </tr>
+            <div class="description">
+              {capture assign=dedupeRules}href="{crmURL p='civicrm/contact/deduperules' q='reset=1'}"{/capture}
+              {ts 1=$dedupeRules}When enabled, checks for possible matches on the "New Contact" form using the Supervised <a %1>matching rule specified in your system</a>.{/ts}
+            </div>
+          </td>
+        </tr>
+      {elseif $fieldSpec.name eq 'user_dashboard_options'}
+        <tr class="crm-preferences-display-form-block-user_dashboard_options">
+          <td class="label">{$form.user_dashboard_options.label}</td>
+          <td>
+            <ul class="crm-checkbox-list">
+              <li>
+                {$form.user_dashboard_options.html}
+                <span style="position: absolute; right: 5px; bottom: 3px;"> {help id="id-invoices_id"}</span>
+              </li>
+            </ul>
+            <div class="description">
+              {$fieldSpec.description}
+            </div>
+          </td>
+        </tr>
+      {else}
+        {include file="CRM/Admin/Form/Setting/SettingField.tpl"}
+      {/if}
+    {/foreach}
   </table>
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
- Convert (most of) the Display Preferences to inputs generated from the metadata
- Allow adding additional settings on this screen using the `settings_pages` metadata key


Before
----------------------------------------
Display Preferences screen uses a static template. It's out of sync with the Settings metadata in places (mainly metadata is missing descriptions).

After
----------------------------------------
- Most of the inputs are auto-generated from the metadata
- A few exceptional cases retain their static setting
- You can add additional settings on this page in your extension using the `settings_pages` metadata key.

Technical details
----------------------------------------
Some of the autogenerated classes may diverge from the static ones - but consistency with other settings pages feels like a good thing to me.

I don't quite understand how the `help_text` setting metadata key is supposed to correspond to the `.hlp` file?

Comments
----------------------------------------
In the static template, the setting descriptions are in a whole separate row, so are always pushed below the bottom of the label. The SettingsField puts it in the same `<tr>` so it tucks underneath the input. Seems better semantic html for e.g. screenreaders to me. Where there's remaining static html, I've made the corresponding change.

The pre-existing template for SettingsField moves the help swatches alongside the description. I've made [a separate PR to make it consistent with other static settings pages](https://github.com/civicrm/civicrm-core/pull/31107), which have it next to the label.
