### PR TITLE
SearchKit - Fix task links after an inline-edit

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -899,8 +899,8 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       if (!empty($link['join'])) {
         $link['prefix'] = $link['join'] . '.';
       }
-      // Get path from action
-      if (!empty($link['action'])) {
+      // Get path from action for non-task links
+      if (!empty($link['action']) && empty($link['task'])) {
         $getLinks = civicrm_api4($entity, 'getLinks', [
           'checkPermissions' => FALSE,
           'where' => [
@@ -917,6 +917,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
           $link['path'] = str_replace('[', '[' . $link['prefix'], $link['path']);
         }
       }
+      // Process task links
       elseif (!$link['path'] && !empty($link['task'])) {
         $task = $this->getTask($link['task']);
         $link['conditions'] = $task['conditions'] ?? [];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug where task links (enable/disable) would be incorrectly rendered after an inline-edit refresh.

Regressed in 5.82 from https://github.com/civicrm/civicrm-core/pull/31583