### PR TITLE
dev/core#5510 Fix retriving of the soft credit profile when generating…

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -19,6 +19,7 @@ use Civi\Api4\LineItem;
 use Civi\Api4\ContributionSoft;
 use Civi\Api4\MembershipLog;
 use Civi\Api4\PaymentProcessor;
+use Civi\Api4\UFJoin;
 use Civi\Core\Event\PostEvent;
 
 /**
@@ -2657,7 +2658,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       if (!empty($values['id'])) {
         $values['honor'] = [
           'honor_profile_values' => [],
-          'honor_profile_id' => CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFJoin', $values['id'], 'uf_group_id', 'entity_id'),
+          'honor_profile_id' => UFJoin::get(FALSE)->addWhere('entity_id', '=', $values['id'])->addWhere('entity_table', '=', 'civicrm_contribution_page')->addWhere('module', '=', 'soft_credit')->execute()->first()['uf_group_id'] ?? 0,
           'honor_id' => $softRecord['soft_credit'][1]['contact_id'],
         ];
 

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -922,4 +922,94 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     $this->assertEquals(2, $contributionRecur['frequency_interval']);
   }
 
+  public function testSubmitInHonorOfContributionPage(): void {
+    $tributeProfile = $this->callAPISuccess('UFGroup', 'create', [
+      'group_type' => [
+        'Individual',
+        'Contact',
+      ],
+      'title' => 'Tribute',
+      'frontend_title' => 'Tribute',
+    ]);
+    $fields = [
+      'First Name' => 'first_name',
+      'Last Name' => 'last_name',
+      'Street Address (Home)' => 'street_address',
+      'City (Home)' => 'city',
+      'Postal Code (Home)' => 'postal_code',
+      'Country (Home)' => 'country',
+      'State (Home)' => 'state_province',
+    ];
+    foreach ($fields as $label => $fieldName) {
+      $field_type = 'Individual';
+      if ($fieldName !== 'first_name' && $fieldName !== 'last_name') {
+        $field_type = 'Contact';
+      }
+      $params = [
+        'uf_group_id' => $tributeProfile['id'],
+        'field_name' => $fieldName,
+        'label' => $label,
+        'field_type' => $field_type,
+      ];
+      if ($field_type === 'Contact') {
+        $params['location_type_id'] = 1;
+      }
+      $this->callAPISuccess('UFField', 'create', $params);
+    }
+    $this->contributionPageWithPriceSetCreate();
+    $this->callAPISuccess('UFJoin', 'create', [
+      'is_active' => 1,
+      'module' => 'CiviEvent',
+      'entity_table' => 'civicrm_event',
+      'entity_id' => $this->getContributionPageID(),
+      'weight' => 1,
+      'uf_group_id' => 1,
+    ]);
+    $this->callAPISuccess('UFJoin', 'create', [
+      'is_active' => 1,
+      'module' => 'soft_credit',
+      'entity_table' => 'civicrm_contribution_page',
+      'entity_id' => 1,
+      'uf_group_id' => $tributeProfile['id'],
+      'module_data' => [
+        'soft_credit' => [
+          'soft_credit_types' => [
+            0 => '1',
+            1 => '2',
+          ],
+          'default' => [
+            'honor_block_title' => 'SL Test',
+            'honor_block_text' => '',
+          ],
+        ],
+      ],
+    ]);
+    $processor = \Civi\Payment\System::singleton()->getById($this->ids['PaymentProcessor']['dummy']);
+    $processor->setDoDirectPaymentResult(['payment_status_id' => 1, 'fee_amount' => .72]);
+    $this->submitOnlineContributionForm([
+      'priceSetId' => $this->getPriceSetID('ContributionPage'),
+      'price_' . $this->ids['PriceField']['radio_field'] => $this->ids['PriceFieldValue']['10_dollars'],
+      'id' => $this->getContributionPageID(),
+      'soft_credit_type_id' => 2,
+      'honor' => [
+        'first_name' => 'James',
+        'last_name' => 'Bond',
+        'street_address-1' => 'Vaxhaul Cross',
+        'city-1' => 'London',
+        'postal_code-1' => 'M4K1J1',
+        'country-1' => 1039,
+        'state_province-1' => 1068,
+      ],
+    ] + $this->getBillingSubmitValues(), $this->getContributionPageID());
+    $contribution = $this->callAPISuccessGetSingle('Contribution', ['contribution_page_id' => $this->getContributionPageID(), 'version' => 4]);
+    $this->assertEquals(10, $contribution['total_amount']);
+    // Ensure that Honoree details have been pritned
+    $this->assertMailSentContainingStrings(
+      [
+        'In Memory of',
+        'Name    James Bond',
+      ],
+    );
+  }
+
 }


### PR DESCRIPTION
… receipt

Overview
----------------------------------------
This fixes pulling out the soft credit profile id when generating receipt

Before
----------------------------------------
Potentially incorrect profile id is returned due to lacking of checking on the module + the lack of checking of the relevant entity_table

After
----------------------------------------
Correct profile for soft crediting is returned

@eileenmcnaughton @demeritcowboy 