### PR TITLE
Fix error message for invalid step

### DIFF
--- a/Civi/Test/CiviEnvBuilder.php
+++ b/Civi/Test/CiviEnvBuilder.php
@@ -152,7 +152,7 @@ class CiviEnvBuilder {
   protected function assertValid() {
     foreach ($this->steps as $step) {
       if (!$step->isValid()) {
-        throw new RuntimeException("Found invalid step: " . var_dump($step, 1));
+        throw new RuntimeException("Found invalid step: " . var_export($step, TRUE));
       }
     }
   }


### PR DESCRIPTION
The information from `$step` is clearly meant to go into the exception message. However, `var_dump` writes to output and does not return it as a string. Use `var_export` instead, and pass TRUE as second parameter so that a string is returned.
