### PR TITLE
Bump min php version to 8.0

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -40,7 +40,7 @@ class CRM_Upgrade_Incremental_General {
   /**
    * The minimum PHP version required to install Civi.
    */
-  const MIN_INSTALL_PHP_VER = '7.4.0';
+  const MIN_INSTALL_PHP_VER = '8.0.0';
 
   /**
    * The minimum recommended MySQL version.

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
   "include-path": ["vendor/tecnickcom"],
   "config": {
     "platform": {
-      "php": "7.4.0"
+      "php": "8.0.0"
     },
     "allow-plugins": {
       "civicrm/composer-compile-plugin": true,
@@ -51,7 +51,7 @@
     }
   },
   "require": {
-    "php": "~7.4 || ~8",
+    "php": "~8.0",
     "composer-runtime-api": "~2.0",
     "dompdf/dompdf" : "~2.0.4",
     "firebase/php-jwt": ">=3 <7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a6e5af9769894acb75abaf93463dae41",
+    "content-hash": "2fd3522948f4611c3784bf704b6ed2e2",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -5521,25 +5521,26 @@
         },
         {
             "name": "typo3/phar-stream-wrapper",
-            "version": "v3.1.4",
+            "version": "v3.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3/phar-stream-wrapper.git",
-                "reference": "e0c1b495cfac064f4f5c4bcb6bf67bb7f345ed04"
+                "reference": "a931b28f422a60052db85c0a84a05a366453b2c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3/phar-stream-wrapper/zipball/e0c1b495cfac064f4f5c4bcb6bf67bb7f345ed04",
-                "reference": "e0c1b495cfac064f4f5c4bcb6bf67bb7f345ed04",
+                "url": "https://api.github.com/repos/TYPO3/phar-stream-wrapper/zipball/a931b28f422a60052db85c0a84a05a366453b2c0",
+                "reference": "a931b28f422a60052db85c0a84a05a366453b2c0",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "php": "^7.0"
+                "php": "^7.0 || ~8.0 || ~8.1 || ~8.2 || ~8.3"
             },
             "require-dev": {
                 "ext-xdebug": "*",
-                "phpunit/phpunit": "^6.5"
+                "phpspec/prophecy": "^1.10",
+                "symfony/phpunit-bridge": "^5.1"
             },
             "suggest": {
                 "ext-fileinfo": "For PHP builtin file type guessing, otherwise uses internal processing"
@@ -5569,9 +5570,9 @@
             ],
             "support": {
                 "issues": "https://github.com/TYPO3/phar-stream-wrapper/issues",
-                "source": "https://github.com/TYPO3/phar-stream-wrapper/tree/master"
+                "source": "https://github.com/TYPO3/phar-stream-wrapper/tree/v3.1.8"
             },
-            "time": "2019-12-10T11:53:27+00:00"
+            "time": "2024-12-09T23:06:33+00:00"
         },
         {
             "name": "xkerman/restricted-unserialize",
@@ -5786,7 +5787,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~7.4 || ~8",
+        "php": "~8.0",
         "composer-runtime-api": "~2.0",
         "ext-intl": "*",
         "ext-json": "*",
@@ -5794,7 +5795,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.4.0"
+        "php": "8.0.0"
     },
     "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
Overview
----------------------------------------
With the major version bump to Civi 6.0, let's also bump the dependencies.
PHP 7.4 has been [EOL since 2022](https://www.php.net/supported-versions.php), time to drop it.

Blog announcement: https://civicrm.org/blog/eileen/php-74-going-end-life-php-84-ramping

Technical Details
----------------------------------------
Note that existing sites that use php 7.4 won't immediately stop working, rather a system check will alert them "To ensure the continued operation of CiviCRM, upgrade your server now."

This required a minor version bump to typo3/phar-stream-wrapper, which seems fine.