### PR TITLE
[REF] Add in CiviCRM Status checks to check for inconsistencies betwe…

### DIFF
--- a/ext/civi_event/civi_event.php
+++ b/ext/civi_event/civi_event.php
@@ -1,3 +1,41 @@
 <?php
 
 require_once 'civi_event.civix.php';
+
+/**
+ * Implements hook_civicrm_check().
+ *
+ * Check for any legacy data where there is a participant_payment record but not a matching line item
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_check/
+ */
+function civi_event_civicrm_check(&$messages) :void {
+  $parcitipantPayments = CRM_Core_DAO::executeQuery("SELECT contribution_id, participant_id FROM civicrm_participant_payment");
+  $lineItemsMissingPayments = [];
+  while ($parcitipantPayments->fetch()) {
+    $lineItemCheck = CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_line_item WHERE contribution_id = %1 AND entity_id = %2 AND entity_table = 'civicrm_participant'", [
+      1 => [$parcitipantPayments->contribution_id, 'Positive'],
+      2 => [$parcitipantPayments->participant_id, 'Positive'],
+    ]);
+    if (empty($lineItemCheck)) {
+      $lineItemsMissingPayments[] = [
+        'contribution_id' => $parcitipantPayments->contribution_id,
+        'participant_id' => $parcitipantPayments->participant_id,
+      ];
+    }
+  }
+  if (!empty($lineItemsMissingPayments)) {
+    $strings = '';
+    foreach ($lineItemsMissingPayments as $lineItemsMissingPayment) {
+      $strings .= '<tr><td>'. $lineItemsMissingPayment['contribution_id'] . '</td><td>' .  $lineItemsMissingPayment['participant_id']  . '</td></tr>';
+    }
+    $messages[] = new CRM_Utils_Check_Message(
+      'civi_event_participant_payments_missing',
+      ts('The Following Participant Payments do not have a corresponding line item record linking the contribution to participant.') . ts('This should be corrected either by updating the relevant line item record or adding a line item record as appropriate.') . '</p>
+        <p></p><table><thead><th>Contribution ID</th><th>Participant ID</th></thead><tbody>' . $strings  . '</tbody></table></p>',
+      ts('CiviCRM Participant Payment Records not matching'),
+      \Psr\Log\LogLevel::WARNING,
+      'fa-database',
+    );
+  }
+}

--- a/ext/civi_member/civi_member.php
+++ b/ext/civi_member/civi_member.php
@@ -1,3 +1,41 @@
 <?php
 
 require_once 'civi_member.civix.php';
+
+/**
+ * Implements hook_civicrm_check().
+ *
+ * Check for any legacy data where there is a membership_payment record but not a matching line item
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_check/
+ */
+function civi_member_civicrm_check(&$messages) :void {
+  $membershipPayments = CRM_Core_DAO::executeQuery("SELECT contribution_id, membership_id FROM civicrm_membership_payment");
+  $lineItemsMissingPayments = [];
+  while ($membershipPayments->fetch()) {
+    $lineItemCheck = CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_line_item WHERE contribution_id = %1 AND entity_id = %2 AND entity_table = 'civicrm_membership'", [
+      1 => [$membershipPayments->contribution_id, 'Positive'],
+      2 => [$membershipPayments->membership_id, 'Positive'],
+    ]);
+    if (empty($lineItemCheck)) {
+      $lineItemsMissingPayments[] = [
+        'contribution_id' => $membershipPayments->contribution_id,
+        'membership_id' => $membershipPayments->membership_id,
+      ];
+    }
+  }
+  if (!empty($lineItemsMissingPayments)) {
+    $strings = '';
+    foreach ($lineItemsMissingPayments as $lineItemsMissingPayment) {
+      $strings .= '<tr><td>'. $lineItemsMissingPayment['contribution_id'] . '</td><td>' .  $lineItemsMissingPayment['membership_id']  . '</td></tr>';
+    }
+    $messages[] = new CRM_Utils_Check_Message(
+      'civi_member_membership_payments_missing',
+      ts('The Following Membership Payments do not have a corresponding line item record linking the contribution to membership.') . ts('This should be corrected either by updating the relevant line item record or adding a line item record as appropriate.') . '</p>
+        <p></p><table><thead><th>Contribution ID</th><th>Membership ID</th></thead><tbody>' . $strings  . '</tbody></table></p>',
+      ts('CiviCRM Membership Payment Records not matching'),
+      \Psr\Log\LogLevel::WARNING,
+      'fa-database',
+    );
+  }
+}


### PR DESCRIPTION
…en the membership_payment participant_payment and line item tables

Overview
----------------------------------------
We have "soft" deprecated the civicrm_membership_payment and civicrm_participant_table in favour of the civicrm_line_item table. This aims to add a status check to see if there is data inconsistencies between the two tables at least as far as the _payment tables having records that are not present in the line_item table

Before
----------------------------------------
No check on consistency

After
----------------------------------------
Check and an alert if data is not matching 

Technical Details
----------------------------------------
I would be open to closing this if people didn't think it was useful but I think it might be helpful if in a future CiviCRM we stop actually adding records to the _payment tables and or drop them.  I have also put these in the extensions so that they would only be shown if the system is using memberships or events. I would also be open to fixing language as needed

ping @JoeMurray @KarinG @eileenmcnaughton @mattwire @artfulrobot 

