### PR TITLE
Queue.reset - Add API to drop all pending items

### DIFF
--- a/CRM/Queue/Queue.php
+++ b/CRM/Queue/Queue.php
@@ -143,6 +143,14 @@ abstract class CRM_Queue_Queue {
   abstract public function existsQueue();
 
   /**
+   * Delete all items in the queue.
+   */
+  public function resetQueue(): void {
+    $this->deleteQueue();
+    $this->createQueue();
+  }
+
+  /**
    * Add a new item to the queue.
    *
    * @param mixed $data

--- a/CRM/Queue/Service.php
+++ b/CRM/Queue/Service.php
@@ -115,8 +115,7 @@ class CRM_Queue_Service {
       $queue->createQueue();
     }
     elseif (@$queueSpec['reset']) {
-      $queue->deleteQueue();
-      $queue->createQueue();
+      $queue->resetQueue();
     }
     else {
       $queue->loadQueue();

--- a/Civi/Api4/Action/Queue/Reset.php
+++ b/Civi/Api4/Action/Queue/Reset.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Civi\Api4\Action\Queue;
+
+use Civi\Api4\Generic\Result;
+
+/**
+ * Drop all pending items in the queue.
+ *
+ * @method ?string getQueue
+ * @method $this setQueue(?string $queue)
+ */
+class Reset extends \Civi\Api4\Generic\AbstractAction {
+
+  /**
+   * Name of the target queue.
+   *
+   * @var string
+   * @required
+   */
+  protected $queue;
+
+  public function _run(Result $result) {
+    $queue = \Civi::queue($this->queue);
+    $start = $queue->getStatistic('total');
+    $queue->resetQueue();
+    $end = $queue->getStatistic('total');
+
+    $result[] = [
+      'items' => $start - $end,
+    ];
+  }
+
+}

--- a/Civi/Api4/Queue.php
+++ b/Civi/Api4/Queue.php
@@ -11,6 +11,7 @@
 namespace Civi\Api4;
 
 use Civi\Api4\Action\Queue\ClaimItems;
+use Civi\Api4\Action\Queue\Reset;
 use Civi\Api4\Action\Queue\RunItems;
 use Civi\Api4\Action\Queue\Run;
 
@@ -86,6 +87,17 @@ class Queue extends Generic\DAOEntity {
    */
   public static function run($checkPermissions = TRUE) {
     return (new Run(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * Delete all items in a queue.
+   *
+   * @param bool $checkPermissions
+   * @return \Civi\Api4\Action\Queue\Reset
+   */
+  public static function reset($checkPermissions = TRUE) {
+    return (new Reset(static::getEntityName(), __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

Add a new API, `Queue.reset`. It is similar to `Queue.run` or `Queue.runItems` in that it's targeted at a specific queue. It deletes all pending items in the queue.

This is extracted from #27860. I believe the main goal was to facilitate development-work. (Ex: You write some code to fill the queue, and then you realize that you did it wrong, and you need to start over.)

Before
----------------------------------------

No way to delete items (except via SQL or some other third-party tool, specific to the queue backend).

After
----------------------------------------

Delete via API/CLI:

```
$ cv api4 Queue.reset  queue=qstart-greeter
[
    {
        "items": 1200
    }
]
```

Note that the default permissions required for `Queue` API actions is `administer queues`.