### PR TITLE
riverlea - consistent button alignment for menu and button cols

### DIFF
--- a/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
+++ b/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
@@ -95,7 +95,7 @@ fieldset.af-container.af-layout-inline {
 }
 
 /* Multiple button gap */
-
-#bootstrap-theme .crm-search-col-type-buttons .btn {
+#bootstrap-theme .crm-search-col-type-buttons .btn,
+#bootstrap-theme .crm-search-col-type-menu .btn {
   margin: 0 var(--crm-flex-gap) var(--crm-flex-gap) 0;
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix inconsistent alignment of button in different search kit column types.


Before
----------------------------------------
- buttons in menu and button columns are out of line:
![image](https://github.com/user-attachments/assets/e519ac0d-c010-441a-bd13-6c6a47b47bfc)


[Manage Contribution page with 5.80.1 AdminUI + Standalone 5.80.1 / Riverlea / Thames (+ custom crm-c-primary)]

After
----------------------------------------
- buttons align:
![image](https://github.com/user-attachments/assets/ef839a98-a212-4143-82ea-8d0ff60830c0)

Comments
---------------------------------------
I'm afraid I haven't tested lots of variations, but it makes sense these columns should get the same rules?

cc @vingle 