### PR TITLE
Afform - Fix check for empty contact values

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -319,7 +319,7 @@ class Submit extends AbstractProcessor {
       if (!empty($contact['fields']['id'])) {
         continue;
       }
-      if (empty($contact['fields']) || \CRM_Contact_BAO_Contact::hasName($contact['fields'] + ['contact_type' => $entityType])) {
+      if (!empty($contact['fields']) && \CRM_Contact_BAO_Contact::hasName($contact['fields'] + ['contact_type' => $entityType])) {
         continue;
       }
       foreach ($contact['joins']['Email'] ?? [] as $email) {

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformContactUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformContactUsageTest.php
@@ -86,6 +86,28 @@ EOHTML;
       'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
     ]);
 
+    // Try creating empty contact: not ok
+    $submission = [
+      ['fields' => []],
+    ];
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues(['me' => $submission])
+      ->execute();
+    // Contact not created
+    $this->assertEmpty($result[0]['me']);
+
+    // Try creating contact with only first_name: ok
+    $submission = [
+      ['fields' => ['first_name' => 'Hello']],
+    ];
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues(['me' => $submission])
+      ->execute();
+    // Contact created
+    $this->assertNotEmpty($result[0]['me']);
+
     $cid = $this->createLoggedInUser();
     \CRM_Core_Config::singleton()->userPermissionTemp = new \CRM_Core_Permission_Temp();
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where affom was not properly validating a blank contact.

Before
----------------------------------------
Afform allowed a completely blank contact to be created


After
----------------------------------------
Contact must have at least one name or email