### PR TITLE
Remove some phone type restrictions around Send SMS

### DIFF
--- a/CRM/Contact/Form/Task/SMSCommon.php
+++ b/CRM/Contact/Form/Task/SMSCommon.php
@@ -177,16 +177,14 @@ class CRM_Contact_Form_Task_SMSCommon {
         $mobilePhone = NULL;
         $contactDetails = $form->_contactDetails[$contactId];
 
-        //to check if the phone type is "Mobile"
+        // To prioritize the "Mobile" phone type
         $phoneTypes = CRM_Core_OptionGroup::values('phone_type', TRUE, FALSE, FALSE, NULL, 'name');
 
         if (CRM_Utils_System::getClassName($form) == 'CRM_Activity_Form_Task_SMS') {
-          //to check for "if the contact id belongs to a specified activity type"
+          // To check for "if the contact id belongs to a specified activity type"
           // @todo use the api instead - function is deprecated.
           $actDetails = CRM_Activity_BAO_Activity::getContactActivity($contactId);
-          if (self::RECIEVED_SMS_ACTIVITY_SUBJECT !=
-            CRM_Utils_Array::retrieveValueRecursive($actDetails, 'subject')
-          ) {
+          if (self::RECIEVED_SMS_ACTIVITY_SUBJECT != CRM_Utils_Array::retrieveValueRecursive($actDetails, 'subject')) {
             $suppressedSms++;
             unset($form->_contactDetails[$contactId]);
             continue;
@@ -200,7 +198,9 @@ class CRM_Contact_Form_Task_SMSCommon {
           continue;
         }
         elseif ($contactDetails['phone_type_id'] != ($phoneTypes['Mobile'] ?? NULL)) {
-          //if phone is not primary check if non-primary phone is "Mobile"
+          // if phone is not primary check if non-primary phone is "Mobile"
+          // @todo It's not clear what the aim here is, and allPhones is deprecated
+          // We could use getContactMobileOrPrimary, but not sure if the phone_id/etc is needed?
           $filter = ['do_not_sms' => 0];
           $contactPhones = CRM_Core_BAO_Phone::allPhones($contactId, FALSE, 'Mobile', $filter);
           if (count($contactPhones) > 0) {
@@ -208,11 +208,6 @@ class CRM_Contact_Form_Task_SMSCommon {
             $form->_contactDetails[$contactId]['phone_id'] = CRM_Utils_Array::retrieveValueRecursive($contactPhones, 'id');
             $form->_contactDetails[$contactId]['phone'] = $mobilePhone;
             $form->_contactDetails[$contactId]['phone_type_id'] = $phoneTypes['Mobile'] ?? NULL;
-          }
-          else {
-            $suppressedSms++;
-            unset($form->_contactDetails[$contactId]);
-            continue;
           }
         }
 

--- a/CRM/Contact/Form/Task/SMSTrait.php
+++ b/CRM/Contact/Form/Task/SMSTrait.php
@@ -77,7 +77,6 @@ trait CRM_Contact_Form_Task_SMSTrait {
         ->addWhere('contact_id.do_not_sms', '=', FALSE)
         ->addWhere('contact_id.is_deceased', '=', FALSE)
         ->addWhere('phone_numeric', '>', 0)
-        ->addWhere('phone_type_id:name', '=', 'Mobile')
         ->addOrderBy('is_primary')
         ->addSelect('id', 'contact_id', 'phone', 'phone_type_id:name', 'phone_numeric', 'contact_id.sort_name', 'phone_type_id', 'contact_id.display_name');
       if ($this->getSubmittedValue('to')) {

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -477,7 +477,7 @@ FROM civicrm_action_schedule cas
     if (!isset(Civi::$statics[__CLASS__]['sms'][$cacheKey])) {
       $numbers = [];
       foreach ($cids as $cid) {
-        $number = self::pickSmsPhoneNumber($cid);
+        $number = CRM_Core_BAO_Phone::getContactMobileOrPrimary($cid);
         if ($number) {
           $numbers[$cid] = $number;
         }
@@ -654,7 +654,7 @@ FROM civicrm_action_schedule cas
       $toPhoneNumbers = self::getSmsNumbers($alternateRecipients);
     }
     else {
-      $toPhoneNumbers = self::pickSmsPhoneNumber($toContactID);
+      $toPhoneNumbers = CRM_Core_BAO_Phone::getContactMobileOrPrimary($toContactID);
       $toPhoneNumbers = $toPhoneNumbers ? [$toContactID => $toPhoneNumbers] : NULL;
     }
     if (!$toPhoneNumbers) {
@@ -807,25 +807,11 @@ FROM civicrm_action_schedule cas
   }
 
   /**
-   * Pick SMS phone number.
-   *
-   * @param int $smsToContactId
-   *
-   * @return NULL|string
+   * @deprecatd
    */
-  protected static function pickSmsPhoneNumber($smsToContactId) {
-    $toPhoneNumbers = CRM_Core_BAO_Phone::allPhones($smsToContactId, FALSE, 'Mobile', [
-      'is_deceased' => 0,
-      'is_deleted' => 0,
-      'do_not_sms' => 0,
-    ]);
-    //to get primary mobile ph,if not get a first mobile phONE
-    if (!empty($toPhoneNumbers)) {
-      $toPhoneNumberDetails = reset($toPhoneNumbers);
-      $toPhoneNumber = $toPhoneNumberDetails['phone'] ?? NULL;
-      return $toPhoneNumber;
-    }
-    return NULL;
+  protected static function pickSmsPhoneNumber($contactID) {
+    CRM_Core_Error::deprecatedFunctionWarning('CRM_Core_BAO_Phone::getContactMobileOrPrimary');
+    return CRM_Core_BAO_Phone::getContactMobileOrPrimary($contactID);
   }
 
   /**

--- a/Civi/Api4/Service/Links/ActivityLinksProvider.php
+++ b/Civi/Api4/Service/Links/ActivityLinksProvider.php
@@ -111,7 +111,6 @@ class ActivityLinksProvider extends \Civi\Core\Service\AutoSubscriber {
         try {
           $phone = civicrm_api3('Phone', 'getsingle', [
             'contact_id' => $contactId,
-            'phone_type_id' => \CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Phone', 'phone_type_id', 'Mobile'),
             'return' => ['phone', 'contact_id'],
             'options' => ['limit' => 1, 'sort' => "is_primary DESC"],
             'api.Contact.getsingle' => [

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -1461,8 +1461,9 @@ $text
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function testSendSmsLandLinePhoneNumber(): void {
-    $sent = $this->createSendSmsTest(FALSE, 1);
-    $this->assertEquals('Recipient phone number is invalid or recipient does not want to receive SMS', $sent[0], "Expected error doesn't match");
+    // Since PR#31180 this is now be allowed
+    $sent = $this->createSendSmsTest(TRUE, 1);
+    $this->assertEquals(TRUE, $sent[0]);
   }
 
   /**
@@ -1567,7 +1568,7 @@ $text
         break;
 
       case 1:
-        // Create a fixed phone number
+        // Create a fixed phone number (since PR#31180 this should now be allowed)
         $phone = civicrm_api3('Phone', 'create', [
           'contact_id' => $contactId,
           'phone' => 654321,
@@ -1581,7 +1582,7 @@ $text
     }
 
     // Now run the actual test
-    [$sent, $activityId, $success] = CRM_Activity_BAO_Activity::sendSms(
+    [$sent, $activityId, $success] = CRM_Activity_BAO_Activity::sendSMS(
       $contactDetails,
       $activityParams,
       $smsProviderParams,


### PR DESCRIPTION
Overview
----------------------------------------

The "Send SMS" feature requires that the contact have a phone of type "mobile". The year is 2024 and most people have phones that support SMS (my VoIP provider does anyway).

I sometimes encounter situations where people change those phone types, without knowing that there are hardcoded meanings around some of them. Or they are confused about why a phone would not receive SMS :phone: 

Before
----------------------------------------

Admin can SMS only a contact with a phone of type "mobile".

After
----------------------------------------

Admin can SMS any number.

Comments
----------------------------------------

I tried keeping the feature that prioritizes a mobile number, if there is one. I only removed the restrictions on the "Send SMS" activity.

Mass-sms is maybe a bit more tricky, since if you know about the behaviour, maybe you expect it. I was thinking of maybe adding a help-text on that interface. I was curious how people felt about this change first.

This doc would need some tweaks: https://docs.civicrm.org/user/en/latest/sms-text-messaging/everyday-tasks/