### PR TITLE
Fix recent updates to import member to align with import activity

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -21,15 +21,6 @@ use Civi\Api4\Activity;
  */
 class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
 
-  /**
-   * Has this parser been fixed to expect `getMappedRow` to break it up
-   * by entity yet? This is a transitional property to allow the classes
-   * to be fixed up individually.
-   *
-   * @var bool
-   */
-  protected $isUpdatedForEntityRowParsing = TRUE;
-
   protected string $baseEntity = 'Activity';
 
   /**

--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -105,6 +105,19 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
   }
 
   /**
+   * Get a list of entities this import supports.
+   *
+   * @return array
+   */
+  public function getImportEntities() : array {
+    return [
+      'Activity' => ['text' => ts('Activity Fields'), 'is_contact' => FALSE, 'entity_field_prefix' => ''],
+      'TargetContact' => ['text' => ts('Target Contact Fields'), 'is_contact' => TRUE, 'entity_field_prefix' => 'target_contact.'],
+      'SourceContact' => ['text' => ts('Source Contact Fields'), 'is_contact' => TRUE, 'entity_field_prefix' => 'source_contact.'],
+    ];
+  }
+
+  /**
    * Ensure metadata is loaded.
    *
    * @throws \CRM_Core_Exception

--- a/CRM/Custom/Import/Parser/Api.php
+++ b/CRM/Custom/Import/Parser/Api.php
@@ -7,6 +7,8 @@ use Civi\Api4\CustomValue;
  */
 class CRM_Custom_Import_Parser_Api extends CRM_Import_Parser {
 
+  protected string $baseEntity = 'Contact';
+
   /**
    * Get information about the provided job.
    *
@@ -37,7 +39,7 @@ class CRM_Custom_Import_Parser_Api extends CRM_Import_Parser {
   public function import(array $values): void {
     $rowNumber = (int) $values[array_key_last($values)];
     try {
-      $params = $this->getMappedRow($values);
+      $params = $this->getMappedRow($values)['Contact'];
       $params['skipRecentView'] = TRUE;
       $params['entity_id'] = $params['contact_id'];
       $group = CRM_Core_BAO_CustomGroup::getGroup(['id' => $this->getCustomGroupID()]);
@@ -60,7 +62,7 @@ class CRM_Custom_Import_Parser_Api extends CRM_Import_Parser {
       $importableFields = $this->getGroupFieldsForImport($customGroupID);
       $this->importableFieldsMetadata = array_merge([
         'do_not_import' => ['title' => ts('- do not import -')],
-        'contact_id' => ['title' => ts('Contact ID'), 'name' => 'contact_id', 'type' => CRM_Utils_Type::T_INT, 'options' => FALSE, 'headerPattern' => '/contact?|id$/i'],
+        'contact_id' => ['title' => ts('Contact ID'), 'name' => 'contact_id', 'type' => CRM_Utils_Type::T_INT, 'options' => FALSE, 'headerPattern' => '/contact?|id$/i', 'entity' => 'Contact'],
         'external_identifier' => ['title' => ts('External Identifier'), 'name' => 'external_identifier', 'type' => CRM_Utils_Type::T_STRING, 'options' => FALSE, 'headerPattern' => '/external\s?id/i'],
       ], $importableFields);
     }

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -21,15 +21,6 @@ use Civi\Api4\Participant;
  */
 class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
 
-  /**
-   * Has this parser been fixed to expect `getMappedRow` to break it up
-   * by entity yet? This is a transitional property to allow the classes
-   * to be fixed up individually.
-   *
-   * @var bool
-   */
-  protected $isUpdatedForEntityRowParsing = TRUE;
-
   protected string $baseEntity = 'Participant';
 
   /**

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -25,6 +25,18 @@ use Civi\Api4\MappingField;
 abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
 
   /**
+   * Does the form layer convert field names to support QuickForm widgets.
+   *
+   * (e.g) if 'yes' we swap
+   * `soft_credit.external_identifier` to `soft_credit__external_identifier`
+   * because the contribution form would break on the . as it would treat it as
+   * javascript.
+   *
+   * @var bool
+   */
+  protected bool $supportsDoubleUnderscoreFields = TRUE;
+
+  /**
    * Mapper fields
    *
    * @var array

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -764,12 +764,14 @@ class CRM_Import_Forms extends CRM_Core_Form {
         // but is now loaded in the Parser for the LexIM variant.
         continue;
       }
-      // Swap out dots for double underscores so as not to break the quick form js.
-      // We swap this back on postProcess.
-      // Arg - we need to swap out _. first as it seems some groups end in a trailing underscore.
-      // https://lab.civicrm.org/dev/core/-/issues/4317#note_91322
-      $name = str_replace('_.', '~~', $name);
-      $name = str_replace('.', '__', $name);
+      if (isset($this->supportsDoubleUnderscoreFields) && !empty($this->supportsDoubleUnderscoreFields)) {
+        // Swap out dots for double underscores so as not to break the quick form js.
+        // We swap this back on postProcess.
+        // Arg - we need to swap out _. first as it seems some groups end in a trailing underscore.
+        // https://lab.civicrm.org/dev/core/-/issues/4317#note_91322
+        $name = str_replace('_.', '~~', $name);
+        $name = str_replace('.', '__', $name);
+      }
       $return[$name] = $field['title'];
     }
     return $return;

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -81,15 +81,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   protected $siteDefaultCountry = NULL;
 
   /**
-   * Has this parser been fixed to expect `getMappedRow` to break it up
-   * by entity yet? This is a transitional property to allow the classes
-   * to be fixed up individually.
-   *
-   * @var bool
-   */
-  protected $isUpdatedForEntityRowParsing = FALSE;
-
-  /**
    * @return int|null
    */
   public function getUserJobID(): ?int {
@@ -1399,7 +1390,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
       if ($mappedField['name']) {
         $fieldSpec = $this->getFieldMetadata($mappedField['name']);
         $entity = $fieldSpec['entity_instance'] ?? $fieldSpec['entity'] ?? $fieldSpec['extends'] ?? NULL;
-        if ($this->isUpdatedForEntityRowParsing && $entity) {
+        if ($entity) {
           // Split values into arrays by entity.
           // Apiv4 name is currently only set for contact, & only in cases where it would
           // be used for the dedupe rule (ie Membership import).

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -26,7 +26,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
    *
    * @var array
    */
-  protected $fieldMetadata = [];
+  protected array $fieldMetadata = [];
 
   protected string $baseEntity = 'Membership';
 
@@ -38,19 +38,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
    * @var bool
    */
   protected $isUpdatedForEntityRowParsing = TRUE;
-
-  /**
-   * Array of successfully imported membership id's
-   *
-   * @var array
-   */
-  protected $_newMemberships;
-
-  /**
-   * Separator being used
-   * @var string
-   */
-  protected $_separator;
 
   /**
    * Get information about the provided job.
@@ -82,8 +69,8 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
    */
   public function getImportEntities() : array {
     return [
-      'Membership' => ['text' => ts('Membership Fields'), 'is_contact' => FALSE],
-      'Contact' => ['text' => ts('Contact Fields'), 'is_contact' => TRUE],
+      'Membership' => ['text' => ts('Membership Fields'), 'is_contact' => FALSE, 'entity_field_prefix' => ''],
+      'Contact' => ['text' => ts('Contact Fields'), 'is_contact' => TRUE, 'entity_field_prefix' => 'contact.'],
     ];
   }
 

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -31,15 +31,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
   protected string $baseEntity = 'Membership';
 
   /**
-   * Has this parser been fixed to expect `getMappedRow` to break it up
-   * by entity yet? This is a transitional property to allow the classes
-   * to be fixed up individually.
-   *
-   * @var bool
-   */
-  protected $isUpdatedForEntityRowParsing = TRUE;
-
-  /**
    * Get information about the provided job.
    *  - name
    *  - id (generally the same as name)

--- a/CRM/Upgrade/Incremental/php/SixOne.php
+++ b/CRM/Upgrade/Incremental/php/SixOne.php
@@ -180,29 +180,37 @@ class CRM_Upgrade_Incremental_php_SixOne extends CRM_Upgrade_Incremental_Base {
       // as only the email rule can be selected. However, keeping the 'set'
       // together (from Contribution convert in FiveFiftyFour) feels like
       // it has merit
+      $contactPrefix = '';
+      if ($importType === 'Import Membership') {
+        $contactPrefix = 'contact.';
+      }
+      if ($importType === 'Import Activity') {
+        $contactPrefix = 'target_contact.';
+      }
       $fieldsToConvert = [
-        'email' => 'email_primary.email',
-        'phone' => 'phone_primary.phone',
-        'street_address' => 'address_primary.street_address',
-        'supplemental_address_1' => 'address_primary.supplemental_address_1',
-        'supplemental_address_2' => 'address_primary.supplemental_address_2',
-        'supplemental_address_3' => 'address_primary.supplemental_address_3',
-        'city' => 'address_primary.city',
-        'county_id' => 'address_primary.county_id',
-        'state_province_id' => 'address_primary.state_province_id',
-        'country_id' => 'address_primary.country_id',
-        'membership_id' => 'membership.id',
-        'membership_contact_id' => 'membership.contact_id',
-        'membership_start_date' => 'membership.start_date',
-        'membership_type_id' => 'membership.membership_type_id',
-        'membership_join_date' => 'membership.join_date',
-        'membership_end_date' => 'membership.end_date',
-        'membership_source' => 'membership.source',
-        'member_is_override' => 'membership.is_override',
-        'status_override_end_date' => 'membership.status_override_end_date',
-        'member_is_test' => 'membership.is_test',
-        'member_is_pay_later' => 'membership.is_pay_later',
-        'member_campaign_id' => 'membership.campaign_id',
+        'email' => $contactPrefix . 'email_primary.email',
+        'phone' => $contactPrefix . 'phone_primary.phone',
+        'street_address' => $contactPrefix . 'address_primary.street_address',
+        'supplemental_address_1' => $contactPrefix . 'address_primary.supplemental_address_1',
+        'supplemental_address_2' => $contactPrefix . 'address_primary.supplemental_address_2',
+        'supplemental_address_3' => $contactPrefix . 'address_primary.supplemental_address_3',
+        'city' => $contactPrefix . 'address_primary.city',
+        'county_id' => $contactPrefix . 'address_primary.county_id',
+        'state_province_id' => $contactPrefix . 'address_primary.state_province_id',
+        'country_id' => $contactPrefix . 'address_primary.country_id',
+        'external_identifier' => $contactPrefix . 'external_identifier',
+        'membership_id' => 'id',
+        'membership_contact_id' => 'contact.id',
+        'membership_start_date' => 'start_date',
+        'membership_type_id' => 'membership_type_id',
+        'membership_join_date' => 'join_date',
+        'membership_end_date' => 'end_date',
+        'membership_source' => 'source',
+        'member_is_override' => 'is_override',
+        'status_override_end_date' => 'status_override_end_date',
+        'member_is_test' => 'is_test',
+        'member_is_pay_later' => 'is_pay_later',
+        'member_campaign_id' => 'campaign_id',
         'source_contact_id' => 'source_contact.id',
         'target_contact_id' => 'target_contact.id',
         'source_contact_external_identifier' => 'source_contact.external_identifier',
@@ -222,13 +230,6 @@ class CRM_Upgrade_Incremental_php_SixOne extends CRM_Upgrade_Incremental_Base {
         'activity_engagement_level' => 'engagement_level',
         'activity_is_star' => 'is_star',
       ];
-      if ($importType === 'Import Activity') {
-        $fieldsToConvert['email'] = 'target_contact.email_primary.email';
-        $fieldsToConvert['external_identifier'] = 'target_contact.external_identifier';
-      }
-      if ($importType === 'Import Membership') {
-        $fieldsToConvert['status_id'] = 'membership.status_id';
-      }
 
       $customFields = CRM_Core_DAO::executeQuery('
       SELECT custom_field.id, custom_field.name, custom_group.name as custom_group_name, custom_group.extends
@@ -237,7 +238,8 @@ class CRM_Upgrade_Incremental_php_SixOne extends CRM_Upgrade_Incremental_Base {
       WHERE extends IN ("Contact", "Individual", "Organization", "Household", "Participant", "Membership", "Activity")
     ');
       while ($customFields->fetch()) {
-        $fieldsToConvert['custom_' . $customFields->id] = $customFields->custom_group_name . '.' . $customFields->name;
+        $prefix = in_array($customFields->extends, ['Contact', 'Individual', 'Household', 'Organization']) ? $contactPrefix : '';
+        $fieldsToConvert['custom_' . $customFields->id] = $prefix . $customFields->custom_group_name . '.' . $customFields->name;
       }
       while ($mappingFields->fetch()) {
         // Convert the field.

--- a/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
@@ -18,7 +18,7 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
   use CRMTraits_Custom_CustomDataTrait;
   use CRMTraits_Import_ParserTrait;
 
-  protected $entity = 'Participant';
+  protected string $entity = 'Participant';
 
   /**
    * @var int

--- a/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
@@ -147,7 +147,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
       ],
     ];
 
-    $importObject = $this->createImportObject(['email_primary.email', 'membership.membership_type_id', 'membership.start_date', 'membership.join_date']);
+    $importObject = $this->createImportObject(['contact.email_primary.email', 'membership_type_id', 'start_date', 'join_date']);
     foreach ($params as $values) {
       $this->assertEquals(CRM_Import_Parser::VALID, $importObject->import($values), $values[0]);
     }
@@ -164,7 +164,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
     $this->individualCreate(['email' => 'anthony_anderson2@civicrm.org']);
     $membershipImporter = new CRM_Member_Import_Parser_Membership();
     $membershipImporter->setUserJobID($this->getUserJobID([
-      'mapper' => [['email_primary.email'], ['membership.membership_type_id'], ['membership.start_date'], ['membership.is_override']],
+      'mapper' => [['contact.email_primary.email'], ['membership_type_id'], ['start_date'], ['is_override']],
       'onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE,
     ]));
     $membershipImporter->init();
@@ -192,11 +192,11 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
   public function testImportOverriddenMembershipWithStatus(): void {
     $this->individualCreate(['email' => 'anthony_anderson3@civicrm.org']);
     $membershipImporter = $this->createImportObject([
-      'email_primary.email',
-      'membership.membership_type_id',
-      'membership.start_date',
-      'membership.is_override',
-      'membership.status_id',
+      'contact.email_primary.email',
+      'membership_type_id',
+      'start_date',
+      'is_override',
+      'status_id',
     ]);
 
     $importValues = [
@@ -215,7 +215,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
     $this->individualCreate(['email' => 'anthony_anderson4@civicrm.org']);
     $membershipImporter = new CRM_Member_Import_Parser_Membership();
     $membershipImporter->setUserJobID($this->getUserJobID([
-      'mapper' => [['email_primary.email'], ['membership.membership_type_id'], ['membership.start_date'], ['membership.is_override'], ['membership.status_id'], ['membership.status_override_end_date']],
+      'mapper' => [['contact.email_primary.email'], ['membership_type_id'], ['start_date'], ['is_override'], ['status_id'], ['status_override_end_date']],
     ]));
     $membershipImporter->init();
 
@@ -235,7 +235,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
   public function testImportOverriddenMembershipWithInvalidOverrideEndDate(): void {
     $this->individualCreate(['email' => 'anthony_anderson5@civicrm.org']);
     $this->userJobID = $this->getUserJobID([
-      'mapper' => [['email_primary.email'], ['membership.membership_type_id'], ['membership.start_date'], ['membership.is_override'], ['membership.status_id'], ['membership.status_override_end_date']],
+      'mapper' => [['contact.email_primary.email'], ['membership_type_id'], ['start_date'], ['is_override'], ['status_id'], ['status_override_end_date']],
       'onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE,
     ]);
     $membershipImporter = new CRM_Member_Import_Parser_Membership();
@@ -275,11 +275,11 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
       ],
     ]);
     $membershipImporter = $this->createImportObject([
-      'email_primary.email',
-      'membership.membership_type_id',
-      'membership.start_date',
-      'membership.is_override',
-      'membership.status_id',
+      'contact.email_primary.email',
+      'membership_type_id',
+      'start_date',
+      'is_override',
+      'status_id',
     ]);
 
     $importValues = [
@@ -362,11 +362,11 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
     $donaldDuckID = $this->individualCreate(['first_name' => 'Donald', 'last_name' => 'Duck']);
     $this->createCustomGroupWithFieldsOfAllTypes(['extends' => 'Membership']);
     $membershipImporter = $this->createImportObject([
-      'membership.contact_id',
-      'membership.membership_type_id',
-      'membership.start_date',
-      'membership.' . $this->getCustomFieldName('text', 4),
-      'membership.' . $this->getCustomFieldName('select_string', 4),
+      'contact_id',
+      'membership_type_id',
+      'start_date',
+      '' . $this->getCustomFieldName('text', 4),
+      '' . $this->getCustomFieldName('select_string', 4),
     ]);
     $importValues = [
       $donaldDuckID,
@@ -394,12 +394,12 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
   public function testRequiredFields(array $dataProvider): void {
     $this->individualCreate(['external_identifier' => 'abc', 'email' => 'jenny@example.com']);
     $mapper = [
-      ['name' => 'membership.membership_type_id'],
-      ['name' => 'membership.id'],
-      ['name' => 'membership.contact_id'],
-      ['name' => 'external_identifier'],
-      ['name' => 'email_primary.email'],
-      ['name' => 'membership.start_date'],
+      ['name' => 'membership_type_id'],
+      ['name' => 'id'],
+      ['name' => 'contact_id'],
+      ['name' => 'contact.external_identifier'],
+      ['name' => 'contact.email_primary.email'],
+      ['name' => 'start_date'],
     ];
     foreach ($mapper as $index => $field) {
       if (!in_array($field['name'], $dataProvider)) {
@@ -415,9 +415,9 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
 
   public function requiredFields(): array {
     return [
-      'membership.contact_id' => [['membership.contact_id', 'membership.membership_type_id', 'membership.start_date']],
-      'external_identifier' => [['external_identifier', 'membership.membership_type_id', 'membership.start_date']],
-      'email' => [['email_primary.email', 'membership.membership_type_id', 'membership.start_date']],
+      'contact_id' => [['contact_id', 'membership_type_id', 'start_date']],
+      'external_identifier' => [['contact.external_identifier', 'membership_type_id', 'start_date']],
+      'email' => [['contact.email_primary.email', 'membership_type_id', 'start_date']],
     ];
   }
 
@@ -426,10 +426,10 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
    */
   public function testImportCSV() :void {
     $this->importCSV('memberships_invalid.csv', [
-      ['name' => 'membership.contact_id'],
-      ['name' => 'membership.source'],
-      ['name' => 'membership.membership_type_id'],
-      ['name' => 'membership.start_date'],
+      ['name' => 'contact_id'],
+      ['name' => 'source'],
+      ['name' => 'membership_type_id'],
+      ['name' => 'start_date'],
       ['name' => 'do_not_import'],
     ]);
     $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
@@ -447,10 +447,10 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
       'contact_id' => $this->individualCreate(),
     ]);
     $this->importCSV('memberships_with_id.csv', [
-      ['name' => 'membership.id'],
-      ['name' => 'membership.source'],
-      ['name' => 'membership.membership_type_id'],
-      ['name' => 'membership.start_date'],
+      ['name' => 'id'],
+      ['name' => 'source'],
+      ['name' => 'membership_type_id'],
+      ['name' => 'start_date'],
       ['name' => 'do_not_import'],
     ]);
     $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
@@ -471,8 +471,8 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
       'start_date' => '2019-03-23',
     ]);
     $this->importCSV('memberships_with_id.csv', [
-      ['name' => 'membership.id'],
-      ['name' => 'membership.source'],
+      ['name' => 'id'],
+      ['name' => 'source'],
       ['name' => 'do_not_import'],
       ['name' => 'do_not_import'],
       ['name' => 'do_not_import'],
@@ -488,14 +488,16 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
 
   /**
    * Test the full form-flow import.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testImportTSV() :void {
     $this->individualCreate(['email' => 'member@example.com']);
     $this->importCSV('memberships_valid.tsv', [
-      ['name' => 'email_primary.email'],
-      ['name' => 'membership.source'],
-      ['name' => 'membership.membership_type_id'],
-      ['name' => 'membership.start_date'],
+      ['name' => 'contact.email_primary.email'],
+      ['name' => 'source'],
+      ['name' => 'membership_type_id'],
+      ['name' => 'start_date'],
       ['name' => 'do_not_import'],
     ], ['fieldSeparator' => 'tab']);
     $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
@@ -517,11 +519,11 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
       'start_date' => '2020-10-01',
     ]);
     $mapping = [
-      ['name' => 'membership.id'],
-      ['name' => 'membership.source'],
-      ['name' => 'membership.membership_type_id'],
-      ['name' => 'membership.start_date'],
-      ['name' => 'membership.' . $this->getCustomFieldName('date', 4)],
+      ['name' => 'id'],
+      ['name' => 'source'],
+      ['name' => 'membership_type_id'],
+      ['name' => 'start_date'],
+      ['name' => $this->getCustomFieldName('date', 4)],
     ];
     $this->importCSV('memberships_update_custom_date.csv', $mapping, ['dateFormats' => 32]);
     $membership = $this->callAPISuccessGetSingle('Membership', []);
@@ -537,6 +539,8 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
    * @param string $csv Name of csv file.
    * @param array $fieldMappings
    * @param array $submittedValues
+   *
+   * @throws \CRM_Core_Exception
    */
   protected function importCSV(string $csv, array $fieldMappings, array $submittedValues = []): void {
     $submittedValues = array_merge([


### PR DESCRIPTION
Overview
----------------------------------------
Fix recent updates to import member to align with import activity

Before
----------------------------------------
When I updated the membership import to use apiv4 I added namespacing to the membership fields (& not the contact fields) - However, in the context of the Activity Import update I agreed the reverse with @colemanw 

After
----------------------------------------
Fixed to namespace contact fields and NOT membership fields

Technical Details
----------------------------------------

Comments
----------------------------------------