### PR TITLE
Fix failure to permit actions on deleted contributions (move) - use apiv4

### DIFF
--- a/CRM/Core/Controller/Task.php
+++ b/CRM/Core/Controller/Task.php
@@ -29,12 +29,11 @@ abstract class CRM_Core_Controller_Task extends CRM_Core_Controller {
     $id = explode(',', CRM_Utils_Request::retrieve('id', 'CommaSeparatedIntegers', $this, TRUE));
 
     // Check permissions
-    $perm = civicrm_api3($this->getEntity(), 'get', [
-      'return' => 'id',
-      'options' => ['limit' => 0],
-      'check_permissions' => 1,
-      'id' => ['IN' => $id],
-    ])['values'];
+    $perm = (array) civicrm_api4($this->getEntity(), 'get', [
+      'select' => ['id'],
+      'checkPermissions' => TRUE,
+      'where' => [['id', 'IN', $id]],
+    ])->indexBy('id');
     if (empty($perm)) {
       throw new CRM_Core_Exception(ts('No records available'));
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fix failure to permit actions on deleted contributions (move)

Before
----------------------------------------
With the [movecontrib extension](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://github.com/lcdservices/biz.lcdservices.movecontrib&ved=2ahUKEwjMto2Pqc6LAxVR8qACHeLRKzcQFnoECA0QAQ&usg=AOvVaw1tnF_41oHGlLevPg8i6M9v) by @lcdservices enabled
1) add a contribution to a contact
2) delete the contact
3) attempt to move the contribution to another contact  - error

![image](https://github.com/user-attachments/assets/d86b626e-434d-4994-8dc8-f756815f9c49)


After
----------------------------------------
The actions works

Technical Details
----------------------------------------
The v3 api for Contribution is a bit of an anomaly in that it uses the `BAO_Query` object which 
1) has some dubious stuff around soft credits with performance impacts and
2) includes whether the contact is_deleted by default in the criteria - resulting in none being found & a hard error.

Whether tasks are appropriate to deleted contacts varies (in this case it is) but filter-by-unintentional-error doesn't feel like the way to determine that & seems accidental

The contact actions (the only other one to use query object) don't appear to go through this code

Comments
----------------------------------------
