### PR TITLE
(REF) Queue - Extract better helper for batch operations

### DIFF
--- a/CRM/Queue/BAO/Queue.php
+++ b/CRM/Queue/BAO/Queue.php
@@ -86,24 +86,4 @@ class CRM_Queue_BAO_Queue extends CRM_Queue_DAO_Queue implements \Civi\Core\Hook
     ];
   }
 
-  /**
-   * Queues which contain `CRM_Queue_Task` records should use the `task` runner to evaluate them.
-   *
-   * @code
-   * $q = Civi::queue('do-stuff', ['type' => 'Sql', 'runner' => 'task']);
-   * $q->createItem(new CRM_Queue_Task('my_callback_func', [1,2,3]));
-   * @endCode
-   *
-   * @param \CRM_Queue_Queue $queue
-   * @param array $items
-   * @param array $outcomes
-   * @throws \CRM_Core_Exception
-   * @see CRM_Utils_Hook::queueRun()
-   */
-  public static function hook_civicrm_queueRun_task(CRM_Queue_Queue $queue, array $items, array &$outcomes) {
-    foreach ($items as $itemPos => $item) {
-      $outcomes[$itemPos] = (new \CRM_Queue_TaskRunner())->run($queue, $item);
-    }
-  }
-
 }

--- a/CRM/Queue/BasicHandler.php
+++ b/CRM/Queue/BasicHandler.php
@@ -34,12 +34,9 @@ abstract class CRM_Queue_BasicHandler extends AutoService implements EventSubscr
    * Do a unit of work with one item from the queue.
    *
    * @param $item
-   * @param $queue
-   * @return mixed
-   *   Boolean-ish. TRUE for success. FALSE for failure.
-   *   Same as CRM_Queue_Task::run()
+   * @param \CRM_Queue_Queue $queue
    */
-  abstract protected function runItem($item, $queue);
+  abstract protected function runItem($item, $queue): void;
 
   /**
    * Get a nice title for the item.
@@ -122,9 +119,8 @@ abstract class CRM_Queue_BasicHandler extends AutoService implements EventSubscr
     else {
       \Civi::log()->debug('Running task: ' . $this->getItemTitle($item));
       try {
-        $runResult = $this->runItem($item, $queue);
-        $outcome = $runResult ? 'ok' : $queue->getSpec('error');
-        $exception = ($outcome === 'ok') ? NULL : new \CRM_Core_Exception('Queue task returned false', 'queue_false');
+        $this->runItem($item, $queue);
+        $outcome = 'ok';
       }
       catch (\Exception $e) {
         $outcome = $queue->getSpec('error');

--- a/CRM/Queue/BasicHandler.php
+++ b/CRM/Queue/BasicHandler.php
@@ -106,11 +106,15 @@ abstract class CRM_Queue_BasicHandler extends AutoService implements EventSubscr
    * @throws \CRM_Core_Exception
    */
   final public function run(CRM_Queue_Queue $queue, $item): string {
-    $this->assertType($item->data, ['CRM_Queue_Task'], 'Cannot run. Invalid task given.');
-
     /** @var string $outcome One of 'ok', 'retry', 'delete', 'abort' */
 
-    if (is_numeric($queue->getSpec('retry_limit')) && $item->run_count > 1 + $queue->getSpec('retry_limit')) {
+    if (!$this->validateItem($item)) {
+      // Invalid item. Do not collect $200. Do not pass go. Go directly to fail.
+      \Civi::log()->debug('Skipping invalid item: ' . $this->getItemTitle($item));
+      $outcome = $queue->getSpec('error');
+      $exception = new \Exception('Cannot run. Received invalid queue item.');
+    }
+    elseif (is_numeric($queue->getSpec('retry_limit')) && $item->run_count > 1 + $queue->getSpec('retry_limit')) {
       \Civi::log()->debug('Skipping exhausted task: ' . $this->getItemTitle($item));
       $outcome = $queue->getSpec('error');
       $exception = new \CRM_Core_Exception(sprintf('Skipping exhausted task after %d tries: %s', $item->run_count, print_r($this->getItemDetails($item), TRUE)), 'queue_retry_exhausted');
@@ -204,13 +208,8 @@ abstract class CRM_Queue_BasicHandler extends AutoService implements EventSubscr
     }
   }
 
-  final protected function assertType($object, array $types, string $message) {
-    foreach ($types as $type) {
-      if ($object instanceof $type) {
-        return;
-      }
-    }
-    throw new \Exception($message);
+  protected function validateItem($item): bool {
+    return TRUE;
   }
 
   final protected function isRetriable(\CRM_Queue_Queue $queue, $item): bool {

--- a/CRM/Queue/BasicHandlerTrait.php
+++ b/CRM/Queue/BasicHandlerTrait.php
@@ -9,40 +9,34 @@
  +--------------------------------------------------------------------+
  */
 
-use Civi\Core\Service\AutoService;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-
 /**
- * `CRM_Queue_BasicHandler` is a base-class that helps to execute queue-items.
+ * `CRM_Queue_BasicHandlerTrait` is a base-class that helps to execute queue-items.
  * It takes a batch of items and executes them 1-by-1. It enforces the
  * queue configuration options, such as `retry_limit=>5` and `error=>abort`.
  *
- * This class will have an incubation period circa Oct 2023 - Apr 2024. Unless otherwise
+ * This class will have an incubation period circa Feb 2025 - Dec 2025. Unless otherwise
  * noted, it should be considered stable at that point.
  */
-abstract class CRM_Queue_BasicHandler extends AutoService implements EventSubscriberInterface {
-
-  public static function getSubscribedEvents() {
-    return [
-      '&hook_civicrm_queueRun_' . static::getTypeName() => 'runBatch',
-    ];
-  }
-
-  abstract public static function getTypeName(): string;
+trait CRM_Queue_BasicHandlerTrait {
 
   /**
    * Do a unit of work with one item from the queue.
    *
+   * This should emit an exception if there is a problem handling the item.
+   * If runItem() encounters a fatal, then
+   *
    * @param $item
    * @param \CRM_Queue_Queue $queue
+   * @api
    */
-  abstract protected function runItem($item, $queue): void;
+  abstract protected function runItem($item, \CRM_Queue_Queue $queue): void;
 
   /**
    * Get a nice title for the item.
    *
    * @param \CRM_Queue_DAO_QueueItem $item
    * @return string
+   * @api
    */
   protected function getItemTitle($item): string {
     return ($item instanceof CRM_Queue_DAO_QueueItem)
@@ -55,6 +49,7 @@ abstract class CRM_Queue_BasicHandler extends AutoService implements EventSubscr
    *
    * @param $item
    * @return array
+   * @api
    */
   protected function getItemDetails($item): array {
     return [];
@@ -68,6 +63,7 @@ abstract class CRM_Queue_BasicHandler extends AutoService implements EventSubscr
    * @param array $outcomes
    * @throws \CRM_Core_Exception
    * @see CRM_Utils_Hook::queueRun()
+   * @api
    */
   final public function runBatch(CRM_Queue_Queue $queue, array $items, array &$outcomes): void {
     $todos = array_keys($items);
@@ -204,6 +200,11 @@ abstract class CRM_Queue_BasicHandler extends AutoService implements EventSubscr
     }
   }
 
+  /**
+   * @param $item
+   * @return bool
+   * @api
+   */
   protected function validateItem($item): bool {
     return TRUE;
   }

--- a/CRM/Queue/Queue/BatchQueueInterface.php
+++ b/CRM/Queue/Queue/BatchQueueInterface.php
@@ -54,4 +54,12 @@ interface CRM_Queue_Queue_BatchQueueInterface {
    */
   public function releaseItems(array $items): void;
 
+  /**
+   * Return items that were not even attempted (due to a preceding error in some other item).
+   *
+   * @param array $items
+   *   The items returned by claimItem.
+   */
+  public function relinquishItems(array $items): void;
+
 }

--- a/CRM/Queue/Queue/SqlTrait.php
+++ b/CRM/Queue/Queue/SqlTrait.php
@@ -184,6 +184,21 @@ trait CRM_Queue_Queue_SqlTrait {
     $this->freeDAOs($items);
   }
 
+  /**
+   * An item was previously claimed. No work was even attempted.
+   *
+   * @param array $items
+   * @throws \Civi\Core\Exception\DBQueryException
+   */
+  public function relinquishItems($items): void {
+    $sql = CRM_Utils_SQL::interpolate('UPDATE civicrm_queue_item SET release_time = NULL, run_count = run_count - 1 WHERE id IN (#ids) AND queue_name = @name', [
+      'ids' => CRM_Utils_Array::collect('id', $items),
+      'name' => $this->getName(),
+    ]);
+    CRM_Core_DAO::executeQuery($sql);
+    $this->releaseItems($items);
+  }
+
   protected function freeDAOs($mixed) {
     $mixed = (array) $mixed;
     foreach ($mixed as $item) {

--- a/CRM/Queue/TaskHandler.php
+++ b/CRM/Queue/TaskHandler.php
@@ -24,6 +24,10 @@ class CRM_Queue_TaskHandler extends CRM_Queue_BasicHandler {
     return 'task';
   }
 
+  protected function validateItem($item): bool {
+    return $item->data instanceof CRM_Queue_Task;
+  }
+
   /**
    * Do a unit of work with one item from the queue.
    *

--- a/CRM/Queue/TaskHandler.php
+++ b/CRM/Queue/TaskHandler.php
@@ -1,0 +1,74 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * `CRM_Queue_TaskHandler`  a list tasks from a queue. It is designed to supported background
+ * tasks which run automatically.
+ *
+ * This runner is not appropriate for all queues or workloads, so you might choose or create
+ * a different runner. For example, `CRM_Queue_Runner` is geared toward background task lists.
+ *
+ * @service civi.queue.task_handler
+ */
+class CRM_Queue_TaskHandler extends CRM_Queue_BasicHandler {
+
+  public static function getTypeName(): string {
+    return 'task';
+  }
+
+  /**
+   * Do a unit of work with one item from the queue.
+   *
+   * @param $item
+   * @param $queue
+   * @return mixed
+   *   Boolean-ish. TRUE for success. FALSE for failure.
+   */
+  protected function runItem($item, $queue) {
+    return $item->data->run($this->createContext($queue));
+  }
+
+  /**
+   * Get a nice title for the item.
+   *
+   * @param $item
+   * @return string|null
+   */
+  protected function getItemTitle($item): string {
+    $title = parent::getItemTitle($item);
+    if (isset($item->data->title)) {
+      $title .= '(' . $item->data->title . ')';
+    }
+    return $title;
+  }
+
+  /**
+   * Get detailed info about the item. This is used for debugging.
+   *
+   * @param $item
+   * @return array
+   */
+  protected function getItemDetails($item): array {
+    return CRM_Utils_Array::subset((array) $item->data, ['title', 'callback', 'arguments']);
+  }
+
+  /**
+   * @param \CRM_Queue_Queue $queue
+   * return CRM_Queue_TaskContext;
+   */
+  private function createContext(\CRM_Queue_Queue $queue): \CRM_Queue_TaskContext {
+    $taskCtx = new \CRM_Queue_TaskContext();
+    $taskCtx->queue = $queue;
+    $taskCtx->log = \CRM_Core_Error::createDebugLogger();
+    return $taskCtx;
+  }
+
+}

--- a/CRM/Queue/TaskHandler.php
+++ b/CRM/Queue/TaskHandler.php
@@ -35,7 +35,10 @@ class CRM_Queue_TaskHandler extends CRM_Queue_BasicHandler {
    * @param $queue
    */
   protected function runItem($item, $queue): void {
-    $runResult = $item->data->run($this->createContext($queue));
+    $taskCtx = new \CRM_Queue_TaskContext();
+    $taskCtx->queue = $queue;
+    $taskCtx->log = \CRM_Core_Error::createDebugLogger();
+    $runResult = $item->data->run($taskCtx);
     if (!$runResult) {
       throw new \CRM_Core_Exception('Queue task returned false', 'queue_false');
     }
@@ -63,17 +66,6 @@ class CRM_Queue_TaskHandler extends CRM_Queue_BasicHandler {
    */
   protected function getItemDetails($item): array {
     return CRM_Utils_Array::subset((array) $item->data, ['title', 'callback', 'arguments']);
-  }
-
-  /**
-   * @param \CRM_Queue_Queue $queue
-   * return CRM_Queue_TaskContext;
-   */
-  private function createContext(\CRM_Queue_Queue $queue): \CRM_Queue_TaskContext {
-    $taskCtx = new \CRM_Queue_TaskContext();
-    $taskCtx->queue = $queue;
-    $taskCtx->log = \CRM_Core_Error::createDebugLogger();
-    return $taskCtx;
   }
 
 }

--- a/CRM/Queue/TaskHandler.php
+++ b/CRM/Queue/TaskHandler.php
@@ -33,11 +33,12 @@ class CRM_Queue_TaskHandler extends CRM_Queue_BasicHandler {
    *
    * @param $item
    * @param $queue
-   * @return mixed
-   *   Boolean-ish. TRUE for success. FALSE for failure.
    */
-  protected function runItem($item, $queue) {
-    return $item->data->run($this->createContext($queue));
+  protected function runItem($item, $queue): void {
+    $runResult = $item->data->run($this->createContext($queue));
+    if (!$runResult) {
+      throw new \CRM_Core_Exception('Queue task returned false', 'queue_false');
+    }
   }
 
   /**

--- a/CRM/Queue/TaskRunner.php
+++ b/CRM/Queue/TaskRunner.php
@@ -34,20 +34,17 @@ class CRM_Queue_TaskRunner {
   public function run(CRM_Queue_Queue $queue, $item): string {
     $this->assertType($item->data, ['CRM_Queue_Task'], 'Cannot run. Invalid task given.');
 
-    /** @var \CRM_Queue_Task $task */
-    $task = $item->data;
-
     /** @var string $outcome One of 'ok', 'retry', 'delete', 'abort' */
 
     if (is_numeric($queue->getSpec('retry_limit')) && $item->run_count > 1 + $queue->getSpec('retry_limit')) {
-      \Civi::log()->debug('Skipping exhausted task: ' . $task->title);
+      \Civi::log()->debug('Skipping exhausted task: ' . $this->getItemTitle($item));
       $outcome = $queue->getSpec('error');
-      $exception = new \CRM_Core_Exception(sprintf('Skipping exhausted task after %d tries: %s', $item->run_count, print_r($task, 1)), 'queue_retry_exhausted');
+      $exception = new \CRM_Core_Exception(sprintf('Skipping exhausted task after %d tries: %s', $item->run_count, print_r($this->getItemDetails($item), TRUE)), 'queue_retry_exhausted');
     }
     else {
-      \Civi::log()->debug('Running task: ' . $task->title);
+      \Civi::log()->debug('Running task: ' . $this->getItemTitle($item));
       try {
-        $runResult = $task->run($this->createContext($queue));
+        $runResult = $this->runItem($item, $queue);
         $outcome = $runResult ? 'ok' : $queue->getSpec('error');
         $exception = ($outcome === 'ok') ? NULL : new \CRM_Core_Exception('Queue task returned false', 'queue_false');
       }
@@ -72,7 +69,7 @@ class CRM_Queue_TaskRunner {
 
     $logDetails = [
       'id' => $queue->getName() . '#' . $item->id,
-      'task' => CRM_Utils_Array::subset((array) $task, ['title', 'callback', 'arguments']),
+      'task' => $this->getItemDetails($item),
       'outcome' => $outcome,
       'message' => $exception ? $exception->getMessage() : NULL,
       'exception' => $exception,
@@ -101,6 +98,38 @@ class CRM_Queue_TaskRunner {
     }
 
     return $outcome;
+  }
+
+  /**
+   * Do a unit of work with one item from the queue.
+   *
+   * @param $item
+   * @param $queue
+   * @return mixed
+   *   Boolean-ish. TRUE for success. FALSE for failure.
+   */
+  protected function runItem($item, $queue) {
+    return $item->data->run($this->createContext($queue));
+  }
+
+  /**
+   * Get a nice title for the item.
+   *
+   * @param $item
+   * @return string|null
+   */
+  protected function getItemTitle($item): ?string {
+    return $item->data->title;
+  }
+
+  /**
+   * Get detailed info about the item. This is used for debugging.
+   *
+   * @param $item
+   * @return array
+   */
+  protected function getItemDetails($item) {
+    return CRM_Utils_Array::subset((array) $item->data, ['title', 'callback', 'arguments']);
   }
 
   /**

--- a/tests/phpunit/api/v4/Entity/QueueTest.php
+++ b/tests/phpunit/api/v4/Entity/QueueTest.php
@@ -171,6 +171,56 @@ class QueueTest extends Api4TestBase {
     $this->assertEquals([6], \Civi::$statics[__CLASS__]['onHookQueueRunLog'][2]);
   }
 
+  /**
+   * Similar to testBatchParallelPolling(). But the hook-listener doesn't directly manipulate
+   * queue-items. Instead, it uses the BasicHandlerTrait.
+   */
+  public function testBatchParallelPolling_WithBasicHandler(): void {
+    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_parallel';
+
+    $handler = new class() {
+
+      use \CRM_Queue_BasicHandlerTrait;
+
+      protected function runItem($item, \CRM_Queue_Queue $queue): void {
+        \Civi::$statics['QueueTest']['onHandlerLog'][] = $item->data['thingy'] * 10;
+      }
+
+    };
+    \Civi::dispatcher()->addListener('&hook_civicrm_queueRun_testHandler', [$handler, 'runBatch']);
+
+    $queue = \Civi::queue($queueName, [
+      'type' => 'SqlParallel',
+      'runner' => 'testHandler',
+      'error' => 'delete',
+      'batch_limit' => 3,
+    ]);
+    $this->assertQueueStats(0, 0, 0, $queue);
+
+    for ($i = 0; $i < 7; $i++) {
+      \Civi::queue($queueName)->createItem(['thingy' => $i]);
+    }
+    $this->assertQueueStats(7, 7, 0, $queue);
+
+    \Civi::$statics['QueueTest']['onHandlerLog'] = [];
+    $result = Queue::runItems(0)->setQueue($queueName)->execute();
+    $this->assertEquals(3, count($result));
+    $this->assertEquals([0, 10, 20], \Civi::$statics['QueueTest']['onHandlerLog']);
+    $this->assertQueueStats(4, 4, 0, $queue);
+
+    \Civi::$statics['QueueTest']['onHandlerLog'] = [];
+    $result = Queue::runItems(0)->setQueue($queueName)->execute();
+    $this->assertEquals(3, count($result));
+    $this->assertEquals([30, 40, 50], \Civi::$statics['QueueTest']['onHandlerLog']);
+    $this->assertQueueStats(1, 1, 0, $queue);
+
+    \Civi::$statics['QueueTest']['onHandlerLog'] = [];
+    $result = Queue::runItems(0)->setQueue($queueName)->execute();
+    $this->assertEquals(1, count($result));
+    $this->assertEquals([60], \Civi::$statics['QueueTest']['onHandlerLog']);
+    $this->assertQueueStats(0, 0, 0, $queue);
+  }
+
   public function testReset() {
     $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_reset';
     \Civi::dispatcher()->addListener('hook_civicrm_queueRun_testStuff', [$this, 'onHookQueueRun']);


### PR DESCRIPTION
Background
----------------------------------------

Recall that:

* Queues can process executable tasks (`CRM_Queue_Task`s). Additionally, they can process arbitrary kinds of  data (eg `array`s).
* #22762 previously introduced `hook_civicrm_queueRun_{XXX}` as a way to process batches of data. ([Example Extension](https://gist.github.com/totten/27b16b8b1fc78a6e582c7f2e8ded964a))
  
Overview
----------------------------------------

`hook_civicrm_queueRun_{XXX}` provides basic wiring to handle a batch of data from a queue. However, support for batching is a double-edged sword for the downstream hook-implementer:

* They have the _opportunity_ to optimize the overall handling of the batch (*e.g. to pass-through sets of data to other batch-oriented APIs*).
* They have the _obligation_ to think in terms of batches. That's harder than thinking about items one-by-one. And if you don't need batch-optimizations, then it's unwanted effort.
    * Ex: Suppose a batch contains 10 times. When processing, 8 items succeed and 2 items fail. You need to explicitly loop through the items, assess the success/failure of each one, and update the queue-statuses for each one. And the way you handle problems should respect the queue-configuration (re: retries, aborts, failures, etc).

This PR speaks to the scenario where:

* You want to process queue data (i.e. as an `array` not a `Task`), so
* You implement `hook_civicrm_queueRun_{XXX}`, but
* You don't want fine-grained responsibility for breaking-down the batches, toggling item-statuses, or applying an error-policy.

The implementation is based on the existing (internal) implementation of `CRM_Queue_TaskRunner` (which has similar goal/problem/situation). It reorganizes that code and extracts helpers so that we can reuse the logic for other (non-`task`) data.

Before
----------------------------------------

* For `hook_civicrm_queueRun_task`, it calls out to `CRM_Queue_TaskRunner`. 
* If you want to handle custom array data (instead of `task`s), you need a bunch of loops+conditionals. You basically need to copy `CRM_Queue_TaskRunner` and replace the `$task->run()` step.


After
----------------------------------------

* For `hook_civicrm_queueRun_task`, it calls out to `CRM_Queue_TaskHandler`.
    * _Same general behavior as before -- just a different class-name._
* If you want handle custom array data (instead `task`s), you can create another class like this:

```php
/**
 * @service civi.queue.my_stuff
 */
class MyHandler extends AutoService implements EventSubscriberInterface {

  use CRM_Queue_BasicHandlerTrait;

  public static function getSubscribedEvents() {
    return ['&hook_civicrm_queueRun_my_stuff' => 'runBatch'];
  }

  protected function runItem($item, \CRM_Queue_Queue $queue): void {
    print_r(["Received item:" => $item));

    // If this function ends normally, then we consider the $item successful.

    // If this function encounters a recoverable error, then we check the $queue configuration
    // to decide what to do next (e.g. retry, abort, delete, etc).

    // If this function abends (PHP fatal, power-outage, etc), then any pending items in the
    // batch (incl $item and its successors) will be retried later.
  }

  // Optionally, pre-validate items before executing them.
  // protected function validateItem($item): bool {}

  // Optionally, make a loggable summary of the 
  // protected function getItemDetails($item): array  {}
}
```

Comments
-----------------

* This removes symbol `CRM_Queue_TaskRunner`. There are no references to that symbol in `universe`.
* This refactors queue code. There are several existing unit-tests which cover this area (eg `api\v4\Entity\QueueTest`).
* This PR was extracted from #27860.