### PR TITLE
(dev/core#5712) Debug Mode - Provide consistent behavior for BD/D7

### DIFF
--- a/CRM/Core/Region.php
+++ b/CRM/Core/Region.php
@@ -64,6 +64,11 @@ class CRM_Core_Region implements CRM_Core_Resources_CollectionInterface, CRM_Cor
     if (defined('CIVICRM_IFRAME')) {
       $allowCmsOverride = FALSE;
     }
+    if (Civi::settings()->get('debug_enabled')) {
+      // The point of debug mode is to allow debugging. The CMS override only applies on BD/D7, and it makes debugging harder.
+      // https://lab.civicrm.org/dev/core/-/issues/5712
+      $allowCmsOverride = FALSE;
+    }
 
     Civi::dispatcher()->dispatch('civi.region.render', \Civi\Core\Event\GenericHookEvent::create(['region' => $this]));
 


### PR DESCRIPTION
Overview
----------------------------------------

See: https://lab.civicrm.org/dev/core/-/issues/5712

TLDR: On Backdrop and Drupal 7, the "Debug Mode" has exactly the wrong effect in some configurations -- it becomes _harder_ to test+develop (if the CMS setting `preprocess_js` is concurrently enabled).

Before
----------------------------------------

If you enable "Debug Mode", and if BD/D7 have `preprocess_js=1`, then you cannot reload updated JS files in an Angular page -- even if you repeatedly call `cv flush` or `civicrm/clearcache`.

After
----------------------------------------

If you enable "Debug Mode", then you can reload updated JS files (with or without `cv flush`).

Comments
----------------------------------------

The content of `$allowCmsOverride` only matters if the CMS has an override in `CRM_Utils_System_*::addScriptUrl()`. BD/D7 are the only systems which define the override, so they're the only systems that would see a change.