### PR TITLE
(dev/core#5734) Caching - Tweaks to FileCache, Memcached

### DIFF
--- a/CRM/Utils/Cache/FileCache.php
+++ b/CRM/Utils/Cache/FileCache.php
@@ -97,10 +97,10 @@ class CRM_Utils_Cache_FileCache implements CRM_Utils_Cache_Interface {
     }
 
     $expires = CRM_Utils_Date::convertCacheTtlToExpires($ttl, self::DEFAULT_TIMEOUT);
-    $serialized = CRM_Core_BAO_Cache::encode([
+    $serialized = serialize([
       'created' => time(),
       'expires' => $expires,
-      'value' => $this->reobjectify($value),
+      'value' => $value,
     ]);
 
     $key_path = $this->keyPath($key);
@@ -130,7 +130,7 @@ class CRM_Utils_Cache_FileCache implements CRM_Utils_Cache_Interface {
       if (!$cache) {
         return $default;
       }
-      $item = CRM_Core_BAO_Cache::decode($cache);
+      $item = unserialize($cache);
       if ($item !== FALSE) {
         $this->expiresCache[$key_path] = $item['expires'];
         $this->valueCache[$key_path] = $item['value'];

--- a/CRM/Utils/Cache/FileCache.php
+++ b/CRM/Utils/Cache/FileCache.php
@@ -101,6 +101,7 @@ class CRM_Utils_Cache_FileCache implements CRM_Utils_Cache_Interface {
       'created' => time(),
       'expires' => $expires,
       'value' => $value,
+      'key' => $key,
     ]);
 
     $key_path = $this->keyPath($key);

--- a/CRM/Utils/Cache/FileCache.php
+++ b/CRM/Utils/Cache/FileCache.php
@@ -103,7 +103,7 @@ class CRM_Utils_Cache_FileCache implements CRM_Utils_Cache_Interface {
       'value' => $this->reobjectify($value),
     ]);
 
-    $key_path = $this->KeyPath($key);
+    $key_path = $this->keyPath($key);
     if (!file_put_contents($this->getCacheFile($key_path), $serialized, LOCK_EX)) {
       return FALSE;
     }
@@ -120,7 +120,7 @@ class CRM_Utils_Cache_FileCache implements CRM_Utils_Cache_Interface {
   public function get($key, $default = NULL) {
     CRM_Utils_Cache::assertValidKey($key);
 
-    $key_path = $this->KeyPath($key);
+    $key_path = $this->keyPath($key);
     if (!isset($this->expiresCache[$key_path]) || time() >= $this->expiresCache[$key_path]) {
       $path = $this->getCacheFile($key_path);
       if (!file_exists($path)) {
@@ -171,7 +171,7 @@ class CRM_Utils_Cache_FileCache implements CRM_Utils_Cache_Interface {
    */
   public function delete($key) {
     CRM_Utils_Cache::assertValidKey($key);
-    $key_path = $this->KeyPath($key);
+    $key_path = $this->keyPath($key);
     $path = $this->getCacheFile($key_path);
     $success = TRUE;
 
@@ -258,7 +258,7 @@ class CRM_Utils_Cache_FileCache implements CRM_Utils_Cache_Interface {
    */
   public function has($key) {
     CRM_Utils_Cache::assertValidKey($key);
-    $key_path = $this->KeyPath($key);
+    $key_path = $this->keyPath($key);
     $this->get($key);
     return isset($this->expiresCache[$key_path]) && time() < $this->expiresCache[$key_path];
   }
@@ -282,7 +282,7 @@ class CRM_Utils_Cache_FileCache implements CRM_Utils_Cache_Interface {
    * @return string
    *   The prefix used as a directory plus the cleaned key.
    */
-  protected function KeyPath($key) {
+  protected function keyPath($key) {
     return $this->_prefix . $this->cleanKey($key);
   }
 

--- a/CRM/Utils/Cache/Memcached.php
+++ b/CRM/Utils/Cache/Memcached.php
@@ -23,6 +23,10 @@ class CRM_Utils_Cache_Memcached implements CRM_Utils_Cache_Interface {
   const DEFAULT_PORT = 11211;
   const DEFAULT_TIMEOUT = 3600;
   const DEFAULT_PREFIX = '';
+
+  /**
+   * This is an aggregate limit, including all prefixes and key items.
+   */
   const MAX_KEY_LEN = 200;
 
   /**
@@ -212,10 +216,10 @@ class CRM_Utils_Cache_Memcached implements CRM_Utils_Cache_Interface {
     $maxLen = self::MAX_KEY_LEN - strlen($truePrefix);
     $key = preg_replace('/\s+|\W+/', '_', $key);
     if (strlen($key) > $maxLen) {
-      // this should be 32 characters in length
-      $md5Key = md5($key);
-      $subKeyLen = $maxLen - 1 - strlen($md5Key);
-      $key = substr($key, 0, $subKeyLen) . "_" . $md5Key;
+      // In memcache, the total path length is limited, and keys are case-sensitive. Base64 seems good.
+      $digest = base64_encode(hash('sha256', $key, TRUE));
+      $subKeyLen = $maxLen - 1 - strlen($digest);
+      $key = substr($key, 0, $subKeyLen) . "_" . $digest;
     }
     return $truePrefix . $key;
   }


### PR DESCRIPTION
Overview
----------------------------------------

This includes a few tweaks to the FileCache and Memcached drivers, based on discussion in #32069.  (Ping @Sjord @herbdool)

Technical Details
----------------------------------------

Each commit is a distinct change and could be on its own. (My guess is they're easier to read as a set, but we could split if others want.) There are more comments in the commit-notes.

In summary, main changes are:

1. _FileCache_: We can store with `serialize()` and we don't need `base64_encode()`. This  SQL-based cache (*where the base64 originated*) has some peculiar history. (*It [`CRM_Core_BAO_Cache`] worked badly if you serialized any binary data.*) But `file_get_contents()` (etc) should work fine with binary data.

2. _FileCache and Memcached_: Strengthen protections against collisions
