### PR TITLE
dev/core#5567 Api4 - Ignore 'null' when validating param data type

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -305,6 +305,10 @@ abstract class AbstractAction implements \ArrayAccess {
         if ($name != 'version' && $name[0] != '_') {
           $docs = ReflectionUtils::getCodeDocs($property, 'Property', $vars);
           $docs['default'] = $defaults[$name];
+          // Exclude `null` which is not a value type
+          if (!empty($docs['type']) && is_array($docs['type'])) {
+            $docs['type'] = array_diff($docs['type'], ['null']);
+          }
           if (!empty($docs['optionsCallback'])) {
             $docs['options'] = $this->{$docs['optionsCallback']}();
             unset($docs['optionsCallback']);

--- a/Civi/Api4/Utils/ReflectionUtils.php
+++ b/Civi/Api4/Utils/ReflectionUtils.php
@@ -83,7 +83,7 @@ class ReflectionUtils {
         $key = array_shift($words);
         $param = NULL;
         if ($key == 'var') {
-          $info['type'] = explode('|', $words[0]);
+          $info['type'] = explode('|', strtolower($words[0]));
         }
         elseif ($key == 'return') {
           $info['return'] = explode('|', $words[0]);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/5567

@eileenmcnaughton 