### PR TITLE
Api3 - Fix profile.submit function to correctly handle more fields

### DIFF
--- a/api/v3/Profile.php
+++ b/api/v3/Profile.php
@@ -277,7 +277,7 @@ function civicrm_api3_profile_submit($params) {
  *   BAO Field Name
  */
 function _civicrm_api3_profile_translate_fieldnames_for_bao($fieldName) {
-  $fieldName = str_replace('url', 'URL', $fieldName);
+  $fieldName = str_replace('image_url', 'image_URL', $fieldName);
   return str_replace('primary', 'Primary', $fieldName);
 }
 
@@ -491,6 +491,7 @@ function _civicrm_api3_buildprofile_submitfields($profileID, $optionsBehaviour, 
     }
     list($entity, $fieldName) = _civicrm_api3_map_profile_fields_to_entity($field);
     $aliasArray = [];
+    // Use alias to handle the inconsistency between -Primary and -primary suffixes
     if (strtolower($fieldName) != $fieldName) {
       $aliasArray['api.aliases'] = [$fieldName];
       $fieldName = strtolower($fieldName);
@@ -630,25 +631,7 @@ function _civicrm_api3_map_profile_fields_to_entity(&$field) {
     $entity = 'contact';
   }
   $entity = _civicrm_api_get_entity_name_from_camel($entity);
-  $locationFields = ['email', 'phone'];
   $fieldName = $field['field_name'];
-  if (!empty($field['location_type_id'])) {
-    if (in_array($fieldName, $locationFields)) {
-      $entity = $fieldName;
-    }
-    else {
-      $entity = 'address';
-    }
-    $fieldName .= '-' . $field['location_type_id'];
-  }
-  elseif (in_array($fieldName, $locationFields)) {
-    $entity = $fieldName;
-    $fieldName .= '-Primary';
-  }
-  if (!empty($field['phone_type_id'])) {
-    $fieldName .= '-' . $field['phone_type_id'];
-    $entity = 'phone';
-  }
 
   // @todo - sort this out!
   //here we do a hard-code list of known fields that don't map to where they are mapped to
@@ -664,6 +647,10 @@ function _civicrm_api3_map_profile_fields_to_entity(&$field) {
     'postal_code' => 'address',
     'city' => 'address',
     'email' => 'email',
+    'phone' => 'phone',
+    'phone_and_ext' => 'phone',
+    'url' => 'website',
+    'im' => 'im',
     'state_province' => 'address',
     'country' => 'address',
     'county' => 'address',
@@ -685,6 +672,23 @@ function _civicrm_api3_map_profile_fields_to_entity(&$field) {
   if (array_key_exists($fieldName, $hardCodedEntityMappings)) {
     $entity = $hardCodedEntityMappings[$fieldName];
   }
+
+  $locationEntities = ['email', 'phone', 'address', 'im'];
+  if (!empty($field['location_type_id'])) {
+    $fieldName .= '-' . $field['location_type_id'];
+  }
+  elseif (in_array($entity, $locationEntities)) {
+    $fieldName .= '-Primary';
+  }
+  if (!empty($field['phone_type_id'])) {
+    $fieldName .= '-' . $field['phone_type_id'];
+    $entity = 'phone';
+  }
+  if (!empty($field['website_type_id'])) {
+    $fieldName .= '-' . $field['website_type_id'];
+    $entity = 'website';
+  }
+
   return [$entity, $fieldName];
 }
 

--- a/tests/phpunit/api/v3/ProfileTest.php
+++ b/tests/phpunit/api/v3/ProfileTest.php
@@ -302,18 +302,101 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
    * Check getfields works & gives us our fields
    */
   public function testGetFields(): void {
-    $this->createIndividualProfile();
-    $this->addCustomFieldToProfile($this->_profileID);
+    $ufGroupParams = [
+      'group_type' => 'Individual,Contact',
+      'title' => 'Flat Coffee',
+      'api.uf_field.create' => [
+        [
+          'field_name' => 'first_name',
+          'is_required' => 1,
+          'visibility' => 'Public Pages and Listings',
+          'field_type' => 'Individual',
+          'label' => 'First Name',
+        ],
+        [
+          // No location type == Primary
+          'field_name' => 'email',
+          'is_required' => 1,
+          'visibility' => 'Public Pages and Listings',
+          'field_type' => 'Contact',
+          'label' => 'Email',
+        ],
+        [
+          // No location type == Primary
+          'field_name' => 'phone',
+          'is_required' => 1,
+          'visibility' => 'Public Pages and Listings',
+          'field_type' => 'Contact',
+          'phone_type_id' => 1,
+          'label' => 'Phone',
+        ],
+        [
+          'field_name' => 'phone_and_ext',
+          'is_required' => 1,
+          'visibility' => 'Public Pages and Listings',
+          'field_type' => 'Contact',
+          'phone_type_id' => 2,
+          'location_type_id' => 1,
+          'label' => 'Phone',
+        ],
+        [
+          // No location type == Primary
+          'field_name' => 'country',
+          'is_required' => 1,
+          'visibility' => 'Public Pages and Listings',
+          'field_type' => 'Contact',
+          'label' => 'Country',
+        ],
+        [
+          'field_name' => 'state_province',
+          'is_required' => 1,
+          'visibility' => 'Public Pages and Listings',
+          'field_type' => 'Contact',
+          'location_type_id' => 1,
+          'label' => 'State Province',
+        ],
+        [
+          'field_name' => 'postal_code',
+          'is_required' => 0,
+          'field_type' => 'Contact',
+          'location_type_id' => 1,
+          'label' => 'State Province',
+        ],
+        [
+          'field_name' => 'im',
+          'is_required' => 0,
+          'visibility' => 'User and User Admin Only',
+          'label' => 'Messenger',
+          'field_type' => 'Contact',
+        ],
+        [
+          'field_name' => 'url',
+          'is_required' => 0,
+          'visibility' => 'User and User Admin Only',
+          'label' => 'Website',
+          'website_type_id' => 1,
+          'field_type' => 'Contact',
+        ],
+      ],
+    ];
+    $profile = $this->callAPISuccess('uf_group', 'create', $ufGroupParams);
+    $this->addCustomFieldToProfile($profile['id']);
+    // Add some more fields
+
     $result = $this->callAPISuccess('profile', 'getfields', [
       'action' => 'submit',
-      'profile_id' => $this->_profileID,
+      'profile_id' => $profile['id'],
     ]);
     $this->assertArrayKeyExists('first_name', $result['values']);
     $this->assertEquals('2', $result['values']['first_name']['type']);
     $this->assertEquals('Email', $result['values']['email-primary']['title']);
+    $this->assertEquals('phone', $result['values']['phone-primary-1']['entity']);
+    $this->assertEquals('phone', $result['values']['phone_and_ext-1-2']['entity']);
     $this->assertEquals('civicrm_state_province', $result['values']['state_province-1']['pseudoconstant']['table']);
     $this->assertEquals('defaultValue', $result['values']['custom_1']['default_value']);
     $this->assertArrayNotHasKey('participant_status', $result['values']);
+    $this->assertEquals('website', $result['values']['url-1']['entity']);
+    $this->assertEquals('im', $result['values']['im-primary']['entity']);
   }
 
   /**
@@ -368,29 +451,6 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
   }
 
   /**
-   * Check Without ProfileId.
-   */
-  public function testProfileSubmitWithoutProfileId(): void {
-    $params = [
-      'contact_id' => 1,
-    ];
-    $this->callAPIFailure('profile', 'submit', $params,
-      'Mandatory key(s) missing from params array: profile_id'
-    );
-  }
-
-  /**
-   * Check with no invalid profile Id.
-   */
-  public function testProfileSubmitInvalidProfileId(): void {
-    $params = [
-      'contact_id' => 1,
-      'profile_id' => 1000,
-    ];
-    $this->callAPIFailure('profile', 'submit', $params);
-  }
-
-  /**
    * Check with missing required field in profile.
    */
   public function testProfileSubmitCheckProfileRequired(): void {
@@ -423,6 +483,37 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
     $profileFieldValues = $this->createIndividualContact();
     $contactId = key($profileFieldValues);
 
+    // Add a few more fields
+    civicrm_api3('UfGroup', 'get', [
+      'id' => $this->_profileID,
+      'api.uf_field.create' => [
+        [
+          'field_name' => 'im',
+          'is_required' => 0,
+          'visibility' => 'User and User Admin Only',
+          'label' => 'Messenger',
+          'field_type' => 'Contact',
+        ],
+        [
+          'field_name' => 'url',
+          'is_required' => 0,
+          'visibility' => 'User and User Admin Only',
+          'label' => 'Website',
+          'website_type_id' => 1,
+          'field_type' => 'Contact',
+        ],
+        [
+          'field_name' => 'city',
+          'is_required' => FALSE,
+          'visibility' => 'User and User Admin Only',
+          'location_type_id' => NULL,
+          'phone_type_id' => NULL,
+          'website_type_id' => NULL,
+          'field_type' => 'Contact',
+        ],
+      ],
+    ]);
+
     $updateParams = [
       'first_name' => 'abc2',
       'last_name' => 'xyz2',
@@ -430,6 +521,9 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
       'phone-1-1' => '022 321 826',
       'country-1' => '1013',
       'state_province-1' => '1000',
+      'city-primary' => 'Somewhere',
+      'url-1' => 'http://example.com',
+      'im-primary' => 'abc2xyz2',
     ];
 
     $params = array_merge([
@@ -446,8 +540,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
     $profileDetails = $this->callAPISuccess('profile', 'get', $getParams);
 
     foreach ($updateParams as $profileField => $value) {
-      $this->assertEquals($value, $profileDetails['values'][$profileField], "missing/mismatching value for $profileField"
-      );
+      $this->assertEquals($value, $profileDetails['values'][$profileField], "missing/mismatching value for $profileField");
     }
     unset($params['email-primary']);
     $params['email-Primary'] = 'my@mail.com';


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bugs in ContactLayout editor where certain profile fields were not working.

See https://chat.civicrm.org/civicrm/pl/7uxoyoktqjrbbrhez9yny9r8wa

Technical Details
----------------------------------------
The Api3 Profile functions are pretty bad.
Due to (incomplete) hard-coding, Primary address fields, website fields, IM fields were all broken amid a sea of messy code.
I've fixed those fields and added test coverage, but the code is still a mess.