### PR TITLE
SearchKit - Improve behavior of appending (copy) to cloned searches

### DIFF
--- a/CRM/Tag/Form/Edit.php
+++ b/CRM/Tag/Form/Edit.php
@@ -138,7 +138,7 @@ class CRM_Tag_Form_Edit extends CRM_Admin_Form {
     if (empty($this->_id) && $cloneFrom) {
       $params = ['id' => $cloneFrom];
       CRM_Core_BAO_Tag::retrieve($params, $this->_values);
-      $this->_values['label'] .= ' (' . ts('copy') . ')';
+      $this->_values['label'] .= ' ' . ts('(copy)');
       if (!empty($this->_values['is_reserved']) && !CRM_Core_Permission::check('administer reserved tags')) {
         $this->_values['is_reserved'] = 0;
       }

--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -51,7 +51,7 @@
           savedSearch: function($route, crmApi4) {
             var params = $route.current.params;
             return crmApi4('SavedSearch', 'get', {
-              select: ['label', 'description', 'api_entity', 'api_params', 'expires_date', 'GROUP_CONCAT(DISTINCT entity_tag.tag_id) AS tag_id'],
+              select: ['label', 'description', 'api_entity', 'api_params', 'is_template', 'expires_date', 'GROUP_CONCAT(DISTINCT entity_tag.tag_id) AS tag_id'],
               where: [['id', '=', params.id]],
               join: [
                 ['EntityTag AS entity_tag', 'LEFT', ['entity_tag.entity_table', '=', '"civicrm_saved_search"'], ['id', '=', 'entity_tag.entity_id']],
@@ -130,15 +130,25 @@
 
     // Controller for cloning a SavedSearch
     .controller('searchClone', function($scope, $routeParams, savedSearch) {
+      const makeTemplate = ($routeParams.is_template == '1');
       searchEntity = savedSearch.api_entity;
-      savedSearch.label += ' (' + ts('copy') + ')';
+      // When cloning a search or a template as-is, append 'copy' to the label
+      if (savedSearch.is_template === makeTemplate) {
+        savedSearch.label += ' ' + ts('(copy)');
+      }
+      // When making a new search from a template, delete label
+      else if (!makeTemplate) {
+        savedSearch.label = '';
+      }
       delete savedSearch.id;
       savedSearch.displays.forEach(display => {
         delete display.id;
         display.acl_bypass = false;
-        display.label += ' (' + ts('copy') + ')';
+        if (savedSearch.is_template === makeTemplate) {
+          display.label += ' ' + ts('(copy)');
+        }
       });
-      savedSearch.is_template = ($routeParams.is_template == '1');
+      savedSearch.is_template = makeTemplate;
       this.savedSearch = savedSearch;
       $scope.$ctrl = this;
     })

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -270,7 +270,7 @@
       var newDisplay = angular.copy(display);
       delete newDisplay.name;
       delete newDisplay.id;
-      newDisplay.label += ts(' (copy)');
+      newDisplay.label += ' ' + ts('(copy)');
       ctrl.savedSearch.displays.push(newDisplay);
       $scope.selectTab('display_' + (ctrl.savedSearch.displays.length - 1));
     };


### PR DESCRIPTION
Overview
----------------------------------------
Smarter default labels when cloning or creating a search from a template.

Before
----------------------------------------
'(copy)' always appended

After
----------------------------------------
'(copy)' not added when creating a template from a search or a search from a template

Technical Details
----------------------------------------
Also cleans up inconsistencies in the way the word was passed into ts()
