### PR TITLE
Riverlea rollout - set as the default theme from 6.0 (but freeze on Greenwich for existing installs using Greenwich)

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixZero.php
+++ b/CRM/Upgrade/Incremental/php/SixZero.php
@@ -38,6 +38,7 @@ class CRM_Upgrade_Incremental_php_SixZero extends CRM_Upgrade_Incremental_Base {
       FALSE
     );
     $this->addTask('Set a default activity priority', 'addActivityPriorityDefault');
+    $this->addExtensionTask('Enable Riverlea extension', ['riverlea']);
   }
 
   /**

--- a/CRM/Upgrade/Incremental/php/SixZero.php
+++ b/CRM/Upgrade/Incremental/php/SixZero.php
@@ -38,6 +38,7 @@ class CRM_Upgrade_Incremental_php_SixZero extends CRM_Upgrade_Incremental_Base {
       FALSE
     );
     $this->addTask('Set a default activity priority', 'addActivityPriorityDefault');
+    $this->addTask('Freeze theme choice to Greenwich', 'freezeDefaultThemeToGreenwich');
     $this->addExtensionTask('Enable Riverlea extension', ['riverlea']);
   }
 
@@ -66,6 +67,27 @@ class CRM_Upgrade_Incremental_php_SixZero extends CRM_Upgrade_Incremental_Base {
       'group' => CRM_Core_DAO::singleValueQuery('SELECT id FROM civicrm_option_group WHERE name = "priority"'),
     ]);
     CRM_Core_DAO::executeQuery($sql);
+
+    return TRUE;
+  }
+
+  /**
+   * On 6.0 the default theme changes to Riverlea.
+   *
+   * For sites upgrading that have not made an explicit theme choice and have previously got
+   * Greenwich by default, change this to an explicit choice of Greenwich.
+   *
+   * @return bool
+   */
+  public static function freezeDefaultThemeToGreenwich() {
+    $themeSettings = ['theme_backend','theme_frontend'];
+
+    foreach ($themeSettings as $key) {
+      $value = \Civi::settings()->get($key);
+      if ($value === 'default') {
+        \Civi::settings()->set($key, 'greenwich');
+      }
+    }
 
     return TRUE;
   }

--- a/Civi/Core/Themes.php
+++ b/Civi/Core/Themes.php
@@ -22,7 +22,7 @@ use Civi;
 class Themes extends \Civi\Core\Service\AutoService {
 
   /**
-   * The "default" theme adapts based on the latest recommendation from civicrm.org
+   * The "default" theme adapts based on the latest recommendation
    * by switching to DEFAULT_THEME at runtime.
    */
   const DEFAULT_THEME = 'minetta';

--- a/Civi/Core/Themes.php
+++ b/Civi/Core/Themes.php
@@ -25,7 +25,7 @@ class Themes extends \Civi\Core\Service\AutoService {
    * The "default" theme adapts based on the latest recommendation from civicrm.org
    * by switching to DEFAULT_THEME at runtime.
    */
-  const DEFAULT_THEME = 'greenwich';
+  const DEFAULT_THEME = 'minetta';
 
   /**
    * Fallback is a pseudotheme which can be included in "search_order".

--- a/Civi/Core/Themes.php
+++ b/Civi/Core/Themes.php
@@ -202,11 +202,6 @@ class Themes extends \Civi\Core\Service\AutoService {
         'help' => ts('Determine a system default automatically'),
         // This is an alias. url_callback, search_order don't matter.
       ],
-      'greenwich' => [
-        'ext' => 'civicrm',
-        'title' => 'Greenwich',
-        'help' => ts('CiviCRM 4.x look-and-feel'),
-      ],
       'none' => [
         'ext' => 'civicrm',
         'title' => ts('None (Unstyled)'),

--- a/ext/greenwich/info.xml
+++ b/ext/greenwich/info.xml
@@ -16,9 +16,6 @@
   </urls>
   <releaseDate>[civicrm.releaseDate]</releaseDate>
   <version>[civicrm.version]</version>
-  <tags>
-    <tag>mgmt:hidden</tag>
-  </tags>
   <develStage>stable</develStage>
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>

--- a/ext/riverlea/info.xml
+++ b/ext/riverlea/info.xml
@@ -17,6 +17,9 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <tags>
+    <tag>mgmt:required</tag>
+  </tags>
   <comments>A cross-CMS CiviCRM theme framework.</comments>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/setup/plugins/init/DefaultExtensions.civi-setup.php
+++ b/setup/plugins/init/DefaultExtensions.civi-setup.php
@@ -22,5 +22,6 @@ if (!defined('CIVI_SETUP')) {
     $e->getModel()->extensions[] = 'authx';
     $e->getModel()->extensions[] = 'civiimport';
     $e->getModel()->extensions[] = 'message_admin';
+    $e->getModel()->extensions[] = 'riverlea';
 
   });


### PR DESCRIPTION
Overview
----------------------------------------
This effects the switch from Greenwich to Riverlea as the default theme from 6.0.

Before
----------------------------------------
- Greenwich is always installed, hidden, and the default theme
- Riverlea is installed by default on Standalone, but not on other CMSes
- Riverlea extension may or may not be installed on sites upgrading

After
----------------------------------------
- Riverlea extension is required (installed on upgrade or new install). This does not mean it's always selected as the active theme, but its always available as theme option.
- pre-existing sites with "default"/"automatic" selected for their theme at the point of upgrade will be tweaked so they have Greenwich explicitly selected (ie if you were getting Greenwich, you'll still have Greenwich)
- new sites, and any users switching to "default" selection will get Riverlea Minetta (the Greenwich lookalike)
- Greenwich is unhidden, so you can disable it in the UI (and you will then fallback to Riverlea if you were on Greenwich before)

