### PR TITLE
UFField: remove unclear field_name check

### DIFF
--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -55,11 +55,6 @@ class CRM_Core_BAO_UFField extends CRM_Core_DAO_UFField implements \Civi\Core\Ho
       }
     }
 
-    // Validate field_name
-    if (strpos($params['field_name'], 'formatting') !== 0 && !CRM_Core_BAO_UFField::isValidFieldName($params['field_name'])) {
-      throw new CRM_Core_Exception('The field_name is not valid');
-    }
-
     // Supply default label if not set
     if (empty($id) && !isset($params['label'])) {
       $params['label'] = self::getAvailableFieldTitles()[$params['field_name']];


### PR DESCRIPTION
Overview
----------------------------------------

Removes a `field_name` validation rule in the BAO/create function.

It is not clear what is the purpose of the check and it can fail mysteriously. See also: https://lab.civicrm.org/extensions/fixoptiontranslations/-/issues/5

These kind of validations do not seem to be consistent. Sometimes they are in the form layer, sometimes in the BAO. It's also not clear what they are for: sometimes they validate if the name already exists (like in this case) - not if it's munged correctly, why doesn't it handle new vs update? Is `field_name` unique across Profile Groups? etc.

In this specific case, admins are not very likely to shoot themselves in the foot because UF Field `field_name` is not based on user-input, but a select list.

Before
----------------------------------------

Enabling the `fixoptiontranslations` fails with ` The field_name is not valid` while attempting to run the equivalent of:

```
 \Civi\Api4\UFField::update(FALSE)
  ->addValue('label', "Statut de participant")
  ->addWhere('id', '=', 11)
  ->execute();
```

After
----------------------------------------

No fatal.

Technical Details
----------------------------------------

I ran in circles trying to find other ways to reproduce this, such as when using the API explorer for a single update. Also tried removing the static cache in `getAvailableFieldsFlat`.

Sometimes running `cv php:eval 'CRM_Fixoptiontranslations_Utils::updateOptions();' -vvv` would eventually work, but then crash on another UFField update. It didn't crash systematically, only maybe on 10% of updates.

One theory is that it is because `getAvailableFields` calls functions such as `CRM_Core_Permission::access('CiviEvent')` to determine whether to list a field or not. Presumably this would mean that `fixoptiontranslations` would fail if the component is disabled, but the components were enabled on the sites I tested. And even if the component was disabled, it should not crash.

I cannot reproduce the error  when using the API Explorer, but I did find some support requests, such as : https://civicrm.stackexchange.com/questions/41386/creating-uffield-using-api-error-with-field-name