### PR TITLE
Copy functions back to only caller, deprecate old versions, clean up & fix undefined property

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -65,7 +65,7 @@ INNER JOIN   civicrm_contact AS contact ON ( contact.id = contrib.contact_id )
    *
    * @return array|null
    *   associated array
-
+   *
    * @deprecated since 5.80 will be removed around 5.90
    */
   public static function contributionChartYearly() {

--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -19,6 +19,7 @@ class CRM_Contribute_BAO_Contribution_Utils {
   /**
    * Get the contribution details by month of the year.
    *
+   * @deprecated since 5.80 will be removed around 5.90
    * @param int $param
    *   Year.
    *
@@ -26,6 +27,7 @@ class CRM_Contribute_BAO_Contribution_Utils {
    *   associated array
    */
   public static function contributionChartMonthly($param) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     if ($param) {
       $param = [1 => [$param, 'Integer']];
     }
@@ -63,8 +65,11 @@ INNER JOIN   civicrm_contact AS contact ON ( contact.id = contrib.contact_id )
    *
    * @return array|null
    *   associated array
+
+   * @deprecated since 5.80 will be removed around 5.90
    */
   public static function contributionChartYearly() {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     $config = CRM_Core_Config::singleton();
     $yearClause = "year(contrib.receive_date) as contribYear";
     if (!empty($config->fiscalYearStart) && ($config->fiscalYearStart['M'] != 1 || $config->fiscalYearStart['d'] != 1)) {

--- a/CRM/Contribute/Form/ContributionCharts.php
+++ b/CRM/Contribute/Form/ContributionCharts.php
@@ -92,7 +92,7 @@ class CRM_Contribute_Form_ContributionCharts extends CRM_Core_Form {
     }
 
     //take contribution information monthly
-    $chartInfoMonthly = CRM_Contribute_BAO_Contribution_Utils::contributionChartMonthly($selectedYear);
+    $chartInfoMonthly = $this->contributionChartMonthly($selectedYear);
 
     $chartData = $abbrMonthNames = [];
     if (is_array($chartInfoMonthly)) {
@@ -117,7 +117,7 @@ class CRM_Contribute_Form_ContributionCharts extends CRM_Core_Form {
     }
 
     //take contribution information by yearly
-    $chartInfoYearly = CRM_Contribute_BAO_Contribution_Utils::contributionChartYearly();
+    $chartInfoYearly = $this->contributionChartYearly();
 
     //get the years.
     $this->_years = $chartInfoYearly['By Year'] ?? [];
@@ -219,5 +219,90 @@ class CRM_Contribute_Form_ContributionCharts extends CRM_Core_Form {
     $this->assign('hasChart', !empty($chartData));
     $this->assign('chartData', json_encode($chartData ?? []));
   }
+
+
+  /**
+   * Get the contribution details by month of the year.
+   *
+   * @param int $param
+   *   Year.
+   *
+   * @return array|null
+   *   associated array
+   */
+  private function contributionChartMonthly($param) {
+    if ($param) {
+      $param = [1 => [$param, 'Integer']];
+    }
+    else {
+      $param = date("Y");
+      $param = [1 => [$param, 'Integer']];
+    }
+
+    $query = "
+    SELECT   sum(contrib.total_amount) AS ctAmt,
+             MONTH( contrib.receive_date) AS contribMonth
+      FROM   civicrm_contribution AS contrib
+INNER JOIN   civicrm_contact AS contact ON ( contact.id = contrib.contact_id )
+     WHERE   contrib.contact_id = contact.id
+       AND   contrib.is_test = 0
+       AND   contrib.contribution_status_id = 1
+       AND   date_format(contrib.receive_date,'%Y') = %1
+       AND   contact.is_deleted = 0
+  GROUP BY   contribMonth
+  ORDER BY   month(contrib.receive_date)";
+
+    $dao = CRM_Core_DAO::executeQuery($query, $param);
+
+    $params = NULL;
+    while ($dao->fetch()) {
+      if ($dao->contribMonth) {
+        $params['By Month'][$dao->contribMonth] = $dao->ctAmt;
+      }
+    }
+    return $params;
+  }
+
+  /**
+   * Get the contribution details by year.
+   *
+   * @return array|null
+   *   associated array
+   */
+  private function contributionChartYearly() {
+    $config = CRM_Core_Config::singleton();
+    $yearClause = "year(contrib.receive_date) as contribYear";
+    if (!empty($config->fiscalYearStart) && ($config->fiscalYearStart['M'] != 1 || $config->fiscalYearStart['d'] != 1)) {
+      $yearClause = "CASE
+        WHEN (MONTH(contrib.receive_date)>= " . $config->fiscalYearStart['M'] . "
+          && DAYOFMONTH(contrib.receive_date)>= " . $config->fiscalYearStart['d'] . " )
+          THEN
+            concat(YEAR(contrib.receive_date), '-',YEAR(contrib.receive_date)+1)
+          ELSE
+            concat(YEAR(contrib.receive_date)-1,'-', YEAR(contrib.receive_date))
+        END AS contribYear";
+    }
+
+    $query = "
+    SELECT   sum(contrib.total_amount) AS ctAmt,
+             {$yearClause}
+      FROM   civicrm_contribution AS contrib
+INNER JOIN   civicrm_contact contact ON ( contact.id = contrib.contact_id )
+     WHERE   contrib.is_test = 0
+       AND   contrib.contribution_status_id = 1
+       AND   contact.is_deleted = 0
+  GROUP BY   contribYear
+  ORDER BY   contribYear";
+    $dao = CRM_Core_DAO::executeQuery($query);
+
+    $params = NULL;
+    while ($dao->fetch()) {
+      if (!empty($dao->contribYear)) {
+        $params['By Year'][$dao->contribYear] = $dao->ctAmt;
+      }
+    }
+    return $params;
+  }
+
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

1) moves some one-form-only functions back to that clas (Having public static functions on other classes makes it hard to rationalise code as there is the possibility of something else calling it)
2) does some code cleanup 
3) resolves the property

The thing that is really confusing prior to clean up is the property is set in PostProcess & accessed in buildForm but (perhaps because of this property) preProcess calls postProcess before buildForm is called ... got it?

This moves the property off to a function that handles the property within the function - note the value is used for 2 things

1) to render the chart on the right (get the values)
2) to come up with a list of valid years for the selector under the 'month' graph


- 
Before
----------------------------------------
![image](https://github.com/user-attachments/assets/f1524589-40ce-4986-8c9f-5424380cb8ba)

After
----------------------------------------
![image](https://github.com/user-attachments/assets/dd02d4f5-ff3a-41f4-b84a-45b5791dec34)


Ode to Quick form - let me list all the ways I love you
----------------------------------------
- 

