### PR TITLE
[REF] Api4 - Use str_starts_with instead of strpos

### DIFF
--- a/Civi/Api4/Service/Autocomplete/MailingRecipientsAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/MailingRecipientsAutocompleteProvider.php
@@ -45,7 +45,7 @@ class MailingRecipientsAutocompleteProvider extends AutoService implements Event
       !is_array($e->savedSearch) ||
       $e->savedSearch['api_entity'] !== 'EntitySet' ||
       ($e->fieldName !== 'Mailing.recipients_include' && $e->fieldName !== 'Mailing.recipients_exclude') ||
-      strpos($e->formName ?? '', 'crmMailing.') !== 0
+      !str_starts_with($e->formName ?? '', 'crmMailing.')
     ) {
       return;
     }

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -35,7 +35,7 @@ class CoreUtil {
   public static function getBAOFromApiName($entityName): ?string {
     // TODO: It would be nice to just call self::getInfoItem($entityName, 'dao')
     // but that currently causes test failures, probably due to early-bootstrap issues.
-    if ($entityName === 'CustomValue' || strpos($entityName, 'Custom_') === 0) {
+    if ($entityName === 'CustomValue' || str_starts_with($entityName, 'Custom_')) {
       $dao = \Civi\Api4\CustomValue::getInfo()['dao'];
     }
     else {

--- a/Civi/Api4/Utils/ReflectionUtils.php
+++ b/Civi/Api4/Utils/ReflectionUtils.php
@@ -78,7 +78,7 @@ class ReflectionUtils {
       if (strlen($line) && $line[0] === ' ') {
         $line = substr($line, 1);
       }
-      if (strpos(ltrim($line), '@') === 0) {
+      if (str_starts_with(ltrim($line), '@')) {
         $words = explode(' ', ltrim($line, ' @'));
         $key = array_shift($words);
         $param = NULL;

--- a/Civi/Api4/Utils/SelectUtil.php
+++ b/Civi/Api4/Utils/SelectUtil.php
@@ -55,7 +55,7 @@ class SelectUtil {
     $search = '/^' . str_replace('\*', '.*', preg_quote($search, '/')) . '$/';
     return array_values(array_filter($fieldNames, function($field) use ($search, $prefix) {
       // Exclude fields that don't have the same join prefix
-      if (($prefix !== '' && strpos($field, $prefix) !== 0) || substr_count($prefix, '.') !== substr_count($field, '.')) {
+      if (($prefix !== '' && !str_starts_with($field, $prefix)) || substr_count($prefix, '.') !== substr_count($field, '.')) {
         return FALSE;
       }
       // Now strip the prefix and compare field name to the pattern


### PR DESCRIPTION
Overview
----------------------------------------
General refactor - updates code to use preferred newer PHP function.

Technical Details
----------------------------------------
Before/after functionality is the same, but `str_starts_with` is preferred for readability.