### PR TITLE
[REF] Use random_bytes instead of uniqid/rand for random hex strings

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -191,7 +191,7 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact implements Civi\Co
     // Fixed in 1.5 by making hash optional, only do this in create mode, not update.
     if ((!isset($contact->hash) || !$contact->hash) && !$contact->id) {
       $allNull = FALSE;
-      $contact->hash = md5(uniqid(rand(), TRUE));
+      $contact->hash = bin2hex(random_bytes(16));
     }
 
     // Even if we don't need $employerId, it's important to call getFieldValue() before

--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -165,7 +165,7 @@ WHERE  id IN ( $idString )
       // to avoid breaking things elsewhere
       // See lab issue #5541
       do {
-        $hash = md5(uniqid(rand(), TRUE));
+        $hash = bin2hex(random_bytes(16));
         if ($hashSize) {
           $hash = substr($hash, 0, $hashSize);
         }

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -447,7 +447,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
     if ($searchParams['radio_ts'] == 'ts_sel') {
       // Create a static group.
       // groups require a unique name
-      $randID = md5(time() . rand(1, 1000));
+      $randID = bin2hex(random_bytes(16));
       $grpTitle = "Hidden Group {$randID}";
       $grpID = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Group', $grpTitle, 'id', 'title');
 

--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -272,7 +272,7 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
    */
   public function getInvoiceID(): string {
     if (!$this->invoiceID) {
-      $this->invoiceID = md5(uniqid(mt_rand(), TRUE));
+      $this->invoiceID = bin2hex(random_bytes(16));
     }
     return $this->invoiceID;
   }

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1234,7 +1234,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     CRM_Contribute_Form_AdditionalInfo::postProcessCommon($params, $this->_params, $this);
 
     if (empty($this->_params['invoice_id'])) {
-      $this->_params['invoiceID'] = md5(uniqid(rand(), TRUE));
+      $this->_params['invoiceID'] = bin2hex(random_bytes(16));
     }
     else {
       $this->_params['invoiceID'] = $this->_params['invoice_id'];

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1669,7 +1669,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $financialType->id = $financialTypeID;
     $financialType->find(TRUE);
     $tempParams['amount'] = $minimumFee;
-    $tempParams['invoiceID'] = md5(uniqid(rand(), TRUE));
+    $tempParams['invoiceID'] = bin2hex(random_bytes(16));
     $isRecur = $tempParams['is_recur'] ?? NULL;
 
     //assign receive date when separate membership payment
@@ -1850,7 +1850,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     //this way the mocked up controller ignores the session stuff
     $_SERVER['REQUEST_METHOD'] = 'GET';
     $form->controller = new CRM_Contribute_Controller_Contribution();
-    $params['invoiceID'] = md5(uniqid(rand(), TRUE));
+    $params['invoiceID'] = bin2hex(random_bytes(16));
 
     $paramsProcessedForForm = $form->_params = self::getFormParams($params['id'], $params);
 

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1252,7 +1252,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     $this->set('amount', $this->getMainContributionAmount());
 
     // generate and set an invoiceID for this transaction
-    $invoiceID = md5(uniqid(rand(), TRUE));
+    $invoiceID = bin2hex(random_bytes(16));
     $this->set('invoiceID', $invoiceID);
     $params['invoiceID'] = $invoiceID;
     $title = !empty($this->_values['frontend_title']) ? $this->_values['frontend_title'] : $this->_values['title'];

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -509,7 +509,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
 
     if ($log) {
       // Log the output to error_log with a unique reference.
-      $unique = substr(md5(random_bytes(32)), 0, 12);
+      $unique = bin2hex(random_bytes(6));
       error_log("errorID:$unique\n$out");
 
       if (!$checkPermission) {

--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -161,7 +161,7 @@ class CRM_Core_Payment_AuthorizeNetIPN {
     // Per CRM-17611 it would also not be passed back for a decline.
     elseif ($this->isSuccess()) {
       $input['is_test'] = 1;
-      $input['trxn_id'] = $this->transactionID ?: md5(uniqid(mt_rand(), TRUE));
+      $input['trxn_id'] = $this->transactionID ?: bin2hex(random_bytes(16));
     }
     $this->transactionID = $input['trxn_id'];
 

--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -261,7 +261,7 @@ class CRM_Core_Payment_PayPalProIPN {
           // In future moving to create pending & then complete, but this OK for now.
           // Also consider accepting 'Failed' like other processors.
           $input['contribution_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
-          $input['invoice_id'] = md5(uniqid(rand(), TRUE));
+          $input['invoice_id'] = bin2hex(random_bytes(16));
           $input['original_contribution_id'] = $this->getContributionID();
           $input['contribution_recur_id'] = $this->getContributionRecurID();
 

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -2044,7 +2044,7 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
    */
   public function getInvoiceID(): string {
     if (!$this->invoiceID) {
-      $this->invoiceID = md5(uniqid(rand(), TRUE));
+      $this->invoiceID = bin2hex(random_bytes(16));
     }
     return $this->invoiceID;
   }

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -833,7 +833,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       $this->set('amount_level', $params['amount_level']);
 
       // generate and set an invoiceID for this transaction
-      $invoiceID = md5(uniqid(rand(), TRUE));
+      $invoiceID = bin2hex(random_bytes(16));
       $this->set('invoiceID', $invoiceID);
 
       if ($this->_paymentProcessor) {

--- a/CRM/Import/Form/Preview.php
+++ b/CRM/Import/Form/Preview.php
@@ -52,7 +52,7 @@ abstract class CRM_Import_Form_Preview extends CRM_Import_Forms {
   public function setStatusUrl() {
     $statusID = $this->get('statusID');
     if (!$statusID) {
-      $statusID = md5(uniqid(rand(), TRUE));
+      $statusID = bin2hex(random_bytes(16));
       $this->set('statusID', $statusID);
     }
     $statusUrl = CRM_Utils_System::url('civicrm/ajax/status', "id={$statusID}", FALSE, NULL, FALSE);

--- a/CRM/Utils/Chart.php
+++ b/CRM/Utils/Chart.php
@@ -270,7 +270,7 @@ class CRM_Utils_Chart {
         }
 
         // generate unique id for this chart instance
-        $uniqueId = md5(uniqid(rand(), TRUE));
+        $uniqueId = bin2hex(random_bytes(16));
 
         $theChart["chart_{$uniqueId}"]['size'] = ['xSize' => $xSize, 'ySize' => $ySize];
         $theChart["chart_{$uniqueId}"]['object'] = $chartObj;

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -458,7 +458,7 @@ class CRM_Utils_File {
    * @return string
    */
   public static function makeFileName($name, bool $unicode = FALSE) {
-    $uniqID = md5(uniqid(rand(), TRUE));
+    $uniqID = bin2hex(random_bytes(16));
     $info = pathinfo($name);
     $basename = substr($info['basename'],
       0, -(strlen($info['extension'] ?? '') + (($info['extension'] ?? '') == '' ? 0 : 1))
@@ -509,7 +509,7 @@ class CRM_Utils_File {
    */
   public static function duplicate($filePath) {
     $oldName = pathinfo($filePath, PATHINFO_FILENAME);
-    $uniqID = md5(uniqid(rand(), TRUE));
+    $uniqID = bin2hex(random_bytes(16));
     $newName = preg_replace('/(_[\w]{32})$/', '', $oldName) . '_' . $uniqID;
     $newPath = str_replace($oldName, $newName, $filePath);
     copy($filePath, $newPath);
@@ -730,9 +730,6 @@ HTACCESS;
    * @see tempnam
    */
   public static function tempnam($prefix = 'tmp-') {
-    // $config = CRM_Core_Config::singleton();
-    // $nonce = md5(uniqid() . $config->dsn . $config->userFrameworkResourceURL);
-    // $fileName = "{$config->configAndLogDir}" . $prefix . $nonce . $suffix;
     $fileName = tempnam(sys_get_temp_dir(), $prefix);
     return $fileName;
   }

--- a/CRM/Utils/SQL/TempTable.php
+++ b/CRM/Utils/SQL/TempTable.php
@@ -92,7 +92,7 @@ class CRM_Utils_SQL_TempTable {
   public static function build() {
     $t = new CRM_Utils_SQL_TempTable();
     $t->category = NULL;
-    $t->id = md5(uniqid('', TRUE));
+    $t->id = bin2hex(random_bytes(16));
     // The constant CIVICRM_TEMP_FORCE_DURABLE is for local debugging.
     $t->durable = CRM_Utils_Constant::value('CIVICRM_TEMP_FORCE_DURABLE', FALSE);
     $t->utf8 = TRUE;

--- a/Civi/Test/ContactTestTrait.php
+++ b/Civi/Test/ContactTestTrait.php
@@ -154,7 +154,7 @@ trait ContactTestTrait {
     foreach ($samples[$contact_type] as $key => $values) {
       $params[$key] = $values[$seq % count($values)];
       if ($random) {
-        $params[$key] .= substr(sha1(mt_rand()), 0, 5);
+        $params[$key] .= bin2hex(random_bytes(3));
       }
     }
     if ($contact_type === 'Individual') {

--- a/api/v3/Contribution/Transact.php
+++ b/api/v3/Contribution/Transact.php
@@ -55,7 +55,7 @@ function civicrm_api3_contribution_transact($params) {
   }
 
   // Some payment processors expect a unique invoice_id - generate one if not supplied
-  $params['invoice_id'] ??= md5(uniqid(rand(), TRUE));
+  $params['invoice_id'] ??= bin2hex(random_bytes(16));
 
   $paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getPayment($params['payment_processor'], $params['payment_processor_mode']);
   $params = $paymentProcessor['object']->doPayment($params);

--- a/bin/ContributionProcessor.php
+++ b/bin/ContributionProcessor.php
@@ -436,7 +436,7 @@ class CiviContributeProcessor {
       // errors due to invoice ID. See:
       // ./CRM/Core/Payment/PayPalIPN.php:200
       if ($recurring->id) {
-        $params['invoice_id'] = md5(uniqid(rand(), TRUE));
+        $params['invoice_id'] = bin2hex(random_bytes(16));
       }
 
       $recurring->copyValues($params);
@@ -496,7 +496,7 @@ class CiviContributeProcessor {
     }
     else {
       // generate a new transaction id, if not already exist
-      $transaction['trxn_id'] = md5(uniqid(rand(), TRUE));
+      $transaction['trxn_id'] = bin2hex(random_bytes(16));
     }
 
     if (!isset($transaction['financial_type_id'])) {

--- a/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormTest.php
+++ b/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormTest.php
@@ -50,7 +50,7 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
   public function testPublicCreateAllowed() {
     $initialMaxId = CRM_Core_DAO::singleValueQuery('SELECT max(id) FROM civicrm_contact');
 
-    $r = md5(random_bytes(16));
+    $r = bin2hex(random_bytes(16));
 
     $me = [0 => ['fields' => []]];
     $me[0]['fields']['first_name'] = 'Firsty' . $r;
@@ -75,7 +75,7 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
       ->execute()
       ->first();
 
-    $r = md5(random_bytes(16));
+    $r = bin2hex(random_bytes(16));
 
     $me = [0 => ['fields' => []]];
     $me[0]['fields']['id'] = $contact['id'];

--- a/ext/authx/Civi/Authx/AuthxRequestBuilder.php
+++ b/ext/authx/Civi/Authx/AuthxRequestBuilder.php
@@ -156,7 +156,7 @@ class AuthxRequestBuilder {
   }
 
   public function credApikey($cid) {
-    $api_key = md5(\random_bytes(16));
+    $api_key = bin2hex(\random_bytes(16));
     \civicrm_api3('Contact', 'create', [
       'id' => $cid,
       'api_key' => $api_key,

--- a/ext/eventcart/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/ext/eventcart/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -474,7 +474,7 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
     }
 
     $params['now'] = date('YmdHis');
-    $params['invoiceID'] = md5(uniqid(rand(), TRUE));
+    $params['invoiceID'] = bin2hex(random_bytes(16));
     $params['amount'] = $this->total;
     $params['financial_type_id'] = $this->financial_type_id;
     if ($this->payment_required && empty($params['is_pay_later'])) {

--- a/ext/ewaysingle/CRM/Core/Payment/eWAY.php
+++ b/ext/ewaysingle/CRM/Core/Payment/eWAY.php
@@ -214,7 +214,7 @@ class CRM_Core_Payment_eWAY extends CRM_Core_Payment {
     //----------------------------------------------------------------------------------------------------
     // We use CiviCRM's param's 'invoiceID' as the unique transaction token to feed to eWAY
     // Trouble is that eWAY only accepts 16 chars for the token, while CiviCRM's invoiceID is an 32.
-    // As its made from a "$invoiceID = md5(uniqid(rand(), true));" then using the fierst 16 chars
+    // As its made from a "$invoiceID = bin2hex(random_bytes(16))" then using the first 16 chars
     // should be alright
     //----------------------------------------------------------------------------------------------------
     $uniqueTrnxNum = substr($params['invoiceID'], 0, 16);

--- a/tests/phpunit/CRM/Contact/BAO/ContactType/ContactSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactType/ContactSearchTest.php
@@ -83,7 +83,7 @@ class CRM_Contact_BAO_ContactType_ContactSearchTest extends CiviUnitTestCase {
 
   public function setUp(): void {
     parent::setUp();
-    $students = 'indivi_student' . substr(sha1(rand()), 0, 7);
+    $students = 'indivi_student' . bin2hex(random_bytes(4));
     $params = [
       'label' => $students,
       'name' => $students,
@@ -94,7 +94,7 @@ class CRM_Contact_BAO_ContactType_ContactSearchTest extends CiviUnitTestCase {
     CRM_Contact_BAO_ContactType::writeRecord($params);
     $this->student = $params['name'];
 
-    $parents = 'indivi_parent' . substr(sha1(rand()), 0, 7);
+    $parents = 'indivi_parent' . bin2hex(random_bytes(4));
     $params = [
       'label' => $parents,
       'name' => $parents,
@@ -105,7 +105,7 @@ class CRM_Contact_BAO_ContactType_ContactSearchTest extends CiviUnitTestCase {
     CRM_Contact_BAO_ContactType::writeRecord($params);
     $this->parent = $params['name'];
 
-    $organizations = 'org_sponsor' . substr(sha1(rand()), 0, 7);
+    $organizations = 'org_sponsor' . bin2hex(random_bytes(4));
     $params = [
       'label' => $organizations,
       'name' => $organizations,

--- a/tests/phpunit/CRM/Contact/Form/Search/SearchContactTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Search/SearchContactTest.php
@@ -49,7 +49,7 @@ class CRM_Contact_Form_Search_SearchContactTest extends CiviUnitTestCase {
   protected function searchContacts($contactSubType) {
     // create contact
     $params = [
-      'first_name' => 'Peter' . substr(sha1(rand()), 0, 4),
+      'first_name' => 'Peter' . bin2hex(random_bytes(2)),
       'last_name' => 'Lastname',
       'contact_type' => 'Individual',
       'contact_sub_type' => $contactSubType,

--- a/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
@@ -790,7 +790,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
       'id' => $customField['id'],
       'token' => sprintf('{contact.custom_%s}', $customField['id']),
       'name' => sprintf('custom_%s', $customField['id']),
-      'value' => 'text ' . substr(sha1(mt_rand()), 0, 7),
+      'value' => 'text ' . bin2hex(random_bytes(4)),
     ];
 
     $this->fixtures['sched_on_custom_date'] = [

--- a/tests/phpunit/CRM/Core/BAO/NavigationTest.php
+++ b/tests/phpunit/CRM/Core/BAO/NavigationTest.php
@@ -93,7 +93,7 @@ class CRM_Core_BAO_NavigationTest extends CiviUnitTestCase {
    * Test that a navigation item can be retrieved by it's url.
    */
   public function testGetNavItemByUrl(): void {
-    $random_string = substr(sha1(rand()), 0, 7);
+    $random_string = bin2hex(random_bytes(4));
     $name = "Test Menu Link {$random_string}";
     $url = "civicrm/test/{$random_string}";
     $url_params = "reset=1";
@@ -120,7 +120,7 @@ class CRM_Core_BAO_NavigationTest extends CiviUnitTestCase {
    * that is part of the navigation but not the instance.
    */
   public function testGetNavItemByUrlWildcard(): void {
-    $random_string = substr(sha1(rand()), 0, 7);
+    $random_string = bin2hex(random_bytes(4));
     $name = "Test Menu Link {$random_string}";
     $url = "civicrm/test/{$random_string}";
     $url_params = "reset=1&output=criteria";

--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -379,8 +379,8 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
     $contactIDs = [];
     for ($i = 0; $i < 10; $i++) {
       $contactIDs[] = $this->individualCreate([
-        'first_name' => 'Alan' . substr(sha1(rand()), 0, 7),
-        'last_name' => 'Smith' . substr(sha1(rand()), 0, 4),
+        'first_name' => 'Alan' . bin2hex(random_bytes(4)),
+        'last_name' => 'Smith' . bin2hex(random_bytes(2)),
       ]);
     }
 

--- a/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
@@ -174,7 +174,7 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
     $this->hookClass->setHook('civicrm_aclGroup', [$this, 'hook_civicrm_aclGroup']);
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'edit groups'];
     // Create dummy group and assign 2 contacts
-    $name = 'Test static group ' . substr(sha1(rand()), 0, 7);
+    $name = 'Test static group ' . bin2hex(random_bytes(4));
     $groupID = $this->groupCreate([
       'name' => $name,
       'title' => $name,

--- a/tests/phpunit/CRM/Mailing/BAO/SpoolTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/SpoolTest.php
@@ -29,17 +29,17 @@ class CRM_Mailing_BAO_SpoolTest extends CiviUnitTestCase {
    */
   public function testSend(): void {
     $contact_params_1 = [
-      'first_name' => substr(sha1(rand()), 0, 7),
+      'first_name' => bin2hex(random_bytes(4)),
       'last_name' => 'Anderson',
-      'email' => substr(sha1(rand()), 0, 7) . '@example.org',
+      'email' => bin2hex(random_bytes(4)) . '@example.org',
       'contact_type' => 'Individual',
     ];
     $contact_id_1 = $this->individualCreate($contact_params_1);
 
     $contact_params_2 = [
-      'first_name' => substr(sha1(rand()), 0, 7),
+      'first_name' => bin2hex(random_bytes(4)),
       'last_name' => 'Xylophone',
-      'email' => substr(sha1(rand()), 0, 7) . '@example.org',
+      'email' => bin2hex(random_bytes(4)) . '@example.org',
       'contact_type' => 'Individual',
     ];
     $contact_id_2 = $this->individualCreate($contact_params_2);

--- a/tests/phpunit/CRM/Price/Form/FieldTest.php
+++ b/tests/phpunit/CRM/Price/Form/FieldTest.php
@@ -76,7 +76,7 @@ class CRM_Price_Form_FieldTest extends CiviUnitTestCase {
     $this->setCurrencySeparators($thousandSeparator);
     $thousands = Civi::settings()->get('monetaryThousandSeparator');
     $decimal = Civi::settings()->get('monetaryDecimalPoint');
-    $paramsSet['title'] = 'Price Set' . substr(sha1(rand()), 0, 7);
+    $paramsSet['title'] = 'Price Set' . bin2hex(random_bytes(4));
     $paramsSet['name'] = CRM_Utils_String::titleToVar($paramsSet['title']);
     $paramsSet['is_active'] = TRUE;
     $paramsSet['financial_type_id'] = 'Event Fee';

--- a/tests/phpunit/api/v3/ActionScheduleTest.php
+++ b/tests/phpunit/api/v3/ActionScheduleTest.php
@@ -53,7 +53,7 @@ class api_v3_ActionScheduleTest extends CiviUnitTestCase {
     $oldCount = CRM_Core_DAO::singleValueQuery('select count(*) from civicrm_action_schedule');
     $activityContacts = CRM_Activity_BAO_ActivityContact::buildOptions('record_type_id', 'validate');
     $assigneeID = CRM_Utils_Array::key('Activity Assignees', $activityContacts);
-    $title = 'simpleActionSchedule' . substr(sha1(rand()), 0, 7);
+    $title = 'simpleActionSchedule' . bin2hex(random_bytes(4));
     $params = [
       'title' => $title,
       'recipient' => $assigneeID,
@@ -101,7 +101,7 @@ class api_v3_ActionScheduleTest extends CiviUnitTestCase {
     $oldCount = CRM_Core_DAO::singleValueQuery('select count(*) from civicrm_action_schedule');
     $activityContacts = CRM_Activity_BAO_ActivityContact::buildOptions('record_type_id', 'validate');
     $assigneeID = CRM_Utils_Array::key('Activity Assignees', $activityContacts);
-    $title = 'simpleActionSchedule' . substr(sha1(rand()), 0, 7);
+    $title = 'simpleActionSchedule' . bin2hex(random_bytes(4));
     $params = [
       'title' => $title,
       'recipient' => $assigneeID,

--- a/tests/phpunit/api/v3/ActivityTest.php
+++ b/tests/phpunit/api/v3/ActivityTest.php
@@ -754,7 +754,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
   public function testJoinOnTags(): void {
     $tagName = 'act_tag_nm_' . mt_rand();
     $tagDescription = 'act_tag_ds_' . mt_rand();
-    $tagColor = '#' . substr(md5(mt_rand()), 0, 6);
+    $tagColor = '#' . bin2hex(random_bytes(3));
     $tag = $this->callAPISuccess('Tag', 'create', ['name' => $tagName, 'color' => $tagColor, 'description' => $tagDescription, 'used_for' => 'Activities']);
     $activity = $this->callAPISuccess('Activity', 'Create', $this->_params);
     $this->callAPISuccess('EntityTag', 'create', ['entity_table' => 'civicrm_activity', 'tag_id' => $tag['id'], 'entity_id' => $activity['id']]);

--- a/tests/phpunit/api/v3/CustomValueContactTypeTest.php
+++ b/tests/phpunit/api/v3/CustomValueContactTypeTest.php
@@ -55,7 +55,7 @@ class api_v3_CustomValueContactTypeTest extends CiviUnitTestCase {
     parent::setUp();
     //  Create Group For Individual  Contact Type
     $groupIndividual = [
-      'title' => 'TestGroup For Individual' . substr(sha1(rand()), 0, 5),
+      'title' => 'TestGroup For Individual' . bin2hex(random_bytes(3)),
       'extends' => ['Individual'],
       'style' => 'Inline',
       'is_active' => 1,
@@ -68,7 +68,7 @@ class api_v3_CustomValueContactTypeTest extends CiviUnitTestCase {
 
     //  Create Group For Individual-Student  Contact Sub  Type
     $groupIndividualStudent = [
-      'title' => 'Student Test' . substr(sha1(rand()), 0, 5),
+      'title' => 'Student Test' . bin2hex(random_bytes(3)),
       'extends' => ['Individual', ['Student']],
       'style' => 'Inline',
       'is_active' => 1,

--- a/tests/phpunit/api/v3/CustomValueTest.php
+++ b/tests/phpunit/api/v3/CustomValueTest.php
@@ -28,7 +28,7 @@ class api_v3_CustomValueTest extends CiviUnitTestCase {
     $dataValues = [
       'integer' => [1, 2, 3],
       'number' => [10.11, 20.22, 30.33],
-      'string' => [substr(sha1(rand()), 0, 4) . '(', substr(sha1(rand()), 0, 3) . '|', substr(sha1(rand()), 0, 2) . ','],
+      'string' => [bin2hex(random_bytes(2)) . '(', bin2hex(random_bytes(2)) . '|', bin2hex(random_bytes(1)) . ','],
       // 'country' => array_rand(CRM_Core_PseudoConstant::country(FALSE, FALSE), 3),
       // This does not work in the test at the moment due to caching issues.
       //'state_province' => array_rand(CRM_Core_PseudoConstant::stateProvince(FALSE, FALSE), 3),
@@ -54,7 +54,7 @@ class api_v3_CustomValueTest extends CiviUnitTestCase {
       }
       elseif ($dataType === 'contact') {
         for ($i = 0; $i < 3; $i++) {
-          $result = $this->callAPISuccess('Contact', 'create', ['contact_type' => 'Individual', 'email' => substr(sha1(rand()), 0, 7) . '@yahoo.com']);
+          $result = $this->callAPISuccess('Contact', 'create', ['contact_type' => 'Individual', 'email' => bin2hex(random_bytes(4)) . '@yahoo.com']);
           $this->optionGroup[$dataType]['values'][$i] = $result['id'];
         }
       }
@@ -170,7 +170,7 @@ class api_v3_CustomValueTest extends CiviUnitTestCase {
     $customId = $customField['id'];
     $params = [
       'contact_type' => 'Individual',
-      'email' => substr(sha1(rand()), 0, 7) . 'man1@yahoo.com',
+      'email' => bin2hex(random_bytes(4)) . 'man1@yahoo.com',
     ];
     $result = $this->callAPISuccess('Contact', 'create', $params);
     $contactId = $result['id'];
@@ -183,8 +183,8 @@ class api_v3_CustomValueTest extends CiviUnitTestCase {
       unset($selectedValue[$count]);
     }
     elseif ($customField['html_type'] == 'Link') {
-      $selectedValue = "http://" . substr(sha1(rand()), 0, 7) . ".com";
-      $notselectedValue = "http://" . substr(sha1(rand()), 0, 7) . ".com";
+      $selectedValue = "http://" . bin2hex(random_bytes(4)) . ".com";
+      $notselectedValue = "http://" . bin2hex(random_bytes(4)) . ".com";
     }
     elseif ($type == 'date') {
       $selectedValue = date('Ymd');
@@ -265,7 +265,7 @@ class api_v3_CustomValueTest extends CiviUnitTestCase {
           }
           // To be precise in for these operator we can't just rely on one contact,
           // hence creating multiple contact with custom value less/more then $selectedValue respectively
-          $result = $this->callAPISuccess('Contact', 'create', ['contact_type' => 'Individual', 'email' => substr(sha1(rand()), 0, 7) . 'man2@yahoo.com']);
+          $result = $this->callAPISuccess('Contact', 'create', ['contact_type' => 'Individual', 'email' => bin2hex(random_bytes(4)) . 'man2@yahoo.com']);
           $contactId2 = $result['id'];
           $this->callAPISuccess('CustomValue', 'create', ['entity_id' => $contactId2, 'custom_' . $customId => $lesserSelectedValue]);
 
@@ -278,7 +278,7 @@ class api_v3_CustomValueTest extends CiviUnitTestCase {
             $this->assertEquals($contactId2, $result['id']);
           }
           else {
-            $result = $this->callAPISuccess('Contact', 'create', ['contact_type' => 'Individual', 'email' => substr(sha1(rand()), 0, 7) . 'man3@yahoo.com']);
+            $result = $this->callAPISuccess('Contact', 'create', ['contact_type' => 'Individual', 'email' => bin2hex(random_bytes(4)) . 'man3@yahoo.com']);
             $contactId3 = $result['id'];
             $this->callAPISuccess('CustomValue', 'create', ['entity_id' => $contactId3, 'custom_' . $customId => $greaterSelectedValue]);
 

--- a/tests/phpunit/api/v3/FinancialTypeTest.php
+++ b/tests/phpunit/api/v3/FinancialTypeTest.php
@@ -39,11 +39,11 @@ class api_v3_FinancialTypeTest extends CiviUnitTestCase {
       'is_multiple' => FALSE,
     ]);
     $financialTypeData = [
-      'Financial Type' . substr(sha1(rand()), 0, 4) => [
+      'Financial Type' . bin2hex(random_bytes(2)) => [
         ['Test-1', 'Test-2', NULL],
         [NULL, '', 'Test_3'],
       ],
-      'Financial Type' . substr(sha1(rand()), 0, 4) => [
+      'Financial Type' . bin2hex(random_bytes(2)) => [
         [NULL, NULL, NULL],
         ['Test_1', NULL, 'Test_3'],
       ],

--- a/tests/phpunit/api/v4/Entity/QueueTest.php
+++ b/tests/phpunit/api/v4/Entity/QueueTest.php
@@ -51,7 +51,7 @@ class QueueTest extends Api4TestBase {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function testBasicLinearPolling(): void {
-    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_linear';
+    $queueName = 'QueueTest_' . bin2hex(random_bytes(16)) . '_linear';
     $queue = \Civi::queue($queueName, [
       'type' => 'Sql',
       'runner' => 'task',
@@ -105,7 +105,7 @@ class QueueTest extends Api4TestBase {
   }
 
   public function testBasicParallelPolling(): void {
-    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_parallel';
+    $queueName = 'QueueTest_' . bin2hex(random_bytes(16)) . '_parallel';
     $queue = \Civi::queue($queueName, ['type' => 'SqlParallel', 'runner' => 'task', 'error' => 'delete']);
     $this->assertQueueStats(0, 0, 0, $queue);
 
@@ -144,7 +144,7 @@ class QueueTest extends Api4TestBase {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function testBatchParallelPolling(): void {
-    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_parallel';
+    $queueName = 'QueueTest_' . bin2hex(random_bytes(16)) . '_parallel';
     \Civi::dispatcher()->addListener('hook_civicrm_queueRun_testStuff', [$this, 'onHookQueueRun']);
     $queue = \Civi::queue($queueName, [
       'type' => 'SqlParallel',
@@ -172,7 +172,7 @@ class QueueTest extends Api4TestBase {
   }
 
   public function testReset() {
-    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_reset';
+    $queueName = 'QueueTest_' . bin2hex(random_bytes(16)) . '_reset';
     \Civi::dispatcher()->addListener('hook_civicrm_queueRun_testStuff', [$this, 'onHookQueueRun']);
     $queue = \Civi::queue($queueName, [
       'type' => 'SqlParallel',
@@ -192,7 +192,7 @@ class QueueTest extends Api4TestBase {
   }
 
   public function testRunLoop() {
-    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_runloop';
+    $queueName = 'QueueTest_' . bin2hex(random_bytes(16)) . '_runloop';
     \Civi::dispatcher()->addListener('hook_civicrm_queueRun_testStuff', [$this, 'onHookQueueRun']);
     $queue = \Civi::queue($queueName, [
       'type' => 'SqlParallel',
@@ -235,7 +235,7 @@ class QueueTest extends Api4TestBase {
   }
 
   public function testRunLoop_abort() {
-    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_runloopabort';
+    $queueName = 'QueueTest_' . bin2hex(random_bytes(16)) . '_runloopabort';
     $queue = \Civi::queue($queueName, [
       'type' => 'Sql',
       'runner' => 'task',
@@ -290,7 +290,7 @@ class QueueTest extends Api4TestBase {
   }
 
   public function testSelect(): void {
-    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_parallel';
+    $queueName = 'QueueTest_' . bin2hex(random_bytes(16)) . '_parallel';
     $queue = \Civi::queue($queueName, ['type' => 'SqlParallel', 'runner' => 'task', 'error' => 'delete']);
     $this->assertQueueStats(0, 0, 0, $queue);
 
@@ -307,7 +307,7 @@ class QueueTest extends Api4TestBase {
   }
 
   public function testSelectRunAs(): void {
-    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_select';
+    $queueName = 'QueueTest_' . bin2hex(random_bytes(16)) . '_select';
     $queue = \Civi::queue($queueName, ['type' => 'SqlParallel', 'runner' => 'task', 'error' => 'delete']);
     $this->assertQueueStats(0, 0, 0, $queue);
 
@@ -323,7 +323,7 @@ class QueueTest extends Api4TestBase {
   }
 
   public function testEmptyPoll(): void {
-    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_linear';
+    $queueName = 'QueueTest_' . bin2hex(random_bytes(16)) . '_linear';
     $queue = \Civi::queue($queueName, ['type' => 'Sql', 'runner' => 'task', 'error' => 'delete']);
     $this->assertQueueStats(0, 0, 0, $queue);
 
@@ -343,7 +343,7 @@ class QueueTest extends Api4TestBase {
    * @dataProvider getDelayableDrivers
    */
   public function testDelayedStart(array $queueSpec) {
-    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_delayed';
+    $queueName = 'QueueTest_' . bin2hex(random_bytes(16)) . '_delayed';
     $queue = \Civi::queue($queueName, $queueSpec);
     $this->assertQueueStats(0, 0, 0, $queue);
 
@@ -380,7 +380,7 @@ class QueueTest extends Api4TestBase {
    * @dataProvider getErrorModes
    */
   public function testRetryWithPoliteExhaustion(string $errorMode) {
-    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_linear';
+    $queueName = 'QueueTest_' . bin2hex(random_bytes(16)) . '_linear';
     $queue = \Civi::queue($queueName, [
       'type' => 'Sql',
       'runner' => 'task',
@@ -422,7 +422,7 @@ class QueueTest extends Api4TestBase {
    * few tasks. But the third one works!
    */
   public function testRetryWithDelinquencyAndSuccess(): void {
-    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_linear';
+    $queueName = 'QueueTest_' . bin2hex(random_bytes(16)) . '_linear';
     $queue = \Civi::queue($queueName, [
       'type' => 'Sql',
       'runner' => 'task',
@@ -468,7 +468,7 @@ class QueueTest extends Api4TestBase {
   public function testRetryWithEventualFailure(string $errorMode) {
     \Civi::$statics[__CLASS__]['doSomethingResult'] = FALSE;
 
-    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_linear';
+    $queueName = 'QueueTest_' . bin2hex(random_bytes(16)) . '_linear';
     $queue = \Civi::queue($queueName, [
       'type' => 'Sql',
       'runner' => 'task',
@@ -518,7 +518,7 @@ class QueueTest extends Api4TestBase {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function testUserJobQueue_Completion(): void {
-    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_userjob';
+    $queueName = 'QueueTest_' . bin2hex(random_bytes(16)) . '_userjob';
 
     $firedQueueStatus = [];
     \Civi::dispatcher()->addListener('hook_civicrm_queueStatus', function($e) use (&$firedQueueStatus) {
@@ -578,7 +578,7 @@ class QueueTest extends Api4TestBase {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function testServiceQueue_NeverComplete(): void {
-    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_service';
+    $queueName = 'QueueTest_' . bin2hex(random_bytes(16)) . '_service';
 
     $firedQueueStatus = [];
     \Civi::dispatcher()->addListener('hook_civicrm_queueStatus', function($e) use (&$firedQueueStatus) {


### PR DESCRIPTION
Using random_bytes is both faster and more secure than md5(uniqid(rand(), TRUE)). It is possibly also easier to read, in the sense that it is more obvious that it returns hexadecimal encoded random bytes.

I did not find an instance where guessing the random identifier would result in a security vulnerability. So this change does not have direct security impact as far as I know. It's more of a best practice thing and I hope people copy paste the new, secure way of generating random bytes when creating identifiers for security-sensitive stuff, instead of copying the old, insecure way.

In some test files the lengths of the random strings are one character longer. E.g. I replaced `substr(sha1(rand()), 0, 7)` with `bin2hex(random_bytes(4))`. The length did not seem very important here, so I don't think this matters.

I haven't tested all changed code. I rely on unit tests, and that the code generates a random hex string of a certain length before and after I replaced it.

I also looked into the SQL statements that use MD5(RAND()). These should be replaced by HEX(RANDOM_BYTES()), but this is only available starting in MariaDB 10.10, and we require 10.2.
