### PR TITLE
Deprecate legacy parameters to Address::format()

### DIFF
--- a/CRM/Utils/Address.php
+++ b/CRM/Utils/Address.php
@@ -53,6 +53,9 @@ class CRM_Utils_Address {
       CRM_Core_Error::deprecatedFunctionWarning('CRM_Utils_Address::formatVCard (not recommended outside core - figure out a token way)');
       self::formatVCard($fields);
     }
+    if ($format) {
+      CRM_Core_Error::deprecatedWarning('passing format is deprecated, use the token processor directly');
+    }
     if (!$format) {
       $format = Civi::settings()->get('address_format');
     }
@@ -127,6 +130,7 @@ class CRM_Utils_Address {
 
     // also sub all token fields
     if ($tokenFields) {
+      CRM_Core_Error::deprecatedWarning('passing tokenFields is deprecated, use the token processor directly');
       foreach ($tokenFields as $token) {
         $replacements["{$token}"] = $fields["{$token}"] ?? NULL;
       }


### PR DESCRIPTION
Overview
----------------------------------------
Deprecate legacy parameters to Address::format()

Before
----------------------------------------
Once https://github.com/civicrm/civicrm-core/pull/31983  is merged there are no more parameter passers

![image](https://github.com/user-attachments/assets/edc71a8a-6876-4c2f-ab93-5b075a0fe59b)


After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
