### PR TITLE
Fix position of closing icon tags

### DIFF
--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -214,19 +214,19 @@
           <p>
             {{:: ts('To enable REST authentication, the AuthX extension must be installed.') }}
             <a target="_blank" ng-href="{{ crmUrl('civicrm/admin/extensions') }}">
-              <i class="crm-i fa-gear"> {{:: ts('Manage Extensions') }}</i>
+              <i class="crm-i fa-gear"></i> {{:: ts('Manage Extensions') }}
             </a>
           </p>
         </div>
         <div class="alert alert-warning" ng-if="selectedTab.code === 'rest' && $ctrl.authxEnabled">
           <p>
             <a target="_blank" ng-href="{{ crmUrl('civicrm/admin/setting/authx', {reset: 1}) }}">
-              <i class="crm-i fa-gear"> {{:: ts('Configure REST Authentication') }}</i>
+              <i class="crm-i fa-gear"></i> {{:: ts('Configure REST Authentication') }}
             </a>
           </p>
           <p>
             <a target="_blank" href="https://docs.civicrm.org/dev/en/latest/api/v4/rest/">
-              <i class="crm-i fa-external-link"> {{:: ts('REST Documentation') }}</i>
+              <i class="crm-i fa-external-link"></i> {{:: ts('REST Documentation') }}
             </a>
           </p>
         </div>

--- a/ext/message_admin/ang/crmMsgadm/EditContent.html
+++ b/ext/message_admin/ang/crmMsgadm/EditContent.html
@@ -38,7 +38,7 @@
           {{::ts('Show diff')}}
         </button>
         <button type="button" class="btn btn-primary" title="{{::ts('Open preview')}}" ng-click="$ctrl.openPreview({formatName: 'msg_html'})">
-          <i class="crm-i fa-eye"> {{::ts('Open preview')}}</i>
+          <i class="crm-i fa-eye"></i> {{::ts('Open preview')}}
         </button>
         <button type="button" class="btn btn-secondary" title="{{::ts('Open large editor')}}" ng-click="$ctrl.openFull(ts('HTML Content'), 'msg_html', {language: 'html'})">
           <i class="crm-i fa-expand"></i>


### PR DESCRIPTION
Overview
----------------------------------------
Fix position of closing icon tags

Before
-------------
In a strange way I kinda like it, but I don't think "Open Preview" is meant to look like this 😛

<img width="613" alt="Screenshot 2025-01-20 at 20 44 55" src="https://github.com/user-attachments/assets/6450a868-5786-4bce-be0e-d2950e0ffff2" />
 
(this is when editing a system message template, using https://smaster.demo.civicrm.org with Riverlea/Hackney Brook).

After
----------------------------------------
The icon is now correctly closed imediately, without wrapping the text.

The API explorer visually looked ok with the bad markup, but makes sense for it to be consistent with the use of `<i>` everywhere else too.
