### PR TITLE
dev/core#5717 Ensure  `getProfiles()` always returns an array

### DIFF
--- a/CRM/Core/WorkflowMessage/ProfileTrait.php
+++ b/CRM/Core/WorkflowMessage/ProfileTrait.php
@@ -132,7 +132,7 @@ trait CRM_Core_WorkflowMessage_ProfileTrait {
         }
       }
     }
-    return $this->profiles;
+    return $this->profiles ?: [];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5717 Ensure  `getProfiles()` always returns an array

Before
----------------------------------------
Per the logged issue this function sometimes returns NULL - in conflict with the type hint. Reading the code, this would occur if there is no `eventID()` - which is presumably abnormal - or when the event has no profiles - possible? Either way if the type hint is an array it should return an array 

After
----------------------------------------
returns an array

Technical Details
----------------------------------------
I didn't set the property when empty in case there is some load order issue - fixing the return seemed safer

Comments
----------------------------------------
