### PR TITLE
(dev/core#5606) user_dashboard - Fix upgrade error

### DIFF
--- a/ext/user_dashboard/ang/afsearchUserDashboard.aff.php
+++ b/ext/user_dashboard/ang/afsearchUserDashboard.aff.php
@@ -1,32 +1,13 @@
 <?php
 use CRM_UserDashboard_ExtensionUtil as E;
 
-$afform = [
+return [
   'type' => 'search',
   'title' => E::ts('User Dashboard'),
   'server_route' => 'civicrm/user',
   'permission' => ['access Contact Dashboard'],
+  // NOTE: Layout dynamically generated via hook_civicrm_alterAngular
   'layout' => '',
   // temporary, remove after merging https://github.com/civicrm/civicrm-core/pull/27783
   'requires' => ['af', 'afCore', 'crmSearchDisplayTable'],
 ];
-
-// Add displays for every SavedSearch tagged "UserDashboard"
-$searchDisplays = civicrm_api4('SearchDisplay', 'get', [
-  'checkPermissions' => FALSE,
-  'select' => ['name', 'label', 'type:name', 'saved_search_id.name'],
-  'where' => [
-    ['saved_search_id.is_current', '=', TRUE],
-    ['saved_search_id.tags:name', 'IN', ['UserDashboard']],
-  ],
-  'orderBy' => ['name' => 'ASC'],
-]);
-foreach ($searchDisplays as $display) {
-  $afform['layout'] .= <<<HTML
-    <div af-fieldset="" class="af-container-style-pane" af-title="$display[label]">
-      <{$display['type:name']} search-name="{$display['saved_search_id.name']}" display-name="$display[name]"></{$display['type:name']}>
-    </div>
-  HTML;
-}
-
-return $afform;

--- a/ext/user_dashboard/ang/afsearchUserDashboard.alterLayout.php
+++ b/ext/user_dashboard/ang/afsearchUserDashboard.alterLayout.php
@@ -1,0 +1,26 @@
+<?php
+return function (phpQueryObject $doc) {
+  // Add displays for every SavedSearch tagged "UserDashboard"
+  $searchDisplays = civicrm_api4('SearchDisplay', 'get', [
+    'checkPermissions' => FALSE,
+    'select' => ['name', 'label', 'type:name', 'saved_search_id.name'],
+    'where' => [
+      ['saved_search_id.is_current', '=', TRUE],
+      ['saved_search_id.tags:name', 'IN', ['UserDashboard']],
+    ],
+    'orderBy' => ['name' => 'ASC'],
+  ]);
+  $layout = '';
+  foreach ($searchDisplays as $display) {
+    $layout .= <<<HTML
+    <div af-fieldset="" class="af-container-style-pane" af-title="$display[label]">
+      <{$display['type:name']} search-name="{$display['saved_search_id.name']}" display-name="$display[name]"></{$display['type:name']}>
+    </div>
+  HTML;
+  }
+
+  // This naively adds all displays, under the assumption that site-builders never edit `afsearchUserDashboard` layout.
+  // However, if they do it that, then this could instead do some reconciliation (adding/removing blocks as needed).
+  $doc->html($layout);
+  // $doc->append($layout);
+};

--- a/ext/user_dashboard/user_dashboard.php
+++ b/ext/user_dashboard/user_dashboard.php
@@ -78,3 +78,16 @@ function user_dashboard_civicrm_post($action, $entity, $id, $savedSearch) {
       ->execute();
   }
 }
+
+/**
+ * @param \Civi\Angular\Manager $angular
+ * @see \CRM_Utils_Hook::alterAngular()
+ */
+Civi::dispatcher()->addListener('&hook_civicrm_alterAngular', function(\Civi\Angular\Manager $angular) {
+  $changeSet = \Civi\Angular\ChangeSet::create('afsearchUserDashboard')
+    ->alterHtml('~/afsearchUserDashboard/afsearchUserDashboard.aff.html', function (phpQueryObject $doc) {
+      $f = require __DIR__ . '/ang/afsearchUserDashboard.alterLayout.php';
+      $f($doc);
+    });
+  $angular->add($changeSet);
+}, 1500);


### PR DESCRIPTION
Overview
----------------------------------------

This fixes an upgrade error reported in https://lab.civicrm.org/dev/core/-/issues/5606.

The general issue is that the upgrader checks Afform metadata. But this particular metadata file (`afsearchUserDashboard.aff.php`) has an unusual sort of dynamism that doesn't work in upgrade context. So we move it somewhere that does work.

(ping @colemanw)

Before
----------------------------------------

Whenever you try to read *any* metadata bout `afsearchUserDashboard`, it tries to immediately render a dynamic layout.

After
----------------------------------------

It only renders the dynamic layout when it needs to (*which is not during the upgrade*).

Technical Details
----------------------------------------

To ensure that the code works the same as I before, I dumped some example output before+after. Compare:

```bash
cv en user_dashboard
cv ang:html:show afsearchUserDashboard/afsearchUserDashboard.aff.html  > /tmp/before.html

## Apply patch, then...
cv ang:html:show afsearchUserDashboard/afsearchUserDashboard.aff.html  > /tmp/after.html

diff -u /tmp/before.html /tmp/after.html
md5sum /tmp/before.html /tmp/after.html
```

For me, this gives the same output.

Comments
----------------------------------------

* With [this procedure to reproduce](https://lab.civicrm.org/dev/core/-/issues/5606#note_174211), I see the upgrade working.

* One thing that I'm not sure about is the story of a site-builder who edits `afsearchUserDashboard`:
    * I don't understand that story before the patch. It seems to me that... once an edit is made... the ability to enable or disable dashlets would break. So my suspicion is that this story just generally isn't expected/supported?
    * The current patch should work the same in that case.
    * But if the admin tries to edit, then this patch works different -- basically, those edits should be ignored/inert. (The `hook_alterAngular` listener is written to replace the full `layout`.)

* I think dynamism in `*.aff.php` is like dynamism in other metadata files (`*.ang.php`, `*.setting.php`). It can be done. It's a valid quick-hack to prove a concept. But for long-term maintainability, one looks for something else.
