### PR TITLE
Afform - Add (no placeholder) placeholder in FormBuilder

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/inputType/Email.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/Email.html
@@ -1,6 +1,6 @@
 <div class="form-inline">
   <div class="form-group" ng-repeat="i in $ctrl.getRangeElements('Text')">
     <span class="af-field-range-sep" ng-if="i">-</span>
-    <input autocomplete="off" class="form-control" ng-model="getSet('input_attrs.placeholder' + i)" ng-model-options="$ctrl.editor.debounceWithGetterSetter" type="text" title="{{:: ts('Click to add placeholder text') }}"/>
+    <input autocomplete="off" class="form-control" placeholder="{{:: ts('(no placeholder)') }}" ng-model="getSet('input_attrs.placeholder' + i)" ng-model-options="$ctrl.editor.debounceWithGetterSetter" type="text" title="{{:: ts('Click to add placeholder text') }}"/>
   </div>
 </div>

--- a/ext/afform/admin/ang/afGuiEditor/inputType/Text.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/Text.html
@@ -1,6 +1,6 @@
 <div class="form-inline">
   <div class="form-group" ng-repeat="i in $ctrl.getRangeElements('Text')">
     <span class="af-field-range-sep" ng-if="i">-</span>
-    <input autocomplete="off" class="form-control" ng-model="getSet('input_attrs.placeholder' + i)" ng-model-options="$ctrl.editor.debounceWithGetterSetter" type="text" title="{{:: ts('Click to add placeholder text') }}"/>
+    <input autocomplete="off" class="form-control" placeholder="{{:: ts('(no placeholder)') }}" ng-model="getSet('input_attrs.placeholder' + i)" ng-model-options="$ctrl.editor.debounceWithGetterSetter" type="text" title="{{:: ts('Click to add placeholder text') }}"/>
   </div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Make it more obvious that placeholders can be added by typing into the field.
Per discussion in https://lab.civicrm.org/dev/core/-/issues/3070#note_173869

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/11aeac37-09e5-4e37-a666-2b8bf7d04f8d)


After
----------------------------------------
![image](https://github.com/user-attachments/assets/ec2fd97a-2bcc-4eea-af71-29fc5e73d9eb)

