### PR TITLE
dev/core#5653 - Add screen tip for URL filter to show format should be "#/?field=value"

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
@@ -23,7 +23,7 @@
             </li>
           </ul>
         </div>
-        <input ng-if="filter.mode === 'routeParams'" class="form-control" ng-model="filter.value" title="{{:: ts('Append %1 to the URL to pass a parameter value to the form' , {1: '\'#/?' + filter.value + '=value\''}) }}" />
+        <input ng-if="filter.mode === 'routeParams'" class="form-control" ng-model="filter.value" title="{{ ts('Append %1 to the URL to pass a parameter value to the form' , {1: '\'#/?' + filter.value + '=value\''}) }}" />
         <span ng-if="filter.mode === 'val'">
           <input class="form-control" af-gui-field-value="getField($ctrl.getFieldEntity(filter.name), filter.name)" ng-model="filter.value" />
         </span>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
@@ -23,7 +23,7 @@
             </li>
           </ul>
         </div>
-        <input ng-if="filter.mode === 'routeParams'" class="form-control" ng-model="filter.value" title="Append '#/?{{ filter.value }}=value' to URL to pass parameter value to form." />
+        <input ng-if="filter.mode === 'routeParams'" class="form-control" ng-model="filter.value" title="{{:: ts('Append %1 to the URL to pass a parameter value to the form' , {1: '\'#/?' + filter.value + '=value\''}) }}" />
         <span ng-if="filter.mode === 'val'">
           <input class="form-control" af-gui-field-value="getField($ctrl.getFieldEntity(filter.name), filter.name)" ng-model="filter.value" />
         </span>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
@@ -23,7 +23,7 @@
             </li>
           </ul>
         </div>
-        <input ng-if="filter.mode === 'routeParams'" class="form-control" ng-model="filter.value" />
+        <input ng-if="filter.mode === 'routeParams'" class="form-control" ng-model="filter.value" title="Append '#/?{{ filter.value }}=value' to URL to pass parameter value to form." />
         <span ng-if="filter.mode === 'val'">
           <input class="form-control" af-gui-field-value="getField($ctrl.getFieldEntity(filter.name), filter.name)" ng-model="filter.value" />
         </span>


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5653

Before
----------------------------------------
No screen tip

After
----------------------------------------
Add screen tip to show correct format to pass value to form in URL when URL filter is selected

