### PR TITLE
(dev/core#4462) Afform Tokens - Shuffle names to ease 5.78=>5.79 migration

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSeventyNine.php
+++ b/CRM/Upgrade/Incremental/php/FiveSeventyNine.php
@@ -26,7 +26,7 @@ class CRM_Upgrade_Incremental_php_FiveSeventyNine extends CRM_Upgrade_Incrementa
       $tokenForms = static::findAfformsWithMsgToken();
       if (!empty($tokenForms)) {
         $formList = implode(', ', array_map(fn($name) => '<em>"' . htmlentities($name) . '"</em>', $tokenForms));
-        $message .= '<p>' . ts('Some custom forms (%1) support authenticated email links. Links will still be generated in 5.79+, but they only confer access to one page at a time. Please review the <strong><a %2>CiviCRM 5.79 Form-Token Notice</a></strong>.', [
+        $message .= '<p>' . ts('Some custom forms (%1) support authenticated email links. Please review the <strong><a %2>CiviCRM 5.79 Form-Token Notice</a></strong>.', [
           1 => $formList,
           2 => 'href="https://lab.civicrm.org/dev/core/-/wikis/CiviCRM-v5.79-Form-Token-Notice" target="_blank"',
         ]) . '</p>';
@@ -62,6 +62,21 @@ class CRM_Upgrade_Incremental_php_FiveSeventyNine extends CRM_Upgrade_Incrementa
     $this->addTask('Populate financial labels', 'populateFinancialLabels');
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Update "Website Type" options', 'updateWebsiteType');
+
+    Civi::queue(CRM_Upgrade_Form::QUEUE_NAME)->createItem(
+      new CRM_Queue_Task([static::CLASS, 'checkEnableLoginTokens']),
+      ['weight' => 2001]
+    );
+  }
+
+  public static function checkEnableLoginTokens(CRM_Queue_TaskContext $ctx) {
+    if (static::findAfformsWithMsgToken()) {
+      $ctx->queue->createItem(
+        new CRM_Queue_Task([static::CLASS, 'enableExtension'], [['afform_login_token']], 'Enable Form Core Login Tokens'),
+        ['weight' => 2000]
+      );
+    }
+    return TRUE;
   }
 
   /**

--- a/ext/afform/core/Civi/Afform/Tokens.php
+++ b/ext/afform/core/Civi/Afform/Tokens.php
@@ -27,9 +27,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class Tokens extends AutoService implements EventSubscriberInterface {
 
-  private static $placement = 'msg_token';
+  private static $placement = 'msg_token_single';
 
-  private static $prefix = 'afform';
+  private static $prefix = 'form';
 
   private static $jwtScope = 'afform';
 

--- a/ext/afform/core/Civi/Afform/Tokens.php
+++ b/ext/afform/core/Civi/Afform/Tokens.php
@@ -27,6 +27,12 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class Tokens extends AutoService implements EventSubscriberInterface {
 
+  private static $placement = 'msg_token';
+
+  private static $prefix = 'afform';
+
+  private static $jwtScope = 'afform';
+
   public static function getSubscribedEvents(): array {
     if (!\CRM_Extension_System::singleton()->getMapper()->isActiveModule('authx')) {
       return [];
@@ -46,9 +52,10 @@ class Tokens extends AutoService implements EventSubscriberInterface {
    * @see CRM_Utils_Hook::alterMailContent
    */
   public static function applyCkeditorWorkaround(GenericHookEvent $e) {
+    $pat = ';https?://(\{' . preg_quote(static::$prefix, ';') . '.*Url\});';
     foreach (array_keys($e->content) as $field) {
       if (is_string($e->content[$field])) {
-        $e->content[$field] = preg_replace(';https?://(\{afform.*Url\});', '$1', $e->content[$field]);
+        $e->content[$field] = preg_replace($pat, '$1', $e->content[$field]);
       }
     }
   }
@@ -57,9 +64,9 @@ class Tokens extends AutoService implements EventSubscriberInterface {
     // this tokens should be available only in contact context i.e. in Message Templates (add/edit)
     $tokenForms = static::getTokenForms();
     foreach ($tokenForms as $tokenName => $afform) {
-      $e->entity('afform')
+      $e->entity(static::$prefix)
         ->register("{$tokenName}Url", E::ts('%1 (URL)', [1 => $afform['title'] ?? $afform['name']]));
-      $e->entity('afform')
+      $e->entity(static::$prefix)
         ->register("{$tokenName}Link", E::ts('%1 (Full Hyperlink)', [1 => $afform['title'] ?? $afform['name']]));
     }
     if (!in_array('contactId', $e->getTokenProcessor()->getContextValues('schema')[0])) {
@@ -75,7 +82,7 @@ class Tokens extends AutoService implements EventSubscriberInterface {
     $messageTokens = $e->getTokenProcessor()->getMessageTokens();
 
     try {
-      $activeAfformTokens = $messageTokens['afform'] ?? [];
+      $activeAfformTokens = $messageTokens[static::$prefix] ?? [];
       if (!empty($activeAfformTokens)) {
         $tokenForms = static::getTokenForms();
         foreach ($tokenForms as $formName => $afform) {
@@ -94,8 +101,8 @@ class Tokens extends AutoService implements EventSubscriberInterface {
               continue;
             }
             $url = self::createUrl($afform, $row->context['contactId']);
-            $row->format('text/plain')->tokens('afform', $afform['name'] . 'Url', $url);
-            $row->format('text/html')->tokens('afform', $afform['name'] . 'Link', sprintf('<a href="%s">%s</a>', htmlentities($url), htmlentities($afform['title'] ?? $afform['name'])));
+            $row->format('text/plain')->tokens(static::$prefix, $afform['name'] . 'Url', $url);
+            $row->format('text/html')->tokens(static::$prefix, $afform['name'] . 'Link', sprintf('<a href="%s">%s</a>', htmlentities($url), htmlentities($afform['title'] ?? $afform['name'])));
           }
         }
       }
@@ -162,7 +169,7 @@ class Tokens extends AutoService implements EventSubscriberInterface {
   public static function getTokenForms(): array {
     if (!isset(\Civi::$statics[__CLASS__]['tokenForms'])) {
       $tokenForms = (array) \Civi\Api4\Afform::get(FALSE)
-        ->addWhere('placement', 'CONTAINS', 'msg_token')
+        ->addWhere('placement', 'CONTAINS', static::$placement)
         ->addSelect('name', 'title', 'server_route', 'is_public')
         ->execute()
         ->indexBy('name');
@@ -195,7 +202,7 @@ class Tokens extends AutoService implements EventSubscriberInterface {
     $bearerToken = "Bearer " . $jwt->encode([
       'exp' => $expires,
       'sub' => "cid:" . $contactId,
-      'scope' => 'afform',
+      'scope' => static::$jwtScope,
       'afform' => $afform['name'],
     ]);
     return $url->addQuery(['_aff' => $bearerToken]);

--- a/ext/afform/core/managed/AfformPlacement.mgd.php
+++ b/ext/afform/core/managed/AfformPlacement.mgd.php
@@ -87,7 +87,7 @@ return [
     ],
   ],
   [
-    'name' => 'AfformPlacement:msg_token',
+    'name' => 'AfformPlacement:msg_token_single',
     'entity' => 'OptionValue',
     'cleanup' => 'always',
     'update' => 'always',
@@ -95,8 +95,8 @@ return [
       'version' => 4,
       'values' => [
         'option_group_id.name' => 'afform_placement',
-        'name' => 'msg_token',
-        'value' => 'msg_token',
+        'name' => 'msg_token_single',
+        'value' => 'msg_token_single',
         'label' => E::ts('Message Tokens'),
         'is_reserved' => TRUE,
         'is_active' => TRUE,

--- a/ext/afform/login_token/Civi/AfformLoginToken/Tokens.php
+++ b/ext/afform/login_token/Civi/AfformLoginToken/Tokens.php
@@ -25,6 +25,8 @@ class Tokens extends AutoService implements EventSubscriberInterface {
 
   private static $placement = 'msg_token_login';
 
+  private static $prefix = 'afformLogin';
+
   public static function getSubscribedEvents(): array {
     if (!\CRM_Extension_System::singleton()->getMapper()->isActiveModule('authx')) {
       return [];
@@ -40,7 +42,7 @@ class Tokens extends AutoService implements EventSubscriberInterface {
     if (in_array('contactId', $e->getTokenProcessor()->getContextValues('schema')[0])) {
       $tokenForms = static::getTokenForms();
       foreach ($tokenForms as $formName => $afform) {
-        $e->entity('afformLogin')
+        $e->entity(static::$prefix)
           ->register("{$formName}Url", E::ts('%1 (URL, Login)', [1 => $afform['title'] ?? $afform['name']]))
           ->register("{$formName}Link", E::ts('%1 (Hyperlink, Login)', [1 => $afform['title'] ?? $afform['name']]));
       }
@@ -52,7 +54,7 @@ class Tokens extends AutoService implements EventSubscriberInterface {
    */
   public function evaluateTokens(\Civi\Token\Event\TokenValueEvent $e): void {
     $activeTokens = $e->getTokenProcessor()->getMessageTokens();
-    if (empty($activeTokens['afformLogin'])) {
+    if (empty($activeTokens[static::$prefix])) {
       return;
     }
 
@@ -60,8 +62,8 @@ class Tokens extends AutoService implements EventSubscriberInterface {
     foreach ($tokenForms as $formName => $afform) {
       foreach ($e->getRows() as $row) {
         $url = self::createUrl($afform, $row->context['contactId']);
-        $row->format('text/plain')->tokens('afformLogin', "{$formName}Url", $url);
-        $row->format('text/html')->tokens('afformLogin', "{$formName}Link", sprintf('<a href="%s">%s</a>', htmlentities($url), htmlentities($afform['title'] ?? $afform['name'])));
+        $row->format('text/plain')->tokens(static::$prefix, "{$formName}Url", $url);
+        $row->format('text/html')->tokens(static::$prefix, "{$formName}Link", sprintf('<a href="%s">%s</a>', htmlentities($url), htmlentities($afform['title'] ?? $afform['name'])));
       }
     }
   }

--- a/ext/afform/login_token/managed/AfformPlacement.mgd.php
+++ b/ext/afform/login_token/managed/AfformPlacement.mgd.php
@@ -5,7 +5,7 @@ use CRM_Afform_ExtensionUtil as E;
 // Option group for Afform.placement field
 return [
   [
-    'name' => 'AfformPlacement:msg_token_login',
+    'name' => 'AfformPlacement:msg_token',
     'entity' => 'OptionValue',
     'cleanup' => 'always',
     'update' => 'always',
@@ -13,8 +13,8 @@ return [
       'version' => 4,
       'values' => [
         'option_group_id.name' => 'afform_placement',
-        'name' => 'msg_token_login',
-        'value' => 'msg_token_login',
+        'name' => 'msg_token',
+        'value' => 'msg_token',
         'label' => E::ts('Message Tokens (Login)'),
         'is_reserved' => TRUE,
         'is_active' => TRUE,

--- a/ext/afform/mock/ang/mockPublicForm.aff.php
+++ b/ext/afform/mock/ang/mockPublicForm.aff.php
@@ -5,6 +5,6 @@ return [
   'server_route' => 'civicrm/mock-public-form',
   'is_public' => TRUE,
   'permission' => '*always allow*',
-  'is_token' => TRUE,
+  'placement' => ['msg_token_single'],
   'create_submission' => FALSE,
 ];

--- a/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormBrowserTest.php
+++ b/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormBrowserTest.php
@@ -35,7 +35,7 @@ class MockPublicFormBrowserTest extends Civi\Test\MinkBase {
     $this->assertEquals('Donald', $this->getContact($donny)['middle_name'], 'Middle name has original value');
 
     $session = $this->mink->getSession();
-    $url = $this->renderToken('{afform.mockPublicFormUrl}', $donny);
+    $url = $this->renderToken('{form.mockPublicFormUrl}', $donny);
     $this->visit($url);
 
     // Goal: Wait for the fields to be populated. But how...?

--- a/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormTest.php
+++ b/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormTest.php
@@ -94,7 +94,7 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
   }
 
   /**
-   * There are two tokens ({afform.mockPublicFormUrl} and {afform.mockPublicFormLink})
+   * There are two tokens ({form.mockPublicFormUrl} and {form.mockPublicFormLink})
    * which are rendered in two contexts (text and HTML).
    *
    * Make sure that the resulting URLs point to the same place, regardless of which
@@ -105,8 +105,8 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
   public function testWellFormedTokens() {
     $lebowski = $this->getLebowskiCID();
     $messages = \CRM_Core_TokenSmarty::render([
-      'text' => 'url=({afform.mockPublicFormUrl}) link=({afform.mockPublicFormLink})',
-      'html' => '<p>url=({afform.mockPublicFormUrl}) link=({afform.mockPublicFormLink})</p>',
+      'text' => 'url=({form.mockPublicFormUrl}) link=({form.mockPublicFormLink})',
+      'html' => '<p>url=({form.mockPublicFormUrl}) link=({form.mockPublicFormLink})</p>',
     ], ['contactId' => $lebowski]);
 
     $httpTextUrl = '(https?:[a-zA-Z0-9%_/\.\?\-\+:=#&]+)';
@@ -120,21 +120,21 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
     preg_match($textPattern, $messages['text'], $textMatches);
     preg_match($htmlPattern, $messages['html'], $htmlMatches);
 
-    $this->assertEquals($textMatches[1], html_entity_decode($htmlMatches[1]), 'Text and HTML values of {afform.mockPublicFormUrl} should point to same place');
-    $this->assertEquals($textMatches[2], html_entity_decode($htmlMatches[2]), 'Text and HTML values of {afform.mockPublicFormLink} should point to same place');
+    $this->assertEquals($textMatches[1], html_entity_decode($htmlMatches[1]), 'Text and HTML values of {form.mockPublicFormUrl} should point to same place');
+    $this->assertEquals($textMatches[2], html_entity_decode($htmlMatches[2]), 'Text and HTML values of {form.mockPublicFormLink} should point to same place');
 
     $this->assertMatchesRegularExpression(';^https?:.*civicrm(/|%2F)mock-public-form.*;', $textMatches[1], "URL should look plausible");
     $this->assertMatchesRegularExpression(';^https?:.*civicrm(/|%2F)mock-public-form.*;', $textMatches[2], "URL should look plausible");
   }
 
   /**
-   * Evaluate the email token `{afform.mockPublicFormUrl}`. The output should be a page-level auth token.
+   * Evaluate the email token `{form.mockPublicFormUrl}`. The output should be a page-level auth token.
    */
   public function testAuthenticatedUrlToken_Page() {
     $this->assertTrue(function_exists('authx_civicrm_config'), 'Cannot test without authx');
 
     $lebowski = $this->getLebowskiCID();
-    $url = $this->renderTokens($lebowski, '{afform.mockPublicFormUrl}', 'text/plain');
+    $url = $this->renderTokens($lebowski, '{form.mockPublicFormUrl}', 'text/plain');
     $this->assertMatchesRegularExpression(';^https?:.*civicrm(/|%2F)mock-public-form.*;', $url, "URL should look plausible");
 
     // This URL doesn't specifically log you in to a durable session.


### PR DESCRIPTION
Overview
--------

This is a follow-up to #30585.  The upgrade process circa 5.78=>5.79-alpha is fairly sticky.  This provides a simpler upgrade for 5.78=>5.79.

ping @eileenmcnaughton  @ufundo

Before + After
-------------

With 5.78=>5.79-alpha, the interpretation of various symbols changes. This restores the interpretation to be consistent with 5.78.

|                               | 5.78          | 5.79.alpha            | 5.79.rc-late |
| -- | -- | -- | -- |
| Login Token: Placement ID        | `msg_token`   | `msg_token_login`     | `msg_token`   |
| Login Token: Pattern          | `{afform.*}`  | `{afformLogin.*}`     | `{afform.*}` (deprecated) <br/> `{login.*}` (suggested)       |
| Login Token: Implemented By   | Core          | Ext `afform_login_token` | Ext `afform_login_token` |
| -- | -- | -- | -- |
| Single Page Token: Placement ID  | `msg_token`   | `msg_token`           | `msg_token_single`    |
| Single Page Token: Pattern    | N/A           | `{afform.*}`          | `{form.*}`    |
| Single Page Token: Implemented By | N/A       | Core                  | Core          |

With <=5.78,  you can flag an afform with `placement=>msg_token`, and this will enable generation of
login-tokens using the formula `{afform.*}`. This again true for 5.79 with this PR.

Comments
----------------------------------------

Tomorrow, I should also add upgrade step to auto-enable the extension on sites which have enabled `msg_token` placement. But submitting now to get CI test-runs and review-feedback going.