### PR TITLE
Afform - Prevent saving draft after submitting form

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -16,6 +16,7 @@
         submissionResponse,
         saveDraftButtons = [],
         draftStatus = 'unsaved',
+        cancelDraftWatcher,
         ts = CRM.ts('org.civicrm.afform'),
         ctrl = this;
 
@@ -162,7 +163,7 @@
         // If autosave enabled, save every ten seconds if changes have been made
         const saveEveryTenSeconds = autoSaveEnabled ? _.debounce(ctrl.submitDraft, 10000) : _.noop;
 
-        $scope.$watch(() => data, function (newVal, oldVal) {
+        cancelDraftWatcher = $scope.$watch(() => data, function (newVal, oldVal) {
             if (oldVal) {
               setDraftStatus('unsaved');
               saveEveryTenSeconds(newVal);
@@ -343,6 +344,9 @@
         }
         status = CRM.status({});
         $element.block();
+        if (cancelDraftWatcher) {
+          cancelDraftWatcher();
+        }
 
         crmApi4('Afform', 'submit', {
           name: ctrl.getFormMeta().name,


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug in the new "Save Draft" feature.

Before
----------------------------------------
After clicking the "Submit" button, the autosave might still run and overwrite the submission with a draft.

After
----------------------------------------
Prevents autosave from firing after the submit button has been clicked.