### PR TITLE
(dev/core#1926) MySQL SSL - Fixes for Backdrop, Drupal 7, Standalone

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -337,10 +337,8 @@ class CRM_Utils_File {
     }
     else {
       require_once 'DB.php';
-      $dsn = CRM_Utils_SQL::autoSwitchDSN($dsn);
       try {
-        $options = CRM_Utils_SQL::isSSLDSN($dsn) ? ['ssl' => TRUE] : [];
-        $db = DB::connect($dsn, $options);
+        $db = CRM_Utils_SQL::connect($dsn);
       }
       catch (Exception $e) {
         throw new CRM_Core_Exception("Cannot open $dsn: " . $e->getMessage());

--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -179,6 +179,12 @@ class CRM_Utils_SQL {
     return CRM_Core_DAO::singleValueQuery('SELECT VERSION()');
   }
 
+  public static function connect($dsn) {
+    $dsn = CRM_Utils_SQL::autoSwitchDSN($dsn);
+    $options = CRM_Utils_SQL::isSSLDSN($dsn) ? ['ssl' => TRUE] : [];
+    return DB::connect($dsn, $options);
+  }
+
   /**
    * Does the DSN indicate the connection should use ssl.
    *

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -289,9 +289,9 @@ class CRM_Utils_System_Backdrop extends CRM_Utils_System_DrupalBase {
   public function authenticate($name, $password, $loadCMSBootstrap = FALSE, $realPath = NULL) {
     $config = CRM_Core_Config::singleton();
 
-    $ufDSN = CRM_Utils_SQL::autoSwitchDSN($config->userFrameworkDSN);
+    $ufDSN = $config->userFrameworkDSN;
     try {
-      $dbBackdrop = DB::connect($ufDSN);
+      $dbBackdrop = CRM_Utils_SQL::connect($ufDSN);
     }
     catch (Exception $e) {
       throw new CRM_Core_Exception("Cannot connect to Backdrop database via $ufDSN, " . $e->getMessage());

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -313,9 +313,10 @@ class CRM_Utils_System_Drupal extends CRM_Utils_System_DrupalBase {
 
     $config = CRM_Core_Config::singleton();
 
-    $ufDSN = CRM_Utils_SQL::autoSwitchDSN($config->userFrameworkDSN);
+    $ufDSN = $config->userFrameworkDSN;
+
     try {
-      $dbDrupal = DB::connect($ufDSN);
+      $dbDrupal = CRM_Utils_SQL::connect($ufDSN);
     }
     catch (Exception $e) {
       throw new CRM_Core_Exception("Cannot connect to drupal db via $ufDSN, " . $e->getMessage());

--- a/ext/standaloneusers/Civi/Standalone/SessionHandler.php
+++ b/ext/standaloneusers/Civi/Standalone/SessionHandler.php
@@ -96,7 +96,7 @@ class SessionHandler implements SessionHandlerInterface, SessionIdInterface, Ses
    * @return bool
    */
   public function open($path, $name): bool {
-    $this->db = DB::connect(\CRM_Core_Config::singleton()->dsn);
+    $this->db = \CRM_Utils_SQL::connect(\CRM_Core_Config::singleton()->dsn);
     $this->db->autoCommit(FALSE);
 
     return TRUE;

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -596,8 +596,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
     // Re:^^^ => the failure was probably correct behavior, and test is now fixed, but yeah 5.5 is deprecated, and don't care enough to verify.
     // Test data providers should be able to run in pre-boot environment, so we connect directly to SQL server.
     require_once 'DB.php';
-    $dsn = CRM_Utils_SQL::autoSwitchDSN(CIVICRM_DSN);
-    $db = DB::connect($dsn);
+    $db = CRM_Utils_SQL::connect(CIVICRM_DSN);
     if ($db->connection instanceof mysqli && $db->connection->server_version < 50600) {
       $entitiesWithout[] = 'Dedupe';
     }


### PR DESCRIPTION
Overview
----------------------------------------

This addresses connectivity issue where MySQL-SSL may not work in some environments/call-paths.

(*This is an off-shoot from https://lab.civicrm.org/dev/core/-/issues/1926.*)

Before
----------------------------------------

* In testing for https://lab.civicrm.org/dev/core/-/issues/1926, we found this scenario fails:
    * Install Drupal 7 with MySQL SSL
    * Install CiviCRM on the same database
    * Configure MySQL to *strictly require* SSL. (`set global require_secure_transport = 1;`)
    * Run `bin/cron.php?name=...&pass=...&key=...` via HTTP.
* After grepping for the `DB::connect()` code pattern, it appears the same problem would also affect Backdrop's `cron.php` and Standalone's session-handler.

After
----------------------------------------

All three of these should work with MySQL-SSL. (Specifically, I've tested D7 cron.)

Technical Details
----------------------------------------

The clearest way to understand the problem is to consider: _How do you issue a PHP call to connect to the database?_ This has evolved over various releases of CiviCRM:

* Originally, to connect to MySQL, you simply call `DB::connect()` with a connection string (`$dsn`), eg
    ```php
    $db = DB::connect($dsn);
    ```
* Several years later, changes in upstream PHP compelled a transition. Live deployments had `$dsn` strings using a mix of `mysql://` (*deprecated*) and `mysqli://` (*maintained*) drivers, but we needed all of them to start using the `mysqli://` driver. So the idiom changed:
    ```php
    $dsn = CRM_Utils_SQL::autoSwitchDSN($dsn);
    $db = DB::connect($dsn);
    ```
* Several years after that, the idiom changed again to support SSL. Specifically, if the `$dsn` involves SSL, then `DB::connect()` requires an extra hint.
    ```php
    $dsn = CRM_Utils_SQL::autoSwitchDSN($dsn);
    $options = CRM_Utils_SQL::isSSLDSN($dsn) ? ['ssl' => TRUE] : [];
    $db = DB::connect($dsn, $options);
    ```

If `DB::connect()` were called in a single spot, then this evolution would be simple. However, in reality, there are several places which use `DB::connect()`. And all of them needed these updates.

But several of them are harder to see, so they've been addressed in whack-a-mole fashion. This PR does a little refactoring to ensure that they all work the same.
