### PR TITLE
Drupal8::isMaintenceMode() - Don't crash on new/clean sites

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -1020,7 +1020,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
    */
   public function isMaintenanceMode(): bool {
     try {
-      return \Drupal::state()->get('system.maintenance_mode');
+      return \Drupal::state()->get('system.maintenance_mode') ?: FALSE;
     }
     catch (\Exception $e) {
       // catch in case Drupal isn't fully booted and can't answer


### PR DESCRIPTION
## Overview

In `E2E\AfformMock\MockPublicFormTest`, it attempts to submit a form as an anonymous user. On a new/clean instance of D9/D10 with php83, the submission fails consistently. This is a new regression in 6.1 (#31893, cc @ufundo).

## Before

The submission is rejected. `MockPublicFormTest` fails. In the Drupal log, we see a corresponding error:

```
TypeError: CRM_Utils_System_Drupal8::isMaintenanceMode(): Return value must be of type bool, null returned in CRM_Utils_System_Drupal8->isMaintenanceMode() (line 1023 of /home/totten/bknix/build/build-0/src/civicrm-core/CRM/Utils/System/Drupal8.php).
```
```
- #0 /home/totten/bknix/build/build-0/src/civicrm-core/CRM/Utils/System.php(1952): CRM_Utils_System_Drupal8->isMaintenanceMode()
- #1 /home/totten/bknix/build/build-0/src/civicrm-core/CRM/Api4/Page/AJAX.php(28): CRM_Utils_System::isMaintenanceMode()
- #2 /home/totten/bknix/build/build-0/src/civicrm-core/CRM/Core/Invoke.php(278): CRM_Api4_Page_AJAX->run(Array, NULL)
- #3 /home/totten/bknix/build/build-0/src/civicrm-core/CRM/Core/Invoke.php(73): CRM_Core_Invoke::runItem(Array)
```

## After

The test passes.

## Technical details

On a new/clean system, the content of `system.maintenance_mode` appears to be `NULL`.

The bug is likely hard to see in manual testing because:

1. A lot of manual testing is done as admin user (who can bypass maintenance-mode checks).
2. After you've toggled maintenance-mode for the first time, the value becomes `0` or `1`.

It's a bit confusing because these tests are *generally* flaky (e.g. on D7/SA/WP, you see them fail randomly). However, in this context, the failure is real.