### PR TITLE
dev/core#5499 Fix missing translation on Relationships tab by setting…

### DIFF
--- a/ext/afform/core/ang/af/afFieldset.directive.js
+++ b/ext/afform/core/ang/af/afFieldset.directive.js
@@ -16,6 +16,7 @@
         let ctrl = this;
         let localData = [];
         let joinOffsets = {};
+        let ts = $scope.ts = CRM.ts('org.civicrm.afform');
 
         this.getData = function() {
           return ctrl.afFormCtrl ? ctrl.afFormCtrl.getData(ctrl.modelName) : localData;


### PR DESCRIPTION
… module in the ts to afform in fieldSet

https://lab.civicrm.org/dev/core/-/issues/5499

Overview
----------------------------------------
This fixes strings that are in the html rather than in the search display config to be the translated language instead of english. This is because for some reason the wrong module name was being used in the ts

Before
----------------------------------------
Strings not translated

After
----------------------------------------
Strings translated

@eileenmcnaughton @mlutfy @colemanw 