### PR TITLE
Afform - Do not allow DisplayOnly fields to submit

### DIFF
--- a/Civi/Test/Api4TestTrait.php
+++ b/Civi/Test/Api4TestTrait.php
@@ -48,6 +48,25 @@ trait Api4TestTrait {
   }
 
   /**
+   * @param string $entityName
+   * @param array|string|int $idOrFilters
+   *   Either the entity id or filters like ['name' => 'foo']
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  public function getTestRecord(string $entityName, $idOrFilters): array {
+    if (!is_array($idOrFilters)) {
+      $idField = CoreUtil::getIdFieldName($entityName);
+      $idOrFilters = [$idField => $idOrFilters];
+    }
+    $where = [];
+    foreach ($idOrFilters as $key => $value) {
+      $where[] = [$key, '=', $value];
+    }
+    return civicrm_api4($entityName, 'get', ['where' => $where])->single();
+  }
+
+  /**
    * Saves one or more test records, supplying default values.
    *
    * Test records will be deleted when the `deleteTestRecords` function is


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/5473 and https://lab.civicrm.org/dev/core/-/issues/5287

Before
----------------------------------------
Display-only field submits and overwrites existing values.

After
----------------------------------------
Display-only fields are ignored when submitting an Afform.