### PR TITLE
(unreleased regression) Fix Participant import to use apiv4 fields for the contact part to pick up email again

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -33,7 +33,8 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
    * Should contact fields be filtered which determining fields to show.
    *
    * This applies to Contribution import as we put all contact fields in the metadata
-   * but only present those used for a match - but will permit create via LeXIM.
+   * but only present those used for a match in QuickForm - the civiimport extension has
+   * more functionality to update and create.
    *
    * @return bool
    */
@@ -136,12 +137,7 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
     try {
       $parser = $self->getParser();
       $rule = $parser->getDedupeRule($self->getContactType(), $self->getUserJob()['metadata']['entity_configuration']['Contact']['dedupe_rule'] ?? NULL);
-      if (!$self->isUpdateExisting()) {
-        $missingDedupeFields = $self->validateDedupeFieldsSufficientInMapping($rule, $fields['mapper'], ['external_identifier', 'contribution_contact_id', 'contact__id']);
-        if ($missingDedupeFields) {
-          $mapperError[] = $missingDedupeFields;
-        }
-      }
+      $mapperError = $self->validateContactFields($rule, $fields['mapper'], ['external_identifier', 'contribution_contact_id', 'contact__id']);
       $parser->validateMapping($fields['mapper']);
     }
     catch (CRM_Core_Exception $e) {

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -918,6 +918,8 @@ class CRM_Core_Error extends PEAR_ErrorStack {
   }
 
   /**
+   * @deprecated since 6.1 will be removed around 6.13
+   *
    * @param $message
    * @param int $code
    * @param string $level
@@ -926,6 +928,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * @return object
    */
   public static function createError($message, $code = 8000, $level = 'Fatal', $params = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning('something that is less silly');
     $error = CRM_Core_Error::singleton();
     $error->push($code, $level, [$params], $message);
     return $error;

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -30,6 +30,8 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
    */
   protected $isUpdatedForEntityRowParsing = TRUE;
 
+  protected string $baseEntity = 'Participant';
+
   /**
    * Get information about the provided job.
    *
@@ -80,7 +82,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
         $participantParams['contact_id'] = !empty($participantParams['contact_id']) ? (int) $participantParams['contact_id'] : $existingParticipant['contact_id'];
       }
 
-      $participantParams['contact_id'] = $this->getContactID($contactParams, $participantParams['contact_id'] ?? NULL, 'Contact', $this->getDedupeRulesForEntity('Contact'));
+      $participantParams['contact_id'] = $this->getContactID($contactParams, $participantParams['contact_id'] ?? $contactParams['id'] ?? NULL, 'Contact', $this->getDedupeRulesForEntity('Contact'));
       // don't add to recent items, CRM-4399
       $participantParams['skipRecentView'] = TRUE;
 
@@ -138,12 +140,14 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
           ],
         ],
         $this->getImportFieldsForEntity('Participant'),
-        CRM_Core_BAO_CustomField::getFieldsForImport('Participant'),
-        $this->getContactMatchingFields()
+        CRM_Core_BAO_CustomField::getFieldsForImport('Participant')
       );
-
+      $contactFields = $this->getContactFields($this->getContactType());
+      $fields['contact_id'] = $contactFields['id'];
+      unset($contactFields['id']);
       $fields['contact_id']['title'] .= ' (match to contact)';
       $fields['contact_id']['html']['label'] = $fields['contact_id']['title'];
+      $fields += $contactFields;
       $this->importableFieldsMetadata = $fields;
     }
   }

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -600,4 +600,22 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     return NULL;
   }
 
+  /**
+   * @param array $rule
+   * @param array $mapper
+   * @param array $contactIdentifierFields
+   *
+   * @return array
+   */
+  protected function validateContactFields(array $rule, array $mapper, array $contactIdentifierFields): array {
+    $mapperError = [];
+    if (!$this->isUpdateExisting()) {
+      $missingDedupeFields = $this->validateDedupeFieldsSufficientInMapping($rule, $mapper, $contactIdentifierFields);
+      if ($missingDedupeFields) {
+        $mapperError[] = $missingDedupeFields;
+      }
+    }
+    return $mapperError;
+  }
+
 }

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -558,4 +558,46 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     return $defaults;
   }
 
+  /**
+   * Validate the the mapped fields contain enough to meet the dedupe rule lookup requirements.
+   *
+   * @internal this function may change without notice.
+   *
+   * @param array $rule
+   * @param array $mapper Mapper array as submitted
+   * @param array $contactIdentifierFields Array of fields which in themselves uniquely identify a contact.
+   *   This array will likely have an import specific prefix.
+   *
+   * @return string|null
+   *   Error string if insufficient.
+   */
+  protected function validateDedupeFieldsSufficientInMapping(array $rule, array $mapper, array $contactIdentifierFields): ?string {
+    $threshold = $rule['threshold'];
+    $ruleFields = $rule['fields'];
+    $weightSum = 0;
+    foreach ($mapper as $mapping) {
+      // Because api v4 style fields have a . and QuickForm multiselect js does
+      // not cope with a . the quick form layer will use a double underscore
+      // as a stand in (the angular layer will not)
+      $fieldName = str_replace('__', '.', $mapping[0]);
+      if (str_contains($fieldName, '.')) {
+        // If the field name contains a . - eg. address_primary.street_address
+        // we just want the part after the .
+        $fieldName = substr($fieldName, strpos($fieldName, '.') + 1);
+      }
+      if (in_array($fieldName, $contactIdentifierFields)) {
+        // It is enough to have external identifier or contact ID mapped..
+        $weightSum = $threshold;
+        break;
+      }
+      if (array_key_exists($fieldName, $ruleFields)) {
+        $weightSum += $ruleFields[$fieldName];
+      }
+    }
+    if ($weightSum < $threshold) {
+      return $rule['rule_message'];
+    }
+    return NULL;
+  }
+
 }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -2365,7 +2365,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
           $fields[$customField['custom_group_id.name'] . '.' . $customField['name']] = $ruleField['rule_weight'];
         }
       }
-      $this->dedupeRules[$name]['rule_message'] = ts('Missing required contact matching fields.') . " $fieldMessage " . ts('(Sum of all weights should be greater than or equal to threshold: %1).', [1 => $this->dedupeRules[$name]['threshold']]) . '<br />';
+      $this->dedupeRules[$name]['rule_message'] = ts('Missing required contact matching fields.') . " $fieldMessage " . ts('(Sum of all weights should be greater than or equal to threshold: %1).', [1 => $this->dedupeRules[$name]['threshold']]) . '<br />' . ts('Or Provide Contact ID or External ID.');
 
       $this->dedupeRules[$name]['fields'] = $fields;
     }

--- a/CRM/Upgrade/Incremental/php/SixOne.php
+++ b/CRM/Upgrade/Incremental/php/SixOne.php
@@ -29,7 +29,7 @@ class CRM_Upgrade_Incremental_php_SixOne extends CRM_Upgrade_Incremental_Base {
    */
   public function upgrade_6_1_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
-
+    $this->addTask('Update import mappings', 'updateFieldMappingsForImport');
     $this->addTask('Replace Clear Caches & Reset Paths with Clear Caches in Nav Menu', 'updateUpdateConfigBackendNavItem');
   }
 
@@ -83,6 +83,73 @@ class CRM_Upgrade_Incremental_php_SixOne extends CRM_Upgrade_Incremental_Base {
     ");
 
     return TRUE;
+  }
+
+  /**
+   * Update the fields that have been converted to apiv4 within the field mappings
+   * - participant_import : email => email_primary.email (there are no other pre-existing contact fields)
+   * @return bool
+   */
+  public static function updateFieldMappingsForImport(): bool {
+    $mappingFields = self::getMappingFieldsForImportType('Import Participant');
+    // The only possible contact field for participant import is email
+    // as only the email rule can be selected. However, keeping the 'set'
+    // together (from Contribution convert in FiveFiftyFour) feels like
+    // it has merit
+    $fieldsToConvert = [
+      'email' => 'email_primary.email',
+      'phone' => 'phone_primary.phone',
+      'street_address' => 'address_primary.street_address',
+      'supplemental_address_1' => 'address_primary.supplemental_address_1',
+      'supplemental_address_2' => 'address_primary.supplemental_address_2',
+      'supplemental_address_3' => 'address_primary.supplemental_address_3',
+      'city' => 'address_primary.city',
+      'county_id' => 'address_primary.county_id',
+      'state_province_id' => 'address_primary.state_province_id',
+      'country_id' => 'address_primary.country_id',
+    ];
+    $customFields = CRM_Core_DAO::executeQuery('
+      SELECT custom_field.id, custom_field.name, custom_group.name as custom_group_name
+      FROM civicrm_custom_field custom_field INNER JOIN civicrm_custom_group custom_group
+      ON custom_field.custom_group_id = custom_group.id
+      WHERE extends IN ("Contact", "Individual", "Organization", "Household")
+    ');
+    while ($customFields->fetch()) {
+      $fieldsToConvert['custom_' . $customFields->id] = $customFields->custom_group_name . '.' . $customFields->name;
+    }
+    while ($mappingFields->fetch()) {
+      // Convert the field.
+      if (isset($fieldsToConvert[$mappingFields->name])) {
+        CRM_Core_DAO::executeQuery(' UPDATE civicrm_mapping_field SET name = %1 WHERE id = %2', [
+          1 => [$fieldsToConvert[$mappingFields->name], 'String'],
+          2 => [$mappingFields->id, 'Integer'],
+        ]);
+      }
+    }
+    return TRUE;
+  }
+
+  /**
+   * @return \CRM_Core_DAO
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\Core\Exception\DBQueryException
+   */
+  public static function getMappingFieldsForImportType(string $importType): CRM_Core_DAO {
+    $mappingTypeID = (int) CRM_Core_DAO::singleValueQuery("
+      SELECT option_value.value
+      FROM civicrm_option_value option_value
+        INNER JOIN civicrm_option_group option_group
+        ON option_group.id = option_value.option_group_id
+        AND option_group.name =  'mapping_type'
+      WHERE option_value.name = '{$importType}'");
+
+    $mappingFields = CRM_Core_DAO::executeQuery('
+      SELECT field.id, field.name FROM civicrm_mapping_field field
+        INNER JOIN civicrm_mapping mapping
+          ON field.mapping_id = mapping.id
+          AND mapping_type_id = ' . $mappingTypeID
+    );
+    return $mappingFields;
   }
 
 }

--- a/tests/phpunit/CRM/Event/Import/Parser/data/participant_with_ext_id.csv
+++ b/tests/phpunit/CRM/Event/Import/Parser/data/participant_with_ext_id.csv
@@ -1,2 +1,3 @@
 Event Title,Campaign ID,External Identifier,Fee Amount,Fee Currency,Fee level,Is Pay Later,Participant Role,Participant Source,Participant Status,Register date,Do not import,Color
 Rain-forest Cup Youth Soccer Tournament,Soccer Cup,ref-77,5000.55,USD,High,No,"Attendee, Volunteer",Phoned up,Registered,2022-12-07,,"Purple, Mauve"
+Second event,Soccer Cup,ref-77,5000.55,USD,High,No,"Attendee, Volunteer",Phoned up,Registered,2022-12-07,,"Purple, Mauve"

--- a/tests/phpunit/CRM/Event/Import/Parser/data/participant_with_multiple_identifiers.csv
+++ b/tests/phpunit/CRM/Event/Import/Parser/data/participant_with_multiple_identifiers.csv
@@ -1,0 +1,2 @@
+Event ID, Participant ID, Contact ID, External Identifier, Email,Status
+1,1,3,abc, jenny@example.com,Registered


### PR DESCRIPTION
Overview
----------------------------------------
(unreleased regression) Fix Participant import to use apiv4 fields for the contact part to pick up email again

Before
----------------------------------------
A recent refactor (master branch) to participant ID was working towards moving the import from apiv3 to apiv4 - but it got ahead of it's skis a bit - fixing the field `email` to expect to be `email_primary.email` in some places but not others, resulting in passing in email to match the contact ID not finding the contact

After
----------------------------------------
Fixed, all Contact interaction moved over to apiv4

Technical Details
----------------------------------------
Builds on https://github.com/civicrm/civicrm-core/pull/32029 (which can be rebased out once merged)

Next step is to move the participant fields over to apiv4

Comments
----------------------------------------
