### PR TITLE
Support apiv4 in test functions individualCreate, organizationCreate,householdCreate

### DIFF
--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -766,17 +766,19 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
   public function testGetRowsElementsAndInfoSpecialInfo(): void {
     $contact1 = $this->individualCreate([
       'preferred_communication_method' => [],
-      'communication_style_id' => 'Familiar',
-      'prefix_id' => 'Mrs.',
-      'suffix_id' => 'III',
+      'communication_style_id:label' => 'Familiar',
+      'prefix_id:label' => 'Mrs.',
+      'suffix_id:label' => 'III',
+      'version' => 4,
     ]);
     $contact2 = $this->individualCreate([
-      'preferred_communication_method' => [
+      'preferred_communication_method:label' => [
         'SMS',
         'Fax',
       ],
-      'communication_style_id' => 'Formal',
-      'gender_id' => 'Female',
+      'communication_style_id:label' => 'Formal',
+      'gender_id:label' => 'Female',
+      'version' => 4,
     ]);
     $rowsElementsAndInfo = CRM_Dedupe_Merger::getRowsElementsAndInfo($contact1, $contact2);
     $rows = $rowsElementsAndInfo['rows'];

--- a/tests/phpunit/CRM/Mailing/MailingSystemTestBase.php
+++ b/tests/phpunit/CRM/Mailing/MailingSystemTestBase.php
@@ -474,8 +474,8 @@ abstract class CRM_Mailing_MailingSystemTestBase extends CiviUnitTestCase {
     }
   }
 
-  public function testModifyMailingReceipientsIgnoreOptOut(): void {
-    $optOutContact = $this->individualCreate(['is_opt_out' => 1, 'email' => 'testoptout@example.com'], 'opt_out_individual');
+  public function testModifyMailingRecipientsIgnoreOptOut(): void {
+    $optOutContact = $this->individualCreate(['is_opt_out' => 1, 'email_primary.email' => 'testoptout@example.com'], 'opt_out_individual');
     $this->callAPISuccess('GroupContact', 'create', [
       'contact_id' => $optOutContact,
       'group_id' => $this->_groupID,

--- a/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
@@ -124,7 +124,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
       'last_name' => 'Anderson',
       'prefix_id' => 3,
       'suffix_id' => 3,
-      'email' => 'b@c.com',
+      'email_primary.email' => 'b@c.com',
       'contact_type' => 'Individual',
     ];
 
@@ -140,7 +140,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
         date('Y-m-d'),
       ],
       [
-        $contact2Params['email'],
+        $contact2Params['email_primary.email'],
         self::MEMBERSHIP_TYPE_NAME,
         $startDate2,
         $joinDate2,


### PR DESCRIPTION


Overview
----------------------------------------
These functions are handy & ubiquitous but when you want to pass in apiv4 values it gets confusing real fast. 



Before
----------------------------------------
Requires apiv3 style

After
----------------------------------------
This fixes it to accept version=4 if passed in & to default to apiv4 is all the values passed in are easily recognized as apiv4 values.

Technical Details
----------------------------------------
Ideally we can migrate a bunch of places to use the apiv4 although deprecating the apiv3 might be noisy - that's for another day, removing friction on apiv4 is first

Comments
----------------------------------------
