### PR TITLE
[REF][PHP8.2] Decalare properties - CRM_Contact_Form_Merge

### DIFF
--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -19,15 +19,66 @@
  * Class CRM_Contact_Form_Merge.
  */
 class CRM_Contact_Form_Merge extends CRM_Core_Form {
-  // The id of the contact that there's a duplicate for; this one will
+
   /**
+   * Rule group ID
+   *
+   * @var int
+   */
+  public $_rgid;
+
+  /**
+   * Group ID
+   *
+   * @var int
+   */
+  public $_gid;
+
+  /**
+   * @var int
+   */
+  public $_mergeId;
+
+  /**
+   * The URL to view the "next" mergeable contact
+   *
+   * @var string|null
+   */
+  public $next = NULL;
+
+  /**
+   * The URL to view the "previous" mergeable contact
+   *
+   * @var string|null
+   */
+  public $prev = NULL;
+
+  /**
+   * Details about the main contact, required for the merge handler and UI.
+   *
+   * @var array
+   */
+  protected $_mainDetails;
+
+  /**
+   * Details about the other contact, required for the merge handler and UI.
+   *
+   * @var array
+   */
+  protected $_otherDetails;
+
+
+  /**
+   * The id of the contact that there's a duplicate for; this one will
    * possibly inherit some of $_oid's properties and remain in the system.
+   *
    * @var int
    */
   public $_cid = NULL;
 
   /**
    * The id of the other contact - the duplicate one that will get deleted.
+   *
    * @var int
    */
   public $_oid = NULL;
@@ -35,7 +86,9 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
   public $_contactType = NULL;
 
   /**
-   * @var array
+   * JSON encoded string
+   *
+   * @var string
    */
   public $criteria = [];
 


### PR DESCRIPTION
Overview
----------------------------------------
Decalare properties - `CRM_Contact_Form_Merge`

Before
----------------------------------------
Many PHP deprecation notices were triggered when merging contacts (on the `civicrm/contact/merge` path)

After
----------------------------------------
Properties.

Technical Details
----------------------------------------
I've seen quite a few cases where this screen has been hooked into and extended, and so it feels safe to leave the properties public.