### PR TITLE
Support csv_importer import jobs in searchkit import report

### DIFF
--- a/ext/civiimport/civiimport.php
+++ b/ext/civiimport/civiimport.php
@@ -99,7 +99,7 @@ function _civiimport_civicrm_get_import_tables(): array {
        -- it is a new convention, at best, to require anything
        -- specific in the job_type, but it saves any onerous lookups
        -- in a function which needs to avoid loops
-       AND job_type LIKE "%import"
+       AND job_type LIKE "%import%"
          -- also more of a feature than a specification - but we need a table
          -- to do this pseudo-api
        AND metadata LIKE "%table_name%"');


### PR DESCRIPTION
Overview
----------------------------------------
Users are not able to see the error that happens during the import of entities with the [API CSV Importer](https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport) extension.



Before
----------------------------------------
When the `see error` link is clicked, the user is redirected to an empty screen
![error_see2_work22](https://github.com/user-attachments/assets/07a703aa-d71d-4905-9840-463a3ac4cfd7)


After
----------------------------------------
With this fix the user is redirected to the expected search display with errors
![error_see](https://github.com/user-attachments/assets/8eca3ea7-1fae-4a31-848f-27b9317599be)



Technical Details
----------------------------------------
This happens because [API CSV importer](https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport/blob/e65d79126e405dd054ae1d3c6b94d538fe592711/CRM/Csvimport/Import/Parser/Api.php#L32-L34) https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport/blob/e65d79126e405dd054ae1d3c6b94d538fe592711/CRM/Csvimport/Import/Parser/Api.php#L32-L34 job name is `csv_api_importer` so civiimport is not able to generate temporary import data.
