### PR TITLE
dev/financial#231 - Option A part 2 - Don't allow selecting disabled financial accounts when assigning accounts and fix translation of dropdown options

### DIFF
--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -93,10 +93,10 @@ class CRM_Financial_Page_AJAX {
       ],
     ];
 
-    $countResult = count($financialAccountType[$financialAccountTypeId]);
     if (!empty($result)) {
       foreach ($result as $id => $name) {
-        if (in_array($id, $financialAccountType[$financialAccountTypeId]) && $_GET['_value'] != 'select') {
+        if ($_GET['_value'] != 'select' && in_array($id, $financialAccountType[$financialAccountTypeId])) {
+          $countResult = count($financialAccountType[$financialAccountTypeId]);
           if ($countResult != 1) {
             $elements[] = [
               'name' => $name,

--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -36,13 +36,25 @@ class CRM_Financial_Page_AJAX {
     }
     $defaultId = NULL;
     if ($_GET['_value'] === 'select') {
-      $result = CRM_Contribute_PseudoConstant::financialAccount();
+      $result = \Civi\Api4\FinancialAccount::get()
+        ->addSelect('id', 'label')
+        ->addWhere('is_active', '=', TRUE)
+        ->addOrderBy('label')
+        ->execute()
+        ->column('label', 'id');
     }
     else {
       $financialAccountType = CRM_Financial_BAO_FinancialAccount::getfinancialAccountRelations();
       $financialAccountType = $financialAccountType[$_GET['_value']] ?? NULL;
-      $result = CRM_Contribute_PseudoConstant::financialAccount(NULL, $financialAccountType);
+      $result = [];
       if ($financialAccountType) {
+        $result = \Civi\Api4\FinancialAccount::get()
+          ->addSelect('id', 'label')
+          ->addWhere('financial_account_type_id', '=', $financialAccountType)
+          ->addWhere('is_active', '=', TRUE)
+          ->addOrderBy('label')
+          ->execute()
+          ->column('label', 'id');
         $defaultId = CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_financial_account WHERE is_default = 1 AND financial_account_type_id = $financialAccountType");
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Followup to https://github.com/civicrm/civicrm-core/pull/32084

Before
----------------------------------------
On the financial types account assignment form, if you fiddle around with the dropdowns some ajax happens to alter the options. It currently offers disabled accounts.

After
----------------------------------------
Only active

Technical Details
----------------------------------------
Also an undefined variables fix in the ajax call.

Comments
----------------------------------------

