### PR TITLE
CiviGrant - Remove multi-domain from grant_type option group

### DIFF
--- a/CRM/Core/OptionGroup.php
+++ b/CRM/Core/OptionGroup.php
@@ -27,7 +27,6 @@ class CRM_Core_OptionGroup {
    */
   public static $_domainIDGroups = [
     'from_email_address',
-    'grant_type',
   ];
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Many years ago when CiviGrant was being developed, a little flag was added in the code to indicate that there could be different types of grants per multisite-domain. However, I couldn't find any other code or documentation to support such a feature, so I suspect it was aspirational rather than functional. This removes that one flag. There was no other code to remove, but I wrote a small upgrade script to ensure the list of grant types is consistent across all domains.

Comments
----------------------------------------
The purpose of this removal is to simplify the rather overcomplicated `civicrm_option_value` table. For the sake of what appears to be non-functional, aspirational code, the table has an extra column for `domain_id` and some extra logic to cope with it. That can all be deprecated now.
