### PR TITLE
[REF][PHP8.2] Declare properties on CRM_Admin_Form_WordReplacements

### DIFF
--- a/CRM/Admin/Form/WordReplacements.php
+++ b/CRM/Admin/Form/WordReplacements.php
@@ -15,10 +15,27 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 class CRM_Admin_Form_WordReplacements extends CRM_Core_Form {
+
+  /**
+   * The "Single object" instance.
+   * Used to output a single row of the form (at the specified index)
+   *
+   * @var null|int
+   */
+  protected $_soInstance = NULL;
+
+  /**
+   * The default number of strings to output
+   *
+   * @var int
+   */
   protected $_numStrings = 10;
 
-  protected $_stringName = NULL;
-
+  /**
+   * Indicate if this form should warn users of unsaved changes
+   *
+   * @var bool
+   */
   public $unsavedChangesWarn = TRUE;
 
   /**
@@ -31,7 +48,7 @@ class CRM_Admin_Form_WordReplacements extends CRM_Core_Form {
     // should rewrite this UI.
     CRM_Core_BAO_WordReplacement::rebuild(FALSE);
 
-    $this->_soInstance = $_GET['instance'] ?? NULL;
+    $this->_soInstance = CRM_Utils_Request::retrieve('instance', 'Positive', NULL, FALSE, NULL, 'GET');
     $this->assign('soInstance', $this->_soInstance);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
[REF][PHP8.2] Declare properties on CRM_Admin_Form_WordReplacements (and general tidy up)

Before
----------------------------------------
When using the WordReplacements screen, PHP 8.2+ would complain about undeclared properties.

After
----------------------------------------
`_soInstance` is declared.

In the comment I've described this as a "Single object" instance. I have no idea if this is what `so` originally stood for, but it fits...

The `_stringName` property is removed as it was not used.

Finally the direct use of `_GET` is swapped for `CRM_Utils_Request::retrieve`. Previously passing in anything other than an `int` would cause a critical error. Now the param gets silently ignored in that case.