### PR TITLE
Afform - Restore token listing

### DIFF
--- a/ext/afform/core/Civi/Afform/Tokens.php
+++ b/ext/afform/core/Civi/Afform/Tokens.php
@@ -58,9 +58,9 @@ class Tokens extends AutoService implements EventSubscriberInterface {
     $tokenForms = static::getTokenForms();
     foreach ($tokenForms as $tokenName => $afform) {
       $e->entity('afform')
-        ->register("afform.{$tokenName}Url", E::ts('%1 (URL)', [1 => $afform['title'] ?? $afform['name']]));
+        ->register("{$tokenName}Url", E::ts('%1 (URL)', [1 => $afform['title'] ?? $afform['name']]));
       $e->entity('afform')
-        ->register("afform.{$tokenName}Link", E::ts('%1 (Full Hyperlink)', [1 => $afform['title'] ?? $afform['name']]));
+        ->register("{$tokenName}Link", E::ts('%1 (Full Hyperlink)', [1 => $afform['title'] ?? $afform['name']]));
     }
     if (!in_array('contactId', $e->getTokenProcessor()->getContextValues('schema')[0])) {
       return;


### PR DESCRIPTION
Overview
--------

If you enable Afform mail tokens, the GUI will suggest incorrect tokens.

Followup to the recent refactoring (a9b78870907c0a01d62952daf838835a7f13c550; circa 5.79-alpha). ping @eileenmcnaughton 

Before
------

If you use the token-picker, it suggests tokens like `{afform.afform.afformHelloUrl}`.

Admittedly, it sounds like a magic spell, but this particular one doesn't work.

After
-----

If you use the token-picker, it suggests tokens like `{afform.afformHelloUrl}`.

That's a shorter spell, and it does work.