### PR TITLE
dev/core#5543 - Fix modal print button

### DIFF
--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -394,7 +394,7 @@
             $(this).dialog('option', 'title', data.title);
           }
           // Update print url
-          $(this).parent().find('a.crm-dialog-titlebar-print').attr('href', $(this).data('civiCrmSnippet')._formatUrl($(this).crmSnippet('option', 'url'), '2'));
+          $(this).parent().find('a.crm-dialog-titlebar-print').attr('href', $(this).data('civiCrmSnippet')._formatUrl($(this).crmSnippet('option', 'url'), '1'));
         });
     }
     $(settings.target).crmSnippet(settings).crmSnippet('refresh');


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/5543

Before
----------------------------------------
Clicking the "Print" icon (in the title bar of a modal dialog) results in an error.

After
----------------------------------------
Works correctly

Technical Details
----------------------------------------
Recent security hardening blocks `snippet=2` which is `CRM_Core_Smarty::PRINT_SNIPPET` & intended to be loaded via ajax.
But '2' appears to be incorrect anyway, it should have been '1' which is `CRM_Core_Smarty::PRINT_PAGE`. That's the appropriate setting for printing a page.