### PR TITLE
Extract out remaining usage of MembershipPayment

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -631,7 +631,7 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
       $params['source_record_id'] = $membershipId;
       CRM_Activity_BAO_Activity::deleteActivity($params);
     }
-    self::deleteMembershipPayment($membershipId, $preserveContrib);
+    CRM_Member_BAO_MembershipPayment::deleteMembershipPayment($membershipId, $preserveContrib);
     CRM_Price_BAO_LineItem::deleteLineItems($membershipId, 'civicrm_membership');
 
     $results = $membership->delete();
@@ -1398,32 +1398,6 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
         $numRelatedAvailable--;
       }
     }
-  }
-
-  /**
-   * Delete the record that are associated with this Membership Payment.
-   *
-   * @param int $membershipId
-   * @param bool $preserveContrib
-   *
-   * @return object
-   *   $membershipPayment deleted membership payment object
-   */
-  public static function deleteMembershipPayment($membershipId, $preserveContrib = FALSE) {
-
-    $membershipPayment = new CRM_Member_DAO_MembershipPayment();
-    $membershipPayment->membership_id = $membershipId;
-    $membershipPayment->find();
-
-    while ($membershipPayment->fetch()) {
-      if (!$preserveContrib) {
-        CRM_Contribute_BAO_Contribution::deleteContribution($membershipPayment->contribution_id);
-      }
-      CRM_Utils_Hook::pre('delete', 'MembershipPayment', $membershipPayment->id, $membershipPayment);
-      $membershipPayment->delete();
-      CRM_Utils_Hook::post('delete', 'MembershipPayment', $membershipPayment->id, $membershipPayment);
-    }
-    return $membershipPayment;
   }
 
   /**

--- a/CRM/Member/BAO/MembershipPayment.php
+++ b/CRM/Member/BAO/MembershipPayment.php
@@ -136,4 +136,101 @@ class CRM_Member_BAO_MembershipPayment extends CRM_Member_DAO_MembershipPayment 
     return $latestContributionID ?? NULL;
   }
 
+  /**
+   * This is a helper function towards deprecating/removing MembershipPayment
+   * It checks for memberships linked via MembershipPayment with missing LineItems
+   *
+   * @param int $contributionID
+   * @param array $membershipIDsWithLineItems
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   * @internal
+   */
+  public static function getMembershipPaymentsWithMissingLineitems(int $contributionID, array $membershipIDsWithLineItems): array {
+    $doubleCheckParams = [
+      'return' => 'membership_id',
+      'contribution_id' => $contributionID,
+    ];
+    if (!empty($membershipIDsWithLineItems)) {
+      $doubleCheckParams['membership_id'] = ['NOT IN' => $membershipIDsWithLineItems];
+    }
+    $membershipPayments = civicrm_api3('MembershipPayment', 'get', $doubleCheckParams)['values'];
+    if (!empty($membershipPayments)) {
+      $membershipIDsWithLineItems = [];
+      self::deprecatedWarning($contributionID);
+      foreach ($membershipPayments as $membershipPayment) {
+        $membershipIDsWithLineItems[] = $membershipPayment['membership_id'];
+      }
+    }
+    return $membershipIDsWithLineItems;
+  }
+
+  /**
+   * Delete the records that are associated with this Membership Payment.
+   *
+   * @param int $membershipId
+   * @param bool $preserveContrib
+   *
+   * @return object
+   *   $membershipPayment deleted membership payment object
+   * @internal
+   */
+  public static function deleteMembershipPayment(int $membershipId, bool $preserveContrib = FALSE) {
+    $membershipPayment = new CRM_Member_DAO_MembershipPayment();
+    $membershipPayment->membership_id = $membershipId;
+    $membershipPayment->find();
+
+    while ($membershipPayment->fetch()) {
+      if (!$preserveContrib) {
+        CRM_Contribute_BAO_Contribution::deleteContribution($membershipPayment->contribution_id);
+      }
+      CRM_Utils_Hook::pre('delete', 'MembershipPayment', $membershipPayment->id, $membershipPayment);
+      $membershipPayment->delete();
+      CRM_Utils_Hook::post('delete', 'MembershipPayment', $membershipPayment->id, $membershipPayment);
+    }
+    return $membershipPayment;
+  }
+
+  /**
+   * @param int $membershipID
+   * @param int $contributionID
+   * @param bool $isSkipLineItem Creating a legacy MembershipPayment record creates a LineItem. If we already have a lineItem
+   *   set this to TRUE to skip creating lineItems
+   *
+   * @return void
+   * @throws \CRM_Core_Exception
+   * @internal
+   */
+  public static function legacyMembershipPaymentCreate(int $membershipID, int $contributionID, bool $isSkipLineItem = FALSE) {
+    $membershipPaymentParams = [
+      'membership_id' => $membershipID,
+      'contribution_id' => $contributionID,
+      'isSkipLineItem' => $isSkipLineItem,
+    ];
+    civicrm_api3('MembershipPayment', 'create', $membershipPaymentParams);
+  }
+
+  /**
+   * Checks if a MembershipPayment exists and if not creates one
+   *
+   * @param int $membershipID
+   * @param int $contributionID
+   * @param bool $isSkipLineItem Creating a legacy MembershipPayment record creates a LineItem. If we already have a lineItem
+   *   set this to TRUE to skip creating lineItems
+   *
+   * @return void
+   * @throws \CRM_Core_Exception
+   * @internal
+   */
+  public static function legacyMembershipPaymentCreateIfNotExist(int $membershipID, int $contributionID, bool $isSkipLineItem = FALSE) {
+    $membershipPayment = civicrm_api3('MembershipPayment', 'get', [
+      'membership_id' => $membershipID,
+      'contribution_id' => $contributionID,
+    ]);
+    if (empty($membershipPayment['count'])) {
+      self::legacyMembershipPaymentCreate($membershipID, $contributionID, $isSkipLineItem);
+    }
+  }
+
 }

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -62,16 +62,7 @@ class CRM_Price_BAO_LineItem extends CRM_Price_DAO_LineItem {
 
     $return = $lineItemBAO->save();
     if ($lineItemBAO->entity_table === 'civicrm_membership' && $lineItemBAO->contribution_id && $lineItemBAO->entity_id) {
-      $membershipPaymentParams = [
-        'membership_id' => $lineItemBAO->entity_id,
-        'contribution_id' => $lineItemBAO->contribution_id,
-      ];
-      if (!civicrm_api3('MembershipPayment', 'getcount', $membershipPaymentParams)) {
-        // If we are creating the membership payment row from the line item then we
-        // should have correct line item & membership payment should not need to fix.
-        $membershipPaymentParams['isSkipLineItem'] = TRUE;
-        civicrm_api3('MembershipPayment', 'create', $membershipPaymentParams);
-      }
+      CRM_Member_BAO_MembershipPayment::legacyMembershipPaymentCreateIfNotExist($lineItemBAO->entity_id, $lineItemBAO->contribution_id, TRUE);
     }
     if ($lineItemBAO->entity_table === 'civicrm_participant' && $lineItemBAO->contribution_id && $lineItemBAO->entity_id) {
       $participantPaymentParams = [


### PR DESCRIPTION
Overview
----------------------------------------
`MembershipPayment` entity is used to map Contributions to Memberships. But it is deprecated in favour of LineItems which provide the same information but in a more flexible manner.

However, we still have various bits of logic in CiviCRM either creating or relying on `MembershipPayment` records existing so we end up with some bizarre bugs and inconsistencies that are difficult to debug.

This PR takes the approach of extracting *all* MembershipPayment interaction out into functions in the `CRM_Member_BAO_MembershipPayment` class which gives us the ability to "turn off" all interaction with the `MembershipPayment` records or make consistent changes through the whole system.
Eg. `CRM_Member_BAO_MembershipPayment::getLatestContributionIDFromLineitemAndFallbackToMembershipPayment()` (split out into #32244) takes over all the places were we were using `getFieldValue()` to get a Contribution ID from a membership ID - see the PR for details. The logic was flawed previously. With this change it makes it really easy in future to simply turn off checking the MembershipPayment records.

Before
----------------------------------------
Various bits of MembershipPayment record logic in various places in the code.

After
----------------------------------------
All bits of MembershipPayment record extracted out to functions in `CRM_Member_BAO_MembershipPayment`. It's now a much simpler task to identify if they are actually required and to further deprecate/remove them.

Technical Details
----------------------------------------
Explained above.

Comments
----------------------------------------

