### PR TITLE
dev/core#5706 - Afform: Fix displayOnly field rendering

### DIFF
--- a/ext/afform/core/Civi/Afform/Utils.php
+++ b/ext/afform/core/Civi/Afform/Utils.php
@@ -105,11 +105,10 @@ class Utils {
     $value = $values[$fieldName] ?? NULL;
     if (isset($value) && $value !== '') {
       $dataType = $fieldInfo['data_type'] ?? NULL;
-      $inputType = $fieldInfo['input_type'] ?? NULL;
       if (!empty($fieldInfo['options'])) {
         $value = FormattingUtil::replacePseudoconstant(array_column($fieldInfo['options'], 'label', 'id'), $value);
       }
-      elseif ($inputType === 'EntityRef' && !empty($fieldInfo['fk_entity']) && $formName) {
+      elseif (!empty($fieldInfo['fk_entity']) && $formName) {
         $autocomplete = civicrm_api4($fieldInfo['fk_entity'], 'autocomplete', [
           'checkPermissions' => FALSE,
           'formName' => "afform:$formName",

--- a/ext/afform/core/Civi/Api4/Action/Afform/Prefill.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Prefill.php
@@ -20,34 +20,65 @@ class Prefill extends AbstractProcessor {
     return \CRM_Utils_Array::makeNonAssociative($entityValues, 'name', 'values');
   }
 
+  /**
+   * Find and replace values for fields that are "DisplayOnly"
+   * @param array $afformEntity
+   * @param array $valueSets
+   * @return void
+   */
   private function formatViewValues(array $afformEntity, array &$valueSets): void {
-    $originalValues = $valueSets;
-    foreach ($this->getDisplayOnlyFields($afformEntity['fields']) as $fieldName) {
-      foreach ($valueSets as $index => $valueSet) {
-        $this->replaceViewValue($afformEntity['name'], $afformEntity['type'], $fieldName, $valueSets[$index]['fields'], $originalValues[$index]['fields']);
-      }
+    foreach ($valueSets as $index => $valueSet) {
+      $this->replaceViewValues($afformEntity['name'], $afformEntity['type'], $afformEntity['fields'], $valueSets[$index]['fields']);
     }
     foreach ($afformEntity['joins'] ?? [] as $joinEntity => $join) {
-      foreach ($this->getDisplayOnlyFields($join['fields']) as $fieldName) {
-        foreach ($valueSets as $index => $valueSet) {
-          if (!empty($valueSet['joins'][$joinEntity])) {
-            foreach ($valueSet['joins'][$joinEntity] as $joinIndex => $joinValues) {
-              $this->replaceViewValue("{$afformEntity['name']}+$joinEntity", $joinEntity, $fieldName, $valueSets[$index]['joins'][$joinEntity][$joinIndex], $originalValues[$index]['joins'][$joinEntity][$joinIndex]);
-            }
+      foreach ($valueSets as $index => $valueSet) {
+        if (!empty($valueSet['joins'][$joinEntity])) {
+          foreach ($valueSet['joins'][$joinEntity] as $joinIndex => $joinValues) {
+            $this->replaceViewValues("{$afformEntity['name']}+$joinEntity", $joinEntity, $join['fields'], $valueSets[$index]['joins'][$joinEntity][$joinIndex]);
           }
         }
       }
     }
   }
 
-  private function replaceViewValue(string $entityName, string $entityType, string $fieldName, array &$values, $originalValues) {
+  private function replaceViewValues(string $entityName, string $entityType, array $fields, ?array &$values): void {
+    if (!$fields || !$values) {
+      return;
+    }
+    $originalValues = $values;
+    $conditions = [['input_type', '=', 'DisplayOnly']];
+    $displayOnlyFields = $this->getDisplayOnlyFields($fields);
+    if ($displayOnlyFields) {
+      $conditions[] = ['name', 'IN', $displayOnlyFields];
+    }
+    $getFields = civicrm_api4($entityType, 'getFields', [
+      'checkPermissions' => FALSE,
+      'loadOptions' => ['id', 'label'],
+      'values' => $values,
+      'action' => 'create',
+      'where' => [
+        ['name', 'IN', array_keys($fields)],
+        ['OR', $conditions],
+      ],
+    ]);
+    foreach ($getFields as $fieldInfo) {
+      $this->replaceViewValue($entityName, $fieldInfo, $values, $originalValues);
+    }
+  }
+
+  private function replaceViewValue(string $entityName, array $fieldInfo, array &$values, $originalValues): void {
+    $fieldName = $fieldInfo['name'];
     if (isset($values[$fieldName]) && !isset($values[$fieldName]['file_name'])) {
-      $fieldInfo = $this->_formDataModel->getField($entityType, $fieldName, 'create', $originalValues);
       $values[$fieldName] = Utils::formatViewValue($fieldName, $fieldInfo, $originalValues, $entityName, $this->name);
     }
   }
 
-  private function getDisplayOnlyFields(array $fields) {
+  /**
+   * Gets fields that have been explicitly configured "DisplayOnly" on the form
+   * @param array $fields
+   * @return array
+   */
+  private function getDisplayOnlyFields(array $fields): array {
     $displayOnly = array_filter($fields, fn($field) => ($field['defn']['input_type'] ?? NULL) === 'DisplayOnly');
     return array_keys($displayOnly);
   }

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformPrefillUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformPrefillUsageTest.php
@@ -21,6 +21,7 @@ class AfformPrefillUsageTest extends AfformUsageTestCase {
     <div class="af-container">
       <af-field name="id"></af-field>
       <af-field name="preferred_communication_method"></af-field>
+      <af-field name="sort_name"></af-field>
       <afblock-name-individual></afblock-name-individual>
     </div>
     <div af-join="Email" af-repeat="Add" af-copy="Copy" min="1">
@@ -67,9 +68,12 @@ EOHTML;
     // Form entity has `max="3"`
     $this->assertCount(3, $prefill['Individual1']['values']);
     $this->assertEquals('A', $prefill['Individual1']['values'][0]['fields']['first_name']);
+    $this->assertEquals('_A, A', $prefill['Individual1']['values'][0]['fields']['sort_name']);
     $this->assertEquals([1, 3], $prefill['Individual1']['values'][0]['fields']['preferred_communication_method']);
     $this->assertEquals('B', $prefill['Individual1']['values'][1]['fields']['first_name']);
+    $this->assertEquals('_B, B', $prefill['Individual1']['values'][1]['fields']['sort_name']);
     $this->assertEquals('C', $prefill['Individual1']['values'][2]['fields']['first_name']);
+    $this->assertEquals('_C, C', $prefill['Individual1']['values'][2]['fields']['sort_name']);
 
     // One email should have been filled
     $this->assertCount(1, $prefill['Individual1']['values'][1]['joins']['Email']);


### PR DESCRIPTION

Overview
----------------------------------------
For fields that are defined as DisplayOnly in their metadata, this fixes their rendering on the form.

Fixes [dev/core#5706](https://lab.civicrm.org/dev/core/-/issues/5706)

Before
----------------------------------------
Fields manually configured as DisplayOnly would render properly, but de-facto DisplayOnly fields would not.

After
----------------------------------------
Both types of DisplayOnly fields render.