### PR TITLE
Remove unused function

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -756,38 +756,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   }
 
   /**
-   * This is code extracted from 4 places where this exact snippet was being duplicated.
-   *
-   * FIXME: Extracting this was a first step, but there's also
-   *  1. Inconsistency in the way other select options are handled.
-   *     Contribution adds handling for Select/Radio/Autocomplete
-   *     Participant/Activity only handles Select/Radio and misses Autocomplete
-   *     Membership is missing all of it
-   *  2. Inconsistency with the way this works vs. how it's implemented in Contact import.
-   *
-   * @param $customFieldID
-   * @param $value
-   * @param $fieldType
-   * @return array
-   */
-  public static function unserializeCustomValue($customFieldID, $value, $fieldType) {
-    $mulValues = explode(',', $value);
-    $customOption = CRM_Core_BAO_CustomOption::getCustomOption($customFieldID, TRUE);
-    $values = [];
-    foreach ($mulValues as $v1) {
-      foreach ($customOption as $customValueID => $customLabel) {
-        $customValue = $customLabel['value'];
-        if ((strtolower(trim($customLabel['label'])) == strtolower(trim($v1))) ||
-          (strtolower(trim($customValue)) == strtolower(trim($v1)))
-        ) {
-          $values[] = $customValue;
-        }
-      }
-    }
-    return $values;
-  }
-
-  /**
    * Validate that the field requirements are met in the params.
    *
    * @param array $requiredFields


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused function

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/84727c01-874d-4bcb-a1fe-b0acbc5134f7)


After
----------------------------------------
poof

Technical Details
----------------------------------------
Per the code comments this was only ever really transitional so I don't think we need to worry about it not having been formally deprecated

Comments
----------------------------------------
