### PR TITLE
Riverlea - set color-scheme in DynamicCss so system elements respect dark_mode setting

### DIFF
--- a/ext/riverlea/Civi/riverlea/DynamicCss.php
+++ b/ext/riverlea/Civi/riverlea/DynamicCss.php
@@ -62,17 +62,22 @@ class DynamicCss implements \Symfony\Component\EventDispatcher\EventSubscriberIn
 
     switch ($params['dark'] ?? NULL) {
       case 'light':
-        // nothing more to do
+        // tell OS we want light for system elements
+        $content[] = ":root { color-scheme: light; }";
         break;
 
       case 'dark':
-        // add dark vars unconditionally
+        // tell OS we want dark for system elements
+        $content[] = ":root { color-scheme: dark; }";
+        // add stream dark vars unconditionally
         $content[] = self::getCSSFromFile('_dark.css', $stream);
         break;
 
       case 'inherit':
       default:
-        // add dark vars wrapped inside a media query
+        // tell OS we are happy with light or dark for system elements
+        $content[] = ":root { color-scheme: light dark; }";
+        // add stream dark vars wrapped inside a media query
         $content[] = '@media (prefers-color-scheme: dark) {';
         $content[] = self::getCSSFromFile('_dark.css', $stream);
         $content[] = '}';

--- a/ext/riverlea/streams/thames/css/_variables.css
+++ b/ext/riverlea/streams/thames/css/_variables.css
@@ -24,9 +24,6 @@
 /* --crm-font-bold-italic:; */
 }
 :root {
-/* COLOUR */
-  color-scheme: light dark; /* check to use simpler syntax late-2024 (Edge+iOS Safari)
-
 /* COLOUR NAMES */
   --crm-c-darkest: #0a0a0a;
   --crm-c-gray-900: #2f2f2e;


### PR DESCRIPTION
Overview
----------------------------------------
Set the [CSS color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme) property to match your dark mode setting preference. This means system elements (like checkboxes) will respect this setting.

Note: Thames is currently setting `light dark` unconditionally. This means even if you set the Riverlea mode to "Always light", there are some leaks if your OS is set to dark mode.

Before
----------------------------------------
Drupal Garland, Riverlea Dark Mode = Always Light, OS Dark Mode ON

Note titles and checkbox backgrounds:
![image](https://github.com/user-attachments/assets/1d51f603-4676-43ba-b8a1-d8113703c802)


After
----------------------------------------
Same configuration as above:

![image](https://github.com/user-attachments/assets/9c10e23d-9eb0-4c0c-9f0f-b1a59b235bbf)


Riverlea dark mode = Always Dark, OS Dark Mode = OFF or ON:

_Note checkbox backgrounds are dark (obviously setting Always Dark is a bad idea when you are using Garland)_
![image](https://github.com/user-attachments/assets/efeff32d-8b19-4b20-9744-de6d7d88f9f5)


Other permutations work as expected.

cc @vingle @artfulrobot 