### PR TITLE
Mailing Report: call mailingSize only if the queue is empty

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1510,7 +1510,9 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       $report['jobs'][] = $row;
     }
 
-    $report['event_totals']['queue'] = CRM_Mailing_BAO_MailingRecipients::mailingSize($mailing_id);
+    if (empty($report['event_totals']['queue'])) {
+      $report['event_totals']['queue'] = CRM_Mailing_BAO_MailingRecipients::mailingSize($mailing_id);
+    }
 
     if (!empty($report['event_totals']['queue'])) {
       $report['event_totals']['delivered_rate'] = (100.0 * $report['event_totals']['delivered']) / $report['event_totals']['queue'];


### PR DESCRIPTION
Overview
----------------------------------------

The Mailing Report uses data from the 'queue' tables, except for some reason the number of recipients, which uses mailingSize(), which in turn queries the civicrm_mailing_recipients SQL table.

Presumably this is for when the mailing is still in Draft. Otherwise the data is already loaded from the queue table, so there is a small performance gain from not querying again. And while in theory the queue table and the recipients table should be the same, it could result in inconsistent stats if someone uses the resendmailing extension, for example.

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/eefda1be-6e7f-4297-8c5f-d8cde770a112)

After
----------------------------------------

![image](https://github.com/user-attachments/assets/22dd7318-de80-490b-a5de-edd3288df2fe)

Comments
-----------------

If this bug sounds familiar, there was #22800 to stop recalculating recipients, but it didn't anything about how recipients were queried (after no longer being recalculated). There was also #26378.