### PR TITLE
Form Builder - Support uploading files with "secret link" (JWT)

### DIFF
--- a/ext/afform/core/Civi/Afform/PageTokenCredential.php
+++ b/ext/afform/core/Civi/Afform/PageTokenCredential.php
@@ -201,7 +201,7 @@ class PageTokenCredential extends AutoService implements EventSubscriberInterfac
         'checkRequest' => fn($request, $jwt) => ($request['name'] === $jwt['afform']),
       ],
       ';^civicrm/ajax/api4/Afform/submitFile$;' => [
-        'allowFields' => $abstractProcessorParams,
+        'allowFields' => [...$abstractProcessorParams, 'token', 'modelName', 'fieldName', 'joinEntity', 'entityIndex', 'joinIndex'],
         'checkRequest' => fn($request, $jwt) => ($request['name'] === $jwt['afform']),
       ],
       ';^civicrm/ajax/api4/\w+/autocomplete$;' => [

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -131,9 +131,14 @@
       }
 
       // Used when submitting file fields
+      var token = new URLSearchParams(window.location.search).get('_aff');
+      var headers = {'X-Requested-With': 'XMLHttpRequest'};
+      if (token) {
+        headers['X-Civi-Auth-Afform'] = token;
+      }
       this.fileUploader = new FileUploader({
         url: CRM.url('civicrm/ajax/api4/Afform/submitFile'),
-        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        headers: headers,
         onCompleteAll: postProcess,
         onBeforeUploadItem: function(item) {
           status.resolve();


### PR DESCRIPTION
Overview
----------------------------------------
If you access a FormBuilder form with a "secret link" (JWT), you can't upload files, even if you ordinarily have the permission to do so.

Before
----------------------------------------
403 error on `Afform.submitFiles`.

After
----------------------------------------
File successfully uploads.

Technical Details
----------------------------------------
There are two issues:
* the JWT is normally only passed via `jQuery.ajaxSetup()`, which doesn't persist if that function is called again.  So we explicitly set the header when sending the file.
* The POST request format for files is different, so values that might ordinarily be in `values` are at the top level of the POST submission. So we must allow them in `allowFields`.