### PR TITLE
SearchKit - Add link to edit search when viewing results

### DIFF
--- a/ext/search_kit/ang/crmSearchPage.module.js
+++ b/ext/search_kit/ang/crmSearchPage.module.js
@@ -8,18 +8,28 @@
       // Load & render a SearchDisplay
       $routeProvider.when('/display/:savedSearchName/:displayName?', {
         controller: 'crmSearchPageDisplay',
-        // Dynamic template generates the directive for each display type
         template: '<h1 crm-page-title>{{:: $ctrl.display.label }}</h1>\n' +
-          '<form ng-include="\'~/crmSearchPage/displayType/\' + $ctrl.display.type + \'.html\'" id="bootstrap-theme"></form>',
+          '<form id="bootstrap-theme">' +
+          // Edit link for authorized users
+          '  <div class="pull-right btn-group" ng-if="$ctrl.editLink">' +
+          '    <a class="btn btn-sm" ng-href="{{:: $ctrl.editLink }}"><i class="crm-i fa-pencil"></i> {{:: ts("Edit Search") }}</a>' +
+          '  </div>' +
+          // Dynamic template generates the directive for each display type
+          // @see \Civi\Search\Display::getPartials()
+          '  <div ng-include="\'~/crmSearchPage/displayType/\' + $ctrl.display.type + \'.html\'"></div>' +
+          '</form>',
         resolve: {
           // Load saved search display
           info: function($route, crmApi4) {
             var params = $route.current.params;
             var apiCalls = {
               search: ['SavedSearch', 'get', {
-                select: ['name', 'api_entity'],
-                where: [['name', '=', params.savedSearchName]]
-              }, 0]
+                select: ['id', 'name', 'api_entity'],
+                where: [['name', '=', params.savedSearchName]],
+                chain: {
+                  checkAccess: ['SavedSearch', 'checkAccess', {action: 'update', values: {id: '$id'}}, 0],
+                },
+              }, 0],
             };
             if (params.displayName) {
               apiCalls.display = ['SearchDisplay', 'get', {
@@ -38,10 +48,13 @@
 
     // Controller for displaying a search
     .controller('crmSearchPageDisplay', function($scope, $location, info) {
-      var ctrl = $scope.$ctrl = this;
+      const ctrl = $scope.$ctrl = this;
+      const ts = $scope.ts = CRM.ts('org.civicrm.search_kit');
       this.display = info.display;
       this.searchName = info.search.name;
       this.apiEntity = info.search.api_entity;
+      // Format edit link if user has access
+      this.editLink = info.search.checkAccess.access ? CRM.url('civicrm/admin/search#/edit/' + info.search.id) : false;
 
       $scope.$watch(function() {return $location.search();}, function(params) {
         ctrl.filters = params;


### PR DESCRIPTION
Overview
----------------------------------------
Adds a handy edit button when viewing searchKit results

Before
----------------------------------------
1. Open SearchKit
2. Open the dropdown next to a saved search and click "View Results"
3. From this screen, no way to edit the saved search.

After
----------------------------------------
Now there's an edit link at the top-right.
<img width="830" alt="Screenshot 2024-09-29 at 12 04 20 PM" src="https://github.com/user-attachments/assets/922db5e2-1bcf-4fc6-be40-58fa34905940">
