### PR TITLE
dev/core#5688 restore contact summary tab keys

### DIFF
--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -478,7 +478,7 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
     }
 
     // now sort the tabs based on weight
-    usort($tabs, ['CRM_Utils_Sort', 'cmpFunc']);
+    uasort($tabs, ['CRM_Utils_Sort', 'cmpFunc']);
 
     return $tabs;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix dev/core#5688 - the lines above work hard to ensure the tab array has associative keys - then `usort` resets them all to numeric.

Comments
----------------------------------------
Have noticed there _is_ a similar issue with contactlayouteditor - I can put up a patch for that but fear people will still hit the regression if they upgrade core but not contactlayout editor? :grimacing: 
