### PR TITLE
dev/core#5620 [REF] Update Spreadsheet download action to work with PHPSpreadsheet v2

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
@@ -179,14 +179,14 @@ class Download extends AbstractRunAction {
 
     // Header row
     foreach (array_values($columns) as $index => $col) {
-      $sheet->setCellValueByColumnAndRow($index + 1, 1, $col['label']);
+      $sheet->setCellValue([$index + 1, 1], $col['label']);
       $sheet->getColumnDimensionByColumn($index)->setAutoSize(TRUE);
     }
 
     foreach ($rows as $rowNum => $data) {
       $colNum = 1;
       foreach ($columns as $index => $col) {
-        $sheet->setCellValueByColumnAndRow($colNum++, $rowNum + 2, $this->formatColumnValue($col, $data['columns'][$index]));
+        $sheet->setCellValue([$colNum++, $rowNum + 2], $this->formatColumnValue($col, $data['columns'][$index]));
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
setCellValueByColumnAndRow has been removed in v2 of PHPSpreadsheet

Before
----------------------------------------
Fatal error using V2 of PHPSpreadsheet

After
----------------------------------------
No Fatal error

ping @demeritcowboy 