### PR TITLE
(dev/core#4462) Form Builder (etal) - Define generic permissions to assist with message-tokens

### DIFF
--- a/CRM/Core/Permission/List.php
+++ b/CRM/Core/Permission/List.php
@@ -86,6 +86,11 @@ class CRM_Core_Permission_List {
       // The functionality that actually handles this pseudo-permission is in `CRM_Core_Permission_*::check()`
       'implies' => ['*'],
     ];
+    $e->permissions[\CRM_Core_Permission::ANY_AUTHENTICATED_CONTACT] = [
+      'group' => 'const',
+      'title' => ts('Generic: Allow any authenticated contact'),
+      'is_synthetic' => TRUE,
+    ];
   }
 
 }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -503,6 +503,7 @@ class Container {
     $dispatcher->addListener('hook_civicrm_permissionList', ['CRM_Core_Permission_List', 'findConstPermissions'], 975);
     $dispatcher->addListener('hook_civicrm_permissionList', ['CRM_Core_Permission_List', 'findCiviPermissions'], 950);
     $dispatcher->addListener('hook_civicrm_permissionList', ['CRM_Core_Permission_List', 'findCmsPermissions'], 925);
+    $dispatcher->addListener('hook_civicrm_permission_check', ['CRM_Core_Permission', 'checkConstPermissions'], 1000);
 
     $dispatcher->addListener('hook_civicrm_postSave_civicrm_domain', ['\CRM_Core_BAO_Domain', 'onPostSave']);
     $dispatcher->addListener('hook_civicrm_unhandled_exception', [

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -457,6 +457,11 @@ function afform_civicrm_permission_check($permission, &$granted, $contactId) {
       ->first();
     $granted = $check['access'];
   }
+  elseif ($permission === '@afformPageToken') {
+    $session = CRM_Core_Session::singleton();
+    $data = $session->get('authx');
+    $granted = isset($data['jwt']['scope'], $data['flow']) && $data['jwt']['scope'] === 'afform' && $data['flow'] === 'afformpage';
+  }
 }
 
 /**
@@ -465,6 +470,11 @@ function afform_civicrm_permission_check($permission, &$granted, $contactId) {
  * @see CRM_Utils_Hook::permissionList()
  */
 function afform_civicrm_permissionList(&$permissions) {
+  $permissions['@afformPageToken'] = [
+    'group' => 'const',
+    'title' => E::ts('Generic: Anyone with secret link'),
+    'description' => E::ts('If you link to the form with a secure token, then no other permission is needed.'),
+  ];
   $scanner = Civi::service('afform_scanner');
   foreach ($scanner->getMetas() as $name => $meta) {
     $permissions['@afform:' . $name] = [

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -446,18 +446,17 @@ function afform_civicrm_permission(&$permissions) {
  * @see CRM_Utils_Hook::permission_check()
  */
 function afform_civicrm_permission_check($permission, &$granted, $contactId) {
-  if (!str_starts_with($permission, '@afform:') || strlen($permission) < 9) {
-    // Micro-optimization - this function may get hit a lot.
-    return;
+  // Micro-optimization - this function may get hit a lot.
+  if (str_starts_with($permission, '@afform:') && strlen($permission) >= 9) {
+    [, $name] = explode(':', $permission, 2);
+    // Delegate permission check to APIv4
+    $check = \Civi\Api4\Afform::checkAccess()
+      ->addValue('name', $name)
+      ->setAction('get')
+      ->execute()
+      ->first();
+    $granted = $check['access'];
   }
-  [, $name] = explode(':', $permission, 2);
-  // Delegate permission check to APIv4
-  $check = \Civi\Api4\Afform::checkAccess()
-    ->addValue('name', $name)
-    ->setAction('get')
-    ->execute()
-    ->first();
-  $granted = $check['access'];
 }
 
 /**

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -446,7 +446,7 @@ function afform_civicrm_permission(&$permissions) {
  * @see CRM_Utils_Hook::permission_check()
  */
 function afform_civicrm_permission_check($permission, &$granted, $contactId) {
-  // Micro-optimization - this function may get hit a lot.
+  // This function may get hit a lot. Try to keep the conditionals efficient.
   if (str_starts_with($permission, '@afform:') && strlen($permission) >= 9) {
     [, $name] = explode(':', $permission, 2);
     // Delegate permission check to APIv4

--- a/ext/afform/mock/tests/phpunit/Civi/AfformMock/FormTestCase.php
+++ b/ext/afform/mock/tests/phpunit/Civi/AfformMock/FormTestCase.php
@@ -56,7 +56,7 @@ abstract class FormTestCase extends \PHPUnit\Framework\TestCase implements \Civi
   }
 
   protected function revertForm() {
-    \Civi\Api4\Afform::revert()
+    \Civi\Api4\Afform::revert(FALSE)
       ->addWhere('name', '=', $this->getFormName())
       ->execute();
     return $this;

--- a/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormTest.php
+++ b/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormTest.php
@@ -2,7 +2,10 @@
 
 namespace E2E\AfformMock;
 
+use Civi\Authx\AuthxRequestBuilder;
 use CRM_Core_DAO;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Uri;
 
 /**
  * Perform some tests against `mockPublicForm.aff.html`.
@@ -26,6 +29,15 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
     'Drupal' => '/<body.* class=".* logged-in[ "]/',
     'Drupal8' => '/<body.* class=".* user-logged-in[ "]/',
   ];
+
+  protected ?AuthxRequestBuilder $authxRequest;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->authxRequest = (new AuthxRequestBuilder())
+      ->addFlow('afformpage', [$this, 'authAfformPage'])
+      ->addCred('afformjwt', [$this, 'credAfformJwt']);
+  }
 
   public function testGetPage() {
     $r = $this->createGuzzle()->get('civicrm/mock-public-form');
@@ -189,6 +201,94 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
     $this->assertBodyRegexp($this->sessionCues[CIVICRM_UF], $sendRequest(['userMode' => 'require']));
   }
 
+  public function getAuthUrlPermissionExamples(): array {
+    // What kind of users might request the form?
+    $asDemo = ['xheader', 'jwt', 'getDemoCID'];
+    $asLebowski = ['xheader', 'jwt', 'getLebowskiCID'];
+    $asLebowskiPageToken = ['afformpage', 'afformjwt', 'getLebowskiCID'];
+    $asAnon = ['none', 'none', NULL];
+
+    $cases = [];
+    // Array(array $formSpec, string $flowType, string $credType, string $cidProvider, bool $expectRencdered)
+
+    $permAlways = ['permission' => '*always allow*'];
+    $cases['always-demo'] = [$permAlways, ...$asDemo, TRUE];
+    $cases['always-lebowski-xhj'] = [$permAlways, ...$asLebowski, TRUE];
+    $cases['always-lebowski-aff'] = [$permAlways, ...$asLebowskiPageToken, TRUE];
+    $cases['always-anon'] = [$permAlways, ...$asAnon, TRUE];
+
+    $permAuthenticated = ['permission' => '*authenticated*'];
+    $cases['auth-demo'] = [$permAuthenticated, ...$asDemo, TRUE];
+    $cases['auth-lebowski-xhj'] = [$permAuthenticated, ...$asLebowski, TRUE];
+    $cases['auth-lebowski-aff'] = [$permAuthenticated, ...$asLebowskiPageToken, TRUE];
+    $cases['auth-anon'] = [$permAuthenticated, ...$asAnon, FALSE];
+
+    $permAdmin = ['permission' => 'administer CiviCRM'];
+    $cases['admin-demo'] = [$permAdmin, ...$asDemo, TRUE];
+    $cases['admin-lebowski-xhj'] = [$permAdmin, ...$asLebowski, FALSE];
+    $cases['admin-lebowski-aff'] = [$permAdmin, ...$asLebowskiPageToken, FALSE];
+    $cases['admin-anon'] = [$permAdmin, ...$asAnon, FALSE];
+
+    $permSecretLink = ['permission' => '@afformPageToken'];
+    $cases['secret-demo'] = [$permSecretLink, ...$asDemo, FALSE];
+    $cases['secret-lebowski-xhj'] = [$permSecretLink, ...$asLebowski, FALSE];
+    $cases['secret-lebowski-aff'] = [$permSecretLink, ...$asLebowskiPageToken, TRUE];
+    $cases['secret-anon'] = [$permSecretLink, ...$asAnon, FALSE];
+
+    $permAccessCiviOrSecretLink = ['permission' => ['access CiviCRM', '@afformPageToken'], 'permission_operator' => 'OR'];
+    $cases['or-demo'] = [$permAccessCiviOrSecretLink, ...$asDemo, TRUE];
+    $cases['or-lebowski-xhj'] = [$permAccessCiviOrSecretLink, ...$asLebowski, FALSE];
+    $cases['or-lebowski-aff'] = [$permAccessCiviOrSecretLink, ...$asLebowskiPageToken, TRUE];
+
+    $permAccessCiviAndSecretLink = ['permission' => ['access CiviCRM', '@afformPageToken'], 'permission_operator' => 'AND'];
+    $cases['and-demo'] = [$permAccessCiviAndSecretLink, ...$asDemo, FALSE];
+    $cases['and-lebowski-xhj'] = [$permAccessCiviAndSecretLink, ...$asLebowski, FALSE];
+    $cases['and-lebowski-aff'] = [$permAccessCiviAndSecretLink, ...$asLebowskiPageToken, FALSE];
+
+    return $cases;
+  }
+
+  /**
+   * The general purpose of the test is to see how special permissions -- like '*always allow*',
+   * '*authenticated*', or '@afformPageToken' behave.
+   *
+   * @param array $formSpec
+   *   Configuration options to apply the form.
+   *   Ex: ['permission' => 'administer CiviCRM']
+   * @param string $flowType
+   *   How to transmit authentication info for this HTTP request.
+   *   Ex: 'param', 'header', 'xheader'
+   * @param string $credType
+   *   How to encode the credential.
+   *   Ex: 'pass', 'jwt', 'afformjwt'
+   * @param string|null $contactMethod
+   *   For an authenticated page-view, which contact should we use?
+   *   Ex: 'getLebowskiCID', 'getDemoCID'
+   * @param bool $expectRendered
+   *   Should the form be displayed?
+   * @dataProvider getAuthUrlPermissionExamples
+   */
+  public function testSpecialPermissions(array $formSpec, string $flowType, string $credType, ?string $contactMethod, bool $expectRendered): void {
+    \Civi\Api4\Afform::update(FALSE)
+      ->addWhere('name', '=', $this->formName)
+      ->setValues($formSpec)
+      ->execute();
+
+    $contactId = $contactMethod ? $this->$contactMethod() : NULL;
+    $http = $this->createGuzzle(['http_errors' => FALSE]);
+    $formUrl = \Civi::url('frontend://civicrm/mock-public-form', 'a');
+    $request = $this->authxRequest->applyAuth(new Request('GET', (new Uri($formUrl))), $credType, $flowType, $contactId);
+    $response = $http->send($request);
+
+    if ($expectRendered) {
+      $this->assertStatusCode(200, $response);
+      $this->assertContentType('text/html', $response);
+    }
+    else {
+      $this->assertPageNotShown($response);
+    }
+  }
+
   protected function renderTokens($cid, $body, $format) {
     $tp = new \Civi\Token\TokenProcessor(\Civi::dispatcher(), []);
     $tp->addRow()->context('contactId', $cid);
@@ -294,6 +394,25 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
     // We make another request in the same session. Is it the expected contact?
     $response = $http->get('civicrm/authx/id');
     $this->assertContactJson($contactId, $response);
+  }
+
+  public function authAfformPage(Request $request, $cred) {
+    $query = $request->getUri()->getQuery();
+    return $request->withUri(
+      $request->getUri()->withQuery($query . '&_aff=' . urlencode($cred))
+    );
+  }
+
+  public function credAfformJwt(int $cid, array $claims = []) {
+    $defaults = [
+      'exp' => \CRM_Utils_Time::time() + (60 * 60),
+      'sub' => 'cid:' . $cid,
+      'scope' => 'afform',
+      'afform' => $this->formName,
+    ];
+
+    $token = \Civi::service('crypto.jwt')->encode(array_merge($defaults, $claims));
+    return 'Bearer ' . $token;
   }
 
 }

--- a/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormTest.php
+++ b/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormTest.php
@@ -17,6 +17,16 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
 
   protected $formName = 'mockPublicForm';
 
+  /**
+   * These patterns are hints to indicate whether the page-view is authenticated in the CMS.
+   * @var string[]
+   */
+  private $sessionCues = [
+    'Backdrop' => '/<body.* class=".* logged-in[ "]/',
+    'Drupal' => '/<body.* class=".* logged-in[ "]/',
+    'Drupal8' => '/<body.* class=".* user-logged-in[ "]/',
+  ];
+
   public function testGetPage() {
     $r = $this->createGuzzle()->get('civicrm/mock-public-form');
     $this->assertContentType('text/html', $r);
@@ -152,14 +162,7 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
    * We do a sniff test to see if a few other exampleswork.
    */
   public function testAuthenticatedUrl_CustomJwt(): void {
-    $sessionCues = [
-      // These patterns are hints to indicate whether the page-view is authenticated in the CMS.
-      'Backdrop' => '/<body.* class=".* logged-in[ "]/',
-      'Drupal' => '/<body.* class=".* logged-in[ "]/',
-      'Drupal8' => '/<body.* class=".* user-logged-in[ "]/',
-    ];
-
-    if (!isset($sessionCues[CIVICRM_UF])) {
+    if (!isset($this->sessionCues[CIVICRM_UF])) {
       $this->markTestIncomplete(sprintf('Cannot run test for this environment (%s). Need session-cues to identify logged-in page-views.', CIVICRM_UF));
     }
 
@@ -181,9 +184,9 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
 
     // This might be nicer as 4 separate tests.
     $this->assertBodyRegexp('/Invalid credential/', $sendRequest(['scope' => 'wrong-scope']));
-    $this->assertNotBodyRegexp($sessionCues[CIVICRM_UF], $sendRequest(['userMode' => 'ignore']));
-    $this->assertBodyRegexp($sessionCues[CIVICRM_UF], $sendRequest(['userMode' => 'optional']));
-    $this->assertBodyRegexp($sessionCues[CIVICRM_UF], $sendRequest(['userMode' => 'require']));
+    $this->assertNotBodyRegexp($this->sessionCues[CIVICRM_UF], $sendRequest(['userMode' => 'ignore']));
+    $this->assertBodyRegexp($this->sessionCues[CIVICRM_UF], $sendRequest(['userMode' => 'optional']));
+    $this->assertBodyRegexp($this->sessionCues[CIVICRM_UF], $sendRequest(['userMode' => 'require']));
   }
 
   protected function renderTokens($cid, $body, $format) {

--- a/ext/authx/Civi/Authx/AuthxRequestBuilder.php
+++ b/ext/authx/Civi/Authx/AuthxRequestBuilder.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Civi\Authx;
+
+use GuzzleHttp\Psr7\AppendStream;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
+
+/**
+ * (TEST HELPER/EXPERIMENTAL)
+ * This class helps with building test-scenarios where we use different authx flows/credentials.
+ * It is based on refactoring test code. It still includes some test-specific bits (like knowledge of the "demo" user).
+ */
+class AuthxRequestBuilder {
+
+  protected $flows;
+
+  protected $creds;
+
+  public function __construct() {
+    $this->flows = [
+      'param' => [$this, 'authParam'],
+      'auto' => [$this, 'authAuto'],
+      'login' => [$this, 'authLogin'],
+      'header' => fn(Request $request, $cred) => $request->withHeader('Authorization', $cred),
+      'xheader' => fn(Request $request, $cred) => $request->withHeader('X-Civi-Auth', $cred),
+      'none' => fn(Request $request, $cred) => $request,
+    ];
+    $this->creds = [
+      'pass' => [$this, 'credPass'],
+      'api_key' => [$this, 'credApikey'],
+      'jwt' => [$this, 'credJwt'],
+      'none' => fn($cid) => NULL,
+    ];
+  }
+
+  /**
+   * Apply authentication options to a prepared HTTP request.
+   *
+   * @param \Psr\Http\Message\RequestInterface $request
+   *   The original HTTP request (without any authentication options).
+   * @param string $credType
+   *   Ex: 'pass', 'jwt', 'api_key'
+   * @param string $flowType
+   *   Ex: 'param', 'header', 'xheader'
+   * @param int $cid
+   *   Authenticate as a specific contact (contact ID#).
+   * @return \Psr\Http\Message\RequestInterface
+   *   The new HTTP request (with authentication options).
+   */
+  public function applyAuth($request, $credType, $flowType, $cid) {
+    $cred = $this->createCred($credType, $cid);
+    return $this->applyFlow($request, $flowType, $cred);
+  }
+
+  /**
+   * Apply authentication options to a prepared HTTP request.
+   *
+   * @param \Psr\Http\Message\RequestInterface $request
+   *   The original HTTP request (without any authentication options).
+   * @param string $flowType
+   *   Ex: 'param', 'header', 'xheader'
+   * @param string $credValue
+   *   Ex: 'Bearer ABCD1234'
+   * @return \Psr\Http\Message\RequestInterface
+   *   The new HTTP request (with authentication options).
+   */
+  public function applyFlow($request, $flowType, $credValue) {
+    $flowFunc = $this->flows[$flowType] ?? NULL;
+    if (!$flowFunc) {
+      throw new \LogicException("Invalid flow type: $flowType");
+    }
+    return $flowFunc($request, $credValue);
+  }
+
+  /**
+   * Create a credential of the given type on behalf of the given contact
+   * @param string $credType
+   * @param int $cid
+   * @return string
+   */
+  public function createCred($credType, $cid) {
+    $credFunc = $this->creds[$credType] ?? NULL;
+    if (!$credFunc) {
+      throw new \LogicException("Invalid credential type: $credType");
+    }
+    return $credFunc($cid);
+  }
+
+  public function addFlow(string $flowType, callable $flowFunc) {
+    $this->flows[$flowType] = $flowFunc;
+    return $this;
+  }
+
+  public function addCred(string $credType, callable $credFunc) {
+    $this->creds[$credType] = $credFunc;
+    return $this;
+  }
+
+  // ------------------------------------------------
+  // Library: Flow functions
+
+  /**
+   * Add query parameter ("&_authx=<CRED>").
+   *
+   * @param \GuzzleHttp\Psr7\Request $request
+   * @param string $cred
+   *   The credential add to the request (e.g. "Basic ASDF==" or "Bearer FDSA").
+   * @return \GuzzleHttp\Psr7\Request
+   */
+  protected function authParam(Request $request, $cred) {
+    $query = $request->getUri()->getQuery();
+    return $request->withUri(
+      $request->getUri()->withQuery($query . '&_authx=' . urlencode($cred))
+    );
+  }
+
+  /**
+   * Add query parameter ("&_authx=<CRED>&_authxSes=1").
+   *
+   * @param \GuzzleHttp\Psr7\Request $request
+   * @param string $cred
+   *   The credential add to the request (e.g. "Basic ASDF==" or "Bearer FDSA").
+   * @return \GuzzleHttp\Psr7\Request
+   */
+  protected function authAuto(Request $request, $cred) {
+    $query = $request->getUri()->getQuery();
+    return $request->withUri(
+      $request->getUri()->withQuery($query . '&_authx=' . urlencode($cred) . '&_authxSes=1')
+    );
+  }
+
+  protected function authLogin(Request $request, $cred) {
+    return $request->withMethod('POST')
+      ->withBody(new AppendStream([
+        Utils::streamFor('_authx=' . urlencode($cred) . '&'),
+        $request->getBody(),
+      ]));
+  }
+
+  // ------------------------------------------------
+  // Library: Credential functions
+
+  /**
+   * @param int $cid
+   * @return string
+   *   The credential add to the request (e.g. "Basic ASDF==" or "Bearer FDSA").
+   */
+  protected function credPass($cid) {
+    if ($cid === $this->getDemoCID()) {
+      return 'Basic ' . base64_encode($GLOBALS['_CV']['DEMO_USER'] . ':' . $GLOBALS['_CV']['DEMO_PASS']);
+    }
+    else {
+      $this->fail("This test does not have the password for the requested contact.");
+    }
+  }
+
+  public function credApikey($cid) {
+    $api_key = md5(\random_bytes(16));
+    \civicrm_api3('Contact', 'create', [
+      'id' => $cid,
+      'api_key' => $api_key,
+    ]);
+    return 'Bearer ' . $api_key;
+  }
+
+  public function credJwt($cid, $expired = FALSE) {
+    if (empty(\Civi::service('crypto.registry')->findKeysByTag('SIGN'))) {
+      $this->markTestIncomplete('Cannot test JWT. No CIVICRM_SIGN_KEYS are defined.');
+    }
+    $token = \Civi::service('crypto.jwt')->encode([
+      'exp' => $expired ? time() - 60 * 60 : time() + 60 * 60,
+      'sub' => "cid:$cid",
+      'scope' => 'authx',
+    ]);
+    return 'Bearer ' . $token;
+  }
+
+  /**
+   * @return int
+   * @throws \CRM_Core_Exception
+   */
+  protected function getDemoCID(): int {
+    if (!isset(\Civi::$statics[__CLASS__]['demoId'])) {
+      \Civi::$statics[__CLASS__]['demoId'] = (int) \civicrm_api3('Contact', 'getvalue', [
+        'id' => '@user:' . $GLOBALS['_CV']['DEMO_USER'],
+        'return' => 'id',
+      ]);
+    }
+    return \Civi::$statics[__CLASS__]['demoId'];
+  }
+
+}

--- a/ext/authx/tests/phpunit/Civi/Authx/AbstractFlowsTest.php
+++ b/ext/authx/tests/phpunit/Civi/Authx/AbstractFlowsTest.php
@@ -4,11 +4,9 @@ namespace Civi\Authx;
 
 use Civi\Test\EndToEndInterface;
 use Civi\Test\HttpTestTrait;
-use GuzzleHttp\Psr7\AppendStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\ResponseInterface;
-use GuzzleHttp\Psr7\Utils;
 
 class AbstractFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterface {
 
@@ -91,9 +89,7 @@ class AbstractFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndI
    *   The new HTTP request (with authentication options).
    */
   protected function applyAuth($request, $credType, $flowType, $cid) {
-    $credFunc = 'cred' . ucfirst(preg_replace(';[^a-zA-Z0-9];', '', $credType));
-    $flowFunc = 'auth' . ucfirst(preg_replace(';[^a-zA-Z0-9];', '', $flowType));
-    return $this->$flowFunc($request, $this->$credFunc($cid));
+    return (new AuthxRequestBuilder())->applyAuth($request, $credType, $flowType, $cid);
   }
 
   // ------------------------------------------------
@@ -193,98 +189,16 @@ class AbstractFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndI
   }
 
   // ------------------------------------------------
-  // Library: Flow functions
 
   /**
-   * Add query parameter ("&_authx=<CRED>").
-   *
-   * @param \GuzzleHttp\Psr7\Request $request
-   * @param string $cred
-   *   The credential add to the request (e.g. "Basic ASDF==" or "Bearer FDSA").
-   * @return \GuzzleHttp\Psr7\Request
+   * @deprecated
    */
-  public function authParam(Request $request, $cred) {
-    $query = $request->getUri()->getQuery();
-    return $request->withUri(
-      $request->getUri()->withQuery($query . '&_authx=' . urlencode($cred))
-    );
-  }
-
-  /**
-   * Add query parameter ("&_authx=<CRED>&_authxSes=1").
-   *
-   * @param \GuzzleHttp\Psr7\Request $request
-   * @param string $cred
-   *   The credential add to the request (e.g. "Basic ASDF==" or "Bearer FDSA").
-   * @return \GuzzleHttp\Psr7\Request
-   */
-  public function authAuto(Request $request, $cred) {
-    $query = $request->getUri()->getQuery();
-    return $request->withUri(
-      $request->getUri()->withQuery($query . '&_authx=' . urlencode($cred) . '&_authxSes=1')
-    );
-  }
-
-  public function authLogin(Request $request, $cred) {
-    return $request->withMethod('POST')
-      ->withBody(new AppendStream([
-        Utils::streamFor('_authx=' . urlencode($cred) . '&'),
-        $request->getBody(),
-      ]));
-  }
-
-  public function authHeader(Request $request, $cred) {
-    return $request->withHeader('Authorization', $cred);
-  }
-
-  public function authXHeader(Request $request, $cred) {
-    return $request->withHeader('X-Civi-Auth', $cred);
-  }
-
-  public function authNone(Request $request, $cred) {
-    return $request;
-  }
-
-  // ------------------------------------------------
-  // Library: Credential functions
-
-  /**
-   * @param int $cid
-   * @return string
-   *   The credential add to the request (e.g. "Basic ASDF==" or "Bearer FDSA").
-   */
-  public function credPass($cid) {
-    if ($cid === $this->getDemoCID()) {
-      return 'Basic ' . base64_encode($GLOBALS['_CV']['DEMO_USER'] . ':' . $GLOBALS['_CV']['DEMO_PASS']);
-    }
-    else {
-      $this->fail("This test does have the password the requested contact.");
-    }
-  }
-
   public function credApikey($cid) {
-    $api_key = md5(\random_bytes(16));
-    \civicrm_api3('Contact', 'create', [
-      'id' => $cid,
-      'api_key' => $api_key,
-    ]);
-    return 'Bearer ' . $api_key;
+    return (new AuthxRequestBuilder())->{__FUNCTION__}($cid);
   }
 
   public function credJwt($cid, $expired = FALSE) {
-    if (empty(\Civi::service('crypto.registry')->findKeysByTag('SIGN'))) {
-      $this->markTestIncomplete('Cannot test JWT. No CIVICRM_SIGN_KEYS are defined.');
-    }
-    $token = \Civi::service('crypto.jwt')->encode([
-      'exp' => $expired ? time() - 60 * 60 : time() + 60 * 60,
-      'sub' => "cid:$cid",
-      'scope' => 'authx',
-    ]);
-    return 'Bearer ' . $token;
-  }
-
-  public function credNone($cid) {
-    return NULL;
+    return (new AuthxRequestBuilder())->{__FUNCTION__}($cid, $expired);
   }
 
   /**

--- a/ext/authx/tests/phpunit/Civi/Authx/JwtCredsTest.php
+++ b/ext/authx/tests/phpunit/Civi/Authx/JwtCredsTest.php
@@ -22,9 +22,8 @@ class JwtCredsTest extends AbstractFlowsTest {
 
     $cred = $this->credJwt('Bearer thisisnotavalidjwt');
 
-    $flowFunc = 'auth' . ucfirst(preg_replace(';[^a-zA-Z0-9];', '', $flowType));
     /** @var \Psr\Http\Message\RequestInterface $request */
-    $request = $this->$flowFunc($this->requestMyContact(), $cred);
+    $request = (new AuthxRequestBuilder())->applyFlow($this->requestMyContact(), $flowType, $cred);
 
     \Civi::settings()->set("authx_{$flowType}_cred", ['jwt']);
     $response = $http->send($request);
@@ -43,9 +42,8 @@ class JwtCredsTest extends AbstractFlowsTest {
     $http = $this->createGuzzle(['http_errors' => FALSE]);
 
     $cred = $this->credJwt($this->getDemoCID(), TRUE);
-    $flowFunc = 'auth' . ucfirst(preg_replace(';[^a-zA-Z0-9];', '', $flowType));
     /** @var \Psr\Http\Message\RequestInterface $request */
-    $request = $this->$flowFunc($this->requestMyContact(), $cred);
+    $request = (new AuthxRequestBuilder())->applyFlow($this->requestMyContact(), $flowType, $cred);
 
     \Civi::settings()->set("authx_{$flowType}_cred", ['jwt']);
     $response = $http->send($request);

--- a/ext/authx/tests/phpunit/Civi/Authx/StatefulFlowsTest.php
+++ b/ext/authx/tests/phpunit/Civi/Authx/StatefulFlowsTest.php
@@ -23,7 +23,6 @@ class StatefulFlowsTest extends AbstractFlowsTest {
    */
   public function testStatefulLoginAllowed($credType): void {
     $flowType = 'login';
-    $credFunc = 'cred' . ucfirst(preg_replace(';[^a-zA-Z0-9];', '', $credType));
 
     // Phase 1: Some pages are not accessible.
     $http = $this->createGuzzle(['http_errors' => FALSE]);
@@ -35,7 +34,7 @@ class StatefulFlowsTest extends AbstractFlowsTest {
     $http = $this->createGuzzle(['http_errors' => FALSE, 'cookies' => $cookieJar]);
     \Civi::settings()->set("authx_{$flowType}_cred", [$credType]);
     $response = $http->post('civicrm/authx/login', [
-      'form_params' => ['_authx' => $this->$credFunc($this->getDemoCID())],
+      'form_params' => ['_authx' => (new AuthxRequestBuilder())->createCred($credType, $this->getDemoCID())],
     ]);
     $this->assertMyContact($this->getDemoCID(), $this->getDemoUID(), $credType, $flowType, $response);
     $this->assertHasCookies($response);
@@ -70,11 +69,11 @@ class StatefulFlowsTest extends AbstractFlowsTest {
   public function testStatefulLoginProhibited($credType): void {
     $flowType = 'login';
     $http = $this->createGuzzle(['http_errors' => FALSE]);
-    $credFunc = 'cred' . ucfirst(preg_replace(';[^a-zA-Z0-9];', '', $credType));
 
     \Civi::settings()->set("authx_{$flowType}_cred", []);
     $response = $http->post('civicrm/authx/login', [
-      'form_params' => ['_authx' => $this->$credFunc($this->getDemoCID())],
+      'form_params' => ['_authx' => (new AuthxRequestBuilder())->createCred($credType, $this->getDemoCID())],
+
     ]);
     $this->assertFailedDueToProhibition($response);
   }

--- a/ext/standaloneusers/CRM/Standaloneusers/Page/PermissionDenied.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/PermissionDenied.php
@@ -1,0 +1,21 @@
+<?php
+use CRM_Standaloneusers_ExtensionUtil as E;
+
+/**
+ * Display an "Access Denied" screen.
+ *
+ * This is only one of three ways in which "Access Denied" may be communicated.
+ * This specific variant is used for authenticated, stateless requests. See
+ * the main `permissionDenied()` controller for more complete explanation.
+ *
+ * @see CRM_Utils_System_Standalone::permissionDenied()
+ */
+class CRM_Standaloneusers_Page_PermissionDenied extends CRM_Core_Page {
+
+  public function run() {
+    http_response_code(403);
+    CRM_Utils_System::setTitle(ts('Access denied'));
+    parent::run();
+  }
+
+}

--- a/ext/standaloneusers/templates/CRM/Standaloneusers/Page/PermissionDenied.tpl
+++ b/ext/standaloneusers/templates/CRM/Standaloneusers/Page/PermissionDenied.tpl
@@ -1,0 +1,1 @@
+<p>{ts}You do not have permission to access that.{/ts}</p>


### PR DESCRIPTION
Overview
----------------------------------------

> This is a follow-up to https://github.com/civicrm/civicrm-core/pull/30585 (5.79.alpha) to address some of remaining issues (for 5.79.beta). It is part of https://lab.civicrm.org/dev/core/-/issues/4462.  It's one off-shoot from last week's discussion with @eileenmcnaughton @ufundo @seamuslee001 about about how to improve configuration of permissions.

Suppose you are creating a custom form. You wish to link to it from mailings/messages. You must define the permissions for reading the form. But which permissions should you use? You need to think about the roles/authorizations of every person in the email list.

Before
----------------------------------------

You can theoretically use permissions like `access CiviEvent` or `access CiviCRM`, but these aren't very useful for a list of email recipients.

When mailing links to regular constituents, the only useful option is `*always allow*`:

![Screenshot from 2024-10-29 15-41-16](https://github.com/user-attachments/assets/198bd52c-9379-4519-a637-c384db294359)

That's OK sometimes, but it can also be too broad -- it means that *anonymous users* (who never received the email) can access it.

After
----------------------------------------

You have two more generic options:

![Screenshot from 2024-10-29 15-36-00](https://github.com/user-attachments/assets/3e6de8b8-6404-4b08-8ea5-34dd8532a236)

Compare:

| Permission | Description | 
| -- | -- |
| Generic: Anyone with secret link | You must access form through a signed/authenticated hyperlink (as might be generated in a mail-blast). This specifically refers to Afform page-tokens. |
| Generic: Allow any authenticated contact | You can access the form as you are somehow authenticated (e.g. login-session). |
| Generic: Allow all users (including anonymous) | OK if you really want the form to be public |

Technical Details
----------------------------------------

The patch-set looks a bit bigger than it should. This is mostly because the afform/authx test-suites needed some reorganization to develop tests for these things.
