### PR TITLE
dev/core#5484 SettingsManager - reinstate intermediary boot phase...

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -691,6 +691,7 @@ class Container {
 
     if ($loadFromDB && $runtime->dsn) {
       \CRM_Core_DAO::init($runtime->dsn);
+      $bootServices['settings_manager']->dbAvailable();
       \CRM_Utils_Hook::singleton(TRUE);
       \CRM_Extension_System::singleton(TRUE);
       \CRM_Extension_System::singleton()->getClassLoader()->register();

--- a/tests/phpunit/Civi/Core/SettingsManagerTest.php
+++ b/tests/phpunit/Civi/Core/SettingsManagerTest.php
@@ -132,8 +132,8 @@ class SettingsManagerTest extends \CiviUnitTestCase {
    */
   protected function createManager() {
     $cache = new \CRM_Utils_Cache_ArrayCache([]);
-    $cache->set('defaults_domain', $this->domainDefaults);
-    $cache->set('defaults_contact', $this->contactDefaults);
+    $cache->set('phase2_defaults_domain', $this->domainDefaults);
+    $cache->set('phase2_defaults_contact', $this->contactDefaults);
     foreach ($this->mandates as $entity => $keyValues) {
       foreach ($keyValues as $k => $v) {
         $GLOBALS['civicrm_setting'][$entity][$k] = $v;


### PR DESCRIPTION
... to allow reading extension container settings from the database.

Overview
----------------------------------------
This is a more thoughtful alternative to https://github.com/civicrm/civicrm-core/pull/31169/files in order to fix https://lab.civicrm.org/dev/core/-/issues/5484

Before
----------------------------------------
SettingsManager has 2 states: 
1. preBoot = only core boot settings (extension hooks have not been called), only values from env var or civicrm.settings.php (no database values)
2. bootComplete = fully online

A database value for extensionDir isn't respected when booting the extension system.

After
----------------------------------------
SettingsManager has 3 states: 
1. preBoot and preDB = preBoot as above
2. preBoot but DB online = extension hooks have not been called, but values *are* read from the database
3. bootComplete = fully online

Database values for extensionDir , extensionUrl and ext_max_depth can be respected again when booting the extension system.


Comments
----------------------------------------
I preferred the cleaner separation before. I wonder if in the long run we could deprecate storing the extension system config values in the database? To me they feel like they _should_ be in `civicrm.settings.php` / environment variables. They are very closely coupled with the arrangement of files on the system.