### PR TITLE
dev/core#5492 Allow selecting any contact type autocomplete search for forms

### DIFF
--- a/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
+++ b/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
@@ -137,7 +137,13 @@ class AfformAutocompleteSubscriber extends AutoService implements EventSubscribe
     }
     switch ($fieldName) {
       case 'autocompleteSavedSearch':
-        $apiRequest->addFilter('api_entity', $apiRequest->getFilters()['api_entity']);
+        if (CoreUtil::isContact($apiRequest->getFilters()['api_entity'])) {
+          $filter = ['Contact', $apiRequest->getFilters()['api_entity']];
+          $apiRequest->addFilter('api_entity', $filter);
+        }
+        else {
+          $apiRequest->addFilter('api_entity', $apiRequest->getFilters()['api_entity']);
+        }
         return;
 
       case 'autocompleteDisplay':

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformAutocompleteUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformAutocompleteUsageTest.php
@@ -22,7 +22,7 @@ class AfformAutocompleteUsageTest extends AfformUsageTestCase {
   public function testAutocompleteWithSavedSearchFilter(): void {
     $layout = <<<EOHTML
 <af-form ctrl="afform">
-  <af-entity data="{contact_type: 'Individual'}" type="Contact" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="RBAC" />
+  <af-entity type="Individual" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="RBAC" />
   <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
     <div class="af-container">
       <af-field name="id" defn="{saved_search: 'the_unit_test_search', input_attrs: {}}" />
@@ -152,7 +152,7 @@ EOHTML;
 
     $layout = <<<EOHTML
 <af-form ctrl="afform">
-  <af-entity data="{contact_type: 'Individual'}" type="Contact" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="RBAC" />
+  <af-entity type="Individual" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="RBAC" />
   <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
     <div class="af-container">
       <af-field name="first_name" />
@@ -243,7 +243,7 @@ EOHTML;
 
     $layout = <<<EOHTML
 <af-form ctrl="afform">
-  <af-entity data="{contact_type: 'Individual'}" type="Contact" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="RBAC" />
+  <af-entity type="Individual" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="RBAC" />
   <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
     <div class="af-container">
       <af-field name="first_name" />


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5492

Since contact type "pseudo" APIs were introduced it is no longer possible to select an autocomplete searchkit of type "Contact". This means previously created/selected autocomplete searchkits can not be selected anymore for autocomplet fields on forms. It also means that if you built a search that does not specifically start from the contact type you cannot select that search (for example, the Contact search might implicitly be an "Individual" because of the type of relationship that was joined.

Before
----------------------------------------
Can no longer select autocomplete searches of type "Contact".

After
----------------------------------------
Can select autocomplete searches of type "Contact".

Technical Details
----------------------------------------


Comments
----------------------------------------
Note that this *does* mean the admin could select an autocomplete that returns no results - eg. an "Organization" autocomplete for an "Individual". But the alternative would be massively complex I think as you'd have to carefully inspect "Contact" searches to see if they are restricted in some way or not by the expected contact type.

