### PR TITLE
Remove another use of api3 contribution.completetransaction

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1606,11 +1606,11 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           $this->_paymentProcessor['id'] = $paymentProcessorIDs[0];
         }
         try {
-          civicrm_api3('contribution', 'completetransaction', [
-            'id' => $membershipContribution->id,
-            'payment_processor_id' => $this->_paymentProcessor['id'],
-            'is_transactional' => FALSE,
-          ]);
+          CRM_Contribute_BAO_Contribution::completeOrder(
+            ['payment_processor_id' => $this->getPaymentProcessorID()],
+            $membershipContribution->contribution_recur_id,
+            $membershipContribution->id,
+            NULL);
         }
         catch (CRM_Core_Exception $e) {
           if ($e->getErrorCode() != 'contribution_completed') {


### PR DESCRIPTION
Overview
----------------------------------------
This one is for the case when the total amount is 0.

Before
----------------------------------------
Calls deprecated API3 `contribution.completetransaction`

After
----------------------------------------
Simplifies by calling the internal function directly.

Technical Details
----------------------------------------
The API takes the params and refactors/changes them a bit before passing them on to `completeOrder`. But we only have 3 params in this case so we can call `completeOrder()` directly with the same number of lines.
This makes it easier to read and we might be able to further refactor/simplify.

Comments
----------------------------------------
