### PR TITLE
Standalone login improvements (message/theme/events)

### DIFF
--- a/CRM/Core/Session.php
+++ b/CRM/Core/Session.php
@@ -452,10 +452,11 @@ class CRM_Core_Session {
    * Stores an alert to be displayed to the user via crm-messages.
    *
    * @param string $text
-   *   The status message
+   *   The status message.
    *
    * @param string $title
-   *   The optional title of this message
+   *   The optional title of this message. For accessibility reasons,
+   *   please terminate with a full stop/period.
    *
    * @param string $type
    *   The type of this message (printed as a css class). Possible options:

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -602,7 +602,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
       // render a login page
       if (class_exists('CRM_Standaloneusers_Page_Login')) {
         $loginPage = new CRM_Standaloneusers_Page_Login();
-        CRM_Core_Session::setStatus(ts('You need to be logged in to access this page.'), ts('Please sign in'));
+        CRM_Core_Session::setStatus(ts('You need to be logged in to access this page.'), ts('Please sign in.'));
         return $loginPage->run();
       }
 

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -602,7 +602,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
       // render a login page
       if (class_exists('CRM_Standaloneusers_Page_Login')) {
         $loginPage = new CRM_Standaloneusers_Page_Login();
-        $loginPage->assign('anonAccessDenied', TRUE);
+        CRM_Core_Session::setStatus(ts('You need to be logged in to access this page.'), ts('Please sign in'));
         return $loginPage->run();
       }
 

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformRoutingTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformRoutingTest.php
@@ -84,7 +84,7 @@ class AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \Civi\Tes
   private function assertNotAuthorized(\Psr\Http\Message\ResponseInterface $result, string $directive) {
     $contents = $result->getBody()->getContents();
     $this->assertEquals(403, $result->getStatusCode());
-    $this->assertMatchesRegularExpression(';(You are not authorized to access|You do not have permission to access);', $contents);
+    $this->assertMatchesRegularExpression(';(You are not authorized to access|You do not have permission to access|You need to be logged in to access this page);', $contents);
     $this->assertDoesNotMatchRegularExpression(';' . preg_quote("<$directive>", ';') . ';', $contents);
   }
 
@@ -96,7 +96,7 @@ class AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \Civi\Tes
   private function assertOpensPage(\Psr\Http\Message\ResponseInterface $result, string $directive) {
     $contents = $result->getBody()->getContents();
     $this->assertEquals(200, $result->getStatusCode());
-    $this->assertDoesNotMatchRegularExpression(';(You are not authorized to access|You do not have permission to access);', $contents);
+    $this->assertDoesNotMatchRegularExpression(';(You are not authorized to access|You do not have permission to access|You need to be logged in to access this page);', $contents);
     $this->assertMatchesRegularExpression(';' . preg_quote("<$directive>", ';') . ';', $contents);
   }
 

--- a/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
@@ -8,14 +8,27 @@ class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
       // Already logged in.
       CRM_Utils_System::redirect('/civicrm');
     }
+    if (isset($_GET['justLoggedOut'])) {
+      // When the user has just logged out their session is destroyed
+      // so we are unable to use setStatus in that request. Here we
+      // add the session message and redirect so the user doesn't keep getting
+      // the message when they press Back.
+      CRM_Core_Session::setStatus(
+        ts('You have been logged out.'),
+        ts('Successfully signed out'),
+        'success');
+      CRM_Utils_System::redirect('/civicrm/login');
+    }
 
     $this->assign('logoUrl', E::url('images/civicrm-logo.png'));
     $this->assign('pageTitle', '');
     $this->assign('forgottenPasswordURL', CRM_Utils_System::url('civicrm/login/password'));
     // Remove breadcrumb for login page.
     $this->assign('breadcrumb', NULL);
-    $this->assign('justLoggedOut', isset($_GET['justLoggedOut']));
-    $this->assign('sessionLost', isset($_GET['sessionLost']));
+
+    // statusMessages are usually at top of page but in login forms they look much better
+    // inside the main box.
+    $this->assign('statusMessages', CRM_Core_Smarty::singleton()->fetch("CRM/common/status.tpl"));
 
     parent::run();
   }

--- a/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
@@ -15,7 +15,7 @@ class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
       // the message when they press Back.
       CRM_Core_Session::setStatus(
         ts('You have been logged out.'),
-        ts('Successfully signed out'),
+        ts('Successfully signed out.'),
         'success');
       CRM_Utils_System::redirect('/civicrm/login');
     }

--- a/ext/standaloneusers/CRM/Standaloneusers/Page/TOTP.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/TOTP.php
@@ -23,15 +23,15 @@ class CRM_Standaloneusers_Page_TOTP extends CRM_Core_Page {
       || (($pending['expiry'] ?? 0) < time())
     ) {
       // Invalid, send user back to login.
-      CRM_Core_Session::singleton()->set('pendingLogin', []);
+      $pending = CRM_Core_Session::singleton()->set('pendingLogin', []);
+      CRM_Core_Session::setStatus('Please try again.', 'Session expired', 'warning');
       CRM_Utils_System::redirect('/civicrm/login');
     }
 
-    // In order to ask for TOTP, we need to have it set up.
-    $mfa = new TOTP($pending['userID']);
-    if (!$mfa->userHasCompletedSetup()) {
-      CRM_Utils_System::redirect('/civicrm/mfa/totp-setup');
-    }
+    // CRM_Core_Session::setStatus('hello', 'oi!', 'success');
+    // statusMessages are usually at top of page but in login forms they look much better
+    // inside the main box.
+    $this->assign('statusMessages', CRM_Core_Smarty::singleton()->fetch("CRM/common/status.tpl"));
 
     $this->assign('pageTitle', '');
     $this->assign('logoUrl', E::url('images/civicrm-logo.png'));

--- a/ext/standaloneusers/CRM/Standaloneusers/Page/TOTP.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/TOTP.php
@@ -2,7 +2,6 @@
 
 use CRM_Standaloneusers_ExtensionUtil as E;
 use Civi\Standalone\MFA\Base as MFABase;
-use Civi\Standalone\MFA\TOTP;
 
 /**
  * Page for /civicrm/mfa/totp

--- a/ext/standaloneusers/CRM/Standaloneusers/Page/TOTP.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/TOTP.php
@@ -27,9 +27,8 @@ class CRM_Standaloneusers_Page_TOTP extends CRM_Core_Page {
       CRM_Utils_System::redirect('/civicrm/login');
     }
 
-    // CRM_Core_Session::setStatus('hello', 'oi!', 'success');
     // statusMessages are usually at top of page but in login forms they look much better
-    // inside the main box.
+    // inside the main box, so we assign them to this var for the tpl to output.
     $this->assign('statusMessages', CRM_Core_Smarty::singleton()->fetch("CRM/common/status.tpl"));
 
     $this->assign('pageTitle', '');

--- a/ext/standaloneusers/CRM/Standaloneusers/Page/TOTPSetup.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/TOTPSetup.php
@@ -36,6 +36,11 @@ class CRM_Standaloneusers_Page_TOTPSetup extends CRM_Core_Page {
       CRM_Utils_System::redirect('/civicrm/mfa/totp');
     }
 
+    // CRM_Core_Session::setStatus('hello', 'oi!', 'success');
+    // statusMessages are usually at top of page but in login forms they look much better
+    // inside the main box.
+    $this->assign('statusMessages', CRM_Core_Smarty::singleton()->fetch("CRM/common/status.tpl"));
+
     $totp = new \Civi\Standalone\MFA\TOTP($pending['userID']);
 
     $seed = $totp->generateNew();
@@ -54,7 +59,7 @@ class CRM_Standaloneusers_Page_TOTPSetup extends CRM_Core_Page {
         'issuer' => $domain,
       ]);
     $barcodeobj = new TCPDF2DBarcode($url, 'QRCODE,H');
-    $this->assign('totpqr', $barcodeobj->getBarcodeHTML(6, 6, 'black'));
+    $this->assign('totpqr', $barcodeobj->getBarcodeHTML(4, 4, 'black'));
 
     $this->assign('logoUrl', E::url('images/civicrm-logo.png'));
     $this->assign('pageTitle', '');

--- a/ext/standaloneusers/CRM/Standaloneusers/Page/TOTPSetup.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/TOTPSetup.php
@@ -36,9 +36,8 @@ class CRM_Standaloneusers_Page_TOTPSetup extends CRM_Core_Page {
       CRM_Utils_System::redirect('/civicrm/mfa/totp');
     }
 
-    // CRM_Core_Session::setStatus('hello', 'oi!', 'success');
     // statusMessages are usually at top of page but in login forms they look much better
-    // inside the main box.
+    // inside the main box, so we assign them to this var for the tpl to output.
     $this->assign('statusMessages', CRM_Core_Smarty::singleton()->fetch("CRM/common/status.tpl"));
 
     $totp = new \Civi\Standalone\MFA\TOTP($pending['userID']);

--- a/ext/standaloneusers/Civi/Api4/Action/User/Login.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/Login.php
@@ -1,8 +1,10 @@
 <?php
 namespace Civi\Api4\Action\User;
 
+use Civi;
 use Civi\Api4\Generic\AbstractAction;
 use Civi\Api4\Generic\Result;
+use Civi\Standalone\Event\LoginEvent;
 use Civi\Standalone\MFA\Base as MFABase;
 use Civi\Standalone\Security;
 
@@ -58,7 +60,7 @@ class Login extends AbstractAction {
       return $this->passwordCheck($result);
     }
     else {
-      // This call is from an MFA class, needing to check the mfaData.
+      // This call is from Javascript from an MFA class, needing to check the mfaData.
       $mfaClass = MFABase::classIsAvailable($this->mfaClass);
       if (!$mfaClass) {
         \CRM_Core_Session::singleton()->set('pendingLogin', []);
@@ -68,12 +70,15 @@ class Login extends AbstractAction {
       $pending = MFABase::getPendingLogin();
       if (!$pending) {
         // Invalid, send user back to login.
-        $result['url'] = '/civicrm/login?sessionLost';
+        \CRM_Core_Session::setStatus('Please try again.', 'Session expired', 'warning');
+        $result['url'] = '/civicrm/login';
         return;
       }
 
       $mfa = new $mfaClass($pending['userID']);
       $okToLogin = $mfa->processMFAAttempt($pending, $this->mfaData);
+      $event = new LoginEvent($pending['userID'], 'post_mfa', $okToLogin ? NULL : 'wrongMFA');
+      Civi::dispatcher()->dispatch('civi.standalone.login', $event);
       if ($okToLogin) {
         // OK!
         \CRM_Core_Session::singleton()->set('pendingLogin', []);
@@ -107,9 +112,25 @@ class Login extends AbstractAction {
       return;
     }
     $security = Security::singleton();
+    $user = \Civi\Api4\User::get(FALSE)
+      ->addWhere('username', '=', $this->username)
+      ->addWhere('is_active', '=', TRUE)
+      ->addSelect('hashed_password', 'id')
+      ->execute()->first();
+
+    // Allow flood control (etc.) by extensions.
+    $event = new LoginEvent($user['id'] ?? NULL, 'pre_credentials_check');
+    Civi::dispatcher()->dispatch('civi.standalone.login', $event);
+    if ($event->stopReason) {
+      $result['url'] = '/civicrm/login?' . $event->stopReason;
+    }
+
     $userID = $security->checkPassword($this->username, $this->password);
     if (!$userID) {
       $result['publicError'] = "Invalid credentials";
+      // Allow monitoring of failed attempts.
+      $event = new LoginEvent($user['id'] ?? NULL, 'post_credentials_check', 'wrongUserPassword');
+      Civi::dispatcher()->dispatch('civi.standalone.login', $event);
       return;
     }
     // Password is ok. Do we have mfa configured?
@@ -154,6 +175,8 @@ class Login extends AbstractAction {
 
   protected function loginUser(int $userID) {
     _authx_uf()->loginSession($userID);
+    $event = new LoginEvent($userID, 'post_login');
+    Civi::dispatcher()->dispatch('civi.standalone.login', $event);
   }
 
 }

--- a/ext/standaloneusers/Civi/Api4/Action/User/PasswordReset.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/PasswordReset.php
@@ -3,7 +3,7 @@ namespace Civi\Api4\Action\User;
 
 use Civi\Api4\Generic\Result;
 use Civi\Standalone\Security;
-use API_Exception;
+use CRM_Core_Exception;
 use Civi\Api4\User;
 use Civi\Api4\Generic\AbstractAction;
 
@@ -33,7 +33,7 @@ class PasswordReset extends AbstractAction {
   public function _run(Result $result) {
 
     if (empty($this->password)) {
-      throw new API_Exception("Invalid password");
+      throw new CRM_Core_Exception("Invalid password");
     }
 
     // todo: some minimum password quality check?
@@ -41,7 +41,7 @@ class PasswordReset extends AbstractAction {
     // Only valid change here is password, for a known ID.
     $userID = Security::singleton()->checkPasswordResetToken($this->token);
     if (!$userID) {
-      throw new API_Exception("Invalid token.");
+      throw new CRM_Core_Exception("Invalid token.");
     }
 
     User::update(FALSE)

--- a/ext/standaloneusers/Civi/Api4/Action/User/SendPasswordReset.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/SendPasswordReset.php
@@ -8,16 +8,14 @@ namespace Civi\Api4\Action\User;
 
 use Civi;
 use Civi\Api4\Generic\Result;
-use API_Exception;
+use CRM_Core_Exception;
 use Civi\Api4\User;
 use Civi\Standalone\Security;
 use Civi\Api4\Generic\AbstractAction;
 
 /**
- * @class API_Exception
- */
-
-/**
+ * @class SendPasswordReset
+ *
  * This is designed to be a public API
  *
  * @method static setIdentifier(string $identifier)
@@ -37,7 +35,7 @@ class SendPasswordReset extends AbstractAction {
 
     $identifier = trim($this->identifier);
     if (!$identifier) {
-      throw new API_Exception("Missing identifier");
+      throw new CRM_Core_Exception("Missing identifier");
     }
 
     $user = User::get(FALSE)

--- a/ext/standaloneusers/Civi/Api4/Action/User/WriteTrait.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/WriteTrait.php
@@ -53,10 +53,10 @@ trait WriteTrait {
     }
     if (array_key_exists('password', $record)) {
       if (!empty($record['hashed_password'])) {
-        throw new \API_Exception("Ambiguous password parameters: Cannot pass password AND hashed_password.");
+        throw new \CRM_Core_Exception("Ambiguous password parameters: Cannot pass password AND hashed_password.");
       }
       if (empty($record['password'])) {
-        throw new \API_Exception("Disallowing empty password.");
+        throw new \CRM_Core_Exception("Disallowing empty password.");
       }
     }
     parent::formatWriteValues($record);

--- a/ext/standaloneusers/Civi/Standalone/Event/LoginEvent.php
+++ b/ext/standaloneusers/Civi/Standalone/Event/LoginEvent.php
@@ -1,0 +1,103 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Standalone\Event;
+
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * Class LoginEvent
+ *
+ * This event (civi.standalone.login) is fired various times during the
+ * standalone login process.
+ *
+ * Generally, listeners may set stopReason to a valid string (see below)
+ * to prevent login continuing.
+ */
+class LoginEvent extends GenericHookEvent {
+
+  /**
+   * What stage are we at?
+   *
+   * Valid values:
+   *
+   * - 'pre_credentials_check'
+   *
+   *   userID should be set if the user exists but the password
+   *   has not been checked yet. Example use: per IP/per user flood checks.
+   *
+   * - 'post_credentials_check'
+   *
+   *   userID must be set; password has been checked and stopReason
+   *   should be 'wrongUserPassword' or NULL.
+   *   Example use: limit incorrect password attempts per user.
+   *
+   * - 'post_mfa'
+   *
+   *   userID must be set; password was OK. stopReason should be
+   *   'wrongMFA' (about to reject login)' or NULL (login about to happen).
+   *   Example use: identify suspicious activity?
+   *
+   * - 'post_login'
+   *
+   *   userID is set; password and possibly MFA were correct. User is
+   *   successfully logged in. Setting stopReason would have no effect.
+   *   Example use: monitor logins.
+   *
+   * @var string
+   */
+  public $stage;
+
+  /**
+   * The user ID of the user attempting to login.
+   *
+   * NULL if the username provided was invalid.
+   *
+   * @var int
+   */
+  public $userID;
+
+  /**
+   * If set, authentication will not proceed.
+   *
+   * It may be set when the event is created or altered by listeners,
+   * e.g. loginPrevented
+   *
+   * Valid values:
+   * - 'wrongUserPassword'
+   * - 'wrongMFA'
+   * - 'loginPrevented'
+   *
+   * @var null|string
+   */
+  public $stopReason = NULL;
+
+  /**
+   * Class constructor.
+   *
+   * @param string $stage
+   * @param int|null $userID
+   * @param string|null $stopReason
+   */
+  public function __construct($stage, $userID, $stopReason = NULL) {
+    $this->stage = $stage;
+    $this->userID = $userID;
+    $this->stopReason = $stopReason;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getHookValues() {
+    return [$this->stage, $this->userID, $this->stopReason];
+  }
+
+}

--- a/ext/standaloneusers/css/standalone.css
+++ b/ext/standaloneusers/css/standalone.css
@@ -8,11 +8,13 @@ html.crm-standalone  nav.breadcrumb>ol {
 
 .standalone-auth-form {
   display: grid;
-  place-content: center;
+  grid-template-rows: 1fr auto 3fr;
+  justify-content: center;
   width: 100%;
   height: 100vh;
 }
 .standalone-auth-box {
+  grid-row: 2;
   box-sizing: border-box;
   width: clamp(280px, 68vw, 45rem);
   margin: 0;
@@ -30,11 +32,13 @@ html.crm-standalone  nav.breadcrumb>ol {
 .standalone-auth-form .input-wrapper {
   margin-bottom: 1rem;
 }
-.standalone-auth-form label {
+/* the div.crm-container is to beat the specificity of civicrm.css under Greenwich */
+div.crm-container .standalone-auth-form label {
   display: block;
   margin-bottom: 0.25rem;
 }
-.standalone-auth-form input {
+/* the div.crm-container is to beat the specificity of civicrm.css under Greenwich */
+div.crm-container .standalone-auth-form input {
   box-sizing: border-box;
   width: 100%;
   height: 2rem;

--- a/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
+++ b/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
@@ -2,23 +2,19 @@
   <div class="standalone-auth-box">
     <form id=login-form>
       <img class="crm-logo" src="{$logoUrl}" alt="logo for CiviCRM, with an intersecting blue and green triangle">
-      {if $justLoggedOut}<div class="help message info">{ts}You have been logged out.{/ts}</div>{/if}
-      {if $anonAccessDenied}<div class="help message warning">
-        {ts}You do not have permission to access that. You may need to login.{/ts}
-      </div>{/if}
-      {if $sessionLost}<div class="help message warning">{ts}Your session timed out.{/ts}</div>{/if}
+      {$statusMessages}
       <div class="input-wrapper">
         <label for="usernameInput" name=username class="form-label">Username</label>
-        <input type="text" class="form-control" id="usernameInput">
+        <input type="text" class="form-control crm-form-text" id="usernameInput" >
       </div>
       <div class="input-wrapper">
         <label for="passwordInput" class="form-label">Password</label>
-        <input type="password" class="form-control" id="passwordInput">
+        <input type="password" class="form-control crm-form-text" id="passwordInput">
       </div>
       <div id="error" style="display:none;" class="form-alert">Your username and password do not match</div>
       <div class="login-or-forgot">
         <a href="{$forgottenPasswordURL}">Forgotten password?</a>
-        <button id="loginSubmit" type="submit" class="btn btn-secondary crm-button">Submit</button>
+        <button id="loginSubmit" type="submit" class="btn btn-primary crm-button">Submit</button>
       </div>
     </form>
   </div>

--- a/ext/standaloneusers/templates/CRM/Standaloneusers/Page/TOTP.tpl
+++ b/ext/standaloneusers/templates/CRM/Standaloneusers/Page/TOTP.tpl
@@ -2,6 +2,7 @@
   <div class="standalone-auth-box">
     <form id=totp-form>
       <img class="crm-logo" src="{$logoUrl}" alt="logo for CiviCRM, with an intersecting blue and green triangle">
+      {$statusMessages}
 
       <div class="input-wrapper">
         <label for="totpcode" name=totp class="form-label">{ts}Enter the code from your authenticator app{/ts}</label>
@@ -36,6 +37,7 @@
         console.error('caught', e);
       }
       alert(errorMsg);
+      totpcodeInput.value = '';
     }
 
     form.addEventListener('submit', submit);
@@ -44,6 +46,9 @@
         submit(e);
       }
     });
+
+    // Get ready for user to type code.
+    totpcodeInput.focus();
 
   });
 </script>

--- a/ext/standaloneusers/templates/CRM/Standaloneusers/Page/TOTPSetup.tpl
+++ b/ext/standaloneusers/templates/CRM/Standaloneusers/Page/TOTPSetup.tpl
@@ -2,6 +2,7 @@
   <div class="standalone-auth-box">
     <form id=totp-form>
       <img class="crm-logo" src="{$logoUrl}" alt="logo for CiviCRM, with an intersecting blue and green triangle">
+      {$statusMessages}
 
       <h1>{ts}Set up Multi-Factor Authentication{/ts}</h1>
       <div class="input-wrapper">
@@ -53,6 +54,7 @@
         submit(e);
       }
     });
+    totpcodeInput.focus();
 
   });
 </script>

--- a/tests/phpunit/E2E/Core/ErrorTest.php
+++ b/tests/phpunit/E2E/Core/ErrorTest.php
@@ -60,7 +60,7 @@ class ErrorTest extends \CiviEndToEndTestCase {
     $messages = [
       'fatal' => '/This is a fake problem \(fatal\)/',
       'exception' => '/This is a fake problem \(exception\)/',
-      'permission' => '/(You do not have permission|You are not authorized to access)/',
+      'permission' => '/(You do not have permission|You are not authorized to access|You need to be logged in to access this page)/',
     ];
     $response = $this->provokeError($url, $errorType);
     $this->assertBodyRegexp($messages[$errorType] ?? 'Test error: Invalid error type', $response);


### PR DESCRIPTION
Various standalone login related items:

1.  improves the standalone login and TOTP screens by using set status message + standard display of messages ("you have just been logged out" etc.)
2. Adds a new event class and fires it a bunch of times during the login process. There are no listeners to these events, but extensions could listen to them to implement things like flood control/monitoring etc.
3. Some code comment updates/clarifications.
4. TOTP: minor improvements: clear the field if a TOTP code was invalid; focus the field on page load.
5. Minor CSS change to login screens: position the form box up a bit; it was technically vertically centred but this did not *visually* appear centred due to the logo; i.e. it looked not-centred/weirdlylow on the page and now it's a bit nearer the top. Meh, but nicer.

