### PR TITLE
Use print.tpl in print mode

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -378,7 +378,7 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
       // it appears that all callers use 'html-header' (either implicitly or explicitly).
       throw new \CRM_Core_Exception("Error: addCoreResources only supports html-header");
     }
-    if (!self::isAjaxMode()) {
+    if (!self::isAjaxMode() && ($_GET['snippet'] ?? NULL) !== '1') {
       $this->addBundle('coreResources');
       $this->addCoreStyles($region);
       if (!CRM_Core_Config::isUpgradeMode()) {

--- a/templates/CRM/common/snippet.tpl
+++ b/templates/CRM/common/snippet.tpl
@@ -18,7 +18,7 @@
       {include file=$tplFile}
     {/if}
   {else}
-    {if $smarty.get.snippet eq 2}
+    {if $smarty.get.snippet eq 1}
       {include file="CRM/common/print.tpl"}
     {else}
       {crmRegion name='ajax-snippet'}{/crmRegion}


### PR DESCRIPTION
Overview
----------------------------------------
Followup fix for [dev/core#5543](https://lab.civicrm.org/dev/core/-/issues/5543) to trigger automatic printing of the page.

Before
------
Clicking printer icon in a popup would bring you to the whitepage version, but would not auto-print (you'd need to hit ctrl-p)

After
------
Works as before.

Technical Details
--------
Ensure rendering goes through `print.tpl` when snippet=1 (full-page print mode), and then another fix to CRM_Core_Resources to disable core styles in that mode.