### PR TITLE
dev/core#5516 - Backport - Fix Smarty5 compatibility

### DIFF
--- a/templates/CRM/Case/Form/Activity/ChangeCaseStatus.tpl
+++ b/templates/CRM/Case/Form/Activity/ChangeCaseStatus.tpl
@@ -13,7 +13,7 @@
       <td class="label">{$form.case_status_id.label}</td>
       <td>{$form.case_status_id.html}</td>
     </tr>
-    {if sizeof($linkedCases) > 0}
+    {if count($linkedCases) > 0}
       <tr>
         <td rowspan="2">{ts}Update Linked Cases Status?{/ts}</td>
         <td>{$form.updateLinkedCases.html}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Backport https://github.com/civicrm/civicrm-core/pull/31256.

https://lab.civicrm.org/dev/core/-/issues/5516#note_172534

Since the status check is now telling people to use smarty 5, there's an argument this should have been in 5.79.