### PR TITLE
Break variable assignment into 2 rows

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1888,7 +1888,8 @@ abstract class CRM_Import_Parser implements UserJobInterface {
         continue;
       }
       if ($mappedField['name']) {
-        $params[$this->getFieldMetadata($mappedField['name'])['name']] = $this->getTransformedFieldValue($mappedField['name'], $values[$i]);
+        $fieldSpec = $this->getFieldMetadata($mappedField['name']);
+        $params[$fieldSpec['name']] = $this->getTransformedFieldValue($mappedField['name'], $values[$i]);
       }
     }
     return $params;


### PR DESCRIPTION
This is partly cos it is a shortly line, but also because this reduces the follow on patch cognitive load, which will look again at the fieldSpec

