### PR TITLE
dev/core#5557 Remove performance-killing cache-clear

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -688,8 +688,6 @@ class CRM_Core_I18n {
     // For self::getLocale()
     global $tsLocale;
     $tsLocale = $civicrmLocale->ts;
-
-    Civi::cache('metadata')->clear();
     CRM_Core_I18n::singleton()->reactivate();
   }
 

--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -134,7 +134,7 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
 
   private function getSqlOptions(array $field, bool $includeDisabled = FALSE): array {
     $pseudoconstant = $field['pseudoconstant'];
-    $cacheKey = 'EntityMetadataGetSqlOptions' . md5(json_encode($pseudoconstant));
+    $cacheKey = 'EntityMetadataGetSqlOptions' . \CRM_Core_Config::domainID() . '_' . \CRM_Core_I18n::getLocale() . md5(json_encode($pseudoconstant));
     $entity = \Civi::table($pseudoconstant['table']);
     $cache = \Civi::cache('metadata');
     $options = $cache->get($cacheKey);


### PR DESCRIPTION
Overview
----------------------------------------
This addresses the performance regression documented in https://civicrm.org/blog/eileen/developer-content-down-rabbit-hole-redis

Before
----------------------------------------
The [recent addition of a cache clear in `setLocale()`](https://github.com/civicrm/civicrm-core/commit/00f1ac4a8d5991823811d02e03b52aaac7409ae6) led to a very significant slow down in sending out communications where different locales are in play, causing `setLocale()` to be called frequently and resulting in excessive cache rebuilding


After
----------------------------------------
The new cache clear is removed.  The original test error it was trying to address is fixed by appending the locale to the cache key string - meaning the new cache key is cached per locale (and per domain, as this is more consistent with other metadata caching, where some options might be domain specific)


Technical Details
----------------------------------------
@colemanw  - this is the refix

Comments
----------------------------------------
