### PR TITLE
[REF][PHP8.2] Move single and limit properties to parent class

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -33,20 +33,6 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
   protected $_queryParams;
 
   /**
-   * Are we restricting ourselves to a single contact.
-   *
-   * @var bool
-   */
-  protected $_single = FALSE;
-
-  /**
-   * Are we restricting ourselves to a single contact.
-   *
-   * @var bool
-   */
-  protected $_limit;
-
-  /**
    * Prefix for the controller.
    * @var string
    */

--- a/CRM/Campaign/Form/Search.php
+++ b/CRM/Campaign/Form/Search.php
@@ -28,20 +28,6 @@ class CRM_Campaign_Form_Search extends CRM_Core_Form_Search {
   protected $_queryParams;
 
   /**
-   * Are we restricting ourselves to a single contact.
-   *
-   * @var bool
-   */
-  protected $_single = FALSE;
-
-  /**
-   * Are we restricting ourselves to a single contact.
-   *
-   * @var bool
-   */
-  protected $_limit = NULL;
-
-  /**
    * Prefix for the controller.
    * @var string
    */

--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -28,20 +28,6 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
   protected $_queryParams;
 
   /**
-   * Are we restricting ourselves to a single contact
-   *
-   * @var bool
-   */
-  protected $_single = FALSE;
-
-  /**
-   * Are we restricting ourselves to a single contact
-   *
-   * @var bool
-   */
-  protected $_limit = NULL;
-
-  /**
    * Prefix for the controller
    * @var string
    */

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -28,20 +28,6 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
   protected $_queryParams;
 
   /**
-   * Are we restricting ourselves to a single contact.
-   *
-   * @var bool
-   */
-  protected $_single = FALSE;
-
-  /**
-   * Are we restricting ourselves to a single contact.
-   *
-   * @var bool
-   */
-  protected $_limit = NULL;
-
-  /**
    * Prefix for the controller.
    * @var string
    */

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -60,6 +60,19 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
   protected $entityReferenceFields = [];
 
   /**
+   * Are we restricting ourselves to a single contact
+   *
+   * @var bool
+   */
+  protected bool $_single = FALSE;
+
+  /**
+   * How many records should we return
+   * @var int|null
+   */
+  protected ?int $_limit = NULL;
+
+  /**
    * Builds the list of tasks or actions that a searcher can perform on a result set.
    *
    * To modify the task list, child classes should alter $this->_taskList,

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -28,20 +28,6 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
   protected $_queryParams;
 
   /**
-   * Are we restricting ourselves to a single contact.
-   *
-   * @var bool
-   */
-  protected $_single = FALSE;
-
-  /**
-   * Are we restricting ourselves to a single contact.
-   *
-   * @var bool
-   */
-  protected $_limit = NULL;
-
-  /**
    * Prefix for the controller.
    * @var string
    */

--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -30,20 +30,6 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
   protected $_queryParams;
 
   /**
-   * Are we restricting ourselves to a single contact.
-   *
-   * @var bool
-   */
-  protected $_single = FALSE;
-
-  /**
-   * Are we restricting ourselves to a single contact.
-   *
-   * @var bool
-   */
-  protected $_limit = NULL;
-
-  /**
    * Prefix for the controller.
    * @var string
    */

--- a/CRM/Pledge/Form/Search.php
+++ b/CRM/Pledge/Form/Search.php
@@ -35,20 +35,6 @@ class CRM_Pledge_Form_Search extends CRM_Core_Form_Search {
   }
 
   /**
-   * Are we restricting ourselves to a single contact.
-   *
-   * @var bool
-   */
-  protected $_single = FALSE;
-
-  /**
-   * Are we restricting ourselves to a single contact.
-   *
-   * @var bool
-   */
-  protected $_limit = NULL;
-
-  /**
    * Prefix for the controller.
    * @var string
    */

--- a/ext/civigrant/CRM/Grant/Form/Search.php
+++ b/ext/civigrant/CRM/Grant/Form/Search.php
@@ -28,20 +28,6 @@ class CRM_Grant_Form_Search extends CRM_Core_Form_Search {
   protected $_queryParams;
 
   /**
-   * Are we restricting ourselves to a single contact.
-   *
-   * @var bool
-   */
-  protected $_single = FALSE;
-
-  /**
-   * Return limit.
-   *
-   * @var int
-   */
-  protected $_limit;
-
-  /**
    * Prefix for the controller.
    *
    * @var string


### PR DESCRIPTION
Overview
----------------------------------------
This started by me trying to fix this notice:
```
Deprecated function: Creation of dynamic property CRM_Mailing_Form_Search::$_limit is deprecated
```

However, I noticed some code quality issues so I decided to go a bit further.

Before
----------------------------------------
* Properties declared on every class, even though they're primarily used from the parent class.
* Incorrect comment.
* Uninitialized properties.

After
----------------------------------------
Property declarations moved to parent class.