### PR TITLE
SearchKit - Add labels for joins

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -251,6 +251,21 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
       // Set by mysql
       unset($event->params['modified_date']);
 
+      // Delete empty form values and save as null if completely empty
+      if (isset($event->params['form_values']) && is_array($event->params['form_values'])) {
+        // Exclude legacy smart groups by checking if api_entity is set
+        if (!empty($event->params['api_entity'])) {
+          foreach ($event->params['form_values'] as $key => $value) {
+            if (is_array($value) && !$value) {
+              unset($event->params['form_values'][$key]);
+            }
+          }
+          if (!$event->params['form_values']) {
+            $event->params['form_values'] = '';
+          }
+        }
+      }
+
       // Flush angular caches to refresh search displays
       if (isset($event->params['api_params'])) {
         Civi::container()->get('angular')->clear();

--- a/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
+++ b/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
@@ -445,7 +445,7 @@ trait SavedSearchInspectorTrait {
           $joinCount[$entityName] = 1;
         }
         $label = CoreUtil::getInfoItem($entityName, 'title');
-        $this->_joinMap[$alias] = $label . $num;
+        $this->_joinMap[$alias] = $this->savedSearch['form_values']['join'][$alias] ?? "$label$num";
       }
     }
     return $this->_joinMap[$joinAlias];

--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -173,7 +173,7 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
             ->setSavedSearch($displayTag['search-name']);
         }
         $display = $displayGet
-          ->addSelect('*', 'type:name', 'type:icon', 'saved_search_id.name', 'saved_search_id.label', 'saved_search_id.api_entity', 'saved_search_id.api_params')
+          ->addSelect('*', 'type:name', 'type:icon', 'saved_search_id.name', 'saved_search_id.label', 'saved_search_id.api_entity', 'saved_search_id.api_params', 'saved_search_id.form_values')
           ->execute()->first();
         if (!$display) {
           continue;

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
@@ -128,21 +128,23 @@
         countEntity(mainEntity.entity);
 
         _.each(ctrl.display.settings['saved_search_id.api_params'].join, function(join) {
-          var joinInfo = join[0].split(' AS '),
-            entity = afGui.getEntity(joinInfo[0]),
-            joinEntity = afGui.getEntity(join[2]);
+          const joinInfo = join[0].split(' AS ');
+          const entity = afGui.getEntity(joinInfo[0]);
+          const bridgeEntity = afGui.getEntity(join[2]);
+          const defaultLabel = entity.label + countEntity(entity.entity);
+          const formValues = ctrl.display.settings['saved_search_id.form_values'] || {};
           entities.push({
             name: entity.entity,
             prefix: joinInfo[1] + '.',
-            label: entity.label + countEntity(entity.entity),
+            label: (formValues && formValues.join && formValues.join[joinInfo[1]]) || defaultLabel,
             fields: entity.fields,
           });
-          if (joinEntity) {
+          if (bridgeEntity) {
             entities.push({
-              name: joinEntity.entity,
+              name: bridgeEntity.entity,
               prefix: joinInfo[1] + '.',
-              label: joinEntity.label + countEntity(joinEntity.entity),
-              fields: _.omit(joinEntity.fields, _.keys(entity.fields)),
+              label: bridgeEntity.label + countEntity(bridgeEntity.entity),
+              fields: _.omit(bridgeEntity.fields, _.keys(entity.fields)),
             });
           }
         });

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearch-for.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearch-for.html
@@ -6,7 +6,10 @@
   <fieldset ng-repeat="join in $ctrl.savedSearch.api_params.join" class="crm-search-join">
     <div class="form-inline">
       <select class="form-control" ng-model="join[1]" ng-change="$ctrl.changeJoinType(join)" ng-options="o.k as o.v for o in ::joinTypes" ></select>
-      <input id="crm-search-join-{{ $index }}" class="form-control huge" ng-model="join[0]" crm-ui-select="{placeholder: ' ', data: getJoinEntities}" disabled >
+      <div class="input-group">
+        <span class="input-group-addon" title="{{:: getJoin(join[0]).defaultLabel }}"><i class="crm-i {{:: getJoin(join[0]).icon }}"></i></span>
+        <input class="form-control crm-search-join-label huge" ng-model="$ctrl.getSetJoinLabel(join[0])" ng-model-options="{getterSetter: true, updateOn: 'blur'}" placeholder="{{:: getJoin(join[0]).defaultLabel }}" title="{{:: ts('Optional label for this join') }}">
+      </div>
       <button type="button" class="btn btn-xs btn-danger-outline" ng-click="$ctrl.removeJoin($index)" title="{{:: ts('Remove join') }}">
         <i class="crm-i fa-trash" aria-hidden="true"></i>
       </button>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -90,6 +90,8 @@
       this.entityTitle = searchMeta.getEntity(this.savedSearch.api_entity).title_plural;
 
       this.savedSearch.displays = this.savedSearch.displays || [];
+      this.savedSearch.form_values = this.savedSearch.form_values || {};
+      this.savedSearch.form_values.join = this.savedSearch.form_values.join || {};
       this.savedSearch.groups = this.savedSearch.groups || [];
       this.savedSearch.tag_id = this.savedSearch.tag_id || [];
       this.groupExists = !!this.savedSearch.groups.length;
@@ -128,6 +130,8 @@
           default: ctrl.savedSearch.label
         });
       }
+
+      $scope.getJoin = _.wrap(this.savedSearch, searchMeta.getJoin);
 
       $scope.mainEntitySelect = searchMeta.getPrimaryAndSecondaryEntitySelect();
 
@@ -289,7 +293,7 @@
     $scope.selectTab = function(tab) {
       if (tab === 'group') {
         loadFieldOptions('Group');
-        $scope.smartGroupColumns = searchMeta.getSmartGroupColumns(ctrl.savedSearch.api_entity, ctrl.savedSearch.api_params);
+        $scope.smartGroupColumns = searchMeta.getSmartGroupColumns(ctrl.savedSearch);
         var smartGroupColumns = _.map($scope.smartGroupColumns, 'id');
         if (smartGroupColumns.length && !_.includes(smartGroupColumns, ctrl.savedSearch.api_params.select[0])) {
           ctrl.savedSearch.api_params.select.unshift(smartGroupColumns[0]);
@@ -316,11 +320,9 @@
 
     function getExistingJoins() {
       return _.transform(ctrl.savedSearch.api_params.join || [], function(joins, join) {
-        joins[join[0].split(' AS ')[1]] = searchMeta.getJoin(join[0]);
+        joins[join[0].split(' AS ')[1]] = searchMeta.getJoin(ctrl.savedSearch, join[0]);
       }, {});
     }
-
-    $scope.getJoin = searchMeta.getJoin;
 
     $scope.getJoinEntities = function() {
       var existingJoins = getExistingJoins();
@@ -362,8 +364,8 @@
     this.addJoin = function(value) {
       if (value) {
         ctrl.savedSearch.api_params.join = ctrl.savedSearch.api_params.join || [];
-        var join = searchMeta.getJoin(value),
-          entity = searchMeta.getEntity(join.entity),
+        var join = searchMeta.getJoin(ctrl.savedSearch, value),
+          entity = searchMeta.getEntity(ctrl.savedSearch, join.entity),
           params = [value, $scope.controls.joinType || 'LEFT'];
         _.each(_.cloneDeep(join.conditions), function(condition) {
           params.push(condition);
@@ -388,9 +390,27 @@
       }
     };
 
+    // Factory returns a getter-setter function for ngModel
+    this.getSetJoinLabel = function(joinName) {
+      return _.wrap(joinName, getSetJoinLabel);
+    };
+
+    function getSetJoinLabel(joinName, value) {
+      const joinInfo = searchMeta.getJoin(ctrl.savedSearch, joinName);
+      const alias = joinInfo.alias;
+      // Setter
+      if (arguments.length > 1) {
+        ctrl.savedSearch.form_values.join[alias] = value;
+        if (!value || value === joinInfo.defaultLabel) {
+          delete ctrl.savedSearch.form_values.join[alias];
+        }
+      }
+      return ctrl.savedSearch.form_values.join[alias] || joinInfo.defaultLabel;
+    }
+
     // Remove an explicit join + all SELECT, WHERE & other JOINs that use it
     this.removeJoin = function(index) {
-      var alias = searchMeta.getJoin(ctrl.savedSearch.api_params.join[index][0]).alias;
+      var alias = searchMeta.getJoin(ctrl.savedSearch, ctrl.savedSearch.api_params.join[index][0]).alias;
       ctrl.clearParam('join', index);
       removeJoinStuff(alias);
     };
@@ -404,16 +424,17 @@
         return clauseUsesJoin(clause, alias);
       });
       _.eachRight(ctrl.savedSearch.api_params.join, function(item, i) {
-        var joinAlias = searchMeta.getJoin(item[0]).alias;
+        var joinAlias = searchMeta.getJoin(ctrl.savedSearch, item[0]).alias;
         if (joinAlias !== alias && joinAlias.indexOf(alias) === 0) {
           ctrl.removeJoin(i);
         }
       });
+      delete ctrl.savedSearch.form_values.join[alias];
     }
 
     this.changeJoinType = function(join) {
       if (join[1] === 'EXCLUDE') {
-        removeJoinStuff(searchMeta.getJoin(join[0]).alias);
+        removeJoinStuff(searchMeta.getJoin(ctrl.savedSearch, join[0]).alias);
       }
     };
 
@@ -639,7 +660,7 @@
         result = [];
 
       function addJoin(join) {
-        var joinInfo = searchMeta.getJoin(join),
+        let joinInfo = searchMeta.getJoin(ctrl.savedSearch, join),
           joinEntity = searchMeta.getEntity(joinInfo.entity);
         result.push({
           text: joinInfo.label,
@@ -702,7 +723,7 @@
 
       // Join entities + bridge entities
       _.each(ctrl.savedSearch.api_params.join, function(join) {
-        var joinInfo = searchMeta.getJoin(join[0]);
+        var joinInfo = searchMeta.getJoin(ctrl.savedSearch, join[0]);
         entitiesToLoad.push(joinInfo.entity);
         if (joinInfo.bridge) {
           entitiesToLoad.push(joinInfo.bridge);
@@ -733,7 +754,7 @@
       });
       // Links to explicitly joined entities
       _.each(ctrl.savedSearch.api_params.join, function(joinClause) {
-        var join = searchMeta.getJoin(joinClause[0]),
+        var join = searchMeta.getJoin(ctrl.savedSearch, joinClause[0]),
           joinEntity = searchMeta.getEntity(join.entity),
           bridgeEntity = _.isString(joinClause[2]) ? searchMeta.getEntity(joinClause[2]) : null;
         _.each(_.cloneDeep(joinEntity.links), function(link) {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -147,7 +147,7 @@
 
       this.getFieldLabel = function(key) {
         var expr = ctrl.getExprFromSelect(selectToKey(key));
-        return searchMeta.getDefaultLabel(expr);
+        return searchMeta.getDefaultLabel(expr, ctrl.savedSearch);
       };
 
       this.getColLabel = function(col) {

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
@@ -74,6 +74,10 @@
         ctrl.crmSearchAdmin.clearParam('select', index);
       };
 
+      $scope.getColumnLabel = function(index) {
+        return searchMeta.getDefaultLabel(ctrl.search.api_params.select[index], ctrl.search);
+      };
+
     }
   });
 

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html
@@ -11,7 +11,7 @@
         </th>
         <th ng-repeat="item in $ctrl.search.api_params.select" ng-click="$ctrl.setSort($ctrl.settings.columns[$index], $event)" title="{{$index || !$ctrl.crmSearchAdmin.groupExists ? ts('Drag to reorder columns, click to sort results (shift-click to sort by multiple).') : ts('Column reserved for smart group.')}}">
           <i ng-if=":: $ctrl.isSortable($ctrl.settings.columns[$index])" class="crm-i {{ $ctrl.getSort($ctrl.settings.columns[$index]) }}"></i>
-          <span ng-class="{'crm-draggable': $index || !$ctrl.crmSearchAdmin.groupExists}">{{ $ctrl.settings.columns[$index].label }}</span>
+          <span ng-class="{'crm-draggable': $index || !$ctrl.crmSearchAdmin.groupExists}">{{ getColumnLabel($index) }}</span>
           <span ng-switch="$index || !$ctrl.crmSearchAdmin.groupExists ? 'sortable' : 'locked'">
             <i ng-switch-when="locked" class="crm-i fa-lock" aria-hidden="true"></i>
             <a href ng-switch-default class="crm-hover-button" title="{{:: ts('Clear') }}" ng-click="removeColumn($index); $event.stopPropagation();"><i class="crm-i fa-times" aria-hidden="true"></i></a>


### PR DESCRIPTION
Overview
----------------------------------------
Enables SearchKit joins to be labelled.

Before
----------------------------------------
Adding multiple joins to the same entity creates sequential entity labels, i.e. "Contact Activities", "Contact Activities 2", ...).
These labels can be hard to work with as you'd have to remember which label is associated with which criteria. 

After
----------------------------------------
The user can now set the label when joining entities, so you' could use something like "Email Activity" for the first join, "Meeting Activity" for the second, etc.

