### PR TITLE
dev/core#5570 Participant view fixes when tax is enabled

### DIFF
--- a/CRM/Event/Form/ParticipantView.php
+++ b/CRM/Event/Form/ParticipantView.php
@@ -35,6 +35,11 @@ class CRM_Event_Form_ParticipantView extends CRM_Core_Form {
     $contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
     $params = ['id' => $participantID];
 
+    // set tax related information
+    $this->assign('taxTerm', Civi::settings()->get('tax_term'));
+    $invoicing = Civi::settings()->get('invoicing');
+    $this->assign('getTaxDetails', $invoicing);
+
     CRM_Event_BAO_Participant::getValues($params,
       $values,
       $ids
@@ -180,6 +185,12 @@ class CRM_Event_Form_ParticipantView extends CRM_Core_Form {
     // no contribution attached to it - maybe we have eliminated this? But I have a nasty feeling about
     // webform.
     $this->assign('totalTaxAmount', $totalTaxAmount ?? NULL);
+
+    // let's add add when tax is enabled.
+    if ($invoicing) {
+      $totalAmount = $totalAmount + $totalTaxAmount;
+    }
+
     $this->assign('totalAmount', $totalAmount);
     $this->assign('pricesetFieldsCount', $participantCount);
     $this->assign('displayName', $displayName);


### PR DESCRIPTION
Overview
----------------------------------------
Participant fees are incorrectly displayed when Tax is enabled. This fixes following:

- adds missing tax term
- fixes incorrect event subtotal and total amount


Before
----------------------------------------
![2024-11-27-154844_hyprshot](https://github.com/user-attachments/assets/1d23d077-bbb5-4e30-86ca-a96bcea7f31b)



After
----------------------------------------
![2024-11-27-154455_hyprshot](https://github.com/user-attachments/assets/c6976ffe-a945-43ee-9890-76c7c584bb97)


