### PR TITLE
ext/*/info.xml - Use a short expressions instead of constantly revising files

### DIFF
--- a/CRM/Extension/Info.php
+++ b/CRM/Extension/Info.php
@@ -261,8 +261,20 @@ class CRM_Extension_Info {
    * Copy attributes from an XML document to $this
    *
    * @param SimpleXMLElement $info
+   * @param bool $useVariables
+   *  Whether to interpolate variables like [civicrm.version]
    */
-  public function parse($info) {
+  public function parse($info, bool $useVariables = TRUE) {
+    // Note that these variables must evaluated at fairly low-level of bootstrap.
+    // So it's good to be conservative about how much dynamism you put in.
+    $vars = [
+      '[civicrm.version]' => CRM_Utils_System::version(),
+      '[civicrm.majorVersion]' => CRM_Utils_System::majorVersion(),
+      '[civicrm.releaseDate]' => CRM_Utils_System::versionXml()['releaseDate'],
+      '[self.key]' => (string) $info->attributes()->key,
+    ];
+    $eval = $useVariables ? (fn($v) => $this->interpolate($v, $vars)) : (fn($v) => $v);
+
     $this->key = (string) $info->attributes()->key;
     $this->type = (string) $info->attributes()->type;
     $this->file = (string) $info->file;
@@ -277,7 +289,7 @@ class CRM_Extension_Info {
         continue;
       }
       if (!count($val->children())) {
-        $this->$attr = is_array($this->$attr) ? [] : trim((string) $val);
+        $this->$attr = $eval(is_array($this->$attr) ? [] : trim((string) $val));
       }
       elseif ($attr === 'urls') {
         $this->urls = [];
@@ -336,8 +348,20 @@ class CRM_Extension_Info {
         }
       }
       else {
-        $this->$attr = CRM_Utils_XML::xmlObjToArray($val);
+        $this->$attr = $eval(CRM_Utils_XML::xmlObjToArray($val));
       }
+    }
+  }
+
+  private function interpolate($value, $vars) {
+    if (is_string($value)) {
+      return strtr($value, $vars);
+    }
+    elseif (is_array($value)) {
+      return array_map(fn($item) => $this->interpolate($item, $vars), $value);
+    }
+    else {
+      return $value;
     }
   }
 

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1149,6 +1149,10 @@ class CRM_Utils_System {
    * @throws CRM_Core_Exception
    */
   public static function version() {
+    return static::versionXml()['version_no'];
+  }
+
+  public static function versionXml(): array {
     static $version;
 
     if (!$version) {
@@ -1158,11 +1162,11 @@ class CRM_Utils_System {
       if (file_exists($verFile)) {
         $str = file_get_contents($verFile);
         $xmlObj = simplexml_load_string($str);
-        $version = (string) $xmlObj->version_no;
+        $version = CRM_Utils_XML::xmlObjToArray($xmlObj);
       }
 
       // pattern check
-      if (!CRM_Utils_System::isVersionFormatValid($version)) {
+      if (!$version || !CRM_Utils_System::isVersionFormatValid($version['version_no'])) {
         throw new CRM_Core_Exception('Unknown codebase version.');
       }
     }

--- a/ext/afform/admin/info.xml
+++ b/ext/afform/admin/info.xml
@@ -12,11 +12,11 @@
     <url desc="Chat">https://chat.civicrm.org/civicrm/channels/dev-afform</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>beta</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>FormBuilder provides a UI to administer and edit forms. It is an optional admin tool and not required for the forms to function.</comments>
   <requires>

--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -12,10 +12,10 @@
     <url desc="Chat">https://chat.civicrm.org/civicrm/channels/dev-afform</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <develStage>stable</develStage>
   <tags>

--- a/ext/afform/html/info.xml
+++ b/ext/afform/html/info.xml
@@ -12,11 +12,11 @@
     <url desc="Chat">https://chat.civicrm.org/civicrm/channels/dev-afform</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <requires>
     <ext>org.civicrm.afform</ext>

--- a/ext/afform/mock/info.xml
+++ b/ext/afform/mock/info.xml
@@ -11,14 +11,14 @@
   <urls>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <requires>
     <ext>org.civicrm.afform</ext>

--- a/ext/authx/info.xml
+++ b/ext/authx/info.xml
@@ -14,14 +14,14 @@
     <url desc="Issues">https://lab.civicrm.org/dev/core/-/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <tags>
     <tag>mgmt:required</tag>
   </tags>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>AuthX enables remote applications to connect to CiviCRM. Use it to enable and disable different forms of authentication (such as username-password, API key, and/or JWT).</comments>
   <classloader>

--- a/ext/chart_kit/info.xml
+++ b/ext/chart_kit/info.xml
@@ -14,11 +14,11 @@
     <url desc="Issues">https://lab.civicrm.org/dev/report/-/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>beta</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>Click on the chat link above to discuss development, report problems or ask questions.</comments>
   <classloader>

--- a/ext/civi_campaign/info.xml
+++ b/ext/civi_campaign/info.xml
@@ -12,14 +12,14 @@
     <url desc="Documentation">https://docs.civicrm.org/user/en/latest/campaign/what-is-civicampaign/</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <tags>
     <tag>component</tag>
   </tags>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>Core Component</comments>
   <upgrader>CRM_Extension_Upgrader_Component</upgrader>

--- a/ext/civi_case/info.xml
+++ b/ext/civi_case/info.xml
@@ -12,14 +12,14 @@
     <url desc="Documentation">https://docs.civicrm.org/user/en/latest/case-management/what-is-civicase/</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <tags>
     <tag>component</tag>
   </tags>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>Core Component</comments>
   <upgrader>CRM_Extension_Upgrader_Component</upgrader>

--- a/ext/civi_contribute/info.xml
+++ b/ext/civi_contribute/info.xml
@@ -12,14 +12,14 @@
     <url desc="Documentation">https://docs.civicrm.org/user/en/latest/contributions/what-is-civicontribute/</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <tags>
     <tag>component</tag>
   </tags>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>Core Component</comments>
   <upgrader>CRM_Extension_Upgrader_Component</upgrader>

--- a/ext/civi_event/info.xml
+++ b/ext/civi_event/info.xml
@@ -12,14 +12,14 @@
     <url desc="Documentation">https://docs.civicrm.org/user/en/latest/events/what-is-civievent</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <tags>
     <tag>component</tag>
   </tags>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>Core Component</comments>
   <upgrader>CRM_Extension_Upgrader_Component</upgrader>

--- a/ext/civi_mail/info.xml
+++ b/ext/civi_mail/info.xml
@@ -12,14 +12,14 @@
     <url desc="Documentation">https://docs.civicrm.org/user/en/latest/email/what-is-civimail/</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <tags>
     <tag>component</tag>
   </tags>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>Core Component</comments>
   <upgrader>CRM_Extension_Upgrader_Component</upgrader>

--- a/ext/civi_member/info.xml
+++ b/ext/civi_member/info.xml
@@ -12,14 +12,14 @@
     <url desc="Documentation">https://docs.civicrm.org/user/en/latest/membership/what-is-civimember/</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <tags>
     <tag>component</tag>
   </tags>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>Core Component</comments>
   <upgrader>CRM_Extension_Upgrader_Component</upgrader>

--- a/ext/civi_pledge/info.xml
+++ b/ext/civi_pledge/info.xml
@@ -12,14 +12,14 @@
     <url desc="Documentation">https://docs.civicrm.org/user/en/latest/pledges/what-is-civipledge/</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <tags>
     <tag>component</tag>
   </tags>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>Core Component</comments>
   <upgrader>CRM_Extension_Upgrader_Component</upgrader>

--- a/ext/civi_report/info.xml
+++ b/ext/civi_report/info.xml
@@ -12,14 +12,14 @@
     <url desc="Documentation">https://docs.civicrm.org/user/en/latest/reporting/what-is-civireport/</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <tags>
     <tag>component</tag>
   </tags>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>Core Component</comments>
   <upgrader>CRM_Extension_Upgrader_Component</upgrader>

--- a/ext/civicrm_admin_ui/info.xml
+++ b/ext/civicrm_admin_ui/info.xml
@@ -12,11 +12,11 @@
     <url desc="Documentation">https://lab.civicrm.org/dev/core/-/issues/3912</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>beta</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>Key CiviCRM interfaces are being rewritten as configurable Search Display Forms. This extension lets you try these updates now, before the screens are permanently replaced in core.</comments>
   <classloader>

--- a/ext/civicrm_search_ui/info.xml
+++ b/ext/civicrm_search_ui/info.xml
@@ -12,11 +12,11 @@
     <url desc="Documentation">https://lab.civicrm.org/dev/core/-/issues/3912</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>Replacement SearchKit/FormBuilder pages for core Search pages.</comments>
   <classloader>

--- a/ext/civigrant/info.xml
+++ b/ext/civigrant/info.xml
@@ -12,11 +12,11 @@
     <url desc="Documentation">https://docs.civicrm.org/user/en/latest/grants/what-is-civigrant/</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>CiviGrant was originally a core component before migrating to an extension</comments>
   <requires>

--- a/ext/civiimport/info.xml
+++ b/ext/civiimport/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">http://civicrm.org</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>This extension contains import functionality which was previously in CiviCRM Core. If you use the import functionality it is recommended to enable this extension.</comments>
   <requires>

--- a/ext/ckeditor4/info.xml
+++ b/ext/ckeditor4/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">https://github.com/civicrm/civicrm-core/</url>
     <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>This is the version of CKEditor that originally shipped with CiviCRM core</comments>
   <classloader>

--- a/ext/contributioncancelactions/info.xml
+++ b/ext/contributioncancelactions/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">http://civicrm.org</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>This code has been moved from core to a separate extension in 5.32. Note that if you disable it failed or cancelled contributions will not cause related memberships and participant records to be updated</comments>
   <classloader>

--- a/ext/elavon/info.xml
+++ b/ext/elavon/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">https://lab.civicrm.org</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments/>
   <classloader>

--- a/ext/eventcart/info.xml
+++ b/ext/eventcart/info.xml
@@ -12,11 +12,11 @@
     <url desc="Main Extension Page">https://github.com/civicrm/civicrm-core/tree/master/ext/eventcart</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/ewaysingle/info.xml
+++ b/ext/ewaysingle/info.xml
@@ -14,14 +14,14 @@
     <url desc="Support">https://github.com/civicrm/civicrm-core/blob/master/ext/ewaysingle</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>This is an extension to contain the eWAY Single Currency Payment Processor</comments>
   <classloader>

--- a/ext/financialacls/info.xml
+++ b/ext/financialacls/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">http://FIXME</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>Financial acls - working towards moving this code to the extension from core</comments>
   <classloader>

--- a/ext/flexmailer/info.xml
+++ b/ext/flexmailer/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">http://civicrm.stackexchange.com/</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <comments>
     FlexMailer is an email delivery engine which replaces the internal guts
@@ -23,7 +23,7 @@
     to provide richer email features.
   </comments>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <tags>
     <tag>mgmt:required</tag>

--- a/ext/greenwich/info.xml
+++ b/ext/greenwich/info.xml
@@ -14,14 +14,14 @@
     <url desc="Support">http://civicrm.org</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/iframe/info.xml
+++ b/ext/iframe/info.xml
@@ -14,14 +14,14 @@
     <url desc="Issues">https://lab.civicrm.org/dev/core/-/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>alpha</develStage>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>This is a new, undeveloped module</comments>
   <classloader>

--- a/ext/legacycustomsearches/info.xml
+++ b/ext/legacycustomsearches/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">http://FIXME</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>This is our old search system which has limited support. All new effort is on SearchKit</comments>
   <classloader>

--- a/ext/message_admin/info.xml
+++ b/ext/message_admin/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">http://civicrm.org</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments/>
   <classloader>

--- a/ext/oauth-client/info.xml
+++ b/ext/oauth-client/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">https://lab.civicrm.org/dev/core/-/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <requires>
     <ext version="~4.5">org.civicrm.afform</ext>

--- a/ext/oembed/info.xml
+++ b/ext/oembed/info.xml
@@ -14,14 +14,14 @@
     <url desc="Support">http://FIXME</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>alpha</develStage>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>This is a new, undeveloped module</comments>
   <classloader>

--- a/ext/payflowpro/info.xml
+++ b/ext/payflowpro/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">https://lab.civicrm.org</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>This extension is extraction of the original Core Payflow Pro Payment Processor</comments>
   <classloader>

--- a/ext/recaptcha/info.xml
+++ b/ext/recaptcha/info.xml
@@ -12,14 +12,14 @@
     <url desc="Main Extension Page">https://github.com/civicrm/civicrm-core/tree/master/ext/recaptcha</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/scheduled_communications/info.xml
+++ b/ext/scheduled_communications/info.xml
@@ -12,11 +12,11 @@
     <url desc="Chat">https://chat.civicrm.org/civicrm/channels/search-improvements</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>beta</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>Click on the chat link above to discuss development, report problems or ask questions.</comments>
   <classloader>

--- a/ext/search_kit/info.xml
+++ b/ext/search_kit/info.xml
@@ -14,14 +14,14 @@
     <url desc="Issues">https://lab.civicrm.org/dev/report/-/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <tags>
     <tag>mgmt:required</tag>
   </tags>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>Click on the chat link above to discuss development, report problems or ask questions.</comments>
   <classloader>

--- a/ext/sequentialcreditnotes/info.xml
+++ b/ext/sequentialcreditnotes/info.xml
@@ -14,14 +14,14 @@
     <url desc="Support">https://lab.civicrm.org/extensions/sequentialcreditnotes</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <mixins>
     <mixin>setting-php@1.0.0</mixin>

--- a/ext/standaloneusers/info.xml
+++ b/ext/standaloneusers/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">http://FIXME</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <requires>
     <ext>org.civicrm.search_kit</ext>

--- a/ext/tellafriend/info.xml
+++ b/ext/tellafriend/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">https://lab.civicrm.org/dev/core/-/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>This used to be a core CiviCRM functionality and is slowly being phased out. See dev/core#1036</comments>
   <classloader>

--- a/ext/user_dashboard/info.xml
+++ b/ext/user_dashboard/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">http://FIXME</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-09-05</releaseDate>
-  <version>5.79.alpha1</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>This extension is still experimental</comments>
   <classloader>

--- a/tools/extensions/event_check/info.xml
+++ b/tools/extensions/event_check/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">https://lab.civicrm.org</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2023-12-19</releaseDate>
-  <version>5.70</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>5.70</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments></comments>
   <classloader>

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="iso-8859-1" ?>
+<?xml version="1.0" encoding="iso-8859-1"?>
 <version>
   <version_no>5.79.alpha1</version_no>
+  <releaseDate>(unreleased)</releaseDate>
 </version>


### PR DESCRIPTION
Overview
----------------------------------------

Whenever we do a release, we have to update the `info.xml` files for all the core extensions. With this update, the files don't have to change so much... so they'll produce less git-noise.

This is loosely inspired by `composer` which allows `composer.json` files to include a few limited variables like `self.version` -- it introduces a few limited variables (`civicrm.version`, `civicrm.releaseDate`).

Before
----------------------------------------

Every core extension has an `info.xml` file:

```xml
  <releaseDate>2025-09-09</releaseDate>
  <version>5.88.12</version>
  <compatibility>
   <ver>5.79</ver>
  </compatibility>
```

Whenever we issue a new release, `set-version.php` has to identify each core extension and update this value.

After
----------------------------------------

Every core extension has an `info.xml` file. They use variable expressions:

```xml
  <releaseDate>[civicrm.releaseDate]</releaseDate>
  <version>[civicrm.version]</version>
  <compatibility>
   <ver>[civicrm.majorVersion]</ver>
  </compatibility>
```

These values are fed from the same `version.xml` that identifies civicrm-core.

