### PR TITLE
Afform - Fix admin access to forms requiring secret link

### DIFF
--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -481,7 +481,11 @@ function afform_civicrm_permission_check($permission, &$granted, $contactId) {
   elseif ($permission === '@afformPageToken') {
     $session = CRM_Core_Session::singleton();
     $data = $session->get('authx');
-    $granted = isset($data['jwt']['scope'], $data['flow']) && $data['jwt']['scope'] === 'afform' && $data['flow'] === 'afformpage';
+    $granted =
+      // Check authx token
+      isset($data['jwt']['scope'], $data['flow']) && $data['jwt']['scope'] === 'afform' && $data['flow'] === 'afformpage'
+      // Allow admins to edit forms without requiring a token
+      || CRM_Core_Permission::check('administer afform');
   }
 }
 
@@ -495,7 +499,10 @@ function afform_civicrm_permissionList(&$permissions) {
     'group' => 'const',
     'title' => E::ts('Generic: Anyone with secret link'),
     'description' => E::ts('If you link to the form with a secure token, then no other permission is needed.'),
+    'parent' => 'administer afform',
   ];
+  $permissions['administer afform']['implies'] ??= [];
+  $permissions['administer afform']['implies'][] = '@afformPageToken';
   $scanner = Civi::service('afform_scanner');
   foreach ($scanner->getMetas() as $name => $meta) {
     $permissions['@afform:' . $name] = [

--- a/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormTest.php
+++ b/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormTest.php
@@ -230,7 +230,7 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
     $cases['admin-anon'] = [$permAdmin, ...$asAnon, FALSE];
 
     $permSecretLink = ['permission' => '@afformPageToken'];
-    $cases['secret-demo'] = [$permSecretLink, ...$asDemo, FALSE];
+    $cases['secret-demo'] = [$permSecretLink, ...$asDemo, TRUE];
     $cases['secret-lebowski-xhj'] = [$permSecretLink, ...$asLebowski, FALSE];
     $cases['secret-lebowski-aff'] = [$permSecretLink, ...$asLebowskiPageToken, TRUE];
     $cases['secret-anon'] = [$permSecretLink, ...$asAnon, FALSE];
@@ -241,7 +241,7 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
     $cases['or-lebowski-aff'] = [$permAccessCiviOrSecretLink, ...$asLebowskiPageToken, TRUE];
 
     $permAccessCiviAndSecretLink = ['permission' => ['access CiviCRM', '@afformPageToken'], 'permission_operator' => 'AND'];
-    $cases['and-demo'] = [$permAccessCiviAndSecretLink, ...$asDemo, FALSE];
+    $cases['and-demo'] = [$permAccessCiviAndSecretLink, ...$asDemo, TRUE];
     $cases['and-lebowski-xhj'] = [$permAccessCiviAndSecretLink, ...$asLebowski, FALSE];
     $cases['and-lebowski-aff'] = [$permAccessCiviAndSecretLink, ...$asLebowskiPageToken, FALSE];
 


### PR DESCRIPTION
Overview
----------------------------------------
Followup fix to https://github.com/civicrm/civicrm-core/pull/31386
Fixes [dev/core#5704](https://lab.civicrm.org/dev/core/-/issues/5704)

Before
----------------------------------------
1. Create a new FormBuilder submission form.
2. Grant the "Generic: Anyone with secret link" permission.
3. Save the form. Hard reload the page.
4. Page crashes due to internal access denied error.

After
----------------------------------------
Form editors are allowed to edit the form.