### PR TITLE
[REF] Use shared TabHeader.tpl for contact summary tabs as well

### DIFF
--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -469,9 +469,18 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
     // ensure all keys used in the template are set, to avoid notices
     $allTabs = \CRM_Core_Smarty::setRequiredTabTemplateKeys($allTabs);
 
+    // ensure the array keys match the value in the "id" of each item
+    $tabs = [];
+
+    foreach ($allTabs as $key => $tab) {
+      $finalKey = $tab['id'] ?? $key;
+      $tabs[$finalKey] = $tab;
+    }
+
     // now sort the tabs based on weight
-    usort($allTabs, ['CRM_Utils_Sort', 'cmpFunc']);
-    return $allTabs;
+    usort($tabs, ['CRM_Utils_Sort', 'cmpFunc']);
+
+    return $tabs;
   }
 
   /**

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -299,12 +299,17 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
       'count' => NULL,
       'hideCount' => FALSE,
       'template' => NULL,
+      'active' => TRUE,
+      'valid' => TRUE,
       // Afform tabs set the afform module and directive - NULL for non-afform tabs
       'module' => NULL,
       'directive' => NULL,
     ];
 
     foreach ($tabs as $i => $tab) {
+      if (empty($tab['url'])) {
+        $tab['url'] = $tab['link'] ?? '';
+      }
       $tabs[$i] = array_merge($defaults, (array) $tab);
     }
     return $tabs;

--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -430,21 +430,21 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
     ];
 
     $tabs = [];
-    $tabs['settings'] = ['title' => ts('Info and Settings'), 'class' => 'ajaxForm livePage'] + $default;
-    $tabs['location'] = ['title' => ts('Event Location')] + $default;
+    $tabs['settings'] = ['title' => ts('Info and Settings'), 'class' => 'ajaxForm livePage', 'icon' => 'crm-i fa-circle-info'] + $default;
+    $tabs['location'] = ['title' => ts('Event Location'), 'icon' => 'crm-i fa-map-marker'] + $default;
     // If CiviContribute is active, create the Fees tab.
     if (CRM_Core_Component::isEnabled('CiviContribute')) {
-      $tabs['fee'] = ['title' => ts('Fees')] + $default;
+      $tabs['fee'] = ['title' => ts('Fees'), 'icon' => 'crm-i fa-money'] + $default;
     }
-    $tabs['registration'] = ['title' => ts('Online Registration')] + $default;
+    $tabs['registration'] = ['title' => ts('Online Registration'), 'icon' => 'crm-i fa-check'] + $default;
     // @fixme I don't understand the event permissions check here - can we just get rid of it?
     $permissions = CRM_Event_BAO_Event::getAllPermissions();
     if (CRM_Core_Permission::check('administer CiviCRM data') || !empty($permissions[CRM_Core_Permission::EDIT])) {
-      $tabs['reminder'] = ['title' => ts('Schedule Reminders'), 'class' => 'livePage'] + $default;
+      $tabs['reminder'] = ['title' => ts('Schedule Reminders'), 'class' => 'livePage', 'icon' => 'crm-i fa-envelope'] + $default;
     }
 
-    $tabs['pcp'] = ['title' => ts('Personal Campaigns')] + $default;
-    $tabs['repeat'] = ['title' => ts('Repeat')] + $default;
+    $tabs['pcp'] = ['title' => ts('Personal Campaigns'), 'icon' => 'crm-i fa-user'] + $default;
+    $tabs['repeat'] = ['title' => ts('Repeat'), 'icon' => 'crm-i fa-repeat'] + $default;
 
     // Repeat tab must refresh page when switching repeat mode so js & vars will get set-up
     if (!$this->_isRepeatingEvent) {

--- a/templates/CRM/Contact/Page/View/Summary.tpl
+++ b/templates/CRM/Contact/Page/View/Summary.tpl
@@ -101,35 +101,8 @@
     </div><!-- .crm-actions-ribbon -->
   {/if}
 
-  <div class="crm-block crm-content-block crm-contact-page crm-inline-edit-container">
-    <div id="mainTabContainer">
-      <ul class="crm-contact-tabs-list">
-        {foreach from=$allTabs item=tabValue}
-          <li id="tab_{$tabValue.id}" class="crm-tab-button ui-corner-all{if is_numeric($tabValue.count)} crm-count-{$tabValue.count}{/if}{if $tabValue.class} {$tabValue.class}{/if}">
-            <a href="{if $tabValue.template}#contact-{$tabValue.id}{else}{$tabValue.url|smarty:nodefaults}{/if}" title="{$tabValue.title|escape}">
-              <i class="{if !empty($tabValue.icon)}{$tabValue.icon}{else}crm-i fa-puzzle-piece{/if}" aria-hidden="true"></i>
-              <span>{$tabValue.title}</span>
-              {if empty($tabValue.hideCount)}<em>{if is_numeric($tabValue.count)}{$tabValue.count}{/if}</em>{/if}
-            </a>
-          </li>
-        {/foreach}
-      </ul>
+  {include file='CRM/common/TabHeader.tpl' tabHeader=$allTabs containerClasses="crm-contact-page crm-inline-edit-container" listClasses="crm-contact-tabs-list" tabIdPrefix="contact-"}
 
-      {foreach from=$allTabs item=tabValue}
-        {if $tabValue.template}
-          <div id="contact-{$tabValue.id}">
-            {if $tabValue.module}
-              <!-- afform tab - need to pass module and directive to afform param -->
-              {include file=$tabValue.template afform=$tabValue}
-            {else}
-              {include file=$tabValue.template}
-            {/if}
-          </div>
-        {/if}
-      {/foreach}
-    </div>
-    <div class="clear"></div>
-  </div>
 {/if}
 
 {* CRM-10560 *}

--- a/templates/CRM/common/TabHeader.tpl
+++ b/templates/CRM/common/TabHeader.tpl
@@ -8,27 +8,28 @@
  +--------------------------------------------------------------------+
 *}
 {* enclose all tabs and its content in a block *}
-<div class="crm-block crm-content-block">
+<div class="crm-block crm-content-block {$containerClasses|default:''}">
   {if $tabHeader}
     <div id="mainTabContainer">
-    <ul>
-       {foreach from=$tabHeader key=tabName item=tabValue}
-          <li id="tab_{$tabName}" class="crm-tab-button ui-corner-all{if !$tabValue.valid} disabled{/if} {$tabValue.class}" {$tabValue.extra}>
-          {if $tabValue.active}
-             <a href="{if $tabValue.template}#panel_{$tabName}{else}{$tabValue.link|smarty:nodefaults}{/if}" title="{$tabValue.title|escape}{if !$tabValue.valid} ({ts}disabled{/ts}){/if}">
-               {if $tabValue.icon}<i class="{$tabValue.icon}"></i>{/if}
-               <span>{$tabValue.title}</span>
-               {if is_numeric($tabValue.count)}<em>{$tabValue.count}</em>{/if}
-             </a>
-          {else}
-             <span {if !$tabValue.valid} title="{ts}disabled{/ts}"{/if}>{$tabValue.title}</span>
-          {/if}
+      <ul class="{$listClasses|default:''}">
+        {foreach from=$tabHeader key=tabName item=tabValue}
+          <li id="tab_{$tabName}" class="crm-tab-button ui-corner-all {if !$tabValue.valid}disabled{/if} {if is_numeric($tabValue.count)}crm-count-{$tabValue.count}{/if} {if $tabValue.class} {$tabValue.class}{/if}" {$tabValue.extra}>
+            {if $tabValue.active}
+              <a href="{if $tabValue.template}#{$tabIdPrefix|default:'panel_'}{$tabName}{else}{$tabValue.url|smarty:nodefaults}{/if}" title="{$tabValue.title|escape} {if !$tabValue.valid}({ts}disabled{/ts}){/if}">
+                <i class="{$tabValue.icon|default:'crm-i fa-puzzle-piece'}" aria-hidden="true"></i>
+                <span>{$tabValue.title}</span>
+                {if empty($tabValue.hideCount) && is_numeric($tabValue.count)}<em>{$tabValue.count}</em>{/if}
+              </a>
+            {else}
+               <span {if !$tabValue.valid} title="{ts}disabled{/ts}"{/if}>{$tabValue.title}</span>
+            {/if}
           </li>
-       {/foreach}
-    </ul>
+        {/foreach}
+      </ul>
+
       {foreach from=$tabHeader key=tabName item=tabValue}
         {if $tabValue.template}
-          <div id="panel_{$tabName}">
+          <div id="{$tabIdPrefix|default:'panel_'}{$tabName}">
             {if $tabValue.module}
               <!-- afform tab - need to pass module and directive to afform param -->
               {include file=$tabValue.template afform=$tabValue}
@@ -41,4 +42,4 @@
     </div>
   {/if}
   <div class="clear"></div>
-</div> {* crm-content-block ends here *}
+</div>


### PR DESCRIPTION
Before
----------------------------------------
- very slightly different templates for the contact summary tabs inline in `Summary.tpl` and other tabsets which use `TabHeader.tpl`
- hard time keeping track of what keys are expected for tabs (including when using `hook_civicrm_tabset` ) - different tabsets need different ones
- contact tabs fallback to a puzzle piece icon, other tabsets do not
- contact tabs use a `url` key, other tabs use a `link` key
- contact tabs use an `id` key, other tabs use the array key from the tabs array

After
----------------------------------------
- additional parameters in `TabHeader.tpl`
- Contact Summary uses the shared template
- more consistency in the expected values for tabset arrays
- Manage Event tabs have icons
- all tabs without an icon will use the default "puzzle piece" fallback
- all tabs use `url` key in the template (this is set from the link key if not provided explicitly, for backwards compatibility)
- all tabs use the array key from the tabs array (this is set from the `id` key for contact tabs, for backwards compatibility)

Technical Details
----------------------------------------
Should have very minimal impact on outputted markup for now, but should be a step towards making the markup more consistent. 
