### PR TITLE
RiverLea 1.3.4: 3 Thames & 1 core fix, ref MR #49

### DIFF
--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.3.4-6.0alpha
+ - FIXED - Responsive: add wrap to Contact Form Contact Name inline edit (thanks Artful Robot)
+ - CHANGED - Thames, A11y: darkened default blue.
+ - CHANGED - Thames, tweaks (removes redundant css, adds box-shadow on part of contact dashboard)
+ - CHANGED - Thames, improves QuickSearch appearance
+
 1.3.3-6.0alpha
  - FIXED - FrontEnd: restored padding on alert boxes
  - FIXED - FrontEnd: front-end-compressed table display form
@@ -7,7 +13,7 @@
  - CHANGED - FrontEnd: Added an 800px default width, similar to Greenwich, which impacts Minetta and Walbrook (forms are no longer 100% width).
  - FIXED - Select lists match width of content
  - FIXED - Select list padding on front-end doesn't hide selected value
- - FIXED - Select list inline alignment for descriiption
+ - FIXED - Select list inline alignment for description
  - FIXED - Dark mode for alpha list Contrast Ratio across all streams, plus extra fixes in Walbrook and Thames.
  - FIXED - AFGuiEditor - button group wrapping
  - FIXED - alignment of buttons above some SearchKit table displays corrected
@@ -46,7 +52,7 @@
  - ADDED provisional support for SearchKit Tree Display.
  - FIXED wrong text colour on footer status label.
  - FIXED image on contact dashboard can overlap multiple tags: https://lab.civicrm.org/extensions/riverlea/-/issues/99.
- - CHANAGED Minetta colours for Contrast Ratio WCAG AAA: success, danger & info alert bg & text;
+ - CHANGED Minetta colours for Contrast Ratio WCAG AAA: success, danger & info alert bg & text;
  - CHANGED Minetta DarkMode colours for Contrast Ratio WCAG AAA: alerts, backgrounds, input description, border, tabs.
  - CHANGED Walbrook colours for Contrast Ratio WCAG AAA: darker text, lighter success & warning button bg, lighter danger alert bg, darker link + hover, alert-status
  - CHANGED Walbrook DarkMode colours for Contrast Ratio WCAG AAA: brighter links, darker column rows, wizard, buttons, bg regions, alerts, accordions, heading bg color

--- a/ext/riverlea/core/css/_core.css
+++ b/ext/riverlea/core/css/_core.css
@@ -4,5 +4,5 @@
    can be merged later. */
 
 @import url(components/_accordion.css); @import url(components/_alerts.css); @import url(components/_buttons.css); @import url(components/_form.css); @import url(components/_icons.css); @import url(components/_nav.css); @import url(components/_tabs.css); @import url(components/_dropdowns.css); @import url(components/_tables.css); @import url(components/_dialogs.css); @import url(components/_page.css); @import url(components/_components.css); @import url(components/_front.css); :root {
-  --crm-release: '1.3.3-6.0.alpha';
+  --crm-release: '1.3.4-6.0.alpha';
 }

--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -130,6 +130,7 @@
   white-space: nowrap;
   padding: var(--crm-dash-block-padding);
   display: flex;
+  flex-wrap: wrap;
   color: var(--crm-c-text);
   background-color: var(--crm-inline-edit-bg);
 }

--- a/ext/riverlea/info.xml
+++ b/ext/riverlea/info.xml
@@ -12,7 +12,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>[civicrm.releaseDate]</releaseDate>
-  <version>1.3.3-[civicrm.version]</version>
+  <version>1.3.4-[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>

--- a/ext/riverlea/streams/thames/css/_variables.css
+++ b/ext/riverlea/streams/thames/css/_variables.css
@@ -41,9 +41,8 @@
   --crm-c-blue-overlay: #dce9ef; /* thames only */
   --crm-c-blue-light: #d8edfe; /* thames */
   --crm-c-blue: #c5e4fc; /* thames */
-/* non-WCAG-AA --crm-c-blue-dark:     #2c98ed ; /* thames */
-  --crm-c-blue-dark: #127aca; /* thames */
-  --crm-c-blue-darker: #02477d; /* thames */
+  --crm-c-blue-dark: #0d5790; /* thames. nb #127aca not AAA on #f8f8f8  */
+  --crm-c-blue-darker: #033b67; /* thames */
   --crm-c-purple: #4d4d69;
   --crm-c-purple-dark: #3e3e54;
   --crm-c-green: #d6e9c6;

--- a/ext/riverlea/streams/thames/css/civicrm.css
+++ b/ext/riverlea/streams/thames/css/civicrm.css
@@ -28,14 +28,6 @@ html.cms-standalone body {
   background-color: var(--crm-c-blue-overlay2);
 }
 
-/* RL introduces a border on focus which causes layout shift
- * https://lab.civicrm.org/extensions/riverlea/-/issues/49
- */
-.crm-container :focus,
-.crm-container .ui-dialog :focus {
-  border: none;
-}
-
 /* Replace Riverlea's FontAwesome icon with our own shape. */
 /* This rule is really sensitive to specificity. */
 /* .crm-container :where(details, .crm-accordion-wrapper)>:is(summary,.crm-accordion-header)::before {  */
@@ -250,6 +242,10 @@ html.cms-standalone body {
 
 .crm-contact-page #mainTabContainer .ui-tabs-nav li .ui-tabs-anchor .crm-i:first-child {
   justify-self: center;
+}
+
+.crm-summary-contactname-block:not(.crm-edit-ready) #crm-contactname-content {
+  box-shadow: 0 0 50px rgba(0, 0, 0, 0.2);
 }
 
 /* make count badges more readable */
@@ -636,3 +632,19 @@ html.crm-standalone  nav.breadcrumb>ol {
 .contactCardRight:has(#crm-contact-thumbnail) .float-left {
   width: calc(100% - var(--crm-flex-gap) - var(--crm-dash-image-size));
 }
+
+/* Quicksearch */
+ul.crm-quickSearch-results a {
+  padding: 0.25rem 1rem;
+  text-decoration: none;
+  color: var(--crm-c-link);
+}
+ul.crm-quickSearch-results .ui-state-active a /* mouse,keyboard nav */ {
+  background: var(--crm-c-blue);
+  color: var(--crm-c-link-hover);
+}
+ul.crm-quickSearch-results a:active {
+  background: white;
+}
+
+

--- a/ext/riverlea/streams/thames/css/civicrm.css
+++ b/ext/riverlea/streams/thames/css/civicrm.css
@@ -646,5 +646,3 @@ ul.crm-quickSearch-results .ui-state-active a /* mouse,keyboard nav */ {
 ul.crm-quickSearch-results a:active {
   background: white;
 }
-
-


### PR DESCRIPTION
Resolves the issues raised in this MR - https://lab.civicrm.org/extensions/riverlea/-/merge_requests/49 - and ups the version number. Corrects some typos in the Changelog.

Overview
----------------------------------------
  - FIXED - Responsive: add wrap to Contact Form Contact Name inline edit (thanks Artful Robot)
 - CHANGED - Thames, A11y: darkened default blue - commit by @artfulrobot 
 - CHANGED - Thames, tweaks (removes redundant css, adds box-shadow on part of contact dashboard) - commit by @artfulrobot 
 - CHANGED - Thames, improves QuickSearch appearance - commit by @artfulrobot 

Before
----------------------------------------
Contact Form Contact Name inline edit doesn't wrap at smaller sizes on any screens.

<img width="1106" alt="image" src="https://github.com/user-attachments/assets/30a1d424-c4ce-4641-b162-00535a3ef9db" />

Link colours in Thames aren't WCAG AAA.

After
----------------------------------------
<img width="1104" alt="image" src="https://github.com/user-attachments/assets/f233223a-6fc4-42b4-907d-9b4c912c70b6" />

![image](https://github.com/user-attachments/assets/044253c1-a384-471a-8492-81ac7bf012f6)

Thames link colours are WCAG AAA.

Technical Details
----------------------------------------
Impacts Thames, plus the inline contact name edit layout on the contact layout dashboard on smaller viewports on all Streams.