### PR TITLE
Afform - Fix maxlength comparisons

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -304,8 +304,8 @@ class Submit extends AbstractProcessor {
       $fullDefn = FormDataModel::getField($apiEntity, $fieldName, 'create');
       $maxlength = $fullDefn['input_attrs']['maxlength'] ?? NULL;
     }
-
-    if ($maxlength && strlen($value) > $maxlength) {
+    // Use mb_strlen() which better matches the behavior of javascript's String.length
+    if ($maxlength && mb_strlen($value) > $maxlength) {
       $fullDefn ??= FormDataModel::getField($apiEntity, $fieldName, 'create');
       $label = $attributes['defn']['label'] ?? $fullDefn['label'] ?? $fieldName;
       return E::ts('%1 has a max length of %2.', [1 => $label, 2 => $maxlength]);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5759
](https://lab.civicrm.org/dev/core/-/issues/5759)

Before
----------------------------------------
Server-side validation fails even if the client-side count is under the limit.

After
----------------------------------------
Serer-side and client-side counts match.

Technical Details
----------------------------------------
This seems to make php's strlen() match javascript's String.length, whereas before php thought the string was longer.


