### PR TITLE
Fix Contribution Receipt empty Receipt From Name causes fallback to site default even if Receipt From Email set.

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -422,7 +422,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         ];
       }
 
-      if (empty($values['receipt_from_name']) && empty($values['receipt_from_name'])) {
+      if (empty($values['receipt_from_email'])) {
         [$values['receipt_from_name'], $values['receipt_from_email']] = CRM_Core_BAO_Domain::getNameAndEmail();
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
This is caused by:
`if (empty($values['receipt_from_name']) && empty($values['receipt_from_name'])) {`

This was added in -> ec7e395452267920d9cd37c27bac5505350ba7e1
https://github.com/civicrm/civicrm-core/pull/8119

I think the original intent here was to add a check for empty from name and email and populate it if it was empty.

However currently the From email is required - but the Name is not.

I don' t think we want to populate the from name from the default and we use it in the next line with a guard against it being empty defaulting to an empty string.

So I think while it's good to ensure we have a default email set - I don't think we should fall back to the default if we are missing the name. 

Before
----------------------------------------
Setting a Receipt From Email without setting a Receipt From Name results in defaulting to the default organisation from name and email, despite a from email being present.

After
----------------------------------------

If the from name is blank the from email will still be used, instead of the default site one.

