### PR TITLE
[REF] Chart kit - move reduce types to a separate service

### DIFF
--- a/ext/chart_kit/README.md
+++ b/ext/chart_kit/README.md
@@ -58,6 +58,6 @@ Edit the render logic in `ang/crmChartKit/crmSearchDisplayChartKit.component.js`
 
 ### To implement a new chart type
 
-To add a new chart type, add an additional service and admin template in `ang/crmChartKit/chartTypes` and then add to the list of available chart types in `ang/crmChartKit/chartKitTypes.service.js`
+To add a new chart type, add an additional service and admin template in `ang/crmChartKit/chartTypes` and then add to the list of available chart types in `ang/crmChartKit/chartKitChartTypes.service.js`
 
-TODO: implementing a new chart type in a separate extension. Need to add some kind of hook to gather chart types from elsewhere in `ang/crmChartKit/chartKitTypes.service.js`...
+TODO: implementing a new chart type in a separate extension. Need to add some kind of hook to gather chart types from elsewhere in `ang/crmChartKit/chartKitChartTypes.service.js`...

--- a/ext/chart_kit/ang/crmChartKit/chartKitChartTypes.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartKitChartTypes.service.js
@@ -2,7 +2,7 @@
   "use strict";
 
   // Provides pluggable chart types for use in the chart_kit display and admin components
-  angular.module('crmChartKit').factory('chartKitTypes', (
+  angular.module('crmChartKit').factory('chartKitChartTypes', (
     chartKitPie,
     chartKitRow,
     chartKitStack,

--- a/ext/chart_kit/ang/crmChartKit/chartKitColumnConfig.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartKitColumnConfig.service.js
@@ -6,32 +6,6 @@
         const ts = CRM.ts('chart_kit');
 
         return {
-            reduceType: [
-                {
-                    key: 'sum',
-                    label: ts('Sum')
-                },
-                {
-                    key: 'count',
-                    label: ts('Count')
-                },
-                {
-                    key: 'mean',
-                    label: ts('Average')
-                },
-                {
-                    key: "percentage_sum",
-                    label: ts("Percentage of total"),
-                },
-                {
-                    key: "percentage_count",
-                    label: ts("Percentage of count"),
-                },
-                {
-                    key: 'list',
-                    label: ts('List')
-                }
-            ],
             scaleType: [
                 {
                     key: 'numeric',

--- a/ext/chart_kit/ang/crmChartKit/chartKitReduceTypes.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartKitReduceTypes.service.js
@@ -1,0 +1,73 @@
+(function (angular, $, _) {
+  "use strict";
+
+  // Provides pluggable reducer for use in the chart_kit crossfilter
+  // - see `buildGroup` function in `crmSearchDisplayChartKit`
+  // - in the UI these are exposed as "Stat type"
+  angular.module('crmChartKit').factory('chartKitReduceTypes', () => {
+
+    const ts = CRM.ts('chart_kit');
+
+    return [
+        {
+            key: 'sum',
+            label: ts('Sum'),
+            final: (f) => f,
+            add: (p, v) => p + v,
+            sub: (p, v) => p - v,
+            start: () => 0
+        },
+        {
+            key: 'count',
+            label: ts('Count'),
+            final: (f) => f,
+            add: (p, v) => p + 1,
+            sub: (p, v) => p - 1,
+            start: () => 0
+        },
+        {
+            key: 'mean',
+            label: ts('Average'),
+            final: (f) => f[0] / f[1],
+            add: (p, v) => [
+              p[0] + v,
+              p[1] + 1,
+            ],
+            sub: (p, v) => [
+              p[0] - v,
+              p[1] - 1,
+            ],
+            start: () => [0, 0]
+        },
+        {
+            key: "percentage_sum",
+            label: ts("Percentage of total"),
+            final: (f, total) => f / total,
+            add: (p, v) => p + v,
+            sub: (p, v) => p - v,
+            start: () => 0
+        },
+        {
+            key: "percentage_count",
+            label: ts("Percentage of count"),
+            final: (f, total) => f / total,
+            add: (p, v) => p + 1,
+            sub: (p, v) => p - 1,
+            start: () => 0
+        },
+        {
+            key: 'list',
+            label: ts('List'),
+            final: (f) => f,
+            add: (p, v) => {
+              if (p.indexOf(v) < 0) {
+                p.push(v);
+              }
+              return p;
+            },
+            sub: (p, v) => p.filter((x) => x != v),
+            start: () => []
+        }
+    ];
+  });
+})(angular, CRM.$, CRM._);

--- a/ext/chart_kit/ang/crmChartKit/crmSearchDisplayChartKit.component.js
+++ b/ext/chart_kit/ang/crmChartKit/crmSearchDisplayChartKit.component.js
@@ -15,7 +15,7 @@
             afFieldset: '?^^afFieldset'
         },
         templateUrl: '~/crmChartKit/chartKitCanvas.html',
-        controller: function ($scope, $element, searchDisplayBaseTrait, chartKitTypes, chartKitReduceTypes) {
+        controller: function ($scope, $element, searchDisplayBaseTrait, chartKitChartTypes, chartKitReduceTypes) {
             const ts = $scope.ts = CRM.ts('chart_kit');
 
             // Mix in base display trait
@@ -94,7 +94,7 @@
             };
 
             this.initChartType = () => {
-                const type = chartKitTypes.find((type) => type.key === this.settings.chartType);
+                const type = chartKitChartTypes.find((type) => type.key === this.settings.chartType);
                 this.chartType = type.service;
             };
 

--- a/ext/chart_kit/ang/crmChartKit/crmSearchDisplayChartKit.component.js
+++ b/ext/chart_kit/ang/crmChartKit/crmSearchDisplayChartKit.component.js
@@ -15,7 +15,7 @@
             afFieldset: '?^^afFieldset'
         },
         templateUrl: '~/crmChartKit/chartKitCanvas.html',
-        controller: function ($scope, $element, searchDisplayBaseTrait, chartKitTypes) {
+        controller: function ($scope, $element, searchDisplayBaseTrait, chartKitTypes, chartKitReduceTypes) {
             const ts = $scope.ts = CRM.ts('chart_kit');
 
             // Mix in base display trait
@@ -176,76 +176,18 @@
                     return;
                 }
 
-                // define our custom reducer functions based on the reduceType of each column
-                const reduceAdd = (p, v) => this.getColumns().map((col) => {
-                    switch (col.reduceType) {
-                        case 'mean':
-                            const previous = p[col.index];
-                            return [
-                                previous[0] + v[col.index],
-                                previous[1] + 1
-                            ];
-                        case 'list':
-                            // add the new value if we dont already have it
-                            if (p[col.index].indexOf(v[col.index]) < 0) {
-                                p[col.index].push(v[col.index]);
-                            }
+                const cols = this.getColumnsWithReducers();
 
-                            return p[col.index];
-                        // we track the same value for percentages
-                        // we'll just divide by the total across all
-                        // records when displaying
-                        case 'percentage_count':
-                        case 'count':
-                            // just increment the record counter
-                            return p[col.index] + 1;
-                        case 'percentage_sum':
-                        case 'sum':
-                        default:
-                            // default reduce type is SUM
-                            return p[col.index] + v[col.index];
-                    }
+                // reduce every coordinate using the functions from its column reduce type
+                const reduceAdd = (p, v) => cols.map((col) => {
+                    return col.reducer.add(p[col.index], v[col.index]);
                 });
-                const reduceSub = (p, v) => this.getColumns().map((col) => {
-                    switch (col.reduceType) {
-                        case 'mean':
-                            // increment the SUM and COUNT sub-coordinates
-                            const previous = p[col.index];
-                            return [
-                                previous[0] - v[col.index],
-                                previous[1] - 1
-                            ];
-                        case 'list':
-                            // remove value from the list
-                            return p[col.index].filter((item) => (item !== v[col.index]));
-                        case 'percentage_count':
-                        case 'count':
-                            // just decrement the record counter
-                            return p[col.index] - 1;
-                        case 'percentage_sum':
-                        case 'sum':
-                        default:
-                            // default reduce type is SUM
-                            return p[col.index] - v[col.index];
-                    }
+                const reduceSub = (p, v) => cols.map((col) => {
+                    return col.reducer.sub(p[col.index], v[col.index]);
                 });
-                // start with an array of "zeroes"
-                // though what zero is depends on the reduce type...
-                // NOTE we dont use getColumns because we need to leave gaps
-                // in the starting array for unset columns (which are excluded from getColumns)
-                const reduceStart = () => this.settings.columns.map((col) => {
-                    switch (col.reduceType) {
-                        case 'mean':
-                            // sub-coordinates for SUM and COUNT
-                            return [0, 0];
-                        case 'list':
-                            return [];
-                        default:
-                            // COUNT or SUM
-                            return 0;
-                    }
+                const reduceStart = () => cols.map((col) => {
+                    return col.reducer.start();
                 });
-
 
                 this.group = this.dimension.group().reduce(reduceAdd, reduceSub, reduceStart);
 
@@ -411,7 +353,6 @@
                     .clipPadding(this.settings.format.padding.clip ? this.settings.format.padding.clip : 20);
             };
 
-
             this.addLegend = () => {
                 const legend = dc.legend();
 
@@ -448,6 +389,22 @@
 
             this.getColumnsForAxis = (axisKey) => this.getColumns().filter((col) => col.axis === axisKey);
 
+            /**
+             * Get the reducer for a column, based on its reduceType key
+             * ( defaults to returning the "list" reducer if reduceType isn't set )
+             */
+            this.getReducerForColumn = (col) => {
+                if (col.reduceType) {
+                  return chartKitReduceTypes.find((type) => type.key === col.reduceType);
+                }
+                return chartKitReduceTypes.find((type) => type.key === 'list');
+            };
+
+            this.getColumnsWithReducers = () => this.getColumns().map((col) => {
+                col.reducer = this.getReducerForColumn(col);
+                return col;
+            });
+
             this.getXColumn = () => this.getColumnsForAxis('x')[0];
 
             this.getOrderColumn = () => this.getColumns()[parseInt(this.settings.chartOrderColIndex ? this.settings.chartOrderColIndex : 0)];
@@ -464,17 +421,9 @@
             this.getValueAccessor = (col) => ((d) => {
                 const columnData = d.value[col.index];
 
-                switch (col.reduceType) {
-                    case 'mean':
-                        return columnData[0] / columnData[1];
-                    case 'percentage_count':
-                    case 'percentage_sum':
-                        return columnData / this.columnTotals[col.index];
-                    case 'list':
-                    case 'count':
-                    case 'sum':
-                        return columnData;
-                }
+                const reducer = this.getReducerForColumn(col);
+
+                return reducer.final(columnData, this.columnTotals[col.index]);
             });
 
 
@@ -541,17 +490,20 @@
             };
 
             this.renderReduceTypeValue = (value, col) => {
+                const reducer = this.getReducerForColumn(col);
+
+                value = reducer.final(value, this.columnTotals[col.index]);
+
+                // list and percentage are special cases
+                // for how we apply data value renderer
                 switch (col.reduceType) {
                     case 'list':
-                        // we need to apply the datavalue mapping to each element
+                        // we need to apply the datavalue rendering to each element
                         return value.map((item) => this.renderDataValue(item, col)).join(', ');
-                    case 'mean':
-                        const mean = value[0] / value[1];
-                        return this.renderDataValue(mean, col);
                     case 'percentage_sum':
                     case 'percentage_count':
                         // TODO would we ever need to call renderDataValue here? before or after division?
-                        const percentage = Math.floor(100 * value / this.columnTotals[col.index]);
+                        const percentage = Math.floor(100 * value);
                         return `${percentage}%`;
                     default:
                         return this.renderDataValue(value, col);

--- a/ext/chart_kit/ang/crmChartKit/searchAdminDisplayChartKit.component.js
+++ b/ext/chart_kit/ang/crmChartKit/searchAdminDisplayChartKit.component.js
@@ -12,7 +12,7 @@
             crmSearchAdmin: '^crmSearchAdmin'
         },
         templateUrl: '~/crmChartKit/searchAdminDisplayChartKit.html',
-        controller: function ($scope, searchMeta, chartKitColumnConfig, chartKitTypes) {
+        controller: function ($scope, searchMeta, chartKitColumnConfig, chartKitTypes, chartKitReduceTypes) {
             const ts = $scope.ts = CRM.ts('chart_kit');
 
             this.getColumnSlots = () => this.display.settings.columns.map((col, colIndex) => {
@@ -137,7 +137,7 @@
             this.axisDefaults = () => {
                 return {
                     // by default allow all types we know
-                    reduceTypes: chartKitColumnConfig.reduceType.map((type) => type.key),
+                    reduceTypes: chartKitReduceTypes.map((type) => type.key),
                     scaleTypes: chartKitColumnConfig.scaleType.map((type) => type.key),
                     dataLabelTypes: chartKitColumnConfig.dataLabelType.map((type) => type.key),
                     // by default no option
@@ -332,8 +332,15 @@
                 .map((optionKey) => this.getOptionDetailsForKey(configKey, optionKey))
                 .filter((details) => !!details);
 
-            this.getAllOptionDetails = (configKey) =>
-                (configKey === 'searchColumn') ? this.searchColumns : chartKitColumnConfig[configKey];
+            this.getAllOptionDetails = (configKey) => {
+                if (configKey === 'searchColumn') {
+                    return this.searchColumns;
+                }
+                if (configKey === 'reduceType') {
+                    return chartKitReduceTypes;
+                }
+                return chartKitColumnConfig[configKey];
+            };
 
             this.getOptionDetailsForKey = (configKey, optionKey) => this.getAllOptionDetails(configKey).find((option) => option.key === optionKey);
 

--- a/ext/chart_kit/ang/crmChartKit/searchAdminDisplayChartKit.component.js
+++ b/ext/chart_kit/ang/crmChartKit/searchAdminDisplayChartKit.component.js
@@ -12,7 +12,7 @@
             crmSearchAdmin: '^crmSearchAdmin'
         },
         templateUrl: '~/crmChartKit/searchAdminDisplayChartKit.html',
-        controller: function ($scope, searchMeta, chartKitColumnConfig, chartKitTypes, chartKitReduceTypes) {
+        controller: function ($scope, searchMeta, chartKitColumnConfig, chartKitChartTypes, chartKitReduceTypes) {
             const ts = $scope.ts = CRM.ts('chart_kit');
 
             this.getColumnSlots = () => this.display.settings.columns.map((col, colIndex) => {
@@ -28,7 +28,7 @@
                 return this.getColumns().filter((col) => col.axis === axisKey);
             };
 
-            this.getChartTypeOptions = () => chartKitTypes.map((type) => ({ key: type.key, label: type.label, icon: type.icon }));
+            this.getChartTypeOptions = () => chartKitChartTypes.map((type) => ({ key: type.key, label: type.label, icon: type.icon }));
 
             this.getInitialDisplaySettings = () => ({
                 columns: [],
@@ -81,7 +81,7 @@
             };
 
             this.initChartType = () => {
-                const type = chartKitTypes.find((type) => type.key === this.display.settings.chartType);
+                const type = chartKitChartTypes.find((type) => type.key === this.display.settings.chartType);
                 this.chartType = type.service;
             };
 


### PR DESCRIPTION
Overview
----------------------------------------
Refactor `reduceType` implementation in ChartKit to more object-oriented service.

Before
----------------------------------------
- you can choose different reduce types (they are labelled "Stat Type" in the UI) for your columns in Chart Kit, which determine how values in that column are aggregated (e.g. sum / count / average / percentage).
- the implementation relies on lots of `switch` statements

After
----------------------------------------
- same choices available
- the implementation relies on a service which provides the available "reducers". Reducers are defined by `start`, `add`, `sub` which are passed through when generating the crossfilter, and a `final` function which computes the final value (e.g. for average we need to keep track of the sum and count as we add and sub records, and then divide one by the other to get the final value)


Comments
----------------------------------------
I renamed `chartKitTypes` to `chartKitChartTypes` for more consistent distinction from `chartKitReduceTypes`.

This PR is first step on a bigger refactor journey, to allow for cleaner column handling with more chart types (like https://lab.civicrm.org/extensions/chart_kit/-/merge_requests/19 https://lab.civicrm.org/extensions/chart_kit/-/merge_requests/18)
