### PR TITLE
Advanced Search: icon for the Search Settings

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2290,6 +2290,14 @@ div.crm-master-accordion-header a.helpicon {
   display: none;
 }
 
+/* Ex: Advanced Search (but not limited to) */
+.crm-container details.crm-accordion-settings summary {
+  text-align: right;
+}
+.crm-container details.crm-accordion-settings summary::before {
+  content: '\f013';
+}
+
 .crm-container details details {
   padding: 0 0.25rem; /* adds padding for nested accordions */
 }
@@ -2311,7 +2319,7 @@ div.crm-master-accordion-header a.helpicon {
 .crm-container details > summary:before {
   font-family: "FontAwesome";
   display: inline-block;
-  width: 1em;
+  padding-right: 0.5rem;
   content: "\f0da";
   font-size: 13px;
 }

--- a/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
+++ b/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
@@ -86,7 +86,7 @@ CRM.$(function($) {
 {/if}
 
 {strip}
-  <details class="crm-accordion-bold crm-search_criteria_basic-accordion">
+  <details class="crm-accordion-settings crm-search_criteria_basic-accordion">
     <summary>
       {ts}Search Settings{/ts}
     </summary>


### PR DESCRIPTION
Overview
----------------------------------------

Converts the "Search Settings" fieldset to something toggled by an icon.

Before
----------------------------------------

Greenwich:

![image](https://github.com/user-attachments/assets/88b723f1-8556-4606-ae85-2f10781cd840)

![image](https://github.com/user-attachments/assets/f314d539-1e9a-4da5-876a-b9ffdb1ccfb8)

The Island:

![image](https://github.com/user-attachments/assets/bb4bf93d-d299-46d8-8d08-daef3f2d16d3)

![image](https://github.com/user-attachments/assets/c23b194a-1b06-4587-aa20-e42800b59798)

After
----------------------------------------

Greenwich:

![image](https://github.com/user-attachments/assets/554b28fe-8f9c-4c0c-adac-cf496e14f2b7)

![image](https://github.com/user-attachments/assets/3c422c97-281b-491b-9ff1-1dda0ff6ad4b)

The Island:

![image](https://github.com/user-attachments/assets/2b30e49f-979c-4bcb-b2ae-512a484138ca)

![image](https://github.com/user-attachments/assets/19f5df32-bae7-4d3c-afac-5fb072f2c580)


Technical Details
----------------------------------------

Intentionally keeping this change small, because going forward we may want to only do these things in RiverLea.

Comments
----------------------------------------

Based on changes proposed by @vingle  in #31226