### PR TITLE
dev/core#5779 - Don't crash when a cg_extends option is disabled, like civigrant

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -2158,13 +2158,15 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
     $ogId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'cg_extend_objects', 'id', 'name');
     $ogValues = CRM_Core_BAO_OptionValue::getOptionValuesArray($ogId);
     foreach ($ogValues as $ogValue) {
-      $options[] = [
-        'id' => $ogValue['value'],
-        'label' => $ogValue['label'],
-        'grouping' => $ogValue['grouping'] ?? NULL,
-        'table_name' => $ogValue['name'],
-        'allow_is_multiple' => !empty($ogValue['filter']),
-      ];
+      if ($ogValue['is_active']) {
+        $options[] = [
+          'id' => $ogValue['value'],
+          'label' => $ogValue['label'],
+          'grouping' => $ogValue['grouping'] ?? NULL,
+          'table_name' => $ogValue['name'],
+          'allow_is_multiple' => !empty($ogValue['filter']),
+        ];
+      }
     }
     foreach ($options as &$option) {
       $option['icon'] ??= CoreUtil::getInfoItem($option['id'], 'icon');


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5779

Before
----------------------------------------
crash for doing some things if you have a cg_extends_objects option value that is disabled, for example if you had civigrant enabled but then disabled it

After
----------------------------------------
Not crash, at least for this reason.

Technical Details
----------------------------------------


Comments
----------------------------------------
