### PR TITLE
Fix deprecated warning in explode

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -1122,9 +1122,11 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     // here we replace the user context with the url to view this contact
     $buttonName = $this->controller->getButtonName();
     if ($buttonName == $this->getButtonName('upload', 'new')) {
-      $contactSubTypes = array_filter(explode(CRM_Core_DAO::VALUE_SEPARATOR, $this->_contactSubType));
       $resetStr = "reset=1&ct={$contact->contact_type}";
-      $resetStr .= (count($contactSubTypes) == 1) ? "&cst=" . array_pop($contactSubTypes) : '';
+      if (is_string($this->_contactSubType)) {
+        $contactSubTypes = array_filter(explode(CRM_Core_DAO::VALUE_SEPARATOR, $this->_contactSubType));
+        $resetStr .= (count($contactSubTypes) == 1) ? "&cst=" . array_pop($contactSubTypes) : '';
+      }
       $session->replaceUserContext(CRM_Utils_System::url('civicrm/contact/add', $resetStr));
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
`$this->_contactSubType` is NULL if contact has no subtypes.

Before
----------------------------------------
Deprecated warning on explode (eg. on create new contact)

After
----------------------------------------
No deprecated warning.

Technical Details
----------------------------------------


Comments
----------------------------------------
PHP8.2
