### PR TITLE
Riverlea - merge crm-c-light-text and crm-c-text-light

### DIFF
--- a/ext/riverlea/core/civi_mail-ang/crmMailing.css
+++ b/ext/riverlea/core/civi_mail-ang/crmMailing.css
@@ -6,7 +6,8 @@
   height: 20em;
 }
 .crmMailing-recip-est {
-  background: var(--crm-c-yellow-less-light);
+  background: var(--crm-checkbox-list-bg);
+  color: var(--crm-checkbox-list-col);
   font-size: var(--crm-small-font-size);
   padding: var(--crm-padding-small);
   margin: 0 0 0 var(--crm-m);

--- a/ext/riverlea/core/css/_bootstrap.css
+++ b/ext/riverlea/core/css/_bootstrap.css
@@ -128,7 +128,7 @@
 #bootstrap-theme mark,
 #bootstrap-theme .mark {
   background: var(--crm-c-yellow);
-  color: var(--crm-c-text);
+  color: var(--crm-c-text-dark);
   padding: .2rem;
 }
 @media (min-width: 768px) {

--- a/ext/riverlea/core/css/_bootstrap.css
+++ b/ext/riverlea/core/css/_bootstrap.css
@@ -1848,7 +1848,7 @@ fieldset[disabled] #bootstrap-theme .btn-link:focus {
 #bootstrap-theme .navbar-default {
   background-color: var(--crm-c-darkest);
   border-color: var(--crm-c-darkest);
-  color: var(--crm-c-light-text);
+  color: var(--crm-c-text-light);
 }
 #bootstrap-theme .nav-justified,
 #bootstrap-theme .nav-tabs.nav-justified {
@@ -3385,7 +3385,7 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
   display: inline;
   padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline);
   font-weight: normal;
-  color: var(--crm-c-light-text);
+  color: var(--crm-c-text-light);
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
@@ -3400,13 +3400,13 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 }
 #bootstrap-theme a.label:hover,
 #bootstrap-theme a.label:focus {
-  color: var(--crm-c-light-text);
+  color: var(--crm-c-text-light);
   text-decoration: none;
   cursor: var(--crm-hover-clickable);
 }
 #bootstrap-theme .label-default {
   background-color: var(--crm-c-text);
-  color: var(--crm-c-light-text);
+  color: var(--crm-c-text-light);
 }
 #bootstrap-theme .label-default[href]:hover,
 #bootstrap-theme .label-default[href]:focus {

--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -45,7 +45,7 @@
   --crm-c-dark-teal: #3e8079;
 /* Practical colours */
   --crm-c-text: #464354;
-  --crm-c-light-text: #fff;
+  --crm-c-text-light: #fff;
   --crm-c-dark-text: var(--crm-c-text);
   --crm-c-link: var(--crm-c-blue-dark);
   --crm-c-link-hover: var(--crm-c-blue-darker);
@@ -60,20 +60,20 @@
   --crm-c-code-background: var(--crm-c-background2); /* background for code regions */
   --crm-c-primary: var(--crm-c-gray-700);
   --crm-c-primary-hover: var(--crm-c-gray-800);
-  --crm-c-primary-text: var(--crm-c-light-text);
-  --crm-c-primary-hover-text: var(--crm-c-light-text);
+  --crm-c-primary-text: var(--crm-c-text-light);
+  --crm-c-primary-hover-text: var(--crm-c-text-light);
   --crm-c-secondary: #5d677b;
   --crm-c-secondary-hover: #3e485b;
-  --crm-c-secondary-text: var(--crm-c-light-text);
-  --crm-c-secondary-hover-text: var(--crm-c-light-text);
+  --crm-c-secondary-text: var(--crm-c-text-light);
+  --crm-c-secondary-hover-text: var(--crm-c-text-light);
   --crm-c-success: var(--crm-c-green-dark);
-  --crm-c-success-text: var(--crm-c-light-text);
+  --crm-c-success-text: var(--crm-c-text-light);
   --crm-c-alert: var(--crm-c-red-dark);
-  --crm-c-alert-text: var(--crm-c-light-text);
+  --crm-c-alert-text: var(--crm-c-text-light);
   --crm-c-warning: var(--crm-c-amber);
-  --crm-c-warning-text: var(--crm-c-light-text);
+  --crm-c-warning-text: var(--crm-c-text-light);
   --crm-c-info: var(--crm-c-blue-dark);
-  --crm-c-info-text: var(--crm-c-light-text);
+  --crm-c-info-text: var(--crm-c-text-light);
   --crm-c-focus: var(--crm-c-blue-dark);
   --crm-c-inactive: #696969;
 /* Shadows */
@@ -192,7 +192,7 @@
 /* .crm-accordion-bold */
   --crm-expand-header-bg: var(--crm-c-secondary);
   --crm-expand-header-bg-active: var(--crm-c-gray-900);
-  --crm-expand-header-color: var(--crm-c-light-text);
+  --crm-expand-header-color: var(--crm-c-text-light);
   --crm-expand-header-padding: var(--crm-s) var(--crm-m);
   --crm-expand-header-weight: bold;
   --crm-expand-header-font: var(--crm-font-bold);
@@ -337,7 +337,7 @@
   --crm-dialog-line: unset;
   --crm-dialog-inner-shadow: var(--crm-bottom-shadow);
   --crm-dialog-header-bg: var(--crm-c-secondary);
-  --crm-dialog-header-col: var(--crm-c-light-text);
+  --crm-dialog-header-col: var(--crm-c-text-light);
   --crm-dialog-header-size: var(--crm-r1);
   --crm-dialog-header-padding: var(--crm-m1) var(--crm-r);
   --crm-dialog-header-radius: var(--crm-dialog-radius);
@@ -363,7 +363,7 @@
   --crm-dropdown-padding: var(--crm-s);
   --crm-dropdown-radius: var(--crm-roundness);
   --crm-dropdown-bg: var(--crm-c-secondary-hover);
-  --crm-dropdown-col: var(--crm-c-light-text);
+  --crm-dropdown-col: var(--crm-c-text-light);
   --crm-dropdown-hover: var(--crm-c-text);
   --crm-dropdown-hover-bg: var(--crm-c-page-background);
   --crm-dropdown-border: 0;
@@ -375,7 +375,7 @@
 /* Notifications */
   --crm-notify-background: rgba(0,0,0,0.85);
   --crm-notify-padding: var(--crm-m2);
-  --crm-notify-col: var(--crm-c-light-text);
+  --crm-notify-col: var(--crm-c-text-light);
   --crm-notify-accent-border: 2px 0 0 0; /* adds a border to one/several sides of the notification - set to 0 for none */
   --crm-notify-radius: var(--crm-roundness);
   --crm-notify-alert: #d02e2e;
@@ -401,7 +401,7 @@
   --crm-wizard-radius: var(--crm-l);
   --crm-wizard-angle: 0px;
   --crm-wizard-arrow-thickness: 1px;
-  --crm-wizard-active-col: var(--crm-c-light-text);
+  --crm-wizard-active-col: var(--crm-c-text-light);
   --crm-wizard-active-bg: var(--crm-c-link);
   --crm-wizard-border: var(--crm-c-divider);
   --crm-wizard-bg: var(--crm-c-page-background);

--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -44,9 +44,9 @@
   --crm-c-teal: #63c4b9;
   --crm-c-dark-teal: #3e8079;
 /* Practical colours */
-  --crm-c-text: #464354;
   --crm-c-text-light: #fff;
-  --crm-c-dark-text: var(--crm-c-text);
+  --crm-c-text-dark: #464354;
+  --crm-c-text: var(--crm-c-text-dark);
   --crm-c-link: var(--crm-c-blue-dark);
   --crm-c-link-hover: var(--crm-c-blue-darker);
   --crm-c-divider: 1px solid var(--crm-c-gray-300);
@@ -117,7 +117,7 @@
   --crm-link-decoration: none;
   --crm-link-decoration-hover: underline;
   --crm-heading-bg: var(--crm-c-blue-light);
-  --crm-heading-col: var(--crm-c-text);
+  --crm-heading-col: var(--crm-c-text-dark);
   --crm-heading-padding: var(--crm-s1) var(--crm-m1);
   --crm-heading-margin: var(--crm-m) 0;
   --crm-heading-radius: var(--crm-roundness);
@@ -192,7 +192,7 @@
 /* .crm-accordion-bold */
   --crm-expand-header-bg: var(--crm-c-secondary);
   --crm-expand-header-bg-active: var(--crm-c-gray-900);
-  --crm-expand-header-color: var(--crm-c-text-light);
+  --crm-expand-header-color: var(--crm-c-secondary-text);
   --crm-expand-header-padding: var(--crm-s) var(--crm-m);
   --crm-expand-header-weight: bold;
   --crm-expand-header-font: var(--crm-font-bold);
@@ -225,7 +225,7 @@
   --crm-alert-text-help: var(--crm-c-green-dark);
   --crm-alert-background-warning: var(--crm-c-yellow-light);
   --crm-alert-border-warning: var(--crm-c-yellow);
-  --crm-alert-text-warning: var(--crm-c-text);
+  --crm-alert-text-warning: var(--crm-c-text-dark);
   --crm-alert-background-info: var(--crm-c-blue-light);
   --crm-alert-border-info: var(--crm-c-blue);
   --crm-alert-text-info: var(--crm-c-blue-dark);
@@ -263,7 +263,9 @@
   --crm-fieldset-border-color: var(--crm-c-gray-400);
   --crm-fieldset-border: 1px 0 0 0;
   --crm-fieldset-padding: var(--crm-padding-reg) var(--crm-padding-small);
-  --crm-checkbox-list-col: var(--crm-c-text);
+  --crm-checkbox-list-col: var(--crm-c-text-dark);
+  --crm-checkbox-list-bg: var(--crm-c-yellow-light);
+  --crm-checkbox-list-bg2: var(--crm-c-yellow-less-light);
 /* Tabs */
   --crm-tabs-bg: var(--crm-c-background4);
   --crm-tabs-padding: var(--crm-s);
@@ -337,7 +339,7 @@
   --crm-dialog-line: unset;
   --crm-dialog-inner-shadow: var(--crm-bottom-shadow);
   --crm-dialog-header-bg: var(--crm-c-secondary);
-  --crm-dialog-header-col: var(--crm-c-text-light);
+  --crm-dialog-header-col: var(--crm-c-secondary-text);
   --crm-dialog-header-size: var(--crm-r1);
   --crm-dialog-header-padding: var(--crm-m1) var(--crm-r);
   --crm-dialog-header-radius: var(--crm-dialog-radius);

--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -33,24 +33,25 @@
 .crm-container ul.crm-checkbox-list li input {
   margin: 0;
 }
+.crm-container ul.crm-checkbox-list li:nth-child(2n) {
+  background-color: var(--crm-c-background3);
+}
 .crm-container ul.crm-checkbox-list li:has(input:checked) label {
   color: var(--crm-checkbox-list-col);
 }
+.crm-container ul.crm-checkbox-list li:has(input:checked) {
+  background-color: var(--crm-checkbox-list-bg);
+}
+.crm-container ul.crm-checkbox-list li:nth-child(2n):has(input:checked) {
+  background-color: var(--crm-checkbox-list-bg2);
+}
+
 .listing-box input.crm-form-checkbox {
   margin: 0 0 0 var(--crm-s);
 }
 tbody.scrollContent tr.alternateRow {
   background-color: var(--crm-c-background3);
   padding-inline: var(--crm-s) var(--crm-m2);
-}
-.crm-container ul.crm-checkbox-list li:nth-child(2n) {
-  background-color: var(--crm-c-background3);
-}
-.crm-container ul.crm-checkbox-list li:has(input:checked) {
-  background-color: var(--crm-c-yellow-light);
-}
-.crm-container ul.crm-checkbox-list li:nth-child(2n):has(input:checked) {
-  background-color: var(--crm-c-yellow-less-light);
 }
 
 /* Action Links */

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -806,7 +806,7 @@ input.crm-form-checkbox) + label {
 }
 .crm-container .ui-spinner a.ui-spinner-button:hover,
 .crm-container .ui-spinner a.ui-spinner-button:focus {
-  color: var(--crm-c-light-text);
+  color: var(--crm-c-text-light);
 }
 .crm-container .ui-spinner a.ui-spinner-button span::before {
   font-family: "FontAwesome";

--- a/ext/riverlea/core/css/components/_front.css
+++ b/ext/riverlea/core/css/components/_front.css
@@ -43,7 +43,7 @@ af-form > fieldset > legend {
 }
 .crm-container.crm-public .header-dark {
   background: var(--crm-c-secondary);
-  color: var(--crm-c-light-text);
+  color: var(--crm-c-text-light);
   padding: var(--crm-m1) var(--crm-f-fieldset-padding);
   font-family: var(--crm-font-bold);
   font-weight: bold;

--- a/ext/riverlea/core/css/components/_tables.css
+++ b/ext/riverlea/core/css/components/_tables.css
@@ -279,7 +279,7 @@ tbody .crm-row-child:not(:has(~ .crm-row-child)) td {
 }
 .crm-container tr.columnheader-dark th {
   background-color: var(--crm-c-gray-700);
-  color: var(--crm-c-light-text);
+  color: var(--crm-c-text-light);
   border: 1px solid var(--crm-c-gray-800);
 }
 

--- a/ext/riverlea/core/css/components/_tabs.css
+++ b/ext/riverlea/core/css/components/_tabs.css
@@ -96,7 +96,7 @@
 .crm-container .ui-tabs ul.ui-tabs-nav .crm-count-0 a em,
 .crm-container #mainTabContainer ul.ui-tabs-nav .crm-count-0 a em {
   background: var(--crm-c-background5);
-  color: var(--crm-c-light-text);
+  color: var(--crm-c-text-light);
 }
 .crm-container .ui-tabs ul li em:empty,
 .crm-container .nav-tabs .badge:empty { /* this is to keep the height of tabs with empty badges */

--- a/ext/riverlea/core/css/rename-css-var.php
+++ b/ext/riverlea/core/css/rename-css-var.php
@@ -20,7 +20,7 @@ $names = explode("\n", <<<TXT
 --crm-blue-darker       --crm-c-blue-darker
 --crm-blue-light        --crm-c-blue-light
 --crm-dark-teal         --crm-c-dark-teal
---crm-dark-text         --crm-c-dark-text
+--crm-dark-text         --crm-c-text-dark
 --crm-darkest           --crm-c-darkest
 --crm-divider           --crm-c-divider
 --crm-drag-background   --crm-c-drag-background

--- a/ext/riverlea/core/css/rename-css-var.php
+++ b/ext/riverlea/core/css/rename-css-var.php
@@ -42,7 +42,7 @@ $names = explode("\n", <<<TXT
 --crm-inactive          --crm-c-inactive
 --crm-info              --crm-c-info
 --crm-info-text         --crm-c-info-text
---crm-light-text        --crm-c-light-text
+--crm-light-text        --crm-c-text-light
 --crm-link              --crm-c-link
 --crm-link-hover        --crm-c-link-hover
 --crm-page-background   --crm-c-page-background

--- a/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
+++ b/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
@@ -77,7 +77,7 @@ details.af-container > *:last-of-type {
 }
 #bootstrap-theme .af-container-style-pane > .af-title {
   background-color: var(--crm-c-background5);
-  color: var(--crm-c-light-text);
+  color: var(--crm-c-text-light);
   border-radius: var(--crm-form-block-border-radius) var(--crm-form-block-border-radius) 0 0;
   position: absolute;
   top: 0;

--- a/ext/riverlea/streams/empty/css/_dark.css
+++ b/ext/riverlea/streams/empty/css/_dark.css
@@ -3,7 +3,6 @@
   --crm-c-text: #fff;
   --crm-c-link: var(--crm-c-teal);
   --crm-c-link-hover: var(--crm-c-yellow);
-  --crm-c-text-light: var(--crm-c-darkest);
   --crm-c-background: var(--crm-c-gray-900);
   --crm-c-page-background: var(--crm-c-gray-900);
   --crm-c-background2: var(--crm-c-gray-800);

--- a/ext/riverlea/streams/empty/css/_dark.css
+++ b/ext/riverlea/streams/empty/css/_dark.css
@@ -49,7 +49,6 @@
   --crm-c-inactive: var(--crm-c-gray-400);
   --crm-input-color: var(--crm-c-text);
   --crm-input-description: var(--crm-c-gray-300);
-  --crm-checkbox-list-col: var(--crm-c-text-light);
   --crm-alert-text-help: var(--crm-c-text);
   --crm-dialog-header-border-col: transparent;
   --crm-dialog-header-bg: var(--crm-c-background2);

--- a/ext/riverlea/streams/empty/css/_variables.css
+++ b/ext/riverlea/streams/empty/css/_variables.css
@@ -262,7 +262,6 @@
 --crm-fieldset-border-color: var(--crm-c-gray-400);
 --crm-fieldset-border: 1px 0 0 0;
 --crm-fieldset-padding: var(--crm-padding-reg) var(--crm-padding-small);
---crm-checkbox-list-col: var(--crm-c-text);
 /* Tabs *
 --crm-tabs-bg: var(--crm-c-background4);
 --crm-tabs-padding: var(--crm-s);

--- a/ext/riverlea/streams/empty/css/_variables.css
+++ b/ext/riverlea/streams/empty/css/_variables.css
@@ -47,7 +47,7 @@
 /* Practical colours *
 --crm-c-text: #464354;
 --crm-c-text-light: #fff;
---crm-c-dark-text: var(--crm-c-text);
+--crm-c-text-dark: var(--crm-c-text);
 --crm-c-link: var(--crm-c-blue-dark);
 --crm-c-link-hover: var(--crm-c-blue-darker);
 --crm-c-divider: 1px solid var(--crm-c-gray-300);

--- a/ext/riverlea/streams/empty/css/_variables.css
+++ b/ext/riverlea/streams/empty/css/_variables.css
@@ -46,7 +46,7 @@
 --crm-c-dark-teal: #3e8079;
 /* Practical colours *
 --crm-c-text: #464354;
---crm-c-light-text: #fff;
+--crm-c-text-light: #fff;
 --crm-c-dark-text: var(--crm-c-text);
 --crm-c-link: var(--crm-c-blue-dark);
 --crm-c-link-hover: var(--crm-c-blue-darker);
@@ -61,20 +61,20 @@
 --crm-c-code-background: var(--crm-c-background2); /* background for code regions *
 --crm-c-primary: var(--crm-c-gray-700);
 --crm-c-primary-hover: var(--crm-c-gray-800);
---crm-c-primary-text: var(--crm-c-light-text);
---crm-c-primary-hover-text: var(--crm-c-light-text);
+--crm-c-primary-text: var(--crm-c-text-light);
+--crm-c-primary-hover-text: var(--crm-c-text-light);
 --crm-c-secondary: #5d677b;
 --crm-c-secondary-hover: #3e485b;
---crm-c-secondary-text: var(--crm-c-light-text);
---crm-c-secondary-hover-text: var(--crm-c-light-text);
+--crm-c-secondary-text: var(--crm-c-text-light);
+--crm-c-secondary-hover-text: var(--crm-c-text-light);
 --crm-c-success: var(--crm-c-green-dark);
---crm-c-success-text: var(--crm-c-light-text);
+--crm-c-success-text: var(--crm-c-text-light);
 --crm-c-alert: var(--crm-c-red-dark);
---crm-c-alert-text: var(--crm-c-light-text);
+--crm-c-alert-text: var(--crm-c-text-light);
 --crm-c-warning: var(--crm-c-amber);
---crm-c-warning-text: var(--crm-c-light-text);
+--crm-c-warning-text: var(--crm-c-text-light);
 --crm-c-info: var(--crm-c-blue-dark);
---crm-c-info-text: var(--crm-c-light-text);
+--crm-c-info-text: var(--crm-c-text-light);
 --crm-c-focus: var(--crm-c-blue-dark);
 --crm-c-inactive: #696969;
 /* Shadows *
@@ -191,7 +191,7 @@
 /* .crm-accordion-bold *
 --crm-expand-header-bg: var(--crm-c-secondary);
 --crm-expand-header-bg-active: var(--crm-c-gray-900);
---crm-expand-header-color: var(--crm-c-light-text);
+--crm-expand-header-color: var(--crm-c-text-light);
 --crm-expand-header-padding: var(--crm-s) var(--crm-m);
 --crm-expand-header-weight: bold;
 --crm-expand-header-font: var(--crm-font-bold);
@@ -336,7 +336,7 @@
 --crm-dialog-line:;
 --crm-dialog-inner-shadow: var(--crm-bottom-shadow);
 --crm-dialog-header-bg: var(--crm-c-secondary);
---crm-dialog-header-col: var(--crm-c-light-text);
+--crm-dialog-header-col: var(--crm-c-text-light);
 --crm-dialog-header-size: var(--crm-r1);
 --crm-dialog-header-padding: var(--crm-m1) var(--crm-r);
 --crm-dialog-header-radius: var(--crm-dialog-radius);
@@ -362,7 +362,7 @@
 --crm-dropdown-padding: var(--crm-s);
 --crm-dropdown-radius: var(--crm-roundness);
 --crm-dropdown-bg: var(--crm-c-secondary-hover);
---crm-dropdown-col: var(--crm-c-light-text);
+--crm-dropdown-col: var(--crm-c-text-light);
 --crm-dropdown-hover: var(--crm-c-text);
 --crm-dropdown-hover-bg: var(--crm-c-page-background);
 --crm-dropdown-border: 0;
@@ -374,7 +374,7 @@
 /* Notifications *
 --crm-notify-background: rgba(0,0,0,0.85);
 --crm-notify-padding: var(--crm-m2);
---crm-notify-col: var(--crm-c-light-text);
+--crm-notify-col: var(--crm-c-text-light);
 --crm-notify-accent-border: 2px 0 0 0; /* adds a border to one/several sides of the notification - set to 0 for none *
 --crm-notify-radius: var(--crm-roundness);
 /* Icons *
@@ -395,14 +395,14 @@
 --crm-wizard-height: 30px;
 --crm-wizard-radius: var(--crm-l);
 --crm-wizard-angle: 0px;
---crm-wizard-active-col: var(--crm-c-light-text);
+--crm-wizard-active-col: var(--crm-c-text-light);
 --crm-wizard-active-bg: var(--crm-c-link);
 --crm-wizard-border: var(--crm-c-divider);
 --crm-wizard-bg: var(--crm-c-page-background);
 /* Alpha filter *
 --crm-filter-bg: var(--crm-c-blue-light);
 --crm-filter-padding: var(--crm-m);
---crm-filter-item-bg:  #fafafa;
+--crm-filter-item-bg: #fafafa;
 --crm-filter-item-shadow: 0px 0px 3px rgba(0,0,0,0.1);
 --crm-filter-spacing: start; /* choose 'space-between' to spread out evenly, or 'end' to right align. */
 /* Frontend *

--- a/ext/riverlea/streams/hackneybrook/css/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/css/_dark.css
@@ -3,7 +3,6 @@
   --crm-c-text: #fff;
   --crm-c-link: #f5c929;
   --crm-c-link-hover: #f2d465;
-  --crm-c-text-light: var(--crm-c-darkest);
   --crm-c-background: var(--crm-c-gray-900);
   --crm-c-page-background: var(--crm-c-gray-900);
   --crm-c-background2: var(--crm-c-gray-800);

--- a/ext/riverlea/streams/hackneybrook/css/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/css/_dark.css
@@ -9,9 +9,9 @@
   --crm-c-background3: var(--crm-c-gray-700);
   --crm-c-background4: var(--crm-c-gray-600);
   --crm-c-code-background: var(--crm-c-gray-200);
-  --crm-c-primary: var(--crm-c-gray-800);
-  --crm-c-primary-text: #fff;
-  --crm-c-primary-hover: var(--crm-c-gray-900);
+  --crm-c-primary: var(--crm-c-background);
+  --crm-c-primary-text: var(--crm-c-text);
+  --crm-c-primary-hover: var(--crm-c-darkest);
   --crm-c-secondary: var(--crm-c-gray-800);
   --crm-c-secondary-hover: var(--crm-c-gray-900);
   --crm-c-inactive: var(--crm-c-gray-400);

--- a/ext/riverlea/streams/hackneybrook/css/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/css/_dark.css
@@ -3,7 +3,7 @@
   --crm-c-text: #fff;
   --crm-c-link: #f5c929;
   --crm-c-link-hover: #f2d465;
-  --crm-c-light-text: var(--crm-c-darkest);
+  --crm-c-text-light: var(--crm-c-darkest);
   --crm-c-background: var(--crm-c-gray-900);
   --crm-c-page-background: var(--crm-c-gray-900);
   --crm-c-background2: var(--crm-c-gray-800);
@@ -21,7 +21,7 @@
   --crm-c-red-light: #f1b6bd;
   --crm-c-blue-light: #195e80;
   --crm-c-alert: var(--crm-c-red-light);
-  --crm-c-alert-text: var(--crm-c-light-text);
+  --crm-c-alert-text: var(--crm-c-text-light);
   --crm-c-teal: #a3ebe6;
   --crm-c-green-light: #1d3d1d;
   --crm-c-green: #236225;

--- a/ext/riverlea/streams/hackneybrook/css/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/css/_dark.css
@@ -11,8 +11,9 @@
   --crm-c-background4: var(--crm-c-gray-600);
   --crm-c-code-background: var(--crm-c-gray-200);
   --crm-c-primary: var(--crm-c-gray-800);
-  --crm-c-secondary: var(--crm-c-gray-800);
+  --crm-c-primary-text: #fff;
   --crm-c-primary-hover: var(--crm-c-gray-900);
+  --crm-c-secondary: var(--crm-c-gray-800);
   --crm-c-secondary-hover: var(--crm-c-gray-900);
   --crm-c-inactive: var(--crm-c-gray-400);
   --crm-c-amber: #993b00;

--- a/ext/riverlea/streams/hackneybrook/css/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/css/_dark.css
@@ -72,7 +72,6 @@
   --crm-alert-background-danger: #fcf3f5;
   --crm-input-color: var(--crm-c-text);
   --crm-input-description: var(--crm-c-gray-300);
-  --crm-checkbox-list-col: var(--crm-c-text-light);
   --crm-alert-text-help: var(--crm-c-text);
   --crm-dialog-header-border-col: transparent;
   --crm-dialog-header-bg: var(--crm-c-background2);

--- a/ext/riverlea/streams/hackneybrook/css/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/css/_dark.css
@@ -34,9 +34,10 @@
   --crm-c-gray-500: #6c6c6c;
   --crm-c-gray-300: #e1dfdf;
   --crm-c-gray-200: #bdbdbd;
-  --crm-c-yellow-light: #665800;
-  --crm-c-yellow-less-light: #525209;
   --crm-c-divider: 1px solid var(--crm-c-gray-500);
+  --crm-checkbox-list-col: #665800;
+  --crm-checkbox-list-bg2: #525209;
+  --crm-checkbox-list-col: var(--crm-c-text-light);
   /* And others */
   --crm-c-focus: #00a3a5;
   --crm-btn-icon-bg: var(--crm-c-gray-700);

--- a/ext/riverlea/streams/hackneybrook/css/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/css/_dark.css
@@ -43,6 +43,7 @@
   --crm-block-shadow: 0;
   --crm-popup-shadow: 0 3px 18px 0 rgb(0,0,0);
   --crm-heading-bg: #354b55;
+  --crm-heading-col: var(--crm-c-text-light);
   --crm-dashlet-bg: var(--crm-c-background2);
   --crm-dashlet-header-bg: var(--crm-c-background3);
   --crm-dashlet-tabs-border: 0;

--- a/ext/riverlea/streams/hackneybrook/css/_variables.css
+++ b/ext/riverlea/streams/hackneybrook/css/_variables.css
@@ -75,7 +75,7 @@
   /* Tabs */
   --crm-tabs-border: var(--crm-c-divider);
   --crm-tab-count-bg: var(--crm-c-blue-dark);
-  --crm-tab-count-col: var(--crm-c-light-text);
+  --crm-tab-count-col: var(--crm-c-text-light);
   --crm-tab-border: 1px solid var(--crm-c-gray-400);
   /* Contact dashboard */
   --crm-dash-border: 0;

--- a/ext/riverlea/streams/hackneybrook/css/_variables.css
+++ b/ext/riverlea/streams/hackneybrook/css/_variables.css
@@ -71,7 +71,6 @@
   --crm-input-label-weight: normal;
   --crm-input-label-width: 10em;
   --crm-fieldset-border: 1px;
-  --crm-checkbox-list-col: var(--crm-c-text);
   /* Tabs */
   --crm-tabs-border: var(--crm-c-divider);
   --crm-tab-count-bg: var(--crm-c-blue-dark);

--- a/ext/riverlea/streams/minetta/css/_dark.css
+++ b/ext/riverlea/streams/minetta/css/_dark.css
@@ -4,7 +4,6 @@
   --crm-c-focus: #8cd4cb;
   --crm-c-link: var(--crm-c-teal);
   --crm-c-link-hover: var(--crm-c-yellow);
-  --crm-c-text-light: var(--crm-c-darkest);
   --crm-c-primary-text: #fff;
   --crm-c-background: var(--crm-c-gray-900);
   --crm-c-page-background: var(--crm-c-gray-900);

--- a/ext/riverlea/streams/minetta/css/_dark.css
+++ b/ext/riverlea/streams/minetta/css/_dark.css
@@ -5,6 +5,7 @@
   --crm-c-link: var(--crm-c-teal);
   --crm-c-link-hover: var(--crm-c-yellow);
   --crm-c-text-light: var(--crm-c-darkest);
+  --crm-c-primary-text: #fff;
   --crm-c-background: var(--crm-c-gray-900);
   --crm-c-page-background: var(--crm-c-gray-900);
   --crm-c-background2: var(--crm-c-gray-800);

--- a/ext/riverlea/streams/minetta/css/_dark.css
+++ b/ext/riverlea/streams/minetta/css/_dark.css
@@ -33,6 +33,7 @@
   --crm-block-shadow: 0;
   --crm-popup-shadow: 0 3px 18px 0 rgb(0,0,0);
   --crm-heading-bg: var(--crm-c-blue-dark);
+  --crm-heading-col: var(--crm-c-text-light);
   --crm-dashlet-bg: var(--crm-c-background2);
   --crm-dashlet-header-bg: var(--crm-c-background3);
   --crm-expand-header-bg: var(--crm-c-background3);

--- a/ext/riverlea/streams/minetta/css/_dark.css
+++ b/ext/riverlea/streams/minetta/css/_dark.css
@@ -56,7 +56,6 @@
   --crm-table-even-row: var(--crm-c-page-background);
   --crm-table-even-hover: var(--crm-c-gray-700);
   --crm-alert-text-help: var(--crm-c-text-light);
-  --crm-alert-text-warning: var(--crm-c-text-light);
   --crm-alert-background-info: var(--crm-c-blue-dark);
   --crm-alert-text-info: var(--crm-c-blue-light);
   --crm-c-inactive: var(--crm-c-gray-400);

--- a/ext/riverlea/streams/minetta/css/_dark.css
+++ b/ext/riverlea/streams/minetta/css/_dark.css
@@ -63,7 +63,6 @@
   --crm-input-color: var(--crm-c-text);
   --crm-input-description: var(--crm-c-gray-300);
   --crm-input-radio-color: #38c4b4;
-  --crm-checkbox-list-col: var(--crm-c-text-light);
   --crm-alert-text-help: var(--crm-c-text);
   --crm-btn-cancel-bg: #9b3d4b;
   --crm-btn-alert-bg: var(--crm-btn-cancel-bg);

--- a/ext/riverlea/streams/thames/css/_dark.css
+++ b/ext/riverlea/streams/thames/css/_dark.css
@@ -49,12 +49,11 @@
   --crm-notify-background: var(--crm-c-dkblue-02);
   --crm-expand-header-bg-active: var(--crm-c-dkblue-04);
   --crm-checkbox-list-col: var(--crm-input-label-color);
+  --crm-checkbox-list-bg: var(--crm-c-dkblue-01);
+  --crm-checkbox-list-bg2: var(--crm-c-dkblue-02);
   --crm-input-description: var(--crm-input-label-color);
   --crm-c-warning-text: black;
   --crm-filter-bg: var(--crm-c-dkblue-02);
-  /* these colour descriptions are used prescriptively */
-  --crm-c-yellow-light: var(--crm-c-dkblue-01);
-  --crm-c-yellow-less-light: var(--crm-c-dkblue-02);
 }
 
 .crm-container div.crm-summary-row div.crm-label {

--- a/ext/riverlea/streams/thames/css/_variables.css
+++ b/ext/riverlea/streams/thames/css/_variables.css
@@ -60,9 +60,8 @@
   --crm-c-teal: #63c4b9;
   --crm-c-dark-teal: #3e8079;
 /* PRACTICAL COLOURS */
-  --crm-c-text: #000000dd; /* thames */
   --crm-c-text-light: #fff;
-  --crm-c-text-dark: var(--crm-c-text);
+  --crm-c-text-dark:  #000000dd; /* thames */
   --crm-c-link: var(--crm-c-blue-dark);
   --crm-c-link-hover: var(--crm-c-blue-darker);
   --crm-c-divider: 1px solid var(--crm-c-blue-overlay); /* thames */
@@ -294,7 +293,6 @@
   --crm-fieldset-border-color: var(--crm-c-gray-400);
   --crm-fieldset-border: 1px 0 0 0;
   --crm-fieldset-padding: var(--crm-padding-reg) var(--crm-padding-small);
-  --crm-checkbox-list-col: var(--crm-c-text);
 }
 :root {
 /* Tabs */

--- a/ext/riverlea/streams/thames/css/_variables.css
+++ b/ext/riverlea/streams/thames/css/_variables.css
@@ -61,7 +61,7 @@
   --crm-c-dark-teal: #3e8079;
 /* PRACTICAL COLOURS */
   --crm-c-text: #000000dd; /* thames */
-  --crm-c-light-text: #fff;
+  --crm-c-text-light: #fff;
   --crm-c-dark-text: var(--crm-c-text);
   --crm-c-link: var(--crm-c-blue-dark);
   --crm-c-link-hover: var(--crm-c-blue-darker);
@@ -76,20 +76,20 @@
   --crm-c-code-background: var(--crm-c-blue-overlay2); /* background for code regions */
   --crm-c-primary: var(--crm-c-blue-dark); /* primary button bgs */ /* thames */
   --crm-c-primary-hover: var(--crm-c-blue-darker); /* thames */
-  --crm-c-primary-text: var(--crm-c-light-text);
+  --crm-c-primary-text: var(--crm-c-text-light);
   --crm-c-primary-hover-text: white; /* thames */
   --crm-c-secondary: #c9e1f1; /* buttons */ /* thames */
   --crm-c-secondary-hover: #a1cef3; /* thames */
   --crm-c-secondary-text: var(--crm-c-blue-darker); /* thames */
-  --crm-c-secondary-hover-text: var(--crm-c-light-text); /* thames todo */
+  --crm-c-secondary-hover-text: var(--crm-c-text-light); /* thames todo */
   --crm-c-success: var(--crm-c-green-dark);
-  --crm-c-success-text: var(--crm-c-light-text);
+  --crm-c-success-text: var(--crm-c-text-light);
   --crm-c-alert: var(--crm-c-red-dark); /* thames */
-  --crm-c-alert-text: var(--crm-c-light-text);
+  --crm-c-alert-text: var(--crm-c-text-light);
   --crm-c-warning: var(--crm-c-amber); /* bg on .btn-warning, .label-warming but border on notification .alert */
   --crm-c-warning-text: var(--crm-c-text);
   --crm-c-info: var(--crm-c-blue-dark);
-  --crm-c-info-text: var(--crm-c-light-text);
+  --crm-c-info-text: var(--crm-c-text-light);
   --crm-c-focus: var(--crm-c-blue-dark);
   --crm-c-inactive: #696969;
 }
@@ -338,7 +338,7 @@
   --crm-dash-tab-border-width: 0; /* to remove border on one side for hanging tabs */
   --crm-dash-tab-col: unset; /* thames */
   --crm-dash-tab-count-bg: var(--crm-c-primary); /* thames */
-  --crm-dash-tab-count-col: var(--crm-c-light-text); /* thames */
+  --crm-dash-tab-count-col: var(--crm-c-text-light); /* thames */
   --crm-dash-tab-width: 100%;
   --crm-dash-tab-align: none;
   --crm-dash-tab-hang: 0 0 -1px 0; /* lip to extend tab flush with active region - set to 0 for no lip */ /* thames */
@@ -452,7 +452,7 @@
   --crm-wizard-height: 30px;
   --crm-wizard-radius: var(--crm-l);
   --crm-wizard-angle: 0px;
-  --crm-wizard-active-col: var(--crm-c-light-text);
+  --crm-wizard-active-col: var(--crm-c-text-light);
   --crm-wizard-active-bg: var(--crm-c-link);
   --crm-wizard-border: var(--crm-c-divider);
   --crm-wizard-bg: var(--crm-c-page-background);

--- a/ext/riverlea/streams/thames/css/_variables.css
+++ b/ext/riverlea/streams/thames/css/_variables.css
@@ -62,7 +62,7 @@
 /* PRACTICAL COLOURS */
   --crm-c-text: #000000dd; /* thames */
   --crm-c-text-light: #fff;
-  --crm-c-dark-text: var(--crm-c-text);
+  --crm-c-text-dark: var(--crm-c-text);
   --crm-c-link: var(--crm-c-blue-dark);
   --crm-c-link-hover: var(--crm-c-blue-darker);
   --crm-c-divider: 1px solid var(--crm-c-blue-overlay); /* thames */

--- a/ext/riverlea/streams/thames/css/_variables.css
+++ b/ext/riverlea/streams/thames/css/_variables.css
@@ -252,9 +252,7 @@
   --crm-alert-background-help: var(--crm-c-blue-light); /* thames */
   --crm-alert-border-help: unset; /* thames */
   --crm-alert-text-help: unset; /* thames */
-  --crm-alert-background-warning: var(--crm-c-yellow-light);
   --crm-alert-border-warning: var(--crm-c-yellow);
-  --crm-alert-text-warning: var(--crm-c-text);
   --crm-alert-background-info: var(--crm-c-blue-light);
   --crm-alert-border-info: var(--crm-c-blue);
   --crm-alert-text-info: var(--crm-c-blue-darker);

--- a/ext/riverlea/streams/walbrook/css/_dark.css
+++ b/ext/riverlea/streams/walbrook/css/_dark.css
@@ -5,7 +5,6 @@
   --crm-c-link: var(--crm-c-amber);
   --crm-c-link-hover: var(--crm-c-amber-light);
   --crm-c-focus: var(--crm-c-link);
-  --crm-c-text-light: var(--crm-c-darkest);
   --crm-c-background: var(--crm-c-gray-900);
   --crm-c-page-background: var(--crm-c-darkest);
   --crm-c-code-background: var(--crm-c-background2);

--- a/ext/riverlea/streams/walbrook/css/_dark.css
+++ b/ext/riverlea/streams/walbrook/css/_dark.css
@@ -61,7 +61,6 @@
   --crm-c-inactive: var(--crm-c-gray-400);
   --crm-input-color: var(--crm-c-text);
   --crm-input-description: var(--crm-c-gray-300);
-  --crm-checkbox-list-col: var(--crm-c-darkest);
   --crm-dialog-header-border-col: transparent;
   --crm-dialog-header-bg: var(--crm-c-background2);
   --crm-dialog-body-bg: var(--crm-c-background2);

--- a/ext/riverlea/streams/walbrook/css/_dark.css
+++ b/ext/riverlea/streams/walbrook/css/_dark.css
@@ -61,7 +61,7 @@
   --crm-c-inactive: var(--crm-c-gray-400);
   --crm-input-color: var(--crm-c-text);
   --crm-input-description: var(--crm-c-gray-300);
-  --crm-checkbox-list-col: var(--crm-c-text-light);
+  --crm-checkbox-list-col: var(--crm-c-darkest);
   --crm-dialog-header-border-col: transparent;
   --crm-dialog-header-bg: var(--crm-c-background2);
   --crm-dialog-body-bg: var(--crm-c-background2);

--- a/ext/riverlea/streams/walbrook/css/_dark.css
+++ b/ext/riverlea/streams/walbrook/css/_dark.css
@@ -28,6 +28,7 @@
   --crm-block-shadow: 0 3px 18px 0 rgb(0,0,0);
   --crm-popup-shadow: 0 3px 18px 0 rgb(0,0,0);
   --crm-heading-bg: var(--crm-c-secondary);
+  --crm-heading-col: var(--crm-c-text-light);
   --crm-dashlet-bg: var(--crm-c-background2);
   --crm-dashlet-header-bg: var(--crm-c-background3);
   --crm-expand-header-bg: transparent;

--- a/ext/riverlea/streams/walbrook/css/_dark.css
+++ b/ext/riverlea/streams/walbrook/css/_dark.css
@@ -55,7 +55,6 @@
   --crm-table-even-row: var(--crm-c-gray-800);
   --crm-table-even-hover: var(--crm-alert-border-info);
   --crm-alert-text-help: var(--crm-c-text);
-  --crm-alert-text-warning: var(--crm-c-text-light);
   --crm-alert-background-info: var(--crm-c-blue-dark);
   --crm-alert-text-info: var(--crm-c-blue-light);
   --crm-c-inactive: var(--crm-c-gray-400);

--- a/ext/riverlea/streams/walbrook/css/_variables.css
+++ b/ext/riverlea/streams/walbrook/css/_variables.css
@@ -48,9 +48,9 @@
   --crm-c-secondary: var(--crm-c-purple);
   --crm-c-secondary-hover: var(--crm-c-purple-dark);
   --crm-c-success: var(--crm-c-green);
-  --crm-c-success-text: var(--crm-c-dark-text);
+  --crm-c-success-text: var(--crm-c-text-dark);
   --crm-c-alert: var(--crm-c-red);
-  --crm-c-warning-text: var(--crm-c-dark-text);
+  --crm-c-warning-text: var(--crm-c-text-dark);
   --crm-c-info-text: var(--crm-c-text-light);
 /* Shadows */
   --crm-block-shadow: 0 3px 18px 0 rgba(48,40,40,.25);

--- a/ext/riverlea/streams/walbrook/css/_variables.css
+++ b/ext/riverlea/streams/walbrook/css/_variables.css
@@ -44,14 +44,14 @@
   --crm-c-code-background: var(--crm-c-background3); /* background for code regions */
   --crm-c-primary: var(--crm-c-blue);
   --crm-c-primary-hover: var(--crm-c-blue-darker);
-  --crm-c-primary-text: var(--crm-c-light-text); /* text colour when on top of primary */
+  --crm-c-primary-text: var(--crm-c-text-light); /* text colour when on top of primary */
   --crm-c-secondary: var(--crm-c-purple);
   --crm-c-secondary-hover: var(--crm-c-purple-dark);
   --crm-c-success: var(--crm-c-green);
   --crm-c-success-text: var(--crm-c-dark-text);
   --crm-c-alert: var(--crm-c-red);
   --crm-c-warning-text: var(--crm-c-dark-text);
-  --crm-c-info-text: var(--crm-c-light-text);
+  --crm-c-info-text: var(--crm-c-text-light);
 /* Shadows */
   --crm-block-shadow: 0 3px 18px 0 rgba(48,40,40,.25);
   --crm-popup-shadow: var(--crm-block-shadow);
@@ -168,7 +168,7 @@
   --crm-dash-tab-border-hover: unset;
   --crm-dash-tab-col: unset;
   --crm-dash-tab-count-bg: var(--crm-c-primary);
-  --crm-dash-tab-count-col: var(--crm-c-light-text);
+  --crm-dash-tab-count-col: var(--crm-c-text-light);
   --crm-dash-tab-hang: 0 0 -1px 0; /* lip to extend tab flush with active region - set to 0 for no lip */
   --crm-dash-icon-size: var(--crm-m2);
   --crm-dash-box-shadow: inset 0 3px 18px -5px rgba(0, 0, 0, 0.25);
@@ -179,7 +179,7 @@
   --crm-dash-label-bg: var(--crm-c-background);
   --crm-dash-header-bg: var(--crm-c-gray-900);
   --crm-dash-header-bg2: var(--crm-c-gray-800);
-  --crm-dash-header-col: var(--crm-c-light-text);
+  --crm-dash-header-col: var(--crm-c-text-light);
   --crm-dash-header-size: var(--crm-l);
   --crm-dash-header-padding: var(--crm-r) var(--crm-r1);
   --crm-dash-image-size: 100px;
@@ -198,7 +198,7 @@
   --crm-dashlet-bg: var(--crm-c-background);
   --crm-dashlet-padding: 0;
   --crm-dashlet-header-bg: var(--crm-c-secondary);
-  --crm-dashlet-header-col: var(--crm-c-light-text);
+  --crm-dashlet-header-col: var(--crm-c-text-light);
   --crm-dashlet-header-padding: var(--crm-padding-reg);
   --crm-dashlet-tabs-border: var(--crm-tabs-border);
 /* Notifications */

--- a/ext/riverlea/streams/walbrook/css/_variables.css
+++ b/ext/riverlea/streams/walbrook/css/_variables.css
@@ -63,6 +63,7 @@
 /* Type */
   --crm-link-decoration-hover: none;
   --crm-heading-bg: var(--crm-c-background3);
+  --crm-heading-col: var(--crm-c-text-dark);
   --crm-heading-padding: var(--crm-m2) var(--crm-m);
   --crm-heading-margin: 0;
   --crm-heading-radius: 0;

--- a/ext/standaloneusers/css/standalone.css
+++ b/ext/standaloneusers/css/standalone.css
@@ -51,6 +51,7 @@ div.crm-container .standalone-auth-form input {
   height: 2rem;
   padding: 0.5rem;
   background-color: var(--crm-standalone-auth-box-bg);
+  color: var(--crm-standalone-auth-box-text);
 }
 .standalone-auth-form .login-or-forgot {
   display: grid;


### PR DESCRIPTION
_updated description_

Overview
----------------------------------------
Merge eerily similar css vars, then try to fix some things that break as a result of the merge.

This standardises on `crm-text-light`. It also updates use of `crm-text-dark` so that `crm-text` is set to either `text-light` or `text-dark` depending on the context/dark mode.

(Previously some of the streams set `text-light` to something dark in dark mode, but this a) caused some issues; b) made it hard to follow what was going on in dark mode.

There's also some consequences for:
- `crm-heading-col` and friends
- `crm-checkbox-list-bg` and friends
- `crm-c-yellow` and friends
- `alert-text-warning` and `alert-background-warning`

I've done my best to follow through the consequences as minimally but logically as poss.


Comments
-----------------------------------------------
I noticed this when looking at the Standalone login page on Hackney Brook with Dark Mode -- the alert message text color seems to be undefined, because it's using crm-c-light-text , which isnt defined in that context. 
`