### PR TITLE
ChartKit - add week as a date rounding option

### DIFF
--- a/ext/chart_kit/ang/crmChartKit/chartKitColumnConfig.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartKitColumnConfig.service.js
@@ -56,6 +56,10 @@
                     label: ts('Month'),
                 },
                 {
+                    key: 'week',
+                    label: ts('Week'),
+                },
+                {
                     key: 'day',
                     label: ts('Day'),
                 },

--- a/ext/chart_kit/ang/crmChartKit/crmSearchDisplayChartKit.component.js
+++ b/ext/chart_kit/ang/crmChartKit/crmSearchDisplayChartKit.component.js
@@ -108,6 +108,9 @@
                         case 'month':
                             value = d3.timeMonth.floor(Date.parse(value)).valueOf();
                             break;
+                        case 'week':
+                            value = d3.timeWeek.floor(Date.parse(value)).valueOf();
+                            break;
                         case 'day':
                             value = d3.timeDay.floor(Date.parse(value)).valueOf();
                             break;
@@ -536,8 +539,10 @@
                     case 'month':
                         value = new Date(value).toLocaleString(undefined, {year: 'numeric', month: 'long'});
                         break;
+                    case 'week':
+                        value = new Date(value).toLocaleString(undefined, {year: 'numeric', month: 'long', day: 'numeric'});
+                        break;
                     case 'day':
-                        //value = (new Date(value)).toLocaleDateString();
                         value = new Date(value).toLocaleString(undefined, {year: 'numeric', month: 'long', day: 'numeric'});
                         break;
                     case 'hour':


### PR DESCRIPTION
Overview
----------------------------------------
Adds week as an additional rounding bucket option for Datetime columns

After
----------------------------------------
Can make e.g.
![image](https://github.com/user-attachments/assets/7ff4eb7b-d57d-49ec-8719-188e4db682a8)
