### PR TITLE
[REF] Civi - Use str_contains instead of strpos

### DIFF
--- a/Civi/Angular/Coder.php
+++ b/Civi/Angular/Coder.php
@@ -74,7 +74,7 @@ class Coder {
 
     switch ($attr) {
       case 'href':
-        if (strpos($value, '%7B%7B') !== FALSE && strpos($value, '%7D%7D') !== FALSE) {
+        if (str_contains($value, '%7B%7B') && str_contains($value, '%7D%7D')) {
           $value = urldecode($value);
         }
         break;

--- a/Civi/ComposerTasks.php
+++ b/Civi/ComposerTasks.php
@@ -14,7 +14,7 @@ class ComposerTasks {
    * @return void
    */
   public static function stripSourceMap(array $task = []): void {
-    if (empty($task['src-path']) || !is_string($task['src-path']) || strpos($task['src-path'], '..') !== FALSE) {
+    if (empty($task['src-path']) || !is_string($task['src-path']) || str_contains($task['src-path'], '..')) {
       throw new \LogicException("stripSourceMap(): Task must specify a valid 'src-path'");
     }
     $path = dirname(__DIR__) . '/' . $task['src-path'];

--- a/Civi/Core/AssetBuilder.php
+++ b/Civi/Core/AssetBuilder.php
@@ -113,8 +113,8 @@ class AssetBuilder extends \Civi\Core\Service\AutoService {
    */
   public function isValidName($name) {
     return preg_match(';^[a-zA-Z0-9\.\-_/]+$;', $name)
-    && strpos($name, '..') === FALSE
-    && strpos($name, '.') !== FALSE;
+    && !str_contains($name, '..')
+    && str_contains($name, '.');
   }
 
   /**

--- a/Civi/Core/CiviEventDispatcher.php
+++ b/Civi/Core/CiviEventDispatcher.php
@@ -78,7 +78,7 @@ class CiviEventDispatcher implements CiviEventDispatcherInterface {
    * @return bool
    */
   protected function isHookEvent($eventName) {
-    return (substr($eventName, 0, 5) === 'hook_') && (strpos($eventName, '::') === FALSE);
+    return (substr($eventName, 0, 5) === 'hook_') && (!str_contains($eventName, '::'));
   }
 
   /**

--- a/Civi/Core/Resolver.php
+++ b/Civi/Core/Resolver.php
@@ -63,11 +63,11 @@ class Resolver {
       return $id;
     }
 
-    if (strpos($id, '::') !== FALSE) {
+    if (str_contains($id, '::')) {
       // Callback: Static method.
       return explode('::', $id);
     }
-    elseif (strpos($id, '://') !== FALSE) {
+    elseif (str_contains($id, '://')) {
       $url = parse_url($id);
       switch ($url['scheme']) {
         case 'obj':

--- a/Civi/Crypto/CryptoRegistry.php
+++ b/Civi/Crypto/CryptoRegistry.php
@@ -191,7 +191,7 @@ class CryptoRegistry extends AutoService {
    * @return bool
    */
   public function isValidKeyId($id) {
-    if (strpos($id, "\n") !== FALSE) {
+    if (str_contains($id, "\n")) {
       return FALSE;
     }
     return (bool) preg_match(';^[a-zA-Z0-9_\-\.:,=+/\;\\\\]+$;s', $id);

--- a/Civi/Install/Requirements.php
+++ b/Civi/Install/Requirements.php
@@ -613,7 +613,7 @@ class Requirements {
 
     // Ensure that the MySQL driver supports utf8mb4 encoding.
     $version = mysqli_get_client_info();
-    if (strpos($version, 'mysqlnd') !== FALSE) {
+    if (str_contains($version, 'mysqlnd')) {
       // The mysqlnd driver supports utf8mb4 starting at version 5.0.9.
       $version = preg_replace('/^\D+([\d.]+).*/', '$1', $version);
       if (version_compare($version, '5.0.9', '<')) {

--- a/Civi/Test/CiviTestListener.php
+++ b/Civi/Test/CiviTestListener.php
@@ -263,20 +263,20 @@ else {
       foreach ($byInterface['HeadlessInterface'] as $className => $nonce) {
         $clazz = new \ReflectionClass($className);
         $docComment = str_replace("\r\n", "\n", $clazz->getDocComment());
-        if (strpos($docComment, "@group headless\n") === FALSE) {
+        if (!str_contains($docComment, "@group headless\n")) {
           echo "WARNING: Class $className implements HeadlessInterface. It should declare \"@group headless\".\n";
         }
-        if (strpos($docComment, "@group e2e\n") !== FALSE) {
+        if (str_contains($docComment, "@group e2e\n")) {
           echo "WARNING: Class $className implements HeadlessInterface. It should not declare \"@group e2e\".\n";
         }
       }
       foreach ($byInterface['EndToEndInterface'] as $className => $nonce) {
         $clazz = new \ReflectionClass($className);
         $docComment = str_replace("\r\n", "\n", $clazz->getDocComment());
-        if (strpos($docComment, "@group e2e\n") === FALSE) {
+        if (!str_contains($docComment, "@group e2e\n")) {
           echo "WARNING: Class $className implements EndToEndInterface. It should declare \"@group e2e\".\n";
         }
-        if (strpos($docComment, "@group headless\n") !== FALSE) {
+        if (str_contains($docComment, "@group headless\n")) {
           echo "WARNING: Class $className implements EndToEndInterface. It should not declare \"@group headless\".\n";
         }
       }

--- a/Civi/Test/CiviTestListenerPHPUnit7.php
+++ b/Civi/Test/CiviTestListenerPHPUnit7.php
@@ -251,20 +251,20 @@ class CiviTestListenerPHPUnit7 implements \PHPUnit\Framework\TestListener {
     foreach ($byInterface['HeadlessInterface'] as $className => $nonce) {
       $clazz = new \ReflectionClass($className);
       $docComment = str_replace("\r\n", "\n", $clazz->getDocComment());
-      if (strpos($docComment, "@group headless\n") === FALSE) {
+      if (!str_contains($docComment, "@group headless\n")) {
         echo "WARNING: Class $className implements HeadlessInterface. It should declare \"@group headless\".\n";
       }
-      if (strpos($docComment, "@group e2e\n") !== FALSE) {
+      if (str_contains($docComment, "@group e2e\n")) {
         echo "WARNING: Class $className implements HeadlessInterface. It should not declare \"@group e2e\".\n";
       }
     }
     foreach ($byInterface['EndToEndInterface'] as $className => $nonce) {
       $clazz = new \ReflectionClass($className);
       $docComment = str_replace("\r\n", "\n", $clazz->getDocComment());
-      if (strpos($docComment, "@group e2e\n") === FALSE) {
+      if (!str_contains($docComment, "@group e2e\n")) {
         echo "WARNING: Class $className implements EndToEndInterface. It should declare \"@group e2e\".\n";
       }
-      if (strpos($docComment, "@group headless\n") !== FALSE) {
+      if (str_contains($docComment, "@group headless\n")) {
         echo "WARNING: Class $className implements EndToEndInterface. It should not declare \"@group headless\".\n";
       }
     }

--- a/Civi/Test/FormWrapper.php
+++ b/Civi/Test/FormWrapper.php
@@ -356,14 +356,14 @@ class FormWrapper {
         $this->form->setAction(\CRM_Core_Action::BASIC);
         break;
 
-      case strpos($class, 'Search') !== FALSE:
+      case str_contains($class, 'Search'):
         $this->form->controller = new \CRM_Contact_Controller_Search();
         if ($class === 'CRM_Contact_Form_Search_Basic') {
           $this->form->setAction(\CRM_Core_Action::BASIC);
         }
         break;
 
-      case strpos($class, '_Form_') !== FALSE:
+      case str_contains($class, '_Form_'):
         $this->form->controller = new \CRM_Core_Controller_Simple($class, $this->form->getName());
         break;
 

--- a/Civi/Test/Legacy/CiviTestListener.php
+++ b/Civi/Test/Legacy/CiviTestListener.php
@@ -256,7 +256,7 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
       if (strpos($docComment, "@group headless\n") === FALSE) {
         echo "WARNING: Class $className implements HeadlessInterface. It should declare \"@group headless\".\n";
       }
-      if (strpos($docComment, "@group e2e\n") !== FALSE) {
+      if (str_contains($docComment, "@group e2e\n")) {
         echo "WARNING: Class $className implements HeadlessInterface. It should not declare \"@group e2e\".\n";
       }
     }
@@ -266,7 +266,7 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
       if (strpos($docComment, "@group e2e\n") === FALSE) {
         echo "WARNING: Class $className implements EndToEndInterface. It should declare \"@group e2e\".\n";
       }
-      if (strpos($docComment, "@group headless\n") !== FALSE) {
+      if (str_contains($docComment, "@group headless\n")) {
         echo "WARNING: Class $className implements EndToEndInterface. It should not declare \"@group headless\".\n";
       }
     }

--- a/Civi/Token/TidySubscriber.php
+++ b/Civi/Token/TidySubscriber.php
@@ -34,7 +34,7 @@ class TidySubscriber implements EventSubscriberInterface {
    * @noinspection PhpUnused
    */
   public function tidyHtml(TokenRenderEvent $e): void {
-    if (strpos($e->string, 'http') !== FALSE) {
+    if (str_contains($e->string, 'http')) {
       $e->string = str_replace(
         [
           'https://https://',

--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -203,7 +203,7 @@ class TokenRow {
     // This is a bit of a clumsy wy of detecting a link field but if you look into the displayValue
     // function you will understand.... By assigning the url as a plain token the text version can
     // use it as plain text (not html re-converted which kinda works but not in subject lines)
-    if (is_string($fieldValue) && is_string($originalValue) && strpos($fieldValue, '<a href') !== FALSE && strpos($originalValue, '<a href') === FALSE) {
+    if (is_string($fieldValue) && is_string($originalValue) && str_contains($fieldValue, '<a href') && !str_contains($originalValue, '<a href')) {
       $this->format('text/plain')->tokens($entity, $customFieldName, $originalValue);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
General refactor - updates code to use preferred newer PHP function.

Technical Details
----------------------------------------
Before/after functionality is the same, but `str_contains` is preferred for readability.