### PR TITLE
Metadata - Add default_callback to Group & SavedSearch entities

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1386,8 +1386,6 @@ WHERE {$whereClause}";
         $event->params['group_type'] = CRM_Utils_Array::convertCheckboxFormatToArray((array) $event->params['group_type']);
       }
 
-      $cid = CRM_Core_Session::singleton()->get('userID');
-
       // CRM-19068.
       // Validate parents parameter when creating group.
       if (!CRM_Utils_System::isNull($event->params['parents'])) {
@@ -1398,16 +1396,8 @@ WHERE {$whereClause}";
       }
     }
 
-    if ($event->action === 'create') {
-      // this action is add
-      if ($cid) {
-        $event->params['created_id'] = $cid;
-      }
-    }
-    elseif ($event->action === 'edit') {
-      if ($cid) {
-        $event->params['modified_id'] = $cid;
-      }
+    if ($event->action === 'edit') {
+      $event->params['modified_id'] ??= CRM_Core_Session::getLoggedInContactID();
 
       // If title isn't specified, retrieve it because we use it later, e.g.
       // for RecentItems. But note we use array_key_exists not isset or empty

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -234,7 +234,7 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
    * @param array $params
    * @return CRM_Contact_DAO_SavedSearch
    */
-  public static function create(&$params) {
+  public static function create($params) {
     return self::writeRecord($params);
   }
 
@@ -247,13 +247,7 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
    */
   public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event): void {
     if ($event->action === 'create' || $event->action === 'edit') {
-      $loggedInContactID = CRM_Core_Session::getLoggedInContactID();
-      if ($loggedInContactID) {
-        if ($event->action === 'create') {
-          $event->params['created_id'] ??= $loggedInContactID;
-        }
-        $event->params['modified_id'] ??= $loggedInContactID;
-      }
+      $event->params['modified_id'] ??= CRM_Core_Session::getLoggedInContactID();
       // Set by mysql
       unset($event->params['modified_date']);
 

--- a/schema/Contact/Group.entityType.php
+++ b/schema/Contact/Group.entityType.php
@@ -258,6 +258,7 @@ return [
       'input_type' => 'EntityRef',
       'description' => ts('FK to contact table.'),
       'add' => '4.3',
+      'default_callback' => ['CRM_Core_Session', 'getLoggedInContactID'],
       'input_attrs' => [
         'label' => ts('Created By'),
       ],
@@ -274,6 +275,7 @@ return [
       'readonly' => TRUE,
       'description' => ts('FK to contact table.'),
       'add' => '4.5',
+      'default_callback' => ['CRM_Core_Session', 'getLoggedInContactID'],
       'input_attrs' => [
         'label' => ts('Modified By'),
       ],

--- a/schema/Contact/SavedSearch.entityType.php
+++ b/schema/Contact/SavedSearch.entityType.php
@@ -116,10 +116,11 @@ return [
     'created_id' => [
       'title' => ts('Created By Contact ID'),
       'sql_type' => 'int unsigned',
-      'input_type' => NULL,
+      'input_type' => 'EntityRef',
       'readonly' => TRUE,
       'description' => ts('FK to contact table.'),
       'add' => '5.36',
+      'default_callback' => ['CRM_Core_Session', 'getLoggedInContactID'],
       'input_attrs' => [
         'label' => ts('Created By'),
       ],
@@ -132,10 +133,11 @@ return [
     'modified_id' => [
       'title' => ts('Modified By Contact ID'),
       'sql_type' => 'int unsigned',
-      'input_type' => NULL,
+      'input_type' => 'EntityRef',
       'readonly' => TRUE,
       'description' => ts('FK to contact table.'),
       'add' => '5.36',
+      'default_callback' => ['CRM_Core_Session', 'getLoggedInContactID'],
       'input_attrs' => [
         'label' => ts('Modified By'),
       ],


### PR DESCRIPTION
Overview
----------------------------------------
Followup on #31172, moves more ad-hoc bao logic into `default_callback` schema declarations & adds test coverage.
