### PR TITLE
dev/core#5679 - Fix autocomplete for savedSearch filter on join entity

### DIFF
--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -62,7 +62,7 @@ class AfformMetadataInjector {
           if ($apiEntities) {
             $action = 'get';
             $entityList = \CRM_Utils_JS::decode(htmlspecialchars_decode($apiEntities));
-            $entityType = self::getFieldEntityType($afField->getAttribute('name'), $entityList);
+            $entityType = FormDataModel::getSearchFieldEntityType($afField->getAttribute('name'), $entityList);
           }
           else {
             $entityName = pq($fieldset)->attr('af-fieldset');
@@ -205,31 +205,6 @@ class AfformMetadataInjector {
     if ($fieldInfo) {
       self::setFieldMetadata($afField, $fieldInfo);
     }
-  }
-
-  /**
-   * Determines name of the api entit(ies) based on the field name prefix
-   *
-   * Note: Normally will return a single entity name, but
-   * Will return 2 entity names in the case of Bridge joins e.g. RelationshipCache
-   *
-   * @param string $fieldName
-   * @param string[] $entityList
-   * @return string|array
-   */
-  private static function getFieldEntityType($fieldName, $entityList) {
-    $prefix = strpos($fieldName, '.') ? explode('.', $fieldName)[0] : NULL;
-    $joinEntities = [];
-    $baseEntity = array_shift($entityList);
-    if ($prefix) {
-      foreach ($entityList as $entityAndAlias) {
-        [$entity, $alias] = explode(' AS ', $entityAndAlias);
-        if ($alias === $prefix) {
-          $joinEntities[] = $entityAndAlias;
-        }
-      }
-    }
-    return $joinEntities ?: $baseEntity;
   }
 
   private static function getFormEntities(\phpQueryObject $doc) {

--- a/ext/afform/core/Civi/Afform/FormDataModel.php
+++ b/ext/afform/core/Civi/Afform/FormDataModel.php
@@ -272,6 +272,52 @@ class FormDataModel {
   }
 
   /**
+   * Retrieves the main search entity plus join entities & their aliases.
+   *
+   * @param array $savedSearch
+   * @return array
+   *   e.g.
+   *   ```
+   *   ['Contact', 'Activity AS Contact_Activity_01']
+   *   ```
+   */
+  public static function getSearchEntities(array $savedSearch): array {
+    $entityList = [$savedSearch['api_entity']];
+    foreach ($savedSearch['api_params']['join'] ?? [] as $join) {
+      $entityList[] = $join[0];
+      if (is_string($join[2] ?? NULL)) {
+        $entityList[] = $join[2] . ' AS ' . (explode(' AS ', $join[0])[1]);
+      }
+    }
+    return $entityList;
+  }
+
+  /**
+   * Determines name of the api entit(ies) based on the field name prefix
+   *
+   * Note: Normally will return a single entity name, but
+   * Will return 2 entity names in the case of Bridge joins e.g. RelationshipCache
+   *
+   * @param string $fieldName
+   * @param string[] $entityList
+   * @return array
+   */
+  public static function getSearchFieldEntityType($fieldName, $entityList): array {
+    $prefix = strpos($fieldName, '.') ? explode('.', $fieldName)[0] : NULL;
+    $joinEntities = [];
+    $baseEntity = array_shift($entityList);
+    if ($prefix) {
+      foreach ($entityList as $entityAndAlias) {
+        [$entity, $alias] = explode(' AS ', $entityAndAlias);
+        if ($alias === $prefix) {
+          $joinEntities[] = $entityAndAlias;
+        }
+      }
+    }
+    return $joinEntities ?: [$baseEntity];
+  }
+
+  /**
    * Finds a search display within a fieldset
    *
    * @param array $node

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformUsageTestCase.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformUsageTestCase.php
@@ -31,6 +31,7 @@ abstract class AfformUsageTestCase extends AfformTestCase {
     CustomGroup::delete(FALSE)
       ->addWhere('id', '>', 0)
       ->execute();
+    $this->deleteTestRecords();
     parent::tearDown();
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5679 Afform - Autocomplete as filter fails when entity is not primary in SK](https://lab.civicrm.org/dev/core/-/issues/5679)