### PR TITLE
Participant Import: avoid listing custom fields twice

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -273,7 +273,10 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    */
   protected function getImportFieldsForEntity(string $entity): array {
     return (array) civicrm_api4($entity, 'getFields', [
-      'where' => [['usage', 'CONTAINS', 'import']],
+      'where' => [
+        ['usage', 'CONTAINS', 'import'],
+        ['type', '!=', 'Custom'],
+      ],
     ])->indexBy('name');
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

Custom fields are listed twice on the mapping screen when importing participants

Before
----------------------------------------

If you create a custom participant field (used for Participants - ANY). Then, click Events -> Import Participants. Add a csv file and go to the Mapping page. You will see that custom fields are listed twice:

![image](https://github.com/user-attachments/assets/4b8e3bb8-d215-43c4-bed6-94b06870a10b)

After
----------------------------------------
They are only listed once.

Technical Details
----------------------------------------
@eileenmcnaughton I think this is a regression from c56953d6e41f4695a531a8db91a8c6f0eccf7e7f. 