### PR TITLE
email propogation during Standalone user email creation

### DIFF
--- a/ext/standaloneusers/CRM/Standaloneusers/BAO/User.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/BAO/User.php
@@ -48,12 +48,24 @@ class CRM_Standaloneusers_BAO_User extends CRM_Standaloneusers_DAO_User implemen
    * @param \Civi\Core\Event\PreEvent $event
    */
   public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
-    if (
-      in_array($event->action, ['create', 'edit'], TRUE) &&
-      empty($event->params['when_updated'])
-    ) {
-      // Track when_updated.
-      $event->params['when_updated'] = date('YmdHis');
+    if (in_array($event->action, ['create', 'edit'], TRUE)) {
+      if (empty($event->params['when_updated'])) {
+        // Track when_updated.
+        $event->params['when_updated'] = date('YmdHis');
+      }
+      if (empty($event->params['uf_name'])) {
+        // If no email is specified, fetch from contact
+        $contactId = $event->params['contact_id'] ?? NULL;
+
+        if ($contactId) {
+          $email = \Civi\Api4\Contact::get(FALSE)
+            ->addWhere('id', '=', $contactId)
+            ->addSelect('email_primary.email')
+            ->execute()->single()['email_primary.email'] ?? NULL;
+
+          $event->params['uf_name'] = $email;
+        }
+      }
     }
   }
 

--- a/ext/standaloneusers/ang/afformEditUserAccount.aff.html
+++ b/ext/standaloneusers/ang/afformEditUserAccount.aff.html
@@ -4,7 +4,7 @@
     <af-field name="roles" />
     <af-field name="username" />
     <af-field name="contact_id" defn="{required: true, input_attrs: {quickAdd: ['civicrm/quick-add/Individual']}}" />
-    <af-field name="uf_name" />
+    <af-field name="uf_name" defn="{help_pre: ts('Email used for password resets.'), input_attrs: {placeholder: ts('Leave blank to use the primary email from the selected contact')}}" />
     <af-field name="is_active" />
     <af-field name="timezone" defn="{help_pre: ts('Set the timezone of the user. Date and times will be shown in this timezone. You can also leave it empty to use the default system timezone (which is a server setting).'), input_attrs: {placeholder: ts('Server default timezone')}}" />
     <af-field name="language" defn="{help_pre: ts('Set the user interface language of this user. You can also leave it empty to use the default system language.'), input_attrs: {placeholder: ts('System default language')}}" />

--- a/setup/plugins/init/StandaloneUsers.civi-setup.php
+++ b/setup/plugins/init/StandaloneUsers.civi-setup.php
@@ -171,6 +171,12 @@ if (!defined('CIVI_SETUP')) {
       ->addValue('last_name', 'Admin')
       ->execute()->single()['id'];
 
+    // add email to the contact
+    \Civi\Api4\Email::create(FALSE)
+      ->addValue('contact_id', $contactID)
+      ->addValue('email', $adminEmail)
+      ->execute();
+
     // NOTE: normally uf_name would be derived automatically
     // from the contact email, and roles could be provided using
     // the facade on the User entity

--- a/setup/plugins/init/StandaloneUsers.civi-setup.php
+++ b/setup/plugins/init/StandaloneUsers.civi-setup.php
@@ -161,22 +161,27 @@ if (!defined('CIVI_SETUP')) {
       ->execute()->indexBy('name');
 
     // Create contact+user for admin.
-    $contactID = \Civi\Api4\Contact::create(FALSE)
-      ->setValues([
-        'contact_type' => 'Individual',
-        'first_name' => 'Standalone',
-        'last_name' => 'Admin',
-      ])
-      ->execute()->first()['id'];
+    $adminUser = $e->getModel()->extras['adminUser'];
+    $adminPass = $e->getModel()->extras['adminPass'];
     $adminEmail = $e->getModel()->extras['adminEmail'];
-    $params = [
-      'cms_name'   => $e->getModel()->extras['adminUser'],
-      'cms_pass'   => $e->getModel()->extras['adminPass'],
-      'email'      => $adminEmail,
-      'notify'     => FALSE,
-      'contact_id' => $contactID,
-    ];
-    $userID = \CRM_Core_BAO_CMSUser::create($params, 'email');
+
+    $contactID = \Civi\Api4\Contact::create(FALSE)
+      ->addValue('contact_type', 'Individual')
+      ->addValue('first_name', 'Standalone')
+      ->addValue('last_name', 'Admin')
+      ->execute()->single()['id'];
+
+    // NOTE: normally uf_name would be derived automatically
+    // from the contact email, and roles could be provided using
+    // the facade on the User entity
+    // BUT: User BAO pre hooks are not online in the installer
+    // so we need to do them directly
+    $userID = \Civi\Api4\User::create(FALSE)
+      ->addValue('contact_id', $contactID)
+      ->addValue('username', $adminUser)
+      ->addValue('password', $adminPass)
+      ->addValue('uf_name', $adminEmail)
+      ->execute()->single()['id'];
 
     // Assign 'admin' role to user
     \Civi\Api4\UserRole::create(FALSE)
@@ -184,9 +189,9 @@ if (!defined('CIVI_SETUP')) {
       ->addValue('role_id', $roles['admin']['id'])
       ->execute();
 
-    $message = "Created new user \"{$e->getModel()->extras['adminUser']}\" (user ID #$userID, contact ID #$contactID) with 'admin' role and ";
+    $message = "Created new user \"{$adminUser}\" (user ID #$userID, contact ID #$contactID) with 'admin' role and ";
     $message .= empty($e->getModel()->extras['adminPassWasSpecified'])
-    ? "random password \"" . ($e->getModel()->extras['adminPass']) . '"'
+    ? "random password \"" . ($adminPass) . '"'
     : "specified password";
     \Civi::log()->notice($message);
 


### PR DESCRIPTION
Overview
-----------------------------------
Fix https://lab.civicrm.org/dev/core/-/issues/5396 and https://lab.civicrm.org/dev/core/-/issues/5503 


Before
----------------------------------------
- The admin user doesn't have an email record post install
- You have to specify the User email again when creating a user for a Contact that already has an email

After
----------------------------------------
- Default Standalone User email to the linked Contact primary email.
- Create an email record for the admin user contact on install

Technical Details
----------------------------------------
Unfortunately you can't use the default email behaviour during the install process, because extension hooks don't fire at that point.