### PR TITLE
Remove DEFAULT_THEME handling

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixOne.php
+++ b/CRM/Upgrade/Incremental/php/SixOne.php
@@ -31,6 +31,8 @@ class CRM_Upgrade_Incremental_php_SixOne extends CRM_Upgrade_Incremental_Base {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
 
     $this->addTask('Replace Clear Caches & Reset Paths with Clear Caches in Nav Menu', 'updateUpdateConfigBackendNavItem');
+
+    $this->addExtensionTask('Enable Riverlea extension', ['riverlea']);
   }
 
   /**

--- a/CRM/Upgrade/Incremental/php/SixOne.php
+++ b/CRM/Upgrade/Incremental/php/SixOne.php
@@ -33,6 +33,28 @@ class CRM_Upgrade_Incremental_php_SixOne extends CRM_Upgrade_Incremental_Base {
     $this->addTask('Replace Clear Caches & Reset Paths with Clear Caches in Nav Menu', 'updateUpdateConfigBackendNavItem');
 
     $this->addExtensionTask('Enable Riverlea extension', ['riverlea']);
+    $this->addTask('Freeze "default" theme to Greenwich', 'freezeDefaultThemeToGreenwich');
+  }
+
+  /**
+   * 'default' is being removed as a valid theme choice.
+   *
+   * It has always meant Greenwich, so sites previously on
+   * "default" change this to an explicit value Greenwich.
+   *
+   * @return bool
+   */
+  public static function freezeDefaultThemeToGreenwich() {
+    $themeSettings = ['theme_backend', 'theme_frontend'];
+
+    foreach ($themeSettings as $key) {
+      $value = \Civi::settings()->get($key);
+      if ($value === 'default') {
+        \Civi::settings()->set($key, 'greenwich');
+      }
+    }
+
+    return TRUE;
   }
 
   /**

--- a/Civi/Core/Themes.php
+++ b/Civi/Core/Themes.php
@@ -22,10 +22,14 @@ use Civi;
 class Themes extends \Civi\Core\Service\AutoService {
 
   /**
-   * No theme only uses core CSS. It is what you get if your theme is set to an
-   * unavailable theme.
+   * Disable core CSS.
    */
-  const NO_THEME = 'none';
+  const NO_STYLES = 'none';
+
+  /**
+   * Core CSS only.
+   */
+  const NO_THEME = 'no_theme';
 
   /**
    * Fallback is a pseudotheme which can be included in "search_order".
@@ -201,15 +205,20 @@ class Themes extends \Civi\Core\Service\AutoService {
    */
   protected function buildAll() {
     $themes = [
-      self::NO_THEME => [
+      self::NO_STYLES => [
         'ext' => 'civicrm',
-        'title' => ts('None (Unstyled)'),
+        'title' => ts('No Styles'),
         'help' => ts('Disable CiviCRM\'s built-in CSS files.'),
-        'search_order' => ['none', self::FALLBACK_THEME],
+        'search_order' => [self::NO_STYLES, self::FALLBACK_THEME],
         'excludes' => [
           "css/civicrm.css",
           "css/bootstrap.css",
         ],
+      ],
+      self::NO_THEME => [
+        'ext' => 'civicrm',
+        'title' => ts('No Theme'),
+        'search_order' => [self::NO_THEME, self::FALLBACK_THEME],
       ],
       self::FALLBACK_THEME => [
         'ext' => 'civicrm',

--- a/ext/greenwich/info.xml
+++ b/ext/greenwich/info.xml
@@ -16,9 +16,6 @@
   </urls>
   <releaseDate>[civicrm.releaseDate]</releaseDate>
   <version>[civicrm.version]</version>
-  <tags>
-    <tag>mgmt:hidden</tag>
-  </tags>
   <develStage>stable</develStage>
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -1184,7 +1184,7 @@ return [
     'pseudoconstant' => array(
       'callback' => 'call://themes/getAvailable',
     ),
-    'default' => 'default',
+    'default' => 'no_theme',
     'add' => '5.16',
     'title' => ts('Frontend Theme'),
     'is_domain' => 1,
@@ -1209,7 +1209,7 @@ return [
     'pseudoconstant' => array(
       'callback' => 'call://themes/getAvailable',
     ),
-    'default' => 'default',
+    'default' => 'no_theme',
     'add' => '5.16',
     'title' => ts('Backend Theme'),
     'is_domain' => 1,

--- a/tests/phpunit/Civi/Core/ThemesTest.php
+++ b/tests/phpunit/Civi/Core/ThemesTest.php
@@ -54,10 +54,23 @@ class ThemesTest extends \CiviUnitTestCase {
 
     // --- Library of tests ---
 
-    // Use the default theme, Greenwich.
+    // Use Minetta from Riverlea
+    // TODO: why is Greenwich enabled here, but Riverlea is not?
+    // $cases[] = [
+    //   [],
+    //   'minetta',
+    //   'Minetta (RiverLea ~Greenwich)',
+    //   [
+    //     'civicrm-css/civicrm.css' => ["$civicrmBaseUrl/ext/riverlea/core/css/civicrm.css"],
+    //     'civicrm-css/joomla.css' => ["$civicrmBaseUrl/ext/riverlea/core/css/joomla.css"],
+    //     'test.extension.uitest-files/foo.css' => ["$civicrmBaseUrl/tests/extensions/test.extension.uitest/files/foo.css"],
+    //   ],
+    // ];
+
+    // Use Greenwich
     $cases[] = [
       [],
-      'default',
+      'greenwich',
       'Greenwich',
       [
         'civicrm-css/civicrm.css' => ["$civicrmBaseUrl/css/civicrm.css"],
@@ -82,11 +95,11 @@ class ThemesTest extends \CiviUnitTestCase {
       ],
     ];
 
-    // Misconfiguration: liza was previously used but then disappeared. Fallback to default, Greenwich.
+    // Misconfiguration: liza was previously used but then disappeared. Fallback to default, NO_THEME.
     $cases[] = [
       $hookJudy,
       'liza',
-      'Greenwich',
+      'No Theme',
       [
         'civicrm-css/civicrm.css' => ["$civicrmBaseUrl/css/civicrm.css"],
         'civicrm-css/joomla.css' => ["$civicrmBaseUrl/css/joomla.css"],
@@ -98,7 +111,7 @@ class ThemesTest extends \CiviUnitTestCase {
     $cases[] = [
       $hookJudy,
       'none',
-      'None (Unstyled)',
+      'No Styles',
       [
         'civicrm-css/civicrm.css' => [],
         'civicrm-css/joomla.css' => ["$civicrmBaseUrl/css/joomla.css"],
@@ -195,15 +208,20 @@ class ThemesTest extends \CiviUnitTestCase {
     return $map[$themeKey][$cssExt][$cssFile] ?? Themes::PASSTHRU;
   }
 
+  /**
+   * TODO with all these: why do we have greenwich not minetta here?
+   */
   public function testGetAll(): void {
     $all = \Civi::service('themes')->getAll();
     $this->assertTrue(isset($all['greenwich']));
+    // $this->assertTrue(isset($all['minetta']));
     $this->assertTrue(isset($all['_fallback_']));
   }
 
   public function testGetAvailable(): void {
     $all = \Civi::service('themes')->getAvailable();
     $this->assertTrue(isset($all['greenwich']));
+    // $this->assertTrue(isset($all['minetta']));
     $this->assertFalse(isset($all['_fallback_']));
   }
 
@@ -212,6 +230,7 @@ class ThemesTest extends \CiviUnitTestCase {
       'field' => 'theme_backend',
     ]);
     $this->assertTrue(isset($result['values']['greenwich']));
+    // $this->assertTrue(isset($result['values']['minetta']));
     $this->assertFalse(isset($result['values']['_fallback_']));
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove DEFAULT_THEME handling and Greenwich dependency. Follow up to https://github.com/civicrm/civicrm-core/pull/31985

Before
----------------------------------------
- `default` = "Automatic" theme option, which gives you Greenwich
- Greenwich is required

After
----------------------------------------
- no `default` = "Automatic" theme option
- people previously on "default" switched to explicit Greenwich on upgrade
- Riverlea should be installed during install/uprade
- "minetta" is the default for each theme setting. If not available will give you no theme.
- Greenwich is no longer hidden/required, can be disabled if desired


Comments
--------‐‐------------
In previous PR's @totten concluded that the theme setting *should* have an explicit value. Based on this I think its reasonable that an invalid value falls back to no theme (just core css) => indicates to the user they need to pick a theme. This also avoids any dependency on any specific theme.