### PR TITLE
dev/core#5558, dev/core#5552 - crash on file-on-case search result action if with-contact sort_name contains special chars

### DIFF
--- a/CRM/Activity/Form/Task/FileOnCase.php
+++ b/CRM/Activity/Form/Task/FileOnCase.php
@@ -77,10 +77,7 @@ class CRM_Activity_Form_Task_FileOnCase extends CRM_Activity_Form_Task {
       if (CRM_Case_BAO_Case::checkPermission($id, 'File On Case', $defaults['activity_type_id'])) {
 
         if (!CRM_Utils_Array::crmIsEmptyArray($defaults['target_contact'])) {
-          $targetContactValues = array_combine(array_unique($defaults['target_contact']),
-            explode(';', trim($defaults['target_contact_value']))
-          );
-          $targetContactValues = implode(',', array_keys($targetContactValues));
+          $targetContactValues = implode(',', array_unique($defaults['target_contact']));
         }
 
         $params = [


### PR DESCRIPTION
Overview
----------------------------------------
Same thing as
* https://lab.civicrm.org/dev/core/-/issues/5558
* https://lab.civicrm.org/dev/core/-/issues/5552

Before
----------------------------------------
1. Make a regular activity for a contact that has e.g. an `'` in their name.
2. Search - Find Activities
3. Select the activity and from the actions dropdown choose File On Case.
4. Pick a case.
5. Same crash as in above tickets.

After
----------------------------------------


Technical Details
----------------------------------------
While the code isn't completely useless as in https://github.com/civicrm/civicrm-core/pull/31369, it also does a lot of unnecessary work just to do an implode on the original ids array we already had. The target names aren't needed at all.

Comments
----------------------------------------

