### PR TITLE
Separate auto_increment values for tests

### DIFF
--- a/Civi/Test.php
+++ b/Civi/Test.php
@@ -127,7 +127,10 @@ class Test {
       ->callback(function ($ctx) {
         // (1) Set baseline components. (2) Listeners on this setting are janky about "revert()".
         \CRM_Core_BAO_ConfigSetting::setEnabledComponents(\Civi::settings()->getDefault('enable_components'));
-      }, 'reset');
+      }, 'reset')
+      ->callback(function ($ctx) {
+        \Civi\Test::schema()->setAutoIncrement();
+      });
     $builder->install(['org.civicrm.search_kit', 'org.civicrm.afform', 'authx']);
     return $builder;
   }

--- a/Civi/Test/Schema.php
+++ b/Civi/Test/Schema.php
@@ -176,4 +176,211 @@ class Schema {
     return $file;
   }
 
+  /**
+   * This sets the AUTO_INCREMENT to flush out tests or code that muddle ids
+   * of test entities but pass because the ids are all low starting at 1
+   *
+   * @return Schema
+   */
+  public function setAutoIncrement() {
+    // Might want to tweak this
+    $separation = 100;
+    $autoIncrement = 1;
+
+    // This is a list of all standard tables (as of 2025/05/26)
+    // The intention is to gradually comment out tables from this list and fix the related failures.
+    // This continues until the entire list is commented out.  Or the earth is struck by a giant asteroid...
+
+    $excluded_tables = [
+      'civicrm_acl',
+      // 'civicrm_acl_cache',
+      // 'civicrm_acl_contact_cache',
+      'civicrm_acl_entity_role',
+      // 'civicrm_action_log',
+      'civicrm_action_schedule',
+      'civicrm_activity',
+      'civicrm_activity_contact',
+      'civicrm_address',
+      // 'civicrm_address_format',
+      'civicrm_afform_submission',
+      'civicrm_batch',
+      // 'civicrm_cache',
+      'civicrm_campaign',
+      'civicrm_campaign_group',
+      'civicrm_case',
+      'civicrm_case_activity',
+      'civicrm_case_contact',
+      'civicrm_case_type',
+      'civicrm_component',
+      'civicrm_contact',
+      'civicrm_contact_type',
+      'civicrm_contribution',
+      'civicrm_contribution_page',
+      'civicrm_contribution_product',
+      'civicrm_contribution_recur',
+      'civicrm_contribution_soft',
+      'civicrm_contribution_widget',
+      // 'civicrm_country',
+      // 'civicrm_county',
+      'civicrm_currency',
+      'civicrm_custom_field',
+      'civicrm_custom_group',
+      'civicrm_dashboard',
+      'civicrm_dashboard_contact',
+      // 'civicrm_dedupe_exception',
+      'civicrm_dedupe_rule',
+      'civicrm_dedupe_rule_group',
+      // 'civicrm_domain',
+      'civicrm_email',
+      'civicrm_entity_batch',
+      'civicrm_entity_file',
+      'civicrm_entity_financial_account',
+      'civicrm_entity_financial_trxn',
+      'civicrm_entity_tag',
+      'civicrm_event',
+      'civicrm_extension',
+      'civicrm_file',
+      'civicrm_financial_account',
+      'civicrm_financial_item',
+      'civicrm_financial_trxn',
+      'civicrm_financial_type',
+      'civicrm_group',
+      'civicrm_group_contact',
+      // 'civicrm_group_contact_cache',
+      'civicrm_group_nesting',
+      'civicrm_group_organization',
+      'civicrm_im',
+      'civicrm_import_template_field',
+      // 'civicrm_install_canary',
+      'civicrm_job',
+      // 'civicrm_job_log',
+      'civicrm_line_item',
+      'civicrm_location_type',
+      'civicrm_loc_block',
+      // 'civicrm_log',
+      'civicrm_mailing',
+      'civicrm_mailing_abtest',
+      'civicrm_mailing_bounce_pattern',
+      'civicrm_mailing_bounce_type',
+      'civicrm_mailing_component',
+      'civicrm_mailing_event_bounce',
+      'civicrm_mailing_event_confirm',
+      'civicrm_mailing_event_delivered',
+      'civicrm_mailing_event_opened',
+      'civicrm_mailing_event_queue',
+      'civicrm_mailing_event_reply',
+      'civicrm_mailing_event_subscribe',
+      'civicrm_mailing_event_trackable_url_open',
+      'civicrm_mailing_event_unsubscribe',
+      'civicrm_mailing_group',
+      'civicrm_mailing_job',
+      'civicrm_mailing_recipients',
+      'civicrm_mailing_spool',
+      'civicrm_mailing_trackable_url',
+      'civicrm_mail_settings',
+      'civicrm_managed',
+      'civicrm_mapping',
+      'civicrm_mapping_field',
+      'civicrm_membership',
+      'civicrm_membership_block',
+      'civicrm_membership_log',
+      'civicrm_membership_payment',
+      'civicrm_membership_status',
+      'civicrm_membership_type',
+      'civicrm_menu',
+      'civicrm_msg_template',
+      'civicrm_navigation',
+      'civicrm_note',
+      'civicrm_openid',
+      'civicrm_option_group',
+      'civicrm_option_value',
+      'civicrm_participant',
+      'civicrm_participant_payment',
+      'civicrm_participant_status_type',
+      'civicrm_payment_processor',
+      'civicrm_payment_processor_type',
+      'civicrm_payment_token',
+      'civicrm_pcp',
+      'civicrm_pcp_block',
+      'civicrm_phone',
+      'civicrm_pledge',
+      'civicrm_pledge_block',
+      'civicrm_pledge_payment',
+      'civicrm_preferences_date',
+      'civicrm_premiums',
+      'civicrm_premiums_product',
+      'civicrm_prevnext_cache',
+      'civicrm_price_field',
+      'civicrm_price_field_value',
+      'civicrm_price_set',
+      'civicrm_price_set_entity',
+      'civicrm_print_label',
+      'civicrm_product',
+      'civicrm_queue',
+      'civicrm_queue_item',
+      'civicrm_recurring_entity',
+      'civicrm_relationship',
+      // 'civicrm_relationship_cache',
+      'civicrm_relationship_type',
+      'civicrm_report_instance',
+      'civicrm_role',
+      'civicrm_saved_search',
+      // 'civicrm_search_display',
+      // 'civicrm_search_segment',
+      'civicrm_session',
+      'civicrm_setting',
+      'civicrm_site_email_address',
+      'civicrm_site_token',
+      'civicrm_sms_provider',
+      'civicrm_state_province',
+      'civicrm_status_pref',
+      'civicrm_subscription_history',
+      'civicrm_survey',
+      // 'civicrm_system_log',
+      'civicrm_tag',
+      'civicrm_tell_friend',
+      'civicrm_timezone',
+      'civicrm_totp',
+      'civicrm_translation',
+      'civicrm_uf_field',
+      'civicrm_uf_group',
+      'civicrm_uf_join',
+      'civicrm_uf_match',
+      'civicrm_user_job',
+      'civicrm_user_role',
+      'civicrm_website',
+      'civicrm_word_replacement',
+      'civicrm_worldregion',
+    ];
+
+    $dbName = \Civi\Test::dsn('database');
+
+    $pdo = \Civi\Test::pdo();
+    $query = sprintf(
+      "SELECT table_name FROM INFORMATION_SCHEMA.TABLES
+        WHERE TABLE_SCHEMA = %s AND TABLE_TYPE = 'BASE TABLE' AND AUTO_INCREMENT = 1",
+      $pdo->quote($dbName)
+    );
+    $tables = $pdo->query($query);
+    $queries = [
+      "USE {$dbName};",
+    ];
+
+    if (!empty($tables)) {
+      foreach ($tables as $table) {
+        $table_name = $table['TABLE_NAME'] ?? $table['table_name'];
+        if (!in_array($table_name, $excluded_tables, TRUE)) {
+          $autoIncrement += $separation;
+          $queries[] = "ALTER TABLE $table_name AUTO_INCREMENT=$autoIncrement;";
+        }
+      }
+    }
+    foreach ($queries as $query) {
+      if (\Civi\Test::execute($query) === FALSE) {
+        throw new RuntimeException("Query failed: $query");
+      }
+    }
+    return $this;
+  }
+
 }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -311,7 +311,10 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
 
     // Otherwise: Merely TRUNCATE and INSERT basic data
     $b = new \Civi\Test\CiviEnvBuilder('Basic Data');
-    $b->callback([\Civi\Test::data(), 'populate']);
+    $b->callback([\Civi\Test::data(), 'populate'])
+      ->callback(function ($ctx) {
+        \Civi\Test::schema()->setAutoIncrement();
+      });
     return $b;
   }
 
@@ -1722,6 +1725,9 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
       CRM_Core_DAO::executeQuery($sql);
     }
     CRM_Core_DAO::executeQuery('SET FOREIGN_KEY_CHECKS = 1;');
+
+    // Truncate resets the autoincrements, so re-apply separation
+    \Civi\Test::schema()->setAutoIncrement();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Entities created by tests usually have small ids starting at 1.  Code or tests may muddle the identities and still pass.  For example, see https://github.com/civicrm/civicrm-core/pull/32258   The code looks up ParticipantPayment records and then uses the ids of those records to update Participants instead of using Participant ids.  There is a test but it passes because both the ParticipantPayment and Participant entities have id=1.

This change creates separation between the test entity values by changing the AUTO_INCREMENT value of tables.

Discussed with @totten & @eileenmcnaughton at sprint.  The plan is to gradually remove tables from the excluded list to broaden the scope of compliance enforcement.  This arrangement should prevent tests on any new tables that don't handle ids carefully.


Before
----------------------------------------
Some tests pass but should not.

After
----------------------------------------
More likely to catch identity muddles.

Technical Details
----------------------------------------
It only changes tables that still have AUTO_INCREMENT set to 1 after data is loaded.  Might be worth extending to others.

Comments
----------------------------------------



