### PR TITLE
Fix unix timestamp bug in deferred revenue report

### DIFF
--- a/CRM/Report/Form/Contribute/DeferredRevenue.php
+++ b/CRM/Report/Form/Contribute/DeferredRevenue.php
@@ -362,7 +362,7 @@ class CRM_Report_Form_Contribute_DeferredRevenue extends CRM_Report_Form {
   public function where() {
     parent::where();
     $startDate = date('Y-m-01');
-    $endDate = date('Y-m-t', strtotime(date('ymd') . '+11 month'));
+    $endDate = (new DateTime('+11 month'))->format('Y-m-d');
     $this->_where .= " AND {$this->_aliases['civicrm_financial_trxn_1']}.trxn_date BETWEEN '{$startDate}' AND '{$endDate}'";
   }
 

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -1037,14 +1037,14 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
       [
         'contact_id' => $this->ids['Contact']['first'],
         'receive_date' => '2016-10-01',
-        'revenue_recognition_date' => date('Y-m-t', strtotime(date('ymd') . '+3 month')),
+        'revenue_recognition_date' => (new DateTime('+3 month'))->format('Y-m-t'),
         'financial_type_id' => 2,
       ]
     );
     $this->contributionCreate(
       [
         'contact_id' => $this->ids['Contact']['first'],
-        'revenue_recognition_date' => date('Y-m-t', strtotime(date('ymd') . '+22 month')),
+        'revenue_recognition_date' => (new DateTime('+22 month'))->format('Y-m-t'),
         'financial_type_id' => 4,
         'trxn_id' => NULL,
         'invoice_id' => NULL,
@@ -1053,7 +1053,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     $this->contributionCreate(
       [
         'contact_id' => $this->ids['Contact']['second'],
-        'revenue_recognition_date' => date('Y-m-t', strtotime(date('ymd') . '+1 month')),
+        'revenue_recognition_date' => (new DateTime('+1 month'))->format('Y-m-t'),
         'financial_type_id' => 4,
         'trxn_id' => NULL,
         'invoice_id' => NULL,
@@ -1063,7 +1063,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
       [
         'contact_id' => $this->ids['Contact']['second'],
         'receive_date' => '2016-03-01',
-        'revenue_recognition_date' => date('Y-m-t', strtotime(date('ymd') . '+4 month')),
+        'revenue_recognition_date' => (new DateTime('+4 month'))->format('Y-m-t'),
         'financial_type_id' => 2,
         'trxn_id' => NULL,
         'invoice_id' => NULL,


### PR DESCRIPTION
Overview
----------------------------------------
Fix [this fail](https://test.civicrm.org/job/CiviCRM-Test/39170/) caused by buggy offset generation looping round to 1960-something...

