### PR TITLE
Api4 - Generalise CustomGroup.get caching approach and use for CustomField also

### DIFF
--- a/Civi/Api4/Action/CustomField/Get.php
+++ b/Civi/Api4/Action/CustomField/Get.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\CustomField;
+
+/**
+ * @inheritDoc
+ */
+class Get extends \Civi\Api4\Generic\CachedDAOGetAction {
+
+  /**
+   * @inheritdoc
+   *
+   * Flatten field records from the CustomGroup cache
+   */
+  protected function getCachedRecords(): array {
+    $groups = \CRM_Core_BAO_CustomGroup::getAll();
+    return array_merge(...array_map(fn ($group) => $group['fields'], $groups));
+  }
+
+}

--- a/Civi/Api4/CustomField.php
+++ b/Civi/Api4/CustomField.php
@@ -26,6 +26,15 @@ class CustomField extends Generic\DAOEntity {
 
   /**
    * @param bool $checkPermissions
+   * @return Action\CustomField\Get
+   */
+  public static function get($checkPermissions = TRUE) {
+    return (new Action\CustomField\Get(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
    * @return Action\CustomField\Create
    */
   public static function create($checkPermissions = TRUE) {

--- a/Civi/Api4/CustomGroup.php
+++ b/Civi/Api4/CustomGroup.php
@@ -10,6 +10,8 @@
  */
 namespace Civi\Api4;
 
+use Civi\Api4\Generic\CachedDAOGetAction;
+
 /**
  * CustomGroup entity.
  *
@@ -25,11 +27,12 @@ class CustomGroup extends Generic\DAOEntity {
 
   /**
    * @param bool $checkPermissions
-   * @return Action\CustomGroup\Get
+   * @return Generic\CachedDAOGetAction
    */
   public static function get($checkPermissions = TRUE) {
-    return (new Action\CustomGroup\Get(__CLASS__, __FUNCTION__))
-      ->setCheckPermissions($checkPermissions);
+    return (new CachedDAOGetAction(__CLASS__, __FUNCTION__, function (CachedDAOGetAction $action) {
+      return \CRM_Core_BAO_CustomGroup::getAll();
+    }))->setCheckPermissions($checkPermissions);
   }
 
 }

--- a/Civi/Api4/Generic/CachedDAOGetAction.php
+++ b/Civi/Api4/Generic/CachedDAOGetAction.php
@@ -49,7 +49,7 @@ class CachedDAOGetAction extends \Civi\Api4\Generic\DAOGetAction {
    *
    * @param string $entityName
    * @param string $actionName
-   * @param callable $getter
+   * @param callable $cacheGetter
    */
   public function __construct($entityName, $actionName, $cacheGetter = NULL) {
     parent::__construct($entityName, $actionName);

--- a/Civi/Api4/Generic/CachedDAOGetAction.php
+++ b/Civi/Api4/Generic/CachedDAOGetAction.php
@@ -10,19 +10,17 @@
  +--------------------------------------------------------------------+
  */
 
-namespace Civi\Api4\Action\CustomGroup;
+namespace Civi\Api4\Generic;
 
-use Civi\Api4\Generic\Result;
-use Civi\Api4\Generic\Traits\ArrayQueryActionTrait;
-use Civi\Api4\Generic\Traits\PseudoconstantOutputTrait;
+use Civi\API\Exception\NotImplementedException;
 
 /**
  * @inheritDoc
  *
  */
-class Get extends \Civi\Api4\Generic\DAOGetAction {
-  use ArrayQueryActionTrait;
-  use PseudoconstantOutputTrait;
+class CachedDAOGetAction extends \Civi\Api4\Generic\DAOGetAction {
+  use Traits\ArrayQueryActionTrait;
+  use Traits\PseudoconstantOutputTrait;
 
   /**
    * @var bool
@@ -36,9 +34,32 @@ class Get extends \Civi\Api4\Generic\DAOGetAction {
   protected ?bool $useCache = NULL;
 
   /**
+   * @var callable
+   *   Function(BasicGetAction $thisAction): array[]
+   */
+  private $cacheGetter;
+
+  /**
+   * Cached DAO Get constructor.
+   *
+   * Pass a function that returns the cached records
+   * The cache should contain all the fields in the
+   * EntityRepository schema for this entity. If not override
+   * this class and override getCachedFields as well
+   *
+   * @param string $entityName
+   * @param string $actionName
+   * @param callable $getter
+   */
+  public function __construct($entityName, $actionName, $cacheGetter = NULL) {
+    parent::__construct($entityName, $actionName);
+    $this->cacheGetter = $cacheGetter;
+  }
+
+  /**
    * @param \Civi\Api4\Generic\Result $result
    *
-   * Use self::getFromCache or DAOGetAction::getObjects
+   * Decide whether to use self::getFromCache or DAOGetAction::getObjects
    */
   protected function getObjects(Result $result): void {
     if (is_null($this->useCache)) {
@@ -62,16 +83,17 @@ class Get extends \Civi\Api4\Generic\DAOGetAction {
       return TRUE;
     }
 
-    $standardFields = \Civi::entity($this->getEntityName())->getFields();
+    $cachedFields = $this->getCachedFields();
+
     foreach ($this->select as $field) {
       [$field] = explode(':', $field);
-      if (!isset($standardFields[$field])) {
+      if (!isset($cachedFields[$field])) {
         return TRUE;
       }
     }
     foreach ($this->where as $clause) {
       [$field] = explode(':', $clause[0] ?? '');
-      if (!$field || !isset($standardFields[$field])) {
+      if (!$field || !isset($cachedFields[$field])) {
         return TRUE;
       }
       // ArrayQueryTrait doesn't yet support field-to-field comparisons
@@ -81,11 +103,24 @@ class Get extends \Civi\Api4\Generic\DAOGetAction {
     }
     foreach ($this->orderBy as $field => $dir) {
       [$field] = explode(':', $field);
-      if (!isset($standardFields[$field])) {
+      if (!isset($cachedFields[$field])) {
         return TRUE;
       }
     }
     return FALSE;
+  }
+
+  /**
+   * Which fields are included in the cache?
+   *
+   * By default, this is standard fields from the
+   * EntityRepository schema - but could be overridden
+   * in child classes.
+   *
+   * @return array with known fields as array *keys*
+   */
+  protected function getCachedFields(): array {
+    return \Civi::entity($this->getEntityName())->getFields();
   }
 
   /**
@@ -100,8 +135,11 @@ class Get extends \Civi\Api4\Generic\DAOGetAction {
     $this->queryArray($values, $result);
   }
 
-  protected function getCachedRecords() {
-    return \CRM_Core_BAO_CustomGroup::getAll();
+  protected function getCachedRecords(): array {
+    if (is_callable($this->cacheGetter)) {
+      return call_user_func($this->cacheGetter, $this);
+    }
+    throw new NotImplementedException('Cache getter function not found for api4 ' . $this->getEntityName() . '::' . $this->getActionName());
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Generalise the approach to leverage existing cache for CustomGroup.get calls to a new generic Api4 action class `CachedDAOGetAction`.

The general idea is if you have a class of simple calls that can be answered by an in-memory cache, act like a BasicGetAction; and only escalate to a database call if needed.

CustomField and CustomGroup get calls can then use the pre-existing in-memory cache.

Before
----------------------------------------
- only CustomGroup.get uses the in-memory cache

After
----------------------------------------
- CustomGroup and CustomField use the in-memory cache
- further entities can use the same approach by extending `CachedDAOGetAction`

Comments
----------------------------------------
Added some CustomField cases to the test class.