### PR TITLE
CiviCampaign - Remove hard-coded reference to unused custom fields

### DIFF
--- a/CRM/Campaign/BAO/Query.php
+++ b/CRM/Campaign/BAO/Query.php
@@ -373,27 +373,6 @@ civicrm_activity_assignment.record_type_id = $assigneeID ) ";
       }
     }
 
-    //build ward and precinct custom fields.
-    $query = '
-    SELECT  fld.id, fld.label
-      FROM  civicrm_custom_field fld
-INNER JOIN  civicrm_custom_group grp on fld.custom_group_id = grp.id
-     WHERE  grp.name = %1';
-    $dao = CRM_Core_DAO::executeQuery($query, [1 => ['Voter_Info', 'String']]);
-    $customSearchFields = [];
-    while ($dao->fetch()) {
-      foreach (['ward', 'precinct'] as $name) {
-        if (stripos($name, $dao->label) !== FALSE) {
-          $fieldId = $dao->id;
-          $fieldName = 'custom_' . $dao->id;
-          $customSearchFields[$name] = $fieldName;
-          CRM_Core_BAO_CustomField::addQuickFormElement($form, $fieldName, $fieldId, FALSE);
-          break;
-        }
-      }
-    }
-    $form->assign('customSearchFields', $customSearchFields);
-
     $surveys = CRM_Campaign_BAO_Survey::getSurveys();
 
     if (empty($surveys) &&

--- a/templates/CRM/Campaign/Form/Search/Common.tpl
+++ b/templates/CRM/Campaign/Form/Search/Common.tpl
@@ -106,29 +106,6 @@
             {$form.postal_code.html}
           </td>
         </tr>
-        {if $customSearchFields.ward || $customSearchFields.precinct}
-          <tr>
-            {if $customSearchFields.ward}
-              {assign var='ward' value=$customSearchFields.ward}
-              <td>
-                {$form.$ward.label}
-              </td>
-              <td>
-                {$form.$ward.html}
-              </td>
-            {/if}
-
-            {if $customSearchFields.precinct}
-              {assign var='precinct' value=$customSearchFields.precinct}
-              <td>
-                {$form.$precinct.label}
-              </td>
-              <td>
-                {$form.$precinct.html}
-              </td>
-            {/if}
-          </tr>
-        {/if}
         <tr>
           <td colspan="2">
             {if $context eq 'search'}


### PR DESCRIPTION
Overview
----------------------------------------
CiviCampaign hard-codes 2 specific custom fields into the template. It's been there since 2010, but I can't find any reference to them in `universe`. They were probably part of a long-forgotten political campaign. Time to retire.