### PR TITLE
Support for time sql type for legacy metadata

### DIFF
--- a/Civi/Schema/LegacySqlEntityMetadata.php
+++ b/Civi/Schema/LegacySqlEntityMetadata.php
@@ -170,6 +170,9 @@ class LegacySqlEntityMetadata extends EntityMetadataBase {
       case \CRM_Utils_Type::T_DATE + \CRM_Utils_Type::T_TIME:
         return 'datetime';
 
+      case \CRM_Utils_Type::T_TIME:
+        return 'time';
+
       default:
         throw new \CRM_Core_Exception('Unknown field type for ' . $legacyField['name']);
     }


### PR DESCRIPTION
Overview
----------------------------------------
In civibooking extensions, some fields use the sql type `time` (without date) but it's not supported when using the legacy metadata.

Before
----------------------------------------
CiviCRM crash with error: `Unknown field type for day_start_at`

After
----------------------------------------
No more crash

Comments
----------------------------------------
We should upgrade CiviBooking to the new metadata structure so this is a temporary measure to give us time to upgrade.
