### PR TITLE
SearchKit - Hierarchical entity displays

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -596,6 +596,7 @@ class CRM_Core_Permission {
       foreach ($permission['implied_by'] ?? [] as $parent) {
         if (isset($allPermissions[$parent])) {
           $allPermissions[$parent]['implies'][] = $name;
+          $allPermissions[$name]['parent'] = $parent;
         }
       }
     }
@@ -615,13 +616,17 @@ class CRM_Core_Permission {
    * @param array $metaPermissions
    * @param array $subPermissions
    * @param array $allPermissions
+   * @param int $recursionLevel
    */
-  protected static function setImpliedBy(array $metaPermissions, array $subPermissions, array &$allPermissions): void {
+  protected static function setImpliedBy(array $metaPermissions, array $subPermissions, array &$allPermissions, int $recursionLevel = 0): void {
     foreach ($subPermissions as $name) {
       if (isset($allPermissions[$name])) {
         $allPermissions[$name]['implied_by'] = array_unique(array_merge($allPermissions[$name]['implied_by'] ?? [], $metaPermissions));
+        if (!$recursionLevel) {
+          $allPermissions[$name]['parent'] = $metaPermissions[0];
+        }
         if (!empty($allPermissions[$name]['implies'])) {
-          self::setImpliedBy(array_merge([$name], $metaPermissions), $allPermissions[$name]['implies'], $allPermissions);
+          self::setImpliedBy(array_merge([$name], $metaPermissions), $allPermissions[$name]['implies'], $allPermissions, $recursionLevel + 1);
         }
       }
     }

--- a/CRM/Core/Permission/List.php
+++ b/CRM/Core/Permission/List.php
@@ -39,6 +39,7 @@ class CRM_Core_Permission_List {
         'description' => $corePerm['description'] ?? NULL,
         'is_active' => empty($corePerm['disabled']),
         'implies' => $corePerm['implies'] ?? NULL,
+        'parent' => $corePerm['parent'] ?? NULL,
       ];
     }
   }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2336,7 +2336,7 @@ abstract class CRM_Utils_Hook {
    *     - description: string (ex: "Register for events online")
    *     - is_synthetic: bool (TRUE for synthetic permissions with a bespoke evaluation. FALSE for concrete permissions that registered+granted in the UF user-management layer.
    *        Default TRUE iff name begins with '@')
-   *     - is_active: bool (TRUE if this permission is defined by. Default: TRUE)
+   *     - is_active: bool (FALSE for permissions belonging to disabled components, TRUE otherwise)
    *
    * @return null
    *   The return value is ignored

--- a/Civi/Api4/Action/Permission/Get.php
+++ b/Civi/Api4/Action/Permission/Get.php
@@ -39,9 +39,7 @@ class Get extends BasicGetAction {
       foreach ($perms as $permName => $permission) {
         $defaults = [
           'name' => $permName,
-          'group' => 'unknown',
           'is_synthetic' => ($permName[0] === '@'),
-          'is_active' => TRUE,
         ];
         $perms[$permName] = array_merge($defaults, $permission);
       }

--- a/Civi/Api4/ContactType.php
+++ b/Civi/Api4/ContactType.php
@@ -27,5 +27,6 @@ namespace Civi\Api4;
  */
 class ContactType extends Generic\DAOEntity {
   use Generic\Traits\ManagedEntity;
+  use Generic\Traits\HierarchicalEntity;
 
 }

--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -89,6 +89,10 @@ class Entity extends Generic\AbstractEntity {
       'description' => 'Default column to sort results',
     ],
     [
+      'name' => 'parent_field',
+      'description' => 'Field linking a hierarchical entity to its parent',
+    ],
+    [
       'name' => 'searchable',
       'description' => 'How should this entity be presented in search UIs',
       'pseudoconstant' => ['callback' => ['Civi\Api4\Utils\CoreUtil', 'getSearchableOptions']],

--- a/Civi/Api4/Event/Subscriber/HierarchicalEntitySubscriber.php
+++ b/Civi/Api4/Event/Subscriber/HierarchicalEntitySubscriber.php
@@ -1,0 +1,131 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Event\Subscriber;
+
+use Civi\API\Event\Event;
+use Civi\API\Event\PrepareEvent;
+use Civi\API\Event\RespondEvent;
+use Civi\Api4\Utils\CoreUtil;
+use Civi\Core\Service\AutoService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * This intercepts api.get actions for HierarchicalEntities and, if the `_depth` field is present in the select clause,
+ * will populate the `_depth` field and sort results into hierarchical order.
+ *
+ * @service
+ * @internal
+ */
+class HierarchicalEntitySubscriber extends AutoService implements EventSubscriberInterface {
+
+  private static $_originalLimit;
+  private static $_originalOffset;
+
+  /**
+   * @return array
+   */
+  public static function getSubscribedEvents() {
+    return [
+      'civi.api.prepare' => ['onApiPrepare', 100],
+      'civi.api.respond' => ['onApiRespond', 100],
+    ];
+  }
+
+  /**
+   * Preprocess
+   */
+  public function onApiPrepare(PrepareEvent $event): void {
+    if ($this->applies($event)) {
+      /** @var \Civi\Api4\Generic\AbstractGetAction $apiRequest */
+      $apiRequest = $event->getApiRequest();
+      // Stash limit & offset for later
+      self::$_originalLimit = $apiRequest->getLimit();
+      self::$_originalOffset = $apiRequest->getOffset();
+      // Remove limit & offset because we need to process every entity in the tree
+      $apiRequest->setLimit(0);
+      $apiRequest->setOffset(0);
+      // Ensure id & parent are selected for use in postprocessing
+      $parentField = $this->getParentField($apiRequest->getEntityName());
+      $requiredFields = [$parentField['fk_column'], $parentField['name']];
+      $apiRequest->setSelect(array_unique(array_merge($apiRequest->getSelect(), $requiredFields)));
+    }
+  }
+
+  /**
+   * Postprocess
+   */
+  public function onApiRespond(RespondEvent $event): void {
+    if ($this->applies($event)) {
+      $apiRequest = $event->getApiRequest();
+      $result = $event->getResponse();
+      $records = $result->getArrayCopy();
+      $parentField = $this->getParentField($apiRequest->getEntityName());
+      $parentName = $parentField['name'];
+      $idName = $parentField['fk_column'];
+
+      // Filter out children, maintaining sorted order
+      $children = [];
+      $records = array_filter($records, function($record) use ($parentName, &$children) {
+        if (!empty($record[$parentName])) {
+          $children[] = $record;
+        }
+        return empty($record[$parentName]);
+      });
+      $records = array_column($records, NULL, $idName);
+
+      $childCount = count($children) + 1;
+      // Maintaining other sort criteria, move children under their parents
+      while ($children && $childCount > count($children)) {
+        // This guards against a loop getting "stuck" - if there's no progress after an iteration, abandon the orphaned children
+        $childCount = count($children);
+        foreach (array_reverse($children, TRUE) as $index => $child) {
+          if (isset($records[$child[$parentName]])) {
+            $child['_depth'] = $records[$child[$parentName]]['_depth'] + 1;
+            $records = self::array_insert_after($records, $child[$parentName], [$child[$idName] => $child]);
+            unset($children[$index]);
+          }
+        }
+      }
+
+      // Apply original limit/offset
+      if (self::$_originalOffset || self::$_originalLimit) {
+        $records = array_slice($records, self::$_originalOffset ?: 0, self::$_originalLimit ?: NULL);
+      }
+
+      $result->exchangeArray(array_values($records));
+    }
+  }
+
+  private function applies(Event $event): bool {
+    $apiRequest = $event->getApiRequest();
+    return $apiRequest['version'] == 4 &&
+      is_a($apiRequest, 'Civi\Api4\Generic\AbstractGetAction') &&
+      CoreUtil::isType($apiRequest->getEntityName(), 'HierarchicalEntity') &&
+      in_array('_depth', $apiRequest->getSelect(), TRUE);
+  }
+
+  private function getParentField(string $entityName): array {
+    return civicrm_api4($entityName, 'getFields', [
+      'checkPermissions' => FALSE,
+      'where' => [['name', '=', CoreUtil::getInfoItem($entityName, 'parent_field')]],
+    ])->first();
+  }
+
+  private static function array_insert_after(array $records, string $key, array $newRecord) {
+    $pos = array_search($key, array_keys($records)) + 1;
+
+    return array_slice($records, 0, $pos, TRUE) +
+      $newRecord +
+      array_slice($records, $pos, NULL, TRUE);
+  }
+
+}

--- a/Civi/Api4/Generic/Traits/HierarchicalEntity.php
+++ b/Civi/Api4/Generic/Traits/HierarchicalEntity.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Generic\Traits;
+
+/**
+ * A hierarchical entity has nested parent/child levels.
+ *
+ * A special `_depth` field is available to these entities. Adding it to the select clause
+ * will cause returned records to be sorted in nested order.
+ *
+ * NOTE: In order to use this trait, an entity must have a column that is an EntityReference to itself.
+ * Note: Hierarchical sorting is performed in-memory, so this is not suitable for entities with unlimited records.
+ */
+trait HierarchicalEntity {
+
+  /**
+   * Automatically adds "parent_field" info, if it hasn't already been declared via `@parentField` annotation.
+   *
+   * @return array
+   */
+  public static function getInfo() {
+    $info = parent::getInfo();
+    if (empty($info['parent_field'])) {
+      $entityName = self::getEntityName();
+      $entity = \Civi::entity($entityName);
+      foreach ($entity->getFields() as $fieldName => $field) {
+        if (($field['entity_reference']['entity'] ?? NULL) === $entityName) {
+          $info['parent_field'] = $fieldName;
+          break;
+        }
+      }
+    }
+    return $info;
+  }
+
+}

--- a/Civi/Api4/Group.php
+++ b/Civi/Api4/Group.php
@@ -16,11 +16,13 @@ namespace Civi\Api4;
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/groups-and-tags/#groups
  *
  * @searchable secondary
+ * @parentField parents
  * @since 5.19
  * @package Civi\Api4
  */
 class Group extends Generic\DAOEntity {
   use Generic\Traits\ManagedEntity;
+  use Generic\Traits\HierarchicalEntity;
 
   /**
    * @param bool $checkPermissions

--- a/Civi/Api4/Permission.php
+++ b/Civi/Api4/Permission.php
@@ -10,6 +10,8 @@
  */
 namespace Civi\Api4;
 
+use Civi\Api4\Generic\Traits\HierarchicalEntity;
+
 /**
  * (Read-only) Available permissions
  *
@@ -19,10 +21,12 @@ namespace Civi\Api4;
  *
  * @searchable none
  * @primaryKey name
+ * @parentField parent
  * @since 5.34
  * @package Civi\Api4
  */
 class Permission extends Generic\AbstractEntity {
+  use HierarchicalEntity;
 
   /**
    * @param bool $checkPermissions
@@ -99,7 +103,7 @@ class Permission extends Generic\AbstractEntity {
           'name' => 'is_active',
           'title' => 'Enabled',
           'description' => '',
-          'default' => TRUE,
+          'default_value' => TRUE,
           'data_type' => 'Boolean',
           'input_type' => 'CheckBox',
           'readonly' => TRUE,
@@ -113,6 +117,26 @@ class Permission extends Generic\AbstractEntity {
           'description' => 'List of sub-permissions automatically granted by this one',
           'data_type' => 'Array',
           'readonly' => TRUE,
+        ],
+        [
+          'name' => 'parent',
+          'title' => 'Parent',
+          'description' => 'Higher permission that implies this one',
+          'data_type' => 'String',
+          'fk_entity' => 'Permission',
+          'fk_column' => 'name',
+          'readonly' => TRUE,
+        ],
+        [
+          'name' => '_depth',
+          'type' => 'Extra',
+          'readonly' => TRUE,
+          'title' => ts('Depth'),
+          'description' => ts('Depth in the nested hierarchy'),
+          'data_type' => 'Integer',
+          'default_value' => 0,
+          'label' => ts('Depth'),
+          'input_type' => 'Number',
         ],
       ];
     }))->setCheckPermissions($checkPermissions);

--- a/Civi/Api4/Service/Spec/Provider/HierarchicalEntitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/HierarchicalEntitySpecProvider.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\FieldSpec;
+use Civi\Api4\Service\Spec\RequestSpec;
+use Civi\Api4\Utils\CoreUtil;
+
+/**
+ * @service
+ * @internal
+ */
+class HierarchicalEntitySpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
+
+  /**
+   * Generic create spec function applies to all SortableEntity types.
+   * Disables required 'weight' field because that's auto-managed.
+   *
+   * @param \Civi\Api4\Service\Spec\RequestSpec $spec
+   */
+  public function modifySpec(RequestSpec $spec): void {
+    $field = new FieldSpec('_depth', $spec->getEntity(), 'Integer');
+    $field->setLabel(ts('Depth'))
+      ->setTitle(ts('Depth'))
+      ->setColumnName('id')
+      ->setInputType('Number')
+      ->setDescription(ts('Depth in the nested hierarchy'))
+      ->setType('Extra')
+      ->setReadonly(TRUE)
+      ->setSqlRenderer([__CLASS__, 'getDepth']);
+    $spec->addFieldSpec($field);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function applies($entity, $action) {
+    return $action === 'get' && CoreUtil::isType($entity, 'HierarchicalEntity');
+  }
+
+  /**
+   * Generate SQL for _depth field
+   * @param array $field
+   * @return string
+   */
+  public static function getDepth(array $field): string {
+    return "0";
+  }
+
+}

--- a/ext/civicrm_admin_ui/ang/afsearchManageGroups.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchManageGroups.aff.html
@@ -3,7 +3,6 @@
     <af-field name="title" defn="{label: 'Title', input_attrs: {}}" />
     <af-field name="visibility" defn="{label: 'Visibility', input_attrs: {multiple: true}}" />
     <af-field name="is_active" defn="{input_type: 'Radio', label: 'Enabled', afform_default: true}" />
-    <af-field name="parents" />
   </div>
   <crm-search-display-table search-name="Manage_groups" display-name="Manage_groups"></crm-search-display-table>
 </div>

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Contact_Types.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Contact_Types.mgd.php
@@ -20,7 +20,6 @@ return [
           'version' => 4,
           'select' => [
             'label',
-            'parent_id:label',
             'description',
           ],
           'orderBy' => [],
@@ -64,10 +63,6 @@ return [
           'placeholder' => 5,
           'sort' => [
             [
-              'parent_id:label',
-              'ASC',
-            ],
-            [
               'label',
               'ASC',
             ],
@@ -86,23 +81,6 @@ return [
                 ],
               ],
               'editable' => TRUE,
-            ],
-            [
-              'type' => 'field',
-              'key' => 'parent_id:label',
-              'dataType' => 'Integer',
-              'label' => E::ts('Parent'),
-              'sortable' => TRUE,
-              'icons' => [
-                [
-                  'icon' => 'fa-lock',
-                  'side' => 'left',
-                  'if' => [
-                    'parent_id:label',
-                    'IS EMPTY',
-                  ],
-                ],
-              ],
             ],
             [
               'type' => 'field',
@@ -158,6 +136,7 @@ return [
               'icon' => 'fa-plus',
             ],
           ],
+          'hierarchical' => TRUE,
         ],
         'acl_bypass' => FALSE,
       ],

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Manage_Group.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Manage_Group.mgd.php
@@ -13,9 +13,6 @@ return [
       'values' => [
         'name' => 'Manage_groups',
         'label' => E::ts('Manage groups'),
-        'form_values' => NULL,
-        'mapping_id' => NULL,
-        'search_custom_id' => NULL,
         'api_entity' => 'Group',
         'api_params' => [
           'version' => 4,
@@ -31,7 +28,6 @@ return [
             'is_active',
             'frontend_title',
             'name',
-            'parents:label',
           ],
           'orderBy' => [],
           'where' => [
@@ -68,8 +64,6 @@ return [
           ],
           'having' => [],
         ],
-        'expires_date' => NULL,
-        'description' => NULL,
       ],
       'match' => [
         'name',
@@ -79,7 +73,7 @@ return [
   [
     'name' => 'SavedSearch_Manage_groups_SearchDisplay_Manage_groups',
     'entity' => 'SearchDisplay',
-    'cleanup' => 'unused',
+    'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,
@@ -112,16 +106,7 @@ return [
               'sortable' => TRUE,
               'rewrite' => '',
               'editable' => TRUE,
-              'icons' => [
-                [
-                  'icon' => 'fa-wpforms',
-                  'side' => 'left',
-                  'if' => [
-                    'saved_search_id',
-                    'IS NOT EMPTY',
-                  ],
-                ],
-              ],
+              'icons' => [],
             ],
             [
               'type' => 'field',
@@ -134,29 +119,11 @@ return [
             ],
             [
               'type' => 'field',
-              'key' => 'is_active',
-              'dataType' => 'Boolean',
-              'label' => E::ts('Enabled'),
+              'key' => 'description',
+              'dataType' => 'Text',
+              'label' => E::ts('Description'),
               'sortable' => TRUE,
               'editable' => TRUE,
-            ],
-            [
-              'type' => 'field',
-              'key' => 'COUNT_Group_GroupContact_Contact_01_display_name',
-              'dataType' => 'Integer',
-              'label' => E::ts('Count'),
-              'sortable' => TRUE,
-              'rewrite' => '{if "[saved_search_id]"}{else}[COUNT_Group_GroupContact_Contact_01_display_name]{/if}',
-              'icons' => [
-                [
-                  'icon' => 'fa-question',
-                  'side' => 'left',
-                  'if' => [
-                    'saved_search_id',
-                    'IS NOT EMPTY',
-                  ],
-                ],
-              ],
             ],
             [
               'type' => 'field',
@@ -172,14 +139,6 @@ return [
                 'target' => '_blank',
               ],
               'title' => E::ts('View Contact'),
-            ],
-            [
-              'type' => 'field',
-              'key' => 'description',
-              'dataType' => 'Text',
-              'label' => E::ts('Description'),
-              'sortable' => TRUE,
-              'editable' => TRUE,
             ],
             [
               'type' => 'field',
@@ -199,20 +158,42 @@ return [
             ],
             [
               'type' => 'field',
-              'key' => 'parents:label',
-              'dataType' => 'Text',
-              'label' => E::ts('Parents'),
+              'key' => 'is_active',
+              'dataType' => 'Boolean',
+              'label' => E::ts('Enabled'),
               'sortable' => TRUE,
               'editable' => TRUE,
             ],
             [
+              'type' => 'field',
+              'key' => 'COUNT_Group_GroupContact_Contact_01_display_name',
+              'dataType' => 'Integer',
+              'label' => E::ts('Count'),
+              'sortable' => TRUE,
+              'rewrite' => '{if "[saved_search_id]"}{else}[COUNT_Group_GroupContact_Contact_01_display_name]{/if}',
+              'icons' => [
+                [
+                  'icon' => 'fa-lightbulb',
+                  'side' => 'left',
+                  'if' => [
+                    'saved_search_id',
+                    'IS NOT EMPTY',
+                  ],
+                ],
+              ],
+            ],
+            [
+              'text' => '',
+              'style' => 'default',
+              'size' => 'btn-xs',
+              'icon' => 'fa-bars',
               'links' => [
                 [
                   'entity' => '',
                   'action' => '',
                   'join' => '',
                   'target' => '',
-                  'icon' => 'fa-external-link',
+                  'icon' => 'fa-users',
                   'text' => E::ts('Contacts'),
                   'style' => 'default',
                   'path' => 'civicrm/group/search?reset=1&force=1&context=smog&gid=[id]&component_mode=1',
@@ -229,16 +210,6 @@ return [
                   'join' => '',
                   'target' => 'crm-popup',
                 ],
-              ],
-              'type' => 'buttons',
-              'alignment' => 'text-right',
-            ],
-            [
-              'text' => '',
-              'style' => 'default',
-              'size' => 'btn-xs',
-              'icon' => 'fa-bars',
-              'links' => [
                 [
                   'task' => 'enable',
                   'entity' => 'Group',
@@ -296,6 +267,7 @@ return [
               FALSE,
             ],
           ],
+          'hierarchical' => TRUE,
         ],
         'acl_bypass' => FALSE,
       ],

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialTypeTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialTypeTest.php
@@ -56,6 +56,7 @@ class FinancialTypeTest extends BaseTestClass {
             ]),
             'description' => ts('%1 contributions of type %2', [1 => $action_ts, 2 => $type]),
             'implied_by' => [ts('%1 contributions of all types', [1 => $action_ts])],
+            'parent' => $action_ts . ' contributions of all types',
           ],
           $permissions[$action . ' contributions of type ' . $type]
         );

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -146,6 +146,11 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         $columns[] = $this->formatColumn($column, $data);
       }
       $style = $this->getCssStyles($this->display['settings']['cssRules'] ?? [], $data);
+      // Add hierarchical styles
+      if (!empty($this->display['settings']['hierarchical'])) {
+        $style[] = 'crm-hierarchical-row crm-hierarchical-depth-' . ($data['_depth'] ?? '0');
+        $style[] = empty($data['_depth']) ? 'crm-hierarchical-parent' : 'crm-hierarchical-child';
+      }
       $row = [
         'data' => $data,
         'columns' => $columns,
@@ -1307,6 +1312,10 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       (!empty($this->display['settings']['actions']) || !empty($this->display['settings']['draggable']))
     ) {
       $this->addSelectExpression(CoreUtil::getIdFieldName($this->savedSearch['api_entity']));
+    }
+    // Add `depth_` column for hierarchical entity displays
+    if (!empty($this->display['settings']['hierarchical'])) {
+      $this->addSelectExpression('_depth');
     }
     // Add draggable column (typically "weight")
     if (!empty($this->display['settings']['draggable'])) {

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
@@ -78,7 +78,7 @@ class Download extends AbstractRunAction {
       $apiParams['limit'] = $settings['limit'];
     }
     $apiParams['orderBy'] = $this->getOrderByFromSort();
-    $this->augmentSelectClause($apiParams);
+    $this->augmentSelectClause($apiParams, $settings);
 
     $this->applyFilters();
 

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -46,7 +46,7 @@ class Run extends AbstractRunAction {
     $pagerMode = NULL;
 
     $this->preprocessLinks();
-    $this->augmentSelectClause($apiParams);
+    $this->augmentSelectClause($apiParams, $settings);
     $this->applyFilters();
 
     switch ($this->return) {

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -56,7 +56,8 @@
         // Displays created prior to 5.43 may not have this property
         ctrl.display.settings.classes = ctrl.display.settings.classes || [];
         // Table can be draggable if the main entity is a SortableEntity.
-        ctrl.canBeDraggable = _.includes(searchMeta.getEntity(ctrl.apiEntity).type, 'SortableEntity');
+        ctrl.sortableEntity = _.includes(searchMeta.getEntity(ctrl.apiEntity).type, 'SortableEntity');
+        ctrl.hierarchicalEntity = _.includes(searchMeta.getEntity(ctrl.apiEntity).type, 'HierarchicalEntity');
         ctrl.parent.initColumns({label: true, sortable: true});
       };
 

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -3,11 +3,19 @@
   <summary>{{:: ts('Settings') }}</summary>
   <fieldset ng-if="!$ctrl.display.settings.draggable" ng-include="'~/crmSearchAdmin/crmSearchAdminDisplaySort.html'"></fieldset>
   <fieldset>
-    <div ng-if="$ctrl.canBeDraggable" class="form-inline">
+    <div ng-if="$ctrl.sortableEntity" class="form-inline">
       <div class="checkbox-inline form-control">
         <label>
           <input type="checkbox" ng-checked="!!$ctrl.display.settings.draggable" ng-click="$ctrl.toggleDraggable()">
           <span>{{:: ts('Drag and drop sorting') }}</span>
+        </label>
+      </div>
+    </div>
+    <div ng-if="$ctrl.hierarchicalEntity" class="form-inline">
+      <div class="checkbox-inline form-control">
+        <label>
+          <input type="checkbox" ng-model="$ctrl.display.settings.hierarchical">
+          <span>{{:: ts('Show nested hierarchy') }}</span>
         </label>
       </div>
     </div>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
@@ -1,5 +1,5 @@
 <tr ng-repeat="(rowIndex, row) in $ctrl.results" data-entity-id="{{:: row.key }}">
-  <td ng-if=":: $ctrl.hasExtraFirstColumn()" class="{{:: row.cssClass }}">
+  <td ng-if=":: $ctrl.hasExtraFirstColumn()" class="crm-search-ctrl-column {{:: row.cssClass }}">
     <span ng-if=":: $ctrl.settings.draggable" class="crm-draggable" title="{{:: ts('Drag to reposition') }}">
       <i class="crm-i fa-arrows-v"></i>
     </span>

--- a/ext/search_kit/css/crmSearchDisplayTable.css
+++ b/ext/search_kit/css/crmSearchDisplayTable.css
@@ -32,3 +32,51 @@ table.crm-sticky-header > thead > tr {
   position: sticky !important;
   top: var(--crm-menubar-bottom, 0px);
 }
+
+/* Nested styling for hierarchical rows */
+#bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-row {
+  position: relative;
+}
+/* Depth >= 1 */
+#bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-child:first-child:not(.crm-search-ctrl-column),
+#bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-child {
+  padding-left: 35px;
+}
+#bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-child:first-child:not(.crm-search-ctrl-column):before,
+#bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-child:before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 15px;
+  width: 15px;
+  height: calc(100%/2);
+  border-bottom: 2px dotted currentColor;
+  border-left: 2px dotted currentColor;
+}
+/* Depth = 2 */
+#bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-2:first-child:not(.crm-search-ctrl-column),
+#bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-2 {
+  padding-left: 65px;
+}
+#bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-2:first-child:not(.crm-search-ctrl-column):before,
+#bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-2:before {
+  left: 45px;
+}
+/* Depth = 3 */
+#bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-3:first-child:not(.crm-search-ctrl-column),
+#bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-3 {
+  padding-left: 95px;
+}
+#bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-3:first-child:not(.crm-search-ctrl-column):before,
+#bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-3:before {
+  left: 75px;
+}
+/* Depth = 4 */
+#bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-4:first-child:not(.crm-search-ctrl-column),
+#bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-4 {
+  padding-left: 125px;
+}
+#bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-4:first-child:not(.crm-search-ctrl-column):before,
+#bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-4:before {
+  left: 105px;
+}

--- a/ext/standaloneusers/Civi/Api4/RolePermission.php
+++ b/ext/standaloneusers/Civi/Api4/RolePermission.php
@@ -13,6 +13,7 @@
 namespace Civi\Api4;
 
 use Civi\Api4\Generic\BasicGetFieldsAction;
+use Civi\Api4\Generic\Traits\HierarchicalEntity;
 use CRM_Standaloneusers_ExtensionUtil as E;
 
 /**
@@ -21,9 +22,11 @@ use CRM_Standaloneusers_ExtensionUtil as E;
  * @searchable secondary
  * @labelField title
  * @primaryKey name
+ * @parentField parent
  * @package standaloneusers
  */
 class RolePermission extends Generic\AbstractEntity {
+  use HierarchicalEntity;
 
   /**
    * @param bool $checkPermissions
@@ -103,6 +106,26 @@ class RolePermission extends Generic\AbstractEntity {
           'input_attrs' => [
             'label' => E::ts('Description'),
           ],
+        ],
+        [
+          'name' => 'parent',
+          'title' => 'Parent',
+          'description' => 'Permission that implies this one',
+          'data_type' => 'String',
+          'fk_entity' => 'RolePermission',
+          'fk_column' => 'name',
+          'readonly' => TRUE,
+        ],
+        [
+          'name' => '_depth',
+          'type' => 'Extra',
+          'readonly' => TRUE,
+          'title' => E::ts('Depth'),
+          'description' => E::ts('Depth in the nested hierarchy'),
+          'data_type' => 'Integer',
+          'default_value' => 0,
+          'label' => E::ts('Depth'),
+          'input_type' => 'Number',
         ],
       ];
       foreach ($roles as $roleName => $roleLabel) {

--- a/ext/standaloneusers/ang/afsearchPermissions.aff.html
+++ b/ext/standaloneusers/ang/afsearchPermissions.aff.html
@@ -1,6 +1,6 @@
 <div af-fieldset="">
   <div class="af-container af-layout-inline">
-    <af-field name="title" defn="{input_attrs: {multiple: true}}" />
+    <af-field name="title" defn="{label: false, input_attrs: {placeholder: ts('Search Permissions')}}" />
   </div>
   <crm-search-display-table search-name="Permissions" display-name="Permissions_Table_1"></crm-search-display-table>
 </div>

--- a/ext/standaloneusers/managed/SavedSearch_Permissions.mgd.php
+++ b/ext/standaloneusers/managed/SavedSearch_Permissions.mgd.php
@@ -70,6 +70,7 @@ $items = [
             'table-striped',
             'crm-sticky-header',
           ],
+          'hierarchical' => TRUE,
         ],
       ],
       'match' => [

--- a/ext/standaloneusers/tests/phpunit/Civi/Api4/Action/RolePermissionTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Api4/Action/RolePermissionTest.php
@@ -3,6 +3,7 @@ namespace Civi\Api4\Action;
 
 use Civi\Api4\Role;
 use Civi\Api4\RolePermission;
+use Civi\Api4\Utils\CoreUtil;
 use Civi\Test\HeadlessInterface;
 
 /**
@@ -14,6 +15,10 @@ class RolePermissionTest extends \PHPUnit\Framework\TestCase implements Headless
     return \Civi\Test::headless()
       ->installMe(__DIR__)
       ->apply();
+  }
+
+  public function testMetadata(): void {
+    $this->assertEquals('parent', CoreUtil::getInfoItem('RolePermission', 'parent_field'));
   }
 
   /**

--- a/tests/phpunit/api/v4/Entity/ContactTypeTest.php
+++ b/tests/phpunit/api/v4/Entity/ContactTypeTest.php
@@ -26,12 +26,17 @@ use Civi\Api4\Email;
 use Civi\Api4\Individual;
 use Civi\Api4\Navigation;
 use Civi\Api4\Organization;
+use Civi\Api4\Utils\CoreUtil;
 use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
 class ContactTypeTest extends Api4TestBase implements TransactionalInterface {
+
+  public function testMetadata(): void {
+    $this->assertEquals('parent_id', CoreUtil::getInfoItem('ContactType', 'parent_field'));
+  }
 
   public function testMenuItemWillBeCreatedAndDeleted(): void {
     ContactType::create(FALSE)
@@ -198,6 +203,37 @@ class ContactTypeTest extends Api4TestBase implements TransactionalInterface {
 
     $this->assertEquals('Household', $household['contact_type']);
     $this->assertTrue(empty($household['organization_name']));
+  }
+
+  public function testDepth(): void {
+    ContactType::delete(FALSE)
+      ->addWhere('parent_id', 'IS NOT NULL')
+      ->execute();
+
+    $this->saveTestRecords('ContactType', [
+      'records' => [
+        ['parent_id.name' => 'Organization', 'name' => 'ZOrg'],
+        ['parent_id.name' => 'Individual', 'name' => '1Ind'],
+        ['parent_id.name' => 'Organization', 'name' => '1Org'],
+        ['parent_id.name' => 'Individual', 'name' => '2Ind'],
+      ],
+    ]);
+
+    $result = ContactType::get(FALSE)
+      ->addSelect('name', '_depth')
+      ->addOrderBy('name', 'ASC')
+      ->setLimit(5)
+      ->setOffset(1)
+      ->execute()->column('_depth', 'name');
+
+    $expected = [
+      'Individual' => 0,
+      '1Ind' => 1,
+      '2Ind' => 1,
+      'Organization' => 0,
+      '1Org' => 1,
+    ];
+    $this->assertEquals($expected, $result);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Makes it possible to visualize nested hierarchies in search display tables. Updates 3 Admin tables to do so (screenshots below).

Before
----------------------------------------
Trying to do this in SearchKit was like... 🤔

After
----------------------------------------
Now you can! Here's the updated "Administer Contact Types" screen in Admin UI:

![image](https://github.com/user-attachments/assets/52c38c8c-a7d3-4563-87a7-6a4ea59f74c2)

And here's the "Administer Role Permissions" screen in Standalone:

![image](https://github.com/user-attachments/assets/99d1a0a7-ff5a-4384-807f-af6c9a179637)

(requires https://github.com/civicrm/civicrm-core/pull/31191 to show all the grey checkboxes correctly)

And the updated "Manage Groups" screen in Admin UI:

![image](https://github.com/user-attachments/assets/ef4dbdd0-ab4c-4f40-a67d-d5b0ba4400d8)


Technical Details
----------------------------------------
Adds `HierarchicalEntity` APIv4 trait.

A special `_depth` field is available to these entities. Adding it to the select clause will cause returned records to be sorted in nested order.