### PR TITLE
ChartKit - allow more numeric formats as sourceDataTypes

### DIFF
--- a/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitComposite.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitComposite.service.js
@@ -20,7 +20,7 @@
             'y': {
                 key: 'y',
                 label: ts('Values'),
-                sourceDataTypes: ['Integer', 'Money', 'Boolean'],
+                sourceDataTypes: ['Integer', 'Money', 'Boolean', 'Float', 'Double'],
                 seriesTypes: ['bar', 'line', 'area'],
                 multiColumn: true,
                 colorType: 'one-per-column',

--- a/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitPie.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitPie.service.js
@@ -14,7 +14,7 @@
         },
         'y': {
           label: ts('Values'),
-          sourceDataTypes: ['Integer', 'Money', 'Boolean'],
+          sourceDataTypes: ['Integer', 'Money', 'Boolean', 'Float', 'Double'],
         },
         'z': {
           label: ts('Additional labels'),

--- a/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitRow.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitRow.service.js
@@ -14,7 +14,7 @@
         },
         'y': {
           label: ts('Values'),
-          sourceDataTypes: ['Integer', 'Money', 'Boolean'],
+          sourceDataTypes: ['Integer', 'Money', 'Boolean', 'Float', 'Double'],
         },
         'z': {
           label: ts('Additional labels'),

--- a/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitStack.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitStack.service.js
@@ -18,7 +18,7 @@
             'y': {
                 key: 'y',
                 label: ts('Values'),
-                sourceDataTypes: ['Integer', 'Money', 'Boolean'],
+                sourceDataTypes: ['Integer', 'Money', 'Boolean', 'Float', 'Double'],
                 multiColumn: true,
                 colorType: 'one-per-column',
             },


### PR DESCRIPTION
Overview
-------------------------------------
Allow more valid columns to be selected when building charts.

 [Originally raised by @bdpfreizeiten in ChartKit repo](https://lab.civicrm.org/extensions/chart_kit/-/merge_requests/16) :

> I would like to enable the selection of the numeric format float as columns. This is useful if you use ‘Group by’ and then calculate the average of a data field.

Before
----------------------------------------
- only whole number columns are selectable for Y axis

After
----------------------------------------
- columns with float / double values are selectable for Y axis also

