### PR TITLE
Add unit test to validate event

### DIFF
--- a/Civi/Test/EventTestTrait.php
+++ b/Civi/Test/EventTestTrait.php
@@ -116,6 +116,23 @@ trait EventTestTrait {
   }
 
   /**
+   * Update an event.
+   *
+   * @param array $eventParameters
+   *   Values to
+   *
+   * @param string $identifier
+   *   Index for storing event ID in ids array.
+   *
+   */
+  protected function updateEvent(array $eventParameters = [], string $identifier = 'event'): void {
+    Event::update(FALSE)
+      ->addWhere('id', '=', $this->getEventID($identifier))
+      ->setValues($eventParameters)
+      ->execute();
+  }
+
+  /**
    * Get the event id of the event created in set up.
    *
    * If only one has been created it will be selected. Otherwise

--- a/tests/phpunit/CRM/Event/Form/Registration/RegisterTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/RegisterTest.php
@@ -42,6 +42,19 @@ class CRM_Event_Form_Registration_RegisterTest extends CiviUnitTestCase {
     $this->assertValidationError($expectedResult);
   }
 
+  public function testValidateEventWithAvailableSpace(): void {
+    $event = $this->eventCreateUnpaid(['max_participants' => 2]);
+    $form = $this->getTestForm('CRM_Event_Form_Registration_Register', [
+      'additional_participants' => 2,
+      'email-Primary' => 'someone@example.com',
+    ], ['id' => $this->getEventID()]);
+    $form->processForm(FormWrapper::VALIDATED);
+    $expectedResult = [
+      'additional_participants' => 'There is only enough space left on this event for 2 participant(s).',
+    ];
+    $this->assertValidationError($expectedResult);
+  }
+
   /**
    * event#30
    *


### PR DESCRIPTION
Overview
----------------------------------------
Add unit test to validate event and also to supplement the refactoring changes in https://github.com/civicrm/civicrm-core/pull/30698 to ensure we are keeping the behaviour and validation rules intact in backoffice form for event registration.


Comments
----------------------------------------
ping @eileenmcnaughton @jensschuppe @JoeMurray @colemanw 