### PR TITLE
Urgent (before 6 freeze): Fix broken select2s on Thames stream

### DIFF
--- a/ext/riverlea/streams/thames/css/_variables.css
+++ b/ext/riverlea/streams/thames/css/_variables.css
@@ -126,7 +126,7 @@
   --crm-xl: 3rem;
   --crm-xxl: 4rem;
   --crm-big-input: 15em;
-  --crm-huge-input: 100%; /* thames */
+  --crm-huge-input: 25em;
   --crm-padding-reg: var(--crm-r);
   --crm-padding-small: var(--crm-s);
   --crm-padding-inset: var(--crm-m);


### PR DESCRIPTION


Before
----------------------------------------

Some select2s options unreadable - off page!

![image](https://github.com/user-attachments/assets/d43a60e5-52be-47fa-b5fd-f1dfbcd973d5)




After
----------------------------------------

![image](https://github.com/user-attachments/assets/76619f1d-2b84-417b-a28c-4edc885c4c51)

works


Technical Details
----------------------------------------

Select2 does *not* like --crm-huge-input being set to a %...

