### PR TITLE
Membership User Dashboard.tpl adding Recurring links and cleanup

### DIFF
--- a/CRM/Member/Page/UserDashboard.php
+++ b/CRM/Member/Page/UserDashboard.php
@@ -65,8 +65,54 @@ class CRM_Member_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBoard 
     $activeMembers = CRM_Member_BAO_Membership::activeMembers($membership);
     $inActiveMembers = CRM_Member_BAO_Membership::activeMembers($membership, 'inactive');
 
+    // Add Recurring Links (if allowed)
+    $this->buildMemberLinks($activeMembers);
+    $this->buildMemberLinks($inActiveMembers);
+
     $this->assign('activeMembers', $activeMembers);
     $this->assign('inActiveMembers', $inActiveMembers);
+
+  }
+
+  /**
+   * Helper function to build appropriate Member links
+   */
+  public function buildMemberLinks(&$members) {
+    if (!empty($members)) {
+      foreach($members as $id => &$member) {
+        if (empty($member['contribution_recur_id'])) {
+          continue;
+        }
+
+        $paymentProcessor = NULL;
+        try {
+          $contributionRecur = \Civi\Api4\ContributionRecur::get(FALSE)
+            ->addSelect('payment_processor_id')
+            ->addWhere('id', '=', $member['contribution_recur_id'])
+            ->execute()
+            ->first();
+
+          if (!empty($contributionRecur['payment_processor_id'])) {
+            $paymentProcessor = \Civi\Api4\PaymentProcessor::get(FALSE)
+              ->addWhere('id', '=', $contributionRecur['payment_processor_id'])
+              ->execute()
+              ->first();
+          }
+        }
+        catch(Exception $e) {
+          Civi::log()->warning('Member/UserDashboard: Unable to retrieve recur information '.$e->getMessage());
+          continue;
+        }
+
+        if (!empty($paymentProcessor)) {
+          $paymentObject = Civi\Payment\System::singleton()->getByProcessor($paymentProcessor);
+          $member['cancelSubscriptionUrl'] = $paymentObject->subscriptionURL($member['membership_id'], 'membership', 'cancel');
+          $member['updateSubscriptionBillingUrl'] = $paymentObject->subscriptionURL($member['membership_id'], 'membership', 'billing');
+          $member['updateSubscriptionUrl'] = $paymentObject->subscriptionURL($member['membership_id'], 'membership', 'update');
+        }
+      }
+    }
+
   }
 
   /**

--- a/CRM/Member/Page/UserDashboard.php
+++ b/CRM/Member/Page/UserDashboard.php
@@ -79,7 +79,7 @@ class CRM_Member_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBoard 
    */
   public function buildMemberLinks(&$members) {
     if (!empty($members)) {
-      foreach($members as $id => &$member) {
+      foreach ($members as $id => &$member) {
         if (empty($member['contribution_recur_id'])) {
           continue;
         }
@@ -99,8 +99,8 @@ class CRM_Member_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBoard 
               ->first();
           }
         }
-        catch(Exception $e) {
-          Civi::log()->warning('Member/UserDashboard: Unable to retrieve recur information '.$e->getMessage());
+        catch (Exception $e) {
+          Civi::log()->warning('Member/UserDashboard: Unable to retrieve recur information ' . $e->getMessage());
           continue;
         }
 

--- a/templates/CRM/Member/Page/UserDashboard.tpl
+++ b/templates/CRM/Member/Page/UserDashboard.tpl
@@ -30,7 +30,14 @@
           <td class="crm-active-membership-start_date">{$activeMember.start_date|crmDate}</td>
           <td class="crm-active-membership-end_date">{$activeMember.end_date|crmDate}</td>
           <td class="crm-active-membership-status">{$activeMember.status}</td>
-          <td class="crm-active-membership-renew">{if $activeMember.renewPageId}<a href="{crmURL p='civicrm/contribute/transact' q="id=`$activeMember.renewPageId`&mid=`$activeMember.id`&reset=1"}">[ {ts}Renew Now{/ts} ]</a>{/if}</td>
+          {if ($activeMember.status !== 'Current' AND $activeMember.status !== 'Cancelled') OR !empty($activeMember.cancelSubscriptionUrl) OR !empty($activeMember.updateSubscriptionBillingUrl) OR !empty($activeMember.updateSubscriptionURL)}
+            <td class="crm-active-membership-renew">
+              {if $activeMember.status !== 'Current' AND $activeMember.status !== 'Cancelled'}<a href="{crmURL p='civicrm/contribute/transact' q="id=`$activeMember.renewPageId`&mid=`$activeMember.id`&reset=1"}" class="button"><span class="nowrap">{ts}Renew Now{/ts}</span></a>{/if}
+              {if !empty($activeMember.cancelSubscriptionUrl)}<a href="{$activeMember.cancelSubscriptionUrl}" class="button"><span class="nowrap">{ts}Cancel Subscription{/ts}</span></a>{/if}
+              {if !empty($activeMember.updateSubscriptionBillingUrl)}<a href="{$activeMember.updateSubscriptionBillingUrl}" class="button"><span class="nowrap">{ts}Update Billing Information{/ts}</span></a>{/if}
+              {if !empty($activeMember.updateSubscriptionUrl)}<a href="{$activeMember.updateSubscriptionUrl}" class="button"><span class="nowrap">{ts}Chnage Subscription Amount{/ts}</span></a>{/if}
+            </td>
+          {/if}
         </tr>
         {/foreach}
         </table>
@@ -60,6 +67,14 @@
           <td class="crm-inactive-membership-start_date">{$inActiveMember.start_date|crmDate}</td>
           <td class="crm-inactive-membership-end_date">{$inActiveMember.end_date|crmDate}</td>
           <td class="crm-inactive-membership-status">{$inActiveMember.status}</td>
+          {if $inActiveMember.status == 'Expired' OR !empty($activeMember.cancelSubscriptionUrl) OR !empty($activeMember.updateSubscriptionBillingUrl) OR !empty($activeMember.updateSubscriptionURL)}
+            <td class="crm-active-membership-renew">
+              {if $inActiveMember.status == 'Expired'}<a href="{crmURL p='civicrm/contribute/transact' q="id=`$inActiveMember.renewPageId`&mid=`$inActiveMember.id`&reset=1"}" class="button"><span class="nowrap">{ts}Renew Now{/ts}</span></a>{/if}
+              {if !empty($inActiveMember.cancelSubscriptionUrl)}<a href="{$inActiveMember.cancelSubscriptionUrl}" class="button"><span class="nowrap">{ts}Cancel Subscription{/ts}</span></a>{/if}
+              {if !empty($inActiveMember.updateSubscriptionBillingUrl)}<a href="{$inActiveMember.updateSubscriptionBillingUrl}" class="button"><span class="nowrap">{ts}Update Billing Information{/ts}</span></a>{/if}
+              {if !empty($inActiveMember.updateSubscriptionUrl)}<a href="{$inActiveMember.updateSubscriptionUrl}" class="button"><span class="nowrap">{ts}Chnage Subscription Amount{/ts}</span></a>{/if}
+            </td>
+          {/if}
           <td class="crm-inactive-membership-renew">{if $inActiveMember.renewPageId}<a href="{crmURL p='civicrm/contribute/transact' q="id=`$inActiveMember.renewPageId`&mid=`$inActiveMember.id`&reset=1"}">[ {ts}Renew Now{/ts} ]</a>{/if}</td>
         </tr>
         {/foreach}


### PR DESCRIPTION
Overview
----------------------------------------
In order to improve the UX experience for people on the User Dashboard I wanted to add the Recurring links (Cancel Subscription, Update Billing, and Update Recurring Amount). These are normally available in a Contribution email, but while useful I felt it would be good that we include them also in the dashboard.

As well, I have a few folks confused about the `Renew Now` link as it implies that the Membership needs to be renewed and appears _even_ when the Membership is Active and not in Grace. So I wanted to change that around a bit.

Finally, I standardized all the buttons to the same format as the rest of the buttons to be consistent.

Before
----------------------------------------
![Selection_023](https://github.com/user-attachments/assets/f4e6b87e-e31a-454b-8404-fb55f280a895)


After
----------------------------------------
![Selection_022](https://github.com/user-attachments/assets/88f2f1f7-66ae-4bac-92d8-ea1dacfe5d45)

![Selection_024](https://github.com/user-attachments/assets/2b23f066-b9fa-41bb-a408-cd69bb0fd6ce)



Comments
----------------------------------------
+ Not sure if the way that I am "checking" the status to display the `Renew Now` is correct, but I'm happy to change that if need be
+ If people think we should add an icon I'm happy to add one as well for easier identification