### PR TITLE
SearchKit - Improve enable/disable responsiveness and fix bugs in hierarchical displays

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -1379,8 +1379,8 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     if ($this->savedSearch['api_entity'] === 'EntitySet') {
       return;
     }
-    // Add `depth_` column for hierarchical entity displays
-    if (!empty($this->display['settings']['hierarchical'])) {
+    // Add `depth_` column for hierarchical entity displays (but not during inline-edit)
+    if (!empty($this->display['settings']['hierarchical']) && !is_a($this, 'Civi\Api4\Action\SearchDisplay\InlineEdit')) {
       $this->addSelectExpression('_depth');
       $this->addSelectExpression('_descendents');
     }

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -928,6 +928,8 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
           }
           // Fill in the api action if known, for the sake of $this->checkLinkAccess
           $link['action'] = $task['apiBatch']['action'] ?? NULL;
+          // Used by inlineEdit action when running inline tasks
+          $link['api_params'] = $task['apiBatch']['params'] ?? [];
         }
       }
       $link['key'] = $link['prefix'] . $idKey;

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -19,6 +19,7 @@
       // Called by the controller's $onInit function
       initializeDisplay: function($scope, $element) {
         var ctrl = this;
+        this.$element = $element;
         this.limit = this.settings.limit;
         this.sort = this.settings.sort ? _.cloneDeep(this.settings.sort) : [];
         this.seed = Date.now();

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayEditableTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayEditableTrait.service.js
@@ -69,11 +69,10 @@
         // If the api returned a refreshed row, replace the current row with it
         if (result.length && rowIndex >= 0) {
           const row = this.results[rowIndex];
-          // Preserve hierarchical info which isn't returned by the refresh
-          result[0].data._descendents = row.data._descendents;
-          result[0].data._depth = row.data._depth;
-          // Note that extend() will preserve top-level items like 'collapsed' which aren't returned by the refresh
-          this.results[rowIndex] = result[0];
+          // Preserve hierarchical info like _descendents and _depth which isn't returned by the refresh
+          _.defaults(result[0].data, row.data);
+          // Note that extend() will preserve top-level items like 'collapsed' while replacing columns and data
+          angular.extend(row, result[0]);
         }
         // Or it's possible that the update caused this row to no longer match filters, in which case do a full refresh
         else {

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayEditableTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayEditableTrait.service.js
@@ -54,32 +54,36 @@
 
         crmStatus({}, crmApi4('SearchDisplay', 'inlineEdit', apiParams))
           .then(function(result) {
-            // Create mode
-            if (!row && result.length) {
-              ctrl.results.push(result[0]);
-              ctrl.rowCount++;
-            }
-            // Edit mode
-            else if (row) {
-              // If the api returned a refreshed row, replace the current row with it
-              if (result.length) {
-                // Preserve hierarchical info which isn't returned by the refresh
-                result[0].data._descendents = row.data._descendents;
-                result[0].data._depth = row.data._depth;
-                // Note that extend() will preserve top-level items like 'collapsed' which aren't returned by the refresh
-                angular.extend(row, result[0]);
-              }
-              // Or it's possible that the update caused this row to no longer match filters, in which case remove it
-              else {
-                const rowIndex = ctrl.results.findIndex(result => result.key === row.key);
-                if (rowIndex >= 0) {
-                  ctrl.results.splice(rowIndex, 1);
-                }
-                ctrl.rowCount--;
-              }
-            }
+            ctrl.refreshAfterEditing(result, row ? row.key : null);
           });
       },
+
+      refreshAfterEditing: function(result, rowKey) {
+        // Create mode
+        if (!rowKey && result.length) {
+          this.results.push(result[0]);
+          this.rowCount++;
+          return;
+        }
+        const rowIndex = this.results.findIndex(result => result.key === rowKey);
+        // If the api returned a refreshed row, replace the current row with it
+        if (result.length && rowIndex >= 0) {
+          const row = this.results[rowIndex];
+          // Preserve hierarchical info which isn't returned by the refresh
+          result[0].data._descendents = row.data._descendents;
+          result[0].data._depth = row.data._depth;
+          // Note that extend() will preserve top-level items like 'collapsed' which aren't returned by the refresh
+          this.results[rowIndex] = result[0];
+        }
+        // Or it's possible that the update caused this row to no longer match filters, in which case do a full refresh
+        else {
+          this.rowCount = null;
+          this.getResultsPronto();
+          // Trigger all other displays in the same form to update.
+          // This display won't update twice because of the debounce in getResultsPronto()
+          this.$element.trigger('crmPopupFormSuccess');
+        }
+      }
 
     };
   });

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
@@ -16,7 +16,7 @@
       </button>
     </div>
   </td>
-  <td ng-repeat="(colIndex, colData) in row.columns" ng-include=":: $ctrl.getFieldTemplate(colIndex, colData)" title="{{:: colData.title }}" class="crm-search-col-type-{{:: $ctrl.settings.columns[colIndex].type }} {{:: row.cssClass }} {{:: colData.cssClass }}" data-field-name="{{:: $ctrl.settings.columns[colIndex].key }}">
+  <td ng-repeat="(colIndex, colData) in row.columns" ng-include=":: $ctrl.getFieldTemplate(colIndex, colData)" title="{{:: colData.title }}" class="crm-search-col-type-{{:: $ctrl.settings.columns[colIndex].type }} {{:: $ctrl.getRowClass(row) }} {{:: colData.cssClass }}" data-field-name="{{:: $ctrl.settings.columns[colIndex].key }}">
   </td>
 </tr>
 <tr ng-if="$ctrl.rowCount === 0">

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
@@ -8,6 +8,8 @@
       ids: '<',
       idField: '@',
       params: '<',
+      displayCtrl: '<',
+      isLink: '<',
       success: '&',
       error: '&'
     },
@@ -41,6 +43,8 @@
       };
 
       function runBatch() {
+        let entityName = ctrl.entity;
+        let actionName = ctrl.action;
         ctrl.first = currentBatch * BATCH_SIZE;
         ctrl.last = (currentBatch + 1) * BATCH_SIZE;
         if (ctrl.last > ctrl.ids.length) {
@@ -55,12 +59,18 @@
               records.push(record);
             });
           });
+        } else if (ctrl.isLink && ctrl.action === 'update' && ctrl.ids.length === 1 && ctrl.displayCtrl) {
+          // When updating a single record from a link, use the inlineEdit action
+          entityName = 'SearchDisplay';
+          actionName = 'inlineEdit';
+          angular.extend(params, ctrl.displayCtrl.getApiParams(null));
+          params.rowKey = ctrl.ids[0];
         } else if (ctrl.action !== 'create') {
           // For other batch actions (update, delete), add supplied ids to the where clause
           params.where = params.where || [];
           params.where.push([ctrl.idField || 'id', 'IN', ctrl.ids.slice(ctrl.first, ctrl.last)]);
         }
-        crmApi4(ctrl.entity, ctrl.action, params).then(
+        crmApi4(entityName, actionName, params).then(
           function(result) {
             stopIncrementer();
             ctrl.progress = Math.floor(100 * ++currentBatch / totalBatches);

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.ctrl.js
@@ -35,8 +35,12 @@
 
     this.onSuccess = function(result) {
       var entityTitle = this.getEntityTitle(result.batchCount);
-      CRM.alert(ts(ctrl.apiBatch.successMsg, {1: result.batchCount, 2: entityTitle}), ts('%1 Complete', {1: ctrl.taskTitle}), 'success');
-      this.close();
+      if (result.action === 'inlineEdit') {
+        CRM.status(ts('Saved'));
+      } else {
+        CRM.alert(ts(ctrl.apiBatch.successMsg, {1: result.batchCount, 2: entityTitle}), ts('%1 Complete', {1: ctrl.taskTitle}), 'success');
+      }
+      this.close(result);
     };
 
     this.onError = function() {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.html
@@ -7,7 +7,7 @@
     <hr />
     <div ng-if="$ctrl.run" class="crm-search-task-progress">
       <h5>{{:: ts(model.apiBatch.runMsg, {1: model.ids.length, 2: $ctrl.entityTitle}) }}</h5>
-      <crm-search-batch-runner entity="model.entity" action="{{:: model.apiBatch.action }}" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess(result)" error="$ctrl.onError()" id-field="{{:: $ctrl.entityInfo.primary_key[0] }}"></crm-search-batch-runner>
+      <crm-search-batch-runner entity="model.entity" action="{{:: model.apiBatch.action }}" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess(result)" error="$ctrl.onError()" id-field="{{:: $ctrl.entityInfo.primary_key[0] }}" display-ctrl="$ctrl.displayCtrl" is-link="$ctrl.isLink"></crm-search-batch-runner>
     </div>
 
     <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" ></crm-dialog-button>

--- a/ext/search_kit/ang/crmSearchTasks/traits/searchTaskBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchTaskBaseTrait.service.js
@@ -24,8 +24,8 @@
         dialogService.cancel('crmSearchTask');
       },
 
-      close: function() {
-        dialogService.close('crmSearchTask');
+      close: function(result) {
+        dialogService.close('crmSearchTask', result);
       }
 
     };

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EditableSearchTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EditableSearchTest.php
@@ -393,7 +393,7 @@ class EditableSearchTest extends Api4TestBase {
     }
     catch (\CRM_Core_Exception $e) {
     }
-    $this->assertStringContainsString('Cannot edit', $e->getMessage());
+    $this->assertStringContainsString('Inline edit failed', $e->getMessage());
   }
 
   public function testEditableRelationshipCustomFields() {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes broken css in table displays, and broken inline-edit & nesting in hierarchical displays.

Also improves responsiveness of enable/disable action links by routing them through inlineEdit instead of refreshing all results.

Before
-------
- Hierarchical displays (e.g. Admin UI's *Manage Groups* page) lacked the visual nesting due to missing css classes
- In hierarchical table displays, Inline-edit of sub-rows was broken
- Clicking the "Enable" or "Disable" actions in a row would trigger a full refresh

After
------
- Visual nesting fixed
- Inline-edit fixed
- Clicking "Enable" or "Disable" actions in a row just updates that row