### PR TITLE
Fix undefined array key error in Smarty

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1353,6 +1353,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       if (isset($mailing->group_id)) {
         $row['id'] = $mailing->group_id;
         $row['name'] = $mailing->group_title;
+        $row['mailing'] = FALSE;
         $row['link'] = CRM_Utils_System::url('civicrm/group/search',
           "reset=1&force=1&context=smog&gid={$row['id']}"
         );


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a warning in PHP8 when viewing a mailing report.

To replicate:
* View a mailing report.
* Check for PHP warnings (watchdog, PHP log, on-screen, etc.)

Before
----------------------------------------
```
Undefined array key "mailing" in content_67c8b11b8d8a04_52125119() (line 258 of /home/jon/local/mysite/web/sites/default/files/civicrm/templates_c/en_US/d7/f0/ce/d7f0cee44e11a00fc8fafdc76958bca99125a66f_0.file.Report.tpl.php) 
```

After
----------------------------------------
No warning.

Technical Details
----------------------------------------
You can see where `$row['mailing']` is initialized in the `else` statement directly below this change.  You can see `{if $group.mailing}` in `templates/CRM/Mailing/Page/Report.tpl`.
