### PR TITLE
dev/financial#230 - When changing payment method, only make journal entries when financial account changes

### DIFF
--- a/tests/phpunit/CRM/Financial/Form/PaymentEditTest.php
+++ b/tests/phpunit/CRM/Financial/Form/PaymentEditTest.php
@@ -107,6 +107,70 @@ class CRM_Financial_Form_PaymentEditTest extends CiviUnitTestCase {
   }
 
   /**
+   * Same as testSubmitOnPaymentInstrumentChange but when the financial
+   * account is the same before and after.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
+   */
+  public function testSubmitOnPaymentInstrumentChangeSameAccount(): void {
+    // First create a contribution using 'Check' as payment instrument
+    $paymentInstrument = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check');
+    $this->getTestForm('CRM_Contribute_Form_Contribution', [
+      'total_amount' => 50,
+      'receive_date' => '2015-04-21 23:27:00',
+      'financial_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Donation'),
+      'contact_id' => $this->_individualID,
+      'payment_instrument_id' => $paymentInstrument,
+      'check_number' => '123XA',
+      'contribution_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed'),
+    ])->processForm();
+    // fetch the financial trxn record later used in setting default values of payment edit form
+    $contribution = $this->callAPISuccessGetSingle('Contribution', ['contact_id' => $this->_individualID]);
+    $payments = CRM_Contribute_BAO_Contribution::getPaymentInfo($contribution['id'], 'contribute', TRUE);
+    $financialTrxnInfo = $payments['transaction'][0];
+
+    // Create a new payment instrument with the same asset account.
+    // SpaceChecks are the same as Checks, but in space.
+    $asset_account = CRM_Financial_BAO_EntityFinancialAccount::getInstrumentFinancialAccount($paymentInstrument);
+    $forHistoricalReasonsThisNeedsToBePassByRef = [
+      'name' => 'space_check',
+      'label' => 'SpaceCheck',
+      'financial_account_id' => $asset_account,
+      'is_active' => 1,
+      // It will just pick the next `value` for us so no need to specify `value`
+    ];
+    $newPaymentInstrument = CRM_Core_OptionValue::addOptionValue($forHistoricalReasonsThisNeedsToBePassByRef, 'payment_instrument', CRM_Core_Action::ADD, NULL);
+
+    // Change the payment instrument
+    $params = [
+      'payment_instrument_id' => $newPaymentInstrument->value,
+      'trxn_date' => '2015-04-21 23:27:00',
+    ];
+    $this->getTestForm('CRM_Financial_Form_PaymentEdit', $params, [
+      'contribution_id' => $contribution['id'],
+      'id' => $financialTrxnInfo['id'],
+    ])->processForm();
+
+    $payments = CRM_Contribute_BAO_Contribution::getPaymentInfo($contribution['id'], 'contribute', TRUE);
+    $expectedPaymentParams = [
+      [
+        'total_amount' => 50.00,
+        'financial_type' => 'Donation',
+        'payment_instrument' => 'SpaceCheck',
+        'status' => 'Completed',
+        'receive_date' => '2015-04-21 23:27:00',
+      ],
+    ];
+    $this->assertCount(1, $payments['transaction']);
+    foreach ($expectedPaymentParams as $key => $paymentParams) {
+      foreach ($paymentParams as $fieldName => $expectedValue) {
+        $this->assertEquals($paymentParams[$fieldName], $payments['transaction'][$key][$fieldName]);
+      }
+    }
+  }
+
+  /**
    * Test to ensure that multiple check_numbers are concatenated
    *  and stored in related contribution's check_number
    */


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/financial/-/issues/230

Before
----------------------------------------
Changing payment method works differently than changing financial type when the financial accounts are the same before and after.

After
----------------------------------------
They work the same.

Technical Details
----------------------------------------
Currently when you change the financial type on a contribution, it checks to see if the before and after financial account is the same, since then there's no need for a journal entry, since money isn't being moved between accounts. See https://github.com/civicrm/civicrm-core/blob/9e356d41f4715bae90d214edce7dab7db750c270/CRM/Contribute/BAO/Contribution.php#L3058

But for payment method, it still creates journal entries but just moving money to the same account. This PR makes it check if the account is different first the same as for financial type changes.

Comments
----------------------------------------
