### PR TITLE
Remove Enum from validTypes list; call deprecatedFunctionWarning

### DIFF
--- a/CRM/Utils/Type.php
+++ b/CRM/Utils/Type.php
@@ -84,7 +84,8 @@ class CRM_Utils_Type {
         break;
 
       case 3:
-        $string = 'Enum';
+        CRM_Core_Error::deprecatedFunctionWarning("Enum data type not supported.");
+        $string = 'String';
         break;
 
       case 4:
@@ -145,7 +146,6 @@ class CRM_Utils_Type {
     return [
       'Int' => self::T_INT,
       'String' => self::T_STRING,
-      'Enum' => self::T_ENUM,
       'Date' => self::T_DATE,
       'Time' => self::T_TIME,
       'Boolean' => self::T_BOOLEAN,


### PR DESCRIPTION
As per @colemanw 's [comment](https://lab.civicrm.org/documentation/docs/dev/-/merge_requests/1214#note_177974) `Enum` is not a valid type, but is found in the codebase.

This PR removes Enum from the list of valid types, and if typeToString() gets passed an Enum type it returns `"String"` instead and calls deprecatedFunctionWarning as I guess this is safest alternative?

Expecting that nothing ever calls typeToString with an Enum type and that the deprecatedFunctionWarning is actually unnecessary but it's softer than throwing an exception, although I haven't worked through what checks valid types and what that code would do if it came back invalid: perhaps it would be cleaner to remove Enum from typeToString too?
