### PR TITLE
Remove some legacy copy & paste from mailing labels

### DIFF
--- a/CRM/Contact/Form/Task/Label.php
+++ b/CRM/Contact/Form/Task/Label.php
@@ -230,16 +230,6 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
 
     // format the addresses according to CIVICRM_ADDRESS_FORMAT (CRM-1327)
     foreach ($rows as $id => $row) {
-      $commMethods = $row['preferred_communication_method'] ?? NULL;
-      if ($commMethods) {
-        $val = array_filter(explode(CRM_Core_DAO::VALUE_SEPARATOR, $commMethods));
-        $comm = CRM_Contact_DAO_Contact::buildOptions('preferred_communication_method');
-        $temp = [];
-        foreach ($val as $vals) {
-          $temp[] = $comm[$vals];
-        }
-        $row['preferred_communication_method'] = implode(', ', $temp);
-      }
       $row['id'] = $id;
       $formatted = CRM_Utils_Address::formatMailingLabel($row);
       $rows[$id] = [$formatted];

--- a/CRM/Member/Form/Task/Label.php
+++ b/CRM/Member/Form/Task/Label.php
@@ -91,16 +91,6 @@ class CRM_Member_Form_Task_Label extends CRM_Member_Form_Task {
     }
     // format the addresses according to CIVICRM_ADDRESS_FORMAT (CRM-1327)
     foreach ((array) $rows as $id => $row) {
-      $commMethods = $row['preferred_communication_method'] ?? NULL;
-      if ($commMethods) {
-        $val = array_filter(explode(CRM_Core_DAO::VALUE_SEPARATOR, $commMethods));
-        $comm = CRM_Contact_DAO_Contact::buildOptions('preferred_communication_method');
-        $temp = [];
-        foreach ($val as $vals) {
-          $temp[] = $comm[$vals];
-        }
-        $row['preferred_communication_method'] = implode(', ', $temp);
-      }
       $row['id'] = $id;
       $formatted = CRM_Utils_Address::formatMailingLabel($row);
       $rows[$id] = [$formatted];


### PR DESCRIPTION
Overview
----------------------------------------
Remove some legacy copy & paste from mailing labels

On the off chance someone wants to add 'preferred_communication_method' to a mailing label in a nicely formatted way it could be done without these lines - as the token is handled by the token processor within  - however I highly doubt anyone ever has or would & suspect copy & paste ...


Before
----------------------------------------
Legacy code to support now-removed token function to render preferred_communication_method token

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
