### PR TITLE
afform - use smarty template to render dynamic custom group block

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Get.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Get.php
@@ -188,17 +188,10 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
         $item['join_entity'] = 'Custom_' . $custom['name'];
       }
       if ($getLayout) {
-        $item['layout'] = ($custom['help_pre'] ? '<div class="af-markup">' . $custom['help_pre'] . "</div>\n" : '');
-        foreach ($custom['fields'] as $field) {
-          $nameAttribute = $field['name'];
-          // for multiple record fields there is no need to prepend the custom group name
-          // because it is provided as the join_entity above
-          if (!$custom['is_multiple']) {
-            $nameAttribute = $custom['name'] . "." . $nameAttribute;
-          }
-          $item['layout'] .= "<af-field name=\"{$nameAttribute}\" />\n";
-        }
-        $item['layout'] .= ($custom['help_post'] ? '<div class="af-markup">' . $custom['help_post'] . "</div>\n" : '');
+        $item['layout'] = \CRM_Core_Smarty::singleton()->fetchWith(
+          'afform/customGroups/afblock.tpl',
+          ['custom' => $custom]
+        );
       }
       $afforms[$name] = $item;
     }

--- a/ext/afform/core/templates/afform/customGroups/afblock.tpl
+++ b/ext/afform/core/templates/afform/customGroups/afblock.tpl
@@ -1,0 +1,14 @@
+{if $custom.help_pre}
+  <div class="af-markup">{$custom.help_pre}</div>
+{/if}
+
+{foreach $custom.fields as $field}
+  {* for multiple record fields there is no need to prepend
+  the group name because it is provided as the join_entity above *}
+  <af-field name="{if !$custom.is_multiple}{$custom.name}.{/if}{$field.name}" />
+{/foreach}
+
+{if $custom.help_post}
+  <div class="af-markup">{$custom.help_post}</div>
+{/if}
+


### PR DESCRIPTION
Overview
----------------------------------------
Here's something I never thought I'd do: **use smarty to generate afforms.**

This PR replaces the PHP string-fu currently used to generate the afform html layout for dynamic <afblock-custom-X-y> blocks with a smarty template.


Before
----------------------------------------
- layout for the block html is generated with PHP string fu

After
----------------------------------------
- layout for the block html is generated with a smarty template
- should generate the same string and behave exactly the same


Comments
----------------------------------------
@colemanw I was thinking this approach would extend well to generating standalone afforms for custom group CRUD forms (and thereafter contact summary tabs). Putting this PR up as a prelim to get your feedback on the approach

(Have been using a more complex variant of this in a project and it's working well.)
