### PR TITLE
Schema - Add support for default_callback functions

### DIFF
--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -34,12 +34,6 @@ class CRM_Campaign_BAO_Campaign extends CRM_Campaign_DAO_Campaign {
       return NULL;
     }
 
-    if (empty($params['id'])) {
-      if (empty($params['created_id'])) {
-        $params['created_id'] = CRM_Core_Session::getLoggedInContactID();
-      }
-    }
-
     /** @var \CRM_Campaign_DAO_Campaign $campaign */
     $campaign = self::writeRecord($params);
 

--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -30,31 +30,12 @@ class CRM_Core_BAO_File extends CRM_Core_DAO_File {
   const DEFAULT_MAX_ATTACHMENTS_BACKEND = 100;
 
   /**
-   * Takes an associative array and creates a File object.
-   *
    * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
-   *
+   * @deprecated
    * @return CRM_Core_BAO_File
    */
   public static function create($params) {
-    $fileDAO = new CRM_Core_DAO_File();
-
-    $op = empty($params['id']) ? 'create' : 'edit';
-
-    CRM_Utils_Hook::pre($op, 'File', $params['id'] ?? NULL, $params);
-
-    $fileDAO->copyValues($params);
-
-    if (empty($params['id']) && empty($params['created_id'])) {
-      $fileDAO->created_id = CRM_Core_Session::getLoggedInContactID();
-    }
-
-    $fileDAO->save();
-
-    CRM_Utils_Hook::post($op, 'File', $fileDAO->id, $fileDAO);
-
-    return $fileDAO;
+    return self::writeRecord($params);
   }
 
   /**

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -48,10 +48,9 @@ class SpecFormatter {
       $field = new FieldSpec($fieldName, $entityName, $dataTypeName);
       $field->setColumnName($fieldName);
       $field->setType('Field');
-      $field->setRequired(!empty($data['required']) && !$hasDefault && empty($data['primary_key']));
+      $field->setRequired(!empty($data['required']) && !$hasDefault && empty($data['primary_key']) && empty($data['default_fallback']) && empty($data['default_callback']));
       // Translate 'default_fallback' into 'required_if' rules:
       if (!empty($data['default_fallback'])) {
-        $field->setRequired(FALSE);
         $field->setRequiredIf('empty($values.' . implode(') && empty($values.', $data['default_fallback']) . ')');
       }
     }

--- a/schema/Campaign/Campaign.entityType.php
+++ b/schema/Campaign/Campaign.entityType.php
@@ -231,6 +231,7 @@ return [
       'input_type' => 'EntityRef',
       'description' => ts('FK to civicrm_contact, who created this Campaign.'),
       'add' => '3.3',
+      'default_callback' => ['CRM_Core_Session', 'getLoggedInContactID'],
       'input_attrs' => [
         'label' => ts('Created By'),
       ],

--- a/schema/Core/File.entityType.php
+++ b/schema/Core/File.entityType.php
@@ -73,6 +73,7 @@ return [
       'input_type' => 'EntityRef',
       'description' => ts('FK to civicrm_contact, who uploaded this file'),
       'add' => '5.3',
+      'default_callback' => ['CRM_Core_Session', 'getLoggedInContactID'],
       'input_attrs' => [
         'label' => ts('Created By'),
       ],

--- a/tests/phpunit/api/v3/CampaignTest.php
+++ b/tests/phpunit/api/v3/CampaignTest.php
@@ -34,10 +34,11 @@ class api_v3_CampaignTest extends CiviUnitTestCase {
    */
   public function testCreateCampaign($version) {
     $this->_apiversion = $version;
+    $cid = $this->createLoggedInUser();
     $result = $this->callAPISuccess('campaign', 'create', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
-    $this->getAndCheck(array_merge($this->params, ['created_date' => '2008-07-05 00:00:00']), $result['id'], 'campaign', TRUE);
+    $this->getAndCheck(array_merge($this->params, ['created_date' => '2008-07-05 00:00:00', 'created_id' => $cid]), $result['id'], 'campaign', TRUE);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Makes entity create functions more metadata-driven by allowing a callback to supply field default values.

Before
----------------------------------------
Previously, it was up to a `DAO::create` or pre-hook implementation to supply default values programmatically, e.g. looking up the current user and adding it to the `created_id` value before inserting a new record.

After
----------------------------------------
Now a callback can be specified directly in the schema, and the field default will be determined by the return value of the function.

Comments
-------

- Updates a couple of example entities to demonstrate & test the functionality
- Builds on #31096 