### PR TITLE
Follow-up to #31487 - fix for old smarty

### DIFF
--- a/templates/CRM/Contribute/Form/ContributionPage/Settings.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Settings.tpl
@@ -135,6 +135,7 @@
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>
 
+{literal}
 <script type="text/javascript">
   CRM.$(function($) {
     $('#financial_type_id').change( function() {
@@ -142,6 +143,7 @@
     });
   });
 </script>
+{/literal}
 
 {include file="CRM/common/showHideByFieldValue.tpl"
   trigger_field_id    ="is_organization"


### PR DESCRIPTION
Overview
----------------------------------------
Avoids a smarty fatal error on systems not configured to use a newer version of smarty.
Follow-up to https://github.com/civicrm/civicrm-core/pull/31487

Before
----------------------------------------
Fails when creating a new Contribution Page

After
----------------------------------------
No error

