### PR TITLE
dev/core#4448 - SearchKit: Support relative dates in HAVING clause

### DIFF
--- a/Civi/Api4/Query/Api4Query.php
+++ b/Civi/Api4/Query/Api4Query.php
@@ -286,6 +286,20 @@ abstract class Api4Query {
           }
         }
       }
+      // Format a function in the HAVING clause
+      if (isset($fieldAlias) && !isset($field)) {
+        try {
+          $expr = $this->getExpression($this->selectAliases[$fieldAlias], ['SqlFunction']);
+          $fauxField = [
+            'name' => NULL,
+            'data_type' => $expr->getRenderedDataType($this->apiFieldSpec),
+          ];
+          FormattingUtil::formatInputValue($value, NULL, $fauxField, $this->entityValues, $operator);
+        }
+        catch (\CRM_Core_Exception $e) {
+          // Not a function
+        }
+      }
       if (!isset($fieldAlias)) {
         if (in_array($expr, $this->getSelect())) {
           throw new UnauthorizedException("Unauthorized field '$expr'");
@@ -295,6 +309,7 @@ abstract class Api4Query {
         }
       }
       $fieldAlias = '`' . $fieldAlias . '`';
+      // Comparing two fields in the HAVING clause
       if ($isExpression) {
         $targetField = isset($this->selectAliases[$value]) ? $value : array_search($value, $this->selectAliases);
         if (!$targetField) {

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -275,6 +275,28 @@ abstract class SqlFunction extends SqlExpression {
   }
 
   /**
+   * Returns the dataType of rendered output, based on the fields passed into the function
+   *
+   * @param array $fieldSpecs
+   *   List of available fields, e.g. Api4Query::$apiFieldSpec
+   * @return string|null
+   */
+  public function getRenderedDataType(array $fieldSpecs): ?string {
+    $dataType = $this::getDataType();
+    if ($dataType) {
+      return $dataType;
+    }
+    if ($this->getSerialize()) {
+      return 'Array';
+    }
+    $fields = $this->getFields();
+    if (!empty($fields[0])) {
+      return $fieldSpecs[$fields[0]]['data_type'] ?? NULL;
+    }
+    return NULL;
+  }
+
+  /**
    * @param string|null $suffix
    */
   private function setSuffix(?string $suffix): void {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearch-conditions.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearch-conditions.html
@@ -2,7 +2,7 @@
   <crm-search-clause clauses="$ctrl.savedSearch.api_params.where" format="string" op="AND" label="{{:: ts('Where') }}" fields="fieldsForWhere" allow-functions="true" ></crm-search-clause>
 </fieldset>
 <fieldset ng-if="$ctrl.paramExists('having')" class="api4-clause-fieldset crm-search-havings">
-  <crm-search-clause clauses="$ctrl.savedSearch.api_params.having" format="string" op="AND" label="{{:: ts('Having') }}" help="having" fields="fieldsForHaving" ></crm-search-clause>
+  <crm-search-clause clauses="$ctrl.savedSearch.api_params.having" format="string" op="AND" label="{{:: ts('Having') }}" help="having" fields="fieldsForHaving" aliases="$ctrl.savedSearch.api_params.select" ></crm-search-clause>
 </fieldset>
 
 

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.component.js
@@ -5,6 +5,7 @@
     bindings: {
       fields: '<',
       clauses: '<',
+      aliases: '<?',
       format: '@',
       op: '@',
       allowFunctions: '<',
@@ -49,8 +50,16 @@
       };
 
       this.getFieldOrFunction = function(expr) {
+        // Search select clause for this alias (used for HAVING expressions which only include the alias)
+        if (this.aliases) {
+          let fullExpr = this.aliases.find(item => item.endsWith(' AS ' + expr));
+          expr = fullExpr || expr;
+        }
         if (ctrl.hasFunction(expr)) {
-          return searchMeta.parseExpr(expr).fn;
+          let parsed = searchMeta.parseExpr(expr);
+          // Pass-thru data_type of expression if fn doesn't have a data_type
+          parsed.fn.data_type = parsed.fn.data_type || parsed.data_type;
+          return parsed.fn;
         }
         return ctrl.getField(expr);
       };


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/4448 to allow relative dates in the HAVING clause, even when used in an aggregate function.

E.g. you can now aggregate a search for contacts by MAX participant register date, and then filter using the HAVING clause on the most recent registration:

![image](https://github.com/user-attachments/assets/92b91532-d30d-4a32-8c8b-b6802370dace)


