### PR TITLE
CiviReport - Fix saving report with is_reserved = false

### DIFF
--- a/CRM/Report/Form/Instance.php
+++ b/CRM/Report/Form/Instance.php
@@ -97,7 +97,7 @@ class CRM_Report_Form_Instance {
     $form->add('number', 'cache_minutes', ts('Cache dashlet for'), ['class' => 'four', 'min' => 1]);
     $form->addElement('checkbox', 'add_to_my_reports', ts('Add to My Reports?'), NULL);
 
-    $form->addElement('checkbox', 'is_reserved', ts('Reserved Report?'));
+    $form->addElement('advcheckbox', 'is_reserved', ts('Reserved Report?'));
     if (!CRM_Core_Permission::check('administer reserved reports')) {
       $form->freeze('is_reserved');
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug when saving a report as _not_ reserved.

Alternate fix to https://github.com/civicrm/civicrm-core/pull/32138

Replication
----------------------------------------
1. Go to Constituent Summary report,
2. Check "Reserved Report?" 
3. Save
4. Uncheck "Reserved Report?"
5. Save

Before
----------------------------------------
From checked to unchecked, does not save.

After
----------------------------------------
Save from checked to unchecked status.

Technical Details
----------------------------------------
This is the same old quickform gotcha: checkboxes don't have any value when unchecked