### PR TITLE
Fix Inherited Memberships To Respect Multiple Qualifying Relationships

### DIFF
--- a/CRM/Member/Utils/RelationshipProcessor.php
+++ b/CRM/Member/Utils/RelationshipProcessor.php
@@ -54,12 +54,15 @@ class CRM_Member_Utils_RelationshipProcessor {
    *
    * @param int $contactID
    *
+   * @param array $membershipTypeIds
+   *
    * @return array
    */
-  public function getRelationshipMembershipsForContact(int $contactID):array {
+  public function getRelationshipMembershipsForContact(int $contactID, array $membershipTypeIds = []):array {
     $memberships = [];
     foreach ($this->memberships as $id => $membership) {
-      if ((int) $membership['contact_id'] === $contactID) {
+      if ((int) $membership['contact_id'] === $contactID &&
+        (in_array($membership['membership_type_id'], $membershipTypeIds) || empty($membershipTypeIds))) {
         $memberships[$id] = $membership;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Currently there are below mentioned issues related to relationships and inherited memberships

- When a membership type has multiple relationships enabled to inherit, and an individual has multiple relationships with the organisation that are enabled for inheriting and when user edits one of the relationships, and add an end date in the past relationship gets inactive which is correct, but the inherited membership gets removed which is incorrect as there is still one qualifying active relationship.
- Then when user edits the second relationship and adds an end date in the past and save, relationship gets inactive which is correct, but the inherited membership will be added back which is incorrect as at this point there is no qualifying active relationship.
- When there are two membership types that has one relationships each enabled to inherit and user creates an organisation with both these memberships and create both of the relationships between an individual and the organisation then inherited memberships are created for individual but when user edits one of the relationships, and add an end date in the past the relationship gets inactive which is correct, but both the memberships gets removed from individual whereas only one should get removed.

This pr solves this issue as per below rules

- When a relationship is ended and if that relationship type provides any memberships by relationship and is the only relationship type which is proving that membership by relationship then the relevant membership (and only that membership) by relationship is ended.
- If however there are other relationship types that provide that membership by relationship those membership should not end plus if there are other memberships provided by other relationship types they should not be affected as well.

This is in response to https://lab.civicrm.org/dev/core/-/issues/4788