### PR TITLE
dev/core#5387 add CiviCRM Maintenance Mode

### DIFF
--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -24,6 +24,19 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
    */
   public function run() {
     $response = [];
+
+    if (\CRM_Utils_System::isMaintenanceMode()) {
+      if (!CRM_Core_Permission::check(['bypass maintenance mode'])) {
+        // HTTP 503 Service Unavailable
+        $this->httpResponseCode = 503;
+        $this->returnJSON([
+          'status_code' => 503,
+          'status_message' => 'Temporarily unavailable for maintenance.',
+        ]);
+        return;
+      }
+    }
+
     // `$this->urlPath` contains the http request path as an exploded array.
     // Path for single calls is `civicrm/ajax/api4/Entity/action` with `params` passed to $_REQUEST
     // or for multiple calls the path is `civicrm/ajax/api4` with `calls` passed to $_POST

--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -26,7 +26,7 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
     $response = [];
 
     if (\CRM_Utils_System::isMaintenanceMode()) {
-      if (!CRM_Core_Permission::check(['bypass maintenance mode'])) {
+      if (!CRM_Core_Permission::check([['administer CiviCRM system', 'cms:bypass maintenance mode']])) {
         // HTTP 503 Service Unavailable
         $this->httpResponseCode = 503;
         $this->returnJSON([

--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -25,7 +25,7 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
   public function run() {
     $response = [];
 
-    if (\CRM_Utils_System::isMaintenanceMode()) {
+    if (\CRM_Utils_System::isMaintenanceMode() && ($this->urlPath[3] ?? NULL) !== 'User') {
       if (!CRM_Core_Permission::check([['administer CiviCRM system', 'cms:bypass maintenance mode']])) {
         // HTTP 503 Service Unavailable
         $this->httpResponseCode = 503;

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -357,6 +357,8 @@ class CRM_Core_Invoke {
   /**
    * Show status in the footer (admin only)
    *
+   * If in Maintenance Mode, display a message to user
+   *
    * @param CRM_Core_Smarty $template
    */
   public static function statusCheck($template) {
@@ -367,6 +369,14 @@ class CRM_Core_Invoke {
     $status = Civi::cache('checks')->get('systemStatusCheckResult');
     $template->assign('footer_status_severity', $status);
     $template->assign('footer_status_message', CRM_Utils_Check::toStatusLabel($status));
+
+    // show user a warning if CiviCRM is in explicit maintenance mode
+    // NOTE: if maintenance mode is inherited from the CMS, we expect the CMS
+    // to issue its own warning
+    $coreMaintenanceMode = \Civi::settings()->get('core_maintenance_mode');
+    if ($coreMaintenanceMode && ($coreMaintenanceMode !== 'inherit')) {
+      \CRM_Core_Session::setStatus(ts('CiviCRM is currently in maintenance mode. To deactivate, update the <code>core_maintenance_mode</code> setting.'), ts('Maintenance Mode'), 'warning');
+    }
   }
 
   /**

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -853,6 +853,10 @@ class CRM_Core_Permission {
         'label' => $prefix . ts('access AJAX API'),
         'description' => ts('Allow API access even if Access CiviCRM is not granted'),
       ],
+      'bypass maintenance mode' => [
+        'label' => $prefix . ts('Bypass Maintenance Mode'),
+        'description' => ts('Allow to bypass maintenance mode checks - e.g. when using AJAX API'),
+      ],
       'access contact reference fields' => [
         'label' => $prefix . ts('access contact reference fields'),
         'description' => ts('Allow entering data into contact reference fields'),

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -853,10 +853,6 @@ class CRM_Core_Permission {
         'label' => $prefix . ts('access AJAX API'),
         'description' => ts('Allow API access even if Access CiviCRM is not granted'),
       ],
-      'bypass maintenance mode' => [
-        'label' => $prefix . ts('Bypass Maintenance Mode'),
-        'description' => ts('Allow to bypass maintenance mode checks - e.g. when using AJAX API'),
-      ],
       'access contact reference fields' => [
         'label' => $prefix . ts('access contact reference fields'),
         'description' => ts('Allow entering data into contact reference fields'),
@@ -972,7 +968,6 @@ class CRM_Core_Permission {
         'label' => $prefix . ts('administer CiviCRM System'),
         'description' => ts('Perform all system administration tasks in CiviCRM'),
         'implies' => [
-          'bypass maintenance mode',
           'edit system workflow message templates',
         ],
       ],

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -972,6 +972,7 @@ class CRM_Core_Permission {
         'label' => $prefix . ts('administer CiviCRM System'),
         'description' => ts('Perform all system administration tasks in CiviCRM'),
         'implies' => [
+          'bypass maintenance mode',
           'edit system workflow message templates',
         ],
       ],

--- a/CRM/Core/Permission/Backdrop.php
+++ b/CRM/Core/Permission/Backdrop.php
@@ -59,6 +59,7 @@ class CRM_Core_Permission_Backdrop extends CRM_Core_Permission_DrupalBase {
     $str = $this->translatePermission($str, 'Drupal', [
       'view user account' => 'access user profiles',
       'administer users' => 'administer users',
+      'bypass maintenance mode' => 'access site in maintenance mode',
     ]);
     if ($str == CRM_Core_Permission::ALWAYS_DENY_PERMISSION) {
       return FALSE;

--- a/CRM/Core/Permission/Base.php
+++ b/CRM/Core/Permission/Base.php
@@ -322,6 +322,11 @@ class CRM_Core_Permission_Base {
         'description' => ts('Administer user accounts. (Synthetic permission - adapts to local CMS)'),
         'is_synthetic' => TRUE,
       ],
+      'cms:bypass maintenance mode' => [
+        'label' => ts('CMS') . ': ' . ts('Bypass maintenance mode'),
+        'description' => ts('Allow to bypass maintenance mode checks - e.g. when using AJAX API'),
+        'is_synthetic' => TRUE,
+      ],
     ];
   }
 

--- a/CRM/Core/Permission/Drupal.php
+++ b/CRM/Core/Permission/Drupal.php
@@ -58,6 +58,7 @@ class CRM_Core_Permission_Drupal extends CRM_Core_Permission_DrupalBase {
     $str = $this->translatePermission($str, 'Drupal', [
       'view user account' => 'access user profiles',
       'administer users' => 'administer users',
+      'bypass maintenance mode' => 'access site in maintenance mode',
     ]);
     if ($str == CRM_Core_Permission::ALWAYS_DENY_PERMISSION) {
       return FALSE;

--- a/CRM/Core/Permission/Drupal8.php
+++ b/CRM/Core/Permission/Drupal8.php
@@ -34,6 +34,7 @@ class CRM_Core_Permission_Drupal8 extends CRM_Core_Permission_DrupalBase {
     $str = $this->translatePermission($str, 'Drupal', [
       'view user account' => 'access user profiles',
       'administer users' => 'administer users',
+      'bypass maintenance mode' => 'access site in maintenance mode',
     ]);
 
     if ($str == CRM_Core_Permission::ALWAYS_DENY_PERMISSION) {

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1982,4 +1982,25 @@ class CRM_Utils_System {
     self::sendResponse(new Response(200, [], $message));
   }
 
+  public static function isMaintenanceMode(): bool {
+    try {
+      $civicrmSetting = \Civi::settings()->get('core_maintenance_mode');
+
+      // if CiviCRM setting is set, use that answer
+      if (!is_null($civicrmSetting)) {
+        return (bool) $civicrmSetting;
+      }
+
+      // otherwise ask the userSystem
+      return CRM_Core_Config::singleton()->userSystem->isMaintenanceMode();
+    }
+    catch (\Exception $e) {
+      // catch in case something isn't fully booted and can't answer
+      //
+      // we assume we are *NOT* in maintenance mode. though maybe we
+      // should check a constant / env var / database directly?
+      return FALSE;
+    }
+  }
+
 }

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1986,13 +1986,15 @@ class CRM_Utils_System {
     try {
       $civicrmSetting = \Civi::settings()->get('core_maintenance_mode');
 
-      // if CiviCRM setting is set, use that answer
-      if (!is_null($civicrmSetting)) {
-        return (bool) $civicrmSetting;
+      // inherit => ask the userSystem
+      if ($civicrmSetting === 'inherit') {
+        return CRM_Core_Config::singleton()->userSystem->isMaintenanceMode();
       }
 
-      // otherwise ask the userSystem
-      return CRM_Core_Config::singleton()->userSystem->isMaintenanceMode();
+      // otherwise cast the set value to a boolean
+      // this will follow PHP rules so empty string, 0 etc will be OFF
+      // and anything else will be on
+      return (bool) $civicrmSetting;
     }
     catch (\Exception $e) {
       // catch in case something isn't fully booted and can't answer

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -1247,4 +1247,8 @@ AND    u.status = 1
     return function_exists('ip_address') ? ip_address() : ($_SERVER['REMOTE_ADDR'] ?? NULL);
   }
 
+  public function isMaintenanceMode(): bool {
+    return state_get('maintenance_mode', FALSE);
+  }
+
 }

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1262,4 +1262,14 @@ abstract class CRM_Utils_System_Base {
     return FALSE;
   }
 
+  /**
+   * Does the userSystem think we are in maintenance mode?
+   *
+   * @return bool
+   */
+  public function isMaintenanceMode(): bool {
+    // if not implemented at CMS level, we assume FALSE
+    return FALSE;
+  }
+
 }

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -932,4 +932,8 @@ AND    u.status = 1
     return function_exists('ip_address') ? ip_address() : ($_SERVER['REMOTE_ADDR'] ?? NULL);
   }
 
+  public function isMaintenanceMode(): bool {
+    return variable_get('maintenance_mode', FALSE);
+  }
+
 }

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -1015,4 +1015,24 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     }
   }
 
+  /**
+   * @inheritdoc
+   */
+  public function isMaintenanceMode(): bool {
+    try {
+      return \Drupal::state()->get('system.maintenance_mode');
+    }
+    catch (\Exception $e) {
+      // catch in case Drupal isn't fully booted and can't answer
+      //
+      // we assume we are *NOT* in maintenance mode
+      //
+      // TODO: this may not be a good assumption for e.g. cv cron job
+      // which could be exactly the sort of thing we would want to
+      // prevent running in maintenance mode... maybe we should check
+      // try to check the drupal database directly here?
+      return FALSE;
+    }
+  }
+
 }

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -113,6 +113,12 @@ function civicrm_api3_job_delete($params) {
  *   API Result Array
  */
 function civicrm_api3_job_execute($params) {
+  if (\CRM_Utils_System::isMaintenanceMode() && !$params['run_in_maintenance_mode']) {
+    // skip execution
+    return civicrm_api3_create_success(0, $params, 'Job', NULL, NULL, [
+      'skipped' => 'maintenance_mode',
+    ]);
+  }
 
   $facility = new CRM_Core_JobManager();
   $facility->execute(FALSE);
@@ -128,6 +134,11 @@ function civicrm_api3_job_execute($params) {
  *   Array of parameters determined by getfields.
  */
 function _civicrm_api3_job_execute_spec(&$params) {
+  $params['run_in_maintenance_mode'] = [
+    'title' => ts('Run jobs even if system is in maintenance mode'),
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+    'api.default' => FALSE,
+  ];
 }
 
 /**

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -115,7 +115,7 @@ function civicrm_api3_job_delete($params) {
 function civicrm_api3_job_execute($params) {
   if (\CRM_Utils_System::isMaintenanceMode() && !$params['run_in_maintenance_mode']) {
     // skip execution
-    return civicrm_api3_create_success(0, $params, 'Job', NULL, NULL, [
+    return civicrm_api3_create_success(0, $params, 'Job', NULL, $dao, [
       'skipped' => 'maintenance_mode',
     ]);
   }

--- a/ext/standaloneusers/standaloneusers.php
+++ b/ext/standaloneusers/standaloneusers.php
@@ -77,12 +77,19 @@ function standaloneusers_civicrm_permission(&$permissions) {
     'label' => E::ts('CiviCRM Standalone Users: Allow users to access the reset password system'),
   ];
   // provide expected cms: permissions.
+  //
+  // This duplicates the list from CRM_Core_Permission_Base::getAvailablePermissions.
+  // It may be cleaner to extend via CRM_Core_Permission_Standalone::getAvailablePermissions (call parent and flip is_synthetic).
   $permissions['cms:administer users'] = [
     'label' => E::ts('CiviCRM Standalone Users: Administer user accounts'),
     'implies' => ['cms:view user account'],
   ];
   $permissions['cms:view user account'] = [
     'label' => E::ts('CiviCRM Standalone Users: View user accounts'),
+  ];
+  $permissions['cms:bypass maintenance mode'] = [
+    'label' => ts('CiviCRM Standalone Users: Bypass maintenance mode'),
+    'description' => ts('Allow to bypass maintenance mode checks - e.g. when using AJAX API'),
   ];
 }
 

--- a/settings/Core.boot.setting.php
+++ b/settings/Core.boot.setting.php
@@ -74,13 +74,19 @@ return [
     'global_name' => 'CIVICRM_DOMAIN_ID',
     'add' => '5.80',
   ],
+  // NOTE: consumers should probably not check the value of this setting directly
+  // instead please use CRM_Utils_System::isMaintenanceMode()
   'core_maintenance_mode' => [
     'group_name' => 'CiviCRM Preferences',
     'group' => 'core',
     'name' => 'core_maintenance_mode',
-    'type' => 'Boolean',
-    // NOTE: NULL means ask the userSystem
-    'default' => NULL,
+    'type' => 'String',
+    'default' => 'inherit',
+    'options' => [
+      '0' => 'Off',
+      '1' => 'On',
+      'inherit' => 'Inherit from CMS',
+    ],
     'title' => ts('CiviCRM Maintenance Mode'),
     'description' => ts('Enabling Maintenance Mode will restrict certain functionality such as scheduled job runs and REST api calls. If not set, CiviCRM will attempt to check whether the CMS is in maintenance mode.'),
     'help_text' => NULL,

--- a/settings/Core.boot.setting.php
+++ b/settings/Core.boot.setting.php
@@ -74,4 +74,21 @@ return [
     'global_name' => 'CIVICRM_DOMAIN_ID',
     'add' => '5.80',
   ],
+  'core_maintenance_mode' => [
+    'group_name' => 'CiviCRM Preferences',
+    'group' => 'core',
+    'name' => 'core_maintenance_mode',
+    'type' => 'Boolean',
+    // NOTE: NULL means ask the userSystem
+    'default' => NULL,
+    'title' => ts('CiviCRM Maintenance Mode'),
+    'description' => ts('Enabling Maintenance Mode will restrict certain functionality such as scheduled job runs and REST api calls. If not set, CiviCRM will attempt to check whether the CMS is in maintenance mode.'),
+    'help_text' => NULL,
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'is_constant' => FALSE,
+    'is_env_loadable' => TRUE,
+    'global_name' => 'CIVICRM_MAINTENANCE_MODE',
+    'add' => '6.0',
+  ],
 ];

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -2536,4 +2536,27 @@ ENDSQLUPDATE;
     ]);
   }
 
+  /**
+   * Test that Job.execute is disabled when in Maintenance Mode
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testMaintenanceModeGate(): void {
+    $settings = \Civi::settings();
+
+    // stash the starting value of setting
+    $startMode = $settings->get('core_maintenance_mode');
+
+    $settings->set('core_maintenance_mode', TRUE);
+    $result = $this->callAPISuccess('Job', 'execute');
+    $this->assertEquals($result['skipped'] ?? NULL, 'maintenance_mode');
+
+    $settings->set('core_maintenance_mode', FALSE);
+    $result = $this->callAPISuccess('Job', 'execute');
+    $this->assertEquals($result['skipped'] ?? FALSE, FALSE);
+
+    // revert
+    $settings->set('core_maintenance_mode', $startMode);
+  }
+
 }

--- a/tests/phpunit/api/v4/Request/AjaxTest.php
+++ b/tests/phpunit/api/v4/Request/AjaxTest.php
@@ -87,7 +87,7 @@ class AjaxTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals(503, http_response_code());
 
     // now add bypass maintenance mode permission
-    \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'add contacts', 'bypass maintenance mode'];
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'add contacts', 'cms:bypass maintenance mode'];
     $response = $this->runAjax([
       'path' => 'civicrm/ajax/api4/Contact/get',
     ]);


### PR DESCRIPTION
Overview
----------------------------------------
This adds a Maintenance Mode concept to CiviCRM.

It can be explicitly controlled by a CiviCRM setting, or if unset will fallback to checking if CMS maintenance mode is set (though CMS check only implemented for Drupal8 so far).

When Maintenance Mode is activated:
- Job.execute will be skipped (unless you explicitly specify `run_in_maintenance_mode`) 
- REST api calls will respond with 503 (unless user has `bypass maintenance mode` permission)

Technical Details
----------------------------------------
The setting `core_maintenance_mode` can have 3 values:
- TRUE = Maintenance Mode is explicitly activated
- FALSE = Maintenance Mode is explicitly deactivated
- NULL = refer to CMS (this is the default, only supports Drupal8 so far)

It has an env var `CIVICRM_MAINTENANCE_MODE`.

Comments
----------------------------------------
I haven't exposed the setting in the UI. Given this is very much sysadmin functionality, I guess most would be happy to access with env var / cv / $civicrm_setting. 

I think it could be good follow up to add to UI specifically for Standalone (for most CMS users, the CMS toggle makes more sense, so shouldn't really need this). 

