### PR TITLE
FormBuilder - Fix draggy cursor in dropdown menu

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor.css
+++ b/ext/afform/admin/ang/afGuiEditor.css
@@ -420,7 +420,7 @@ body.af-gui-dragging {
   left: -4px;
 }
 
-#afGuiEditor .dropdown-menu li {
+#afGuiEditor ul.dropdown-menu {
   cursor: default;
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
Simple cursor css fix in FormBuilder.

Before
----------------------------------------
Hovering the mouse inside a gear menu sometimes shows pointer, sometimes hand (esp on separators)

After
----------------------------------------
Consistently cursor.

Comments
-----
This is just the CSS part of https://github.com/civicrm/civicrm-core/pull/31423, as the js part wasn't needed.