### PR TITLE
fix appendBreadCrumb calls when deleting PriceSet / PriceField 

### DIFF
--- a/CRM/Price/Page/Field.php
+++ b/CRM/Price/Page/Field.php
@@ -269,9 +269,12 @@ class CRM_Price_Page_Field extends CRM_Core_Page {
       else {
         // add breadcrumb
         $url = CRM_Utils_System::url('civicrm/admin/price/field', 'reset=1');
-        CRM_Utils_System::appendBreadCrumb(ts('Price'),
-          $url
-        );
+        CRM_Utils_System::appendBreadCrumb([
+          [
+            'title' => ts('Price'),
+            'url' => $url,
+          ],
+        ]);
         $this->assign('usedPriceSetTitle', CRM_Price_BAO_PriceField::getTitle($fid));
       }
     }

--- a/CRM/Price/Page/Option.php
+++ b/CRM/Price/Page/Option.php
@@ -229,9 +229,12 @@ class CRM_Price_Page_Option extends CRM_Core_Page {
     if ($action & CRM_Core_Action::DELETE) {
       // add breadcrumb
       $url = CRM_Utils_System::url('civicrm/admin/price/field/option', 'reset=1');
-      CRM_Utils_System::appendBreadCrumb(ts('Price Option'),
-        $url
-      );
+      CRM_Utils_System::appendBreadCrumb([
+        [
+          'title' => ts('Price Option'),
+          'url' => $url,
+        ],
+      ]);
       $this->assign('usedPriceSetTitle', CRM_Price_BAO_PriceFieldValue::getOptionLabel($oid));
       $comps = [
         'Event' => 'civicrm_event',

--- a/CRM/Price/Page/Set.php
+++ b/CRM/Price/Page/Set.php
@@ -159,7 +159,12 @@ class CRM_Price_Page_Set extends CRM_Core_Page {
         else {
           // add breadcrumb
           $url = CRM_Utils_System::url('civicrm/admin/price', 'reset=1');
-          CRM_Utils_System::appendBreadCrumb(ts('Price Sets'), $url);
+          CRM_Utils_System::appendBreadCrumb([
+            [
+              'title' => ts('Price Sets'),
+              'url' => $url,
+            ],
+          ]);
           $this->assign('usedPriceSetTitle', CRM_Price_BAO_PriceSet::getTitle($sid));
           $this->assign('usedBy', $usedBy);
 

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -101,15 +101,16 @@ abstract class CRM_Utils_System_Base {
   }
 
   /**
-   * Append an additional breadcrumb tag to the existing breadcrumb.
+   * Append additional breadcrumbs to the existing breadcrumb trail.
    *
-   * @param array $breadCrumbs
+   * @param array $breadCrumbs array of arrays
+   * sub-arrays should each have 'title' and 'url' keys
    */
   public function appendBreadCrumb($breadCrumbs) {
   }
 
   /**
-   * Reset an additional breadcrumb tag to the existing breadcrumb.
+   * Reset the breadcrumb trail
    */
   public function resetBreadCrumb() {
   }

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -140,6 +140,11 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    * @inheritDoc
    */
   public function appendBreadCrumb($breadcrumbs) {
+    if (!is_array($breadcrumbs)) {
+      // invalid - but no need to crash the whole page
+      \Civi::log()->warning('Non-array passed to appendBreadCrumb');
+      return;
+    }
     $crumbs = \Civi::$statics[__CLASS__]['breadcrumb'] ?? [];
     $crumbs += array_column($breadcrumbs, NULL, 'url');
     \Civi::$statics[__CLASS__]['breadcrumb'] = $crumbs;


### PR DESCRIPTION
Overview
----------------------------------------
`appendBreadCrumb` expects an array. Most Systems just ignore a non-array param, but Standalone errors, so you notice. 

Before
----------------------------------------
- cant delete price fields through the UI on Standalone

After
----------------------------------------
- can delete price fields through the UI on Standalone

Technical Details
----------------------------------------
While the function is called `appendBreadCrumb` but it actually takes an array of multiple breadcrumb**s**. Each breadcrumb should be an array with `url` and `title` keys.