### PR TITLE
[REF] Ext - Use str_contains instead of strpos

### DIFF
--- a/ext/afform/core/CRM/Afform/ArrayHtml.php
+++ b/ext/afform/core/CRM/Afform/ArrayHtml.php
@@ -128,7 +128,7 @@ class CRM_Afform_ArrayHtml {
       }
     }
 
-    if (isset($array['#markup']) && (!$this->formatWhitespace || strpos($array['#markup'], '<') === FALSE)) {
+    if (isset($array['#markup']) && (!$this->formatWhitespace || !str_contains($array['#markup'], '<'))) {
       $buf .= '>' . $array['#markup'] . '</' . $tag . '>';
     }
     elseif (isset($array['#markup'])) {
@@ -141,7 +141,7 @@ class CRM_Afform_ArrayHtml {
     else {
       $contents = $this->convertArraysToHtml($children);
       // No indentation if contents are only text
-      if (!$this->formatWhitespace || strpos($contents, '<') === FALSE) {
+      if (!$this->formatWhitespace || !str_contains($contents, '<')) {
         $buf .= '>' . $contents;
       }
       else {

--- a/ext/afform/core/Civi/Afform/AngularDependencyMapper.php
+++ b/ext/afform/core/Civi/Afform/AngularDependencyMapper.php
@@ -55,10 +55,10 @@ class AngularDependencyMapper {
         continue;
       }
       foreach ($angularModules[$module]['exports'] as $symbolName => $symbolTypes) {
-        if (strpos($symbolTypes, 'A') !== FALSE) {
+        if (str_contains($symbolTypes, 'A')) {
           $revMap['attr'][$symbolName] = $module;
         }
-        if (strpos($symbolTypes, 'E') !== FALSE) {
+        if (str_contains($symbolTypes, 'E')) {
           $revMap['el'][$symbolName] = $module;
         }
       }

--- a/ext/afform/core/Civi/Afform/PageTokenCredential.php
+++ b/ext/afform/core/Civi/Afform/PageTokenCredential.php
@@ -110,7 +110,7 @@ class PageTokenCredential extends AutoService implements EventSubscriberInterfac
         }
       }
       catch (CryptoException $e) {
-        if (strpos($e->getMessage(), 'Expired token') !== FALSE) {
+        if (str_contains($e->getMessage(), 'Expired token')) {
           $check->reject('Expired token');
         }
 

--- a/ext/afform/core/Civi/Afform/Symbols.php
+++ b/ext/afform/core/Civi/Afform/Symbols.php
@@ -85,7 +85,7 @@ class Symbols {
     if ($expr === '' || $expr === NULL || $expr === FALSE) {
       return [];
     }
-    if (strpos($expr, '{{') === FALSE) {
+    if (!str_contains($expr, '{{')) {
       return explode(' ', $expr);
     }
     if (preg_match_all(';([a-zA-Z\-_]+|\{\{.*\}\}) ;U', "$expr ", $m)) {

--- a/ext/authx/Civi/Authx/CheckCredential.php
+++ b/ext/authx/Civi/Authx/CheckCredential.php
@@ -109,7 +109,7 @@ class CheckCredential extends AutoService implements EventSubscriberInterface {
       }
       catch (CryptoException $e) {
         // TODO: Is responding that its expired a security risk?
-        if (strpos($e->getMessage(), 'Expired token') !== FALSE) {
+        if (str_contains($e->getMessage(), 'Expired token')) {
           $check->reject('Expired token');
         }
 

--- a/ext/flexmailer/src/Listener/DefaultSender.php
+++ b/ext/flexmailer/src/Listener/DefaultSender.php
@@ -165,7 +165,7 @@ class DefaultSender extends AutoService {
     // SMTP response code is buried in the message.
     $code = preg_match('/ \(code: (.+), response: /', $message, $matches) ? $matches[1] : '';
 
-    if (strpos($message, 'Failed to write to socket') !== FALSE) {
+    if (str_contains($message, 'Failed to write to socket')) {
       return TRUE;
     }
 

--- a/ext/flexmailer/src/MailParams.php
+++ b/ext/flexmailer/src/MailParams.php
@@ -50,7 +50,7 @@ class MailParams {
     // 1. Consolidate: 'toName' and 'toEmail' should be 'To'.
     $toName = trim($mailParams['toName']);
     $toEmail = trim($mailParams['toEmail']);
-    if ($toName == $toEmail || strpos($toName, '@') !== FALSE) {
+    if ($toName == $toEmail || str_contains($toName, '@')) {
       $toName = NULL;
     }
     else {

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/MultipleValues.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/MultipleValues.php
@@ -223,7 +223,7 @@ contact_a.sort_name    as sort_name,
     $params = [];
     $name = $this->_formValues['sort_name'] ?? NULL;
     if ($name != NULL) {
-      if (strpos($name, '%') === FALSE) {
+      if (!str_contains($name, '%')) {
         $name = "%{$name}%";
       }
       $params[$count] = [$name, 'String'];

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Sample.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Sample.php
@@ -149,7 +149,7 @@ LEFT JOIN civicrm_state_province state_province ON state_province.id = address.s
     $clause = [];
     $name = $this->_formValues['household_name'] ?? NULL;
     if ($name != NULL) {
-      if (strpos($name, '%') === FALSE) {
+      if (!str_contains($name, '%')) {
         $name = "%{$name}%";
       }
       $params[$count] = [$name, 'String'];

--- a/ext/legacycustomsearches/CRM/Utils/QueryFormatter.php
+++ b/ext/legacycustomsearches/CRM/Utils/QueryFormatter.php
@@ -174,7 +174,7 @@ class CRM_Utils_QueryFormatter {
 
     $strtolower = function_exists('mb_strtolower') ? 'mb_strtolower' : 'strtolower';
 
-    if (strpos($table, ' ') === FALSE) {
+    if (!str_contains($table, ' ')) {
       $tableName = $tableAlias = $table;
     }
     else {
@@ -232,7 +232,7 @@ class CRM_Utils_QueryFormatter {
     if (empty($text)) {
       $result = '*';
     }
-    elseif (strpos($text, '*') !== FALSE) {
+    elseif (str_contains($text, '*')) {
       // if user supplies their own wildcards, then don't do any sophisticated changes
       $result = $text;
     }
@@ -297,11 +297,11 @@ class CRM_Utils_QueryFormatter {
     if (empty($text)) {
       $result = '*';
     }
-    elseif (strpos($text, '+') !== FALSE || strpos($text, '-') !== FALSE) {
+    elseif (str_contains($text, '+') || str_contains($text, '-')) {
       // if user supplies their own include/exclude operators, use text as is (with trailing wildcard)
       $result = $this->mapWords($text, 'word*');
     }
-    elseif (strpos($text, '*') !== FALSE) {
+    elseif (str_contains($text, '*')) {
       // if user supplies their own wildcards, then don't do any sophisticated changes
       $result = $this->mapWords($text, '+word');
     }
@@ -353,7 +353,7 @@ class CRM_Utils_QueryFormatter {
     if (empty($text)) {
       $result = '%';
     }
-    elseif (strpos($text, '%') !== FALSE) {
+    elseif (str_contains($text, '%')) {
       // if user supplies their own wildcards, then don't do any sophisticated changes
       $result = $text;
     }
@@ -435,7 +435,7 @@ class CRM_Utils_QueryFormatter {
     }
 
     // don't use preg_replace because $wildcard might be special char
-    while (strpos($text, "{$wildcard}{$wildcard}") !== FALSE) {
+    while (str_contains($text, "{$wildcard}{$wildcard}")) {
       $text = str_replace("{$wildcard}{$wildcard}", "{$wildcard}", $text);
     }
     return $text;

--- a/ext/legacycustomsearches/legacycustomsearches.php
+++ b/ext/legacycustomsearches/legacycustomsearches.php
@@ -67,7 +67,7 @@ function legacycustomsearches_civicrm_buildGroupContactCache(array $savedSearch,
   }
   $searchSQL = CRM_Contact_BAO_SearchCustom::customClass($ssParams['customSearchID'], $savedSearchID)->contactIDs();
   $searchSQL = str_replace('ORDER BY contact_a.id ASC', '', $searchSQL);
-  if (strpos($searchSQL, 'WHERE') === FALSE) {
+  if (!str_contains($searchSQL, 'WHERE')) {
     $searchSQL .= " WHERE contact_a.id $excludeClause";
   }
   else {

--- a/ext/oauth-client/Civi/OAuth/CiviGenericProvider.php
+++ b/ext/oauth-client/Civi/OAuth/CiviGenericProvider.php
@@ -69,7 +69,7 @@ class CiviGenericProvider extends \League\OAuth2\Client\Provider\GenericProvider
    * @return string
    */
   private function replaceTenantToken($str) {
-    if (strpos($str, '{{tenant}}') !== FALSE) {
+    if (str_contains($str, '{{tenant}}')) {
       $tenant = !empty($this->tenant) ? $this->tenant : 'common';
       $str = str_replace('{{tenant}}', $tenant, $str);
     }

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -325,8 +325,8 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    * @return string
    */
   protected function rewrite(string $rewrite, array $data, string $format = 'view'): string {
-    // Cheap strpos to skip Smarty processing if not needed
-    $hasSmarty = strpos($rewrite, '{') !== FALSE;
+    // Cheap str_contains to skip Smarty processing if not needed
+    $hasSmarty = str_contains($rewrite, '{');
     $output = $this->replaceTokens($rewrite, $data, $format);
     if ($hasSmarty) {
       $vars = [];
@@ -995,7 +995,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    * @return string
    */
   private function getUrl(string $path, $query = NULL) {
-    if ($path[0] === '/' || strpos($path, 'http://') !== FALSE || strpos($path, 'https://') !== FALSE) {
+    if ($path[0] === '/' || str_contains($path, 'http://') || str_contains($path, 'https://')) {
       return $path;
     }
     // Use absolute urls when downloading spreadsheet
@@ -1831,7 +1831,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
   private function getWhereClauseValues(): array {
     $values = [];
     foreach ($this->_apiParams['where'] as $clause) {
-      if (count($clause) > 2 && $clause[1] === '=' && empty($clause[3]) && strpos('(', $clause[0]) === FALSE) {
+      if (count($clause) > 2 && $clause[1] === '=' && empty($clause[3]) && !str_contains('(', $clause[0])) {
         $values[$clause[0]] = $clause[2];
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
General refactor - updates code to use preferred newer PHP function.

Technical Details
----------------------------------------
Before/after functionality is the same, but `str_contains` is preferred for readability.