### PR TITLE
ManagedEntity - Ensure multisite domain entities match on domain_id

### DIFF
--- a/Civi/Managed/MultisiteManaged.php
+++ b/Civi/Managed/MultisiteManaged.php
@@ -55,7 +55,12 @@ class MultisiteManaged extends AutoService implements EventSubscriberInterface {
       if ($index) {
         $copy['name'] .= '_' . $domainId;
       }
+      // Add concrete domain_id to the values
       $copy['params']['values']['domain_id'] = $domainId;
+      // If matching is enabled, ensure we also match on domain_id
+      if (isset($copy['params']['match']) && !in_array('domain_id', $copy['params']['match'])) {
+        $copy['params']['match'][] = 'domain_id';
+      }
       $copies[] = $copy;
     }
     return $copies;

--- a/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
+++ b/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
@@ -675,12 +675,14 @@ class ManagedEntityTest extends TestCase implements HeadlessInterface, Transacti
           'weight' => 50,
           'domain_id' => 'current_domain',
         ],
+        'match' => ['name'],
       ],
     ];
     $managedRecords = [];
     \CRM_Utils_Hook::managed($managedRecords, ['unit.test.fake.ext']);
     $result = \CRM_Utils_Array::findAll($managedRecords, ['module' => 'unit.test.fake.ext', 'name' => 'Navigation_Test_Domains']);
     $this->assertCount(1, $result);
+    $this->assertSame(['name'], $result[0]['params']['match']);
 
     // Enable multisite with multiple domains
     \Civi::settings()->set('is_enabled', TRUE);
@@ -697,11 +699,13 @@ class ManagedEntityTest extends TestCase implements HeadlessInterface, Transacti
     // Base entity should not have been renamed
     $result = \CRM_Utils_Array::findAll($managedRecords, ['module' => 'unit.test.fake.ext', 'name' => 'Navigation_Test_Domains']);
     $this->assertCount(1, $result);
+    $this->assertSame(['name', 'domain_id'], $result[0]['params']['match']);
 
     // New item should have been inserted for extra domains
     foreach (array_slice($allDomains->column('id'), 1) as $domain) {
       $result = \CRM_Utils_Array::findAll($managedRecords, ['module' => 'unit.test.fake.ext', 'name' => 'Navigation_Test_Domains_' . $domain]);
       $this->assertCount(1, $result);
+      $this->assertSame(['name', 'domain_id'], $result[0]['params']['match']);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Followup to [ManagedEntity - Replicate multi-domain entities when multisite is enabled](https://github.com/civicrm/civicrm-core/pull/27876), due to exports not being 100% consistent on this point, we should always match existing records by domain_id if it is a domain-specific entity.
