### PR TITLE
Add icons to CiviCRM menu

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -912,6 +912,7 @@ ORDER BY weight";
             'label' => ts('CiviCRM Home'),
             'name' => 'CiviCRM Home',
             'url' => 'civicrm/dashboard?reset=1',
+            'icon' => 'crm-i fa-house-user',
             'weight' => 1,
           ],
         ];
@@ -921,6 +922,7 @@ ORDER BY weight";
               'label' => ts('Hide Menu'),
               'name' => 'Hide Menu',
               'url' => '#hidemenu',
+              'icon' => 'crm-i fa-minus',
               'weight' => 2,
             ],
           ];
@@ -931,6 +933,7 @@ ORDER BY weight";
               'label' => ts('Change Password'),
               'name' => 'Change Password',
               'url' => 'civicrm/admin/user/password',
+              'icon' => 'crm-i fa-keyboard',
               'weight' => 2,
             ],
           ];
@@ -940,6 +943,7 @@ ORDER BY weight";
             'label' => ts('Log out'),
             'name' => 'Log out',
             'url' => 'civicrm/logout?reset=1',
+            'icon' => 'crm-i fa-person-walking-arrow-right',
             'weight' => 3,
           ],
         ];


### PR DESCRIPTION
Overview
----------------------------------------
Adds some icons to the CIviCRM-logo menu

Before
----------------------------------------
No icons in CiviCRM-logo menu

After
----------------------------------------
![image](https://github.com/user-attachments/assets/8b0b3f25-ede5-4b3f-b0b5-593a3ef75d00)

