### PR TITLE
Remove variables used for 2 non-localisatable tables

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1257,7 +1257,6 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       'mailing' => self::getTableName(),
       'mailing_group' => CRM_Mailing_DAO_MailingGroup::getTableName(),
       'group' => CRM_Contact_BAO_Group::getTableName(),
-      'job' => CRM_Mailing_BAO_MailingJob::getTableName(),
       'queue' => CRM_Mailing_Event_BAO_MailingEventQueue::getTableName(),
       'delivered' => CRM_Mailing_Event_BAO_MailingEventDelivered::getTableName(),
       'opened' => CRM_Mailing_Event_BAO_MailingEventOpened::getTableName(),
@@ -1268,7 +1267,6 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       'url' => CRM_Mailing_BAO_MailingTrackableURL::getTableName(),
       'urlopen' => CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen::getTableName(),
       'component' => CRM_Mailing_BAO_MailingComponent::getTableName(),
-      'spool' => CRM_Mailing_BAO_Spool::getTableName(),
     ];
 
     // Get the mailing info
@@ -1390,17 +1388,17 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
     // Get the event totals, grouped by job (retries)
     $mailing->query("
-            SELECT          {$t['job']}.*,
+            SELECT          civicrm_mailing_job.*,
                             COUNT(DISTINCT {$t['queue']}.id) as queue,
                             COUNT(DISTINCT {$t['delivered']}.id) as delivered,
                             COUNT(DISTINCT {$t['reply']}.id) as reply,
                             COUNT(DISTINCT {$t['forward']}.id) as forward,
                             COUNT(DISTINCT {$t['bounce']}.id) as bounce,
                             COUNT(DISTINCT {$t['urlopen']}.id) as url,
-                            COUNT(DISTINCT {$t['spool']}.id) as spool
-            FROM            {$t['job']}
+                            COUNT(DISTINCT civicrm_mailing_spool.id) as spool
+            FROM            civicrm_mailing_job
             LEFT JOIN       {$t['queue']}
-                    ON      {$t['queue']}.job_id = {$t['job']}.id
+                    ON      {$t['queue']}.job_id = civicrm_mailing_job.id
             LEFT JOIN       {$t['reply']}
                     ON      {$t['reply']}.event_queue_id = {$t['queue']}.id
             LEFT JOIN       {$t['forward']}
@@ -1412,11 +1410,11 @@ ORDER BY   civicrm_email.is_bulkmail DESC
                     AND     {$t['bounce']}.id IS null
             LEFT JOIN       {$t['urlopen']}
                     ON      {$t['urlopen']}.event_queue_id = {$t['queue']}.id
-            LEFT JOIN       {$t['spool']}
-                    ON      {$t['spool']}.job_id = {$t['job']}.id
-            WHERE           {$t['job']}.mailing_id = $mailing_id
-                    AND     {$t['job']}.is_test = 0
-            GROUP BY        {$t['job']}.id");
+            LEFT JOIN       civicrm_mailing_spool
+                    ON      civicrm_mailing_spool.job_id = civicrm_mailing_job.id
+            WHERE           civicrm_mailing_job.mailing_id = $mailing_id
+                    AND     civicrm_mailing_job.is_test = 0
+            GROUP BY        civicrm_mailing_job.id");
 
     $report['jobs'] = [];
     $report['event_totals'] = [];
@@ -1538,10 +1536,10 @@ ORDER BY   civicrm_email.is_bulkmail DESC
                     ON  {$t['urlopen']}.trackable_url_id = {$t['url']}.id
             LEFT JOIN  {$t['queue']}
                     ON  {$t['urlopen']}.event_queue_id = {$t['queue']}.id
-            LEFT JOIN  {$t['job']}
-                    ON  {$t['queue']}.job_id = {$t['job']}.id
+            LEFT JOIN  civicrm_mailing_job
+                    ON  {$t['queue']}.job_id = civicrm_mailing_job.id
             WHERE       {$t['url']}.mailing_id = $mailing_id
-                    AND {$t['job']}.is_test = 0
+                    AND civicrm_mailing_job.is_test = 0
             GROUP BY    {$t['url']}.id
             ORDER BY    unique_clicks DESC");
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove variables used for 2 non-localisatable tables

Before
----------------------------------------
Neither of the 2 tables touched are localisable so the variable names would be unchangeable

After
----------------------------------------
Swapped for table names

Technical Details
----------------------------------------
I kept to the 3 cos it's easy to verify they are straight swaps & the tables are non-localisable - more changes seemed hard to review

Comments
----------------------------------------
