### PR TITLE
Fix comment for getCMSPermissionsUrlParams

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -24,7 +24,7 @@ use GuzzleHttp\Psr7\Response;
  *
  * FIXME: This is a massive and random collection that could be split into smaller services
  *
- * @method static void getCMSPermissionsUrlParams() Immediately stop script execution and display a 401 "Access Denied" page.
+ * @method static array getCMSPermissionsUrlParams() Return the CMS-specific url for its permissions page.
  * @method static mixed permissionDenied() Show access denied screen.
  * @method static string getContentTemplate(int|string $print = 0) Get the template path to render whole content.
  * @method static mixed logout() Log out the current user.


### PR DESCRIPTION
It clearly returns an array and does not abort. Copied comment from function itself.
