### PR TITLE
dev/core#5507 - Temporarily remove `{include}` that crashes smarty 2

### DIFF
--- a/templates/CRM/Contact/Form/Inline/Email.tpl
+++ b/templates/CRM/Contact/Form/Inline/Email.tpl
@@ -38,7 +38,6 @@
       <td align="center" class="crm-email-is_primary">{$form.email.$blockId.is_primary.1.html}</td>
       <td><a title="{ts}Delete Email{/ts}" class="crm-delete-inline crm-hover-button" href="#"><span class="icon delete-icon"></span></a></td>
     </tr>
-    {include file="CRM/Contact/Form/Inline/BlockCustomData.tpl" entity=email customFields=$custom_fields_email blockId=$blockId actualBlockCount=$actualBlockCount}
 
   {/section}
 </table>


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5507

Before
----------------------------------------
Use smarty2
Click on inline edit for the email on a contact.
Crash.

After
----------------------------------------


Technical Details
----------------------------------------
This only removes the `{include}` line and leaves the rest of https://github.com/civicrm/civicrm-core/pull/30843 intact. Another option would be to start conditionally including things based on smarty version but not sure we want to clutter up templates with that.

Comments
----------------------------------------
Nobody should lose any functionality from this since custom fields on emails would be a new feature and wouldn't be in use anywhere.
