### PR TITLE
[REF][PHP8.2] Declare properies in CRM_Contact_Page_View_Tag

### DIFF
--- a/CRM/Contact/Page/View/Tag.php
+++ b/CRM/Contact/Page/View/Tag.php
@@ -17,6 +17,12 @@
 class CRM_Contact_Page_View_Tag extends CRM_Core_Page {
 
   /**
+   * @var int
+   * @internal
+   */
+  public $_contactId;
+
+  /**
    * Called when action is browse.
    */
   public function browse() {


### PR DESCRIPTION
Overview
----------------------------------------
Declare properies in `CRM_Contact_Page_View_Tag`

Before
----------------------------------------
`Creation of dynamic property CRM_Contact_Page_View_Tag::$_contactId is deprecated`

After
----------------------------------------
No such deprecation

Technical Details
----------------------------------------
This probably could/should be `protected`, but keeping it public keeps the risk and testing required to a minimum.