### PR TITLE
Add Regions to the Case View template

### DIFF
--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -17,6 +17,7 @@
   {* Main case view *}
   {else}
 
+  {crmRegion name="case-view-summary"}
   <h3>{ts}Summary{/ts}</h3>
   <table class="report crm-entity case-summary" data-entity="case" data-id="{$caseID}" data-cid="{$contactID}">
     {if $multiClient}
@@ -82,6 +83,8 @@
       </td>
     </tr>
   </table>
+  {/crmRegion}
+  {crmRegion name="case-view-hook-case-summary"}
   {if $hookCaseSummary}
     <div id="caseSummary" class="crm-clearfix">
       {foreach from=$hookCaseSummary item=val key=div_id}
@@ -89,7 +92,9 @@
       {/foreach}
     </div>
   {/if}
+  {/crmRegion}
 
+  {crmRegion name="case-view-control-panel"}
   <div class="case-control-panel">
     <div>
       <p>
@@ -124,10 +129,14 @@
       </p>
     </div>
   </div>
+  {/crmRegion}
 
+  {crmRegion name="case-view-custom-data-view"}
   <div class="clear"></div>
   {include file="CRM/Case/Page/CustomDataView.tpl"}
+  {/crmRegion}
 
+  {crmRegion name="case-view-roles"}
   <details class="crm-accordion-bold crm-case-roles-block">
     <summary>
       {ts}Roles{/ts}
@@ -187,7 +196,9 @@
 
    </div>
   </details>
+  {/crmRegion}
 
+  {crmRegion name="case-view-other-relationships"}
   {if $hasAccessToAllCases}
   <details class="crm-accordion-bold crm-case-other-relationships-block">
     <summary>
@@ -256,9 +267,11 @@
 </details>
 
 {/if} {* other relationship section ends *}
+  {/crmRegion}
 {include file="CRM/Case/Form/ActivityToCase.tpl"}
 
 {* pane to display / edit regular tags or tagsets for cases *}
+{crmRegion name="case-view-tags"}
 {if $showTags}
 <details id="casetags" class="crm-accordion-bold  crm-case-tags-block" open>
  <summary>
@@ -309,8 +322,11 @@
 </div>
 
 {/if} {* end of tag block*}
+{/crmRegion}
 
+{crmRegion name="case-view-activity-tab"}
 {include file="CRM/Case/Form/ActivityTab.tpl"}
+{/crmRegion}
 
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 {/if} {* view related cases if end *}


### PR DESCRIPTION
Overview
----------------------------------------
Add {crmRegion} tags to the Case View template, so the pageRun hook can add content in the correct place.

This is an updated version of the [previous request](https://github.com/civicrm/civicrm-core/pull/31163).

I avoided the repeated use of the word "case" for all except "case-view-hook-case-summary" because it seemed to make sense to me to leave it there. Please let me know if you'd like me to update it.

Also just for my knowledge, is closing the previous merge request and opening a new one the best way to keep everything in one commit, or is there a better way?