### PR TITLE
ChartKit - fix legend item vertical alignment on Chrome

### DIFF
--- a/ext/chart_kit/ang/crmChartKit/crmSearchDisplayChartKit.component.js
+++ b/ext/chart_kit/ang/crmChartKit/crmSearchDisplayChartKit.component.js
@@ -392,6 +392,13 @@
                     legend.x(this.settings.format.width - legend.itemWidth() - rightPadding);
                 }
                 this.chart.legend(legend);
+
+                // Correct vertical alignment of legend labels on Chrome
+                // Should be fixed upstream and therefore unnecessary in DCv5
+                this.chart.on('pretransition', (chart) =>
+                  chart.selectAll('.dc-legend-item text')
+                    .attr('y', legend.itemHeight() - 2)
+                );
             };
 
             // TODO: move everything from here down  to a util service?


### PR DESCRIPTION
Overview
----------------------------------------
Fix for https://lab.civicrm.org/ufundo/chart_kit/-/issues/37

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/797c4733-dc32-43b9-94ed-a1c7a14d99fe)


After
----------------------------------------
![image](https://github.com/user-attachments/assets/b93a6788-3e1e-4abc-abf7-eb37c76b4104)


Technical Details
----------------------------------------
There's an upstream fix, but hasn't been backported to v4 DC library chart kit we are currently using.

