### PR TITLE
Fix another Financial Type ACL bug

### DIFF
--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -254,7 +254,8 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType im
       $financialTypeOptions = array_intersect_key($financialTypeOptions, $financialTypes);
     }
     if (!self::isACLFinancialTypeStatus()) {
-      return array_column($financialTypeOptions, 'label', 'id');
+      $financialTypes = array_column($financialTypeOptions, 'label', 'id');
+      return $financialTypes;
     }
 
     $actions = [

--- a/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
@@ -71,15 +71,21 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
    */
   public function testGetAvailableFinancialTypes(): void {
     $this->setACL();
+    FinancialType::create(FALSE)
+      ->addValue('label', 'New FinType')
+      ->addValue('name', 'new_fin_type')
+      ->execute();
     $this->setPermissions([
       'view contributions of type Donation',
       'view contributions of type Member Dues',
+      'view contributions of type new_fin_type',
     ]);
     $types = [];
     CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($types);
     $expectedResult = [
       1 => 'Donation',
       2 => 'Member Dues',
+      5 => 'New FinType',
     ];
     $this->assertEquals($expectedResult, $types, 'Verify that only certain financial types can be retrieved');
 
@@ -87,6 +93,7 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
       'view contributions of type Donation',
     ]);
     unset($expectedResult[2]);
+    unset($expectedResult[5]);
     CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($types);
     $this->assertEquals($expectedResult, $types, 'Verify that removing permission for a financial type restricts the available financial types');
   }

--- a/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
@@ -71,7 +71,7 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
    */
   public function testGetAvailableFinancialTypes(): void {
     $this->setACL();
-    FinancialType::create(FALSE)
+    $newFinancialType = FinancialType::create(FALSE)
       ->addValue('label', 'New FinType')
       ->addValue('name', 'new_fin_type')
       ->execute();
@@ -85,7 +85,7 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
     $expectedResult = [
       1 => 'Donation',
       2 => 'Member Dues',
-      5 => 'New FinType',
+      $newFinancialType[0]['id'] => 'New FinType',
     ];
     $this->assertEquals($expectedResult, $types, 'Verify that only certain financial types can be retrieved');
 
@@ -93,7 +93,7 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
       'view contributions of type Donation',
     ]);
     unset($expectedResult[2]);
-    unset($expectedResult[5]);
+    unset($expectedResult[$newFinancialType[0]['id']]);
     CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($types);
     $this->assertEquals($expectedResult, $types, 'Verify that removing permission for a financial type restricts the available financial types');
   }


### PR DESCRIPTION
Overview
----------------------------------------
While writing a test for #32189, I found two issues:
* My last change reintroduced the bug I was trying to solve, but only in some scenarios, because  `getAvailableFinancialTypes()` gets a value passed by reference AND returns a value.
* The expected behavior for adding and removing ACLs without clearing cache is different.

Before
----------------------------------------
Sometimes, permissions for financial types with mismatched names/labels are incorrect.

After
----------------------------------------
Fixed.

Comments
----------------------------------------
This became much more complicated because the test seems to suggest that removing financial ACL permissions should have an immediate effect, even if adding financial ACL permissions requires a cache clear.  Does that make sense? I don't know. But I had to jump through some hoops to maintain the original behavior.