### PR TITLE
[REF][PHP8.2] Declare tabs property in CRM_Campaign_Page_Vote

### DIFF
--- a/CRM/Campaign/Page/Vote.php
+++ b/CRM/Campaign/Page/Vote.php
@@ -23,6 +23,13 @@ class CRM_Campaign_Page_Vote extends CRM_Core_Page {
   private $_interviewerId;
 
   /**
+   * Tab key => label
+   *
+   * @var array
+   */
+  private $tabs = [];
+
+  /**
    * @return mixed
    */
   public function reserve() {
@@ -54,7 +61,7 @@ class CRM_Campaign_Page_Vote extends CRM_Core_Page {
   }
 
   public function browse() {
-    $this->_tabs = [
+    $this->tabs = [
       'reserve' => ts('Reserve Respondents'),
       'interview' => ts('Interview Respondents'),
     ];
@@ -63,7 +70,7 @@ class CRM_Campaign_Page_Vote extends CRM_Core_Page {
     $this->_interviewerId = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
 
     $subPageType = CRM_Utils_Request::retrieve('type', 'String', $this);
-    if ($subPageType) {
+    if ($subPageType && array_key_exists($subPageType, $this->tabs)) {
       $session = CRM_Core_Session::singleton();
       $session->pushUserContext(CRM_Utils_System::url('civicrm/campaign/vote', "reset=1&subPage={$subPageType}"));
       //load the data in tabs.
@@ -95,7 +102,7 @@ class CRM_Campaign_Page_Vote extends CRM_Core_Page {
 
   public function buildTabs() {
     $allTabs = [];
-    foreach ($this->_tabs as $name => $title) {
+    foreach ($this->tabs as $name => $title) {
       // check for required permissions.
       if (!CRM_Core_Permission::check([
           [


### PR DESCRIPTION
Overview
----------------------------------------
[REF][PHP8.2] Declare tabs property in CRM_Campaign_Page_Vote

Before
----------------------------------------
`_tabs` was not declared, leading to deprecation warning on PHP 8.2+

After
----------------------------------------
The property is declared, the deprecation warning is resolved.

Technical Details
----------------------------------------
Given that the tab key refers to a method `$this->{$subPageType}();`, I can't see any reason why an extension would need to read the tabs. Therefore it feels very safe for the property to be `private`.

I've also added a check that the `type` `$_GET` param is an allowed tab before calling `$this->{$subPageType}();`. I think previously it might have been possible to cause an infinite loop by accessing the page `?type=browse` (although I wasn't able to actually produce this result).