### PR TITLE
Api - Adjust permissions for custom field metadata

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1289,8 +1289,10 @@ class CRM_Core_Permission {
     // Custom field permissions
     $permissions['custom_field'] = [
       'default' => [
-        'administer CiviCRM',
-        'access all custom data',
+        'administer CiviCRM data',
+      ],
+      'get' => [
+        ['access CiviCRM', 'access all custom data'],
       ],
     ];
     $permissions['custom_group'] = $permissions['custom_field'];


### PR DESCRIPTION
Overview
----------------------------------------
Lowers permission requirements for accessing custom field metadata, so that higher permissions do not need to be granted to so many users.

See https://lab.civicrm.org/dev/core/-/issues/5664

Before
----------------------------------------
All actions required 'administer CiviCRM' AND 'access all custom data'

After
----------------------------------------
Permission for create/update/delete reduced to 'administer CiviCRM data',
Permission for get reduced to 'access CiviCRM' OR 'access all custom data'.

Technical Details
----------------------------------------
Note that this is about accessing the custom field _definitions_, not the data stored in the custom fields.