### PR TITLE
[REF] Misc - Use str_starts_with instead of strpos

### DIFF
--- a/CRM/Core/Smarty/plugins/block.crmButton.php
+++ b/CRM/Core/Smarty/plugins/block.crmButton.php
@@ -47,7 +47,7 @@ function smarty_block_crmButton($params, $text, &$smarty, &$repeat) {
       $icon = $params['icon'] ?? 'fa-pencil';
       // Assume for now that all icons are Font Awesome v4.x but handle if it's
       // specified
-      if (strpos($icon, 'fa-') !== 0) {
+      if (!str_starts_with($icon, 'fa-')) {
         $icon = "fa-$icon";
       }
       $iconMarkup = "<i class='crm-i $icon' aria-hidden=\"true\"></i> ";

--- a/CRM/Member/ActionMapping.php
+++ b/CRM/Member/ActionMapping.php
@@ -91,7 +91,7 @@ class CRM_Member_ActionMapping extends \Civi\ActionSchedule\MappingBase {
 
     // Options currently are just 'join_date', 'start_date', and 'end_date':
     // they need an alias
-    if (strpos($query['casDateField'], 'e.') !== 0) {
+    if (!str_starts_with($query['casDateField'], 'e.')) {
       $query['casDateField'] = 'e.' . $query['casDateField'];
     }
 

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -564,7 +564,7 @@ class Api4SelectQuery extends Api4Query {
         if ($field['entity'] !== $joinEntity && $field['fk_entity'] === $joinEntity) {
           $conditions[] = $this->treeWalkClauses([$name, '=', "$alias.id"], 'ON');
         }
-        elseif (strpos($name, "$alias.") === 0 && substr_count($name, '.') === 1 && $field['fk_entity'] === $this->getEntity()) {
+        elseif (str_starts_with($name, "$alias.") && substr_count($name, '.') === 1 && $field['fk_entity'] === $this->getEntity()) {
           $conditions[] = $this->treeWalkClauses([$name, '=', 'id'], 'ON');
           $aclStack = ['id'];
         }

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -414,7 +414,7 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends AbstractMappingTestCase {
     ]);
     $comparison = [];
     foreach ($tokenProcessor->listTokens() as $token => $label) {
-      if (strpos($token, '{domain.') === 0) {
+      if (str_starts_with($token, '{domain.')) {
         // domain token - ignore.
         continue;
       }


### PR DESCRIPTION
Overview
----------------------------------------
General refactor - updates code to use preferred newer PHP function.

Technical Details
----------------------------------------
Before/after functionality is the same, but `str_starts_with` is preferred for readability.