### PR TITLE
Backport: move Standaloneusers password reset email to Managed record

### DIFF
--- a/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
@@ -1,6 +1,5 @@
 <?php
 use CRM_Standaloneusers_ExtensionUtil as E;
-use Civi\Api4\MessageTemplate;
 use Civi\Api4\Navigation;
 
 /**
@@ -52,44 +51,9 @@ class CRM_Standaloneusers_Upgrader extends CRM_Extension_Upgrader_Base {
       ['pass']
     )));
 
-    $this->createPasswordResetMessageTemplate();
-
     // `standaloneusers` is installed as part of the overall install process for `Standalone`.
     // A subsequent step will configure some default users (*depending on local options*).
     // See also: `StandaloneUsers.civi-setup.php`
-  }
-
-  protected function createPasswordResetMessageTemplate() {
-
-    $baseTpl = [
-      'workflow_name' => 'password_reset',
-      'msg_title' => 'Password reset',
-      'msg_subject' => '{ts}Password reset link for{/ts} {domain.name}',
-      'msg_text' => <<<TXT
-        {ts}A password reset link was requested for this account.  If this wasn\'t you (and nobody else can access this email account) you can safely ignore this email.{/ts}
-
-        {\$resetUrlPlaintext}
-
-        {domain.name}
-        TXT,
-      'msg_html' => <<<HTML
-        <p>{ts}A password reset link was requested for this account.&nbsp; If this wasn\'t you (and nobody else can access this email account) you can safely ignore this email.{/ts}</p>
-
-        <p><a href="{\$resetUrlHtml}">{\$resetUrlHtml}</a></p>
-
-        <p>{domain.name}</p>
-        HTML,
-    ];
-
-    // Create a "reserved" template. This is a pristine copy provided for reference.
-    MessageTemplate::save(FALSE)
-      ->setDefaults($baseTpl)
-      ->setRecords([
-        ['is_reserved' => TRUE, 'is_default' => FALSE],
-        ['is_reserved' => FALSE, 'is_default' => TRUE],
-      ])
-      ->execute();
-
   }
 
   /**

--- a/ext/standaloneusers/managed/MessageTemplate_PasswordReset.mgd.php
+++ b/ext/standaloneusers/managed/MessageTemplate_PasswordReset.mgd.php
@@ -3,16 +3,6 @@ use CRM_Standaloneusers_ExtensionUtil as E;
 
 $passwordResetSubject = '{ts}Password reset link for{/ts} {domain.name}';
 
-$passwordResetText = <<<TXT
-  {ts}A password reset link was requested for this account.  If this wasn't you (and nobody else can access this email account) you can safely ignore this email.{/ts}
-
-  {\$resetUrlPlaintext}
-
-  {\$tokenTimeoutPlaintext}
-
-  {domain.name}
-TXT;
-
 $passwordResetHtml = <<<HTML
   <p>{ts}A password reset link was requested for this account.&nbsp; If this wasn't you (and nobody else can access this email account) you can safely ignore this email.{/ts}</p>
 
@@ -38,7 +28,7 @@ return [
         'workflow_name' => 'password_reset',
         'msg_title' => E::ts('Password reset'),
         'msg_subject' => $passwordResetSubject,
-        'msg_text' => $passwordResetText,
+        'msg_text' => '',
         'msg_html' => $passwordResetHtml,
         'is_default' => FALSE,
         'is_reserved' => TRUE,
@@ -61,7 +51,7 @@ return [
         'workflow_name' => 'password_reset',
         'msg_title' => E::ts('Password reset'),
         'msg_subject' => $passwordResetSubject,
-        'msg_text' => $passwordResetText,
+        'msg_text' => '',
         'msg_html' => $passwordResetHtml,
         'is_default' => TRUE,
         'is_reserved' => FALSE,

--- a/ext/standaloneusers/managed/MessageTemplate_PasswordReset.mgd.php
+++ b/ext/standaloneusers/managed/MessageTemplate_PasswordReset.mgd.php
@@ -1,0 +1,71 @@
+<?php
+use CRM_Standaloneusers_ExtensionUtil as E;
+
+$passwordResetSubject = '{ts}Password reset link for{/ts} {domain.name}';
+
+$passwordResetText = <<<TXT
+  {ts}A password reset link was requested for this account.  If this wasn't you (and nobody else can access this email account) you can safely ignore this email.{/ts}
+
+  {\$resetUrlPlaintext}
+
+  {\$tokenTimeoutPlaintext}
+
+  {domain.name}
+TXT;
+
+$passwordResetHtml = <<<HTML
+  <p>{ts}A password reset link was requested for this account.&nbsp; If this wasn't you (and nobody else can access this email account) you can safely ignore this email.{/ts}</p>
+
+  <p><a href="{\$resetUrlHtml}">{\$resetUrlHtml}</a></p>
+
+  <p>{domain.name}</p>
+HTML;
+
+return [
+  [
+    'name' => 'MessageTemplate_PasswordResetReserved',
+    'entity' => 'MessageTemplate',
+    'cleanup' => 'unused',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'checkPermissions' => FALSE,
+      'match' => [
+        'workflow_name',
+        'is_reserved',
+      ],
+      'values' => [
+        'workflow_name' => 'password_reset',
+        'msg_title' => E::ts('Password reset'),
+        'msg_subject' => $passwordResetSubject,
+        'msg_text' => $passwordResetText,
+        'msg_html' => $passwordResetHtml,
+        'is_default' => FALSE,
+        'is_reserved' => TRUE,
+      ],
+    ],
+  ],
+  [
+    'name' => 'MessageTemplate_PasswordResetEditable',
+    'entity' => 'MessageTemplate',
+    'cleanup' => 'unused',
+    'update' => 'never',
+    'params' => [
+      'version' => 4,
+      'checkPermissions' => FALSE,
+      'match' => [
+        'workflow_name',
+        'is_reserved',
+      ],
+      'values' => [
+        'workflow_name' => 'password_reset',
+        'msg_title' => E::ts('Password reset'),
+        'msg_subject' => $passwordResetSubject,
+        'msg_text' => $passwordResetText,
+        'msg_html' => $passwordResetHtml,
+        'is_default' => TRUE,
+        'is_reserved' => FALSE,
+      ],
+    ],
+  ],
+];

--- a/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
@@ -230,7 +230,6 @@ class SecurityTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
     $this->assertNotNull($workflow);
     $result = $workflow->renderTemplate();
 
-    $this->assertMatchesRegularExpression(';https?://[^/]+/civicrm/login/password.*' . $token . ';', $result['text']);
     $this->assertMatchesRegularExpression(';https?://[^/]+/civicrm/login/password.*' . $token . ';', $result['html']);
     $this->assertEquals('Password reset link for Demonstrators Anonymous', $result['subject']);
 


### PR DESCRIPTION
Overview
----------------------------------------
Backport https://github.com/civicrm/civicrm-core/pull/32110

This is required for `standalonemigrate` extension to work properly - this makes `6.0` a valid target for migration once released.

_edit: it also adds an upgrade step which prevents overwriting user edits to the password reset template when upgrading from pre-6.0. Currently we have a risk of data loss on the `6.1` branch._

Technical Details
----------------------------------------
NOTE: the backport is slightly different because a timeout token was added to the message template on `master` branch. Want to avoid removing that if forward-merged.
