### PR TITLE
standaloneusers: support translation on the login screen

### DIFF
--- a/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
@@ -14,12 +14,13 @@ class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
       // add the session message and redirect so the user doesn't keep getting
       // the message when they press Back.
       CRM_Core_Session::setStatus(
-        ts('You have been logged out.'),
-        ts('Successfully signed out.'),
+        E::ts('You have been logged out.'),
+        E::ts('Successfully signed out.'),
         'success');
       CRM_Utils_System::redirect('/civicrm/login');
     }
 
+    CRM_Utils_System::setTitle(E::ts('Log In'));
     $this->assign('logoUrl', E::url('images/civicrm-logo.png'));
     $this->assign('pageTitle', '');
     $this->assign('forgottenPasswordURL', CRM_Utils_System::url('civicrm/login/password'));

--- a/ext/standaloneusers/ang/crmResetPassword/crmResetPassword.html
+++ b/ext/standaloneusers/ang/crmResetPassword/crmResetPassword.html
@@ -3,7 +3,9 @@
   <form name="requestLink" crm-ui-id-scope
     ng-if="!$ctrl.formSubmitted && !$ctrl.token">
 
-    <h1>{{:: ts('Request Password Reset Link')}}</h1>
+    <h1>{{:: ts('Reset Password')}}</h1>
+
+    <p>{{:: ts('You will receive an email with instructions on how to reset your password.')}}</p>
 
     <div class="input-wrapper">
       <label crm-ui-for="identifier">{{:: ts('Enter the username or email on your account')}}</label>

--- a/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
+++ b/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
@@ -1,20 +1,21 @@
+{crmScope extensionKey="standaloneusers"}
 <div class="standalone-auth-form">
   <div class="standalone-auth-box">
     <form id=login-form>
-      <img class="crm-logo" src="{$logoUrl}" alt="logo for CiviCRM, with an intersecting blue and green triangle">
+      <img class="crm-logo" src="{$logoUrl}" alt="{ts escape='htmlattribute'}Logo for CiviCRM, with an intersecting blue and green triangle{/ts}">
       {$statusMessages}
       <div class="input-wrapper">
-        <label for="usernameInput" name=username class="form-label">Username</label>
+        <label for="usernameInput" name=username class="form-label">{ts}Username{/ts}</label>
         <input type="text" class="form-control crm-form-text" id="usernameInput" >
       </div>
       <div class="input-wrapper">
-        <label for="passwordInput" class="form-label">Password</label>
+        <label for="passwordInput" class="form-label">{ts}Password{/ts}</label>
         <input type="password" class="form-control crm-form-text" id="passwordInput">
       </div>
-      <div id="error" style="display:none;" class="form-alert">Your username and password do not match</div>
+      <div id="error" style="display:none;" class="form-alert">{ts}Your username and password do not match{/ts}</div>
       <div class="login-or-forgot">
-        <a href="{$forgottenPasswordURL}">Forgotten password?</a>
-        <button id="loginSubmit" type="submit" class="btn btn-primary crm-button">Submit</button>
+        <a href="{$forgottenPasswordURL}">{ts}Forgotten password?{/ts}</a>
+        <button id="loginSubmit" type="submit" class="btn btn-primary crm-button">{ts}Log In{/ts}</button>
       </div>
     </form>
   </div>
@@ -31,7 +32,7 @@
     form.addEventListener('submit', async e => {
       e.preventDefault();
 
-      let errorMsg = 'Unexpected error';
+      let errorMsg = '{/literal}{ts escape="js"}Unexpected error{/ts}{literal}';
       try {
         let originalUrl = location.href;
         const response = await CRM.api4('User', 'login', {
@@ -43,7 +44,7 @@
           window.location = response.url;
           return;
         }
-        errorMsg = response.publicError || "Unexpected error";
+        errorMsg = response.publicError || "{/literal}{ts escape="js"}Unexpected error{/ts}{literal}";
       }
       catch (e) {
         console.error('caught', e);
@@ -53,3 +54,4 @@
   });
 </script>
 {/literal}
+{/crmScope}

--- a/ext/standaloneusers/xml/Menu/standaloneusers.xml
+++ b/ext/standaloneusers/xml/Menu/standaloneusers.xml
@@ -3,7 +3,7 @@
   <item>
     <path>civicrm/login</path>
     <page_callback>CRM_Standaloneusers_Page_Login</page_callback>
-    <title>Login</title>
+    <title>Log In</title>
     <access_arguments>*always allow*</access_arguments>
   </item>
   <item>


### PR DESCRIPTION
Overview
----------------------------------------

Add translation support on the login screen for CiviCRM (standalone).

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/948c6cc0-d354-4848-baf7-5049d9d376a9)

![image](https://github.com/user-attachments/assets/ef18bf23-56b4-4a3f-b188-8ae3ac05016f)

After
----------------------------------------

![image](https://github.com/user-attachments/assets/dab3f365-b919-4c79-94de-e2c4854ec77d)

![image](https://github.com/user-attachments/assets/8c83f5be-5e3b-42d6-b9b6-2e960222a4bf)

(updated screenshot based on comments)

Technical Details
----------------------------------------

Requires the `standaloneusers.mo` file, which does not exist. I will add it to Transifex once this PR is merged.

Comments
----------------------------------------

- I renamed the "Submit" to "Log In", same as WordPress
- Also renamed the page title (and had to user `setTitle` because it's how Smarty page titles are translated)
- spent way too much time (10 mins) reading on the differences between "Login" and "Log In". One is a noun (your login), and the other is a verb (you are going to log in). https://www.reddit.com/r/webdev/comments/aml4hb/login_vs_log_in_are_we_using_these_wrong/
- Also tweaked the title of the Password Reset, because it felt a bit intense, and it will not translate well (it will be very long).

cc @artfulrobot @ufundo @jaapjansma 