### PR TITLE
(dev/core#1926) MySQL - Improve debug info about SSL failures

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -506,7 +506,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
 
       if (!$checkPermission) {
         // Permission system inactive, only emit a reference to content in logfile
-        echo "Critical error. Please see server logs for errorID:$unique";
+        echo "Critical error. Please see server logs for errorID:$unique" . (PHP_SAPI !== 'cli' ? '<br/>' : '') . "\n";
       }
       else {
         if (CRM_Core_Permission::check('view debug output')) {

--- a/composer.json
+++ b/composer.json
@@ -283,7 +283,8 @@
         "Apply patch to fix php8.2 deprecation notice on dynamic property $filename": "https://patch-diff.githubusercontent.com/raw/adrienrn/php-mimetyper/pull/17.patch"
       },
       "pear/db": {
-        "Apply CiviCRM Customisations for the pear:db package": "https://raw.githubusercontent.com/civicrm/civicrm-core/2ad420c394/tools/scripts/composer/pear_db_civicrm_changes.patch"
+        "Apply CiviCRM Customisations for the pear:db package": "https://raw.githubusercontent.com/civicrm/civicrm-core/2ad420c394/tools/scripts/composer/pear_db_civicrm_changes.patch",
+        "Ensure that error messages about MySQL-SSL connections are reported": "https://gist.githubusercontent.com/totten/f491faadc95c43bf7750596c79b6fbba/raw/69d24ef6b136656a5fdb6398bf2e491a6c659e48/DB_mysqli.patch"
       },
       "pear/mail": {
         "Apply CiviCRM Customisations for CRM-1367 and CRM-5946": "https://raw.githubusercontent.com/civicrm/civicrm-core/36319938a5bf26c1e7e2110a26a65db6a5979268/tools/scripts/composer/patches/pear-mail.patch"


### PR DESCRIPTION
Overview
----------------------------------------

When MySQL uses SSL for connections, there are several ways for a connection to breakdown -- e.g. neglecting the CA certificate, receiving an expired certificate, using mismatched hostname in the DSN, and so on.

If the connection is failing, then the errors about SSL should be available *somewhere*.

This PR improves reporting in both HTTP and CLI contexts.

(*This is an off-shoot from https://lab.civicrm.org/dev/core/-/issues/1926*.)

Before
----------------------------------------

When you make an HTTP request to CiviCRM, it connects to MySQL. If there's an error, it shows this:

> ![Screenshot from 2025-01-29 22-09-47](https://github.com/user-attachments/assets/e8557108-aeae-4f61-9009-f5d86c19c624)

This looks a little wonky, but fair enough - the error could reveal private details about the DB connection. So you go to the Apache/PHP log, and it shows a message like this:

```
Wed Jan 29 22:11:16.793473 2025] [proxy_fcgi:error] [pid 8467:tid 140070275241536] [client 127.0.0.1:48562] AH01071: Got error 'PHP message: errorID:c4aa1fef1d14
Initialization Error:
Array
(
    [callback] => Array
        (
            [0] => CRM_Core_Error
            [1] => simpleHandler
        )

    [code] => -24
    [message] => DB Error: connect failed
    [mode] => 16
    [debug_info] =>  [DB Error: connect failed]
    [type] => DB_Error
    [user_info] =>  [DB Error: connect failed]
    [to_string] => [db_error: message="DB Error: connect failed" code=-24 mode=callback callback=CRM_Core_Error::simpleHandler prefix="" info=" [DB Error: connect failed]"]
)
```

Which looks verbose... but says nothing. It just repeats the phrase "DB Error: connect failed" five times. Why is there no useful information?

The reason can be found in PEAR DB: the `mysqli` driver specifically [hides all messages](https://github.com/pear/DB/blob/v1.12.2/DB/mysqli.php#L315) when making an SSL connection:

```php
if ($this->connection = @mysqli_real_connect(
```

After
----------------------------------------

Add a patch for PEAR DB's `mysqli` (https://gist.github.com/totten/f491faadc95c43bf7750596c79b6fbba) -- instead of using `@` to suppress all messages, we capture the messages in a buffer. And in the event of a failure, we report the full buffer.

Retrying our use-case, we see a (slightly) better error-message:

> ![Screenshot from 2025-01-29 21-59-03](https://github.com/user-attachments/assets/91f6f83e-0bee-4ad9-9893-4e2459a97ca1)

And when we drill-down on Apache/PHP logs, we find much more informative data:

```
[Wed Jan 29 21:56:10.566125 2025] [proxy_fcgi:error] [pid 9999:tid 140070141023808] [client 127.0.0.1:48554] AH01071: Got error 'PHP message: errorID:1bd7c864e20b
Initialization Error:
Array
(
    [callback] => Array
        (
            [0] => CRM_Core_Error
            [1] => simpleHandler
        )

    [code] => -24
    [message] => DB Error: connect failed
    [mode] => 16
    [debug_info] => 
mysqli_real_connect(): Peer certificate CN=`mysql.bknix' did not match expected CN=`127.0.0.1'
mysqli_real_connect(): Cannot connect to MySQL by using SSL
mysqli_real_connect(): [2002]  (trying to connect via (null))
mysqli_real_connect(): (HY000/2002):  [DB Error: connect failed]
    [type] => DB_Error
    [user_info] => 
mysqli_real_connect(): Peer certificate CN=`mysql.bknix' did not match expected CN=`127.0.0.1'
mysqli_real_connect(): Cannot connect to MySQL by using SSL
mysqli_real_connect(): [2002]  (trying to connect via (null))
mysqli_real_connect(): (HY000/2002):  [DB Error: connect failed]
    [to_string] => [db_error: message="DB Error: connect failed" code=-24 mode=callback callback=CRM_Core_Error::simpleHandler
```

The "peer certificate" presented a value of `mysql.bknix`, but it was expecting to see `127.0.0.1`. This indicates either a man-in-the-middle diverting our traffic or (more likely) a misconfiguration. But it's a specific kind of misconfiguration, so it can be understood/fixed.


Comments
-----------------------

* If you have a working SSL environment, a quick way to provoke an SSL error is to edit your DSN -- change the DBMS address from its hostname to its IP address. This will provoke a "Peer certificate" error.
* I also tried this in the CLI -- with `cv` and `drush`. In both cases, it improved -- reporting the full error information on the console.
* Sharp readers will notice that the error is printed twice. That's a little silly -- but it's a separate/pre-existing issue. It arises from an error-cascade -- it hits the first error and reports it to screen. Then it considers whether to relay the error to the CMS's logger... but this involves some settings, which come from the database, which makes the second failure. If someone wants to untangle that, then... that sounds like a fine (and separate) PR...