### PR TITLE
(dev/backdrop#88) Backdrop Installer - Fix failure (Option A)

### DIFF
--- a/setup/plugins/installDatabase/FlushBackdrop.civi-setup.php
+++ b/setup/plugins/installDatabase/FlushBackdrop.civi-setup.php
@@ -24,7 +24,15 @@ if (!defined('CIVI_SETUP')) {
     $failure = FALSE;
 
     system_rebuild_module_data();
-    module_enable(array('civicrm', 'civicrmtheme'));
+
+    $modules = ['civicrm'];
+    if (!empty(backdrop_get_path('module', 'civicrmtheme'))) {
+      // FIXME: In 5.81, this module is getting juggled around. Hopefully, for 5.82+,
+      // the final disposition will be resolved, and you can remove this reference completely.
+      $modules[] = 'civicrmtheme';
+    }
+    \Civi\Setup::log()->info(sprintf('[%s] Activate Backdrop module(s): %s', basename(__FILE__), implode(', ', $modules)));
+    module_enable($modules);
     backdrop_flush_all_caches();
     civicrm_install_set_backdrop_perms();
   }, \Civi\Setup::PRIORITY_LATE + 50);


### PR DESCRIPTION
Overview
----------------------------------------

Follow-up to https://github.com/civicrm/civicrm-backdrop/pull/184 for https://lab.civicrm.org/dev/backdrop/-/issues/88

Before
----------------------------------------

On `master`, all jobs involving CiviCRM-Backdrop are failing to build. This is because the installer tries to activate `civicrmtheme` which no longer exists.

After
----------------------------------------

The installer will only try to activate `civicrmtheme` it if it exists. This doesn't make much sense long-term, but it might be more forgiving in the short-term. (Hence the FIXME.)