### PR TITLE
Add schema support for bigint

### DIFF
--- a/CRM/Utils/Schema.php
+++ b/CRM/Utils/Schema.php
@@ -86,7 +86,7 @@ class CRM_Utils_Schema {
 
       default:
         $field['sqlType'] = $type;
-        if ($type === 'int unsigned' || $type === 'tinyint') {
+        if ($type === 'int unsigned' || $type === 'tinyint' || $type === 'bigint unsigned') {
           $field['crmType'] = 'CRM_Utils_Type::T_INT';
         }
         else {
@@ -156,6 +156,7 @@ class CRM_Utils_Schema {
         return CRM_Utils_Type::T_FLOAT;
 
       case 'int unsigned':
+      case 'bigint unsigned':
       case 'tinyint':
         return CRM_Utils_Type::T_INT;
 


### PR DESCRIPTION
Overview
----------------------------------------
Add schema support for ` bigint`

Before
----------------------------------------
When adding a new entity it is possible to define the sql type as `int unsigned` but not `bigint unsigned`

After
----------------------------------------
`bigint` also works

Technical Details
----------------------------------------
I updated the docs to reflect this change
https://lab.civicrm.org/documentation/docs/dev/-/blob/master/docs/framework/entities/index.md

Comments
----------------------------------------
