### PR TITLE
SearchKit - Refresh DB entities via table-swap

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SKEntity/Refresh.php
+++ b/ext/search_kit/Civi/Api4/Action/SKEntity/Refresh.php
@@ -32,13 +32,40 @@ class Refresh extends AbstractAction {
       return;
     }
 
+    // Build a new table with full data. Swap-in the new table and drop the old one.
+    //
+    // NOTE: This protocol destroys inbound FKs. But the prior protocol (TRUNCATE + INSERT SELECT)
+    // also destroyed inbound FKs. To keep inbound FKs, you would probably wind up working on
+    // something more incremental. (Maybe put new data into TEMPORARY table - and use INSERT/DELETE/UPDATE
+    // to sync to the real table. But that requires guaranteeing the presence of a stable PK column(s),
+    // and it would change the default ordering over time.)
+
+    // Prepare a sketch of the process. Ensure metadata is well-formed.
     $query = (new SKEntityGenerator())->createQuery($display['saved_search_id.api_entity'], $display['saved_search_id.api_params'], $display['settings']);
     $sql = $query->getSql();
-    $tableName = _getSearchKitDisplayTableName($displayName);
+    $finalTable = _getSearchKitDisplayTableName($displayName);
     $columnSpecs = array_column($display['settings']['columns'], 'spec');
     $columns = implode(', ', array_column($columnSpecs, 'name'));
-    \CRM_Core_DAO::executeQuery("TRUNCATE TABLE `$tableName`");
-    \CRM_Core_DAO::executeQuery("INSERT INTO `$tableName` ($columns) $sql");
+    $newTable = \CRM_Utils_SQL_TempTable::build()->setDurable()->setAutodrop(FALSE)->getName();
+    $junkTable = \CRM_Utils_SQL_TempTable::build()->setDurable()->setAutodrop(FALSE)->getName();
+
+    // Only one process should actually refresh this entity (at a given time).
+    $lock = \Civi::lockManager()->acquire("data.skentity." . $display['id'], 1);
+    if (!$lock->isAcquired()) {
+      throw new \Civi\Search\Exception\RefreshInProgressException(sprintf('Refresh (%s) is already in progress', $this->getEntityName()));
+    }
+    $releaseLock = \CRM_Utils_AutoClean::with([$lock, 'release']);
+
+    // Go!
+    \CRM_Core_DAO::executeQuery("CREATE TABLE `$newTable` LIKE `$finalTable`");
+    \CRM_Core_DAO::executeQuery("INSERT INTO `$newTable` ($columns) $sql");
+    \CRM_Core_DAO::executeQuery(sprintf('RENAME TABLE `%s` TO `%s`, `%s` TO `%s`',
+      $finalTable, $junkTable,
+      $newTable, $finalTable
+    ));
+    \CRM_Core_DAO::executeQuery(sprintf('DROP TABLE `%s`', $junkTable));
+
+    // All done
     $result[] = [
       'refresh_date' => \CRM_Core_DAO::singleValueQuery("SELECT NOW()"),
     ];

--- a/ext/search_kit/Civi/Search/Exception/RefreshInProgressException.php
+++ b/ext/search_kit/Civi/Search/Exception/RefreshInProgressException.php
@@ -1,0 +1,5 @@
+<?php
+namespace Civi\Search\Exception;
+
+class RefreshInProgressException extends \CRM_Core_Exception {
+}


### PR DESCRIPTION
Overview
---------

This updates the handling of "DB Entity" (table-mode). In this mode, you need some mechanism to update the content of the table (e.g. the "refresh" operation). This revises the mechanism.

(This is an alternative to #31768. ping @colemanw)

Before
------

Clear the table (TRUNCATE) and re-fill with regenerated data (INSERT) .

In the period between the truncation and the last insertion, the content of the table is ill-defined.

After
-----

Make a new table with a temporary name and fill that. The original table remains available during the build.  Once ready, swap the tables atomically.

Comments
-----------

I'm kind of ambivalent about whether to do a straight policy-change or to configurable policy-change. This PR is a straight change-- which is simpler. In theory, new algo sounds better -- but it's clearly not proven yet. There may be some trade-offs (eg space-efficiency), and there may be other modes the future. *shrug*