### PR TITLE
OptionGroup - Deprecate isDomainOptionGroup function

### DIFF
--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -40,12 +40,6 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
   protected $_gLabel;
 
   /**
-   * Is this Option Group Domain Specific
-   * @var bool
-   */
-  protected $_domainSpecific = FALSE;
-
-  /**
    * @var bool
    */
   public $submitOnce = TRUE;
@@ -88,7 +82,6 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
       'name'
     );
     $this->_gLabel = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', $this->_gid, 'title');
-    $this->_domainSpecific = CRM_Core_OptionGroup::isDomainOptionGroup($this->_gName);
     $url = "civicrm/admin/options/{$this->_gName}";
     $params = "reset=1";
 
@@ -115,12 +108,6 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
     $session->pushUserContext(CRM_Utils_System::url($url, $params));
     $this->assign('id', $this->_id);
     $this->setDeleteMessage();
-    if ($this->_id && CRM_Core_OptionGroup::isDomainOptionGroup($this->_gName)) {
-      $domainID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionValue', $this->_id, 'domain_id', 'id');
-      if (CRM_Core_Config::domainID() != $domainID) {
-        CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
-      }
-    }
     if ($this->isSubmitted()) {
       // The custom data fields are added to the form by an ajax form.
       // However, if they are not present in the element index they will
@@ -221,7 +208,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
       $this->addRule('value',
         ts('This Value already exists in the database for this option group. Please select a different Value.'),
         'optionExists',
-        ['CRM_Core_DAO_OptionValue', $this->_id, $this->_gid, 'value', $this->_domainSpecific]
+        ['CRM_Core_DAO_OptionValue', $this->_id, $this->_gid, 'value']
       );
     }
 
@@ -239,7 +226,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
       $this->addRule('label',
         ts('This Label already exists in the database for this option group. Please select a different Label.'),
         'optionExists',
-        ['CRM_Core_DAO_OptionValue', $this->_id, $this->_gid, 'label', $this->_domainSpecific]
+        ['CRM_Core_DAO_OptionValue', $this->_id, $this->_gid, 'label']
       );
     }
 

--- a/CRM/Campaign/Form/SurveyType.php
+++ b/CRM/Campaign/Form/SurveyType.php
@@ -57,13 +57,6 @@ class CRM_Campaign_Form_SurveyType extends CRM_Admin_Form {
     $session = CRM_Core_Session::singleton();
     $url = CRM_Utils_System::url('civicrm/admin/campaign/surveyType', 'reset=1');
     $session->pushUserContext($url);
-
-    if ($this->_id && CRM_Core_OptionGroup::isDomainOptionGroup($this->_gName)) {
-      $domainID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionValue', $this->_id, 'domain_id', 'id');
-      if (CRM_Core_Config::domainID() != $domainID) {
-        CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
-      }
-    }
   }
 
   /**

--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -144,12 +144,6 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue implements \Civi
     $optionValue = new CRM_Core_DAO_OptionValue();
     $optionValue->copyValues($params);
 
-    $isDomainOptionGroup = CRM_Core_OptionGroup::isDomainOptionGroup($groupName);
-    // When creating a new option for a group that requires a domain, set default domain
-    if ($isDomainOptionGroup && empty($params['id']) && (empty($params['domain_id']) || CRM_Utils_System::isNull($params['domain_id']))) {
-      $optionValue->domain_id = CRM_Core_Config::domainID();
-    }
-
     $groupsSupportingDuplicateValues = ['languages'];
     if (!$id && !empty($params['value'])) {
       $dao = new CRM_Core_DAO_OptionValue();
@@ -159,9 +153,6 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue implements \Civi
       else {
         // CRM-21737 languages option group does not use unique values but unique names.
         $dao->name = $params['name'];
-      }
-      if (CRM_Core_OptionGroup::isDomainOptionGroup($groupName)) {
-        $dao->domain_id = $optionValue->domain_id;
       }
       $dao->option_group_id = $params['option_group_id'];
       if ($dao->find(TRUE)) {

--- a/CRM/Core/OptionGroup.php
+++ b/CRM/Core/OptionGroup.php
@@ -19,15 +19,13 @@ class CRM_Core_OptionGroup {
   public static $_cache = [];
 
   /**
-   * $_domainIDGroups array maintains the list of option groups for whom
-   * domainID is to be considered.
+   * Deprecated flag for domain-specific optionValues. The `is_domain` column is no longer used.
+   * Any set of options that needs domain specificity should be stored in its own table.
    *
    * @var array
-   * @deprecated - going forward the optionValue table will not support domain-specific options
+   * @deprecated
    */
-  public static $_domainIDGroups = [
-    'from_email_address',
-  ];
+  public static $_domainIDGroups = [];
 
   /**
    * @deprecated - going forward the optionValue table will not support domain-specific options
@@ -35,7 +33,7 @@ class CRM_Core_OptionGroup {
    * @return bool
    */
   public static function isDomainOptionGroup($groupName) {
-    return in_array($groupName, self::$_domainIDGroups, TRUE);
+    return FALSE;
   }
 
   /**
@@ -153,9 +151,6 @@ WHERE  v.option_group_id = g.id
         $componentClause .= " OR v.component_id IN (SELECT id FROM civicrm_component WHERE name IN ($enabledComponents)) ";
       }
       $query .= " AND ($componentClause) ";
-    }
-    if (self::isDomainOptionGroup($name)) {
-      $query .= ' AND v.domain_id = ' . CRM_Core_Config::domainID();
     }
 
     if ($condition) {

--- a/CRM/Core/OptionValue.php
+++ b/CRM/Core/OptionValue.php
@@ -82,10 +82,6 @@ class CRM_Core_OptionValue {
     if ($optionGroupID) {
       $dao->option_group_id = $optionGroupID;
 
-      if (CRM_Core_OptionGroup::isDomainOptionGroup($groupName)) {
-        $dao->domain_id = CRM_Core_Config::domainID();
-      }
-
       $dao->orderBy($orderBy);
       $dao->find();
     }
@@ -242,23 +238,14 @@ class CRM_Core_OptionValue {
    * @param int $optionGroupID
    * @param string $fieldName
    *   The name of the field in the DAO.
-   * @param bool $domainSpecific
-   *   Filter this check to the current domain.
-   *   Some optionGroups allow for same labels or same names but
-   *   they must be in different domains, so filter the check to
-   *   the current domain.
    *
    * @return bool
    *   true if object exists
    */
-  public static function optionExists($value, $daoName, $daoID, $optionGroupID, $fieldName, $domainSpecific) {
+  public static function optionExists($value, $daoName, $daoID, $optionGroupID, $fieldName) {
     $object = new $daoName();
     $object->$fieldName = $value;
     $object->option_group_id = $optionGroupID;
-
-    if ($domainSpecific) {
-      $object->domain_id = CRM_Core_Config::domainID();
-    }
 
     if ($object->find(TRUE)) {
       return $daoID && $object->id == $daoID;
@@ -433,10 +420,6 @@ FROM
     if ($groupName) {
       $where .= " AND option_group.name = %2";
       $params[2] = [$groupName, 'String'];
-    }
-
-    if (CRM_Core_OptionGroup::isDomainOptionGroup($groupName)) {
-      $where .= " AND option_value.domain_id = " . CRM_Core_Config::domainID();
     }
 
     $query = $select . $from . $where . $order;

--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -775,7 +775,7 @@ class CRM_Utils_Rule {
    * @return bool
    */
   public static function optionExists($value, $options) {
-    return CRM_Core_OptionValue::optionExists($value, $options[0], $options[1], $options[2], CRM_Utils_Array::value(3, $options, 'name'), CRM_Utils_Array::value(4, $options, FALSE));
+    return CRM_Core_OptionValue::optionExists($value, $options[0], $options[1], $options[2], $options[3] ?? 'name');
   }
 
   /**

--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -123,11 +123,6 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
     foreach ($optionValueFields as $optionValueField) {
       $field['pseudoconstant'] += ["{$optionValueField}_column" => $optionValueField];
     }
-
-    // Filter for domain-specific groups
-    if (\CRM_Core_OptionGroup::isDomainOptionGroup($groupName)) {
-      $field['pseudoconstant']['condition'][] = 'domain_id = ' . \CRM_Core_Config::domainID();
-    }
   }
 
   private function formatOptionValues(array $optionValues): array {

--- a/schema/Core/OptionValue.entityType.php
+++ b/schema/Core/OptionValue.entityType.php
@@ -193,7 +193,8 @@ return [
       'title' => ts('Domain ID'),
       'sql_type' => 'int unsigned',
       'input_type' => 'EntityRef',
-      'description' => ts('Which Domain is this option value for'),
+      'deprecated' => TRUE,
+      'description' => ts('Unused deprecated column.'),
       'add' => '3.1',
       'input_attrs' => [
         'label' => ts('Domain'),


### PR DESCRIPTION
Overview
----------------------------------------
Cleanup unused domain-specific setting for option values.

See https://lab.civicrm.org/dev/core/-/issues/4721

Technical Details
----------------------------------------
Now that the last 2 domain-specific option groups have been dealt with:

- https://github.com/civicrm/civicrm-core/pull/31909
- https://github.com/civicrm/civicrm-core/pull/31924

... we can stop using this godawful is_domain column for good. The OptionValue table is complex enough without it!
