### PR TITLE
Display custom fields on Price Field Values

### DIFF
--- a/templates/CRM/Price/Form/Option.tpl
+++ b/templates/CRM/Price/Form/Option.tpl
@@ -96,6 +96,8 @@
       </tr>
     </table>
 
+    {include file="CRM/common/customDataBlock.tpl" customDataType='PriceFieldValue' cid=''}
+
   {literal}
     <script type="text/javascript">
 
@@ -108,8 +110,8 @@
 
         }, 'json');
       }
-      {/literal}
     </script>
+  {/literal}
   {/if}
 
 


### PR DESCRIPTION
Overview
----------------------------------------
Show Custom Fields on Price Field Values on the Edit Price Option page

Before
----------------------------------------
Price Field Value custom fields are not shown.

After
----------------------------------------
Price Field Value custom fields are shown on the Edit Price Option page.

Technical Details
----------------------------------------
Follows a similar pattern to https://github.com/civicrm/civicrm-core/pull/31487

Comments
----------------------------------------
This PR does not enable custom fields on Price Field Values since those are unlikely to be commonly needed.  Extensions wanting to enable this can do so by editing the option group 'cg_extend_objects' similar to [this](https://github.com/civicrm/civicrm-core/pull/31487/files#diff-90fdc55fac19a3138ca5608c14172dda26fc83eee09bb4289be0009ce713edcd) or using API Explorer as below:

To test this:
- enable Custom Fields on PriceFieldValues - can do this via API Explorer4:
    - entity: OptionValue
    - action: create
    - values:  label: "Price Field Value", value: "PriceFieldValue", name: "price_field_value"
 - create Custom Field Group "used for" "Price Field Value"
 - add some custom fields
 - go to Manage Price Sets and create a new Price Set, doesn't matter what it is used for
 - create a Price Field with a type that uses options (ie Select, Radio or CheckBox)
 - add some option values
 - click 'Edit Price Options'
 - for an option, click 'Edit Option'
 - your custom fields should be shown ... !!
 - make changes, save, reopen to confirm changes have been saved
 - try adding a new option - your custom fields should be shown and saved
 
These custom fields are not shown elsewhere - they are intended for use by extensions.