### PR TITLE
dev/core#5468 Do not output event contact details if empty

### DIFF
--- a/templates/CRM/Event/Form/Registration/EventInfoBlock.tpl
+++ b/templates/CRM/Event/Form/Registration/EventInfoBlock.tpl
@@ -48,7 +48,7 @@
     {/if}
   {/if}{*End of isShowLocation condition*}
 
-  {if (array_key_exists(1, $location.phone) && !empty($location.phone)) || (array(1, $location.email) && !empty($location.email))}
+  {if !empty($location.phone.1.phone) || !empty($location.email.1.email)}
     <tr><td>{ts}Contact{/ts}</td>
         <td>
         {* loop on any phones and emails for this event *}

--- a/templates/CRM/Event/Form/Registration/EventInfoBlock.tpl
+++ b/templates/CRM/Event/Form/Registration/EventInfoBlock.tpl
@@ -48,7 +48,7 @@
     {/if}
   {/if}{*End of isShowLocation condition*}
 
-  {if array_key_exists(1, $location.phone) || array(1, $location.email)}
+  {if (array_key_exists(1, $location.phone) && !empty($location.phone)) || (array(1, $location.email) && !empty($location.email))}
     <tr><td>{ts}Contact{/ts}</td>
         <td>
         {* loop on any phones and emails for this event *}


### PR DESCRIPTION
Overview
----------------------------------------
Events with no contact details output an empty "Contact" line in the Event Information section (Event Info Block).


Before
----------------------------------------
EventInfoBlock.tpl only checks if $location.phone or $location.empty keys exist. It does not check to see if they are empty. This means that the "Contact" line can be rendered with an empty value.


After
----------------------------------------
Adds a check to see if $location.phone and $location.empty tokens are empty. If either does have a value, then it renders the contact details section.


Comments
----------------------------------------
dev/core#5468
Agileware Ref : CIVICRM-2275
