### PR TITLE
(REF) Remove dead code (re: CIVICRM_UF_HEAD)

### DIFF
--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -269,11 +269,6 @@ class CRM_Core_Page {
     }
 
     $content = self::$_template->fetch(CRM_Utils_System::getContentTemplate());
-
-    // Render page header
-    if (!defined('CIVICRM_UF_HEAD') && $region = CRM_Core_Region::instance('html-header', FALSE)) {
-      CRM_Utils_System::addHTMLHead($region->render(''));
-    }
     CRM_Utils_System::appendTPLFile($pageTemplateFile, $content);
 
     //its time to call the hook.

--- a/CRM/Core/QuickForm/Action/Display.php
+++ b/CRM/Core/QuickForm/Action/Display.php
@@ -116,9 +116,6 @@ class CRM_Core_QuickForm_Action_Display extends CRM_Core_QuickForm_Action {
 
     $content = $template->fetch($controller->getTemplateFile());
 
-    if (!defined('CIVICRM_UF_HEAD') && $region = CRM_Core_Region::instance('html-header', FALSE)) {
-      CRM_Utils_System::addHTMLHead($region->render(''));
-    }
     CRM_Utils_System::appendTPLFile($pageTemplateFile,
       $content,
       $page->overrideExtraTemplateFileName()

--- a/CRM/Queue/Page/Runner.php
+++ b/CRM/Queue/Page/Runner.php
@@ -51,10 +51,6 @@ class CRM_Queue_Page_Runner extends CRM_Core_Page {
     ]);
 
     if ($runner->isMinimal) {
-      // Render page header
-      if (!defined('CIVICRM_UF_HEAD') && $region = CRM_Core_Region::instance('html-header', FALSE)) {
-        CRM_Utils_System::addHTMLHead($region->render(''));
-      }
       $smarty = CRM_Core_Smarty::singleton();
       $content = $smarty->fetch('CRM/Queue/Page/Runner.tpl');
       echo CRM_Utils_System::theme($content, $this->_print, TRUE);

--- a/CRM/Upgrade/Page/Upgrade.php
+++ b/CRM/Upgrade/Page/Upgrade.php
@@ -107,11 +107,6 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
       $template->assign('upgraded', FALSE);
     }
 
-    // Render page header
-    if (!defined('CIVICRM_UF_HEAD') && $region = CRM_Core_Region::instance('html-header', FALSE)) {
-      CRM_Utils_System::addHTMLHead($region->render(''));
-    }
-
     $content = $template->fetch('CRM/common/success.tpl');
     echo CRM_Utils_System::theme($content, $this->_print, TRUE);
   }
@@ -184,11 +179,6 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
     $template->assign('upgraded', TRUE);
     $template->assign('newVersion', $latestVer);
     $template->assign('sid', CRM_Utils_System::getSiteID());
-
-    // Render page header
-    if (!defined('CIVICRM_UF_HEAD') && $region = CRM_Core_Region::instance('html-header', FALSE)) {
-      CRM_Utils_System::addHTMLHead($region->render(''));
-    }
 
     $content = $template->fetch('CRM/common/success.tpl');
     echo CRM_Utils_System::theme($content, $this->_print, TRUE);

--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -397,10 +397,6 @@ class CRM_Utils_REST {
       $smarty->assign('tplFile', $tpl);
       $config = CRM_Core_Config::singleton();
       $content = $smarty->fetch('CRM/common/' . strtolower($config->userFramework) . '.tpl');
-
-      if (!defined('CIVICRM_UF_HEAD') && $region = CRM_Core_Region::instance('html-header', FALSE)) {
-        CRM_Utils_System::addHTMLHead($region->render(''));
-      }
       CRM_Utils_System::appendTPLFile($tpl, $content);
 
       return CRM_Utils_System::theme($content);


### PR DESCRIPTION
Overview
--------

This is a general cleanup that removes old, transitional code.

Technical Details
-----------------

If you search all the UF integrations, every one defines the constant very early:

```
WordPress/civicrm.php:define('CIVICRM_UF_HEAD', TRUE);
backdrop/civicrm.module:define('CIVICRM_UF_HEAD', TRUE);
drupal/civicrm.module:define('CIVICRM_UF_HEAD', TRUE); 
joomla/site/civicrm.php:  define('CIVICRM_UF_HEAD', TRUE);
joomla/admin/admin.civicrm.php:  define('CIVICRM_UF_HEAD', TRUE);
drupal-8/civicrm.module:define('CIVICRM_UF_HEAD', TRUE); 
Civi/Standalone/WebEntrypoint.php:  define('CIVICRM_UF_HEAD', TRUE);
```

Consequently, `CIVICRM_UF_HEAD` is always defined. We never need to fallback on these code-paths where `CIVICRM_UF_HEAD` is undefined.

Ancient History
---------------

Around the time of Drupal 5/6, Civi used the following method to output the HTML header:

```
CRM_Utils_System::addHTMLHead()
```

As we see in this patch, the method was sprinkled in many random places (`CRM_Core_Page`, `CRM_Core_QuickForm_Action_Display`, etc). Of course, this is a bit brittle because:

1. When creating new kinds of pages, you need to sprinkle-in more calls to it.
2. Each UF has its own lifecycle for generating HTML HEAD. If you call this method at some random moment, it might work for one UF -- but not on another UF.

`CIVICRM_UF_HEAD` was an opt-out: each UF-integration could announce: "_We don't need random pages  outputting the HEAD. The UF-integration has one really good place where it will do the job._"

And now-a-days, that's what they do. All UF-integrations set `CIVICRM_UF_HEAD`. 

Comments
---------------

As another follow-up, we could also remove the various `define()`s from the UF repos. ___However___, that should be in a ___subsequent version___ (e.g. 6.2 or 6.3). If the two cleanups are in the same version, then __git-bisections and debugging will get quite confusing__. It's easier to just phase-in the cleanup across versions.