### PR TITLE
Standalone login box coloring - use riverlea vars if defined

### DIFF
--- a/ext/standaloneusers/css/standalone.css
+++ b/ext/standaloneusers/css/standalone.css
@@ -18,7 +18,9 @@ html.crm-standalone  nav.breadcrumb>ol {
   box-sizing: border-box;
   width: clamp(280px, 68vw, 45rem);
   margin: 0;
-  background-color: white;
+  /* use riverlea colors if available, fallback to black on white */
+  background-color: var(--crm-c-background2, white);
+  color: var(--crm-c-text, black);
   border: none;
   border-radius: 3px;
   padding: clamp(1rem, 3vw, 2rem);


### PR DESCRIPTION
Overview
----------------------------------------
This demonstrating an alternative to https://github.com/civicrm/civicrm-core/pull/31991 which takes background and text color for the login page from Riverlea vars.

It's nice in that the page feels more in keeping with the selected Stream.

BUT:
- I think the Civi logo can look a bit bad if not on nice crisp white, so I'm not sure about it.
- it would prob be more appropriate to implement this in Riverlea css (that could be done whether or not https://github.com/civicrm/civicrm-core/pull/31991 is merged)

