### PR TITLE
Api4 - Add attachment functionality to the File api

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2638,6 +2638,14 @@ WHERE      f.id IN ($ids)";
     return is_object($field) ? !empty($field->serialize) : !empty($field['serialize']);
   }
 
+  public static function getFkEntity(array $field): ?string {
+    $dataTypeToFK = [
+      'ContactReference' => 'Contact',
+      'File' => 'File',
+    ];
+    return $field['fk_entity'] ?? $dataTypeToFK[$field['data_type']] ?? NULL;
+  }
+
   public static function getFkEntityOnDeleteOptions(): array {
     return [
       'set_null' => ts('Delete reference'),

--- a/Civi/Api4/Action/File/Create.php
+++ b/Civi/Api4/Action/File/Create.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\File;
+
+/**
+ * @inheritDoc
+ */
+class Create extends \Civi\Api4\Generic\DAOCreateAction {
+  use FileSaveTrait;
+
+}

--- a/Civi/Api4/Action/File/Delete.php
+++ b/Civi/Api4/Action/File/Delete.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\File;
+
+/**
+ * @inheritDoc
+ */
+class Delete extends \Civi\Api4\Generic\DAODeleteAction {
+
+  /**
+   * Whether to remove the file from the filesystem.
+   *
+   * If FALSE, only the row in the `civicrm_file` table will be deleted and the filesystem will not be touched.
+   *
+   * @var bool
+   */
+  protected $deleteFile = TRUE;
+
+  protected function deleteObjects($items): array {
+    $result = [];
+    foreach (\CRM_Core_BAO_File::deleteRecords($items) as $instance) {
+      $result[] = ['id' => $instance->id];
+    }
+    if ($this->deleteFile) {
+      foreach ($items as $item) {
+        $path = \CRM_Core_Config::singleton()->customFileUploadDir . $item['uri'];
+        if ($item['uri'] && file_exists($path)) {
+          unlink($path);
+        }
+      }
+    }
+    return $result;
+  }
+
+  protected function getSelect(): array {
+    return ['id', 'uri'];
+  }
+
+}

--- a/Civi/Api4/Action/File/FileSaveTrait.php
+++ b/Civi/Api4/Action/File/FileSaveTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\File;
+
+trait FileSaveTrait {
+
+  /**
+   * @inheritDoc
+   */
+  protected function write(array $items) {
+    foreach ($items as &$file) {
+      if (empty($file['id']) && !empty($file['file_name'])) {
+        $file['uri'] = $this->makeFileUri($file['file_name']);
+        if (!empty($file['move_file'])) {
+          $path = $this->getFilePath($file);
+          if (!copy($file['move_file'], $path)) {
+            throw new \CRM_Core_Exception("Cannot copy uploaded file {$file['move_file']} to $path");
+          }
+          unlink($file['move_file']);
+        }
+      }
+      if (!empty($file['content'])) {
+        $path = $this->getFilePath($file);
+        file_put_contents($path, $file['content']);
+      }
+    }
+    return \CRM_Core_BAO_File::writeRecords($items);
+  }
+
+  private function getFilePath(array $file) {
+    $uri = $file['uri'] ?? \CRM_Core_DAO_File::getDbVal('uri', $file['id']);
+    return \CRM_Core_Config::singleton()->customFileUploadDir . $uri;
+  }
+
+  private function makeFileUri($fileName) {
+    if ($fileName != basename($fileName) || preg_match(':[/\\\\]:', $fileName)) {
+      throw new \CRM_Core_Exception('Malformed name');
+    }
+    return \CRM_Utils_File::makeFileName($fileName);
+  }
+
+}

--- a/Civi/Api4/Action/File/Save.php
+++ b/Civi/Api4/Action/File/Save.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\File;
+
+/**
+ * @inheritDoc
+ */
+class Save extends \Civi\Api4\Generic\DAOSaveAction {
+  use FileSaveTrait;
+
+}

--- a/Civi/Api4/Action/File/Update.php
+++ b/Civi/Api4/Action/File/Update.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\File;
+
+/**
+ * @inheritDoc
+ */
+class Update extends \Civi\Api4\Generic\DAOUpdateAction {
+  use FileSaveTrait;
+
+}

--- a/Civi/Api4/File.php
+++ b/Civi/Api4/File.php
@@ -46,4 +46,13 @@ class File extends Generic\DAOEntity {
       ->setCheckPermissions($checkPermissions);
   }
 
+  /**
+   * @param bool $checkPermissions
+   * @return Action\File\Delete
+   */
+  public static function delete($checkPermissions = TRUE) {
+    return (new Action\File\Delete(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
 }

--- a/Civi/Api4/File.php
+++ b/Civi/Api4/File.php
@@ -19,4 +19,31 @@ namespace Civi\Api4;
  */
 class File extends Generic\DAOEntity {
 
+  /**
+   * @param bool $checkPermissions
+   * @return Action\File\Create
+   */
+  public static function create($checkPermissions = TRUE) {
+    return (new Action\File\Create(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return Action\File\Save
+   */
+  public static function save($checkPermissions = TRUE) {
+    return (new Action\File\Save(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return Action\File\Update
+   */
+  public static function update($checkPermissions = TRUE) {
+    return (new Action\File\Update(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
 }

--- a/Civi/Api4/Generic/DAODeleteAction.php
+++ b/Civi/Api4/Generic/DAODeleteAction.php
@@ -51,7 +51,7 @@ class DAODeleteAction extends AbstractBatchAction {
   }
 
   /**
-   * @param $items
+   * @param array $items
    * @return array
    * @throws \CRM_Core_Exception
    */

--- a/Civi/Api4/Service/Schema/SchemaMapBuilder.php
+++ b/Civi/Api4/Service/Schema/SchemaMapBuilder.php
@@ -129,10 +129,10 @@ class SchemaMapBuilder extends AutoService {
         $customTable->addTableLink('entity_id', $oldJoin);
       }
 
-      // Add joins for entityReference fields
+      // Add joins for fields with foreign keys
       foreach ($customGroup['fields'] as $field) {
-        if ($field['data_type'] === 'EntityReference' && isset($field['fk_entity'])) {
-          $targetEntity = $field['fk_entity'];
+        $targetEntity = \CRM_Core_BAO_CustomField::getFkEntity($field);
+        if ($targetEntity) {
           $targetTable = self::getTableName($targetEntity);
           if (!$targetTable) {
             // the target entity doesn't exist - skip to avoid crashing
@@ -140,11 +140,6 @@ class SchemaMapBuilder extends AutoService {
             continue;
           }
           $joinable = new Joinable($targetTable, 'id', $field['name']);
-          $customTable->addTableLink($field['column_name'], $joinable);
-        }
-
-        if ($field['data_type'] === 'ContactReference') {
-          $joinable = new Joinable('civicrm_contact', 'id', $field['name']);
           if ($field['serialize']) {
             $joinable->setSerialize((int) $field['serialize']);
           }

--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -294,10 +294,11 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
           $field['pseudoconstant'] = $addressField['pseudoconstant'];
         }
         // Set FK for EntityRef, ContactRef & File fields
-        if ($customField['fk_entity'] || $customField['data_type'] === 'ContactReference' || $customField['data_type'] === 'File') {
+        $fkEntity = \CRM_Core_BAO_CustomField::getFkEntity($customField);
+        if ($fkEntity) {
           $onDelete = empty($customField['fk_entity_on_delete']) ? 'SET NULL' : strtoupper(str_replace('_', ' ', $customField['fk_entity_on_delete']));
           $field['entity_reference'] = [
-            'entity' => $customField['fk_entity'] ?? str_replace('Reference', '', $customField['data_type']),
+            'entity' => $fkEntity,
             'key' => 'id',
             'on_delete' => $onDelete,
           ];

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -2731,14 +2731,16 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     ])->column('id');
 
     foreach (['text/plain' => 'txt', 'image/png' => 'png', 'image/foo' => 'foo'] as $mimeType => $ext) {
-      // FIXME: Use api4 when available
-      civicrm_api3('Attachment', 'create', [
-        'entity_table' => 'civicrm_note',
-        'entity_id' => $notes[0],
-        'name' => 'test_file.' . $ext,
+      $file = $this->createTestRecord('File', [
+        'file_name' => 'test_file.' . $ext,
         'mime_type' => $mimeType,
         'content' => 'hello',
-      ])['id'];
+      ]);
+      $this->createTestRecord('EntityFile', [
+        'file_id' => $file['id'],
+        'entity_table' => 'civicrm_note',
+        'entity_id' => $notes[0],
+      ]);
     }
 
     $params = [

--- a/tests/phpunit/api/v4/Action/EntityFileTest.php
+++ b/tests/phpunit/api/v4/Action/EntityFileTest.php
@@ -48,15 +48,18 @@ class EntityFileTest extends Api4TestBase implements TransactionalInterface, Hoo
 
     $file = [];
 
-    // FIXME: Use api4 when available
     foreach ($note as $nid) {
-      $file[] = civicrm_api3('Attachment', 'create', [
-        'entity_table' => 'civicrm_note',
-        'entity_id' => $nid,
-        'name' => 'file_for_' . $nid . '.txt',
+      $fileId = $this->createTestRecord('File', [
+        'file_name' => 'file_for_' . $nid . '.txt',
         'mime_type' => 'text/plain',
         'content' => 'hello',
       ])['id'];
+      $file[] = $fileId;
+      $this->createTestRecord('EntityFile', [
+        'file_id' => $fileId,
+        'entity_table' => 'civicrm_note',
+        'entity_id' => $nid,
+      ]);
     }
 
     // Grant access to contact 2 & 3, deny to 0 & 1
@@ -103,14 +106,16 @@ class EntityFileTest extends Api4TestBase implements TransactionalInterface, Hoo
     $activity = $this->createTestRecord('Activity');
 
     foreach (['text/plain' => 'txt', 'image/png' => 'png', 'image/jpg' => 'jpg'] as $mimeType => $ext) {
-      // FIXME: Use api4 when available
-      civicrm_api3('Attachment', 'create', [
-        'entity_table' => 'civicrm_activity',
-        'entity_id' => $activity['id'],
-        'name' => 'test_file.' . $ext,
+      $file = $this->createTestRecord('File', [
+        'file_name' => 'test_file.' . $ext,
         'mime_type' => $mimeType,
         'content' => 'hello',
-      ])['id'];
+      ]);
+      $this->createTestRecord('EntityFile', [
+        'file_id' => $file['id'],
+        'entity_table' => 'civicrm_activity',
+        'entity_id' => $activity['id'],
+      ]);
     }
 
     $get = Activity::get(FALSE)

--- a/tests/phpunit/api/v4/Custom/CustomFileTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomFileTest.php
@@ -18,6 +18,8 @@
 namespace api\v4\Custom;
 
 use api\v4\Api4TestBase;
+use Civi\Api4\Activity;
+use Civi\Api4\Contact;
 use Civi\Api4\File;
 
 /**
@@ -27,50 +29,109 @@ class CustomFileTest extends Api4TestBase {
 
   /**
    */
-  public function testCustomFileField(): void {
-    $group = $this->createTestRecord('CustomGroup', [
-      'title' => 'FileFields',
+  public function testCustomFileContent(): void {
+    $fieldName = 'ContactFileFields.TestMyFile';
+    [$customGroup, $customField] = explode('.', $fieldName);
+
+    $this->createTestRecord('CustomGroup', [
+      'title' => $customGroup,
       'extends' => 'Individual',
     ]);
     $this->createTestRecord('CustomField', [
-      'label' => 'TestMyFile',
-      'custom_group_id.name' => 'FileFields',
+      'label' => $customField,
+      'custom_group_id.name' => $customGroup,
       'html_type' => 'File',
       'data_type' => 'File',
     ]);
 
-    $fieldName = 'FileFields.TestMyFile';
+    $getFields = Contact::getFields(FALSE)
+      ->execute()->indexBy('name');
+    $this->assertEquals('File', $getFields[$fieldName]['fk_entity']);
 
     $contact = $this->createTestRecord('Individual');
 
-    // FIXME: Use Api4 when available
-    $file = civicrm_api3('Attachment', 'create', [
-      // The mismatch between entity id and entity table feels very wrong but that's how core does it for now
-      'entity_id' => $contact['id'],
-      'entity_table' => $group['table_name'],
+    $file = $this->createTestRecord('File', [
       'mime_type' => 'text/plain',
-      'name' => 'test123.txt',
+      'file_name' => 'test123.txt',
       'content' => 'Hello World 123',
     ]);
-    // FIXME: Autocleanup would happen if using Api4 + $this->createTestRecord
-    $this->registerTestRecord('File', $file['id']);
+
+    Contact::update(FALSE)
+      ->addWhere('id', '=', $contact['id'])
+      ->addValue($fieldName, $file['id'])
+      ->execute();
+    // Register hidden entityFile record for cleanup
     $this->registerTestRecord('EntityFile', [['file_id', '=', $file['id']]]);
 
-    civicrm_api4('Individual', 'update', [
-      'values' => [
-        'id' => $contact['id'],
-        $fieldName => $file['id'],
-      ],
-      'checkPermissions' => FALSE,
-    ]);
-
-    $file = File::get(FALSE)
-      ->addSelect('id', 'file_name', 'url')
+    $result = File::get(FALSE)
+      ->addSelect('uri', 'file_name', 'url', 'content')
       ->addWhere('id', '=', $file['id'])
       ->execute()->single();
+    $this->assertEquals($file['uri'], $result['uri']);
+    $this->assertEquals('test123.txt', $result['file_name']);
+    $this->assertEquals('Hello World 123', $result['content']);
+    $this->assertStringContainsString("id={$file['id']}&fcs=", $result['url']);
 
-    $this->assertEquals('test123.txt', $file['file_name']);
-    $this->assertStringContainsString("id={$file['id']}&fcs=", $file['url']);
+    // Update file contents
+    File::update(FALSE)
+      ->addWhere('id', '=', $file['id'])
+      ->addValue('content', 'Hello World 456')
+      ->execute();
+
+    // This time use a join to fetch the file
+    $result = Contact::get(FALSE)
+      ->addSelect('id', "$fieldName.uri", "$fieldName.file_name", "$fieldName.url", "$fieldName.content")
+      ->addWhere('id', '=', $contact['id'])
+      ->execute()->single();
+
+    $this->assertEquals($file['uri'], $result["$fieldName.uri"]);
+    $this->assertEquals('test123.txt', $result["$fieldName.file_name"]);
+    $this->assertEquals('Hello World 456', $result["$fieldName.content"]);
+    $this->assertStringContainsString("id={$file['id']}&fcs=", $result["$fieldName.url"]);
+  }
+
+  public function testMoveFile(): void {
+    $fieldName = 'ActFileFields.TestMyFile';
+    [$customGroup, $customField] = explode('.', $fieldName);
+
+    $this->createTestRecord('CustomGroup', [
+      'title' => $customGroup,
+      'extends' => 'Activity',
+    ]);
+    $this->createTestRecord('CustomField', [
+      'label' => $customField,
+      'custom_group_id.name' => $customGroup,
+      'html_type' => 'File',
+      'data_type' => 'File',
+    ]);
+
+    $file = $this->createTestRecord('File', [
+      'mime_type' => 'text/plain',
+      'file_name' => 'test456.txt',
+      'move_file' => $this->createTmpFile('Hello World 12345'),
+    ]);
+
+    $activity = $this->createTestRecord('Activity', [
+      $fieldName => $file['id'],
+    ]);
+
+    $result = Activity::get(FALSE)
+      ->addSelect('id', "$fieldName.uri", "$fieldName.file_name", "$fieldName.url", "$fieldName.content")
+      ->addWhere('id', '=', $activity['id'])
+      ->execute()->single();
+
+    $this->assertEquals($file['uri'], $result["$fieldName.uri"]);
+    $this->assertEquals('test456.txt', $result["$fieldName.file_name"]);
+    $this->assertEquals('Hello World 12345', $result["$fieldName.content"]);
+    $this->assertStringContainsString("id={$file['id']}&fcs=", $result["$fieldName.url"]);
+  }
+
+  protected function createTmpFile(string $content): string {
+    $tmpDir = sys_get_temp_dir();
+    $this->assertTrue($tmpDir && is_dir($tmpDir), 'Tmp dir must exist: ' . $tmpDir);
+    $path = tempnam(sys_get_temp_dir(), 'Test');
+    file_put_contents($path, $content);
+    return $path;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Gets Api4 up to feature parity with the v3 Attachment API.

Technical Details
----------------------------------------
Now the v4 File API can

- Delete files
- Move files
- Read/write file contents
- Get file info via joins on custom fields