### PR TITLE
properly merge NULL into custom money field

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -937,6 +937,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
             $type = CRM_Utils_Array::explodePadded($data['contact_sub_type']);
           }
 
+          $includeViewOnly = TRUE;
           CRM_Core_BAO_CustomField::formatCustomField($customFieldId,
             $data['custom'],
             $value,
@@ -944,7 +945,8 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
             $valueId,
             $contactID,
             FALSE,
-            FALSE
+            FALSE,
+            $includeViewOnly,
           );
         }
         elseif ($key === 'edit') {
@@ -1746,8 +1748,6 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       $submitted = [];
     }
 
-    // Move view only custom fields CRM-5362
-    $viewOnlyCustomFields = [];
     foreach ($submitted as $key => $value) {
       if (strpos($key, 'custom_') === 0) {
         $fieldID = (int) substr($key, 7);
@@ -1757,17 +1757,8 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
           $isSerialized = $fieldMetadata['serialize'];
           $isView = $fieldMetadata['is_view'];
           $submitted = self::processCustomFields($mainId, $key, $submitted, $value, $fieldID, $isView, $htmlType, $isSerialized);
-          if ($isView) {
-            $viewOnlyCustomFields[$key] = $submitted[$key];
-          }
         }
       }
-    }
-
-    // special case to set values for view only, CRM-5362
-    if (!empty($viewOnlyCustomFields)) {
-      $viewOnlyCustomFields['entityID'] = $mainId;
-      CRM_Core_BAO_CustomValueTable::setValues($viewOnlyCustomFields);
     }
 
     // dev/core#996 Ensure that the earliest created date is stored against the kept contact id

--- a/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
+++ b/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
@@ -455,6 +455,18 @@ trait CRMTraits_Custom_CustomDataTrait {
   }
 
   /**
+   * Create a custom field of type money.
+   *
+   * @param array $params
+   *
+   * @return array
+   */
+  protected function createMoneyTextCustomField(array $params): array {
+    $params = array_merge($this->getFieldsValuesByType('Money'), $params);
+    return $this->callAPISuccess('custom_field', 'create', $params)['values'][0];
+  }
+
+  /**
    * Get default field values for the type of field.
    *
    * @param string $dataType


### PR DESCRIPTION
Overview
----------------------------------------

With custom fields, it's possible to have a merge screen in which one contact has no record at all in the custom data table and the other contact does. If you choose to merge the "no record at all" value into the contact that has a record, we merge NULL into a field that might have a data type that dis-allows a NULL value.

Specifically, if the custom field is Money and the custom field is set to view only, you get:

> CRM_Core_Exception: value: null is not of the right field data type: Money in /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Dedupe/Merger.php on line 1789

Before
----------------------------------------
If you merge a NULL value into a Custom Field of the type Money, you get an error.

After
----------------------------------------
The NULL value is converted into an appropriate value for the field.

Technical Details
----------------------------------------
There are a lot of places to fix this. And, the fix I chose tackles the scenario when we are passing the string 'null' to mean the value NULL. That all seems really dicey. 

Additionally, the real problem is with [this call](https://github.com/civicrm/civicrm-core/blob/ec0d89e62c598219c813bdd71455c3cc3514c900/CRM/Dedupe/Merger.php#L1770). I'm not entirely sure why `CRM_Core_BAO_CustomValueTable::setValues` is called when the fields are view only. Why would we treat them differently in this context? Maybe we should just remove that call?

