### PR TITLE
APIv4 - Fix filtering on Route API (etal) using LIKE operator

### DIFF
--- a/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
+++ b/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
@@ -165,6 +165,9 @@ trait ArrayQueryActionTrait {
 
       case 'LIKE':
       case 'NOT LIKE':
+        if ($value === NULL) {
+          return FALSE;
+        }
         $pattern = '/^' . str_replace('%', '.*', preg_quote($expected, '/')) . '$/i';
         return !preg_match($pattern, $value) == ($operator != 'LIKE');
 
@@ -172,6 +175,10 @@ trait ArrayQueryActionTrait {
       case 'NOT REGEXP':
       case 'REGEXP BINARY':
       case 'NOT REGEXP BINARY':
+        if ($value === NULL) {
+          return FALSE;
+        }
+
         // Perform case-sensitive matching for BINARY operator, otherwise insensitive
         $i = str_ends_with($operator, 'BINARY') ? '' : 'i';
         $pattern = '/' . str_replace('/', '\\/', $expected) . "/$i";

--- a/Civi/Api4/Route.php
+++ b/Civi/Api4/Route.php
@@ -33,6 +33,10 @@ class Route extends Generic\AbstractEntity {
       $result = [];
       // Pulling from ::items() rather than DB -- because it provides the final/live/altered data.
       foreach (\CRM_Core_Menu::items() as $path => $item) {
+        if (isset($item['page_callback']) && is_array($item['page_callback'])) {
+          // Satisfy declared field-type ("String") and match literal config values (xml/Menu/*.xml).
+          $item['page_callback'] = implode('::', $item['page_callback']);
+        }
         $result[] = ['path' => $path] + $item;
       }
       return $result;

--- a/tests/phpunit/api/v4/Entity/RouteTest.php
+++ b/tests/phpunit/api/v4/Entity/RouteTest.php
@@ -33,6 +33,21 @@ class RouteTest extends Api4TestBase {
 
     $result = Route::get()->addWhere('path', 'LIKE', 'civicrm/admin/%')->execute();
     $this->assertGreaterThan(10, $result->count());
+    $this->assertTrue(str_starts_with($result[0]['path'], 'civicrm/admin/'));
+
+    $result = Route::get()->addWhere('page_callback', 'LIKE', 'CRM_Contact_%')->execute();
+    $this->assertGreaterThan(10, $result->count());
+    $this->assertTrue(str_starts_with($result[0]['page_callback'], 'CRM_Contact_'));
+
+    $result = Route::get()->addWhere('page_callback', 'REGEXP', 'CRM_Contact_.*')->execute();
+    $this->assertGreaterThan(10, $result->count());
+    $this->assertTrue(str_starts_with($result[0]['page_callback'], 'CRM_Contact_'));
+
+    $result = Route::get()->addWhere('page_arguments', 'LIKE', 'url=%')->execute();
+    $this->assertGreaterThan(1, $result->count());
+
+    $result = Route::get()->addWhere('path_arguments', 'LIKE', 'action=%')->execute();
+    $this->assertGreaterThan(1, $result->count());
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

Suppose you  issue a request like:

```
cv api4 Route.get -T +w 'page_callback LIKE CRM_Admin%'
```

This request is legal and should not cause any warnings/errors.

Before
----------------------------------------

The request emits a warning (php74) or failure (php83):

```
TypeError : preg_match(): Argument #2 ($subject) must be of type string, array given
 /home/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php:169
```

There are two reasons why it presents these kinds of failures:

* ___Null Scenario___: On some records, `page_callback` is `NULL`. There's a general problem in the implementation of `LIKE` operator for array-based entities which causes this to fail.
* ___Array Scenario___: On some records, `page_callback` has been converted to an array. (The original value is a string, and the defined data-type is a string, and most results are strings... but *some* value are arrays.)

After
----------------------------------------

The query `page_callback LIKE CRM_Admin%` is runnable. The two edge-cases are addressed like so:

* ___Null Scenario___: It is perfectly legit to query nullable-strings with LIKE operator. Array-based entities should LIKE in the same way as SQL-based entities. (In SQL, `null LIKE "pattern"` ==> `FALSE`.)
* ___Array Scenario___: `page_callback` should not be an array. If the callback is a static-method, then it should be in string-form.

Comments
----------------------------------------

Is it bad for `Route.get` to return a simple `string` instead of `string|array`? Well, the Route API was mainly implemented to support manual inspection. (*And for that usage, it doesn't matter.*) I did search universe to see if anything might be upset with normalizing the upset. (Specifically, find any lines like `route.*get`. There are a dozen matching files, and I read each one. None of them actually used APIv4's Route.get.)