### PR TITLE
composer.json - Lighten up the load from bower_components/monaco-editor

### DIFF
--- a/Civi/ComposerTasks.php
+++ b/Civi/ComposerTasks.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Civi;
+
+use Symfony\Component\Finder\Finder;
+
+class ComposerTasks {
+
+  /**
+   * Find Javascript files and remove the "sourceMappingURL" option.
+   *
+   * @param array $task
+   *   Ex: ['src-path' => 'bower_components/foo']
+   * @return void
+   */
+  public static function stripSourceMap(array $task = []): void {
+    if (empty($task['src-path']) || !is_string($task['src-path']) || strpos($task['src-path'], '..') !== FALSE) {
+      throw new \LogicException("stripSourceMap(): Task must specify a valid 'src-path'");
+    }
+    $path = dirname(__DIR__) . '/' . $task['src-path'];
+    $files = (new Finder())->files()->name('*.js')->in($path)->ignoreVCS(TRUE);
+    foreach ($files as $file) {
+      $code = file_get_contents($file);
+      $lines = explode("\n", $code);
+      $filteredLines = preg_grep(';^//# sourceMappingURL=;', $lines, PREG_GREP_INVERT);
+      if (count($lines) > count($filteredLines)) {
+        \CCL::dumpFile($file, implode("\n", $filteredLines));
+      }
+    }
+  }
+
+}

--- a/composer.compile.json
+++ b/composer.compile.json
@@ -1,0 +1,9 @@
+{
+  "compile": [
+    {
+      "title": "Optimize Monaco",
+      "run": ["@php-method \\Civi\\ComposerTasks::stripSourceMap"],
+      "src-path": "bower_components/monaco-editor"
+    }
+  ]
+}

--- a/composer.json
+++ b/composer.json
@@ -231,7 +231,7 @@
       "monaco-editor": {
         "url": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.49.0.tgz",
         "path": "bower_components/monaco-editor",
-        "ignore": ["dev", "esm"]
+        "ignore": ["dev", "esm", "min-maps", "min/vs/language/typescript"]
       },
       "google-code-prettify": {
         "url": "https://github.com/tcollard/google-code-prettify/archive/v1.0.5.zip",

--- a/composer.json
+++ b/composer.json
@@ -299,7 +299,7 @@
         "CiviCRM Custom patch to fix a php8.1 issue found in CiviCRM unit tests": "https://raw.githubusercontent.com/civicrm/civicrm-core/5506f4ce5d46799857b4f4ddf34069e7541e9cc5/tools/scripts/composer/zetacomponents-php-81-civicrm-custom.patch"
       }
     },
-    "compile-includes": ["ext/greenwich/composer.compile.json"],
+    "compile-includes": ["composer.compile.json", "ext/greenwich/composer.compile.json"],
     "compile-whitelist": ["civicrm/composer-compile-lib"]
   }
 }


### PR DESCRIPTION
Overview
----------------------------------------

Drop files that we don't need to ship for runtime. In particular, it drops Javascript debugging files and TypeScript language-services.

Before
----------------------------------------

`du -sm bower_components/monaco-editor` shows 29 MB.

After
----------------------------------------

`du -sm bower_components/monaco-editor` shows 9 MB.

This corresponds to -20 MB (on disk) aka -4.5M (zip format).