### PR TITLE
standalone.css: lower padding around crm-container

### DIFF
--- a/ext/standaloneusers/css/standalone.css
+++ b/ext/standaloneusers/css/standalone.css
@@ -1,5 +1,5 @@
 .standalone-page-padding {
-  padding: 1px 3vw 1rem;
+  padding: 1px max(10px, 1vw) 1rem;
 }
 
 html.crm-standalone  nav.breadcrumb>ol {


### PR DESCRIPTION
Overview
----------------------------------------

The crm-container has a lot of padding on CiviCRM Standalone.

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/4db467a6-f56f-4bf0-ab6b-79bddf6443a4)

After
----------------------------------------

![image](https://github.com/user-attachments/assets/06d283e3-0404-46fa-837b-d4c2fe778e2d)

Comments
----------------------------------------

I understand that this is a personal preference, and in part because I am mostly full-screen on a desktop, it is less of an issue on mobile, but still, it feels like a waste of space.

cc @artfulrobot @vingle 