### PR TITLE
dev/core#5406 avoid user logout when resetting paths on Standalone

### DIFF
--- a/CRM/Core/BAO/ConfigSetting.php
+++ b/CRM/Core/BAO/ConfigSetting.php
@@ -289,11 +289,14 @@ class CRM_Core_BAO_ConfigSetting {
       FALSE,
       FALSE
     );
-    if ($config->userSystem->is_drupal &&
-      $resetSessionTable
-    ) {
+
+    if ($resetSessionTable && $config->userSystem->is_drupal) {
       db_query("DELETE FROM {sessions} WHERE 1");
       $moveStatus .= ts('Drupal session table cleared.') . '<br />';
+    }
+    elseif (!$resetSessionTable && CIVICRM_UF === 'Standalone') {
+      // dont reset CRM sessions on Standalone unless explicitly requested
+      // as otherwise it will log you out
     }
     else {
       $session = CRM_Core_Session::singleton();


### PR DESCRIPTION
Overview
----------------------------------------
Fix for https://lab.civicrm.org/dev/core/-/issues/5406

Before
----------------------------------------
- The Reset Paths button on Cleanup Caches and Update Paths button unexpectedly logs you out on Standalone

After
----------------------------------------
- it doesn't, unless you add `resetSessionTable=1` to your url param

Comments
----------------------------------------
It's nasty non-OO System code, but this is a weird legacy function that I feel like should be pulled out anyway. So this is just a quick fix
