### PR TITLE
Cast null description to string

### DIFF
--- a/ext/legacycustomsearches/CRM/Contact/Page/CustomSearch.php
+++ b/ext/legacycustomsearches/CRM/Contact/Page/CustomSearch.php
@@ -44,7 +44,7 @@ ORDER By  v.weight
 
     $rows = [];
     while ($dao->fetch()) {
-      if (trim($dao->description)) {
+      if (trim($dao->description ?? '')) {
         $rows[$dao->value] = $dao->description;
       }
       else {


### PR DESCRIPTION
Overview
----------------------------------------
Cast null `description` to string.


Technical Details
----------------------------------------
Modern PHP complains if `null` is passed into `trim`. This just ensures it's always a string. I know `
ext/legacycustomsearches` isn't really being maintained now, but equally this is such a small, quick change I don't see much downside.