### PR TITLE
LegacySpecScanner - only needs to look in extensions

### DIFF
--- a/Civi/Api4/Service/LegacySpecScanner.php
+++ b/Civi/Api4/Service/LegacySpecScanner.php
@@ -52,9 +52,7 @@ class LegacySpecScanner implements AutoServiceInterface {
     $classes = [];
 
     $namespace = \CRM_Utils_File::addTrailingSlash($namespace, '\\');
-    $locations = array_merge([\Civi::paths()->getPath('[civicrm.root]/Civi.php')],
-      array_column(\CRM_Extension_System::singleton()->getMapper()->getActiveModuleFiles(), 'filePath')
-    );
+    $locations = array_column(\CRM_Extension_System::singleton()->getMapper()->getActiveModuleFiles(), 'filePath');
     foreach ($locations as $location) {
       $path = \CRM_Utils_File::addTrailingSlash(dirname($location ?? '')) . str_replace('\\', DIRECTORY_SEPARATOR, $namespace);
       if (!file_exists($path) || !is_dir($path)) {


### PR DESCRIPTION
Overview
----------------------------------------
... as no core classes need this any more

Before
----------------------------------------
- looks for core classes and in extensions

After
----------------------------------------
- only checks extensions
