### PR TITLE
Afform - Add action modes for joins

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor.css
+++ b/ext/afform/admin/ang/afGuiEditor.css
@@ -433,6 +433,9 @@ body.af-gui-dragging {
   white-space: nowrap;
 }
 
+#afGuiEditor .dropdown-menu li .checkbox-inline label {
+  font-weight: normal;
+}
 #afGuiEditor .dropdown-menu li > * > label {
   font-weight: normal;
   cursor: pointer;

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer-menu.html
@@ -31,6 +31,19 @@
     </div>
   </div>
 </li>
+<li ng-click="$event.stopPropagation()" ng-if="$ctrl.isJoin()">
+  <div class="form-inline af-gui-field-select-in-dropdown">
+    <div class="form-group">
+      <label>{{:: ts('Allow:') }}</label>
+      <div class="checkbox-inline">
+        <label><input type="checkbox" ng-model="$ctrl.node.actions.update" ng-change="$ctrl.onChangeUpdateAction()">{{:: ts('Update') }}</label>
+      </div>
+      <div class="checkbox-inline">
+        <label><input type="checkbox" ng-model="$ctrl.node.actions.delete" ng-disabled="!$ctrl.node.actions.update">{{:: ts('Delete') }}</label>
+      </div>
+    </div>
+  </div>
+</li>
 <li><af-gui-menu-item-style node="$ctrl.node"></af-gui-menu-item-style></li>
 <li><af-gui-menu-item-border node="$ctrl.node"></af-gui-menu-item-border></li>
 <li><af-gui-menu-item-background node="$ctrl.node"></af-gui-menu-item-background></li>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
@@ -111,6 +111,10 @@
         return 'layout' in block;
       };
 
+      this.isJoin = function() {
+        return !!ctrl.join;
+      };
+
       $scope.getSetChildren = function(val) {
         var collection = block.layout || (ctrl.node && ctrl.node['#children']);
         return arguments.length ? (collection = val) : collection;
@@ -255,7 +259,17 @@
         }
       };
 
+      this.onChangeUpdateAction = function() {
+        if (!ctrl.node.actions.update) {
+          ctrl.node.actions.delete = false;
+        }
+      };
+
       function initializeBlockContainer() {
+        // Set defaults for 'actions'
+        if (!('actions' in ctrl.node)) {
+          ctrl.node.actions = {update: true, delete: true};
+        }
 
         // Cancel the below $watch expressions if already set
         _.each(block.listeners, function(deregister) {

--- a/ext/afform/core/CRM/Afform/ArrayHtml.php
+++ b/ext/afform/core/CRM/Afform/ArrayHtml.php
@@ -24,6 +24,7 @@ class CRM_Afform_ArrayHtml {
       '*' => 'text',
       'af-fieldset' => 'text',
       'data' => 'js',
+      'actions' => 'js',
     ],
     'af-entity' => [
       '#selfClose' => TRUE,

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -732,4 +732,21 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     return is_array($firstValue) && $firstValue ? array_keys($firstValue)[0] : NULL;
   }
 
+  /**
+   * Function to get allowed action of a join entity
+   *
+   * @param array $mainEntity
+   * @param string $joinEntityName
+   *
+   * @return array
+   */
+  public static function getJoinAllowedAction(array $mainEntity, string $joinEntityName) {
+    $actions = ["update" => TRUE, "delete" => TRUE];
+    if (array_key_exists('actions', $mainEntity['joins'][$joinEntityName])) {
+      $actions = array_merge($actions, $mainEntity['joins'][$joinEntityName]['actions']);
+    }
+
+    return $actions;
+  }
+
 }

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -486,8 +486,8 @@ class Submit extends AbstractProcessor {
    */
   protected static function saveJoins(AfformSubmitEvent $event, $index, $entityId, $joins) {
     $mainEntity = $event->getFormDataModel()->getEntity($event->getEntityName());
-    foreach ($joins as $joinEntityName => $join) {
-      $values = self::filterEmptyJoins($mainEntity, $joinEntityName, $join);
+    foreach ($joins as $joinEntityName => $joinValues) {
+      $values = self::filterEmptyJoins($mainEntity, $joinEntityName, $joinValues);
       $whereClause = self::getJoinWhereClause($event->getFormDataModel(), $event->getEntityName(), $joinEntityName, $entityId);
       $mainIdField = CoreUtil::getIdFieldName($mainEntity['type']);
       $joinIdField = CoreUtil::getIdFieldName($joinEntityName);
@@ -497,7 +497,7 @@ class Submit extends AbstractProcessor {
       $forwardFkField = self::getFkField($mainEntity['type'], $joinEntityName);
       if ($forwardFkField && $values) {
         // Add id to values for update op, but only if id is not already on the form
-        if ($whereClause && empty($mainEntity['joins'][$joinEntityName]['fields'][$joinIdField])) {
+        if ($whereClause && $joinAllowedAction['update'] && empty($mainEntity['joins'][$joinEntityName]['fields'][$joinIdField])) {
           $values[0][$joinIdField] = $whereClause[0][2];
         }
         $result = civicrm_api4($joinEntityName, 'save', [
@@ -515,19 +515,23 @@ class Submit extends AbstractProcessor {
       }
 
       // Reverse FK e.g. Contact <= Email.contact_id
-      // TODO: REPLACE works for creating or updating contacts, but different logic would be needed if
-      // the contact was being auto-updated via a dedupe rule; in that case we would not want to
-      // delete any existing records.
       elseif ($values) {
-        if ($joinAllowedAction["delete"] === FALSE) {
-          $result = civicrm_api4($joinEntityName, 'save', [
-            // Disable permission checks because the main entity has already been vetted
-            'checkPermissions' => FALSE,
-            'defaults' => ['entity_id' => $entityId],
-            'records' => $values,
-          ]);
+        // In update mode, set ids of existing values
+        if ($joinAllowedAction['update']) {
+          $existingJoinValues = $event->getApiRequest()->loadJoins($joinEntityName, $mainEntity, $entityId, $index);
+          foreach ($existingJoinValues as $joinIndex => $existingJoin) {
+            if (!empty($existingJoin[$joinIdField]) && !empty($values[$joinIndex])) {
+              $values[$joinIndex][$joinIdField] = $existingJoin[$joinIdField];
+            }
+          }
         }
         else {
+          foreach ($values as $key => $value) {
+            unset($values[$key][$joinIdField]);
+          }
+        }
+        // Use REPLACE action if update+delete are both allowed (only need to check for 'delete' as it implies 'update')
+        if ($joinAllowedAction['delete']) {
           $result = civicrm_api4($joinEntityName, 'replace', [
             // Disable permission checks because the main entity has already been vetted
             'checkPermissions' => FALSE,
@@ -535,11 +539,20 @@ class Submit extends AbstractProcessor {
             'records' => $values,
           ]);
         }
+        else {
+          $fkField = self::getFkField($joinEntityName, $mainEntity['type']);
+          $result = civicrm_api4($joinEntityName, 'save', [
+            // Disable permission checks because the main entity has already been vetted
+            'checkPermissions' => FALSE,
+            'defaults' => [$fkField['name'] => $entityId],
+            'records' => $values,
+          ]);
+        }
         $indexedResult = array_combine(array_keys($values), (array) $result);
         $event->setJoinIds($index, $joinEntityName, $indexedResult);
       }
       // REPLACE doesn't work if there are no records, have to use DELETE
-      else {
+      elseif ($joinAllowedAction['delete']) {
         try {
           civicrm_api4($joinEntityName, 'delete', [
             // Disable permission checks because the main entity has already been vetted

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -491,6 +491,7 @@ class Submit extends AbstractProcessor {
       $whereClause = self::getJoinWhereClause($event->getFormDataModel(), $event->getEntityName(), $joinEntityName, $entityId);
       $mainIdField = CoreUtil::getIdFieldName($mainEntity['type']);
       $joinIdField = CoreUtil::getIdFieldName($joinEntityName);
+      $joinAllowedAction = self::getJoinAllowedAction($mainEntity, $joinEntityName);
 
       // Forward FK e.g. Event.loc_block_id => LocBlock
       $forwardFkField = self::getFkField($mainEntity['type'], $joinEntityName);
@@ -518,12 +519,22 @@ class Submit extends AbstractProcessor {
       // the contact was being auto-updated via a dedupe rule; in that case we would not want to
       // delete any existing records.
       elseif ($values) {
-        $result = civicrm_api4($joinEntityName, 'replace', [
-          // Disable permission checks because the main entity has already been vetted
-          'checkPermissions' => FALSE,
-          'where' => $whereClause,
-          'records' => $values,
-        ]);
+        if ($joinAllowedAction["delete"] === FALSE) {
+          $result = civicrm_api4($joinEntityName, 'save', [
+            // Disable permission checks because the main entity has already been vetted
+            'checkPermissions' => FALSE,
+            'defaults' => ['entity_id' => $entityId],
+            'records' => $values,
+          ]);
+        }
+        else {
+          $result = civicrm_api4($joinEntityName, 'replace', [
+            // Disable permission checks because the main entity has already been vetted
+            'checkPermissions' => FALSE,
+            'where' => $whereClause,
+            'records' => $values,
+          ]);
+        }
         $indexedResult = array_combine(array_keys($values), (array) $result);
         $event->setJoinIds($index, $joinEntityName, $indexedResult);
       }

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformJoinActionUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformJoinActionUsageTest.php
@@ -1,0 +1,217 @@
+<?php
+namespace api\v4\Afform;
+
+use Civi\Api4\Afform;
+use Civi\Api4\Contact;
+use Civi\Api4\CustomField;
+use Civi\Api4\CustomGroup;
+
+/**
+ * Test case for Afform.submit.
+ *
+ * @group headless
+ */
+class AfformJoinActionUsageTest extends AfformUsageTestCase {
+
+  public function tearDown(): void {
+    parent::tearDown();
+    CustomField::delete(FALSE)->addWhere('id', '>', '0')->execute();
+    CustomGroup::delete(FALSE)->addWhere('id', '>', '0')->execute();
+  }
+
+  public static function setUpBeforeClass(): void {
+    parent::setUpBeforeClass();
+    self::$layouts['joinUncheckedActions'] = <<<EOHTML
+      <af-form ctrl="afform">
+        <af-entity data="{contact_type: 'Individual'}" type="Contact" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="FBAC" contact-dedupe="Individual.Supervised"/>
+        <fieldset af-fieldset="Individual1">
+          <legend class="af-text">Individual 1</legend>
+          <afblock-name-individual></afblock-name-individual>
+          <div af-join="Email" min="1" af-repeat="Add" actions="{update: true, delete: true}" >
+            <afblock-contact-email></afblock-contact-email>
+          </div>
+          <div af-join="Custom_MyThings" af-repeat="Add" actions="{update: false, delete: false}">
+            <afblock-custom-my-things></afblock-custom-my-things>
+          </div>
+        </fieldset>
+        <button class="af-button btn-primary" crm-icon="fa-check" ng-click="afform.submit()">Submit</button>
+      </af-form>
+    EOHTML;
+
+    self::$layouts['joinCheckedActions'] = <<<EOHTML
+      <af-form ctrl="afform">
+        <af-entity data="{contact_type: 'Individual'}" type="Contact" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="FBAC" contact-dedupe="Individual.Supervised"/>
+        <fieldset af-fieldset="Individual1">
+          <legend class="af-text">Individual 1</legend>
+          <afblock-name-individual></afblock-name-individual>
+          <div af-join="Email" min="1" af-repeat="Add" actions="{update: true, delete: true}" >
+            <afblock-contact-email></afblock-contact-email>
+          </div>
+          <div af-join="Custom_MyThings" af-repeat="Add" actions="{update: true, delete: true}">
+            <afblock-custom-my-things></afblock-custom-my-things>
+          </div>
+        </fieldset>
+        <button class="af-button btn-primary" crm-icon="fa-check" ng-click="afform.submit()">Submit</button>
+      </af-form>
+    EOHTML;
+  }
+
+  /**
+   * Checks that unchecked actions allows creation without deleting previous data
+   */
+  public function testJoinEntityActionsUnchecked(): void {
+    CustomGroup::create(FALSE)
+      ->addValue('name', 'MyThings')
+      ->addValue('title', 'My Things')
+      ->addValue('style', 'Tab with table')
+      ->addValue('extends', 'Contact')
+      ->addValue('is_multiple', TRUE)
+      ->addChain('fields', CustomField::save()
+        ->addDefault('custom_group_id', '$id')
+        ->setRecords([
+          ['name' => 'my_text', 'label' => 'My Text', 'data_type' => 'String', 'html_type' => 'Text'],
+          ['name' => 'my_friend', 'label' => 'My Friend', 'data_type' => 'ContactReference', 'html_type' => 'Autocomplete-Select'],
+        ])
+      )
+      ->execute();
+
+    $this->useValues([
+      'layout' => self::$layouts['joinUncheckedActions'],
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+    ]);
+
+    $lastName = uniqid(__FUNCTION__);
+    $locationType = \CRM_Core_BAO_LocationType::getDefault()->id;
+    $cid1 = $this->createTestRecord('Individual')['id'];
+    $cid2 = $this->createTestRecord('Individual')['id'];
+
+    // Create contact with email and custom fields
+    $contact = \Civi\Api4\Contact::create(FALSE)
+      ->addValue('first_name', 'Bob')
+      ->addValue('last_name', $lastName)
+      ->addValue('email_primary.email', '123@example.com')
+      ->addValue('email_primary.location_type_id', $locationType)
+      ->addValue('email_primary.is_primary', TRUE)
+      ->addValue('Custom_MyThings.my_text', "One")
+      ->addValue('Custom_MyThings.my_friend', $cid1)
+      ->execute()->single();
+
+    $values = [
+      'Individual1' => [
+        [
+          'fields' => [
+            'first_name' => 'Bob',
+            'last_name' => $lastName,
+          ],
+          'joins' => [
+            'Email' => [
+              ['email' => '123@example.com', 'location_type_id' => $locationType, 'is_primary' => TRUE],
+            ],
+            'Custom_MyThings' => [
+              ['my_text' => 'Two', 'my_friend' => $cid2],
+              ['my_text' => 'Three', 'my_friend' => $cid2],
+            ],
+          ],
+        ],
+      ],
+    ];
+    Afform::submit()
+      ->setName($this->formName)
+      ->setValues($values)
+      ->execute();
+
+    $contact = Contact::get(FALSE)
+      ->addWhere('last_name', '=', $lastName)
+      ->addJoin('Custom_MyThings AS Custom_MyThings', 'LEFT', ['id', '=', 'Custom_MyThings.entity_id'])
+      ->addSelect('Custom_MyThings.my_text', 'Custom_MyThings.my_friend')
+      ->addOrderBy('Custom_MyThings.id')
+      ->execute();
+
+    $this->assertEquals('One', $contact[0]['Custom_MyThings.my_text']);
+    $this->assertEquals($cid1, $contact[0]['Custom_MyThings.my_friend']);
+    $this->assertEquals('Two', $contact[1]['Custom_MyThings.my_text']);
+    $this->assertEquals($cid2, $contact[1]['Custom_MyThings.my_friend']);
+    // We can test more since this custom data set has no max
+    $this->assertEquals('Three', $contact[2]['Custom_MyThings.my_text']);
+    $this->assertEquals($cid2, $contact[2]['Custom_MyThings.my_friend']);
+  }
+
+  /**
+   * Checks that checked actions will behave as is
+   */
+  public function testJoinEntityActionsChecked(): void {
+    CustomGroup::create(FALSE)
+      ->addValue('name', 'MyThings')
+      ->addValue('title', 'My Things')
+      ->addValue('style', 'Tab with table')
+      ->addValue('extends', 'Contact')
+      ->addValue('is_multiple', TRUE)
+      ->addChain('fields', CustomField::save()
+        ->addDefault('custom_group_id', '$id')
+        ->setRecords([
+          ['name' => 'my_text', 'label' => 'My Text', 'data_type' => 'String', 'html_type' => 'Text'],
+          ['name' => 'my_friend', 'label' => 'My Friend', 'data_type' => 'ContactReference', 'html_type' => 'Autocomplete-Select'],
+        ])
+      )
+      ->execute();
+
+    $this->useValues([
+      'layout' => self::$layouts['joinCheckedActions'],
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+    ]);
+
+    $lastName = uniqid(__FUNCTION__);
+    $locationType = \CRM_Core_BAO_LocationType::getDefault()->id;
+    $cid1 = $this->createTestRecord('Individual')['id'];
+    $cid2 = $this->createTestRecord('Individual')['id'];
+
+    // Create contact with email and custom fields
+    $contact = \Civi\Api4\Contact::create(FALSE)
+      ->addValue('first_name', 'Bobby')
+      ->addValue('last_name', $lastName)
+      ->addValue('email_primary.email', '1234@example.com')
+      ->addValue('email_primary.location_type_id', $locationType)
+      ->addValue('email_primary.is_primary', TRUE)
+      ->addValue('Custom_MyThings.my_text', "One")
+      ->addValue('Custom_MyThings.my_friend', $cid1)
+      ->execute()->single();
+
+    $values = [
+      'Individual1' => [
+        [
+          'fields' => [
+            'first_name' => 'Bobby',
+            'last_name' => $lastName,
+          ],
+          'joins' => [
+            'Email' => [
+              ['email' => '1234@example.com', 'location_type_id' => $locationType, 'is_primary' => TRUE],
+            ],
+            'Custom_MyThings' => [
+              ['my_text' => 'Two', 'my_friend' => $cid2],
+              ['my_text' => 'Three', 'my_friend' => $cid2],
+            ],
+          ],
+        ],
+      ],
+    ];
+    Afform::submit()
+      ->setName($this->formName)
+      ->setValues($values)
+      ->execute();
+
+    $contact = Contact::get(FALSE)
+      ->addWhere('last_name', '=', $lastName)
+      ->addJoin('Custom_MyThings AS Custom_MyThings', 'LEFT', ['id', '=', 'Custom_MyThings.entity_id'])
+      ->addSelect('Custom_MyThings.my_text', 'Custom_MyThings.my_friend')
+      ->addOrderBy('Custom_MyThings.id')
+      ->execute();
+
+    $this->assertEquals('Two', $contact[0]['Custom_MyThings.my_text']);
+    $this->assertEquals($cid2, $contact[0]['Custom_MyThings.my_friend']);
+    // We can test more since this custom data set has no max
+    $this->assertEquals('Three', $contact[1]['Custom_MyThings.my_text']);
+    $this->assertEquals($cid2, $contact[1]['Custom_MyThings.my_friend']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds an "Allowed Actions" setting for joined records (e.g. Phone, Email, Multi-value custom) in Afform
Fixes [dev/core#5589](https://lab.civicrm.org/dev/core/-/issues/5589)
Replaces https://github.com/civicrm/civicrm-core/pull/31477

Before
----------
The main entity supports lets you enable/disable actions, but not the joined entities (email, address, phone, multi-record custom data). Those are currently set to allow create+update+delete.

![image](https://github.com/user-attachments/assets/d4fc4e2e-009b-40dc-b75e-b503691debc7)

After
-------
Can disable update & delete actions if desired (if both are unchecked, only create is allowed).

<img width="775" alt="Screenshot 2024-11-14 at 11 19 35 AM" src="https://github.com/user-attachments/assets/c46d11ea-de91-4f60-a958-ab4148909828">
