### PR TITLE
[REF] Ensure that ContactId is passed through on Mailing Event Emails…

### DIFF
--- a/CRM/Mailing/Event/BAO/MailingEventConfirm.php
+++ b/CRM/Mailing/Event/BAO/MailingEventConfirm.php
@@ -140,6 +140,7 @@ class CRM_Mailing_Event_BAO_MailingEventConfirm extends CRM_Mailing_Event_DAO_Ma
       'returnPath' => CRM_Core_BAO_Domain::getNoReplyEmailAddress(),
       'html' => $html,
       'text' => $text,
+      'contactId' => $contact_id,
     ];
     // send - ignore errors because the desired status change has already been successful
     CRM_Utils_Mail::send($mailParams);

--- a/CRM/Mailing/Event/BAO/MailingEventReply.php
+++ b/CRM/Mailing/Event/BAO/MailingEventReply.php
@@ -199,7 +199,8 @@ class CRM_Mailing_Event_BAO_MailingEventReply extends CRM_Mailing_Event_DAO_Mail
     $eq = CRM_Core_DAO::executeQuery(
       'SELECT
                   email.email as email,
-                  queue.hash as hash
+                  queue.hash as hash,
+                  queue.contact_id as contact_id
         FROM civicrm_contact contact
         INNER JOIN  civicrm_mailing_event_queue queue ON queue.contact_id = contact.id
         INNER JOIN  civicrm_email email ON queue.email_id = email.id
@@ -221,6 +222,7 @@ class CRM_Mailing_Event_BAO_MailingEventReply extends CRM_Mailing_Event_DAO_Mail
       'from' => "\"{$domainEmailName}\" <{$domainEmailAddress}>",
       'replyTo' => CRM_Core_BAO_Domain::getNoReplyEmailAddress(),
       'returnPath' => CRM_Core_BAO_Domain::getNoReplyEmailAddress(),
+      'contactId' => $eq->contact_id,
     ];
 
     $html = $component->body_html;

--- a/CRM/Mailing/Event/BAO/MailingEventResubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventResubscribe.php
@@ -252,6 +252,7 @@ class CRM_Mailing_Event_BAO_MailingEventResubscribe {
       'returnPath' => CRM_Core_BAO_Domain::getNoReplyEmailAddress(),
       'html' => $html,
       'text' => $text,
+      'contactId' => $eq->contact_id,
     ];
     CRM_Mailing_BAO_Mailing::addMessageIdHeader($params, 'e', NULL, $queue_id, $eq->hash);
     if (CRM_Core_BAO_MailSettings::includeMessageId()) {

--- a/CRM/Mailing/Event/BAO/MailingEventSubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventSubscribe.php
@@ -201,6 +201,7 @@ SELECT     civicrm_email.id as email_id
       'toEmail' => $email,
       'replyTo' => $confirm,
       'returnPath' => CRM_Core_BAO_Domain::getNoReplyEmailAddress(),
+      'contactId' => $this->contact_id,
     ];
 
     $url = CRM_Utils_System::url('civicrm/mailing/confirm',

--- a/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
@@ -385,6 +385,7 @@ WHERE  email = %2
       'returnPath' => CRM_Core_BAO_Domain::getNoReplyEmailAddress(),
       'html' => $html,
       'text' => $text,
+      'contactId' => $eq->contact_id,
     ];
     CRM_Mailing_BAO_Mailing::addMessageIdHeader($params, 'u', NULL, $queue_id, $eq->hash);
     if (CRM_Core_BAO_MailSettings::includeMessageId()) {


### PR DESCRIPTION
… to mailParams hook

Overview
----------------------------------------
This ensures that the contactId param is passed thought to the mailParams hooks when sending these automated emails

Before
----------------------------------------
contactId is not set on these automated emails

After
----------------------------------------
contactId param is set on these automated emails

ping @mattwire @eileenmcnaughton 