### PR TITLE
AdminUI: tweak TabMember markup and translation

### DIFF
--- a/ang/afform/afsearchTabRel.aff.html
+++ b/ang/afform/afsearchTabRel.aff.html
@@ -1,12 +1,11 @@
 <div af-fieldset="">
+  <crm-search-display-table search-name="Contact_Summary_Relationships" display-name="Contact_Summary_Relationships_Active" filters="{near_contact_id: options.contact_id, is_current: true}"></crm-search-display-table>
+  <h3>{{:: ts('Inactive Relationships') }}</h3>
+  <div class="help">{{:: ts('These relationships are Disabled OR have a past End Date.') }}</div>
+  <crm-search-display-table search-name="Contact_Summary_Relationships" display-name="Contact_Summary_Relationships_Inactive" filters="{near_contact_id: options.contact_id, is_current: false}"></crm-search-display-table>
   <div class="help">
     <strong>{{:: ts('Permissioned Relationships:') }}</strong>
     <i class="crm-i fa-eye"></i> {{:: ts('This contact can be viewed by the other.') }}
     <i class="crm-i fa-pencil-square"></i> {{:: ts('This contact can be viewed and edited by the other.') }}
   </div>
-  <h3>{{:: ts('Current Relationships') }}</h3>
-  <crm-search-display-table search-name="Contact_Summary_Relationships" display-name="Contact_Summary_Relationships_Active" filters="{near_contact_id: options.contact_id, is_current: true}"></crm-search-display-table>
-  <h3>{{:: ts('Inactive Relationships') }}</h3>
-  <div class="help">{{:: ts('These relationships are Disabled OR have a past End Date.') }}</div>
-  <crm-search-display-table search-name="Contact_Summary_Relationships" display-name="Contact_Summary_Relationships_Inactive" filters="{near_contact_id: options.contact_id, is_current: false}"></crm-search-display-table>
 </div>

--- a/ext/civicrm_admin_ui/ang/afformTabMember.aff.html
+++ b/ext/civicrm_admin_ui/ang/afformTabMember.aff.html
@@ -1,11 +1,6 @@
 <div af-fieldset="">
-  <div class="af-markup">
-    <div class="alert alert-warning">Click Add Membership to record a new membership. Click Submit Credit Card Membership to process a Membership on behalf of the member using their credit card.</div>
-  </div>
   <crm-search-display-table search-name="Contact_Summary_Memberships" display-name="Contact_Summary_Memberships_Active" filters="{contact_id: options.contact_id, 'status_id.is_current_member': true}"></crm-search-display-table>
-  <div class="af-markup">
-    <div class="alert alert-info font-red">Pending and Inactive Memberships </div>
-  </div>
+  <h3>{{:: ts('Pending and Inactive Memberships') }}</h3>
   <crm-search-display-table search-name="Contact_Summary_Memberships" display-name="Contact_Summary_Memberships_Inactive" filters="{contact_id: options.contact_id, 'status_id.is_current_member': false}"></crm-search-display-table>
 </div>
 <div class="af-markup">

--- a/ext/civicrm_admin_ui/ang/afsearchTabMember.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchTabMember.aff.html
@@ -1,10 +1,5 @@
 <div af-fieldset="">
-  <div class="af-markup">
-    <div class="alert alert-warning">Click Add Membership to record a new membership. Click Submit Credit Card Membership to process a Membership on behalf of the member using their credit card.</div>
-  </div>
   <crm-search-display-table search-name="Contact_Summary_Memberships" display-name="Contact_Summary_Memberships_Active" filters="{contact_id: options.contact_id, 'status_id.is_current_member': true}"></crm-search-display-table>
-  <div class="af-markup">
-    <div class="alert alert-info font-red">Pending and Inactive Memberships </div>
-  </div>
+  <h3>{{:: ts('Pending and Inactive Memberships') }}</h3>
   <crm-search-display-table search-name="Contact_Summary_Memberships" display-name="Contact_Summary_Memberships_Inactive" filters="{contact_id: options.contact_id, 'status_id.is_current_member': false}"></crm-search-display-table>
 </div>

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Memberships.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Memberships.mgd.php
@@ -79,7 +79,7 @@ return [
         'saved_search_id.name' => 'Contact_Summary_Memberships',
         'type' => 'table',
         'settings' => [
-          'description' => E::ts('Active Memberships'),
+          'description' => '',
           'sort' => [
             [
               'id',
@@ -285,8 +285,8 @@ return [
               'action' => '',
               'entity' => '',
               'text' => E::ts('Add Membership'),
-              'icon' => 'fa-external-link',
-              'style' => 'default',
+              'icon' => 'fa-plus-circle',
+              'style' => 'primary',
               'target' => 'crm-popup',
               'join' => '',
               'path' => 'civicrm/contact/view/membership?reset=1&action=add&cid=[contact_id]&context=membership',


### PR DESCRIPTION
Overview
----------------------------------------

Tweaks the AdminUI Contact -> Membership Tab markup, so that it is more similar to other tabs. Also fixes some translations.

Before
----------------------------------------

Colourful BLT Sandwhich, CiviCRM edition:

![image](https://github.com/user-attachments/assets/92bdfd60-3a5e-41fc-9dff-d5d6c5206e4a)

After
----------------------------------------

It's not much better, but I think we need to talk about what need to standout:

![image](https://github.com/user-attachments/assets/7431c56d-54c9-420b-a18a-e231b587084b)

Ideally, it should look more like this:

![image](https://github.com/user-attachments/assets/b0fef0c8-d9c6-44c1-b53d-80f5ef895a55)

cc @vingle 