### PR TITLE
iconPicker - Fix initial height

### DIFF
--- a/js/jquery/jquery.crmIconPicker.js
+++ b/js/jquery/jquery.crmIconPicker.js
@@ -139,12 +139,12 @@
           e.preventDefault();
         }
 
-        dialog = $('<div id="crmIconPicker"/>').dialog({
+        dialog = $('<div id="crmIconPicker"/>').dialog(CRM.utils.adjustDialogDefaults({
           title: $input.attr('title'),
           width: '80%',
           height: '90%',
           modal: true
-        }).block()
+        })).block()
           .on('click', 'a', pickIcon)
           .on('keyup', 'input[name=search]', displayIcons)
           .on('dialogclose', function() {


### PR DESCRIPTION
Overview
----------------------------------------
This seemed to change when we upgraded FontAwesome. This fixes it.

Before
----------------------------------------
The icon picker dialog opens only a few pixels high.

After
----------------------------------------
Opens full height.