### PR TITLE
Remove do-nothing legacy code

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -351,11 +351,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
             $break = TRUE;
           }
 
-          if (!$break) {
-            if (!empty($value['location_type_id'])) {
-              $this->formatLocationBlock($value, $formatted);
-            }
-          }
         }
         if (!$isAddressCustomField) {
           continue;
@@ -1103,67 +1098,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     }
     Civi::cache('fields')->set($cacheKey, $fields);
     return $fields;
-  }
-
-  /**
-   * Format location block ready for importing.
-   *
-   * Note this formatting should all be by the time the code reaches this point
-   *
-   * There is some test coverage for this in
-   * CRM_Contact_Import_Parser_ContactTest e.g. testImportPrimaryAddress.
-   *
-   * @deprecated
-   *
-   * @param array $values
-   *
-   * @return bool
-   * @throws \CRM_Core_Exception
-   */
-  protected function formatLocationBlock(&$values) {
-    // @todo - remove this function.
-    // Original explantion .....
-    // Note: we doing multiple value formatting here for address custom fields, plus putting into right format.
-    // The actual formatting (like date, country ..etc) for address custom fields is taken care of while saving
-    // the address in CRM_Core_BAO_Address::create method
-    if (!empty($values['location_type_id'])) {
-      static $customFields = [];
-      if (empty($customFields)) {
-        $customFields = CRM_Core_BAO_CustomField::getFields('Address');
-      }
-      // make a copy of values, as we going to make changes
-      $newValues = $values;
-      foreach ($values as $key => $val) {
-        $customFieldID = CRM_Core_BAO_CustomField::getKeyID($key);
-        if ($customFieldID && array_key_exists($customFieldID, $customFields)) {
-
-          $htmlType = $customFields[$customFieldID]['html_type'] ?? NULL;
-          if (CRM_Core_BAO_CustomField::isSerialized($customFields[$customFieldID]) && $val) {
-            $mulValues = explode(',', $val);
-            $customOption = CRM_Core_BAO_CustomOption::getCustomOption($customFieldID, TRUE);
-            $newValues[$key] = [];
-            foreach ($mulValues as $v1) {
-              foreach ($customOption as $v2) {
-                if ((strtolower($v2['label']) == strtolower(trim($v1))) ||
-                  (strtolower($v2['value']) == strtolower(trim($v1)))
-                ) {
-                  if ($htmlType == 'CheckBox') {
-                    $newValues[$key][$v2['value']] = 1;
-                  }
-                  else {
-                    $newValues[$key][] = $v2['value'];
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-      // consider new values
-      $values = $newValues;
-    }
-
-    return TRUE;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Remove do-nothing legacy code

Before
----------------------------------------
Code from previously shared function passes in 2 variables

1) `$value` this is received & possibly altered in the function, but never used again in the calling function
2) `$formatted` - this is not received by the function as it is no longer part of the function signature
![image](https://github.com/user-attachments/assets/a6448a46-384d-4fa7-803a-ee297ca4a9ba)

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
