### PR TITLE
delaying crm-ui-select `init` until the next tick

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -658,7 +658,7 @@
               };
             });
           } else {
-            init();
+            $timeout(init);
           }
         }
       };


### PR DESCRIPTION
Overview
----------------------------------------
Addresses a UI glitch when using crm-ui-select on an element with interpolated attributes e.g. `title="{{inputTitle}}"`, where the non-interpolated string is cloned instead of the interpolated value

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/d75ac067-42d4-4f4d-954b-a335a5ae5cd4)

After
----------------------------------------
![image](https://github.com/user-attachments/assets/9b8e1dba-28aa-4513-a2f7-0f4b076db693)

Technical Details
----------------------------------------
`init` is being called too soon, before the element has the correct attributes applied, so this change delays the call by one tick, allowing the attributes to be updated before being cloned by select2
