### PR TITLE
Fix notices when rendering advanced search as contributions

### DIFF
--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -193,7 +193,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     return (bool) $searchContext;
   }
 
-  public static function setModeValues() {
+  public static function setModeValues(): void {
     self::$_modeValues = [
       CRM_Contact_BAO_Query::MODE_CONTACTS => [
         'selectorName' => self::$_selectorName,
@@ -214,6 +214,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
         'resultContext' => 'Search',
         'taskClassName' => 'CRM_Contribute_Task',
         'component' => 'CiviContribute',
+        'contributionSummary' => [],
       ],
       CRM_Contact_BAO_Query::MODE_EVENT => [
         'selectorName' => 'CRM_Event_Selector_Search',

--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -58,7 +58,9 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
     // if contribute mode add contribution id
     if ($query->_mode & CRM_Contact_BAO_Query::MODE_CONTRIBUTE) {
       $query->_select['contribution_id'] = "civicrm_contribution.id as contribution_id";
+      $query->_select['is_template'] = "civicrm_contribution.is_template as is_template";
       $query->_element['contribution_id'] = 1;
+      $query->_element['is_template'] = 1;
       $query->_tables['civicrm_contribution'] = $query->_whereTables['civicrm_contribution'] = 1;
     }
 

--- a/templates/CRM/Contribute/Page/ContributionTotals.tpl
+++ b/templates/CRM/Contribute/Page/ContributionTotals.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {*Table displays contribution totals for a contact or search result-set *}
-{if !empty($annual.count) OR $contributionSummary.total.count OR $contributionSummary.cancel.count OR $contributionSummary.soft_credit.count}
+{if !empty($annual.count) OR (!empty($contributionSummary) AND ($contributionSummary.total.count OR $contributionSummary.cancel.count OR $contributionSummary.soft_credit.count))}
     <table class="form-layout-compressed">
 
     {if !empty($annual.count)}


### PR DESCRIPTION
Overview
----------------------------------------
Fix notices when rendering advanced search as contributions

When a selection is made in advanced search notices appear. These notices are higher when there are recurring contributions amongst those selected

![image](https://github.com/user-attachments/assets/7d59334b-e9fc-4391-9aff-46a37c20ab73)

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/3fbc034a-eaa8-4b5e-8a2e-d776b246dbd8)


After
----------------------------------------
![image](https://github.com/user-attachments/assets/c1d41e60-7d87-49c4-a8f0-2874517f9a91)


Technical Details
----------------------------------------
Note that the second fix ensures `is_template` is always included as the template expects it (for recurrings) - I tried including participant criteria as well to be sure there was no conflict with the is_template field on the civicrm_event table - but that does not seem to be exposed anywhere in advanced search

Comments
----------------------------------------
