### PR TITLE
(dev/core#5563) Upgrade - Cannot navigate. Mismatched caches.

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -681,7 +681,7 @@ class Container {
     $bootServices['userPermissionClass'] = new $userPermissionClass();
 
     $bootServices['cache.settings'] = \CRM_Utils_Cache::create([
-      'name' => 'settings',
+      'name' => 'settings_' . preg_replace(';[^0-9a-z_];', '_', \CRM_Utils_System::version()),
       'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
     ]);
 


### PR DESCRIPTION
Overview
----------------------------------------

Suppose you install 5.78, then download 5.79, and then try to browse to the dashboard or status-console (*where it links to "Upgrade" UI*). At that moment, the navigation is broken - because settings data is mismatched.

See also: https://lab.civicrm.org/dev/core/-/issues/5563

Before
----------------------------------------

Lots of pages complain about writing files. The paths are wrong.

![image](https://github.com/user-attachments/assets/1bd69d82-5cef-4a99-808e-b4e46f248fd3)

After
----------------------------------------

It's fine.

Technical Details
----------------------------------------

In short: if 5.79 uses the `settings` cache from `5.78`, then things get weird. The two caches (5.78 and 5.79) have different data-structures.

When I bisected the current symptom, it pointed to c75a9c0ebecfee9c91db873b1929fd5b9109f016. This feels a bit circumstantial. Yes, that patch does some juggling that affects the content of the cache. But that just creates the present symptom. The problem is deeper -- _the scope of `settings` cache is all settings, and the settings change between versions_. Granted, typical monthly changes are small and less symptomatic. But IMHO, it's a categorical mistake to mix the settings-cache between different versions of Civi.

The is similar to the `metadata` cache. The solution here is simply copied from the [same solution on metadata cache](https://github.com/civicrm/civicrm-core/blob/5b23f71c40c56ca65bfe333f06eeb51b9bf6b3f0/Civi/Core/Container.php#L184-L190).