### PR TITLE
[REF] CRM/Export - Use str_contains instead of strpos

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -840,7 +840,7 @@ class CRM_Export_BAO_ExportProcessor {
       // always add contact_a.id to the ORDER clause
       // so the order is deterministic
       //CRM-15301
-      if (strpos('contact_a.id', $order) === FALSE) {
+      if (!str_contains('contact_a.id', $order)) {
         $order .= ", contact_a.id";
       }
 

--- a/CRM/Export/Controller/Standalone.php
+++ b/CRM/Export/Controller/Standalone.php
@@ -72,7 +72,7 @@ class CRM_Export_Controller_Standalone extends CRM_Core_Controller {
     $className = 'CRM_' . $this->getComponent($this->get('entity')) . '_Task';
     foreach ($className::tasks() as $taskId => $task) {
       $taskForm = (array) $task['class'];
-      if (strpos($taskForm[0], '_Export_Form_Select') !== FALSE) {
+      if (str_contains($taskForm[0], '_Export_Form_Select')) {
         $values['task'] = $taskId;
       }
     }

--- a/CRM/Import/DataSource/SQL.php
+++ b/CRM/Import/DataSource/SQL.php
@@ -87,7 +87,7 @@ class CRM_Import_DataSource_SQL extends CRM_Import_DataSource {
 
     $columnNames = [];
     while ($columnsResult->fetch()) {
-      if (strpos($columnsResult->Field, ' ') !== FALSE) {
+      if (str_contains($columnsResult->Field, ' ')) {
         // Remove spaces as the Database object does this
         // $keys = str_replace(array(".", " "), "_", array_keys($array));
         // https://lab.civicrm.org/dev/core/-/issues/1337


### PR DESCRIPTION
Overview
----------------------------------------
General refactor - updates code to use preferred newer PHP function.

Technical Details
----------------------------------------
Before/after functionality is the same, but `str_contains` is preferred for readability.