### PR TITLE
(dev/core#5464) Iframe - Add support for hosting Civi IFRAMEs on WordPress

### DIFF
--- a/ext/iframe/Civi/Iframe/Iframe.php
+++ b/ext/iframe/Civi/Iframe/Iframe.php
@@ -34,6 +34,13 @@ class Iframe extends AutoService implements EventSubscriberInterface {
    * @throws \CRM_Core_Exception
    */
   public function onRenderUrl(Url $url, ?string &$result) {
+    if (CIVICRM_UF === 'WordPress') {
+      $result = \Civi::url('frontend://', 'a')
+        ->merge($url, ['path', 'query', 'fragment', 'fragmentQuery', 'flags'])
+        ->addQuery('_cvwpif=1');
+      return;
+    }
+
     $result = \Civi::url('[civicrm.iframe]', 'a')->merge($url, ['path', 'query', 'fragment', 'fragmentQuery', 'flags']);
   }
 

--- a/ext/iframe/Civi/Iframe/Router.php
+++ b/ext/iframe/Civi/Iframe/Router.php
@@ -140,7 +140,7 @@ class Router extends AutoService {
       case 'WordPress':
         // N.B. There are sufficient events in WP API to enforce IFRAME invariants.
         // @see \CiviCRM_For_WordPress::activate_iframe()
-        throw new \LogicException("In Civi-WP, IFRAMEs with CMS page-chrome shuld use standard invoker.");
+        throw new \LogicException("In Civi-WP, IFRAMEs with CMS page-chrome should use standard invoker.");
 
       default:
         throw new \CRM_Core_Exception("Unimplemented: invokeCms(" . CIVICRM_UF . ")");

--- a/ext/iframe/Civi/Iframe/Router.php
+++ b/ext/iframe/Civi/Iframe/Router.php
@@ -9,6 +9,16 @@ use Civi\Core\Service\AutoService;
  */
 class Router extends AutoService {
 
+  /**
+   * @param array $params
+   *    Some mix of:
+   *    - route: string, eg "civicrm/event/info"
+   *    - printPage: function(string), Print an exact web page response
+   *    - drupalKernel: The HTTP kernel handling the iframe request in D8/9/10/11
+   *    - drupalRequest: The HTTP object representing the iframe request in D8/9/10/11
+   * @return void
+   * @throws \CRM_Core_Exception
+   */
   public function invoke(array $params) {
     if (!$this->isAllowedRoute($params['route'])) {
       throw new \CRM_Core_Exception("Route not available for embedding.");
@@ -68,7 +78,9 @@ class Router extends AutoService {
     if (empty($pageContent) && !empty($printedContent)) {
       $pageContent = $printedContent;
     }
-    echo $pageContent;
+
+    $printPage = $params['printPage'] ?? 'print';
+    $printPage($pageContent);
   }
 
   /**
@@ -94,12 +106,15 @@ class Router extends AutoService {
     $htmlHeader = \CRM_Core_Region::instance('html-header')->render('');
     $locale = \CRM_Core_I18n::getLocale();
 
-    echo \CRM_Core_Smarty::singleton()->fetchWith('iframe-basic-page.tpl', [
+    $fullPage = \CRM_Core_Smarty::singleton()->fetchWith('iframe-basic-page.tpl', [
       'lang' => substr($locale, 0, 2),
       'dir' => \CRM_Core_I18n::isLanguageRTL($locale) ? 'rtl' : 'ltr',
       'head' => $htmlHeader,
       'body' => $pageContent,
     ]);
+
+    $printPage = $params['printPage'] ?? 'print';
+    $printPage($fullPage);
   }
 
   protected function invokeCms(array $params):void {

--- a/ext/iframe/Civi/Iframe/Router.php
+++ b/ext/iframe/Civi/Iframe/Router.php
@@ -17,7 +17,7 @@ class Router extends AutoService {
     $config = \CRM_Core_Config::singleton();
     $_GET[$config->userFrameworkURLVar] = $params['route'];
 
-    $handler = $this->getHandler();
+    $handler = [$this, 'invoke' . ucfirst($this->getLayout())];
     $handler($params);
   }
 
@@ -46,12 +46,16 @@ class Router extends AutoService {
     return FALSE;
   }
 
-  protected function getHandler(): callable {
+  /**
+   * @return string
+   *   'basic' or 'raw' or 'cms'
+   */
+  public function getLayout(): string {
     $setting = \Civi::settings()->get('iframe_layout');
     if ($setting === 'auto') {
       $setting = 'basic';
     }
-    return [$this, 'invoke' . ucfirst($setting)];
+    return $setting;
   }
 
   protected function invokeRaw(array $params): void {

--- a/ext/iframe/Civi/Iframe/Router.php
+++ b/ext/iframe/Civi/Iframe/Router.php
@@ -137,6 +137,11 @@ class Router extends AutoService {
         $kernel->terminate($request, $response);
         break;
 
+      case 'WordPress':
+        // N.B. There are sufficient events in WP API to enforce IFRAME invariants.
+        // @see \CiviCRM_For_WordPress::activate_iframe()
+        throw new \LogicException("In Civi-WP, IFRAMEs with CMS page-chrome shuld use standard invoker.");
+
       default:
         throw new \CRM_Core_Exception("Unimplemented: invokeCms(" . CIVICRM_UF . ")");
     }

--- a/ext/iframe/Civi/Iframe/ScriptManager.php
+++ b/ext/iframe/Civi/Iframe/ScriptManager.php
@@ -32,6 +32,11 @@ class ScriptManager extends AutoService implements HookInterface {
       return;
     }
 
+    if (CIVICRM_UF === 'WordPress') {
+      // WP doesn't require installing a separate `/iframe.php`. Instead, it uses `?_cvwpif=1`.
+      return;
+    }
+
     $path = $this->getPath();
     $template = $this->iframe->getTemplate();
 


### PR DESCRIPTION
Overview
----------------------------------------

See https://lab.civicrm.org/dev/core/-/issues/5464

Before
----------------------------------------

If you enable the extension `iframe`, then it complains about the lack of a template.

<img width="914" alt="Screenshot 2024-11-11 at 5 12 17 PM" src="https://github.com/user-attachments/assets/25c51acb-60e9-40c2-8b4e-1a672af22537">

After
----------------------------------------

In combination with other patches for `civicrm-wordpress.git` (https://github.com/civicrm/civicrm-wordpress/pull/336), it should be able to handle IFRAMEs on WordPress without needing to deploy a dedicated `iframe.php` connector.

To indicate that a URL should be rendered in the fashion of an iframe, append `?_cvwpif=1`.

Technical Details
----------------------------------------

When making an `<IFRAME SRC="...">` tag, this uses `/index.php?...&_cvwpif=1` instead of using `/iframe.php`. This indicates that the request is supposed to be handled in the style of an IFRAME (*stripping out CMS navigation; disregarding any pre-existing sessions within the iframe*).

I've done some initial testing using a cross-domain IFRAME:

* __Workflow__: Register for a free event (`civicrm/event/register`)
* __Provider Site__: CiviCRM@master with WordPress@6.6.1
* __Consumer Site__: Raw HTML site (on separate domain-name)
* __Browsers__: Firefox (macOS) and Safari (macOS)

We'll see what Jenkins has to say. It should be safe to merge the PRs for `civicrm-core` and `civicrm-wordpress` in any order, though it generally makes to merge them at about the same time. 