### PR TITLE
restore alpha-selector to the top of search results

### DIFF
--- a/templates/CRM/Contact/Form/Selector.tpl
+++ b/templates/CRM/Contact/Form/Selector.tpl
@@ -8,6 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {include file="CRM/common/pager.tpl" location="top"}
+{include file="CRM/common/pagerAToZ.tpl"}
 <table summary="{ts}Search results listings.{/ts}" class="selector row-highlight">
   <thead class="sticky">
     <tr>
@@ -119,7 +120,6 @@
     {/foreach}
   {/if}
 </table>
-{include file="CRM/common/pagerAToZ.tpl"}
 {include file="CRM/common/pager.tpl" location="bottom"}
 <script type="text/javascript">
   {literal}


### PR DESCRIPTION
Restores alpha-selector removed in https://github.com/civicrm/civicrm-core/pull/31187

The conversation was about pagination and the Alpha selector was also moved to the bottom.  This will restore to the alpha selector while leaving the rest of the PR changes.

Targeting the RC as I think this should be in 5.81 ESR as well.