### PR TITLE
Handle possibility of a NULL source_record_id (address fatal error)

### DIFF
--- a/CRM/Activity/Selector/Activity.php
+++ b/CRM/Activity/Selector/Activity.php
@@ -108,8 +108,6 @@ class CRM_Activity_Selector_Activity extends CRM_Core_Selector_Base implements C
     $showView = TRUE;
     $showUpdate = $showDelete = FALSE;
     $qsUpdate = NULL;
-    $url = NULL;
-    $qsView = NULL;
 
     $activityTypeName = CRM_Core_PseudoConstant::getName('CRM_Activity_BAO_Activity', 'activity_type_id', $activityTypeId);
 
@@ -130,7 +128,9 @@ class CRM_Activity_Selector_Activity extends CRM_Core_Selector_Base implements C
 
       case 'Payment':
       case 'Refund':
-        $participantId = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_ParticipantPayment', $sourceRecordId, 'participant_id', 'contribution_id');
+        if ($sourceRecordId) {
+          $participantId = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_ParticipantPayment', $sourceRecordId, 'participant_id', 'contribution_id');
+        }
         if (!empty($participantId)) {
           $url = 'civicrm/contact/view/participant';
           $qsView = "action=view&reset=1&id={$participantId}&cid=%%cid%%&context=%%cxt%%{$extraParams}";


### PR DESCRIPTION

Overview
----------------------------------------
Handle possibility of a NULL source_record_id (address fatal error)

Before
----------------------------------------
If a contact has an activity record of the type 'Payment' or 'Refund' and the `source_record_id` is NULL then the activity tab will not load due to a fatal error when calling `

`       $participantId = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_ParticipantPayment', $sourceRecordId, 'participant_id', 'contribution_id');
     `

After
----------------------------------------
The screen degrades gracefully

Technical Details
----------------------------------------
The code already has some handling for orphan activities but if the missing value is the source_record_id and it is NULL then the getFieldValue() call fatals and we don't get to the handling

Comments
----------------------------------------
