### PR TITLE
add parent_id to campaign form entity fields

### DIFF
--- a/CRM/Campaign/Form/Campaign.php
+++ b/CRM/Campaign/Form/Campaign.php
@@ -127,6 +127,7 @@ class CRM_Campaign_Form_Campaign extends CRM_Core_Form {
       'end_date' => ['name' => 'end_date'],
       'campaign_type_id' => ['name' => 'campaign_type_id'],
       'status_id' => ['name' => 'status_id'],
+      'parent_id' => ['name' => 'parent_id'],
       'goal_general' => ['name' => 'goal_general'],
       'goal_revenue' => ['name' => 'goal_revenue'],
       'external_identifier' => ['name' => 'external_identifier'],


### PR DESCRIPTION
Overview
----------------------------------------

In 871b9f1, a list of campaign entity fields has been added to the campaign form, which does not include the `parent_id` field.

Before
----------------------------------------

- The campaign form (core) works fine
- The `parent_id` is not included in the form data
- The `parent_id` cannot be retrieved in a `buildForm` hook via `$form->get('values')`
- The [de.systopia.campaign](https://github.com/systopia/de.systopia.campaign) extension does not display the `parent_id` correctly

After
----------------------------------------
- The campaign form (core) works fine
- The `parent_id` is included in the form data and can be retrieved from it within a hook
- The [de.systopia.campaign](https://github.com/systopia/de.systopia.campaign) extension does display the `parent_id` correctly

Comments
----------------------------------------

Although the `parent_id` field is [not currently displayed](https://github.com/civicrm/civicrm-core/blob/8b0b1d725377221ed07f505f60223d765dccfc23/templates/CRM/Campaign/Form/Campaign.tpl#L59-L64), this also makes the field data unavailable via hook (see PR systopia/de.systopia.campaign#125)). This behaviour may be intentional, but I find it confusing and unexpected. So you might want to consider including the field there.
