### PR TITLE
[not mergeable] Set edit-options 'spanner' to be non-tabable

### DIFF
--- a/CRM/Core/Form/Renderer.php
+++ b/CRM/Core/Form/Renderer.php
@@ -427,8 +427,11 @@ class CRM_Core_Form_Renderer extends HTML_QuickForm_Renderer_ArraySmarty {
       // NOTE: If we ever needed to support arguments in this link other than reset=1 we could split $path here if it contains a ?
       $url = CRM_Utils_System::url($path, 'reset=1');
       $icon = CRM_Core_Page::crmIcon('fa-wrench', ts('Edit %1 Options', [1 => $field->getLabel() ?: ts('Field')]));
+      // tabIndex is set to -1 so the tab bypasses it - this makes sense since the edit
+      // link it outside of the main form flow & is a feature only present for admins
+      // https://lab.civicrm.org/dev/core/-/issues/5577
       $el['html'] .= <<<HEREDOC
- <a href="$url" class="crm-option-edit-link medium-popup crm-hover-button" target="_blank" data-option-edit-path="$path">$icon</a>
+ <a href="$url" tabindex="-1" class="crm-option-edit-link medium-popup crm-hover-button" target="_blank" data-option-edit-path="$path">$icon</a>
 HEREDOC;
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Set edit-options 'spanner' to be non-tabable

Before
----------------------------------------
After investigating user reports that the tab didn't work on the batch data entry screen for some fields I found it DID work - but it was tabbing not from field to field but from field to spanner to field

Note that on testing I see the the user analysis of 'tab doesn't work' might not have come about had we been using greenwich rather than the island - in this version on greenwich it is at least clear what is selected. It still feels 'wrong' in the batch scenario

![Peek batch -before](https://github.com/user-attachments/assets/9375fc42-0d34-48ec-bbac-8357ae8ddcc5)

![Peek before](https://github.com/user-attachments/assets/3a66a18c-cc2b-47de-a48c-4c7c6c018203)

![image](https://lab.civicrm.org/-/project/70/uploads/33dc0e4ff5019d956b0311a8ff6ade0e/image.png)

After
----------------------------------------
The spanner is no longer a tab-able element

![Peek after](https://github.com/user-attachments/assets/c617a33f-bcce-4702-9d29-7774a24f5bd1)


![Peek after-batch](https://github.com/user-attachments/assets/6ec38b9a-53e9-4933-959a-5db63fa97ede)


Technical Details
----------------------------------------
The location for this change is very central / affects a number of screens but I feel the argument that the spanner is an aside rather than part of the form flow & tabbing onto it is not intuitive is a general argument - although on other screens there are other elements that should not be tabbable - ie on contact edit the help-icons are too

![image](https://github.com/user-attachments/assets/c69076ff-a134-4ae2-8015-705b519c02c4)


Comments
----------------------------------------
@vingle @artfulrobot can you advise here on what behaviour is right - however 'wrong' having to tab through the 'side notes' to the form flow feels to me I realise there is best practice around it for accessibility reasons that I'm not across