### PR TITLE
dev/core#5571 dev/core#5566 Fix regressions on radio options rendering in profiles

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -771,11 +771,16 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
           $qf->add('text', $elementName . '_to', ts('To'), $fieldAttributes);
         }
         else {
+          $separator = NULL;
           $fieldAttributes = array_merge($fieldAttributes, $customFieldAttributes);
           if ($search || empty($useRequired)) {
             $fieldAttributes['allowClear'] = TRUE;
           }
-          $qf->addRadio($elementName, $label, $options, $fieldAttributes, NULL, $useRequired);
+          if ($field->options_per_line) {
+            $fieldAttributes['options_per_line'] = $field->options_per_line;
+            $separator = '';
+          }
+          $qf->addRadio($elementName, $label, $options, $fieldAttributes, $separator, $useRequired);
         }
         break;
 

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -390,7 +390,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       $this->_state->setName($this->_name);
     }
     $this->_action = (int) $action;
-
+    $this->registerElementType('radio_with_div', 'CRM/Core/QuickForm/RadioWithDiv.php', 'CRM_Core_QuickForm_RadioWithDiv');
     $this->registerRules();
 
     // let the constructor initialize this, should happen only once
@@ -1494,7 +1494,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       if ($required) {
         $optAttributes['class'] .= ' required';
       }
-      $element = $this->createElement('radio', NULL, NULL, $var, $key, $optAttributes);
+      $element = $this->createElement('radio_with_div', NULL, NULL, $var, $key, $optAttributes);
       $options[] = $element;
     }
     $group = $this->addGroup($options, $name, $title, $separator);

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -391,6 +391,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     }
     $this->_action = (int) $action;
     $this->registerElementType('radio_with_div', 'CRM/Core/QuickForm/RadioWithDiv.php', 'CRM_Core_QuickForm_RadioWithDiv');
+    $this->registerElementType('group_with_div', 'CRM/Core/QuickForm/GroupWithDiv.php', 'CRM_Core_QuickForm_GroupWithDiv');
     $this->registerRules();
 
     // let the constructor initialize this, should happen only once
@@ -1497,7 +1498,13 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       $element = $this->createElement('radio_with_div', NULL, NULL, $var, $key, $optAttributes);
       $options[] = $element;
     }
-    $group = $this->addGroup($options, $name, $title, $separator);
+    if (!empty($attributes['options_per_line'])) {
+      $group = $this->addElement('group_with_div', $name, $title, $options, $separator, TRUE);
+      $group->setAttribute('options_per_line', $attributes['options_per_line']);
+    }
+    else {
+      $group = $this->addGroup($options, $name, $title, $separator);
+    }
 
     $optionEditKey = 'data-option-edit-path';
     if (!empty($attributes[$optionEditKey])) {

--- a/CRM/Core/QuickForm/GroupWithDiv.php
+++ b/CRM/Core/QuickForm/GroupWithDiv.php
@@ -16,15 +16,15 @@
  *
  */
 
-require_once 'HTML/QuickForm/radio.php';
+require_once 'HTML/QuickForm/group.php';
 
 /**
- * Class CRM_Core_QuickForm_RadioWithDiv
+ * Class CRM_Core_QuickForm_GroupWithDiv
  */
-class CRM_Core_QuickForm_RadioWithDiv extends HTML_QuickForm_radio {
+class CRM_Core_QuickForm_GroupWithDiv extends HTML_QuickForm_group {
 
   /**
-   * Returns the radio element in HTML
+   * Returns the group element in HTML
    *
    * @since     1.0
    * @access    public
@@ -33,7 +33,7 @@ class CRM_Core_QuickForm_RadioWithDiv extends HTML_QuickForm_radio {
   public function toHtml(): string {
     $html = parent::toHtml();
     if (is_numeric($this->getAttribute('options_per_line'))) {
-      return '<div class="crm-option-label-pair" >' . $html . '</div>';
+      return '<div class="crm-multiple-checkbox-radio-options crm-options-per-line" style="--crm-opts-per-line:' . $this->getAttribute('options_per_line') . ';">' . $html . '</div>';
     }
     return $html;
   }

--- a/CRM/Core/QuickForm/RadioWithDiv.php
+++ b/CRM/Core/QuickForm/RadioWithDiv.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright U.S. PIRG Education Fund 2007
+ *
+ */
+
+require_once 'HTML/QuickForm/radio.php';
+
+/**
+ * Class CRM_Core_QuickForm_RadioWithDiv
+ */
+class CRM_Core_QuickForm_RadioWithDiv extends HTML_QuickForm_radio {
+
+  /**
+   * Returns the radio element in HTML
+   *
+   * @since     1.0
+   * @access    public
+   * @return    string
+   */
+  function toHtml()
+  {
+    $html = parent::toHtml();
+    if (is_numeric( $this->getAttribute('options_per_line'))) {
+      return '<div class="crm-option-label-pair" >' . $html. '</div>';
+    }
+    return $html;
+  }
+
+}

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -62,6 +62,8 @@
       {/if}
       {assign var="profileID" value=$field.group_id}
       {assign var="profileFieldName" value=$field.name}
+      {assign var="formElement" value=$form.$profileFieldName}
+      {assign var="rowIdentifier" value=$field.name}
 
       {if $field.groupTitle != $fieldset}
         {if $mode neq 8 && $mode neq 4}
@@ -99,30 +101,10 @@
           <div class="crm-section editrow_{$profileFieldName}-section form-item" id="editrow-{$profileFieldName}">
             <div class="label">{$form.$profileFieldName.label}</div>
             <div class="content edit-value">
-              {assign var="count" value=1}
-              {strip}
-                <table class="form-layout-compressed">
-                <tr>
-                {* sort by fails for option per line. Added a variable to iterate through the element array*}
-                  {foreach name=outer key=key item=item from=$form.$profileFieldName}
-                    {* There are both numeric and non-numeric keys mixed in here, where the non-numeric are metadata that aren't arrays with html members. *}
-                    {if is_array($item) && array_key_exists('html', $item)}
-                      <td class="labels font-light">{$form.$profileFieldName.$key.html}</td>
-                      {if $count == $field.options_per_line}
-                      </tr>
-                      <tr>
-                        {assign var="count" value=1}
-                        {else}
-                        {assign var="count" value=$count+1}
-                      {/if}
-                    {/if}
-                  {/foreach}
-                </tr>
-                </table>
-              {/strip}
-            </div>
+              {$formElement.html}
+             </div>
             <div class="clear"></div>
-          </div>{* end of main edit section div*}
+          </div>
           {else}
           <div id="editrow-{$profileFieldName}" class="crm-section editrow_{$profileFieldName}-section form-item">
             <div class="label">

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -30,10 +30,6 @@
           <div class="crm-multiple-checkbox-radio-options crm-options-per-line" style="--crm-opts-per-line:{$field.options_per_line};">
             {$formElement.html}
           </div>
-          {* Include the edit options list for admins *}
-          {if $formElement.html|strstr:"crm-option-edit-link"}
-            {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@":"$1"}
-          {/if}
         </div>
         <div class="clear"></div>
       </div>

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -28,11 +28,7 @@
         <div class="label option-label">{$formElement.label}</div>
         <div class="content">
           <div class="crm-multiple-checkbox-radio-options crm-options-per-line" style="--crm-opts-per-line:{$field.options_per_line};">
-            {foreach name=outer key=key item=item from=$formElement}
-              {if is_array($item) && array_key_exists('html', $item)}
-                <div class="crm-option-label-pair" >{$formElement.$key.html}</div>
-              {/if}
-            {/foreach}
+            {$formElement.html}
           </div>
           {* Include the edit options list for admins *}
           {if $formElement.html|strstr:"crm-option-edit-link"}


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to https://github.com/civicrm/civicrm-core/pull/31705 

@totten @artfulrobot  - this is my preferred approach



Before
----------------------------------------
This addresses 2 regressions from This change https://github.com/civicrm/civicrm-core/commit/b163ff876e01d2363e5346ea2720400bae6b81a3#diff-6848a25bfee634154a321db3c9c9125345b96609e62dcf7155ecbdd4d4fe4f64L35 that affect Radio Custom Fields in profiles when the 'options_per_line' is set

That PR improved the mark-up but by trying to alter it post render & missed some edge cases - this moves the markup to pre-render

1) when the field is not required :  the 'clear' button is missing for non admin users (and always missing on the uf screen - e.g https://dmaster.localhost:32353/civicrm/profile/create?gid=1&reset=1 - but that is longer standing )

2) when the field is required : the options html renders twice if when rendering the 'required field missing' if not entered

After
----------------------------------------
Both of the above are fixed when options_per_line is set - as of writing I have not tested when they are not set but expect the issues may persist as they are in a separate copy & paste of the code

Technical Details
----------------------------------------

I think this is the right approach - but I have only looked at the ones with options_per_line set - I think it would be extended for the others. I suspect the classes should be renamed to 'crm_radio' and 'crm_group' rather than 'radio_with_div' and 'group_with_div' since I think I land on these being classes to add civi-specific divs rather than try to make them flexible enough to force in the relevant divs / html from the outside

Comments
----------------------------------------
