### PR TITLE
Finish removing string-wrangled array of tables from dedupe optimizer

### DIFF
--- a/CRM/Dedupe/BAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/BAO/DedupeRuleGroup.php
@@ -163,7 +163,7 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup impl
       return;
     }
 
-    $dedupeTable = $optimizer->runTablesQuery($tableQueries, $threshold);
+    $dedupeTable = $optimizer->runTablesQuery();
     if (!$dedupeTable) {
       return;
     }
@@ -214,7 +214,7 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup impl
       return;
     }
 
-    $dedupeTable = $optimizer->runTablesQuery($tableQueries, $threshold);
+    $dedupeTable = $optimizer->runTablesQuery();
 
     $aclFrom = '';
     $aclWhere = '';


### PR DESCRIPTION
Overview
----------------------------------------
Finish removing string-wrangled array of tables from dedupe optimizer

Before
----------------------------------------
Prior to separating out the legacy-hook-supporting code we had to work with a very specific, difficult, string format in the optimizer. The requirement is gone but that code lingers on

After
----------------------------------------
poof - we work with the array rather than trying to deconstruct a string into an array

Technical Details
----------------------------------------

Comments
----------------------------------------
