### PR TITLE
Partial fix for broken tokens in event confirmation email

### DIFF
--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -173,6 +173,13 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
   }
 
   /**
+   * Prevent tokens within URLs on comfirm_email_text from being munged.
+   */
+  protected function getFieldsToExcludeFromPurification(): array {
+    return ['confirm_email_text'];
+  }
+
+  /**
    * Fix what blocks to show/hide based on the default values set
    *
    * @param array $defaults

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -2091,4 +2091,11 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
     $this->assign('priceSet', $this->_priceSet);
   }
 
+  /**
+   * Prevent tokens within URLs on comfirm_email_text from being munged.
+   */
+  protected function getFieldsToExcludeFromPurification(): array {
+    return ['receipt_text'];
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/5676.

Before
----------------------------------------
The email confirmation text gets curly braces within URLs converted to URL encoding, breaking tokens. This happens on  a) the **Manage Event » Online Registration** tab, b)  the **Register Participant** page, and c) the email itself.

After
----------------------------------------
a) and b) are fixed, because we can override `getFieldsToExcludeFromPurification()`. However, the email itself is purified in `Civi\WorkflowMessage\GenericWorkflowMessage::getUserEnteredHTML()`, which has no such bypass.

Comments
----------------------------------------
Given that this was the very field that let to `getPurifiedDefaults()` in the first place, I'm not sure we should be bypassing purification.

In fact, it seems like there's a potential security issue here if purification happens before the tokens are rendered.  