### PR TITLE
A11y - Add aria roles to tablists

### DIFF
--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -201,15 +201,15 @@
   <div class="api4-explorer-row crm-flex-box">
     <div class="panel panel-info explorer-code-panel">
       <div class="panel-heading">
-        <ul class="nav nav-tabs">
-          <li role="presentation" ng-repeat="lang in ::langs" ng-class="{active: selectedTab.code === lang}">
+        <ul role="tablist" class="nav nav-tabs">
+          <li role="tab" ng-repeat="lang in ::langs" ng-class="{active: selectedTab.code === lang}">
             <a href ng-click="selectLang(lang)">
               {{:: lang }}
             </a>
           </li>
         </ul>
       </div>
-      <div class="panel-body">
+      <div role="tabpanel" class="panel-body">
         <div class="alert alert-danger" ng-if="selectedTab.code === 'rest' && !$ctrl.authxEnabled">
           <p>
             {{:: ts('To enable REST authentication, the AuthX extension must be installed.') }}
@@ -253,8 +253,8 @@
             </option>
           </select>
         </div>
-        <ul class="nav nav-tabs">
-          <li role="presentation" ng-class="{active: selectedTab.result === 'result'}">
+        <ul role="tablist" class="nav nav-tabs">
+          <li role="tab" ng-class="{active: selectedTab.result === 'result'}">
             <a href ng-click="selectedTab.result = 'result'">
               <span ng-switch="status">
                 <i class="fa fa-fw fa-circle-o" ng-switch-when="default"></i>
@@ -266,7 +266,7 @@
               <span>{{:: ts('Result') }}</span>
             </a>
           </li>
-          <li role="presentation" ng-if="::perm.viewDebugOutput" ng-class="{active: selectedTab.result === 'debug'}">
+          <li role="tab" ng-if="::perm.viewDebugOutput" ng-class="{active: selectedTab.result === 'debug'}">
             <a href ng-click="selectedTab.result = 'debug'">
               <i class="fa fa-fw fa-{{ debug ? (status === 'warning' || status === 'danger' ? 'warning' : 'bug') : 'circle-o' }}"></i>
               <span>{{:: ts('Debug') }}</span>
@@ -275,7 +275,7 @@
         </ul>
       </div>
       <div class="panel-body">
-        <div ng-show="selectedTab.result === 'result'">
+        <div ng-show="selectedTab.result === 'result'" role="tabpanel">
           <div ng-repeat="code in result">
             <div class="clearfix">
               <button ng-if="$index" class="btn btn-xs btn-default pull-right" ng-click="$ctrl.copyCode('api4-result-' + $index)">
@@ -286,7 +286,7 @@
             <pre class="prettyprint" id="api4-result-{{ $index }}" ng-bind-html="code"></pre>
           </div>
         </div>
-        <div ng-if="::perm.viewDebugOutput" ng-show="selectedTab.result === 'debug'">
+        <div ng-if="::perm.viewDebugOutput" ng-show="selectedTab.result === 'debug'" role="tabpanel">
           <pre ng-if="debug" class="prettyprint" ng-bind-html="debug"></pre>
           <div ng-if="!debug">
             <p>

--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -863,6 +863,7 @@
         template: '<div ng-transclude></div>',
         transclude: true,
         link: function (scope, element, attrs, crmUiTabSetCtrl) {
+          element.attr('role', 'tabpanel');
           crmUiTabSetCtrl.add(scope);
         }
       };

--- a/ang/crmUi/tabset.html
+++ b/ang/crmUi/tabset.html
@@ -1,6 +1,6 @@
 <div class="crm-tabset">
-  <ul>
-    <li ng-repeat="tab in tabs" class="ui-corner-all crm-tab-button crm-count-{{tab.count}}">
+  <ul role="tablist">
+    <li ng-repeat="tab in tabs" role="tab" class="ui-corner-all crm-tab-button crm-count-{{tab.count}}">
       <a ng-href="#{{tab.id}}">
         <i ng-if="tab.crmIcon" class="crm-i {{tab.crmIcon}}" aria-hidden="true"></i>
         {{tab.$parent.$eval(tab.crmTitle)}}

--- a/ext/afform/admin/ang/afAdmin/afAdminList.html
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.html
@@ -1,8 +1,8 @@
 <div id="bootstrap-theme" class="afadmin-list">
   <h1 crm-page-title>{{:: ts('FormBuilder') }}</h1>
 
-  <ul class="nav nav-tabs">
-    <li role="presentation" ng-repeat="tab in $ctrl.tabs" ng-class="{active: tab.name === $ctrl.tab}">
+  <ul role="tablist" class="nav nav-tabs">
+    <li role="tab" ng-repeat="tab in $ctrl.tabs" ng-class="{active: tab.name === $ctrl.tab}">
       <a href ng-click="$ctrl.tab = tab.name; $ctrl.searchAfformList = ''">
         <i class="crm-i {{ tab.icon }}"></i> {{:: tab.plural }}
         <span class="badge">{{ $ctrl.afforms[tab.name].length }}</span>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditorCanvas.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditorCanvas.html
@@ -27,14 +27,14 @@
       </div>
     </div>
 
-    <ul class="nav nav-tabs">
-      <li role="presentation" ng-class="{active: canvasTab === 'layout'}">
+    <ul role="tablist" class="nav nav-tabs">
+      <li role="tab" ng-class="{active: canvasTab === 'layout'}">
         <a href ng-click="canvasTab = 'layout'">
           <i class="crm-i fa-list-alt"></i>
           <span>{{:: ts('Form Layout') }}</span>
         </a>
       </li>
-      <li role="presentation" ng-class="{active: canvasTab === 'markup'}">
+      <li role="tab" ng-class="{active: canvasTab === 'markup'}">
         <a href ng-click="canvasTab = 'markup'; updateLayoutHtml()">
           <i class="crm-i fa-code"></i>
           <span>{{:: ts('Markup') }}</span>
@@ -43,10 +43,10 @@
     </ul>
 
   </div>
-  <div id="afGuiEditor-canvas-body" class="panel-body" ng-if="canvasTab === 'layout'">
+  <div id="afGuiEditor-canvas-body" role="tabpanel" class="panel-body" ng-if="canvasTab === 'layout'">
     <af-gui-container ng-if="editor.layout" node="editor.layout" entity-name="editor.blockEntity" data-entity="{{ editor.blockEntity }}" ></af-gui-container>
   </div>
-  <div class="panel-body" ng-if="canvasTab === 'markup'">
+  <div class="panel-body" role="tabpanel" ng-if="canvasTab === 'markup'">
     <p class="help-block">{{:: ts('This is a read-only preview of the auto-generated markup.') }}</p>
     <!-- Wiring up edit mode wouldn't be super-hard in itself, but it's not worthwhile until we have validation to ensure that GUI+raw content are exchangeable  -->
     <div crm-monaco="{readOnly: true}" ng-model="layoutHtml"></div>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditorPalette.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditorPalette.html
@@ -1,13 +1,13 @@
 <div id="afGuiEditor-palette-config" class="panel panel-default">
   <div class="panel-heading">
-    <ul id="afGuiEditor-palette-tabs" class="nav nav-tabs">
-      <li role="presentation" class="fluid-width-tab" ng-class="{active: selectedEntityName === null}" title="{{:: ts('Form Settings') }}">
+    <ul id="afGuiEditor-palette-tabs" role="tablist" class="nav nav-tabs">
+      <li role="tab" class="fluid-width-tab" ng-class="{active: selectedEntityName === null}" title="{{:: ts('Form Settings') }}">
         <a href ng-click="editor.selectEntity(null)">
           <i class="crm-i fa-gear"></i>
           <span>{{:: ts('Form Settings') }}</span>
         </a>
       </li>
-      <li role="presentation" ng-repeat="entity in entities" class="fluid-width-tab" ng-class="{active: selectedEntityName === entity.name}" title="{{ entity.label }}">
+      <li role="tab" ng-repeat="entity in entities" class="fluid-width-tab" ng-class="{active: selectedEntityName === entity.name}" title="{{ entity.label }}">
         <a href ng-click="editor.selectEntity(entity.name); editor.scrollToEntity(entity.name);">
           <i class="crm-i {{:: editor.getEntityDefn(entity).icon }}"></i>
           <span ng-if="!entity.loading && editor.allowEntityConfig && selectedEntityName === entity.name" crm-ui-editable ng-model="entity.label" ng-change="editor.adjustTabWidths()">{{ entity.label }}</span>
@@ -15,14 +15,14 @@
           <i ng-if="entity.loading" class="crm-i fa-spin fa-spinner"></i>
         </a>
       </li>
-      <li role="presentation" ng-repeat="(key, display) in editor.searchDisplays" class="fluid-width-tab" ng-class="{active: selectedEntityName === key}" title="{{ display.label }}">
+      <li role="tab" ng-repeat="(key, display) in editor.searchDisplays" class="fluid-width-tab" ng-class="{active: selectedEntityName === key}" title="{{ display.label }}">
         <a href ng-click="display.settings && editor.selectEntity(key)">
           <i ng-if="display.settings" class="crm-i {{:: display.settings['type:icon'] }}"></i>
           <i ng-if="!display.settings" class="crm-i fa-spin fa-spinner"></i>
           <span>{{ display.settings.label }}</span>
         </a>
       </li>
-      <li role="presentation" class="dropdown" ng-if="editor.allowEntityConfig" title="{{:: ts('Add Entity') }}" af-gui-menu>
+      <li role="tab" class="dropdown" ng-if="editor.allowEntityConfig" title="{{:: ts('Add Entity') }}" af-gui-menu>
         <a href class="dropdown-toggle" data-toggle="dropdown">
           <i class="crm-i fa-plus"></i>
         </a>
@@ -35,7 +35,7 @@
           </li>
         </ul>
       </li>
-      <li role="presentation" class="dropdown" ng-if="editor.getFormType() === 'search'" title="{{:: ts('Add Search') }}" af-gui-menu>
+      <li role="tab" class="dropdown" ng-if="editor.getFormType() === 'search'" title="{{:: ts('Add Search') }}" af-gui-menu>
         <a href class="dropdown-toggle" data-toggle="dropdown" ng-click="editor.getSearchDisplaySelector();">
           <i class="crm-i fa-plus"></i>
         </a>
@@ -55,11 +55,11 @@
       </li>
     </ul>
   </div>
-  <div class="panel-body" ng-include="'~/afGuiEditor/config-form.html'" ng-if="selectedEntityName === null"></div>
-  <div class="panel-body" ng-repeat="entity in entities" ng-if="selectedEntityName === entity.name">
+  <div class="panel-body" role="tabpanel" ng-include="'~/afGuiEditor/config-form.html'" ng-if="selectedEntityName === null"></div>
+  <div class="panel-body" role="tabpanel" ng-repeat="entity in entities" ng-if="selectedEntityName === entity.name">
     <af-gui-entity entity="entity"></af-gui-entity>
   </div>
-  <div class="panel-body" ng-repeat="(key, display) in editor.searchDisplays" ng-if="selectedEntityName === key">
+  <div class="panel-body" role="tabpanel" ng-repeat="(key, display) in editor.searchDisplays" ng-if="selectedEntityName === key">
     <af-gui-search display="display"></af-gui-search>
   </div>
 </div>

--- a/ext/message_admin/ang/crmMsgadm/ListNav.html
+++ b/ext/message_admin/ang/crmMsgadm/ListNav.html
@@ -1,11 +1,11 @@
 <nav class="bg-info">
-  <ul class="nav nav-tabs">
-    <li role="presentation"
+  <ul role="tablist" class="nav nav-tabs">
+    <li role="tab"
         ng-class="{active: location.path() === '/user'}"
         ng-if="checkPerm('edit message templates') || checkPerm('edit user-driven message templates')">
       <a ng-href="#/user">{{:: ts('User-Driven Messages') }}</a>
     </li>
-    <li role="presentation"
+    <li role="tab"
         ng-class="{active: location.path() === '/workflow'}"
         ng-if="checkPerm('edit message templates') || checkPerm('edit system workflow message templates')">
       <a ng-href="#/workflow">{{:: ts('System Workflow Messages' )}}</a>
@@ -15,12 +15,12 @@
 
 <div class="help">
 
-  <div ng-if="location.path() === '/user'">
+  <div role="tabpanel" ng-if="location.path() === '/user'">
     <span ng-bind-html="ts('Message templates allow you to easily create similar emails or letters on a recurring basis. Messages used for membership renewal reminders, as well as event and activity related reminders should be created via <a href=\'%1\'>Schedule Reminders</a>.', {1: crmUrl('civicrm/admin/scheduleReminders', 'reset=1')})"></span>
     <span ng-if="checkPerm('access CiviMail')" ng-bind-html="ts('You can also use message templates for CiviMail (bulk email) content. However, subscribe, unsubscribe and opt-out messages are configured at <a href=\'%1\'>Administer > CiviMail > Headers, Footers and Automated Messages</a>.', {1: crmUrl('civicrm/admin/component', 'reset=1')})"></span>
     <a crm-ui-help="hs({title:ts('User-Driven Messages'), id:'id-intro', file:'CRM/Admin/Page/MessageTemplates'})"></a>
   </div>
-  <div ng-if="location.path() === '/workflow'">
+  <div role="tabpanel" ng-if="location.path() === '/workflow'">
     {{ts('System workflow message templates are used to generate the emails sent to constituents and administrators for contribution receipts, event confirmations and many other workflows. You can customize the style and wording of these messages here.')}}
     <a crm-ui-help="hs({title:ts('System Workflow Messages'), id:'id-system-workflow', file:'CRM/Admin/Page/MessageTemplates'})"></a>
   </div>

--- a/ext/oauth-client/ang/oauthProviderDetail.aff.html
+++ b/ext/oauth-client/ang/oauthProviderDetail.aff.html
@@ -5,16 +5,16 @@
 <div ng-if="!theClients.loading">
   <div class="panel panel-info" ng-init="selected = {tab: theClients.result.length > 0 ? 'client_' + theClients.result[0].id : 'new'}">
     <ul class="panel-heading nav nav-tabs">
-      <li role="presentation" ng-repeat="theClient in theClients.result" ng-class="{active: selected.tab === 'client_' + theClient.id}"><a ng-click="selected.tab = 'client_' + theClient.id">{{ts('Client #%1', {1: theClient.id})}}</a></li>
-      <li role="presentation" ng-class="{active: selected.tab === 'new'}"><a ng-click="selected.tab = 'new'">{{ts('Register Client')}}</a></li>
-      <li role="presentation" ng-class="{active: selected.tab === 'details'}"><a ng-click="selected.tab = 'details'">{{ts('Details')}}</a></li>
+      <li role="tab" ng-repeat="theClient in theClients.result" ng-class="{active: selected.tab === 'client_' + theClient.id}"><a ng-click="selected.tab = 'client_' + theClient.id">{{ts('Client #%1', {1: theClient.id})}}</a></li>
+      <li role="tab" ng-class="{active: selected.tab === 'new'}"><a ng-click="selected.tab = 'new'">{{ts('Register Client')}}</a></li>
+      <li role="tab" ng-class="{active: selected.tab === 'details'}"><a ng-click="selected.tab = 'details'">{{ts('Details')}}</a></li>
     </ul>
 
-    <div class="panel-body" ng-if="selected.tab === 'details'">
+    <div role="tabpanel" class="panel-body" ng-if="selected.tab === 'details'">
       <pre>{{options.provider|json}}</pre>
     </div>
 
-    <div class="panel-body" ng-repeat="resultClient in theClients.result" ng-if="selected.tab === 'client_'+resultClient.id">
+    <div role="tabpanel" class="panel-body" ng-repeat="resultClient in theClients.result" ng-if="selected.tab === 'client_'+resultClient.id">
       <div ng-form="editClientForm">
         <h4>{{ts('Tokens')}}</h4>
 
@@ -39,7 +39,7 @@
       </div>
     </div>
 
-    <div class="panel-body" ng-if="selected.tab === 'new'" ng-form="newClientForm" ng-init="theNew = {provider: options.provider.name}">
+    <div role="tabpanel" class="panel-body" ng-if="selected.tab === 'new'" ng-form="newClientForm" ng-init="theNew = {provider: options.provider.name}">
       <oauth-client-create-help options="{provider: options.provider}"></oauth-client-create-help>
       <div crm-ui-debug="theNew"></div>
       <oauth-client-creator options="{client: theNew}"></oauth-client-creator>

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/searchList.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/searchList.html
@@ -3,14 +3,14 @@
 
   <!-- Tabs based on the has_base filter -->
   <div class="crm-search-nav-tabs">
-    <ul class="nav nav-tabs">
-      <li ng-repeat="tab in $ctrl.tabs" role="presentation" ng-class="{active: $ctrl.tab === tab.name}">
+    <ul role="tablist" class="nav nav-tabs">
+      <li ng-repeat="tab in $ctrl.tabs" role="tab" ng-class="{active: $ctrl.tab === tab.name}">
         <a href ng-click="$ctrl.tab = tab.name"><i class="crm-i {{:: tab.icon }}"></i>
           {{:: tab.title }}
           <span class="badge">{{ tab.rowCount }}</span>
         </a>
       </li>
-      <li ng-class="{active: $ctrl.tab === 'segment'}">
+      <li role="tab" ng-class="{active: $ctrl.tab === 'segment'}">
         <a href ng-click="$ctrl.tab = 'segment'"><i class="crm-i fa-object-group"></i>
           {{:: ts('Data Segmentation') }}
           <span class="badge">{{ $ctrl.searchSegmentCount }}</span>
@@ -59,7 +59,7 @@
     </div>
   </div>
 
-  <div ng-repeat="tab in $ctrl.tabs" ng-show="$ctrl.tab === tab.name">
+  <div role="tabpanel" ng-repeat="tab in $ctrl.tabs" ng-show="$ctrl.tab === tab.name">
     <div class="form-inline">
       <input class="form-control" type="search" ng-model="tab.filters.label" placeholder="{{:: ts('Filter by label...') }}">
       <input class="form-control" type="search" ng-if="tab.name === 'custom'" ng-model="tab.filters['created_id.display_name,modified_id.display_name']" placeholder="{{:: ts('Filter by author...') }}">

--- a/templates/CRM/Admin/Page/APIExplorer.tpl
+++ b/templates/CRM/Admin/Page/APIExplorer.tpl
@@ -225,16 +225,16 @@
 </div>
 <div class="crm-block crm-content-block">
 <div id="mainTabContainer">
-  <ul>
-    <li class="ui-corner-all" title="GUI to build and execute API calls">
+  <ul role="tablist">
+    <li role="tab" class="ui-corner-all" title="GUI to build and execute API calls">
       <a href="#explorer-tab"><i class="crm-i fa-search" aria-hidden="true"></i> {ts}Explorer{/ts}</a>
     </li>
-    <li class="ui-corner-all" title="API source-code and code-level documentation">
+    <li role="tab" class="ui-corner-all" title="API source-code and code-level documentation">
       <a href="#docs-tab"><i class="crm-i fa-code" aria-hidden="true"></i> {ts}Code Docs{/ts}</a>
     </li>
   </ul>
 
-  <div id="explorer-tab">
+  <div id="explorer-tab" role="tabpanel">
     <div class="crm-block crm-form-block">
     <form id="api-explorer">
       <label for="api-entity">{ts}Entity{/ts}:</label>
@@ -312,7 +312,7 @@
   </div>
   </div>
 
-  <div id="docs-tab">
+  <div id="docs-tab" role="tabpanel">
     <div class="crm-block crm-form-block">
     <form id="api-docs">
       <label for="doc-entity">{ts}Entity{/ts}:</label>

--- a/templates/CRM/Admin/Page/Extensions.tpl
+++ b/templates/CRM/Admin/Page/Extensions.tpl
@@ -28,14 +28,14 @@
     {include file="CRM/common/jsortable.tpl"}
 
     <div id="mainTabContainer" class="ui-tabs ui-widget ui-widget-content ui-corner-all">
-        <ul class="crm-extensions-tabs-list">
-            <li id="tab_summary" class="crm-tab-button">
+        <ul class="crm-extensions-tabs-list" role="tablist">
+            <li id="tab_summary" role="tab" class="crm-tab-button">
               <a href="#extensions-main" title="{ts escape='htmlattribute'}Extensions{/ts}">
               <span> </span> {ts}Extensions{/ts}
               <em>&nbsp;</em>
               </a>
             </li>
-            <li id="tab_addnew" class="crm-tab-button">
+            <li id="tab_addnew" role="tab" class="crm-tab-button">
               <a href="#extensions-addnew" title="{ts escape='htmlattribute'}Add New{/ts}">
               <span> </span> {ts}Add New{/ts}
               <em>&nbsp;</em>
@@ -43,10 +43,10 @@
             </li>
         </ul>
 
-        <div id="extensions-main" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
+        <div id="extensions-main" role="tabpanel" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
             {include file="CRM/Admin/Page/Extensions/Main.tpl"}
         </div>
-        <div id="extensions-addnew" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
+        <div id="extensions-addnew" role="tabpanel" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
             {if $extAddNewEnabled}
                 {if $extAddNewReqs}
                     {include file="CRM/Admin/Page/Extensions/AddNewReq.tpl"}

--- a/templates/CRM/Admin/Page/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Page/MessageTemplates.tpl
@@ -72,12 +72,12 @@
 {if $rows and $action ne 2 and $action ne 4}
 <div class="crm-content-block crm-block">
   <div id='mainTabContainer'>
-    <ul>
+    <ul role="tablist">
       {if $canEditUserDrivenMessageTemplates or $canEditMessageTemplates}
-        <li id='tab_user'><a href='#user' title='{ts escape='htmlattribute'}User-driven Messages{/ts}'>{ts}User-driven Messages{/ts}</a></li>
+        <li id='tab_user' role="tab"><a href='#user' title='{ts escape='htmlattribute'}User-driven Messages{/ts}'>{ts}User-driven Messages{/ts}</a></li>
       {/if}
       {if $canEditSystemTemplates or $canEditMessageTemplates}
-        <li id='tab_workflow'><a href='#workflow' title='{ts escape='htmlattribute'}System Workflow Messages{/ts}'>{ts}System Workflow Messages{/ts}</a></li>
+        <li id='tab_workflow' role="tab"><a href='#workflow' title='{ts escape='htmlattribute'}System Workflow Messages{/ts}'>{ts}System Workflow Messages{/ts}</a></li>
       {/if}
     </ul>
 
@@ -90,7 +90,7 @@
       ) or (
         $type eq 'userTemplates' && ($canEditUserDrivenMessageTemplates or $canEditMessageTemplates)
       )}
-      <div id="{if $type eq 'userTemplates'}user{else}workflow{/if}" class='ui-tabs-panel ui-widget-content ui-corner-bottom'>
+      <div id="{if $type eq 'userTemplates'}user{else}workflow{/if}" role="tabpanel" class='ui-tabs-panel ui-widget-content ui-corner-bottom'>
           <div class="help">
           {if $type eq 'userTemplates'}
             {capture assign=schedRemURL}{crmURL p='civicrm/admin/scheduleReminders' q="reset=1"}{/capture}

--- a/templates/CRM/Contribute/Page/DashBoard.tpl
+++ b/templates/CRM/Contribute/Page/DashBoard.tpl
@@ -44,10 +44,10 @@
 {crmRegion name="contribute-dashboard-summary"}
   <h3>{ts}Contribution Summary{/ts} {help id="id-contribute-intro"}</h3>
       <div id="mainTabContainer" class="ui-tabs ui-widget ui-widget-content ui-corner-all">
-        <ul class="ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all">
-           <li id="chart_view"   class="crm-tab-button ui-state-active ui-corner-top ui-corner-bottom ui-tabs-selected" >
+        <ul role="tablist" class="ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all">
+           <li role="tab" id="chart_view"   class="crm-tab-button ui-state-active ui-corner-top ui-corner-bottom ui-tabs-selected" >
              <a href="#chart_layout"><span>&nbsp;</span>&nbsp;{ts}Chart Layout{/ts}&nbsp;</a> </li>&nbsp;
-           <li id ="table_view"  class="crm-tab-button ui-corner-top ui-corner-bottom ui-state-default" >
+           <li role="tab" id ="table_view"  class="crm-tab-button ui-corner-top ui-corner-bottom ui-state-default" >
              <a href="#table_layout"><span>&nbsp;</span>&nbsp;{ts}Table Layout{/ts}&nbsp;</a>
            </li>
 {if $isAdmin}

--- a/templates/CRM/Report/Form/Fields.tpl
+++ b/templates/CRM/Report/Form/Fields.tpl
@@ -12,20 +12,20 @@
     <div class="crm-report-criteria"> {* criteria section starts *}
       <div id="mainTabContainer">
         {*tab navigation bar*}
-        <ul>
+        <ul role="tablist">
           {foreach from=$tabs item='tab'}
-            <li class="ui-corner-all">
+            <li class="ui-corner-all" role="tab">
               <a title="{$tab.title|escape}" href="#report-tab-{$tab.div_label}">{$tab.title}</a>
             </li>
           {/foreach}
           {if !empty($instanceForm) OR !empty($instanceFormError)}
-            <li id="tab_settings" class="ui-corner-all">
+            <li id="tab_settings" class="ui-corner-all" role="tab">
               <a title="{ts escape='htmlattribute'}Title and Format{/ts}" href="#report-tab-format">{ts}Title and Format{/ts}</a>
             </li>
-            <li class="ui-corner-all">
+            <li class="ui-corner-all" role="tab">
               <a title="{ts escape='htmlattribute'}Email Delivery{/ts}" href="#report-tab-email">{ts}Email Delivery{/ts}</a>
             </li>
-            <li class="ui-corner-all">
+            <li class="ui-corner-all" role="tab">
               <a title="{ts escape='htmlattribute'}Access{/ts}" href="#report-tab-access">{ts}Access{/ts}</a>
             </li>
           {/if}

--- a/templates/CRM/Report/Form/Tabs/Developer.tpl
+++ b/templates/CRM/Report/Form/Tabs/Developer.tpl
@@ -1,4 +1,4 @@
-<div id="report-tab-set-developer" class="civireport-criteria">
+<div id="report-tab-set-developer" role="tabpanel" class="civireport-criteria">
   <p><b>{ts}Class used{/ts}: {$report_class|escape}</b></p>
   <p>{ts}SQL Modes{/ts}:
   {foreach from=$sqlModes item=sqlMode}

--- a/templates/CRM/Report/Form/Tabs/FieldSelection.tpl
+++ b/templates/CRM/Report/Form/Tabs/FieldSelection.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 
-  <div id="report-tab-col-groups" class="civireport-criteria">
+  <div id="report-tab-col-groups" role="tabpanel" class="civireport-criteria">
     {foreach from=$colGroups item=grpFields key=dnc}
       {assign  var="count" value=0}
       {* Wrap custom field sets in collapsed accordion pane. *}

--- a/templates/CRM/Report/Form/Tabs/Filters.tpl
+++ b/templates/CRM/Report/Form/Tabs/Filters.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 
-<div id="report-tab-set-filters" class="civireport-criteria">
+<div id="report-tab-set-filters" role="tabpanel" class="civireport-criteria">
   <div class="report-layout">
       {assign var="counter" value=1}
       {foreach from=$filterGroups item=filterGroup}

--- a/templates/CRM/Report/Form/Tabs/GroupBy.tpl
+++ b/templates/CRM/Report/Form/Tabs/GroupBy.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-  <div id="report-tab-group-by-elements" class="civireport-criteria">
+  <div id="report-tab-group-by-elements" role="tabpanel" class="civireport-criteria">
     {assign  var="count" value=0}
     <table class="report-layout">
       <tr class="crm-report crm-report-criteria-groupby">

--- a/templates/CRM/Report/Form/Tabs/Instance.tpl
+++ b/templates/CRM/Report/Form/Tabs/Instance.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-<div id="report-tab-format" class="civireport-criteria">
+<div id="report-tab-format" class="civireport-criteria" role="tabpanel">
   <table class="form-layout">
     <tr class="crm-report-instanceForm-form-block-title">
       <td class="report-label" width="20%">{$form.title.label} {help id="id-report_title" file="CRM/Report/Form/Tabs/Settings.hlp"}</td>
@@ -28,7 +28,7 @@
   </table>
 </div>
 
-<div id="report-tab-email" class="civireport-criteria">
+<div id="report-tab-email" class="civireport-criteria" role="tabpanel">
   <h3 class="email-delivery-settings-title">{ts}Email Delivery Settings{/ts} {help id="id-email_settings" file="CRM/Report/Form/Tabs/Settings.hlp"}</h3>
   <table class="form-layout email-delivery-settings-fields">
     <tr class="crm-report-instanceForm-form-block-email_subject">
@@ -46,7 +46,7 @@
   </table>
 </div>
 
-<div id="report-tab-access" class="civireport-criteria">
+<div id="report-tab-access" class="civireport-criteria" role="tabpanel">
   <table class="form-layout">
     <tr class="crm-report-instanceForm-form-block-is_navigation">
       <td class="report-label">{$form.is_navigation.label}</td>

--- a/templates/CRM/Report/Form/Tabs/OrderBy.tpl
+++ b/templates/CRM/Report/Form/Tabs/OrderBy.tpl
@@ -9,7 +9,7 @@
 *}
 
 
-  <div id="report-tab-order-by-elements" class="civireport-criteria">
+  <div id="report-tab-order-by-elements" role="tabpanel" class="civireport-criteria">
     <table id="optionField">
       <tr>
         <th>&nbsp;</th>

--- a/templates/CRM/Report/Form/Tabs/ReportOptions.tpl
+++ b/templates/CRM/Report/Form/Tabs/ReportOptions.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {if $otherOptions}
-  <div id="report-tab-other-options" class="civireport-criteria">
+  <div id="report-tab-other-options" role="tabpanel" class="civireport-criteria">
     <table class="report-layout">
       {assign var="optionCount" value=0}
       <tr class="crm-report crm-report-criteria-field">

--- a/templates/CRM/Tag/Page/Tag.tpl
+++ b/templates/CRM/Tag/Page/Tag.tpl
@@ -18,22 +18,22 @@
   </div>
 
   <div id="mainTabContainer">
-    <ul>
-      <li class="ui-corner-all crm-tab-button" title="{ts escape='htmlattribute'}Main Tag List{/ts}">
+    <ul role="tablist">
+      <li role="tab" class="ui-corner-all crm-tab-button" title="{ts escape='htmlattribute'}Main Tag List{/ts}">
         <a href="#tree"><i class="crm-i fa-tags" aria-hidden="true"></i> {ts}Tag Tree{/ts}</a>
       </li>
       {foreach from=$tagsets item=set}
-        <li class="ui-corner-all crm-tab-button {if ($set.is_reserved)}is-reserved{/if}" title="{ts escape='htmlattribute' 1=$set.used_for_label_str}Tag Set for %1{/ts}">
+        <li role="tab" class="ui-corner-all crm-tab-button {if ($set.is_reserved)}is-reserved{/if}" title="{ts escape='htmlattribute' 1=$set.used_for_label_str}Tag Set for %1{/ts}">
           <a href="#tagset-{$set.id}">{$set.label}</a>
         </li>
       {/foreach}
       {crmPermission has='administer Tagsets'}
-        <li class="ui-corner-all crm-tab-button" title="{ts escape='htmlattribute'}Add Tag Set{/ts}">
+        <li role="tab" class="ui-corner-all crm-tab-button" title="{ts escape='htmlattribute'}Add Tag Set{/ts}">
           <a href="#new-tagset"><i class="crm-i fa-plus" aria-hidden="true"></i></a>
         </li>
       {/crmPermission}
     </ul>
-    <div id="tree">
+    <div id="tree" role="tabpanel">
       <div class="help">
         {ts}Organize the tag hierarchy by clicking and dragging. Shift-click to select multiple tags to merge/move/delete.{/ts}
       </div>
@@ -41,10 +41,10 @@
       <a class="crm-hover-button crm-clear-link" style="visibility:hidden;" title="{ts escape='htmlattribute'}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
     </div>
     {foreach from=$tagsets item=set}
-      <div id="tagset-{$set.id}">
+      <div id="tagset-{$set.id}" role="tabpanel">
       </div>
     {/foreach}
-    <div id="new-tagset">
+    <div id="new-tagset" role="tabpanel">
     </div>
   </div>
 </div>

--- a/templates/CRM/UF/Page/Group.tpl
+++ b/templates/CRM/UF/Page/Group.tpl
@@ -43,15 +43,19 @@
     {/if}
     {if $rows}
       <div id='mainTabContainer'>
-        <ul>
-          <li id='tab_user-profiles'>    <a href='#user-profiles'     title='{ts escape='htmlattribute'}User-defined Profile{/ts}'>{ts}User-defined Profiles{/ts}</a></li>
-          <li id='tab_reserved-profiles'><a href='#reserved-profiles' title='{ts escape='htmlattribute'}Reserved Profiles{/ts}'>{ts}Reserved Profiles{/ts}</a></li>
+        <ul role="tablist">
+          <li id='tab_user-profiles' role="tab">
+            <a href='#user-profiles' title='{ts escape='htmlattribute'}User-defined Profile{/ts}'>{ts}User-defined Profiles{/ts}</a>
+          </li>
+          <li id='tab_reserved-profiles' role="tab">
+            <a href='#reserved-profiles' title='{ts escape='htmlattribute'}Reserved Profiles{/ts}'>{ts}Reserved Profiles{/ts}</a>
+          </li>
         </ul>
 
         {* handle enable/disable actions*}
         {include file="CRM/common/enableDisableApi.tpl"}
         {include file="CRM/common/jsortable.tpl"}
-        <div id="user-profiles">
+        <div id="user-profiles" role="tabpanel">
           <div class="crm-content-block">
             <table class="display">
               <thead>
@@ -96,7 +100,7 @@
           </div>
         </div>{* user profile*}
 
-        <div id="reserved-profiles">
+        <div id="reserved-profiles" role="tabpanel">
           <div class="crm-content-block">
             <table class="display">
               <thead>

--- a/templates/CRM/common/TabHeader.tpl
+++ b/templates/CRM/common/TabHeader.tpl
@@ -11,9 +11,9 @@
 <div class="crm-block crm-content-block {$containerClasses|default:''}">
   {if $tabHeader}
     <div id="mainTabContainer">
-      <ul class="{$listClasses|default:''}">
+      <ul class="{$listClasses|default:''}" role="tablist">
         {foreach from=$tabHeader key=tabName item=tabValue}
-          <li id="tab_{$tabName}" class="crm-tab-button ui-corner-all {if !$tabValue.valid}disabled{/if} {if is_numeric($tabValue.count)}crm-count-{$tabValue.count}{/if} {if $tabValue.class} {$tabValue.class}{/if}" {$tabValue.extra}>
+          <li id="tab_{$tabName}" role="tab" class="crm-tab-button ui-corner-all {if !$tabValue.valid}disabled{/if} {if is_numeric($tabValue.count)}crm-count-{$tabValue.count}{/if} {if $tabValue.class} {$tabValue.class}{/if}" {$tabValue.extra}>
             {if $tabValue.active}
               <a href="{if $tabValue.template}#{$tabIdPrefix|default:'panel_'}{$tabName}{else}{$tabValue.url|smarty:nodefaults}{/if}" title="{$tabValue.title|escape} {if !$tabValue.valid}({ts escape='htmlattribute'}disabled{/ts}){/if}">
                 <i class="{$tabValue.icon|default:'crm-i fa-puzzle-piece'}" aria-hidden="true"></i>
@@ -29,7 +29,7 @@
 
       {foreach from=$tabHeader key=tabName item=tabValue}
         {if $tabValue.template}
-          <div id="{$tabIdPrefix|default:'panel_'}{$tabName}">
+          <div id="{$tabIdPrefix|default:'panel_'}{$tabName}" role="tabpanel">
             {if $tabValue.module}
               <!-- afform tab - need to pass module and directive to afform param -->
               {include file=$tabValue.template afform=$tabValue}


### PR DESCRIPTION
Overview
----------------------------------------
Adds accessibility tags to our tab markup.

Technical Details
----------------------------------------
Adds role=tablist to the ul, role=tab to the li, and role=tabpanel to the panel.
See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role#example