### PR TITLE
Simplify tab count calculation

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -354,9 +354,10 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
         ->setValues(['address_id' => $contributionAddressID])->execute();
     }
     if ($this->getContributionID() && CRM_Core_Permission::access('CiviMember')) {
-      $membershipPaymentCount = civicrm_api3('MembershipPayment', 'getCount', ['contribution_id' => $this->_contributionId]);
-      if ($membershipPaymentCount) {
-        $this->ajaxResponse['updateTabs']['#tab_member'] = CRM_Contact_BAO_Contact::getCountComponent('membership', $this->_contactID);
+      $membershipCount = CRM_Contact_BAO_Contact::getCountComponent('membership', $this->_contactID);
+      // @fixme: Probably don't need a variable here but the old code counted MembershipPayment records and only returned a count if > 0
+      if ($membershipCount) {
+        $this->ajaxResponse['updateTabs']['#tab_member'] = $membershipCount;
       }
     }
     if ($this->getContributionID() && CRM_Core_Permission::access('CiviEvent')) {

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1156,9 +1156,10 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     }
     $this->ajaxResponse['updateTabs']['#tab_activity'] = TRUE;
     if (!empty($this->_id) && CRM_Core_Permission::access('CiviMember')) {
-      $membershipPaymentCount = civicrm_api3('MembershipPayment', 'getCount', ['contribution_id' => $this->_id]);
-      if ($membershipPaymentCount) {
-        $this->ajaxResponse['updateTabs']['#tab_member'] = CRM_Contact_BAO_Contact::getCountComponent('membership', $this->_contactID);
+      $membershipCount = CRM_Contact_BAO_Contact::getCountComponent('membership', $this->_contactID);
+      // @fixme: Probably don't need a variable here but the old code counted MembershipPayment records and only returned a count if > 0
+      if ($membershipCount) {
+        $this->ajaxResponse['updateTabs']['#tab_member'] = $membershipCount;
       }
     }
     if (!empty($this->_id) && CRM_Core_Permission::access('CiviEvent')) {


### PR DESCRIPTION
Overview
----------------------------------------
Partial from https://github.com/civicrm/civicrm-core/pull/32222

Simplify calculations for tab counts so we just do the count instead of counting MembershipPayments to see if we should do the count.

Before
----------------------------------------
Count membershipPayments and if we have any return a tab count.

After
----------------------------------------
Do a tab count and if not empty return it.

Technical Details
----------------------------------------
Note: Maybe we could simplify further and just return the tab count always. But just in case there's any weird logic that relies on the array key being set or not I left that part the same - i.e. only assigning if there is a count.

Comments
----------------------------------------

