### PR TITLE
MixinTestCase - Small usability tweaks

### DIFF
--- a/Civi/Test/MixinTestCase.php
+++ b/Civi/Test/MixinTestCase.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Civi\Test;
+
+/**
+ * Enable, disable, and uninstall an extension. Ensure that various local example is enabled and disabled appropriately.
+ *
+ * The substantive assertions are split across various files in `tests/mixins/*.php`.
+ */
+abstract class MixinTestCase extends \PHPUnit\Framework\TestCase implements \Civi\Test\EndToEndInterface {
+
+  /**
+   * @var array
+   */
+  protected $mixinTests;
+
+  abstract protected function getMixinTests(): array;
+
+  public static function setUpBeforeClass(): void {
+    civicrm_api3('Extension', 'refresh', ['local' => TRUE, 'remote' => FALSE]);
+  }
+
+  protected function setUp(): void {
+    $this->assertNotEquals('UnitTests', getenv('CIVICRM_UF'), 'This is an end-to-end test involving CLI and HTTP. CIVICRM_UF should not be set to UnitTests.');
+    parent::setUp();
+    $this->mixinTests = $this->getMixinTests();
+  }
+
+  /**
+   * @param object $cv
+   *   The `$cv` object is (roughly speaking) a wrapper for calling `cv`.
+   *   It has method bindings for `$cv->api3()` and `$cv->api4()`.
+   *   Different variations of `$cv` may be supplied - they will execute
+   *   `$cv->api3()` and `$cv->api4()` in slightly different ways.
+   */
+  protected function runLifecycle($cv): void {
+    $this->runMethods('testPreConditions', $cv);
+
+    // Clear out anything from previous runs.
+    $cv->api3('Extension', 'disable', ['key' => 'shimmy']);
+    $cv->api3('Extension', 'uninstall', ['key' => 'shimmy']);
+
+    // The main show.
+    $cv->api3('Extension', 'enable', ['key' => 'shimmy']);
+    $this->runMethods('testInstalled', $cv);
+
+    // This is a duplicate - make sure things still work after an extra run.
+    $cv->api3('Extension', 'enable', ['key' => 'shimmy']);
+    $this->runMethods('testInstalled', $cv);
+
+    // OK, how's the cleanup?
+    $cv->api3('Extension', 'disable', ['key' => 'shimmy']);
+    $this->runMethods('testDisabled', $cv);
+
+    $cv->api3('Extension', 'uninstall', ['key' => 'shimmy']);
+    $this->runMethods('testUninstalled', $cv);
+  }
+
+  protected function runMethods(string $method, ...$args): void {
+    if (empty($this->mixinTests)) {
+      $this->fail('Cannot run methods. No mixin tests found.');
+    }
+    foreach ($this->mixinTests as $test) {
+      $test->$method(...$args);
+    }
+  }
+
+  protected function createCvWithLocalFunctions() {
+    return new class {
+
+      public function isLocal(): bool {
+        return TRUE;
+      }
+
+      public function api3($entity, $action, $params) {
+        return civicrm_api3($entity, $action, $params);
+      }
+
+      public function api4($entity, $action, $params): array {
+        $params = array_merge(['checkPermissions' => FALSE], $params);
+        return (array) civicrm_api4($entity, $action, $params);
+      }
+
+      public function phpCall($func, array $args = []) {
+        return call_user_func_array($func, $args);
+      }
+
+      public function phpEval(string $expr) {
+        // phpcs:ignore
+        return eval($expr);
+      }
+
+    };
+  }
+
+  protected function createCvWithSubprocesses() {
+    return new class {
+
+      public function isLocal(): bool {
+        return FALSE;
+      }
+
+      public function api3($entity, $action, $params) {
+        return $this->cv('api3 --in=json ' . escapeshellarg("$entity.$action"), json_encode($params));
+      }
+
+      public function api4($entity, $action, $params): array {
+        $params = array_merge(['checkPermissions' => FALSE], $params);
+        return $this->cv('api4 --in=json ' . escapeshellarg("$entity.$action"), json_encode($params));
+      }
+
+      public function phpCall($func, array $args = []) {
+        return $this->phpEval(sprintf('return call_user_func_array(%s, %s);', var_export($func, 1), var_export($args, 1)));
+      }
+
+      public function phpEval(string $expr) {
+        return $this->cv('php:eval ' . escapeshellarg($expr));
+      }
+
+      /**
+       * Call the "cv" command.
+       *
+       * @param string $cmd
+       *   The rest of the command to send.
+       * @param string|NULL $pipeData
+       *   Optional data to send to `cv` via pipe.
+       * @param string $decode
+       *   Ex: 'json' or 'phpcode'.
+       * @return string|array
+       *   Response output (if the command executed normally).
+       * @throws \RuntimeException
+       *   If the command terminates abnormally.
+       */
+      protected function cv(string $cmd, ?string $pipeData = NULL, string $decode = 'json') {
+        $cmd = 'cv ' . $cmd;
+        $descriptorSpec = array(0 => array('pipe', 'r'), 1 => array('pipe', 'w'), 2 => STDERR);
+        $oldOutput = getenv('CV_OUTPUT');
+        putenv("CV_OUTPUT=json");
+
+        // Execute `cv` in the original folder. This is a work-around for
+        // phpunit/codeception, which seem to manipulate PWD.
+        $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+        $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+        putenv("CV_OUTPUT=$oldOutput");
+
+        if ($pipeData !== NULL) {
+          fwrite($pipes[0], $pipeData);
+        }
+        fclose($pipes[0]);
+        $result = stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
+        if (proc_close($process) !== 0) {
+          throw new RuntimeException("Command failed ($cmd):\n$result");
+        }
+        switch ($decode) {
+          case 'raw':
+            return $result;
+
+          case 'phpcode':
+            // If the last output is /*PHPCODE*/, then we managed to complete execution.
+            if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+              throw new \RuntimeException("Command failed ($cmd):\n$result");
+            }
+            return $result;
+
+          case 'json':
+            return json_decode($result, 1);
+
+          default:
+            throw new RuntimeException("Bad decoder format ($decode)");
+        }
+      }
+
+    };
+
+  }
+
+}

--- a/tests/extensions/shimmy/tests/phpunit/E2E/Shimmy/LifecycleTest.php
+++ b/tests/extensions/shimmy/tests/phpunit/E2E/Shimmy/LifecycleTest.php
@@ -8,29 +8,22 @@
  * @group e2e
  * @see cv
  */
-class E2E_Shimmy_LifecycleTest extends \PHPUnit\Framework\TestCase implements \Civi\Test\EndToEndInterface {
+class E2E_Shimmy_LifecycleTest extends \Civi\Test\MixinTestCase {
 
   /**
-   * @var array
+   * @return array
    */
-  protected $mixinTests;
+  protected function getMixinTests(): array {
+    $src = dirname(__DIR__, 4);
 
-  public static function setUpBeforeClass(): void {
-    civicrm_api3('Extension', 'refresh', ['local' => TRUE, 'remote' => FALSE]);
-  }
-
-  protected function setUp(): void {
-    $this->assertNotEquals('UnitTests', getenv('CIVICRM_UF'), 'This is an end-to-end test involving CLI and HTTP. CIVICRM_UF should not be set to UnitTests.');
-
-    parent::setUp();
-
-    $this->mixinTests = [];
-    $mixinTestFiles = (array) glob($this->getPath('/tests/mixin/*Test.php'));
+    $mixinTests = [];
+    $mixinTestFiles = (array) glob($src . '/tests/mixin/*Test.php');
     foreach ($mixinTestFiles as $file) {
       require_once $file;
-      $class = '\\Civi\Shimmy\\Mixins\\' . basename($file, '.php');
-      $this->mixinTests[] = new $class();
+      $class = '\\Civi\\Shimmy\\Mixins\\' . basename($file, '.php');
+      $mixinTests[] = new $class();
     }
+    return $mixinTests;
   }
 
   /**
@@ -52,160 +45,6 @@ class E2E_Shimmy_LifecycleTest extends \PHPUnit\Framework\TestCase implements \C
    */
   public function testLifecycleWithLocalFunctions(): void {
     $this->runLifecycle($this->createCvWithLocalFunctions());
-  }
-
-  /**
-   * @param object $cv
-   *   The `$cv` object is (roughly speaking) a wrapper for calling `cv`.
-   *   It has method bindings for `$cv->api3()` and `$cv->api4()`.
-   *   Different variations of `$cv` may be supplied - they will execute
-   *   `$cv->api3()` and `$cv->api4()` in slightly different ways.
-   */
-  private function runLifecycle($cv): void {
-    $this->runMethods('testPreConditions', $cv);
-
-    // Clear out anything from previous runs.
-    $cv->api3('Extension', 'disable', ['key' => 'shimmy']);
-    $cv->api3('Extension', 'uninstall', ['key' => 'shimmy']);
-
-    // The main show.
-    $cv->api3('Extension', 'enable', ['key' => 'shimmy']);
-    $this->runMethods('testInstalled', $cv);
-
-    // This is a duplicate - make sure things still work after an extra run.
-    $cv->api3('Extension', 'enable', ['key' => 'shimmy']);
-    $this->runMethods('testInstalled', $cv);
-
-    // OK, how's the cleanup?
-    $cv->api3('Extension', 'disable', ['key' => 'shimmy']);
-    $this->runMethods('testDisabled', $cv);
-
-    $cv->api3('Extension', 'uninstall', ['key' => 'shimmy']);
-    $this->runMethods('testUninstalled', $cv);
-  }
-
-  protected static function getPath($suffix = ''): string {
-    return dirname(__DIR__, 4) . $suffix;
-  }
-
-  protected function runMethods(string $method, ...$args): void {
-    if (empty($this->mixinTests)) {
-      $this->fail('Cannot run methods. No mixin tests found.');
-    }
-    foreach ($this->mixinTests as $test) {
-      $test->$method(...$args);
-    }
-  }
-
-  protected function createCvWithLocalFunctions() {
-    return new class {
-
-      public function isLocal(): bool {
-        return TRUE;
-      }
-
-      public function api3($entity, $action, $params) {
-        return civicrm_api3($entity, $action, $params);
-      }
-
-      public function api4($entity, $action, $params): array {
-        $params = array_merge(['checkPermissions' => FALSE], $params);
-        return (array) civicrm_api4($entity, $action, $params);
-      }
-
-      public function phpCall($func, array $args = []) {
-        return call_user_func_array($func, $args);
-      }
-
-      public function phpEval(string $expr) {
-        // phpcs:ignore
-        return eval($expr);
-      }
-
-    };
-  }
-
-  protected function createCvWithSubprocesses() {
-    return new class {
-
-      public function isLocal(): bool {
-        return FALSE;
-      }
-
-      public function api3($entity, $action, $params) {
-        return $this->cv('api3 --in=json ' . escapeshellarg("$entity.$action"), json_encode($params));
-      }
-
-      public function api4($entity, $action, $params): array {
-        $params = array_merge(['checkPermissions' => FALSE], $params);
-        return $this->cv('api4 --in=json ' . escapeshellarg("$entity.$action"), json_encode($params));
-      }
-
-      public function phpCall($func, array $args = []) {
-        return $this->phpEval(sprintf('return call_user_func_array(%s, %s);', var_export($func, 1), var_export($args, 1)));
-      }
-
-      public function phpEval(string $expr) {
-        return $this->cv('php:eval ' . escapeshellarg($expr));
-      }
-
-      /**
-       * Call the "cv" command.
-       *
-       * @param string $cmd
-       *   The rest of the command to send.
-       * @param string|NULL $pipeData
-       *   Optional data to send to `cv` via pipe.
-       * @param string $decode
-       *   Ex: 'json' or 'phpcode'.
-       * @return string|array
-       *   Response output (if the command executed normally).
-       * @throws \RuntimeException
-       *   If the command terminates abnormally.
-       */
-      protected function cv(string $cmd, ?string $pipeData = NULL, string $decode = 'json') {
-        $cmd = 'cv ' . $cmd;
-        $descriptorSpec = array(0 => array('pipe', 'r'), 1 => array('pipe', 'w'), 2 => STDERR);
-        $oldOutput = getenv('CV_OUTPUT');
-        putenv("CV_OUTPUT=json");
-
-        // Execute `cv` in the original folder. This is a work-around for
-        // phpunit/codeception, which seem to manipulate PWD.
-        $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
-
-        $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
-        putenv("CV_OUTPUT=$oldOutput");
-
-        if ($pipeData !== NULL) {
-          fwrite($pipes[0], $pipeData);
-        }
-        fclose($pipes[0]);
-        $result = stream_get_contents($pipes[1]);
-        fclose($pipes[1]);
-        if (proc_close($process) !== 0) {
-          throw new RuntimeException("Command failed ($cmd):\n$result");
-        }
-        switch ($decode) {
-          case 'raw':
-            return $result;
-
-          case 'phpcode':
-            // If the last output is /*PHPCODE*/, then we managed to complete execution.
-            if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
-              throw new \RuntimeException("Command failed ($cmd):\n$result");
-            }
-            return $result;
-
-          case 'json':
-            return json_decode($result, 1);
-
-          default:
-            throw new RuntimeException("Bad decoder format ($decode)");
-        }
-      }
-
-    };
-
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

This makes it a little bit easier to debug failures in mixin tests. Specifically:

1. For CLI invocation, you can set `DEBUG=1`. It will print details of all the subcommands that it runs. This shows a story about what the test is doing.
2. For IDE inspection, there's one debuggable copy of `MixinTestCase` where you can set breakpoints. You don't need to re-run code-generator after editing this file. (And if you do re-run code-generator, it won't affect this file.)

Not great... but better...