### PR TITLE
Add unit test for getDuplicates behaviour on Register task

### DIFF
--- a/tests/phpunit/CRM/Event/Form/Task/RegisterTest.php
+++ b/tests/phpunit/CRM/Event/Form/Task/RegisterTest.php
@@ -19,4 +19,51 @@ class CRM_Event_Form_Task_RegisterTest extends CiviUnitTestCase {
     $this->assertEquals(FALSE, $form->_single);
   }
 
+  /**
+   * Test that duplicate participants are not registered.
+   *
+   * @dataProvider participantDataProvider
+   *
+   * @return void
+   */
+  public function testRegisterDuplicateParticipant(array $participantValues, bool $isDuplicate): void {
+    $event = $this->eventCreateUnpaid();
+
+    $this->participantCreate($participantValues + ['event_id' => $event['id'], 'contact_id' => $this->individualCreate([])]);
+
+    $this->getTestForm('CRM_Contact_Form_Search_Basic', [
+      'radio_ts' => 'ts_all',
+      ['contact_id', 'IN', $this->ids['Contact']],
+      'task' => CRM_Core_Task::BATCH_UPDATE,
+    ], ['action' => 1])
+      ->addSubsequentForm('CRM_Event_Form_Task_Register', ['event_id' => $this->getEventID()])
+      ->processForm();
+    $message = CRM_Core_Session::singleton()->getStatus();
+    if ($isDuplicate) {
+      $this->assertEquals('1 contacts have already been assigned to this event. They were not added a second time.', $message[0]['text']);
+      $this->assertEquals('No participants were added.', $message[1]['text']);
+    }
+    else {
+      $this->assertEquals('Total Participant(s) added to event: 1.', $message[0]['text']);
+    }
+  }
+
+  public function participantDataProvider(): array {
+    return [
+      'basic' => [
+        'participant_values' => [],
+        'duplicate' => TRUE,
+      ],
+      'different_event' => [
+        'participant_values' => ['is_test' => TRUE],
+        'duplicate' => FALSE,
+      ],
+      'cancelled' => [
+        'participant_values' => ['participant_status_id.name' => 'Cancelled'],
+        // @todo - TRUE is existing behaviour but it might be better to change the behaviour.
+        'duplicate' => TRUE,
+      ],
+    ];
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Add unit test for getDuplicates behaviour on Register task Form

Before
----------------------------------------
No test cover & discussion coming out of the order api group is that writing unit tests is blocked on not being sure how to tackle them. Hence I figured I would write one for one of the forms touched in https://github.com/civicrm/civicrm-core/pull/30698 to provide some help with that. This is probably the most difficult form as there was no existing test for the `postProcess()` function on this form, whereas the others all have many (the online ones are in the `CRM_Event_Form_Registration_ConfirmTestt` class)

After
----------------------------------------
Unit test added for the Register participants form. I also did a minor extraction of the functionality involved. There has been discussion on #30698 about treating `is_test` the same here as on other forms so I added that.

I think it makes sense to also add the cancelled status filter  (as per the other back office form) - but I didn't find existing discussion on that so I just commented it.

Technical Details
----------------------------------------
This is mostly to try to help unblock the process of getting tests written to allow parts of #30698 to be merged.

I did a minor refactor - extracting the few lines of code to a function - which would make it easier to update that function to call the relevant api once one exists

Note that
- the `getTestForm()->processForm()` is now the preferred way to test forms - there are instances in the tests of older approaches

Comments
----------------------------------------
In general with a piece of work like #30698, if I were doing it myself I would probably do 20+ incremental PRs like this (I realise that probably sounds like a crazy high number), with each one adding unit tests, under the belief that most of the value is in the scoping out & the tests and that it would be hard to get someone to review a large refactor PR that changes multiple forms in ways that do not have good test cover. The code in the form layer & `BAO` layer would change multiple times, sometimes for the better, and probably sometimes for the worse, in the process but it would become incrementally more stable with the tests and ultimately reach a point where the forms could be safely updated to call the (tested) `validate` & `getduplicates` apis appropriately (possibly from shared functions on the `EventFormTrait` rather than directly from the individual forms since any api function would be written as makes sense for an api, & it might require some contortion for legacy forms to call it ) 