### PR TITLE
Standalone - Faster page load times

### DIFF
--- a/Civi/Standalone/WebEntrypoint.php
+++ b/Civi/Standalone/WebEntrypoint.php
@@ -15,6 +15,7 @@ class WebEntrypoint {
    * @see self::checkCiviInstalled
    */
   public static function index(): void {
+    define('CIVICRM_UF_HEAD', TRUE);
     if (self::checkCiviInstalled()) {
       ErrorHandler::setHandler();
       self::invoke();


### PR DESCRIPTION
Overview
----------------------------------------
Loads every page faster

Before
----------------------------------------
Standalone is sluggish, especially loading a page like SearchKit.

After
----------------------------------------
Much faster.

Technical Details
----------------------------------------
The html header is already loaded by the standalone CMS; this avoids multiple redundant re-renders.