### PR TITLE
dev/core#4470 Allow disabling Households

### DIFF
--- a/CRM/Admin/Form/ContactType.php
+++ b/CRM/Admin/Form/ContactType.php
@@ -49,7 +49,7 @@ class CRM_Admin_Form_ContactType extends CRM_Admin_Form {
     $contactType = $this->add('select', 'parent_id', ts('Basic Contact Type'),
       CRM_Contact_BAO_ContactType::basicTypePairs(FALSE, 'id')
     );
-    $enabled = $this->add('checkbox', 'is_active', ts('Enabled?'));
+    $enabled = $this->add('advcheckbox', 'is_active', ts('Enabled'));
     if ($this->_action & CRM_Core_Action::UPDATE) {
       $contactType->freeze();
       // We'll display actual "name" for built-in types (for reference) when editing their label / image_URL
@@ -58,7 +58,8 @@ class CRM_Admin_Form_ContactType extends CRM_Admin_Form {
 
       $this->parentId = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_ContactType', $this->_id, 'parent_id');
       // Freeze Enabled field for built-in contact types (parent_id is NULL for these)
-      if (is_null($this->parentId)) {
+      // dev/core#4470 except Household which can be disabled
+      if (is_null($this->parentId) && $contactTypeName != 'Household') {
         $enabled->freeze();
       }
     }
@@ -118,8 +119,6 @@ class CRM_Admin_Form_ContactType extends CRM_Admin_Form {
    * Process the form submission.
    */
   public function postProcess() {
-    CRM_Utils_System::flushCache();
-
     if ($this->_action & CRM_Core_Action::DELETE) {
       try {
         CRM_Contact_BAO_ContactType::deleteRecord(['id' => $this->_id]);
@@ -130,15 +129,11 @@ class CRM_Admin_Form_ContactType extends CRM_Admin_Form {
       }
       return;
     }
-    // store the submitted values in an array
+
     $params = $this->exportValues();
 
     if ($this->_action & CRM_Core_Action::UPDATE) {
       $params['id'] = $this->_id;
-      // Force Enabled = true for built-in contact types to fix problems caused by CRM-6471 (parent_id is NULL for these types)
-      if (is_null($this->parentId)) {
-        $params['is_active'] = 1;
-      }
     }
 
     // If icon is set, it overrides image_URL


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/4470

Allow disabling the Households contact-type from the Administer > Customize > Contact Types.

Before
----------------------------------------

Households cannot be disabled.

After
----------------------------------------

Households can be disabled.

Technical Details
----------------------------------------

I also moved the `flushCache` to after the `writeRecord`/`deleteRecord`, because it seemed to flush systematically.

I also couldn't reproduce CRM-6471, and I tried a few combos of editing contact-types, including Individuals, subtypes, etc, and it all seemed fine. I looked at some other forms who have an `is_active` checkbox, and they don't do that either.