### PR TITLE
dev/core#5568 - Fix SearchKit sticky table headers to hide editable fields

### DIFF
--- a/ext/search_kit/css/crmSearchDisplayTable.css
+++ b/ext/search_kit/css/crmSearchDisplayTable.css
@@ -31,6 +31,7 @@
 table.crm-sticky-header > thead > tr {
   position: sticky !important;
   top: var(--crm-menubar-bottom, 0px);
+  z-index: 2;
 }
 
 /* Nested styling for hierarchical rows */


### PR DESCRIPTION
See details in [dev/core#5568](https://lab.civicrm.org/dev/core/-/issues/5568)