### PR TITLE
(NFC) mixin/polyfill.php - Tweak boolean notation

### DIFF
--- a/mixin/polyfill.php
+++ b/mixin/polyfill.php
@@ -74,7 +74,7 @@ return function ($longName, $shortName, $basePath) {
       }
       else {
         $data = $callback();
-        file_put_contents($file, '<' . "?php\nreturn " . var_export($data, 1) . ';');
+        file_put_contents($file, '<' . "?php\nreturn " . var_export($data, TRUE) . ';');
         return $data;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------

Fix a linter warning per https://github.com/totten/civix/issues/334 (@jofranz)

Comments
----------------------------------------

I've never seen a warning about this in PHP-runtime or in `civicrm/coder`. But `var_export(...)` is hinted with `bool`, and maybe other linters care. I have no objection to a few extra characters here...