### PR TITLE
CRM_Utils_System::isSSL - support X_FORWARDED_PROTO to work behind reverse proxy

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1247,9 +1247,6 @@ class CRM_Utils_System {
 
   /**
    * Determine whether this is an SSL request.
-   *
-   * Note that we inline this function in install/civicrm.php, so if you change
-   * this function, please go and change the code in the install script as well.
    */
   public static function isSSL() {
     return !empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) != 'off';

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1249,7 +1249,18 @@ class CRM_Utils_System {
    * Determine whether this is an SSL request.
    */
   public static function isSSL() {
-    return !empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) != 'off';
+    $proto = $_SERVER['HTTP_X_FORWARDED_PROTO'] ?? NULL;
+    // accept 'https' (however capitalised)
+    if (is_string($proto) && (strtolower($proto) === 'https')) {
+      return TRUE;
+    }
+
+    $https = $_SERVER['HTTPS'] ?? NULL;
+    // accept any truthy value except 'off' (however capitalised)
+    if ($https && !(is_string($https) && (strtolower($https) === 'off'))) {
+      return TRUE;
+    }
+    return FALSE;
   }
 
   /**
@@ -1262,11 +1273,7 @@ class CRM_Utils_System {
   public static function redirectToSSL($abort = FALSE) {
     $config = CRM_Core_Config::singleton();
     $req_headers = self::getRequestHeaders();
-    // FIXME: Shouldn't the X-Forwarded-Proto check be part of CRM_Utils_System::isSSL()?
-    if (Civi::settings()->get('enableSSL') &&
-      !self::isSSL() &&
-      strtolower($req_headers['X_FORWARDED_PROTO'] ?? '') != 'https'
-    ) {
+    if (Civi::settings()->get('enableSSL') && !self::isSSL()) {
       // ensure that SSL is enabled on a civicrm url (for cookie reasons etc)
       $url = "https://{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
       // @see https://lab.civicrm.org/dev/core/issues/425 if you're seeing this message.


### PR DESCRIPTION
Overview
----------------------------------------
Fixes incorrect SSL detection when running CiviCRM behind a reverse proxy, e.g. with Docker image behind Traefik.

Before
----------------------------------------
- in-place edit AJAX requests are generated with `http://` and fail

After
----------------------------------------
- they are fine

Technical Details
----------------------------------------
Someone fixed the problem of redirect loops behind a reverse proxy in the `redirectToSSL` function below. I guess there were worries about other callers of `isSSL` - but this feels semantically correct to me.