### PR TITLE
Removing this awesomeness makes me sad but suspect this is tidier

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2200,7 +2200,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       if (!$paymentProcessorID) {
         $paymentProcessorID = $this->_relatedObjects['event']->payment_processor;
         if ($paymentProcessorID) {
-          $intentionalEnotice = $CRM16923AnUnreliableMethodHasBeenUserToDeterminePaymentProcessorFromEvent;
+          CRM_Core_Error::deprecatedWarning('CRM-16923 An Unreliable Method Has Been User To Determine Payment Processor From Event');
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Before we announced badness by badness.

Now we announce badness in a more consistent way.

Perhaps we could cause fatal errors with this badness given elapsed time but perhaps safer to progress this way.

Before
----------------------------------------
An unused variable is set to a named undefined variable to indicate that things are not as they should be.

After
----------------------------------------
Shift to using a more consistent CRM_Core_Error::deprecatedWarning 