### PR TITLE
dev/core#5179 Afform - Enable file downloads

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/FileGetSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/FileGetSpecProvider.php
@@ -105,10 +105,10 @@ class FileGetSpecProvider extends \Civi\Core\Service\AutoService implements Gene
       }
     }
     if (isset($entityIdField)) {
-      return "CONCAT('civicrm/file?reset=1&id=', $idField[sql_name], '&eid=', $entityIdField[sql_name])";
+      return "CONCAT('civicrm/file?reset=1&id=', {$idField['sql_name']}, '&eid=', {$entityIdField['sql_name']})";
     }
-    // Guess we couldn't find an `entity_id` in the query. This function could probably be improved.
-    return "NULL";
+    // Couldn't find an `entity_id` in the query so add a subquery instead.
+    return "CONCAT('civicrm/file?reset=1&id=', {$idField['sql_name']}, '&eid=', (SELECT `entity_id` FROM `civicrm_entity_file` WHERE `file_id` = {$idField['sql_name']} LIMIT 1))";
   }
 
   public static function renderFileIsImage(array $mimeTypeField, Api4SelectQuery $query): string {

--- a/ext/afform/core/ang/af/fields/DisplayOnly.html
+++ b/ext/afform/core/ang/af/fields/DisplayOnly.html
@@ -1,1 +1,13 @@
-{{dataProvider.getFieldData()[$ctrl.fieldName]}}
+<span ng-if="dataProvider.getFieldData()[$ctrl.fieldName].file_name">
+  <a ng-if="dataProvider.getFieldData()[$ctrl.fieldName].url" ng-href="{{:: dataProvider.getFieldData()[$ctrl.fieldName].url }}">
+    <i class="crm-i {{ dataProvider.getFieldData()[$ctrl.fieldName].icon }}"></i>
+    {{ dataProvider.getFieldData()[$ctrl.fieldName].file_name }}
+  </a>
+  <span ng-if="!dataProvider.getFieldData()[$ctrl.fieldName].url">
+    <i class="crm-i {{ dataProvider.getFieldData()[$ctrl.fieldName].icon }}"></i>
+    {{ dataProvider.getFieldData()[$ctrl.fieldName].file_name }}
+  </span>
+</span>
+<span ng-if="!dataProvider.getFieldData()[$ctrl.fieldName].file_name">
+  {{ dataProvider.getFieldData()[$ctrl.fieldName] }}
+</span>

--- a/ext/afform/core/ang/af/fields/File.html
+++ b/ext/afform/core/ang/af/fields/File.html
@@ -1,6 +1,12 @@
 <span ng-if="dataProvider.getFieldData()[$ctrl.fieldName].file_name">
-  <i class="crm-i {{ dataProvider.getFieldData()[$ctrl.fieldName].icon }}"></i>
-  {{ dataProvider.getFieldData()[$ctrl.fieldName].file_name }}
+  <a ng-if="dataProvider.getFieldData()[$ctrl.fieldName].url" ng-href="{{:: dataProvider.getFieldData()[$ctrl.fieldName].url }}">
+    <i class="crm-i {{ dataProvider.getFieldData()[$ctrl.fieldName].icon }}"></i>
+    {{ dataProvider.getFieldData()[$ctrl.fieldName].file_name }}
+  </a>
+  <span ng-if="!dataProvider.getFieldData()[$ctrl.fieldName].url">
+    <i class="crm-i {{ dataProvider.getFieldData()[$ctrl.fieldName].icon }}"></i>
+    {{ dataProvider.getFieldData()[$ctrl.fieldName].file_name }}
+  </span>
   <a class="crm-hover-button" title="{{:: ts('Replace') }}" ng-click="dataProvider.getFieldData()[$ctrl.fieldName].file_name = null">
     <i class="crm-i fa-times" aria-hidden="true"></i>
   </a>

--- a/tests/phpunit/api/v4/Custom/CustomFileTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomFileTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace Civi\tests\phpunit\api\v4\Custom;
+
+use api\v4\Custom\CustomTestBase;
+use Civi\Api4\CustomGroup;
+use Civi\Api4\CustomField;
+use Civi\Api4\File;
+
+/**
+ * @group headless
+ */
+class CustomFileTest extends CustomTestBase {
+
+  /**
+   */
+  public function testCustomFileField(): void {
+    $group = CustomGroup::create()->setValues([
+      'title' => 'FileFields',
+      'extends' => 'Individual',
+    ])->execute()->single();
+    $field = CustomField::create()->setValues([
+      'label' => 'TestMyFile',
+      'custom_group_id.name' => 'FileFields',
+      'html_type' => 'File',
+      'data_type' => 'File',
+    ])->execute()->single();
+
+    $fieldName = 'FileFields.TestMyFile';
+
+    $contact = $this->createTestRecord('Individual');
+
+    // FIXME: Use Api4 when available
+    $file = civicrm_api3('Attachment', 'create', [
+      // The mismatch between entity id and entity table feels very wrong but that's how core does it for now
+      'entity_id' => $contact['id'],
+      'entity_table' => $group['table_name'],
+      'mime_type' => 'text/plain',
+      'name' => 'test123.txt',
+      'content' => 'Hello World 123',
+    ]);
+
+    civicrm_api4('Individual', 'update', [
+      'values' => [
+        'id' => $contact['id'],
+        $fieldName => $file['id'],
+      ],
+      'checkPermissions' => FALSE,
+    ]);
+
+    $file = File::get(FALSE)
+      ->addSelect('id', 'file_name', 'url')
+      ->addWhere('id', '=', $file['id'])
+      ->execute()->single();
+
+    $this->assertEquals('test123.txt', $file['file_name']);
+    $this->assertStringContainsString("id={$file['id']}&eid={$contact['id']}&fcs=", $file['url']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5179](https://lab.civicrm.org/dev/core/-/issues/5179).

Users with 'access uploaded files' permission (or afform entities with permission checks disables) will see uploaded files as a link which can be clicked to download the file.
