### PR TITLE
Import code consolidation, membership import

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -176,18 +176,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
     return $this->removeEmptyValues($params);
   }
 
-  protected function removeEmptyValues($array) {
-    foreach ($array as $key => $value) {
-      if (is_array($value)) {
-        $array[$key] = $this->removeEmptyValues($value);
-      }
-      elseif ($value === '') {
-        unset($array[$key]);
-      }
-    }
-    return $array;
-  }
-
   /**
    * Validate the import values.
    *

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -80,6 +80,15 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   protected $siteDefaultCountry = NULL;
 
   /**
+   * Has this parser been fixed to expect `getMappedRow` to break it up
+   * by entity yet? This is a transitional property to allow the classes
+   * to be fixed up individually.
+   *
+   * @var bool
+   */
+  protected $isUpdatedForEntityRowParsing = FALSE;
+
+  /**
    * @return int|null
    */
   public function getUserJobID(): ?int {
@@ -1893,7 +1902,23 @@ abstract class CRM_Import_Parser implements UserJobInterface {
       }
       if ($mappedField['name']) {
         $fieldSpec = $this->getFieldMetadata($mappedField['name']);
-        $params[$fieldSpec['name']] = $this->getTransformedFieldValue($mappedField['name'], $values[$i]);
+
+        $entity = $fieldSpec['entity_instance'] ?? $fieldSpec['entity'] ?? $fieldSpec['extends'] ?? NULL;
+        if ($this->isUpdatedForEntityRowParsing && $entity) {
+          // Split values into arrays by entity.
+          if (!isset($params[$entity])) {
+            $params[$entity] = [];
+            if ($entity === 'Contact') {
+              $params[$entity]['contact_type'] = $this->getContactTypeForEntity($entity) ?: $this->getContactType();
+            }
+          }
+          // Apiv4 name is currently only set for contact, & only in cases where it would
+          // be used for the dedupe rule (ie Membership import).
+          $params[$entity][$fieldSpec['apiv4_name'] ?? $fieldSpec['name']] = $this->getTransformedFieldValue($mappedField['name'], $values[$i]);
+        }
+        else {
+          $params[$fieldSpec['name']] = $this->getTransformedFieldValue($mappedField['name'], $values[$i]);
+        }
       }
     }
     return $params;

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -2402,4 +2402,16 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     }
   }
 
+  protected function removeEmptyValues($array) {
+    foreach ($array as $key => $value) {
+      if (is_array($value)) {
+        $array[$key] = $this->removeEmptyValues($value);
+      }
+      elseif ($value === '') {
+        unset($array[$key]);
+      }
+    }
+    return $array;
+  }
+
 }

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -121,6 +121,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
     $rowNumber = (int) ($values[array_key_last($values)]);
     try {
       $params = $this->getMappedRow($values);
+      $this->removeEmptyValues($params);
       if (!empty($params['contact_id'])) {
         $this->validateContactID($params['contact_id'], $this->getContactType());
       }
@@ -134,15 +135,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
       // don't add to recent items, CRM-4399
       $formatted['skipRecentView'] = TRUE;
 
-      $formatValues = [];
-      foreach ($params as $key => $field) {
-        // ignore empty values or empty arrays etc
-        if (CRM_Utils_System::isNull($field)) {
-          continue;
-        }
-
-        $formatValues[$key] = $field;
-      }
+      $formatValues = $params;
 
       if (!$this->isUpdateExisting()) {
         $formatted['custom'] = CRM_Core_BAO_CustomField::postProcess($formatted,


### PR DESCRIPTION
Overview
----------------------------------------
Import code consolidation, membership import

The code in the Contribution import uses api v4 and uses metadata to separate the values into various entities. The other imports do some of this - with various approaches, using a lot of old code. This updates the Membership import such that when it calls `getMappedRow()` the values returned are split by entity

Before
----------------------------------------
`getMappedRow()` returns an array like

```
[
  'external_identifier' => '123',
  'membership_type_id' => 'General',
  'join_date' => '2024-07-09',
]
```

After
----------------------------------------
`getMappedRow()` returns an array like

```
[
  'Contact' => [
    'external_identifier' => '123',
  ],
  'Membership' => [
    'membership_type_id' => 'General',
    'join_date' => '2024-07-09',
  ],
]
```

Technical Details
----------------------------------------
Note that by virtue of the only rule being supported being the reserved IndividualSupervisedRule - email is the only additional field supported

Comments
----------------------------------------
also fix  for 
![image](https://github.com/user-attachments/assets/129333ac-788b-4f71-9916-ff39c6923a2a)

