### PR TITLE
(REF) Tests - Sundry cleanups

### DIFF
--- a/tests/phpunit/CRM/Utils/FileTest.php
+++ b/tests/phpunit/CRM/Utils/FileTest.php
@@ -8,6 +8,7 @@ class CRM_Utils_FileTest extends CiviUnitTestCase {
 
   public function tearDown(): void {
     $this->callAPISuccess('OptionValue', 'get', ['option_group_id' => 'safe_file_extension', 'value' => 17, 'api.option_value.delete' => ['id' => "\$value.id"]]);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/api/v4/Action/ContactIsDeletedTest.php
+++ b/tests/phpunit/api/v4/Action/ContactIsDeletedTest.php
@@ -40,10 +40,18 @@ class ContactIsDeletedTest extends Api4TestBase implements TransactionalInterfac
       'civicrm_activity_contact',
     ];
     $this->cleanup(['tablesToTruncate' => $relatedTables]);
+    return parent::setUpHeadless();
+  }
+
+  protected function setUp(): void {
     $displayNameFormat = '{contact.first_name}{ }{contact.last_name}';
     \Civi::settings()->set('display_name_format', $displayNameFormat);
+    parent::setUp();
+  }
 
-    return parent::setUpHeadless();
+  public function tearDown(): void {
+    parent::tearDown();
+    \Civi::settings()->revert('display_name_format');
   }
 
   /**

--- a/tests/phpunit/api/v4/Action/ReplaceTest.php
+++ b/tests/phpunit/api/v4/Action/ReplaceTest.php
@@ -38,7 +38,7 @@ class ReplaceTest extends Api4TestBase implements TransactionalInterface {
   /**
    * Set up baseline for testing
    */
-  public function setUp(): void {
+  public function tearDown(): void {
     $tablesToTruncate = [
       'civicrm_custom_group',
       'civicrm_custom_field',
@@ -46,7 +46,7 @@ class ReplaceTest extends Api4TestBase implements TransactionalInterface {
     ];
     $this->dropByPrefix('civicrm_value_replacetest');
     $this->cleanup(['tablesToTruncate' => $tablesToTruncate]);
-    parent::setUp();
+    parent::tearDown();
   }
 
   public function testEmailReplace(): void {


### PR DESCRIPTION
Fix some issues with setup/teardown in random tests. (These came up when running locally with the sloppy-test detection.)