### PR TITLE
Distmaster: Stop producing two versions of Joomla4 build

### DIFF
--- a/distmaker/distmaker.conf.dist
+++ b/distmaker/distmaker.conf.dist
@@ -29,8 +29,5 @@ DM_REF_PACKAGES=${DM_REF_CORE}
 ## Keep the existing dependencies
 # DM_KEEP_DEPS=1
 
-## Don't build Joomla's alt. Useful if you're frequently rebuilding Joomla for dev-test process.
-# DM_SKIP_ALT=1
-
 ## Don't download external extensions
 # DM_SKIP_EXT=1

--- a/distmaker/distmaker.sh
+++ b/distmaker/distmaker.sh
@@ -39,7 +39,7 @@ BPACK=0
 D7PACK=0
 D7DIR=0
 J4PACK=0
-J5PACKBC=0
+J5BCPACK=0
 WPPACK=0
 PATCHPACK=0
 SKPACK=0
@@ -188,7 +188,7 @@ case $1 in
   # JOOMLA5BC
   j5bc|Joomla5bc)
   dm_note "Enable CiviCRM-Joomla 5 requiring Back Compatibility plugin"
-  J5PACKBC=1
+  J5BCPACK=1
   ;;
 
   # WORDPRESS
@@ -304,7 +304,7 @@ if [ "$J4PACK" = 1 ]; then
   bash $P/dists/joomla4.sh
 fi
 
-if [ "$J5PACKBC" = 1 ]; then
+if [ "$J5BCPACK" = 1 ]; then
   dm_title "Build CiviCRM-Joomla 5 (Back Compatibility)"
   dm_git_checkout "$DM_SOURCEDIR/joomla" "$DM_REF_JOOMLA"
   bash $P/dists/joomla5bc.sh

--- a/distmaker/dists/joomla4.sh
+++ b/distmaker/dists/joomla4.sh
@@ -13,6 +13,7 @@ fi
 
 SRC=$DM_SOURCEDIR
 TRG=$DM_TMPDIR/civicrm
+JPKG=$DM_TMPDIR/com_civicrm
 
 dm_h1 "Prepare files (civicrm-*-joomla.zip)"
 dm_reset_dirs "$TRG" "$DM_TMPDIR/com_civicrm"
@@ -25,22 +26,20 @@ dm_install_vendor "$SRC/vendor" "$TRG/vendor"
 dm_install_bower "$SRC/bower_components" "$TRG/bower_components"
 dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
 
-## WTF: It's so good we'll install it twice!
-## (The first is probably extraneous, but there could be bugs dependent on it.)
+## Different parts of the repo need to appear in different places
+## It's small so just duplicate the files for now.
 dm_install_joomla "$SRC/joomla" "$TRG/joomla"
-dm_install_joomla "$SRC/joomla" "$DM_TMPDIR/com_civicrm"
+dm_install_joomla "$SRC/joomla" "$JPKG"
 
 ## joomla 3.0 likes admin.civicrm.php to be called civicrm.php; keep both names
-cp "$SRC/joomla/admin/admin.civicrm.php" "$DM_TMPDIR/com_civicrm/admin/civicrm.php"
+cp "$JPKG/admin/admin.civicrm.php" "$JPKG/admin/civicrm.php"
 
 # gen zip file
+mv "$TRG" "$JPKG/admin/civicrm"
 cd $DM_TMPDIR;
-
-cp -R -p civicrm com_civicrm/admin/civicrm
+## generate the civicrm.xml (files in package) and access.xml (permissions)
 ${DM_PHP:-php} $DM_SOURCEDIR/distmaker/utils/joomlaxml.php $DM_SOURCEDIR com_civicrm $DM_VERSION alt
 dm_zip $DM_TARGETDIR/civicrm-$DM_VERSION-joomla.zip com_civicrm
-rm -rf com_civicrm/admin/civicrm
 
 # clean up
-rm -rf com_civicrm
-rm -rf $TRG
+rm -rf "$JPKG"

--- a/distmaker/dists/joomla4.sh
+++ b/distmaker/dists/joomla4.sh
@@ -36,18 +36,10 @@ cp "$SRC/joomla/admin/admin.civicrm.php" "$DM_TMPDIR/com_civicrm/admin/civicrm.p
 # gen zip file
 cd $DM_TMPDIR;
 
-# generate alt version of package
-if [ -z "$DM_SKIP_ALT" ]; then
-  cp -R -p civicrm com_civicrm/admin/civicrm
-  ${DM_PHP:-php} $DM_SOURCEDIR/distmaker/utils/joomlaxml.php $DM_SOURCEDIR com_civicrm $DM_VERSION alt
-  dm_zip $DM_TARGETDIR/civicrm-$DM_VERSION-joomla-alt.zip com_civicrm
-  rm -rf com_civicrm/admin/civicrm
-fi
-
-# generate zip version of civicrm.xml
-${DM_PHP:-php} $DM_SOURCEDIR/distmaker/utils/joomlaxml.php $DM_SOURCEDIR com_civicrm $DM_VERSION zip
-dm_zip com_civicrm/admin/civicrm.zip civicrm
-dm_zip $DM_TARGETDIR/civicrm-$DM_VERSION-joomla.zip com_civicrm -x 'com_civicrm/admin/civicrm'
+cp -R -p civicrm com_civicrm/admin/civicrm
+${DM_PHP:-php} $DM_SOURCEDIR/distmaker/utils/joomlaxml.php $DM_SOURCEDIR com_civicrm $DM_VERSION alt
+dm_zip $DM_TARGETDIR/civicrm-$DM_VERSION-joomla.zip com_civicrm
+rm -rf com_civicrm/admin/civicrm
 
 # clean up
 rm -rf com_civicrm


### PR DESCRIPTION
Overview
----------------------------------------
Historically we have produced a 'joomla' and 'joomla-alt' packages.  The 'joomla' version has a zip file within a zip file, the 'alt' version has the same files but directly in the main zip file. The [docs](https://docs.civicrm.org/installation/en/latest/joomla/#installer) suggest using the 'joomla' version and to use the 'joomla-alt' version if the webserver does not have the zip enabled within zip.

After some [discussion](https://lab.civicrm.org/dev/joomla/-/issues/54#note_164744), the agreed approach was to stop producing two versions and have all the files in the main zip.  In other words to keep the 'alt' approach and rename it as 'joomla'

This changed implements that.


Before
----------------------------------------
'joomla' and 'joomla-alt' builds

After
----------------------------------------
'joomla' build using the approach of the 'joomla-alt' build

Technical Details
----------------------------------------
~~This includes the changes of https://github.com/civicrm/civicrm-core/pull/31325    I will rebase this once the other is merged.~~
Now rebased after merger of 31325 

Comments
----------------------------------------
Note there is a separate 'joomla5' build that is not changed by this PR although there are some improvements to the dist script in line with the 'joomla' changes.
