### PR TITLE
CustomField - Increase maxLength for Link fields to 2047 characters.

### DIFF
--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -235,22 +235,21 @@ class CRM_Core_BAO_CustomValueTable {
    * Given a field return the mysql data type associated with it.
    *
    * @param string $type
-   * @param int $maxLength
+   * @param int|null $maxLength
    *
    * @return string
    *   the mysql data store placeholder
    */
-  public static function fieldToSQLType($type, $maxLength = 255) {
-    if (!isset($maxLength) ||
-      !is_numeric($maxLength) ||
-      $maxLength <= 0
-    ) {
-      $maxLength = 255;
-    }
-
+  public static function fieldToSQLType(string $type, $maxLength = NULL) {
     switch ($type) {
       case 'String':
+        $maxLength = $maxLength ?: 255;
+        return "varchar($maxLength)";
+
       case 'Link':
+        // URLs can be up to 2047 characters
+        // according to https://www.sitemaps.org/protocol.html#locdef
+        $maxLength = $maxLength ?: 2047;
         return "varchar($maxLength)";
 
       case 'Boolean':

--- a/CRM/Core/DAO/Base.php
+++ b/CRM/Core/DAO/Base.php
@@ -136,7 +136,7 @@ abstract class CRM_Core_DAO_Base extends CRM_Core_DAO {
         $field['required'] = TRUE;
       }
       if (str_starts_with($fieldSpec['sql_type'], 'decimal(')) {
-        $precision = self::getFieldLength($fieldSpec['sql_type']);
+        $precision = CRM_Core_BAO_SchemaHandler::getFieldLength($fieldSpec['sql_type']);
         $field['precision'] = array_map('intval', explode(',', $precision));
       }
       foreach (['maxlength', 'size', 'rows', 'cols'] as $attr) {
@@ -146,7 +146,7 @@ abstract class CRM_Core_DAO_Base extends CRM_Core_DAO {
         }
       }
       if (str_contains($fieldSpec['sql_type'], 'char(')) {
-        $length = self::getFieldLength($fieldSpec['sql_type']);
+        $length = CRM_Core_BAO_SchemaHandler::getFieldLength($fieldSpec['sql_type']);
         if (!isset($field['size'])) {
           $field['size'] = constant(CRM_Utils_Schema::getDefaultSize($length));
         }
@@ -230,14 +230,6 @@ abstract class CRM_Core_DAO_Base extends CRM_Core_DAO {
       $fields[$fieldName] = $field;
     }
     return $fields;
-  }
-
-  private static function getFieldLength($sqlType): ?string {
-    $open = strpos($sqlType, '(');
-    if ($open) {
-      return substr($sqlType, $open + 1, -1);
-    }
-    return NULL;
   }
 
   /**

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -879,6 +879,10 @@ AND    option_group_id = %2";
     if ($params['data_type'] == "Memo") {
       $params['text_length'] = $params['note_length'];
     }
+    // Urls can be up to 2047 characters according to https://www.sitemaps.org/protocol.html#locdef
+    if ($params['data_type'] == 'Link') {
+      $params['text_length'] = 2047;
+    }
 
     // need the FKEY - custom group id
     $params['custom_group_id'] = $this->_gid;

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -978,7 +978,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
     $dao = CRM_Core_DAO::executeQuery(('SHOW CREATE TABLE ' . $customGroup['values'][$customGroup['id']]['table_name']));
     $dao->fetch();
     $collation = \CRM_Core_BAO_SchemaHandler::getInUseCollation();
-    $this->assertStringContainsString('`test_link_2` varchar(255) COLLATE ' . $collation . ' DEFAULT NULL', $dao->Create_Table);
+    $this->assertStringContainsString('`test_link_2` varchar(2047) COLLATE ' . $collation . ' DEFAULT NULL', $dao->Create_Table);
     $this->assertStringContainsString('KEY `index_my_text` (`my_text`)', $dao->Create_Table);
     $characterSet = stripos($collation, 'utf8mb4') !== FALSE ? 'utf8mb4' : 'utf8';
     $this->assertStringContainsString("ENGINE=InnoDB DEFAULT CHARSET={$characterSet} COLLATE={$collation}", $dao->Create_Table);

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -980,6 +980,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
     $collation = \CRM_Core_BAO_SchemaHandler::getInUseCollation();
     $this->assertStringContainsString('`test_link_2` varchar(2047) COLLATE ' . $collation . ' DEFAULT NULL', $dao->Create_Table);
     $this->assertStringContainsString('KEY `index_my_text` (`my_text`)', $dao->Create_Table);
+    $this->assertStringContainsString('KEY `index_test_link_2` (`test_link_2`(512))', $dao->Create_Table);
     $characterSet = stripos($collation, 'utf8mb4') !== FALSE ? 'utf8mb4' : 'utf8';
     $this->assertStringContainsString("ENGINE=InnoDB DEFAULT CHARSET={$characterSet} COLLATE={$collation}", $dao->Create_Table);
   }

--- a/tests/phpunit/api/v4/Custom/BasicCustomFieldTest.php
+++ b/tests/phpunit/api/v4/Custom/BasicCustomFieldTest.php
@@ -35,85 +35,87 @@ class BasicCustomFieldTest extends Api4TestBase {
   /**
    * @throws \CRM_Core_Exception
    */
-  public function testWithSingleField(): void {
+  public function testWithLinkField(): void {
     $this->createTestRecord('CustomGroup', [
       'title' => 'MyIndividualFields',
       'extends' => 'Individual',
     ]);
 
     $this->createTestRecord('CustomField', [
-      'label' => 'FavColor',
+      'label' => 'MyLink',
       'custom_group_id.name' => 'MyIndividualFields',
       'html_type' => 'Text',
-      'data_type' => 'String',
+      // Will default to 2047 characters
+      'data_type' => 'Link',
     ]);
 
     // Individual fields should show up when contact_type = null|Individual but not other contact types
     $getFields = Contact::getFields(FALSE);
-    $this->assertEquals('Custom', $getFields->execute()->indexBy('name')['MyIndividualFields.FavColor']['type']);
-    $this->assertContains('MyIndividualFields.FavColor', $getFields->setValues(['contact_type' => 'Individual'])->execute()->column('name'));
-    $this->assertNotContains('MyIndividualFields.FavColor', $getFields->setValues(['contact_type:name' => 'Household'])->execute()->column('name'));
+    $this->assertEquals('Custom', $getFields->execute()->indexBy('name')['MyIndividualFields.MyLink']['type']);
+    $this->assertContains('MyIndividualFields.MyLink', $getFields->setValues(['contact_type' => 'Individual'])->execute()->column('name'));
+    $this->assertNotContains('MyIndividualFields.MyLink', $getFields->setValues(['contact_type:name' => 'Household'])->execute()->column('name'));
 
     $contactId = $this->createTestRecord('Contact', [
       'first_name' => 'Johann',
       'last_name' => 'Tester',
       'contact_type' => 'Individual',
-      'MyIndividualFields.FavColor' => '<Red>',
+      'MyIndividualFields.MyLink' => 'http://example.com/?q=123&a=456',
     ])['id'];
 
     $contact = Contact::get(FALSE)
       ->addSelect('first_name')
-      ->addSelect('MyIndividualFields.FavColor')
+      ->addSelect('MyIndividualFields.MyLink')
       ->addWhere('id', '=', $contactId)
-      ->addWhere('MyIndividualFields.FavColor', '=', '<Red>')
+      ->addWhere('MyIndividualFields.MyLink', 'LIKE', '%q=123&a=456')
       ->execute()
       ->first();
 
-    $this->assertEquals('<Red>', $contact['MyIndividualFields.FavColor']);
+    $this->assertEquals('http://example.com/?q=123&a=456', $contact['MyIndividualFields.MyLink']);
 
+    $veryLongLink = 'http://example.com/?a=' . str_repeat('a', 500) . '&b=' . str_repeat('b', 500) . '&c=' . str_repeat('c', 500) . '&d=' . str_repeat('d', 500);
     Contact::update()
       ->addWhere('id', '=', $contactId)
-      ->addValue('MyIndividualFields.FavColor', 'Blue&Pink')
+      ->addValue('MyIndividualFields.MyLink', $veryLongLink)
       ->execute();
 
     $contact = Contact::get(FALSE)
-      ->addSelect('MyIndividualFields.FavColor')
+      ->addSelect('MyIndividualFields.MyLink')
       ->addWhere('id', '=', $contactId)
       ->execute()
       ->first();
 
-    $this->assertEquals('Blue&Pink', $contact['MyIndividualFields.FavColor']);
+    $this->assertSame($veryLongLink, $contact['MyIndividualFields.MyLink']);
 
     // Try setting to null
     Contact::update()
       ->addWhere('id', '=', $contactId)
-      ->addValue('MyIndividualFields.FavColor', NULL)
+      ->addValue('MyIndividualFields.MyLink', NULL)
       ->execute();
     $contact = Contact::get(FALSE)
-      ->addSelect('MyIndividualFields.FavColor')
+      ->addSelect('MyIndividualFields.MyLink')
       ->addWhere('id', '=', $contactId)
       ->execute()
       ->first();
-    $this->assertEquals(NULL, $contact['MyIndividualFields.FavColor']);
+    $this->assertEquals(NULL, $contact['MyIndividualFields.MyLink']);
 
     // Disable the field and it disappears from getFields and from the API output.
     CustomField::update(FALSE)
       ->addWhere('custom_group_id:name', '=', 'MyIndividualFields')
-      ->addWhere('name', '=', 'FavColor')
+      ->addWhere('name', '=', 'MyLink')
       ->addValue('is_active', FALSE)
       ->execute();
 
     $getFields = Contact::getFields(FALSE)
       ->execute()->column('name');
     $this->assertContains('first_name', $getFields);
-    $this->assertNotContains('MyIndividualFields.FavColor', $getFields);
+    $this->assertNotContains('MyIndividualFields.MyLink', $getFields);
 
     $contact = Contact::get(FALSE)
-      ->addSelect('MyIndividualFields.FavColor')
+      ->addSelect('MyIndividualFields.MyLink')
       ->addWhere('id', '=', $contactId)
       ->execute()
       ->first();
-    $this->assertArrayNotHasKey('MyIndividualFields.FavColor', $contact);
+    $this->assertArrayNotHasKey('MyIndividualFields.MyLink', $contact);
   }
 
   public function testWithTwoFields(): void {

--- a/tests/phpunit/api/v4/Custom/BasicCustomFieldTest.php
+++ b/tests/phpunit/api/v4/Custom/BasicCustomFieldTest.php
@@ -47,6 +47,8 @@ class BasicCustomFieldTest extends Api4TestBase {
       'html_type' => 'Text',
       // Will default to 2047 characters
       'data_type' => 'Link',
+      // Test that adding an index works for such a large field
+      'is_searchable' => TRUE,
     ]);
 
     // Individual fields should show up when contact_type = null|Individual but not other contact types


### PR DESCRIPTION
Overview
----------------------------------------
Increase size of custom Link fields to handle very long links.
See https://civicrm.stackexchange.com/questions/49123/how-can-i-store-longer-urls

Also fixes a bug triggered by adding an index to very long varchar fields.

Before
----------------------------------------
Limit for Link custom fields 255 characters, which was arbitrarily small.

After
----------------------------------------
Bumped maxLength to 2047, reflecting [sitemap URL limits](https://www.sitemaps.org/protocol.html#locdef).
Existing fields will not be affected immediately, but editing and re-saving them will update the maxlength.

Comments
---------
While testing the above, a bug surfaced:
1. Create a custom field with maxlength > 2000 and check the **Optimize for Search** option.
2. The result is a fatal error.

I'm kinda surprised that this is the first time anyone noticed that bug, but the problem is that mySql has a limit to how long an index can be. Fixed the error by constraining the length of the index, and added test coverage.