### PR TITLE
Api4 - Improve CachedDAOGetAction to handle simple implicit joins

### DIFF
--- a/Civi/Api4/Action/CustomField/Get.php
+++ b/Civi/Api4/Action/CustomField/Get.php
@@ -18,13 +18,41 @@ namespace Civi\Api4\Action\CustomField;
 class Get extends \Civi\Api4\Generic\CachedDAOGetAction {
 
   /**
+   * Return all fields for CustomField entity plus all the ones from
+   * CustomGroup that we are able to get from the cache.
+   *
+   * @return array
+   */
+  protected function getCachedFields(): array {
+    $fields = \Civi::entity('CustomField')->getFields();
+    $groupFields = \Civi::entity('CustomGroup')->getFields();
+    foreach ($groupFields as $name => $groupField) {
+      // CachedDAOGetAction can't handle pseudoconstants across joins
+      if (!isset($groupField['pseudoconstant'])) {
+        $fields["custom_group_id.$name"] = $groupField;
+      }
+    }
+    return $fields;
+  }
+
+  /**
    * @inheritdoc
    *
-   * Flatten field records from the CustomGroup cache
+   * Flatten field records from the CustomGroup cache,
+   * formatted as CustomField + implicit joins to CustomGroup
    */
   protected function getCachedRecords(): array {
+    $records = [];
     $groups = \CRM_Core_BAO_CustomGroup::getAll();
-    return array_merge(...array_map(fn ($group) => $group['fields'], $groups));
+    foreach ($groups as $group) {
+      $groupInfo = $group;
+      unset($groupInfo['fields']);
+      $groupInfo = \CRM_Utils_Array::prefixKeys($groupInfo, 'custom_group_id.');
+      foreach ($group['fields'] as $field) {
+        $records[] = $field + $groupInfo;
+      }
+    }
+    return $records;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Builds on #31569 and makes a few improvements to the CustomField api.

Technical Details
----------------------------------------
- Adds ability to handle simple implicit joins like `'custom_group_id.title'`.
- Adds `useCache` to debug output for transparency
- Fixes discrepancy where the query action would always return ID but the cached action would not.

@ufundo 