### PR TITLE
Fix default property value: CRM_Contact_Form_Merge->criteria

### DIFF
--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -90,7 +90,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
    *
    * @var string
    */
-  public $criteria = [];
+  public $criteria;
 
   /**
    * Query limit to be retained in the urls.


### PR DESCRIPTION
Overview
----------------------------------------
Follow up to feedback from https://github.com/civicrm/civicrm-core/pull/31658/files.

Before
----------------------------------------
`$criteria` was initialised as an array, but later was set to a string, and passed into `json_decode` which only accepts a string.

After
----------------------------------------
A default value is not set.