### PR TITLE
Get Membership Contribution from LineItem instead of MembershipPayment

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3420,7 +3420,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       }
     }
     elseif ($component == 'membership') {
-      $contributionId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipPayment', $id, 'contribution_id', 'membership_id');
+      $contributionId = CRM_Member_BAO_MembershipPayment::getLatestContributionIDFromLineitemAndFallbackToMembershipPayment($id);
     }
     else {
       $contributionId = $id;

--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -374,7 +374,7 @@ WHERE ceft.entity_id = %1";
       $contributionId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_ParticipantPayment', $entityId, 'contribution_id', 'participant_id');
     }
     elseif ($entityName == 'membership') {
-      $contributionId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipPayment', $entityId, 'contribution_id', 'membership_id');
+      $contributionId = CRM_Member_BAO_MembershipPayment::getLatestContributionIDFromLineitemAndFallbackToMembershipPayment($entityId);
     }
     else {
       $contributionId = $entityId;

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -312,16 +312,10 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
     // once we are rid of direct calls to the BAO::create from core
     // we will deprecate this stuff into the v3 api.
     if (($params['version'] ?? 0) !== 4) {
-      // @todo further cleanup required to remove use of $ids['contribution'] from here
       if (isset($ids['membership'])) {
-        $contributionID = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipPayment',
-          $membership->id,
-          'contribution_id',
-          'membership_id'
-        );
-        // @todo this is a temporary step to removing $ids['contribution'] completely
-        if (empty($params['contribution_id']) && !empty($contributionID)) {
-          $params['contribution_id'] = $contributionID;
+        $latestContributionID = CRM_Member_BAO_MembershipPayment::getLatestContributionIDFromLineitemAndFallbackToMembershipPayment($membership->id);
+        if (empty($params['contribution_id']) && !empty($latestContributionID)) {
+          $params['contribution_id'] = $latestContributionID;
         }
       }
 
@@ -341,7 +335,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
       // If the membership has no associated contribution then we ensure
       // the line items are 'correct' here. This is a lazy legacy
       // hack whereby they are deleted and recreated
-      if (empty($contributionID)) {
+      if (empty($latestContributionID)) {
         if (!empty($params['lineItems'])) {
           $params['line_item'] = $params['lineItems'];
         }

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1394,12 +1394,8 @@ DESC limit 1");
       }
 
       // retrieve the related contribution ID
-      $contributionID = CRM_Core_DAO::getFieldValue(
-        'CRM_Member_DAO_MembershipPayment',
-        $this->getMembershipID(),
-        'contribution_id',
-        'membership_id'
-      );
+      $contributionID = CRM_Member_BAO_MembershipPayment::getLatestContributionIDFromLineitemAndFallbackToMembershipPayment($this->getMembershipID());
+
       // get price fields of chosen price-set
       $priceSetDetails = CRM_Utils_Array::value(
         $this->_priceSetId,

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -183,11 +183,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     $defaults['receive_date'] = $now . ' ' . CRM_Utils_Time::date('H:i:s');
 
     if ($defaults['id']) {
-      $defaults['record_contribution'] = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipPayment',
-        $defaults['id'],
-        'contribution_id',
-        'membership_id'
-      );
+      $defaults['record_contribution'] = CRM_Member_BAO_MembershipPayment::getLatestContributionIDFromLineitemAndFallbackToMembershipPayment($defaults['id']);
     }
 
     $defaults['financial_type_id'] = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType', $this->_memType, 'financial_type_id');

--- a/api/v3/MembershipPayment.php
+++ b/api/v3/MembershipPayment.php
@@ -13,7 +13,6 @@
  * This api exposes CiviCRM membership contribution link.
  *
  * @package CiviCRM_APIv3
- * @todo delete function doesn't exist
  */
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
There are various places in the code that still use `membershipPayment` to identify the Contribution for a given Membership.
This is problematic for a few reasons:
- MembershipPayment is deprecated and we should be getting the information from LineItems instead. But older CiviCRM systems probably have data with MembershipPayment but no LineItems so without writing a migration/upgrade script we cannot simply remove "MembershipPayment".
- Most of the places which get the contribution are using `CRM_Core_DAO::getFieldValue()` which generally returns the first one that it finds. Usually that's the lowest by ID but SQL doesn't guarantee that. In any case the lowest by ID is almost certainly NOT the one we want as we usually want the most recent contribution. Which would *usually* be the latest by ID, but not necessarily (eg. if data was imported).
- There are assumptions in a couple of places that if a MembershipPayment doesn't exist then we should delete *ALL* lineitems for a given membership. That seems completely mad... especially as MembershipPayment is per contribution.
- If lineitems get deleted the membership doesn't get renewed automatically and people get upset or pay twice.

I'm really struggling to reliably reproduce the problem in a test environment. On a live environment with Stripe setup I'm finding it happening intermittently.
Last time this happened was about 8 months ago and it was "fixed" with this PR: https://github.com/civicrm/civicrm-core/pull/30493 which solved the problem because API3 Membership::create and there was no chance of the problematic `CRM_Price_BAO_LineItem::deleteLineItems` being called via the job.

However, the problem started again in the last few weeks as the client has another round of renewals. This time the only caller of API3 `Membership::create` and `CRM_Price_BAO_LineItem::deleteLineItems` is via the API3 `Contribution::repeattransaction` which is triggered via Stripe webhooks when recurring contribution payments are received.

The same symptoms can be found in the database. All contributions missing lineitems. What I *have* found is that the ones that are deleting lineItems don't have MembershipPayment records. That's probably because of the way the original records were created/imported and I *could* create MembershipPayment records for them. But that doesn't really fix the underlying problem of disappearing lineitems.

I've created a function `CRM_Member_BAO_MembershipPayment::getLatestContributionIDFromLineitemAndFallbackToMembershipPayment()` to replace the `CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipPayment', [membershipID], 'contribution_id', 'membership_id');`
That changes the logic from:
- Get a random contribution (probably lowest by ID) that is linked to the membership via a MembershipPayment record.

To:
- Try to get most recent (by Contribution Receive Date) Contribution from LineItems with the matching MembershipID.
- If not found, try to get the most recent (by Contribution Receive Date) Contribution from MembershipPayment with the matching MembershipID.

I've replaced all instances of the `CRM_Core_DAO::getFieldValue(..)` with this new function.

Before
----------------------------------------
Bad use of MembershipPayment records.

After
----------------------------------------
Good use of LineItems, with fallback to good use of MembershipPayment records.

Technical Details
----------------------------------------
Explained above I think

Comments
----------------------------------------

