### PR TITLE
Call Membership BAO::create directly instead of API3. This bypasses some duplicate functions and stops passing in ids[membership]

### DIFF
--- a/Civi/Membership/OrderCompleteSubscriber.php
+++ b/Civi/Membership/OrderCompleteSubscriber.php
@@ -164,8 +164,7 @@ class OrderCompleteSubscriber extends AutoService implements EventSubscriberInte
       //so make status override false.
       $membershipParams['is_override'] = FALSE;
       $membershipParams['status_override_end_date'] = 'null';
-      $membership = civicrm_api3('Membership', 'create', $membershipParams);
-      $membership = $membership['values'][$membership['id']];
+      $membershipBAO = \CRM_Member_BAO_Membership::create($membershipParams);
       // Update activity to Completed.
       // Perhaps this should be in Membership::create? Test cover in
       // api_v3_ContributionTest.testPendingToCompleteContribution.
@@ -173,10 +172,10 @@ class OrderCompleteSubscriber extends AutoService implements EventSubscriberInte
         'status_id:name' => 'Completed',
         'subject' => ts('Status changed from %1 to %2'), [
           1 => $priorMembershipStatus,
-          2 => \CRM_Core_PseudoConstant::getLabel('CRM_Member_BAO_Membership', 'status_id', $membership['status_id']),
+          2 => \CRM_Core_PseudoConstant::getLabel('CRM_Member_BAO_Membership', 'status_id', $membershipBAO->status_id),
         ],
 
-      ])->addWhere('source_record_id', '=', $membership['id'])
+      ])->addWhere('source_record_id', '=', $membershipBAO->id)
         ->addWhere('status_id:name', '=', 'Scheduled')
         ->addWhere('activity_type_id:name', 'IN', ['Membership Signup', 'Membership Renewal'])
         ->execute();


### PR DESCRIPTION
Overview
----------------------------------------
Towards not passing `$ids['membership']` into `CRM_Member_BAO_Membership::create()`

Before
----------------------------------------
API3 always passes in $ids

After
----------------------------------------
Not using API3 so not passed in.

Technical Details
----------------------------------------


Comments
----------------------------------------
Was part of #32222
