### PR TITLE
dev/core#5717 Loosen type hinting on getProfileDisplay

### DIFF
--- a/CRM/Core/WorkflowMessage/ProfileTrait.php
+++ b/CRM/Core/WorkflowMessage/ProfileTrait.php
@@ -89,7 +89,7 @@ trait CRM_Core_WorkflowMessage_ProfileTrait {
             $profile['participant_id'] = $this->getParticipantID();
             try {
               $fields = CRM_Event_BAO_Event::getProfileDisplay([$profile['id']],
-                $this->getParticipant()['contact_id'] ?? 0,
+                $this->getParticipant()['contact_id'] ?? NULL,
                 $this->getParticipantID(),
                 $this->getNote(),
               );
@@ -111,7 +111,7 @@ trait CRM_Core_WorkflowMessage_ProfileTrait {
                 }
                 try {
                   $fields = CRM_Event_BAO_Event::getProfileDisplay([$profile['id']],
-                    $participant['contact']['id'],
+                    $participant['contact']['id'] ?? NULL,
                     $participant['id'],
                     $this->getNote()
                   );

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -2270,7 +2270,7 @@ WHERE  ce.loc_block_id = $locBlockId";
    * @throws \CRM_Core_Exception
    * @throws \Civi\Core\Exception\DBQueryException
    */
-  public static function getProfileDisplay(array $profileIds, int $cid, int $participantId, ?string $note = NULL, ?array $groups = NULL, bool $isTest = FALSE): ?array {
+  public static function getProfileDisplay(array $profileIds, ?int $cid, int $participantId, ?string $note = NULL, ?array $groups = NULL, bool $isTest = FALSE): ?array {
     foreach ($profileIds as $gid) {
       if (CRM_Core_BAO_UFGroup::filterUFGroups($gid, $cid)) {
         $values = [];


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5717 Loosen type hinting on getProfileDisplay

Before
----------------------------------------
Fatal error (e.g in message preview) when the value is NULL

After
----------------------------------------
Type hint loosened

Technical Details
----------------------------------------
It's apparent from the 2 callers to this function that NULL is a legitimate value & it is clearer to pass NULL when NULL than to cast to 0.

The next stuff that goes on is a bit weird but I don't think this changes it - it just fixes the regression

Comments
----------------------------------------
