### PR TITLE
(REF) Api4TestBase - Each test starts with default list of components

### DIFF
--- a/Civi/Test.php
+++ b/Civi/Test.php
@@ -123,7 +123,11 @@ class Test {
       ->sql("DELETE FROM civicrm_extension")
       ->callback(function ($ctx) {
         \Civi\Test::data()->populate();
-      }, 'populate');
+      }, 'populate')
+      ->callback(function ($ctx) {
+        // (1) Set baseline components. (2) Listeners on this setting are janky about "revert()".
+        \CRM_Core_BAO_ConfigSetting::setEnabledComponents(\Civi::settings()->getDefault('enable_components'));
+      }, 'reset');
     $builder->install(['org.civicrm.search_kit', 'org.civicrm.afform', 'authx']);
     return $builder;
   }

--- a/tests/phpunit/api/v4/Api4TestBase.php
+++ b/tests/phpunit/api/v4/Api4TestBase.php
@@ -53,6 +53,7 @@ class Api4TestBase extends TestCase implements HeadlessInterface {
    */
   public function tearDown(): void {
     $this->conditionallyDeleteTestRecords();
+    \CRM_Core_BAO_ConfigSetting::setEnabledComponents(\Civi::settings()->getDefault('enable_components'));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

There are several subclasses which toggle components. However, restoring the list of components is adhoc. It's cheap for us to restore them systematically.

(These came up when running locally with the sloppy-test detection.)
