### PR TITLE
afform - provide useful console error for invalid fields

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -35,6 +35,10 @@
         }
 
         if (this.defn.name !== this.fieldName) {
+          if (!this.defn.name) {
+            console.error('Missing field definition for: ' + this.fieldName);
+            return;
+          }
           namePrefix = this.fieldName.substr(0, this.fieldName.length - this.defn.name.length);
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
It's easy to end up with an invalid field on an afform e.g. when you disable a custom field. This makes it easier to find and fix.


Before
----------------------------------------
Cryptic console error:

![image](https://github.com/user-attachments/assets/5b60442e-e010-48ca-866f-237064a24a20)


After
----------------------------------------
Useful console error:

![image](https://github.com/user-attachments/assets/f47204e0-d1e7-46a3-90c3-df601133e1c7)


Technical details
-------------------------------------
By invalid here I mean specifically the name attribute doesn't match a valid field.


