### PR TITLE
CRM_Utils_Cache - Use more consistent group names

### DIFF
--- a/CRM/Extension/System.php
+++ b/CRM/Extension/System.php
@@ -263,10 +263,11 @@ class CRM_Extension_System {
    */
   public function getCache() {
     if ($this->cache === NULL) {
-      $cacheGroup = md5(serialize(['ext', $this->parameters, CRM_Utils_System::version()]));
+      $cacheGroup = 'ext_' . CRM_Utils_String::base64UrlEncode(md5(serialize($this->parameters), TRUE));
       // Extension system starts before container. Manage our own cache.
       $this->cache = CRM_Utils_Cache::create([
         'name' => $cacheGroup,
+        'scope' => 'version',
         'service' => 'extension_system',
         'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
         'prefetch' => TRUE,

--- a/CRM/Utils/Cache.php
+++ b/CRM/Utils/Cache.php
@@ -151,6 +151,10 @@ class CRM_Utils_Cache {
    *     should function correctly, but it can be harder to inspect/debug.
    *   - type: array|string, list of acceptable cache types, in order of preference.
    *   - prefetch: bool, whether to prefetch all data in cache (if possible).
+   *   - scope: string, How broadly is this cache shared? (Available in v5.80+)
+   *       - version: Cache is tied to current version of CiviCRM (RECOMMENDED)
+   *       - runtime: Cache is tied to domain ID, HTTP host, version, etc
+   *       - global: Cache is shared across all versions, domain IDs, HTTP hosts, etc (DEFAULT)
    *   - withArray: bool|null|'fast', whether to setup a thread-local array-cache in front of the cache driver.
    *     Note that cache-values may be passed to the underlying driver with extra metadata,
    *     so this will slightly change/enlarge the on-disk format.
@@ -168,6 +172,23 @@ class CRM_Utils_Cache {
   public static function create($params = []) {
     $types = (array) $params['type'];
 
+    switch ($params['scope'] ?? 'global') {
+      case 'version':
+        $scopeId = self::DELIMITER . static::getVersionCode();
+        break;
+
+      case 'runtime':
+        $scopeId = self::DELIMITER . CRM_Core_Config_Runtime::getId();
+        break;
+
+      case 'global':
+        $scopeId = '';
+        break;
+
+      default:
+        throw new \LogicException("Invalid scope given to CRM_Utils_Cache::create()");
+    }
+
     foreach ($types as $type) {
       switch ($type) {
         case '*memory*':
@@ -175,7 +196,7 @@ class CRM_Utils_Cache {
             $shortName = self::cleanKey($params['name'], 64);
             $dbCacheClass = 'CRM_Utils_Cache_' . CIVICRM_DB_CACHE_CLASS;
             $settings = self::getCacheSettings(CIVICRM_DB_CACHE_CLASS);
-            $settings['prefix'] = CRM_Utils_Array::value('prefix', $settings, '') . self::DELIMITER . $shortName . self::DELIMITER;
+            $settings['prefix'] = CRM_Utils_Array::value('prefix', $settings, '') . self::DELIMITER . $shortName . $scopeId;
             $cache = new $dbCacheClass($settings);
             if (!empty($params['withArray'])) {
               $cache = $params['withArray'] === 'fast' ? new CRM_Utils_Cache_FastArrayDecorator($cache) : new CRM_Utils_Cache_ArrayDecorator($cache);
@@ -186,7 +207,8 @@ class CRM_Utils_Cache {
 
         case 'SqlGroup':
           if (defined('CIVICRM_DSN') && CIVICRM_DSN) {
-            $shortName = self::cleanKey($params['name'], 32);
+            $shortName = self::cleanKey($params['name'] . $scopeId, 32, 16, ';[^A-Za-z0-9_\. /];');
+            // Name goes first because it's most interesting to skim. When value is long enough to provoke hashing, we want to retain as much ['name'] as possible.
             $cache = new CRM_Utils_Cache_SqlGroup([
               'group' => $shortName,
               'prefetch' => $params['prefetch'] ?? FALSE,
@@ -206,6 +228,18 @@ class CRM_Utils_Cache {
       return new CRM_Utils_Cache_CacheWrapper($cache, $params['service'] ?? $params['name'] ?? NULL);
     }
     throw new CRM_Core_Exception("Failed to instantiate cache. No supported cache type found. " . print_r($params, 1));
+  }
+
+  private static function getVersionCode(): string {
+    static $ver = NULL;
+    if ($ver === NULL) {
+      $ver = CRM_Utils_System::version();
+      if (preg_match('/^(\d+)\.(\d+)\.(alpha|beta|)(\d+)/', $ver, $matches)) {
+        $stages = ['alpha' => 'a', 'beta' => 'b', '' => '.' /* stable */];
+        $ver = $matches[1] . '.' . $matches[2] . $stages[$matches[3]] . $matches[4];
+      }
+    }
+    return $ver;
   }
 
   /**

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -176,7 +176,9 @@ class Container {
       'js_strings' => ['withArray' => 'fast'],
       'community_messages' => [],
       'checks' => [],
-      'session' => ['name' => 'CiviCRM Session'],
+      // Putting session-cache in global scope means that QF form-state will endure across upgrades.
+      // (*For better or worse -- mostly better.*)
+      'session' => ['name' => 'CiviCRM Session', 'scope' => 'global'],
       'long' => [],
       'groups' => ['name' => 'contact groups', 'withArray' => 'fast'],
       'navigation' => ['withArray' => 'fast'],

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -183,10 +183,9 @@ class Container {
       'contactTypes' => 'contactTypes',
       'metadata' => 'metadata',
     ];
-    $verSuffixCaches = ['metadata'];
     foreach ($basicCaches as $cacheSvc => $cacheGrp) {
       $definitionParams = [
-        'scope' => in_array($cacheGrp, $verSuffixCaches) ? 'version' : 'global',
+        'scope' => 'version',
         'name' => $cacheGrp,
         'service' => $cacheSvc,
         'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
@@ -212,6 +211,10 @@ class Container {
         [
           'name' => 'CiviCRM Search PrevNextCache',
           'type' => ['SqlGroup'],
+          'scope' => 'global',
+          // Scope is debatable. Logically, version scope might make sense. But there are several
+          // places which bypass $cache object and use this name, so any prefix/suffix would
+          // require more updates.
         ],
       ]
     ))->setFactory('CRM_Utils_Cache::create')->setPublic(TRUE);
@@ -222,6 +225,7 @@ class Container {
       'CRM_Utils_Cache_Interface',
       [
         [
+          'scope' => 'version',
           'name' => 'extension_browser',
           'type' => ['SqlGroup', 'ArrayCache'],
         ],
@@ -441,9 +445,9 @@ class Container {
    * @return \Civi\Angular\Manager
    */
   public function createAngularManager() {
-    $moduleEnvId = md5(\CRM_Core_Config_Runtime::getId());
     $angCache = \CRM_Utils_Cache::create([
-      'name' => substr('angular_' . $moduleEnvId, 0, 32),
+      'scope' => 'version',
+      'name' => 'angular',
       'service' => 'angular_manager',
       'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
       'withArray' => 'fast',

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -184,10 +184,10 @@ class Container {
       'metadata' => 'metadata',
     ];
     $verSuffixCaches = ['metadata'];
-    $verSuffix = '_' . preg_replace(';[^0-9a-z_];', '_', \CRM_Utils_System::version());
     foreach ($basicCaches as $cacheSvc => $cacheGrp) {
       $definitionParams = [
-        'name' => $cacheGrp . (in_array($cacheGrp, $verSuffixCaches) ? $verSuffix : ''),
+        'scope' => in_array($cacheGrp, $verSuffixCaches) ? 'version' : 'global',
+        'name' => $cacheGrp,
         'service' => $cacheSvc,
         'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
       ];
@@ -681,7 +681,8 @@ class Container {
     $bootServices['userPermissionClass'] = new $userPermissionClass();
 
     $bootServices['cache.settings'] = \CRM_Utils_Cache::create([
-      'name' => 'settings_' . preg_replace(';[^0-9a-z_];', '_', \CRM_Utils_System::version()),
+      'scope' => 'version',
+      'name' => 'settings',
       'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
     ]);
 

--- a/tests/phpunit/CRM/Core/BAO/CacheTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CacheTest.php
@@ -92,15 +92,15 @@ class CRM_Core_BAO_CacheTest extends CiviUnitTestCase {
     // short with emoji
     $es[] = ["LF-\nTAB-\tCR-\remojiskull💀", 'LF-2d-aTAB-2d-9CR-2d-demojiskull-f0-9f-92-80'];
     // long with emoji
-    $es[] = ["LF-\nTAB-\tCR-\remojibomb💣emojiskull💀", '-5d9324e052f6e10240dce5029c5e8525'];
+    $es[] = ["LF-\nTAB-\tCR-\remojibomb💣emojiskull💀", '-LF-2d-aTAB-2d-9CR-2d-demojibomb-f0-9f-9XZMk4FL24QJA3OUCnF6FJQ'];
     // spaces are escaped
     $es[] = ['123456789 123456789 123456789 123456789 123456789 123', '123456789-20123456789-20123456789-20123456789-20123456789-20123'];
     // long but allowed
     $es[] = ['123456789_123456789_123456789_123456789_123456789_123456789_123', '123456789_123456789_123456789_123456789_123456789_123456789_123'];
     // too long, md5 fallback
-    $es[] = ['123456789_123456789_123456789_123456789_123456789_123456789_1234', '-e02b981aff954fdcc9a81c25f5ec9681'];
+    $es[] = ['123456789_123456789_123456789_123456789_123456789_123456789_1234', '-123456789_123456789_123456789_1234567894CuYGv-VT9zJqBwl9eyWgQ'];
     // too long, md5 fallback
-    $es[] = ['123456789-/23456789-+23456789--23456789_123456789_123456789', '-43b6dec1026187ae6f6a8fe4d56ab22e'];
+    $es[] = ['123456789-/23456789-+23456789--23456789_123456789_123456789', '-123456789-2d-2f23456789-2d-2b23456789-2Q7bewQJhh65vao_k1WqyLg'];
     return $es;
   }
 

--- a/tests/phpunit/Civi/Core/Service/AutoDefinitionTest.php
+++ b/tests/phpunit/Civi/Core/Service/AutoDefinitionTest.php
@@ -104,7 +104,7 @@ class AutoDefinitionTest extends \CiviUnitTestCase {
     $this->assertInstanceOf(\CRM_Utils_Cache_CacheWrapper::class, $instance->cache);
     $cacheClass = Invasive::get([$instance->cache, 'delegate']);
     $this->assertInstanceOf(\CRM_Utils_Cache_SqlGroup::class, $cacheClass);
-    $this->assertEquals('extension_browser', Invasive::get([$cacheClass, 'group']));
+    $this->assertStringStartsWith('extension_browser/', Invasive::get([$cacheClass, 'group']));
   }
 
   /**
@@ -184,7 +184,7 @@ class AutoDefinitionTest extends \CiviUnitTestCase {
     $cacheClass = Invasive::get([$cacheWrapper, 'delegate']);
     $this->assertInstanceOf(\CRM_Utils_Cache_SqlGroup::class, $cacheClass);
     $this->assertEquals('extension_browser', Invasive::get([$cacheWrapper, 'serviceName']));
-    $this->assertEquals('extension_browser', Invasive::get([$cacheClass, 'group']));
+    $this->assertStringStartsWith('extension_browser/', Invasive::get([$cacheClass, 'group']));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

This is a batch of refinements for how `civicrm_cache` groups are named.

Before + After (Effective Cache Names)
----------------------------------------

| `old_group_name`                   | `new_group_name`                   |
|------------------------------------|-------------------------------------|
| `698ba0f63041a6f1a88d60caf82c17e7` | `-ext_QpVei68UFYfiMP1l-hLBu2Bx5`    |
| `angular_5c6c14c55af45f3ba5b78a02` | `angular/5.80a1`    |
| `CiviCRM-20Session`                | ~~`CiviCRM Session/5.80a1`~~ <br/> `CiviCRM Session`            |
| `contact-20fields`                 | `contact fields/5.80a1`             |
| `contactTypes`                     | `contactTypes/5.80a1`               |
| `js_strings`                       | `js_strings/5.80a1`                 |
| `long`                             | `long/5.80a1`                       |
| `metadata_5_80_alpha1`             | `metadata/5.80a1`                   |
| `settings_5_80_alpha1`             | `settings/5.80a1`                   |

Before + After (Coding Style)
----------------------------------------

* Before, the `settings` and `metadata` and `ext` caches each had different logic to apply a suffix.
    ```php
    $cache = CRM_Utils_Cache::create([
      'name' => 'foo_' . figureOutVersionNumber(),
    ]);
    ```
* After, they let the cache-helper figure out what to append.
    ```php
    $cache = CRM_Utils_Cache::create([
      'name' => 'foo',
      'scope' => 'version',
    ]);
    ```

Technical Details
----------------------------------------

1. When faced with a long group-name, try harder to preserve a recognizable prefix.
    * In the example, the extension-cache has a long name.
    * To fit within the SQL limits while preserving uniqueness, the name was hashed -- yielding the completely inscrutable value `698ba0f63041a6f1a88d60caf82c17e7`. 
    * Now, it's still looks funny, but it retains a prefix which hints at the content. (`ext_42955e8ba23Hvwkl1xaFlEtxA` is probably related to extensions.)
    * Additionally, it uses shorter encoding for the hash (Base64 vs Base16) to improve the amount of prefix-data that we can display.
2. Allow some more common characters in SQL group name
    * In the example, note how the name `CiviCRM-20Session` differs from `CiviCRM Session`.
    * This is because the escaping rule was tailored to PSR-16, and PSR-16 doesn't defined space (` `) for use in keys..
    * However, SQL group-names aren't really subject to PSR-16 restrictions. When setting up the `SqlGroup` object, we can allow a slightly more relaxed formula.
3. Trim the version code
    * Shorter expressions are less likely to provoke hashing. "5.80a1" and  "5.80.alpha1" are equally readable.
4.  Expand on the idea from #31399 regarding upgrades -- Several caches are (initially) re-used across different versions, but they probably shouldn't be.
    * 1-by-1, we've been adding version-code to cache-groups (settings, metadata, extensions, etc). But actually the technique makes sense for several more caches (js_strings, contact fields, afform paths, etc).
5. Include the idea of https://lab.civicrm.org/dev/core/-/issues/5436 
    * The Angular cache can now be shared between different runtimes (eg between WP frontend and WP backend).

Should we be optimistic?  I expect Jenkins to have some initial complaints, but I'm fairly optimistic.
    * Basically -- Civi already supports multiple cache-backends (SQL/Redis/Memcache). Storage is abstracted around `$cache` objects. The encoding of the group-name is an internal detail of the cache-object and shouldn't matter much for consumers of the `$cache` API.
    * There is one quirky cache (`CiviCRM Search PrevNextCache`) which I left as-is because it has funny rules.

Comments
----------------------------------------

Expanding the size of `civicrm_cache.group_name` may also be a good idea. But some limit will still exist, so it's still fine to tune these rules.
