### PR TITLE
dev/core#5558 dev/core#5552 - Alternate - fix crash editing case activities with special chars in names

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -210,35 +210,15 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
    */
   public function setDefaultValues() {
     $this->_defaults = parent::setDefaultValues();
-    $targetContactValues = [];
-    foreach ($this->_caseId as $key => $val) {
-      //get all clients.
-      $clients = CRM_Case_BAO_Case::getContactNames($val);
-      if (isset($this->_activityId) && empty($_POST)) {
-        if (!CRM_Utils_Array::crmIsEmptyArray($this->_defaults['target_contact'])) {
-          $targetContactValues = array_combine(array_unique($this->_defaults['target_contact']),
-            explode(';', trim($this->_defaults['target_contact_value']))
-          );
-          //exclude all clients.
-          foreach ($clients as $clientId => $vals) {
-            if (array_key_exists($clientId, $targetContactValues)) {
-              unset($targetContactValues[$clientId]);
-            }
-          }
-        }
+    if (empty($this->_defaults['medium_id'])) {
+      // set default encounter medium CRM-4816
+      $medium = CRM_Core_OptionGroup::values('encounter_medium', FALSE, FALSE, FALSE, 'AND is_default = 1');
+      if (count($medium) == 1) {
+        $this->_defaults['medium_id'] = key($medium);
       }
-      $this->assign('targetContactValues', empty($targetContactValues) ? FALSE : $targetContactValues);
-
-      if (empty($this->_defaults['medium_id'])) {
-        // set default encounter medium CRM-4816
-        $medium = CRM_Core_OptionGroup::values('encounter_medium', FALSE, FALSE, FALSE, 'AND is_default = 1');
-        if (count($medium) == 1) {
-          $this->_defaults['medium_id'] = key($medium);
-        }
-      }
-
-      return $this->_defaults;
     }
+
+    return $this->_defaults;
   }
 
   public function buildQuickForm() {


### PR DESCRIPTION
Overview
----------------------------------------
Alternate to https://github.com/civicrm/civicrm-core/pull/31365

Before
----------------------------------------
* https://lab.civicrm.org/dev/core/-/issues/5558
* https://lab.civicrm.org/dev/core/-/issues/5552

After
----------------------------------------


Technical Details
----------------------------------------
This code does a lot of manipulation only to assign a smarty var that is never used. My guess is it's from older times when the contact widget was a different widget.

Also all the foreach loop was doing was acting arbitrarily on the first one since there's a return at the end of the loop. So the diff makes it look like a bigger change but really I'm just removing the useless crashy part and all that's left is the encountermedium code.

Comments
----------------------------------------

