### PR TITLE
SearchDisplay rewrites: don't truncate long field keys

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -325,7 +325,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       // Convert dots to nested arrays which are more Smarty-friendly
       foreach ($data as $key => $value) {
         $parent = &$vars;
-        $allKeys = $keys = array_map('CRM_Utils_String::munge', explode('.', $key));
+        $allKeys = $keys = array_map(fn($s) => \CRM_Utils_String::munge($s, '_', 0), explode('.', $key));
         while (count($keys) > 1) {
           $level = array_shift($keys);
           $parent[$level] = $parent[$level] ?? [];


### PR DESCRIPTION
Overview
----------------------------------------
SearchKit creates a unique key for each selected column. Sometimes these are short (`start_date`), but they can also get quite long (`GROUP_CONCAT_Eck_Contract_Role_entity_id_01_contact_id_display_name_Eck_Contract_Role_entity_id_01_contact_id_sort_name`). These keys are used as token names in SearchDisplays -- for example, when you choose to "Rewrite Text" or "Rewrite HTML" for a field. However, because of the way a particular munging function is called, the keys get truncated, causing token rendering to fail for some long key names. This PR corrects the issue.

Before
----------------------------------------
Some SearchDisplay field tokens with long keys failed to render. 

After
----------------------------------------
SearchDisplay tokens render.

Comments
----------------------------------------
Happy to add a test if @colemanw agrees with the approach here.