### PR TITLE
Core/File - Decouple file download links from the entityFile table

### DIFF
--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -40,25 +40,18 @@ class CRM_Core_BAO_File extends CRM_Core_DAO_File {
 
   /**
    * @param int $fileID
-   * @param int $entityID
    *
    * @return array
    */
-  public static function path($fileID, $entityID) {
-    $entityFileDAO = new CRM_Core_DAO_EntityFile();
-    $entityFileDAO->entity_id = $entityID;
-    $entityFileDAO->file_id = $fileID;
+  public static function path($fileID): array {
+    $fileDAO = new CRM_Core_DAO_File();
+    $fileDAO->id = $fileID;
+    if ($fileDAO->find(TRUE)) {
+      $config = CRM_Core_Config::singleton();
+      $path = $config->customFileUploadDir . $fileDAO->uri;
 
-    if ($entityFileDAO->find(TRUE)) {
-      $fileDAO = new CRM_Core_DAO_File();
-      $fileDAO->id = $fileID;
-      if ($fileDAO->find(TRUE)) {
-        $config = CRM_Core_Config::singleton();
-        $path = $config->customFileUploadDir . $fileDAO->uri;
-
-        if (file_exists($path) && is_readable($path)) {
-          return [$path, $fileDAO->mime_type];
-        }
+      if (file_exists($path) && is_readable($path)) {
+        return [$path, $fileDAO->mime_type];
       }
     }
 
@@ -741,10 +734,15 @@ HEREDOC;
     return NULL;
   }
 
+  public static function getFileUrl(int $fileId, string $cmsEnd = 'current', ?string $flags = NULL): \Civi\Core\Url {
+    $fileHash = self::generateFileHash(NULL, $fileId);
+    return Civi::url("$cmsEnd://civicrm/file?reset=1&id=$fileId&fcs=$fileHash", $flags);
+  }
+
   /**
    * Generates an access-token for downloading a specific file.
    *
-   * @param int $entityId entity id the file is attached to
+   * @param null $entityId deprecated unused param
    * @param int $fileId file ID
    * @param int $genTs
    * @param int $life
@@ -766,7 +764,7 @@ HEREDOC;
     }
     // Trim 8 chars off the string, make it slightly easier to find
     // but reveals less information from the hash.
-    $cs = hash_hmac('sha256', "entity={$entityId}&file={$fileId}&life={$life}", $siteKey);
+    $cs = hash_hmac('sha256', "file={$fileId}&life={$life}", $siteKey);
     return "{$cs}_{$genTs}_{$life}";
   }
 
@@ -774,7 +772,7 @@ HEREDOC;
    * Validate a file access token.
    *
    * @param string $hash
-   * @param int $entityId Entity Id the file is attached to
+   * @param null $entityId deprecated unused param
    * @param int $fileId File Id
    * @return bool
    */
@@ -782,7 +780,7 @@ HEREDOC;
     $input = CRM_Utils_System::explode('_', $hash, 3);
     $inputTs = $input[1] ?? NULL;
     $inputLF = $input[2] ?? NULL;
-    $testHash = CRM_Core_BAO_File::generateFileHash($entityId, $fileId, $inputTs, $inputLF);
+    $testHash = CRM_Core_BAO_File::generateFileHash(NULL, $fileId, $inputTs, $inputLF);
     if (hash_equals($testHash, $hash)) {
       $now = time();
       if ($inputTs + ($inputLF * 60 * 60) >= $now) {

--- a/CRM/Core/Page/File.php
+++ b/CRM/Core/Page/File.php
@@ -38,7 +38,7 @@ class CRM_Core_Page_File extends CRM_Core_Page {
     }
 
     if (empty($fileName)) {
-      $hash = CRM_Utils_Request::retrieve('fcs', 'Alphanumeric', $this);
+      $hash = CRM_Utils_Request::retrieve('fcs', 'String', $this);
       if (!CRM_Core_BAO_File::validateFileHash($hash, $entityId, $fileId)) {
         CRM_Core_Error::statusBounce(ts('URL for file is not valid'));
       }

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -186,33 +186,11 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         if (!empty($data[$key])) {
           $item = $this->getSelectExpression($key);
           if ($item['expr'] instanceof SqlField && isset($item['fields'][$key]) && $item['fields'][$key]['fk_entity'] === 'File') {
-            return $this->generateFileUrl($data[$key]);
+            return (string) \CRM_Core_BAO_File::getFileUrl($data[$key]);
           }
         }
         return $data[$key] ?? NULL;
     }
-  }
-
-  /**
-   * Convert file id to a readable url
-   *
-   * @param $fileID
-   * @return string
-   * @throws \CRM_Core_Exception
-   */
-  private function generateFileUrl($fileID) {
-    $entityId = \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_EntityFile',
-      $fileID,
-      'entity_id',
-      'file_id'
-    );
-    $fileHash = \CRM_Core_BAO_File::generateFileHash($entityId, $fileID);
-    return $this->getUrl('civicrm/file', [
-      'reset' => 1,
-      'id' => $fileID,
-      'eid' => $entityId,
-      'fcs' => $fileHash,
-    ]);
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/FileTest.php
+++ b/tests/phpunit/CRM/Core/BAO/FileTest.php
@@ -148,4 +148,60 @@ class CRM_Core_BAO_FileTest extends CiviUnitTestCase {
     return $activity;
   }
 
+  /**
+   * Data provider for testing `generateFileHash` and `validateFileHash`.
+   *
+   * @return array
+   */
+  public function fileHashProvider() {
+    $currentTimestamp = time();
+
+    return [
+      // Test case 1: Valid token with a specific fileId
+      'valid_file_hash' => [
+        'fileId' => 123,
+        'genTs' => $currentTimestamp,
+        'life' => 1,
+        'expectedResult' => TRUE,
+      ],
+
+      // Test case 2: Expired token
+      'expired_file_hash' => [
+        'fileId' => 123,
+        // Token generated 2 hours ago
+        'genTs' => $currentTimestamp - (2 * 60 * 60),
+        'life' => 1,
+        'expectedResult' => FALSE,
+      ],
+
+      // Test case 3: Invalid fileId
+      'invalid_file_id' => [
+        'fileId' => 123,
+        'invalidFileId' => 999,
+        'genTs' => $currentTimestamp,
+        'life' => 1,
+        'expectedResult' => FALSE,
+      ],
+    ];
+  }
+
+  /**
+   * Test `generateFileHash` and `validateFileHash` using a data provider.
+   *
+   * @dataProvider fileHashProvider
+   */
+  public function testFileHash($fileId, $genTs, $life, $expectedResult, $invalidFileId = NULL) {
+    // Generate token
+    $token = CRM_Core_BAO_File::generateFileHash(NULL, $fileId, $genTs, $life);
+
+    // Validate token (valid or invalid fileId depending on the scenario)
+    $result = CRM_Core_BAO_File::validateFileHash(
+      $token,
+      NULL,
+      $invalidFileId ?: $fileId
+    );
+
+    $this->assertEquals($expectedResult, $result);
+  }
+
 }

--- a/tests/phpunit/api/v3/AttachmentTest.php
+++ b/tests/phpunit/api/v3/AttachmentTest.php
@@ -309,6 +309,7 @@ class api_v3_AttachmentTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testCreate(string $testEntityClass, array $createParams, string $expectedContent): void {
+    $this->useFrozenTime();
     $entity = CRM_Core_DAO::createTestObject($testEntityClass);
     $entity_table = CRM_Core_DAO_AllCoreTables::getTableForClass($testEntityClass);
     $this->assertIsNumeric($entity->id);
@@ -333,14 +334,7 @@ class api_v3_AttachmentTest extends CiviUnitTestCase {
     ]);
     $this->assertEquals(1, $getResult['count']);
     foreach (['id', 'entity_table', 'entity_id', 'url'] as $field) {
-      if ($field === 'url') {
-        $this->assertEquals(substr($createResult['values'][$fileId][$field], 0, -15), substr($getResult['values'][$fileId][$field], 0, -15));
-        $this->assertEquals(substr($createResult['values'][$fileId][$field], -3), substr($getResult['values'][$fileId][$field], -3));
-        $this->assertApproxEquals(substr($createResult['values'][$fileId][$field], -14, 10), substr($getResult['values'][$fileId][$field], -14, 10), 2);
-      }
-      else {
-        $this->assertEquals($createResult['values'][$fileId][$field], $getResult['values'][$fileId][$field], "Expect field $field to match");
-      }
+      $this->assertEquals($createResult['values'][$fileId][$field], $getResult['values'][$fileId][$field], "Expect field $field to match");
     }
     $this->assertNotTrue(isset($getResult['values'][$fileId]['content']));
 
@@ -352,14 +346,7 @@ class api_v3_AttachmentTest extends CiviUnitTestCase {
     $this->assertEquals($expectedContent, $getResult2['values'][$fileId]['content']);
     // Do this again even though we just tested above to demonstrate that these fields should be returned even if you only ask to return 'content'.
     foreach (['id', 'entity_table', 'entity_id', 'url'] as $field) {
-      if ($field === 'url') {
-        $this->assertEquals(substr($createResult['values'][$fileId][$field], 0, -15), substr($getResult2['values'][$fileId][$field], 0, -15));
-        $this->assertEquals(substr($createResult['values'][$fileId][$field], -3), substr($getResult2['values'][$fileId][$field], -3));
-        $this->assertApproxEquals(substr($createResult['values'][$fileId][$field], -14, 10), substr($getResult2['values'][$fileId][$field], -14, 10), 2);
-      }
-      else {
-        $this->assertEquals($createResult['values'][$fileId][$field], $getResult2['values'][$fileId][$field], "Expect field $field to match");
-      }
+      $this->assertEquals($createResult['values'][$fileId][$field], $getResult2['values'][$fileId][$field], "Expect field $field to match");
     }
   }
 
@@ -532,7 +519,7 @@ class api_v3_AttachmentTest extends CiviUnitTestCase {
       $queryResult = [];
       $parsedURl = parse_url($result['url']);
       parse_str($parsedURl['query'], $queryResult);
-      $this->assertTrue(CRM_Core_BAO_File::validateFileHash($queryResult['fcs'], $queryResult['eid'], $queryResult['id']));
+      $this->assertTrue(CRM_Core_BAO_File::validateFileHash($queryResult['fcs'], NULL, $queryResult['id']));
     }
 
     sort($actualNames);


### PR DESCRIPTION
Overview
----------------------------------------
Simplifies the creation of links to file downloads, and modernizes the file hash generator.


Technical Details
----------------------------------------
The `EntityFile` table serves 2 purposes:

1. As a many-to-many bridge table for entities that support multiple attachments
2. As a redundant copy of the value of custom fields of type File

The 2nd use is problematic and it would be good to eliminate these redundant records.

This chips away at the problem by removing the need for an entry in the EntityFile table in order to create a link to the file.

Comments
---------
The coupling between the EntityFile table and the download links served no purpose except to add a bit more entropy to the hash... if it even did that.