### PR TITLE
issue#5370: Relationship Update Screen Not Showing Existing Start/End Dates

### DIFF
--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -131,7 +131,7 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
     $this->_values = [];
     if ($this->_relationshipId) {
       $this->_values = \Civi\Api4\Relationship::get(FALSE)
-        ->addSelect('contact_id_a', 'contact_id_b', 'created_date', 'id', 'is_active', 'is_permission_a_b', 'is_permission_b_a', 'modified_date', 'relationship_type_id')
+        ->addSelect('*')
         ->addWhere('id', '=', $this->_relationshipId)
         ->execute()
         ->first();


### PR DESCRIPTION

Overview
----------------------------------------
Fixes regression mentioned in https://lab.civicrm.org/dev/core/-/issues/5730 

Before
----------------------------------------
On edit screen dates are not prefilled

After
----------------------------------------
Dates are set by default.

Technical Details
----------------------------------------
caused by https://github.com/civicrm/civicrm-core/commit/e12cd2368eaf91bed3ea726671ed9c420f403410#diff-187873f4ab353d001d4f590f7d492f861e67acfe4000f4ad74608de3ebe18bcaR134

Comments
----------------------------------------
ping @colemanw 