### PR TITLE
search_kit -  render classes settings key for non-table search displays

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.html
+++ b/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.html
@@ -1,4 +1,4 @@
-<div class="crm-search-display crm-search-display-grid">
+<div class="crm-search-display crm-search-display-grid {{:: $ctrl.settings.classes.join(' ') }}">
   <div class="alert alert-info crm-search-display-description" ng-if="$ctrl.settings.description">{{:: $ctrl.settings.description }}</div>
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.html
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.html
@@ -1,11 +1,21 @@
-<div class="crm-search-display crm-search-display-list">
+<div class="crm-search-display crm-search-display-list {{:: $ctrl.settings.classes.join(' ') }}">
   <div class="alert alert-info crm-search-display-description" ng-if="$ctrl.settings.description">{{:: $ctrl.settings.description }}</div>
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>
     <span ng-if="$ctrl.settings.headerCount" ng-include="'~/crmSearchDisplay/ResultCount.html'"></span>
     <div class="form-group pull-right" ng-include="'~/crmSearchDisplay/toolbar.html'" ng-if="$ctrl.toolbar"></div>
   </div>
-  <ol ng-if=":: $ctrl.settings.style === 'ol'" ng-include="'~/crmSearchDisplayList/crmSearchDisplayList' + ($ctrl.loading ? 'Loading' : 'Items') + '.html'" ng-style="{'list-style': $ctrl.settings.symbol}"></ol>
-  <ul ng-if=":: $ctrl.settings.style !== 'ol'" ng-include="'~/crmSearchDisplayList/crmSearchDisplayList' + ($ctrl.loading ? 'Loading' : 'Items') + '.html'" ng-style="{'list-style': $ctrl.settings.symbol}"></ul>
+  <ol
+    class="crm-search-display-list-container"
+    ng-if=":: $ctrl.settings.style === 'ol'"
+    ng-include="'~/crmSearchDisplayList/crmSearchDisplayList' + ($ctrl.loading ? 'Loading' : 'Items') + '.html'"
+    ng-style="{'list-style': $ctrl.settings.symbol}"
+    ></ol>
+  <ul
+    class="crm-search-display-list-container"
+    ng-if=":: $ctrl.settings.style !== 'ol'"
+    ng-include="'~/crmSearchDisplayList/crmSearchDisplayList' + ($ctrl.loading ? 'Loading' : 'Items') + '.html'"
+    ng-style="{'list-style': $ctrl.settings.symbol}"
+    ></ul>
   <div ng-include="'~/crmSearchDisplay/Pager.html'"></div>
 </div>

--- a/ext/search_kit/ang/crmSearchDisplayTree/crmSearchDisplayTree.html
+++ b/ext/search_kit/ang/crmSearchDisplayTree/crmSearchDisplayTree.html
@@ -1,4 +1,4 @@
-<div class="crm-search-display crm-search-display-tree">
+<div class="crm-search-display crm-search-display-tree {{:: $ctrl.settings.classes.join(' ') }}">
   <div class="alert alert-info crm-search-display-description" ng-if="$ctrl.settings.description">{{:: $ctrl.settings.description }}</div>
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>


### PR DESCRIPTION
Overview
----------------------------------------
On Table search displays there is a `classes` setting which is very useful for targeting specific styles to specific search kits.

It would be really useful for other display types. 

There's no UI yet to edit this, but if you have a search kit in a `*.mgd.php` you can really easily add it to the `settings` array.

Before
----------------------------------------
- Very hard to target styles at specific search kits

After
----------------------------------------
- Fairly easy for e.g. extension developer to target styles at a search kit packaged using `*.mgd.php`

Technical Details
----------------------------------------
I wondered if this would cause any null errors if the `classes` array doesn't exist by default for these display types (when you try to call `join` on it). But as far as I can see angular swallows any error.


Comments
----------------------------------------
I think this could also be used to make the List display type more useful by adding some utility style classes (analogous to table-striped). I'm thinking flexbox and responsive grid styling.
