### PR TITLE
dev/core#5722 AdminUI - Fix Manage ACLs mode column

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Manage_ACLs.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Manage_ACLs.mgd.php
@@ -116,7 +116,7 @@ return [
               'dataType' => 'Boolean',
               'label' => E::ts('Mode'),
               'sortable' => TRUE,
-              'rewrite' => '{if "[deny]" eq "1"}' . E::ts('Deny') . '{else}' . E::ts('Allow') . '{/if}',
+              'rewrite' => '{if $deny}' . E::ts('Deny') . '{else}' . E::ts('Allow') . '{/if}',
             ],
             [
               'type' => 'field',


### PR DESCRIPTION
Overview
----------------------------------------
Fix [dev/core#5722](https://lab.civicrm.org/dev/core/-/issues/5722)


Technical Details
--------
Use smarty variable which is a boolean instead of the token which is localized