### PR TITLE
Improve product description

### DIFF
--- a/schema/Contribute/Product.entityType.php
+++ b/schema/Contribute/Product.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Product'),
     'title_plural' => ts('Products'),
-    'description' => ts('able - stores "product info" for premiums and can be used for non-incentive products'),
+    'description' => ts('Stores "product info" for premiums and can be used for non-incentive products'),
     'log' => TRUE,
     'add' => '1.4',
     'label_field' => 'name',


### PR DESCRIPTION
Overview
----------------------------------------
Improve product description

Before
----------------------------------------
The description was:

> able - stores "product info" for premiums and can be used for non-incentive products

I assume "able" should have been "Table", but that's pretty superflous when using Searchkit/ API explorer.

After
----------------------------------------
The description is now simply:

> Stores "product info" for premiums and can be used for non-incentive products