### PR TITLE
Financial Type label should be required in form

### DIFF
--- a/CRM/Financial/Form/FinancialType.php
+++ b/CRM/Financial/Form/FinancialType.php
@@ -91,7 +91,7 @@ class CRM_Financial_Form_FinancialType extends CRM_Core_Form {
     if ($this->_action == CRM_Core_Action::UPDATE && CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialType', $this->_id, 'is_reserved')) {
       $this->freeze(['is_active']);
     }
-    $this->addRule('label', ts('A financial type with this name already exists. Please select another name.'), 'objectExists',
+    $this->addRule('label', ts('A financial type with this label already exists. Please select another label.'), 'objectExists',
       ['CRM_Financial_DAO_FinancialType', $this->_id]
     );
   }
@@ -120,7 +120,10 @@ class CRM_Financial_Form_FinancialType extends CRM_Core_Form {
       foreach (['is_active', 'is_reserved', 'is_deductible'] as $field) {
         $params[$field] ??= FALSE;
       }
-      $financialType = civicrm_api3('FinancialType', 'create', $params);
+      $financialType = civicrm_api4('FinancialType', 'save', [
+        'records' => [$params],
+        'checkPermissions' => TRUE,
+      ])->first();
       if ($this->_action & CRM_Core_Action::UPDATE) {
         $url = CRM_Utils_System::url('civicrm/admin/financial/financialType', 'reset=1&action=browse');
         CRM_Core_Session::setStatus(ts('The financial type "%1" has been updated.', [1 => $params['label']]), ts('Saved'), 'success');


### PR DESCRIPTION
Overview
----------------------------------------
Regression fix - on adding a new financial type : 
`Mandatory key(s) missing from params array: name` in CRM/Financial/Form/FinancialType.php:123


Technical Details
----------------------------------------
Regression caused by https://github.com/civicrm/civicrm-core/pull/31116 In that PR I have made the `FinancialType.label` parameter required and `name` should be defaulted to label if empty. The break occurred when we are saving the FinancialType via apiv3 which expects name as required parameter. So I have replaced the apiv3 call with apiv4, 

ping @colemanw @mattwire 
