### PR TITLE
Provide additional information to Mail class (original values)

### DIFF
--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -195,7 +195,9 @@ class CRM_Utils_Mail {
       'html' => $params['html'] ?? NULL,
       'text' => $params['text'] ?? NULL,
       'attachments' => $params['attachments'] ?? [],
-      'bcc' => isset($headers['Bcc']) ? (array) $headers['Bcc'] : [],
+      // bcc comes in as a comma-separated string of email addresses in $params['bcc'] and is copied to $headers['Bcc']
+      // Eg. testbcc@test.com,testanotherbcc@test.com
+      'bcc' => $headers['Bcc'] ?? NULL,
     ];
     if (!$isPhpMail) {
       // get emails from headers, since these are

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -268,6 +268,9 @@ class CRM_Utils_Mail {
         'html' => $params['html'] ?? NULL,
         'text' => $params['text'] ?? NULL,
         'attachments' => $params['attachments'] ?? [],
+        // bcc comes in as a comma-separated string of email addresses in $params['bcc'] and is copied to $headers['Bcc']
+        // Eg. testbcc@test.com,testanotherbcc@test.com
+        'bcc' => $headers['Bcc'] ?? NULL,
       ];
       $mailer->send($to, $headers, $message, $originalValues);
 


### PR DESCRIPTION
Overview
----------------------------------------
I'm working through replacing the mail library in an extension - https://github.com/eileenmcnaughton/symfony_mailer - although I think I'd like to see it changed in core - at the moment its hard to do that because our code interprets the html into `body` before it gets to the library - which wants to do it itself

We do have VARIOUS hooks = but so far changing it out in `hook_civicrm_alterMailer` seems to intervene in the most places / most reliably & other extensions seem to use it



Before
----------------------------------------
It is possible to entirely swap out the REALLY OLD Pear mail libraries - but if you do so the library does not receive adequate information about the bcc or the attachments

After
----------------------------------------
These extra parameters are passed

Technical Details
----------------------------------------
I think we should consider migrating to symfony_mailer in core given it seems to be winning the mailer adoption battle and move the old mail classes to an extension. But out of scope here

Comments
----------------------------------------
