### PR TITLE
dev/core#5609 - Fix literal `<del>` appearing on activity tab when source contact is deleted

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -723,12 +723,6 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
           }
         }
       }
-      // if deleted, wrap in <del>
-      if (!empty($activity['source_contact_id']) &&
-        CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $activity['source_contact_id'], 'is_deleted')
-      ) {
-        $activities[$id]['source_contact_name'] = sprintf("<del>%s<del>", htmlentities($activity['source_contact_name']));
-      }
       $activities[$id]['is_recurring_activity'] = CRM_Core_BAO_RecurringEntity::getParentFor($id, 'civicrm_activity');
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5609

Before
----------------------------------------
1. Delete a contact that has activities where they are the source contact.
2. Visit their activity tab.
3. It has a literal `<del>` tag appearing.

Two things going on:
1. Inserting `<del>` into the field's text value isn't really the right way to style.
2. There's double-escaping of the actual value because it's escaped here and then later at https://github.com/civicrm/civicrm-core/blob/9a3717d6c7728e3fef4a407a21b31cf46738c2c5/CRM/Activity/BAO/Activity.php#L2347. For example if the contact name is "O'Reilly & Sons". This is sort of separate from the `<del>` problem, but the double-escaping only happens when the contact is deleted.

After
----------------------------------------
No styling, but it's a datatable so I'm not sure how to properly style it. It's nice to have, but this also solves the double-escaping.

Technical Details
----------------------------------------


Comments
----------------------------------------

