### PR TITLE
dev/core#5465 - Fix deselect entityReference

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -368,7 +368,7 @@
           return (currentVal || {})[ctrl.search_operator];
         }
         // Convert false to "false" and 0 to "0"
-        else if (!ctrl.isMultiple() && typeof currentVal !== 'string') {
+        else if (!ctrl.isMultiple() && (typeof currentVal === 'boolean' || typeof currentVal === 'number')) {
           return JSON.stringify(currentVal);
         }
         return currentVal;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug described in https://lab.civicrm.org/dev/core/-/issues/5465

Technical Details
----------------------------------------
The conversion of `null` to `"null"` caused an infinite loop of lookups of a nonexistant value
