### PR TITLE
Add deprecated warning to BaseIPN

### DIFF
--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -18,7 +18,14 @@ use Civi\Api4\PaymentProcessor;
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
+class CRM_Core_Payment_AuthorizeNetIPN {
+
+  /**
+   * Input parameters from payment processor. Store these so that
+   * the code does not need to keep retrieving from the http request
+   * @var array
+   */
+  protected $_inputParameters = [];
 
   /**
    * Constructor function.
@@ -29,8 +36,10 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
    * @throws CRM_Core_Exception
    */
   public function __construct($inputData) {
-    $this->setInputParameters($inputData);
-    parent::__construct();
+    if (!is_array($inputData)) {
+      throw new CRM_Core_Exception('Invalid input parameters');
+    }
+    $this->_inputParameters = $inputData;
   }
 
   /**

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -47,6 +47,7 @@ class CRM_Core_Payment_BaseIPN {
    * Constructor.
    */
   public function __construct() {
+    CRM_Core_Error::deprecatedWarning('CRM_Core_Payment_BaseIPN will be removed around 6.6 - if you see this warning your payment processor needs to be updated!');
     self::$_now = date('YmdHis');
   }
 

--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -16,7 +16,7 @@ use Civi\Api4\Contribution;
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
+class CRM_Core_Payment_PayPalIPN {
 
   /**
    * Input parameters from payment processor. Store these so that
@@ -45,8 +45,11 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
     $params = (!empty($inputData['custom'])) ?
       array_merge($inputData, json_decode($inputData['custom'], TRUE) ?? []) :
       $inputData;
-    $this->setInputParameters($params);
-    parent::__construct();
+
+    if (!is_array($params)) {
+      throw new CRM_Core_Exception('Invalid input parameters');
+    }
+    $this->_inputParameters = $params;
   }
 
   /**

--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -16,7 +16,7 @@ use Civi\Api4\Contribution;
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
+class CRM_Core_Payment_PayPalProIPN {
 
   /**
    * Input parameters from payment processor. Store these so that
@@ -129,9 +129,11 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
    * @throws CRM_Core_Exception
    */
   public function __construct($inputData) {
-    $this->setInputParameters($inputData);
+    if (!is_array($inputData)) {
+      throw new CRM_Core_Exception('Invalid input parameters');
+    }
+    $this->_inputParameters = $inputData;
     $this->setInvoiceData();
-    parent::__construct();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
`CRM_Core_Payment_BaseIPN` contains a lot of deprecated code. It is time we removed it.

Before
----------------------------------------
`CRM_Core_Payment_BaseIPN` class not deprecated.

After
----------------------------------------
`CRM_Core_Payment_BaseIPN` class deprecated.

Technical Details
----------------------------------------
This was a helper class for payment processors that is not used by most payment processors any more. It contains a lot of code that was either removed or integrated into core elsewhere.

Comments
----------------------------------------
Includes https://github.com/civicrm/civicrm-core/pull/31451

