### PR TITLE
specify light mode for civicrm.css to fix Standalone logo in Greenwich

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -6,6 +6,15 @@
  * All styles should start with .crm-container unless they are specific to the main div only
  */
 
+/**
+ * CiviCRM themes do not generally have dark mode, so this declares we expect light mode
+ * for system components (and our responsive svg logo).
+ * In Riverlea, this is overridden depending on the dark mode setting.
+ */
+.crm-container {
+  color-scheme: only light;
+}
+
 /* Use this class to hide text that should only be there for screen readers */
 .sr-only {
   border: 0;


### PR DESCRIPTION
Overview
----------------------------------------
Tell browser that our non-Riverlea themes dont have darkmode.


Before
----------------------------------------
- system components and SVG will respond if the user has set dark mode (in their browser/OS)
- this causes a particular issue with the logo on Standalone login page if your theme is set to Greenwich and your browser asks for dark mode => you get a dark mode logo (white) on the fixed white background

After
----------------------------------------
- in Greenwich, everything inside `.crm-container` CiviCRM always stays in light mode
- in Riverlea this gets overridden and handled as per Riverlea's dark mode setting

Comments
----------------------------------------
I wonder if there is a risk that someone is using Greenwich but has custom components that *do* respond to dark mode?
