### PR TITLE
Afform - More accurate check in GUI to see if a field is in-use.

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
@@ -64,6 +64,7 @@
             $scope.fieldList.push({
               entityName: ctrl.entity.name + '-join-' + entityName,
               entityType: entityName,
+              afJoin: entityName,
               label: ts('%1 Fields', {1: entity.label}),
               fields: filterFields(entity.fields)
             });
@@ -153,12 +154,23 @@
       };
 
       // Checks if a field is on the form or set as a value
-      $scope.fieldInUse = function(fieldName) {
+      $scope.fieldInUse = function(fieldName, joinEntity) {
         var data = ctrl.entity.data || {};
-        if (fieldName in data) {
-          return true;
+        if (!joinEntity) {
+          return (fieldName in data) || check(ctrl.editor.layout['#children'], {'#tag': 'af-field', name: fieldName});
         }
-        return check(ctrl.editor.layout['#children'], {'#tag': 'af-field', name: fieldName});
+        // Joins might support multiple instances per entity; first fetch them all
+        let afJoinContainers = afGui.getFormElements(ctrl.editor.layout['#children'], {'af-join': joinEntity}, (item) => {
+          return item['af-join'] || (item['af-fieldset'] && item['af-fieldset'] !== ctrl.entity.name);
+        });
+        // Check if ALL af-join containers are using the field
+        let inUse = true;
+        afJoinContainers.forEach(function(container) {
+          if (inUse && !check(container['#children'], {'#tag': 'af-field', name: fieldName})) {
+            inUse = false;
+          }
+        });
+        return inUse;
       };
 
       // Checks if fields in a block are already in use on the form.
@@ -189,7 +201,7 @@
           }
           if (_.isPlainObject(item)) {
             // Recurse through everything but skip fieldsets for other entities
-            if ((!item['af-fieldset'] || (item['af-fieldset'] === ctrl.entity.name)) && item['#children']) {
+            if (!item['af-join'] && (!item['af-fieldset'] || (item['af-fieldset'] === ctrl.entity.name)) && item['#children']) {
               check(item['#children'], criteria, found);
             }
             // Recurse into block directives

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.html
@@ -56,7 +56,7 @@
         <div ng-if="fieldGroup.fields.length">
           <label>{{ fieldGroup.label }}</label>
           <div ui-sortable="$ctrl.editor.getSortableOptions(fieldGroup.entityName)" ui-sortable-update="buildPaletteLists" ng-model="fieldGroup.fields">
-            <div ng-repeat="field in fieldGroup.fields" ng-class="{disabled: fieldInUse(field.name)}">
+            <div ng-repeat="field in fieldGroup.fields" ng-class="{disabled: fieldInUse(field.name, fieldGroup.afJoin)}">
               <div class="af-gui-palette-item">{{:: getField(fieldGroup.entityType, field.name).label }}</div>
             </div>
           </div>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes Afform GUI erroneously not allowing the user to drag fields onto the form if they are used by other entities.

Before
----------------------------------------
  1. Create multiple email blocks for a contact;
        - note that you can't drag a field into one if it's already in-use in the other
  3. Add an Event to the form & add the Event Location block; 
        - note that "Existing Event" and "Existing Location" fields can't both be added to the form, because adding one causes the other to be greyed out as well.
  
After
----------------------------------------
  Fields are correctly available.

