### PR TITLE
Search Kit - For "Entity" displays, provide TABLE/VIEW options

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -1000,4 +1000,15 @@ MODIFY      {$columnName} varchar( $length )
     return CRM_Core_DAO::singleValueQuery('SELECT @@character_set_database');
   }
 
+  /**
+   * @param string $table
+   * @return string|null
+   *   Ex: 'BASE TABLE' or 'VIEW'
+   */
+  public static function getTableType(string $table): ?string {
+    return \CRM_Core_DAO::singleValueQuery(
+      'SELECT TABLE_TYPE  FROM information_schema.tables  WHERE TABLE_SCHEMA=database() AND TABLE_NAME LIKE %1',
+      [1 => [$table, 'String']]);
+  }
+
 }

--- a/Civi/Api4/Generic/AbstractGetAction.php
+++ b/Civi/Api4/Generic/AbstractGetAction.php
@@ -83,7 +83,7 @@ abstract class AbstractGetAction extends AbstractQueryAction {
     }
     foreach ($uniqueIndices as $indexFields) {
       $fetchByUnique = TRUE;
-      foreach ($indexFields as $fieldName) {
+      foreach ($indexFields ?: [] as $fieldName) {
         if (!$this->_itemsToGet($fieldName)) {
           $fetchByUnique = FALSE;
         }

--- a/ext/search_kit/Civi/Api4/Action/SKEntity/Refresh.php
+++ b/ext/search_kit/Civi/Api4/Action/SKEntity/Refresh.php
@@ -28,6 +28,10 @@ class Refresh extends AbstractAction {
       ->addWhere('name', '=', $displayName)
       ->execute()->single();
 
+    if (($display['settings']['data_mode'] ?? 'table') !== 'table') {
+      return;
+    }
+
     $query = (new SKEntityGenerator())->createQuery($display['saved_search_id.api_entity'], $display['saved_search_id.api_params'], $display['settings']);
     $sql = $query->getSql();
     $tableName = _getSearchKitDisplayTableName($displayName);

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
@@ -36,8 +36,8 @@ class SKEntitySubscriber extends AutoService implements EventSubscriberInterface
   public static function getSubscribedEvents(): array {
     return [
       'civi.api4.entityTypes' => 'on_civi_api4_entityTypes',
-      'hook_civicrm_pre' => 'onPreSaveDisplay',
-      'hook_civicrm_post' => 'onPostSaveDisplay',
+      'hook_civicrm_pre::SearchDisplay' => 'onPreSaveDisplay',
+      'hook_civicrm_post::SearchDisplay' => 'onPostSaveDisplay',
     ];
   }
 

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
@@ -55,7 +55,6 @@ class SKEntitySubscriber extends AutoService implements EventSubscriberInterface
         'title' => $display['label'],
         'title_plural' => $display['label'],
         'description' => $display['settings']['description'] ?? NULL,
-        'primary_key' => ['_row'],
         'type' => ['SavedSearch'],
         'table_name' => $display['tableName'],
         'class_args' => [$display['name']],
@@ -101,15 +100,6 @@ class SKEntitySubscriber extends AutoService implements EventSubscriberInterface
       'is_multiple' => FALSE,
       'attributes' => 'ENGINE=InnoDB',
       'fields' => [],
-    ];
-    // Primary key field
-    $table['fields'][] = [
-      'name' => '_row',
-      'type' => 'int unsigned',
-      'primary' => TRUE,
-      'required' => TRUE,
-      'attributes' => 'AUTO_INCREMENT',
-      'comment' => 'Row number',
     ];
     foreach ($newSettings['columns'] as &$column) {
       $expr = $this->getSelectExpression($column['key']);

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
@@ -127,10 +127,7 @@ class SKEntitySubscriber extends AutoService implements EventSubscriberInterface
         $query = (new SKEntityGenerator())->createQuery($this->savedSearch['api_entity'], $this->savedSearch['api_params'], $tempSettings);
         $columnSpecs = array_column($tempSettings['columns'], 'spec');
         $columns = implode(', ', array_column($columnSpecs, 'name'));
-
-        $sql = "CREATE VIEW `$tableName` (_row, $columns) AS " . $query->getSql();
-        $sql = preg_replace('/ SELECT /', ' SELECT row_number() over () AS _row, ', $sql, 1);
-        // Q: Do we really need _row? What are the performance implications?
+        $sql = "CREATE VIEW `$tableName` ($columns) AS " . $query->getSql();
 
         // do not i18n-rewrite
         \CRM_Core_DAO::executeQuery($sql, [], TRUE, NULL, FALSE, FALSE);

--- a/ext/search_kit/Civi/BAO/SK_Entity.php
+++ b/ext/search_kit/Civi/BAO/SK_Entity.php
@@ -21,18 +21,11 @@ use CRM_Core_DAO;
 class SK_Entity extends CRM_Core_DAO {
 
   /**
-   * This is the primary key - it has an underscore to prevent possible conflicts with other columns.
-   *
-   * @var int
-   */
-  protected $_row;
-
-  /**
    * Primary key field.
    *
    * @var string[]
    */
-  public static $_primaryKey = ['_row'];
+  public static $_primaryKey = [];
 
   /**
    * Over-ride the parent to prevent a NULL return.

--- a/ext/search_kit/Civi/Schema/SkEntityMetaProvider.php
+++ b/ext/search_kit/Civi/Schema/SkEntityMetaProvider.php
@@ -10,7 +10,6 @@ class SkEntityMetaProvider extends SqlEntityMetadata {
 
   public function getProperty(string $propertyName) {
     $staticProps = [
-      'primary_keys' => ['_row'],
       'log' => FALSE,
       'icon' => 'fa-search-plus',
       'paths' => [],
@@ -31,18 +30,6 @@ class SkEntityMetaProvider extends SqlEntityMetadata {
 
   public function getFields(): array {
     $entityDisplay = $this->getDisplayInfo();
-    $fields = [
-      '_row' => [
-        'title' => E::ts('Case ID'),
-        'sql_type' => 'int unsigned',
-        'input_type' => 'Number',
-        'required' => TRUE,
-        'description' => E::ts('Search result row number'),
-        'usage' => [],
-        'primary_key' => TRUE,
-        'auto_increment' => TRUE,
-      ],
-    ];
     foreach ($entityDisplay['settings']['columns'] as $column) {
       $field = [
         'title' => $column['label'],

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -190,7 +190,7 @@ class Admin {
   private static function getDefaultColumns(array $entity, iterable $getFields): array {
     // Start with id & label
     $defaultColumns = array_merge(
-      $entity['primary_key'],
+      $entity['primary_key'] ?? [],
       $entity['search_fields'] ?? []
     );
     $possibleColumns = [];

--- a/ext/search_kit/Civi/Search/SKEntityGenerator.php
+++ b/ext/search_kit/Civi/Search/SKEntityGenerator.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Search;
+
+use Civi\API\Request;
+use Civi\Api4\Query\Api4SelectQuery;
+
+class SKEntityGenerator {
+
+  /**
+   * @param string $realEntity
+   *   The underlying API entity that we need to query
+   * @param array $realParams
+   *   Basic API request
+   * @param array $settings
+   *   The settings from the SearchDisplay record.
+   * @return \Civi\Api4\Query\Api4SelectQuery
+   *   A prepared query
+   * @throws \Civi\API\Exception\NotImplementedException
+   */
+  public function createQuery(string $realEntity, array $realParams, array $settings): Api4SelectQuery {
+    $apiParams = $realParams;
+    // Add orderBy to api params
+    foreach ($settings['sort'] ?? [] as $item) {
+      $apiParams['orderBy'][$item[0]] = $item[1];
+    }
+    // Set select clause to match display columns
+    $select = [];
+    foreach ($settings['columns'] as $column) {
+      foreach ($apiParams['select'] as $selectExpr) {
+        if ($selectExpr === $column['key'] || str_ends_with($selectExpr, " AS {$column['key']}")) {
+          $select[] = $selectExpr;
+          continue 2;
+        }
+      }
+    }
+    $apiParams['select'] = $select;
+    $api = Request::create($realEntity, 'get', $apiParams);
+    $query = new Api4SelectQuery($api);
+    $query->forceSelectId = FALSE;
+    return $query;
+  }
+
+}

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.component.js
@@ -17,6 +17,12 @@
       $scope.hs = crmUiHelp({file: 'CRM/Search/Help/DisplayTypeEntity'});
 
       this.permissions = CRM.crmSearchAdmin.permissions;
+      this.dataModes = [
+        {id: 'table', text: ts('MySQL Table')},
+        {id: 'view', text: ts('MySQL View')}
+        // {id: 'cte', text: ts('MySQL Table Expression')}
+      ];
+      ctrl.isDataMode = (m) => (m == (ctrl.display.settings.data_mode || 'table'));
 
       this.$onInit = function () {
         ctrl.jobFrequency = CRM.crmSearchAdmin.jobFrequency;

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.html
@@ -6,18 +6,23 @@
   <textarea class="form-control" placeholder="{{:: ts('Description') }}" ng-model="$ctrl.display.settings.description"></textarea>
 </div>
 <div class="form-inline">
+  <label for="display_data_mode">{{:: ts('Data Mode') }}</label>
+  <a crm-ui-help="hs({id: 'data_mode', title: ts('Data Mode')})"></a>
+  <input id="display_data_mode" class="form-control" crm-ui-select="{data: $ctrl.dataModes, placeholder: ts('MySQL Table')}" ng-model="$ctrl.display.settings.data_mode">
+</div>
+<div class="form-inline">
   <label for="crm-search-admin-display-api">{{:: ts('API Name') }} <span class="crm-marker">*</span></label>
   <div class="input-group">
     <span class="input-group-addon">SK_</span>
     <input id="crm-search-admin-display-api" type="text" class="form-control" ng-model="$ctrl.display.name" required />
   </div>
 </div>
-<p ng-if="$ctrl.display.id">
+<p ng-if="$ctrl.isDataMode('table') && $ctrl.display.id">
   <i class="crm-i fa-clock-o"></i>
   <strong ng-if="$ctrl.display._refresh_date">{{:: ts('Last refreshed: %1. Click "Save" to refresh now.', {1: $ctrl.display._refresh_date}) }}</strong>
   <strong ng-if="!$ctrl.display._refresh_date">{{:: ts('Checking last refresh date...') }}</strong>
 </p>
-<div class="form-inline" ng-if="$ctrl.display._job">
+<div class="form-inline" ng-if="$ctrl.isDataMode('table') && $ctrl.display._job">
   <div class="checkbox-inline form-control">
     <label>
       <input type="checkbox" ng-model="$ctrl.display._job.is_active">

--- a/ext/search_kit/templates/CRM/Search/Help/DisplayTypeEntity.hlp
+++ b/ext/search_kit/templates/CRM/Search/Help/DisplayTypeEntity.hlp
@@ -2,3 +2,31 @@
   <p>{ts}Set the permission level needed to view this entity.{/ts}</p>
   <p>{ts}Users without this permission will not be able to see this entity in SearchKit nor in any search queries or displays that use this entity.{/ts}</p>
 {/htxt}
+{htxt id="data_mode"}
+  <p>{ts}Determine which data-storage features to use when generating this entity.{/ts}</p>
+  <ul>
+    {* We should probably give some more hints about when to use each. Included draft notes about expected trade-offs. *}
+
+    {* TABLE: Expected trade-offs:
+      Strength: Stable data. Stable structure. Analytics with grouping/aggregation/function-evaluation.
+      Weakness: Volatile data. Volatile structure.
+    *}
+    <li>{ts}<strong>MySQL Table</strong>: Create a persistent MySQL table and re-fill it periodically.{/ts}</li>
+    {* VIEW: Expected trade-offs:
+      Strength: Volatile data. Stable structure. Simple variations on existing entities. Targeted access to subsets of data.
+      Weakness: Volatile structure. Analytics with grouping/aggregation/function-evaluation.
+    *}
+    <li>{ts}<strong>MySQL View</strong>: Create a persistent MySQL view. Better suited to volatile data with a stable data-structure. Better suited to targeted data-access but not to analytics.{/ts}</li>
+    {* CTE: Expected trade-offs:
+      Strength: Volatile data. Volatile structure.
+      Moderate: Analytics with grouping/aggregation/function-evaluation.
+      Weakness: Targeted access to subsets of data.
+
+      Compared to VIEWs, a key difference is CTEs are likely to build an on-demand temporary table to cache intermediate
+      results. This is good if you need to full-table operations like grouping/aggregating. But it may be bad if you're
+      only accessing a small portion of the data.
+    <li>{ts}<strong>MySQL CTE</strong>: Create dynamic MySQL query using Common Table Expression. Better suited to volatile {/ts}</li>
+    *}
+  </ul>
+
+{/htxt}

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EntityDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EntityDisplayTest.php
@@ -105,21 +105,16 @@ class EntityDisplayTest extends Api4TestBase {
     $this->assertEquals($expectTypes[$dataMode], \CRM_Core_BAO_SchemaHandler::getTableType('civicrm_sk_my_new_entity'));
 
     $schema = \CRM_Core_DAO::executeQuery('DESCRIBE civicrm_sk_my_new_entity')->fetchAll();
-    $this->assertCount(7, $schema);
-    $this->assertEquals('_row', $schema[0]['Field']);
-    // $this->assertStringStartsWith('int', $schema[0]['Type']);
+    $this->assertCount(6, $schema);
     $this->assertMatchesRegularExpression('/^(int|bigint)/', $schema[0]['Type']);
-    if ($dataMode === 'table') {
-      $this->assertEquals('PRI', $schema[0]['Key']);
-    }
 
     if ($dataMode === 'table') {
       // created_date and modified_date should be NULLable and have no default/extra
+      $this->assertEmpty($schema[4]['Default']);
+      $this->assertEmpty($schema[4]['Extra']);
+      $this->assertEquals('YES', $schema[4]['Null']);
       $this->assertEmpty($schema[5]['Default']);
       $this->assertEmpty($schema[5]['Extra']);
-      $this->assertEquals('YES', $schema[5]['Null']);
-      $this->assertEmpty($schema[6]['Default']);
-      $this->assertEmpty($schema[6]['Extra']);
       $this->assertEquals('YES', $schema[5]['Null']);
     }
 
@@ -146,7 +141,7 @@ class EntityDisplayTest extends Api4TestBase {
 
     civicrm_api4('SK_MyNewEntity', 'refresh');
 
-    $rows = \CRM_Core_DAO::executeQuery('SELECT * FROM civicrm_sk_my_new_entity ORDER BY `_row`')->fetchAll();
+    $rows = \CRM_Core_DAO::executeQuery('SELECT * FROM civicrm_sk_my_new_entity ORDER BY first')->fetchAll();
     $this->assertCount(3, $rows);
     $this->assertEquals('A', $rows[0]['first']);
     $this->assertEquals('C', $rows[2]['first']);
@@ -162,7 +157,7 @@ class EntityDisplayTest extends Api4TestBase {
     \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['view all contacts'];
     $rows = civicrm_api4('SK_MyNewEntity', 'get', [
       'select' => ['first', 'prefix_id:label'],
-      'orderBy' => ['_row' => 'ASC'],
+      'orderBy' => ['first' => 'ASC'],
     ]);
     $this->assertCount(4, $rows);
     $this->assertEquals('A', $rows[0]['first']);
@@ -250,7 +245,7 @@ class EntityDisplayTest extends Api4TestBase {
       ->execute();
 
     $fields = civicrm_api4('SK_MyNewEntityWithJoin', 'getFields', [], 'name');
-    $this->assertCount(4, $fields);
+    $this->assertCount(3, $fields);
     $this->assertSame('Integer', $fields['id']['data_type']);
     $this->assertSame('EntityRef', $fields['id']['input_type']);
     $this->assertSame('Contact', $fields['id']['fk_entity']);
@@ -264,7 +259,7 @@ class EntityDisplayTest extends Api4TestBase {
     civicrm_api4('SK_MyNewEntityWithJoin', 'refresh');
     $rows = (array) civicrm_api4('SK_MyNewEntityWithJoin', 'get', [
       'select' => ['*', 'Contact_Participant_contact_id_01_event_id.title', 'id.first_name'],
-      'orderBy' => ['_row' => 'ASC'],
+      'orderBy' => ['id' => 'ASC'],
     ]);
     $this->assertCount(3, $rows);
     $this->assertEquals(array_column($contacts, 'id'), array_column($rows, 'id'));
@@ -389,19 +384,17 @@ class EntityDisplayTest extends Api4TestBase {
 
     // Validate schema
     $schema = \CRM_Core_DAO::executeQuery('DESCRIBE civicrm_sk_major_donors_entity_test_db_entity1')->fetchAll();
-    $this->assertCount(6, $schema);
-    $this->assertEquals('_row', $schema[0]['Field']);
+    $this->assertCount(5, $schema);
     $this->assertMatchesRegularExpression('/^(int|bigint)/', $schema[0]['Type']);
     $this->assertMatchesRegularExpression('/^(int|bigint)/', $schema[1]['Type']);
-    $this->assertMatchesRegularExpression('/^(int|bigint)/', $schema[2]['Type']);
-    $this->assertStringStartsWith('text', $schema[3]['Type']);
-    $this->assertStringStartsWith('decimal', $schema[4]['Type']);
-    $this->assertStringStartsWith('text', $schema[3]['Type']);
+    $this->assertStringStartsWith('text', $schema[2]['Type']);
+    $this->assertStringStartsWith('decimal', $schema[3]['Type']);
+    $this->assertStringStartsWith('text', $schema[2]['Type']);
 
     civicrm_api4('SK_MajorDonorsEntityTestDbEntity1', 'refresh');
 
     $fields = civicrm_api4('SK_MajorDonorsEntityTestDbEntity1', 'getFields', ['loadOptions' => TRUE], 'name');
-    $this->assertCount(6, $fields);
+    $this->assertCount(5, $fields);
 
     $this->assertSame('Integer', $fields['YEAR_receive_date']['data_type']);
     $this->assertSame('Number', $fields['YEAR_receive_date']['input_type']);


### PR DESCRIPTION
Overview
----------------------------------------

In Search Kit, you can create a saved-search and use it to generate a read-only custom API.

Steps to Reproduce
----------------------------------------

* Go to "Search" => "Search Kit" => "New Search"
* Call it "Grown Ups". Select display name, primary email, and primary phone. Filter on contact-type and age.
* Add a search-display of type "DB Entity"
* Call it "GrownUps"
* Save

Before
----------------------------------------

The DB entity is created as a `TABLE`. This table must be periodically refreshed.

After
----------------------------------------

You can optionally set a flag to control data-storage for the entity ("MySQL TABLE" vs "MySQL VIEW" vs ~~"MySQL CTE"~~).

![Screenshot from 2024-12-19 00-26-28](https://github.com/user-attachments/assets/bfbf5091-c100-4bfa-98ad-d779767c51b0)

(*EDIT: CTE support as very cursory and dropped later. But if it was implemented, this is where it would show up.*)

Technical Details
----------------------------------------

* Implementing the `_row` column on a `VIEW` requires some trickery. 
    * I'm a little skeptical about the performance. Seems like something that should be tested.
    * What are the alternatives? An entity with no primary key? Or make a key using joined values `CONCAT(a.id,"_",b.id",...)`? Or limit the feature to non-joined searches?
    * Haven't tested, but this trick probably requires MySQL 8.0. (Don't know about Maria versions.)
* This is currently a draft. I haven't yet written tests or implemented CTE support.
* In theory, CTE might perform better than VIEW for certain kinds of queries. AFAIK, CTE is more likely to create a (hidden) temporary table (in memory or on disk). 
    * That should make it better than VIEW when you need to perform multiple passes over the data (e.g. for analytics -- for aggregate operations). 
    * But it may be worse than VIEW if you have (a) large data-sets combined with (b) narrow queries for specific records.
    * It also requires MySQL 8.0. (Don't know about Maria versions.)