### PR TITLE
Fix dev/core#5561 - CMS theme floats break FormBuilder layout

### DIFF
--- a/ext/greenwich/scss/_tweaks.scss
+++ b/ext/greenwich/scss/_tweaks.scss
@@ -29,3 +29,9 @@ input[type="search"]::-webkit-search-cancel-button {
 summary {
   display: list-item;
 }
+/* Reset breaky stuff from some cms themes: https://lab.civicrm.org/dev/core/-/issues/5561 */
+legend {
+  position: initial;
+  text-transform: inherit;
+  float: none;
+}


### PR DESCRIPTION
Overview
----------------------------------------
Fix CMS theme from breaking FormBuilder layout.

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/a0bd02e6-6793-4209-80fc-0b2681be443f)


After
----------------------------------------
![image](https://github.com/user-attachments/assets/242fd7d5-70a2-4565-952d-22cd6c5477db)


Technical Details
----------------------------------------
I don't know if this is the best place to put this. Doing it here, it'll need to be copied into every other theme as well. But I don't think we have any "central" place for these things, so I guess we just have to copy it.