### PR TITLE
Add *.boot.setting.php meta for CIVICRM_UF_BASEURL and CIVICRM_DOMAIN_ID 

### DIFF
--- a/api/v3/Setting.php
+++ b/api/v3/Setting.php
@@ -156,6 +156,7 @@ function civicrm_api3_setting_revert($params) {
   $fields = $fields['values'];
   $domains = _civicrm_api3_setting_getDomainArray($params);
   $result = [];
+  $isError = FALSE;
   foreach ($domains as $domainID) {
     $valuesToRevert = array_intersect_key($defaults['values'][$domainID], $fields);
     if (!empty($valuesToRevert)) {
@@ -163,7 +164,14 @@ function civicrm_api3_setting_revert($params) {
       $valuesToRevert['domain_id'] = $domainID;
       // note that I haven't looked at how the result would appear with multiple domains in play
       $result = array_merge($result, civicrm_api('Setting', 'create', $valuesToRevert));
+      if ($result['is_error'] ?? FALSE) {
+        $isError = TRUE;
+      }
     }
+  }
+
+  if ($isError) {
+    return civicrm_api3_create_error('Error reverting settings');
   }
 
   return civicrm_api3_create_success($result, $params, 'Setting', 'revert');

--- a/api/v3/Setting.php
+++ b/api/v3/Setting.php
@@ -152,13 +152,17 @@ function civicrm_api3_setting_getoptions($params) {
  */
 function civicrm_api3_setting_revert($params) {
   $defaults = civicrm_api('Setting', 'getdefaults', $params);
-  $fields = civicrm_api('Setting', 'getfields', $params);
-  $fields = $fields['values'];
+  $allSettings = civicrm_api('Setting', 'getfields', $params)['values'] ?? [];
+  // constant settings can't be set through the API, so can't be reverted
+  // so we must filter them out here
+  $revertable = array_filter($allSettings, function ($settingMeta) {
+    return !($settingMeta['is_constant'] ?? FALSE);
+  });
   $domains = _civicrm_api3_setting_getDomainArray($params);
   $result = [];
   $isError = FALSE;
   foreach ($domains as $domainID) {
-    $valuesToRevert = array_intersect_key($defaults['values'][$domainID], $fields);
+    $valuesToRevert = array_intersect_key($defaults['values'][$domainID], $revertable);
     if (!empty($valuesToRevert)) {
       $valuesToRevert['version'] = $params['version'];
       $valuesToRevert['domain_id'] = $domainID;

--- a/settings/Core.boot.setting.php
+++ b/settings/Core.boot.setting.php
@@ -20,7 +20,6 @@
  */
 return [
   'installed' => [
-    'bootstrap_comment' => 'This is a boot setting which may be loaded during bootstrap.',
     'group_name' => 'CiviCRM Preferences',
     'group' => 'core',
     'name' => 'installed',
@@ -35,7 +34,6 @@ return [
     'help_text' => NULL,
   ],
   'enable_components' => [
-    'bootstrap_comment' => 'This is a boot setting which may be loaded during bootstrap.',
     'group_name' => 'CiviCRM Preferences',
     'group' => 'core',
     'name' => 'enable_components',
@@ -59,5 +57,21 @@ return [
     'pseudoconstant' => [
       'callback' => 'CRM_Core_SelectValues::getComponentSelectValues',
     ],
+  ],
+  'domain' => [
+    'group_name' => 'CiviCRM Preferences',
+    'group' => 'core',
+    'name' => 'domain',
+    'type' => 'String',
+    'default' => 1,
+    'title' => ts('CiviCRM Domain ID'),
+    'description' => ts('The current domain if CiviCRM is running multi-site.'),
+    'help_text' => NULL,
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'is_constant' => TRUE,
+    'is_env_loadable' => TRUE,
+    'global_name' => 'CIVICRM_DOMAIN_ID',
+    'add' => '5.80',
   ],
 ];

--- a/settings/Url.boot.setting.php
+++ b/settings/Url.boot.setting.php
@@ -18,6 +18,22 @@
  * Settings metadata file
  */
 return [
+  'userFrameworkBaseURL' => [
+    'group_name' => 'URL Preferences',
+    'group' => 'url',
+    'name' => 'userFrameworkBaseURL',
+    'type' => 'String',
+    'default' => NULL,
+    'title' => ts('User Framework Base URL'),
+    'description' => ts('The base URL of the user framework or CMS that CiviCRM is running in.'),
+    'help_text' => NULL,
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'is_constant' => TRUE,
+    'is_env_loadable' => TRUE,
+    'global_name' => 'CIVICRM_UF_BASEURL',
+    'add' => '5.80',
+  ],
   'userFrameworkResourceURL' => [
     'bootstrap_comment' => 'This is a boot setting which may be loaded during bootstrap. Defaults are loaded via SettingsBag::getSystemDefaults().',
     'group' => 'url',

--- a/tests/phpunit/Civi/Core/SettingsStyleTest.php
+++ b/tests/phpunit/Civi/Core/SettingsStyleTest.php
@@ -3,6 +3,20 @@ namespace Civi\Core;
 
 class SettingsStyleTest extends \CiviUnitTestCase {
 
+  /**
+   * @var array
+   *
+   * Around 5.80 new settings for pre-existing globals were added
+   * to the SettingsManager
+   * However the sensible name keys for these settings don't
+   * follow the group prefix requirement for newly added settings.
+   * This array defines opted out keys
+   */
+  const NEW_SETTINGS_WITH_OLD_NAMES = [
+    'domain',
+    'userFrameworkBaseURL',
+  ];
+
   protected function setUp(): void {
     parent::setUp();
     $this->useTransaction(TRUE);
@@ -38,7 +52,7 @@ class SettingsStyleTest extends \CiviUnitTestCase {
       $assert($key, $key === $name, 'Should have matching name');
       $type = $spec['type'] ?? 'UNKNOWN';
       $assert($key, in_array($type, $validTypes), 'Should have known type. Found: ' . $type);
-      if (version_compare($spec['add'], '5.53', '>=')) {
+      if (version_compare($add, '5.53', '>=') && !in_array($key, self::NEW_SETTINGS_WITH_OLD_NAMES)) {
         $assert($key, preg_match(';^[a-z0-9]+(_[a-z0-9]+)+$;', $key), 'In 5.53+, names should use snake_case with a group/subsystem prefix.');
       }
       else {


### PR DESCRIPTION
Overview
----------------------------------------
**EDIT: Jenkins / cv bootstrap didn't like the addition of CIVICRM_UF as a defined env var, for reasons I can't quite pin down - so I've rolled that back for now**

Now just adds CIVICRM_UF_BASEURL and CIVICRM_DOMAIN_ID as globals, which means:
a) they can be provided using environment variables,
b) CIVICRM_DOMAIN_ID will default to 1 if not set (so the `define('CIVICRM_DOMAIN_ID', 1)` is not required in civicrm.settings.php)

Before
----------------------------------------
- CIVICRM_DOMAIN_ID and CIVICRM_UF_BASEURL must be defined in civicrm.settings.php


After
----------------------------------------
- CIVICRM_UF_BASEURL can be provided as env var on in civicrm.settings.php
- CIVICRM_DOMAIN_ID can be provided as env var or in civicrm.settings.php - but if not provided will default to 1


Technical details
--------------------------------------
All the above applies only to Standalone, as that is where we have the SettingsManager::bootSettings function wired into the bootstrap, in order to source env vars for these kind of things early enough.

I've put in an explicit opt out from the naming convention in settings style test, instead of a backdated value for the version `add`ed.



...


_Previous bolder scope:_

---

Following on from https://github.com/civicrm/civicrm-core/pull/30533 - this brings a few more constants into the `*.boot.setting.php` system, in order that they can be loaded from environment variables or defaults.

It's based upon https://github.com/civicrm/civicrm-core/pull/31150 - between the two I was able to run Standalone *without civicrm.settings.php* - just providing a three env vars.

Before
----------------------------------------
- `civicrm.settings.php` provides many critical constants


After
----------------------------------------
- provide `CIVICRM_DSN`, `CIVICRM_UF_BASEURL` and `CIVICRM_UF` as environment variables 
- set  CIVICRM_SETTINGS_PATH to a non-existent path (to work around current is installed check)

![image](https://github.com/user-attachments/assets/18093c8b-000a-4b9c-954e-71afd3d856fb)

- delete `civicrm.settings.php`
- Standalone still runs :grinning: 


Comments
----------------------------------------
It's running Smarty2, but it's running....

@michaelmcandrew could you have a go testing this branch with the Docker container?
