### PR TITLE
Remove pointless price set wrangling from batch data entry form

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -94,11 +94,6 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
   protected $currentRowExistingMembership;
 
   /**
-   * @var array
-   */
-  protected $_priceSet;
-
-  /**
    * Get the contribution id for the current row.
    *
    * @return int
@@ -552,11 +547,6 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
       }
     }
     $params['actualBatchTotal'] = CRM_Utils_Rule::cleanMoney($params['actualBatchTotal']);
-    // get the price set associated with offline contribution record.
-    $priceSetId = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', 'default_contribution_amount', 'id', 'name');
-    $this->_priceSet = current(CRM_Price_BAO_PriceSet::getSetDetail($priceSetId));
-    $priceFieldID = CRM_Price_BAO_PriceSet::getOnlyPriceFieldID($this->_priceSet);
-    $priceFieldValueID = CRM_Price_BAO_PriceSet::getOnlyPriceFieldValueID($this->_priceSet);
 
     if (isset($params['field'])) {
       foreach ($params['field'] as $key => $value) {
@@ -623,29 +613,6 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
         $params['actualBatchTotal'] += $value['total_amount'];
         $value['batch_id'] = $this->_batchId;
         $value['skipRecentView'] = TRUE;
-
-        // build line item params
-        $this->_priceSet['fields'][$priceFieldID]['options'][$priceFieldValueID]['amount'] = $value['total_amount'];
-        $value['price_' . $priceFieldID] = 1;
-
-        $lineItem = [];
-        CRM_Price_BAO_PriceSet::processAmount($this->_priceSet['fields'], $value, $lineItem[$priceSetId]);
-
-        // @todo - stop setting amount level in this function - use $this->order->getAmountLevel()
-        unset($value['amount_level']);
-
-        //CRM-11529 for back office transactions
-        //when financial_type_id is passed in form, update the
-        //line items with the financial type selected in form
-        // @todo - create a price set or price field per financial type & simply choose the appropriate
-        // price field rather than working around the fact that each price_field is supposed to have a financial
-        // type & we are allowing that to be overridden.
-        if (!empty($value['financial_type_id']) && !empty($lineItem[$priceSetId])) {
-          foreach ($lineItem[$priceSetId] as &$values) {
-            $values['financial_type_id'] = $value['financial_type_id'];
-          }
-        }
-        $value['line_item'] = $lineItem;
 
         //finally call contribution create for all the magic
         $contribution = CRM_Contribute_BAO_Contribution::create($value);
@@ -745,9 +712,6 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
    */
   private function processMembership(array $params) {
     $batchTotal = 0;
-    // get the price set associated with offline membership
-    $priceSetId = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', 'default_membership_type_amount', 'id', 'name');
-    $this->_priceSet = current(CRM_Price_BAO_PriceSet::getSetDetail($priceSetId));
 
     if (isset($params['field'])) {
       // @todo - most of the wrangling in this function is because the api is not being used, especially date stuff.

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -507,12 +507,15 @@ WHERE  id = %1";
    *
    * We call this function when more than one being present would represent an error
    * starting format derived from current(CRM_Price_BAO_PriceSet::getSetDetail($priceSetId))
+   *
    * @param array $priceSet
    *
-   * @throws CRM_Core_Exception
    * @return int
+   * @throws CRM_Core_Exception
+   * @deprecated since 5.82 will be removed around 5.92
    */
   public static function getOnlyPriceFieldID(array $priceSet) {
+    CRM_Core_Error::deprecatedFunctionWarning('api');
     if (count($priceSet['fields']) > 1) {
       throw new CRM_Core_Exception(ts('expected only one price field to be in price set but multiple are present'));
     }
@@ -524,10 +527,13 @@ WHERE  id = %1";
    * current(CRM_Price_BAO_PriceSet::getSetDetail($priceSetId))
    * @param array $priceSet
    *
+   * @deprecated since 5.82 will be removed around 5.92
+   *
    * @throws CRM_Core_Exception
    * @return int
    */
   public static function getOnlyPriceFieldValueID(array $priceSet) {
+    CRM_Core_Error::deprecatedFunctionWarning('api');
     $priceFieldID = self::getOnlyPriceFieldID($priceSet);
     if (count($priceSet['fields'][$priceFieldID]['options']) > 1) {
       throw new CRM_Core_Exception(ts('expected only one price field to be in price set but multiple are present'));


### PR DESCRIPTION

Overview
----------------------------------------
Remove pointless price set wrangling from batch data entry form

Before
----------------------------------------
Various deprecated code that, as the test shows, does nothing over & above what calling `Contribution:create()` does

After
----------------------------------------
poof

Technical Details
----------------------------------------
All the removed code does is ensure the line item financial type is set to match the contribution financial type - but that has long been handled correctly in the BAO for single line item contributions
- which is the only sort of contribution handled by this form.

Note that the test changes one contribution to have a different financial type & tests the relevant line item to lock this in

Comments
----------------------------------------
