### PR TITLE
Fix token labels for custom fields with colons in their labels

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -661,7 +661,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
       // the space open for that.
       // Not the existing QuickForm widget has handling for the custom field
       // format based on the title using this syntax.
-      $parts = explode(': ', $field['label']);
+      $parts = explode(': ', $field['label'], 2);
       $field['title'] = "{$parts[1]} :: {$parts[0]}";
       $tokenName = 'custom_' . $field['custom_field_id'];
       $tokensMetadata[$tokenName] = $field;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes token labels being incomplete for custom fields with colons in their labels. 

Example: the 'Useful Info' group has a field called 'Life Cycle: Status'. Its token name appears as 'Useful Info :: Life Cycle'

Before
----------------------------------------
The label was split into an array based on colons. Then only the first two elements were used.

After
----------------------------------------
Token label is 'Useful Info :: Life Cycle :: Status'

Uses all relevant elements. This only affects the label, and not the {contact.custom_3033} syntax, so should be safe I think