### PR TITLE
add ability to output iframe.php file to stdout

### DIFF
--- a/ext/iframe/Civi/Api4/Iframe.php
+++ b/ext/iframe/Civi/Api4/Iframe.php
@@ -23,6 +23,20 @@ class Iframe extends BasicEntity {
     };
   }
 
+  public static function renderScript(): AbstractAction {
+    return new class('Iframe', __FUNCTION__) extends AbstractAction {
+
+      public function _run(Result $result) {
+        $iframe = \Civi::service('iframe');
+        $scriptMgr = \Civi::service('iframe.script');
+        $result[] = [
+          'content' => $scriptMgr->render($iframe->getTemplate()),
+        ];
+      }
+
+    };
+  }
+
   public static function permissions(): array {
     return [
       'installScript' => ['administer iframe'],

--- a/ext/iframe/README.md
+++ b/ext/iframe/README.md
@@ -63,9 +63,9 @@ IFRAME Example Page:  https://example.org/iframe.php/civicrm/contribute/transact
 
 * Whenever you edit your template in `Civi/Iframe/EntryPoint/`, the status-check will complain that `iframe.php` is out-of-date and prompt you to re-deploy it.
 
-    (The quickest way to republish is to run `cv api4 Iframe.installScript`)
+    (The quickest way to republish is to run `cv api4 Iframe.installScript` or `cv api4 -I Iframe.RenderScript > /path/to/iframe.php`)
 
-* The D10 template is ore involved. It needs some helper classes. These are in `lib/`.
+* The D10 template is more involved. It needs some helper classes. These are in `lib/`.
 
 * Does this absolutely need to be a separate PHP file in the web-root?  Maybe not; it depends.
     * It has some benefits.  It can use the regular UF bootstrap methods.  The URL is easy to predict and interpret.  It gets high privileges in manipulating the app (e.g.  to configure session options).


### PR DESCRIPTION
Overview
----------------------------------------
Provide an API action for the iframe extension that outputs the iframe.php code to standard out.

Before
----------------------------------------

The only available API action (`Iframe.installScript`) is to save the iframe.php to the expected location in the web root.

However, if you are running CiviCRM with locked down permission that prevents the user that execute the `cv` command from writing to any source directories, the `Iframe.installScript` action will fail. That makes it hard to automate this process.

After
----------------------------------------
With a new API action, `outputScript`, we can run a cv command the sends the contents of the script to standard out, allowing the user that calls the script to save it to the right spot and/or use sudo or any other method to ensure it get's put in the right place.


Comments
----------------------------------------
We still get "[]" output at the end of the `cv` call. I'm not sure how to suppress that, but it's not that hard to handle.
