### PR TITLE
Undeleted file in deleted file list (5.80.2 only)

### DIFF
--- a/deleted-files-list.json
+++ b/deleted-files-list.json
@@ -790,7 +790,6 @@
     "ext/afform/core/ang/blockWebsiteDefault.aff.html",
     "ext/afform/core/ang/blockWebsiteDefault.aff.json",
     "ext/afform/core/settings/*",
-    "ext/afform/core/sql/*",
     "ext/afform/core/tests/phpunit/Civi/Afform/AfformGetFieldsTest.php",
     "ext/afform/core/tests/phpunit/api/*",
     "ext/afform/core/xml/schema/*",


### PR DESCRIPTION
Overview
----------------------------------------
On install of 5.80.2, CiviCRM websites all fail the "Old Files" system check.

Before
----------------------------------------
Old files check shows:
```
The local system includes old files which should not exist:

    /home/jon/local/civicrm-buildkit/build/dmaster/web/sites/all/modules/civicrm/ext/afform/core/sql
```

After
----------------------------------------
No warning.

Comments
----------------------------------------
This file was undeleted in https://github.com/civicrm/civicrm-core/pull/30740.  demeritcowboy updated the `deleted-files-list.json` to reflect this in #31645 and #31647.  #30740 was backported, but not the other one.

This could mirror #31645 a little more closely, and if 5.80 was the ESR I probably would.  But this should be sufficient to avoid alarming folks.
