### PR TITLE
Avoid JS error when user does not have permission to save the template

### DIFF
--- a/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
@@ -305,6 +305,9 @@ function convertMetric( value, from, to ) {
 }
 
 function showSaveDetails(chkbox)  {
+    if (chkbox === undefined) {
+      return;
+    }
     var formatSelected = ( document.getElementById('format_id').value > 0 );
     var templateSelected = ( document.getElementById('template') != null && document.getElementById('template').value > 0 );
     if (chkbox.checked) {


### PR DESCRIPTION
Overview
----------------------------------------
Avoid JS error when user does not have permission to save the template

I hit this attempting to replicate https://lab.civicrm.org/dev/core/-/issues/5463 but it differs from the js error reported there

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/98bc6d89-13ec-44c1-bc2b-287ac4227658)


After
----------------------------------------
early return if the element does not exist

Technical Details
----------------------------------------

Comments
----------------------------------------
