### PR TITLE
dev/core#5581 Expose php & smarty compatibility

### DIFF
--- a/CRM/Extension/Info.php
+++ b/CRM/Extension/Info.php
@@ -112,6 +112,18 @@ class CRM_Extension_Info {
   public $compatibility;
 
   /**
+   * @var array
+   *   Ex: ['ver' => '8.4']
+   */
+  public $php_compatibility;
+
+  /**
+   * @var array
+   *   Ex: ['ver' => '5']
+   */
+  public $smarty_compatibility;
+
+  /**
    * @var string|null
    */
   public $description;

--- a/templates/CRM/Admin/Page/ExtensionDetails.tpl
+++ b/templates/CRM/Admin/Page/ExtensionDetails.tpl
@@ -60,15 +60,39 @@
     </tr>
     {/if}
     <tr>
-        <td class="label">{ts}Compatible with{/ts}</td>
-        <td>
-            {if $extension.compatibility}
-                {foreach from=$extension.compatibility.ver item=ver}
-                    {$ver|escape} &nbsp;
-                {/foreach}
-            {/if}
-        </td>
-    </tr>
+      <td class="label">{ts}Compatible with CiviCRM version{/ts}</td>
+      <td>
+        {if $extension.compatibility}
+          {foreach from=$extension.compatibility.ver item=ver}
+            {$ver|escape} &nbsp;
+          {/foreach}
+        {/if}
+      </td>
+  </tr>
+  <tr>
+    <td class="label">{ts}Compatible with PHP version{/ts}</td>
+    <td>
+      {if $extension.php_compatibility}
+        {foreach from=$extension.php_compatibility.ver item=ver}
+          {$ver|escape} &nbsp;
+        {/foreach}
+      {else}
+        {ts}Unknown{/ts}
+      {/if}
+    </td>
+  </tr>
+  <tr>
+    <td class="label">{ts}Compatible with Smarty version{/ts}</td>
+    <td>
+      {if $extension.smarty_compatibility}
+        {foreach from=$extension.smarty_compatibility.ver item=ver}
+          {$ver|escape} &nbsp;
+        {/foreach}
+      {else}
+        {ts}Unknown{/ts}
+      {/if}
+    </td>
+  </tr>
     <tr>
       <td class="label">{ts}License{/ts}</td><td>{$extension.license|escape}</td>
     </tr>


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5581 Expose php & smarty compatibility

Before
----------------------------------------
No visibility over whether extensions are compatible with various smarty & php versions. For example recent releases of extendedreports are not compatible with smarty 2 and recent Omnipay is not compatible with PHP 7.4 - however there is no clue to that in the UI or the extension download system. In both cases they could cause obscure hard fails so this could be important information.

After
----------------------------------------
The compatibility can now be declared in the same way as the CiviCRM compatibility. At this point very few extensions will be declaring their compatibility so it will be of limited use to end users - but with the facility to declare it we can start to add the declarations into extensions

![image](https://github.com/user-attachments/assets/4b61d282-3a4a-47e9-bc0d-02c7fce54e46)

![image](https://github.com/user-attachments/assets/64479c7a-0a4d-4e32-a6af-c7783ed22182)



Technical Details
----------------------------------------

Comments
----------------------------------------
