### PR TITLE
SearchKit - Test fix

### DIFF
--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EntityDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EntityDisplayTest.php
@@ -117,7 +117,7 @@ class EntityDisplayTest extends Api4TestBase {
     $this->assertSame('Select', $getFields['prefix_id']['input_type']);
     $this->assertNull($getFields['prefix_id']['fk_entity']);
     $this->assertSame('Timestamp', $getFields['created_date']['data_type']);
-    $this->assertSame('Select Date', $getFields['created_date']['input_type']);
+    $this->assertSame('Date', $getFields['created_date']['input_type']);
     $this->assertNull($getFields['created_date']['fk_entity']);
 
     civicrm_api4('SK_MyNewEntity', 'refresh');


### PR DESCRIPTION
Overview
----------------------------------------
Not sure why this changed but the previous 'Select Date' was incorrect. Api4 uses 'Date' for 'input_type'.

I assume the cause was e6e0f468966771a43cc7374e47efa776460936e8 but I'm not sure why the test is just catching up to that change.