### PR TITLE
SearchSegmentExtraField - use AutoService rather than LegacySpecScanner

### DIFF
--- a/ext/search_kit/Civi/Api4/Service/Spec/Provider/SearchSegmentExtraFieldProvider.php
+++ b/ext/search_kit/Civi/Api4/Service/Spec/Provider/SearchSegmentExtraFieldProvider.php
@@ -15,8 +15,13 @@ namespace Civi\Api4\Service\Spec\Provider;
 use Civi\Api4\Query\Api4SelectQuery;
 use Civi\Api4\Service\Spec\FieldSpec;
 use Civi\Api4\Service\Spec\RequestSpec;
+use Civi\Core\Service\AutoService;
 
-class SearchSegmentExtraFieldProvider implements Generic\SpecProviderInterface {
+/**
+ * @service
+ * @internal
+ */
+class SearchSegmentExtraFieldProvider extends AutoService implements Generic\SpecProviderInterface {
 
   /**
    * @inheritDoc


### PR DESCRIPTION
Overview
----------------------------------------
Stop relying on the legacy interface in a core class. See explanation https://github.com/civicrm/civicrm-core/blob/b872e54a69aba0e04aa87d3a5981d9986dd40f97/Civi/Api4/Service/LegacySpecScanner.php#L10


Technical Details
----------------------------------------
I think this might _slightly_ change the behaviour in that the Legacy interface ignores the restricted hook dispatch policy during upgrade, whereas the updated one relying on `scan-classes` is dropped during upgrades. Though I'm not 100% sure how that manifests during upgrade based on when the container build actually runs.