### PR TITLE
Remove extraneous angular module dependency from chart_kit 

### DIFF
--- a/ext/chart_kit/ang/crmChartKit.ang.php
+++ b/ext/chart_kit/ang/crmChartKit.ang.php
@@ -20,7 +20,6 @@ return [
     'ngRoute',
     'ui.bootstrap',
     'crmSearchDisplay',
-    'crmSearchAdmin',
   ],
   'basePages' => ['civicrm/admin/search'],
   'bundles' => ['bootstrap3', 'chart_kit'],


### PR DESCRIPTION
Overview
----------------------------------------
Remove unnecessary dependency on `crmSearchAdmin` from `crmChartKit`. Improves performance for chart_kit displays when not admin-ing them. 


Before
----------------------------------------
Any page with a chart_kit search display currently loads the `crmSearchAdmin` module, which calls the expensive settingsFactory `\Civi\Search\Admin::getAdminSettings`. Nothing from the module is used when you are just displaying the chart


After
----------------------------------------
Dont load the unnecessary module when displaying charts. Charts should load faster.