### PR TITLE
RiverLea 1.3.5: Contact dashboard inline edit - fixes lab/#107 - and delete icon colour.

### DIFF
--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.3.5-6.0alpha
+ - ADDED - padding to contact dashboard inline edit div (#107)
+ - FIXED - Contact Layout Editor extension: double padding; broken right float (#107)
+ - FIXED - Contact dashboard inline edit responsive handling.
+ - CHANGED - Contact dashboard inline edit - add sidebar link width to positioning to keep inline
+ - CHANGED - Moved Contact Layout Editor extension CSS from fixes.css into ContactSummary.css to reduce when it's being loaded.
+ - FIXED - Delete icon on delete buttons inherits the button text colour not the delete icon colour.
+
 1.3.4-6.0alpha
  - FIXED - Responsive: add wrap to Contact Form Contact Name inline edit (thanks Artful Robot)
  - CHANGED - Thames, A11y: darkened default blue.

--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -3,7 +3,6 @@
  - FIXED - Contact Layout Editor extension: double padding; broken right float (#107)
  - FIXED - Contact dashboard inline edit responsive handling.
  - CHANGED - Contact dashboard inline edit - add sidebar link width to positioning to keep inline
- - CHANGED - Moved Contact Layout Editor extension CSS from fixes.css into ContactSummary.css to reduce when it's being loaded.
  - FIXED - Delete icon on delete buttons inherits the button text colour not the delete icon colour.
 
 1.3.4-6.0alpha

--- a/ext/riverlea/core/css/_core.css
+++ b/ext/riverlea/core/css/_core.css
@@ -4,5 +4,5 @@
    can be merged later. */
 
 @import url(components/_accordion.css); @import url(components/_alerts.css); @import url(components/_buttons.css); @import url(components/_form.css); @import url(components/_icons.css); @import url(components/_nav.css); @import url(components/_tabs.css); @import url(components/_dropdowns.css); @import url(components/_tables.css); @import url(components/_dialogs.css); @import url(components/_page.css); @import url(components/_components.css); @import url(components/_front.css); :root {
-  --crm-release: '1.3.4-6.0.alpha';
+  --crm-release: '1.3.5-6.0.alpha';
 }

--- a/ext/riverlea/core/css/_fixes.css
+++ b/ext/riverlea/core/css/_fixes.css
@@ -787,36 +787,6 @@ details + .crm-content-block:has(.dataTables_wrapper) {
     COMMON EXTENSIONS
 *******************/
 
-/* Contact Dashboard Editor */
-
-.crm-actions-ribbon ul#actions:has(.crm-contact-summary-edit-layout) {
-  grid-template-columns: min-content min-content min-content auto min-content min-content;
-}
-.crm-container .crm-contact-summary-edit-layout a.crm-hover-button {
-  background: var(--crm-c-primary);
-  color: var(--crm-c-primary-text) !important;
-  padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline) var(--crm-btn-padding-block) 0;
-  border: var(--crm-btn-border);
-}
-.crm-container .crm-contact-summary-edit-layout a.crm-hover-button i.crm-i {
-  padding: 0 var(--crm-btn-icon-spacing) 0 var(--crm-btn-padding-inline);
-}
-.crm-container .crm-contact-summary-edit-layout a.crm-hover-button:hover,
-.crm-container .crm-contact-summary-edit-layout a.crm-hover-button:focus {
-  background: var(--crm-c-primary-hover);
-  color: var(--crm-c-primary-text) !important;
-  padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline) var(--crm-btn-padding-block) 0;
-}
-.crm-previous-action {
-  order: 3;
-}
-.crm-next-action {
-  order: 4;
-}
-#contactLayoutEditor .panel-heading .btn {
-  padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline);
-}
-
 /* Mosaico (all importants vs the extension css) */
 
 .crm-mosaico-wizard .crm_wizard__title .panel-body {

--- a/ext/riverlea/core/css/_fixes.css
+++ b/ext/riverlea/core/css/_fixes.css
@@ -787,6 +787,40 @@ details + .crm-content-block:has(.dataTables_wrapper) {
     COMMON EXTENSIONS
 *******************/
 
+/* Style rules for Contact Layout Editor extension */
+
+#contact-summary .crm-contact-summary-layout-col {
+  flex: 1 1 250px;
+  padding: 0;
+}
+.crm-actions-ribbon ul#actions:has(.crm-contact-summary-edit-layout) {
+  grid-template-columns: min-content min-content min-content auto min-content min-content;
+}
+.crm-container .crm-contact-summary-edit-layout a.crm-hover-button {
+  background: var(--crm-c-primary);
+  color: var(--crm-c-primary-text) !important;
+  padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline) var(--crm-btn-padding-block) 0;
+  border: var(--crm-btn-border);
+}
+.crm-container .crm-contact-summary-edit-layout a.crm-hover-button i.crm-i {
+  padding: 0 var(--crm-btn-icon-spacing) 0 var(--crm-btn-padding-inline);
+}
+.crm-container .crm-contact-summary-edit-layout a.crm-hover-button:hover,
+.crm-container .crm-contact-summary-edit-layout a.crm-hover-button:focus {
+  background: var(--crm-c-primary-hover);
+  color: var(--crm-c-primary-text) !important;
+  padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline) var(--crm-btn-padding-block) 0;
+}
+.crm-previous-action {
+  order: 3;
+}
+.crm-next-action {
+  order: 4;
+}
+#contactLayoutEditor .panel-heading .btn {
+  padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline);
+}
+
 /* Mosaico (all importants vs the extension css) */
 
 .crm-mosaico-wizard .crm_wizard__title .panel-body {

--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -213,6 +213,9 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
   background-image: none;
   color: var(--crm-alert-text-danger);
 }
+.crm-container .delete-button > .delete-icon {
+  color: inherit;
+}
 .crm-container .delete-icon::before,
 .crm-container .crm-i.fa-trash::before {
   content: "\f1f8";

--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -61,12 +61,12 @@
   width: fit-content;
   z-index: 99;
   position: absolute;
-  left: 0;
+  left: calc(var(--crm-dash-panel-padding) + var(--crm-side-tabs-width));
 }
-#mainTabContainer:not(.narrowpage) .contactCardRight div.crm-inline-edit.form {
-  right: 0;
+.crm-contact-summary-layout-col-2 .crm-inline-edit.form, /* CLE */
+.contactCardRight .crm-inline-edit.form {
+  right: var(--crm-dash-panel-padding);
   left: initial;
-  position: absolute;
 }
 .crm-container .crm-inline-edit.add-new {
   min-height: 2.5em;
@@ -385,10 +385,19 @@ div.crm-summary-contactname-block + .crm-actions-ribbon {
   .crm-container div.contact_panel {
     display: block;
   }
+  .crm-container .contact_panel.crm-contact-summary-layout-row {
+    flex-direction: column;
+  }
+  .crm-contact-summary-layout-col-2 .crm-inline-edit.form,
+  .contactCardRight .crm-inline-edit.form {
+    right: inherit;
+    left: calc(var(--crm-dash-panel-padding) + var(--crm-side-tabs-width));
+  }
 }
 @media (max-width: 767px) {
   #crm-main-content-wrapper {
     --crm-dash-heading-inset: 0; /* resets any inset on the title/action links */
+    --crm-side-tabs-width: auto; /* resets offset inline edit */
   }
   .crm-container #mainTabContainer,
   .crm-container div.crm-summary-row {
@@ -414,4 +423,38 @@ div.crm-summary-contactname-block + .crm-actions-ribbon {
   .crm-container #mainTabContainer .ui-tabs-nav li .ui-tabs-anchor i {
     font-size: var(--crm-font-size);
   }
+}
+
+/* Style rules for Contact Layout Editor extension */
+
+#contact-summary .crm-contact-summary-layout-col {
+  flex: 1 1 250px;
+  padding: 0;
+}
+.crm-actions-ribbon ul#actions:has(.crm-contact-summary-edit-layout) {
+  grid-template-columns: min-content min-content min-content auto min-content min-content;
+}
+.crm-container .crm-contact-summary-edit-layout a.crm-hover-button {
+  background: var(--crm-c-primary);
+  color: var(--crm-c-primary-text) !important;
+  padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline) var(--crm-btn-padding-block) 0;
+  border: var(--crm-btn-border);
+}
+.crm-container .crm-contact-summary-edit-layout a.crm-hover-button i.crm-i {
+  padding: 0 var(--crm-btn-icon-spacing) 0 var(--crm-btn-padding-inline);
+}
+.crm-container .crm-contact-summary-edit-layout a.crm-hover-button:hover,
+.crm-container .crm-contact-summary-edit-layout a.crm-hover-button:focus {
+  background: var(--crm-c-primary-hover);
+  color: var(--crm-c-primary-text) !important;
+  padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline) var(--crm-btn-padding-block) 0;
+}
+.crm-previous-action {
+  order: 3;
+}
+.crm-next-action {
+  order: 4;
+}
+#contactLayoutEditor .panel-heading .btn {
+  padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline);
 }

--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -424,37 +424,3 @@ div.crm-summary-contactname-block + .crm-actions-ribbon {
     font-size: var(--crm-font-size);
   }
 }
-
-/* Style rules for Contact Layout Editor extension */
-
-#contact-summary .crm-contact-summary-layout-col {
-  flex: 1 1 250px;
-  padding: 0;
-}
-.crm-actions-ribbon ul#actions:has(.crm-contact-summary-edit-layout) {
-  grid-template-columns: min-content min-content min-content auto min-content min-content;
-}
-.crm-container .crm-contact-summary-edit-layout a.crm-hover-button {
-  background: var(--crm-c-primary);
-  color: var(--crm-c-primary-text) !important;
-  padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline) var(--crm-btn-padding-block) 0;
-  border: var(--crm-btn-border);
-}
-.crm-container .crm-contact-summary-edit-layout a.crm-hover-button i.crm-i {
-  padding: 0 var(--crm-btn-icon-spacing) 0 var(--crm-btn-padding-inline);
-}
-.crm-container .crm-contact-summary-edit-layout a.crm-hover-button:hover,
-.crm-container .crm-contact-summary-edit-layout a.crm-hover-button:focus {
-  background: var(--crm-c-primary-hover);
-  color: var(--crm-c-primary-text) !important;
-  padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline) var(--crm-btn-padding-block) 0;
-}
-.crm-previous-action {
-  order: 3;
-}
-.crm-next-action {
-  order: 4;
-}
-#contactLayoutEditor .panel-heading .btn {
-  padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline);
-}

--- a/ext/riverlea/info.xml
+++ b/ext/riverlea/info.xml
@@ -12,7 +12,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>[civicrm.releaseDate]</releaseDate>
-  <version>1.3.4-[civicrm.version]</version>
+  <version>1.3.5-[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>


### PR DESCRIPTION
Overview
----------------------------------------
Inline edit on the contact dashboard floats left or right depending if it's the left or right column. The right column was broken when a custom layout with Contact Layout Editor was used. In edition, the inset on the inline edit form was `0` which isn't as neat as alignment with the box that's being edited. Both these points are described here: https://lab.civicrm.org/extensions/riverlea/-/issues/107 by @colemanw.

In addition, for themes with side tabs on the contact dashboard the left column alignment overlayed the tabs. This update offsets the left column by the padding for the dashboard, plus the width of sidetabs if they exist. Furthermore, for smaller (< 768px) screen where the tabs collapse to just their icons, the inset for the inline form also collapses by the same amount.

While fixing these two things, three other fixes were made: there was an extra 10px of padding on contact layout editor custom layouts; and the trash icon on some delete buttons was showing red on red, so invisible, this resets the icon colour to inherit when used on a delete button. Also the Contact Layout Editor columns were not responsive, this stacks the two dashboard columns < 991px, the same as the regular contact dashboard.

Before
----------------------------------------
Right floats are on the left:
![image](https://github.com/user-attachments/assets/4c72b378-df07-40d4-97f6-dee2f8567ed5)

Left floats cover the side tabs:
![image](https://github.com/user-attachments/assets/6cbe3734-bad9-4cee-bc0e-d4482d2b8e17)

Offsetting them needs fixing at smaller viewports:
![image](https://github.com/user-attachments/assets/9f1f785c-6e5a-4cb4-b2b7-7e1ab850a6d9)

Delete icon colour clash:
<img width="335" alt="image" src="https://github.com/user-attachments/assets/4890718a-8635-4867-8660-b654a4559d35" />

After
----------------------------------------
Right floats are on the right:
![image](https://github.com/user-attachments/assets/dd33bc6c-6927-4257-b35f-908f0a3b82e2)

Left floats with side tabs are in the right place:
![image](https://github.com/user-attachments/assets/f2474e05-1439-495b-abd1-0fab761a1893)

The offset resets at smaller viewports:
![image](https://github.com/user-attachments/assets/5f03e126-6554-43fb-b4b2-91b5cd8cfdcd)
![image](https://github.com/user-attachments/assets/79fefdbe-338e-4137-b403-60874e7dc9ad)
![image](https://github.com/user-attachments/assets/5116c8ff-917f-44fd-8384-80dc1600b0fb)

Delete icon is ok
<img width="348" alt="image" src="https://github.com/user-attachments/assets/4c376dd6-eb1a-45ae-8b78-77c297475674" />

Technical Details
----------------------------------------
This has been tested against Minetta, Walbrook and Hackney; with and without Contact Layout Editor; at desktop, tablet and mobile viewports.