### PR TITLE
dev/core#5556 Update the packaged version of league/csv to be 9.8.0 b…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
     "adrienrn/php-mimetyper": "0.2.2",
     "civicrm/composer-downloads-plugin": "^3.0 || ^4.0",
     "laravel/serializable-closure": "^1.3",
-    "league/csv": "~9.7.4",
+    "league/csv": "^9.8.0",
     "league/oauth2-client": "^2.4",
     "league/oauth2-google": "^3.0 || ^4.0",
     "tplaner/when": "~3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e061582ca77bdc80bd3367b7c145d1a",
+    "content-hash": "46dcf090fac83dffdeaba00f0d36b933",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -1412,31 +1412,31 @@
         },
         {
             "name": "league/csv",
-            "version": "9.7.4",
+            "version": "9.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/csv.git",
-                "reference": "002f55f649e7511710dc7154ff44c7be32c8195c"
+                "reference": "9d2e0265c5d90f5dd601bc65ff717e05cec19b47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/csv/zipball/002f55f649e7511710dc7154ff44c7be32c8195c",
-                "reference": "002f55f649e7511710dc7154ff44c7be32c8195c",
+                "url": "https://api.github.com/repos/thephpleague/csv/zipball/9d2e0265c5d90f5dd601bc65ff717e05cec19b47",
+                "reference": "9d2e0265c5d90f5dd601bc65ff717e05cec19b47",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "php": "^7.3 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "ext-curl": "*",
                 "ext-dom": "*",
-                "friendsofphp/php-cs-fixer": "^3.0",
-                "phpstan/phpstan": "^1.0",
+                "friendsofphp/php-cs-fixer": "^v3.4.0",
+                "phpstan/phpstan": "^1.3.0",
                 "phpstan/phpstan-phpunit": "^1.0.0",
-                "phpstan/phpstan-strict-rules": "^1.0",
-                "phpunit/phpunit": "^9.5"
+                "phpstan/phpstan-strict-rules": "^1.1.0",
+                "phpunit/phpunit": "^9.5.11"
             },
             "suggest": {
                 "ext-dom": "Required to use the XMLConverter and or the HTMLConverter classes",
@@ -1469,7 +1469,7 @@
                 }
             ],
             "description": "CSV data manipulation made easy in PHP",
-            "homepage": "http://csv.thephpleague.com",
+            "homepage": "https://csv.thephpleague.com",
             "keywords": [
                 "convert",
                 "csv",
@@ -1492,7 +1492,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-11-30T07:09:34+00:00"
+            "time": "2022-01-04T00:13:07+00:00"
         },
         {
             "name": "league/oauth2-client",
@@ -5882,5 +5882,5 @@
     "platform-overrides": {
         "php": "8.0.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
…ut permit Drupal 10/11 sites to install more recent versions of league/csv

Overview
----------------------------------------
This updates the version for Backdrop/WordPress/Joomla (Drupal 7) to be 9.8.0 which is the last version that supports 8.0 but modifies composer to allow for newer versions to be install by D10/11

Before
----------------------------------------
Composer locked to 9.7.4

After
----------------------------------------
Composer less locked for d10/d11 and set to 9.8.0 for those that get tar balls / zips

Note I haven't tested installing more recent versions of league/csv and running the unit tests but there wasn't anything immediately that was jumping out at me as breaking but maybe if someone else wants to check the Release notes

ping @colemanw @demeritcowboy @eileenmcnaughton 