### PR TITLE
UnitTests - Allow mocking date/time functions in sql

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -525,6 +525,9 @@ class CRM_Core_DAO extends DB_DataObject {
     if ($i18nRewrite and $dbLocale) {
       $query = CRM_Core_I18n_Schema::rewriteQuery($query);
     }
+    if (CIVICRM_UF === 'UnitTests' && CRM_Utils_Time::isOverridden()) {
+      $query = CRM_Utils_Time::rewriteQuery($query);
+    }
 
     $ret = parent::query($query);
 

--- a/CRM/Utils/Time.php
+++ b/CRM/Utils/Time.php
@@ -183,6 +183,10 @@ class CRM_Utils_Time {
     self::$callback = NULL;
   }
 
+  public static function isOverridden(): bool {
+    return isset(self::$callback);
+  }
+
   /**
    * Approximate time-comparison. $a and $b are considered equal if they
    * are within $threshold seconds of each other.
@@ -232,6 +236,37 @@ class CRM_Utils_Time {
       return $timeZoneOffset;
     }
     return NULL;
+  }
+
+  /**
+   * Rewrite a SQL query to use overridden date/time values for unit tests.
+   *
+   * @param string $query
+   *   The query to rewrite.
+   *
+   * @return string
+   *   The rewritten query with mocked time replacements.
+   */
+  public static function rewriteQuery(string $query): string {
+    // Replace date/time expressions with literal values.
+    $patterns = [
+      '/\bNOW\(\s*\)/' => '"' . self::date('Y-m-d H:i:s') . '"',
+      '/\bCURDATE\(\s*\)/' => '"' . self::date('Y-m-d') . '"',
+      '/\bCURTIME\(\s*\)/' => '"' . self::date('H:i:s') . '"',
+      '/\bCURRENT_DATE\b/' => '"' . self::date('Y-m-d') . '"',
+      '/\bCURRENT_TIME\b/' => '"' . self::date('H:i:s') . '"',
+      '/\bCURRENT_TIMESTAMP\b/' => '"' . self::date('Y-m-d H:i:s') . '"',
+      '/\bSYSDATE\(\)/' => '"' . self::date('Y-m-d H:i:s') . '"',
+      '/\bLOCALTIME\b/' => '"' . self::date('Y-m-d H:i:s') . '"',
+      '/\bLOCALTIMESTAMP\b/' => '"' . self::date('Y-m-d H:i:s') . '"',
+    ];
+
+    // Iterate over the patterns and replace matches in the query.
+    foreach ($patterns as $pattern => $replacement) {
+      $query = preg_replace($pattern, $replacement, $query);
+    }
+
+    return $query;
   }
 
 }

--- a/ext/scheduled_communications/tests/phpunit/Civi/ScheduledCommunications/SendTest.php
+++ b/ext/scheduled_communications/tests/phpunit/Civi/ScheduledCommunications/SendTest.php
@@ -29,6 +29,11 @@ class SendTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface,
     $this->mut = new \CiviMailUtils($this, TRUE);
   }
 
+  public function tearDown(): void {
+    \CRM_Utils_Time::resetTime();
+    parent::tearDown();
+  }
+
   public function setUpHeadless(): CiviEnvBuilder {
     return \Civi\Test::headless()
       ->installMe(__DIR__)

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -540,6 +540,7 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
    */
   protected function tearDown(): void {
     $this->_apiversion = 3;
+    CRM_Utils_Time::resetTime();
     $this->frozenTime = NULL;
 
     error_reporting(E_ALL & ~E_NOTICE);

--- a/tests/phpunit/api/v4/Api4TestBase.php
+++ b/tests/phpunit/api/v4/Api4TestBase.php
@@ -53,7 +53,9 @@ class Api4TestBase extends TestCase implements HeadlessInterface {
    */
   public function tearDown(): void {
     $this->conditionallyDeleteTestRecords();
+    \CRM_Utils_Time::resetTime();
     \CRM_Core_BAO_ConfigSetting::setEnabledComponents(\Civi::settings()->getDefault('enable_components'));
+    parent::tearDown();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
When a unit test overrides the system time, this will now propagate to sql queries as well.


Technical Details
----------------------------------------
Fixes `Civi\ScheduledCommunications\SendTest::testBirthdayMessage` by overriding not just date functions in php, but also in mySql.
