### PR TITLE
dev/core#3880 - Clone searchKit displays along with the saved search

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -9,6 +9,8 @@
   angular.module('crmSearchAdmin', CRM.angRequires('crmSearchAdmin'))
 
     .config(function($routeProvider) {
+      const ts = CRM.ts('org.civicrm.search_kit');
+
       $routeProvider.when('/list', {
         controller: 'searchList',
         reloadOnSearch: false,
@@ -36,6 +38,30 @@
               chain: {
                 groups: ['Group', 'get', {select: ['id', 'title', 'description', 'visibility', 'group_type', 'custom.*'], where: [['saved_search_id', '=', '$id']]}],
                 displays: ['SearchDisplay', 'get', {where: [['saved_search_id', '=', '$id']]}]
+              }
+            }, 0);
+          }
+        }
+      });
+      $routeProvider.when('/clone/:id', {
+        controller: 'searchClone',
+        template: '<crm-search-admin saved-search="$ctrl.savedSearch"></crm-search-admin>',
+        resolve: {
+          // Load saved search
+          savedSearch: function($route, crmApi4) {
+            var params = $route.current.params;
+            return crmApi4('SavedSearch', 'get', {
+              select: ['label', 'description', 'api_entity', 'api_params', 'expires_date', 'GROUP_CONCAT(DISTINCT entity_tag.tag_id) AS tag_id'],
+              where: [['id', '=', params.id]],
+              join: [
+                ['EntityTag AS entity_tag', 'LEFT', ['entity_tag.entity_table', '=', '"civicrm_saved_search"'], ['id', '=', 'entity_tag.entity_id']],
+              ],
+              groupBy: ['id'],
+              chain: {
+                displays: ['SearchDisplay', 'get', {
+                  select: ['label', 'type', 'settings'],
+                  where: [['saved_search_id', '=', '$id']],
+                }]
               }
             }, 0);
           }
@@ -96,6 +122,19 @@
     // Controller for editing a SavedSearch
     .controller('searchEdit', function($scope, savedSearch) {
       searchEntity = savedSearch.api_entity;
+      this.savedSearch = savedSearch;
+      $scope.$ctrl = this;
+    })
+
+    // Controller for cloning a SavedSearch
+    .controller('searchClone', function($scope, savedSearch) {
+      searchEntity = savedSearch.api_entity;
+      savedSearch.label += ' (' + ts('copy') + ')';
+      delete savedSearch.id;
+      savedSearch.displays.forEach(display => {
+        delete display.id;
+        display.label += ' (' + ts('copy') + ')';
+      });
       this.savedSearch = savedSearch;
       $scope.$ctrl = this;
     })

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -94,7 +94,9 @@
       this.savedSearch.tag_id = this.savedSearch.tag_id || [];
       this.groupExists = !!this.savedSearch.groups.length;
 
-      if (!this.savedSearch.id) {
+      const path = $location.path();
+      // In create mode, set defaults and bind params to route for easy copy/paste
+      if (path.includes('create/')) {
         var defaults = {
           version: 4,
           select: searchMeta.getEntity(ctrl.savedSearch.api_entity).default_columns,
@@ -115,7 +117,7 @@
         });
 
         // Set default label
-        ctrl.savedSearch.label = ts('%1 Search by %2', {
+        ctrl.savedSearch.label = ctrl.savedSearch.label || ts('%1 Search by %2', {
           1: searchMeta.getEntity(ctrl.savedSearch.api_entity).title,
           2: CRM.crmSearchAdmin.myName
         });

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminExport.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminExport.component.js
@@ -3,9 +3,7 @@
 
   angular.module('crmSearchAdmin').component('crmSearchAdminExport', {
     bindings: {
-      savedSearchId: '<',
-      savedSearchName: '<',
-      displayNames: '<'
+      savedSearch: '<'
     },
     templateUrl: '~/crmSearchAdmin/crmSearchAdminExport.html',
     controller: function ($scope, $element, crmApi4) {
@@ -20,15 +18,19 @@
       ];
 
       this.$onInit = function() {
-        this.apiExplorerLink = CRM.url('civicrm/api4#/explorer/SavedSearch/export?_format=php&cleanup=always&id=' + ctrl.savedSearchId);
+        this.apiExplorerLink = CRM.url('civicrm/api4#/explorer/SavedSearch/export?_format=php&cleanup=always&id=' + ctrl.savedSearch.id);
+        this.simpleLink = CRM.url('civicrm/admin/search#/create/' + ctrl.savedSearch.api_entity + '?params=' + encodeURI(angular.toJson(ctrl.savedSearch.api_params)));
 
-        var findDisplays = _.transform(ctrl.displayNames, function(findDisplays, displayName) {
-          findDisplays.push(['search_displays', 'CONTAINS', ctrl.savedSearchName + '.' + displayName]);
-        }, [['search_displays', 'CONTAINS', ctrl.savedSearchName]]);
-        var apiCalls = [
-          ['SavedSearch', 'export', {id: ctrl.savedSearchId}],
+        let apiCalls = [
+          ['SavedSearch', 'export', {id: ctrl.savedSearch.id}],
         ];
         if (ctrl.afformEnabled) {
+          let findDisplays = [['search_displays', 'CONTAINS', ctrl.savedSearch.name]];
+          if (ctrl.savedSearch.display_name) {
+            ctrl.savedSearch.display_name.forEach(displayName => {
+              findDisplays.push(['search_displays', 'CONTAINS', `${ctrl.savedSearch.name}.${displayName}`]);
+            });
+          }
           apiCalls.push(['Afform', 'get', {layoutFormat: 'html', where: [['type', '=', 'search'], ['OR', findDisplays]]}]);
         }
         crmApi4(apiCalls)

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminExport.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminExport.html
@@ -5,10 +5,21 @@
       {{:: ts('Search configuration can be copied from here, then pasted into "Import" to e.g. transfer between sites.') }}
     </p>
     <p>
+      <i class="crm-i fa-link"></i>
+      {{:: ts('Copyable link:') }}
+      <a ng-href="{{:: $ctrl.simpleLink }}" target="_blank">
+        <u>{{:: ts('Saved Search Criteria') }}</u>
+      </a>
+    <p>
       <i class="crm-i fa-suitcase"></i>
       {{:: ts('To package for distribution in an extension, use') }}
+      <a ng-href="https://docs.civicrm.org/dev/en/latest/extensions/civix/#export" target="_blank">
+        <u>{{:: ts('Civix Export') }}</u>
+        <i class="crm-i fa-file-circle-question"></i>
+      </a>
+      {{:: ts('or') }}
       <a ng-href="{{:: $ctrl.apiExplorerLink }}" target="_blank">
-        <u>{{:: ts('API Explorer Export') }}</u>
+        <u>{{:: ts('API Explorer') }}</u>
         <i class="crm-i fa-external-link"></i>
       </a>
     </p>

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/buttons.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/buttons.html
@@ -20,7 +20,7 @@
       </a>
     </li>
     <li title="{{:: ts('Create a new search based on this one') }}">
-      <a ng-href="#/create/{{:: row.data.api_entity + '?params=' + $ctrl.encode(row.data.api_params) }}">
+      <a ng-href="#/clone/{{:: row.data.id }}">
         <i class="crm-i fa-copy"></i>
         {{:: ts('Clone...') }}
       </a>

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -119,10 +119,6 @@
         updateAfformCounts();
       });
 
-      this.encode = function(params) {
-        return encodeURI(angular.toJson(params));
-      };
-
       this.deleteOrRevert = function(row) {
         var search = row.data,
           revert = !!search['base_module:label'];

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/export.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/export.html
@@ -1,1 +1,1 @@
-<crm-search-admin-export saved-search-id="model.data.id" saved-search-name="model.data.name" display-names="model.data.display_name"></crm-search-admin-export>
+<crm-search-admin-export saved-search="model.data"></crm-search-admin-export>


### PR DESCRIPTION
Overview
----------------------------------------
By popular request, this implements the feature in https://lab.civicrm.org/dev/core/-/issues/3880

Before
----------------------------------------
Clicking the "Clone" button only includes search criteria.

After
----------------------------------------
Now it includes tags and displays.
