### PR TITLE
[REF] CiviImport - Use str_starts_with instead of strpos

### DIFF
--- a/ext/civiimport/Civi/Api4/Event/Subscriber/ImportSubscriber.php
+++ b/ext/civiimport/Civi/Api4/Event/Subscriber/ImportSubscriber.php
@@ -171,7 +171,7 @@ class ImportSubscriber extends AutoService implements EventSubscriberInterface {
   public function onApiAuthorize(AuthorizeEvent $event): void {
     $apiRequest = $event->getApiRequest();
     $entity = $apiRequest['entity'];
-    if (strpos($entity, 'Import_') === 0 && !in_array($event->getActionName(), ['getFields', 'getActions', 'checkAccess'], TRUE)) {
+    if (str_starts_with($entity, 'Import_') && !in_array($event->getActionName(), ['getFields', 'getActions', 'checkAccess'], TRUE)) {
       $userJobID = (int) (str_replace('Import_', '', $entity));
       if (!UserJob::get(TRUE)->addWhere('id', '=', $userJobID)->selectRowCount()->execute()->count()) {
         throw new UnauthorizedException('Import access not permitted');

--- a/ext/civiimport/Civi/Api4/Import/ImportSpecProvider.php
+++ b/ext/civiimport/Civi/Api4/Import/ImportSpecProvider.php
@@ -72,7 +72,7 @@ class ImportSpecProvider extends AutoService implements SpecProviderInterface {
 
     $userJobType = $this->getJobType($spec);
     foreach ($columns as $column) {
-      $isInternalField = strpos($column['name'], '_') === 0;
+      $isInternalField = str_starts_with($column['name'], '_');
       $exists = $isInternalField && $spec->getFieldByName($column['name']);
       if ($exists) {
         continue;

--- a/ext/civiimport/Civi/BAO/Import.php
+++ b/ext/civiimport/Civi/BAO/Import.php
@@ -169,7 +169,7 @@ class Import extends CRM_Core_DAO {
     $userFieldIndex = 0;
     while ($result->fetch()) {
       $columns[$result->Field] = ['name' => $result->Field, 'table_name' => $tableName];
-      if (strpos($result->Field, '_') !== 0) {
+      if (!str_starts_with($result->Field, '_')) {
         $columns[$result->Field]['label'] = ts('Import field') . ':' . ($headers[$userFieldIndex] ?? $result->Field);
         $columns[$result->Field]['data_type'] = 'String';
         $userFieldIndex++;
@@ -177,7 +177,7 @@ class Import extends CRM_Core_DAO {
       else {
         $columns[$result->Field]['label'] = ($result->Field === '_entity_id') ? E::ts('Row Imported to %1 ID', [1 => $entity]) : $result->Field;
         $columns[$result->Field]['fk_entity'] = ($result->Field === '_entity_id') ? $entity : NULL;
-        $columns[$result->Field]['data_type'] = strpos($result->Type, 'int') === 0 ? 'Integer' : 'String';
+        $columns[$result->Field]['data_type'] = str_starts_with($result->Type, 'int') ? 'Integer' : 'String';
       }
     }
     \Civi::cache('metadata')->set($cacheKey, $columns);

--- a/ext/civiimport/Managed/ImportSearches.mgd.php
+++ b/ext/civiimport/Managed/ImportSearches.mgd.php
@@ -89,7 +89,7 @@ foreach ($importEntities as $importEntity) {
       'dataType' => $field['data_type'] ?? 'String',
       'label' => $field['title'] ?? $field['label'],
       'sortable' => TRUE,
-      'editable' => strpos($field['name'], '_') !== 0,
+      'editable' => !str_starts_with($field['name'], '_'),
       'link' => $field['link'] ?? NULL,
     ];
   }

--- a/ext/civiimport/civiimport.php
+++ b/ext/civiimport/civiimport.php
@@ -143,7 +143,7 @@ function civiimport_civicrm_alterTemplateFile($formName, $form, $type, &$templat
   }
   if ($formName === 'CRM_Queue_Page_Monitor') {
     $jobName = CRM_Utils_Request::retrieveValue('name', 'String');
-    if (strpos($jobName, 'user_job_') === 0) {
+    if (str_starts_with($jobName, 'user_job_')) {
       try {
         $userJobID = (int) str_replace('user_job_', '', $jobName);
         $jobType = UserJob::get()->addWhere('id', '=', $userJobID)


### PR DESCRIPTION
Overview
----------------------------------------
General refactor - updates code to use preferred newer PHP function.

Technical Details
----------------------------------------
Before/after functionality is the same, but `str_starts_with` is preferred for readability.