### PR TITLE
core/dev#5548 add per custom field display definition

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -3235,6 +3235,25 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * This hook is called to alter Custom FIeld display definition before it is passed to the template.
+   *
+   * @param array $values
+   * @param array $properties
+   * @param array $group
+   * @param int $entityId
+   * @param array $editableGroups
+   *
+   * @return mixed
+   */
+  public static function alterCustomFieldDisplayDefinition(&$values, $properties, $group, $entityId, $editableGroups) {
+    $null = NULL;
+    return self::singleton()->invoke(
+      ['values', 'properties', 'group', 'entityId', 'editableGroups'],
+      $values, $properties, $group, $entityId, $editableGroups, $null, 'civicrm_alterCustomFieldDisplayDefinition'
+    );
+  }
+
+  /**
    * Allows an extension to override the checksum validation.
    * For example you may want to invalidate checksums that were sent out/forwarded by mistake. You could also
    * intercept and redirect to a different page in this case - eg. to say "sorry, you tried to use a compromised


### PR DESCRIPTION
Fixes https://lab.civicrm.org/dev/core/-/issues/5548

This version refactors `buildCustomDataView()` so that the hook is easier to use. Instead of needing to traverse the whole group tree again, it can adjust each custom field before they get sent to the template. (But still gets called after the `alterCustomFieldDisplayValue` hook so it can have the final say).