### PR TITLE
[REF] Ensure that when copying a mailing the status is reset to draft…

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1079,6 +1079,9 @@ ORDER BY   civicrm_email.is_bulkmail DESC
         'created_date' => date('YmdHis'),
         'scheduled_date' => NULL,
         'approval_date' => NULL,
+        'status' => 'Draft',
+        'start_date' => NULL,
+        'end_date' => NULL,
       ];
 
       // Get the default from email address, if not provided.
@@ -1919,6 +1922,9 @@ LEFT JOIN civicrm_mailing_group g ON g.mailing_id   = m.id
       $params['resubscribe_id'] ??= CRM_Mailing_PseudoConstant::defaultComponent('Resubscribe', '');
       $params['unsubscribe_id'] ??= CRM_Mailing_PseudoConstant::defaultComponent('Unsubscribe', '');
       $params['mailing_type'] ??= 'standalone';
+      $params['status'] ??= 'Draft';
+      $params['start_date'] ??= 'null';
+      $params['end_date'] ??= 'null';
     }
     if ($event->action === 'delete' && $event->id) {
       // Delete all file attachments

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -156,6 +156,9 @@ function civicrm_api3_mailing_clone($params) {
     'is_archived',
     'hash',
     'mailing_type',
+    'start_date',
+    'end_date',
+    'status',
   ];
 
   $get = civicrm_api3('Mailing', 'getsingle', ['id' => $params['id']]);


### PR DESCRIPTION
… and start date and end date are blanked out

Overview
----------------------------------------
it was reported to me that when copying a mailing the start date and end date were being copied as part of that process. I think status should also be re-set as well

Before
----------------------------------------
Start and End dates copied when cloning a mailing

After
----------------------------------------
fields not copied

@andrew-cormick-dockery @johntwyman @eileenmcnaughton @demeritcowboy 