### PR TITLE
ActionObjectProvider - roll back on throwing error if api entity not recognised

### DIFF
--- a/Civi/Api4/Provider/ActionObjectProvider.php
+++ b/Civi/Api4/Provider/ActionObjectProvider.php
@@ -52,7 +52,22 @@ class ActionObjectProvider extends AutoService implements EventSubscriberInterfa
     if ($apiRequest instanceof AbstractAction) {
       $entityName = $apiRequest->getEntityName();
       if (!isset($this->getEntities()[$entityName])) {
-        throw new \CRM_Core_Exception("Unrecognised entity in Api4 ActionObjectProvider: $entityName");
+        // this certainly seems bad - we're taking an action on an entity that doesn't currently exist
+        //
+        // however some existing behaviours seem to rely on this being possible
+        // @see https://lab.civicrm.org/dev/core/-/issues/5533
+        //
+        // maybe this is reasonable for some kinds of AbstractAction that happen to live
+        // on an entity, but the entity isn't really doing anything (like a static method)?
+        //
+        // for something like DAOEntities, it will definitely fail later when it realises
+        // the entity doesnt exist - and give a more cryptic error message
+        //
+        // unfortunately because the entity doesn't exist we can't check what kind of entity
+        // for now let's just log that something weird is happening
+        //
+        // throw new \CRM_Core_Exception("Unrecognised entity in Api4 ActionObjectProvider: $entityName");
+        \Civi::log()->debug("Unrecognised entity in Api4 ActionObjectProvider: $entityName");
       }
       $event->setApiRequest($apiRequest);
       $event->setApiProvider($this);


### PR DESCRIPTION
Overview
----------------------------------------
Fix for https://lab.civicrm.org/dev/core/-/issues/5533

Before
----------------------------------------
- throw an error when trying to take an action on an entity we dont recognise
- making api calls for entities that dont exist (yet) always throw an error
- calling an api provided by an extension in that extension's own installer crashes

After
----------------------------------------
- dont throw the error
- some api actions will still work, even when the entity doesn't exist yet
- others will fail in diverse ways (e.g. getting DAOEntities gives a cryptic mysql error)
- others might not definitely fail, but could behave unexpected ways?

Comments
----------------------------------------
It doesn't feel great to me to allow this, as I think it might cause some strange bugs. But it is the pre-existing behaviour.

Maybe going forward we could add a flag on a given API action class that allows you to bypass this check. Then in @eileenmcnaughton 's example, the required WMFConfig 's could opt out of the check. But in general we'll catch weird edge cases before they become a problem.
