### PR TITLE
dev/core#5419: Add FinancialType and FinancialAccount label field

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -6514,10 +6514,9 @@ AND   displayRelType.is_active = 1
       return FALSE;
     }
     $pseudoConstant = $realField['pseudoconstant'];
-    if (empty($pseudoConstant['optionGroupName']) &&
-      ($pseudoConstant['labelColumn'] ?? NULL) !== 'name') {
+
+    if (empty($pseudoConstant['optionGroupName']) && ((($pseudoConstant['prefetch'] ?? NULL) === 'disabled') || !empty($pseudoConstant['abbrColumn']))) {
       // We are increasing our pseudoconstant handling - but still very cautiously,
-      // hence the check for labelColumn === name
       return FALSE;
     }
 
@@ -6949,8 +6948,7 @@ AND   displayRelType.is_active = 1
    */
   protected function isPseudoFieldAnFK($fieldSpec) {
     if (empty($fieldSpec['FKClassName'])
-      || ($fieldSpec['pseudoconstant']['keyColumn'] ?? NULL) !== 'id'
-      || ($fieldSpec['pseudoconstant']['labelColumn'] ?? NULL) !== 'name') {
+      || ($fieldSpec['pseudoconstant']['keyColumn'] ?? NULL) !== 'id') {
       return FALSE;
     }
     return TRUE;

--- a/CRM/Contribute/PseudoConstant.php
+++ b/CRM/Contribute/PseudoConstant.php
@@ -95,7 +95,7 @@ class CRM_Contribute_PseudoConstant extends CRM_Core_PseudoConstant {
         self::$financialType,
         'CRM_Financial_DAO_FinancialType',
         TRUE,
-        'name',
+        'label',
         NULL,
         $condition
       );

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2855,7 +2855,6 @@ SELECT contact_id
         elseif (
           !empty($field['FKClassName'])
           && ($pseudoConstant['keyColumn'] ?? NULL) === 'id'
-          && ($pseudoConstant['labelColumn'] ?? NULL) === 'name'
         ) {
           $pseudoFieldName = str_replace('_' . $pseudoConstant['keyColumn'], '', $field['name']);
           // This if is just an extra caution when adding change.

--- a/CRM/Financial/BAO/EntityFinancialAccount.php
+++ b/CRM/Financial/BAO/EntityFinancialAccount.php
@@ -198,7 +198,7 @@ class CRM_Financial_BAO_EntityFinancialAccount extends CRM_Financial_DAO_EntityF
     $existingFinancialAccount = [];
     if (!$dao->N) {
       $params = [
-        'name' => $financialType->name,
+        'label' => $financialType->label,
         'contact_id' => CRM_Core_BAO_Domain::getDomain()->contact_id,
         'financial_account_type_id' => array_search('Revenue', $financialAccountTypeID),
         'description' => $financialType->description,

--- a/CRM/Financial/Form/FinancialAccount.php
+++ b/CRM/Financial/Form/FinancialAccount.php
@@ -80,8 +80,8 @@ class CRM_Financial_Form_FinancialAccount extends CRM_Contribute_Form {
 
     $this->applyFilter('__ALL__', 'trim');
     $attributes = CRM_Core_DAO::getAttribute('CRM_Financial_DAO_FinancialAccount');
-    $this->add('text', 'name', ts('Name'), $attributes['name'], TRUE);
-    $this->addRule('name', ts('A financial type with this name already exists. Please select another name.'),
+    $this->add('text', 'label', ts('Label'), $attributes['label'], TRUE);
+    $this->addRule('label', ts('A financial type with this label already exists. Please select another label.'),
       'objectExists', ['CRM_Financial_DAO_FinancialAccount', $this->_id]);
 
     $this->add('text', 'description', ts('Description'), $attributes['description']);
@@ -119,7 +119,7 @@ class CRM_Financial_Form_FinancialAccount extends CRM_Contribute_Form {
     if ($this->_action == CRM_Core_Action::UPDATE &&
       CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialAccount', $this->_id, 'is_reserved')
     ) {
-      $this->freeze(['name', 'description', 'is_active']);
+      $this->freeze(['description', 'is_active']);
     }
     $this->addFormRule(['CRM_Financial_Form_FinancialAccount', 'formRule'], $this);
   }
@@ -204,7 +204,7 @@ class CRM_Financial_Form_FinancialAccount extends CRM_Contribute_Form {
         $params[$field] ??= FALSE;
       }
       $financialAccount = CRM_Financial_BAO_FinancialAccount::writeRecord($params);
-      CRM_Core_Session::setStatus(ts('The Financial Account \'%1\' has been saved.', [1 => $financialAccount->name]), ts('Saved'), 'success');
+      CRM_Core_Session::setStatus(ts('The Financial Account \'%1\' has been saved.', [1 => $financialAccount->label]), ts('Saved'), 'success');
     }
   }
 

--- a/CRM/Financial/Form/FinancialType.php
+++ b/CRM/Financial/Form/FinancialType.php
@@ -48,8 +48,8 @@ class CRM_Financial_Form_FinancialType extends CRM_Core_Form {
    */
   protected function setEntityFields() {
     $this->entityFields = [
-      'name' => [
-        'name' => 'name',
+      'label' => [
+        'name' => 'label',
         'required' => TRUE,
       ],
       'description' => ['name' => 'description'],
@@ -91,7 +91,7 @@ class CRM_Financial_Form_FinancialType extends CRM_Core_Form {
     if ($this->_action == CRM_Core_Action::UPDATE && CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialType', $this->_id, 'is_reserved')) {
       $this->freeze(['is_active']);
     }
-    $this->addRule('name', ts('A financial type with this name already exists. Please select another name.'), 'objectExists',
+    $this->addRule('label', ts('A financial type with this name already exists. Please select another name.'), 'objectExists',
       ['CRM_Financial_DAO_FinancialType', $this->_id]
     );
   }
@@ -123,13 +123,13 @@ class CRM_Financial_Form_FinancialType extends CRM_Core_Form {
       $financialType = civicrm_api3('FinancialType', 'create', $params);
       if ($this->_action & CRM_Core_Action::UPDATE) {
         $url = CRM_Utils_System::url('civicrm/admin/financial/financialType', 'reset=1&action=browse');
-        CRM_Core_Session::setStatus(ts('The financial type "%1" has been updated.', [1 => $params['name']]), ts('Saved'), 'success');
+        CRM_Core_Session::setStatus(ts('The financial type "%1" has been updated.', [1 => $params['label']]), ts('Saved'), 'success');
       }
       else {
         $url = CRM_Utils_System::url('civicrm/admin/financial/financialType/accounts', 'reset=1&action=browse&aid=' . $financialType['id']);
 
         $statusArray = [
-          1 => $params['name'],
+          1 => $params['label'],
         ];
         $financialAccounts = civicrm_api3('EntityFinancialAccount', 'get', [
           'return' => ['financial_account_id.name'],

--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -273,7 +273,7 @@ class CRM_Financial_Page_AJAX {
       'contact_a.contact_sub_type',
       'civicrm_financial_trxn.trxn_date as transaction_date',
       'civicrm_contribution.receive_date as receive_date',
-      'civicrm_financial_type.name',
+      'civicrm_financial_type.label',
       'civicrm_financial_trxn.currency as currency',
       'civicrm_financial_trxn.status_id as status',
       'civicrm_financial_trxn.check_number as check_number',
@@ -290,7 +290,7 @@ class CRM_Financial_Page_AJAX {
       'receive_date' => ts('Contribution Date'),
       'payment_method' => ts('Payment Method'),
       'status' => ts('Status'),
-      'name' => ts('Type'),
+      'label' => ts('Type'),
     ];
 
     if ($sort && $sortOrder) {
@@ -446,7 +446,7 @@ class CRM_Financial_Page_AJAX {
       'receive_date',
       'payment_method',
       'status',
-      'name',
+      'label',
       'action',
     ];
 

--- a/CRM/Financial/Page/FinancialAccount.php
+++ b/CRM/Financial/Page/FinancialAccount.php
@@ -85,7 +85,7 @@ class CRM_Financial_Page_FinancialAccount extends CRM_Core_Page_Basic {
     // get all custom groups sorted by weight
     $contributionType = [];
     $dao = new CRM_Financial_DAO_FinancialAccount();
-    $dao->orderBy('financial_account_type_id, name');
+    $dao->orderBy('financial_account_type_id, label');
     $dao->find();
     $financialAccountType = CRM_Financial_DAO_FinancialAccount::buildOptions('financial_account_type_id');
 

--- a/CRM/Upgrade/Incremental/php/FiveSeventyNine.php
+++ b/CRM/Upgrade/Incremental/php/FiveSeventyNine.php
@@ -58,6 +58,8 @@ class CRM_Upgrade_Incremental_php_FiveSeventyNine extends CRM_Upgrade_Incrementa
    *   The version number matching this function name
    */
   public function upgrade_5_79_alpha1($rev): void {
+    $this->addTask('Add Financial Type.label field', 'addColumn', 'civicrm_financial_type', 'label', "varchar(64) NOT NULL COMMENT 'User-facing financial type label' AFTER `name`", TRUE);
+    $this->addTask('Add Financial Account.label field', 'addColumn', 'civicrm_financial_account', 'label', "varchar(64) NOT NULL COMMENT 'User-facing financial account label' AFTER `name`", TRUE);
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Update "Website Type" options', 'updateWebsiteType');
   }

--- a/CRM/Upgrade/Incremental/sql/5.79.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.79.alpha1.mysql.tpl
@@ -1,1 +1,3 @@
 {* file to handle db changes in 5.79.alpha1 during upgrade *}
+UPDATE `civicrm_financial_type` SET {localize field="label"}`label` = `name`{/localize};
+UPDATE `civicrm_financial_account` SET {localize field="label"}`label` = `name`{/localize};

--- a/schema/Contribute/Contribution.entityType.php
+++ b/schema/Contribute/Contribution.entityType.php
@@ -133,7 +133,7 @@ return [
       'pseudoconstant' => [
         'table' => 'civicrm_financial_type',
         'key_column' => 'id',
-        'label_column' => 'name',
+        'label_column' => 'label',
       ],
       'entity_reference' => [
         'entity' => 'FinancialType',

--- a/schema/Contribute/ContributionPage.entityType.php
+++ b/schema/Contribute/ContributionPage.entityType.php
@@ -89,7 +89,7 @@ return [
       'pseudoconstant' => [
         'table' => 'civicrm_financial_type',
         'key_column' => 'id',
-        'label_column' => 'name',
+        'label_column' => 'label',
         'condition_provider' => ['CRM_Financial_BAO_FinancialType', 'alterIncomeFinancialTypes'],
       ],
       'entity_reference' => [

--- a/schema/Contribute/ContributionProduct.entityType.php
+++ b/schema/Contribute/ContributionProduct.entityType.php
@@ -121,7 +121,7 @@ return [
       'pseudoconstant' => [
         'table' => 'civicrm_financial_type',
         'key_column' => 'id',
-        'label_column' => 'name',
+        'label_column' => 'label',
       ],
       'entity_reference' => [
         'entity' => 'FinancialType',

--- a/schema/Contribute/ContributionRecur.entityType.php
+++ b/schema/Contribute/ContributionRecur.entityType.php
@@ -345,7 +345,7 @@ return [
       'pseudoconstant' => [
         'table' => 'civicrm_financial_type',
         'key_column' => 'id',
-        'label_column' => 'name',
+        'label_column' => 'label',
       ],
       'entity_reference' => [
         'entity' => 'FinancialType',

--- a/schema/Contribute/PremiumsProduct.entityType.php
+++ b/schema/Contribute/PremiumsProduct.entityType.php
@@ -72,7 +72,7 @@ return [
       'pseudoconstant' => [
         'table' => 'civicrm_financial_type',
         'key_column' => 'id',
-        'label_column' => 'name',
+        'label_column' => 'label',
       ],
       'entity_reference' => [
         'entity' => 'FinancialType',

--- a/schema/Contribute/Product.entityType.php
+++ b/schema/Contribute/Product.entityType.php
@@ -121,7 +121,7 @@ return [
       'pseudoconstant' => [
         'table' => 'civicrm_financial_type',
         'key_column' => 'id',
-        'label_column' => 'name',
+        'label_column' => 'label',
       ],
       'entity_reference' => [
         'entity' => 'FinancialType',

--- a/schema/Event/Event.entityType.php
+++ b/schema/Event/Event.entityType.php
@@ -253,7 +253,7 @@ return [
       'pseudoconstant' => [
         'table' => 'civicrm_financial_type',
         'key_column' => 'id',
-        'label_column' => 'name',
+        'label_column' => 'label',
         'condition_provider' => ['CRM_Financial_BAO_FinancialType', 'alterIncomeFinancialTypes'],
       ],
     ],

--- a/schema/Financial/FinancialAccount.entityType.php
+++ b/schema/Financial/FinancialAccount.entityType.php
@@ -43,8 +43,22 @@ return [
       'sql_type' => 'varchar(255)',
       'input_type' => 'Text',
       'required' => TRUE,
+      'default_fallback' => ['label'],
       'description' => ts('Financial Account Name.'),
       'add' => '3.2',
+    ],
+    'label' => [
+      'title' => ts('Financial Account Label'),
+      'sql_type' => 'varchar(64)',
+      'input_type' => 'Text',
+      'description' => ts('User-facing financial account label'),
+      'required' => TRUE,
+      'default_fallback' => ['name'],
+      'localizable' => TRUE,
+      'add' => '5.79',
+      'input_attrs' => [
+        'label' => ts('Financial Account'),
+      ],
     ],
     'contact_id' => [
       'title' => ts('Contact ID'),

--- a/schema/Financial/FinancialType.entityType.php
+++ b/schema/Financial/FinancialType.entityType.php
@@ -30,10 +30,11 @@ return [
       'auto_increment' => TRUE,
     ],
     'name' => [
-      'title' => ts('Financial Type'),
+      'title' => ts('Financial Type Name'),
       'sql_type' => 'varchar(64)',
       'input_type' => 'Text',
       'required' => TRUE,
+      'default_fallback' => ['label'],
       'description' => ts('Financial Type Name.'),
       'add' => '1.3',
       'unique_name' => 'financial_type',
@@ -44,6 +45,19 @@ return [
       ],
       'input_attrs' => [
         'label' => ts('Name'),
+      ],
+    ],
+    'label' => [
+      'title' => ts('Financial Type Label'),
+      'sql_type' => 'varchar(64)',
+      'input_type' => 'Text',
+      'description' => ts('User-facing financial type label'),
+      'required' => TRUE,
+      'default_fallback' => ['name'],
+      'localizable' => TRUE,
+      'add' => '5.79',
+      'input_attrs' => [
+        'label' => ts('Financial Type'),
       ],
     ],
     'description' => [

--- a/schema/Member/MembershipType.entityType.php
+++ b/schema/Member/MembershipType.entityType.php
@@ -116,7 +116,7 @@ return [
       'pseudoconstant' => [
         'table' => 'civicrm_financial_type',
         'key_column' => 'id',
-        'label_column' => 'name',
+        'label_column' => 'label',
       ],
       'entity_reference' => [
         'entity' => 'FinancialType',

--- a/schema/Pledge/Pledge.entityType.php
+++ b/schema/Pledge/Pledge.entityType.php
@@ -78,7 +78,7 @@ return [
       'pseudoconstant' => [
         'table' => 'civicrm_financial_type',
         'key_column' => 'id',
-        'label_column' => 'name',
+        'label_column' => 'label',
       ],
       'entity_reference' => [
         'entity' => 'FinancialType',

--- a/schema/Price/LineItem.entityType.php
+++ b/schema/Price/LineItem.entityType.php
@@ -161,7 +161,7 @@ return [
       'pseudoconstant' => [
         'table' => 'civicrm_financial_type',
         'key_column' => 'id',
-        'label_column' => 'name',
+        'label_column' => 'label',
       ],
       'entity_reference' => [
         'entity' => 'FinancialType',

--- a/schema/Price/PriceFieldValue.entityType.php
+++ b/schema/Price/PriceFieldValue.entityType.php
@@ -208,7 +208,7 @@ return [
       'pseudoconstant' => [
         'table' => 'civicrm_financial_type',
         'key_column' => 'id',
-        'label_column' => 'name',
+        'label_column' => 'label',
       ],
       'entity_reference' => [
         'entity' => 'FinancialType',

--- a/schema/Price/PriceSet.entityType.php
+++ b/schema/Price/PriceSet.entityType.php
@@ -149,7 +149,7 @@ return [
       'pseudoconstant' => [
         'table' => 'civicrm_financial_type',
         'key_column' => 'id',
-        'label_column' => 'name',
+        'label_column' => 'label',
       ],
       'entity_reference' => [
         'entity' => 'FinancialType',

--- a/sql/civicrm_data/civicrm_financial_account.sqldata.php
+++ b/sql/civicrm_data/civicrm_financial_account.sqldata.php
@@ -10,7 +10,8 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_financial_account')
   ])
   ->addValues([
     [
-      'name' => ts('Donation'),
+      'label' => ts('Donation'),
+      'name' => 'Donation',
       'financial_account_type_id' => new Literal('@opval'),
       'description' => 'Default account for donations',
       'accounting_code' => '4200',
@@ -19,7 +20,8 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_financial_account')
       'is_default' => 1,
     ],
     [
-      'name' => ts('Member Dues'),
+      'label' => ts('Member Dues'),
+      'name' => 'Member Dues',
       'financial_account_type_id' => new Literal('@opval'),
       'description' => 'Default account for membership sales',
       'accounting_code' => '4400',
@@ -28,7 +30,8 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_financial_account')
       'is_default' => 0,
     ],
     [
-      'name' => ts('Campaign Contribution'),
+      'label' => ts('Campaign Contribution'),
+      'name' => 'Campaign Contribution',
       'financial_account_type_id' => new Literal('@opval'),
       'description' => 'Sample account for recording payments to a campaign',
       'accounting_code' => '4100',
@@ -37,7 +40,8 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_financial_account')
       'is_default' => 0,
     ],
     [
-      'name' => ts('Event Fee'),
+      'label' => ts('Event Fee'),
+      'name' => 'Event Fee',
       'financial_account_type_id' => new Literal('@opval'),
       'description' => 'Default account for event ticket sales',
       'accounting_code' => '4300',
@@ -46,7 +50,8 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_financial_account')
       'is_default' => 0,
     ],
     [
-      'name' => ts('Banking Fees'),
+      'label' => ts('Banking Fees'),
+      'name' => 'Banking Fees',
       'financial_account_type_id' => new Literal('@opexp'),
       'description' => 'Payment processor fees and manually recorded banking fees',
       'accounting_code' => '5200',
@@ -55,7 +60,8 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_financial_account')
       'is_default' => 1,
     ],
     [
-      'name' => ts('Deposit Bank Account'),
+      'label' => ts('Deposit Bank Account'),
+      'name' => 'Deposit Bank Account',
       'financial_account_type_id' => new Literal('@opAsset'),
       'description' => 'All manually recorded cash and cheques go to this account',
       'accounting_code' => '1100',
@@ -64,7 +70,8 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_financial_account')
       'is_default' => 1,
     ],
     [
-      'name' => ts('Accounts Receivable'),
+      'label' => ts('Accounts Receivable'),
+      'name' => 'Accounts Receivable',
       'financial_account_type_id' => new Literal('@opAsset'),
       'description' => 'Amounts to be received later (eg pay later event revenues)',
       'accounting_code' => '1200',
@@ -73,7 +80,8 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_financial_account')
       'is_default' => 0,
     ],
     [
-      'name' => ts('Accounts Payable'),
+      'label' => ts('Accounts Payable'),
+      'name' => 'Accounts Payable',
       'financial_account_type_id' => new Literal('@opLiability'),
       'description' => 'Amounts to be paid out such as grants and refunds',
       'accounting_code' => '2200',
@@ -82,7 +90,8 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_financial_account')
       'is_default' => 1,
     ],
     [
-      'name' => ts('Premiums'),
+      'label' => ts('Premiums'),
+      'name' => 'Premiums',
       'financial_account_type_id' => new Literal('@opCost'),
       'description' => 'Account to record cost of premiums provided to payors',
       'accounting_code' => '5100',
@@ -91,7 +100,8 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_financial_account')
       'is_default' => 1,
     ],
     [
-      'name' => ts('Premiums inventory'),
+      'label' => ts('Premiums inventory'),
+      'name' => 'Premiums inventory',
       'financial_account_type_id' => new Literal('@opAsset'),
       'description' => 'Account representing value of premiums inventory',
       'accounting_code' => '1375',
@@ -100,7 +110,8 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_financial_account')
       'is_default' => 0,
     ],
     [
-      'name' => ts('Discounts'),
+      'label' => ts('Discounts'),
+      'name' => 'Discounts',
       'financial_account_type_id' => new Literal('@opval'),
       'description' => 'Contra-revenue account for amounts discounted from sales',
       'accounting_code' => '4900',
@@ -109,7 +120,8 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_financial_account')
       'is_default' => 0,
     ],
     [
-      'name' => ts('Payment Processor Account'),
+      'label' => ts('Payment Processor Account'),
+      'name' => 'Payment Processor Account',
       'financial_account_type_id' => new Literal('@opAsset'),
       'description' => 'Account to record payments into a payment processor merchant account',
       'accounting_code' => '1150',
@@ -118,7 +130,8 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_financial_account')
       'is_default' => 0,
     ],
     [
-      'name' => ts('Deferred Revenue - Event Fee'),
+      'label' => ts('Deferred Revenue - Event Fee'),
+      'name' => 'Deferred Revenue - Event Fee',
       'financial_account_type_id' => new Literal('@opLiability'),
       'description' => 'Event revenue to be recognized in future months when the events occur',
       'accounting_code' => '2730',
@@ -127,7 +140,8 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_financial_account')
       'is_default' => 0,
     ],
     [
-      'name' => ts('Deferred Revenue - Member Dues'),
+      'label' => ts('Deferred Revenue - Member Dues'),
+      'name' => 'Deferred Revenue - Member Dues',
       'financial_account_type_id' => new Literal('@opLiability'),
       'description' => 'Membership revenue to be recognized in future months',
       'accounting_code' => '2740',

--- a/sql/civicrm_data/civicrm_financial_type.sqldata.php
+++ b/sql/civicrm_data/civicrm_financial_type.sqldata.php
@@ -1,10 +1,10 @@
 <?php
 return CRM_Core_CodeGen_SqlData::create('civicrm_financial_type')
-  ->addValueTable(['name', 'is_deductible'], [
-    [ts('Donation'), 1],
-    [ts('Member Dues'), 1],
-    [ts('Campaign Contribution'), 0],
-    [ts('Event Fee'), 0],
+  ->addValueTable(['label', 'name', 'is_deductible'], [
+    [ts('Donation'), 'Donation', 1],
+    [ts('Member Dues'), 'Member Dues', 1],
+    [ts('Campaign Contribution'), 'Campaign Contribution', 0],
+    [ts('Event Fee'), 'Event Fee', 0],
   ])
   ->addDefaults([
     'is_reserved' => 0,

--- a/templates/CRM/Financial/Form/FinancialAccount.tpl
+++ b/templates/CRM/Financial/Form/FinancialAccount.tpl
@@ -16,9 +16,9 @@
   </div>
 {else}
   <table class="form-layout-compressed">
-    <tr class="crm-contribution-form-block-name">
-      <td class="label">{$form.name.label}</td>
-      <td class="html-adjust">{$form.name.html}</td>
+    <tr class="crm-contribution-form-block-label">
+      <td class="label">{$form.label.label}</td>
+      <td class="html-adjust">{$form.label.html}</td>
     </tr>
     <tr class="crm-contribution-form-block-description">
       <td class="label">{$form.description.label}</td>

--- a/templates/CRM/Financial/Page/FinancialAccount.tpl
+++ b/templates/CRM/Financial/Page/FinancialAccount.tpl
@@ -46,7 +46,7 @@
         </thead>
         {foreach from=$rows item=row}
         <tr id="financial_account-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"} {if !empty($row.class)}{$row.class}{/if}{if NOT $row.is_active} disabled{/if}">
-          <td class="crm-editable" data-field="name">{$row.name}</td>
+          <td class="crm-editable" data-field="label">{$row.label}</td>
           <td class="crm-editable" data-field="description" data-type="textarea">{if !empty($row.description)}{$row.description}{/if}</td>
           <td class="crm-editable" data-field="accounting_code">{$row.accounting_code}</td>
           <td>{$row.financial_account_type_id}{if $row.account_type_code} ({$row.account_type_code}){/if}</td>

--- a/templates/CRM/Financial/Page/FinancialType.tpl
+++ b/templates/CRM/Financial/Page/FinancialType.tpl
@@ -38,7 +38,7 @@
           </thead>
          {foreach from=$rows item=row}
         <tr id="financial_type-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"} {if !empty($row.class)}{$row.class}{/if}{if NOT $row.is_active} disabled{/if}">
-          <td class="crm-editable" data-field="name">{$row.name}</td>
+          <td class="crm-editable" data-field="label">{$row.label}</td>
           <td class="crm-editable" data-field="description" data-type="textarea">{if !empty($row.description)}{$row.description}{/if}</td>
           <td>{$row.financial_account}</td>
           <td class="crm-editable" data-field="is_deductible" data-type="boolean">{if $row.is_deductible eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -2372,7 +2372,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    */
   protected function getContributeHeaderDefinition(): array {
     return [
-      82 => 'Financial Type',
+      82 => 'Financial Type Label',
       83 => 'Contribution Source',
       84 => 'Contribution Date',
       85 => 'Thank-you Date',

--- a/tests/phpunit/api/v3/FinancialTypeTest.php
+++ b/tests/phpunit/api/v3/FinancialTypeTest.php
@@ -67,7 +67,7 @@ class api_v3_FinancialTypeTest extends CiviUnitTestCase {
       });
       $this->callAPISuccessGetSingle('FinancialType', [
         'id' => $financialType['id'],
-      ], $expectedResult);
+      ], $expectedResult + ['label' => $financialTypeName]);
 
       // updated financial type with custom field
       $updateCustomFields = [];
@@ -87,7 +87,7 @@ class api_v3_FinancialTypeTest extends CiviUnitTestCase {
       });
       $this->callAPISuccessGetSingle('FinancialType', [
         'id' => $financialType['id'],
-      ], $expectedResult);
+      ], $expectedResult + ['label' => $financialTypeName]);
       $this->callAPISuccess('FinancialType', 'delete', ['id' => $financialType['id']]);
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Add FinancialType and FinancialAccount label field and make changes in other places to expose label not name in UX

Before
-------
Financial Type and Financial Type have name field which was used as the unique identifier and the user-facing label.

After
------
- FT and FA have a name field as a unique identifier, and a label field which can be translated characters.
- Label is a required field while create action, and name takes label value if blank
- Made changes in search pages, form to use label instead of name
