### PR TITLE
[REF] Api3 - Use str_starts_with instead of strpos

### DIFF
--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -402,11 +402,11 @@ function _civicrm_api3_activity_get_formatResult($params, $activities, $options)
   $tagGet = ['tag_id', 'entity_id'];
   $caseGet = $caseIds = [];
   foreach (array_keys($returns) as $key) {
-    if (strpos($key, 'tag_id.') === 0) {
+    if (str_starts_with($key, 'tag_id.')) {
       $tagGet[] = $key;
       $returns['tag_id'] = 1;
     }
-    if (strpos($key, 'case_id.') === 0) {
+    if (str_starts_with($key, 'case_id.')) {
       $caseGet[] = str_replace('case_id.', '', $key);
       $returns['case_id'] = 1;
     }

--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -287,7 +287,7 @@ function civicrm_api3_case_get($params, $sql = NULL) {
     $sort = explode(', ', $options['sort']);
     $contactSort = NULL;
     foreach ($sort as $index => &$sortString) {
-      if (strpos($sortString, 'contact_id') === 0) {
+      if (str_starts_with($sortString, 'contact_id')) {
         $contactSort = $sortString;
         $sortString = '(1)';
         // Get sort field and direction
@@ -630,7 +630,7 @@ function _civicrm_api3_case_read(&$cases, $options) {
   // Bulk-load tags. Supports joins onto the tag entity.
   $tagGet = ['tag_id', 'entity_id'];
   foreach (array_keys($options['return']) as $key) {
-    if (strpos($key, 'tag_id.') === 0) {
+    if (str_starts_with($key, 'tag_id.')) {
       $tagGet[] = $key;
       $options['return']['tag_id'] = 1;
     }

--- a/api/v3/CustomField.php
+++ b/api/v3/CustomField.php
@@ -33,7 +33,7 @@ function civicrm_api3_custom_field_create(array $params): array {
 
   // Legacy handling for old way of naming serialized fields
   if (!empty($params['html_type'])) {
-    if ($params['html_type'] === 'CheckBox' || strpos($params['html_type'], 'Multi-') === 0) {
+    if ($params['html_type'] === 'CheckBox' || str_starts_with($params['html_type'], 'Multi-')) {
       $params['serialize'] = 1;
     }
     $params['html_type'] = str_replace(['Multi-Select', 'Select Country', 'Select State/Province'], 'Select', $params['html_type']);
@@ -153,7 +153,7 @@ function civicrm_api3_custom_field_get($params) {
   if ($handleLegacy && !empty($params['html_type'])) {
     $serializedTypes = ['CheckBox', 'Multi-Select', 'Multi-Select Country', 'Multi-Select State/Province'];
     if (is_string($params['html_type'])) {
-      if (strpos($params['html_type'], 'Multi-Select') === 0) {
+      if (str_starts_with($params['html_type'], 'Multi-Select')) {
         $params['html_type'] = str_replace('Multi-Select', 'Select', $params['html_type']);
         $params['serialize'] = 1;
       }

--- a/api/v3/Generic/Setvalue.php
+++ b/api/v3/Generic/Setvalue.php
@@ -48,7 +48,7 @@ function civicrm_api3_generic_setValue($apiRequest) {
   }
   $fields = $fields['values'];
 
-  $isCustom = strpos($field, 'custom_') === 0;
+  $isCustom = str_starts_with($field, 'custom_');
   // Trim off the id portion of a multivalued custom field name
   $fieldKey = $isCustom && substr_count($field, '_') > 1 ? rtrim(rtrim($field, '1234567890'), '_') : $field;
   if (!array_key_exists($fieldKey, $fields)) {

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -2351,7 +2351,7 @@ function _civicrm_api3_api_match_pseudoconstant_value(&$value, $options, $fieldN
   }
 
   // Hack for Profile formatting fields
-  if ($fieldName === 'field_name' && (strpos($value, 'formatting') === 0)) {
+  if ($fieldName === 'field_name' && (str_starts_with($value, 'formatting'))) {
     return;
   }
 
@@ -2415,7 +2415,7 @@ function _civicrm_api3_api_resolve_alias($entity, $fieldName, $action = 'create'
   if (!$fieldName) {
     return FALSE;
   }
-  if (strpos($fieldName, 'custom_') === 0 && is_numeric($fieldName[7])) {
+  if (str_starts_with($fieldName, 'custom_') && is_numeric($fieldName[7])) {
     return $fieldName;
   }
   if ($fieldName === (CRM_Core_DAO_AllCoreTables::convertEntityNameToLower($entity) . '_id')) {


### PR DESCRIPTION
Overview
----------------------------------------
General refactor - updates code to use preferred newer PHP function.

Technical Details
----------------------------------------
Before/after functionality is the same, but `str_starts_with` is preferred for readability.