### PR TITLE
Add Unit test to demonstrate & remove code cruft

### DIFF
--- a/CRM/Contact/Form/Task/Label.php
+++ b/CRM/Contact/Form/Task/Label.php
@@ -112,21 +112,6 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
       unset($mailingFormatProperties['addressee']);
     }
 
-    $customFormatProperties = [];
-    if (stristr($mailingFormat, 'custom_')) {
-      foreach ($mailingFormatProperties as $token => $true) {
-        if (substr($token, 0, 7) == 'custom_') {
-          if (empty($customFormatProperties[$token])) {
-            $customFormatProperties[$token] = $mailingFormatProperties[$token];
-          }
-        }
-      }
-    }
-
-    if (!empty($customFormatProperties)) {
-      $returnProperties = array_merge($returnProperties, $customFormatProperties);
-    }
-
     if (isset($fv['merge_same_address'])) {
       // we need first name/last name for summarising to avoid spillage
       $returnProperties['first_name'] = 1;
@@ -174,24 +159,11 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
     // fix for CRM-2613
     $params[] = ['is_deceased', '=', 0, 0, 0];
 
-    $custom = [];
-    foreach ($returnProperties as $name => $dontCare) {
-      $cfID = CRM_Core_BAO_CustomField::getKeyID($name);
-      if ($cfID) {
-        $custom[] = $cfID;
-      }
-    }
-
     //get the total number of contacts to fetch from database.
     $numberofContacts = count($this->_contactIds);
     [$details] = CRM_Contact_BAO_Query::apiQuery($params, $returnProperties, NULL, NULL, 0, $numberofContacts, TRUE, FALSE, TRUE, CRM_Contact_BAO_Query::MODE_CONTACTS, NULL, $primaryLocationOnly);
 
     foreach ($this->_contactIds as $value) {
-      foreach ($custom as $cfID) {
-        if (isset($details[$value]["custom_{$cfID}"])) {
-          $details[$value]["custom_{$cfID}"] = CRM_Core_BAO_CustomField::displayValue($details[$value]["custom_{$cfID}"], $cfID);
-        }
-      }
       $contact = $details[$value] ?? NULL;
 
       // we need to remove all the "_id"

--- a/CRM/Contact/Form/Task/LabelCommon.php
+++ b/CRM/Contact/Form/Task/LabelCommon.php
@@ -74,23 +74,10 @@ class CRM_Contact_Form_Task_LabelCommon {
     $returnProperties = ['display_name' => 1, 'contact_type' => 1, 'prefix_id' => 1];
     $mailingFormat = Civi::settings()->get('mailing_format');
 
-    $mailingFormatProperties = [];
     if ($mailingFormat) {
       $mailingFormatProperties = CRM_Utils_Token::getReturnProperties($mailingFormat);
       $returnProperties = array_merge($returnProperties, $mailingFormatProperties);
     }
-
-    $customFormatProperties = [];
-    if (stristr($mailingFormat, 'custom_')) {
-      foreach ($mailingFormatProperties as $token => $true) {
-        if (substr($token, 0, 7) == 'custom_') {
-          if (empty($customFormatProperties[$token])) {
-            $customFormatProperties[$token] = $mailingFormatProperties[$token];
-          }
-        }
-      }
-    }
-    $returnProperties = array_merge($returnProperties, $customFormatProperties);
 
     if ($mergeSameAddress) {
       // we need first name/last name for summarising to avoid spillage
@@ -128,13 +115,6 @@ class CRM_Contact_Form_Task_LabelCommon {
       $returnProperties = array_merge($returnProperties, $addressReturnProperties);
     }
 
-    foreach ($returnProperties as $name) {
-      $cfID = CRM_Core_BAO_CustomField::getKeyID($name);
-      if ($cfID) {
-        $custom[] = $cfID;
-      }
-    }
-
     //get the total number of contacts to fetch from database.
     $numberofContacts = count($contactIDs);
     //this does the same as calling civicrm_api3('contact, get, array('id' => array('IN' => $this->_contactIds)
@@ -142,11 +122,6 @@ class CRM_Contact_Form_Task_LabelCommon {
     [$details] = CRM_Contact_BAO_Query::apiQuery($params, $returnProperties, NULL, NULL, 0, $numberofContacts);
 
     foreach ($contactIDs as $value) {
-      foreach ($custom as $cfID) {
-        if (isset($details[$value]["custom_{$cfID}"])) {
-          $details[$value]["custom_{$cfID}"] = CRM_Core_BAO_CustomField::displayValue($details[$value]["custom_{$cfID}"], $cfID);
-        }
-      }
       $contact = $details[$value] ?? NULL;
 
       // we need to remove all the "_id"


### PR DESCRIPTION

Overview
----------------------------------------
Add Unit test to demonstrate & remove code cruft

Before
----------------------------------------
legacy code wrangles custom data into the array, only to be discarded. No test to ensure the token IS wrangled

After
----------------------------------------
Test cover, less code


Technical Details
----------------------------------------
The code cruft adds custom field data to the array - however, the custom field data in the array is no longer used as the tokens are rendered using the token processor rather than the functions that were in place in the past - hence the custom field wrangling is all for nought.

The unit test ensures the field is still rendered, absent the extra code

Comments
----------------------------------------
