### PR TITLE
Update the help wording for DB Entity permissions

### DIFF
--- a/ext/search_kit/templates/CRM/Search/Help/DisplayTypeEntity.hlp
+++ b/ext/search_kit/templates/CRM/Search/Help/DisplayTypeEntity.hlp
@@ -1,4 +1,4 @@
 {htxt id="entity_permission"}
   <p>{ts}Set the permission level needed to view this entity.{/ts}</p>
-  <p>{ts}Users without this permission will not be able to see this entity in SearchKit.{/ts}</p>
+  <p>{ts}Users without this permission will not be able to see this entity in SearchKit nor in any search queries or displays that use this entity.{/ts}</p>
 {/htxt}


### PR DESCRIPTION
By default DB Entities are set to API Permission = "administer CiviCRM", which most users do not have. When building DB Entities for use in SK queries and displays, this permission must be changed to the broader "CiviCRM: access CiviCRM backend and API" to allow most normal CiviCRM users to see the display.

This change updates the wording to reflect that the permission governs not just viewing the DB entity in SearchKit but more broadly wherever the DB entity may be used in SK searches and displays.

Please feel free to revise my proposed wording.