### PR TITLE
Update authx.php: Update hook_civicrm_permission to use new format

### DIFF
--- a/ext/authx/authx.php
+++ b/ext/authx/authx.php
@@ -124,11 +124,11 @@ function authx_civicrm_enable() {
 function authx_civicrm_permission(&$permissions) {
   $permissions['authenticate with password'] = [
     'label' => E::ts('AuthX: Authenticate to services with password'),
-	  'description' => E::ts('AuthX: Authenticate to services with password'),
+    'description' => E::ts('AuthX: Authenticate to services with password'),
   ];
   $permissions['authenticate with api key'] = [
     'label' => E::ts('AuthX: Authenticate to services with API key'),
-	  'description' => E::ts('AuthX: Authenticate to services with API key'),
+    'description' => E::ts('AuthX: Authenticate to services with API key'),
   ];
   $permissions['generate any authx credential'] = [
     'label' => E::ts('Authx: Generate new JWT credentials for other users via the API'),

--- a/ext/authx/authx.php
+++ b/ext/authx/authx.php
@@ -124,14 +124,18 @@ function authx_civicrm_enable() {
 function authx_civicrm_permission(&$permissions) {
   $permissions['authenticate with password'] = [
     'label' => E::ts('AuthX: Authenticate to services with password'),
+	'description' => E::ts('AuthX: Authenticate to services with password'),
   ];
   $permissions['authenticate with api key'] = [
     'label' => E::ts('AuthX: Authenticate to services with API key'),
+	'description' => E::ts('AuthX: Authenticate to services with API key'),
   ];
   $permissions['generate any authx credential'] = [
     'label' => E::ts('Authx: Generate new JWT credentials for other users via the API'),
+    'description' => E::ts('Authx: Generate new JWT credentials for other users via the API'),
   ];
   $permissions['validate any authx credential'] = [
     'label' => E::ts('Authx: Validate credentials for other users via the API'),
+    'description' => E::ts('Authx: Validate credentials for other users via the API'),
   ];
 }

--- a/ext/authx/authx.php
+++ b/ext/authx/authx.php
@@ -124,11 +124,11 @@ function authx_civicrm_enable() {
 function authx_civicrm_permission(&$permissions) {
   $permissions['authenticate with password'] = [
     'label' => E::ts('AuthX: Authenticate to services with password'),
-	'description' => E::ts('AuthX: Authenticate to services with password'),
+	  'description' => E::ts('AuthX: Authenticate to services with password'),
   ];
   $permissions['authenticate with api key'] = [
     'label' => E::ts('AuthX: Authenticate to services with API key'),
-	'description' => E::ts('AuthX: Authenticate to services with API key'),
+	  'description' => E::ts('AuthX: Authenticate to services with API key'),
   ];
   $permissions['generate any authx credential'] = [
     'label' => E::ts('Authx: Generate new JWT credentials for other users via the API'),


### PR DESCRIPTION
Permissions should be declared with 'label' and 'description' keys. Description added. https://lab.civicrm.org/dev/core/-/issues/5551

Overview
----------------------------------------
_PHP: Permissions should be declared with 'label' and 'description' keys._

Before
----------------------------------------
_Description has been missing._

After
----------------------------------------
_Description added._

Technical Details
----------------------------------------
_(https://lab.civicrm.org/dev/core/-/issues/5551)_

Comments
----------------------------------------
-
