### PR TITLE
Updates RiverLea (v1.80.11) - new version numbering, fixes hidden input regression, contact merge bg cols & others

### DIFF
--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -1,5 +1,16 @@
 1.80.11
- - CHANGED version numbering again. See note in ReadMe: the 2nd number represents the Civi version tested against, the 3rd number is the RL version number for that Civi version.
+ - FIXED - Wallbrook avatar image returned to 100px as had created a gap (ext/riverlea/#87)
+ - FIXED - Double icon on .messages.crm-empty-table
+ - FIXED - changed specificity of .hiddenElement (ext/riverlea/#11) to ensure unhidden elements are unhidden.
+ - CHANGED - version numbering again. See note in ReadMe: the 2nd number represents the Civi version tested against, the 3rd number is the RL version number for that Civi version.
+ - CHANGED - Alert colour bg for .messages.crm-empty-table now matches icon colour ('info' range)
+ - CHANGED - streams/empty/_variables.css to match core variables.css
+ - CHANGED - reduce verbose Bootstrap table styling css in tables.css
+ - CHANGED - cascade order of table colours to put .crm-row-selected class last
+ - ADDED - contact merge screen error/ok/selected background colours (ext/riverlea/#88)
+ - ADDED - margin (`--crm-flex-gap`) to bottom of .description text.
+ - ADDED - accordion with error text and border colour to fix contrast ratio issues
+ - ADDED - D9 Claro .action-link margin reset
 
 1.1.10 / 5.80.9
  - FIXED - D7 Seven theme .button style overwriting colours

--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -1,4 +1,7 @@
-5.80.9
+1.80.11
+ - CHANGED version numbering again. See note in ReadMe: the 2nd number represents the Civi version tested against, the 3rd number is the RL version number for that Civi version.
+
+1.1.10 / 5.80.9
  - FIXED - D7 Seven theme .button style overwriting colours
  - CHANGED - D7 Seven, matched page-padding.
  - FIXED - Responsive contact dashboard, below 768px: wrapped contact-summary label/data, wrap action links.
@@ -7,7 +10,7 @@
  - CHANGED - Walbrook avatar image - made a little larger and thiner border
  - FIXED - better name-spaced AFform padding for front-end vs backend
 
-5.80.8
+1.1.9 / 5.80.8
  - CHANGED - CiviLint - further lint adjustments (tabs for double space, missing semi-colons)
  - FIXED - SearchKit button group hierarchy wrapping button groups
  - FIXED - removed button styling for another (x)-type cancel-only button in SearchKit builder
@@ -22,7 +25,7 @@
     --crm-dash-image-justify
     --crm-dash-image-direction
 
-5.80.7
+1.1.8 / 5.80.7
  - CHANGED - CiviLint - made Thames CSS more verbose (#84)
  - CHANGED - CiviLint - reduced four char spaces to two
  - CHANGED - CiviLint - changes to PHP files
@@ -30,7 +33,7 @@
  - CHANGED - .gitignore file updated
  - REMOVED - Duplicate BoostrapJS files
 
-5.80.6
+1.1.7 / 5.80.6
  - FIXED - trailing comma (merge_requests/42)
  - FIXED - FormBuilder customise options doesn't show icons on Wallbrook (#83)
  - FIXED - FormBuilder customise options grab region background doesn't show
@@ -38,13 +41,13 @@
  - CHANGED - CSS tidying around FormBuilder customise options
  - REMOVED - responsive tables - fix being used wasn't responsive and had some usability questions (#82)
 
-5.80.5
+1.1.6 / 5.80.5
  - FIXED - reset checkbox margin in checkbox lists (that shrunk the checkbox size)
  - FIXED - changed td.label to table-cell to address sizing inconsistencies (#68)
  - CHANGED - apply `--crm-c-page-background` to WordPress body, not only .crm-container (#77)
  - FIXED - right column inline edit on contact dashboard was positioned left (#76)
 
-5.80.4
+1.1.5 / 5.80.4
  - CHANGED - CSS Variable '--crm-flex-gap' moved from core css into variables (fixed scenarios where it wasn't loading)
  - ADDED - right/bottom margin to SK grid buttons to create space in SK displays (#81)
  - CHANGED - multi-select select2, use input padding variable
@@ -76,10 +79,10 @@
  - CHANGED crm-accordion-settings body padding changed from 0 to match crm-accordion-bold
  - FIXED focus colour on Select2 now should display on tab/focus (github.com/31433)
 
-1.1.1
+1.1.1 / 5.80.0
  - FIXED metadata - RiverLea version numbering in variables file & info.xml
 
-1.1.0
+1.1.0 / 5.80.0
  - CHANGED info.xml version to 5.80 to synch with CiviCRM core (github.com/31389)
  - FIXED clipping of dropdown on sidescroll tables (#73).
  - FIXED Wallbrook, table header bg, should be white.

--- a/ext/riverlea/README.md
+++ b/ext/riverlea/README.md
@@ -11,13 +11,13 @@ This Framework separates CiviCRM's visual/UI CSS from structural CSS, using CSS 
 
  ## Use in Front-End CiviCRM
 
-**USE WITH CAUTION AND TESTING** While RiverLea has been widely tested in the backend of CiviCRM, given the wide number of themes and scenarios for front-end pages, for existing sites we recommend only applying it to an existing web front-end after extensive testing on a dev site.
+**USE WITH CAUTION AND TESTING** While RiverLea has been widely tested in the backend of CiviCRM, be very careful to use in front-end. Given the wide number of themes and scenarios for front-end pages, for existing sites we recommend only applying it to an existing web front-end after comprehensive testing on a dev site.
 
 Overwriting CSS variables for the front is straightforward (they can be nested within `.crm-container.crm-public` and there's a number of front-end specific variables, prefixed `--crm-f-`), but **testing is essential**.
 
 ## [Changelog](CHANGELOG.md)
 
-- 1.1 (5.80) - Release for packaging with CiviCRM core, v5.80.
+- 1.80 (5.80) - Release for packaging with CiviCRM core, v5.80 (see note on numbering below)
 - 1.0 - **Release candidate**, with ongoing testing and fixes.
 - 0.10 - **Adds fourth stream**. Thames (Aah), as well as extensive fixes & adjustments.
 - 0.9 - **Overwrites civi core CSS**. 5.75 only - overwrites core css like SearchKit & FormBuilder with extensive work on both. D7 Garland support.
@@ -29,6 +29,11 @@ Overwriting CSS variables for the front is straightforward (they can be nested w
 - 0.3 - **Two streams, 6 CMS setups tested:** adds Minetta and Walbrook streams. Backdrop, D7 (Seven), D9 (Claro + Seven), Joomla 4, Standalone & WordPress.
 - 0.2 - **Establishes structure**, adds Bootstrap3, components - accordion.
 - 0.1 - **Proof-of-concept**, basic variables.
+
+### Version numbering
+RiverLea has its own version number and confusingly this has changed a few times while we figured out the best approach. It is also different in the core-extension info.xml which in core will always match the Civi version its shipped with, but as a standalone extension has its own numbering.
+
+The pattern is `1.x.y` where x = the CiviCRM version it is developed against and y = the version number of of RiverLea for that Civi version. So `1.80.11` is the 11th version of RiverLea v1 built against CiviCRM `5.80.x`. Some previous versions tried to match the CiviCRM core version number and build on that (ie RiverLea 5.80.11), but this caused problems with upgrade prompts.
 
 ## Installation
 
@@ -140,3 +145,7 @@ function ocean_civicrm_themes(&$themes) {
     'search_order' => array('_riverlea_core_', 'styx',  '_fallback_'),
   );
 }
+
+## Troubleshooting
+- Unless you really need it (e.g. applying an urgent fix, or running a test), delete the custom/ext version of RiverLea, once you are on CiviCRM 5.80 or later.
+- After removing the custom/ext RiverLea directory, the civicrm/ext version should load automatically. It may appear to be enabled, but normally you will need to disable and re-enable it before RiverLea streams appear in Display Settings.

--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -16,9 +16,10 @@ body {
 .crm-container *::after {
   box-sizing: border-box;
 }
+#crm-container .hiddenElement,
 .crm-container .hiddenElement,
 .crm-container .collapse {
-  display: none !important /* needs to hide items further down the cascade */;
+  display: none
 }
 .crm-container .clear {
   clear: both;

--- a/ext/riverlea/core/css/_cms.css
+++ b/ext/riverlea/core/css/_cms.css
@@ -103,6 +103,9 @@ body.page-civicrm .page-content:has(#block-claro-content) {
   background-image: unset;
   display: inherit;
 }
+#block-claro-content .action-link + .action-link {
+  margin-inline-start: unset;
+}
 @media (max-width: 959px) {
   #block-claro-content {
     --crm-page-padding: 1rem;

--- a/ext/riverlea/core/css/_core.css
+++ b/ext/riverlea/core/css/_core.css
@@ -4,5 +4,5 @@
    can be merged later. */
 
 @import url(components/_accordion.css); @import url(components/_alerts.css); @import url(components/_buttons.css); @import url(components/_form.css); @import url(components/_icons.css); @import url(components/_nav.css); @import url(components/_tabs.css); @import url(components/_dropdowns.css); @import url(components/_tables.css); @import url(components/_dialogs.css); @import url(components/_page.css); @import url(components/_components.css); @import url(components/_front.css); :root {
-  --crm-release: '5.80.9';
+  --crm-release: '1.80.11';
 }

--- a/ext/riverlea/core/css/components/_accordion.css
+++ b/ext/riverlea/core/css/components/_accordion.css
@@ -29,6 +29,8 @@
 .crm-container details:has(input.crm-inline-error) summary,
 .crm-container details:has(input.crm-inline-error) summary.active {
   background-color: var(--crm-alert-background-danger);
+  color: var(--crm-alert-text-danger);
+  border-color: var(--crm-alert-border-danger);
 }
 
 /* Expand/collapse icons */

--- a/ext/riverlea/core/css/components/_alerts.css
+++ b/ext/riverlea/core/css/components/_alerts.css
@@ -47,7 +47,8 @@
   background-color: var(--crm-alert-background-help);
   color: var(--crm-alert-text-info);
 }
-.crm-container .alert-info {
+.crm-container .alert-info,
+.crm-container .messages.crm-empty-table {
   background-color: var(--crm-alert-background-info);
   border-color: var(--crm-alert-border-info);
   color: var(--crm-alert-text-info);

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -82,7 +82,6 @@
 .crm-container td.description {
   color: var(--crm-input-description);
   font-size: var(--crm-input-label-size);
-
   margin-bottom: var(--crm-flex-gap);
 }
 .crm-container .crm-marker {

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -82,6 +82,8 @@
 .crm-container td.description {
   color: var(--crm-input-description);
   font-size: var(--crm-input-label-size);
+
+  margin-bottom: var(--crm-flex-gap);
 }
 .crm-container .crm-marker {
   color: var(--crm-c-alert);

--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -53,6 +53,9 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
   content: var(--crm-icon-info);
   color: var(--crm-c-info);
 }
+.crm-container .messages.crm-empty-table > i.crm-i {
+  display: none; /* removes double icon when markup uses both */
+}
 
 /* Help icon */
 .crm-container a.helpicon::before {

--- a/ext/riverlea/core/css/components/_tables.css
+++ b/ext/riverlea/core/css/components/_tables.css
@@ -309,7 +309,7 @@ tbody .crm-row-child:not(:has(~ .crm-row-child)) td {
   background: var(--crm-c-page-background);
 }
 
-/* BOOTSTRAP tables */
+/* Table bg colours */
 
 .crm-container .table {
   width: 100%;
@@ -386,60 +386,27 @@ tbody .crm-row-child:not(:has(~ .crm-row-child)) td {
 .crm-container .table-hover > tbody > tr.active:hover > th {
   background-color: var(--crm-table-odd-hover);
 }
-.crm-container .table > thead > tr > td.success,
-.crm-container .table > thead > tr > th.success,
-.crm-container .table > thead > tr.success > td,
-.crm-container .table > thead > tr.success > th,
-.crm-container .table > tbody > tr > td.success,
-.crm-container .table > tbody > tr > th.success,
-.crm-container .table > tbody > tr.success > td,
-.crm-container .table > tbody > tr.success > th,
-.crm-container .table > tfoot > tr > td.success,
-.crm-container .table > tfoot > tr > th.success,
-.crm-container .table > tfoot > tr.success > td,
-.crm-container .table > tfoot > tr.success > th {
+.crm-container .table td.success,
+.crm-container .table th.success,
+.crm-container .table tr.success > td,
+.crm-container .table tr.success > th,
+.crm-container table tr.crm-row-ok,
+.crm-container table tr.crm-row-ok > td {
   background-color: var(--crm-alert-background-help);
 }
 .crm-container .table-hover > tbody > tr > td.success:hover,
 .crm-container .table-hover > tbody > tr > th.success:hover,
 .crm-container .table-hover > tbody > tr.success:hover > td,
 .crm-container .table-hover > tbody > tr:hover > .success,
-.crm-container .table-hover > tbody > tr.success:hover > th {
+.crm-container .table-hover > tbody > tr.success:hover > th,
+.crm-container table tr.crm-row-ok:hover > td,
+.crm-container table tr.crm-row-ok > td:hover {
   background-color: var(--crm-alert-border-help);
 }
-.crm-container .table > thead > tr > td.info,
-.crm-container .table > thead > tr > th.info,
-.crm-container .table > thead > tr.info > td,
-.crm-container .table > thead > tr.info > th,
-.crm-container .table > tbody > tr > td.info,
-.crm-container .table > tbody > tr > th.info,
-.crm-container .table > tbody > tr.info > td,
-.crm-container .table > tbody > tr.info > th,
-.crm-container .table > tfoot > tr > td.info,
-.crm-container .table > tfoot > tr > th.info,
-.crm-container .table > tfoot > tr.info > td,
-.crm-container .table > tfoot > tr.info > th {
-  background-color: var(--crm-alert-background-info);
-}
-.crm-container .table-hover > tbody > tr > td.info:hover,
-.crm-container .table-hover > tbody > tr > th.info:hover,
-.crm-container .table-hover > tbody > tr.info:hover > td,
-.crm-container .table-hover > tbody > tr:hover > .info,
-.crm-container .table-hover > tbody > tr.info:hover > th {
-  background-color: var(--crm-alert-border-info);
-}
-.crm-container .table > thead > tr > td.warning,
-.crm-container .table > thead > tr > th.warning,
-.crm-container .table > thead > tr.warning > td,
-.crm-container .table > thead > tr.warning > th,
-.crm-container .table > tbody > tr > td.warning,
-.crm-container .table > tbody > tr > th.warning,
-.crm-container .table > tbody > tr.warning > td,
-.crm-container .table > tbody > tr.warning > th,
-.crm-container .table > tfoot > tr > td.warning,
-.crm-container .table > tfoot > tr > th.warning,
-.crm-container .table > tfoot > tr.warning > td,
-.crm-container .table > tfoot > tr.warning > th {
+.crm-container .table td.warning,
+.crm-container .table th.warning,
+.crm-container .table tr.warning > td,
+.crm-container .table tr.warning > th {
   background-color: var(--crm-alert-background-warning);
 }
 .crm-container .table-hover > tbody > tr > td.warning:hover,
@@ -449,26 +416,39 @@ tbody .crm-row-child:not(:has(~ .crm-row-child)) td {
 .crm-container .table-hover > tbody > tr.warning:hover > th {
   background-color: var(--crm-alert-border-warning);
 }
-.crm-container .table > thead > tr > td.danger,
-.crm-container .table > thead > tr > th.danger,
-.crm-container .table > thead > tr.danger > td,
-.crm-container .table > thead > tr.danger > th,
-.crm-container .table > tbody > tr > td.danger,
-.crm-container .table > tbody > tr > th.danger,
-.crm-container .table > tbody > tr.danger > td,
-.crm-container .table > tbody > tr.danger > th,
-.crm-container .table > tfoot > tr > td.danger,
-.crm-container .table > tfoot > tr > th.danger,
-.crm-container .table > tfoot > tr.danger > td,
-.crm-container .table > tfoot > tr.danger > th {
+.crm-container .table td.danger,
+.crm-container .table th.danger,
+.crm-container .table tr.danger > td,
+.crm-container .table tr.danger > th,
+.crm-container table tr.crm-row-error,
+.crm-container table tr.crm-row-error > td {
   background-color: var(--crm-alert-background-danger);
 }
 .crm-container .table-hover > tbody > tr > td.danger:hover,
 .crm-container .table-hover > tbody > tr > th.danger:hover,
 .crm-container .table-hover > tbody > tr.danger:hover > td,
 .crm-container .table-hover > tbody > tr:hover > .danger,
-.crm-container .table-hover > tbody > tr.danger:hover > th {
+.crm-container .table-hover > tbody > tr.danger:hover > th,
+.crm-container table tr.crm-row-error:hover > td,
+.crm-container table tr.crm-row-error > td:hover  {
   background-color: var(--crm-alert-border-danger);
+}
+.crm-container .table td.info,
+.crm-container .table th.info,
+.crm-container .table tr.info > td,
+.crm-container .table tr.info > th,
+.crm-container table tr.crm-row-selected,
+.crm-container table tr.crm-row-selected > td {
+  background-color: var(--crm-alert-background-info);
+}
+.crm-container .table-hover > tbody > tr > td.info:hover,
+.crm-container .table-hover > tbody > tr > th.info:hover,
+.crm-container .table-hover > tbody > tr.info:hover > td,
+.crm-container .table-hover > tbody > tr:hover > .info,
+.crm-container .table-hover > tbody > tr.info:hover > th,
+.crm-container table tr.crm-row-selected:hover > td,
+.crm-container table tr.crm-row-selected > td:hover {
+  background-color: var(--crm-alert-border-info);
 }
 .crm-container .table-responsive {
   min-height: .01%;

--- a/ext/riverlea/core/css/components/_tables.css
+++ b/ext/riverlea/core/css/components/_tables.css
@@ -430,7 +430,7 @@ tbody .crm-row-child:not(:has(~ .crm-row-child)) td {
 .crm-container .table-hover > tbody > tr:hover > .danger,
 .crm-container .table-hover > tbody > tr.danger:hover > th,
 .crm-container table tr.crm-row-error:hover > td,
-.crm-container table tr.crm-row-error > td:hover  {
+.crm-container table tr.crm-row-error > td:hover {
   background-color: var(--crm-alert-border-danger);
 }
 .crm-container .table td.info,

--- a/ext/riverlea/streams/empty/css/_variables.css
+++ b/ext/riverlea/streams/empty/css/_variables.css
@@ -12,7 +12,6 @@
 --crm-font-bold:;
 --crm-font-italic:;
 --crm-font-bold-italic:;
-
 /* Colour names *
 --crm-c-darkest: #0a0a0a;
 --crm-c-gray-900: #2f2f2e;
@@ -45,7 +44,6 @@
 --crm-c-yellow-less-light: #fffdb2;
 --crm-c-teal: #63c4b9;
 --crm-c-dark-teal: #3e8079;
-
 /* Practical colours *
 --crm-c-text: #464354;
 --crm-c-light-text: #fff;
@@ -79,13 +77,11 @@
 --crm-c-info-text: var(--crm-c-light-text);
 --crm-c-focus: var(--crm-c-blue-dark);
 --crm-c-inactive: #696969;
-
 /* Shadows *
 --crm-block-shadow:;
 --crm-popup-shadow: 0 3px 18px 0 rgba(48,40,40,.25);
 --crm-bottom-shadow: 0 0 16px 1px rgba(0,0,0,.1);
 --crm-body-inset:;
-
 /* Sizes *
 --crm-roundness: 0.25rem;
 --crm-xs: 0.1rem;
@@ -113,7 +109,8 @@
 --crm-padding-small: var(--crm-s);
 --crm-padding-inset: var(--crm-m);
 --crm-page-padding: var(--crm-xl); /* Margin left/right *
---crm-page-width: 100%; /* Default that CMS can overwrite */
+--crm-page-width: 100%; /* Default that CMS can overwrite *
+--crm-flex-gap: 0.5rem;
 /* Type *
 --crm-font-size: var(--crm-r);
 --crm-small-font-size: var(--crm-m2);
@@ -125,10 +122,8 @@
 --crm-heading-padding: var(--crm-s1) var(--crm-m1);
 --crm-heading-margin: var(--crm-m) 0;
 --crm-heading-radius: var(--crm-roundness);
-
 /* Mouse events *
 --crm-hover-clickable: pointer;
-
 /* Buttons *
 --crm-btn-box-shadow: none;
 --crm-btn-border: 0 solid transparent;
@@ -180,13 +175,11 @@
 --crm-table-nested-head-border: 0 solid transparent;
 --crm-table-nested-border: var(--crm-c-divider);
 --crm-table-inset-bg: var(--crm-c-background3);
-
 /* Panels *
 --crm-panel-shadow: var(--crm-block-shadow);
 --crm-panel-background: var(--crm-c-page-background);
 --crm-panel-border: var(--crm-c-divider);
 --crm-panel-head-margin: 0px;
-
 /* Accordions *
 --crm-expand-icon: "\f0da"; /* unicode value for FontAwesome icon *
 --crm-expand-icon-color: var(--text);
@@ -222,7 +215,6 @@
 --crm-expand2-border-width:;
 --crm-expand2-body-bg:;
 --crm-expand2-body-padding: var(--crm-s);
-
 /* Alerts *
 --crm-alert-padding: var(--crm-m) var(--crm-m2);
 --crm-alert-margin: 0 0 var(--crm-m);
@@ -239,7 +231,6 @@
 --crm-alert-background-danger: var(--crm-c-red-light);
 --crm-alert-border-danger: var(--crm-c-red);
 --crm-alert-text-danger: var(--crm-c-red-dark);
-
 /* Form *
 --crm-form-block-box-shadow: var(--crm-block-shadow);
 --crm-form-block-background: var(--crm-c-background);
@@ -272,7 +263,6 @@
 --crm-fieldset-border: 1px 0 0 0;
 --crm-fieldset-padding: var(--crm-padding-reg) var(--crm-padding-small);
 --crm-checkbox-list-col: var(--crm-c-text);
-
 /* Tabs *
 --crm-tabs-bg: var(--crm-c-background4);
 --crm-tabs-padding: var(--crm-s);
@@ -293,7 +283,6 @@
 --crm-tab-border: var(--crm-c-divider);
 --crm-tab-border-width: 0;
 --crm-tab-border-active: 0 solid transparent;
-
 /* Contact dashboard *
 --crm-dash-border: var(--crm-tab-border);
 --crm-dash-roundness: var(--crm-roundness);
@@ -354,7 +343,6 @@
 --crm-dialog-header-border-col: transparent transparent var(--crm-c-gray-300) transparent; /* set a border color for each side of the header *
 --crm-dialog-body-bg: var(--crm-c-background);
 --crm-dialog-body-padding: var(--crm-m);
-
 /* Dashlet *
 --crm-dashlet-border:;
 --crm-dashlet-bg: var(--crm-c-page-background);
@@ -370,7 +358,6 @@
 --crm-dashlet-content-padding: var(--crm-dashlet-padding) 0;
 --crm-dashlet-tabs-border:0;
 --crm-dashlet-radius: var(--crm-roundness);
-
 /* Button dropdowns *
 --crm-dropdown-padding: var(--crm-s);
 --crm-dropdown-radius: var(--crm-roundness);
@@ -384,14 +371,12 @@
 --crm-dropdown-2-bg: var(--crm-c-secondary);
 --crm-dropdown-2-col: var(--crm-c-text);
 --crm-dropdown-2-padding: var(--crm-padding-small);
-
 /* Notifications *
 --crm-notify-background: rgba(0,0,0,0.85);
 --crm-notify-padding: var(--crm-m2);
 --crm-notify-col: var(--crm-c-light-text);
 --crm-notify-accent-border: 2px 0 0 0; /* adds a border to one/several sides of the notification - set to 0 for none *
 --crm-notify-radius: var(--crm-roundness);
-
 /* Icons *
 --crm-icon-alert: "\f06a";
 --crm-icon-success: "\f058";
@@ -404,7 +389,6 @@
 --crm-icon-success-color: inherit;
 --crm-icon-warning-color: inherit;
 --crm-icon-info-color: inherit;
-
 /* Wizard *
 --crm-wizard-width: fit-content;
 --crm-wizard-margin: 0.5rem auto;
@@ -415,7 +399,6 @@
 --crm-wizard-active-bg: var(--crm-c-link);
 --crm-wizard-border: var(--crm-c-divider);
 --crm-wizard-bg: var(--crm-c-page-background);
-
 /* Alpha filter *
 --crm-filter-bg: var(--crm-c-blue-light);
 --crm-filter-padding: var(--crm-m);

--- a/ext/riverlea/streams/walbrook/css/_variables.css
+++ b/ext/riverlea/streams/walbrook/css/_variables.css
@@ -179,7 +179,7 @@
   --crm-dash-header-col: var(--crm-c-light-text);
   --crm-dash-header-size: var(--crm-l);
   --crm-dash-header-padding: var(--crm-r) var(--crm-r1);
-  --crm-dash-image-size: 120px;
+  --crm-dash-image-size: 100px;
   --crm-dash-image-radius: 200px;
   --crm-dash-image-right: 30px; /* distance from right of dashboard */
   --crm-dash-image-top: 30px; /* distance from top of dashboard */


### PR DESCRIPTION
Overview
----------------------------------------
Fixes important regression. Also restores older 1.x version numbering after issue with upgrade notices. In new system, second number is the Civi version it's been tested/built on, and third number is an incremental version number for releases against that (sorry for confusion)

Fixes hidden input regression, contact merge bg cols & others issues.

Before
----------------------------------------
RiverLea version 5.80.9

After
----------------------------------------
RiverLea version 1.80.11 (see [note on version numbering](https://github.com/vingle/civicrm-core/blob/ec3227d60402797c642f60b0f372c340e4970378/ext/riverlea/README.md))

Technical Details
----------------------------------------
 - FIXED SIGNIFICANT REGRESSION - changed specificity of .hiddenElement ([ext/riverlea/#11](https://lab.civicrm.org/extensions/riverlea/-/issues/11#note_173838)) to ensure unhidden elements are unhidden.
 - FIXED - Wallbrook avatar image returned to 100px as had created a gap ([ext/riverlea/#87](https://lab.civicrm.org/extensions/riverlea/-/issues/87#note_173844))
 - FIXED - Double icon on .messages.crm-empty-table
 - CHANGED - version numbering again. See note in ReadMe: the 2nd number represents the Civi version tested against, the 3rd number is the RL version number for that Civi version.
 - CHANGED - Alert colour bg for .messages.crm-empty-table now matches icon colour ('info' range)
 - CHANGED - streams/empty/_variables.css to match core variables.css
 - CHANGED - reduce verbose Bootstrap table styling css in tables.css
 - CHANGED - cascade order of table colours to put .crm-row-selected class last
 - ADDED - contact merge screen error/ok/selected background colours ([ext/riverlea/#88](https://lab.civicrm.org/extensions/riverlea/-/issues/88)) - see screengrab.
 - ADDED - margin (`--crm-flex-gap`) to bottom of .description text.
 - ADDED - accordion with error text and border colour to fix contrast ratio issues
 - ADDED - D9 Claro .action-link margin reset
 
 Comments
 ----------------------------------------
 Changes to contact merge background colours seen across all four streams (using their default success/error/info colours):
 
<img width="801" alt="image" src="https://github.com/user-attachments/assets/d7d8ce6f-70a4-48e3-8d6a-453f77fe5016">
