### PR TITLE
dev/financial#231 - Option A - Don't allow selecting disabled financial accounts when assigning accounts and fix translation of dropdown options

### DIFF
--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -248,7 +248,13 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
     // CRM-11516
     if ($this->_gName == 'payment_instrument') {
       $accountType = CRM_Core_PseudoConstant::accountOptionValues('financial_account_type', NULL, " AND v.name = 'Asset' ");
-      $financialAccount = CRM_Contribute_PseudoConstant::financialAccount(NULL, key($accountType));
+      $financialAccount = \Civi\Api4\FinancialAccount::get()
+        ->addSelect('id', 'label')
+        ->addWhere('financial_account_type_id', '=', key($accountType))
+        ->addWhere('is_active', '=', TRUE)
+        ->addOrderBy('label')
+        ->execute()
+        ->column('label', 'id');
 
       $this->add('select', 'financial_account_id', ts('Financial Account'),
         ['' => ts('- select -')] + $financialAccount,

--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -187,7 +187,13 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
 
     // Financial Account of account type asset CRM-11515
     $accountType = CRM_Core_PseudoConstant::accountOptionValues('financial_account_type', NULL, " AND v.name = 'Asset' ");
-    $financialAccount = CRM_Contribute_PseudoConstant::financialAccount(NULL, key($accountType));
+    $financialAccount = \Civi\Api4\FinancialAccount::get()
+      ->addSelect('id', 'label')
+      ->addWhere('financial_account_type_id', '=', key($accountType))
+      ->addWhere('is_active', '=', TRUE)
+      ->addOrderBy('label')
+      ->execute()
+      ->column('label', 'id');
     if ($fcount = count($financialAccount)) {
       $this->assign('financialAccount', $fcount);
     }

--- a/CRM/Financial/Form/FinancialTypeAccount.php
+++ b/CRM/Financial/Form/FinancialTypeAccount.php
@@ -168,20 +168,38 @@ class CRM_Financial_Form_FinancialTypeAccount extends CRM_Core_Form {
       if (!empty($this->_submitValues['account_relationship']) || !empty($this->_submitValues['financial_account_id'])) {
         $financialAccountType = CRM_Financial_BAO_FinancialAccount::getfinancialAccountRelations();
         $financialAccountType = $financialAccountType[$this->_submitValues['account_relationship']] ?? NULL;
-        $result = CRM_Contribute_PseudoConstant::financialAccount(NULL, $financialAccountType);
+        $result = \Civi\Api4\FinancialAccount::get()
+          ->addSelect('id', 'label')
+          ->addWhere('financial_account_type_id', '=', $financialAccountType)
+          ->addWhere('is_active', '=', TRUE)
+          ->addOrderBy('label')
+          ->execute()
+          ->column('label', 'id');
 
         $financialAccountSelect = ['' => ts('- select -')] + $result;
       }
       else {
+        $result = \Civi\Api4\FinancialAccount::get()
+          ->addSelect('id', 'label')
+          ->addWhere('is_active', '=', TRUE)
+          ->addOrderBy('label')
+          ->execute()
+          ->column('label', 'id');
         $financialAccountSelect = [
           'select' => ts('- select -'),
-        ] + CRM_Contribute_PseudoConstant::financialAccount();
+        ] + $result;
       }
     }
     if ($this->_action == CRM_Core_Action::UPDATE) {
       $financialAccountType = CRM_Financial_BAO_FinancialAccount::getfinancialAccountRelations();
       $financialAccountType = $financialAccountType[$this->_defaultValues['account_relationship']];
-      $result = CRM_Contribute_PseudoConstant::financialAccount(NULL, $financialAccountType);
+      $result = \Civi\Api4\FinancialAccount::get()
+        ->addSelect('id', 'label')
+        ->addWhere('financial_account_type_id', '=', $financialAccountType)
+        ->addWhere('is_active', '=', TRUE)
+        ->addOrderBy('label')
+        ->execute()
+        ->column('label', 'id');
 
       $financialAccountSelect = ['' => ts('- select -')] + $result;
     }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/financial/-/issues/231

Before
----------------------------------------
1. Disable one of the Asset accounts.
2. Go to edit or create payment method.
3. You can chose the disabled account for the payment method.

Ditto on the financial types assignment screen and the payment processor form.

After
----------------------------------------
Only active

Technical Details
----------------------------------------
For the financial types assignment screen (e.g. `civicrm/admin/financial/financialType/accounts?reset=1&action=browse&aid=3`) there's two versions of the form. The ADD one is when you click the button above the table, and the UPDATE one is when you click Edit on the right of the table.

And for the ADD one there's two versions of it, you can trigger the other one by doing something like picking a type, and then for the account change it to "- select -" and then submit. When it reloads that's the line 171 version.

You may notice on that form there is some javascript that reloads the choices which also includes disabled still. I'll do that in another PR since there's also some undefined variables there and wanted to keep this straightforward.

Comments
----------------------------------------
Also fixes the dropdown always appearing in english since the label field was added last year, but you might not notice on upgrade if you'd already translated them.