### PR TITLE
Scales login box padding down at smaller screen widths

### DIFF
--- a/ext/standaloneusers/css/standalone.css
+++ b/ext/standaloneusers/css/standalone.css
@@ -19,7 +19,7 @@ html.crm-standalone  nav.breadcrumb>ol {
   background-color: white;
   border: none;
   border-radius: 3px;
-  padding: 2rem;
+  padding: clamp(1rem, 3vw, 2rem);
 }
 .standalone-auth-form img.crm-logo {
   width: 100%;


### PR DESCRIPTION
Overview
----------------------------------------
Follows comment by @artfulrobot on this related issue: https://github.com/civicrm/civicrm-core/pull/31102.

Before
----------------------------------------
2rem padding at all sizes

<img width="368" alt="image" src="https://github.com/user-attachments/assets/759c5916-1ca4-4c01-b9b3-0c0a7ac26098">

After
----------------------------------------
Padding scales from 1-2rem depending on screen width.

<img width="363" alt="image" src="https://github.com/user-attachments/assets/e0140de2-f3a2-41ab-8b4d-fdd28993c7bb">

Technical Details
----------------------------------------
Uses Clamp so doesn't work on any version of IE.