### PR TITLE
Event Profiles: remove HR tags

### DIFF
--- a/templates/CRM/UF/Page/ProfileTemplates.tpl
+++ b/templates/CRM/UF/Page/ProfileTemplates.tpl
@@ -3,19 +3,13 @@
  *}
 <script type="text/template" id="designer_template">
   <div class="crm-designer-toolbar full-height">
-    <div class="crm-designer-buttonset-region ui-dialog-buttonset">
-    </div>
-    <hr />
-    <div class="crm-designer-palette-region full-height">
-    </div>
+    <div class="crm-designer-buttonset-region ui-dialog-buttonset"></div>
+    <div class="crm-designer-palette-region full-height"></div>
   </div>
   <div class="crm-designer-canvas full-height scroll">
     <div class="crm-designer-preview-canvas"></div>
-    <div class="crm-designer-form-region">
-    </div>
-    <hr />
-    <div class="crm-designer-fields-region">
-    </div>
+    <div class="crm-designer-form-region"></div>
+    <div class="crm-designer-fields-region"></div>
   </div>
 </script>
 
@@ -34,7 +28,6 @@
           </select>
         </span>
       </div>
-      <hr>
       <input type="text" class="crm-form-text" placeholder="{ts}Search Fields{/ts}" />
       <a class="crm-designer-palette-clear-search crm-hover-button" href="#" style="visibility:hidden" title="{ts}Clear search{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
       <div class="crm-designer-palette-controls">


### PR DESCRIPTION
Overview
----------------------------------------

Removes some odd-looking HRs from CiviEvent "Manage Profiles" popups

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/01e8e884-a88f-4076-8cf1-f9297f7f930e)

After
----------------------------------------

![image](https://github.com/user-attachments/assets/46a92d60-ccd3-4663-b30a-1765854c7244)

Comments
----------------------------------------

I pinged for feedback in the user-interface channel (https://chat.civicrm.org/civicrm/pl/m3zm8tehttrebyiy39ez6x69re)

cc @vingle @artfulrobot 