### PR TITLE
[REF] Fix demo site install issues becuase resource url doesn't have …

### DIFF
--- a/setup/src/Setup/SettingsUtil.php
+++ b/setup/src/Setup/SettingsUtil.php
@@ -51,7 +51,11 @@ class SettingsUtil {
     }
 
     foreach ($m->mandatorySettings as $key => $value) {
-      $extraSettings[] = sprintf('$civicrm_setting[%s][%s] = %s;', '\'domain\'', var_export($key, 1), var_export($value, 1));
+      $v = $value;
+      if (str_contains($m->cmsBaseUrl, 'https') && str_contains($value, 'http') && !str_contains($value, 'https')) {
+        $v = str_replace('http', 'https', $v);
+      }
+      $extraSettings[] = sprintf('$civicrm_setting[%s][%s] = %s;', '\'domain\'', var_export($key, 1), var_export($v, 1));
     }
 
     // FIXME $m->defaultSettings, $m->components, $m->extensions, $m->callbacks


### PR DESCRIPTION
…https in it

Overview
----------------------------------------
CiviCRM's WP Master demo site has been "broken" in the last week or so because nothing shows up when you load the CIviCRM home page. This is because it is trying to load assets from http://<demo url> instead of https://<demo url>

This is because when run via cli it seems the plugin_dir_url is always generating an http:// url. This aims to fix this 

Relevant portion of the CIvibuild output shown below

```
[Setup:info] [SyncUsers.civi-setup.php] Synchronize CMS users
{
    "srcPath": "/srv/buildkit/build/wpmaster/web/wp-content/plugins/civicrm/civicrm",
    "setupPath": "/srv/buildkit/build/wpmaster/web/wp-content/plugins/civicrm/civicrm/setup",
    "settingsPath": "/srv/buildkit/build/wpmaster/web/wp-content/uploads/civicrm/civicrm.settings.php",
    "templateCompilePath": "/srv/buildkit/build/wpmaster/web/wp-content/uploads/civicrm/templates_c",
    "cms": "WordPress",
    "cmsBaseUrl": "https://wpmaster.demo.civicrm.org",
....
    "paths": {
        "civicrm.private": {
            "path": "/srv/buildkit/build/wpmaster/web/wp-content/uploads/civicrm"
        },
        "wp.frontend.base": {
            "url": "https://wpmaster.demo.civicrm.org/"
        },
        "wp.backend.base": {
            "url": "https://wpmaster.demo.civicrm.org/wp-admin/"
        }
    },
    "settings": [],
    "mandatorySettings": {
        "userFrameworkResourceURL": "http://wpmaster.demo.civicrm.org/wp-content/plugins/civicrm/civicrm"
...
}
``` 

Before
----------------------------------------
WP Demo site broken

After
----------------------------------------
WP Demo site should work

@totten @JoeMurray @mlutfy @kcristiano 