### PR TITLE
[REF] Permit lock mechanism having a 0 second timeout and use that in…

### DIFF
--- a/CRM/Core/Lock.php
+++ b/CRM/Core/Lock.php
@@ -175,7 +175,7 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
       $query = "SELECT GET_LOCK( %1, %2 )";
       $params = [
         1 => [$this->_id, 'String'],
-        2 => [$timeout ?: $this->_timeout, 'Integer'],
+        2 => [!is_null($timeout) ? $timeout : $this->_timeout, 'Integer'],
       ];
       $res = CRM_Core_DAO::singleValueQuery($query, $params);
       if ($res) {

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -107,7 +107,7 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
     while ($result->fetch()) {
       $mailingID = $result->mailing_id;
       // still use job level lock for each child job
-      $lock = Civi::lockManager()->acquire("data.mailing.job.{$result->id}");
+      $lock = Civi::lockManager()->acquire("data.mailing.job.{$result->id}", 0);
       if (!$lock->isAcquired()) {
         continue;
       }
@@ -327,7 +327,7 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
     // X Number of child jobs
     while ($job->fetch()) {
       // still use job level lock for each child job
-      $lock = Civi::lockManager()->acquire("data.mailing.job.{$job->id}");
+      $lock = Civi::lockManager()->acquire("data.mailing.job.{$job->id}", 0);
       if (!$lock->isAcquired()) {
         continue;
       }


### PR DESCRIPTION
… MailJobs to speed up the aquisition of Child jobs

Overview
----------------------------------------
This allows the locking mechanism to only try for 0s rather than 3s to get a lock and specifies mailing job lock timeout to be 0 as well. 

Before
----------------------------------------
0 second timeout not permitted by locking mechansim

After
----------------------------------------
0 second timeout permitted by locking mechanism 


I believe AUG have been using this in their production for a while right ? @andrew-cormick-dockery @johntwyman 

ping @JoeMurray @totten 