### PR TITLE
dev/core#5459 - (5.77 backport) Fix one of the bad timestamp columns from the schema changes

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSeventySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveSeventySeven.php
@@ -33,4 +33,14 @@ class CRM_Upgrade_Incremental_php_FiveSeventySeven extends CRM_Upgrade_Increment
     $this->addTask('Alter QueueItem.queue_name length', 'alterColumn', 'civicrm_queue_item', 'queue_name', "varchar(128) NOT NULL COMMENT 'Name of the queue which includes this item'", FALSE);
   }
 
+  /**
+   * Upgrade step; adds tasks including 'runSql'.
+   *
+   * @param string $rev
+   *   The version number matching this function name
+   */
+  public function upgrade_5_77_1($rev): void {
+    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+  }
+
 }

--- a/CRM/Upgrade/Incremental/sql/5.77.1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.77.1.mysql.tpl
@@ -1,0 +1,5 @@
+UPDATE `civicrm_job_log` jl
+  LEFT JOIN `civicrm_job` j ON j.id = jl.job_id
+  SET jl.`run_time` = COALESCE(j.`last_run_end`, j.`last_run`, current_timestamp())
+  WHERE jl.`run_time` IS NULL;
+ALTER TABLE `civicrm_job_log` MODIFY COLUMN `run_time` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp() COMMENT 'Log entry date';

--- a/schema/Core/JobLog.entityType.php
+++ b/schema/Core/JobLog.entityType.php
@@ -47,6 +47,8 @@ return [
       'sql_type' => 'timestamp',
       'input_type' => NULL,
       'description' => ts('Log entry date'),
+      'required' => TRUE,
+      'default' => 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
       'add' => '4.1',
     ],
     'job_id' => [


### PR DESCRIPTION
Overview
----------------------------------------
Backport #31104 

The difference is there is no 5.78 in 5.77, so the upgrade script needs to be in 5.77.1, but
** **THIS WILL FAIL TESTS** ** because there is no 5.77.1 yet.

To run it you need to update civicrm-version.php and xml/version.xml to fool it into thinking it's 5.77.1