### PR TITLE
[REF] Add Test of Billing update form for contribution Recur and ensure receipt from is assigned

### DIFF
--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -319,7 +319,7 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Contribute_Form_Contribution
       $tplParams['contact'] = ['display_name' => $donorDisplayName];
 
       $tplParams = array_merge($tplParams, CRM_Contribute_Form_AbstractEditPayment::formatCreditCardDetails($processorParams));
-
+      $tplParams['receipt_from_email'] = CRM_Contribute_BAO_ContributionRecur::getRecurFromAddress($this->getContributionRecurID());
       $sendTemplateParams = [
         'groupName' => $this->getSubscriptionDetails()->membership_id ? 'msg_tpl_workflow_membership' : 'msg_tpl_workflow_contribution',
         'workflow' => $this->getSubscriptionDetails()->membership_id ? 'membership_autorenew_billing' : 'contribution_recurring_billing',
@@ -327,7 +327,7 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Contribute_Form_Contribution
         'tplParams' => $tplParams,
         'isTest' => $this->getSubscriptionDetails()->is_test,
         'PDFFilename' => 'receipt.pdf',
-        'from' => CRM_Contribute_BAO_ContributionRecur::getRecurFromAddress($this->getContributionRecurID()),
+        'from' => $tplParams['receipt_from_email'],
         'toName' => $donorDisplayName,
         'toEmail' => $donorEmail,
       ];

--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -20,6 +20,9 @@
  */
 class CRM_Contribute_Form_UpdateBilling extends CRM_Contribute_Form_ContributionRecur {
   protected $_mode = NULL;
+  protected $_bltID = NULL;
+  public $_paymentFields;
+  public $_fields = [];
 
   /**
    * Set variables up before form is built.
@@ -254,8 +257,8 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Contribute_Form_Contribution
       $tplParams['address'] = CRM_Utils_Address::format($addressParts);
 
       // format old address to store in activity details
-      $this->_defaults["state_province-{$billingLocationID}"] = CRM_Core_PseudoConstant::stateProvince($this->_defaults["state_province-{$billingLocationID}"], FALSE);
-      $this->_defaults["country-{$billingLocationID}"] = CRM_Core_PseudoConstant::country($this->_defaults["country-{$billingLocationID}"], FALSE);
+      $this->_defaults["state_province-{$billingLocationID}"] = CRM_Core_PseudoConstant::stateProvince($this->_defaults["state_province-{$billingLocationID}"] ?? NULL, FALSE);
+      $this->_defaults["country-{$billingLocationID}"] = CRM_Core_PseudoConstant::country($this->_defaults["country-{$billingLocationID}"] ?? NULL, FALSE);
       $addressParts = ["street_address", "city", "postal_code", "state_province", "country"];
       foreach ($addressParts as $part) {
         $key = "{$part}-{$billingLocationID}";

--- a/CRM/Core/Payment/Dummy.php
+++ b/CRM/Core/Payment/Dummy.php
@@ -370,4 +370,9 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
     return $string . '_' . $trxn_id . '_' . uniqid();
   }
 
+  public function updateSubscriptionBillingInfo(&$message = '', $params = []) {
+    $message = ts('Recurring Contribution Updated');
+    return TRUE;
+  }
+
 }

--- a/tests/phpunit/CRM/Contribute/Form/UpdateBillingTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/UpdateBillingTest.php
@@ -61,7 +61,7 @@ class CRM_Contribute_Form_UpdateBillingTest extends CiviUnitTestCase {
       'Visa',
       '************1111',
       'Billing details for your recurring contribution of 10.00, every 1 month have been updated.',
-      'If you have questions please contact us at "Bob" <bob@example.org>.',
+      'If you have questions please contact us at "Bob" <bob@example.org>',
     ];
   }
 

--- a/tests/phpunit/CRM/Contribute/Form/UpdateBillingTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/UpdateBillingTest.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | Use of this source code is governed by the AGPL license with some  |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\Test\FormTrait;
+
+/**
+ * Class CRM_Contribute_Form_UpdateBillingTest
+ */
+class CRM_Contribute_Form_UpdateBillingTest extends CiviUnitTestCase {
+
+  use CRMTraits_Contribute_RecurFormsTrait;
+  use FormTrait;
+
+  /**
+   * Test the mail sent on update.
+   */
+  public function testMail(): void {
+    $this->addContribution();
+    $billingLocationID = CRM_Core_BAO_LocationType::getBilling();
+    $form = $this->getTestForm('CRM_Contribute_Form_UpdateBilling',
+      [
+        'is_notify' => TRUE,
+        'credit_card_number' => '4444333322221111',
+        'credit_card_exp_date' => ['Y' => '2032', 'M' => '08'],
+        'credit_card_type' => 'Visa',
+        'billing_first_name' => 'Charles',
+        'billing_last_name' => 'Windsor',
+        "billing_street_address-{$billingLocationID}" => '1 Buckingham Palace',
+        "billing_city-{$billingLocationID}" => 'London',
+        "biiling_postal_code-{$billingLocationID}" => 'SW1A 1AA',
+        "billing_country_id-{$billingLocationID}" => '1003',
+        "billing_state_province_id-{$billingLocationID}" => '',
+        "state_province-{$billingLocationID}" => '',
+      ],
+      ['crid' => $this->getContributionRecurID()]);
+    $form->processForm();
+    $this->assertMailSentContainingHeaderStrings([
+      'Return-Path: bob@example.org',
+      'Anthony Anderson <anthony_anderson@civicrm.org>',
+      'Subject: Recurring Contribution Billing Updates - Mr. Anthony Anderson II',
+    ]);
+    $this->assertMailSentContainingStrings($this->getExpectedMailStrings());
+  }
+
+  /**
+   * Get the strings to check for.
+   *
+   * @return string[]
+   */
+  public function getExpectedMailStrings(): array {
+    return [
+      'Dear Anthony,',
+      'Visa',
+      '************1111',
+      'Billing details for your recurring contribution of 10.00, every 1 month have been updated.',
+      'If you have questions please contact us at "Bob" <bob@example.org>.',
+    ];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This adds a unit test of the Update Billing form 

Before
----------------------------------------
No unit test covered this form

After
----------------------------------------
Unit test


Comments
----------------------------------------
I expect the first pass of this to fail because the update billing details form doesn't seem to be assigning the from name token correctly but not sure if that is to be done in a workflow @eileenmcnaughton thoughts?

cc @andrew-cormick-dockery @johntwyman 
