### PR TITLE
(dev/backdrop#88) Backdrop Installer - Fix failure (Option B)

### DIFF
--- a/setup/plugins/installDatabase/FlushBackdrop.civi-setup.php
+++ b/setup/plugins/installDatabase/FlushBackdrop.civi-setup.php
@@ -24,7 +24,7 @@ if (!defined('CIVI_SETUP')) {
     $failure = FALSE;
 
     system_rebuild_module_data();
-    module_enable(array('civicrm', 'civicrmtheme'));
+    module_enable(['civicrm']);
     backdrop_flush_all_caches();
     civicrm_install_set_backdrop_perms();
   }, \Civi\Setup::PRIORITY_LATE + 50);


### PR DESCRIPTION
Overview
----------------------------------------

Follow-up to https://github.com/civicrm/civicrm-backdrop/pull/184 for https://lab.civicrm.org/dev/backdrop/-/issues/88

Before
----------------------------------------

On `master`, all jobs involving CiviCRM-Backdrop are failing to build. This is because the installer tries to activate `civicrmtheme` which no longer exists.

After
----------------------------------------

The installer never tries to activate `civicrmtheme`, so it works.