### PR TITLE
dev/core#5611 - exclude ext tests from tarball

### DIFF
--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -140,6 +140,7 @@ function dm_install_coreext() {
 
   local repo="$1"
   local to="$2"
+  local excludes_rsync="--exclude=tests"
   shift
   shift
 


### PR DESCRIPTION
Overview
----------------------------------------
Followup to https://github.com/civicrm/civicrm-core/pull/31498 and is the part that https://lab.civicrm.org/dev/core/-/issues/5611 was actually about

Before
----------------------------------------
sites/all/modules/civicrm/ext/legacycustomsearches/tests/phpunit/bootstrap.php flagged as bad file (incorrectly but whatever)

After
----------------------------------------
file not included in tarball

Technical Details
----------------------------------------


Comments
----------------------------------------
I have no idea if this works since I've never run distmaker. Will add the tag and see what happens.
