### PR TITLE
Add CustomField support to Products

### DIFF
--- a/CRM/Contribute/Form/ManagePremiums.php
+++ b/CRM/Contribute/Form/ManagePremiums.php
@@ -21,6 +21,7 @@ use Civi\Api4\Product;
  * This class generates form components for Premiums.
  */
 class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
+  use CRM_Custom_Form_CustomDataTrait;
 
   /**
    * Classes extending CRM_Core_Form should implement this method.
@@ -37,7 +38,7 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
   public function setDefaultValues() {
     $defaults = parent::setDefaultValues();
     if ($this->_id) {
-      $tempDefaults = Product::get()->addWhere('id', '=', $this->_id)->execute()->first();
+      $tempDefaults = Product::get()->addSelect('*', 'custom.*')->addWhere('id', '=', $this->_id)->execute()->first();
       if (isset($tempDefaults['image']) && isset($tempDefaults['thumbnail'])) {
         $defaults['imageUrl'] = $tempDefaults['image'];
         $defaults['thumbnailUrl'] = $tempDefaults['thumbnail'];
@@ -55,9 +56,38 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
       if (isset($tempDefaults['period_type'])) {
         $this->assign('showSubscriptions', TRUE);
       }
+
+      // Convert api3 field names to custom_xx format
+      foreach ($tempDefaults as $name => $value) {
+        $short = CRM_Core_BAO_CustomField::getShortNameFromLongName($name);
+        if ($short) {
+          $tempDefaults[$short . '_' . $this->_id] = $value;
+          unset($tempDefaults[$name]);
+        }
+      }
     }
 
     return $defaults;
+  }
+
+  /**
+   * Build the form object.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function preProcess() {
+    parent::preProcess();
+
+    // when custom data is included in this page
+    if ($this->isSubmitted()) {
+      // The custom data fields are added to the form by an ajax form.
+      // However, if they are not present in the element index they will
+      // not be available from `$this->getSubmittedValue()` in post process.
+      // We do not have to set defaults or otherwise render - just add to the element index.
+      $this->addCustomDataFieldsToForm('Product', array_filter([
+        'id' => $this->_id,
+      ]));
+    }
   }
 
   /**
@@ -103,7 +133,7 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
     $this->addElement('text', 'imageUrl', ts('Image URL'));
     $this->addElement('text', 'thumbnailUrl', ts('Thumbnail URL'));
 
-    $this->add('file', 'uploadFile', ts('Image File Name'), ['onChange' => 'select_option();']);
+    $this->add('file', 'uploadFile', ts('Image File Name'), ['onChange' => 'CRM.$("input[name=imageOption][value=image]").prop("checked", true);']);
 
     $this->add('text', 'price', ts('Market Value'), CRM_Core_DAO::getAttribute('CRM_Contribute_DAO_Product', 'price'), TRUE);
     $this->addRule('price', ts('Please enter the Market Value for this product.'), 'money');
@@ -287,6 +317,8 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
     }
 
     $this->_processImages($params);
+
+    $params += $this->getSubmittedCustomFieldsForApi4();
 
     // Save the premium product to database
     $premium = Product::save()->addRecord($params)->execute()->first();

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -614,6 +614,9 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
    */
   public static function getShortNameFromLongName(string $longName): ?string {
     [$groupName, $fieldName] = explode('.', $longName);
+    if (empty($groupName) || empty($fieldName)) {
+      return NULL;
+    }
     foreach (CRM_Core_BAO_CustomGroup::getAll() as $customGroup) {
       if ($customGroup['name'] === $groupName) {
         foreach ($customGroup['fields'] as $id => $field) {

--- a/CRM/Custom/Form/CustomDataTrait.php
+++ b/CRM/Custom/Form/CustomDataTrait.php
@@ -168,8 +168,8 @@ trait CRM_Custom_Form_CustomDataTrait {
   /**
    * Get the submitted custom fields.
    *
-   * This is returned apiv3 style but in future could take
-   * api version as a parameter.
+   * This is returned apiv3 style.
+   * @see getSubmittedCustomFieldsForApi4()
    *
    * @return array
    */
@@ -178,6 +178,23 @@ trait CRM_Custom_Form_CustomDataTrait {
     foreach ($this->getSubmittedValues() as $label => $field) {
       if (CRM_Core_BAO_CustomField::getKeyID($label)) {
         $fields[$label] = $field;
+      }
+    }
+    return $fields;
+  }
+
+  /**
+   * Get the submitted custom fields in Api4 format.
+   *
+   * @return array
+   */
+  protected function getSubmittedCustomFieldsForApi4(): array {
+    $fields = [];
+    foreach ($this->getSubmittedValues() as $label => $field) {
+      if (preg_match('/^custom_(\d+)_?(-?\d+)?$/', $label)) {
+        if ($new = CRM_Core_BAO_CustomField::getLongNameFromShortName($label)) {
+          $fields[$new] = $field;
+        }
       }
     }
     return $fields;

--- a/templates/CRM/Contribute/Form/ManagePremiums.tpl
+++ b/templates/CRM/Contribute/Form/ManagePremiums.tpl
@@ -137,7 +137,8 @@
   </details>
   {/crmRegion}
  {/if}
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+  {include file="CRM/common/customDataBlock.tpl" customDataType='Product' entityID=$productId}
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>
 {if $action eq 1 or $action eq 2}
 

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -334,7 +334,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'min_contribution' => 100,
       'is_active' => 1,
     ];
-    $premium = CRM_Contribute_BAO_Product::create($params);
+    $premium = CRM_Contribute_BAO_Product::writeRecord($params);
 
     $this->assertEquals('TEST Premium', $premium->name, 'Check for premium  name.');
 

--- a/tests/phpunit/CRM/Contribute/BAO/ProductTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ProductTest.php
@@ -29,7 +29,7 @@ class CRM_Contribute_BAO_ProductTest extends CiviUnitTestCase {
       'is_active' => 1,
     ];
 
-    $product = CRM_Contribute_BAO_Product::create($params);
+    $product = CRM_Contribute_BAO_Product::writeRecord($params);
     $result = $this->assertDBNotNull('CRM_Contribute_BAO_Product', $product->id,
       'sku', 'id',
       'Database check on updated product record.'
@@ -52,7 +52,7 @@ class CRM_Contribute_BAO_ProductTest extends CiviUnitTestCase {
       'is_active' => 1,
     ];
 
-    $product = CRM_Contribute_BAO_Product::create($params);
+    $product = CRM_Contribute_BAO_Product::writeRecord($params);
     $params = ['id' => $product->id];
     $default = [];
     $result = CRM_Contribute_BAO_Product::retrieve($params, $default);
@@ -73,7 +73,7 @@ class CRM_Contribute_BAO_ProductTest extends CiviUnitTestCase {
       'is_active' => 1,
     ];
 
-    $product = CRM_Contribute_BAO_Product::create($params);
+    $product = CRM_Contribute_BAO_Product::writeRecord($params);
     CRM_Contribute_BAO_Product::deleteRecord(['id' => $product->id]);
 
     $params = ['id' => $product->id];


### PR DESCRIPTION
Overview
----------------------------------------

Adds support for adding and editing Custom Fields on Product entities.

Needs testing: make sure that image upload still works.

Before
----------------------------------------

Even if Custom Fields are enabled for the Product entity, we cannot add custom data neither through api4 or using the "edit product" form.

After
----------------------------------------

![image](https://github.com/user-attachments/assets/90ffc391-07b6-463e-8254-85337bf5b997)

Technical Details
----------------------------------------

Requires enabling Custom Fields for the "Product" entity, as per: https://docs.civicrm.org/dev/en/latest/step-by-step/create-entity/#custom-data

Ex:

```
    \Civi\Api4\OptionValue::create(FALSE)
      ->addValue('option_group_id.name', 'cg_extend_objects')
      ->addValue('label', ts('Product'))
      ->addValue('name', 'civicrm_product')
      ->addValue('value', 'Product')
      ->execute();
```

(add to a php file, and run `cv php:script foo.php`)

Comments
----------------------------------------

The code does some api3/api4 conversions, because as far as I know, QuickForm always uses api3 custom field conventions, but the Form class used api4 to fetch and save data.

I'm not really sure about the `self_hook_civicrm_pre` part, with the `simplifyURL` lines.