### PR TITLE
dev/core#5711 Smarty - Escape all translated html attributes

### DIFF
--- a/ext/civigrant/templates/CRM/Grant/Form/Selector.tpl
+++ b/ext/civigrant/templates/CRM/Grant/Form/Selector.tpl
@@ -16,7 +16,7 @@
   <thead class="sticky">
   <tr>
   {if ! $single and $context eq 'Search'}
-     <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
+     <th scope="col" title="{ts escape='htmlattribute'}Select rows{/ts}">{$form.toggleSelect.html}</th>
   {/if}
   {foreach from=$columnHeaders item=header}
     <th scope="col">

--- a/ext/ckeditor4/templates/CRM/Ckeditor4/Form/CKEditorConfig.tpl
+++ b/ext/ckeditor4/templates/CRM/Ckeditor4/Form/CKEditorConfig.tpl
@@ -71,7 +71,7 @@
       </select>
       &nbsp;&nbsp;
       <label for="extraPlugins">{ts}Plugins{/ts}</label>
-      <input id="extraPlugins" name="config_extraPlugins" class="huge config-param" value="{$extraPlugins}" placeholder="{ts}Select optional extra features{/ts}">
+      <input id="extraPlugins" name="config_extraPlugins" class="huge config-param" value="{$extraPlugins}" placeholder="{ts escape='htmlattribute'}Select optional extra features{/ts}">
     </div>
 
     <div class="editors-container">
@@ -98,6 +98,6 @@
 </div>
 <script type="text/template" id="config-row-tpl">
   <div class="crm-config-option-row">
-    <input class="huge crm-config-option-name" placeholder="{ts}Option{/ts}"/>
+    <input class="huge crm-config-option-name" placeholder="{ts escape='htmlattribute'}Option{/ts}"/>
   </div>
 </script>

--- a/ext/eventcart/templates/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.tpl
+++ b/ext/eventcart/templates/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.tpl
@@ -2,7 +2,7 @@
 
   {if $contact}
     <div class="messages status no-popup">
-      {ts 1=$contact.display_name}Welcome %1{/ts}. (<a href="{crmURL p='civicrm/event/cart_checkout' q="cid=0&reset=1"}" title="{ts}Click here to register a different person for this event.{/ts}">{ts 1=$contact.display_name}Not %1, or want to register a different person{/ts}</a>?)</div>
+      {ts 1=$contact.display_name}Welcome %1{/ts}. (<a href="{crmURL p='civicrm/event/cart_checkout' q="cid=0&reset=1"}" title="{ts escape='htmlattribute'}Click here to register a different person for this event.{/ts}">{ts 1=$contact.display_name}Not %1, or want to register a different person{/ts}</a>?)</div>
   {/if}
 
   {foreach from=$events_in_carts key=index item=event_in_cart}

--- a/ext/eventcart/templates/CRM/Event/Cart/Page/ViewCart.tpl
+++ b/ext/eventcart/templates/CRM/Event/Cart/Page/ViewCart.tpl
@@ -20,7 +20,7 @@
         {if !$event_in_cart.main_conference_event_id}
           <tr>
             <td>
-              <a href="{crmURL p='civicrm/event/info' q="reset=1&id=`$event_in_cart.event.id`"}" title="{ts}View event info page{/ts}" class="bold">{$event_in_cart.event.title}</a>
+              <a href="{crmURL p='civicrm/event/info' q="reset=1&id=`$event_in_cart.event.id`"}" title="{ts escape='htmlattribute'}View event info page{/ts}" class="bold">{$event_in_cart.event.title}</a>
             </td>
             <td>
               <a title="Remove From Cart" class="action-item" href="{crmURL p='civicrm/event/remove_from_cart' q="reset=1&id=`$event_in_cart.event.id`"}">{ts}Remove{/ts}</a>

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom.tpl
@@ -59,7 +59,7 @@
         {/if}
 
         {strip}
-        <table class="selector row-highlight" summary="{ts}Search results listings.{/ts}">
+        <table class="selector row-highlight" summary="{ts escape='htmlattribute'}Search results listings.{/ts}">
             <thead class="sticky">
                 <tr>
                 <th scope="col" title="Select All Rows">{$form.toggleSelect.html}</th>

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/ActivitySearch.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/ActivitySearch.tpl
@@ -56,7 +56,7 @@
           {include file="CRM/common/pagerAToZ.tpl"}
 
           {strip}
-            <table summary="{ts}Search results listings.{/ts}">
+            <table summary="{ts escape='htmlattribute'}Search results listings.{/ts}">
               <thead class="sticky">
                 <th scope="col" title="Select All Rows">{$form.toggleSelect.html}</th>
                 {foreach from=$columnHeaders item=header}
@@ -88,9 +88,9 @@
                       {elseif $fName eq 'activity_subject'}
                          <td>
                            {if $row.case_id}
-                              <a href="{crmURL p='civicrm/case/activity/view' q="reset=1&aid=`$row.activity_id`&cid=`$row.contact_id`&caseID=`$row.case_id`"}" title="{ts}View activity details{/ts}">
+                              <a href="{crmURL p='civicrm/case/activity/view' q="reset=1&aid=`$row.activity_id`&cid=`$row.contact_id`&caseID=`$row.case_id`"}" title="{ts escape='htmlattribute'}View activity details{/ts}">
                            {else}
-                              <a href="{crmURL p='civicrm/contact/view/activity' q="atype=`$row.activity_type_id`&action=view&reset=1&id=`$row.activity_id`&cid=`$row.contact_id`"}" title="{ts}View activity details{/ts}">
+                              <a href="{crmURL p='civicrm/contact/view/activity' q="atype=`$row.activity_type_id`&action=view&reset=1&id=`$row.activity_id`&cid=`$row.contact_id`"}" title="{ts escape='htmlattribute'}View activity details{/ts}">
                            {/if}
                            {if isset($row.activity_subject) AND $row.activity_subject NEQ 'NULL'}{$row.activity_subject}{else}{ts}(no subject){/ts}{/if}</a>
                          </td>

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/ContribSYBNT.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/ContribSYBNT.tpl
@@ -88,7 +88,7 @@
         {/if}
 
         {strip}
-        <table class="selector row-highlight" summary="{ts}Search results listings.{/ts}">
+        <table class="selector row-highlight" summary="{ts escape='htmlattribute'}Search results listings.{/ts}">
             <thead class="sticky">
                 <th scope="col" title="Select All Rows">{$form.toggleSelect.html}</th>
                 {foreach from=$columnHeaders item=header}

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/ContributionAggregate.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/ContributionAggregate.tpl
@@ -68,7 +68,7 @@
         {/if}
 
         {strip}
-        <table class="selector row-highlight" summary="{ts}Search results listings.{/ts}">
+        <table class="selector row-highlight" summary="{ts escape='htmlattribute'}Search results listings.{/ts}">
             <thead class="sticky">
                 <tr>
                 <th scope="col" title="Select All Rows">{$form.toggleSelect.html}</th>

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/EventDetails.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/EventDetails.tpl
@@ -65,7 +65,7 @@
         {include file="CRM/common/pagerAToZ.tpl"}
 
         {strip}
-        <table summary="{ts}Search results listings.{/ts}">
+        <table summary="{ts escape='htmlattribute'}Search results listings.{/ts}">
             <thead class="sticky">
                 {foreach from=$columnHeaders item=header}
                     <th scope="col">

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/FullText.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/FullText.tpl
@@ -44,7 +44,7 @@
       : {if !$table}{if $summary.Count.Contact <= $limit}{$summary.Count.Contact}{else}{ts 1=$limit}%1 or more{/ts}{/if}{else}{$summary.Count.Contact}{/if}</h3>
     {if $table}{include file="CRM/common/pager.tpl" location="top"}{/if}
     {* This section displays the rows along and includes the paging controls *}
-      <table id="contact_listing" class="display" class="selector" summary="{ts}Contact listings.{/ts}">
+      <table id="contact_listing" class="display" class="selector" summary="{ts escape='htmlattribute'}Contact listings.{/ts}">
         <thead>
         <tr>
           <th class='link'>{ts}Name{/ts}</th>
@@ -56,7 +56,7 @@
           <tr class="{cycle values="odd-row,even-row"}">
             <td><a
                 href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`&context=fulltext&key=`$qfKey`"}"
-                title="{ts}View Contact Details{/ts}">{$row.sort_name}</a></td>
+                title="{ts escape='htmlattribute'}View Contact Details{/ts}">{$row.sort_name}</a></td>
             {if $allowFileSearch}<td>{$row.fileHtml}</td>{/if}
             <td><a
                 href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`&context=fulltext&key=`$qfKey`"}">{ts}View{/ts}</a>
@@ -67,7 +67,7 @@
     {if !$table and $summary.addShowAllLink.Contact}
       <div class="crm-section full-text-view-all-section">
         <a href="{crmURL p='civicrm/contact/search/custom' q="csid=`$csID`&reset=1&force=1&table=Contact&text=$text"}"
-        title="{ts}View all results for contacts{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}View all results for contacts{/ts}</a>
+        title="{ts escape='htmlattribute'}View all results for contacts{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}View all results for contacts{/ts}</a>
       </div>{/if}
     {* note we using location="below" because we don't want to use rows per page for now. And therefore don't put location="bottom" for now. *}
     {if $table}{include file="CRM/common/pager.tpl" location="below"}{/if}
@@ -83,7 +83,7 @@
       : {if !$table}{if $summary.Count.Activity <= $limit}{$summary.Count.Activity}{else}{ts 1=$limit}%1 or more{/ts}{/if}{else}{$summary.Count.Activity}{/if}</h3>
     {if $table}{include file="CRM/common/pager.tpl" location="top"}{/if}
     {* This section displays the rows along and includes the paging controls *}
-      <table id="activity_listing" class="display" summary="{ts}Activity listings.{/ts}">
+      <table id="activity_listing" class="display" summary="{ts escape='htmlattribute'}Activity listings.{/ts}">
         <thead>
         <tr>
           <th>{ts}Type{/ts}</th>
@@ -103,15 +103,15 @@
             <td>{$row.details|escape}</td>
             <td>
               <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`&context=fulltext&key=`$qfKey`"}"
-                title="{ts}View Contact Details{/ts}">{$row.sort_name}</a>
+                title="{ts escape='htmlattribute'}View Contact Details{/ts}">{$row.sort_name}</a>
             </td>
             <td>
               <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.target_contact_id`&context=fulltext&key=`$qfKey`"}"
-                title="{ts}View Contact Details{/ts}">{$row.target_sort_name}</a>
+                title="{ts escape='htmlattribute'}View Contact Details{/ts}">{$row.target_sort_name}</a>
             </td>
             <td>
               <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.assignee_contact_id`&context=fulltext&key=`$qfKey`"}"
-                title="{ts}View Contact Details{/ts}">{$row.assignee_sort_name}</a>
+                title="{ts escape='htmlattribute'}View Contact Details{/ts}">{$row.assignee_sort_name}</a>
             </td>
             {if $allowFileSearch}<td>{$row.fileHtml}</td>{/if}
             <td>
@@ -130,7 +130,7 @@
     {if !$table and $summary.addShowAllLink.Activity}
       <div class="crm-section full-text-view-all-section">
         <a href="{crmURL p='civicrm/contact/search/custom' q="csid=`$csID`&reset=1&force=1&table=Activity&text=$text"}"
-        title="{ts}View all results for activities{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}View all results for activities{/ts}</a>
+        title="{ts escape='htmlattribute'}View all results for activities{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}View all results for activities{/ts}</a>
       </div>
     {/if}
     {if $table}{include file="CRM/common/pager.tpl" location="below"}{/if}
@@ -145,7 +145,7 @@
       : {if !$table}{if $summary.Count.Case <= $limit}{$summary.Count.Case}{else}{ts 1=$limit}%1 or more{/ts}{/if}{else}{$summary.Count.Case}{/if}</h3>
     {if $table}{include file="CRM/common/pager.tpl" location="top"}{/if}
     {* This section displays the rows along and includes the paging controls *}
-      <table id="case_listing" class="display" summary="{ts}Case listings.{/ts}">
+      <table id="case_listing" class="display" summary="{ts escape='htmlattribute'}Case listings.{/ts}">
         <thead>
         <tr>
           <th class='link'>{ts}Client Name{/ts}</th>
@@ -162,7 +162,7 @@
           <tr class="{cycle values="odd-row,even-row"}">
             <td>
               <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`&context=fulltext&key=`$qfKey`"}"
-                title="{ts}View Contact Details{/ts}">{$row.sort_name}</a>
+                title="{ts escape='htmlattribute'}View Contact Details{/ts}">{$row.sort_name}</a>
             </td>
             <td>{$row.case_start_date|crmDate:"%b %d, %Y %l:%M %P"}</td>
             <td>{$row.case_end_date|crmDate:"%b %d, %Y %l:%M %P"}</td>
@@ -187,7 +187,7 @@
     {if !$table and $summary.addShowAllLink.Case}
       <div class="crm-section full-text-view-all-section">
         <a href="{crmURL p='civicrm/contact/search/custom' q="csid=`$csID`&reset=1&force=1&table=Case&text=$text"}"
-        title="{ts}View all results for cases{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}View all results for cases{/ts}</a>
+        title="{ts escape='htmlattribute'}View all results for cases{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}View all results for cases{/ts}</a>
       </div>
     {/if}
     {if $table}{include file="CRM/common/pager.tpl" location="below"}{/if}
@@ -203,7 +203,7 @@
       : {if !$table}{if $summary.Count.Contribution <= $limit}{$summary.Count.Contribution}{else}{ts 1=$limit}%1 or more{/ts}{/if}{else}{$summary.Count.Contribution}{/if}</h3>
     {if $table}{include file="CRM/common/pager.tpl" location="top"}{/if}
     {* This section displays the rows along and includes the paging controls *}
-      <table id="contribute_listing" class="display" summary="{ts}Contribution listings.{/ts}">
+      <table id="contribute_listing" class="display" summary="{ts escape='htmlattribute'}Contribution listings.{/ts}">
         <thead>
         <tr>
           <th class='link'>{ts}Contributor's Name{/ts}</th>
@@ -222,7 +222,7 @@
             <td>
               <a href="{crmURL p='civicrm/contact/view'
               q="reset=1&cid=`$row.contact_id`&context=fulltext&key=`$qfKey`"}"
-                title="{ts}View Contact Details{/ts}">{$row.sort_name}</a>
+                title="{ts escape='htmlattribute'}View Contact Details{/ts}">{$row.sort_name}</a>
             </td>
             <td>{$row.contribution_total_amount|crmMoney}</td>
             <td>{$row.financial_type}</td>
@@ -241,7 +241,7 @@
     {if !$table and $summary.addShowAllLink.Contribution}
       <div class="crm-section full-text-view-all-section">
         <a href="{crmURL p='civicrm/contact/search/custom' q="csid=`$csID`&reset=1&force=1&table=Contribution&text=$text"}"
-        title="{ts}View all results for contributions{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}View all results for contributions{/ts}</a>
+        title="{ts escape='htmlattribute'}View all results for contributions{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}View all results for contributions{/ts}</a>
       </div>
     {/if}
     {if $table}{include file="CRM/common/pager.tpl" location="below"}{/if}
@@ -257,7 +257,7 @@
       : {if !$table}{if $summary.Count.Participant <= $limit}{$summary.Count.Participant}{else}{ts 1=$limit}%1 or more{/ts}{/if}{else}{$summary.Count.Participant}{/if}</h3>
     {if $table}{include file="CRM/common/pager.tpl" location="top"}{/if}
     {* This section displays the rows along and includes the paging controls *}
-      <table id="participant_listing" class="display" summary="{ts}Participant listings.{/ts}">
+      <table id="participant_listing" class="display" summary="{ts escape='htmlattribute'}Participant listings.{/ts}">
         <thead>
         <tr>
           <th class='link'>{ts}Participant's Name{/ts}</th>
@@ -277,7 +277,7 @@
           <tr class="{cycle values="odd-row,even-row"}">
             <td>
               <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`&context=fulltext&key=`$qfKey`"}"
-                title="{ts}View Contact Details{/ts}">{$row.sort_name}</a>
+                title="{ts escape='htmlattribute'}View Contact Details{/ts}">{$row.sort_name}</a>
             </td>
             <td>{$row.event_title}</td>
             <td>{$row.participant_fee_level}</td>
@@ -298,7 +298,7 @@
     {if !$table and $summary.addShowAllLink.Participant}
       <div class="crm-section full-text-view-all-section"><a
         href="{crmURL p='civicrm/contact/search/custom' q="csid=`$csID`&reset=1&force=1&table=Participant&text=$text"}"
-        title="{ts}View all results for participants{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}View all results for participants{/ts}</a>
+        title="{ts escape='htmlattribute'}View all results for participants{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}View all results for participants{/ts}</a>
       </div>{/if}
     {if $table}{include file="CRM/common/pager.tpl" location="below"}{/if}
     {* END Actions/Results section *}
@@ -313,7 +313,7 @@
       : {if !$table}{if $summary.Count.Membership <= $limit}{$summary.Count.Membership}{else}{ts 1=$limit}%1 or more{/ts}{/if}{else}{$summary.Count.Membership}{/if}</h3>
     {if $table}{include file="CRM/common/pager.tpl" location="top"}{/if}
     {* This section displays the rows along and includes the paging controls *}
-      <table id="membership_listing" class="display" summary="{ts}Membership listings.{/ts}">
+      <table id="membership_listing" class="display" summary="{ts escape='htmlattribute'}Membership listings.{/ts}">
         <thead>
         <tr>
           <th class='link'>{ts}Member's Name{/ts}</th>
@@ -333,7 +333,7 @@
           <tr class="{cycle values="odd-row,even-row"}">
             <td>
               <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`&context=fulltext&key=`$qfKey`"}"
-                title="{ts}View Contact Details{/ts}">{$row.sort_name}</a>
+                title="{ts escape='htmlattribute'}View Contact Details{/ts}">{$row.sort_name}</a>
             </td>
             <td>{$row.membership_type}</td>
             <td>{$row.membership_fee|crmMoney}</td>
@@ -354,7 +354,7 @@
     {if !$table and $summary.addShowAllLink.Membership}
       <div class="crm-section full-text-view-all-section">
         <a href="{crmURL p='civicrm/contact/search/custom' q="csid=`$csID`&reset=1&force=1&table=Membership&text=$text"}"
-        title="{ts}View all results for memberships{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}View all results for memberships{/ts}</a>
+        title="{ts escape='htmlattribute'}View all results for memberships{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}View all results for memberships{/ts}</a>
       </div>
     {/if}
     {if $table}{include file="CRM/common/pager.tpl" location="below"}{/if}
@@ -375,7 +375,7 @@
   {if $table}{include file="CRM/common/pager.tpl" location="top"}{/if}
 
   {* This section displays the rows along and includes the paging controls *}
-  <table id="file_listing" class="display" summary="{ts}File listings.{/ts}">
+  <table id="file_listing" class="display" summary="{ts escape='htmlattribute'}File listings.{/ts}">
     <thead>
     <tr>
       <th class='link'>{ts}File Name{/ts}</th>
@@ -400,7 +400,7 @@
   {if !$table and $summary.addShowAllLink.File}
   <div class="crm-section full-text-view-all-section">
     <a href="{crmURL p='civicrm/contact/search/custom' q="csid=`$csID`&reset=1&force=1&table=File&text=$text"}"
-          title="{ts}View all results for files{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}View all results for files{/ts}</a>
+          title="{ts escape='htmlattribute'}View all results for files{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}View all results for files{/ts}</a>
   </div>{/if}
   {if $table}{include file="CRM/common/pager.tpl" location="below"}{/if}
 {* END Actions/Results section *}

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/MultipleValues.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/MultipleValues.tpl
@@ -43,7 +43,7 @@
         {include file="CRM/common/pagerAToZ.tpl"}
 
         {strip}
-        <table class="selector row-highlight" summary="{ts}Search results listings.{/ts}">
+        <table class="selector row-highlight" summary="{ts escape='htmlattribute'}Search results listings.{/ts}">
             <thead class="sticky">
                 <th scope="col" title="Select All Rows">{$form.toggleSelect.html}</th>
                 {foreach from=$columnHeaders item=header}

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/Proximity.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/Proximity.tpl
@@ -66,7 +66,7 @@
         {/if}
 
         {strip}
-        <table class="selector row-highlight" summary="{ts}Search results listings.{/ts}">
+        <table class="selector row-highlight" summary="{ts escape='htmlattribute'}Search results listings.{/ts}">
             <thead class="sticky">
                 <th scope="col" title="Select All Rows">{$form.toggleSelect.html}</th>
                 {foreach from=$columnHeaders item=header}

--- a/ext/legacycustomsearches/templates/CRM/Contact/Page/CustomSearch.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Page/CustomSearch.tpl
@@ -16,7 +16,7 @@
 {if $rows}
     {foreach from=$rows item=customTitle key=csid}
         <div class="action-link">
-            <a href="{crmURL p="civicrm/contact/search/custom" q="csid=`$csid`&reset=1"}" title="{ts}Use this search{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {$customTitle}</a>
+            <a href="{crmURL p="civicrm/contact/search/custom" q="csid=`$csid`&reset=1"}" title="{ts escape='htmlattribute'}Use this search{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {$customTitle}</a>
         </div>
     {/foreach}
 {else}

--- a/templates/CRM/ACL/Page/ACL.tpl
+++ b/templates/CRM/ACL/Page/ACL.tpl
@@ -61,7 +61,7 @@
       </div>
     {else}
       <div class="messages status no-popup">
-        <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
+        <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>
         {capture assign=crmURL}{crmURL q="action=add&reset=1"}{/capture}
         {ts 1=$crmURL}There are no ACLs entered. You can <a href='%1'>add one</a>.{/ts}
       </div>

--- a/templates/CRM/ACL/Page/EntityRole.tpl
+++ b/templates/CRM/ACL/Page/EntityRole.tpl
@@ -52,7 +52,7 @@
 </div>
 {elseif $action ne 1 and $action ne 2 and $action ne 8}
     <div class="messages status no-popup">
-         <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
+         <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>
         {capture assign=crmURL}{crmURL q="action=add&reset=1"}{/capture}
         {ts 1=$crmURL}There are no Role Assignments. You can <a href='%1'>add one</a> now.{/ts}
     </div>

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -75,7 +75,7 @@
         {$form.assignee_contact_id.html}
         {if $action neq 4}
           {if empty($disable_swap_button)}
-            <a href="#" class="crm-hover-button" id="swap_target_assignee" title="{ts}Swap Target and Assignee Contacts{/ts}" style="position:relative; bottom: 1em;">
+            <a href="#" class="crm-hover-button" id="swap_target_assignee" title="{ts escape='htmlattribute'}Swap Target and Assignee Contacts{/ts}" style="position:relative; bottom: 1em;">
               <i class="crm-i fa-random" aria-hidden="true"></i>
             </a>
           {/if}
@@ -240,7 +240,7 @@
       {if ($context eq 'fulltext' || $context eq 'search') && $searchKey}
         {assign var='urlParams' value="reset=1&atype=$atype&action=update&reset=1&id=$entityID&cid=$contactId&context=$context&key=$searchKey"}
       {/if}
-      <a href="{crmURL p='civicrm/activity/add' q=$urlParams}" class="edit button" title="{ts}Edit{/ts}"><span><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Edit{/ts}</span></a>
+      <a href="{crmURL p='civicrm/activity/add' q=$urlParams}" class="edit button" title="{ts escape='htmlattribute'}Edit{/ts}"><span><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Edit{/ts}</span></a>
     {/if}
 
     {crmPermission has='delete activities'}
@@ -248,11 +248,11 @@
       {if ($context eq 'fulltext' || $context eq 'search') && $searchKey}
         {assign var='urlParams' value="reset=1&atype=$atype&action=delete&reset=1&id=$entityID&cid=$contactId&context=$context&key=$searchKey"}
       {/if}
-      <a href="{crmURL p='civicrm/contact/view/activity' q=$urlParams}" class="delete button" title="{ts}Delete{/ts}"><span><i class="crm-i fa-trash" aria-hidden="true"></i> {ts}Delete{/ts}</span></a>
+      <a href="{crmURL p='civicrm/contact/view/activity' q=$urlParams}" class="delete button" title="{ts escape='htmlattribute'}Delete{/ts}"><span><i class="crm-i fa-trash" aria-hidden="true"></i> {ts}Delete{/ts}</span></a>
     {/crmPermission}
   {/if}
   {if $action eq 4 and $context != 'case' and call_user_func(array('CRM_Case_BAO_Case','checkPermission'), $activityId, 'File On Case', $atype)}
-    <a href="#" onclick="fileOnCase('file', {$activityId}, null, this); return false;" class="cancel button" title="{ts}File On Case{/ts}"><span><i class="crm-i fa-clipboard" aria-hidden="true"></i> {ts}File on Case{/ts}</span></a>
+    <a href="#" onclick="fileOnCase('file', {$activityId}, null, this); return false;" class="cancel button" title="{ts escape='htmlattribute'}File On Case{/ts}"><span><i class="crm-i fa-clipboard" aria-hidden="true"></i> {ts}File on Case{/ts}</span></a>
     {include file="CRM/Case/Form/ActivityToCase.tpl"}
   {/if}
   {include file="CRM/common/formButtons.tpl" location="bottom"}

--- a/templates/CRM/Activity/Form/ActivityLinks.tpl
+++ b/templates/CRM/Activity/Form/ActivityLinks.tpl
@@ -10,7 +10,7 @@
 {* Links for scheduling/logging meetings and calls and Sending Email *}
 
 {if $as_select} {* on 3.2, the activities can be either a drop down select (on the activity tab) or a list (on the action menu) *}
-<select name="other_activity" class="crm-form-select crm-select2 crm-action-menu fa-plus" title="{ts}New Activity{/ts}">
+<select name="other_activity" class="crm-form-select crm-select2 crm-action-menu fa-plus" title="{ts escape='htmlattribute'}New Activity{/ts}">
   <option value="">{ts}New Activity{/ts}</option>
 {foreach from=$activityTypes item=act}
   <option value="{$act.url}" data-icon="{$act.icon}">{$act.label}</option>

--- a/templates/CRM/Activity/Form/ActivityView.tpl
+++ b/templates/CRM/Activity/Form/ActivityView.tpl
@@ -22,7 +22,7 @@
        {/if}
        {if (array_key_exists('mailingId', $values) && $values.mailingId)}
            <tr>
-                <td class="label">{ts}With Contact{/ts}</td><td class="view-value"><a href="{$values.mailingId}" title="{ts}View Mailing Report{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i>{ts}Mailing Report{/ts}</a></td>
+                <td class="label">{ts}With Contact{/ts}</td><td class="view-value"><a href="{$values.mailingId}" title="{ts escape='htmlattribute'}View Mailing Report{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i>{ts}Mailing Report{/ts}</a></td>
            </tr>
        {/if}
         <tr>

--- a/templates/CRM/Activity/Form/Selector.tpl
+++ b/templates/CRM/Activity/Form/Selector.tpl
@@ -17,7 +17,7 @@
    <thead class="sticky">
      <tr>
        {if !$single and $context eq 'Search'}
-          <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
+          <th scope="col" title="{ts escape='htmlattribute'}Select rows{/ts}">{$form.toggleSelect.html}</th>
        {/if}
        {foreach from=$columnHeaders item=header}
           <th scope="col">
@@ -60,13 +60,13 @@
     {if !$row.source_contact_id}
       <em>n/a</em>
     {else}
-      <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.source_contact_id`"}" title="{ts}View contact{/ts}">{$row.source_contact_name|purify}</a>
+      <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.source_contact_id`"}" title="{ts escape='htmlattribute'}View contact{/ts}">{$row.source_contact_name|purify}</a>
     {/if}
     </td>
 
     <td>
     {if $row.mailingId}
-      <a href="{$row.mailingId}" title="{ts}View Mailing Report{/ts}">{$row.recipients}</a>
+      <a href="{$row.mailingId}" title="{ts escape='htmlattribute'}View Mailing Report{/ts}">{$row.recipients}</a>
     {elseif $row.recipients}
       {$row.recipients}
     {elseif !$row.target_contact_name}
@@ -75,7 +75,7 @@
         {assign var="showTarget" value=0}
         {foreach from=$row.target_contact_name item=targetName key=targetID}
             {if $showTarget < 5}
-                {if $showTarget};&nbsp;{/if}<a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$targetID`"}" title="{ts}View contact{/ts}">{$targetName}</a>
+                {if $showTarget};&nbsp;{/if}<a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$targetID`"}" title="{ts escape='htmlattribute'}View contact{/ts}">{$targetName}</a>
                 {assign var="showTarget" value=$showTarget+1}
             {/if}
         {/foreach}
@@ -90,7 +90,7 @@
         {assign var="showAssignee" value=0}
         {foreach from=$row.assignee_contact_name item=assigneeName key=assigneeID}
             {if $showAssignee < 5}
-                {if $showAssignee};&nbsp;{/if}<a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$assigneeID`"}" title="{ts}View contact{/ts}">{$assigneeName}</a>
+                {if $showAssignee};&nbsp;{/if}<a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$assigneeID`"}" title="{ts escape='htmlattribute'}View contact{/ts}">{$assigneeName}</a>
                 {assign var="showAssignee" value=$showAssignee+1}
             {/if}
         {/foreach}

--- a/templates/CRM/Activity/Form/Task/Print.tpl
+++ b/templates/CRM/Activity/Form/Task/Print.tpl
@@ -39,7 +39,7 @@
              {assign var="showTarget" value=0}
              {foreach from=$row.target_contact_name item=targetName key=targetID}
                 {if $showTarget < 5}
-                   {if $showTarget};&nbsp;{/if}<a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$targetID`"}" title="{ts}View contact{/ts}">{$targetName}</a>
+                   {if $showTarget};&nbsp;{/if}<a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$targetID`"}" title="{ts escape='htmlattribute'}View contact{/ts}">{$targetName}</a>
                      {assign var="showTarget" value=$showTarget+1}
                 {/if}
              {/foreach}
@@ -52,7 +52,7 @@
              {assign var="showAssignee" value=0}
              {foreach from=$row.assignee_contact_name item=assigneeName key=assigneeID}
                 {if $showAssignee < 5}
-                   {if $showAssignee};&nbsp;{/if}<a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$assigneeID`"}" title="{ts}View contact{/ts}">{$assigneeName}</a>
+                   {if $showAssignee};&nbsp;{/if}<a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$assigneeID`"}" title="{ts escape='htmlattribute'}View contact{/ts}">{$assigneeName}</a>
                      {assign var="showAssignee" value=$showAssignee+1}
                 {/if}
              {/foreach}

--- a/templates/CRM/Activity/Selector/Activity.tpl
+++ b/templates/CRM/Activity/Selector/Activity.tpl
@@ -41,7 +41,7 @@
         {if $contactId == $row.source_contact_id}
           {$row.source_contact_name}
         {elseif $row.source_contact_id}
-          <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.source_contact_id`"}" title="{ts}View contact{/ts}">{$row.source_contact_name}</a>
+          <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.source_contact_id`"}" title="{ts escape='htmlattribute'}View contact{/ts}">{$row.source_contact_name}</a>
         {else}
           <em>n/a</em>
         {/if}
@@ -49,7 +49,7 @@
 
         <td class="crm-activity-target_contact_name">
         {if $row.mailingId}
-          <a href="{$row.mailingId}" title="{ts}View Mailing Report{/ts}">{$row.recipients}</a>
+          <a href="{$row.mailingId}" title="{ts escape='htmlattribute'}View Mailing Report{/ts}">{$row.recipients}</a>
         {elseif $row.recipients}
           {$row.recipients}
         {elseif !$row.target_contact_name}
@@ -58,7 +58,7 @@
             {assign var="showTarget" value=0}
             {foreach from=$row.target_contact_name item=targetName key=targetID}
                 {if $showTarget < 5}
-                    {if $showTarget};&nbsp;{/if}<a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$targetID`"}" title="{ts}View contact{/ts}">{$targetName}</a>
+                    {if $showTarget};&nbsp;{/if}<a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$targetID`"}" title="{ts escape='htmlattribute'}View contact{/ts}">{$targetName}</a>
                     {assign var="showTarget" value=$showTarget+1}
                 {/if}
             {/foreach}
@@ -73,7 +73,7 @@
             {assign var="showAssignee" value=0}
             {foreach from=$row.assignee_contact_name item=assigneeName key=assigneeID}
                 {if $showAssignee < 5}
-                    {if $showAssignee};&nbsp;{/if}<a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$assigneeID`"}" title="{ts}View contact{/ts}">{$assigneeName}</a>
+                    {if $showAssignee};&nbsp;{/if}<a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$assigneeID`"}" title="{ts escape='htmlattribute'}View contact{/ts}">{$assigneeName}</a>
                     {assign var="showAssignee" value=$showAssignee+1}
                 {/if}
             {/foreach}

--- a/templates/CRM/Admin/Form/CMSUser.tpl
+++ b/templates/CRM/Admin/Form/CMSUser.tpl
@@ -13,7 +13,7 @@
     <p>{ts}Synchronize Users{/ts}</p>
 </div>
 <div class="messages status no-popup">
-      <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
+      <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>
            <span class="label">{ts}Synchronize Users to Contacts:{/ts}</span> {ts}CiviCRM will check each user record for a contact record. A new contact record will be created for each user where one does not already exist.{/ts} {ts}Do you want to continue?{/ts}
 </div>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>

--- a/templates/CRM/Admin/Form/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Form/MessageTemplates.tpl
@@ -54,7 +54,7 @@
               <strong><a class="crm-attachment" href="{$attVal.url}">{$attVal.cleanName}</a></strong>
               {if $attVal.description}&nbsp;-&nbsp;{$attVal.description}{/if}
               {if $attVal.deleteURLArgs}
-                <a href="#" class="crm-hover-button delete-attachment" data-mimetype="{$attVal.mime_type}" data-filename="{$attVal.cleanName}" data-args="{$attVal.deleteURLArgs}" title="{ts}Delete File{/ts}"><span class="icon delete-icon"></span></a>
+                <a href="#" class="crm-hover-button delete-attachment" data-mimetype="{$attVal.mime_type}" data-filename="{$attVal.cleanName}" data-args="{$attVal.deleteURLArgs}" title="{ts escape='htmlattribute'}Delete File{/ts}"><span class="icon delete-icon"></span></a>
               {/if}
               {include file="CRM/Form/attachmentjs.tpl" context='MessageTemplate'}
               {/foreach}

--- a/templates/CRM/Admin/Page/APIExplorer.tpl
+++ b/templates/CRM/Admin/Page/APIExplorer.tpl
@@ -252,12 +252,12 @@
       <input class="crm-form-text" id="api-action" name="action" value="get">
       &nbsp;&nbsp;
 
-      <label for="debug-checkbox" class="api-checkbox-label" title="{ts}Display debug output with results.{/ts}">
+      <label for="debug-checkbox" class="api-checkbox-label" title="{ts escape='htmlattribute'}Display debug output with results.{/ts}">
         <input type="checkbox" class="crm-form-checkbox api-param-checkbox api-input" id="debug-checkbox" name="debug" value="1" >debug
       </label>
       &nbsp;|&nbsp;
 
-      <label for="sequential-checkbox" class="api-checkbox-label" title="{ts}Sequential is more compact format, well-suited for json and smarty.{/ts}">
+      <label for="sequential-checkbox" class="api-checkbox-label" title="{ts escape='htmlattribute'}Sequential is more compact format, well-suited for json and smarty.{/ts}">
         <input type="checkbox" class="crm-form-checkbox api-param-checkbox api-input" id="sequential-checkbox" name="sequential" checked="checked" value="1">sequential
       </label>
 
@@ -300,7 +300,7 @@
         </table>
       </div>
       <div class="crm-submit-buttons">
-        <button type="submit" class="crm-button crm-form-submit" accesskey="S" title="{ts}Execute API call and display results{/ts}">
+        <button type="submit" class="crm-button crm-form-submit" accesskey="S" title="{ts escape='htmlattribute'}Execute API call and display results{/ts}">
           <i class="crm-i fa-bolt" aria-hidden="true"></i> {ts}Execute{/ts}
         </button>
       </div>
@@ -355,13 +355,13 @@
   <tr class="api-param-row">
     <td>
       <i class="crm-i api-sort-handle fa-arrows" aria-hidden="true"></i>
-      <input style="width: 90%;" class="crm-form-text api-param-name api-input" value="<%= name %>" placeholder="{ts}Parameter{/ts}" />
+      <input style="width: 90%;" class="crm-form-text api-param-name api-input" value="<%= name %>" placeholder="{ts escape='htmlattribute'}Parameter{/ts}" />
       <div class="api-and-or"><span><span class="api-and">{ts}AND{/ts}</span> <i class="crm-i fa-toggle-on" aria-hidden="true"></i> <span class="api-or">{ts}OR{/ts}</span></span></div>
     </td>
     <td>
       {literal}
       <% if (noOps) { %>
-        <input class="crm-form-text api-param-op" value="=" readonly="true" title="{/literal}{ts}Other operators not available for this action.{/ts}{literal}" />
+        <input class="crm-form-text api-param-op" value="=" readonly="true" title="{/literal}{ts escape='htmlattribute'}Other operators not available for this action.{/ts}{literal}" />
       <% } else { %>
       {/literal}
         <select class="crm-form-select api-param-op">
@@ -374,7 +374,7 @@
       {/literal}
     </td>
     <td>
-      <input style="width: 85%;" class="crm-form-text api-param-value api-input" placeholder="{ts}Value{/ts}"/>
+      <input style="width: 85%;" class="crm-form-text api-param-value api-input" placeholder="{ts escape='htmlattribute'}Value{/ts}"/>
       <a class="crm-hover-button api-param-remove" href="#"><i class="crm-i fa-times" aria-hidden="true"></i></a>
     </td>
   </tr>
@@ -399,10 +399,10 @@
       <label>{ts}Options{/ts}: &nbsp;</label>
     </td>
     <td>
-      <input class="crm-form-text api-option-name api-input" style="width: 12em;" placeholder="{ts}Option{/ts}"/>
+      <input class="crm-form-text api-option-name api-input" style="width: 12em;" placeholder="{ts escape='htmlattribute'}Option{/ts}"/>
     </td>
     <td>
-      <input style="width: 85%;" class="crm-form-text api-option-value api-input" placeholder="{ts}Value{/ts}"/>
+      <input style="width: 85%;" class="crm-form-text api-option-value api-input" placeholder="{ts escape='htmlattribute'}Value{/ts}"/>
       <a class="crm-hover-button api-param-remove" href="#"><i class="crm-i fa-times" aria-hidden="true"></i></a>
     </td>
   </tr>
@@ -427,7 +427,7 @@
       </select>
     </td>
     <td>
-      <input style="width: 85%;" class="crm-form-text api-param-value api-input" value="{ldelim}{rdelim}" placeholder="{ts}API Params{/ts}"/>
+      <input style="width: 85%;" class="crm-form-text api-param-value api-input" value="{ldelim}{rdelim}" placeholder="{ts escape='htmlattribute'}API Params{/ts}"/>
       <a class="crm-hover-button api-param-remove" href="#"><i class="crm-i fa-times" aria-hidden="true"></i></a>
     </td>
   </tr>

--- a/templates/CRM/Admin/Page/ConfigTaskList.tpl
+++ b/templates/CRM/Admin/Page/ConfigTaskList.tpl
@@ -33,7 +33,7 @@
         <td>{ts}Extensions are installable packages which give CiviCRM new functionality.{/ts} {ts}Some extenions are shipped with CiviCRM (known as core extensions, such as SearchKit and FormBuilder), but there are also many extensions developed by the community.{/ts}</td>
     </tr>
     <tr class="even">
-        <td class="tasklist nowrap"><a href="{$registerSite}" title="{ts}Register your site at CiviCRM.org. Opens in a new window.{/ts}" target="_blank">{ts}Register your site{/ts}</a></td>
+        <td class="tasklist nowrap"><a href="{$registerSite}" title="{ts escape='htmlattribute'}Register your site at CiviCRM.org. Opens in a new window.{/ts}" target="_blank">{ts}Register your site{/ts}</a></td>
         <td>{ts}Join the community and help CiviCRM remain a leading CRM for organizations worldwide.{/ts}</td>
     </tr>
     <tr class="columnheader">

--- a/templates/CRM/Admin/Page/ContactType.tpl
+++ b/templates/CRM/Admin/Page/ContactType.tpl
@@ -44,7 +44,7 @@
   </div>
   {else}
     <div class="messages status no-popup">
-      <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
+      <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>
       {ts}None found.{/ts}
     </div>
   {/if}

--- a/templates/CRM/Admin/Page/Extensions.tpl
+++ b/templates/CRM/Admin/Page/Extensions.tpl
@@ -30,13 +30,13 @@
     <div id="mainTabContainer" class="ui-tabs ui-widget ui-widget-content ui-corner-all">
         <ul class="crm-extensions-tabs-list">
             <li id="tab_summary" class="crm-tab-button">
-              <a href="#extensions-main" title="{ts}Extensions{/ts}">
+              <a href="#extensions-main" title="{ts escape='htmlattribute'}Extensions{/ts}">
               <span> </span> {ts}Extensions{/ts}
               <em>&nbsp;</em>
               </a>
             </li>
             <li id="tab_addnew" class="crm-tab-button">
-              <a href="#extensions-addnew" title="{ts}Add New{/ts}">
+              <a href="#extensions-addnew" title="{ts escape='htmlattribute'}Add New{/ts}">
               <span> </span> {ts}Add New{/ts}
               <em>&nbsp;</em>
               </a>

--- a/templates/CRM/Admin/Page/LocationType.tpl
+++ b/templates/CRM/Admin/Page/LocationType.tpl
@@ -49,7 +49,7 @@
   </div>
   {else}
     <div class="messages status no-popup">
-        <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
+        <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>
         {ts}None found.{/ts}
     </div>
   {/if}

--- a/templates/CRM/Admin/Page/MailSettings.tpl
+++ b/templates/CRM/Admin/Page/MailSettings.tpl
@@ -52,13 +52,13 @@
 </div>
 {else}
     <div class="messages status no-popup">
-      <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
+      <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>
       {ts}None found.{/ts}
     </div>
 {/if}
     {if !empty($setupActions)}
         <form>
-            <select id="crm-mail-setup" name="crm-mail-setup" class="crm-select2 crm-form-select" aria-label="{ts}Add Mail Account{/ts}">
+            <select id="crm-mail-setup" name="crm-mail-setup" class="crm-select2 crm-form-select" aria-label="{ts escape='htmlattribute'}Add Mail Account{/ts}">
                 <option value="" aria-hidden="true">{ts}Add Mail Account{/ts}</option>
                 {foreach from=$setupActions key=setupActionsName item=setupAction}
                     <option data-url="{$setupAction.url|escape}" value="{$setupActionsName|escape}">{$setupAction.title|escape}</option>

--- a/templates/CRM/Admin/Page/Mapping.tpl
+++ b/templates/CRM/Admin/Page/Mapping.tpl
@@ -40,7 +40,7 @@
     </div>
     {else}
         <div class="messages status no-popup">
-            <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
+            <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>
             {ts}There are currently no saved import or export mappings. You create saved mappings as part of an Import or Export task.{/ts}
         </div>
     {/if}

--- a/templates/CRM/Admin/Page/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Page/MessageTemplates.tpl
@@ -74,10 +74,10 @@
   <div id='mainTabContainer'>
     <ul>
       {if $canEditUserDrivenMessageTemplates or $canEditMessageTemplates}
-        <li id='tab_user'><a href='#user' title='{ts}User-driven Messages{/ts}'>{ts}User-driven Messages{/ts}</a></li>
+        <li id='tab_user'><a href='#user' title='{ts escape='htmlattribute'}User-driven Messages{/ts}'>{ts}User-driven Messages{/ts}</a></li>
       {/if}
       {if $canEditSystemTemplates or $canEditMessageTemplates}
-        <li id='tab_workflow'><a href='#workflow' title='{ts}System Workflow Messages{/ts}'>{ts}System Workflow Messages{/ts}</a></li>
+        <li id='tab_workflow'><a href='#workflow' title='{ts escape='htmlattribute'}System Workflow Messages{/ts}'>{ts}System Workflow Messages{/ts}</a></li>
       {/if}
     </ul>
 
@@ -160,7 +160,7 @@
 
 {elseif $action ne 1 and $action ne 2 and $action ne 4 and $action ne 8}
   <div class="messages status no-popup">
-      <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
+      <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>
       {ts 1=$crmURL}There are no Message Templates entered. You can <a href='%1'>add one</a>.{/ts}
   </div>
 {/if}

--- a/templates/CRM/Admin/Page/OptionGroup.tpl
+++ b/templates/CRM/Admin/Page/OptionGroup.tpl
@@ -45,8 +45,8 @@
           <td class="crm-admin-optionGroup-is_reserved">{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td class="crm-admin-optionGroup-is_active" id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td>
-            <a href="{crmURL p="civicrm/admin/options" q="id=`$row.id`&action=update&reset=1"}" class="action-item crm-hover-button" title="{ts}OptionGroup settings{/ts}">{ts}Settings{/ts}</a>
-            <a href="{crmURL p="civicrm/admin/options" q="gid=`$row.id`&reset=1"}" class="action-item crm-hover-button" title="{ts}View and Edit Options{/ts}">{ts}Edit Options{/ts}</a>
+            <a href="{crmURL p="civicrm/admin/options" q="id=`$row.id`&action=update&reset=1"}" class="action-item crm-hover-button" title="{ts escape='htmlattribute'}OptionGroup settings{/ts}">{ts}Settings{/ts}</a>
+            <a href="{crmURL p="civicrm/admin/options" q="gid=`$row.id`&reset=1"}" class="action-item crm-hover-button" title="{ts escape='htmlattribute'}View and Edit Options{/ts}">{ts}Edit Options{/ts}</a>
           </td>
         </tr>
         {/foreach}
@@ -62,7 +62,7 @@
 </div>
 {elseif $action ne 1 and $action ne 2}
     <div class="messages status no-popup">
-        <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
+        <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>
         {capture assign=crmURL}{crmURL p='civicrm/admin/optionGroup' q="action=add&reset=1"}{/capture}
         {ts 1=$crmURL}There are no Option Groups entered. You can <a href='%1'>add one</a>.{/ts}
     </div>

--- a/templates/CRM/Admin/Page/PaymentProcessorType.tpl
+++ b/templates/CRM/Admin/Page/PaymentProcessorType.tpl
@@ -53,7 +53,7 @@
 </div>
 {elseif $action ne 1}
     <div class="messages status no-popup">
-      <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
+      <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>
       {ts}None found.{/ts}
     </div>
 {/if}

--- a/templates/CRM/Admin/Page/RelationshipType.tpl
+++ b/templates/CRM/Admin/Page/RelationshipType.tpl
@@ -63,7 +63,7 @@
 </div>
 {else}
     <div class="messages status no-popup">
-      <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
+      <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>
       {ts}None found.{/ts}
     </div>
 {/if}

--- a/templates/CRM/Badge/Form/Layout.tpl
+++ b/templates/CRM/Badge/Form/Layout.tpl
@@ -35,7 +35,7 @@
          <table>
            <tr>
             <td>{$form.image_1.html}
-               <a href="#" class="crm-hover-button clear-image" title="{ts}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
+               <a href="#" class="crm-hover-button clear-image" title="{ts escape='htmlattribute'}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
              <br/>
              <span class="description">{ts}Click above and select a file by double clicking on it.{/ts}</span>
             </td>
@@ -55,7 +55,7 @@
          <table>
           <tr>
            <td>{$form.image_2.html}
-              <a href="#" class="crm-hover-button clear-image" title="{ts}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
+              <a href="#" class="crm-hover-button clear-image" title="{ts escape='htmlattribute'}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
             <br/>
             <span class="description">{ts}Click above and select a file by double clicking on it.{/ts}</span>
            </td>

--- a/templates/CRM/Badge/Page/Layout.tpl
+++ b/templates/CRM/Badge/Page/Layout.tpl
@@ -54,7 +54,7 @@
     </div>
   {else}
     <div class="messages status no-popup">
-      <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
+      <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>
       {capture assign=crmURL}{crmURL p='civicrm/admin/badgelayout' q="action=add&reset=1"}{/capture}
       {ts 1=$crmURL}There are no Badge Layout entered for this Contact. You can<a href='%1'>add one</a>.{/ts}
     </div>

--- a/templates/CRM/Campaign/Form/ResultOptions.tpl
+++ b/templates/CRM/Campaign/Form/ResultOptions.tpl
@@ -43,7 +43,7 @@
   <tr id="optionField_{$index}" class="form-item {cycle values="odd-row,even-row"}">
         <td>
         {if $index GT 1}
-            <a onclick="showHideRow({$index}); return false;" name="optionField_{$index}" href="#" class="form-link"><i class="crm-i fa-trash" title="{ts}hide field or section{/ts}" aria-hidden="true"></i></a>
+            <a onclick="showHideRow({$index}); return false;" name="optionField_{$index}" href="#" class="form-link"><i class="crm-i fa-trash" title="{ts escape='htmlattribute'}hide field or section{/ts}" aria-hidden="true"></i></a>
         {/if}
         </td>
       <td>

--- a/templates/CRM/Campaign/Form/Search/Common.tpl
+++ b/templates/CRM/Campaign/Form/Search/Common.tpl
@@ -111,7 +111,7 @@
             {if $context eq 'search'}
               {$form.buttons.html}
               {else}
-              <a class="searchVoter button" style="float:left;" href="#" title={ts}Search{/ts} onClick="searchVoters( '{$qfKey}' );return false;">{ts}Search{/ts}</a>
+              <a class="searchVoter button" style="float:left;" href="#" title="{ts escape='htmlattribute'}Search{/ts}" onClick="searchVoters( '{$qfKey}' );return false;">{ts}Search{/ts}</a>
             {/if}
           </td>
         </tr>

--- a/templates/CRM/Campaign/Form/Selector.tpl
+++ b/templates/CRM/Campaign/Form/Selector.tpl
@@ -16,7 +16,7 @@
   <thead class="sticky">
   <tr>
     {if !$single and $context eq 'Search'}
-        <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
+        <th scope="col" title="{ts escape='htmlattribute'}Select rows{/ts}">{$form.toggleSelect.html}</th>
     {/if}
     <th scope="col"></th>
     {foreach from=$columnHeaders item=header}

--- a/templates/CRM/Campaign/Form/Task/Interview.tpl
+++ b/templates/CRM/Campaign/Form/Task/Interview.tpl
@@ -122,7 +122,7 @@
 
         <th>{capture assign="tsNote"}{ts}Note{/ts}{/capture}{copyIcon name=note title=$tsNote}{$tsNote}</th>
         <th>{capture assign="tsResult"}{ts}Result{/ts}{/capture}{copyIcon name=result title=$tsResult}{$tsResult}</th>
-        <th><a id="interview_voter_button" class='button' style="float:left;" href="#" title={ts}Vote{/ts} onclick="registerInterviewforall( ); return false;">{ts}Record Responses for All{/ts}</a></th>
+        <th><a id="interview_voter_button" class='button' style="float:left;" href="#" title="{ts escape='htmlattribute'}Vote{/ts}" onclick="registerInterviewforall( ); return false;">{ts}Record Responses for All{/ts}</a></th>
       </tr>
       </thead>
 
@@ -157,11 +157,11 @@
           <td class='result'>{$form.field.$voterId.result.html}</td>
 
           <td>
-            <a id="interview_voter_button_{$voterId}" class='button' style="float:left;" href="#" title={ts}Vote{/ts} onclick="registerInterview( {$voterId} ); return false;">
+            <a id="interview_voter_button_{$voterId}" class='button' style="float:left;" href="#" title="{ts escape='htmlattribute'}Vote{/ts}" onclick="registerInterview( {$voterId} ); return false;">
               {ts}record response{/ts}
             </a>
             {if $allowAjaxReleaseButton}
-              <a id="release_voter_button_{$voterId}" class='button'  href="#" title={ts}Release{/ts} onclick="releaseOrReserveVoter( {$voterId} ); return false;">
+              <a id="release_voter_button_{$voterId}" class='button'  href="#" title="{ts escape='htmlattribute'}Release{/ts}" onclick="releaseOrReserveVoter( {$voterId} ); return false;">
                 {ts}release{/ts}
               </a>
             {/if}

--- a/templates/CRM/Case/Form/ActivityView.tpl
+++ b/templates/CRM/Case/Form/ActivityView.tpl
@@ -21,7 +21,7 @@
           <tr {if $row.id EQ $latestRevisionID}style="font-weight: bold;"{/if}>
             <td class="crm-case-activityview-form-block-name">{$row.name}</td>
             <td class="crm-case-activityview-form-block-date">{$row.date|crmDate}</td>
-            <td class="crm-case-activityview-form-block-{$row.id}"><a class="open-inline-noreturn" href="{crmURL p='civicrm/case/activity/view' h=0 q="cid=$contactID&aid="}{$row.id}" title="{ts}View this revision of the activity record.{/ts}">{if $row.id != $latestRevisionID}{ts}View{/ts}{else}{ts}View (Current Revision){/ts}{/if}</a></td>
+            <td class="crm-case-activityview-form-block-{$row.id}"><a class="open-inline-noreturn" href="{crmURL p='civicrm/case/activity/view' h=0 q="cid=$contactID&aid="}{$row.id}" title="{ts escape='htmlattribute'}View this revision of the activity record.{/ts}">{if $row.id != $latestRevisionID}{ts}View{/ts}{else}{ts}View (Current Revision){/ts}{/if}</a></td>
           </tr>
         {/foreach}
       </table>

--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -25,13 +25,13 @@
         <td colspan="5" class="label">
           {ts}Clients:{/ts}
           {foreach from=$caseRoles.client item=client name=clients}
-            <a href="{crmURL p='civicrm/contact/view' q="action=view&reset=1&cid=`$client.contact_id`"}" title="{ts}View contact record{/ts}">{$client.display_name}</a>{if count($caseRoles.client) gt 1}<a class="crm-popup crm-hover-button" href="{crmURL p='civicrm/contact/view/case/deleteClient' q="action=delete&reset=1&cid=`$client.contact_id`&id=`$caseId`&rcid=`$contactID`"}" title="{ts}Remove Client{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>{/if}{if not $smarty.foreach.clients.last}, &nbsp; {/if}
+            <a href="{crmURL p='civicrm/contact/view' q="action=view&reset=1&cid=`$client.contact_id`"}" title="{ts escape='htmlattribute'}View contact record{/ts}">{$client.display_name}</a>{if count($caseRoles.client) gt 1}<a class="crm-popup crm-hover-button" href="{crmURL p='civicrm/contact/view/case/deleteClient' q="action=delete&reset=1&cid=`$client.contact_id`&id=`$caseId`&rcid=`$contactID`"}" title="{ts escape='htmlattribute'}Remove Client{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>{/if}{if not $smarty.foreach.clients.last}, &nbsp; {/if}
           {/foreach}
-          <a href="#addClientDialog" class="crm-hover-button case-miniform" title="{ts}Add Client{/ts}" data-key="{crmKey name='civicrm/case/ajax/addclient'}">
+          <a href="#addClientDialog" class="crm-hover-button case-miniform" title="{ts escape='htmlattribute'}Add Client{/ts}" data-key="{crmKey name='civicrm/case/ajax/addclient'}">
             <i class="crm-i fa-user-plus" aria-hidden="true"></i>
           </a>
           <div id="addClientDialog" class="hiddenElement">
-            <input name="add_client_id" placeholder="{ts}- select contact -{/ts}" class="huge" data-api-params='{ldelim}"params": {ldelim}"contact_type": "{$contactType}"{rdelim}{rdelim}' />
+            <input name="add_client_id" placeholder="{ts escape='htmlattribute'}- select contact -{/ts}" class="huge" data-api-params='{ldelim}"params": {ldelim}"contact_type": "{$contactType}"{rdelim}{rdelim}' />
           </div>
           {if $hasRelatedCases}
             <div class="crm-block relatedCases-link"><a class="crm-hover-button crm-popup medium-popup" href="{$relatedCaseUrl}">{$relatedCaseLabel}</a></div>
@@ -46,7 +46,7 @@
             {foreach from=$caseRoles.client item=client}
               <tr class="crm-case-caseview-display_name">
                 <td class="label-left bold" style="padding: 0px; border: none;">
-                  <a href="{crmURL p='civicrm/contact/view' q="action=view&reset=1&cid=`$client.contact_id`"}" title="{ts}View contact record{/ts}">{$client.display_name}</a>{if $client.email}{crmAPI var='email_type_id' entity='OptionValue' action='getsingle' return="value" name="Email" option_group_id="activity_type"}<span class="crm-case-caseview-email"><a class="crm-hover-button crm-popup" href="{crmURL p='civicrm/case/email/add' q="reset=1&action=add&atype=`$email_type_id.value`&cid=`$client.contact_id`&caseid=`$caseId`"}" title="{ts 1=$client.email|escape}Email: %1{/ts}"><i class="crm-i fa-envelope" aria-hidden="true"></i></a></span>{/if}
+                  <a href="{crmURL p='civicrm/contact/view' q="action=view&reset=1&cid=`$client.contact_id`"}" title="{ts escape='htmlattribute'}View contact record{/ts}">{$client.display_name}</a>{if $client.email}{crmAPI var='email_type_id' entity='OptionValue' action='getsingle' return="value" name="Email" option_group_id="activity_type"}<span class="crm-case-caseview-email"><a class="crm-hover-button crm-popup" href="{crmURL p='civicrm/case/email/add' q="reset=1&action=add&atype=`$email_type_id.value`&cid=`$client.contact_id`&caseid=`$caseId`"}" title="{ts escape='htmlattribute' 1=$client.email}Email: %1{/ts}"><i class="crm-i fa-envelope" aria-hidden="true"></i></a></span>{/if}
                 </td>
               </tr>
               {if $client.phone}
@@ -70,13 +70,13 @@
         <span class="crm-case-summary-label">{ts}Subject{/ts}:</span>&nbsp;<span class="crm-editable" data-field="subject">{$caseDetails.case_subject}</span>
       </td>
       <td class="crm-case-caseview-case_type label">
-        <span class="crm-case-summary-label">{ts}Type{/ts}:</span>&nbsp;{$caseDetails.case_type}&nbsp;<a class="crm-hover-button crm-popup"  href="{crmURL p='civicrm/case/activity' q="action=add&reset=1&cid=`$contactId`&caseid=`$caseId`&selectedChild=activity&atype=`$changeCaseTypeId`"}" title="{ts}Change case type (creates activity record){/ts}"><i class="crm-i fa-pencil" aria-hidden="true"></i></a>
+        <span class="crm-case-summary-label">{ts}Type{/ts}:</span>&nbsp;{$caseDetails.case_type}&nbsp;<a class="crm-hover-button crm-popup"  href="{crmURL p='civicrm/case/activity' q="action=add&reset=1&cid=`$contactId`&caseid=`$caseId`&selectedChild=activity&atype=`$changeCaseTypeId`"}" title="{ts escape='htmlattribute'}Change case type (creates activity record){/ts}"><i class="crm-i fa-pencil" aria-hidden="true"></i></a>
       </td>
       <td class="crm-case-caseview-case_status label">
-        <span class="crm-case-summary-label">{ts}Status{/ts}:</span>&nbsp;{$caseDetails.case_status}&nbsp;<a class="crm-hover-button crm-popup"  href="{crmURL p='civicrm/case/activity' q="action=add&reset=1&cid=`$contactId`&caseid=`$caseId`&selectedChild=activity&atype=`$changeCaseStatusId`"}" title="{ts}Change case status (creates activity record){/ts}"><i class="crm-i fa-pencil" aria-hidden="true"></i></a>
+        <span class="crm-case-summary-label">{ts}Status{/ts}:</span>&nbsp;{$caseDetails.case_status}&nbsp;<a class="crm-hover-button crm-popup"  href="{crmURL p='civicrm/case/activity' q="action=add&reset=1&cid=`$contactId`&caseid=`$caseId`&selectedChild=activity&atype=`$changeCaseStatusId`"}" title="{ts escape='htmlattribute'}Change case status (creates activity record){/ts}"><i class="crm-i fa-pencil" aria-hidden="true"></i></a>
       </td>
       <td class="crm-case-caseview-case_start_date label">
-        <span class="crm-case-summary-label">{ts}Open Date{/ts}:</span>&nbsp;{$caseDetails.case_start_date|crmDate}&nbsp;<a class="crm-hover-button crm-popup"  href="{crmURL p='civicrm/case/activity' q="action=add&reset=1&cid=`$contactId`&caseid=`$caseId`&selectedChild=activity&atype=`$changeCaseStartDateId`"}" title="{ts}Change case start date (creates activity record){/ts}"><i class="crm-i fa-pencil" aria-hidden="true"></i></a>
+        <span class="crm-case-summary-label">{ts}Open Date{/ts}:</span>&nbsp;{$caseDetails.case_start_date|crmDate}&nbsp;<a class="crm-hover-button crm-popup"  href="{crmURL p='civicrm/case/activity' q="action=add&reset=1&cid=`$contactId`&caseid=`$caseId`&selectedChild=activity&atype=`$changeCaseStartDateId`"}" title="{ts escape='htmlattribute'}Change case start date (creates activity record){/ts}"><i class="crm-i fa-pencil" aria-hidden="true"></i></a>
       </td>
       <td class="crm-case-caseview-{$caseID} label">
         <span class="crm-case-summary-label">{ts}ID{/ts}:</span>&nbsp;{$caseID}
@@ -151,13 +151,13 @@
           <div>{$form.role_type.label}</div>
           <div>{$form.role_type.html}</div><br />
           <div><label for="add_role_contact_id">{ts}Assign To{/ts}:</label></div>
-          <div><input name="add_role_contact_id" placeholder="{ts}- first select relationship type -{/ts}" class="huge" /></div>
+          <div><input name="add_role_contact_id" placeholder="{ts escape='htmlattribute'}- first select relationship type -{/ts}" class="huge" /></div>
         </div>
       {/if}
 
       <div id="editCaseRoleDialog" class="hiddenElement">
         <div><label for="edit_role_contact_id">{ts}Change To{/ts} <span class="crm-marker">*</span></label></div>
-        <div><input name="edit_role_contact_id" placeholder="{ts}- select contact -{/ts}" class="huge" /></div>
+        <div><input name="edit_role_contact_id" placeholder="{ts escape='htmlattribute'}- select contact -{/ts}" class="huge" /></div>
       </div>
       <div id="caseRoles-selector-show-active">
         {* Add checkbox to show inactive roles. For open cases, default value is unchecked, i.e. show active roles. For closed cases default is checked. *}
@@ -238,7 +238,7 @@
       </a>
     </div>
     <div id="addMembersToGroupDialog" class="hiddenElement">
-      <input name="add_member_to_group_contact_id" placeholder="{ts}- select contacts -{/ts}" class="huge" />
+      <input name="add_member_to_group_contact_id" placeholder="{ts escape='htmlattribute'}- select contacts -{/ts}" class="huge" />
     </div>
     <table id="globalRelationships-selector-{$caseId}"  class="report-layout crm-ajax-table" data-page-length="10">
       <thead>

--- a/templates/CRM/Case/Form/Selector.tpl
+++ b/templates/CRM/Case/Form/Selector.tpl
@@ -13,7 +13,7 @@
   <tr class="columnheader">
 
   {if ! $single and $context eq 'Search'}
-    <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
+    <th scope="col" title="{ts escape='htmlattribute'}Select rows{/ts}">{$form.toggleSelect.html}</th>
   {/if}
 
   <th></th>
@@ -39,11 +39,11 @@
         <td>{$form.$cbName.html}</td>
     {/if}
         <td class="crm-case-id crm-case-id_{$row.case_id}">
-          <a title="{ts}Activities{/ts}" class="crm-expand-row" href="{crmURL p='civicrm/case/details' q="caseId=`$row.case_id`&cid=`$row.contact_id`"}"></a>
+          <a title="{ts escape='htmlattribute'}Activities{/ts}" class="crm-expand-row" href="{crmURL p='civicrm/case/details' q="caseId=`$row.case_id`&cid=`$row.contact_id`"}"></a>
         </td>
 
     {if !$single}
-      <td class="crm-case-id crm-case-id_{$row.case_id}"><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}" title="{ts}View Contact Details{/ts}">{$row.sort_name}</a>{if $row.phone}<br /><span class="description">{$row.phone}</span>{/if}<br /><span class="description">{ts}Case ID{/ts}: {$row.case_id}</span></td>
+      <td class="crm-case-id crm-case-id_{$row.case_id}"><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}" title="{ts escape='htmlattribute'}View Contact Details{/ts}">{$row.sort_name}</a>{if $row.phone}<br /><span class="description">{$row.phone}</span>{/if}<br /><span class="description">{ts}Case ID{/ts}: {$row.case_id}</span></td>
     {/if}
 
     <td class="crm-case-subject">{$row.case_subject}</td>

--- a/templates/CRM/Contact/Form/Contact.tpl
+++ b/templates/CRM/Contact/Form/Contact.tpl
@@ -16,7 +16,7 @@
   {/if}
   <div class="crm-form-block crm-search-form-block">
     {crmPermission has='administer CiviCRM'}
-      <a href='{crmURL p="civicrm/admin/setting/preferences/display" q="reset=1"}' title="{ts}Click here to configure the panes.{/ts}"><i class="crm-i fa-wrench" aria-hidden="true"></i></a>
+      <a href='{crmURL p="civicrm/admin/setting/preferences/display" q="reset=1"}' title="{ts escape='htmlattribute'}Click here to configure the panes.{/ts}"><i class="crm-i fa-wrench" aria-hidden="true"></i></a>
     {/crmPermission}
     <span style="float:right;"><a href="#expand" id="expand">{ts}Expand all tabs{/ts}</a></span>
     <div class="crm-submit-buttons">

--- a/templates/CRM/Contact/Form/DedupeRules.tpl
+++ b/templates/CRM/Contact/Form/DedupeRules.tpl
@@ -28,7 +28,7 @@
           <div>
             <p><strong>{ts}Currently set to: {/ts}<span class='js-dedupe-rules-current'></span></strong></p>
             <p class='js-dedupe-rules-desc'></p>
-            <p><button class='crm-button js-dedupe-rules-change' type='button' {if NOT $canChangeUsage} disabled title='{ts 1=$ruleUsed}To change the usage for this rule, please configure another rule as %1{/ts}'{/if}>{ts}Change usage{/ts}</button></p>
+            <p><button class='crm-button js-dedupe-rules-change' type='button' {if NOT $canChangeUsage} disabled title='{ts escape='htmlattribute' 1=$ruleUsed}To change the usage for this rule, please configure another rule as %1{/ts}'{/if}>{ts}Change usage{/ts}</button></p>
           </div>
         </td>
      </tr>
@@ -102,7 +102,7 @@
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>
 
-<div class='dedupe-rules-dialog' data-title='{ts escape='js'}Change usage{/ts}' data-button-close='{ts escape='js'}Close{/ts}' data-button-update='{ts escape='js'}Update{/ts}' hidden>
+<div class='dedupe-rules-dialog' data-title='{ts escape='htmlattribute'}Change usage{/ts}' data-button-close='{ts escape='htmlattribute'}Close{/ts}' data-button-update='{ts escape='htmlattribute'}Update{/ts}' hidden>
   <p>{ts}CiviCRM includes three types of dedupe rule. <strong>You can only configure one 'Unsupervised' and one 'Supervised' rule for each contact type, but you can configure any number of additional 'General' rules to provide other criteria to scan for possible duplicates.</strong>{/ts}</p>
   <p>{ts}Selecting 'Unsupervised' or 'Supervised' will convert the previously configured rule of that type to 'General'.{/ts}</p>
   <div>

--- a/templates/CRM/Contact/Form/Edit/Address.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address.tpl
@@ -36,7 +36,7 @@
         </td>
      {if $blockId gt 0}
          <td>
-             <a href="#" title="{ts}Delete Address Block{/ts}" onClick="removeBlock( 'Address', '{$blockId}' ); return false;">{ts}Delete this address{/ts}</a>
+             <a href="#" title="{ts escape='htmlattribute'}Delete Address Block{/ts}" onClick="removeBlock( 'Address', '{$blockId}' ); return false;">{ts}Delete this address{/ts}</a>
          </td>
      {/if}
      </tr>

--- a/templates/CRM/Contact/Form/Edit/Address/street_address.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address/street_address.tpl
@@ -13,7 +13,7 @@
       {$form.address.$blockId.street_address.label} {help id="id-street-address" file="CRM/Contact/Form/Contact.hlp"}<br />
       {$form.address.$blockId.street_address.html}
       {if $parseStreetAddress eq 1 && ($action eq 1 || $action eq 2)}
-          &nbsp;&nbsp;<a href="#" title="{ts}Edit Address Elements{/ts}" onClick="processAddressFields( 'addressElements' , '{$blockId}', 1 );return false;">{ts}Edit Address Elements{/ts}</a>
+          &nbsp;&nbsp;<a href="#" title="{ts escape='htmlattribute'}Edit Address Elements{/ts}" onClick="processAddressFields( 'addressElements' , '{$blockId}', 1 );return false;">{ts}Edit Address Elements{/ts}</a>
           {help id="id-edit-street-elements" file="CRM/Contact/Form/Contact.hlp"}
       {/if}
     </td>
@@ -34,7 +34,7 @@
       <td colspan="2">
         {$form.address.$blockId.street_unit.label}<br />
         {$form.address.$blockId.street_unit.html}
-        <a href="#" title="{ts}Edit Street Address{/ts}" onClick="processAddressFields( 'streetAddress', '{$blockId}', 1 );return false;">{ts}Edit Complete Street Address{/ts}</a>
+        <a href="#" title="{ts escape='htmlattribute'}Edit Street Address{/ts}" onClick="processAddressFields( 'streetAddress', '{$blockId}', 1 );return false;">{ts}Edit Complete Street Address{/ts}</a>
         {help id="id-edit-complete-street" file="CRM/Contact/Form/Contact.hlp"}
       </td>
     </tr>

--- a/templates/CRM/Contact/Form/Edit/CommunicationPreferences.tpl
+++ b/templates/CRM/Contact/Form/Edit/CommunicationPreferences.tpl
@@ -41,7 +41,7 @@
                 <td>
                     <span id="email_greeting" {if !empty($email_greeting_display) and $action eq 2} class="hiddenElement"{/if}>{$form.email_greeting_id.html|crmAddClass:big}</span>
                     {if !empty($email_greeting_display) and $action eq 2}
-                      <div data-id="email_greeting" class="replace-plain" title="{ts}Click to edit{/ts}">
+                      <div data-id="email_greeting" class="replace-plain" title="{ts escape='htmlattribute'}Click to edit{/ts}">
                         {$email_greeting_display}
                       </div>
                     {/if}
@@ -51,7 +51,7 @@
                 <td>
                     <span id="postal_greeting" {if !empty($postal_greeting_display) and $action eq 2} class="hiddenElement"{/if}>{$form.postal_greeting_id.html|crmAddClass:big}</span>
                     {if !empty($postal_greeting_display) and $action eq 2}
-                      <div data-id="postal_greeting" class="replace-plain" title="{ts}Click to edit{/ts}">
+                      <div data-id="postal_greeting" class="replace-plain" title="{ts escape='htmlattribute'}Click to edit{/ts}">
                         {$postal_greeting_display}
                       </div>
                     {/if}
@@ -61,7 +61,7 @@
                 <td>
                     <span id="addressee" {if !empty($addressee_display) and $action eq 2} class="hiddenElement"{/if}>{$form.addressee_id.html|crmAddClass:big}</span>
                     {if !empty($addressee_display) and $action eq 2}
-                      <div data-id="addressee" class="replace-plain" title="{ts}Click to edit{/ts}">
+                      <div data-id="addressee" class="replace-plain" title="{ts escape='htmlattribute'}Click to edit{/ts}">
                         {$addressee_display}
                       </div>
                     {/if}

--- a/templates/CRM/Contact/Form/Edit/Email.tpl
+++ b/templates/CRM/Contact/Form/Edit/Email.tpl
@@ -47,7 +47,7 @@
   </td>
   {if $blockId gt 1}
     <td>
-      <a href="#" title="{ts}Delete Email Block{/ts}" onClick="removeBlock( 'Email', '{$blockId}' ); return false;">{ts}delete{/ts}</a>
+      <a href="#" title="{ts escape='htmlattribute'}Delete Email Block{/ts}" onClick="removeBlock( 'Email', '{$blockId}' ); return false;">{ts}delete{/ts}</a>
     </td>
   {/if}
 </tr>

--- a/templates/CRM/Contact/Form/Edit/Email.tpl
+++ b/templates/CRM/Contact/Form/Edit/Email.tpl
@@ -15,7 +15,7 @@
 {if !$addBlock}
   <tr>
     <td>{ts}Email{/ts}
-      &nbsp;&nbsp;<a id='addEmail' href="#" title={ts}Add{/ts} onClick="buildAdditionalBlocks( 'Email', '{$className}');return false;">{ts}add{/ts}</a>
+      &nbsp;&nbsp;<a id='addEmail' href="#" title="{ts escape='htmlattribute'}Add{/ts}" onClick="buildAdditionalBlocks( 'Email', '{$className}');return false;">{ts}add{/ts}</a>
     </td>
     {if $className eq 'CRM_Contact_Form_Contact'}
       <td>{ts}On Hold?{/ts} {help id="id-onhold" file="CRM/Contact/Form/Contact.hlp"}</td>

--- a/templates/CRM/Contact/Form/Edit/IM.tpl
+++ b/templates/CRM/Contact/Form/Edit/IM.tpl
@@ -32,7 +32,7 @@
 {if !$addBlock}
 <tr>
 <td colspan="4">
-&nbsp;&nbsp;<a href="#" title={ts}Add{/ts} onClick="buildAdditionalBlocks( 'IM', '{$className}');return false;">{ts}Add another IM{/ts}</a>
+&nbsp;&nbsp;<a href="#" title="{ts escape='htmlattribute'}Add{/ts}" onClick="buildAdditionalBlocks( 'IM', '{$className}');return false;">{ts}Add another IM{/ts}</a>
 </td>
 </tr>
 {/if}

--- a/templates/CRM/Contact/Form/Edit/IM.tpl
+++ b/templates/CRM/Contact/Form/Edit/IM.tpl
@@ -26,7 +26,7 @@
     <td colspan="2">{$form.im.$blockId.provider_id.html}</td>
     <td align="center" id="IM-Primary-html" {if $blockId eq 1}class="hiddenElement"{/if}>{$form.im.$blockId.is_primary.1.html}</td>
     {if $blockId gt 1}
-        <td><a href="#" title="{ts}Delete IM Block{/ts}" onClick="removeBlock('IM','{$blockId}'); return false;">{ts}delete{/ts}</a></td>
+        <td><a href="#" title="{ts escape='htmlattribute'}Delete IM Block{/ts}" onClick="removeBlock('IM','{$blockId}'); return false;">{ts}delete{/ts}</a></td>
     {/if}
 </tr>
 {if !$addBlock}

--- a/templates/CRM/Contact/Form/Edit/OpenID.tpl
+++ b/templates/CRM/Contact/Form/Edit/OpenID.tpl
@@ -24,7 +24,7 @@
     <td>{$form.openid.$blockId.location_type_id.html}</td>
     <td align="center" id="OpenID-Primary-html" {if $blockId eq 1}class="hiddenElement"{/if}>{$form.openid.$blockId.is_primary.1.html}</td>
     {if $blockId gt 1}
-    <td><a href="#" title="{ts}Delete OpenID Block{/ts}" onClick="removeBlock('OpenID','{$blockId}'); return false;">{ts}delete{/ts}</a></td>
+    <td><a href="#" title="{ts escape='htmlattribute'}Delete OpenID Block{/ts}" onClick="removeBlock('OpenID','{$blockId}'); return false;">{ts}delete{/ts}</a></td>
     {/if}
 </tr>
 {if !$addBlock}

--- a/templates/CRM/Contact/Form/Edit/OpenID.tpl
+++ b/templates/CRM/Contact/Form/Edit/OpenID.tpl
@@ -30,7 +30,7 @@
 {if !$addBlock}
 <tr>
 <td colspan="4">
-&nbsp;&nbsp;<a href="#" title={ts}Add{/ts} onClick="buildAdditionalBlocks( 'OpenID', '{$className}');return false;">{ts}Add another Open Id{/ts}</a>
+&nbsp;&nbsp;<a href="#" title="{ts escape='htmlattribute'}Add{/ts}" onClick="buildAdditionalBlocks( 'OpenID', '{$className}');return false;">{ts}Add another Open Id{/ts}</a>
 </td>
 </tr>
 {/if}

--- a/templates/CRM/Contact/Form/Edit/Phone.tpl
+++ b/templates/CRM/Contact/Form/Edit/Phone.tpl
@@ -34,7 +34,7 @@
     <td align="center" id="Phone-Primary-html" {if $blockId eq 1}class="hiddenElement"{/if}>{$form.phone.$blockId.is_primary.1.html}</td>
   {/if}
   {if $blockId gt 1}
-    <td><a href="#" title="{ts}Delete Phone Block{/ts}" onClick="removeBlock('Phone','{$blockId}'); return false;">{ts}delete{/ts}</a></td>
+    <td><a href="#" title="{ts escape='htmlattribute'}Delete Phone Block{/ts}" onClick="removeBlock('Phone','{$blockId}'); return false;">{ts}delete{/ts}</a></td>
   {/if}
 </tr>
 

--- a/templates/CRM/Contact/Form/Edit/Phone.tpl
+++ b/templates/CRM/Contact/Form/Edit/Phone.tpl
@@ -41,7 +41,7 @@
 {if !$addBlock}
 <tr>
   <td colspan="4">
-  &nbsp;&nbsp;<a id='addPhone' href="#" title={ts}Add{/ts} onClick="buildAdditionalBlocks( 'Phone', '{$className}');return false;">{ts}Add another phone number{/ts}</a>
+  &nbsp;&nbsp;<a id='addPhone' href="#" title="{ts escape='htmlattribute'}Add{/ts}" onClick="buildAdditionalBlocks( 'Phone', '{$className}');return false;">{ts}Add another phone number{/ts}</a>
   </td>
 </tr>
 {/if}

--- a/templates/CRM/Contact/Form/Edit/Website.tpl
+++ b/templates/CRM/Contact/Form/Edit/Website.tpl
@@ -26,7 +26,7 @@
     <td>{$form.website.$blockId.url.html|crmAddClass:url}&nbsp;</td>
     <td>{$form.website.$blockId.website_type_id.html}</td>
     {if $blockId gt 1}
-      <td colspan="3"><a href="#" title="{ts}Delete Website Block{/ts}" onClick="removeBlock('Website','{$blockId}'); return false;">{ts}delete{/ts}</a></td>
+      <td colspan="3"><a href="#" title="{ts escape='htmlattribute'}Delete Website Block{/ts}" onClick="removeBlock('Website','{$blockId}'); return false;">{ts}delete{/ts}</a></td>
     {/if}
 </tr>
 {if !$addBlock}

--- a/templates/CRM/Contact/Form/Edit/Website.tpl
+++ b/templates/CRM/Contact/Form/Edit/Website.tpl
@@ -32,7 +32,7 @@
 {if !$addBlock}
 <tr>
 <td colspan="4">
-&nbsp;&nbsp;<a href="#" title={ts}Add{/ts} onClick="buildAdditionalBlocks( 'Website', '{$className}');return false;">{ts}Add another website{/ts}</a>
+&nbsp;&nbsp;<a href="#" title="{ts escape='htmlattribute'}Add{/ts}" onClick="buildAdditionalBlocks( 'Website', '{$className}');return false;">{ts}Add another website{/ts}</a>
 </td>
 </tr>
 {/if}

--- a/templates/CRM/Contact/Form/Inline/CommunicationPreferences.tpl
+++ b/templates/CRM/Contact/Form/Inline/CommunicationPreferences.tpl
@@ -62,7 +62,7 @@
             {$form.email_greeting_id.html|crmAddClass:big}
           </span>
           {if !empty($email_greeting_display)}
-            <div data-id="email_greeting" class="replace-plain big" title="{ts}Click to edit{/ts}">
+            <div data-id="email_greeting" class="replace-plain big" title="{ts escape='htmlattribute'}Click to edit{/ts}">
               {$email_greeting_display}
             </div>
           {/if}
@@ -84,7 +84,7 @@
             {$form.postal_greeting_id.html|crmAddClass:big}
           </span>
           {if !empty($postal_greeting_display)}
-            <div data-id="postal_greeting" class="replace-plain big" title="{ts}Click to edit{/ts}">
+            <div data-id="postal_greeting" class="replace-plain big" title="{ts escape='htmlattribute'}Click to edit{/ts}">
               {$postal_greeting_display}
             </div>
           {/if}
@@ -105,7 +105,7 @@
             {$form.addressee_id.html|crmAddClass:big}
           </span>
           {if !empty($addressee_display)}
-            <div data-id="addressee" class="replace-plain big" title="{ts}Click to edit{/ts}">
+            <div data-id="addressee" class="replace-plain big" title="{ts escape='htmlattribute'}Click to edit{/ts}">
               {$addressee_display}
             </div>
           {/if}

--- a/templates/CRM/Contact/Form/Inline/Email.tpl
+++ b/templates/CRM/Contact/Form/Inline/Email.tpl
@@ -19,7 +19,7 @@
   <tr>
     <td>{ts}Email{/ts}&nbsp;
       {if $actualBlockCount lt 5}
-        <span id="add-more-email" title="{ts}click to add more{/ts}">
+        <span id="add-more-email" title="{ts escape='htmlattribute'}click to add more{/ts}">
           <a class="crm-hover-button action-item add-more-inline" href="#">{ts}add{/ts}</a>
         </span>
       {/if}
@@ -36,7 +36,7 @@
       <td align="center">{$form.email.$blockId.on_hold.html}</td>
       <td align="center" {if !$multipleBulk}class="crm-email-bulkmail"{/if}>{$form.email.$blockId.is_bulkmail.html}</td>
       <td align="center" class="crm-email-is_primary">{$form.email.$blockId.is_primary.1.html}</td>
-      <td><a title="{ts}Delete Email{/ts}" class="crm-delete-inline crm-hover-button" href="#"><span class="icon delete-icon"></span></a></td>
+      <td><a title="{ts escape='htmlattribute'}Delete Email{/ts}" class="crm-delete-inline crm-hover-button" href="#"><span class="icon delete-icon"></span></a></td>
     </tr>
     {include file="CRM/Contact/Form/Inline/BlockCustomData.tpl" entity=email customFields=$custom_fields_email blockId=$blockId actualBlockCount=$actualBlockCount}
 

--- a/templates/CRM/Contact/Form/Inline/IM.tpl
+++ b/templates/CRM/Contact/Form/Inline/IM.tpl
@@ -19,7 +19,7 @@
     <tr>
       <td>{ts}Instant Messenger{/ts}&nbsp;
       {if $actualBlockCount lt 5}
-        <span id="add-more-im" title="{ts}click to add more{/ts}"><a class="crm-hover-button action-item add-more-inline" href="#">{ts}add{/ts}</a></span>
+        <span id="add-more-im" title="{ts escape='htmlattribute'}click to add more{/ts}"><a class="crm-hover-button action-item add-more-inline" href="#">{ts}add{/ts}</a></span>
       {/if}
       </td>
       <td>{ts}IM Location{/ts}</td>
@@ -36,7 +36,7 @@
         <td align="center" class="crm-im-is_primary">{$form.im.$blockId.is_primary.1.html}</td>
         <td>
           {if $blockId gt 1}
-            <a class="crm-delete-inline crm-hover-button" href="#" title="{ts}Delete IM{/ts}"><span class="icon delete-icon"></span></a>
+            <a class="crm-delete-inline crm-hover-button" href="#" title="{ts escape='htmlattribute'}Delete IM{/ts}"><span class="icon delete-icon"></span></a>
           {/if}
         </td>
     </tr>

--- a/templates/CRM/Contact/Form/Inline/OpenID.tpl
+++ b/templates/CRM/Contact/Form/Inline/OpenID.tpl
@@ -20,7 +20,7 @@
   <tr>
     <td>{ts}Open ID{/ts}&nbsp;
     {if $actualBlockCount lt 5}
-      <span id="add-more-openid" title="{ts}click to add more{/ts}"><a class="crm-hover-button action-item add-more-inline" href="#">{ts}add{/ts}</a></span>
+      <span id="add-more-openid" title="{ts escape='htmlattribute'}click to add more{/ts}"><a class="crm-hover-button action-item add-more-inline" href="#">{ts}add{/ts}</a></span>
     {/if}
     </td>
     <td>{ts}Open ID Location{/ts}</td>
@@ -36,7 +36,7 @@
     <td align="center" id="OpenID-Primary-html" class="crm-openid-is_primary">{$form.openid.$blockId.is_primary.1.html}</td>
     <td>
       {if $blockId gt 1}
-        <a class="crm-delete-inline crm-hover-button" href="#" title="{ts}Delete OpenID{/ts}"><span class="icon delete-icon"></span></a>
+        <a class="crm-delete-inline crm-hover-button" href="#" title="{ts escape='htmlattribute'}Delete OpenID{/ts}"><span class="icon delete-icon"></span></a>
       {/if}
     </td>
   </tr>

--- a/templates/CRM/Contact/Form/Inline/Phone.tpl
+++ b/templates/CRM/Contact/Form/Inline/Phone.tpl
@@ -19,7 +19,7 @@
     <tr>
       <td>{ts}Phone{/ts}&nbsp;
       {if $actualBlockCount lt 5}
-        <span id="add-more-phone" title="{ts}click to add more{/ts}"><a class="crm-hover-button action-item add-more-inline" href="#">{ts}add{/ts}</a></span>
+        <span id="add-more-phone" title="{ts escape='htmlattribute'}click to add more{/ts}"><a class="crm-hover-button action-item add-more-inline" href="#">{ts}add{/ts}</a></span>
       {/if}
       </td>
       <td>{ts}Phone Location{/ts}</td>
@@ -36,7 +36,7 @@
         <td align="center" class="crm-phone-is_primary">{$form.phone.$blockId.is_primary.1.html}</td>
         <td>
           {if $blockId gt 1}
-            <a class="crm-delete-inline crm-hover-button" href="#" title="{ts}Delete phone{/ts}"><span class="icon delete-icon"></span></a>
+            <a class="crm-delete-inline crm-hover-button" href="#" title="{ts escape='htmlattribute'}Delete phone{/ts}"><span class="icon delete-icon"></span></a>
           {/if}
         </td>
     </tr>

--- a/templates/CRM/Contact/Form/Inline/Website.tpl
+++ b/templates/CRM/Contact/Form/Inline/Website.tpl
@@ -21,7 +21,7 @@
       <td>{ts}Website{/ts}
         {help id="id-website" file="CRM/Contact/Form/Contact.hlp"}
         {if $actualBlockCount lt 25}
-          &nbsp;&nbsp;<span id="add-more-website" title="{ts}click to add more{/ts}"><a class="crm-hover-button action-item add-more-inline" href="#">{ts}add{/ts}</a></span>
+          &nbsp;&nbsp;<span id="add-more-website" title="{ts escape='htmlattribute'}click to add more{/ts}"><a class="crm-hover-button action-item add-more-inline" href="#">{ts}add{/ts}</a></span>
         {/if}
       </td>
       <td>{ts}Website Type{/ts}</td>
@@ -34,7 +34,7 @@
       <td>{$form.website.$blockId.url.html|crmAddClass:url}&nbsp;</td>
       <td>{$form.website.$blockId.website_type_id.html}</td>
       {if $blockId gt 1}
-        <td><a class="crm-delete-inline crm-hover-button action-item" href="#" title="{ts}Delete Website{/ts}"><span class="icon delete-icon"></span></a></td>
+        <td><a class="crm-delete-inline crm-hover-button action-item" href="#" title="{ts escape='htmlattribute'}Delete Website{/ts}"><span class="icon delete-icon"></span></a></td>
       {/if}
     </tr>
     {/section}

--- a/templates/CRM/Contact/Form/Merge.tpl
+++ b/templates/CRM/Contact/Form/Merge.tpl
@@ -40,7 +40,7 @@
   </div>
 
   <div class="action-link">
-    <a href="#" class="action-item crm-hover-button crm-notDuplicate" title={ts}Mark this pair as not a duplicate.{/ts} onClick="processDupes( {$main_cid|escape}, {$other_cid|escape}, 'dupe-nondupe', 'merge-contact', '{$browseUrl}' );return false;">
+    <a href="#" class="action-item crm-hover-button crm-notDuplicate" title="{ts escape='htmlattribute'}Mark this pair as not a duplicate.{/ts}" onClick="processDupes( {$main_cid|escape}, {$other_cid|escape}, 'dupe-nondupe', 'merge-contact', '{$browseUrl}' );return false;">
       <i class="crm-i fa-times-circle" aria-hidden="true"></i>
       {ts}Mark this pair as not a duplicate.{/ts}
     </a>

--- a/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
+++ b/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
@@ -65,7 +65,7 @@ CRM.$(function($) {
     var body = $('.crm-accordion-body.' + id);
     if (header.length > 0 && body.length > 0 && !body.html()) {
       body.html('<div class="crm-loading-element"><span class="loading-text">{/literal}{ts escape='js'}Loading{/ts}{literal}...</span></div>');
-      header.append('{/literal}<a href="#" class="crm-close-accordion crm-hover-button css_right" title="{ts escape='js'}Remove from search criteria{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>{literal}');
+      header.append('{/literal}<a href="#" class="crm-close-accordion crm-hover-button css_right" title="{ts escape='htmlattribute'}Remove from search criteria{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>{literal}');
       header.addClass('active');
       CRM.loadPage(url, {target: body, block: false});
     }
@@ -101,7 +101,7 @@ CRM.$(function($) {
     <div class="crm-accordion-body">
       <div class="float-right">
         <span class="crm-submit-buttons reset-advanced-search">
-          <a href="{crmURL p='civicrm/contact/search/advanced' q='reset=1'}" id="resetAdvancedSearch" class="crm-hover-button crm-inline-button" title="{ts}Clear all search criteria{/ts}">
+          <a href="{crmURL p='civicrm/contact/search/advanced' q='reset=1'}" id="resetAdvancedSearch" class="crm-hover-button crm-inline-button" title="{ts escape='htmlattribute'}Clear all search criteria{/ts}">
             <i class="crm-i fa-undo" aria-hidden="true"></i>
             &nbsp;{ts}Reset Form{/ts}
           </a>

--- a/templates/CRM/Contact/Form/Search/Criteria/Location.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Location.tpl
@@ -16,7 +16,7 @@
           {$form.street_address.html|crmAddClass:big}
           {if $parseStreetAddress}
             <div>
-              <a href="#" title="{ts}Use Address Elements{/ts}" rel="addressElements" class="address-elements-toggle">{ts}Use Address Elements{/ts}</a>
+              <a href="#" title="{ts escape='htmlattribute'}Use Address Elements{/ts}" rel="addressElements" class="address-elements-toggle">{ts}Use Address Elements{/ts}</a>
             </div>
           {/if}
         </div>
@@ -28,7 +28,7 @@
               <td>{$form.street_unit.label}<br />{$form.street_unit.html|crmAddClass:four}</td>
             </tr>
             <tr>
-              <td colspan="3"><a href="#" title="{ts}Use Complete Address{/ts}" rel="streetAddress" class="address-elements-toggle">{ts}Use Street Address{/ts}</a></td>
+              <td colspan="3"><a href="#" title="{ts escape='htmlattribute'}Use Complete Address{/ts}" rel="streetAddress" class="address-elements-toggle">{ts}Use Street Address{/ts}</a></td>
             </tr>
           </table>
         </div>

--- a/templates/CRM/Contact/Form/Search/table.tpl
+++ b/templates/CRM/Contact/Form/Search/table.tpl
@@ -25,7 +25,7 @@
                 {$form.value[$x][$i].html|crmAddClass:'required'}
               </span>
               {if $i gt 0 or $x gt 1}
-                &nbsp;<a href="#" class="crm-reset-builder-row crm-hover-button" title="{ts}Remove this row{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
+                &nbsp;<a href="#" class="crm-reset-builder-row crm-hover-button" title="{ts escape='htmlattribute'}Remove this row{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
               {/if}
             </td>
           </tr>

--- a/templates/CRM/Contact/Form/Selector.tpl
+++ b/templates/CRM/Contact/Form/Selector.tpl
@@ -9,10 +9,10 @@
 *}
 {include file="CRM/common/pager.tpl" location="top"}
 {include file="CRM/common/pagerAToZ.tpl"}
-<table summary="{ts}Search results listings.{/ts}" class="selector row-highlight">
+<table summary="{ts escape='htmlattribute'}Search results listings.{/ts}" class="selector row-highlight">
   <thead class="sticky">
     <tr>
-      <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
+      <th scope="col" title="{ts escape='htmlattribute'}Select rows{/ts}">{$form.toggleSelect.html}</th>
       {if $context eq 'smog'}
           <th scope="col">
             {ts}Status{/ts}

--- a/templates/CRM/Contact/Form/Task.tpl
+++ b/templates/CRM/Contact/Form/Task.tpl
@@ -29,7 +29,7 @@
     </table>
   </div>
 </div><br />
-<a href="#" id="popup-button" title="{ts}View Selected Contacts{/ts}">{ts}View Selected Contacts{/ts}</a>
+<a href="#" id="popup-button" title="{ts escape='htmlattribute'}View Selected Contacts{/ts}">{ts}View Selected Contacts{/ts}</a>
 {/if}
 
 {if $isSelectedContacts}

--- a/templates/CRM/Contact/Form/Task/Email.tpl
+++ b/templates/CRM/Contact/Form/Task/Email.tpl
@@ -29,14 +29,14 @@
       <td class="label">{$form.cc_id.label}</td>
       <td>
         {$form.cc_id.html}
-        <a class="crm-hover-button clear-cc-link" rel="cc_id" title="{ts}Clear{/ts}" href="#"><i class="crm-i fa-times" aria-hidden="true"></i></a>
+        <a class="crm-hover-button clear-cc-link" rel="cc_id" title="{ts escape='htmlattribute'}Clear{/ts}" href="#"><i class="crm-i fa-times" aria-hidden="true"></i></a>
       </td>
     </tr>
     <tr class="crm-contactEmail-form-block-bcc_id" {if empty($form.bcc_id.value)}style="display:none;"{/if}>
       <td class="label">{$form.bcc_id.label}</td>
       <td>
         {$form.bcc_id.html}
-        <a class="crm-hover-button clear-cc-link" rel="bcc_id" title="{ts}Clear{/ts}" href="#"><i class="crm-i fa-times" aria-hidden="true"></i></a>
+        <a class="crm-hover-button clear-cc-link" rel="bcc_id" title="{ts escape='htmlattribute'}Clear{/ts}" href="#"><i class="crm-i fa-times" aria-hidden="true"></i></a>
       </td>
     </tr>
     <tr>

--- a/templates/CRM/Contact/Page/DedupeException.tpl
+++ b/templates/CRM/Contact/Page/DedupeException.tpl
@@ -61,7 +61,7 @@
             <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$exception.contact_id2`"}" target="_blank">{$exception.$contact2name}</a>
           </td>
           <td>
-            <a id='duplicateContacts' href="#" title={ts}Remove Exception{/ts} onClick="processDupes( {$exception.contact_id1}, {$exception.contact_id2}, 'nondupe-dupe', 'dedupe-exception' );return false;"><i class="crm-i fa-trash" aria-hidden="true"></i> {ts}Remove Exception{/ts}</a>
+            <a id='duplicateContacts' href="#" title="{ts escape='htmlattribute'}Remove Exception{/ts}" onClick="processDupes( {$exception.contact_id1}, {$exception.contact_id2}, 'nondupe-dupe', 'dedupe-exception' );return false;"><i class="crm-i fa-trash" aria-hidden="true"></i> {ts}Remove Exception{/ts}</a>
           </td>
         </tr>
 

--- a/templates/CRM/Contact/Page/DedupeException.tpl
+++ b/templates/CRM/Contact/Page/DedupeException.tpl
@@ -18,7 +18,7 @@
         <tr>
           <td class="crm-contact-form-block-contact1">
             <label for="search-contact1">{ts}Contact Name{/ts}</label><br />
-            <input class="crm-form-text" type="text" size="50" placeholder="{ts}Search Contacts{/ts}" value="{$searchcontact1}" id="search-contact1" search-column="0" />
+            <input class="crm-form-text" type="text" size="50" placeholder="{ts escape='htmlattribute'}Search Contacts{/ts}" value="{$searchcontact1}" id="search-contact1" search-column="0" />
           </td>
           <td class="crm-contact-form-block-search">
             <label>&nbsp;</label><br />

--- a/templates/CRM/Contact/Page/DedupeFind.tpl
+++ b/templates/CRM/Contact/Page/DedupeFind.tpl
@@ -18,37 +18,37 @@
         <tr>
           <td class="crm-contact-form-block-contact1">
             <label for="contact1">{ts}Contact 1{/ts}</label><br />
-            <input type="text" placeholder="{ts}Search Contact1{/ts}" search-column="2" id="contact1"/>
+            <input type="text" placeholder="{ts escape='htmlattribute'}Search Contact1{/ts}" search-column="2" id="contact1"/>
           </td>
           <td class="crm-contact-form-block-contact2">
             <label for="contact2">{ts}Contact 2{/ts}</label><br />
-            <input type="text" placeholder="{ts}Search Contact2{/ts}" search-column="4" id="contact2"/>
+            <input type="text" placeholder="{ts escape='htmlattribute'}Search Contact2{/ts}" search-column="4" id="contact2"/>
           </td>
           <td class="crm-contact-form-block-email1">
             <label for="email1">{ts}Email 1{/ts}</label><br />
-            <input type="text" placeholder="{ts}Search Email1{/ts}" search-column="5" id="email1"/>
+            <input type="text" placeholder="{ts escape='htmlattribute'}Search Email1{/ts}" search-column="5" id="email1"/>
           </td>
           <td class="crm-contact-form-block-email2">
             <label for="email2">{ts}Email 2{/ts}</label><br />
-            <input type="text" placeholder="{ts}Search Email2{/ts}" search-column="6" id="email2"/>
+            <input type="text" placeholder="{ts escape='htmlattribute'}Search Email2{/ts}" search-column="6" id="email2"/>
           </td>
         </tr>
         <tr>
           <td class="crm-contact-form-block-street-address1">
             <label for="street-adddress1">{ts}Street Address 1{/ts}</label><br />
-            <input type="text" placeholder="{ts}Search Street Address1{/ts}" search-column="7" id="street-adddress1"/>
+            <input type="text" placeholder="{ts escape='htmlattribute'}Search Street Address1{/ts}" search-column="7" id="street-adddress1"/>
           </td>
           <td class="crm-contact-form-block-street-address2">
             <label for="street-adddress2">{ts}Street Address 2{/ts}</label><br />
-            <input type="text" placeholder="{ts}Search Street Address2{/ts}" search-column="8" id="street-adddress2"/>
+            <input type="text" placeholder="{ts escape='htmlattribute'}Search Street Address2{/ts}" search-column="8" id="street-adddress2"/>
           </td>
           <td class="crm-contact-form-block-postcode1">
             <label for="postcode1">{ts}Postcode 1{/ts}</label><br />
-            <input type="text" placeholder="{ts}Search Postcode1{/ts}" search-column="9" id="postcode1"/>
+            <input type="text" placeholder="{ts escape='htmlattribute'}Search Postcode1{/ts}" search-column="9" id="postcode1"/>
           </td>
           <td class="crm-contact-form-block-postcode2">
             <label for="postcode2">{ts}Postcode 2{/ts}</label><br />
-            <input type="text" placeholder="{ts}Search Postcode2{/ts}" search-column="10" id="postcode2"/>
+            <input type="text" placeholder="{ts escape='htmlattribute'}Search Postcode2{/ts}" search-column="10" id="postcode2"/>
           </td>
         </tr>
       </table>
@@ -107,27 +107,27 @@
 {elseif $context eq 'conflicts'}
   {crmPermission has='force merge duplicate contacts'}
      {capture assign=backURL}{crmURL p="civicrm/contact/dedupemerge" q="`$urlQuery`&action=map&mode=aggressive" a=1}{/capture}
-     <a href="{$backURL}" title="{ts}Force Merge Selected Duplicates{/ts}" onclick="return confirm('{ts escape="js"}This will run the batch merge process on the selected duplicates. The operation will run in force merge mode - all selected duplicates will be merged into main contacts even in case of any conflicts. Click OK to proceed if you are sure you wish to run this operation.{/ts}');" class="button"><span><i class="crm-i fa-bolt" aria-hidden="true"></i> {ts}Force Merge Selected Duplicates{/ts}</span></a>
+     <a href="{$backURL}" title="{ts escape='htmlattribute'}Force Merge Selected Duplicates{/ts}" onclick="return confirm('{ts escape="js"}This will run the batch merge process on the selected duplicates. The operation will run in force merge mode - all selected duplicates will be merged into main contacts even in case of any conflicts. Click OK to proceed if you are sure you wish to run this operation.{/ts}');" class="button"><span><i class="crm-i fa-bolt" aria-hidden="true"></i> {ts}Force Merge Selected Duplicates{/ts}</span></a>
 
      {capture assign=backURL}{crmURL p="civicrm/contact/dedupemerge" q="`$urlQuery`&action=map" a=1}{/capture}
-     <a href="{$backURL}" title="{ts}Safe Merge Selected Duplicates{/ts}" onclick="return confirm('{ts escape="js"}This will run the batch merge process on the selected duplicates. The operation will run in safe mode - only records with no direct data conflicts will be merged. Click OK to proceed if you are sure you wish to run this operation.{/ts}');" class="button"><span><i class="crm-i fa-compress" aria-hidden="true"></i> {ts}Safe Merge Selected Duplicates{/ts}</span></a>
+     <a href="{$backURL}" title="{ts escape='htmlattribute'}Safe Merge Selected Duplicates{/ts}" onclick="return confirm('{ts escape="js"}This will run the batch merge process on the selected duplicates. The operation will run in safe mode - only records with no direct data conflicts will be merged. Click OK to proceed if you are sure you wish to run this operation.{/ts}');" class="button"><span><i class="crm-i fa-compress" aria-hidden="true"></i> {ts}Safe Merge Selected Duplicates{/ts}</span></a>
   {/crmPermission}
 
   {capture assign=backURL}{crmURL p="civicrm/contact/dedupefind" q="`$urlQuery`&action=update&selected=0" a=1}{/capture}
-   <a href="{$backURL}" title="{ts}List All Duplicates{/ts}" class="button"><span><i class="crm-i fa-refresh" aria-hidden="true"></i> {ts}List All Duplicates{/ts}</span></a>
+   <a href="{$backURL}" title="{ts escape='htmlattribute'}List All Duplicates{/ts}" class="button"><span><i class="crm-i fa-refresh" aria-hidden="true"></i> {ts}List All Duplicates{/ts}</span></a>
 {else}
    {capture assign=backURL}{crmURL p="civicrm/contact/dedupefind" q="`$urlQuery`&action=renew" a=1}{/capture}
-   <a href="{$backURL}" title="{ts}Refresh List of Duplicates{/ts}" onclick="return confirm('{ts escape="js"}This will refresh the duplicates list. Click OK to proceed.{/ts}');" class="button">
+   <a href="{$backURL}" title="{ts escape='htmlattribute'}Refresh List of Duplicates{/ts}" onclick="return confirm('{ts escape="js"}This will refresh the duplicates list. Click OK to proceed.{/ts}');" class="button">
      <span><i class="crm-i fa-refresh" aria-hidden="true"></i> {ts}Refresh Duplicates{/ts}</span>
    </a>
 
   {capture assign=backURL}{crmURL p="civicrm/contact/dedupemerge" q="`$urlQuery`&action=map" a=1}{/capture}
-   <a href="{$backURL}" title="{ts}Batch Merge Duplicate Contacts{/ts}" onclick="return confirm('{ts escape="js"}This will run the batch merge process on the selected duplicates. The operation will run in safe mode - only records with no direct data conflicts will be merged. Click OK to proceed if you are sure you wish to run this operation.{/ts}');" class="button"><span><i class="crm-i fa-compress" aria-hidden="true"></i> {ts}Batch Merge Selected Duplicates{/ts}</span></a>
+   <a href="{$backURL}" title="{ts escape='htmlattribute'}Batch Merge Duplicate Contacts{/ts}" onclick="return confirm('{ts escape="js"}This will run the batch merge process on the selected duplicates. The operation will run in safe mode - only records with no direct data conflicts will be merged. Click OK to proceed if you are sure you wish to run this operation.{/ts}');" class="button"><span><i class="crm-i fa-compress" aria-hidden="true"></i> {ts}Batch Merge Selected Duplicates{/ts}</span></a>
 
    {capture assign=backURL}{crmURL p="civicrm/contact/dedupemerge" q=$urlQuery a=1}{/capture}
-   <a href="{$backURL}" title="{ts}Batch Merge Duplicate Contacts{/ts}" onclick="return confirm('{ts escape="js"}This will run the batch merge process on the listed duplicates. The operation will run in safe mode - only records with no direct data conflicts will be merged. Click OK to proceed if you are sure you wish to run this operation.{/ts}');" class="button"><span><i class="crm-i fa-compress" aria-hidden="true"></i> {ts}Batch Merge All Duplicates{/ts}</span></a>
+   <a href="{$backURL}" title="{ts escape='htmlattribute'}Batch Merge Duplicate Contacts{/ts}" onclick="return confirm('{ts escape="js"}This will run the batch merge process on the listed duplicates. The operation will run in safe mode - only records with no direct data conflicts will be merged. Click OK to proceed if you are sure you wish to run this operation.{/ts}');" class="button"><span><i class="crm-i fa-compress" aria-hidden="true"></i> {ts}Batch Merge All Duplicates{/ts}</span></a>
 
-   <a href='#' title="{ts}Flip Selected Duplicates{/ts}" class="crm-dedupe-flip-selections button"><span><i class="crm-i fa-exchange" aria-hidden="true"></i> {ts}Flip Selected Duplicates{/ts}</span></a>
+   <a href='#' title="{ts escape='htmlattribute'}Flip Selected Duplicates{/ts}" class="crm-dedupe-flip-selections button"><span><i class="crm-i fa-exchange" aria-hidden="true"></i> {ts}Flip Selected Duplicates{/ts}</span></a>
 
    {capture assign=backURL}{crmURL p="civicrm/contact/deduperules" q="reset=1" a=1}{/capture}
    <a href="{$backURL}" class="button crm-button-type-cancel">

--- a/templates/CRM/Contact/Page/Inline/Address.tpl
+++ b/templates/CRM/Contact/Page/Inline/Address.tpl
@@ -9,7 +9,7 @@
 *}
 {* template for a single address block*}
 <div id="address-block-{$locationIndex}" class="address {if $add}crm-address_type_{$add.location_type}{else}add-new{/if}{if $permission EQ 'edit'} crm-inline-edit" data-dependent-fields='["#crm-contactinfo-content", ".crm-inline-edit.address:not(.add-new)"]' data-edit-params='{ldelim}"cid": "{$contactId}", "class_name": "CRM_Contact_Form_Inline_Address", "locno": "{$locationIndex}", "aid": "{if $add}{$add.id}{else}0{/if}"{rdelim}' data-location-type-id="{if $add}{$add.location_type_id}{else}0{/if}{/if}">
-  <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{if $add}{ts}Edit address{/ts}{else}{ts}Add address{/ts}{/if}"{/if}>
+  <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{if $add}{ts escape='htmlattribute'}Edit address{/ts}{else}{ts escape='htmlattribute'}Add address{/ts}{/if}"{/if}>
     {if $permission EQ 'edit'}
       <div class="crm-edit-help">
         <span class="crm-i fa-pencil" aria-hidden="true"></span> {if $add}{ts}Edit address{/ts}{else}{ts}Add address{/ts}{/if}
@@ -32,7 +32,7 @@
               is_numeric($add.geo_code_2)
           }
           {assign var='mapLocationTypeID' value=$add.location_type_id}
-          <br /><a href="{crmURL p='civicrm/contact/map' q="reset=1&cid=$contactId&lid=$mapLocationTypeID"}" title="{ts 1=$add.location_type}Map %1 Address{/ts}"><i class="crm-i fa-map-marker" aria-hidden="true"></i> {ts}Map{/ts}</a>
+          <br /><a href="{crmURL p='civicrm/contact/map' q="reset=1&cid=$contactId&lid=$mapLocationTypeID"}" title="{ts escape='htmlattribute' 1=$add.location_type}Map %1 Address{/ts}"><i class="crm-i fa-map-marker" aria-hidden="true"></i> {ts}Map{/ts}</a>
           {/if}
         </div>
         <div class="crm-content">

--- a/templates/CRM/Contact/Page/Inline/Basic.tpl
+++ b/templates/CRM/Contact/Page/Inline/Basic.tpl
@@ -2,7 +2,7 @@
   <div class="crm-summary-row">
     <div class="crm-label" id="tagLink">
       <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$contactId&selectedChild=tag"}"
-         title="{ts}Edit Tags{/ts}">{ts}Tags{/ts}</a>
+         title="{ts escape='htmlattribute'}Edit Tags{/ts}">{ts}Tags{/ts}</a>
     </div>
     <div class="crm-content" id="tags">
       {foreach from=$contactTag item=tagName key=tagId}
@@ -26,7 +26,7 @@
       <span class="crm-contact-contact_id">{$contactId}</span>
       {if $userRecordUrl}
         <span class="crm-contact-user_record_id">
-          &nbsp;/&nbsp;<a title="{ts}View user record{/ts}" class="user-record-link"
+          &nbsp;/&nbsp;<a title="{ts escape='htmlattribute'}View user record{/ts}" class="user-record-link"
                           href="{$userRecordUrl}">{$userRecordId}</a>
         </span>
       {/if}

--- a/templates/CRM/Contact/Page/Inline/CommunicationPreferences.tpl
+++ b/templates/CRM/Contact/Page/Inline/CommunicationPreferences.tpl
@@ -9,7 +9,7 @@
 *}
 {* template for building communication preference block*}
 <div id="crm-communication-pref-content" {if $permission EQ 'edit'} class="crm-inline-edit" data-edit-params='{ldelim}"cid": "{$contactId}", "class_name": "CRM_Contact_Form_Inline_CommunicationPreferences"{rdelim}' data-dependent-fields='["#crm-phone-content", "#crm-email-content", ".address.crm-inline-edit:not(.add-new)", "#crm-contact-actions-wrapper"]'{/if}>
-  <div class="crm-clear crm-inline-block-content"{if $permission EQ 'edit'} title="{ts}Edit communication preferences{/ts}"{/if}>
+  <div class="crm-clear crm-inline-block-content"{if $permission EQ 'edit'} title="{ts escape='htmlattribute'}Edit communication preferences{/ts}"{/if}>
     {if $permission EQ 'edit'}
     <div class="crm-edit-help">
       <span class="crm-i fa-pencil" aria-hidden="true"></span> {ts}Edit communication preferences{/ts}

--- a/templates/CRM/Contact/Page/Inline/ContactInfo.tpl
+++ b/templates/CRM/Contact/Page/Inline/ContactInfo.tpl
@@ -9,7 +9,7 @@
 *}
 {* data-edit-params to reload this info whenever relationship gets updated *}
 <div id="crm-contactinfo-content" {if $permission EQ 'edit'} class="crm-inline-edit" {/if} data-edit-params='{ldelim}"cid": "{$contactId}", "class_name": "CRM_Contact_Form_Inline_ContactInfo"{rdelim}'>
-  <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts}Edit info{/ts}"{/if}>
+  <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts escape='htmlattribute'}Edit info{/ts}"{/if}>
     {if $permission EQ 'edit'}
     <div class="crm-edit-help">
       <span class="crm-i fa-pencil" aria-hidden="true"></span> {ts}Edit info{/ts}
@@ -21,7 +21,7 @@
         <div class="crm-label">{ts}Employer{/ts}</div>
         <div class="crm-content crm-contact-current_employer">
           {if !empty($current_employer_id)}
-          <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$current_employer_id`"}" title="{ts}view current employer{/ts}">{$current_employer}</a>
+          <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$current_employer_id`"}" title="{ts escape='htmlattribute'}view current employer{/ts}">{$current_employer}</a>
           {/if}
         </div>
       </div>

--- a/templates/CRM/Contact/Page/Inline/ContactName.tpl
+++ b/templates/CRM/Contact/Page/Inline/ContactName.tpl
@@ -9,7 +9,7 @@
 *}
 <div id="crm-contactname-content" {if $permission EQ 'edit'}class="crm-inline-edit" data-edit-params='{ldelim}"cid": "{$contactId}", "class_name": "CRM_Contact_Form_Inline_ContactName"{rdelim}' data-dependent-fields='["#crm-communication-pref-content"]'{/if}>
   {crmRegion name="contact-page-contactname"}
-    <div class="crm-inline-block-content"{if $permission EQ 'edit'} title="{ts}Edit Contact Name{/ts}"{/if}>
+    <div class="crm-inline-block-content"{if $permission EQ 'edit'} title="{ts escape='htmlattribute'}Edit Contact Name{/ts}"{/if}>
       {if $permission EQ 'edit'}
         <div class="crm-edit-help">
           <span class="crm-i fa-pencil" aria-hidden="true"></span> {ts}Edit name{/ts}

--- a/templates/CRM/Contact/Page/Inline/Demographics.tpl
+++ b/templates/CRM/Contact/Page/Inline/Demographics.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 <div id="crm-demographic-content" {if $permission EQ 'edit'} class="crm-inline-edit" data-dependent-fields='["#crm-contactname-content"]' data-edit-params='{ldelim}"cid": "{$contactId}", "class_name": "CRM_Contact_Form_Inline_Demographics"{rdelim}'{/if}>
-  <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts}Edit demographics{/ts}"{/if}>
+  <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts escape='htmlattribute'}Edit demographics{/ts}"{/if}>
     {if $permission EQ 'edit'}
     <div class="crm-edit-help">
       <span class="crm-i fa-pencil" aria-hidden="true"></span> {ts}Edit demographics{/ts}

--- a/templates/CRM/Contact/Page/Inline/Email.tpl
+++ b/templates/CRM/Contact/Page/Inline/Email.tpl
@@ -9,7 +9,7 @@
 *}
 {* template for building email block*}
 <div id="crm-email-content" {if $permission EQ 'edit'} class="crm-inline-edit" data-edit-params='{ldelim}"cid": "{$contactId}", "class_name": "CRM_Contact_Form_Inline_Email"{rdelim}' data-dependent-fields='["#crm-contact-actions-wrapper"]'{/if}>
-  <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts}Add or edit email{/ts}"{/if}>
+  <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts escape='htmlattribute'}Add or edit email{/ts}"{/if}>
   {if $permission EQ 'edit'}
     <div class="crm-edit-help">
       <span class="crm-i fa-pencil" aria-hidden="true"></span> {if empty($email)}{ts}Add email{/ts}{else}{ts}Add or edit email{/ts}{/if}
@@ -34,11 +34,11 @@
       <div class="crm-content crm-contact_email">
         {if !$item.on_hold and !$privacy.do_not_email}
           {if $mailingOutboundOption == 2} {* Outbound email is disabled, use a mailto link *}
-            <a href="mailto:{$item.email}" title="{ts 1=$item.email}Send email to %1{/ts}">
+            <a href="mailto:{$item.email}" title="{ts escape='htmlattribute' 1=$item.email}Send email to %1{/ts}">
             {$item.email}
             </a>
           {else}
-            <a href="{crmURL p="civicrm/activity/email/add" q="action=add&reset=1&email_id=`$item.id`"}" class="crm-popup" title="{ts 1=$item.email}Send email to %1{/ts}">
+            <a href="{crmURL p="civicrm/activity/email/add" q="action=add&reset=1&email_id=`$item.id`"}" class="crm-popup" title="{ts escape='htmlattribute' 1=$item.email}Send email to %1{/ts}">
             {$item.email}
             </a>
           {/if}
@@ -46,10 +46,10 @@
           {$item.email}
         {/if}
         {crmAPI var='civi_mail' entity='Extension' action='get' full_name="civi_mail" is_active=1}
-        {if $item.on_hold == 2}&nbsp;({ts}On Hold - Opt Out{/ts})&nbsp;{ts}{$item.hold_date|truncate:10:''|crmDate}{/ts}{elseif $item.on_hold}&nbsp;{if $civi_mail.count}<a href="{crmURL p="civicrm/contact/view/bounces" f="?email_id=`$item.id`"}" class="crm-popup" title="{ts 1=$item.email}Email Bounce History{/ts}">{/if}({ts}On Hold{/ts})&nbsp;{ts}{$item.hold_date|truncate:10:''|crmDate}{/ts}{if $civi_mail.count}&nbsp;<i class="crm-i fa-list-alt" aria-hidden="true"></i></a>{/if}{/if}{if $item.is_bulkmail}&nbsp;({ts}Bulk{/ts}){/if}
+        {if $item.on_hold == 2}&nbsp;({ts}On Hold - Opt Out{/ts})&nbsp;{ts}{$item.hold_date|truncate:10:''|crmDate}{/ts}{elseif $item.on_hold}&nbsp;{if $civi_mail.count}<a href="{crmURL p="civicrm/contact/view/bounces" f="?email_id=`$item.id`"}" class="crm-popup" title="{ts escape='htmlattribute' 1=$item.email}Email Bounce History{/ts}">{/if}({ts}On Hold{/ts})&nbsp;{ts}{$item.hold_date|truncate:10:''|crmDate}{/ts}{if $civi_mail.count}&nbsp;<i class="crm-i fa-list-alt" aria-hidden="true"></i></a>{/if}{/if}{if $item.is_bulkmail}&nbsp;({ts}Bulk{/ts}){/if}
         {if !empty($item.signature_text) OR !empty($item.signature_html)}
         <span class="signature-link description">
-          <a href="#" title="{ts}Signature{/ts}" onClick="showHideSignature( '{$blockId}' ); return false;">{ts}(signature){/ts}</a>
+          <a href="#" title="{ts escape='htmlattribute'}Signature{/ts}" onClick="showHideSignature( '{$blockId}' ); return false;">{ts}(signature){/ts}</a>
         </span>
         {/if}
         <div id="Email_Block_{$blockId}_signature" class="hiddenElement">

--- a/templates/CRM/Contact/Page/Inline/IM.tpl
+++ b/templates/CRM/Contact/Page/Inline/IM.tpl
@@ -9,7 +9,7 @@
 *}
 {* template for building IM block*}
 <div id="crm-im-content" {if $permission EQ 'edit'} class="crm-inline-edit" data-edit-params='{ldelim}"cid": "{$contactId}", "class_name": "CRM_Contact_Form_Inline_IM"{rdelim}'{/if}>
-  <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts}Add or edit IM{/ts}"{/if}>
+  <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts escape='htmlattribute'}Add or edit IM{/ts}"{/if}>
     {if $permission EQ 'edit'}
       <div class="crm-edit-help">
         <span class="crm-i fa-pencil" aria-hidden="true"></span> {if empty($im)}{ts}Add IM{/ts}{else}{ts}Add or edit IM{/ts}{/if}

--- a/templates/CRM/Contact/Page/Inline/OpenID.tpl
+++ b/templates/CRM/Contact/Page/Inline/OpenID.tpl
@@ -9,7 +9,7 @@
 *}
 {* template for building OpenID block*}
 <div id="crm-openid-content" {if $permission EQ 'edit'} class="crm-inline-edit" data-edit-params='{ldelim}"cid": "{$contactId}", "class_name": "CRM_Contact_Form_Inline_OpenID"{rdelim}'{/if}>
-  <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts}Add or edit OpenID{/ts}"{/if}>
+  <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts escape='htmlattribute'}Add or edit OpenID{/ts}"{/if}>
     {if $permission EQ 'edit'}
       <div class="crm-edit-help">
         <span class="crm-i fa-pencil" aria-hidden="true"></span> {if empty($openid)}{ts}Add OpenID{/ts}{else}{ts}Add or edit OpenID{/ts}{/if}

--- a/templates/CRM/Contact/Page/Inline/Phone.tpl
+++ b/templates/CRM/Contact/Page/Inline/Phone.tpl
@@ -9,7 +9,7 @@
 *}
 {* template for building phone block*}
 <div id="crm-phone-content" {if $permission EQ 'edit'} class="crm-inline-edit" data-edit-params='{ldelim}"cid": "{$contactId}", "class_name": "CRM_Contact_Form_Inline_Phone"{rdelim}' data-dependent-fields='["#crm-contact-actions-wrapper"]'{/if}>
-  <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts}Add or edit phone{/ts}"{/if}>
+  <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts escape='htmlattribute'}Add or edit phone{/ts}"{/if}>
     {if $permission EQ 'edit'}
       <div class="crm-edit-help">
         <span class="crm-i fa-pencil" aria-hidden="true"></span> {if empty($phone)}{ts}Add phone{/ts}{else}{ts}Add or edit phone{/ts}{/if}

--- a/templates/CRM/Contact/Page/Inline/Website.tpl
+++ b/templates/CRM/Contact/Page/Inline/Website.tpl
@@ -9,7 +9,7 @@
 *}
 {* template for building website block *}
 <div id="crm-website-content" {if $permission EQ 'edit'} class="crm-inline-edit" data-edit-params='{ldelim}"cid": "{$contactId}", "class_name": "CRM_Contact_Form_Inline_Website"{rdelim}'{/if}>
-  <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts}Add or edit website{/ts}"{/if}>
+  <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts escape='htmlattribute'}Add or edit website{/ts}"{/if}>
     {if $permission EQ 'edit'}
       <div class="crm-edit-help">
         <span class="crm-i fa-pencil" aria-hidden="true"></span> {if empty($website)}{ts}Add website{/ts}{else}{ts}Add or edit website{/ts}{/if}

--- a/templates/CRM/Contact/Page/SavedSearch.tpl
+++ b/templates/CRM/Contact/Page/SavedSearch.tpl
@@ -35,7 +35,7 @@
 {else}
     <div class="messages status no-popup">
       <dl>
-        <dt><img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/></dt>
+        <dt><img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/></dt>
         <dd>
             {ts}There are currently no Saved Searches. To create a Saved search:{/ts}
             <p>

--- a/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
+++ b/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 <div id="custom-set-content-{$customGroupId}" {if $permission EQ 'edit' && !empty($cd_edit.editable)} class="crm-inline-edit" data-edit-params='{ldelim}"cid": "{$contactId}", "class_name": "CRM_Contact_Form_Inline_CustomData", "groupID": "{$customGroupId}", "customRecId": "{$customRecId}", "cgcount" : "{$cgcount}"{rdelim}' data-dependent-fields='["#crm-communication-pref-content"]'{/if}>
-  <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit' && !empty($cd_edit.editable)}title="{ts}Edit{/ts}"{/if}>
+  <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit' && !empty($cd_edit.editable)}title="{ts escape='htmlattribute'}Edit{/ts}"{/if}>
     {if $permission EQ 'edit' && !empty($cd_edit.editable)}
       <div class="crm-edit-help">
         <span class="crm-i fa-pencil" aria-hidden="true"></span> {ts}Edit{/ts}

--- a/templates/CRM/Contact/Page/View/GroupContact.tpl
+++ b/templates/CRM/Contact/Page/View/GroupContact.tpl
@@ -47,9 +47,9 @@
             <td>{$row.in_date|crmDate}</td>
             <td>
               {if $permission EQ 'edit'}
-                <a class="action-item crm-hover-button" href="#Removed" title="{ts 1=$displayName 2=$row.title}Remove %1 from %2? (status in this group will be changed to 'Removed').{/ts}">
+                <a class="action-item crm-hover-button" href="#Removed" title="{ts escape='htmlattribute' 1=$displayName 2=$row.title}Remove %1 from %2? (status in this group will be changed to 'Removed').{/ts}">
                   {ts}Remove{/ts}</a>
-                <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2? (remove contact AND delete their record of having been in this group).{/ts}">
+                <a class="action-item crm-hover-button" href="#Deleted" title="{ts escape='htmlattribute' 1=$displayName 2=$row.title}Delete %1 from %2? (remove contact AND delete their record of having been in this group).{/ts}">
                   {ts}Delete{/ts}</a>
               {/if}
             </td>
@@ -98,9 +98,9 @@
             <td>{$row.pending_date|crmDate}</td>
             <td>
               {if $permission EQ 'edit'}
-                <a class="action-item crm-hover-button" href="#Removed" title="{ts 1=$displayName 2=$row.title}Remove %1 from %2? (status in this group will be changed to 'Removed').{/ts}">
+                <a class="action-item crm-hover-button" href="#Removed" title="{ts escape='htmlattribute' 1=$displayName 2=$row.title}Remove %1 from %2? (status in this group will be changed to 'Removed').{/ts}">
                   {ts}Remove{/ts}</a>
-                <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2? (this group will no longer be listed under Pending Groups){/ts}">
+                <a class="action-item crm-hover-button" href="#Deleted" title="{ts escape='htmlattribute' 1=$displayName 2=$row.title}Delete %1 from %2? (this group will no longer be listed under Pending Groups){/ts}">
                   {ts}Delete{/ts}</a>
               {/if}
             </td>
@@ -139,11 +139,11 @@
             <td>
               {if $permission EQ 'edit'}
                 {if $row.saved_search_id}
-                <a class="action-item crm-hover-button" href="#Added" title="{ts 1=$displayName 2=$row.title}Add %1 manually into %2, overriding smart group critera?{/ts}">
+                <a class="action-item crm-hover-button" href="#Added" title="{ts escape='htmlattribute' 1=$displayName 2=$row.title}Add %1 manually into %2, overriding smart group critera?{/ts}">
                   {ts}Manual Add{/ts}
                 </a>
                 {else}
-                <a class="action-item crm-hover-button" href="#Added" title="{ts 1=$displayName 2=$row.title}Add %1 back into %2?{/ts}">
+                <a class="action-item crm-hover-button" href="#Added" title="{ts escape='htmlattribute' 1=$displayName 2=$row.title}Add %1 back into %2?{/ts}">
                   {ts}Rejoin Group{/ts}
                 </a>
                 {/if}
@@ -152,11 +152,11 @@
             <td>
               {if $permission EQ 'edit'}
                 {if $row.saved_search_id}
-                <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2?{/ts} {ts}They will be in the smart group or not based on the smart group criteria.{/ts}">
+                <a class="action-item crm-hover-button" href="#Deleted" title="{ts escape='htmlattribute' 1=$displayName 2=$row.title}Delete %1 from %2?{/ts} {ts}They will be in the smart group or not based on the smart group criteria.{/ts}">
                   {ts}Delete{/ts}
                 </a>
                 {else}
-                <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2?{/ts} {ts}This group will no longer be listed under Removed Groups.{/ts}">
+                <a class="action-item crm-hover-button" href="#Deleted" title="{ts escape='htmlattribute' 1=$displayName 2=$row.title}Delete %1 from %2?{/ts} {ts}This group will no longer be listed under Removed Groups.{/ts}">
                   {ts}Delete{/ts}
                 </a>
                 {/if}

--- a/templates/CRM/Contact/Page/View/Print.tpl
+++ b/templates/CRM/Contact/Page/View/Print.tpl
@@ -27,7 +27,7 @@
     {include file="CRM/Contact/Page/View/Summary.tpl"}
     <form action="{crmURL p='civicrm/contact/view' q="cid=`$contactId`&reset=1"}" method="post" id="Print2" >
       <div class="form-item">
-           <span class="element-right"><input onclick="window.print(); return false" class="crm-form-submit default" name="_qf_Print_next" value="{ts}Print{/ts}" type="submit" />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input class="crm-form-submit" name="_qf_Print_back" value="{ts}Done{/ts}" type="submit" /></span>
+           <span class="element-right"><input onclick="window.print(); return false" class="crm-form-submit default" name="_qf_Print_next" value="{ts escape='htmlattribute'}Print{/ts}" type="submit" />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input class="crm-form-submit" name="_qf_Print_back" value="{ts escape='htmlattribute'}Done{/ts}" type="submit" /></span>
       </div>
     </form>
 </div>

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -59,7 +59,7 @@
     {crmRegion name='contribution-main-not-you-block'}
     {if $contact_id && !$isPaymentOnExistingContribution}
       <div class="messages status no-popup crm-not-you-message">
-        {ts 1=$display_name}Welcome %1{/ts}. (<a href="{crmURL p='civicrm/contribute/transact' q="cid=0&reset=1&id=`$contributionPageID`"}" title="{ts}Click here to do this for a different person.{/ts}">{ts 1=$display_name}Not %1, or want to do this for a different person{/ts}</a>?)
+        {ts 1=$display_name}Welcome %1{/ts}. (<a href="{crmURL p='civicrm/contribute/transact' q="cid=0&reset=1&id=`$contributionPageID`"}" title="{ts escape='htmlattribute'}Click here to do this for a different person.{/ts}">{ts 1=$display_name}Not %1, or want to do this for a different person{/ts}</a>?)
       </div>
     {/if}
     {/crmRegion}

--- a/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
@@ -41,13 +41,13 @@
             <td>
             <table class="form-layout">
                 <tr class="crm-contribution-contributionpage-amount-form-block-pay_later_text">
-                    <td scope="row" class="label">{$form.pay_later_text.label} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span> {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_contribution_page' field='pay_later_text' id=$contributionPageID}{/if}</td>
+                    <td scope="row" class="label">{$form.pay_later_text.label} <span class="crm-marker" title="{ts escape='htmlattribute'}This field is required.{/ts}">*</span> {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_contribution_page' field='pay_later_text' id=$contributionPageID}{/if}</td>
                     <td>{$form.pay_later_text.html|crmAddClass:big}</td>
                 </tr>
                 <tr class="crm-contribution-contributionpage-amount-form-block-pay_later_receipt">
                     <td scope="row" class="label">
                         {$form.pay_later_receipt.label}
-                        <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span>
+                        <span class="crm-marker" title="{ts escape='htmlattribute'}This field is required.{/ts}">*</span>
                         {help id="id-pay_later_receipt"}
                         {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_contribution_page' field='pay_later_receipt' id=$contributionPageID}{/if}
                     </td>
@@ -82,7 +82,7 @@
                <td>
                   <table class="form-layout-compressed">
                     <tr class="crm-contribution-form-block-recur_frequency_unit">
-                        <td scope="row" class="label">{$form.recur_frequency_unit.label} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></td>
+                        <td scope="row" class="label">{$form.recur_frequency_unit.label} <span class="crm-marker" title="{ts escape='htmlattribute'}This field is required.{/ts}">*</span></td>
                         <td>{$form.recur_frequency_unit.html}</td>
                     </tr>
                     <tr class="crm-contribution-form-block-is_recur_interval"><td scope="row" class="label">{$form.is_recur_interval.label}</td>

--- a/templates/CRM/Contribute/Form/ContributionPage/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/ThankYou.tpl
@@ -40,7 +40,7 @@
   </td>
     </tr>
     <tr class="crm-contribution-contributionpage-thankyou-form-block-receipt_from_email">
-      <td class="label">{$form.receipt_from_email.label} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span> {help id="id_receipt-from-email"}</td>
+      <td class="label">{$form.receipt_from_email.label} <span class="crm-marker" title="{ts escape='htmlattribute'}This field is required.{/ts}">*</span> {help id="id_receipt-from-email"}</td>
       <td class="html-adjust">{$form.receipt_from_email.html}</td>
     </tr>
     <tr class="crm-contribution-contributionpage-thankyou-form-block-receipt_text">

--- a/templates/CRM/Contribute/Form/ContributionView.tpl
+++ b/templates/CRM/Contribute/Form/ContributionView.tpl
@@ -189,7 +189,7 @@
           <tr>
             <td>
               <a href="{crmURL p="civicrm/contact/view" q="reset=1&cid=`$softCont.contact_id`"}"
-                 title="{ts}View contact record{/ts}">{$softCont.contact_name}
+                 title="{ts escape='htmlattribute'}View contact record{/ts}">{$softCont.contact_name}
               </a>
             </td>
             <td>{$softCont.amount|crmMoney:$currency}
@@ -238,7 +238,7 @@
         <tr>
           <td class="label">{ts}Soft Credit To{/ts}</td>
           <td><a href="{crmURL p="civicrm/contact/view" q="reset=1&cid=`$pcp_soft_credit_to_id`"}" id="view_contact"
-                 title="{ts}View contact record{/ts}">{$pcp_soft_credit_to_name}</a></td>
+                 title="{ts escape='htmlattribute'}View contact record{/ts}">{$pcp_soft_credit_to_name}</a></td>
         </tr>
         <tr>
           <td class="label">{ts}In Public Honor Roll?{/ts}</td>

--- a/templates/CRM/Contribute/Form/Selector.tpl
+++ b/templates/CRM/Contribute/Form/Selector.tpl
@@ -15,7 +15,7 @@
     <thead class="sticky">
     <tr>
       {if !$single and $context eq 'Search'}
-        <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
+        <th scope="col" title="{ts escape='htmlattribute'}Select rows{/ts}">{$form.toggleSelect.html}</th>
       {/if}
       {if !$single}
       <th scope="col"></th>
@@ -45,7 +45,7 @@
           <td><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}">{$row.sort_name}</a></td>
         {/if}
         <td class="crm-contribution-amount">
-             <a class="nowrap bold crm-expand-row" title="{ts}view payments{/ts}" href="{crmURL p='civicrm/payment' q="view=transaction&component=contribution&action=browse&cid=`$row.contact_id`&id=`$row.contribution_id`&selector=1"}">
+             <a class="nowrap bold crm-expand-row" title="{ts escape='htmlattribute'}view payments{/ts}" href="{crmURL p='civicrm/payment' q="view=transaction&component=contribution&action=browse&cid=`$row.contact_id`&id=`$row.contribution_id`&selector=1"}">
                &nbsp; {$row.total_amount|crmMoney:$row.currency}
             </a>
           {if $row.amount_level}<br/>({$row.amount_level}){/if}

--- a/templates/CRM/Contribute/Page/ContributionPage.tpl
+++ b/templates/CRM/Contribute/Page/ContributionPage.tpl
@@ -86,7 +86,7 @@
     {else}
   {if $isSearch eq 1}
       <div class="status messages">
-                <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
+                <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>
                 {capture assign=browseURL}{crmURL p='civicrm/admin/contribute/manage' q="reset=1"}{/capture}
                     {ts}No available Contribution Pages match your search criteria. Suggestions:{/ts}
                     <div class="spacer"></div>

--- a/templates/CRM/Contribute/Page/DashBoard.tpl
+++ b/templates/CRM/Contribute/Page/DashBoard.tpl
@@ -14,7 +14,7 @@
 <tr class="columnheader-dark">
     <th scope="col">{ts}Period{/ts}</th>
     <th scope="col">{ts}Total Amount{/ts}</th>
-    <th scope="col" title="{ts}Contribution Count{/ts}"><strong>#</strong></th><th></th></tr>
+    <th scope="col" title="{ts escape='htmlattribute'}Contribution Count{/ts}"><strong>#</strong></th><th></th></tr>
 <tr>
     <td><strong>{ts}Current Month-To-Date{/ts}</strong></td>
     <td class="label">{if NOT $monthToDate.Valid.amount}{ts}(n/a){/ts}{else}{$monthToDate.Valid.amount}{/if}</td>

--- a/templates/CRM/Contribute/Page/ManagePremiums.tpl
+++ b/templates/CRM/Contribute/Page/ManagePremiums.tpl
@@ -65,7 +65,7 @@
 {else}
     {if $action ne 1 and $action ne 2}
     <div class="messages status no-popup">
-        <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
+        <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>
         {capture assign=crmURL}{crmURL p='civicrm/admin/contribute/managePremiums/edit' q="action=add&reset=1"}{/capture}
         {ts 1=$crmURL}No premium products have been created for your site. You can <a href='%1'>add one</a>.{/ts}
     </div>

--- a/templates/CRM/Contribute/Page/PcpUserDashboard.tpl
+++ b/templates/CRM/Contribute/Page/PcpUserDashboard.tpl
@@ -26,7 +26,7 @@
 
   {foreach from=$pcpInfo item=row}
   <tr class="{cycle values="odd-row,even-row"}{if !empty($row.class)} {$row.class}{/if}">
-        <td class="bold"><a href="{crmURL p='civicrm/pcp/info' q="reset=1&id=`$row.pcpId`" a=1}" title="{ts}Preview your Personal Campaign Page{/ts}">{$row.pcpTitle}</a></td>
+        <td class="bold"><a href="{crmURL p='civicrm/pcp/info' q="reset=1&id=`$row.pcpId`" a=1}" title="{ts escape='htmlattribute'}Preview your Personal Campaign Page{/ts}">{$row.pcpTitle}</a></td>
         <td>{$row.pageTitle}</td>
         <td>{if $row.end_date}{$row.end_date|truncate:10:''|crmDate}{else}({ts}ongoing{/ts}){/if}</td>
         <td>{$row.pcpStatus}</td>
@@ -64,7 +64,7 @@
 
   {foreach from=$pcpBlock item=row}
   <tr class="{cycle values="odd-row,even-row"}">
-    <td>{if $row.pageComponent eq 'contribute'}<a href="{crmURL p='civicrm/contribute/transact' q="id=`$row.pageId`&reset=1"}" title="{ts}View campaign page{/ts}">{else}<a href="{crmURL p='civicrm/event/register' q="id=`$row.pageId`&reset=1"}" title="{ts}View campaign page{/ts}">{/if}{$row.pageTitle}</a></td>
+    <td>{if $row.pageComponent eq 'contribute'}<a href="{crmURL p='civicrm/contribute/transact' q="id=`$row.pageId`&reset=1"}" title="{ts escape='htmlattribute'}View campaign page{/ts}">{else}<a href="{crmURL p='civicrm/event/register' q="id=`$row.pageId`&reset=1"}" title="{ts escape='htmlattribute'}View campaign page{/ts}">{/if}{$row.pageTitle}</a></td>
         <td>{if $row.end_date}{$row.end_date|truncate:10:''|crmDate}{else}({ts}ongoing{/ts}){/if}</td>
     <td>{$row.action|replace:'xx':$row.pageId}</td>
   </tr>

--- a/templates/CRM/Contribute/Page/Tab.tpl
+++ b/templates/CRM/Contribute/Page/Tab.tpl
@@ -19,12 +19,12 @@
 
         <ul class="ui-tabs-nav ui-corner-all ui-helper-reset ui-helper-clearfix ui-widget-header">
           <li id="tab_contributions" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab ui-tabs-active ui-state-active">
-            <a href="#contributions-subtab" title="{ts}Contributions{/ts}">
+            <a href="#contributions-subtab" title="{ts escape='htmlattribute'}Contributions{/ts}">
               {ts}Contributions{/ts} <em>{$tabCount}</em>
             </a>
           </li>
           <li id="tab_recurring" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab">
-            <a href="#recurring-subtab" title="{ts}Recurring Contributions{/ts}">
+            <a href="#recurring-subtab" title="{ts escape='htmlattribute'}Recurring Contributions{/ts}">
               {ts}Recurring Contributions{/ts} <em>{$contributionRecurCount}</em>
             </a>
           </li>

--- a/templates/CRM/Contribute/Page/Widget.tpl
+++ b/templates/CRM/Contribute/Page/Widget.tpl
@@ -137,7 +137,7 @@
         <span id="crm_cpid_{$cpageId}_amt_raised" class="crm-amount-raised"> -- placeholder -- </span>
     </div>
     {if !empty($form.url_logo.value)}
-        <div class="crm-logo"><img src="{$form.url_logo.value}" alt={ts}Logo{/ts}></div>
+        <div class="crm-logo"><img src="{$form.url_logo.value}" alt="{ts escape='htmlattribute'}Logo{/ts}"></div>
     {/if}
     <div id="crm_cpid_{$cpageId}_donors" class="crm-donors"></div>
     <div id="crm_cpid_{$cpageId}_comments" class="crm-comments"></div>

--- a/templates/CRM/Core/BillingBlock.tpl
+++ b/templates/CRM/Core/BillingBlock.tpl
@@ -21,14 +21,14 @@
           {assign var='name' value=$form.$paymentField.name}
           <div class="crm-section {$form.$paymentField.name}-section">
             <div class="label">{$form.$paymentField.label}
-              {if $requiredPaymentFields.$name}<span class="crm-marker" title="{ts}This field is required.{/ts}">*</span>{/if}
+              {if $requiredPaymentFields.$name}<span class="crm-marker" title="{ts escape='htmlattribute'}This field is required.{/ts}">*</span>{/if}
             </div>
             <div class="content">
                 {$form.$paymentField.html}
               {if $paymentFieldsMetadata.$name.description}
                 <div class="description">{$paymentFieldsMetadata.$name.description}</div>
               {elseif $paymentField == 'cvv2'}{* @todo move to form assignment*}
-                <span class="cvv2-icon" title="{ts}Usually the last 3-4 digits in the signature area on the back of the card.{/ts}"> </span>
+                <span class="cvv2-icon" title="{ts escape='htmlattribute'}Usually the last 3-4 digits in the signature area on the back of the card.{/ts}"> </span>
               {/if}
               {if $paymentField == 'credit_card_type'}
                 <div class="crm-credit_card_type-icons"></div>
@@ -60,7 +60,7 @@
           {assign var='name' value=$form.$billingField.name}
           <div class="crm-section {$form.$billingField.name}-section">
             <div class="label">{$form.$billingField.label}
-              {if $requiredPaymentFields.$name}<span class="crm-marker" title="{ts}This field is required.{/ts}">*</span>{/if}
+              {if $requiredPaymentFields.$name}<span class="crm-marker" title="{ts escape='htmlattribute'}This field is required.{/ts}">*</span>{/if}
             </div>
             {if $form.$billingField.type == 'text'}
               <div class="content">{$form.$billingField.html}</div>

--- a/templates/CRM/Core/I18n/Dialog.tpl
+++ b/templates/CRM/Core/I18n/Dialog.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {if $config->languageLimit && $config->languageLimit|@count >= 2 and $translatePermission}
-  <a href="{crmURL p='civicrm/i18n' q="reset=1&table=$table&field=$field&id=$id"}" data-field="{$field}" class="crm-hover-button crm-multilingual-edit-button" title="{ts}Languages{/ts}">
+  <a href="{crmURL p='civicrm/i18n' q="reset=1&table=$table&field=$field&id=$id"}" data-field="{$field}" class="crm-hover-button crm-multilingual-edit-button" title="{ts escape='htmlattribute'}Languages{/ts}">
     <i class="crm-i fa-language fa-lg" aria-hidden="true"></i>
   </a>
 {/if}

--- a/templates/CRM/Custom/Form/Edit/CustomData.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomData.tpl
@@ -1,6 +1,6 @@
 {if !$isSingleRecordEdit && $cd_edit.is_multiple eq 1 and array_key_exists('table_id', $cd_edit) && $cd_edit.table_id and $contactId and !$skipTitle and $cd_edit.style eq 'Inline'}
   {assign var=tableID value=$cd_edit.table_id}
-  <a href="#" class="crm-hover-button crm-custom-value-del" title="{ts 1=$cd_edit.title}Delete %1{/ts}"
+  <a href="#" class="crm-hover-button crm-custom-value-del" title="{ts escape='htmlattribute' 1=$cd_edit.title}Delete %1{/ts}"
      data-post='{ldelim}"valueID": "{$tableID}", "groupID": "{$group_id}", "contactId": "{$contactId}", "key": "{crmKey name='civicrm/ajax/customvalue'}"{rdelim}'>
     <span class="icon delete-icon"></span> {ts}Delete{/ts}
   </a>

--- a/templates/CRM/Custom/Form/Edit/CustomField.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomField.tpl
@@ -62,7 +62,7 @@
               {if $element.element_value.deleteURL}
                 <a href="#" class="crm-hover-button delete-attachment"
                    data-filename="{$element.element_value.fileName}"
-                   data-args="{$element.element_value.deleteURLArgs}" title="{ts}Delete File{/ts}">
+                   data-args="{$element.element_value.deleteURLArgs}" title="{ts escape='htmlattribute'}Delete File{/ts}">
                   <span class="icon delete-icon"></span>
                 </a>
               {/if}

--- a/templates/CRM/Custom/Form/Optionfields.tpl
+++ b/templates/CRM/Custom/Form/Optionfields.tpl
@@ -42,7 +42,7 @@
   <tr id="optionField_{$index}" class="form-item {cycle values="odd-row,even-row"}">
         <td>
         {if $index GT 1}
-            <a onclick="showHideRow({$index}); return false;" name="optionField_{$index}" href="#" class="form-link"><i class="crm-i fa-trash" title="{ts}hide field or section{/ts}" aria-hidden="true"></i></a>
+            <a onclick="showHideRow({$index}); return false;" name="optionField_{$index}" href="#" class="form-link"><i class="crm-i fa-trash" title="{ts escape='htmlattribute'}hide field or section{/ts}" aria-hidden="true"></i></a>
         {/if}
         </td>
       <td>

--- a/templates/CRM/Custom/Page/CustomDataView.tpl
+++ b/templates/CRM/Custom/Page/CustomDataView.tpl
@@ -42,7 +42,7 @@
                 <div class="crm-submit-buttons">
                   <a href="#" class="crm-hover-button crm-custom-value-del"
                      data-post='{ldelim}"valueID": "{$cvID}", "groupID": "{$customGroupId}", "contactId": "{$contactId}", "key": "{crmKey name='civicrm/ajax/customvalue'}"{rdelim}'
-                     title="{ts 1=$cd_edit.title|cat:" `$rowCount`"}Delete %1{/ts}">
+                     title="{ts escape='htmlattribute' 1=$cd_edit.title|cat:" `$rowCount`"}Delete %1{/ts}">
                     <i class="crm-i fa-trash" aria-hidden="true"></i> {ts}Delete{/ts}
                   </a>
                 </div>

--- a/templates/CRM/Custom/Page/Field.tpl
+++ b/templates/CRM/Custom/Page/Field.tpl
@@ -49,7 +49,7 @@
 
     {else}
         <div class="messages status no-popup crm-empty-table">
-          <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
+          <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>
           {ts}None found.{/ts}
         </div>
     {/if}

--- a/templates/CRM/Custom/Page/Group.tpl
+++ b/templates/CRM/Custom/Page/Group.tpl
@@ -56,7 +56,7 @@
     </div>
     {else}
        <div class="messages status no-popup">
-       <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/> &nbsp;
+       <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/> &nbsp;
          {capture assign=crmURL}{crmURL p='civicrm/admin/custom/group/edit' q='action=add&reset=1'}{/capture}
          {ts 1=$crmURL}No custom data groups have been created yet. You can <a id="newCustomDataGroup" href='%1'>add one</a>.{/ts}
        </div>

--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
@@ -68,7 +68,7 @@
       <td>
         {$form.max_participants.html|crmAddClass:four}
         {crmPermission has='administer CiviCRM'}
-          <a class="crm-popup crm-hover-button" target="_blank" title="{ts}Edit Participant Status Options{/ts}" href="{crmURL p='civicrm/admin/participant_status' q='reset=1'}"><i class="crm-i fa-wrench" aria-hidden="true"></i></a>
+          <a class="crm-popup crm-hover-button" target="_blank" title="{ts escape='htmlattribute'}Edit Participant Status Options{/ts}" href="{crmURL p='civicrm/admin/participant_status' q='reset=1'}"><i class="crm-i fa-wrench" aria-hidden="true"></i></a>
         {/crmPermission}
       </td>
     </tr>

--- a/templates/CRM/Event/Form/ManageEvent/Repeat.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Repeat.tpl
@@ -38,7 +38,7 @@
           <tr class="row_{$row.id}{if NOT $row.is_active} disabled{/if}">
           <td class="crm-event_{$row.id}{$highlight}">
             <a href="{crmURL p='civicrm/event/info' q="id=`$row.id`&reset=1"}"
-               title="{ts}View event info page{/ts}" class="bold">{$row.title}</a>&nbsp;&nbsp;({ts}ID:{/ts} {$row.id})
+               title="{ts escape='htmlattribute'}View event info page{/ts}" class="bold">{$row.title}</a>&nbsp;&nbsp;({ts}ID:{/ts} {$row.id})
           </td>
           <td class="crm-event-is_public{$highlight}">{if $row.is_public eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
               <td class="crm-event-start_date{$highlight}" data-order="{$row.start_date|crmDate:'%Y-%m-%d'}">{$row.start_date|crmDate:"%b %d, %Y %l:%M %P"}</td>

--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -47,7 +47,7 @@
                 <td class="label"><label>{ts}Also Registered by this Participant{/ts}</label></td>
                 <td>
                   {foreach from=$additionalParticipants key=apName item=apURL}
-                    <a href="{$apURL}" title="{ts}view additional participant{/ts}">{$apName}</a><br />
+                    <a href="{$apURL}" title="{ts escape='htmlattribute'}view additional participant{/ts}">{$apName}</a><br />
                   {/foreach}
                 </td>
               </tr>
@@ -57,7 +57,7 @@
                 <td class="label"><label>{ts}Registered By{/ts}</label></td>
                 <td class="view-value">
                   <a href="{crmURL p='civicrm/contact/view/participant' q="reset=1&id=$participant_registered_by_id&cid=$registered_by_contact_id&action=view"}"
-                     title="{ts}view primary participant{/ts}">{$registered_by_display_name}</a>
+                     title="{ts escape='htmlattribute'}view primary participant{/ts}">{$registered_by_display_name}</a>
                 </td>
               </tr>
             {/if}

--- a/templates/CRM/Event/Form/ParticipantView.tpl
+++ b/templates/CRM/Event/Form/ParticipantView.tpl
@@ -28,7 +28,7 @@
     <tr class="crm-event-participantview-form-block-displayName">
       <td class="label">{ts}Participant Name{/ts}</td>
       <td>
-        <strong><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$contactId"}" title="{ts}View contact record{/ts}">{$displayName|escape}</a></strong>
+        <strong><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$contactId"}" title="{ts escape='htmlattribute'}View contact record{/ts}">{$displayName|escape}</a></strong>
         <div>
             <a class="action-item crm-hover-button" href="{crmURL p='civicrm/event/badge' q="reset=1&context=view&id=$participantId&cid=$contactId"}"><i class="crm-i fa-print" aria-hidden="true"></i> {ts}Print Name Badge{/ts}</a>
             <a class="action-item crm-hover-button" href="{crmURL p='civicrm/event/participant/print' q="reset=1&context=view&id=$participantId&cid=$contactId"}"><i class="crm-i fa-print" aria-hidden="true"></i> {ts}PDF letter - print for participant{/ts}</a>
@@ -38,7 +38,7 @@
   {if $participant_registered_by_id} {* Display primary participant *}
       <tr class="crm-event-participantview-form-block-registeredBy">
           <td class="label">{ts}Registered By{/ts}</td>
-          <td><a href="{crmURL p='civicrm/contact/view/participant' q="reset=1&id=$participant_registered_by_id&cid=$registered_by_contact_id&action=view"}" title="{ts}view primary participant{/ts}">{$registered_by_display_name|escape}</a></td>
+          <td><a href="{crmURL p='civicrm/contact/view/participant' q="reset=1&id=$participant_registered_by_id&cid=$registered_by_contact_id&action=view"}" title="{ts escape='htmlattribute'}view primary participant{/ts}">{$registered_by_display_name|escape}</a></td>
       </tr>
   {/if}
   {if $additionalParticipants} {* Display others registered by this participant *}
@@ -46,14 +46,14 @@
             <td class="label">{ts}Also Registered by this Participant{/ts}</td>
             <td>
                 {foreach from=$additionalParticipants key=participantName item=participantURL}
-                    <a href="{$participantURL}" title="{ts}view additional participant{/ts}">{$participantName|escape}</a><br />
+                    <a href="{$participantURL}" title="{ts escape='htmlattribute'}view additional participant{/ts}">{$participantName|escape}</a><br />
                 {/foreach}
             </td>
         </tr>
   {/if}
     <tr class="crm-event-participantview-form-block-event">
       <td class="label">{ts}Event{/ts}</td><td>
-        <a href="{crmURL p='civicrm/event/manage/settings' q="action=update&reset=1&id=$event_id"}" title="{ts}Configure this event{/ts}">{$event|escape}</a>
+        <a href="{crmURL p='civicrm/event/manage/settings' q="action=update&reset=1&id=$event_id"}" title="{ts escape='htmlattribute'}Configure this event{/ts}">{$event|escape}</a>
       </td>
   </tr>
 
@@ -74,7 +74,7 @@
     <tr class="crm-event-participantview-form-block-status">
       <td class="label">{ts}Status{/ts}</td><td>{$status|escape}&nbsp;
       {if $transferName}
-        {ts}(Transferred to <a href="{crmURL p='civicrm/contact/view/participant' q="action=view&reset=1&id=$pid&cid=$transferId"}" title="{ts}View this Participant{/ts}">{$transferName|escape}</a>){/ts}
+        {ts}(Transferred to <a href="{crmURL p='civicrm/contact/view/participant' q="action=view&reset=1&id=$pid&cid=$transferId"}" title="{ts escape='htmlattribute'}View this Participant{/ts}">{$transferName|escape}</a>){/ts}
       {/if}
       </td>
   </tr>

--- a/templates/CRM/Event/Form/Registration/EventInfoBlock.tpl
+++ b/templates/CRM/Event/Form/Registration/EventInfoBlock.tpl
@@ -12,7 +12,7 @@
   <tr>
     <td colspan="2">
     {if $context EQ 'ThankYou'} {* Provide link back to event info page from Thank-you page *}
-        <a href="{crmURL p='civicrm/event/info' q="reset=1&id=`$event.id`"}"title="{ts}View complete event information.{/ts}"><strong>{$event.event_title}</strong></a>
+        <a href="{crmURL p='civicrm/event/info' q="reset=1&id=`$event.id`"}"title="{ts escape='htmlattribute'}View complete event information.{/ts}"><strong>{$event.event_title}</strong></a>
     {else}
         <strong>{$event.event_title}</strong>
     {/if}
@@ -41,7 +41,7 @@
             $config->mapProvider &&
       ((!empty($location.address.1.geo_code_1) && is_numeric($location.address.1.geo_code_1)) ||
         (!empty($location.address.1.city) AND !empty($location.address.1.state_province))))}
-              <br/><a href="{crmURL p='civicrm/contact/map/event' q="reset=1&eid=`$event.id`"}" title="{ts}Map this Address{/ts}" target="_blank">{ts}Map this Location{/ts}</a>
+              <br/><a href="{crmURL p='civicrm/contact/map/event' q="reset=1&eid=`$event.id`"}" title="{ts escape='htmlattribute'}Map this Address{/ts}" target="_blank">{ts}Map this Location{/ts}</a>
             {/if}
           </td>
       </tr>

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -36,7 +36,7 @@
       <div class="messages status no-popup crm-not-you-message" id="crm-event-register-different">
         {ts 1=$display_name}Welcome %1{/ts}. (<a
           href="{crmURL p='civicrm/event/register' q="cid=0&reset=1&id=`$event.id`"}"
-          title="{ts}Click here to register a different person for this event.{/ts}">{ts 1=$display_name}Not %1, or want to register a different person{/ts}</a>?)
+          title="{ts escape='htmlattribute'}Click here to register a different person for this event.{/ts}">{ts 1=$display_name}Not %1, or want to register a different person{/ts}</a>?)
       </div>
     {/if}
     {/crmRegion}
@@ -56,7 +56,7 @@
 
     {if !empty($form.additional_participants.html)}
       <div class="crm-public-form-item crm-section additional_participants-section" id="noOfparticipants">
-        <div class="label">{$form.additional_participants.label} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></div>
+        <div class="label">{$form.additional_participants.label} <span class="crm-marker" title="{ts escape='htmlattribute'}This field is required.{/ts}">*</span></div>
         <div class="content">
           {$form.additional_participants.html}{ts}(including yourself){/ts}
           <br/>

--- a/templates/CRM/Event/Form/Selector.tpl
+++ b/templates/CRM/Event/Form/Selector.tpl
@@ -16,7 +16,7 @@
 <thead class="sticky">
   <tr>
     {if ! $single and $context eq 'Search'}
-      <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
+      <th scope="col" title="{ts escape='htmlattribute'}Select rows{/ts}">{$form.toggleSelect.html}</th>
     {/if}
     {foreach from=$columnHeaders item=header}
         <th scope="col">
@@ -40,11 +40,11 @@
         <td>{$form.$cbName.html}</td>
       {/if}
       <td class="crm-participant-contact_type">{$row.contact_type}</td>
-      <td class="crm-participant-sort_name"><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}" title="{ts}View contact record{/ts}">{$row.sort_name|smarty:nodefaults|purify}</a></td>
+      <td class="crm-participant-sort_name"><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}" title="{ts escape='htmlattribute'}View contact record{/ts}">{$row.sort_name|smarty:nodefaults|purify}</a></td>
     {/if}
 
-    <td class="crm-participant-event_title"><a href="{crmURL p='civicrm/event/info' q="id=`$row.event_id`&reset=1"}" title="{ts}View event info page{/ts}">{$row.event_title|smarty:nodefaults|purify}</a>
-      {if !empty($contactId)}<br /><a href="{crmURL p='civicrm/event/search' q="reset=1&force=1&event=`$row.event_id`"}" title="{ts}List participants for this event (all statuses){/ts}">({ts}participants{/ts})</a>{/if}
+    <td class="crm-participant-event_title"><a href="{crmURL p='civicrm/event/info' q="id=`$row.event_id`&reset=1"}" title="{ts escape='htmlattribute'}View event info page{/ts}">{$row.event_title|smarty:nodefaults|purify}</a>
+      {if !empty($contactId)}<br /><a href="{crmURL p='civicrm/event/search' q="reset=1&force=1&event=`$row.event_id`"}" title="{ts escape='htmlattribute'}List participants for this event (all statuses){/ts}">({ts}participants{/ts})</a>{/if}
     </td>
     <td class="crm-participant-participant_fee_level">
       {assign var="participant_id" value=$row.participant_id}

--- a/templates/CRM/Event/Page/DashBoard.tpl
+++ b/templates/CRM/Event/Page/DashBoard.tpl
@@ -37,7 +37,7 @@
     <tbody>
     {foreach from=$eventSummary.events item=values key=id}
     <tr class="crm-event_{$id}">
-        <td class="crm-event-eventTitle"><a href="{crmURL p="civicrm/event/info" q="reset=1&id=`$id`"}" title="{ts}View event info page{/ts}">{$values.eventTitle|smarty:nodefaults|purify}</a>
+        <td class="crm-event-eventTitle"><a href="{crmURL p="civicrm/event/info" q="reset=1&id=`$id`"}" title="{ts escape='htmlattribute'}View event info page{/ts}">{$values.eventTitle|smarty:nodefaults|purify}</a>
             {if $values.is_repeating_event}
                 <br/>
                 {if $values.is_repeating_event eq $id}
@@ -53,25 +53,25 @@
         <td class="nowrap crm-event-startDate">{$values.startDate}&nbsp;{if $values.endDate}to{/if}&nbsp;{$values.endDate}</td>
         <td class="right crm-event-participants_url">
             {if $values.participants and $values.participants_url}
-    <a href="{$values.participants_url}" title="{ts 1=$eventSummary.countedStatusANDRoles}List %1 participants{/ts}">{ts}Counted{/ts}:&nbsp;{$values.participants}</a>
+    <a href="{$values.participants_url}" title="{ts escape='htmlattribute' 1=$eventSummary.countedStatusANDRoles}List %1 participants{/ts}">{ts}Counted{/ts}:&nbsp;{$values.participants}</a>
       {else}
     {ts}Counted{/ts}:&nbsp;{$values.participants}
       {/if}
 
       {if $values.notCountedParticipants and $values.notCountedParticipants_url}
-    <a href="{$values.notCountedParticipants_url}" title="{ts 1=$eventSummary.nonCountedStatusANDRoles}List %1 participants{/ts}">{ts}Not&nbsp;Counted{/ts}:&nbsp;{$values.notCountedParticipants}</a><hr />
+    <a href="{$values.notCountedParticipants_url}" title="{ts escape='htmlattribute' 1=$eventSummary.nonCountedStatusANDRoles}List %1 participants{/ts}">{ts}Not&nbsp;Counted{/ts}:&nbsp;{$values.notCountedParticipants}</a><hr />
       {else}
     {ts}Not&nbsp;Counted{/ts}:&nbsp;{$values.notCountedParticipants}<hr />
       {/if}
 
       {if $values.notCountedDueToStatus and $values.notCountedDueToStatus_url}
-    <a href="{$values.notCountedDueToStatus_url}" title="{ts 1=$eventSummary.nonCountedStatus}List %1 participants{/ts}">{ts}Not&nbsp;Counted&nbsp;Due&nbsp;To&nbsp;Status{/ts}:&nbsp;{$values.notCountedDueToStatus}</a><hr />
+    <a href="{$values.notCountedDueToStatus_url}" title="{ts escape='htmlattribute' 1=$eventSummary.nonCountedStatus}List %1 participants{/ts}">{ts}Not&nbsp;Counted&nbsp;Due&nbsp;To&nbsp;Status{/ts}:&nbsp;{$values.notCountedDueToStatus}</a><hr />
       {else}
     {ts}Not&nbsp;Counted&nbsp;Due&nbsp;To&nbsp;Status{/ts}:&nbsp;{$values.notCountedDueToStatus}<hr />
       {/if}
 
             {if $values.notCountedDueToRole and $values.notCountedDueToRole_url}
-    <a href="{$values.notCountedDueToRole_url}" title="{ts 1=$eventSummary.nonCountedRoles}List %1 participants{/ts}">{ts}Not&nbsp;Counted&nbsp;Due&nbsp;To&nbsp;Role{/ts}:&nbsp;{$values.notCountedDueToRole}</a><hr />
+    <a href="{$values.notCountedDueToRole_url}" title="{ts escape='htmlattribute' 1=$eventSummary.nonCountedRoles}List %1 participants{/ts}">{ts}Not&nbsp;Counted&nbsp;Due&nbsp;To&nbsp;Role{/ts}:&nbsp;{$values.notCountedDueToRole}</a><hr />
       {else}
     {ts}Not&nbsp;Counted&nbsp;Due&nbsp;To&nbsp;Role{/ts}:&nbsp;{$values.notCountedDueToRole}<hr />
       {/if}
@@ -79,7 +79,7 @@
             {foreach from=$values.statuses item=class}
                 {if $class}
                     {foreach from=$class item=status}
-                        <a href="{$status.url}" title="{ts 1=$status.label}List %1 participants{/ts}">{$status.label}: {$status.count}</a>
+                        <a href="{$status.url}" title="{ts escape='htmlattribute' 1=$status.label}List %1 participants{/ts}">{$status.label}: {$status.count}</a>
                     {/foreach}
                     <hr />
                 {/if}
@@ -89,7 +89,7 @@
       {if $actionColumn}
         <td class="crm-event-isMap">
           {if $values.isMap}
-            <a href="{$values.isMap}" title="{ts}Map event location{/ts}"><i class="crm-i fa-map-marker" aria-hidden="true"></i> {ts}Map{/ts}</a>
+            <a href="{$values.isMap}" title="{ts escape='htmlattribute'}Map event location{/ts}"><i class="crm-i fa-map-marker" aria-hidden="true"></i> {ts}Map{/ts}</a>
             &nbsp;|&nbsp;
           {/if}
           {if $values.configure}

--- a/templates/CRM/Event/Page/EventInfo.tpl
+++ b/templates/CRM/Event/Page/EventInfo.tpl
@@ -24,7 +24,7 @@
   <li>
     <div id="crm-event-links-wrapper">
       <span id="crm-event-configure-link" class="crm-hover-button">
-        <span title="{ts}Configure this event.{/ts}" class="crm-i fa-wrench" aria-hidden="true"></span>
+        <span title="{ts escape='htmlattribute'}Configure this event.{/ts}" class="crm-i fa-wrench" aria-hidden="true"></span>
       </span>
       <div class="ac_results" id="crm-event-links-list" style="margin-left: -25px;">
         <div class="crm-event-links-list-inner">
@@ -49,7 +49,7 @@
   <li>
     <div id="crm-participant-wrapper">
       <span id="crm-participant-links" class="crm-hover-button">
-        <span title="{ts}Participant listing links.{/ts}" class="crm-i fa-search" aria-hidden="true"></span>
+        <span title="{ts escape='htmlattribute'}Participant listing links.{/ts}" class="crm-i fa-search" aria-hidden="true"></span>
       </span>
       <div class="ac_results" id="crm-participant-list" style="margin-left: -25px;">
         <div class="crm-participant-list-inner">
@@ -142,7 +142,7 @@
               <div class="content">
                     {assign var=showDirectly value="1"}
                     {include file="CRM/Contact/Form/Task/Map/`$config->mapProvider`.tpl" fields=$showDirectly profileGID=false}
-                    <a href="{$mapURL}" title="{ts}Show large map{/ts}">{ts}Show large map{/ts}</a>
+                    <a href="{$mapURL}" title="{ts escape='htmlattribute'}Show large map{/ts}">{ts}Show large map{/ts}</a>
               </div>
               <div class="clear"></div>
           </div>

--- a/templates/CRM/Event/Page/List.tpl
+++ b/templates/CRM/Event/Page/List.tpl
@@ -27,8 +27,8 @@
     </thead>
     {foreach from=$events key=uid item=event}
       <tr class="{cycle values="odd-row,even-row"}{if !empty($row.class)} {$row.class}{/if}">
-        <td><a href="{crmURL p='civicrm/event/info' q="reset=1&id=`$event.event_id`"}" title="{ts}read more{/ts}"><strong>{$event.title}</strong></a></td>
-        <td>{if $event.summary}{$event.summary|purify} (<a href="{crmURL p='civicrm/event/info' q="reset=1&id=`$event.event_id`"}" title="{ts}details...{/ts}">{ts}read more{/ts}...</a>){else}&nbsp;{/if}</td>
+        <td><a href="{crmURL p='civicrm/event/info' q="reset=1&id=`$event.event_id`"}" title="{ts escape='htmlattribute'}read more{/ts}"><strong>{$event.title}</strong></a></td>
+        <td>{if $event.summary}{$event.summary|purify} (<a href="{crmURL p='civicrm/event/info' q="reset=1&id=`$event.event_id`"}" title="{ts escape='htmlattribute'}details...{/ts}">{ts}read more{/ts}...</a>){else}&nbsp;{/if}</td>
         <td class="nowrap" data-order="{$event.start_date|crmDate:'%Y-%m-%d'}">
           {if $event.start_date}{$event.start_date|crmDate}{if $event.end_date}<br /><em>{ts}through{/ts}</em><br />{strip}
             {* Only show end time if end date = start date *}

--- a/templates/CRM/Event/Page/ManageEvent.tpl
+++ b/templates/CRM/Event/Page/ManageEvent.tpl
@@ -54,7 +54,7 @@
           <tr id="event-{$row.id}" class="crm-entity {if NOT $row.is_active} disabled{/if}">
           <td class="crm-event_{$row.id}">
             <a href="{crmURL p='civicrm/event/info' q="id=`$row.id`&reset=1"}"
-               title="{ts}View event info page{/ts}" class="bold">{$row.title|smarty:nodefaults|purify}</a>&nbsp;&nbsp;({ts}ID:{/ts} {$row.id})<br/>
+               title="{ts escape='htmlattribute'}View event info page{/ts}" class="bold">{$row.title|smarty:nodefaults|purify}</a>&nbsp;&nbsp;({ts}ID:{/ts} {$row.id})<br/>
                <span><b>{$row.repeat}</b></span>
           </td>
           <td class="crm-event-city">{$row.city}</td>
@@ -93,14 +93,14 @@
                 <ul class="panel" id="panel_participants_{$row.id}">
                   {if $findParticipants.statusCounted}
                     <li>
-                      <a title="{ts}Counted Participants{/ts}" class="action-item crm-hover-button" href="{crmURL p='civicrm/event/search'
+                      <a title="{ts escape='htmlattribute'}Counted Participants{/ts}" class="action-item crm-hover-button" href="{crmURL p='civicrm/event/search'
                       q="reset=1&force=1&status=true&event=`$row.id`"}">{$findParticipants.statusCounted}
                       </a>
                     </li>
                   {/if}
                   {if $findParticipants.statusNotCounted}
                     <li>
-                      <a title="{ts}Participants Not Counted{/ts}" class="action-item crm-hover-button"
+                      <a title="{ts escape='htmlattribute'}Participants Not Counted{/ts}" class="action-item crm-hover-button"
                            href="{crmURL p='civicrm/event/search'
                            q="reset=1&force=1&status=false&event=`$row.id`"}">{$findParticipants.statusNotCounted}
                       </a>
@@ -108,7 +108,7 @@
                   {/if}
                   {if $row.participant_listing_id}
                     <li>
-                      <a title="{ts}Public Participant Listing{/ts}" class="action-item crm-hover-button"
+                      <a title="{ts escape='htmlattribute'}Public Participant Listing{/ts}" class="action-item crm-hover-button"
                          href="{crmURL p='civicrm/event/participant' q="reset=1&id=`$row.id`"
                          fe='true'}">{ts}Public Participant Listing{/ts}
                       </a>

--- a/templates/CRM/Form/attachment.tpl
+++ b/templates/CRM/Form/attachment.tpl
@@ -45,7 +45,7 @@
         {/if}
         <tr>
           <td class="label">{$form.attachFile_1.label}</td>
-          <td>{$form.attachFile_1.html}&nbsp;<label for="attachDesc_1" class="sr-only">{ts}File 1 description{/ts}</label>{$form.attachDesc_1.html}<a href="#" class="crm-hover-button crm-clear-attachment" style="visibility: hidden;" title="{ts}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
+          <td>{$form.attachFile_1.html}&nbsp;<label for="attachDesc_1" class="sr-only">{ts}File 1 description{/ts}</label>{$form.attachDesc_1.html}<a href="#" class="crm-hover-button crm-clear-attachment" style="visibility: hidden;" title="{ts escape='htmlattribute'}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
             <div class="description">{if $maxAttachments GT 1} {ts 1=$maxAttachments}You can have a maximum of %1 attachment(s).{/ts}{/if} {ts 1=$config->maxFileSize}Each file must be less than %1M in size. You can also add a short description.{/ts}</div>
           </td>
         </tr>
@@ -66,7 +66,7 @@
             <tr class="attachment-fieldset solid-border-top"><td colspan="2"></td></tr>
             <tr>
                 <td class="label">{ts}Attach File{/ts}</td>
-                <td><label class="sr-only" for="{$attachName}">{ts 1=$index}Attach File %1{/ts}</label>{$form.$attachName.html}&nbsp;<label for="{$attachDesc}" class="sr-only">{ts 1=$index}File %1 description{/ts}</label>{$form.$attachDesc.html}<a href="#" class="crm-hover-button crm-clear-attachment" style="visibility: hidden;" title="{ts}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a></td>
+                <td><label class="sr-only" for="{$attachName}">{ts 1=$index}Attach File %1{/ts}</label>{$form.$attachName.html}&nbsp;<label for="{$attachDesc}" class="sr-only">{ts 1=$index}File %1 description{/ts}</label>{$form.$attachDesc.html}<a href="#" class="crm-hover-button crm-clear-attachment" style="visibility: hidden;" title="{ts escape='htmlattribute'}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a></td>
             </tr>
             {if $form.$tagElement}
             <tr>
@@ -90,7 +90,7 @@
                   <strong><a class="crm-attachment" href="{$attVal.url}">{$attVal.cleanName}</a></strong>
                   {if $attVal.description}&nbsp;-&nbsp;{$attVal.description}{/if}
                   {if $attVal.deleteURLArgs}
-                   <a href="#" class="crm-hover-button delete-attachment" data-filename="{$attVal.cleanName}" data-args="{$attVal.deleteURLArgs}" title="{ts}Delete File{/ts}"><span class="icon delete-icon"></span></a>
+                   <a href="#" class="crm-hover-button delete-attachment" data-filename="{$attVal.cleanName}" data-args="{$attVal.deleteURLArgs}" title="{ts escape='htmlattribute'}Delete File{/ts}"><span class="icon delete-icon"></span></a>
                   {/if}
                   {if $attVal.tag}
                     <br/>

--- a/templates/CRM/Form/label.tpl
+++ b/templates/CRM/Form/label.tpl
@@ -11,13 +11,13 @@
   <span class="crm-error crm-error-label">
     {$label}
     {if $required}
-       <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span>
+       <span class="crm-marker" title="{ts escape='htmlattribute'}This field is required.{/ts}">*</span>
   {/if}
   </span>
 {else}
   {$label}
   {if $required}
-   <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span>
+   <span class="crm-marker" title="{ts escape='htmlattribute'}This field is required.{/ts}">*</span>
 {/if}
 {/if}
 

--- a/templates/CRM/Group/Form/Delete.tpl
+++ b/templates/CRM/Group/Form/Delete.tpl
@@ -12,7 +12,7 @@
 
 <h3>{ts}Delete Group{/ts}</h3>
     <div class="messages status no-popup">
-        <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
+        <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>
     {ts 1=$title}Are you sure you want to delete the group %1?{/ts}<br /><br />
     {if $count !== NULL}
         {ts count=$count plural='This group currently has %count members in it.'}This group currently has one member in it.{/ts}

--- a/templates/CRM/Group/Form/Search.tpl
+++ b/templates/CRM/Group/Form/Search.tpl
@@ -150,7 +150,7 @@
           if (parentsOnly) {
             $('tbody tr.crm-group-parent', settings.nTable).each(function () {
               $(this).find('td:first')
-                .prepend('{/literal}<span class="collapsed show-children" title="{ts}show child groups{/ts}"/></span>{literal}')
+                .prepend('{/literal}<span class="collapsed show-children" title="{ts escape='htmlattribute'}show child groups{/ts}"/></span>{literal}')
                 .find('div').css({'display': 'inline'});
             });
           }
@@ -232,7 +232,7 @@
                 }
                 appendHTML += '<tr id="row_'+val.group_id+'_'+parent_id+'" data-entity="group" data-id="'+val.group_id+'" class="' + val.row_classes.join(' ') + '">';
                 if ( val.is_parent ) {
-                  appendHTML += '<td class="crm-group-name crmf-title ' + levelClass + '">' + '{/literal}<span class="collapsed show-children" title="{ts}show child groups{/ts}"/></span><div class="crmf-title {$editableClass}" style="display:inline">{literal}' + val.title + '</div>' + smartGroupText + '</td>';
+                  appendHTML += '<td class="crm-group-name crmf-title ' + levelClass + '">' + '{/literal}<span class="collapsed show-children" title="{ts escape='htmlattribute'}show child groups{/ts}"/></span><div class="crmf-title {$editableClass}" style="display:inline">{literal}' + val.title + '</div>' + smartGroupText + '</td>';
                 }
                 else {
                   appendHTML += '<td class="crm-group-name' + levelClass + '"><div class="crmf-title {/literal}{$editableClass}{literal}"><span class="crm-no-children"></span>' + val.title + '</div>' + smartGroupText + '</td>';

--- a/templates/CRM/Mailing/Form/Count.tpl
+++ b/templates/CRM/Mailing/Form/Count.tpl
@@ -29,7 +29,7 @@
         </tbody>
       </table>
     </div>
-     <a href="#" id="button" title="{ts}Contacts selected in the Find Contacts page{/ts}"> {ts}View Selected Contacts{/ts}</a>
+     <a href="#" id="button" title="{ts escape='htmlattribute'}Contacts selected in the Find Contacts page{/ts}"> {ts}View Selected Contacts{/ts}</a>
   </div>
 {literal}
 <script type="text/javascript">

--- a/templates/CRM/Mailing/Form/Selector.tpl
+++ b/templates/CRM/Mailing/Form/Selector.tpl
@@ -16,7 +16,7 @@
   <thead class="sticky">
   <tr>
     {if $context eq 'Search' }
-        <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
+        <th scope="col" title="{ts escape='htmlattribute'}Select rows{/ts}">{$form.toggleSelect.html}</th>
     {/if}
     {foreach from=$columnHeaders item=header}
         <th scope="col">

--- a/templates/CRM/Mailing/Page/Browse.tpl
+++ b/templates/CRM/Mailing/Page/Browse.tpl
@@ -66,7 +66,7 @@
         <td class="crm-mailing-start">{$row.start}</td>
         <td class="crm-mailing-end">{$row.end}</td>
        {if call_user_func(array('CRM_Campaign_BAO_Campaign','isComponentEnabled'))}
-          <td class="crm-mailing-campaign crm-editable crmf-campaign_id" data-type="select" data-empty-option="{ts}- none -{/ts}">{$row.campaign}</td>
+          <td class="crm-mailing-campaign crm-editable crmf-campaign_id" data-type="select" data-empty-option="{ts escape='htmlattribute'}- none -{/ts}">{$row.campaign}</td>
       {/if}
         <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
       </tr>

--- a/templates/CRM/Member/Form/MembershipView.tpl
+++ b/templates/CRM/Member/Form/MembershipView.tpl
@@ -36,9 +36,9 @@
     </div>
     {/if}
     <table class="crm-info-panel">
-      <tr><td class="label">{ts}Member{/ts}</td><td class="bold"><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$contact_id&context=$context"}" title="{ts}View contact summary{/ts}">{$displayName}</td></tr>
+      <tr><td class="label">{ts}Member{/ts}</td><td class="bold"><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$contact_id&context=$context"}" title="{ts escape='htmlattribute'}View contact summary{/ts}">{$displayName}</td></tr>
         {if $owner_display_name}
-            <tr><td class="label">{ts}By Relationship{/ts}</td><td>{$relationship}&nbsp;&nbsp;<a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$owner_contact_id&context=$context"}" title="{ts}View primary member contact summary{/ts}">{$owner_display_name}</a>&nbsp;</td></tr>
+            <tr><td class="label">{ts}By Relationship{/ts}</td><td>{$relationship}&nbsp;&nbsp;<a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$owner_contact_id&context=$context"}" title="{ts escape='htmlattribute'}View primary member contact summary{/ts}">{$owner_display_name}</a>&nbsp;</td></tr>
         {/if}
         <tr><td class="label">{ts}Membership Type{/ts}</td><td>{$membership_type}</td></tr>
         {if $has_related}

--- a/templates/CRM/Member/Form/Selector.tpl
+++ b/templates/CRM/Member/Form/Selector.tpl
@@ -15,7 +15,7 @@
 <table class="selector row-highlight">
 <thead class="sticky">
 {if ! $single and $context eq 'Search'}
-  <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
+  <th scope="col" title="{ts escape='htmlattribute'}Select rows{/ts}">{$form.toggleSelect.html}</th>
 {/if}
   {foreach from=$columnHeaders item=header}
     <th scope="col">
@@ -39,7 +39,7 @@
        {/if}
        <td>{$row.contact_type}</td>
        <td>
-            <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}" title="{ts}View contact record{/ts}">{$row.sort_name}</a>
+            <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}" title="{ts escape='htmlattribute'}View contact record{/ts}">{$row.sort_name}</a>
         </td>
     {/if}
     <td class="crm-membership-type crm-membership-type_{$row.membership_type}">
@@ -53,15 +53,15 @@
     <td class="crm-membership-status crm-membership-status_{$row.membership_status}">{$row.membership_status}</td>
     <td class="crm-membership-auto_renew">
       {if $row.auto_renew eq 1}
-        <i class="crm-i fa-check" aria-hidden="true" title="{ts}Auto-renew active{/ts}"></i>
+        <i class="crm-i fa-check" aria-hidden="true" title="{ts escape='htmlattribute'}Auto-renew active{/ts}"></i>
       {elseif $row.auto_renew eq 2}
-        <i class="crm-i fa-ban" aria-hidden="true" title="{ts}Auto-renew error{/ts}"></i>
+        <i class="crm-i fa-ban" aria-hidden="true" title="{ts escape='htmlattribute'}Auto-renew error{/ts}"></i>
       {/if}
     </td>
     <td>
         {$row.action|replace:'xx':$row.membership_id}
         {if $row.owner_membership_id}
-            <a href="{crmURL p='civicrm/membership/view' q="reset=1&id=`$row.owner_membership_id`&action=view&context=search"}" title="{ts}View Primary member record{/ts}" class="action-item">{ts}View Primary{/ts}</a>
+            <a href="{crmURL p='civicrm/membership/view' q="reset=1&id=`$row.owner_membership_id`&action=view&context=search"}" title="{ts escape='htmlattribute'}View Primary member record{/ts}" class="action-item">{ts}View Primary{/ts}</a>
         {/if}
     </td>
    </tr>

--- a/templates/CRM/Member/Form/Task/Print.tpl
+++ b/templates/CRM/Member/Form/Task/Print.tpl
@@ -44,7 +44,7 @@
 
 {else}
    <div class="messages status no-popup">
-    <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}">
+    <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}">
         {ts}There are no records selected for Print.{/ts}
    </div>
 {/if}

--- a/templates/CRM/Member/Page/DashBoard.tpl
+++ b/templates/CRM/Member/Page/DashBoard.tpl
@@ -46,21 +46,21 @@
             <td><strong>{$row.month.total.name}</strong></td>
           {if $preMonth}
             <td class="label crm-grid-cell">
-              {if $row.premonth.new.url}<a href="{$row.premonth.new.url}" title="{ts}View details{/ts}">{$row.premonth.new.count}</a>
+              {if $row.premonth.new.url}<a href="{$row.premonth.new.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$row.premonth.new.count}</a>
               {else}{$row.premonth.new.count}{/if}
             </td>
             <td class="label crm-grid-cell">
-              {if $row.premonth.renew.url}<a href="{$row.premonth.renew.url}" title="{ts}View details{/ts}">{$row.premonth.renew.count}</a>
+              {if $row.premonth.renew.url}<a href="{$row.premonth.renew.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$row.premonth.renew.count}</a>
               {else}{$row.premonth.renew.count}{/if}
             </td>
             <td class="label crm-grid-cell">
               {if $row.premonth.total.url}
-                <a href="{$row.premonth.total.url}" title="{ts}View details{/ts}">{$row.premonth.total.count}</a>
+                <a href="{$row.premonth.total.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$row.premonth.total.count}</a>
               {else}
                 {$row.premonth.total.count}
               {/if}&nbsp;[
               {if $row.premonth_owner.premonth_owner.url}
-                <a href="{$row.premonth_owner.premonth_owner.url}" title="{ts}View details{/ts}">{$row.premonth_owner.premonth_owner.count}</a>
+                <a href="{$row.premonth_owner.premonth_owner.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$row.premonth_owner.premonth_owner.count}</a>
               {else}
                 {$row.premonth_owner.premonth_owner.count}
               {/if}]
@@ -68,42 +68,42 @@
           {/if}
 
             <td class="label crm-grid-cell">
-              {if $row.month.new.url}<a href="{$row.month.new.url}" title="{ts}View details{/ts}">{$row.month.new.count}</a>
+              {if $row.month.new.url}<a href="{$row.month.new.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$row.month.new.count}</a>
               {else}{$row.month.new.count}{/if}
             </td>
             <td class="label crm-grid-cell">
-              {if $row.month.renew.url}<a href="{$row.month.renew.url}" title="{ts}View details{/ts}">{$row.month.renew.count}</a>
+              {if $row.month.renew.url}<a href="{$row.month.renew.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$row.month.renew.count}</a>
               {else}{$row.month.renew.count}{/if}
             </td>
             <td class="label crm-grid-cell">
               {if $row.month.total.url}
-                <a href="{$row.month.total.url}" title="{ts}View details{/ts}">{$row.month.total.count}</a>
+                <a href="{$row.month.total.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$row.month.total.count}</a>
               {else}
                 {$row.month.total.count}
               {/if}&nbsp;[
               {if $row.month_owner.month_owner.url}
-                <a href="{$row.month_owner.month_owner.url}" title="{ts}View details{/ts}">{$row.month_owner.month_owner.count}</a>
+                <a href="{$row.month_owner.month_owner.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$row.month_owner.month_owner.count}</a>
               {else}
                 {$row.month_owner.month_owner.count}
               {/if}]
             </td>
 
             <td class="label crm-grid-cell">
-              {if $row.year.new.url}<a href="{$row.year.new.url}" title="{ts}View details{/ts}">{$row.year.new.count}</a>
+              {if $row.year.new.url}<a href="{$row.year.new.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$row.year.new.count}</a>
               {else}{$row.year.new.count}{/if}
             </td>
             <td class="label crm-grid-cell">
-              {if $row.year.renew.url}<a href="{$row.year.renew.url}" title="{ts}View details{/ts}">{$row.year.renew.count}</a>
+              {if $row.year.renew.url}<a href="{$row.year.renew.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$row.year.renew.count}</a>
               {else}{$row.year.renew.count}{/if}
             </td>
             <td class="label crm-grid-cell">
               {if $row.year.total.url}
-                <a href="{$row.year.total.url}" title="{ts}View details{/ts}">{$row.year.total.count}</a>
+                <a href="{$row.year.total.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$row.year.total.count}</a>
               {else}
                 {$row.year.total.count}
               {/if}&nbsp;[
               {if $row.year_owner.year_owner.url}
-                <a href="{$row.year_owner.year_owner.url}" title="{ts}View details{/ts}">{$row.year_owner.year_owner.count}</a>
+                <a href="{$row.year_owner.year_owner.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$row.year_owner.year_owner.count}</a>
               {else}
                 {$row.year_owner.year_owner.count}
               {/if}]
@@ -112,23 +112,23 @@
             <td class="label crm-grid-cell">
               {if $isCurrent}
                 {if $row.current.total.url}
-                  <a href="{$row.current.total.url}" title="{ts}View details{/ts}">{$row.current.total.count}</a>
+                  <a href="{$row.current.total.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$row.current.total.count}</a>
                 {else}
                   {$row.current.total.count}
                 {/if}&nbsp;[
                 {if $row.current_owner.current_owner.url}
-                  <a href="{$row.current_owner.current_owner.url}" title="{ts}View details{/ts}">{$row.current_owner.current_owner.count}</a>
+                  <a href="{$row.current_owner.current_owner.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$row.current_owner.current_owner.count}</a>
                 {else}
                   {$row.current_owner.current_owner.count}
                 {/if} ]
               {else}
                 {if $row.total.total.url}
-                  <a href="{$row.total.total.url}" title="{ts}View details{/ts}">{$row.total.total.count}</a>
+                  <a href="{$row.total.total.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$row.total.total.count}</a>
                 {else}
                   {$row.total.total.count}
                 {/if}&nbsp;[
                 {if $row.total_owner.total_owner.url}
-                  <a href="{$row.total_owner.total_owner.url}" title="{ts}View details{/ts}">{$row.total_owner.total_owner.count}</a>
+                  <a href="{$row.total_owner.total_owner.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$row.total_owner.total_owner.count}</a>
                 {else}
                   {$row.total_owner.total_owner.count}
                 {/if} ]
@@ -141,21 +141,21 @@
         <td><strong>{ts}Totals (all types){/ts}</strong></td>
         {if $preMonth}
             <td class="label crm-grid-cell">
-              {if $totalCount.premonth.new.url}<a href="{$totalCount.premonth.new.url}" title="{ts}View details{/ts}">{$totalCount.premonth.new.count}</a>
+              {if $totalCount.premonth.new.url}<a href="{$totalCount.premonth.new.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$totalCount.premonth.new.count}</a>
               {else}{$totalCount.premonth.new.count}{/if}
             </td>
             <td class="label crm-grid-cell">
-              {if $totalCount.premonth.renew.url}<a href="{$totalCount.premonth.renew.url}" title="{ts}View details{/ts}">{$totalCount.premonth.renew.count}</a>
+              {if $totalCount.premonth.renew.url}<a href="{$totalCount.premonth.renew.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$totalCount.premonth.renew.count}</a>
               {else}{$totalCount.premonth.renew.count}{/if}
             </td>
             <td class="label crm-grid-cell">
               {if $totalCount.premonth.total.url}
-                <a href="{$totalCount.premonth.total.url}" title="{ts}View details{/ts}">{$totalCount.premonth.total.count}</a>
+                <a href="{$totalCount.premonth.total.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$totalCount.premonth.total.count}</a>
               {else}
                 {$totalCount.premonth.total.count}
               {/if}&nbsp;[
               {if $totalCount.premonth_owner.premonth_owner.url}
-                <a href="{$totalCount.premonth_owner.premonth_owner.url}" title="{ts}View details{/ts}">{$totalCount.premonth_owner.premonth_owner.count}</a>
+                <a href="{$totalCount.premonth_owner.premonth_owner.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$totalCount.premonth_owner.premonth_owner.count}</a>
               {else}
                 {$totalCount.premonth_owner.premonth_owner.count}
               {/if}]
@@ -163,42 +163,42 @@
         {/if}
 
             <td class="label crm-grid-cell">
-              {if $totalCount.month.new.url}<a href="{$totalCount.month.new.url}" title="{ts}View details{/ts}">{$totalCount.month.new.count}</a>
+              {if $totalCount.month.new.url}<a href="{$totalCount.month.new.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$totalCount.month.new.count}</a>
               {else}{$totalCount.month.new.count}{/if}
             </td>
             <td class="label crm-grid-cell">
-              {if $totalCount.month.renew.url}<a href="{$totalCount.month.renew.url}" title="{ts}View details{/ts}">{$totalCount.month.renew.count}</a>
+              {if $totalCount.month.renew.url}<a href="{$totalCount.month.renew.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$totalCount.month.renew.count}</a>
               {else}{$totalCount.month.renew.count}{/if}
             </td>
             <td class="label crm-grid-cell">
               {if $totalCount.month.total.url}
-                <a href="{$totalCount.month.total.url}" title="{ts}View details{/ts}">{$totalCount.month.total.count}</a>
+                <a href="{$totalCount.month.total.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$totalCount.month.total.count}</a>
               {else}
                 {$totalCount.month.total.count}
               {/if}&nbsp;[
               {if $totalCount.month_owner.month_owner.url}
-                <a href="{$totalCount.month_owner.month_owner.url}" title="{ts}View details{/ts}">{$totalCount.month_owner.month_owner.count}</a>
+                <a href="{$totalCount.month_owner.month_owner.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$totalCount.month_owner.month_owner.count}</a>
               {else}
                 {$totalCount.month_owner.month_owner.count}
               {/if}]
             </td>
 
             <td class="label crm-grid-cell">
-              {if $totalCount.year.new.url}<a href="{$totalCount.year.new.url}" title="{ts}View details{/ts}">{$totalCount.year.new.count}</a>
+              {if $totalCount.year.new.url}<a href="{$totalCount.year.new.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$totalCount.year.new.count}</a>
               {else}{$totalCount.year.new.count}{/if}
             </td>
             <td class="label crm-grid-cell">
-              {if $totalCount.year.renew.url}<a href="{$totalCount.year.renew.url}" title="{ts}View details{/ts}">{$totalCount.year.renew.count}</a>
+              {if $totalCount.year.renew.url}<a href="{$totalCount.year.renew.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$totalCount.year.renew.count}</a>
               {else}{$totalCount.year.renew.count}{/if}
             </td>
             <td class="label crm-grid-cell">
               {if $totalCount.year.total.url}
-                <a href="{$totalCount.year.total.url}" title="{ts}View details{/ts}">{$totalCount.year.total.count}</a>
+                <a href="{$totalCount.year.total.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$totalCount.year.total.count}</a>
               {else}
                 {$totalCount.year.total.count}
               {/if}&nbsp;[
               {if $totalCount.year_owner.year_owner.url}
-                <a href="{$totalCount.year_owner.year_owner.url}" title="{ts}View details{/ts}">{$totalCount.year_owner.year_owner.count}</a>
+                <a href="{$totalCount.year_owner.year_owner.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$totalCount.year_owner.year_owner.count}</a>
               {else}
                 {$totalCount.year_owner.year_owner.count}
               {/if}]
@@ -207,23 +207,23 @@
             <td class="label crm-grid-cell">
               {if $isCurrent}
                 {if $row.total.total.url}
-                  <a href="{$row.total.total.url}" title="{ts}View details{/ts}">{$totalCount.current.total.count}</a>
+                  <a href="{$row.total.total.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$totalCount.current.total.count}</a>
                 {else}
                   {$totalCount.current.total.count}
                 {/if}&nbsp;[
                 {if $row.total_owner.total_owner.url}
-                  <a href="{$row.total_owner.total_owner.url}" title="{ts}View details{/ts}">{$totalCount.current_owner.current_owner.count}</a>
+                  <a href="{$row.total_owner.total_owner.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$totalCount.current_owner.current_owner.count}</a>
                 {else}
                   {$totalCount.current_owner.current_owner.count}
                 {/if} ]
               {else}
                 {if $totalCount.total.url}
-                  <a href="{$totalCount.total.url}" title="{ts}View details{/ts}">{$totalCount.total.total.count}</a>
+                  <a href="{$totalCount.total.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$totalCount.total.total.count}</a>
                 {else}
                   {$totalCount.total.total.count}
                 {/if}&nbsp;[
                 {if $totalCount.total_owner.total_owner.url}
-                  <a href="{$totalCount.total_owner.total_owner.url}" title="{ts}View details{/ts}">{$totalCount.total_owner.total_owner.count}</a>
+                  <a href="{$totalCount.total_owner.total_owner.url}" title="{ts escape='htmlattribute'}View details{/ts}">{$totalCount.total_owner.total_owner.count}</a>
                 {else}
                   {$totalCount.total_owner.total_owner.count}
                 {/if} ]

--- a/templates/CRM/Member/Page/MembershipStatus.tpl
+++ b/templates/CRM/Member/Page/MembershipStatus.tpl
@@ -40,9 +40,9 @@
         {foreach from=$rows item=row}
         <tr id="membership_status-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"} {if !empty($row.class)}{$row.class}{/if} {if NOT $row.is_active} disabled{/if} crmf">
           <td class="crmf-label crm-editable" >{$row.label}</td>
-          <td class="nowrap crmf-start_event crm-editable" data-type="select" data-empty-option="{ts}- none -{/ts}">{if !empty($row.start_event)}{$row.start_event}{/if}</td>
+          <td class="nowrap crmf-start_event crm-editable" data-type="select" data-empty-option="{ts escape='htmlattribute'}- none -{/ts}">{if !empty($row.start_event)}{$row.start_event}{/if}</td>
           <td class="nowrap crmf-start_event_adjust_unit_interval">{if !empty($row.start_event_adjust_unit_interval)}{$row.start_event_adjust_unit_interval}{/if}</td>
-          <td class="nowrap crmf-end_event crm-editable" data-type="select" data-empty-option="{ts}- none -{/ts}">{if !empty($row.end_event)}{$row.end_event}{/if}</td>
+          <td class="nowrap crmf-end_event crm-editable" data-type="select" data-empty-option="{ts escape='htmlattribute'}- none -{/ts}">{if !empty($row.end_event)}{$row.end_event}{/if}</td>
           <td class="nowrap crmf-end_event_adjust_interval">{if !empty($row.end_event_adjust_interval)}{$row.end_event_adjust_interval}{/if}</td>
           <td class="crmf-is_current_member crm-editable" data-type="boolean">{if $row.is_current_member eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td class="crmf-is_admin crm-editable" data-type="boolean">{if $row.is_admin eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
@@ -66,7 +66,7 @@
   {else}
     {if $action ne 1}
       <div class="messages status no-popup">
-         <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>{ts 1=$crmURL}There are no custom membership status entered. You can <a href='%1'>add one</a>.{/ts}
+         <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>{ts 1=$crmURL}There are no custom membership status entered. You can <a href='%1'>add one</a>.{/ts}
       </div>
     {/if}
   {/if}

--- a/templates/CRM/Member/Page/Tab.tpl
+++ b/templates/CRM/Member/Page/Tab.tpl
@@ -78,7 +78,7 @@
     <td>
                     {$activeMember.action|replace:'xx':$activeMember.id}
                     {if $activeMember.owner_membership_id}
-                      <a href="{crmURL p='civicrm/membership/view' q="reset=1&id=`$activeMember.owner_membership_id`&action=view&context=membership&selectedChild=member"}" title="{ts}View Primary member record{/ts}" class="crm-hover-button action-item">{ts}View Primary{/ts}</a>
+                      <a href="{crmURL p='civicrm/membership/view' q="reset=1&id=`$activeMember.owner_membership_id`&action=view&context=membership&selectedChild=member"}" title="{ts escape='htmlattribute'}View Primary member record{/ts}" class="crm-hover-button action-item">{ts}View Primary{/ts}</a>
                     {/if}
                 </td>
             </tr>
@@ -126,7 +126,7 @@
                 </td>
     <td>{$inActiveMember.action|replace:'xx':$inActiveMember.id}
     {if $inActiveMember.owner_membership_id}
-      <a href="{crmURL p='civicrm/membership/view' q="reset=1&id=`$inActiveMember.owner_membership_id`&action=view&context=membership&selectedChild=member"}" title="{ts}View Primary member record{/ts}" class="crm-hover-button action-item">{ts}View Primary{/ts}
+      <a href="{crmURL p='civicrm/membership/view' q="reset=1&id=`$inActiveMember.owner_membership_id`&action=view&context=membership&selectedChild=member"}" title="{ts escape='htmlattribute'}View Primary member record{/ts}" class="crm-hover-button action-item">{ts}View Primary{/ts}
       </a>
     {/if}
     </td>

--- a/templates/CRM/PCP/Page/PCP.tpl
+++ b/templates/CRM/PCP/Page/PCP.tpl
@@ -37,9 +37,9 @@
   <tbody>
   {foreach from=$rows item=row}
   <tr id="row_{$row.id}" class="{$row.class}">
-    <td><a href="{crmURL p='civicrm/pcp/info' q="reset=1&id=`$row.id`" fe='true'}" title="{ts}View Personal Campaign Page{/ts}" target="_blank">{$row.title}</a></td>
-    <td><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.supporter_id`"}" title="{ts}View contact record{/ts}">{$row.supporter}</a></td>
-    <td><a href="{$row.page_url}" title="{ts}View page{/ts}" target="_blank">{$row.page_title}</td>
+    <td><a href="{crmURL p='civicrm/pcp/info' q="reset=1&id=`$row.id`" fe='true'}" title="{ts escape='htmlattribute'}View Personal Campaign Page{/ts}" target="_blank">{$row.title}</a></td>
+    <td><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.supporter_id`"}" title="{ts escape='htmlattribute'}View contact record{/ts}">{$row.supporter}</a></td>
+    <td><a href="{$row.page_url}" title="{ts escape='htmlattribute'}View page{/ts}" target="_blank">{$row.page_title}</td>
     <td>{$row.start_date|crmDate}</td>
     <td>{if $row.end_date}{$row.end_date|crmDate}{else}({ts}ongoing{/ts}){/if}</td>
     <td>{$row.status_id}</td>

--- a/templates/CRM/PCP/Page/PCPInfo.tpl
+++ b/templates/CRM/PCP/Page/PCPInfo.tpl
@@ -77,7 +77,7 @@
               </marquee>
           </div>
           <div class="description">
-              [<a href="#" onclick="roll_start_stop(); return false;" id="roll" title="{ts}Stop scrolling{/ts}">{ts}Stop{/ts}</a>]
+              [<a href="#" onclick="roll_start_stop(); return false;" id="roll" title="{ts escape='htmlattribute'}Stop scrolling{/ts}">{ts}Stop{/ts}</a>]
           </div>
         </div>
      {/if}

--- a/templates/CRM/Pledge/Form/Selector.tpl
+++ b/templates/CRM/Pledge/Form/Selector.tpl
@@ -16,7 +16,7 @@
 <table class="selector row-highlight">
     <thead class="sticky">
         {if ! $single and $context eq 'Search'}
-            <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
+            <th scope="col" title="{ts escape='htmlattribute'}Select rows{/ts}">{$form.toggleSelect.html}</th>
         {/if}
             <th></th>
         {foreach from=$columnHeaders item=header}
@@ -39,7 +39,7 @@
                 <td>{$form.$cbName.html}</td>
             {/if}
             <td>
-                <a class="crm-expand-row" title="{ts}view payments{/ts}" href="{crmURL p='civicrm/pledge/payment' q="action=browse&context=`$context`&pledgeId=`$row.pledge_id`&cid=`$row.contact_id`"}"></a>
+                <a class="crm-expand-row" title="{ts escape='htmlattribute'}view payments{/ts}" href="{crmURL p='civicrm/pledge/payment' q="action=browse&context=`$context`&pledgeId=`$row.pledge_id`&cid=`$row.contact_id`"}"></a>
             </td>
             {if ! $single}
                 <td>{$row.contact_type}</td>

--- a/templates/CRM/Pledge/Page/UserDashboard.tpl
+++ b/templates/CRM/Pledge/Page/UserDashboard.tpl
@@ -35,7 +35,7 @@
         {if $row.pledge_contribution_page_id and ($row.pledge_status_name neq 'Completed') and ($row.contact_id eq $loggedUserID)}
           <a href="{crmURL p='civicrm/contribute/transact' q="reset=1&id=`$row.pledge_contribution_page_id`&pledgeId=`$row.pledge_id`"}">{ts}Make Payment{/ts}</a><br/>
         {/if}
-        <a class="crm-expand-row" title="{ts}view payments{/ts}" href="{crmURL p='civicrm/pledge/payment' q="action=browse&context=`$context`&pledgeId=`$row.pledge_id`&cid=`$row.contact_id`"}">{ts}Payments{/ts}</a>
+        <a class="crm-expand-row" title="{ts escape='htmlattribute'}view payments{/ts}" href="{crmURL p='civicrm/pledge/payment' q="action=browse&context=`$context`&pledgeId=`$row.pledge_id`&cid=`$row.contact_id`"}">{ts}Payments{/ts}</a>
       </td>
     {/if}
    </tr>

--- a/templates/CRM/Price/Form/DeleteSet.tpl
+++ b/templates/CRM/Price/Form/DeleteSet.tpl
@@ -9,7 +9,7 @@
 *}
 {* this template is used for confirmation of delete for a price set  *}
     <div class="messages status no-popup">
-     <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
+     <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>
           {ts 1=$title}WARNING: Deleting this price set will result in the loss of all '%1' data.{/ts} {ts}This action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
 
     </div>

--- a/templates/CRM/Price/Form/Field.tpl
+++ b/templates/CRM/Price/Form/Field.tpl
@@ -95,7 +95,7 @@
   <div id="price-block" {if $action eq 2 && $form.html_type.value.0 eq 'Text'} class="show-block" {else} class="hiddenElement" {/if}>
     <table class="form-layout">
       <tr class="crm-price-field-form-block-price">
-        <td class="label">{$form.price.label|smarty:nodefaults} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span> {help id="id-negative"}</td>
+        <td class="label">{$form.price.label|smarty:nodefaults} <span class="crm-marker" title="{ts escape='htmlattribute'}This field is required.{/ts}">*</span> {help id="id-negative"}</td>
         <td>{$form.price.html}</td>
       </tr>
       <tr class="crm-price-field-form-block-non-deductible-amount">
@@ -117,7 +117,7 @@
       </tr>
     {/if}
       <tr class="crm-price-field-form-block-financial_type">
-        <td class="label">{$form.financial_type_id.label|smarty:nodefaults}<span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></td></td>
+        <td class="label">{$form.financial_type_id.label|smarty:nodefaults}<span class="crm-marker" title="{ts escape='htmlattribute'}This field is required.{/ts}">*</span></td></td>
         <td>
         {if !$financialType}
           {capture assign=ftUrl}{crmURL p='civicrm/admin/financial/financialType' q="reset=1"}{/capture}

--- a/templates/CRM/Price/Form/OptionFields.tpl
+++ b/templates/CRM/Price/Form/OptionFields.tpl
@@ -41,7 +41,7 @@
   <tr id="optionField_{$index}" class="form-item {cycle values="odd-row,even-row"}">
         <td>
         {if $index GT 1}
-            <a onclick="showHideRow({$index}); return false;" name="optionField_{$index}" href="#" class="form-link"><i class="crm-i fa-trash" title="{ts}hide field or section{/ts}" aria-hidden="true"></i></a>
+            <a onclick="showHideRow({$index}); return false;" name="optionField_{$index}" href="#" class="form-link"><i class="crm-i fa-trash" title="{ts escape='htmlattribute'}hide field or section{/ts}" aria-hidden="true"></i></a>
         {/if}
         </td>
       <td>

--- a/templates/CRM/Price/Page/Option.tpl
+++ b/templates/CRM/Price/Page/Option.tpl
@@ -90,7 +90,7 @@
   {else}
     {if $action eq 16}
       <div class="messages status no-popup">
-        <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
+        <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>
         {ts}None found.{/ts}
       </div>
     {/if}

--- a/templates/CRM/Price/Page/table.tpl
+++ b/templates/CRM/Price/Page/table.tpl
@@ -28,7 +28,7 @@
 
       {foreach from=$usedBy.civicrm_event item=event key=id}
            <tr>
-               <td><a href="{crmURL p="civicrm/event/manage/fee" q="action=update&reset=1&id=`$id`"}" title="{ts}Change or remove the price set used for this event.{/ts}">{$event.title}</a></td>
+               <td><a href="{crmURL p="civicrm/event/manage/fee" q="action=update&reset=1&id=`$id`"}" title="{ts escape='htmlattribute'}Change or remove the price set used for this event.{/ts}">{$event.title}</a></td>
                <td>{$event.eventType}</td>
                <td>{if $event.isPublic}{ts}Yes{/ts}{else}{ts}No{/ts}{/if}</td>
                <td>{$event.startDate|crmDate}{if $event.endDate}&nbsp;to&nbsp;{$event.endDate|crmDate}{/if}</td>
@@ -53,7 +53,7 @@
 
       {foreach from=$usedBy.civicrm_contribution_page item=contributionPage key=id}
            <tr>
-               <td><a href="{crmURL p="civicrm/admin/contribute/settings" q="action=update&reset=1&id=`$id`"}" title="{ts}Change or remove the price set used for this contribution page.{/ts}">{$contributionPage.title}</a></td>
+               <td><a href="{crmURL p="civicrm/admin/contribute/settings" q="action=update&reset=1&id=`$id`"}" title="{ts escape='htmlattribute'}Change or remove the price set used for this contribution page.{/ts}">{$contributionPage.title}</a></td>
                <td>{$contributionPage.type}</td>
                <td>{$contributionPage.startDate|truncate:10:''|crmDate}{if $contributionPage.endDate}&nbsp;to&nbsp;{$contributionPage.endDate|truncate:10:''|crmDate}{/if}</td>
            </tr>
@@ -76,7 +76,7 @@
   </thead>
   {foreach from=$usedBy.civicrm_event_template item=eventTemplate key=id}
     <tr>
-      <td><a href="{crmURL p="civicrm/event/manage/fee" q="action=update&reset=1&id=`$id`"}" title="{ts}Change or remove the price set used for this event template.{/ts}">{$eventTemplate.title}</a></td>
+      <td><a href="{crmURL p="civicrm/event/manage/fee" q="action=update&reset=1&id=`$id`"}" title="{ts escape='htmlattribute'}Change or remove the price set used for this event template.{/ts}">{$eventTemplate.title}</a></td>
       <td>{$eventTemplate.eventType}</td>
       <td>{if $eventTemplate.isPublic}{ts}Yes{/ts}{else}{ts}No{/ts}{/if}</td>
     </tr>

--- a/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
+++ b/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
@@ -101,7 +101,7 @@
   {if empty($reachedMax) && !empty($editPermission)}
     <div class="action-link">
       {if $pageViewType eq 'customDataView'}
-        <br/><a accesskey="N" title="{ts 1=$customGroupTitle}Add %1 Record{/ts}" href="{crmURL p='civicrm/contact/view/cd/edit' q="reset=1&type=$ctype&groupID=$customGroupId&entityID=$contactId&cgcount=$newCgCount&multiRecordDisplay=single&mode=add"}"
+        <br/><a accesskey="N" title="{ts escape='htmlattribute' 1=$customGroupTitle}Add %1 Record{/ts}" href="{crmURL p='civicrm/contact/view/cd/edit' q="reset=1&type=$ctype&groupID=$customGroupId&entityID=$contactId&cgcount=$newCgCount&multiRecordDisplay=single&mode=add"}"
          class="button action-item"><span><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts 1=$customGroupTitle}Add %1 Record{/ts}</span></a>
       {else}
         <a accesskey="N" href="{crmURL p='civicrm/profile/edit' q="reset=1&id=`$contactId`&multiRecord=add&gid=`$gid`&context=multiProfileDialog"}"

--- a/templates/CRM/Report/Form/Fields.tpl
+++ b/templates/CRM/Report/Form/Fields.tpl
@@ -20,13 +20,13 @@
           {/foreach}
           {if !empty($instanceForm) OR !empty($instanceFormError)}
             <li id="tab_settings" class="ui-corner-all">
-              <a title="{ts}Title and Format{/ts}" href="#report-tab-format">{ts}Title and Format{/ts}</a>
+              <a title="{ts escape='htmlattribute'}Title and Format{/ts}" href="#report-tab-format">{ts}Title and Format{/ts}</a>
             </li>
             <li class="ui-corner-all">
-              <a title="{ts}Email Delivery{/ts}" href="#report-tab-email">{ts}Email Delivery{/ts}</a>
+              <a title="{ts escape='htmlattribute'}Email Delivery{/ts}" href="#report-tab-email">{ts}Email Delivery{/ts}</a>
             </li>
             <li class="ui-corner-all">
-              <a title="{ts}Access{/ts}" href="#report-tab-access">{ts}Access{/ts}</a>
+              <a title="{ts escape='htmlattribute'}Access{/ts}" href="#report-tab-access">{ts}Access{/ts}</a>
             </li>
           {/if}
         </ul>

--- a/templates/CRM/Report/Page/InstanceList.tpl
+++ b/templates/CRM/Report/Page/InstanceList.tpl
@@ -29,7 +29,7 @@
               <table class="report-layout">
                 {foreach from=$rows item=row}
                   <tr id="row_{counter}" class="crm-report-instanceList">
-                    <td class="crm-report-instanceList-title" style="width:35%"><a href="{$row.url}" title="{ts}Run this report{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> <strong>{$row.title}</strong></a></td>
+                    <td class="crm-report-instanceList-title" style="width:35%"><a href="{$row.url}" title="{ts escape='htmlattribute'}Run this report{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> <strong>{$row.title}</strong></a></td>
                     <td class="crm-report-instanceList-description">{$row.description}</td>
                     <td>
                     <a href="{$row.viewUrl}" class="action-item crm-hover-button">{ts}View Results{/ts}</a>

--- a/templates/CRM/Report/Page/Options.tpl
+++ b/templates/CRM/Report/Page/Options.tpl
@@ -64,6 +64,6 @@
   </div>
 {else}
   <div class="messages status no-popup">
-    <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>&nbsp; {ts 1=$newReport}There are no option values entered. You can <a href="%1">add one</a>.{/ts}
+    <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>&nbsp; {ts 1=$newReport}There are no option values entered. You can <a href="%1">add one</a>.{/ts}
   </div>
 {/if}

--- a/templates/CRM/Report/Page/TemplateList.tpl
+++ b/templates/CRM/Report/Page/TemplateList.tpl
@@ -27,7 +27,7 @@
                 {foreach from=$rows item=row}
                   <tr id="row_{counter}" class="crm-report-templateList">
                     <td class="crm-report-templateList-title" style="width:35%;">
-                      <a href="{$row.url}" title="{ts}Create report from this template{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> <strong>{$row.title}</strong></a>
+                      <a href="{$row.url}" title="{ts escape='htmlattribute'}Create report from this template{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> <strong>{$row.title}</strong></a>
                       {if !empty($row.instanceUrl)}
                         <div style="font-size:10px;text-align:right;margin-top:3px;">
                           <a href="{$row.instanceUrl}">{ts}Existing Report(s){/ts}</a>

--- a/templates/CRM/Tag/Form/Tag.tpl
+++ b/templates/CRM/Tag/Form/Tag.tpl
@@ -86,8 +86,8 @@
     <tbody>
       <tr>
         <td>
-          <input class="crm-form-text big" name="filter_tag_tree" placeholder="{ts}Filter List{/ts}" allowclear="1"/>
-          <a class="crm-hover-button crm-clear-link" style="visibility:hidden;" title="{ts}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
+          <input class="crm-form-text big" name="filter_tag_tree" placeholder="{ts escape='htmlattribute'}Filter List{/ts}" allowclear="1"/>
+          <a class="crm-hover-button crm-clear-link" style="visibility:hidden;" title="{ts escape='htmlattribute'}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
           <div id="tagtree">
             {include file="CRM/Tag/Form/Tagtree.tpl" level=1}
           </div>

--- a/templates/CRM/Tag/Page/Tag.tpl
+++ b/templates/CRM/Tag/Page/Tag.tpl
@@ -19,16 +19,16 @@
 
   <div id="mainTabContainer">
     <ul>
-      <li class="ui-corner-all crm-tab-button" title="{ts}Main Tag List{/ts}">
+      <li class="ui-corner-all crm-tab-button" title="{ts escape='htmlattribute'}Main Tag List{/ts}">
         <a href="#tree"><i class="crm-i fa-tags" aria-hidden="true"></i> {ts}Tag Tree{/ts}</a>
       </li>
       {foreach from=$tagsets item=set}
-        <li class="ui-corner-all crm-tab-button {if ($set.is_reserved)}is-reserved{/if}" title="{ts 1=$set.used_for_label_str}Tag Set for %1{/ts}">
+        <li class="ui-corner-all crm-tab-button {if ($set.is_reserved)}is-reserved{/if}" title="{ts escape='htmlattribute' 1=$set.used_for_label_str}Tag Set for %1{/ts}">
           <a href="#tagset-{$set.id}">{$set.label}</a>
         </li>
       {/foreach}
       {crmPermission has='administer Tagsets'}
-        <li class="ui-corner-all crm-tab-button" title="{ts}Add Tag Set{/ts}">
+        <li class="ui-corner-all crm-tab-button" title="{ts escape='htmlattribute'}Add Tag Set{/ts}">
           <a href="#new-tagset"><i class="crm-i fa-plus" aria-hidden="true"></i></a>
         </li>
       {/crmPermission}
@@ -37,8 +37,8 @@
       <div class="help">
         {ts}Organize the tag hierarchy by clicking and dragging. Shift-click to select multiple tags to merge/move/delete.{/ts}
       </div>
-      <input class="crm-form-text big" name="filter_tag_tree" placeholder="{ts}Filter List{/ts}" allowclear="1"/>
-      <a class="crm-hover-button crm-clear-link" style="visibility:hidden;" title="{ts}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
+      <input class="crm-form-text big" name="filter_tag_tree" placeholder="{ts escape='htmlattribute'}Filter List{/ts}" allowclear="1"/>
+      <a class="crm-hover-button crm-clear-link" style="visibility:hidden;" title="{ts escape='htmlattribute'}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
     </div>
     {foreach from=$tagsets item=set}
       <div id="tagset-{$set.id}">
@@ -481,7 +481,7 @@
 <script type="text/template" id="oneSelectedTpl">
   <div class="crm-entity" data-entity="Tag" data-id="<%= id %>">
     <h4>
-      <input type="color" value="<%= data.color %>" <% if (!data.is_reserved || adminReserved) {ldelim} %>title="{ts}Select color{/ts}" <% {rdelim} else {ldelim} %>disabled<% {rdelim} %> />
+      <input type="color" value="<%= data.color %>" <% if (!data.is_reserved || adminReserved) {ldelim} %>title="{ts escape='htmlattribute'}Select color{/ts}" <% {rdelim} else {ldelim} %>disabled<% {rdelim} %> />
       <span class="<% if (!data.is_reserved || adminReserved) {ldelim} %>crm-editable<% {rdelim} %>" data-field="label"><%- text %></span>
     </h4>
     <hr />
@@ -514,20 +514,20 @@
       </div>
     <% {rdelim} %>
     <div><span class="tdl">{ts}Usage Count:{/ts}</span> <%= data.usages %></div>
-    <a class="clear-tag-selection" href="#" title="{ts}Clear selection{/ts}"><i class="crm-i fa-ban" aria-hidden="true"></i></a>
+    <a class="clear-tag-selection" href="#" title="{ts escape='htmlattribute'}Clear selection{/ts}"><i class="crm-i fa-ban" aria-hidden="true"></i></a>
   </div>
   <div class="crm-submit-buttons">
     <% if(!tagset) {ldelim} %>
-      <a href="{crmURL p="civicrm/tag/edit" q="action=add&parent_id="}<%= id %>" class="button crm-popup" title="{ts}Create new tag under this one{/ts}">
+      <a href="{crmURL p="civicrm/tag/edit" q="action=add&parent_id="}<%= id %>" class="button crm-popup" title="{ts escape='htmlattribute'}Create new tag under this one{/ts}">
         <span><i class="crm-i fa-plus" aria-hidden="true"></i> {ts}Add Child{/ts}</span>
       </a>
     <% {rdelim} %>
-    <a href="{crmURL p="civicrm/tag/edit" q="action=add&clone_from="}<%= id %>" class="button crm-popup" title="{ts}Duplicate this tag{/ts}">
+    <a href="{crmURL p="civicrm/tag/edit" q="action=add&clone_from="}<%= id %>" class="button crm-popup" title="{ts escape='htmlattribute'}Duplicate this tag{/ts}">
       <span><i class="crm-i fa-copy" aria-hidden="true"></i> {ts}Clone Tag{/ts}</span>
     </a>
     <% if(!data.is_reserved || adminReserved) {ldelim} %>
       <% if(tagsetCount) {ldelim} %>
-        <a href="#move" class="button move-tag-button" title="{ts}Move to a different tagset{/ts}">
+        <a href="#move" class="button move-tag-button" title="{ts escape='htmlattribute'}Move to a different tagset{/ts}">
           <span><i class="crm-i fa-share-square-o" aria-hidden="true"></i> {ts}Move Tag{/ts}</span>
         </a>
       <% {rdelim} %>
@@ -547,14 +547,14 @@
       <p>* {ts 1="<%= reserved %>"}%1 reserved.{/ts}</p>
     <% {rdelim} %>
   <p><span class="tdl">{ts}Total Usage:{/ts}</span> <%= usages %></p>
-  <a class="clear-tag-selection" href="#" title="{ts}Clear selection{/ts}"><i class="crm-i fa-ban" aria-hidden="true"></i></a>
+  <a class="clear-tag-selection" href="#" title="{ts escape='htmlattribute'}Clear selection{/ts}"><i class="crm-i fa-ban" aria-hidden="true"></i></a>
   <div class="crm-submit-buttons">
     <% if(!reserved || adminReserved) {ldelim} %>
-      <a href="{crmURL p="civicrm/tag/merge" q="id="}<%= items.join() %>" class="button crm-popup small-popup" title="{ts}Combine tags into one{/ts}">
+      <a href="{crmURL p="civicrm/tag/merge" q="id="}<%= items.join() %>" class="button crm-popup small-popup" title="{ts escape='htmlattribute'}Combine tags into one{/ts}">
         <span><i class="crm-i fa-compress" aria-hidden="true"></i> {ts}Merge Tags{/ts}</span>
       </a>
       <% if(tagsetCount) {ldelim} %>
-        <a href="#move" class="button move-tag-button" title="{ts}Move to a different tagset{/ts}">
+        <a href="#move" class="button move-tag-button" title="{ts escape='htmlattribute'}Move to a different tagset{/ts}">
           <span><i class="crm-i fa-share-square-o" aria-hidden="true"></i> {ts}Move Tags{/ts}</span>
         </a>
       <% {rdelim} %>
@@ -575,7 +575,7 @@
       {ts 1="<%= used_for_label.join(', ') %>" 2="<%= date %>" 3="<%= display_name %>"}Tag Set for %1 (created %2 by %3).{/ts}
       <% if(typeof description === 'string' && description.length && description !== 'null') {ldelim} %><p><em><%- description %></em></p><% {rdelim} %>
     </div>
-    <input class="crm-form-text big" name="filter_tag_tree" placeholder="{ts}Filter List{/ts}" allowclear="1"/>
-    <a class="crm-hover-button crm-clear-link" style="visibility:hidden;" title="{ts}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
+    <input class="crm-form-text big" name="filter_tag_tree" placeholder="{ts escape='htmlattribute'}Filter List{/ts}" allowclear="1"/>
+    <a class="crm-hover-button crm-clear-link" style="visibility:hidden;" title="{ts escape='htmlattribute'}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
   </div>
 </script>

--- a/templates/CRM/UF/Page/Group.tpl
+++ b/templates/CRM/UF/Page/Group.tpl
@@ -44,8 +44,8 @@
     {if $rows}
       <div id='mainTabContainer'>
         <ul>
-          <li id='tab_user-profiles'>    <a href='#user-profiles'     title='{ts}User-defined Profile{/ts}'>{ts}User-defined Profiles{/ts}</a></li>
-          <li id='tab_reserved-profiles'><a href='#reserved-profiles' title='{ts}Reserved Profiles{/ts}'>{ts}Reserved Profiles{/ts}</a></li>
+          <li id='tab_user-profiles'>    <a href='#user-profiles'     title='{ts escape='htmlattribute'}User-defined Profile{/ts}'>{ts}User-defined Profiles{/ts}</a></li>
+          <li id='tab_reserved-profiles'><a href='#reserved-profiles' title='{ts escape='htmlattribute'}Reserved Profiles{/ts}'>{ts}Reserved Profiles{/ts}</a></li>
         </ul>
 
         {* handle enable/disable actions*}

--- a/templates/CRM/UF/Page/ProfileTemplates.tpl
+++ b/templates/CRM/UF/Page/ProfileTemplates.tpl
@@ -28,8 +28,8 @@
           </select>
         </span>
       </div>
-      <input type="text" class="crm-form-text" placeholder="{ts}Search Fields{/ts}" />
-      <a class="crm-designer-palette-clear-search crm-hover-button" href="#" style="visibility:hidden" title="{ts}Clear search{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
+      <input type="text" class="crm-form-text" placeholder="{ts escape='htmlattribute'}Search Fields{/ts}" />
+      <a class="crm-designer-palette-clear-search crm-hover-button" href="#" style="visibility:hidden" title="{ts escape='htmlattribute'}Clear search{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
       <div class="crm-designer-palette-controls">
         <a href="#" class="crm-designer-palette-toggle" rel="open_all">{ts}Open All{/ts}</a>&nbsp; |&nbsp;
         <a href="#" class="crm-designer-palette-toggle" rel="close_all">{ts}Close All{/ts}</a>
@@ -58,8 +58,8 @@
  *}
 <script type="text/template" id="field_summary_template">
   <span class="crm-designer-buttons">
-    <a class="crm-i fa-pencil crm-designer-action-settings" title="{ts}Settings{/ts}" aria-hidden="true"></a>
-    <a class="crm-i fa-trash crm-designer-action-remove" title="{ts}Remove{/ts}" aria-hidden="true"></a>
+    <a class="crm-i fa-pencil crm-designer-action-settings" title="{ts escape='htmlattribute'}Settings{/ts}" aria-hidden="true"></a>
+    <a class="crm-i fa-trash crm-designer-action-remove" title="{ts escape='htmlattribute'}Remove{/ts}" aria-hidden="true"></a>
   </span>
   <div class="description"><%= help_pre %></div>
   <div class="crm-designer-row-label">
@@ -86,7 +86,7 @@
 <script type="text/template" id="form_summary_template">
   <h3><%= title %></h3>
   <div class="crm-designer-buttons">
-    <a class="crm-designer-action-settings crm-i fa-pencil" title="{ts}Settings{/ts}" aria-hidden="true"></a>
+    <a class="crm-designer-action-settings crm-i fa-pencil" title="{ts escape='htmlattribute'}Settings{/ts}" aria-hidden="true"></a>
   </div>
 </script>
 
@@ -106,7 +106,7 @@
 <script type="text/template" id="profile_selector_template">
     <div>
         <span class="crm-profile-selector-select"></span>
-        <button type="button" class="crm-profile-selector-preview" title="{ts}Preview{/ts}"><i class="crm-i fa-television" aria-hidden="true"></i> {ts}Preview{/ts}</button>
+        <button type="button" class="crm-profile-selector-preview" title="{ts escape='htmlattribute'}Preview{/ts}"><i class="crm-i fa-television" aria-hidden="true"></i> {ts}Preview{/ts}</button>
         {if $perm}
           <button class="crm-profile-selector-edit">{ts}Edit{/ts}</button>
           <button class="crm-profile-selector-copy">{ts}Copy{/ts}</button>

--- a/templates/CRM/common/SocialNetwork.tpl
+++ b/templates/CRM/common/SocialNetwork.tpl
@@ -20,14 +20,14 @@
     {/if}
     </p>
     {if $emailMode eq true}
-        <a href="https://twitter.com/share?url={$url|escape:'url'}&amp;text={$title|escape:'url'}" class="btn btn-default" role="button" target="_blank" title="{ts}Tweet{/ts}">{ts}Twitter{/ts}</a>
-        <a href="https://facebook.com/sharer/sharer.php?u={$url|escape:'url'}" target="_blank" class="btn btn-default" role="button" title="{ts}Share{/ts}">{ts}Facebook{/ts}</a>
-        <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url={$url|escape:'url'}&amp;title={$title|escape:'url'}" target="_blank" rel="noopener" class="btn btn-default" title="{ts}Share{/ts}">{ts}LinkedIn{/ts}</a>
+        <a href="https://twitter.com/share?url={$url|escape:'url'}&amp;text={$title|escape:'url'}" class="btn btn-default" role="button" target="_blank" title="{ts escape='htmlattribute'}Tweet{/ts}">{ts}Twitter{/ts}</a>
+        <a href="https://facebook.com/sharer/sharer.php?u={$url|escape:'url'}" target="_blank" class="btn btn-default" role="button" title="{ts escape='htmlattribute'}Share{/ts}">{ts}Facebook{/ts}</a>
+        <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url={$url|escape:'url'}&amp;title={$title|escape:'url'}" target="_blank" rel="noopener" class="btn btn-default" title="{ts escape='htmlattribute'}Share{/ts}">{ts}LinkedIn{/ts}</a>
     {else}
-        <button onclick="window.open('https://twitter.com/intent/tweet?url={$url|escape:'url'}&amp;text={$title|escape:'url'}','_blank')" type="button" class="btn btn-default crm-button" id="crm-tw" title="{ts}Tweet{/ts}"><i aria-hidden="true" class="crm-i fa-twitter"></i>&nbsp;&nbsp;{ts}Twitter{/ts}</button>
-        <button onclick="window.open('https://facebook.com/sharer/sharer.php?u={$url|escape:'url'}','_blank')" type="button" class="btn btn-default crm-button" role="button" id="crm-fb" title="{ts}Share{/ts}"><i aria-hidden="true" class="crm-i fa-facebook"></i>&nbsp;&nbsp;{ts}Facebook{/ts}</button>
-        <button onclick="window.open('https://www.linkedin.com/shareArticle?mini=true&amp;url={$url|escape:'url'}&amp;title={$title|escape:'url'}','_blank')" type="button" rel="noopener" class="btn btn-default crm-button" id="crm-li" title="{ts}Share{/ts}"><i aria-hidden="true" class="crm-i fa-linkedin"></i>&nbsp;&nbsp;{ts}LinkedIn{/ts}</button>
-        <button onclick="window.open('mailto:?subject={$title|escape:'quotes'}&amp;body={$url|escape:'url'}','_self')" type="button" rel="noopener" class="btn btn-default crm-button" id="crm-email"><i aria-hidden="true" class="crm-i fa-envelope" title="{ts}Email{/ts}"></i>&nbsp;&nbsp;{ts}Email{/ts}</button>
+        <button onclick="window.open('https://twitter.com/intent/tweet?url={$url|escape:'url'}&amp;text={$title|escape:'url'}','_blank')" type="button" class="btn btn-default crm-button" id="crm-tw" title="{ts escape='htmlattribute'}Tweet{/ts}"><i aria-hidden="true" class="crm-i fa-twitter"></i>&nbsp;&nbsp;{ts}Twitter{/ts}</button>
+        <button onclick="window.open('https://facebook.com/sharer/sharer.php?u={$url|escape:'url'}','_blank')" type="button" class="btn btn-default crm-button" role="button" id="crm-fb" title="{ts escape='htmlattribute'}Share{/ts}"><i aria-hidden="true" class="crm-i fa-facebook"></i>&nbsp;&nbsp;{ts}Facebook{/ts}</button>
+        <button onclick="window.open('https://www.linkedin.com/shareArticle?mini=true&amp;url={$url|escape:'url'}&amp;title={$title|escape:'url'}','_blank')" type="button" rel="noopener" class="btn btn-default crm-button" id="crm-li" title="{ts escape='htmlattribute'}Share{/ts}"><i aria-hidden="true" class="crm-i fa-linkedin"></i>&nbsp;&nbsp;{ts}LinkedIn{/ts}</button>
+        <button onclick="window.open('mailto:?subject={$title|escape:'quotes'}&amp;body={$url|escape:'url'}','_self')" type="button" rel="noopener" class="btn btn-default crm-button" id="crm-email"><i aria-hidden="true" class="crm-i fa-envelope" title="{ts escape='htmlattribute'}Email{/ts}"></i>&nbsp;&nbsp;{ts}Email{/ts}</button>
     {/if}
     {if $pageURL}
     <p class="clear">

--- a/templates/CRM/common/TabHeader.tpl
+++ b/templates/CRM/common/TabHeader.tpl
@@ -15,13 +15,13 @@
         {foreach from=$tabHeader key=tabName item=tabValue}
           <li id="tab_{$tabName}" class="crm-tab-button ui-corner-all {if !$tabValue.valid}disabled{/if} {if is_numeric($tabValue.count)}crm-count-{$tabValue.count}{/if} {if $tabValue.class} {$tabValue.class}{/if}" {$tabValue.extra}>
             {if $tabValue.active}
-              <a href="{if $tabValue.template}#{$tabIdPrefix|default:'panel_'}{$tabName}{else}{$tabValue.url|smarty:nodefaults}{/if}" title="{$tabValue.title|escape} {if !$tabValue.valid}({ts}disabled{/ts}){/if}">
+              <a href="{if $tabValue.template}#{$tabIdPrefix|default:'panel_'}{$tabName}{else}{$tabValue.url|smarty:nodefaults}{/if}" title="{$tabValue.title|escape} {if !$tabValue.valid}({ts escape='htmlattribute'}disabled{/ts}){/if}">
                 <i class="{$tabValue.icon|default:'crm-i fa-puzzle-piece'}" aria-hidden="true"></i>
                 <span>{$tabValue.title}</span>
                 {if empty($tabValue.hideCount) && is_numeric($tabValue.count)}<em>{$tabValue.count}</em>{/if}
               </a>
             {else}
-               <span {if !$tabValue.valid} title="{ts}disabled{/ts}"{/if}>{$tabValue.title}</span>
+               <span {if !$tabValue.valid} title="{ts escape='htmlattribute'}disabled{/ts}"{/if}>{$tabValue.title}</span>
             {/if}
           </li>
         {/foreach}

--- a/templates/CRM/common/fatal.tpl
+++ b/templates/CRM/common/fatal.tpl
@@ -56,7 +56,7 @@
          </div>
         </details>
     {/if}
-    <p><a href="{$config->userFrameworkBaseURL}" title="{ts}Main Menu{/ts}">{ts}Return to home page.{/ts}</a></p>
+    <p><a href="{$config->userFrameworkBaseURL}" title="{ts escape='htmlattribute'}Main Menu{/ts}">{ts}Return to home page.{/ts}</a></p>
 </div>
 </div> {* end crm-container div *}
 {if $config->userFramework != 'WordPress'}

--- a/templates/CRM/common/jcalendar.tpl
+++ b/templates/CRM/common/jcalendar.tpl
@@ -52,7 +52,7 @@
 {/if}
 
 
- <a href="#" class="crm-hover-button crm-clear-link" title="{ts}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
+ <a href="#" class="crm-hover-button crm-clear-link" title="{ts escape='htmlattribute'}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
 
 <script type="text/javascript">
     {literal}

--- a/templates/CRM/common/logButton.tpl
+++ b/templates/CRM/common/logButton.tpl
@@ -20,7 +20,7 @@
   Note: This file is used by CivHR
 *}
 
-<a class="css_right {$snippet.css_class}" href="#" title="{ts}View Revisions{/ts}">View Revisions</a>
+<a class="css_right {$snippet.css_class}" href="#" title="{ts escape='htmlattribute'}View Revisions{/ts}">View Revisions</a>
 
 {literal}
 <script type="text/javascript">

--- a/templates/CRM/common/notifications.tpl
+++ b/templates/CRM/common/notifications.tpl
@@ -1,7 +1,7 @@
 <div id="crm-notification-container" role="alert" aria-live="assertive" aria-atomic="true" style="display:none">
   <div id="crm-notification-alert" class="#{ldelim}type{rdelim}">
-    <div class="icon ui-notify-close" title="{ts}close{/ts}"> </div>
-    <a class="ui-notify-cross ui-notify-close" href="#" title="{ts}close{/ts}">x</a>
+    <div class="icon ui-notify-close" title="{ts escape='htmlattribute'}close{/ts}"> </div>
+    <a class="ui-notify-cross ui-notify-close" href="#" title="{ts escape='htmlattribute'}close{/ts}">x</a>
     <h1>#{ldelim}title{rdelim}</h1>
     <div class="notify-content">#{ldelim}text{rdelim}</div>
   </div>

--- a/templates/CRM/common/publicFooter.tpl
+++ b/templates/CRM/common/publicFooter.tpl
@@ -9,7 +9,7 @@
 *}
 
 {if $config->empoweredBy}
-  {capture assign=civilogo}<a href="https://civicrm.org/" title="{ts}CiviCRM.org - Growing and Sustaining Relationships{/ts}" target="_blank" class="empowered-by-link"><div class="empowered-by-logo"><span>CiviCRM</span></div></a>{/capture}
+  {capture assign=civilogo}<a href="https://civicrm.org/" title="{ts escape='htmlattribute'}CiviCRM.org - Growing and Sustaining Relationships{/ts}" target="_blank" class="empowered-by-link"><div class="empowered-by-logo"><span>CiviCRM</span></div></a>{/capture}
   <div class="crm-public-footer" id="civicrm-footer">
     {ts 1=$civilogo}empowered by %1{/ts}
   </div>

--- a/templates/CRM/common/standalone-frontend.tpl
+++ b/templates/CRM/common/standalone-frontend.tpl
@@ -24,7 +24,7 @@
 
   <div id="crm-container" class="crm-container standalone-page-padding" lang="{$config->lcMessages|substr:0:2}" xml:lang="{$config->lcMessages|substr:0:2}">
     {if $breadcrumb}
-      <nav aria-label="{ts}Breadcrumb{/ts}" class="breadcrumb"><ol>
+      <nav aria-label="{ts escape='htmlattribute'}Breadcrumb{/ts}" class="breadcrumb"><ol>
         <li><a href="/civicrm/dashboard?reset=1" >{ts}Home{/ts}</a></li>
         {foreach from=$breadcrumb item=crumb key=key}
           <li><a href="{$crumb.url}">{$crumb.title}</a></li>

--- a/templates/CRM/common/standalone.tpl
+++ b/templates/CRM/common/standalone.tpl
@@ -24,7 +24,7 @@
 
   <div id="crm-container" class="crm-container standalone-page-padding" lang="{$config->lcMessages|substr:0:2}" xml:lang="{$config->lcMessages|substr:0:2}">
     {if $breadcrumb}
-      <nav aria-label="{ts}Breadcrumb{/ts}" class="breadcrumb"><ol>
+      <nav aria-label="{ts escape='htmlattribute'}Breadcrumb{/ts}" class="breadcrumb"><ol>
         <li><a href="/civicrm/dashboard?reset=1" >{ts}Home{/ts}</a></li>
         {foreach from=$breadcrumb item=crumb key=key}
           <li><a href="{$crumb.url}">{$crumb.title}</a></li>

--- a/templates/CRM/common/success.tpl
+++ b/templates/CRM/common/success.tpl
@@ -45,8 +45,8 @@
           <div>{$message}</div>
         </div>
         <div>
-          <p><a href="{crmURL p='civicrm/a/#/status'}" title="{ts}CiviCRM Status Check{/ts}" style="text-decoration: underline;">{ts}View the CiviCRM System Status{/ts}</a></p>
-          <p><a href="{crmURL p='civicrm/dashboard' q='reset=1'}" title="{ts}CiviCRM home page{/ts}" style="text-decoration: underline;">{ts}Return to CiviCRM home page.{/ts}</a></p>
+          <p><a href="{crmURL p='civicrm/a/#/status'}" title="{ts escape='htmlattribute'}CiviCRM Status Check{/ts}" style="text-decoration: underline;">{ts}View the CiviCRM System Status{/ts}</a></p>
+          <p><a href="{crmURL p='civicrm/dashboard' q='reset=1'}" title="{ts escape='htmlattribute'}CiviCRM home page{/ts}" style="text-decoration: underline;">{ts}Return to CiviCRM home page.{/ts}</a></p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5711](https://lab.civicrm.org/dev/core/-/issues/5711)

Ensure translated strings don't inadvertently break out of the quotes or contain any unsupported characters.

Technical Details
------
Uses escape mode introduced in https://github.com/civicrm/civicrm-core/pull/26792

Comments
----------------------------------------

Per my comment in https://github.com/civicrm/civicrm-core/pull/31920 this does all of them.