### PR TITLE
SloppyTestChecker - Refine the definitions

### DIFF
--- a/Civi/Test/CiviTestListenerPHPUnit7.php
+++ b/Civi/Test/CiviTestListenerPHPUnit7.php
@@ -60,7 +60,7 @@ class CiviTestListenerPHPUnit7 implements \PHPUnit\Framework\TestListener {
       $this->tx = NULL;
     }
 
-    if ($this->isCiviTest($test) || $test instanceof \CiviUnitTestCase) {
+    if ($this->isCiviTest($test)) {
       \Civi\Test::eventChecker()->start($test);
     }
   }
@@ -68,7 +68,7 @@ class CiviTestListenerPHPUnit7 implements \PHPUnit\Framework\TestListener {
   public function endTest(\PHPUnit\Framework\Test $test, float $time): void {
     $exception = NULL;
 
-    if ($this->isCiviTest($test) || $test instanceof \CiviUnitTestCase) {
+    if ($this->isCiviTest($test)) {
       try {
         \Civi\Test::eventChecker()->stop($test);
       }
@@ -127,7 +127,7 @@ class CiviTestListenerPHPUnit7 implements \PHPUnit\Framework\TestListener {
    * @return bool
    */
   protected function isCiviTest(\PHPUnit\Framework\Test $test) {
-    return $test instanceof HookInterface || $test instanceof HeadlessInterface;
+    return $test instanceof HookInterface || $test instanceof HeadlessInterface || $test instanceof \CiviUnitTestCase;
   }
 
   /**

--- a/Civi/Test/SloppyTestChecker.php
+++ b/Civi/Test/SloppyTestChecker.php
@@ -156,6 +156,19 @@ class SloppyTestChecker {
     $snapshot['civicrm_option_value'] = static::fetchAll('SELECT * FROM %s.civicrm_option_value WHERE is_reserved = 1 ORDER BY option_group_id, name', ['option_group_id', 'name']);
     $snapshot['civicrm_relationship_type'] = static::fetchAll('SELECT * FROM %s.civicrm_relationship_type WHERE is_reserved = 1 ORDER BY name_a_b', ['name_a_b']);
 
+    // Normalize various parts of snapshot to make it easier to compare
+
+    // In "civicrm_domain", the locale_custom_strings may be stored as empty... in different ways...
+    $domains = &$snapshot['civicrm_domain'];
+    foreach ($domains as $key => $domain) {
+      if (isset($domains[$key]['locale_custom_strings'])) {
+        $domains[$key]['locale_custom_strings'] = \CRM_Utils_String::unserialize($domains[$key]['locale_custom_strings']);
+        if (empty($domains[$key]['locale_custom_strings']['en_US'])) {
+          unset($domains[$key]['locale_custom_strings']['en_US']);
+        }
+      }
+    }
+
     // In "civicrm_setting", a value of NULL is equivalent to a non-existent value.
     $settings = &$snapshot['civicrm_setting'];
     foreach (array_keys($settings) as $key) {

--- a/Civi/Test/SloppyTestChecker.php
+++ b/Civi/Test/SloppyTestChecker.php
@@ -114,16 +114,35 @@ class SloppyTestChecker {
     $tables = \Civi\Test::schema()->getTables('BASE TABLE');
     $views = \Civi\Test::schema()->getTables('VIEW');
 
+    $ignoreSettings = '("resCacheCode")';
+
     $snapshot = [];
     $snapshot['tables'] = array_combine($tables, $tables);
     $snapshot['view'] = array_combine($views, $views);
-    $snapshot['extensions'] = static::fetchAll('SELECT full_name, is_active FROM %s.civicrm_extension ORDER BY full_name', ['full_name']);
-    $snapshot['custom_groups'] = static::fetchAll('SELECT id, name FROM %s.civicrm_custom_group ORDER BY name', ['name']);
-    $snapshot['custom_fields'] = static::fetchAll('SELECT id, name, custom_group_id FROM %s.civicrm_custom_field ORDER BY name', ['name']);
-    $snapshot['settings'] = static::fetchAll('SELECT name, domain_id, value FROM %s.civicrm_setting WHERE name NOT IN ("resCacheCode") ORDER BY name, domain_id', ['name', 'domain_id']);
-    // $snapshot['settings'] = static::fetchAll('SELECT name, domain_id, value FROM %s.civicrm_setting ORDER BY name, domain_id', ['name', 'domain_id']);
-    $snapshot['contacts'] = static::fetchAll('SELECT id, display_name FROM %s.civicrm_contact', ['display_name']);
-    $snapshot['events'] = static::fetchAll('SELECT id, title FROM %s.civicrm_event', ['title']);
+    $snapshot['civicrm_extension'] = static::fetchAll('SELECT full_name, is_active FROM %s.civicrm_extension ORDER BY full_name', ['full_name']);
+    $snapshot['civicrm_component'] = static::fetchAll('SELECT id, name, namespace FROM %s.civicrm_component', ['name']);
+    $snapshot['civicrm_custom_group'] = static::fetchAll('SELECT id, name FROM %s.civicrm_custom_group ORDER BY name', ['name']);
+    $snapshot['civicrm_custom_field'] = static::fetchAll('SELECT id, name, custom_group_id FROM %s.civicrm_custom_field ORDER BY name', ['name']);
+    $snapshot['civicrm_setting'] = static::fetchAll("SELECT name, domain_id, value FROM %s.civicrm_setting WHERE name NOT IN $ignoreSettings ORDER BY name, domain_id", ['name', 'domain_id']);
+    $snapshot['civicrm_preferences_date'] = static::fetchAll('SELECT id, name, start, end, date_format, time_format FROM %s.civicrm_preferences_date ORDER BY name', ['name']);
+    $snapshot['civicrm_domain'] = static::fetchAll('SELECT name, version, locales, locale_custom_strings FROM %s.civicrm_domain', ['name']);
+    $snapshot['civicrm_membership_status'] = static::fetchAll('SELECT * FROM %s.civicrm_membership_status ORDER BY name', ['name']);
+
+    $snapshot['civicrm_worldregion'] = static::fetchAll('SELECT id, name FROM %s.civicrm_worldregion ORDER BY name', ['name']);
+    $snapshot['civicrm_timezone'] = static::fetchAll('SELECT name, abbreviation, gmt FROM %s.civicrm_timezone ORDER BY name', ['name']);
+    $snapshot['civicrm_country'] = static::fetchAll('SELECT * FROM %s.civicrm_country ORDER BY name', ['name']);
+    $snapshot['civicrm_currency'] = static::fetchAll('SELECT id, name, symbol, numeric_code FROM %s.civicrm_currency ORDER BY name', ['name']);
+
+    // Maybe: civicrm_contact_type, civicrm_financial_type, civicrm_case_type, civicrm_dashboard, civicrm_dedupe_rule,
+    // civicrm_mail_settings, civicrm_membership_type, civicrm_membership_status
+
+    // These have a mix of reserved and bespoke data. Only reserved is tracked.
+    $snapshot['civicrm_msg_template'] = static::fetchAll('SELECT id, msg_title, msg_subject, workflow_name, is_active, is_default FROM %s.civicrm_msg_template WHERE is_reserved = 1 ORDER BY id', ['id']);
+    $snapshot['civicrm_location_type'] = static::fetchAll('SELECT * FROM %s.civicrm_location_type WHERE is_reserved = 1 ORDER BY name', ['name']);
+    $snapshot['civicrm_option_group'] = static::fetchAll('SELECT * FROM %s.civicrm_option_group WHERE is_reserved = 1 ORDER BY name', ['name']);
+    $snapshot['civicrm_option_value'] = static::fetchAll('SELECT * FROM %s.civicrm_option_value WHERE is_reserved = 1 ORDER BY option_group_id, name', ['option_group_id', 'name']);
+    $snapshot['civicrm_relationship_type'] = static::fetchAll('SELECT * FROM %s.civicrm_relationship_type WHERE is_reserved = 1 ORDER BY name_a_b', ['name_a_b']);
+
     return $snapshot;
   }
 
@@ -135,6 +154,7 @@ class SloppyTestChecker {
       foreach ($index as $indexPart) {
         $key[] = $item[$indexPart] ?? 'NULL';
       }
+      unset($item['modified_date'], $item['created_date']);
       $result[implode(' ', $key)] = $item;
     }
     return $result;

--- a/Civi/Test/SloppyTestChecker.php
+++ b/Civi/Test/SloppyTestChecker.php
@@ -143,6 +143,17 @@ class SloppyTestChecker {
     $snapshot['civicrm_option_value'] = static::fetchAll('SELECT * FROM %s.civicrm_option_value WHERE is_reserved = 1 ORDER BY option_group_id, name', ['option_group_id', 'name']);
     $snapshot['civicrm_relationship_type'] = static::fetchAll('SELECT * FROM %s.civicrm_relationship_type WHERE is_reserved = 1 ORDER BY name_a_b', ['name_a_b']);
 
+    // In "civicrm_setting", a value of NULL is equivalent to a non-existent value.
+    $settings = &$snapshot['civicrm_setting'];
+    foreach (array_keys($settings) as $key) {
+      if ($settings[$key]['value'] === NULL) {
+        unset($settings[$key]);
+      }
+      else {
+        $settings[$key]['value'] = \CRM_Utils_String::unserialize($settings[$key]['value']);
+      }
+    }
+
     return $snapshot;
   }
 

--- a/tests/phpunit/CRM/Custom/Page/AJAXTest.php
+++ b/tests/phpunit/CRM/Custom/Page/AJAXTest.php
@@ -15,6 +15,11 @@
  */
 class CRM_Custom_Page_AJAXTest extends CiviUnitTestCase {
 
+  protected function setUp(): void {
+    parent::setUp();
+    $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+  }
+
   /**
    * Test multi-record custom fields
    */


### PR DESCRIPTION
Overview
----------------------------------------

Follow-up to #31693, which defined an optional mechanism to inspect test-leaks. This update is based on more experience with actually examining results and making a better distinction between meaningful/meaningless outputs.

Generally, the changes are:

* Relax criteria about data-data. (It won't care if there are some extra `Contact` records leftover.)
* Ignore some variations in data that are non-functional. (For example, suppose a test modifies a setting and then reverts it. This leaves behind an empty placeholder record for the setting -- which is functionally equivalent to having deleted the setting. For purposes of SloppyTestChecker, we don't care which way it was cleaned.)
* Tighten criteria about meta-data.
