### PR TITLE
dev/core#5566 Fix clear options not showing for non-admin user

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -775,6 +775,9 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
           if ($search || empty($useRequired)) {
             $fieldAttributes['allowClear'] = TRUE;
           }
+          if ($field->options_per_line) {
+            $fieldAttributes['options_per_line'] = $field->options_per_line;
+          }
           $qf->addRadio($elementName, $label, $options, $fieldAttributes, NULL, $useRequired);
         }
         break;

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1498,7 +1498,9 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       $options[] = $element;
     }
     $group = $this->addGroup($options, $name, $title, $separator);
-
+    if (!empty($attributes['options_per_line'])) {
+      $group->setAttribute('options_per_line', $attributes['options_per_line']);
+    }
     $optionEditKey = 'data-option-edit-path';
     if (!empty($attributes[$optionEditKey])) {
       $group->setAttribute($optionEditKey, $attributes[$optionEditKey]);

--- a/CRM/Core/Form/Renderer.php
+++ b/CRM/Core/Form/Renderer.php
@@ -84,6 +84,13 @@ class CRM_Core_Form_Renderer extends HTML_QuickForm_Renderer_ArraySmarty {
   public function _elementToArray(&$element, $required, $error) {
     self::updateAttributes($element, $required, $error);
 
+    if ($element->getType() === 'group' && $element->getAttribute('options_per_line')) {
+      // Our standard template renders the erroneous html as part of it.
+      // This results in double renders in some cases - see https://lab.civicrm.org/dev/core/-/issues/5571
+      // I suspect not rendering the html is probably often better but
+      // this adds it for our known problem case.
+      $this->setErrorTemplate('CRM/Form/errorClean.tpl');
+    }
     $el = parent::_elementToArray($element, $required, $error);
     $el['textLabel'] = $element->_label ?? NULL;
 
@@ -126,7 +133,13 @@ class CRM_Core_Form_Renderer extends HTML_QuickForm_Renderer_ArraySmarty {
     else {
       $typesToShowEditLink = ['select', 'group'];
       $hasEditPath = NULL !== $element->getAttribute('data-option-edit-path');
-
+      if ($element->getType() === 'group' && $element->getAttribute('options_per_line')) {
+        // Our standard template renders the erroneous html as part of it.
+        // This results in double renders in some cases - see https://lab.civicrm.org/dev/core/-/issues/5571
+        // I suspect not rendering the html is probably often better but
+        // this adds it for our known problem case.
+        $this->setErrorTemplate('CRM/Form/errorClean.tpl');
+      }
       if (in_array($element->getType(), $typesToShowEditLink) && $hasEditPath) {
         $this->addOptionsEditLink($el, $element);
       }
@@ -135,7 +148,9 @@ class CRM_Core_Form_Renderer extends HTML_QuickForm_Renderer_ArraySmarty {
         $this->appendUnselectButton($el, $element);
       }
     }
-
+    // We can't do a get to check but the only time we ever use a different template is within this
+    // function.
+    $this->setErrorTemplate('CRM/Form/error.tpl');
     return $el;
   }
 

--- a/templates/CRM/Form/errorLabel.tpl
+++ b/templates/CRM/Form/errorLabel.tpl
@@ -1,0 +1,14 @@
+{*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+*}
+
+{if $error}
+  <span class="crm-error">{$error}</span>
+{/if}
+

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -62,6 +62,8 @@
       {/if}
       {assign var="profileID" value=$field.group_id}
       {assign var="profileFieldName" value=$field.name}
+      {assign var="rowIdentifier" value=$field.name}
+      {assign var="formElement" value=$form.$profileFieldName}
 
       {if $field.groupTitle != $fieldset}
         {if $mode neq 8 && $mode neq 4}
@@ -96,34 +98,9 @@
           </div>
         {/if}
         {if array_key_exists('options_per_line', $field) && $field.options_per_line}
-          <div class="crm-section editrow_{$profileFieldName}-section form-item" id="editrow-{$profileFieldName}">
-            <div class="label">{$form.$profileFieldName.label}</div>
-            <div class="content edit-value">
-              {assign var="count" value=1}
-              {strip}
-                <table class="form-layout-compressed">
-                <tr>
-                {* sort by fails for option per line. Added a variable to iterate through the element array*}
-                  {foreach name=outer key=key item=item from=$form.$profileFieldName}
-                    {* There are both numeric and non-numeric keys mixed in here, where the non-numeric are metadata that aren't arrays with html members. *}
-                    {if is_array($item) && array_key_exists('html', $item)}
-                      <td class="labels font-light">{$form.$profileFieldName.$key.html}</td>
-                      {if $count == $field.options_per_line}
-                      </tr>
-                      <tr>
-                        {assign var="count" value=1}
-                        {else}
-                        {assign var="count" value=$count+1}
-                      {/if}
-                    {/if}
-                  {/foreach}
-                </tr>
-                </table>
-              {/strip}
-            </div>
-            <div class="clear"></div>
+          {include file="CRM/UF/Form/FieldRadioOptionsPerLine.tpl"}
           </div>{* end of main edit section div*}
-          {else}
+        {else}
           <div id="editrow-{$profileFieldName}" class="crm-section editrow_{$profileFieldName}-section form-item">
             <div class="label">
               {$form.$profileFieldName.label}

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -61,7 +61,8 @@
         {continue}
       {/if}
       {assign var="profileID" value=$field.group_id}
-      {assign var=n value=$field.name}
+      {assign var="profileFieldName" value=$field.name}
+
       {if $field.groupTitle != $fieldset}
         {if $mode neq 8 && $mode neq 4}
           <div {if $context neq 'dialog'}id="profilewrap{$field.group_id}"{/if}>
@@ -75,7 +76,7 @@
       {/if}
       {if $field.field_type eq "Formatting"}
         {$field.help_pre}
-      {elseif $n}
+      {elseif $profileFieldName}
         {if $field.groupTitle != $fieldset}
           {if $fieldset != $zeroField}
             {if $groupHelpPost}
@@ -89,24 +90,24 @@
           {/if}
         <div class="form-layout-compressed">
         {/if}
-        {if $field.help_pre && $action neq 4 && $form.$n.html}
-          <div class="crm-section helprow-{$n}-section helprow-pre" id="helprow-{$n}">
+        {if $field.help_pre && $action neq 4 && $form.$profileFieldName.html}
+          <div class="crm-section helprow-{$profileFieldName}-section helprow-pre" id="helprow-{$profileFieldName}">
             <div class="content description">{$field.help_pre}</div>
           </div>
         {/if}
         {if array_key_exists('options_per_line', $field) && $field.options_per_line}
-          <div class="crm-section editrow_{$n}-section form-item" id="editrow-{$n}">
-            <div class="label">{$form.$n.label}</div>
+          <div class="crm-section editrow_{$profileFieldName}-section form-item" id="editrow-{$profileFieldName}">
+            <div class="label">{$form.$profileFieldName.label}</div>
             <div class="content edit-value">
               {assign var="count" value=1}
               {strip}
                 <table class="form-layout-compressed">
                 <tr>
                 {* sort by fails for option per line. Added a variable to iterate through the element array*}
-                  {foreach name=outer key=key item=item from=$form.$n}
+                  {foreach name=outer key=key item=item from=$form.$profileFieldName}
                     {* There are both numeric and non-numeric keys mixed in here, where the non-numeric are metadata that aren't arrays with html members. *}
                     {if is_array($item) && array_key_exists('html', $item)}
-                      <td class="labels font-light">{$form.$n.$key.html}</td>
+                      <td class="labels font-light">{$form.$profileFieldName.$key.html}</td>
                       {if $count == $field.options_per_line}
                       </tr>
                       <tr>
@@ -123,21 +124,21 @@
             <div class="clear"></div>
           </div>{* end of main edit section div*}
           {else}
-          <div id="editrow-{$n}" class="crm-section editrow_{$n}-section form-item">
+          <div id="editrow-{$profileFieldName}" class="crm-section editrow_{$profileFieldName}-section form-item">
             <div class="label">
-              {$form.$n.label}
+              {$form.$profileFieldName.label}
             </div>
             <div class="edit-value content">
-              {if $n|substr:0:3 eq 'im-'}
-                {assign var="provider" value="$n-provider_id"}
+              {if $profileFieldName|substr:0:3 eq 'im-'}
+                {assign var="provider" value="$profileFieldName-provider_id"}
                 {$form.$provider.html}&nbsp;
               {/if}
-              {if $n eq 'email_greeting' or  $n eq 'postal_greeting' or $n eq 'addressee'}
+              {if $profileFieldName eq 'email_greeting' or  $profileFieldName eq 'postal_greeting' or $profileFieldName eq 'addressee'}
                 {include file="CRM/Profile/Form/GreetingType.tpl"}
-              {elseif ( $n eq 'group' && $form.group ) || ( $n eq 'tag' && $form.tag )}
-                {include file="CRM/Contact/Form/Edit/TagsAndGroups.tpl" type=$n context="profile" tableLayout=1}
-              {elseif ( $form.$n.name eq 'image_URL' )}
-                {$form.$n.html}
+              {elseif ( $profileFieldName eq 'group' && $form.group ) || ( $profileFieldName eq 'tag' && $form.tag )}
+                {include file="CRM/Contact/Form/Edit/TagsAndGroups.tpl" type=$profileFieldName context="profile" tableLayout=1}
+              {elseif ( $form.$profileFieldName.name eq 'image_URL' )}
+                {$form.$profileFieldName.html}
                 {if !empty($imageURL)}
                   <div class="crm-section contact_image-section">
                     <div class="content">
@@ -145,19 +146,19 @@
                     </div>
                   </div>
                  {/if}
-              {elseif $n|substr:0:5 eq 'phone'}
-                {assign var="phone_ext_field" value=$n|replace:'phone':'phone_ext'}
-                {$form.$n.html}
+              {elseif $profileFieldName|substr:0:5 eq 'phone'}
+                {assign var="phone_ext_field" value=$profileFieldName|replace:'phone':'phone_ext'}
+                {$form.$profileFieldName.html}
                 {if $form.$phone_ext_field.html}
                 &nbsp;{$form.$phone_ext_field.html}
                 {/if}
               {else}
                 {if $field.html_type neq 'File' || ($field.html_type eq 'File' && !$field.is_view)}
-                   {$form.$n.html}
+                   {$form.$profileFieldName.html}
                 {/if}
                 {if $field.html_type eq 'Autocomplete-Select'}
                   {if $field.data_type eq 'ContactReference'}
-                    {include file="CRM/Custom/Form/ContactReference.tpl" element_name = $n}
+                    {include file="CRM/Custom/Form/ContactReference.tpl" element_name = $profileFieldName}
                   {/if}
                 {/if}
               {/if}
@@ -165,17 +166,17 @@
             <div class="clear"></div>
           </div>
 
-          {if $form.$n.type eq 'file'}
-            <div class="crm-section file_displayURL-section file_displayURL{$n}-section"><div class="content">{$customFiles.$n.displayURL}</div></div>
-            {if !$fields.$n.is_view}
-               <div class="crm-section file_deleteURL-section file_deleteURL{$n}-section"><div class="content">{$customFiles.$n.deleteURL}</div></div>
+          {if $form.$profileFieldName.type eq 'file'}
+            <div class="crm-section file_displayURL-section file_displayURL{$profileFieldName}-section"><div class="content">{$customFiles.$profileFieldName.displayURL}</div></div>
+            {if !$fields.$profileFieldName.is_view}
+               <div class="crm-section file_deleteURL-section file_deleteURL{$profileFieldName}-section"><div class="content">{$customFiles.$profileFieldName.deleteURL}</div></div>
             {/if}
           {/if}
         {/if}
 
       {* Show explanatory text for field if not in 'view' mode *}
-        {if $field.help_post && $action neq 4 && $form.$n.html}
-          <div class="crm-section helprow-{$n}-section helprow-post" id="helprow-{$n}">
+        {if $field.help_post && $action neq 4 && $form.$profileFieldName.html}
+          <div class="crm-section helprow-{$profileFieldName}-section helprow-post" id="helprow-{$profileFieldName}">
             <div class="content description">{$field.help_post}</div>
           </div>
         {/if}

--- a/templates/CRM/UF/Form/FieldRadioOptionsPerLine.tpl
+++ b/templates/CRM/UF/Form/FieldRadioOptionsPerLine.tpl
@@ -1,0 +1,20 @@
+<div class="crm-section editrow_{$profileFieldName}-section form-item" id="editrow-{$rowIdentifier}">
+  <div class="label option-label">{$formElement.label}</div>
+  <div class="content">
+    <div class="crm-multiple-checkbox-radio-options crm-options-per-line" style="--crm-opts-per-line:{$field.options_per_line};">
+      {foreach name=outer key=key item=item from=$formElement}
+        {if is_array($item) && array_key_exists('html', $item)}
+          <div class="crm-option-label-pair" >{$formElement.$key.html}</div>
+        {/if}
+      {/foreach}
+    </div>
+    {* Include the edit options list for admins *}
+    {if $formElement.html|strstr:"crm-option-edit-link"}
+      {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@":"$1"}
+    {else}
+      {$formElement.html}
+    {/if}
+  </div>
+  <div class="clear"></div>
+</div>
+<div class="clear"></div>

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -24,23 +24,7 @@
       </div>
     {/if}
     {if array_key_exists('options_per_line', $field) && $field.options_per_line != 0}
-      <div class="crm-section editrow_{$profileFieldName}-section form-item" id="editrow-{$rowIdentifier}">
-        <div class="label option-label">{$formElement.label}</div>
-        <div class="content">
-          <div class="crm-multiple-checkbox-radio-options crm-options-per-line" style="--crm-opts-per-line:{$field.options_per_line};">
-            {foreach name=outer key=key item=item from=$formElement}
-              {if is_array($item) && array_key_exists('html', $item)}
-                <div class="crm-option-label-pair" >{$formElement.$key.html}</div>
-              {/if}
-            {/foreach}
-          </div>
-          {* Include the edit options list for admins *}
-          {if $formElement.html|strstr:"crm-option-edit-link"}
-            {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@":"$1"}
-          {/if}
-        </div>
-        <div class="clear"></div>
-      </div>
+      {include file="CRM/UF/Form/FieldRadioOptionsPerLine.tpl"}
     {else}
       <div class="crm-section editrow_{$profileFieldName}-section form-item" id="editrow-{$rowIdentifier}">
         <div class="label">


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5566 Fix clear options not showing for non-admin user

Before
----------------------------------------
When a non admin user views a profile with a radio custom field in it with options_per_line set to 2 the clear link is missing. Depending on how the profile is accessed it may also be missing for non-admin users

![image](https://github.com/user-attachments/assets/fd60856a-27e8-4bc5-b31f-5cdc7f8fb6b8)


After
----------------------------------------
![image](https://github.com/user-attachments/assets/83c55c86-fb58-4d97-8cde-a237e9066217)

Technical Details
----------------------------------------
This is confusing cos replication is hard - in part due to caching & also because viewing profiles in different ways accesses different tpls

1) the Dynamic tpl - this is at (e.g) https://dmaster.localhost:32353/civicrm/profile/create?gid=1&reset=1
2) the fields.tpl - this is accessed at (e.g) https://dmaster.localhost:32353/civicrm/admin/uf/group/preview?reset=1&gid=1&fieldId=1

Prior to this change the edit & clear never rendered at all in the former tpl and in the latter tpl the clear was not displayed unless the edit was ALSO displayed. This changes it so they both share a tpl snippet and the clear should always be present

Comments
----------------------------------------