### PR TITLE
[REF] Add back in support to buildOptions for fields with pseudoconst…

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2946,6 +2946,10 @@ SELECT contact_id
       $uniqueNames = static::fieldKeys();
       $fieldName = array_search($fieldName, $uniqueNames) ?: $fieldName;
     }
+    // Legacy handling for hook-based fields from `fields_callback`
+    if (!$entity->getField($fieldName)) {
+      return CRM_Core_PseudoConstant::get(static::class, $fieldName, [], $context);
+    }
     $checkPermissions = (bool) ($values['check_permissions'] ?? ($context == 'create' || $context == 'search'));
     $includeDisabled = ($context == 'validate' || $context == 'get');
     $options = $entity->getOptions($fieldName, $values, $includeDisabled, $checkPermissions);


### PR DESCRIPTION
…ants added to core entities using entitytype hook

Overview
----------------------------------------
This adds back in support for fields such as the [Case Type Category](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/civicase.php#L550) that Compucorp's CiviCase adds to the core CaseType into the buildOptions.

Before
----------------------------------------
Since entityV2 buildOptions/v3 broke for fields added to core entities via the entityTypesHook

After
----------------------------------------
Support is returned to buildOptions but note that v4 will not return the options

Technical Details
----------------------------------------
The entityTypes hook allows for fields to be added using the fields_callback. But since entity v2 the pseudoconstant support was broken for these fields. This adds back the support. to make this work for v4 will be difficult because the structure of the fields that the fields_callback supports is the legacy DAO style not the entity v2 style that v4 needs

ping @totten @eileenmcnaughton @colemanw 