### PR TITLE
standalone error handler caused error

### DIFF
--- a/Civi/Standalone/ErrorHandler.php
+++ b/Civi/Standalone/ErrorHandler.php
@@ -47,7 +47,7 @@ class ErrorHandler {
             $_ = htmlspecialchars("$item[function]() ");
           }
         }
-        $_ .= "<code>" . htmlspecialchars($item['file']) . '</code> line ' . $item['line'];
+        $_ .= "<code>" . htmlspecialchars($item['file'] ?? '(internal)') . '</code> line ' . ($item['line'] ?? '(none)');
         $trace[] = $_;
       }
       $trace = '<pre class=backtrace>' . implode("\n", $trace) . '</pre>';
@@ -62,7 +62,7 @@ class ErrorHandler {
     . '</li>';
     \CRM_Core_Smarty::singleton()->assign('standaloneErrors', implode("\n", \Civi::$statics[__FUNCTION__]));
 
-    $handlingError = FALSE;
+    self::$handlingError = FALSE;
   }
 
 }


### PR DESCRIPTION
Before
----------------------------------------

The standalone error handler would

- cause an error due to `file` and `line` keys being missing in various frames of a `debug_backtrace` array.
- turn itself off after the first error due to updating the wrong variable that protects against infinite looping.

After
----------------------------------------

- missing keys guarded against; they are missing when the backtrace is in an internal callback, for example.
- corrected setting the infinite loop protection variable.



