### PR TITLE
Fix typo in release notes

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -28,7 +28,7 @@ Released February 5, 2025
 
 ## CiviCRM 5.81.0
 
-eleased January 8, 2025
+Released January 8, 2025
 
 - **[Synopsis](release-notes/5.81.0.md#synopsis)**
 - **[Features](release-notes/5.81.0.md#features)**


### PR DESCRIPTION
Fixes a fatal error in the Extension File Overrides extension that parses the release notes:

https://github.com/konadave/com.klangsoft.overrides/issues/11

Looking at git blame this typo was [added on 6 Feb 2025](https://github.com/civicrm/civicrm-core/commit/edf7cc98e19f7e03650d563ddce2fa7788e19af7) so is a recent change.

