### PR TITLE
(NFC) Test cases should cleanup HTTP_X_REQUESTED_WITH consistently.

### DIFF
--- a/Civi/Test/CiviTestListener.php
+++ b/Civi/Test/CiviTestListener.php
@@ -98,6 +98,7 @@ else {
       \CRM_Utils_Time::resetTime();
       if ($this->isCiviTest($test)) {
         unset($GLOBALS['CIVICRM_TEST_CASE']);
+        unset($_SERVER['HTTP_X_REQUESTED_WITH']); /* Several tests neglect to clean this up... */
         error_reporting(E_ALL & ~E_NOTICE);
         $this->errorScope = NULL;
       }

--- a/Civi/Test/CiviTestListenerPHPUnit7.php
+++ b/Civi/Test/CiviTestListenerPHPUnit7.php
@@ -87,6 +87,7 @@ class CiviTestListenerPHPUnit7 implements \PHPUnit\Framework\TestListener {
     \CRM_Utils_Time::resetTime();
     if ($this->isCiviTest($test)) {
       unset($GLOBALS['CIVICRM_TEST_CASE']);
+      unset($_SERVER['HTTP_X_REQUESTED_WITH']); /* Several tests neglect to clean this up... */
       error_reporting(E_ALL & ~E_NOTICE);
       $this->errorScope = NULL;
     }

--- a/Civi/Test/Legacy/CiviTestListener.php
+++ b/Civi/Test/Legacy/CiviTestListener.php
@@ -88,6 +88,7 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
     \CRM_Utils_Time::resetTime();
     if ($this->isCiviTest($test)) {
       unset($GLOBALS['CIVICRM_TEST_CASE']);
+      unset($_SERVER['HTTP_X_REQUESTED_WITH']); /* Several tests neglect to clean this up... */
       error_reporting(E_ALL & ~E_NOTICE);
       $this->errorScope = NULL;
     }

--- a/tests/phpunit/CRM/Core/Page/AJAXTest.php
+++ b/tests/phpunit/CRM/Core/Page/AJAXTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Core_Page_AJAXTest extends CiviUnitTestCase {
 
+  protected function setUp(): void {
+    parent::setUp();
+    $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+  }
+
   public function testCheckAuthz(): void {
     $cases = [];
 


### PR DESCRIPTION
Backport #31597 from 5.82-dev to 5.81-rc

Why: CI updated to split `phpunit-crm` a little bit further, which shuffles the placement of `CRM_Core_Page_AJAXTest`, and exposes more risk of false-negatives on that test.