### PR TITLE
remove outdated references to getSystemDefaults in bootstrap_comments

### DIFF
--- a/settings/System.boot.setting.php
+++ b/settings/System.boot.setting.php
@@ -20,7 +20,7 @@
  */
 return [
   'installed' => [
-    'bootstrap_comment' => 'This is a boot setting which may be loaded during bootstrap. Defaults are loaded via SettingsBag::getSystemDefaults().',
+    'bootstrap_comment' => 'This is a boot setting which may be loaded during bootstrap.',
     'group_name' => 'CiviCRM Preferences',
     'group' => 'core',
     'name' => 'installed',
@@ -35,7 +35,7 @@ return [
     'help_text' => NULL,
   ],
   'enable_components' => [
-    'bootstrap_comment' => 'This is a boot setting which may be loaded during bootstrap. Defaults are loaded via SettingsBag::getSystemDefaults().',
+    'bootstrap_comment' => 'This is a boot setting which may be loaded during bootstrap.',
     'group_name' => 'CiviCRM Preferences',
     'group' => 'core',
     'name' => 'enable_components',


### PR DESCRIPTION
Dont apply since https://github.com/civicrm/civicrm-core/pull/30533

