### PR TITLE
SettingsField.tpl - move help swatch next to label

### DIFF
--- a/templates/CRM/Admin/Form/Setting/SettingField.tpl
+++ b/templates/CRM/Admin/Form/Setting/SettingField.tpl
@@ -1,6 +1,12 @@
 {* Display setting field from metadata - todo consolidate with CRM_Core_Form_Field.tpl *}
 <tr class="crm-setting-form-block-{$setting_name}">
-  <td class="label">{$form.$setting_name.label}</td>
+  <td class="label">
+    {$form.$setting_name.label}
+    {if $fieldSpec.help_text}
+      {* @todo the appended -id here appears to be inconsistent in the hlp files *}
+      {assign var='tplhelp_id' value = $setting_name|cat:'-id'|replace:'_':'-'}{help id="$tplhelp_id"}
+    {/if}
+  </td>
   <td>
     {if array_key_exists('wrapper_element', $fieldSpec) && !empty($fieldSpec.wrapper_element)}
       {$fieldSpec.wrapper_element.0|smarty:nodefaults}{$form.$setting_name.html}{$fieldSpec.wrapper_element.1|smarty:nodefaults}
@@ -10,9 +16,5 @@
     <div class="description">
       {$fieldSpec.description}
     </div>
-    {if $fieldSpec.help_text}
-      {* @todo the appended -id here appears to be inconsistent in the hlp files *}
-      {assign var='tplhelp_id' value = $setting_name|cat:'-id'|replace:'_':'-'}{help id="$tplhelp_id"}
-    {/if}
   </td>
 </tr>


### PR DESCRIPTION

Before
----------------------------------------
- Many static settings pages put help swatches next to the label, like this:
![image](https://github.com/user-attachments/assets/825e43c5-f01b-49b4-8f45-0efb826f3094)

- Dynamically generated settings put their help swatches next to the description, like this: 
![image](https://github.com/user-attachments/assets/128cb702-e565-479e-8c22-7dabab1002e0)
(note those fields are dynamically generated on this branch https://github.com/civicrm/civicrm-core/pull/31106 )

After
----------------------------------------
- All use the next to the label position. Order is restored :relaxed: 
