### PR TITLE
Backport #31345 - radio button width regression

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3333,6 +3333,10 @@ span.crm-select-item-color {
   flex-wrap: wrap;
   gap: var(--gap);
 }
+/* Reset checkbox width when its rendered as text '(x)' in confirmation screens /dev/core/-/issues/5550 */
+.crm-container.crm-public .crm-profile-view .crm-option-label-pair {
+  --checkbox-width: auto;
+}
 /* Override more general styling */
 .crm-container .crm-multiple-checkbox-radio-options :where(input.crm-form-radio,
 input.crm-form-checkbox) + label {


### PR DESCRIPTION
Backport of https://github.com/civicrm/civicrm-core/pull/31345

The work on multi-column Radio Buttons / Checkboxes (#30162) missed that text rendered output on a Contribution Confirmation Screen uses the same CSS. Fixes by reseting the width.