### PR TITLE
Online regen script needs sendmail now

### DIFF
--- a/.github/workflows/regen.yml
+++ b/.github/workflows/regen.yml
@@ -55,6 +55,10 @@ jobs:
             echo "You need to run this in your own fork."
             exit -1
           fi
+      - name: Sendmail is now needed or else drupal install gets marked as fail
+        run: |
+          sudo apt-get update
+          sudo apt-get install sendmail
       - name: Download cv
         run: |
           cd $GITHUB_WORKSPACE


### PR DESCRIPTION
Overview
----------------------------------------
This worked 2 months ago, but now for some reason the github action fails if it can't find sendmail while doing the drupal install.

Before
----------------------------------------
github action fails

After
----------------------------------------


Technical Details
----------------------------------------
Drupal tries to send an email when it does a site install. Apparently there's no way to turn this off. It's possible to set php.ini sendmail_path to /bin/true, but it seems like you don't have permission to do that in a github action. So just do a mollifying install of sendmail.

Comments
----------------------------------------
This is the same as e.g. [here](https://github.com/colemanw/webform_civicrm/blob/f95d3074f59845fc06080d50b27ef87e66649b3f/.github/workflows/main.yml#L69-L72), but there it's for other reasons.
