### PR TITLE
Remove unreachable code in CRM_Report_Form_Mailing_Summary

### DIFF
--- a/CRM/Report/Form/Mailing/Summary.php
+++ b/CRM/Report/Form/Mailing/Summary.php
@@ -435,17 +435,12 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
             $op = $this->_params["{$fieldName}_op"] ?? NULL;
 
             if ($op) {
-              if ($fieldName == 'relationship_type_id') {
-                $clause = "{$this->_aliases['civicrm_relationship']}.relationship_type_id=" . $this->relationshipId;
-              }
-              else {
-                $clause = $this->whereClause($field,
-                  $op,
-                  $this->_params["{$fieldName}_value"] ?? NULL,
-                  $this->_params["{$fieldName}_min"] ?? NULL,
-                  $this->_params["{$fieldName}_max"] ?? NULL
-                );
-              }
+              $clause = $this->whereClause($field,
+                $op,
+                $this->_params["{$fieldName}_value"] ?? NULL,
+                $this->_params["{$fieldName}_min"] ?? NULL,
+                $this->_params["{$fieldName}_max"] ?? NULL
+              );
             }
           }
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove unreachable code in `CRM_Report_Form_Mailing_Summary`.

Before
----------------------------------------
I noticed `$this->relationshipId` being flagged as un undeclared property by a code quality tool I'm using. Closer investigation shows that this report does not allow filtering by relationship, and so this code is not reachable. It looks to have been incorrectly copy and pasted from `CRM_Report_Form_Contribute_HouseholdSummary` or `CRM_Report_Form_Contribute_OrganizationSummary`.

After
----------------------------------------
Remove the unreachable code.
