### PR TITLE
Afform - Fully deprecate `contact_id` and remove AfformBlock.tpl

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
@@ -8,7 +8,7 @@
           <button type="button" ng-switch="filter.mode" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <span ng-switch-when="routeParams">{{:: ts('Url') }}</span>
             <span ng-switch-when="val">{{:: ts('Value') }}</span>
-            <span ng-switch-when="options">{{:: ts('Current Contact') }}</span>
+            <span ng-switch-when="options">{{:: ts('Contact being Viewed') }}</span>
             <span class="caret"></span>
           </button>
           <ul class="dropdown-menu">
@@ -19,7 +19,7 @@
               <a href ng-click="filter.mode = 'val'; filter.value = ''">{{:: ts('Fixed value') }}</a>
             </li>
             <li ng-if="$ctrl.editor.isContactSummary()">
-              <a href ng-click="filter.mode = 'options'; filter.value = 'contact_id';">{{:: ts('Current Contact') }}</a>
+              <a href ng-click="filter.mode = 'options'; filter.value = 'entity_id';">{{:: ts('Contact being Viewed') }}</a>
             </li>
           </ul>
         </div>

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -201,9 +201,7 @@ function afform_civicrm_tabset($tabsetName, &$tabs, $context) {
       // If this is the real contact summary page (and not a callback from ContactLayoutEditor), load module
       // and assign contact id to required smarty variable
       if (empty($context['caller'])) {
-        // note we assign the contact id to entity_id as preferred key
-        // but also contact_id to maintain backwards compatibility with older
-        // afforms
+        // Preferred key is entity_id but also assign contact_id to maintain backwards compatibility with older afforms
         CRM_Core_Smarty::singleton()->assign('afformOptions', [
           'entity_id' => $context['contact_id'],
           'contact_id' => $context['contact_id'],
@@ -233,6 +231,11 @@ function afform_civicrm_pageRun(&$page) {
   $contact = NULL;
   $side = 'left';
   $weight = ['left' => 1, 'right' => 1];
+  // Preferred key is entity_id but also assign contact_id to maintain backwards compatibility with older afforms
+  $afformOptions = [
+    'entity_id' => $cid,
+    'contact_id' => $cid,
+  ];
   foreach ($afforms as $afform) {
     // If Afform specifies a contact type, lookup the contact and compare
     if (!empty($afform['summary_contact_type'])) {
@@ -248,9 +251,9 @@ function afform_civicrm_pageRun(&$page) {
     }
     $block = [
       'module' => $afform['module_name'],
-      'directive' => _afform_angular_module_name($afform['name'], 'dash'),
+      'directive' => $afform['directive_name'],
     ];
-    $content = CRM_Core_Smarty::singleton()->fetchWith('afform/contactSummary/AfformBlock.tpl', ['contactId' => $cid, 'block' => $block]);
+    $content = CRM_Core_Smarty::singleton()->fetchWith('afform/InlineAfform.tpl', ['afformOptions' => $afformOptions, 'afform' => $block]);
     CRM_Core_Region::instance("contact-basic-info-$side")->add([
       'markup' => '<div class="crm-summary-block">' . $content . '</div>',
       'name' => 'afform:' . $afform['name'],
@@ -287,7 +290,7 @@ function afform_civicrm_contactSummaryBlocks(&$blocks) {
     $blocks["afform_{$afform['type']}"]['blocks'][$afform['name']] = [
       'title' => $afform['title'],
       'contact_type' => $contactType ?: NULL,
-      'tpl_file' => 'afform/contactSummary/AfformBlock.tpl',
+      'tpl_file' => 'afform/InlineAfform.tpl',
       'module' => $afform['module_name'],
       'directive' => $afform['directive_name'],
       'sample' => [

--- a/ext/afform/core/templates/afform/contactSummary/AfformBlock.tpl
+++ b/ext/afform/core/templates/afform/contactSummary/AfformBlock.tpl
@@ -1,5 +1,0 @@
-<crm-angular-js modules="{$block.module}">
-  <form id="bootstrap-theme">
-    <{$block.directive} options="{ldelim}contact_id: {$contactId}{rdelim}"></{$block.directive}>
-  </form>
-</crm-angular-js>

--- a/ext/afform/core/tests/phpunit/Civi/Afform/AfformContactSummaryTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/AfformContactSummaryTest.php
@@ -149,10 +149,14 @@ class AfformContactSummaryTest extends TestCase implements HeadlessInterface {
     // TODO: Be more flexible
     // The presence of any other afform blocks in the system might alter the left-right assumptions here
     $blockA = \CRM_Core_Region::instance('contact-basic-info-left')->get('afform:' . $this->formNames[2]);
-    $this->assertStringContainsString("<af-search-tab-test2 options=\"{contact_id: $cid}\"></af-search-tab-test2>", $blockA['markup']);
+    $this->assertStringContainsString("<af-search-tab-test2 options=", $blockA['markup']);
+    $this->assertStringContainsString("\"contact_id\":$cid", $blockA['markup']);
+    $this->assertStringContainsString("\"entity_id\":$cid", $blockA['markup']);
 
     $blockB = \CRM_Core_Region::instance('contact-basic-info-right')->get('afform:' . $this->formNames[1]);
-    $this->assertStringContainsString("<af-form-tab-test1 options=\"{contact_id: $cid}\"></af-form-tab-test1>", $blockB['markup']);
+    $this->assertStringContainsString("<af-form-tab-test1 options=", $blockB['markup']);
+    $this->assertStringContainsString("\"contact_id\":$cid", $blockB['markup']);
+    $this->assertStringContainsString("\"entity_id\":$cid", $blockB['markup']);
 
     // Block for wrong contact type should not appear
     $this->assertNull(\CRM_Core_Region::instance('contact-basic-info-left')->get('afform:' . $this->formNames[0]));


### PR DESCRIPTION
Overview
----------------------------------------
Refactors Afform contact summary code for consistency.

Technical Details
----------------------------------------
This completes work started in 2e4ce31e4d74de093a769f34602da1dcc59c96df by switching FormBuilder over to use 'entity_id' instead of 'contact_id', and removing the AfformBlock.tpl which was made redundant by the new InlineAfform.tpl.
@ufundo 
