### PR TITLE
Bugfix for windows machines

### DIFF
--- a/CRM/Extension/Container/Basic.php
+++ b/CRM/Extension/Container/Basic.php
@@ -98,7 +98,7 @@ class CRM_Extension_Container_Basic implements CRM_Extension_Container_Interface
   public function __construct($baseDir, $baseUrl, ?CRM_Utils_Cache_Interface $cache = NULL, $cacheKey = NULL, ?int $maxDepth = NULL) {
     $this->cache = $cache;
     $this->cacheKey = $cacheKey;
-    $this->baseDir = rtrim($baseDir, DIRECTORY_SEPARATOR);
+    $this->baseDir = rtrim($baseDir, '/' . DIRECTORY_SEPARATOR);
     $this->baseUrl = rtrim($baseUrl, '/');
     $this->maxDepth = $maxDepth;
   }

--- a/CRM/Extension/Container/Basic.php
+++ b/CRM/Extension/Container/Basic.php
@@ -98,7 +98,7 @@ class CRM_Extension_Container_Basic implements CRM_Extension_Container_Interface
   public function __construct($baseDir, $baseUrl, ?CRM_Utils_Cache_Interface $cache = NULL, $cacheKey = NULL, ?int $maxDepth = NULL) {
     $this->cache = $cache;
     $this->cacheKey = $cacheKey;
-    $this->baseDir = rtrim($baseDir, '/');
+    $this->baseDir = rtrim($baseDir, DIRECTORY_SEPARATOR);
     $this->baseUrl = rtrim($baseUrl, '/');
     $this->maxDepth = $maxDepth;
   }


### PR DESCRIPTION
Uses the platform-dependent `DIRECTORY_SEPARATOR` constant instead of a hard-coded `/` when determining the extension directory, as this was not working in windows
