### PR TITLE
Search: disable the alpha pager by default

### DIFF
--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -102,7 +102,7 @@ return [
     'name' => 'includeAlphabeticalPager',
     'type' => 'Boolean',
     'quick_form_type' => 'YesNo',
-    'default' => 1,
+    'default' => 0,
     'add' => '4.6',
     'title' => ts('Include Alphabetical Pager'),
     'is_domain' => 1,

--- a/templates/CRM/common/pagerAToZ.tpl
+++ b/templates/CRM/common/pagerAToZ.tpl
@@ -8,6 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {* Displays alphabetic filter bar for search results. If one more records in resultset starts w/ that letter, item is a link. *}
+{if $aToZ}
 <div id="alpha-filter">
     <ul>
     {foreach from=$aToZ item=letter}
@@ -15,3 +16,4 @@
     {/foreach}
     </ul>
 </div>
+{/if}


### PR DESCRIPTION
Overview
----------------------------------------

CiviCRM displays an alphabetic pager in the search results of certain screens (advanced/basic search, list of mailings).

In #31187 the pager was moved to the bottom of the search screens, but #31794 restored it to the top, while suggesting we disable it for new installs by default.

My user observations are that the alpha pager is:

- Distracting clutter
- Inconsistent (not all screens implement it)
- Not clear what the use-case is for using it

Other CRMs rarely have this kind of pager. Those that do, such as MS Dynamics, display it at the bottom of the list of contacts.

This PR therefore disables the alpha-pager by default, but keeps the setting for enabling the previous behaviour. This only impacts new installations.

Before
----------------------------------------

On smaster with the default configuration/theme:

![image](https://github.com/user-attachments/assets/a61b479b-da87-452a-85fd-ac904313f5a5)


After
----------------------------------------

![image](https://github.com/user-attachments/assets/9cdfa450-9abb-4d83-93e7-2fd37f3ca9e2)

Comments
----------------------------------------

cc @kcristiano @christianwach 