### PR TITLE
Don't suggest to admins to update their customized message templates when it's just a cosmetic change

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -385,21 +385,6 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'event_online_receipt', 'type' => 'html'],
         ],
       ],
-      [
-        'version' => '6.1.alpha1',
-        'upgrade_descriptor' => ts('Remove the Financial Type from contribution and event receipts. Rename Billing Address.'),
-        'templates' => [
-          ['name' => 'event_online_receipt', 'type' => 'html'],
-          ['name' => 'event_offline_receipt', 'type' => 'html'],
-          ['name' => 'contribution_online_receipt', 'type' => 'html'],
-          ['name' => 'contribution_offline_receipt', 'type' => 'html'],
-          ['name' => 'contribution_recurring_billing', 'type' => 'html'],
-          ['name' => 'membership_online_receipt', 'type' => 'html'],
-          ['name' => 'membership_offline_receipt', 'type' => 'html'],
-          ['name' => 'membership_autorenew_billing', 'type' => 'html'],
-          ['name' => 'payment_or_refund_notification', 'type' => 'html'],
-        ],
-      ],
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Updating customized message templates is a painstaking thing. Unless it's a necessary change for the template to keep functioning, we usually don't bother admins with the task.

Before
----------------------------------------
Upgrade shows message about needing to update message templates.

After
----------------------------------------
Upgrade doesn't show message. Anyone who hasn't customized them will get the updates anyway.

Technical Details
----------------------------------------


Comments
----------------------------------------
@mlutfy 
