### PR TITLE
WordPress Permissions: code cleanup, use cycle and odd-row css classes

### DIFF
--- a/templates/CRM/ACL/Form/WordPress/Permissions.tpl
+++ b/templates/CRM/ACL/Form/WordPress/Permissions.tpl
@@ -12,42 +12,33 @@
   <p>{ts}Use this form to Grant access to CiviCRM components and other CiviCRM permissions to WordPress roles.{/ts}</p>
   <p>{ts}<strong>NOTE: Super Admin</strong> and <strong>Administrator</strong> roles will have all permissions in CiviCRM.{/ts}</p>
 </div>
-<div class="crm-block crm-form-block crm-export-form-block crm-sticky">
-  <table>
+<div class="crm-block crm-sticky">
+  <table class="table-striped">
     <thead>
       <tr>
         <th class="label">&nbsp;</th>
         {assign var="num" value=0}
         {foreach from=$roles key=role_name item=role_value}
-          <th align="center"><strong>{$role_value}</strong></th>
+          <th align="center">{$role_value}</th>
           {assign var="num" value=$num+1}
         {/foreach}
       </tr>
     </thead>
     <tbody>
-      {assign var="x" value=0}
       {foreach from=$table key=perm_name item=row}
-        {if $x mod 2 eq 1}
-          <tr style="background-color: #E6E6DC;">
-        {else}
-          <tr style="background-color: #FFFFFF;">
-        {/if}
-
-       <td style="height: 2.6em;">
-           {$row.label}
-          {if !empty($row.desc)}
-            <br/><span class="description">{$row.desc}</span>
-          {/if}
-        </td>
-
-        {foreach from=$row.roles key=index item=role_name}
-          <td align="center" style="padding-top: 0.6em;">
-            {$form.$role_name.$perm_name.html}
+        <tr class="{cycle values="odd-row,even-row"}">
+          <td style="height: 2.6em;">
+            {$row.label}
+            {if !empty($row.desc)}
+              <br/><span class="description">{$row.desc}</span>
+            {/if}
           </td>
-        {/foreach}
-
+          {foreach from=$row.roles key=index item=role_name}
+            <td align="center" style="padding-top: 0.6em;">
+              {$form.$role_name.$perm_name.html}
+            </td>
+          {/foreach}
         </tr>
-        {assign var="x" value=$x+1}
       {/foreach}
     </tbody>
   </table>


### PR DESCRIPTION
Overview
----------------------------------------

Minor code cleanup of the CiviCRM/WordPress permissions page.

I was going to do bigger changes, until I stumbled on #30180 which already fixes the sticky headers (hurray!).

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/6fafa4b2-8e31-4021-bb5c-b4b3cc52c505)

After
----------------------------------------

![image](https://github.com/user-attachments/assets/ef08d009-3c5d-4b4c-8b56-648f8b8edc9d)

Comments
----------------------------------------

There is a small difference, but now the markup is more standard, easier for theming.

cc @shaneonabike 