### PR TITLE
add AdminUI Settings Inspector screen

### DIFF
--- a/ext/civicrm_admin_ui/Civi/Api4/Action/SettingEntry/Get.php
+++ b/ext/civicrm_admin_ui/Civi/Api4/Action/SettingEntry/Get.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Civi\Api4\Action\SettingEntry;
+
+/**
+ * Get defined SettingsMeta
+ *
+ * TODO: would like to be able to show set values + layer at which they are set
+ */
+class Get extends \Civi\Api4\Generic\BasicGetAction {
+
+  /**
+   * Only fetch settings available at boot
+   * @var bool
+   */
+  protected $bootOnly = FALSE;
+
+  /**
+   * @return array
+   */
+  protected function getRecords() {
+    return \Civi\Core\SettingsMetadata::getMetadata([], NULL, FALSE, $this->bootOnly);
+  }
+
+}

--- a/ext/civicrm_admin_ui/Civi/Api4/Action/SettingEntry/Get.php
+++ b/ext/civicrm_admin_ui/Civi/Api4/Action/SettingEntry/Get.php
@@ -25,6 +25,10 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
       $allValues = \Civi::settings()->all();
 
       foreach ($meta as $i => $record) {
+        if ($record['is_secret']) {
+          $meta[$i]['current_value'] = '[SECRET]';
+          continue;
+        }
         $name = $record['name'];
 
         $value = $allValues[$name] ?? NULL;
@@ -39,7 +43,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
 
     // TODO: SettingsManager doesn't expose the layer at which a setting
     // is set publicly, so this is a slightly rough implementation for now
-    if ($this->_isFieldSelected('current_layer')) {
+    if ($this->_isFieldSelected('current_layer') || $this->_isFieldSelected('current_layer:label')) {
       foreach ($meta as $i => $record) {
         $meta[$i]['current_layer'] = $this->getLayer($record);
       }

--- a/ext/civicrm_admin_ui/Civi/Api4/Action/SettingEntry/Get.php
+++ b/ext/civicrm_admin_ui/Civi/Api4/Action/SettingEntry/Get.php
@@ -19,7 +19,53 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
    * @return array
    */
   protected function getRecords() {
-    return \Civi\Core\SettingsMetadata::getMetadata([], NULL, FALSE, $this->bootOnly);
+    $meta = \Civi\Core\SettingsMetadata::getMetadata([], NULL, FALSE, $this->bootOnly);
+
+    if ($this->_isFieldSelected('current_value')) {
+      $allValues = \Civi::settings()->all();
+
+      foreach ($meta as $i => $record) {
+        $name = $record['name'];
+
+        $value = $allValues[$name] ?? NULL;
+
+        if (is_array($value)) {
+          $value = json_encode($value);
+        }
+
+        $meta[$i]['current_value'] = (string) $value;
+      }
+    }
+
+    // TODO: SettingsManager doesn't expose the layer at which a setting
+    // is set publicly, so this is a slightly rough implementation for now
+    if ($this->_isFieldSelected('current_layer')) {
+      foreach ($meta as $i => $record) {
+        $meta[$i]['current_layer'] = $this->getLayer($record);
+      }
+    }
+
+    return $meta;
+  }
+
+  protected function getLayer(array $record): string {
+    $envVarName = $record['is_env_loadable'] ? $record['global_name'] : NULL;
+
+    if ($envVarName && (getenv($envVarName) !== FALSE)) {
+      return 'environment';
+    }
+
+    $settingName = $record['name'];
+
+    if (!is_null(\Civi::settings()->getMandatory($settingName))) {
+      return 'file';
+    }
+
+    if (\Civi::settings()->hasExplicit($settingName)) {
+      return 'database';
+    }
+
+    return 'default';
   }
 
 }

--- a/ext/civicrm_admin_ui/Civi/Api4/SettingEntry.php
+++ b/ext/civicrm_admin_ui/Civi/Api4/SettingEntry.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Civi\Api4;
+
+use CRM_CivicrmAdminUi_ExtensionUtil as E;
+
+/**
+ * SettingMeta entity.
+ *
+ * Abstract entity to allow inspection of available Settings
+ *
+ * @package Civi\Api4
+ */
+class SettingEntry extends Generic\AbstractEntity {
+
+  public static function getFields($checkPermissions = TRUE) {
+    return (new Generic\BasicGetFieldsAction(__CLASS__, __FUNCTION__, function ($getFieldsAction) {
+      return [
+        [
+          'name' => 'title',
+          'title' => E::ts('Setting'),
+          'description' => E::ts('Public-facing name of the setting.'),
+          'input_type' => 'Text',
+        ],
+        [
+          'name' => 'name',
+          'title' => E::ts('Machine-name'),
+          'description' => E::ts('Machine-name of the setting. Use for `\Civi::settings()->get([name]);`'),
+        ],
+        [
+          'name' => 'group',
+          'title' => E::ts('Group Key'),
+          'description' => E::ts('Machine-name of the group this setting belongs to.'),
+        ],
+        [
+          'name' => 'group_name',
+          'title' => E::ts('Group'),
+          'description' => E::ts('Public-facing name of the group this setting belongs to.'),
+          'input_type' => 'Text',
+        ],
+        [
+          'name' => 'description',
+          'title' => E::ts('Description'),
+          'description' => E::ts('More details about this setting.'),
+          'input_type' => 'Text',
+        ],
+        [
+          'name' => 'help_text',
+          'title' => E::ts('Help text'),
+          'description' => E::ts('Further help for setting this setting.'),
+          'input_type' => 'Text',
+        ],
+        [
+          'name' => 'global_name',
+          'title' => E::ts('Global Name'),
+          'description' => E::ts('Used for PHP defines / environment variables.'),
+          'input_type' => 'Text',
+        ],
+        [
+          'name' => 'is_env_loadable',
+          'title' => E::ts('Environment Variable?'),
+          'description' => E::ts('Can this setting be set using an Environment Variable?'),
+          'data_type' => 'Boolean',
+          'input_type' => 'Radio',
+        ],
+        [
+          'name' => 'is_constant',
+          'title' => E::ts('PHP Constant?'),
+          'description' => E::ts('Is there a php define corresponding to this setting'),
+          'data_type' => 'Boolean',
+          'input_type' => 'Radio',
+        ],
+        [
+          'name' => 'is_domain',
+          'title' => E::ts('Is domain-level?'),
+          'description' => E::ts('Is this a contact or domain level setting?'),
+          'data_type' => 'Boolean',
+          'input_type' => 'Radio',
+        ],
+        [
+          'name' => 'is_contact',
+          'title' => E::ts('Is contact-level?'),
+          'description' => E::ts('Is this a contact or domain level setting?'),
+          'data_type' => 'Boolean',
+          'input_type' => 'Radio',
+        ],
+      ];
+    }))->setCheckPermissions($checkPermissions);
+  }
+
+}

--- a/ext/civicrm_admin_ui/Civi/Api4/SettingEntry.php
+++ b/ext/civicrm_admin_ui/Civi/Api4/SettingEntry.php
@@ -84,6 +84,29 @@ class SettingEntry extends Generic\AbstractEntity {
           'data_type' => 'Boolean',
           'input_type' => 'Radio',
         ],
+        [
+          'name' => 'current_value',
+          'title' => E::ts('Current value'),
+          'description' => E::ts('Current value of this setting'),
+          'data_type' => 'String',
+          'input_type' => 'Text',
+        ],
+        [
+          'name' => 'current_layer',
+          'title' => E::ts('Current layer'),
+          'description' => E::ts('Where is the current value of this setting set? (e.g. environment variable, settings file, database)'),
+          'data_type' => 'String',
+          'input_type' => 'Select',
+          'options' => [
+            'environment' => 'Environment variable',
+            'file' => 'PHP define or $civicrm_setting override (usually in civicrm.settings.php)',
+            // we can't easily distinguish between these.. yet?
+            //'define' => 'PHP Define (usually in civicrm.settings.php)',
+            //'override' => '$civicrm_setting override (usually in civicrm.settings.php)',
+            'database' => 'Database (civicrm_setting table)',
+            'default' => 'Using the default value',
+          ],
+        ],
       ];
     }))->setCheckPermissions($checkPermissions);
   }

--- a/ext/civicrm_admin_ui/ang/afsearchSettingsInspector.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchSettingsInspector.aff.html
@@ -1,0 +1,7 @@
+<div af-fieldset="">
+  <af-field name="title" />
+  <af-field name="group_name" />
+  <af-field name="is_env_loadable" />
+  <af-field name="current_layer" defn="{input_attrs: {multiple: true}}" />
+  <crm-search-display-table search-name="Settings_Inspector" display-name="Settings_Inspector"></crm-search-display-table>
+</div>

--- a/ext/civicrm_admin_ui/ang/afsearchSettingsInspector.aff.php
+++ b/ext/civicrm_admin_ui/ang/afsearchSettingsInspector.aff.php
@@ -1,0 +1,16 @@
+<?php
+use CRM_CivicrmAdminUi_ExtensionUtil as E;
+
+return [
+  'type' => 'search',
+  'title' => E::ts('Settings Inspector'),
+  'description' => E::ts('Allows inspecting settings on the CiviCRM site'),
+  'icon' => 'fa-list-alt',
+  'server_route' => 'civicrm/admin/settings-inspector',
+  'permission' => [
+    'administer CiviCRM system',
+  ],
+  'search_displays' => [
+    'Settings_Inspector.Settings_Inspector',
+  ],
+];

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Settings_Inspector.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Settings_Inspector.mgd.php
@@ -1,0 +1,130 @@
+<?php
+use CRM_CivicrmAdminUi_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'SavedSearch_Settings_Inspector',
+    'entity' => 'SavedSearch',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Settings_Inspector',
+        'label' => E::ts('Settings Inspector'),
+        'api_entity' => 'SettingEntry',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'title',
+            'name',
+            'description',
+            'group_name',
+            'is_constant',
+            'is_env_loadable',
+            'global_name',
+            'current_value',
+            'current_layer:label',
+          ],
+          'orderBy' => [],
+          'where' => [],
+        ],
+      ],
+      'match' => ['name'],
+    ],
+  ],
+  [
+    'name' => 'SavedSearch_Settings_Inspector_SearchDisplay_Settings_Inspector',
+    'entity' => 'SearchDisplay',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Settings_Inspector',
+        'label' => E::ts('Settings Inspector'),
+        'saved_search_id.name' => 'Settings_Inspector',
+        'type' => 'table',
+        'settings' => [
+          'description' => E::ts(NULL),
+          'sort' => [],
+          'limit' => 50,
+          'pager' => [],
+          'placeholder' => 5,
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'group_name',
+              'dataType' => 'String',
+              'label' => E::ts('Group'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'title',
+              'dataType' => 'String',
+              'label' => E::ts('Setting'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'name',
+              'dataType' => 'String',
+              'label' => E::ts('Machine-name'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'description',
+              'dataType' => 'String',
+              'label' => E::ts('Description'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'is_constant',
+              'dataType' => 'Boolean',
+              'label' => E::ts('PHP Constant?'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'is_env_loadable',
+              'dataType' => 'Boolean',
+              'label' => E::ts('Environment Variable?'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'global_name',
+              'dataType' => 'String',
+              'label' => E::ts('Global Name'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'current_layer:label',
+              'dataType' => 'String',
+              'label' => E::ts('Current layer'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'current_value',
+              'dataType' => 'String',
+              'label' => E::ts('Current value'),
+              'sortable' => TRUE,
+            ],
+          ],
+          'actions' => TRUE,
+          'classes' => ['table', 'table-striped'],
+          'actions_display_mode' => 'menu',
+        ],
+      ],
+      'match' => [
+        'saved_search_id',
+        'name',
+      ],
+    ],
+  ],
+];

--- a/settings/Database.boot.setting.php
+++ b/settings/Database.boot.setting.php
@@ -35,6 +35,7 @@ return [
     'is_constant' => TRUE,
     'is_env_loadable' => TRUE,
     'global_name' => 'CIVICRM_DSN',
+    'is_secret' => TRUE,
   ],
   'civicrm_db_name' => [
     'name' => 'civicrm_db_name',
@@ -86,6 +87,7 @@ return [
     'is_constant' => TRUE,
     'is_env_loadable' => TRUE,
     'global_name' => 'CIVICRM_DB_PASSWORD',
+    'is_secret' => TRUE,
   ],
   'civicrm_db_host' => [
     'name' => 'civicrm_db_host',


### PR DESCRIPTION
Overview
----------------------------------------
Adds an Api4 entity for inspecting settings meta and values.

Before
----------------------------------------
- Lots of settings meta, not very discoverable

After
----------------------------------------
- Find settings with a directory style format


Technical Details
----------------------------------------
Want to be careful about exposing sensitive values through the `current_value` key. Added a new `is_secret` to DSN and Password settings, but probably should be used in more places.

I could be convinced to hold back on the `current_value` column for now.