### PR TITLE
Increment minimum PHP version for 5.82

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -35,12 +35,12 @@ class CRM_Upgrade_Incremental_General {
    *
    * A site running an earlier version will be told to upgrade.
    */
-  const MIN_RECOMMENDED_PHP_VER = '8.1.0';
+  const MIN_RECOMMENDED_PHP_VER = '8.2.0';
 
   /**
    * The minimum PHP version required to install Civi.
    */
-  const MIN_INSTALL_PHP_VER = '7.4.0';
+  const MIN_INSTALL_PHP_VER = '8.0.0';
 
   /**
    * The minimum recommended MySQL version.

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
   "include-path": ["vendor/tecnickcom"],
   "config": {
     "platform": {
-      "php": "7.4.0"
+      "php": "8.0.0"
     },
     "allow-plugins": {
       "civicrm/composer-compile-plugin": true,
@@ -51,7 +51,7 @@
     }
   },
   "require": {
-    "php": "~7.4 || ~8",
+    "php": "~8",
     "composer-runtime-api": "~2.0",
     "dompdf/dompdf" : "~2.0.4",
     "firebase/php-jwt": ">=3 <7",


### PR DESCRIPTION
per https://civicrm.org/blog/eileen/php-74-going-end-life-php-84-ramping