### PR TITLE
AdminUI - dynamically generate afform tabs for CustomGroups of style Tab with table

### DIFF
--- a/Civi/Api4/Event/Subscriber/CustomValueAccessSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/CustomValueAccessSubscriber.php
@@ -1,0 +1,100 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Event\Subscriber;
+
+use Civi\API\Events;
+use Civi\Api4\Event\AuthorizeRecordEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Enforce constraints on Custom entities
+ *
+ * Currently:
+ * - deny create if max_multiple reached for the given entity_id
+ *
+ * TODO:
+ * - deny delete if min_multiple under threat
+ * - deny replace / save if it will threaten min/max
+ * - ?
+ *
+ * @service internal
+ */
+class CustomValueAccessSubscriber extends \Civi\Core\Service\AutoService implements EventSubscriberInterface {
+
+  /**
+   * @return array
+   */
+  public static function getSubscribedEvents() {
+    return [
+      'civi.api4.authorizeRecord' => ['onApiAuthorizeRecord', Events::W_LATE],
+    ];
+  }
+
+  /**
+   * @param \Civi\Api4\Event\AuthorizeRecordEvent $event
+   *   API record authorize event
+   */
+  public function onApiAuthorizeRecord(AuthorizeRecordEvent $event) {
+    $apiRequest = $event->getApiRequest();
+
+    if (!in_array(
+        'Civi\Api4\Generic\Traits\CustomValueActionTrait',
+        class_uses($apiRequest)
+        )) {
+      return;
+    }
+
+    $action = $apiRequest->getActionName();
+
+    // TODO: what api actions should we apply to?
+    // min/max should apply to create + delete
+    // also save and replace but trickier
+    // also update if we ever allow changing entity_id
+
+    // for now only apply to create
+    if ($action !== 'create') {
+      return;
+    }
+
+    $parentId = $event->getRecord()['entity_id'] ?? NULL;
+    if (!$parentId) {
+      // we dont know the parent so cant check existing records
+      return;
+    }
+
+    $group = \Civi\Api4\CustomGroup::get(FALSE)
+      ->addSelect('name', 'min_multiple', 'max_multiple')
+      ->addWhere('name', '=', $apiRequest->getCustomGroup())
+      ->addWhere('is_multiple', '=', TRUE)
+      ->execute()->first();
+
+    if (!$group) {
+      return;
+    }
+    if ($group['min_multiple']) {
+      // TODO: prevent delete
+    }
+    if ($group['max_multiple']) {
+      $currentCount = civicrm_api4($apiRequest->getEntityName(), 'get', [
+        'select' => ['row_count'],
+        'where' => [['entity_id', '=', $parentId]],
+      ])->count();
+
+      if ($currentCount >= $group['max_multiple']) {
+        // would be good if we could provide a clearer error message
+        // at the moment will just get ACL check failed
+        $event->setAuthorized(FALSE);
+      }
+    }
+  }
+
+}

--- a/Civi/Api4/Event/Subscriber/CustomValueAccessSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/CustomValueAccessSubscriber.php
@@ -71,11 +71,7 @@ class CustomValueAccessSubscriber extends \Civi\Core\Service\AutoService impleme
       return;
     }
 
-    $group = \Civi\Api4\CustomGroup::get(FALSE)
-      ->addSelect('name', 'min_multiple', 'max_multiple')
-      ->addWhere('name', '=', $apiRequest->getCustomGroup())
-      ->addWhere('is_multiple', '=', TRUE)
-      ->execute()->first();
+    $group = \CRM_Core_BAO_CustomGroup::getGroup(['name' => $apiRequest->getCustomGroup()]);
 
     if (!$group) {
       return;

--- a/ext/afform/core/Civi/Api4/Action/Afform/Get.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Get.php
@@ -138,66 +138,6 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
   }
 
   /**
-   * Generates afform blocks from custom field sets.
-   *
-   * @param \Civi\Core\Event\GenericHookEvent $event
-   * @throws \CRM_Core_Exception
-   */
-  public static function getCustomGroupBlocks($event) {
-    // Early return if blocks are not requested
-    if ($event->getTypes && !in_array('block', $event->getTypes, TRUE)) {
-      return;
-    }
-
-    $getNames = $event->getNames;
-    $getLayout = $event->getLayout;
-    $groupNames = [];
-    $afforms =& $event->afforms;
-    foreach ($getNames['name'] ?? [] as $name) {
-      if (str_starts_with($name, 'afblockCustom_') && strlen($name) > 13) {
-        $groupNames[] = substr($name, 14);
-      }
-    }
-    // Early return if this api call is fetching afforms by name and those names are not custom-related
-    if ((!empty($getNames['name']) && !$groupNames)
-      || (!empty($getNames['module_name']) && !str_contains(implode(' ', $getNames['module_name']), 'afblockCustom'))
-      || (!empty($getNames['directive_name']) && !str_contains(implode(' ', $getNames['directive_name']), 'afblock-custom'))
-    ) {
-      return;
-    }
-    $filters = [
-      'is_active' => TRUE,
-    ];
-    if ($groupNames) {
-      $filters['name'] = $groupNames;
-    }
-    $customGroups = \CRM_Core_BAO_CustomGroup::getAll($filters);
-    foreach ($customGroups as $custom) {
-      $name = 'afblockCustom_' . $custom['name'];
-      $item = [
-        'name' => $name,
-        'type' => 'block',
-        'requires' => [],
-        'title' => E::ts('%1 block', [1 => $custom['title']]),
-        'description' => '',
-        'is_public' => FALSE,
-        'permission' => ['access CiviCRM'],
-        'entity_type' => $custom['extends'],
-      ];
-      if ($custom['is_multiple']) {
-        $item['join_entity'] = 'Custom_' . $custom['name'];
-      }
-      if ($getLayout) {
-        $item['layout'] = \CRM_Core_Smarty::singleton()->fetchWith(
-          'afform/customGroups/afblock.tpl',
-          ['custom' => $custom]
-        );
-      }
-      $afforms[$name] = $item;
-    }
-  }
-
-  /**
    * Find search display tags in afform markup
    *
    * @param string $html

--- a/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
+++ b/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
@@ -44,7 +44,7 @@ class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
   protected array $formTypes = ['block', 'form', 'search'];
 
   protected function getSelect() {
-    return ['id', 'name', 'title', 'is_multiple', 'help_pre', 'help_post', 'extends'];
+      return ['id', 'name', 'title', 'is_multiple', 'help_pre', 'help_post', 'extends', 'icon'];
   }
 
   protected function doTask($item) {
@@ -102,6 +102,7 @@ class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
       'is_public' => FALSE,
       'permission' => ['access CiviCRM'],
       'entity_type' => $item['extends'],
+      'icon' => $item['icon'],
     ];
     if ($item['is_multiple']) {
       $afform['join_entity'] = 'Custom_' . $item['name'];
@@ -127,6 +128,7 @@ class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
       // to edit contacts
       'permission' => ['access CiviCRM'],
       'server_route' => 'civicrm/af/custom/' . $item['name'] . '/update',
+      'icon' => $item['icon'],
     ];
     if ($this->getLayout) {
 
@@ -181,6 +183,7 @@ class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
       // to edit contacts
       'permission' => ['access CiviCRM'],
       'server_route' => 'civicrm/af/custom/' . $item['name'] . '/create',
+      'icon' => $item['icon'],
     ];
     if ($this->getLayout) {
       $formEntity = [

--- a/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
+++ b/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
@@ -58,7 +58,11 @@ class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
       ->execute()
       ->column('name');
 
-    // we also needs this for
+    // restrict forms other than block to if Admin UI is enabled
+    $hasAdminUi = \CRM_Extension_System::singleton()->getMapper()->isActiveModule('civicrm_admin_ui');
+    if (!$hasAdminUi) {
+      $this->formTypes = array_intersect(['block'], $this->formTypes);
+    }
 
     foreach ($this->formTypes as $type) {
       switch ($type) {

--- a/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
+++ b/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
@@ -1,0 +1,295 @@
+<?php
+
+namespace Civi\Api4\Action\CustomGroup;
+
+use CRM_Afform_ExtensionUtil as E;
+
+/**
+ * Get dynamic afforms for a custom group.
+ *
+ * For single value custom groups we generate:
+ * - a field block with all of the fields from the group
+ * - a submission form for editing these fields on a parent entity record
+ *
+ * For multi-value custom groups we generate:
+ * - a field block with all of the fields from the group
+ * - a submission form for adding a new Custom record to a parent entity record
+ * - a submission form for editing a particular Custom record
+ * - (not implemented yet) a search form for viewing all the Custom records
+ *
+ * @package Civi\Api4\Action\CustomGroup
+ */
+class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
+
+  protected const FORM_TYPES = [
+    'afblockCustom',
+    'afformUpdateCustom',
+    'afformCreateCustom',
+    //'afsearchCustom',
+  ];
+
+  /**
+   * Whether to generate the form layouts
+   * @var bool
+   */
+  protected bool $getLayout = FALSE;
+
+  /**
+   * Limit to generating specific afform types
+   *
+   * Default to all
+   *
+   * @var array
+   */
+  protected array $formTypes = ['block', 'form', 'search'];
+
+  protected function getSelect() {
+    return ['id', 'name', 'title', 'is_multiple', 'help_pre', 'help_post', 'extends'];
+  }
+
+  protected function doTask($item) {
+    $forms = [];
+
+    // get field names once, for use across all the generate actions
+    $item['field_names'] = \Civi\Api4\CustomField::get(FALSE)
+      ->addSelect('name')
+      ->addWhere('custom_group_id', '=', $item['id'])
+      ->addWhere('is_active', '=', TRUE)
+      ->execute()
+      ->column('name');
+
+    // we also needs this for
+
+    foreach ($this->formTypes as $type) {
+      switch ($type) {
+        case 'block':
+          $forms[] = $this->generateFieldBlock($item);
+          break;
+
+        case 'form':
+          $forms[] = $this->generateUpdateForm($item);
+          if ($item['is_multiple']) {
+            $forms[] = $this->generateCreateForm($item);
+          }
+          break;
+
+        // TODO: implement search kit listings for multi value
+        // case 'search':
+        //   if ($item['is_multiple']) {
+        //     $forms[] = $this->generateSearchForm($item);
+        //   }
+        //   break;
+      }
+    }
+
+    return [
+      'id' => $item['id'],
+      'forms' => $forms,
+    ];
+  }
+
+  private function generateFieldBlock($item): array {
+    $afform = [
+      'name' => 'afblockCustom_' . $item['name'],
+      'type' => 'block',
+      'requires' => [],
+      'title' => E::ts('%1 block', [1 => $item['title']]),
+      'description' => '',
+      'is_public' => FALSE,
+      'permission' => ['access CiviCRM'],
+      'entity_type' => $item['extends'],
+    ];
+    if ($item['is_multiple']) {
+      $afform['join_entity'] = 'Custom_' . $item['name'];
+    }
+    if ($this->getLayout) {
+      $afform['layout'] = \CRM_Core_Smarty::singleton()->fetchWith(
+        'afform/customGroups/afblock.tpl',
+        ['group' => $item]
+      );
+    }
+    return $afform;
+  }
+
+  private function generateUpdateForm($item): array {
+    $afform = [
+      'name' => 'afformUpdateCustom_' . $item['name'],
+      'type' => 'form',
+      'title' => E::ts('Update %1', [1 => $item['title']]),
+      'description' => '',
+      'is_public' => FALSE,
+      // NOTE: we will use RBAC for entities to ensure
+      // this form does not allow folks who shouldn't
+      // to edit contacts
+      'permission' => ['access CiviCRM'],
+      'server_route' => 'civicrm/af/custom/' . $item['name'] . '/update',
+    ];
+    if ($this->getLayout) {
+
+      // form entity depends on whether this is a multirecord custom group
+      $formEntity = $item['is_multiple'] ?
+        [
+          'type' => 'Custom_' . $item['name'],
+          'name' => 'Record',
+          'label' => $item['extends'] . ' ' . $item['title'],
+          'parent_field' => 'entity_id',
+          'parent_field_defn' => [
+            'input_type' => 'Hidden',
+            'label' => FALSE,
+          ],
+        ] :
+        [
+          'type' => $item['extends'],
+          'name' => $item['extends'] . '1',
+          'label' => $item['extends'],
+          'parent_field' => 'id',
+          'parent_field_defn' => [
+            'input_type' => 'Hidden',
+            'label' => FALSE,
+          ],
+        ];
+
+      $afform['layout'] = \CRM_Core_Smarty::singleton()->fetchWith(
+        'afform/customGroups/afform.tpl',
+        [
+          'formEntity' => $formEntity,
+          'formActions' => [
+            'create' => FALSE,
+            'update' => TRUE,
+          ],
+          'urlAutofill' => TRUE,
+          'blockDirective' => _afform_angular_module_name('afblockCustom_' . $item['name'], 'dash'),
+        ]
+      );
+    }
+    return $afform;
+  }
+
+  private function generateCreateForm($item): array {
+    $afform = [
+      'name' => 'afformCreateCustom_' . $item['name'],
+      'type' => 'form',
+      'title' => E::ts('Add %1', [1 => $item['title']]),
+      'description' => '',
+      'is_public' => FALSE,
+      // NOTE: we will use RBAC for entities to ensure
+      // this form does not allow folks who shouldn't
+      // to edit contacts
+      'permission' => ['access CiviCRM'],
+      'server_route' => 'civicrm/af/custom/' . $item['name'] . '/create',
+    ];
+    if ($this->getLayout) {
+      $formEntity = [
+        'type' => 'Custom_' . $item['name'],
+        'name' => 'Record',
+        'label' => $item['extends'] . ' ' . $item['title'],
+        'parent_field' => 'entity_id',
+        'parent_field_defn' => [
+          'input_type' => 'Hidden',
+          'label' => FALSE,
+        ],
+      ];
+      $afform['layout'] = \CRM_Core_Smarty::singleton()->fetchWith(
+        'afform/customGroups/afform.tpl',
+        [
+          'formEntity' => $formEntity,
+          'formActions' => [
+            'create' => TRUE,
+            'update' => FALSE,
+          ],
+          'urlAutofill' => FALSE,
+          'blockDirective' => _afform_angular_module_name('afblockCustom_' . $item['name'], 'dash'),
+        ]
+      );
+    }
+    return $afform;
+  }
+
+  public static function getCustomGroupAfforms($event) {
+    $formGenerate = \Civi\Api4\CustomGroup::getAfforms(FALSE)
+      ->addWhere('is_active', '=', TRUE);
+
+    // only generate layout if this is required by the Afform.get
+    $formGenerate->setGetLayout($event->getLayout);
+
+    // if the Afform.get is limited to specific form types
+    // we can limit to those
+    if ($event->getTypes) {
+      $formGenerate->setFormTypes($event->getTypes);
+    }
+
+    // if the Afform.get is limited to specific form names
+    // we can limit our action to specific custom groups
+    if ($event->getNames) {
+      $groupNames = self::parseGroupNamesFromAfformGetNames($event->getNames);
+      if (!$groupNames) {
+        // Afform.get is limited to specific form names, none of which
+        // correspond to a custom group form, so we can return early
+        return;
+      }
+
+      $formGenerate->addWhere('name', 'IN', $groupNames);
+    }
+
+    $formsByGroup = $formGenerate->execute()->column('forms');
+
+    // add generated forms back to the hook event
+    // indexing by the form name
+    $forms = array_merge(...$formsByGroup);
+
+    foreach ($forms as $form) {
+      $event->afforms[$form['name']] = $form;
+    }
+  }
+
+  protected static function parseGroupNamesFromAfformGetNames(array $getNames): array {
+    // preserves previous logic when module_name or directive_name
+    // are specified
+    //
+    // I suspect we cannot more accurately parse kebab case names as special chars
+    // from group name may have been lost?
+    if (
+      (!empty($getNames['module_name']) && !str_contains(implode(' ', $getNames['module_name']), 'afblockCustom'))
+      || (!empty($getNames['directive_name']) && !str_contains(implode(' ', $getNames['directive_name']), 'afblock-custom'))
+    ) {
+      return [];
+    }
+
+    $formNames = $getNames['name'] ?? [];
+
+    $groupNames = array_map(fn ($name) => self::parseGroupNameFromFormName($name), $formNames);
+
+    // filter nulls where form name didnt correspond to a group name
+    return array_filter($groupNames);
+  }
+
+  /**
+   * For afform base name, get the custom group name it corresponds to
+   * Or null if none
+   *
+   * @return ?string
+   */
+  protected static function parseGroupNameFromFormName(string $name): ?string {
+    $prefixLength = strpos($name, '_');
+
+    if (!$prefixLength) {
+      // no prefix
+      return NULL;
+    }
+    $prefix = substr($name, 0, $prefixLength);
+
+    if (!in_array($prefix, self::FORM_TYPES)) {
+      // prefix doesn't match our custom group
+      // form prefixes
+      return NULL;
+    }
+
+    // TODO the prefix tells us which types of forms we
+    // want - so we could further optimise by passing
+    // that along to the generate action
+
+    // we have a match - return everything after the '_'
+    return substr($name, $prefixLength + 1);
+  }
+
+}

--- a/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
+++ b/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
@@ -228,9 +228,10 @@ class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
       'description' => E::ts('Contact summary tab display for %1', [1 => $item['title']]),
       'type' => 'search',
       'is_public' => FALSE,
-      // Q: how to restrict this appropriately?
-      // for now default to administer
-      // 'permission' => ['access CiviCRM'],
+      // Q: should this be more permissive if user has access
+      // to contact record?
+      // what about ACLs?
+      'permission' => ['access all custom data'],
       'title' => $item['title'],
       'icon' => $item['icon'],
     ];

--- a/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
+++ b/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
@@ -54,12 +54,8 @@ class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
     $forms = [];
 
     // get field names once, for use across all the generate actions
-    $item['field_names'] = \Civi\Api4\CustomField::get(FALSE)
-      ->addSelect('name')
-      ->addWhere('custom_group_id', '=', $item['id'])
-      ->addWhere('is_active', '=', TRUE)
-      ->execute()
-      ->column('name');
+    $fields = \CRM_Core_BAO_CustomGroup::getGroup(['id' => $item['id']])['fields'];
+    $item['field_names'] = array_column($fields, 'name');
 
     // restrict forms other than block to if Admin UI is enabled
     $hasAdminUi = \CRM_Extension_System::singleton()->getMapper()->isActiveModule('civicrm_admin_ui');

--- a/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
+++ b/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
@@ -293,6 +293,10 @@ class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
     $forms = array_merge(...$formsByGroup);
 
     foreach ($forms as $form) {
+      $form['has_base'] = TRUE;
+      // blocks are provided by this module, but others are effectively provided
+      // by `civicrm_admin_ui` at this stage
+      $form['base_module'] = ($form['type'] === 'block') ? E::LONG_NAME : 'civicrm_admin_ui';
       $event->afforms[$form['name']] = $form;
     }
   }

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -46,7 +46,7 @@ function afform_civicrm_config(&$config) {
   $dispatcher->addListener('hook_civicrm_angularModules', '_afform_hook_civicrm_angularModules', -1000);
   $dispatcher->addListener('hook_civicrm_alterAngular', ['\Civi\Afform\AfformMetadataInjector', 'preprocess']);
   $dispatcher->addListener('hook_civicrm_check', ['\Civi\Afform\StatusChecks', 'hook_civicrm_check']);
-  $dispatcher->addListener('civi.afform.get', ['\Civi\Api4\Action\Afform\Get', 'getCustomGroupBlocks']);
+  $dispatcher->addListener('civi.afform.get', ['\Civi\Api4\Action\CustomGroup\GetAfforms', 'getCustomGroupAfforms']);
 }
 
 /**

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -171,13 +171,12 @@ function afform_civicrm_tabset($tabsetName, &$tabs, $context) {
       $tabId = CRM_Utils_String::convertStringToSnakeCase(preg_replace('#^(afformtab|afsearchtab|afform|afsearch)#i', '', $afform['name']));
       if (strpos($tabId, 'custom_') === 0) {
         // custom group tab forms use name, but need to replace tabs using ID
-	// remove 'afsearchTabCustom_' from the form name to get the group name
+        // remove 'afsearchTabCustom_' from the form name to get the group name
         $groupName = substr($afform['name'], 18);
-        $groupId = \Civi\Api4\CustomGroup::get(FALSE)
-          ->addSelect('id')
-          ->addWhere('name', '=', $groupName)
-          ->execute()->first()['id'] ?? NULL;
-        $tabId = 'custom_' . $groupId;
+        $group = \CRM_Core_BAO_CustomGroup::getGroup(['name' => $groupName]);
+        if ($group) {
+          $tabId = 'custom_' . $group['id'];
+        }
       }
       // If a tab with that id already exists, allow the afform to replace it.
       $existingTab = array_search($tabId, $existingTabs);

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -171,7 +171,8 @@ function afform_civicrm_tabset($tabsetName, &$tabs, $context) {
       $tabId = CRM_Utils_String::convertStringToSnakeCase(preg_replace('#^(afformtab|afsearchtab|afform|afsearch)#i', '', $afform['name']));
       if (strpos($tabId, 'custom_') === 0) {
         // custom group tab forms use name, but need to replace tabs using ID
-        $groupName = substr($tabId, 8);
+	// remove 'afsearchTabCustom_' from the form name to get the group name
+        $groupName = substr($afform['name'], 18);
         $groupId = \Civi\Api4\CustomGroup::get(FALSE)
           ->addSelect('id')
           ->addWhere('name', '=', $groupName)

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -169,6 +169,15 @@ function afform_civicrm_tabset($tabsetName, &$tabs, $context) {
     if (!$summaryContactType || !$contactTypes || array_intersect($summaryContactType, $contactTypes)) {
       // Convention is to name the afform like "afformTabMyInfo" which gets the tab name "my_info"
       $tabId = CRM_Utils_String::convertStringToSnakeCase(preg_replace('#^(afformtab|afsearchtab|afform|afsearch)#i', '', $afform['name']));
+      if (strpos($tabId, 'custom_') === 0) {
+        // custom group tab forms use name, but need to replace tabs using ID
+        $groupName = substr($tabId, 8);
+        $groupId = \Civi\Api4\CustomGroup::get(FALSE)
+          ->addSelect('id')
+          ->addWhere('name', '=', $groupName)
+          ->execute()->first()['id'] ?? NULL;
+        $tabId = 'custom_' . $groupId;
+      }
       // If a tab with that id already exists, allow the afform to replace it.
       $existingTab = array_search($tabId, $existingTabs);
       if ($existingTab !== FALSE) {

--- a/ext/afform/core/templates/afform/customGroups/afblock.tpl
+++ b/ext/afform/core/templates/afform/customGroups/afblock.tpl
@@ -1,14 +1,13 @@
-{if $custom.help_pre}
-  <div class="af-markup">{$custom.help_pre}</div>
+{if $group.help_pre}
+  <div class="af-markup">{$group.help_pre}</div>
 {/if}
 
-{foreach from=$custom.fields item=field}
+{foreach from=$group.field_names item=field_name}
   {* for multiple record fields there is no need to prepend
   the group name because it is provided as the join_entity above *}
-  <af-field name="{if !$custom.is_multiple}{$custom.name}.{/if}{$field.name}" />
+  <af-field name="{if !$group.is_multiple}{$group.name}.{/if}{$field_name}" />
 {/foreach}
 
-{if $custom.help_post}
-  <div class="af-markup">{$custom.help_post}</div>
+{if $group.help_post}
+  <div class="af-markup">{$group.help_post}</div>
 {/if}
-

--- a/ext/afform/core/templates/afform/customGroups/afform.tpl
+++ b/ext/afform/core/templates/afform/customGroups/afform.tpl
@@ -1,0 +1,19 @@
+<af-form ctrl="afform">
+  <af-entity
+    type="{$formEntity.type}"
+    name="{$formEntity.name}"
+    label="{$formEntity.label}"
+    actions='{$formActions|@json_encode}'
+    security="RBAC"
+    url-autofill="{$urlAutofill}"
+    />
+
+  <fieldset af-fieldset="{$formEntity.name}" class="af-container">
+    <af-field
+        name="{$formEntity.parent_field}"
+        defn='{$formEntity.parent_field_defn|@json_encode}'
+        />
+    <{$blockDirective} />
+  </fieldset>
+  <button class="af-button btn btn-primary" crm-icon="fa-save" ng-click="afform.submit()">Save</button>
+</af-form>

--- a/ext/afform/core/templates/afform/customGroups/afsearchTab.tpl
+++ b/ext/afform/core/templates/afform/customGroups/afsearchTab.tpl
@@ -1,7 +1,4 @@
 <div af-fieldset="">
-  <div class="af-container af-layout-inline">
-    <a class="af-button btn btn-primary" crm-i="fa-plus" target="crm-popup" ng-href="/civicrm/af/custom/{$group.name}/create#?entity_id={ldelim}{ldelim} options.contact_id {rdelim}{rdelim}">{ts 1=$group.title}Add new %1{/ts}</a>
-  </div>
   <crm-search-display-{$display_type}
     search-name="{$saved_search}"
     display-name="{$search_display}"

--- a/ext/afform/core/templates/afform/customGroups/afsearchTab.tpl
+++ b/ext/afform/core/templates/afform/customGroups/afsearchTab.tpl
@@ -1,6 +1,6 @@
 <div af-fieldset="">
-  <div class="af-container">
-    <a class="btn btn-primary" crm-i="fa-plus" target="crm-popup" ng-href="/civicrm/af/custom/{$group.name}/create#?entity_id={ldelim}{ldelim} options.contact_id {rdelim}{rdelim}">{ts 1=$group.title}Add new %1{/ts}</a>
+  <div class="af-container af-layout-inline">
+    <a class="af-button btn btn-primary" crm-i="fa-plus" target="crm-popup" ng-href="/civicrm/af/custom/{$group.name}/create#?entity_id={ldelim}{ldelim} options.contact_id {rdelim}{rdelim}">{ts 1=$group.title}Add new %1{/ts}</a>
   </div>
   <crm-search-display-{$display_type}
     search-name="{$saved_search}"

--- a/ext/afform/core/templates/afform/customGroups/afsearchTab.tpl
+++ b/ext/afform/core/templates/afform/customGroups/afsearchTab.tpl
@@ -1,0 +1,10 @@
+<div af-fieldset="">
+  <div class="af-container">
+    <a class="btn btn-primary" crm-i="fa-plus" target="crm-popup" ng-href="/civicrm/af/custom/{$group.name}/create#?entity_id={ldelim}{ldelim} options.contact_id {rdelim}{rdelim}">{ts 1=$group.title}Add new %1{/ts}</a>
+  </div>
+  <crm-search-display-{$display_type}
+    search-name="{$saved_search}"
+    display-name="{$search_display}"
+    filters="{ldelim}entity_id: options.contact_id{rdelim}"
+    />
+</div>

--- a/ext/civicrm_admin_ui/Civi/Api4/Action/CustomGroup/GetSearchKit.php
+++ b/ext/civicrm_admin_ui/Civi/Api4/Action/CustomGroup/GetSearchKit.php
@@ -37,6 +37,9 @@ class GetSearchKit extends \Civi\Api4\Generic\BasicBatchAction {
       ->addSelect('name', 'label')
       ->addWhere('custom_group_id', '=', $item['id'])
       ->addWhere('is_active', '=', TRUE)
+      // respect "Display in table" config on each field
+      // (Q: should we respect this for other displays?)
+      ->addWhere('in_selector', '=', TRUE)
       ->execute();
 
     $managed = [];

--- a/ext/civicrm_admin_ui/Civi/Api4/Action/CustomGroup/GetSearchKit.php
+++ b/ext/civicrm_admin_ui/Civi/Api4/Action/CustomGroup/GetSearchKit.php
@@ -140,15 +140,15 @@ class GetSearchKit extends \Civi\Api4\Generic\BasicBatchAction {
             'colno' => '3',
             'toolbar' => [
               [
-                'action' => '',
-                'entity' => '',
+                'action' => 'add',
+                'entity' => $group['entity_name'],
                 'text' => E::ts('Add %1', [1 => $group['title']]),
                 'icon' => 'fa-plus',
                 'style' => 'default',
                 'target' => 'crm-popup',
                 'join' => '',
-                'path' => "civicrm/af/custom/{$group['name']}/create#?entity_id=[entity_id]",
                 'task' => '',
+                //'condition' => ['check user permission', TRUE],
               ],
             ],
           ],
@@ -196,8 +196,8 @@ class GetSearchKit extends \Civi\Api4\Generic\BasicBatchAction {
           'style' => 'default',
         ],
         [
-          // TODO: can we register this as the canonical Update link
-          'path' => "civicrm/af/custom/{$groupName}/update#?Record=[id]",
+          'entity' => $entityName,
+          'action' => 'update',
           'target' => 'crm-popup',
           'icon' => 'fa-pencil',
           'text' => E::ts('Edit'),

--- a/ext/civicrm_admin_ui/Civi/Api4/Action/CustomGroup/GetSearchKit.php
+++ b/ext/civicrm_admin_ui/Civi/Api4/Action/CustomGroup/GetSearchKit.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Civi\Api4\Action\CustomGroup;
+
+use CRM_Afform_ExtensionUtil as E;
+
+/**
+ * For multi-value custom groups, produce managed records
+ * to generate a search kit SavedSearch and SearchDisplays
+ * for listing the custom records
+ *
+ * @package Civi\Api4\Action\CustomGroup
+ */
+class GetSearchKit extends \Civi\Api4\Generic\BasicBatchAction {
+
+  protected function getSelect() {
+    return ['id', 'name', 'title', 'is_multiple', 'style'];
+  }
+
+  protected function doTask($item) {
+    // searches only apply to multi-record CustomGroups
+    if (!$item['is_multiple'] || ($item['style'] !== 'Tab with table')) {
+      return [
+        'id' => $item['id'],
+        'managed' => [],
+      ];
+    }
+
+    // derive the entity name for later use
+    $item['entity_name'] = 'Custom_' . $item['name'];
+    // derive the search name here - must be consistent between
+    // SavedSearch and SearchDisplays
+    $item['search_name'] = $item['entity_name'] . '_Search';
+
+    // get active fields for this group to include as columns
+    $item['fields'] = (array) \Civi\Api4\CustomField::get(FALSE)
+      ->addSelect('name', 'label')
+      ->addWhere('custom_group_id', '=', $item['id'])
+      ->addWhere('is_active', '=', TRUE)
+      ->execute();
+
+    $managed = [];
+
+    // Get SavedSearch
+    $managed[] = $this->getSavedSearch($item);
+
+    foreach ($this->getSearchDisplays($item) as $display) {
+      $managed[] = $display;
+    }
+
+    return [
+      'id' => $item['id'],
+      'managed' => $managed,
+    ];
+  }
+
+  protected function getSavedSearch(array $group): array {
+    $entityName = $group['entity_name'];
+    $searchName = $group['search_name'];
+    $searchLabel = E::ts('%1 Search', [1 => $group['title']]);
+
+    // select all fields by name
+    $select = array_map(fn ($field) => $field['name'], $group['fields']);
+    // add id and entity_id - always useful
+    $select[] = 'id';
+    $select[] = 'entity_id';
+
+    return [
+      'name' => "SavedSearch_{$searchName}",
+      'entity' => 'SavedSearch',
+      'cleanup' => 'unused',
+      'update' => 'unmodified',
+      'params' => [
+        'version' => 4,
+        'values' => [
+          'name' => $searchName,
+          'label' => $searchLabel,
+          'api_entity' => $entityName,
+          'api_params' => [
+            'version' => 4,
+            'select' => $select,
+          ],
+        ],
+        'match' => ['name'],
+      ],
+    ];
+  }
+
+  protected function getSearchDisplays(array $group): array {
+    $searchDisplays = [];
+
+    // most columns are reusable across displays
+    $columns = $this->getFieldColumns($group['fields']);
+    $columns[] = $this->getButtonColumn($group);
+
+    $searchDisplays[] = $this->getTabSearchDisplay($group, $columns);
+
+    return $searchDisplays;
+  }
+
+  protected function getTabSearchDisplay($group, $columns, $displayType = 'table') {
+    $searchName = $group['search_name'];
+    $displayName = $group['entity_name'] . '_Tab';
+    $displayLabel = $group['title'];
+    $description = E::ts('Tab display for %1', [1 => $group['title']]);
+
+    return [
+      'name' => "SavedSearch_{$searchName}_SearchDisplay_{$displayName}",
+      'entity' => 'SearchDisplay',
+      'cleanup' => 'unused',
+      'update' => 'unmodified',
+      'params' => [
+        'version' => 4,
+        'values' => [
+          'name' => $displayName,
+          'label' => $displayLabel,
+          'saved_search_id.name' => $searchName,
+          'type' => $displayType,
+          'settings' => [
+            'limit' => 50,
+            'placeholder' => 5,
+            'columns' => $columns,
+            // only for table but harmless otherwise
+            'actions' => TRUE,
+            'classes' => ['table', 'table-striped'],
+            'actions_display_mode' => 'menu',
+            // only for grid but harmless otherwise
+            'colno' => '3',
+          ],
+        ],
+        'match' => [
+          'saved_search_id',
+          'name',
+        ],
+      ],
+    ];
+  }
+
+  protected function getFieldColumns($fields) {
+    return array_map(fn ($field) => [
+      'type' => 'field',
+      'key' => $field['name'],
+      'label' => $field['label'],
+      'sortable' => TRUE,
+      'break' => TRUE,
+    ], $fields);
+  }
+
+  protected function getButtonColumn($group) {
+    $groupName = $group['name'];
+    $entityName = $group['entity_name'];
+    return [
+      'size' => 'btn-xs',
+      'links' => [
+        [
+          'entity' => $entityName,
+          'action' => 'view',
+          'target' => 'crm-popup',
+          'icon' => 'fa-eye',
+          'text' => E::ts('View'),
+          'style' => 'default',
+        ],
+        [
+          // TODO: can we register this as the canonical Update link
+          'path' => "civicrm/af/custom/{$groupName}/update#?Record=[id]",
+          'target' => 'crm-popup',
+          'icon' => 'fa-pencil',
+          'text' => E::ts('Edit'),
+          'style' => 'warning',
+        ],
+        [
+          'entity' => $entityName,
+          'task' => 'delete',
+          'target' => 'crm-popup',
+          'icon' => 'fa-trash',
+          'text' => E::ts('Delete'),
+          'style' => 'danger',
+        ],
+      ],
+      'type' => 'buttons',
+      'alignment' => 'text-right',
+    ];
+  }
+
+  public static function getAllManaged() {
+    // for now we only fetch for Groups that have a Tab with table on the contact summary
+    $all = \Civi\Api4\CustomGroup::getSearchKit(FALSE)
+      ->addWhere('is_active', '=', TRUE)
+      ->addWhere('is_multiple', '=', TRUE)
+      ->addWhere('style', 'IN', ['Tab', 'Tab with table'])
+      ->addWhere('extends', 'IN', ['Contact', 'Individual', 'Household', 'Organization'])
+      ->execute()
+      ->column('managed');
+
+    return array_merge(...$all);
+  }
+
+}

--- a/ext/civicrm_admin_ui/Civi/Api4/Action/CustomGroup/GetSearchKit.php
+++ b/ext/civicrm_admin_ui/Civi/Api4/Action/CustomGroup/GetSearchKit.php
@@ -201,7 +201,7 @@ class GetSearchKit extends \Civi\Api4\Generic\BasicBatchAction {
           'target' => 'crm-popup',
           'icon' => 'fa-pencil',
           'text' => E::ts('Edit'),
-          'style' => 'warning',
+          'style' => 'default',
         ],
         [
           'entity' => $entityName,

--- a/ext/civicrm_admin_ui/Civi/Api4/Action/CustomGroup/GetSearchKit.php
+++ b/ext/civicrm_admin_ui/Civi/Api4/Action/CustomGroup/GetSearchKit.php
@@ -124,9 +124,14 @@ class GetSearchKit extends \Civi\Api4\Generic\BasicBatchAction {
           'saved_search_id.name' => $searchName,
           'type' => $displayType,
           'settings' => [
-            'limit' => 50,
             'placeholder' => 5,
             'columns' => $columns,
+            'pager' => [
+              'show_count' => TRUE,
+              'expose_limit' => TRUE,
+              'hide_single' => TRUE,
+            ],
+            'headerCount' => TRUE,
             // only for table but harmless otherwise
             'actions' => TRUE,
             'classes' => ['table', 'table-striped'],

--- a/ext/civicrm_admin_ui/Civi/Api4/Action/CustomGroup/GetSearchKit.php
+++ b/ext/civicrm_admin_ui/Civi/Api4/Action/CustomGroup/GetSearchKit.php
@@ -32,15 +32,10 @@ class GetSearchKit extends \Civi\Api4\Generic\BasicBatchAction {
     // SavedSearch and SearchDisplays
     $item['search_name'] = $item['entity_name'] . '_Search';
 
-    // get active fields for this group to include as columns
-    $item['fields'] = (array) \Civi\Api4\CustomField::get(FALSE)
-      ->addSelect('name', 'label', 'option_group_id')
-      ->addWhere('custom_group_id', '=', $item['id'])
-      ->addWhere('is_active', '=', TRUE)
-      // respect "Display in table" config on each field
-      // (Q: should we respect this for other displays?)
-      ->addWhere('in_selector', '=', TRUE)
-      ->execute();
+    // get Active + Display In Table fields for this group to include as columns
+    // note: `in_selector` is the field key for "display in table"
+    $activeFields = \CRM_Core_BAO_CustomGroup::getGroup(['id' => $item['id']])['fields'];
+    $item['fields'] = array_filter($activeFields, fn ($field) => $field['in_selector']);
 
     $managed = [];
 

--- a/ext/civicrm_admin_ui/Civi/Api4/Action/CustomGroup/GetSearchKit.php
+++ b/ext/civicrm_admin_ui/Civi/Api4/Action/CustomGroup/GetSearchKit.php
@@ -138,6 +138,19 @@ class GetSearchKit extends \Civi\Api4\Generic\BasicBatchAction {
             'actions_display_mode' => 'menu',
             // only for grid but harmless otherwise
             'colno' => '3',
+            'toolbar' => [
+              [
+                'action' => '',
+                'entity' => '',
+                'text' => E::ts('Add %1', [1 => $group['title']]),
+                'icon' => 'fa-plus',
+                'style' => 'default',
+                'target' => 'crm-popup',
+                'join' => '',
+                'path' => "civicrm/af/custom/{$group['name']}/create#?entity_id=[entity_id]",
+                'task' => '',
+              ],
+            ],
           ],
         ],
         'match' => [

--- a/ext/civicrm_admin_ui/Civi/Api4/Event/Subscriber/CustomGroupEntityLinks.php
+++ b/ext/civicrm_admin_ui/Civi/Api4/Event/Subscriber/CustomGroupEntityLinks.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Event\Subscriber;
+
+/**
+ * Register links for our new forms
+ */
+class CustomGroupEntityLinks extends \Civi\Core\Service\AutoSubscriber {
+
+  /**
+   * @return array
+   */
+  public static function getSubscribedEvents() {
+    return [
+      'civi.api4.entityTypes' => ['addCustomGroupLinks', \Civi\API\Events::W_LATE],
+    ];
+  }
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $event
+   */
+  public function addCustomGroupLinks(\Civi\Core\Event\GenericHookEvent $event) {
+    foreach ($event->entities as $name => $entity) {
+      if (strpos($name, 'Custom_') === 0) {
+        $groupName = substr($name, 7);
+        $event->entities[$name]['paths']['add'] = "civicrm/af/custom/{$groupName}/create#?entity_id=[entity_id]";
+        $event->entities[$name]['paths']['update'] = "civicrm/af/custom/{$groupName}/update#?Record=[id]";
+      }
+    }
+  }
+
+}

--- a/ext/civicrm_admin_ui/civicrm_admin_ui.php
+++ b/ext/civicrm_admin_ui/civicrm_admin_ui.php
@@ -60,3 +60,16 @@ function civicrm_admin_ui_civicrm_postProcess($className, $form) {
     CRM_Core_Session::singleton()->replaceUserContext($url);
   }
 }
+
+function civicrm_admin_ui_civicrm_managed(&$entities, $modules) {
+  if ($modules && !in_array(E::LONG_NAME, $modules, TRUE)) {
+    return;
+  }
+
+  $records = \Civi\Api4\Action\CustomGroup\GetSearchKit::getAllManaged();
+
+  foreach ($records as $record) {
+    $record['module'] = E::LONG_NAME;
+    $entities[] = $record;
+  }
+}

--- a/ext/civicrm_admin_ui/info.xml
+++ b/ext/civicrm_admin_ui/info.xml
@@ -30,6 +30,7 @@
   </civix>
   <mixins>
     <mixin>mgd-php@1.0.0</mixin>
+    <mixin>scan-classes@1.0.0</mixin>
   </mixins>
   <upgrader>CRM_CivicrmAdminUi_Upgrader</upgrader>
 </extension>


### PR DESCRIPTION
Overview
----------------------------------------
Following https://github.com/civicrm/civicrm-core/pull/31484 - this adds a SearchKit and tab for each CustomGroup where style = Tab with table

Before
----------------------------------------
Hard-coded Tab with table:
![image](https://github.com/user-attachments/assets/e9450c89-5c05-471d-93f0-9cf9311a0eee)


Error when adding a record (from @colemanw )
![image](https://github.com/user-attachments/assets/33222a39-44b1-490e-8ff3-b87345e3ccfe)


After
----------------------------------------
Generated afform tab:
![image](https://github.com/user-attachments/assets/57e8f72b-5337-4063-8ed3-d4bac11fb310)


Additional functionality:
- create form without weird error
- bulk actions
- tweakability through SearchKit / FormBuilder

e.g.

add a filter field:
![image](https://github.com/user-attachments/assets/bb699891-b7ae-466a-8976-c59d2dad9c74)

![image](https://github.com/user-attachments/assets/9f566d66-9f5f-469e-a8af-cc66a1df85d4)


Technical Details
----------------------------------------
For each multi-value Tab with table custom group, we generate:
- a SavedSearch managed record with active fields where `Display in table` is set
- a SearchDisplay managed record based on this SavedSearch, with the same columns 
- a search-type Afform with the necessary meta to displace the existing custom group tab (*)

There's a bit of back-n-forth in terms of the interplay between `afform_core` and `civicrm_admin_ui`:

 The SearchKit bits are added in `civicrm_admin_ui` only.

The code for Afform generation is added to CustomGroup.GetAfforms action, which is implemented in `afform_core` because it includes the Custom Group blocks, which are already provided by `afform_core`. But generating the additional forms is gated based on having `civicrm_admin_ui` enabled. (These forms depend on the search kit bits from `civicrm_admin_ui`.)

(*) - this required small patch to the tabset hook in afform, because it uses a convention for displacing tabs based on matching the afform name to the existing tab ID. But I really wanted the new afforms to use the CustomGroup *name*, whereas the existing tabs are keyed by the custom group *id*.

The whole thing lends itself to more generalisability. I've tried to structure in a way that supports some of the next steps below. 


Questions
-----------------------------------------
Permissions: 
- for the create/update forms, I'm hopeful RBAC on the entities is providing the guard we need
- here I've used 'access all custom data' but I'm not too sure if that is right?

Deprecation:
- I've not replicated the Copy button on each row. Is it useful? (If so, I think it might be something to implement more generally in afform: some variant path to Prefill where you are prefilling with the copyable fields from another entity)


Next steps
---------------------------------------------
- EntityRef fields will display as IDs for now, would be good to pick a better column
-  I think it should be fairly trivial to add a "grid" style tab where style = Tab.
- it shouldn't be much of a leap to e.g. add tabs for Event CustomGroups to the event tabset
- I'd like to add a general listing/directory page for any multi-record CustomGroup, no matter what entity it extends
