### PR TITLE
Fix Duplicate Transaction Creation Due To Invalid Amount Comparison

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3134,7 +3134,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         $params['trxnParams']['total_amount'] = $trxnParams['total_amount'] = $params['total_amount'] = $totalAmount;
         $params['trxnParams']['trxn_id'] = $params['contribution']->trxn_id;
         if (isset($totalAmount) &&
-          $totalAmount != $params['prevContribution']->total_amount
+          bccomp($totalAmount, $params['prevContribution']->total_amount, 5) !== 0
         ) {
           //Update Financial Records
           $params['trxnParams']['from_financial_account_id'] = NULL;


### PR DESCRIPTION
Overview
----------------------------------------
In the line that is getting changed in this PR we are comparing two floats for equality but as per [php manual](https://www.php.net/manual/en/language.types.float.php) this can result in unexpected behaviours. For example consider a contribution of amount 1878.72 in which 1565.60 is the actual amount and 313.12 is the tax amount and if we add both [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Contribute/Form/Contribution.php#L2076) we should get 1878.72 but this is not the case as we get 1878.7199999999998 due to which the comparison in changed line was failing and we were ending with an extra transaction being created of amount 0 every time we edit the contribution.