### PR TITLE
dev/translation#92 fix multilingual insert trigger

### DIFF
--- a/CRM/Core/I18n/Schema.php
+++ b/CRM/Core/I18n/Schema.php
@@ -560,41 +560,11 @@ class CRM_Core_I18n_Schema {
       $info[] = [
         'table' => [$table],
         'when' => 'BEFORE',
-        'event' => ['UPDATE'],
+        'event' => ['INSERT', 'UPDATE'],
         'sql' => $sql,
       ];
     }
 
-    // take care of the ON INSERT triggers
-    foreach ($columns as $table => $hash) {
-      $trigger = [];
-      foreach ($hash as $column => $_) {
-        $trigger[] = "IF NEW.{$column}_{$locale} IS NOT NULL THEN";
-        foreach ($locales as $old) {
-          $trigger[] = "SET NEW.{$column}_{$old} = NEW.{$column}_{$locale};";
-        }
-        foreach ($locales as $old) {
-          $trigger[] = "ELSEIF NEW.{$column}_{$old} IS NOT NULL THEN";
-          foreach (array_merge($locales, [
-            $locale,
-          ]) as $loc) {
-            if ($loc == $old) {
-              continue;
-            }
-            $trigger[] = "SET NEW.{$column}_{$loc} = NEW.{$column}_{$old};";
-          }
-        }
-        $trigger[] = 'END IF;';
-      }
-
-      $sql = implode(' ', $trigger);
-      $info[] = [
-        'table' => [$table],
-        'when' => 'BEFORE',
-        'event' => ['INSERT'],
-        'sql' => $sql,
-      ];
-    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Sometimes, the multilingual fields are empty upon creation and can cause a DB error.

See https://lab.civicrm.org/dev/translation/-/issues/92

Before
----------------------------------------
Upon insertion on table with multilingual fields, the trigger is wrong and create empty tilte:
```
SELECT id, log_date, log_action, title_fr_FR, title_en_GB, title_nl_NL FROM log_civicrm_group ORDER BY id desc LIMIT 2;
+------+---------------------+------------+-------------+-------------+-------------+
| id   | log_date            | log_action | title_fr_FR | title_en_GB | title_nl_NL |
+------+---------------------+------------+-------------+-------------+-------------+
| 4537 | 2024-10-31 21:21:12 | Insert     |             |             |             |
| 4537 | 2024-10-31 21:21:12 | Update     | group title | group title | group title |
+------+---------------------+------------+-------------+-------------+-------------+
2 rows in set (0,000 sec)
```

After
----------------------------------------
Insert is now correct:
```
SELECT id, log_date, log_action, title_fr_FR, title_en_GB, title_nl_NL FROM log_civicrm_group ORDER BY id desc LIMIT 2;
+------+---------------------+------------+-------------+-------------+-------------+
| id   | log_date            | log_action | title_fr_FR | title_en_GB | title_nl_NL |
+------+---------------------+------------+-------------+-------------+-------------+
| 4538 | 2024-10-31 22:01:13 | Insert     | New group   | New group   | New group   |
| 4538 | 2024-10-31 22:01:13 | Update     | New group   | New group   | New group   |
+------+---------------------+------------+-------------+-------------+-------------+
```

Technical Details
----------------------------------------
Update trigger was fixed here : https://github.com/civicrm/civicrm-core/pull/22647/files

We simply use the same trigger definition for `INSERT` and `UPDATE`
