### PR TITLE
CRM_Report_Form::_aliases set public

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -266,9 +266,10 @@ class CRM_Report_Form extends CRM_Core_Form {
   protected $groupTempTable = '';
 
   /**
+   * Table aliases. May be altered by hook_civicrm_alterReportVar.
    * @var array
    */
-  protected $_aliases = [];
+  public $_aliases = [];
 
   /**
    * SQL where clause. May be altered by hook_civicrm_alterReportVar.


### PR DESCRIPTION
Overview
----------------------------------------
Now that `\CRM_Core_Form::getVar` and `setVar` is deprecated there's no way to access this property in the alterReportVar hook.
This property is needed to join custom tables to reports.

Before
----------------------------------------
Not accessible

After
----------------------------------------
Accessible