### PR TITLE
issue#5726 : Repeat Activity triggers an error

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/ActionScheduleSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ActionScheduleSpecProvider.php
@@ -29,8 +29,7 @@ class ActionScheduleSpecProvider extends \Civi\Core\Service\AutoService implemen
       $spec->getFieldByName('name')->setRequired(FALSE);
       // Repeat events do not require mapping_id or start_action_unit (or seemingly start_action_condition)- although
       // we don't have that level of nuance available so we make them optional for all events.
-      $spec->getFieldByName('mapping_id')->setRequiredIf('empty($values.used_for) || $values.used_for !== "civicrm_event"');
-      $spec->getFieldByName('start_action_unit')->setRequiredIf('empty($values.absolute_date) && (empty($values.used_for) || $values.used_for !== "civicrm_event")');
+      $spec->getFieldByName('mapping_id')->setRequiredIf('empty($values.used_for)');
       $spec->getFieldByName('start_action_condition')->setRequiredIf('empty($values.absolute_date) && (empty($values.used_for) || $values.used_for !== "civicrm_event")');
       $spec->getFieldByName('entity_value')->setRequired(TRUE);
       $spec->getFieldByName('start_action_offset')->setRequiredIf('empty($values.absolute_date)');


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5726

Before
----------------------------------------
On using 'Repeat Activity' at the bottom of the Activity edit screen and save, you get the following error and only the original Activity is saved:

> Mandatory values missing from Api4 ActionSchedule::save: start_action_unit, mapping_id

After
----------------------------------------
Correctly saved. 

Technical Details
----------------------------------------
This reverts commit [0f589cef49495bebcd1fb97ba5ef76385bd9586b](https://github.com/civicrm/civicrm-core/commit/0f589cef49495bebcd1fb97ba5ef76385bd9586b) . It works with `CRM_Core_BAO_ActionSchedule::writeRecord()` because it doesn't pass through validator but when we use save action it eventually hits the validator and throw the error message: 
```
Civi\Api4\Generic\AbstractSaveAction->validateValues() | /Users/monish/src/civicrm-core/Civi/Api4/Generic/DAOSaveAction.php:40
Civi\Api4\Generic\DAOSaveAction->_run(Object(Civi\Api4\Generic\Result)) | /Users/monish/src/civicrm-core/Civi/Api4/Provider/ActionObjectProvider.php:91
Civi\Api4\Provider\ActionObjectProvider->invoke(Object(Civi\Api4\Generic\DAOSaveAction)) | /Users/monish/src/civicrm-core/Civi/API/Kernel.php:153
Civi\API\Kernel->runRequest(Object(Civi\Api4\Generic\DAOSaveAction)) | /Users/monish/src/civicrm-core/Civi/Api4/Generic/AbstractAction.php:256
Civi\Api4\Generic\AbstractAction->execute() | /Users/monish/src/civicrm-core/CRM/Core/Form/RecurringEntity.php:366
CRM_Core_Form_RecurringEntity::postProcess(Array, 'civicrm_activity', Array) | /Users/monish/src/civicrm-core/CRM/Activity/Form/Activity.php:1009
```
It failed for mapping_id and start_action_unit values because these have following `required_if` condition:
1. Mapping ID - `empty($values.used_for) || $values.used_for !== "civicrm_event"`
2. Start action unit - `empty($values.absolute_date) && (empty($values.used_for) || $values.used_for !== "civicrm_event")`
The actual record which is passed to `ActionSchedule::save` action [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Form/RecurringEntity.php#L360) is : 
```
2025-02-28 09:37:23+0000  [info] $dbParams = Array
(
    [used_for] => civicrm_activity
    [entity_value] => 664
    [start_action_date] => 20250228092200
    [repetition_frequency_unit] => week
    [repetition_frequency_interval] => 1
    [start_action_condition] => sunday,monday
    [start_action_offset] => 2
)
```

I think that required_if condition is bit incorrect in this case as we have the user_for value but since its not civicrm_event it will always fail and and the start_action_unit should also check for start_action_date along with absolute date ? 

So I suppose the validators should be : 

1. Mapping ID - `empty($values.used_for) || ($values.used_for !== "civicrm_event" && $values.used_for !== "civicrm_activity")`
2. Start action unit - `empty($values.absolute_date) && empty($values.start_action_date) && (empty($values.used_for) || ($values.used_for !== "civicrm_event" && $values.used_for !== "civicrm_activity"))`

If you agree with this logic I will submit a separate PR against master and submit another PR dependent on it restore Eilieen;s commit. 
 
Comments
----------------------------------------
ping @colemanw @eileenmcnaughton @seamuslee001 