### PR TITLE
Log payment processor errors that get reported to the user

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -798,10 +798,12 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $result = $this->processFormSubmission($contactID);
     }
     catch (CRM_Core_Exception $e) {
+      \Civi::log()->error('CRM_Contribute_Form_Contribution_Confirm::PostProcess processFormSubmissionException: ' . $e->getMessage());
       $this->bounceOnError($e->getMessage());
     }
 
     if (is_array($result) && !empty($result['is_payment_failure'])) {
+      \Civi::log()->error('CRM_Contribute_Form_Contribution_Confirm::PostProcess is_payment_failure: ' . $result['error']->getMessage());
       $this->bounceOnError($result['error']->getMessage());
     }
     // Presumably this is for hooks to access? Not quite clear & perhaps not required.


### PR DESCRIPTION
Overview
----------------------------------------
Client reported that some users were seeing the following error when submitting a contribution page:

`Payment Processor Error message :DB Error: no such table`

The payment etc. was actually going through but the user was being bounced back to the main contribution page with that error. Nothing was reported in the Civi logs etc. and I've now got a lot more grey hair.

`Payment Processor Error message` appears 3 times in the civicrm codebase but if you look carefully you'll notice that only one instance has a space before the ":" which tracked it down to `CRM/Contribute/Form/Contribution/Confirm.php:bounceOnError()`

Tracking through various functions eventually led me to check custom data and I found two old custom group definitions (which weren't being used) without tables which I believe is the cause of the problem on this particular site.
Probably recent changes to caching/loading of metadata etc. has made this config error become a problem. Oh, it doesn't affect all submissions either, just a few...

Anyway, we should really have something in the server logs when the user is getting this kind of error.

Before
----------------------------------------
`Payment Processor Error message` errors don't get logged on the server.

After
----------------------------------------
``Payment Processor Error message` do get logged on the server. So there is a chance that you'll actually be aware of a problem and able to debug it!

Technical Details
----------------------------------------
Just adds two log statements.

Comments
----------------------------------------

