### PR TITLE
Api4 - Case-insensitive matching for arrayQuery entities

### DIFF
--- a/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
+++ b/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
@@ -127,6 +127,13 @@ trait ArrayQueryActionTrait {
       case '=':
       case '!=':
       case '<>':
+        // For parity with SQL operators, do case-insensitive matching
+        if (is_string($value)) {
+          $value = strtolower($value);
+        }
+        if (is_string($expected)) {
+          $expected = strtolower($expected);
+        }
         $equal = $value == $expected;
         // PHP is too imprecise about comparing the number 0
         if ($expected === 0 || $expected === '0') {

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -172,6 +172,13 @@
           case '!=':
           // Legacy operator, changed to '=', but may still exist on older forms.
           case '==':
+            // Case-insensitive string comparisons
+            if (typeof val1 === 'string') {
+              val1 = val1.toLowerCase();
+            }
+            if (typeof val2 === 'string') {
+              val2 = val2.toLowerCase();
+            }
             return angular.equals(val1, val2) === yes;
 
           case '>':

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformConditionalUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformConditionalUsageTest.php
@@ -30,11 +30,11 @@ EOHTML;
     ]);
 
     // Conditional rule is that last_name is required
-    // IF first_name = A (case-sensitive) OR first_name CONTAINS "bc" (case-insensitive)
+    // IF first_name = a (case-insensitive) OR first_name CONTAINS "bc" (case-insensitive)
 
     // Conditional field shown: this will fail validation
     $submission = [
-      ['fields' => ['first_name' => 'A', 'last_name' => '']],
+      ['fields' => ['first_name' => 'a', 'last_name' => '']],
     ];
     try {
       Afform::submit()
@@ -62,7 +62,7 @@ EOHTML;
 
     // Conditional field hidden: this will pass validation
     $submission = [
-      ['fields' => ['first_name' => 'a', 'last_name' => '']],
+      ['fields' => ['first_name' => 'q', 'last_name' => '']],
     ];
     $result = Afform::submit()
       ->setName($this->formName)

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -1630,7 +1630,7 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
 
     $result = civicrm_api4('SearchDisplay', 'run', $params);
     $this->assertCount(3, $result);
-    $data = array_column(array_column((array) $result, 'data'), 'COUNT_id', 'contact_type:label');
+    $data = array_column($result->column('data'), 'COUNT_id', 'contact_type:label');
     $this->assertEquals(3, $data['Individual']);
     $this->assertEquals(2, $data['Organization']);
     $this->assertEquals(1, $data['Household']);
@@ -1726,7 +1726,7 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
 
     $result = civicrm_api4('SearchDisplay', 'run', $params);
     $this->assertCount(2, $result);
-    $data = array_column(array_column((array) $result, 'data'), 'COUNT_id');
+    $data = array_column($result->column('data'), 'COUNT_id');
     sort($data);
     $this->assertEquals([1, 2], $data);
   }

--- a/tests/phpunit/api/v4/Action/GetFromArrayTest.php
+++ b/tests/phpunit/api/v4/Action/GetFromArrayTest.php
@@ -27,6 +27,10 @@ use Civi\Api4\MockArrayEntity;
  */
 class GetFromArrayTest extends Api4TestBase {
 
+  /**
+   * Test get with existing dataset
+   * @see \Civi\Api4\Action\MockArrayEntity\Get::getRecords
+   */
   public function testArrayGetWithLimit(): void {
     $result = MockArrayEntity::get()
       ->setOffset(2)
@@ -40,25 +44,33 @@ class GetFromArrayTest extends Api4TestBase {
     $this->assertCount(6, $result);
   }
 
+  /**
+   * Test get with existing dataset
+   * @see \Civi\Api4\Action\MockArrayEntity\Get::getRecords
+   */
   public function testArrayGetWithSort(): void {
     $result = MockArrayEntity::get()
       ->addOrderBy('field1', 'DESC')
       ->execute();
-    $this->assertEquals([6, 5, 4, 3, 2, 1], array_column((array) $result, 'field1'));
+    $this->assertEquals([6, 5, 4, 3, 2, 1], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addOrderBy('field5', 'DESC')
       ->addOrderBy('field2', 'ASC')
       ->execute();
-    $this->assertEquals([3, 2, 5, 4, 1, 6], array_column((array) $result, 'field1'));
+    $this->assertEquals([3, 2, 5, 4, 1, 6], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addOrderBy('field3', 'ASC')
       ->addOrderBy('field2', 'ASC')
       ->execute();
-    $this->assertEquals([3, 1, 2, 5, 4, 6], array_column((array) $result, 'field1'));
+    $this->assertEquals([3, 1, 2, 5, 4, 6], $result->column('field1'));
   }
 
+  /**
+   * Test get with existing dataset
+   * @see \Civi\Api4\Action\MockArrayEntity\Get::getRecords
+   */
   public function testArrayGetWithSelect(): void {
     $result = MockArrayEntity::get()
       ->addSelect('field1')
@@ -85,67 +97,71 @@ class GetFromArrayTest extends Api4TestBase {
     ], (array) $result);
   }
 
+  /**
+   * Test where clause with existing dataset
+   * @see \Civi\Api4\Action\MockArrayEntity\Get::getRecords
+   */
   public function testArrayGetWithWhere(): void {
     $result = MockArrayEntity::get()
       ->addWhere('field2', '=', 'yack')
       ->execute();
-    $this->assertEquals([2], array_column((array) $result, 'field1'));
+    $this->assertEquals([2], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addWhere('field5', '!=', 'banana')
       ->addWhere('field3', 'IS NOT NULL')
       ->execute();
-    $this->assertEquals([4, 5, 6], array_column((array) $result, 'field1'));
+    $this->assertEquals([4, 5, 6], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addWhere('field1', '>=', '4')
       ->execute();
-    $this->assertEquals([4, 5, 6], array_column((array) $result, 'field1'));
+    $this->assertEquals([4, 5, 6], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addWhere('field1', '<', '2')
       ->execute();
-    $this->assertEquals([1], array_column((array) $result, 'field1'));
+    $this->assertEquals([1], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addWhere('field2', 'LIKE', '%ra%')
       ->execute();
-    $this->assertEquals([1, 3], array_column((array) $result, 'field1'));
+    $this->assertEquals([1, 3], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addWhere('field2', 'REGEXP', '(zebra|yac[a-z]|something/else)')
       ->execute();
-    $this->assertEquals([1, 2, 6], array_column((array) $result, 'field1'));
+    $this->assertEquals([1, 2, 6], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addWhere('field2', 'NOT REGEXP', '^[x|y|z]')
       ->execute();
-    $this->assertEquals([4, 5], array_column((array) $result, 'field1'));
+    $this->assertEquals([4, 5], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addWhere('field2', 'REGEXP BINARY', 'Yack')
       ->execute();
-    $this->assertEquals([6], array_column((array) $result, 'field1'));
+    $this->assertEquals([6], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addWhere('field5', 'NOT REGEXP BINARY', 'Apple')
       ->execute();
-    $this->assertEquals([1, 2, 3, 4, 5], array_column((array) $result, 'field1'));
+    $this->assertEquals([1, 2, 3, 4, 5], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addWhere('field3', 'IS NULL')
       ->execute();
-    $this->assertEquals([1, 3], array_column((array) $result, 'field1'));
+    $this->assertEquals([1, 3], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addWhere('field3', '=', '0')
       ->execute();
-    $this->assertEquals([2], array_column((array) $result, 'field1'));
+    $this->assertEquals([2], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addWhere('field2', 'LIKE', '%ra')
       ->execute();
-    $this->assertEquals([1], array_column((array) $result, 'field1'));
+    $this->assertEquals([1], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addWhere('field2', 'LIKE', 'ra')
@@ -155,45 +171,49 @@ class GetFromArrayTest extends Api4TestBase {
     $result = MockArrayEntity::get()
       ->addWhere('field2', 'NOT LIKE', '%ra%')
       ->execute();
-    $this->assertEquals([2, 4, 5, 6], array_column((array) $result, 'field1'));
+    $this->assertEquals([2, 4, 5, 6], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addWhere('field6', '=', '0')
       ->execute();
-    $this->assertEquals([3, 4, 5, 6], array_column((array) $result, 'field1'));
+    $this->assertEquals([3, 4, 5, 6], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addWhere('field1', 'BETWEEN', [3, 5])
       ->execute();
-    $this->assertEquals([3, 4, 5], array_column((array) $result, 'field1'));
+    $this->assertEquals([3, 4, 5], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addWhere('field1', 'NOT BETWEEN', [3, 4])
       ->execute();
-    $this->assertEquals([1, 2, 5, 6], array_column((array) $result, 'field1'));
+    $this->assertEquals([1, 2, 5, 6], $result->column('field1'));
   }
 
+  /**
+   * Test complex where clause with existing dataset
+   * @see \Civi\Api4\Action\MockArrayEntity\Get::getRecords
+   */
   public function testArrayGetWithNestedWhereClauses(): void {
     $result = MockArrayEntity::get()
       ->addClause('OR', ['field2', 'LIKE', '%ra'], ['field2', 'LIKE', 'x ray'])
       ->execute();
-    $this->assertEquals([1, 3], array_column((array) $result, 'field1'));
+    $this->assertEquals([1, 3], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addClause('OR', ['field2', '=', 'zebra'], ['field2', '=', 'yack'])
       ->addClause('OR', ['field5', '!=', 'apple'], ['field3', 'IS NULL'])
       ->execute();
-    $this->assertEquals([1, 2], array_column((array) $result, 'field1'));
+    $this->assertEquals([1, 2], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addClause('NOT', ['field2', '!=', 'yack'])
       ->execute();
-    $this->assertEquals([2], array_column((array) $result, 'field1'));
+    $this->assertEquals([2], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addClause('OR', ['field1', '=', 2], ['AND', [['field5', '=', 'apple'], ['field3', '=', 1]]])
       ->execute();
-    $this->assertEquals([2, 4, 5], array_column((array) $result, 'field1'));
+    $this->assertEquals([2, 4, 5], $result->column('field1'));
   }
 
 }

--- a/tests/phpunit/api/v4/Action/GetFromArrayTest.php
+++ b/tests/phpunit/api/v4/Action/GetFromArrayTest.php
@@ -105,7 +105,7 @@ class GetFromArrayTest extends Api4TestBase {
     $result = MockArrayEntity::get()
       ->addWhere('field2', '=', 'yack')
       ->execute();
-    $this->assertEquals([2], $result->column('field1'));
+    $this->assertEquals([2, 6], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addWhere('field5', '!=', 'banana')
@@ -208,12 +208,12 @@ class GetFromArrayTest extends Api4TestBase {
     $result = MockArrayEntity::get()
       ->addClause('NOT', ['field2', '!=', 'yack'])
       ->execute();
-    $this->assertEquals([2], $result->column('field1'));
+    $this->assertEquals([2, 6], $result->column('field1'));
 
     $result = MockArrayEntity::get()
       ->addClause('OR', ['field1', '=', 2], ['AND', [['field5', '=', 'apple'], ['field3', '=', 1]]])
       ->execute();
-    $this->assertEquals([2, 4, 5], $result->column('field1'));
+    $this->assertEquals([2, 4, 5, 6], $result->column('field1'));
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Normalizes case-sensitivity across Api4 entities. This also affects Afform conditionals, to make the `=` and `!=` operators case-insensitive.

Before
----------------------------------------
Mismatch between the behavior of `=` and `!=` in different API entities:
- In a regular sql-based entity, the operators are case-insensitive
- In other entities (like Afform) they are case-sentitive

After
----------------------------------------
Always case-insensitive unless using the BINARY operators.

Comments
----------------------------------------
Includes test cleanup in a separate commit.