### PR TITLE
Fix addScriptUrl missing joining / between base and file paths

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -290,8 +290,8 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
     // TODO consider caching results
     $base = $this->paths->hasVariable($ext)
       ? $this->paths->getVariable($ext, 'url')
-      : ($this->extMapper->keyToUrl($ext) . '/');
-    return $base . $file;
+      : $this->extMapper->keyToUrl($ext);
+    return rtrim($base, '/') . "/$file";
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

Various scripts could not be loaded because the urls were wrong, e.g. 

```
http://sa3.localhost:8100/core/packagesbackbone-forms/distribution/backbone-fo....
                                       ↑
                                Missing slash!
```

See my monolog at
https://chat.civicrm.org/civicrm/pl/s4nshetf17nafrrgbasmix6hmo


Before
----------------------------------------

Pages such as configuring a contribution page failed to load.


After
----------------------------------------

Pages work


Technical Details
----------------------------------------

I opted for a solution that will work whether or not a trailing slash is included in the configured path.
