### PR TITLE
[Not for merge] Less greedy action object provider, hack scan-class mixin

### DIFF
--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -387,7 +387,9 @@ class CRM_Core_Invoke {
     CRM_Core_BAO_Navigation::resetNavigation();
 
     // also cleanup module permissions
-    $config->cleanupPermissions();
+    if (!CRM_Core_Config::isUpgradeMode()) {
+      $config->cleanupPermissions();
+    }
 
     // rebuild word replacement cache - pass false to prevent operations redundant with this fn
     CRM_Core_BAO_WordReplacement::rebuild(FALSE);
@@ -409,7 +411,9 @@ class CRM_Core_Invoke {
       $config->userSystem->invalidateRouteCache();
     }
 
-    CRM_Core_ManagedEntities::singleton(TRUE)->reconcile();
+    if (!CRM_Core_Config::isUpgradeMode()) {
+      CRM_Core_ManagedEntities::singleton(TRUE)->reconcile();
+    }
   }
 
 }

--- a/Civi/Api4/Provider/ActionObjectProvider.php
+++ b/Civi/Api4/Provider/ActionObjectProvider.php
@@ -162,7 +162,7 @@ class ActionObjectProvider extends AutoService implements EventSubscriberInterfa
 
     if (!$entities) {
       // Load entities declared in API files
-      foreach ($this->getAllApiClasses() as $className) {
+      foreach ($this->getCoreApiClasses() as $className) {
         $info = $className::getInfo();
         $entities[$info['name']] = $info;
       }
@@ -186,23 +186,16 @@ class ActionObjectProvider extends AutoService implements EventSubscriberInterfa
   }
 
   /**
-   * Scan all api directories to discover entities
+   * Scan core api4 directory to discover entities
    * @return \Civi\Api4\Generic\AbstractEntity[]
    */
-  public function getAllApiClasses(): array {
+  public function getCoreApiClasses(): array {
     $classNames = [];
-    $locations = array_merge([\Civi::paths()->getPath('[civicrm.root]/Civi.php')],
-      array_column(\CRM_Extension_System::singleton()->getMapper()->getActiveModuleFiles(), 'filePath')
-    );
-    foreach ($locations as $location) {
-      $dir = \CRM_Utils_File::addTrailingSlash(dirname($location ?? '')) . 'Civi/Api4';
-      if (is_dir($dir)) {
-        foreach (glob("$dir/*.php") as $file) {
-          $className = 'Civi\Api4\\' . basename($file, '.php');
-          if (is_a($className, 'Civi\Api4\Generic\AbstractEntity', TRUE)) {
-            $classNames[] = $className;
-          }
-        }
+    $dir = \Civi::paths()->getPath('[civicrm.root]/Civi/Api4');
+    foreach (glob("$dir/*.php") as $file) {
+      $className = 'Civi\Api4\\' . basename($file, '.php');
+      if (is_a($className, 'Civi\Api4\Generic\AbstractEntity', TRUE)) {
+        $classNames[] = $className;
       }
     }
     return $classNames;

--- a/mixin/scan-classes@1/mixin.php
+++ b/mixin/scan-classes@1/mixin.php
@@ -63,4 +63,20 @@ return function ($mixInfo, $bootCache) {
     $event->classes = array_merge($event->classes, $all);
   });
 
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $event
+   */
+  Civi::dispatcher()->addListener('civi.api4.entityTypes', function ($event) use ($mixInfo) {
+    if (!$mixInfo->isActive()) {
+      return;
+    }
+
+    foreach (glob("$mixInfo->path/Civi/Api4/*.php") as $file) {
+      $className = 'Civi\Api4\\' . basename($file, '.php');
+      if (is_a($className, 'Civi\Api4\Generic\AbstractEntity', TRUE)) {
+        $info = $className::getInfo();
+        $event->entities[$info['name']] = $info;
+      }
+    }
+  });
 };


### PR DESCRIPTION
Overview
----------------------------------------
Attempt to find a way to fix https://lab.civicrm.org/dev/core/-/issues/5493

Before
----------------------------------------
- during upgrade, Api4 classes are available for extension entities, but the underlying Entities are not in the EntityRepository
- strange crashes ensue when metadata is gathered: like this one on Standalone upgrade test https://lab.civicrm.org/dev/core/-/issues/5493


After
----------------------------------------
- extension entities are only loaded into Api4 using the `civi.api4.entityTypes` hook, which respects the restricted dispatch policy during upgrade, so *extension entities are generally not available*
- at the moment this causes some odd warnings in `doCoreFinish` when `CRM_Core_Invoke::rebuildMenuAndCaches` is called - still investigating


Technical Details
----------------------------------------
I've hacked `scan-classes` to provide the listener for registering Api4 classes. I'm not sure how this works with version control of published mixins etc. and so probably this is not right.

I figured:
- using a new mixin would be good ("provides api4 classes") - but not backward compatible
-  could `AbstractEntity` class implement `EventSubscriberInterface` - so each entity class registered itself? seems conceptually tidy but maybe in practice overkill (1 listener per entity = a lot of listeners)
- maybe a single core listener that checks all the extension classes - i.e. like `getAllApiClasses` but through a hook so it gets disabled by the dispatch policy
