### PR TITLE
(NFC) RegionTest, SmartyTest - Restore performance

### DIFF
--- a/tests/phpunit/CRM/Core/RegionTest.php
+++ b/tests/phpunit/CRM/Core/RegionTest.php
@@ -9,6 +9,11 @@ class CRM_Core_RegionTest extends CiviUnitTestCase {
 
   use CRM_Core_Resources_CollectionTestTrait;
 
+  public function setUp(): void {
+    parent::setUp();
+    $this->useTransaction();
+  }
+
   /**
    * @return \CRM_Core_Resources_CollectionInterface
    */

--- a/tests/phpunit/CRM/Core/Smarty/plugins/CrmMoneyTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/CrmMoneyTest.php
@@ -7,6 +7,11 @@
  */
 class CRM_Core_Smarty_plugins_CrmMoneyTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    parent::setUp();
+    $this->useTransaction();
+  }
+
   /**
    * @return array
    */

--- a/tests/phpunit/CRM/Core/Smarty/plugins/CrmPermissionTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/CrmPermissionTest.php
@@ -7,6 +7,11 @@
  */
 class CRM_Core_Smarty_plugins_CrmPermissionTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    parent::setUp();
+    $this->useTransaction();
+  }
+
   /**
    * @dataProvider permissionCases
    *

--- a/tests/phpunit/CRM/Core/Smarty/plugins/CrmRSSPubDateTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/CrmRSSPubDateTest.php
@@ -9,6 +9,11 @@ class CRM_Core_Smarty_plugins_CrmRSSPubDateTest extends CiviUnitTestCase {
   const FIXED_DATE = '2022-06-20 13:14:15';
   const FIXED_DATE_RSS = 'Mon, 20 Jun 2022 13:14:15';
 
+  public function setUp(): void {
+    parent::setUp();
+    $this->useTransaction();
+  }
+
   /**
    * DataProvider for testRSSPubDate
    * @return array

--- a/tests/phpunit/CRM/Core/Smarty/plugins/CrmScopeTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/CrmScopeTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Core_Smarty_plugins_CrmScopeTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    parent::setUp();
+    $this->useTransaction();
+  }
+
   /**
    * @return array
    */

--- a/tests/phpunit/CRM/Core/Smarty/plugins/CrmUpperTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/CrmUpperTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Core_Smarty_plugins_CrmUpperTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    parent::setUp();
+    $this->useTransaction();
+  }
+
   /**
    * Test accents with upper
    */

--- a/tests/phpunit/CRM/Core/Smarty/plugins/HtxtTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/HtxtTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Core_Smarty_plugins_HtxtTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    parent::setUp();
+    $this->useTransaction();
+  }
+
   /**
    * @return array
    */

--- a/tests/phpunit/CRM/Core/Smarty/plugins/UrlTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/UrlTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Core_Smarty_plugins_UrlTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    parent::setUp();
+    $this->useTransaction();
+  }
+
   /**
    * @return array
    */

--- a/tests/phpunit/CRM/Core/SmartyTest.php
+++ b/tests/phpunit/CRM/Core/SmartyTest.php
@@ -7,6 +7,11 @@
  */
 class CRM_Core_SmartyTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    parent::setUp();
+    $this->useTransaction();
+  }
+
   /**
    * Check that temporary Smarty variables work.
    *


### PR DESCRIPTION
Overview
----------------------------------------

This appears to have been collateral damage from e9cceb3799e74357c96123a0456a27c5b5468856.

Before + After
----------------------------------------

| Suite | Runtime (Before) | Runtime (After) | Change |
| -- | -- | -- | -- |
| `tests/phpunit/CRM/Core/RegionTest.php` | 57 seconds | 30 seconds | -27 seconds |
| `tests/phpunit/CRM/Core/Smarty/` | 79 seconds | 55 seconds | -24 seconds |

Overall, this cuts a minute from the CRM test-suite.

(*Times measured on Intel 12600k. Values are rounded and may vary slightly but were generally consistent in a couple runs.*)
