### PR TITLE
Clarify function parameter

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -958,7 +958,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * Process the contribution.
    *
    * @param array $params
-   * @param array $result
+   * @param null|mixed $paymentProcessor
+   *   Value that may always be NULL?
    * @param array $contributionParams
    *   Parameters to be passed to contribution create action.
    *   This differs from params in that we are currently adding params to it and 1) ensuring they are being
@@ -985,7 +986,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    */
   protected function processFormContribution(
     $params,
-    $result,
+    $paymentProcessor,
     $contributionParams,
     $financialType,
     $isRecur
@@ -1039,7 +1040,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         $recurringContributionID), $contributionParams
       );
 
-      $contributionParams['payment_processor'] = $result ? ($result['payment_processor'] ?? NULL) : NULL;
+      $contributionParams['payment_processor'] = $paymentProcessor;
       $contributionParams['non_deductible_amount'] = $this->getNonDeductibleAmount($params, $financialType, TRUE, $form);
       $contributionParams['skipCleanMoney'] = TRUE;
       // @todo this is the wrong place for this - it should be done as close to form submission
@@ -1709,7 +1710,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     $membershipContribution = $this->processFormContribution(
       $tempParams,
-      $tempParams,
+      $tempParams['payment_processor'] ?? NULL,
       $contributionParams,
       $financialType,
       $isRecur


### PR DESCRIPTION
Overview
----------------------------------------
Clarify function parameter

Before
----------------------------------------
previously shared function `processContribution` has 2 callers - 
- one always passes NULL as `$result` 
 
![image](https://github.com/user-attachments/assets/3185d26d-2a1a-487f-8ee7-36835fa33cf7)

- the other passes an array (which likely doesn't contain `payment_processor` - but we need to trace more to be sure

Only the `payment_processor` array key is used


After
----------------------------------------
Just the `payment_processor` value that is used is passed in

Technical Details
----------------------------------------

Comments
----------------------------------------
