### PR TITLE
(NFC) Civi\Test::execute() - Raise exception for SQL error

### DIFF
--- a/Civi/Test.php
+++ b/Civi/Test.php
@@ -245,9 +245,7 @@ class Test {
           continue;
         }
         else {
-          var_dump($result);
-          var_dump($pdo->errorInfo());
-          // die( "Cannot execute $query: " . $pdo->errorInfo() );
+          throw new \RuntimeException('Cannot execute query: ' . json_encode([$query, $pdo->errorInfo()], JSON_PRETTY_PRINT));
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------

This is a helper function used during test-initialization to setup SQL DB. (*It should have no effect on runtime behavior.*)

Before
----------------------------------------

If it encounters a SQL error, it warns and proceeds.

After
----------------------------------------

If it encounters a SQL error, it fails with an exception (and therefore backtrace, etc).

Comments
----------------------------------------

I'm not really sure what it was soft before. Maybe we'll something in the results to explain it. Or maybe it'll just work fine...