### PR TITLE
AdminUI - Add 'sticky-header' to all tables

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_ACL_Roles.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_ACL_Roles.mgd.php
@@ -162,6 +162,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
           'cssRules' => [
             [

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Assigned_Financial_Accounts.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Assigned_Financial_Accounts.mgd.php
@@ -74,6 +74,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
           'pager' => [
             'show_count' => TRUE,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Contact_Types.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Contact_Types.mgd.php
@@ -54,6 +54,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
           'pager' => [
             'show_count' => TRUE,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Fields.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Fields.mgd.php
@@ -60,6 +60,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
           'pager' => [
             'show_count' => TRUE,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Groups.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Groups.mgd.php
@@ -74,6 +74,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
           'pager' => [
             'show_count' => TRUE,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Financial_Accounts.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Financial_Accounts.mgd.php
@@ -66,6 +66,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
           'pager' => [
             'show_count' => TRUE,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Financial_Types.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Financial_Types.mgd.php
@@ -82,6 +82,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
           'pager' => [
             'show_count' => TRUE,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Location_Types.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Location_Types.mgd.php
@@ -59,6 +59,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
           'pager' => [
             'show_count' => TRUE,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Manage_Group.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Manage_Group.mgd.php
@@ -248,6 +248,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
           'toolbar' => [
             [

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Payment_Processors.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Payment_Processors.mgd.php
@@ -89,6 +89,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
           'pager' => [
             'show_count' => TRUE,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_ProfileFields.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_ProfileFields.mgd.php
@@ -60,6 +60,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
           'pager' => [
             'show_count' => TRUE,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Profiles.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Profiles.mgd.php
@@ -73,6 +73,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
           'pager' => [
             'show_count' => TRUE,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Relationship_Types.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Relationship_Types.mgd.php
@@ -57,6 +57,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
           'pager' => [
             'show_count' => TRUE,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Headers_Footers_and_Automated_Messages.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Headers_Footers_and_Automated_Messages.mgd.php
@@ -172,6 +172,7 @@ return [
           'classes' => [
             'table-striped',
             'table',
+            'crm-sticky-header',
           ],
           'toolbar' => [
             [

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Import_Export_Mappings.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Import_Export_Mappings.mgd.php
@@ -137,6 +137,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
         ],
       ],

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Label_Formats.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Label_Formats.mgd.php
@@ -159,6 +159,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
           'draggable' => 'weight',
           'toolbar' => [

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Contribution_Pages.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Contribution_Pages.mgd.php
@@ -61,6 +61,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
           'pager' => [
             'show_count' => TRUE,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Mail_Accounts.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Mail_Accounts.mgd.php
@@ -191,6 +191,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
           'toolbar' => [
             [

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Premiums.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Premiums.mgd.php
@@ -195,6 +195,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
           'cssRules' => [
             [

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Scheduled_Jobs.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Scheduled_Jobs.mgd.php
@@ -242,6 +242,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
         ],
         'acl_bypass' => FALSE,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Print_Page_PDF_Formats.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Print_Page_PDF_Formats.mgd.php
@@ -146,6 +146,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
           'draggable' => 'weight',
           'toolbar' => [

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Queues.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Queues.mgd.php
@@ -88,6 +88,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
         ],
       ],

--- a/ext/civicrm_admin_ui/managed/SavedSearch_SMS_Provider.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_SMS_Provider.mgd.php
@@ -151,6 +151,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
           'toolbar' => [
             [

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Scheduled_Jobs_Log.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Scheduled_Jobs_Log.mgd.php
@@ -92,6 +92,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
         ],
         'acl_bypass' => FALSE,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Settings_Date_Preferences.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Settings_Date_Preferences.mgd.php
@@ -118,6 +118,7 @@ return [
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
         ],
       ],


### PR DESCRIPTION
Overview
----------------------------------------
Consistently uses the `crm-sticky-header` class for all tables in the AdminUI extension.

Before
----------------------------------------
Some had it, others didn't. 

After
----------------------------------------
Now they all do (except for the contact summary tabs).
