### PR TITLE
Event Profile: remove the preview button from the popup

### DIFF
--- a/templates/CRM/UF/Page/ProfileTemplates.tpl
+++ b/templates/CRM/UF/Page/ProfileTemplates.tpl
@@ -99,7 +99,6 @@
 
 <script type="text/template" id="designer_buttons_template">
   <button class="crm-designer-save">{ts}Save{/ts}</button>
-  <button class="crm-designer-preview">{ts}Preview{/ts}</button>
 </script>
 
 <script type="text/template" id="field_canvas_view_template">


### PR DESCRIPTION
Overview
----------------------------------------

When editing a profile from the Manage Event screen, remove the "preview" button, which is clutter-y and does not work anyway.

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/ace7080d-d465-4b61-a0ac-628db3f51677)

Broken preview:

![image](https://github.com/user-attachments/assets/52bdbd87-c291-43e9-9713-687aa199f37f)

After
----------------------------------------

![image](https://github.com/user-attachments/assets/826d50b4-55f7-4c7e-b19b-7458b4ec8756)

Technical Details
----------------------------------------

This UI runs on Backbone and I don't feel like debugging this. It has probably been broken for a long time.

Besides, unless an admin is doing something really fancy, they sort of see a preview, but most of the time, you want to see the actual live form, not a backend preview - although there is a backend preview, when we close the popup (and it works).

Comments
----------------------------------------

See also #31383

I pinged for feedback in the user-interface channel (https://chat.civicrm.org/civicrm/pl/m3zm8tehttrebyiy39ez6x69re)