### PR TITLE
dev/core#5711 Escape html attributes in titles

### DIFF
--- a/templates/CRM/Contact/Page/View/GroupContact.tpl
+++ b/templates/CRM/Contact/Page/View/GroupContact.tpl
@@ -47,9 +47,9 @@
             <td>{$row.in_date|crmDate}</td>
             <td>
               {if $permission EQ 'edit'}
-                <a class="action-item crm-hover-button" href="#Removed" title="{ts 1=$displayName 2=$row.title}Remove %1 from %2? (status in this group will be changed to 'Removed').{/ts}">
+                <a class="action-item crm-hover-button" href="#Removed" title="{ts 1=$displayName 2=$row.title escape='htmlattribute'}Remove %1 from %2? (status in this group will be changed to 'Removed').{/ts}">
                   {ts}Remove{/ts}</a>
-                <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2? (remove contact AND delete their record of having been in this group).{/ts}">
+                <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title escape='htmlattribute'}Delete %1 from %2? (remove contact AND delete their record of having been in this group).{/ts}">
                   {ts}Delete{/ts}</a>
               {/if}
             </td>
@@ -98,9 +98,9 @@
             <td>{$row.pending_date|crmDate}</td>
             <td>
               {if $permission EQ 'edit'}
-                <a class="action-item crm-hover-button" href="#Removed" title="{ts 1=$displayName 2=$row.title}Remove %1 from %2? (status in this group will be changed to 'Removed').{/ts}">
+                <a class="action-item crm-hover-button" href="#Removed" title="{ts 1=$displayName 2=$row.title escape='htmlattribute'}Remove %1 from %2? (status in this group will be changed to 'Removed').{/ts}">
                   {ts}Remove{/ts}</a>
-                <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2? (this group will no longer be listed under Pending Groups){/ts}">
+                <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title escape='htmlattribute'}Delete %1 from %2? (this group will no longer be listed under Pending Groups){/ts}">
                   {ts}Delete{/ts}</a>
               {/if}
             </td>
@@ -139,11 +139,11 @@
             <td>
               {if $permission EQ 'edit'}
                 {if $row.saved_search_id}
-                <a class="action-item crm-hover-button" href="#Added" title="{ts 1=$displayName 2=$row.title}Add %1 manually into %2, overriding smart group critera?{/ts}">
+                <a class="action-item crm-hover-button" href="#Added" title="{ts 1=$displayName 2=$row.title escape='htmlattribute'}Add %1 manually into %2, overriding smart group critera?{/ts}">
                   {ts}Manual Add{/ts}
                 </a>
                 {else}
-                <a class="action-item crm-hover-button" href="#Added" title="{ts 1=$displayName 2=$row.title}Add %1 back into %2?{/ts}">
+                <a class="action-item crm-hover-button" href="#Added" title="{ts 1=$displayName 2=$row.title escape='htmlattribute'}Add %1 back into %2?{/ts}">
                   {ts}Rejoin Group{/ts}
                 </a>
                 {/if}
@@ -152,11 +152,11 @@
             <td>
               {if $permission EQ 'edit'}
                 {if $row.saved_search_id}
-                <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2?{/ts} {ts}They will be in the smart group or not based on the smart group criteria.{/ts}">
+                <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title escape='htmlattribute'}Delete %1 from %2?{/ts} {ts}They will be in the smart group or not based on the smart group criteria.{/ts}">
                   {ts}Delete{/ts}
                 </a>
                 {else}
-                <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2?{/ts} {ts}This group will no longer be listed under Removed Groups.{/ts}">
+                <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title escape='htmlattribute'}Delete %1 from %2?{/ts} {ts}This group will no longer be listed under Removed Groups.{/ts}">
                   {ts}Delete{/ts}
                 </a>
                 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5711](https://lab.civicrm.org/dev/core/-/issues/5711)

Technical Details
------
Uses escape mode introduced in https://github.com/civicrm/civicrm-core/pull/26792

Comments
----------------------------------------

Really I think we ought to do this for every html attribute that contains `{ts}`.