### PR TITLE
Temporary fix for frontend AfformTokens being generated incorrectly

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -350,7 +350,14 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
 
     // Overwrite base URL if we already have a front-end URL.
     if (!$forceBackend && $frontend_url != '') {
-      $base = $frontend_url;
+      if (!empty(\Civi::$statics['afformtokenscontext'])) {
+        \Civi::log()->debug('url(): In afformTokens context. Clearing $frontend_url');
+        $frontend_url = '';
+      }
+      else {
+        // Only if not in afform tokens context
+        $base = $frontend_url;
+      }
     }
 
     $queryParts = [];
@@ -419,6 +426,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
 
     }
 
+    unset(Civi::$statics['afformtokenscontext']);
     return $final;
   }
 

--- a/ext/afform/core/Civi/Afform/Tokens.php
+++ b/ext/afform/core/Civi/Afform/Tokens.php
@@ -101,6 +101,7 @@ class Tokens extends AutoService implements EventSubscriberInterface {
             if (empty($row->context['contactId'])) {
               continue;
             }
+            \Civi::$statics['afformtokenscontext'] = TRUE;
             $url = self::createUrl($afform, $row->context['contactId'], self::getAfformArgsFromTokenContext($row));
             $row->format('text/plain')->tokens(static::$prefix, $afform['name'] . 'Url', $url);
             $row->format('text/html')->tokens(static::$prefix, $afform['name'] . 'Link', sprintf('<a href="%s">%s</a>', htmlentities($url), htmlentities($afform['title'] ?? $afform['name'])));


### PR DESCRIPTION
Overview
----------------------------------------
On WordPress when you use the Afform "MessageTokens" it doesn't always generate the correct URLs.

Before
----------------------------------------
URLs generated incorrectly depending on context

After
----------------------------------------
URLs generated correctly.

Technical Details
----------------------------------------
Example:
1. Submit an Afform (with contact + activity) that is on the WordPress frontend (eg. embedded in a page): `https://mysite.com/myfirstform`.
2. Trigger a CiviRule on "activity create" that sends an email containing a "Message Token" for another form: `https://mysite.com/mysecondform`.
3. Review the sent email and see that the link to the form is not correct.

It looks like: `https://mysite.com/myfirstform?civiwp=mysite.com/mysecondform&token=...`
But should look like: `https://mysite.com/mysecondform?token=...`

This is because the tokens code detects the referrer form and uses that as the frontend_url which we don't want in this case because the forms are completely separate.

Comments
----------------------------------------
Adding this as draft because it's a hacky proof of concept using \Civi::$statics to pass context through. But we should do it a better way.
