### PR TITLE
dev/core#4782 (alternate) to 28191 - don't crash when memory engine not available

### DIFF
--- a/CRM/Utils/SQL/TempTable.php
+++ b/CRM/Utils/SQL/TempTable.php
@@ -317,6 +317,9 @@ class CRM_Utils_SQL_TempTable {
    * @return $this
    */
   public function setMemory($value = TRUE) {
+    if ($value && !CRM_Utils_SQL::isUnvexedMemoryEngineAvailable()) {
+      $value = FALSE;
+    }
     $this->memory = $value;
     return $this;
   }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2355,6 +2355,16 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
    *   Whether to use nesting or reference-counting.
    */
   public function useTransaction($nest = TRUE) {
+    // Prime this now so it doesn't cause problems in db transactions.
+    // We need the env var because otherwise the cache keeps getting cleared
+    // and then it causes problems anyway.
+    if (CRM_Utils_SQL::isUnvexedMemoryEngineAvailable()) {
+      putenv('CIVICRM_MEMORY_ENGINE_AVAILABLE=1');
+    }
+    else {
+      putenv('CIVICRM_MEMORY_ENGINE_AVAILABLE=0');
+    }
+
     if (!$this->tx) {
       $this->tx = new CRM_Core_Transaction($nest);
       $this->tx->rollback();


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4782

Before
----------------------------------------
Crash

After
----------------------------------------
Not crash

Technical Details
----------------------------------------
The problem we ran into in #28191 is that unit tests than run in transactions were failing. So this moves the check, and then we cache it. But during unit tests there's still a gotcha because the cache gets cleared, so we also introduce an environment variable.

Comments
----------------------------------------

