### PR TITLE
SearchKit - Fix permission check error

### DIFF
--- a/ext/search_kit/Civi/Search/Meta.php
+++ b/ext/search_kit/Civi/Search/Meta.php
@@ -29,7 +29,7 @@ class Meta {
    * @return array
    */
   public static function getCalcFields($apiEntity, $apiParams): array {
-    $api = \Civi\API\Request::create($apiEntity, 'get', $apiParams);
+    $api = \Civi\API\Request::create($apiEntity, 'get', $apiParams + ['checkPermissions' => FALSE]);
     if (!is_a($api, '\Civi\Api4\Generic\DAOGetAction')) {
       return [];
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes crash described in [dev/core#5769](https://lab.civicrm.org/dev/core/-/issues/5769)

Technical Details
----------------------------------------
Gathering internal field metadata should not cause a crash for anonymous users. 