### PR TITLE
CustomGroup: provide a more helpful message when a extendsChildType fails to validate

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -201,13 +201,13 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
       if (is_array($extendsChildType)) {
         foreach ($extendsChildType as $childType) {
           if (!array_key_exists($childType, $registeredSubTypes) && !in_array($childType, $registeredSubTypes, TRUE)) {
-            throw new CRM_Core_Exception('Supplied Sub type is not valid for the specified entity');
+            throw new CRM_Core_Exception(ts('The Sub Type ID %1 is not valid for the specified entity or it has been disabled. If the Sub Type was disabled, re-enable it temporarily and re-save this form in order to remove the setting.', [1 => $childType]));
           }
         }
       }
       else {
         if (!array_key_exists($extendsChildType, $registeredSubTypes) && !in_array($extendsChildType, $registeredSubTypes, TRUE)) {
-          throw new CRM_Core_Exception('Supplied Sub type is not valid for the specified entity');
+          throw new CRM_Core_Exception(ts('The Sub Type ID %1 is not valid for the specified entity or it has been disabled. If the Sub Type was disabled, re-enable it temporarily and re-save this form in order to remove the setting.', [1 => $childType]));
         }
         $extendsChildType = [$extendsChildType];
       }


### PR DESCRIPTION
Overview
----------------------------------------

Editing Custom Group settings can lead to the error "Supplied Sub type is not valid for the specified entity" if a sub-type was disabled, but still present in the settings.

For example:

- Create a Custom Group for Cases, applying to 2 case types
- Disable one of the case types
- Edit the custom group settings, and save the form again

Result: fatal error, sub-type not valid (because it's disabled)



Before
----------------------------------------

> Supplied Sub type is not valid for the specified entity

After
----------------------------------------

Example:

> The Sub Type ID 5 is not valid for the specified entity or it has been disabled. If the Sub Type was disabled, re-enable it temporarily and re-save this form in order to remove the setting.

Comments
----------------------------------------

A workaround is to temporarily re-enable the Case Type and edit/save the cg settings. A CiviCRM Spark user reported this problem and thought it was a CiviCRM bug (and it took me a while to figure it out).