### PR TITLE
Fix Standalone Login Events

### DIFF
--- a/ext/standaloneusers/Civi/Api4/Action/User/Login.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/Login.php
@@ -77,7 +77,7 @@ class Login extends AbstractAction {
 
       $mfa = new $mfaClass($pending['userID']);
       $okToLogin = $mfa->processMFAAttempt($pending, $this->mfaData);
-      $event = new LoginEvent($pending['userID'], 'post_mfa', $okToLogin ? NULL : 'wrongMFA');
+      $event = new LoginEvent('post_mfa', $pending['userID'], $okToLogin ? NULL : 'wrongMFA');
       Civi::dispatcher()->dispatch('civi.standalone.login', $event);
       if ($okToLogin) {
         // OK!
@@ -119,7 +119,7 @@ class Login extends AbstractAction {
       ->execute()->first();
 
     // Allow flood control (etc.) by extensions.
-    $event = new LoginEvent($user['id'] ?? NULL, 'pre_credentials_check');
+    $event = new LoginEvent('pre_credentials_check', $user['id'] ?? NULL);
     Civi::dispatcher()->dispatch('civi.standalone.login', $event);
     if ($event->stopReason) {
       $result['url'] = '/civicrm/login?' . $event->stopReason;
@@ -129,7 +129,7 @@ class Login extends AbstractAction {
     if (!$userID) {
       $result['publicError'] = "Invalid credentials";
       // Allow monitoring of failed attempts.
-      $event = new LoginEvent($user['id'] ?? NULL, 'post_credentials_check', 'wrongUserPassword');
+      $event = new LoginEvent('post_credentials_check', $user['id'] ?? NULL, 'wrongUserPassword');
       Civi::dispatcher()->dispatch('civi.standalone.login', $event);
       return;
     }
@@ -175,7 +175,7 @@ class Login extends AbstractAction {
 
   protected function loginUser(int $userID) {
     _authx_uf()->loginSession($userID);
-    $event = new LoginEvent($userID, 'post_login');
+    $event = new LoginEvent('login_success', $userID);
     Civi::dispatcher()->dispatch('civi.standalone.login', $event);
   }
 

--- a/ext/standaloneusers/Civi/Standalone/Event/LoginEvent.php
+++ b/ext/standaloneusers/Civi/Standalone/Event/LoginEvent.php
@@ -46,11 +46,16 @@ class LoginEvent extends GenericHookEvent {
    *   'wrongMFA' (about to reject login)' or NULL (login about to happen).
    *   Example use: identify suspicious activity?
    *
-   * - 'post_login'
+   * - 'login_success'
    *
-   *   userID is set; password and possibly MFA were correct. User is
-   *   successfully logged in. Setting stopReason would have no effect.
-   *   Example use: monitor logins.
+   *   userID is set; password was correct. MFA was correct if used.
+   *   User is successfully logged in. Setting stopReason would have
+   *   no effect. Example use: monitor logins.
+   *
+   * - 'pre_send_password_reset'
+   *
+   *   userID is set if the entered username/email matched, otherwise NULL.
+   *   Throwing an exception will (silently) prevent the email being sent.
    *
    * @var string
    */


### PR DESCRIPTION
Overview
----------------------------------------

This fixes the calling of various symfony events as part of the standalone login process. Nothing in core listens to these events yet, so should be safe.

<del>It also exposes the method to make the password reset email as public so that migrations can more easily run it. See https://lab.civicrm.org/extensions/standalonemigrate/-/merge_requests/9</del> moved to 

