### PR TITLE
fix end date field in campaign form

### DIFF
--- a/CRM/Campaign/Form/Campaign.php
+++ b/CRM/Campaign/Form/Campaign.php
@@ -124,7 +124,7 @@ class CRM_Campaign_Form_Campaign extends CRM_Core_Form {
       'title' => ['name' => 'title'],
       'description' => ['name' => 'description'],
       'start_date' => ['name' => 'start_date', 'default' => date('Y-m-d H:i:s')],
-      'end_date' => ['name' => 'start_date'],
+      'end_date' => ['name' => 'end_date'],
       'campaign_type_id' => ['name' => 'campaign_type_id'],
       'status_id' => ['name' => 'status_id'],
       'goal_general' => ['name' => 'goal_general'],


### PR DESCRIPTION
Overview
----------------------------------------
A small typo causes the form field for the end date not to load when editing a campaign. If this is not noticed and the form is saved, the end date of the campaign is lost.

Before
----------------------------------------

- create a new campaign and set an end date
- save the campaign
- edit it again
- the end date **is not** displayed in the form

After
----------------------------------------

- create a new campaign and set an end date
- save the campaign
- edit it again
- the end date **is** displayed in the form

Comments
----------------------------------------
Technically, the `parent_id` is also missing in the form data (see MarcMichalsky/civicrm-core@84ef687459fe496d9386d19d030823efed23a5c2). Even if this is intentional, it causes problems in other extensions (systopia/de.systopia.campaign#125). Should I create a separate PR for this?
