### PR TITLE
Upgrading typo3/phar-stream-wrapper (v3.1.8 => v4.0.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
     "league/oauth2-google": "^3.0 || ^4.0",
     "tplaner/when": "~3.1",
     "xkerman/restricted-unserialize": "~1.1",
-    "typo3/phar-stream-wrapper": "^2 || ^3.0",
+    "typo3/phar-stream-wrapper": "^3.0 || ^4.0",
     "brick/money": "~0.5",
     "ext-intl": "*",
     "pear/mail_mime": "~1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "151d2a4d086f0f866c76c48887865113",
+    "content-hash": "d185e1de1fd9cd385698cd24e6d03ca1",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -5756,26 +5756,25 @@
         },
         {
             "name": "typo3/phar-stream-wrapper",
-            "version": "v3.1.8",
+            "version": "v4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3/phar-stream-wrapper.git",
-                "reference": "a931b28f422a60052db85c0a84a05a366453b2c0"
+                "reference": "ce4b6e9873d4dd7dce2a397511713bf14977fdf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3/phar-stream-wrapper/zipball/a931b28f422a60052db85c0a84a05a366453b2c0",
-                "reference": "a931b28f422a60052db85c0a84a05a366453b2c0",
+                "url": "https://api.github.com/repos/TYPO3/phar-stream-wrapper/zipball/ce4b6e9873d4dd7dce2a397511713bf14977fdf2",
+                "reference": "ce4b6e9873d4dd7dce2a397511713bf14977fdf2",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "php": "^7.0 || ~8.0 || ~8.1 || ~8.2 || ~8.3"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
                 "ext-xdebug": "*",
-                "phpspec/prophecy": "^1.10",
-                "symfony/phpunit-bridge": "^5.1"
+                "phpunit/phpunit": "^7 || ^8 || ^9"
             },
             "suggest": {
                 "ext-fileinfo": "For PHP builtin file type guessing, otherwise uses internal processing"
@@ -5783,7 +5782,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "v3.x-dev"
+                    "dev-master": "4.x-dev"
                 }
             },
             "autoload": {
@@ -5805,9 +5804,9 @@
             ],
             "support": {
                 "issues": "https://github.com/TYPO3/phar-stream-wrapper/issues",
-                "source": "https://github.com/TYPO3/phar-stream-wrapper/tree/v3.1.8"
+                "source": "https://github.com/TYPO3/phar-stream-wrapper/tree/v4.0.0"
             },
-            "time": "2024-12-09T23:06:33+00:00"
+            "time": "2024-12-10T00:00:25+00:00"
         },
         {
             "name": "xkerman/restricted-unserialize",
@@ -6018,7 +6017,7 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -6030,9 +6029,9 @@
         "ext-mysqli": "*",
         "ext-fileinfo": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.0.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
Overview
----------------------------------------
Update phar-stream-wrapper to drop php 5.x & add php 8.x

![image](https://github.com/user-attachments/assets/f0d8606c-8dff-4245-bc35-41e8ba47d10e)


Before
----------------------------------------
3.18

After
----------------------------------------
4.0.0

Technical Details
----------------------------------------
https://github.com/TYPO3/phar-stream-wrapper/releases/tag/v4.0.0

Comments
----------------------------------------
