### PR TITLE
Remove the Financial Type from contribution and event receipts, update Billing Address label

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -385,6 +385,21 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'event_online_receipt', 'type' => 'html'],
         ],
       ],
+      [
+        'version' => '6.1.alpha1',
+        'upgrade_descriptor' => ts('Remove the Financial Type from contribution and event receipts. Rename Billing Address.'),
+        'templates' => [
+          ['name' => 'event_online_receipt', 'type' => 'html'],
+          ['name' => 'event_offline_receipt', 'type' => 'html'],
+          ['name' => 'contribution_online_receipt', 'type' => 'html'],
+          ['name' => 'contribution_offline_receipt', 'type' => 'html'],
+          ['name' => 'contribution_recurring_billing', 'type' => 'html'],
+          ['name' => 'membership_online_receipt', 'type' => 'html'],
+          ['name' => 'membership_offline_receipt', 'type' => 'html'],
+          ['name' => 'membership_autorenew_billing', 'type' => 'html'],
+          ['name' => 'payment_or_refund_notification', 'type' => 'html'],
+        ],
+      ],
     ];
   }
 

--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -139,7 +139,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
       '$100.00',
       'This Payment Amount',
       '$70.00',
-      'Billing Name and Address',
+      'Billing Address',
       'Vancouver, British Columbia 1321312',
       'Visa',
       '***********1111',
@@ -223,7 +223,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
       'check-12345',
     ],
     [
-      'Billing Name and Address',
+      'Billing Address',
       'Visa',
     ]);
     $mut->stop();
@@ -252,7 +252,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
       'Paid By',
       'Credit Card',
       '***********1111',
-      'Billing Name and Address',
+      'Billing Address',
       'Vancouver, British Columbia 1321312',
     ]);
     $mut->stop();

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -626,7 +626,6 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
       'Dear Anthony,',
       'Contribution Information',
       'Contributor Name Mr. Anthony Anderson II',
-      'Financial Type Donation',
       'Contribution Date ' . date('m/d/Y'),
       'Receipt Date ' . date('m/d/Y'),
     ]);
@@ -1210,8 +1209,6 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
       'Check',
       'Check Number',
       '12345',
-      'Financial Type',
-      'Donation',
     ]);
 
     $this->callAPISuccessGetCount('FinancialTrxn', [], 4);

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1169,7 +1169,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
       'contribution_id' => $contribution['id'],
     ], 1);
     $this->assertMailSentContainingStrings([
-      'Billing Name and Address',
+      'Billing Address',
       'Test Last',
       '10 Test St',
       'Test, AR 90210',

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3661,7 +3661,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     ]);
     $mut->checkMailLog([
       // billing header
-      'Billing Name and Address',
+      'Billing Address',
       // billing name
       'anthony_anderson@civicrm.org',
     ], [

--- a/xml/templates/message_templates/contribution_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_html.tpl
@@ -43,17 +43,6 @@
        {contact.display_name}
       </td>
      </tr>
-     <tr>
-      {if '{contribution.financial_type_id}'}
-        <td {$labelStyle}>
-         {ts}Financial Type{/ts}
-        </td>
-        <td {$valueStyle}>
-         {contribution.financial_type_id:label}
-        </td>
-      {/if}
-     </tr>
-
      {if $isShowLineItems}
        <tr>
         <td colspan="2" {$valueStyle}>
@@ -201,7 +190,7 @@
      {if !empty($ccContribution)}
       <tr>
        <th {$headerStyle}>
-        {ts}Billing Name and Address{/ts}
+        {ts}Billing Address{/ts}
        </th>
       </tr>
       <tr>

--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -291,7 +291,7 @@
      {if !empty($billingName)}
        <tr>
         <th {$headerStyle}>
-         {ts}Billing Name and Address{/ts}
+         {ts}Billing Address{/ts}
         </th>
        </tr>
        <tr>

--- a/xml/templates/message_templates/contribution_recurring_billing_html.tpl
+++ b/xml/templates/message_templates/contribution_recurring_billing_html.tpl
@@ -30,7 +30,7 @@
   <table style="width:100%; max-width:500px; border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse;">
     <tr>
         <th {$headerStyle}>
-         {ts}Billing Name and Address{/ts}
+         {ts}Billing Address{/ts}
         </th>
        </tr>
        <tr>

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -325,17 +325,6 @@
             </tr>
           {/if}
 
-          {if {contribution.financial_type_id|boolean}}
-            <tr>
-              <td {$labelStyle}>
-                  {ts}Financial Type{/ts}
-              </td>
-              <td {$valueStyle}>
-                {contribution.financial_type_id:label}
-              </td>
-            </tr>
-          {/if}
-
           {if {contribution.trxn_id|boolean}}
             <tr>
               <td {$labelStyle}>
@@ -372,7 +361,7 @@
           {if {contribution.address_id.display|boolean}}
             <tr>
               <th {$headerStyle}>
-                {ts}Billing Name and Address{/ts}
+                {ts}Billing Address{/ts}
               </th>
             </tr>
             <tr>

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -322,17 +322,6 @@
                 </tr>
               {/if}
 
-              {if {contribution.financial_type_id|boolean}}
-                <tr>
-                  <td {$labelStyle}>
-                    {ts}Financial Type{/ts}
-                  </td>
-                  <td {$valueStyle}>
-                    {contribution.financial_type_id:label}
-                  </td>
-                </tr>
-              {/if}
-
               {if {contribution.trxn_id|boolean}}
                 <tr>
                   <td {$labelStyle}>
@@ -369,7 +358,7 @@
               {if {contribution.address_id.display|boolean}}
                 <tr>
                   <th {$headerStyle}>
-                    {ts}Billing Name and Address{/ts}
+                    {ts}Billing Address{/ts}
                   </th>
                 </tr>
                 <tr>

--- a/xml/templates/message_templates/membership_autorenew_billing_html.tpl
+++ b/xml/templates/message_templates/membership_autorenew_billing_html.tpl
@@ -30,7 +30,7 @@
   <table style="width:100%; max-width:500px; border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse;">
    <tr>
         <th {$headerStyle}>
-         {ts}Billing Name and Address{/ts}
+         {ts}Billing Address{/ts}
         </th>
        </tr>
        <tr>

--- a/xml/templates/message_templates/membership_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_html.tpl
@@ -72,17 +72,6 @@
                   {ts}Membership Fee{/ts}
                 </th>
               </tr>
-              {if {contribution.financial_type_id|boolean}}
-                <tr>
-                  <td {$labelStyle}>
-                    {ts}Financial Type{/ts}
-                  </td>
-                  <td {$valueStyle}>
-                    {contribution.financial_type_id:label}
-                  </td>
-                </tr>
-              {/if}
-
               {if $isShowLineItems}
                   <tr>
                     <td colspan="2" {$valueStyle}>
@@ -215,7 +204,7 @@
             {if !empty($billingName)}
               <tr>
                 <th {$headerStyle}>
-                  {ts}Billing Name and Address{/ts}
+                  {ts}Billing Address{/ts}
                 </th>
               </tr>
               <tr>

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -284,7 +284,7 @@
     {if {contribution.address_id.display|boolean}}
       <tr>
         <th {$headerStyle}>
-          {ts}Billing Name and Address{/ts}
+          {ts}Billing Address{/ts}
         </th>
       </tr>
       <tr>

--- a/xml/templates/message_templates/payment_or_refund_notification_html.tpl
+++ b/xml/templates/message_templates/payment_or_refund_notification_html.tpl
@@ -145,7 +145,7 @@
     {if {contribution.address_id.display|boolean}}
         <tr>
           <th {$headerStyle}>
-              {ts}Billing Name and Address{/ts}
+              {ts}Billing Address{/ts}
           </th>
         </tr>
         <tr>


### PR DESCRIPTION
Overview
----------------------------------------

Two changes:

- Payments receipts sometimes mention the Financial Type of the contribution. This information, which is mostly for accounting purposes, is not relevant on those kind of receipts.
- Renames the label "Billing Name and Address" to just "Billing Address", because that label is long for no good reason other than being pedantic.

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/479ddecf-c19a-4c8f-96ff-d0ddf43d6d6d)

After
----------------------------------------

Gone :magic_wand: 

Comments
----------------------------------------

The `contribution_online_receipt_html` does not mention the Financial Type. I could not see if it was removed, or if it was never there.

cc @eileenmcnaughton @mattwire 