### PR TITLE
Move flushing of activityType static to OptionValue:create

### DIFF
--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -38,13 +38,6 @@ class CRM_Core_PseudoConstant {
   private static $cache;
 
   /**
-   * activity type
-   * @var array
-   * @deprecated Please use the buildOptions() method in the appropriate BAO object.
-   */
-  private static $activityType;
-
-  /**
    * States, provinces
    * @var array
    */
@@ -437,7 +430,7 @@ class CRM_Core_PseudoConstant {
   /**
    * @deprecated Please use the buildOptions() method in the appropriate BAO object.
    *
-   * Get all Activty types.
+   * Get all Activity types.
    *
    * The static array activityType is returned
    *
@@ -445,7 +438,7 @@ class CRM_Core_PseudoConstant {
    * @return array
    *   array reference of all activity types.
    */
-  public static function &activityType() {
+  public static function activityType() {
     $args = func_get_args();
     $all = $args[0] ?? TRUE;
     $includeCaseActivities = $args[1] ?? FALSE;
@@ -456,12 +449,12 @@ class CRM_Core_PseudoConstant {
     $index = (int) $all . '_' . $returnColumn . '_' . (int) $includeCaseActivities;
     $index .= '_' . (int) $includeCampaignActivities;
     $index .= '_' . (int) $onlyComponentActivities;
-
-    if (NULL === self::$activityType) {
-      self::$activityType = [];
+    if (!isset(\Civi::$statics[__CLASS__]['activityType'])) {
+      \Civi::$statics[__CLASS__]['activityType'] = [];
     }
+    $activityTypes = &\Civi::$statics[__CLASS__]['activityType'];
 
-    if (!isset(self::$activityType[$index]) || $reset) {
+    if (!isset($activityTypes[$index]) || $reset) {
       $condition = NULL;
       if (!$all) {
         $condition = 'AND filter = 0';
@@ -501,9 +494,9 @@ class CRM_Core_PseudoConstant {
       }
       $condition = $condition . ' AND ' . $componentClause;
 
-      self::$activityType[$index] = CRM_Core_OptionGroup::values('activity_type', FALSE, FALSE, FALSE, $condition, $returnColumn);
+      $activityTypes[$index] = CRM_Core_OptionGroup::values('activity_type', FALSE, FALSE, FALSE, $condition, $returnColumn);
     }
-    return self::$activityType[$index];
+    return $activityTypes[$index];
   }
 
   /**

--- a/tests/phpunit/CiviTest/CiviCaseTestCase.php
+++ b/tests/phpunit/CiviTest/CiviCaseTestCase.php
@@ -102,10 +102,6 @@ class CiviCaseTestCase extends CiviUnitTestCase {
 
     // create a logged in USER since the code references it for source_contact_id
     $this->createLoggedInUser();
-    /// note that activityType options are cached by the FULL set of options you pass in
-    // ie. because Activity api includes campaign in it's call cache is not flushed unless
-    // included in this call. Also note flush function doesn't work on this property as it sets to null not empty array
-    CRM_Core_PseudoConstant::activityType(TRUE, TRUE, TRUE, 'name', TRUE);
   }
 
   /**

--- a/tests/phpunit/api/v3/ActivityTypeTest.php
+++ b/tests/phpunit/api/v3/ActivityTypeTest.php
@@ -36,7 +36,6 @@ class api_v3_ActivityTypeTest extends CiviUnitTestCase {
 
   public function setUp(): void {
     $this->_apiversion = 3;
-    CRM_Core_PseudoConstant::activityType(TRUE, TRUE, TRUE, 'name');
     parent::setUp();
     $this->useTransaction(TRUE);
   }

--- a/tests/phpunit/api/v3/MembershipPaymentTest.php
+++ b/tests/phpunit/api/v3/MembershipPaymentTest.php
@@ -41,7 +41,7 @@ class api_v3_MembershipPaymentTest extends CiviUnitTestCase {
     $this->_contactID = $this->organizationCreate();
     $this->_membershipTypeID = $this->membershipTypeCreate(['member_of_contact_id' => $this->_contactID]);
     $this->_membershipStatusID = $this->membershipStatusCreate('test status');
-    $activityTypes = CRM_Core_PseudoConstant::activityType(TRUE, TRUE, TRUE, 'name');
+
     $params = [
       'contact_id' => $this->_contactID,
       'currency' => 'USD',

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -56,7 +56,6 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $this->_membershipStatusID = $this->membershipStatusCreate('test status');
 
     CRM_Member_PseudoConstant::membershipStatus(NULL, NULL, 'name', TRUE);
-    CRM_Core_PseudoConstant::activityType(TRUE, TRUE, TRUE, 'name');
 
     $this->_entity = 'Membership';
     $this->_params = [


### PR DESCRIPTION
Overview
----------------------------------------
Move flushing of activityType static to OptionValue:create

Before
----------------------------------------
Most places where option values are stored flushed when OptionValue::add() is called - but not `activityType` because it is stored in a property not the statics array,  so tests do a work around

After
----------------------------------------
It is moved to Civi::statics, which is stored

Technical Details
----------------------------------------


Comments
----------------------------------------
