### PR TITLE
PHPUnit Bootstrap - Minor workflow improvement re:xdebug

### DIFF
--- a/tests/phpunit/CiviTest/bootstrap.php
+++ b/tests/phpunit/CiviTest/bootstrap.php
@@ -74,7 +74,8 @@ function _phpunit_mockoloader($prefix, $base_dir, $class) {
  *   If the command terminates abnormally.
  */
 function cv($cmd, $decode = 'json') {
-  $cmd = 'cv ' . $cmd;
+  // If xdebug is active when launching phpunit, we usually want to focus on phpunit.
+  $cmd = 'env XDEBUG_MODE=off XDEBUG_PORT= cv ' . $cmd;
   $descriptorSpec = [0 => ["pipe", "r"], 1 => ["pipe", "w"], 2 => STDERR];
   $oldOutput = getenv('CV_OUTPUT');
   putenv("CV_OUTPUT=json");

--- a/tests/phpunit/CiviTest/bootstrap.php
+++ b/tests/phpunit/CiviTest/bootstrap.php
@@ -75,7 +75,12 @@ function _phpunit_mockoloader($prefix, $base_dir, $class) {
  */
 function cv($cmd, $decode = 'json') {
   // If xdebug is active when launching phpunit, we usually want to focus on phpunit.
-  $cmd = 'env XDEBUG_MODE=off XDEBUG_PORT= cv ' . $cmd;
+  if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
+    $cmd = 'env XDEBUG_MODE=off XDEBUG_PORT= cv ' . $cmd;
+  }
+  else {
+    $cmd = 'cv ' . $cmd;
+  }
   $descriptorSpec = [0 => ["pipe", "r"], 1 => ["pipe", "w"], 2 => STDERR];
   $oldOutput = getenv('CV_OUTPUT');
   putenv("CV_OUTPUT=json");


### PR DESCRIPTION
Overview
----------------------------------------

This mainly matters in the case where you:

1. Run phpunit from CLI, and
2. Use another application (eg PhpStorm) as the listening-debugger

The debugger may monitor for all CLI PHP processes -- and generate UI widgets (notifications, prompts, etc) about each one.

However, in the context of phpunit, you don't normally need xdebug for this small subprocess. It just creates noise in the UI.

Before
----------------------------------------

Debugger shows extra noise.

After
----------------------------------------

Less noise.

