### PR TITLE
Fix mail settings page to use metadata

### DIFF
--- a/CRM/Admin/Form/Preferences/Mailing.php
+++ b/CRM/Admin/Form/Preferences/Mailing.php
@@ -20,26 +20,6 @@
  */
 class CRM_Admin_Form_Preferences_Mailing extends CRM_Admin_Form_Preferences {
 
-  protected $_settings = [
-    'profile_double_optin' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
-    'no_reply_email_address' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
-    'profile_add_to_group_double_optin' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
-    'track_civimail_replies' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
-    'civimail_workflow' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
-    'civimail_multiple_bulk_emails' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
-    'civimail_server_wide_lock' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
-    'include_message_id' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
-    'write_activity_record' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
-    'disable_mandatory_tokens_check' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
-    'dedupe_email_default' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
-    'hash_mailing_url' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
-    'auto_recipient_rebuild' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
-    'url_tracking_default' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
-    'open_tracking_default' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
-    'scheduled_reminder_smarty' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
-    'smtp_450_is_permanent' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
-  ];
-
   public function postProcess() {
     $params = $this->controller->exportValues($this->_name);
 

--- a/settings/Mailing.setting.php
+++ b/settings/Mailing.setting.php
@@ -34,6 +34,7 @@ return [
     'is_contact' => 0,
     'description' => ts('When CiviMail is enabled, users who "subscribe" to a group from a profile Group(s) checkbox will receive a confirmation email. They must respond (opt-in) before they are added to the group.'),
     'help_text' => NULL,
+    'settings_pages' => ['mailing' => ['weight' => 10]],
   ],
   'no_reply_email_address' => [
     'group_name' => 'Mailing Preferences',
@@ -50,6 +51,7 @@ return [
     'description' => '',
     'help_text' => NULL,
     'help' => ['id' => 'no_reply_email_address'],
+    'settings_pages' => ['mailing' => ['weight' => 20]],
   ],
   'track_civimail_replies' => [
     'group_name' => 'Mailing Preferences',
@@ -65,6 +67,7 @@ return [
     'description' => ts('If checked, mailings will default to tracking replies using VERP-ed Reply-To.'),
     'help_text' => NULL,
     'validate_callback' => 'CRM_Core_BAO_Setting::validateBoolSetting',
+    'settings_pages' => ['mailing' => ['weight' => 30]],
   ],
   'civimail_workflow' => [
     'group_name' => 'Mailing Preferences',
@@ -79,6 +82,7 @@ return [
     'is_contact' => 0,
     'description' => ts('Drupal-only. Rules module must be enabled (beta feature - use with caution).'),
     'help_text' => NULL,
+    'settings_pages' => ['mailing' => ['weight' => 40]],
   ],
   'civimail_server_wide_lock' => [
     'group_name' => 'Mailing Preferences',
@@ -92,6 +96,7 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'help_text' => NULL,
+    'settings_pages' => ['mailing' => ['weight' => 60]],
   ],
   'civimail_unsubscribe_methods' => [
     'group_name' => 'Mailing Preferences',
@@ -171,6 +176,7 @@ return [
     'is_contact' => 0,
     'description' => ts('Don\'t check for presence of mandatory tokens (domain address; unsubscribe/opt-out) before sending mailings. WARNING: Mandatory tokens are a safe-guard which facilitate compliance with the US CAN-SPAM Act. They should only be disabled if your organization adopts other mechanisms for compliance or if your organization is not subject to CAN-SPAM.'),
     'help_text' => NULL,
+    'settings_pages' => ['mailing' => ['weight' => 90]],
   ],
   'dedupe_email_default' => [
     'group_name' => 'Mailing Preferences',
@@ -185,6 +191,7 @@ return [
     'is_contact' => 0,
     'description' => ts('Set the "dedupe e-mail" option when sending a new mailing to "true" by default.'),
     'help_text' => NULL,
+    'settings_pages' => ['mailing' => ['weight' => 100]],
   ],
   'hash_mailing_url' => [
     'group_name' => 'Mailing Preferences',
@@ -199,6 +206,7 @@ return [
     'is_contact' => 0,
     'description' => ts('If enabled, a randomized hash key will be used to reference the mailing URL in the mailing.viewUrl token, instead of the mailing ID.'),
     'help_text' => NULL,
+    'settings_pages' => ['mailing' => ['weight' => 110]],
   ],
   'civimail_multiple_bulk_emails' => [
     'group_name' => 'Mailing Preferences',
@@ -213,6 +221,7 @@ return [
     'is_contact' => 0,
     'description' => ts('CiviMail will deliver a copy of the email to each bulk email listed for the contact. Enabling this setting will also change the options for the "Email on Hold" field in Advanced Search.'),
     'help_text' => NULL,
+    'settings_pages' => ['mailing' => ['weight' => 60]],
   ],
   'include_message_id' => [
     'group_name' => 'Mailing Preferences',
@@ -226,6 +235,7 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'help_text' => NULL,
+    'settings_pages' => ['mailing' => ['weight' => 70]],
   ],
   'mailerBatchLimit' => [
     'group_name' => 'Mailing Preferences',
@@ -340,6 +350,7 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'help_text' => NULL,
+    'settings_pages' => ['mailing' => ['weight' => 80]],
   ],
   'simple_mail_limit' => [
     'group_name' => 'Mailing Preferences',
@@ -374,6 +385,7 @@ return [
     'description' => ts('Enable this setting to rebuild recipient list automatically during composing mail. Disable will allow you to rebuild recipient manually.'),
     'help_text' => ts('CiviMail automatically fetches recipient list and count whenever mailing groups are included or excluded while composing bulk mail. This phenomena may degrade performance for large sites, so disable this setting to build and fetch recipients for selected groups, manually.'),
     'add' => '4.7.30',
+    'settings_pages' => ['mailing' => ['weight' => 120]],
   ],
   'allow_mail_from_logged_in_contact' => [
     'group_name' => 'Mailing Preferences',
@@ -403,6 +415,7 @@ return [
     'description' => ts('If checked, mailings will have click-through tracking enabled by default.'),
     'help_text' => NULL,
     'add' => '5.27.0',
+    'settings_pages' => ['mailing' => ['weight' => 130]],
   ],
   'open_tracking_default' => [
     'group_name' => 'Mailing Preferences',
@@ -418,6 +431,7 @@ return [
     'description' => ts('If checked, mailings will have open tracking enabled by default.'),
     'help_text' => NULL,
     'add' => '5.27.0',
+    'settings_pages' => ['mailing' => ['weight' => 140]],
   ],
   // dev/cor#1768 Allow mailer sync interval to be configured by the
   // adminstrator.
@@ -454,6 +468,7 @@ return [
     'is_contact' => 0,
     'description' => ts('Controls whether scheduled reminders will attempt to process smarty tokens.'),
     'help_text' => NULL,
+    'settings_pages' => ['mailing' => ['weight' => 150]],
   ],
   'smtp_450_is_permanent' => [
     'group_name' => 'Mailing Preferences',
@@ -470,5 +485,6 @@ return [
     'description' => ts('Consider domains that will not resolve (SMTP Error 450 - class 4.1.2 "Domain not found") as permanent failures.'),
     'help_text' => NULL,
     'help' => ['id' => 'smtp_450_is_permanent'],
+    'settings_pages' => ['mailing' => ['weight' => 160]],
   ],
 ];


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the Mailing preferences page to use metadata after a setting was recently added to it & I realised there was no warning not to do that on the preferences pages (only the settings pages - which are the same but the parent class is different - don't ask).

There is no change (not even a notice fix) in the output. Before & after screen shots should show no change

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/95a73d88-178d-4dbe-8198-e90f7c3fe951)

![image](https://github.com/user-attachments/assets/aae0f649-d7ec-4863-a00f-fc2ed00daacc)


After
----------------------------------------
![image](https://github.com/user-attachments/assets/278c90bd-a46a-46eb-9a84-21b4489bc1b3)
![image](https://github.com/user-attachments/assets/54c0ded3-7fe1-4fed-8ff6-8fdb6f689c2e)


Technical Details
----------------------------------------

Comments
----------------------------------------

