### PR TITLE
Update ContrabutionPage schema/bao to use best-practices

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -26,17 +26,12 @@ use Civi\Core\HookInterface;
 class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_ContributionPage implements HookInterface {
 
   /**
-   * Creates a contribution page.
-   *
+   * @deprecated
    * @param array $params
-   *
    * @return CRM_Contribute_DAO_ContributionPage
    */
   public static function create($params) {
-    // @todo  - this implode is probably handled by writeRecord - test & remove.
-    if (isset($params['payment_processor']) && is_array($params['payment_processor'])) {
-      $params['payment_processor'] = implode(CRM_Core_DAO::VALUE_SEPARATOR, $params['payment_processor']);
-    }
+    CRM_Core_Error::deprecatedFunctionWarning('writeRecord');
     return self::writeRecord($params);
   }
 

--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -539,7 +539,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
       $params['payment_processor'] = 'null';
     }
 
-    $contributionPage = CRM_Contribute_BAO_ContributionPage::create($params);
+    $contributionPage = CRM_Contribute_BAO_ContributionPage::writeRecord($params);
     $contributionPageID = $contributionPage->id;
 
     // prepare for data cleanup.

--- a/CRM/Contribute/Form/ContributionPage/Settings.php
+++ b/CRM/Contribute/Form/ContributionPage/Settings.php
@@ -304,9 +304,6 @@ class CRM_Contribute_Form_ContributionPage_Settings extends CRM_Contribute_Form_
       $params['id'] = $this->_id;
     }
     else {
-      $session = CRM_Core_Session::singleton();
-      $params['created_id'] = $session->get('userID');
-      $params['created_date'] = date('YmdHis');
       $config = CRM_Core_Config::singleton();
       $params['currency'] = $config->defaultCurrency;
     }
@@ -316,7 +313,7 @@ class CRM_Contribute_Form_ContributionPage_Settings extends CRM_Contribute_Form_
     $params['is_active'] ??= FALSE;
     $params['is_credit_card_only'] ??= FALSE;
     $params['honor_block_is_active'] ??= FALSE;
-    $params['is_for_organization'] = !empty($params['is_organization']) ? CRM_Utils_Array::value('is_for_organization', $params, FALSE) : 0;
+    $params['is_for_organization'] ??= FALSE;
     $params['goal_amount'] = CRM_Utils_Rule::cleanMoney($params['goal_amount']);
 
     if (!$params['honor_block_is_active']) {
@@ -324,7 +321,7 @@ class CRM_Contribute_Form_ContributionPage_Settings extends CRM_Contribute_Form_
       $params['honor_block_text'] = NULL;
     }
 
-    $dao = CRM_Contribute_BAO_ContributionPage::create($params);
+    $dao = CRM_Contribute_BAO_ContributionPage::writeRecord($params);
 
     $ufJoinParams = [
       'is_organization' => [
@@ -352,7 +349,6 @@ class CRM_Contribute_Form_ContributionPage_Settings extends CRM_Contribute_Form_
           $ufJoinParam['id'] = $ufJoinDAO->id;
         }
 
-        $ufJoinParam['uf_group_id'] = $params[$index];
         $ufJoinParam['weight'] = 1;
         $ufJoinParam['is_active'] = 1;
         if ($index == 'honor_block_is_active') {

--- a/CRM/Contribute/Form/ContributionPage/ThankYou.php
+++ b/CRM/Contribute/Form/ContributionPage/ThankYou.php
@@ -109,7 +109,7 @@ class CRM_Contribute_Form_ContributionPage_ThankYou extends CRM_Contribute_Form_
       $params['bcc_receipt'] = NULL;
     }
 
-    $dao = CRM_Contribute_BAO_ContributionPage::create($params);
+    CRM_Contribute_BAO_ContributionPage::writeRecord($params);
     parent::endPostProcess();
   }
 

--- a/CRM/Upgrade/Incremental/sql/5.79.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.79.alpha1.mysql.tpl
@@ -1,5 +1,8 @@
 {* file to handle db changes in 5.79.alpha1 during upgrade *}
 
+UPDATE `civicrm_contribution_page` SET `created_date` = current_timestamp() WHERE `created_date` IS NULL;
+ALTER TABLE `civicrm_contribution_page` MODIFY COLUMN `created_date` datetime NOT NULL DEFAULT current_timestamp() COMMENT 'Date and time that contribution page was created.';
+
 UPDATE `civicrm_batch` SET `created_date` = current_timestamp() WHERE `created_date` IS NULL;
 UPDATE `civicrm_batch` SET `modified_date` = `created_date` WHERE `modified_date` IS NULL;
 

--- a/schema/Contribute/ContributionPage.entityType.php
+++ b/schema/Contribute/ContributionPage.entityType.php
@@ -435,6 +435,7 @@ return [
       'input_type' => 'EntityRef',
       'description' => ts('FK to civicrm_contact, who created this contribution page'),
       'add' => '3.0',
+      'default_callback' => ['CRM_Core_Session', 'getLoggedInContactID'],
       'input_attrs' => [
         'label' => ts('Created By'),
       ],
@@ -449,6 +450,9 @@ return [
       'sql_type' => 'datetime',
       'input_type' => 'Select Date',
       'description' => ts('Date and time that contribution page was created.'),
+      'required' => TRUE,
+      'readonly' => TRUE,
+      'default' => 'CURRENT_TIMESTAMP',
       'add' => '3.0',
     ],
     'currency' => [

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionPageTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionPageTest.php
@@ -16,35 +16,6 @@
 class CRM_Contribute_BAO_ContributionPageTest extends CiviUnitTestCase {
 
   /**
-   * Create() method (create Contribution Page)
-   */
-  public function testCreate(): void {
-
-    $params = [
-      'qfkey' => '9a3ef3c08879ad4c8c109b21c583400e',
-      'title' => 'Test Contribution Page',
-      'financial_type_id' => 1,
-      'intro_text' => '',
-      'footer_text' => 'Thanks',
-      'is_for_organization' => 0,
-      'for_organization' => ' I am contributing on behalf of an organization',
-      'goal_amount' => '400',
-      'is_active' => 1,
-      'honor_block_title' => '',
-      'honor_block_text' => '',
-      'start_date' => '20091022105900',
-      'start_date_time' => '10:59AM',
-      'end_date' => '19700101000000',
-      'end_date_time' => '',
-      'is_credit_card_only' => '',
-    ];
-
-    $contributionPageID = CRM_Contribute_BAO_ContributionPage::create($params)->id;
-    $this->assertIsInt($contributionPageID);
-    $this->callAPISuccess('ContributionPage', 'delete', ['id' => $contributionPageID]);
-  }
-
-  /**
    * Test setValues() method
    */
   public function testSetValues(): void {
@@ -55,7 +26,7 @@ class CRM_Contribute_BAO_ContributionPageTest extends CiviUnitTestCase {
       'is_active' => 1,
     ];
 
-    $contributionPage = CRM_Contribute_BAO_ContributionPage::create($params);
+    $contributionPage = CRM_Contribute_BAO_ContributionPage::writeRecord($params);
 
     $id = $contributionPage->id;
     $values = [];
@@ -90,7 +61,7 @@ class CRM_Contribute_BAO_ContributionPageTest extends CiviUnitTestCase {
       'is_credit_card_only' => '',
     ];
 
-    $contributionPage = CRM_Contribute_BAO_ContributionPage::create($params);
+    $contributionPage = CRM_Contribute_BAO_ContributionPage::writeRecord($params);
     $copyContributionPage = CRM_Contribute_BAO_ContributionPage::copy($contributionPage->id);
     $this->assertEquals(1, $copyContributionPage->financial_type_id, 'Check for Financial type id.');
     $this->assertEquals(400, $copyContributionPage->goal_amount, 'Check for goal amount.');

--- a/tests/phpunit/CRM/Contribute/Form/ContributionPageTranslationTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionPageTranslationTest.php
@@ -58,7 +58,7 @@ class CRM_Contribute_Form_ContributionPageTranslationTest extends CiviUnitTestCa
       'is_credit_card_only' => '',
     ];
 
-    $contributionPage = CRM_Contribute_BAO_ContributionPage::create($params);
+    $contributionPage = CRM_Contribute_BAO_ContributionPage::writeRecord($params);
 
     // The BAO does not save these
     $params['id'] = $contributionPage->id;


### PR DESCRIPTION
Overview
----------------------------------------
BAO/metadata updates for the ContributionPage entity

Technical Details
----------------------------------------
- Not null date fields
- Callbacks for default values
- current_timestamp() field defaults
- Deprecate BAO::create function