### PR TITLE
Upgrade - Fix error in `getSqlOptions()` when navigating

### DIFF
--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -1517,7 +1517,7 @@ WHERE  id = %1
     foreach ($options as $option) {
       // Some fallbacks in case the array is missing a 'name' or 'label' or 'abbr'
       $id = $option[$key] ?? $option['id'] ?? $option['name'];
-      $result[$id] = $option[$value] ?? $option['label'] ?? $option['name'];
+      $result[$id] = $option[$value] ?? $option['label'] ?? $option['name'] ?? $option['id'];
     }
     return $result;
   }

--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -140,13 +140,13 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
     $options = $cache->get($cacheKey);
     if (!isset($options)) {
       $options = [];
-      $fields = $entity->getFields();
+      $fields = $entity->getSupportedFields();
       $select = \CRM_Utils_SQL_Select::from($pseudoconstant['table']);
       $idCol = $pseudoconstant['key_column'] ?? $entity->getMeta('primary_key');
       $pseudoconstant['name_column'] ??= (isset($fields['name']) ? 'name' : $idCol);
       $select->select(["$idCol AS id"]);
       foreach (array_keys(\CRM_Core_SelectValues::optionAttributes()) as $prop) {
-        if (!empty($pseudoconstant["{$prop}_column"])) {
+        if (isset($pseudoconstant["{$prop}_column"], $fields[$pseudoconstant["{$prop}_column"]])) {
           $propColumn = $pseudoconstant["{$prop}_column"];
           $select->select("$propColumn AS $prop");
         }
@@ -159,13 +159,13 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
       if (isset($fields['component_id'])) {
         $select->select('component_id');
       }
-      // Order by: prefer order_column or 'weight' column
-      if (!empty($pseudoconstant['order_column']) || isset($fields['weight'])) {
-        $select->orderBy($pseudoconstant['order_column'] ?? 'weight');
-      }
-      // Fall back on label_column or id if nothing else
-      else {
-        $select->orderBy($pseudoconstant['label_column'] ?? $idCol);
+      // Order by: prefer order_column; or else 'weight' column; or else lobel_column; or as a last resort, $idCol
+      $orderColumns = [$pseudoconstant['order_column'] ?? NULL, 'weight', $pseudoconstant['label_column'] ?? NULL, $idCol];
+      foreach ($orderColumns as $orderColumn) {
+        if (isset($fields[$orderColumn])) {
+          $select->orderBy($orderColumn);
+          break;
+        }
       }
       // Filter on domain, but only if field is required
       if (!empty($fields['domain_id']['required'])) {

--- a/Civi/Schema/EntityProvider.php
+++ b/Civi/Schema/EntityProvider.php
@@ -36,6 +36,13 @@ final class EntityProvider {
     return $this->getMetaProvider()->getProperty($property);
   }
 
+  /**
+   * @return array
+   *   List of field descriptors, keyed by name.
+   *   Fields may or may not be defined in the underlying data-store, depending on the status of upgrade.
+   *
+   *   Ex: ['field_1' => ['title' => ..., 'sqlType' => ...]]
+   */
   public function getFields(): array {
     return $this->getMetaProvider()->getFields();
   }
@@ -44,6 +51,13 @@ final class EntityProvider {
     return $this->getMetaProvider()->getCustomFields($customGroupFilters);
   }
 
+  /**
+   * @return array
+   *   List of field descriptors, keyed by name.
+   *   Only include fields that are currently expected to be active/supported.
+   *
+   *   Ex: ['field_1' => ['title' => ..., 'sqlType' => ...]]
+   */
   public function getSupportedFields(): array {
     $fields = $this->getMetaProvider()->getFields();
     if ($this->getMeta('module') === 'civicrm') {


### PR DESCRIPTION
Overview
----------------------------------------

Suppose you install 5.69, then download the code for 5.79, and then navigate to the upgrade screen. The basic navigational pages (like `civicrm/dashboard`, `civicrm/admin`) fail to render.

(This PR follows an approach suggested by @colemanw.)

Before
----------------------------------------

Screens fail with:

<img width="1298" alt="Screenshot 2024-11-05 at 12 24 36 PM" src="https://github.com/user-attachments/assets/37977184-6f98-41f7-8250-92422ce4ae00">

caused by a bad query for:

```
SELECT id AS id, label AS label, name AS name, is_active
FROM civicrm_financial_type
ORDER BY label
```

The query arises from:

<img width="648" alt="Screenshot 2024-11-05 at 12 42 55 PM" src="https://github.com/user-attachments/assets/6f7f7d11-c39e-4890-89e0-8e8c16f3c24f">

The problem is that (1) the column `civicrm_financial_type.label` is new in 5.79 and (2) on any ordinary page, the `financialacls` extension tries to use data from `civicrm_financial_type` to help construct its ACLs.

After
----------------------------------------

It quietly falls back to using the `id` as a label.

Comments
----------------------------------------

* Hmmm, as I read this, it seems to me that it needs a warning... because a real mistake (like a typo or miscommunication over schema) would be silently ignored... in favor of the fallback. (*Fiddling locally if I can find a pretty way to make a warning. But for now, probably best to let test run against this variant.*)
* When processing incremental upgrade steps, the `metadata` cache will likely be incorrect at some points. But it should be cleared at the end of the upgrade...
* There's a similar when `CRM_Core_Pseudoconstant::populate()`. However, it's less symptomatic. (Ex: You might crash individual dashlets -- but not the entire dashboard.)