### PR TITLE
SqlGenerator - Always specify NULL or NOT NULL in DDL

### DIFF
--- a/mixin/lib/civimix-schema/src/SqlGenerator.php
+++ b/mixin/lib/civimix-schema/src/SqlGenerator.php
@@ -164,8 +164,7 @@ return new class() {
     if (!empty($field['required'])) {
       $fieldSql .= ' NOT NULL';
     }
-    // Mysql 5.7 requires timestamp to be explicitly declared NULL
-    if (empty($field['required']) && $field['sql_type'] === 'timestamp') {
+    else {
       $fieldSql .= ' NULL';
     }
     if (!empty($field['auto_increment'])) {


### PR DESCRIPTION
Overview
----------------------------------------
This keeps our DDL internally consistent.
See https://github.com/civicrm/civicrm-core/pull/31006
