### PR TITLE
Profile - Fix e-notice when displaying website field with no value

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -976,7 +976,7 @@ class CRM_Utils_System {
    *   The fixed URL.
    */
   public static function fixURL($url) {
-    $components = parse_url($url);
+    $components = parse_url($url ?? '');
 
     if (!$components) {
       return NULL;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a php e-notice, passing NULL to `parse_url()` which expects a string.