### PR TITLE
respect Custom Group collapse on Activity and Case search forms

### DIFF
--- a/templates/CRM/Custom/Form/Search.tpl
+++ b/templates/CRM/Custom/Form/Search.tpl
@@ -13,12 +13,8 @@
   <details
     class="crm-accordion-bold crm-contactDetails-accordion"
     id="{$cd_edit.name}"
-    {if $form.formName eq 'Advanced'}
-        {if $cd_edit.collapse_adv_display eq 1}{else}open{/if}
-    {else}
-        {if $cd_edit.collapse_display eq 1}{else}open{/if}
-    {/if}
-        >
+    {if $cd_edit.collapse_adv_display eq 1}{else}open{/if}
+    >
     <summary>
         {$cd_edit.title}
     </summary>

--- a/templates/CRM/Custom/Form/Search.tpl
+++ b/templates/CRM/Custom/Form/Search.tpl
@@ -10,7 +10,15 @@
 {if $groupTree}
 {foreach from=$groupTree item=cd_edit key=group_id}
 
-  <details class="crm-accordion-bold crm-contactDetails-accordion" id="{$cd_edit.name}"  {if $form.formName eq 'Advanced' AND $cd_edit.collapse_adv_display eq 1}{else}open{/if}>
+  <details
+    class="crm-accordion-bold crm-contactDetails-accordion"
+    id="{$cd_edit.name}"
+    {if $form.formName eq 'Advanced'}
+        {if $cd_edit.collapse_adv_display eq 1}{else}open{/if}
+    {else}
+        {if $cd_edit.collapse_display eq 1}{else}open{/if}
+    {/if}
+        >
     <summary>
         {$cd_edit.title}
     </summary>


### PR DESCRIPTION
Before
----------------------------------------
Custom Group sections are always open on Find Activity and Find Case screens

After
----------------------------------------
Custom Group sections respect the "Collapse this set on inital display" setting

Comments
----------------------------------------
I wasn't sure if they should respect this Collapse setting, or "Collapse this set in Advanced Search". But I think these things aren't attached searches.

@gibsonoliver 
