### PR TITLE
dev/core#5465 - Fix Afform clearing entity when deselecting join

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -95,7 +95,11 @@
               disableForm(error.error_message);
             });
         }
-        // Clear existing contact selection
+        // Clear existing join selection
+        else if (joinEntity) {
+          data[selectedEntity][selectedIndex].joins[joinEntity][joinIndex] = {};
+        }
+        // Clear existing entity selection
         else if (selectedEntity) {
           // Delete object keys without breaking object references
           Object.keys(data[selectedEntity][selectedIndex].fields).forEach(key => delete data[selectedEntity][selectedIndex].fields[key]);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes second problem in https://lab.civicrm.org/dev/core/-/issues/5465 - when clearing an "Existing" select field on a join, the entire entity is cleared.

Before
------
![image](https://github.com/user-attachments/assets/5f8ed831-d04c-481c-9fa1-189a03ff4170)

After
------
Fixed.