### PR TITLE
Afform - Fix default showing literal 'undefined'

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -436,7 +436,7 @@
           }
           return val;
         }
-        return $scope.getProp(propName);
+        return $scope.getProp(propName) || '';
       }
       this.getSet = getSet;
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes quirk when adding a default value to an Afform field

Before
----------------------------------------
1. Add a text field to a form
2. Click on the gear and enable a default value:
![image](https://github.com/user-attachments/assets/70768680-6201-4c82-95c7-a8fac8f91f89)



After
----------------------------------------
Instead of literally 'undefined' it will be blank.
