### PR TITLE
dev/core#5548 Add hook to alter the custom fields data view

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1732,6 +1732,9 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
       }
     }
 
+    // Call hook to alter CustomDataView.
+    CRM_Utils_Hook::alterCustomDataView($details, $groupTree, $entityId);
+
     if ($returnCount) {
       // return a single value count if group id is passed to function
       // else return a groupId and count mapped array

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -3235,6 +3235,25 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * This hook is called to alter Custom data view before its displayed.
+   *
+   * @param array $details
+   * @param array $groupTree
+   * @param int $entityId
+   *
+   * @return mixed
+   */
+  public static function alterCustomDataView(&$details, $groupTree, $entityId) {
+    $null = NULL;
+    return self::singleton()->invoke(
+      ['details', 'groupTree', 'entityId'],
+      $details, $groupTree, $entityId,
+      $null, $null, $null,
+      'civicrm_alterCustomDataView'
+    );
+  }
+
+  /**
    * Allows an extension to override the checksum validation.
    * For example you may want to invalidate checksums that were sent out/forwarded by mistake. You could also
    * intercept and redirect to a different page in this case - eg. to say "sorry, you tried to use a compromised


### PR DESCRIPTION
Fixes https://lab.civicrm.org/dev/core/-/issues/5548

This adds a new hook to allow a final alteration before the data is sent to templates. 

This is needed despite there being `hook_civicrm_alterCustomFieldDisplayValue` because field display is still altered even after that is called. And because that hook only returns a single string rather than an array of the display data.