### PR TITLE
SearchKit - Set acl_bypass=false when cloning a display

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -133,6 +133,7 @@
       delete savedSearch.id;
       savedSearch.displays.forEach(display => {
         delete display.id;
+        display.acl_bypass = false;
         display.label += ' (' + ts('copy') + ')';
       });
       this.savedSearch = savedSearch;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes error for less-permissioned users.

Before
----------------------------------------
When users without super-admin permissions attempt to clone a savedSearch with acl_bypass displays, an error occurs.

After
----------------------------------------
No error.