### PR TITLE
riverlea - remove margin from search col buttons, we have gap

### DIFF
--- a/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
+++ b/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
@@ -93,9 +93,3 @@ af-form {
 fieldset.af-container.af-layout-inline {
   border: 0;
 }
-
-/* Multiple button gap */
-
-#bootstrap-theme .crm-search-col-type-buttons .btn {
-  margin: 0 var(--crm-flex-gap) var(--crm-flex-gap) 0;
-}


### PR DESCRIPTION
Overview
----------------------------------------
Remove inconsistency between search kit display in and out of afform.
Fix odd vertical alignment between menu and button columns (https://github.com/civicrm/civicrm-core/pull/31728)

Before
----------------------------------------
- buttons in a button column in a search kit are spaced using gap
![image](https://github.com/user-attachments/assets/81c1916a-f317-49db-9cf7-842a19af86b5)

- buttons in a button column for the same search kit in an afform are spaced using gap AND margin
![image](https://github.com/user-attachments/assets/74185119-02fe-4b91-93ec-1ae6c1b215c7)
(those spaces are a little wider)

- vertical alignment between button and menu columns is off
![image](https://github.com/user-attachments/assets/51fb3f3c-ce35-4a36-b7f2-9dc29e580837)



After
----------------------------------------
- just use gap
![image](https://github.com/user-attachments/assets/1a3afe6d-426d-49ac-8382-8e445afd1844)
- vertical alignment with menu columns is fixed too
![image](https://github.com/user-attachments/assets/ce4d8b9b-c58c-4407-acc3-d782ed972167)

