### PR TITLE
Decommission thresholdQuery, only call legacy hook from backward compat extension

### DIFF
--- a/CRM/Dedupe/BAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/BAO/DedupeRuleGroup.php
@@ -156,7 +156,30 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup impl
     if (!$tempTable) {
       return;
     }
-    $dao = \CRM_Core_DAO::executeQuery($ruleGroup->thresholdQuery($event->checkPermissions));
+    $aclFrom = $aclWhere = '';
+    $dedupeTable = $tempTable;
+    $contactType = $ruleGroup->contact_type;
+    $threshold = $ruleGroup->threshold;
+
+    if ($event->checkPermissions) {
+      [$aclFrom, $aclWhere] = CRM_Contact_BAO_Contact_Permission::cacheClause(['c1', 'c2']);
+      $aclWhere = $aclWhere ? "AND {$aclWhere}" : '';
+    }
+    $query = "SELECT IF(dedupe.id1 < dedupe.id2, dedupe.id1, dedupe.id2) as id1,
+              IF(dedupe.id1 < dedupe.id2, dedupe.id2, dedupe.id1) as id2, dedupe.weight
+              FROM $dedupeTable dedupe JOIN civicrm_contact c1 ON dedupe.id1 = c1.id
+                JOIN civicrm_contact c2 ON dedupe.id2 = c2.id {$aclFrom}
+                LEFT JOIN civicrm_dedupe_exception exc
+                  ON dedupe.id1 = exc.contact_id1 AND dedupe.id2 = exc.contact_id2
+              WHERE c1.contact_type = %1 AND
+                    c2.contact_type = %1
+                     AND c1.is_deleted = 0 AND c2.is_deleted = 0
+                    {$aclWhere}
+                    AND weight >= %2 AND exc.contact_id1 IS NULL";
+    $dao = \CRM_Core_DAO::executeQuery($query, [
+      1 => [$contactType, 'String'],
+      2 => [$threshold, 'Integer'],
+    ]);
     $duplicates = [];
     while ($dao->fetch()) {
       $duplicates[] = ['entity_id_1' => $dao->id1, 'entity_id_2' => $dao->id2, 'weight' => $dao->weight];
@@ -420,45 +443,6 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup impl
       return 0;
     }
     return CRM_Core_BAO_SchemaHandler::getRowCountForTable($tableA) <=> CRM_Core_BAO_SchemaHandler::getRowCountForTable($tableB);
-  }
-
-  /**
-   * Return the SQL query for getting only the interesting results out of the dedupe table.
-   *
-   * @$checkPermission boolean $params a flag to indicate if permission should be considered.
-   * default is to always check permissioning but public pages for example might not want
-   * permission to be checked for anonymous users. Refer CRM-6211. We might be beaking
-   * Multi-Site dedupe for public pages.
-   *
-   * @param bool $checkPermission
-   *
-   * @return string
-   */
-  public function thresholdQuery($checkPermission = TRUE) {
-    $aclFrom = '';
-    $aclWhere = '';
-    $dedupeTable = $this->temporaryTables['dedupe'];
-    $contactType = $this->contact_type;
-    $threshold = $this->threshold;
-
-    if ($checkPermission) {
-      [$aclFrom, $aclWhere] = CRM_Contact_BAO_Contact_Permission::cacheClause(['c1', 'c2']);
-      $aclWhere = $aclWhere ? "AND {$aclWhere}" : '';
-    }
-    $query = "SELECT IF(dedupe.id1 < dedupe.id2, dedupe.id1, dedupe.id2) as id1,
-              IF(dedupe.id1 < dedupe.id2, dedupe.id2, dedupe.id1) as id2, dedupe.weight
-              FROM $dedupeTable dedupe JOIN civicrm_contact c1 ON dedupe.id1 = c1.id
-                JOIN civicrm_contact c2 ON dedupe.id2 = c2.id {$aclFrom}
-                LEFT JOIN civicrm_dedupe_exception exc
-                  ON dedupe.id1 = exc.contact_id1 AND dedupe.id2 = exc.contact_id2
-              WHERE c1.contact_type = '{$contactType}' AND
-                    c2.contact_type = '{$contactType}'
-                     AND c1.is_deleted = 0 AND c2.is_deleted = 0
-                    {$aclWhere}
-                    AND weight >= {$threshold} AND exc.contact_id1 IS NULL";
-
-    CRM_Utils_Hook::dupeQuery($this, 'threshold', $query);
-    return $query;
   }
 
   /**


### PR DESCRIPTION
…

Overview
----------------------------------------
Decommission thresholdQuery, only call legacy hook from backward compat extension

This is the second part of https://github.com/civicrm/civicrm-core/pull/31980

Before
----------------------------------------
`thresholdQuery` is called from the legacy extension and the code-to-be-kept. Only the legacy extension (which exists for hook backward compatibility should call the `dupeQuery` hook, but it is in the shared code

After
----------------------------------------
Each path has it's own copy - the path to be kept will be subject to further tidy ups post merge whereas the extension has an 'archive copy'

Technical Details
----------------------------------------

Comments
----------------------------------------
