### PR TITLE
Regression on bulk task Invoices - email

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -539,7 +539,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
       elseif ($component === 'event') {
         $email = CRM_Contact_BAO_Contact::getPrimaryEmail($contribution->contact_id);
 
-        $sendTemplateParams['tplParams'] = $tplParams;
+        $sendTemplateParams['tplParams'] = array_merge($tplParams, ['email_comment' => $params['email_comment']]);
         $sendTemplateParams['from'] = $fromEmailAddress;
         $sendTemplateParams['toEmail'] = $email;
         $sendTemplateParams['cc'] = $values['cc_confirm'] ?? NULL;


### PR DESCRIPTION
Overview
----------------------------------------
Sending batch invoice email for event doesn't work the same as regular invoice.

This is a regression as it used to work in CiviCRM 5.65.

To reproduce:
- go to civicrm/admin/setting/preferences/contribute?reset=1
- enable "Enable Tax and Invoicing"
- register a participant to an event with a payment to create a contribution
- search contributions and select the previously created contribution
- choose task "Invoices - print or email"
- select "Email" and set an "Additional Message"
- submit -> the email contains the invoice and no additional message "Additional Message"

Before
----------------------------------------
The email content contains the invoice content (already attached as a pdf) instead of the "Additional Message"

After
----------------------------------------
The email content contains the "Additional Message" with invoice attached as pdf.

Comments
----------------------------------------
It was introduced in this PR https://github.com/civicrm/civicrm-core/pull/27162
