### PR TITLE
Avoid fatal error editing CiviMail when current user missing email

### DIFF
--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -83,7 +83,12 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
     $enabledLanguages = CRM_Core_I18n::languages(TRUE);
     $isMultiLingual = (count($enabledLanguages) > 1);
     $requiredTokens = Civi\Core\Resolver::singleton()->call('call://civi_flexmailer_required_tokens/getRequiredTokens', []);
-
+    $default_email = \Civi\Api4\Email::get(TRUE)
+      ->addWhere('contact_id', '=', 'user_contact_id')
+      ->addWhere('is_primary', '=', '')
+      ->setLimit(25)
+      ->execute()
+      ->first()['email'] ?? '';
     $crmMailingSettings = [
       'templateTypes' => CRM_Mailing_BAO_Mailing::getTemplateTypes(),
       'civiMails' => [],
@@ -99,10 +104,7 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
       'disableMandatoryTokensCheck' => (int) Civi::settings()
         ->get('disable_mandatory_tokens_check'),
       'fromAddress' => $fromAddress['values'],
-      'defaultTestEmail' => civicrm_api3('Contact', 'getvalue', [
-        'id' => 'user_contact_id',
-        'return' => 'email',
-      ]),
+      'defaultTestEmail' => $default_email,
       'visibility' => CRM_Utils_Array::makeNonAssociative(CRM_Core_SelectValues::groupVisibility()),
       'workflowEnabled' => CRM_Mailing_Info::workflowEnabled(),
       'reportIds' => $reportIds,

--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -85,7 +85,7 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
     $requiredTokens = Civi\Core\Resolver::singleton()->call('call://civi_flexmailer_required_tokens/getRequiredTokens', []);
     $default_email = \Civi\Api4\Email::get(TRUE)
       ->addWhere('contact_id', '=', 'user_contact_id')
-      ->addWhere('is_primary', '=', '')
+      ->addWhere('is_primary', '=', TRUE)
       ->setLimit(25)
       ->execute()
       ->first()['email'] ?? '';


### PR DESCRIPTION
Overview
----------------------------------------

The default email is now set using API4 with a guard for a null value.

Before
----------------------------------------

If the logged in user (or anonymous) views an edit email screen -> https://smaster.demo.civicrm.org/civicrm/a/#/mailing/1
but doesn't have an email a fatal api 3 error is generated - expected 1 found 25...

(note this link will expire and to recreate the mailing just head to Create New mailing and wait until the url updates to match the above)

Note this route is still protected and access is denied for the anon user once fixed.

After
----------------------------------------

We use API4 to populate the default test email and fall back to empty email address if we can't get it.

Technical Details
----------------------------------------

I have shifted from API3 to API4 because we are living in an API4 world.
