### PR TITLE
Check if property is set before using

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -277,7 +277,7 @@ abstract class AbstractAction implements \ArrayAccess {
     $params = [];
     $magicProperties = $this->getMagicProperties();
     foreach ($magicProperties as $name => $bool) {
-      $params[$name] = $this->$name;
+      $params[$name] = $this->$name ?? NULL;
     }
     return $params;
   }


### PR DESCRIPTION
In later versions of php it is necessary to check if a property isset before accessing as a typed property will give an error if it is accessed before it is set
