### PR TITLE
Convert MembershipLog.modified_date from date to timestamp so we record time as well

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1181,7 +1181,7 @@ AND civicrm_membership.is_test = %2";
           $currentMembership['end_date'],
           $format
         ),
-        'modified_date' => date('Y-m-d H:i:s', CRM_Utils_Time::strtotime($today)),
+        'modified_date' => date('YmdHis', CRM_Utils_Time::strtotime($today)),
         'membership_type_id' => $currentMembership['membership_type_id'],
         'max_related' => $currentMembership['max_related'] ?? 0,
       ];
@@ -2490,7 +2490,7 @@ WHERE {$whereClause}";
           'start_date' => CRM_Utils_Date::isoToMysql($dao->start_date),
           'end_date' => CRM_Utils_Date::isoToMysql($dao->end_date),
           'modified_id' => $userId,
-          'modified_date' => CRM_Utils_Time::date('Ymd'),
+          'modified_date' => CRM_Utils_Time::date('YmdHis'),
           'membership_type_id' => $dao->membership_type_id,
           'max_related' => $dao->max_related,
         ];
@@ -2576,7 +2576,7 @@ WHERE {$whereClause}";
       'status_id' => $membership->status_id,
       'start_date' => $logStartDate,
       'end_date' => CRM_Utils_Date::isoToMysql($membership->end_date),
-      'modified_date' => CRM_Utils_Time::date('Ymd'),
+      'modified_date' => CRM_Utils_Time::date('YmdHis'),
       'membership_type_id' => $membershipTypeID ?? $membership->membership_type_id,
       'max_related' => $membership->max_related,
     ];

--- a/CRM/Upgrade/Incremental/php/SixZero.php
+++ b/CRM/Upgrade/Incremental/php/SixZero.php
@@ -29,6 +29,14 @@ class CRM_Upgrade_Incremental_php_SixZero extends CRM_Upgrade_Incremental_Base {
    */
   public function upgrade_6_0_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask(
+      'Convert MembershipLog.modified_date to timestamp',
+      'alterColumn',
+      'civicrm_membership_log',
+      'modified_date',
+      "timestamp NULL DEFAULT NULL COMMENT 'Date this membership modification action was logged.'",
+      FALSE
+    );
   }
 
 }

--- a/schema/Member/MembershipLog.entityType.php
+++ b/schema/Member/MembershipLog.entityType.php
@@ -85,7 +85,7 @@ return [
     ],
     'modified_date' => [
       'title' => ts('Membership Change Date'),
-      'sql_type' => 'date',
+      'sql_type' => 'timestamp',
       'input_type' => 'Select Date',
       'description' => ts('Date this membership modification action was logged.'),
       'add' => '1.5',

--- a/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
@@ -379,7 +379,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
     $log = $this->callAPISuccessGetSingle('MembershipLog', ['membership_id' => $membership['id'], 'options' => ['limit' => 1, 'sort' => 'id DESC']]);
     $this->assertEquals(CRM_Utils_Time::date($nextYear . '-01-01'), $log['start_date']);
     $this->assertEquals(CRM_Utils_Time::date($nextYear . '-01-31'), $log['end_date']);
-    $this->assertEquals(CRM_Utils_Time::date('Y-m-d'), $log['modified_date']);
+    $this->assertApproxEquals(strtotime(CRM_Utils_Time::date('Y-m-d H:i:s')), strtotime($log['modified_date']), 20);
 
     $contributionRecur = $this->callAPISuccessGetSingle('ContributionRecur', ['contact_id' => $this->_individualId]);
     $this->assertEquals($contributionRecur['id'], $membership['contribution_recur_id']);
@@ -710,7 +710,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
     $log = $this->callAPISuccessGetSingle('MembershipLog', ['membership_id' => $renewedMembership['id'], 'options' => ['limit' => 1, 'sort' => 'id DESC']]);
     $this->assertEquals(CRM_Utils_Time::date('Y-01-01'), $log['start_date']);
     $this->assertEquals(CRM_Utils_Time::date('Y-12-31'), $log['end_date']);
-    $this->assertEquals(CRM_Utils_Time::date('Y-m-d'), $log['modified_date']);
+    $this->assertApproxEquals(strtotime(CRM_Utils_Time::date('Y-m-d H:i:s')), strtotime($log['modified_date']), 20);
     $this->assertEquals(CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Current'), $log['status_id']);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Currently only the date is recorded in civicrm_membership_log. This is problematic if there are multiple changes on the same day because it is not clear which ones happened first. You can guess if you sort by table ID as well but it makes it much harder to correlate changes with other log entries.

Before
----------------------------------------
Only date recorded in MembershipLog.modified_date

After
----------------------------------------
Both date and time recorded in MembershipLog.modified_date

Technical Details
----------------------------------------
Converts database field to timestamp and checks that we are passing in full date/time as params when updating.

Comments
----------------------------------------
