### PR TITLE
Add support for custom css class names for afform containers.

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer-menu.html
@@ -47,6 +47,17 @@
 <li><af-gui-menu-item-style node="$ctrl.node"></af-gui-menu-item-style></li>
 <li><af-gui-menu-item-border node="$ctrl.node"></af-gui-menu-item-border></li>
 <li><af-gui-menu-item-background node="$ctrl.node"></af-gui-menu-item-background></li>
+<li>
+  <a href ng-click="toggleClassName(); $event.stopPropagation(); $event.target.blur();" title="{{:: ts('CSS class name') }}">
+    <i class="crm-i fa-{{ $ctrl.hasClassName? 'check-' : '' }}square-o"></i>
+    {{:: ts('CSS class name') }}
+  </a>
+</li>
+<li ng-if="$ctrl.hasClassName">
+  <form ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown form-inline">
+    <input class="form-control" af-gui-field-value="$ctrl.node" ng-model="getSetClassName" ng-model-options="{getterSetter: true}" >
+  </form>
+</li>
 <li af-gui-conditional-menu="$ctrl.node" ng-if="$ctrl.editor.getEntities().length"></li>
 
 <li role="separator" class="divider"></li>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
@@ -45,6 +45,8 @@
             genericElements.push(element.directive);
           }
         });
+        ctrl.hasClassName = !!$scope.getSetClassName();
+
       };
 
       this.sortableOptions = {
@@ -180,6 +182,34 @@
           }
         }
         return ctrl.node.max ? parseInt(ctrl.node.max, 10) : null;
+      };
+
+      $scope.getSetClassName = function(value) {
+        if (arguments.length) {
+          // Build a list of classes to add (as given, then prefixed).
+          var customClasses = [];
+          if (typeof value != 'undefined') {
+            _.each(afGui.splitClass(value), function(valueClass){
+              customClasses.push('af-container-class-' + valueClass);
+            });
+          }
+          // Build a list of classes to remove (any prefixed classes in node.class).
+          var oldCustomClasses = _.filter(afGui.splitClass(ctrl.node['class']), function(className){
+            return className.startsWith('af-container-class-');
+          });
+          // Add and remove those classes.
+          afGui.modifyClasses(ctrl.node, oldCustomClasses, customClasses);
+        }
+        // Get a list of all prefixed clases in node.class.
+        var currentCustomClasses = _.filter(afGui.splitClass(ctrl.node['class']), function(className){
+          return className.startsWith('af-container-class');
+        });
+        // Build a list of prefix-stripped base class names, and return them as a string.
+        var classBaseNames = [];
+        _.each(currentCustomClasses, function(className) {
+          classBaseNames.push(className.replace(/^af-container-class-/, ''));
+        });
+        return classBaseNames.join(' ');
       };
 
       // Returns the maximum number of repeats allowed if this is a joined entity with a limit
@@ -344,6 +374,15 @@
             setBlockDirective(block.directive_name);
             initializeBlockContainer();
           });
+      };
+
+      $scope.toggleClassName = function() {
+        if (ctrl.hasClassName) {
+          $scope.getSetClassName(undefined);
+          ctrl.hasClassName = false;
+        } else {
+          ctrl.hasClassName = true;
+        }
       };
 
       this.node = ctrl.node;


### PR DESCRIPTION
Overview
----------------------------------------
Add support for adding custom class names (html 'class' attribute) to afform containers.  
Similar to #32266 (which does the same for afform fields).

Ref: https://lab.civicrm.org/dev/core/-/issues/4571

Before
----------------------------------------
No way to add custom class names for containers in afform UI.

After
----------------------------------------
Now you can.

Technical Details
----------------------------------------
Unlike fields, containers are already using the 'class' attribute for special `af-*`-prefixed classes such as 'af-layout-rows' etc.

- This PR adds custom class names by prefixing them with `af-container-class-`, while only displaying the 'un-prefixed class name' in the UI.
-  E.g. if you add a class name `my-class`:
   - The string `my-class` appears in the UI.
   - The actual added class name is `af-container-class-my-class`.
- I acknowledge the downside: this could lead to confusion if the user is looking for the CSS selector `div.af-container.my-class`, when in fact the correct selector would be `div.af-container.af-container-class-my-class`.
 
Comments
----------------------------------------
I'm sure there's a more elegant way to do this, even if we accept the downside mentioned above.
