### PR TITLE
SearchKit - Support fields in apiBatch task

### DIFF
--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInput.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInput.component.js
@@ -4,15 +4,18 @@
   angular.module('crmSearchTasks').component('crmSearchInput', {
     bindings: {
       field: '<',
-      'op': '<',
-      'format': '<',
-      'optionKey': '<'
+      op: '<',
+      format: '<',
+      optionKey: '<',
+      showLabel: '<',
     },
     require: {ngModel: 'ngModel'},
     templateUrl: '~/crmSearchTasks/crmSearchInput/crmSearchInput.html',
     controller: function($scope) {
-      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
+      const ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
+
+      this.domId = 'search-input-' + Math.random().toString(36).substr(2, 9);
 
       this.$onInit = function() {
 

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInput.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInput.html
@@ -1,13 +1,16 @@
+<label ng-if="$ctrl.showLabel && $ctrl.field.label" for="{{:: $ctrl.domId }}">
+  {{ $ctrl.field.label }}
+</label>
 <div ng-switch="$ctrl.op || ''" class="form-group">
 
   <div ng-switch-when="BETWEEN|NOT BETWEEN" ng-switch-when-separator="|" class="form-group">
-    <crm-search-input-val field="$ctrl.field" op="'&gt;'" option-key="$ctrl.optionKey" ng-model="$ctrl.value[0]" class="form-group"></crm-search-input-val>
+    <crm-search-input-val field="$ctrl.field" op="'&gt;'" option-key="$ctrl.optionKey" ng-model="$ctrl.value[0]" class="form-group" label-id="{{:: $ctrl.domId }}"></crm-search-input-val>
     -
     <crm-search-input-val field="$ctrl.field" op="'&lt;'" option-key="$ctrl.optionKey" ng-model="$ctrl.value[1]" class="form-group"></crm-search-input-val>
   </div>
 
   <div ng-switch-default class="form-group">
-    <crm-search-input-val field="$ctrl.field" op="$ctrl.op" option-key="$ctrl.optionKey" ng-model="$ctrl.value" class="form-group"></crm-search-input-val>
+    <crm-search-input-val field="$ctrl.field" op="$ctrl.op" option-key="$ctrl.optionKey" ng-model="$ctrl.value" class="form-group" label-id="{{:: $ctrl.domId }}"></crm-search-input-val>
   </div>
 
 </div>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
@@ -5,7 +5,8 @@
     bindings: {
       field: '<',
       'op': '<',
-      'optionKey': '<'
+      'optionKey': '<',
+      labelId: '@',
     },
     require: {ngModel: 'ngModel'},
     template: '<div class="form-group" ng-include="$ctrl.getTemplate()"></div>',

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/date.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/date.html
@@ -1,5 +1,5 @@
 <div class="form-group">
-  <select class="form-control" ng-if="$ctrl.isMulti() === false" ng-model="$ctrl.dateType" ng-change="$ctrl.changeDateType()">
+  <select id="{{:: $ctrl.labelId }}" class="form-control" ng-if="$ctrl.isMulti() === false" ng-model="$ctrl.dateType" ng-change="$ctrl.changeDateType()">
     <option value="fixed">{{:: ts('Pick Date') }}</option>
     <option value="range">{{:: ts('Date Range') }}</option>
     <option value="now">{{:: ts('Now') }}</option>
@@ -10,8 +10,8 @@
   <div class="form-group" ng-switch="$ctrl.dateType">
 
     <div class="form-group" ng-switch-when="fixed">
-      <input class="form-control" crm-ui-datepicker="{time: $ctrl.field.data_type === 'Timestamp'}" ng-model="$ctrl.value" ng-required="!$ctrl.field.nullable" ng-if="!$ctrl.isMulti()">
-      <input class="form-control" crm-multi-select-date ng-model="$ctrl.value" ng-required="!$ctrl.field.nullable" ng-if="$ctrl.isMulti()">
+      <input class="form-control" crm-ui-datepicker="{time: $ctrl.field.data_type === 'Timestamp'}" ng-model="$ctrl.value" id="{{:: $ctrl.labelId }}" ng-required="!$ctrl.field.nullable || $ctrl.field.required" ng-if="!$ctrl.isMulti()">
+      <input class="form-control" crm-multi-select-date ng-model="$ctrl.value" id="{{:: $ctrl.labelId }}" ng-required="!$ctrl.field.nullable || $ctrl.field.required" ng-if="$ctrl.isMulti()">
     </div>
 
     <div class="form-group" ng-switch-when="range">

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/email.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/email.html
@@ -1,6 +1,6 @@
 <div class="form-group" ng-if="!$ctrl.isMulti()" >
-  <input type="email" class="form-control" ng-model="$ctrl.value" ng-required="!$ctrl.field.nullable">
+  <input type="email" class="form-control" ng-model="$ctrl.value" id="{{:: $ctrl.labelId }}" ng-required="!$ctrl.field.nullable || $ctrl.field.required">
 </div>
 <div class="form-group" ng-if="$ctrl.isMulti()" >
-  <input class="form-control" ng-model="$ctrl.value" ng-required="!$ctrl.field.nullable" crm-ui-select="{multiple: true, tags: [], tokenSeparators: [','], formatNoMatches: ''}" ng-list>
+  <input class="form-control" ng-model="$ctrl.value" id="{{:: $ctrl.labelId }}" ng-required="!$ctrl.field.nullable || $ctrl.field.required" crm-ui-select="{multiple: true, tags: [], tokenSeparators: [','], formatNoMatches: ''}" ng-list>
 </div>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/float.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/float.html
@@ -1,6 +1,6 @@
 <div class="form-group" ng-if="!$ctrl.isMulti()" >
-  <input type="number" step="any" class="form-control" ng-model="$ctrl.value" ng-required="!$ctrl.field.nullable">
+  <input type="number" step="any" class="form-control" ng-model="$ctrl.value" id="{{:: $ctrl.labelId }}" ng-required="!$ctrl.field.nullable || $ctrl.field.required">
 </div>
 <div class="form-group" ng-if="$ctrl.isMulti()" >
-  <input class="form-control" ng-model="$ctrl.value" ng-required="!$ctrl.field.nullable" crm-ui-select="{multiple: true, tags: [], tokenSeparators: [','], formatNoMatches: ''}" ng-list>
+  <input class="form-control" ng-model="$ctrl.value" id="{{:: $ctrl.labelId }}" ng-required="!$ctrl.field.nullable || $ctrl.field.required" crm-ui-select="{multiple: true, tags: [], tokenSeparators: [','], formatNoMatches: ''}" ng-list>
 </div>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/integer.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/integer.html
@@ -1,6 +1,6 @@
 <div class="form-group" ng-if="!$ctrl.isMulti()" >
-  <input type="number" step="1" class="form-control" ng-model="$ctrl.value" ng-required="!$ctrl.field.nullable">
+  <input type="number" step="1" class="form-control" ng-model="$ctrl.value" id="{{:: $ctrl.labelId }}" ng-required="!$ctrl.field.nullable || $ctrl.field.required">
 </div>
 <div class="form-group" ng-if="$ctrl.isMulti()" >
-  <input class="form-control" ng-model="$ctrl.value" ng-required="!$ctrl.field.nullable" crm-ui-select="{multiple: true, tags: [], tokenSeparators: [','], formatNoMatches: ''}" ng-list>
+  <input class="form-control" ng-model="$ctrl.value" id="{{:: $ctrl.labelId }}" ng-required="!$ctrl.field.nullable || $ctrl.field.required" crm-ui-select="{multiple: true, tags: [], tokenSeparators: [','], formatNoMatches: ''}" ng-list>
 </div>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/text.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/text.html
@@ -1,6 +1,6 @@
 <div class="form-group" ng-if="!$ctrl.isMulti()" >
-  <input type="text" class="form-control" ng-model="$ctrl.value" ng-required="!$ctrl.field.nullable">
+  <input type="text" class="form-control" ng-model="$ctrl.value" id="{{:: $ctrl.labelId }}" ng-required="!$ctrl.field.nullable || $ctrl.field.required">
 </div>
 <div class="form-group" ng-if="$ctrl.isMulti()" >
-  <input class="form-control" ng-model="$ctrl.value" ng-required="!$ctrl.field.nullable" crm-ui-select="{multiple: true, tags: [], tokenSeparators: [','], formatNoMatches: ''}" ng-list>
+  <input class="form-control" ng-model="$ctrl.value" id="{{:: $ctrl.labelId }}" ng-required="!$ctrl.field.nullable || $ctrl.field.required" crm-ui-select="{multiple: true, tags: [], tokenSeparators: [','], formatNoMatches: ''}" ng-list>
 </div>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.ctrl.js
@@ -19,9 +19,17 @@
       ctrl.apiBatch.params.values = ctrl.apiBatch.params.values || {};
       // Set values from field defaults
       ctrl.apiBatch.fields.forEach((field) => {
-        if (field.default_value) {
-          ctrl.apiBatch.params.values[field.name] = field.default_value;
+        let value = '';
+        if ('default_value' in field) {
+          value = field.default_value;
+        } else if (field.serialize || field.data_type === 'Array') {
+          value = [];
+        } else if (field.data_type === 'Boolean') {
+          value = true;
+        } else if (field.options && field.options.length) {
+          value = field.options[0].id;
         }
+        ctrl.apiBatch.params.values[field.name] = value;
       });
     }
 

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.ctrl.js
@@ -9,9 +9,20 @@
 
     this.entityTitle = this.getEntityTitle();
 
-    // If no confirmation message, skip straight to processing
-    if (!ctrl.apiBatch.confirmMsg) {
+    // If no selectable fields or confirmation message, skip straight to processing
+    if (!ctrl.apiBatch.confirmMsg && !ctrl.apiBatch.fields) {
       ctrl.start(ctrl.apiBatch.params);
+    }
+
+    if (ctrl.apiBatch.fields) {
+      ctrl.apiBatch.params = ctrl.apiBatch.params || {};
+      ctrl.apiBatch.params.values = ctrl.apiBatch.params.values || {};
+      // Set values from field defaults
+      ctrl.apiBatch.fields.forEach((field) => {
+        if (field.default_value) {
+          ctrl.apiBatch.params.values[field.name] = field.default_value;
+        }
+      });
     }
 
     this.onSuccess = function(result) {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.html
@@ -1,6 +1,9 @@
 <div id="bootstrap-theme" crm-dialog="crmSearchTask">
-  <form ng-controller="crmSearchTaskApiBatch as $ctrl">
+  <form name="crmSearchTaskApiBatchForm" ng-controller="crmSearchTaskApiBatch as $ctrl">
     <p><strong ng-if="model.apiBatch.confirmMsg">{{:: ts(model.apiBatch.confirmMsg, {1: model.ids.length, 2: $ctrl.entityTitle}) }}</strong></p>
+    <div class="form-inline" ng-repeat="field in model.apiBatch.fields">
+      <crm-search-input class="form-group" ng-model="model.apiBatch.params.values[field.name]" field="field" show-label="true"></crm-search-input>
+    </div>
     <hr />
     <div ng-if="$ctrl.run" class="crm-search-task-progress">
       <h5>{{:: ts(model.apiBatch.runMsg, {1: model.ids.length, 2: $ctrl.entityTitle}) }}</h5>
@@ -8,6 +11,6 @@
     </div>
 
     <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" ></crm-dialog-button>
-    <crm-dialog-button ng-if="model.apiBatch.confirmMsg" text="model.taskTitle" icons="{primary: $ctrl.run ? 'fa-spin fa-spinner' : 'fa-check'}" on-click="$ctrl.start(model.apiBatch.params)" disabled="$ctrl.run" ></crm-dialog-button>
+    <crm-dialog-button ng-if="model.apiBatch.confirmMsg || model.apiBatch.fields" text="model.taskTitle" icons="{primary: $ctrl.run ? 'fa-spin fa-spinner' : 'fa-check'}" on-click="$ctrl.start(model.apiBatch.params)" disabled="$ctrl.run || !crmSearchTaskApiBatchForm.$valid" ></crm-dialog-button>
   </form>
 </div>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.ctrl.js
@@ -37,7 +37,7 @@
         if (ctrl.add) {
           var field = ctrl.getField(ctrl.add),
             value = '';
-          if (field.serialize) {
+          if (field.serialize || field.data_type === 'Array') {
             value = [];
           } else if (field.data_type === 'Boolean') {
             value = true;

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.ctrl.js
@@ -18,10 +18,8 @@
         loadOptions: ['id', 'name', 'label', 'description', 'color', 'icon'],
         where: [['deprecated', '=', false], ["readonly", "=", false]],
       }],
-      entityInfo: ['Entity', 'get', {select: ['primary_key'], where: [['name', '=', this.entity]]}, 0]
     }).then(function(results) {
         ctrl.fields = results.getFields;
-        ctrl.idField = results.entityInfo.primary_key[0];
       });
 
     this.updateField = function(index) {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.html
@@ -10,7 +10,7 @@
     </div>
     <div ng-if="$ctrl.run" class="crm-search-task-progress">
       <h5>{{:: ts('Updating %1 %2...', {1: model.ids.length, 2: $ctrl.entityTitle}) }}</h5>
-      <crm-search-batch-runner entity="model.entity" action="update" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess()" error="$ctrl.onError()" id-field="{{:: $ctrl.idField }}"></crm-search-batch-runner>
+      <crm-search-batch-runner entity="model.entity" action="update" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess()" error="$ctrl.onError()" id-field="{{:: $ctrl.entityInfo.primary_key[0] }}"></crm-search-batch-runner>
     </div>
 
     <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" ></crm-dialog-button>


### PR DESCRIPTION
Overview
----------------------------------------
Allows api batch tasks to include fields for the user to interact with.

Technical Details
----------------------------------------
Try the following task as a test & use it in a search for Individuals:

```php
    $tasks['Individual']['rename'] = [
      'title' => E::ts('Rename Person'),
      'icon' => 'fa-random',
      'apiBatch' => [
        'action' => 'update',
        'fields' => [
          ['name' => 'first_name', 'required' => TRUE],
          ['name' => 'last_name', 'default_value' => 'Hello'],
        ],
        'confirmMsg' => E::ts('Rename %1 %2'),
        'runMsg' => E::ts('Renaming %1 %2...'),
        'successMsg' => E::ts('Successfully renamed %1 %2.'),
        'errorMsg' => E::ts('An error occurred while attempting to enable %1 %2.'),
      ],
    ];
```