### PR TITLE
release notes update - add info that was in master but not 5.82

### DIFF
--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -112,6 +112,7 @@
 
 - github      : AnwenW
   name        : Anwen Williams
+  organization: BrightMinded Ltd
 
 - github      : amsharma9
   name        : Amal Sharma

--- a/release-notes/5.82.0.md
+++ b/release-notes/5.82.0.md
@@ -491,13 +491,13 @@ Released February 5, 2025;
 
 This release was developed by the following code authors:
 
-AGH Strategies - Alice Frumin; Anwen Williams; Benjamin W; Ben Mango;
-BrightMinded Ltd - Bradley Taylor; CiviCoop - Jaap Jansma; CiviCRM - Coleman
-Watts, Tim Otten; Compuco - Olayiwola Odunsi; Coop SymbioTIC - Mathieu Lutfy,
-Shane Bill; Dave D; DevApp - David Cativo; JMA Consulting - Seamus Lee;
-Megaphone Technology Consulting - Jon Goldberg; MJW Consulting - Matthew Wire;
-Nicol Wistreich; PERORA SRL - Samuele Masetto; Tadpole Collective - Kevin
-Cristiano; Wikimedia Foundation - Eileen McNaughton
+AGH Strategies - Alice Frumin; BrightMinded Ltd - Anwen Williams; Benjamin W;
+Ben Mango; BrightMinded Ltd - Bradley Taylor; CiviCoop - Jaap Jansma;
+CiviCRM - Coleman Watts, Tim Otten; Compuco - Olayiwola Odunsi;
+Coop SymbioTIC - Mathieu Lutfy, Shane Bill; Dave D; DevApp - David Cativo;
+JMA Consulting - Seamus Lee; Megaphone Technology Consulting - Jon Goldberg;
+MJW Consulting - Matthew Wire; Nicol Wistreich; PERORA SRL - Samuele Masetto;
+Tadpole Collective - Kevin Cristiano; Wikimedia Foundation - Eileen McNaughton
 
 Most authors also reviewed code for this release; in addition, the following
 reviewers contributed their comments:


### PR DESCRIPTION
Overview
----------------------------------------
Because of the timing the contributor-key update https://github.com/civicrm/civicrm-core/pull/31743 was merged into master for something that was in 5.82, so this name is now in the master version twice, but is here in 5.82 without org info.

This adds the org info into 5.82 and then probably easiest to remove the duplicate separately in master after.