### PR TITLE
SettingsManager::bootSettings - derive $civicrm_root global if not set

### DIFF
--- a/Civi/Core/SettingsManager.php
+++ b/Civi/Core/SettingsManager.php
@@ -487,6 +487,13 @@ class SettingsManager {
       // TODO: should we complain here if there are inconsistent defines
       // from elsewhere?
     }
+
+    // if in doubt, the root of civicrm-core is 3 steps
+    // up from this file
+    global $civicrm_root;
+    if (!$civicrm_root) {
+      $civicrm_root = dirname(__FILE__, 3) . DIRECTORY_SEPARATOR;
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Derive a value for $civicrm_root, so we don't have to set it explicitly.

Before
----------------------------------------
- $civicrm_root global must always be set in `civicrm.settings.php`

After
----------------------------------------
- if using `SettingsManager::bootSettings` the correct value for $civicrm_root will be derived if it has not been set explicitly in `civicrm.settings.php`