### PR TITLE
dev/core#5626 SMS messages incorrectly contain header and footer

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1068,8 +1068,8 @@ ORDER BY   civicrm_email.is_bulkmail DESC
         'url_tracking' => Civi::settings()->get('url_tracking_default'),
         'visibility' => 'Public Pages',
         'replyto_email' => $domain_email,
-        'header_id' => CRM_Mailing_PseudoConstant::defaultComponent('Header', ''),
-        'footer_id' => CRM_Mailing_PseudoConstant::defaultComponent('Footer', ''),
+        'header_id' => NULL,
+        'footer_id' => NULL,
         'from_email' => $domain_email,
         'from_name' => $domain_name,
         'msg_template_id' => NULL,
@@ -1083,6 +1083,10 @@ ORDER BY   civicrm_email.is_bulkmail DESC
         'start_date' => NULL,
         'end_date' => NULL,
       ];
+      if (CRM_Utils_System::isNull($params['sms_provider_id'] ?? NULL)) {
+        $defaults['header_id'] = CRM_Mailing_PseudoConstant::defaultComponent('Header', '');
+        $defaults['footer_id'] = CRM_Mailing_PseudoConstant::defaultComponent('Footer', '');
+      }
 
       // Get the default from email address, if not provided.
       if (empty($defaults['from_email'])) {
@@ -1915,8 +1919,10 @@ LEFT JOIN civicrm_mailing_group g ON g.mailing_id   = m.id
       $params['dedupe_email'] ??= Civi::settings()->get('dedupe_email_default');
       $params['open_tracking'] ??= Civi::settings()->get('open_tracking_default');
       $params['url_tracking'] ??= Civi::settings()->get('url_tracking_default');
-      $params['header_id'] ??= CRM_Mailing_PseudoConstant::defaultComponent('Header', '');
-      $params['footer_id'] ??= CRM_Mailing_PseudoConstant::defaultComponent('Footer', '');
+      if (CRM_Utils_System::isNull($params['sms_provider_id'] ?? NULL)) {
+        $params['header_id'] ??= CRM_Mailing_PseudoConstant::defaultComponent('Header', '');
+        $params['footer_id'] ??= CRM_Mailing_PseudoConstant::defaultComponent('Footer', '');
+      }
       $params['optout_id'] ??= CRM_Mailing_PseudoConstant::defaultComponent('OptOut', '');
       $params['reply_id'] ??= CRM_Mailing_PseudoConstant::defaultComponent('Reply', '');
       $params['resubscribe_id'] ??= CRM_Mailing_PseudoConstant::defaultComponent('Resubscribe', '');

--- a/tests/phpunit/CRM/Mailing/MailingHeaderFooterTest.php
+++ b/tests/phpunit/CRM/Mailing/MailingHeaderFooterTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Test that email headers and footers work as expected.
+ *
+ * @package CiviCRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+use Civi\Api4\OptionValue;
+
+/**
+ * Class CRM_Mailing_MailingHeaderFooterTest
+ * @group headless
+ */
+class CRM_Mailing_MailingHeaderFooterTest extends CiviUnitTestCase {
+
+  /**
+   * The group ID.
+   *
+   * @var int
+   */
+  protected $groupID;
+
+  public function setUp(): void {
+    parent::setUp();
+    $this->groupID = $this->groupCreate();
+  }
+
+  /**
+   * Clean up after tests.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function tearDown(): void {
+    $this->quickCleanup(['civicrm_group']);
+    OptionValue::delete(FALSE)->addWhere('name', '=', 'CiviTestSMSProvider')->execute();
+    parent::tearDown();
+  }
+
+  /**
+   * Test that a new email has the default header and footer.
+   */
+  public function testNewEmailHasDefaultHeaderFooter() : void {
+    $mailing = $this->callAPISuccess('Mailing', 'create', [
+      'sequential' => 1,
+      'name' => 'mailing name',
+      'created_id' => 1,
+      'groups' => ['include' => [$this->groupID]],
+      'scheduled_date' => 'now',
+      'subject' => 'My really interesting subject',
+      'body_text' => 'Hello world',
+    ]);
+
+    $defaultHeader = CRM_Mailing_PseudoConstant::defaultComponent('Header', '');
+    $defaultFooter = CRM_Mailing_PseudoConstant::defaultComponent('Footer', '');
+    $this->assertEquals($mailing['values'][0]['header_id'], $defaultHeader);
+    $this->assertEquals($mailing['values'][0]['footer_id'], $defaultFooter);
+  }
+
+  /**
+   * Test that a new email has the default header and footer.
+   */
+  public function testNewEmailCustomHeaderFooter() : void {
+    $mailingComponentHeader = $this->createTestEntity('MailingComponent', [
+      'name' => 'Custom Header',
+      'component_type' => 'Header',
+      'is_active' => 1,
+      'is_default' => 0,
+    ]);
+    $mailingComponentFooter = $this->createTestEntity('MailingComponent', [
+      'name' => 'Custom Footer',
+      'component_type' => 'Footer',
+      'is_active' => 1,
+      'is_default' => 0,
+    ]);
+
+    $mailing = $this->callAPISuccess('Mailing', 'create', [
+      'sequential' => 1,
+      'name' => 'mailing name',
+      'created_id' => 1,
+      'groups' => ['include' => [$this->groupID]],
+      'scheduled_date' => 'now',
+      'header_id' => $mailingComponentHeader['name'],
+      'footer_id' => $mailingComponentFooter['name'],
+      'subject' => 'My really interesting subject',
+      'body_text' => 'Hello world',
+    ]);
+
+    $this->assertEquals($mailing['values'][0]['header_id'], $mailingComponentHeader['id']);
+    $this->assertEquals($mailing['values'][0]['footer_id'], $mailingComponentFooter['id']);
+  }
+
+  /**
+   * Test that a new sms has no header and footer
+   */
+  public function testNewSMSNoHeaderFooter() : void {
+    $smsProvider = civicrm_api3('SmsProvider', 'create', [
+      'name' => 'CiviTestSMSProvider',
+      'api_type' => 1,
+      'username' => 1,
+      'password' => 1,
+      'api_url' => 1,
+      'api_params' => 'a=1',
+      'is_default' => 1,
+      'is_active' => 1,
+      'domain_id' => 1,
+    ])['id'];
+
+    $mailing = $this->callAPISuccess('Mailing', 'create', [
+      'sequential' => 1,
+      'name' => 'mailing name',
+      'created_id' => 1,
+      'groups' => ['include' => [$this->groupID]],
+      'scheduled_date' => 'now',
+      'subject' => 'My really interesting subject',
+      'body_text' => 'Hello world',
+      'sms_provider_id' => $smsProvider,
+    ]);
+
+    $this->assertEquals($mailing['values'][0]['header_id'], NULL);
+    $this->assertEquals($mailing['values'][0]['footer_id'], NULL);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
SMS messages incorrectly contain header and footer

Before
----------------------------------------
New SMS' incorrectly contained the email header and footer:

![image](https://github.com/user-attachments/assets/fc063c4b-6b2e-4c05-bf64-7defa33ad1ca)

The opt-out link doesn't work in a SMS context.

After
----------------------------------------
SMS' do not contain the header and footer.

Technical Details
----------------------------------------
I think this issue was introduced in https://github.com/civicrm/civicrm-core/commit/9b567ec2dbbb6a5dffe0805ca40098bfa454bd8a. 

I figured some tests were a good idea, but I'm not totally satisfied with the approach I've taken. Perhaps there was a better way to test this?
