### PR TITLE
Standalone: more user friendly error when credentials are invalid

### DIFF
--- a/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
@@ -31,6 +31,9 @@ class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
     // inside the main box.
     $this->assign('statusMessages', CRM_Core_Smarty::singleton()->fetch("CRM/common/status.tpl"));
 
+    // Add the jQuery notify library because this library is only loaded whne the user is logged in. And we need this for CRM.alert
+    CRM_Core_Resources::singleton()->addScriptFile('civicrm', "packages/jquery/plugins/jquery.notify.min.js", ['region' => 'html-header']);
+
     parent::run();
   }
 

--- a/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
@@ -27,10 +27,6 @@ class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
     // Remove breadcrumb for login page.
     $this->assign('breadcrumb', NULL);
 
-    // statusMessages are usually at top of page but in login forms they look much better
-    // inside the main box.
-    $this->assign('statusMessages', CRM_Core_Smarty::singleton()->fetch("CRM/common/status.tpl"));
-
     // Add the jQuery notify library because this library is only loaded whne the user is logged in. And we need this for CRM.alert
     CRM_Core_Resources::singleton()->addScriptFile('civicrm', "packages/jquery/plugins/jquery.notify.min.js", ['region' => 'html-header']);
 

--- a/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
+++ b/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
@@ -3,7 +3,6 @@
   <div class="standalone-auth-box">
     <form id=login-form>
       <img class="crm-logo" src="{$logoUrl}" alt="{ts escape='htmlattribute'}Logo for CiviCRM, with an intersecting blue and green triangle{/ts}">
-      {$statusMessages}
       <div class="input-wrapper">
         <label for="usernameInput" name=username class="form-label">{ts}Username{/ts}</label>
         <input type="text" class="form-control crm-form-text" id="usernameInput" >

--- a/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
+++ b/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
@@ -12,7 +12,6 @@
         <label for="passwordInput" class="form-label">{ts}Password{/ts}</label>
         <input type="password" class="form-control crm-form-text" id="passwordInput">
       </div>
-      <div id="error" style="display:none;" class="form-alert">{ts}Your username and password do not match{/ts}</div>
       <div class="login-or-forgot">
         <a href="{$forgottenPasswordURL}">{ts}Forgotten password?{/ts}</a>
         <button id="loginSubmit" type="submit" class="btn btn-primary crm-button">{ts}Log In{/ts}</button>
@@ -20,6 +19,9 @@
     </form>
   </div>
 </div>
+
+{* The notification template is not loaded when the user is logged out. And we need this for CRM.alert *}
+{include file="CRM/common/notifications.tpl"}
 
 {literal}
 <script>
@@ -35,6 +37,8 @@
       let errorMsg = '{/literal}{ts escape="js"}Unexpected error{/ts}{literal}';
       try {
         let originalUrl = location.href;
+        // Remove the current status popup messages. 
+        CRM.$('#crm-notification-container .ui-notify-message').remove();
         const response = await CRM.api4('User', 'login', {
           username: username.value,
           password: password.value,
@@ -49,7 +53,7 @@
       catch (e) {
         console.error('caught', e);
       }
-      alert(errorMsg);
+      CRM.alert('', errorMsg, 'error', {'expires': 10000});
     });
   });
 </script>


### PR DESCRIPTION
Overview
----------------------------------------

When a user enters invalid credentials the error is shown as an popup. This PR shows them as a nice message on the form.

Before
----------------------------------------

![2025-02-05_16-18](https://github.com/user-attachments/assets/692245c2-bb4f-42a1-8921-dbf1eff8f151)


After
----------------------------------------

![2025-02-05_16-15](https://github.com/user-attachments/assets/b66f8c8f-639f-4c3c-a348-c226f39ca03e)



Comments
----------------------------------------

There is also an hidden error message already on the form. I believe that one can go away. 
