### PR TITLE
[REF] Api4 - Use str_contains instead of strpos

### DIFF
--- a/Civi/Api4/Action/GetActions.php
+++ b/Civi/Api4/Action/GetActions.php
@@ -91,7 +91,7 @@ class GetActions extends BasicGetAction {
             if ($method) {
               $methodDocs = ReflectionUtils::getCodeDocs($method, 'Method', $vars);
               // Allow method doc to inherit class doc
-              if (strpos($method->getDocComment(), '@inheritDoc') !== FALSE && !empty($methodDocs['comment']) && !empty($actionDocs['comment'])) {
+              if (str_contains($method->getDocComment(), '@inheritDoc') && !empty($methodDocs['comment']) && !empty($actionDocs['comment'])) {
                 $methodDocs['comment'] .= "\n\n" . $actionDocs['comment'];
               }
               $actionDocs = array_filter($methodDocs) + $actionDocs + ['deprecated' => FALSE];

--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -563,7 +563,7 @@ abstract class AbstractAction implements \ArrayAccess {
    * @throws \Exception
    */
   public static function evaluateCondition($expr, $vars) {
-    if (strpos($expr, '}') !== FALSE || strpos($expr, '{') !== FALSE) {
+    if (str_contains($expr, '}') || str_contains($expr, '{')) {
       throw new \CRM_Core_Exception('Illegal character in expression');
     }
     $tpl = "{if $expr}1{else}0{/if}";

--- a/Civi/Api4/Generic/AbstractGetAction.php
+++ b/Civi/Api4/Generic/AbstractGetAction.php
@@ -111,7 +111,7 @@ abstract class AbstractGetAction extends AbstractQueryAction {
   protected function _itemsToGet($field) {
     foreach ($this->where as $clause) {
       // Look for exact-match operators (=, IN, or LIKE with no wildcard)
-      if ($clause[0] == $field && (in_array($clause[1], ['=', 'IN'], TRUE) || ($clause[1] == 'LIKE' && !(is_string($clause[2]) && strpos($clause[2], '%') !== FALSE)))) {
+      if ($clause[0] == $field && (in_array($clause[1], ['=', 'IN'], TRUE) || ($clause[1] == 'LIKE' && !(is_string($clause[2]) && str_contains($clause[2], '%'))))) {
         return (array) $clause[2];
       }
     }
@@ -132,7 +132,7 @@ abstract class AbstractGetAction extends AbstractQueryAction {
    *   Returns true if any given fields are in use.
    */
   protected function _isFieldSelected(string ...$fieldNames) {
-    if ((!$this->select && strpos($fieldNames[0], ':') === FALSE) || array_intersect($fieldNames, array_merge($this->select, array_keys($this->orderBy)))) {
+    if ((!$this->select && !str_contains($fieldNames[0], ':')) || array_intersect($fieldNames, array_merge($this->select, array_keys($this->orderBy)))) {
       return TRUE;
     }
     return $this->_whereContains($fieldNames);

--- a/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
+++ b/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
@@ -256,7 +256,7 @@ trait ArrayQueryActionTrait {
       // With no SELECT specified, return all values that are keyed by plain field name; omit those with :pseudoconstant suffixes
       foreach ($values as &$value) {
         $value = array_filter($value, function($key) {
-          return strpos($key, ':') === FALSE;
+          return !str_contains($key, ':');
         }, ARRAY_FILTER_USE_KEY);
       }
     }

--- a/Civi/Api4/Generic/Traits/SelectParamTrait.php
+++ b/Civi/Api4/Generic/Traits/SelectParamTrait.php
@@ -58,7 +58,7 @@ trait SelectParamTrait {
     }
     // Get expressions containing wildcards but no dots or parentheses
     $wildFields = array_filter($this->select, function($item) {
-      return strpos($item, '*') !== FALSE && strpos($item, '.') === FALSE && strpos($item, '(') === FALSE && strpos($item, ' ') === FALSE;
+      return str_contains($item, '*') && !str_contains($item, '.') && !str_contains($item, '(') && !str_contains($item, ' ');
     });
     if ($wildFields) {
       // Wildcards should not match "Extra" fields

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -171,7 +171,7 @@ class Api4SelectQuery extends Api4Query {
 
       // Expand wildcards in joins (the api wrapper already expanded non-joined wildcards)
       $wildFields = array_filter($select, function($item) {
-        return strpos($item, '*') !== FALSE && strpos($item, '.') !== FALSE && strpos($item, '(') === FALSE && strpos($item, ' ') === FALSE;
+        return str_contains($item, '*') && str_contains($item, '.') && !str_contains($item, '(') && !str_contains($item, ' ');
       });
 
       foreach ($wildFields as $wildField) {

--- a/Civi/Api4/Utils/ReflectionUtils.php
+++ b/Civi/Api4/Utils/ReflectionUtils.php
@@ -71,7 +71,7 @@ class ReflectionUtils {
     $info = [];
     $param = NULL;
     foreach (preg_split("/((\r?\n)|(\r\n?))/", $comment) as $num => $line) {
-      if (!$num || strpos($line, '*/') !== FALSE) {
+      if (!$num || str_contains($line, '*/')) {
         continue;
       }
       $line = ltrim(trim($line), '*');
@@ -190,7 +190,7 @@ class ReflectionUtils {
   public static function isMethodDeprecated(string $className, string $methodName): bool {
     $reflection = new \ReflectionClass($className);
     $docBlock = $reflection->getMethod($methodName)->getDocComment();
-    return strpos($docBlock, "@deprecated") !== FALSE;
+    return str_contains($docBlock, "@deprecated");
   }
 
   /**

--- a/Civi/Api4/Utils/SelectUtil.php
+++ b/Civi/Api4/Utils/SelectUtil.php
@@ -22,11 +22,11 @@ class SelectUtil {
    * @return bool
    */
   public static function isFieldSelected($field, $selects) {
-    if (in_array($field, $selects) || (in_array('*', $selects) && strpos($field, '.') === FALSE)) {
+    if (in_array($field, $selects) || (in_array('*', $selects) && !str_contains($field, '.'))) {
       return TRUE;
     }
     foreach ($selects as $item) {
-      if (strpos($item, '*') !== FALSE && self::getMatchingFields($item, [$field])) {
+      if (str_contains($item, '*') && self::getMatchingFields($item, [$field])) {
         return TRUE;
       }
     }
@@ -46,7 +46,7 @@ class SelectUtil {
     // If the pattern is "select all" then we return all base fields (excluding those with a dot)
     if ($pattern === '*') {
       return array_values(array_filter($fieldNames, function($field) {
-        return strpos($field, '.') === FALSE;
+        return !str_contains($field, '.');
       }));
     }
     $dot = strrpos($pattern, '.');


### PR DESCRIPTION
Overview
----------------------------------------
General refactor - updates code to use preferred newer PHP function.

Technical Details
----------------------------------------
Before/after functionality is the same, but `str_contains` is preferred for readability.