### PR TITLE
RiverLea 1.3.7: code block, api3 select2 legibility & version numbering

### DIFF
--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -1,4 +1,9 @@
-1.3.6-6.1alpha
+1.3.7-6.0alpha
+ - FIXED - inline code/pre block issue. Also applied to keyboard elements. Override created for td > code. (#113)
+ - FIXED - API3 - illegible colours on Select2 description
+ - CHANGED - Version numbers on streams -> updated to latest.
+
+1.3.6-6.0alpha
  - FIXED - Responsive: make dashlets stack on Civi Dashboard under 990px (same as Greenwich)
  - FIXED - Show Add Address without hover on Contact Dashboard (#109)
  - FIXED - code/pre formatting is wrapping on one line (#108)

--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -334,8 +334,15 @@ dl dl {
 .crm-container h6 {
   color: var(--crm-c-text);
 }
-.crm-container code,
 .crm-container kbd,
+.crm-container code {
+  display: inline;
+  background-color: var(--crm-c-code-background);
+  border: 1px solid var(--crm-c-background4);
+  color: var(--crm-c-text);
+  border-radius: 2px;
+  padding: 2px;
+}
 .crm-container samp,
 .crm-container pre {
   display: block;
@@ -349,14 +356,15 @@ dl dl {
   border-radius: var(--crm-roundness);
 }
 .crm-container pre code {
+  display: block;
   padding: 0;
   font-size: inherit;
   color: inherit;
   background-color: transparent;
   border-radius: 0;
 }
-.crm-container p code {
-  display: inline-block;
+.crm-container td > code {
+  display: block;
 }
 .crm-container .pre-scrollable {
   max-height: 340px;

--- a/ext/riverlea/core/css/_core.css
+++ b/ext/riverlea/core/css/_core.css
@@ -4,5 +4,5 @@
    can be merged later. */
 
 @import url(components/_accordion.css); @import url(components/_alerts.css); @import url(components/_buttons.css); @import url(components/_form.css); @import url(components/_icons.css); @import url(components/_nav.css); @import url(components/_tabs.css); @import url(components/_dropdowns.css); @import url(components/_tables.css); @import url(components/_dialogs.css); @import url(components/_page.css); @import url(components/_components.css); @import url(components/_front.css); :root {
-  --crm-release: '1.3.6-6.1alpha';
+  --crm-release: '1.3.7-6.0alpha';
 }

--- a/ext/riverlea/core/css/_fixes.css
+++ b/ext/riverlea/core/css/_fixes.css
@@ -578,6 +578,11 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 }
 /* API3 explorer */
 
+.crm-container .select2-highlighted .api-field-desc,
+.crm-container .select2-highlighted .crm-marker,
+.crm-container .api-field-desc {
+  color: inherit;
+}
 #api-generated caption {
   font-weight: var(--crm-bold-weight);
   font-family: var(--crm-font-bold);

--- a/ext/riverlea/info.xml
+++ b/ext/riverlea/info.xml
@@ -12,7 +12,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>[civicrm.releaseDate]</releaseDate>
-  <version>1.3.6-[civicrm.version]</version>
+  <version>1.3.7-[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>

--- a/ext/riverlea/streams/empty/css/_variables.css
+++ b/ext/riverlea/streams/empty/css/_variables.css
@@ -1,7 +1,7 @@
 /*
     Name: Empty stream;
     Description: duplicate this to create a new stream;
-    Riverlea version: 1.1.0;
+    Riverlea version: 1.3.7;
 */
 
 :root {

--- a/ext/riverlea/streams/hackneybrook/css/_variables.css
+++ b/ext/riverlea/streams/hackneybrook/css/_variables.css
@@ -1,7 +1,7 @@
 /*
     Name: HackneyBrook;
     Description: named after the Hackney Brook, a tributary of the River Lea that ran through Finsbury Park;
-    Riverlea version: 1.1.0;
+    Riverlea version: 1.3.7;
 */
 
 :root {

--- a/ext/riverlea/streams/minetta/css/_variables.css
+++ b/ext/riverlea/streams/minetta/css/_variables.css
@@ -1,7 +1,7 @@
 /*
     Name: Minetta;
     Description: Generic CiviCRM UI, somewhat familiar to users of CiviCRM since 2014. Named after Minetta Creek, which runs under Greenwich, New York;
-    Riverlea version: 1.1.0;
+    Riverlea version: 1.3.7;
 */
 
 :root {

--- a/ext/riverlea/streams/thames/css/_variables.css
+++ b/ext/riverlea/streams/thames/css/_variables.css
@@ -1,7 +1,7 @@
 /*
     Name: Thames;
     Description: Aaaaah;
-    Riverlea version: 1.1.0;
+    Riverlea version: 1.3.7;
 
     I have added 'thames' to lines I changed.
     This means I can track changes to the core variables with diff.

--- a/ext/riverlea/streams/walbrook/css/_variables.css
+++ b/ext/riverlea/streams/walbrook/css/_variables.css
@@ -1,7 +1,7 @@
 /*
     Name: Walbrook;
     Description: Based on Shoreditch theme. Named after after River Walbrook, which runs under Shoreditch, London;
-    Riverlea version: 1.1.0;
+    Riverlea version: 1.3.7;
 */
 
 :root {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes two issues, and updates the version number in the metadata on all of the streams:
 - FIXED - inline code/pre block issue. Also applied to keyboard elements. Override created for td > code: https://lab.civicrm.org/extensions/riverlea/-/issues/113
 - FIXED - API3 - illegible colours on Select2 description
 - CHANGED - Version numbers on streams -> updated to latest.

Before
----------------------------------------
**API3 select list description**

![image](https://github.com/user-attachments/assets/03c4dd08-e5d7-4fcf-9e7d-9ec1fde60fe4)

After
----------------------------------------
**API3 select list description**

![image](https://github.com/user-attachments/assets/82e0e592-7a0c-45af-9209-a2f6a3a65abe)
![image](https://github.com/user-attachments/assets/8e53ca96-4f13-4575-ac8a-a2e91e1788de)

Comments
----------------------------------------
There's no visual change from reverting `<code>` tags to display inline as they should, rather than as blocks, this is more a consequence in extensions.