### PR TITLE
[WIP] dev/core#5652 - country list is wrong

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1302,10 +1302,23 @@ SELECT is_primary,
 
   /**
    * Silly wrapper because the entity callback passes in different vars than
-   * the pseudoconstant takes.
+   * the pseudoconstant takes, and wants a different result format back.
+   *
+   * Note the pseudoconstant only ever returned active countries.
    */
   public static function pseudoconstantCountry($dummy, $dummy2) {
-    return CRM_Core_PseudoConstant::country();
+    $countries = CRM_Core_PseudoConstant::country();
+    $reformatted = [];
+    foreach ($countries as $id => $country) {
+      $reformatted[] = [
+        'id' => $id,
+        'label' => $country,
+        'name' => CRM_Core_PseudoConstant::countryIsoCode($id),
+        'abbr' => CRM_Core_PseudoConstant::countryIsoCode($id),
+        'is_active' => 1,
+      ];
+    }
+    return $reformatted;
   }
 
   /**

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1301,27 +1301,6 @@ SELECT is_primary,
   }
 
   /**
-   * Silly wrapper because the entity callback passes in different vars than
-   * the pseudoconstant takes, and wants a different result format back.
-   *
-   * Note the pseudoconstant only ever returned active countries.
-   */
-  public static function pseudoconstantCountry($dummy, $dummy2) {
-    $countries = CRM_Core_PseudoConstant::country();
-    $reformatted = [];
-    foreach ($countries as $id => $country) {
-      $reformatted[] = [
-        'id' => $id,
-        'label' => $country,
-        'name' => CRM_Core_PseudoConstant::countryIsoCode($id),
-        'abbr' => CRM_Core_PseudoConstant::countryIsoCode($id),
-        'is_active' => 1,
-      ];
-    }
-    return $reformatted;
-  }
-
-  /**
    * Pseudoconstant condition_provider for county_id field.
    * @see \Civi\Schema\EntityMetadataBase::getConditionFromProvider
    */

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1301,6 +1301,14 @@ SELECT is_primary,
   }
 
   /**
+   * Silly wrapper because the entity callback passes in different vars than
+   * the pseudoconstant takes.
+   */
+  public static function pseudoconstantCountry($dummy, $dummy2) {
+    return CRM_Core_PseudoConstant::country();
+  }
+
+  /**
    * Pseudoconstant condition_provider for county_id field.
    * @see \Civi\Schema\EntityMetadataBase::getConditionFromProvider
    */

--- a/Civi/Schema/Entity/AddressMetadata.php
+++ b/Civi/Schema/Entity/AddressMetadata.php
@@ -29,9 +29,16 @@ class AddressMetadata extends SqlEntityMetadata {
         // It's currently indexed sequentially.
         $originalReindexed[$opt['id']] = $opt;
       }
-      // This sorting isn't identical to the pre-entity output because it used
-      // db rules whereas this is php, e.g. Åland Islands
-      asort($map);
+
+      // At the moment it's unsorted. The pre-entity output used the db for
+      // sorting. We don't know what all the mysql parameters are, but the
+      // strings right now are still all en_US, so let's just use that. It
+      // will get resorted in a minute according to locale if the civi locale
+      // is different anyway. If we just use asort() here, then e.g. Åland
+      // Islands is wrong.
+      $collator = new \Collator('en_US.utf8');
+      $collator->asort($map);
+
       $map = \CRM_Core_BAO_Country::_defaultContactCountries($map);
       // Now merge the format it wants back in
       $newOptions = [];

--- a/Civi/Schema/Entity/AddressMetadata.php
+++ b/Civi/Schema/Entity/AddressMetadata.php
@@ -32,7 +32,8 @@ class AddressMetadata extends SqlEntityMetadata {
         // There must be a better algorithm. Maybe reindex the original first so can just pull by key?
         foreach ($options as $opt) {
           if ($opt['id'] == $id) {
-            $newOptions[] = $opt;
+            // We may have translated the label in the map so we want that label.
+            $newOptions[] = array_merge($opt, ['label' => $country]);
             break;
           }
         }

--- a/Civi/Schema/Entity/AddressMetadata.php
+++ b/Civi/Schema/Entity/AddressMetadata.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Schema\Entity;
+
+use Civi\Schema\SqlEntityMetadata;
+
+class AddressMetadata extends SqlEntityMetadata {
+
+  public function getOptions(string $fieldName, array $values = [], bool $includeDisabled = FALSE, bool $checkPermissions = FALSE, ?int $userId = NULL): ?array {
+    $options = parent::getOptions($fieldName, $values, $includeDisabled, $checkPermissions, $userId);
+    if ($fieldName == 'country_id') {
+      $map = [];
+      foreach ($options as $opt) {
+        $map[$opt['id']] = $opt['label'];
+      }
+      // This sorting isn't identical to the pre-entity output because it used
+      // db rules whereas this is php, e.g. Åland Islands
+      asort($map);
+      $map = \CRM_Core_BAO_Country::_defaultContactCountries($map);
+      // Now merge the format it wants back in
+      $newOptions = [];
+      foreach ($map as $id => $country) {
+        // There must be a better algorithm. Maybe reindex the original first so can just pull by key?
+        foreach ($options as $opt) {
+          if ($opt['id'] == $id) {
+            $newOptions[] = $opt;
+            break;
+          }
+        }
+      }
+      $options = $newOptions;
+    }
+    return $options;
+  }
+
+}

--- a/schema/Core/Address.entityType.php
+++ b/schema/Core/Address.entityType.php
@@ -350,16 +350,7 @@ return [
         'label' => ts('Country'),
       ],
       'pseudoconstant' => [
-        'table' => 'civicrm_country',
-        'key_column' => 'id',
-        'label_column' => 'name',
-        'name_column' => 'iso_code',
-        'abbr_column' => 'iso_code',
-        'condition_provider' => ['CRM_Core_BAO_Address', 'alterCountry'],
-        'suffixes' => [
-          'label',
-          'abbr',
-        ],
+        'callback' => ['CRM_Core_BAO_Address', 'pseudoconstantCountry'],
       ],
       'entity_reference' => [
         'entity' => 'Country',

--- a/schema/Core/Address.entityType.php
+++ b/schema/Core/Address.entityType.php
@@ -4,6 +4,7 @@ return [
   'name' => 'Address',
   'table' => 'civicrm_address',
   'class' => 'CRM_Core_DAO_Address',
+  'metaProvider' => '\Civi\Schema\Entity\AddressMetadata',
   'getInfo' => fn() => [
     'title' => ts('Address'),
     'title_plural' => ts('Addresses'),
@@ -350,7 +351,16 @@ return [
         'label' => ts('Country'),
       ],
       'pseudoconstant' => [
-        'callback' => ['CRM_Core_BAO_Address', 'pseudoconstantCountry'],
+        'table' => 'civicrm_country',
+        'key_column' => 'id',
+        'label_column' => 'name',
+        'name_column' => 'iso_code',
+        'abbr_column' => 'iso_code',
+        'condition_provider' => ['CRM_Core_BAO_Address', 'alterCountry'],
+        'suffixes' => [
+          'label',
+          'abbr',
+        ],
       ],
       'entity_reference' => [
         'entity' => 'Country',

--- a/tests/phpunit/CRM/Core/BAO/AddressTest.php
+++ b/tests/phpunit/CRM/Core/BAO/AddressTest.php
@@ -26,6 +26,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
 
   public function tearDown(): void {
     \Civi::settings()->set('pinnedContactCountries', []);
+    CRM_Core_I18n::singleton()->setLocale('en_US');
     parent::tearDown();
   }
 
@@ -939,6 +940,52 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
     \Civi::settings()->set('pinnedContactCountries', ['1228']);
     $countries = \Civi::entity('Address')->getOptions('country_id');
     $this->assertEquals('US', $countries[0]['name']);
+  }
+
+  public function testCountryLabelTranslation(): void {
+    CRM_Core_I18n::singleton()->setLocale('nl_NL');
+    $countries = \Civi::entity('Address')->getOptions('country_id');
+    $checked = [];
+    foreach ($countries as $country) {
+      switch ($country['name']) {
+        case 'NL':
+          $this->assertEquals('Nederland', $country['label']);
+          $checked[] = 'NL';
+          break;
+
+        case 'US':
+          $this->assertEquals('Verenigde Staten', $country['label']);
+          $checked[] = 'US';
+          break;
+      }
+    }
+    $this->assertCount(2, $checked, 'Country list incomplete');
+  }
+
+  public function testCountrySorting(): void {
+    $countries = \Civi::entity('Address')->getOptions('country_id');
+    $this->assertEquals('AF', $countries[0]['name']);
+    // Åland Islands should sort second in en_US locale
+    $this->assertEquals('AX', $countries[1]['name']);
+    $this->assertEquals('AL', $countries[2]['name']);
+    $this->assertEquals('ZW', array_pop($countries)['name']);
+
+    CRM_Core_I18n::singleton()->setLocale('nl_NL');
+    $countries = \Civi::entity('Address')->getOptions('country_id');
+    $this->assertEquals('AF', $countries[0]['name']);
+    $this->assertEquals('AL', $countries[1]['name']);
+    $this->assertEquals('DZ', $countries[2]['name']);
+    // Åland Islands
+    $this->assertEquals('AX', array_pop($countries)['name']);
+
+    CRM_Core_I18n::singleton()->setLocale('it_IT');
+    $countries = \Civi::entity('Address')->getOptions('country_id');
+    $this->assertEquals('AF', $countries[0]['name']);
+    $this->assertEquals('AL', $countries[1]['name']);
+    $this->assertEquals('DZ', $countries[2]['name']);
+    // Åland Islands
+    $this->assertEquals('AX', $countries[114]['name']);
+    $this->assertEquals('ZW', array_pop($countries)['name']);
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/AddressTest.php
+++ b/tests/phpunit/CRM/Core/BAO/AddressTest.php
@@ -24,6 +24,11 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
     $this->quickCleanup(['civicrm_contact', 'civicrm_address']);
   }
 
+  public function tearDown(): void {
+    \Civi::settings()->set('pinnedContactCountries', []);
+    parent::tearDown();
+  }
+
   /**
    * Create() method (create and update modes)
    */
@@ -928,6 +933,12 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
     $this->assertEquals(1152, $availableCountries[1]);
     // United States
     $this->assertEquals(1228, $availableCountries[2]);
+  }
+
+  public function testPinnedCountryWithEntity(): void {
+    \Civi::settings()->set('pinnedContactCountries', ['1228']);
+    $countries = \Civi::entity('Address')->getOptions('country_id');
+    $this->assertEquals('US', $countries[0]['name']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5652

Before
----------------------------------------
Go to New Individual and open the address section. The country list isn't ordered properly and ignores pinned countries if you have set them.

After
----------------------------------------


Technical Details
----------------------------------------
This is obviously not the right fix, but points out where the problem is.

Also a real fix should be against 5.81.

Comments
----------------------------------------
Billing address fields like on a contribution page are probably still using the pseudoconstant so you won't see the problem there.
