### PR TITLE
Metadata - Add default_callback to UserJob, SiteToken & Tag entities

### DIFF
--- a/CRM/Core/BAO/SiteToken.php
+++ b/CRM/Core/BAO/SiteToken.php
@@ -22,43 +22,35 @@ class CRM_Core_BAO_SiteToken extends CRM_Core_DAO_SiteToken implements \Civi\Cor
    * @throws CRM_Core_Exception
    */
   public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
-    if ($event->entity === 'SiteToken') {
-      // Here we perform some basic validation; note that the user in the admin UI
-      // will probably never see any exceptions thrown here and may believe that
-      // their submission was saved; also note more validation is recommended.
-      // See "Note on Validation" at https://github.com/civicrm/civicrm-core/pull/30451#issuecomment-2184316807
-      $loggedInContactID = CRM_Core_Session::getLoggedInContactID();
+    // Here we perform some basic validation; note that the user in the admin UI
+    // will probably never see any exceptions thrown here and may believe that
+    // their submission was saved; also note more validation is recommended.
+    // See "Note on Validation" at https://github.com/civicrm/civicrm-core/pull/30451#issuecomment-2184316807
 
-      if ($event->action === 'create') {
-        // On create, auto-fill created_id and modfied_id.
-        $event->params['created_id'] = $loggedInContactID;
-        $event->params['modified_id'] = $loggedInContactID;
+    // On edit:
+    if ($event->action === 'edit') {
+      // Prevent changing of 'name' attribute for entities that are currently is_reserved.
+      $currentValues = Civi\Api4\SiteToken::get(FALSE)
+        ->addWhere('id', '=', $event->params['id'])
+        ->execute()
+        ->single();
+      if ($currentValues['is_reserved']
+        && !empty($event->params['name'])
+        && ($event->params['name'] != $currentValues['name'])
+      ) {
+        throw new \Civi\API\Exception\UnauthorizedException('Permission denied to modify name on reserved Site Token');
       }
-      elseif ($event->action === 'edit') {
-        // On edit:
-        // Prevent changing of 'name' attribute for entities that are currently is_reserved.
-        $currentValues = Civi\Api4\SiteToken::get(FALSE)
-          ->addWhere('id', '=', $event->params['id'])
-          ->execute()
-          ->single();
-        if ($currentValues['is_reserved']
-          && !empty($event->params['name'])
-          && ($event->params['name'] != $currentValues['name'])
-        ) {
-          throw new \Civi\API\Exception\UnauthorizedException('Permission denied to modify name on reserved Site Token');
-        }
-        // If we're still here, auto-fill modified_id.
-        $event->params['modified_id'] = $loggedInContactID;
-      }
-      elseif ($event->action === 'delete') {
-        // On delete, prevent deletion for entities that are currently is_reserved.
-        $currentValues = Civi\Api4\SiteToken::get(FALSE)
-          ->addWhere('id', '=', $event->params['id'])
-          ->execute()
-          ->single();
-        if ($currentValues['is_reserved']) {
-          throw new \Civi\API\Exception\UnauthorizedException('Permission denied to delete reserved Site Token');
-        }
+      // If we're still here, auto-fill modified_id.
+      $event->params['modified_id'] = CRM_Core_Session::getLoggedInContactID();;
+    }
+    elseif ($event->action === 'delete') {
+      // On delete, prevent deletion for entities that are currently is_reserved.
+      $currentValues = Civi\Api4\SiteToken::get(FALSE)
+        ->addWhere('id', '=', $event->params['id'])
+        ->execute()
+        ->single();
+      if ($currentValues['is_reserved']) {
+        throw new \Civi\API\Exception\UnauthorizedException('Permission denied to delete reserved Site Token');
       }
     }
   }

--- a/CRM/Core/BAO/Tag.php
+++ b/CRM/Core/BAO/Tag.php
@@ -412,11 +412,6 @@ class CRM_Core_BAO_Tag extends CRM_Core_DAO_Tag {
       $params['color'] = '';
     }
 
-    // save creator id and time
-    if (!$id) {
-      $params['created_id'] ??= CRM_Core_Session::getLoggedInContactID();
-    }
-
     $tag = self::writeRecord($params);
 
     // if we modify parent tag, then we need to update all children

--- a/schema/Core/SiteToken.entityType.php
+++ b/schema/Core/SiteToken.entityType.php
@@ -131,6 +131,7 @@ return [
       'input_type' => 'EntityRef',
       'description' => ts('Contact responsible for creating this token'),
       'add' => '5.76',
+      'default_callback' => ['CRM_Core_Session', 'getLoggedInContactID'],
       'input_attrs' => [
         'label' => ts('Created By'),
       ],
@@ -147,6 +148,7 @@ return [
       'readonly' => TRUE,
       'description' => ts('FK to contact table.'),
       'add' => '5.76',
+      'default_callback' => ['CRM_Core_Session', 'getLoggedInContactID'],
       'input_attrs' => [
         'label' => ts('Modified By'),
       ],

--- a/schema/Core/Tag.entityType.php
+++ b/schema/Core/Tag.entityType.php
@@ -121,6 +121,7 @@ return [
       'input_type' => 'EntityRef',
       'description' => ts('FK to civicrm_contact, who created this tag'),
       'add' => '3.4',
+      'default_callback' => ['CRM_Core_Session', 'getLoggedInContactID'],
       'input_attrs' => [
         'label' => ts('Created By'),
       ],

--- a/schema/Core/UserJob.entityType.php
+++ b/schema/Core/UserJob.entityType.php
@@ -47,6 +47,7 @@ return [
       'input_type' => 'EntityRef',
       'description' => ts('FK to contact table.'),
       'add' => '5.50',
+      'default_callback' => ['CRM_Core_Session', 'getLoggedInContactID'],
       'input_attrs' => [
         'label' => ts('Created By'),
       ],

--- a/tests/phpunit/api/v4/Entity/QueueTest.php
+++ b/tests/phpunit/api/v4/Entity/QueueTest.php
@@ -512,11 +512,15 @@ class QueueTest extends Api4TestBase {
     ]);
     $this->assertQueueStats(0, 0, 0, $queue);
 
+    $cid = $this->createLoggedInUser();
+
     $userJob = \Civi\Api4\UserJob::create(FALSE)->setValues([
       'job_type:name' => 'contact_import',
       'status_id:name' => 'in_progress',
       'queue_id.name' => $queue->getName(),
     ])->execute()->single();
+
+    $this->assertEquals($cid, $userJob['created_id']);
 
     \Civi::queue($queueName)->createItem(new \CRM_Queue_Task(
       [QueueTest::class, 'doSomething'],

--- a/tests/phpunit/api/v4/Entity/TagTest.php
+++ b/tests/phpunit/api/v4/Entity/TagTest.php
@@ -32,7 +32,7 @@ class TagTest extends Api4TestBase implements TransactionalInterface {
 
   public function testTagFilter(): void {
     // Ensure bypassing permissions works correctly by giving none to the logged-in user
-    $this->createLoggedInUser();
+    $cid = $this->createLoggedInUser();
     \CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
 
     $conTag = Tag::create(FALSE)
@@ -57,6 +57,8 @@ class TagTest extends Api4TestBase implements TransactionalInterface {
       ->addValue('name', uniqid('child'))
       ->addValue('parent_id', $tagSet['id'])
       ->execute()->first();
+    $this->assertEquals($cid, $conTag['created_id']);
+    $this->assertEquals($cid, $setChild['created_id']);
 
     $contact1 = Contact::create(FALSE)
       ->execute()->first();


### PR DESCRIPTION
Overview
----------------------------------------
Followup on #31172, moves more ad-hoc bao logic into `default_callback` schema declarations & adds test coverage.
