### PR TITLE
Form Builder - Assign a default route to new "Submission Forms" and "Search Forms"

### DIFF
--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -49,6 +49,7 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
           $info['definition'] = $this->definition + [
             'title' => '',
             'permission' => ['access CiviCRM'],
+            'server_route' => $this->createDefaultRoute('form'),
             'layout' => [
               [
                 '#tag' => 'af-form',
@@ -71,6 +72,7 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
           $info['definition'] = $this->definition + [
             'title' => '',
             'permission' => ['access CiviCRM'],
+            'server_route' => $this->createDefaultRoute('search'),
             'layout' => [
               [
                 '#tag' => 'div',
@@ -262,6 +264,19 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
         ->execute();
       $info['blocks'] = array_merge(array_values($info['blocks']), (array) $blockInfo);
     }
+  }
+
+  /**
+   * @param string $type
+   *   Ex: 'form' or 'search'
+   * @return string
+   *   Ex: 'civicrm/form/abcd-1234-abcd'
+   */
+  private function createDefaultRoute(string $type): string {
+    $randChars = fn() => \CRM_Utils_String::createRandom(4, 'abcdefghijklmnopqrstuvwxyz1234567890');
+    $id = implode('-', [$randChars(), $randChars(), $randChars()]);
+    $buckets = ['form' => 'civicrm/form/', 'search' => 'civicrm/search/'];
+    return ($buckets[$type] ?? $buckets['form']) . $id;
   }
 
   /**

--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -33,6 +33,15 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
    */
   protected $skipEntities = [];
 
+  /**
+   * Set TRUE if creating a clone.
+   *
+   * Some properties (such as `name`, `title`, `server_route`) may be filtered.
+   *
+   * @var bool
+   */
+  protected $clone = FALSE;
+
   public function _run(\Civi\Api4\Generic\Result $result) {
     $info = ['entities' => [], 'fields' => [], 'blocks' => []];
     $entities = [];
@@ -219,6 +228,17 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
       }
     }
     $info['blocks'] = array_values($info['blocks']);
+
+    if ($this->clone) {
+      unset($info['definition']['name']);
+      $info['definition']['title'] .= ' ' . ts('(copy)');
+      if (!empty($info['definition']['server_route'])) {
+        $info['definition']['server_route'] = $this->createDefaultRoute($info['definition']['type']);
+      }
+      if (!empty($info['definition']['navigation']['label'])) {
+        $info['definition']['navigation']['label'] .= ' ' . ts('(copy)');
+      }
+    }
 
     $result[] = $info;
   }

--- a/ext/afform/admin/ang/afAdmin.js
+++ b/ext/afform/admin/ang/afAdmin.js
@@ -48,6 +48,7 @@
           // Load data for gui editor
           data: function($route, crmApi4) {
             return crmApi4('Afform', 'loadAdminData', {
+              clone: true,
               definition: {name: $route.current.params.name}
             }, 0);
           }

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -95,12 +95,6 @@
         if (!editor.afform) {
           alert('Error: unknown form');
         }
-        if (editor.mode === 'clone') {
-          delete editor.afform.name;
-          delete editor.afform.server_route;
-          delete editor.afform.navigation;
-          editor.afform.title += ' ' + ts('(copy)');
-        }
         editor.afform.icon = editor.afform.icon || 'fa-list-alt';
         editor.afform.placement = editor.afform.placement || [];
         $scope.canvasTab = 'layout';


### PR DESCRIPTION
Overview
----------------------------------------

Compare with #31834.

Before
----------------------------------------

* When you make a "New Submission Form" or "New Search Form" (or "Clone" an existing one), the form starts out unpublished. You can edit the new form, but you cannot view it. (It has no URL.) You have to take steps to make-up a URL.

After
----------------------------------------

* When you make a "New Submission Form" or "New Search Form" (or "Clone" an existing one), it starts out with a real URL. Specifically:

    | Type | URL |
    | -- | -- |
    | "Submission Form" |`civicrm/form/XXXX-XXXX-XXXX` |
    | "Search Form" | `civicrm/search/XXXX-XXXX-XXXX` |

    The value is random but completely editable.

Comments
----------------------------------------

* When you first make a new screen, you may be going back/forth in your own mind about what the screen should do. In effect, you are _drafting_ the document. As a draft, you don't want random people to guess+access. But you do want it to be sufficiently *live* that you can use it (and maybe share with a colleague). The random ID is a very simple way to make it *live* without making it *de facto public*.

* This patch does not affect "Field Block" forms. For that scenario, you still start out unpublished. And unpublished items are not web-addressable.
* This patch doesn't require any changes to data-model or routing mechanics.
