### PR TITLE
Normalize and sort SYSTOPIA contributor info

### DIFF
--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -219,10 +219,6 @@
   name        : Andrew West
   organization: British Humanist Association
 
-- github      : bjendres
-  name        : Björn Endres
-  organization: SYSTOPIA Organisationsberatung
-
 - github      : BeccaTregenna
   name        : Becca Tregenna
 
@@ -432,10 +428,6 @@
 
 - github      : don-alejandro-z
 
-- github      : dontub
-  name        : Dominic Tubach
-  organization: Systopia
-
 - github      : dptarrant
   name        : Dave T
 
@@ -543,9 +535,6 @@
 
 - name        : Evan Summers
   organization: National Democratic Institute
-
-- name        : Fabian Schuttenberg
-  organization: Systopia
 
 - name        : Fatih Ateş
 
@@ -772,9 +761,6 @@
 - name        : Jane Hanley
   organization: AGH Strategies
 
-- github      : jensschuppe
-  name        : Jens Schuppe
-
 - github      : jernic
   name        : jernic
 
@@ -819,10 +805,6 @@
 - github      : johntwyman
   name        : John Twyman
   organization: Australian Greens
-
-- github      : jofranz
-  organization: Systopia
-  name        : Johannes
 
 - github      : jorich-2000
   name        : Jonathan Richardson
@@ -1195,9 +1177,6 @@
   organization: Mountev Ltd
   name        : Mountev Ltd
 
-- name        : Martin Peth
-  organization: Systopia
-
 - github      : mukeshcompucorp
   name        : Mukesh Ram
   organization: CompuCorp
@@ -1329,10 +1308,6 @@
 
 - name        : Paul Barmak
 
-- github      : pbatroff
-  name        : Philipp Batroff
-  organization: Systopia
-
 - github      : penguintrax
   name        : Barbara Forbes-Lyons
   organization: Lyons Digital Media
@@ -1340,8 +1315,6 @@
 - github      : petednz
   name        : Peter Davis
   organization: Fuzion
-
-- github      : peth-systopia
 
 - github      : pillarsdotnet
   name        : Bob Vincent
@@ -1573,8 +1546,44 @@
   organization: QED42
 
 - github      : systopia
+  name        : SYSTOPIA
+  organization: SYSTOPIA
+
+- github      : bjendres
   name        : Björn Endres
-  organization: Systopia
+  organization: SYSTOPIA
+
+- github      : dontub
+  name        : Dominic Tubach
+  organization: SYSTOPIA
+
+- github      : Fabian-SYSTOPIA
+  name        : Fabian Schuttenberg
+  organization: SYSTOPIA
+
+- github      : jensschuppe
+  name        : Jens Schuppe
+  organization: SYSTOPIA
+
+- github      : jofranz
+  name        : Johannes Franz
+  organization: SYSTOPIA
+
+- github      : peth-systopia
+  name        : Martin Peth
+  organization: SYSTOPIA
+
+- github      : pbatroff
+  name        : Philipp Batroff
+  organization: SYSTOPIA
+
+- github      : thomst
+  name        : Thomas Leichtfuss
+  organization: SYSTOPIA
+
+- github      : TychoSchottelius
+  name        : Tycho Schottelius
+  organization: SYSTOPIA
 
 - github      : tamarmeir
   name        : Tamar Meir
@@ -1605,10 +1614,6 @@
 
 - name        : Troy Mumm
   organization: Third Sun
-
-- github      : thomst
-  name        : Thomas Leichtfuss
-  organization: Systopia
 
 - github      : thoni56
   name        : Thomas Nilefalk
@@ -1667,10 +1672,6 @@
 - github      : twomice
   name        : Allen Shaw
   organization: Joinery
-
-- github      : TychoSchottelius
-  name        : Tycho Schottelius
-  organization: Systopia
 
 - github      : ufundo
   name        : Benjamin W
@@ -1811,10 +1812,6 @@
 - github      : gellweiler
   name        : Sebastian Gellweiler
   organization: craft-coders.de
-
-- github      : jofranz
-  name        : Johannes Franz
-  organization: Systopia
 
 - github      : mikeybeck
   name        : Mike Beck


### PR DESCRIPTION
Is the organization being linked (e.g. in release notes) based on an exact (i.e. case-sensitive) match with https://civicrm.org/providers/xyz?