### PR TITLE
standaloneusers - translate password reset page titles

### DIFF
--- a/ext/standaloneusers/ang/crmResetPassword/crmResetPassword.html
+++ b/ext/standaloneusers/ang/crmResetPassword/crmResetPassword.html
@@ -3,7 +3,7 @@
   <form name="requestLink" crm-ui-id-scope
     ng-if="!$ctrl.formSubmitted && !$ctrl.token">
 
-    <h1>Request Password Reset Link</h1>
+    <h1>{{ts('Request Password Reset Link')}}</h1>
 
     <div class="input-wrapper">
       <label crm-ui-for="identifier">{{ts('Enter the username or email on your account')}}</label>
@@ -28,7 +28,7 @@
 
   <!-- without a token, we offer for them to generate one. -->
   <form ng-if="$ctrl.token && $ctrl.token !== 'invalid' && !$ctrl.formSubmitted" name="resetPassword" crm-ui-id-scope >
-    <h1>Reset Password</h1>
+    <h1>{{ts('Reset Password')}}</h1>
 
     <div class="input-wrapper">
       <label crm-ui-for="newPassword">{{ts('Enter a new password')}}</label>

--- a/ext/standaloneusers/ang/crmResetPassword/crmResetPassword.html
+++ b/ext/standaloneusers/ang/crmResetPassword/crmResetPassword.html
@@ -3,10 +3,10 @@
   <form name="requestLink" crm-ui-id-scope
     ng-if="!$ctrl.formSubmitted && !$ctrl.token">
 
-    <h1>{{ts('Request Password Reset Link')}}</h1>
+    <h1>{{:: ts('Request Password Reset Link')}}</h1>
 
     <div class="input-wrapper">
-      <label crm-ui-for="identifier">{{ts('Enter the username or email on your account')}}</label>
+      <label crm-ui-for="identifier">{{:: ts('Enter the username or email on your account')}}</label>
       <input
           crm-ui-id="identifier"
           name="identifier"
@@ -16,22 +16,22 @@
           />
     </div>
 
-    <button class=crm-button ng-click="$ctrl.requestPasswordResetEmail()" >{{ts('Request Password Reset')}}</button>
+    <button class=crm-button ng-click="$ctrl.requestPasswordResetEmail()" >{{:: ts('Request Password Reset')}}</button>
   </form>
 
   <div ng-if="$ctrl.resetSuccessfullySubmitted" class="help" >
-    <p>{{ts('Thanks. If your username/email matched an active account, we will email you with a special link to provide a new password.')}}</p>
-    <p>{{ts('The link must be used within an hour, and can only be used once.')}}</p>
+    <p>{{:: ts('Thanks. If your username/email matched an active account, we will email you with a special link to provide a new password.')}}</p>
+    <p>{{:: ts('The link must be used within an hour, and can only be used once.')}}</p>
   </div>
 
   <div ng-if="$ctrl.busy" >{{$ctrl.busy}}</div>
 
   <!-- without a token, we offer for them to generate one. -->
   <form ng-if="$ctrl.token && $ctrl.token !== 'invalid' && !$ctrl.formSubmitted" name="resetPassword" crm-ui-id-scope >
-    <h1>{{ts('Reset Password')}}</h1>
+    <h1>{{:: ts('Reset Password')}}</h1>
 
     <div class="input-wrapper">
-      <label crm-ui-for="newPassword">{{ts('Enter a new password')}}</label>
+      <label crm-ui-for="newPassword">{{:: ts('Enter a new password')}}</label>
       <input
           crm-ui-id="newPassword"
           name="newPassword"
@@ -41,7 +41,7 @@
           />
     </div>
     <div class="input-wrapper">
-      <label crm-ui-for="newPasswordAgain">{{ts('Re-enter new password')}}</label>
+      <label crm-ui-for="newPasswordAgain">{{:: ts('Re-enter new password')}}</label>
       <input
           crm-ui-id="newPasswordAgain"
           name="newPasswordAgain"
@@ -50,16 +50,16 @@
           type=password
           />
       <span class="crm-error" ng-show="$ctrl.newPasswordAgain && $ctrl.newPassword && $ctrl.newPassword !== $ctrl.newPasswordAgain">
-          {{ts('Passwords do not match')}}
+          {{:: ts('Passwords do not match')}}
       </span>
     </div>
 
-    <button class=crm-button ng-click="$event.preventDefault();$ctrl.attemptChange()" ng-disabled="$ctrl.formSubmitted">{{ts('Change Password')}}</button>
+    <button class=crm-button ng-click="$event.preventDefault();$ctrl.attemptChange()" ng-disabled="$ctrl.formSubmitted">{{:: ts('Change Password')}}</button>
   </form>
 
   <div ng-if="$ctrl.token === 'invalid'" >
-    <p>{{ts("This password reset link has expired or is otherwise invalid.")}}</p>
-    <p><a href ng-click="$ctrl.completeReset()">{{ts('Send new password reset link')}}</a></p>
+    <p>{{:: ts("This password reset link has expired or is otherwise invalid.")}}</p>
+    <p><a href ng-click="$ctrl.completeReset()">{{:: ts('Send new password reset link')}}</a></p>
   </div>
 
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Just noticed these titles missing `ts` wrappers which I think they should have?

- use ts for these
- switch ts to use one-time angular bindings throughout the template for static content

Note: translation doesn't seem to be working at all on this page - or the login page. But I think that is a separate issue.