### PR TITLE
Avoid duplicate ID on location form

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/Location.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Location.tpl
@@ -37,7 +37,7 @@
         <td id="locUsedMsg" colspan="3">
         </td>
       </tr>
-      <tr id="is_show_location" class="crm-event-manage-location-form-block-is_show_location">
+      <tr class="crm-event-manage-location-form-block-is_show_location">
         <td class="labels">
           {$form.is_show_location.label} {help id="id-is_show_location"}
         </td>


### PR DESCRIPTION
Overview
----------------------------------------
Fix duplicate ID in HTML source of the location form when managing events.

Before
----------------------------------------
The wrapping `<tr>` element contained `id="is_show_location"`, but so did the field itself. This duplicate ID is not valid HTML and meant the accessible association between the label and the input was broken.

After
----------------------------------------
`id="is_show_location"` is only output on the checkbox itself.
