### PR TITLE
[REF] - Simplify redundant calls to `empty()` function

### DIFF
--- a/CRM/Admin/Form/WordReplacements.php
+++ b/CRM/Admin/Form/WordReplacements.php
@@ -199,7 +199,7 @@ class CRM_Admin_Form_WordReplacements extends CRM_Core_Form {
     for ($i = 1; $i <= $this->_numStrings; $i++) {
       if (!empty($params['new'][$i]) && !empty($params['old'][$i])) {
         if (isset($params['enabled']) && !empty($params['enabled'][$i])) {
-          if (!empty($params['cb']) && !empty($params['cb'][$i])) {
+          if (!empty($params['cb'][$i])) {
             $enabled['exactMatch'] += [$params['old'][$i] => $params['new'][$i]];
           }
           else {

--- a/CRM/Contact/BAO/ProximityQuery.php
+++ b/CRM/Contact/BAO/ProximityQuery.php
@@ -238,9 +238,7 @@ ACOS(
     $qill = [];
     foreach ($proximityVars as $var => $recordQill) {
       $proximityValues = $query->getWhereValues("prox_{$var}", $grouping);
-      if (!empty($proximityValues) &&
-        !empty($proximityValues[2])
-      ) {
+      if (!empty($proximityValues[2])) {
         $proximityAddress[$var] = $proximityValues[2];
         if ($recordQill) {
           $qill[] = $proximityValues[2];

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -131,7 +131,7 @@ class CRM_Contact_Form_Edit_Address {
     }
 
     $entityId = NULL;
-    if (!empty($form->_values['address']) && !empty($form->_values['address'][$blockId])) {
+    if (!empty($form->_values['address'][$blockId])) {
       $entityId = $form->_values['address'][$blockId]['id'];
     }
 

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4016,7 +4016,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         ->addOrderBy('id', 'DESC')
         ->execute()
         ->first();
-      if (!empty($preChangeMembership) && !empty($preChangeMembership['membership_type_id'])) {
+      if (!empty($preChangeMembership['membership_type_id'])) {
         $membershipParams['membership_type_id'] = $preChangeMembership['membership_type_id'];
       }
       if (empty($membership['end_date']) || (int) $membership['status_id'] !== CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Pending')) {

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -794,7 +794,7 @@ LEFT  JOIN civicrm_membership_payment mp  ON ( mp.contribution_id = con.id )
         break;
       }
       // If data has been entered for a recurring field, tell the tpl layer to open the pane
-      if (!empty($form->_formValues) && !empty($form->_formValues[$key . '_relative']) || !empty($form->_formValues[$key . '_low']) || !empty($form->_formValues[$key . '_high'])) {
+      if (!empty($form->_formValues[$key . '_relative']) || !empty($form->_formValues[$key . '_low']) || !empty($form->_formValues[$key . '_high'])) {
         $form->assign('contribution_recur_pane_open', TRUE);
         break;
       }

--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -114,7 +114,7 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
     $defaultDashlets = [];
     $defaults = ['blog' => 1, 'getting-started' => '0'];
     foreach ($defaults as $name => $column) {
-      if (!empty($allDashlets[$name]) && !empty($allDashlets[$name]['id'])) {
+      if (!empty($allDashlets[$name]['id'])) {
         $defaultDashlets[$name] = [
           'dashboard_id' => $allDashlets[$name]['id'],
           'is_active' => 1,

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2355,7 +2355,6 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
           else {
             if (is_array($details)) {
               if ($fieldName === 'url'
-                && !empty($details['website'])
                 && !empty($details['website'][$locTypeId])
               ) {
                 $defaults[$fldName] = $details['website'][$locTypeId]['url'] ?? NULL;

--- a/CRM/Core/Payment/ProcessorForm.php
+++ b/CRM/Core/Payment/ProcessorForm.php
@@ -106,7 +106,7 @@ class CRM_Core_Payment_ProcessorForm {
       CRM_Core_Error::statusBounce(ts('Payment processor is not set for this page'));
     }
 
-    if (!empty($form->_membershipBlock) && !empty($form->_membershipBlock['is_separate_payment']) &&
+    if (!empty($form->_membershipBlock['is_separate_payment']) &&
       (!empty($form->_paymentProcessor['class_name']) &&
         !$paymentObject->supports('MultipleConcurrentPayments')
       )
@@ -130,7 +130,7 @@ class CRM_Core_Payment_ProcessorForm {
     // because payment processor is not selected
     $processorId = $form->getPaymentProcessorID();
     $billing_profile_id = CRM_Utils_Request::retrieve('billing_profile_id', 'String');
-    if (!empty($form->_values) && !empty($form->_values['is_billing_required'])) {
+    if (!empty($form->_values['is_billing_required'])) {
       $billing_profile_id = 'billing';
     }
     if (!empty($processorId)) {

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -2578,7 +2578,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
 
     // Now, build the table rows appropriately, based off the information on
     // the 'other' contact
-    if (!empty($locations['other']) && !empty($locations['other'][$blockName])) {
+    if (!empty($locations['other'][$blockName])) {
       foreach ($locations['other'][$blockName] as $count => $value) {
 
         $displayValue = $value[$blockInfo['displayField']];

--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -731,7 +731,7 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
                   if (!empty($value['is_default'])) {
                     $fieldParams['default_option'] = $value['weight'];
                   }
-                  if (!empty($discountFieldIDs[$j]) && !empty($discountFieldIDs[$j][$value['weight']])) {
+                  if (!empty($discountFieldIDs[$j][$value['weight']])) {
                     $fieldParams['option_id'][$value['weight']] = $discountFieldIDs[$j][$value['weight']];
                     unset($discountFieldIDs[$j][$value['weight']]);
                   }

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -84,7 +84,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     $this->assign('confirm_text', $this->getEventValue('confirm_text'));
     CRM_Utils_Hook::eventDiscount($this, $this->_params);
 
-    if (!empty($this->_params[0]['discount']) && !empty($this->_params[0]['discount']['applied'])) {
+    if (!empty($this->_params[0]['discount']['applied'])) {
       $this->set('hookDiscount', $this->_params[0]['discount']);
     }
     $this->assign('hookDiscount', $this->_params[0]['discount'] ?? '');
@@ -403,7 +403,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
 
     // if a discount has been applied, lets now deduct it from the amount
     // and fix the fee level
-    if (!empty($this->_params[0]['discount']) && !empty($this->_params[0]['discount']['applied'])) {
+    if (!empty($this->_params[0]['discount']['applied'])) {
       foreach ($this->_params as $k => $v) {
         if (($this->_params[$k]['amount'] ?? NULL) > 0 && !empty($this->_params[$k]['discountAmount'])) {
           $this->_params[$k]['amount'] -= $this->_params[$k]['discountAmount'];

--- a/CRM/Mailing/Controller/Send.php
+++ b/CRM/Mailing/Controller/Send.php
@@ -39,7 +39,7 @@ class CRM_Mailing_Controller_Send extends CRM_Core_Controller {
     if ($mid && $continue) {
       //CRM-15979 - check if abtest exist for mailing then redirect accordingly
       $abtest = CRM_Mailing_BAO_MailingAB::getABTest($mid);
-      if (!empty($abtest) && !empty($abtest->id)) {
+      if (!empty($abtest->id)) {
         $redirect = CRM_Utils_System::url('civicrm/a/', NULL, TRUE, '/abtest/' . $abtest->id);
       }
       else {

--- a/CRM/Mailing/Page/Report.php
+++ b/CRM/Mailing/Page/Report.php
@@ -82,7 +82,7 @@ class CRM_Mailing_Page_Report extends CRM_Core_Page_Basic {
     $this->_mailing_id = CRM_Utils_Request::retrieve('mid', 'Positive', $this);
     //CRM-15979 - check if abtest exist for mailing then redirect accordingly
     $abtest = CRM_Mailing_BAO_MailingAB::getABTest($this->_mailing_id);
-    if (!empty($abtest) && !empty($abtest->id)) {
+    if (!empty($abtest->id)) {
       CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/a/', NULL, TRUE, '/abtest/' . $abtest->id));
     }
     // check that the user has permission to access mailing id

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -152,7 +152,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           throw new CRM_Core_Exception($e->getMessage());
         }
       }
-      elseif (!empty($optionsIds) && !empty($optionsIds['id'])) {
+      elseif (!empty($optionsIds['id'])) {
         $optionsLoad = civicrm_api3('price_field_value', 'get', ['id' => $optionsIds['id']]);
         $options = $optionsLoad['values'][$optionsIds['id']];
         $options['is_active'] = $params['is_active'] ?? 1;

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2820,8 +2820,7 @@ class CRM_Report_Form extends CRM_Core_Form {
             continue;
           }
 
-          if (!empty($this->_params['group_bys']) &&
-            !empty($this->_params['group_bys'][$fieldName]) &&
+          if (!empty($this->_params['group_bys'][$fieldName]) &&
             !empty($this->_params['group_bys_freq'])
           ) {
             switch ($this->_params['group_bys_freq'][$fieldName] ?? NULL) {

--- a/CRM/Report/Form/Contribute/Lybunt.php
+++ b/CRM/Report/Form/Contribute/Lybunt.php
@@ -495,7 +495,7 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
     // Perhaps that works on some other report? But here it just seems odd.
     $this->countStat($statistics, count($rows));
     if (!empty($rows)) {
-      if (!empty($this->rollupRow) && !empty($this->rollupRow['civicrm_contribution_last_year_total_amount'])) {
+      if (!empty($this->rollupRow['civicrm_contribution_last_year_total_amount'])) {
         $statistics['counts']['civicrm_contribution_last_year_total_amount'] = [
           'value' => $this->rollupRow['civicrm_contribution_last_year_total_amount'],
           'title' => $this->getLastYearColumnTitle(),
@@ -503,7 +503,7 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
         ];
 
       }
-      if (!empty($this->rollupRow) && !empty($this->rollupRow['civicrm_contribution_civicrm_life_time_total'])) {
+      if (!empty($this->rollupRow['civicrm_contribution_civicrm_life_time_total'])) {
         $statistics['counts']['civicrm_contribution_civicrm_life_time_total'] = [
           'value' => $this->rollupRow['civicrm_contribution_civicrm_life_time_total'],
           'title' => ts('Total LifeTime'),

--- a/CRM/Utils/Schema.php
+++ b/CRM/Utils/Schema.php
@@ -112,7 +112,7 @@ class CRM_Utils_Schema {
    */
   public static function getSize(SimpleXMLElement $fieldXML): string {
     // Extract from <size> tag if supplied
-    if (!empty($fieldXML->html) && !empty($fieldXML->html->size)) {
+    if (!empty($fieldXML->html->size)) {
       return (string) $fieldXML->html->size;
     }
     return self::getDefaultSize(self::toString('length', $fieldXML));

--- a/api/class.api.php
+++ b/api/class.api.php
@@ -181,7 +181,7 @@ class civicrm_api3 {
     $this->local      = TRUE;
     $this->input      = [];
     $this->lastResult = new stdClass();
-    if (!empty($config) && !empty($config['server'])) {
+    if (!empty($config['server'])) {
       // we are calling a remote server via REST
       $this->local = FALSE;
       $this->uri = $config['server'];
@@ -207,7 +207,7 @@ class civicrm_api3 {
       $this->useragent = !empty($config['useragent']) ? $config['useragent'] : 'curl';
       return;
     }
-    if (!empty($config) && !empty($config['conf_path'])) {
+    if (!empty($config['conf_path'])) {
       if (!defined('CIVICRM_SETTINGS_PATH')) {
         define('CIVICRM_SETTINGS_PATH', $config['conf_path'] . '/civicrm.settings.php');
       }

--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -710,7 +710,7 @@ function civicrm_api3_case_getList($params) {
   require_once 'api/v3/Generic/Getlist.php';
   require_once 'api/v3/CaseContact.php';
   //CRM:19956 - Assign case_id param if both id and case_id is passed to retrieve the case
-  if (!empty($params['id']) && !empty($params['params']) && !empty($params['params']['case_id'])) {
+  if (!empty($params['id']) && !empty($params['params']['case_id'])) {
     $params['params']['case_id'] = ['IN' => $params['id']];
     unset($params['id']);
   }

--- a/api/v3/CaseType.php
+++ b/api/v3/CaseType.php
@@ -41,7 +41,7 @@ function civicrm_api3_case_type_create($params) {
  *   case types keyed by id
  */
 function civicrm_api3_case_type_get($params) {
-  if (!empty($params['options']) && !empty($params['options']['is_count'])) {
+  if (!empty($params['options']['is_count'])) {
     return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
   }
   $caseTypes = _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);

--- a/api/v3/Domain.php
+++ b/api/v3/Domain.php
@@ -31,7 +31,7 @@ function civicrm_api3_domain_get($params) {
   if (!empty($params['current_domain'])) {
     $params['id'] = CRM_Core_Config::domainID();
   }
-  if (!empty($params['options']) && !empty($params['options']['is_count'])) {
+  if (!empty($params['options']['is_count'])) {
     return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
   }
 

--- a/ext/flexmailer/src/Listener/OpenTracker.php
+++ b/ext/flexmailer/src/Listener/OpenTracker.php
@@ -34,7 +34,7 @@ class OpenTracker extends AutoService {
       /** @var \Civi\FlexMailer\FlexMailerTask $task */
       $mailParams = $task->getMailParams();
 
-      if (!empty($mailParams) && !empty($mailParams['html'])) {
+      if (!empty($mailParams['html'])) {
         $openUrl = \CRM_Utils_System::externUrl('extern/open', 'q=' . $task->getEventQueueId());
         $mailParams['html'] .= "\n" . '<img src="' . htmlentities($openUrl) . "\" width='1' height='1' alt='' border='0'>";
 


### PR DESCRIPTION
Overview
----------------------------------------
Overly-verbose code cleanup.

Technical Details
----------------------------------------
The `empty()` function will automatically handle the case where the first part of the expression is not set, so there's no need to add an extra call to `empty()`.
