### PR TITLE
dev/financial#229 - Financial account name being displayed a few places where it should be label

### DIFF
--- a/CRM/Financial/Page/FinancialType.php
+++ b/CRM/Financial/Page/FinancialType.php
@@ -99,7 +99,7 @@ class CRM_Financial_Page_FinancialType extends CRM_Core_Page_Basic {
       $financialType[$dao->id] = [];
       CRM_Core_DAO::storeValues($dao, $financialType[$dao->id]);
       $defaults = $financialAccountId = [];
-      $financialAccounts = CRM_Contribute_PseudoConstant::financialAccount();
+      $financialAccounts = CRM_Contribute_PseudoConstant::financialAccount(NULL, NULL, 'label');
       $financialAccountIds = [];
 
       $params['entity_id'] = $dao->id;

--- a/CRM/Financial/Page/FinancialTypeAccount.php
+++ b/CRM/Financial/Page/FinancialTypeAccount.php
@@ -112,7 +112,7 @@ class CRM_Financial_Page_FinancialTypeAccount extends CRM_Core_Page {
     $params['entity_table'] = 'civicrm_financial_type';
     if ($this->_aid) {
       $relationTypeId = key(CRM_Core_PseudoConstant::accountOptionValues('account_relationship', NULL, " AND v.name LIKE 'Accounts Receivable Account is' "));
-      $this->_title = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialType', $this->_aid, 'name');
+      $this->_title = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialType', $this->_aid, 'label');
       CRM_Utils_System::setTitle($this->_title . ' - ' . ts('Assigned Financial Accounts'));
       $financialAccountType = CRM_Financial_DAO_FinancialAccount::buildOptions('financial_account_type_id');
       $accountRelationship = CRM_Financial_DAO_EntityFinancialAccount::buildOptions('account_relationship');
@@ -126,7 +126,7 @@ class CRM_Financial_Page_FinancialTypeAccount extends CRM_Core_Page {
         $defaults = [];
         $financialAccount = CRM_Financial_BAO_FinancialAccount::retrieve($params, $defaults);
         if (!empty($financialAccount)) {
-          $financialType[$dao->id]['financial_account'] = $financialAccount->name;
+          $financialType[$dao->id]['financial_account'] = $financialAccount->label;
           $financialType[$dao->id]['accounting_code'] = $financialAccount->accounting_code;
           $financialType[$dao->id]['account_type_code'] = $financialAccount->account_type_code;
           $financialType[$dao->id]['is_active'] = $financialAccount->is_active;


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/financial/-/issues/229

Before
----------------------------------------
1. On the financial types admin screen in the accounts column
   ![before-type](https://github.com/user-attachments/assets/63dd398c-eebd-4d40-a4ae-dc15ffdee870)
2. Then when you click on the accounts link for a type in the popup it's using name for the account, and also in the popup title.
   ![before-popup](https://github.com/user-attachments/assets/c0e8d52f-0171-4461-b865-af5888fb9147)

After
----------------------------------------
![after-type](https://github.com/user-attachments/assets/94e8f78e-fd25-4b9f-b20b-9e32099eeb20)
![after-popup](https://github.com/user-attachments/assets/3515b4fa-2ca2-489b-bf9d-13bdab7c3095)

Technical Details
----------------------------------------
Name

Comments
----------------------------------------
Label