### PR TITLE
Event Settings: rename labels for public listing, calendar links

### DIFF
--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -157,10 +157,10 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
 
     $this->add('textarea', 'summary', ts('Event Summary'), $attributes['summary']);
     $this->add('wysiwyg', 'description', ts('Complete Description'), $attributes['event_description'] + ['preset' => 'civievent']);
-    $this->addElement('checkbox', 'is_public', ts('Public Event'));
-    $this->addElement('checkbox', 'is_share', ts('Add footer region with Twitter, Facebook and LinkedIn share buttons and scripts?'));
-    $this->addElement('checkbox', 'is_map', ts('Include Map to Event Location'));
-    $this->addElement('checkbox', 'is_show_calendar_links', ts('Show Calendar Links'));
+    $this->addElement('checkbox', 'is_public', ts('Display the event in public listings'));
+    $this->addElement('checkbox', 'is_share', ts('Social media sharing links'));
+    $this->addElement('checkbox', 'is_map', ts('Map to the event location'));
+    $this->addElement('checkbox', 'is_show_calendar_links', ts('Calendar links'));
 
     $this->add('datepicker', 'start_date', ts('Start'), [], !$this->_isTemplate, ['time' => TRUE]);
     $this->add('datepicker', 'end_date', ts('End'), [], FALSE, ['time' => TRUE]);
@@ -181,7 +181,7 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
 
     $this->add('textarea', 'event_full_text', ts('Message if Event Is Full'), $attributes['event_full_text']);
 
-    $this->addElement('checkbox', 'is_active', ts('Is this Event Active?'));
+    $this->addElement('checkbox', 'is_active', ts('Event is active'));
 
     $this->addFormRule(['CRM_Event_Form_ManageEvent_EventInfo', 'formRule']);
     if ($this->isSubmitted()) {

--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.hlp
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.hlp
@@ -95,11 +95,26 @@
 {ts 1=$mapURL}Include map presenting event location on event information page? (A map provider must be configured under <a href='%1'>Administer > System Settings > Mapping and Geocoding</a>){/ts}
 {/htxt}
 
+{htxt id="id-is_show_calendar_links-title"}
+  {ts}Calendar Links{/ts}
+{/htxt}
+{htxt id="id-is_show_calendar_links"}
+{ts}Displays links to download an iCal file with the event information, as well as a link to add to Google Calendar. The links will be displayed on the event information page, as well as on the thank-you page and in the email receipt.{/ts}
+{/htxt}
+
+{htxt id="id-is_active-title"}
+  {ts}Event is active{/ts}
+{/htxt}
+{htxt id="id-is_active"}
+<p>{ts}Enables the Event Information page, which also allows access to Event Registration (if registrations are open).{/ts}</p>
+{/htxt}
+
 {htxt id="id-is_public-title"}
   {ts}Public Events{/ts}
 {/htxt}
 {htxt id="id-is_public"}
-<p>{ts}When enabled, this event will be included in iCalendar feeds and displayed on your site's "Upcoming Events" block.{/ts}</p>
+{capture assign=eventsURL}target="_blank" href="{crmURL p="civicrm/event/list" q="reset=1" fe=1 h=1}"{/capture}
+<p>{ts 1=$eventsURL}When enabled, this event will be included in iCalendar feeds and displayed on your site's <a %1>Upcoming Events</a> block.{/ts}</p>
 {/htxt}
 
 {htxt id="id-is_share-title"}

--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
@@ -89,25 +89,29 @@
         <td>{$form.waitlist_text.html}</td>
       {/if}
     </tr>
-    <tr class="crm-event-manage-eventinfo-form-block-is_map">
+    <tr class="crm-event-manage-eventinfo-form-block-is_active">
       <td>&nbsp;</td>
-      <td>{$form.is_map.html} {$form.is_map.label} {help id="id-is_map"}</td>
+      <td>{$form.is_active.html} {$form.is_active.label} {help id="id-is_active"}</td>
     </tr>
     <tr class="crm-event-manage-eventinfo-form-block-is_public">
       <td>&nbsp;</td>
       <td>{$form.is_public.html} {$form.is_public.label} {help id="id-is_public"}</td>
     </tr>
-    <tr class="crm-event-manage-eventinfo-form-block-is_share">
+    <tr class="crm-event-manage-eventinfo-form-block-separator">
       <td>&nbsp;</td>
-      <td>{$form.is_share.html} {$form.is_share.label} {help id="id-is_share"}
+      <td>{ts}Display event information:{/ts}</td>
     </tr>
-    <tr class="crm-event-manage-eventinfo-form-block-is_active">
+    <tr class="crm-event-manage-eventinfo-form-block-is_map">
       <td>&nbsp;</td>
-      <td>{$form.is_active.html} {$form.is_active.label}</td>
+      <td>{$form.is_map.html} {$form.is_map.label} {help id="id-is_map"}</td>
     </tr>
     <tr class="crm-event-manage-eventinfo-form-block-is_show_calendar_links">
       <td>&nbsp;</td>
-      <td>{$form.is_show_calendar_links.html} {$form.is_show_calendar_links.label}</td>
+      <td>{$form.is_show_calendar_links.html} {$form.is_show_calendar_links.label} {help id="id-is_show_calendar_links"}</td>
+    </tr>
+    <tr class="crm-event-manage-eventinfo-form-block-is_share">
+      <td>&nbsp;</td>
+      <td>{$form.is_share.html} {$form.is_share.label} {help id="id-is_share"}
     </tr>
 
     {if $eventID AND !$isTemplate}


### PR DESCRIPTION
Overview
----------------------------------------

Renames some settings on Manage Event.

This are perhaps obvious to many experienced CiviCRM users, but I find that they systematically cause discomfort to admins during training.

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/1798653a-a5b2-4521-b4e5-e7a34db458fd)

After
----------------------------------------

![image](https://github.com/user-attachments/assets/efafdce0-791f-41fe-a264-f6fca20934c6)
