### PR TITLE
[REF] Ensure that Reply-To header is appropriately quoted if copying …

### DIFF
--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -337,12 +337,12 @@ class CRM_Utils_Mail {
     $headers['Return-Path'] = $params['returnPath'] ?? $defaultReturnPath;
 
     // CRM-11295: Omit reply-to headers if empty; this avoids issues with overzealous mailservers
-    // dev/core#5301: Allow Reply-To to be set directly.
-    $replyTo = $params['Reply-To'] ?? ($params['replyTo'] ?? ($params['from'] ?? NULL));
+    $replyTo = $params['Reply-To'] ?? ($params['replyTo'] ?? NULL);
 
     if (!empty($replyTo)) {
       $headers['Reply-To'] = $replyTo;
     }
+
     $headers['Date'] = date('r');
     if ($includeMessageId) {
       $headers['Message-ID'] = $params['messageId'] ?? '<' . uniqid('civicrm_', TRUE) . "@$emailDomain>";
@@ -366,6 +366,11 @@ class CRM_Utils_Mail {
         substr(trim($from[1]), 0, -1),
         TRUE
       );
+    }
+
+    // dev/core#5301: Allow Reply-To to be set directly.
+    if (empty($replyTo)) {
+      $headers['Reply-To'] = $headers['From'];
     }
 
     require_once 'Mail/mime.php';


### PR DESCRIPTION
…from the from address as well

Overview
----------------------------------------
When a from name from say an Event confirmation has a `,` the Reply-To header can break in some situations because it doesn't get " like the From header

Before
----------------------------------------
Reply-To header can break sometimes

After
----------------------------------------
Reply To Correctly quoted

@andrew-cormick-dockery @johntwyman @demeritcowboy @mattwire 