### PR TITLE
dev/core#4808 Profile Create: remove the default Return to listing link

### DIFF
--- a/CRM/Profile/Page/View.php
+++ b/CRM/Profile/Page/View.php
@@ -107,16 +107,6 @@ class CRM_Profile_Page_View extends CRM_Core_Page {
           )
         );
       }
-      if (CRM_Core_Permission::ufGroupValid($this->_gid,
-        CRM_Core_Permission::SEARCH
-      )
-      ) {
-        $this->assign('listingURL',
-          CRM_Utils_System::url("civicrm/profile",
-            "force=1&gid={$gidString}"
-          )
-        );
-      }
     }
     else {
       $ufGroups = CRM_Core_BAO_UFGroup::getModuleUFGroup('Profile');
@@ -132,20 +122,15 @@ class CRM_Profile_Page_View extends CRM_Core_Page {
         }
         $profileGroups[] = $profileGroup;
       }
-      $this->assign('listingURL',
-        CRM_Utils_System::url("civicrm/profile",
-          "force=1"
-        )
-      );
     }
 
     $this->assign('groupID', $this->_gid);
-
     $this->assign('profileGroups', $profileGroups);
     $this->assign('recentlyViewed', FALSE);
+    // This is being phased out, but could be set by extensions
+    $this->assign('listingURL', NULL);
 
-    // do not set title if there is no content
-    // CRM-6081
+    // CRM-6081 Do not set title if there is no content
     if (!$anyContent) {
       CRM_Utils_System::setTitle('');
     }

--- a/templates/CRM/Profile/Page/View.tpl
+++ b/templates/CRM/Profile/Page/View.tpl
@@ -24,6 +24,7 @@
         </div>
     {/foreach}
     <div class="action-link">
+        {* dev/core#4808 profile listings are being phased out, but extensions can still set this *}
         {if $listingURL}
             <a href="{$listingURL}"><i class="crm-i fa-chevron-left" aria-hidden="true"></i> {ts}Back to Listings{/ts}</a>&nbsp;&nbsp;&nbsp;&nbsp;
         {/if}


### PR DESCRIPTION
Overview
----------------------------------------

Removes the "Return to listing" link shown when we submit a profile form.

- Profile listings are clunky and often a security liability. We recommend using SearchKit/FormBuilder instead.
- The link is often displayed even if there are no public fields. While I did check to see if I could fix that specific permission check, I decided it was not worth the effort. Permissions around profiles are very weird.

https://lab.civicrm.org/dev/core/-/issues/4808

Before
----------------------------------------

Submit a form, see the result, with a link "Back to Listings", which 99.99% of people hide in CSS.

After
----------------------------------------

No link :magic_wand: 

Comments
----------------------------------------

We still use Profiles for things like newsletter subscription forms (add to a group, notify).