### PR TITLE
Throw exception when saving afforms with mandatory values missing

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -353,6 +353,9 @@ class Submit extends AbstractProcessor {
         // What to do here? Sometimes we should silently ignore errors, e.g. an optional entity
         // intentionally left blank. Other times it's a real error the user should know about.
         \Civi::log('afform')->debug('Silently ignoring exception in Afform processGenericEntity call for "' . $event->getEntityName() . '". Message: ' . $e->getMessage());
+        if ('mandatory_missing' === $e->getErrorCode()) {
+          throw $e;
+        }
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Do not silently fail *FormBuilder* submissions when the entity actually couldn't be saved due to missing mandatory values.

Before
----------------------------------------
*FormBuilder* forms silently fail with any submission error in [`\Civi\Api4\Action\Afform\Submit::processGenericEntity()`](https://github.com/civicrm/civicrm-core/blob/1b44560000ac6296150f4e1878d011bfc35213ac/ext/afform/core/Civi/Api4/Action/Afform/Submit.php#L352-L356), only logging the error. The code has this comment:
```php
// What to do here? Sometimes we should silently ignore errors, e.g. an optional entity
// intentionally left blank. Other times it's a real error the user should know about.
```

After
----------------------------------------
For exceptions with the error code `mandatory_missing` the exception is thrown forward in order for the form to show an error message to the user, instead of silently failing and showing *Saved*.

Technical Details
----------------------------------------
There might be more error codes which throwing forward the exception might be useful for, but `mandatory_missing` seems to always justify an error message.

Comments
----------------------------------------
cross-referencing https://github.com/systopia/de.systopia.eck/issues/138#issuecomment-2476233032
