### PR TITLE
Afform - Use entity-specific filter key, revert entity_id generic key

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -1421,7 +1421,7 @@ class CRM_Utils_Array {
       if (!empty($option['children'])) {
         $option['children'] = self::formatForSelect2($option['children'], $label, $id);
       }
-      $option = array_intersect_key($option, array_flip(['id', 'text', 'children', 'color', 'icon', 'description', 'grouping']));
+      $option = array_intersect_key($option, array_flip(['id', 'text', 'children', 'color', 'icon', 'description', 'grouping', 'filter']));
     }
     return $options;
   }

--- a/ang/afform/afsearchTabNote.aff.html
+++ b/ang/afform/afsearchTabNote.aff.html
@@ -1,3 +1,3 @@
 <div af-fieldset="">
-  <crm-search-display-table search-name="Contact_Summary_Notes" display-name="Contact_Summary_Notes_Tab" filters="{entity_id: options.entity_id, entity_table: 'civicrm_contact'}"></crm-search-display-table>
+  <crm-search-display-table search-name="Contact_Summary_Notes" display-name="Contact_Summary_Notes_Tab" filters="{entity_id: options.contact_id, entity_table: 'civicrm_contact'}"></crm-search-display-table>
 </div>

--- a/ang/afform/afsearchTabRel.aff.html
+++ b/ang/afform/afsearchTabRel.aff.html
@@ -1,8 +1,8 @@
 <div af-fieldset="">
-  <crm-search-display-table search-name="Contact_Summary_Relationships" display-name="Contact_Summary_Relationships_Active" filters="{near_contact_id: options.entity_id, is_current: true}"></crm-search-display-table>
+  <crm-search-display-table search-name="Contact_Summary_Relationships" display-name="Contact_Summary_Relationships_Active" filters="{near_contact_id: options.contact_id, is_current: true}"></crm-search-display-table>
   <h3>{{:: ts('Inactive Relationships') }}</h3>
   <div class="help">{{:: ts('These relationships are Disabled OR have a past End Date.') }}</div>
-  <crm-search-display-table search-name="Contact_Summary_Relationships" display-name="Contact_Summary_Relationships_Inactive" filters="{near_contact_id: options.entity_id, is_current: false}"></crm-search-display-table>
+  <crm-search-display-table search-name="Contact_Summary_Relationships" display-name="Contact_Summary_Relationships_Inactive" filters="{near_contact_id: options.contact_id, is_current: false}"></crm-search-display-table>
   <div class="help">
     <strong>{{:: ts('Permissioned Relationships:') }}</strong>
     <i class="crm-i fa-eye"></i> {{:: ts('This contact can be viewed by the other.') }}

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -14,7 +14,7 @@ class AfformAdminMeta {
    */
   public static function getAdminSettings() {
     $afformPlacement = \CRM_Utils_Array::formatForSelect2((array) \Civi\Api4\OptionValue::get(FALSE)
-      ->addSelect('value', 'label', 'icon', 'description', 'grouping')
+      ->addSelect('value', 'label', 'icon', 'description', 'grouping', 'filter')
       ->addWhere('is_active', '=', TRUE)
       ->addWhere('option_group_id:name', '=', 'afform_placement')
       ->addOrderBy('weight')

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -362,7 +362,7 @@
         let requiresServerRoute = false;
         editor.afform.placement.forEach(function(placement) {
           const item = editor.meta.afform_placement.find(item => item.id === placement);
-          if (item && item.grouping === 'server_route') {
+          if (item && item.filter) {
             requiresServerRoute = item.text;
           }
         });

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
@@ -19,7 +19,7 @@
               <a href ng-click="filter.mode = 'val'; filter.value = ''">{{:: ts('Fixed value') }}</a>
             </li>
             <li ng-if="$ctrl.editor.isContactSummary()">
-              <a href ng-click="filter.mode = 'options'; filter.value = 'entity_id';">{{:: ts('Contact being Viewed') }}</a>
+              <a href ng-click="filter.mode = 'options'; filter.value = 'contact_id';">{{:: ts('Contact being Viewed') }}</a>
             </li>
           </ul>
         </div>

--- a/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
+++ b/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
@@ -119,7 +119,7 @@ class ContactAutofill extends AbstractBehavior implements EventSubscriberInterfa
       }
       // Autofill with current entity (e.g. on the contact summary screen)
       if (!$id && $autoFillMode === 'entity_id' && $apiRequest->getFillMode() === 'form') {
-        $id = $apiRequest->getArgs()['entity_id'] ?? NULL;
+        $id = $apiRequest->getArgs()['contact_id'] ?? NULL;
         if ($id) {
           $apiRequest->loadEntity($entity, [['id' => $id]]);
         }

--- a/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
+++ b/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
@@ -286,10 +286,14 @@ class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
       'title' => $item['title'],
       'icon' => $item['icon'],
     ];
+    $entityIdFilter = \CRM_Utils_String::convertStringToSnakeCase($item['extends']) . '_id';
+    // Place in Contact Summary Tabs
     if ($item['extends'] === 'Contact') {
       $afform['placement'] = ['contact_summary_tab'];
     }
     elseif (CoreUtil::isContact($item['extends'])) {
+      // override e.g. "individual_id", we want "contact_id"
+      $entityIdFilter = 'contact_id';
       $afform['placement'] = ['contact_summary_tab'];
       $afform['summary_contact_type'] = [$item['extends']];
     }
@@ -308,6 +312,8 @@ class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
           'saved_search' => 'Custom_' . $item['name'] . '_Search',
           'display_type' => 'table',
           'search_display' => 'Custom_' . $item['name'] . '_Tab',
+          // 'contact_id', 'event_id', etc.
+          'entity_id_filter' => $entityIdFilter,
         ]
       );
     }

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -201,9 +201,7 @@ function afform_civicrm_tabset($tabsetName, &$tabs, $context) {
       // If this is the real contact summary page (and not a callback from ContactLayoutEditor), load module
       // and assign contact id to required smarty variable
       if (empty($context['caller'])) {
-        // Preferred key is entity_id but also assign contact_id to maintain backwards compatibility with older afforms
         CRM_Core_Smarty::singleton()->assign('afformOptions', [
-          'entity_id' => $context['contact_id'],
           'contact_id' => $context['contact_id'],
         ]);
         Civi::service('angularjs.loader')->addModules($afform['module_name']);
@@ -244,7 +242,7 @@ function afform_civicrm_summaryActions(&$actions, $contactID) {
         'weight' => $afform['summary_weight'] ?? 0,
         'icon' => 'crm-i ' . ($afform['icon'] ?: 'fa-list-alt'),
         'class' => 'crm-popup',
-        'href' => CRM_Utils_System::url($afform['server_route'], '', FALSE, "?entity_id=$contactID"),
+        'href' => CRM_Utils_System::url($afform['server_route'], '', FALSE, "?contact_id=$contactID"),
       ];
     }
   }
@@ -269,9 +267,7 @@ function afform_civicrm_pageRun(&$page) {
   $contact = NULL;
   $side = 'left';
   $weight = ['left' => 1, 'right' => 1];
-  // Preferred key is entity_id but also assign contact_id to maintain backwards compatibility with older afforms
   $afformOptions = [
-    'entity_id' => $cid,
     'contact_id' => $cid,
   ];
   foreach ($afforms as $afform) {

--- a/ext/afform/core/managed/AfformPlacement.mgd.php
+++ b/ext/afform/core/managed/AfformPlacement.mgd.php
@@ -102,7 +102,7 @@ return [
         'is_active' => TRUE,
         'icon' => 'fa-bars',
         // Indicates that a server_route is required for this placement
-        'grouping' => 'server_route',
+        'filter' => 1,
         'description' => E::ts('Add to the contact summary actions menu.'),
       ],
       'match' => ['option_group_id', 'name'],

--- a/ext/afform/core/templates/afform/customGroups/afsearchTab.tpl
+++ b/ext/afform/core/templates/afform/customGroups/afsearchTab.tpl
@@ -2,6 +2,6 @@
   <crm-search-display-{$display_type}
     search-name="{$saved_search}"
     display-name="{$search_display}"
-    filters="{ldelim}entity_id: options.entity_id{rdelim}"
+    filters="{ldelim}entity_id: options.{$entity_id_filter}{rdelim}"
     />
 </div>

--- a/ext/afform/core/tests/phpunit/Civi/Afform/AfformContactSummaryTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/AfformContactSummaryTest.php
@@ -151,7 +151,6 @@ class AfformContactSummaryTest extends TestCase implements HeadlessInterface {
     $blockA = \CRM_Core_Region::instance('contact-basic-info-left')->get('afform:' . $this->formNames[2]);
     $this->assertStringContainsString("<af-search-tab-test2 options=", $blockA['markup']);
     $this->assertStringContainsString("\"contact_id\":$cid", $blockA['markup']);
-    $this->assertStringContainsString("\"entity_id\":$cid", $blockA['markup']);
 
     $blockB = \CRM_Core_Region::instance('contact-basic-info-right')->get('afform:' . $this->formNames[1]);
     $this->assertStringContainsString("<af-form-tab-test1 options=", $blockB['markup']);

--- a/ext/afform/core/tests/phpunit/Civi/Afform/AfformContactSummaryTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/AfformContactSummaryTest.php
@@ -156,7 +156,6 @@ class AfformContactSummaryTest extends TestCase implements HeadlessInterface {
     $blockB = \CRM_Core_Region::instance('contact-basic-info-right')->get('afform:' . $this->formNames[1]);
     $this->assertStringContainsString("<af-form-tab-test1 options=", $blockB['markup']);
     $this->assertStringContainsString("\"contact_id\":$cid", $blockB['markup']);
-    $this->assertStringContainsString("\"entity_id\":$cid", $blockB['markup']);
 
     // Block for wrong contact type should not appear
     $this->assertNull(\CRM_Core_Region::instance('contact-basic-info-left')->get('afform:' . $this->formNames[0]));

--- a/ext/civicrm_admin_ui/ang/afformTabMember.aff.html
+++ b/ext/civicrm_admin_ui/ang/afformTabMember.aff.html
@@ -1,11 +1,11 @@
 <div af-fieldset="">
-  <crm-search-display-table search-name="Contact_Summary_Memberships" display-name="Contact_Summary_Memberships_Active" filters="{contact_id: options.entity_id, 'status_id.is_current_member': true}"></crm-search-display-table>
+  <crm-search-display-table search-name="Contact_Summary_Memberships" display-name="Contact_Summary_Memberships_Active" filters="{contact_id: options.contact_id, 'status_id.is_current_member': true}"></crm-search-display-table>
   <h3>{{:: ts('Pending and Inactive Memberships') }}</h3>
-  <crm-search-display-table search-name="Contact_Summary_Memberships" display-name="Contact_Summary_Memberships_Inactive" filters="{contact_id: options.entity_id, 'status_id.is_current_member': false}"></crm-search-display-table>
+  <crm-search-display-table search-name="Contact_Summary_Memberships" display-name="Contact_Summary_Memberships_Inactive" filters="{contact_id: options.contact_id, 'status_id.is_current_member': false}"></crm-search-display-table>
 </div>
 <div class="af-markup">
   <hr />
 </div>
 <div af-fieldset="" af-title="Membership Types">
-  <crm-search-display-table search-name="Contact_Summary_Membership_Type" display-name="Contact_Summary_Membership_Type" filters="{member_of_contact_id: options.entity_id, 'is_active': true}"></crm-search-display-table>
+  <crm-search-display-table search-name="Contact_Summary_Membership_Type" display-name="Contact_Summary_Membership_Type" filters="{member_of_contact_id: options.contact_id, 'is_active': true}"></crm-search-display-table>
 </div>

--- a/ext/civicrm_admin_ui/ang/afsearchTabActivity.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchTabActivity.aff.html
@@ -5,5 +5,5 @@
     <af-field name="status_id" defn="{input_attrs: {multiple: true, placeholder: ts('Status')}, label: false}" />
     <af-field name="activity_date_time" defn="{input_type: 'Select', search_range: true, input_attrs: {placeholder: ts('Date')}, label: false}" />
   </div>
-  <crm-search-display-table search-name="Contact_Summary_Activities" display-name="Contact_Summary_Activities_Tab" filters="{'Activity_ActivityContact_Contact_01.id': options.entity_id}"></crm-search-display-table>
+  <crm-search-display-table search-name="Contact_Summary_Activities" display-name="Contact_Summary_Activities_Tab" filters="{'Activity_ActivityContact_Contact_01.id': options.contact_id}"></crm-search-display-table>
 </div>

--- a/ext/civicrm_admin_ui/ang/afsearchTabMember.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchTabMember.aff.html
@@ -1,5 +1,5 @@
 <div af-fieldset="">
-  <crm-search-display-table search-name="Contact_Summary_Memberships" display-name="Contact_Summary_Memberships_Active" filters="{contact_id: options.entity_id, 'status_id.is_current_member': true}"></crm-search-display-table>
+  <crm-search-display-table search-name="Contact_Summary_Memberships" display-name="Contact_Summary_Memberships_Active" filters="{contact_id: options.contact_id, 'status_id.is_current_member': true}"></crm-search-display-table>
   <h3>{{:: ts('Pending and Inactive Memberships') }}</h3>
-  <crm-search-display-table search-name="Contact_Summary_Memberships" display-name="Contact_Summary_Memberships_Inactive" filters="{contact_id: options.entity_id, 'status_id.is_current_member': false}"></crm-search-display-table>
+  <crm-search-display-table search-name="Contact_Summary_Memberships" display-name="Contact_Summary_Memberships_Inactive" filters="{contact_id: options.contact_id, 'status_id.is_current_member': false}"></crm-search-display-table>
 </div>

--- a/ext/civicrm_admin_ui/ang/afsearchTabParticipant.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchTabParticipant.aff.html
@@ -1,3 +1,3 @@
 <div af-fieldset="">
-  <crm-search-display-table search-name="Contact_Summary_Events" display-name="Contact_Summary_Events_Tab" filters="{contact_id: options.entity_id}"></crm-search-display-table>
+  <crm-search-display-table search-name="Contact_Summary_Events" display-name="Contact_Summary_Events_Tab" filters="{contact_id: options.contact_id}"></crm-search-display-table>
 </div>

--- a/ext/civicrm_admin_ui/civicrm_admin_ui.php
+++ b/ext/civicrm_admin_ui/civicrm_admin_ui.php
@@ -88,7 +88,7 @@ function civicrm_admin_ui_civicrm_tabset($tabsetName, &$tabs, $context) {
     case 'civicrm/event/manage':
       $entities = ['Event'];
       \CRM_Core_Smarty::singleton()->assign('afformOptions', [
-        'entity_id' => $context['event_id'] ?? NULL,
+        'event_id' => $context['event_id'] ?? NULL,
       ]);
       break;
 

--- a/ext/civigrant/ang/afsearchTabGrant.aff.html
+++ b/ext/civigrant/ang/afsearchTabGrant.aff.html
@@ -1,3 +1,3 @@
 <div af-fieldset="">
-  <crm-search-display-table search-name="CiviGrant_Summary" display-name="Grant_Tab" filters="{'contact_id': options.entity_id}"></crm-search-display-table>
+  <crm-search-display-table search-name="CiviGrant_Summary" display-name="Grant_Tab" filters="{'contact_id': options.contact_id}"></crm-search-display-table>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Reverts 2 bad decisions before they get locked into a release.

Technical Details
----------------------------------------
### Bad decision 1:

Back in #31606 @ufundo tried to move us toward a generic `entity_id` passed into tabs and blocks instead of `contact_id`, which seemed sensible, so then in #31836 I made the switch in FormBuilder. Fortunately that hasn't made it into the stable release yet, because I've changed my mind. This switches it back.
The reason to stick with `contact_id`, `event_id`, etc. instead of `entity_id` is that these placements are all context-specific; they don't need to be generalized that much, and it's better that they aren't. This change opens the possibility of multi-entity contexts, like the case summary screen which would have *both* `case_id` *and* `contact_id` passed into the form.

### Bad decision 2:

In #31838 I utilized the unused field "grouping" in the "afform_placement" OptionValues to indicate whether a placement requires a url. I've changed my mind about that too, because I'd rather use "grouping" to indicate contexts (see above) and it's a bigger field better suited to that. So I've switched this flag over to another unused column "filter" which still works fine.


Comments
-------
This doesn't affect any stable releases & these changes have only been in beta for 5 days, so let's revert them now! If anyone actually downloaded the beta in the past 5 days and created an afform for use on the contact summary tab/block/menu, then they'll just have to manually update their form to fix the filter.