### PR TITLE
Add Joomla 4 compatibility to CRM_Utils_System_Joomla::loadUser()

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -503,15 +503,16 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
         require_once $joomlaBase . '/plugins/user/joomla/src/Extension/Joomla.php';
         $container = \Joomla\CMS\Factory::getContainer();
         $container->alias('session.web', 'session.web.site')
-                  ->alias('session', 'session.web.site')
-                  ->alias('JSession', 'session.web.site')
-                  ->alias(\Joomla\CMS\Session\Session::class, 'session.web.site')
-                  ->alias(\Joomla\Session\Session::class, 'session.web.site')
-                  ->alias(\Joomla\Session\SessionInterface::class, 'session.web.site');
+          ->alias('session', 'session.web.site')
+          ->alias('JSession', 'session.web.site')
+          ->alias(\Joomla\CMS\Session\Session::class, 'session.web.site')
+          ->alias(\Joomla\Session\Session::class, 'session.web.site')
+          ->alias(\Joomla\Session\SessionInterface::class, 'session.web.site');
         $app = $container->get(\Joomla\CMS\Application\SiteApplication::class);
         \Joomla\CMS\Factory::$application = $app;
         $instance = JFactory::getApplication();
-      } else {
+      }
+      else {
         $instance = JFactory::getApplication('site');
       }
       $params = [


### PR DESCRIPTION
Overview
----------------------------------------
This PR proposes a fix to the issue https://lab.civicrm.org/dev/core/-/issues/5645, where it was found that cron jobs running via cli.php are not compatible with Joomla 4.

Before
----------------------------------------
Running a cron job on Joomla 4 results in process failure with the following error message:

```
Symfony\Component\ErrorHandler\Error\UndefinedMethodError {#2612
  #message: "Attempted to call an undefined method named "login" of class "Joomla\CMS\Application\ConsoleApplication"."
  #code: 0
  #file: "./public_html/administrator/components/com_civicrm/civicrm/CRM/Utils/System/Joomla.php"
  #line: 483
  trace: {
    ./public_html/administrator/components/com_civicrm/civicrm/CRM/Utils/System/Joomla.php:483 {
      CRM_Utils_System_Joomla->loadUser($username, $password = null)
      ›   //perform the login action
      ›   $instance->login($params);
      › }
    }
    ./public_html/administrator/components/com_civicrm/civicrm/bin/cli.class.php:269 { …}
    ./public_html/administrator/components/com_civicrm/civicrm/bin/cli.class.php:67 { …}
    ./public_html/administrator/components/com_civicrm/civicrm/bin/cli.php:16 { …}
  }
}
```

After
----------------------------------------
Cron job completes successfully.

Technical Details
----------------------------------------
This has been tested using CiviCRM 5.78.3 on Joomla 4.4.9. The proposed code change is based heavily on the suggestion made in this discussion (https://groups.google.com/g/joomla-dev-general/c/55J2s9hhMxA?pli=1), which replicates the object instantiation code used in Joomla's `includes/app.php`. It then needed some further `require_once` directives to get this to work.

Comments
----------------------------------------
This is ONLY a workaround / temporary fix, as it does not address the wider Joomla 4/5/6 compatibility issues such as using deprecated naming conventions and methods. Furthermore, the need for `alias()` is a temporary bridging arrangement during the transitions between Joomla 3 and 5 (possibly 6).

As such, this issue will need to be revisited later. This will still NOT work with Joomla 5 or above.