### PR TITLE
Riverlea rollout - set Minetta as default, freeze previous default of Greenwich, sidestep DEFAULT_THEME

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixZero.php
+++ b/CRM/Upgrade/Incremental/php/SixZero.php
@@ -45,6 +45,7 @@ class CRM_Upgrade_Incremental_php_SixZero extends CRM_Upgrade_Incremental_Base {
     $this->addTask('Set a default activity priority', 'addActivityPriorityDefault');
     $this->addSimpleExtensionTask(ts('enable dedupe backward compatibility'), ['legacydedupefinder']);
     $this->addExtensionTask('Enable Riverlea extension', ['riverlea']);
+    $this->addTask('Freeze theme choice to Greenwich', 'freezeDefaultThemeToGreenwich');
   }
 
   public static function migrateFromEmailAddressValues($rev): bool {
@@ -109,6 +110,27 @@ SQL;
       'group' => CRM_Core_DAO::singleValueQuery('SELECT id FROM civicrm_option_group WHERE name = "priority"'),
     ]);
     CRM_Core_DAO::executeQuery($sql);
+
+    return TRUE;
+  }
+
+  /**
+   * On 6.0 the default theme changes to Riverlea.
+   *
+   * For sites upgrading that have not made an explicit theme choice and have previously got
+   * Greenwich by default, change this to an explicit choice of Greenwich.
+   *
+   * @return bool
+   */
+  public static function freezeDefaultThemeToGreenwich() {
+    $themeSettings = ['theme_backend', 'theme_frontend'];
+
+    foreach ($themeSettings as $key) {
+      $value = \Civi::settings()->get($key);
+      if ($value === 'default') {
+        \Civi::settings()->set($key, 'greenwich');
+      }
+    }
 
     return TRUE;
   }

--- a/CRM/Upgrade/Incremental/php/SixZero.php
+++ b/CRM/Upgrade/Incremental/php/SixZero.php
@@ -44,6 +44,7 @@ class CRM_Upgrade_Incremental_php_SixZero extends CRM_Upgrade_Incremental_Base {
     );
     $this->addTask('Set a default activity priority', 'addActivityPriorityDefault');
     $this->addSimpleExtensionTask(ts('enable dedupe backward compatibility'), ['legacydedupefinder']);
+    $this->addExtensionTask('Enable Riverlea extension', ['riverlea']);
   }
 
   public static function migrateFromEmailAddressValues($rev): bool {

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -1184,7 +1184,7 @@ return [
     'pseudoconstant' => array(
       'callback' => 'call://themes/getAvailable',
     ),
-    'default' => 'default',
+    'default' => 'minetta',
     'add' => '5.16',
     'title' => ts('Frontend Theme'),
     'is_domain' => 1,
@@ -1209,7 +1209,7 @@ return [
     'pseudoconstant' => array(
       'callback' => 'call://themes/getAvailable',
     ),
-    'default' => 'default',
+    'default' => 'minetta',
     'add' => '5.16',
     'title' => ts('Backend Theme'),
     'is_domain' => 1,

--- a/setup/plugins/init/DefaultExtensions.civi-setup.php
+++ b/setup/plugins/init/DefaultExtensions.civi-setup.php
@@ -22,5 +22,6 @@ if (!defined('CIVI_SETUP')) {
     $e->getModel()->extensions[] = 'authx';
     $e->getModel()->extensions[] = 'civiimport';
     $e->getModel()->extensions[] = 'message_admin';
+    $e->getModel()->extensions[] = 'riverlea';
 
   });


### PR DESCRIPTION
Overview
----------------------------------------
Stop using Civi\Theme::DEFAULT_THEME , make Minetta the default at the settings level, switch upgraders to explicit Greenwich.

Alternative to https://github.com/civicrm/civicrm-core/pull/31979 based on wisdom of "[31979] swaps the hard-dependency in Civi\Core\Themes from greenwich to riverlea. I would tempted to relax that dependency"

Before
----------------------------------------
- Default theme setting is Default, which resolves itself to Greenwich

After
----------------------------------------
- Default theme setting is Minetta
- People upgrading whose theme was previously "Default" get switched to Greenwich
- everyone has Riverlea extension enabled (which is one less click to switching to using it)

Technical Details
----------------------------------------
This leaves the DEFAULT_THEME code in, in the hope Test Gods dont notice what we're up to. But I would plan to remove that in a follow up.



