### PR TITLE
Add pageRun hook to `CRM_Core_Page_File`

### DIFF
--- a/CRM/Core/Page/File.php
+++ b/CRM/Core/Page/File.php
@@ -20,6 +20,8 @@ class CRM_Core_Page_File extends CRM_Core_Page {
    * Run page.
    */
   public function run() {
+    CRM_Utils_Hook::pageRun($this);
+
     $action = CRM_Utils_Request::retrieve('action', 'String', $this);
     $download = CRM_Utils_Request::retrieve('download', 'Integer', $this, FALSE, 1);
     $disposition = $download == 0 ? 'inline' : 'download';


### PR DESCRIPTION
Overview
----------------------------------------
In `CRM_Core_Page_File` the execution of [hook_civicrm_pageRun](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_pageRun/) was missing. This is changed by this PR.