### PR TITLE
[REF] Fix notice error if accepted credit cards field IS NULL

### DIFF
--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -333,7 +333,7 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
     $cards = json_decode(CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_PaymentProcessor',
           $this->_id,
           'accepted_credit_cards'
-        ), TRUE);
+         ) ?? '', TRUE);
     $acceptedCards = [];
     if (!empty($cards)) {
       foreach ($cards as $card => $val) {


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix a potential notice error if getFieldValue returns NULL that would cause a notice error when json_decode is expecting a string

Before
----------------------------------------
Possible notice error about passing NULL into json_decode

After
----------------------------------------
No Notice

@eileenmcnaughton @demeritcowboy 