### PR TITLE
Fix illogical ignore/skip duplicates handling

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -918,6 +918,8 @@ class CRM_Core_Error extends PEAR_ErrorStack {
   }
 
   /**
+   * @deprecated since 6.1 will be removed around 6.13
+   *
    * @param $message
    * @param int $code
    * @param string $level
@@ -926,6 +928,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * @return object
    */
   public static function createError($message, $code = 8000, $level = 'Fatal', $params = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning('something that is less silly');
     $error = CRM_Core_Error::singleton();
     $error->push($code, $level, [$params], $message);
     return $error;

--- a/tests/phpunit/CRM/Event/Import/Parser/data/participant_with_ext_id.csv
+++ b/tests/phpunit/CRM/Event/Import/Parser/data/participant_with_ext_id.csv
@@ -1,2 +1,3 @@
 Event Title,Campaign ID,External Identifier,Fee Amount,Fee Currency,Fee level,Is Pay Later,Participant Role,Participant Source,Participant Status,Register date,Do not import,Color
 Rain-forest Cup Youth Soccer Tournament,Soccer Cup,ref-77,5000.55,USD,High,No,"Attendee, Volunteer",Phoned up,Registered,2022-12-07,,"Purple, Mauve"
+Second event,Soccer Cup,ref-77,5000.55,USD,High,No,"Attendee, Volunteer",Phoned up,Registered,2022-12-07,,"Purple, Mauve"


### PR DESCRIPTION
Overview
----------------------------------------
The code for importing duplicates offers the option to 'skip' or 'ignore' duplicate contact handling

![image](https://github.com/user-attachments/assets/306efc29-f238-4265-97b4-dcc0ec248e0b)

The help text is messed up for this - but the screen & code imply the expectation is

1) if skip is selected & the contact already has a registration for that event then skip as a duplicate
2) if ignore is selected the contact gets a second duplicate.

However, the code doesn't actually do this
![image](https://github.com/user-attachments/assets/b96e4073-dd65-4286-ba36-3759750e2a99)

Before
----------------------------------------
The code that kicks in for "skip" relies on 
`if (is_array($newParticipant) && civicrm_error($newParticipant)) {`

- However, this is only ever true if `$newParticipant` is set in the `isIgnoreDuplicates()`  if clause. Conversely if `isIgnoreDuplicates` is true the code never attempts to import the contact

After
----------------------------------------
I concluded the `if` that looks up the existing registrations was mistakenly set to `isIgnoreDuplicates()` and should have been `isSkipDuplicates()`

Technical Details
----------------------------------------
I didn't do additional clean up to not add further confusion but the whole error routine is batshit

Comments
----------------------------------------
\