### PR TITLE
RiverLea: 1.80.14, fixes regression extensions/riverlea/#91

### DIFF
--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -1,3 +1,6 @@
+1.80.14
+ - FIXED - regression caused by trying to reset clipping in Thames (ref: https://lab.civicrm.org/extensions/riverlea/-/issues/91)
+
 1.80.13
  - FIXED - removed margin on ul.nav that's added by browser/CMS theme ul styling (seen on Message Template Afform)
  - FIXED - extra box-shadow from .panel-heading (was creating an odd dble shadow)

--- a/ext/riverlea/core/css/_core.css
+++ b/ext/riverlea/core/css/_core.css
@@ -4,5 +4,5 @@
    can be merged later. */
 
 @import url(components/_accordion.css); @import url(components/_alerts.css); @import url(components/_buttons.css); @import url(components/_form.css); @import url(components/_icons.css); @import url(components/_nav.css); @import url(components/_tabs.css); @import url(components/_dropdowns.css); @import url(components/_tables.css); @import url(components/_dialogs.css); @import url(components/_page.css); @import url(components/_components.css); @import url(components/_front.css); :root {
-  --crm-release: '1.80.13';
+  --crm-release: '1.80.14';
 }

--- a/ext/riverlea/core/css/components/_tables.css
+++ b/ext/riverlea/core/css/components/_tables.css
@@ -142,11 +142,11 @@ table.dataTable.order-column.stripe tbody tr.extension-installed.even > .sorting
   overflow-x: auto;
   max-width: 100%;
 }*/
-/* resets the scroll in presence of dropdown to avoid clipping */
+/* needed to reset the scroll in Thames but causes other problem - #91)
 .crm-container div:has(td span > .panel),
 .crm-container div:has(td > div > .dropdown-menu) {
   overflow: initial;
-}
+}*/
 .crm-selection-reset {
   padding: var(--crm-m) 0;
   margin-bottom: var(--crm-m);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes regression described here: https://lab.civicrm.org/extensions/riverlea/-/issues/91. 

That regression is a response to Thames Responsive Tables clipping dropdowns, described https://lab.civicrm.org/extensions/riverlea/-/issues/90.

Before
----------------------------------------
Modals with tables behave strangely:

<img width="1046" alt="image" src="https://github.com/user-attachments/assets/60d82313-94aa-4deb-b71e-a01ffb0cc03c">

After
----------------------------------------
They don't:

<img width="1042" alt="image" src="https://github.com/user-attachments/assets/4941ca01-16e6-4e46-949d-f9947c291cb8">

Comments
----------------------------------------
This fix doesn't solve the original issue in Thames, but comments out the fix for that, which stops it causing problems in the other streams. 

Sorry for submitting this late.