### PR TITLE
Standalone login page - fix input text color

### DIFF
--- a/ext/standaloneusers/css/standalone.css
+++ b/ext/standaloneusers/css/standalone.css
@@ -51,6 +51,7 @@ div.crm-container .standalone-auth-form input {
   height: 2rem;
   padding: 0.5rem;
   background-color: var(--crm-standalone-auth-box-bg);
+  color: var(--crm-standalone-auth-box-text);
 }
 .standalone-auth-form .login-or-forgot {
   display: grid;


### PR DESCRIPTION
Overview
----------------------------------------
On 6.0 branch the Standalone login box has fixed colors (always dark text on white background). 

Except for the input text color - which is being left up to the theme. However this is a problem if the theme sets input colors to white (e.g. Riverlea dark mode)

Before
----------------------------------------
- input text invisible in Riverlea dark mode

After
----------------------------------------
- input text visible in Riverlea dark mode


Comments
----------------------------------------
Note: the colour fixing is reverted on `master` in  https://github.com/civicrm/civicrm-core/pull/32153 (switch to a responsive svg logo). If this gets merged here and then forward merged to `master`, we will need to revert this line on `master`.
