### PR TITLE
Standalone - Remove crashy debug code

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -332,14 +332,6 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    * @inheritDoc
    */
   public function theme(&$content, $print = FALSE, $maintenance = FALSE) {
-
-    // Q. what does this do? Why do we only include this for maintenance?
-    if ($maintenance) {
-      $smarty = CRM_Core_Smarty::singleton();
-      echo implode('', $smarty->getTemplateVars('pageHTMLHead'));
-    }
-
-    // @todo Add variables from the body tag? (for Shoreditch)
     print $content;
     return NULL;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes crash during standalone upgrade.

Technical Details
----------------------------------------
This code appears to be for debugging purposes but causes the upgrader to crash