### PR TITLE
ChartKit - add new chart type: Series Chart

### DIFF
--- a/ext/chart_kit/ang/crmChartKit/chartKitTypes.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartKitTypes.service.js
@@ -1,47 +1,60 @@
-(function(angular, $, _) {
+(function (angular, $, _) {
   "use strict";
 
   // Provides pluggable chart types for use in the chart_kit display and admin components
-  angular.module('crmChartKit').factory('chartKitTypes', (chartKitPie, chartKitRow, chartKitStack, chartKitComposite) => {
+  angular.module('crmChartKit').factory('chartKitTypes', (
+    chartKitPie,
+    chartKitRow,
+    chartKitStack,
+    chartKitComposite,
+    chartKitSeries
+  ) => {
+
     const ts = CRM.ts('chart_kit');
 
     return [
-        {
-            key: 'pie',
-            label: ts('Pie'),
-            icon: 'fa-pie-chart',
-            service: chartKitPie,
-        },
-        {
-            key: 'row',
-            label: ts('Row'),
-            icon: 'fa-bar-chart fa-rotate-90',
-            service: chartKitRow
-        },
-        {
-            key: 'line',
-            label: ts('Line'),
-            icon: 'fa-line-chart',
-            service: chartKitStack
-        },
-        {
-            key: 'bar',
-            label: ts('Bar'),
-            icon: 'fa-bar-chart',
-            service: chartKitStack
-        },
-        {
-            key: 'area',
-            label: ts('Area'),
-            icon: 'fa-area-chart',
-            service: chartKitStack
-        },
-        {
-            key: 'composite',
-            label: ts('Combined'),
-            icon: 'fa-bar-chart',
-            service: chartKitComposite
-        },
+      {
+        key: 'pie',
+        label: ts('Pie'),
+        icon: 'fa-pie-chart',
+        service: chartKitPie,
+      },
+      {
+        key: 'row',
+        label: ts('Row'),
+        icon: 'fa-chart-bar',
+        service: chartKitRow
+      },
+      {
+        key: 'line',
+        label: ts('Line'),
+        icon: 'fa-line-chart',
+        service: chartKitStack
+      },
+      {
+        key: 'bar',
+        label: ts('Bar'),
+        icon: 'fa-chart-column',
+        service: chartKitStack
+      },
+      {
+        key: 'area',
+        label: ts('Area'),
+        icon: 'fa-chart-area',
+        service: chartKitStack
+      },
+      {
+        key: 'series',
+        label: ts('Series'),
+        icon: 'fa-chart-gantt',
+        service: chartKitSeries
+      },
+      {
+        key: 'composite',
+        label: ts('Combined'),
+        icon: 'fa-layer-group',
+        service: chartKitComposite
+      },
     ];
   });
 })(angular, CRM.$, CRM._);

--- a/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitSeries.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitSeries.service.js
@@ -28,7 +28,7 @@
             },
             'z': {
               label: ts('Additional labels'),
-              dataLabelTypes: ['label', 'title'],
+              dataLabelTypes: ['title', 'label'],
               multiColumn: true,
               prepopulate: false,
             }
@@ -55,7 +55,7 @@
 
                 // we use a string separator rather than array to
                 // not corrupt ordering on xValue
-                return `${xValue}\x00${seriesVal}`;
+                return [xValue, seriesVal];
             });
         },
 
@@ -63,15 +63,9 @@
             displayCtrl.chart
                 .dimension(displayCtrl.dimension)
                 .group(displayCtrl.group)
-                // value is the y axis
                 .valueAccessor(displayCtrl.getValueAccessor(displayCtrl.getColumnsForAxis('y')[0]))
-                .keyAccessor((d) => d.key.split('\x00')[0]);
-
-            const seriesCol = displayCtrl.getColumnsForAxis('w').length ? displayCtrl.getColumnsForAxis('w')[0] : null;
-
-            if (seriesCol) {
-                displayCtrl.chart.seriesAccessor((d) => d.key.split('\x00')[1])
-            }
+                .keyAccessor((d) => d.key[0])
+                .seriesAccessor((d) => d.key[1]);
 
             displayCtrl.buildCoordinateGrid();
         }

--- a/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitSeries.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitSeries.service.js
@@ -1,0 +1,80 @@
+(function (angular, $, _, dc) {
+    "use strict";
+
+    // common renderer for line/bar/area charts, which will stack by default
+    // (compare with composite chart, where each column can be line/bar/area )
+    angular.module('crmChartKit').factory('chartKitSeries', () => ({
+        adminTemplate: '~/crmChartKit/chartTypes/chartKitSeriesAdmin.html',
+
+        getInitialDisplaySettings: () => ({
+          showLegend: 'right',
+        }),
+
+        getAxes: function () {
+            return ({
+            'x': {
+                label: ts('X-Axis'),
+                scaleTypes: ['date', 'numeric', 'categorical'],
+                reduceTypes: [],
+            },
+            'w': {
+                label: ts('Grouping'),
+                scaleTypes: ['categorical'],
+                reduceTypes: [],
+            },
+            'y': {
+                label: ts('Value'),
+                sourceDataTypes: ['Integer', 'Money', 'Boolean'],
+            },
+            'z': {
+              label: ts('Additional labels'),
+              dataLabelTypes: ['label', 'title'],
+              multiColumn: true,
+              prepopulate: false,
+            }
+          });
+        },
+
+        hasCoordinateGrid: () => true,
+
+        showLegend: (displayCtrl) => (displayCtrl.settings.showLegend && displayCtrl.settings.showLegend !== 'none'),
+
+        // the legend gets the series "name", which is the delisted value of the series column
+        legendTextAccessor: (displayCtrl) => ((d) => displayCtrl.renderDataValue(d.name, displayCtrl.getColumnsForAxis('w')[0])),
+
+        // fallback to a line chart if we dont have a grouping column yet
+        getChartConstructor: (displayCtrl) => displayCtrl.getColumnsForAxis('w') ? dc.seriesChart : dc.lineChart,
+
+        buildDimension: (displayCtrl) => {
+            // we need to add the series values in the dimension or they will get
+            // aggregated
+            displayCtrl.dimension = displayCtrl.ndx.dimension((d) => {
+                const xValue = d[displayCtrl.getXColumn().index];
+                const seriesCol = displayCtrl.getColumnsForAxis('w').length ? displayCtrl.getColumnsForAxis('w')[0] : null;
+                const seriesVal = seriesCol ? d[seriesCol.index] : null;
+
+                // we use a string separator rather than array to
+                // not corrupt ordering on xValue
+                return `${xValue}\x00${seriesVal}`;
+            });
+        },
+
+        loadChartData: (displayCtrl) => {
+            displayCtrl.chart
+                .dimension(displayCtrl.dimension)
+                .group(displayCtrl.group)
+                // value is the y axis
+                .valueAccessor(displayCtrl.getValueAccessor(displayCtrl.getColumnsForAxis('y')[0]))
+                .keyAccessor((d) => d.key.split('\x00')[0]);
+
+            const seriesCol = displayCtrl.getColumnsForAxis('w').length ? displayCtrl.getColumnsForAxis('w')[0] : null;
+
+            if (seriesCol) {
+                displayCtrl.chart.seriesAccessor((d) => d.key.split('\x00')[1])
+            }
+
+            displayCtrl.buildCoordinateGrid();
+        }
+    }));
+})(angular, CRM.$, CRM._, CRM.chart_kit.dc);
+

--- a/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitSeries.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitSeries.service.js
@@ -8,6 +8,7 @@
 
         getInitialDisplaySettings: () => ({
           showLegend: 'right',
+          seriesDisplayType: 'line',
         }),
 
         getAxes: function () {
@@ -60,6 +61,7 @@
         },
 
         loadChartData: (displayCtrl) => {
+            displayCtrl.chart.chart((displayCtrl.settings.seriesDisplayType === 'bar') ? dc.barChart : dc.lineChart);
             displayCtrl.chart
                 .dimension(displayCtrl.dimension)
                 .group(displayCtrl.group)

--- a/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitSeriesAdmin.html
+++ b/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitSeriesAdmin.html
@@ -1,0 +1,16 @@
+<div class="crm-chart-kit-series-admin">
+
+  <div ng-include="'~/crmChartKit/chartKitAdminColumns.html'"></div>
+
+  <div class="crm-chart-kit-admin-presentation">
+
+    <div ng-include="'~/crmChartKit/chartKitAdminCanvas.html'"></div>
+
+    <fieldset>
+      <legend>{{:: ts('Series options') }}</legend>
+        <div ng-include="'~/crmChartKit/chartKitAdminLegend.html'" />
+    </fieldset>
+
+  </div>
+
+</div>

--- a/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitSeriesAdmin.html
+++ b/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitSeriesAdmin.html
@@ -8,7 +8,19 @@
 
     <fieldset>
       <legend>{{:: ts('Series options') }}</legend>
-        <div ng-include="'~/crmChartKit/chartKitAdminLegend.html'" />
+      <div ng-include="'~/crmChartKit/chartKitAdminLegend.html'" />
+      <div class="form-inline">
+        <label>
+          {{:: ts('Show as') }}
+        </label>
+        <select
+          ng-model="$ctrl.display.settings.seriesDisplayType"
+          class="form-control crm-search-display-chart-series-display-type"
+          >
+          <option value="line">{{:: ts('Lines') }}</option>
+          <option value="bar">{{:: ts('Bars') }}</option>
+        </select>
+      </div>
     </fieldset>
 
   </div>


### PR DESCRIPTION
Overview
----------------------------------------
Adds additional chart kit chart type Series Chart.

This allows plotting multi-line data according to the value of a given column - e.g. "Activity Type" or "Contact Type". (Previously multi-line/bar charts require having separate columns - e.g. Total Amount, Tax Amount)

![image](https://github.com/user-attachments/assets/c4e767f4-c0ca-4a07-bc6b-261980a9f50e)



Technical Details
----------------------------------------
We have to create a 2-part dimension when we build the chart. This PR splits out the `buildCrossfilter` step from the render pipeline of the main chart component to allow more fine-grained overriding in the chart type (ie we can build a custom dimension, but use the standard grouping function).

Comments
----------------------------------------
I've updated all the chart type icons to use Font Awesome 6 icons. There aren't really enough chart icons in the Free iconset for our different types, but I've tried to make the best of what we have:

![image](https://github.com/user-attachments/assets/b770aea4-76a4-4c81-ad4c-bf9d2814ad9e)

