### PR TITLE
SearchKit - Improve UI for adding/removing tags & fix error when tags already exist

### DIFF
--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -123,9 +123,8 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
       unset($response['rowCount']);
       $response['count'] = $result->count();
       $response['countFetched'] = $result->countFetched();
-      if (in_array('row_count', $params['select'] ?? [])) {
-        // We can only return countMatched (whose value is independent of LIMIT clauses) if row_count was in the select.
-        $response['countMatched'] = $result->count();
+      if ($result->hasCountMatched()) {
+        $response['countMatched'] = $result->countMatched();
       }
       // If at least one call succeeded, we give a success code
       $this->httpResponseCode = 200;

--- a/Civi/Api4/Generic/AutocompleteAction.php
+++ b/Civi/Api4/Generic/AutocompleteAction.php
@@ -218,10 +218,15 @@ class AutocompleteAction extends AbstractAction {
       }
       $result[] = $item;
     }
-    $result->setCountMatched($apiResult->count());
+    // Unlike a traditional pager, a scroll-type pager doesn't care about the total number of results,
+    // it just needs to know whether there are any more.
+    // If so, countMatched will include the 1 extra result fetched but not returned.
+    $countMatched = $apiResult->hasCountMatched() ? $apiResult->countMatched() : $apiResult->count();
+    $result->setCountMatched($countMatched);
+    $result->rowCount = $apiResult->count();
     if (!empty($initialSearchById)) {
       // Trigger "more results" after searching by exact id
-      $result->setCountMatched($apiResult->count() + 1);
+      $result->setCountMatched($countMatched + 1);
     }
   }
 

--- a/Civi/Api4/Generic/BasicReplaceAction.php
+++ b/Civi/Api4/Generic/BasicReplaceAction.php
@@ -97,12 +97,15 @@ class BasicReplaceAction extends AbstractBatchAction {
     $idField = $this->getSelect()[0];
     $toDelete = array_diff_key(array_column($items, NULL, $idField), array_flip(array_column($this->records, $idField)));
 
+    /** @var AbstractSaveAction $saveAction */
     $saveAction = \Civi\API\Request::create($this->getEntityName(), 'save', ['version' => 4]);
-    $saveAction
+    $saveResult = $saveAction
       ->setCheckPermissions($this->getCheckPermissions())
       ->setReload($this->reload)
-      ->setRecords($this->records);
-    $result->exchangeArray((array) $saveAction->execute());
+      ->setRecords($this->records)
+      ->execute();
+    $result->exchangeArray((array) $saveResult);
+    $result->setCountMatched($saveResult->countMatched());
 
     if ($toDelete) {
       $result->deleted = (array) civicrm_api4($this->getEntityName(), 'delete', [

--- a/Civi/Api4/Generic/BasicSaveAction.php
+++ b/Civi/Api4/Generic/BasicSaveAction.php
@@ -52,15 +52,19 @@ class BasicSaveAction extends AbstractSaveAction {
    * @param \Civi\Api4\Generic\Result $result
    */
   public function _run(Result $result) {
-    $idField = CoreUtil::getIdFieldName($this->getEntityName());
+    // Keep track of the number of records updated vs created
+    $matched = 0;
+
     foreach ($this->records as &$record) {
       $record += $this->defaults;
       $this->formatWriteValues($record);
-      $this->matchExisting($record);
+      $matched += $this->matchExisting($record);
     }
     $this->validateValues();
     $savedRecords = $this->updateRecords($this->records);
+    $result->setCountMatched($matched);
     if ($this->reload) {
+      $idField = CoreUtil::getIdFieldName($this->getEntityName());
       /** @var BasicGetAction $get */
       $get = \Civi\API\Request::create($this->getEntityName(), 'get', ['version' => 4]);
       $get

--- a/Civi/Api4/Generic/DAOGetAction.php
+++ b/Civi/Api4/Generic/DAOGetAction.php
@@ -114,16 +114,16 @@ class DAOGetAction extends AbstractGetAction {
           $result->setCountMatched(count($rows) + $this->getOffset());
           $getCount = FALSE;
         }
-        else {
-          // Set rowCount for backward compatibility.
-          $result->rowCount = count($rows) + $this->getOffset();
-        }
+        // Set rowCount for backward compatibility.
+        $result->rowCount = count($rows) + $this->getOffset();
       }
     }
 
     if ($getCount) {
       $query = new Api4SelectQuery($this);
       $result->setCountMatched($query->getCount());
+      // Set rowCount for backward compatibility.
+      $result->rowCount = $result->countMatched();
     }
   }
 

--- a/Civi/Api4/Generic/DAOSaveAction.php
+++ b/Civi/Api4/Generic/DAOSaveAction.php
@@ -25,10 +25,14 @@ class DAOSaveAction extends AbstractSaveAction {
    */
   public function _run(Result $result) {
     $idField = CoreUtil::getIdFieldName($this->getEntityName());
+
+    // Keep track of the number of records updated vs created
+    $matched = 0;
+
     foreach ($this->records as &$record) {
       $record += $this->defaults;
       $this->formatWriteValues($record);
-      $this->matchExisting($record);
+      $matched += $this->matchExisting($record);
       if (empty($record[$idField])) {
         $this->fillDefaults($record);
       }
@@ -38,6 +42,7 @@ class DAOSaveAction extends AbstractSaveAction {
     $resultArray = $this->writeObjects($this->records);
 
     $result->exchangeArray($resultArray);
+    $result->setCountMatched($matched);
   }
 
 }

--- a/Civi/Api4/Generic/Result.php
+++ b/Civi/Api4/Generic/Result.php
@@ -163,7 +163,10 @@ class Result extends \ArrayObject implements \JsonSerializable {
   }
 
   /**
-   * Returns the number of results
+   * Returns the number of results matched. This is different from the number of results returned:
+   *
+   * - For `get` actions, this is the total number of records regardless of LIMIT, so can be >= the number of results returned.
+   * - For `save` actions, this is the number of records UPDATED (not created), so can be <= the number of results returned.
    *
    * @return int
    */
@@ -176,14 +179,13 @@ class Result extends \ArrayObject implements \JsonSerializable {
 
   /**
    * Provides a way for API implementations to set the *matched* count.
-   *
-   * The matched count is the number of matching entities, regardless of any imposed limit clause.
    */
   public function setCountMatched(int $c) {
     $this->matchedCount = $c;
+  }
 
-    // Set rowCount for backward compatibility.
-    $this->rowCount = $c;
+  public function hasCountMatched(): bool {
+    return isset($this->matchedCount);
   }
 
   /**

--- a/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
+++ b/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
@@ -34,16 +34,14 @@ trait ArrayQueryActionTrait {
     if (in_array('row_count', $this->getSelect())) {
       $result->setCountMatched(count($values));
     }
-    else {
-      // Set total count before applying limit
-      //
-      // This is kept here for backward compatibility, but could be confusing because
-      // the API behaviour is different with ArrayQueryActionTrait than with DAO
-      // queries. With DAO queries, the rowCount is only the same as the total
-      // matched count in specific cases, whereas with the implementation here we are
-      // setting rowCount explicitly to the matches count, before we apply limit.
-      $result->rowCount = count($values);
-    }
+    // Set total count before applying limit
+    //
+    // This is kept here for backward compatibility, but could be confusing because
+    // the API behaviour is different with ArrayQueryActionTrait than with DAO
+    // queries. With DAO queries, the rowCount is only the same as the total
+    // matched count in specific cases, whereas with the implementation here we are
+    // setting rowCount explicitly to the matches count, before we apply limit.
+    $result->rowCount = count($values);
 
     $values = $this->limitArray($values);
     $values = $this->selectArray($values);

--- a/Civi/Api4/Generic/Traits/MatchParamTrait.php
+++ b/Civi/Api4/Generic/Traits/MatchParamTrait.php
@@ -38,8 +38,10 @@ trait MatchParamTrait {
    * Find existing record based on $this->match param
    *
    * @param $record
+   * @return int
+   *   Returns number of existing records (1 or 0)
    */
-  protected function matchExisting(&$record) {
+  protected function matchExisting(&$record): int {
     $primaryKey = CoreUtil::getIdFieldName($this->getEntityName());
     if (empty($record[$primaryKey]) && !empty($this->match)) {
       $where = [];
@@ -66,6 +68,7 @@ trait MatchParamTrait {
         }
       }
     }
+    return empty($record[$primaryKey]) ? 0 : 1;
   }
 
   /**

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
@@ -18,6 +18,7 @@
         currentBatch = 0,
         totalBatches,
         processedCount = 0,
+        countMatched = 0,
         incrementer;
 
       this.progress = 0;
@@ -63,10 +64,12 @@
           function(result) {
             stopIncrementer();
             ctrl.progress = Math.floor(100 * ++currentBatch / totalBatches);
-            processedCount += result.count;
+            processedCount += result.countFetched;
+            countMatched += (result.countMatched || result.count);
             if (ctrl.last >= ctrl.ids.length) {
               $timeout(function() {
                 result.batchCount = processedCount;
+                result.countMatched = countMatched;
                 ctrl.success({result: result});
               }, 500);
             } else {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskTag.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskTag.ctrl.js
@@ -67,6 +67,7 @@
         params.records = ctrl.selection.map(tagId => {
           return {tag_id: tagId};
         });
+        params.match = ['entity_id', 'tag_id', 'entity_table'];
       }
       // Remove tags
       else {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskTag.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskTag.ctrl.js
@@ -86,11 +86,19 @@
       });
     };
 
-    this.onSuccess = function() {
+    this.onSuccess = function(result) {
+      let msg;
       if (ctrl.action === 'delete') {
-        CRM.alert(ts('Removed tags from %1 %2.', {1: ctrl.ids.length, 2: ctrl.entityTitle}), ts('Saved'), 'success');
+        msg = result.batchCount === 1 ? ts('1 tag removed.') : ts('%1 tags removed.', {1: result.batchCount});
+        CRM.alert(msg, ts('Saved'), 'success');
       } else {
-        CRM.alert(ts('Added tags to %1 %2.', {1: ctrl.ids.length, 2: ctrl.entityTitle}), ts('Saved'), 'success');
+        const added = result.batchCount - result.countMatched;
+        msg = added === 1 ? ts('1 tag added') : ts('%1 tags added.', {1: added});
+        msg += '<br/>';
+        if (result.countMatched > 0) {
+          msg += result.countMatched === 1 ? ts('1 tag already exists and was not added.') : ts('%1 tags already exist and were not added.', {1: result.countMatched});
+        }
+        CRM.alert(msg, ts('Saved'), 'success');
       }
       this.close();
     };

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskTag.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskTag.html
@@ -40,7 +40,7 @@
     </fieldset>
     <div ng-if="$ctrl.run" class="crm-search-task-progress">
       <h5>{{:: $ctrl.action === 'save' ? ts('Adding tags...') : ts('Removing tags...') }}</h5>
-      <crm-search-batch-runner entity="'EntityTag'" action="{{ $ctrl.action }}" id-field="entity_id" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess()" error="$ctrl.onError()" ></crm-search-batch-runner>
+      <crm-search-batch-runner entity="'EntityTag'" action="{{ $ctrl.action }}" id-field="entity_id" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess(result)" error="$ctrl.onError()" ></crm-search-batch-runner>
     </div>
 
     <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" ></crm-dialog-button>

--- a/tests/phpunit/api/v4/Action/BasicActionsTest.php
+++ b/tests/phpunit/api/v4/Action/BasicActionsTest.php
@@ -100,6 +100,12 @@ class BasicActionsTest extends Api4TestBase implements HookInterface, Transactio
       ->execute()
       ->indexBy('identifier');
 
+    // 3 total records saved
+    $this->assertEquals(3, $result->countFetched());
+    // 2 records updated
+    $this->assertEquals(2, $result->countMatched());
+
+    // Check updated values
     $this->assertTrue(5 === $result[$id1]['weight']);
     $this->assertEquals('new', $result[$id2]['foo']);
     $this->assertEquals('two', $result[$id2]['group']);

--- a/tests/phpunit/api/v4/Action/ReplaceTest.php
+++ b/tests/phpunit/api/v4/Action/ReplaceTest.php
@@ -82,6 +82,8 @@ class ReplaceTest extends Api4TestBase implements TransactionalInterface {
       ->execute();
     // Should have saved 2 records
     $this->assertEquals(2, $replaced->count());
+    // Should have updated 1 record
+    $this->assertEquals(1, $replaced->countMatched());
     // Should have deleted email2
     $this->assertEquals([['id' => $e2]], $replaced->deleted);
     // Verify contact now has the new email records


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5678](https://lab.civicrm.org/dev/core/-/issues/5678)

Before
----------------------------------------
Error when trying to add tags that already exist.
No user-feedback about how many tags were actually added/removed.

After
----------------------------------------
No error; feedback given about how many tags were added vs how many already existed and were not added.