### PR TITLE
CiviCampaign - Update metadata defaults to use best-practices

### DIFF
--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -14,44 +14,50 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Campaign_BAO_Campaign extends CRM_Campaign_DAO_Campaign {
+class CRM_Campaign_BAO_Campaign extends CRM_Campaign_DAO_Campaign implements Civi\Core\HookInterface {
 
   /**
-   * Takes an associative array and creates a campaign object.
-   *
-   * the function extract all the params it needs to initialize the create a
-   * contact object. the params array could contain additional unused name/value
-   * pairs
+   * @deprecated
    *
    * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
    *
-   * @return CRM_Campaign_DAO_Campaign
-   * @throws \CRM_Core_Exception
+   * @return null|CRM_Campaign_DAO_Campaign
    */
-  public static function create(&$params) {
+  public static function create($params) {
+    CRM_Core_Error::deprecatedFunctionWarning('writeRecord');
     if (empty($params)) {
       return NULL;
     }
+    return self::writeRecord($params);
+  }
 
-    /** @var \CRM_Campaign_DAO_Campaign $campaign */
-    $campaign = self::writeRecord($params);
+  /**
+   * Event fired prior to modifying a Campaign.
+   * @param \Civi\Core\Event\PreEvent $event
+   */
+  public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
+    if ($event->action === 'edit') {
+      $event->params['last_modified_id'] ??= CRM_Core_Session::getLoggedInContactID();
+    }
+  }
 
+  /**
+   * Event fired after modifying a Campaign.
+   * @param \Civi\Core\Event\PostEvent $event
+   */
+  public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $event) {
     /* Create the campaign group record */
-    $groupTableName = CRM_Contact_BAO_Group::getTableName();
-
-    if (isset($params['groups']) && !empty($params['groups']['include']) && is_array($params['groups']['include'])) {
+    $params = $event->params;
+    if (in_array($event->action, ['create', 'edit']) && !empty($params['groups']['include']) && is_array($params['groups']['include'])) {
       foreach ($params['groups']['include'] as $entityId) {
         $dao = new CRM_Campaign_DAO_CampaignGroup();
-        $dao->campaign_id = $campaign->id;
-        $dao->entity_table = $groupTableName;
+        $dao->campaign_id = $event->id;
+        $dao->entity_table = 'civicrm_group';
         $dao->entity_id = $entityId;
         $dao->group_type = 'Include';
         $dao->save();
       }
     }
-
-    return $campaign;
   }
 
   /**

--- a/CRM/Campaign/BAO/Survey.php
+++ b/CRM/Campaign/BAO/Survey.php
@@ -31,36 +31,18 @@ class CRM_Campaign_BAO_Survey extends CRM_Campaign_DAO_Survey implements Civi\Co
   }
 
   /**
-   * Takes an associative array and creates a Survey object based on the
-   * supplied values.
+   * @deprecated
    *
    * @param array $params
    *
    * @return bool|CRM_Campaign_DAO_Survey
    */
-  public static function create(&$params) {
+  public static function create($params) {
+    CRM_Core_Error::deprecatedFunctionWarning('writeRecord');
     if (empty($params)) {
       return FALSE;
     }
-
-    if (!empty($params['is_default'])) {
-      $query = "UPDATE civicrm_survey SET is_default = 0";
-      CRM_Core_DAO::executeQuery($query);
-    }
-
-    if (empty($params['id'])) {
-      if (empty($params['created_id'])) {
-        $params['created_id'] = CRM_Core_Session::getLoggedInContactID();
-      }
-
-      if (empty($params['created_date'])) {
-        $params['created_date'] = date('YmdHis');
-      }
-    }
-
-    $dao = self::writeRecord($params);
-
-    return $dao;
+    return self::writeRecord($params);
   }
 
   /**
@@ -234,6 +216,13 @@ SELECT  survey.id    as id,
       if ($reportId) {
         CRM_Report_BAO_ReportInstance::deleteRecord(['id' => $reportId]);
       }
+    }
+    if ($event->action === 'edit') {
+      if (!empty($event->params['is_default'])) {
+        $query = "UPDATE civicrm_survey SET is_default = 0";
+        CRM_Core_DAO::executeQuery($query);
+      }
+      $event->params['last_modified_id'] ??= CRM_Core_Session::getLoggedInContactID();
     }
   }
 

--- a/CRM/Campaign/Form/Campaign.php
+++ b/CRM/Campaign/Form/Campaign.php
@@ -334,8 +334,6 @@ class CRM_Campaign_Form_Campaign extends CRM_Core_Form {
     }
     // format params
     $params['is_active'] ??= FALSE;
-    $params['last_modified_id'] = $session->get('userID');
-    $params['last_modified_date'] = date('YmdHis');
     $result = self::submit($params, $this);
     if (!$result['is_error']) {
       CRM_Core_Session::setStatus(ts('Campaign %1 has been saved.', [1 => $result['values'][$result['id']]['title']]), ts('Saved'), 'success');

--- a/CRM/Campaign/Form/Petition.php
+++ b/CRM/Campaign/Form/Petition.php
@@ -315,8 +315,6 @@ WHERE  $whereClause
 
     $session = CRM_Core_Session::singleton();
 
-    $params['last_modified_id'] = $session->get('userID');
-    $params['last_modified_date'] = date('YmdHis');
     $params['is_share'] ??= FALSE;
 
     if ($this->_surveyId) {
@@ -341,7 +339,7 @@ WHERE  $whereClause
 
     $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params, $this->getEntityId(), $this->getDefaultEntity());
 
-    $surveyId = CRM_Campaign_BAO_Survey::create($params);
+    $surveyId = CRM_Campaign_BAO_Survey::writeRecord($params);
 
     // also update the ProfileModule tables
     $ufJoinParams = [

--- a/CRM/Campaign/Form/Petition/Signature.php
+++ b/CRM/Campaign/Form/Petition/Signature.php
@@ -365,16 +365,6 @@ class CRM_Campaign_Form_Petition_Signature extends CRM_Core_Form {
     // export the field values to be used for saving the profile form
     $params = $this->controller->exportValues($this->_name);
 
-    $session = CRM_Core_Session::singleton();
-    // format params
-    $params['last_modified_id'] = $session->get('userID');
-    $params['last_modified_date'] = date('YmdHis');
-
-    if ($this->_action & CRM_Core_Action::ADD) {
-      $params['created_id'] = $session->get('userID');
-      $params['created_date'] = date('YmdHis');
-    }
-
     if (isset($this->_surveyId)) {
       $params['sid'] = $this->_surveyId;
     }

--- a/CRM/Campaign/Form/Survey/Main.php
+++ b/CRM/Campaign/Form/Survey/Main.php
@@ -151,15 +151,8 @@ class CRM_Campaign_Form_Survey_Main extends CRM_Campaign_Form_Survey {
 
     $session = CRM_Core_Session::singleton();
 
-    $params['last_modified_id'] = $session->get('userID');
-    $params['last_modified_date'] = date('YmdHis');
-
     if ($this->_surveyId) {
       $params['id'] = $this->_surveyId;
-    }
-    else {
-      $params['created_id'] = $session->get('userID');
-      $params['created_date'] = date('YmdHis');
     }
 
     $params['is_active'] ??= 0;
@@ -167,7 +160,7 @@ class CRM_Campaign_Form_Survey_Main extends CRM_Campaign_Form_Survey {
 
     $params['custom'] = CRM_Core_BAO_CustomField::postProcess($this->getSubmittedValues(), $this->getSurveyID(), 'Survey');
 
-    $survey = CRM_Campaign_BAO_Survey::create($params);
+    $survey = CRM_Campaign_BAO_Survey::writeRecord($params);
     $this->_surveyId = $survey->id;
 
     if (!empty($this->_values['result_id'])) {

--- a/CRM/Campaign/Form/Survey/Results.php
+++ b/CRM/Campaign/Form/Survey/Results.php
@@ -384,7 +384,7 @@ class CRM_Campaign_Form_Survey_Results extends CRM_Campaign_Form_Survey {
       }
     }
 
-    $survey = CRM_Campaign_BAO_Survey::create($params);
+    $survey = CRM_Campaign_BAO_Survey::writeRecord($params);
 
     // create report if required.
     if (!$this->_reportId && $survey->id && !empty($params['create_report'])) {

--- a/CRM/Upgrade/Incremental/sql/5.79.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.79.alpha1.mysql.tpl
@@ -5,3 +5,15 @@ UPDATE `civicrm_batch` SET `modified_date` = `created_date` WHERE `modified_date
 
 ALTER TABLE `civicrm_batch` MODIFY COLUMN `created_date` datetime NOT NULL DEFAULT current_timestamp() COMMENT 'When was this item created';
 ALTER TABLE `civicrm_batch` MODIFY COLUMN `modified_date` datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp() COMMENT 'When was this item modified';
+
+UPDATE `civicrm_survey` SET `created_date` = current_timestamp() WHERE `created_date` IS NULL;
+UPDATE `civicrm_survey` SET `last_modified_date` = `created_date` WHERE `last_modified_date` IS NULL;
+
+ALTER TABLE `civicrm_survey` MODIFY COLUMN `created_date` datetime NOT NULL DEFAULT current_timestamp() COMMENT 'Date and time that Survey was created.';
+ALTER TABLE `civicrm_survey` MODIFY COLUMN `last_modified_date` datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp() COMMENT 'Date and time that Survey was edited last time.';
+
+UPDATE `civicrm_campaign` SET `created_date` = current_timestamp() WHERE `created_date` IS NULL;
+UPDATE `civicrm_campaign` SET `last_modified_date` = `created_date` WHERE `last_modified_date` IS NULL;
+
+ALTER TABLE `civicrm_campaign` MODIFY COLUMN `created_date` datetime NOT NULL DEFAULT current_timestamp() COMMENT 'Date and time that Campaign was created.';
+ALTER TABLE `civicrm_campaign` MODIFY COLUMN `last_modified_date` datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp() COMMENT 'Date and time that Campaign was edited last time.';

--- a/schema/Campaign/Campaign.entityType.php
+++ b/schema/Campaign/Campaign.entityType.php
@@ -245,6 +245,7 @@ return [
       'title' => ts('Campaign Created Date'),
       'sql_type' => 'datetime',
       'input_type' => 'Select Date',
+      'required' => TRUE,
       'readonly' => TRUE,
       'description' => ts('Date and time that Campaign was created.'),
       'add' => '3.3',
@@ -260,6 +261,7 @@ return [
       'input_type' => 'EntityRef',
       'description' => ts('FK to civicrm_contact, who recently edited this Campaign.'),
       'add' => '3.3',
+      'default_callback' => ['CRM_Core_Session', 'getLoggedInContactID'],
       'input_attrs' => [
         'label' => ts('Modified By'),
       ],
@@ -274,6 +276,9 @@ return [
       'sql_type' => 'datetime',
       'input_type' => 'Select Date',
       'description' => ts('Date and time that Campaign was edited last time.'),
+      'required' => TRUE,
+      'readonly' => TRUE,
+      'default' => 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
       'add' => '3.3',
     ],
     'goal_general' => [

--- a/schema/Campaign/Survey.entityType.php
+++ b/schema/Campaign/Survey.entityType.php
@@ -155,6 +155,7 @@ return [
       'input_type' => 'EntityRef',
       'description' => ts('FK to civicrm_contact, who created this Survey.'),
       'add' => '3.3',
+      'default_callback' => ['CRM_Core_Session', 'getLoggedInContactID'],
       'input_attrs' => [
         'label' => ts('Created By'),
       ],
@@ -169,6 +170,13 @@ return [
       'sql_type' => 'datetime',
       'input_type' => 'Select Date',
       'description' => ts('Date and time that Survey was created.'),
+      'required' => TRUE,
+      'readonly' => TRUE,
+      'default' => 'CURRENT_TIMESTAMP',
+      'input_attrs' => [
+        'format_type' => 'activityDateTime',
+        'label' => ts('Created Date'),
+      ],
       'add' => '3.3',
     ],
     'last_modified_id' => [
@@ -177,6 +185,7 @@ return [
       'input_type' => 'EntityRef',
       'description' => ts('FK to civicrm_contact, who recently edited this Survey.'),
       'add' => '3.3',
+      'default_callback' => ['CRM_Core_Session', 'getLoggedInContactID'],
       'input_attrs' => [
         'label' => ts('Modified By'),
       ],
@@ -191,6 +200,9 @@ return [
       'sql_type' => 'datetime',
       'input_type' => 'Select Date',
       'description' => ts('Date and time that Survey was edited last time.'),
+      'required' => TRUE,
+      'readonly' => TRUE,
+      'default' => 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
       'add' => '3.3',
     ],
     'result_id' => [

--- a/tests/phpunit/CRM/Campaign/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Campaign/BAO/QueryTest.php
@@ -27,7 +27,7 @@ class CRM_Campaign_BAO_QueryTest extends CiviUnitTestCase {
       'activity_type_id' => $activityType,
       'created_id' => $loggedInContact,
     ];
-    $survery = CRM_Campaign_BAO_Survey::create($surveyParams);
+    $survery = CRM_Campaign_BAO_Survey::writeRecord($surveyParams);
     $voterClauseParams = [
       'campaign_search_voter_for' => 'reserve',
       'campaign_survey_id' => $survery->id,

--- a/tests/phpunit/api/v4/Entity/CampaignTest.php
+++ b/tests/phpunit/api/v4/Entity/CampaignTest.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\tests\phpunit\api\v4\Entity;
+
+use api\v4\Api4TestBase;
+
+/**
+ * @group headless
+ */
+class CampaignTest extends Api4TestBase {
+
+  public function setUp(): void {
+    parent::setUp();
+    \CRM_Core_BAO_ConfigSetting::enableComponent('CiviCampaign');
+  }
+
+  public function testCampaignAndSurveyUpdate(): void {
+    $cid1 = $this->createLoggedInUser();
+
+    foreach (['Campaign', 'Survey'] as $entityName) {
+      $entity = $this->createTestRecord($entityName);
+      $created[$entityName] = civicrm_api4($entityName, 'get', [
+        'where' => [['id', '=', $entity['id']]],
+      ])->single();
+      $this->assertEquals($cid1, $created[$entityName]['created_id']);
+      $this->assertEquals($cid1, $created[$entityName]['last_modified_id']);
+      $this->assertNotNull($created[$entityName]['created_date']);
+      $this->assertEquals($created[$entityName]['created_date'], $created[$entityName]['last_modified_date']);
+    }
+
+    // Switch user, update time
+    $cid2 = $this->createLoggedInUser();
+    sleep(1);
+
+    // Ensure updated record reflects new user id and modified_date
+    foreach (['Campaign', 'Survey'] as $entityName) {
+      $updated[$entityName] = civicrm_api4($entityName, 'update', [
+        'checkPermissions' => FALSE,
+        'values' => ['title' => 'new', 'id' => $created[$entityName]['id']],
+        'reload' => TRUE,
+      ])->single();
+
+      $this->assertEquals('new', $updated[$entityName]['title']);
+      $this->assertEquals($cid1, $updated[$entityName]['created_id']);
+      $this->assertEquals($cid2, $updated[$entityName]['last_modified_id']);
+      $this->assertEquals($created[$entityName]['created_date'], $updated[$entityName]['created_date']);
+      $this->assertGreaterThan($updated[$entityName]['created_date'], $updated[$entityName]['last_modified_date']);
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Updates campaign & survey schema/BAOs to use current best practices for default column values

Technical Details
----------------------------------------
- Not null date fields
- Callbacks for default values
- current_timestamp() field defaults
- Hooks instead of logic in BAO::create functions
- Add tests