### PR TITLE
dev/core#5507 - Fix invalid smarty syntax that crashes smarty 2

### DIFF
--- a/templates/CRM/Contact/Form/Inline/BlockCustomData.tpl
+++ b/templates/CRM/Contact/Form/Inline/BlockCustomData.tpl
@@ -11,12 +11,12 @@
  - ie email & in the future phone, maybe im, website & openID although those
  may not rise to the top of anyone's to-do *}
 {if array_key_exists($blockId, $customFields)}
-  {foreach item='custom_field' from=$customFields[$blockId] key='custom_field_name'}
+  {foreach item='custom_field' from=$customFields.$blockId key='custom_field_name'}
     <tr class="crm-block-entity-{$entity}-{$blockId} {if $blockId gt $actualBlockCount}hiddenElement{/if}">
-      <td colspan="5">{$form[$entity][$blockId][$custom_field_name]['label']}</td>
+      <td colspan="5">{$form.$entity.$blockId.$custom_field_name.label}</td>
     </tr>
     <tr class="crm-block-entity-{$entity}-{$blockId} {if $blockId gt $actualBlockCount}hiddenElement{/if}">
-      <td colspan="5">{$form[$entity][$blockId][$custom_field_name]['html']}</td>
+      <td colspan="5">{$form.$entity.$blockId.$custom_field_name.html}</td>
     </tr>
   {/foreach}
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5507

Alternative to https://github.com/civicrm/civicrm-core/pull/31236

Before
----------------------------------------
Use smarty2
Click on inline edit for the email on a contact.
Crash.

After
----------------------------------------


Technical Details
----------------------------------------
Looking closer the problem actually seemed to be it was using php syntax instead of smarty syntax, which obviously works in v5.

Comments
----------------------------------------

