### PR TITLE
[REF] Fix fatal error about converting object of class CRM_Core_Confi…

### DIFF
--- a/templates/CRM/Admin/Form/Setting/Url.hlp
+++ b/templates/CRM/Admin/Form/Setting/Url.hlp
@@ -46,7 +46,7 @@
 {htxt id='id-extensions_url'}
 {ts}Base URL for extension resources (images, stylesheets, etc).{/ts}<br/>
 {capture assign=civicrmAdminSettingPath}{crmURL p="civicrm/admin/setting/path" q="reset=1"}{/capture}
-{ts 1=$civicrmAdminSettingPath 2="$config->extensionsDir"}This should match the <a href="%1">"CiviCRM Extensions Directory"</a> ("%2").{/ts}
+{ts 1=$civicrmAdminSettingPath 2=$config->extensionsDir}This should match the <a href="%1">"CiviCRM Extensions Directory"</a> ("%2").{/ts}
 {/htxt}
 
 {htxt id='id-css_url-title'}


### PR DESCRIPTION
…g to string in template

Overview
----------------------------------------
This fixes a fatal error when clicking on the Extension Resource Help icon. The error is "Object of class CRM_Core_Config could not be converted to string "

Before
----------------------------------------
Fatal error and no help is shown

After
----------------------------------------
Help is shown

@demeritcowboy @eileenmcnaughton 