### PR TITLE
Standalone - Omit trailing `?` from query string

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -228,13 +228,16 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
     $frontend = FALSE,
     $forceBackend = FALSE
   ) {
-    $fragment = $fragment ? ('#' . $fragment) : '';
-    if ($absolute) {
-      return Civi::paths()->getUrl("[cms.root]/{$path}?{$query}$fragment", 'absolute');
+    // TODO: Add type hints
+    $query = (string) $query;
+    if (strlen($query)) {
+      $query = "?$query";
     }
-    else {
-      return Civi::paths()->getUrl("[cms.root]/{$path}?{$query}$fragment");
+    $fragment = (string) $fragment;
+    if (strlen($fragment)) {
+      $fragment = "#$fragment";
     }
+    return Civi::paths()->getUrl("[cms.root]/$path$query$fragment", $absolute ? 'absolute' : 'relative');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
I was wondering why standalone links always contain a trailing `?` even if they have no query args. This is why.

It doesn't make a big difference except that:
1. None of the CMSs do it.
2. It somewhat messes up single-page-apps like Afform & SearchKit by making a slightly different url than they were expecting & forcing the page to refresh sometimes when it wouldn't otherwise need to.