### PR TITLE
[Afform] Process submission error because of empty "name"

### DIFF
--- a/ext/afform/core/ang/afSearchTasks/afformSubmissionProcessTask.ctrl..js
+++ b/ext/afform/core/ang/afSearchTasks/afformSubmissionProcessTask.ctrl..js
@@ -32,7 +32,7 @@
       }, function(error) {
         ctrl.onError();
       });
-    }
+    };
 
     this.save = function() {
       // process submission

--- a/ext/afform/core/ang/afSearchTasks/afformSubmissionProcessTask.ctrl..js
+++ b/ext/afform/core/ang/afSearchTasks/afformSubmissionProcessTask.ctrl..js
@@ -9,40 +9,34 @@
     this.entityTitle = this.getEntityTitle();
     this.afformName = '';
 
-    this.getAfformName = function(id) {
+    this.processData = function (submissionId) {
       crmApi4('AfformSubmission', 'get', {
         select: ["afform_name"],
-        where: [["id", "=", id]],
+        where: [["id", "=", submissionId]],
       }).then(function(afformSubmissions) {
         ctrl.afformName = afformSubmissions[0].afform_name;
+
+        _.each(ctrl.ids, function(id) {
+          ctrl.start();
+          crmApi4('Afform', 'process', {
+            submissionId: id,
+            name: ctrl.afformName
+          }).then(function(result) {
+          }, function(failure) {
+            ctrl.onError();
+          });
+        });
+
+        ctrl.onSuccess();
+
       }, function(error) {
         ctrl.onError();
       });
-    };
-
-    this.processData = function() {
-      _.each(ctrl.ids, function(id) {
-        ctrl.start();
-        crmApi4('Afform', 'process', {
-          submissionId: id,
-          name: ctrl.afformName
-        }).then(function(result) {
-        }, function(failure) {
-          ctrl.onError();
-        });
-      });
-
-      ctrl.onSuccess();
-    };
+    }
 
     this.save = function() {
-      // get the afform name
-      ctrl.getAfformName(ctrl.ids[0]);
-
-      $timeout(function() {
-        ctrl.processData();
-      },500);
-
+      // process submission
+      ctrl.processData();
     };
 
     this.onSuccess = function() {

--- a/ext/afform/core/ang/afSearchTasks/afformSubmissionProcessTask.ctrl..js
+++ b/ext/afform/core/ang/afSearchTasks/afformSubmissionProcessTask.ctrl..js
@@ -36,7 +36,7 @@
 
     this.save = function() {
       // process submission
-      ctrl.processData();
+      ctrl.processData(ctrl.ids[0]);
     };
 
     this.onSuccess = function() {


### PR DESCRIPTION
Overview
----------------------------------------
When processing submissions from Form Builder that has "Verify submission before processing" checked, it prompts an error: "Parameter name is required". Where `name` is `afform_name`.
Replicate:
1. Make Individual Form builder with "Verify submission before processing" checked.
2. Submit your entries.
3. Go to the submissions page of your form builder.
4. Process the submissions.
5. ---> Error then prompts.

Before
----------------------------------------
`processData` does not get the fetched afformName.

After
----------------------------------------
Fetch the afform_name then, on success, process the data.

Technical Details
----------------------------------------
CiviCRM: 5.78.4, 5.79, 5.81.alpha1

