### PR TITLE
Afform - Set data values in quick-add popup

### DIFF
--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -42,6 +42,7 @@ function afform_civicrm_config(&$config) {
   $dispatcher->addListener('civi.afform.validate', ['\Civi\Api4\Action\Afform\Submit', 'validateEntityRefFields'], 45);
   $dispatcher->addListener('civi.afform.submit', ['\Civi\Api4\Action\Afform\Submit', 'processGenericEntity'], 0);
   $dispatcher->addListener('civi.afform.submit', ['\Civi\Api4\Action\Afform\Submit', 'preprocessContact'], 10);
+  $dispatcher->addListener('civi.afform.submit', ['\Civi\Api4\Action\Afform\Submit', 'preprocessParentFormValues'], 100);
   $dispatcher->addListener('civi.afform.submit', ['\Civi\Api4\Action\Afform\Submit', 'processRelationships'], 1);
   $dispatcher->addListener('hook_civicrm_angularModules', '_afform_hook_civicrm_angularModules', -1000);
   $dispatcher->addListener('hook_civicrm_alterAngular', ['\Civi\Afform\AfformMetadataInjector', 'preprocess']);

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -302,8 +302,8 @@
         crmApi4('Afform', 'submit', {
           name: ctrl.getFormMeta().name,
           args: args,
-          values: data}
-        ).then(function(response) {
+          values: data,
+        }).then(function(response) {
           submissionResponse = response;
           if (ctrl.fileUploader.getNotUploadedItems().length) {
             _.each(ctrl.fileUploader.getNotUploadedItems(), function(file) {

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformContactUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformContactUsageTest.php
@@ -223,7 +223,7 @@ EOHTML;
     // Check that the data overrides form submission
     $this->assertEquals('Register A site', $contact['source']);
     // Check that the contact and the activity were correctly linked up as per the form.
-    $this->callAPISuccessGetSingle('ActivityContact', ['contact_id' => $contact['id'], 'activity_id' => $activity['id']]);
+    $this->getTestRecord('ActivityContact', ['contact_id' => $contact['id'], 'activity_id' => $activity['id']]);
   }
 
   public function testCheckAccess(): void {
@@ -272,6 +272,7 @@ EOHTML;
     catch (\CRM_Core_Exception $e) {
       // Should fail permission check
     }
+    $this->assertTrue(is_a($e, '\Civi\API\Exception\UnauthorizedException'));
 
     try {
       Afform::submit()
@@ -286,6 +287,7 @@ EOHTML;
     catch (\CRM_Core_Exception $e) {
       // Should fail permission check
     }
+    $this->assertTrue(is_a($e, '\Civi\API\Exception\UnauthorizedException'));
   }
 
   public function testEmployerReference(): void {
@@ -617,6 +619,7 @@ EOHTML;
     }
     catch (\Civi\API\Exception\UnauthorizedException $e) {
     }
+    $this->assertTrue(is_a($e, '\Civi\API\Exception\UnauthorizedException'));
   }
 
 }

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformCustomFieldUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformCustomFieldUsageTest.php
@@ -70,8 +70,8 @@ EOHTML;
     $this->assertEquals('my_text', $block['layout'][0]['name']);
     $this->assertEquals('my_friend', $block['layout'][1]['name']);
 
-    $cid1 = $this->individualCreate([], 1);
-    $cid2 = $this->individualCreate([], 2);
+    $cid1 = $this->createTestRecord('Individual')['id'];
+    $cid2 = $this->createTestRecord('Individual')['id'];
 
     $this->useValues([
       'layout' => self::$layouts['customMulti'],

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformEventUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformEventUsageTest.php
@@ -11,22 +11,21 @@ use Civi\Test\TransactionalInterface;
  * @group headless
  */
 class AfformEventUsageTest extends AfformUsageTestCase implements TransactionalInterface {
-  use \Civi\Test\Api4TestTrait;
 
   /**
    * Tests prefilling an event from a template
    */
   public function testEventTemplatePrefill(): void {
-    $locBlock1 = $this->createTestEntity('LocBlock', [
-      'email_id' => $this->createTestEntity('Email', ['email' => '1@te.st'])['id'],
-      'phone_id' => $this->createTestEntity('Phone', ['phone' => '1234567'])['id'],
+    $locBlock1 = $this->createTestRecord('LocBlock', [
+      'email_id' => $this->createTestRecord('Email', ['email' => '1@te.st'])['id'],
+      'phone_id' => $this->createTestRecord('Phone', ['phone' => '1234567'])['id'],
     ]);
-    $locBlock2 = $this->createTestEntity('LocBlock', [
-      'email_id' => $this->createTestEntity('Email', ['email' => '2@te.st'])['id'],
-      'phone_id' => $this->createTestEntity('Phone', ['phone' => '2234567'])['id'],
+    $locBlock2 = $this->createTestRecord('LocBlock', [
+      'email_id' => $this->createTestRecord('Email', ['email' => '2@te.st'])['id'],
+      'phone_id' => $this->createTestRecord('Phone', ['phone' => '2234567'])['id'],
     ]);
 
-    $eventTemplate = $this->createTestEntity('Event', [
+    $eventTemplate = $this->createTestRecord('Event', [
       'template_title' => 'Test Template Title',
       'title' => 'Test Me',
       'event_type_id' => 1,

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformPrefillUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformPrefillUsageTest.php
@@ -9,7 +9,6 @@ use Civi\Api4\Afform;
  * @group headless
  */
 class AfformPrefillUsageTest extends AfformUsageTestCase {
-  use \Civi\Test\Api4TestTrait;
 
   /**
    * Ensure that Afform restricts autocomplete results when it's set to use a SavedSearch

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformUsageTestCase.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformUsageTestCase.php
@@ -10,8 +10,7 @@ use Civi\Api4\CustomGroup;
  * @group headless
  */
 abstract class AfformUsageTestCase extends AfformTestCase {
-  use \Civi\Test\Api3TestTrait;
-  use \Civi\Test\ContactTestTrait;
+  use \Civi\Test\Api4TestTrait;
 
   protected static $layouts = [];
 

--- a/ext/authx/tests/phpunit/api/v4/AuthxCredentialTest.php
+++ b/ext/authx/tests/phpunit/api/v4/AuthxCredentialTest.php
@@ -16,8 +16,6 @@ use PHPUnit\Framework\TestCase;
 class AuthxCredentialTest extends TestCase implements HeadlessInterface, TransactionalInterface {
 
   use \Civi\Test\Api4TestTrait;
-  use \Civi\Test\Api3TestTrait;
-  use \Civi\Test\ContactTestTrait;
 
   public function setUpHeadless() {
     return \Civi\Test::headless()
@@ -26,7 +24,6 @@ class AuthxCredentialTest extends TestCase implements HeadlessInterface, Transac
   }
 
   public function testGenerateToken(): void {
-    $this->_apiversion = 4;
     $contactRecord = $this->createTestRecord('Contact', ['contact_type' => 'Individual']);
     $this->createLoggedInUser();
     $this->setPermissions([
@@ -47,7 +44,6 @@ class AuthxCredentialTest extends TestCase implements HeadlessInterface, Transac
   }
 
   public function testValidation(): void {
-    $this->_apiversion = 4;
     $contactRecord = $this->createTestRecord('Contact', ['contact_type' => 'Individual']);
     $this->createLoggedInUser();
     $this->setPermissions([

--- a/js/Common.js
+++ b/js/Common.js
@@ -543,12 +543,10 @@ if (!CRM.vars) CRM.vars = {};
       return '';
     }
     let markup = '<div class="crm-entityref-links crm-entityref-quick-add">';
-    CRM.config.quickAdd.forEach((link) => {
-      if (quickAddLinks.includes(link.path)) {
-        markup += ' <a class="crm-hover-button" href="' + _.escape(CRM.url(link.path)) + '">' +
-          '<i class="crm-i ' + _.escape(link.icon) + '" aria-hidden="true"></i> ' +
-          _.escape(link.title) + '</a>';
-      }
+    quickAddLinks.forEach((link) => {
+      markup += ' <a class="crm-hover-button" href="' + _.escape(CRM.url(link.path)) + '">' +
+        '<i class="crm-i ' + _.escape(link.icon) + '" aria-hidden="true"></i> ' +
+        _.escape(link.title) + '</a>';
     });
     markup += '</div>';
     return markup;
@@ -576,6 +574,26 @@ if (!CRM.vars) CRM.vars = {};
       }
       return apiParams || {};
     }
+    function getQuickAddLinks(paths) {
+      const links = [];
+      if (paths && paths.length) {
+        const apiParams = getApiParams();
+        paths.forEach((path) => {
+          let link = CRM.config.quickAdd.find((link) => link.path === path);
+          if (link) {
+            links.push({
+              path: path + '#?' + $.param({
+                parentFormName: apiParams.formName,
+                parentFormFieldName: apiParams.fieldName,
+              }),
+              icon: link.icon,
+              title: link.title,
+            });
+          }
+        });
+      }
+      return links;
+    }
     if (entityName === 'destroy') {
       return $(this).off('.crmEntity').crmSelect2('destroy');
     }
@@ -583,7 +601,7 @@ if (!CRM.vars) CRM.vars = {};
     return $(this).each(function() {
       const $el = $(this).off('.crmEntity');
       let staticItems = getStaticOptions(select2Options.static),
-        quickAddLinks = select2Options.quickAdd,
+        quickAddLinks = getQuickAddLinks(select2Options.quickAdd),
         multiple = !!select2Options.multiple;
 
       $el.crmSelect2(_.extend({

--- a/tests/phpunit/api/v4/Api4TestBase.php
+++ b/tests/phpunit/api/v4/Api4TestBase.php
@@ -19,7 +19,6 @@
 
 namespace api\v4;
 
-use Civi\Api4\UFMatch;
 use Civi\Test;
 use Civi\Test\Api4TestTrait;
 use Civi\Test\CiviEnvBuilder;
@@ -76,37 +75,6 @@ class Api4TestBase extends TestCase implements HeadlessInterface {
       \CRM_Core_DAO::executeQuery($sql);
     }
     \CRM_Core_DAO::executeQuery('SET FOREIGN_KEY_CHECKS = 1;');
-  }
-
-  /**
-   * Emulate a logged in user since certain functions use that.
-   * value to store a record in the DB (like activity)
-   *
-   * @see https://issues.civicrm.org/jira/browse/CRM-8180
-   *
-   * @return int
-   *   Contact ID of the created user.
-   * @throws \CRM_Core_Exception
-   */
-  public function createLoggedInUser(): int {
-    $contactID = $this->createTestRecord('Individual')['id'];
-    UFMatch::delete(FALSE)->addWhere('uf_id', '=', 6)->execute();
-    $this->createTestRecord('UFMatch', [
-      'contact_id' => $contactID,
-      'uf_name' => 'superman',
-      'uf_id' => 6,
-    ]);
-
-    $session = \CRM_Core_Session::singleton();
-    $session->set('userID', $contactID);
-    return $contactID;
-  }
-
-  public function userLogout() {
-    \CRM_Core_Session::singleton()->reset();
-    UFMatch::delete(FALSE)
-      ->addWhere('uf_name', '=', 'superman')
-      ->execute();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/5477

When using a quick-add form, this ensures the predetermined data values from the parent form's entity will be copied to the newly-created entity in the popup form.

Before
--------
Create a form with an Individual and "Existing Individual" autocomplete field. Enable the "quick add" button.
In the values section on the left, pick a contact subtype for the individual.
Now use the form and use the quick add button to create a new contact.
Note that the new contact did not get the subtype.

Comments
-------
I wanted to use `Api4TestTrait` in the unit test so I had to do some general cleanup in the Afform test suite to ditch the `Api3TestTrait`. 