### PR TITLE
Navigation - Get 'delete' link working

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -876,6 +876,28 @@ ORDER BY weight";
   }
 
   /**
+   * Count all nested child items (including sub-children and sub-sub-children, etc).
+   *
+   * @param int $id
+   *   The ID of the parent item.
+   *
+   * @return int
+   *   The total number of children.
+   */
+  public static function getChildCount(int $id): int {
+    $childCount = 0;
+    $parentIds = [$id];
+    while ($parentIds) {
+      $parentIds = \Civi\Api4\Navigation::get(FALSE)
+        ->addWhere('parent_id', 'IN', $parentIds)
+        ->addSelect('id')
+        ->execute()->column('id');
+      $childCount += count($parentIds);
+    }
+    return $childCount;
+  }
+
+  /**
    * @param array $menu
    */
   public static function buildHomeMenu(&$menu) {

--- a/templates/CRM/Admin/Form/Navigation.tpl
+++ b/templates/CRM/Admin/Form/Navigation.tpl
@@ -7,49 +7,73 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{* Template for adding/editing a CiviCRM Navigation Menu Item *}
-<div class="crm-block crm-form-block crm-navigation-form-block">
-  <table class="form-layout-compressed">
-    <tr class="crm-navigation-form-block-label">
-      <td class="label">{$form.label.label}</td><td>{$form.label.html}</td>
-    </tr>
-    <tr class="crm-navigation-form-block-url">
-      <td class="label">{$form.url.label} {help id="id-menu_url" file="CRM/Admin/Form/Navigation.hlp"}</td>
-      <td>{$form.url.html} </td>
-    </tr>
-    <tr class="crm-navigation-form-block-icon">
-      <td class="label">{$form.icon.label} {help id="id-menu_icon" file="CRM/Admin/Form/Navigation.hlp"}</td>
-      <td>{$form.icon.html} </td>
-    </tr>
-    {if !empty($form.parent_id.html)}
-      <tr class="crm-navigation-form-block-parent_id">
-        <td class="label">{$form.parent_id.label} {help id="id-parent" file="CRM/Admin/Form/Navigation.hlp"}</td>
-        <td>{$form.parent_id.html}</td>
+{* Template for CiviCRM Navigation Menu Item form *}
+
+{if $action eq 8} {* Delete *}
+  <div class="messages status no-popup">
+    {icon icon="fa-info-circle"}{/icon}
+    {ts 1=$label}Menu item "%1" will be permanently deleted for all users of this site.{/ts}
+  </div>
+  {if $childCount}
+    <div class="messages crm-error no-popup">
+      {icon icon="fa-exclamation-triangle"}{/icon}
+      {if $childCount > 1}
+        {ts 1=$childCount}%1 sub-menu items will also be deleted.{/ts}
+      {else}
+        {ts}One sub-menu item will also be deleted.{/ts}
+      {/if}
+    </div>
+  {/if}
+  <p>{ts}Do you want to continue?{/ts}</p>
+  <div class="form-item">
+    {include file="CRM/common/formButtons.tpl"}
+  </div>
+
+{else} {* Add/Edit *}
+  <div class="crm-block crm-form-block crm-navigation-form-block">
+    <table class="form-layout-compressed">
+      <tr class="crm-navigation-form-block-label">
+        <td class="label">{$form.label.label}</td><td>{$form.label.html}</td>
       </tr>
-    {/if}
-    <tr class="crm-navigation-form-block-has_separator">
-      <td class="label">{$form.has_separator.label} {help id="id-has_separator" file="CRM/Admin/Form/Navigation.hlp"}</td>
-      <td>{$form.has_separator.html} </td>
-    </tr>
-    <tr class="crm-navigation-form-block-permission">
-      <td class="label">{$form.permission.label} {help id="id-menu_permission" file="CRM/Admin/Form/Navigation.hlp"}</td>
-      <td>{$form.permission.html} <span class="permission_operator_wrapper">{$form.permission_operator.html}  {help id="id-permission_operator" file="CRM/Admin/Form/Navigation.hlp"}</span></td>
-    </tr>
-    <tr class="crm-navigation-form-block-is_active">
-      <td class="label">{$form.is_active.label}</td><td>{$form.is_active.html}</td>
-    </tr>
-  </table>
-  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
-</div>
-{literal}
-<script type="text/javascript">
-  CRM.$(function($) {
-    var $form = $('form.{/literal}{$form.formClass}{literal}');
-    $('input[name=permission]', $form)
-      .on('change', function() {
-        $('span.permission_operator_wrapper').toggle(CRM._.includes($(this).val(), ','));
-      })
-      .change();
-  });
-</script>
-{/literal}
+      <tr class="crm-navigation-form-block-url">
+        <td class="label">{$form.url.label} {help id="id-menu_url" file="CRM/Admin/Form/Navigation.hlp"}</td>
+        <td>{$form.url.html} </td>
+      </tr>
+      <tr class="crm-navigation-form-block-icon">
+        <td class="label">{$form.icon.label} {help id="id-menu_icon" file="CRM/Admin/Form/Navigation.hlp"}</td>
+        <td>{$form.icon.html} </td>
+      </tr>
+      {if !empty($form.parent_id.html)}
+        <tr class="crm-navigation-form-block-parent_id">
+          <td class="label">{$form.parent_id.label} {help id="id-parent" file="CRM/Admin/Form/Navigation.hlp"}</td>
+          <td>{$form.parent_id.html}</td>
+        </tr>
+      {/if}
+      <tr class="crm-navigation-form-block-has_separator">
+        <td class="label">{$form.has_separator.label} {help id="id-has_separator" file="CRM/Admin/Form/Navigation.hlp"}</td>
+        <td>{$form.has_separator.html} </td>
+      </tr>
+      <tr class="crm-navigation-form-block-permission">
+        <td class="label">{$form.permission.label} {help id="id-menu_permission" file="CRM/Admin/Form/Navigation.hlp"}</td>
+        <td>{$form.permission.html} <span class="permission_operator_wrapper">{$form.permission_operator.html}  {help id="id-permission_operator" file="CRM/Admin/Form/Navigation.hlp"}</span></td>
+      </tr>
+      <tr class="crm-navigation-form-block-is_active">
+        <td class="label">{$form.is_active.label}</td><td>{$form.is_active.html}</td>
+      </tr>
+    </table>
+    <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+  </div>
+  {literal}
+  <script type="text/javascript">
+    CRM.$(function($) {
+      var $form = $('form.{/literal}{$form.formClass}{literal}');
+      // Show AND/OR selector only if multiple permissions are selected
+      $('input[name=permission]', $form)
+        .on('change', function() {
+          $('span.permission_operator_wrapper').toggle($(this).val().includes(','));
+        })
+        .change();
+    });
+  </script>
+  {/literal}
+{/if}


### PR DESCRIPTION
Overview
----------------------------------------
Another pre-fixup for the sake of https://github.com/civicrm/civicrm-core/pull/31520, this gets the "Delete navigation" quickform working which had previously only been a stub.

Before
----------------------------------------
"Delete Navigation" is handled entirely in Javascript on the JSTree page, so no one ever noticed that the quickform is broken.

After
----------------------------------------
Now the quickform works, which will be needed when migrating to SearchKit. It also works better than the javascript version because it counts *all* children in the hierarchy, not just the first level deep, so it gives you a more accurate count of how many items are about to be deleted.