### PR TITLE
Add timestamp as a crmDate option

### DIFF
--- a/CRM/Core/Smarty/plugins/modifier.crmDate.php
+++ b/CRM/Core/Smarty/plugins/modifier.crmDate.php
@@ -38,6 +38,9 @@
  *   human readable date format | invalid date message
  */
 function smarty_modifier_crmDate($dateString, ?string $dateFormat = NULL, bool $onlyTime = FALSE): string {
+  if ($dateFormat === 'Timestamp') {
+    return strtotime($dateString);
+  }
   if ($dateString) {
     $configuredFormats = [
       'Datetime',


### PR DESCRIPTION
Overview
----------------------------------------
Add timestamp as a crmDate option

Before
----------------------------------------
Not possible to render `{membership.end_date}` or `{$membershipEndDate}` as a timestamp

After
----------------------------------------
This works
```
{capture assign=time_start}{domain.now|crmDate:"Timestamp"}{/capture}
{capture assign=time_end}{membership.end_date|crmDate:"Timestamp"}{/capture}
{capture assign=days}{math equation="floor((y-x)/86400)" y=$time_end x=$time_start}{/capture}
{$days}
```

Technical Details
----------------------------------------
putting it here means it also works for template variables - although they are generally less reliable with `crmDate` as they may be pre-formatted

- strftime is deprecated & the alternative does not have a timestamp option so I think it makes sense for this to sit alongside our other civi-specific ones - which are in the `crmDate` function
- 
https://unicode-org.github.io/icu/userguide/format_parse/datetime/#date-field-symbol-table

Comments
----------------------------------------
