### PR TITLE
dev/core#5455 Reduce severity of extension download error

### DIFF
--- a/CRM/Admin/Page/Extensions.php
+++ b/CRM/Admin/Page/Extensions.php
@@ -240,7 +240,7 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
     }
     catch (CRM_Extension_Exception $e) {
       $remoteExtensions = [];
-      CRM_Core_Session::setStatus($e->getMessage(), ts('Extension download error'), 'error');
+      CRM_Core_Session::setStatus($e->getMessage(), ts('Extension download error'), 'warning');
     }
 
     // build list of available downloads

--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -222,14 +222,14 @@ class CRM_Extension_Browser {
       ]);
     }
     catch (GuzzleException $e) {
-      throw new CRM_Extension_Exception(ts('The CiviCRM public extensions directory at %1 could not be contacted - please check your webserver can make external HTTP requests', [1 => $this->getRepositoryUrl()]), 'connection_error');
+      throw new CRM_Extension_Exception(ts('It is not possible to contact the CiviCRM extensions directory. You may be missing out on the latest updates to extensions. Check that you can view the <a %1>extension feed</a>. If that works check that your webserver can make external HTTP requests.', [1 => 'href="' . $this->getRepositoryUrl() . '"']), 'connection_error');
     }
     finally {
       restore_error_handler();
     }
 
     if ($response->getStatusCode() !== 200) {
-      throw new CRM_Extension_Exception(ts('The CiviCRM public extensions directory at %1 could not be contacted - please check your webserver can make external HTTP requests', [1 => $this->getRepositoryUrl()]), 'connection_error');
+      throw new CRM_Extension_Exception(ts('It is not possible to contact the CiviCRM extensions directory. You may be missing out on the latest updates to extensions. Check that you can view the <a %1>extension feed</a>. If that works check that your webserver can make external HTTP requests.', [1 => 'href="' . $this->getRepositoryUrl() . '"']), 'connection_error');
     }
 
     $json = $response->getBody()->getContents();

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -594,8 +594,8 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
         $e->getMessage(),
-        ts('Extension download error'),
-        \Psr\Log\LogLevel::ERROR,
+        ts('Unable to get updates to extensions'),
+        \Psr\Log\LogLevel::WARNING,
         'fa-plug'
       );
       return $messages;


### PR DESCRIPTION
Overview
----------------------------------------

The 'extension download error' in system status can [look quite dramatic](https://civicrm.stackexchange.com/questions/48540/502-bad-gateway-on-https-civicrm-org-extdir-ver-5-76-2cms-wordpress/) to CiviCRM users however it is usually caused by a failure in the remote server rather than anything wrong with the CiviCRM installation itself.

This PR reduces the severity to a warning and clarifies the message.

Relates to https://lab.civicrm.org/dev/core/-/issues/5455

Before
----------------------------------------

Error is shown in system status with vague message.

What does 'Extension download error' actually mean to the average user? It sounds scary but what can they do about it?

![image](https://github.com/user-attachments/assets/bdd5183e-3c1f-4661-8822-e78d7e60ed23)


After
----------------------------------------

Warning is shown in system status with clearer, less dramatic message.

![image](https://github.com/user-attachments/assets/f6e8ba03-7ba8-45db-bee7-6cda188069cc)


