### PR TITLE
RiverLea: Fixes SearchKit admin UI regression & removes stream name & version number from footer

### DIFF
--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -375,10 +375,11 @@ table.advmultiselect {
   text-align: center;
   font-size: var(--crm-m2);
 }
+/* Outputs stream + version number
 #civicrm-footer::after {
   content: var(--crm-version);
   float: right;
-}
+}*/
 .crm-container #civicrm-footer .status {
   border-radius: var(--crm-roundness);
   padding: var(--crm-btn-small-padding);

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
@@ -234,7 +234,6 @@ i.crm-i.crm-search-move-icon {
   max-width: 125px;
 }
 .crm-search-admin-edit-columns .crm-draggable > td.form-inline {
-  font-size: 0;
   padding-right: var(--crm-s);
 }
 .crm-search-admin-edit-columns .crm-draggable tfoot td.form-inline {


### PR DESCRIPTION
Overview
----------------------------------------
I just noticed a regression, this is a one-line fix for that. At the same time it seemed a good time to hide the RiverLea stream name and version number that has been useful during development and testing - this is just commented out so it could be turned back on during development.

Before
----------------------------------------
In searchkit admin - on select lists in tables inside draggable regions, all streams. Version name and number is at the bottom right.

![image](https://github.com/user-attachments/assets/2626795e-801f-4f95-ae7e-d7a013cac8a8)

After
----------------------------------------
Regression fixed, numbering removed

![image](https://github.com/user-attachments/assets/5a0fe3d3-b8eb-4146-8bac-93d9bdda46e4)

Technical Details
----------------------------------------
I can't see why this font-size was set to zero = it's a method to hide text, but there are more accessible methods such as visibility none, so was maybe a quick 'fix' during dev. The original [SearchKit css file that this was forked from](https://github.com/civicrm/civicrm-core/blob/master/ext/search_kit/css/crmSearchAdmin.css) doesn't include this line, so the issue is within RIverLea, it's reverting something non-essential in the original css. So the consequences should be small.