### PR TITLE
(dev/core#5602) CiviAccount - Fix "Close Batch" on older Smarty

### DIFF
--- a/templates/CRM/Financial/Page/BatchTransaction.tpl
+++ b/templates/CRM/Financial/Page/BatchTransaction.tpl
@@ -140,7 +140,7 @@ function saveRecord(recordID, op, recordBAO, entityID) {
     window.location.href = CRM.url('civicrm/financial/batch/export', {reset: 1, id: recordID, status: 1});
     return;
   }
-  var postUrl = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q="className=CRM_Financial_Page_AJAX&fnName=assignRemove&qfKey={$financialAJAXQFKey}"}"{literal};
+  var postUrl = "{/literal}{crmURL p='civicrm/ajax/rest' h=0 q="className=CRM_Financial_Page_AJAX&fnName=assignRemove"}&qfKey={$financialAJAXQFKey}{literal}";
   //post request and get response
   CRM.$.post( postUrl, { records: [recordID], recordBAO: recordBAO, op:op, entityID:entityID }, function( html ){
     //this is custom status set when record update success.


### PR DESCRIPTION
Overview
----------------------------------------

For steps to reproduce, see https://lab.civicrm.org/dev/core/-/issues/5602. Ensure that you are running an older version Smarty. (I've specifically been testing v2 and v5; no info about v3 or v4.)

Technical Details
----------------------------------------

When viewing a page like `civicrm/batchtransaction?reset=1&bid=7`, the main HTML document describes a post URL like this

```javascript
function saveRecord(recordID, op, recordBAO, entityID) {
  ...
  var postUrl = "/civicrm/ajax/rest?className=CRM_Financial_Page_AJAX&fnName=assignRemove&qfKey=CRMFinancialPageAJAX258gtzp8cfwkcgg4wk88kg0swwoos844sskc4w0k4sk4kgw04g";
```

Before
----------------------------------------

* On Smarty v2, the URL is mangled. _Therefore, you cannot send requests to that postUrl._
* On Smarty v5, the URL is OK.

After
----------------------------------------

* On Smarty v2, the URL is OK.
* On Smarty v5, the URL is OK.

