### PR TITLE
Installer - Use Riverlea's Minetta by default

### DIFF
--- a/setup/plugins/init/DefaultExtensions.civi-setup.php
+++ b/setup/plugins/init/DefaultExtensions.civi-setup.php
@@ -22,5 +22,8 @@ if (!defined('CIVI_SETUP')) {
     $e->getModel()->extensions[] = 'authx';
     $e->getModel()->extensions[] = 'civiimport';
     $e->getModel()->extensions[] = 'message_admin';
+    $e->getModel()->extensions[] = 'riverlea';
 
+    $e->getModel()->settings['theme_backend'] = 'minetta';
+    $e->getModel()->settings['theme_frontend'] = 'minetta';
   });


### PR DESCRIPTION
Overview
----------------------------------------

In keeping with the 6.0 recommendation for Riverlea... use it on new sites (by default).

This is an alternative implementation of #31979 (which should be less likely to anger the testgods).

Before
----------------------------------------

New installations use Greenwich

After
----------------------------------------

New installations use Minetta.
