### PR TITLE
Standalone - Respect include_disabled param in permission.getOptions

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -1321,12 +1321,12 @@ class CRM_Core_SelectValues {
    *
    * @return array
    */
-  public static function permissions() {
+  public static function permissions($fieldName = NULL, $params = []) {
     $perms = $options = [];
     \CRM_Utils_Hook::permissionList($perms);
 
     foreach ($perms as $machineName => $details) {
-      if (!empty($details['is_active'])) {
+      if (!empty($details['is_active']) || !empty($params['include_disabled'])) {
         $options[$machineName] = $details['title'];
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Improves pseudoconstant handling for Standalone role.permissions field.

Technical Details
----------------------------------------
This doesn't fix any known bugs, but just seems like a good idea for this param to be respected, as ignoring it has been known to cause bugs.

See, for example, https://github.com/civicrm/civicrm-core/pull/32166 for the type of bugs that can pop up when this param is ignored.