### PR TITLE
Standalone System - bring default Civi::paths factories in line with installer defaults

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -36,9 +36,8 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    */
   public function getDefaultFileStorage() {
     return [
-      'url' => 'upload',
-      // @todo Not sure if this is wise - what about CLI invocation?
-      'path' => $_SERVER['DOCUMENT_ROOT'],
+      'path' => \Civi::paths()->getPath('[cms.root]/public'),
+      'url' => \Civi::paths()->getUrl('[cms.root]/public'),
     ];
   }
 
@@ -361,31 +360,22 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    * @inheritdoc
    */
   public function getCiviSourceStorage(): array {
-    global $civicrm_root;
-
-    if (!defined('CIVICRM_UF_BASEURL')) {
-      throw new RuntimeException('Undefined constant: CIVICRM_UF_BASEURL');
-    }
-
     return [
-      'url' => CRM_Utils_File::addTrailingSlash(CIVICRM_UF_BASEURL, '/') . 'core/',
-      'path' => CRM_Utils_File::addTrailingSlash($civicrm_root),
+      'path' => Civi::paths()->getPath('[cms.root]/core'),
+      'url' => Civi::paths()->getUrl('[cms.root]/core'),
     ];
   }
 
   /**
-   * Determine the location of the CMS root.
+   * In Standalone, this returns the app root
    *
-   * @param string $path
+   * The $appRootPath global is set in civicrm.standalone.php
    *
    * @return NULL|string
    */
-  public function cmsRootPath($path = NULL) {
-    global $civicrm_paths;
-    if (!empty($civicrm_paths['cms.root']['path'])) {
-      return $civicrm_paths['cms.root']['path'];
-    }
-    throw new \RuntimeException("Standalone requires the path is set for now. Set \$civicrm_paths['cms.root']['path'] in civicrm.settings.php to the webroot.");
+  public function cmsRootPath() {
+    global $appRootPath;
+    return $appRootPath;
   }
 
   public function isFrontEndPage() {
@@ -599,6 +589,38 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
       'use_only_cookies' => 1,
       'use_strict_mode'  => 1,
     ]);
+  }
+
+  public function initialize() {
+    parent::initialize();
+    $this->registerDefaultPaths();
+  }
+
+  /**
+   * Specify the default computation for various paths/URLs.
+   */
+  protected function registerDefaultPaths(): void {
+    \Civi::paths()
+      ->register('civicrm.private', function () {
+          return [
+            'path' => \Civi::paths()->getPath('[cms.root]/private'),
+          ];
+      })
+      ->register('civicrm.compile', function () {
+        return [
+          'path' => \Civi::paths()->getPath('[civicrm.private]/cache'),
+        ];
+      })
+      ->register('civicrm.log', function () {
+        return [
+          'path' => \Civi::paths()->getPath('[civicrm.private]/log'),
+        ];
+      })
+      ->register('civicrm.l10n', function () {
+        return [
+          'path' => \Civi::paths()->getPath('[civicrm.private]/l10n'),
+        ];
+      });
   }
 
   /**

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -279,7 +279,17 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
   /**
    * Bootstrap Standalone.
    *
+   * In CRM_Utils_System context, this function is used by cv/civix/? to bootstrap
+   * the CMS *after* CiviCRM is already loaded (as compared to normal web requests,
+   * which load the CMS then CiviCRM)
+   *
+   * For Standalone there shouldn't be anything additional to load at this
+   * stage in terms of system services.
+   *
+   *
    * This is used by cv and civix, but not I (artfulrobot) think, in the main http requests.
+   * External scripts may assume loading a users requires the CMS bootstrap
+   * - so we keep support for logging in a user now
    *
    * @param array $params
    *   Either uid, or name & pass.
@@ -287,7 +297,8 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    *   Boolean Require CMS user load.
    * @param bool $throwError
    *   If true, print error on failure and exit.
-   * @param bool|string $realPath path to script
+   * @param bool|string $realPath
+   *   Not used in Standalone context
    *
    * @return bool
    * @Todo Handle setting cleanurls configuration for CiviCRM?
@@ -301,21 +312,6 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
     else {
       return TRUE;
     }
-
-    global $civicrm_paths;
-    require_once $civicrm_paths['civicrm.vendor']['path'] . '/autoload.php';
-
-    // seems like we've bootstrapped drupal
-    $config = CRM_Core_Config::singleton();
-    $config->cleanURL = 1;
-
-    // I don't *think* this applies to Standalone:
-    //
-    // we need to call the config hook again, since we now know
-    // all the modules that are listening on it, does not apply
-    // to J! and WP as yet
-    // CRM-8655
-    // CRM_Utils_Hook::config($config);
 
     if (!$loadUser) {
       return TRUE;


### PR DESCRIPTION
Overview
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/29960 updated the default Standalone directory structure in a somewhat brute force way - by setting path overrides in the installer, that are then written out into `civicrm.settings.php`

This returns to `CRM_Utils_System_Standalone` to bring the underlying defaults in line with the directory structure changes.

Before
----------------------------------------
`civicrm.settings.php` contains many path overrides
![image](https://github.com/user-attachments/assets/ed6888db-0156-4cbc-8f23-427fd28aaffa)

Even though they just reiterate our intended defaults, removing them will cause your system to crash because the underlying defaults are different.


After
----------------------------------------
The above overrides will all still be set by the installer.

But if you haven't diverged from the default, those lines can be safely removed.

This is a helpful step to reduce reliance on `civicrm.settings.php` in a portable context (e.g. Docker container). 

Technical Details
----------------------------------------
In many cases having these paths fixed in your `civicrm.settings.php` makes sense: if the defaults ever change in the codebase, your folders will still be where they were at install time, so the "frozen" copy of the paths is helpful.

But we shouldn't *rely* on the settings file to provide defaults.

Some extraneous bootstap code in `CRM_Utils_System_Standalone` is removed which otherwise caused a crash by trying to read directly `$civicrm_paths`. The line is trying to reload the autoloader - which is always handled in Standalone context by `civicrm.standalone.php`.