### PR TITLE
[REF][PHP8.2] Declare _mailingID property

### DIFF
--- a/CRM/SMS/Form/Schedule.php
+++ b/CRM/SMS/Form/Schedule.php
@@ -19,6 +19,13 @@ class CRM_SMS_Form_Schedule extends CRM_Core_Form {
   public $submitOnce = TRUE;
 
   /**
+   * The mailing ID being scheduled
+   *
+   * @var int
+   */
+  protected $_mailingID;
+
+  /**
    * Set variables up before form is built.
    */
   public function preProcess() {


### PR DESCRIPTION
Overview
----------------------------------------
Declare _mailingID property

Before
----------------------------------------
Undeclared `_mailingID` property, causing deprecation notices.

After
----------------------------------------
Fixed.
