### PR TITLE
Update info.xml for search_kit_reports and fix links in search_kit chart_kit 

### DIFF
--- a/ext/chart_kit/info.xml
+++ b/ext/chart_kit/info.xml
@@ -9,7 +9,7 @@
     <email>ben@civicrm.org</email>
   </maintainer>
   <urls>
-    <url desc="Documentation">https://docs.civicrm.org/user/en/latest/the-user-interface/search-kit/</url>
+    <url desc="Documentation">https://docs.civicrm.org/user/en/latest/searching/searchkit/what-is-searchkit/</url>
     <url desc="Chat">https://chat.civicrm.org/civicrm/channels/search-improvements</url>
     <url desc="Issues">https://lab.civicrm.org/dev/report/-/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>

--- a/ext/chart_kit/info.xml
+++ b/ext/chart_kit/info.xml
@@ -10,7 +10,7 @@
   </maintainer>
   <urls>
     <url desc="Documentation">https://docs.civicrm.org/user/en/latest/searching/searchkit/what-is-searchkit/</url>
-    <url desc="Chat">https://chat.civicrm.org/civicrm/channels/search-improvements</url>
+    <url desc="Chat">https://chat.civicrm.org/civicrm/channels/dataviz</url>
     <url desc="Issues">https://lab.civicrm.org/dev/report/-/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>

--- a/ext/search_kit/info.xml
+++ b/ext/search_kit/info.xml
@@ -9,7 +9,7 @@
     <email>coleman@civicrm.org</email>
   </maintainer>
   <urls>
-    <url desc="Documentation">https://docs.civicrm.org/user/en/latest/the-user-interface/search-kit/</url>
+    <url desc="Documentation">https://docs.civicrm.org/user/en/latest/searching/searchkit/what-is-searchkit/</url>
     <url desc="Chat">https://chat.civicrm.org/civicrm/channels/search-improvements</url>
     <url desc="Issues">https://lab.civicrm.org/dev/report/-/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>

--- a/ext/search_kit_reports/info.xml
+++ b/ext/search_kit_reports/info.xml
@@ -12,7 +12,7 @@
     </author>
   </authors>
   <urls>
-    <url desc="Documentation">https://docs.civicrm.org/user/en/latest/the-user-interface/search-kit/</url>
+    <url desc="Documentation">https://docs.civicrm.org/user/en/latest/searching/searchkit/what-is-searchkit/</url>
     <url desc="Chat">https://chat.civicrm.org/civicrm/channels/search-improvements</url>
     <url desc="Issues">https://lab.civicrm.org/dev/report/-/issues</url>
     <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>

--- a/ext/search_kit_reports/info.xml
+++ b/ext/search_kit_reports/info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <extension key="search_kit_reports" type="module">
   <file>search_kit_reports</file>
-  <name>search_kit_reports</name>
+  <name>Search Kit Reports</name>
   <description>SearchKit-based Reports UI</description>
   <license>AGPL-3.0</license>
   <authors>
@@ -12,16 +12,16 @@
     </author>
   </authors>
   <urls>
-    <url desc="Main Extension Page">https://FIXME</url>
-    <url desc="Documentation">https://FIXME</url>
-    <url desc="Support">https://FIXME</url>
+    <url desc="Documentation">https://docs.civicrm.org/user/en/latest/the-user-interface/search-kit/</url>
+    <url desc="Chat">https://chat.civicrm.org/civicrm/channels/search-improvements</url>
+    <url desc="Issues">https://lab.civicrm.org/dev/report/-/issues</url>
     <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-11-27</releaseDate>
-  <version>1.0.0</version>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>5.81</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <comments>SearchKit-based reporting UI</comments>
   <classloader>
@@ -29,9 +29,9 @@
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
   <civix>
-    <namespace>CRM/AfformReports</namespace>
+    <namespace>CRM/SearchKitReports</namespace>
     <format>24.09.1</format>
-    <angularModule>afReports</angularModule>
+    <angularModule>crmSearchKitReports</angularModule>
   </civix>
   <mixins>
     <mixin>mgd-php@1.0.0</mixin>


### PR DESCRIPTION
Before
----------------------------------------
- static release declarations
- old namespace declarations (used to be called afform_reports)
- FIXME links
- broken docs link for search kit
- chart kit links to search kit mattermost channel

After
----------------------------------------
- use core version tag for release declarations
- updated namespace declarations 
- actual links
- fixed link to search kit docs
- used new dataviz mattermost channel for chart kit chat link


