### PR TITLE
Api4 - Fix CustomField.delete to perform all postprocessing

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -20,7 +20,7 @@ use Civi\Api4\Utils\CoreUtil;
 /**
  * Class CRM_Core_BAO_CustomField
  */
-class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
+class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi\Core\HookInterface {
 
   /**
    * Build and retrieve the list of data types and descriptions.
@@ -970,26 +970,32 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
    * Delete the Custom Field.
    *
    * @param object $field
-   *   The field object.
+   * @deprecated
    */
   public static function deleteField($field) {
-    CRM_Utils_System::flushCache();
+    self::deleteRecord(['id' => $field->id]);
+  }
 
-    // first delete the custom option group and values associated with this field
-    if ($field->option_group_id) {
-      //check if option group is related to any other field, if
-      //not delete the option group and related option values
-      self::checkOptionGroup($field->option_group_id);
+  /**
+   * Callback for hook_civicrm_post().
+   * @param \Civi\Core\Event\PostEvent $event
+   */
+  public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $event) {
+    if ($event->action === 'delete') {
+      CRM_Utils_System::flushCache();
+
+      // first delete the custom option group and values associated with this field
+      if (!empty($event->object->option_group_id)) {
+        // Check if option group is related to any other field.
+        // If not, delete the option group and related option values.
+        self::checkOptionGroup($event->object->option_group_id, 0);
+      }
+      // next drop the column from the custom value table
+      self::createField($event->object, 'delete');
+
+      CRM_Utils_Weight::correctDuplicateWeights('CRM_Core_DAO_CustomField');
+      Civi::cache('metadata')->clear();
     }
-    // next drop the column from the custom value table
-    self::createField($field, 'delete');
-
-    $field->delete();
-    CRM_Core_BAO_UFField::delUFField($field->id);
-    CRM_Core_BAO_Mapping::removeFieldFromMapping('custom_' . $field->id);
-    CRM_Utils_Weight::correctDuplicateWeights('CRM_Core_DAO_CustomField');
-
-    CRM_Utils_Hook::post('delete', 'CustomField', $field->id, $field);
   }
 
   /**
@@ -2290,8 +2296,10 @@ INNER JOIN  civicrm_custom_field f ON ( g.id = f.option_group_id )
    *
    * @param int $optionGroupId
    *   Option group id.
+   * @param int $max
+   *   Set to 1 if the field still exists, 0 otherwise
    */
-  public static function checkOptionGroup($optionGroupId) {
+  public static function checkOptionGroup($optionGroupId, int $max = 1) {
     $query = "
 SELECT count(*)
 FROM   civicrm_custom_field
@@ -2299,7 +2307,7 @@ WHERE  option_group_id = {$optionGroupId}";
 
     $count = CRM_Core_DAO::singleValueQuery($query);
 
-    if ($count < 2) {
+    if ($count <= $max) {
       //delete the option group
       CRM_Core_BAO_OptionGroup::deleteRecord(['id' => $optionGroupId]);
     }

--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -767,8 +767,10 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping implements \Civi\Core\Ho
   /**
    * Remove references to a specific field from save Mappings
    * @param string $fieldName
+   * @deprecated
    */
   public static function removeFieldFromMapping($fieldName): void {
+    CRM_Core_Error::deprecatedFunctionWarning('Api');
     $mappingField = new CRM_Core_DAO_MappingField();
     $mappingField->name = $fieldName;
     $mappingField->delete();
@@ -784,6 +786,12 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping implements \Civi\Core\Ho
       // CRM-3323 - Delete mappingField records when deleting relationship type
       \Civi\Api4\MappingField::delete(FALSE)
         ->addWhere('relationship_type_id', '=', $event->id)
+        ->execute();
+    }
+    if ($event->action === 'delete' && $event->entity === 'CustomField') {
+      // Delete mappingField records when deleting custom field
+      \Civi\Api4\MappingField::delete(FALSE)
+        ->addWhere('name', '=', 'custom_' . $event->id)
         ->execute();
     }
     if ($event->action === 'create' && $event->entity === 'Mapping') {

--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -18,8 +18,7 @@
 /**
  * This class contains function for UFField.
  */
-class CRM_Core_BAO_UFField extends CRM_Core_DAO_UFField {
-
+class CRM_Core_BAO_UFField extends CRM_Core_DAO_UFField implements \Civi\Core\HookInterface {
   /**
    * Batch entry fields.
    * @var array
@@ -281,9 +280,10 @@ class CRM_Core_BAO_UFField extends CRM_Core_DAO_UFField {
    * Delete profile field given a custom field.
    *
    * @param int $customFieldId
-   *   ID of the custom field to be deleted.
+   * @deprecated
    */
   public static function delUFField($customFieldId) {
+    CRM_Core_Error::deprecatedFunctionWarning('Api');
     //find the profile id given custom field id
     $ufField = new CRM_Core_DAO_UFField();
     $ufField->field_name = "custom_" . $customFieldId;
@@ -1133,6 +1133,19 @@ SELECT  id
       ];
     }
     return self::$_memberBatchEntryFields;
+  }
+
+  /**
+   * Callback for hook_civicrm_pre().
+   * @param \Civi\Core\Event\PreEvent $event
+   * @throws CRM_Core_Exception
+   */
+  public static function on_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
+    if ($event->action === 'delete' && $event->entity === 'CustomField') {
+      \Civi\Api4\UFField::delete(FALSE)
+        ->addWhere('field_name', '=', 'custom_' . $event->id)
+        ->execute();
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes APIv4 bug with custom field deletion & adds tests.
Fixes unit test failure on #31569

Before
----------------------------------------
Messy code in the CustomField BAO caused inconsistent behavior, some code paths (e.g. the UI) would properly clean up after deleting a custom field (dropping the column, etc), and other code paths (e.g. the API) would not.

After
----------------------------------------
Switched to standard writeRecord + hooks code pattern. Deprecated the old function.