### PR TITLE
Event Register: tweak statusBounce on some error messages

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -381,7 +381,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
           $isPaidEvent = $this->_values['event']['is_monetary'] ?? NULL;
         }
         if ($isPaidEvent && empty($this->getPriceFieldMetaData())) {
-          CRM_Core_Error::statusBounce(ts('No Fee Level(s) or Price Set is configured for this event.<br />Click <a href=\'%1\'>CiviEvent >> Manage Event >> Configure >> Event Fees</a> to configure the Fee Level(s) or Price Set for this event.', [1 => CRM_Utils_System::url('civicrm/event/manage/fee', 'reset=1&action=update&id=' . $this->_eventId)]));
+          CRM_Core_Error::statusBounce(ts('Click <a href=\'%1\'>CiviEvent >> Manage Event >> Configure >> Event Fees</a> to configure the Fee Level(s) or Price Set for this event.', [1 => CRM_Utils_System::url('civicrm/event/manage/fee', 'reset=1&action=update&id=' . $this->_eventId)]), $this->getInfoPageUrl(), ts('No Fee Level(s) or Price Set is configured for this event.'));
         }
       }
 
@@ -1648,8 +1648,9 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
   protected function checkValidEvent(): void {
     // is the event active (enabled)?
     if (!$this->_values['event']['is_active']) {
-      // form is inactive, die a fatal death
-      CRM_Core_Error::statusBounce(ts('The event you requested is currently unavailable (contact the site administrator for assistance).'));
+      // Form is inactive, redirect to the list of events
+      $urlList = CRM_Utils_System::url('civicrm/event/list', FALSE, NULL, FALSE, TRUE);
+      CRM_Core_Error::statusBounce(ts('The event you requested is currently unavailable (contact the site administrator for assistance).'), $urlList);
     }
 
     // is online registration is enabled?


### PR DESCRIPTION
Overview
----------------------------------------

When we encounter certain errors, the statusBounce (redirection) sometimes leads to pages where we will not see the error message.

- If the Event does not have a valid price set, we get bounced, and most likely to the front page, so if the site is using a CMS, we will not see the bounce reason.
- If the Event is not active, we also get bounced to the front page.

Before
----------------------------------------

Bounce to front page, no error message displayed (since we are not in CiviCRM anymore, when using a CMS).

After
----------------------------------------

We can see error messages.

Technical Details
----------------------------------------

statusBounce usage more in line with other usages on that form.

Comments
----------------------------------------

I'm sure some people will say that `event/list` is an obscure ugly feature no one knows about, but .. maybe we can improve that too :)