### PR TITLE
standaloneusers - fix send password reset action on Administer Users

### DIFF
--- a/ext/standaloneusers/managed/SavedSearch_Administer_UserAccounts.mgd.php
+++ b/ext/standaloneusers/managed/SavedSearch_Administer_UserAccounts.mgd.php
@@ -200,6 +200,7 @@ return [
             'disable',
             'download',
             'enable',
+            'send_password_reset',
           ],
           'classes' => [
             'table',


### PR DESCRIPTION
Overview
----------------------------------------
Fix action for admins to send user password reset from Administer Users screen.

Before
----------------------------------------
- There is a search kit action to Send Password Reset on Administer Users screen `/civicrm/admin/users`
- But when you click it nothing happens (and there's a console error)
- The button is added but the action is not in the allow list for the search for some reason

After
----------------------------------------
- Action is in the allow-list
- Button works as intended

Technical Details
----------------------------------------
Not sure how this was missed from the original PR to add this feature. I guess maybe an issue exporting the managed record :facepalm: 

Comments
----------------------------------------
Not technically a regression as this feature was new in 5.81. But it's broken without it so would be good to include in a point release if scheduled.
