### PR TITLE
(dev/core#5591) HTMLPurifier - Allow image widths to use percentages

### DIFF
--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -642,6 +642,8 @@ class CRM_Utils_String {
       $config->set('Cache.DefinitionImpl', NULL);
       $config->set('HTML.DefinitionID', 'enduser-customize.html tutorial');
       $config->set('HTML.DefinitionRev', 1);
+      $config->set('HTML.MaxImgLength', NULL);
+      $config->set('CSS.MaxImgLength', NULL);
       $def = $config->maybeGetRawHTMLDefinition();
       if (!empty($def)) {
         $def->addElement('figcaption', 'Block', 'Flow', 'Common');


### PR DESCRIPTION
Overview
----------------------------------------

See: https://lab.civicrm.org/dev/core/-/issues/5591

This appears as a suggestion in some discussion forums and aligns with future defaults for HTMLPurifier.

Before
----------------------------------------

CSS widths must be absolute width (pixels).

After
----------------------------------------

CSS widths may be absolute or percentages.

Comments
----------------------------------------

I haven't actually tested this, but I think the historical POV seems OK. I defer to @demeritcowboy on whether it actually works. 😁 