### PR TITLE
Further clean up in dedupe query builder

### DIFF
--- a/CRM/Dedupe/FinderQueryOptimizer.php
+++ b/CRM/Dedupe/FinderQueryOptimizer.php
@@ -521,9 +521,6 @@ class CRM_Dedupe_FinderQueryOptimizer {
     }
     $patternColumn = '/t1.(\w+)/';
     $exclWeightSum = [];
-    // @todo move all this to the FinderQueryOptimizer - there used to be a
-    // hook which meant we had to keep this 'after' the hook - but the
-    // hook is now only in the legacydedupefinder so we can clean that up now
     while (!empty($tableQueries)) {
       [$isInclusive, $isDie] = $this->isQuerySetInclusive($tableQueries, $threshold, $exclWeightSum);
 

--- a/CRM/Dedupe/FinderQueryOptimizer.php
+++ b/CRM/Dedupe/FinderQueryOptimizer.php
@@ -526,7 +526,7 @@ class CRM_Dedupe_FinderQueryOptimizer {
     $patternColumn = '/t1.(\w+)/';
     $exclWeightSum = [];
     while (!empty($tableQueries)) {
-      [$isInclusive, $isDie] = $this->isQuerySetInclusive($tableQueries, $threshold, $exclWeightSum);
+      [$isInclusive, $isDie] = $this->isQuerySetInclusive($threshold, $exclWeightSum);
 
       if ($isInclusive) {
         // order queries by table count
@@ -614,11 +614,10 @@ class CRM_Dedupe_FinderQueryOptimizer {
    *
    * @return array
    */
-  private function isQuerySetInclusive($tableQueries, $threshold, $exclWeightSum = []) {
+  private function isQuerySetInclusive($threshold, $exclWeightSum = []) {
     $input = [];
-    foreach ($tableQueries as $key => $query) {
-      $optimizedQuery = $this->optimizedQueries[$key];
-      $input[] = $optimizedQuery['weight'];
+    foreach ($this->getRemainingQueries() as $query) {
+      $input[] = $query['weight'];
     }
 
     if (!empty($exclWeightSum)) {
@@ -645,6 +644,16 @@ class CRM_Dedupe_FinderQueryOptimizer {
       }
     }
     return [$totalCombinations == 1, $totalCombinations <= 0];
+  }
+
+  protected function getRemainingQueries(): array {
+    $remaining = [];
+    foreach ($this->optimizedQueries as $key => $query) {
+      if (!isset($query['found_rows'])) {
+        $remaining[$key] = $query;
+      }
+    }
+    return $remaining;
   }
 
   /**

--- a/CRM/Dedupe/FinderQueryOptimizer.php
+++ b/CRM/Dedupe/FinderQueryOptimizer.php
@@ -28,6 +28,8 @@ class CRM_Dedupe_FinderQueryOptimizer {
 
   private array $queries = [];
 
+  private array $optimizedQueries = [];
+
   /**
    * Threshold weight for merge.
    *
@@ -253,6 +255,7 @@ class CRM_Dedupe_FinderQueryOptimizer {
     $tableQueryFormat = [];
     foreach ($queries as $query) {
       $tableQueryFormat[$query['key']] = $query['query'];
+      $this->optimizedQueries[$query['key']] = $query;
     }
     return $tableQueryFormat;
   }
@@ -338,6 +341,7 @@ class CRM_Dedupe_FinderQueryOptimizer {
     $tableQueryFormat = [];
     foreach ($queries as $query) {
       $tableQueryFormat[$query['key']] = $query['query'];
+      $this->optimizedQueries[$query['key']] = $query;
     }
     return $tableQueryFormat;
   }
@@ -610,6 +614,7 @@ class CRM_Dedupe_FinderQueryOptimizer {
   private function isQuerySetInclusive($tableQueries, $threshold, $exclWeightSum = []) {
     $input = [];
     foreach ($tableQueries as $key => $query) {
+      $optimizedQuery = $this->optimizedQueries[$key];
       $input[] = substr($key, strrpos($key, '.') + 1);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Minor refactoring building on https://github.com/civicrm/civicrm-core/pull/32283

Before
----------------------------------------
Legacy code relies on some weird formatting to decipher queries

After
----------------------------------------
Queries mostly used from informative array

Technical Details
----------------------------------------
This code is not live on most sites as it only kicks in when `legacydedupefinder` is disabled - which has to be done deliberately as it is a hidden extension enabled on new installs & upgrades

Comments
----------------------------------------