### PR TITLE
Ensure null is not passed to htmlentities

### DIFF
--- a/CRM/Activity/BAO/ActivityContact.php
+++ b/CRM/Activity/BAO/ActivityContact.php
@@ -82,8 +82,8 @@ AND        contact_a.is_deleted = 0
 
     $dao = CRM_Core_DAO::executeQuery($query, $params);
     while ($dao->fetch()) {
-      $names[$dao->id] = htmlentities($dao->sort_name);
-      $ids[] = $dao->id;
+      $names[(int) $dao->id] = htmlentities((string) $dao->sort_name);
+      $ids[] = (int) $dao->id;
     }
 
     return $alsoIDs ? [$names, $ids] : $names;


### PR DESCRIPTION
Overview
----------------------------------------
Ensure null is not passed to `htmlentities()`

Before
----------------------------------------
NULL potentially passed to `htmlentities()`

After
----------------------------------------
null cast to a string first

Technical Details
----------------------------------------
I'm seeing this in a dev environment and don't know it would show up on a 'real' site - however it still seems worth fixing as on a high enough php version it would be a fatal - which feels like it would create unnecessary debugging / headaches

Comments
----------------------------------------
