### PR TITLE
dev/core#5587, dev/core#5560 - bring back validation of emails in profiles

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -466,6 +466,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup implements \Civi\Core\Ho
       'help_post' => $field->help_post,
       'visibility' => $field->visibility,
       'in_selector' => $field->in_selector,
+      // In core I believe "rule" will never exist anymore in $importableFields since 5.75, but see farther down where it gets set for some input_types.
       'rule' => $importableFields[$field->field_name]['rule'] ?? NULL,
       'location_type_id' => $field->location_type_id ?? NULL,
       'website_type_id' => $field->website_type_id ?? NULL,
@@ -483,6 +484,20 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup implements \Civi\Core\Ho
       'bao' => $fieldMetaData['bao'] ?? NULL,
       'html_type' => $fieldMetaData['html']['type'] ?? NULL,
     ];
+
+    // "rule" used to come from the xml schema, but now we fall back to basing it on the html_type.
+    // It's used for example in buildProfile to add a form rule.
+    if (empty($formattedField['rule'])) {
+      switch ($formattedField['html_type']) {
+        case 'Email':
+          $formattedField['rule'] = 'email';
+          break;
+
+        case 'Url':
+          $formattedField['rule'] = 'url';
+          break;
+      }
+    }
 
     $formattedField = CRM_Utils_Date::addDateMetadataToField($fieldMetaData, $formattedField);
 


### PR DESCRIPTION
Overview
----------------------------------------
* https://lab.civicrm.org/dev/core/-/issues/5587
* https://lab.civicrm.org/dev/core/-/issues/5560

Before
----------------------------------------
Since 5.75:
1. Visit e.g. a standalone profile in create mode, or e.g. an event registration, that uses a profile containing either email or openid.
2. Enter an invalid email, or an openid that isn't in url format.
3. It will accept it.

After
----------------------------------------
1. Like before.

Technical Details
----------------------------------------
The xml schema used to contain a `<rule>` for 3 fields, one of them being email. This is used when building the profile to add a form rule. Since it was only 3 fields, one of them deprecated, it didn't get copied over to the new way.
See ticket for more details.

Technically I should also update [user_unique_id](https://github.com/civicrm/civicrm-core/blob/c4f52da9d7561b25af1d82a5d4d24a159cfd0fc8/schema/Contact/Contact.entityType.php#L860)'s input type to be Url the same as [openid](https://github.com/civicrm/civicrm-core/blob/c4f52da9d7561b25af1d82a5d4d24a159cfd0fc8/schema/Core/OpenID.entityType.php#L75) because that's what it was [before](https://github.com/civicrm/civicrm-core/blob/5.74/xml/schema/Contact/Contact.xml#L798), but it's marked deprecated and I couldn't see how to add it to a profile.

Comments
----------------------------------------
This isn't a "beautiful" fix but I don't know where else to put it. There's a little discussion in ticket.

I'm not sure openid is even working in profiles. I think this is a separate issue. Note to see it on the contact you have to enable it under Display Preferences, but even then it doesn't seem to get stored when entered in a profile form. But at least now the validation will work.