### PR TITLE
Fix failing test

### DIFF
--- a/ext/scheduled_communications/tests/phpunit/Civi/ScheduledCommunications/SendTest.php
+++ b/ext/scheduled_communications/tests/phpunit/Civi/ScheduledCommunications/SendTest.php
@@ -71,33 +71,39 @@ class SendTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface,
       'body_html' => '<p>Your birthday is tomorrow!</p>',
       'subject' => 'Happy birthday {contact.first_name}!',
     ]);
-    $this->assertCronRuns([
+    $yearToUse = date('Y') + 1;
+    $cronRuns = [
       [
         // No birthdays tomorrow
-        'time' => '2025-04-02 04:00:00',
+        'time' => $yearToUse . '-04-02 04:00:00',
         'to' => [],
         'subjects' => [],
       ],
       [
-        'time' => '2025-02-18 04:00:00',
+        'time' => $yearToUse . '-02-18 04:00:00',
         'to' => [["b@$lastName"]],
         'all_recipients' => ["b@$lastName;alt1@$lastName"],
         'subjects' => ['Happy birthday B!'],
       ],
       [
         // Upcoming birthday but contact is deceased
-        'time' => '2025-02-08 04:00:00',
+        'time' => $yearToUse . '-02-08 04:00:00',
         'to' => [],
         'subjects' => [],
       ],
-      [
+    ];
+    // We can only run this case if the current year is a leap year.
+    // CRM_Utils_Time doesn't change what mysql CURDATE returns, so it will fail.
+    if ((new \IntlGregorianCalendar())->isLeapYear(date('Y'))) {
+      $cronRuns[] = [
         // On a non-leap-year, birthday is the 28th
-        'time' => '2025-02-27 04:00:00',
+        'time' => $yearToUse . '-02-27 04:00:00',
         'to' => [["a@$lastName"], ["aa@$lastName"]],
         'all_recipients' => ["a@$lastName;alt1@$lastName", "aa@$lastName;alt1@$lastName"],
         'subjects' => ['Happy birthday A!', 'Happy birthday AA!'],
-      ],
-    ]);
+      ];
+    }
+    $this->assertCronRuns($cronRuns);
   }
 
   public function testAlternateRecipients():void {


### PR DESCRIPTION
Overview
----------------------------------------
The main thing is that CURDATE is not affected by CRM_Utils_Time.

Before
----------------------------------------
fail

After
----------------------------------------

Technical Details
----------------------------------------
Two of the tests are failing because CURDATE is always being evaluated in the real world, whereas the other dates are frozen by CRM_Utils_Time. This test was written last year so this is why it's failing now, as we've past the earliest birthday anniversary in the test.

Comments
----------------------------------------
There may be a better way to do this, but this solves it for now.

I stole the gregoriancalendar thing from another test, so it's already in use elsewhere.