### PR TITLE
CustomGroup - When deleting an entity, remove references from customGroupExtends

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -15,6 +15,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\Utils\CoreUtil;
+
 /**
  * Business object for managing custom data groups.
  */
@@ -24,8 +26,13 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
    * @param \Civi\Core\Event\PostEvent $e
    * @see CRM_Utils_Hook::post()
    */
-  public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $e): void {
-    Civi::cache('metadata')->clear();
+  public static function on_hook_civicrm_post(\Civi\Core\Event\PostEvent $e): void {
+    if ($e->entity === 'CustomGroup') {
+      Civi::cache('metadata')->clear();
+    }
+    elseif ($e->action === 'delete') {
+      self::onDeleteEntity($e->entity, (array) $e->object);
+    }
   }
 
   /**
@@ -1825,8 +1832,8 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
           $fkFields = civicrm_api4($field['entity'], 'getFields', [
             'checkPermissions' => FALSE,
           ])->indexBy('name');
-          $fkIdField = \Civi\Api4\Utils\CoreUtil::getIdFieldName($field['fk_entity']);
-          $fkLabelField = \Civi\Api4\Utils\CoreUtil::getInfoItem($field['fk_entity'], 'label_field');
+          $fkIdField = CoreUtil::getIdFieldName($field['fk_entity']);
+          $fkLabelField = CoreUtil::getInfoItem($field['fk_entity'], 'label_field');
           $fkNameField = isset($fkFields['name']) ? 'name' : 'id';
           $select = [$fkIdField, $fkNameField, $fkLabelField];
           $where = [];
@@ -2167,7 +2174,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
       ];
     }
     foreach ($options as &$option) {
-      $option['icon'] ??= \Civi\Api4\Utils\CoreUtil::getInfoItem($option['id'], 'icon');
+      $option['icon'] ??= CoreUtil::getInfoItem($option['id'], 'icon');
     }
     return $options;
   }
@@ -2280,6 +2287,100 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
       $permittedIds = CRM_Core_Permission::customGroup(CRM_Core_Permission::VIEW, FALSE, $hook->userId) ?: [0];
       $hook->clauses[$idField][] = 'IN (' . implode(', ', $permittedIds) . ')';
     }
+  }
+
+  /**
+   * When deleting an entity, remove any references from custom groups' extends_entity_column_value.
+   * If there are no references left, disable the custom group.
+   */
+  private static function onDeleteEntity(string $entityName, array $entityValues): void {
+    if (CoreUtil::isContact($entityName)) {
+      // There's no such thing as a custom field extending a specific contact
+      return;
+    }
+    // E.g. activity_type_id, event_type_id, etc.
+    if ($entityName === 'OptionValue' && !empty($entityValues['option_group_id'])) {
+      $mode = 'pseudoconstant';
+      $property = [
+        'option_group_name' => CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', $entityValues['option_group_id']),
+      ];
+    }
+    // E.g. event_id, financial_type_id, etc.
+    else {
+      $mode = 'entity_reference';
+      $property = [
+        'entity' => $entityName,
+      ];
+    }
+
+    $customEntityMap = self::getCustomEntityTypeMap();
+    foreach ($customEntityMap as $customEntity) {
+      // Go by table_name for the sake of contact types and complex entities with alternate tables
+      $field = Civi::table($customEntity['table_name'])->getField($customEntity['grouping']);
+      if (array_intersect_assoc($field[$mode] ?? [], $property)) {
+        $key = $mode === 'pseudoconstant' ? 'value' : 'id';
+        // This shouldn't happen, but some calls to hook_civicrm_post are weird.
+        if (empty($entityValues[$key])) {
+          return;
+        }
+        $customGroups = self::getAll([
+          'extends' => $customEntity['id'],
+          'extends_entity_column_value' => [$entityValues[$key]],
+          'extends_entity_column_id' => $customEntity['extends_entity_column_id'] ?? NULL,
+        ]);
+        foreach ($customGroups as $customGroup) {
+          $newExtendsEntityColumnValue = array_diff($customGroup['extends_entity_column_value'], [$entityValues[$key]]);
+          self::writeRecord([
+            'id' => $customGroup['id'],
+            'extends_entity_column_value' => $newExtendsEntityColumnValue,
+            // If the value is empty, disable the group; otherwise the empty set would be interpreted as "all".
+            'is_active' => !$newExtendsEntityColumnValue ? FALSE : $customGroup['is_active'],
+          ]);
+        }
+      }
+    }
+  }
+
+  /**
+   * Gets a combined map of extendsOptions and extendsEntityColumnIdOptions
+   *
+   * Currently this is only used for finding custom groups that reference a deleted entity
+   * @see self::onDeleteEntity()
+   *
+   * If needed for other purposes, the combining of the 2 maps could be a tad more complete
+   * (missing labels, confusing hijack of table_name, etc), so keeping private for now.
+   */
+  private static function getCustomEntityTypeMap(): array {
+    $customEntityMap = Civi::$statics[__CLASS__][__FUNCTION__] ?? NULL;
+    if ($customEntityMap !== NULL) {
+      return $customEntityMap;
+    }
+    $customEntityMap = self::getCustomGroupExtendsOptions();
+    // Remove any without a grouping
+    $customEntityMap = array_filter($customEntityMap, fn($customEntity) => !empty($customEntity['grouping']));
+    // Get complex entities (at time of writing, only applies to Participant)
+    $complexEntities = self::getExtendsEntityColumnIdOptions();
+    // Merge in complex entities
+    foreach ($complexEntities as $complexEntity) {
+      if ($complexEntity['grouping']) {
+        $entityName = $complexEntity['extends'];
+        $grouping = $complexEntity['grouping'];
+        // Grouping uses an FK like 'event_id.event_type_id'
+        if (str_contains($grouping, '.')) {
+          [$entityNameField, $grouping] = explode('.', $complexEntity['grouping']);
+          $entityName = Civi::entity($entityName)->getField($entityNameField)['entity_reference']['entity'];
+        }
+        $customEntityMap[] = [
+          'id' => $complexEntity['extends'],
+          'grouping' => $grouping,
+          // If grouping pointed to a different entity, table_name will point to the alternate entity
+          'table_name' => Civi::entity($entityName)->getMeta('table'),
+          'extends_entity_column_id' => $complexEntity['id'],
+        ];
+      }
+    }
+    Civi::$statics[__CLASS__][__FUNCTION__] = $customEntityMap;
+    return $customEntityMap;
   }
 
 }

--- a/tests/phpunit/api/v4/Custom/CustomGroupTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomGroupTest.php
@@ -21,6 +21,8 @@ namespace api\v4\Custom;
 
 use api\v4\Api4TestBase;
 use Civi\Api4\CustomGroup;
+use Civi\Api4\Event;
+use Civi\Api4\OptionValue;
 
 /**
  * @group headless
@@ -120,6 +122,68 @@ class CustomGroupTest extends Api4TestBase {
       ->execute()->single();
 
     $this->assertEquals($customField1['id'], $result['id']);
+  }
+
+  public function testWithDeletedActivityType(): void {
+    $ActivityTypes = $this->saveTestRecords('OptionValue', [
+      'records' => 2,
+      'defaults' => ['option_group_id:name' => 'activity_type'],
+    ]);
+    $customGroup = $this->createTestRecord('CustomGroup', [
+      'extends' => 'Activity',
+      'extends_entity_column_value' => $ActivityTypes->column('value'),
+    ]);
+
+    // Delete the first ActivityType
+    OptionValue::delete(FALSE)
+      ->addWhere('id', '=', $ActivityTypes[0]['id'])
+      ->execute();
+
+    // The ActivityType should be removed from the custom group
+    $customGroup = $this->getTestRecord('CustomGroup', $customGroup['id']);
+    $this->assertEquals([$ActivityTypes[1]['value']], $customGroup['extends_entity_column_value']);
+    $this->assertTrue($customGroup['is_active']);
+
+    // Delete the second
+    OptionValue::delete(FALSE)
+      ->addWhere('id', '=', $ActivityTypes[1]['id'])
+      ->execute();
+
+    // Custom group should now be disabled with no ActivityTypes
+    $customGroup = $this->getTestRecord('CustomGroup', $customGroup['id']);
+    $this->assertEmpty($customGroup['extends_entity_column_value']);
+    $this->assertFalse($customGroup['is_active']);
+  }
+
+  public function testWithDeletedEvent(): void {
+    $events = $this->saveTestRecords('Event', [
+      'records' => 3,
+    ]);
+    $customGroup = $this->createTestRecord('CustomGroup', [
+      'extends' => 'Participant',
+      'extends_entity_column_id:name' => 'ParticipantEventName',
+      'extends_entity_column_value' => $events->column('id'),
+    ]);
+
+    // Delete the first event
+    Event::delete(FALSE)
+      ->addWhere('id', '=', $events[0]['id'])
+      ->execute();
+
+    // The event should be removed from the custom group
+    $customGroup = $this->getTestRecord('CustomGroup', $customGroup['id']);
+    $this->assertEquals([$events[1]['id'], $events[2]['id']], $customGroup['extends_entity_column_value']);
+    $this->assertTrue($customGroup['is_active']);
+
+    // Delete the 2nd & 3rd
+    Event::delete(FALSE)
+      ->addWhere('id', 'IN', $events->column('id'))
+      ->execute();
+
+    // Custom group should now be disabled with no events
+    $customGroup = $this->getTestRecord('CustomGroup', $customGroup['id']);
+    $this->assertEmpty($customGroup['extends_entity_column_value']);
+    $this->assertFalse($customGroup['is_active']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5749](https://lab.civicrm.org/dev/core/-/issues/5749)

Technical Details
----------------------------------------
This essentially enforces cascading delete of foreign keys that are not "real" FKs in sql.

When deleting something that's the criteria for a custom group (e.g. an activity type, event type, event, financial type, etc) this will clean up stale references so the custom group no longer points to entities that don't exist.

If the deleted thing is the last reference, the custom group will be disabled, as otherwise the empty set would be interpreted as "all" (e.g. the custom group that only applied to one activity type will now apply to *all* of them, so better disable the custom group).