### PR TITLE
[REF] Config - Clarify that directories have trailing slashes

### DIFF
--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -255,7 +255,7 @@ class CRM_Core_BAO_File extends CRM_Core_DAO_File {
         // Delete file only if there are no longer any entities using this file.
         if (!CRM_Core_DAO::getFieldValue('CRM_Core_DAO_EntityFile', $fileID, 'id', 'file_id')) {
           self::deleteRecord(['id' => $fileID]);
-          unlink($config->customFileUploadDir . DIRECTORY_SEPARATOR . $fUri);
+          unlink($config->customFileUploadDir . $fUri);
         }
       }
       $isDeleted = TRUE;
@@ -292,7 +292,7 @@ class CRM_Core_BAO_File extends CRM_Core_DAO_File {
       $result['fileName'] = $dao->uri;
       $result['description'] = $dao->description;
       $result['cleanName'] = CRM_Utils_File::cleanFileName($dao->uri);
-      $result['fullPath'] = $config->customFileUploadDir . DIRECTORY_SEPARATOR . $dao->uri;
+      $result['fullPath'] = $config->customFileUploadDir . $dao->uri;
       $result['url'] = CRM_Utils_System::url('civicrm/file', "reset=1&id={$dao->cfID}&eid={$dao->entity_id}&fcs={$fileHash}");
       $result['href'] = "<a href=\"{$result['url']}\">{$result['cleanName']}</a>";
       $result['tag'] = CRM_Core_BAO_EntityTag::getTag($dao->cfID, 'civicrm_file');

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -48,7 +48,9 @@ require_once 'api/api.php';
  * @property string $defaultContactStateProvince
  * @property string $monetaryDecimalPoint
  * @property string $monetaryThousandSeparator
- * @property array fiscalYearStart
+ * @property array $fiscalYearStart
+ * @property string $customFileUploadDir user file upload directory with trailing slash
+ * @property string $imageUploadDir media upload directory with trailing slash
  */
 class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
 

--- a/CRM/Mailing/MailStore.php
+++ b/CRM/Mailing/MailStore.php
@@ -190,7 +190,7 @@ class CRM_Mailing_MailStore {
    */
   public function maildir($name) {
     $config = CRM_Core_Config::singleton();
-    $dir = $config->customFileUploadDir . DIRECTORY_SEPARATOR . $name;
+    $dir = $config->customFileUploadDir . $name;
     foreach (['cur', 'new', 'tmp'] as $sub) {
       if (!file_exists($dir . DIRECTORY_SEPARATOR . $sub)) {
         if ($this->_debug) {

--- a/Civi/Core/AssetBuilder.php
+++ b/Civi/Core/AssetBuilder.php
@@ -256,7 +256,7 @@ class AssetBuilder extends \Civi\Core\Service\AutoService {
   protected function getCachePath($fileName = NULL) {
     // imageUploadDir has the correct functional properties but a wonky name.
     $suffix = ($fileName === NULL) ? '' : (DIRECTORY_SEPARATOR . $fileName);
-    return \CRM_Utils_File::addTrailingSlash(\CRM_Core_Config::singleton()->imageUploadDir)
+    return \CRM_Core_Config::singleton()->imageUploadDir
       . 'dyn' . $suffix;
   }
 

--- a/api/v3/Attachment.php
+++ b/api/v3/Attachment.php
@@ -139,7 +139,7 @@ function civicrm_api3_attachment_create($params) {
   $entityFileDao->file_id = $fileDao->id;
   $entityFileDao->save();
 
-  $path = $config->customFileUploadDir . DIRECTORY_SEPARATOR . $fileDao->uri;
+  $path = $config->customFileUploadDir . $fileDao->uri;
   if (is_string($content)) {
     file_put_contents($path, $content);
   }
@@ -238,7 +238,7 @@ function civicrm_api3_attachment_delete($params) {
   $filePaths = [];
   $fileIds = [];
   while ($dao->fetch()) {
-    $filePaths[] = $config->customFileUploadDir . DIRECTORY_SEPARATOR . $dao->uri;
+    $filePaths[] = $config->customFileUploadDir . $dao->uri;
     $fileIds[] = $dao->id;
   }
 
@@ -410,7 +410,7 @@ function _civicrm_api3_attachment_parse_params($params) {
  */
 function _civicrm_api3_attachment_format_result($fileDao, $entityFileDao, $returnContent, $isTrusted) {
   $config = CRM_Core_Config::singleton();
-  $path = $config->customFileUploadDir . DIRECTORY_SEPARATOR . $fileDao->uri;
+  $path = $config->customFileUploadDir . $fileDao->uri;
 
   $result = [
     'id' => $fileDao->id,

--- a/schema/Core/File.entityType.php
+++ b/schema/Core/File.entityType.php
@@ -43,7 +43,7 @@ return [
       'title' => ts('Path'),
       'sql_type' => 'varchar(255)',
       'input_type' => 'Text',
-      'description' => ts('uri of the file on disk'),
+      'description' => ts('Location of file on disk relative to $config.customFileUploadDir'),
       'add' => '1.5',
     ],
     'document' => [

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -1716,7 +1716,7 @@ $textValue
 
     $filepath = CRM_Core_Config::singleton()->customFileUploadDir;
     $fileName = 'test_email_create.txt';
-    $fileUri = "{$filepath}/{$fileName}";
+    $fileUri = "{$filepath}{$fileName}";
     // Create a file.
     CRM_Utils_File::createFakeFile($filepath, 'aaaaaa', $fileName);
 
@@ -1781,7 +1781,7 @@ $textValue
 
     $filepath = CRM_Core_Config::singleton()->customFileUploadDir;
     $fileName = 'test_email_create.txt';
-    $fileUri = "{$filepath}/{$fileName}";
+    $fileUri = "{$filepath}{$fileName}";
     // Create a file.
     CRM_Utils_File::createFakeFile($filepath, 'Bananas do not bend themselves without a little help.', $fileName);
 

--- a/tests/phpunit/api/v3/AttachmentTest.php
+++ b/tests/phpunit/api/v3/AttachmentTest.php
@@ -690,11 +690,11 @@ class api_v3_AttachmentTest extends CiviUnitTestCase {
   protected function cleanupFiles(): void {
     $config = CRM_Core_Config::singleton();
     $dirs = [
-      sys_get_temp_dir(),
+      sys_get_temp_dir() . DIRECTORY_SEPARATOR,
       $config->customFileUploadDir,
     ];
     foreach ($dirs as $dir) {
-      $files = (array) glob($dir . '/' . self::getFilePrefix() . '*');
+      $files = (array) glob($dir . self::getFilePrefix() . '*');
       foreach ($files as $file) {
         unlink($file);
       }


### PR DESCRIPTION
Overview
----------------------------------------
Cleans up some directory handling code to be more consistent.

Technical Details
----------------------------------------
Usage was all over the place, but I checked and these settings will always have a trailing slash due to the 'setting-path' property in MagicMerge.