### PR TITLE
Allow language mapping for German language variants (de)

### DIFF
--- a/CRM/Core/I18n/PseudoConstant.php
+++ b/CRM/Core/I18n/PseudoConstant.php
@@ -48,6 +48,7 @@ class CRM_Core_I18n_PseudoConstant {
       $longForShortMapping['pt'] = defined("CIVICRM_LANGUAGE_MAPPING_PT") ? CIVICRM_LANGUAGE_MAPPING_PT : 'pt_PT';
       $longForShortMapping['es'] = defined("CIVICRM_LANGUAGE_MAPPING_ES") ? CIVICRM_LANGUAGE_MAPPING_ES : 'es_ES';
       $longForShortMapping['nl'] = defined("CIVICRM_LANGUAGE_MAPPING_NL") ? CIVICRM_LANGUAGE_MAPPING_NL : 'nl_NL';
+      $longForShortMapping['de'] = defined("CIVICRM_LANGUAGE_MAPPING_DE") ? CIVICRM_LANGUAGE_MAPPING_DE : 'de_DE';
     }
     return $longForShortMapping;
   }

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -520,6 +520,7 @@ if (!defined('CIVICRM_PSR16_STRICT')) {
 // define('CIVICRM_LANGUAGE_MAPPING_PT', 'pt_BR');
 // define('CIVICRM_LANGUAGE_MAPPING_ZH', 'zh_TW');
 // define('CIVICRM_LANGUAGE_MAPPING_NL', 'nl_BE');
+// define('CIVICRM_LANGUAGE_MAPPING_DE', 'de_CH');
 
 /**
  * Native gettext improves performance of localized CiviCRM installations


### PR DESCRIPTION
Overview
----------------------------------------
The [CiviCRM documentation](https://docs.civicrm.org/user/en/latest/the-civicrm-community/localising-civicrm/#mapping-languages-to-specific-regional-translations) states that we can add language mappings for certain regional languages in the civicrm.settings.php file. However, German is not supported despite there are common variants used in Austria and Switzerland.

Before
----------------------------------------
`define('CIVICRM_LANGUAGE_MAPPING_DE', 'de_CH');` has no effect.

After
----------------------------------------
`define('CIVICRM_LANGUAGE_MAPPING_DE', 'de_CH');` will map the Swiss German language variant. Not to be confused with spoken Swiss German (sg).

Comments
----------------------------------------
This just adds German as an additional hardcoded exception. It also helps in situation where 'de' is not mapped to 'de_DE' out of the box. Maybe there's a need for a more flexible / robust approach to solve this problem for other languages, too.
