### PR TITLE
[REF][PHP8.2]  Fix typo in property name

### DIFF
--- a/CRM/Mailing/Selector/Event.php
+++ b/CRM/Mailing/Selector/Event.php
@@ -31,9 +31,9 @@ class CRM_Mailing_Selector_Event extends CRM_Core_Selector_Base implements CRM_C
 
   /**
    * What event type are we browsing?
-   * @var sting
+   * @var string
    */
-  private $_event;
+  private $_event_type;
 
   /**
    * Should we only count distinct contacts?


### PR DESCRIPTION
Overview
----------------------------------------
Fix typo in property name.

Before
----------------------------------------

- `_event_type` was not declared, causing deprecation notices.
- `_event` was declared, but never used.

Therefore it seems fairly clear that `_event` was a typo, which was meant to be `_event_type`.

After
----------------------------------------
The declaration of `_event` has been updated to the correct `_event_type`.