### PR TITLE
Minor test cleanup on setUp & tearDown

### DIFF
--- a/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
@@ -56,13 +56,6 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
   protected $relationshipTypeID;
 
   /**
-   * Membership type id used in test function.
-   *
-   * @var int
-   */
-  protected $membershipStatusID;
-
-  /**
    * Set up for test.
    *
    * @throws \CRM_Core_Exception
@@ -78,7 +71,6 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
     ];
     $this->relationshipTypeID = $this->relationshipTypeCreate($params);
     $organizationContactID = $this->organizationCreate();
-    $this->restoreMembershipTypes();
     $params = [
       'name' => self::MEMBERSHIP_TYPE_NAME,
       'description' => NULL,
@@ -98,22 +90,15 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
     $membershipType = CRM_Member_BAO_MembershipType::add($params);
     $this->membershipTypeID = (int) $membershipType->id;
 
-    $this->membershipStatusID = $this->membershipStatusCreate('test status');
+    $this->membershipStatusCreate('test status');
   }
 
   /**
    * Tears down the fixture, for example, closes a network connection.
    * This method is called after a test is executed.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function tearDown(): void {
     $tablesToTruncate = [
-      'civicrm_membership',
-      'civicrm_membership_log',
-      'civicrm_contribution',
-      'civicrm_membership_payment',
-      'civicrm_contact',
       'civicrm_email',
       'civicrm_user_job',
       'civicrm_queue',
@@ -121,7 +106,8 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
     ];
     $this->relationshipTypeDelete($this->relationshipTypeID);
     $this->membershipTypeDelete(['id' => $this->membershipTypeID]);
-    $this->membershipStatusDelete($this->membershipStatusID);
+    $this->quickCleanUpFinancialEntities();
+    $this->restoreMembershipTypes();
     $this->quickCleanup($tablesToTruncate, TRUE);
     parent::tearDown();
   }
@@ -260,7 +246,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
       'General',
       date('Y-m-d'),
       1,
-      $this->membershipStatusID,
+      $this->ids['MembershipStatus']['test status'],
       'abc',
     ];
     try {

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -766,17 +766,16 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
    *
    * @return int
    */
-  public function membershipStatusCreate($name = 'test member status'): int {
+  public function membershipStatusCreate(string $name = 'test member status'): int {
     $params['name'] = $name;
     $params['start_event'] = 'start_date';
     $params['end_event'] = 'end_date';
-    $params['is_current_member'] = 1;
+    $params['is_current_member'] = TRUE;
     $params['is_active'] = 1;
     // Make sure weight is after existing statuses (could be cleverer and get max(weight) first).
     $params['weight'] = 100;
 
-    $result = $this->callAPISuccess('MembershipStatus', 'Create', $params);
-    CRM_Member_PseudoConstant::flush('membershipStatus');
+    $result = $this->createTestEntity('MembershipStatus', $params, $name);
     return (int) $result['id'];
   }
 

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -231,33 +231,6 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test membership get.
-   */
-  public function testContactMembershipsGet(): void {
-    $membershipID = $this->contactMembershipCreate($this->_params);
-    $this->callAPISuccess('Membership', 'get');
-    $this->callAPISuccess('Membership', 'Delete', ['id' => $membershipID]);
-  }
-
-  /**
-   * Test civicrm_membership_get with params not array.
-   *
-   * Gets treated as contact_id, memberships expected.
-   */
-  public function testGetWithParamsContactId(): void {
-    $this->_membershipID = $this->contactMembershipCreate($this->_params);
-    $params = [
-      'contact_id' => $this->_contactID,
-      'return' => array_keys($this->_params),
-    ];
-    $membership = $this->callAPISuccess('membership', 'get', $params);
-
-    $result = $membership['values'][$this->_membershipID];
-    $this->validateGetResult($result);
-    $this->assertEquals(1, $result['is_override']);
-  }
-
-  /**
    * Test civicrm_membership_get with params not array.
    *
    * Gets treated as contact_id, memberships expected.
@@ -304,23 +277,6 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $membership = $this->callAPISuccess('membership', 'get', $params);
     $this->assertEquals(1, $membership['count']);
     $this->assertEquals([$this->_membershipID2], array_keys($membership['values']));
-  }
-
-  /**
-   * Test civicrm_membership_get with params not array.
-   *
-   * Gets treated as contact_id, memberships expected.
-   */
-  public function testGetWithParamsMemberShipTypeId(): void {
-    $this->callAPISuccess('Membership', 'create', $this->_params);
-    $params = [
-      'membership_type_id' => 'General',
-      'return' => array_keys($this->_params),
-    ];
-    $membership = $this->callAPISuccess('membership', 'get', $params);
-    $result = $membership['values'][$membership['id']];
-    $this->validateGetResult($result);
-    $this->assertEquals(1, $result['is_override']);
   }
 
   /**
@@ -384,7 +340,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $this->assertEquals('2009-01-21', $result['join_date']);
     $this->assertEquals($result['contact_id'], $this->_contactID);
     $this->assertEquals($result['membership_type_id'], $this->getMembershipTypeID('General'));
-    $this->assertEquals($result['status_id'], $this->ids['MembershipStatus']['test']);
+    $this->assertEquals($result['status_id'], $this->ids['MembershipStatus']['test member status']);
 
     $this->assertEquals('2009-01-21', $result['start_date']);
     $this->assertEquals('2009-12-21', $result['end_date']);
@@ -438,69 +394,6 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $membership = $this->callAPISuccess('membership', 'get', $params);
     $this->assertEquals($membership['values'][$this->_membershipID]['status_id'], $this->_membershipStatusID);
     $this->assertEquals($membership['values'][$this->_membershipID]['contact_id'], $this->_contactID);
-  }
-
-  /**
-   * Test civicrm_membership_get with relationship.
-   * get Memberships.
-   */
-  public function testGetWithRelationship(): void {
-    $membershipOrgId = $this->organizationCreate();
-    $memberContactId = $this->individualCreate();
-
-    $relTypeParams = [
-      'name_a_b' => 'Relation 1',
-      'name_b_a' => 'Relation 2',
-      'description' => 'Testing relationship type',
-      'contact_type_a' => 'Organization',
-      'contact_type_b' => 'Individual',
-      'is_reserved' => 1,
-      'is_active' => 1,
-    ];
-    $relTypeID = $this->relationshipTypeCreate($relTypeParams);
-
-    $params = [
-      'name' => 'test General',
-      'duration_unit' => 'year',
-      'duration_interval' => 1,
-      'period_type' => 'rolling',
-      'member_of_contact_id' => $membershipOrgId,
-      'domain_id' => 1,
-      'financial_type_id' => 1,
-      'relationship_type_id' => $relTypeID,
-      'relationship_direction' => 'b_a',
-      'is_active' => 1,
-    ];
-    $memType = $this->callAPISuccess('membership_type', 'create', $params);
-
-    $params = [
-      'contact_id' => $memberContactId,
-      'membership_type_id' => $memType['id'],
-      'join_date' => '2009-01-21',
-      'start_date' => '2009-01-21',
-      'end_date' => '2009-12-21',
-      'source' => 'Payment',
-      'is_override' => 1,
-      'status_id' => $this->_membershipStatusID,
-    ];
-    $membershipID = $this->contactMembershipCreate($params);
-
-    $params = [
-      'contact_id' => $memberContactId,
-      'membership_type_id' => $memType['id'],
-    ];
-
-    $result = $this->callAPISuccess('membership', 'get', $params);
-
-    $membership = $result['values'][$membershipID];
-    $this->assertEquals($this->ids['MembershipStatus']['test'], $membership['status_id']);
-    $this->callAPISuccess('Membership', 'Delete', [
-      'id' => $membership['id'],
-    ]);
-    $this->membershipTypeDelete(['id' => $memType['id']]);
-    $this->relationshipTypeDelete($relTypeID);
-    $this->contactDelete($membershipOrgId);
-    $this->contactDelete($memberContactId);
   }
 
   /**

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -44,7 +44,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
   public function setUp(): void {
     parent::setUp();
     $this->_contactID = $this->individualCreate();
-    $this->_membershipTypeID = $this->membershipTypeCreate(['member_of_contact_id' => $this->_contactID]);
+    $this->_membershipTypeID = $this->membershipTypeCreate(['member_of_contact_id' => $this->ids['Contact']['individual_0']]);
     $this->_membershipTypeID2 = $this->membershipTypeCreate([
       'period_type' => 'fixed',
        // Ie. 1 March.
@@ -53,20 +53,18 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       'fixed_period_rollover_day' => '1111',
       'name' => 'Another one',
     ]);
-    $this->_membershipStatusID = $this->membershipStatusCreate('test status');
-
-    CRM_Member_PseudoConstant::membershipStatus(NULL, NULL, 'name', TRUE);
+    $this->_membershipStatusID = $this->membershipStatusCreate();
 
     $this->_entity = 'Membership';
     $this->_params = [
-      'contact_id' => $this->_contactID,
+      'contact_id' => $this->ids['Contact']['individual_0'],
       'membership_type_id' => 'General',
       'join_date' => '2009-01-21',
       'start_date' => '2009-01-21',
       'end_date' => '2009-12-21',
       'source' => 'Payment',
       'is_override' => 1,
-      'status_id' => $this->_membershipStatusID,
+      'status_id' => $this->ids['MembershipStatus']['test member status'],
     ];
   }
 
@@ -236,9 +234,9 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
    * Test membership get.
    */
   public function testContactMembershipsGet(): void {
-    $this->_membershipID = $this->contactMembershipCreate($this->_params);
-    $this->callAPISuccess('membership', 'get', []);
-    $this->callAPISuccess('Membership', 'Delete', ['id' => $this->_membershipID]);
+    $membershipID = $this->contactMembershipCreate($this->_params);
+    $this->callAPISuccess('Membership', 'get');
+    $this->callAPISuccess('Membership', 'Delete', ['id' => $membershipID]);
   }
 
   /**
@@ -255,13 +253,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $membership = $this->callAPISuccess('membership', 'get', $params);
 
     $result = $membership['values'][$this->_membershipID];
-    $this->assertEquals($result['contact_id'], $this->_contactID);
-    $this->assertEquals($this->getMembershipTypeID('General'), $result['membership_type_id']);
-    $this->assertEquals($result['status_id'], $this->_membershipStatusID);
-    $this->assertEquals($result['join_date'], '2009-01-21');
-    $this->assertEquals($result['start_date'], '2009-01-21');
-    $this->assertEquals($result['end_date'], '2009-12-21');
-    $this->assertEquals($result['source'], 'Payment');
+    $this->validateGetResult($result);
     $this->assertEquals(1, $result['is_override']);
   }
 
@@ -320,22 +312,15 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
    * Gets treated as contact_id, memberships expected.
    */
   public function testGetWithParamsMemberShipTypeId(): void {
-    $this->callAPISuccess($this->_entity, 'create', $this->_params);
+    $this->callAPISuccess('Membership', 'create', $this->_params);
     $params = [
       'membership_type_id' => 'General',
       'return' => array_keys($this->_params),
     ];
     $membership = $this->callAPISuccess('membership', 'get', $params);
     $result = $membership['values'][$membership['id']];
-    $this->assertEquals($result['contact_id'], $this->_contactID);
-    $this->assertEquals($this->getMembershipTypeID('General'), $result['membership_type_id']);
-    $this->assertEquals($result['status_id'], $this->_membershipStatusID);
-    $this->assertEquals($result['join_date'], '2009-01-21');
-    $this->assertEquals($result['start_date'], '2009-01-21');
-    $this->assertEquals($result['end_date'], '2009-12-21');
-    $this->assertEquals($result['source'], 'Payment');
-    $this->assertEquals($result['is_override'], 1);
-    $this->assertEquals($result['id'], $membership['id']);
+    $this->validateGetResult($result);
+    $this->assertEquals(1, $result['is_override']);
   }
 
   /**
@@ -344,9 +329,9 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
    */
   public function testGetWithParamsMemberShipTypeIdContactID(): void {
     $params = $this->_params;
-    $this->callAPISuccess($this->_entity, 'create', $params);
+    $this->callAPISuccess('Membership', 'create', $params);
     $params['membership_type_id'] = $this->_membershipTypeID2;
-    $this->callAPISuccess($this->_entity, 'create', $params);
+    $this->callAPISuccess('Membership', 'create', $params);
     $this->callAPISuccessGetCount('membership', ['contact_id' => $this->_contactID], 2);
     $params = [
       'membership_type_id' => $this->_membershipTypeID,
@@ -399,12 +384,12 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $this->assertEquals('2009-01-21', $result['join_date']);
     $this->assertEquals($result['contact_id'], $this->_contactID);
     $this->assertEquals($result['membership_type_id'], $this->getMembershipTypeID('General'));
-    $this->assertEquals($result['status_id'], $this->_membershipStatusID);
+    $this->assertEquals($result['status_id'], $this->ids['MembershipStatus']['test']);
 
-    $this->assertEquals($result['start_date'], '2009-01-21');
-    $this->assertEquals($result['end_date'], '2009-12-21');
-    $this->assertEquals($result['source'], 'Payment');
-    $this->assertEquals($result['is_override'], 1);
+    $this->assertEquals('2009-01-21', $result['start_date']);
+    $this->assertEquals('2009-12-21', $result['end_date']);
+    $this->assertEquals('Payment', $result['source']);
+    $this->assertEquals(1, $result['is_override']);
   }
 
   /**
@@ -453,28 +438,11 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $membership = $this->callAPISuccess('membership', 'get', $params);
     $this->assertEquals($membership['values'][$this->_membershipID]['status_id'], $this->_membershipStatusID);
     $this->assertEquals($membership['values'][$this->_membershipID]['contact_id'], $this->_contactID);
-
-    $this->callAPISuccess('Membership', 'Delete', ['id' => $this->_membershipID]);
-  }
-
-  /**
-   * Test civicrm_membership_get for non exist contact.
-   * empty Memberships.
-   */
-  public function testGetNoContactExists(): void {
-    $params = [
-      'contact_id' => 55555,
-    ];
-
-    $membership = $this->callAPISuccess('membership', 'get', $params);
-    $this->assertEquals($membership['count'], 0);
   }
 
   /**
    * Test civicrm_membership_get with relationship.
    * get Memberships.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testGetWithRelationship(): void {
     $membershipOrgId = $this->organizationCreate();
@@ -525,7 +493,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess('membership', 'get', $params);
 
     $membership = $result['values'][$membershipID];
-    $this->assertEquals($this->_membershipStatusID, $membership['status_id']);
+    $this->assertEquals($this->ids['MembershipStatus']['test'], $membership['status_id']);
     $this->callAPISuccess('Membership', 'Delete', [
       'id' => $membership['id'],
     ]);
@@ -916,12 +884,12 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
 
     // Create a new membership, but don't assign anything to the custom field.
-    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
+    $this->callAPISuccess('Membership', 'create', $this->_params);
 
     // search memberships with CRM-16036 as custom field value.
     // Since we did not touch the custom field of any membership,
     // this should not return any results.
-    $check = $this->callAPISuccess($this->_entity, 'get', [
+    $check = $this->callAPISuccess('Membership', 'get', [
       'custom_' . $ids['custom_field_id'] => 'CRM-16036',
     ]);
     $this->assertEquals(0, $check['count']);
@@ -1662,6 +1630,21 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $this->assertEquals('Another one', array_pop($options['values']));
     $this->assertEquals('General', array_pop($options['values']));
     $this->assertEquals(NULL, array_pop($options['values']));
+  }
+
+  /**
+   * @param array $result
+   *
+   * @return void
+   */
+  public function validateGetResult(array $result): void {
+    $this->assertEquals($result['contact_id'], $this->_contactID);
+    $this->assertEquals($this->getMembershipTypeID('General'), $result['membership_type_id']);
+    $this->assertEquals($result['status_id'], $this->ids['MembershipStatus']['test']);
+    $this->assertEquals('2009-01-21', $result['join_date']);
+    $this->assertEquals('2009-01-21', $result['start_date']);
+    $this->assertEquals('2009-12-21', $result['end_date']);
+    $this->assertEquals('Payment', $result['source']);
   }
 
 }


### PR DESCRIPTION
I also dumped a few `get` tests that don't really add any value - right back in apiv2 there were 2 apis that were merged & eventually standardised in apiv3 so the tests were relevant in that transition but just duplicate many others now