### PR TITLE
dev/core#5693 Afform - Fix missing labels in conditional popup

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiConditionalDialog.ctrl.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiConditionalDialog.ctrl.js
@@ -40,7 +40,7 @@
             if (field) {
               var key = entity.name + "[0][fields][" + field.name + "]";
               ctrl.fieldDefns[key] = field;
-              items.push({id: key, text: field.label});
+              items.push({id: key, text: field.label || field.input_attrs.label});
             }
           });
         _.each(entityFields.joins, function(join) {
@@ -49,7 +49,7 @@
             children: _.transform(join.fields, function(items, field) {
               var key = entity.name + "[0][joins][" + join.entity + "][0][" + field.name + "]";
               ctrl.fieldDefns[key] = field;
-              items.push({id: key, text: field.label});
+              items.push({id: key, text: field.label || field.input_attrs.label});
             })
           });
         });


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5693](https://lab.civicrm.org/dev/core/-/issues/5693)

Before
----------------------------------------
Fields with their labels disabled would be listed as "false" in the conditional popup.

After
----------------------------------------
Labels shown correctly.