### PR TITLE
Api4 - Prefer @primaryKey annotation in BasicEntity

### DIFF
--- a/Civi/Api4/Generic/BasicEntity.php
+++ b/Civi/Api4/Generic/BasicEntity.php
@@ -32,13 +32,6 @@ namespace Civi\Api4\Generic;
 abstract class BasicEntity extends AbstractEntity {
 
   /**
-   * Unique identifier for this entity.
-   *
-   * @var string|string[]
-   */
-  protected static $idField = 'id';
-
-  /**
    * Function to read records. Used by `get` action.
    *
    * @var callable
@@ -150,7 +143,10 @@ abstract class BasicEntity extends AbstractEntity {
    */
   public static function getInfo() {
     $info = parent::getInfo();
-    $info['primary_key'] = (array) static::$idField;
+    if (isset(static::$idField)) {
+      // Deprecated in favor of `@primaryKey` annotation
+      $info['primary_key'] = (array) static::$idField;
+    }
     return $info;
   }
 

--- a/Civi/Api4/RecentItem.php
+++ b/Civi/Api4/RecentItem.php
@@ -19,12 +19,11 @@ namespace Civi\Api4;
  * The number of items stored is determined by the setting `recentItemsMaxCount`.
  *
  * @searchable secondary
+ * @primaryKey entity_id,entity_type
  * @since 5.49
  * @package Civi\Api4
  */
 class RecentItem extends Generic\BasicEntity {
-
-  protected static $idField = ['entity_id', 'entity_type'];
 
   protected static $getter = ['CRM_Utils_Recent', 'get'];
   protected static $setter = ['CRM_Utils_Recent', 'create'];

--- a/tests/phpunit/api/v4/Action/RecentItemsTest.php
+++ b/tests/phpunit/api/v4/Action/RecentItemsTest.php
@@ -21,6 +21,7 @@ namespace api\v4\Action;
 
 use api\v4\Api4TestBase;
 use Civi\Api4\Activity;
+use Civi\Api4\Entity;
 use Civi\Api4\RecentItem;
 use Civi\Test\TransactionalInterface;
 
@@ -28,6 +29,14 @@ use Civi\Test\TransactionalInterface;
  * @group headless
  */
 class RecentItemsTest extends Api4TestBase implements TransactionalInterface {
+
+  public function testMetadata(): void {
+    $metadata = Entity::get(FALSE)
+      ->addWhere('name', '=', 'RecentItem')
+      ->execute()->single();
+
+    $this->assertEquals(['entity_id', 'entity_type'], $metadata['primary_key']);
+  }
 
   public function testAddDeleteActivity(): void {
     $cid = $this->createLoggedInUser();

--- a/tests/phpunit/api/v4/Mock/Api4/MockBasicEntity.php
+++ b/tests/phpunit/api/v4/Mock/Api4/MockBasicEntity.php
@@ -25,11 +25,10 @@ use api\v4\Mock\MockEntityDataStorage;
  * MockBasicEntity entity.
  *
  * @labelField foo
+ * @primaryKey identifier
  * @package Civi\Api4
  */
 class MockBasicEntity extends Generic\BasicEntity {
-
-  protected static $idField = 'identifier';
 
   protected static $getter = [MockEntityDataStorage::CLASS, 'get'];
   protected static $setter = [MockEntityDataStorage::CLASS, 'write'];


### PR DESCRIPTION
Overview
----------------------------------------
Once upon a time, classes that extended BasicEntity were in need of a way to declare their primary keys, and nothing was readily available, so a static class variable was added.
These days there is something available: the `@primaryKey` annotation. So let's use that.