### PR TITLE
Api4 - Use global cache for entityFields

### DIFF
--- a/Civi/API/Subscriber/SiteEmailLegacyOptionValueAdapter.php
+++ b/Civi/API/Subscriber/SiteEmailLegacyOptionValueAdapter.php
@@ -201,10 +201,6 @@ class SiteEmailLegacyOptionValueAdapter extends AutoSubscriber {
     $entityNameProperty = $reflection->getProperty('_entityName');
     $entityNameProperty->setAccessible(TRUE);
     $entityNameProperty->setValue($apiRequest, 'SiteEmailAddress');
-    // Also reset $_entityFields
-    $entityFieldsProperty = $reflection->getProperty('_entityFields');
-    $entityFieldsProperty->setAccessible(TRUE);
-    $entityFieldsProperty->setValue($apiRequest, NULL);
     $allowedFields = array_keys(\Civi::entity('SiteEmailAddress')->getFields());
     if ($reflection->hasProperty('where')) {
       $where = $apiRequest->getWhere();

--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -130,11 +130,6 @@ abstract class AbstractAction implements \ArrayAccess {
   /**
    * @var array
    */
-  protected $_entityFields;
-
-  /**
-   * @var array
-   */
   private $_arrayStorage = [];
 
   /**
@@ -455,20 +450,22 @@ abstract class AbstractAction implements \ArrayAccess {
    * @return array
    */
   public function entityFields() {
-    if (!$this->_entityFields) {
+    $entityName = $this->getEntityName();
+    $actionName = $this->getActionName();
+    if (empty(\Civi::$statics['Api4EntityFields'][$entityName][$actionName])) {
       $allowedTypes = ['Field', 'Filter', 'Extra'];
-      $getFields = \Civi\API\Request::create($this->getEntityName(), 'getFields', [
+      $getFields = \Civi\API\Request::create($entityName, 'getFields', [
         'version' => 4,
         'checkPermissions' => FALSE,
-        'action' => $this->getActionName(),
+        'action' => $actionName,
         'where' => [['type', 'IN', $allowedTypes]],
       ]);
       $result = new Result();
       // Pass TRUE for the private $isInternal param
       $getFields->_run($result, TRUE);
-      $this->_entityFields = (array) $result->indexBy('name');
+      \Civi::$statics['Api4EntityFields'][$entityName][$actionName] = (array) $result->indexBy('name');
     }
-    return $this->_entityFields;
+    return \Civi::$statics['Api4EntityFields'][$entityName][$actionName];
   }
 
   /**

--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -46,6 +46,8 @@ class SpecGatherer extends AutoService implements EventSubscriberInterface {
   public function onClearMetadata(): void {
     $this->entityActionValues = [];
     $this->fieldCache = [];
+    // Also clear static used by `entityFields()`
+    \Civi::$statics['Api4EntityFields'] = [];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Api4 performance improvement: fewer calls to getFields, more caching.
Fixes [dev/core#5757](https://lab.civicrm.org/dev/core/-/issues/5757)


Technical Details
----------------------------------------

Instead of caching entityFields once per instance, cache once per entity/action.