### PR TITLE
(NFC) Cast null to string for explode

### DIFF
--- a/CRM/Member/Form/MembershipBlock.php
+++ b/CRM/Member/Form/MembershipBlock.php
@@ -119,7 +119,7 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
       $paymentProcessorIds = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_ContributionPage',
         $this->_id, 'payment_processor'
       );
-      $paymentProcessorId = explode(CRM_Core_DAO::VALUE_SEPARATOR, $paymentProcessorIds);
+      $paymentProcessorId = explode(CRM_Core_DAO::VALUE_SEPARATOR, $paymentProcessorIds ?? '');
       $isRecur = TRUE;
       foreach ($paymentProcessorId as $id) {
         if (!array_key_exists($id, $paymentProcessor)) {


### PR DESCRIPTION
Overview
----------------------------------------
`$paymentProcessorIds` might be null. This casts `null` to an empty string so that modern PHP doesn't complain.
