### PR TITLE
riverlea - cleanup double definition of alert-text-help

### DIFF
--- a/ext/riverlea/streams/hackneybrook/css/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/css/_dark.css
@@ -66,14 +66,13 @@
   --crm-table-odd-hover: var(--crm-c-gray-700);
   --crm-table-even-row: var(--crm-c-gray-700);
   --crm-table-even-hover: var(--crm-c-gray-600);
-  --crm-alert-text-help: var(--crm-c-text-light);
+  --crm-alert-text-help: var(--crm-c-text);
   --crm-alert-text-warning: var(--crm-c-text-light);
   --crm-alert-background-info: var(--crm-c-blue-dark);
   --crm-alert-background-danger: #fcf3f5;
   --crm-input-color: var(--crm-c-text);
   --crm-input-description: var(--crm-c-gray-300);
   --crm-checkbox-list-col: var(--crm-c-text-light);
-  --crm-alert-text-help: var(--crm-c-text);
   --crm-dialog-header-border-col: transparent;
   --crm-dialog-header-bg: var(--crm-c-background2);
   --crm-dialog-body-bg: var(--crm-c-background2);

--- a/ext/riverlea/streams/minetta/css/_dark.css
+++ b/ext/riverlea/streams/minetta/css/_dark.css
@@ -54,7 +54,7 @@
   --crm-table-odd-hover: var(--crm-c-gray-700);
   --crm-table-even-row: var(--crm-c-page-background);
   --crm-table-even-hover: var(--crm-c-gray-700);
-  --crm-alert-text-help: var(--crm-c-text-light);
+  --crm-alert-text-help: var(--crm-c-text);
   --crm-alert-text-warning: var(--crm-c-text-light);
   --crm-alert-background-info: var(--crm-c-blue-dark);
   --crm-alert-text-info: var(--crm-c-blue-light);
@@ -63,7 +63,6 @@
   --crm-input-description: var(--crm-c-gray-300);
   --crm-input-radio-color: #38c4b4;
   --crm-checkbox-list-col: var(--crm-c-text-light);
-  --crm-alert-text-help: var(--crm-c-text);
   --crm-btn-cancel-bg: #9b3d4b;
   --crm-btn-alert-bg: var(--crm-btn-cancel-bg);
   --crm-btn-alert-text: var(--crm-c-text);


### PR DESCRIPTION
Overview
----------------------------------------
Just fix a couple of places where a variable gets defined twice in the same block. The earlier one is redundant.

cc @vingle (pulled out from the other MR)
