### PR TITLE
SearchKit - Fix missing pseudofield label

### DIFF
--- a/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
+++ b/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
@@ -4,6 +4,7 @@ namespace Civi\Api4\Generic\Traits;
 
 use Civi\API\Exception\UnauthorizedException;
 use Civi\API\Request;
+use Civi\Api4\Action\SearchDisplay\AbstractRunAction;
 use Civi\Api4\Query\SqlEquation;
 use Civi\Api4\Query\SqlExpression;
 use Civi\Api4\Query\SqlField;
@@ -413,6 +414,10 @@ trait SavedSearchInspectorTrait {
     }
     elseif ($expr instanceof SqlField) {
       $field = $this->getField($expr->getExpr());
+      if (!$field) {
+        $pseudoFields = array_column(AbstractRunAction::getPseudoFields(), NULL, 'name');
+        $field = $pseudoFields[$expr->getExpr()] ?? NULL;
+      }
       $label = '';
       if (!empty($field['explicit_join'])) {
         $label = $this->getJoinLabel($field['explicit_join']) . ': ';


### PR DESCRIPTION
Overview
----------------------------------------
Fixes php warning and missing field label when using "Extra" fields like "Row Number" as columns.

Before
----------------------------------------
Using "Row Number" as a column, the default display is missing a label. PHP warning in logs.

After
----------------------------------------
Fixed.