### PR TITLE
Assign taxTerm at top level on all forms

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -487,7 +487,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
     $this->assign('receiptFromEmail', $this->_values['receipt_from_email'] ?? NULL);
     $this->assign('amount_block_is_active', $this->isFormSupportsNonMembershipContributions());
-    $this->assign('taxTerm', \Civi::settings()->get('tax_term'));
     $this->assign('totalTaxAmount', $this->order->getTotalTaxAmount());
     $isDisplayLineItems = $this->_priceSetId && !CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $this->_priceSetId, 'is_quick_config');
     $this->assign('isDisplayLineItems', $isDisplayLineItems);

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -750,6 +750,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * buildQuickForm.
    */
   public function buildForm() {
+    $this->assign('taxTerm', \Civi::settings()->get('tax_term'));
     $this->preProcess();
 
     CRM_Utils_Hook::preProcess(get_class($this), $this);


### PR DESCRIPTION
Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._

Before
----------------------------------------
per https://github.com/civicrm/civicrm-core/pull/31532 the tax term (e.g VAT, GST) is only available if assigned

After
----------------------------------------
This, along with probably some other organizational settings, should really always be available to templates as it is frequently required

Technical Details
----------------------------------------
If this is merged there are other places it could be removed from

We could go with a crmSetting type smarty call - but it might be more disruptive

Comments
----------------------------------------