### PR TITLE
Update comments on setting property on admin forms

### DIFF
--- a/CRM/Admin/Form/Preferences.php
+++ b/CRM/Admin/Form/Preferences.php
@@ -26,6 +26,13 @@ class CRM_Admin_Form_Preferences extends CRM_Core_Form {
   protected $_contactID = NULL;
   public $_action = NULL;
 
+  /**
+   * This should only be populated programmatically via the settings metadata.
+   *
+   * @var array
+   */
+  protected $_settings = [];
+
   protected $_params = NULL;
 
   /**

--- a/CRM/Admin/Form/Preferences/Address.php
+++ b/CRM/Admin/Form/Preferences/Address.php
@@ -20,6 +20,13 @@
  */
 class CRM_Admin_Form_Preferences_Address extends CRM_Admin_Form_Preferences {
 
+  /**
+   * This should only be populated programmatically via the settings metadata.
+   *
+   * DO NOT add new settings to these - they need to be migrated to being declared in metadata.
+   *
+   * @var array
+   */
   protected $_settings = [
     'address_options' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
     'address_format' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,

--- a/CRM/Admin/Form/Preferences/Display.php
+++ b/CRM/Admin/Form/Preferences/Display.php
@@ -20,8 +20,6 @@
  */
 class CRM_Admin_Form_Preferences_Display extends CRM_Admin_Form_Preferences {
 
-  protected array $_settings;
-
   /**
    * Build the form object.
    */

--- a/CRM/Admin/Form/Preferences/Member.php
+++ b/CRM/Admin/Form/Preferences/Member.php
@@ -20,6 +20,13 @@
  */
 class CRM_Admin_Form_Preferences_Member extends CRM_Admin_Form_Preferences {
 
+  /**
+   * This should only be populated programmatically via the settings metadata.
+   *
+   * DO NOT add new settings to these - they need to be migrated to being declared in metadata.
+   *
+   * @var array
+   */
   protected $_settings = [
     'default_renewal_contribution_page' => CRM_Core_BAO_Setting::MEMBER_PREFERENCES_NAME,
   ];


### PR DESCRIPTION
Overview
----------------------------------------
Update comments on setting property on admin forms

Before
----------------------------------------
Each admin form that extends `CRM_Admin_Form_Preferences` must define `$settings` - even though it's use is discouraged

After
----------------------------------------
Declared on the parent. Discouraged on the children

Technical Details
----------------------------------------

Comments
----------------------------------------
