### PR TITLE
Set the default value for the domain ID on the membership type get action

### DIFF
--- a/ext/civi_member/Civi/Api4/Service/Spec/Provider/MembershipTypeGetSpecProvider.php
+++ b/ext/civi_member/Civi/Api4/Service/Spec/Provider/MembershipTypeGetSpecProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\RequestSpec;
+
+/**
+ * @service
+ * @internal
+ */
+class MembershipTypeGetSpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
+
+  /**
+   * @param \Civi\Api4\Service\Spec\RequestSpec $spec
+   */
+  public function modifySpec(RequestSpec $spec): void {
+    $spec->getFieldByName('domain_id')->setDefaultValue('current_domain');
+  }
+
+  /**
+   * When does this apply.
+   *
+   * @param string $entity
+   * @param string $action
+   *
+   * @return bool
+   */
+  public function applies($entity, $action): bool {
+    return $entity === 'MembershipType' && $action === 'get';
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Set domain id on membership type get api action like api3 have.

Before
----------------------------------------
domain id is not used; when the site is multisite and different membership types are present on each domain, then it pulled all membership types of all domains.

After
----------------------------------------
current domain gets used as the default domain ID.

It work like API3 : https://github.com/civicrm/civicrm-core/blob/master/api/v3/MembershipType.php#L92

