### PR TITLE
MixinTestCase - Run all operations the same way. Fix recent test-failure.

### DIFF
--- a/Civi/Test/MixinTestCase.php
+++ b/Civi/Test/MixinTestCase.php
@@ -18,10 +18,6 @@ abstract class MixinTestCase extends \PHPUnit\Framework\TestCase implements \Civ
 
   abstract protected function getMixinTests(): array;
 
-  public static function setUpBeforeClass(): void {
-    civicrm_api3('Extension', 'refresh', ['local' => TRUE, 'remote' => FALSE]);
-  }
-
   protected function setUp(): void {
     $this->assertNotEquals('UnitTests', getenv('CIVICRM_UF'), 'This is an end-to-end test involving CLI and HTTP. CIVICRM_UF should not be set to UnitTests.');
     parent::setUp();
@@ -39,6 +35,7 @@ abstract class MixinTestCase extends \PHPUnit\Framework\TestCase implements \Civ
     $this->runMethods('testPreConditions', $cv);
 
     // Clear out anything from previous runs.
+    $cv->api3('Extension', 'refresh', ['local' => TRUE, 'remote' => FALSE]);
     $cv->api3('Extension', 'disable', ['key' => 'shimmy']);
     $cv->api3('Extension', 'uninstall', ['key' => 'shimmy']);
 

--- a/Civi/Test/MixinTestCase.php
+++ b/Civi/Test/MixinTestCase.php
@@ -146,9 +146,11 @@ abstract class MixinTestCase extends \PHPUnit\Framework\TestCase implements \Civ
         if (getenv('DEBUG')) {
           fprintf(STDERR, "#$# ");
           if (!empty($pipeData)) {
-            fprintf(STDERR, "echo %s | ", escapeshellarg($pipeData));
+            fprintf(STDERR, "echo %s | (%s)\n", escapeshellarg($pipeData), $cmd);
           }
-          fprintf(STDERR, "%s\n", $cmd);
+          else {
+            fprintf(STDERR, "%s\n", $cmd);
+          }
         }
         $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
         putenv("CV_OUTPUT=$oldOutput");


### PR DESCRIPTION
Overview
----------------------------------------

Fixes an issue where the mixin tests don't run reliably on the current version of `cv`.

Technical Details
----------------------------------------

To reproduce this, I needed to use a `drupal-clean` build. Within that, the *first* mixin test would fail -- but all subsequent ones would work. The shortest dev-loop I found was like this:

```
rm -rf /home/totten/bknix/build/build-0/web/sites/default/files/civicrm/ext/example-mixin/
DEBUG=2 civi-test-run -b build-0 -j /tmp/junit mixin 
```

The underlying problem is that `Extension.refresh` operation doesn't consistently apply to all extension-caches. I doubt this problem is new, and it feels like a bigger thing that should be fixed.

Regardless, the changes here make `MixinTestCase` behave more consistently. (All of its operations are executed in the same way -- rather than a mishmash of ways.)
