### PR TITLE
Upgrader - Fix upgrade error with i18n-enabled databases

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveThirtyFour.php
+++ b/CRM/Upgrade/Incremental/php/FiveThirtyFour.php
@@ -240,7 +240,7 @@ class CRM_Upgrade_Incremental_php_FiveThirtyFour extends CRM_Upgrade_Incremental
       MODIFY COLUMN `is_deductible` tinyint(4) DEFAULT 0 NOT NULL COMMENT 'Is this financial type tax-deductible? If true, contributions of this type may be fully OR partially deductible - non-deductible amount is stored in the Contribution record.',
       MODIFY COLUMN `is_reserved` tinyint(4) DEFAULT 0 NOT NULL COMMENT 'Is this a predefined system object?',
       MODIFY COLUMN `is_active` tinyint(4) DEFAULT 1 NOT NULL COMMENT 'Is this property active?'
-    ");
+    ", [], TRUE, NULL, FALSE, FALSE);
 
     return TRUE;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes upgrade error reported at https://civicrm.stackexchange.com/questions/49194/db-upgrade-error-version-5-17-3-to-5-81-1

Technical Details
----------------------------------------
ALTER TABLE is not compatible with i18n-rewrite and it must be disabled.