### PR TITLE
dev/core#5541 Prevent generation of numeric hashes

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -161,10 +161,15 @@ WHERE  id IN ( $idString )
     }
 
     if (!$hash) {
-      $hash = md5(uniqid(rand(), TRUE));
-      if ($hashSize) {
-        $hash = substr($hash, 0, $hashSize);
-      }
+      // Ensure we cannot generate numeric hashes
+      // to avoid breaking things elsewhere
+      // See lab issue #5541
+      do {
+        $hash = md5(uniqid(rand(), TRUE));
+        if ($hashSize) {
+          $hash = substr($hash, 0, $hashSize);
+        }
+      } while (is_numeric($hash));
 
       if ($entityType == 'contact') {
         CRM_Core_DAO::setFieldValue('CRM_Contact_DAO_Contact',


### PR DESCRIPTION
Overview
----------------------------------------
This code wraps the hash generation code in `CRM/Contact/BAO/Contact/Utils::generateChecksum` to ensure numeric hashes can never be created. This is to prevent failures elsewhere in the code base, notably `CRM/Mailing/Page/View::run` which uses PHP's `is_numeric()` to check whether or not it should retrieve a mailing's contents via its ID or hash when processing a request for a mailing's public view URL.

Full details in [issue #5541](https://lab.civicrm.org/dev/core/-/issues/5541).

Before
----------------------------------------
Hashes generated by `md5(uniqid(rand(), TRUE))` can produce numeric outputs such as `7571647522317445` or `109002430016e903`.

After
----------------------------------------
Hash generation is wrapped in a do...while loop to ensure any numeric hash is discarded and a new one generated.

Comments
----------------------------------------
This is pretty obviously quick and dirty and I'm completely happy for others to decide it should be done in a more robust manner. Seems to me that the checks in `CRM/Mailing/Page/View.php` could likely be improved too.

I do wonder though how often `is_numeric()` is being used in a similar manner elsewhere in the code.