### PR TITLE
Perform custom field cascade deletion independent of user's permissions

### DIFF
--- a/Civi/Custom/EventSubscriber/FkEntityDeleteSubscriber.php
+++ b/Civi/Custom/EventSubscriber/FkEntityDeleteSubscriber.php
@@ -26,6 +26,8 @@ final class FkEntityDeleteSubscriber extends AutoSubscriber {
     foreach ($this->getReferenceFieldNames($fkEntity, 'cascade') as $entity => $referenceFieldName) {
       civicrm_api4($entity, 'delete', [
         'where' => [[$referenceFieldName, '=', $id]],
+        // Cascade deletion shall be performed independent of current user's permissions.
+        'checkPermissions' => FALSE,
       ]);
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Perform custom field cascade deletion independent of current users' permissions.

Before
----------------------------------------
In #28225 cascade deletion for custom fields was introduced. Currently the current user has to have the permission to delete the entity that should be deleted because of a cascade deletion.

After
----------------------------------------
Custom field cascade deletions are performed independent of current user's permissions. Thereby it behaves more like a cascade deletion on database level which is independent of CiviCRM permissions.
