### PR TITLE
SettingsManager - maintain loading db values before boot is complete

### DIFF
--- a/Civi/Core/SettingsManager.php
+++ b/Civi/Core/SettingsManager.php
@@ -194,7 +194,7 @@ class SettingsManager {
 
     if (!isset($this->bagsByDomain[$domainId])) {
       $this->bagsByDomain[$domainId] = new SettingsBag($domainId, NULL);
-      if (!$this->preBoot) {
+      if (\CRM_Core_Config::singleton()->dsn) {
         $this->bagsByDomain[$domainId]->loadValues();
       }
       $this->bagsByDomain[$domainId]
@@ -231,7 +231,7 @@ class SettingsManager {
     $key = "$domainId:$contactId";
     if (!isset($this->bagsByContact[$key])) {
       $this->bagsByContact[$key] = new SettingsBag($domainId, $contactId);
-      if (!$this->preBoot) {
+      if (\CRM_Core_Config::singleton()->dsn) {
         $this->bagsByContact[$key]->loadValues();
       }
       $this->bagsByContact[$key]


### PR DESCRIPTION
Overview
----------------------------------------
Draft fix for https://lab.civicrm.org/dev/core/-/issues/5484

Partial revert of https://github.com/civicrm/civicrm-core/pull/30533

Before
----------------------------------------
SettingsManager has 2 states: 
1. preBoot = only core boot settings (extension hooks have not been called), only values from env var or civicrm.settings.php (no database values)
2. bootComplete = fully online

A database value for extensionDir isn't respected when booting the extension system.

After
----------------------------------------
SettingsManager has 3 states: 
1. preBoot and preDB = preBoot as above
2. preBoot but DB online = extension hooks have not been called, but values *are* read from the database
3. bootComplete = fully online

A database value for extensionDir can be respected when booting the extension system.


Comments
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/30533 intentionally tried to remove the "in between" third state. 

But I guess supporting extensionDir from the database is always going to require this intermediate stage. Wondering if we make that setting an exceptional case - or make explicit the "in between" state.
