### PR TITLE
[REF] Tests - Use str_contains instead of strpos

### DIFF
--- a/tests/phpunit/CRM/Activity/Form/ActivityViewTest.php
+++ b/tests/phpunit/CRM/Activity/Form/ActivityViewTest.php
@@ -146,7 +146,7 @@ class CRM_Activity_Form_ActivityViewTest extends CiviUnitTestCase {
       'details' => $input['details'],
       'activity_type_id' => $input['activity_type'],
       'source_record_id' => ($input['activity_type'] === 'Bulk Email' ? $this->mailing_id : NULL),
-      'case_id' => (strpos($input['url'], 'caseid') === FALSE ? NULL : $this->case_id),
+      'case_id' => (!str_contains($input['url'], 'caseid') ? NULL : $this->case_id),
     ]);
 
     // We have to replace these at runtime because dataproviders are

--- a/tests/phpunit/CRM/Contact/Form/Search/SearchContactTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Search/SearchContactTest.php
@@ -57,7 +57,7 @@ class CRM_Contact_Form_Search_SearchContactTest extends CiviUnitTestCase {
     $contacts = $this->callAPISuccess('Contact', 'create', $params);
     $contactTypes = CRM_Contact_BAO_ContactType::getSelectElements(TRUE);
     foreach ($contactTypes as $contactType => $ignore) {
-      if (strpos($contactType, $contactSubType) !== FALSE) {
+      if (str_contains($contactType, $contactSubType)) {
         $formValues = [
           'contact_type' => $contactType,
         ];

--- a/tests/phpunit/CRM/Contact/SelectorTest.php
+++ b/tests/phpunit/CRM/Contact/SelectorTest.php
@@ -178,7 +178,7 @@ class CRM_Contact_SelectorTest extends CiviUnitTestCase {
 
     //Check if email column contains (On Hold) string.
     foreach ($rows[$contactID] as $key => $value) {
-      if (strpos($key, 'email') !== FALSE) {
+      if (str_contains($key, 'email')) {
         $this->assertStringContainsString('(On Hold)', (string) $value);
       }
     }

--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -198,7 +198,7 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     );
     $actual = CRM_Core_Region::instance('html-header')->render('');
     $expected = '})(' . json_encode(['fruit' => ['yours' => 'orange', 'mine' => 'apple']]) . ')';
-    $this->assertTrue(strpos($actual, $expected) !== FALSE);
+    $this->assertTrue(str_contains($actual, $expected));
   }
 
   public function testAddSettingToBillingBlock(): void {
@@ -211,7 +211,7 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     );
     $actual = CRM_Core_Region::instance('billing-block')->render('');
     $expected = '})(' . json_encode(['cheese' => ['edam' => 'red', 'cheddar' => 'yellow']]) . ')';
-    $this->assertTrue(strpos($actual, $expected) !== FALSE);
+    $this->assertTrue(str_contains($actual, $expected));
   }
 
   public function testAddSettingHook(): void {

--- a/tests/phpunit/CRM/Utils/Mail/EmailProcessorInboundTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/EmailProcessorInboundTest.php
@@ -146,7 +146,7 @@ class CRM_Utils_Mail_EmailProcessorInboundTest extends CiviUnitTestCase {
       return;
     }
     // change the activity type depending on subject
-    if (strpos($mail->subject, 'for hooks') !== FALSE) {
+    if (str_contains($mail->subject, 'for hooks')) {
       $this->callAPISuccess('Activity', 'create', ['id' => $result['id'], 'activity_type_id' => 'Phone Call']);
     }
   }

--- a/tests/phpunit/CRM/Utils/NumberTest.php
+++ b/tests/phpunit/CRM/Utils/NumberTest.php
@@ -35,7 +35,7 @@ class CRM_Utils_NumberTest extends CiviUnitTestCase {
       $decimal = CRM_Utils_Number::createRandomDecimal($precision);
       // print "Assert $decimal between $expectedMinInclusive and $expectedMaxExclusive\n";
       $this->assertTrue(($expectedMinInclusive <= $decimal) && ($decimal < $expectedMaxExclusive), "Assert $decimal between $expectedMinInclusive and $expectedMaxExclusive");
-      if (strpos($decimal, '.') === FALSE) {
+      if (!str_contains($decimal, '.')) {
         $decimal .= '.';
       }
       list ($before, $after) = explode('.', $decimal);

--- a/tests/phpunit/CRM/Utils/versionCheckTest.php
+++ b/tests/phpunit/CRM/Utils/versionCheckTest.php
@@ -185,7 +185,7 @@ class CRM_Utils_versionCheckTest extends CiviUnitTestCase {
 
     // See CRM_Utils_VersionCheck::getSiteStats where alpha versions don't get
     // full stats generated
-    if (array_key_exists('version', $stats) && strpos($stats['version'], 'alpha') === FALSE) {
+    if (array_key_exists('version', $stats) && !str_contains($stats['version'], 'alpha')) {
       $this->assertArrayHasKey('hash', $stats);
       $this->assertArrayHasKey('uf', $stats);
       $this->assertArrayHasKey('lang', $stats);

--- a/tests/phpunit/CiviTest/CiviTestSuite.php
+++ b/tests/phpunit/CiviTest/CiviTestSuite.php
@@ -183,7 +183,7 @@ class CiviTestSuite extends PHPUnit\Framework\TestSuite {
         foreach (array_diff($newClassNames,
           $oldClassNames
                  ) as $name) {
-          if (strpos($fileInfo->getRealPath(), strtr($name, '_\\', '//') . ".php") !== FALSE) {
+          if (str_contains($fileInfo->getRealPath(), strtr($name, '_\\', '//') . ".php")) {
             if (preg_match('/Test$/', $name)) {
               $addTestSuites[] = $name;
             }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3183,11 +3183,11 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
         $_SESSION['_' . $form->controller->_name . '_container']['values']['Preview'] = $formValues;
         return $form;
 
-      case strpos($class, 'Search') !== FALSE:
+      case str_contains($class, 'Search'):
         $form->controller = new CRM_Contact_Controller_Search();
         break;
 
-      case strpos($class, '_Form_') !== FALSE:
+      case str_contains($class, '_Form_'):
         $form->controller = new CRM_Core_Controller_Simple($class, $form->getName());
         break;
 
@@ -3232,7 +3232,7 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
     /** @var CRM_Core_Form $form */
     $form = new $class();
     $pageName = $pageName ?: $form->getName();
-    if (strpos($class, 'Search') !== FALSE) {
+    if (str_contains($class, 'Search')) {
       $form->controller = new CRM_Contact_Controller_Search();
     }
     else {

--- a/tests/phpunit/CiviTest/bootstrap.php
+++ b/tests/phpunit/CiviTest/bootstrap.php
@@ -16,7 +16,7 @@ $GLOBALS['CIVICRM_FORCE_MODULES'][] = 'civitest';
 
 function civitest_civicrm_scanClasses(array &$classes): void {
   $phpunit = \Civi::paths()->getPath('[civicrm.root]/tests/phpunit');
-  if (strpos(get_include_path(), $phpunit) !== FALSE) {
+  if (str_contains(get_include_path(), $phpunit)) {
     \Civi\Core\ClassScanner::scanFolders($classes, $phpunit, 'CRM/*/WorkflowMessage', '_', '/Test$/');
     \Civi\Core\ClassScanner::scanFolders($classes, $phpunit, 'Civi/*/WorkflowMessage', '\\', '/Test$/');
     // Exclude all `*Test.php` files - if we load them, then phpunit gets confused.

--- a/tests/phpunit/EnvTests.php
+++ b/tests/phpunit/EnvTests.php
@@ -22,7 +22,7 @@ class EnvTests extends \PHPUnit\Framework\TestSuite {
     $suite = new EnvTests();
     $tests = getenv('PHPUNIT_TESTS');
     foreach (explode(' ', $tests) as $test) {
-      if (strpos($test, '::') !== FALSE) {
+      if (str_contains($test, '::')) {
         list ($class, $method) = explode('::', $test);
         $clazz = new \ReflectionClass($class);
         $suite->addTestMethod($clazz, $clazz->getMethod($method));

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -137,7 +137,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     ]);
     $found = FALSE;
     foreach ($result['metadata']['sql'] as $sql) {
-      if (strpos($sql, " =  'Organization' ") !== FALSE) {
+      if (str_contains($sql, " =  'Organization' ")) {
         $found = TRUE;
       }
     }

--- a/tests/phpunit/api/v4/Action/ContactApiKeyTest.php
+++ b/tests/phpunit/api/v4/Action/ContactApiKeyTest.php
@@ -33,7 +33,7 @@ class ContactApiKeyTest extends Api4TestBase implements TransactionalInterface {
     \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'add contacts', 'edit api keys', 'view all contacts', 'edit all contacts'];
     $key = \CRM_Utils_String::createRandom(16, \CRM_Utils_String::ALPHANUMERIC);
     $isSafe = function ($mixed) use ($key) {
-      return strpos(json_encode($mixed), $key) === FALSE;
+      return !str_contains(json_encode($mixed), $key);
     };
 
     $contact = Contact::create()
@@ -206,7 +206,7 @@ class ContactApiKeyTest extends Api4TestBase implements TransactionalInterface {
       if ($mixed instanceof Result) {
         $mixed = $mixed->getArrayCopy();
       }
-      return strpos(json_encode($mixed), $key) === FALSE;
+      return !str_contains(json_encode($mixed), $key);
     };
 
     $contact = Contact::create(FALSE)


### PR DESCRIPTION
Overview
----------------------------------------
General refactor - updates code to use preferred newer PHP function.

Technical Details
----------------------------------------
Before/after functionality is the same, but `str_contains` is preferred for readability.