### PR TITLE
add time when default datetime is 'now'/'relative' and time is present

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -208,7 +208,7 @@
         }
 
         if (ctrl.defn.input_type === 'Date' && typeof value === 'string' && value.startsWith('now')) {
-          value = getRelativeDate(value);
+          value = getRelativeDate(value, ctrl.defn.input_attrs.time);
         }
         if (ctrl.defn.input_type === 'Number' && ctrl.defn.search_range) {
           if (!_.isPlainObject(value)) {
@@ -374,7 +374,7 @@
         return currentVal;
       };
 
-      function getRelativeDate(dateString) {
+      function getRelativeDate(dateString, includeTime) {
         const parts = dateString.split(' ');
         const baseDate = new Date();
         let unit = parts[2] || 'day';
@@ -389,7 +389,11 @@
             offset *= 365;
         }
         let newDate = new Date(baseDate.getTime() + offset * 24 * 60 * 60 * 1000);
-        return newDate.toISOString().split('T')[0];
+        let defaultDate = newDate.toISOString().split('T')[0];
+        if (includeTime) {
+          defaultDate += ' ' + newDate.toTimeString().slice(0,8);
+        }
+        return defaultDate;
       }
 
     }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5517

If you add a datetime field to a FormBuilder form, and select "now" or a relative date as the default value, the time is not included.

Before
----------------------------------------
![Selection_2406](https://github.com/user-attachments/assets/a667fce4-0f22-4c0b-8997-011efbd28ef4)

After
----------------------------------------
![Selection_2407](https://github.com/user-attachments/assets/16a0b95a-32f2-42af-8493-d6af07096bb6)
