### PR TITLE
extdir: remove cms=uf parameter to reduce the number of cache entries

### DIFF
--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -324,8 +324,8 @@ function dm_install_cvext() {
     return
   fi
   dm_h2 "dm_install_cvext: $@"
-  # cv dl -b '@https://civicrm.org/extdir/ver=4.7.25|cms=Drupal/com.iatspayments.civicrm.xml' --destination=$PWD/iatspayments
-  cv dl -b "@https://civicrm.org/extdir/ver=$DM_VERSION|cms=Drupal/$1.xml" --to="$2"
+  # cv dl -b '@https://civicrm.org/extdir/ver=4.7.25/com.iatspayments.civicrm.xml' --destination=$PWD/iatspayments
+  cv dl -b "@https://civicrm.org/extdir/ver=$DM_VERSION/$1.xml" --to="$2"
 }
 
 ## Export a list of patch files from a git repo

--- a/settings/Extension.setting.php
+++ b/settings/Extension.setting.php
@@ -29,7 +29,7 @@ return [
       'maxlength' => 128,
     ],
     'html_type' => 'text',
-    'default' => 'https://civicrm.org/extdir/ver={ver}|cms={uf}',
+    'default' => 'https://civicrm.org/extdir/ver={ver}',
     'add' => '4.3',
     'title' => ts('Extension Repo URL'),
     'is_domain' => 1,


### PR DESCRIPTION
This information was never used. It might not make a huge difference on the number of variations of queries we receive for the extdir on civicrm.org, but it will help to reduce the number of cache entries (and it is a trivial change, removing dead code).

Before
----------------------------------------

URL look like this: https://civicrm.org/extdir/ver=5.78.alpha2|cms=Standalone|status=stable/single

After
----------------------------------------

URL look like this: https://civicrm.org/extdir/ver=5.78.alpha2|status=stable/single

Technical Details
----------------------------------------

- this information was never used
- it will simplify caching on civicrm.org