### PR TITLE
Fix escaping relationship display name

### DIFF
--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -121,7 +121,7 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
       ->first();
     $this->_contactType = $contact['contact_type'];
     $this->_display_name_a = $contact['display_name'];
-    $this->assign('display_name_a', $this->_display_name_a);
+    $this->assign('display_name_a', htmlspecialchars($this->_display_name_a));
 
     $this->_rtype = CRM_Utils_Request::retrieve('rtype', 'String', $this);
     $this->_rtypeId = CRM_Utils_Request::retrieve('relTypeId', 'String', $this);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes unreleased regression.

This regressed with https://github.com/civicrm/civicrm-core/commit/e12cd2368eaf91bed3ea726671ed9c420f403410 - previously the escaped value was fetched from the database, but the api returns an unescaped value.