### PR TITLE
Add function for setting max query execution time to core

### DIFF
--- a/CRM/Utils/AutoClean.php
+++ b/CRM/Utils/AutoClean.php
@@ -116,6 +116,15 @@ class CRM_Utils_AutoClean {
     });
   }
 
+  public static function swapMaxExecutionTime(int $newTime): CRM_Utils_AutoClean {
+    $originalTimeLimit = CRM_Core_DAO::setMaxExecutionTime($newTime);
+    $ac = new CRM_Utils_AutoClean();
+    $ac->args = [$originalTimeLimit];
+    $ac->callback = ['CRM_Core_DAO', 'setMaxExecutionTime'];
+    CRM_Core_DAO::setMaxExecutionTime($newTime);
+    return $ac;
+  }
+
   /**
    * Temporarily swap values using callback functions, and cleanup
    * when the current context shuts down.

--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -227,7 +227,7 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
       ],
       'SELECT * FROM whatever WHERE name = \'Alice\' AND title = \'Bob\' AND year LIKE \'%2012\' ',
     ];
-    list($inputSql, $inputParams, $expectSql) = $cases[0];
+    [$inputSql, $inputParams, $expectSql] = $cases[0];
     $actualSql = CRM_Core_DAO::composeQuery($inputSql, $inputParams);
     $this->assertFalse(($expectSql == $actualSql));
     unset($scope);
@@ -690,6 +690,21 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
     foreach ($expectedCidRefs as $table => $refs) {
       $this->assertEquals($refs, $cidRefs[$table]);
     }
+  }
+
+  /**
+   * Test our ability to alter the maximum execution time temporarily.
+   *
+   * https://mariadb.com/kb/en/aborting-statements/
+   *
+   * @return void
+   */
+  public function testSetMaxExecutionTime() {
+    $original = CRM_Core_DAO::getMaxExecutionTime();
+    $autoClean = CRM_Utils_AutoClean::swapMaxExecutionTime(800);
+    $this->assertEquals(800, CRM_Core_DAO::getMaxExecutionTime());
+    $autoClean->cleanup();
+    $this->assertEquals($original, CRM_Core_DAO::getMaxExecutionTime());
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Add function for setting max query execution time to core

Before
----------------------------------------
@twomice has figured out how to leverage mysql / mariaDB max execution variable in an extension but it is not available to core / other extensions

https://github.com/JoineryHQ/com.joineryhq.dupmon/blob/master/CRM/Dupmon/Util.php#L126-L131

After
----------------------------------------
New Core functions 
`CRM_Core_DAO::getMaxExecutionTime()`
`CRM_Core_DAO::setMaxExecutionTime()`

With recommended usage being
```
$autoClean = CRM_Utils_AutoClean::swapMaxExecutionTime(800);
$autoClean->cleanup();
```



Technical Details
----------------------------------------
We don't know if there are any non-handled edge cases - hopefully tests can try a few sql versions.... 

However, this currently has no core callers outside of the unit test so we can add it cautiously.

I propose we follow up by adding a core caller in `hook_civicrm_findExistingDuplicates()` - this core code currently has no users as it is only called when the new hidden, installed on upgrade and new installs `legacydedupefinder` extension is enabled. This is allowing is to roll out less tested but more performant dedupe methodology.

We would need to determine a core setting to replace the one in https://github.com/JoineryHQ/com.joineryhq.dupmon/blob/master/CRM/Dupmon/Util.php#L194C6-L194C27 and possibly think about managing the migration with @twomice - either a version check or cutting a new extension release for 6.1 would do it

Comments
----------------------------------------

