### PR TITLE
dev/core#5732 Check watchdog function exists

### DIFF
--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -277,7 +277,7 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
    * @inheritDoc
    */
   public function logger($message, $priority = NULL) {
-    if (CRM_Core_Config::singleton()->userFrameworkLogging) {
+    if (CRM_Core_Config::singleton()->userFrameworkLogging && function_exists('watchdog')) {
       watchdog('civicrm', '%message', ['%message' => $message], $priority ?? WATCHDOG_DEBUG);
     }
   }


### PR DESCRIPTION
[port ](https://github.com/civicrm/civicrm-core/pull/32181)


This check was removed in https://github.com/civicrm/civicrm-core/pull/25573

However, it seems still reachable in Drupal7 from the old extern/AuthorizeNet.ipn file withou a full drupal initialisation

This path is only used for recurrings that started until a VERY early Civi version
