### PR TITLE
Optimize dedupe query in finder flow - speed improvement

### DIFF
--- a/CRM/Dedupe/BAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/BAO/DedupeRuleGroup.php
@@ -163,7 +163,7 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup impl
       return;
     }
 
-    $dedupeTable = $optimizer->runTablesQuery($tableQueries, $threshold);
+    $dedupeTable = $optimizer->runTablesQuery();
     if (!$dedupeTable) {
       return;
     }
@@ -214,7 +214,7 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup impl
       return;
     }
 
-    $dedupeTable = $optimizer->runTablesQuery($tableQueries, $threshold);
+    $dedupeTable = $optimizer->runTablesQuery();
 
     $aclFrom = '';
     $aclWhere = '';

--- a/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
+++ b/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
@@ -160,7 +160,15 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
     $this->assertEquals([$this->ids['Contact']['individual_0']], $result);
     $queries = \Civi::$statics['CRM_Dedupe_FinderQueryOptimizer']['queries'];
     // Check that the city query was eliminated - it has data but it's weight of 3 cannot influence the match outcome.
-    $this->assertEquals(['civicrm_contact.first_name_nick_name.12', 'civicrm_address.street_address.4'], array_keys($queries));
+    // The other queries are combined.
+    $this->assertCount(1, $queries);
+    $query = reset($queries);
+    $this->assertEquals(16, $query['weight']);
+    $this->assertEquals(1, $query['found_rows']);
+    $this->assertLike("SELECT civicrm_address .contact_id id1,  16 weight  FROM civicrm_contact t1
+          INNER JOIN civicrm_address
+          ON t1.id = civicrm_address.contact_id
+          AND civicrm_address.street_address = 'sesame street' WHERE t1.contact_type = 'Individual' AND t1.first_name = 'Robert' AND t1.contact_type = 'Individual' AND t1.nick_name = 'Bob'", $query['query']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Optimize dedupe query in *new* dedupe finder flow when parameters are provided

*note* In 6.1 there is a new extension that holds the pre-existing dedupe query logic called `legacydedupefinder` - it is installed on new installs and on upgrade and is hidden so all live sites will be using it.  This PR affects what happens when the hidden extension is disabled (which a site would have to do deliberately at this stage.

Before
----------------------------------------
The dedupe code is clever enough to combine queries from 1 table if appropriate but not from 2. Take for example a rule

- first_name = 5
- nick_name = 5
- city = 5

with a threshold of 15

Before this patch on the new code two queries would run - one combining the 2 fields in the contact table and 1 searching within those results for the city match - on our site the first of those queries takes the best part of a second

```
SELECT t1.id id1, 16 weight FROM civicrm_contact t1    WHERE t1.contact_type = 'Individual'   AND t1.first_name = 'Robert' AND t1.contact_type = 'Individual' AND t1.nick_name = 'Bob';
2483 rows in set (0.765 sec)
```

(I didn't time the second query but it would be quicker)

After
----------------------------------------
Just 1 query runs - and it is many many times faster (note the repetition of the `contact_type` filter did not affect the query speed)

```
SELECT civicrm_address.contact_id id1, 16 weight FROM civicrm_contact t1          INNER JOIN civicrm_address
     ON t1.id = civicrm_address.contact_id                         AND civicrm_address.city = 'megaville' WHERE t1.contact_type = 'Individual'   AND
 t1.first_name = 'Robert' AND t1.contact_type = 'Individual' AND t1.nick_name = 'Bob';
Empty set (0.002 sec)
```

Technical Details
----------------------------------------
This only affects when parameters are passed in - I also want to try to do the same optimisation to the find duplicates code path

Comments
----------------------------------------
As of writing there is one scenario that is not quite handled - I'm hoping to see a test fail on it - otherwise I'll have to write one!