### PR TITLE
Make sorting of countries more consistent

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -567,12 +567,12 @@ class CRM_Utils_Array {
    * Sorts an array and maintains index association (with localization).
    *
    * @param array $array
-   *   (optional) Array to be sorted.
+   *   Array to be sorted.
    *
    * @return array
    *   Sorted array.
    */
-  public static function asort($array = []) {
+  public static function asort(array $array) {
     $lcMessages = CRM_Core_I18n::getLocale();
 
     $collator = new Collator($lcMessages . '.utf8');

--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -566,11 +566,6 @@ class CRM_Utils_Array {
   /**
    * Sorts an array and maintains index association (with localization).
    *
-   * Uses Collate from the PECL "intl" package, if available, for UTF-8
-   * sorting (e.g. list of countries). Otherwise calls PHP's asort().
-   *
-   * On Debian/Ubuntu: apt-get install php5-intl
-   *
    * @param array $array
    *   (optional) Array to be sorted.
    *
@@ -578,20 +573,10 @@ class CRM_Utils_Array {
    *   Sorted array.
    */
   public static function asort($array = []) {
-    $lcMessages = CRM_Utils_System::getUFLocale();
+    $lcMessages = CRM_Core_I18n::getLocale();
 
-    if ($lcMessages && $lcMessages != 'en_US' && class_exists('Collator')) {
-      $collator = new Collator($lcMessages . '.utf8');
-      $collator->asort($array);
-    }
-    elseif (version_compare(PHP_VERSION, '8', '<') && class_exists('Collator')) {
-      $collator = new Collator('en_US.utf8');
-      $collator->asort($array);
-    }
-    else {
-      // This calls PHP's built-in asort().
-      asort($array);
-    }
+    $collator = new Collator($lcMessages . '.utf8');
+    $collator->asort($array);
 
     return $array;
   }

--- a/tests/phpunit/CRM/Core/BAO/AddressTest.php
+++ b/tests/phpunit/CRM/Core/BAO/AddressTest.php
@@ -973,10 +973,11 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
     CRM_Core_I18n::singleton()->setLocale('nl_NL');
     $countries = \Civi::entity('Address')->getOptions('country_id');
     $this->assertEquals('AF', $countries[0]['name']);
-    $this->assertEquals('AL', $countries[1]['name']);
-    $this->assertEquals('DZ', $countries[2]['name']);
     // Åland Islands
-    $this->assertEquals('AX', array_pop($countries)['name']);
+    $this->assertEquals('AX', $countries[1]['name']);
+    $this->assertEquals('AL', $countries[2]['name']);
+    $this->assertEquals('US', $countries[237]['name']);
+    $this->assertEquals('CH', array_pop($countries)['name']);
 
     CRM_Core_I18n::singleton()->setLocale('it_IT');
     $countries = \Civi::entity('Address')->getOptions('country_id');
@@ -984,7 +985,8 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
     $this->assertEquals('AL', $countries[1]['name']);
     $this->assertEquals('DZ', $countries[2]['name']);
     // Åland Islands
-    $this->assertEquals('AX', $countries[114]['name']);
+    $this->assertEquals('AX', $countries[104]['name']);
+    $this->assertEquals('US', $countries[213]['name']);
     $this->assertEquals('ZW', array_pop($countries)['name']);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
I expect some tests to fail on the first go.

Before
----------------------------------------
Sort order depends on php version. In php 8 it looks wrong for some non-en_US, i.e. has reverted to the description in https://issues.civicrm.org/jira/browse/CRM-9531

After
----------------------------------------
Sort order depends on whatever the writers of Collator do, but at the moment seems consistent.

Technical Details
----------------------------------------
At the time the function was written, intl was not required, so there was a conditional added. Then later, to fix some test issue with php 7/8, another conditional was added. Neither of them seem needed, just we might need to adjust tests since they might be enforcing the "wrong" thing.

Also at the time the function was written, there was no getLocale(), there was only getUFLocale(), but getLocale() seems more appropriate for where this function is used (country/state/province/event location sorting).

Comments
----------------------------------------
See also https://github.com/civicrm/civicrm-core/pull/31718#discussion_r1924949524 and https://chat.civicrm.org/civicrm/pl/f17e5ki89ffouc5jkfrqncetdy
