### PR TITLE
[REF] Api4 - Custom field auto-cleanup improvements

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -977,6 +977,21 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
   }
 
   /**
+   * Callback for hook_civicrm_pre().
+   * @param \Civi\Core\Event\PreEvent $event
+   */
+  public static function on_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
+    // When deleting a custom group, delete all orphaned fields
+    if ($event->entity === 'CustomGroup' && $event->action === 'delete') {
+      $sql = "SELECT id FROM civicrm_custom_field WHERE custom_group_id = " . $event->id;
+      $orphanedFields = CRM_Core_DAO::executeQuery($sql)->fetchAll();
+      if ($orphanedFields) {
+        self::deleteRecords($orphanedFields);
+      }
+    }
+  }
+
+  /**
    * Callback for hook_civicrm_post().
    * @param \Civi\Core\Event\PostEvent $event
    */

--- a/Civi/Test/Api4TestTrait.php
+++ b/Civi/Test/Api4TestTrait.php
@@ -164,7 +164,7 @@ trait Api4TestTrait {
     $extraValues = [];
     foreach ($requiredFields as $fieldName => $field) {
       if (
-        !isset($values[$fieldName]) &&
+        self::isMissingValue($values, $fieldName) &&
         ($field['required'] || AbstractAction::evaluateCondition($field['required_if'], ['values' => $values + $extraValues]))
       ) {
         $extraValues[$fieldName] = $this->getRequiredValue($field);
@@ -249,6 +249,19 @@ trait Api4TestTrait {
 
     $values += $extraValues;
     return $values;
+  }
+
+  private static function isMissingValue(array $values, string $fieldName): bool {
+    // Check if field value is set
+    if (isset($values[$fieldName])) {
+      return FALSE;
+    }
+    // Also check unique-field joins like :name or .name
+    if (isset($values["$fieldName:name"]) || isset($values["$fieldName.name"])) {
+      return FALSE;
+    }
+    // A few other unique-field joins are possible, but not important for unit tests
+    return TRUE;
   }
 
   /**

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -48,8 +48,6 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
       ->addSelect('geoProvider')
       ->execute();
     parent::tearDown();
-    // Skipped by parent because of TransactionalInterface, but needed to delete custom fields & groups
-    $this->deleteTestRecords();
   }
 
   /**

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunWithCustomFieldTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunWithCustomFieldTest.php
@@ -3,18 +3,15 @@ namespace api\v4\SearchDisplay;
 
 // This is apparently necessary due to autoloader issues with test classes
 require_once 'tests/phpunit/api/v4/Api4TestBase.php';
-require_once 'tests/phpunit/api/v4/Custom/CustomTestBase.php';
 
-use api\v4\Custom\CustomTestBase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
-use Civi\Api4\CustomField;
-use Civi\Api4\CustomGroup;
 use Civi\Test\CiviEnvBuilder;
 
 /**
  * @group headless
  */
-class SearchRunWithCustomFieldTest extends CustomTestBase {
+class SearchRunWithCustomFieldTest extends Api4TestBase {
 
   public function setUpHeadless(): CiviEnvBuilder {
     return \Civi\Test::headless()
@@ -44,17 +41,17 @@ class SearchRunWithCustomFieldTest extends CustomTestBase {
    * Test running a searchDisplay with various filters.
    */
   public function testRunWithImageField() {
-    CustomGroup::create(FALSE)
-      ->addValue('title', 'TestSearchFields')
-      ->addValue('extends', 'Individual')
-      ->execute();
+    $this->createTestRecord('CustomGroup', [
+      'title' => 'TestSearchFields',
+      'extends' => 'Individual',
+    ]);
 
-    CustomField::create(FALSE)
-      ->addValue('label', 'MyFile')
-      ->addValue('custom_group_id.name', 'TestSearchFields')
-      ->addValue('html_type', 'File')
-      ->addValue('data_type', 'File')
-      ->execute();
+    $this->createTestRecord('CustomField', [
+      'label' => 'MyFile',
+      'custom_group_id.name' => 'TestSearchFields',
+      'html_type' => 'File',
+      'data_type' => 'File',
+    ]);
 
     $lastName = uniqid(__FUNCTION__);
 
@@ -115,17 +112,17 @@ class SearchRunWithCustomFieldTest extends CustomTestBase {
   }
 
   public function testMultiValuedFields():void {
-    CustomGroup::create(FALSE)
-      ->addValue('extends', 'Contact')
-      ->addValue('title', 'my_test')
-      ->addChain('field', CustomField::create()
-        ->addValue('custom_group_id', '$id')
-        ->addValue('label', 'my_field')
-        ->addValue('html_type', 'Select')
-        ->addValue('serialize', 1)
-        ->addValue('option_values', ['zero', 'one', 'two', 'three'])
-      )
-      ->execute();
+    $this->createTestRecord('CustomGroup', [
+      'extends' => 'Contact',
+      'title' => 'my_test',
+    ]);
+    $this->createTestRecord('CustomField', [
+      'custom_group_id.name' => 'my_test',
+      'label' => 'my_field',
+      'html_type' => 'Select',
+      'serialize' => 1,
+      'option_values' => ['zero', 'one', 'two', 'three'],
+    ]);
 
     $lastName = uniqid(__FUNCTION__);
 
@@ -184,18 +181,18 @@ class SearchRunWithCustomFieldTest extends CustomTestBase {
   }
 
   public function testEntityReferenceJoins() {
-    CustomGroup::create()->setValues([
+    $this->createTestRecord('CustomGroup', [
       'title' => 'EntityRefFields',
       'extends' => 'Individual',
-    ])->execute();
-    CustomField::create()->setValues([
+    ]);
+    $this->createTestRecord('CustomField', [
       'label' => 'Favorite Nephew',
       'name' => 'favorite_nephew',
       'custom_group_id.name' => 'EntityRefFields',
       'html_type' => 'Autocomplete-Select',
       'data_type' => 'EntityReference',
       'fk_entity' => 'Contact',
-    ])->execute();
+    ]);
     $nephewId = $this->createTestRecord('Contact', ['first_name' => 'Dewey', 'last_name' => 'Duck'])['id'];
     $uncleId = $this->createTestRecord('Contact', ['first_name' => 'Donald', 'last_name' => 'Duck', 'EntityRefFields.favorite_nephew' => $nephewId])['id'];
     $contact = Contact::get(FALSE)
@@ -239,16 +236,16 @@ class SearchRunWithCustomFieldTest extends CustomTestBase {
     $contact = $this->createTestRecord('Contact');
 
     // CustomGroup based on Activity Type
-    CustomGroup::create(FALSE)
-      ->addValue('extends', 'Activity')
-      ->addValue('title', 'testactivity2')
-      ->addChain('field', CustomField::create()
-        ->addValue('custom_group_id', '$id')
-        ->addValue('label', 'testactivity_')
-        ->addValue('data_type', 'Boolean')
-        ->addValue('html_type', 'Radio')
-      )
-      ->execute();
+    $this->createTestRecord('CustomGroup', [
+      'extends' => 'Activity',
+      'title' => 'testactivity2',
+    ]);
+    $this->createTestRecord('CustomField', [
+      'custom_group_id.name' => 'testactivity2',
+      'label' => 'testactivity_',
+      'data_type' => 'Boolean',
+      'html_type' => 'Radio',
+    ]);
 
     $sampleData = [
       ['activity_type_id:name' => 'Meeting', 'testactivity2.testactivity_' => TRUE],

--- a/tests/phpunit/api/v4/Action/ContactDuplicatesTest.php
+++ b/tests/phpunit/api/v4/Action/ContactDuplicatesTest.php
@@ -19,13 +19,13 @@
 
 namespace api\v4\Action;
 
-use api\v4\Custom\CustomTestBase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
 
 /**
  * @group headless
  */
-class ContactDuplicatesTest extends CustomTestBase {
+class ContactDuplicatesTest extends Api4TestBase {
 
   public function testGetDuplicatesUnsupervised(): void {
     $email = uniqid('test@');

--- a/tests/phpunit/api/v4/Api4TestBase.php
+++ b/tests/phpunit/api/v4/Api4TestBase.php
@@ -54,7 +54,10 @@ class Api4TestBase extends TestCase implements HeadlessInterface {
   public function tearDown(): void {
     $implements = class_implements($this);
     // If not created in a transaction, test records must be deleted
-    if (!in_array('Civi\Test\TransactionalInterface', $implements, TRUE)) {
+    $needsCleanup = !in_array('Civi\Test\TransactionalInterface', $implements, TRUE) ||
+      // Creating custom groups or custom fields breaks transactions & requires cleanup
+      array_intersect(['CustomField', 'CustomGroup'], array_column($this->testRecords, 0));
+    if ($needsCleanup) {
       $this->deleteTestRecords();
     }
   }

--- a/tests/phpunit/api/v4/Custom/CreateCustomValueTest.php
+++ b/tests/phpunit/api/v4/Custom/CreateCustomValueTest.php
@@ -19,9 +19,9 @@
 
 namespace api\v4\Custom;
 
+use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
 use Civi\Api4\CustomField;
-use Civi\Api4\CustomGroup;
 use Civi\Api4\CustomValue;
 use Civi\Api4\OptionGroup;
 use Civi\Api4\OptionValue;
@@ -30,16 +30,15 @@ use Civi\Api4\Activity;
 /**
  * @group headless
  */
-class CreateCustomValueTest extends CustomTestBase {
+class CreateCustomValueTest extends Api4TestBase {
 
   public function testGetWithCustomData(): void {
     $optionValues = ['r' => 'Red', 'g' => 'Green', 'b' => 'Blue'];
 
-    $customGroup = CustomGroup::create(FALSE)
-      ->addValue('title', 'MyContactFields')
-      ->addValue('extends', 'Contact')
-      ->execute()
-      ->first();
+    $customGroup = $this->createTestRecord('CustomGroup', [
+      'title' => 'MyContactFields',
+      'extends' => 'Contact',
+    ]);
 
     CustomField::create(FALSE)
       ->addValue('label', 'Color')
@@ -96,12 +95,11 @@ class CreateCustomValueTest extends CustomTestBase {
    * Test setting/getting a multivalue customfield with date+time
    */
   public function testCustomDataWithDateTime(): void {
-    CustomGroup::create(FALSE)
-      ->addValue('title', 'MyContactDateFields')
-      ->addValue('name', 'MyContactDateFields')
-      ->addValue('extends', 'Contact')
-      ->addValue('is_multiple', TRUE)
-      ->execute();
+    $this->createTestRecord('CustomGroup', [
+      'title' => 'MyContactDateFields',
+      'extends' => 'Contact',
+      'is_multiple' => TRUE,
+    ]);
 
     CustomField::create(FALSE)
       ->addValue('custom_group_id:name', 'MyContactDateFields')
@@ -140,11 +138,10 @@ class CreateCustomValueTest extends CustomTestBase {
 
   public function testEmptyValueArrayForCustomFields(): void {
     $contactID = $this->createTestRecord('Contact')['id'];
-    CustomGroup::create(FALSE)
-      ->addValue('title', 'MyActivityFields')
-      ->addValue('name', 'MyActivityFields')
-      ->addValue('extends', 'Activity')
-      ->execute();
+    $this->createTestRecord('CustomGroup', [
+      'title' => 'MyActivityFields',
+      'extends' => 'Activity',
+    ]);
 
     $optionValues = ['r' => 'Red', 'g' => 'Green', 'b' => 'Blue'];
     CustomField::create(FALSE)

--- a/tests/phpunit/api/v4/Custom/CreateWithOptionGroupTest.php
+++ b/tests/phpunit/api/v4/Custom/CreateWithOptionGroupTest.php
@@ -19,25 +19,24 @@
 
 namespace api\v4\Custom;
 
+use api\v4\Api4TestBase;
 use Civi\Api4\CustomField;
-use Civi\Api4\CustomGroup;
 use Civi\Api4\Contact;
 
 /**
  * @group headless
  */
-class CreateWithOptionGroupTest extends CustomTestBase {
+class CreateWithOptionGroupTest extends Api4TestBase {
 
   public function testGetWithCustomData(): void {
     $group = uniqid('fava');
     $colorField = uniqid('colora');
     $foodField = uniqid('fooda');
 
-    $customGroupId = CustomGroup::create(FALSE)
-      ->addValue('title', $group)
-      ->addValue('extends', 'Contact')
-      ->execute()
-      ->first()['id'];
+    $customGroupId = $this->createTestRecord('CustomGroup', [
+      'title' => $group,
+      'extends' => 'Contact',
+    ])['id'];
 
     CustomField::create(FALSE)
       ->addValue('label', $colorField)
@@ -57,11 +56,10 @@ class CreateWithOptionGroupTest extends CustomTestBase {
       ->addValue('data_type', 'String')
       ->execute();
 
-    $customGroupId = CustomGroup::create(FALSE)
-      ->addValue('title', 'FinancialStuff')
-      ->addValue('extends', 'Contact')
-      ->execute()
-      ->first()['id'];
+    $customGroupId = $this->createTestRecord('CustomGroup', [
+      'title' => 'FinancialStuff',
+      'extends' => 'Contact',
+    ])['id'];
 
     CustomField::create(FALSE)
       ->addValue('label', 'Salary')
@@ -99,11 +97,10 @@ class CreateWithOptionGroupTest extends CustomTestBase {
     $colorField = uniqid('colorb');
     $foodField = uniqid('foodb');
 
-    $customGroupId = CustomGroup::create(FALSE)
-      ->addValue('title', $group)
-      ->addValue('extends', 'Contact')
-      ->execute()
-      ->first()['id'];
+    $customGroupId = $this->createTestRecord('CustomGroup', [
+      'title' => $group,
+      'extends' => 'Contact',
+    ])['id'];
 
     CustomField::create(FALSE)
       ->addValue('label', $colorField)
@@ -123,11 +120,10 @@ class CreateWithOptionGroupTest extends CustomTestBase {
       ->addValue('data_type', 'String')
       ->execute();
 
-    $customGroupId = CustomGroup::create(FALSE)
-      ->addValue('title', 'FinancialStuff')
-      ->addValue('extends', 'Contact')
-      ->execute()
-      ->first()['id'];
+    $customGroupId = $this->createTestRecord('CustomGroup', [
+      'title' => 'FinancialStuff',
+      'extends' => 'Contact',
+    ])['id'];
 
     CustomField::create(FALSE)
       ->addValue('label', 'Salary')

--- a/tests/phpunit/api/v4/Custom/CustomContactRefTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomContactRefTest.php
@@ -19,23 +19,22 @@
 
 namespace api\v4\Custom;
 
+use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
 use Civi\Api4\CustomField;
-use Civi\Api4\CustomGroup;
 
 /**
  * @group headless
  */
-class CustomContactRefTest extends CustomTestBase {
+class CustomContactRefTest extends Api4TestBase {
 
   public function testGetWithJoin(): void {
     $firstName = uniqid('fav');
 
-    $customGroup = CustomGroup::create(FALSE)
-      ->addValue('title', 'MyContactRef')
-      ->addValue('extends', 'Individual')
-      ->execute()
-      ->first();
+    $customGroup = $this->createTestRecord('CustomGroup', [
+      'title' => 'MyContactRef',
+      'extends' => 'Contact',
+    ]);
 
     CustomField::create(FALSE)
       ->addValue('label', 'FavPerson')
@@ -121,11 +120,10 @@ class CustomContactRefTest extends CustomTestBase {
   public function testCurrentUser(): void {
     $currentUser = $this->createLoggedInUser();
 
-    $customGroup = CustomGroup::create(FALSE)
-      ->addValue('title', 'MyContactRef')
-      ->addValue('extends', 'Individual')
-      ->execute()
-      ->first();
+    $customGroup = $this->createTestRecord('CustomGroup', [
+      'title' => 'MyContactRef',
+      'extends' => 'Contact',
+    ]);
 
     CustomField::create(FALSE)
       ->addValue('label', 'FavPerson')

--- a/tests/phpunit/api/v4/Custom/CustomEntityReferenceTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomEntityReferenceTest.php
@@ -17,9 +17,9 @@
 
 namespace api\v4\Custom;
 
+use api\v4\Api4TestBase;
 use Civi\Api4\Activity;
 use Civi\Api4\Contact;
-use Civi\Api4\CustomGroup;
 use Civi\Api4\CustomField;
 use Civi\Api4\Individual;
 use Civi\Api4\Organization;
@@ -27,17 +27,17 @@ use Civi\Api4\Organization;
 /**
  * @group headless
  */
-class CustomEntityReferenceTest extends CustomTestBase {
+class CustomEntityReferenceTest extends Api4TestBase {
 
   /**
    * Ensure custom fields of type EntityReference correctly apply filters
    */
   public function testEntityReferenceCustomField(): void {
     $subject = uniqid();
-    CustomGroup::create()->setValues([
+    $this->createTestRecord('CustomGroup', [
       'title' => 'EntityRefFields',
       'extends' => 'Individual',
-    ])->execute();
+    ]);
     $field = CustomField::create()->setValues([
       'label' => 'TestActivityReference',
       'custom_group_id.name' => 'EntityRefFields',
@@ -83,10 +83,10 @@ class CustomEntityReferenceTest extends CustomTestBase {
    * Ensure custom fields of type EntityReference correctly apply filters
    */
   public function testEntityReferenceCustomFieldByContactType(): void {
-    CustomGroup::create()->setValues([
+    $this->createTestRecord('CustomGroup', [
       'title' => 'EntityRefFields',
       'extends' => 'Individual',
-    ])->execute();
+    ]);
     CustomField::create()->setValues([
       'label' => 'TestOrgRef',
       'custom_group_id.name' => 'EntityRefFields',

--- a/tests/phpunit/api/v4/Custom/CustomFieldAlterTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomFieldAlterTest.php
@@ -19,6 +19,7 @@
 
 namespace api\v4\Custom;
 
+use api\v4\Api4TestBase;
 use Civi\Api4\Activity;
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
@@ -27,47 +28,50 @@ use Civi\Api4\OptionGroup;
 /**
  * @group headless
  */
-class CustomFieldAlterTest extends CustomTestBase {
+class CustomFieldAlterTest extends Api4TestBase {
 
   public function testChangeSerialize(): void {
     $contact = $this->createTestRecord('Contact');
 
-    $customGroup = CustomGroup::create(FALSE)
-      ->addValue('title', 'MyFieldsToAlter')
-      ->addValue('extends', 'Activity')
-      ->addChain('field1', CustomField::create()
-        ->addValue('custom_group_id', '$id')
-        ->addValue('label', 'TestOptions')
-        ->addValue('html_type', 'Select')
-        ->addValue('option_values', [
-          1 => 'One',
-          2 => 'Two',
-          3 => 'Three',
-          4 => 'Four',
-        ]), 0
-      )
-      ->addChain('field2', CustomField::create()
-        ->addValue('custom_group_id', '$id')
-        ->addValue('label', 'TestText')
-        ->addValue('html_type', 'Text'), 0
-      )
-      ->addChain('field3', CustomField::create()
-        ->addValue('custom_group_id', '$id')
-        ->addValue('serialize', TRUE)
-        ->addValue('label', 'TestCountry')
-        ->addValue('data_type', 'Country')
-        ->addValue('html_type', 'Select'), 0
-      )
-      ->addChain('field4', CustomField::create()
-        ->addValue('custom_group_id', '$id')
-        ->addValue('serialize', TRUE)
-        ->addValue('is_required', TRUE)
-        ->addValue('label', 'TestContact')
-        ->addValue('data_type', 'ContactReference')
-        ->addValue('html_type', 'Autocomplete-Select'), 0
-      )
-      ->execute()
-      ->first();
+    $customGroup = $this->createTestRecord('CustomGroup', [
+      'title' => 'MyFieldsToAlter',
+      'extends' => 'Activity',
+    ]);
+
+    $field1 = CustomField::create(FALSE)->setValues([
+      'custom_group_id' => $customGroup['id'],
+      'label' => 'TestOptions',
+      'html_type' => 'Select',
+      'option_values' => [
+        1 => 'One',
+        2 => 'Two',
+        3 => 'Three',
+        4 => 'Four',
+      ],
+    ])->execute()->single();
+
+    $field2 = CustomField::create(FALSE)->setValues([
+      'custom_group_id' => $customGroup['id'],
+      'label' => 'TestText',
+      'html_type' => 'Text',
+    ])->execute()->single();
+
+    $field3 = CustomField::create(FALSE)->setValues([
+      'custom_group_id' => $customGroup['id'],
+      'serialize' => TRUE,
+      'label' => 'TestCountry',
+      'data_type' => 'Country',
+      'html_type' => 'Select',
+    ])->execute()->single();
+
+    $field4 = CustomField::create(FALSE)->setValues([
+      'custom_group_id' => $customGroup['id'],
+      'serialize' => TRUE,
+      'is_required' => TRUE,
+      'label' => 'TestContact',
+      'data_type' => 'ContactReference',
+      'html_type' => 'Autocomplete-Select',
+    ])->execute()->single();
 
     $sampeData = [
       ['subject' => 'A1', 'MyFieldsToAlter.TestText' => 'A1', 'MyFieldsToAlter.TestOptions' => '1'],
@@ -95,7 +99,7 @@ class CustomFieldAlterTest extends CustomTestBase {
 
     // Change options field to multiselect
     CustomField::update(FALSE)
-      ->addWhere('id', '=', $customGroup['field1']['id'])
+      ->addWhere('id', '=', $field1['id'])
       ->addValue('serialize', TRUE)
       ->execute();
 
@@ -112,7 +116,7 @@ class CustomFieldAlterTest extends CustomTestBase {
 
     // Change back to single-select
     CustomField::update(FALSE)
-      ->addWhere('id', '=', $customGroup['field1']['id'])
+      ->addWhere('id', '=', $field1['id'])
       ->addValue('serialize', FALSE)
       ->execute();
 
@@ -131,7 +135,7 @@ class CustomFieldAlterTest extends CustomTestBase {
 
     // Change country field from multiselect to single
     CustomField::update(FALSE)
-      ->addWhere('id', '=', $customGroup['field3']['id'])
+      ->addWhere('id', '=', $field3['id'])
       ->addValue('serialize', FALSE)
       ->execute();
 
@@ -145,7 +149,7 @@ class CustomFieldAlterTest extends CustomTestBase {
 
     // Change country field from single to multiselect
     CustomField::update(FALSE)
-      ->addWhere('id', '=', $customGroup['field3']['id'])
+      ->addWhere('id', '=', $field3['id'])
       ->addValue('serialize', TRUE)
       ->execute();
 
@@ -160,14 +164,14 @@ class CustomFieldAlterTest extends CustomTestBase {
     // Repeatedly change contact ref field to ensure FK index is correctly added/dropped with no SQL error
     for ($i = 1; $i < 6; ++$i) {
       CustomField::update(FALSE)
-        ->addWhere('id', '=', $customGroup['field4']['id'])
+        ->addWhere('id', '=', $field4['id'])
         ->addValue('serialize', $i % 2 == 0)
         ->addValue('is_required', $i % 2 == 0)
         ->execute();
     }
 
     $this->assertCount(1, OptionGroup::get(FALSE)
-      ->addWhere('id', '=', $customGroup['field1']['option_group_id'])
+      ->addWhere('id', '=', $field1['option_group_id'])
       ->selectRowCount()
       ->execute());
 
@@ -175,27 +179,24 @@ class CustomFieldAlterTest extends CustomTestBase {
     $this->assertNotNull(\CRM_Core_DAO::singleValueQuery("SHOW TABLES LIKE '{$customGroup['table_name']}';"));
 
     $columnCheck = "SELECT COUNT(*) as count
-          FROM INFORMATION_SCHEMA.COLUMNS
-          WHERE table_schema = DATABASE()
-          AND table_name = '{$customGroup['table_name']}'
-          AND column_name = '{$customGroup['field1']['column_name']}'";
-    $this->assertEquals('1', \CRM_Core_DAO::singleValueQuery($columnCheck));
-
-    CustomField::delete(FALSE)
-      ->addWhere('custom_group_id', '=', $customGroup['id'])
-      ->execute();
-
-    // Column should be gone
-    $this->assertEquals('0', \CRM_Core_DAO::singleValueQuery($columnCheck));
-
-    // Option group should be gone
-    $this->assertCount(0, OptionGroup::get(FALSE)
-      ->addWhere('id', '=', $customGroup['field1']['option_group_id'])
-      ->execute());
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE table_schema = DATABASE()
+      AND table_name = '{$customGroup['table_name']}'
+      AND column_name IN ('{$field1['column_name']}', '{$field2['column_name']}', '{$field3['column_name']}', '{$field4['column_name']}')";
+    $this->assertEquals('4', \CRM_Core_DAO::singleValueQuery($columnCheck));
 
     CustomGroup::delete(FALSE)
       ->addWhere('id', '=', $customGroup['id'])
       ->execute();
+
+    // All columns should be gone
+    $this->assertEquals('0', \CRM_Core_DAO::singleValueQuery($columnCheck));
+
+    // Option group should be gone
+    $this->assertCount(0, OptionGroup::get(FALSE)
+      ->addWhere('id', '=', $field1['option_group_id'])
+      ->execute());
+
     // The table should be gone
     $this->assertNull(\CRM_Core_DAO::singleValueQuery("SHOW TABLES LIKE '{$customGroup['table_name']}';"));
   }

--- a/tests/phpunit/api/v4/Custom/CustomFieldGetFieldsTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomFieldGetFieldsTest.php
@@ -19,12 +19,11 @@
 
 namespace api\v4\Custom;
 
+use api\v4\Api4TestBase;
 use Civi\Api4\Activity;
 use Civi\Api4\Contact;
-use Civi\Api4\ContactType;
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
-use Civi\Api4\Event;
 use Civi\Api4\Individual;
 use Civi\Api4\Organization;
 use Civi\Api4\Participant;
@@ -32,31 +31,15 @@ use Civi\Api4\Participant;
 /**
  * @group headless
  */
-class CustomFieldGetFieldsTest extends CustomTestBase {
+class CustomFieldGetFieldsTest extends Api4TestBase {
 
   private $subTypeName = 'Sub_Tester';
 
-  public function tearDown(): void {
-    parent::tearDown();
-    Contact::delete(FALSE)
-      ->addWhere('id', '>', 0)
-      ->execute();
-    Participant::delete(FALSE)
-      ->addWhere('id', '>', 0)
-      ->execute();
-    Event::delete(FALSE)
-      ->addWhere('id', '>', 0)
-      ->execute();
-    ContactType::delete(FALSE)
-      ->addWhere('name', '=', $this->subTypeName)
-      ->execute();
-  }
-
   public function testCustomFieldTypes(): void {
-    $customGroupName = CustomGroup::create(FALSE)
-      ->addValue('extends', 'Activity')
-      ->addValue('title', __FUNCTION__)
-      ->execute()->single()['name'];
+    $customGroupName = $this->createTestRecord('CustomGroup', [
+      'extends' => 'Activity',
+      'title' => __FUNCTION__,
+    ])['name'];
 
     $customFields = $this->saveTestRecords('CustomField', [
       'records' => [
@@ -346,10 +329,10 @@ class CustomFieldGetFieldsTest extends CustomTestBase {
 
   public function testDisabledAndHiddenFields(): void {
     // Create a custom group with one enabled and one disabled field
-    CustomGroup::create(FALSE)
-      ->addValue('extends', 'Activity')
-      ->addValue('title', 'act_test_grp')
-      ->execute();
+    $this->createTestRecord('CustomGroup', [
+      'extends' => 'Activity',
+      'title' => 'act_test_grp',
+    ]);
     $this->saveTestRecords('CustomField', [
       'records' => [
         ['label' => 'enabled_field'],
@@ -382,25 +365,24 @@ class CustomFieldGetFieldsTest extends CustomTestBase {
   }
 
   public function testCustomGetFieldsWithContactSubType(): void {
-    ContactType::create(FALSE)
-      ->addValue('name', $this->subTypeName)
-      ->addValue('label', $this->subTypeName)
-      ->addValue('parent_id:name', 'Individual')
-      ->execute();
+    $this->createTestRecord('ContactType', [
+      'name' => $this->subTypeName,
+      'label' => $this->subTypeName,
+      'parent_id:name' => 'Individual',
+    ]);
 
-    $contact1 = Individual::create(FALSE)
-      ->execute()->first();
-    $contact2 = Individual::create(FALSE)->addValue('contact_sub_type', [$this->subTypeName])
-      ->execute()->first();
-    $org = Organization::create(FALSE)
-      ->execute()->first();
+    $contact1 = $this->createTestRecord('Individual');
+    $contact2 = $this->createTestRecord('Individual', [
+      'contact_sub_type' => [$this->subTypeName],
+    ]);
+    $org = $this->createTestRecord('Organization');
 
     // Individual sub-type custom group
-    CustomGroup::create(FALSE)
-      ->addValue('extends', 'Individual')
-      ->addValue('extends_entity_column_value', [$this->subTypeName])
-      ->addValue('title', 'contact_sub')
-      ->execute();
+    $this->createTestRecord('CustomGroup', [
+      'extends' => 'Individual',
+      'extends_entity_column_value' => [$this->subTypeName],
+      'title' => 'contact_sub',
+    ]);
     CustomField::create(FALSE)
       ->addValue('custom_group_id.name', 'contact_sub')
       ->addValue('label', 'sub_field')
@@ -408,10 +390,10 @@ class CustomFieldGetFieldsTest extends CustomTestBase {
       ->execute();
 
     // Organization custom group
-    CustomGroup::create(FALSE)
-      ->addValue('extends', 'Organization')
-      ->addValue('title', 'org_group')
-      ->execute();
+    $this->createTestRecord('CustomGroup', [
+      'extends' => 'Organization',
+      'title' => 'org_group',
+    ]);
     CustomField::create(FALSE)
       ->addValue('custom_group_id.name', 'org_group')
       ->addValue('label', 'sub_field')
@@ -419,14 +401,15 @@ class CustomFieldGetFieldsTest extends CustomTestBase {
       ->execute();
 
     // Unconditional Contact CustomGroup
-    CustomGroup::create(FALSE)
-      ->addValue('extends', 'Contact')
-      ->addValue('title', 'always')
-      ->addChain('field', CustomField::create()
-        ->addValue('custom_group_id', '$id')
-        ->addValue('label', 'on')
-        ->addValue('html_type', 'Text')
-      )->execute();
+    $this->createTestRecord('CustomGroup', [
+      'extends' => 'Contact',
+      'title' => 'always',
+    ]);
+    $this->createTestRecord('CustomField', [
+      'custom_group_id.name' => 'always',
+      'label' => 'on',
+      'html_type' => 'Text',
+    ]);
 
     $allFields = Contact::getFields(FALSE)
       ->execute()->indexBy('name');
@@ -478,28 +461,28 @@ class CustomFieldGetFieldsTest extends CustomTestBase {
   }
 
   public function testCustomGetFieldsForParticipantSubTypes(): void {
-    $event1 = Event::create(FALSE)
-      ->addValue('title', 'Test1')
-      ->addValue('event_type_id:name', 'Meeting')
-      ->addValue('start_date', 'now')
-      ->execute()->first();
-    $event2 = Event::create(FALSE)
-      ->addValue('title', 'Test2')
-      ->addValue('event_type_id:name', 'Meeting')
-      ->addValue('start_date', 'now')
-      ->execute()->first();
-    $event3 = Event::create(FALSE)
-      ->addValue('title', 'Test3')
-      ->addValue('event_type_id:name', 'Conference')
-      ->addValue('start_date', 'now')
-      ->execute()->first();
-    $event4 = Event::create(FALSE)
-      ->addValue('title', 'Test4')
-      ->addValue('event_type_id:name', 'Fundraiser')
-      ->addValue('start_date', 'now')
-      ->execute()->first();
+    $event1 = $this->createTestRecord('Event', [
+      'title' => 'Test1',
+      'event_type_id:name' => 'Meeting',
+      'start_date' => 'now',
+    ]);
+    $event2 = $this->createTestRecord('Event', [
+      'title' => 'Test2',
+      'event_type_id:name' => 'Meeting',
+      'start_date' => 'now',
+    ]);
+    $event3 = $this->createTestRecord('Event', [
+      'title' => 'Test3',
+      'event_type_id:name' => 'Conference',
+      'start_date' => 'now',
+    ]);
+    $event4 = $this->createTestRecord('Event', [
+      'title' => 'Test4',
+      'event_type_id:name' => 'Fundraiser',
+      'start_date' => 'now',
+    ]);
 
-    $cid = Contact::create(FALSE)->execute()->single()['id'];
+    $cid = $this->createTestRecord('Contact')['id'];
 
     $sampleData = [
       ['event_id' => $event1['id'], 'role_id:name' => ['Attendee']],
@@ -507,61 +490,63 @@ class CustomFieldGetFieldsTest extends CustomTestBase {
       ['event_id' => $event3['id'], 'role_id:name' => ['Attendee']],
       ['event_id' => $event4['id'], 'role_id:name' => ['Host']],
     ];
-    $participants = Participant::save(FALSE)
-      ->addDefault('contact_id', $cid)
-      ->addDefault('status_id:name', 'Registered')
-      ->setRecords($sampleData)
-      ->execute();
+    $participants = $this->saveTestRecords('Participant', [
+      'records' => $sampleData,
+      'defaults' => [
+        'contact_id' => $cid,
+        'status_id:name' => 'Registered',
+      ],
+    ]);
 
     // CustomGroup based on Event Type = Meeting|Conference
-    CustomGroup::create(FALSE)
-      ->addValue('extends', 'Participant')
-      ->addValue('extends_entity_column_id:name', 'ParticipantEventType')
-      ->addValue('extends_entity_column_value:name', ['Meeting', 'Conference'])
-      ->addValue('title', 'meeting_conference')
-      ->addChain('field', CustomField::create()
-        ->addValue('custom_group_id', '$id')
-        ->addValue('label', 'sub_field')
-        ->addValue('html_type', 'Text')
-      )
-      ->execute();
+    $this->createTestRecord('CustomGroup', [
+      'extends' => 'Participant',
+      'extends_entity_column_id:name' => 'ParticipantEventType',
+      'extends_entity_column_value:name' => ['Meeting', 'Conference'],
+      'title' => 'meeting_conference',
+    ]);
+    $this->createTestRecord('CustomField', [
+      'custom_group_id.name' => 'meeting_conference',
+      'label' => 'sub_field',
+      'html_type' => 'Text',
+    ]);
 
     // CustomGroup based on Participant Role
-    CustomGroup::create(FALSE)
-      ->addValue('extends', 'Participant')
-      ->addValue('extends_entity_column_id:name', 'ParticipantRole')
-      ->addValue('extends_entity_column_value:name', ['Volunteer', 'Host'])
-      ->addValue('title', 'volunteer_host')
-      ->addChain('field', CustomField::create()
-        ->addValue('custom_group_id', '$id')
-        ->addValue('label', 'sub_field')
-        ->addValue('html_type', 'Text')
-      )
-      ->execute();
+    $this->createTestRecord('CustomGroup', [
+      'extends' => 'Participant',
+      'extends_entity_column_id:name' => 'ParticipantRole',
+      'extends_entity_column_value:name' => ['Volunteer', 'Host'],
+      'title' => 'volunteer_host',
+    ]);
+    $this->createTestRecord('CustomField', [
+      'custom_group_id.name' => 'volunteer_host',
+      'label' => 'sub_field',
+      'html_type' => 'Text',
+    ]);
 
     // CustomGroup based on Specific Events
-    CustomGroup::create(FALSE)
-      ->addValue('extends', 'Participant')
-      ->addValue('extends_entity_column_id:name', 'ParticipantEventName')
-      ->addValue('extends_entity_column_value', [$event2['id'], $event3['id']])
-      ->addValue('title', 'event_2_and_3')
-      ->addChain('field', CustomField::create()
-        ->addValue('custom_group_id', '$id')
-        ->addValue('label', 'sub_field')
-        ->addValue('html_type', 'Text')
-      )
-      ->execute();
+    $this->createTestRecord('CustomGroup', [
+      'extends' => 'Participant',
+      'extends_entity_column_id:name' => 'ParticipantEventName',
+      'extends_entity_column_value' => [$event2['id'], $event3['id']],
+      'title' => 'event_2_and_3',
+    ]);
+    $this->createTestRecord('CustomField', [
+      'custom_group_id.name' => 'event_2_and_3',
+      'label' => 'sub_field',
+      'html_type' => 'Text',
+    ]);
 
     // Unconditional Participant CustomGroup
-    CustomGroup::create(FALSE)
-      ->addValue('extends', 'Participant')
-      ->addValue('title', 'always')
-      ->addChain('field', CustomField::create()
-        ->addValue('custom_group_id', '$id')
-        ->addValue('label', 'on')
-        ->addValue('html_type', 'Text')
-      )
-      ->execute();
+    $this->createTestRecord('CustomGroup', [
+      'extends' => 'Participant',
+      'title' => 'always',
+    ]);
+    $this->createTestRecord('CustomField', [
+      'custom_group_id.name' => 'always',
+      'label' => 'on',
+      'html_type' => 'Text',
+    ]);
 
     $allFields = Participant::getFields(FALSE)->execute()->indexBy('name');
     $this->assertArrayHasKey('meeting_conference.sub_field', $allFields);
@@ -616,10 +601,10 @@ class CustomFieldGetFieldsTest extends CustomTestBase {
   }
 
   public function testFiltersAreReturnedForContactRefFields(): void {
-    $grp = CustomGroup::create(FALSE)
-      ->addValue('extends', 'Activity')
-      ->addValue('title', 'act_test_grp2')
-      ->execute()->single();
+    $grp = $this->createTestRecord('CustomGroup', [
+      'extends' => 'Activity',
+      'title' => 'act_test_grp2',
+    ]);
     $field = $this->createTestRecord('CustomField', [
       'data_type' => 'ContactReference',
       'html_type' => 'Autocomplete-Select',

--- a/tests/phpunit/api/v4/Custom/CustomFileTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomFileTest.php
@@ -17,28 +17,27 @@
 
 namespace api\v4\Custom;
 
-use Civi\Api4\CustomGroup;
-use Civi\Api4\CustomField;
+use api\v4\Api4TestBase;
 use Civi\Api4\File;
 
 /**
  * @group headless
  */
-class CustomFileTest extends CustomTestBase {
+class CustomFileTest extends Api4TestBase {
 
   /**
    */
   public function testCustomFileField(): void {
-    $group = CustomGroup::create()->setValues([
+    $group = $this->createTestRecord('CustomGroup', [
       'title' => 'FileFields',
       'extends' => 'Individual',
-    ])->execute()->single();
-    $field = CustomField::create()->setValues([
+    ]);
+    $this->createTestRecord('CustomField', [
       'label' => 'TestMyFile',
       'custom_group_id.name' => 'FileFields',
       'html_type' => 'File',
       'data_type' => 'File',
-    ])->execute()->single();
+    ]);
 
     $fieldName = 'FileFields.TestMyFile';
 
@@ -53,6 +52,9 @@ class CustomFileTest extends CustomTestBase {
       'name' => 'test123.txt',
       'content' => 'Hello World 123',
     ]);
+    // FIXME: Autocleanup would happen if using Api4 + $this->createTestRecord
+    $this->registerTestRecord('File', $file['id']);
+    $this->registerTestRecord('EntityFile', [['file_id', '=', $file['id']]]);
 
     civicrm_api4('Individual', 'update', [
       'values' => [

--- a/tests/phpunit/api/v4/Custom/CustomGroupTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomGroupTest.php
@@ -19,12 +19,13 @@
 
 namespace api\v4\Custom;
 
+use api\v4\Api4TestBase;
 use Civi\Api4\CustomGroup;
 
 /**
  * @group headless
  */
-class CustomGroupTest extends CustomTestBase {
+class CustomGroupTest extends Api4TestBase {
 
   public function testUpdateCustomGroup(): void {
     $this->createTestRecord('ContactType', [

--- a/tests/phpunit/api/v4/Custom/CustomProfileFieldTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomProfileFieldTest.php
@@ -19,20 +19,19 @@
 
 namespace api\v4\Custom;
 
-use Civi\Api4\CustomGroup;
+use api\v4\Api4TestBase;
 use Civi\Api4\UFGroup;
 
 /**
  * @group headless
  */
-class CustomProfileFieldTest extends CustomTestBase {
+class CustomProfileFieldTest extends Api4TestBase {
 
   public function testExportProfileWithCustomFields(): void {
-    $customGroup = CustomGroup::create(FALSE)
-      ->addValue('title', 'ProfileGroup')
-      ->addValue('extends', 'Individual')
-      ->execute()
-      ->first();
+    $customGroup = $this->createTestRecord('CustomGroup', [
+      'title' => 'ProfileGroup',
+      'extends' => 'Individual',
+    ]);
 
     $custom1 = $this->createTestRecord('CustomField', [
       'label' => 'F1',

--- a/tests/phpunit/api/v4/Custom/CustomTestBase.php
+++ b/tests/phpunit/api/v4/Custom/CustomTestBase.php
@@ -21,29 +21,20 @@ namespace api\v4\Custom;
 
 use api\v4\Api4TestBase;
 use Civi\Api4\CustomGroup;
-use Civi\Api4\CustomField;
 
 /**
- * Use this base class for any APIv4 tests which create custom groups/fields,
- * to ensure they get cleaned up properly.
- *
- * Note: The TransactionalInterface won't work with custom fields because of adding/dropping tables.
- * So these tests have to do their own cleanup of any contacts or other entities created.
- * The recommended way is to override the `tearDown` function and calling `parent::tearDown()`.
+ * @deprecated
+ * Not needed if you use `$this->createTestRecord()` to make your custom groups,
+ * as that will cleanup automatically.
  */
 abstract class CustomTestBase extends Api4TestBase {
 
   /**
-   * Delete all created options groups.
+   * Delete all created custom groups.
    *
    * @throws \CRM_Core_Exception
    */
   public function tearDown(): void {
-    $optgroups = CustomField::get(FALSE)->addSelect('option_group_id')->addWhere('option_group_id', 'IS NOT NULL')->execute();
-    foreach ($optgroups as $optgroup) {
-      \Civi\Api4\OptionGroup::delete(FALSE)->addWhere('id', '=', $optgroup['option_group_id'])->execute();
-    }
-    CustomField::delete(FALSE)->addWhere('id', '>', 0)->execute();
     CustomGroup::delete(FALSE)->addWhere('id', '>', 0)->execute();
     parent::tearDown();
   }

--- a/tests/phpunit/api/v4/Custom/CustomValueTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomValueTest.php
@@ -19,6 +19,7 @@
 
 namespace api\v4\Custom;
 
+use api\v4\Api4TestBase;
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
 use Civi\Api4\CustomValue;
@@ -27,7 +28,7 @@ use Civi\Api4\Entity;
 /**
  * @group headless
  */
-class CustomValueTest extends CustomTestBase {
+class CustomValueTest extends Api4TestBase {
 
   /**
    * Test CustomValue::GetFields/Get/Create/Update/Replace/Delete
@@ -40,12 +41,11 @@ class CustomValueTest extends CustomTestBase {
     $multiFieldName = uniqid('chkbx');
     $refFieldName = uniqid('txt');
 
-    $customGroup = CustomGroup::create(FALSE)
-      ->addValue('title', $group)
-      ->addValue('extends', 'Contact')
-      ->addValue('is_multiple', TRUE)
-      ->execute()
-      ->first();
+    $customGroup = $this->createTestRecord('CustomGroup', [
+      'title' => $group,
+      'extends' => 'Contact',
+      'is_multiple' => TRUE,
+    ]);
 
     $colorField = CustomField::create(FALSE)
       ->addValue('label', $colorFieldName)
@@ -296,11 +296,11 @@ class CustomValueTest extends CustomTestBase {
 
     $this->assertNotContains("Custom_$groupName", Entity::get()->execute()->column('name'));
 
-    $customGroup = CustomGroup::create(FALSE)
-      ->addValue('title', $groupName)
-      ->addValue('extends', 'Contact')
-      ->addValue('is_multiple', FALSE)
-      ->execute()->single();
+    $customGroup = $this->createTestRecord('CustomGroup', [
+      'title' => $groupName,
+      'extends' => 'Contact',
+      'is_multiple' => FALSE,
+    ]);
 
     $this->assertNotContains("Custom_$groupName", Entity::get()->execute()->column('name'));
 

--- a/tests/phpunit/api/v4/Custom/ExportCustomGroupTest.php
+++ b/tests/phpunit/api/v4/Custom/ExportCustomGroupTest.php
@@ -19,38 +19,41 @@
 
 namespace api\v4\Custom;
 
+use api\v4\Api4TestBase;
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
 
 /**
  * @group headless
  */
-class ExportCustomGroupTest extends CustomTestBase {
+class ExportCustomGroupTest extends Api4TestBase {
 
   public function testExportCustomGroupWithFieldOptions(): void {
     $optionValues = ['r' => 'Red', 'g' => 'Green', 'b' => 'Blue'];
 
-    $customGroup = CustomGroup::create(FALSE)
-      ->addValue('title', 'exportTest')
-      ->addValue('extends', 'Individual')
-      ->addChain('field1', CustomField::create()
-        ->addValue('custom_group_id', '$id')
-        ->addValue('option_values', $optionValues)
-        ->addValue('label', 'Color')
-        ->addValue('html_type', 'Select'), 0
-      )->addChain('field2', CustomField::create()
-        ->addValue('custom_group_id', '$id')
-        ->addValue('data_type', 'Boolean')
-        ->addValue('label', 'On Off')
-        ->addValue('html_type', 'CheckBox'), 0
-      )->execute()->single();
+    $customGroup = $this->createTestRecord('CustomGroup', [
+      'title' => 'exportTest',
+      'extends' => 'Individual',
+    ]);
+    $field1 = $this->createTestRecord('CustomField', [
+      'custom_group_id' => $customGroup['id'],
+      'option_values' => $optionValues,
+      'label' => 'Color',
+      'html_type' => 'Select',
+    ]);
+    $field2 = $this->createTestRecord('CustomField', [
+      'custom_group_id' => $customGroup['id'],
+      'data_type' => 'Boolean',
+      'label' => 'On Off',
+      'html_type' => 'CheckBox',
+    ]);
 
     // Add a 3rd fields that shares the same option group as field1
     CustomField::create(FALSE)
       ->addValue('custom_group_id', $customGroup['id'])
       ->addValue('label', 'Color2')
       ->addValue('html_type', 'Select')
-      ->addValue('option_group_id', $customGroup['field1']['option_group_id'])
+      ->addValue('option_group_id', $field1['option_group_id'])
       ->execute();
 
     $export = CustomGroup::export(FALSE)

--- a/tests/phpunit/api/v4/Custom/ExtendFromIndividualTest.php
+++ b/tests/phpunit/api/v4/Custom/ExtendFromIndividualTest.php
@@ -19,23 +19,22 @@
 
 namespace api\v4\Custom;
 
+use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
 use Civi\Api4\CustomField;
-use Civi\Api4\CustomGroup;
 
 /**
  * @group headless
  */
-class ExtendFromIndividualTest extends CustomTestBase {
+class ExtendFromIndividualTest extends Api4TestBase {
 
   public function testGetWithNonStandardExtends(): void {
 
-    $customGroup = CustomGroup::create(FALSE)
-      ->addValue('title', 'MyContactFields')
+    $customGroup = $this->createTestRecord('CustomGroup', [
+      'title' => 'MyContactFields',
       // not Contact
-      ->addValue('extends', 'Individual')
-      ->execute()
-      ->first();
+      'extends' => 'Individual',
+    ]);
 
     CustomField::create(FALSE)
       ->addValue('label', 'FavColor')

--- a/tests/phpunit/api/v4/Custom/FalseNotEqualsZeroTest.php
+++ b/tests/phpunit/api/v4/Custom/FalseNotEqualsZeroTest.php
@@ -19,22 +19,21 @@
 
 namespace api\v4\Custom;
 
+use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
 use Civi\Api4\CustomField;
-use Civi\Api4\CustomGroup;
 
 /**
  * @group headless
  */
-class FalseNotEqualsZeroTest extends CustomTestBase {
+class FalseNotEqualsZeroTest extends Api4TestBase {
 
   public function testFalseNotEqualsZero(): void {
 
-    $customGroup = CustomGroup::create(FALSE)
-      ->addValue('title', 'MyContactFields')
-      ->addValue('extends', 'Contact')
-      ->execute()
-      ->first();
+    $customGroup = $this->createTestRecord('CustomGroup', [
+      'title' => 'MyContactFields',
+      'extends' => 'Contact',
+    ]);
 
     CustomField::create(FALSE)
       ->addValue('label', 'Lightswitch')

--- a/tests/phpunit/api/v4/Custom/PseudoconstantTest.php
+++ b/tests/phpunit/api/v4/Custom/PseudoconstantTest.php
@@ -19,12 +19,12 @@
 
 namespace api\v4\Custom;
 
+use api\v4\Api4TestBase;
 use Civi\Api4\Address;
 use Civi\Api4\Contact;
 use Civi\Api4\Activity;
 use Civi\Api4\Contribution;
 use Civi\Api4\CustomField;
-use Civi\Api4\CustomGroup;
 use Civi\Api4\Email;
 use Civi\Api4\EntityTag;
 use Civi\Api4\Participant;
@@ -32,7 +32,7 @@ use Civi\Api4\Participant;
 /**
  * @group headless
  */
-class PseudoconstantTest extends CustomTestBase {
+class PseudoconstantTest extends Api4TestBase {
 
   public function testOptionValue(): void {
     $cid = $this->createTestRecord('Contact', ['first_name', 'bill'])['id'];
@@ -154,20 +154,22 @@ class PseudoconstantTest extends CustomTestBase {
       ['id' => 'b', 'name' => 'blue', 'label' => 'BLUE', 'color' => '#0000ff', 'description' => 'Blue color', 'icon' => 'fa-blue'],
     ];
 
-    CustomGroup::create(FALSE)
-      ->addValue('title', 'myPseudoconstantTest')
-      ->addValue('extends', 'Individual')
-      ->addChain('field1', CustomField::create()
-        ->addValue('custom_group_id', '$id')
-        ->addValue('option_values', ['r' => 'red', 'g' => 'green', 'b' => 'blü'])
-        ->addValue('label', 'Color')
-        ->addValue('html_type', 'Select')
-      )->addChain('field2', CustomField::create()
-        ->addValue('custom_group_id', '$id')
-        ->addValue('option_values', $technicolor)
-        ->addValue('label', 'Multicolor')
-        ->addValue('html_type', 'CheckBox')
-      )->execute();
+    $this->createTestRecord('CustomGroup', [
+      'title' => 'myPseudoconstantTest',
+      'extends' => 'Individual',
+    ]);
+    CustomField::create(FALSE)
+      ->addValue('custom_group_id.name', 'myPseudoconstantTest')
+      ->addValue('option_values', ['r' => 'red', 'g' => 'green', 'b' => 'blü'])
+      ->addValue('label', 'Color')
+      ->addValue('html_type', 'Select')
+      ->execute();
+    CustomField::create(FALSE)
+      ->addValue('custom_group_id.name', 'myPseudoconstantTest')
+      ->addValue('option_values', $technicolor)
+      ->addValue('label', 'Multicolor')
+      ->addValue('html_type', 'CheckBox')
+      ->execute();
 
     // Ensure option_value_fields were correctly set based on provided values
     $customFields = CustomField::get(FALSE)

--- a/tests/phpunit/api/v4/Custom/UpdateCustomValueTest.php
+++ b/tests/phpunit/api/v4/Custom/UpdateCustomValueTest.php
@@ -19,23 +19,22 @@
 
 namespace api\v4\Custom;
 
+use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
 use Civi\Api4\CustomField;
-use Civi\Api4\CustomGroup;
 use CRM_Core_BAO_CustomValueTable as CustomValueTable;
 
 /**
  * @group headless
  */
-class UpdateCustomValueTest extends CustomTestBase {
+class UpdateCustomValueTest extends Api4TestBase {
 
   public function testGetWithCustomData(): void {
 
-    $customGroup = CustomGroup::create(FALSE)
-      ->addValue('title', 'MyContactFields')
-      ->addValue('extends', 'Contact')
-      ->execute()
-      ->first();
+    $customGroup = $this->createTestRecord('CustomGroup', [
+      'title' => 'MyContactFields',
+      'extends' => 'Contact',
+    ]);
 
     CustomField::create(FALSE)
       ->addValue('label', 'FavColor')


### PR DESCRIPTION
Overview
----------------------------------------
Followup to https://github.com/civicrm/civicrm-core/pull/31570
Improves the following:

1. Orphaned custom fields are automatically cleaned up when deleting a custom group
2. Tests refactored to no longer rely on `CustomTestBase` for cleanup
3. Tests updated to more consistently use createTestRecord() method
4. Test createTestRecord method updated to recognize values passed as `.name` or `:name`
5. Api4TestBase cleanup is now smarter and recognizes when transactions may have been broken
