### PR TITLE
Developer settings page - switch to generating from meta

### DIFF
--- a/CRM/Admin/Form/Setting/Debugging.php
+++ b/CRM/Admin/Form/Setting/Debugging.php
@@ -28,31 +28,21 @@ class CRM_Admin_Form_Setting_Debugging extends CRM_Admin_Form_Setting {
    * @deprecated - do not add new settings here - the page to display
    * settings on should be defined in the setting metadata.
    */
-  protected $_settings = [
-    // @todo remove these, define any not yet defined in the setting metadata.
-    'debug_enabled' => CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME,
-    'backtrace' => CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME,
-    'fatalErrorHandler' => CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME,
-    'assetCache' => CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME,
-    'esm_loader' => CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME,
-    'environment' => CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME,
-  ];
+  protected $_settings = [];
 
   /**
    * Build the form object.
    */
   public function buildQuickForm() {
-    $this->setTitle(ts(' Settings - Debugging and Error Handling '));
-    if (CRM_Core_Config::singleton()->userSystem->supportsUfLogging()) {
-      $this->_settings['userFrameworkLogging'] = CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME;
-    }
+    $this->setTitle(ts('Settings - Debugging and Error Handling'));
 
     parent::buildQuickForm();
-    if (Civi::settings()->getMandatory('environment') !== NULL) {
-      $element = $this->getElement('environment');
-      $element->freeze();
-      CRM_Core_Session::setStatus(ts('The environment settings have been disabled because it has been overridden in the settings file.'), ts('Environment settings'), 'info');
+
+    $settingMetaData = $this->getSettingsMetaData();
+    if (!CRM_Core_Config::singleton()->userSystem->supportsUfLogging()) {
+      unset($settingMetaData['userFrameworkLogging']);
     }
+    $this->assign('settings_fields', $settingMetaData);
   }
 
 }

--- a/settings/Developer.setting.php
+++ b/settings/Developer.setting.php
@@ -74,8 +74,13 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => ts("Set this value to Yes if you want to use one of CiviCRM's debugging tools. This feature should NOT be enabled for production sites."),
-    // TODO: how to incorporate extensive help text from .hlp file?
-    'help_text' => ts('Debug output is triggered by adding specific name-value pairs to the CiviCRM query string. See Developer Docs for more details.'),
+    // TODO: how to avoid duplication in .hlp file?
+    'help_text' => implode('<br />', [
+      ts('Debug output is triggered by adding specific name-value pairs to the CiviCRM query string.'),
+      ts('For more details, see <a %1>the Developer Docs</a>', [
+        1 => 'href="https://docs.civicrm.org/dev/en/latest/tools/debugging/#using-url-parameters" target="_blank"',
+      ]),
+    ]),
     'settings_pages' => ['debug' => ['weight' => 200]],
   ],
   'backtrace' => [

--- a/settings/Developer.setting.php
+++ b/settings/Developer.setting.php
@@ -39,6 +39,7 @@ return [
     'pseudoconstant' => [
       'callback' => '\Civi\Core\AssetBuilder::getCacheModes',
     ],
+    'settings_pages' => ['debug' => ['weight' => 600]],
   ],
   // note: this setting is only exposed if the userFramework declares it has support
   // (currently only Drupal)
@@ -56,6 +57,7 @@ return [
     'is_contact' => 0,
     'description' => ts('Set this value to Yes if you want CiviCRM error/debugging messages to appear in your CMS error log.'),
     'help_text' => ts('In the case of Drupal, this will cause all CiviCRM error messages to appear in the Watchdog logs (assuming you have Watchdog enabled)'),
+    'settings_pages' => ['debug' => ['weight' => 100]],
   ],
   'debug_enabled' => [
     'group_name' => 'Developer Preferences',
@@ -72,7 +74,9 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => ts("Set this value to Yes if you want to use one of CiviCRM's debugging tools. This feature should NOT be enabled for production sites."),
-    'help_text' => 'Do not turn this on on production sites',
+    // TODO: how to incorporate extensive help text from .hlp file?
+    'help_text' => ts('Debug output is triggered by adding specific name-value pairs to the CiviCRM query string. See Developer Docs for more details.'),
+    'settings_pages' => ['debug' => ['weight' => 200]],
   ],
   'backtrace' => [
     'group_name' => 'Developer Preferences',
@@ -86,6 +90,7 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => ts('Set this value to Yes if you want to display a backtrace listing when a fatal error is encountered. This feature should NOT be enabled for production sites.'),
+    'settings_pages' => ['debug' => ['weight' => 300]],
   ],
   'environment' => [
     'group_name' => 'Developer Preferences',
@@ -106,6 +111,7 @@ return [
     'on_change' => [
       'CRM_Core_BAO_Setting::onChangeEnvironmentSetting',
     ],
+    'settings_pages' => ['debug' => ['weight' => 400]],
   ],
   'esm_loader' => [
     'group_name' => 'Developer Preferences',
@@ -125,6 +131,7 @@ return [
     'description' => ts('Specify how to load ESM (JS) files. The "Default" mode is the supported option. Other options may assist with diagnosing or temporarily mitigating compatibility issues.'),
     'help_text' => NULL,
     'options' => ['auto' => ts('Default (Auto-detect)'), 'browser' => ts('Browser'), 'shim-fast' => ts('es-module-shims (fast mode)'), 'shim-slow' => ts('es-module-shims (slow mode)')],
+    'settings_pages' => ['debug' => ['weight' => 700]],
   ],
   'fatalErrorHandler' => [
     'group_name' => 'Developer Preferences',
@@ -139,5 +146,6 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => ts('Enter the path and class for a custom PHP error-handling function if you want to override built-in CiviCRM error handling for your site.'),
+    'settings_pages' => ['debug' => ['weight' => 500]],
   ],
 ];

--- a/templates/CRM/Admin/Form/Setting/Debugging.hlp
+++ b/templates/CRM/Admin/Form/Setting/Debugging.hlp
@@ -7,10 +7,10 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{htxt id="debug-title"}
+{htxt id="debug-enabled-id-title"}
   {ts}Debugging{/ts}
 {/htxt}
-{htxt id="debug"}
+{htxt id="debug-enabled-id"}
 <p>{ts}Set this value to <strong>Yes</strong> if you want to use one of CiviCRM's debugging tools.{/ts} <strong>{ts}This feature should NOT be enabled for production sites.{/ts}</strong></p>
 <p>{ts}Debug output is triggered by adding specific name-value pairs to the CiviCRM query string:{/ts}<br />
 <ul>
@@ -27,10 +27,10 @@
 </p>
 {/htxt}
 
-{htxt id="userFrameworkLogging-title"}
+{htxt id="userFrameworkLogging-id-title"}
   {ts}Logging{/ts}
 {/htxt}
-{htxt id="userFrameworkLogging"}
+{htxt id="userFrameworkLogging-id"}
 <p>{ts}Set this value to <strong>Yes</strong> if you want CiviCRM error/debugging messages the appear in your CMS' error log.{/ts}</strong></p>
 <p>{ts}In the case of Drupal, this will cause all CiviCRM error messages to appear in the watchdog (assuming you have Drupal's watchdog enabled){/ts}</p>
 {/htxt}

--- a/templates/CRM/Admin/Form/Setting/Debugging.hlp
+++ b/templates/CRM/Admin/Form/Setting/Debugging.hlp
@@ -12,18 +12,14 @@
 {/htxt}
 {htxt id="debug-enabled-id"}
 <p>{ts}Set this value to <strong>Yes</strong> if you want to use one of CiviCRM's debugging tools.{/ts} <strong>{ts}This feature should NOT be enabled for production sites.{/ts}</strong></p>
-<p>{ts}Debug output is triggered by adding specific name-value pairs to the CiviCRM query string:{/ts}<br />
-<ul>
-<li><strong>{ts}Smarty Debug Window{/ts}</strong> - {ts}Loads all variables available to the current page template into a pop-up window. To trigger, add <em>&smartyDebug=1</em> to any CiviCRM URL query string. Make sure you have pop-up blocking disabled in your browser for the CiviCRM site URL.{/ts}</li>
-<li><strong>{ts}Session Reset{/ts}</strong> - {ts 1='&sessionReset=2'}Resets all values in your client session. To trigger, add <em>%1</em>{/ts}</li>
-<li><strong>{ts}Directory Cleanup{/ts}</strong> -{ts}Empties template cache and/or temporary upload file folders.{/ts}
-<ul>
-<li>{ts 1='&directoryCleanup=1'}To empty template cache (civicrm/templates_c folder), add <em>%1</em>{/ts}</li>
-<li>{ts 1='&directoryCleanup=2'}To remove temporary upload files (civicrm/upload folder), add <em>%1</em>{/ts}</li>
-<li>{ts 1='&directoryCleanup=3'}To cleanup both, add <em>%1</em>{/ts}</li>
-</ul></li>
-<li><strong>{ts}Stack Trace{/ts}</strong> - {ts 1='&backtrace=1'}To display a stack trace listing at the top of a page, add <em>%1</em>{/ts}</li>
-</ul>
+<p>
+  {ts}
+    Debug output is triggered by adding specific name-value pairs to the CiviCRM query string.
+  {/ts}
+  <br />
+  {ts 1='href="https://docs.civicrm.org/dev/en/latest/tools/debugging/#using-url-parameters" target="_blank"'}
+    For more details, see <a %1>the Developer Docs</a>
+  {/ts}
 </p>
 {/htxt}
 

--- a/templates/CRM/Admin/Form/Setting/Debugging.tpl
+++ b/templates/CRM/Admin/Form/Setting/Debugging.tpl
@@ -11,45 +11,5 @@
     {ts}In addition to the settings on this screen, there are a number of settings you can add to your sites's settings file (civicrm.settings.php) to provide additional debugging information.{/ts} {docURL page="dev/tools/debugging/#changing-file-based-settings"}
 </div>
 <div class="crm-block crm-form-block crm-debugging-form-block">
-    <table class="form-layout">
-        {if !empty($form.userFrameworkLogging)}
-            <tr class="crm-debugging-form-block-userFrameworkLogging">
-                <td class="label">{$form.userFrameworkLogging.label}</td>
-                <td>{$form.userFrameworkLogging.html}<br />
-                <span class="description">{ts}Set this value to <strong>Yes</strong> if you want CiviCRM error/debugging messages to appear in the Drupal error logs{/ts} {help id='userFrameworkLogging'}</span></td>
-            </tr>
-        {/if}
-            <tr class="crm-debugging-form-block-debug">
-                <td class="label">{$form.debug_enabled.label}</td>
-                <td>{$form.debug_enabled.html}<br />
-                <span class="description">{ts}<strong>This feature should NOT be enabled for production sites.</strong><br />Set this value to <strong>Yes</strong> if you want to use one of CiviCRM's debugging tools.{/ts} {help id='debug'}</span></td>
-            </tr>
-            <tr class="crm-debugging-form-block-backtrace">
-                <td class="label">{$form.backtrace.label}</td>
-                <td>{$form.backtrace.html}<br />
-                <span class="description">{ts}<strong>This feature should NOT be enabled for production sites.</strong><br />Set this value to <strong>Yes</strong> if you want to display a backtrace listing when a fatal error is encountered.{/ts}</span></td>
-            </tr>
-            <tr class="crm-debugging-form-block-environment">
-                <td class="label">{$form.environment.label}</td>
-                <td>{$form.environment.html}<br />
-                <span class="description">{ts}Set this value to <strong>Staging/Development</strong> to prevent cron jobs & mailings from being executed.{/ts}</span></td>
-            </tr>
-            <tr class="crm-debugging-form-block-fatalErrorHandler">
-                <td class="label">{$form.fatalErrorHandler.label}</td>
-                <td>{$form.fatalErrorHandler.html}<br />
-                <span class="description">{ts}Enter the path and class for a custom PHP error-handling function if you want to override built-in CiviCRM error handling for your site.{/ts}</span></td>
-            </tr>
-            <tr class="crm-debugging-form-block-assetCache">
-                <td class="label">{$form.assetCache.label}</td>
-                <td>{$form.assetCache.html}<br />
-                <span class="description">{ts}Store computed JS/CSS content in cache files? (Note: In "Auto" mode, the "Debug" setting will determine whether to activate the cache.){/ts}</span></td>
-            </tr>
-            <tr class="crm-debugging-form-block-esm_loader">
-                <td class="label">{$form.esm_loader.label}</td>
-                <td>{$form.esm_loader.html}<br />
-                <span class="description">{$settings_fields.esm_loader.description}</span></td>
-            </tr>
-    </table>
-    <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
-    <div class="spacer"></div>
+    {include file="CRM/Admin/Form/Setting/SettingForm.tpl"}
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Switch another settings page to meta generated, as per @todo comments

Before
----------------------------------------
- hard coded settings page for Debugging
- long detailed help text for Debugging query strings, similar but different to the corresponding bit of Developer Docs

After
----------------------------------------
- Debugging settings page mostly generated from meta
- `.hlp` file still hardcoded to align with meta
- shorter help text for Debugging query strings, link to the corresponding bit of Developer Docs

Technical Details
----------------------------------------
Another PR I thought would take 5 minutes, but actually ended up in worms.

I thought I would be able to delete the hard-coded `.hlp` page, but fetching help text from the `help_text` in the meta didn't seem to work?

Comments
----------------------------------------
Initial motivation: I was considering this as the page to expose Maintenance Mode setting on Standalone.
