### PR TITLE
Fix poor quality markup on no events message

### DIFF
--- a/templates/CRM/Event/Page/DashBoard.tpl
+++ b/templates/CRM/Event/Page/DashBoard.tpl
@@ -125,13 +125,9 @@
 {else}
     <br />
     <div class="messages status no-popup">
-        <table>
-            <tr>{icon icon="fa-info-circle"}{/icon}</tr>
-            <tr>
-                {ts}There are no active Events to display.{/ts}
-                {ts 1=$newEventURL}You can <a href="%1">Create a New Event</a> now.{/ts}
-            </tr>
-        </table>
+      {icon icon="fa-info-circle"}{/icon}
+      {ts}There are no active Events to display.{/ts}
+      {ts 1=$newEventURL}You can <a href="%1">Create a New Event</a> now.{/ts}
     </div>
 {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix poor quality markup on no events message.

Before
----------------------------------------
When there are no upcoming events, CiviCRM displays the message "There are no active Events to display. You can Create a New Event now." This message was wrapped in a `<table>` element. However, because the `<tr>` elements did not contain `<td>` elements, browsers actually extracted the text outside of the table. This lead to unintended whitespace below the text, at the bottom of the message. This isn't that obvious on the default theme, but is more obvious on Shoreditch.

<img width="968" alt="Screenshot 2024-10-20 at 16 16 10" src="https://github.com/user-attachments/assets/484f7aa7-72d6-425f-a11a-02601bc03106">


After
----------------------------------------
The table markup is removed. Tables are not used in other messages, and using a table here doesn't really make sense.
