### PR TITLE
dev/core#5629 - case activity send copy has blank details on the email activity filed on the case

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1422,7 +1422,7 @@ HERESQL;
       );
 
       $activityParams['subject'] = ts('%1 - copy sent to %2', [1 => $activitySubject, 2 => $displayName]);
-      $activityParams['details'] = $message;
+      $activityParams['details'] = $html;
 
       if (!empty($result[$info['contact_id']])) {
         /*


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5629

Before
----------------------------------------
In 5.71, the case activity message template text version was blanked out. While the sending of the actual email converts the html to text, the code that files the email on the case as an activity never gets a copy of that conversion, so was filing the blanked out text.

After
----------------------------------------
I chose option 2a, to just use the html. Besides looking nicer when viewing the activity, it's an easier code update.

Technical Details
----------------------------------------


Comments
----------------------------------------
This is a little hard to test on the PR test site since it locks outbound mail down to smtp which fails. You used to be able to set it to Redirect to Database and then actions wouldn't fail and you could view it under Archived Mailings. But here's a partial screenshot of what it looks like on my local:

![untitled4](https://github.com/user-attachments/assets/5d209f9f-03b0-4298-b30c-2429b0ee5fb7)
