### PR TITLE
[REF] CRM/Utils - Use str_starts_with instead of strpos

### DIFF
--- a/CRM/Utils/API/AbstractFieldCoder.php
+++ b/CRM/Utils/API/AbstractFieldCoder.php
@@ -48,7 +48,7 @@ abstract class CRM_Utils_API_AbstractFieldCoder implements API_Wrapper {
       return FALSE;
     }
     // Strip extra numbers from custom fields e.g. custom_32_1 should be custom_32
-    if (strpos($fldName, 'custom_') === 0) {
+    if (str_starts_with($fldName, 'custom_')) {
       list($fldName, $customId) = explode('_', $fldName);
       $fldName .= '_' . $customId;
     }

--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -1394,7 +1394,7 @@ class CRM_Utils_Array {
   public static function filterByPrefix(array &$collection, string $prefix): array {
     $filtered = [];
     foreach (array_keys($collection) as $key) {
-      if (!$prefix || strpos($key, $prefix) === 0) {
+      if (!$prefix || str_starts_with($key, $prefix)) {
         $filtered[substr($key, strlen($prefix))] = $collection[$key];
         unset($collection[$key]);
       }

--- a/CRM/Utils/Check/Component.php
+++ b/CRM/Utils/Check/Component.php
@@ -51,7 +51,7 @@ abstract class CRM_Utils_Check_Component {
    */
   public function getAllChecks() {
     return array_filter(get_class_methods($this), function($method) {
-      return $method !== 'checkAll' && strpos($method, 'check') === 0;
+      return $method !== 'checkAll' && str_starts_with($method, 'check');
     });
   }
 
@@ -91,7 +91,7 @@ abstract class CRM_Utils_Check_Component {
       return TRUE;
     }
     foreach ($requestedChecks as $name) {
-      if (strpos($name, $method) === 0) {
+      if (str_starts_with($name, $method)) {
         return TRUE;
       }
     }

--- a/CRM/Utils/Color.php
+++ b/CRM/Utils/Color.php
@@ -54,7 +54,7 @@ class CRM_Utils_Color {
   public static function getRgb($color) {
     $color = str_replace(' ', '', $color);
     $color = self::nameToHex($color) ?? $color;
-    if (strpos($color, 'rgb(') === 0) {
+    if (str_starts_with($color, 'rgb(')) {
       return explode(',', substr($color, 4, strpos($color, ')') - 4));
     }
     $color = ltrim($color, '#');

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -1097,7 +1097,7 @@ HTACCESS;
     }
     $iconClasses = Civi::$statics[__CLASS__]['mimeIcons'];
     foreach ($iconClasses as $text => $icon) {
-      if (strpos(($mimeType ?? ''), $text) === 0) {
+      if (str_starts_with(($mimeType ?? ''), $text)) {
         return $icon;
       }
     }

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -1021,7 +1021,7 @@ AND    u.status = 1
     // Handle absolute urls
     // compares $url (which is some unknown/untrusted value from a third-party dev) to the CMS's base url (which is independent of civi's url)
     // to see if the url is within our Backdrop dir, if it is we are able to treated it as an internal url
-    if (strpos($url, $base_url) === 0) {
+    if (str_starts_with($url, $base_url)) {
       $file = trim(str_replace($base_url, '', $url), '/');
       // CRM-18130: Custom CSS URL not working if aliased or rewritten
       if (file_exists(BACKDROP_ROOT . $file)) {
@@ -1030,7 +1030,7 @@ AND    u.status = 1
       }
     }
     // Handle relative urls that are within the CiviCRM module directory
-    elseif (strpos($url, $base) === 0) {
+    elseif (str_starts_with($url, $base)) {
       $internal = TRUE;
       $url = $this->appendCoreDirectoryToResourceBase(dirname(backdrop_get_path('module', 'civicrm')) . '/') . trim(substr($url, strlen($base)), '/');
     }

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -107,7 +107,7 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
     // Handle absolute urls
     // compares $url (which is some unknown/untrusted value from a third-party dev) to the CMS's base url (which is independent of civi's url)
     // to see if the url is within our drupal dir, if it is we are able to treated it as an internal url
-    if (strpos($url_path, $base_url) === 0) {
+    if (str_starts_with($url_path, $base_url)) {
       $file = trim(str_replace($base_url, '', $url_path), '/');
       // CRM-18130: Custom CSS URL not working if aliased or rewritten
       if (file_exists(DRUPAL_ROOT . '/' . $file)) {
@@ -116,7 +116,7 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
       }
     }
     // Handle relative urls that are within the CiviCRM module directory
-    elseif (strpos($url_path, $base) === 0) {
+    elseif (str_starts_with($url_path, $base)) {
       $internal = TRUE;
       $url = $this->appendCoreDirectoryToResourceBase(dirname(drupal_get_path('module', 'civicrm')) . '/') . trim(substr($url_path, strlen($base)), '/');
     }


### PR DESCRIPTION
Overview
----------------------------------------
General refactor - updates code to use preferred newer PHP function.

Technical Details
----------------------------------------
Before/after functionality is the same, but `str_starts_with` is preferred for readability.