### PR TITLE
dev/core#5758: event listing page refreshes to participant add form with pager, more/less than 20 items

### DIFF
--- a/CRM/Event/Page/Tab.php
+++ b/CRM/Event/Page/Tab.php
@@ -103,7 +103,7 @@ class CRM_Event_Page_Tab extends CRM_Core_Page {
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
 
-    if (($context == 'standalone' || $context === 'search') && ($this->_action !== CRM_Core_Action::VIEW && $this->_action !== CRM_Core_Action::UPDATE)) {
+    if (($context == 'standalone' || $context === 'search') && ($this->_action !== CRM_Core_Action::BROWSE && $this->_action !== CRM_Core_Action::VIEW && $this->_action !== CRM_Core_Action::UPDATE)) {
       $this->_action = CRM_Core_Action::ADD;
     }
     else {


### PR DESCRIPTION


Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5758

Before
----------------------------------------
Reproduction steps

- Go to page on contact with more than 20 event registrations

- Enter Events tab scrool down and select other number than current rows per page.

 - Ajax page load event register form.

After
----------------------------------------
Fixed


Comments
----------------------------------------
ping @colemanw @seamuslee001 