### PR TITLE
dev/core#5541 Shift Mailing View page away from using is_numeric and …

### DIFF
--- a/CRM/Mailing/Page/View.php
+++ b/CRM/Mailing/Page/View.php
@@ -62,7 +62,7 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
    *   Not really sure if anything should be returned - parent doesn't
    */
   public function run($id = NULL, $contactID = NULL, $print = TRUE, $allowID = FALSE) {
-    if (empty($id) || (!empty($id) && is_array($id))) {
+    if (empty($id) || is_array($id)) {
       $print = TRUE;
     }
     $this->getMailingID($id);
@@ -164,7 +164,7 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
 
   public function getMailingID($id): void {
     if (!empty($id) && !is_array($id)) {
-      $check = CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_mailing WHERE id = %1", [
+      $check = CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_mailing WHERE CAST(id AS CHAR) = %1", [
         1 => [$id, 'String'],
       ]);
       $this->_mailingID = $id;
@@ -177,7 +177,7 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
     }
     else {
       $this->_mailingID = CRM_Utils_Request::retrieveValue('id', 'String', NULL, TRUE);
-      $check = CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_mailing WHERE id = %1", [
+      $check = CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_mailing WHERE CAST(id AS CHAR) = %1", [
         1 => [$this->_mailingID, 'String'],
       ]);
       if (!empty($check)) {

--- a/CRM/Mailing/Page/View.php
+++ b/CRM/Mailing/Page/View.php
@@ -23,6 +23,7 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
   protected $_mailingID;
   protected $_mailing;
   protected $_contactID;
+  private $_mailingIDIsHash;
 
   /**
    * Lets do permission checking here.
@@ -61,13 +62,10 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
    *   Not really sure if anything should be returned - parent doesn't
    */
   public function run($id = NULL, $contactID = NULL, $print = TRUE, $allowID = FALSE) {
-    if (is_numeric($id)) {
-      $this->_mailingID = $id;
-    }
-    else {
+    if (empty($id) || (!empty($id) && is_array($id))) {
       $print = TRUE;
-      $this->_mailingID = CRM_Utils_Request::retrieve('id', 'String', CRM_Core_DAO::$_nullObject, TRUE);
     }
+    $this->getMailingID($id);
 
     // Retrieve contact ID and checksum from the URL
     $cs = CRM_Utils_Request::retrieve('cs', 'String');
@@ -93,8 +91,7 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
     // mailing key check
     if (Civi::settings()->get('hash_mailing_url')) {
       $this->_mailing = new CRM_Mailing_BAO_Mailing();
-
-      if (!is_numeric($this->_mailingID)) {
+      if ($this->_mailingIDIsHash) {
 
         //lets get the id from the hash
         $result_id = civicrm_api3('Mailing', 'get', [
@@ -104,7 +101,7 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
         $this->_mailing->hash = $this->_mailingID;
         $this->_mailingID     = $result_id['id'];
       }
-      elseif (is_numeric($this->_mailingID)) {
+      else {
         $this->_mailing->id = $this->_mailingID;
         // if mailing is present and associated hash is present
         // while 'hash' is not been used for mailing view : throw 'permissionDenied'
@@ -162,6 +159,33 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
     }
     else {
       return $content;
+    }
+  }
+
+  public function getMailingID($id): void {
+    if (!empty($id) && !is_array($id)) {
+      $check = CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_mailing WHERE id = %1", [
+        1 => [$id, 'String'],
+      ]);
+      $this->_mailingID = $id;
+      if (!empty($check)) {
+        $this->_mailingIDIsHash = FALSE;
+      }
+      else {
+        $this->_mailingIDIsHash = TRUE;
+      }
+    }
+    else {
+      $this->_mailingID = CRM_Utils_Request::retrieveValue('id', 'String', NULL, TRUE);
+      $check = CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_mailing WHERE id = %1", [
+        1 => [$this->_mailingID, 'String'],
+      ]);
+      if (!empty($check)) {
+        $this->_mailingIDIsHash = FALSE;
+      }
+      else {
+        $this->_mailingIDIsHash = TRUE;
+      }
     }
   }
 

--- a/tests/phpunit/CRM/Mailing/Page/ViewTest.php
+++ b/tests/phpunit/CRM/Mailing/Page/ViewTest.php
@@ -1,0 +1,86 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\Api4\Email;
+
+/**
+ * Test class for CRM_Mailing_Page_View.
+ * @group headless
+ */
+class CRM_Mailing_Page_ViewTest extends CiviUnitTestCase {
+
+  public function testHashNumericMailingView(): void {
+    Civi::settings()->set('hash_mailing_url', 1);
+    $this->setupMailing();
+    CRM_Core_DAO::executeQuery("UPDATE civicrm_mailing SET hash = %1 WHERE id = %2", [
+      1 => ['109002430016e903', 'String'],
+      2 => [$this->ids['Mailing']['default'], 'Positive'],
+    ]);
+    $_REQUEST['id'] = '109002430016e903';
+    $page = new CRM_Mailing_Page_View('View Mailing');
+    try {
+      $page->run();
+      $this->fail('Page Run should cause a Premeture Exit Exemption to occur');
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+    }
+
+  }
+
+  /**
+   * Set up a 'sent' mailing with 2 attached groups which the contact is part of.
+   *
+   * One group is a smarty group of all individuals.
+   *
+   * @return void
+   * @throws \CRM_Core_Exception
+   */
+  public function setupMailing(): void {
+
+    $savedSearch = $this->createTestEntity('SavedSearch', [
+      'api_entity' => 'Contact',
+      'api_params' => [
+        'version' => 4,
+        'select' => ['id'],
+        'where' => [['contact_type', '=', 'Individual']],
+      ],
+    ]);
+
+    $params = [
+      'contact_id' => $this->individualCreate(),
+      'group_id' => $this->groupCreate(['name' => 'Test group 2', 'title' => 'group title 2']),
+    ];
+    $this->createTestEntity('GroupContact', $params);
+
+    $email = Email::get()
+      ->addWhere('id', '=', $params['contact_id'])
+      ->execute()->first();
+    $this->createTestEntity('MailingEventQueue', [
+      'mailing_id' => $this->createMailing(),
+      'hash' => 'abc',
+      'contact_id' => $params['contact_id'],
+      'email_id' => $email['id'],
+    ]);
+    $this->createTestEntity('MailingGroup', [
+      'mailing_id' => $this->ids['Mailing']['default'],
+      'entity_table' => 'civicrm_group',
+      'entity_id' => $params['group_id'],
+      'group_type' => 'Base',
+    ]);
+    $this->createTestEntity('MailingGroup', [
+      'mailing_id' => $this->ids['Mailing']['default'],
+      'entity_table' => 'civicrm_group',
+      'entity_id' => $this->groupCreate(['saved_search_id' => $savedSearch['id']], 'smart_group'),
+      'group_type' => 'Include',
+    ]);
+  }
+
+}


### PR DESCRIPTION
…add test of View Page class

Overview
----------------------------------------
This should be seen as a companion to https://github.com/civicrm/civicrm-core/pull/31330. This PR aims to address the problem that if there are already hashes which would pass the is_numeric test already exist in the DB this should the Mailing View handling

Before
----------------------------------------
Hashes that match is_numeric fail on Mailing View

After
----------------------------------------
Mailing View page works

@demeritcowboy @johntwyman @eileenmcnaughton @colemanw 