### PR TITLE
dev/core#5751 Broaden support for 'title' in permission metadata functions

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -611,6 +611,13 @@ class CRM_Core_Permission {
     $allPermissions = array_merge($permissions, $module_permissions);
     // Propagate implied_by permissions to their parents
     foreach ($allPermissions as $name => $permission) {
+      if (!empty($permission['label']) && empty($permission['title'])) {
+        // We have a mix of metadata historically - but have concluded we should
+        // migrate to title - hence ensuring it is present (but not removing label for
+        // backwards compatibility).
+        // dev/core#5751
+        $allPermissions[$name]['title'] = $permission['title'] = $permission['label'];
+      }
       foreach ($permission['implied_by'] ?? [] as $parent) {
         if (isset($allPermissions[$parent])) {
           $allPermissions[$parent]['implies'][] = $name;

--- a/CRM/Core/Permission/Base.php
+++ b/CRM/Core/Permission/Base.php
@@ -413,15 +413,18 @@ class CRM_Core_Permission_Base {
     CRM_Utils_Hook::permission($permissions);
 
     // Normalize permission array format.
-    // Historically, a string was acceptable (interpreted as label), as was a non-associative array.
+    // Historically, a string was acceptable (interpreted as title), as was a non-associative array.
     // Convert them all to associative arrays.
     foreach ($permissions as $name => $defn) {
       $defn = (array) $defn;
-      if (!isset($defn['label'])) {
-        CRM_Core_Error::deprecatedWarning("Permission '$name' should be declared with 'label' and 'description' keys. See https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/");
+      // We are consolidating on title rather than label for these - accept either as label
+      // was the historical one.
+      // dev/core#5751
+      if (!isset($defn['title']) && !isset($defn['label'])) {
+        CRM_Core_Error::deprecatedWarning("Permission '$name' should be declared with 'title' and 'description' keys. See https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/");
       }
       $permission = [
-        'label' => $defn['label'] ?? $defn[0],
+        'label' => $defn['title'] ?? $defn['label'] ?? $defn[0],
         'description' => $defn['description'] ?? $defn[1] ?? NULL,
         'disabled' => $defn['disabled'] ?? NULL,
         'implies' => $defn['implies'] ?? NULL,

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialTypeTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialTypeTest.php
@@ -54,6 +54,10 @@ class FinancialTypeTest extends BaseTestClass {
               1 => $action_ts,
               2 => $type,
             ]),
+            'title' => ts('CiviCRM: %1 contributions of type %2', [
+              1 => $action_ts,
+              2 => $type,
+            ]),
             'description' => ts('%1 contributions of type %2', [1 => $action_ts, 2 => $type]),
             'implied_by' => [ts('%1 contributions of all types', [1 => $action_ts])],
             'parent' => $action_ts . ' contributions of all types',
@@ -64,6 +68,7 @@ class FinancialTypeTest extends BaseTestClass {
     }
     $this->assertEquals([
       'label' => ts('CiviCRM: administer CiviCRM Financial Types'),
+      'title' => ts('CiviCRM: administer CiviCRM Financial Types'),
       'description' => ts('Administer access to Financial Types'),
     ], $permissions['administer CiviCRM Financial Types']);
   }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5751 Broaden support for 'title' in permission metadata functions

https://lab.civicrm.org/dev/core/-/issues/5751

Before
----------------------------------------
Some core metadata functions support label, some support title

After
----------------------------------------
moving the needle towards always supporting title - without removing any label support

Technical Details
----------------------------------------

Comments
----------------------------------------
