### PR TITLE
i18n: throw an exception if an invalid escape mode is used

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -42,6 +42,9 @@ class CRM_Core_I18n {
    * @return string
    */
   protected static function escape($text, $mode) {
+    if (!$mode) {
+      return $text;
+    }
     switch ($mode) {
       case 'sql':
         return CRM_Core_DAO::escapeString($text);
@@ -52,7 +55,7 @@ class CRM_Core_I18n {
       case 'htmlattribute':
         return htmlspecialchars($text, ENT_QUOTES);
     }
-    return $text;
+    throw new Exception('Invalid escape mode: ' . $mode);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

In #31954 I initially wrote a typo `escape="ts"` instead of `"escape="js"` and tests did not flag it. It could be used as a way to sneak security bugs past review.

Before
----------------------------------------

ts accepts any escape mode.

After
----------------------------------------

ts throws an exception

