### PR TITLE
afform - dont repeat custom group label in custom group field blocks

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Get.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Get.php
@@ -196,7 +196,13 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
           if (!$custom['is_multiple']) {
             $nameAttribute = $custom['name'] . "." . $nameAttribute;
           }
-          $item['layout'] .= "<af-field name=\"{$nameAttribute}\" />\n";
+
+          // by default, the AfformMetadataInjector prefixes the field label with the custom group label
+          // but in the context of a group block this is overkill, because the custom group label
+          // prefix is repeated on every field - so override the label defn with the unprefixed field label
+          $label = $field['label'];
+
+          $item['layout'] .= "<af-field name=\"{$nameAttribute}\" defn=\"{label: '{$label}'}\" />\n";
         }
         $item['layout'] .= ($custom['help_post'] ? '<div class="af-markup">' . $custom['help_post'] . "</div>\n" : '');
       }


### PR DESCRIPTION

Before
----------------------------------------
Custom Group label repeated on every field in custom field block:
![image](https://github.com/user-attachments/assets/f080cc2a-4c39-4193-8d33-67087596fbb3)


After
----------------------------------------
No repetition
![image](https://github.com/user-attachments/assets/ea2d203f-ba1b-4af9-bc4a-3c5d18bebd11)


Comments
----------------------------------------
I would happily remove the prefixing from AfformMetadataInjector altogether.

However I can see it might makes sense when you are adding a single custom field from a group somewhere on a form of other fields.

In the context of a custom group block I'm pretty sure it's just annoying.
