### PR TITLE
RiverLea 1.3.6 - Fixes GL#108, GL#109, #31994 & couple more

### DIFF
--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -1,3 +1,10 @@
+1.3.6-6.1alpha
+ - FIXED - Responsive: make dashlets stack on Civi Dashboard under 990px (same as Greenwich)
+ - FIXED - Show Add Address without hover on Contact Dashboard (#109)
+ - ADDED - Swapped edit icon for add icon on add address on Contact Dashboard (#109)
+ - FIXED - code/pre formatting is wrapping on one line (#108)
+ - FIXED - HackneyBrook/DarkMode: Notification text colour illegible (https://github.com/civicrm/civicrm-core/pull/31994)
+
 1.3.5-6.0alpha
  - ADDED - padding to contact dashboard inline edit div (#107)
  - FIXED - Contact Layout Editor extension: double padding; broken right float (#107)

--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -1,9 +1,10 @@
 1.3.6-6.1alpha
  - FIXED - Responsive: make dashlets stack on Civi Dashboard under 990px (same as Greenwich)
  - FIXED - Show Add Address without hover on Contact Dashboard (#109)
- - ADDED - Swapped edit icon for add icon on add address on Contact Dashboard (#109)
  - FIXED - code/pre formatting is wrapping on one line (#108)
  - FIXED - HackneyBrook/DarkMode: Notification text colour illegible (https://github.com/civicrm/civicrm-core/pull/31994)
+ - CHANGED - Select2 search box now fills width of Select, neatens padding.
+ - CHANGED - Swapped edit icon for add icon on add address on Contact Dashboard (#109)
 
 1.3.5-6.0alpha
  - ADDED - padding to contact dashboard inline edit div (#107)

--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -4,7 +4,7 @@
  - FIXED - code/pre formatting is wrapping on one line (#108)
  - FIXED - HackneyBrook/DarkMode: Notification text colour illegible (https://github.com/civicrm/civicrm-core/pull/31994)
  - CHANGED - Select2 search box now fills width of Select, neatens padding.
- - CHANGED - Swapped edit icon for add icon on add address on Contact Dashboard (#109)
+ - CHANGED - Swapped edit icon for add icon on add address on Contact Dashboard & tidied appearance (#109)
 
 1.3.5-6.0alpha
  - ADDED - padding to contact dashboard inline edit div (#107)

--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -344,21 +344,14 @@ dl dl {
   font-size: var(--crm-font-size) !important /* vs inline css on api3 */;
   line-height: 1.4  !important /* vs inline css on api3 */;
   color: var(--crm-c-text);
-  word-break: break-all;
-  word-wrap: break-word;
   background-color: var(--crm-c-code-background);
   border: 1px solid var(--crm-c-background4);
   border-radius: var(--crm-roundness);
-}
-.crm-container pre {
-  white-space: normal;
-  word-break: normal;
 }
 .crm-container pre code {
   padding: 0;
   font-size: inherit;
   color: inherit;
-  white-space: pre-wrap;
   background-color: transparent;
   border-radius: 0;
 }

--- a/ext/riverlea/core/css/_core.css
+++ b/ext/riverlea/core/css/_core.css
@@ -4,5 +4,5 @@
    can be merged later. */
 
 @import url(components/_accordion.css); @import url(components/_alerts.css); @import url(components/_buttons.css); @import url(components/_form.css); @import url(components/_icons.css); @import url(components/_nav.css); @import url(components/_tabs.css); @import url(components/_dropdowns.css); @import url(components/_tables.css); @import url(components/_dialogs.css); @import url(components/_page.css); @import url(components/_components.css); @import url(components/_front.css); :root {
-  --crm-release: '1.3.5-6.0.alpha';
+  --crm-release: '1.3.6-6.1alpha';
 }

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -557,6 +557,9 @@ input.crm-form-checkbox) + label {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }
+.select2-search {
+  padding: var(--crm-s);
+}
 .select2-search::after {
   font-family: "FontAwesome";
   font-style: normal;
@@ -574,6 +577,7 @@ input.crm-form-checkbox) + label {
   font-family: var(--crm-font);
   line-height: 20px;
   max-width: 100%;
+  width: 100%;
 }
 .crm-container .select2-results {
   font-size: var(--crm-m2);
@@ -662,7 +666,6 @@ input.crm-form-checkbox) + label {
 .select2-drop.select2-drop-active.crm-container li.select2-result-with-children {
   padding: 0;
 }
-
 
 /* Dates */
 

--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -85,7 +85,8 @@
   background-color: transparent;
 }
 .crm-container #crm-contactname-content .crm-edit-help:hover,
-.crm-edit-ready .crm-summary-block .crm-inline-edit:hover .crm-edit-help {
+.crm-edit-ready .crm-summary-block .crm-inline-edit:hover .crm-edit-help,
+.crm-container .crm-summary-block .address.add-new .crm-edit-help {
   color: var(--crm-c-text);
   display: block;
   opacity: 1;
@@ -97,9 +98,20 @@
   color: var(--crm-c-text);
   margin: var(--crm-xs) 0 0 var(--crm-m);
 }
+.crm-container .address.add-new .crm-i.fa-pencil::before {
+  content: "\f055";
+}
 .crm-container div.crm-inline-edit.form .crm-edit-help {
   display: none !important;
 }
+/* .crm-container .address.add-new .crm-edit-help {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+} */
 .crm-container .crm-address-block+.crm-address-block .add-new .crm-summary-row {
   display: none;
 }

--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -80,10 +80,6 @@
   opacity: .6;
   padding: var(--crm-padding-small);
 }
-.crm-container .crm-address-block+.crm-address-block .add-new .crm-edit-help {
-  display: block;
-  background-color: transparent;
-}
 .crm-container #crm-contactname-content .crm-edit-help:hover,
 .crm-edit-ready .crm-summary-block .crm-inline-edit:hover .crm-edit-help,
 .crm-container .crm-summary-block .address.add-new .crm-edit-help {
@@ -104,14 +100,14 @@
 .crm-container div.crm-inline-edit.form .crm-edit-help {
   display: none !important;
 }
-/* .crm-container .address.add-new .crm-edit-help {
+.crm-container .crm-summary-block .address.add-new .crm-edit-help {
   width: 100%;
   height: 100%;
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-} */
+  justify-content: right;
+  flex-direction: row-reverse;
+}
 .crm-container .crm-address-block+.crm-address-block .add-new .crm-summary-row {
   display: none;
 }

--- a/ext/riverlea/core/css/dashboard.css
+++ b/ext/riverlea/core/css/dashboard.css
@@ -200,3 +200,8 @@ fieldset.crm-inactive-dashlet-fieldset legend .crm-hover-button {
 .crm-dashlet .crm-search-display .form-inline {
   padding: var(--crm-padding-reg);
 }
+@media (max-width: 991px) {
+  #civicrm-dashboard > .crm-flex-box {
+    grid-template-columns: 1fr;
+  }
+}

--- a/ext/riverlea/info.xml
+++ b/ext/riverlea/info.xml
@@ -12,7 +12,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>[civicrm.releaseDate]</releaseDate>
-  <version>1.3.5-[civicrm.version]</version>
+  <version>1.3.6-[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>

--- a/ext/riverlea/streams/hackneybrook/css/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/css/_dark.css
@@ -78,6 +78,7 @@
   --crm-dialog-header-bg: var(--crm-c-background2);
   --crm-dialog-body-bg: var(--crm-c-background2);
   --crm-notify-background: var(--crm-c-darkest);
+  --crm-notify-col: var(--crm-c-text);
   --crm-wizard-active-bg: var(--crm-c-blue-dark);
   --crm-form-block-background: var(--crm-c-background2);
   --crm-c-code-background: var(--crm-c-background2);


### PR DESCRIPTION
Overview
----------------------------------------
This fixes four regressions: two major (breaks functionality), two minor (restores Greenwich functionality). It also makes two changes.

Regression 1 - code/pre formatting is wrapping on one line (#108) - before
----------------------------------------
![image](https://github.com/user-attachments/assets/b4ccaa69-e256-493b-b637-ff8f7946ddc5)

Regression 1 - after
----------------------------------------
<img width="1285" alt="image" src="https://github.com/user-attachments/assets/c52abd5a-b41a-4342-a165-e7f8e8839642" />

Regression 2 - HackneyBrook/DarkMode: Notification text colour illegible - before
----------------------------------------
<img width="377" alt="image" src="https://github.com/user-attachments/assets/effadee8-9166-4276-a7ce-0368bc649812" />
Replaces one part of this PR: #31994 cc @ufundo. 

Regression 2 - after
----------------------------------------
<img width="388" alt="image" src="https://github.com/user-attachments/assets/e5bc9dbf-cc50-433a-8b07-9dde6931f01b" />

Regression (minor) 3 - Responsive: make dashlets stack on Civi Dashboard under 990px (same as Greenwich) - before
----------------------------------------
<img width="578" alt="image" src="https://github.com/user-attachments/assets/09718247-74e8-449f-8207-4acc78d0f383" />

Regression 3 - after
----------------------------------------
<img width="579" alt="image" src="https://github.com/user-attachments/assets/7b2a0a20-cd0b-45e1-a910-cb9320c0f8e1" />

Regression 4 (minor) - Show Add Address without hover on Contact Dashboard (#109) + Change 1 - Swapped edit icon for add icon on add address on Contact Dashboard (#109) & adjust appearance - before
----------------------------------------
<img width="1220" alt="image" src="https://github.com/user-attachments/assets/de8a6bc6-6f8d-4b53-bb49-d0f402819d4a" />

Regression 4 + Change 1 - after
----------------------------------------
![image](https://github.com/user-attachments/assets/b2828be4-3762-49c3-99ed-f6efed88f1f6)
NB - doesn't work fully on Thames because of Thames custom CSS overrides - cc @artfulrobot 

Change 2 - Select2 search box now fills width of Select, neatens padding. - before
----------------------------------------
<img width="1221" alt="image" src="https://github.com/user-attachments/assets/973b1709-05f1-44f0-9751-5d9084915618" />

Change 2 - after
----------------------------------------
<img width="1229" alt="image" src="https://github.com/user-attachments/assets/8ed4f49f-b0ef-42b5-a8b4-5cc280018a74" />

Comments
----------------------------------------
Strictly speaking I'm assuming the four regressions should go against 6.0.RC and the two changes on 6.1.alpha. One of the changes is entangled with one regression, and the other change was identified while fixing another regression. Hopefully these can be merged together.