### PR TITLE
dev/core#5482 Add in Unsubscribe Mode setting and field to allow for …

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1081,6 +1081,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
         'status' => 'Draft',
         'start_date' => NULL,
         'end_date' => NULL,
+        'unsubscribe_mode' => Civi::settings()->get('default_oneclick_unsubscribe_mode'),
       ];
       if (CRM_Utils_System::isNull($params['sms_provider_id'] ?? NULL)) {
         $defaults['header_id'] = CRM_Mailing_PseudoConstant::defaultComponent('Header', '');
@@ -1913,6 +1914,7 @@ LEFT JOIN civicrm_mailing_group g ON g.mailing_id   = m.id
       $params['status'] ??= 'Draft';
       $params['start_date'] ??= 'null';
       $params['end_date'] ??= 'null';
+      $params['unsubscribe_mode'] ??= Civi::settings()->get('default_oneclick_unsubscribe_mode');
     }
     if ($event->action === 'delete' && $event->id) {
       // Delete all file attachments

--- a/CRM/Mailing/DAO/Mailing.php
+++ b/CRM/Mailing/DAO/Mailing.php
@@ -54,6 +54,7 @@
  * @property int|string|null $location_type_id
  * @property string|null $email_selection_method
  * @property string|null $language
+ * @property string $unsubscribe_mode
  */
 class CRM_Mailing_DAO_Mailing extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/Page/OptOut.php
+++ b/CRM/Mailing/Page/OptOut.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class CRM_Mailing_Page_OptOut extends CRM_Core_Page {
+
+  /**
+   * Run page.
+   *
+   * This includes assigning smarty variables and other page processing.
+   *
+   * @return string
+   * @throws Exception
+   */
+  public function run() {
+    $isOneClick = ($_SERVER['REQUEST_METHOD'] === 'POST' && CRM_Utils_Request::retrieve('List-Unsubscribe', 'String') === 'One-Click');
+    if ($isOneClick) {
+      $this->handleOneClick();
+      return NULL;
+    }
+
+    $wrapper = new CRM_Utils_Wrapper();
+    return $wrapper->run('CRM_Mailing_Form_OptOut', $this->_title);
+  }
+
+  /**
+   *
+   * Pre-condition: Validated the _job_id, _queue_id, _hash.
+   * Post-condition: Unsubscribed
+   *
+   * @link https://datatracker.ietf.org/doc/html/rfc8058
+   * @return void
+   */
+  public function handleOneClick(): void {
+    $jobId = CRM_Utils_Request::retrieve('jid', 'Integer');
+    $queueId = CRM_Utils_Request::retrieve('qid', 'Integer');
+    $hash = CRM_Utils_Request::retrieve('h', 'String');
+
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queueId, $hash);
+    if (!$q) {
+      CRM_Utils_System::sendResponse(
+        new \GuzzleHttp\Psr7\Response(400, [], ts("Invalid request: bad parameters"))
+      );
+    }
+
+    if (CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_domain($jobId, $queueId, $hash)) {
+      CRM_Mailing_Event_BAO_MailingEventUnsubscribe::send_unsub_response($queueId, NULL, TRUE, $jobId);
+    }
+
+    CRM_Utils_System::sendResponse(
+      new \GuzzleHttp\Psr7\Response(200, [], 'OK')
+    );
+  }
+
+}

--- a/CRM/Mailing/Service/ListUnsubscribe.php
+++ b/CRM/Mailing/Service/ListUnsubscribe.php
@@ -114,7 +114,8 @@ class CRM_Mailing_Service_ListUnsubscribe extends \Civi\Core\Service\AutoService
 
   private function replaceUnsubscribeWithOptOut($listUnsubscribeEmail): string {
     $sep = Civi::settings()->get('verpSeparator');
-    return str_replace('u' . $sep, 'o' . $sep, $listUnsubscribeEmail);
+    $pregSep = preg_quote(Civi::settings()->get('verpSeparator'), ';');
+    return preg_replace(";u{$pregSep}(\d+){$pregSep}(\d+){$pregSep}(\w*);", "o{$sep}$1{$sep}$2{$sep}$3", $listUnsubscribeEmail);
   }
 
 }

--- a/CRM/Mailing/Service/ListUnsubscribe.php
+++ b/CRM/Mailing/Service/ListUnsubscribe.php
@@ -18,6 +18,13 @@ class CRM_Mailing_Service_ListUnsubscribe extends \Civi\Core\Service\AutoService
     ];
   }
 
+  public static function unsubscribeModes(): array {
+    return [
+      'unsubscribe' => ts('Unsubscribe'),
+      'opt-out' => ts('Opt Out'),
+    ];
+  }
+
   public static function getSubscribedEvents() {
     return [
       '&hook_civicrm_alterMailParams' => ['alterMailParams', 1000],
@@ -43,9 +50,7 @@ class CRM_Mailing_Service_ListUnsubscribe extends \Civi\Core\Service\AutoService
     }
 
     $methods = Civi::settings()->get('civimail_unsubscribe_methods');
-    if ($methods === ['mailto']) {
-      return;
-    }
+    $mode = Civi::settings()->get('default_oneclick_unsubscribe_mode');
 
     $sep = preg_quote(Civi::settings()->get('verpSeparator'), ';');
     $regex = ";^<mailto:[^>]*u{$sep}(\d+){$sep}(\d+){$sep}(\w*)@(.+)>$;";
@@ -53,6 +58,23 @@ class CRM_Mailing_Service_ListUnsubscribe extends \Civi\Core\Service\AutoService
       // This can happen when generating a preview of a mailing or bots
       // crawling public mailings with invalid checkums
       return;
+    }
+
+    $mailing_unsubscribe_mode = CRM_Core_DAO::singleValueQuery("SELECT m.unsubscribe_mode
+      FROM civicrm_mailing_event_queue mq
+      INNER JOIN civicrm_mailing m ON m.id = mq.mailing_id
+      WHERE mq.id = %1", [1 => [$m[2], 'Positive']]);
+    if ($mailing_unsubscribe_mode !== $mode) {
+      $mode = $mailing_unsubscribe_mode;
+    }
+    if ($methods === ['mailto']) {
+      if ($mode === 'unsubscribe') {
+        return;
+      }
+      else {
+        $params['List-Unsubscribe'] = $this->replaceUnsubscribeWithOptOut($params['List-Unsubscribe']);
+        return;
+      }
     }
 
     if ($this->urlFlags === NULL) {
@@ -66,10 +88,16 @@ class CRM_Mailing_Service_ListUnsubscribe extends \Civi\Core\Service\AutoService
 
     $listUnsubscribe = [];
     if (in_array('mailto', $methods)) {
-      $listUnsubscribe[] = $params['List-Unsubscribe'];
+      $listUnsubscribe[] = ($mode === 'unsubscribe' ? $params['List-Unsubscribe'] : $this->replaceUnsubscribeWithOptOut($params['List-Unsubscribe']));
     }
     if (array_intersect(['http', 'oneclick'], $methods)) {
-      $listUnsubscribe[] = '<' . Civi::url('frontend://civicrm/mailing/unsubscribe', $this->urlFlags)->addQuery([
+      if ($mode === 'unsubscribe') {
+        $url = 'frontend://civicrm/mailing/unsubscribe';
+      }
+      else {
+        $url = 'frontend://civicrm/mailing/optout';
+      }
+      $listUnsubscribe[] = '<' . Civi::url($url, $this->urlFlags)->addQuery([
         'reset' => 1,
         'jid' => $m[1],
         'qid' => $m[2],
@@ -82,6 +110,11 @@ class CRM_Mailing_Service_ListUnsubscribe extends \Civi\Core\Service\AutoService
     }
     $params['headers']['List-Unsubscribe'] = implode(', ', $listUnsubscribe);
     unset($params['List-Unsubscribe']);
+  }
+
+  private function replaceUnsubscribeWithOptOut($listUnsubscribeEmail): string {
+    $sep = Civi::settings()->get('verpSeparator');
+    return str_replace('u' . $sep, 'o' . $sep, $listUnsubscribeEmail);
   }
 
 }

--- a/CRM/Mailing/xml/Menu/Mailing.xml
+++ b/CRM/Mailing/xml/Menu/Mailing.xml
@@ -123,7 +123,7 @@
   <item>
     <path>civicrm/mailing/optout</path>
     <title>Opt-out</title>
-    <page_callback>CRM_Mailing_Form_Optout</page_callback>
+    <page_callback>CRM_Mailing_Page_OptOut</page_callback>
     <access_arguments>access CiviMail subscribe/unsubscribe pages</access_arguments>
     <is_public>true</is_public>
     <weight>650</weight>

--- a/CRM/Upgrade/Incremental/php/SixSeven.php
+++ b/CRM/Upgrade/Incremental/php/SixSeven.php
@@ -29,6 +29,27 @@ class CRM_Upgrade_Incremental_php_SixSeven extends CRM_Upgrade_Incremental_Base 
    */
   public function upgrade_6_7_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask('Add unsubscribe mode column to civicrm mailing', 'alterSchemaField', 'Mailing', 'unsubscribe_mode', [
+      'title' => ts('One Click Unsubscribe Mode'),
+      'sql_type' => 'varchar(70)',
+      'input_type' => 'select',
+      'description' => ts('One Click Unsubscribe mode either unsubscribe or opt-out'),
+      'add' => '6.7',
+      'input_attrs' => [
+        'label' => ts('One Click Unsubscribe Mode'),
+      ],
+      'pseudoconstant' => [
+        'callback' => ['CRM_Mailing_Service_ListUnsubscribe', 'unsubscribeModes'],
+      ],
+      'default' => 'unsubscribe',
+      'required' => TRUE,
+    ]);
+    $this->addTask('Populate Unsubscribe mode column on civicrm_mailing', 'populateUnsubscribeMode');
+  }
+
+  public static function populateUnsubscribeMode(): bool {
+    CRM_Core_DAO::executeQuery("UPDATE civicrm_mailing SET unsubscribe_mode = 'unsubscribe' WHERE unsubscribe_mode IS NULL");
+    return TRUE;
   }
 
 }

--- a/ext/civi_mail/ang/crmMailing/BlockResponses.html
+++ b/ext/civi_mail/ang/crmMailing/BlockResponses.html
@@ -74,7 +74,7 @@ Required vars: mailing, crmMailingConst
         <option value=""></option>
       </select>
     </div>
-    <div crm-ui-field="{name: 'subform.unsubscribe_mode', title: ts('Unsubscribe Mode')}">
+    <div crm-ui-field="{name: 'subform.unsubscribe_mode', title: ts('One-Click Unsubscribe Mode')}">
       <select
         crm-ui-id="subform.unsubscribe_mode"
         name="unsubscribe_mode"

--- a/ext/civi_mail/ang/crmMailing/BlockResponses.html
+++ b/ext/civi_mail/ang/crmMailing/BlockResponses.html
@@ -74,5 +74,16 @@ Required vars: mailing, crmMailingConst
         <option value=""></option>
       </select>
     </div>
+    <div crm-ui-field="{name: 'subform.unsubscribe_mode', title: ts('Unsubscribe Mode')}">
+      <select
+        crm-ui-id="subform.unsubscribe_mode"
+        name="unsubscribe_mode"
+        crm-ui-select="{dropdownAutoWidth : true}"
+        ng-model="mailing.unsubscribe_mode"
+        required>
+        <option value="unsubscribe">{{:: ts('Unsubscribe') }}</option>
+        <option value="opt-out">{{:: ts('Opt Out') }}</option>
+      </select>
+    </div>
   </div>
 </div>

--- a/ext/civi_mail/settings/Mailing.setting.php
+++ b/ext/civi_mail/settings/Mailing.setting.php
@@ -389,4 +389,25 @@ return [
     'help_text' => ts('CiviMail records email sent at the frequency you specify. If you set it to 1, it will update the database every time it sends an email. This ensures that emails are not resent if the batch job fails, but this may cause a performance hit, particularly for large jobs.'),
     'settings_pages' => ['mail' => ['weight' => 60]],
   ],
+  'default_oneclick_unsubscribe_mode' => [
+    'group_name' => 'Mailing Preferences',
+    'group' => 'mailing',
+    'name' => 'default_oneclick_unsubscribe_mode',
+    'type' => 'String',
+    'html_type' => 'select',
+    'html_attributes' => [
+      'class' => 'crm-select2',
+    ],
+    'default' => 'unsubscribe',
+    'add' => '6.7',
+    'title' => ts('Default One Click Unsubscribe Mode'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => ts("This sets the default One Click unsubscribe mode for any new mailings created") . $unsubLearnMore,
+    'help_text' => NULL,
+    'pseudoconstant' => [
+      'callback' => 'CRM_Mailing_Service_ListUnsubscribe::unsubscribeModes',
+    ],
+    'settings_pages' => ['mail' => ['weight' => 70]],
+  ],
 ];

--- a/schema/Mailing/Mailing.entityType.php
+++ b/schema/Mailing/Mailing.entityType.php
@@ -609,5 +609,20 @@ return [
         'key_column' => 'name',
       ],
     ],
+    'unsubscribe_mode' => [
+      'title' => ts('One Click Unsubscribe Mode'),
+      'sql_type' => 'varchar(70)',
+      'input_type' => 'select',
+      'description' => ts('One Click Unsubscribe mode either unsubscribe or opt-out'),
+      'add' => '6.7',
+      'input_attrs' => [
+        'label' => ts('One Click Unsubscribe Mode'),
+      ],
+      'pseudoconstant' => [
+        'callback' => ['CRM_Mailing_Service_ListUnsubscribe', 'unsubscribeModes'],
+      ],
+      'default' => 'unsubscribe',
+      'required' => TRUE,
+    ],
   ],
 ];


### PR DESCRIPTION
…site admins to configure if One Click should be unsubscribe or opt out and modify Mailing interface appropriately

Overview
----------------------------------------
This adds in the ability for Site Admins to configure how the One Click is to be respond either as a standard Unsubscribe or Opt out

Before
----------------------------------------
One Click always unsubscribe option

After
----------------------------------------
One Click either opt out on the basis of a per mailing setting with the default for mailing set on a global setting basis

@JoeMurray 