### PR TITLE
(dev/core#5606) user_dashboard - Fix upgrade error

### DIFF
--- a/ext/user_dashboard/ang/afsearchUserDashboard.aff.php
+++ b/ext/user_dashboard/ang/afsearchUserDashboard.aff.php
@@ -1,32 +1,13 @@
 <?php
 use CRM_UserDashboard_ExtensionUtil as E;
 
-$afform = [
+return [
   'type' => 'search',
   'title' => E::ts('User Dashboard'),
   'server_route' => 'civicrm/user',
   'permission' => ['access Contact Dashboard'],
+  // NOTE: Layout dynamically generated via hook_civicrm_alterAngular
   'layout' => '',
   // temporary, remove after merging https://github.com/civicrm/civicrm-core/pull/27783
   'requires' => ['af', 'afCore', 'crmSearchDisplayTable'],
 ];
-
-// Add displays for every SavedSearch tagged "UserDashboard"
-$searchDisplays = civicrm_api4('SearchDisplay', 'get', [
-  'checkPermissions' => FALSE,
-  'select' => ['name', 'label', 'type:name', 'saved_search_id.name'],
-  'where' => [
-    ['saved_search_id.is_current', '=', TRUE],
-    ['saved_search_id.tags:name', 'IN', ['UserDashboard']],
-  ],
-  'orderBy' => ['name' => 'ASC'],
-]);
-foreach ($searchDisplays as $display) {
-  $afform['layout'] .= <<<HTML
-    <div af-fieldset="" class="af-container-style-pane" af-title="$display[label]">
-      <{$display['type:name']} search-name="{$display['saved_search_id.name']}" display-name="$display[name]"></{$display['type:name']}>
-    </div>
-  HTML;
-}
-
-return $afform;

--- a/ext/user_dashboard/ang/afsearchUserDashboard.alterLayout.php
+++ b/ext/user_dashboard/ang/afsearchUserDashboard.alterLayout.php
@@ -1,0 +1,26 @@
+<?php
+return function (phpQueryObject $doc) {
+  // Add displays for every SavedSearch tagged "UserDashboard"
+  $searchDisplays = civicrm_api4('SearchDisplay', 'get', [
+    'checkPermissions' => FALSE,
+    'select' => ['name', 'label', 'type:name', 'saved_search_id.name'],
+    'where' => [
+      ['saved_search_id.is_current', '=', TRUE],
+      ['saved_search_id.tags:name', 'IN', ['UserDashboard']],
+    ],
+    'orderBy' => ['name' => 'ASC'],
+  ]);
+  $layout = '';
+  foreach ($searchDisplays as $display) {
+    $layout .= <<<HTML
+    <div af-fieldset="" class="af-container-style-pane" af-title="$display[label]">
+      <{$display['type:name']} search-name="{$display['saved_search_id.name']}" display-name="$display[name]"></{$display['type:name']}>
+    </div>
+  HTML;
+  }
+
+  // This naively adds all displays, under the assumption that site-builders never edit `afsearchUserDashboard` layout.
+  // However, if they do it that, then this could instead do some reconciliation (adding/removing blocks as needed).
+  $doc->html($layout);
+  // $doc->append($layout);
+};

--- a/ext/user_dashboard/user_dashboard.php
+++ b/ext/user_dashboard/user_dashboard.php
@@ -78,3 +78,16 @@ function user_dashboard_civicrm_post($action, $entity, $id, $savedSearch) {
       ->execute();
   }
 }
+
+/**
+ * @param \Civi\Angular\Manager $angular
+ * @see \CRM_Utils_Hook::alterAngular()
+ */
+Civi::dispatcher()->addListener('&hook_civicrm_alterAngular', function(\Civi\Angular\Manager $angular) {
+  $changeSet = \Civi\Angular\ChangeSet::create('afsearchUserDashboard')
+    ->alterHtml('~/afsearchUserDashboard/afsearchUserDashboard.aff.html', function (phpQueryObject $doc) {
+      $f = require __DIR__ . '/ang/afsearchUserDashboard.alterLayout.php';
+      $f($doc);
+    });
+  $angular->add($changeSet);
+}, 1500);


### PR DESCRIPTION
Backport #31581 from 5.81-rc to 5.80-stable

Re-checked some of the QA signals from the original PR, and these were good:

* Installing `user_dashboard` and running `cv ang:html:show` to print content (with or without patch)
* Running  `civibuild upgrade-test ... 5.75*big*`