### PR TITLE
Afform - Fix prefilling location blocks with different fields

### DIFF
--- a/ext/afform/core/Civi/Afform/FormDataModel.php
+++ b/ext/afform/core/Civi/Afform/FormDataModel.php
@@ -189,7 +189,7 @@ class FormDataModel {
             }
           }
         }
-        $this->entities[$entity]['joins'][$node['af-join']] = $joinProps;
+        $this->entities[$entity]['joins'][$node['af-join']] = $joinProps + $existingJoin;
         $this->parseFields($node['#children'] ?? [], $entity, $node['af-join'], NULL, $afIfConditions);
       }
       elseif (!empty($node['#children'])) {

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -636,7 +636,15 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
             }
 
             // Merge in pre-set data
-            $joinValues[$index] = array_merge($joinValues[$index], $entity['joins'][$joinEntity]['data'] ?? []);
+            foreach ($entity['joins'][$joinEntity]['data'] ?? [] as $dataKey => $dataVal) {
+              // For multiple location blocks, values will be in an array (see FormDataModel::parseFields)
+              if (is_array($dataVal) && array_key_exists($index, $dataVal)) {
+                $joinValues[$index][$dataKey] = $dataVal[$index];
+              }
+              else {
+                $joinValues[$index][$dataKey] = $dataVal;
+              }
+            }
           }
         }
         $entityValues[$entityName][] = $values;

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -252,7 +252,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
       $items = array_column($joinResult, NULL, 'location_type_id');
       $joinResult = [];
       foreach ($join['data']['location_type_id'] as $locationType) {
-        $joinResult[] = $items[$locationType] ?? [];
+        $joinResult[] = $items[$locationType] ?? NULL;
       }
     }
     $this->_entityIds[$afEntity['name']][$index]['joins'][$joinEntity] = \CRM_Utils_Array::filterColumns($joinResult, [$joinIdField]);

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformContactUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformContactUsageTest.php
@@ -772,7 +772,7 @@ EOHTML;
 
     $this->assertCount(1, $prefill['Individual1']['values']);
     $this->assertEquals('One', $prefill['Individual1']['values'][0]['fields']['first_name']);
-    $this->assertEmpty($prefill['Individual1']['values'][0]['joins']['Phone'][0]);
+    $this->assertNull($prefill['Individual1']['values'][0]['joins']['Phone'][0]);
     $this->assertEquals('2-2', $prefill['Individual1']['values'][0]['joins']['Phone'][1]['phone']);
 
     // Create one new phone, update the other


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5737](https://lab.civicrm.org/dev/core/-/issues/5737) and [dev/core#5738](https://lab.civicrm.org/dev/core/-/issues/5738)

Before
-------
Submitting an afform with multiple location blocks would mess up the location type.

After
------
Fixed.


Technical Details
----------------------------------------
Due to the way joins were originally designed, the multiple blocks aren't treated separately. So any fields in one are accepted for all. This fixes it so the last block's list of fields don't override the others, and fixes the location types all getting jumbled together.

