### PR TITLE
[REF] Api3 - Refactor out uses of deprecated CRM_Utils_Array::value.

### DIFF
--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -35,7 +35,7 @@
  * @throws \CRM_Core_Exception
  */
 function civicrm_api3_contact_create($params) {
-  $contactID = CRM_Utils_Array::value('contact_id', $params, $params['id'] ?? NULL);
+  $contactID = $params['contact_id'] ?? $params['id'] ?? NULL;
 
   if ($contactID && !empty($params['check_permissions']) && !CRM_Contact_BAO_Contact_Permission::allow($contactID, CRM_Core_Permission::EDIT)) {
     throw new \Civi\API\Exception\UnauthorizedException('Permission denied to modify contact record');

--- a/api/v3/Contribution/Transact.php
+++ b/api/v3/Contribution/Transact.php
@@ -55,7 +55,7 @@ function civicrm_api3_contribution_transact($params) {
   }
 
   // Some payment processors expect a unique invoice_id - generate one if not supplied
-  $params['invoice_id'] = CRM_Utils_Array::value('invoice_id', $params, md5(uniqid(rand(), TRUE)));
+  $params['invoice_id'] ??= md5(uniqid(rand(), TRUE));
 
   $paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getPayment($params['payment_processor'], $params['payment_processor_mode']);
   $params = $paymentProcessor['object']->doPayment($params);

--- a/api/v3/Domain.php
+++ b/api/v3/Domain.php
@@ -66,7 +66,7 @@ function civicrm_api3_domain_get($params) {
       if (!empty($values['location']['phone'])) {
         $domain['domain_phone'] = [
           'phone_type' => CRM_Core_PseudoConstant::getLabel('CRM_Core_BAO_Phone', 'phone_type_id',
-            CRM_Utils_Array::value('phone_type_id', $values['location']['phone'][1])),
+            $values['location']['phone'][1]['phone_type_id'] ?? NULL),
           'phone' => $values['location']['phone'][1]['phone'] ?? NULL,
         ];
       }

--- a/api/v3/Generic.php
+++ b/api/v3/Generic.php
@@ -477,7 +477,7 @@ function _civicrm_api3_generic_getoptions_spec(&$params, $apiRequest) {
     $fields = civicrm_api3_generic_getfields(['entity' => $apiRequest['entity'], ['params' => ['action' => 'create']]]);
     $params['field']['options'] = [];
     foreach ($fields['values'] as $name => $field) {
-      if (isset($field['pseudoconstant']) || CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_BOOLEAN) {
+      if (isset($field['pseudoconstant']) || ($field['type'] ?? NULL) == CRM_Utils_Type::T_BOOLEAN) {
         $params['field']['options'][$name] = $field['title'] ?? $name;
       }
     }

--- a/api/v3/GroupContact.php
+++ b/api/v3/GroupContact.php
@@ -149,7 +149,7 @@ function civicrm_api3_group_contact_delete($params) {
   if ($groupContact['count'] == 0 && $groupContact2['count'] == 0) {
     throw new CRM_Core_Exception('Cannot Delete GroupContact');
   }
-  $params['status'] = CRM_Utils_Array::value('status', $params, empty($params['skip_undelete']) ? 'Removed' : 'Deleted');
+  $params['status'] ??= (empty($params['skip_undelete']) ? 'Removed' : 'Deleted');
   // "Deleted" isn't a real option so skip the api wrapper to avoid pseudoconstant validation
   return civicrm_api3_group_contact_create($params);
 }


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup to stop using deprecated function.

Comments
---------
Part of me thinks, old code isn't worth updating, but OTOH even old code gets copied around.