### PR TITLE
[REF][PHP8.2] Declare properies in CRM_Export_Form_Select

### DIFF
--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -53,6 +53,24 @@ class CRM_Export_Form_Select extends CRM_Core_Form_Task {
   public $_componentTable;
 
   /**
+   * @var bool
+   * @internal
+   */
+  public $_selectAll;
+
+  /**
+   * @var bool
+   * @internal
+   */
+  public $_matchingContacts;
+
+  /**
+   * @var array
+   * @internal
+   */
+  public $_greetingOptions;
+
+  /**
    * Use the form name to create the tpl file name.
    *
    * @return string


### PR DESCRIPTION
Overview
----------------------------------------
Declare properies in `CRM_Export_Form_Select`

Before
----
<img width="1280" alt="Screenshot 2024-10-26 at 11 07 40" src="https://github.com/user-attachments/assets/21a74db1-c352-4933-85d1-083ec4af9728">
------------------------------------


After
----------------------------------------
No more deprecation notices when exporting

Technical Details
----------------------------------------
I'm not very familiar with import/export in Civi, so decided to keep these properties public incase any extensions might be using them.