### PR TITLE
Revert "afform tabs - use CRM_Core_BAO_CustomGroup cache"

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
+++ b/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
@@ -54,8 +54,12 @@ class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
     $forms = [];
 
     // get field names once, for use across all the generate actions
-    $fields = \CRM_Core_BAO_CustomGroup::getGroup(['id' => $item['id']])['fields'];
-    $item['field_names'] = array_column($fields, 'name');
+    $item['field_names'] = \Civi\Api4\CustomField::get(FALSE)
+      ->addSelect('name')
+      ->addWhere('custom_group_id', '=', $item['id'])
+      ->addWhere('is_active', '=', TRUE)
+      ->execute()
+      ->column('name');
 
     // restrict forms other than block to if Admin UI is enabled
     $hasAdminUi = \CRM_Extension_System::singleton()->getMapper()->isActiveModule('civicrm_admin_ui');

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -174,9 +174,12 @@ function afform_civicrm_tabset($tabsetName, &$tabs, $context) {
         // custom group tab forms use name, but need to replace tabs using ID
         // remove 'afsearchTabCustom_' from the form name to get the group name
         $groupName = substr($afform['name'], 18);
-        $group = \CRM_Core_BAO_CustomGroup::getGroup(['name' => $groupName]);
-        if ($group) {
-          $tabId = 'custom_' . $group['id'];
+        $groupId = \Civi\Api4\CustomGroup::get(FALSE)
+          ->addSelect('id')
+          ->addWhere('name', '=', $groupName)
+          ->execute()->first()['id'] ?? NULL;
+        if ($groupId) {
+          $tabId = 'custom_' . $groupId;
         }
       }
       // If a tab with that id already exists, allow the afform to replace it.

--- a/ext/civicrm_admin_ui/Civi/Api4/Action/CustomGroup/GetSearchKit.php
+++ b/ext/civicrm_admin_ui/Civi/Api4/Action/CustomGroup/GetSearchKit.php
@@ -32,10 +32,15 @@ class GetSearchKit extends \Civi\Api4\Generic\BasicBatchAction {
     // SavedSearch and SearchDisplays
     $item['search_name'] = $item['entity_name'] . '_Search';
 
-    // get Active + Display In Table fields for this group to include as columns
-    // note: `in_selector` is the field key for "display in table"
-    $activeFields = \CRM_Core_BAO_CustomGroup::getGroup(['id' => $item['id']])['fields'];
-    $item['fields'] = array_filter($activeFields, fn ($field) => $field['in_selector']);
+    // get active fields for this group to include as columns
+    $item['fields'] = (array) \Civi\Api4\CustomField::get(FALSE)
+      ->addSelect('name', 'label', 'option_group_id')
+      ->addWhere('custom_group_id', '=', $item['id'])
+      ->addWhere('is_active', '=', TRUE)
+      // respect "Display in table" config on each field
+      // (Q: should we respect this for other displays?)
+      ->addWhere('in_selector', '=', TRUE)
+      ->execute();
 
     $managed = [];
 


### PR DESCRIPTION
Overview
----------------------------------------
This reverts commit 14f487022c2e45ebb7b5bfb6a38adb10a5d2750c.

Following https://github.com/civicrm/civicrm-core/pull/31569 using Api4 should have equivalent performance to the `CRM_Core_BAO_CustomGroup::getAll` equivalents. Given it's a more standardised query format used for other entities, it seems preferable to me.

(It's a reversion as the Api4 calls were switched for performance reasons)

Before
----------------------------------------
- afform_tab generation uses calls to CRM_Core_BAO_CustomGroup::getAll to get metadata about custom fields

After
----------------------------------------
- afform_tab generation uses CustomField and CustomGroup api4 to get metadata about custom fields



