### PR TITLE
Admin ACLs: remove report class on table

### DIFF
--- a/templates/CRM/Admin/Page/Access.tpl
+++ b/templates/CRM/Admin/Page/Access.tpl
@@ -20,7 +20,7 @@
     <p>{ts 1=$ufAccessURL|smarty:nodefaults 2=$jAccessParams 3=$config->userFramework}Note that <a href='%1' %2>%3 permissions</a> take precedence over CiviCRM ACLs. If you wish to use CiviCRM ACLs, first disable the related permission in %3 for a user role, and then gradually add ACLs to replace that permission for certain groups of contacts.{/ts}
   {/if}
 </div>
-<table class="report">
+<table>
   <tr>
     {if $config->userFramework == 'Standalone'}
       <td class="nowrap"><a href="{$ufAccessURL|smarty:nodefaults}" id="adminAccess"><i class="crm-i fa-chevron-right fa-fw" aria-hidden="true"></i>{ts}User Roles{/ts}</a></td>


### PR DESCRIPTION
Overview
----------------------------------------

Fixes the Manage ACLs screen on RiverLea and TheIsland, by removing a class used on CiviReport.

RiverLea
----------------------------------------

Before:

![image](https://github.com/user-attachments/assets/6744d1b6-d576-4c65-b358-7f439e9c4a6b)

After:

![image](https://github.com/user-attachments/assets/5a790f1d-7f92-4e26-b5a1-5b7d1420ad4d)

The Island
----------------------------------------

Before:

![image](https://github.com/user-attachments/assets/5757862a-8507-4fc3-874a-3a7060451fe4)

(well, TheIsland has a extra CSS just for this specific table, which I now removed)

After:

![image](https://github.com/user-attachments/assets/50efaf97-182c-4bdb-b6a6-a7143851d6e3)

Greenwich
----------------------

Before:

![image](https://github.com/user-attachments/assets/650689ce-fed6-4391-9142-5d6407c8e72b)

After:

![image](https://github.com/user-attachments/assets/9d916158-c3b5-4375-a642-81d9ba707ecb)

Comments
----------------------------------------

There is a small impact on Greenwhich that I suspect most Greenwhich users will not notice (after all, they are using Greenwhich).