### PR TITLE
WIP: proof of concept for moving towards popover API

### DIFF
--- a/CRM/Core/Action.php
+++ b/CRM/Core/Action.php
@@ -373,11 +373,13 @@ class CRM_Core_Action {
     }
 
     $mainLinks = $url;
+    $uniqueId = uniqid('domid-');
     if ($enclosedAllInSingleUL) {
       $allLinks = '';
       CRM_Utils_String::append($allLinks, '</li><li>', $mainLinks);
       $allLinks = "{$extraULName}<ul class='panel'><li>{$allLinks}</li></ul>";
-      $result = "<span class='btn-slide crm-hover-button'>{$allLinks}</span>";
+      $result = "<span class='btn-slidex crm-hover-button'>{$allLinks}</span>";
+      $result = "<button type=button class='btn-popover-menu crm-hover-button' popovertarget=$uniqueId >{allLinks}</button>";
     }
     else {
       $extra = '';
@@ -386,13 +388,13 @@ class CRM_Core_Action {
         if (count($extraLinks) > 1) {
           $mainLinks = array_slice($url, 0, 2);
           CRM_Utils_String::append($extra, '</li><li>', $extraLinks);
-          $extra = "{$extraULName}<ul class='panel'><li>{$extra}</li></ul>";
+          $extra = "{$extraULName}<ul class='panel' popover=auto id=$uniqueId><li>{$extra}</li></ul>";
         }
       }
       $resultLinks = '';
       CRM_Utils_String::append($resultLinks, '', $mainLinks);
       if ($extra) {
-        $result = "<span>{$resultLinks}</span><span class='btn-slide crm-hover-button'>{$extra}</span>";
+        $result = "<span>{$resultLinks}</span><button type=button class='btn-popover-menu crm-hover-button' popovertarget=$uniqueId >{$extra}</button>";
       }
       else {
         $result = "<span>{$resultLinks}</span>";

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -4009,3 +4009,19 @@ html.crm-standalone body {
   font-family: var(--crm-font, sans-serif);
   background-color: var(--crm-c-page-background, #f8f8f8);
 }
+
+/* proof of concept styling: positions menu with its top-right corner over the clicked element */
+.crm-container .panel[popover] {
+	background: white;
+	inset: unset;
+	position: absolute;
+	transform: translateX(-100%) translateY(50%);
+  border-radius: 0.4rem;
+}
+/* proof of concept styling: subtle text-only button. */
+.btn-popover-menu {
+  height: 1.2rem;
+  background: transparent;
+  color: var(--crm-c-text, black);
+  padding: 0 var(--crm-s, 0.5ch);
+}

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -1562,7 +1562,7 @@ input.crm-form-entityref {
   text-decoration: none;
 }
 
-.crm-container ul.panel {
+.crm-container ul.panel:not([popover]) {
   display: none;
   z-index: 9999;
   position: absolute;
@@ -4012,10 +4012,9 @@ html.crm-standalone body {
 
 /* proof of concept styling: positions menu with its top-right corner over the clicked element */
 .crm-container .panel[popover] {
-	background: white;
 	inset: unset;
 	position: absolute;
-	transform: translateX(-100%) translateY(50%);
+	transform: translateX(-100%);
   border-radius: 0.4rem;
 }
 /* proof of concept styling: subtle text-only button. */
@@ -4024,4 +4023,5 @@ html.crm-standalone body {
   background: transparent;
   color: var(--crm-c-text, black);
   padding: 0 var(--crm-s, 0.5ch);
+  border: none;
 }


### PR DESCRIPTION
In various places we use little pop-up menus. These are typically done with jQuery hacks on <spans> etc. There's a new, native HTML5 [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) which is platform-only (no js!) way to do it which will be more accessible and solve at least one other theming problem.

It's akin to the `<details>` changes we made.

This is  a proof-of-concept. @vingle and @JoeMurray  might be interested!

