### PR TITLE
issue#5764 Cancel the correct participant records when cancelling contributions

### DIFF
--- a/ext/contributioncancelactions/contributioncancelactions.php
+++ b/ext/contributioncancelactions/contributioncancelactions.php
@@ -45,8 +45,11 @@ function contributioncancelactions_cancel_related_pending_participant_records(in
   if (empty($cancellableParticipantRecords)) {
     return;
   }
+  foreach ($cancellableParticipantRecords as $record) {
+    $participantIDs[] = $record['participant_id'];
+  }
   Participant::update(FALSE)
-    ->addWhere('id', 'IN', array_keys($cancellableParticipantRecords))
+    ->addWhere('id', 'IN', $participantIDs)
     ->setValues(['status_id:name' => 'Cancelled'])
     ->execute();
 }


### PR DESCRIPTION
Overview
----------------------------------------
The wrong participant records may be cancelled when cancelling a contribution, when Contribution Cancel Actions ext is enabled.

See https://lab.civicrm.org/dev/core/-/issues/5764

Before
----------------------------------------
Wrong participant records cancelled

After
----------------------------------------
Correct participant records cancelled

Technical Details
----------------------------------------
1. This still uses API3, but there is no API4 for ParticipantPayment
2. The tests were erroneously passing because the Participant and ParticipantPayment records are created together in the test resulting in them having the same id (ie 1 for first test etc).  

Fixing those are more complex, but this stops it doing things that are clearly bad.

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
