### PR TITLE
EventCart - Remove fk before dropping column

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSeventySix.php
+++ b/CRM/Upgrade/Incremental/php/FiveSeventySix.php
@@ -114,6 +114,7 @@ class CRM_Upgrade_Incremental_php_FiveSeventySix extends CRM_Upgrade_Incremental
         CRM_Core_DAO::executeQuery('DROP table civicrm_event_carts');
       }
       if (!CRM_Core_DAO::singleValueQuery('SELECT cart_id FROM civicrm_participant WHERE cart_id > 0 LIMIT 1')) {
+        \CRM_Core_BAO_SchemaHandler::safeRemoveFK('civicrm_participant', 'FK_civicrm_participant_cart_id');
         \CRM_Core_BAO_SchemaHandler::dropColumn('civicrm_participant', 'cart_id', FALSE, TRUE);
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/5521

Technical Details
------
If the previous conditional was `false` but this one is `true`, the fk hasn't yet been removed. No harm doing it twice.