### PR TITLE
riverlea - fix is_active to allow streams from external extensions

### DIFF
--- a/ext/riverlea/riverlea.php
+++ b/ext/riverlea/riverlea.php
@@ -44,9 +44,9 @@ function riverlea_civicrm_themes(&$themes) {
  * @return bool
  */
 function _riverlea_is_active() {
-  $themeKey = Civi::service('themes')->getActiveThemeKey();
-  $themeExt = Civi::service('themes')->get($themeKey)['ext'];
-  return ($themeExt === 'riverlea');
+  $themeKey = \Civi::service('themes')->getActiveThemeKey();
+  $themeSearchOrder = \Civi::service('themes')->get($themeKey)['search_order'] ?? [];
+  return in_array('_riverlea_core_', $themeSearchOrder);
 }
 
 function riverlea_civicrm_config(&$config) {


### PR DESCRIPTION
Overview
----------------------------------------
Riverlea framework currently loads if the current theme is from the Riverlea extension.

This is a blocker for adding streams with other extensions.

Instead we should check whether `_riverlea_core_` is in the search order for the current theme.

Before
----------------------------------------
- cant add a Riverlea stream in another extension

After
----------------------------------------
- can add a Riverlea stream in another extension


Comments
----------------------------------------
Example of an external stream, for testing purposes: https://lab.civicrm.org/extensions/deptfordcreek/-/tree/dev . Doesn't work properly before this patch.
