### PR TITLE
dev/core#5459 - (5.77 backport) - fix timestamp columns

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSeventySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveSeventySeven.php
@@ -33,4 +33,14 @@ class CRM_Upgrade_Incremental_php_FiveSeventySeven extends CRM_Upgrade_Increment
     $this->addTask('Alter QueueItem.queue_name length', 'alterColumn', 'civicrm_queue_item', 'queue_name', "varchar(128) NOT NULL COMMENT 'Name of the queue which includes this item'", FALSE);
   }
 
+  /**
+   * Upgrade step; adds tasks including 'runSql'.
+   *
+   * @param string $rev
+   *   The version number matching this function name
+   */
+  public function upgrade_5_77_1($rev): void {
+    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+  }
+
 }

--- a/CRM/Upgrade/Incremental/sql/5.77.1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.77.1.mysql.tpl
@@ -1,0 +1,5 @@
+UPDATE `civicrm_job_log` jl
+  LEFT JOIN `civicrm_job` j ON j.id = jl.job_id
+  SET jl.`run_time` = COALESCE(j.`last_run_end`, j.`last_run`, current_timestamp())
+  WHERE jl.`run_time` IS NULL;
+ALTER TABLE `civicrm_job_log` MODIFY COLUMN `run_time` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp() COMMENT 'Log entry date';

--- a/CRM/Upgrade/Incremental/sql/5.77.1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.77.1.mysql.tpl
@@ -1,5 +1,40 @@
+-- Not accurate but we need to set it to SOMETHING before changing to NOT NULL
 UPDATE `civicrm_job_log` jl
   LEFT JOIN `civicrm_job` j ON j.id = jl.job_id
   SET jl.`run_time` = COALESCE(j.`last_run_end`, j.`last_run`, current_timestamp())
   WHERE jl.`run_time` IS NULL;
 ALTER TABLE `civicrm_job_log` MODIFY COLUMN `run_time` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp() COMMENT 'Log entry date';
+
+-- There is no reasonable date to use, but this is just cache anyway and will get cleared at the end of the upgrade.
+UPDATE `civicrm_cache` c
+  SET c.`created_date` = current_timestamp()
+  WHERE c.`created_date` IS NULL;
+ALTER TABLE `civicrm_cache` MODIFY COLUMN `created_date` timestamp NOT NULL DEFAULT current_timestamp() COMMENT 'When was the cache item created';
+
+-- Not accurate but we need to set it to SOMETHING before changing to NOT NULL
+UPDATE `civicrm_contribution_recur` c
+  SET c.`modified_date` = COALESCE(c.`create_date`, current_timestamp())
+  WHERE c.`modified_date` IS NULL;
+ALTER TABLE `civicrm_contribution_recur` MODIFY COLUMN `modified_date` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp() COMMENT 'Last updated date for this record. mostly the last time a payment was received';
+
+-- Not accurate but we need to set it to SOMETHING before changing to NOT NULL
+UPDATE `civicrm_note` c
+  SET c.`note_date` = COALESCE(c.`created_date`, current_timestamp())
+  WHERE c.`note_date` IS NULL;
+UPDATE `civicrm_note` c
+  SET c.`modified_date` = COALESCE(c.`created_date`, current_timestamp())
+  WHERE c.`modified_date` IS NULL;
+ALTER TABLE `civicrm_note` MODIFY COLUMN `note_date` timestamp NOT NULL DEFAULT current_timestamp() COMMENT 'Date attached to the note';
+ALTER TABLE `civicrm_note` MODIFY COLUMN `modified_date` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp() COMMENT 'When was this note last modified/edited';
+
+-- Not accurate but we need to set it to SOMETHING before changing to NOT NULL
+UPDATE `civicrm_payment_token` c
+  SET c.`created_date` = current_timestamp()
+  WHERE c.`created_date` IS NULL;
+ALTER TABLE `civicrm_payment_token` MODIFY COLUMN `created_date` timestamp NOT NULL DEFAULT current_timestamp() COMMENT 'Date created';
+
+-- Not accurate but we need to set it to SOMETHING before changing to NOT NULL
+UPDATE `civicrm_system_log` c
+  SET c.`timestamp` = current_timestamp()
+  WHERE c.`timestamp` IS NULL;
+ALTER TABLE `civicrm_system_log` MODIFY COLUMN `timestamp` timestamp NOT NULL DEFAULT current_timestamp() COMMENT 'Timestamp of when event occurred.';

--- a/schema/Contribute/ContributionRecur.entityType.php
+++ b/schema/Contribute/ContributionRecur.entityType.php
@@ -155,6 +155,7 @@ return [
       'add' => '1.6',
       'unique_name' => 'contribution_recur_modified_date',
       'unique_title' => 'Recurring Contribution Modified Date',
+      'required' => TRUE,
       'default' => 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
       'input_attrs' => [
         'format_type' => 'activityDateTime',

--- a/schema/Core/Cache.entityType.php
+++ b/schema/Core/Cache.entityType.php
@@ -84,6 +84,7 @@ return [
       'input_type' => NULL,
       'description' => ts('When was the cache item created'),
       'add' => '2.1',
+      'required' => TRUE,
       'default' => 'CURRENT_TIMESTAMP',
     ],
     'expired_date' => [

--- a/schema/Core/JobLog.entityType.php
+++ b/schema/Core/JobLog.entityType.php
@@ -47,6 +47,8 @@ return [
       'sql_type' => 'timestamp',
       'input_type' => NULL,
       'description' => ts('Log entry date'),
+      'required' => TRUE,
+      'default' => 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
       'add' => '4.1',
     ],
     'job_id' => [

--- a/schema/Core/Note.entityType.php
+++ b/schema/Core/Note.entityType.php
@@ -104,6 +104,7 @@ return [
       'input_type' => 'Select Date',
       'description' => ts('Date attached to the note'),
       'add' => '5.36',
+      'required' => TRUE,
       'default' => 'CURRENT_TIMESTAMP',
       'input_attrs' => [
         'format_type' => 'activityDateTime',
@@ -129,6 +130,7 @@ return [
       'readonly' => TRUE,
       'description' => ts('When was this note last modified/edited'),
       'add' => '1.1',
+      'required' => TRUE,
       'default' => 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
       'input_attrs' => [
         'label' => ts('Modified Date'),

--- a/schema/Core/SystemLog.entityType.php
+++ b/schema/Core/SystemLog.entityType.php
@@ -50,6 +50,7 @@ return [
       'input_type' => NULL,
       'description' => ts('Timestamp of when event occurred.'),
       'add' => '4.5',
+      'required' => TRUE,
       'default' => 'CURRENT_TIMESTAMP',
     ],
     'contact_id' => [

--- a/schema/Financial/PaymentToken.entityType.php
+++ b/schema/Financial/PaymentToken.entityType.php
@@ -67,6 +67,7 @@ return [
       'input_type' => NULL,
       'description' => ts('Date created'),
       'add' => '4.6',
+      'required' => TRUE,
       'default' => 'CURRENT_TIMESTAMP',
     ],
     'created_id' => [


### PR DESCRIPTION
Overview
----------------------------------------
Backport #31158 

This includes #31157.

** **THIS WILL FAIL TESTS** ** because there is no 5.77.1 yet.

To run it you need to update civicrm-version.php and xml/version.xml to fool it into thinking it's 5.77.1