### PR TITLE
dev/core#5735 SearchKit - Fix displaying disabled relationship types

### DIFF
--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -872,10 +872,12 @@ WHERE  id = %1";
    *
    * @return array
    */
-  public static function relationshipTypeOptions() {
+  public static function relationshipTypeOptions($fieldName = NULL, $options = []) {
     $relationshipTypes = [];
-    $relationshipLabels = self::relationshipType();
-    foreach (self::relationshipType('name') as $id => $type) {
+    $onlyActive = empty($options['include_disabled']) ? 1 : NULL;
+    $relationshipLabels = self::relationshipType('label', FALSE, $onlyActive);
+    $relationshipNames = self::relationshipType('name', FALSE, $onlyActive);
+    foreach ($relationshipNames as $id => $type) {
       $relationshipTypes[$type['name_a_b']] = $relationshipLabels[$id]['label_a_b'];
       if ($type['name_b_a'] && $type['name_b_a'] != $type['name_a_b']) {
         $relationshipTypes[$type['name_b_a']] = $relationshipLabels[$id]['label_b_a'];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5735](https://lab.civicrm.org/dev/core/-/issues/5735)

Technical Details
------
Api4 is smart enough to show disabled options for view but not for create. But this doesn't work automatically when the pseudoconstant uses a callback function like this:
https://github.com/civicrm/civicrm-core/blob/59f71582761992e76e12b171a8f2b2b56d85d9ac/schema/Contact/RelationshipCache.entityType.php#L136-L138

The fix is to ensure the callback function respects the passed-in `$options['include_disabled']`.