### PR TITLE
civicrm#31342 Refactor for the renew link conditions

### DIFF
--- a/CRM/Member/Page/UserDashboard.php
+++ b/CRM/Member/Page/UserDashboard.php
@@ -76,11 +76,21 @@ class CRM_Member_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBoard 
 
   /**
    * Helper function to build appropriate Member links
+   *
+   * @array &members
+   * bool isActiveMembers
    */
-  public function buildMemberLinks(&$members) {
+  public function buildMemberLinks(&$members, $isActiveMembers) {
     if (!empty($members)) {
+      $statuses = ($isActiveMembers) ? ['Current', 'New', 'Cancelled', 'Deceased', 'Pending'] : ['Expired'];
       foreach ($members as $id => &$member) {
+
+        // Is this recurring membership?
         if (empty($member['contribution_recur_id'])) {
+          // Build Renewal Link if appropriate
+          if (($isActiveMembers && !in_array($member['status'], $statuses)) || (!$isActiveMembers && !empty($member['renewPageId']) && in_array($member['status'], $statuses))) {
+            $member['renewMembershipLink'] = CRM_Utils_System::url('civicrm/contribute/transact', "reset=1&id={$member['renewPageId']}&mid={$member['id']}", TRUE, NULL, FALSE, TRUE);
+          }
           continue;
         }
 

--- a/CRM/Member/Page/UserDashboard.php
+++ b/CRM/Member/Page/UserDashboard.php
@@ -80,7 +80,7 @@ class CRM_Member_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBoard 
    * @array &members
    * bool isActiveMembers
    */
-  public function buildMemberLinks(&$members, $isActiveMembers) {
+  public function buildMemberLinks(&$members, $isActiveMembers = FALSE) {
     if (!empty($members)) {
       $statuses = ($isActiveMembers) ? ['Current', 'New', 'Cancelled', 'Deceased', 'Pending'] : ['Expired'];
       foreach ($members as $id => &$member) {

--- a/templates/CRM/Member/Page/UserDashboard.tpl
+++ b/templates/CRM/Member/Page/UserDashboard.tpl
@@ -30,9 +30,9 @@
           <td class="crm-active-membership-start_date">{$activeMember.start_date|crmDate}</td>
           <td class="crm-active-membership-end_date">{$activeMember.end_date|crmDate}</td>
           <td class="crm-active-membership-status">{$activeMember.status}</td>
-          {if ($activeMember.status !== 'Current' AND $activeMember.status !== 'Cancelled') OR !empty($activeMember.cancelSubscriptionUrl) OR !empty($activeMember.updateSubscriptionBillingUrl) OR !empty($activeMember.updateSubscriptionURL)}
+          {if !empty($activeMember.renewMembershipLink) OR !empty($activeMember.cancelSubscriptionUrl) OR !empty($activeMember.updateSubscriptionBillingUrl) OR !empty($activeMember.updateSubscriptionURL)}
             <td class="crm-active-membership-renew">
-              {if $activeMember.status !== 'Current' AND $activeMember.status !== 'Cancelled'}<a href="{crmURL p='civicrm/contribute/transact' q="id=`$activeMember.renewPageId`&mid=`$activeMember.id`&reset=1"}" class="button"><span class="nowrap">{ts}Renew Now{/ts}</span></a>{/if}
+              {if !empty($activeMember.renewMembershipLink}<a href="{$activeMember.renewMembershipLink}" class="button"><span class="nowrap">{ts}Renew Now{/ts}</span></a>{/if}
               {if !empty($activeMember.cancelSubscriptionUrl)}<a href="{$activeMember.cancelSubscriptionUrl}" class="button"><span class="nowrap">{ts}Cancel Subscription{/ts}</span></a>{/if}
               {if !empty($activeMember.updateSubscriptionBillingUrl)}<a href="{$activeMember.updateSubscriptionBillingUrl}" class="button"><span class="nowrap">{ts}Update Billing Information{/ts}</span></a>{/if}
               {if !empty($activeMember.updateSubscriptionUrl)}<a href="{$activeMember.updateSubscriptionUrl}" class="button"><span class="nowrap">{ts}Change Subscription Amount{/ts}</span></a>{/if}
@@ -67,15 +67,14 @@
           <td class="crm-inactive-membership-start_date">{$inActiveMember.start_date|crmDate}</td>
           <td class="crm-inactive-membership-end_date">{$inActiveMember.end_date|crmDate}</td>
           <td class="crm-inactive-membership-status">{$inActiveMember.status}</td>
-          {if $inActiveMember.status == 'Expired' OR !empty($activeMember.cancelSubscriptionUrl) OR !empty($activeMember.updateSubscriptionBillingUrl) OR !empty($activeMember.updateSubscriptionURL)}
+          {if !empty($inActiveMember.renewMembershipLink) OR !empty($inActiveMember.cancelSubscriptionUrl) OR !empty($inActiveMember.updateSubscriptionBillingUrl) OR !empty($inActiveMember.updateSubscriptionURL)}
             <td class="crm-active-membership-renew">
-              {if $inActiveMember.status == 'Expired'}<a href="{crmURL p='civicrm/contribute/transact' q="id=`$inActiveMember.renewPageId`&mid=`$inActiveMember.id`&reset=1"}" class="button"><span class="nowrap">{ts}Renew Now{/ts}</span></a>{/if}
+              {if !empty($inActiveMember.renewMembershipLink)}<a href="{$inActiveMember.renewMembershipLink}" class="button"><span class="nowrap">{ts}Renew Now{/ts}</span></a>{/if}
               {if !empty($inActiveMember.cancelSubscriptionUrl)}<a href="{$inActiveMember.cancelSubscriptionUrl}" class="button"><span class="nowrap">{ts}Cancel Subscription{/ts}</span></a>{/if}
               {if !empty($inActiveMember.updateSubscriptionBillingUrl)}<a href="{$inActiveMember.updateSubscriptionBillingUrl}" class="button"><span class="nowrap">{ts}Update Billing Information{/ts}</span></a>{/if}
               {if !empty($inActiveMember.updateSubscriptionUrl)}<a href="{$inActiveMember.updateSubscriptionUrl}" class="button"><span class="nowrap">{ts}Chnage Subscription Amount{/ts}</span></a>{/if}
             </td>
           {/if}
-          <td class="crm-inactive-membership-renew">{if $inActiveMember.renewPageId}<a href="{crmURL p='civicrm/contribute/transact' q="id=`$inActiveMember.renewPageId`&mid=`$inActiveMember.id`&reset=1"}">[ {ts}Renew Now{/ts} ]</a>{/if}</td>
         </tr>
         {/foreach}
         </table>

--- a/templates/CRM/Member/Page/UserDashboard.tpl
+++ b/templates/CRM/Member/Page/UserDashboard.tpl
@@ -32,7 +32,7 @@
           <td class="crm-active-membership-status">{$activeMember.status}</td>
           {if !empty($activeMember.renewMembershipLink) OR !empty($activeMember.cancelSubscriptionUrl) OR !empty($activeMember.updateSubscriptionBillingUrl) OR !empty($activeMember.updateSubscriptionURL)}
             <td class="crm-active-membership-renew">
-              {if !empty($activeMember.renewMembershipLink}<a href="{$activeMember.renewMembershipLink}" class="button"><span class="nowrap">{ts}Renew Now{/ts}</span></a>{/if}
+              {if !empty($activeMember.renewMembershipLink)}<a href="{$activeMember.renewMembershipLink}" class="button"><span class="nowrap">{ts}Renew Now{/ts}</span></a>{/if}
               {if !empty($activeMember.cancelSubscriptionUrl)}<a href="{$activeMember.cancelSubscriptionUrl}" class="button"><span class="nowrap">{ts}Cancel Subscription{/ts}</span></a>{/if}
               {if !empty($activeMember.updateSubscriptionBillingUrl)}<a href="{$activeMember.updateSubscriptionBillingUrl}" class="button"><span class="nowrap">{ts}Update Billing Information{/ts}</span></a>{/if}
               {if !empty($activeMember.updateSubscriptionUrl)}<a href="{$activeMember.updateSubscriptionUrl}" class="button"><span class="nowrap">{ts}Change Subscription Amount{/ts}</span></a>{/if}


### PR DESCRIPTION
Overview
----------------------------------------
Repeating the work in this merge https://github.com/civicrm/civicrm-core/pull/31342 but refactoring how the Renew links are being generated to consider the appropriate statuses for when the `Renew Now` should be displayed.

cc @colemanw @composerjk 