### PR TITLE
Afform - add css selector to distinguish multi select af field

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -29,6 +29,10 @@
         $scope.fieldId = _.kebabCase(ctrl.fieldName) + '-' + id++;
 
         $element.addClass('af-field-type-' + _.kebabCase(ctrl.defn.input_type));
+  
+        if (this.defn.input_attrs && this.defn.input_attrs.multiple) {
+          $element.addClass('af-field-type-multiple');
+        }
 
         if (this.defn.name !== this.fieldName) {
           namePrefix = this.fieldName.substr(0, this.fieldName.length - this.defn.name.length);


### PR DESCRIPTION
Before
----------------------------------------
- Only css class selector for af-field elements is `af-field-type-[field type]` 
- This works for most things, but can't distinguish between selects and multi-selects, which often need to look a bit different


After
----------------------------------------
- multi-select fields have the additional selector `af-field-type-multiple`


Technical Details
----------------------------------------
Maybe it should have a slightly different prefix, because the `input_attrs.multiple`  -ness is different from the `input_type` property. But I think in the context of the class it's reasonable to flatten this distinction.
