### PR TITLE
Civi::rebuild() - Consolidate super-functions rebuildMenuAndCaches, flushCache, and cleanupCaches

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -270,7 +270,7 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
    *   Deprecated Feb 2025 in favor of Civi::rebuild().
    *   Reassess after Jun 2026.
    *   For an extension bridging before+after, suggest guard like:
-   *     if (version_compare(CRM_Utils_System::version(), 'X.Y.Z', '>=')) Civi::rebuild([...]) :
+   *     if (version_compare(CRM_Utils_System::version(), 'X.Y.Z', '>=')) Civi::rebuild(...)->execute()
    *     else CRM_Core_Config::singleton()->cleanupCaches();
    *   Choose an 'X.Y.Z' after determining that your preferred rebuild-target(s) are specifically available in X.Y.Z.
    */
@@ -282,7 +282,7 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
       'metadata' => TRUE,
       'system' => TRUE,
       'userjob' => TRUE,
-    ]);
+    ])->execute();
   }
 
   /**

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -267,6 +267,12 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
    *
    * @param bool $sessionReset
    * @deprecated
+   *   Deprecated Feb 2025 in favor of Civi::rebuild().
+   *   Reassess after Jun 2026.
+   *   For an extension bridging before+after, suggest guard like:
+   *     if (version_compare(CRM_Utils_System::version(), 'X.Y.Z', '>=')) Civi::rebuild([...]) :
+   *     else CRM_Core_Config::singleton()->cleanupCaches();
+   *   Choose an 'X.Y.Z' after determining that your preferred rebuild-target(s) are specifically available in X.Y.Z.
    */
   public function cleanupCaches($sessionReset = FALSE) {
     Civi::rebuild([

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -19,8 +19,6 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-use Civi\Api4\UserJob;
-
 require_once 'Log.php';
 require_once 'Mail.php';
 
@@ -268,28 +266,17 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
    * @see https://issues.civicrm.org/jira/browse/CRM-8739
    *
    * @param bool $sessionReset
+   * @deprecated
    */
   public function cleanupCaches($sessionReset = FALSE) {
-    // cleanup templates_c directory
-    $this->cleanup(1, FALSE);
-    // clear all caches
-    self::clearDBCache();
-    // Avoid clearing QuickForm sessions unless explicitly requested
-    if ($sessionReset) {
-      Civi::cache('session')->clear();
-    }
-    Civi::cache('metadata')->clear();
-    CRM_Core_DAO_AllCoreTables::flush();
-    CRM_Utils_System::flushCache();
-
-    // note this used to be earlier, but was crashing because of api4 instability
-    // during extension install
-    UserJob::delete(FALSE)->addWhere('expires_date', '<', 'now')->execute();
-
-    if ($sessionReset) {
-      $session = CRM_Core_Session::singleton();
-      $session->reset(2);
-    }
+    Civi::rebuild([
+      'files' => TRUE,
+      'tables' => TRUE,
+      'sessions' => $sessionReset,
+      'metadata' => TRUE,
+      'system' => TRUE,
+      'userjob' => TRUE,
+    ]);
   }
 
   /**

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -372,51 +372,23 @@ class CRM_Core_Invoke {
    * @throws Exception
    */
   public static function rebuildMenuAndCaches(bool $triggerRebuild = FALSE, bool $sessionReset = FALSE): void {
-    $config = CRM_Core_Config::singleton();
-    $config->clearModuleList();
-
-    // dev/core#3660 - Activate any new classloaders/mixins/etc before re-hydrating any data-structures.
-    CRM_Extension_System::singleton()->getClassLoader()->refresh();
-    CRM_Extension_System::singleton()->getMixinLoader()->run(TRUE);
-
     Civi::rebuild([
+      'ext' => TRUE,
       'files' => TRUE,
       'tables' => TRUE,
       'sessions' => $sessionReset || CRM_Utils_Request::retrieve('sessionReset', 'Boolean', CRM_Core_DAO::$_nullObject, FALSE, 0, 'GET'),
       'metadata' => TRUE,
       'system' => TRUE,
       'userjob' => TRUE,
+      'menu' => TRUE,
+      'perms' => TRUE,
+      'strings' => TRUE,
+      'settings' => TRUE,
+      'cases' => TRUE,
+      'triggers' => $triggerRebuild || CRM_Utils_Request::retrieve('triggerRebuild', 'Boolean', CRM_Core_DAO::$_nullObject, FALSE, 0, 'GET'),
+      'entities' => TRUE,
     ]);
 
-    CRM_Core_Menu::store();
-
-    // also reset navigation
-    CRM_Core_BAO_Navigation::resetNavigation();
-
-    // also cleanup module permissions
-    $config->cleanupPermissions();
-
-    // rebuild word replacement cache - pass false to prevent operations redundant with this fn
-    CRM_Core_BAO_WordReplacement::rebuild(FALSE);
-
-    Civi::service('settings_manager')->flush();
-    // Clear js caches
-    CRM_Core_Resources::singleton()->flushStrings()->resetCacheCode();
-    CRM_Case_XMLRepository::singleton(TRUE);
-
-    // also rebuild triggers if requested explicitly
-    if (
-      $triggerRebuild ||
-      CRM_Utils_Request::retrieve('triggerRebuild', 'Boolean', CRM_Core_DAO::$_nullObject, FALSE, 0, 'GET')
-    ) {
-      Civi::service('sql_triggers')->rebuild();
-      // Rebuild Drupal 8/9/10 route cache only if "triggerRebuild" is set to TRUE as it's
-      // computationally very expensive and only needs to be done when routes change on the Civi-side.
-      // For example - when uninstalling an extension. We already set "triggerRebuild" to true for these operations.
-      $config->userSystem->invalidateRouteCache();
-    }
-
-    CRM_Core_ManagedEntities::singleton(TRUE)->reconcile();
   }
 
 }

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -374,7 +374,7 @@ class CRM_Core_Invoke {
    *   Deprecated Feb 2025 in favor of Civi::rebuild().
    *   Reassess after Jun 2026.
    *   For an extension bridging before+after, suggest guard like:
-   *     if (version_compare(CRM_Utils_System::version(), 'X.Y.Z', '>=')) Civi::rebuild([...]) :
+   *     if (version_compare(CRM_Utils_System::version(), 'X.Y.Z', '>=')) Civi::rebuild(...)->execute()
    *     else CRM_Core_Invoke::rebuildMenuAndCaches();
    *   Choose an 'X.Y.Z' after determining that your preferred rebuild-target(s) are specifically available in X.Y.Z.
    */
@@ -394,7 +394,7 @@ class CRM_Core_Invoke {
       'cases' => TRUE,
       'triggers' => $triggerRebuild || CRM_Utils_Request::retrieve('triggerRebuild', 'Boolean', CRM_Core_DAO::$_nullObject, FALSE, 0, 'GET'),
       'entities' => TRUE,
-    ]);
+    ])->execute();
 
   }
 

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -379,8 +379,14 @@ class CRM_Core_Invoke {
     CRM_Extension_System::singleton()->getClassLoader()->refresh();
     CRM_Extension_System::singleton()->getMixinLoader()->run(TRUE);
 
-    // also cleanup all caches
-    $config->cleanupCaches($sessionReset || CRM_Utils_Request::retrieve('sessionReset', 'Boolean', CRM_Core_DAO::$_nullObject, FALSE, 0, 'GET'));
+    Civi::rebuild([
+      'files' => TRUE,
+      'tables' => TRUE,
+      'sessions' => $sessionReset || CRM_Utils_Request::retrieve('sessionReset', 'Boolean', CRM_Core_DAO::$_nullObject, FALSE, 0, 'GET'),
+      'metadata' => TRUE,
+      'system' => TRUE,
+      'userjob' => TRUE,
+    ]);
 
     CRM_Core_Menu::store();
 

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -370,6 +370,13 @@ class CRM_Core_Invoke {
    * @param bool $sessionReset
    *
    * @throws Exception
+   * @deprecated
+   *   Deprecated Feb 2025 in favor of Civi::rebuild().
+   *   Reassess after Jun 2026.
+   *   For an extension bridging before+after, suggest guard like:
+   *     if (version_compare(CRM_Utils_System::version(), 'X.Y.Z', '>=')) Civi::rebuild([...]) :
+   *     else CRM_Core_Invoke::rebuildMenuAndCaches();
+   *   Choose an 'X.Y.Z' after determining that your preferred rebuild-target(s) are specifically available in X.Y.Z.
    */
   public static function rebuildMenuAndCaches(bool $triggerRebuild = FALSE, bool $sessionReset = FALSE): void {
     Civi::rebuild([

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1508,12 +1508,12 @@ class CRM_Utils_System {
    *   Deprecated Feb 2025 in favor of Civi::rebuild().
    *   Reassess after Jun 2026.
    *   For an extension bridging before+after, suggest guard like:
-   *     if (version_compare(CRM_Utils_System::version(), 'X.Y.Z', '>=')) Civi::rebuild([...]) :
+   *     if (version_compare(CRM_Utils_System::version(), 'X.Y.Z', '>=')) Civi::rebuild(...)->execute()
    *     else CRM_Utils_System::flushCache();)
    *   Choose an 'X.Y.Z' after determining that your preferred rebuild-target(s) are specifically available in X.Y.Z.
    */
   public static function flushCache() {
-    Civi::rebuild(['system' => TRUE]);
+    Civi::rebuild(['system' => TRUE])->execute();
   }
 
   /**

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1505,6 +1505,12 @@ class CRM_Utils_System {
    * Reset the various system caches and some important static variables.
    *
    * @deprecated
+   *   Deprecated Feb 2025 in favor of Civi::rebuild().
+   *   Reassess after Jun 2026.
+   *   For an extension bridging before+after, suggest guard like:
+   *     if (version_compare(CRM_Utils_System::version(), 'X.Y.Z', '>=')) Civi::rebuild([...]) :
+   *     else CRM_Utils_System::flushCache();)
+   *   Choose an 'X.Y.Z' after determining that your preferred rebuild-target(s) are specifically available in X.Y.Z.
    */
   public static function flushCache() {
     Civi::rebuild(['system' => TRUE]);

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1503,51 +1503,11 @@ class CRM_Utils_System {
 
   /**
    * Reset the various system caches and some important static variables.
+   *
+   * @deprecated
    */
   public static function flushCache() {
-    // flush out all cache entries so we can reload new data
-    // a bit aggressive, but livable for now
-    CRM_Utils_Cache::singleton()->flush();
-
-    if (Civi\Core\Container::isContainerBooted()) {
-      Civi::cache('long')->flush();
-      Civi::cache('settings')->flush();
-      Civi::cache('js_strings')->flush();
-      Civi::cache('community_messages')->flush();
-      Civi::cache('groups')->flush();
-      Civi::cache('navigation')->flush();
-      Civi::cache('customData')->flush();
-      Civi::cache('contactTypes')->clear();
-      Civi::cache('metadata')->clear();
-      \Civi\Core\ClassScanner::cache('index')->flush();
-      CRM_Extension_System::singleton()->getCache()->flush();
-    }
-
-    // also reset the various static memory caches
-
-    // reset the memory or array cache
-    Civi::cache('fields')->flush();
-
-    // reset ACL cache
-    CRM_ACL_BAO_Cache::resetCache();
-
-    // clear asset builder folder
-    \Civi::service('asset_builder')->clear(FALSE);
-
-    // reset various static arrays used here
-    CRM_Contact_BAO_Contact::$_importableFields = CRM_Contact_BAO_Contact::$_exportableFields
-      = CRM_Contribute_BAO_Contribution::$_importableFields
-        = CRM_Contribute_BAO_Contribution::$_exportableFields
-          = CRM_Pledge_BAO_Pledge::$_exportableFields
-            = CRM_Core_DAO::$_dbColumnValueCache = NULL;
-
-    CRM_Core_OptionGroup::flushAll();
-    CRM_Utils_PseudoConstant::flushAll();
-
-    if (Civi\Core\Container::isContainerBooted()) {
-      Civi::dispatcher()->dispatch('civi.core.clearcache');
-    }
-
+    Civi::rebuild(['system' => TRUE]);
   }
 
   /**

--- a/Civi/Core/Rebuilder.php
+++ b/Civi/Core/Rebuilder.php
@@ -1,0 +1,205 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Core;
+
+use Civi;
+use Civi\Api4\UserJob;
+use CRM_ACL_BAO_Cache;
+use CRM_Case_XMLRepository;
+use CRM_Contact_BAO_Contact;
+use CRM_Contribute_BAO_Contribution;
+use CRM_Core_BAO_Navigation;
+use CRM_Core_BAO_WordReplacement;
+use CRM_Core_Config;
+use CRM_Core_DAO;
+use CRM_Core_DAO_AllCoreTables;
+use CRM_Core_ManagedEntities;
+use CRM_Core_Menu;
+use CRM_Core_OptionGroup;
+use CRM_Core_Resources;
+use CRM_Core_Session;
+use CRM_Extension_System;
+use CRM_Pledge_BAO_Pledge;
+use CRM_Utils_Cache;
+use CRM_Utils_PseudoConstant;
+
+/**
+ * The Rebuilder can identify, select, execute any tasks needed to destroy/create any
+ * ephemeral data-structures (caches, etc) in the system.
+ *
+ * The canonical way to access this is is \Civi::rebuild()
+ * @see \Civi::rebuild()
+ *
+ * NOTE: The initial API emphasizes an array of targets. However, in the future, we may need changes.
+ * The Rebuilder class-design should be amenable to phasing-in fluent helpers.
+ */
+class Rebuilder {
+
+  private array $targets;
+
+  /**
+   * @param array $targets
+   */
+  public function __construct($targets) {
+    if (is_string($targets)) {
+      $targets = [$targets => TRUE];
+    }
+
+    $this->targets = $targets;
+  }
+
+  public function execute(): void {
+    // This is a rebuild-super-function. It was produced by merging three prior rebuild-super-functions.
+    // These three prior super-functions were all entwined. By merging them, we get a clearer view of
+    // what's going-on. Of course, "what's going-on" includes... confusing things. Have fun!
+
+    $targets = $this->targets;
+
+    $all = [
+      'ext' => TRUE,
+      'files' => TRUE,
+      'tables' => TRUE,
+      'sessions' => TRUE,
+      'metadata' => TRUE,
+      'system' => TRUE,
+      'userjob' => TRUE,
+      'menu' => TRUE,
+      'perms' => TRUE,
+      'strings' => TRUE,
+      'settings' => TRUE,
+      'cases' => TRUE,
+      'triggers' => TRUE,
+      'entities' => TRUE,
+    ];
+    if (!empty($targets['*'])) {
+      $targets = array_merge($all, $targets);
+      unset($targets['*']);
+    }
+
+    $config = CRM_Core_Config::singleton();
+
+    if (!empty($targets['ext'])) {
+      $config->clearModuleList();
+
+      // dev/core#3660 - Activate any new classloaders/mixins/etc before re-hydrating any data-structures.
+      CRM_Extension_System::singleton()->getClassLoader()->refresh();
+      CRM_Extension_System::singleton()->getMixinLoader()->run(TRUE);
+    }
+
+    if (!empty($targets['files'])) {
+      $config->cleanup(1, FALSE);
+    }
+    if (!empty($targets['tables'])) {
+      // Truncate and drop various tables that track replaceable data (e.g. ACL caches and temp-tables).
+
+      // This is fun and confusing:
+      // - On systems with Memcache/Redis, 'tables' and 'system' are mostly independent.
+      // - On systems with SQL-based caches, 'tables' and 'system' are overlapping rebuilds,
+      //   but neither is strictly redundant with the other.
+      CRM_Core_Config::clearDBCache();
+    }
+    if (!empty($targets['sessions'])) {
+      Civi::cache('session')->clear();
+    }
+    if (!empty($targets['metadata'])) {
+      Civi::cache('metadata')->clear();
+      CRM_Core_DAO_AllCoreTables::flush();
+    }
+    if (!empty($targets['system'])) {
+      // flush out all cache entries so we can reload new data
+      // a bit aggressive, but livable for now
+      CRM_Utils_Cache::singleton()->flush();
+
+      if (Container::isContainerBooted()) {
+        Civi::cache('long')->flush();
+        Civi::cache('settings')->flush();
+        Civi::cache('js_strings')->flush();
+        Civi::cache('community_messages')->flush();
+        Civi::cache('groups')->flush();
+        Civi::cache('navigation')->flush();
+        Civi::cache('customData')->flush();
+        Civi::cache('contactTypes')->clear();
+        Civi::cache('metadata')->clear(); /* Again? Huh. */
+        ClassScanner::cache('index')->flush();
+        CRM_Extension_System::singleton()->getCache()->flush();
+      }
+
+      // also reset the various static memory caches
+
+      // reset the memory or array cache
+      Civi::cache('fields')->flush();
+
+      // reset ACL cache
+      CRM_ACL_BAO_Cache::resetCache();
+
+      // clear asset builder folder
+      Civi::service('asset_builder')->clear(FALSE);
+      // ^^ This really doesn't make sense in this section, does it?
+
+      // reset various static arrays used here
+      CRM_Contact_BAO_Contact::$_importableFields = CRM_Contact_BAO_Contact::$_exportableFields
+        = CRM_Contribute_BAO_Contribution::$_importableFields
+          = CRM_Contribute_BAO_Contribution::$_exportableFields
+            = CRM_Pledge_BAO_Pledge::$_exportableFields
+              = CRM_Core_DAO::$_dbColumnValueCache = NULL;
+
+      CRM_Core_OptionGroup::flushAll();
+      CRM_Utils_PseudoConstant::flushAll();
+
+      if (Container::isContainerBooted()) {
+        Civi::dispatcher()->dispatch('civi.core.clearcache');
+      }
+    }
+    if (!empty($targets['userjob'])) {
+      // (1) note this used to be earlier, but was crashing because of api4 instability
+      // during extension install
+      // (2) I'm not sure this belongs at such a low level...
+      UserJob::delete(FALSE)->addWhere('expires_date', '<', 'now')->execute();
+    }
+    if (!empty($targets['sessions'])) {
+      $session = CRM_Core_Session::singleton();
+      $session->reset(2);
+    }
+    if (!empty($targets['menu'])) {
+      CRM_Core_Menu::store();
+      CRM_Core_BAO_Navigation::resetNavigation();
+    }
+    if (!empty($targets['perms'])) {
+      $config->cleanupPermissions();
+    }
+    if (!empty($targets['strings'])) {
+      // rebuild word replacement cache - pass false to prevent operations redundant with this fn
+      CRM_Core_BAO_WordReplacement::rebuild(FALSE);
+    }
+    if (!empty($targets['settings'])) {
+      Civi::service('settings_manager')->flush();
+    }
+    if (!empty($targets['strings'])) {
+      CRM_Core_Resources::singleton()->flushStrings()->resetCacheCode();
+    }
+    if (!empty($targets['cases'])) {
+      CRM_Case_XMLRepository::singleton(TRUE);
+    }
+    if (!empty($targets['triggers'])) {
+      Civi::service('sql_triggers')->rebuild();
+      // (1) Rebuild Drupal 8/9/10 route cache only if "triggerRebuild" is set to TRUE as it's
+      // computationally very expensive and only needs to be done when routes change on the Civi-side.
+      // For example - when uninstalling an extension. We already set "triggerRebuild" to true for these operations.
+      // (2) FIXME: That ^^ seems silly now. Shouldn't it go under $targets['menu']?
+      $config->userSystem->invalidateRouteCache();
+    }
+    if (!empty($targets['entities'])) {
+      CRM_Core_ManagedEntities::singleton(TRUE)->reconcile();
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

When doing a general flush/rebuild/reset, one invokes a few gnarly functions. This combines them. The result is still a bit gnarly, but it improves the situation in that:

1. The steps have more distinctive names.
2. You can opt-in/opt-out for specific steps.
3. You can see how all the steps fit together. It's easier to read/trace.

Before
----------------------------------------

Civi has many helpers for batch-clearing/batch-rebuilding of caches

* `CRM_Core_Invoke::rebuildMenuAndCaches(bool $triggerRebuild = FALSE, bool $sessionReset = FALSE)`
* `CRM_Utils_System::flushCache()`
* `CRM_Core_Config::cleanupCaches($sessionReset = FALSE)`

All of these are super-functions touching multiple (qualitatively different) structures. The names sound alike. They also call each  other. But the lines between them aren't particularly clear. The names put them in a support-gray-zone (*sort-of-private; sort-of-public*). The functionality is fairly important, so they wind up being used by contrib.

After
----------------------------------------

All the functions have been merged into one `Civi::rebuild($targets)`, e.g.

```php
// Rebuild everything
Civi::rebuild('*')->execute();

// Rebuild a couple specific things
Civi::rebuild(['menus' => TRUE, 'triggers' => TRUE])->execute();

// Rebuild everything, except for a couple really expensive parts
Civi::rebuild(['*' => TRUE, 'triggers' => FALSE, 'entities' => FALSE])->execute();
```

The original functions are preserved with stubs to call `Civi::rebuild()`.

(*EDIT: Original draft was non-fluent. Added `execute()` to make style more fluent.*)

Comments
------------------------------------

* This doesn't address the API access for this functionality. (API exposure is good for providing HTTP/REST/CLI access. )  Presumably, `System.flush` API should be expanded to pass-through more of these keys. (However, in terms of making a robust mechanism that can recover the system from weird states... the API has the challenge of being tied-up with all the same data-structures that are being rebuilt. Keeping the guts of it as plain PHP feels safer.)
* Philosophically, I might prefer that the system leaned more into "flush" or "clear"  (*delete; leave empty; let someone else hydrate*) rather than "rebuild" (*proactive; warmup; hydrate*). But that's a longer road, and we've held-off on this cleanup forever because it looks longish/scaryish. Maybe it's fine aim for "better" and leave "perfect" for another day...