### PR TITLE
Update searchTest to not call form class in legacy way

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -985,6 +985,8 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
    * If you feel tempted to use this in live code then it probably means there is some functionality
    * that needs to be moved out of the form layer.
    *
+   * @deprecated since 5.82 will be removed around 5.86
+   *
    * @param array $params
    *
    * @return bool


### PR DESCRIPTION
Overview
----------------------------------------
Update searchTest to not call form class in legacy way

Before
----------------------------------------
legacy entry point to the Batch_Entry form

After
----------------------------------------
 Full form flow used for Batch_Entry form, additional minor clean ups

Technical Details
----------------------------------------

Comments
----------------------------------------