### PR TITLE
Financial ACLs broken in 5.75+ when a line item with no contribution ID exists

### DIFF
--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -96,7 +96,7 @@ function financialacls_civicrm_selectWhereClause($entity, &$clauses) {
       if ($entity === 'Contribution') {
         $unavailableTypes = _financialacls_civicrm_get_inaccessible_financial_types();
         if (!empty($unavailableTypes)) {
-          $clauses['id'][] = 'NOT IN (SELECT contribution_id FROM civicrm_line_item WHERE financial_type_id IN (' . implode(',', $unavailableTypes) . '))';
+          $clauses['id'][] = 'NOT IN (SELECT contribution_id FROM civicrm_line_item WHERE contribution_id IS NOT NULL AND financial_type_id IN (' . implode(',', $unavailableTypes) . '))';
         }
       }
       break;


### PR DESCRIPTION
Overview
----------------------------------------
PR #28967 changed how financial ACL clauses are calculated such that if there are any line items without a contribution ID, no contributions are visible to ACLed users.

**Replication Steps**
* On a demo site, enable Financial ACLs.  Add a new role that has access to Civi, but only to contributions of type "Donation", and create a user with that role.
* Log in as that user.  Search for contributions. Observe that you can see all the Donation contributions.
* Create a line item with no contribution ID.  The easiest way to do this is to do a back-end registration for the Rainforest Cup Soccer Tournament (or any event with a price set), but do not record a payment.
* Search for contributions as the ACLed user again.

Before
----------------------------------------
Donation contributions should still be present.

After
----------------------------------------
No contributions are visible at all.

Technical Details
----------------------------------------
The new code generates a `WHERE` clause that looks like this:
```
SELECT * FROM civicrm_contribution WHERE id NOT IN (1, 2, 3, NULL);
```

Having the `NOT IN (NULL)` always returns no records.

Comments
----------------------------------------
Putting against the rc because it's a recent regression.
