### PR TITLE
dev/core#5516 Fix Smarty5 compatibility when changing Case Status in CiviCase

### DIFF
--- a/templates/CRM/Case/Form/Activity/ChangeCaseStatus.tpl
+++ b/templates/CRM/Case/Form/Activity/ChangeCaseStatus.tpl
@@ -13,7 +13,7 @@
       <td class="label">{$form.case_status_id.label}</td>
       <td>{$form.case_status_id.html}</td>
     </tr>
-    {if sizeof($linkedCases) > 0}
+    {if count($linkedCases) > 0}
       <tr>
         <td rowspan="2">{ts}Update Linked Cases Status?{/ts}</td>
         <td>{$form.updateLinkedCases.html}</td>


### PR DESCRIPTION
Fixes [issue #5516](https://lab.civicrm.org/dev/core/-/issues/5516)

Since PHP's 'sizeof' function is an alias of 'count', I just used 'count' since it's already registered as a modifier [here](https://github.com/civicrm/civicrm-core/blob/4edab64edf61ccd885aaf35a9d45a5104e0dd05d/setup/src/Setup/SmartyUtil.php#L27) and [here](https://github.com/civicrm/civicrm-core/blob/4edab64edf61ccd885aaf35a9d45a5104e0dd05d/CRM/Core/CodeGen/Util/Smarty.php#L63).

See Smarty4 to Smarty5 upgrade documentation:
https://smarty-php.github.io/smarty/5.x/upgrading/#using-native-php-functions-or-userland-functions-in-your-templates