### PR TITLE
many relative dates aren't going to 11:59:59

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -1189,6 +1189,8 @@ class CRM_Utils_Date {
     $now = getdate(CRM_Utils_Time::time());
     $from = $to = $dateRange = [];
     $from['H'] = $from['i'] = $from['s'] = 0;
+    $to['H'] = 23;
+    $to['i'] = $to['s'] = 59;
     $relativeTermParts = explode('_', $relativeTerm);
     $relativeTermPrefix = $relativeTermParts[0];
     $relativeTermSuffix = $relativeTermParts[1] ?? '';
@@ -1242,8 +1244,6 @@ class CRM_Utils_Date {
             $to['d'] = $now['mday'];
             $to['M'] = $now['mon'];
             $to['Y'] = $now['year'];
-            $to['H'] = 23;
-            $to['i'] = $to['s'] = 59;
             $from = self::intervalAdd('year', -1, $to);
             $from = self::intervalAdd('second', 1, $from);
             break;
@@ -1251,8 +1251,6 @@ class CRM_Utils_Date {
           case 'current':
             $from['M'] = $from['d'] = 1;
             $from['Y'] = $now['year'];
-            $to['H'] = 23;
-            $to['i'] = $to['s'] = 59;
             $to['d'] = $now['mday'];
             $to['M'] = $now['mon'];
             $to['Y'] = $now['year'];
@@ -1262,8 +1260,6 @@ class CRM_Utils_Date {
             $to['d'] = $now['mday'];
             $to['M'] = $now['mon'];
             $to['Y'] = $now['year'];
-            $to['H'] = 23;
-            $to['i'] = $to['s'] = 59;
             $from = self::intervalAdd('year', -2, $to);
             $from = self::intervalAdd('second', 1, $from);
             break;
@@ -1272,8 +1268,6 @@ class CRM_Utils_Date {
             $to['d'] = $now['mday'];
             $to['M'] = $now['mon'];
             $to['Y'] = $now['year'];
-            $to['H'] = 23;
-            $to['i'] = $to['s'] = 59;
             $from = self::intervalAdd('year', -3, $to);
             $from = self::intervalAdd('second', 1, $from);
             break;
@@ -1308,8 +1302,6 @@ class CRM_Utils_Date {
                 $to['d'] = $now['mday'];
                 $to['M'] = $now['mon'];
                 $to['Y'] = $now['year'];
-                $to['H'] = 23;
-                $to['i'] = $to['s'] = 59;
                 $from = self::intervalAdd('year', -$relativeTermSuffix, $to);
                 $from = self::intervalAdd('second', 1, $from);
                 break;
@@ -1341,8 +1333,6 @@ class CRM_Utils_Date {
             $to['d'] = $fiscalEnd['2'];
             $to['M'] = $fiscalEnd['1'];
             $to['Y'] = $fiscalEnd['0'];
-            $to['H'] = 23;
-            $to['i'] = $to['s'] = 59;
             if (is_numeric($relativeTermSuffix)) {
               $from = self::intervalAdd('year', (-$relativeTermSuffix), $to);
               $from = self::intervalAdd('second', 1, $from);
@@ -1357,8 +1347,6 @@ class CRM_Utils_Date {
               $to['d'] = $fiscalEnd['2'];
               $to['M'] = $fiscalEnd['1'];
               $to['Y'] = $fiscalEnd['0'];
-              $to['H'] = 23;
-              $to['i'] = $to['s'] = 59;
             }
             else {
               $from['Y'] = $fYear - $relativeTermSuffix;
@@ -1368,8 +1356,6 @@ class CRM_Utils_Date {
               $to['M'] = $fiscalEnd['1'];
               // We need the year from FiscalEnd, instead of just fYear, because these differ if the FY starts on Jan 1
               $to['Y'] = $fiscalEnd['0'];
-              $to['H'] = 23;
-              $to['i'] = $to['s'] = 59;
             }
             break;
 
@@ -1503,8 +1489,6 @@ class CRM_Utils_Date {
             $to['d'] = $now['mday'];
             $to['M'] = $now['mon'];
             $to['Y'] = $now['year'];
-            $to['H'] = 23;
-            $to['i'] = $to['s'] = 59;
             $from = self::intervalAdd('day', -90, $to);
             $from = self::intervalAdd('second', 1, $from);
             break;
@@ -1517,8 +1501,6 @@ class CRM_Utils_Date {
             $to['d'] = $now['mday'];
             $to['M'] = $now['mon'];
             $to['Y'] = $now['year'];
-            $to['H'] = 23;
-            $to['i'] = $to['s'] = 59;
             break;
 
           case 'less':
@@ -1565,8 +1547,6 @@ class CRM_Utils_Date {
               $to['d'] = $now['mday'];
               $to['M'] = $now['mon'];
               $to['Y'] = $now['year'];
-              $to['H'] = 23;
-              $to['i'] = $to['s'] = 59;
               $from = self::intervalAdd('month', -($relativeTermSuffix * 3), $to);
               $from = self::intervalAdd('second', 1, $from);
             }
@@ -1672,8 +1652,6 @@ class CRM_Utils_Date {
             $to['d'] = $now['mday'];
             $to['M'] = $now['mon'];
             $to['Y'] = $now['year'];
-            $to['H'] = 23;
-            $to['i'] = $to['s'] = 59;
             $from = self::intervalAdd('day', -60, $to);
             $from = self::intervalAdd('second', 1, $from);
             break;
@@ -1682,8 +1660,6 @@ class CRM_Utils_Date {
             $to['d'] = $now['mday'];
             $to['M'] = $now['mon'];
             $to['Y'] = $now['year'];
-            $to['H'] = 23;
-            $to['i'] = $to['s'] = 59;
             $from = self::intervalAdd('day', -30, $to);
             $from = self::intervalAdd('second', 1, $from);
             break;
@@ -1695,8 +1671,6 @@ class CRM_Utils_Date {
             $to['d'] = $now['mday'];
             $to['M'] = $now['mon'];
             $to['Y'] = $now['year'];
-            $to['H'] = 23;
-            $to['i'] = $to['s'] = 59;
             break;
 
           case 'less':
@@ -1745,8 +1719,6 @@ class CRM_Utils_Date {
               $to['d'] = $now['mday'];
               $to['M'] = $now['mon'];
               $to['Y'] = $now['year'];
-              $to['H'] = 23;
-              $to['i'] = $to['s'] = 59;
               $from = self::intervalAdd($unit, -$relativeTermSuffix, $to);
               $from = self::intervalAdd('second', 1, $from);
             }
@@ -1823,8 +1795,6 @@ class CRM_Utils_Date {
             $to['d'] = $now['mday'];
             $to['M'] = $now['mon'];
             $to['Y'] = $now['year'];
-            $to['H'] = 23;
-            $to['i'] = $to['s'] = 59;
             $from = self::intervalAdd('day', -7, $to);
             $from = self::intervalAdd('second', 1, $from);
             break;
@@ -1837,8 +1807,6 @@ class CRM_Utils_Date {
             $to['d'] = $now['mday'];
             $to['M'] = $now['mon'];
             $to['Y'] = $now['year'];
-            $to['H'] = 23;
-            $to['i'] = $to['s'] = 59;
             break;
 
           case 'less':
@@ -1873,8 +1841,6 @@ class CRM_Utils_Date {
               $to['d'] = $now['mday'];
               $to['M'] = $now['mon'];
               $to['Y'] = $now['year'];
-              $to['H'] = 23;
-              $to['i'] = $to['s'] = 59;
               $from = self::intervalAdd($unit, -$relativeTermSuffix, $to);
               $from = self::intervalAdd('second', 1, $from);
             }
@@ -1947,8 +1913,6 @@ class CRM_Utils_Date {
               $to['d'] = $now['mday'];
               $to['M'] = $now['mon'];
               $to['Y'] = $now['year'];
-              $to['H'] = 23;
-              $to['i'] = $to['s'] = 59;
               $from = self::intervalAdd($unit, -$relativeTermSuffix, $to);
               $from = self::intervalAdd('second', 1, $from);
             }

--- a/tests/phpunit/CRM/Utils/DateTest.php
+++ b/tests/phpunit/CRM/Utils/DateTest.php
@@ -122,7 +122,7 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
       $date = CRM_Utils_Date::relativeToAbsolute($relativeString, 'year');
       $this->assertEquals([
         'from' => $year . '0101',
-        'to' => $year . '1231',
+        'to' => $year . '1231235959',
       ], $date, 'relative term is ' . $relativeString);
 
       $year--;
@@ -133,7 +133,7 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
     $thisYear = date('Y');
     $this->assertEquals([
       'from' => ($thisYear - 1) . '0101',
-      'to' => $thisYear . '1231',
+      'to' => $thisYear . '1231235959',
     ], $date, 'relative term is this_2 year');
   }
 
@@ -228,7 +228,7 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
       $offset = (substr($relativeString, -1, 1)) - 1;
       $this->assertEquals([
         'from' => $lastYear - $offset . '0101',
-        'to' => $lastYear . '1231',
+        'to' => $lastYear . '1231235959',
       ], $date, 'relative term is ' . $relativeString);
     }
   }
@@ -2618,7 +2618,7 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
 
     $this->assertEquals([
       'from' => NULL,
-      'to' => date('Ymd000000', strtotime('-1 day')),
+      'to' => date('Ymd235959', strtotime('-1 day')),
     ], $date);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
All of our relative date filters that have an ending day should be ending on that day at 11:59:59pm.  Many relative date filters do not.

This behavior is hidden because the addition of the 23:59:59 is done elsewhere.  But a) this shouldn't be necessary, and b) it's not done everywhere.

In particular, it's not happening when searching contributions from the "Open Batch" screen.

**Replication Steps**.
* Create a contribution that was received on the last day of the month before last.  E.g. during November, create a contribution for September 30th.
* Ensure the contribution has a time other than midnight.
* Go to **Contributions » Accounting Batches » New Batch** and create a batch.
* Search for contributions with a contribution date of "Month prior to previous calendar month".

Before
----------------------------------------
The contribution on 2024-09-30 will not be in the search results.

After
----------------------------------------
It will be.

Technical Details
----------------------------------------
I don't see any scenario in which you wouldn't want the 23:59:59, *unless* you are using a filter with no `to` date (e.g. "From start of current month").  But those all unset the `to` anyway.

It might be nice to find where in the code the "23:59:59" is set otherwise and remove it, but that's courting trouble and out of scope.

Comments
----------------------------------------
This fails 3 tests. That's because IMO the tests are wrong. But I wanted to hear from the test authors (@eileenmcnaughton, @magnolia61, and @demeritcowboy respectively) to make sure I understand.

That said, in the case of the first 2 tests, the "fiscal year" version of those same tests specifically expects the 23:59:59.  I don't see a scenario in which we want "year" and "fiscal year" to return different results if the fiscal year starts January 1st.

```
1) CRM_Utils_DateTest::testRelativeToAbsoluteYear
relative term is this
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     'from' => '20240101'
-    'to' => '20241231'
+    'to' => '20241231235959'
 )

/home/jon/local/civicrm-buildkit/build/dmaster/web/sites/all/modules/civicrm/tests/phpunit/CRM/Utils/DateTest.php:123
/home/jon/local/civicrm-buildkit/build/dmaster/web/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:293
/home/jon/local/civicrm-buildkit/extern/phpunit9/phpunit9.phar:2520

2) CRM_Utils_DateTest::testRelativeToAbsoluteYearRange
relative term is previous_2
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     'from' => '20220101'
-    'to' => '20231231'
+    'to' => '20231231235959'
 )

/home/jon/local/civicrm-buildkit/build/dmaster/web/sites/all/modules/civicrm/tests/phpunit/CRM/Utils/DateTest.php:229
/home/jon/local/civicrm-buildkit/build/dmaster/web/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:293
/home/jon/local/civicrm-buildkit/extern/phpunit9/phpunit9.phar:2520

3) CRM_Utils_DateTest::testRelativeEarlierDay
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     'from' => null
-    'to' => '20241104000000'
+    'to' => '20241104235959'
 )

/home/jon/local/civicrm-buildkit/build/dmaster/web/sites/all/modules/civicrm/tests/phpunit/CRM/Utils/DateTest.php:2619
/home/jon/local/civicrm-buildkit/build/dmaster/web/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:293
/home/jon/local/civicrm-buildkit/extern/phpunit9/phpunit9.phar:2520
```