### PR TITLE
Standaloneusers - move password reset email to managed record

### DIFF
--- a/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
@@ -1,6 +1,5 @@
 <?php
 use CRM_Standaloneusers_ExtensionUtil as E;
-use Civi\Api4\MessageTemplate;
 use Civi\Api4\Navigation;
 
 /**
@@ -52,48 +51,9 @@ class CRM_Standaloneusers_Upgrader extends CRM_Extension_Upgrader_Base {
       ['pass']
     )));
 
-    $this->createPasswordResetMessageTemplate();
-
     // `standaloneusers` is installed as part of the overall install process for `Standalone`.
     // A subsequent step will configure some default users (*depending on local options*).
     // See also: `StandaloneUsers.civi-setup.php`
-  }
-
-  public function createPasswordResetMessageTemplate() {
-
-    $baseTpl = [
-      'workflow_name' => 'password_reset',
-      'msg_title' => 'Password reset',
-      'msg_subject' => '{ts}Password reset link for{/ts} {domain.name}',
-      'msg_text' => <<<TXT
-        {ts}A password reset link was requested for this account.  If this wasn't you (and nobody else can access this email account) you can safely ignore this email.{/ts}
-
-        {\$resetUrlPlaintext}
-
-        {\$tokenTimeoutPlaintext}
-
-        {domain.name}
-        TXT,
-      'msg_html' => <<<HTML
-        <p>{ts}A password reset link was requested for this account.&nbsp; If this wasn't you (and nobody else can access this email account) you can safely ignore this email.{/ts}</p>
-
-        <p><a href="{\$resetUrlHtml}">{\$resetUrlHtml}</a></p>
-
-        <p><strong>{\$tokenTimeoutHtml}</strong></p>
-
-        <p>{domain.name}</p>
-        HTML,
-    ];
-
-    // Create a "reserved" template. This is a pristine copy provided for reference.
-    MessageTemplate::save(FALSE)
-      ->setDefaults($baseTpl)
-      ->setRecords([
-        ['is_reserved' => TRUE, 'is_default' => FALSE],
-        ['is_reserved' => FALSE, 'is_default' => TRUE],
-      ])
-      ->execute();
-
   }
 
   /**

--- a/ext/standaloneusers/managed/MessageTemplate_PasswordReset.mgd.php
+++ b/ext/standaloneusers/managed/MessageTemplate_PasswordReset.mgd.php
@@ -3,16 +3,6 @@ use CRM_Standaloneusers_ExtensionUtil as E;
 
 $passwordResetSubject = '{ts}Password reset link for{/ts} {domain.name}';
 
-$passwordResetText = <<<TXT
-  {ts}A password reset link was requested for this account.  If this wasn't you (and nobody else can access this email account) you can safely ignore this email.{/ts}
-
-  {\$resetUrlPlaintext}
-
-  {\$tokenTimeoutPlaintext}
-
-  {domain.name}
-TXT;
-
 $passwordResetHtml = <<<HTML
   <p>{ts}A password reset link was requested for this account.&nbsp; If this wasn't you (and nobody else can access this email account) you can safely ignore this email.{/ts}</p>
 
@@ -40,7 +30,7 @@ return [
         'workflow_name' => 'password_reset',
         'msg_title' => E::ts('Password reset'),
         'msg_subject' => $passwordResetSubject,
-        'msg_text' => $passwordResetText,
+        'msg_text' => '',
         'msg_html' => $passwordResetHtml,
         'is_default' => FALSE,
         'is_reserved' => TRUE,
@@ -63,7 +53,7 @@ return [
         'workflow_name' => 'password_reset',
         'msg_title' => E::ts('Password reset'),
         'msg_subject' => $passwordResetSubject,
-        'msg_text' => $passwordResetText,
+        'msg_text' => '',
         'msg_html' => $passwordResetHtml,
         'is_default' => TRUE,
         'is_reserved' => FALSE,

--- a/ext/standaloneusers/managed/MessageTemplate_PasswordReset.mgd.php
+++ b/ext/standaloneusers/managed/MessageTemplate_PasswordReset.mgd.php
@@ -1,0 +1,73 @@
+<?php
+use CRM_Standaloneusers_ExtensionUtil as E;
+
+$passwordResetSubject = '{ts}Password reset link for{/ts} {domain.name}';
+
+$passwordResetText = <<<TXT
+  {ts}A password reset link was requested for this account.  If this wasn't you (and nobody else can access this email account) you can safely ignore this email.{/ts}
+
+  {\$resetUrlPlaintext}
+
+  {\$tokenTimeoutPlaintext}
+
+  {domain.name}
+TXT;
+
+$passwordResetHtml = <<<HTML
+  <p>{ts}A password reset link was requested for this account.&nbsp; If this wasn't you (and nobody else can access this email account) you can safely ignore this email.{/ts}</p>
+
+  <p><a href="{\$resetUrlHtml}">{\$resetUrlHtml}</a></p>
+
+  <p><strong>{\$tokenTimeoutHtml}</strong></p>
+
+  <p>{domain.name}</p>
+HTML;
+
+return [
+  [
+    'name' => 'MessageTemplate_PasswordResetReserved',
+    'entity' => 'MessageTemplate',
+    'cleanup' => 'unused',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'checkPermissions' => FALSE,
+      'match' => [
+        'workflow_name',
+        'is_reserved',
+      ],
+      'values' => [
+        'workflow_name' => 'password_reset',
+        'msg_title' => E::ts('Password reset'),
+        'msg_subject' => $passwordResetSubject,
+        'msg_text' => $passwordResetText,
+        'msg_html' => $passwordResetHtml,
+        'is_default' => FALSE,
+        'is_reserved' => TRUE,
+      ],
+    ],
+  ],
+  [
+    'name' => 'MessageTemplate_PasswordResetEditable',
+    'entity' => 'MessageTemplate',
+    'cleanup' => 'unused',
+    'update' => 'never',
+    'params' => [
+      'version' => 4,
+      'checkPermissions' => FALSE,
+      'match' => [
+        'workflow_name',
+        'is_reserved',
+      ],
+      'values' => [
+        'workflow_name' => 'password_reset',
+        'msg_title' => E::ts('Password reset'),
+        'msg_subject' => $passwordResetSubject,
+        'msg_text' => $passwordResetText,
+        'msg_html' => $passwordResetHtml,
+        'is_default' => TRUE,
+        'is_reserved' => FALSE,
+      ],
+    ],
+  ],
+];

--- a/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
@@ -230,10 +230,8 @@ class SecurityTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
     $this->assertNotNull($workflow);
     $result = $workflow->renderTemplate();
 
-    $this->assertMatchesRegularExpression(';https?://[^/]+/civicrm/login/password.*' . $token . ';', $result['text']);
     $this->assertMatchesRegularExpression(';https?://[^/]+/civicrm/login/password.*' . $token . ';', $result['html']);
     $this->assertEquals('Password reset link for Demonstrators Anonymous', $result['subject']);
-    $this->assertStringContainsString('This link expires 60 minutes after the date of this email.', $result['text']);
     $this->assertStringContainsString('This link expires 60 minutes after the date of this email.', $result['html']);
 
     // Fake an expired token


### PR DESCRIPTION

Before
----------------------------------------
- bespoke step in the standaloneusers installer to create two MessageTemplate records

After
----------------------------------------
- managed record to ensure the two password reset templates exist

Technical Details
----------------------------------------
This should remove the need for https://lab.civicrm.org/extensions/standalonemigrate/-/merge_requests/9

And I think allow future updates to be made just by updating the Managed Record.

The reserved template is set to `update` => `unmodified` to update unless a super-admin type has concertedly changed the reserved template. The user editable template is set to `update` => `never` to preserve any user changes.
