### PR TITLE
Add value check in DisplayProfile.tpl

### DIFF
--- a/templates/CRM/Event/Form/Registration/DisplayProfile.tpl
+++ b/templates/CRM/Event/Form/Registration/DisplayProfile.tpl
@@ -12,30 +12,55 @@
         <div class="crm-group participant_info-group">
       <div class="header-dark">{if $addParticipantProfile}{ts}Participant 1{/ts}{else}{ts}Participant Information{/ts}{/if}</div>
             {if $primaryParticipantProfile.CustomPre}
-               <fieldset class="label-left no-border"><div class="bold crm-profile-view-title">{$primaryParticipantProfile.CustomPreGroupTitle}</div>
+              {assign var="hasValue" value=false}
+              {foreach from=$primaryParticipantProfile.CustomPre item=value key=field}
+                {if $value !== ''}
+                  {assign var="hasValue" value=true}
+                {/if}
+              {/foreach}
+
+              {if $hasValue}
+                <fieldset class="label-left no-border">
+                   <div class="bold crm-profile-view-title">{$primaryParticipantProfile.CustomPreGroupTitle}</div>
                    {foreach from=$primaryParticipantProfile.CustomPre item=value key=field}
-                      <div class="crm-public-form-item crm-section {$field}-section">
-                          <div class="label">{$field}</div>
-                          <div class="content">{$value}</div>
-                          <div class="clear"></div>
-                      </div>
-                   {/foreach}
-               </fieldset>
-            {/if}
-         {if array_key_exists('CustomPost', $primaryParticipantProfile) && $primaryParticipantProfile.CustomPost}
-               {foreach from=$primaryParticipantProfile.CustomPost item=value key=field}
-                  <fieldset class="label-left no-border"><div class="bold crm-profile-view-title">{$primaryParticipantProfile.CustomPostGroupTitle.$field.groupTitle}</div>
-                    <div class="crm-profile-view">
-                      {foreach from=$primaryParticipantProfile.CustomPost.$field item=value key=field}
+                      {if $value !== ''}
                         <div class="crm-public-form-item crm-section {$field}-section">
-                          <div class="label">{$field}</div>
-                          <div class="content">{$value}</div>
-                          <div class="clear"></div>
+                            <div class="label">{$field}</div>
+                            <div class="content">{$value}</div>
+                            <div class="clear"></div>
                         </div>
-                      {/foreach}
+                      {/if}
+                   {/foreach}
+                </fieldset>
+              {/if}
+            {/if}
+
+            {if array_key_exists('CustomPost', $primaryParticipantProfile) && $primaryParticipantProfile.CustomPost}
+              {foreach from=$primaryParticipantProfile.CustomPost item=fieldValues key=field}
+                {assign var="hasValue" value=false}
+                {foreach from=$fieldValues item=value}
+                  {if $value !== ''}
+                    {assign var="hasValue" value=true}
+                  {/if}
+                {/foreach}
+
+                {if $hasValue}
+                  <fieldset class="label-left no-border">
+                    <div class="bold crm-profile-view-title">{$primaryParticipantProfile.CustomPostGroupTitle.$field.groupTitle}</div>
+                    <div class="crm-profile-view">
+                    {foreach from=$fieldValues item=value key=field}
+                      {if $value !== ''}
+                        <div class="crm-public-form-item crm-section {$field}-section">
+                            <div class="label">{$field}</div>
+                            <div class="content">{$value}</div>
+                            <div class="clear"></div>
+                        </div>
+                      {/if}
+                    {/foreach}
                     </div>
                   </fieldset>
-               {/foreach}
+                {/if}
+              {/foreach}
             {/if}
         </div>
         <div class="spacer"></div>
@@ -49,32 +74,56 @@
                     {ts 1=$participantNo}Participant %1{/ts}
                 </div>
             {if $participant.additionalCustomPre}
-              <fieldset class="label-left no-border"><div class="bold crm-additional-profile-view-title">{$participant.additionalCustomPreGroupTitle}</div>
-                <div class="crm-profile-view">
-                  {foreach from=$participant.additionalCustomPre item=value key=field}
-                    <div class="crm-public-form-item crm-section {$field}-section">
-                      <div class="label">{$field}</div>
-                      <div class="content">{$value}</div>
-                      <div class="clear"></div>
-                    </div>
-                  {/foreach}
-                </div>
-              </fieldset>
-            {/if}
+              {assign var="hasValue" value=false}
+              {foreach from=$participant.additionalCustomPre item=value}
+                {if $value !== ''}
+                  {assign var="hasValue" value=true}
+                {/if}
+              {/foreach}
 
-            {if $participant.additionalCustomPost}
-              {foreach from=$participant.additionalCustomPost item=value key=field}
-                <fieldset class="label-left no-border"><div class="bold crm-additional-profile-view-title">{$participant.additionalCustomPostGroupTitle.$field.groupTitle}</div>
+              {if $hasValue}
+                <fieldset class="label-left no-border">
+                  <div class="bold crm-additional-profile-view-title">{$participant.additionalCustomPreGroupTitle}</div>
                   <div class="crm-profile-view">
-                    {foreach from=$participant.additionalCustomPost.$field item=value key=field}
-                      <div class="crm-public-form-item crm-section {$field}-section">
-                        <div class="label">{$field}</div>
-                        <div class="content">{$value}</div>
-                        <div class="clear"></div>
-                      </div>
+                    {foreach from=$participant.additionalCustomPre item=value key=field}
+                      {if $value !== ''}
+                        <div class="crm-public-form-item crm-section {$field}-section">
+                          <div class="label">{$field}</div>
+                          <div class="content">{$value}</div>
+                          <div class="clear"></div>
+                        </div>
+                      {/if}
                     {/foreach}
                   </div>
                 </fieldset>
+              {/if}
+            {/if}
+
+            {if $participant.additionalCustomPost}
+              {foreach from=$participant.additionalCustomPost item=fieldValues key=field}
+                {assign var="hasValue" value=false}
+                {foreach from=$fieldValues item=value}
+                  {if $value !== ''}
+                    {assign var="hasValue" value=true}
+                  {/if}
+                {/foreach}
+
+                {if $hasValue}
+                  <fieldset class="label-left no-border">
+                    <div class="bold crm-additional-profile-view-title">{$participant.additionalCustomPostGroupTitle.$field.groupTitle}</div>
+                    <div class="crm-profile-view">
+                    {foreach from=$fieldValues item=value key=field}
+                      {if $value !== ''}
+                        <div class="crm-public-form-item crm-section {$field}-section">
+                            <div class="label">{$field}</div>
+                            <div class="content">{$value}</div>
+                            <div class="clear"></div>
+                        </div>
+                      {/if}
+                    {/foreach}
+                    </div>
+                  </fieldset>
+                {/if}
               {/foreach}
             {/if}
             </div>


### PR DESCRIPTION
Overview
----------------------------------------
Ensure labels for empty fields aren't displayed in Event registration confirmation pages. 

Before
----------------------------------------
No value was submitted for the 'soup selection' field, but the label (and empty content) is showing.
![Screenshot 2024-11-29 at 16 24 47](https://github.com/user-attachments/assets/b14dd492-7563-4613-882f-5fcc7d6adf0b)

After
----------------------------------------
After, if no value has been submitted for that profile field, the label does not display.

Comments
----------------------------------------
A similar issue occurs on contribution pages, which I haven't fixed yet.
