### PR TITLE
Make 'on_delete' accessible in DAO fields

### DIFF
--- a/CRM/Core/DAO/Base.php
+++ b/CRM/Core/DAO/Base.php
@@ -195,6 +195,9 @@ abstract class CRM_Core_DAO_Base extends CRM_Core_DAO {
           $field['DFKEntityColumn'] = $fieldSpec['entity_reference']['dynamic_entity'];
         }
         $field['FKColumnName'] = $fieldSpec['entity_reference']['key'] ?? 'id';
+        if (isset($fieldSpec['entity_reference']['on_delete'])) {
+          $field['FKOnDelete'] = $fieldSpec['entity_reference']['on_delete'];
+        }
       }
       if (!empty($fieldSpec['component'])) {
         $field['component'] = $fieldSpec['component'];


### PR DESCRIPTION
Overview
----------------------------------------
I've written a bit of code to generate "ALTER TABLE" statements for missing foreign keys which hopefully I'll try and PR at some point. However, I hit a problem that I couldn't get the "ON DELETE" parameter using the schema functions.

I did this:
```
    $entities = \CRM_Core_DAO_AllCoreTables::getEntities();
    // Get the information about all the fields
    foreach ($entities as $entity) {
      if (is_callable([$entity['class'], 'fields'])) {
        $entityFields[$entity['class']::getTableName()] = $entity['class']::fields();
      }
    }
```
`fields()` gave me `FKClassName` and `FKColumnName` but the `on_delete` is ignored and not accessible. I couldn't find any other way to retrieve the schema that would contain it either.

Before
----------------------------------------
Cannot access FK on_delete.

After
----------------------------------------
Can access via schema functions.

Technical Details
----------------------------------------
This just parses it in as another key in the fields array.

Comments
----------------------------------------
@colemanw @totten you've done a load of work on the schema functions recently so don't know if I'm doing the right thing here?
