### PR TITLE
Standalone password reset email template

### DIFF
--- a/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
@@ -59,23 +59,27 @@ class CRM_Standaloneusers_Upgrader extends CRM_Extension_Upgrader_Base {
     // See also: `StandaloneUsers.civi-setup.php`
   }
 
-  protected function createPasswordResetMessageTemplate() {
+  public function createPasswordResetMessageTemplate() {
 
     $baseTpl = [
       'workflow_name' => 'password_reset',
       'msg_title' => 'Password reset',
       'msg_subject' => '{ts}Password reset link for{/ts} {domain.name}',
       'msg_text' => <<<TXT
-        {ts}A password reset link was requested for this account.  If this wasn\'t you (and nobody else can access this email account) you can safely ignore this email.{/ts}
+        {ts}A password reset link was requested for this account.  If this wasn't you (and nobody else can access this email account) you can safely ignore this email.{/ts}
 
         {\$resetUrlPlaintext}
+
+        {ts}This link expires one hour after the date of this email.{/ts}
 
         {domain.name}
         TXT,
       'msg_html' => <<<HTML
-        <p>{ts}A password reset link was requested for this account.&nbsp; If this wasn\'t you (and nobody else can access this email account) you can safely ignore this email.{/ts}</p>
+        <p>{ts}A password reset link was requested for this account.&nbsp; If this wasn't you (and nobody else can access this email account) you can safely ignore this email.{/ts}</p>
 
         <p><a href="{\$resetUrlHtml}">{\$resetUrlHtml}</a></p>
+
+        <p><strong>{ts}This link expires one hour after the date of this email.{/ts}</strong></p>
 
         <p>{domain.name}</p>
         HTML,

--- a/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
@@ -70,7 +70,7 @@ class CRM_Standaloneusers_Upgrader extends CRM_Extension_Upgrader_Base {
 
         {\$resetUrlPlaintext}
 
-        {ts}This link expires one hour after the date of this email.{/ts}
+        {\$tokenTimeoutPlaintext}
 
         {domain.name}
         TXT,
@@ -79,7 +79,7 @@ class CRM_Standaloneusers_Upgrader extends CRM_Extension_Upgrader_Base {
 
         <p><a href="{\$resetUrlHtml}">{\$resetUrlHtml}</a></p>
 
-        <p><strong>{ts}This link expires one hour after the date of this email.{/ts}</strong></p>
+        <p><strong>{\$tokenTimeoutHtml}</strong></p>
 
         <p>{domain.name}</p>
         HTML,

--- a/ext/standaloneusers/CRM/Standaloneusers/WorkflowMessage/PasswordReset.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/WorkflowMessage/PasswordReset.php
@@ -1,5 +1,6 @@
 <?php
 use Civi\WorkflowMessage\GenericWorkflowMessage;
+use CRM_Standaloneusers_ExtensionUtil as E;
 
 /**
  *
@@ -7,6 +8,8 @@ use Civi\WorkflowMessage\GenericWorkflowMessage;
  * @method $this setResetUrlHtml(string $s)
  * @method $this setUsernamePlaintext(string $s)
  * @method $this setUsernameHtml(string $s)
+ * @method $this setTokenTimeoutPlaintext(string $s)
+ * @method $this setTokenTimeoutHtml(string $s)
  *
  */
 class CRM_Standaloneusers_WorkflowMessage_PasswordReset extends GenericWorkflowMessage {
@@ -50,21 +53,52 @@ class CRM_Standaloneusers_WorkflowMessage_PasswordReset extends GenericWorkflowM
   public $usernameHtml;
 
   /**
+   * Plaintext token timeout.
+   *
+   * @var string
+   *
+   * @scope tplParams
+   */
+  public $tokenTimeoutPlaintext;
+
+  /**
+   * HTML token timeout.
+   *
+   * @var string
+   *
+   * @scope tplParams
+   */
+  public $tokenTimeoutHtml;
+
+  /**
    * Load the required tplParams
    */
   public function setRequiredParams(
     string $username,
     string $email,
     int $contactId,
-    string $token
+    string $token,
+    int $tokenTimeout
     ) {
     $resetUrlPlaintext = \CRM_Utils_System::url('civicrm/login/password', ['token' => $token], TRUE, NULL, FALSE);
+
+    if ($tokenTimeout < 120) {
+      $timeout = E::ts("This link expires %1 minutes after the date of this email.", [1 => $tokenTimeout]);
+    }
+    elseif ($tokenTimeout < 60 * 48) {
+      $timeout = E::ts("This link expires %1 hours after the date of this email.", [1 => floor($tokenTimeout / 60)]);
+    }
+    else {
+      $timeout = E::ts("This link expires %1 days after the date of this email.", [1 => floor($tokenTimeout / 60 / 24)]);
+    }
 
     $this
       ->setResetUrlPlaintext($resetUrlPlaintext)
       ->setResetUrlHtml(htmlspecialchars($resetUrlPlaintext))
       ->setUsernamePlaintext($username)
       ->setUsernameHtml(htmlspecialchars($username))
+      ->setTokenTimeoutPlaintext($timeout)
+      ->setTokenTimeoutHtml(htmlspecialchars($timeout))
       ->setTo(['name' => $username, 'email' => $email])
       ->setContactID($contactId);
     return $this;

--- a/ext/standaloneusers/Civi/Api4/Action/User/SendPasswordResetEmail.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/SendPasswordResetEmail.php
@@ -40,7 +40,7 @@ class SendPasswordResetEmail extends BasicBatchAction {
     // (Re)generate token and store on User.
     $token = PasswordReset::updateToken($user['id'], $this->timeout);
 
-    $workflowMessage = self::preparePasswordResetWorkflow($user, $token);
+    $workflowMessage = self::preparePasswordResetWorkflow($user, $token, $this->timeout);
     if ($workflowMessage) {
       // The template_params are used in the template like {$resetUrlHtml} and {$resetUrlHtml} {$usernamePlaintext} {$usernameHtml}
       try {
@@ -76,7 +76,7 @@ class SendPasswordResetEmail extends BasicBatchAction {
    *
    * @return \CRM_Standaloneusers_WorkflowMessage_PasswordReset|null
    */
-  public static function preparePasswordResetWorkflow(array $user, string $token): ?CRM_Standaloneusers_WorkflowMessage_PasswordReset {
+  public static function preparePasswordResetWorkflow(array $user, string $token, int $tokenTimeout): ?CRM_Standaloneusers_WorkflowMessage_PasswordReset {
     // Find the message template
     $tplID = MessageTemplate::get(FALSE)
       ->setSelect(['id'])
@@ -100,10 +100,11 @@ class SendPasswordResetEmail extends BasicBatchAction {
     $email = $user['uf_name'];
     $contactId = $user['contact_id'];
 
-    // The template_params are used in the template like {$resetUrlHtml} and {$resetUrlHtml} {$usernamePlaintext} {$usernameHtml}
+    // The template_params are used in the template like {$resetUrlHtml} and {$resetUrlHtml}
+    // {$usernamePlaintext} {$usernameHtml} {$tokenTimeoutPlaintext} {$tokenTimeoutHtml}
     [$domainFromName, $domainFromEmail] = \CRM_Core_BAO_Domain::getNameAndEmail(TRUE);
     $workflowMessage = (new CRM_Standaloneusers_WorkflowMessage_PasswordReset())
-      ->setRequiredParams($username, $email, $contactId, $token)
+      ->setRequiredParams($username, $email, $contactId, $token, $tokenTimeout)
       ->setFrom("\"$domainFromName\" <$domainFromEmail>");
 
     return $workflowMessage;

--- a/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
@@ -226,13 +226,15 @@ class SecurityTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
 
     // Check the message template generation
     $token = PasswordReset::updateToken($userID);
-    $workflow = SendPasswordResetEmail::preparePasswordResetWorkflow($user, $token);
+    $workflow = SendPasswordResetEmail::preparePasswordResetWorkflow($user, $token, 60);
     $this->assertNotNull($workflow);
     $result = $workflow->renderTemplate();
 
     $this->assertMatchesRegularExpression(';https?://[^/]+/civicrm/login/password.*' . $token . ';', $result['text']);
     $this->assertMatchesRegularExpression(';https?://[^/]+/civicrm/login/password.*' . $token . ';', $result['html']);
     $this->assertEquals('Password reset link for Demonstrators Anonymous', $result['subject']);
+    $this->assertStringContainsString('This link expires 60 minutes after the date of this email.', $result['text']);
+    $this->assertStringContainsString('This link expires 60 minutes after the date of this email.', $result['html']);
 
     // Fake an expired token
     $token = $this->storeFakePasswordResetToken($userID, time() - 1);


### PR DESCRIPTION
- corrects grammar due to wrongly back-slashed apostrophes.
- makes the createPasswordResetMessageTemplate public, which may enable its use from elsewhere.

Further improvements for future PRs:

- use a mgd file? But avoid duplicating the content somehow?
- check for the existence before creating (like `->match('name')` except that it's more complex than that.

See related https://lab.civicrm.org/extensions/standalonemigrate/-/merge_requests/9