### PR TITLE
(dev/core#5702) Installer - Multiple cleanups for requirement-checks

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -85,29 +85,6 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
   }
 
   /**
-   * @return CRM_Utils_Check_Message[]
-   */
-  public function checkPhpMysqli() {
-    $messages = [];
-
-    if (!extension_loaded('mysqli')) {
-      $messages[] = new CRM_Utils_Check_Message(
-        __FUNCTION__,
-        ts('Future versions of CiviCRM may require the PHP extension "%2". To ensure that your system will be compatible, please install it in advance. For more explanation, see <a href="%1">the announcement</a>.',
-          [
-            1 => 'https://civicrm.org/blog/totten/psa-please-verify-php-extension-mysqli',
-            2 => 'mysqli',
-          ]),
-          ts('Forward Compatibility: Enable "mysqli"'),
-          \Psr\Log\LogLevel::WARNING,
-          'fa-server'
-      );
-    }
-
-    return $messages;
-  }
-
-  /**
    * Check that the MySQL time settings match the PHP time settings.
    *
    * @return CRM_Utils_Check_Message[]

--- a/Civi/Install/Requirements.php
+++ b/Civi/Install/Requirements.php
@@ -28,7 +28,6 @@ class Requirements {
    */
   protected $system_checks = [
     'checkMemory',
-    'checkMysqlConnectExists',
   ];
 
   protected $system_checks_web = [
@@ -107,6 +106,16 @@ class Requirements {
    * @return array
    */
   public function checkDatabase(array $db_config) {
+    if (!extension_loaded('mysqli')) {
+      return [
+        [
+          'title' => 'Driver',
+          'severity' => $this::REQUIREMENT_ERROR,
+          'details' => 'mysqli driver is missing. Cannot connect to database for testing.',
+        ],
+      ];
+    }
+
     $errors = [];
 
     foreach ($this->database_checks as $check) {
@@ -226,23 +235,6 @@ class Requirements {
     if ($missing) {
       $results['severity'] = $this::REQUIREMENT_ERROR;
       $results['details'] = 'The following PHP variables are not set: ' . implode(', ', $missing);
-    }
-
-    return $results;
-  }
-
-  /**
-   * @return array
-   */
-  public function checkMysqlConnectExists() {
-    $results = [
-      'title' => 'CiviCRM MySQL check',
-      'severity' => $this::REQUIREMENT_OK,
-      'details' => 'Function mysqli_connect() found',
-    ];
-    if (!function_exists('mysqli_connect')) {
-      $results['severity'] = $this::REQUIREMENT_ERROR;
-      $results['details'] = 'Function mysqli_connect() does not exist';
     }
 
     return $results;

--- a/Civi/Install/Requirements.php
+++ b/Civi/Install/Requirements.php
@@ -30,7 +30,6 @@ class Requirements {
     'checkMemory',
     'checkMysqlConnectExists',
     'checkJsonEncodeExists',
-    'checkMultibyteExists',
   ];
 
   protected $system_checks_web = [
@@ -245,24 +244,6 @@ class Requirements {
     if (!function_exists('json_encode')) {
       $results['severity'] = $this::REQUIREMENT_ERROR;
       $results['details'] = 'Function json_encode() does not exist';
-    }
-
-    return $results;
-  }
-
-  /**
-   * CHeck that PHP Multibyte functions are enabled.
-   * @return array
-   */
-  public function checkMultibyteExists() {
-    $results = [
-      'title' => 'CiviCRM MultiByte encoding support',
-      'severity' => $this::REQUIREMENT_OK,
-      'details' => 'PHP Multibyte etension found',
-    ];
-    if (!function_exists('mb_substr')) {
-      $results['severity'] = $this::REQUIREMENT_ERROR;
-      $results['details'] = 'PHP Multibyte extension has not been installed and enabled';
     }
 
     return $results;

--- a/Civi/Install/Requirements.php
+++ b/Civi/Install/Requirements.php
@@ -29,7 +29,6 @@ class Requirements {
   protected $system_checks = [
     'checkMemory',
     'checkMysqlConnectExists',
-    'checkJsonEncodeExists',
   ];
 
   protected $system_checks_web = [
@@ -227,23 +226,6 @@ class Requirements {
     if ($missing) {
       $results['severity'] = $this::REQUIREMENT_ERROR;
       $results['details'] = 'The following PHP variables are not set: ' . implode(', ', $missing);
-    }
-
-    return $results;
-  }
-
-  /**
-   * @return array
-   */
-  public function checkJsonEncodeExists() {
-    $results = [
-      'title' => 'CiviCRM JSON encoding support',
-      'severity' => $this::REQUIREMENT_OK,
-      'details' => 'Function json_encode() found',
-    ];
-    if (!function_exists('json_encode')) {
-      $results['severity'] = $this::REQUIREMENT_ERROR;
-      $results['details'] = 'Function json_encode() does not exist';
     }
 
     return $results;

--- a/composer.json
+++ b/composer.json
@@ -98,6 +98,7 @@
     "pear/db": "~1.12.1",
     "civicrm/composer-compile-lib": "~0.6 || ~1.0",
     "ext-json": "*",
+    "ext-mbstring": "*",
     "ezyang/htmlpurifier": "^4.13",
     "phpoffice/phpspreadsheet": "^1.18 || ^2",
     "symfony/polyfill-php80": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -99,6 +99,7 @@
     "civicrm/composer-compile-lib": "~0.6 || ~1.0",
     "ext-json": "*",
     "ext-mbstring": "*",
+    "ext-mysqli": "*",
     "ezyang/htmlpurifier": "^4.13",
     "phpoffice/phpspreadsheet": "^1.18 || ^2",
     "symfony/polyfill-php80": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "36385de081e74e6fa0154f69d622f853",
+    "content-hash": "cac8aeec407d2e88c894b8e250b789ce",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -5786,7 +5786,7 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -5794,11 +5794,12 @@
         "composer-runtime-api": "~2.0",
         "ext-intl": "*",
         "ext-json": "*",
+        "ext-mbstring": "*",
         "ext-fileinfo": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.0.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cac8aeec407d2e88c894b8e250b789ce",
+    "content-hash": "f31d9afa29112903a0ec52390903c67a",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -5795,6 +5795,7 @@
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
+        "ext-mysqli": "*",
         "ext-fileinfo": "*"
     },
     "platform-dev": {},

--- a/setup/plugins/checkRequirements/ComposerAdapter.civi-setup.php
+++ b/setup/plugins/checkRequirements/ComposerAdapter.civi-setup.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @file
+ *
+ * Re-enforce any PHP-PECL requirements from `composer.{json,lock}` as part of the installer.
+ * This speaks to platforms like SA, WP, BD, D7 where admins do not directly run `composer install`.
+ */
+
+if (!defined('CIVI_SETUP')) {
+  exit("Installation plugins must only be loaded by the installer.\n");
+}
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setup.checkRequirements', function (\Civi\Setup\Event\CheckRequirementsEvent $e) {
+    $model = $e->getModel();
+    $lockFile = $model->srcPath . '/composer.lock';
+    if (!file_exists($lockFile)) {
+      \Civi\Setup::log()->warning(sprintf('[%s] Skip Composer requirements. Missing civicrm-core:composer.lock', basename(__FILE__)));
+      return;
+    }
+
+    $lock = json_decode(file_get_contents($lockFile), TRUE);
+    if (empty($lock['platform'])) {
+      \Civi\Setup::log()->warning(sprintf('[%s] Skip Composer requirements. The civicrm-core:composer.lock does not declare valid platform requirements.', basename(__FILE__)));
+      return;
+    }
+
+    \Civi\Setup::log()->info(sprintf('[%s] Check Composer requirements', basename(__FILE__)));
+    $loadedExtensions = get_loaded_extensions();
+    foreach ($lock['platform'] as $key => $constraint) {
+      if (str_starts_with($key, 'ext-')) {
+        $extension = substr($key, 4);
+
+        if (!in_array($extension, $loadedExtensions)) {
+          $e->addError('system', $key, sprintf('The PHP extension "%s" is not installed.', $extension));
+        }
+        else {
+          $e->addInfo('system', $key, sprintf('The PHP extension "%s" is installed.', $extension));
+        }
+
+        // The above (basic existence check) is much better than status quo.
+        // It would be nicer to use composer/semver's `Semver::satisfies`, but then you'd need to deal with conflict-y risks across platforms (eg J4/J5).
+        //
+        // $version = phpversion($extension);
+        // if (!\Composer\Semver\Semver::satisfies($version, $constraint)) { .... }
+        //   $e->addError('system', 'php_' . $extension, sprintf('The PHP extension \"%s\" (%s) does not satisfy constraint (%s).', $extension, $version, $constraint));
+        // }
+      }
+    }
+  });

--- a/setup/src/Setup/DbUtil.php
+++ b/setup/src/Setup/DbUtil.php
@@ -87,6 +87,10 @@ class DbUtil {
    * @throws SqlException
    */
   public static function connect($db) {
+    if (!extension_loaded('mysqli')) {
+      throw new SqlException(sprintf("Connection failed: Missing mysqli\n"));
+    }
+
     // During installation, we need to test proposed credentials. Ensure that tests report failure the same way on php7+php8.
     if (version_compare(PHP_VERSION, '8', '>=')) {
       mysqli_report(MYSQLI_REPORT_OFF);


### PR DESCRIPTION
Overview
----------------------------------------

`json`, `mbstring`, `mysqli`, and `intl`are all strongly required -- the system won't work if they're missing.

However, the guards to require them work inconsistently..

See: https://lab.civicrm.org/dev/core/-/issues/5702

Before
----------------------------------------

For each extension, we can consider which mechanisms do a good/poor job of enforcing the requirement.

* `intl`: Properly required by `composer`. Not required by installer.  Strongly suggested by status-checks.
* `json`: Properly required by `composer`. Properly required by installer. (*But these 2 different rules.*)
* `mbstring`: Properly required by installer. Not required by `composer`.
* `mysqli`: Theoretically required by installer and by status-check, but the system is too crashy if it's missing. (You won't see the nice messages.). Not required by `composer` .

After
----------------------------------------

* All four of the four extensions are declared as requirements in `composer.json` (for D8/9/10/11-style users).
* All four of these requirements are enforced during installation (for BD/WP/D7/SA-style users). 
    * The web installer presents decent messages about missing extensions.

        ![Screenshot from 2025-01-24 00-05-07](https://github.com/user-attachments/assets/fd321154-a963-4cc3-aeb2-bc7115254b79)

    * The CLI installer presents decent messages about missing extensions.

        ![Screenshot from 2025-01-24 00-06-16](https://github.com/user-attachments/assets/6801529d-9dbe-4bdc-8937-8c1fd66688ef)


Comments
----------------------------------------

Several commits have additional notes.