### PR TITLE
UtilsArray - An empty padded string should unserialize to an empty array

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -740,7 +740,7 @@ class CRM_Utils_Array {
       return $values;
     }
     // Empty string -> empty array
-    if ($values === '') {
+    if ($values === '' || $values === "$delim$delim") {
       return [];
     }
     return explode($delim, trim((string) $values, $delim));


### PR DESCRIPTION
Overview
----------------------------------------
Part 2 to https://github.com/civicrm/civicrm-core/pull/31260 regression fix.

Before
--------
Empty serialized array unserializes to `[""]`

After
--------
Empty serialized array unserializes to `[]`

Technical Details
--------
It's arguable which is more technically correct, but I can't think of a valid use-case for the former, and this prevents a fatal error.