### PR TITLE
[REF] Migrate determining the connection details to use from Drupal8 …

### DIFF
--- a/setup/plugins/init/Drupal8.civi-setup.php
+++ b/setup/plugins/init/Drupal8.civi-setup.php
@@ -39,16 +39,33 @@ if (!defined('CIVI_SETUP')) {
     }
 
     // Compute DSN.
-    $connectionOptions = \Civi\Setup\DrupalUtil::get_database_configuration()['info'];
+    $connectionDetails = \Civi\Setup\DrupalUtil::get_database_configuration();
+    $connectionOptions = $connectionDetails['info'];
     $ssl_params = \Civi\Setup\DrupalUtil::guessSslParams($connectionOptions);
     // @todo Does Drupal support unixsocket in config? Set 'server' => 'unix(/path/to/socket.sock)'
-    $model->db = $model->cmsDb = array(
+    $model->db = array(
       'server' => \Civi\Setup\DbUtil::encodeHostPort($connectionOptions['host'], $connectionOptions['port'] ?? NULL),
       'username' => $connectionOptions['username'],
       'password' => $connectionOptions['password'],
       'database' => $connectionOptions['database'],
       'ssl_params' => empty($ssl_params) ? NULL : $ssl_params,
     );
+
+    if ($connectionDetails['key'] === 'default') {
+      $model->cmsDb = $model->db;
+    }
+    else {
+      $connectionOptions = \Drupal\Core\Database\Database::getConnectionInfo('default')['default'];
+      $ssl_params = \Civi\Setup\DrupalUtil::guessSslParams($connectionOptions);
+      // @todo Does Drupal support unixsocket in config? Set 'server' => 'unix(/path/to/socket.sock)'
+      $model->cmsDb = array(
+        'server' => \Civi\Setup\DbUtil::encodeHostPort($connectionOptions['host'], $connectionOptions['port'] ?? NULL),
+        'username' => $connectionOptions['username'],
+        'password' => $connectionOptions['password'],
+        'database' => $connectionOptions['database'],
+        'ssl_params' => empty($ssl_params) ? NULL : $ssl_params,
+      );
+    }
 
     // Compute cmsBaseUrl.
     if (empty($model->cmsBaseUrl)) {

--- a/setup/plugins/init/Drupal8.civi-setup.php
+++ b/setup/plugins/init/Drupal8.civi-setup.php
@@ -39,7 +39,7 @@ if (!defined('CIVI_SETUP')) {
     }
 
     // Compute DSN.
-    $connectionOptions = \Drupal::database()->getConnectionOptions();
+    $connectionOptions = \Civi\Setup\DrupalUtil::get_database_configuration()['info'];
     $ssl_params = \Civi\Setup\DrupalUtil::guessSslParams($connectionOptions);
     // @todo Does Drupal support unixsocket in config? Set 'server' => 'unix(/path/to/socket.sock)'
     $model->db = $model->cmsDb = array(

--- a/setup/src/Setup/DrupalUtil.php
+++ b/setup/src/Setup/DrupalUtil.php
@@ -1,6 +1,8 @@
 <?php
 namespace Civi\Setup;
 
+use Drupal\Core\Database\Database;
+
 class DrupalUtil {
 
   /**

--- a/setup/src/Setup/DrupalUtil.php
+++ b/setup/src/Setup/DrupalUtil.php
@@ -83,4 +83,41 @@ class DrupalUtil {
     return $ssl_params;
   }
 
+  /**
+   * Attempt to use a 'civicrm' labelled database connection if one exists.
+   *
+   * Otherwise default to using the same connection used by drupal.
+   * Also handle the special case where this is running as a test.
+   *
+   * @return string[]
+   *   An array of what database-config to use.
+   */
+  public static function get_database_configuration(): array {
+    if (drupal_valid_test_ua()) {
+      $config = Database::getConnectionInfo('civicrm_test');
+      if ($config) {
+        return [
+          'key' => 'civicrm_test',
+          'info' => $config['default'],
+        ];
+      }
+      else {
+        throw new \RuntimeException("No civicrm_test database provided");
+      }
+    }
+
+    if ($config = Database::getConnectionInfo('civicrm')) {
+      return [
+        'key' => 'civicrm',
+        'info' => $config['default'],
+      ];
+    }
+    else {
+      return [
+        'key' => 'default',
+        'info' => Database::getConnectionInfo('default')['default'],
+      ];
+    }
+  }
+
 }


### PR DESCRIPTION
…install file into setup code

Overview
----------------------------------------
This shifts code that is used for determining the database connection strings for Drupal 9/10/11 on install from the install.php file in the module into the setup library as per the fixme https://github.com/civicrm/civicrm-drupal-8/blob/master/civicrm.install#L128

Before
----------------------------------------
Code lives in install.php and doesn't handle MySQL SSL well

After
----------------------------------------
Code lives in setup library and better handling for MySQL ssl

ping @jackrabbithanna @demeritcowboy @totten 