### PR TITLE
Cast to string for explode in CRM_Utils_CommaKV

### DIFF
--- a/CRM/Utils/CommaKV.php
+++ b/CRM/Utils/CommaKV.php
@@ -27,7 +27,7 @@ class CRM_Utils_CommaKV {
    */
   public static function unserialize($string) : array {
     $options = [];
-    $temp = explode(',', $string);
+    $temp = explode(',', $string ?? '');
 
     foreach ($temp as $value) {
       $parts = explode('=', $value, 2);


### PR DESCRIPTION
Overview
----------------------------------------
Avoid deprecation `explode(): Passing null to parameter #2 ($string) of type string is deprecated`.

Before
----------------------------------------
I was getting this deprecation when adding a contribution on a installation where there was a premium setup, but where that premium had no options. 

After
----------------------------------------
Functionally the result is the same, but without the deprecation warning.

Technical Details
----------------------------------------
It might be better if `unserialize` actually returned `NULL` rather than `[]` if the initial string was `NULL`, but that would be a functional change, and I don't understand enough about how premiums work to really know if that's sensible.