### PR TITLE
SearchKit - Improve hierarchical and sortable stability

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -156,20 +156,6 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         'columns' => $columns,
       ];
       $style = $this->getCssStyles($this->display['settings']['cssRules'] ?? [], $data);
-      // Add hierarchical styles
-      if (!empty($this->display['settings']['hierarchical'])) {
-        $depth = $data['_depth'] ?? 0;
-        $style[] = 'crm-hierarchical-row crm-hierarchical-depth-' . $depth;
-        if ($depth) {
-          $style[] = 'crm-hierarchical-child';
-        }
-        if (!empty($data['_descendents'])) {
-          $style[] = 'crm-hierarchical-parent';
-          if (($this->display['settings']['collapsible'] ?? FALSE) === 'closed') {
-            $row['collapsed'] = TRUE;
-          }
-        }
-      }
       if ($style) {
         $row['cssClass'] = implode(' ', $style);
       }

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -27,6 +27,7 @@ class Run extends AbstractRunAction {
    * - "page:x": a single page
    * - "scroll:x": one 'page' of autocomplete results
    * - "tally": summary row
+   * - "draggableWeight": for draggable sorting
    * - null: all rows
    * @var string
    */
@@ -73,6 +74,18 @@ class Run extends AbstractRunAction {
         $result[] = $this->getTally();
         return;
 
+      case 'draggableWeight':
+        // Used when refreshing after a drag-sort.
+        /* @see InlineEdit::updateDraggableWeight */
+        if (empty($this->display['settings']['draggable'])) {
+          throw new \CRM_Core_Exception('Search display is not configured for draggable sorting.');
+        }
+        $idField = CoreUtil::getIdFieldName($entityName);
+        $weightField = $this->display['settings']['draggable'];
+        $apiParams['select'] = [$idField, $weightField];
+        $index = [$idField => $weightField];
+        break;
+
       default:
         // Pager mode: `page:n`
         // AJAX scroll mode: `scroll:n`
@@ -100,7 +113,7 @@ class Run extends AbstractRunAction {
     $result->rowCount = $apiResult->rowCount;
     $result->debug = $apiResult->debug;
 
-    if ($this->return === 'row_count' || $this->return === 'id') {
+    if ($this->return === 'row_count' || $this->return === 'id' || $this->return === 'draggableWeight') {
       $result->exchangeArray($apiResult->getArrayCopy());
     }
     else {

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayEditableTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayEditableTrait.service.js
@@ -54,6 +54,10 @@
               const rowIndex = ctrl.results.findIndex(row => row.key === rowKey);
               // If the api returned a refreshed row, replace the current row with it
               if (result.length) {
+                // Preserve hierarchical info which isn't returned by the refresh
+                result[0].data._descendents = ctrl.results[rowIndex].data._descendents;
+                result[0].data._depth = ctrl.results[rowIndex].data._depth;
+                // Note that extend() will preserve top-level items like 'collapsed' which aren't returned by the refresh
                 angular.extend(ctrl.results[rowIndex], result[0]);
               }
               // Or it's possible that the update caused this row to no longer match filters, in which case remove it

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -94,6 +94,24 @@
         return headerClasses.join(' ');
       };
 
+      this.getRowClass = function (rowIndex) {
+        const row = ctrl.results[rowIndex];
+        let cssClass;
+        if (row) {
+          cssClass = row.cssClass || '';
+          if (ctrl.settings.hierarchical) {
+            cssClass += ' crm-hierarchical-row crm-hierarchical-depth-' + row.data._depth;
+            if (row.data._depth) {
+              cssClass += ' crm-hierarchical-child';
+            }
+            if (row.data._descendents) {
+              cssClass += ' crm-hierarchical-parent';
+            }
+          }
+        }
+        return cssClass;
+      };
+
     }
   });
 

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -56,23 +56,43 @@
               return ui;
             },
             stop: function(e, ui) {
-              $scope.$apply(function() {
-                var movedItem = ui.item.sortable.model,
-                  oldPosition = ui.item.sortable.index,
-                  newPosition = ctrl.results.indexOf(movedItem),
-                  displacement = newPosition < oldPosition ? -1 : 1,
-                  displacedItem = ctrl.results[newPosition - displacement],
-                  weightColumn = ctrl.settings.draggable,
-                  updateParams = {where: [['id', '=', movedItem.data.id]], values: {}};
-                if (newPosition > -1 && oldPosition !== newPosition) {
-                  updateParams.values[weightColumn] = displacedItem.data[weightColumn];
-                  ctrl.runSearch({updateWeight: [ctrl.apiEntity, 'update', updateParams]}, {}, movedItem);
-                }
-              });
+              const movedItem = ui.item.sortable.model,
+                oldPosition = ui.item.sortable.index,
+                newPosition = ctrl.results.indexOf(movedItem),
+                displacement = newPosition < oldPosition ? -1 : 1,
+                displacedItem = ctrl.results[newPosition - displacement];
+              if (newPosition > -1 && oldPosition !== newPosition) {
+                updateDraggableWeights(movedItem.key, displacedItem.data);
+              }
             }
           };
         }
       };
+
+      function updateDraggableWeights(key, data) {
+        const weightField = ctrl.settings.draggable;
+        const newWeight = data[weightField];
+        const apiParams = ctrl.getApiParams('draggableWeight');
+        apiParams.rowKey = key;
+        apiParams.values = {};
+        apiParams.values[weightField] = newWeight;
+        crmApi4('SearchDisplay', 'inlineEdit', apiParams)
+          .then(function(newWeights) {
+            const weightColumn = ctrl.settings.columns.findIndex(col => col.key === weightField);
+            ctrl.results.forEach(function(row) {
+              if (row.key in newWeights) {
+                row.data[weightField] = newWeights[row.key];
+                // If there is a column containing 'weight' as a value, update it and
+                // hope it doesn't use rewrite or any advanced formatting; 'cause this is but a simple refresh function
+                if (weightColumn >= 0) {
+                  row.columns[weightColumn].val = newWeights[row.key];
+                  // Break reference to trigger an Angular view refresh
+                  row.columns[weightColumn] = JSON.parse(angular.toJson(row.columns[weightColumn]));
+                }
+              }
+            });
+          });
+      }
 
       // Get header classes for each column
       this.getHeaderClass = function (column) {

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
@@ -1,10 +1,10 @@
 <tr ng-repeat="(rowIndex, row) in $ctrl.results" data-entity-id="{{:: row.key }}" ng-if="!row.hidden">
-  <td ng-if=":: $ctrl.hasExtraFirstColumn()" class="crm-search-ctrl-column {{:: row.cssClass }}">
+  <td ng-if=":: $ctrl.hasExtraFirstColumn()" class="crm-search-ctrl-column {{:: ctrl.getRowClass(rowIndex) }}">
     <span ng-if=":: $ctrl.settings.draggable" class="crm-draggable" title="{{:: ts('Drag to reposition') }}">
       <i class="crm-i fa-arrows-v"></i>
     </span>
     <input ng-if=":: $ctrl.settings.actions" type="checkbox" ng-checked="$ctrl.isRowSelected(row)" ng-click="$ctrl.toggleRow(row, $event)" ng-disabled="!!$ctrl.loadingAllRows">
-    <crm-search-display-toggle-collapse ng-if=":: $ctrl.settings.collapsible" rows="$ctrl.results" row-index="rowIndex"></crm-search-display-toggle-collapse>
+    <crm-search-display-toggle-collapse ng-if=":: $ctrl.settings.collapsible" default-collapsed="$ctrl.settings.collapsible" rows="$ctrl.results" row-index="rowIndex"></crm-search-display-toggle-collapse>
     <div class="btn-group" ng-if="$ctrl.isEditing(rowIndex)">
       <button type="button" class="btn btn-sm btn-success" ng-click="$ctrl.saveEditing(rowIndex)">
         <span class="sr-only">{{:: ts('Save') }}</span>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayToggleCollapse.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayToggleCollapse.component.js
@@ -5,6 +5,7 @@
     bindings: {
       rows: '<',
       rowIndex: '<',
+      defaultCollapsed: '<',
     },
     templateUrl: '~/crmSearchDisplayTable/crmSearchDisplayToggleCollapse.html',
     controller: function($scope, $element) {
@@ -13,6 +14,9 @@
 
       this.$onInit = function() {
         const row = this.getRow();
+        if (!('collapsed' in row)) {
+          row.collapsed = row.data._descendents && this.defaultCollapsed === 'closed';
+        }
         if (row.collapsed && row.data._descendents) {
           row.collapsed = false;
           this.toggleCollapsed();


### PR DESCRIPTION
Overview
----------------------------------------
This fixes bugs and improves the code for inline-editing and drag-sorting in SearchKit.

Technical Details
----------------------------------------
1. [Fix compatability between hierarchical and editable rows](https://github.com/civicrm/civicrm-core/commit/ab7e164ee4a824265b52cde6f146946118008345): When inline-editing fields in a hierarchical table, the hierarchical state wasn't being correctly recalculated server-side, but it doesn't need to be; just needed to move hierarchical style logic from PHP to JavaScript so the state could be preserved. Calculating default collapsed states client-side means it won't be overwritten during refresh, and since `_depth` and `_children` doesn't change during inline-edit, they can be carried over without the need to recalculate.
2. [Use InlineEdit action for draggable sorting](https://github.com/civicrm/civicrm-core/commit/584830fc6b6d2d3d354d620ee0fa5dcd44142196): Improves efficiency and permission handling by going through the new `InlineEdit` action instead of the vanilla api4 to update weights. This also clears the way for a potential display of type "Tree".
