### PR TITLE
[REF] Throw an Exception if Schema v2 getOptions does not have a fiel…

### DIFF
--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -33,6 +33,9 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
 
   public function getOptions(string $fieldName, array $values = [], bool $includeDisabled = FALSE, bool $checkPermissions = FALSE, ?int $userId = NULL, bool $isView = FALSE): ?array {
     $field = \Civi::entity($this->entityName)->getField($fieldName);
+    if (!$field) {
+      throw new \CRM_Core_Exception("Field '$fieldName' not found");
+    }
     $options = NULL;
     $hookParams = [
       'entity' => $this->entityName,


### PR DESCRIPTION
…d array to work with

Overview
----------------------------------------
It is possible that if someone calls getOptions in the Civi::schema code for a field that was added in a legacy way that a null value would be returned because the field wasn't found in the new entity schmea so we are now throwing an Exception to make it more obvious what is going on

Before
----------------------------------------
No Exception

After
----------------------------------------
Exception

ping @eileenmcnaughton @colemanw @totten 