### PR TITLE
[REF] Dedupe code - copy the existing finder class back to the legacy code

### DIFF
--- a/ext/legacydedupefinder/Civi/LegacyFinder/Finder.php
+++ b/ext/legacydedupefinder/Civi/LegacyFinder/Finder.php
@@ -137,7 +137,7 @@ class Finder extends AutoSubscriber {
     $ruleGroup->id = $id;
     // make sure we've got a fetched dbrecord, not sure if this is enforced
     $ruleGroup->find(TRUE);
-    $optimizer = new \CRM_Dedupe_FinderQueryOptimizer($id, $contactIDs, $params);
+    $optimizer = new FinderQueryBuilder($id, $contactIDs, $params);
     // Reserved Rule Groups can optionally get special treatment by
     // implementing an optimization class and returning a query array.
     if ($legacyMode && $optimizer->isUseReservedQuery()) {


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Dedupe code - copy the existing finder class back to the legacy code

Before
----------------------------------------
The 'to-keep' Finder class has support for legacy dedupe finder & the to-keep core code. This is inhibiting performance improvements & general clean up

After
----------------------------------------
the legacy code has it's own copy - which will not change going forwards

Technical Details
----------------------------------------

Comments
----------------------------------------
