### PR TITLE
Move template selection field when adding a new event to the top

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
@@ -11,6 +11,12 @@
 
 <div class="crm-block crm-form-block crm-event-manage-eventinfo-form-block">
   <table class="form-layout-compressed">
+    {if !empty($form.template_id)}
+      <tr class="crm-event-manage-eventinfo-form-block-template_id">
+        <td class="label">{$form.template_id.label} {help id="id-select-template" isTemplate=$isTemplate}</td>
+        <td>{$form.template_id.html}</td>
+      </tr>
+    {/if}
     <tr class="crm-event-manage-eventinfo-form-block-title">
       <td class="label">{$form.title.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='title' id=$eventID}{/if}</td>
       <td>{$form.title.html}</td>
@@ -29,12 +35,6 @@
       <tr class="crm-event-manage-eventinfo-form-block-end_date">
         <td class="label">{$form.end_date.label}</td>
         <td>{$form.end_date.html}</td>
-      </tr>
-    {/if}
-    {if !empty($form.template_id)}
-      <tr class="crm-event-manage-eventinfo-form-block-template_id">
-        <td class="label">{$form.template_id.label} {help id="id-select-template" isTemplate=$isTemplate}</td>
-        <td>{$form.template_id.html}</td>
       </tr>
     {/if}
     <tr class="crm-event-manage-eventinfo-form-block-event_type_id">


### PR DESCRIPTION
Overview
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/29306 the order of fields in the event form was changed. The template selection field was moved down. As discussed (starting [here](https://github.com/civicrm/civicrm-core/pull/29306#issuecomment-2371294323)) the template selection field should be moved back to the top.