### PR TITLE
fixes core/5635 - Job params are ignored when job.execute is called

### DIFF
--- a/CRM/Core/JobManager.php
+++ b/CRM/Core/JobManager.php
@@ -90,7 +90,7 @@ class CRM_Core_JobManager {
     $jobs = array_merge($successfulJobs, $maybeUnsuccessfulJobs);
     foreach ($jobs as $job) {
       $temp = ['class' => NULL, 'parameters' => NULL, 'last_run' => NULL];
-      $scheduledJobParams = array_merge($job, $temp);
+      $scheduledJobParams = array_merge($temp, $job);
       $jobDAO = new CRM_Core_ScheduledJob($scheduledJobParams);
 
       if ($jobDAO->needsRunning()) {


### PR DESCRIPTION
Overview
----------------------------------------
Starting with #29598 (Civi 5.80.0), when calling `Job.execute`, the params for each scheduled job are ignored.

Before
----------------------------------------
See above

After
----------------------------------------
Pre-5.80 behavior is fixed

Technical Details
----------------------------------------
I think the `array_merge()` just had its array order reversed.

@mattwire does this match the original intent?