### PR TITLE
Api4 - Fix sql renderer for contribution calculated fields

### DIFF
--- a/ext/civi_contribute/Civi/Api4/Service/Spec/Provider/ContributionGetSpecProvider.php
+++ b/ext/civi_contribute/Civi/Api4/Service/Spec/Provider/ContributionGetSpecProvider.php
@@ -12,6 +12,7 @@
 
 namespace Civi\Api4\Service\Spec\Provider;
 
+use Civi\Api4\Query\Api4SelectQuery;
 use Civi\Api4\Service\Spec\FieldSpec;
 use Civi\Api4\Service\Spec\RequestSpec;
 
@@ -35,6 +36,7 @@ class ContributionGetSpecProvider extends \Civi\Core\Service\AutoService impleme
       ->setType('Extra')
       ->setDataType('Money')
       ->setReadonly(TRUE)
+      ->setColumnName('id')
       ->setSqlRenderer([__CLASS__, 'calculateAmountPaid']);
     $spec->addFieldSpec($field);
     $field = new FieldSpec('balance_amount', 'Contribution', 'Float');
@@ -43,6 +45,7 @@ class ContributionGetSpecProvider extends \Civi\Core\Service\AutoService impleme
       ->setDescription(ts('Balance'))
       ->setType('Extra')
       ->setDataType('Money')
+      ->setColumnName('total_amount')
       ->setReadonly(TRUE)
       ->setSqlRenderer([__CLASS__, 'calculateBalance']);
     $spec->addFieldSpec($field);
@@ -53,6 +56,7 @@ class ContributionGetSpecProvider extends \Civi\Core\Service\AutoService impleme
       ->setType('Extra')
       ->setDataType('Money')
       ->setReadonly(TRUE)
+      ->setColumnName('total_amount')
       ->setSqlRenderer([__CLASS__, 'calculateTaxExclusiveAmount']);
     $spec->addFieldSpec($field);
   }
@@ -72,8 +76,9 @@ class ContributionGetSpecProvider extends \Civi\Core\Service\AutoService impleme
    *
    * @return string
    */
-  public static function calculateTaxExclusiveAmount(): string {
-    return 'COALESCE(a.total_amount, 0) - COALESCE(a.tax_amount, 0)';
+  public static function calculateTaxExclusiveAmount(array $totalAmountField, Api4SelectQuery $query): string {
+    $taxAmountField = $query->getFieldSibling($totalAmountField, 'tax_amount');
+    return "COALESCE({$totalAmountField['sql_name']}, 0) - COALESCE({$taxAmountField['sql_name']}, 0)";
   }
 
   /**
@@ -81,7 +86,7 @@ class ContributionGetSpecProvider extends \Civi\Core\Service\AutoService impleme
    *
    * @return string
    */
-  public static function calculateAmountPaid(): string {
+  public static function calculateAmountPaid(array $idField, Api4SelectQuery $query): string {
     $statusIDs = [
       \CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed'),
       \CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Refunded'),
@@ -89,7 +94,7 @@ class ContributionGetSpecProvider extends \Civi\Core\Service\AutoService impleme
 
     return "COALESCE((SELECT SUM(ft.total_amount) FROM civicrm_financial_trxn ft
       INNER JOIN civicrm_entity_financial_trxn eft ON (eft.financial_trxn_id = ft.id AND eft.entity_table = 'civicrm_contribution')
-      WHERE eft.entity_id = a.id AND ft.is_payment = 1 AND ft.status_id IN (" . implode(',', $statusIDs) . ')), 0)';
+      WHERE eft.entity_id = {$idField['sql_name']} AND ft.is_payment = 1 AND ft.status_id IN (" . implode(',', $statusIDs) . ')), 0)';
   }
 
   /**
@@ -97,15 +102,16 @@ class ContributionGetSpecProvider extends \Civi\Core\Service\AutoService impleme
    *
    * @return string
    */
-  public static function calculateBalance(): string {
+  public static function calculateBalance(array $totalAmountField, Api4SelectQuery $query): string {
     $statusIDs = [
       \CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed'),
       \CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Refunded'),
     ];
+    $idField = $query->getFieldSibling($totalAmountField, 'id');
 
-    return "a.total_amount - COALESCE((SELECT SUM(ft.total_amount) FROM civicrm_financial_trxn ft
+    return "{$totalAmountField['sql_name']} - COALESCE((SELECT SUM(ft.total_amount) FROM civicrm_financial_trxn ft
       INNER JOIN civicrm_entity_financial_trxn eft ON (eft.financial_trxn_id = ft.id AND eft.entity_table = 'civicrm_contribution')
-      WHERE eft.entity_id = a.id AND ft.is_payment = 1 AND ft.status_id IN (" . implode(',', $statusIDs) . ')), 0)';
+      WHERE eft.entity_id = {$idField['sql_name']} AND ft.is_payment = 1 AND ft.status_id IN (" . implode(',', $statusIDs) . ')), 0)';
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5687](https://lab.civicrm.org/dev/core/-/issues/5687)

Before
----------------------------------------
Calculated fields do not work as part of a join

After
----------------------------------------
Now they do

Technical Details
----------------------------------------
FYI @eileenmcnaughton this is how to avoid hard-coding the sql alias in these callback functions. This way the field will get the same table alias as whatever join it's part of.