### PR TITLE
AdminUI - Fix custom field tabs appearing for wrong contact subtype

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
+++ b/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
@@ -48,6 +48,7 @@ class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
   protected function getSelect() {
     return ['id', 'name', 'title', 'is_multiple',
       'help_pre', 'help_post', 'extends', 'icon', 'style',
+      'extends_entity_column_value', 'weight',
     ];
   }
 
@@ -285,13 +286,16 @@ class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
       'permission' => ['access all custom data'],
       'title' => $item['title'],
       'icon' => $item['icon'],
+      'summary_weight' => 100 + ($item['weight'] ?? 0),
     ];
-    if ($item['extends'] === 'Contact') {
+    if (CoreUtil::isContact($item['extends'])) {
       $afform['placement'] = ['contact_summary_tab'];
-    }
-    elseif (CoreUtil::isContact($item['extends'])) {
-      $afform['placement'] = ['contact_summary_tab'];
-      $afform['summary_contact_type'] = [$item['extends']];
+      if (!empty($item['extends_entity_column_value'])) {
+        $afform['summary_contact_type'] = (array) $item['extends_entity_column_value'];
+      }
+      elseif ($item['extends'] !== 'Contact') {
+        $afform['summary_contact_type'] = [$item['extends']];
+      }
     }
     else {
       // tabs for other entities are placed without any


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression in AdminUI's SearchKit replacement tabs for multi-record contact custom fields.

Before
----------------------------------------
They were ignoring the contact sub-type filter set for the custom group.
They were ignoring the ordering (weight) for each group.

After
----------------------------------------
Tabs appear correctly based on the contact subtype being viewed, and in the correct order.