### PR TITLE
SearchKit - Fix unit test assumptions

### DIFF
--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -1330,15 +1330,16 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
   public function testIcons() {
     $subject = uniqid(__FUNCTION__);
 
-    $source = Contact::create(FALSE)->execute()->first();
+    $source = $this->createTestRecord('Contact');
 
     $activities = [
       ['activity_type_id:name' => 'Meeting', 'subject' => $subject, 'status_id:name' => 'Scheduled'],
       ['activity_type_id:name' => 'Phone Call', 'subject' => $subject, 'status_id:name' => 'Completed'],
     ];
-    Activity::save(FALSE)
-      ->addDefault('source_contact_id', $source['id'])
-      ->setRecords($activities)->execute();
+    $this->saveTestRecords('Activity', [
+      'defaults' => ['source_contact_id' => $source['id']],
+      'records' => $activities,
+    ]);
 
     $search = [
       'api_entity' => 'Activity',
@@ -1348,7 +1349,9 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
           'id',
         ],
         'orderBy' => [],
-        'where' => [],
+        'where' => [
+          ['subject', '=', $subject],
+        ],
         'groupBy' => [],
         'join' => [],
         'having' => [],

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunWithCustomFieldTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunWithCustomFieldTest.php
@@ -267,7 +267,7 @@ class SearchRunWithCustomFieldTest extends Api4TestBase {
             'GROUP_CONCAT(DISTINCT Contact_ActivityContact_Activity_01.testactivity2.testactivity_:label) AS GROUP_CONCAT_Contact_ActivityContact_Activity_01_testactivity2_testactivity__label',
           ],
           'orderBy' => [],
-          'where' => [['contact_type:name', '=', 'Individual']],
+          'where' => [['id', '=', $contact['id']]],
           'groupBy' => ['id'],
           'join' => [
             ['Activity AS Contact_ActivityContact_Activity_01', 'INNER', 'ActivityContact',


### PR DESCRIPTION
Overview
----------------------------------------
Test fixes

Technical Details
--------
I think @totten's recent cleanups surfaced some bad assumptions in the tests. This fixes 2 search tests by adjusting the where clause to only fetch the sample data and not anything else that happens to be in the database.