### PR TITLE
dev/core#5741 SearchKit - Fix relationship updates with inline-edit

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/InlineEdit.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/InlineEdit.php
@@ -61,8 +61,13 @@ class InlineEdit extends Run {
   public function updateExistingRow(): void {
     // Apply rowKey to filters
     $entityName = $this->savedSearch['api_entity'];
-    $keyName = CoreUtil::getIdFieldName($entityName);
-    $this->applyFilter($keyName, $this->rowKey);
+    $keyName = $filterKey = CoreUtil::getIdFieldName($entityName);
+    // Hack to support relationships
+    if ($entityName === 'RelationshipCache') {
+      $filterKey = 'relationship_id';
+      $entityName = 'Relationship';
+    }
+    $this->applyFilter($filterKey, $this->rowKey);
     $this->return = NULL;
     $this->_apiParams['offset'] = 0;
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5741](https://lab.civicrm.org/dev/core/-/issues/5741)


Before
-----
Cannot enable/disable relationships on contact summary

After
----
Fixed


Technical Details
----------------------------------------

Another entry in the long, not-so-proud tradition of the "hack to support relationships".