### PR TITLE
Add unit test for handling other location in the labels, clean up & handle group by

### DIFF
--- a/CRM/Contact/Form/Task/Label.php
+++ b/CRM/Contact/Form/Task/Label.php
@@ -19,6 +19,7 @@
  * This class helps to print the labels for contacts.
  */
 class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
+  use CRM_Contact_Form_Task_LabelTrait;
 
   /**
    * Build all the data structures needed to build the form.
@@ -91,124 +92,11 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
 
   /**
    * Process the form after the input has been submitted and validated.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function postProcess() {
-    $fv = $this->controller->exportValues($this->_name);
-    $locName = NULL;
-
-    $addressReturnProperties = $this->getAddressReturnProperties();
-
-    //build the returnproperties
-    $returnProperties = ['display_name' => 1, 'contact_type' => 1, 'prefix_id' => 1];
-    $mailingFormat = Civi::settings()->get('mailing_format');
-
-    $mailingFormatProperties = [];
-    if ($mailingFormat) {
-      $mailingFormatProperties = CRM_Utils_Token::getReturnProperties($mailingFormat);
-      $returnProperties = array_merge($returnProperties, $mailingFormatProperties);
-    }
-    //we should not consider addressee for data exists, CRM-6025
-    if (array_key_exists('addressee', $mailingFormatProperties)) {
-      unset($mailingFormatProperties['addressee']);
-    }
-
-    if (isset($fv['merge_same_address'])) {
-      // we need first name/last name for summarising to avoid spillage
-      $returnProperties['first_name'] = 1;
-      $returnProperties['last_name'] = 1;
-    }
-
-    /*
-     * CRM-8338: replace ids of household members with the id of their household
-     * so we can merge labels by household.
-     */
-    if (isset($fv['merge_same_household'])) {
-      $this->mergeContactIdsByHousehold();
-    }
-
-    //get the contacts information
-    $params = [];
-    if (!empty($fv['location_type_id'])) {
-      $locType = CRM_Core_DAO_Address::buildOptions('location_type_id');
-      $locName = $locType[$fv['location_type_id']];
-      $location = ['location' => ["{$locName}" => $addressReturnProperties]];
-      $returnProperties = array_merge($returnProperties, $location);
-      $params[] = ['location_type', '=', [1 => $fv['location_type_id']], 0, 0];
-      $primaryLocationOnly = FALSE;
-    }
-    else {
-      $returnProperties = array_merge($returnProperties, $addressReturnProperties);
-      $primaryLocationOnly = TRUE;
-    }
-
-    $rows = [];
-    foreach ($this->_contactIds as $key => $contactID) {
-      $params[] = [
-        CRM_Core_Form::CB_PREFIX . $contactID,
-        '=',
-        1,
-        0,
-        0,
-      ];
-    }
-
-    // fix for CRM-2651
-    if (!empty($fv['do_not_mail'])) {
-      $params[] = ['do_not_mail', '=', 0, 0, 0];
-    }
-    // fix for CRM-2613
-    $params[] = ['is_deceased', '=', 0, 0, 0];
-
-    //get the total number of contacts to fetch from database.
-    $numberofContacts = count($this->_contactIds);
-    [$details] = CRM_Contact_BAO_Query::apiQuery($params, $returnProperties, NULL, NULL, 0, $numberofContacts, TRUE, FALSE, TRUE, CRM_Contact_BAO_Query::MODE_CONTACTS, NULL, $primaryLocationOnly);
-
-    foreach ($this->_contactIds as $value) {
-      $contact = $details[$value] ?? NULL;
-
-      // we need to remove all the "_id"
-      unset($contact['contact_id']);
-
-      if ($locName && !empty($contact[$locName])) {
-        // If location type is not primary, $contact contains
-        // one more array as "$contact[$locName] = array( values... )"
-
-        $contact = array_merge($contact, $contact[$locName]);
-        unset($contact[$locName]);
-
-        if (!empty($contact['county_id'])) {
-          unset($contact['county_id']);
-        }
-      }
-      else {
-
-        if (!empty($contact['addressee_display'])) {
-          $contact['addressee_display'] = trim($contact['addressee_display']);
-        }
-        if (!empty($contact['addressee'])) {
-          $contact['addressee'] = $contact['addressee_display'];
-        }
-      }
-
-      // now create the rows for generating mailing labels
-      foreach ($contact as $field => $fieldValue) {
-        $rows[$value][$field] = $fieldValue;
-      }
-    }
-
-    if (isset($fv['merge_same_address'])) {
-      CRM_Core_BAO_Address::mergeSameAddress($rows);
-    }
-
-    // format the addresses according to CIVICRM_ADDRESS_FORMAT (CRM-1327)
-    foreach ($rows as $id => $row) {
-      $row['id'] = $id;
-      $formatted = CRM_Utils_Address::formatMailingLabel($row);
-      $rows[$id] = [$formatted];
-    }
-
-    //call function to create labels
-    $this->createLabel($rows, $fv['label_name']);
+  public function postProcess(): void {
+    $this->createLabels();
     CRM_Utils_System::civiExit();
   }
 
@@ -234,51 +122,10 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
   }
 
   /**
-   * Create labels (pdf).
-   *
-   * @param array $contactRows
-   *   Associated array of contact data.
-   * @param string $format
-   *   Format in which labels needs to be printed.
-   */
-  private function createLabel(array $contactRows, $format) {
-    $pdf = new CRM_Utils_PDF_Label($format, 'mm');
-    $pdf->Open();
-    $pdf->AddPage();
-
-    //build contact string that needs to be printed
-    $val = NULL;
-    foreach ($contactRows as $value) {
-      foreach ($value as $v) {
-        $val .= "$v\n";
-      }
-
-      $pdf->AddPdfLabel($val);
-      $val = '';
-    }
-    if (CIVICRM_UF === 'UnitTests') {
-      throw new CRM_Core_Exception_PrematureExitException('pdf output called', ['contactRows' => $contactRows, 'format' => $format, 'pdf' => $pdf]);
-    }
-    $pdf->Output('MailingLabels_CiviCRM.pdf', 'D');
-  }
-
-  /**
-   * Get array of return properties for address fields required for mailing label.
-   *
    * @return array
-   *   return properties for address e.g
-   *   [street_address => 1, supplemental_address_1 => 1, supplemental_address_2 => 1]
    */
-  private function getAddressReturnProperties(): array {
-    $mailingFormat = Civi::settings()->get('mailing_format');
-
-    $addressFields = CRM_Utils_Address::sequence($mailingFormat);
-    $addressReturnProperties = array_fill_keys($addressFields, 1);
-
-    if (array_key_exists('postal_code', $addressReturnProperties)) {
-      $addressReturnProperties['postal_code_suffix'] = 1;
-    }
-    return $addressReturnProperties;
+  protected function getContactIDs(): array {
+    return $this->_contactIds;
   }
 
 }

--- a/CRM/Contact/Form/Task/LabelTrait.php
+++ b/CRM/Contact/Form/Task/LabelTrait.php
@@ -1,0 +1,155 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+use Civi\Api4\Address;
+use Civi\Api4\Contact;
+
+/**
+ * This class provides the common functionality for tasks that create labels.
+ *
+ * @internal - not supported for external use, may change without notice.
+ *
+ */
+trait CRM_Contact_Form_Task_LabelTrait {
+
+  /**
+   *
+   * @throws \CRM_Core_Exception
+   * @internal - not supported for external use, may change without notice.
+   *
+   */
+  public function createLabels(): void {
+    /*
+     * CRM-8338: replace ids of household members with the id of their household
+     * so we can merge labels by household.
+     */
+    if ($this->getSubmittedValue('merge_same_household')) {
+      $this->mergeContactIdsByHousehold();
+    }
+
+    //get the total number of contacts to fetch from database.
+    $contactGet = Contact::get()
+      ->addWhere('is_deceased', '=', FALSE)
+      ->addWhere('id', 'IN', $this->getContactIDs())
+      ->addOrderBy('sort_name');
+    if ($this->getSubmittedValue('do_not_mail')) {
+      $contactGet->addWhere('do_not_mail', '=', FALSE);
+    }
+
+    if ($this->getSubmittedValue('location_type_id')) {
+      $contactGet->addChain('address', Address::get()
+        ->addWhere('contact_id', '=', '$id')
+        ->addWhere('location_type_id', '=', $this->getSubmittedValue('location_type_id'))
+        ->setSelect($this->getAddressFields())
+      );
+    }
+    else {
+      $contactGet->addChain('address', Address::get()
+        ->addWhere('contact_id', '=', '$id')
+        ->addWhere('is_primary', '=', TRUE)
+        ->setSelect($this->getAddressFields())
+      );
+    }
+    $rows = (array) $contactGet->execute()->indexBy('id');
+    foreach ($rows as &$contact) {
+      // do we need to do this?
+      if (!empty($contact['addressee_display'])) {
+        $contact['addressee_display'] = trim($contact['addressee_display']);
+      }
+      // do we need to do this?
+      if (!empty($contact['addressee'])) {
+        $contact['addressee'] = $contact['addressee_display'];
+      }
+      // do we need to do this?
+      if (isset($contact['address'])) {
+        foreach ($contact['address'][0] ?? [] as $field => $value) {
+          if ($field !== 'id') {
+            $contact[$field] = $value;
+          }
+        }
+        unset($contact['address']);
+      }
+    }
+
+    if ($this->getSubmittedValue('merge_same_address')) {
+      CRM_Core_BAO_Address::mergeSameAddress($rows);
+    }
+
+    // format the addresses according to CIVICRM_ADDRESS_FORMAT (CRM-1327)
+    // Iterate contact IDs not rows to get original sort order.
+    foreach ($this->getContactIDs() as $id) {
+      if (isset($rows[$id])) {
+        $rows[$id] = [CRM_Utils_Address::formatMailingLabel($rows[$id])];
+      }
+    }
+
+    //call function to create labels
+    $this->createLabel($rows, $this->getSubmittedValue('label_name'));
+  }
+
+  /**
+   * Create labels (pdf).
+   *
+   * @param array $contactRows
+   *   Associated array of contact data.
+   * @param string $format
+   *   Format in which labels needs to be printed.
+   */
+  private function createLabel(array $contactRows, $format) {
+    $pdf = new CRM_Utils_PDF_Label($format, 'mm');
+    $pdf->Open();
+    $pdf->AddPage();
+
+    //build contact string that needs to be printed
+    $val = NULL;
+    foreach ($contactRows as $value) {
+      foreach ($value as $v) {
+        $val .= "$v\n";
+      }
+
+      $pdf->AddPdfLabel($val);
+      $val = '';
+    }
+    if (CIVICRM_UF === 'UnitTests') {
+      throw new CRM_Core_Exception_PrematureExitException('pdf output called', ['contactRows' => $contactRows, 'format' => $format, 'pdf' => $pdf]);
+    }
+    $pdf->Output('MailingLabels_CiviCRM.pdf', 'D');
+  }
+
+  /**
+   * @return string[]
+   */
+  public function getAddressFields(): array {
+    return [
+      'city',
+      'street_address',
+      'name',
+      'postal_code',
+      'postal_code_suffix',
+      'supplemental_address_1',
+      'supplemental_address_2',
+      'supplemental_address_3',
+      'country_id:label',
+      'country_id',
+      'county_id:label',
+      'county_id',
+      'state_province_id:label',
+      'state_province_id',
+    ];
+  }
+
+}

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1032,13 +1032,13 @@ SELECT is_primary,
    */
   public static function mergeSameAddress(&$rows) {
     $uniqueAddress = [];
-    foreach (array_keys($rows) as $rowID) {
+    foreach ($rows as $rowID => $row) {
       // load complete address as array key
       $address = trim((string) $rows[$rowID]['street_address'])
         . trim((string) $rows[$rowID]['city'])
-        . trim((string) $rows[$rowID]['state_province'])
+        . trim((string) ($row['state_province_id:label'] ?? ''))
         . trim((string) $rows[$rowID]['postal_code'])
-        . trim((string) $rows[$rowID]['country']);
+        . trim((string) $row['country_id:label'] ?? '');
       if (isset($rows[$rowID]['last_name'])) {
         $name = $rows[$rowID]['last_name'];
       }

--- a/CRM/Member/Form/Task/Label.php
+++ b/CRM/Member/Form/Task/Label.php
@@ -278,6 +278,15 @@ class CRM_Member_Form_Task_Label extends CRM_Member_Form_Task {
       }
       // now create the rows for generating mailing labels
       foreach ($contact as $field => $fieldValue) {
+        if ($field === 'state_province_id') {
+          $field = 'state_province_id:label';
+        }
+        if ($field === 'country_id') {
+          $field = 'country_id:label';
+        }
+        if ($field === 'county_id') {
+          $field = 'county_id:label';
+        }
         $rows[$value][$field] = $fieldValue;
       }
     }

--- a/CRM/Utils/Address.php
+++ b/CRM/Utils/Address.php
@@ -297,8 +297,9 @@ class CRM_Utils_Address {
       $fields['postal_code'] .= "-$fields[postal_code_suffix]";
     }
 
+    $country = $fields['country_id:label'];
     //CRM-16876 Display countries in all caps when in mailing mode.
-    if (!empty($fields['country'])) {
+    if ($country) {
       if (Civi::settings()->get('hideCountryMailingLabels')) {
         $domain = CRM_Core_BAO_Domain::getDomain();
         $domainLocation = CRM_Core_BAO_Location::getValues(['contact_id' => $domain->contact_id]);
@@ -309,11 +310,11 @@ class CRM_Utils_Address {
         }
         else {
           //Capitalization display on uppercase to contries with special characters
-          $fields['country'] = mb_convert_case($fields['country'], MB_CASE_UPPER, 'UTF-8');
+          $fields['country'] = mb_convert_case($country, MB_CASE_UPPER, 'UTF-8');
         }
       }
       else {
-        $fields['country'] = mb_convert_case($fields['country'], MB_CASE_UPPER, 'UTF-8');
+        $fields['country'] = mb_convert_case($country, MB_CASE_UPPER, 'UTF-8');
       }
     }
 

--- a/tests/phpunit/CRM/Contact/Form/Task/PrintMailingLabelTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/PrintMailingLabelTest.php
@@ -84,6 +84,19 @@ NETHERLANDS S', $rows[$this->ids['Contact']['collins']][0]);
   }
 
   /**
+   * Test rendering an alternate location.
+   */
+  public function testMailingLabelOtherLocation(): void {
+    \Civi::settings()->set('mailing_format', $this->getDefaultMailingFormat());
+    $this->createTestAddresses();
+    $rows = $this->submitForm([
+      'location_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Address', 'location_type_id', 'Work'),
+    ]);
+    // Check that the non-primary phone has been appended - ie the one with 0 for non-primary at the end.
+    $this->assertEquals($this->getExpectedAddress('souza', FALSE), $rows[$this->ids['Contact']['souza']][0]);
+  }
+
+  /**
    * Test the mailing label rows contain the primary addresses when
    * location_type_id = none (as primary) is chosen in form.
    *
@@ -111,19 +124,20 @@ NETHERLANDS S', $rows[$this->ids['Contact']['collins']][0]);
    * Get the default address we expect for our test contact with the default string.
    *
    * @param string $identifier
+   * @param bool $isPrimary
    *
    * @return string
    */
-  protected function getExpectedAddress(string $identifier): string {
+  protected function getExpectedAddress(string $identifier, bool $isPrimary = TRUE): string {
     if ($identifier === 'souza') {
       return 'Mr. Antonia J. D`souza II
-Main Street 231
+Main Street 23' . (int) $isPrimary . '
 Brummen, 6971 BN
 NETHERLANDS';
     }
     if ($identifier === 'collins') {
       return 'Mr. Anthony J. Collins II
-Main Street 231
+Main Street 23' . (int) $isPrimary . '
 Brummen, 6971 BN
 NETHERLANDS';
     }
@@ -161,6 +175,16 @@ NETHERLANDS';
           'postal_code' => '6971 BN',
           'country_id' => '1152',
           'city' => 'Brummen',
+          // Give them different location types, the actual types are random.
+          'location_type_id:name' => $isPrimary ? 'Main' : 'Work',
+          // this doesn't affect for non-primary address so we need to call the Address.update API again, see below at L57
+          'is_primary' => $isPrimary,
+          'contact_id' => $contactID,
+        ]);
+        $this->createTestEntity('Phone', [
+          'phone' => '123' . (int) $isPrimary,
+          // Give them different location types, the actual types are random.
+          'location_type_id:name' => $isPrimary ? 'Main' : 'Work',
           // this doesn't affect for non-primary address so we need to call the Address.update API again, see below at L57
           'is_primary' => $isPrimary,
           'contact_id' => $contactID,

--- a/tests/phpunit/CRM/Utils/AddressTest.php
+++ b/tests/phpunit/CRM/Utils/AddressTest.php
@@ -24,7 +24,7 @@ class CRM_Utils_AddressTest extends CiviUnitTestCase {
     ]);
     $addressDetails = $address['values'][$address['id']];
     $countries = CRM_Core_PseudoConstant::country();
-    $addressDetails['country'] = $countries[$addressDetails['country_id']];
+    $addressDetails['country_id:label'] = $countries[$addressDetails['country_id']];
     $formatted_address = CRM_Utils_Address::formatMailingLabel($addressDetails);
     $this->assertTrue((bool) strstr($formatted_address, 'UNITED STATES'));
   }


### PR DESCRIPTION
Overview
----------------------------------------
Add unit test for handling other location in the labels - the unit test exposed that this was working unpredictably on different sql versions so I also switched to apiv4 with associated cleanup

Before
----------------------------------------
no test

After
----------------------------------------
test - code cleaned up

Technical Details
----------------------------------------
Testing this basically means using the print label task from contact search and checking that it works the same with this patch as without & maybe a quick check on labels from membership search

I would note it felt pretty broken that it prints blank labels - I could maybe look at fixing that in a follow on although I suppose I would only stop if from printing 100% blank  labels - in case someone uses address-less labels....

Comments
----------------------------------------
