### PR TITLE
(Test-Only) Fix MinkBase::login() on WordPress

### DIFF
--- a/Civi/Test/MinkBase.php
+++ b/Civi/Test/MinkBase.php
@@ -44,7 +44,8 @@ abstract class MinkBase extends \CiviEndToEndTestCase {
       'sub' => 'cid:' . $this->getUserId($user),
       'scope' => 'authx',
     ]);
-    $loginUrl = Civi::url('backend://civicrm/authx/login')->addQuery([
+    // The use of frontend:// or backend:// is abstract on some env's. For WP, only 'frontend' supports auth
+    $loginUrl = Civi::url('frontend://civicrm/authx/login')->addQuery([
       '_authx' => 'Bearer ' . $tok,
       '_authxSes' => 1,
     ]);


### PR DESCRIPTION
Overview
----------------------------------------

Fix an issue with the test-helper `MinkBase::login()` which causes ` E2E_CivicrmAdminUi_ManageGroupsTest.testManageGroups` to fail on WordPress.

Before
----------------------------------------

The test tries to login to WordPress with an authx token. It sends a request to `/wp-admin/admin.php`, but `admin.php` abortively redirects to the login UI before we get a chance to evaluate the authx token.

After
----------------------------------------

The test sends login request to `/index.php`, which is cool with it.

Technical Details
----------------------------------------

The `login()` makes a signed link to setup an authenticated session -- and then requests the link.

If you send the request to the WP backend, then there is a race between two parties that both want to redirect: `/wp-admin` wants to redirect to the login-UI, and `authx` wants to authenticate and redirect to your final page.

Currently, authx loses every time.  It always redirects to `wp-admin/admin.php`.  On a first read of that page, I couldn't recognize a spot for authx to inject itself early enough to stop this.

This commit does the easy work-around: send the login request to `index.php` instead. With no preemptive redirect, it's able to proceed to running authx.

Comments
----------------------------------------

This technically doesn't change anything in runtime behavior. But it would so nice to get some more green dots on the test-matrix...