### PR TITLE
[REF] Tests - Use str_starts_with instead of strpos

### DIFF
--- a/tests/phpunit/CRM/Contact/Form/Task/PrintDocumentTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/PrintDocumentTest.php
@@ -69,8 +69,8 @@ class CRM_Contact_Form_Task_PrintDocumentTest extends CiviUnitTestCase {
     $returnContent = CRM_Utils_PDF_Document::printDocuments($html, $fileName, $type, $zip, TRUE);
     $returnContent = strip_tags($returnContent);
 
-    $this->assertTrue(strpos($returnContent, 'Hello Antonia D`souza') !== 0);
-    $this->assertTrue(strpos($returnContent, 'Hello Anthony Collins') !== 0);
+    $this->assertTrue(!str_starts_with($returnContent, 'Hello Antonia D`souza'));
+    $this->assertTrue(!str_starts_with($returnContent, 'Hello Anthony Collins'));
   }
 
 }

--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -448,7 +448,7 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
       if ($constant === 'SERIALIZE_JSON' || $constant === 'SERIALIZE_PHP') {
         $constants[] = [$val, array_merge($simpleData, $complexData)];
       }
-      elseif (strpos($constant, 'SERIALIZE_') === 0) {
+      elseif (str_starts_with($constant, 'SERIALIZE_')) {
         $constants[] = [$val, $simpleData];
       }
     }

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -1901,14 +1901,14 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
   public function textExportParticipantSpecifyFieldsNoPayment(): void {
     $selectedFields = $this->getAllSpecifiableParticipantReturnFields();
     foreach ($selectedFields as $index => $field) {
-      if (strpos($field[1], 'componentPaymentField_') === 0) {
+      if (str_starts_with($field[1], 'componentPaymentField_')) {
         unset($selectedFields[$index]);
       }
     }
 
     $expected = $this->getAllSpecifiableParticipantReturnFields();
     foreach ($expected as $index => $field) {
-      if (strpos($index, 'componentPaymentField_') === 0) {
+      if (str_starts_with($index, 'componentPaymentField_')) {
         unset($expected[$index]);
       }
     }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1930,7 +1930,7 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
     }
 
     foreach ($params as $key => $value) {
-      if ($key === 'version' || strpos($key, 'api') === 0 || (!array_key_exists($key, $keys) || !array_key_exists($keys[$key], $result))) {
+      if ($key === 'version' || str_starts_with($key, 'api') || (!array_key_exists($key, $keys) || !array_key_exists($keys[$key], $result))) {
         continue;
       }
       if (in_array($key, $dateFields, TRUE)) {

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -255,7 +255,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    * @param string $reportID
    */
   public function testReportTemplateGetRowsAllReports(string $reportID): void {
-    if (strpos($reportID, 'logging') === 0) {
+    if (str_starts_with($reportID, 'logging')) {
       Civi::settings()->set('logging', 1);
     }
 
@@ -301,7 +301,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    * @param $reportID
    */
   public function testReportTemplateGetRowsAllReportsACL($reportID): void {
-    if (strpos($reportID, 'logging') === 0) {
+    if (str_starts_with($reportID, 'logging')) {
       Civi::settings()->set('logging', 1);
     }
     $this->hookClass->setHook('civicrm_aclWhereClause', [$this, 'aclWhereHookNoResults']);
@@ -322,7 +322,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     if (in_array($reportID, ['contribute/softcredit', 'contribute/bookkeeping'])) {
       $this->markTestIncomplete($reportID . ' has non e-notices when calling statistics fn');
     }
-    if (strpos($reportID, 'logging') === 0) {
+    if (str_starts_with($reportID, 'logging')) {
       Civi::settings()->set('logging', 1);
     }
     if ($reportID === 'contribute/summary') {


### PR DESCRIPTION
Overview
----------------------------------------
General refactor - updates code to use preferred newer PHP function.

Technical Details
----------------------------------------
Before/after functionality is the same, but `str_starts_with` is preferred for readability.