### PR TITLE
Removes contact_id condition around 'including yourself' text

### DIFF
--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -58,7 +58,7 @@
       <div class="crm-public-form-item crm-section additional_participants-section" id="noOfparticipants">
         <div class="label">{$form.additional_participants.label} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></div>
         <div class="content">
-          {$form.additional_participants.html}{if $contact_id}&nbsp;{ts}(including yourself){/ts}{/if}
+          {$form.additional_participants.html}{ts}(including yourself){/ts}
           <br/>
           <div class="description" id="additionalParticipantsDescription" style="display: none;">{ts}Fill in your registration information on this page. You will be able to enter the registration information for additional people after you complete this page and click &quot;Continue&quot;.{/ts}</div>
         </div>


### PR DESCRIPTION
Overview
----------------------------------------
On event registration form particpant number selection, the help text 'including yourself' is only shown if the user is logged in. It should always be shown

Before
----------------------------------------
![signed_out](https://github.com/user-attachments/assets/b28b652d-065c-4776-89b4-64eb7f8ad8a3)
![signed_in](https://github.com/user-attachments/assets/6b9e9e31-16de-4970-841d-ebc04dcfd1b0)

After
----------------------------------------
(Including yourself) aways shows
