### PR TITLE
(dev/core#5665) CiviTest/bootstrap.php - Don't try to init DB before tests

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -551,6 +551,10 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
   }
 
   public function getVersion (): int {
+    return static::findVersion();
+  }
+
+  public static function findVersion(): int {
     static $version;
     if ($version === NULL) {
       if (class_exists('Smarty\Smarty')) {

--- a/CRM/Core/Smarty/UserContentPolicy.php
+++ b/CRM/Core/Smarty/UserContentPolicy.php
@@ -178,10 +178,11 @@ class CRM_Core_Smarty_UserContentPolicy extends \Civi\Core\Service\AutoService {
    * So for any potentially-sensitive tags, we support an alternate mechanism to check access.
    *
    * @param string $tag
+   * @param \Smarty|\CRM_Core_Smarty $smarty
    * @return void
    * @throws \Exception
    */
-  public static function assertTagAllowed(string $tag): void {
+  public static function assertTagAllowed(string $tag, $smarty = NULL): void {
     if (!\Civi\Core\Container::isContainerBooted()) {
       // We don't run user content before the system has booted.
       // So the details here are kind of academic.
@@ -189,8 +190,8 @@ class CRM_Core_Smarty_UserContentPolicy extends \Civi\Core\Service\AutoService {
       $disabledTags = ['crmAPI'];
     }
     else {
-      $smarty = CRM_Core_Smarty::singleton();
-      $hasSecurity = ($smarty->getVersion() > 2) ? (bool) $smarty->security_policy : $smarty->security;
+      $smarty ??= CRM_Core_Smarty::singleton();
+      $hasSecurity = (CRM_Core_Smarty::findVersion() > 2) ? (bool) $smarty->security_policy : $smarty->security;
       if (!$hasSecurity) {
         return;
       }

--- a/CRM/Core/Smarty/plugins/function.crmSqlData.php
+++ b/CRM/Core/Smarty/plugins/function.crmSqlData.php
@@ -27,7 +27,7 @@
  * @internal
  */
 function smarty_function_crmSqlData($params, &$smarty) {
-  CRM_Core_Smarty_UserContentPolicy::assertTagAllowed('crmSqlData');
+  CRM_Core_Smarty_UserContentPolicy::assertTagAllowed('crmSqlData', is_callable([$smarty, 'getSmarty']) ? $smarty->getSmarty() : $smarty);
   // In theory, there's nothing actually wrong with running in secure more. We just don't need it.
   // If that changes, then be sure to double-check that the file-name sanitization is good.
 

--- a/Civi/Test.php
+++ b/Civi/Test.php
@@ -110,14 +110,13 @@ class Test {
    */
   public static function headless() {
     $civiRoot = dirname(__DIR__);
-    $builder = new \Civi\Test\CiviEnvBuilder();
+    $builder = new \Civi\Test\CiviEnvBuilder('Headless System');
     $builder
-      ->callback(function ($ctx) {
+      ->callback(function ($builder) {
         if (CIVICRM_UF !== 'UnitTests') {
           throw new \RuntimeException("\\Civi\\Test::headless() requires CIVICRM_UF=UnitTests");
         }
         $dbName = \Civi\Test::dsn('database');
-        fprintf(STDERR, "\nInstalling database {$dbName} (DROP, CREATE, INSERT, etc)\n");
         \Civi\Test::schema()->dropAll();
       }, 'headless-drop')
       ->coreSchema()

--- a/Civi/Test.php
+++ b/Civi/Test.php
@@ -117,7 +117,7 @@ class Test {
           throw new \RuntimeException("\\Civi\\Test::headless() requires CIVICRM_UF=UnitTests");
         }
         $dbName = \Civi\Test::dsn('database');
-        fprintf(STDERR, "Installing {$dbName} schema\n");
+        fprintf(STDERR, "\nInstalling database {$dbName} (DROP, CREATE, INSERT, etc)\n");
         \Civi\Test::schema()->dropAll();
       }, 'headless-drop')
       ->coreSchema()

--- a/Civi/Test/CiviEnvBuilder.php
+++ b/Civi/Test/CiviEnvBuilder.php
@@ -55,6 +55,11 @@ class CiviEnvBuilder {
     $this->name = $name;
   }
 
+  public function setName(string $name) {
+    $this->name = $name;
+    return $this;
+  }
+
   public function addStep(StepInterface $step) {
     $this->targetSignature = NULL;
     $this->steps[] = $step;
@@ -249,6 +254,9 @@ class CiviEnvBuilder {
         $this->finalizeApply();
         return $this;
       }
+
+      fprintf(STDERR, "\nInitializing \"%s\" (%s) in \"%s\"\n", $this->name, $this->getTargetSignature(), $dbName);
+
       foreach ($this->steps as $step) {
         $step->run($this);
       }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -307,11 +307,8 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
       return \Civi\Test::headless();
     }
 
-    // Otherwise: Merely TRUNCATE and INSERT data
-    $b = new \Civi\Test\CiviEnvBuilder();
-    $b->callback(function () {
-      fprintf(STDERR, "\nInstalling database %s (TRUNCATE, INSERT, etc)\n", \Civi\Test::dsn('database'));
-    });
+    // Otherwise: Merely TRUNCATE and INSERT basic data
+    $b = new \Civi\Test\CiviEnvBuilder('Basic Data');
     $b->callback([\Civi\Test::data(), 'populate']);
     return $b;
   }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -296,11 +296,11 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
     // Ideally: return Civi\Test::headless();
 
     // Currently, `CiviUnitTestCase::setUpBeforeClass()` is forcing us to run on nearly ever class.
-    // That should ideally be fixed (but it masks other bugs and needs other work).
-    // Consequently, doing a full and proper `headless()` initialization would further exaggerate
-    // that performance penalty. So we can't quite do that.
+    // (That should ideally be fixed - but doing so would reveal other bugs and need other work)
+    // So for the moment, the choices here impact overall performance -- e.g. doing a full init
+    // (CREATE TABLE, etc) would exaggerate the performance penalty. So we can't quite do that (yet).
 
-    // Rough guess: If there's no schema, then we do need full headless initialization.
+    // Rough guess: If we lack ordinary tables, then we do need full initialization.
     $actualTables = \Civi\Test::schema()->getTables('BASE TABLE');
     $expectTables = ['civicrm_contact', 'civicrm_option_value', 'civicrm_worldregion', 'civitest_revs'];
     if (4 !== count(array_intersect($expectTables, $actualTables))) {

--- a/tests/phpunit/CiviTest/bootstrap.php
+++ b/tests/phpunit/CiviTest/bootstrap.php
@@ -30,10 +30,6 @@ define('CIVICRM_TEST', 1);
 eval(cv('php:boot --level=settings', 'phpcode'));
 // phpcs:enable
 
-if (CIVICRM_UF === 'UnitTests') {
-  Civi\Test::headless()->apply();
-}
-
 spl_autoload_register(function($class) {
   _phpunit_mockoloader('api\\v4\\', "tests/phpunit/api/v4/", $class);
   _phpunit_mockoloader('Civi\\Api4\\', "tests/phpunit/api/v4/Mock/Api4/", $class);

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -164,11 +164,18 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
     // crept into the system where civicrm_api('Entity','get') must be called as part of entities()
     // (even if its return value is ignored).
 
-    $tmp = civicrm_api('Entity', 'Get', ['version' => 3]);
     if (getenv('SYNTAX_CONFORMANCE_ENTITIES')) {
       $tmp = [
         'values' => explode(' ', getenv('SYNTAX_CONFORMANCE_ENTITIES')),
       ];
+    }
+    elseif (isset(\Civi\Test::$statics[__CLASS__]['entities'])) {
+      $tmp = \Civi\Test::$statics[__CLASS__]['entities'];
+    }
+    else {
+      \Civi\Test::asPreInstall([static::CLASS, 'buildEnvironment'])->apply();
+      $tmp = civicrm_api('Entity', 'Get', ['version' => 3]);
+      \Civi\Test::$statics[__CLASS__]['entities'] = $tmp;
     }
 
     if (!is_array($skip)) {

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -109,13 +109,38 @@ class ConformanceTest extends Api4TestBase implements HookInterface {
   public function getEntitiesLotech(): array {
     $entityNames = [];
 
-    $locations = array_merge(
-      [
-        \Civi::paths()->getPath('[civicrm.root]/Civi.php'),
-        \Civi::paths()->getPath('[civicrm.root]/tests/phpunit/AllTests.php'),
-      ],
-      array_column(\CRM_Extension_System::singleton()->getMapper()->getActiveModuleFiles(), 'filePath')
-    );
+    $root = dirname(__DIR__, 5);
+    $locations = [
+      "$root/Civi.php",
+      "$root/tests/phpunit/AllTests.php",
+
+      // The following allows ConformanceTest to run against entities in (some) core-extensions.
+      //
+      // (#1) The goal is good, but the implementation feels misplaced. In the long-term,
+      // the functionality of ConformanceTest would be useful for all extensions
+      // (contrib, core-default, core-non-default, etc).  It would make sense to somehow offer
+      // conformance-testing as a service to run within every extension's respective test-suite.
+      //
+      // (#2) The following list will be validated by testEntitiesProvider(). It may need
+      // to be tweaked... like... once a year? if that?
+      //
+      // (#3) If you want to overthink something, then see (#1) above...
+
+      "$root/ext/civi_campaign/civi_campaign.php",
+      "$root/ext/civi_case/civi_case.php",
+      "$root/ext/civi_contribute/civi_contribute.php",
+      "$root/ext/civi_event/civi_event.php",
+      "$root/ext/civigrant/civigrant.php",
+      "$root/ext/civi_mail/civi_mail.php",
+      "$root/ext/civi_member/civi_member.php",
+      "$root/ext/civi_pledge/civi_pledge.php",
+      "$root/ext/civi_report/civi_report.php",
+      "$root/ext/civi_survey/civi_survey.php",
+      "$root/ext/search_kit/search_kit.php",
+      "$root/ext/afform/core/afform.php",
+      "$root/ext/authx/authx.php",
+    ];
+
     foreach ($locations as $location) {
       $dir = \CRM_Utils_File::addTrailingSlash(dirname($location ?? '')) . 'Civi/Api4';
       if (is_dir($dir)) {


### PR DESCRIPTION
Overview
----------------------------------------

Remove an extraneous call that initializes the database. The essential change is here (5de7bff4e7e06a277381e1aee0083d8591905633), and everything else is dealing with edge-cases that had some implicit reliance.

Before
----------------------------------------

When you run a test, it configures the database twice.

```
CIVICRM_UF=UnitTests phpunit9 tests/phpunit/CRM/Core/RegionTest.php --filter testBlank
```
```
Installing dmastertest_hskvs schema                              <<=== FIRST
PHPUnit 9.6.20 by Sebastian Bergmann and contributors.


Installing dmastertest_hskvs database                            <<=== SECOND
.                                                                   1 / 1 (100%)

Time: 00:02.688, Memory: 101.88 MB

OK (1 test, 7 assertions)
```


After
----------------------------------------

When you run a test, it configures the database once.

```
CIVICRM_UF=UnitTests phpunit9 tests/phpunit/CRM/Core/RegionTest.php --filter testBlank
```
```
PHPUnit 9.6.20 by Sebastian Bergmann and contributors.


Initializing "Headless System" (1d4f6e2b0d21d118dac28b3a24f10585) in "dmastertest_hskvs"
.                                                                   1 / 1 (100%)

Time: 00:04.807, Memory: 101.88 MB

OK (1 test, 7 assertions)
```

