### PR TITLE
[REF] CRM/Core - Use str_starts_with instead of strpos

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1872,7 +1872,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
     // "Participant" but that would prevent extensions from creating enties with complex custom fields.
     $getEntityName = function($optionValueName) use ($extendsEntities) {
       foreach ($extendsEntities as $entityName) {
-        if (strpos($optionValueName, $entityName) === 0) {
+        if (str_starts_with($optionValueName, $entityName)) {
           return $entityName;
         }
       }

--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -875,7 +875,7 @@ MODIFY      {$columnName} varchar( $length )
         if (!$dao->Collation || $dao->Collation === $newCollation || $dao->Collation === $newBinaryCollation) {
           continue;
         }
-        if (strpos($dao->Collation, 'utf8') !== 0) {
+        if (!str_starts_with($dao->Collation, 'utf8')) {
           continue;
         }
 

--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -61,7 +61,7 @@ class CRM_Core_BAO_UFField extends CRM_Core_DAO_UFField implements \Civi\Core\Ho
     }
 
     // Supply field_type if not set
-    if (empty($params['field_type']) && strpos($params['field_name'], 'formatting') !== 0) {
+    if (empty($params['field_type']) && !str_starts_with($params['field_name'], 'formatting')) {
       $params['field_type'] = CRM_Utils_Array::pathGet(self::getAvailableFieldsFlat(), [$params['field_name'], 'field_type']);
     }
     elseif (empty($params['field_type'])) {

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2341,12 +2341,12 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
                         $defaults[$fldName] = $value[$fieldName];
                       }
                     }
-                    elseif (strpos($fieldName, 'address_custom') === 0 && !empty($value[substr($fieldName, 8)])) {
+                    elseif (str_starts_with($fieldName, 'address_custom') && !empty($value[substr($fieldName, 8)])) {
                       $defaults[$fldName] = self::formatCustomValue($field, $value[substr($fieldName, 8)]);
                     }
                   }
                 }
-                elseif (strpos($fieldName, 'address_custom') === 0 && !empty($value[substr($fieldName, 8)])) {
+                elseif (str_starts_with($fieldName, 'address_custom') && !empty($value[substr($fieldName, 8)])) {
                   $defaults[$fldName] = self::formatCustomValue($field, $value[substr($fieldName, 8)]);
                 }
               }
@@ -2484,7 +2484,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       $fields = array_keys($profileFields);
       foreach ($fields as $val) {
         foreach ($required as $key => $field) {
-          if (strpos($val, $field) === 0) {
+          if (str_starts_with($val, $field)) {
             unset($required[$key]);
           }
         }

--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -244,7 +244,7 @@ class CRM_Core_DAO_AllCoreTables {
     foreach ($fragments as & $fragment) {
       $fragment = ucfirst($fragment);
       // Special case: UFGroup, UFJoin, UFMatch, UFField (if passed in without underscores)
-      if (strpos($fragment, 'Uf') === 0 && strlen($name) > 2) {
+      if (str_starts_with($fragment, 'Uf') && strlen($name) > 2) {
         $fragment = 'UF' . ucfirst(substr($fragment, 2));
       }
     }

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1786,7 +1786,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       $props['placeholder'] = $placeholder;
     }
     // Handle custom field
-    if (strpos($name, 'custom_') === 0 && is_numeric($name[7])) {
+    if (str_starts_with($name, 'custom_') && is_numeric($name[7])) {
       [, $id] = explode('_', $name);
       $label = $props['label'] ?? CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', 'label', $id);
       $gid = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', 'option_group_id', $id);
@@ -1895,7 +1895,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     }
 
     // Handle custom fields
-    if (strpos($name, 'custom_') === 0 && is_numeric($name[7])) {
+    if (str_starts_with($name, 'custom_') && is_numeric($name[7])) {
       $fieldId = (int) substr($name, 7);
       return CRM_Core_BAO_CustomField::addQuickFormElement($this, $name, $fieldId, $required, $context == 'search', $props['label'] ?? NULL);
     }

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -143,7 +143,7 @@ class CRM_Core_PseudoConstant {
     $entity = CRM_Core_DAO_AllCoreTables::getEntityNameForClass($daoName);
 
     // Custom fields are not in the schema
-    if (strpos($fieldName, 'custom_') === 0 && is_numeric($fieldName[7])) {
+    if (str_starts_with($fieldName, 'custom_') && is_numeric($fieldName[7])) {
       $customField = new CRM_Core_BAO_CustomField();
       $customField->id = (int) substr($fieldName, 7);
       $options = $customField->getOptions($context);

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -609,7 +609,7 @@ class CRM_Core_SelectValues {
     $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['eventId']]);
     $allTokens = $tokenProcessor->listTokens();
     foreach (array_keys($allTokens) as $token) {
-      if (strpos($token, '{domain.') === 0) {
+      if (str_starts_with($token, '{domain.')) {
         unset($allTokens[$token]);
       }
     }
@@ -628,7 +628,7 @@ class CRM_Core_SelectValues {
     $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['contributionId']]);
     $allTokens = $tokenProcessor->listTokens();
     foreach (array_keys($allTokens) as $token) {
-      if (strpos($token, '{domain.') === 0) {
+      if (str_starts_with($token, '{domain.')) {
         unset($allTokens[$token]);
       }
     }
@@ -646,7 +646,7 @@ class CRM_Core_SelectValues {
     $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['contactId']]);
     $allTokens = $tokenProcessor->listTokens();
     foreach (array_keys($allTokens) as $token) {
-      if (strpos($token, '{domain.') === 0) {
+      if (str_starts_with($token, '{domain.')) {
         unset($allTokens[$token]);
       }
     }
@@ -665,7 +665,7 @@ class CRM_Core_SelectValues {
     $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['participantId']]);
     $allTokens = $tokenProcessor->listTokens();
     foreach (array_keys($allTokens) as $token) {
-      if (strpos($token, '{domain.') === 0 || strpos($token, '{event.') === 0) {
+      if (str_starts_with($token, '{domain.') === 0 || strpos($token, '{event.')) {
         unset($allTokens[$token]);
       }
     }

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -512,30 +512,30 @@ class CRM_Core_Smarty extends CRM_Core_SmartyCompatibility {
     if ($esc_type === 'htmlall') {
       // 'htmlall' is the nothing-specified default.
       // Don't escape things we think quickform added.
-      if (strpos($string, '<input') === 0
-        || strpos($string, '<select') === 0
+      if (str_starts_with($string, '<input')
+        || str_starts_with($string, '<select')
         // Not handling as yet but these ones really should get some love.
-        || strpos($string, '<label') === 0
-        || strpos($string, '<button') === 0
-        || strpos($string, '<span class="crm-frozen-field">') === 0
-        || strpos($string, '<textarea') === 0
+        || str_starts_with($string, '<label')
+        || str_starts_with($string, '<button')
+        || str_starts_with($string, '<span class="crm-frozen-field">')
+        || str_starts_with($string, '<textarea')
 
         // The ones below this point are hopefully here short term.
-        || strpos($string, '<a') === 0
+        || str_starts_with($string, '<a')
         // Message templates screen
-        || strpos($string, '<span><a href') === 0
+        || str_starts_with($string, '<span><a href')
         // Not sure how big a pattern this is - used in Pledge view tab
         // not sure if it needs escaping
-        || strpos($string, ' action="/civicrm/') === 0
+        || str_starts_with($string, ' action="/civicrm/')
         // eg. Tag edit page, civicrm/admin/financial/financialType/accounts?action=add&reset=1&aid=1
-        || strpos($string, ' action="" method="post"') === 0
+        || str_starts_with($string, ' action="" method="post"')
         // This seems to be urls...
-        || strpos($string, '/civicrm/') === 0
+        || str_starts_with($string, '/civicrm/')
         // Validation error message - eg. <span class="crm-error">Tournament Fees is a required field.</span>
         || strpos($string, '
     <span class="crm-error">') === 0
         // e.g from participant tab class="action-item" href=/civicrm/contact/view/participant?reset=1&amp;action=add&amp;cid=142&amp;context=participant
-        || strpos($string, 'class="action-item" href=/civicrm/"') === 0
+        || str_starts_with($string, 'class="action-item" href=/civicrm/"')
       ) {
         // Do not escape the above common patterns.
         return $string;


### PR DESCRIPTION
Overview
----------------------------------------
General refactor - updates code to use preferred newer PHP function.

Technical Details
----------------------------------------
Before/after functionality is the same, but `str_starts_with` is preferred for readability.