### PR TITLE
Enable Riverlea extension (*not* theme) + dark mode on new Standalone installs

### DIFF
--- a/setup/plugins/init/StandaloneRiverlea.civi-setup.php
+++ b/setup/plugins/init/StandaloneRiverlea.civi-setup.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @file
+ *
+ * Enable Riverlea by default on Standalone installs.
+ * - this does not *select* a Riverlea theme but removes one step for doing so
+ * - we set dark_mode setting to inherit instead of always light (which is the default for other CMS)
+ *
+ */
+
+if (!defined('CIVI_SETUP')) {
+  exit("Installation plugins must only be loaded by the installer.\n");
+}
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setup.init', function (\Civi\Setup\Event\InitEvent $e) {
+    $model = $e->getModel();
+    if ($model->cms !== 'Standalone') {
+      return;
+    }
+    \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'init'));
+
+    $e->getModel()->extensions[] = 'riverlea';
+    $e->getModel()->settings['riverlea_dark_mode_frontend'] = 'inherit';
+    $e->getModel()->settings['riverlea_dark_mode_backend'] = 'inherit';
+  });


### PR DESCRIPTION
Overview
----------------------------------------
Enables Riverlea extension in the Standalone install process + set the starting dark mode to *Inherit from browser/OS*.

Note this does *not* select a Riverlea theme by default - but they will be available in the theme options in display settings.


Before
----------------------------------------
- default for Riverlea dark mode has been switched to *Always light* to avoid conflicts with CMS themes
- Two steps required to use Riverlea ( enable the extension, then select a theme )
- Standalone will be *Always light* by default


After
----------------------------------------
- Only one step to use Riverlea on Standalone ( go to Display Settings and pick one)
- Standalone will  *Inherit [dark mode] from browser/os* by default

Technical Details
----------------------------------------
The slight risk of this would be if any of the Riverlea extension hooks caused problems when the extension was installed but a Riverlea theme wasn't selected. There were a couple of issues like this early on, but I **think** these have been ironed out now. 
