### PR TITLE
dev/core#5738 FB apply pre-set data to the corresponding block

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -636,7 +636,13 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
             }
 
             // Merge in pre-set data
-            $joinValues[$index] = array_merge($joinValues[$index], $entity['joins'][$joinEntity]['data'] ?? []);
+            if (!empty($entity['joins'][$joinEntity]['data'])) {
+              foreach ($entity['joins'][$joinEntity]['data'] as $key => $data) {
+                if (!empty($data[$index])) {
+                  $joinValues[$index][$key] = $data[$index];
+                }
+              }
+            }
           }
         }
         $entityValues[$entityName][] = $values;


### PR DESCRIPTION
Overview
----------------------------------------
Saving issue with multiple email/phone/address blocks with forced location_type_id.

See https://lab.civicrm.org/dev/core/-/issues/5738

Before
----------------------------------------
The data is not saved properly because each entity as all the location_type_id instead of just the corresponding one.

After
----------------------------------------
The data is saved as expected.
