### PR TITLE
[REF] Civi/misc - Use str_starts_with instead of strpos

### DIFF
--- a/Civi/API/Provider/MagicFunctionProvider.php
+++ b/Civi/API/Provider/MagicFunctionProvider.php
@@ -156,10 +156,10 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
     $prefix = 'civicrm_api' . $version . '_' . _civicrm_api_get_entity_name_from_camel($entity) . '_';
     $prefixGeneric = 'civicrm_api' . $version . '_generic_';
     foreach ($functions['user'] as $fct) {
-      if (strpos($fct, $prefix) === 0) {
+      if (str_starts_with($fct, $prefix)) {
         $actions[] = substr($fct, strlen($prefix));
       }
-      elseif (strpos($fct, $prefixGeneric) === 0) {
+      elseif (str_starts_with($fct, $prefixGeneric)) {
         $actions[] = substr($fct, strlen($prefixGeneric));
       }
     }

--- a/Civi/API/SelectQuery.php
+++ b/Civi/API/SelectQuery.php
@@ -243,7 +243,7 @@ abstract class SelectQuery {
 
       $this->join($side, $fkTable, $tableAlias, $joinCondition);
 
-      if (strpos($fieldName, 'custom_') === 0) {
+      if (str_starts_with($fieldName, 'custom_')) {
         [$tableAlias, $fieldName] = $this->addCustomField($fieldInfo, $side, $tableAlias);
       }
 
@@ -349,12 +349,12 @@ abstract class SelectQuery {
     $prefix = implode('.', $fieldStack) . '.';
     $len = strlen($prefix);
     foreach ($this->select as $key => $ret) {
-      if (strpos($key, $prefix) === 0) {
+      if (str_starts_with($key, $prefix)) {
         $params['return'][substr($key, $len)] = $ret;
       }
     }
     foreach ($this->where as $key => $param) {
-      if (strpos($key, $prefix) === 0) {
+      if (str_starts_with($key, $prefix)) {
         $params[substr($key, $len)] = $param;
       }
     }
@@ -454,7 +454,7 @@ abstract class SelectQuery {
     $return = $return_all_fields ? $this->entityFieldNames : $this->select;
     if ($return_all_fields || in_array('custom', $this->select)) {
       foreach (array_keys($this->apiFieldSpec) as $fieldName) {
-        if (strpos($fieldName, 'custom_') === 0) {
+        if (str_starts_with($fieldName, 'custom_')) {
           $return[] = $fieldName;
         }
       }
@@ -477,7 +477,7 @@ abstract class SelectQuery {
           $this->selectFields[implode('.', $fkField)] = $fieldName;
         }
       }
-      elseif ($field && strpos($fieldName, 'custom_') === 0) {
+      elseif ($field && str_starts_with($fieldName, 'custom_')) {
         [$table_name, $column_name] = $this->addCustomField($field, 'LEFT');
 
         if ($field['data_type'] != 'ContactReference') {

--- a/Civi/Core/SqlTriggers.php
+++ b/Civi/Core/SqlTriggers.php
@@ -250,7 +250,7 @@ class SqlTriggers extends \Civi\Core\Service\AutoService {
     if (!empty($this->enqueuedQueries) && $this->getFile()) {
       $buf = "DELIMITER //\n";
       foreach ($this->enqueuedQueries as $query) {
-        if (strpos($query, 'CREATE TRIGGER') === 0) {
+        if (str_starts_with($query, 'CREATE TRIGGER')) {
           // The create triggers are long so put spaces between them. For the drops
           // condensed is more readable.
           $buf .= "\n";

--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -338,7 +338,7 @@ trait Api3TestTrait {
     $chains = $custom = [];
     foreach ($v3Params as $key => $val) {
       foreach ($toRemove as $remove) {
-        if (strpos($key, $remove) === 0) {
+        if (str_starts_with($key, $remove)) {
           if ($remove == 'api.') {
             $chains[$key] = $val;
           }
@@ -403,7 +403,7 @@ trait Api3TestTrait {
         }
       }
       // Convert custom field names
-      if (strpos($name, 'custom_') === 0 && is_numeric($name[7])) {
+      if (str_starts_with($name, 'custom_') && is_numeric($name[7])) {
         // Strictly speaking, using titles instead of names is incorrect, but it works for
         // unit tests where names and titles are identical and saves an extra db lookup.
         $custom[$field['groupTitle']][$field['title']] = $name;
@@ -679,7 +679,7 @@ trait Api3TestTrait {
 
     // Replace $value.field_name
     foreach ($params as $name => $param) {
-      if (is_string($param) && strpos($param, '$value.') === 0) {
+      if (is_string($param) && str_starts_with($param, '$value.')) {
         $param = substr($param, 7);
         $params[$name] = $result[$param] ?? NULL;
       }


### PR DESCRIPTION
Overview
----------------------------------------
General refactor - updates code to use preferred newer PHP function.

Technical Details
----------------------------------------
Before/after functionality is the same, but `str_starts_with` is preferred for readability.