### PR TITLE
Api4 - Fix date format metadata

### DIFF
--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -150,7 +150,7 @@ class SpecFormatter {
     if (in_array($inputType, ['Select', 'EntityRef'], TRUE) && !empty($data['serialize'])) {
       $inputAttrs['multiple'] = TRUE;
     }
-    if ($inputType == 'Date' && !empty($inputAttrs['formatType'])) {
+    if ($inputType == 'Date' && !empty($inputAttrs['format_type'])) {
       self::setLegacyDateFormat($inputAttrs);
     }
     if ($inputType == 'Text' && !empty($data['maxlength'])) {
@@ -169,13 +169,13 @@ class SpecFormatter {
    * @param array $inputAttrs
    */
   private static function setLegacyDateFormat(&$inputAttrs) {
-    if (empty(\Civi::$statics['legacyDatePrefs'][$inputAttrs['formatType']])) {
-      \Civi::$statics['legacyDatePrefs'][$inputAttrs['formatType']] = [];
-      $params = ['name' => $inputAttrs['formatType']];
-      \CRM_Core_DAO::commonRetrieve('CRM_Core_DAO_PreferencesDate', $params, \Civi::$statics['legacyDatePrefs'][$inputAttrs['formatType']]);
+    if (empty(\Civi::$statics['legacyDatePrefs'][$inputAttrs['format_type']])) {
+      \Civi::$statics['legacyDatePrefs'][$inputAttrs['format_type']] = [];
+      $params = ['name' => $inputAttrs['format_type']];
+      \CRM_Core_DAO::commonRetrieve('CRM_Core_DAO_PreferencesDate', $params, \Civi::$statics['legacyDatePrefs'][$inputAttrs['format_type']]);
     }
-    $dateFormat = \Civi::$statics['legacyDatePrefs'][$inputAttrs['formatType']];
-    unset($inputAttrs['formatType']);
+    $dateFormat = \Civi::$statics['legacyDatePrefs'][$inputAttrs['format_type']];
+    unset($inputAttrs['format_type']);
     $inputAttrs['time'] = !empty($dateFormat['time_format']);
     $inputAttrs['date'] = TRUE;
     $inputAttrs['start_date_years'] = (int) $dateFormat['start'];

--- a/tests/phpunit/api/v4/Action/GetFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetFieldsTest.php
@@ -86,6 +86,11 @@ class GetFieldsTest extends Api4TestBase implements TransactionalInterface {
 
     $this->assertSame('contact_type', $fields['contact_sub_type']['input_attrs']['control_field']);
     $this->assertTrue($fields['contact_sub_type']['input_attrs']['multiple']);
+
+    // Check date format
+    $this->assertTrue($fields['birth_date']['input_attrs']['date']);
+    $this->assertFalse($fields['birth_date']['input_attrs']['time']);
+    $this->assertArrayNotHasKey('format_type', $fields['birth_date']['input_attrs']);
   }
 
   public function testComponentFields(): void {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://civicrm.stackexchange.com/questions/48701/birth-date-insists-on-time-in-formbuilder

Before
----------------------------------------
In Formbuilder, add contact Birth Date to the form.
The field requires "Time" input, which cannot be deselected.

After
----------------------------------------
Date fields correctly rendered.

Technical Details
-------
This regressed during the transition to entityType.php files