### PR TITLE
dev/core#5654 add support for tagging Afforms using Tag entity

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -19,6 +19,12 @@ class AfformAdminMeta {
       ->addWhere('option_group_id:name', '=', 'afform_placement')
       ->addOrderBy('weight')
       ->execute(), 'label', 'value');
+    $afformTags = \CRM_Utils_Array::formatForSelect2((array) \Civi\Api4\OptionValue::get(FALSE)
+      ->addSelect('value', 'label', 'icon', 'description')
+      ->addWhere('is_active', '=', TRUE)
+      ->addWhere('option_group_id:name', '=', 'afform_tags')
+      ->addOrderBy('weight')
+      ->execute(), 'label', 'value');
     $afformTypes = (array) \Civi\Api4\OptionValue::get(FALSE)
       ->addSelect('name', 'label', 'icon')
       ->addWhere('is_active', '=', TRUE)
@@ -38,6 +44,7 @@ class AfformAdminMeta {
     return [
       'afform_type' => $afformTypes,
       'afform_placement' => $afformPlacement,
+      'afform_tags' => $afformTags,
       'search_operators' => \Civi\Afform\Utils::getSearchOperators(),
     ];
   }

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -19,12 +19,7 @@ class AfformAdminMeta {
       ->addWhere('option_group_id:name', '=', 'afform_placement')
       ->addOrderBy('weight')
       ->execute(), 'label', 'value');
-    $afformTags = \CRM_Utils_Array::formatForSelect2((array) \Civi\Api4\OptionValue::get(FALSE)
-      ->addSelect('value', 'label', 'icon', 'description')
-      ->addWhere('is_active', '=', TRUE)
-      ->addWhere('option_group_id:name', '=', 'afform_tags')
-      ->addOrderBy('weight')
-      ->execute(), 'label', 'value');
+    $afformTags = \CRM_Utils_Array::formatForSelect2((array) \Civi\Api4\Utils\AfformTags::getTagOptions());
     $afformTypes = (array) \Civi\Api4\OptionValue::get(FALSE)
       ->addSelect('name', 'label', 'icon')
       ->addWhere('is_active', '=', TRUE)

--- a/ext/afform/admin/ang/afAdmin.js
+++ b/ext/afform/admin/ang/afAdmin.js
@@ -11,7 +11,7 @@
           // Load data for lists
           afforms: function(crmApi4) {
             return crmApi4('Afform', 'get', {
-              select: ['name', 'title', 'type', 'server_route', 'is_public', 'submission_count', 'submission_date', 'submit_limit', 'submit_enabled', 'submit_currently_open', 'has_local', 'has_base', 'base_module', 'base_module:label', 'placement:label']
+              select: ['name', 'title', 'type', 'server_route', 'is_public', 'submission_count', 'submission_date', 'submit_limit', 'submit_enabled', 'submit_currently_open', 'has_local', 'has_base', 'base_module', 'base_module:label', 'placement:label', 'tags:label']
             });
           }
         }

--- a/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
@@ -25,6 +25,7 @@
     this.afforms = _.transform(afforms, function(afforms, afform) {
       afform.type = afform.type || 'system';
       afform.placement = afform['placement:label'];
+      afform.tags = afform['tags:label'];
       if (afform.submission_date) {
         afform.submission_date = CRM.utils.formatDate(afform.submission_date);
       }

--- a/ext/afform/admin/ang/afAdmin/afAdminList.html
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.html
@@ -75,7 +75,12 @@
         <i class="crm-i fa-sort-{{ $ctrl.sortDir ? 'asc' : 'desc' }}" ng-if="$ctrl.sortField === 'base_module'"></i>
         {{:: ts('Package') }}
       </th>
-      <th></th>
+      <th title="{{:: ts('Click to sort') }}" ng-click="$ctrl.sortBy('tags')">
+        <i class="crm-i fa-sort disabled" ng-if="$ctrl.sortField !== 'tags'"></i>
+        <i class="crm-i fa-sort-{{ $ctrl.sortDir ? 'asc' : 'desc' }}" ng-if="$ctrl.sortField === 'tags'"></i>
+        {{:: ts('Tags') }}
+      </th>
+      <th>{{:: ts('Actions') }}</th>
     </tr>
     </thead>
     <tbody>
@@ -90,7 +95,9 @@
           {{:: afform.server_route }}
         </a>
       </td>
-      <td>{{:: afform.placement.join(', ') }}</td>
+      <td>
+        {{:: afform.placement.join(', ') }}
+      </td>
       <td ng-if="$ctrl.tab === 'form'">
         {{:: afform.submit_currently_open ? ts('Open') : ts('Closed') }}
         <span ng-if="afform.submit_limit && afform.submit_enabled">
@@ -107,6 +114,9 @@
       </td>
       <td>
         {{:: afform['base_module:label'] }}
+      </td>
+      <td>
+        {{:: afform.tags.join(', ') }}
       </td>
       <td class="text-right">
         <a ng-if="afform.type !== 'system'" ng-href="#/edit/{{:: afform.name }}" class="btn btn-xs btn-primary">{{:: ts('Edit') }}</a>

--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -89,7 +89,7 @@
       </label>
       <input ng-list crm-ui-select="{multiple: true, data: editor.meta.afform_placement, placeholder: ts('None')}" class="form-control" id="afform_placement" ng-model="editor.afform.placement" ng-change="editor.onChangePlacement()">
       <p class="help-block" ng-if="editor.afform.server_route || !editor.placementRequiresServerRoute()">
-        {{:: ts('Additional contexts in which the form can be embedded') }}
+        {{:: ts('Additional contexts in which the form can be embedded.') }}
       </p>
       <p class="text-warning" ng-if="!editor.afform.server_route && editor.placementRequiresServerRoute()">
         <i class="crm-i fa-exclamation-triangle"></i>{{ ts('%1 placement requires a page route.', {1: editor.placementRequiresServerRoute()}) }}

--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -101,7 +101,7 @@
         {{:: ts('Tags') }}
       </label>
       <input ng-list crm-ui-select="{multiple: true, data: editor.meta.afform_tags, placeholder: ts('None')}" class="form-control" id="afform_tags" ng-model="editor.afform.tags">
-      <p class="help-block">{{:: ts('Tags can be used to keep track of your forms') }}</p>
+      <p class="help-block">{{:: ts('Tags can be used to keep track of your forms if Used For is set to include Afform.') }} <a target="_blank" href="/civicrm/tag?reset=1">{{:: ts('Manage Tags') }}</a></p>
     </div>
 
     <div class="form-group" ng-if="editor.isContactSummary()">

--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -96,6 +96,14 @@
       </p>
     </div>
 
+    <div class="form-group">
+      <label for="afform_tags">
+        {{:: ts('Tags') }}
+      </label>
+      <input ng-list crm-ui-select="{multiple: true, data: editor.meta.afform_tags, placeholder: ts('None')}" class="form-control" id="afform_tags" ng-model="editor.afform.tags">
+      <p class="help-block">{{:: ts('Tags can be used to keep track of your forms') }}</p>
+    </div>
+
     <div class="form-group" ng-if="editor.isContactSummary()">
       <div class="form-inline">
         <label for="afform_summary_contact_type">{{:: ts('For') }}</label>

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -194,6 +194,13 @@ class Afform extends Generic\AbstractEntity {
           'data_type' => 'Array',
         ],
         [
+          'name' => 'tags',
+          'title' => E::ts('Tags'),
+          'pseudoconstant' => ['optionGroupName' => 'afform_tags'],
+          'data_type' => 'Array',
+          'input_type' => 'Select',
+        ],
+        [
           'name' => 'summary_contact_type',
           'title' => E::ts('Summary Contact Type'),
           'data_type' => 'Array',

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -196,7 +196,9 @@ class Afform extends Generic\AbstractEntity {
         [
           'name' => 'tags',
           'title' => E::ts('Tags'),
-          'pseudoconstant' => ['optionGroupName' => 'afform_tags'],
+          'pseudoconstant' => [
+            'callback' => [Utils\AfformTags::class, 'getTagOptions'],
+          ],
           'data_type' => 'Array',
           'input_type' => 'Select',
         ],

--- a/ext/afform/core/Civi/Api4/Utils/AfformTags.php
+++ b/ext/afform/core/Civi/Api4/Utils/AfformTags.php
@@ -1,0 +1,34 @@
+<?php
+namespace Civi\Api4\Utils;
+
+/**
+ * Class AfformTags
+ * @package Civi\Api4\Utils
+ *
+ * Utils for managing the tags field on Afforms
+ *
+ */
+class AfformTags {
+
+  /**
+   * @return array
+   */
+  public static function getTagOptions(): array {
+    $tagRecords = (array) \Civi\Api4\Tag::get(FALSE)
+      ->addSelect('name', 'label', 'description', 'color')
+      ->addWhere('used_for', 'CONTAINS', 'Afform')
+      ->addWhere('is_selectable', '=', TRUE)
+      ->execute();
+
+    $tagOptions = [];
+
+    // prefer tag names to keys for portability
+    foreach ($tagRecords as $record) {
+      $record['id'] = $record['name'];
+      $tagOptions[] = $record;
+    }
+
+    return $tagOptions;
+  }
+
+}

--- a/ext/afform/core/managed/AfformTags.mgd.php
+++ b/ext/afform/core/managed/AfformTags.mgd.php
@@ -1,0 +1,50 @@
+<?php
+
+use CRM_Afform_ExtensionUtil as E;
+
+// Option group for Afform.tags field
+return [
+  [
+    'name' => 'AfformTags',
+    'entity' => 'OptionGroup',
+    'update' => 'always',
+    'cleanup' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'afform_tags',
+        'title' => E::ts('Afform Tags'),
+        'is_reserved' => TRUE,
+        'is_active' => TRUE,
+        'option_value_fields' => [
+          'name',
+          'label',
+          'icon',
+          'description',
+          'color',
+        ],
+      ],
+      'match' => ['name'],
+    ],
+  ],
+  [
+    'name' => 'AfformTags:donor_journey',
+    'entity' => 'OptionValue',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'option_group_id.name' => 'afform_tags',
+        'name' => 'donor_journey',
+        'value' => 'donor_journey',
+        'label' => E::ts('Donor Journey'),
+        'is_reserved' => FALSE,
+        'is_active' => TRUE,
+        'icon' => 'fa-coins',
+        'description' => E::ts('Forms relating to donor journey.'),
+      ],
+      'match' => ['option_group_id', 'name'],
+    ],
+  ],
+];

--- a/ext/afform/core/managed/AfformTags.mgd.php
+++ b/ext/afform/core/managed/AfformTags.mgd.php
@@ -2,47 +2,27 @@
 
 use CRM_Afform_ExtensionUtil as E;
 
-// Option group for Afform.tags field
+// This file:
+// - adds option value to `tag_used_for`, allowing Afforms to be tagged
+//   NOTE: this is unusual in that afform is not a db entity
+//   (normally the value normally corresponds to a physical table name in the
+//   database - here it is just the entity name)
 return [
   [
-    'name' => 'AfformTags',
-    'entity' => 'OptionGroup',
-    'update' => 'always',
+    'name' => 'AfformTags:tag_used_for',
+    'entity' => 'OptionValue',
     'cleanup' => 'always',
+    'update' => 'always',
     'params' => [
       'version' => 4,
       'values' => [
-        'name' => 'afform_tags',
-        'title' => E::ts('Afform Tags'),
+        'option_group_id.name' => 'tag_used_for',
+        'value' => 'Afform',
+        'name' => 'Afform',
+        'label' => E::ts('Afforms'),
         'is_reserved' => TRUE,
         'is_active' => TRUE,
-        'option_value_fields' => [
-          'name',
-          'label',
-          'icon',
-          'description',
-          'color',
-        ],
-      ],
-      'match' => ['name'],
-    ],
-  ],
-  [
-    'name' => 'AfformTags:donor_journey',
-    'entity' => 'OptionValue',
-    'cleanup' => 'unused',
-    'update' => 'unmodified',
-    'params' => [
-      'version' => 4,
-      'values' => [
-        'option_group_id.name' => 'afform_tags',
-        'name' => 'donor_journey',
-        'value' => 'donor_journey',
-        'label' => E::ts('Donor Journey'),
-        'is_reserved' => FALSE,
-        'is_active' => TRUE,
-        'icon' => 'fa-coins',
-        'description' => E::ts('Forms relating to donor journey.'),
+        'domain_id' => NULL,
       ],
       'match' => ['option_group_id', 'name'],
     ],

--- a/ext/afform/core/managed/AfformTags.mgd.php
+++ b/ext/afform/core/managed/AfformTags.mgd.php
@@ -22,7 +22,8 @@ return [
         'label' => E::ts('Afforms'),
         'is_reserved' => TRUE,
         'is_active' => TRUE,
-        'domain_id' => NULL,
+        // this excludes it from being selected in EntityTag entity_table
+        'filter' => 1,
       ],
       'match' => ['option_group_id', 'name'],
     ],

--- a/ext/search_kit_reports/ang/afsearchSearchKitReports.aff.html
+++ b/ext/search_kit_reports/ang/afsearchSearchKitReports.aff.html
@@ -3,6 +3,7 @@
     <af-field name="title" />
     <af-field name="description" />
     <af-field name="base_module" defn="{input_attrs: {multiple: true}}" />
+    <af-field name="tags" defn="{search_operator: 'CONTAINS', input_attrs: {}, label: 'Tag'}" />
   </div>
   <crm-search-display-table search-name="SearchKit_Reports" display-name="SearchKit_Reports_Table"></crm-search-display-table>
 </div>

--- a/ext/search_kit_reports/managed/SavedSearch_SearchKit_Reports.mgd.php
+++ b/ext/search_kit_reports/managed/SavedSearch_SearchKit_Reports.mgd.php
@@ -21,6 +21,7 @@ return [
             'description',
             'placement:label',
             'server_route',
+            'tags:label',
           ],
           'orderBy' => [],
           'where' => [
@@ -69,13 +70,20 @@ return [
               'sortable' => TRUE,
             ],
             [
+              'type' => 'field',
+              'key' => 'tags:label',
+              'dataType' => 'Array',
+              'label' => E::ts('Tags'),
+              'sortable' => TRUE,
+            ],
+            [
               'size' => 'btn-xs',
               'links' => [
                 [
-                  'path' => '[server_route]',
-                  'icon' => 'fa-external-link',
-                  'text' => E::ts('Open'),
-                  'style' => 'info',
+                  'path' => 'civicrm/admin/afform#/edit/[name]',
+                  'icon' => 'fa-pen-to-square',
+                  'text' => E::ts('Edit'),
+                  'style' => 'warning',
                   'condition' => [],
                   'task' => '',
                   'entity' => '',
@@ -84,10 +92,10 @@ return [
                   'target' => '',
                 ],
                 [
-                  'path' => 'civicrm/admin/afform#/edit/[name]',
-                  'icon' => 'fa-pen-to-square',
-                  'text' => E::ts('Edit'),
-                  'style' => 'warning',
+                  'path' => '[server_route]',
+                  'icon' => 'fa-external-link',
+                  'text' => E::ts('Open'),
+                  'style' => 'info',
                   'condition' => [],
                   'task' => '',
                   'entity' => '',

--- a/schema/Core/EntityTag.entityType.php
+++ b/schema/Core/EntityTag.entityType.php
@@ -41,6 +41,8 @@ return [
       'add' => '3.2',
       'pseudoconstant' => [
         'option_group_name' => 'tag_used_for',
+        // exclude taggable entities without tables (that therefore dont use EntityTable)
+        'condition' => 'filter = 0',
       ],
     ],
     'entity_id' => [

--- a/tests/phpunit/api/v3/EntityTagACLTest.php
+++ b/tests/phpunit/api/v3/EntityTagACLTest.php
@@ -76,7 +76,7 @@ class api_v3_EntityTagACLTest extends CiviUnitTestCase {
    * @return array
    */
   public function getTagOptions() {
-    $options = $this->callAPISuccess('Tag', 'getoptions', ['field' => 'used_for']);
+    $options = $this->callAPISuccess('EntityTag', 'getoptions', ['field' => 'entity_table']);
     return $options['values'];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Adds the ability to tag afforms with Tags (from `civicrm_tag` table).

Alternative to https://github.com/civicrm/civicrm-core/pull/31889


Before
----------------------------------------
- no tagging for Afforms

After
----------------------------------------
- everything in https://github.com/civicrm/civicrm-core/pull/31889
- EXCEPT not using an option group, but allowing Tags to be "used_for" Afforms

Technical Details
----------------------------------------
This implementation uses the `civicrm_tag` table.

The advantage over https://github.com/civicrm/civicrm-core/pull/31889 is we have a nice UI for managing tags, and tags can be reused (e.g. for activities and forms)

On the flipside, this might be a slightly deviant usage of tags, because the `used_for` field generally expects a table name in order to create db table joins between tagged entities and tags, using the EntityTag bridge (with a dynamic FK `entity_table` and `entity_id`). In this case Afform is not a db entity, so cannot be referenced in this way - the values are just being loaded into a pseudoconstant, and then serialized in the Afform meta.

However - I feel like this might be legitimate for tags in an Api4 world - ie the key thing for tags is they reference an entity. If this is a DB entity then great, we get stuff for handling the DB queries out of the box. If not there is a bit more flexibility/work to do in how a BasicEntity uses the tags.

