### PR TITLE
[REF] Misc - Use str_starts_with instead of strpos

### DIFF
--- a/setup/src/Setup/LocaleUtil.php
+++ b/setup/src/Setup/LocaleUtil.php
@@ -47,7 +47,7 @@ class LocaleUtil {
     // Is there anything else that looks remotely close? (e.g. `cy` => `cy_GB`)
     ksort($availLangs);
     foreach ($availLangs as $availLang => $availLabel) {
-      if (strpos($availLang, $first) === 0) {
+      if (str_starts_with($availLang, $first)) {
         return $availLang;
       }
     }

--- a/tools/standalone/router.php
+++ b/tools/standalone/router.php
@@ -258,7 +258,7 @@ class StandaloneRouter {
   private function findFile(string $basePath, string $relPath): ?string {
     $realBase = realpath($basePath);
     $realRel = realpath($basePath . '/' . $relPath);
-    if ($realBase && $realRel && strpos($realRel, $realBase) === 0) {
+    if ($realBase && $realRel && str_starts_with($realRel, $realBase)) {
       return $basePath . '/' . $relPath;
     }
     return NULL;


### PR DESCRIPTION
Overview
----------------------------------------
General refactor - updates code to use preferred newer PHP function.

Technical Details
----------------------------------------
Before/after functionality is the same, but `str_starts_with` is preferred for readability.