### PR TITLE
Afform - Provide default page_route for every form

### DIFF
--- a/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
@@ -25,6 +25,7 @@
     this.afforms = _.transform(afforms, function(afforms, afform) {
       afform.type = afform.type || 'system';
       afform.placement = afform['placement:label'];
+      afform.server_route = afform.server_route || 'civicrm/afform/view/' + afform.name;
       if (afform.submission_date) {
         afform.submission_date = CRM.utils.formatDate(afform.submission_date);
       }

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -588,6 +588,8 @@
       this.getLink = function() {
         if (editor.afform.server_route) {
           return CRM.url(editor.afform.server_route, null, editor.afform.is_public ? 'front' : 'back');
+        } else if (editor.afform.name) {
+          return CRM.url('civicrm/afform/view/' + editor.afform.name);
         }
       };
 

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditorCanvas.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditorCanvas.html
@@ -11,7 +11,7 @@
       </button>
     </div>
     <div class="form-inline pull-right">
-      <div class="form-group" ng-if="editor.isSaved() && !saving && editor.afform.server_route">
+      <div class="form-group" ng-if="editor.isSaved() && !saving && editor.afform.name">
         <a target="_blank" ng-href="{{ editor.getLink() }}">
           <i class="crm-i fa-external-link"></i>
           {{:: ts('View Page') }}

--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -43,8 +43,8 @@
       <label for="af_config_form_server_route">
         {{:: ts('Page Route') }}
       </label>
-      <input ng-model="editor.afform.server_route" name="server_route" class="form-control" id="af_config_form_server_route" pattern="^civicrm\/[\-0-9a-zA-Z\/_]+$" onfocus="this.value = this.value || 'civicrm/'" onblur="if (this.value === 'civicrm/') this.value = ''" title="{{:: ts('Path must begin with &quot;civicrm/&quot;') }}" placeholder="{{:: ts('None') }}" ng-model-options="editor.debounceMode">
-      <p class="help-block">{{:: ts('Expose the form as a standalone webpage. (Example: "civicrm/my-form")') }}</p>
+      <input ng-model="editor.afform.server_route" name="server_route" class="form-control" id="af_config_form_server_route" pattern="^civicrm\/[\-0-9a-zA-Z\/_]+$" onfocus="this.value = this.value || 'civicrm/'" onblur="if (this.value === 'civicrm/') this.value = ''" title="{{:: ts('Path must begin with &quot;civicrm/&quot;') }}" placeholder="civicrm/afform/view/{{ editor.afform.name || '' }}" ng-model-options="editor.debounceMode">
+      <p class="help-block">{{:: ts('Customize the form URL (must begin with "civicrm/"). (Example: "civicrm/my-form")') }}</p>
     </div>
 
     <div class="form-group" ng-if="!!editor.afform.server_route">
@@ -56,8 +56,8 @@
 
     <div class="form-group">
       <div class="form-inline">
-        <label ng-class="{disabled: !editor.afform.server_route}">
-          <input type="checkbox" ng-checked="editor.afform.server_route && editor.afform.navigation" ng-disabled="!editor.afform.server_route" ng-click="editor.toggleNavigation()">
+        <label>
+          <input type="checkbox" ng-checked="editor.afform.navigation" ng-click="editor.toggleNavigation()">
           {{:: ts('Add to Navigation Menu') }}
         </label>
         <div class="form-group" ng-if="editor.afform.navigation">
@@ -73,7 +73,6 @@
           <input class="form-control" id="afform-admin-navigation-weight" type="number" placeholder="{{:: ts('Order') }}" min="0" step="1" ng-model="editor.afform.navigation.weight" required>
         </div>
       </div>
-      <p class="help-block disabled" ng-if="!editor.afform.server_route">{{:: ts('Requires a page route') }}</p>
     </div>
 
     <div class="form-group" ng-show="!!editor.afform.navigation || editor.isContactSummary()">

--- a/ext/afform/core/CRM/Afform/Page/AfformBase.php
+++ b/ext/afform/core/CRM/Afform/Page/AfformBase.php
@@ -9,11 +9,16 @@ class CRM_Afform_Page_AfformBase extends CRM_Core_Page {
     // To avoid php complaints about the number of args passed to this function vs the base function
     [$pagePath, $pageArgs] = func_get_args();
 
-    // The api will throw an exception if afform is not found (because of the index 0 param)
+    $formName = $pageArgs['afform'] ?? NULL;
+    if (!$formName && $this->urlPath[0] === 'civicrm' && $this->urlPath[1] === 'afform' && $this->urlPath[2] === 'view') {
+      $formName = $this->urlPath[3];
+    }
+
+    // The api will throw an exception if afform is not found or the user does not have permission
     $afform = civicrm_api4('Afform', 'get', [
-      'where' => [['name', '=', $pageArgs['afform']]],
+      'where' => [['name', '=', $formName]],
       'select' => ['title', 'module_name', 'directive_name', 'navigation', 'server_route', 'is_public'],
-    ], 0);
+    ])->single();
 
     $this->assign('directive', $afform['directive_name']);
 

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -119,7 +119,7 @@ function afform_civicrm_managed(&$entities, $modules) {
         ],
       ];
     }
-    if (!empty($afform['navigation']) && !empty($afform['server_route'])) {
+    if (!empty($afform['navigation'])) {
       $params = [
         'version' => 4,
         'values' => [
@@ -128,7 +128,7 @@ function afform_civicrm_managed(&$entities, $modules) {
           'permission' => (array) (empty($afform['permission']) ? 'access CiviCRM' : $afform['permission']),
           'permission_operator' => $afform['permission_operator'] ?? 'AND',
           'weight' => $afform['navigation']['weight'] ?? 0,
-          'url' => $afform['server_route'],
+          'url' => !empty($afform['server_route']) ? $afform['server_route'] : "civicrm/afform/view/{$afform['name']}",
           'icon' => !empty($afform['icon']) ? 'crm-i ' . $afform['icon'] : '',
         ],
         'match' => ['domain_id', 'name'],

--- a/ext/afform/core/xml/Menu/afform.xml
+++ b/ext/afform/core/xml/Menu/afform.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <menu>
   <item>
+    <path>civicrm/afform/view</path>
+    <page_callback>CRM_Afform_Page_AfformBase</page_callback>
+    <access_callback>1</access_callback>
+  </item>
+  <item>
     <title>Form Submission</title>
     <path>civicrm/afform/submission/verify</path>
     <page_callback>CRM_Afform_Page_Verify</page_callback>


### PR DESCRIPTION
Overview
----------------------------------------
Ensures every afform is accessible via page route. This allows any afform to be used in a link or popup dialog without requiring the user to configure a route.

Before
----------------------------------------
Previously if a form did not have a page route it was inaccessible from any URL.

After
----------------------------------------
Now a default url exists for every form: `civicrm/afform/view/{afformName}`. This is similar to the way Drupal nodes all have a default url of `node/{nid}`.

FormBuilder UI updated to show that a custom route is optional, and a form can still be viewed in a page or popup or added to the navigation menu. If blank, the placeholder shows the default route:

![image](https://github.com/user-attachments/assets/305eba41-1f40-4865-88ba-400e25f1253c)
