### PR TITLE
dev/core#5163 Afform - Fix conditionals for FK fields

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
@@ -109,10 +109,6 @@
         function getDataType() {
           if (ctrl.field) {
             dataType = ctrl.field.data_type;
-            // FK Entities can use a mix of numeric & string values (see `"static": options` above)
-            if (ctrl.field.fk_entity) {
-              dataType = 'String';
-            }
           }
           else {
             dataType = null;
@@ -121,7 +117,12 @@
 
         function convertDataType(val) {
           if (dataType === 'Integer') {
-            return +val;
+            let newVal = +val;
+            // FK Entities can use a mix of numeric & string values (see `"static": options` above)
+            if (ctrl.field.fk_entity && ('' + newVal) !== val) {
+              return val;
+            }
+            return newVal;
           }
           return val;
         }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/5163#note_167578

Technical Details
----------------------------------------
This regressed (again) with b5a3b63df as FK fields shouldn't always be strings. This fix will correctly save numbers while making an exception for strings like 'user_contact_id'

Comments
-----
Note for testers: you need to edit the form and re-select the conditional rules for that field after applying patch.