### PR TITLE
Remove deprecated code path from 2020

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1786,11 +1786,6 @@ LIKE %1
       $dao = new $daoName();
     }
 
-    if ($trapException) {
-      CRM_Core_Error::deprecatedFunctionWarning('calling functions should handle exceptions');
-      $errorScope = CRM_Core_TemporaryErrorScope::ignoreException();
-    }
-
     if ($dao->isValidOption($options)) {
       $dao->setOptions($options);
     }

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1802,11 +1802,6 @@ LIKE %1
       $dao->N = TRUE;
     }
 
-    if (is_a($result, 'DB_Error')) {
-      CRM_Core_Error::deprecatedFunctionWarning('calling functions should handle exceptions');
-      return $result;
-    }
-
     return $dao;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove deprecated code path from 2020

Before
----------------------------------------
Code has been noisily deprecated for a long time

![image](https://github.com/user-attachments/assets/17bcb73e-8b44-4f3b-b579-b82cc1019aca)

![image](https://github.com/user-attachments/assets/5d0d85a2-376f-42e4-b746-9155763a4633)



After
----------------------------------------
poof

Technical Details
----------------------------------------
The deprecation feels fairly precautionary as it was never used much / maybe not at all outside of core as we switched to exceptions being preferred in the early 4.x series

Comments
----------------------------------------
