### PR TITLE
[REF] CRM/Contribute - Use str_contains instead of strpos

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1767,7 +1767,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
       if ($dao->contribution_id &&
         $dao->is_pay_later &&
         $dao->contribution_status_id == $pendingStatusId &&
-        strpos($dao->source, $source) !== FALSE
+        str_contains($dao->source, $source)
       ) {
         $contributionId = $dao->contribution_id;
       }

--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -219,7 +219,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
       case 'contribution_trxn_id':
       case 'contribution_check_number':
       case 'contribution_contact_id':
-      case (strpos($name, '_amount') !== FALSE):
+      case (str_contains($name, '_amount')):
       case 'contribution_campaign_id':
 
         $fieldNamesNotToStripContributionFrom = [

--- a/CRM/Contribute/Form/Task/Status.php
+++ b/CRM/Contribute/Form/Task/Status.php
@@ -156,7 +156,7 @@ AND    co.id IN ( $contribIDs )";
   public static function formRule($fields) {
     $seen = $errors = [];
     foreach ($fields as $name => $value) {
-      if (strpos($name, 'trxn_id_') !== FALSE) {
+      if (str_contains($name, 'trxn_id_')) {
         if ($fields[$name]) {
           if (array_key_exists($value, $seen)) {
             $errors[$name] = ts('Transaction ID\'s must be unique. Include the account number for checks.');
@@ -165,7 +165,7 @@ AND    co.id IN ( $contribIDs )";
         }
       }
 
-      if ((strpos($name, 'check_number_') !== FALSE) && $value) {
+      if ((str_contains($name, 'check_number_')) && $value) {
         $contribID = substr($name, 13);
 
         if ($fields["payment_instrument_id_{$contribID}"] != CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check')) {

--- a/CRM/Contribute/Page/ContributionPage.php
+++ b/CRM/Contribute/Page/ContributionPage.php
@@ -583,7 +583,7 @@ ORDER BY is_active desc, title asc
 
     if ($title) {
       $clauses[] = "title LIKE %1";
-      if (strpos($title, '%') !== FALSE) {
+      if (str_contains($title, '%')) {
         $params[1] = [trim($title), 'String', FALSE];
       }
       else {


### PR DESCRIPTION
Overview
----------------------------------------
General refactor - updates code to use preferred newer PHP function.

Technical Details
----------------------------------------
Before/after functionality is the same, but `str_contains` is preferred for readability.