### PR TITLE
Improve performance of financial ACL where clause

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4226,13 +4226,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $endDate = "$nextYear$monthDay";
     $havingClause = 'contribution_status_id = ' . (int) CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
 
-    $contributionBAO = new CRM_Contribute_BAO_Contribution();
-    $whereClauses = $contributionBAO->addSelectWhereClause();
-
-    $clauses = [];
-    foreach ($whereClauses as $key => $clause) {
-      $clauses[] = 'b.' . $key . ' ' . implode(' AND b.' . $key . ' ', (array) $clause);
-    }
+    $clauses = CRM_Contribute_BAO_Contribution::getSelectWhereClause('b');
     $clauses[] = 'b.contact_id IN (' . $contactIDs . ')';
     $clauses[] = 'b.is_test = 0';
     $clauses[] = 'b.receive_date >=' . $startDate . ' AND b.receive_date < ' . $endDate;

--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -60,21 +60,23 @@ class CRM_Utils_SQL {
     $baoName = CRM_Core_DAO_AllCoreTables::getBAOClassName(CRM_Core_DAO_AllCoreTables::getDAONameForEntity($entityName));
     $bao = new $baoName();
     $fields = $bao::getSupportedFields();
+    $fieldNames = array_keys($fields);
     $mergeClauses = $subClauses = [];
-    foreach ((array) $bao->addSelectWhereClause($entityName) as $fieldName => $fieldClauses) {
+    foreach ($bao->addSelectWhereClause($entityName) as $fieldName => $fieldClauses) {
       if ($fieldClauses) {
         foreach ((array) $fieldClauses as $fieldClause) {
-          $formattedClause = CRM_Utils_SQL::prefixFieldNames($fieldClause, array_keys($fields), $bao->tableName());
+          $originalClause = $fieldClause;
+          CRM_Utils_SQL::prefixFieldNames($fieldClause, $fieldNames, $bao->tableName());
           // Same as join column with no additional fields - can be added directly
-          if ($fieldName === $joinColumn && $fieldClause === $formattedClause) {
-            $mergeClauses[] = $formattedClause;
+          if ($fieldName === $joinColumn && $originalClause === $fieldClause) {
+            $mergeClauses[] = $fieldClause;
           }
           // Arrays of arrays get joined with OR (similar to CRM_Core_Permission::check)
-          elseif (is_array($formattedClause)) {
-            $subClauses[] = "(($fieldName " . implode(") OR ($fieldName ", $formattedClause) . '))';
+          elseif (is_array($fieldClause)) {
+            $subClauses[] = "(($fieldName " . implode(") OR ($fieldName ", $fieldClause) . '))';
           }
           else {
-            $subClauses[] = "$fieldName $formattedClause";
+            $subClauses[] = "$fieldName $fieldClause";
           }
         }
       }

--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -96,7 +96,7 @@ function financialacls_civicrm_selectWhereClause($entity, &$clauses) {
       if ($entity === 'Contribution') {
         $unavailableTypes = _financialacls_civicrm_get_inaccessible_financial_types();
         if (!empty($unavailableTypes)) {
-          $clauses['id'][] = 'NOT IN (SELECT contribution_id FROM civicrm_line_item WHERE contribution_id IS NOT NULL AND financial_type_id IN (' . implode(',', $unavailableTypes) . '))';
+          $clauses['id'][] = 'AND NOT EXISTS (SELECT 1 FROM civicrm_line_item WHERE contribution_id = {id} AND financial_type_id IN (' . implode(',', $unavailableTypes) . '))';
         }
       }
       break;

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -228,7 +228,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     $sql = CRM_Contribute_BAO_Contribution::getAnnualQuery([1, 2, 3]);
     $this->assertStringContainsString('SUM(total_amount) as amount,', $sql);
     $this->assertStringContainsString('b.contact_id IN (1,2,3)', $sql);
-    $this->assertStringContainsString('b.financial_type_id IN (' . $permittedFinancialType . ')', $sql);
+    $this->assertStringContainsString('`b`.`financial_type_id` IN (' . $permittedFinancialType . ')', $sql);
 
     // Run it to make sure it's not bad sql.
     CRM_Core_DAO::executeQuery($sql);
@@ -260,8 +260,9 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     $sql = CRM_Contribute_BAO_Contribution::getAnnualQuery([1, 2, 3]);
     $this->assertStringContainsString('SUM(total_amount) as amount,', $sql);
     $this->assertStringContainsString('b.contact_id IN (1,2,3)', $sql);
-    $this->assertStringContainsString('WHERE b.id NOT IN (0)', $sql);
+    $this->assertStringContainsString('`b`.`id` NOT IN (0)', $sql);
     $this->assertStringNotContainsString('b.financial_type_id', $sql);
+    $this->assertStringNotContainsString('`b`.`financial_type_id`', $sql);
     CRM_Core_DAO::executeQuery($sql);
   }
 
@@ -275,7 +276,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     if ($entity !== 'Contribution') {
       return;
     }
-    $clauses['id'] = 'NOT IN (0)';
+    $clauses['id'] = ['NOT IN (0)'];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This replaces the `NOT IN` check with a `NOT EXISTS` check in the financial ACL where clause. This massively improves the performance. Before it was more or less unusable with many records.

Technical Details
----------------------------------------
The implementation results in a clause like this:
```sql
`a`.`id` AND NOT EXISTS (SELECT 1 FROM civicrm_line_item WHERE contribution_id = `a`.`id` AND financial_type_id IN (1,2,3,4)
```

The first `` `a`.`id` `` is obviously superfluous, but doesn't really hurt. With `$clauses[''][] = 'AND NOT EXISTS ...` the result would be an invalid clause: ``` `a`.`` AND NOT EXISTS ...```

Edit: The call of
```php
$formattedClause = CRM_Utils_SQL::prefixFieldNames($fieldClause, array_keys($fields), $bao->tableName());
```
in `\CRM_Utils_SQL::mergeSubquery()` always resulted in `$fieldClause === $formattedClause` because `$fieldClause` is passed as reference. Thus, this had to be fixed, too, because of this calls:
https://github.com/civicrm/civicrm-core/blob/9b4e2a6e9894391f989b0e1b040712d8c6e0904a/CRM/Contribute/BAO/ContributionSoft.php#L684
https://github.com/civicrm/civicrm-core/blob/9b4e2a6e9894391f989b0e1b040712d8c6e0904a/CRM/Price/BAO/LineItem.php#L1219
