### PR TITLE
Standalone - explicitly set $appRootPath and $settingsPath as globals in boot file

### DIFF
--- a/setup/res/civicrm.standalone.php.txt
+++ b/setup/res/civicrm.standalone.php.txt
@@ -7,6 +7,9 @@
  * locate and run the CiviCRM autoloader, classloader and settingsloader
  */
 
+// this file should set these two globals
+global $appRootPath, $settingsPath;
+
 // this file should always be in the project root
 $appRootPath = __DIR__;
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an inconsistency in Standalone system initialisation between `index.php` and `cv`.

Before
----------------------------------------
- running on the web (through `index.php`), $appRootPath and $settingsPath are implicitly global => `CRM_Utils_Standalone::cmsRootPath` returns correct value
- running using `cv`, the same vars are *not* globals => `CRM_Utils_Standalone::cmsRootPath` returns `NULL` 

After
----------------------------------------
- vars are explicitly global
- initialisation is consistent between web and cv

Technical Details
----------------------------------------
I think this would often be unsymptomatic, but I it this because of value for `cmsRootPath()` determines whether `[cms.root]/vendor/civicrm` is registered as an extension directory. So currently if using Standalone with composer you end up with strange situation that extensions in `vendor/civicrm` are found when doing a web flush (`civicrm/menu/rebuild`) but then are missing when doing `cv flush`.

The only other reference to these globals is in `Standalone.civi-setup.php` install script. This actually still suffers an inconsistency (between web installer and `cv core:install`) because at the moment `cv core:install` does not run `civicrm.standalone.php`. I would like to bring that into line also but a bit trickier and requires a cv patch, so that will be a follow up.