### PR TITLE
Api4 - Allow anonymous access to 'Contact::validateChecksum'

### DIFF
--- a/Civi/Api4/Contact.php
+++ b/Civi/Api4/Contact.php
@@ -124,11 +124,14 @@ class Contact extends Generic\DAOEntity {
   }
 
   /**
-   * @inheritDoc
+   * Override base method so it can be shared with Individual, Household, Organization APIs.
    */
   public static function permissions() {
-    $permissions = \CRM_Core_Permission::getEntityActionPermissions();
-    return ($permissions['contact'] ?? []) + $permissions['default'];
+    $allPermissions = \CRM_Core_Permission::getEntityActionPermissions();
+    $permissions = ($allPermissions['contact'] ?? []) + $allPermissions['default'];
+    // Checksums are meant for anonymous use
+    $permissions['validateChecksum'] = [];
+    return $permissions;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Opens up permission for an api action that is meant for anonymous use.

Before
----------------------------------------
API requires 'administer CiviCRM' to check a checksum.

After
----------------------------------------
Anyone can do it.

Technical Details
-------
I don't see any problem opening this up, as Civi forms already do this for anonymous users (event registration forms, contribution forms, etc).