### PR TITLE
CustomFields - Enforce ACLs in all API get calls

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -2363,4 +2363,15 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
     return $customValue;
   }
 
+  /**
+   * Enforce ACLs for custom Groups and Fields
+   */
+  public static function on_hook_civicrm_selectWhereClause(\Civi\Core\Event\GenericHookEvent $hook): void {
+    if (($hook->entity === 'CustomGroup' || $hook->entity === 'CustomField') && !CRM_Core_Permission::customGroupAdmin($hook->userId)) {
+      $idField = $hook->entity === 'CustomGroup' ? 'id' : 'custom_group_id';
+      $permittedIds = CRM_Core_Permission::customGroup(CRM_Core_Permission::VIEW, FALSE, $hook->userId) ?: [0];
+      $hook->clauses[$idField][] = 'IN (' . implode(', ', $permittedIds) . ')';
+    }
+  }
+
 }

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -278,10 +278,8 @@ class CRM_Core_Permission {
     }
 
     // By default, users without 'access all custom data' are permitted to see no groups.
-    $allowedGroups = [];
-
     // Allow ACLs and hooks to grant permissions to certain groups.
-    return CRM_ACL_API::group($type, $userId, 'civicrm_custom_group', $customGroups, $allowedGroups);
+    return CRM_ACL_API::group($type, $userId, 'civicrm_custom_group', $customGroups);
   }
 
   /**

--- a/Civi/Api4/Action/CustomField/Get.php
+++ b/Civi/Api4/Action/CustomField/Get.php
@@ -43,7 +43,7 @@ class Get extends \Civi\Api4\Generic\CachedDAOGetAction {
    */
   protected function getCachedRecords(): array {
     $records = [];
-    $groups = \CRM_Core_BAO_CustomGroup::getAll();
+    $groups = \CRM_Core_BAO_CustomGroup::getAll([], $this->getCheckPermissions() ? \CRM_Core_Permission::VIEW : NULL);
     foreach ($groups as $group) {
       $groupInfo = $group;
       unset($groupInfo['fields']);

--- a/Civi/Api4/CustomGroup.php
+++ b/Civi/Api4/CustomGroup.php
@@ -31,7 +31,7 @@ class CustomGroup extends Generic\DAOEntity {
    */
   public static function get($checkPermissions = TRUE) {
     return (new CachedDAOGetAction(__CLASS__, __FUNCTION__, function (CachedDAOGetAction $action) {
-      return \CRM_Core_BAO_CustomGroup::getAll();
+      return \CRM_Core_BAO_CustomGroup::getAll([], $action->getCheckPermissions() ? \CRM_Core_Permission::VIEW : NULL);
     }))->setCheckPermissions($checkPermissions);
   }
 

--- a/Civi/Api4/Generic/CachedDAOGetAction.php
+++ b/Civi/Api4/Generic/CachedDAOGetAction.php
@@ -58,6 +58,24 @@ class CachedDAOGetAction extends \Civi\Api4\Generic\DAOGetAction {
   }
 
   /**
+   * Toggle the in-memory cache
+   *
+   * @param bool $useCache
+   * @return $this
+   */
+  public function setUseCache(bool $useCache): CachedDAOGetAction {
+    $this->useCache = $useCache;
+    return $this;
+  }
+
+  /**
+   * @return bool|null
+   */
+  public function getUseCache(): ?bool {
+    return $this->useCache;
+  }
+
+  /**
    * @param \Civi\Api4\Generic\Result $result
    *
    * Decide whether to use self::getFromCache or DAOGetAction::getObjects


### PR DESCRIPTION
Overview
----------------------------------------
This is a followup to https://github.com/civicrm/civicrm-core/pull/31695 which opened up permissions but neglected ACLs.


Before
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/31695 decreased permission for `Api.CustomField.get` to "access CiviCRM" which is a good change to be consistent with other "metadata"-type api actions. However, it's possible for custom fields to be restricted by ACL and the api ought to enforce that.

After
----------------------------------------
Now the CustomField and CustomGroup API.get functions will consistently enforce ACLs (Entity.get and api.getFields had already been doing so - test added to demonstrate all 4).
