### PR TITLE
dev/core#5440 Fixes PHP Fatal error when viewing the Event Registration Form (PHP Fatal error: Undefined constant "isShowAdminVisibilityFields")

### DIFF
--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -25,7 +25,7 @@
 
     {foreach from=$priceSet.fields item=element key=field_id}
         {* Skip 'Admin' visibility price fields WHEN this tpl is used in online registration unless user has administer CiviCRM permission. *}
-        {if $element.visibility !== 'admin' || isShowAdminVisibilityFields}
+        {if $element.visibility !== 'admin' || $isShowAdminVisibilityFields}
             {if $element.help_pre}<span class="content description">{$element.help_pre|purify}</span><br />{/if}
             <div class="crm-section {$element.name|escape}-section crm-price-field-id-{$field_id}">
             {if ($element.html_type eq 'CheckBox' || $element.html_type == 'Radio') && $element.options_per_line}


### PR DESCRIPTION
When viewing the Event Registration Form, PHP Fatal error:  Uncaught Error: Undefined constant "isShowAdminVisibilityFields"

Comments
----------------------------------------
Fixes bug introduced on https://github.com/civicrm/civicrm-core/pull/31087/files#diff-f9c22197c63b9059fa937e2d5dd3a15974f08b9ce3adec45613bdf53f06a887eR28

Relates to:

- https://github.com/civicrm/civicrm-core/pull/31098
- https://github.com/civicrm/civicrm-core/pull/31087
- https://lab.civicrm.org/dev/core/-/issues/5440
