### PR TITLE
(dev/core#5585) CiviContribute - Consistently encode/decode the value for "Product Options"

### DIFF
--- a/CRM/Contribute/BAO/Premium.php
+++ b/CRM/Contribute/BAO/Premium.php
@@ -171,22 +171,11 @@ class CRM_Contribute_BAO_Premium extends CRM_Contribute_DAO_Premium {
   /**
    * Convert key=val options into an array while keeping
    * compatibility for values only.
+   *
+   * @deprecated
    */
   public static function parseProductOptions($string) : array {
-    $options = [];
-    $temp = explode(',', $string);
-
-    foreach ($temp as $value) {
-      $parts = explode('=', $value, 2);
-      if (count($parts) == 2) {
-        $options[trim($parts[0])] = trim($parts[1]);
-      }
-      else {
-        $options[trim($value)] = trim($value);
-      }
-    }
-
-    return $options;
+    return CRM_Utils_CommaKV::unserialize($string);
   }
 
 }

--- a/CRM/Contribute/Form/ManagePremiums.php
+++ b/CRM/Contribute/Form/ManagePremiums.php
@@ -320,6 +320,13 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
 
     $params += $this->getSubmittedCustomFieldsForApi4();
 
+    if (is_string($params['options'])) {
+      // In setDefaultValues(), we loaded the serialized `options` string to present
+      // it as one editable string. Now we pass to APIv4 save() -- but it doesn't want
+      // the serialized string. It wants the array...
+      $params['options'] = CRM_Utils_CommaKV::unserialize($params['options']);
+    }
+
     // Save the premium product to database
     $premium = Product::save()->addRecord($params)->execute()->first();
 

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -117,7 +117,17 @@ class CRM_Core_DAO extends DB_DataObject {
     /**
      * Comma separated string, no quotes, no spaces
      */
-    SERIALIZE_COMMA = 5;
+    SERIALIZE_COMMA = 5,
+    /**
+     * @deprecated
+     *
+     * Comma separated, spaces trimmed, key=value optional
+     *
+     * This was added to handle a wonky/legacy field, `civicrm_product.options`.
+     * If you're adding new fields, then use SERIALIZE_JSON instead. JSON is more
+     * standardized and has fewer quirks.
+     */
+    SERIALIZE_COMMA_KEY_VALUE = 6;
 
   /**
    * Define entities that shouldn't be created or deleted when creating/ deleting
@@ -3411,6 +3421,9 @@ SELECT contact_id
       case self::SERIALIZE_COMMA:
         return is_array($value) ? implode(',', $value) : $value;
 
+      case self::SERIALIZE_COMMA_KEY_VALUE:
+        return is_array($value) ? CRM_Utils_CommaKV::serialize($value) : $value;
+
       default:
         throw new Exception('Unknown serialization method for field.');
     }
@@ -3447,6 +3460,9 @@ SELECT contact_id
 
       case self::SERIALIZE_COMMA:
         return explode(',', trim(str_replace(', ', '', $value)));
+
+      case self::SERIALIZE_COMMA_KEY_VALUE:
+        return CRM_Utils_CommaKV::unserialize($value);
 
       default:
         throw new CRM_Core_Exception('Unknown serialization method for field.');

--- a/CRM/Utils/CommaKV.php
+++ b/CRM/Utils/CommaKV.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * @deprecated
+ *
+ * Implement a serialization format where:
+ * - Items are comma-separated
+ * - Items maybe barewords or "key=value" pairs
+ *
+ * This format is not well-defined for all possible inputs. It should not be used.
+ * It's included for working with legacy data.
+ */
+class CRM_Utils_CommaKV {
+
+  /**
+   * Convert key=val options into an array while keeping
+   * compatibility for values only.
+   */
+  public static function unserialize($string) : array {
+    $options = [];
+    $temp = explode(',', $string);
+
+    foreach ($temp as $value) {
+      $parts = explode('=', $value, 2);
+      if (count($parts) == 2) {
+        $options[trim($parts[0])] = trim($parts[1]);
+      }
+      else {
+        $options[trim($value)] = trim($value);
+      }
+    }
+
+    return $options;
+  }
+
+  public static function serialize($values) {
+    $parts = [];
+    foreach ($values as $key => $value) {
+      if ($key === $value) {
+        $parts[] = $key;
+      }
+      else {
+        $parts[] = $key . '=' . $value;
+      }
+    }
+    return implode(',', $parts);
+  }
+
+}

--- a/CRM/Utils/CommaKV.php
+++ b/CRM/Utils/CommaKV.php
@@ -52,7 +52,7 @@ class CRM_Utils_CommaKV {
         $parts[] = $key . '=' . $value;
       }
     }
-    return implode(',', $parts);
+    return implode(",\n", $parts);
   }
 
 }

--- a/schema/Contribute/Product.entityType.php
+++ b/schema/Contribute/Product.entityType.php
@@ -67,7 +67,7 @@ return [
       'localizable' => TRUE,
       'description' => ts('Store comma-delimited list of color, size, etc. options for the product.'),
       'add' => '1.4',
-      'serialize' => CRM_Core_DAO::SERIALIZE_COMMA,
+      'serialize' => CRM_Core_DAO::SERIALIZE_COMMA_KEY_VALUE,
     ],
     'image' => [
       'title' => ts('Image'),

--- a/tests/phpunit/CRM/Utils/CommaKVTest.php
+++ b/tests/phpunit/CRM/Utils/CommaKVTest.php
@@ -18,14 +18,16 @@ class CRM_Utils_CommaKVTest extends CiviUnitTestCase {
     $canonicalExamples[''] = ['' => '']; /* Weird, but that's what it has been doing. */
     $canonicalExamples['Orange'] = ['Orange' => 'Orange'];
     $canonicalExamples['2=Purple'] = [2 => 'Purple'];
-    $canonicalExamples['Red,White,Blue'] = ['Red' => 'Red', 'White' => 'White', 'Blue' => 'Blue'];
-    $canonicalExamples['3=Red,2=White,1=Blue'] = [3 => 'Red', 2 => 'White', 1 => 'Blue'];
+    $canonicalExamples["Red,\nWhite,\nBlue"] = ['Red' => 'Red', 'White' => 'White', 'Blue' => 'Blue'];
+    $canonicalExamples["3=Red,\n2=White,\n1=Blue"] = [3 => 'Red', 2 => 'White', 1 => 'Blue'];
 
     // The alternate examples are legal representations of the data, but they differ slightly from canonical encode() output.
     $alternateExamples = [];
+    $alternateExamples['Red,Green,Blue'] = ['Red' => 'Red', 'Green' => 'Green', 'Blue' => 'Blue'];
     $alternateExamples['Red, Green, Blue'] = ['Red' => 'Red', 'Green' => 'Green', 'Blue' => 'Blue'];
     $alternateExamples["\nCyan , Yellow\n,\t\t Magenta "] = ['Cyan' => 'Cyan', 'Yellow' => 'Yellow', 'Magenta' => 'Magenta'];
     $alternateExamples['f00=Red,fff=White,Blue'] = ['f00' => 'Red', 'fff' => 'White', 'Blue' => 'Blue'];
+    $alternateExamples["  FF0000  =  Red,\t\t00FF00  =  Green,  0000FF  =  Blue  "] = ['FF0000' => 'Red', '00FF00' => 'Green', '0000FF' => 'Blue'];
 
     $this->assertNotEmpty($canonicalExamples);
     foreach ($canonicalExamples as $string => $array) {

--- a/tests/phpunit/CRM/Utils/CommaKVTest.php
+++ b/tests/phpunit/CRM/Utils/CommaKVTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @group headless
+ */
+class CRM_Utils_CommaKVTest extends CiviUnitTestCase {
+
+  /**
+   * Set up for tests.
+   */
+  public function setUp(): void {
+    parent::setUp();
+    $this->useTransaction();
+  }
+
+  public function testExamples() {
+    $canonicalExamples = [];
+    $canonicalExamples[''] = ['' => '']; /* Weird, but that's what it has been doing. */
+    $canonicalExamples['Orange'] = ['Orange' => 'Orange'];
+    $canonicalExamples['2=Purple'] = [2 => 'Purple'];
+    $canonicalExamples['Red,White,Blue'] = ['Red' => 'Red', 'White' => 'White', 'Blue' => 'Blue'];
+    $canonicalExamples['3=Red,2=White,1=Blue'] = [3 => 'Red', 2 => 'White', 1 => 'Blue'];
+
+    // The alternate examples are legal representations of the data, but they differ slightly from canonical encode() output.
+    $alternateExamples = [];
+    $alternateExamples['Red, Green, Blue'] = ['Red' => 'Red', 'Green' => 'Green', 'Blue' => 'Blue'];
+    $alternateExamples["\nCyan , Yellow\n,\t\t Magenta "] = ['Cyan' => 'Cyan', 'Yellow' => 'Yellow', 'Magenta' => 'Magenta'];
+    $alternateExamples['f00=Red,fff=White,Blue'] = ['f00' => 'Red', 'fff' => 'White', 'Blue' => 'Blue'];
+
+    $this->assertNotEmpty($canonicalExamples);
+    foreach ($canonicalExamples as $string => $array) {
+      $decoded = CRM_Utils_CommaKV::unserialize($string);
+      $this->assertEquals($array, $decoded, sprintf('String %s should be parsed as array', json_encode($string)));
+      $encoded = CRM_Utils_CommaKV::serialize($decoded);
+      $this->assertEquals($string, $encoded, sprintf('String %s should be re-encoded as equivalent value', json_encode($string)));
+    }
+
+    $this->assertNotEmpty($alternateExamples);
+    foreach ($alternateExamples as $string => $array) {
+      $parsed_1 = CRM_Utils_CommaKV::unserialize($string);
+      $this->assertEquals($array, $parsed_1, sprintf('String %s should be parsed as array', json_encode($string)));
+      $parsed_2 = CRM_Utils_CommaKV::unserialize(CRM_Utils_CommaKV::serialize($parsed_1));
+      $this->assertEquals($array, $parsed_2, sprintf('String %s should yield stable outputs after multiple decode/encode cycles', json_encode($string)));
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

Fixes https://lab.civicrm.org/dev/core/-/issues/5585. Alternative to #31542. 

Steps to Reproduce
----------------------------------------

* Install 5.69 with sample data
* Upgrade to 5.81-head
* Open contribution page `#1` (which includes a "Coffee Mug" product) and determine if the options are correct.

Before
----------------------------------------

When using API to read or write data in `civicrm_product.options`, the options may *sometimes* be converted to a valid list (e.g. if there are no spaces). But _generally_, there are many pre-existing/valid values for this field (*including default demo data*) which are not handled consistently.

The basic problem is that the field is *labeled* as `SERIALIZE_COMMA`, but it's not *really* `SERIALIZE_COMMA` format. (*It is serialized, and it does use commas, but the format is otherwise quite different.*) Passing this data through `SERIALIZE_COMMA` leads to munged results.

For example, with demo data, the contribution page wrongly displays this single option:

<img width="1036" alt="Screenshot 2024-12-10 at 6 26 41 PM" src="https://github.com/user-attachments/assets/389d0b3e-0cf6-4cce-bfd4-32b45bd81694">

After
----------------------------------------

The same encoding/decoding rules are used for CiviContribute logic and API logic. (This format is given a distinct name, `SERIALIZE_COMMA_KEY_VALUE`.)

The contribution page properly shows multiple options:

<img width="1031" alt="Screenshot 2024-12-10 at 6 28 00 PM" src="https://github.com/user-attachments/assets/cf08670a-2c2e-4d85-a254-ab60cdf72708">

Technical Details
----------------------------------------

In the admin UI, the content of `civicrm_product.options` is exposed as a freeform text blob. So we should expect many subtle variations in the input formatting. To ensure consistency, this exactly preserves the decode logic, and it adds several tests/examples.