### PR TITLE
[REF][PHP8.2] Declare property in CRM_Mailing_Form_ForwardMailing

### DIFF
--- a/CRM/Mailing/Form/ForwardMailing.php
+++ b/CRM/Mailing/Form/ForwardMailing.php
@@ -16,6 +16,13 @@
  */
 class CRM_Mailing_Form_ForwardMailing extends CRM_Core_Form {
 
+  /**
+   * The email address associated with the passed job_id, queue_id and hash
+   *
+   * @var string|null
+   */
+  protected $_fromEmail = NULL;
+
   public function preProcess() {
     $job_id = CRM_Utils_Request::retrieve('jid', 'Positive',
       $this, NULL


### PR DESCRIPTION
Overview
----------------------------------------
Declare property in CRM_Mailing_Form_ForwardMailing

Before
----------------------------------------
PHP 8.2+ wasn't happy about the dynamically created property.

After
----------------------------------------
The property is properly declared.