### PR TITLE
Price Field: Field Type: remove help, simplify label

### DIFF
--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -215,12 +215,12 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
       $this->assign('useForEvent', FALSE);
     }
 
-    $sel = $this->add('select', 'html_type', ts('Input Field Type'),
+    $sel = $this->add('select', 'html_type', ts('Field Type'),
       $htmlTypes, TRUE, $javascript
     );
 
     // price (for text inputs)
-    $this->add('text', 'price', ts('Price'));
+    $this->add('text', 'price', ts('Unit Price'));
     $this->registerRule('price', 'callback', 'money', 'CRM_Utils_Rule');
     $this->addRule('price', ts('must be a monetary value'), 'money');
 

--- a/templates/CRM/Price/Form/Field.tpl
+++ b/templates/CRM/Price/Form/Field.tpl
@@ -90,25 +90,13 @@
       <td>{$form.html_type.html}
       </td>
     </tr>
-  {if $action neq 4 and $action neq 2}
-    <tr>
-      <td>&nbsp;</td>
-      <td class="description">{ts}Select the html type used to offer options for this field{/ts}
-      </td>
-    </tr>
-  {/if}
   </table>
-
   <div class="spacer"></div>
   <div id="price-block" {if $action eq 2 && $form.html_type.value.0 eq 'Text'} class="show-block" {else} class="hiddenElement" {/if}>
     <table class="form-layout">
       <tr class="crm-price-field-form-block-price">
-        <td class="label">{$form.price.label|smarty:nodefaults} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></td>
-        <td>{$form.price.html}
-        {if $action neq 4}
-          <br /><span class="description">{ts}Unit price.{/ts}</span> {help id="id-negative"}
-        {/if}
-        </td>
+        <td class="label">{$form.price.label|smarty:nodefaults} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span> {help id="id-negative"}</td>
+        <td>{$form.price.html}</td>
       </tr>
       <tr class="crm-price-field-form-block-non-deductible-amount">
         <td class="label">{$form.non_deductible_amount.label|smarty:nodefaults}</td>
@@ -209,8 +197,8 @@
       <td>&nbsp;{$form.is_required.html}</td>
     </tr>
     <tr class="crm-price-field-form-block-visibility_id">
-      <td class="label">{$form.visibility_id.label}</td>
-      <td>&nbsp;{$form.visibility_id.html}  {help id="id-visibility"}</td>
+      <td class="label">{$form.visibility_id.label} {help id="id-visibility"}</td>
+      <td>&nbsp;{$form.visibility_id.html}</td>
     </tr>
     <tr class="crm-price-field-form-block-is_active">
       <td class="label">{$form.is_active.label}</td>


### PR DESCRIPTION
Overview
----------------------------------------

When adding a Price Field, the label and help are confusing (based on client feedback).

Elsewhere such as Profiles, "Field Type" is used. This is the only place that used "Input Field Type".

To see: Administer > CiviContribute -> Price Set -> Add Field

Also moves some help icons after the label, discussed in: https://lab.civicrm.org/dev/core/-/issues/4297

![image](https://github.com/user-attachments/assets/bf752d34-976b-4fbd-88a9-83db8c3a3557)

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/d0cea62e-ec59-4440-bf59-6c15455eac1a)

After
----------------------------------------

![image](https://github.com/user-attachments/assets/3d51f9dd-df94-4524-9065-e5b6b0a3760e)

![image](https://github.com/user-attachments/assets/74b04542-6633-4ea8-9f71-e9620cdca48d)


