### PR TITLE
Activity import - convert to  apiv4

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -14,14 +14,23 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-
+use Civi\Api4\Activity;
 
 /**
  * Class to parse activity csv files.
  */
 class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
 
-  protected $_newActivity;
+  /**
+   * Has this parser been fixed to expect `getMappedRow` to break it up
+   * by entity yet? This is a transitional property to allow the classes
+   * to be fixed up individually.
+   *
+   * @var bool
+   */
+  protected $isUpdatedForEntityRowParsing = TRUE;
+
+  protected string $baseEntity = 'Activity';
 
   /**
    * Get information about the provided job.
@@ -48,7 +57,7 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
   /**
    * The initializer code, called before the processing.
    */
-  public function init() {
+  public function init(): void {
     $this->setFieldMetadata();
   }
 
@@ -58,119 +67,34 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
    * @param array $values
    *   The array of values belonging to this line.
    */
-  public function import($values) {
+  public function import(array $values): void {
     $rowNumber = (int) ($values[array_key_last($values)]);
     // First make sure this is a valid line
     try {
       $params = $this->getMappedRow($values);
+      $activityParams = $params['Activity'];
+      $targetContactParams = $params['TargetContact'] ?? [];
+      $sourceContactParams = $params['SourceContact'] ?? [];
 
-      if (!empty($params['source_contact_external_identifier'])) {
-        $params['source_contact_id'] = $this->lookupExternalIdentifier($params['source_contact_external_identifier'], $this->getContactType(), $params['contact_id'] ?? NULL);
+      $activityParams['target_contact_id'] = $this->getContactID($targetContactParams, empty($targetContactParams['id']) ? NULL : (int) $targetContactParams['id'], 'TargetContact', $this->getDedupeRulesForEntity('TargetContact'));
+
+      try {
+        $activityParams['source_contact_id'] = $this->getContactID($sourceContactParams, empty($sourceContactParams['id']) ? NULL : (int) $sourceContactParams['id'], 'SourceContact', $this->getDedupeRulesForEntity('SourceContact'));
       }
-
-      if (empty($params['external_identifier']) && empty($params['target_contact_id'])) {
-
-        // Retrieve contact id using contact dedupe rule.
-        // Since we are supporting only individual's activity import.
-        $params['contact_type'] = 'Individual';
-        $params['version'] = 3;
-        $matchedIDs = CRM_Contact_BAO_Contact::getDuplicateContacts($params, 'Individual');
-
-        if (!empty($matchedIDs)) {
-          if (count($matchedIDs) > 1) {
-            throw new CRM_Core_Exception('Multiple matching contact records detected for this row. The activity was not imported');
-          }
-          $cid = $matchedIDs[0];
-          $params['target_contact_id'] = $cid;
-          $params['version'] = 3;
-          $newActivity = civicrm_api('activity', 'create', $params);
-          if (!empty($newActivity['is_error'])) {
-            throw new CRM_Core_Exception($newActivity['error_message']);
-          }
-
-          $this->_newActivity[] = $newActivity['id'];
-          $this->setImportStatus($rowNumber, 'IMPORTED', '', $newActivity['id']);
-          return;
-
-        }
-        // Using new Dedupe rule.
-        $ruleParams = [
-          'contact_type' => 'Individual',
-          'used' => 'Unsupervised',
-        ];
-        $fieldsArray = CRM_Dedupe_BAO_DedupeRule::dedupeRuleFields($ruleParams);
-
-        $disp = NULL;
-        foreach ($fieldsArray as $value) {
-          if (array_key_exists(trim($value), $params)) {
-            $paramValue = $params[trim($value)];
-            if (is_array($paramValue)) {
-              $disp .= $params[trim($value)][0][trim($value)] . " ";
-            }
-            else {
-              $disp .= $params[trim($value)] . " ";
-            }
-          }
-        }
-        if (empty($params['id'])) {
-          throw new CRM_Core_Exception('No matching Contact found for (' . $disp . ')');
+      catch (CRM_Core_Exception $e) {
+        if (empty($activityParams['id'])) {
+          $activityParams['source_contact_id'] = CRM_Core_Session::getLoggedInContactID();
         }
       }
-      if (!empty($params['external_identifier'])) {
-        $targetContactId = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact',
-          $params['external_identifier'], 'id', 'external_identifier'
-        );
-
-        if (!empty($params['target_contact_id']) &&
-          $params['target_contact_id'] != $targetContactId
-        ) {
-          throw new CRM_Core_Exception('Mismatch of External ID:' . $params['external_identifier'] . ' and Contact Id:' . $params['target_contact_id']);
-        }
-        if ($targetContactId) {
-          $params['target_contact_id'] = $targetContactId;
-        }
-        else {
-          throw new CRM_Core_Exception('No Matching Contact for External ID:' . $params['external_identifier']);
-        }
-      }
-
-      $params['version'] = 3;
-      $newActivity = civicrm_api('activity', 'create', $params);
-      if (!empty($newActivity['is_error'])) {
-        throw new CRM_Core_Exception($newActivity['error_message']);
-      }
+      $newActivity = Activity::save()
+        ->addRecord($activityParams)
+        ->execute()->first();
     }
     catch (CRM_Core_Exception $e) {
       $this->setImportStatus($rowNumber, 'ERROR', $e->getMessage());
       return;
     }
-    $this->_newActivity[] = $newActivity['id'];
     $this->setImportStatus($rowNumber, 'IMPORTED', '', $newActivity['id']);
-  }
-
-  /**
-   * Get the row from the csv mapped to our parameters.
-   *
-   * @param array $values
-   *
-   * @return array
-   * @throws \CRM_Core_Exception
-   */
-  public function getMappedRow(array $values): array {
-    $params = [];
-    foreach ($this->getFieldMappings() as $i => $mappedField) {
-      if ($mappedField['name'] === 'do_not_import') {
-        continue;
-      }
-      if ($mappedField['name']) {
-        $fieldName = $this->getFieldMetadata($mappedField['name'])['name'];
-        if (in_array($mappedField['name'], ['target_contact_id', 'source_contact_id', 'source_contact_external_identifier'])) {
-          $fieldName = $mappedField['name'];
-        }
-        $params[$fieldName] = $this->getTransformedFieldValue($mappedField['name'], $values[$i]);
-      }
-    }
-    return $params;
   }
 
   /**
@@ -182,61 +106,63 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
 
   /**
    * Ensure metadata is loaded.
+   *
+   * @throws \CRM_Core_Exception
    */
   protected function setFieldMetadata(): void {
     if (empty($this->importableFieldsMetadata)) {
-      $fields = ['' => ['title' => ts('- do not import -')]];
-
-      $tmpFields = CRM_Activity_DAO_Activity::import();
-      $contactFields = CRM_Contact_BAO_Contact::importableFields('Individual', NULL);
-
-      // Using new Dedupe rule.
-      $ruleParams = [
-        'contact_type' => 'Individual',
-        'used' => 'Unsupervised',
-      ];
-      $fieldsArray = CRM_Dedupe_BAO_DedupeRule::dedupeRuleFields($ruleParams);
-
-      $tmpContactField = [];
-      if (is_array($fieldsArray)) {
-        foreach ($fieldsArray as $value) {
-          $customFieldId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField',
-            $value,
-            'id',
-            'column_name'
-          );
-          $value = trim($customFieldId ? 'custom_' . $customFieldId : $value);
-          $tmpContactField[$value] = $contactFields[$value];
-          $tmpContactField[$value]['title'] = $tmpContactField[$value]['title'] . " (match to contact)";
-        }
+      $fields = ['' => ['title' => '- ' . ts('do not import') . ' -']]
+        + (array) Activity::getFields()
+          ->addWhere('readonly', '=', FALSE)
+          ->addWhere('usage', 'CONTAINS', 'import')
+          ->setAction('save')
+          ->addOrderBy('title')
+          ->execute()->indexBy('name');
+      $contactFields = $this->getContactFields('Individual');
+      foreach ($contactFields as &$field) {
+        // At this stage all fields except those specifically marked are the target_contact.
+        $field['entity_instance'] = 'TargetContact';
       }
-      $tmpContactField['external_identifier'] = $contactFields['external_identifier'];
-      $tmpContactField['external_identifier']['title'] = $contactFields['external_identifier']['title'] . ' (target contact)' . ' (match to contact)';
-      $tmpContactField['source_contact_external_identifier'] = $contactFields['external_identifier'];
-      $tmpContactField['source_contact_external_identifier']['title'] = $contactFields['external_identifier']['title'] . ' (source contact)' . ' (match to contact)';
+      $fields['target_contact.id'] = $contactFields['id'];
+      $fields['target_contact.id']['entity'] = 'Contact';
+      $fields['target_contact.id']['match_rule'] = '*';
+      $fields['source_contact.id'] = $fields['target_contact.id'];
+      $fields['source_contact.id']['entity_instance'] = 'SourceContact';
+      $fields['source_contact.id']['title'] .= ' ' . ts('(match to source contact)');
+      $fields['target_contact.id']['title'] .= ' ' . ts('(match to target contact)');
+      unset($contactFields['id']);
 
-      $fields = array_merge($fields, $tmpContactField);
-      $fields = array_merge($fields, $tmpFields);
-      $fields = array_merge($fields, CRM_Core_BAO_CustomField::getFieldsForImport('Activity'));
-
-      $fields = array_merge($fields, [
-        'source_contact_id' => [
-          'title' => ts('Source Contact'),
-          'headerPattern' => '/Source.Contact?/i',
-          'name' => 'source_type_id',
-          'options' => FALSE,
-          'type' => CRM_Utils_Type::T_INT,
-        ],
-        'target_contact_id' => [
-          'title' => ts('Target Contact'),
-          'headerPattern' => '/Target.Contact?/i',
-          'name' => 'target_type_id',
-          'options' => FALSE,
-          'type' => CRM_Utils_Type::T_INT,
-        ],
-      ]);
+      $fields += $contactFields;
+      $fields['target_contact.external_identifier'] = $contactFields['external_identifier'];
+      $fields['target_contact.external_identifier']['title'] = $contactFields['external_identifier']['title'] . ' (target contact)';
+      $fields['source_contact.external_identifier'] = $contactFields['external_identifier'];
+      $fields['source_contact.external_identifier']['entity_instance'] = 'SourceContact';
+      $fields['source_contact.external_identifier']['title'] = $contactFields['external_identifier']['title'] . ' (source contact)';
+      unset($fields['external_identifier']);
       $this->importableFieldsMetadata = $fields;
     }
+  }
+
+  /**
+   * Get the metadata field for which importable fields does not key the actual field name.
+   *
+   * This is intended as a transitional function to handle fields like
+   * (and probably only) target_contact.email_primary.email when the
+   * declared field is 'email_primary.email'
+   *
+   * @return string[]
+   */
+  protected function getOddlyMappedMetadataFields(): array {
+    $contactSpecificFields = [];
+    foreach ($this->importableFieldsMetadata as $index => $field) {
+      if (!str_starts_with($index, 'target_contact.')
+        && !str_starts_with($index, 'source_contact')
+        && ($field['entity'] ?? '') === 'Contact') {
+        $contactSpecificFields['target_contact.' . $index] = $index;
+        $contactSpecificFields['source_contact.' . $index] = $index;
+      }
+    }
+    return $contactSpecificFields;
   }
 
 }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -890,13 +890,20 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     if (!is_array($requirement)) {
       // In this case we need to match the field....
       // if we do, then return empty, otherwise return
-      if (!empty($params[$requirement])) {
-        if (!is_array($params[$requirement])) {
+      if (isset($this->baseEntity)) {
+        $value = $params[$this->baseEntity][$requirement] ?? $params[$requirement] ?? NULL;
+      }
+      else {
+        $value = $params[$requirement] ?? NULL;
+      }
+
+      if ($value) {
+        if (!is_array($value)) {
           return [];
         }
         // Recurse the array looking for the key - eg. look for email
         // in a location values array
-        foreach ($params[$requirement] as $locationValues) {
+        foreach ($value as $locationValues) {
           if (!empty($locationValues[$requirement])) {
             return [];
           }
@@ -1403,7 +1410,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
           // Split values into arrays by entity.
           // Apiv4 name is currently only set for contact, & only in cases where it would
           // be used for the dedupe rule (ie Membership import).
-          $params[$entity][$fieldSpec['apiv4_name'] ?? $fieldSpec['name']] = $this->getTransformedFieldValue($mappedField['name'], $values[$i]);
+          $params[$entity][$fieldSpec['name']] = $this->getTransformedFieldValue($mappedField['name'], $values[$i]);
         }
         else {
           $params[$fieldSpec['name']] = $this->getTransformedFieldValue($mappedField['name'], $values[$i]);

--- a/CRM/Upgrade/Incremental/php/SixOne.php
+++ b/CRM/Upgrade/Incremental/php/SixOne.php
@@ -22,6 +22,23 @@
 class CRM_Upgrade_Incremental_php_SixOne extends CRM_Upgrade_Incremental_Base {
 
   /**
+   * @param string $importType
+   *
+   * @return int
+   * @throws \CRM_Core_Exception
+   */
+  public static function getMappingTypeID(string $importType): int {
+    $mappingTypeID = (int) CRM_Core_DAO::singleValueQuery("
+      SELECT option_value.value
+      FROM civicrm_option_value option_value
+        INNER JOIN civicrm_option_group option_group
+        ON option_group.id = option_value.option_group_id
+        AND option_group.name =  'mapping_type'
+      WHERE option_value.name = '{$importType}'");
+    return $mappingTypeID;
+  }
+
+  /**
    * Upgrade step; adds tasks including 'runSql'.
    *
    * @param string $rev
@@ -147,80 +164,92 @@ class CRM_Upgrade_Incremental_php_SixOne extends CRM_Upgrade_Incremental_Base {
   /**
    * Update the fields that have been converted to apiv4 within the field mappings
    * - participant_import : email => email_primary.email (there are no other pre-existing contact fields)
+   *
    * @return bool
-   */
-  public static function updateFieldMappingsForImport(): bool {
-    $mappingFields = self::getMappingFieldsForImportType(['Import Participant', 'Import Membership']);
-    // The only possible contact field for participant import is email
-    // as only the email rule can be selected. However, keeping the 'set'
-    // together (from Contribution convert in FiveFiftyFour) feels like
-    // it has merit
-    $fieldsToConvert = [
-      'email' => 'email_primary.email',
-      'phone' => 'phone_primary.phone',
-      'street_address' => 'address_primary.street_address',
-      'supplemental_address_1' => 'address_primary.supplemental_address_1',
-      'supplemental_address_2' => 'address_primary.supplemental_address_2',
-      'supplemental_address_3' => 'address_primary.supplemental_address_3',
-      'city' => 'address_primary.city',
-      'county_id' => 'address_primary.county_id',
-      'state_province_id' => 'address_primary.state_province_id',
-      'country_id' => 'address_primary.country_id',
-      'membership_id' => 'membership.id',
-      'membership_contact_id' => 'membership.contact_id',
-      'membership_start_date' => 'membership.start_date',
-      'membership_type_id' => 'membership.membership_type_id',
-      'membership_join_date' => 'membership.join_date',
-      'membership_end_date' => 'membership.end_date',
-      'membership_source' => 'membership.source',
-      'member_is_override' => 'membership.is_override',
-      'status_override_end_date' => 'membership.status_override_end_date',
-      'member_is_test' => 'membership.is_test',
-      'member_is_pay_later' => 'membership.is_pay_later',
-      'member_campaign_id' => 'membership.campaign_id',
-    ];
-    $customFields = CRM_Core_DAO::executeQuery('
-      SELECT custom_field.id, custom_field.name, custom_group.name as custom_group_name
-      FROM civicrm_custom_field custom_field INNER JOIN civicrm_custom_group custom_group
-      ON custom_field.custom_group_id = custom_group.id
-      WHERE extends IN ("Contact", "Individual", "Organization", "Household", "Participant", "Membership")
-    ');
-    while ($customFields->fetch()) {
-      $fieldsToConvert['custom_' . $customFields->id] = $customFields->custom_group_name . '.' . $customFields->name;
-    }
-    while ($mappingFields->fetch()) {
-      // Convert the field.
-      if (isset($fieldsToConvert[$mappingFields->name])) {
-        CRM_Core_DAO::executeQuery(' UPDATE civicrm_mapping_field SET name = %1 WHERE id = %2', [
-          1 => [$fieldsToConvert[$mappingFields->name], 'String'],
-          2 => [$mappingFields->id, 'Integer'],
-        ]);
-      }
-    }
-    return TRUE;
-  }
-
-  /**
-   * @return \CRM_Core_DAO
-   * @throws \CRM_Core_Exception
    * @throws \Civi\Core\Exception\DBQueryException
    */
-  public static function getMappingFieldsForImportType(array $importTypes): CRM_Core_DAO {
-    $mappingTypeID = (int) CRM_Core_DAO::singleValueQuery("
-      SELECT option_value.value
-      FROM civicrm_option_value option_value
-        INNER JOIN civicrm_option_group option_group
-        ON option_group.id = option_value.option_group_id
-        AND option_group.name =  'mapping_type'
-      WHERE option_value.name IN ('" . implode("','", $importTypes) . "')");
-
-    $mappingFields = CRM_Core_DAO::executeQuery('
+  public static function updateFieldMappingsForImport(): bool {
+    $importTypes = ['Import Participant', 'Import Membership', 'Import Activity'];
+    foreach ($importTypes as $importType) {
+      $mappingFields = CRM_Core_DAO::executeQuery('
       SELECT field.id, field.name FROM civicrm_mapping_field field
         INNER JOIN civicrm_mapping mapping
           ON field.mapping_id = mapping.id
-          AND mapping_type_id = ' . $mappingTypeID
-    );
-    return $mappingFields;
+          AND mapping_type_id = ' . self::getMappingTypeID($importType));
+      // The only possible contact field for participant import is email
+      // as only the email rule can be selected. However, keeping the 'set'
+      // together (from Contribution convert in FiveFiftyFour) feels like
+      // it has merit
+      $fieldsToConvert = [
+        'email' => 'email_primary.email',
+        'phone' => 'phone_primary.phone',
+        'street_address' => 'address_primary.street_address',
+        'supplemental_address_1' => 'address_primary.supplemental_address_1',
+        'supplemental_address_2' => 'address_primary.supplemental_address_2',
+        'supplemental_address_3' => 'address_primary.supplemental_address_3',
+        'city' => 'address_primary.city',
+        'county_id' => 'address_primary.county_id',
+        'state_province_id' => 'address_primary.state_province_id',
+        'country_id' => 'address_primary.country_id',
+        'membership_id' => 'membership.id',
+        'membership_contact_id' => 'membership.contact_id',
+        'membership_start_date' => 'membership.start_date',
+        'membership_type_id' => 'membership.membership_type_id',
+        'membership_join_date' => 'membership.join_date',
+        'membership_end_date' => 'membership.end_date',
+        'membership_source' => 'membership.source',
+        'member_is_override' => 'membership.is_override',
+        'status_override_end_date' => 'membership.status_override_end_date',
+        'member_is_test' => 'membership.is_test',
+        'member_is_pay_later' => 'membership.is_pay_later',
+        'member_campaign_id' => 'membership.campaign_id',
+        'source_contact_id' => 'source_contact.id',
+        'target_contact_id' => 'target_contact.id',
+        'source_contact_external_identifier' => 'source_contact.external_identifier',
+        'activity_id' => 'id',
+        'activity_subject' => 'subject',
+        'activity_type_id' => 'activity_type_id',
+        'activity_date_time' => 'activity_date_time',
+        'activity_duration' => 'duration',
+        'activity_location' => 'location',
+        'activity_details' => 'details',
+        'activity_status_id' => 'status_id',
+        'activity_priority_id' => 'priority_id',
+        'priority_id' => 'priority_id',
+        'activity_is_test' => 'is_test',
+        'activity_is_deleted' => 'is_deleted',
+        'activity_campaign_id' => 'campaign_id',
+        'activity_engagement_level' => 'engagement_level',
+        'activity_is_star' => 'is_star',
+      ];
+      if ($importType === 'Import Activity') {
+        $fieldsToConvert['email'] = 'target_contact.email_primary.email';
+        $fieldsToConvert['external_identifier'] = 'target_contact.external_identifier';
+      }
+      if ($importType === 'Import Membership') {
+        $fieldsToConvert['status_id'] = 'membership.status_id';
+      }
+
+      $customFields = CRM_Core_DAO::executeQuery('
+      SELECT custom_field.id, custom_field.name, custom_group.name as custom_group_name, custom_group.extends
+      FROM civicrm_custom_field custom_field INNER JOIN civicrm_custom_group custom_group
+      ON custom_field.custom_group_id = custom_group.id
+      WHERE extends IN ("Contact", "Individual", "Organization", "Household", "Participant", "Membership", "Activity")
+    ');
+      while ($customFields->fetch()) {
+        $fieldsToConvert['custom_' . $customFields->id] = $customFields->custom_group_name . '.' . $customFields->name;
+      }
+      while ($mappingFields->fetch()) {
+        // Convert the field.
+        if (isset($fieldsToConvert[$mappingFields->name])) {
+          CRM_Core_DAO::executeQuery(' UPDATE civicrm_mapping_field SET name = %1 WHERE id = %2', [
+            1 => [$fieldsToConvert[$mappingFields->name], 'String'],
+            2 => [$mappingFields->id, 'Integer'],
+          ]);
+        }
+      }
+    }
+    return TRUE;
   }
 
 }

--- a/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
@@ -18,6 +18,7 @@
  *   <http://www.gnu.org/licenses/>.
  */
 
+use Civi\Api4\ActivityContact;
 use Civi\Api4\UserJob;
 
 /**
@@ -56,12 +57,12 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
   public function testImport(): void {
     $this->createCustomGroupWithFieldOfType(['extends' => 'Activity'], 'checkbox');
     $values = [
-      'activity_details' => 'fascinating',
+      'details' => 'fascinating',
       'activity_type_id' => 1,
       'activity_date_time' => '2010-01-06',
-      'target_contact_id' => $this->individualCreate(),
-      'activity_subject' => 'riveting stuff',
-      $this->getCustomFieldName('checkbox') => 'L',
+      'target_contact.id' => $this->individualCreate(),
+      'subject' => 'riveting stuff',
+      $this->getCustomFieldName('checkbox', 4) => 'L',
     ];
     $this->importValues($values);
     $this->callAPISuccessGetSingle('Activity', [$this->getCustomFieldName('checkbox') => 'L']);
@@ -126,17 +127,20 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
    * Test validation of various fields.
    *
    * @dataProvider activityImportValidationProvider
+   *
    * @param array $input
    * @param string $expectedError
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testActivityImportValidation(array $input, string $expectedError): void {
     // Supplement some values that can't be done in a data provider because of timing.
-    if (!isset($input['target_contact_id'])) {
-      $input['target_contact_id'] = $this->individualCreate();
+    if (!isset($input['target_contact.id'])) {
+      $input['target_contact.id'] = $this->individualCreate();
     }
     if (isset($input['replace_me_custom_field'])) {
       $this->createCustomGroupWithFieldOfType(['extends' => 'Activity'], 'radio');
-      $input[$this->getCustomFieldName('radio')] = $input['replace_me_custom_field'];
+      $input[$this->getCustomFieldName('radio', 4)] = $input['replace_me_custom_field'];
       unset($input['replace_me_custom_field']);
     }
 
@@ -170,7 +174,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
         'input' => [
           'activity_type_id' => 1,
           'activity_date_time' => $some_date,
-          'activity_subject' => 'asubj',
+          'subject' => 'asubj',
         ],
         'expected_error' => '',
       ],
@@ -179,7 +183,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
         'input' => [
           'activity_type_id' => 1,
           'activity_date_time' => $some_date,
-          'activity_subject' => 'asubj',
+          'subject' => 'asubj',
           'replace_me_custom_field' => '3',
         ],
         'expected_error' => '',
@@ -189,7 +193,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
         'input' => [
           'activity_type_id' => 'Meeting',
           'activity_date_time' => $some_date,
-          'activity_subject' => 'asubj',
+          'subject' => 'asubj',
         ],
         'expected_error' => '',
       ],
@@ -198,7 +202,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
         'input' => [
           'activity_type_id' => 1,
           'activity_date_time' => $some_date,
-          'activity_subject' => 'asubj',
+          'subject' => 'asubj',
         ],
         'expected_error' => '',
       ],
@@ -207,7 +211,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
         'input' => [
           'activity_type_id' => 1,
           'activity_date_time' => $some_date,
-          'activity_subject' => 'asubj',
+          'subject' => 'asubj',
         ],
         'expected_error' => '',
       ],
@@ -216,7 +220,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
         'input' => [
           'activity_type_id' => 'Meeting',
           'activity_date_time' => $some_date,
-          'activity_subject' => 'asubj',
+          'subject' => 'asubj',
         ],
         'expected_error' => '',
       ],
@@ -224,7 +228,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
       7 => [
         'input' => [
           'activity_date_time' => $some_date,
-          'activity_subject' => 'asubj',
+          'subject' => 'asubj',
         ],
         'expected_error' => 'Missing required fields',
       ],
@@ -233,7 +237,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
         'input' => [
           'activity_type_id' => '',
           'activity_date_time' => $some_date,
-          'activity_subject' => 'asubj',
+          'subject' => 'asubj',
         ],
         'expected_error' => 'Missing required fields',
       ],
@@ -241,7 +245,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
       9 => [
         'input' => [
           'activity_type_id' => 'Meeting',
-          'activity_subject' => 'asubj',
+          'subject' => 'asubj',
         ],
         'expected_error' => 'Missing required fields',
       ],
@@ -250,7 +254,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
         'input' => [
           'activity_type_id' => 'Meeting',
           'activity_date_time' => '',
-          'activity_subject' => 'asubj',
+          'subject' => 'asubj',
         ],
         'expected_error' => 'Missing required fields',
       ],
@@ -273,39 +277,39 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
         'input' => [
           'activity_type_id' => 'Meeting',
           'activity_date_time' => $some_date,
-          'activity_subject' => '',
+          'subject' => '',
         ],
         'expected_error' => '',
       ],
 
-      13 => [
+      'invalid_custom_field' => [
         'input' => [
           'activity_type_id' => 'Meeting',
           'activity_date_time' => $some_date,
-          'activity_subject' => 'asubj',
+          'subject' => 'asubj',
           'replace_me_custom_field' => 'InvalidValue',
         ],
-        'expected_error' => 'Invalid value for field(s) : Integer radio',
+        'expected_error' => 'Invalid value for field(s) : Group with field radio: Integer radio',
       ],
 
-      14 => [
+      'present_but_empty_custom_field' => [
         'input' => [
           'activity_type_id' => 'Meeting',
           'activity_date_time' => $some_date,
-          'activity_subject' => 'asubj',
+          'subject' => 'asubj',
           'replace_me_custom_field' => '',
         ],
         'expected_error' => '',
       ],
       // a way to find the contact id is required.
-      15 => [
+      'missing_target_contact_id' => [
         'input' => [
-          'target_contact_id' => '',
+          'target_contact.id' => '',
           'activity_type_id' => 'Meeting',
           'activity_date_time' => $some_date,
-          'activity_subject' => 'asubj',
+          'subject' => 'asubj',
         ],
-        'expected_error' => 'No matching Contact found for ()',
+        'expected_error' => 'No matching TargetContact found',
       ],
 
     ];
@@ -319,8 +323,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
   protected function getMapperFromFieldMappings(array $mappings): array {
     $mapper = [];
     foreach ($mappings as $mapping) {
-      $fieldInput = [$mapping['name']];
-      $mapper[] = $fieldInput;
+      $mapper[] = $mapping['name'];
     }
     return $mapper;
   }
@@ -332,14 +335,14 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
     $this->individualCreate(['email' => 'mum@example.com']);
     $this->importCSV('activity.csv', [
       ['name' => 'activity_date_time'],
-      ['name' => 'activity_status_id'],
-      ['name' => 'email'],
+      ['name' => 'status_id'],
+      ['name' => 'target_contact.email_primary.email'],
       ['name' => 'activity_type_id'],
-      ['name' => 'activity_details'],
-      ['name' => 'activity_duration'],
+      ['name' => 'details'],
+      ['name' => 'duration'],
       ['name' => 'priority_id'],
-      ['name' => 'activity_location'],
-      ['name' => 'activity_subject'],
+      ['name' => 'location'],
+      ['name' => 'subject'],
       ['name' => 'do_not_import'],
     ]);
     $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
@@ -350,32 +353,38 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
 
   /**
    * Test the full form-flow import and make sure we can map source/target external identifier correctly.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testImportCSVExternalIdentifier() :void {
     $contactID1 = $this->individualCreate(['email' => 'mum@example.com', 'external_identifier' => 'individual1']);
     $contactID2 = $this->individualCreate(['email' => 'mum@example.com', 'external_identifier' => 'individual2'], 'individual_2');
     $this->importCSV('activityexternalidentifier.csv', [
       ['name' => 'activity_date_time'],
-      ['name' => 'activity_status_id'],
-      ['name' => 'email'],
+      ['name' => 'status_id'],
+      ['name' => 'target_contact.email_primary.email'],
       ['name' => 'activity_type_id'],
-      ['name' => 'activity_details'],
-      ['name' => 'activity_duration'],
+      ['name' => 'details'],
+      ['name' => 'duration'],
       ['name' => 'priority_id'],
-      ['name' => 'activity_location'],
-      ['name' => 'activity_subject'],
+      ['name' => 'location'],
+      ['name' => 'subject'],
       ['name' => 'do_not_import'],
-      ['name' => 'source_contact_external_identifier'],
-      ['name' => 'external_identifier'],
+      ['name' => 'source_contact.external_identifier'],
+      ['name' => 'target_contact.external_identifier'],
     ]);
     $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
     $row = $dataSource->getRow();
     $this->assertEquals('IMPORTED', $row['_status']);
     $activity = $this->callAPISuccessGetSingle('Activity', ['priority_id' => 'Urgent']);
-    $activityContacts = $this->callAPISuccess('ActivityContact', 'get', ['activity_id' => $activity['id'], 'sequential' => TRUE]);
-    $this->assertCount(2, $activityContacts['values']);
-    $this->assertEquals($activityContacts['values'][0]['contact_id'], $contactID1);
-    $this->assertEquals($activityContacts['values'][1]['contact_id'], $contactID2);
+    $activityContacts = ActivityContact::get(FALSE)
+      ->addWhere('activity_id', '=', $activity['id'])
+      ->addSelect('record_type_id:name')
+      ->addSelect('contact_id')
+      ->execute()->indexBy('record_type_id:name');
+    $this->assertCount(2, $activityContacts);
+    $this->assertEquals($contactID1, $activityContacts['Activity Source']['contact_id']);
+    $this->assertEquals($contactID2, $activityContacts['Activity Targets']['contact_id']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Activity import - convert to apiv4

Before
----------------------------------------
Activity import uses apiv3

After
----------------------------------------
uses apiv4

Technical Details
----------------------------------------
all mappings are namespaced - ie `activity.id` `target_contact.id` - as this is a very flat import this is fairly simple (conceptually _

Comments
----------------------------------------
