### PR TITLE
Afform - Add to contact summary actions menu

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3076,9 +3076,9 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
         if (in_array($values['ref'], ['view-contact', 'edit-contact'])) {
           $contextMenu['primaryActions'][$key] = [
             'title' => $values['title'],
-            'ref' => $values['ref'],
+            'ref' => $values['ref'] ?? $key,
             'class' => $values['class'] ?? NULL,
-            'key' => $values['key'],
+            'key' => $values['key'] ?? $key,
             'weight' => $values['weight'],
           ];
           continue;
@@ -3092,11 +3092,11 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
         }
         $contextMenu['moreActions'][$values['weight']] = [
           'title' => $values['title'],
-          'ref' => $values['ref'],
+          'ref' => $values['ref'] ?? $key,
           'href' => $values['href'] ?? NULL,
           'tab' => $values['tab'] ?? NULL,
           'class' => $values['class'] ?? NULL,
-          'key' => $values['key'],
+          'key' => $values['key'] ?? $key,
           'weight' => $values['weight'],
         ];
       }
@@ -3115,12 +3115,12 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
           }
           $contextMenu['otherActions'][$value['weight']] = [
             'title' => $value['title'],
-            'ref' => $value['ref'],
+            'ref' => $value['ref'] ?? $key,
             'href' => $value['href'] ?? NULL,
             'tab' => $value['tab'] ?? NULL,
             'class' => $value['class'] ?? NULL,
             'icon' => $value['icon'] ?? NULL,
-            'key' => $value['key'],
+            'key' => $value['key'] ?? $key,
             'weight' => $value['weight'],
           ];
         }

--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -1436,7 +1436,7 @@ class CRM_Utils_Array {
       if (!empty($option['children'])) {
         $option['children'] = self::formatForSelect2($option['children'], $label, $id);
       }
-      $option = array_intersect_key($option, array_flip(['id', 'text', 'children', 'color', 'icon', 'description']));
+      $option = array_intersect_key($option, array_flip(['id', 'text', 'children', 'color', 'icon', 'description', 'grouping']));
     }
     return $options;
   }

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -14,7 +14,7 @@ class AfformAdminMeta {
    */
   public static function getAdminSettings() {
     $afformPlacement = \CRM_Utils_Array::formatForSelect2((array) \Civi\Api4\OptionValue::get(FALSE)
-      ->addSelect('value', 'label', 'icon', 'description')
+      ->addSelect('value', 'label', 'icon', 'description', 'grouping')
       ->addWhere('is_active', '=', TRUE)
       ->addWhere('option_group_id:name', '=', 'afform_placement')
       ->addOrderBy('weight')

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -358,6 +358,17 @@
         }
       };
 
+      this.placementRequiresServerRoute = function() {
+        let requiresServerRoute = false;
+        editor.afform.placement.forEach(function(placement) {
+          const item = editor.meta.afform_placement.find(item => item.id === placement);
+          if (item && item.grouping === 'server_route') {
+            requiresServerRoute = item.text;
+          }
+        });
+        return requiresServerRoute;
+      };
+
       // Gets complete field defn, merging values from the field with default values
       function fillFieldDefn(entityType, field) {
         var spec = _.cloneDeep(afGui.getField(entityType, field.name));

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -338,8 +338,9 @@
         return filter ? _.filter($scope.entities, filter) : _.toArray($scope.entities);
       };
 
+      // Does afform placement include the contact summary?
       this.isContactSummary = function() {
-        return editor.afform.placement.includes('contact_summary_block') || editor.afform.placement.includes('contact_summary_tab');
+        return editor.afform.placement.some((item) => item.startsWith('contact_summary_'));
       };
 
       this.onChangePlacement = function() {

--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -91,7 +91,7 @@
       <p class="help-block">{{:: ts('Additional contexts in which the form can be embedded') }}</p>
     </div>
 
-    <div class="form-group" ng-if="editor.afform.placement.includes('contact_summary_block') || editor.afform.placement.includes('contact_summary_tab')">
+    <div class="form-group" ng-if="editor.isContactSummary()">
       <div class="form-inline">
         <label for="afform_summary_contact_type">{{:: ts('For') }}</label>
         <input class="form-control" crm-autocomplete="'ContactType'" id="afform_summary_contact_type" ng-model="editor.afform.summary_contact_type" auto-open="true" multi="true" crm-autocomplete-params="{key: 'name'}" placeholder="{{:: ts('Any contact type') }}">

--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -43,7 +43,7 @@
       <label for="af_config_form_server_route">
         {{:: ts('Page Route') }}
       </label>
-      <input ng-model="editor.afform.server_route" name="server_route" class="form-control" id="af_config_form_server_route" pattern="^civicrm\/[\-0-9a-zA-Z\/_]+$" onfocus="this.value = this.value || 'civicrm/'" onblur="if (this.value === 'civicrm/') this.value = ''" title="{{:: ts('Path must begin with &quot;civicrm/&quot;') }}" placeholder="{{:: ts('None') }}" ng-model-options="editor.debounceMode">
+      <input ng-model="editor.afform.server_route" name="server_route" class="form-control" id="af_config_form_server_route" pattern="^civicrm\/[\-0-9a-zA-Z\/_]+$" onfocus="this.value = this.value || 'civicrm/'" onblur="if (this.value === 'civicrm/') this.value = ''" title="{{:: ts('Path must begin with &quot;civicrm/&quot;') }}" placeholder="{{:: ts('None') }}" ng-model-options="editor.debounceMode" ng-required="!!editor.placementRequiresServerRoute()">
       <p class="help-block">{{:: ts('Expose the form as a standalone webpage. (Example: "civicrm/my-form")') }}</p>
     </div>
 
@@ -88,7 +88,12 @@
         {{:: ts('Expose To') }}
       </label>
       <input ng-list crm-ui-select="{multiple: true, data: editor.meta.afform_placement, placeholder: ts('None')}" class="form-control" id="afform_placement" ng-model="editor.afform.placement" ng-change="editor.onChangePlacement()">
-      <p class="help-block">{{:: ts('Additional contexts in which the form can be embedded') }}</p>
+      <p class="help-block" ng-if="editor.afform.server_route || !editor.placementRequiresServerRoute()">
+        {{:: ts('Additional contexts in which the form can be embedded') }}
+      </p>
+      <p class="text-warning" ng-if="!editor.afform.server_route && editor.placementRequiresServerRoute()">
+        <i class="crm-i fa-exclamation-triangle"></i>{{ ts('%1 placement requires a page route.', {1: editor.placementRequiresServerRoute()}) }}
+      </p>
     </div>
 
     <div class="form-group" ng-if="editor.isContactSummary()">

--- a/ext/afform/core/managed/AfformPlacement.mgd.php
+++ b/ext/afform/core/managed/AfformPlacement.mgd.php
@@ -87,6 +87,26 @@ return [
     ],
   ],
   [
+    'name' => 'AfformPlacement:contact_summary_actions',
+    'entity' => 'OptionValue',
+    'cleanup' => 'always',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'option_group_id.name' => 'afform_placement',
+        'name' => 'contact_summary_actions',
+        'value' => 'contact_summary_actions',
+        'label' => E::ts('Contact Summary Actions'),
+        'is_reserved' => TRUE,
+        'is_active' => TRUE,
+        'icon' => 'fa-bars',
+        'description' => E::ts('Add to the contact summary actions menu.'),
+      ],
+      'match' => ['option_group_id', 'name'],
+    ],
+  ],
+  [
     'name' => 'AfformPlacement:msg_token_single',
     'entity' => 'OptionValue',
     'cleanup' => 'always',

--- a/ext/afform/core/managed/AfformPlacement.mgd.php
+++ b/ext/afform/core/managed/AfformPlacement.mgd.php
@@ -101,6 +101,8 @@ return [
         'is_reserved' => TRUE,
         'is_active' => TRUE,
         'icon' => 'fa-bars',
+        // Indicates that a server_route is required for this placement
+        'grouping' => 'server_route',
         'description' => E::ts('Add to the contact summary actions menu.'),
       ],
       'match' => ['option_group_id', 'name'],


### PR DESCRIPTION
Overview
----------------------------------------
Adds a no-code way to add a form to the "Actions" menu on the contact summary screen.

<img width="707" alt="Screenshot 2025-01-20 at 5 02 20 PM" src="https://github.com/user-attachments/assets/71e75e84-84e8-4ac2-a17d-51d63ebada3b" />


Set it with the Expose To menu.

<img width="667" alt="Screenshot 2025-01-20 at 4 59 59 PM" src="https://github.com/user-attachments/assets/b95466c5-4433-41d4-bd09-cf96ec94ff98" />



Includes a new "Autofill" option which supports all 3 contact summary screen placements (Tab, Block, and Actions Menu) to autofill the form with the contact being viewed.

<img width="667" alt="Screenshot 2025-01-20 at 4 58 36 PM" src="https://github.com/user-attachments/assets/7ec030f6-dd5d-4272-9f2d-1ca49a0cb001" />
