### PR TITLE
dev/core#5411 FormBuilder: Fix array_merge issue which throws errors when values are not arrays in combineValuesAndIds

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -562,8 +562,10 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
           $idData['joins'] = $this->combineValuesAndIds($val['joins'] ?? [], $idData['joins'] ?? [], TRUE);
         }
         // $item = array_merge($isJoin ? $val : ($val['fields'] ?? []), $idData);
-        $item = array_merge(($val ?? []), $idData);
-        $combined[$name][$idx] = $item;
+        if (is_array($val) || empty($val)) {
+          $item = array_merge(($val ?? []), $idData);
+          $combined[$name][$idx] = $item;
+        }
       }
     }
     return $combined;


### PR DESCRIPTION
## Overview

Copied from: https://lab.civicrm.org/dev/core/-/issues/5411

_Previous to 5.73, I was able to use a Form built to submit a CiviCase and create a Contact. After a recent upgrade to 5.73 it would appear (to the user) that an error has occurred and the form cannot be completed. In actuality, the CiviCase is created and so is the contact, but an error occurs in the backend with regards to an Activity not being created_

## Reproduction steps

 1. Go to FormBuilder and add a new Form
 2. Set **Accessible to Front-end**
 3. Set **permissions** to Profile create
 4. Add an **Individual 1** with presets **Contact Type** Individual and **Contact Source** Volunteer Application
 5. Set **Security** to Form-Based
 6. Set **Autofill** to Current User
 7. Set **Duplicate Matching** to Name and Email
 8. Add a **Case**
 9. Set **Case Clients** to Individual 1
10. Set **Case Type** to Volunteer Application
11. Set **Case Subject**
12. Set **Case Creator** to _Individual 1_
13. _Set **Start Date** to Current Date_
14. _Set **Security** to Form-based_
15. Entered **First Name** and **Last Name** and clicked **Save**.
16. Got an error "**Fatal error: DB error**".

## Current behaviour

In the logs we are receiving 

```
 Silently ignoring exception in Afform processGenericEntity call: Not enough data to create activity object
```

As well, the front-end displays a pop-up that indicates that there was an error. The Case is created and so is the individual.

## Expected behaviour

_The Case is created, alongside the Individual and the Activity_

## Environment information

* **CiviCRM:** 5.73
* **PHP:** 8.0
* **CMS:** Wordpress_._

It's using a shortcode embeded on the page but I don't think this makes a difference, because I have an older copy of the site using an actual CiviCRM path and I get the same results

## Comments

_What is strange is that if I add an Activity myself then it reports_

```
Silently ignoring exception in Afform processGenericEntity call: Expected one Case but found 25
```

Perhaps this isn't the best solution I'm not sure, but my attempt is to basically check to see if ```$val``` is an array or empty prior to actually doing an array_merge.

I deployed this on the site that was having the issues and it's super happy now.