### PR TITLE
dev/core#5720 - Ensure default site email address is respected

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -324,6 +324,13 @@ trait CRM_Contact_Form_Task_EmailTrait {
     return $defaults;
   }
 
+  protected function getFieldsToExcludeFromPurification(): array {
+    return [
+      // Because value contains <angle brackets>
+      'from_email_address',
+    ];
+  }
+
   /**
    * Process the form after the input has been submitted and validated.
    *

--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -225,7 +225,6 @@ trait CRM_Contact_Form_Task_PDFTrait {
    * Prepare form.
    */
   public function preProcessPDF(): void {
-    $form = $this;
     $defaults = [];
     $fromEmails = $this->getFromEmails();
     if (is_numeric(key($fromEmails))) {
@@ -235,8 +234,15 @@ trait CRM_Contact_Form_Task_PDFTrait {
     if (!Civi::settings()->get('allow_mail_from_logged_in_contact')) {
       $defaults['from_email_address'] = CRM_Core_BAO_Domain::getFromEmail();
     }
-    $form->setDefaults($defaults);
-    $form->setTitle(ts('Print/Merge Document'));
+    $this->setDefaults($defaults);
+    $this->setTitle(ts('Print/Merge Document'));
+  }
+
+  protected function getFieldsToExcludeFromPurification(): array {
+    return [
+      // Because value contains <angle brackets>
+      'from_email_address',
+    ];
   }
 
   /**

--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -131,6 +131,13 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
     }
   }
 
+  protected function getFieldsToExcludeFromPurification(): array {
+    return [
+      // Because value contains <angle brackets>
+      'from_email_address',
+    ];
+  }
+
   /**
    * Build the form object.
    */

--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -94,6 +94,13 @@ AND    {$this->_componentClause}";
     $this->setDefaults($defaults);
   }
 
+  protected function getFieldsToExcludeFromPurification(): array {
+    return [
+      // Because value contains <angle brackets>
+      'from_email_address',
+    ];
+  }
+
   /**
    * Build the form object.
    */

--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -292,6 +292,7 @@ AND    reset_date IS NULL
       ->addSelect('display_name', 'email')
       ->addWhere('domain_id', '=', 'current_domain')
       ->addWhere('is_active', '=', TRUE)
+      ->addOrderBy('is_default', 'DESC')
       ->addOrderBy('display_name')
       ->execute();
     foreach ($domainFrom as $address) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug in https://lab.civicrm.org/dev/core/-/issues/5720


Technical Details
----------------------------------------
A few forms present a dropdown for "From Email Address", and most of them were not correctly setting the default. I investigated and found a couple causes:

1. Some forms just didn't bother to set it
2. Some forms *tried* to set it, but it got mangled by the html purifier

For the not-even-trying forms, a pretty simple catch-all solution is to put the default at the top of the list, thus the change to CRM_Core_BAO_Email::domainEmails

For the ones that were trying and failing, I added the field to getFieldsToExcludeFromPurification.

Comments
------
I put this against 6.0 because the bug may be dormant for the majority of sites if they've "fixed" it themselves by giving the default the lowest weight. But in 6.0 the option values are moved into a new table and are now sorted alphabetically instead of by weight. So without this fix the bug might suddenly become apparent after upgrading to 6.0.