### PR TITLE
[REF] Fix setting mailing start date when the parent job starts "runn…

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -84,7 +84,7 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
       // Select the first child job that is scheduled
       // CRM-6835
       $query = "
-      SELECT   j.*, m.start_date as mailing_start_date, m.end_date  as mailing_end_date, m.status  as mailing_status
+      SELECT   j.*
         FROM   civicrm_mailing_job     j,
            civicrm_mailing m
        WHERE   m.id = j.mailing_id AND m.domain_id = {$domainID}
@@ -156,13 +156,6 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
           'start_date' => date('YmdHis'),
           'status' => 'Running',
         ])->execute();
-        if (empty($testParams) && empty($result->mailing_start_date)) {
-          Mailing::update(FALSE)->setValues([
-            'id' => $result->mailing_id,
-            'start_date' => $startDate,
-            'status' => 'Running',
-          ])->execute();
-        }
 
         $transaction->commit();
       }
@@ -354,6 +347,12 @@ class CRM_Mailing_BAO_MailingJob extends CRM_Mailing_DAO_MailingJob {
       // Update the status of the parent job
       MailingJob::update(FALSE)->setValues([
         'id' => $job->id,
+        'start_date' => 'now',
+        'status' => 'Running',
+      ])->execute();
+      // Update Mailing record as we have now started the sending process
+      Mailing::update(FALSE)->setValues([
+        'id' => $job->mailing_id,
         'start_date' => 'now',
         'status' => 'Running',
       ])->execute();


### PR DESCRIPTION
…ing" for delivery rather than when a child job is picked up

Overview
----------------------------------------
When a system has multiple concurrent mailing job processes it is possible that the mailing jobs can cause contention on the civicrm_mailing table as each one simultaneously tries updating the mailing table with it's start date. The correct idea should be In my opinion that when the parent job is updated to be running that the mailing table start date is set to that

Before
----------------------------------------
mailing table start date is set when the child jobs are being processed

After
----------------------------------------
mailing table start date is set when the parent job is being processed

ping @eileenmcnaughton @johntwyman @andrew-cormick-dockery 