### PR TITLE
Add  `\DateTime` and `\Brick\Money\Money` to parameter type hint of `TokenRow::tokens()`

### DIFF
--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -154,7 +154,7 @@ class TokenRow {
    *
    * @param string|array $tokenEntity
    * @param string|array $tokenField
-   * @param string|array $tokenValue
+   * @param string|array|\DateTime|\Brick\Money\Money $tokenValue
    *
    * @return TokenRow
    */


### PR DESCRIPTION
Overview
----------------------------------------
In #31379 type hints for `TokenRow::tokens()` were added. Though `\DateTime` and `\Brick\Money\Money` were missing for `$tokenValue`. Those objects are handled in [TokenProcessor](https://github.com/civicrm/civicrm-core/blob/161e790ebd2c41ca651db8b2df8c335d4fe2264f/Civi/Token/TokenProcessor.php#L480).

Before
----------------------------------------
Type hint was incomplete.

After
----------------------------------------
`\DateTime` and `\Brick\Money\Money` are added to the type hint of `$tokenValue`.

Technical Details
----------------------------------------
I've set 5.81 as target branch so this fix will be part of the next release. Should obviously be applied to master as well.

Comments
----------------------------------------
BTW: I'm wondering what kind of arrays are allowed for `$tokenValue` and what the expected result is.
I quickly looked at usages and couldn't spot a place where an array is given...
