### PR TITLE
Suppress the warning Failed to set final value of List-Unsubscribe

### DIFF
--- a/CRM/Mailing/Service/ListUnsubscribe.php
+++ b/CRM/Mailing/Service/ListUnsubscribe.php
@@ -50,7 +50,8 @@ class CRM_Mailing_Service_ListUnsubscribe extends \Civi\Core\Service\AutoService
     $sep = preg_quote(Civi::settings()->get('verpSeparator'), ';');
     $regex = ";^<mailto:[^>]*u{$sep}(\d+){$sep}(\d+){$sep}(\w*)@(.+)>$;";
     if (!preg_match($regex, $params['List-Unsubscribe'], $m)) {
-      \Civi::log()->warning('Failed to set final value of List-Unsubscribe');
+      // This can happen when generating a preview of a mailing or bots
+      // crawling public mailings with invalid checkums
       return;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------

CiviCRM logs a warning "Failed to set final value of List-Unsubscribe" in certain circumstances. Initially it was to help weed it edge-cases, but nowadays it is typically seen when:

- a preview is being generated
- bots are crawling public mailings with invalid checkums (BingBot is not very clever).

Before
----------------------------------------

Obscure warning in the logs.

After
----------------------------------------

No warning.

Comments
----------------------------------------

Alternate to #30718