### PR TITLE
dev/core#5569 Replace our hack on zeta components with upstream patch

### DIFF
--- a/CRM/Mailing/MailStore.php
+++ b/CRM/Mailing/MailStore.php
@@ -166,7 +166,7 @@ class CRM_Mailing_MailStore {
     $mails = [];
     $parser = new ezcMailParser();
     //set property text attachment as file CRM-5408
-    $parser->options->parseTextAttachmentsAsFiles = TRUE;
+    $parser->options->parseMultipartMixedTextAttachmentsAsFiles = TRUE;
 
     foreach ($set->getMessageNumbers() as $nr) {
       if ($this->_debug) {

--- a/CRM/Mailing/MailStore/Localdir.php
+++ b/CRM/Mailing/MailStore/Localdir.php
@@ -103,7 +103,7 @@ class CRM_Mailing_MailStore_Localdir extends CRM_Mailing_MailStore {
       $set = new ezcMailFileSet([$file]);
       $parser = new ezcMailParser();
       // set property text attachment as file CRM-5408
-      $parser->options->parseTextAttachmentsAsFiles = TRUE;
+      $parser->options->parseMultipartMixedTextAttachmentsAsFiles = TRUE;
 
       $mail = $parser->parseMail($set);
 

--- a/CRM/Mailing/MailStore/Maildir.php
+++ b/CRM/Mailing/MailStore/Maildir.php
@@ -80,7 +80,7 @@ class CRM_Mailing_MailStore_Maildir extends CRM_Mailing_MailStore {
     $mails = [];
     $parser = new ezcMailParser();
     // set property text attachment as file CRM-5408
-    $parser->options->parseTextAttachmentsAsFiles = TRUE;
+    $parser->options->parseMultipartMixedTextAttachmentsAsFiles = TRUE;
 
     foreach (['cur', 'new'] as $subdir) {
       $dir = $this->_dir . DIRECTORY_SEPARATOR . $subdir;

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
     "tecnickcom/tcpdf" : "6.7.*",
     "totten/ca-config": "~23.07",
     "zetacomponents/base": "1.9.*",
-    "zetacomponents/mail": "~1.9.4",
+    "zetacomponents/mail": "~1.9",
     "marcj/topsort": "~1.1",
     "phpoffice/phpword": "^1.2",
     "pear/validate_finance_creditcard": "0.7.0",
@@ -295,8 +295,8 @@
         "Add in CiviCRM custom error message for CRM-8744": "https://raw.githubusercontent.com/civicrm/civicrm-core/a6a0ff13d2a155ad962529595dceaef728116f96/tools/scripts/composer/patches/net-smtp-patch.patch"
       },
       "zetacomponents/mail": {
-        "CiviCRM Custom Patches for ZetaCompoents mail": "https://raw.githubusercontent.com/civicrm/civicrm-core/9d93748a36c7c5d44422911db1c98fb2f7067b34/tools/scripts/composer/patches/civicrm-custom-patches-zetacompoents-mail.patch",
-        "CiviCRM Custom patch to fix a php8.1 issue found in CiviCRM unit tests": "https://raw.githubusercontent.com/civicrm/civicrm-core/5506f4ce5d46799857b4f4ddf34069e7541e9cc5/tools/scripts/composer/zetacomponents-php-81-civicrm-custom.patch"
+        "Patch one in https://github.com/zetacomponents/Mail/pull/96/commits": "https://github.com/zetacomponents/Mail/commit/fc981b489d68e65890f26f19efa3fc523e517002.patch",
+        "Patch two in https://github.com/zetacomponents/Mail/pull/96/commits" : "https://github.com/zetacomponents/Mail/commit/bebae735aae2c1030d6fb564d322c1480a51a86d.patch"
       }
     },
     "compile-includes": ["ext/greenwich/composer.compile.json"],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "21b4d53ec38067948395139db45d6d6b",
+    "content-hash": "d81fe7ca358b701c32e9783b410d4d40",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -5836,5 +5836,5 @@
     "platform-overrides": {
         "php": "7.4.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
Overview
----------------------------------------
The upstream maintainer has put up a patch to address our issue in the upstream repo - see https://github.com/zetacomponents/Mail/pull/96 - this switches to using that (in preparation for upgrading to a branch which already has it merged)

Before
----------------------------------------
our special hack

After
----------------------------------------
a path forwards

Technical Details
----------------------------------------
There is specific test cover in `testFetchActivitiesWithManyAttachments()`

Comments
----------------------------------------
