### PR TITLE
Search Kit - Add a status-check to validate SearchDisplays

### DIFF
--- a/ext/search_kit/Civi/Search/SearchDisplayChecks.php
+++ b/ext/search_kit/Civi/Search/SearchDisplayChecks.php
@@ -1,0 +1,82 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Search;
+
+use Civi\Api4\SearchDisplay;
+use Civi\Core\Service\AutoService;
+use Psr\Log\LogLevel;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @service civi.check.search_display
+ */
+class SearchDisplayChecks extends AutoService implements EventSubscriberInterface {
+
+  const PREFIX = 'search_display:';
+
+  public static function getSubscribedEvents() {
+    return ['&hook_civicrm_check' => 'runChecks'];
+  }
+
+  /**
+   * @see \CRM_Utils_Hook::check()
+   */
+  public function runChecks(&$messages, $statusNames = [], $includeDisabled = FALSE) {
+    if (!empty($statusNames) && !preg_grep('/^' . preg_quote(static::PREFIX, '/') . '/', $statusNames)) {
+      return;
+    }
+
+    $displays = SearchDisplay::get(FALSE)
+      ->addSelect('id', 'label', 'type', 'settings', 'saved_search_id', 'saved_search_id.api_entity', 'saved_search_id.api_params')
+      ->execute();
+    foreach ($displays as $display) {
+      $issues = $this->validateSearchDisplay($display['saved_search_id.api_entity'], $display['saved_search_id.api_params'], $display['settings']);
+      if (!empty($issues)) {
+        $message = new \CRM_Utils_Check_Message(
+          static::PREFIX . $display['id'],
+          '<p>' . ts('This record appears to have invalid settings:') . '</p>' .
+          '<ul>' . implode("", array_map(fn($i) => "<li>$i</li>", $issues)) . '</ul>',
+          ts('Search Display "%1" (#%2)', [1 => $display['label'], 2 => $display['id']]),
+          LogLevel::WARNING,
+          'fa-search'
+        );
+        if (!empty($display['saved_search_id'])) {
+          $message->addAction(ts('Edit search'), FALSE, 'href', [
+            'url' => \Civi::url('backend://civicrm/admin/search#/edit/')->addFragment($display['saved_search_id']),
+          ]);
+        }
+
+        $messages[] = $message;
+      }
+    }
+  }
+
+  public function validateSearchDisplay(string $entity, array $params, array $settings): array {
+    $issues = [];
+
+    $fields = civicrm_api4($entity, 'getFields', ['checkPermissions' => FALSE])->indexBy('name')->getArrayCopy();
+    foreach ($settings['columns'] as $column) {
+      if ($column['type'] !== 'field') {
+        continue;
+      }
+
+      // TODO: A better way to validate subfields. For now, we'll just check the first layer. Much better than nothing.
+      [$key] = preg_split('/[:\.]/', $column['key']);
+      if (!isset($fields[$key])) {
+        $issues[] = ts('Unrecognized field "<code>%1</code>"', [1 => htmlentities($column['key'])]);
+      }
+    }
+
+    return $issues;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

Saved-searches and search-displays can be complicated objects -- with references to various fields, entities, flags. Over time, as a system evolves, these values could get out of sync. If that happens... how do you know?

Before
----------------------------------------

The only way to validate a search is to open it.

After
----------------------------------------

The system status-check will warn if any search-displays appear to have problems. For example:

![Screenshot from 2024-12-19 21-50-40](https://github.com/user-attachments/assets/2b7db69a-3f0a-472d-bc91-34e973ba9b59)

Comments
----------------------------------------

This is inspired by #31632 (*though not strictly dependent*) -- under one draft of #31632, there would be a de-facto change in schema. Items of type "DB Entity" would no longer export a field named `_row` (*row-number*). Any downstream `Display`s that consume this field would therefore lose access. The sysadmin should review affected `Display` and decide what to do (*drop the reference to `_row`... or replace it with `id`... or something else...*).

The current validation succeeds at detecting when there's a stale `_row` reference, but...

It's generally a pretty naive validation. I  believe I'm getting some false-negatives with stock data. @colemanw, do you see how we make a more realistic validation?