### PR TITLE
FormBuilder - Fix fatal crash with ContactLayout summary blocks

### DIFF
--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -287,7 +287,7 @@ function afform_civicrm_pageRun(&$page) {
       'module' => $afform['module_name'],
       'directive' => $afform['directive_name'],
     ];
-    $content = CRM_Core_Smarty::singleton()->fetchWith('afform/InlineAfform.tpl', ['afformOptions' => $afformOptions, 'afform' => $block]);
+    $content = CRM_Core_Smarty::singleton()->fetchWith('afform/InlineAfform.tpl', ['afformOptions' => $afformOptions, 'block' => $block]);
     CRM_Core_Region::instance("contact-basic-info-$side")->add([
       'markup' => '<div class="crm-summary-block">' . $content . '</div>',
       'name' => 'afform:' . $afform['name'],

--- a/ext/afform/core/templates/afform/InlineAfform.tpl
+++ b/ext/afform/core/templates/afform/InlineAfform.tpl
@@ -1,5 +1,5 @@
-<crm-angular-js modules="{$afform.module}">
+<crm-angular-js modules="{$block.module}">
   <form id="bootstrap-theme">
-    <{$afform.directive} options='{$afformOptions|@json_encode}'></{$afform.directive}>
+    <{$block.directive} options='{$afformOptions|@json_encode}'></{$block.directive}>
   </form>
 </crm-angular-js>

--- a/templates/CRM/common/TabHeader.tpl
+++ b/templates/CRM/common/TabHeader.tpl
@@ -27,15 +27,11 @@
         {/foreach}
       </ul>
 
-      {foreach from=$tabHeader key=tabName item=tabValue}
-        {if $tabValue.template}
+      {* Item must be named $block for compatibility with InlineAfform.tpl *}
+      {foreach from=$tabHeader key=tabName item=block}
+        {if $block.template}
           <div id="{$tabIdPrefix|default:'panel_'}{$tabName}" role="tabpanel">
-            {if $tabValue.module}
-              <!-- afform tab - need to pass module and directive to afform param -->
-              {include file=$tabValue.template afform=$tabValue}
-            {else}
-              {include file=$tabValue.template}
-            {/if}
+            {include file=$block.template}
           </div>
         {/if}
       {/foreach}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes unreleased regression in 6.0 with Afform Blocks used by the ContactLayout extension.

Before
----------------------------------------
When placing an Afform as a block on the contact summary screen, the ContactLayout extension crashes. 

After
----------------------------------------
No crash.

Technical Details
----------------------------------------
This is due to refactoring done in 6b25cbda8a21fd2b6f6087696fa5622be7a6efdc which deleted AfformBlock.tpl in favor of using the generic InlineAfform.tpl everywhere. Unfortunately this change was not compatible with ContactLayout because the old template counts on a tpl variable called `$block` whereas the new template calls it `$afform`.

Comments
----------------------------------------
In lieu of a fatal crash, `$block` is a perfectly fine name for a variable :)
