### PR TITLE
dev/financial#230 - don't send email receipt when changing payment method on a contribution

### DIFF
--- a/CRM/Financial/Form/PaymentEdit.php
+++ b/CRM/Financial/Form/PaymentEdit.php
@@ -226,6 +226,7 @@ class CRM_Financial_Form_PaymentEdit extends CRM_Core_Form {
       $newFinancialTrxn['total_amount'] = $this->_values['total_amount'];
       $newFinancialTrxn['currency'] = $this->_values['currency'];
       $newFinancialTrxn['contribution_id'] = $this->getContributionID();
+      $newFinancialTrxn['is_send_contribution_notification'] = FALSE;
       $newFinancialTrxn += $this->getSubmittedCustomFields();
       civicrm_api3('Payment', 'create', $newFinancialTrxn);
     }

--- a/tests/phpunit/CRM/Financial/Form/PaymentEditTest.php
+++ b/tests/phpunit/CRM/Financial/Form/PaymentEditTest.php
@@ -66,10 +66,11 @@ class CRM_Financial_Form_PaymentEditTest extends CiviUnitTestCase {
       'trxn_id' => 'txn_12',
       'trxn_date' => date('Y-m-d H:i:s'),
     ];
-    $this->getTestForm('CRM_Financial_Form_PaymentEdit', $params, [
+    $email = $this->getTestForm('CRM_Financial_Form_PaymentEdit', $params, [
       'contribution_id' => $contribution['id'],
       'id' => $financialTrxnInfo['id'],
-    ])->processForm();
+    ])->processForm()->getFirstMail();
+    $this->assertEmpty($email, 'Changing payment method should not send an email');
 
     $payments = CRM_Contribute_BAO_Contribution::getPaymentInfo($contribution['id'], 'contribute', TRUE);
     $expectedPaymentParams = [


### PR DESCRIPTION
Overview
----------------------------------------
This is the other half of https://lab.civicrm.org/dev/financial/-/issues/230

Before
----------------------------------------
1. Create a contribution.
2. Go back and edit it.
3. Edit the payment in the payments section and change the payment method.
4. The donor receives a receipt. Why? And this is undesirable and confusing if it's being changed as part of a year-end cleanup or even years later.

After
----------------------------------------
No email.

Technical Details
----------------------------------------

Comments
----------------------------------------

