### PR TITLE
When changing financial type via UI it uses a different date than via API

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3056,6 +3056,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
           $oldFinancialAccount = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship($params['prevContribution']->financial_type_id, $accountRelationship);
           $newFinancialAccount = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship($params['financial_type_id'], $accountRelationship);
           if ($oldFinancialAccount != $newFinancialAccount) {
+            $params['trxnParams']['trxn_date'] = date('YmdHis');
             $params['total_amount'] = 0;
             // If we have a fee amount set reverse this as well.
             if (isset($params['fee_amount'])) {


### PR DESCRIPTION
Overview
----------------------------------------
https://civicrm.stackexchange.com/questions/49213/financial-trxn-payment-details-contribution-update-behavior-differs-from-ui-v

Before
----------------------------------------
1. Change the financial type of a contribution in the UI.
2. In the payments section notice the journal entries use the original date not "today".
3. Change the financial type of a contribution via api.
4. In the payments section notice the journal entries use "today". This is more correct.

After
----------------------------------------
Both use "today".

Technical Details
----------------------------------------
This just seems like an oversight.

Comments
----------------------------------------
@JoeMurray @andyburnsco 
