### PR TITLE
Add TIMESTAMPDIFF function to searchkit so you can show time between two dates

### DIFF
--- a/Civi/Api4/Query/SqlExpression.php
+++ b/Civi/Api4/Query/SqlExpression.php
@@ -238,8 +238,8 @@ abstract class SqlExpression {
    */
   protected function captureKeyword($keywords, &$arg) {
     foreach (array_filter($keywords, 'strlen') as $key) {
-      // Match keyword followed by a space or eol
-      if (strpos($arg, $key . ' ') === 0 || rtrim($arg) === $key) {
+      // Match keyword followed by a space or comma or eol
+      if (str_starts_with($arg, $key . ' ') || str_starts_with($arg, $key . ',') || rtrim($arg) === $key) {
         $arg = ltrim(substr($arg, strlen($key)));
         return $key;
       }

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -229,6 +229,7 @@ abstract class SqlFunction extends SqlExpression {
       ];
       if (!$param['max_expr']) {
         $param['must_be'] = [];
+        $param['min_expr'] = 0;
       }
       $params[] = $param;
     }

--- a/Civi/Api4/Query/SqlFunctionTIMESTAMPDIFF.php
+++ b/Civi/Api4/Query/SqlFunctionTIMESTAMPDIFF.php
@@ -1,0 +1,89 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Sql function
+ */
+class SqlFunctionTIMESTAMPDIFF extends SqlFunction {
+
+  protected static $category = self::CATEGORY_DATE;
+
+  protected static $dataType = 'Integer';
+
+  protected static function params(): array {
+    /* This produces:
+     * SELECT `a`.`id` AS `id`, `a`.`description` AS `description`, `a`.`is_active` AS `is_active`, `a`.`last_run_end` AS `last_run_end`,
+     * TIMESTAMPDIFF(SECOND `a`.`last_run` , `a`.`last_run`, `a`.`last_run_end`) AS `TIMESTAMPDIFF_last_run_last_run_last_run_end`
+     *
+     * But we need eg. TIMESTAMPDIFF(SECOND, `a`.`last_run`, `a`.`last_run_end`)
+     */
+    return [
+      [
+        'label' => ts('Unit'),
+        'must_be' => ['SqlString'], // This is wrong, it's not a string but a parameter but that doesn't seem to be an option in Civi\Api4\Query\SqlExpression
+        'expr' => [
+          'MICROSECOND' => ts('Microseconds'),
+          'SECOND' => ts('Seconds'),
+          'MINUTE' => ts('Minutes'),
+          'HOUR' => ts('Hours'),
+          'DAY' => ts('Days'),
+          'WEEK' => ts('Weeks'),
+          'MONTH' => ts('Months'),
+          'QUARTER' => ts('Quarters'),
+          'YEAR' => ts('Years'),
+        ],
+        'max_expr' => 1,
+        'optional' => FALSE,
+      ],
+      [
+        'must_be' => ['SqlField'],
+        'max_expr' => 1,
+        'min_expr' => 1,
+        'optional' => FALSE,
+        'label' => ts('diff 1'),
+      ],
+      [
+        'must_be' => ['SqlField'],
+        'max_expr' => 1,
+        'min_expr' => 1,
+        'optional' => FALSE,
+        'label' => ts('diff 2'),
+      ],
+    ];
+  }
+
+  /**
+   * @return string
+   */
+  public static function getTitle(): string {
+    return ts('Time between two dates');
+  }
+
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('Time between two dates.');
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public static function renderExpression(string $output): string {
+    // As we set 'must_be' => ['SqlString'] above we need to remove the quotes from around the "SECOND", "HOUR" etc
+    // to get a valid SQL expression
+    $output = str_replace('"', '', $output);
+    return "TIMESTAMPDIFF($output)";
+  }
+
+}

--- a/Civi/Api4/Query/SqlFunctionTIMESTAMPDIFF.php
+++ b/Civi/Api4/Query/SqlFunctionTIMESTAMPDIFF.php
@@ -21,17 +21,10 @@ class SqlFunctionTIMESTAMPDIFF extends SqlFunction {
   protected static $dataType = 'Integer';
 
   protected static function params(): array {
-    /* This produces:
-     * SELECT `a`.`id` AS `id`, `a`.`description` AS `description`, `a`.`is_active` AS `is_active`, `a`.`last_run_end` AS `last_run_end`,
-     * TIMESTAMPDIFF(SECOND `a`.`last_run` , `a`.`last_run`, `a`.`last_run_end`) AS `TIMESTAMPDIFF_last_run_last_run_last_run_end`
-     *
-     * But we need eg. TIMESTAMPDIFF(SECOND, `a`.`last_run`, `a`.`last_run_end`)
-     */
     return [
       [
         'label' => ts('Unit'),
-        'must_be' => ['SqlString'], // This is wrong, it's not a string but a parameter but that doesn't seem to be an option in Civi\Api4\Query\SqlExpression
-        'expr' => [
+        'flag_before' => [
           'MICROSECOND' => ts('Microseconds'),
           'SECOND' => ts('Seconds'),
           'MINUTE' => ts('Minutes'),
@@ -42,22 +35,14 @@ class SqlFunctionTIMESTAMPDIFF extends SqlFunction {
           'QUARTER' => ts('Quarters'),
           'YEAR' => ts('Years'),
         ],
-        'max_expr' => 1,
+        'max_expr' => 0,
         'optional' => FALSE,
       ],
       [
-        'must_be' => ['SqlField'],
-        'max_expr' => 1,
-        'min_expr' => 1,
+        'max_expr' => 2,
+        'min_expr' => 2,
         'optional' => FALSE,
-        'label' => ts('diff 1'),
-      ],
-      [
-        'must_be' => ['SqlField'],
-        'max_expr' => 1,
-        'min_expr' => 1,
-        'optional' => FALSE,
-        'label' => ts('diff 2'),
+        'label' => ts('diff'),
       ],
     ];
   }
@@ -73,17 +58,7 @@ class SqlFunctionTIMESTAMPDIFF extends SqlFunction {
    * @return string
    */
   public static function getDescription(): string {
-    return ts('Time between two dates.');
-  }
-
-  /**
-   * @inheritDoc
-   */
-  public static function renderExpression(string $output): string {
-    // As we set 'must_be' => ['SqlString'] above we need to remove the quotes from around the "SECOND", "HOUR" etc
-    // to get a valid SQL expression
-    $output = str_replace('"', '', $output);
-    return "TIMESTAMPDIFF($output)";
+    return ts('Number of minutes, hours, days, etc. between two dates.');
   }
 
 }

--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -250,7 +250,7 @@
         function getKeyword(whitelist) {
           var keyword;
           _.each(_.filter(whitelist), function(flag) {
-            if (argString.indexOf(flag + ' ') === 0 || argString === flag) {
+            if (argString.indexOf(flag + ' ') === 0 || argString.indexOf(flag + ',') === 0 || argString === flag) {
               keyword = flag;
               argString = _.trim(argString.substr(flag.length));
               return false;
@@ -310,6 +310,8 @@
               value: '',
               flag_before: flagBefore
             });
+            // Tee up the next param
+            getKeyword([',']);
           }
         });
         if (!info.data_type && info.args.length) {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -210,8 +210,11 @@
             const value = arg.value === undefined ? '' : arg.value;
             const prefix = arg.flag_before || arg.name ? (index ? ' ' : '') + (arg.flag_before || arg.name) + (value === '' ? '' : ' ') : (index ? ', ' : '');
             const suffix = arg.flag_after ? ' ' + arg.flag_after : '';
-
-            return prefix + (arg.type === 'string' || value === '' ? JSON.stringify(value) : value) + suffix;
+            let content = '';
+            if (ctrl.getParam(index).max_expr) {
+              content = (arg.type === 'string' || value === '' ? JSON.stringify(value) : value);
+            }
+            return prefix + content + suffix;
           });
           // Replace fake function "e"
           ctrl.expr = (ctrl.fnName === 'e' ? '' : ctrl.fnName) + '(';

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -234,8 +234,7 @@ class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
       ->addSelect('IFNULL(duration, 2) AS ifnull_duration_2')
       ->addSelect('created_date')
       ->addSelect('activity_date_time')
-      // SECOND in quotes is wrong because it's not a string, but hacked it for now because we specified as type SqlString...
-      ->addSelect('TIMESTAMPDIFF("SECOND", created_date, activity_date_time) AS time_diff')
+      ->addSelect('TIMESTAMPDIFF(SECOND, created_date, activity_date_time) AS time_diff')
       ->addOrderBy('id')
       ->execute()->indexBy('id');
 

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -213,10 +213,11 @@ class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
       ->addValue('first_name', 'hello')
       ->execute()->first()['id'];
     $sampleData = [
-      ['subject' => 'abc', 'activity_type_id:name' => 'Meeting', 'source_contact_id' => $cid, 'duration' => 123, 'location' => 'abc'],
-      ['subject' => 'xyz', 'activity_type_id:name' => 'Meeting', 'source_contact_id' => $cid, 'location' => 'abc', 'is_deleted' => 1],
-      ['subject' => 'def', 'activity_type_id:name' => 'Meeting', 'source_contact_id' => $cid, 'duration' => 456, 'location' => 'abc'],
+      ['subject' => 'abc', 'activity_type_id:name' => 'Meeting', 'source_contact_id' => $cid, 'duration' => 123, 'location' => 'abc', 'activity_date_time' => '2025-02-01 01:00:00'],
+      ['subject' => 'xyz', 'activity_type_id:name' => 'Meeting', 'source_contact_id' => $cid, 'location' => 'abc', 'is_deleted' => 1, 'activity_date_time' => '2025-02-01 01:00:03'],
+      ['subject' => 'def', 'activity_type_id:name' => 'Meeting', 'source_contact_id' => $cid, 'duration' => 456, 'location' => 'abc', 'activity_date_time' => '2025-02-01 03:00:00'],
     ];
+
     $aids = Activity::save(FALSE)
       ->setRecords($sampleData)
       ->execute()->column('id');
@@ -231,6 +232,10 @@ class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
       ->addSelect('LEAST(duration, 300) AS least_of_duration_and_300')
       ->addSelect('ISNULL(duration) AS duration_isnull')
       ->addSelect('IFNULL(duration, 2) AS ifnull_duration_2')
+      ->addSelect('created_date')
+      ->addSelect('activity_date_time')
+      // SECOND in quotes is wrong because it's not a string, but hacked it for now because we specified as type SqlString...
+      ->addSelect('TIMESTAMPDIFF("SECOND", created_date, activity_date_time) AS time_diff')
       ->addOrderBy('id')
       ->execute()->indexBy('id');
 
@@ -266,6 +271,15 @@ class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals(123, $result[$aids[0]]['ifnull_duration_2']);
     $this->assertEquals(2, $result[$aids[1]]['ifnull_duration_2']);
     $this->assertEquals(456, $result[$aids[2]]['ifnull_duration_2']);
+
+    // Calculate expected TIMESTAMPDIFF
+    foreach ($aids as $aid) {
+      // Calculate difference between created_date and activity_date_time
+      $origin = new \DateTimeImmutable($result[$aid]['created_date']);
+      $target = new \DateTimeImmutable($result[$aid]['activity_date_time']);
+      $diffInSeconds = $target->getTimestamp() - $origin->getTimestamp();
+      $this->assertEquals($diffInSeconds, $result[$aid]['time_diff']);
+    }
   }
 
   public function testStringFunctions(): void {


### PR DESCRIPTION
Overview
----------------------------------------
For example, for scheduled jobs you can show number of seconds it took to run by using "Time between two dates" for `last_run` and `last_run_end`.

Before
----------------------------------------
Cannot show time between two dates (can already show days using "Days between two dates" but that's not the same).

After
----------------------------------------
Can show time between two dates (eg. seconds).

Technical Details
----------------------------------------
Uses the SQL function `TIMESTAMPDIFF` which takes 3 parameters - the format, eg. SECONDS, MINUTES etc. and then the two date fields.

Comments
----------------------------------------
@colemanw I couldn't work out how to get the first field to work properly as a dropdown selector and have temporarily added a hacky `renderExpression()` to fix the query and make it work.
But I'm assuming there's a better way to define it in `params()` so that param1=dropdown selector for SECONDS,MINUTES etc. and then param2 is the actual field and param3 is the field to compare.
