### PR TITLE
eventcart: on EventInfo, show checkout/viewcart buttons

### DIFF
--- a/ext/eventcart/CRM/Event/Cart/PageCallback.php
+++ b/ext/eventcart/CRM/Event/Cart/PageCallback.php
@@ -28,6 +28,15 @@ class CRM_Event_Cart_PageCallback {
 
     $event->page->assign('registerText', $registerText);
     $event->page->assign('registerURL', $url);
+
+    // For the "View Cart" and "Checkout" buttons
+    $cart = CRM_Event_Cart_BAO_Cart::find_or_create_for_current_session();
+    $cart->load_associations();
+    $events = $cart->get_main_events_in_carts();
+    $event->page->assign('eventcart_has_events', !empty($events));
+
+    CRM_Core_Region::instance('event-page-eventinfo-actionlinks-top')
+      ->add(['template' => 'CRM/Event/Cart/eventinfo.tpl']);
   }
 
   public static function alterEventList($event) {

--- a/ext/eventcart/templates/CRM/Event/Cart/eventinfo.tpl
+++ b/ext/eventcart/templates/CRM/Event/Cart/eventinfo.tpl
@@ -1,0 +1,13 @@
+<div class="pull-right float-right crm-eventcart-eventinfo-buttons">
+  <div class="action-link align-right crm-eventcart-eventinfo-addtocart"></div>
+  <div class="action-link align-right crm-eventcart-eventinfo-viewcart"><a href="{crmURL p='civicrm/event/view_cart'}" class="button crm-shoppingcart-button"><i class="crm-i fa-shopping-cart" aria-hidden="true"></i> {ts}View Cart{/ts}</a></div>
+  {if $eventcart_has_events}
+    <div class="action-link align-right crm-eventcart-eventinfo-checkout"><a href="{crmURL p='civicrm/event/cart_checkout'}" class="button crm-check-out-button"><i class="crm-i fa-credit-card" aria-hidden="true"></i> {ts}Checkout{/ts}</a></div>
+  {/if}
+</div>
+{literal}
+<script>
+  CRM.$('.register_link-top > a').prependTo('.crm-eventcart-eventinfo-addtocart');
+  CRM.$('.register_link-top').hide();
+</script>
+{/literal}


### PR DESCRIPTION
Overview
----------------------------------------

When using the "Event Cart" feature, display buttons to "View Cart" and "Checkout" (if there are items in the cart).

I have seen a few reports that the "view cart" message was often not obvious to users, and if you miss it, then there is no way to find your cart.

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/fc38c181-658f-46f9-95ac-008874504e8b)

After
----------------------------------------

![image](https://github.com/user-attachments/assets/b834390e-4b5f-4a25-b1e6-38f6abd3e04c)

Comments
----------------------------------------

An alternative could be to display those buttons as plain links:

![image](https://github.com/user-attachments/assets/cdeb978f-28c1-4310-aba3-7f39409d5e37)

I took some inspiration from the boxoffice extension: https://civicrm.org/extensions/boxoffice