### PR TITLE
CustomValueTable - Simplify conditionals

### DIFF
--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -134,7 +134,8 @@ class CRM_Core_BAO_CustomValueTable {
               else {
                 $type = 'Integer';
               }
-              if ($value == NULL || $value === '') {
+              // An empty value should be stored as NULL
+              if (!$value) {
                 $type = 'Timestamp';
                 $value = NULL;
               }
@@ -142,7 +143,8 @@ class CRM_Core_BAO_CustomValueTable {
 
             case 'EntityReference':
               $type = 'Integer';
-              if ($value == NULL || $value === '') {
+              // An empty value should be stored as NULL
+              if (!$value) {
                 $type = 'Timestamp';
                 $value = NULL;
               }


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup & add comments to explain what's going on.

Technical Details
----------------------------------------
Theses conditionals were redundant because of the `==` operator which matches more than `NULL`.