### PR TITLE
[REF] CRM/Contact - Use str_contains instead of strpos

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1661,7 +1661,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
 
     $multipleFields = ['website' => 'url'];
     foreach ($fields as $name => $dontCare) {
-      if (strpos($name, '-') !== FALSE) {
+      if (str_contains($name, '-')) {
         [$fieldName, $id, $type] = CRM_Utils_System::explode('-', $name, 3);
 
         if (!in_array($fieldName, $multipleFields)) {
@@ -2190,7 +2190,7 @@ ORDER BY civicrm_email.is_primary DESC";
           if (isset($params[$key . '-provider_id'])) {
             $data['im'][$loc]['provider_id'] = $params[$key . '-provider_id'];
           }
-          if (strpos($key, '-provider_id') !== FALSE) {
+          if (str_contains($key, '-provider_id')) {
             $data['im'][$loc]['provider_id'] = $params[$key];
           }
           else {

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1017,7 +1017,7 @@ WHERE {$whereClause}";
     $title = $params['title'] ?? NULL;
     if ($title) {
       $clauses[] = "`groups`.title LIKE %1";
-      if (strpos($title, '%') !== FALSE) {
+      if (str_contains($title, '%')) {
         $params[1] = [$title, 'String', FALSE];
       }
       else {
@@ -1083,7 +1083,7 @@ WHERE {$whereClause}";
     $createdBy = $params['created_by'] ?? NULL;
     if ($createdBy) {
       $clauses[] = "createdBy.sort_name LIKE %6";
-      if (strpos($createdBy, '%') !== FALSE) {
+      if (str_contains($createdBy, '%')) {
         $params[6] = [$createdBy, 'String', FALSE];
       }
       else {

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -930,7 +930,7 @@ class CRM_Contact_BAO_Query {
                 $this->_pseudoConstantsSelect[$tName]['select'] = "{$field['where']} as `$name`";
                 $this->_pseudoConstantsSelect[$tName]['element'] = $name;
               }
-              elseif (strpos($name, 'contribution_soft_credit') !== FALSE) {
+              elseif (str_contains($name, 'contribution_soft_credit')) {
                 if (CRM_Contribute_BAO_Query::isSoftCreditOptionEnabled($this->_params)) {
                   $this->_select[$name] = "{$field['where']} as `$name`";
                 }
@@ -1116,7 +1116,7 @@ class CRM_Contact_BAO_Query {
         }
 
         $cond = $elementType = '';
-        if (strpos($elementName, '-') !== FALSE) {
+        if (str_contains($elementName, '-')) {
           // this is either phone, email or IM
           [$elementName, $elementType] = explode('-', $elementName);
 
@@ -1190,7 +1190,7 @@ class CRM_Contact_BAO_Query {
           foreach ($this->_params as $id => $values) {
             if ((is_array($values) && $values[0] == $nm) ||
               (in_array($elementName, ['phone', 'im'])
-                && (strpos($values[0], $nm) !== FALSE)
+                && (str_contains($values[0], $nm))
               )
             ) {
               $addWhere = TRUE;
@@ -1280,7 +1280,7 @@ class CRM_Contact_BAO_Query {
                   if ($cond) {
                     $phoneTypeCondition = " AND `$tName`.$cond ";
                     //gross hack to pickup corrupted data also, CRM-7603
-                    if (strpos($cond, 'phone_type_id') !== FALSE) {
+                    if (str_contains($cond, 'phone_type_id')) {
                       $phoneTypeCondition = " AND ( `$tName`.$cond OR `$tName`.phone_type_id IS NULL ) ";
                       if (!empty($lCond)) {
                         $phoneTypeCondition .= " AND ( `$tName`.$lCond ) ";
@@ -1776,7 +1776,7 @@ class CRM_Contact_BAO_Query {
     if (!$useEquals && in_array($id, $likeNames)) {
       $result = [$id, 'LIKE', $values, 0, 1];
     }
-    elseif (is_string($values) && strpos($values, '%') !== FALSE) {
+    elseif (is_string($values) && str_contains($values, '%')) {
       $result = [$id, 'LIKE', $values, 0, 0];
     }
     elseif ($id == 'contact_type' ||
@@ -2332,7 +2332,7 @@ class CRM_Contact_BAO_Query {
       $this->_qill[$grouping][] = ts("%1 %2 %3", [
         1 => $field['title'],
         2 => $qillop,
-        3 => (strpos($op, 'NULL') !== FALSE || strpos($op, 'EMPTY') !== FALSE) ? $qillVal : "'$qillVal'",
+        3 => (str_contains($op, 'NULL') || str_contains($op, 'EMPTY')) ? $qillVal : "'$qillVal'",
       ]);
 
       if (is_array($value)) {
@@ -2345,7 +2345,7 @@ class CRM_Contact_BAO_Query {
           if (!in_array($operator, CRM_Core_DAO::acceptedSQLOperators())) {
             //Via Contact get api value is not in array(operator => array(values)) format ONLY for IN/NOT IN operators
             //so this condition will satisfy the search for now
-            if (strpos($op, 'IN') !== FALSE) {
+            if (str_contains($op, 'IN')) {
               $value = [$op => $value];
             }
             // we don't know when this might happen
@@ -2460,7 +2460,7 @@ class CRM_Contact_BAO_Query {
 
     foreach ($this->_element as $key => $dontCare) {
       if (property_exists($dao, $key)) {
-        if (strpos($key, '-') !== FALSE) {
+        if (str_contains($key, '-')) {
           $values = explode('-', $key);
           $lastElement = array_pop($values);
           $current = &$value;
@@ -2610,11 +2610,11 @@ class CRM_Contact_BAO_Query {
 
     foreach ($tables as $key => $value) {
       $k = 99;
-      if (strpos($key, '-') !== FALSE) {
+      if (str_contains($key, '-')) {
         $keyArray = explode('-', $key);
         $k = $info['civicrm_' . $keyArray[1]] ?? 99;
       }
-      elseif (strpos($key, '_') !== FALSE) {
+      elseif (str_contains($key, '_')) {
         $keyArray = explode('_', $key);
         if (is_numeric(array_pop($keyArray))) {
           $k = CRM_Utils_Array::value(implode('_', $keyArray), $info, 99);
@@ -2951,7 +2951,7 @@ class CRM_Contact_BAO_Query {
     $op = str_replace('=', 'LIKE', $op);
     $op = str_replace('!', 'NOT ', $op);
 
-    if (strpos($op, 'NULL') !== FALSE || strpos($op, 'EMPTY') !== FALSE) {
+    if (str_contains($op, 'NULL') || str_contains($op, 'EMPTY')) {
       $this->_where[$grouping][] = self::buildClause($alias, $op, $value, 'String');
     }
     elseif (is_array($value)) {
@@ -3003,7 +3003,7 @@ class CRM_Contact_BAO_Query {
     }
 
     if (is_array($value) && count($value) > 1) {
-      if (strpos($op, 'IN') === FALSE && strpos($op, 'NULL') === FALSE) {
+      if (!str_contains($op, 'IN') && !str_contains($op, 'NULL')) {
         throw new CRM_Core_Exception(ts("%1 is not a valid operator", [1 => $op]));
       }
       $this->_useDistinct = TRUE;
@@ -3093,7 +3093,7 @@ class CRM_Contact_BAO_Query {
           $gcTable = "civicrm_group_contact_{$this->_groupUniqueKey}";
           $joinClause = ["contact_a.id = {$gcTable}.contact_id"];
           $this->_tables[$gcTable] = $this->_whereTables[$gcTable] = " LEFT JOIN civicrm_group_contact {$gcTable} ON (" . implode(' AND ', $joinClause) . ")";
-          if (strpos($op, 'IN') !== FALSE) {
+          if (str_contains($op, 'IN')) {
             $groupClause[] = "{$gcTable}.group_id $op ( $groupIds ) AND {$gccTableAlias}.group_id IS NULL";
           }
           else {
@@ -3111,7 +3111,7 @@ class CRM_Contact_BAO_Query {
 
     [$qillop, $qillVal] = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Contact_DAO_Group', 'id', $value, $op);
     $this->_qill[$grouping][] = ts("Group(s) %1 %2", [1 => $qillop, 2 => $qillVal]);
-    if (strpos($op, 'NULL') === FALSE) {
+    if (!str_contains($op, 'NULL')) {
       $this->_qill[$grouping][] = ts("Group Status %1", [1 => implode(' ' . ts('or') . ' ', $this->getSelectedGroupStatuses($grouping))]);
     }
   }
@@ -3152,7 +3152,7 @@ class CRM_Contact_BAO_Query {
    * @throws \CRM_Core_Exception
    */
   public function addGroupContactCache($groups, $tableAlias, $joinTable, $op, $joinColumn = 'id') {
-    $isNullOp = (strpos($op, 'NULL') !== FALSE);
+    $isNullOp = (str_contains($op, 'NULL'));
     $groupsIds = $groups;
 
     $operator = ['=' => 'IN', '!=' => 'NOT IN'];
@@ -3162,7 +3162,7 @@ class CRM_Contact_BAO_Query {
     if (!$isNullOp && !$groups) {
       return NULL;
     }
-    elseif (strpos($op, 'IN') !== FALSE) {
+    elseif (str_contains($op, 'IN')) {
       $groups = [$op => $groups];
     }
     elseif (is_array($groups) && count($groups)) {
@@ -3410,7 +3410,7 @@ WHERE  $smartGroupClause
     $n = trim($value);
     $value = CRM_Core_DAO::escapeString($n);
     if ($wildcard) {
-      if (strpos($value, '%') === FALSE) {
+      if (!str_contains($value, '%')) {
         $value = "%$value%";
       }
       $op = 'LIKE';
@@ -3500,7 +3500,7 @@ WHERE  $smartGroupClause
     // Replace spaces with wildcards for a LIKE operation
     // UNLESS string contains a comma (this exception is a tiny bit questionable)
     // Also need to check if there is space in between sort name.
-    elseif ($op == 'LIKE' && strpos($value, ',') === FALSE && strpos($value, ' ') !== FALSE) {
+    elseif ($op == 'LIKE' && !str_contains($value, ',') && str_contains($value, ' ')) {
       $value = str_replace(' ', '%', $value);
     }
     $value = CRM_Core_DAO::escapeString(trim($value));
@@ -3612,7 +3612,7 @@ WHERE  $smartGroupClause
     // Strip non-numeric characters; allow wildcards
     $number = preg_replace('/[^\d%]/', '', $value);
     if ($number) {
-      if (strpos($number, '%') === FALSE) {
+      if (!str_contains($number, '%')) {
         $number = "%$number%";
       }
 
@@ -3656,7 +3656,7 @@ WHERE  $smartGroupClause
     $n = trim($value);
 
     if ($n) {
-      if (strpos($value, '%') === FALSE) {
+      if (!str_contains($value, '%')) {
         // only add wild card if not there
         $value = "%{$value}%";
       }
@@ -5730,7 +5730,7 @@ civicrm_relationship.start_date > {$today}
     // skip if filter has already applied
     foreach ($_rTempCache as $acache) {
       foreach ($acache['queries'] as $aqcache) {
-        if (strpos($from, $aqcache['from']) !== FALSE) {
+        if (str_contains($from, $aqcache['from'])) {
           $having = NULL;
           return;
         }
@@ -5808,8 +5808,8 @@ AND   displayRelType.is_active = 1
     if (!is_array($this->_qill[0]) || !in_array($iqill, $this->_qill[0])) {
       $this->_qill[0][] = $iqill;
     }
-    if (strpos($from, $qcache['from']) === FALSE) {
-      if (strpos($from, "INNER JOIN") !== FALSE) {
+    if (!str_contains($from, $qcache['from'])) {
+      if (str_contains($from, "INNER JOIN")) {
         // lets replace all the INNER JOIN's in the $from so we dont exclude other data
         // this happens when we have an event_type in the quert (CRM-7969)
         $from = str_replace("INNER JOIN", "LEFT JOIN", $from);
@@ -6009,7 +6009,7 @@ AND   displayRelType.is_active = 1
           // and we can use the metadata to figure it out.
           // ideally this bit of IF will absorb & replace all the rest in time as we move to
           // more metadata based choices.
-          if (strpos($val, CRM_Core_DAO::VALUE_SEPARATOR) !== FALSE) {
+          if (str_contains($val, CRM_Core_DAO::VALUE_SEPARATOR)) {
             $dbValues = explode(CRM_Core_DAO::VALUE_SEPARATOR, trim($val, CRM_Core_DAO::VALUE_SEPARATOR));
             foreach ($dbValues as $pseudoValue) {
               $convertedValues[] = CRM_Core_PseudoConstant::getLabel($value['bao'], $value['idCol'], $pseudoValue);
@@ -6067,7 +6067,7 @@ AND   displayRelType.is_active = 1
 
         // return converted values in array format
         if ($return) {
-          if (strpos($key, '-') !== FALSE) {
+          if (str_contains($key, '-')) {
             $keyVal = explode('-', $key);
             $current = &$values;
             $lastElement = array_pop($keyVal);
@@ -6181,7 +6181,7 @@ AND   displayRelType.is_active = 1
     }
 
     // if Operator chosen is NULL/EMPTY then
-    if (strpos($op, 'NULL') !== FALSE || strpos($op, 'EMPTY') !== FALSE) {
+    if (str_contains($op, 'NULL') || str_contains($op, 'EMPTY')) {
       return [$qillOperators[$op] ?? $op, ''];
     }
 
@@ -6375,7 +6375,7 @@ AND   displayRelType.is_active = 1
 
           // always add contact_a.id to the ORDER clause
           // so the order is deterministic
-          if (strpos('contact_a.id', $orderBy) === FALSE) {
+          if (!str_contains('contact_a.id', $orderBy)) {
             $orderBy .= ", contact_a.id";
           }
         }

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -77,7 +77,7 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
         }
         // Check for a date range field, which might be a standard date
         // range or a relative date.
-        if (strpos($id, '_date_low') !== FALSE || strpos($id, '_date_high') !== FALSE) {
+        if (str_contains($id, '_date_low') || str_contains($id, '_date_high')) {
           $entityName = strstr($id, '_date', TRUE);
 
           // This is the default, for non relative dates. We will overwrite

--- a/CRM/Contact/Controller/Search.php
+++ b/CRM/Contact/Controller/Search.php
@@ -66,10 +66,10 @@ class CRM_Contact_Controller_Search extends CRM_Core_Controller {
     $qString = CRM_Utils_System::currentPath();
     $args = "reset=1";
     $path = 'civicrm/contact/search/advanced';
-    if (strpos($qString, 'basic') !== FALSE) {
+    if (str_contains($qString, 'basic')) {
       $path = 'civicrm/contact/search/basic';
     }
-    elseif (strpos($qString, 'builder') !== FALSE) {
+    elseif (str_contains($qString, 'builder')) {
       $path = 'civicrm/contact/search/builder';
     }
     $url = CRM_Utils_System::url($path, $args);

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -101,7 +101,7 @@ class CRM_Contact_Form_Edit_Address {
 
     foreach ($elements as $name) {
       //Remove id from name, to allow comparison against enabled addressOptions.
-      $nameWithoutID = strpos($name, '_id') !== FALSE ? substr($name, 0, -3) : $name;
+      $nameWithoutID = str_contains($name, '_id') ? substr($name, 0, -3) : $name;
       // Skip fields which are not enabled in the address options.
       if (empty($addressOptions[$nameWithoutID])) {
         $continue = TRUE;

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -329,7 +329,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     $enabledComponents = CRM_Core_Component::getEnabledComponents();
     $componentModes = [];
     foreach (self::$_modeValues as $id => & $value) {
-      if (strpos($value['component'], 'Civi') !== FALSE
+      if (str_contains($value['component'], 'Civi')
         && !array_key_exists($value['component'], $enabledComponents)
       ) {
         continue;
@@ -693,7 +693,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     self::setModeValues();
 
     $setDynamic = FALSE;
-    if (strpos(self::$_selectorName, 'CRM_Contact_Selector') !== FALSE) {
+    if (str_contains(self::$_selectorName, 'CRM_Contact_Selector')) {
       $selector = new self::$_selectorName(
         $this->_customSearchClass,
         $this->_formValues,
@@ -816,7 +816,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
 
       $setDynamic = FALSE;
 
-      if (strpos(self::$_selectorName, 'CRM_Contact_Selector') !== FALSE) {
+      if (str_contains(self::$_selectorName, 'CRM_Contact_Selector')) {
         $selector = new self::$_selectorName(
           $this->_customSearchClass,
           $this->_formValues,

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -192,7 +192,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
         $selectedTypes = explode(' ', $selectedTypes);
       }
       foreach ($selectedTypes as $ct => $dontcare) {
-        if (strpos($ct, CRM_Core_DAO::VALUE_SEPARATOR) === FALSE) {
+        if (!str_contains($ct, CRM_Core_DAO::VALUE_SEPARATOR)) {
           $form->_contactTypes[] = $ct;
         }
         else {

--- a/CRM/Contact/Form/Task/Batch.php
+++ b/CRM/Contact/Form/Task/Batch.php
@@ -267,7 +267,7 @@ class CRM_Contact_Form_Task_Batch extends CRM_Contact_Form_Task {
     if (!isset($parseAddress)) {
       $parseAddress = FALSE;
       foreach ($form->_fields as $key => $fld) {
-        if (strpos($key, $addressFldKey) !== FALSE) {
+        if (str_contains($key, $addressFldKey)) {
           $parseAddress = CRM_Utils_Array::value('street_address_parsing',
             CRM_Core_BAO_Setting::valueOptions(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
               'address_options'
@@ -285,7 +285,7 @@ class CRM_Contact_Form_Task_Batch extends CRM_Contact_Form_Task {
 
     $allParseValues = [];
     foreach ($contactValues as $key => $value) {
-      if (strpos($key, $addressFldKey) !== FALSE) {
+      if (str_contains($key, $addressFldKey)) {
         $locTypeId = substr($key, strlen($addressFldKey) + 1);
 
         // parse address field.

--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -653,7 +653,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
     ];
     $tokenErrors = [];
     foreach ($deprecatedTokens as $token => $replacement) {
-      if (strpos($fields['html_message'], $token) !== FALSE) {
+      if (str_contains($fields['html_message'], $token)) {
         $tokenErrors[] = ts('Token %1 is no longer supported - use %2 instead', [$token, $replacement]);
       }
     }

--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -187,7 +187,7 @@ trait CRM_Contact_Form_Task_PDFTrait {
     ];
     $tokenErrors = [];
     foreach ($deprecatedTokens as $token => $replacement) {
-      if (strpos($fields['html_message'], $token) !== FALSE) {
+      if (str_contains($fields['html_message'], $token)) {
         $tokenErrors[] = ts('Token %1 is no longer supported - use %2 instead', [$token, $replacement]);
       }
     }
@@ -285,7 +285,7 @@ trait CRM_Contact_Form_Task_PDFTrait {
    *     if the form controller does not exist), else FALSE
    */
   protected function isLiveMode(): bool {
-    return strpos($this->controller->getButtonName(), '_preview') === FALSE;
+    return !str_contains($this->controller->getButtonName(), '_preview');
   }
 
   /**

--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -96,8 +96,8 @@ class CRM_Contact_Page_AJAX {
       foreach ($_GET as $param => $val) {
         if (empty($val) ||
           in_array($param, $excludeGet) ||
-          strpos($param, 'return.') !== FALSE ||
-          strpos($param, 'api.') !== FALSE
+          str_contains($param, 'return.') ||
+          str_contains($param, 'api.')
         ) {
           continue;
         }

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -421,7 +421,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
           if (!empty($field['in_selector']) &&
             !in_array($name, $skipFields)
           ) {
-            if (strpos($name, '-') !== FALSE) {
+            if (str_contains($name, '-')) {
               [$fieldName, $lType, $type] = CRM_Utils_System::explode('-', $name, 3);
 
               if ($lType === 'Primary') {
@@ -610,7 +610,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
         if (!empty($field['in_selector']) &&
           !in_array($key, $skipFields)
         ) {
-          if (strpos($key, '-') !== FALSE) {
+          if (str_contains($key, '-')) {
             [$fieldName, $id, $type] = CRM_Utils_System::explode('-', $key, 3);
 
             if ($id === 'Primary') {
@@ -707,7 +707,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
         elseif (isset($pseudoconstants[$property])) {
           $row[$property] = $pseudoconstants[$property]['values'][$result->{$pseudoconstants[$property]['dbName']}] ?? NULL;
         }
-        elseif (strpos($property, '-url') !== FALSE) {
+        elseif (str_contains($property, '-url')) {
           $websiteUrl = '';
           $websiteKey = str_replace('-url', '', $property);
           $propertyArray = explode('-', $property);
@@ -720,7 +720,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
           }
           $row[$property] = $websiteUrl;
         }
-        elseif (strpos($property, '-email') !== FALSE) {
+        elseif (str_contains($property, '-email')) {
           [$locType] = explode("-email", $property);
           $onholdProperty = "{$locType}-on_hold";
 


### PR DESCRIPTION
Overview
----------------------------------------
General refactor - updates code to use preferred newer PHP function.

Technical Details
----------------------------------------
Before/after functionality is the same, but `str_contains` is preferred for readability.