### PR TITLE
Add missing help text for mailer settings screen

### DIFF
--- a/settings/Mailing.setting.php
+++ b/settings/Mailing.setting.php
@@ -431,7 +431,7 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => ts('The frequency that CiviMail updates its sent mail database.'),
-    'help_text' => NULL,
+    'help_text' => ts('CiviMail records email sent at the frequency you specify. If you set it to 1, it will update the database every time it sends an email. This ensures that emails are not resent if the batch job fails, but this may cause a performance hit, particularly for large jobs.'),
   ],
   'scheduled_reminder_smarty' => [
     'group_name' => 'Mailing Preferences',


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
1. Visit Admin - CiviMail - Mailer Settings
2. There's supposed to be a help bubble for database update frequency.

After
----------------------------------------
Now there's the help bubble.

Technical Details
----------------------------------------
If you want to enjoy the rest of your day, I'd advise not looking into how `{help}` currently works and just note that at the moment the settings help_text element's existence is just used as a [toggle to show the help bubble or not](https://github.com/civicrm/civicrm-core/blob/d3accf4ba1266382bcdafcc9689e2178a3da9f97/templates/CRM/Admin/Form/Setting/SettingField.tpl#L5), but it still [loads it](https://github.com/civicrm/civicrm-core/blob/d3accf4ba1266382bcdafcc9689e2178a3da9f97/templates/CRM/Admin/Form/Setting/SettingField.tpl#L7) from the [.hlp file](https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/Admin/Form/Setting/Mail.hlp).

Comments
----------------------------------------

