### PR TITLE
Add guard around CIVICRM_IFRAME constant

### DIFF
--- a/ext/iframe/Civi/Iframe/Cosession.php
+++ b/ext/iframe/Civi/Iframe/Cosession.php
@@ -47,7 +47,8 @@ class Cosession extends AutoService implements EventSubscriberInterface {
   protected ?string $sessionId = NULL;
 
   public function findCreateSessionId(): ?string {
-    if (!defined('CIVICRM_IFRAME')) {
+    // We only want to execute this code if CIVICRM_IFRAME is both defined and is truthy (ie. true/1)
+    if (!(defined('CIVICRM_IFRAME') && CIVICRM_IFRAME)) {
       return NULL;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
See https://github.com/civicrm/civicrm-wordpress/pull/341#issuecomment-2644186966

Before
----------------------------------------
Might crash if CIVICRM_IFRAME is defined and set to falsy

After
----------------------------------------
Won't crash and checks CIVICRM_IFRAME properly

Technical Details
----------------------------------------


Comments
----------------------------------------
