### PR TITLE
[REF] Minor cleanup in CiviMail

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -925,46 +925,6 @@ ORDER BY   civicrm_email.is_bulkmail DESC
   }
 
   /**
-   * Return a list of group names for this mailing.  Does not work with
-   * prior-mailing targets.
-   *
-   * @deprecated since 5.71 will be removed around 5.77
-   *
-   * @return array
-   *   Names of groups receiving this mailing
-   */
-  public function &getGroupNames() {
-    CRM_Core_Error::deprecatedWarning('unused function');
-    if (!isset($this->id)) {
-      return [];
-    }
-
-    /*
-    This bypasses permissions to maintain compatibility with the SQL it replaced.  This should ideally not bypass
-    permissions in the future, but it's called by some extensions during mail processing, when cron isn't necessarily
-    called with a logged-in user.
-     */
-    $mailingGroups = MailingGroup::get(FALSE)
-      ->addSelect('group.title', 'group.frontend_title')
-      ->addJoin('Group AS group', 'LEFT', ['entity_id', '=', 'group.id'])
-      ->addWhere('mailing_id', '=', $this->id)
-      ->addWhere('entity_table', '=', 'civicrm_group')
-      ->addWhere('group_type', '=', 'Include')
-      ->execute();
-
-    $groupNames = [];
-
-    foreach ($mailingGroups as $mg) {
-      $name = $mg['group.frontend_title'] ?? $mg['group.title'];
-      if ($name) {
-        $groupNames[] = $name;
-      }
-    }
-
-    return $groupNames;
-  }
-
-  /**
    * Add the mailings.
    *
    * @param array $params

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -880,7 +880,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     $emailDomain = CRM_Core_BAO_MailSettings::defaultDomain();
     // Make sure the user configured the site correctly, otherwise you just get "Could not identify any recipients. Perhaps the group is empty?" from the mailing UI
     if (empty($emailDomain)) {
-      CRM_Core_Error::debug_log_message('Error setting verp parameters, defaultDomain is NULL.  Did you configure the bounce processing account for this domain?');
+      Civi::log()->error('Error setting verp parameters, defaultDomain is NULL.  Did you configure the bounce processing account for this domain?');
     }
 
     foreach ($verpTokens as $key => $value) {

--- a/CRM/Mailing/Event/BAO/MailingEventReply.php
+++ b/CRM/Mailing/Event/BAO/MailingEventReply.php
@@ -92,7 +92,6 @@ class CRM_Mailing_Event_BAO_MailingEventReply extends CRM_Mailing_Event_DAO_Mail
    *   Whole email to forward in one string.
    */
   public static function send($queue_id, &$mailing, &$bodyTxt, $replyto, &$bodyHTML = NULL, &$fullEmail = NULL) {
-    $domain = CRM_Core_BAO_Domain::getDomain();
     $emails = CRM_Core_BAO_Email::getTableName();
     $queue = CRM_Mailing_Event_BAO_MailingEventQueue::getTableName();
     $contacts = CRM_Contact_BAO_Contact::getTableName();

--- a/CRM/Mailing/Event/BAO/MailingEventReply.php
+++ b/CRM/Mailing/Event/BAO/MailingEventReply.php
@@ -140,17 +140,6 @@ class CRM_Mailing_Event_BAO_MailingEventReply extends CRM_Mailing_Event_DAO_Mail
       $parsed->generateHeaders();
       $h = $parsed->headers->getCaseSensitiveArray();
       $b = $parsed->generateBody();
-
-      // FIXME: ugly hack - find the first MIME boundary in
-      // the body and make the boundary in the header match it
-      $ct = $h['Content-Type'];
-      if (substr_count($ct, 'boundary=')) {
-        $matches = [];
-        preg_match('/^--(.*)$/m', $b, $matches);
-        $boundary = rtrim($matches[1]);
-        $parts = explode('boundary=', $ct);
-        $ct = "{$parts[0]} boundary=\"$boundary\"";
-      }
     }
     else {
       $fromName = empty($eq->display_name) ? $eq->email : "{$eq->display_name} ({$eq->email})";

--- a/CRM/Mailing/Event/BAO/MailingEventSubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventSubscribe.php
@@ -172,8 +172,6 @@ SELECT     civicrm_email.id as email_id
   public function send_confirm_request($email) {
     $config = CRM_Core_Config::singleton();
 
-    $domain = CRM_Core_BAO_Domain::getDomain();
-
     //get the default domain email address.
     [$domainEmailName, $domainEmailAddress] = CRM_Core_BAO_Domain::getNameAndEmail();
 

--- a/CRM/Mailing/Event/BAO/MailingEventSubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventSubscribe.php
@@ -168,6 +168,8 @@ SELECT     civicrm_email.id as email_id
    *
    * @param string $email
    *   The email address.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function send_confirm_request($email) {
     $config = CRM_Core_Config::singleton();

--- a/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
@@ -287,6 +287,8 @@ WHERE  email = %2
    *   Is this domain-level?.
    * @param int $job
    *   The job ID.
+   *
+   * @throws \CRM_Core_Exception
    */
   public static function send_unsub_response($queue_id, $groups, $is_domain, $job) {
     $domain = CRM_Core_BAO_Domain::getDomain();

--- a/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
@@ -289,7 +289,6 @@ WHERE  email = %2
    *   The job ID.
    */
   public static function send_unsub_response($queue_id, $groups, $is_domain, $job) {
-    $config = CRM_Core_Config::singleton();
     $domain = CRM_Core_BAO_Domain::getDomain();
     $mailingObject = new CRM_Mailing_DAO_Mailing();
     $mailingTable = $mailingObject->getTableName();


### PR DESCRIPTION
Overview
----------------------------------------
- Remove unused local variables, block of code
- Remove deprecated `CRM_Mailing_BAO_Mailing::getGroupNames` (scheduled for removal: around 5.77)
- add missing throws tags
- use `Civi::log()->error` instead of `CRM_Core_Error::debug_log_message` 