### PR TITLE
dev/core#5640 explicitly disable mod_negotiation MultiViews in default Standalone apache config

### DIFF
--- a/setup/res/htaccess.txt
+++ b/setup/res/htaccess.txt
@@ -16,6 +16,11 @@
 # Don't show directory listings for URLs which map to a directory.
 Options -Indexes
 
+# Disable mod_negotiation MultiViews as it can interfere with rewrites
+<IfModule mod_negotiation.c>
+  Options -MultiViews
+</IfModule>
+
 # Uncomment if you need to follow symbolic links within your Standalone install
 # (Disabled by default as some webhosts may not allow this)
 # Options +FollowSymLinks
@@ -116,3 +121,4 @@ DirectoryIndex index.php index.html index.htm
   # Disable Proxy header, since it's an attack vector.
   RequestHeader unset Proxy
 </IfModule>
+


### PR DESCRIPTION
Overview
----------------------------------------
[mod_negotiation MultiViews](https://httpd.apache.org/docs/current/mod/mod_negotiation.html) seems liable to cause problems if it is enabled. Let's explicitly disable it.

Before
----------------------------------------
- most people MultiViews is disabled by default
- if your webhost has it enabled for some reason, you can't log in to your standalone site https://lab.civicrm.org/dev/core/-/issues/5640
- it may also cause problems with FormBuilder ? https://lab.civicrm.org/dev/core/-/issues/5640#note_175349

After
----------------------------------------
- if mod_negotiation is enabled, MultiViews is explicitly disabled

Technical Details
----------------------------------------
I'm not sure if there are any times this could cause problems. Maybe if a host's apache config forces you to enable this option it will crash - but it is probably better to crash earlier than go through the install process to get a seemingly working site, then be unable to log in.

I found that this the default Laravel .htaccess has similar: https://github.com/laravel/laravel/blob/658a49a19e98a6059a543be7564d39dc2e6970e0/public/.htaccess#L3 ( Here `Options -Indexes` is also inside the IfModule conditional ? Maybe we should do that too? )
