### PR TITLE
(dev/core#5585) CiviContribute - Fix display of "Premium/Thank You Gift" on confirmation page

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -941,7 +941,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       if ($selectedProductID === $product['id'] && $selectedOption) {
         // In this case we are on the thank you or confirm page so assign
         // the selected option to the page for display.
-        $product['options'] = [ts('Selected Option') . ': ' . $selectedOption];
+        $product['options'] = ts('Selected Option') . ': ' . $selectedOption;
       }
       $options = array_filter((array) $product['options']);
       $productOptions = [];

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -943,6 +943,10 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         // the selected option to the page for display.
         $product['options'] = ts('Selected Option') . ': ' . $selectedOption;
       }
+      elseif ($selectedOption) {
+        // We are on the thank you or confirm page, but this option wasn't selected.
+        continue;
+      }
       $options = array_filter((array) $product['options']);
       $productOptions = [];
       foreach ($options as $option) {


### PR DESCRIPTION
Overview
----------------------------------------

Fix for https://lab.civicrm.org/dev/core/-/issues/5585. Follow-up to #29767, #31590.

Steps to Reproduce
----------------------------------------

* Install 5.69 with sample data
* Upgrade to 5.81-head
* Open contribution page `#1` (which includes a "Coffee Mug" product). 
* Choose an option like "Black".
* Continue to the confirmation screen.

Before
----------------------------------------

The confirmation doesn't show the selection ("Black"). It shows the word "Array".

<img width="791" alt="Screenshot 2024-12-11 at 2 33 42 PM" src="https://github.com/user-attachments/assets/2dda6bf0-2ee9-413d-823b-225483606a21" />

After
----------------------------------------

Option shown correctly.

<img width="804" alt="Screenshot 2024-12-11 at 2 31 57 PM" src="https://github.com/user-attachments/assets/ea468a78-2f4f-4cde-8992-f801bd43695c" />

Technical Details
----------------------------------------

This basically reverts a small part of #29767's f6db1bb55ee12b7907587f3ad4f09961789198f6 (circa line 943-945). The general theme of the PR was to treat APIv4 `Product`.`options` as an array, and it included this change:

```diff
- $product['options'] = ts('Selected Option') . ': ' . $selectedOption;
+ $product['options'] = [ts('Selected Option') . ': ' . $selectedOption];
```

However, `$product` here does not appear to be an APIv4 `Product`. The content here clearly differs. (The prose `ts('Selected Option')` should never go into `Product`.`options`...) Rather, `$product` appears to be a bespoke data-structure that feeds data to Smarty.

Restoring `$product['options']` to its original format means that the Smarty output works again.

Comments
----------------------------------------

I checked that (*with this patch*) the selected value was subsequently displayed in the web-confirmation, the email-confirmation, and the backend UI (`civicrm/contact/view/contribution`). They all looked good.