### PR TITLE
Standalone - Fix crash when viewing afform

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -145,10 +145,9 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
       \Civi::log()->warning('Non-array passed to appendBreadCrumb');
       return;
     }
-    $crumbs = \Civi::$statics[__CLASS__]['breadcrumb'] ?? [];
-    $crumbs += array_column($breadcrumbs, NULL, 'url');
-    \Civi::$statics[__CLASS__]['breadcrumb'] = $crumbs;
-    CRM_Core_Smarty::singleton()->assign('breadcrumb', array_values($crumbs));
+    $allCrumbs = array_merge(\Civi::$statics[__CLASS__]['breadcrumb'] ?? [], $breadcrumbs);
+    \Civi::$statics[__CLASS__]['breadcrumb'] = $allCrumbs;
+    CRM_Core_Smarty::singleton()->assign('breadcrumb', array_values($allCrumbs));
   }
 
   /**

--- a/ext/afform/core/CRM/Afform/Page/AfformBase.php
+++ b/ext/afform/core/CRM/Afform/Page/AfformBase.php
@@ -33,8 +33,10 @@ class CRM_Afform_Page_AfformBase extends CRM_Core_Page {
           ->execute()->first();
         if (!empty($navParent['url'])) {
           CRM_Utils_System::resetBreadCrumb();
-          CRM_Utils_System::appendBreadCrumb([['title' => E::ts('CiviCRM'), 'url' => Civi::url('current://civicrm')]]);
-          CRM_Utils_System::appendBreadCrumb([['title' => $navParent['label'], 'url' => Civi::url('current://' . $navParent['url'])]]);
+          CRM_Utils_System::appendBreadCrumb([
+            ['title' => E::ts('CiviCRM'), 'url' => Civi::url('current://civicrm', 'h')],
+            ['title' => ts($navParent['label']), 'url' => Civi::url('current://' . $navParent['url'], 'h')],
+          ]);
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes fatal crash on Standalone when viewing certain Afforms.

Technical Details
----------------------------------------
If an afform is in the menu, and the parent of that menu item has a url, the afform gets a special breadcrumb. This was crashing on standalone because Civi::url returns a stringable object, not a string, which cannot be directly used as an array key.

Also, less fatal but still worth fixing, the 'h' flag wasn't being passed for html escaping of the breadcrumb url, and the menu label wasn't being translated.