### PR TITLE
(dev/core#5700) Extensions - Implement more robust downloader

### DIFF
--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -138,6 +138,36 @@ class CRM_Extension_Browser {
   }
 
   /**
+   * Prepare a list of download URLs.
+   *
+   * @param array $keys
+   *   The extensions that we want to download.
+   *   Ex: ['apple', 'banana']
+   * @return array
+   *   List of download URLs.
+   *   Ex: ['apple' => 'https://example.com/apple/release/1.0.zip', 'ext2' => 'https://example.com/banana/release/1.2.3.zip']
+   * @throws \CRM_Core_Exception
+   */
+  public function findDownloads(array $keys): array {
+    if (!$this->isEnabled()) {
+      throw new CRM_Core_Exception('Automatic downloading is disabled.');
+    }
+    if ($reqs = $this->checkRequirements()) {
+      $first = array_shift($reqs);
+      throw new CRM_Core_Exception($first['message']);
+    }
+    $downloads = [];
+    foreach ($keys as $key) {
+      if ($info = $this->getExtension($key)) {
+        if ($info->downloadUrl) {
+          $downloads[$key] = $info->downloadUrl;
+        }
+      }
+    }
+    return $downloads;
+  }
+
+  /**
    * Get a description of a particular extension.
    *
    * @param string $key

--- a/CRM/Extension/Downloader.php
+++ b/CRM/Extension/Downloader.php
@@ -102,17 +102,8 @@ class CRM_Extension_Downloader {
     }
 
     if ($extensionInfo) {
-      $requiredExtensions = CRM_Extension_System::singleton()->getManager()->findInstallRequirements([$extensionInfo->key], $extensionInfo);
-      foreach ($requiredExtensions as $extension) {
-        if (CRM_Extension_System::singleton()->getManager()->getStatus($extension) !== CRM_Extension_Manager::STATUS_INSTALLED && $extension !== $extensionInfo->key) {
-          $requiredExtensionInfo = CRM_Extension_System::singleton()->getBrowser()->getExtension($extension);
-          $requiredExtensionInfoName = empty($requiredExtensionInfo->name) ? $extension : $requiredExtensionInfo->name;
-          $errors[] = [
-            'title' => ts('Missing Requirement: %1', [1 => $extension]),
-            'message' => ts('You will not be able to install/upgrade %1 until you have installed the %2 extension.', [1 => $extensionInfo->name, 2 => $requiredExtensionInfoName]),
-          ];
-        }
-      }
+      $reqErrors = CRM_Extension_System::singleton()->getManager()->checkInstallRequirements([$extensionInfo->key], $extensionInfo);
+      $errors = array_merge($errors, $reqErrors);
     }
 
     return $errors;

--- a/CRM/Extension/Downloader.php
+++ b/CRM/Extension/Downloader.php
@@ -125,11 +125,14 @@ class CRM_Extension_Downloader {
    *   The name of the extension being installed.
    * @param string $downloadUrl
    *   URL of a .zip file.
-   * @return bool
-   *   TRUE for success
+   * @param bool $deploy
+   *   Whether to reset statuses and caches, rebuild menus, etc.
+   * @return bool|string
+   *   FALSE for failure
+   *   Otherwise, a string indicating the file-path with the extracted content.
    * @throws CRM_Extension_Exception
    */
-  public function download($key, $downloadUrl) {
+  public function download($key, $downloadUrl, bool $deploy = TRUE) {
     $filename = $this->tmpDir . DIRECTORY_SEPARATOR . $key . '.zip';
 
     if (!$downloadUrl) {
@@ -149,9 +152,7 @@ class CRM_Extension_Downloader {
       return FALSE;
     }
 
-    $this->manager->replace($extractedZipPath);
-
-    return TRUE;
+    return $deploy ? $this->manager->replace($extractedZipPath) : $extractedZipPath;
   }
 
   /**

--- a/CRM/Extension/Downloader.php
+++ b/CRM/Extension/Downloader.php
@@ -181,11 +181,14 @@ class CRM_Extension_Downloader {
    *   The name of the extension being installed; this usually matches the basedir in the .zip.
    * @param string $zipFile
    *   The local path to a .zip file.
+   * @param string|null $extractTo
+   *   Where to extract the zip file. (If omitted, use $this->tmpDir).
    * @return string|FALSE
    *   zip file path
    */
-  public function extractFiles($key, $zipFile) {
+  public function extractFiles($key, $zipFile, ?string $extractTo = NULL) {
     $config = CRM_Core_Config::singleton();
+    $extractTo = $extractTo ?: $this->tmpDir;
 
     $zip = new ZipArchive();
     $res = $zip->open($zipFile);
@@ -196,7 +199,7 @@ class CRM_Extension_Downloader {
         CRM_Core_Session::setStatus(ts('Unable to extract the extension: bad directory structure'), '', 'error');
         return FALSE;
       }
-      $extractedZipPath = $this->tmpDir . DIRECTORY_SEPARATOR . $zipSubDir;
+      $extractedZipPath = $extractTo . DIRECTORY_SEPARATOR . $zipSubDir;
       if (is_dir($extractedZipPath)) {
         if (!CRM_Utils_File::cleanDir($extractedZipPath, TRUE, FALSE)) {
           \Civi::log()->error('Unable to extract the extension {extension}: {path} cannot be cleared', [
@@ -207,9 +210,9 @@ class CRM_Extension_Downloader {
           return FALSE;
         }
       }
-      if (!$zip->extractTo($this->tmpDir)) {
-        \Civi::log()->error('Unable to extract the extension to {path}.', ['path' => $this->tmpDir]);
-        CRM_Core_Session::setStatus(ts('Unable to extract the extension to %1.', [1 => $this->tmpDir]), ts('Installation Error'), 'error');
+      if (!$zip->extractTo($extractTo)) {
+        \Civi::log()->error('Unable to extract the extension to {path}.', ['path' => $extractTo]);
+        CRM_Core_Session::setStatus(ts('Unable to extract the extension to %1.', [1 => $extractTo]), ts('Installation Error'), 'error');
         return FALSE;
       }
       $zip->close();

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -828,6 +828,23 @@ class CRM_Extension_Manager {
     return $sorter->sort();
   }
 
+  public function checkInstallRequirements(array $installKeys, $newInfos = NULL): array {
+    $errors = [];
+    $requiredExtensions = $this->findInstallRequirements($installKeys, $newInfos);
+    $installKeysSummary = implode(',', $requiredExtensions);
+    foreach ($requiredExtensions as $extension) {
+      if ($this->getStatus($extension) !== CRM_Extension_Manager::STATUS_INSTALLED && !in_array($extension, $installKeys)) {
+        $requiredExtensionInfo = CRM_Extension_System::singleton()->getBrowser()->getExtension($extension);
+        $requiredExtensionInfoName = empty($requiredExtensionInfo->name) ? $extension : $requiredExtensionInfo->name;
+        $errors[] = [
+          'title' => ts('Missing Requirement: %1', [1 => $extension]),
+          'message' => ts('You will not be able to install/upgrade %1 until you have installed the %2 extension.', [1 => $installKeysSummary, 2 => $requiredExtensionInfoName]),
+        ];
+      }
+    }
+    return $errors;
+  }
+
   /**
    * Build a list of extensions to remove, in an order that will satisfy dependencies.
    *

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -149,9 +149,11 @@ class CRM_Extension_Manager {
    *
    * @param string $tmpCodeDir
    *   Path to a local directory containing a copy of the new (inert) code.
+   * @return string
+   *   The final path where the extension has been loaded.
    * @throws CRM_Extension_Exception
    */
-  public function replace($tmpCodeDir) {
+  public function replace($tmpCodeDir): string {
     if (!$this->defaultContainer) {
       throw new CRM_Extension_Exception("Default extension container is not configured");
     }
@@ -229,6 +231,8 @@ class CRM_Extension_Manager {
     // \Civi::reset();
     // \CRM_Core_Config::singleton(TRUE, TRUE);
     CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
+
+    return $tgtPath;
   }
 
   /**

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -203,10 +203,6 @@ class CRM_Extension_Manager {
 
       case self::STATUS_INSTALLED_MISSING:
       case self::STATUS_DISABLED_MISSING:
-        // the extension does not exist in any container; we're free to put it anywhere
-        $tgtPath = $this->defaultContainer->getBaseDir() . DIRECTORY_SEPARATOR . $newInfo->key;
-        break;
-
       case self::STATUS_UNKNOWN:
         // the extension does not exist in any container; we're free to put it anywhere
         $tgtPath = $this->defaultContainer->getBaseDir() . DIRECTORY_SEPARATOR . $newInfo->key;

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -782,7 +782,7 @@ class CRM_Extension_Manager {
    *
    * @param array $keys
    *   List of extensions to install.
-   * @param \CRM_Extension_Info $info
+   * @param \CRM_Extension_Info|CRM_Extension_Info[]|null $newInfos
    *   An extension info object that we should use instead of our local versions (eg. when checking for upgradeability).
    *
    * @return array
@@ -791,10 +791,12 @@ class CRM_Extension_Manager {
    * @throws \MJS\TopSort\CircularDependencyException
    * @throws \MJS\TopSort\ElementNotFoundException
    */
-  public function findInstallRequirements($keys, $info = NULL) {
-    // Use our passed in info, or get the local versions
-    if ($info) {
-      $infos[$info->key] = $info;
+  public function findInstallRequirements($keys, $newInfos = NULL) {
+    if (is_object($newInfos)) {
+      $infos[$newInfos->key] = $newInfos;
+    }
+    elseif (is_array($newInfos)) {
+      $infos = $newInfos;
     }
     else {
       $infos = $this->mapper->getAllInfos();

--- a/CRM/Extension/QueueDownloader.php
+++ b/CRM/Extension/QueueDownloader.php
@@ -1,0 +1,291 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Prepare a set of steps for downloading extension upgrades.
+ *
+ * The general idea is:
+ *
+ *   $dl = new CRM_Extension_QueueDownloader();
+ *   $queue = $dl->fillQueue(
+ *     $dl->createQueue(),
+ *     ['ext-1' => 'https://example.com/ext-1/releases/1.2.3./zip']
+ *   );
+ *   $runner = new CRM_Queue_Runner(...$queue...);
+ *   $runner->runAllViaWeb();
+ *
+ * NOTE: When upgrading extensions, you MUST have a chance to reset the PHP process (loading new PHP files).
+ * We will assume that every task runs in a new PHP process. This is compatible with runAllViaWeb() not but runAll().
+ * Headless clients (like `cv`) will need to use a different implementation that spawns new subprocesses.
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class CRM_Extension_QueueDownloader {
+
+  const QUEUE_PREFIX = 'ext_upgrade_';
+
+  /**
+   * Unique ID for this batch of downloads.
+   *
+   * @var string
+   *   Ex: 20250607_abcd1234abcd1234
+   */
+  protected string $upId;
+
+  /**
+   * @param string|null $upId
+   *   Ex: 20250607_abcd1234abcd1234
+   */
+  public function __construct(?string $upId = NULL) {
+    $this->upId = $upId ?: (CRM_Utils_Time::date('Y-m-d') . '-' . CRM_Utils_String::createRandom(16, CRM_Utils_String::ALPHANUMERIC));
+  }
+
+  public function createQueue(): CRM_Queue_Queue {
+    return Civi::queue(static::QUEUE_PREFIX . $this->upId, [
+      'type' => 'Sql',
+      'runner' => 'task',
+      'is_autorun' => FALSE,
+      'retry_limit' => 0,
+      'error' => 'abort',
+      'reset' => TRUE,
+    ]);
+  }
+
+  protected function getStagingPath(...$moreParts): string {
+    // The staging path is basically "{extensionsDir}/.civicrm-staging/{upId}". Note that:
+    // - This puts the staging files in the right filesystem (close to their final location).
+    //   Thus, `rename()` can be used to rearrange folders.
+    // - `uploadDir` might be viable, but it's also at greater risk of getting auto-cleaned
+    //   and being on separate filesystem.
+
+    $baseDir = CRM_Extension_System::singleton()->getDefaultContainer()->baseDir;
+    $prefix = [
+      rtrim($baseDir, DIRECTORY_SEPARATOR . '/'),
+      '.civicrm-staging',
+      $this->upId,
+    ];
+    return implode('/', array_merge($prefix, $moreParts));
+  }
+
+  public function getTitle(): string {
+    return ts('Download and Install (<em><small>ID: %1</small></em>)', [1 => $this->upId]);
+  }
+
+  /**
+   * @param CRM_Queue_Queue $queue
+   * @param array $downloads
+   *   Ex: ['ext1' => 'https://example.com/ext1/releases/1.0.zip']
+   * @param bool $upgradeDb
+   *   Whether to run database updates
+   * @param bool $cleanup
+   *   Whether to delete temporary files and backup files at the end.
+   * @return \CRM_Queue_Queue
+   */
+  public function fillQueue(CRM_Queue_Queue $queue, array $downloads, bool $upgradeDb = TRUE, bool $cleanup = TRUE): CRM_Queue_Queue {
+    if (empty($downloads)) {
+      throw new CRM_Core_Exception("Cannot build download queue. No downloads requested!");
+    }
+
+    // Store some metadata about what's going on. This may help with debugging.
+    $this->mkdir($this->getStagingPath());
+    file_put_contents($this->getStagingPath('details.json'), json_encode([
+      'startTime' => CRM_Utils_Time::date('c'),
+      'upId' => $this->upId,
+      'queue' => $queue->getName(),
+      'downloads' => $downloads,
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+    // Download and extract zip files. This is I/O dependent (error-prone), so we do each as a separate (retriable) step.
+    foreach ($downloads as $ext => $url) {
+      $queue->createItem(
+        static::subtask(ts('Fetch "%1" from "%2"', [1 => $ext, 2 => $url]), 'fetch', [$ext, $url]),
+        ['weight' => 100]
+      );
+    }
+
+    // Verify all requirements with a single operation.
+    // We won't be sensitive to (re)ordering of fetch-tasks, because we only care if the final set is coherent.
+    $queue->createItem(
+      static::subtask(ts('Verify requirements'), 'verify', [array_keys($downloads)]),
+      ['weight' => 200]
+    );
+
+    // Swap-in new folders with a single operation. This should be similar to more sophisticated site-builder
+    // workflows. (f you manage a site in git, then "git pull" swaps all code at the same time.) This
+    // can't guarantee that all combinations of $downloads work, but at least they'll behave consistently.
+    $queue->createItem(
+      static::subtask(ts('Swap folders'), 'swap', [array_keys($downloads)]),
+      ['weight' => 200]
+    );
+
+    // The "swap" and "rebuild" must happen in separate steps.
+    $queue->createItem(
+      static::subtask(ts('Rebuild system'), 'rebuild'),
+      ['weight' => 300]
+    );
+
+    if ($upgradeDb) {
+      $queue->createItem(
+        static::subtask(ts('Upgrade database'), 'upgradeDb'),
+        ['weight' => 400]
+      );
+    }
+
+    if ($cleanup) {
+      $queue->createItem(
+        static::subtask(ts('Cleanup workspace'), 'cleanup'),
+        ['weight' => 2000]
+      );
+    }
+
+    return $queue;
+  }
+
+  /**
+   * Create a CRM_Queue_Task that executes on this class.
+   *
+   * @param string $title
+   * @param string $method
+   * @param array $args
+   *
+   * @return \CRM_Queue_Task
+   */
+  protected function subtask(string $title, string $method, array $args = []): CRM_Queue_Task {
+    return new CRM_Queue_Task(
+      [static::class, 'runSubtask'],
+      [$this->upId, $method, $args],
+      $title
+    );
+  }
+
+  public static function runSubtask(CRM_Queue_TaskContext $ctx, string $upId, string $name, array $args = []): bool {
+    $instance = new static($upId);
+    $method = 'subtask' . ucfirst($name);
+    $instance->{$method}($ctx, ...$args);
+    return TRUE;
+  }
+
+  /**
+   * Download extension ($key) from $url and store it in {$stagingPath}/new/{$key}.
+   */
+  public function subtaskFetch(CRM_Queue_TaskContext $ctx, string $key, string $url): void {
+    $tmpDir = $this->getStagingPath('tmp');
+    $zipFile = $this->getStagingPath('fetch', $key . '.zip');
+    $stageDir = $this->getStagingPath('new', $key);
+    $this->mkdir([$tmpDir, dirname($zipFile), dirname($stageDir)]);
+
+    if (file_exists($stageDir)) {
+      // In case we're retrying from a prior failure.
+      CRM_Utils_File::cleanDir($stageDir, TRUE, FALSE);
+    }
+
+    $downloader = CRM_Extension_System::singleton()->getDownloader();
+    if (!$downloader->fetch($url, $zipFile)) {
+      throw new CRM_Extension_Exception("Failed to download: $url");
+    }
+
+    $extractedZipPath = $downloader->extractFiles($key, $zipFile, $tmpDir);
+    if (!$extractedZipPath) {
+      throw new CRM_Extension_Exception("Failed to extract: $zipFile");
+    }
+
+    if (!$downloader->validateFiles($key, $extractedZipPath)) {
+      throw new CRM_Extension_Exception("Failed to validate $extractedZipPath. Consult CiviCRM log for details.");
+      // FIXME: Might be nice to show errors immediately, but we've got bigger fish to fry right now.
+    }
+
+    if (!rename($extractedZipPath, $stageDir)) {
+      throw new CRM_Extension_Exception("Failed to rename $extractedZipPath to $stageDir");
+    }
+  }
+
+  /**
+   * Scan the downloaded extensions and verify that their requirements are satisfied.
+   */
+  public function subtaskVerify(CRM_Queue_TaskContext $ctx, array $keys): void {
+    $infos = CRM_Extension_System::singleton()->getMapper()->getAllInfos();
+    foreach ($keys as $key) {
+      $infos[$key] = CRM_Extension_Info::loadFromFile($this->getStagingPath('new', $key, CRM_Extension_Info::FILENAME));
+    }
+
+    $errors = CRM_Extension_System::singleton()->getManager()->checkInstallRequirements($keys, $infos);
+    if (!empty($errors)) {
+      $path = $this->getStagingPath();
+      Civi::log()->error('Failed to verify requirements for new downloads in {path}', [
+        'path' => $path,
+        'installKeys' => $keys,
+        'errors' => $errors,
+      ]);
+      throw new CRM_Extension_Exception(implode("\n", [
+        "Failed to verify requirements for new downloads in {$path}.",
+        ...array_column($errors, 'title'),
+        "Consult CiviCRM log for details.",
+      ]));
+    }
+  }
+
+  /**
+   * Take the extracted code (`stagingDir/new/{key}`) and put it into its final place.
+   * Move any old code to the backup (`stagingDir/old/{key}`).
+   * Delete the container-cache
+   */
+  public function subtaskSwap(CRM_Queue_TaskContext $ctx, array $keys): void {
+    $this->mkdir($this->getStagingPath('old'));
+    try {
+      foreach ($keys as $key) {
+        $tmpCodeDir = $this->getStagingPath('new', $key);
+        $backupCodeDir = $this->getStagingPath('old', $key);
+
+        CRM_Extension_System::singleton()->getManager()->replace($tmpCodeDir, $backupCodeDir, FALSE);
+        // What happens when you call replace(.., refresh: false)? Varies by type:
+        // - For report/search/payment-extensions, it runs the uninstallation/reinstallation routines.
+        // - For module-extensions, it swaps the folders and clears the class-index.
+
+        // Arguably, for DownloadQueue, we should only clear class-index after all code is swapped,
+        // but it's messier to write that patch, and it's not clear if it's needed.
+      }
+    }
+    finally {
+      // Delete `CachedCiviContainer.*.php`, `CachedExtLoader.*.php`, and similar.
+      $config = CRM_Core_Config::singleton();
+      // $config->cleanup(1);
+      $config->cleanupCaches(FALSE);
+    }
+  }
+
+  public function subtaskRebuild(CRM_Queue_TaskContext $ctx): void {
+    CRM_Core_Invoke::rebuildMenuAndCaches(TRUE, FALSE);
+    // FIXME: For 6.1+:, use: Civi::rebuild(['*' => TRUE, 'sessions' => FALSE]);
+  }
+
+  public function subtaskUpgradeDb(CRM_Queue_TaskContext $ctx): void {
+    if (CRM_Extension_Upgrades::hasPending()) {
+      CRM_Extension_Upgrades::fillQueue($ctx->queue);
+    }
+  }
+
+  public function subtaskCleanup(): void {
+    CRM_Utils_File::cleanDir($this->getStagingPath(), TRUE, FALSE);
+  }
+
+  private function mkdir($paths): void {
+    $paths = (array) $paths;
+    foreach ($paths as $path) {
+      if (!is_dir($path)) {
+        if (!mkdir($path, 0777, TRUE)) {
+          throw new CRM_Core_Exception("Failed to create directory: $path");
+        }
+      }
+    }
+  }
+
+}

--- a/api/v3/Extension.php
+++ b/api/v3/Extension.php
@@ -200,6 +200,11 @@ function _civicrm_api3_extension_uninstall_spec(&$fields) {
 /**
  * Download and install an extension.
  *
+ * LIMITATIONS: This performs the download and system-flush as a single step. That works for
+ * downloading -new- extensions. However, for downloading -upgraded- extensions, it is
+ * error-prone (dev/core#3686, dev/core#5700). When developing a solution for upgrades,
+ * CRM_Extension_QueueDownloader will be more robust.
+ *
  * @param array $params
  *   Input parameters.
  *   - key: string, eg "com.example.myextension"

--- a/extension-compatibility.json
+++ b/extension-compatibility.json
@@ -1,4 +1,8 @@
 {
+  "hotfix_extup": {
+    "obsolete": "6.1",
+    "force-uninstall": true
+  },
   "org.civicrm.angularex": {
     "obsolete": "5.69",
     "disable": true,


### PR DESCRIPTION
Overview
----------------------------------------

The "Manage Extensions" screen allows you to download new/upgraded extensions, as in:

![Screenshot from 2025-03-03 21-22-18](https://github.com/user-attachments/assets/a0354b2f-2af9-4cf9-b9b2-a9a342c22ae4)

However, the existing downloader is error-prone - especially in the case of upgrades. The PR implements a more robust downloader which produces fewer errors (*and, when errors arise, it handles them better*).

(*This PR resolves https://lab.civicrm.org/dev/core/-/issues/5700 and https://lab.civicrm.org/dev/core/-/issues/3686. Going forward, for new versions of CiviCRM, it obsoletes https://lab.civicrm.org/extensions/hotfix_extup/.*)

Before
----------------------------------------

The old downloader performs the full process (*download, extract, swap folders, and rebuild*) __as a single step__. 

This means that old PHP code (*which was active before the start*) may still linger in memory (*at the end*). Depending on the specific extension/version/change, this can produce a range of misbehavior.

_For example_, when applying an upgrade to Entity Framework v2 (as in https://github.com/civicrm/org.civicrm.contactlayout/issues/152), it fails with:

```
Error: Class "CRM_Contactlayout_DAO_Base" not found in require_once() (line 15 of /XXX/files/civicrm/ext/org.civicrm.contactlayout/CRM/Contactlayout/DAO/ContactLayout.php).
```

_Similarly_, when there's an update to `mymodule_civicrm_managed()` (as in https://lab.civicrm.org/dev/core/-/issues/3686), it also fails. It's not a hard-crash -- but it (initially) loads the wrong data.

After
----------------------------------------

The new downloader splits the process into several steps, __which are executed as a queue.__

The implementation has a few immediate benefits:

* It fixes the main problem, where old PHP code lingers around during the "rebuild" step.
* It does more extensive validation of the new code (*i.e. it calls `checkRequirements()` based on the real/final `info.xml`*) before replacing the old code.
* At the end of the queue, it checks for new database changes and applies them.
* If any step fails, you can retry it.
* If any step fails, you can inspect the interim data. This includes JSON files, ZIP files, and extracted-folders.
* It retains a backup copy of the old code (up until the full process completes) so that it's possible to compare code and/or rollback.

The new downloader also plants a strong seed for other improvements:

* The downloader can install multiple extensions at the same time.
    * This could be used for batch-updates and/or dependency-updates.
    * This requires follow-up work -- i.e. we must also provide the UI for selecting the update targets.

Technical Details
----------------------------------------

(1) How do you test this? You need to install an old extension and then download an update. It's best to test some extension/version which has encountered trouble, such as:

* `bottlecap`: This is a synthetic extension which specifically tests the EFv2 transition. I've documented a [detailed/reproducible testing protocol](https://lab.civicrm.org/dev/core/-/issues/5700#note_176127).
* `contactlayout`: Install 2.3.x. Then upgrade to 2.4.x. (*NOTE: Published versions may change over time.*)
* `civirules`: Install 3.15. Then upgrade to 3.16. (*NOTE: Published versions may change over time.*)

(2) For `r-run`, I've focused my testing on upgrades and EFv2. Other testers may want to focus on other scenarios. (Like... Suppose you try to download an extension without meeting the prerequisites. Does it complain suitably?)

(3) The patch affects both "Add new" and "Upgrade" in the web UI. For `cv` CLI, we'll need additional updates to take advantage of the new implementation.

(4) I based the branch on 6.0.beta, but I'm submitting to 6.1.alpha. It should be amenable to merging on either branch. 

* The PR has ~14 commits targeting an important subsystem, and we're only ~3 days away from 6.0.0.
* So...  6.1.alpha feels more prudent to me. (*6.0.x can use the hotfix...*) 
* However, if others advance the position that the size/QA-level/timing is fine for 6.0.beta, then... OK, that's cool. (It can be switched in Github UI.)