### PR TITLE
Rename in-template variable for clarity

### DIFF
--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -61,7 +61,8 @@
         {continue}
       {/if}
       {assign var="profileID" value=$field.group_id}
-      {assign var=n value=$field.name}
+      {assign var="profileFieldName" value=$field.name}
+
       {if $field.groupTitle != $fieldset}
         {if $mode neq 8 && $mode neq 4}
           <div {if $context neq 'dialog'}id="profilewrap{$field.group_id}"{/if}>
@@ -75,7 +76,7 @@
       {/if}
       {if $field.field_type eq "Formatting"}
         {$field.help_pre}
-      {elseif $n}
+      {elseif $profileFieldName}
         {if $field.groupTitle != $fieldset}
           {if $fieldset != $zeroField}
             {if $groupHelpPost}
@@ -89,24 +90,24 @@
           {/if}
         <div class="form-layout-compressed">
         {/if}
-        {if $field.help_pre && $action neq 4 && $form.$n.html}
-          <div class="crm-section helprow-{$n}-section helprow-pre" id="helprow-{$n}">
+        {if $field.help_pre && $action neq 4 && $form.$profileFieldName.html}
+          <div class="crm-section helprow-{$profileFieldName}-section helprow-pre" id="helprow-{$profileFieldName}">
             <div class="content description">{$field.help_pre}</div>
           </div>
         {/if}
         {if array_key_exists('options_per_line', $field) && $field.options_per_line}
-          <div class="crm-section editrow_{$n}-section form-item" id="editrow-{$n}">
-            <div class="label">{$form.$n.label}</div>
+          <div class="crm-section editrow_{$profileFieldName}-section form-item" id="editrow-{$profileFieldName}">
+            <div class="label">{$form.$profileFieldName.label}</div>
             <div class="content edit-value">
               {assign var="count" value=1}
               {strip}
                 <table class="form-layout-compressed">
                 <tr>
                 {* sort by fails for option per line. Added a variable to iterate through the element array*}
-                  {foreach name=outer key=key item=item from=$form.$n}
+                  {foreach name=outer key=key item=item from=$form.$profileFieldName}
                     {* There are both numeric and non-numeric keys mixed in here, where the non-numeric are metadata that aren't arrays with html members. *}
                     {if is_array($item) && array_key_exists('html', $item)}
-                      <td class="labels font-light">{$form.$n.$key.html}</td>
+                      <td class="labels font-light">{$form.$profileFieldName.$key.html}</td>
                       {if $count == $field.options_per_line}
                       </tr>
                       <tr>
@@ -123,21 +124,21 @@
             <div class="clear"></div>
           </div>{* end of main edit section div*}
           {else}
-          <div id="editrow-{$n}" class="crm-section editrow_{$n}-section form-item">
+          <div id="editrow-{$profileFieldName}" class="crm-section editrow_{$profileFieldName}-section form-item">
             <div class="label">
-              {$form.$n.label}
+              {$form.$profileFieldName.label}
             </div>
             <div class="edit-value content">
-              {if $n|substr:0:3 eq 'im-'}
-                {assign var="provider" value="$n-provider_id"}
+              {if $profileFieldName|substr:0:3 eq 'im-'}
+                {assign var="provider" value="$profileFieldName-provider_id"}
                 {$form.$provider.html}&nbsp;
               {/if}
-              {if $n eq 'email_greeting' or  $n eq 'postal_greeting' or $n eq 'addressee'}
+              {if $profileFieldName eq 'email_greeting' or  $profileFieldName eq 'postal_greeting' or $profileFieldName eq 'addressee'}
                 {include file="CRM/Profile/Form/GreetingType.tpl"}
-              {elseif ( $n eq 'group' && $form.group ) || ( $n eq 'tag' && $form.tag )}
-                {include file="CRM/Contact/Form/Edit/TagsAndGroups.tpl" type=$n context="profile" tableLayout=1}
-              {elseif ( $form.$n.name eq 'image_URL' )}
-                {$form.$n.html}
+              {elseif ( $profileFieldName eq 'group' && $form.group ) || ( $profileFieldName eq 'tag' && $form.tag )}
+                {include file="CRM/Contact/Form/Edit/TagsAndGroups.tpl" type=$profileFieldName context="profile" tableLayout=1}
+              {elseif ( $form.$profileFieldName.name eq 'image_URL' )}
+                {$form.$profileFieldName.html}
                 {if !empty($imageURL)}
                   <div class="crm-section contact_image-section">
                     <div class="content">
@@ -145,19 +146,19 @@
                     </div>
                   </div>
                  {/if}
-              {elseif $n|substr:0:5 eq 'phone'}
-                {assign var="phone_ext_field" value=$n|replace:'phone':'phone_ext'}
-                {$form.$n.html}
+              {elseif $profileFieldName|substr:0:5 eq 'phone'}
+                {assign var="phone_ext_field" value=$profileFieldName|replace:'phone':'phone_ext'}
+                {$form.$profileFieldName.html}
                 {if $form.$phone_ext_field.html}
                 &nbsp;{$form.$phone_ext_field.html}
                 {/if}
               {else}
                 {if $field.html_type neq 'File' || ($field.html_type eq 'File' && !$field.is_view)}
-                   {$form.$n.html}
+                   {$form.$profileFieldName.html}
                 {/if}
                 {if $field.html_type eq 'Autocomplete-Select'}
                   {if $field.data_type eq 'ContactReference'}
-                    {include file="CRM/Custom/Form/ContactReference.tpl" element_name = $n}
+                    {include file="CRM/Custom/Form/ContactReference.tpl" element_name = $profileFieldName}
                   {/if}
                 {/if}
               {/if}
@@ -165,17 +166,17 @@
             <div class="clear"></div>
           </div>
 
-          {if $form.$n.type eq 'file'}
-            <div class="crm-section file_displayURL-section file_displayURL{$n}-section"><div class="content">{$customFiles.$n.displayURL}</div></div>
-            {if !$fields.$n.is_view}
-               <div class="crm-section file_deleteURL-section file_deleteURL{$n}-section"><div class="content">{$customFiles.$n.deleteURL}</div></div>
+          {if $form.$profileFieldName.type eq 'file'}
+            <div class="crm-section file_displayURL-section file_displayURL{$profileFieldName}-section"><div class="content">{$customFiles.$profileFieldName.displayURL}</div></div>
+            {if !$fields.$profileFieldName.is_view}
+               <div class="crm-section file_deleteURL-section file_deleteURL{$profileFieldName}-section"><div class="content">{$customFiles.$profileFieldName.deleteURL}</div></div>
             {/if}
           {/if}
         {/if}
 
       {* Show explanatory text for field if not in 'view' mode *}
-        {if $field.help_post && $action neq 4 && $form.$n.html}
-          <div class="crm-section helprow-{$n}-section helprow-post" id="helprow-{$n}">
+        {if $field.help_post && $action neq 4 && $form.$profileFieldName.html}
+          <div class="crm-section helprow-{$profileFieldName}-section helprow-post" id="helprow-{$profileFieldName}">
             <div class="content description">{$field.help_post}</div>
           </div>
         {/if}


### PR DESCRIPTION
'n' is not very meaningful. The 'sister' template uses profileFieldName - so let's align
