### PR TITLE
Stop using function to get name of non-localised table `civicrm_mailing_event_opened`

### DIFF
--- a/CRM/Mailing/Selector/Event.php
+++ b/CRM/Mailing/Selector/Event.php
@@ -165,7 +165,7 @@ class CRM_Mailing_Selector_Event extends CRM_Core_Selector_Base implements CRM_C
           break;
 
         case 'opened':
-          $dateSort = CRM_Mailing_Event_BAO_MailingEventOpened::getTableName() . '.time_stamp';
+          $dateSort = 'civicrm_mailing_event_opened.time_stamp';
           break;
 
         case 'bounce':

--- a/Civi/Api4/Service/Spec/Provider/MailingGetSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/MailingGetSpecProvider.php
@@ -147,12 +147,12 @@ class MailingGetSpecProvider extends \Civi\Core\Service\AutoService implements G
 
     switch ($field['name']) {
       case 'stats_opens_total':
-        $tableName = \CRM_Mailing_Event_BAO_MailingEventOpened::getTableName();
+        $tableName = 'civicrm_mailing_event_opened';
         break;
 
       case 'stats_opens_unique':
-        $tableName = \CRM_Mailing_Event_BAO_MailingEventOpened::getTableName();
-        $count = "DISTINCT $tableName.event_queue_id";
+        $tableName = 'civicrm_mailing_event_opened';
+        $count = "DISTINCT civicrm_mailing_event_opened.event_queue_id";
         break;
 
       case 'stats_clicks_total':


### PR DESCRIPTION
Overview
----------------------------------------
Stop using function to get name of non-localised table

Before
----------------------------------------
query uses a variable for table name - but the table is not localised so it is always the same 

After
----------------------------------------
table name used directly

Technical Details
----------------------------------------

Comments
----------------------------------------
