### PR TITLE
SettingsManager::bootSettings - fix providing CIVICRM_DSN directly on Standalone

### DIFF
--- a/Civi/Core/SettingsManager.php
+++ b/Civi/Core/SettingsManager.php
@@ -430,9 +430,11 @@ class SettingsManager {
     // file in order to:
     // a) ensure the env values take precedence over define('CIVICRM_DSN'...) in the settings file
     // b) provide the right source value for CIVICRM_LOGGING_DSN (set from CIVICRM_DSN in the settings file template)
-    $composedDsn = $bootSettingsManager->getBagByDomain(NULL)->get('civicrm_db_dsn');
-    if ($composedDsn) {
-      define('CIVICRM_DSN', $composedDsn);
+    if (!defined('CIVICRM_DSN')) {
+      $composedDsn = $bootSettingsManager->getBagByDomain(NULL)->get('civicrm_db_dsn');
+      if ($composedDsn) {
+        define('CIVICRM_DSN', $composedDsn);
+      }
     }
 
     if (file_exists($settingsPath)) {


### PR DESCRIPTION
Overview
----------------------------------------
On Standalone, the CIVICRM_DSN can be provided using env vars for its component parts. However the [exceptional handling](https://github.com/civicrm/civicrm-core/commit/f9ee9993e9b) for this doesn't check whether the value for CIVICRM_DSN has actually come from component parts - and so tries to reset it if it is already set.

Before
----------------------------------------
On Standalone, set CIVICRM_DSN as env var

```
( ! ) Warning: Constant CIVICRM_DSN already defined in /home/ufundo/Code/civicrm/civicrm-buildkit/build/build-0/web/core/Civi/Core/SettingsManager.php on line 435
```

After
----------------------------------------
Setting CIVICRM_DSN as env var works as expected.
