### PR TITLE
dev/core#5611 Exclude tests and tools directories from exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
-.gitattributes export-ignore  
+.gitattributes export-ignore
 .gitignore export-ignore
+**/tests/** export-ignore
+**/tools/** export-ignore


### PR DESCRIPTION
Overview
----------------------------------------
Avoid distributing test files in packaged downloads.
See https://lab.civicrm.org/dev/core/-/issues/5611

Technical Details
----------------------------------------
I'm not sure if this only fixes composer-based installs and we also need to do something for our packaging script to avoid putting `ext/*/tests` directories in the zip/tar files.
