### PR TITLE
Separate back dedupe table drop query

### DIFF
--- a/CRM/Dedupe/BAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/BAO/DedupeRuleGroup.php
@@ -132,8 +132,11 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup impl
 
   /**
    * Return the SQL query for dropping the temporary table.
+   *
+   * @deprecated since 6.1.0 will be removed around 6.7.0
    */
   public function tableDropQuery() {
+    CRM_Core_Error::deprecatedFunctionWarning('none');
     return 'DROP TEMPORARY TABLE IF EXISTS dedupe';
   }
 
@@ -183,7 +186,8 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup impl
       $duplicates[] = ['entity_id_1' => $dao->id1, 'entity_id_2' => $dao->id2, 'weight' => $dao->weight];
     }
     $event->duplicates = $duplicates;
-    \CRM_Core_DAO::executeQuery($ruleGroup->tableDropQuery());
+    // Does it ever exist?
+    \CRM_Core_DAO::executeQuery('DROP TEMPORARY TABLE IF EXISTS dedupe');
   }
 
   public static function hook_civicrm_findDuplicates(GenericHookEvent $event): void {
@@ -221,7 +225,8 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup impl
         $dupes[] = $dao->id;
       }
     }
-    CRM_Core_DAO::executeQuery($rgBao->tableDropQuery());
+    // Does it ever exist?
+    CRM_Core_DAO::executeQuery('DROP TEMPORARY TABLE IF EXISTS dedupe');
     $event->dedupeResults['ids'] = array_diff($dupes, $event->dedupeParams['excluded_contact_ids']);
   }
 

--- a/ext/legacydedupefinder/Civi/LegacyFinder/Finder.php
+++ b/ext/legacydedupefinder/Civi/LegacyFinder/Finder.php
@@ -67,7 +67,8 @@ class Finder extends AutoSubscriber {
       $duplicates[] = ['entity_id_1' => $dao->id1, 'entity_id_2' => $dao->id2, 'weight' => $dao->weight];
     }
     $event->duplicates = $duplicates;
-    \CRM_Core_DAO::executeQuery($ruleGroup->tableDropQuery());
+    // Does it ever exist?
+    \CRM_Core_DAO::executeQuery('DROP TEMPORARY TABLE IF EXISTS dedupe');
   }
 
   public static function findDuplicates(GenericHookEvent $event): void {
@@ -108,7 +109,8 @@ class Finder extends AutoSubscriber {
         $dupes[] = $dao->id;
       }
     }
-    \CRM_Core_DAO::executeQuery($rgBao->tableDropQuery());
+    // Does it ever exist?
+    \CRM_Core_DAO::executeQuery('DROP TEMPORARY TABLE IF EXISTS dedupe');
     $event->dedupeResults['ids'] = array_diff($dupes, $event->dedupeParams['excluded_contact_ids']);
   }
 


### PR DESCRIPTION


Overview
----------------------------------------
Separate back dedupe table drop query

This function might actually be doing nothing as
I'm not convinced it is the right table name - regardless it will be subject to clean up & refactor in the places where we are keeping the code and be 'archived' in places where we are keeping the original code for backward compatibility with hooks

Before
----------------------------------------
Function called from multiple paths that are being separated. It maybe could be removed but it is easier to assess the code paths (that we are keeping) separately as they are a somewhat disparate

After
----------------------------------------
line copied back

Technical Details
----------------------------------------

Comments
----------------------------------------
