### PR TITLE
[REF] CRM/Event - Use str_starts_with instead of strpos

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -897,7 +897,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
     $participantParams['custom'] = [];
     foreach ($form->_params as $paramName => $paramValue) {
-      if (strpos($paramName, 'custom_') === 0) {
+      if (str_starts_with($paramName, 'custom_')) {
         [$customFieldID, $customValueID] = CRM_Core_BAO_CustomField::getKeyID($paramName, TRUE);
         CRM_Core_BAO_CustomField::formatCustomField($customFieldID, $participantParams['custom'], $paramValue, 'Participant', $customValueID);
 

--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -217,7 +217,7 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
   public static function checkProfileComplete($fields, &$errors): ?int {
     $email = '';
     foreach ($fields as $fieldname => $fieldvalue) {
-      if (strpos($fieldname, 'email') === 0 && $fieldvalue) {
+      if (str_starts_with($fieldname, 'email') && $fieldvalue) {
         $email = $fieldvalue;
       }
     }

--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -213,7 +213,7 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
         ->execute()->first();
       $addressValues = ['address_name' => $event['loc_block_id.address_id.name']];
       foreach ($event as $key => $value) {
-        if (strpos($key, 'loc_block_id.address_id.') === 0) {
+        if (str_starts_with($key, 'loc_block_id.address_id.')) {
           $addressValues[str_replace('loc_block_id.address_id.', '', $key)] = $value;
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
General refactor - updates code to use preferred newer PHP function.

Technical Details
----------------------------------------
Before/after functionality is the same, but `str_starts_with` is preferred for readability.