### PR TITLE
[REF] CRM/Mailing - Use str_contains instead of strpos

### DIFF
--- a/CRM/Mailing/BAO/MailingTrackableURL.php
+++ b/CRM/Mailing/BAO/MailingTrackableURL.php
@@ -31,7 +31,7 @@ class CRM_Mailing_BAO_MailingTrackableURL extends CRM_Mailing_DAO_MailingTrackab
    *   The redirect/tracking url
    */
   public static function getTrackerURL($url, $mailing_id, $queue_id) {
-    if (strpos($url, '{') !== FALSE) {
+    if (str_contains($url, '{')) {
       return self::getTrackerURLForUrlWithTokens($url, $mailing_id, $queue_id);
     }
     else {
@@ -108,7 +108,7 @@ class CRM_Mailing_BAO_MailingTrackableURL extends CRM_Mailing_DAO_MailingTrackab
     }
 
     // If we have a token in the URL + path section, we can't tokenise.
-    if (strpos($parsed[1], '{') !== FALSE) {
+    if (str_contains($parsed[1], '{')) {
       return $url;
     }
 
@@ -122,7 +122,7 @@ class CRM_Mailing_BAO_MailingTrackableURL extends CRM_Mailing_DAO_MailingTrackab
 
       // Separate the tokenised from the static parts.
       foreach ($query_key_value_pairs as $_) {
-        if (strpos($_, '{') === FALSE) {
+        if (!str_contains($_, '{')) {
           $static_params[] = $_;
         }
         else {

--- a/CRM/Mailing/Page/Browse.php
+++ b/CRM/Mailing/Page/Browse.php
@@ -314,7 +314,7 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
     $title = $this->get('mailing_name');
     if ($title) {
       $clauses[] = 'name LIKE %1';
-      if (strpos($title, '%') !== FALSE) {
+      if (str_contains($title, '%')) {
         $params[1] = [$title, 'String', FALSE];
       }
       else {

--- a/CRM/Mailing/Page/View.php
+++ b/CRM/Mailing/Page/View.php
@@ -138,7 +138,7 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
     if (!empty($mailing['body_html']) && empty($_GET['text'])) {
       $header = 'text/html; charset=utf-8';
       $content = $mailing['body_html'];
-      if (strpos($content, '<head>') === FALSE && strpos($content, '<title>') === FALSE) {
+      if (!str_contains($content, '<head>') && !str_contains($content, '<title>')) {
         $title = '<head><title>' . $mailing['subject'] . '</title></head>';
       }
     }

--- a/CRM/Mailing/Selector/Browse.php
+++ b/CRM/Mailing/Selector/Browse.php
@@ -502,7 +502,7 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
     $title = $this->_parent->get('mailing_name');
     if ($title) {
       $clauses[] = 'name LIKE %1';
-      if (strpos($title, '%') !== FALSE) {
+      if (str_contains($title, '%')) {
         $params[1] = [$title, 'String', FALSE];
       }
       else {


### PR DESCRIPTION
Overview
----------------------------------------
General refactor - updates code to use preferred newer PHP function.

Technical Details
----------------------------------------
Before/after functionality is the same, but `str_contains` is preferred for readability.