### PR TITLE
Fixes white trash icon bug that could trigger accidental delete

### DIFF
--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -207,6 +207,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 /* Trash icons */
 .crm-container .delete-icon {
   background-image: none;
+  color: var(--crm-alert-text-danger);
 }
 .crm-container .delete-icon::before,
 .crm-container .crm-i.fa-trash::before {


### PR DESCRIPTION
The trash icon colour is set to 'inherit' so that it works with a variety of button and alert styles, but this leaves it white when it's not inside a button, background or alert style. As identified by @GuillaumeSorel here: https://lab.civicrm.org/extensions/riverlea/-/issues/11#note_175623

Overview
----------------------------------------
This PR applies a Stream's 'Alert - danger' colour to the trash icon when it's inside the `delete-icon` class. But this won't overwrite the 'inherit' applied to icons for the (many) situations where the icon needs to match the button/alert/bg style.

Before
----------------------------------------
<img width="781" alt="image" src="https://github.com/user-attachments/assets/b8b31c0c-d2df-417d-9563-1453fade2651" />

Other scenarios
<img width="234" alt="image" src="https://github.com/user-attachments/assets/0128ad80-eb34-4b19-b9d9-a1fcf29305cb" />
<img width="261" alt="image" src="https://github.com/user-attachments/assets/2adb168d-d6ee-4136-b3b0-e0c3832f1e66" />

After
----------------------------------------
Fixed:
<img width="785" alt="image" src="https://github.com/user-attachments/assets/4797dd25-74ab-42e7-aeda-47564ba4ecd7" />

Other scenarios 
BG - in menu:
<img width="230" alt="image" src="https://github.com/user-attachments/assets/b18d1e30-729f-4990-8a66-aa9bed15dcdd" />
<img width="259" alt="image" src="https://github.com/user-attachments/assets/9a4b7738-9e09-4b7d-bc40-bcbebcb3aa36" />

Comments
----------------------------------------
The conseuqneces of this UI bug is accidentally clicking the trash icon and deleting a row, hence why this is being put against the 5.81 branch.