### PR TITLE
Fix undefined array key warning when ward or precinct fields don't exist

### DIFF
--- a/CRM/Campaign/BAO/Query.php
+++ b/CRM/Campaign/BAO/Query.php
@@ -380,9 +380,12 @@ civicrm_activity_assignment.record_type_id = $assigneeID ) ";
 INNER JOIN  civicrm_custom_group grp on fld.custom_group_id = grp.id
      WHERE  grp.name = %1';
     $dao = CRM_Core_DAO::executeQuery($query, [1 => ['Voter_Info', 'String']]);
-    $customSearchFields = [];
+    $customSearchFields = [
+      'ward' => FALSE,
+      'precinct' => FALSE,
+    ];
     while ($dao->fetch()) {
-      foreach (['ward', 'precinct'] as $name) {
+      foreach (array_keys($customSearchFields) as $name) {
         if (stripos($name, $dao->label) !== FALSE) {
           $fieldId = $dao->id;
           $fieldName = 'custom_' . $dao->id;


### PR DESCRIPTION
Overview
----------------------------------------
Fix undefined array key warning when ward or precinct fields don't exist

Before
----------------------------------------
On the voter search and voter listing (GOTV) pages I was getting these warnings:

<img width="1290" alt="Screenshot 2025-01-19 at 11 57 52" src="https://github.com/user-attachments/assets/d4102aa7-7520-44fc-a230-85f21209e82d" />

After
----------------------------------------
The code is slightly re-worked, so that the array keys always exist once we reach templating. Therefore the warnings go away.

Comments
----------------------------------------
This code appears to be special casing fields named `ward` or `precinct`, and adding these fields as filters if the field label is exactly "ward" or "precinct". This doens't seem to be documented anywhere, so perhaps there is a case for deprecating this functionality?
