### PR TITLE
Ensure snippet modes are used correctly

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -378,7 +378,8 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
       // it appears that all callers use 'html-header' (either implicitly or explicitly).
       throw new \CRM_Core_Exception("Error: addCoreResources only supports html-header");
     }
-    if (!self::isAjaxMode() && ($_GET['snippet'] ?? NULL) !== '1') {
+    // Skip adding full-page resources when returning an ajax snippet or in printer mode (print.tpl has its own css)
+    if (!self::isAjaxMode() && intval($_GET['snippet'] ?? 0) !== CRM_Core_Smarty::PRINT_PAGE) {
       $this->addBundle('coreResources');
       $this->addCoreStyles($region);
       if (!CRM_Core_Config::isUpgradeMode()) {

--- a/ext/eventcart/templates/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.tpl
+++ b/ext/eventcart/templates/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.tpl
@@ -62,7 +62,7 @@
     );
 
     // FIXME: this get should be a post according to restful standards
-    cj.get(CRM.url("civicrm/ajax/event/add_participant_to_cart?snippet=1", {cart_id: cart_id,  event_id: event_id}),
+    cj.get(CRM.url("civicrm/ajax/event/add_participant_to_cart?snippet=2", {cart_id: cart_id,  event_id: event_id}),
             function(data) {
               cj('#event_' + event_id + '_participants').append(data).trigger('crmLoad');
             }

--- a/js/view/crm.designer.js
+++ b/js/view/crm.designer.js
@@ -268,7 +268,7 @@
       $.post(CRM.url("civicrm/ajax/inline"), {
         'qfKey': CRM.profilePreviewKey,
         'class_name': 'CRM_UF_Form_Inline_Preview',
-        'snippet': 1,
+        'snippet': 2, // CRM_Core_Smarty::PRINT_SNIPPET
         'ufData': JSON.stringify({
           ufGroup: this.model.toStrictJSON(),
           ufFieldCollection: this.model.getRel('ufFieldCollection').toSortedJSON()

--- a/templates/CRM/Contact/Page/View/Summary.js
+++ b/templates/CRM/Contact/Page/View/Summary.js
@@ -62,7 +62,8 @@
     return $(el).each(function() {
       var data = $(this).data('edit-params');
       if (data) {
-        data.snippet = data.reset = 1;
+        data.reset = 1;
+        data.snippet = 2; // CRM_Core_Smarty::PRINT_SNIPPET
         data.class_name = data.class_name.replace('Form', 'Page');
         data.type = 'page';
         $(this).closest('.crm-summary-block').load(CRM.url('civicrm/ajax/inline', data), function() {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes some ajax requests that were inadvertently triggering a print dialog.

Technical Details
----------------------------------------
According to the comments and runtime logic, `CRM_Core_Smarty::PRINT_SNIPPET` is for ajax and `CRM_Core_Smarty::PRINT_PAGE` is for printing (creating a physical printout using `print.tpl`). Some screens were accidentally confusing the two, causing the wrong behavior.
The difference matters now due to csrf protection on ajax requests.