### PR TITLE
[REF] Faster pseudoconstant name lookups

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5987,7 +5987,7 @@ AND   displayRelType.is_active = 1
     if (empty($this->_pseudoConstantsSelect)) {
       return NULL;
     }
-    $values = [];
+    $values = $labels = [];
     foreach ($this->_pseudoConstantsSelect as $key => $value) {
       if (!empty($this->_pseudoConstantsSelect[$key]['sorting'])) {
         continue;
@@ -6009,10 +6009,11 @@ AND   displayRelType.is_active = 1
           // and we can use the metadata to figure it out.
           // ideally this bit of IF will absorb & replace all the rest in time as we move to
           // more metadata based choices.
+          $labels[$value['bao']][$value['idCol']] ??= $value['bao']::buildOptions($value['idCol'], 'get');
           if (str_contains($val, CRM_Core_DAO::VALUE_SEPARATOR)) {
             $dbValues = explode(CRM_Core_DAO::VALUE_SEPARATOR, trim($val, CRM_Core_DAO::VALUE_SEPARATOR));
             foreach ($dbValues as $pseudoValue) {
-              $convertedValues[] = CRM_Core_PseudoConstant::getLabel($value['bao'], $value['idCol'], $pseudoValue);
+              $convertedValues[] = $labels[$value['bao']][$value['idCol']][$pseudoValue] ?? NULL;
             }
 
             $dao->$key = ($usedForAPI) ? $convertedValues : implode(', ', $convertedValues);
@@ -6027,9 +6028,7 @@ AND   displayRelType.is_active = 1
 
           }
           else {
-            // This is basically the same as the default but since we have the bao we can use
-            // a cached function.
-            $dao->$key = CRM_Core_PseudoConstant::getLabel($value['bao'], $value['idCol'], $val);
+            $dao->$key = $labels[$value['bao']][$value['idCol']][$val] ?? NULL;
           }
         }
         elseif ($baoName) {


### PR DESCRIPTION
Overview
----------------------------------------
Profiling shows that we spend an inordinate amount of time converting pseudoconstant IDs into names. This is a performance fix.

Before
----------------------------------------
Slow.

After
----------------------------------------
Fast.

Comments
----------------------------------------
A few things going on here:
* This function is called a LOT, so even small differences will be magnified.
* We're calling the expensive function once, not once per value (in multivalued fields).
* There's a comment that says that `CRM_Core_PseudoConstant::getlabel()` is a cached function - but that's not necessarily true in places where the BAO overrides `buildOptions()`.
*  `buildOptions` is deprecated, so we remove calls to it.
