### PR TITLE
Send Email: rename HTML Format to Message Body, tweak help

### DIFF
--- a/templates/CRM/Contact/Form/Task/Email.hlp
+++ b/templates/CRM/Contact/Form/Task/Email.hlp
@@ -51,14 +51,7 @@ be an equal sign and a number (=12). The number (12 in this example) is the id o
 <p>{docURL page="user/common-workflows/tokens-and-mail-merge" text=$tokentext}</p>
 {/htxt}
 
-{htxt id="id-message-text-title"}
-  {ts}Message Text{/ts}
-{/htxt}
-{htxt id="id-message-text"}
-<p>{ts}You can include tokens in your message{/ts}</p>
-<p>{docURL page="user/common-workflows/tokens-and-mail-merge" text=$tokentext}</p>
-{/htxt}
-{htxt id="id-message-text-title"}
+{htxt id="id-message-plain-title"}
   {ts}Message Plain Text{/ts}
 {/htxt}
 {htxt id="id-message-plain"}

--- a/templates/CRM/Contact/Form/Task/EmailCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/EmailCommon.tpl
@@ -11,8 +11,7 @@
 
 <details class="crm-accordion-bold crm-html_email-accordion " open>
 <summary>
-    {ts}HTML Format{/ts}
-    {help id="id-message-text" file="CRM/Contact/Form/Task/Email.hlp"}
+  {ts}Message Body{/ts}
 </summary>
  <div class="crm-accordion-body">
   <div class="helpIcon" id="helphtml">
@@ -29,7 +28,8 @@
 <details class="crm-accordion-bold crm-plaint_text_email-accordion">
 <summary>
   {ts}Plain-Text Format{/ts}
-  </summary>
+  {help id="id-message-plain" file="CRM/Contact/Form/Task/Email.hlp"}
+</summary>
  <div class="crm-accordion-body">
    <div class="helpIcon" id="helptext">
      <input class="crm-token-selector big" data-field="text_message" />


### PR DESCRIPTION
Overview
----------------------------------------

When sending a message to a contact (a single email), the "HTML Format" title is not particularly helpful as a title.

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/389c92c9-0437-4f31-b207-8714819f28c7)


After
----------------------------------------

- "HTML Format" becomes "Message Body"
- The help on that field was only about tokens, redundant with the help icon just below
- Added help icon to  "Plain text format", because most people have no idea what that is about.

![image](https://github.com/user-attachments/assets/b18db05c-bfe8-4893-acaf-b265cd5a4edf)

