### PR TITLE
Update Membership import to use apiv4

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1127,6 +1127,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     // See https://lab.civicrm.org/dev/core/-/issues/4317#note_91322 - a further hack for quickform not
     // handling dots in field names. One day we will get rid of the Quick form screen...
     $fieldMapName = str_replace('~~', '_.', $fieldMapName);
+    if (isset($this->baseEntity) && str_starts_with($fieldMapName, strtolower($this->baseEntity) . '.')) {
+      $fieldMapName = str_replace(strtolower($this->baseEntity) . '.', '', $fieldMapName);
+    }
     // This whole business of only loading metadata for one type when we actually need it for all is ... dubious.
     if (empty($this->getImportableFieldsMetadata()[$fieldMapName])) {
       if ($loadOptions || !$limitToContactType) {
@@ -1288,7 +1291,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     if ($value === 'invalid_import_value') {
       if (!is_numeric($key)) {
         $metadata = $this->getFieldMetadata($key);
-        $errors[] = $prefixString . ($metadata['html']['label'] ?? $metadata['title']);
+        $errors[] = $prefixString . ($metadata['label'] ?? $metadata['html']['label'] ?? $metadata['title']);
       }
       else {
         // Numeric key suggests we are drilling into option values

--- a/CRM/Member/Import/Form/MapField.php
+++ b/CRM/Member/Import/Form/MapField.php
@@ -30,6 +30,17 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
     $this->addFormRule(['CRM_Member_Import_Form_MapField', 'formRule'], $this);
 
     $options = $this->getFieldOptions();
+    // Suppress non-match contact fields at the QuickForm layer as
+    // their use will only be on the angular layer.
+    foreach ($options as &$option) {
+      if ($option['is_contact']) {
+        foreach ($option['children'] as $index => $contactField) {
+          if (empty($contactField['match_rule'])) {
+            unset($option['children'][$index]);
+          }
+        }
+      }
+    }
     foreach ($this->getColumnHeaders() as $i => $columnHeader) {
       $this->add('select2', "mapper[$i]", ts('Mapper for Field %1', [1 => $i]), $options, FALSE, ['class' => 'big', 'placeholder' => ts('- do not import -')]);
     }

--- a/CRM/Member/Import/Form/MapField.php
+++ b/CRM/Member/Import/Form/MapField.php
@@ -38,6 +38,23 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
           if (empty($contactField['match_rule'])) {
             unset($option['children'][$index]);
           }
+          if ($contactField['id'] === 'contact_id') {
+            $option['children'][$index]['id'] = 'membership__contact_id';
+          }
+        }
+      }
+      else {
+        foreach ($option['children'] as $index => $membershipField) {
+          // Swap out dots for double underscores so as not to break the quick form js.
+          // We swap this back on postProcess.
+          // Arg - we need to swap out _. first as it seems some groups end in a trailing underscore,
+          // which is indistinguishable to convert back - ie ___ could be _. or ._.
+          // https://lab.civicrm.org/dev/core/-/issues/4317#note_91322
+          $name = $membershipField['id'];
+          $name = str_replace('_.', '~~', $name);
+          $name = str_replace('.', '__', $name);
+          $name = 'membership__' . $name;
+          $option['children'][$index]['id'] = $name;
         }
       }
     }
@@ -69,16 +86,16 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
     $parser = $self->getParser();
     $rule = $parser->getDedupeRule($self->getContactType(), $self->getUserJob()['metadata']['entity_configuration']['Contact']['dedupe_rule'] ?? NULL);
-    $errors = $self->validateContactFields($rule, $importKeys, ['external_identifier', 'membership_contact_id', 'contact__id']);
+    $errors = $self->validateContactFields($rule, $importKeys, ['external_identifier', 'membership.contact_id', 'contact_id']);
 
-    if (!in_array('membership_id', $fields['mapper'])) {
+    if (!in_array('membership.id', $fields['mapper']) && !in_array('membership__id', $fields['mapper'])) {
       // FIXME: should use the schema titles, not redeclare them
       $requiredFields = [
-        'membership_type_id' => ts('Membership Type'),
-        'membership_start_date' => ts('Membership Start Date'),
+        'membership.membership_type_id' => ts('Membership Type'),
+        'membership.start_date' => ts('Membership Start Date'),
       ];
       foreach ($requiredFields as $field => $title) {
-        if (!in_array($field, $fields['mapper'])) {
+        if (!in_array($field, $fields['mapper']) && !in_array(str_replace('membership.', 'membership__', $field), $fields['mapper'])) {
           if (!isset($errors['_qf_default'])) {
             $errors['_qf_default'] = '';
           }
@@ -131,8 +148,8 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
     //membership id is required.
     if ($this->getSubmittedValue('onDuplicate') == CRM_Import_Parser::DUPLICATE_UPDATE) {
       $remove = [
-        'membership_contact_id',
-        'email_primary.email',
+        'membership__contact_id',
+        'email_primary__email',
         'first_name',
         'last_name',
         'external_identifier',
@@ -141,9 +158,9 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
         unset($this->_mapperFields[$value]);
       }
       $highlightedFieldsArray = [
-        'membership_id',
-        'membership_start_date',
-        'membership_type_id',
+        'membership__id',
+        'membership__start_date',
+        'membership__membership_type_id',
       ];
       foreach ($highlightedFieldsArray as $name) {
         $highlightedFields[] = $name;
@@ -152,11 +169,11 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
     elseif ($this->getSubmittedValue('onDuplicate') == CRM_Import_Parser::DUPLICATE_SKIP) {
       unset($this->_mapperFields['membership_id']);
       $highlightedFieldsArray = [
-        'membership_contact_id',
-        'email_primary.email',
+        'membership__contact_id',
+        'email_primary__email',
         'external_identifier',
-        'membership_start_date',
-        'membership_type_id',
+        'membership__start_date',
+        'membership__membership_type_id',
       ];
       foreach ($highlightedFieldsArray as $name) {
         $highlightedFields[] = $name;

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -14,6 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
+use Civi\Api4\Membership;
 
 /**
  * class to parse membership csv files
@@ -26,6 +27,8 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
    * @var array
    */
   protected $fieldMetadata = [];
+
+  protected string $baseEntity = 'Membership';
 
   /**
    * Has this parser been fixed to expect `getMappedRow` to break it up
@@ -166,12 +169,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
       $formatted = $formatValues = $membershipParams;
       // don't add to recent items, CRM-4399
       $formatted['skipRecentView'] = TRUE;
-      if (!$this->isUpdateExisting()) {
-        $formatted['custom'] = CRM_Core_BAO_CustomField::postProcess($formatted,
-          NULL,
-          'Membership'
-        );
-      }
 
       $startDate = $membershipParams['start_date'] ?? $existingMembership['start_date'] ?? NULL;
       // Assign join date equal to start date if join date is not provided.
@@ -216,7 +213,9 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
         }
       }
 
-      $newMembership = civicrm_api3('membership', 'create', $formatted);
+      $newMembership = Membership::save()
+        ->addRecord($formatted)
+        ->execute()->first();
       $this->setImportStatus($rowNumber, 'IMPORTED', '', $newMembership['id']);
       return CRM_Import_Parser::VALID;
 
@@ -276,34 +275,24 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
     $fields = Civi::cache('fields')->get('membership_importable_fields' . $contactType);
     if (!$fields) {
       $fields = ['' => ['title' => '- ' . ts('do not import') . ' -']]
-       + CRM_Member_DAO_Membership::import();
+        + (array) Membership::getFields()
+          ->addWhere('readonly', '=', FALSE)
+          ->addWhere('usage', 'CONTAINS', 'import')
+          ->setAction('save')
+          ->addOrderBy('title')
+          ->execute()->indexBy('name');
 
       $contactFields = $this->getContactFields($this->getContactType());
-      $fields['membership_contact_id'] = $contactFields['id'];
-      $fields['membership_contact_id']['match_rule'] = '*';
-      $fields['membership_contact_id']['html']['label'] = $fields['membership_contact_id']['title'];
-      $fields['membership_contact_id']['title'] .= ' ' . ts('(match to contact)');
+      $fields['contact_id'] = $contactFields['id'];
+      $fields['contact_id']['match_rule'] = '*';
+      $fields['contact_id']['entity'] = 'Contact';
+      $fields['contact_id']['html']['label'] = $fields['contact_id']['title'];
+      $fields['contact_id']['title'] .= ' ' . ts('(match to contact)');
       unset($contactFields['id']);
       $fields += $contactFields;
-      $fields = array_merge($fields, CRM_Core_BAO_CustomField::getFieldsForImport('Membership'));
       Civi::cache('fields')->set('membership_importable_fields' . $contactType, $fields);
     }
     return $fields;
-  }
-
-  /**
-   * Get the metadata field for which importable fields does not key the actual field name.
-   *
-   * @return string[]
-   */
-  protected function getOddlyMappedMetadataFields(): array {
-    $uniqueNames = ['membership_id', 'membership_contact_id', 'membership_start_date', 'membership_join_date', 'membership_end_date', 'membership_source', 'member_is_override', 'member_is_test', 'member_is_pay_later', 'member_campaign_id'];
-    $fields = [];
-    foreach ($uniqueNames as $name) {
-      $fields[$this->importableFieldsMetadata[$name]['name']] = $name;
-    }
-    // Include the parent fields as they could be present if required for matching ...in theory.
-    return array_merge($fields, parent::getOddlyMappedMetadataFields());
   }
 
 }

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -280,6 +280,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
 
       $contactFields = $this->getContactFields($this->getContactType());
       $fields['membership_contact_id'] = $contactFields['id'];
+      $fields['membership_contact_id']['match_rule'] = '*';
       $fields['membership_contact_id']['html']['label'] = $fields['membership_contact_id']['title'];
       $fields['membership_contact_id']['title'] .= ' ' . ts('(match to contact)');
       unset($contactFields['id']);

--- a/CRM/Upgrade/Incremental/php/SixOne.php
+++ b/CRM/Upgrade/Incremental/php/SixOne.php
@@ -166,12 +166,24 @@ class CRM_Upgrade_Incremental_php_SixOne extends CRM_Upgrade_Incremental_Base {
       'county_id' => 'address_primary.county_id',
       'state_province_id' => 'address_primary.state_province_id',
       'country_id' => 'address_primary.country_id',
+      'membership_id' => 'membership.id',
+      'membership_contact_id' => 'membership.contact_id',
+      'membership_start_date' => 'membership.start_date',
+      'membership_type_id' => 'membership.membership_type_id',
+      'membership_join_date' => 'membership.join_date',
+      'membership_end_date' => 'membership.end_date',
+      'membership_source' => 'membership.source',
+      'member_is_override' => 'membership.is_override',
+      'status_override_end_date' => 'membership.status_override_end_date',
+      'member_is_test' => 'membership.is_test',
+      'member_is_pay_later' => 'membership.is_pay_later',
+      'member_campaign_id' => 'membership.campaign_id',
     ];
     $customFields = CRM_Core_DAO::executeQuery('
       SELECT custom_field.id, custom_field.name, custom_group.name as custom_group_name
       FROM civicrm_custom_field custom_field INNER JOIN civicrm_custom_group custom_group
       ON custom_field.custom_group_id = custom_group.id
-      WHERE extends IN ("Contact", "Individual", "Organization", "Household", "Participant")
+      WHERE extends IN ("Contact", "Individual", "Organization", "Household", "Participant", "Membership")
     ');
     while ($customFields->fetch()) {
       $fieldsToConvert['custom_' . $customFields->id] = $customFields->custom_group_name . '.' . $customFields->name;

--- a/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
@@ -147,7 +147,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
       ],
     ];
 
-    $importObject = $this->createImportObject(['email_primary.email', 'membership_type_id', 'membership_start_date', 'membership_join_date']);
+    $importObject = $this->createImportObject(['email_primary.email', 'membership.membership_type_id', 'membership.start_date', 'membership.join_date']);
     foreach ($params as $values) {
       $this->assertEquals(CRM_Import_Parser::VALID, $importObject->import($values), $values[0]);
     }
@@ -164,7 +164,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
     $this->individualCreate(['email' => 'anthony_anderson2@civicrm.org']);
     $membershipImporter = new CRM_Member_Import_Parser_Membership();
     $membershipImporter->setUserJobID($this->getUserJobID([
-      'mapper' => [['email_primary.email'], ['membership_type_id'], ['membership_start_date'], ['member_is_override']],
+      'mapper' => [['email_primary.email'], ['membership.membership_type_id'], ['membership.start_date'], ['membership.is_override']],
       'onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE,
     ]));
     $membershipImporter->init();
@@ -193,10 +193,10 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
     $this->individualCreate(['email' => 'anthony_anderson3@civicrm.org']);
     $membershipImporter = $this->createImportObject([
       'email_primary.email',
-      'membership_type_id',
-      'membership_start_date',
-      'member_is_override',
-      'status_id',
+      'membership.membership_type_id',
+      'membership.start_date',
+      'membership.is_override',
+      'membership.status_id',
     ]);
 
     $importValues = [
@@ -215,7 +215,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
     $this->individualCreate(['email' => 'anthony_anderson4@civicrm.org']);
     $membershipImporter = new CRM_Member_Import_Parser_Membership();
     $membershipImporter->setUserJobID($this->getUserJobID([
-      'mapper' => [['email_primary.email'], ['membership_type_id'], ['membership_start_date'], ['member_is_override'], ['status_id'], ['status_override_end_date']],
+      'mapper' => [['email_primary.email'], ['membership.membership_type_id'], ['membership.start_date'], ['membership.is_override'], ['membership.status_id'], ['membership.status_override_end_date']],
     ]));
     $membershipImporter->init();
 
@@ -235,7 +235,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
   public function testImportOverriddenMembershipWithInvalidOverrideEndDate(): void {
     $this->individualCreate(['email' => 'anthony_anderson5@civicrm.org']);
     $this->userJobID = $this->getUserJobID([
-      'mapper' => [['email_primary.email'], ['membership_type_id'], ['membership_start_date'], ['member_is_override'], ['status_id'], ['status_override_end_date']],
+      'mapper' => [['email_primary.email'], ['membership.membership_type_id'], ['membership.start_date'], ['membership.is_override'], ['membership.status_id'], ['membership.status_override_end_date']],
       'onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE,
     ]);
     $membershipImporter = new CRM_Member_Import_Parser_Membership();
@@ -276,10 +276,10 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
     ]);
     $membershipImporter = $this->createImportObject([
       'email_primary.email',
-      'membership_type_id',
-      'membership_start_date',
-      'member_is_override',
-      'status_id',
+      'membership.membership_type_id',
+      'membership.start_date',
+      'membership.is_override',
+      'membership.status_id',
     ]);
 
     $importValues = [
@@ -362,11 +362,11 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
     $donaldDuckID = $this->individualCreate(['first_name' => 'Donald', 'last_name' => 'Duck']);
     $this->createCustomGroupWithFieldsOfAllTypes(['extends' => 'Membership']);
     $membershipImporter = $this->createImportObject([
-      'membership_contact_id',
-      'membership_type_id',
-      'membership_start_date',
-      $this->getCustomFieldName('text'),
-      $this->getCustomFieldName('select_string'),
+      'membership.contact_id',
+      'membership.membership_type_id',
+      'membership.start_date',
+      'membership.' . $this->getCustomFieldName('text', 4),
+      'membership.' . $this->getCustomFieldName('select_string', 4),
     ]);
     $importValues = [
       $donaldDuckID,
@@ -394,12 +394,12 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
   public function testRequiredFields(array $dataProvider): void {
     $this->individualCreate(['external_identifier' => 'abc', 'email' => 'jenny@example.com']);
     $mapper = [
-      ['name' => 'membership_type_id'],
-      ['name' => 'membership_id'],
-      ['name' => 'membership_contact_id'],
+      ['name' => 'membership.membership_type_id'],
+      ['name' => 'membership.id'],
+      ['name' => 'membership.contact_id'],
       ['name' => 'external_identifier'],
       ['name' => 'email_primary.email'],
-      ['name' => 'membership_start_date'],
+      ['name' => 'membership.start_date'],
     ];
     foreach ($mapper as $index => $field) {
       if (!in_array($field['name'], $dataProvider)) {
@@ -415,9 +415,9 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
 
   public function requiredFields(): array {
     return [
-      'membership_contact_id' => [['membership_contact_id', 'membership_type_id', 'membership_start_date']],
-      'external_identifier' => [['external_identifier', 'membership_type_id', 'membership_start_date']],
-      'email' => [['email_primary.email', 'membership_type_id', 'membership_start_date']],
+      'membership.contact_id' => [['membership.contact_id', 'membership.membership_type_id', 'membership.start_date']],
+      'external_identifier' => [['external_identifier', 'membership.membership_type_id', 'membership.start_date']],
+      'email' => [['email_primary.email', 'membership.membership_type_id', 'membership.start_date']],
     ];
   }
 
@@ -426,10 +426,10 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
    */
   public function testImportCSV() :void {
     $this->importCSV('memberships_invalid.csv', [
-      ['name' => 'membership_contact_id'],
-      ['name' => 'membership_source'],
-      ['name' => 'membership_type_id'],
-      ['name' => 'membership_start_date'],
+      ['name' => 'membership.contact_id'],
+      ['name' => 'membership.source'],
+      ['name' => 'membership.membership_type_id'],
+      ['name' => 'membership.start_date'],
       ['name' => 'do_not_import'],
     ]);
     $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
@@ -447,10 +447,10 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
       'contact_id' => $this->individualCreate(),
     ]);
     $this->importCSV('memberships_with_id.csv', [
-      ['name' => 'membership_id'],
-      ['name' => 'membership_source'],
-      ['name' => 'membership_type_id'],
-      ['name' => 'membership_start_date'],
+      ['name' => 'membership.id'],
+      ['name' => 'membership.source'],
+      ['name' => 'membership.membership_type_id'],
+      ['name' => 'membership.start_date'],
       ['name' => 'do_not_import'],
     ]);
     $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
@@ -471,8 +471,8 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
       'start_date' => '2019-03-23',
     ]);
     $this->importCSV('memberships_with_id.csv', [
-      ['name' => 'membership_id'],
-      ['name' => 'membership_source'],
+      ['name' => 'membership.id'],
+      ['name' => 'membership.source'],
       ['name' => 'do_not_import'],
       ['name' => 'do_not_import'],
       ['name' => 'do_not_import'],
@@ -493,9 +493,9 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
     $this->individualCreate(['email' => 'member@example.com']);
     $this->importCSV('memberships_valid.tsv', [
       ['name' => 'email_primary.email'],
-      ['name' => 'membership_source'],
-      ['name' => 'membership_type_id'],
-      ['name' => 'membership_start_date'],
+      ['name' => 'membership.source'],
+      ['name' => 'membership.membership_type_id'],
+      ['name' => 'membership.start_date'],
       ['name' => 'do_not_import'],
     ], ['fieldSeparator' => 'tab']);
     $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
@@ -517,11 +517,11 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
       'start_date' => '2020-10-01',
     ]);
     $mapping = [
-      ['name' => 'membership_id'],
-      ['name' => 'membership_source'],
-      ['name' => 'membership_type_id'],
-      ['name' => 'membership_start_date'],
-      ['name' => $this->getCustomFieldName('date')],
+      ['name' => 'membership.id'],
+      ['name' => 'membership.source'],
+      ['name' => 'membership.membership_type_id'],
+      ['name' => 'membership.start_date'],
+      ['name' => 'membership.' . $this->getCustomFieldName('date', 4)],
     ];
     $this->importCSV('memberships_update_custom_date.csv', $mapping, ['dateFormats' => 32]);
     $membership = $this->callAPISuccessGetSingle('Membership', []);


### PR DESCRIPTION
Overview
----------------------------------------
Update Membership import to use apiv4

Before
----------------------------------------
Uses apiv3

After
----------------------------------------
Uses apiv4

Technical Details
----------------------------------------
This changes the metadata for membership fields to be prefixed with `membership.` - e.g `membership.start_date` - by comparison the contribution import only prefixes the otherwise-ambigous soft credit contact fields. I feel like I agreed with @colemanw that ideally all the fields would be prefixed. I feel like a reasonable case could be made to prefix with

`membership.` 
`Membership.` (the actual entity)
`membership_base` (ie this would imply that the base entity for any import with be described like this, allowing for the possibility of related entities of the same type

I don't think we need to worry too much about this detail just yet  - we are not hugely locked in here. My current focus is to get *most* of the core imports off apiv3 ie

|Import|Status|
|-----------|---------|
|Contribution|apiv4 (since ages)|
|Participant|apiv4 in 6.1|
|Membership|apiv4 in 6.1|
|Activity|still apiv3 - will do this next (once this is merged)|
|Custom Data|still apiv3 - hopefully also do this for 6.1|
|Contact|apiv3 - might be too challenging to do for 6.1|



Comments
----------------------------------------
