### PR TITLE
Simplify updatedAmount calculation in LineItem changeFeeSelections()

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -613,16 +613,7 @@ WHERE li.contribution_id = %1";
 
     $lineItemObj->addLineItemOnChangeFeeSelection($requiredChanges['line_items_to_add'], $entityID, $entityTable, $contributionId);
 
-    $count = 0;
-    if ($entity == 'participant') {
-      $count = count(CRM_Event_BAO_Participant::getParticipantIds($contributionId));
-    }
-    else {
-      $count = civicrm_api3('MembershipPayment', 'getcount', ['contribution_id' => $contributionId]);
-    }
-    if ($count > 1) {
-      $updatedAmount = CRM_Price_BAO_LineItem::getLineTotal($contributionId);
-    }
+    $updatedAmount = CRM_Price_BAO_LineItem::getLineTotal($contributionId);
     $displayParticipantCount = '';
     if ($totalParticipant > 0) {
       $displayParticipantCount = ' Participant Count -' . $totalParticipant;


### PR DESCRIPTION
Overview
----------------------------------------
Partial from https://github.com/civicrm/civicrm-core/pull/32222

Currently we count the number of participants or the number of memberships and if count > 0 we calculate the updated lineItem amount.
However, if we just calculate the updated amount that's one query instead of at least two and we get to simplify the code.

Before
----------------------------------------
Checking counts before calculating updated amount.

After
----------------------------------------
Just calculate updated amount.

Technical Details
----------------------------------------


Comments
----------------------------------------

