### PR TITLE
Fix missing membershiplog entries and add tests following #30493

### DIFF
--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -9,6 +9,9 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\MembershipLog;
+use Civi\Api4\MembershipStatus;
+
 /**
  * Class CRM_Member_BAO_MembershipTest
  * @group headless
@@ -600,6 +603,19 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
 
     $this->assertEquals($createdMembershipID, $membershipAfterProcess['id']);
     $this->assertArrayNotHasKey('status_override_end_date', $membershipAfterProcess);
+
+    // Check that MembershipLog was created and is correct
+    $latestMembershipLog = MembershipLog::get(FALSE)
+      ->addWhere('membership_id', '=', $createdMembershipID)
+      ->addOrderBy('id', 'DESC')
+      ->execute()
+      ->first();
+    $newMembershipStatus = MembershipStatus::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('name', '=', 'New')
+      ->execute()
+      ->first();
+    $this->assertEquals($newMembershipStatus['id'], $latestMembershipLog['status_id']);
   }
 
   /**
@@ -630,6 +646,19 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
 
     $this->assertEquals($createdMembershipID, $membershipAfterProcess['id']);
     $this->assertArrayNotHasKey('status_override_end_date', $membershipAfterProcess);
+
+    // Check that MembershipLog was created and is correct
+    $latestMembershipLog = MembershipLog::get(FALSE)
+      ->addWhere('membership_id', '=', $createdMembershipID)
+      ->addOrderBy('id', 'DESC')
+      ->execute()
+      ->first();
+    $newMembershipStatus = MembershipStatus::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('name', '=', 'New')
+      ->execute()
+      ->first();
+    $this->assertEquals($newMembershipStatus['id'], $latestMembershipLog['status_id']);
   }
 
   /**
@@ -659,6 +688,14 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
 
     $this->assertEquals($createdMembershipID, $membershipAfterProcess['id']);
     $this->assertEquals(1, $membershipAfterProcess['is_override']);
+
+    // Check that MembershipLog was created and is correct
+    $latestMembershipLog = MembershipLog::get(FALSE)
+      ->addWhere('membership_id', '=', $createdMembershipID)
+      ->addOrderBy('id', 'DESC')
+      ->execute()
+      ->first();
+    $this->assertEquals($this->_membershipStatusID, $latestMembershipLog['status_id']);
   }
 
   /**

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -708,6 +708,8 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
     $params['end_event'] = 'end_date';
     $params['is_current_member'] = 1;
     $params['is_active'] = 1;
+    // Make sure weight is after existing statuses (could be cleverer and get max(weight) first).
+    $params['weight'] = 100;
 
     $result = $this->callAPISuccess('MembershipStatus', 'Create', $params);
     CRM_Member_PseudoConstant::flush('membershipStatus');

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -222,15 +222,15 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $memberships = $this->callAPISuccess('Membership', 'get', ['sort' => 'contact_id', 'sequential' => 1])['values'];
 
     $this->assertEquals($contactId1, $memberships[0]['contact_id']);
-    $this->assertEquals('test status', CRM_Core_PseudoConstant::getName('CRM_Member_BAO_Membership', 'status_id', $memberships[0]['status_id']));
+    $this->assertEquals('New', CRM_Core_PseudoConstant::getName('CRM_Member_BAO_Membership', 'status_id', $memberships[0]['status_id']));
 
     // check for Membership 2
     $this->assertEquals($contactId2, $memberships[1]['contact_id']);
-    $this->assertEquals('test status', CRM_Core_PseudoConstant::getName('CRM_Member_BAO_Membership', 'status_id', $memberships[1]['status_id']));
+    $this->assertEquals('New', CRM_Core_PseudoConstant::getName('CRM_Member_BAO_Membership', 'status_id', $memberships[1]['status_id']));
 
     // check for Membership 3
     $this->assertEquals($contactId3, $memberships[2]['contact_id']);
-    $this->assertEquals('test status', CRM_Core_PseudoConstant::getName('CRM_Member_BAO_Membership', 'status_id', $memberships[2]['status_id']));
+    $this->assertEquals('New', CRM_Core_PseudoConstant::getName('CRM_Member_BAO_Membership', 'status_id', $memberships[2]['status_id']));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
I missed that creation of the MembershipLog record was hidden in the `CRM_Member_BAO_Membership::add()` function and it wasn't checked for by any tests so it got missed following #30493.

Before
----------------------------------------
Missing MembershipLog records when updated via API3 `Job.process_membership`.

After
----------------------------------------
MembershipLog records created and tests updated to check for valid MembershipLog records.

Technical Details
----------------------------------------
Function extracted to create a MembershipLog record. Marked as internal so we can change/refactor further.

Comments
----------------------------------------
Regression since 5.76

Will add a couple more tests but cannot get tests to run locally so pushing up here draft first.
