### PR TITLE
dev/core#5622 Afform conditionals: loosen type comparison on "CONTAINS"

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -195,7 +195,7 @@
           case 'CONTAINS':
           case 'NOT CONTAINS':
             if (Array.isArray(val1)) {
-              return val1.includes(val2) === yes;
+              return val1.some(element => element == val2) === yes;
             } else if (typeof val1 === 'string' && typeof val2 === 'string') {
               return val1.toLowerCase().includes(val2.toLowerCase()) === yes;
             }


### PR DESCRIPTION
Overview
----------------------------------------
Too-strict comparison was causing FormBuilder conditional field behavior to fail. See [dev/core#5622](https://lab.civicrm.org/dev/core/-/issues/5622)

Before
----------------------------------------
Conditional fields don't work when they depend on a multi-select field using an integer data type.

After
----------------------------------------
Conditionals work.

Technical Details
----------------------------------------
The problem was here:
<img width="714" alt="Screenshot 2024-11-22 at 12 54 58" src="https://github.com/user-attachments/assets/5019a4fe-d2b3-4de6-8e14-1c1c54861557">

Note that `val1[0]` is a string, and `val2` is an int. The `includes` function uses strict comparison, so it was returning a non-match.
