### PR TITLE
dev/core#5731 TabHeader - Fix adding count asynchronously

### DIFF
--- a/templates/CRM/common/TabHeader.js
+++ b/templates/CRM/common/TabHeader.js
@@ -126,13 +126,15 @@
     if (typeof count === 'boolean') {
       return;
     }
-    var oldClass = getCountClass(tab);
+    let oldClass = getCountClass(tab);
     if (oldClass) {
       $(tab).removeClass(oldClass);
     }
-    $(tab)
-      .addClass('crm-count-' + count)
-      .find('a em').html('' + count);
+    let countElement = $(tab).addClass('crm-count-' + count).find('a em');
+    if (!countElement.length) {
+      countElement = $(tab).find('a').append('<em></em>').find('em');
+    }
+    countElement.text('' + count);
   };
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5731](https://lab.civicrm.org/dev/core/-/issues/5731)

Before
----------------------------------------
Afform-based tabs missing count in tabheader

After
----------------------------------------
Working

Technical Details
----------------------------------------
In ecc0b99423530890bc1a276e20548c3e71ad7e40 the contact summary tabs were merged with TabHeader.tpl but there were subtle differences; one was that setting tab count via js broke if the tab didn't already have a count, because the markup wasn't there.

This fixes the js to add the count markup if missing.