### PR TITLE
Smarty notice fix on tell-a-friend

### DIFF
--- a/CRM/Event/Form/Registration/ThankYou.php
+++ b/CRM/Event/Form/Registration/ThankYou.php
@@ -158,27 +158,30 @@ class CRM_Event_Form_Registration_ThankYou extends CRM_Event_Form_Registration {
     $params['entity_table'] = 'civicrm_event';
 
     $data = [];
-    $friendURL = NULL;
+    $extensionHtml = [];
 
     if (function_exists('tellafriend_civicrm_config')) {
+      // @todo - move this to tellafriend extension
       CRM_Friend_BAO_Friend::retrieve($params, $data);
       if (!empty($data['is_active'])) {
         $friendText = $data['title'];
-        $this->assign('friendText', $friendText);
         if ($this->_action & CRM_Core_Action::PREVIEW) {
           $friendURL = CRM_Utils_System::url('civicrm/friend',
-            "eid={$this->_eventId}&reset=1&action=preview&pcomponent=event"
+            "eid={$this->getEventID()}&reset=1&action=preview&pcomponent=event"
           );
         }
         else {
           $friendURL = CRM_Utils_System::url('civicrm/friend',
-            "eid={$this->_eventId}&reset=1&pcomponent=event"
+            "eid={$this->getEventID()}&reset=1&pcomponent=event"
           );
         }
+        $extensionHtml[] = '<div id="tell-a-friend" class="crm-section tell_friend_link-section">
+            <a href="' . htmlentities($friendURL) . '" title="' . htmlentities($friendText) . '" class="button"><span><i class="crm-i fa-chevron-right" aria-hidden="true"></i> ' . CRM_Utils_String::purifyHTML($friendText) . '</span></a>
+       </div><br /><br />';
       }
     }
 
-    $this->assign('friendURL', $friendURL);
+    $this->assign('extensionHtml', $extensionHtml);
     $this->assign('iCal', CRM_Event_BAO_Event::getICalLinks($this->_eventId));
     $this->assign('isShowICalIconsInline', TRUE);
 

--- a/templates/CRM/Event/Form/Registration/ThankYou.tpl
+++ b/templates/CRM/Event/Form/Registration/ThankYou.tpl
@@ -21,12 +21,10 @@
         </div>
     {/if}
 
-    {* Show link to Tell a Friend (CRM-2153) *}
-    {if $friendText}
-        <div id="tell-a-friend" class="crm-section tell_friend_link-section">
-            <a href="{$friendURL}" title="{$friendText|escape:'html'}" class="button"><span><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {$friendText}</span></a>
-       </div><br /><br />
-    {/if}
+  {* Show link to Tell a Friend (CRM-2153). Other extensions can also add text here but they must purify it *}
+  {foreach from=$extensionHtml item='html'}
+    {$html}
+  {/foreach}
 
     {* Add button for donor to create their own Personal Campaign page *}
     {if $pcpLink}


### PR DESCRIPTION
Overview
----------------------------------------

This addresses smarty notices : 

PHP Warning:  Undefined array key "friendText" in /.../wp-content/uploads/civicrm/templates_c/en_US/%%10/10E/10E3BF71%%ThankYou.tpl.php on line 24

Before
----------------------------------------
Notice present 

After
----------------------------------------
Resolved

Technical Details
----------------------------------------
A secondary  issue here is that tell-a-friend has been moved to an extension so it doesn't make sense to ensure the variable is always assigned by core - and indeed it should really be moved. My best idea at the moment is to 'help' the extension to inject it - although there is maybe no good answer - if I go this way though @seamuslee001  - what do you think re escaping / purifying - at the moment escaping is reduced by this patch

Comments
----------------------------------------
