### PR TITLE
[REF] Ensure that Privacy (single checkbox) fields show up on Event R…

### DIFF
--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -122,7 +122,7 @@
               {/if}
             {elseif $field.html_type eq 'File' && $viewOnlyFileValues}
               {$viewOnlyFileValues.$profileFieldName}
-            {elseif $field.html_type eq 'Radio' or $field.html_type eq 'CheckBox'}
+            {elseif $field.html_type eq 'Radio' or $field.html_type eq 'CheckBox' && $field.data_type neq "Boolean"}
               <div class="crm-multiple-checkbox-radio-options" >
                 {foreach name=outer key=key item=item from=$formElement}
                   {if is_array($item) && array_key_exists('html', $item)}


### PR DESCRIPTION
…egistrations when fields are used in a profile

Overview
----------------------------------------
This modifies the UFFields templates to only handle Radios and Checkboxes fields here if the field is not type boolean. This seems to fix the problem @jmcclelland identified in this PR https://github.com/civicrm/civicrm-core/pull/30992. 

Before
----------------------------------------
Checkboxes don't show up when privacy fields included on event registrations

After
----------------------------------------
Checkboxes for privacy fields show up correctly

ping @andrew-cormick-dockery 