### PR TITLE
Update existing navigation labels to match new 'Site Email Address' l…

### DIFF
--- a/CRM/Upgrade/Incremental/sql/6.0.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/6.0.beta1.mysql.tpl
@@ -1,0 +1,6 @@
+{* file to handle db changes in 6.0.beta1 during upgrade *}
+
+{* Note: The unfortunate status-quo is that Navigation labels store untranslated strings, so no `ts` needed (see https://issues.civicrm.org/jira/browse/CRM-6998 FWIW).*}
+UPDATE civicrm_navigation
+SET label = 'Site Email Addresses'
+WHERE label = 'FROM Email Addresses';


### PR DESCRIPTION
Overview
----------------------------------------
Followup to https://github.com/civicrm/civicrm-core/pull/31909/ which updated nav menu labels in the installer, this updates them for existing sites.

Before
----------------------------------------
"FROM Email Addresses"

After
----------------------------------------
"Site Email Addresses"

Technical Details
-------
Can-o-worms about translating nav menu items remains shut for now..

Comments
----------------------------------------
NO need to shout!