### PR TITLE
SearchKit - Fix creating smart group from Individual/Organization/Household base entity

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -403,7 +403,7 @@
               entity = getEntity(joinInfo.entity),
               prefix = joinInfo.alias ? joinInfo.alias + '.' : '';
             _.each(entity.fields, function(field) {
-              if ((entity.name === 'Contact' && field.name === 'id') || (field.fk_entity === 'Contact' && joinInfo.baseEntity !== 'Contact')) {
+              if (['Contact', 'Individual', 'Household', 'Organization'].includes(entity.name) && field.name === 'id' || field.fk_entity === 'Contact') {
                 columns.push({
                   id: prefix + field.name,
                   text: (joinInfo.label ? joinInfo.label + ': ' : '') + field.label,


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a recent-ish regression preventing smart groups from being created in the SK UI if the base entity is a contact type.

Before
----------------------------------------
1. Create a search for Individuals
2. Try to create a smart group
3. It won't allow you to select ID as the "Contact Column"

After
----------------------------------------
Fixed.