### PR TITLE
afform - block user input during prefilling

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -90,7 +90,9 @@
           ctrl.showSubmitButton = displaySubmitButton(args);
         }
         if (toLoad) {
-          $element.block();
+          if (params.fillMode === 'form') {
+            $element.block();
+          }
           return crmApi4('Afform', 'prefill', params)
             .then((result) => {
               // In some cases (noticed on Wordpress) the response header incorrectly outputs success when there's an error.

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -90,11 +90,13 @@
           ctrl.showSubmitButton = displaySubmitButton(args);
         }
         if (toLoad) {
+          $element.block();
           return crmApi4('Afform', 'prefill', params)
             .then((result) => {
               // In some cases (noticed on Wordpress) the response header incorrectly outputs success when there's an error.
               if (result.error_message) {
                 disableForm(result.error_message);
+                $element.unblock();
                 return;
               }
               result.forEach((item) => {
@@ -105,8 +107,10 @@
                   angular.merge(data[item.name][index], values, {fields: _.cloneDeep(schema[item.name].data || {})});
                 });
               });
+              $element.unblock();
             }, (error) => {
               disableForm(error.error_message);
+              $element.unblock();
             });
         }
         // Clear existing join selection


### PR DESCRIPTION
Overview
----------------------------------------
Attempt to fix an issue where user can start filling a form whilst the async prefill is happening, and then the prefill result overwrites the user input.

Before
----------------------------------------
- User can interact with an afform whilst the prefill request is happening async
- User input is overwritten by the prefill

After
----------------------------------------
- Form element is blocked during the prefill, to prevent user input

Technical Details
----------------------------------------
This may be too rough. Given sometimes the prefill can be for selected sub elements of the form, it would be nice to target the block to the subelement. But not sure how easy to do that through any combo of `af-join` and `af-fieldset` etc.
