### PR TITLE
afform: add an ability to add css class name for af fields

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -88,7 +88,7 @@ class AfformAdminMeta {
       'checkPermissions' => FALSE,
       'loadOptions' => ['id', 'label'],
       'action' => 'create',
-      'select' => ['name', 'label', 'input_type', 'input_attrs', 'required', 'options', 'help_pre', 'help_post', 'serialize', 'data_type', 'entity', 'fk_entity', 'readonly', 'operators', 'class_name'],
+      'select' => ['name', 'label', 'input_type', 'input_attrs', 'required', 'options', 'help_pre', 'help_post', 'serialize', 'data_type', 'entity', 'fk_entity', 'readonly', 'operators'],
       'where' => [['deprecated', '=', FALSE], ['input_type', 'IS NOT NULL']],
     ];
     if ($entityName === 'Address') {

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -88,7 +88,7 @@ class AfformAdminMeta {
       'checkPermissions' => FALSE,
       'loadOptions' => ['id', 'label'],
       'action' => 'create',
-      'select' => ['name', 'label', 'input_type', 'input_attrs', 'required', 'options', 'help_pre', 'help_post', 'serialize', 'data_type', 'entity', 'fk_entity', 'readonly', 'operators'],
+      'select' => ['name', 'label', 'input_type', 'input_attrs', 'required', 'options', 'help_pre', 'help_post', 'serialize', 'data_type', 'entity', 'fk_entity', 'readonly', 'operators', 'class_name'],
       'where' => [['deprecated', '=', FALSE], ['input_type', 'IS NOT NULL']],
     ];
     if ($entityName === 'Address') {

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -124,7 +124,7 @@
 </li>
 <li ng-if="$ctrl.hasClassName">
   <form ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown form-inline">
-    <input class="form-control" af-gui-field-value="$ctrl.fieldDefn" ng-model="getSet('class_name')" ng-model-options="{getterSetter: true}" >
+    <input class="form-control" type="text" ng-model="getSet('class_name')" >
   </form>
 </li>
 <li role="separator" class="divider" ng-if="$ctrl.canBeRange() || $ctrl.canBeMultiple()"></li>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -116,7 +116,17 @@
     {{:: ts('Post help text') }}
   </a>
 </li>
-
+<li>
+  <a href ng-click="toggleClassName(); $event.stopPropagation(); $event.target.blur();" title="{{:: ts('CSS class name') }}">
+    <i class="crm-i fa-{{ $ctrl.hasClassName? 'check-' : '' }}square-o"></i>
+    {{:: ts('CSS class name') }}
+  </a>
+</li>
+<li ng-if="$ctrl.hasClassName">
+  <form ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown form-inline">
+    <input class="form-control" af-gui-field-value="$ctrl.fieldDefn" ng-model="getSet('class_name')" ng-model-options="{getterSetter: true}" >
+  </form>
+</li>
 <li role="separator" class="divider" ng-if="$ctrl.canBeRange() || $ctrl.canBeMultiple()"></li>
 <li ng-if="$ctrl.canBeMultiple()" ng-click="$event.stopPropagation()">
   <a href ng-click="toggleMultiple()" title="{{:: ts('Search multiple values') }}">

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -28,6 +28,7 @@
 
       this.$onInit = function() {
         ctrl.hasDefaultValue = !!getSet('afform_default');
+        ctrl.hasClassName = !!getSet('class_name');
         setFieldDefn();
         ctrl.inputTypes = _.transform(_.cloneDeep(afGui.meta.inputTypes), function(inputTypes, type) {
           if (inputTypeCanBe(type.name)) {
@@ -290,6 +291,15 @@
           ctrl.hasDefaultValue = false;
         } else {
           ctrl.hasDefaultValue = true;
+        }
+      };
+
+      $scope.toggleClassName = function() {
+        if (ctrl.hasClassName) {
+          getSet('class_name', undefined);
+          ctrl.hasClassName = false;
+        } else {
+          ctrl.hasClassName = true;
         }
       };
 

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -34,6 +34,10 @@
           $element.addClass('af-field-type-multiple');
         }
 
+        if (this.defn.class_name) {
+          $element.addClass(this.defn.class_name);
+        }
+
         if (this.defn.name !== this.fieldName) {
           if (!this.defn.name) {
             console.error('Missing field definition for: ' + this.fieldName);


### PR DESCRIPTION
Overview
----------------------------------------
Allow adding css class for form field


After
----------------------------------------
![2025-03-01-005342_hyprshot](https://github.com/user-attachments/assets/1940f4ec-0c72-4fab-aa5d-a600ecea55c2)
