### PR TITLE
Php 8.x deprecation fixes

### DIFF
--- a/ext/afform/core/Civi/Afform/Utils.php
+++ b/ext/afform/core/Civi/Afform/Utils.php
@@ -101,7 +101,7 @@ class Utils {
       (!empty($updatedAfform['server_route']) && $isChanged('title'));
   }
 
-  public static function formatViewValue(string $fieldName, array $fieldInfo, array $values, string $entityName = NULL, string $formName = NULL): string {
+  public static function formatViewValue(string $fieldName, array $fieldInfo, array $values, ?string $entityName = NULL, ?string $formName = NULL): string {
     $value = $values[$fieldName] ?? NULL;
     if (isset($value) && $value !== '') {
       $dataType = $fieldInfo['data_type'] ?? NULL;

--- a/ext/flexmailer/src/FlexMailer.php
+++ b/ext/flexmailer/src/FlexMailer.php
@@ -129,9 +129,9 @@ class FlexMailer {
    *     - mailing: \CRM_Mailing_BAO_Mailing
    *     - job: \CRM_Mailing_BAO_MailingJob
    *     - attachments: array
-   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface|null $dispatcher
    */
-  public function __construct($context = [], EventDispatcherInterface $dispatcher = NULL) {
+  public function __construct($context = [], ?EventDispatcherInterface $dispatcher = NULL) {
     $this->context = $context;
     $this->dispatcher = $dispatcher ?: \Civi::service('dispatcher');
   }

--- a/ext/flexmailer/src/Validator.php
+++ b/ext/flexmailer/src/Validator.php
@@ -51,9 +51,9 @@ class Validator {
 
   /**
    * FlexMailer constructor.
-   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface|null $dispatcher
    */
-  public function __construct(EventDispatcherInterface $dispatcher = NULL) {
+  public function __construct(?EventDispatcherInterface $dispatcher = NULL) {
     $this->dispatcher = $dispatcher ?: \Civi::service('dispatcher');
   }
 

--- a/ext/search_kit/Civi/Search/Display.php
+++ b/ext/search_kit/Civi/Search/Display.php
@@ -57,7 +57,7 @@ class Display {
    * @param array|null $excludeActions
    * @return array[]
    */
-  public static function getEntityLinks(string $entity, $addLabel = FALSE, array $excludeActions = NULL): array {
+  public static function getEntityLinks(string $entity, $addLabel = FALSE, ?array $excludeActions = NULL): array {
     $apiParams = [
       'checkPermissions' => FALSE,
       'entityTitle' => $addLabel,


### PR DESCRIPTION
Overview
----------------------------------------
Php 8.x deprecation fixes

Before
----------------------------------------
Deprecated: Civi\FlexMailer\Validator::__construct(): Implicitly marking parameter $dispatcher as nullable is deprecated, the explicit nullable type must be used instead in /home/homer/buildkit/build/build-2/web/core/ext/flexmailer/src/Validator.php on line 56

Deprecated: Civi\FlexMailer\FlexMailer::__construct(): Implicitly marking parameter $dispatcher as nullable is deprecated, the explicit nullable type must be used instead in /home/homer/buildkit/build/build-2/web/core/ext/flexmailer/src/FlexMailer.php on line 134

Deprecated: Civi\Afform\Utils::formatViewValue(): Implicitly marking parameter $entityName as nullable is deprecated, the explicit nullable type must be used instead in /home/homer/buildkit/build/build-2/web/core/ext/afform/core/Civi/Afform/Utils.php on line 104

Deprecated: Civi\Afform\Utils::formatViewValue(): Implicitly marking parameter $formName as nullable is deprecated, the explicit nullable type must be used instead in /home/homer/buildkit/build/build-2/web/core/ext/afform/core/Civi/Afform/Utils.php on line 104

Deprecated: Civi\Search\Display::getEntityLinks(): Implicitly marking parameter $excludeActions as nullable is deprecated, the explicit nullable type must be used instead in /home/homer/buildkit/build/build-2/web/core/ext/search_kit/Civi/Search/Display.php on line 60

After
----------------------------------------
declared

Technical Details
----------------------------------------

Comments
----------------------------------------
