### PR TITLE
[REF] Fix variable typo causing excessive updates of civicrm_mailing …

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -156,7 +156,7 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
           'start_date' => date('YmdHis'),
           'status' => 'Running',
         ])->execute();
-        if (empty($testParams) && empty($job->mailing_start_date)) {
+        if (empty($testParams) && empty($result->mailing_start_date)) {
           Mailing::update(FALSE)->setValues([
             'id' => $result->mailing_id,
             'start_date' => $startDate,


### PR DESCRIPTION
…table when mailing jobs are running

Overview
----------------------------------------
This fixes a silly typo which was causing an excessive amount of updating of the civicrm_mailing table. The problem here is `$job` is not defined at this point in the code any more and we are really wanting to access the results of the DB query which is in `$result` anyway

Before
----------------------------------------
Loads of unnecessary queries run

After
----------------------------------------
Less queries

@johntwyman @andrew-cormick-dockery @eileenmcnaughton @demeritcowboy 