### PR TITLE
Smarty notice fix on campaign

### DIFF
--- a/templates/CRM/Mailing/Page/Report.tpl
+++ b/templates/CRM/Mailing/Page/Report.tpl
@@ -206,7 +206,7 @@
 {if $public_url}
   <tr><td class="label">{ts}Public url{/ts}</td><td><a href="{$public_url}"> {$public_url}</a></td></tr>
 {/if}
-{if $report.mailing.campaign}
+{if array_key_exists('campaign', $report.mailing) && $report.mailing.campaign}
   <tr><td class="label">{ts}Campaign{/ts}</td><td>{$report.mailing.campaign}</td></tr>
 {/if}
 </table>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes notice



Before
----------------------------------------
PHP Warning:  Undefined array key "campaign" in /path/wp-content/uploads/civicrm/templates_c/en_NZ/22/dc/d8/22dcd8015a99784b78588bcb1ed8caae2e5b9bdf_0.file_Report.tpl.php on line 889

After
----------------------------------------
Fixed

Technical Details
----------------------------------------

Comments
----------------------------------------
