### PR TITLE
[NFC] Remove override of CiviUnitTestCase::runTests

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -82,7 +82,7 @@ define('API_LATEST_VERSION', 3);
  *
  * @package CiviCRM
  */
-class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
+class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
 
   use Api3TestTrait;
   use EventTestTrait;
@@ -3901,4 +3901,32 @@ WHERE table_schema = DATABASE()");
     return $data;
   }
 
+}
+
+if (version_compare(phpversion(), '8', '<')) {
+  class CiviUnitTestCase extends CiviUnitTestCaseCommon {
+
+  }
+}
+else {
+  class CiviUnitTestCase extends CiviUnitTestCaseCommon {
+
+    /**
+     * Override to run the test and assert its state.
+     *
+     * @return mixed
+     *
+     * @throws \Throwable
+     */
+    protected function runTest(): mixed {
+      try {
+        return parent::runTest();
+      }
+      catch (PEAR_Exception $e) {
+        // PEAR_Exception has metadata in funny places, and PHPUnit won't log it nicely
+        throw new Exception(\CRM_Core_Error::formatTextException($e), $e->getCode());
+      }
+    }
+
+  }
 }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -282,23 +282,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   }
 
   /**
-   * Override to run the test and assert its state.
-   *
-   * @return mixed
-   *
-   * @throws \Throwable
-   */
-  protected function runTest() {
-    try {
-      return parent::runTest();
-    }
-    catch (PEAR_Exception $e) {
-      // PEAR_Exception has metadata in funny places, and PHPUnit won't log it nicely
-      throw new Exception(\CRM_Core_Error::formatTextException($e), $e->getCode());
-    }
-  }
-
-  /**
    * Declare the environment that we wish to run in.
    *
    * TODO: The hope is to get this to align with `Civi\Test::headless()` and perhaps


### PR DESCRIPTION
Overview
----------------------------------------
It prevents using phpunit10, and doesn't seem needed anymore.

Before
----------------------------------------
When using phpunit10 it wants the signature to return "mixed", but we can't do that and still support php 7.

After
----------------------------------------
This function doesn't seem needed anymore.

Technical Details
----------------------------------------
At one time there probably were more pear_exceptions, but for example since https://github.com/civicrm/civicrm-core/commit/ba964907b92666d9e8250a4475a930e964ac6857#diff-f4617ed6d52e9b86056635048e257783f596745fc08c3f9d4df875b55f9b1227L946, they get converted, and I wasn't able to even create a test that could trigger a PEAR_Exception anymore. Even if there is one, all the function does is reformat it, not change whether a test passes or fails. If a test fails can always investigate if the output is too vague.

Comments
----------------------------------------
Possible followup: There are some core tests that have checks for PEAR_Exception, but I suspect what they actually receive is a DBQueryException if something goes wrong.