### PR TITLE
fix 'invalid character in regex' error

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -43,7 +43,7 @@
       <label for="af_config_form_server_route">
         {{:: ts('Page Route') }}
       </label>
-      <input ng-model="editor.afform.server_route" name="server_route" class="form-control" id="af_config_form_server_route" pattern="^civicrm\/[-0-9a-zA-Z\/_]+$" onfocus="this.value = this.value || 'civicrm/'" onblur="if (this.value === 'civicrm/') this.value = ''" title="{{:: ts('Path must begin with &quot;civicrm/&quot;') }}" placeholder="{{:: ts('None') }}" ng-model-options="editor.debounceMode">
+      <input ng-model="editor.afform.server_route" name="server_route" class="form-control" id="af_config_form_server_route" pattern="^civicrm\/[\-0-9a-zA-Z\/_]+$" onfocus="this.value = this.value || 'civicrm/'" onblur="if (this.value === 'civicrm/') this.value = ''" title="{{:: ts('Path must begin with &quot;civicrm/&quot;') }}" placeholder="{{:: ts('None') }}" ng-model-options="editor.debounceMode">
       <p class="help-block">{{:: ts('Expose the form as a standalone webpage. (Example: "civicrm/my-form")') }}</p>
     </div>
 


### PR DESCRIPTION
Overview
----------------------------------------
If you open any FormBuilder form in the editor,  you get two errors like this:
```
Unable to check <input pattern=‘^civicrm\/[-0-9a-zA-Z\/_]+$’> because ‘/^civicrm\/[-0-9a-zA-Z\/_]+$/v’ is not a valid regexp: invalid character in class in regular expression [jquery.min.js:4:9544](https://dmaster.demo.civicrm.org/sites/all/modules/civicrm/bower_components/jquery/dist/jquery.min.js?sjrbvu)
```

Before
----------------------------------------
Error

After
----------------------------------------
No Error

Technical Details
----------------------------------------
This is a one-character change, escaping a hyphen.

The [MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class) are confusing. A light reading suggests the unescaped hyphen is ok, but there's a lot of fine points, and apparently it's not.  It does say you can always use an escaped hyphen though.

Comments
----------------------------------------
I'm trying to fix the spurious console errors for FB so I can track down a legit error.
