### PR TITLE
[REF] Afform - Use str_starts_with instead of strpos

### DIFF
--- a/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
+++ b/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
@@ -96,7 +96,7 @@ class ContactAutofill extends AbstractBehavior implements EventSubscriberInterfa
     foreach ($event->getFormDataModel()->getEntities() as $entityName => $entity) {
       $autoFillMode = $entity['autofill'] ?? '';
       $relatedContact = $entity['autofill-relationship'] ?? NULL;
-      if ($relatedContact && strpos($autoFillMode, 'relationship:') === 0) {
+      if ($relatedContact && str_starts_with($autoFillMode, 'relationship:')) {
         $event->addDependency($entityName, $relatedContact);
       }
     }
@@ -125,7 +125,7 @@ class ContactAutofill extends AbstractBehavior implements EventSubscriberInterfa
         }
       }
       // Autofill by relationship
-      if (!$id && $relatedContact && strpos($autoFillMode, 'relationship:') === 0) {
+      if (!$id && $relatedContact && str_starts_with($autoFillMode, 'relationship:')) {
         $relationshipType = substr($autoFillMode, strlen('relationship:'));
         $relatedEntity = $event->getFormDataModel()->getEntity($relatedContact);
         if ($relatedEntity) {

--- a/ext/afform/core/Civi/Api4/Action/Afform/GetOptions.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/GetOptions.php
@@ -75,7 +75,7 @@ class GetOptions extends AbstractProcessor {
       // Check to see if field belongs to a join
       foreach ($savedSearch['api_params']['join'] ?? [] as $join) {
         [$joinEntity, $joinAlias] = array_pad(explode(' AS ', $join[0]), 2, '');
-        if (strpos($fieldName, $joinAlias . '.') === 0) {
+        if (str_starts_with($fieldName, $joinAlias . '.')) {
           $entity = $joinEntity;
           $fieldName = substr($fieldName, strlen($joinAlias) + 1);
         }


### PR DESCRIPTION
Overview
----------------------------------------
General refactor - updates code to use preferred newer PHP function.

Technical Details
----------------------------------------
Before/after functionality is the same, but `str_starts_with` is preferred for readability.