### PR TITLE
add support for tagging Afforms using an Option Group

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -19,6 +19,12 @@ class AfformAdminMeta {
       ->addWhere('option_group_id:name', '=', 'afform_placement')
       ->addOrderBy('weight')
       ->execute(), 'label', 'value');
+    $afformTags = \CRM_Utils_Array::formatForSelect2((array) \Civi\Api4\OptionValue::get(FALSE)
+      ->addSelect('value', 'label', 'icon', 'description')
+      ->addWhere('is_active', '=', TRUE)
+      ->addWhere('option_group_id:name', '=', 'afform_tags')
+      ->addOrderBy('weight')
+      ->execute(), 'label', 'value');
     $afformTypes = (array) \Civi\Api4\OptionValue::get(FALSE)
       ->addSelect('name', 'label', 'icon')
       ->addWhere('is_active', '=', TRUE)
@@ -38,6 +44,7 @@ class AfformAdminMeta {
     return [
       'afform_type' => $afformTypes,
       'afform_placement' => $afformPlacement,
+      'afform_tags' => $afformTags,
       'search_operators' => \Civi\Afform\Utils::getSearchOperators(),
     ];
   }

--- a/ext/afform/admin/ang/afAdmin.js
+++ b/ext/afform/admin/ang/afAdmin.js
@@ -11,7 +11,7 @@
           // Load data for lists
           afforms: function(crmApi4) {
             return crmApi4('Afform', 'get', {
-              select: ['name', 'title', 'type', 'server_route', 'is_public', 'submission_count', 'submission_date', 'submit_limit', 'submit_enabled', 'submit_currently_open', 'has_local', 'has_base', 'base_module', 'base_module:label', 'placement:label']
+              select: ['name', 'title', 'type', 'server_route', 'is_public', 'submission_count', 'submission_date', 'submit_limit', 'submit_enabled', 'submit_currently_open', 'has_local', 'has_base', 'base_module', 'base_module:label', 'placement:label', 'tags:label']
             });
           }
         }

--- a/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
@@ -25,6 +25,7 @@
     this.afforms = _.transform(afforms, function(afforms, afform) {
       afform.type = afform.type || 'system';
       afform.placement = afform['placement:label'];
+      afform.tags = afform['tags:label'];
       if (afform.submission_date) {
         afform.submission_date = CRM.utils.formatDate(afform.submission_date);
       }

--- a/ext/afform/admin/ang/afAdmin/afAdminList.html
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.html
@@ -75,7 +75,12 @@
         <i class="crm-i fa-sort-{{ $ctrl.sortDir ? 'asc' : 'desc' }}" ng-if="$ctrl.sortField === 'base_module'"></i>
         {{:: ts('Package') }}
       </th>
-      <th></th>
+      <th title="{{:: ts('Click to sort') }}" ng-click="$ctrl.sortBy('tags')">
+        <i class="crm-i fa-sort disabled" ng-if="$ctrl.sortField !== 'tags'"></i>
+        <i class="crm-i fa-sort-{{ $ctrl.sortDir ? 'asc' : 'desc' }}" ng-if="$ctrl.sortField === 'tags'"></i>
+        {{:: ts('Tags') }}
+      </th>
+      <th>{{:: ts('Actions') }}</th>
     </tr>
     </thead>
     <tbody>
@@ -90,7 +95,9 @@
           {{:: afform.server_route }}
         </a>
       </td>
-      <td>{{:: afform.placement.join(', ') }}</td>
+      <td>
+        {{:: afform.placement.join(', ') }}
+      </td>
       <td ng-if="$ctrl.tab === 'form'">
         {{:: afform.submit_currently_open ? ts('Open') : ts('Closed') }}
         <span ng-if="afform.submit_limit && afform.submit_enabled">
@@ -107,6 +114,9 @@
       </td>
       <td>
         {{:: afform['base_module:label'] }}
+      </td>
+      <td>
+        {{:: afform.tags.join(', ') }}
       </td>
       <td class="text-right">
         <a ng-if="afform.type !== 'system'" ng-href="#/edit/{{:: afform.name }}" class="btn btn-xs btn-primary">{{:: ts('Edit') }}</a>

--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -91,6 +91,14 @@
       <p class="help-block">{{:: ts('Additional contexts in which the form can be embedded') }}</p>
     </div>
 
+    <div class="form-group">
+      <label for="afform_tags">
+        {{:: ts('Tags') }}
+      </label>
+      <input ng-list crm-ui-select="{multiple: true, data: editor.meta.afform_tags, placeholder: ts('None')}" class="form-control" id="afform_tags" ng-model="editor.afform.tags">
+      <p class="help-block">{{:: ts('Tags can be used to keep track of your forms') }}</p>
+    </div>
+
     <div class="form-group" ng-if="editor.afform.placement.includes('contact_summary_block') || editor.afform.placement.includes('contact_summary_tab')">
       <div class="form-inline">
         <label for="afform_summary_contact_type">{{:: ts('For') }}</label>

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -185,6 +185,13 @@ class Afform extends Generic\AbstractEntity {
           'data_type' => 'Array',
         ],
         [
+          'name' => 'tags',
+          'title' => E::ts('Tags'),
+          'pseudoconstant' => ['optionGroupName' => 'afform_tags'],
+          'data_type' => 'Array',
+          'input_type' => 'Select',
+        ],
+        [
           'name' => 'summary_contact_type',
           'title' => E::ts('Summary Contact Type'),
           'data_type' => 'Array',

--- a/ext/afform/core/managed/AfformTags.mgd.php
+++ b/ext/afform/core/managed/AfformTags.mgd.php
@@ -1,0 +1,50 @@
+<?php
+
+use CRM_Afform_ExtensionUtil as E;
+
+// Option group for Afform.tags field
+return [
+  [
+    'name' => 'AfformTags',
+    'entity' => 'OptionGroup',
+    'update' => 'always',
+    'cleanup' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'afform_tags',
+        'title' => E::ts('Afform Tags'),
+        'is_reserved' => TRUE,
+        'is_active' => TRUE,
+        'option_value_fields' => [
+          'name',
+          'label',
+          'icon',
+          'description',
+          'color',
+        ],
+      ],
+      'match' => ['name'],
+    ],
+  ],
+  [
+    'name' => 'AfformTags:donor_journey',
+    'entity' => 'OptionValue',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'option_group_id.name' => 'afform_tags',
+        'name' => 'donor_journey',
+        'value' => 'donor_journey',
+        'label' => E::ts('Donor Journey'),
+        'is_reserved' => FALSE,
+        'is_active' => TRUE,
+        'icon' => 'fa-coins',
+        'description' => E::ts('Forms relating to donor journey.'),
+      ],
+      'match' => ['option_group_id', 'name'],
+    ],
+  ],
+];

--- a/ext/search_kit_reports/ang/afsearchSearchKitReports.aff.html
+++ b/ext/search_kit_reports/ang/afsearchSearchKitReports.aff.html
@@ -3,6 +3,7 @@
     <af-field name="title" />
     <af-field name="description" />
     <af-field name="base_module" defn="{input_attrs: {multiple: true}}" />
+    <af-field name="tags" defn="{search_operator: 'CONTAINS', input_attrs: {}, label: 'Tag'}" />
   </div>
   <crm-search-display-table search-name="SearchKit_Reports" display-name="SearchKit_Reports_Table"></crm-search-display-table>
 </div>

--- a/ext/search_kit_reports/managed/SavedSearch_SearchKit_Reports.mgd.php
+++ b/ext/search_kit_reports/managed/SavedSearch_SearchKit_Reports.mgd.php
@@ -21,6 +21,7 @@ return [
             'description',
             'placement:label',
             'server_route',
+            'tags:label',
           ],
           'orderBy' => [],
           'where' => [
@@ -69,13 +70,20 @@ return [
               'sortable' => TRUE,
             ],
             [
+              'type' => 'field',
+              'key' => 'tags:label',
+              'dataType' => 'Array',
+              'label' => E::ts('Tags'),
+              'sortable' => TRUE,
+            ],
+            [
               'size' => 'btn-xs',
               'links' => [
                 [
-                  'path' => '[server_route]',
-                  'icon' => 'fa-external-link',
-                  'text' => E::ts('Open'),
-                  'style' => 'info',
+                  'path' => 'civicrm/admin/afform#/edit/[name]',
+                  'icon' => 'fa-pen-to-square',
+                  'text' => E::ts('Edit'),
+                  'style' => 'warning',
                   'condition' => [],
                   'task' => '',
                   'entity' => '',
@@ -84,10 +92,10 @@ return [
                   'target' => '',
                 ],
                 [
-                  'path' => 'civicrm/admin/afform#/edit/[name]',
-                  'icon' => 'fa-pen-to-square',
-                  'text' => E::ts('Edit'),
-                  'style' => 'warning',
+                  'path' => '[server_route]',
+                  'icon' => 'fa-external-link',
+                  'text' => E::ts('Open'),
+                  'style' => 'info',
                   'condition' => [],
                   'task' => '',
                   'entity' => '',


### PR DESCRIPTION
Overview
----------------------------------------
Adds the ability to tag afforms with values from an OptionGroup

Before
----------------------------------------
- no tagging for Afforms

After
----------------------------------------
- OptionGroup called `afform_tags`
- `tags` field on the Afform entity
- Tags can be added to an afform from the FormBuilder edit screen
- Tags are displayed in the FormBuilder form listing, and in the Search Kit Reports report listing
- In the SearchKit Reports listing, tags can be used to filter the listing

Technical Details
----------------------------------------
It would be nice if these were in-place editable -- but in place edit doesn't seem to work for Afform search kits because it doesn't have a numeric `rowKey`

It would be nice if the FormBuilder listing had a field to filter by tag - but I think it would be best to convert this whole screen to use searchkit rather than bespoke angular listing before adding that.

This implementation uses an option group. There's no clear/nice UI for adding values to that option group. Alternative using the `civicrm_tag` table incoming, which has the advantage of adding this UI.

