### PR TITLE
ClassLoader - Fix loading when using composer `path` repository (symlink mode) with CLI

### DIFF
--- a/CRM/Core/ClassLoader.php
+++ b/CRM/Core/ClassLoader.php
@@ -87,8 +87,8 @@ class CRM_Core_ClassLoader {
     // civicrm-core directory. However, if civicrm-core was installed via
     // composer as a library, that'll be 5 directories up where composer was
     // run (ex. the Drupal root on a Drupal 8 site).
-    $civicrm_base_path = dirname(dirname(__DIR__));
-    $top_path = dirname(dirname(dirname(dirname(dirname(__DIR__)))));
+    $civicrm_base_path = $GLOBALS['civicrm_root'] ?? dirname(dirname(__DIR__));
+    $top_path = dirname(dirname(dirname($civicrm_base_path)));
 
     if (file_exists($civicrm_base_path . '/vendor/autoload.php')) {
       require_once $civicrm_base_path . '/vendor/autoload.php';
@@ -110,7 +110,7 @@ class CRM_Core_ClassLoader {
     if ($this->_registered) {
       return;
     }
-    $civicrm_base_path = dirname(dirname(__DIR__));
+    $civicrm_base_path = $GLOBALS['civicrm_root'] ?? dirname(dirname(__DIR__));
 
     $this->requireComposerAutoload();
 


### PR DESCRIPTION
Overview
----------------------------------------

Generally, this helps composer-style sites (D8/9/10/11) use composer's [`path` repository option](https://getcomposer.org/doc/05-repositories.md#path). The `path` option helps you incorporate a local working-copy of the source-code into a more complex composer site-build. `composer` often implements this option using *symlinks*.

This PR is a step toward enabling https://github.com/civicrm/civicrm-buildkit/pull/891 and https://github.com/civicrm/civicrm-core/pull/31498 for https://lab.civicrm.org/dev/core/-/issues/5611. (cc @colemanw @demeritcowboy)

Steps to Reproduce
----------------------------------------

Create a composer-based D10 site on a POSIX host. It should use a `path` repository with symlinks enabled. 

<details>
<summary>Details: composer.json example snippet</summary>

```
    "repositories": {
        "civicrm-packages": {
            "type": "path",
            "url": "./src/civicrm-packages",
            "options": {
                "symlink": true
            }
        },
        "civicrm-drupal-8": {
            "type": "path",
            "url": "./src/civicrm-drupal-8",
            "options": {
                "symlink": true
            }
        },
        "civicrm-core": {
            "type": "path",
            "url": "./src/civicrm-core",
            "options": {
                "symlink": true
            }
        },
        "0": {
            "type": "composer",
            "url": "https://packages.drupal.org/8"
        }
    },
    "require": {
        "civicrm/civicrm-core": "dev-master",
        "civicrm/civicrm-drupal-8": "dev-master",
        "civicrm/civicrm-packages": "dev-master",
        "composer/installers": "^2.0",
        "drupal/core-composer-scaffold": "^10.3",
        "drupal/core-project-message": "^10.3",
        "drupal/core-recommended": "^10.3",
        "drupal/userprotect": "^1.3",
        "drush/drush": "13.3.1"
    },
```

NOTE: The `options.symlink` should optional. I believe as composer's current default on POSIX hosts willk enable symlinks.

</details>

To make  such a build with civicrm-buildkit, apply  civicrm-buildkit#891 and make a `drupal10-dev` instance:

```
civibuild download tmpd10 --type drupal10-dev
civibuild install tmpd10
```

Before
----------------------------------------

While installing the site, some major steps succeed, but the install overall fails. Specifically, some calls to `cv` fail. The problem affects anything using Civi's traditional CLI bootstrap (Civi-first). Here's the symptom I see:

```
[PHP Warning] require_once(Log.php): Failed to open stream: No such file or directory at /home/totten/bknix/build/tmpd10/src/civicrm-core/CRM/Core/Config.php:24

In Config.php line 24:
                                                                                                                                                                                              
  [Error]                                                                                                                                                                                     
  Failed opening required 'Log.php' (include_path='.:/home/totten/bknix/build/tmpd10/vendor:/home/totten/bknix/build/tmpd10/vendor/packages:.:/home/totten/bknix/build/tmpd10/vendor/civicrm  
  /civicrm-core/:/home/totten/bknix/build/tmpd10/vendor/civicrm/civicrm-core//packages:.:/nix/store/2zsvr8r307lbz3dv6b1bm9xr9ss794gm-php-8.2.6/lib/php')                                      
                                                                                                                                                                                              

Exception trace:
  at /home/totten/bknix/build/tmpd10/src/civicrm-core/CRM/Core/Config.php:24
 require_once() at /home/totten/bknix/build/tmpd10/src/civicrm-core/CRM/Core/ClassLoader.php:171
 CRM_Core_ClassLoader->loadClass() at /home/totten/src/cv/lib/src/Bootstrap.php:240
 Civi\Cv\Bootstrap->boot() at /home/totten/src/cv/lib/src/Util/BootTrait.php:180
 Civi\Cv\Command\CvCommand->_boot_full() at n/a:n/a
 call_user_func() at /home/totten/src/cv/lib/src/Util/BootTrait.php:118
 Civi\Cv\Command\CvCommand->boot() at /home/totten/src/cv/lib/src/Util/BootTrait.php:76
 Civi\Cv\Command\CvCommand->autoboot() at /home/totten/src/cv/lib/src/Command/CvCommand.php:33

```

The underlying problem is that `CRM_Core_ClassLoader::requireComposerAutoload()` failed to locate the true `vendor/autoload.php`, and so some kinds of autoloading don't work.

After
----------------------------------------

`requireComposerAutoload()` should find the true `vendor/autoload.php`. CLI commands should work. Install should complete.

Comments
----------------------------------------

* IMHO, the main regression-risk to look out for would be in other build-layouts, e.g. `drupal10-demo` or Joomla.

* There is no direct test-coverage in this PR. However, once we merge the related PRs, there will be coverage in that our test-jobs and demo-sites will use a mix of configurations (including `drupal10-dev` and `drupal10-demo`).

* An alternative patch is https://github.com/civicrm/civicrm-core/compare/master...totten:civicrm-core:master-d10-sym-cli-b?expand=1. This patch looks cleaner. In theory, if there were other edge-cases where `$civicrm_root` and `dirname(dirname(__DIR__))` disagree, then the other patch might provide better continuity. I mention it more as contingency if this patch doesn't work out. This patch is simpler.