### PR TITLE
dev/core#5520 - Fix SearchKit DB entity displays with long names

### DIFF
--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
@@ -132,8 +132,15 @@ class SKEntitySubscriber extends AutoService implements EventSubscriberInterface
   private function formatFieldSpec(array $column, array $expr): array {
     // Strip the pseuoconstant suffix
     [$name, $suffix] = array_pad(explode(':', $column['key']), 2, NULL);
-    // Sanitize the name
-    $name = \CRM_Utils_String::munge($name, '_', 255);
+    // Sanitize the name and limit to 58 characters.
+    // 64 characters is the max for some versions of SQL, minus the length of "index_" = 58.
+    if (strlen($name) <= 58) {
+      $name = \CRM_Utils_String::munge($name, '_', NULL);
+    }
+    // Append a hash of the full name to trimmed names to keep them unique but predictable
+    else {
+      $name = \CRM_Utils_String::munge($name, '_', 42) . substr(md5($name), 0, 16);
+    }
     $spec = [
       'name' => $name,
       'data_type' => $expr['dataType'],


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/5520

Technical Details
----------------------------------------
Some versions of SQL require a maxlength of 64 characters per column.

This will append a hash of the full name to trimmed names to keep them unique but predictable.