### PR TITLE
SearchKit - Refresh DB entities with configurable mode

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SKEntity/Refresh.php
+++ b/ext/search_kit/Civi/Api4/Action/SKEntity/Refresh.php
@@ -5,6 +5,7 @@ namespace Civi\Api4\Action\SKEntity;
 use Civi\Api4\Generic\AbstractAction;
 use Civi\Api4\Generic\Result;
 use Civi\Search\SKEntityGenerator;
+use CRM_Search_ExtensionUtil as E;
 
 /**
  * Store the results of a SearchDisplay as a SQL table.
@@ -12,9 +13,23 @@ use Civi\Search\SKEntityGenerator;
  * For displays of type `entity` which save to a DB table
  * rather than outputting anything to the user.
  *
+ * @method $this setMode(?string $chain)
+ * @method ?string getMode()
+ *
  * @package Civi\Api4\Action\SKEntity
  */
 class Refresh extends AbstractAction {
+
+  /**
+   * @var string|null
+   * @optionsCallback getModeOptions
+   *
+   * One of:
+   *   truncate: Remove all records from the table. Refill it.
+   *   swap: Prepare a new table in the background. Then atomically swap with the old table.
+   *   NULL: Let the system choose a default.
+   */
+  protected ?string $mode = NULL;
 
   /**
    * @param \Civi\Api4\Generic\Result $result
@@ -32,15 +47,70 @@ class Refresh extends AbstractAction {
       return;
     }
 
+    // Prepare a sketch of the process. Ensure metadata is well-formed.
     $query = (new SKEntityGenerator())->createQuery($display['saved_search_id.api_entity'], $display['saved_search_id.api_params'], $display['settings']);
     $sql = $query->getSql();
-    $tableName = _getSearchKitDisplayTableName($displayName);
+    $finalTable = _getSearchKitDisplayTableName($displayName);
     $columnSpecs = array_column($display['settings']['columns'], 'spec');
     $columns = implode(', ', array_column($columnSpecs, 'name'));
-    \CRM_Core_DAO::executeQuery("TRUNCATE TABLE `$tableName`");
-    \CRM_Core_DAO::executeQuery("INSERT INTO `$tableName` ($columns) $sql");
+
+    // Only one process should actually refresh this entity (at a given time).
+    $lock = \Civi::lockManager()->acquire("data.skentity." . $display['id'], 1);
+    if (!$lock->isAcquired()) {
+      throw new \Civi\Search\Exception\RefreshInProgressException(sprintf('Refresh (%s) is already in progress', $this->getEntityName()));
+    }
+    $releaseLock = \CRM_Utils_AutoClean::with([$lock, 'release']);
+
+    // Go!
+    $mode = $this->getMode() ?: \Civi::settings()->get('search_kit_entity_refresh');
+    switch ($mode) {
+      // Build a new table with full data. Swap-in the new table and drop the old one.
+      case 'swap':
+        $newTable = \CRM_Utils_SQL_TempTable::build()->setDurable()->setAutodrop(FALSE)->getName();
+        $junkTable = \CRM_Utils_SQL_TempTable::build()->setDurable()->setAutodrop(FALSE)->getName();
+
+        // The schema 'CREATE' logic is entwined with an event listener (hard to call). We'll just imitate the output.
+        \CRM_Core_DAO::executeQuery("CREATE TABLE `$newTable` LIKE `$finalTable`");
+        \CRM_Core_DAO::executeQuery("INSERT INTO `$newTable` ($columns) $sql");
+        \CRM_Core_DAO::executeQuery(sprintf('RENAME TABLE `%s` TO `%s`, `%s` TO `%s`',
+          $finalTable, $junkTable,
+          $newTable, $finalTable
+        ));
+        \CRM_Core_DAO::executeQuery(sprintf('DROP TABLE `%s`', $junkTable));
+        break;
+
+      // case 'sync':
+      //   There is a limitation with both 'swap' and 'truncate' -- they break inbound FKs
+      //   and fire triggers. If that's a problem, then another option would be... put the
+      //   query-results into a TEMPORARY table, and then synchronize with the main table
+      //   (INSERT/UPDATE/DELETE). However, doing this would require supporting data
+      //   (suitable PK columns and modified_date or revision-id).
+
+      // Remove all data from the table and re-fill it.
+      case 'truncate':
+      case '':
+      default:
+        \CRM_Core_DAO::executeQuery("TRUNCATE TABLE `$finalTable`");
+        \CRM_Core_DAO::executeQuery("INSERT INTO `$finalTable` ($columns) $sql");
+        break;
+    }
+
+    // All done
     $result[] = [
       'refresh_date' => \CRM_Core_DAO::singleValueQuery("SELECT NOW()"),
+    ];
+  }
+
+  /**
+   * Get a list of layout options.
+   *
+   * @return array
+   *   Array (string $machineName => string $label).
+   */
+  public static function getModeOptions(): array {
+    return [
+      'swap' => E::ts('Build anew and swap'),
+      'truncate' => E::ts('Truncate and re-fill'),
     ];
   }
 

--- a/ext/search_kit/Civi/Search/Exception/RefreshInProgressException.php
+++ b/ext/search_kit/Civi/Search/Exception/RefreshInProgressException.php
@@ -1,0 +1,5 @@
+<?php
+namespace Civi\Search\Exception;
+
+class RefreshInProgressException extends \CRM_Core_Exception {
+}

--- a/ext/search_kit/info.xml
+++ b/ext/search_kit/info.xml
@@ -35,6 +35,7 @@
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>mgd-php@1.0.0</mixin>
     <mixin>entity-types-php@2.0.0</mixin>
+    <mixin>setting-php@1.0.0</mixin>
     <mixin>smarty@1.0.0</mixin>
   </mixins>
   <civix>

--- a/ext/search_kit/settings/SearchKit.setting.php
+++ b/ext/search_kit/settings/SearchKit.setting.php
@@ -1,0 +1,25 @@
+<?php
+use CRM_Search_ExtensionUtil as E;
+
+return [
+  'search_kit_entity_refresh' => [
+    'group_name' => 'Search Kit',
+    'group' => 'search_kit',
+    'name' => 'search_kit_entity_refresh',
+    'type' => 'String',
+    'html_type' => 'select',
+    'html_attributes' => [
+      'class' => 'crm-select2',
+    ],
+    'pseudoconstant' => [
+      'callback' => 'Civi\Api4\Action\SKEntity\Refresh::getModeOptions',
+    ],
+    'default' => '',
+    'add' => '5.83',
+    'title' => E::ts('Default refresh mode'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => E::ts('By default, how should the system perform refreshes on DB Entity?'),
+    'help_text' => NULL,
+  ],
+];


### PR DESCRIPTION
Overview
---------

This updates the handling of "DB Entity" (TABLE storage) -- which requires some mechanism to update the content of the table (e.g. the "refresh" operation). This makes the mechanism configurable, with two options:

* "Truncate and re-fill"
* "Create in background and swap"

(This is an alternative to #31767. ping @colemanw)

Before
------

There's one refresh mechanism: clear the table (TRUNCATE) and re-fill with regenerated data (INSERT) .

In the period between the truncation and the last insertion, the content of the table is ill-defined.

After
-----

Choice of refresh modes:

* `truncate` mode -- as before

* `swap` mode -- Make a new table with a temporary name and fill that. The original table remains available during the build.  Once ready, swap the tables atomically.

Technical Details
-----------------

Configuration hierarchy allows the mode to be set in two ways:

* The setting `search_kit_entity_refresh` determines the default.
* When calling the `refresh` action, you can override the default, eg
    ```
    cv api4 -U admin SK_GrownUps.refresh -v mode=truncate
    cv api4 -U admin SK_GrownUps.refresh -v mode=swap
    ```

Comments
-----------

If we go this way, then it probably merits an update unit-test to ensure that we get coverage over both modes.