### PR TITLE
Fix #5713: Unauthorized API call causes backtrace in logs during install

### DIFF
--- a/ext/civiimport/Civi/Api4/Event/Subscriber/ImportSubscriber.php
+++ b/ext/civiimport/Civi/Api4/Event/Subscriber/ImportSubscriber.php
@@ -213,6 +213,10 @@ class ImportSubscriber extends AutoService implements EventSubscriberInterface {
       return \Civi::cache('metadata')->get($cacheKey);
     }
     $forms = [];
+    if (!\CRM_Core_Permission::check(['access CiviCRM'])) {
+      // Avoid causing backtrace during install due to lack of permission for SearchDisplay::get()
+      return $forms;
+    }
     try {
       $importSearches = SearchDisplay::get()
         ->addWhere('saved_search_id.name', 'LIKE', 'Import\_Summary\_%')


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/5713

The code in this class looks like it's trying to silently see if there's any SearchDisplay to deal with, however since 5.70 any API call that results in an Unauthorized error gets a backtrace in the logs.

This permission check shortcuts this to avoid that. The effect, I believe, is nothing; before this function did nothing but caused an alarming dump in the logs, and after it does nothing but does not cause the logging.

