### PR TITLE
CiviMail: don't pass unused job_id parameter to unsub methods

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -920,7 +920,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       'Subject' => $this->subject,
       'List-Unsubscribe' => "<mailto:{$verp['unsubscribe']}>",
     ];
-    self::addMessageIdHeader($headers, 'm', $job_id, $event_queue_id, $hash);
+    self::addMessageIdHeader($headers, 'm', NULL, $event_queue_id, $hash);
     return [&$verp, &$urls, &$headers];
   }
 

--- a/CRM/Mailing/Event/BAO/MailingEventReply.php
+++ b/CRM/Mailing/Event/BAO/MailingEventReply.php
@@ -175,8 +175,7 @@ class CRM_Mailing_Event_BAO_MailingEventReply extends CRM_Mailing_Event_DAO_Mail
       $h = $message->headers($headers);
     }
 
-    CRM_Mailing_BAO_Mailing::addMessageIdHeader($h, 'r', $eq->job_id, $queue_id, $eq->hash);
-    $config = CRM_Core_Config::singleton();
+    CRM_Mailing_BAO_Mailing::addMessageIdHeader($h, 'r', NULL, $queue_id, $eq->hash);
     $mailer = \Civi::service('pear_mail');
 
     if (is_object($mailer)) {

--- a/CRM/Mailing/Event/BAO/MailingEventResubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventResubscribe.php
@@ -263,7 +263,7 @@ class CRM_Mailing_Event_BAO_MailingEventResubscribe {
       'html' => $html,
       'text' => $text,
     ];
-    CRM_Mailing_BAO_Mailing::addMessageIdHeader($params, 'e', $job, $queue_id, $eq->hash);
+    CRM_Mailing_BAO_Mailing::addMessageIdHeader($params, 'e', NULL, $queue_id, $eq->hash);
     if (CRM_Core_BAO_MailSettings::includeMessageId()) {
       $params['messageId'] = $params['Message-ID'];
     }

--- a/CRM/Mailing/Event/BAO/MailingEventSubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventSubscribe.php
@@ -244,7 +244,7 @@ SELECT     civicrm_email.id as email_id
     $params['subject'] = $tokenProcessor->getRow(0)->render('subject');
 
     CRM_Mailing_BAO_Mailing::addMessageIdHeader($params, 's',
-      $this->contact_id,
+      NULL,
       $this->id,
       $this->hash
     );

--- a/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
@@ -27,8 +27,7 @@ class CRM_Mailing_Event_BAO_MailingEventUnsubscribe extends CRM_Mailing_Event_DA
   /**
    * Unsubscribe a contact from the domain.
    *
-   * @param int $job_id
-   *   The job ID.
+   * @param null $unused
    * @param int $queue_id
    *   The Queue Event ID of the recipient.
    * @param string $hash
@@ -36,8 +35,9 @@ class CRM_Mailing_Event_BAO_MailingEventUnsubscribe extends CRM_Mailing_Event_DA
    *
    * @return bool
    *   Was the contact successfully unsubscribed?
+   * @throws \Civi\Core\Exception\DBQueryException
    */
-  public static function unsub_from_domain($job_id, $queue_id, $hash) {
+  public static function unsub_from_domain($unused, $queue_id, $hash): bool {
     $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify(NULL, $queue_id, $hash);
     if (!$q) {
       return FALSE;
@@ -50,12 +50,12 @@ class CRM_Mailing_Event_BAO_MailingEventUnsubscribe extends CRM_Mailing_Event_DA
       $email = new CRM_Core_BAO_Email();
       $email->id = $q->email_id;
       if ($email->find(TRUE)) {
-        $sql = "
+        $sql = '
 UPDATE civicrm_email
 SET    on_hold = 2,
        hold_date = %1
 WHERE  email = %2
-";
+';
         $sqlParams = [
           1 => [$now, 'Timestamp'],
           2 => [$email->email, 'String'],

--- a/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
@@ -386,7 +386,7 @@ WHERE  email = %2
       'html' => $html,
       'text' => $text,
     ];
-    CRM_Mailing_BAO_Mailing::addMessageIdHeader($params, 'u', $job, $queue_id, $eq->hash);
+    CRM_Mailing_BAO_Mailing::addMessageIdHeader($params, 'u', NULL, $queue_id, $eq->hash);
     if (CRM_Core_BAO_MailSettings::includeMessageId()) {
       $params['messageId'] = $params['Message-ID'];
     }

--- a/CRM/Mailing/Form/Optout.php
+++ b/CRM/Mailing/Form/Optout.php
@@ -92,7 +92,7 @@ class CRM_Mailing_Form_Optout extends CRM_Core_Form {
     CRM_Core_Session::singleton()->pushUserContext($confirmURL);
 
     // Email address verified
-    if (CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_domain($this->_job_id, $this->_queue_id, $this->_hash)) {
+    if (CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_domain(NULL, $this->_queue_id, $this->_hash)) {
       CRM_Mailing_Event_BAO_MailingEventUnsubscribe::send_unsub_response($this->_queue_id, NULL, TRUE, $this->_job_id);
     }
 

--- a/CRM/Mailing/Page/Common.php
+++ b/CRM/Mailing/Page/Common.php
@@ -88,7 +88,7 @@ class CRM_Mailing_Page_Common extends CRM_Core_Page {
         }
       }
       else {
-        if (CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_domain($job_id, $queue_id, $hash)) {
+        if (CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_domain(NULL, $queue_id, $hash)) {
           CRM_Mailing_Event_BAO_MailingEventUnsubscribe::send_unsub_response($queue_id, NULL, TRUE, $job_id);
         }
         else {

--- a/CRM/Mailing/Page/Common.php
+++ b/CRM/Mailing/Page/Common.php
@@ -56,7 +56,7 @@ class CRM_Mailing_Page_Common extends CRM_Core_Page {
     $this->assign('email', $email);
     $this->assign('confirm', $confirm);
 
-    $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing($job_id, $queue_id, $hash, TRUE);
+    $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing(NULL, $queue_id, $hash, TRUE);
     $this->assign('groups', $groups ?? []);
     $groupExist = NULL;
     foreach ($groups as $value) {
@@ -70,7 +70,7 @@ class CRM_Mailing_Page_Common extends CRM_Core_Page {
 
     if ($confirm) {
       if ($this->_type === 'unsubscribe') {
-        $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing($job_id, $queue_id, $hash);
+        $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing(NULL, $queue_id, $hash);
         if (!empty($groups)) {
           CRM_Mailing_Event_BAO_MailingEventUnsubscribe::send_unsub_response($queue_id, $groups, FALSE, $job_id);
         }

--- a/CRM/Mailing/Page/Unsubscribe.php
+++ b/CRM/Mailing/Page/Unsubscribe.php
@@ -53,7 +53,7 @@ class CRM_Mailing_Page_Unsubscribe extends CRM_Core_Page {
       CRM_Utils_System::sendInvalidRequestResponse(ts("Invalid request: bad parameters"));
     }
 
-    $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing($jobId, $queueId, $hash);
+    $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing(NULL, $queueId, $hash);
     if (!empty($groups)) {
       CRM_Mailing_Event_BAO_MailingEventUnsubscribe::send_unsub_response($queueId, $groups, FALSE, $jobId);
     }

--- a/api/v3/MailingEventUnsubscribe.php
+++ b/api/v3/MailingEventUnsubscribe.php
@@ -49,7 +49,7 @@ function civicrm_api3_mailing_event_unsubscribe_create($params) {
     }
   }
   else {
-    $unsubs = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_domain($job, $queue, $hash);
+    $unsubs = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_domain(NULL, $queue, $hash);
     if (!$unsubs) {
       return civicrm_api3_create_error('Domain Queue event could not be found');
     }

--- a/api/v3/MailingEventUnsubscribe.php
+++ b/api/v3/MailingEventUnsubscribe.php
@@ -42,7 +42,7 @@ function civicrm_api3_mailing_event_unsubscribe_create($params) {
   $queue = $params['event_queue_id'];
   $hash = $params['hash'];
   if (empty($params['org_unsubscribe'])) {
-    $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing($job, $queue, $hash);
+    $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing(NULL, $queue, $hash);
     if (!empty($groups)) {
       CRM_Mailing_Event_BAO_MailingEventUnsubscribe::send_unsub_response($queue, $groups, FALSE, $job);
       return civicrm_api3_create_success($params);


### PR DESCRIPTION
Overview
----------------------------------------
After #27531 and #29908 `job_id` is not used in `CRM_Mailing_Event_BAO_Queue::unsub_from_mailing` and `CRM_Mailing_BAO_Mailing::addMessageIdHeader` so we don't need to pass that to it.
Also removed unused `job_id` from `CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_domain`.
Work towards https://lab.civicrm.org/dev/core/-/issues/4567

Before
----------------------------------------
Mailing Job ID is passed, but not actually used.

After
----------------------------------------
Job ID is not passed.
