### PR TITLE
Fix Product image upload

### DIFF
--- a/CRM/Contribute/xml/Menu/Contribute.xml
+++ b/CRM/Contribute/xml/Menu/Contribute.xml
@@ -115,6 +115,7 @@
     <path>civicrm/admin/contribute/managePremiums/edit</path>
     <title>Manage Premiums</title>
     <page_callback>CRM_Contribute_Form_ManagePremiums</page_callback>
+    <page_arguments>imageUpload=1</page_arguments>
   </item>
   <item>
     <path>civicrm/admin/financial/financialType</path>


### PR DESCRIPTION
Overview
----------------------------------------

After some refactoring around the Product UI for admin-ui, the ability to upload images for Products (premiums) was broken. The uploaded file was not moved out of the temporary directory, into the public images directory.

Before
----------------------------------------

Image uploads were broken:

![image](https://github.com/user-attachments/assets/bfcb384b-abfe-4bbe-b565-08a894ceeea0)

The path displayed was OK, but the file was not moved from tmp to the public imageUploadDir.

After
----------------------------------------

Fixed

![image](https://github.com/user-attachments/assets/e716f7ef-fe95-4a03-91f6-867a6111cac3)

Comments
----------------------------------------

cc @aydun 