### PR TITLE
dev/core#5443 - (5.77 backport) Fix crash when using a saved import mapping with a file with more columns

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -189,7 +189,7 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
     foreach ($this->getColumnHeaders() as $i => $columnHeader) {
       $defaults["mapper[$i]"] = [];
       if ($this->getSubmittedValue('savedMapping')) {
-        $fieldMapping = $fieldMappings[$i] ?? NULL;
+        $fieldMapping = $fieldMappings[$i] ?? [];
         $this->addMappingToDefaults($defaults, $fieldMapping, $i);
       }
       elseif ($this->getSubmittedValue('skipColumnHeader')) {


### PR DESCRIPTION
Overview
----------------------------------------
backport https://github.com/civicrm/civicrm-core/pull/31065