### PR TITLE
Api3 Setting.revert - dont swallow errors, fix one reverting constant settings

### DIFF
--- a/api/v3/Setting.php
+++ b/api/v3/Setting.php
@@ -156,6 +156,7 @@ function civicrm_api3_setting_revert($params) {
   $fields = $fields['values'];
   $domains = _civicrm_api3_setting_getDomainArray($params);
   $result = [];
+  $isError = FALSE;
   foreach ($domains as $domainID) {
     $valuesToRevert = array_intersect_key($defaults['values'][$domainID], $fields);
     if (!empty($valuesToRevert)) {
@@ -163,7 +164,14 @@ function civicrm_api3_setting_revert($params) {
       $valuesToRevert['domain_id'] = $domainID;
       // note that I haven't looked at how the result would appear with multiple domains in play
       $result = array_merge($result, civicrm_api('Setting', 'create', $valuesToRevert));
+      if ($result['is_error'] ?? FALSE) {
+        $isError = TRUE;
+      }
     }
+  }
+
+  if ($isError) {
+    return civicrm_api3_create_error('Error reverting settings');
   }
 
   return civicrm_api3_create_success($result, $params, 'Setting', 'revert');

--- a/api/v3/Setting.php
+++ b/api/v3/Setting.php
@@ -152,13 +152,17 @@ function civicrm_api3_setting_getoptions($params) {
  */
 function civicrm_api3_setting_revert($params) {
   $defaults = civicrm_api('Setting', 'getdefaults', $params);
-  $fields = civicrm_api('Setting', 'getfields', $params);
-  $fields = $fields['values'];
+  $allSettings = civicrm_api('Setting', 'getfields', $params)['values'] ?? [];
+  // constant settings can't be set through the API, so can't be reverted
+  // so we must filter them out here
+  $revertable = array_filter($allSettings, function ($settingMeta) {
+    return !($settingMeta['is_constant'] ?? FALSE);
+  });
   $domains = _civicrm_api3_setting_getDomainArray($params);
   $result = [];
   $isError = FALSE;
   foreach ($domains as $domainID) {
-    $valuesToRevert = array_intersect_key($defaults['values'][$domainID], $fields);
+    $valuesToRevert = array_intersect_key($defaults['values'][$domainID], $revertable);
     if (!empty($valuesToRevert)) {
       $valuesToRevert['version'] = $params['version'];
       $valuesToRevert['domain_id'] = $domainID;


### PR DESCRIPTION
Overview
----------------------------------------
`SettingsTest::testRevertAll` should be failing, because the underlying Setting.revert call isn't working. However it isn't because the api3 implementation swallows errors in the sub calls.

Before
----------------------------------------
- Api3 Setting.revert swallows errors in the sub-calls it makes to update settings value to defaults
- Api3 Setting.revert fails because it's trying to reset constants, which can't be set through the API

After
----------------------------------------
- Api3 Setting.revert throws up any errors in the sub-calls it makes to update settings value to defaults
- Api3 Setting.revert fixed because settings with `is_constant` are excluded
