### PR TITLE
attempt to improve text around cleanup caches / reset paths buttons

### DIFF
--- a/CRM/Admin/Form/Setting/UpdateConfigBackend.php
+++ b/CRM/Admin/Form/Setting/UpdateConfigBackend.php
@@ -24,12 +24,12 @@ class CRM_Admin_Form_Setting_UpdateConfigBackend extends CRM_Admin_Form_Setting 
    * Build the form object.
    */
   public function buildQuickForm() {
-    $this->setTitle(ts('Settings - Cleanup Caches and Update Paths'));
+    $this->setTitle(ts('Settings - Clear Caches and Reset Paths'));
 
     $this->addButtons([
       [
         'type' => 'next',
-        'name' => ts('Cleanup Caches'),
+        'name' => ts('Clear Caches'),
         'subName' => 'cleanup',
         'icon' => 'fa-undo',
 

--- a/CRM/Core/xml/Menu/Admin.xml
+++ b/CRM/Core/xml/Menu/Admin.xml
@@ -506,8 +506,8 @@
   </item>
   <item>
      <path>civicrm/admin/setting/updateConfigBackend</path>
-     <title>Cleanup Caches and Update Paths</title>
-     <desc>Reset the Base Directory Path and Base URL settings - generally when a CiviCRM site is moved to another location in the file system and/or to another domain.</desc>
+     <title>Clear Caches and Reset Paths</title>
+     <desc>Clear Caches or Reset Path and URL settings to their default values</desc>
      <page_callback>CRM_Admin_Form_Setting_UpdateConfigBackend</page_callback>
      <adminGroup>System Settings</adminGroup>
      <weight>80</weight>

--- a/sql/test_data_second_domain.mysql
+++ b/sql/test_data_second_domain.mysql
@@ -370,7 +370,7 @@ VALUES
     ( @domainID, 'civicrm/admin/setting/misc&reset=1',                  'Undelete, Logging and ReCAPTCHA', 'Undelete, Logging and ReCAPTCHA', 'administer CiviCRM', '', @systemSettingslastID, '1', NULL, 6 ),
     ( @domainID, 'civicrm/admin/setting/path&reset=1',                  'Directories',        'Directories',                                  'administer CiviCRM', '', @systemSettingslastID, '1', NULL, 7 ),
     ( @domainID, 'civicrm/admin/setting/url&reset=1',                   'Resource URLs',      'Resource URLs',                                'administer CiviCRM', '', @systemSettingslastID, '1', NULL, 8 ),
-    ( @domainID, 'civicrm/admin/setting/updateConfigBackend&reset=1',   'Cleanup Caches and Update Paths', 'Cleanup Caches and Update Paths', 'administer CiviCRM', '', @systemSettingslastID, '1', NULL, 9 ),
+    ( @domainID, 'civicrm/admin/setting/updateConfigBackend&reset=1',   'Clear Caches and Reset paths', 'Clear Caches and Reset paths', 'administer CiviCRM', '', @systemSettingslastID, '1', NULL, 9 ),
     ( @domainID, 'civicrm/admin/setting/uf&reset=1',                    'CMS Database Integration',    'CMS Integration',                     'administer CiviCRM', '', @systemSettingslastID, '1', NULL, 10 ),
     ( @domainID, 'civicrm/admin/options/safe_file_extension&group=safe_file_extension&reset=1', 'Safe File Extensions', 'Safe File Extensions','administer CiviCRM', '',@systemSettingslastID, '1', NULL, 11 ),
     ( @domainID, 'civicrm/admin/options?reset=1',                       'Option Groups', 'Option Groups',                                     'administer CiviCRM', '', @systemSettingslastID, '1', NULL, 12 ),

--- a/templates/CRM/Admin/Form/Setting/UpdateConfigBackend.tpl
+++ b/templates/CRM/Admin/Form/Setting/UpdateConfigBackend.tpl
@@ -9,12 +9,27 @@
 *}
 <div class="help">
   <p>
-    {ts}When migrating a site to a new server, the paths and URLs of your CiviCRM installation may change. {/ts}
+    {ts}On this page you can clear caches or reset paths.{/ts}
+  </p>
+  <p>
+   <b>{ts}Clear Caches{/ts}</b>
+  </p>
+  <p>
+    {ts}This will manually clear site caches. This can be useful if you an upgrade or extension didn't complete cleanly, leaving mismatches in the cache.{/ts}
+  </p>
+  <p>
+    <b>{ts}Reset paths{/ts}</b>
+  </p>
+  <p>
+    {ts}This will reset any path or URL settings in your database to the default values, and then clear caches.{/ts}
+  </p>
+  <p>
+    {ts}This can be useful if you have incorrect or out-of-date custom settings, for example following a site migrating a site to a new server.{/ts}
   </p>
   <p>
     {capture assign="pathsURL"}{crmURL p="civicrm/admin/setting/path" q="reset=1"}{/capture}
     {capture assign="urlsURL"}{crmURL p="civicrm/admin/setting/url" q="reset=1"}{/capture}
-    {ts 1=$pathsURL 2=$urlsURL}The old paths and URLs may be retained in some database records. Use this form to clear caches or to reset paths to their defaults. If you need further customizations, then update the <a href="%1">Directories</a> and <a href="%2">Resource URLs</a>.{/ts}
+    {ts 1=$pathsURL 2=$urlsURL}If you need further customizations, then you can update the <a href="%1">Directories</a> and <a href="%2">Resource URLs</a>.{/ts}
   </p>
 </div>
 <div class="crm-block crm-form-block crm-config-backend-form-block">

--- a/xml/templates/civicrm_navigation.tpl
+++ b/xml/templates/civicrm_navigation.tpl
@@ -352,7 +352,7 @@ VALUES
     ( @domainID, 'civicrm/admin/setting/component?reset=1',             '{ts escape="sql" skip="true"}Components{/ts}', 'Enable Components',                                    'administer CiviCRM', '', @systemSettingslastID, '1', NULL, 1 ),
     ( @domainID, 'civicrm/admin/extensions?reset=1',                    '{ts escape="sql" skip="true"}Extensions{/ts}', 'Manage Extensions',                                    'administer CiviCRM', '', @systemSettingslastID, '1', 1,    3 ),
 
-    ( @domainID, 'civicrm/admin/setting/updateConfigBackend?reset=1',   '{ts escape="sql" skip="true"}Cleanup Caches and Update Paths{/ts}', 'Cleanup Caches and Update Paths', 'administer CiviCRM', '', @systemSettingslastID, '1', NULL, 4 ),
+    ( @domainID, 'civicrm/admin/setting/updateConfigBackend?reset=1',   '{ts escape="sql" skip="true"}Clear Caches and Reset Paths{/ts}', 'Clear Caches and Reset Paths', 'administer CiviCRM', '', @systemSettingslastID, '1', NULL, 4 ),
     ( @domainID, 'civicrm/admin/setting/uf?reset=1',                    '{ts escape="sql" skip="true"}CMS Database Integration{/ts}',    'CMS Integration',                     'administer CiviCRM', '', @systemSettingslastID, '1', NULL, 5 ),
     ( @domainID, 'civicrm/admin/setting/debug?reset=1',                 '{ts escape="sql" skip="true"}Debugging and Error Handling{/ts}','Debugging and Error Handling',        'administer CiviCRM', '', @systemSettingslastID, '1', NULL, 6 ),
     ( @domainID, 'civicrm/admin/setting/path?reset=1',                  '{ts escape="sql" skip="true"}Directories{/ts}',        'Directories',                                  'administer CiviCRM', '', @systemSettingslastID, '1', NULL, 7 ),


### PR DESCRIPTION
Overview
----------------------------------------
Far from perfect but I was trying to provide a slight improvement on the currently mysterious guidance around /civicrm/admin/setting/updateConfigBackend?reset=1

I was particularly taking aim at "Update Paths" which I've always thought meant something cleverer than just resetting paths to defaults. (And is different from the button which says Reset Paths)

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/e48cecbc-ed1f-4457-ae35-d0a491577606)


After
----------------------------------------
![image](https://github.com/user-attachments/assets/dbc336d3-4860-4167-846f-f040298c8e3a)



Comments
----------------------------------------
I would also be very happy to rip out the Reset Paths button.
