### PR TITLE
Fix Smarty notice - never assigned `$fieldHandle`

### DIFF
--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -77,7 +77,7 @@
                           <span class='crm-price-amount-tax'> + {$option.tax_amount|crmMoney:$currency} {$taxTerm}</span>
                         {/if}
                       {else}
-                        {$option.amount|crmMoney:$currency} {$fieldHandle} {$form.$fieldHandle.frozen}
+                        {$option.amount|crmMoney:$currency}
                       {/if}
                       {if $form.$element_name.frozen EQ 1} ({ts}Sold out{/ts}){/if}
                     {/foreach}


### PR DESCRIPTION
Overview
----------------------------------------
Fix Smarty notice

Before
----------------------------------------
PHP log showing

 PHP Warning:  Trying to access array offset on value of type null in /path/wp-content/uploads/civicrm/templates_c/en_NZ/e2/d9/b0/e2d9b0d794561b513b14a81d3fb80623ce8d8df2_0.file_PriceSet.tpl.php on line 194


After
----------------------------------------
Gone

Technical Details
----------------------------------------
@demeritcowboy you were the last one to touch this code - but the variable `fieldHandle` was introduced in https://github.com/civicrm/civicrm-core/commit/4dd3f46d35b13a7efe469c4ab0c366c399235e01#diff-f9c22197c63b9059fa937e2d5dd3a15974f08b9ce3adec45613bdf53f06a887eR87 - it honestly looks like it was always a mistake because there is nothing in the commit that assigns it & no clear reason for adding it. I grepped for `Handle` (case sensitive) and didn't find anything

@JKingsnorth you were involved in the JIRA & commits that added it .... 
https://github.com/civicrm/civicrm-core/pull/4692/files
https://github.com/civicrm/civicrm-core/pull/4715/files
https://github.com/JKingsnorth/civicrm-core/commit/dc0ee906ed6f7525587275387c7f2b0488a6ca71


Comments
----------------------------------------
