### PR TITLE
[NFC] fix intermittent fail about phone export

### DIFF
--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -89,7 +89,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'civicrm_case_activity',
       'civicrm_campaign',
     ]);
-    OptionValue::update(FALSE)->addWhere('name', '=', 'Much Much longer than just phone')->setValues(['label' => 'Mobile'])->execute();
+    OptionValue::update(FALSE)->addWhere('name', '=', 'Mobile')->addWhere('option_group_id:name', '=', 'phone_type')->setValues(['label' => 'Mobile'])->execute();
 
     if (!empty($this->locationTypes)) {
       $this->callAPISuccess('LocationType', 'delete', ['id' => $this->locationTypes['Whare Kai']['id']]);
@@ -850,7 +850,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     $this->contactIDs[] = $this->individualCreate();
     $this->contactIDs[] = $this->individualCreate();
 
-    OptionValue::update()->addWhere('name', '=', 'Mobile')->setValues(['label' => 'Much Much longer than just phone'])->execute();
+    OptionValue::update()->addWhere('name', '=', 'Mobile')->addWhere('option_group_id:name', '=', 'phone_type')->setValues(['label' => 'Much Much longer than just phone'])->execute();
     $locationTypes = ['Billing' => 'Billing', 'Home' => 'Home'];
     $phoneTypes = ['Mobile', 'Phone'];
     foreach ($this->contactIDs as $contactID) {


### PR DESCRIPTION
Overview
----------------------------------------
Intermittent fail

Before
----------------------------------------
```
CRM_Export_BAO_ExportTest::testExportPhoneData
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Much Much longer than just phone'
+'Phone'

/home/homer/buildkit/build/build-0/web/sites/all/modules/civicrm/tests/phpunit/CRM/Export/BAO/ExportTest.php:912
/home/homer/buildkit/build/build-0/web/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:293
/home/homer/buildkit/extern/phpunit9/phpunit9.phar:2520
```

After
----------------------------------------
Hopefully gone

Technical Details
----------------------------------------
In teardown, the intent appears to be to reset the label after testExportPhoneData() has changed it, but it compares against the wrong `name`.

But I'm still at a loss as to why the test fails at all, just that this fix seems correct regardless. One possibility is that this test is somehow running twice SOMETIMES, but that doesn't really make sense.

Another possibility is that SOMETIMES an earlier test changes both the name and the label of the mobile type to something like "Phone", and so the teardown doesn't find it to update and neither does the test, but I can't find where that test would be. If that's true, then this won't fix it by itself, but as noted it seems like the Right Thing To Do™ anyway.

Comments
----------------------------------------
