### PR TITLE
Afform - Prevent clicking in dropdowns from closing the menu

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor.css
+++ b/ext/afform/admin/ang/afGuiEditor.css
@@ -420,7 +420,7 @@ body.af-gui-dragging {
   left: -4px;
 }
 
-#afGuiEditor .dropdown-menu li {
+#afGuiEditor ul.dropdown-menu {
   cursor: default;
 }
 

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiButton.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiButton.html
@@ -4,7 +4,7 @@
       <button type="button" class="btn btn-default btn-xs dropdown-toggle af-gui-add-element-button" data-toggle="dropdown" title="{{:: ts('Configure') }}">
         <span><i class="crm-i fa-gear"></i></span>
       </button>
-      <ul class="dropdown-menu" ng-if="menu.open" ng-include="'~/afGuiEditor/elements/afGuiButton-menu.html'"></ul>
+      <ul class="dropdown-menu" ng-if="menu.open" ng-include="'~/afGuiEditor/elements/afGuiButton-menu.html'" ng-click="$event.stopPropagation()"></ul>
     </div>
   </div>
 </div>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
@@ -12,7 +12,7 @@
         <button type="button" class="btn btn-default btn-xs dropdown-toggle af-gui-add-element-button" data-toggle="dropdown" title="{{:: ts('Configure') }}">
           <span><i class="crm-i fa-gear"></i></span>
         </button>
-        <ul class="dropdown-menu dropdown-menu-right" ng-if="menu.open" ng-include="'~/afGuiEditor/elements/' + ($ctrl.node['af-fieldset'] === '' ? 'afGuiSearchContainer' : 'afGuiContainer') + '-menu.html'"></ul>
+        <ul class="dropdown-menu dropdown-menu-right" ng-if="menu.open" ng-include="'~/afGuiEditor/elements/' + ($ctrl.node['af-fieldset'] === '' ? 'afGuiSearchContainer' : 'afGuiContainer') + '-menu.html'" ng-click="$event.stopPropagation()"></ul>
       </div>
     </div>
   </div>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.html
@@ -7,7 +7,7 @@
         <button type="button" class="btn btn-default btn-xs dropdown-toggle af-gui-add-element-button" data-toggle="dropdown" title="{{:: ts('Configure') }}">
           <span><i class="crm-i fa-gear"></i></span>
         </button>
-        <ul class="dropdown-menu dropdown-menu-right" ng-if="menu.open" ng-include="'~/afGuiEditor/elements/afGuiField-menu.html'"></ul>
+        <ul class="dropdown-menu dropdown-menu-right" ng-if="menu.open" ng-include="'~/afGuiEditor/elements/afGuiField-menu.html'" ng-click="$event.stopPropagation()"></ul>
       </div>
     </div>
   </div>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiGenericElement.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiGenericElement.html
@@ -6,7 +6,7 @@
         <button type="button" class="btn btn-default btn-xs dropdown-toggle af-gui-add-element-button" data-toggle="dropdown" title="{{:: ts('Configure') }}">
           <span><i class="crm-i fa-gear"></i></span>
         </button>
-        <ul class="dropdown-menu" ng-if="menu.open" ng-include="'~/afGuiEditor/elements/afGuiGenericElement-menu.html'"></ul>
+        <ul class="dropdown-menu" ng-if="menu.open" ng-include="'~/afGuiEditor/elements/afGuiGenericElement-menu.html'" ng-click="$event.stopPropagation()"></ul>
       </div>
     </div>
   </div>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiMarkup.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiMarkup.html
@@ -4,7 +4,7 @@
       <button type="button" class="btn btn-default btn-xs dropdown-toggle af-gui-add-element-button" data-toggle="dropdown" title="{{:: ts('Configure') }}">
         <span><i class="crm-i fa-gear"></i></span>
       </button>
-      <ul class="dropdown-menu" ng-if="menu.open" ng-include="'~/afGuiEditor/elements/afGuiMarkup-menu.html'"></ul>
+      <ul class="dropdown-menu" ng-if="menu.open" ng-include="'~/afGuiEditor/elements/afGuiMarkup-menu.html'" ng-click="$event.stopPropagation()"></ul>
     </div>
   </div>
 </div>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiText.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiText.html
@@ -4,7 +4,7 @@
       <button type="button" class="btn btn-default btn-xs dropdown-toggle af-gui-add-element-button" data-toggle="dropdown" title="{{:: ts('Configure') }}">
         <span><i class="crm-i fa-gear"></i></span>
       </button>
-      <ul class="dropdown-menu" ng-if="menu.open" ng-include="'~/afGuiEditor/elements/afGuiText-menu.html'"></ul>
+      <ul class="dropdown-menu" ng-if="menu.open" ng-include="'~/afGuiEditor/elements/afGuiText-menu.html'" ng-click="$event.stopPropagation()"></ul>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/5573 and also addresses a style issue where hovering over dividers in the menu would give a move cursor instead of a plain one.

Technical Details
-------
I'm not quite sure why all this `stopPropigation()` is needed but I'm guessing it's to do with a side-interaction between BS JS and AngularJS.

Hopefully it doesn't cause any side-effects.