### PR TITLE
Don't clobber financial label changes if upgrade is rerun

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.79.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.79.alpha1.mysql.tpl
@@ -1,3 +1,1 @@
 {* file to handle db changes in 5.79.alpha1 during upgrade *}
-UPDATE `civicrm_financial_type` SET {localize field="label"}`label` = `name`{/localize};
-UPDATE `civicrm_financial_account` SET {localize field="label"}`label` = `name`{/localize};


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
1. Upgrade
2. Make some label changes to financial type.
3. If you need to rerun the upgrade, it clobbers your changes.

After
----------------------------------------


Technical Details
----------------------------------------
I moved it to php from sql because {localize} produced gibberish with the WHERE clause.
Also in general when there is some other type of failure during upgrade I find fancy smarty in the sql is harder to debug.

Comments
----------------------------------------
@monishdeb @colemanw 