### PR TITLE
fix administrators not seeing contributions with disabled financial type

### DIFF
--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -166,7 +166,7 @@ function _financialacls_civicrm_get_type_clause(): string {
  */
 function _financialacls_civicrm_get_accessible_financial_types(): array {
   $types = [];
-  CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($types);
+  CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($types, CRM_Core_Action::VIEW, FALSE, TRUE);
   if (empty($types)) {
     $types = [0];
   }


### PR DESCRIPTION
Overview
----------------------------------------
If Financial ACLs are enabled, users who have permission to view all contributions still can't see contributions associated with a disabled financial type.

Technical Details
----------------------------------------
When we get available financial types for ACL purposes, we need to include disabled financial types.  Because the associated permissions no longer exist in the CMS, this only changes the behavior for folks with "bypass all ACLs and permissions" and "view[/edit/delete] contributions of all types". Other folks, by definition, don't have the required permission.