### PR TITLE
dev/core#5690 - Fix subtype filtering on contact summary custom field tabs

### DIFF
--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -422,6 +422,15 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
       'extends' => $this->get('contactType'),
       'style' => ['Tab', 'Tab with table'],
     ];
+    $subTypes = CRM_Utils_Array::explodePadded($this->get('contactSubtype'));
+    if ($subTypes) {
+      // Include groups for this subtype OR groups with no subtype
+      $subTypes[] = NULL;
+      $filters['extends_entity_column_value'] = $subTypes;
+    }
+    else {
+      $filters['extends_entity_column_value'] = NULL;
+    }
     $activeGroups = CRM_Core_BAO_CustomGroup::getAll($filters, CRM_Core_Permission::VIEW);
 
     foreach ($activeGroups as $group) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/5690

Before
-----
Tabs for contact subtypes would appear for contacts without that subtype

After
------
Correct tabs shown for given subtype

Technical Details
------

Fixes regression caused by bbb569a12df4714c56c0c7143d8f2ee06122320f