### PR TITLE
(NFC) Improve comment on CIVICRM_CONTAINER_CACHE

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -48,7 +48,7 @@ class Container {
    * each (eg "templates_c/CachedCiviContainer.$ENVID.php").
    *
    * Constants:
-   *   - CIVICRM_CONTAINER_CACHE -- 'always' [default], 'never', 'auto'
+   *   - CIVICRM_CONTAINER_CACHE -- 'auto' [default], 'always', 'never',
    *   - CIVICRM_DSN
    *   - CIVICRM_DOMAIN_ID
    *


### PR DESCRIPTION
Overview
----------------------------------------
Improve comment on CIVICRM_CONTAINER_CACHE.

In https://github.com/civicrm/civicrm-core/commit/5497e01657c1ad34a2b415985d22b42a96b22608 the default was changed from `always` to `auto`, but the comment was never updated and contradicted this. This caused me some confusion recently when I was looking at how this part of the codebase works.
