### PR TITLE
Add is_numeric to smarty functions

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -180,6 +180,7 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
       'array_key_exists',
       'strstr',
       'strpos',
+      'is_numeric',
     ];
     foreach ($functionsForSmarty as $function) {
       $this->registerPlugin('modifier', $function, $function);


### PR DESCRIPTION
I don't know why this has not been an issue but in the main Contact summary tpl is_numeric is called and has been since 2021.

Recently when trying 'odd things' with a test I his a smarty fail on it

https://test.civicrm.org/job/CiviCRM-Test/39194/testReport/(root)/CRM_Core_InvokeTest/testContactSummary/

It feels like it should have always failed - shrug - seems OK to add though

![image](https://github.com/user-attachments/assets/f3845343-bdbf-4695-a4eb-86f71dccd819)

