### PR TITLE
dev/core#5584 Fix soft credit default setting & copy down 

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -467,10 +467,10 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
    * @throws \CRM_Core_Exception
    */
   public function setDefaultValues() {
+    $defaults = [];
     if (empty($this->_fields)) {
-      return;
+      return $defaults;
     }
-
     // for add mode set smart defaults
     if ($this->_action & CRM_Core_Action::ADD) {
       $currentDate = date('Y-m-d H-i-s');
@@ -491,8 +491,10 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
     else {
       // get the cached info from data column of civicrm_batch
       $data = CRM_Core_DAO::getFieldValue('CRM_Batch_BAO_Batch', $this->_batchId, 'data');
-      $defaults = json_decode($data, TRUE);
-      $defaults = $defaults['values'];
+      if ($data) {
+        $defaults = json_decode($data, TRUE);
+        $defaults = $defaults['values'];
+      }
     }
 
     return $defaults;

--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -579,7 +579,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
 
           //CRM-15350: if soft-credit-type profile field is disabled or removed then
           //we choose configured SCT default value
-          if (!empty($params['soft_credit_type'][$key])) {
+          if (array_key_exists('soft_credit_type', $params)) {
             $value['soft_credit'][$key]['soft_credit_type_id'] = $params['soft_credit_type'][$key];
           }
           else {

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2044,7 +2044,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
     elseif ($fieldName === 'soft_credit_type') {
       $name = "soft_credit_type[$rowNumber]";
       $form->add('select', $name, $title,
-        CRM_Core_OptionGroup::values("soft_credit_type"), ['placeholder' => TRUE]
+        CRM_Core_OptionGroup::values("soft_credit_type"), FALSE, ['placeholder' => TRUE]
       );
       //CRM-15350: choose SCT field default value as 'Gift' for membership use
       //else (for contribution), use configured SCT default value

--- a/templates/CRM/Batch/Form/Entry.js
+++ b/templates/CRM/Batch/Form/Entry.js
@@ -27,8 +27,10 @@ CRM.$(function($) {
     var totalAmount = $('#field_'+rowNum+'_total_amount').val();
     //assign total amount as default soft credit amount
     $('#soft_credit_amount_'+ rowNum).val(totalAmount);
-    //assign soft credit type default value if any
-    $('#soft_credit_type_'+ rowNum).val($('#sct_default_id').val());
+    //assign soft credit type default value if one has not already been selected.
+    if (!$('#soft_credit_type_'+ rowNum).val()) {
+      $('#soft_credit_type_'+ rowNum).val($('#sct_default_id').val());
+    }
   });
 
   // Could be replaced if there ever is a PCP API.

--- a/templates/CRM/Batch/Form/Entry.tpl
+++ b/templates/CRM/Batch/Form/Entry.tpl
@@ -52,7 +52,17 @@
       {/if}
       {foreach from=$fields item=field key=fieldName}
         <div class="crm-grid-cell">
-          {if $field.name|substr:0:11 ne 'soft_credit' and $field.name ne 'trxn_id'}
+          {* do not copy down for trxn_id as that would be invalid.
+          The reason for the other 2 fields to be missing copy functionality
+          is undocumented / lost in the mists of time.
+          It may be because the amount was seen as unlikely to be a copy-down candidate
+           - either that or it was left out of scope because these fields do not follow the
+           naming convention in batchCopy.tpl, making it easier to exclude than address,
+           or because the intention for future support for multiple credits per row was
+           incompatible.
+           https://issues.civicrm.org/jira/browse/CRM-12653
+           *}
+          {if $field.name ne 'trxn_id' && $field.name ne 'soft_credit_amount' && $field.name ne 'soft_credit'}
           {copyIcon name=$field.name title=$field.title}
           {/if}{$field.title}
         </div>

--- a/templates/CRM/common/batchCopy.tpl
+++ b/templates/CRM/common/batchCopy.tpl
@@ -17,10 +17,15 @@
      * @return void
      */
     function copyFieldValues( fname ) {
-      // this is the most common pattern for elements, so first check if it exits
-      // this check field starting with "field[" and contains [fname] and is not
-      // hidden ( for checkbox hidden element is created )
-      var elementId    = $('.crm-copy-fields [name^="field["][name*="[' + fname +']"][type!=hidden]');
+      if (fname === 'soft_credit_type') {
+        var elementId    = $('.crm-copy-fields [name^="soft_credit_type[');
+      }
+      else {
+        // this is the most common pattern for elements, so first check if it exits
+        // this check field starting with "field[" and contains [fname] and is not
+        // hidden ( for checkbox hidden element is created )
+        var elementId = $('.crm-copy-fields [name^="field["][name*="[' + fname + ']"][type!=hidden]');
+      }
 
       // get the first element and it's value
       var firstElement = elementId.eq(0);


### PR DESCRIPTION
Overview
----------------------------------------
this fixes a couple of issues with the soft credit type field in the batch data entry screen

Before
----------------------------------------
1) back in 2020 the soft_credit_type field was accidentally changed from optional to required as part of an large change which accidentally dropped off a parameter in [this line](https://github.com/civicrm/civicrm-core/commit/a2eb61520b685cf139a829d65015b2579caed27d#diff-a8aa0473142a72fc757b2dd20805fa12454951109989fab7cc06a4f0b112a9b1R2097) - meaning that `$extra` is being passed in as `$required` - this adds the extra `$required = FALSE` to revert that
2) in addition setting the soft credit contact was causing the soft credit type to be changed to the default value even when it had already been intentionally been set by the user to something else
3) the copy functionality was missing for the soft credit type field 
![Uploading peek-batch-before.gif…]()


4) deprecation warning 
![image](https://github.com/user-attachments/assets/26aeb8a8-21dc-4199-8437-a52811bfbb45)

**note that another notice warning fix on this screen was merged to core today - if you see a notice on size you may not have that patch**

After
----------------------------------------
![batch-after](https://github.com/user-attachments/assets/e8889b6c-b8a8-4e64-99ee-f83c700d4361)



Technical Details
----------------------------------------

The copy functionality was removed in the course of https://issues.civicrm.org/jira/browse/CRM-12653 but it is not clear that it was intentional - I commented on possible reasons in-code for the fields for the soft credit contact & soft credit amount to have been excluded from the copy down - basically either because of the proximity of the too-hard-basket or because there was an anticipation of new functionality that never happened.

Comments
----------------------------------------
