### PR TITLE
crmSnippet - Fix regexes to match

### DIFF
--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -271,7 +271,7 @@
         if (url.search(/[&?]snippet=/) < 0) {
           url += (url.indexOf('?') < 0 ? '?' : '&') + 'snippet=' + snippetType;
         } else {
-          url = url.replace(/snippet=[^&]*/, 'snippet=' + snippetType);
+          url = url.replace(/([&?])snippet=[^&]*/, '$1snippet=' + snippetType);
         }
         // See Civi\Angular\AngularLoader
         if (snippetType === 'json' && CRM.angular) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes some js regex to be more correct.

Technical Details
----------------------------------------
The regex replace didn't match regex search in the conditional above, and that was bugging me.
Technically this would have resulted in buggy behavior with any url containing an extra arg like `mysnippet=foo`, although that realistically isn't likely, might as well make the code correct.