### PR TITLE
RiverLea (1.80.13): Message Template afform cleanup, .crm-pager layout, Joomla underline bug, Thames tables

### DIFF
--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -1,3 +1,13 @@
+1.80.13
+ - FIXED - removed margin on ul.nav that's added by browser/CMS theme ul styling (seen on Message Template Afform)
+ - FIXED - extra box-shadow from .panel-heading (was creating an odd dble shadow)
+ - FIXED - clipped overflowing responsive tables in Thames (ref https://lab.civicrm.org/extensions/riverlea/-/issues/90)
+ - FIXED - .crm-pager padding/positioning (ref https://lab.civicrm.org/extensions/riverlea/-/issues/11#note_173013) - also removed hidden top pager from some results.
+ - FIXED - Joomla4+ Atum admin theme bug that adds underline on dropdown menu links
+ - CHANGED - removed second drop-shadow on BS .panel inside a .panel (visible in Walbrook, e.g. Message Template Afform).
+ - CHANGED - more balanced padding in panel-heading.
+ - ADDED - .nav.nav-pills style based on buttons Message Template Afform.
+
 1.80.12
  - CHANGED - CRM Status Update page - added drop-shadow to dropdowns, made dropdown button border transparent, made h3 text colour match background variable.
  - CHANGED - Minetta active accordion tab and panel bg colour now matches Greenwich

--- a/ext/riverlea/core/css/_core.css
+++ b/ext/riverlea/core/css/_core.css
@@ -4,5 +4,5 @@
    can be merged later. */
 
 @import url(components/_accordion.css); @import url(components/_alerts.css); @import url(components/_buttons.css); @import url(components/_form.css); @import url(components/_icons.css); @import url(components/_nav.css); @import url(components/_tabs.css); @import url(components/_dropdowns.css); @import url(components/_tables.css); @import url(components/_dialogs.css); @import url(components/_page.css); @import url(components/_components.css); @import url(components/_front.css); :root {
-  --crm-release: '1.80.12';
+  --crm-release: '1.80.13';
 }

--- a/ext/riverlea/core/css/_fixes.css
+++ b/ext/riverlea/core/css/_fixes.css
@@ -638,7 +638,6 @@ tr.crm-preferences-display-form-block-contact_edit_options td table {
 .crm-case_search-accordion .crm-accordion-body .form-layout > tbody:first-child > tr:nth-of-type(1) > td:nth-of-type(1) label + input {
   margin-left: -0.6rem;
 }
-
 /* Member */
 .page-civicrm-member-search .CRM_Member_Form_Search .crm-accordion-body tr:last-child td {
   padding-top: var(--crm-r);

--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -403,7 +403,7 @@
   --crm-filter-padding: var(--crm-m);
   --crm-filter-item-bg: #fafafa;
   --crm-filter-item-shadow: 0px 0px 3px rgba(0,0,0,0.1);
-  --crm-filter-spacing: start; /* choose 'space-between' to spread out evenly, or 'end' to right align. */
+  --crm-filter-spacing: space-between; /* choose 'space-between' to spread out evenly, 'start' for left align, or 'end' for right. */
 /* Frontend */
   --crm-f-form-width: unset;
   --crm-f-box-shadow: var(--crm-block-shadow);

--- a/ext/riverlea/core/css/components/_buttons.css
+++ b/ext/riverlea/core/css/components/_buttons.css
@@ -4,7 +4,8 @@
 .crm-container .crm-button,
 .crm-container [type="button"],
 .crm-container [type="reset"],
-.crm-container [type="submit"] {
+.crm-container [type="submit"],
+.crm-container .nav.nav-pills li.navitem a {
   white-space: nowrap;
   touch-action: manipulation;
   cursor: var(--crm-hover-clickable);
@@ -42,6 +43,16 @@
   background: var(--crm-c-primary-hover);
   color: var(--crm-c-primary-hover-text);
   text-decoration: none;
+}
+.crm-container .nav.nav-pills li.navitem:not(.active) a {
+  background-color: transparent;
+  border-color: transparent;
+  color: var(--crm-c-link);
+}
+.crm-container .nav.nav-pills li.navitem:not(.active) a:hover,
+.crm-container .nav.nav-pills li.navitem:not(.active) a:focus {
+  background-color: transparent;
+  color: var(--crm-c-link-hover);
 }
 .crm-button:focus,
 .crm-container .btn:focus,

--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -109,9 +109,10 @@ table.advmultiselect {
 }
 .crm-container #wizard-steps,
 .crm-container ul.crm-wizard-nav,
-.crm-mosaico-wizard .crm_wizard__title ul {
+.crm-container .crm-mosaico-wizard .crm_wizard__title ul {
   margin: var(--crm-wizard-margin) !important;
   width: var(--crm-wizard-width);
+  gap: initial; /* resets .nav.nav-pills gap */
 }
 .crm-container ul.crm-wizard-nav {
   margin-bottom: var(--crm-r);
@@ -207,10 +208,9 @@ table.advmultiselect {
   background: transparent;
 }
 .crm-container .panel-heading {
-  padding: var(--crm-padding-reg);
+  padding: var(--crm-m2) var(--crm-padding-reg);
   border-radius: var(--crm-roundness) var(--crm-roundness) 0 0;
   border-bottom: var(--crm-panel-border);
-  box-shadow: var(--crm-panel-shadow);
 }
 .crm-container .panel-heading > .dropdown .dropdown-toggle {
   color: inherit;
@@ -307,6 +307,9 @@ table.advmultiselect {
 .crm-container .panel:has(.nav.nav-tabs) {
   border: var(--crm-tabs-border);
   border-radius: var(--crm-tabs-radius);
+}
+.crm-container .panel .panel {
+  box-shadow: none;
 }
 
 /* Badges - from BS3 */

--- a/ext/riverlea/core/css/components/_nav.css
+++ b/ext/riverlea/core/css/components/_nav.css
@@ -2,7 +2,7 @@
 
 .crm-container .nav {
   padding-left: 0;
-  margin-bottom: 0;
+  margin: 0;
   list-style: none;
   display: flex;
   flex-wrap: wrap;
@@ -56,4 +56,7 @@
   height: 2.25rem;
   margin: 0;
   background-position: center center;
+}
+.crm-container .nav.nav-pills {
+  gap: var(--crm-flex-gap);
 }

--- a/ext/riverlea/core/css/components/_page.css
+++ b/ext/riverlea/core/css/components/_page.css
@@ -93,7 +93,9 @@
 
 .crm-pager {
   display: flex;
-  flex-direction: column-reverse;
+  flex-direction: row-reverse;
+  align-items: center;
+  margin-block: 1rem;
 }
 .crm-pager .crm-pager-nav {
   margin: 0 auto;
@@ -107,11 +109,8 @@
 .crm-container .crm-pager-nav a.crm-hover-button:focus {
   background: var(--crm-c-secondary-hover);
 }
-.crm-search-results > .crm-pager:first-of-type {
-  display: none; /* removes second top pager */
-}
 .crm-search-results .form-item.float-right {
-  margin-block: -2rem 1rem; /* positions rows-per-page block somewhat in line with page counter */
+  margin-bottom: 1rem;
 }
 
 /*  Pagination - from BS3 */

--- a/ext/riverlea/core/css/components/_tables.css
+++ b/ext/riverlea/core/css/components/_tables.css
@@ -142,9 +142,9 @@ table.dataTable.order-column.stripe tbody tr.extension-installed.even > .sorting
   overflow-x: auto;
   max-width: 100%;
 }*/
-
 /* resets the scroll in presence of dropdown to avoid clipping */
-.crm-container div:has(td span > .panel) {
+.crm-container div:has(td span > .panel),
+.crm-container div:has(td > div > .dropdown-menu) {
   overflow: initial;
 }
 .crm-selection-reset {

--- a/ext/riverlea/core/css/joomla.css
+++ b/ext/riverlea/core/css/joomla.css
@@ -67,3 +67,6 @@ body.admin.com_civicrm.layout-default #content > .row > .col-md-12 {
 body.admin.com_civicrm.layout-default #content > .row {
   margin-inline: 0;
 }
+body.com_civicm.layout-default .table tbody a:not(.badge):not(.btn):not(.dropdown-item) {
+  text-decoration: var(--crm-link-decoration);
+}


### PR DESCRIPTION
Yesterday's PR around the Message Template afform revealed a number of other issues - lack of a nav-pill style, double drop-shadow when a panel is inside another panel, double drop-shadow on panel-heading, unbalanced visual spacing on panel-heading. This PR fixes all of this, and also:
 - addresses Joomla bug where Atum theme adds underline to dropdown links
 - improves crm-pager layout on search results and removes hidden first pager (hidden during testing perhaps) (ref https://lab.civicrm.org/extensions/riverlea/-/issues/11#note_173013) - also spaces out alpha-filter
 - turns off responsive table scrolls in more dropown scenarios that was causing an issue in Thames (ref https://lab.civicrm.org/extensions/riverlea/-/issues/90)

Before
----------------------------------------
RiverLea 1.80.12.

**.crm-pager & alphafilter:**
<img width="1377" alt="image" src="https://github.com/user-attachments/assets/3a21ab66-5d0b-46ef-8494-3b5037ce6638">
Greenwich:
<img width="1395" alt="image" src="https://github.com/user-attachments/assets/001dfb50-f82b-4883-be1d-7303bb3e46f7">

**Message Template admin:**
![image](https://github.com/user-attachments/assets/5648e3c6-cbcd-440e-a66d-e064ae0d8c81)

After
----------------------------------------
RiverLea 1.80.13

**.crm-pager & alphafilter:**
<img width="1380" alt="image" src="https://github.com/user-attachments/assets/43101b30-ee4b-4256-bb4c-7bdb872b2e87">

**Message template admin:**
![image](https://github.com/user-attachments/assets/5f5c2a5f-d616-4dc0-9b21-4b14785691f7)

Minetta
![image](https://github.com/user-attachments/assets/54b2b6c2-6632-4295-9d4d-a6f887244bd2)
Hackney
<img width="1391" alt="image" src="https://github.com/user-attachments/assets/2da3fdf8-f9d0-4974-b582-cb9504199e69">
Thames
<img width="1398" alt="image" src="https://github.com/user-attachments/assets/775ea92f-79fc-445d-a246-e36d4e14dc37">

Technical Details
----------------------------------------
 - FIXED - removed margin on ul.nav that's added by browser/CMS theme ul styling (seen on Message Template Afform)
 - FIXED - extra box-shadow from .panel-heading (was creating an odd dble shadow)
 - FIXED - clipped overflowing responsive tables in Thames (ref https://lab.civicrm.org/extensions/riverlea/-/issues/90)
 - FIXED - .crm-pager padding/positioning (ref https://lab.civicrm.org/extensions/riverlea/-/issues/11#note_173013) - also removed hidden top pager from some results.
 - FIXED - Joomla4+ Atum admin theme bug that adds underline on dropdown menu links
 - CHANGED - removed second drop-shadow on BS .panel inside a .panel (visible in Walbrook, e.g. Message Template Afform).
 - CHANGED - more balanced padding in panel-heading.
 - ADDED - .nav.nav-pills style based on buttons Message Template Afform.