### PR TITLE
ContributionView: show the contrib id, remove some buttons, layout changes

### DIFF
--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -276,12 +276,6 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
       if (($context === 'fulltext' || $context === 'search') && $searchKey) {
         $urlParams = "reset=1&id={$id}&cid={$values['contact_id']}&action=update&context={$context}&key={$searchKey}";
       }
-      if (!$contribution['is_template']) {
-        foreach (CRM_Contribute_BAO_Contribution::getContributionPaymentLinks($this->getContributionID(), $contributionStatus) as $paymentButton) {
-          $paymentButton['icon'] = 'fa-plus-circle';
-          $linkButtons[] = $paymentButton;
-        }
-      }
       $linkButtons[] = [
         'title' => ts('Edit'),
         'url' => 'civicrm/contact/view/contribution',

--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -508,14 +508,14 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
             'type' => '',
           ],
           [
-            'name' => ts('Contribution Source'),
+            'name' => ts('Source'),
             'sort' => 'contribution_source',
             'field_name' => 'contribution_source',
             'direction' => CRM_Utils_Sort::DONTCARE,
             'type' => '',
           ],
           [
-            'name' => ts('Contribution Date'),
+            'name' => ts('Date'),
             'sort' => 'receive_date',
             'field_name' => 'receive_date',
             'type' => 'date',

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -1015,30 +1015,30 @@ input.crm-form-entityref {
   border: 2px solid #999999;
 }
 
-#crm-container .float-left {
+.crm-container .float-left {
   float: left;
   padding: 4px 0;
   clear: none;
 }
 
-#crm-container .float-left + .float-left {
+.crm-container .float-left + .float-left {
   margin-left: 1em;
 }
 
-#crm-container .float-right {
+.crm-container .float-right {
   float: right;
   width: auto;
   padding: 4px 0;
   clear: none;
 }
 
-#crm-container .align-right {
+.crm-container .align-right {
   display: block;
   margin-right: 20px;
   text-align: right;
 }
 
-#crm-container .element-right {
+.crm-container .element-right {
   float: right;
   margin-right: 35px;
 }

--- a/templates/CRM/Contribute/Form/ContributionView.tpl
+++ b/templates/CRM/Contribute/Form/ContributionView.tpl
@@ -23,39 +23,33 @@
     <td>{$financial_type}{if $is_test} {ts}(test){/ts} {/if}</td>
   </tr>
   <tr class="crm-contribution-form-block-source">
-    <td class="label">{ts}Contribution Source{/ts}</td>
+    <td class="label">{ts}Source{/ts}</td>
     <td>{$source|escape}</td>
   </tr>
   {if empty($is_template)}
   <tr class="crm-contribution-form-block-receive_date">
-    <td class="label">{ts}Contribution Date{/ts}</td>
+    <td class="label">{ts}Date{/ts}</td>
     <td>{if $receive_date}{$receive_date|crmDate}{else}({ts}not available{/ts}){/if}</td>
   </tr>
   {/if}
-  <tr class="crm-contribution-form-block-total_amount">
-    <td class="label">{ts}Contribution Amount{/ts}</td>
-    <td>{include file="CRM/Price/Page/LineItem.tpl" context="Contribution"}
-        {if $contribution_recur_id}
-          <a class="open-inline action-item crm-hover-button" href='{crmURL p="civicrm/contact/view/contributionrecur" q="reset=1&id=`$contribution_recur_id`&cid=`$contact_id`&context=contribution"}'>
-              {ts}View Recurring Contribution{/ts}
-          </a>
-          <br/>
-            {ts}Installments{/ts}: {if $recur_installments}{$recur_installments}{else}{ts}(ongoing){/ts}{/if}, {ts}Interval{/ts}: {$recur_frequency_interval} {$recur_frequency_unit}(s)
-        {/if}
-    </td>
-  </tr>
+</table>
+{include file="CRM/Price/Page/LineItem.tpl" context="Contribution"}
+{if $contribution_recur_id}
+  <a class="open-inline action-item crm-hover-button" href='{crmURL p="civicrm/contact/view/contributionrecur" q="reset=1&id=`$contribution_recur_id`&cid=`$contact_id`&context=contribution"}'>
+      {ts}View Recurring Contribution{/ts}
+  </a>
+  <br/>
+  {ts}Installments{/ts}: {if $recur_installments}{$recur_installments}{else}{ts}(ongoing){/ts}{/if}, {ts}Interval{/ts}: {$recur_frequency_interval} {$recur_frequency_unit}(s)
+{/if}
+<div class="clear"></div>
+<br>
+<table class="crm-info-panel">
   {if $associatedParticipants}
     <tr class="crm-contribution-form-block-associated_participants">
       <td class="label">{ts}Associated participants{/ts}</td>
       <td>
         {include file="CRM/Contribute/Form/ContributionViewAssociatedParticipants.tpl" associatedParticipants=$associatedParticipants}
       </td>
-    </tr>
-  {/if}
-  {if $invoicing && $tax_amount}
-    <tr class="crm-contribution-form-block-tax_amount">
-      <td class="label">{ts 1=$taxTerm}Total %1 Amount{/ts}</td>
-      <td>{$tax_amount|crmMoney:$currency}</td>
     </tr>
   {/if}
   {if $non_deductible_amount}
@@ -66,7 +60,7 @@
   {/if}
   {if $fee_amount}
     <tr class="crm-contribution-form-block-fee_amount">
-      <td class="label">{ts}Fee Amount{/ts}</td>
+      <td class="label">{ts}Processor Fee{/ts}</td>
       <td>{$fee_amount|crmMoney:$currency}</td>
     </tr>
   {/if}
@@ -153,14 +147,10 @@
       </tr>
     {/if}
   {/foreach}
-
-  {if $trxn_id}
-    <tr class="crm-contribution-form-block-trxn_id">
-      <td class="label">{ts}Transaction ID{/ts}</td>
-      <td>{$trxn_id}</td>
-    </tr>
-  {/if}
-
+  <tr class="crm-contribution-form-block-id">
+    <td class="label">{ts}Contribution ID{/ts}</td>
+    <td>{$id}</td>
+  </tr>
   {if $invoice_number}
     <tr class="crm-contribution-form-block-invoice_number">
       <td class="label">{ts}Invoice Number{/ts}</td>
@@ -181,17 +171,12 @@
       <td>{$thankyou_date|crmDate}</td>
     </tr>
   {/if}
-  <tr class="crm-contribution-form-block-payment-info">
-    <td class='label'>{ts}Payment Summary{/ts}</td>
-    <td id='payment-info'></td>
-  </tr>
-  {if empty($is_template)}
-  <tr class="crm-contribution-form-block-payment-details">
-    <td class="label">{ts}Payment Details{/ts}</td>
-    <td>{include file="CRM/Contribute/Form/PaymentInfoBlock.tpl"}</td>
-  </tr>
-  {/if}
 </table>
+
+{if empty($is_template)}
+  <h3>{ts}Payment Details{/ts}</h3>
+  {include file="CRM/Contribute/Form/PaymentInfoBlock.tpl"}
+{/if}
 
 {if $softContributions && count($softContributions)} {* We show soft credit name with PCP section if contribution is linked to a PCP. *}
   <details class="crm-accordion-bold crm-soft-credit-pane" open>
@@ -286,6 +271,8 @@
     </div>
   </fieldset>
 {/if}
+
+<div id="payment-info"></div>
 {include file="CRM/Contribute/Page/PaymentInfo.tpl" show='payments'}
 
 <div class="crm-submit-buttons">

--- a/templates/CRM/Contribute/Form/PaymentInfoBlock.tpl
+++ b/templates/CRM/Contribute/Form/PaymentInfoBlock.tpl
@@ -14,7 +14,7 @@
       <th>{ts}Amount{/ts}</th>
       <th>{ts}Type{/ts}</th>
       <th>{ts}Payment Method{/ts}</th>
-      <th>{ts}Contribution Date{/ts}</th>
+      <th>{ts}Date{/ts}</th>
       <th>{ts}Transaction ID{/ts}</th>
       <th>{ts}Status{/ts}</th>
       <th></th>

--- a/templates/CRM/Contribute/Page/ContributionTotals.tpl
+++ b/templates/CRM/Contribute/Page/ContributionTotals.tpl
@@ -13,9 +13,9 @@
 
     {if !empty($annual.count)}
         <tr>
-            <th class="contriTotalLeft right">{ts}Current Fiscal Year-to-Date{/ts} &ndash; {$annual.amount nofilter}</th>
-            <th class="right"> &nbsp; {ts}# Completed Contributions{/ts} &ndash; {$annual.count nofilter}</th>
-            <th class="right contriTotalRight"> &nbsp; {ts}Avg Amount{/ts} &ndash; {$annual.avg nofilter}</th>
+            <th class="contriTotalLeft right text-right">{ts}Current Fiscal Year-to-Date{/ts} &ndash; {$annual.amount nofilter}</th>
+            <th class="right text-right"> &nbsp; {ts}# Completed Contributions{/ts} &ndash; {$annual.count nofilter}</th>
+            <th class="right text-right contriTotalRight"> &nbsp; {ts}Avg Amount{/ts} &ndash; {$annual.avg nofilter}</th>
             {if $contributionSummary.cancel.amount}
                 <td>&nbsp;</td>
             {/if}
@@ -26,11 +26,11 @@
       <tr>
           {if $contributionSummary.total.amount}
             <th class="contriTotalLeft right">{ts}Total{/ts} &ndash; {$contributionSummary.total.amount nofilter}</th>
-            <th class="right"> &nbsp; {ts}# Completed{/ts} &ndash; {$contributionSummary.total.count nofilter}</th>
-            <th class="right contriTotalRight"> &nbsp; {ts}Avg{/ts} &ndash; {$contributionSummary.total.avg nofilter}</th>
+            <th class="right text-right"> &nbsp; {ts}# Completed{/ts} &ndash; {$contributionSummary.total.count nofilter}</th>
+            <th class="right text-right contriTotalRight"> &nbsp; {ts}Avg{/ts} &ndash; {$contributionSummary.total.avg nofilter}</th>
           {/if}
           {if $contributionSummary.cancel.amount}
-            <th class="disabled right contriTotalRight"> &nbsp; {ts}Cancelled/Refunded{/ts} &ndash; {$contributionSummary.cancel.amount nofilter}</th>
+            <th class="disabled right text-right contriTotalRight"> &nbsp; {ts}Cancelled/Refunded{/ts} &ndash; {$contributionSummary.cancel.amount nofilter}</th>
           {/if}
       </tr>
       {if $contributionSummary.soft_credit.count}

--- a/templates/CRM/Contribute/Page/PaymentInfo.tpl
+++ b/templates/CRM/Contribute/Page/PaymentInfo.tpl
@@ -20,36 +20,24 @@ CRM.$(function($) {
         $("#payment-info").html(html).trigger('crmLoad');
       }
     });
-    // Fixme: Possible bug - the following line won't be processed by smarty because it's in a literal block
-    var taxAmount = "{$totalTaxAmount}";
-    if (taxAmount) {
-      $('.total_amount-section').show();
-    }
-    else {
-      $('.total_amount-section').remove();
-    }
   }
 });
 </script>
 {/literal}
 {/if}
 {if $context eq 'payment_info'}
-<table id='info'>
-  <tr class="columnheader">
-    {if $component eq "event"}
-      <th>{ts}Total Fee(s){/ts}</th>
-    {else}
-      <th>{ts}Contribution Total{/ts}</th>
-    {/if}
-    <th class="right">{ts}Total Paid{/ts}</th>
-    <th class="right">{ts}Balance{/ts}</th>
-  </tr>
-  <tr>
-    <td>{$paymentInfo.total|crmMoney:$paymentInfo.currency}</td>
-    <td class='right'>
-        {$paymentInfo.paid|crmMoney:$paymentInfo.currency}
-    </td>
-    <td class="right" id="payment-info-balance" data-balance="{$paymentInfo.balance}">{$paymentInfo.balance|crmMoney:$paymentInfo.currency}</td>
-  </tr>
-</table>
+  {literal}
+  <script type='text/javascript'>
+  CRM.$(function($) {
+    $('#paymentInfoTotalPaid').text("{/literal}{$paymentInfo.paid|crmMoney:$paymentInfo.currency}{literal}").parent().addClass('crm-grid-row').removeClass('hiddenElement');
+    $('#paymentInfoAmountDue').text("{/literal}{$paymentInfo.balance|crmMoney:$paymentInfo.currency}{literal}").parent().addClass('crm-grid-row').removeClass('hiddenElement');
+    {/literal}
+      {if $paymentInfo.balance > 0}
+        // Add bold on the row so that the theme can more easily do something more meaningful
+        {literal}$('#paymentInfoAmountDue').parent().addClass('bold');{/literal}
+      {/if}
+    {literal}
+  });
+  </script>
+{/literal}
 {/if}

--- a/templates/CRM/Event/Form/ParticipantView.tpl
+++ b/templates/CRM/Event/Form/ParticipantView.tpl
@@ -83,41 +83,34 @@
         <td class="label">{ts}Participant Source{/ts}</td><td>{$source|escape}&nbsp;</td>
       </tr>
     {/if}
-    {if $participantId and $hasPayment}
-      <tr>
-        <td class='label'>{ts}Fees{/ts}</td>
-        <td id='payment-info'></td>
-      </tr>
-    {/if}
     {if $fee_level}
-        <tr class="crm-event-participantview-form-block-fee_amount">
-            {if $lineItem}
-                <td class="label">{ts}Selections{/ts}</td>
-                <td>{include file="CRM/Price/Page/LineItem.tpl" context="Event" displayLineItemFinancialType=false getTaxDetails=$totalTaxAmount hookDiscount=false}
-                {crmPermission has='edit event participants'}
-                    {if $hasPayment or $parentHasPayment}
-                      <a class="action-item crm-hover-button" href='{crmURL p="civicrm/event/participant/feeselection" q="reset=1&id=`$participantId`&cid=`$contactId`&action=update"}'><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Change Selections{/ts}</a>
-                    {else}
-                      <a class="action-item crm-hover-button" href='{crmURL p="civicrm/contact/view/participant" q=$editUrlParams}'><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Change Selections{/ts}</a>
-                    {/if}
-                    {if $transferOrCancelLink}
-                      <a class="action-item crm-hover-button" href={$transferOrCancelLink}><i class="crm-i fa-times" aria-hidden="true"></i> {ts}Transfer or Cancel{/ts}</a>
-                    {/if}
-                {/crmPermission}
-                </td>
-            {else}
-                <td class="label">{ts}Event Level{/ts}</td>
-                <td>{$fee_level|escape}&nbsp;{if $fee_amount}- {$fee_amount|crmMoney:$currency}{/if}</td>
-            {/if}
-        </tr>
-    {/if}
-    {foreach from=$note item="rec"}
-      {if $rec}
-            <tr><td class="label">{ts}Note{/ts}</td><td>{$rec|escape|nl2br}</td></tr>
+      {if $lineItem}
+        {include file="CRM/Price/Page/LineItem.tpl" context="Event" displayLineItemFinancialType=false getTaxDetails=$totalTaxAmount hookDiscount=false}
+        {crmPermission has='edit event participants'}
+          {if $hasPayment or $parentHasPayment}
+            <a class="action-item crm-hover-button" href='{crmURL p="civicrm/event/participant/feeselection" q="reset=1&id=`$participantId`&cid=`$contactId`&action=update"}'><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Change Selections{/ts}</a>
+          {else}
+            <a class="action-item crm-hover-button" href='{crmURL p="civicrm/contact/view/participant" q=$editUrlParams}'><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Change Selections{/ts}</a>
+          {/if}
+          {if $transferOrCancelLink}
+            <a class="action-item crm-hover-button" href={$transferOrCancelLink}><i class="crm-i fa-times" aria-hidden="true"></i> {ts}Transfer or Cancel{/ts}</a>
+          {/if}
+        {/crmPermission}
+        <div class="clear"></div>
+        <br>
+      {else}
+        <td class="label">{ts}Event Level{/ts}</td>
+        <td>{$fee_level|escape}&nbsp;{if $fee_amount}- {$fee_amount|crmMoney:$currency}{/if}</td>
       {/if}
-    {/foreach}
-    </table>
+    {/if}
+  </table>
+  {foreach from=$note item="rec"}
+    {if $rec}
+      <div class="messages status no-popup">{icon icon="fa-info-circle"}{/icon} {ts}Note:{/ts} {$rec|escape|nl2br}</div>
+    {/if}
+  {/foreach}
     {if $participantId and $hasPayment}
+      <div id="payment-info"></div>
       {include file="CRM/Contribute/Page/PaymentInfo.tpl" show='payments'}
     {/if}
     {include file="CRM/Custom/Page/CustomDataView.tpl"}

--- a/templates/CRM/Pledge/Page/Payment.tpl
+++ b/templates/CRM/Pledge/Page/Payment.tpl
@@ -24,12 +24,12 @@
 
   {foreach from=$rows item=row}
    <tr class="{cycle values="odd-row,even-row"} {if $row.status eq 'Overdue'} status-overdue{/if}">
-    <td class="right">{$row.scheduled_amount|crmMoney:$row.currency}</td>
+    <td class="right text-right">{$row.scheduled_amount|crmMoney:$row.currency}</td>
     <td>{$row.scheduled_date|truncate:10:''|crmDate}</td>
-    <td class="right">{$row.total_amount|crmMoney:$row.currency}</td>
+    <td class="right text-right">{$row.total_amount|crmMoney:$row.currency}</td>
     <td>{$row.receive_date|truncate:10:''|crmDate}</td>
     <td>{$row.reminder_date|truncate:10:''|crmDate}</td>
-    <td class="right">{if $row.reminder_count}{$row.reminder_count}{/if}</td>
+    <td class="right text-right">{if $row.reminder_count}{$row.reminder_count}{/if}</td>
     <td {if ! ($permission EQ 'edit' and ($row.status eq 'Pending' or $row.status eq 'Overdue' or $row.status eq 'Completed'))} colspan="2"{/if} >{$row.label}</td>
 {if $context neq 'user'}
     {if $permission EQ 'edit' and ($row.status eq 'Pending' or $row.status eq 'Overdue' or $row.status eq 'Completed')}

--- a/templates/CRM/Price/Page/LineItem.tpl
+++ b/templates/CRM/Price/Page/LineItem.tpl
@@ -25,24 +25,24 @@
           <th>{ts}Financial Type{/ts}</th>
         {/if}
         {if $context EQ "Membership"}
-          <th class="right">{ts}Fee{/ts}</th>
+          <th class="right text-right">{ts}Fee{/ts}</th>
         {else}
-          <th class="right">{ts}Qty{/ts}</th>
-          <th class="right">{ts}Unit Price{/ts}</th>
+          <th class="right text-right">{ts}Qty{/ts}</th>
+          <th class="right text-right">{ts}Unit Price{/ts}</th>
           {if !$getTaxDetails}
-            <th class="right">{ts}Total Price{/ts}</th>
+            <th class="right text-right">{ts}Total Price{/ts}</th>
           {/if}
         {/if}
 
         {if $getTaxDetails}
-          <th class="right">{ts}Subtotal{/ts}</th>
-          <th class="right">{ts}Tax Rate{/ts}</th>
-          <th class="right">{ts}Tax Amount{/ts}</th>
-          <th class="right">{ts}Total Amount{/ts}</th>
+          <th class="right text-right">{ts}Subtotal{/ts}</th>
+          <th class="right text-right">{ts}Tax Rate{/ts}</th>
+          <th class="right text-right">{ts}Tax Amount{/ts}</th>
+          <th class="right text-right">{ts}Total Amount{/ts}</th>
         {/if}
 
         {if $pricesetFieldsCount}
-          <th class="right">{ts}Total Participants{/ts}</th>
+          <th class="right text-right">{ts}Total Participants{/ts}</th>
         {/if}
       </tr>
       {foreach from=$value item=line}
@@ -52,27 +52,27 @@
             <td>{$line.financial_type}</td>
           {/if}
           {if $context NEQ "Membership"}
-            <td class="right">{$line.qty}</td>
-            <td class="right">{$line.unit_price|crmMoney:$currency}</td>
+            <td class="right text-right">{$line.qty}</td>
+            <td class="right text-right">{$line.unit_price|crmMoney:$currency}</td>
     {else}
-            <td class="right">{$line.line_total|crmMoney:$currency}</td>
+            <td class="right text-right">{$line.line_total|crmMoney:$currency}</td>
           {/if}
     {if !$getTaxDetails && $context NEQ "Membership"}
-      <td class="right">{$line.line_total|crmMoney:$currency}</td>
+      <td class="right text-right">{$line.line_total|crmMoney:$currency}</td>
     {/if}
     {if $getTaxDetails}
-      <td class="right">{$line.line_total|crmMoney:$currency}</td>
+      <td class="right text-right">{$line.line_total|crmMoney:$currency}</td>
       {if $line.tax_rate != "" || $line.tax_amount != ""}
-        <td class="right">{$taxTerm} ({$line.tax_rate}%)</td>
-        <td class="right">{$line.tax_amount|crmMoney:$currency}</td>
+        <td class="right text-right">{$taxTerm} ({$line.tax_rate}%)</td>
+        <td class="right text-right">{$line.tax_amount|crmMoney:$currency}</td>
       {else}
         <td></td>
         <td></td>
       {/if}
-      <td class="right">{assign var=totalWithTax value=$line.line_total+$line.tax_amount}{$totalWithTax|crmMoney:$currency}</td>
+      <td class="right text-right">{assign var=totalWithTax value=$line.line_total+$line.tax_amount}{$totalWithTax|crmMoney:$currency}</td>
     {/if}
           {if $pricesetFieldsCount}
-            <td class="right">{$line.participant_count}</td>
+            <td class="right text-right">{$line.participant_count}</td>
           {/if}
         </tr>
       {/foreach}
@@ -80,48 +80,54 @@
   {/if}
 {/foreach}
 
-<div class="crm-section no-label total_amount-section">
-  <div class="content bold">
-    {if $getTaxDetails && $totalTaxAmount}
-      {ts 1=$taxTerm}Total %1 Amount{/ts}: {$totalTaxAmount|crmMoney:$currency}<br />
+<div class="crm-grid-table total_amount-section pull-right float-right">
+  {if $getTaxDetails && $totalTaxAmount}
+    <div class="crm-grid-row">
+      <div class="crm-grid-cell bold right text-right">{ts 1=$taxTerm}Total %1{/ts}</div>
+      <div class="crm-grid-cell right text-right">{$totalTaxAmount|crmMoney:$currency}</div>
+    </div>
+  {/if}
+  {if $context EQ "Event"}
+    {if $totalTaxAmount}
+      {assign var=eventSubTotal value=$totalAmount-$totalTaxAmount}
+      <div class="crm-grid-row">
+        <div class="crm-grid-cell bold right text-right">{ts}Subtotal{/ts}</div>
+        <div class="crm-grid-cell right text-right">{$eventSubTotal|crmMoney:$currency}</div>
+      </div>
     {/if}
-    {if $context EQ "Contribution"}
-      {ts}Contribution Total{/ts}:
-    {elseif $context EQ "Event"}
-      {if $totalTaxAmount}
-        {assign var=eventSubTotal value=$totalAmount-$totalTaxAmount}
-        {ts 1=$eventSubTotal|crmMoney:$currency}Event SubTotal: %1{/ts}<br />
-      {/if}
-      {ts}Total Amount{/ts}:
-    {elseif $context EQ "Membership"}
-      {ts}Membership Fee Total{/ts}:
-    {else}
-      {ts}Total Amount{/ts}:
-    {/if}
-    {$totalAmount|crmMoney:$currency}
+  {/if}
+  <div class="crm-grid-row">
+    <div class="crm-grid-cell bold right text-right">{ts}Total{/ts}</div>
+    <div class="crm-grid-cell right text-right">{$totalAmount|crmMoney:$currency}</div>
   </div>
-  <div class="clear"></div>
-  <div class="content bold">
-    {if $pricesetFieldsCount}
-      {ts}Total Participants{/ts}:
+  {* set by CRM/Contribute/Page/PaymentInfo.tpl *}
+  <div class="hiddenElement">
+    <div class="crm-grid-cell bold right text-right">{ts}Amount Paid{/ts}</div>
+    <div class="crm-grid-cell right text-right" id="paymentInfoTotalPaid"></div>
+  </div>
+  <div class="hiddenElement">
+    <div class="crm-grid-cell bold right text-right">{ts}Amount Due{/ts}</div>
+    <div class="crm-grid-cell right text-right" id="paymentInfoAmountDue"></div>
+  </div>
+  {if $pricesetFieldsCount}
+    <div class="crm-grid-row">
+      <div class="crm-grid-cell bold right text-right">{ts}Total Participants{/ts}</div>
       {foreach from=$lineItem item=pcount}
         {if $pcount neq 'skip'}
-        {assign var="lineItemCount" value=0}
-
-        {foreach from=$pcount item=p_count}
-          {assign var="intPCount" value=$p_count.participant_count|string_format:"%d"}
-          {assign var="lineItemCount" value=$lineItemCount+$intPCount}
-        {/foreach}
-        {if $lineItemCount < 1}
-          {assign var="lineItemCount" value=1}
-        {/if}
-        {assign var="totalcount" value=$totalcount+$lineItemCount}
+          {assign var="lineItemCount" value=0}
+          {foreach from=$pcount item=p_count}
+            {assign var="intPCount" value=$p_count.participant_count|string_format:"%d"}
+            {assign var="lineItemCount" value=$lineItemCount+$intPCount}
+          {/foreach}
+          {if $lineItemCount < 1}
+            {assign var="lineItemCount" value=1}
+          {/if}
+          {assign var="totalcount" value=$totalcount+$lineItemCount}
         {/if}
       {/foreach}
-      {$totalcount}
-    {/if}
-  </div>
-  <div class="clear"></div>
+      <div class="crm-grid-cell right text-right">{$totalcount}</div>
+    </div>
+  {/if}
 </div>
 
 {if $hookDiscount && $hookDiscount.message}

--- a/tests/phpunit/CRM/Contribute/Form/ContributionViewTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionViewTest.php
@@ -71,7 +71,7 @@ class CRM_Contribute_Form_ContributionViewTest extends CiviUnitTestCase {
     unset($_GET['id'], $_REQUEST['id']);
     unset($_GET['cid'], $_REQUEST['cid']);
 
-    $this->assertMatchesRegularExpression('/Contribution Total:\s+\$10\.00/', $contents);
+    $this->assertMatchesRegularExpression('/>Total<\/div>\s*<div class="[^"]+">\$10\.00/', $contents);
     $this->assertStringContainsString('Mr. Anthony Anderson II', $contents);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

This is an attempt to have a slightly more standard layout for Contribution View, and to be slightly less wordy about obvious things.

- "Contribution Source" becomes "Source"
- "Contribution Date" becomes "Date"
- "Fee Amount" becomes "Processor Fee" (the notion of "fee" is also used for event registration fees)
- Show the Contribution ID
- Remove one of the Transaction IDs (it's still visible in the payment details)
- Remove payment buttons at the bottom, since they are redundant and overwhelming
- Tweaks to how the "Amount Due" is shown, as well as some totals, so that it looks more like an invoice
- Removed "table in table" layouts, for the Contribution Amount (display of line items), and list of payments/transactions.
- Added some `text-right` classes sometimes, because RiverLea needs them to align numbers (I guess I could have sent a MR to RiverLea, but `right` is a silly CSS class name)

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/5cffd56a-327f-41ce-9f85-d95e8c374e27)

After
----------------------------------------

![image](https://github.com/user-attachments/assets/c8d1b301-ca84-4906-aadf-73e535f5da42)

The Island will also need a small tweak:

![image](https://github.com/user-attachments/assets/3a228582-7bab-495f-bcb8-c42f5820ab22)

Greenwich needed the `float-right` class to work well:

![image](https://github.com/user-attachments/assets/02d789d0-2ac5-4f34-a09f-63b14fa5ba1b)

Comments
----------------------------------------

The "Total Tax" is only displayed if taxes are enabled.