### PR TITLE
SearchKit - Improve the UI for sql functions

### DIFF
--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -224,6 +224,7 @@ abstract class SqlFunction extends SqlExpression {
         'flag_after' => [],
         'optional' => FALSE,
         'must_be' => ['SqlField', 'SqlFunction', 'SqlString', 'SqlNumber', 'SqlNull'],
+        'can_be_empty' => FALSE,
         'api_default' => NULL,
       ];
       if (!$param['max_expr']) {

--- a/Civi/Api4/Query/SqlFunctionCOALESCE.php
+++ b/Civi/Api4/Query/SqlFunctionCOALESCE.php
@@ -26,6 +26,7 @@ class SqlFunctionCOALESCE extends SqlFunction {
         'max_expr' => 99,
         'optional' => FALSE,
         'label' => ts('Value?'),
+        'can_be_empty' => TRUE,
       ],
     ];
   }

--- a/Civi/Api4/Query/SqlFunctionCONCAT_WS.php
+++ b/Civi/Api4/Query/SqlFunctionCONCAT_WS.php
@@ -26,12 +26,14 @@ class SqlFunctionCONCAT_WS extends SqlFunction {
         'optional' => FALSE,
         'must_be' => ['SqlString'],
         'label' => ts('Separator'),
+        'can_be_empty' => TRUE,
       ],
       [
         'max_expr' => 99,
         'optional' => FALSE,
         'must_be' => ['SqlField', 'SqlString'],
         'label' => ts('Plus'),
+        'can_be_empty' => TRUE,
       ],
     ];
   }

--- a/Civi/Api4/Query/SqlFunctionIF.php
+++ b/Civi/Api4/Query/SqlFunctionIF.php
@@ -29,11 +29,13 @@ class SqlFunctionIF extends SqlFunction {
         'optional' => FALSE,
         'must_be' => ['SqlField', 'SqlString', 'SqlNumber', 'SqlNull', 'SqlFunction'],
         'label' => ts('Then'),
+        'can_be_empty' => TRUE,
       ],
       [
         'optional' => FALSE,
         'must_be' => ['SqlField', 'SqlString', 'SqlNumber', 'SqlNull', 'SqlFunction'],
         'label' => ts('Else'),
+        'can_be_empty' => TRUE,
       ],
     ];
   }

--- a/Civi/Api4/Query/SqlFunctionIFNULL.php
+++ b/Civi/Api4/Query/SqlFunctionIFNULL.php
@@ -29,6 +29,7 @@ class SqlFunctionIFNULL extends SqlFunction {
         'optional' => FALSE,
         'must_be' => ['SqlField', 'SqlFunction', 'SqlString', 'SqlNumber', 'SqlNull'],
         'label' => ts('Fallback value'),
+        'can_be_empty' => TRUE,
       ],
     ];
   }

--- a/Civi/Api4/Query/SqlFunctionLEAST.php
+++ b/Civi/Api4/Query/SqlFunctionLEAST.php
@@ -27,6 +27,7 @@ class SqlFunctionLEAST extends SqlFunction {
         'min_expr' => 2,
         'optional' => FALSE,
         'label' => ts('Else'),
+        'can_be_empty' => TRUE,
       ],
     ];
   }

--- a/Civi/Api4/Query/SqlFunctionREPLACE.php
+++ b/Civi/Api4/Query/SqlFunctionREPLACE.php
@@ -36,6 +36,7 @@ class SqlFunctionREPLACE extends SqlFunction {
         'optional' => FALSE,
         'must_be' => ['SqlString', 'SqlField'],
         'label' => ts('Replace'),
+        'can_be_empty' => TRUE,
       ],
     ];
   }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -61,6 +61,7 @@
           name: param.name,
           value: val
         });
+        this.writeExpr();
       };
 
       function initFunction() {
@@ -196,11 +197,9 @@
       this.writeExpr = function() {
         if (ctrl.fnName) {
           var args = _.transform(ctrl.args, function(args, arg, index) {
-            if (arg.value || arg.value === 0 || arg.flag_before) {
-              var prefix = arg.flag_before || arg.name ? (index ? ' ' : '') + (arg.flag_before || arg.name) + (arg.value ? ' ' : '') : (index ? ', ' : '');
-              var suffix = arg.flag_after ? ' ' + arg.flag_after : '';
-              args.push(prefix + (arg.type === 'string' ? JSON.stringify(arg.value) : arg.value) + suffix);
-            }
+            var prefix = arg.flag_before || arg.name ? (index ? ' ' : '') + (arg.flag_before || arg.name) + (arg.value ? ' ' : '') : (index ? ', ' : '');
+            var suffix = arg.flag_after ? ' ' + arg.flag_after : '';
+            args.push(prefix + (arg.type === 'string' ? JSON.stringify(arg.value) : arg.value) + suffix);
           });
           // Replace fake function "e"
           ctrl.expr = (ctrl.fnName === 'e' ? '' : ctrl.fnName) + '(';

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -11,10 +11,10 @@
     },
     templateUrl: '~/crmSearchAdmin/crmSearchFunction.html',
     controller: function($scope, formatForSelect2, searchMeta) {
-      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
-        ctrl = this;
+      const ts = $scope.ts = CRM.ts('org.civicrm.search_kit');
+      const ctrl = this;
 
-      var allTypes = {
+      const allTypes = {
         aggregate: ts('Aggregate'),
         comparison: ts('Comparison'),
         date: ts('Date'),
@@ -22,14 +22,17 @@
         string: ts('Text')
       };
 
-      this.exprTypes = {
-        SqlField: {label: ts('Field'), type: 'field'},
-        SqlString: {label: ts('Text'), type: 'string'},
-        SqlNumber: {label: ts('Number'), type: 'number'},
-      };
+      this.sqlExprTypes = [
+        {type: 'SqlField', label: ts('Field'), name: 'field', icon: 'fa-database'},
+        {type: 'SqlString', label: ts('Text'), name: 'string', icon: 'fa-i-cursor'},
+        {type: 'SqlNumber', label: ts('Number'), name: 'number', icon: 'fa-hashtag'},
+      ];
+
+      this.exprTypesByType = this.sqlExprTypes.reduce((acc, item) => (acc[item.type] = item, acc), {});
+      this.exprTypesByName = this.sqlExprTypes.reduce((acc, item) => (acc[item.name] = item, acc), {});
 
       this.$onInit = function() {
-        var info = searchMeta.parseExpr(ctrl.expr);
+        const info = searchMeta.parseExpr(ctrl.expr);
         ctrl.fieldArg = _.findWhere(info.args, {type: 'field'});
         ctrl.args = info.args;
         ctrl.fn = info.fn;
@@ -44,22 +47,14 @@
         }
       });
 
-      this.addArg = function(exprType, optional) {
-        var param = ctrl.getParam(ctrl.args.length),
-          val = '';
-        if (exprType === 'SqlNumber') {
-          // Number: default to 0
-          val = 0;
-        } else if (exprType === 'SqlField' && !optional) {
-          // Field: Default to first available field, making it easier to delete the value
-          val = ctrl.getFields().results[0].children[0].id;
-        }
+      this.addArg = function(sqlExprType, optional) {
+        const param = ctrl.getParam(ctrl.args.length);
         ctrl.args.push({
-          type: ctrl.exprTypes[exprType].type,
+          type: ctrl.exprTypesByType[sqlExprType].name,
           flag_before: _.filter(_.keys(param.flag_before))[0],
           flag_after: _.filter(_.keys(param.flag_after))[0],
           name: param.name,
-          value: val
+          value: '',
         });
         this.writeExpr();
       };
@@ -98,6 +93,17 @@
           return false;
         }
         return ctrl.args.length - index < param.max_expr;
+      };
+
+      this.canRemoveArg = function(index) {
+        if (!ctrl.fn) {
+          return false;
+        }
+        // If this param accepts multiple values, all but the first are always removable
+        if (!ctrl.fn.params[index]) {
+          return true;
+        }
+        return ctrl.fn.params[index].optional;
       };
 
       // On-demand options for dropdown function selector
@@ -160,7 +166,7 @@
           while (!_.includes(ctrl.fn.params[pos].must_be, 'SqlField')) {
             exprType = _.first(ctrl.fn.params[pos].must_be);
             ctrl.args.splice(pos, 0, {
-              type: exprType ? ctrl.exprTypes[exprType].type : null,
+              type: exprType ? ctrl.exprTypesByType[exprType].name : null,
               flag_before: _.filter(_.keys(ctrl.fn.params[pos].flag_before))[0],
               flag_after: _.filter(_.keys(ctrl.fn.params[pos].flag_after))[0],
               name: ctrl.fn.params[pos].name,
@@ -178,13 +184,17 @@
         ctrl.writeExpr();
       };
 
-      this.changeArg = function(index) {
-        var val = ctrl.args[index].value,
-          param = ctrl.getParam(index);
-        // Delete empty value if allowed
-        if (index && !val && val !== 0 && !param.optional && ctrl.args.length > param.min_expr) {
-          ctrl.args.splice(index, 1);
+      this.changeArgType = function(arg, type) {
+        if (arg.type === type.name) {
+          return;
         }
+        arg.type = type.name;
+        arg.value = '';
+        this.writeExpr();
+      };
+
+      this.removeArg = function(index) {
+        ctrl.args.splice(index, 1);
         ctrl.writeExpr();
       };
 
@@ -196,10 +206,12 @@
 
       this.writeExpr = function() {
         if (ctrl.fnName) {
-          var args = _.transform(ctrl.args, function(args, arg, index) {
-            var prefix = arg.flag_before || arg.name ? (index ? ' ' : '') + (arg.flag_before || arg.name) + (arg.value ? ' ' : '') : (index ? ', ' : '');
-            var suffix = arg.flag_after ? ' ' + arg.flag_after : '';
-            args.push(prefix + (arg.type === 'string' ? JSON.stringify(arg.value) : arg.value) + suffix);
+          const args = ctrl.args.map((arg, index) => {
+            const value = arg.value === undefined ? '' : arg.value;
+            const prefix = arg.flag_before || arg.name ? (index ? ' ' : '') + (arg.flag_before || arg.name) + (value === '' ? '' : ' ') : (index ? ', ' : '');
+            const suffix = arg.flag_after ? ' ' + arg.flag_after : '';
+
+            return prefix + (arg.type === 'string' || value === '' ? JSON.stringify(value) : value) + suffix;
           });
           // Replace fake function "e"
           ctrl.expr = (ctrl.fnName === 'e' ? '' : ctrl.fnName) + '(';

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.html
@@ -4,12 +4,32 @@
 <label ng-hide="$ctrl.mode !== 'select' && !$ctrl.fn">{{ $ctrl.fieldArg.field.label }}</label>
 
 <div class="form-group" ng-repeat="arg in $ctrl.args">
+  &nbsp;
   <crm-search-function-flag ng-if="$ctrl.fn" flag="flag_before" arg="arg" param="$ctrl.getParam($index)" write-expr="$ctrl.writeExpr()"></crm-search-function-flag>
-  <span ng-switch="arg.type" ng-if="arg !== $ctrl.fieldArg">
-    <input ng-switch-when="number" class="form-control" type="number" ng-model="arg.value" placeholder="{{ $ctrl.getParam($index).label }}" ng-change="$ctrl.changeArg($index)" ng-model-options="{updateOn: 'blur'}">
-    <input ng-switch-when="string" class="form-control" ng-model="arg.value" placeholder="{{ $ctrl.getParam($index).label }}" ng-change="$ctrl.changeArg($index)" ng-trim="false" ng-model-options="{updateOn: 'blur'}">
-    <input ng-switch-when="field" class="form-control" ng-model="arg.value" crm-ui-select="{data: $ctrl.getFields, placeholder: $ctrl.getParam($index).label}" ng-change="$ctrl.changeArg($index)">
-  </span>
+  <div class="input-group" ng-if="arg !== $ctrl.fieldArg" title="{{ $ctrl.getParam($index).label }}">
+    <div class="input-group-btn">
+      <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <i class="crm-i {{ $ctrl.exprTypesByName[arg.type].icon }}"></i>
+        <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu">
+        <li ng-repeat="exprInfo in $ctrl.sqlExprTypes" ng-if="$ctrl.getParam($parent.$index).must_be.indexOf(exprInfo.type) >= 0">
+          <a href ng-click="$ctrl.changeArgType(arg, exprInfo)">
+            <i class="crm-i fa-fw {{ exprInfo.icon }}"></i>
+            {{ exprInfo.label }}
+          </a>
+        </li>
+      </ul>
+    </div>
+    <input ng-if="arg.type === 'number'" class="form-control" type="number" ng-model="arg.value" placeholder="{{ $ctrl.getParam($index).label }}" ng-change="$ctrl.writeExpr()" ng-required="!$ctrl.getParam($index).can_be_empty" ng-model-options="{updateOn: 'blur'}">
+    <input ng-if="arg.type === 'string'" class="form-control" ng-model="arg.value" placeholder="{{ $ctrl.getParam($index).label }}" ng-change="$ctrl.writeExpr()" ng-trim="false" ng-required="!$ctrl.getParam($index).can_be_empty" ng-model-options="{updateOn: 'blur'}">
+    <span ng-if="arg.type === 'field'">
+      <input class="form-control" ng-model="arg.value" crm-ui-select="{data: $ctrl.getFields, placeholder: $ctrl.getParam($index).label, allowClear: false}" required ng-change="$ctrl.writeExpr()">
+    </span>
+    <span class="input-group-btn" ng-if="$ctrl.canRemoveArg($index)">
+      <button class="btn btn-danger" type="button" ng-click="$ctrl.removeArg($index)">x</button>
+    </span>
+  </div>
   <crm-search-function-flag ng-if="$ctrl.fn && arg.value" flag="flag_after" arg="arg" param="$ctrl.getParam($index)" write-expr="$ctrl.writeExpr()"></crm-search-function-flag>
 </div>
 <div class="btn-group" ng-if="$ctrl.canAddArg()">
@@ -17,8 +37,11 @@
     <i class="crm-i fa-plus"></i> <span class="caret"></span>
   </button>
   <ul class="dropdown-menu">
-    <li ng-repeat="(name, type) in $ctrl.exprTypes" ng-show="$ctrl.getParam($ctrl.args.length).must_be.indexOf(name) >= 0">
-      <a href ng-click="$ctrl.addArg(name)">{{ type.label }}</a>
+    <li ng-repeat="exprInfo in $ctrl.sqlExprTypes" ng-if="$ctrl.getParam($ctrl.args.length).must_be.indexOf(exprInfo.type) >= 0">
+      <a href ng-click="$ctrl.addArg(exprInfo.type)">
+        <i class="crm-i fa-fw {{:: exprInfo.icon }}"></i>
+        {{:: exprInfo.label }}
+      </a>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
This started out as a bugfix for https://lab.civicrm.org/dev/core/-/issues/5668 but turned into a UI rewrite.

Before
----------------------------------------
Difficult (sometimes impossible) to change the input type of a sql function value (e.g. text/number/field),
and removing a param could only be done when the type was set to field.

After
----------------------------------------
Each value has a dropdown to select the input type, a red border if required, and a remove button if optional.

![image](https://github.com/user-attachments/assets/5e7820cd-f251-45d7-bb7f-7bd2f9c04ada)
