### PR TITLE
Fix financial type permissions when label doesn't match name

### DIFF
--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -236,16 +236,21 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType im
    *   (reference ) an array of financial types
    * @param int|string $action
    *   the type of action, can be add, view, edit, delete
-   * @param bool $resetCache
-   *   load values from static cache
+   * @param bool $unused
+   *   unused param but we can't get rid of it because of param order
    * @param bool $includeDisabled
    *   Whether we should load in disabled FinancialTypes or Not
    *
    * @return array
    */
-  public static function getAvailableFinancialTypes(&$financialTypes = NULL, $action = CRM_Core_Action::VIEW, $resetCache = FALSE, $includeDisabled = FALSE) {
+  public static function getAvailableFinancialTypes(&$financialTypes = NULL, $action = CRM_Core_Action::VIEW, $unused = FALSE, $includeDisabled = FALSE) {
     if (empty($financialTypes)) {
-      $financialTypes = CRM_Contribute_PseudoConstant::financialType(NULL, $includeDisabled);
+      $query = 'SELECT id, label FROM civicrm_financial_type';
+      if (!$includeDisabled) {
+        $query .= ' WHERE is_active = 1';
+      }
+      $financialTypeOptions = CRM_Core_DAO::executeQuery($query)->fetchAll();
+      $financialTypes = array_column($financialTypeOptions, 'label', 'id');
     }
     if (!self::isACLFinancialTypeStatus()) {
       return $financialTypes;

--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -283,12 +283,12 @@ function financialacls_civicrm_permission(&$permissions) {
       'description' => E::ts('%1 contributions of all types', [1 => $action_ts]),
     ];
   }
-  $financialTypes = \CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'validate', ['check_permissions' => FALSE]);
+  $financialTypes = CRM_Core_DAO::executeQuery('SELECT id, `name`, label FROM civicrm_financial_type')->fetchAll();
   foreach ($financialTypes as $type) {
     foreach ($actions as $action => $action_ts) {
-      $permissions[$action . ' contributions of type ' . $type] = [
-        'label' => E::ts("CiviCRM: %1 contributions of type %2", [1 => $action_ts, 2 => $type]),
-        'description' => E::ts('%1 contributions of type %2', [1 => $action_ts, 2 => $type]),
+      $permissions[$action . ' contributions of type ' . $type['name']] = [
+        'label' => E::ts("CiviCRM: %1 contributions of type %2", [1 => $action_ts, 2 => $type['label']]),
+        'description' => E::ts('%1 contributions of type %2', [1 => $action_ts, 2 => $type['label']]),
         'implied_by' => [$action . ' contributions of all types'],
       ];
     }
@@ -410,8 +410,7 @@ function financialacls_civicrm_fieldOptions($entity, $field, &$options, $params)
       $cacheKey = 'available_types_' . $context;
       if (!isset(\Civi::$statics['CRM_Financial_BAO_FinancialType'][$cacheKey])) {
         foreach ($options as $finTypeId => $option) {
-          // FIXME: Translated labels as names === very bad. See https://lab.civicrm.org/dev/core/-/issues/5419
-          $type = is_string($option) ? $option : $option['label'];
+          $type = is_string($option) ? $option : $option['name'];
           if (!CRM_Core_Permission::check($actions[$action] . ' contributions of type ' . $type)) {
             unset($options[$finTypeId]);
           }


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/5750.

We were generating permissions based off a (potentially translated) label.  That's not great, but when 5.79 was released, changing a label meant that the permission broke.

Before
----------------------------------------
Changing the label of a financial type broke its permission (we were generating permissions based on the label).

After
----------------------------------------
Changing the label doesn't affect the permission.

Comments
----------------------------------------
`getAvailableFinancialTypes()` is a straight refactor and should return the same results, but with much better performance for folks with hundreds of financial types.