### PR TITLE
Package Riverlea theme extension during CiviCRM build

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3341,6 +3341,10 @@ span.crm-select-item-color {
   flex-wrap: wrap;
   gap: var(--gap);
 }
+/* Reset checkbox width when its rendered as text '(x)' in confirmation screens /dev/core/-/issues/5550 */
+.crm-container.crm-public .crm-profile-view .crm-option-label-pair {
+  --checkbox-width: auto;
+}
 /* Override more general styling */
 .crm-container .crm-multiple-checkbox-radio-options :where(input.crm-form-radio,
 input.crm-form-checkbox) + label {

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3341,10 +3341,6 @@ span.crm-select-item-color {
   flex-wrap: wrap;
   gap: var(--gap);
 }
-/* Reset checkbox width when its rendered as text '(x)' in confirmation screens /dev/core/-/issues/5550 */
-.crm-container.crm-public .crm-profile-view .crm-option-label-pair {
-  --checkbox-width: auto;
-}
 /* Override more general styling */
 .crm-container .crm-multiple-checkbox-radio-options :where(input.crm-form-radio,
 input.crm-form-checkbox) + label {

--- a/distmaker/dists/backdrop_php5.sh
+++ b/distmaker/dists/backdrop_php5.sh
@@ -25,6 +25,7 @@ dm_install_vendor "$SRC/vendor" "$TRG/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_drupal "$SRC/backdrop" "$TRG/backdrop"
 dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
+dm_install_cvext riverlea "$TRG/ext/riverlea"
 
 dm_h1 "Generate archive (civicrm-*-backdrop.tar.gz)"
 cd $TRG/..

--- a/distmaker/dists/drupal7_dir_php5.sh
+++ b/distmaker/dists/drupal7_dir_php5.sh
@@ -32,6 +32,7 @@ dm_install_vendor "$SRC/vendor" "$TRG/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_drupal "$DM_DRUPALDIR" "$TRG/drupal"
 dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
+dm_install_cvext riverlea "$TRG/ext/riverlea"
 
 dm_h1 "Generate archive (civicrm-*-drupal dir)"
 cd $TRG

--- a/distmaker/dists/drupal_php5.sh
+++ b/distmaker/dists/drupal_php5.sh
@@ -25,6 +25,7 @@ dm_install_vendor "$SRC/vendor" "$TRG/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_drupal "$SRC/drupal" "$TRG/drupal"
 dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
+dm_install_cvext riverlea "$TRG/ext/riverlea"
 
 dm_h1 "Generate archive (civicrm-*-drupal.tar.gz)"
 cd $TRG/..

--- a/distmaker/dists/drupal_sk_php5.sh
+++ b/distmaker/dists/drupal_sk_php5.sh
@@ -25,6 +25,7 @@ dm_install_vendor "$SRC/vendor" "$TRG/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_drupal "$SRC/drupal" "$TRG/drupal"
 dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
+dm_install_cvext riverlea "$TRG/ext/riverlea"
 
 dm_h1 "Prune packages"
 # delete packages that distributions on Drupal.org repalce if present

--- a/distmaker/dists/joomla5_php.sh
+++ b/distmaker/dists/joomla5_php.sh
@@ -25,6 +25,7 @@ dm_install_vendor "$SRC/vendor" "$TRG/vendor"
 rm -rf "$TRG/vendor/psr/log"
 dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
+dm_install_cvext riverlea "$TRG/ext/riverlea"
 
 ## WTF: It's so good we'll install it twice!
 ## (The first is probably extraneous, but there could be bugs dependent on it.)

--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -24,6 +24,7 @@ dm_install_packages "$SRC/packages" "$TRG/packages"
 dm_install_vendor "$SRC/vendor" "$TRG/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
+dm_install_cvext riverlea "$TRG/ext/riverlea"
 
 ## WTF: It's so good we'll install it twice!
 ## (The first is probably extraneous, but there could be bugs dependent on it.)

--- a/distmaker/dists/standalone.sh
+++ b/distmaker/dists/standalone.sh
@@ -22,6 +22,7 @@ dm_install_packages "$SRC/packages" "$TRG/core/packages"
 dm_install_vendor "$SRC/vendor" "$TRG/core/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/core/bower_components"
 dm_install_cvext com.iatspayments.civicrm "$TRG/core/ext/iatspayments"
+dm_install_cvext riverlea "$TRG/core/ext/riverlea"
 "$SRC/tools/standalone/bin/scaffold" "$TRG"
 
 dm_h1 "Generate archive (civicrm-*-standalone.tar.gz)"

--- a/distmaker/dists/wordpress_php5.sh
+++ b/distmaker/dists/wordpress_php5.sh
@@ -25,6 +25,7 @@ dm_install_vendor "$SRC/vendor" "$TRG/civicrm/civicrm/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/civicrm/civicrm/bower_components"
 dm_install_wordpress "$SRC/WordPress" "$TRG/civicrm"
 dm_install_cvext com.iatspayments.civicrm "$TRG/civicrm/civicrm/ext/iatspayments"
+dm_install_cvext riverlea "$TRG/civicrm/civicrm/ext/riverlea"
 
 dm_h1 "Generate archive (civicrm-*-wordpress.zip)"
 cd $TRG


### PR DESCRIPTION
Overview
----------------------------------------
Following [discussion](https://chat.civicrm.org/civicrm/pl/i5hz77r5ab8cxjobzyzz9wcsfw) this packages the most recent release of the RiverLea theme framework extension (https://lab.civicrm.org/extensions/riverlea) during the CiviCRM build process.

Before
----------------------------------------
RiverLea isn't packaged, so needs to be installed manually.

After
----------------------------------------
It is. Anyone can enable RiverLea to try one of its four subthemes/'streams'.

Technical Details
----------------------------------------
RiverLea is a large extension. To better understand it, a good starting point is to look at the GitLab readme, changelog, issues, & PR history.

Comments
----------------------------------------
I am kind of guessing this is the right way to add this, but cannot test.