### PR TITLE
dev/core#5770 SK edit-in-place: focus appropriately when inline editing is initiated

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/colType/editable.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/editable.html
@@ -3,6 +3,7 @@
   display="$ctrl"
   is-full-row-mode="$ctrl.settings.editableRow.full"
   col-key="$ctrl.settings.columns[colIndex].key"
+  col-data="colData"
   ng-if="!colData.loading && $ctrl.editing === row.key && colData.editing"
 ></crm-search-display-editable>
 <span

--- a/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
@@ -9,6 +9,7 @@
       row: '<?',
       display: '<',
       colKey: '<',
+      colData: '<?',
       isFullRowMode: '<',
     },
     templateUrl: '~/crmSearchDisplay/crmSearchDisplayEditable.html',

--- a/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.html
+++ b/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.html
@@ -1,5 +1,5 @@
 <form name="crmSearchDisplayEditableForm">
-  <crm-search-input class="form-inline" field="$ctrl.field" ng-model="$ctrl.display.editValues[$ctrl.colKey]"></crm-search-input>
+  <crm-search-input class="form-inline" field="$ctrl.field" ng-model="$ctrl.display.editValues[$ctrl.colKey]" crm-search-input-focus="{{:: $ctrl.colData.focused }}"></crm-search-input>
   <div class="form-inline crm-search-display-editable-buttons" ng-if="!$ctrl.isFullRowMode">
     <button type="submit" ng-disabled="!crmSearchDisplayEditableForm.$valid" ng-click="$ctrl.save()" class="btn btn-xs btn-success">
       <span class="sr-only">{{:: ts('Save') }}</span>

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayEditableTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayEditableTrait.service.js
@@ -19,6 +19,7 @@
           this.editing = row.key;
           row.columns.forEach((col, index) => {
             col.editing = (index === colIndex || (this.settings.editableRow && this.settings.editableRow.full));
+            col.focused = index === colIndex;
           });
         }
       },

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputFocus.directive.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputFocus.directive.js
@@ -1,0 +1,86 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('crmSearchTasks').directive('crmSearchInputFocus', function($timeout) {
+    return {
+      link: function(scope, element, attrs) {
+
+        function waitForElement(selector, context = document) {
+          return new Promise((resolve) => {
+            const observer = new MutationObserver((mutations, observer) => {
+              const jQueryResult = $(selector, context);
+              if (jQueryResult.length) {
+                observer.disconnect();
+                resolve(jQueryResult);
+              }
+            });
+
+            observer.observe(context, {
+              childList: true,
+              subtree: true,
+            });
+          });
+        }
+
+        function getFocusableInput() {
+          const types = new Map ([
+            ['select2', 'input[crm-ui-select], input[crm-autocomplete]'],
+            ['datepicker', 'input[crm-ui-datepicker]'],
+            ['boolean', 'input[type="radio"], input[type="checkbox"]'],
+            ['default', ':focusable']
+          ]);
+          for (const [type, selector] of types) {
+            const jQueryObject = $(selector, element);
+            if (jQueryObject.length > 0 || type === 'default') {
+              return [jQueryObject, type];
+            }
+          }
+        }
+
+        function focusOn() {
+          scope.manualFocus = true;
+          let [jQueryObject, type] = getFocusableInput();
+          if (type === 'default') {
+            jQueryObject.first().trigger('focus');
+          } else if (type === 'boolean') {
+            let checkedItem = $(':checked', element);
+            if (checkedItem.length) {
+              jQueryObject = checkedItem;
+            }
+            jQueryObject.first().trigger('focus');
+          }
+          else if (type === 'select2') {
+            waitForElement('.select2-choice', element[0]).then((elements) => {
+              $timeout(() => {
+                const container = elements.first().closest('.select2-container');
+                container.select2('open');
+                $(element[0]).one('initSelectionComplete', () => {
+                  container.select2('open');
+                });
+              });
+            });
+          } else if (type === 'datepicker') {
+            waitForElement('.hasDatepicker', element[0]).then((elements) => {
+              elements.first().datepicker('show');
+            });
+          }
+        }
+
+        function removeFocus() {
+          getFocusableInput().trigger('blur');
+        }
+
+        function endManualFocus() {
+          scope.manualFocus = false;
+        }
+
+        scope.$watch(attrs.crmSearchInputFocus, function(flag) {
+          if(flag === true) {
+            $timeout(focusOn).then(endManualFocus);
+          }
+        });
+      }
+    };
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputFocus.directive.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputFocus.directive.js
@@ -37,7 +37,6 @@
         }
 
         function focusOn() {
-          scope.manualFocus = true;
           let [jQueryObject, type] = getFocusableInput();
 
           if (type === 'default') {
@@ -76,17 +75,9 @@
           }
         }
 
-        function removeFocus() {
-          getFocusableInput().trigger('blur');
-        }
-
-        function endManualFocus() {
-          scope.manualFocus = false;
-        }
-
         scope.$watch(attrs.crmSearchInputFocus, function(flag) {
           if(flag === true) {
-            $timeout(focusOn).then(endManualFocus);
+            $timeout(focusOn);
           }
         });
       }

--- a/js/Common.js
+++ b/js/Common.js
@@ -641,6 +641,7 @@ if (!CRM.vars) CRM.vars = {};
             var params = $.extend({}, getApiParams(), {ids: idsNeeded});
             CRM.api4(entityName, 'autocomplete', params).then(function (result) {
               callback(multiple ? result.concat(existing) : result[0]);
+              $el.trigger('initSelectionComplete');
             });
           }
         },

--- a/js/Common.js
+++ b/js/Common.js
@@ -637,6 +637,7 @@ if (!CRM.vars) CRM.vars = {};
           // If we already have the data, just return it
           if (!idsNeeded.length) {
             callback(multiple ? existing : existing[0]);
+            $el.trigger('initSelectionComplete');
           } else {
             var params = $.extend({}, getApiParams(), {ids: idsNeeded});
             CRM.api4(entityName, 'autocomplete', params).then(function (result) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5770](https://lab.civicrm.org/dev/core/-/issues/5770), at least partially - Fewer mouse clicks/keystrokes required to start editing in place in SearchKit.

Before
----------------------------------------
To actually get to a live cursor in a text field, or open the date picker, etc, multiple clicks/keystrokes are required.

After
----------------------------------------
In a table display with in-place-edit fields,
 
- clicking on an editable field immediately brings focus to that particular field ("focus" means a blinking cursor, an open datepicker, etc as appropriate)
- this works in "single field" in-place-edit mode as well as "full row" mode
- it works with text, integer, boolean (radio, checkbox), select2 (single, whether static or entityref) and datepicker widgets. 

Technical Details
----------------------------------------
My first attempt here feels slightly heavy and stiff, with hard-coded if-else blocks which probably could be refactored so that new/custom widget types could be supported, other display types could be supported, etc. But it's a step in the right direction.

Comments
----------------------------------------
- it currently only works on table displays, afaik
- it doesn't currently seem to work with select2 multi-select widgets
- other widgets are untested