### PR TITLE
Sloppy Test Detector - Add option to complain about test junk

### DIFF
--- a/Civi/Test/SloppyTestChecker.php
+++ b/Civi/Test/SloppyTestChecker.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Civi\Test;
+
+/**
+ * Detect sloppy tests.
+ *
+ * GOALS
+ *
+ * Suppose you have these tests:
+ *
+ *   function setupHeadless() { Civi\Test::headless()->apply(); }
+ *   function test1() { doStuff(); }
+ *   function test2() { doOtherStuff(); }
+ *   function test3() { doMoreStuff(); }
+ *
+ * These tests are all based on the same headless configuration.
+ * Ideally, we only want to initialize the database once and quickly run
+ * through all the test functions.
+ *
+ * However, some tests might be sloppy -- perhaps `test2()` destroys
+ * an important setting, which causes `test3()` to behave erratically.
+ * (`test3()` works on its own but fails in combination with `test2()`.)
+ *
+ * The symptoms will present on `test3()`, but the blame lies with `test2()`.
+ * This class does some sanity-checks and works to point the finger at `test2()`.
+ *
+ * USAGE
+ *
+ * This feature is opt-in. (Detecting sloppy tests requires extra computation...
+ * How much? Not sure yet... Let's get some data before we consider making it mandatory...)
+ *
+ * You may enable by setting one of these environment variables:
+ *
+ * - CIVICRM_SLOPPY_TEST=STDERR             Print warnings to STDERR
+ * - CIVICRM_SLOPPY_TEST=Exception          Throw an exception
+ * - CIVICRM_SLOPPY_TEST=@/tmp/sloppy.log   Append to a log file
+ */
+class SloppyTestChecker {
+
+  public static function isActive(): bool {
+    return !empty(getenv('CIVICRM_SLOPPY_TEST'));
+  }
+
+  protected static function emit(string $message): void {
+    $mode = getenv('CIVICRM_SLOPPY_TEST');
+
+    if ($mode[0] === '@') {
+      $file = substr($mode, 1);
+      $now = date('Y-m-d H:i:s P');
+      file_put_contents($file, "[$now] $message", FILE_APPEND);
+      return;
+    }
+
+    switch ($mode) {
+      case 'Exception':
+        throw new \LogicException(__CLASS__ . ': ' . $message);
+
+      case 'STDERR':
+      default:
+        fwrite(STDERR, "\n$message\n");
+        break;
+    }
+  }
+
+  /**
+   * Determine if $startSnapshot and $endSnapshot match. If they don't,
+   * complain about it and blame the $lastParty/$currentParty.
+   *
+   * @param array $startSnapshot
+   * @param array $endSnapshot
+   * @param string $lastParty
+   *   Ex: 'FooBarTest::testOne()'
+   * @param string $currentParty
+   *   Ex: 'FooBarTest::testTwo()'
+   */
+  public static function doComparison(array $startSnapshot, array $endSnapshot, string $lastParty, string $currentParty): void {
+    \CRM_Utils_Array::flatten($startSnapshot, $flatStart, '', ': ');
+    \CRM_Utils_Array::flatten($endSnapshot, $flatEnd, '', ': ');
+    $removed = array_diff($flatStart, $flatEnd);
+    $added = array_diff($flatEnd, $flatStart);
+
+    $buf = [];
+    foreach (array_keys($removed) as $key) {
+      if (isset($added[$key])) {
+        $buf[] = sprintf("- Baseline data has changed (%s: %s ==> %s)", $key, json_encode($removed[$key]), json_encode($added[$key]));
+        unset($removed[$key]);
+        unset($added[$key]);
+      }
+    }
+    foreach ($removed as $key => $value) {
+      $buf[] = sprintf("- Baseline data has gone missing (%s=%s)", $key, json_encode($value));
+    }
+    foreach ($added as $key => $value) {
+      $buf[] = sprintf("- Found unexpected left-overs (%s=%s)", $key, json_encode($value));
+    }
+    if ($buf) {
+      // The current environment is dirty. Not suitable for re-use.
+      $query = sprintf('DELETE FROM %s.civitest_revs', \Civi\Test::dsn('database'));
+      \Civi\Test::execute($query);
+
+      array_unshift($buf, sprintf("- Environment last configured for '%s'", $lastParty));
+      $buf[] = sprintf("- Now preparing environment for '%s'", $currentParty);
+      $buf[] = sprintf("- Reinitialization will be forced", $currentParty);
+      $buf[] = sprintf("- Recommendations:");
+      $buf[] = sprintf("    - Fix the test-case to cleanup its mess, or...");
+      $buf[] = sprintf("    - Mark the test-case environment as useOnce()");
+      $problems = implode("\n", $buf);
+      static::emit(sprintf("DETECTED SLOPPY TEST:\n%s\n", $problems));
+    }
+  }
+
+  public static function createSnapshot(): array {
+    $tables = \Civi\Test::schema()->getTables('BASE TABLE');
+    $views = \Civi\Test::schema()->getTables('VIEW');
+
+    $snapshot = [];
+    $snapshot['tables'] = array_combine($tables, $tables);
+    $snapshot['view'] = array_combine($views, $views);
+    $snapshot['extensions'] = static::fetchAll('SELECT full_name, is_active FROM %s.civicrm_extension ORDER BY full_name', ['full_name']);
+    $snapshot['custom_groups'] = static::fetchAll('SELECT id, name FROM %s.civicrm_custom_group ORDER BY name', ['name']);
+    $snapshot['custom_fields'] = static::fetchAll('SELECT id, name, custom_group_id FROM %s.civicrm_custom_field ORDER BY name', ['name']);
+    $snapshot['settings'] = static::fetchAll('SELECT name, domain_id, value FROM %s.civicrm_setting WHERE name NOT IN ("resCacheCode") ORDER BY name, domain_id', ['name', 'domain_id']);
+    // $snapshot['settings'] = static::fetchAll('SELECT name, domain_id, value FROM %s.civicrm_setting ORDER BY name, domain_id', ['name', 'domain_id']);
+    $snapshot['contacts'] = static::fetchAll('SELECT id, display_name FROM %s.civicrm_contact', ['display_name']);
+    $snapshot['events'] = static::fetchAll('SELECT id, title FROM %s.civicrm_event', ['title']);
+    return $snapshot;
+  }
+
+  protected static function fetchAll(string $query, array $index): array {
+    $query = sprintf($query, \Civi\Test::dsn('database'));
+    $result = [];
+    foreach (\Civi\Test::pdo()->query($query, \PDO::FETCH_ASSOC)->fetchAll() as $item) {
+      $key = [];
+      foreach ($index as $indexPart) {
+        $key[] = $item[$indexPart] ?? 'NULL';
+      }
+      $result[implode(' ', $key)] = $item;
+    }
+    return $result;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

Suppose you have a headless test-case, such as:

```php
function setupHeadless() { Civi\Test::headless()->apply(); }
function test1() { ... }
function test2() { ... }
function test3() { ... }
```

These tests are all based on the same headless configuration. Ideally, we want to initialize the database once and quickly run through all the test functions (*without needing to reset the entire database*).

However, some tests might be *sloppy*. Perhaps `test2()` changes an important setting, which causes `test3()` to behave erratically. ("Erratically" ==> `test3()` works fine on its own... but in a full suite, it fails due the misfortune of following `test2()`. Or perhaps the opposite - it works when combined with `test2()` but fails on its own.)

Ordinarily, the erratic symptoms will present on `test3()`. But the *blame* lies with `test2()`.

The *sloppy test detector* adds extra sanity checks and logging so that it can complain about `test2()`.

Before
----------------------------------------

No mechanism to detect the sloppy test, except by pulling out your hairs. 

After
----------------------------------------

If you suspect that there are sloppy tests, then you can opt-in to the detector by setting an environment variable

| Configuration | Behavior |
| -- | -- |
| `CIVICRM_SLOPPY_TEST=STDERR` |             Print warnings to STDERR. |
| `CIVICRM_SLOPPY_TEST=Exception` |          Throw an exception. Abort testing. |
| `CIVICRM_SLOPPY_TEST=@/tmp/sloppy.log` |   Append to a log file. |

If it detects a problem, then it will print a message like this:

```
DETECTED SLOPPY TEST:
- Environment last configured for 'api\v4\Action\AutocompleteQuicksearchTest::testQuicksearchAutocompleteOptionsDisplay'
- Found unexpected left-overs (settings: contact_autocomplete_options 1: name="contact_autocomplete_options")
- Found unexpected left-overs (settings: quicksearch_options 1: name="quicksearch_options")
- Now preparing environment for 'api\v4\Action\AutocompleteQuicksearchTest::testQuicksearchAutocompleteWithMultiRecordCustomField'
- Reinitialization will be forced
- Recommendations:
    - Fix the test-case to cleanup its mess, or...
    - Mark the test-case environment as useOnce()
```

Note that this includes an auto-recovery mechanism: if it detects a sloppy test, then it will reinitialize the system. That ensures that subsequent tests run in a more canonical environment.

Technical Details
----------------------------------------

(1) As an example, I've locally run `tests/phpunit/api/v4/` with `CIVICRM_SLOPPY_TEST` enabled. Log file here:

* https://gist.github.com/totten/7987a39054b14e4c3ef12e9378a48fd6

(2) The exact definition of a "sloppy" test may need some iteration. Consider:

* Clearly, some things can have downstream impact and should have strict cleanup -- such as toggling `Extension`s and `Component`s, changing the `Setting`s, or creating `CustomField`s.
* Other things are more debatable -- such as inserting `Event`s and `Contact`s. Perhaps it would be ideal to have these cleanup... but if a large number of tests don't, then maybe we start with a more relaxed enforcement.

(3) It's possible that... sometimes... it's easier to leave a sloppy-test instead of fixing. (Perhaps the test manipulates a gnarly graph of extensions, custom-data, and managed entities... and politely unwinding the changes would be difficult-to-write and slow-to-execute...) In that case, you could flag the test environment as `useOnce()` (*so that the environment will be fully reset before running any other tests*):

```diff
-Test::headless()->apply();
+Test::headless()->useOnce()->apply();
```
