### PR TITLE
Display error for API4 batch action

### DIFF
--- a/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
@@ -88,6 +88,7 @@
               runBatch();
             }
           }, function(error) {
+            CRM.alert(error.error_message, ts('Error'), 'error');
             ctrl.error();
           });
         // Move the bar every second to simulate progress between batches


### PR DESCRIPTION
Overview
----------------------------------------
There doesn't seem to be a way to get/display the error when an API4/angular batch action is executed.

Ideally we'd be able to pass the error through to `ctrl.error();` so that it is available here:

https://lab.civicrm.org/extensions/civirulesextras/-/blob/main/ang/triggerCivirule/crmSearchTaskTriggerCivirule.ctrl.js?ref_type=heads#L33

But that doesn't seem to be possible. The error *is* available in the browser if you look at the response.


Before
----------------------------------------
Error ignored and not shown to user.

After
----------------------------------------
Error shown to user.

Technical Details
----------------------------------------
Note that my code is based on an updated version of https://lab.civicrm.org/extensions/upgraderecur/-/blob/main/ang/updaterecur/crmSearchTaskChangeSubscription.ctrl.js

If you want to test this: Install civirules + civirulesextras. Go to "Manage CiviRules" and make sure you have at least one rule defined. Select it and click the actions menu. Select "Trigger CiviRule(s)".

Comments
----------------------------------------
@colemanw Any ideas if this is the right approach or if we could instead/and pass through the error?

@artfulrobot for ref as you started this!
