### PR TITLE
SearchKit - Fix regression rendering relationship custom fields with options

### DIFF
--- a/Civi/Schema/Entity/RelationshipCacheMetadata.php
+++ b/Civi/Schema/Entity/RelationshipCacheMetadata.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Schema\Entity;
+
+use Civi\Schema\SqlEntityMetadata;
+
+class RelationshipCacheMetadata extends SqlEntityMetadata {
+
+  public function getCustomFields(array $customGroupFilters = []): array {
+    // Include relationship custom fields
+    $customGroupFilters += ['extends' => 'Relationship'];
+    return parent::getCustomFields($customGroupFilters);
+  }
+
+}

--- a/schema/Contact/RelationshipCache.entityType.php
+++ b/schema/Contact/RelationshipCache.entityType.php
@@ -4,6 +4,7 @@ return [
   'name' => 'RelationshipCache',
   'table' => 'civicrm_relationship_cache',
   'class' => 'CRM_Contact_DAO_RelationshipCache',
+  'metaProvider' => '\Civi\Schema\Entity\RelationshipCacheMetadata',
   'getInfo' => fn() => [
     'title' => ts('Related Contact'),
     'title_plural' => ts('Related Contacts'),


### PR DESCRIPTION
Overview
----------------------------------------
Fixes recent regression in SearchKit when displaying custom fields for Relationships.

Before
----------------------------------------
Custom fields extending Relationship would crash SearchKit if they had an option list

After
----------------------------------------
No crash, test added.

Technical Details
----------------------------------------
This was caused by https://github.com/civicrm/civicrm-core/pull/30986 which was not working for Relationship custom fields in the RelationshipCache entity. Solution was to include Relationship custom fields in the RelationshipCache entity.