### PR TITLE
Use print.tpl in print mode

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -378,7 +378,7 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
       // it appears that all callers use 'html-header' (either implicitly or explicitly).
       throw new \CRM_Core_Exception("Error: addCoreResources only supports html-header");
     }
-    if (!self::isAjaxMode()) {
+    if (!self::isAjaxMode() && ($_GET['snippet'] ?? NULL) !== '1') {
       $this->addBundle('coreResources');
       $this->addCoreStyles($region);
       if (!CRM_Core_Config::isUpgradeMode()) {

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -378,7 +378,8 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
       // it appears that all callers use 'html-header' (either implicitly or explicitly).
       throw new \CRM_Core_Exception("Error: addCoreResources only supports html-header");
     }
-    if (!self::isAjaxMode() && ($_GET['snippet'] ?? NULL) !== '1') {
+    // Skip adding full-page resources when returning an ajax snippet or in printer mode (print.tpl has its own css)
+    if (!self::isAjaxMode() && intval($_GET['snippet'] ?? 0) !== CRM_Core_Smarty::PRINT_PAGE) {
       $this->addBundle('coreResources');
       $this->addCoreStyles($region);
       if (!CRM_Core_Config::isUpgradeMode()) {

--- a/ext/eventcart/templates/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.tpl
+++ b/ext/eventcart/templates/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.tpl
@@ -62,7 +62,7 @@
     );
 
     // FIXME: this get should be a post according to restful standards
-    cj.get(CRM.url("civicrm/ajax/event/add_participant_to_cart?snippet=1", {cart_id: cart_id,  event_id: event_id}),
+    cj.get(CRM.url("civicrm/ajax/event/add_participant_to_cart?snippet=2", {cart_id: cart_id,  event_id: event_id}),
             function(data) {
               cj('#event_' + event_id + '_participants').append(data).trigger('crmLoad');
             }

--- a/js/view/crm.designer.js
+++ b/js/view/crm.designer.js
@@ -268,7 +268,7 @@
       $.post(CRM.url("civicrm/ajax/inline"), {
         'qfKey': CRM.profilePreviewKey,
         'class_name': 'CRM_UF_Form_Inline_Preview',
-        'snippet': 1,
+        'snippet': 2, // CRM_Core_Smarty::PRINT_SNIPPET
         'ufData': JSON.stringify({
           ufGroup: this.model.toStrictJSON(),
           ufFieldCollection: this.model.getRel('ufFieldCollection').toSortedJSON()

--- a/templates/CRM/Contact/Page/View/Summary.js
+++ b/templates/CRM/Contact/Page/View/Summary.js
@@ -62,7 +62,8 @@
     return $(el).each(function() {
       var data = $(this).data('edit-params');
       if (data) {
-        data.snippet = data.reset = 1;
+        data.reset = 1;
+        data.snippet = 2; // CRM_Core_Smarty::PRINT_SNIPPET
         data.class_name = data.class_name.replace('Form', 'Page');
         data.type = 'page';
         $(this).closest('.crm-summary-block').load(CRM.url('civicrm/ajax/inline', data), function() {

--- a/templates/CRM/common/snippet.tpl
+++ b/templates/CRM/common/snippet.tpl
@@ -18,7 +18,7 @@
       {include file=$tplFile}
     {/if}
   {else}
-    {if $smarty.get.snippet eq 2}
+    {if $smarty.get.snippet eq 1}
       {include file="CRM/common/print.tpl"}
     {else}
       {crmRegion name='ajax-snippet'}{/crmRegion}


### PR DESCRIPTION
Overview
----------------------------------------
Backports https://github.com/civicrm/civicrm-core/pull/31439 and https://github.com/civicrm/civicrm-core/pull/31442

Fix [dev/core#5543](https://lab.civicrm.org/dev/core/-/issues/5543) to ensure the print.tpl is loaded when snippet=1 (full-page print mode). This triggers automatic printing of the page
