### PR TITLE
fixes warning buildRecurBlock

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -680,9 +680,9 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       if ($buildRecurBlock) {
         $this->buildRecur();
         $this->setDefaults(['is_recur' => 0]);
-        $this->assign('buildRecurBlock', TRUE);
       }
     }
+    $this->assign('buildRecurBlock', $buildRecurBlock);
     $this->addPaymentProcessorSelect(FALSE, $buildRecurBlock);
 
     $qfKey = $this->controller->_key;


### PR DESCRIPTION
Overview
----------------------------------------
Removes a warning concerning undefined array key "buildRecurBlock" in Payment.tpl.php and Contribution.tpl.php.

Before
----------------------------------------
The variable buildRecurBlock is only assigned to the template when it is TRUE. In some environments the user gets a warning when the variable is not set.

![image](https://github.com/user-attachments/assets/408bb055-0b77-4ab8-a78e-3b6905638a38)


After
----------------------------------------
Assigns buildRecurBlock in all cases.

Technical Details
----------------------------------------
This is a very small change. I just moved 1 line of code outside an IF-block.

Comments
----------------------------------------
Related to https://lab.civicrm.org/dev/core/-/issues/4719
