### PR TITLE
PHPUnit 10 - Various fix for scheduled-reminder tests (et al)

### DIFF
--- a/tests/phpunit/CRM/Activity/ActionMappingTest.php
+++ b/tests/phpunit/CRM/Activity/ActionMappingTest.php
@@ -22,10 +22,10 @@ require_once 'CiviTest/CiviUnitTestCase.php';
  * NOTE: There are also pretty deep tests of activity-based reminders in
  * CRM_Core_BAO_ActionScheduleTest.
  *
- * @see \Civi\ActionSchedule\AbstractMappingTest
+ * @see \Civi\ActionSchedule\AbstractMappingTestCase
  * @see CRM_Core_BAO_ActionScheduleTest
  */
-class CRM_Activity_ActionMappingTest extends \Civi\ActionSchedule\AbstractMappingTest {
+class CRM_Activity_ActionMappingTest extends \Civi\ActionSchedule\AbstractMappingTestCase {
 
   /**
    * Generate a list of test cases, where each is a distinct combination of

--- a/tests/phpunit/CRM/Activity/ActionMappingTest.php
+++ b/tests/phpunit/CRM/Activity/ActionMappingTest.php
@@ -40,7 +40,7 @@ class CRM_Activity_ActionMappingTest extends \Civi\ActionSchedule\AbstractMappin
    *        - recipients: array of emails
    *        - subject: regex
    */
-  public function createTestCases() {
+  public static function createTestCases(): array {
     $cs = [];
 
     $cs[] = [

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -9,7 +9,7 @@
  +--------------------------------------------------------------------+
  */
 
-use Civi\ActionSchedule\AbstractMappingTest;
+use Civi\ActionSchedule\AbstractMappingTestCase;
 use Civi\Api4\Contribution;
 use Civi\Token\TokenProcessor;
 
@@ -21,10 +21,10 @@ use Civi\Token\TokenProcessor;
  * reminders for *contribution types*. It follows a design/pattern described in
  * AbstractMappingTest.
  *
- * @see \Civi\ActionSchedule\AbstractMappingTest
+ * @see \Civi\ActionSchedule\AbstractMappingTestCase
  * @group headless
  */
-class CRM_Contribute_ActionMapping_ByTypeTest extends AbstractMappingTest {
+class CRM_Contribute_ActionMapping_ByTypeTest extends AbstractMappingTestCase {
 
   /**
    * Generate a list of test cases, where each is a distinct combination of

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -193,7 +193,7 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends AbstractMappingTestCase {
    * Create a contribution record for Alice with type "Member Dues".
    */
   public function addAliceDues(): void {
-    $campaignID = $this->campaignCreate([
+    $campaignID = $this->ids['Campaign']['big'] = $this->campaignCreate([
       'title' => 'Campaign',
       'name' => 'big_campaign',
     ]);
@@ -373,7 +373,7 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends AbstractMappingTestCase {
       'fee_amount = €5.00',
       'paid_amount = €100.00',
       'balance_amount = €0.00',
-      'campaign_id = 1',
+      'campaign_id = ' . $this->ids['Campaign']['big'],
       'campaign name = big_campaign',
       'campaign label = Campaign',
       'receipt text = Thank you!',

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -39,7 +39,7 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends AbstractMappingTestCase {
    *        - recipients: array of emails
    *        - subject: regex
    */
-  public function createTestCases(): array {
+  public static function createTestCases(): array {
     $cs = [];
 
     $cs[] = [

--- a/tests/phpunit/CRM/Event/ActionMappingTest.php
+++ b/tests/phpunit/CRM/Event/ActionMappingTest.php
@@ -23,20 +23,51 @@ use Civi\ActionSchedule\AbstractMappingTestCase;
  */
 class CRM_Event_ActionMappingTest extends AbstractMappingTestCase {
 
-  public function createTestCases() {
+  public static function createTestCases(): array {
+    $cs = [];
+
+    $cs[] = [
+      '2015-02-01 00:00:00',
+      'createReunion registerAliceDualRole scheduleForEventStart startWeekBefore targetByRole useHelloFirstName',
+      [
+        [
+          'time' => '2015-01-25 00:00:00',
+          'to' => ['alice@example.org'],
+          'subject' => '/Hello, Alice/',
+        ],
+      ],
+    ];
+
+    return $cs;
   }
 
-  public function testLimitByRoleID(): void {
-    $this->participantCreate(['role_id' => [1, 2], 'event_id' => $this->eventCreateUnpaid()['id']]);
+  public function createReunion(array $params = [], string $identifier = 'event') {
+    $this->eventCreateUnpaid([
+      'title' => 'Roadie Reunion',
+      'start_date' => '2015-02-01 00:00:00',
+      'end_date' => '2015-02-03 05:00:00',
+      'registration_start_date' => '2014-08-01 09:00:00',
+      'registration_end_date' => '2015-01-15 23:59:59',
+    ]);
+  }
+
+  public function registerAliceDualRole() {
+    $this->participantCreate([
+      'role_id' => [1, 2],
+      'contact_id' => $this->contacts['alice']['id'],
+      'event_id' => $this->getEventID(),
+    ]);
+  }
+
+  public function scheduleForEventStart(): void {
     $this->schedule->mapping_id = CRM_Event_ActionMapping::EVENT_NAME_MAPPING_ID;
     $this->schedule->start_action_date = 'start_date';
     $this->schedule->entity_value = $this->getEventID();
+  }
+
+  public function targetByRole(): void {
     $this->schedule->limit_to = 1;
     $this->schedule->recipient_listing = 1;
-    $this->startWeekBefore();
-    $this->useHelloFirstName();
-    $this->schedule->save();
-    $this->callAPISuccess('Job', 'send_reminder', []);
   }
 
 }

--- a/tests/phpunit/CRM/Event/ActionMappingTest.php
+++ b/tests/phpunit/CRM/Event/ActionMappingTest.php
@@ -9,7 +9,7 @@
  +--------------------------------------------------------------------+
  */
 
-use Civi\ActionSchedule\AbstractMappingTest;
+use Civi\ActionSchedule\AbstractMappingTestCase;
 
 /**
  * Class CRM_Event_ActionMappingTest
@@ -18,10 +18,10 @@ use Civi\ActionSchedule\AbstractMappingTest;
  * This class tests various configurations of event scheduled-reminders. It follows a design/pattern described in
  * AbstractMappingTest.
  *
- * @see \Civi\ActionSchedule\AbstractMappingTest
+ * @see \Civi\ActionSchedule\AbstractMappingTestCase
  * @group headless
  */
-class CRM_Event_ActionMappingTest extends AbstractMappingTest {
+class CRM_Event_ActionMappingTest extends AbstractMappingTestCase {
 
   public function createTestCases() {
   }

--- a/tests/phpunit/Civi/ActionSchedule/AbstractMappingTest.php
+++ b/tests/phpunit/Civi/ActionSchedule/AbstractMappingTest.php
@@ -198,7 +198,7 @@ abstract class AbstractMappingTest extends \CiviUnitTestCase {
     ];
 
     $this->schedule = new \CRM_Core_DAO_ActionSchedule();
-    $this->schedule->title = $this->getName(TRUE);
+    $this->schedule->title = is_callable([$this, 'name']) ? $this->name() : $this->getName(TRUE);
     $this->schedule->name = \CRM_Utils_String::munge($this->schedule->title);
     $this->schedule->is_active = 1;
     $this->schedule->group_id = NULL;

--- a/tests/phpunit/Civi/ActionSchedule/AbstractMappingTestCase.php
+++ b/tests/phpunit/Civi/ActionSchedule/AbstractMappingTestCase.php
@@ -38,7 +38,7 @@ namespace Civi\ActionSchedule;
  * @see CRM_Contribute_ActionMapping_ByTypeTest
  * @see CRM_Activity_ActionMappingTest
  */
-abstract class AbstractMappingTest extends \CiviUnitTestCase {
+abstract class AbstractMappingTestCase extends \CiviUnitTestCase {
 
   /**
    * @var \CRM_Core_DAO_ActionSchedule

--- a/tests/phpunit/Civi/ActionSchedule/AbstractMappingTestCase.php
+++ b/tests/phpunit/Civi/ActionSchedule/AbstractMappingTestCase.php
@@ -95,7 +95,7 @@ abstract class AbstractMappingTestCase extends \CiviUnitTestCase {
    *        - subject: regex
    *        - message: regex
    */
-  abstract public function createTestCases();
+  abstract public static function createTestCases(): array;
 
   // ---------------------------------------- Setup Helpers ----------------------------------------
 
@@ -274,6 +274,9 @@ abstract class AbstractMappingTestCase extends \CiviUnitTestCase {
    * @throws \Exception
    */
   public function testDefault(string $targetDate, string $setupFuncs, array $expectMessages) {
+    if ($targetDate === 'INCOMPLETE') {
+      $this->markTestIncomplete();
+    }
     $this->targetDate = $targetDate;
 
     foreach (explode(' ', $setupFuncs) as $setupFunc) {

--- a/tests/phpunit/Civi/ActionSchedule/SavedSearchMappingTest.php
+++ b/tests/phpunit/Civi/ActionSchedule/SavedSearchMappingTest.php
@@ -7,10 +7,10 @@ use Civi\Api4\Contact;
  * Test scheduled-communications based on SavedSearches.
  *
  * @group ActionSchedule
- * @see \Civi\ActionSchedule\AbstractMappingTest
+ * @see \Civi\ActionSchedule\AbstractMappingTestCase
  * @group headless
  */
-class SavedSearchMappingTest extends AbstractMappingTest {
+class SavedSearchMappingTest extends AbstractMappingTestCase {
 
   protected $savedSearch = [];
 

--- a/tests/phpunit/Civi/ActionSchedule/SavedSearchMappingTest.php
+++ b/tests/phpunit/Civi/ActionSchedule/SavedSearchMappingTest.php
@@ -159,8 +159,8 @@ class SavedSearchMappingTest extends AbstractMappingTestCase {
   /**
    * Disable testDefault by returning no test cases
    */
-  public function createTestCases() {
-    return [];
+  public static function createTestCases(): array {
+    return [['INCOMPLETE', '', []]];
   }
 
 }

--- a/tests/phpunit/api/v4/Custom/CustomFileTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomFileTest.php
@@ -15,9 +15,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-namespace Civi\tests\phpunit\api\v4\Custom;
+namespace api\v4\Custom;
 
-use api\v4\Custom\CustomTestBase;
 use Civi\Api4\CustomGroup;
 use Civi\Api4\CustomField;
 use Civi\Api4\File;


### PR DESCRIPTION
Most relevant changes here:

* Function `$this->getName()` was renamed to `$this->name()`
* If you make an abstract/intermediate base class, it should end with `TestCase` not `Test`
* Data-provider functions must be static.
* Data-provider functions must return a non-empty array. 