### PR TITLE
Upgrade core extensions to civix v25.01.1

### DIFF
--- a/ext/afform/admin/afform_admin.civix.php
+++ b/ext/afform/admin/afform_admin.civix.php
@@ -75,9 +75,44 @@ class CRM_AfformAdmin_ExtensionUtil {
     return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
   }
 
+  /**
+   * @return \CiviMix\Schema\SchemaHelperInterface
+   */
+  public static function schema() {
+    if (!isset($GLOBALS['CiviMixSchema'])) {
+      pathload()->loadPackage('civimix-schema@5', TRUE);
+    }
+    return $GLOBALS['CiviMixSchema']->getHelper(static::LONG_NAME);
+  }
+
 }
 
 use CRM_AfformAdmin_ExtensionUtil as E;
+
+spl_autoload_register('_afform_admin_civix_class_loader', TRUE, TRUE);
+
+function _afform_admin_civix_class_loader($class) {
+  if ($class === 'CRM_AfformAdmin_DAO_Base') {
+    if (version_compare(CRM_Utils_System::version(), '5.74.beta', '>=')) {
+      class_alias('CRM_Core_DAO_Base', 'CRM_AfformAdmin_DAO_Base');
+      // ^^ Materialize concrete names -- encourage IDE's to pick up on this association.
+    }
+    else {
+      $realClass = 'CiviMix\\Schema\\AfformAdmin\\DAO';
+      class_alias($realClass, $class);
+      // ^^ Abstract names -- discourage IDE's from picking up on this association.
+    }
+    return;
+  }
+
+  // This allows us to tap-in to the installation process (without incurring real file-reads on typical requests).
+  if (strpos($class, 'CiviMix\\Schema\\AfformAdmin\\') === 0) {
+    // civimix-schema@5 is designed for backported use in download/activation workflows,
+    // where new revisions may become dynamically available.
+    pathload()->loadPackage('civimix-schema@5', TRUE);
+    CiviMix\Schema\loadClass($class);
+  }
+}
 
 /**
  * (Delegated) Implements hook_civicrm_config().

--- a/ext/afform/admin/info.xml
+++ b/ext/afform/admin/info.xml
@@ -25,7 +25,7 @@
   </requires>
   <civix>
     <namespace>CRM/AfformAdmin</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>
@@ -37,7 +37,7 @@
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>mgd-php@1.0.0</mixin>
     <mixin>afform-entity-php@1.0.0</mixin>
-    <mixin>smarty@1.0.0</mixin>
+    <mixin>smarty@1.0.3</mixin>
   </mixins>
-  <upgrader>CRM_AfformAdmin_Upgrader</upgrader>
+  <upgrader>CiviMix\Schema\AfformAdmin\AutomaticUpgrader</upgrader>
 </extension>

--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -24,7 +24,7 @@
   <comments>The Form Core extension is required to use any dynamic form. To administer and edit forms, also install the FormBuilder extension.</comments>
   <civix>
     <namespace>CRM/Afform</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>
@@ -37,7 +37,7 @@
     <mixin>ang-php@1.0.0</mixin>
     <mixin>mgd-php@1.0.0</mixin>
     <mixin>scan-classes@1.0.0</mixin>
-    <mixin>smarty@1.0.0</mixin>
+    <mixin>smarty@1.0.3</mixin>
     <mixin>entity-types-php@2.0.0</mixin>
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>

--- a/ext/afform/html/info.xml
+++ b/ext/afform/html/info.xml
@@ -27,7 +27,7 @@
   </mixins>
   <civix>
     <namespace>CRM/AfformHtml</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/ext/afform/login_token/info.xml
+++ b/ext/afform/login_token/info.xml
@@ -20,7 +20,7 @@
   <version>1.0.0</version>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>5.79</ver>
+    <ver>[civicrm.majorVersion]</ver>
   </compatibility>
   <requires>
     <ext>org.civicrm.afform</ext>
@@ -32,7 +32,7 @@
   </classloader>
   <civix>
     <namespace>CRM/AfformLoginToken</namespace>
-    <format>24.09.1</format>
+    <format>25.01.1</format>
     <angularModule>crmAfformLoginToken</angularModule>
   </civix>
   <mixins>

--- a/ext/afform/mock/info.xml
+++ b/ext/afform/mock/info.xml
@@ -29,7 +29,7 @@
   </mixins>
   <civix>
     <namespace>CRM/AfformMock</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/ext/authx/info.xml
+++ b/ext/authx/info.xml
@@ -32,11 +32,11 @@
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>scan-classes@1.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
-    <mixin>setting-admin@1.0.0</mixin>
+    <mixin>setting-admin@1.0.1</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Authx</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
     <setting-page-title>Authentication</setting-page-title>
   </civix>
 </extension>

--- a/ext/chart_kit/info.xml
+++ b/ext/chart_kit/info.xml
@@ -27,7 +27,7 @@
   </classloader>
   <civix>
     <namespace>CRM/ChartKit</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
   <mixins>
     <mixin>mgd-php@1.0.0</mixin>

--- a/ext/civi_campaign/civi_campaign.civix.php
+++ b/ext/civi_campaign/civi_campaign.civix.php
@@ -75,9 +75,44 @@ class CRM_Campaign_ExtensionUtil {
     return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
   }
 
+  /**
+   * @return \CiviMix\Schema\SchemaHelperInterface
+   */
+  public static function schema() {
+    if (!isset($GLOBALS['CiviMixSchema'])) {
+      pathload()->loadPackage('civimix-schema@5', TRUE);
+    }
+    return $GLOBALS['CiviMixSchema']->getHelper(static::LONG_NAME);
+  }
+
 }
 
 use CRM_Campaign_ExtensionUtil as E;
+
+spl_autoload_register('_civi_campaign_civix_class_loader', TRUE, TRUE);
+
+function _civi_campaign_civix_class_loader($class) {
+  if ($class === 'CRM_Campaign_DAO_Base') {
+    if (version_compare(CRM_Utils_System::version(), '5.74.beta', '>=')) {
+      class_alias('CRM_Core_DAO_Base', 'CRM_Campaign_DAO_Base');
+      // ^^ Materialize concrete names -- encourage IDE's to pick up on this association.
+    }
+    else {
+      $realClass = 'CiviMix\\Schema\\CiviCampaign\\DAO';
+      class_alias($realClass, $class);
+      // ^^ Abstract names -- discourage IDE's from picking up on this association.
+    }
+    return;
+  }
+
+  // This allows us to tap-in to the installation process (without incurring real file-reads on typical requests).
+  if (strpos($class, 'CiviMix\\Schema\\CiviCampaign\\') === 0) {
+    // civimix-schema@5 is designed for backported use in download/activation workflows,
+    // where new revisions may become dynamically available.
+    pathload()->loadPackage('civimix-schema@5', TRUE);
+    CiviMix\Schema\loadClass($class);
+  }
+}
 
 /**
  * (Delegated) Implements hook_civicrm_config().

--- a/ext/civi_campaign/info.xml
+++ b/ext/civi_campaign/info.xml
@@ -33,7 +33,7 @@
   </mixins>
   <civix>
     <namespace>CRM/Campaign</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
     <angularModule>civiCampaign</angularModule>
   </civix>
 </extension>

--- a/ext/civi_case/civi_case.civix.php
+++ b/ext/civi_case/civi_case.civix.php
@@ -75,9 +75,44 @@ class CRM_Case_ExtensionUtil {
     return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
   }
 
+  /**
+   * @return \CiviMix\Schema\SchemaHelperInterface
+   */
+  public static function schema() {
+    if (!isset($GLOBALS['CiviMixSchema'])) {
+      pathload()->loadPackage('civimix-schema@5', TRUE);
+    }
+    return $GLOBALS['CiviMixSchema']->getHelper(static::LONG_NAME);
+  }
+
 }
 
 use CRM_Case_ExtensionUtil as E;
+
+spl_autoload_register('_civi_case_civix_class_loader', TRUE, TRUE);
+
+function _civi_case_civix_class_loader($class) {
+  if ($class === 'CRM_Case_DAO_Base') {
+    if (version_compare(CRM_Utils_System::version(), '5.74.beta', '>=')) {
+      class_alias('CRM_Core_DAO_Base', 'CRM_Case_DAO_Base');
+      // ^^ Materialize concrete names -- encourage IDE's to pick up on this association.
+    }
+    else {
+      $realClass = 'CiviMix\\Schema\\CiviCase\\DAO';
+      class_alias($realClass, $class);
+      // ^^ Abstract names -- discourage IDE's from picking up on this association.
+    }
+    return;
+  }
+
+  // This allows us to tap-in to the installation process (without incurring real file-reads on typical requests).
+  if (strpos($class, 'CiviMix\\Schema\\CiviCase\\') === 0) {
+    // civimix-schema@5 is designed for backported use in download/activation workflows,
+    // where new revisions may become dynamically available.
+    pathload()->loadPackage('civimix-schema@5', TRUE);
+    CiviMix\Schema\loadClass($class);
+  }
+}
 
 /**
  * (Delegated) Implements hook_civicrm_config().

--- a/ext/civi_case/info.xml
+++ b/ext/civi_case/info.xml
@@ -33,7 +33,7 @@
   </mixins>
   <civix>
     <namespace>CRM/Case</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
     <angularModule>civiCase</angularModule>
   </civix>
 </extension>

--- a/ext/civi_contribute/civi_contribute.civix.php
+++ b/ext/civi_contribute/civi_contribute.civix.php
@@ -75,9 +75,44 @@ class CRM_Contribute_ExtensionUtil {
     return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
   }
 
+  /**
+   * @return \CiviMix\Schema\SchemaHelperInterface
+   */
+  public static function schema() {
+    if (!isset($GLOBALS['CiviMixSchema'])) {
+      pathload()->loadPackage('civimix-schema@5', TRUE);
+    }
+    return $GLOBALS['CiviMixSchema']->getHelper(static::LONG_NAME);
+  }
+
 }
 
 use CRM_Contribute_ExtensionUtil as E;
+
+spl_autoload_register('_civi_contribute_civix_class_loader', TRUE, TRUE);
+
+function _civi_contribute_civix_class_loader($class) {
+  if ($class === 'CRM_Contribute_DAO_Base') {
+    if (version_compare(CRM_Utils_System::version(), '5.74.beta', '>=')) {
+      class_alias('CRM_Core_DAO_Base', 'CRM_Contribute_DAO_Base');
+      // ^^ Materialize concrete names -- encourage IDE's to pick up on this association.
+    }
+    else {
+      $realClass = 'CiviMix\\Schema\\CiviContribute\\DAO';
+      class_alias($realClass, $class);
+      // ^^ Abstract names -- discourage IDE's from picking up on this association.
+    }
+    return;
+  }
+
+  // This allows us to tap-in to the installation process (without incurring real file-reads on typical requests).
+  if (strpos($class, 'CiviMix\\Schema\\CiviContribute\\') === 0) {
+    // civimix-schema@5 is designed for backported use in download/activation workflows,
+    // where new revisions may become dynamically available.
+    pathload()->loadPackage('civimix-schema@5', TRUE);
+    CiviMix\Schema\loadClass($class);
+  }
+}
 
 /**
  * (Delegated) Implements hook_civicrm_config().

--- a/ext/civi_contribute/info.xml
+++ b/ext/civi_contribute/info.xml
@@ -33,7 +33,7 @@
   </mixins>
   <civix>
     <namespace>CRM/Contribute</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
     <angularModule>civiContribute</angularModule>
   </civix>
 </extension>

--- a/ext/civi_event/civi_event.civix.php
+++ b/ext/civi_event/civi_event.civix.php
@@ -75,9 +75,44 @@ class CRM_Event_ExtensionUtil {
     return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
   }
 
+  /**
+   * @return \CiviMix\Schema\SchemaHelperInterface
+   */
+  public static function schema() {
+    if (!isset($GLOBALS['CiviMixSchema'])) {
+      pathload()->loadPackage('civimix-schema@5', TRUE);
+    }
+    return $GLOBALS['CiviMixSchema']->getHelper(static::LONG_NAME);
+  }
+
 }
 
 use CRM_Event_ExtensionUtil as E;
+
+spl_autoload_register('_civi_event_civix_class_loader', TRUE, TRUE);
+
+function _civi_event_civix_class_loader($class) {
+  if ($class === 'CRM_Event_DAO_Base') {
+    if (version_compare(CRM_Utils_System::version(), '5.74.beta', '>=')) {
+      class_alias('CRM_Core_DAO_Base', 'CRM_Event_DAO_Base');
+      // ^^ Materialize concrete names -- encourage IDE's to pick up on this association.
+    }
+    else {
+      $realClass = 'CiviMix\\Schema\\CiviEvent\\DAO';
+      class_alias($realClass, $class);
+      // ^^ Abstract names -- discourage IDE's from picking up on this association.
+    }
+    return;
+  }
+
+  // This allows us to tap-in to the installation process (without incurring real file-reads on typical requests).
+  if (strpos($class, 'CiviMix\\Schema\\CiviEvent\\') === 0) {
+    // civimix-schema@5 is designed for backported use in download/activation workflows,
+    // where new revisions may become dynamically available.
+    pathload()->loadPackage('civimix-schema@5', TRUE);
+    CiviMix\Schema\loadClass($class);
+  }
+}
 
 /**
  * (Delegated) Implements hook_civicrm_config().

--- a/ext/civi_event/info.xml
+++ b/ext/civi_event/info.xml
@@ -32,7 +32,7 @@
   </mixins>
   <civix>
     <namespace>CRM/Event</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
     <angularModule>civiEvent</angularModule>
   </civix>
 </extension>

--- a/ext/civi_mail/civi_mail.civix.php
+++ b/ext/civi_mail/civi_mail.civix.php
@@ -75,9 +75,44 @@ class CRM_Mailing_ExtensionUtil {
     return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
   }
 
+  /**
+   * @return \CiviMix\Schema\SchemaHelperInterface
+   */
+  public static function schema() {
+    if (!isset($GLOBALS['CiviMixSchema'])) {
+      pathload()->loadPackage('civimix-schema@5', TRUE);
+    }
+    return $GLOBALS['CiviMixSchema']->getHelper(static::LONG_NAME);
+  }
+
 }
 
 use CRM_Mailing_ExtensionUtil as E;
+
+spl_autoload_register('_civi_mail_civix_class_loader', TRUE, TRUE);
+
+function _civi_mail_civix_class_loader($class) {
+  if ($class === 'CRM_Mailing_DAO_Base') {
+    if (version_compare(CRM_Utils_System::version(), '5.74.beta', '>=')) {
+      class_alias('CRM_Core_DAO_Base', 'CRM_Mailing_DAO_Base');
+      // ^^ Materialize concrete names -- encourage IDE's to pick up on this association.
+    }
+    else {
+      $realClass = 'CiviMix\\Schema\\CiviMail\\DAO';
+      class_alias($realClass, $class);
+      // ^^ Abstract names -- discourage IDE's from picking up on this association.
+    }
+    return;
+  }
+
+  // This allows us to tap-in to the installation process (without incurring real file-reads on typical requests).
+  if (strpos($class, 'CiviMix\\Schema\\CiviMail\\') === 0) {
+    // civimix-schema@5 is designed for backported use in download/activation workflows,
+    // where new revisions may become dynamically available.
+    pathload()->loadPackage('civimix-schema@5', TRUE);
+    CiviMix\Schema\loadClass($class);
+  }
+}
 
 /**
  * (Delegated) Implements hook_civicrm_config().

--- a/ext/civi_mail/info.xml
+++ b/ext/civi_mail/info.xml
@@ -34,7 +34,7 @@
   </mixins>
   <civix>
     <namespace>CRM/Mailing</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
     <angularModule>civiMail</angularModule>
   </civix>
 </extension>

--- a/ext/civi_member/civi_member.civix.php
+++ b/ext/civi_member/civi_member.civix.php
@@ -75,9 +75,44 @@ class CRM_Member_ExtensionUtil {
     return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
   }
 
+  /**
+   * @return \CiviMix\Schema\SchemaHelperInterface
+   */
+  public static function schema() {
+    if (!isset($GLOBALS['CiviMixSchema'])) {
+      pathload()->loadPackage('civimix-schema@5', TRUE);
+    }
+    return $GLOBALS['CiviMixSchema']->getHelper(static::LONG_NAME);
+  }
+
 }
 
 use CRM_Member_ExtensionUtil as E;
+
+spl_autoload_register('_civi_member_civix_class_loader', TRUE, TRUE);
+
+function _civi_member_civix_class_loader($class) {
+  if ($class === 'CRM_Member_DAO_Base') {
+    if (version_compare(CRM_Utils_System::version(), '5.74.beta', '>=')) {
+      class_alias('CRM_Core_DAO_Base', 'CRM_Member_DAO_Base');
+      // ^^ Materialize concrete names -- encourage IDE's to pick up on this association.
+    }
+    else {
+      $realClass = 'CiviMix\\Schema\\CiviMember\\DAO';
+      class_alias($realClass, $class);
+      // ^^ Abstract names -- discourage IDE's from picking up on this association.
+    }
+    return;
+  }
+
+  // This allows us to tap-in to the installation process (without incurring real file-reads on typical requests).
+  if (strpos($class, 'CiviMix\\Schema\\CiviMember\\') === 0) {
+    // civimix-schema@5 is designed for backported use in download/activation workflows,
+    // where new revisions may become dynamically available.
+    pathload()->loadPackage('civimix-schema@5', TRUE);
+    CiviMix\Schema\loadClass($class);
+  }
+}
 
 /**
  * (Delegated) Implements hook_civicrm_config().

--- a/ext/civi_member/info.xml
+++ b/ext/civi_member/info.xml
@@ -32,7 +32,7 @@
   </mixins>
   <civix>
     <namespace>CRM/Member</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
     <angularModule>civiMember</angularModule>
   </civix>
 </extension>

--- a/ext/civi_pledge/civi_pledge.civix.php
+++ b/ext/civi_pledge/civi_pledge.civix.php
@@ -75,9 +75,44 @@ class CRM_Pledge_ExtensionUtil {
     return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
   }
 
+  /**
+   * @return \CiviMix\Schema\SchemaHelperInterface
+   */
+  public static function schema() {
+    if (!isset($GLOBALS['CiviMixSchema'])) {
+      pathload()->loadPackage('civimix-schema@5', TRUE);
+    }
+    return $GLOBALS['CiviMixSchema']->getHelper(static::LONG_NAME);
+  }
+
 }
 
 use CRM_Pledge_ExtensionUtil as E;
+
+spl_autoload_register('_civi_pledge_civix_class_loader', TRUE, TRUE);
+
+function _civi_pledge_civix_class_loader($class) {
+  if ($class === 'CRM_Pledge_DAO_Base') {
+    if (version_compare(CRM_Utils_System::version(), '5.74.beta', '>=')) {
+      class_alias('CRM_Core_DAO_Base', 'CRM_Pledge_DAO_Base');
+      // ^^ Materialize concrete names -- encourage IDE's to pick up on this association.
+    }
+    else {
+      $realClass = 'CiviMix\\Schema\\CiviPledge\\DAO';
+      class_alias($realClass, $class);
+      // ^^ Abstract names -- discourage IDE's from picking up on this association.
+    }
+    return;
+  }
+
+  // This allows us to tap-in to the installation process (without incurring real file-reads on typical requests).
+  if (strpos($class, 'CiviMix\\Schema\\CiviPledge\\') === 0) {
+    // civimix-schema@5 is designed for backported use in download/activation workflows,
+    // where new revisions may become dynamically available.
+    pathload()->loadPackage('civimix-schema@5', TRUE);
+    CiviMix\Schema\loadClass($class);
+  }
+}
 
 /**
  * (Delegated) Implements hook_civicrm_config().

--- a/ext/civi_pledge/info.xml
+++ b/ext/civi_pledge/info.xml
@@ -32,7 +32,7 @@
   </mixins>
   <civix>
     <namespace>CRM/Pledge</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
     <angularModule>civiPledge</angularModule>
   </civix>
 </extension>

--- a/ext/civi_report/civi_report.civix.php
+++ b/ext/civi_report/civi_report.civix.php
@@ -75,9 +75,44 @@ class CRM_Report_ExtensionUtil {
     return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
   }
 
+  /**
+   * @return \CiviMix\Schema\SchemaHelperInterface
+   */
+  public static function schema() {
+    if (!isset($GLOBALS['CiviMixSchema'])) {
+      pathload()->loadPackage('civimix-schema@5', TRUE);
+    }
+    return $GLOBALS['CiviMixSchema']->getHelper(static::LONG_NAME);
+  }
+
 }
 
 use CRM_Report_ExtensionUtil as E;
+
+spl_autoload_register('_civi_report_civix_class_loader', TRUE, TRUE);
+
+function _civi_report_civix_class_loader($class) {
+  if ($class === 'CRM_Report_DAO_Base') {
+    if (version_compare(CRM_Utils_System::version(), '5.74.beta', '>=')) {
+      class_alias('CRM_Core_DAO_Base', 'CRM_Report_DAO_Base');
+      // ^^ Materialize concrete names -- encourage IDE's to pick up on this association.
+    }
+    else {
+      $realClass = 'CiviMix\\Schema\\CiviReport\\DAO';
+      class_alias($realClass, $class);
+      // ^^ Abstract names -- discourage IDE's from picking up on this association.
+    }
+    return;
+  }
+
+  // This allows us to tap-in to the installation process (without incurring real file-reads on typical requests).
+  if (strpos($class, 'CiviMix\\Schema\\CiviReport\\') === 0) {
+    // civimix-schema@5 is designed for backported use in download/activation workflows,
+    // where new revisions may become dynamically available.
+    pathload()->loadPackage('civimix-schema@5', TRUE);
+    CiviMix\Schema\loadClass($class);
+  }
+}
 
 /**
  * (Delegated) Implements hook_civicrm_config().

--- a/ext/civi_report/info.xml
+++ b/ext/civi_report/info.xml
@@ -32,7 +32,7 @@
   </mixins>
   <civix>
     <namespace>CRM/Report</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
     <angularModule>civiReport</angularModule>
   </civix>
 </extension>

--- a/ext/civicrm_admin_ui/civicrm_admin_ui.civix.php
+++ b/ext/civicrm_admin_ui/civicrm_admin_ui.civix.php
@@ -89,8 +89,6 @@ class CRM_CivicrmAdminUi_ExtensionUtil {
 
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
 
-($GLOBALS['_PathLoad'][0] ?? require __DIR__ . '/mixin/lib/pathload-0.php');
-pathload()->addSearchDir(__DIR__ . '/mixin/lib');
 spl_autoload_register('_civicrm_admin_ui_civix_class_loader', TRUE, TRUE);
 
 function _civicrm_admin_ui_civix_class_loader($class) {

--- a/ext/civicrm_admin_ui/info.xml
+++ b/ext/civicrm_admin_ui/info.xml
@@ -26,7 +26,7 @@
   <civix>
     <namespace>CRM/CivicrmAdminUi</namespace>
     <angularModule>crmCivicrmAdminUi</angularModule>
-    <format>24.09.1</format>
+    <format>25.01.1</format>
   </civix>
   <mixins>
     <mixin>mgd-php@1.0.0</mixin>

--- a/ext/civicrm_search_ui/civicrm_search_ui.civix.php
+++ b/ext/civicrm_search_ui/civicrm_search_ui.civix.php
@@ -75,9 +75,44 @@ class CRM_CivicrmSearchUi_ExtensionUtil {
     return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
   }
 
+  /**
+   * @return \CiviMix\Schema\SchemaHelperInterface
+   */
+  public static function schema() {
+    if (!isset($GLOBALS['CiviMixSchema'])) {
+      pathload()->loadPackage('civimix-schema@5', TRUE);
+    }
+    return $GLOBALS['CiviMixSchema']->getHelper(static::LONG_NAME);
+  }
+
 }
 
 use CRM_CivicrmSearchUi_ExtensionUtil as E;
+
+spl_autoload_register('_civicrm_search_ui_civix_class_loader', TRUE, TRUE);
+
+function _civicrm_search_ui_civix_class_loader($class) {
+  if ($class === 'CRM_CivicrmSearchUi_DAO_Base') {
+    if (version_compare(CRM_Utils_System::version(), '5.74.beta', '>=')) {
+      class_alias('CRM_Core_DAO_Base', 'CRM_CivicrmSearchUi_DAO_Base');
+      // ^^ Materialize concrete names -- encourage IDE's to pick up on this association.
+    }
+    else {
+      $realClass = 'CiviMix\\Schema\\CivicrmSearchUi\\DAO';
+      class_alias($realClass, $class);
+      // ^^ Abstract names -- discourage IDE's from picking up on this association.
+    }
+    return;
+  }
+
+  // This allows us to tap-in to the installation process (without incurring real file-reads on typical requests).
+  if (strpos($class, 'CiviMix\\Schema\\CivicrmSearchUi\\') === 0) {
+    // civimix-schema@5 is designed for backported use in download/activation workflows,
+    // where new revisions may become dynamically available.
+    pathload()->loadPackage('civimix-schema@5', TRUE);
+    CiviMix\Schema\loadClass($class);
+  }
+}
 
 /**
  * (Delegated) Implements hook_civicrm_config().

--- a/ext/civicrm_search_ui/info.xml
+++ b/ext/civicrm_search_ui/info.xml
@@ -25,13 +25,13 @@
   </classloader>
   <civix>
     <namespace>CRM/CivicrmSearchUi</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
     <angularModule>crmCivicrmSearchUi</angularModule>
   </civix>
   <mixins>
     <mixin>mgd-php@1.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
-    <mixin>smarty@1.0.0</mixin>
+    <mixin>smarty@1.0.3</mixin>
   </mixins>
-  <upgrader>CRM_CivicrmSearchUi_Upgrader</upgrader>
+  <upgrader>CiviMix\Schema\CivicrmSearchUi\AutomaticUpgrader</upgrader>
 </extension>

--- a/ext/civigrant/info.xml
+++ b/ext/civigrant/info.xml
@@ -32,12 +32,12 @@
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>mgd-php@1.0.0</mixin>
     <mixin>afform-entity-php@1.0.0</mixin>
-    <mixin>smarty@1.0.0</mixin>
+    <mixin>smarty@1.0.3</mixin>
     <mixin>entity-types-php@2.0.0</mixin>
     <mixin>scan-classes@1.0.0</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Grant</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
 </extension>

--- a/ext/civiimport/info.xml
+++ b/ext/civiimport/info.xml
@@ -31,7 +31,7 @@
   </classloader>
   <civix>
     <namespace>CRM/Civiimport</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
     <angularModule>crmCiviimport</angularModule>
   </civix>
   <mixins>
@@ -39,6 +39,6 @@
     <mixin>scan-classes@1.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
     <mixin>ang-php@1.0.0</mixin>
-    <mixin>smarty@1.0.0</mixin>
+    <mixin>smarty@1.0.3</mixin>
   </mixins>
 </extension>

--- a/ext/ckeditor4/ckeditor4.civix.php
+++ b/ext/ckeditor4/ckeditor4.civix.php
@@ -75,9 +75,44 @@ class CRM_Ckeditor4_ExtensionUtil {
     return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
   }
 
+  /**
+   * @return \CiviMix\Schema\SchemaHelperInterface
+   */
+  public static function schema() {
+    if (!isset($GLOBALS['CiviMixSchema'])) {
+      pathload()->loadPackage('civimix-schema@5', TRUE);
+    }
+    return $GLOBALS['CiviMixSchema']->getHelper(static::LONG_NAME);
+  }
+
 }
 
 use CRM_Ckeditor4_ExtensionUtil as E;
+
+spl_autoload_register('_ckeditor4_civix_class_loader', TRUE, TRUE);
+
+function _ckeditor4_civix_class_loader($class) {
+  if ($class === 'CRM_Ckeditor4_DAO_Base') {
+    if (version_compare(CRM_Utils_System::version(), '5.74.beta', '>=')) {
+      class_alias('CRM_Core_DAO_Base', 'CRM_Ckeditor4_DAO_Base');
+      // ^^ Materialize concrete names -- encourage IDE's to pick up on this association.
+    }
+    else {
+      $realClass = 'CiviMix\\Schema\\Ckeditor4\\DAO';
+      class_alias($realClass, $class);
+      // ^^ Abstract names -- discourage IDE's from picking up on this association.
+    }
+    return;
+  }
+
+  // This allows us to tap-in to the installation process (without incurring real file-reads on typical requests).
+  if (strpos($class, 'CiviMix\\Schema\\Ckeditor4\\') === 0) {
+    // civimix-schema@5 is designed for backported use in download/activation workflows,
+    // where new revisions may become dynamically available.
+    pathload()->loadPackage('civimix-schema@5', TRUE);
+    CiviMix\Schema\loadClass($class);
+  }
+}
 
 /**
  * (Delegated) Implements hook_civicrm_config().

--- a/ext/ckeditor4/info.xml
+++ b/ext/ckeditor4/info.xml
@@ -27,11 +27,11 @@
   </classloader>
   <mixins>
     <mixin>menu-xml@1.0.0</mixin>
-    <mixin>smarty@1.0.0</mixin>
+    <mixin>smarty@1.0.3</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Ckeditor4</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
-  <upgrader>CRM_Ckeditor4_Upgrader</upgrader>
+  <upgrader>CiviMix\Schema\Ckeditor4\AutomaticUpgrader</upgrader>
 </extension>

--- a/ext/contributioncancelactions/info.xml
+++ b/ext/contributioncancelactions/info.xml
@@ -27,6 +27,6 @@
   </classloader>
   <civix>
     <namespace>CRM/Contributioncancelactions</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
 </extension>

--- a/ext/elavon/info.xml
+++ b/ext/elavon/info.xml
@@ -27,7 +27,7 @@
   </classloader>
   <civix>
     <namespace>CRM/Elavon</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
     <angularModule>crmElavon</angularModule>
   </civix>
   <mixins>

--- a/ext/eventcart/info.xml
+++ b/ext/eventcart/info.xml
@@ -24,13 +24,13 @@
   </classloader>
   <mixins>
     <mixin>menu-xml@1.0.0</mixin>
-    <mixin>smarty@1.0.0</mixin>
+    <mixin>smarty@1.0.3</mixin>
     <mixin>entity-types-php@2.0.0</mixin>
     <mixin>mgd-php@1.0.0</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Event/Cart</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
   <upgrader>CiviMix\Schema\Eventcart\AutomaticUpgrader</upgrader>
 </extension>

--- a/ext/ewaysingle/info.xml
+++ b/ext/ewaysingle/info.xml
@@ -33,6 +33,6 @@
   </mixins>
   <civix>
     <namespace>CRM/Ewaysingle</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
 </extension>

--- a/ext/financialacls/info.xml
+++ b/ext/financialacls/info.xml
@@ -33,6 +33,6 @@
   </requires>
   <civix>
     <namespace>CRM/Financialacls</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
 </extension>

--- a/ext/flexmailer/info.xml
+++ b/ext/flexmailer/info.xml
@@ -38,6 +38,6 @@
   </mixins>
   <civix>
     <namespace>CRM/Flexmailer</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
 </extension>

--- a/ext/greenwich/info.xml
+++ b/ext/greenwich/info.xml
@@ -29,6 +29,6 @@
   </classloader>
   <civix>
     <namespace>CRM/Greenwich</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
 </extension>

--- a/ext/iframe/info.xml
+++ b/ext/iframe/info.xml
@@ -30,15 +30,15 @@
   </classloader>
   <civix>
     <namespace>CRM/Iframe</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
     <angularModule>crmIframe</angularModule>
   </civix>
   <mixins>
     <mixin>mgd-php@1.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
-    <mixin>smarty-v2@1.0.1</mixin>
     <mixin>scan-classes@1.0.0</mixin>
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>setting-admin@1.0.1</mixin>
+    <mixin>smarty@1.0.3</mixin>
   </mixins>
 </extension>

--- a/ext/legacycustomsearches/info.xml
+++ b/ext/legacycustomsearches/info.xml
@@ -28,11 +28,11 @@
   <mixins>
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>mgd-php@1.0.0</mixin>
-    <mixin>smarty@1.0.0</mixin>
+    <mixin>smarty@1.0.3</mixin>
     <mixin>setting-php@1.0.0</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Legacycustomsearches</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
 </extension>

--- a/ext/message_admin/info.xml
+++ b/ext/message_admin/info.xml
@@ -28,10 +28,10 @@
   <mixins>
     <mixin>ang-php@1.0.0</mixin>
     <mixin>menu-xml@1.0.0</mixin>
-    <mixin>smarty@1.0.0</mixin>
+    <mixin>smarty@1.0.3</mixin>
   </mixins>
   <civix>
     <namespace>CRM/MessageAdmin</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
 </extension>

--- a/ext/oembed/info.xml
+++ b/ext/oembed/info.xml
@@ -33,16 +33,16 @@
   </requires>
   <civix>
     <namespace>CRM/Oembed</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
     <angularModule>crmOembed</angularModule>
   </civix>
   <mixins>
     <mixin>mgd-php@1.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
-    <mixin>smarty-v2@1.0.1</mixin>
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>scan-classes@1.0.0</mixin>
     <mixin>setting-admin@1.0.1</mixin>
     <mixin>ang-php@1.0.0</mixin>
+    <mixin>smarty@1.0.3</mixin>
   </mixins>
 </extension>

--- a/ext/payflowpro/info.xml
+++ b/ext/payflowpro/info.xml
@@ -30,6 +30,6 @@
   </mixins>
   <civix>
     <namespace>CRM/Payflowpro</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
 </extension>

--- a/ext/recaptcha/info.xml
+++ b/ext/recaptcha/info.xml
@@ -26,14 +26,14 @@
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
   <mixins>
-    <mixin>setting-admin@1.0.0</mixin>
+    <mixin>setting-admin@1.0.1</mixin>
     <mixin>setting-php@1.0.0</mixin>
     <mixin>ang-php@1.0.0</mixin>
     <mixin>scan-classes@1.0.0</mixin>
-    <mixin>smarty@1.0.0</mixin>
+    <mixin>smarty@1.0.3</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Recaptcha</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
 </extension>

--- a/ext/riverlea/info.xml
+++ b/ext/riverlea/info.xml
@@ -23,7 +23,7 @@
   </classloader>
   <civix>
     <namespace>CRM/riverlea</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
   <mixins>
     <mixin>theme-php@1.0.0</mixin>

--- a/ext/scheduled_communications/info.xml
+++ b/ext/scheduled_communications/info.xml
@@ -25,7 +25,7 @@
   </classloader>
   <civix>
     <namespace>CRM/ScheduledCommunications</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
     <angularModule>crmScheduledCommunications</angularModule>
   </civix>
   <mixins>

--- a/ext/search_kit/info.xml
+++ b/ext/search_kit/info.xml
@@ -35,10 +35,10 @@
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>mgd-php@1.0.0</mixin>
     <mixin>entity-types-php@2.0.0</mixin>
-    <mixin>smarty@1.0.0</mixin>
+    <mixin>smarty@1.0.3</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Search</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
 </extension>

--- a/ext/search_kit_reports/info.xml
+++ b/ext/search_kit_reports/info.xml
@@ -30,7 +30,7 @@
   </classloader>
   <civix>
     <namespace>CRM/SearchKitReports</namespace>
-    <format>24.09.1</format>
+    <format>25.01.1</format>
     <angularModule>crmSearchKitReports</angularModule>
   </civix>
   <mixins>

--- a/ext/sequentialcreditnotes/info.xml
+++ b/ext/sequentialcreditnotes/info.xml
@@ -28,7 +28,7 @@
   </mixins>
   <civix>
     <namespace>CRM/Sequentialcreditnotes</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/ext/standaloneusers/info.xml
+++ b/ext/standaloneusers/info.xml
@@ -32,7 +32,7 @@
   </classloader>
   <civix>
     <namespace>CRM/Standaloneusers</namespace>
-    <format>24.09.1</format>
+    <format>25.01.1</format>
     <angularModule>crmStandaloneusers</angularModule>
   </civix>
   <mixins>

--- a/ext/tellafriend/info.xml
+++ b/ext/tellafriend/info.xml
@@ -29,10 +29,10 @@
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>mgd-php@1.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
-    <mixin>smarty-v2@1.0.1</mixin>
+    <mixin>smarty@1.0.3</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Friend</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
 </extension>

--- a/ext/user_dashboard/info.xml
+++ b/ext/user_dashboard/info.xml
@@ -27,7 +27,7 @@
   </classloader>
   <civix>
     <namespace>CRM/UserDashboard</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
     <angularModule>crmUserDashboard</angularModule>
   </civix>
   <mixins>


### PR DESCRIPTION
Overview
----------------------------------------
Ran `civix upgrade` on all core extensions except for "oauth-client" which needs converting to EFv2.

It all went fine except for a civilint error, fixed with https://github.com/totten/civix/pull/389