### PR TITLE
Fix dedupe lookup to use optimizer to combine queries

### DIFF
--- a/CRM/Dedupe/BAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/BAO/DedupeRuleGroup.php
@@ -208,7 +208,7 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup impl
     $contactType = $ruleGroup->contact_type;
     $threshold = $ruleGroup->threshold;
     $optimizer = new CRM_Dedupe_FinderQueryOptimizer($id, [], $event->dedupeParams['match_params']);
-    $tableQueries = $optimizer->getRuleQueries();
+    $tableQueries = $optimizer->getFindQueries();
     if (empty($tableQueries)) {
       $event->dedupeResults['ids'] = [];
       return;

--- a/CRM/Dedupe/FinderQueryOptimizer.php
+++ b/CRM/Dedupe/FinderQueryOptimizer.php
@@ -445,4 +445,15 @@ class CRM_Dedupe_FinderQueryOptimizer {
     return $combinations;
   }
 
+  /**
+   * It the optimizer being used to lookup existing contacts based on input parameters.
+   *
+   * @internal
+   *
+   * @return bool
+   */
+  public function isLookupMode(): bool {
+    return !empty($this->lookupParameters);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix dedupe lookup to use optimizer to combine queries

Before
----------------------------------------
If the rule requires 3 fields in the same table 3 queries are run

After
----------------------------------------
The queries are combined

Technical Details
----------------------------------------
This only affects the code in core - not in the `legacydedupefinder` - initially all sites will be using the latter as it is hidden & installed on new installs and upgrades (while it beds in).

We are the exception - we will be testing this on production in the rc period

Comments
----------------------------------------
