### PR TITLE
Fix PHP Warning in getAdditionalParticipants

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1009,7 +1009,7 @@ WHERE cpf.price_set_id = %1 AND cpfv.label LIKE %2";
    *   $displayName => $viewUrl
    */
   public static function getAdditionalParticipants($primaryParticipantID) {
-    $additionalParticipantIDs = [];
+    $additionalParticipants = [];
     $additionalParticipantIDs = self::getAdditionalParticipantIds($primaryParticipantID);
     if (!empty($additionalParticipantIDs)) {
       foreach ($additionalParticipantIDs as $additionalParticipantID) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix PHP Warning in getAdditionalParticipants

Before
----------------------------------------
I am seeing this warning when editing a participant:

<img width="1410" alt="Screenshot 2025-01-18 at 19 19 15" src="https://github.com/user-attachments/assets/2699f2d6-735d-43cf-8ce4-023622ac95ca" />


After
----------------------------------------
Ensure the variable is defined outside the `if` and the loop, so that it always exists when we come to return it.