### PR TITLE
Api4 - Update file url formatting

### DIFF
--- a/tests/phpunit/api/v4/Action/EntityFileTest.php
+++ b/tests/phpunit/api/v4/Action/EntityFileTest.php
@@ -95,8 +95,8 @@ class EntityFileTest extends Api4TestBase implements TransactionalInterface, Hoo
     $this->assertCount(2, $allowedNotes);
     $this->assertEquals('file_for_' . $note[2] . '.txt', $allowedNotes[$note[2]]['file.file_name']);
     $this->assertEquals('file_for_' . $note[3] . '.txt', $allowedNotes[$note[3]]['file.file_name']);
-    $this->assertStringContainsString("id=$file[2]&eid=$note[2]&fcs=", $allowedNotes[$note[2]]['file.url']);
-    $this->assertStringContainsString("id=$file[3]&eid=$note[3]&fcs=", $allowedNotes[$note[3]]['file.url']);
+    $this->assertStringContainsString("id=$file[2]&fcs=", $allowedNotes[$note[2]]['file.url']);
+    $this->assertStringContainsString("id=$file[3]&fcs=", $allowedNotes[$note[3]]['file.url']);
   }
 
   public function testGetAggregateFileFields() {

--- a/tests/phpunit/api/v4/Custom/CustomFileTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomFileTest.php
@@ -70,7 +70,7 @@ class CustomFileTest extends Api4TestBase {
       ->execute()->single();
 
     $this->assertEquals('test123.txt', $file['file_name']);
-    $this->assertStringContainsString("id={$file['id']}&eid={$contact['id']}&fcs=", $file['url']);
+    $this->assertStringContainsString("id={$file['id']}&fcs=", $file['url']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Following up on dd68ec4789874098fb6ed723d5b1627039683269 this fixes Api4 to use the new file url format.

Also, we no longer need entity_id to generate a file url, greatly simplifying the formatFileUrl function.