### PR TITLE
Standalone login box coloring - fix the text color to black to fix dark mode

### DIFF
--- a/ext/riverlea/streams/thames/css/_dark.css
+++ b/ext/riverlea/streams/thames/css/_dark.css
@@ -112,6 +112,7 @@
 /* Override standalone.css */
 .standalone-auth-box {
   background: var(--crm-c-dkblue-01) !important;
+  color: white !important;
 }
 #login-form {
   --crm-big-input: 100%;

--- a/ext/standaloneusers/css/standalone.css
+++ b/ext/standaloneusers/css/standalone.css
@@ -14,11 +14,18 @@ html.crm-standalone  nav.breadcrumb>ol {
   height: 100vh;
 }
 .standalone-auth-box {
+  --crm-standalone-auth-box-bg: #fff;
+  --crm-standalone-auth-box-text: #000;
+  --crm-standalone-auth-box-link: #444;
+  --crm-standalone-auth-box-link-hover: #136388;
+  /* box sizing */
   grid-row: 2;
   box-sizing: border-box;
   width: clamp(280px, 68vw, 45rem);
   margin: 0;
-  background-color: white;
+  /* force colors here because the box has an inset civicrm logo, which only looks good on certain background */
+  background-color: var(--crm-standalone-auth-box-bg);
+  color: var(--crm-standalone-auth-box-text);
   border: none;
   border-radius: 3px;
   padding: clamp(1rem, 3vw, 2rem);
@@ -43,6 +50,7 @@ div.crm-container .standalone-auth-form input {
   width: 100%;
   height: 2rem;
   padding: 0.5rem;
+  background-color: var(--crm-standalone-auth-box-bg);
 }
 .standalone-auth-form .login-or-forgot {
   display: grid;
@@ -51,6 +59,11 @@ div.crm-container .standalone-auth-form input {
 }
 .standalone-auth-form .login-or-forgot>a {
   grid-column: 1;
+  /* fixed on white background */
+  color: var(--crm-standalone-auth-box-link);
+}
+.standalone-auth-form .login-or-forgot>a:hover {
+  color: var(--crm-standalone-auth-box-link-hover)
 }
 .standalone-auth-form .login-or-forgot>button {
   grid-column: 2;


### PR DESCRIPTION
Overview
----------------------------------------
Fix disappearing labels on the login box with Riverlea dark mode.

Before
----------------------------------------
Light mode :heavy_check_mark: 
![image](https://github.com/user-attachments/assets/fe8f85c1-e40d-4166-bc01-41c703bd1678)


Dark mode labels disappear :new_moon: :disappointed: 
![image](https://github.com/user-attachments/assets/114dea01-ed61-49f9-8eee-e0554e4511fb)



After
----------------------------------------
Fix the text color in that box to black.

Light mode (label text is very slightly darker than the default --crm-c-text in this stream):
![image](https://github.com/user-attachments/assets/06f1b1aa-6d30-4542-ab8f-5a49c580e856)



Dark mode good:
![image](https://github.com/user-attachments/assets/72694857-a7ee-485e-987d-8473d17b5ac2)



(all screenshots using Hackney Brook. Similar story on Minetta and Walbrook. Thames overrides to a dark background color in dark mode, this PR adds forcing text back to white at the same time)


Comments
----------------------------------------
I don't know how I feel about fixing on specific colors here, but a) it is simplest fix I can think of; b) given we have the Civi logo in this box, which has fixed colors, then that sort of dictates the background color; c) if we are setting a background color, I think we should set a text color that goes with it; d) if themes want to override they can (as Thames is doing)

There is a slight issue in the screenshot above that the change leaks into the alert box text. That seems to be because of a separate issue with an undefined variable specifically in Hackney Brook, I will make a separate PR for that.


cc @vingle @artfulrobot 
