### PR TITLE
Update Miscellaneous admin form to mostly use settings

### DIFF
--- a/CRM/Admin/Form/Setting/Miscellaneous.php
+++ b/CRM/Admin/Form/Setting/Miscellaneous.php
@@ -21,42 +21,6 @@
 class CRM_Admin_Form_Setting_Miscellaneous extends CRM_Admin_Form_Setting {
 
   /**
-   * Subset of settings on the page as defined using the legacy method.
-   *
-   * @var array
-   *
-   * @deprecated - do not add new settings here - the page to display
-   * settings on should be defined in the setting metadata.
-   */
-  protected $_settings = [
-    // @todo remove these, define any not yet defined in the setting metadata.
-    'max_attachments' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'max_attachments_backend' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'contact_undelete' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'empoweredBy' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'logging' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'enableBackgroundQueue' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'maxFileSize' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'doNotAttachPDFReceipt' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'recordGeneratedLetters' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'secondDegRelPermissions' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'checksum_timeout' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'dompdf_font_dir' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'dompdf_chroot' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'dompdf_enable_remote' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'weasyprint_path' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'wkhtmltopdfPath' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'recentItemsMaxCount' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'recentItemsProviders' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'dedupe_default_limit' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'remote_profile_submissions' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'allow_alert_autodismissal' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-    'prevNextBackend' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
-    'import_batch_size' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
-    'disable_sql_memory_engine' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-  ];
-
-  /**
    * Basic setup.
    */
   public function preProcess(): void {
@@ -65,22 +29,6 @@ class CRM_Admin_Form_Setting_Miscellaneous extends CRM_Admin_Form_Setting {
     if ($maxImportFileSize > $postMaxSize) {
       CRM_Core_Session::setStatus(ts("Note: Upload max filesize ('upload_max_filesize') should not exceed Post max size ('post_max_size') as defined in PHP.ini, please check with your system administrator."), ts("Warning"), "alert");
     }
-
-    // This is a temp hack for the fact we really don't need to hard-code each setting in the tpl but
-    // we haven't worked through NOT doing that. These settings have been un-hardcoded.
-    $this->assign('pure_config_settings', [
-      'empoweredBy',
-      'max_attachments',
-      'max_attachments_backend',
-      'maxFileSize',
-      'secondDegRelPermissions',
-      'recentItemsMaxCount',
-      'recentItemsProviders',
-      'dedupe_default_limit',
-      'prevNextBackend',
-      'import_batch_size',
-      'disable_sql_memory_engine',
-    ]);
   }
 
   /**
@@ -96,6 +44,11 @@ class CRM_Admin_Form_Setting_Miscellaneous extends CRM_Admin_Form_Setting {
     $this->addFormRule(['CRM_Admin_Form_Setting_Miscellaneous', 'formRule'], $this);
 
     parent::buildQuickForm();
+    $settingMetaData = $this->getSettingsMetaData();
+    unset($settingMetaData['logging']);
+    unset($settingMetaData['weasyprint_path']);
+    unset($settingMetaData['wkhtmltopdfPath']);
+    $this->assign('settings_fields', $settingMetaData);
     $this->addRule('checksum_timeout', ts('Value should be a positive number'), 'positiveInteger');
   }
 

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -182,6 +182,7 @@ return [
     'is_contact' => 0,
     'description' => ts('If enabled, CiviCRM will permit submissions from external sites to profiles. This is disabled by default to limit abuse.'),
     'help_text' => NULL,
+    'settings_pages' => ['misc' => ['weight' => 200]],
   ],
   'allow_alert_autodismissal' => [
     'group_name' => 'CiviCRM Preferences',
@@ -197,6 +198,7 @@ return [
     'is_contact' => 0,
     'description' => ts('If disabled, CiviCRM will not automatically dismiss any alerts after 10 seconds.'),
     'help_text' => NULL,
+    'settings_pages' => ['misc' => ['weight' => 210]],
   ],
   'editor_id' => [
     'group_name' => 'CiviCRM Preferences',
@@ -259,8 +261,9 @@ return [
     'title' => ts('Background Queues'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => ts('EXPERIMENTAL: %1', [1 => ts('If enabled, some operations will be transferred to background workers. This requires configuring a background service.')]),
+    'description' => ts('If enabled, some operations will be transferred to background workers. This requires configuring a background service.'),
     'help_text' => NULL,
+    'settings_pages' => ['misc' => ['weight' => 30]],
   ],
   'defaultExternUrl' => [
     'group_name' => 'CiviCRM Preferences',
@@ -425,6 +428,7 @@ return [
     'is_contact' => 0,
     'description' => ts('Maximum number of files (documents, images, etc.) which can be attached to emails or activities. This setting applies to UI forms and limits the number of fields available on the form.'),
     'help_text' => NULL,
+    'settings_pages' => ['misc' => ['weight' => 100]],
   ],
   'max_attachments_backend' => [
     'group_name' => 'CiviCRM Preferences',
@@ -445,6 +449,7 @@ return [
     'is_contact' => 0,
     'description' => ts('Maximum number of files (documents, images, etc.) which can be processed during backend processing such as automated inbound email processing. This should be a big number higher than the other Maximum Attachments setting above. This setting here merely provides an upper limit to prevent attacks that might overload the server.'),
     'help_text' => NULL,
+    'settings_pages' => ['misc' => ['weight' => 110]],
   ],
   'maxFileSize' => [
     'group_name' => 'CiviCRM Preferences',
@@ -464,6 +469,7 @@ return [
     'is_contact' => 0,
     'description' => ts('Maximum Size of file (documents, images, etc.) which can be attached to emails or activities.<br />Note: php.ini should support this file size.'),
     'help_text' => NULL,
+    'settings_pages' => ['misc' => ['weight' => 120]],
   ],
   'contact_undelete' => [
     'group_name' => 'CiviCRM Preferences',
@@ -478,6 +484,7 @@ return [
     'is_contact' => 0,
     'description' => ts('If enabled, deleted contacts will be moved to trash (instead of being destroyed). Users with the proper permission are able to search for the deleted contacts and restore them (or delete permanently).'),
     'help_text' => NULL,
+    'settings_pages' => ['misc' => ['weight' => 20]],
   ],
   'allowPermDeleteFinancial' => [
     'group_name' => 'CiviCRM Preferences',
@@ -520,6 +527,7 @@ return [
     'is_contact' => 0,
     'description' => ts("If enabled, CiviCRM sends PDF receipt as an attachment during event signup or online contribution."),
     'help_text' => NULL,
+    'settings_pages' => ['misc' => ['weight' => 40]],
   ],
   'recordGeneratedLetters' => [
     'group_name' => 'CiviCRM Preferences',
@@ -541,6 +549,7 @@ return [
     'pseudoconstant' => [
       'callback' => 'CRM_Core_SelectValues::getPDFLoggingOptions',
     ],
+    'settings_pages' => ['misc' => ['weight' => 50]],
   ],
   'dompdf_font_dir' => [
     'is_domain' => 1,
@@ -560,6 +569,7 @@ return [
     'default' => NULL,
     'help_text' => NULL,
     'add' => '5.43',
+    'settings_pages' => ['misc' => ['weight' => 60]],
   ],
   'dompdf_chroot' => [
     'is_domain' => 1,
@@ -579,6 +589,7 @@ return [
     'default' => NULL,
     'help_text' => NULL,
     'add' => '5.43',
+    'settings_pages' => ['misc' => ['weight' => 70]],
   ],
   'dompdf_enable_remote' => [
     'is_domain' => 1,
@@ -594,6 +605,7 @@ return [
     'default' => TRUE,
     'help_text' => NULL,
     'add' => '5.43',
+    'settings_pages' => ['misc' => ['weight' => 80]],
   ],
   'dompdf_log_output_file' => [
     'is_domain' => 1,
@@ -632,6 +644,7 @@ return [
     'is_contact' => 0,
     'description' => NULL,
     'help_text' => NULL,
+    'settings_pages' => ['misc' => ['weight' => 90]],
   ],
   'wkhtmltopdfPath' => [
     'group_name' => 'CiviCRM Preferences',
@@ -651,6 +664,7 @@ return [
     'is_contact' => 0,
     'description' => NULL,
     'help_text' => NULL,
+    'settings_pages' => ['misc' => ['weight' => 95]],
   ],
   'checksum_timeout' => [
     'group_name' => 'CiviCRM Preferences',
@@ -668,8 +682,9 @@ return [
     'title' => ts('Checksum Lifespan'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => NULL,
+    'description' => ts('The number of days before a personalized (hashed) link will expire.'),
     'help_text' => NULL,
+    'settings_pages' => ['misc' => ['weight' => 10]],
   ],
   'blogUrl' => [
     'group_name' => 'CiviCRM Preferences',
@@ -799,6 +814,7 @@ return [
     'is_contact' => 0,
     'description' => ts("If enabled, contacts with the permission to edit a related contact will inherit that contact's permission to edit other related contacts"),
     'help_text' => NULL,
+    'settings_pages' => ['misc' => ['weight' => 130]],
   ],
   'disable_core_css' => [
     'group_name' => 'CiviCRM Preferences',
@@ -827,6 +843,7 @@ return [
     'is_contact' => 0,
     'description' => ts('When enabled, "empowered by CiviCRM" is displayed at the bottom of public forms.'),
     'help_text' => NULL,
+    'settings_pages' => ['misc' => ['weight' => 35]],
   ],
   'logging_no_trigger_permission' => [
     'add' => '4.7',
@@ -861,6 +878,7 @@ return [
     'on_change' => [
       'CRM_Logging_Schema::onToggle',
     ],
+    'settings_pages' => ['misc' => ['weight' => 20]],
   ],
   'logging_uniqueid_date' => [
     'add' => '4.7',
@@ -978,6 +996,7 @@ return [
     'is_contact' => 0,
     'description' => ts('How many items should CiviCRM store in it\'s "Recently viewed" list.'),
     'help_text' => NULL,
+    'settings_pages' => ['misc' => ['weight' => 140]],
   ],
   'recentItemsProviders' => [
     'group_name' => 'CiviCRM Preferences',
@@ -1000,6 +1019,7 @@ return [
     'pseudoconstant' => [
       'callback' => 'CRM_Utils_Recent::getProviders',
     ],
+    'settings_pages' => ['misc' => ['weight' => 150]],
   ],
   'import_batch_size' => [
     'name' => 'import_batch_size',
@@ -1017,7 +1037,7 @@ return [
     'is_contact' => 0,
     'description' => ts('Number of records to process at once during import.'),
     'help_text' => ts('If your imports time out, reduce this number. You can increase it for better import performance on servers with longer timeouts.'),
-    'settings_pages' => 'misc',
+    'settings_pages' => ['misc' => ['weight' => 180]],
   ],
   'disable_sql_memory_engine' => [
     'name' => 'disable_sql_memory_engine',
@@ -1031,7 +1051,7 @@ return [
     'is_contact' => 0,
     'description' => ts('Some hosting providers do not support this engine.'),
     'help_text' => NULL,
-    'settings_pages' => 'misc',
+    'settings_pages' => ['misc' => ['weight' => 190]],
   ],
   'dedupe_default_limit' => [
     'group_name' => 'CiviCRM Preferences',
@@ -1047,6 +1067,7 @@ return [
     'is_contact' => 0,
     'description' => ts('Default to only loading matches against this number of contacts'),
     'help_text' => ts('Deduping larger databases can crash the server. By configuring a limit other than 0 here the dedupe query will only search for matches against a limited number of contacts.'),
+    'settings_pages' => ['misc' => ['weight' => 160]],
   ],
   'syncCMSEmail' => [
     'group_name' => 'CiviCRM Preferences',

--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -169,9 +169,10 @@ return [
     ],
     'description' => ts('When performing a search, how should the search-results be cached?'),
     'help_text' => '',
-    // Not exposed in UI as breakage possible. As with the SmartGroupCache time out a different page
+    // Originally not exposed in UI as breakage possible. But by accident or design was added to misc .
+    // As with the SmartGroupCache time out a different page
     // might make more sense.
-    'settings_pages' => [],
+    'settings_pages' => ['misc' => ['weight' => 170]],
   ],
   'searchPrimaryDetailsOnly' => [
     'group_name' => 'Search Preferences',

--- a/templates/CRM/Admin/Form/Setting/Miscellaneous.tpl
+++ b/templates/CRM/Admin/Form/Setting/Miscellaneous.tpl
@@ -9,20 +9,6 @@
 *}
 <div class="crm-block crm-form-block crm-miscellaneous-form-block">
     <table class="form-layout">
-      <tr class="crm-miscellaneous-form-block-checksum_timeout">
-        <td class="label">{$form.checksum_timeout.label}</td>
-        <td>{$form.checksum_timeout.html}<br />
-            <span class="description">{ts}The number of days before a personalized (hashed) link will expire.{/ts}</span></td>
-      </tr>
-    </table>
-    <table class="form-layout">
-      <tr class="crm-miscellaneous-form-block-contact_undelete">
-        <td class="label">{$form.contact_undelete.label}</td>
-        <td>
-          {$form.contact_undelete.html}<br />
-          <p class="description">{ts}{$contact_undelete_description}{/ts}</p>
-        </td>
-      </tr>
       <tr class="crm-miscellaneous-form-block-logging">
         <td class="label">{$form.logging.label}</td>
         <td>
@@ -38,42 +24,6 @@
         {/if}
         </td>
       </tr>
-      <tr class="crm-miscellaneous-form-block-enableBackgroundQueue">
-        <td class="label">{$form.enableBackgroundQueue.label}</td>
-        <td>{$form.enableBackgroundQueue.html}<br />
-          <span class="description">{$setting_descriptions.enableBackgroundQueue}</span>
-        </td>
-      </tr>
-      <tr class="crm-miscellaneous-form-block-doNotAttachPDFReceipt">
-        <td class="label">{$form.doNotAttachPDFReceipt.label}</td>
-        <td>{$form.doNotAttachPDFReceipt.html}<br />
-          <p class="description">{ts}If enabled, CiviCRM sends PDF receipt as an attachment during event signup or online contribution.{/ts}</p>
-        </td>
-      </tr>
-      <tr class="crm-miscellaneous-form-block-recordGeneratedLetters">
-        <td class="label">{$form.recordGeneratedLetters.label}</td>
-        <td>{$form.recordGeneratedLetters.html}<br />
-          <p class="description">{ts}When generating a letter (PDF/Word) via mail-merge, how should the letter be recorded?{/ts}</p>
-        </td>
-      </tr>
-      <tr class="crm-miscellaneous-form-block-dompdf_font_dir">
-        <td class="label">{$form.dompdf_font_dir.label}</td>
-        <td>{$form.dompdf_font_dir.html}<br />
-          <p class="description">{ts}Additional folder where DOMPDF will look for fonts.{/ts}</p>
-        </td>
-      </tr>
-      <tr class="crm-miscellaneous-form-block-dompdf_chroot">
-        <td class="label">{$form.dompdf_chroot.label}</td>
-        <td>{$form.dompdf_chroot.html}<br />
-          <p class="description">{ts}Folder to restrict where DOMPDF looks when loading local images. By default it is the DOMPDF folder itself for security reasons. It will search in subfolders.{/ts}</p>
-        </td>
-      </tr>
-      <tr class="crm-miscellaneous-form-block-dompdf_enable_remote">
-        <td class="label">{$form.dompdf_enable_remote.label}</td>
-        <td>{$form.dompdf_enable_remote.html}<br />
-          <p class="description">{ts}Enable the use of remote images. By default this is enabled, but if not using remote images you may wish to turn it off for security reasons.{/ts}</p>
-        </td>
-      </tr>
       <tr class="crm-miscellaneous-form-block-weasyprint_path">
         <td class="label">{$form.weasyprint_path.label}</td>
         <td>{$form.weasyprint_path.html}<br />
@@ -86,26 +36,6 @@
           <p class="description">{ts 1="http://wkhtmltopdf.org/"}<a href="%1">wkhtmltopdf is an alternative utility for generating PDFs</a> which may provide better performance especially if you are generating a large number of PDF letters or receipts. Your system administrator will need to download and install this utility, and enter the executable path here.{/ts}</p>
         </td>
       </tr>
-      {foreach from=$pure_config_settings item=setting_name}
-        <tr class="crm-miscellaneous-form-block-{$setting_name}">
-          <td class="label">{$form.$setting_name.label}</td>
-          <td>{$form.$setting_name.html}<br />
-            <span class="description">{$setting_descriptions.$setting_name}</span>
-          </td>
-        </tr>
-      {/foreach}
-      <tr class="crm-miscellaneous-form-block-remote_profile_submissions_allowed">
-        <td class="label">{$form.remote_profile_submissions.label}</td>
-        <td>{$form.remote_profile_submissions.html}<br />
-          <p class="description">{ts}If enabled, CiviCRM will allow users to submit profiles from external sites. This is disabled by default to limit abuse.{/ts}</p>
-        </td>
-      </tr>
-      <tr class="crm-miscellaneous-form-block-allow_alert_autodismissal">
-        <td class="label">{$form.allow_alert_autodismissal.label}</td>
-        <td>{$form.allow_alert_autodismissal.html}<br />
-          <p class="description">{ts}If disabled, CiviCRM will not automatically dismiss any alerts after 10 seconds.{/ts}</p>
-        </td>
-      </tr>
-    </table>
-  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+      {include file="CRM/Admin/Form/Setting/SettingForm.tpl"}
+     </table>
 </div>


### PR DESCRIPTION


Overview
----------------------------------------
Update Miscellaneous admin form to mostly use settings

I left the last 3 as is cos a bit more work needs to be done & I am already 50% past the scope of the change I intended to include in this 'go at it'

Before
----------------------------------------
- form uses legacy methods
- not possible to inject / alter what shows on the form using settings metadata hooks

After
----------------------------------------
Form is mostly the same but the normal metadata methods can be used to alter it.

Note there is some re-ordering because the settings I didn't touch bubbled to the top. Also I didn't think the order was so well thought out it needed preserving. Easy to alter it again now anyway - metadata is your friend - but Dave is also your friend.


![image](https://github.com/user-attachments/assets/a2bd962d-fe0c-4220-a67d-e71bc3ca1822)
![image](https://github.com/user-attachments/assets/db31b8f8-8bb8-46a8-9423-7a07e062ab54)

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
