### PR TITLE
[Afform] Relative date not converted

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -662,7 +662,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     foreach ($entityWeights as $entityName) {
       $entityType = $this->_formDataModel->getEntity($entityName)['type'];
       $records = $this->replaceReferences($entityName, $entityValues[$entityName]);
-      $records = $this->replaceRelativeDates($entityName, $entityValues[$entityName]);
+      $records = $this->replaceRelativeDates($records);
       $this->fillIdFields($records, $entityName);
       $event = new AfformSubmitEvent($this->_afform, $this->_formDataModel, $this, $records, $entityType, $entityName, $this->_entityIds);
       \Civi::dispatcher()->dispatch('civi.afform.submit', $event);
@@ -685,7 +685,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
    * @param string $entityName
    * @param $records
    */
-  protected function replaceRelativeDates($entityName, $records) {
+  protected function replaceRelativeDates($records) {
     foreach ($records as $key => $record) {
       foreach ($record['fields'] as $field => $value) {
         if (str_contains($field, "date") && str_contains($value, ".")) {

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -11,6 +11,7 @@ use Civi\Api4\File;
 use Civi\Api4\Generic\Result;
 use Civi\Api4\Utils\CoreUtil;
 use CRM_Afform_ExtensionUtil as E;
+use CRM_Utils_Date;
 
 /**
  * Shared functionality for form submission pre & post processing.
@@ -661,6 +662,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     foreach ($entityWeights as $entityName) {
       $entityType = $this->_formDataModel->getEntity($entityName)['type'];
       $records = $this->replaceReferences($entityName, $entityValues[$entityName]);
+      $records = $this->replaceRelativeDates($entityName, $entityValues[$entityName]);
       $this->fillIdFields($records, $entityName);
       $event = new AfformSubmitEvent($this->_afform, $this->_formDataModel, $this, $records, $entityType, $entityName, $this->_entityIds);
       \Civi::dispatcher()->dispatch('civi.afform.submit', $event);
@@ -676,6 +678,25 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
   protected static function getNestedKey(array $values) {
     $firstValue = \CRM_Utils_Array::first(array_filter($values));
     return is_array($firstValue) && $firstValue ? array_keys($firstValue)[0] : NULL;
+  }
+
+  /**
+   * Replace relative date
+   * @param string $entityName
+   * @param $records
+   */
+  protected function replaceRelativeDates($entityName, $records) {
+    foreach ($records as $key => $record) {
+      foreach ($record['fields'] as $field => $value) {
+        if (str_contains($field, "date") && str_contains($value, ".")) {
+          $dateFormat = explode(".", $value, 2);
+          $dataRange = CRM_Utils_Date::relativeToAbsolute($dateFormat[0], $dateFormat[1]);
+          $records[$key]['fields'][$field] = $dataRange["from"];
+        }
+      }
+    }
+
+    return $records;
   }
 
 }

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -682,7 +682,6 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
 
   /**
    * Replace relative date
-   * @param string $entityName
    * @param $records
    */
   protected function replaceRelativeDates($records) {


### PR DESCRIPTION
Overview
----------------------------------------
_Dates in FormBuilder that were hidden and had default value from Relative Date Filters, e.g. Today, is using fallback or default date of 1970-01-01 when saved (probably default from database). It seems that "this.day" was not converted as I check the value in afform_submissions table it was still "this.day", but not really sure if this is the cause. An example is submitting a contact with birth date, make it hidden, and select a default of any relative date like "Today", it would fall back to 1970-01-01 or a database default._

Before
----------------------------------------
_Does not convert Relative date (this.day, this.week, ...)_

After
----------------------------------------
_Convert using `CRM_Utils_Date::relativeToAbsolute` when submitting the form during `processFormData`._

Technical Details
----------------------------------------
_CiviCRM: 5.78.2_

Comments
----------------------------------------
_I feel like the fix is too broad and needs more filters._
