### PR TITLE
afform - add dynamic forms for creating/update custom group data

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Get.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Get.php
@@ -138,66 +138,6 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
   }
 
   /**
-   * Generates afform blocks from custom field sets.
-   *
-   * @param \Civi\Core\Event\GenericHookEvent $event
-   * @throws \CRM_Core_Exception
-   */
-  public static function getCustomGroupBlocks($event) {
-    // Early return if blocks are not requested
-    if ($event->getTypes && !in_array('block', $event->getTypes, TRUE)) {
-      return;
-    }
-
-    $getNames = $event->getNames;
-    $getLayout = $event->getLayout;
-    $groupNames = [];
-    $afforms =& $event->afforms;
-    foreach ($getNames['name'] ?? [] as $name) {
-      if (str_starts_with($name, 'afblockCustom_') && strlen($name) > 13) {
-        $groupNames[] = substr($name, 14);
-      }
-    }
-    // Early return if this api call is fetching afforms by name and those names are not custom-related
-    if ((!empty($getNames['name']) && !$groupNames)
-      || (!empty($getNames['module_name']) && !str_contains(implode(' ', $getNames['module_name']), 'afblockCustom'))
-      || (!empty($getNames['directive_name']) && !str_contains(implode(' ', $getNames['directive_name']), 'afblock-custom'))
-    ) {
-      return;
-    }
-    $filters = [
-      'is_active' => TRUE,
-    ];
-    if ($groupNames) {
-      $filters['name'] = $groupNames;
-    }
-    $customGroups = \CRM_Core_BAO_CustomGroup::getAll($filters);
-    foreach ($customGroups as $custom) {
-      $name = 'afblockCustom_' . $custom['name'];
-      $item = [
-        'name' => $name,
-        'type' => 'block',
-        'requires' => [],
-        'title' => E::ts('%1 block', [1 => $custom['title']]),
-        'description' => '',
-        'is_public' => FALSE,
-        'permission' => ['access CiviCRM'],
-        'entity_type' => $custom['extends'],
-      ];
-      if ($custom['is_multiple']) {
-        $item['join_entity'] = 'Custom_' . $custom['name'];
-      }
-      if ($getLayout) {
-        $item['layout'] = \CRM_Core_Smarty::singleton()->fetchWith(
-          'afform/customGroups/afblock.tpl',
-          ['custom' => $custom]
-        );
-      }
-      $afforms[$name] = $item;
-    }
-  }
-
-  /**
    * Find search display tags in afform markup
    *
    * @param string $html

--- a/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
+++ b/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
@@ -44,7 +44,7 @@ class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
   protected array $formTypes = ['block', 'form', 'search'];
 
   protected function getSelect() {
-    return ['id', 'name', 'title', 'is_multiple', 'help_pre', 'help_post', 'extends'];
+      return ['id', 'name', 'title', 'is_multiple', 'help_pre', 'help_post', 'extends', 'icon'];
   }
 
   protected function doTask($item) {
@@ -102,6 +102,7 @@ class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
       'is_public' => FALSE,
       'permission' => ['access CiviCRM'],
       'entity_type' => $item['extends'],
+      'icon' => $item['icon'],
     ];
     if ($item['is_multiple']) {
       $afform['join_entity'] = 'Custom_' . $item['name'];
@@ -127,6 +128,7 @@ class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
       // to edit contacts
       'permission' => ['access CiviCRM'],
       'server_route' => 'civicrm/af/custom/' . $item['name'] . '/update',
+      'icon' => $item['icon'],
     ];
     if ($this->getLayout) {
 
@@ -181,6 +183,7 @@ class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
       // to edit contacts
       'permission' => ['access CiviCRM'],
       'server_route' => 'civicrm/af/custom/' . $item['name'] . '/create',
+      'icon' => $item['icon'],
     ];
     if ($this->getLayout) {
       $formEntity = [

--- a/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
+++ b/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
@@ -58,7 +58,11 @@ class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
       ->execute()
       ->column('name');
 
-    // we also needs this for
+    // restrict forms other than block to if Admin UI is enabled
+    $hasAdminUi = \CRM_Extension_System::singleton()->getMapper()->isActiveModule('civicrm_admin_ui');
+    if (!$hasAdminUi) {
+      $this->formTypes = array_intersect(['block'], $this->formTypes);
+    }
 
     foreach ($this->formTypes as $type) {
       switch ($type) {

--- a/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
+++ b/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
@@ -1,0 +1,295 @@
+<?php
+
+namespace Civi\Api4\Action\CustomGroup;
+
+use CRM_Afform_ExtensionUtil as E;
+
+/**
+ * Get dynamic afforms for a custom group.
+ *
+ * For single value custom groups we generate:
+ * - a field block with all of the fields from the group
+ * - a submission form for editing these fields on a parent entity record
+ *
+ * For multi-value custom groups we generate:
+ * - a field block with all of the fields from the group
+ * - a submission form for adding a new Custom record to a parent entity record
+ * - a submission form for editing a particular Custom record
+ * - (not implemented yet) a search form for viewing all the Custom records
+ *
+ * @package Civi\Api4\Action\CustomGroup
+ */
+class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
+
+  protected const FORM_TYPES = [
+    'afblockCustom',
+    'afformUpdateCustom',
+    'afformCreateCustom',
+    //'afsearchCustom',
+  ];
+
+  /**
+   * Whether to generate the form layouts
+   * @var bool
+   */
+  protected bool $getLayout = FALSE;
+
+  /**
+   * Limit to generating specific afform types
+   *
+   * Default to all
+   *
+   * @var array
+   */
+  protected array $formTypes = ['block', 'form', 'search'];
+
+  protected function getSelect() {
+    return ['id', 'name', 'title', 'is_multiple', 'help_pre', 'help_post', 'extends'];
+  }
+
+  protected function doTask($item) {
+    $forms = [];
+
+    // get field names once, for use across all the generate actions
+    $item['field_names'] = \Civi\Api4\CustomField::get(FALSE)
+      ->addSelect('name')
+      ->addWhere('custom_group_id', '=', $item['id'])
+      ->addWhere('is_active', '=', TRUE)
+      ->execute()
+      ->column('name');
+
+    // we also needs this for
+
+    foreach ($this->formTypes as $type) {
+      switch ($type) {
+        case 'block':
+          $forms[] = $this->generateFieldBlock($item);
+          break;
+
+        case 'form':
+          $forms[] = $this->generateUpdateForm($item);
+          if ($item['is_multiple']) {
+            $forms[] = $this->generateCreateForm($item);
+          }
+          break;
+
+        // TODO: implement search kit listings for multi value
+        // case 'search':
+        //   if ($item['is_multiple']) {
+        //     $forms[] = $this->generateSearchForm($item);
+        //   }
+        //   break;
+      }
+    }
+
+    return [
+      'id' => $item['id'],
+      'forms' => $forms,
+    ];
+  }
+
+  private function generateFieldBlock($item): array {
+    $afform = [
+      'name' => 'afblockCustom_' . $item['name'],
+      'type' => 'block',
+      'requires' => [],
+      'title' => E::ts('%1 block', [1 => $item['title']]),
+      'description' => '',
+      'is_public' => FALSE,
+      'permission' => ['access CiviCRM'],
+      'entity_type' => $item['extends'],
+    ];
+    if ($item['is_multiple']) {
+      $afform['join_entity'] = 'Custom_' . $item['name'];
+    }
+    if ($this->getLayout) {
+      $afform['layout'] = \CRM_Core_Smarty::singleton()->fetchWith(
+        'afform/customGroups/afblock.tpl',
+        ['group' => $item]
+      );
+    }
+    return $afform;
+  }
+
+  private function generateUpdateForm($item): array {
+    $afform = [
+      'name' => 'afformUpdateCustom_' . $item['name'],
+      'type' => 'form',
+      'title' => E::ts('Update %1', [1 => $item['title']]),
+      'description' => '',
+      'is_public' => FALSE,
+      // NOTE: we will use RBAC for entities to ensure
+      // this form does not allow folks who shouldn't
+      // to edit contacts
+      'permission' => ['access CiviCRM'],
+      'server_route' => 'civicrm/af/custom/' . $item['name'] . '/update',
+    ];
+    if ($this->getLayout) {
+
+      // form entity depends on whether this is a multirecord custom group
+      $formEntity = $item['is_multiple'] ?
+        [
+          'type' => 'Custom_' . $item['name'],
+          'name' => 'Record',
+          'label' => $item['extends'] . ' ' . $item['title'],
+          'parent_field' => 'entity_id',
+          'parent_field_defn' => [
+            'input_type' => 'Hidden',
+            'label' => FALSE,
+          ],
+        ] :
+        [
+          'type' => $item['extends'],
+          'name' => $item['extends'] . '1',
+          'label' => $item['extends'],
+          'parent_field' => 'id',
+          'parent_field_defn' => [
+            'input_type' => 'Hidden',
+            'label' => FALSE,
+          ],
+        ];
+
+      $afform['layout'] = \CRM_Core_Smarty::singleton()->fetchWith(
+        'afform/customGroups/afform.tpl',
+        [
+          'formEntity' => $formEntity,
+          'formActions' => [
+            'create' => FALSE,
+            'update' => TRUE,
+          ],
+          'urlAutofill' => TRUE,
+          'blockDirective' => _afform_angular_module_name('afblockCustom_' . $item['name'], 'dash'),
+        ]
+      );
+    }
+    return $afform;
+  }
+
+  private function generateCreateForm($item): array {
+    $afform = [
+      'name' => 'afformCreateCustom_' . $item['name'],
+      'type' => 'form',
+      'title' => E::ts('Add %1', [1 => $item['title']]),
+      'description' => '',
+      'is_public' => FALSE,
+      // NOTE: we will use RBAC for entities to ensure
+      // this form does not allow folks who shouldn't
+      // to edit contacts
+      'permission' => ['access CiviCRM'],
+      'server_route' => 'civicrm/af/custom/' . $item['name'] . '/create',
+    ];
+    if ($this->getLayout) {
+      $formEntity = [
+        'type' => 'Custom_' . $item['name'],
+        'name' => 'Record',
+        'label' => $item['extends'] . ' ' . $item['title'],
+        'parent_field' => 'entity_id',
+        'parent_field_defn' => [
+          'input_type' => 'Hidden',
+          'label' => FALSE,
+        ],
+      ];
+      $afform['layout'] = \CRM_Core_Smarty::singleton()->fetchWith(
+        'afform/customGroups/afform.tpl',
+        [
+          'formEntity' => $formEntity,
+          'formActions' => [
+            'create' => TRUE,
+            'update' => FALSE,
+          ],
+          'urlAutofill' => FALSE,
+          'blockDirective' => _afform_angular_module_name('afblockCustom_' . $item['name'], 'dash'),
+        ]
+      );
+    }
+    return $afform;
+  }
+
+  public static function getCustomGroupAfforms($event) {
+    $formGenerate = \Civi\Api4\CustomGroup::getAfforms(FALSE)
+      ->addWhere('is_active', '=', TRUE);
+
+    // only generate layout if this is required by the Afform.get
+    $formGenerate->setGetLayout($event->getLayout);
+
+    // if the Afform.get is limited to specific form types
+    // we can limit to those
+    if ($event->getTypes) {
+      $formGenerate->setFormTypes($event->getTypes);
+    }
+
+    // if the Afform.get is limited to specific form names
+    // we can limit our action to specific custom groups
+    if ($event->getNames) {
+      $groupNames = self::parseGroupNamesFromAfformGetNames($event->getNames);
+      if (!$groupNames) {
+        // Afform.get is limited to specific form names, none of which
+        // correspond to a custom group form, so we can return early
+        return;
+      }
+
+      $formGenerate->addWhere('name', 'IN', $groupNames);
+    }
+
+    $formsByGroup = $formGenerate->execute()->column('forms');
+
+    // add generated forms back to the hook event
+    // indexing by the form name
+    $forms = array_merge(...$formsByGroup);
+
+    foreach ($forms as $form) {
+      $event->afforms[$form['name']] = $form;
+    }
+  }
+
+  protected static function parseGroupNamesFromAfformGetNames(array $getNames): array {
+    // preserves previous logic when module_name or directive_name
+    // are specified
+    //
+    // I suspect we cannot more accurately parse kebab case names as special chars
+    // from group name may have been lost?
+    if (
+      (!empty($getNames['module_name']) && !str_contains(implode(' ', $getNames['module_name']), 'afblockCustom'))
+      || (!empty($getNames['directive_name']) && !str_contains(implode(' ', $getNames['directive_name']), 'afblock-custom'))
+    ) {
+      return [];
+    }
+
+    $formNames = $getNames['name'] ?? [];
+
+    $groupNames = array_map(fn ($name) => self::parseGroupNameFromFormName($name), $formNames);
+
+    // filter nulls where form name didnt correspond to a group name
+    return array_filter($groupNames);
+  }
+
+  /**
+   * For afform base name, get the custom group name it corresponds to
+   * Or null if none
+   *
+   * @return ?string
+   */
+  protected static function parseGroupNameFromFormName(string $name): ?string {
+    $prefixLength = strpos($name, '_');
+
+    if (!$prefixLength) {
+      // no prefix
+      return NULL;
+    }
+    $prefix = substr($name, 0, $prefixLength);
+
+    if (!in_array($prefix, self::FORM_TYPES)) {
+      // prefix doesn't match our custom group
+      // form prefixes
+      return NULL;
+    }
+
+    // TODO the prefix tells us which types of forms we
+    // want - so we could further optimise by passing
+    // that along to the generate action
+
+    // we have a match - return everything after the '_'
+    return substr($name, $prefixLength + 1);
+  }
+
+}

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -46,7 +46,7 @@ function afform_civicrm_config(&$config) {
   $dispatcher->addListener('hook_civicrm_angularModules', '_afform_hook_civicrm_angularModules', -1000);
   $dispatcher->addListener('hook_civicrm_alterAngular', ['\Civi\Afform\AfformMetadataInjector', 'preprocess']);
   $dispatcher->addListener('hook_civicrm_check', ['\Civi\Afform\StatusChecks', 'hook_civicrm_check']);
-  $dispatcher->addListener('civi.afform.get', ['\Civi\Api4\Action\Afform\Get', 'getCustomGroupBlocks']);
+  $dispatcher->addListener('civi.afform.get', ['\Civi\Api4\Action\CustomGroup\GetAfforms', 'getCustomGroupAfforms']);
 }
 
 /**

--- a/ext/afform/core/templates/afform/customGroups/afblock.tpl
+++ b/ext/afform/core/templates/afform/customGroups/afblock.tpl
@@ -1,14 +1,13 @@
-{if $custom.help_pre}
-  <div class="af-markup">{$custom.help_pre}</div>
+{if $group.help_pre}
+  <div class="af-markup">{$group.help_pre}</div>
 {/if}
 
-{foreach from=$custom.fields item=field}
+{foreach from=$group.field_names item=field_name}
   {* for multiple record fields there is no need to prepend
   the group name because it is provided as the join_entity above *}
-  <af-field name="{if !$custom.is_multiple}{$custom.name}.{/if}{$field.name}" />
+  <af-field name="{if !$group.is_multiple}{$group.name}.{/if}{$field_name}" />
 {/foreach}
 
-{if $custom.help_post}
-  <div class="af-markup">{$custom.help_post}</div>
+{if $group.help_post}
+  <div class="af-markup">{$group.help_post}</div>
 {/if}
-

--- a/ext/afform/core/templates/afform/customGroups/afform.tpl
+++ b/ext/afform/core/templates/afform/customGroups/afform.tpl
@@ -1,0 +1,19 @@
+<af-form ctrl="afform">
+  <af-entity
+    type="{$formEntity.type}"
+    name="{$formEntity.name}"
+    label="{$formEntity.label}"
+    actions='{$formActions|@json_encode}'
+    security="RBAC"
+    url-autofill="{$urlAutofill}"
+    />
+
+  <fieldset af-fieldset="{$formEntity.name}" class="af-container">
+    <af-field
+        name="{$formEntity.parent_field}"
+        defn='{$formEntity.parent_field_defn|@json_encode}'
+        />
+    <{$blockDirective} />
+  </fieldset>
+  <button class="af-button btn btn-primary" crm-icon="fa-save" ng-click="afform.submit()">Save</button>
+</af-form>


### PR DESCRIPTION
Overview
----------------------------------------
Currently afform blocks are auto generated for custom group data, which you can add to your own forms.

This adds automatic **forms** which can be used to edit the custom group data.

Comments
----------------------------------------
 I've moved the form generation from the Afform/Get class to a dedicated action on CustomGroup entity, as it gets a bit more involved creating multiple forms for each Group.

Still a bit WIP.

Questions:
-  For multi record custom groups we have to wrangle with af-join - I think it could be nice if we could enable them to be the primary form entity (with a required `entity_id` field).
- Currently I've implemented this directly in afform core - because that's where the blocks generation was, and it's nice to keep it together - but I do wonder if the forms should be in `civicrm_admin_ui`, because there are a bit more involved
- Permissions: I think the forms should be safe as long at they use RBAC - but not sure exactly what the (default) form level permission should be

Next step:
- Search forms to display multi value data. This requires creating SearchKits as well.