### PR TITLE
[REF] use common helper to set expected keys for tabs in Summary.tpl and TabHeader.tpl

### DIFF
--- a/CRM/Campaign/Form/Survey.php
+++ b/CRM/Campaign/Form/Survey.php
@@ -133,6 +133,7 @@ class CRM_Campaign_Form_Survey extends CRM_Core_Form {
       $tabs = $this->processSurveyForm();
       $form->set('tabHeader', $tabs);
     }
+    $tabs = \CRM_Core_Smarty::setRequiredTabTemplateKeys($tabs);
     $form->assign('tabHeader', $tabs);
     CRM_Core_Resources::singleton()
       ->addScriptFile('civicrm', 'templates/CRM/common/TabHeader.js', 1, 'html-header')

--- a/CRM/Campaign/Form/Survey/TabHeader.php
+++ b/CRM/Campaign/Form/Survey/TabHeader.php
@@ -36,6 +36,7 @@ class CRM_Campaign_Form_Survey_TabHeader {
       $tabs = self::process($form);
       $form->set('tabHeader', $tabs);
     }
+    $tabs = \CRM_Core_Smarty::setRequiredTabTemplateKeys($tabs);
     $form->assign('tabHeader', $tabs);
     CRM_Core_Resources::singleton()
       ->addScriptFile('civicrm', 'templates/CRM/common/TabHeader.js', 1, 'html-header')

--- a/CRM/Campaign/Page/Vote.php
+++ b/CRM/Campaign/Page/Vote.php
@@ -122,7 +122,8 @@ class CRM_Campaign_Page_Vote extends CRM_Core_Page {
       ];
     }
 
-    $this->assign('tabHeader', empty($allTabs) ? FALSE : $allTabs);
+    $tabs = empty($allTabs) ? [] : \CRM_Core_Smarty::setRequiredTabTemplateKeys($allTabs);
+    $this->assign('tabHeader', $tabs);
   }
 
 }

--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -456,11 +456,7 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
       }
     }
 
-    $expectedKeys = ['count', 'class', 'template', 'hideCount', 'icon'];
-
     foreach ($allTabs as &$tab) {
-      // Ensure tab has all expected keys
-      $tab += array_fill_keys($expectedKeys, NULL);
       // Get tab counts last to avoid wasting time; if a tab was removed by hook, the count isn't needed.
       if (!isset($tab['count']) && isset($getCountParams[$tab['id']])) {
         $tab['count'] = call_user_func_array([
@@ -469,6 +465,9 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
         ], $getCountParams[$tab['id']]);
       }
     }
+
+    // ensure all keys used in the template are set, to avoid notices
+    $allTabs = \CRM_Core_Smarty::setRequiredTabTemplateKeys($allTabs);
 
     // now sort the tabs based on weight
     usort($allTabs, ['CRM_Utils_Sort', 'cmpFunc']);

--- a/CRM/Contribute/Form/ContributionPage/TabHeader.php
+++ b/CRM/Contribute/Form/ContributionPage/TabHeader.php
@@ -31,6 +31,7 @@ class CRM_Contribute_Form_ContributionPage_TabHeader {
       $tabs = self::process($form);
       $form->set('tabHeader', $tabs);
     }
+    $tabs = \CRM_Core_Smarty::setRequiredTabTemplateKeys($tabs);
     $form->assign('tabHeader', $tabs);
     CRM_Core_Resources::singleton()
       ->addScriptFile('civicrm', 'templates/CRM/common/TabHeader.js', 1, 'html-header')

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -806,7 +806,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     // our ensured variables get blown away, so we need to set them even if
     // it's already been initialized.
     self::$_template->ensureVariablesAreAssigned($this->expectedSmartyVariables);
-    self::$_template->addExpectedTabHeaderKeys();
     $this->_formBuilt = TRUE;
   }
 

--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -218,8 +218,6 @@ class CRM_Core_Page {
     $pageTemplateFile = $this->getHookedTemplateFileName();
     self::$_template->assign('tplFile', $pageTemplateFile);
 
-    self::$_template->addExpectedTabHeaderKeys();
-
     // invoke the pagRun hook, CRM-3906
     CRM_Utils_Hook::pageRun($this);
 

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -277,23 +277,37 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
   }
 
   /**
-   * Avoid e-notices on pages with tabs,
-   * by ensuring tabHeader items contain the necessary keys
+   * @deprecated
+   * Directly apply self::setRequiredTemplateTabKeys to the tabHeader
+   * variable
    */
   public function addExpectedTabHeaderKeys(): void {
+    $tabs = $this->getTemplateVars('tabHeader');
+    $tabs = self::setRequiredTabTemplateKeys($tabs);
+    $this->assign('tabHeader', $tabs);
+  }
+
+  /**
+   * Ensure an array of tabs has the required keys to be passed
+   * to our Smarty tabs templates (TabHeader.tpl or Summary.tpl)
+   */
+  public static function setRequiredTabTemplateKeys(array $tabs): array {
     $defaults = [
       'class' => '',
       'extra' => '',
-      'icon' => FALSE,
-      'count' => FALSE,
-      'template' => FALSE,
+      'icon' => NULL,
+      'count' => NULL,
+      'hideCount' => FALSE,
+      'template' => NULL,
+      // Afform tabs set the afform module and directive - NULL for non-afform tabs
+      'module' => NULL,
+      'directive' => NULL,
     ];
 
-    $tabs = $this->getTemplateVars('tabHeader');
-    foreach ((array) $tabs as $i => $tab) {
-      $tabs[$i] = array_merge($defaults, $tab);
+    foreach ($tabs as $i => $tab) {
+      $tabs[$i] = array_merge($defaults, (array) $tab);
     }
-    $this->assign('tabHeader', $tabs);
+    return $tabs;
   }
 
   /**

--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -399,6 +399,7 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
       $tabs = $this->processTab();
       $this->set('tabHeader', $tabs);
     }
+    $tabs = \CRM_Core_Smarty::setRequiredTabTemplateKeys($tabs);
     $this->assign('tabHeader', $tabs);
     CRM_Core_Resources::singleton()
       ->addScriptFile('civicrm', 'templates/CRM/common/TabHeader.js', 1, 'html-header')

--- a/CRM/Event/Form/ManageEvent/TabHeader.php
+++ b/CRM/Event/Form/ManageEvent/TabHeader.php
@@ -37,6 +37,7 @@ class CRM_Event_Form_ManageEvent_TabHeader {
       $tabs = self::process($form);
       $form->set('tabHeader', $tabs);
     }
+    $tabs = \CRM_Core_Smarty::setRequiredTabTemplateKeys($tabs);
     $form->assign('tabHeader', $tabs);
     CRM_Core_Resources::singleton()
       ->addScriptFile('civicrm', 'templates/CRM/common/TabHeader.js', 1, 'html-header')


### PR DESCRIPTION
Overview
----------------------------------------
Consolidate and more tightly target the preprocessing of tabs arrays before they are passed to smarty templates.

Before
----------------------------------------
- TabHeader.tpl and Contact summary tabs in Summary.tpl handle the issue of ensuring the expected smarty vars are assigned slightly differently
- The TabHeader way is also called for **every single page and form load** regardless of whether there are any tabs on the page/form.

After
----------------------------------------
- a common helper function is used to set expected array keys
- the function is used at the point of assigning the tabs variable, rather than on every page/form load


Comments
----------------------------------------
This should help with avoiding any ENOTICEs caused by https://github.com/civicrm/civicrm-core/pull/31606
