### PR TITLE
[REF] Standalone System - graduate some functions from Civi\Standalone\Security to CRM_Utils_System_Standalone and Civi\Authx\Standalone

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -15,7 +15,6 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-use Civi\Standalone\Security;
 use Civi\Standalone\SessionHandler;
 
 /**
@@ -259,6 +258,9 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    * @inheritDoc
    * Authenticate the user against the CMS db.
    *
+   * I think this is only used by CLI so setting the session
+   * doesn't make sense
+   *
    * @param string $name
    *   The user name.
    * @param string $password
@@ -274,13 +276,6 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    */
   public function authenticate($name, $password, $loadCMSBootstrap = FALSE, $realPath = NULL) {
     $authxLogin = authx_login(['flow' => 'login', 'cred' => 'Basic ' . base64_encode("{$name}:{$password}")]);
-
-    $user = \Civi\Api4\User::get(FALSE)
-      ->addWhere('id', '=', $authxLogin['userId'])
-      ->addWhere('is_active', '=', TRUE)
-      ->execute()->single();
-
-    Security::singleton()->applyLocaleFromUser($user);
 
     // Note: random_int is more appropriate for cryptographical use than mt_rand
     // The long number is the max 32 bit value.

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -584,7 +584,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
 
   public function permissionDenied() {
     // If not logged in, they need to.
-    if (CRM_Core_Session::singleton()->get('ufID')) {
+    if ($this->isUserLoggedIn()) {
       // They are logged in; they're just not allowed this page.
       CRM_Core_Error::statusBounce(ts("Access denied"), CRM_Utils_System::url('civicrm'));
     }
@@ -598,7 +598,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
         return $loginPage->run();
       }
 
-      throw new CRM_Core_Exception('Access denied. Standaloneusers extension not found');
+      throw new CRM_Core_Exception('Access denied. Standaloneusers login page not found');
     }
   }
 

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -247,9 +247,6 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
 
   /**
    * Immediately stop script execution, log out the user and redirect to the home page.
-   *
-   * @deprecated
-   *   This function should be removed in favor of linking to the CMS's logout page
    */
   public function logout() {
     return Security::singleton()->logoutUser();

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -452,52 +452,6 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
   }
 
   /**
-   * I don't know why this needs to be here? Does it even?
-   *
-   * Helper function to extract path, query and route name from Civicrm URLs.
-   *
-   * For example, 'civicrm/contact/view?reset=1&cid=66' will be returned as:
-   *
-   * ```
-   * array(
-   *   'path' => 'civicrm/contact/view',
-   *   'route' => 'civicrm.civicrm_contact_view',
-   *   'query' => array('reset' => '1', 'cid' => '66'),
-   * );
-   * ```
-   *
-   * @param string $url
-   *   The url to parse.
-   *
-   * @return string[]
-   *   The parsed url parts, containing 'path', 'route' and 'query'.
-   */
-  public function parseUrl($url) {
-    $processed = ['path' => '', 'route_name' => '', 'query' => []];
-
-    // Remove leading '/' if it exists.
-    $url = ltrim($url, '/');
-
-    // Separate out the url into its path and query components.
-    $url = parse_url($url);
-    if (empty($url['path'])) {
-      return $processed;
-    }
-    $processed['path'] = $url['path'];
-
-    // Create a route name by replacing the forward slashes in the path with
-    // underscores, civicrm/contact/search => civicrm.civicrm_contact_search.
-    $processed['route_name'] = 'civicrm.' . implode('_', explode('/', $url['path']));
-
-    // Turn the query string (if it exists) into an associative array.
-    if (!empty($url['query'])) {
-      parse_str($url['query'], $processed['query']);
-    }
-
-    return $processed;
-  }
-
-  /**
    * Append any Standalone js to coreResourcesList.
    *
    * @param \Civi\Core\Event\GenericHookEvent $e

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -55,8 +55,10 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
   }
 
   /**
-   * @internal
-   * @return bool
+   * @inheritdoc
+   *
+   * In Standalone the UF is CiviCRM, so we're never
+   * running without it
    */
   public function isLoaded(): bool {
     return TRUE;
@@ -74,18 +76,6 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
 
   /**
    * @inheritDoc
-   *
-   * Create a user in the CMS.
-   *
-   * @param array $params keys:
-   *    - 'cms_name'
-   *    - 'cms_pass' plaintext password
-   *    - 'notify' boolean
-   * @param string $emailParam
-   *   Name of the $param which contains the email address.
-   *
-   * @return int|bool
-   *   uid if user was created, false otherwise
    */
   public function createUser(&$params, $emailParam) {
     try {
@@ -102,11 +92,6 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
       \Civi::log()->warning("Failed to create user '$email': " . $e->getMessage());
       return FALSE;
     }
-
-    // @todo This next line is what Drupal does, but it's unclear why.
-    // I think it assumes we want to be logged in as this contact, and as there's no uf match, it's not in civi.
-    // But I'm not sure if we are always becomming this user; I'm not sure waht calls this function.
-    // CRM_Core_Config::singleton()->inCiviCRM = FALSE;
 
     return (int) $userID;
   }

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -520,14 +520,16 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
 
   /**
    * Start a new session.
+   *
+   * Generally this uses the SessionHander provided by Standaloneusers
+   * extension - but we fallback to a default PHP session to:
+   * a) allow the installer to work (early in the Standalone install, we dont have Standaloneusers yet)
+   * b) avoid unhelpfully hard crash if the ExtensionSystem goes down (without the fallback, the crash
+   * here swallows whatever error is actually causing the crash)
    */
   public function sessionStart() {
-    if (defined('CIVI_SETUP')) {
-      // during installation we can't use the session
-      // handler from the extension yet so we just
-      // use a default php session
-      // use a different cookie name to avoid any nasty clash
-      $session_cookie_name = 'SESSCIVISOINSTALL';
+    if (!class_exists(SessionHandler::class)) {
+      $session_cookie_name = 'SESSCIVISOFALLBACK';
     }
     else {
       $session_handler = new SessionHandler();

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -43,9 +43,19 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    *   Whether user extension is available
    */
   protected function isUserExtensionAvailable(): bool {
-    if (!\Civi\Api4\Utils\CoreUtil::entityExists('User')) {
+    if (!class_exists(\Civi\Api4\User::class)) {
       return FALSE;
     }
+    // TODO: the following would be be a better check, as sometimes during
+    // upgrade the User class can exist but the entity is not actually loaded
+    //
+    // HOWEVER: it currently causes a crash during the install phase.
+    // https://github.com/civicrm/civicrm-core/pull/31198 may help.
+    //
+    // if (!\Civi\Api4\Utils\CoreUtil::entityExists('User')) {
+    //   return FALSE;
+    // }
+
     // authx function is required for standalone user system
     if (!function_exists('_authx_uf')) {
       return FALSE;

--- a/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
@@ -5,7 +5,6 @@ use Civi\Standalone\Security;
 class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
 
   public function run() {
-    Security::singleton()->getLoggedInUfID();
     if (CRM_Core_Session::singleton()->get('ufID')) {
       // Already logged in.
       CRM_Utils_System::redirect('/civicrm');
@@ -26,7 +25,7 @@ class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
    * Log out.
    */
   public static function logout() {
-    Security::singleton()->logoutUser();
+    _authx_uf()->logoutSession();
     // Dump them back on the log-IN page.
     CRM_Utils_System::redirect('/civicrm/login?justLoggedOut');
   }

--- a/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
@@ -1,11 +1,10 @@
 <?php
 use CRM_Standaloneusers_ExtensionUtil as E;
-use Civi\Standalone\Security;
 
 class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
 
   public function run() {
-    if (CRM_Core_Session::singleton()->get('ufID')) {
+    if (CRM_Core_Config::singleton()->userSystem->isUserLoggedIn()) {
       // Already logged in.
       CRM_Utils_System::redirect('/civicrm');
     }
@@ -25,7 +24,7 @@ class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
    * Log out.
    */
   public static function logout() {
-    _authx_uf()->logoutSession();
+    CRM_Core_Config::singleton()->userSystem->logout();
     // Dump them back on the log-IN page.
     CRM_Utils_System::redirect('/civicrm/login?justLoggedOut');
   }

--- a/ext/standaloneusers/Civi/Api4/Action/User/Login.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/Login.php
@@ -153,8 +153,7 @@ class Login extends AbstractAction {
   }
 
   protected function loginUser(int $userID) {
-    $authx = new \Civi\Authx\Standalone();
-    $authx->loginSession($userID);
+    _authx_uf()->loginSession($userID);
   }
 
 }

--- a/ext/standaloneusers/Civi/Api4/Action/User/PasswordReset.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/PasswordReset.php
@@ -39,8 +39,7 @@ class PasswordReset extends AbstractAction {
     // todo: some minimum password quality check?
 
     // Only valid change here is password, for a known ID.
-    $security = Security::singleton();
-    $userID = $security->checkPasswordResetToken($this->token);
+    $userID = Security::singleton()->checkPasswordResetToken($this->token);
     if (!$userID) {
       throw new API_Exception("Invalid token.");
     }

--- a/ext/standaloneusers/Civi/Api4/Action/User/WriteTrait.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/WriteTrait.php
@@ -75,15 +75,10 @@ trait WriteTrait {
     $loggedInUserID = \CRM_Utils_System::getLoggedInUfID() ?? FALSE;
     $hasAdminPermission = \CRM_Core_Permission::check(['cms:administer users']);
     $authenticatedAsLoggedInUser = FALSE;
-    $security = Security::singleton();
     // Check that we have the logged-in-user's password.
     if ($this->actorPassword && $loggedInUserID) {
-      $storedHashedPassword = \Civi\Api4\User::get(FALSE)
-        ->addWhere('id', '=', $loggedInUserID)
-        ->addSelect('hashed_password')
-        ->execute()
-        ->single()['hashed_password'];
-      if (!$security->checkPassword($this->actorPassword, $storedHashedPassword)) {
+      $user = \CRM_Core_Config::singleton()->userSystem->getUserById($loggedInUserID);
+      if (!_authx_uf()->checkPassword($user['username'], $this->actorPassword)) {
         throw new UnauthorizedException("Incorrect password");
       }
       $authenticatedAsLoggedInUser = TRUE;

--- a/ext/standaloneusers/Civi/Authx/Standalone.php
+++ b/ext/standaloneusers/Civi/Authx/Standalone.php
@@ -37,10 +37,12 @@ class Standalone implements AuthxInterface {
       ->execute()
       ->single();
 
-
     // Confusingly, Civi stores it's *Contact* ID as *userID* on the session.
     $session->set('userID', $user['contact_id'] ?? NULL);
-    Security::singleton()->applyLocaleFromUser($user);
+
+    if (!empty($user['language'])) {
+      $session->set('lcMessages', $user['language']);
+    }
   }
 
   /**
@@ -50,7 +52,7 @@ class Standalone implements AuthxInterface {
     global $loggedInUserId;
     $loggedInUserId = NULL;
     \CRM_Core_Session::singleton()->reset();
-   // session_destroy();
+    // session_destroy();
   }
 
   /**

--- a/ext/standaloneusers/Civi/Authx/Standalone.php
+++ b/ext/standaloneusers/Civi/Authx/Standalone.php
@@ -47,8 +47,10 @@ class Standalone implements AuthxInterface {
    * @inheritDoc
    */
   public function logoutSession() {
+    global $loggedInUserId;
+    $loggedInUserId = NULL;
     \CRM_Core_Session::singleton()->reset();
-    session_destroy();
+   // session_destroy();
   }
 
   /**

--- a/ext/standaloneusers/Civi/Authx/Standalone.php
+++ b/ext/standaloneusers/Civi/Authx/Standalone.php
@@ -19,17 +19,28 @@ class Standalone implements AuthxInterface {
    * @inheritDoc
    */
   public function checkPassword(string $username, string $password) {
-    $security = Security::singleton();
-    $user = $security->loadUserByName($username);
-    return $security->checkPassword($password, $user['hashed_password'] ?? '') ? $user['id'] : NULL;
+    return Security::singleton()->checkPassword($username, $password);
   }
 
   /**
    * @inheritDoc
    */
   public function loginSession($userId) {
-    $user = Security::singleton()->loadUserByID($userId);
-    Security::singleton()->loginAuthenticatedUserRecord($user, TRUE);
+    $this->loginStateless($userId);
+
+    $session = \CRM_Core_Session::singleton();
+    $session->set('ufID', $userId);
+
+    // Identify the contact
+    $user = \Civi\Api4\User::get(FALSE)
+      ->addWhere('id', '=', $userId)
+      ->execute()
+      ->single();
+
+
+    // Confusingly, Civi stores it's *Contact* ID as *userID* on the session.
+    $session->set('userID', $user['contact_id'] ?? NULL);
+    Security::singleton()->applyLocaleFromUser($user);
   }
 
   /**
@@ -44,8 +55,8 @@ class Standalone implements AuthxInterface {
    * @inheritDoc
    */
   public function loginStateless($userId) {
-    $user = Security::singleton()->loadUserByID($userId);
-    Security::singleton()->loginAuthenticatedUserRecord($user, FALSE);
+    global $loggedInUserId;
+    $loggedInUserId = $userId;
   }
 
   /**

--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -2,7 +2,6 @@
 namespace Civi\Standalone;
 
 use Civi\Crypto\Exception\CryptoException;
-use CRM_Core_Session;
 use Civi;
 use Civi\Api4\User;
 use Civi\Api4\MessageTemplate;
@@ -282,19 +281,6 @@ class Security {
       ->setFrom("\"$domainFromName\" <$domainFromEmail>");
 
     return $workflowMessage;
-  }
-
-  /**
-   * Applies the locale from the user record.
-   *
-   * @param array $user
-   * @return void
-   */
-  public function applyLocaleFromUser(array $user) {
-    $session = CRM_Core_Session::singleton();
-    if (!empty($user['language'])) {
-      $session->set('lcMessages', $user['language']);
-    }
   }
 
 }

--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -9,11 +9,19 @@ use Civi\Api4\MessageTemplate;
 use CRM_Standaloneusers_WorkflowMessage_PasswordReset;
 
 /**
- * This is a single home for security related functions for Civi Standalone.
+ * Security related functions for Standaloneusers.
  *
- * Things may yet move around in the codebase; at the time of writing this helps
- * keep core PRs to a minimum.
+ * This is closely coupled with CRM_Utils_System_Standalone
+ * Many functions there started life here when Standalone
+ * was being resurrected.
  *
+ * Some of the generic user functions have been moved back to the
+ * System class so that they are more permanently available.
+ *
+ * Things may yet move around in the codebase - particularly if
+ * alternative user extensions to Standaloneusers are developed as
+ * these would then need to share an interface with the System
+ * class
  */
 class Security {
 
@@ -53,7 +61,10 @@ class Security {
     }
 
     // NULL means the current logged-in user
-    $userID ??= $this->getLoggedInUfID() ?? 0;
+    $userID = $userID ?? \CRM_Utils_System::getLoggedInUfID();
+
+    // now any falsey userid is equivalent to userID = 0 = anonymous user
+    $userID = $userID ?: 0;
 
     if (!isset(\Civi::$statics[__METHOD__][$userID])) {
 
@@ -88,162 +99,6 @@ class Security {
   }
 
   /**
-   */
-  public function getUserIDFromUsername(string $username): ?int {
-    return \Civi\Api4\User::get(FALSE)
-      ->addWhere('username', '=', $username)
-      ->execute()
-      ->first()['id'] ?? NULL;
-  }
-
-  /**
-   * Load an active user by username.
-   *
-   * @return array|bool FALSE if not found.
-   */
-  public function loadUserByName(string $username) {
-    $user = \Civi\Api4\User::get(FALSE)
-      ->addWhere('username', '=', $username)
-      ->addWhere('is_active', '=', TRUE)
-      ->execute()->first() ?? [];
-    if ($user) {
-      return $user;
-    }
-    return FALSE;
-  }
-
-  /**
-   * Load an active user by internal user ID.
-   *
-   * @return array|bool FALSE if not found.
-   */
-  public function loadUserByID(int $userID) {
-    $user = \Civi\Api4\User::get(FALSE)
-      ->addWhere('id', '=', $userID)
-      ->addWhere('is_active', '=', TRUE)
-      ->execute()->first() ?? [];
-    if ($user) {
-      return $user;
-    }
-    return FALSE;
-  }
-
-  /**
-   *
-   */
-  public function logoutUser() {
-    // This is the same call as in CRM_Authx_Page_AJAX::logout()
-    _authx_uf()->logoutSession();
-  }
-
-  /**
-   * Create a user in the CMS.
-   *
-   * This is the (perhaps temporary location for) the implementation of CRM_Utils_System_Standalone method.
-   *
-   * @param array $params keys:
-   *    - 'cms_name'
-   *    - 'cms_pass' plaintext password
-   *    - 'notify' boolean
-   * @param string $emailParam
-   *   Name of the $param which contains the email address.
-   *
-   * @return int|bool
-   *   uid if user was created, false otherwise
-   */
-  public function createUser(&$params, $emailParam) {
-    try {
-      $email = $params[$emailParam];
-      $userID = User::create(FALSE)
-        ->addValue('username', $params['cms_name'])
-        ->addValue('uf_name', $email)
-        ->addValue('password', $params['cms_pass'])
-        ->addValue('contact_id', $params['contact_id'] ?? NULL)
-        // ->addValue('uf_id', 0) // does not work without this.
-        ->execute()->single()['id'];
-    }
-    catch (\Exception $e) {
-      \Civi::log()->warning("Failed to create user '$email': " . $e->getMessage());
-      return FALSE;
-    }
-
-    // @todo This next line is what Drupal does, but it's unclear why.
-    // I think it assumes we want to be logged in as this contact, and as there's no uf match, it's not in civi.
-    // But I'm not sure if we are always becomming this user; I'm not sure waht calls this function.
-    // CRM_Core_Config::singleton()->inCiviCRM = FALSE;
-
-    return (int) $userID;
-  }
-
-  /**
-   * Update a user's email
-   *
-   * This is the (perhaps temporary location for) the implementation of CRM_Utils_System_Standalone method.
-   */
-  public function updateCMSName($ufID, $email) {
-    \Civi\Api4\User::update(FALSE)
-      ->addWhere('id', '=', $ufID)
-      ->addValue('uf_name', $email)
-      ->execute();
-  }
-
-  /**
-   * Register the given user as the currently logged in user.
-   */
-  public function loginAuthenticatedUserRecord(array $user, bool $withSession) {
-    global $loggedInUserId, $loggedInUser;
-    $loggedInUserId = $user['id'];
-    $loggedInUser = $user;
-
-    if ($withSession) {
-      $session = \CRM_Core_Session::singleton();
-      $session->set('ufID', $user['id']);
-
-      // Identify the contact
-      $contactID = civicrm_api3('UFMatch', 'get', [
-        'sequential' => 1,
-        'return' => ['contact_id'],
-        'uf_id' => $user['id'],
-      ])['values'][0]['contact_id'] ?? NULL;
-      // Confusingly, Civi stores it's *Contact* ID as *userID* on the session.
-      $session->set('userID', $contactID);
-      $this->applyLocaleFromUser($user);
-    }
-  }
-
-  /**
-   * This is the (perhaps temporary location for) the implementation of CRM_Utils_System_Standalone method.
-   */
-  public function isUserLoggedIn(): bool {
-    return !empty($this->getLoggedInUfID());
-  }
-
-  /**
-   * This is the (perhaps temporary location for) the implementation of CRM_Utils_System_Standalone method.
-   */
-  public function getLoggedInUfID(): ?int {
-    $authX = new \Civi\Authx\Standalone();
-    return $authX->getCurrentUserId();
-  }
-
-  /**
-   * This is the (perhaps temporary location for) the implementation of CRM_Utils_System_Standalone method.
-   */
-  public function languageNegotiationURL($url, $addLanguagePart = TRUE, $removeLanguagePart = FALSE) {
-    // @todo
-    return $url;
-  }
-
-  /**
-   * This is the (perhaps temporary location for) the implementation of CRM_Utils_System_Standalone method.
-   * Return the CMS-specific url for its permissions page
-   * @return array
-   */
-  public function getCMSPermissionsUrlParams() {
-    return ['ufAccessURL' => '/civicrm/admin/roles'];
-  }
-
-  /**
    * High level function to encrypt password using the site-default mechanism.
    */
   public function hashPassword(string $plaintext): string {
@@ -255,9 +110,28 @@ class Security {
   }
 
   /**
-   * Check whether a password matches a hashed version.
+   * Standaloneusers implementation of AuthxInterface::checkPassword
+   * @see \Civi\Authx\Standalone
    */
-  public function checkPassword(string $plaintextPassword, string $storedHashedPassword): bool {
+  public function checkPassword(string $username, string $plaintextPassword): ?int {
+    $user = \Civi\Api4\User::get(FALSE)
+      ->addWhere('username', '=', $username)
+      ->addWhere('is_active', '=', TRUE)
+      ->addSelect('hashed_password', 'id')
+      ->execute()
+      ->first();
+
+    if ($user && $this->checkHashedPassword($plaintextPassword, $user['hashed_password'])) {
+      return $user['id'];
+    }
+    return NULL;
+  }
+
+  /**
+   * Check whether a password matches a hashed version.
+   * @return bool
+   */
+  protected function checkHashedPassword(string $plaintextPassword, string $storedHashedPassword): bool {
 
     if (preg_match('@^\$S\$[A-Za-z./0-9]{52}$@', $storedHashedPassword)) {
       // Looks like a default D7 password.

--- a/ext/standaloneusers/tests/phpunit/Civi/Api4/Action/UserTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Api4/Action/UserTest.php
@@ -8,10 +8,9 @@ use Civi\Api4\User;
 use Civi\Api4\Role;
 use Civi\Api4\UserRole;
 use Civi\Api4\Contact;
-use Civi\Standalone\Security;
 
 /**
- * FIXME - Add test description.
+ * Test the Standaloneusers User Api4 actions
  *
  * Tips:
  *  - With HookInterface, you may implement CiviCRM hooks directly in the test class.
@@ -92,29 +91,20 @@ class UserTest extends \PHPUnit\Framework\TestCase implements EndToEndInterface,
     }
   }
 
-  /**
-   * Note I thought I could use \Civi\Authx\Standalone::logoutSession()
-   * but it calls session_destroy which messes up future tests.
-   *
-   * Not sure if there is a generic logout without session destroy.
-   *
-   */
   public function ensureLoggedOut() {
-    global $loggedInUserId, $loggedInUser;
-
-    if (\CRM_Utils_System::getLoggedInUfID()) {
-      \CRM_Core_Session::singleton()->reset();
-      $loggedInUser = $loggedInUserId = NULL;
-    }
+    \CRM_Utils_System::logout();
   }
 
   public function tearDown():void {
-    $this->deleteStuffWeMade();
+    // only tear down if we set up
+    if (CIVICRM_UF === 'Standalone') {
+      $this->ensureLoggedOut();
+      $this->deleteStuffWeMade();
+    }
     parent::tearDown();
   }
 
   protected function loginUser($userID) {
-    $security = Security::singleton();
     $user = \Civi\Api4\User::get(FALSE)
       ->addWhere('id', '=', $userID)
       ->execute()->first();
@@ -125,8 +115,8 @@ class UserTest extends \PHPUnit\Framework\TestCase implements EndToEndInterface,
       'uf_id' => $user['id'],
     ])['values'][0]['contact_id'] ?? NULL;
     $this->assertNotNull($contactID);
-    /** @var \Civi\Standalone\Security $security */
-    $security->loginAuthenticatedUserRecord($user, FALSE);
+
+    \CRM_Core_Config::singleton()->userSystem->loadUser($user['username']);
   }
 
   /**

--- a/ext/standaloneusers/tests/phpunit/Civi/Api4/Action/UserTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Api4/Action/UserTest.php
@@ -105,18 +105,7 @@ class UserTest extends \PHPUnit\Framework\TestCase implements EndToEndInterface,
   }
 
   protected function loginUser($userID) {
-    $user = \Civi\Api4\User::get(FALSE)
-      ->addWhere('id', '=', $userID)
-      ->execute()->first();
-
-    $contactID = civicrm_api3('UFMatch', 'get', [
-      'sequential' => 1,
-      'return' => ['contact_id'],
-      'uf_id' => $user['id'],
-    ])['values'][0]['contact_id'] ?? NULL;
-    $this->assertNotNull($contactID);
-
-    \CRM_Core_Config::singleton()->userSystem->loadUser($user['username']);
+    _authx_uf()->loginSession($userID);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Attempt at consolidating some of the functions in `CRM_Utils_System_Standalone` , `Civi\Standalone\Security` and `Civi\Authx\Standalone` .

Before
----------------------------------------
- Many of the functions for `CRM_Utils_System_Standalone` are implemented in `Civi\Standalone\Security`
- Piecemeal handling in the `CRM_Utils_System_Standalone` for when standaloneusers extension is unavailable

After
----------------------------------------
- System functions that it seems unlikely the user extension would want to change moved to the System class
- \Civi\Standalone\Security keeps the juicy password algorithm logic
- a reusable check for whether standaloneusers and authx are available, and more failsafes when not

Comments
----------------------------------------
I've edited to break out some of the more functional changes.