### PR TITLE
dev/drupal#200: Performance improvement

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -294,7 +294,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     $query = html_entity_decode($query);
 
     $config = CRM_Core_Config::singleton();
-    $base = $absolute ? $config->userFrameworkBaseURL : 'internal:/';
+    $base = $absolute ? $config->userFrameworkBaseURL : 'base:/';
 
     $url = $this->parseURL("{$path}?{$query}");
 


### PR DESCRIPTION
Performance improvement

Overview
----------------------------------------

With this change loading the contact summary on my local install will improve from 700ms to 500ms. 

On a production site this had a similar impact where performance went down from 7 seconds to 4 seconds.

Before
----------------------------------------
The `internal:/`  path makes the router component in Drupal lookup the routing and check whether it is a valid route. Which means looking up a civicrm route from CiviCRM. 

After
----------------------------------------

The routing component does not lookup whether the route exists. 

Comments
----------------------------------------

See https://lab.civicrm.org/dev/drupal/-/issues/200
