### PR TITLE
OAuth - opt into scan-classes to pick up Api4 entities

### DIFF
--- a/ext/oauth-client/info.xml
+++ b/ext/oauth-client/info.xml
@@ -35,6 +35,7 @@
     <mixin>setting-php@1.0.0</mixin>
     <mixin>smarty@1.0.0</mixin>
     <mixin>entity-types-php@1.0.0</mixin>
+    <mixin>scan-classes@1.0.0</mixin>
   </mixins>
   <civix>
     <namespace>CRM/OAuth</namespace>


### PR DESCRIPTION
Overview
----------------------------------------
If https://github.com/civicrm/civicrm-core/pull/31198 is merged, it will become "Legacy" for Api4 classes to get picked up without going via the scan-classes mixin (or manually providing to hook_civicrm_scanClasses)

Before
----------------------------------------
- OAuth relies on the to-be-legacy class scanning to provide Api4 entities


After
----------------------------------------
- OAuth uses scan-classes mixin to reveal it has important classes that need to get picked up


