### PR TITLE
(NFC) tests/phpunit/api/v4 - Fix inconsistent namespace

### DIFF
--- a/tests/phpunit/api/v4/Action/AutocompleteQuicksearchTest.php
+++ b/tests/phpunit/api/v4/Action/AutocompleteQuicksearchTest.php
@@ -17,7 +17,7 @@
  */
 
 
-namespace Civi\tests\phpunit\api\v4\Action;
+namespace api\v4\Action;
 
 use Civi\Api4\Contact;
 use Civi\Api4\Setting;

--- a/tests/phpunit/api/v4/Action/FieldsCallbackTest.php
+++ b/tests/phpunit/api/v4/Action/FieldsCallbackTest.php
@@ -17,7 +17,7 @@
  */
 
 
-namespace Civi\tests\phpunit\api\v4\Action;
+namespace api\v4\Action;
 
 use api\v4\Api4TestBase;
 use Civi\Api4\Email;

--- a/tests/phpunit/api/v4/Entity/CampaignTest.php
+++ b/tests/phpunit/api/v4/Entity/CampaignTest.php
@@ -9,7 +9,7 @@
  +--------------------------------------------------------------------+
  */
 
-namespace Civi\tests\phpunit\api\v4\Entity;
+namespace api\v4\Entity;
 
 use api\v4\Api4TestBase;
 


### PR DESCRIPTION
Overview
----------------------------------------

This fixes a quirk in the test declaration. Depending on how the test-suite is executed, this means that the tests are sometimes skipped.

Before + After
----------------------------------------

| Codebase | Example Command | Outcome | 
| -- | -- | -- |
| Before Patch | `CIVICRM_UF=UnitTests phpunit9 tests/phpunit/api/v4/AllTests.php` | :red_circle: Skip tests
| Before Patch | `CIVICRM_UF=UnitTests phpunit9 tests/phpunit/api/v4/` | :repeat:  Run tests
| After Patch | `CIVICRM_UF=UnitTests phpunit9 tests/phpunit/api/v4/AllTests.php` | :repeat: Run tests
| After Patch | `CIVICRM_UF=UnitTests phpunit9 tests/phpunit/api/v4/` | :repeat: Run tests

Comments
----------------------------------------

I wouldn't normally post this to the RC -- it's just NFC.  (*Aside: it should be easy to edit/switch to `master` if others want.*)

However, this fits into a longer arc: one of these tests (`FieldsCallbackTest`) actually fails if you run it in a new/clean environment. Don't know the fix yet -- but there's a fairly good chance that the fix for *that* will target the RC.