### PR TITLE
[REF][PHP8.2] Declare fields property in CRM_Contact_Form_Task_Batch

### DIFF
--- a/CRM/Contact/Form/Task/Batch.php
+++ b/CRM/Contact/Form/Task/Batch.php
@@ -52,6 +52,13 @@ class CRM_Contact_Form_Task_Batch extends CRM_Contact_Form_Task {
   protected $_preserveDefault = TRUE;
 
   /**
+   * Array of fields within the selected profile group
+   *
+   * @var array
+   */
+  protected $_fields;
+
+  /**
    * Build all the data structures needed to build the form.
    */
   public function preProcess() {
@@ -247,7 +254,7 @@ class CRM_Contact_Form_Task_Batch extends CRM_Contact_Form_Task {
    *
    * @param array $contactValues
    *   Contact values.
-   * @param CRM_Core_Form $form
+   * @param self $form
    *   Form object.
    */
   public static function parseStreetAddress(&$contactValues, &$form) {


### PR DESCRIPTION
Overview
----------------------------------------
Declare fields property in `CRM_Contact_Form_Task_Batch`

Before
----------------------------------------
A deprecation notice was thrown due to undefined `_fields` property when doing a bulk profile update of contacts.

After
----------------------------------------
The property is declared.

Technical Details
----------------------------------------
This is property that I was unsure whether to go public or protected. The rest of the properties on this class are protected, so I made this one protected too.