### PR TITLE
Prevent saving an empty "array" for serialised Contact Reference fields

### DIFF
--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -126,6 +126,10 @@ class CRM_Core_BAO_CustomValueTable {
                 if (str_replace($validChars, '', $value)) {
                   throw new CRM_Core_Exception('Contact ID must be of type Integer');
                 }
+                // Prevent saving an empty "array" which results in a fatal error on render.
+                if ($value === '' || $value === $VS . $VS) {
+                  $value = NULL;
+                }
               }
               elseif ($value == NULL || $value === '') {
                 $type = 'Timestamp';


### PR DESCRIPTION
Overview
----------------------------------------
In CiviCRM 5.78+ saving a Contact Reference field with "Multi-Select" checked where no Contact has been selected causes a fatal error on rendering the Contact.

Steps to reproduce on Sample Data:

* Edit "Constituent Information"
* Create a Custom Field of type "Contact Reference"
* Check "Multi-Select"
* View any Contact
* Edit "Constituent Information" fields
* DO NOT select a Contact
* Save "Constituent Information" fields
* Spinny wheel of death
* Viewing that Contact's screen throws `getFieldValue failed` fatal error.

[This change](https://github.com/civicrm/civicrm-core/pull/30985) fixed a similar issue for non-serialised Contact Reference fields, but introduced this issue for serialised Contact Reference fields.

Before
----------------------------------------
Saving a serialised Contact Reference field where no Contact is selected results in the string `CRM_Core_DAO::VALUE_SEPARATOR . CRM_Core_DAO::VALUE_SEPARATOR` being saved in the database.

After
----------------------------------------
Saving a serialised Contact Reference field where no Contact is selected results in `NULL` being saved in the database.

Technical Details
----------------------------------------
There is a further issue which I am not sure how to tackle:

If a Contact with a serialised Contact Reference field has that value saved in CiviCRM 5.78+, then their Contact Summary screen throws a fatal error and is unrecoverable without "nulling" the actual entry in the database. This can't be done via the API because of the issue this PR addresses. I've set this up and confirmed on `dmaster`.

So there are two possible approaches possible here:

1. Test for `CRM_Core_DAO::VALUE_SEPARATOR . CRM_Core_DAO::VALUE_SEPARATOR` before passing the `$value` to `CRM_Utils_Array::explodePadded()`. The way the code currently is makes it difficult to do this for *only* serialised Contact Reference fields.
2. Modify `CRM_Utils_Array::explodePadded()` to detect `CRM_Core_DAO::VALUE_SEPARATOR . CRM_Core_DAO::VALUE_SEPARATOR` as an invalid "array" and return an appropriate value. I assume `NULL` is the appropriate return value, but would appreciate confirmation.

I can add code for either approach to this PR.