### PR TITLE
Switch long & angular caches to use fast-array

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -173,13 +173,14 @@ class Container {
       // Putting session-cache in global scope means that QF form-state will endure across upgrades.
       // (*For better or worse -- mostly better.*)
       'session' => ['name' => 'CiviCRM Session', 'scope' => 'global'],
-      'long' => [],
+      'long' => ['withArray' => 'fast'],
       'groups' => ['name' => 'contact groups', 'withArray' => 'fast'],
       'navigation' => ['withArray' => 'fast'],
       'customData' => ['name' => 'custom data', 'withArray' => 'fast'],
       'fields' => ['name' => 'contact fields', 'withArray' => 'fast'],
       'contactTypes' => ['withArray' => 'fast'],
       'metadata' => ['withArray' => 'fast'],
+      'angular' => ['withArray' => 'fast'],
     ];
     // Use the FastArrayDecorator on caches where (1) we don't really care about TTL,
     // (2) they're accessed frequently, (3) there's not much risk of concurrency issues.


### PR DESCRIPTION
Overview
----------------------------------------
Switch long & angular caches to use fast-array

Before
----------------------------------------
We are seeing these hit the Redis cache for the same key related to angular forms dozens of times within a page load - each time involving unserialization overhead.


After
----------------------------------------

This switches to using the fast-cache - which means that after the first cache hit the value is held in the array cache



Technical Details
----------------------------------------
On discussion with @totten  scenarios which would be a problem here are already a problem - but it is not made worse by this change because the metadata cache is implicated in the tokens & is already using array caching support


Scenario of cache-coherence bugginess for afform is  like this:

You have a background queue-listener responsible for email delivery. The listening agent has a lifespan of (say) 10min or 20min.
You have a staff-user creating forms. They make a new form and flag it for message-tokens.
They send themselves a test message using the new token.
But the background agent has stale afform data. So it doesn't know how to render the token.

Comments
----------------------------------------
Ulitmately given the interaction between data in the 'long' cache and the 'metadata' cache it feels safer (as well as more performant) to align them
