### PR TITLE
SearchKit - Make hierarchical tables collapsible

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/HierarchicalEntitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/HierarchicalEntitySpecProvider.php
@@ -22,8 +22,7 @@ use Civi\Api4\Utils\CoreUtil;
 class HierarchicalEntitySpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
 
   /**
-   * Generic create spec function applies to all SortableEntity types.
-   * Disables required 'weight' field because that's auto-managed.
+   * Generic create spec function applies to all HierarchicalEntity types.
    *
    * @param \Civi\Api4\Service\Spec\RequestSpec $spec
    */
@@ -36,7 +35,18 @@ class HierarchicalEntitySpecProvider extends \Civi\Core\Service\AutoService impl
       ->setDescription(ts('Depth in the nested hierarchy'))
       ->setType('Extra')
       ->setReadonly(TRUE)
-      ->setSqlRenderer([__CLASS__, 'getDepth']);
+      ->setSqlRenderer([__CLASS__, 'getZero']);
+    $spec->addFieldSpec($field);
+
+    $field = new FieldSpec('_descendents', $spec->getEntity(), 'Integer');
+    $field->setLabel(ts('Descendents'))
+      ->setTitle(ts('Descendents'))
+      ->setColumnName('id')
+      ->setInputType('Number')
+      ->setDescription(ts('Number of descendents in the nested hierarchy'))
+      ->setType('Extra')
+      ->setReadonly(TRUE)
+      ->setSqlRenderer([__CLASS__, 'getZero']);
     $spec->addFieldSpec($field);
   }
 
@@ -48,11 +58,11 @@ class HierarchicalEntitySpecProvider extends \Civi\Core\Service\AutoService impl
   }
 
   /**
-   * Generate SQL for _depth field
+   * Generate SQL for default value of _depth & _descendents fields
    * @param array $field
    * @return string
    */
-  public static function getDepth(array $field): string {
+  public static function getZero(array $field): string {
     return "0";
   }
 

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Manage_Group.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Manage_Group.mgd.php
@@ -268,6 +268,7 @@ return [
             ],
           ],
           'hierarchical' => TRUE,
+          'collapsible' => 'closed',
         ],
         'acl_bypass' => FALSE,
       ],

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -151,17 +151,28 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       foreach ($this->display['settings']['columns'] as $column) {
         $columns[] = $this->formatColumn($column, $data);
       }
-      $style = $this->getCssStyles($this->display['settings']['cssRules'] ?? [], $data);
-      // Add hierarchical styles
-      if (!empty($this->display['settings']['hierarchical'])) {
-        $style[] = 'crm-hierarchical-row crm-hierarchical-depth-' . ($data['_depth'] ?? '0');
-        $style[] = empty($data['_depth']) ? 'crm-hierarchical-parent' : 'crm-hierarchical-child';
-      }
       $row = [
         'data' => $data,
         'columns' => $columns,
-        'cssClass' => implode(' ', $style),
       ];
+      $style = $this->getCssStyles($this->display['settings']['cssRules'] ?? [], $data);
+      // Add hierarchical styles
+      if (!empty($this->display['settings']['hierarchical'])) {
+        $depth = $data['_depth'] ?? 0;
+        $style[] = 'crm-hierarchical-row crm-hierarchical-depth-' . $depth;
+        if ($depth) {
+          $style[] = 'crm-hierarchical-child';
+        }
+        if (!empty($data['_descendents'])) {
+          $style[] = 'crm-hierarchical-parent';
+          if (($this->display['settings']['collapsible'] ?? FALSE) === 'closed') {
+            $row['collapsed'] = TRUE;
+          }
+        }
+      }
+      if ($style) {
+        $row['cssClass'] = implode(' ', $style);
+      }
       if (isset($record[$keyName])) {
         $row['key'] = $record[$keyName];
       }
@@ -1352,6 +1363,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     // Add `depth_` column for hierarchical entity displays
     if (!empty($this->display['settings']['hierarchical'])) {
       $this->addSelectExpression('_depth');
+      $this->addSelectExpression('_descendents');
     }
     // Add draggable column (typically "weight")
     if (!empty($this->display['settings']['draggable'])) {

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -18,6 +18,11 @@
           <span>{{:: ts('Show nested hierarchy') }}</span>
         </label>
       </div>
+      <select class="form-control" ng-if="$ctrl.display.settings.hierarchical" ng-model="$ctrl.display.settings.collapsible" title="{{:: ts('Should hierarchical tree be collapsible') }}">
+        <option value="">{{:: ts('Not collapsible') }}</option>
+        <option value="open">{{:: ts('Collapsible - Open') }}</option>
+        <option value="closed">{{:: ts('Collapsible - Closed') }}</option>
+      </select>
     </div>
     <div class="form-inline">
       <search-admin-tasks-config display="$ctrl.display" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></search-admin-tasks-config>

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -100,7 +100,7 @@
       },
 
       hasExtraFirstColumn: function() {
-        return this.settings.actions || this.settings.draggable || (this.settings.tally && this.settings.tally.label);
+        return this.settings.actions || this.settings.draggable || this.settings.collapsible || (this.settings.tally && this.settings.tally.label);
       },
 
       getFilters: function() {

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
@@ -1,9 +1,10 @@
-<tr ng-repeat="(rowIndex, row) in $ctrl.results" data-entity-id="{{:: row.key }}">
+<tr ng-repeat="(rowIndex, row) in $ctrl.results" data-entity-id="{{:: row.key }}" ng-if="!row.hidden">
   <td ng-if=":: $ctrl.hasExtraFirstColumn()" class="crm-search-ctrl-column {{:: row.cssClass }}">
     <span ng-if=":: $ctrl.settings.draggable" class="crm-draggable" title="{{:: ts('Drag to reposition') }}">
       <i class="crm-i fa-arrows-v"></i>
     </span>
     <input ng-if=":: $ctrl.settings.actions" type="checkbox" ng-checked="$ctrl.isRowSelected(row)" ng-click="$ctrl.toggleRow(row, $event)" ng-disabled="!!$ctrl.loadingAllRows">
+    <crm-search-display-toggle-collapse ng-if=":: $ctrl.settings.collapsible" rows="$ctrl.results" row-index="rowIndex"></crm-search-display-toggle-collapse>
   </td>
   <td ng-repeat="(colIndex, colData) in row.columns" ng-include="'~/crmSearchDisplay/colType/' + $ctrl.settings.columns[colIndex].type + '.html'" title="{{:: colData.title }}" class="crm-search-col-type-{{:: $ctrl.settings.columns[colIndex].type }} {{:: row.cssClass }} {{:: colData.cssClass }}" data-field-name="{{:: colData.edit.value_key }}">
   </td>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayToggleCollapse.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayToggleCollapse.component.js
@@ -1,0 +1,62 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('crmSearchDisplayTable').component('crmSearchDisplayToggleCollapse', {
+    bindings: {
+      rows: '<',
+      rowIndex: '<',
+    },
+    templateUrl: '~/crmSearchDisplayTable/crmSearchDisplayToggleCollapse.html',
+    controller: function($scope, $element) {
+      const ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
+        ctrl = this;
+
+      this.$onInit = function() {
+        const row = this.getRow();
+        if (row.collapsed && row.data._descendents) {
+          row.collapsed = false;
+          this.toggleCollapsed();
+        } else {
+          row.collapsed = false;
+        }
+        if (!row.data._descendents) {
+          $element.css('visibility', 'hidden');
+        }
+      };
+
+      this.getRow = function () {
+        return this.rows[this.rowIndex];
+      };
+
+      this.isCollapsed = function() {
+        return this.getRow().collapsed && this.getRow().data._descendents;
+      };
+
+      this.countDescendents = function () {
+        return this.getRow().data._descendents;
+      };
+
+      this.toggleCollapsed = function() {
+        const row = this.getRow();
+        row.collapsed = !row.collapsed;
+
+        let descendentsEnd = this.rowIndex + row.data._descendents;
+        for (let i = this.rowIndex + 1; i <= descendentsEnd; i++) {
+          let hide = row.collapsed;
+          // We're past the end of the page
+          if (!ctrl.rows[i]) {
+            return;
+          }
+          ctrl.rows[i].hidden = hide;
+          // Hiding rows is simple, just hide all of them, but when un-hiding we need to skip over
+          // the children of collapsed elements.
+          if (!hide && ctrl.rows[i].collapsed) {
+            i += ctrl.rows[i]._descendents;
+          }
+        }
+      };
+
+    }
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayToggleCollapse.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayToggleCollapse.html
@@ -1,0 +1,4 @@
+<button class="btn" type="button" title="{{:: ts('Show sub-rows') }}" ng-click="$ctrl.toggleCollapsed()">
+  <i class="crm-i" ng-class="{'fa-caret-right': $ctrl.isCollapsed(), 'fa-caret-down': !$ctrl.isCollapsed()}"></i>
+  <span ng-show="$ctrl.isCollapsed()">{{:: $ctrl.countDescendents() }}</span>
+</button>

--- a/ext/search_kit/css/crmSearchDisplayTable.css
+++ b/ext/search_kit/css/crmSearchDisplayTable.css
@@ -37,6 +37,10 @@ table.crm-sticky-header > thead > tr {
 #bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-row {
   position: relative;
 }
+#bootstrap-theme .crm-search-display-table crm-search-display-toggle-collapse {
+  position: relative;
+  z-index: 1;
+}
 /* Depth >= 1 */
 #bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-child:first-child:not(.crm-search-ctrl-column),
 #bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-child {
@@ -53,6 +57,9 @@ table.crm-sticky-header > thead > tr {
   border-bottom: 2px dotted currentColor;
   border-left: 2px dotted currentColor;
 }
+#bootstrap-theme .crm-search-display-table .crm-hierarchical-depth-1 crm-search-display-toggle-collapse {
+  left: 30px;
+}
 /* Depth = 2 */
 #bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-2:first-child:not(.crm-search-ctrl-column),
 #bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-2 {
@@ -61,6 +68,9 @@ table.crm-sticky-header > thead > tr {
 #bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-2:first-child:not(.crm-search-ctrl-column):before,
 #bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-2:before {
   left: 45px;
+}
+#bootstrap-theme .crm-search-display-table .crm-hierarchical-depth-2 crm-search-display-toggle-collapse {
+  left: 60px;
 }
 /* Depth = 3 */
 #bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-3:first-child:not(.crm-search-ctrl-column),
@@ -71,6 +81,9 @@ table.crm-sticky-header > thead > tr {
 #bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-3:before {
   left: 75px;
 }
+#bootstrap-theme .crm-search-display-table .crm-hierarchical-depth-3 crm-search-display-toggle-collapse {
+  left: 90px;
+}
 /* Depth = 4 */
 #bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-4:first-child:not(.crm-search-ctrl-column),
 #bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-4 {
@@ -79,4 +92,7 @@ table.crm-sticky-header > thead > tr {
 #bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-4:first-child:not(.crm-search-ctrl-column):before,
 #bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-4:before {
   left: 105px;
+}
+#bootstrap-theme .crm-search-display-table .crm-hierarchical-depth-4 crm-search-display-toggle-collapse {
+  left: 120px;
 }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -1357,7 +1357,7 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals('text-center', $result[0]['columns'][0]['cssClass']);
     // First contact is deceased, gets strikethrough class
     $this->assertEquals('strikethrough', $result[0]['cssClass']);
-    $this->assertNotEquals('strikethrough', $result[1]['cssClass']);
+    $this->asserttrue(empty($result[1]['cssClass']));
     // Ensure the view contact link was formed
     $this->assertStringContainsString('cid=' . $contacts[0]['id'], $result[0]['columns'][1]['links'][0]['url']);
     $this->assertEquals('_blank', $result[0]['columns'][1]['links'][0]['target']);

--- a/tests/phpunit/api/v4/Entity/GroupTest.php
+++ b/tests/phpunit/api/v4/Entity/GroupTest.php
@@ -22,11 +22,12 @@ namespace api\v4\Entity;
 use api\v4\Api4TestBase;
 use Civi\API\Exception\UnauthorizedException;
 use Civi\Api4\Group;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class GroupTest extends Api4TestBase {
+class GroupTest extends Api4TestBase implements TransactionalInterface {
 
   public function testGetFields(): void {
     $fields = Group::getFields(FALSE)
@@ -193,17 +194,17 @@ class GroupTest extends Api4TestBase {
 
   public function testGetParents(): void {
     $parent1 = Group::create(FALSE)
-      ->addValue('title', uniqid())
+      ->addValue('title', uniqid('e'))
       ->execute()->single();
     $parent2 = Group::create(FALSE)
-      ->addValue('title', uniqid())
+      ->addValue('title', uniqid('b'))
       ->execute()->single();
     $child1 = Group::create(FALSE)
-      ->addValue('title', uniqid())
+      ->addValue('title', uniqid('d'))
       ->addValue('parents', [$parent1['id'], $parent2['id']])
       ->execute()->single();
     $child2 = Group::create(FALSE)
-      ->addValue('title', uniqid())
+      ->addValue('title', uniqid('c'))
       ->addValue('parents', [$parent2['id']])
       ->execute()->single();
 
@@ -246,6 +247,39 @@ class GroupTest extends Api4TestBase {
     $this->assertEquals($child1['title'], $joined[1]['child_group.title']);
     $this->assertEquals($parent2['id'], $joined[2]['id']);
     $this->assertEquals($child2['title'], $joined[2]['child_group.title']);
+
+    // Add a sub-child to increase the depth
+    $subChild = Group::create(FALSE)
+      ->addValue('title', uniqid('a'))
+      ->addValue('parents', [$child2['id']])
+      ->execute()->single();
+
+    // Using hierarchical entity trait, get the _descendents and _depth of each group
+    $herarchical = Group::get(FALSE)
+      ->addWhere('id', 'IN', [$parent1['id'], $parent2['id'], $child1['id'], $child2['id'], $subChild['id']])
+      ->addSelect('id', '_depth', '_descendents')
+      ->addOrderBy('title')
+      ->execute();
+
+    $this->assertCount(5, $herarchical);
+    $this->assertEquals($parent2['id'], $herarchical[0]['id']);
+    $this->assertEquals(0, $herarchical[0]['_depth']);
+    // Parent 2 has 2 descendents; child2 and subChild
+    $this->assertEquals(2, $herarchical[0]['_descendents']);
+    $this->assertEquals($child2['id'], $herarchical[1]['id']);
+    $this->assertEquals(1, $herarchical[1]['_depth']);
+    $this->assertEquals(1, $herarchical[1]['_descendents']);
+    $this->assertEquals($subChild['id'], $herarchical[2]['id']);
+    $this->assertEquals(2, $herarchical[2]['_depth']);
+    $this->assertEquals(0, $herarchical[2]['_descendents']);
+    // Parent1 comes after parent2, alphabetically
+    $this->assertEquals($parent1['id'], $herarchical[3]['id']);
+    $this->assertEquals(0, $herarchical[3]['_depth']);
+    $this->assertEquals(1, $herarchical[3]['_descendents']);
+    // Parent 1 has 1 descendent; child1
+    $this->assertEquals($child1['id'], $herarchical[4]['id']);
+    $this->assertEquals(1, $herarchical[4]['_depth']);
+    $this->assertEquals(0, $herarchical[4]['_descendents']);
   }
 
   public function testAddRemoveParents(): void {


### PR DESCRIPTION
Overview
----------------------------------------
SK tables with nested hierarchies can now display them as collapsed, which makes it visually easier to work with parent/child rows.

![image](https://github.com/user-attachments/assets/685bdf78-4e98-47c0-b07f-da7937543d9a)

---

![image](https://github.com/user-attachments/assets/f38b7ec2-c76d-4e68-acd3-302668fe23b3)
