### PR TITLE
Shimmy - Fix deprecated php implicit null

### DIFF
--- a/tests/extensions/shimmy/shimmy.civix.php
+++ b/tests/extensions/shimmy/shimmy.civix.php
@@ -186,7 +186,7 @@ function _shimmy_civix_civicrm_disable() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
-function _shimmy_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
+function _shimmy_civix_civicrm_upgrade($op, ?CRM_Queue_Queue $queue = NULL) {
   if ($upgrader = _shimmy_civix_upgrader()) {
     return $upgrader->onUpgrade($op, $queue);
   }


### PR DESCRIPTION
Overview
----------------------------------------
In PHP 8.4, implicitly marking param as nullable is deprecated