### PR TITLE
(dev/core#4462) Afform - Fixes for page-token handling

### DIFF
--- a/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormTest.php
+++ b/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormTest.php
@@ -87,8 +87,8 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
       'html' => '<p>url=({afform.mockPublicFormUrl}) link=({afform.mockPublicFormLink})</p>',
     ], ['contactId' => $lebowski]);
 
-    $httpTextUrl = '(https?:[a-zA-Z0-9_/\.\?\-\+:=#&]+)';
-    $httpHtmlUrl = '(https?:[a-zA-Z0-9_/\.\?\-\+:=#&\;]+)';
+    $httpTextUrl = '(https?:[a-zA-Z0-9%_/\.\?\-\+:=#&]+)';
+    $httpHtmlUrl = '(https?:[a-zA-Z0-9%_/\.\?\-\+:=#&\;]+)';
     $textPattern = ";url=\($httpTextUrl\) link=\(\[My public form\]\($httpTextUrl\)\); ";
     $htmlPattern = ";\<p\>url=\($httpHtmlUrl\) link=\(<a href=\"$httpHtmlUrl\">My public form</a>\)\</p\>;";
 
@@ -101,8 +101,8 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
     $this->assertEquals($textMatches[1], html_entity_decode($htmlMatches[1]), 'Text and HTML values of {afform.mockPublicFormUrl} should point to same place');
     $this->assertEquals($textMatches[2], html_entity_decode($htmlMatches[2]), 'Text and HTML values of {afform.mockPublicFormLink} should point to same place');
 
-    $this->assertMatchesRegularExpression(';^https?:.*civicrm/mock-public-form.*;', $textMatches[1], "URL should look plausible");
-    $this->assertMatchesRegularExpression(';^https?:.*civicrm/mock-public-form.*;', $textMatches[2], "URL should look plausible");
+    $this->assertMatchesRegularExpression(';^https?:.*civicrm(/|%2F)mock-public-form.*;', $textMatches[1], "URL should look plausible");
+    $this->assertMatchesRegularExpression(';^https?:.*civicrm(/|%2F)mock-public-form.*;', $textMatches[2], "URL should look plausible");
   }
 
   /**
@@ -113,7 +113,7 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
 
     $lebowski = $this->getLebowskiCID();
     $url = $this->renderTokens($lebowski, '{afform.mockPublicFormUrl}', 'text/plain');
-    $this->assertMatchesRegularExpression(';^https?:.*civicrm/mock-public-form.*;', $url, "URL should look plausible");
+    $this->assertMatchesRegularExpression(';^https?:.*civicrm(/|%2F)mock-public-form.*;', $url, "URL should look plausible");
 
     // This URL doesn't specifically log you in to a durable session.
     $this->assertUrlSessionContact($url, NULL);
@@ -156,7 +156,7 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
       // These patterns are hints to indicate whether the page-view is authenticated in the CMS.
       'Backdrop' => '/<body.* class=".* logged-in[ "]/',
       'Drupal' => '/<body.* class=".* logged-in[ "]/',
-      'Drupal8' => '/<body.* class=".* logged-in[ "]/',
+      'Drupal8' => '/<body.* class=".* user-logged-in[ "]/',
     ];
 
     if (!isset($sessionCues[CIVICRM_UF])) {

--- a/ext/authx/Civi/Authx/Backdrop.php
+++ b/ext/authx/Civi/Authx/Backdrop.php
@@ -43,6 +43,7 @@ class Backdrop implements AuthxInterface {
    * @inheritDoc
    */
   public function loginStateless($userId) {
+    backdrop_save_session(FALSE);
     global $user;
     $user = user_load($userId);
   }

--- a/ext/authx/Civi/Authx/CheckPolicyEvent.php
+++ b/ext/authx/Civi/Authx/CheckPolicyEvent.php
@@ -1,0 +1,70 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Authx;
+
+/**
+ * After we have determined that a credential appears authentic, we must check
+ * whether our current policies allow this credential be used in this way.
+ */
+class CheckPolicyEvent extends \Civi\Core\Event\GenericHookEvent {
+
+  /**
+   * Describe the credential which we have accepted as authentic.
+   *
+   * @var \Civi\Authx\AuthenticatorTarget
+   */
+  public $target;
+
+  /**
+   * Describe whether we wish to authorize this credential to be used.
+   *
+   * @var array{userMode: string, allowCreds: string[], guards: string[]}
+   */
+  public $policy;
+
+
+  /**
+   * Rejection message - If you know that this credential is intended for your listener,
+   * and if it has some problem, then you can
+   *
+   * @var string|null
+   */
+  protected $rejection = NULL;
+
+  /**
+   * @param array{userMode: string, allowCreds: string[], guards: string[]} $policy
+   * @param \Civi\Authx\AuthenticatorTarget $target
+   */
+  public function __construct(array $policy, AuthenticatorTarget $target) {
+    $this->policy = $policy;
+    $this->target = $target;
+  }
+
+  public function getRejection(): ?string {
+    return $this->rejection;
+  }
+
+  /**
+   * Emphatically reject the credential.
+   *
+   * If you know that the credential is targeted at your provider, and if there
+   * is an error in it, then you may set a rejection message. This will can
+   * provide more detailed debug information. However, it will preclude other
+   * listeners from accepting the credential.
+   *
+   * @param string $message
+   */
+  public function reject(string $message): void {
+    $this->rejection = $message;
+  }
+
+}

--- a/ext/authx/Civi/Authx/Drupal.php
+++ b/ext/authx/Civi/Authx/Drupal.php
@@ -43,6 +43,7 @@ class Drupal implements AuthxInterface {
    * @inheritDoc
    */
   public function loginStateless($userId) {
+    drupal_save_session(FALSE);
     global $user;
     $user = user_load($userId);
   }

--- a/ext/authx/tests/phpunit/Civi/Authx/AbstractFlowsTest.php
+++ b/ext/authx/tests/phpunit/Civi/Authx/AbstractFlowsTest.php
@@ -112,6 +112,14 @@ class AbstractFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndI
     return $req;
   }
 
+  public function requestMyContactDashboard() {
+    $p = (['reset' => 1]);
+    $uri = (new Uri('civicrm/user'))
+      ->withQuery('params=' . urlencode(json_encode($p)));
+    $req = new Request('GET', $uri);
+    return $req;
+  }
+
   /**
    * Assert the AJAX response provided the expected contact.
    *


### PR DESCRIPTION
Overview
----------------------------------------

This is a follow-up to #30585 (5.79.alpha) to address some of remaining issues (for 5.79.beta). It is part of https://lab.civicrm.org/dev/core/-/issues/4462. There is still more to do for 5.79 after this. (But I just wanted to keep the patchset from getting too big in one PR.)

ping @ufundo @eileenmcnaughton @aydun 

Steps to Reproduce
----------------------------------------

* Setup 5.79 on D7/BD.
* Create an "Individual" form.
    * Form Settings: Placement: Enable "Message Tokens".
    * Form Settings: Permission: "Generic: Allow all users (including anonymous)"
    * Individual 1: Security: Form-Based
    * Individual 1: Autofill: Current User
    * Individual 1: Allowed Actions: Create=>yes, Update=>yes
    * Individual 1: Accept ID from URL: No
* Send an email with the new token. The recipient should be someone has a `User` account.
* Read the rendered email. Open the link in a new/private browser.

Before (circa 5.79.alpha)
----------------------------------------

The general idea is that the baseline HTML page is shown anonymously -- and then any AJAX subrequests will be authenticated (setting the active Civi `Contact` and active CMS `User` based on the token).

However, this runs into some snags:

* __Authx Bug__: On the initial page-view, the site navigation looks anonymous. But it secretly initializes an authenticated session. This becomes obvious if you reload the page or manually open any other page.
  That defeats the whole point of 30585. The goal is to have a limited-use token that does not create a session.
* __First-Request Does Not Set Identity__: The initial HTTP request doesn't set the active contact/user. That only happens in the AJAX subrequests. Consequently, it only works if the page is viewable by anonymous.
* __User-Loading Policy__: You can kind of work-around problems by going to "System Settings > Authentication" and setting user-mapping policy for "HTTP X-Header" requests.
    * It requires work for site-builder to configure.
    * Those configuration steps are heavy-handed. They could impact other/unrelated customizations.
    * One size doesn't fit for all page-token use-cases. (CiviMail and cross-site IFRAMEs have some differing needs.)

After
----------------------------------------

This is an intermediate step/improvement.

The general idea is that you show the baseline HTML page (and its AJAX requests) as the target `Contact` and/or `User`.

Addressing those snags:

* __Authx Bug__: Fixed. It no longer creates the unintended session.
* __First-Request Auth__: It now sets the active `Contact` and/or `User`.
* __User-Loading Policy__: 
    * We still have the fundamental trade-offs in deciding whether to set active `Contact` and/or `User`.
    * But given that trade-off exists, you can distinguish policies for different use-cases.

Technical Details
----------------------------------------

Recall the basic mechanism of the page-level auth-token. You can take any afform and generate a signed token to view that one page.

```
https://example.com/civicrm/my-form?_aff=Bearer+XXXXXXXXX
```

For email hyperlinks (in the current work), message-tokens are used to generate these kinds of links. The policy is to set the active `Contact` but leave the anonymous `User`.

* This should be closest analog to how "Profile+Checksum" behaves.
* This means that the CMS will render nav-menus that are suitable to anonymous. (It's confusing to see non-functional nav-links for "New Individual" or "My Account" or "Logout".)
* When configuring a form, you should set permissions suitable for anonymous users. (It's kinda hard to check the user-permissions if we don't load the user-accounts.)

For new/bespoke integrations (eg remote sites which embed IFRAMEs with auth-token links), it also defaults to "Contact-only". But:

* If you enable "User" accounts for this case, it should work fine. (Navbars are already suppressed -- so no conflict there.
* The integrator can decide whether to enable User account integration. They do this by putting a signed claim in the `XXXXXXXX` token:

    * Set JWT claim `userMode=>ignore` to disable user-loading.
    * Set JWT claim `userMode=>optional` or `userMode=>require` to enable user-loading.


