### PR TITLE
Remove unreachable & do-nothing code

### DIFF
--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -144,44 +144,11 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
         $formatValues[$key] = $field;
       }
 
-      require_once 'api/v3/utils.php';
-      // It's very likely this line does nothing.
-      _civicrm_api3_store_values(CRM_Member_DAO_Membership::fields(), $formatValues, $formatted);
-
       if (!$this->isUpdateExisting()) {
         $formatted['custom'] = CRM_Core_BAO_CustomField::postProcess($formatted,
           NULL,
           'Membership'
         );
-      }
-      else {
-
-        if (!empty($formatValues['membership_id'])) {
-          $dao = new CRM_Member_BAO_Membership();
-          $dao->id = $formatValues['membership_id'];
-          $dates = ['join_date', 'start_date', 'end_date'];
-          foreach ($dates as $v) {
-            if (empty($formatted[$v])) {
-              $formatted[$v] = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $formatValues['membership_id'], $v);
-            }
-          }
-
-          $formatted['custom'] = CRM_Core_BAO_CustomField::postProcess($formatted,
-            $formatValues['membership_id'],
-            'Membership'
-          );
-          if ($dao->find(TRUE)) {
-            if (empty($params['line_item']) && !empty($formatted['membership_type_id'])) {
-              CRM_Price_BAO_LineItem::getLineItemArray($formatted, NULL, 'membership', $formatted['membership_type_id']);
-            }
-
-            $newMembership = civicrm_api3('Membership', 'create', $formatted);
-            $this->_newMemberships[] = $newMembership['id'];
-            $this->setImportStatus($rowNumber, 'IMPORTED', 'Required parameter missing: Status');
-            return CRM_Import_Parser::VALID;
-          }
-          throw new CRM_Core_Exception('Matching Membership record not found for Membership ID ' . $formatValues['membership_id'] . '. Row was skipped.', CRM_Import_Parser::ERROR);
-        }
       }
 
       //Format dates

--- a/tests/phpunit/CRM/Member/Import/Parser/data/memberships_with_id.csv
+++ b/tests/phpunit/CRM/Member/Import/Parser/data/memberships_with_id.csv
@@ -1,0 +1,2 @@
+ID,Source,Membership Type,Start Date,Ignore me
+1,Import,General,2019-03-23,Just some cruft


### PR DESCRIPTION
Overview
----------------------------------------
Remove unreachable & do-nothing code

On looking at this code I found it looks for membership ID in 2 separate places

`$formatValues['membership_id']` and `$formatValues['id']` - so which is it?

By adding tests & stepping through the code I was able to verify that the values returned from `getMappedRow()` are in the 'non unique' format - & the code that relies on the unique format is unreachable. I was also able to verify that the line that 'very likely does nothing' does indeed do nothing - as `getMappedRow` has already been there done that

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/edf835ef-e7fd-4f10-8a45-39191bfb5b63)

& later

![image](https://github.com/user-attachments/assets/2084758a-ec22-485f-bb54-19fc50d4096a)

After
----------------------------------------
poof - always FALSE `if (!empty($formatValues['membership_id'])) {` is gone


Technical Details
----------------------------------------

Comments
----------------------------------------
