### PR TITLE
Event dashboard slow on large site

### DIFF
--- a/CRM/Event/Page/DashBoard.php
+++ b/CRM/Event/Page/DashBoard.php
@@ -60,6 +60,8 @@ class CRM_Event_Page_DashBoard extends CRM_Core_Page {
     $controller->set('limit', 10);
     $controller->set('force', 1);
     $controller->set('context', 'dashboard');
+    // last 7 days including today
+    $_GET['participant_register_date_relative'] = 'ending.week';
     $controller->process();
     $controller->run();
 


### PR DESCRIPTION
Overview
----------------------------------------
On a large site the event dashboard takes ~20s to load.

Before
----------------------------------------
Sloooowww

After
----------------------------------------
20000% faster. I made up that number but it sounds good. From about 20s down to under a second.

Technical Details
----------------------------------------
At the bottom of the event dashboard is an equivalent of the Find Participants search with no parameters, and then it groups and sorts it and then takes the top 10. Since there are no parameters, you not only get the dreaded "using where, using temporary, using filesort", but the result row count is based on CONTACTS, which in this case is around 500000. So it's querying and sorting all of those by registration date and then taking the top 10.

In a normal Find Participants search, there is a hardcoded default of participant.is_test=0. It turns out adding any PARTICIPANT parameter to the query causes it to query participants first, thus basing its starting row count on the number of participants, in this case about 40000.

In theory, this might slow down the query if you had a site with way more participants than contacts. I found one that had more, but where contacts was about 20000 and participants about 30000. It doesn't slow that one down but the numbers and discrepancy might not be big enough. But this would be no different than the performance of a typical Find Participants search on such a site. I don't have enough stats to estimate how common it would be to have a large site with way more participants than contacts.

Comments
----------------------------------------
Using "last 7 days" is a bit arbitrary but matches the section heading "Recent Registrations", and since it's limiting to most recent 10 anyway the 7 days seems about right.
