### PR TITLE
dev/core#4840 StandaloneUsers - Improve performance & usability of 'User Permissions' screen

### DIFF
--- a/Civi/Api4/Generic/BasicSaveAction.php
+++ b/Civi/Api4/Generic/BasicSaveAction.php
@@ -59,17 +59,26 @@ class BasicSaveAction extends AbstractSaveAction {
       $this->matchExisting($record);
     }
     $this->validateValues();
-    foreach ($this->records as $item) {
-      $result[] = $this->writeRecord($item);
-    }
+    $savedRecords = $this->updateRecords($this->records);
     if ($this->reload) {
       /** @var BasicGetAction $get */
       $get = \Civi\API\Request::create($this->getEntityName(), 'get', ['version' => 4]);
       $get
         ->setCheckPermissions($this->getCheckPermissions())
-        ->addWhere($idField, 'IN', (array) $result->column($idField));
+        ->addWhere($idField, 'IN', array_column($savedRecords, $idField));
       $result->exchangeArray((array) $get->execute());
     }
+    else {
+      $result->exchangeArray(array_values($savedRecords));
+    }
+  }
+
+  /**
+   * @param array $items
+   * @return array
+   */
+  protected function updateRecords(array $items): array {
+    return array_map([$this, 'writeRecord'], $items);
   }
 
   /**

--- a/Civi/Api4/Permission.php
+++ b/Civi/Api4/Permission.php
@@ -18,6 +18,7 @@ namespace Civi\Api4;
  * on top of permissions!) or during install/uninstall processes.
  *
  * @searchable none
+ * @primaryKey name
  * @since 5.34
  * @package Civi\Api4
  */
@@ -43,6 +44,8 @@ class Permission extends Generic\AbstractEntity {
           'name' => 'group',
           'title' => 'Group',
           'data_type' => 'String',
+          'input_type' => 'Select',
+          'readonly' => TRUE,
           'options' => [
             'civicrm' => 'civicrm',
             'cms' => 'cms',
@@ -51,39 +54,65 @@ class Permission extends Generic\AbstractEntity {
             'afformGeneric' => 'afformGeneric',
             'unknown' => 'unknown',
           ],
+          'input_attrs' => [
+            'label' => ts('Group'),
+          ],
         ],
         [
           'name' => 'name',
           'title' => 'Name',
           'data_type' => 'String',
+          'input_type' => 'Text',
+          'readonly' => TRUE,
+          'input_attrs' => [
+            'label' => ts('Machine name'),
+          ],
         ],
         [
           'name' => 'title',
           'title' => 'Title',
           'data_type' => 'String',
+          'input_type' => 'Text',
+          'readonly' => TRUE,
+          'input_attrs' => [
+            'label' => ts('Title'),
+          ],
         ],
         [
           'name' => 'description',
           'title' => 'Description',
           'data_type' => 'String',
+          'input_type' => 'Text',
+          'readonly' => TRUE,
+          'input_attrs' => [
+            'label' => ts('Description'),
+          ],
         ],
         [
           'name' => 'is_synthetic',
           'title' => 'Is Synthetic',
           'data_type' => 'Boolean',
+          'input_type' => 'CheckBox',
+          'readonly' => TRUE,
         ],
         [
           'name' => 'is_active',
-          'title' => 'Is Active',
+          'title' => 'Enabled',
           'description' => '',
           'default' => TRUE,
           'data_type' => 'Boolean',
+          'input_type' => 'CheckBox',
+          'readonly' => TRUE,
+          'input_attrs' => [
+            'label' => ts('Enabled'),
+          ],
         ],
         [
           'name' => 'implies',
           'title' => 'Implies',
           'description' => 'List of sub-permissions automatically granted by this one',
           'data_type' => 'Array',
+          'readonly' => TRUE,
         ],
       ];
     }))->setCheckPermissions($checkPermissions);

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.ctrl.js
@@ -18,10 +18,10 @@
         loadOptions: ['id', 'name', 'label', 'description', 'color', 'icon'],
         where: [['deprecated', '=', false], ["readonly", "=", false]],
       }],
-      getInfo: ['Entity', 'get', {select: ['primary_key'], where: [['name', '=', this.entity]]}, 0]
+      entityInfo: ['Entity', 'get', {select: ['primary_key'], where: [['name', '=', this.entity]]}, 0]
     }).then(function(results) {
         ctrl.fields = results.getFields;
-        ctrl.idField = results.getInfo.primary_key[0];
+        ctrl.idField = results.entityInfo.primary_key[0];
       });
 
     this.updateField = function(index) {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.ctrl.js
@@ -11,13 +11,17 @@
     this.add = null;
     this.fields = null;
 
-    crmApi4(this.entity, 'getFields', {
-      action: 'update',
-      select: ['name', 'label', 'description', 'input_type', 'data_type', 'serialize', 'options', 'fk_entity', 'nullable'],
-      loadOptions: ['id', 'name', 'label', 'description', 'color', 'icon'],
-      where: [['deprecated', '=', false], ["readonly", "=", false]],
-    }).then(function(fields) {
-        ctrl.fields = fields;
+    crmApi4({
+      getFields: [this.entity, 'getFields', {
+        action: 'update',
+        select: ['name', 'label', 'description', 'input_type', 'data_type', 'serialize', 'options', 'fk_entity', 'nullable'],
+        loadOptions: ['id', 'name', 'label', 'description', 'color', 'icon'],
+        where: [['deprecated', '=', false], ["readonly", "=", false]],
+      }],
+      getInfo: ['Entity', 'get', {select: ['primary_key'], where: [['name', '=', this.entity]]}, 0]
+    }).then(function(results) {
+        ctrl.fields = results.getFields;
+        ctrl.idField = results.getInfo.primary_key[0];
       });
 
     this.updateField = function(index) {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.html
@@ -10,7 +10,7 @@
     </div>
     <div ng-if="$ctrl.run" class="crm-search-task-progress">
       <h5>{{:: ts('Updating %1 %2...', {1: model.ids.length, 2: $ctrl.entityTitle}) }}</h5>
-      <crm-search-batch-runner entity="model.entity" action="update" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess()" error="$ctrl.onError()" ></crm-search-batch-runner>
+      <crm-search-batch-runner entity="model.entity" action="update" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess()" error="$ctrl.onError()" id-field="{{:: $ctrl.idField }}"></crm-search-batch-runner>
     </div>
 
     <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" ></crm-dialog-button>

--- a/ext/standaloneusers/CRM/Standaloneusers/BAO/Role.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/BAO/Role.php
@@ -5,6 +5,7 @@
  */
 
 use Civi\Api4\Event\AuthorizeRecordEvent;
+use CRM_Standaloneusers_ExtensionUtil as E;
 
 class CRM_Standaloneusers_BAO_Role extends CRM_Standaloneusers_DAO_Role implements \Civi\Core\HookInterface {
 
@@ -15,6 +16,14 @@ class CRM_Standaloneusers_BAO_Role extends CRM_Standaloneusers_DAO_Role implemen
   public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $event) {
     // Reset cache
     Civi::cache('metadata')->clear();
+    // Rebuild role-based search displays if they will be affected by this action
+    if ($event->action === 'delete' || $event->action === 'create' ||
+      ($event->action === 'edit' && (isset($event->params['label']) || isset($event->params['is_active'])))
+    ) {
+      \Civi\Api4\Managed::reconcile(FALSE)
+        ->addModule(E::LONG_NAME)
+        ->execute();
+    }
   }
 
   /**

--- a/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
@@ -20,10 +20,10 @@ class CRM_Standaloneusers_Upgrader extends CRM_Extension_Upgrader_Base {
   public function preInstall() {
     $config = \CRM_Core_Config::singleton();
     // We generally only want to run on standalone. In theory, we might also run headless tests.
-    if (!in_array(get_class($config->userPermissionClass), ['CRM_Core_Permission_Standalone', 'CRM_Core_Permission_Headless'])) {
+    if (!in_array(get_class($config->userPermissionClass), ['CRM_Core_Permission_Standalone', 'CRM_Core_Permission_UnitTests'])) {
       throw new \CRM_Core_Exception("standaloneusers can only be installed on standalone");
     }
-    if (!in_array(get_class($config->userSystem), ['CRM_Utils_System_Standalone', 'CRM_Utils_System_Headless'])) {
+    if (!in_array(get_class($config->userSystem), ['CRM_Utils_System_Standalone', 'CRM_Utils_System_UnitTests'])) {
       throw new \CRM_Core_Exception("standaloneusers can only be installed on standalone");
     }
     CRM_Core_DAO::executeQuery('DROP TABLE civicrm_uf_match');

--- a/ext/standaloneusers/Civi/Api4/Action/RolePermission/RolePermissionSaveTrait.php
+++ b/ext/standaloneusers/Civi/Api4/Action/RolePermission/RolePermissionSaveTrait.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\RolePermission;
+
+use Civi\Api4\Role;
+
+trait RolePermissionSaveTrait {
+
+  protected function updateRecords(array $items): array {
+    $rolesToUpdate = [];
+    foreach ($items as $item) {
+      if (!empty($item['name'])) {
+        foreach ($item as $key => $grant) {
+          if (str_starts_with($key, 'granted_')) {
+            [, $roleName] = explode('_', $key, 2);
+            $op = $grant ? 'add' : 'remove';
+            $rolesToUpdate[$roleName][$op][] = $item['name'];
+          }
+        }
+      }
+    }
+    if (!$rolesToUpdate) {
+      return $items;
+    }
+    $roles = Role::get(FALSE)
+      ->addSelect('name', 'permissions')
+      ->addWhere('name', 'IN', array_keys($rolesToUpdate))
+      ->execute()
+      ->column('permissions', 'name');
+    foreach ($rolesToUpdate as $roleName => $rolePermissions) {
+      $roles[$roleName] = array_diff($roles[$roleName], $rolePermissions['remove'] ?? []);
+      $roles[$roleName] = array_unique(array_merge($roles[$roleName], $rolePermissions['add'] ?? []));
+
+      Role::update($this->getCheckPermissions())
+        ->addWhere('name', '=', $roleName)
+        ->addValue('permissions', $roles[$roleName])
+        ->execute();
+    }
+    return $items;
+  }
+
+}

--- a/ext/standaloneusers/Civi/Api4/Action/RolePermission/Save.php
+++ b/ext/standaloneusers/Civi/Api4/Action/RolePermission/Save.php
@@ -11,9 +11,9 @@
 
 namespace Civi\Api4\Action\RolePermission;
 
-use Civi\Api4\Generic\BasicUpdateAction;
+use Civi\Api4\Generic\BasicSaveAction;
 
-class Update extends BasicUpdateAction {
+class Save extends BasicSaveAction {
   use RolePermissionSaveTrait;
 
 }

--- a/ext/standaloneusers/ang/afsearchPermissions.aff.html
+++ b/ext/standaloneusers/ang/afsearchPermissions.aff.html
@@ -1,9 +1,6 @@
 <div af-fieldset="">
   <div class="af-container af-layout-inline">
-    <af-field name="role_name" defn="{input_attrs: {multiple: true}, label: 'Role'}" />
-    <af-field name="permission_group" defn="{input_attrs: {multiple: true}, label: 'Component / Extension'}" />
-    <af-field name="permission_title" />
-    <af-field name="permission_granted" defn="{input_type: 'Select', input_attrs: {}, options: [{id: '1', label: 'Granted'}, {id: '0', label: 'Not granted'}]}" />
+    <af-field name="title" defn="{input_attrs: {multiple: true}}" />
   </div>
   <crm-search-display-table search-name="Permissions" display-name="Permissions_Table_1"></crm-search-display-table>
 </div>

--- a/ext/standaloneusers/ang/afsearchPermissions.aff.php
+++ b/ext/standaloneusers/ang/afsearchPermissions.aff.php
@@ -3,7 +3,7 @@ use CRM_Standaloneusers_ExtensionUtil as E;
 
 return [
   'type' => 'form',
-  'title' => E::ts('Permissions'),
+  'title' => E::ts('User Permissions'),
   'icon' => 'fa-list-alt',
   'server_route' => 'civicrm/admin/rolepermissions',
   'permission' => ['cms:administer users'],

--- a/ext/standaloneusers/managed/SavedSearch_Administer_Roles.mgd.php
+++ b/ext/standaloneusers/managed/SavedSearch_Administer_Roles.mgd.php
@@ -144,7 +144,7 @@ return [
             [
               'path' => 'civicrm/admin/rolepermissions',
               'icon' => 'fa-external-link',
-              'text' => E::ts('Permissions'),
+              'text' => E::ts('User Permissions'),
               'style' => 'info',
               'condition' => [],
               'task' => '',

--- a/ext/standaloneusers/managed/SavedSearch_Permissions.mgd.php
+++ b/ext/standaloneusers/managed/SavedSearch_Permissions.mgd.php
@@ -1,7 +1,7 @@
 <?php
 use CRM_Standaloneusers_ExtensionUtil as E;
 
-return [
+$items = [
   [
     'name' => 'SavedSearch_Permissions',
     'entity' => 'SavedSearch',
@@ -11,23 +11,17 @@ return [
       'version' => 4,
       'values' => [
         'name' => 'Permissions',
-        'label' => E::ts('Permissions'),
+        'label' => E::ts('Administer Role Permissions'),
         'api_entity' => 'RolePermission',
         'api_params' => [
           'version' => 4,
           'select' => [
-            'role_name',
-            'role_label',
-            'permission_group',
-            'permission_name',
-            'permission_title',
-            'permission_description',
-            'permission_granted',
+            'name',
+            'title',
           ],
           'orderBy' => [],
           'where' => [],
         ],
-        'description' => E::ts('Shows the permissions of the different roles in standalone CiviCRM.'),
       ],
       'match' => [
         'name',
@@ -43,64 +37,38 @@ return [
       'version' => 4,
       'values' => [
         'name' => 'Permissions_Table_1',
-        'label' => E::ts('Permissions Table 1'),
+        'label' => E::ts('Administer Role Permissions'),
         'saved_search_id.name' => 'Permissions',
         'type' => 'table',
         'settings' => [
-          'description' => E::ts('This lists all the permissions for each role. You need to click the the granted column to change it.
-    It takes a while before the screen is shown.'),
+          'description' => NULL,
           'sort' => [
             [
-              'role_label',
-              'ASC',
-            ],
-            [
-              'permission_name',
+              'title',
               'ASC',
             ],
           ],
-          'limit' => 0,
-          'pager' => FALSE,
-          'placeholder' => 5,
+          'limit' => 50,
+          'pager' => [
+            'expose_limit' => TRUE,
+          ],
+          'placeholder' => 10,
           'columns' => [
             [
-              'type' => 'field',
-              'key' => 'role_label',
-              'dataType' => 2,
-              'label' => E::ts('Role'),
-              'sortable' => TRUE,
-            ],
-            [
-              'type' => 'field',
-              'key' => 'permission_group',
-              'dataType' => 2,
-              'label' => E::ts('Component / Extension'),
-              'sortable' => TRUE,
-            ],
-            [
               'type' => 'html',
-              'key' => 'permission_title',
-              'dataType' => 2,
+              'key' => 'title',
               'label' => E::ts('Permission'),
               'sortable' => TRUE,
-              'rewrite' => '[permission_title]
-    <p class="description">[permission_description]</p>',
-              'title' => E::ts('[permission_description]'),
-            ],
-            [
-              'type' => 'field',
-              'key' => 'permission_granted',
-              'dataType' => 16,
-              'label' => E::ts('Granted'),
-              'sortable' => TRUE,
-              'rewrite' => '',
-              'editable' => TRUE,
+              'rewrite' => '[title]<p class="description">[description]</p>',
             ],
           ],
-          'actions' => FALSE,
+          'actions' => [
+            'update',
+          ],
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
         ],
       ],
@@ -111,3 +79,57 @@ return [
     ],
   ],
 ];
+
+$roles = \Civi\Api4\Role::get(FALSE)
+  ->addSelect('name', 'label')
+  ->addWhere('name', '!=', 'admin')
+  ->execute()
+  ->column('label', 'name');
+
+foreach ($roles as $roleName => $roleLabel) {
+  $items[0]['params']['values']['api_params']['select'][] = 'granted_' . $roleName;
+  $items[1]['params']['values']['settings']['columns'][] = [
+    'type' => 'field',
+    'key' => 'granted_' . $roleName,
+    'label' => $roleLabel,
+    'sortable' => FALSE,
+    'rewrite' => ' ',
+    'icons' => [
+      [
+        'icon' => 'fa-square-check',
+        'side' => 'left',
+        'if' => [
+          'granted_' . $roleName,
+          '=',
+          TRUE,
+        ],
+      ],
+      [
+        'icon' => 'fa-circle-check',
+        'side' => 'left',
+        'if' => [
+          'implied_' . $roleName,
+          '=',
+          TRUE,
+        ],
+      ],
+    ],
+    'cssRules' => [
+      [
+        'text-success',
+        'granted_' . $roleName,
+        '=',
+        TRUE,
+      ],
+      [
+        'disabled',
+        'implied_' . $roleName,
+        '=',
+        TRUE,
+      ],
+    ],
+    'alignment' => 'text-center',
+  ];
+}
+
+return $items;

--- a/ext/standaloneusers/tests/phpunit/Civi/Api4/Action/RolePermissionTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Api4/Action/RolePermissionTest.php
@@ -1,0 +1,77 @@
+<?php
+namespace Civi\Api4\Action;
+
+use Civi\Api4\Role;
+use Civi\Api4\RolePermission;
+use Civi\Test\HeadlessInterface;
+
+/**
+ * @group headless
+ */
+class RolePermissionTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  /**
+   * Test batch-updating role permissions
+   */
+  public function testRolePermissionUpdate() {
+    $role1 = uniqid(1);
+    $role2 = uniqid(2);
+    Role::create(FALSE)
+      ->addValue('name', $role1)
+      ->addValue('label', $role1)
+      ->addValue('permissions', [
+        'access AJAX API',
+        'access CiviCRM',
+        'access Contact Dashboard',
+        'access uploaded files',
+        'add contacts',
+        'view all contacts',
+        'edit all contacts',
+      ])
+      ->execute();
+    Role::create(FALSE)
+      ->addValue('name', $role2)
+      ->addValue('label', $role2)
+      ->addValue('permissions', [
+        'administer CiviCRM',
+      ])
+      ->execute();
+    $rolePermissions = RolePermission::get(FALSE)
+      ->execute()
+      ->indexBy('name');
+
+    $this->assertTrue($rolePermissions['view all contacts']["granted_$role1"]);
+    $this->assertFalse($rolePermissions['view my contact']["granted_$role1"]);
+    $this->assertTrue($rolePermissions['view my contact']["implied_$role1"]);
+    $this->assertFalse($rolePermissions['administer CiviCRM']["granted_$role1"]);
+    $this->assertFalse($rolePermissions['view all contacts']["granted_$role2"]);
+    $this->assertFalse($rolePermissions['access CiviCRM']["granted_$role2"]);
+    $this->assertTrue($rolePermissions['access CiviCRM']["implied_$role2"]);
+
+    RolePermission::save(FALSE)
+      ->addRecord(['name' => 'view all contacts', "granted_$role1" => FALSE, "granted_$role2" => TRUE])
+      ->addRecord(['name' => 'administer CiviCRM', "granted_$role1" => FALSE])
+      ->execute();
+
+    $rolePermissions = RolePermission::get(FALSE)
+      ->execute()
+      ->indexBy('name');
+
+    $this->assertFalse($rolePermissions['view all contacts']["granted_$role1"]);
+    $this->assertFalse($rolePermissions['view my contact']["granted_$role1"]);
+    $this->assertFalse($rolePermissions['view my contact']["implied_$role1"]);
+    $this->assertFalse($rolePermissions['administer CiviCRM']["granted_$role1"]);
+    $this->assertTrue($rolePermissions['view all contacts']["granted_$role2"]);
+    $this->assertFalse($rolePermissions['view my contact']["granted_$role2"]);
+    $this->assertTrue($rolePermissions['view my contact']["implied_$role2"]);
+    $this->assertFalse($rolePermissions['access CiviCRM']["granted_$role2"]);
+    $this->assertTrue($rolePermissions['access CiviCRM']["implied_$role2"]);
+  }
+
+}

--- a/schema/Financial/PaymentProcessor.entityType.php
+++ b/schema/Financial/PaymentProcessor.entityType.php
@@ -67,7 +67,7 @@ return [
       'description' => ts('Payment Processor Name.'),
       'add' => '1.8',
       'input_attrs' => [
-        'label' => ts('Machine Name'),
+        'label' => ts('Machine name'),
       ],
     ],
     'title' => [


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/4840

This implements a Drupal-like screen which shows all roles as table columns.
Implied permissions are indicated in grey.
Bulk-update actions are used instead of inline editing, which is more performant.

<img width="1174" alt="Screenshot 2024-09-24 at 6 36 59 PM" src="https://github.com/user-attachments/assets/eeee2e41-ed80-4db9-b53c-7ec06b805516">

Technical Details
--------------

This modifies the signature of the `RolePermission` api to give pivot-table-like output, with one row per permission, and every role as a field.
This api was [created solely for the purpose of this screen](https://github.com/civicrm/civicrm-core/pull/28523) & that's the only use I can find. As Standalone is still in beta, I think it's a safe change to make at this point.
