### PR TITLE
Update Case.php

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -448,17 +448,6 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
    * @param string $type
    * @param int $userID
    * @param string $condition
-   *
-   * @return string
-   */
-  public static function getCaseActivityCountQuery($type, $userID, $condition = NULL) {
-    return sprintf(" SELECT COUNT(*) FROM (%s) temp ", self::getCaseActivityQuery($type, $userID, $condition));
-  }
-
-  /**
-   * @param string $type
-   * @param int $userID
-   * @param string $condition
    * @param string $limit
    * @param string $order
    *
@@ -622,7 +611,7 @@ HERESQL;
     }
     $condition = implode(' AND ', $whereClauses);
 
-    Civi::$statics[__CLASS__]['totalCount'][$type] = $totalCount = CRM_Core_DAO::singleValueQuery(self::getCaseActivityCountQuery($type, $userID, $condition));
+    Civi::$statics[__CLASS__]['totalCount'][$type] = $totalCount = CRM_Core_DAO::singleValueQuery("SELECT COUNT(*) FROM civicrm_case WHERE is_deleted = 0");
     if ($getCount) {
       return $totalCount;
     }

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -448,6 +448,21 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
    * @param string $type
    * @param int $userID
    * @param string $condition
+   *
+   * @return string
+   */
+  public static function getCaseXountQuery($allCases, $type, $userID, $condition = NULL) {
+    if ($allCases && $type == 'any') {
+      return "SELECT COUNT(*) FROM civicrm_case WHERE is_deleted = 0";
+    }
+    return sprintf(" SELECT COUNT(*) FROM (%s) temp ", self::getCaseActivityQuery($type, $userID, $condition));
+  }
+
+
+  /**
+   * @param string $type
+   * @param int $userID
+   * @param string $condition
    * @param string $limit
    * @param string $order
    *
@@ -611,7 +626,7 @@ HERESQL;
     }
     $condition = implode(' AND ', $whereClauses);
 
-    Civi::$statics[__CLASS__]['totalCount'][$type] = $totalCount = CRM_Core_DAO::singleValueQuery("SELECT COUNT(*) FROM civicrm_case WHERE is_deleted = 0");
+    Civi::$statics[__CLASS__]['totalCount'][$type] = $totalCount = CRM_Core_DAO::singleValueQuery(self::getCaseCountQuery($allCases, $type, $userID, $condition));
     if ($getCount) {
       return $totalCount;
     }

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -451,7 +451,7 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
    *
    * @return string
    */
-  public static function getCaseXountQuery($allCases, $type, $userID, $condition = NULL) {
+  public static function getCaseCountQuery($allCases, $type, $userID, $condition = NULL) {
     if ($allCases && $type == 'any') {
       return "SELECT COUNT(*) FROM civicrm_case WHERE is_deleted = 0";
     }


### PR DESCRIPTION

Overview
----------------------------------------
Query running very slow, doing unnecessary work - see  https://civicrm.stackexchange.com/questions/48892/is-my-reasoning-correct-in-regard-to-speeding-up-this-core-query-and-if-so-how

Before
----------------------------------------
Line 625 calls getCaseActivityCountQuery which in turn calls getCaseActivityQuery

After
----------------------------------------
Line 625 runs much simpler but equivalent SQL query directly (Coleman suggested using API4, but when I try to do a count in the API4 explorer it comes back as 0, so I was not sure of the right syntax)


Technical Details
----------------------------------------
I believe the function getCaseActivityCountQuery is not called anywhere else so it seems appropriate to inline it.


