### PR TITLE
[REF][PHP8.2] Declare properies in CRM_Contact_Page_View_GroupContact

### DIFF
--- a/CRM/Contact/Page/View/GroupContact.php
+++ b/CRM/Contact/Page/View/GroupContact.php
@@ -17,6 +17,14 @@
 class CRM_Contact_Page_View_GroupContact extends CRM_Core_Page {
 
   /**
+   * The contact being viewed
+   *
+   * @var int
+   * @internal
+   */
+  public $_contactId;
+
+  /**
    * Called when action is browse.
    */
   public function browse() {


### PR DESCRIPTION
Overview
----------------------------------------
Declare properies in `CRM_Contact_Page_View_GroupContact`

Before
----------------------------------------
`Creation of dynamic property CRM_Contact_Page_View_GroupContact::$_contactId is deprecated`

After
----------------------------------------
No such deprecation

Technical Details
----------------------------------------
This probably could/should be `protected`, but keeping it public keeps the risk and testing required to a minimum.