### PR TITLE
Remove remaining calls to (deprecated) cache()->flush

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -25,7 +25,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
    * @see CRM_Utils_Hook::post()
    */
   public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $e): void {
-    Civi::cache('metadata')->flush();
+    Civi::cache('metadata')->clear();
   }
 
   /**

--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -185,7 +185,7 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue implements \Civi
       CRM_Core_BAO_CustomValueTable::store($params['custom'], 'civicrm_option_value', $optionValue->id, $op);
     }
 
-    Civi::cache('metadata')->flush();
+    Civi::cache('metadata')->clear();
     CRM_Core_PseudoConstant::flush();
 
     CRM_Utils_Hook::post($op, 'OptionValue', $id, $optionValue);
@@ -236,7 +236,7 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue implements \Civi
   public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
     if ($event->action === 'delete' && $event->id) {
       if (self::updateRecords($event->id, CRM_Core_Action::DELETE)) {
-        Civi::cache('metadata')->flush();
+        Civi::cache('metadata')->clear();
         CRM_Core_PseudoConstant::flush();
       }
     }

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -167,7 +167,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
     }
 
     $transaction->commit();
-    Civi::cache('metadata')->flush();
+    Civi::cache('metadata')->clear();
     return $priceField;
   }
 

--- a/CRM/Upgrade/Incremental/php/FiveFortySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortySeven.php
@@ -115,7 +115,7 @@ class CRM_Upgrade_Incremental_php_FiveFortySeven extends CRM_Upgrade_Incremental
     }
     // Reload the civi cache here as 'table_name' may not be in the cached entities
     // array generated in an earlier version retrieved via $cache->get('api4.entities.info', []);
-    Civi::cache('metadata')->flush();
+    Civi::cache('metadata')->clear();
 
     // There are existing records which should be managed by `civigrant`. To assign ownership, we need
     // placeholders in `civicrm_extension` and `civicrm_managed`.

--- a/CRM/Utils/Cache/ArrayCache.php
+++ b/CRM/Utils/Cache/ArrayCache.php
@@ -92,15 +92,19 @@ class CRM_Utils_Cache_ArrayCache implements CRM_Utils_Cache_Interface {
     return TRUE;
   }
 
+  /**
+   * @return true
+   * @deprecated since 5.80 will be removed around 5.98
+   */
   public function flush() {
+    return $this->clear();
+  }
+
+  public function clear() {
     unset($this->_cache);
     unset($this->_expires);
     $this->_cache = [];
     return TRUE;
-  }
-
-  public function clear() {
-    return $this->flush();
   }
 
   private function reobjectify($value) {


### PR DESCRIPTION
cache()->clear() is the non-deprected version per https://github.com/civicrm/civicrm-core/blob/f452d72c08c27b1881af42f12c669185c43c3e30/CRM/Utils/Cache/Interface.php#L61
