### PR TITLE
dev/core#5524 SearchKit - More sensible defaults for 1-1 joins

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -327,7 +327,8 @@ class Admin {
                   'description' => '',
                   'entity' => $targetEntityName,
                   'conditions' => self::getJoinConditions($keyField['name'], $alias . '.' . $reference->getTargetKey(), $dynamicValue, $dynamicCol),
-                  'defaults' => self::getJoinDefaults($alias, $targetEntity),
+                  // No default conditions for straight joins as they ought to be direct 1-1
+                  'defaults' => [],
                   'alias' => $alias,
                   'multi' => FALSE,
                 ];

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -506,28 +506,30 @@ class Admin {
    * @throws \CRM_Core_Exception
    * @throws \Civi\API\Exception\NotImplementedException
    */
-  private static function getJoinDefaults(string $alias, ...$entities):array {
+  private static function getJoinDefaults(string $alias, ...$entities): array {
     $conditions = [];
     foreach ($entities as $entity) {
-      foreach ($entity['ui_join_filters'] ?? [] as $fieldName) {
-        $field = civicrm_api4($entity['name'], 'getFields', [
-          'select' => ['options', 'data_type'],
-          'where' => [['name', '=', $fieldName]],
+      if (!empty($entity['ui_join_filters'])) {
+        $filterFields = civicrm_api4($entity['name'], 'getFields', [
+          'select' => ['name', 'options', 'data_type'],
+          'where' => [['name', 'IN', $entity['ui_join_filters']]],
           'loadOptions' => ['name'],
-        ])->first();
-        $value = '';
-        if ($field['data_type'] === 'Boolean') {
-          $value = TRUE;
+        ])->indexBy('name');
+        foreach ($filterFields as $fieldName => $field) {
+          $value = '';
+          if ($field['data_type'] === 'Boolean') {
+            $value = TRUE;
+          }
+          elseif (isset($field['options'][0])) {
+            $fieldName .= ':name';
+            $value = json_encode($field['options'][0]['name']);
+          }
+          $conditions[] = [
+            $alias . '.' . $fieldName,
+            '=',
+            $value,
+          ];
         }
-        elseif (isset($field['options'][0])) {
-          $fieldName .= ':name';
-          $value = json_encode($field['options'][0]['name']);
-        }
-        $conditions[] = [
-          $alias . '.' . $fieldName,
-          '=',
-          $value,
-        ];
       }
     }
     return $conditions;

--- a/ext/search_kit/tests/phpunit/Civi/Search/AdminTest.php
+++ b/ext/search_kit/tests/phpunit/Civi/Search/AdminTest.php
@@ -126,6 +126,36 @@ class AdminTest extends Api4TestBase {
       'multi' => FALSE,
     ]);
     $this->assertCount(1, $optionValueToGroup);
+
+    // Location joins
+    $addressJoins = \CRM_Utils_Array::findAll($joins['Individual'], [
+      'entity' => 'Address',
+      'multi' => TRUE,
+    ]);
+    $this->assertCount(1, $addressJoins);
+    $this->assertEquals(
+      [['id', '=', 'Contact_Address_contact_id.contact_id']],
+      $addressJoins[0]['conditions']
+    );
+    $this->assertEquals(
+      [['Contact_Address_contact_id.is_primary', '=', TRUE]],
+      $addressJoins[0]['defaults']
+    );
+
+    // LocBlock joins
+    $locBlockAddress = \CRM_Utils_Array::findAll($joins['LocBlock'], [
+      'entity' => 'Address',
+    ]);
+    $this->assertCount(2, $locBlockAddress);
+    $this->assertEquals(
+      [['address_id', '=', 'LocBlock_Address_address_id.id']],
+      $locBlockAddress[0]['conditions']
+    );
+    // Should have no defaults because it's a straight 1-1 join
+    $this->assertEquals(
+      [],
+      $locBlockAddress[0]['defaults']
+    );
   }
 
   public function testEntityRefGetJoins(): void {


### PR DESCRIPTION
Overview
----------------------------------------
Improves SearchKit user experience of adding 1-1 joins.
Fixes https://lab.civicrm.org/dev/core/-/issues/5524

Before
----------------------------------------
Irrelevant conditions like "is primary" get added by default.

After
----------------------------------------
No irrelevant conditions added.

Technical Details
----------------------------------------
1-1 joins do not need any default conditions as they join directly from one entity to another