### PR TITLE
FormBuilder - DisplayOnly fields cannot be required

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -263,8 +263,17 @@ class Submit extends AbstractProcessor {
     if (isset($attributes['defn']['required']) && !$attributes['defn']['required']) {
       return NULL;
     }
+    // InputType set to 'DisplayOnly' which skips validation
+    if (($attributes['defn']['input_type'] ?? NULL) === 'DisplayOnly') {
+      return NULL;
+    }
+    // Load full field definition, because $attributes['defn'] only has the form markup
     $fullDefn = FormDataModel::getField($apiEntity, $fieldName, 'create');
 
+    // With the full definition loaded, check input_type again
+    if (($attributes['defn']['input_type'] ?? $fullDefn['input_type']) === 'DisplayOnly') {
+      return NULL;
+    }
     // we don't need to validate the file fields as it's handled separately
     if ($fullDefn['input_type'] === 'File') {
       return NULL;

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformSubmitUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformSubmitUsageTest.php
@@ -1,0 +1,60 @@
+<?php
+namespace Civi\ext\afform\mock\tests\phpunit\api\v4\Afform;
+
+use api\v4\Afform\AfformUsageTestCase;
+use Civi\Api4\Afform;
+
+/**
+ * Test case for Afform with autocomplete.
+ *
+ * @group headless
+ */
+class AfformSubmitUsageTest extends AfformUsageTestCase {
+
+  public function testSubmitWithDisplayOnlyFields(): void {
+
+    $layout = <<<EOHTML
+<af-form ctrl="afform">
+  <af-entity data="{contact_type: 'Individual'}" type="Contact" name="Individual1" label="Individual 1" actions="{create: true, update: true}" url-autofill="1" security="RBAC"  />
+  <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
+    <af-field name="first_name" defn="{input_type: 'DisplayOnly', required: true}" />
+    <af-field name="last_name" />
+  </fieldset>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()">Submit</button>
+</af-form>
+EOHTML;
+
+    $this->useValues([
+      'layout' => $layout,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+    ]);
+
+    $cid = $this->saveTestRecords('Individual', [
+      'records' => [
+        ['first_name' => 'One', 'last_name' => 'Person'],
+      ],
+    ])->column('id');
+
+    $prefill = Afform::prefill()
+      ->setName($this->formName)
+      ->setFillMode('form')
+      ->setArgs(['Individual1' => $cid])
+      ->execute()
+      ->indexBy('name');
+    $this->assertCount(1, $prefill['Individual1']['values']);
+    $this->assertEquals('One', $prefill['Individual1']['values'][0]['fields']['first_name']);
+    $this->assertEquals('Person', $prefill['Individual1']['values'][0]['fields']['last_name']);
+
+    // Submit with empty first_name: should not hit a validation error because DisplayOnly fields cannot be required
+    $submission = [
+      ['fields' => ['last_name' => 'Person']],
+    ];
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues(['Individual1' => $submission])
+      ->setArgs(['Individual1' => $cid])
+      ->execute();
+    $this->assertSame($cid[0], $result[0]['Individual1'][0]['id']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5710](https://lab.civicrm.org/dev/core/-/issues/5710)

Before
----------------------------------------
A field configured as "DisplayOnly" and also "Required" would cause a form validation error.

After
----------------------------------------
No error