### PR TITLE
[REF][PHP8.2] Declare missing properties: CRM_Admin_Form_MessageTemplates

### DIFF
--- a/CRM/Admin/Form/MessageTemplates.php
+++ b/CRM/Admin/Form/MessageTemplates.php
@@ -42,6 +42,20 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Core_Form {
   public $submitOnce = TRUE;
 
   /**
+   * The ID of the message template being edited
+   *
+   * @var int
+   */
+  protected $_id;
+
+  /**
+   * The (current) message template database values
+   *
+   * @var array
+   */
+  protected $_values;
+
+  /**
    * PreProcess form - load existing values.
    *
    * @throws \CRM_Core_Exception


### PR DESCRIPTION
Overview
----------------------------------------
Declare missing properties: CRM_Admin_Form_MessageTemplates.

Before
----------------------------------------
Missing properties, causing deprecation notices on PHP 8.2.

After
----------------------------------------
Fixed.