### PR TITLE
Prevent duplication of unsent scheduled reminders

### DIFF
--- a/Civi/ActionSchedule/RecipientBuilder.php
+++ b/Civi/ActionSchedule/RecipientBuilder.php
@@ -257,7 +257,7 @@ class RecipientBuilder {
         ->merge($this->joinReminder('INNER JOIN', 'addl', $query))
         ->merge($this->prepareAddlFilter('c.id'), ['params'])
         ->where("c.is_deleted = 0 AND c.is_deceased = 0")
-        ->groupBy("reminder.contact_id")
+        ->groupBy("reminder.contact_id, reminder.entity_id, reminder.entity_table")
         ->having("SUM(ISNULL(reminder.action_date_time)) = 0")
         ->having("TIMESTAMPDIFF(HOUR, MAX(reminder.action_date_time), CAST(!casNow AS datetime)) >= TIMESTAMPDIFF(HOUR, MAX(reminder.action_date_time), DATE_ADD(MAX(reminder.action_date_time), INTERVAL !casRepetitionInterval))")
         ->param([

--- a/Civi/ActionSchedule/RecipientBuilder.php
+++ b/Civi/ActionSchedule/RecipientBuilder.php
@@ -215,12 +215,14 @@ class RecipientBuilder {
     // the first part of the startDateClause array is the earliest the reminder can be sent. If the
     // event (e.g membership_end_date) has changed then the reminder may no longer apply
     // @todo - this only handles events that get moved later. Potentially they might get moved earlier
+    // also, do not create any more entries if there are unprocessed ones still pending
     $repeatInsert = $query
       ->merge($this->joinReminder('INNER JOIN', 'rel', $query))
       ->merge($this->selectIntoActionLog(self::PHASE_RELATION_REPEAT, $query))
       ->merge($this->prepareRepetitionEndFilter($query['casDateField']))
       ->where($this->actionSchedule->start_action_date ? $startDateClauses[0] : [])
       ->groupBy("reminder.contact_id, reminder.entity_id, reminder.entity_table")
+      ->having("SUM(ISNULL(reminder.action_date_time)) = 0")
       ->having("TIMESTAMPDIFF(HOUR, MAX(reminder.action_date_time), CAST(!casNow AS datetime)) >= TIMESTAMPDIFF(HOUR, MAX(reminder.action_date_time), DATE_ADD(MAX(reminder.action_date_time), INTERVAL !casRepetitionInterval))")
       ->param([
         'casRepetitionInterval' => $this->parseRepetitionInterval(),
@@ -256,6 +258,7 @@ class RecipientBuilder {
         ->merge($this->prepareAddlFilter('c.id'), ['params'])
         ->where("c.is_deleted = 0 AND c.is_deceased = 0")
         ->groupBy("reminder.contact_id")
+        ->having("SUM(ISNULL(reminder.action_date_time)) = 0")
         ->having("TIMESTAMPDIFF(HOUR, MAX(reminder.action_date_time), CAST(!casNow AS datetime)) >= TIMESTAMPDIFF(HOUR, MAX(reminder.action_date_time), DATE_ADD(MAX(reminder.action_date_time), INTERVAL !casRepetitionInterval))")
         ->param([
           'casRepetitionInterval' => $this->parseRepetitionInterval(),


### PR DESCRIPTION
Overview
----------------------------------------
This PR provides a fix for the issue identified and discussed in https://lab.civicrm.org/dev/core/-/issues/3824. In the original issue, a server misconfiguration caused the sending of scheduled reminders to fail partway through. This resulted in multiple copies of the same reminder being queued up for sending every time the job ran (even if the reminder was already queued to send), meaning that when the job eventually succeeded, thousands of duplicate reminders were sent to contacts in the database.

Before
----------------------------------------
When sending a scheduled reminder on a repetition schedule, there is no mechanism to check whether a previous instance of the reminder was already queued to send but never actually got sent. As such, every time the job runs, a new copy of the reminder is queued to send. If and when the emails are actually sent, you get duplicate reminders.

![image](https://github.com/user-attachments/assets/4989ccac-5c51-42a6-91ac-eda753c43092)

See issue linked above for further details and screenshots etc.

After
----------------------------------------
When sending a scheduled reminder on a repetition schedule, we now check to make sure that no previous unsent copies exist. If there are, we leave those to be sent but do not queue up a new copy of the reminder to be sent, thus avoiding duplication.

![Screenshot 2024-11-09 234925](https://github.com/user-attachments/assets/3d82bedb-7f4b-418f-bb97-e24d85bf35a2)

Technical Details
----------------------------------------
The linked issue includes details of the testing used to simulate the problem and prove that it can be contained by this fix, and to prove that the fix does not interfere with normal sending of reminders.

In addition to this, the proposed fix has been live for > 1 month on a production system running CiviCRM 5.78.3. Reminders have been observed to continue sending as normal.

Comments
----------------------------------------
This is a robustness improvement to prevent a highly undesirable cascade failure mode (sending many hundreds or thousands of emails to users) in the event of a fault.
