### PR TITLE
(NFC) Test cases should cleanup HTTP_X_REQUESTED_WITH consistently.

### DIFF
--- a/Civi/Test/CiviTestListener.php
+++ b/Civi/Test/CiviTestListener.php
@@ -98,6 +98,7 @@ else {
       \CRM_Utils_Time::resetTime();
       if ($this->isCiviTest($test)) {
         unset($GLOBALS['CIVICRM_TEST_CASE']);
+        unset($_SERVER['HTTP_X_REQUESTED_WITH']); /* Several tests neglect to clean this up... */
         error_reporting(E_ALL & ~E_NOTICE);
         $this->errorScope = NULL;
       }

--- a/Civi/Test/CiviTestListenerPHPUnit7.php
+++ b/Civi/Test/CiviTestListenerPHPUnit7.php
@@ -87,6 +87,7 @@ class CiviTestListenerPHPUnit7 implements \PHPUnit\Framework\TestListener {
     \CRM_Utils_Time::resetTime();
     if ($this->isCiviTest($test)) {
       unset($GLOBALS['CIVICRM_TEST_CASE']);
+      unset($_SERVER['HTTP_X_REQUESTED_WITH']); /* Several tests neglect to clean this up... */
       error_reporting(E_ALL & ~E_NOTICE);
       $this->errorScope = NULL;
     }

--- a/Civi/Test/Legacy/CiviTestListener.php
+++ b/Civi/Test/Legacy/CiviTestListener.php
@@ -88,6 +88,7 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
     \CRM_Utils_Time::resetTime();
     if ($this->isCiviTest($test)) {
       unset($GLOBALS['CIVICRM_TEST_CASE']);
+      unset($_SERVER['HTTP_X_REQUESTED_WITH']); /* Several tests neglect to clean this up... */
       error_reporting(E_ALL & ~E_NOTICE);
       $this->errorScope = NULL;
     }

--- a/tests/phpunit/CRM/Core/Page/AJAXTest.php
+++ b/tests/phpunit/CRM/Core/Page/AJAXTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Core_Page_AJAXTest extends CiviUnitTestCase {
 
+  protected function setUp(): void {
+    parent::setUp();
+    $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+  }
+
   public function testCheckAuthz(): void {
     $cases = [];
 


### PR DESCRIPTION
Overview
--------

Reduce spooky interactions between tests.

This is "NFC" because it has no effect on runtime logic, and it doesn't change the real semantics of any tests.

Before
------

Several tests manipulate the value of `HTTP_X_REQUESTED_WITH`. Almost all of them neglect to reset it afterward.

This creates spooky interactions between tests. For example, consider `CRM_Core_Page_AJAXTest`:

* It passes when run as part of `CRM_AllTests`... because prior tests initialize `HTTP_X_REQUESTED_WITH`.
* It fails when run in isolation... because it doesn't initialize `HTTP_X_REQUESTED_WITH` for itself.

After
-----

Less spookiness.

Cannot rely on happenstance of prior tests to manipulate `HTTP_X_REQUESTED_WITH`.

Comment
-------

If any tests fail from this, it's probably because they're like `CRM_Core_Page_AJAXTest` (ie they have undeclared dependency on `HTTP_X_REQUESTED_WITH`).

Putting this in CiviTestListener is a bit heavy-handed, but otherwise it's a game of whack-a-mole...