### PR TITLE
SearchKit - Add search templates feature

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveEightyOne.php
+++ b/CRM/Upgrade/Incremental/php/FiveEightyOne.php
@@ -29,6 +29,15 @@ class CRM_Upgrade_Incremental_php_FiveEightyOne extends CRM_Upgrade_Incremental_
    */
   public function upgrade_5_81_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask('Add SavedSearch.is_template column', 'alterSchemaField', 'SavedSearch', 'is_template', [
+      'title' => ts('Template'),
+      'sql_type' => 'boolean',
+      'input_type' => 'CheckBox',
+      'required' => TRUE,
+      'description' => ts('Search templates are used as a starting point for building new searches'),
+      'add' => '5.81',
+      'default' => FALSE,
+    ]);
   }
 
 }

--- a/Civi/Api4/Generic/AbstractGetAction.php
+++ b/Civi/Api4/Generic/AbstractGetAction.php
@@ -12,6 +12,8 @@
 
 namespace Civi\Api4\Generic;
 
+use Civi\Api4\Utils\CoreUtil;
+
 /**
  * Base class for all `Get` api actions.
  *
@@ -34,13 +36,21 @@ abstract class AbstractGetAction extends AbstractQueryAction {
   /**
    * Adds field defaults to the where clause.
    *
-   * Note: it will skip adding field defaults when fetching records by id,
+   * This is of questionable value, but locked in by tests so we're stuck with it:
+   * APIv4.get automatically adds certain default conditions to the WHERE clause,
+   * e.g. `domain_id = current_domain` or `is_template = 0`.
+   *
+   * For the source of these defaults,
+   * @see GetActionDefaultsProvider
+   *
+   * Note: this will skip adding field defaults when fetching records by a unique field like name or id,
    * or if that field has already been added to the where clause.
    *
    * @throws \CRM_Core_Exception
    */
   public function setDefaultWhereClause() {
-    if (!$this->_itemsToGet('id')) {
+    // If the entity is being fetched by unique id or a unique combo, disable these defaults
+    if (!$this->isFetchByUniqueIdentifier()) {
       $fields = $this->entityFields();
       foreach ($fields as $field) {
         if (isset($field['default_value']) && !$this->_whereContains($field['name'])) {
@@ -48,6 +58,41 @@ abstract class AbstractGetAction extends AbstractQueryAction {
         }
       }
     }
+  }
+
+  /**
+   * Check whether this get operation is fetching a single record by id, name, etc.
+   *
+   * @return bool
+   */
+  protected function isFetchByUniqueIdentifier(): bool {
+    // Collect unique indices, starting with the primary key
+    $uniqueIndices = [
+      CoreUtil::getInfoItem($this->getEntityName(), 'primary_key'),
+    ];
+    // Get other unique index combos
+    try {
+      $entity = \Civi::entity($this->getEntityName());
+      foreach ($entity->getMeta('indices') ?? [] as $index) {
+        if (!empty($index['unique']) && !empty($index['fields'])) {
+          $uniqueIndices[] = array_keys($index['fields']);
+        }
+      }
+    }
+    catch (\Exception $e) {
+    }
+    foreach ($uniqueIndices as $indexFields) {
+      $fetchByUnique = TRUE;
+      foreach ($indexFields as $fieldName) {
+        if (!$this->_itemsToGet($fieldName)) {
+          $fetchByUnique = FALSE;
+        }
+      }
+      if ($fetchByUnique) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
   /**

--- a/Civi/Schema/SqlEntityMetadata.php
+++ b/Civi/Schema/SqlEntityMetadata.php
@@ -38,6 +38,12 @@ class SqlEntityMetadata extends EntityMetadataBase {
         }
         return [];
 
+      case 'indices':
+        if (isset($this->getEntity()['getIndices'])) {
+          return $this->getEntity()['getIndices']();
+        }
+        return [];
+
       default:
         return $this->getEntity()[$propertyName] ?? $this->getEntity()['getInfo']()[$propertyName] ?? NULL;
 

--- a/ext/afform/admin/ang/afGuiEditor.js
+++ b/ext/afform/admin/ang/afGuiEditor.js
@@ -165,7 +165,7 @@
           // Non-aggregated query will return the same search multiple times - once per display
           crmApi4('SavedSearch', 'get', {
             select: ['name', 'label', 'display.name', 'display.label', 'display.type:name', 'display.type:icon'],
-            where: [['api_entity', 'IS NOT NULL'], ['api_params', 'IS NOT NULL']],
+            where: [['api_entity', 'IS NOT NULL'], ['api_params', 'IS NOT NULL'], ['is_template', '=', false]],
             join: [['SearchDisplay AS display', 'LEFT', ['id', '=', 'display.saved_search_id']]],
             orderBy: {'label':'ASC'}
           }).then(function(searches) {

--- a/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
+++ b/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
@@ -144,6 +144,7 @@ class AfformAutocompleteSubscriber extends AutoService implements EventSubscribe
         else {
           $apiRequest->addFilter('api_entity', $apiRequest->getFilters()['api_entity']);
         }
+        $apiRequest->addFilter('is_template', FALSE);
         return;
 
       case 'autocompleteDisplay':

--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -29,7 +29,7 @@
           savedSearch: function($route, crmApi4) {
             var params = $route.current.params;
             return crmApi4('SavedSearch', 'get', {
-              select: ['id', 'name', 'label', 'description', 'api_entity', 'api_params', 'expires_date', 'GROUP_CONCAT(DISTINCT entity_tag.tag_id) AS tag_id'],
+              select: ['id', 'name', 'label', 'description', 'api_entity', 'api_params', 'is_template', 'expires_date', 'GROUP_CONCAT(DISTINCT entity_tag.tag_id) AS tag_id'],
               where: [['id', '=', params.id]],
               join: [
                 ['EntityTag AS entity_tag', 'LEFT', ['entity_tag.entity_table', '=', '"civicrm_saved_search"'], ['id', '=', 'entity_tag.entity_id']],
@@ -91,7 +91,8 @@
       // Tabs include a rowCount which will be updated by the search controller
       this.tabs = [
         {name: 'custom', title: ts('Custom Searches'), icon: 'fa-search-plus', rowCount: null, filters: {has_base: false}},
-        {name: 'packaged', title: ts('Packaged Searches'), icon: 'fa-suitcase', rowCount: null, filters: {has_base: true}}
+        {name: 'packaged', title: ts('Packaged Searches'), icon: 'fa-suitcase', rowCount: null, filters: {has_base: true}},
+        {name: 'template', title: ts('Search Templates'), icon: 'fa-clipboard', rowCount: null, filters: {is_template: true}},
       ];
       $scope.$bindToRoute({
         expr: '$ctrl.tab',
@@ -109,7 +110,8 @@
       searchEntity = $routeParams.entity;
       var ctrl = $scope.$ctrl = this;
       this.savedSearch = {
-        api_entity: searchEntity
+        api_entity: searchEntity,
+        is_template: ($routeParams.is_template == '1'),
       };
       // Changing entity will refresh the angular page
       $scope.$watch('$ctrl.savedSearch.api_entity', function(newEntity, oldEntity) {
@@ -127,7 +129,7 @@
     })
 
     // Controller for cloning a SavedSearch
-    .controller('searchClone', function($scope, savedSearch) {
+    .controller('searchClone', function($scope, $routeParams, savedSearch) {
       searchEntity = savedSearch.api_entity;
       savedSearch.label += ' (' + ts('copy') + ')';
       delete savedSearch.id;
@@ -136,6 +138,7 @@
         display.acl_bypass = false;
         display.label += ' (' + ts('copy') + ')';
       });
+      savedSearch.is_template = ($routeParams.is_template == '1');
       this.savedSearch = savedSearch;
       $scope.$ctrl = this;
     })

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -144,6 +144,10 @@
       loadAfforms();
     };
 
+    this.canAddSmartGroup = function() {
+      return !ctrl.savedSearch.groups.length && !ctrl.savedSearch.is_template;
+    };
+
     function onChangeAnything() {
       $scope.status = 'unsaved';
     }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.html
@@ -1,5 +1,5 @@
 <div id="bootstrap-theme" class="crm-search">
-  <h1 crm-page-title>{{ $ctrl.entityTitle + ': ' + $ctrl.savedSearch.label }}</h1>
+  <h1 crm-page-title>{{ ($ctrl.savedSearch.is_template ? ts('Search Template') : ts('Saved Search')) + ': ' + $ctrl.savedSearch.label }}</h1>
   <div crm-ui-debug="$ctrl.savedSearch"></div>
 
   <!--This warning will show if bootstrap is unavailable. Normally it will be hidden by the bootstrap .collapse class.-->
@@ -28,7 +28,7 @@
 
         <div class="form-group pull-right">
 
-          <div class="btn-group" ng-if="$ctrl.afformEnabled && $ctrl.savedSearch.id">
+          <div class="btn-group" ng-if="$ctrl.afformEnabled && $ctrl.savedSearch.id && !$ctrl.savedSearch.is_template">
             <button type="button" ng-click="$ctrl.openAfformMenu = true;" class="btn dropdown-toggle btn-primary-outline" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               <i class="crm-i fa-list-alt"></i>
               {{ ($ctrl.afformCount !== undefined) ? ($ctrl.afformCount === 1 ? ts('1 Form') : ts('%1 Forms', {1: $ctrl.afformCount})) : ts('Forms...') }}

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/buttons.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/buttons.html
@@ -1,6 +1,9 @@
 <div class="btn-group btn-group-xs crm-search-admin-search-listing-buttons">
-  <a class="btn btn-primary" ng-href="#/edit/{{:: row.data.id }}" ng-if=":: row.permissionToEdit" title="{{:: ts('Edit search and displays') }}">
+  <a class="btn btn-primary" ng-href="#/edit/{{:: row.data.id }}" ng-if=":: row.permissionToEdit && !row.data.is_template" title="{{:: ts('Edit search and displays') }}">
     <i class="crm-i fa-pencil fa-fw"></i>
+  </a>
+  <a class="btn btn-primary" ng-href="#/clone/{{:: row.data.id }}?is_template=0" ng-if=":: !row.permissionToEdit || row.data.is_template" title="{{:: ts('Create a new search based on this one') }}">
+    <i class="crm-i fa-clone"></i>
   </a>
   <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" ng-click="row.menuOpen = true">
     <i class="crm-i fa-bars"></i>
@@ -10,7 +13,7 @@
     <li ng-if=":: row.permissionToEdit" title="{{:: ts('Edit search and displays') }}">
       <a ng-href="#/edit/{{:: row.data.id }}">
         <i class="crm-i fa-pencil fa-fw"></i>
-        {{:: ts('Edit') }}
+        {{ row.data.is_template ? ts('Edit Template') : ts('Edit Search') }}
       </a>
     </li>
     <li title="{{:: ts('View search results table') }}">
@@ -20,15 +23,21 @@
       </a>
     </li>
     <li title="{{:: ts('Create a new search based on this one') }}">
-      <a ng-href="#/clone/{{:: row.data.id }}">
-        <i class="crm-i fa-copy"></i>
-        {{:: ts('Clone...') }}
+      <a ng-href="#/clone/{{:: row.data.id }}?is_template=0">
+        <i class="crm-i fa-clone"></i>
+        {{ row.data.is_template ? ts('Create from Template') : ts('Clone Search') }}
       </a>
     </li>
-    <li title="{{:: ts('Export this saved search to a file') }}">
+    <li title="{{:: ts('Create a new template based on this one') }}">
+      <a ng-href="#/clone/{{:: row.data.id }}?is_template=1">
+        <i class="crm-i fa-paste"></i>
+        {{ row.data.is_template ? ts('Clone Template') : ts('Save as Template') }}
+      </a>
+    </li>
+    <li title="{{:: ts('Export this saved search for sharing or reuse') }}">
       <a href crm-dialog-popup="crmSearchAdminExport" popup-data="row" popup-tpl="~/crmSearchAdmin/searchListing/export.html" title="{{:: ts('Export %1', {1: row.data.label}) }}">
         <i class="crm-i fa-download"></i>
-        {{:: ts('Export...') }}
+        {{ row.data.is_template ? ts('Export Template') : ts('Export Search') }}
       </a>
     </li>
     <li ng-if="!row.data['base_module:label']" title="{{:: ts('Delete search along with any displays and forms') }}">

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/searchList.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/searchList.html
@@ -18,22 +18,22 @@
       </li>
     </ul>
     <div class="btn-group" ng-if="$ctrl.tab !== 'segment'">
-      <a class="btn btn-primary" href="#/create/Contact" >
+      <a class="btn btn-primary" ng-href="#/create/Contact?is_template={{ $ctrl.tab === 'template' ? 1 : 0}}" >
         <i class="crm-i fa-plus"></i>
-        {{:: ts('New Search') }}
+        {{ $ctrl.tab === 'template' ? ts('New Template') : ts('New Search') }}
       </a>
       <button type="button" ng-click="$ctrl.getPrimaryEntities()" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <span class="caret"></span>
       </button>
       <ul class="dropdown-menu dropdown-menu-right">
         <li ng-repeat="entity in $ctrl.primaryEntities">
-          <a ng-href="#/create/{{ entity.name }}">
+          <a ng-href="#/create/{{ entity.name }}?is_template={{ $ctrl.tab === 'template' ? 1 : 0}}">
             <i class="crm-i {{:: entity.icon }}"></i>
             {{:: entity.title_plural }}
           </a>
         </li>
         <li title="{{:: ts('Choose other entities on the search screen') }}">
-          <a href="#/create/Contact">{{:: ts('More...') }}</a>
+          <a ng-href="#/create/Contact?is_template={{ $ctrl.tab === 'template' ? 1 : 0}}">{{:: ts('More...') }}</a>
         </li>
       </ul>
     </div>

--- a/ext/search_kit/ang/crmSearchAdmin/tabs.html
+++ b/ext/search_kit/ang/crmSearchAdmin/tabs.html
@@ -31,7 +31,7 @@
     <i class="crm-i fa-plus"></i> {{:: ts('Add...') }} <span class="caret"></span>
   </button>
   <ul class="dropdown-menu">
-    <li ng-if="!$ctrl.savedSearch.groups.length" title="{{:: ts('Smart group of contacts based on search results') }}">
+    <li ng-if="$ctrl.canAddSmartGroup()" title="{{:: ts('Smart group of contacts based on search results') }}">
       <a href ng-click="$ctrl.addGroup()">
         <i class="crm-i fa-users"></i>
         {{:: ts('Smart Group') }}

--- a/schema/Contact/SavedSearch.entityType.php
+++ b/schema/Contact/SavedSearch.entityType.php
@@ -185,5 +185,14 @@ return [
         'cols' => 60,
       ],
     ],
+    'is_template' => [
+      'title' => ts('Template'),
+      'sql_type' => 'boolean',
+      'input_type' => 'CheckBox',
+      'required' => TRUE,
+      'description' => ts('Search templates are used as a starting point for building new searches'),
+      'add' => '5.81',
+      'default' => FALSE,
+    ],
   ],
 ];

--- a/tests/phpunit/api/v4/Entity/SavedSearchTest.php
+++ b/tests/phpunit/api/v4/Entity/SavedSearchTest.php
@@ -22,6 +22,7 @@ namespace api\v4\Entity;
 use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
 use Civi\Api4\Email;
+use Civi\Api4\SavedSearch;
 use Civi\Test\TransactionalInterface;
 
 /**
@@ -205,6 +206,28 @@ class SavedSearchTest extends Api4TestBase implements TransactionalInterface {
       ],
     ]);
     $this->assertCount(5, $aNotB);
+  }
+
+  public function testSearchTemplateGet(): void {
+    $name = uniqid();
+    $savedSearch = $this->createTestRecord('SavedSearch', [
+      'name' => $name,
+      'is_template' => TRUE,
+    ]);
+
+    // APIv4 automatically excludes is_template from normal GET
+    $getWithout = SavedSearch::get(FALSE)
+      ->setSelect(['id', 'name'])
+      ->execute()->column('name', 'id');
+    $this->assertArrayNotHasKey($savedSearch['id'], $getWithout);
+
+    // Get by name will override that exclusion rule
+    $getWith = SavedSearch::get(FALSE)
+      ->addWhere('name', '=', $name)
+      ->setSelect(['id', 'name'])
+      ->execute()->column('name', 'id');
+    $this->assertCount(1, $getWith);
+    $this->assertArrayHasKey($savedSearch['id'], $getWith);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Search templates are identical to other saved searches, but they cannot be used
as a smart group or placed in an Afform.

They are intended to be cloned and used as the starting place for building a new search.

This adds in the UI a new tab for templates, and a button allowing any existing search
to be saved as a template.

![image](https://github.com/user-attachments/assets/e2abd975-b85e-4e03-bba5-61c47c1a4e57)



Technical Details
------

In the database, the new column is_template is added to the civicrm_saved_search table.
