### PR TITLE
Removed Unneccesary Enter Text

### DIFF
--- a/ext/standaloneusers/ang/afsearchAdministerRoles.aff.html
+++ b/ext/standaloneusers/ang/afsearchAdministerRoles.aff.html
@@ -1,4 +1,3 @@
-<p class="af-text">Enter text</p>
 <div class="af-markup">
   <div class="help">
   <p>{{:: ts('Roles define sets of permissions for different types of users. You can give users roles to grant them permissions appropriate to their needs.') }}</p>


### PR DESCRIPTION
Overview
----------------------------------------

Stand alone administer roles screen contains: Enter Text. Which does not make sense

Before
----------------------------------------

Enter Text is shown on Administer Roles. 

See attached screenshot: 
![2025-01-22_20-32](https://github.com/user-attachments/assets/a180ab49-f45a-4909-88e5-0c1160117a92)


After
----------------------------------------

Enter Text is removed
