### PR TITLE
Improve crmUiIconPicker with ngModel support for binding

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -1294,10 +1294,21 @@
     .directive('crmUiIconPicker', function($timeout) {
       return {
         restrict: 'A',
-        controller: function($element) {
+        require: '?ngModel', // Soft require ngModel
+        controller: function($element, $scope, $attrs) {
           CRM.loadScript(CRM.config.resourceBase + 'js/jquery/jquery.crmIconPicker.js').then(function() {
             $timeout(function() {
               $element.crmIconPicker();
+
+              // If ngModel is present, set up two-way binding
+              if ($attrs.ngModel) {
+                $scope.$watch($attrs.ngModel, function(newValue) {
+                  if (newValue !== undefined) {
+                    // Update the value in the picker
+                    $element.val(newValue).trigger('change');
+                  }
+                });
+              }
             });
           });
         }


### PR DESCRIPTION

Overview
----------------------------------------
Fixes a UI bug in SearchKit

Before
----------------------------------------
1. Add an icon to a column from the "Choose Icon..." popup
2. Select "Choose Icon..." again and pick a different icon
3. The icon displayed does not change

After
----------------------------------------
The displayed icon is updated properly