### PR TITLE
Use escaping in SQL query for best practice

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -988,8 +988,9 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
   public static function on_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
     // When deleting a custom group, delete all orphaned fields
     if ($event->entity === 'CustomGroup' && $event->action === 'delete') {
-      $sql = "SELECT id FROM civicrm_custom_field WHERE custom_group_id = " . $event->id;
-      $orphanedFields = CRM_Core_DAO::executeQuery($sql)->fetchAll();
+      $sql = "SELECT id FROM civicrm_custom_field WHERE custom_group_id = %1";
+      $orphanedFields = CRM_Core_DAO::executeQuery($sql, [1 => [$event->id, 'Positive']])
+        ->fetchAll();
       if ($orphanedFields) {
         self::deleteRecords($orphanedFields);
       }


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup following comment from https://github.com/civicrm/civicrm-core/pull/31729#discussion_r1908361348


Technical Details
----------------------------------------
As a practical matter this was not vulnerable to SQLi because `$event->id` is already validated at this point, but it's still good to follow best practices and set a good example.