### PR TITLE
SearchKit - Save to file rather than browser download.

### DIFF
--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -852,6 +852,7 @@ HEREDOC;
       'civicrm_activity' => ts('Activity'),
       'civicrm_case' => ts('Case'),
       'civicrm_note' => ts('Note'),
+      'civicrm_saved_search' => ts('Saved Search'),
     ];
   }
 

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
@@ -2,10 +2,6 @@
 
 namespace Civi\Api4\Action\SearchDisplay;
 
-use League\Csv\Writer;
-use PhpOffice\PhpSpreadsheet\IOFactory;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
-
 /**
  * Download the results of a SearchDisplay as a spreadsheet.
  *
@@ -17,33 +13,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
  * @package Civi\Api4\Action\SearchDisplay
  */
 class Download extends AbstractRunAction {
-
-  /**
-   * Requested file format.
-   *
-   * 'array' will return a normal api result, with table headers as the first row.
-   * 'csv', etc. will directly output a file to the browser.
-   *
-   * @var string
-   * @required
-   * @options array,csv,xlsx,ods,pdf
-   */
-  protected $format = 'array';
-
-  private $formats = [
-    'xlsx' => [
-      'writer' => 'Xlsx',
-      'mime' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    ],
-    'ods' => [
-      'writer' => 'Ods',
-      'mime' => 'application/vnd.oasis.opendocument.spreadsheet',
-    ],
-    'pdf' => [
-      'writer' => 'Dompdf',
-      'mime' => 'application/pdf',
-    ],
-  ];
+  use ResultDataTrait;
 
   /**
    * @param \Civi\Api4\Result\SearchDisplayRunResult $result
@@ -53,6 +23,7 @@ class Download extends AbstractRunAction {
     $entityName = $this->savedSearch['api_entity'];
     $apiParams =& $this->_apiParams;
     $settings =& $this->display['settings'];
+    $fileName = '';
 
     // Checking permissions for menu, link or button columns is costly, so remove them early
     foreach ($settings['columns'] as $index => $col) {
@@ -86,40 +57,17 @@ class Download extends AbstractRunAction {
 
     $rows = $this->formatResult($apiResult);
 
-    $columns = [];
-    foreach ($this->display['settings']['columns'] as $index => $col) {
-      $col += ['type' => NULL, 'label' => '', 'rewrite' => FALSE];
-      $columns[$index] = $col;
-      // Convert html to plain text
-      if ($col['type'] === 'html') {
-        foreach ($rows as $i => $row) {
-          $row['columns'][$index]['val'] = htmlspecialchars_decode(strip_tags($row['columns'][$index]['val']));
-          $rows[$i] = $row;
-        }
-      }
+    if ('array' === $this->format) {
+      $result->exchangeArray($this->processData($this->display['label'], $this->display['settings']['columns'], $rows, $fileName));
+      return;
     }
-
-    // Unicode-safe filename for download
-    $fileName = \CRM_Utils_File::makeFilenameWithUnicode($this->display['label']) . '.' . $this->format;
-
-    switch ($this->format) {
-      case 'array':
-        $result[] = array_column($columns, 'label');
-        foreach ($rows as $data) {
-          $row = array_column(array_intersect_key($data['columns'], $columns), 'val');
-          $result[] = $row;
-        }
-        return;
-
-      case 'csv':
-        $this->outputCSV($rows, $columns, $fileName);
-        break;
-
-      default:
-        $this->sendHeaders($fileName);
-        $this->outputSpreadsheet($rows, $columns);
+    else {
+      $this->processData($this->display['label'], $this->display['settings']['columns'], $rows, $fileName);
     }
-
+    $bypass_headers = ['array', 'csv'];
+    if (!in_array($this->format, $bypass_headers)) {
+      $this->sendHeaders($fileName);
+    }
     \CRM_Utils_System::civiExit();
   }
 
@@ -138,73 +86,6 @@ class Download extends AbstractRunAction {
     else {
       return parent::formatViewValue($key, $rawValue, $data, $dataType, $format);
     }
-  }
-
-  /**
-   * Outputs headers and CSV directly to browser for download
-   * @param array $rows
-   * @param array $columns
-   * @param string $fileName
-   */
-  private function outputCSV(array $rows, array $columns, string $fileName) {
-    $csv = Writer::createFromFileObject(new \SplTempFileObject());
-    $csv->setOutputBOM(Writer::BOM_UTF8);
-
-    // Header row
-    $csv->insertOne(array_column($columns, 'label'));
-
-    foreach ($rows as $data) {
-      $row = array_column(array_intersect_key($data['columns'], $columns), 'val');
-      foreach ($row as &$val) {
-        if (is_array($val)) {
-          $val = implode(', ', $val);
-        }
-      }
-      $csv->insertOne($row);
-    }
-    // Echo headers and content directly to browser
-    $csv->output($fileName);
-  }
-
-  /**
-   * Create PhpSpreadsheet document and output directly to browser for download
-   * @param array $rows
-   * @param array $columns
-   */
-  private function outputSpreadsheet(array $rows, array $columns) {
-    $document = new Spreadsheet();
-    $document->getProperties()
-      ->setTitle($this->display['label']);
-    $sheet = $document->getActiveSheet();
-
-    // Header row
-    foreach (array_values($columns) as $index => $col) {
-      $sheet->setCellValue([$index + 1, 1], $col['label']);
-      $sheet->getColumnDimensionByColumn($index)->setAutoSize(TRUE);
-    }
-
-    foreach ($rows as $rowNum => $data) {
-      $colNum = 1;
-      foreach ($columns as $index => $col) {
-        $sheet->setCellValue([$colNum++, $rowNum + 2], $this->formatColumnValue($col, $data['columns'][$index]));
-      }
-    }
-
-    $writer = IOFactory::createWriter($document, $this->formats[$this->format]['writer']);
-
-    $writer->save('php://output');
-  }
-
-  /**
-   * Returns final formatted column value
-   *
-   * @param array $col
-   * @param array $value
-   * @return string
-   */
-  protected function formatColumnValue(array $col, array $value) {
-    $val = $value['val'] ?? '';
-    return is_array($val) ? implode(', ', $val) : $val;
   }
 
   /**

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/ResultDataTrait.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/ResultDataTrait.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Civi\Api4\Action\SearchDisplay;
+
+use League\Csv\Writer;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+
+trait ResultDataTrait {
+
+  /**
+   * Requested file format.
+   *
+   * 'array' will return a normal api result, with table headers as the first row.
+   * 'csv', etc. will directly output a file to the browser.
+   *
+   * @var string
+   * @required
+   * @options array,csv,xlsx,ods,pdf
+   */
+  protected $format = 'array';
+  private $formats = [
+    'array' => [
+      'writer' => 'JSON',
+      'mime' => 'application/json',
+    ],
+    'csv' => [
+      'writer' => 'CSV',
+      'mime' => 'text/csv',
+    ],
+    'xlsx' => [
+      'writer' => 'Xlsx',
+      'mime' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    ],
+    'ods' => [
+      'writer' => 'Ods',
+      'mime' => 'application/vnd.oasis.opendocument.spreadsheet',
+    ],
+    'pdf' => [
+      'writer' => 'Dompdf',
+      'mime' => 'application/pdf',
+    ],
+  ];
+
+  private function processData($label, $columns, $rows, &$fileName) {
+    $data_columns = [];
+    $result = [];
+    foreach ($columns as $index => $col) {
+      $col += ['type' => NULL, 'label' => '', 'rewrite' => FALSE];
+      $data_columns[$index] = $col;
+      // Convert html to plain text
+      if ($col['type'] === 'html') {
+        foreach ($rows as $i => $row) {
+          $row['columns'][$index]['val'] = htmlspecialchars_decode(strip_tags($row['columns'][$index]['val']));
+          $rows[$i] = $row;
+        }
+      }
+    }
+
+    if (empty($fileName)) {
+      // Unicode-safe filename for download
+      $fileName = \CRM_Utils_File::makeFilenameWithUnicode($label) . '.' . $this->format;
+    }
+
+    switch ($this->format) {
+      case 'array':
+        $result[] = array_column($data_columns, 'label');
+        foreach ($rows as $data) {
+          $row = array_column(array_intersect_key($data['columns'], $data_columns), 'val');
+          $result[] = $row;
+        }
+        return $result;
+
+      case 'csv':
+        $this->outputCSV($rows, $data_columns, $fileName);
+        break;
+
+      default:
+        $this->outputSpreadsheet($rows, $data_columns);
+    }
+  }
+
+  /**
+   * Outputs headers and CSV directly to browser for download
+   * @param array $rows
+   * @param array $columns
+   * @param string $fileName
+   */
+  private function outputCSV(array $rows, array $columns, string $fileName) {
+    $csv = Writer::createFromFileObject(new \SplTempFileObject());
+    $csv->setOutputBOM(Writer::BOM_UTF8);
+
+    // Header row
+    $csv->insertOne(array_column($columns, 'label'));
+
+    foreach ($rows as $data) {
+      $row = array_column(array_intersect_key($data['columns'], $columns), 'val');
+      foreach ($row as &$val) {
+        if (is_array($val)) {
+          $val = implode(', ', $val);
+        }
+      }
+      $csv->insertOne($row);
+    }
+    // Echo headers and content directly to browser
+    $csv->output($fileName);
+  }
+
+  /**
+   * Create PhpSpreadsheet document and output directly to browser for download
+   * @param array $rows
+   * @param array $columns
+   */
+  private function outputSpreadsheet(array $rows, array $columns) {
+    $document = new Spreadsheet();
+    $document->getProperties()
+      ->setTitle($this->display['label']);
+    $sheet = $document->getActiveSheet();
+
+    // Header row
+    foreach (array_values($columns) as $index => $col) {
+      $sheet->setCellValue([$index + 1, 1], $col['label']);
+      $sheet->getColumnDimensionByColumn($index)->setAutoSize(TRUE);
+    }
+
+    foreach ($rows as $rowNum => $data) {
+      $colNum = 1;
+      foreach ($columns as $index => $col) {
+        $sheet->setCellValue([$colNum++, $rowNum + 2], $this->formatColumnValue($col, $data['columns'][$index]));
+      }
+    }
+
+    $writer = IOFactory::createWriter($document, $this->formats[$this->format]['writer']);
+
+    $writer->save('php://output');
+  }
+
+  /**
+   * Returns final formatted column value
+   *
+   * @param array $col
+   * @param array $value
+   * @return string
+   */
+  protected function formatColumnValue(array $col, array $value) {
+    $val = $value['val'] ?? '';
+    return is_array($val) ? implode(', ', $val) : $val;
+  }
+
+}

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/SaveFile.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/SaveFile.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\SearchDisplay;
+
+/**
+ * Runs the SearchDisplay and saves the output to a file and adds to the Document entity.
+ *
+ */
+class SaveFile extends AbstractRunAction {
+  use ResultDataTrait;
+  /**
+   * The name of the file for the report output that is saved to the file system.
+   *
+   * @var string
+   * @required
+   */
+  protected $fileName;
+
+  /**
+   * The name of the report for the document being created.
+   *
+   * @var string
+   * @required
+   */
+  protected $reportName;
+
+  /**
+   * If provided, the folder name will be used when saving the file.
+   *
+   * @var string
+   */
+  protected $folderName;
+
+  /**
+   * Whether to append the date to the file name.
+   *
+   * @var bool
+   */
+  protected $appendDate = FALSE;
+
+  /**
+   * @param \Civi\Api4\Result\SearchDisplayRunResult $result
+   * @throws \CRM_Core_Exception
+   */
+  protected function processResult(\Civi\Api4\Result\SearchDisplayRunResult $result) {
+    $entityName = $this->savedSearch['api_entity'];
+    $apiParams =& $this->_apiParams;
+    $settings =& $this->display['settings'];
+    $fileName = '';
+
+    // Checking permissions for menu, link or button columns is costly, so remove them early
+    foreach ($settings['columns'] as $index => $col) {
+      // Remove buttons/menus and other column types that cannot be rendered in a spreadsheet
+      if (empty($col['key'])) {
+        unset($settings['columns'][$index]);
+      }
+      // Avoid wasting time processing links, editable and other non-printable items from spreadsheet
+      else {
+        \CRM_Utils_Array::remove($settings['columns'][$index], 'link', 'editable', 'icons', 'cssClass');
+      }
+    }
+    // Reset indexes as some items may have been removed
+    $settings['columns'] = array_values($settings['columns']);
+
+    // Displays are only exportable if they have actions enabled
+    if (empty($settings['actions'])) {
+      \CRM_Utils_System::permissionDenied();
+    }
+
+    // Force limit if the display has no pager
+    if (!isset($settings['pager']) && !empty($settings['limit'])) {
+      $apiParams['limit'] = $settings['limit'];
+    }
+    $apiParams['orderBy'] = $this->getOrderByFromSort();
+    $this->augmentSelectClause($apiParams, $settings);
+
+    $this->applyFilters();
+
+    $apiResult = civicrm_api4($entityName, 'get', $apiParams);
+
+    $rows = $this->formatResult($apiResult);
+
+    if ($this->appendDate) {
+      $this->fileName .= date("_Ymd", time());
+    }
+    $this->fileName .= '.' . ('array' === $this->format ? 'json' : $this->format);
+
+    // Download file contents.
+    if ('array' === $this->format) {
+      $content = $this->processData($this->display['label'], $this->display['settings']['columns'], $rows, $fileName);
+      $searchDisplayContent = json_encode($content);
+    }
+    else {
+      ob_start();
+      $this->processData($this->display['label'], $this->display['settings']['columns'], $rows, $fileName);
+      $searchDisplayContent = ob_get_contents();
+      ob_end_clean();
+    }
+
+    if (!empty($searchDisplayContent)) {
+      $config = \CRM_Core_Config::singleton();
+      $directoryName = $config->customFileUploadDir;
+      $fileName = \CRM_Utils_File::makeFileName($this->fileName);
+      $info = pathinfo($fileName);
+      // Regex in makeFileName blocks json due to check for js file names. Need to fix for saving as json.
+      if ('unknown' === $info['extension'] && 'array' === $this->format) {
+        $fileName = str_replace('unknown', 'json', $fileName);
+        $fileName = str_replace('_json', '', $fileName);
+      }
+
+      // Append folder name if provided.
+      if (!empty($this->folderName)) {
+        $folderName = preg_replace('/[-\s]/', '_', preg_replace('/[^\w\s_]/', '', $this->folderName));
+        // After replacement make sure we still have something for the folder name.
+        if (!empty($folderName)) {
+          $directoryName .= $folderName . '/';
+        }
+      }
+      \CRM_Utils_File::createDir($directoryName);
+      $fileParams = [
+        'name' => $this->fileName,
+        'mime_type' => $this->formats[$this->format]['mime'],
+        'uri' => $directoryName . $fileName,
+        'description' => $this->reportName,
+        'upload_date' => date('Y-m-d H:i:s', time()),
+      ];
+
+      $fileDao = \CRM_Core_BAO_File::writeRecord($fileParams);
+      $fileDao->find(TRUE);
+
+      $entityFileDao = new \CRM_Core_DAO_EntityFile();
+      $entityFile['entity_table'] = 'civicrm_saved_search';
+      $entityFile['entity_id'] = $this->savedSearch['id'];
+      $entityFileDao->copyValues($entityFile);
+      $entityFileDao->file_id = $fileDao->id;
+      $entityFileDao->save();
+
+      $path = $directoryName . $fileName;
+      file_put_contents($path, $searchDisplayContent);
+
+      $result['file'] = $fileDao;
+    }
+  }
+
+}

--- a/ext/search_kit/Civi/Api4/SearchDisplay.php
+++ b/ext/search_kit/Civi/Api4/SearchDisplay.php
@@ -46,6 +46,15 @@ class SearchDisplay extends Generic\DAOEntity {
 
   /**
    * @param bool $checkPermissions
+   * @return Action\SearchDisplay\SaveFile
+   */
+  public static function saveFile($checkPermissions = TRUE) {
+    return (new Action\SearchDisplay\SaveFile(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
    * @return Action\SearchDisplay\InlineEdit
    */
   public static function inlineEdit($checkPermissions = TRUE) {

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchSaveFileTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchSaveFileTest.php
@@ -1,0 +1,109 @@
+<?php
+namespace api\v4\SearchDisplay;
+
+use Civi\Api4\Activity;
+use Civi\Api4\Contact;
+use Civi\Api4\SavedSearch;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class SearchSaveFileTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  /**
+   * Test saving an array formatted SavedSearch.
+   */
+  public function testSaveArrayFile() {
+    $cid = Contact::create(FALSE)->execute()->single()['id'];
+    $subject = uniqid(__FUNCTION__);
+    $sampleData = [
+      ['duration' => 1, 'subject' => $subject, 'details' => '<p>Markup</p>'],
+      ['duration' => 3, 'subject' => $subject, 'details' => 'Plain &amp; simple'],
+      ['duration' => 3, 'subject' => $subject],
+      ['duration' => 4, 'subject' => $subject],
+    ];
+    Activity::save(FALSE)
+      ->setRecords($sampleData)
+      ->setDefaults(['activity_type_id:name' => 'Meeting', 'source_contact_id' => $cid])
+      ->execute();
+
+    SavedSearch::create(FALSE)
+      ->setValues([
+        'name' => 'TestContactActivity',
+        'label' => 'TestContactActivity',
+        'api_entity' => 'Activity',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['subject', 'details'],
+          'where' => [],
+        ],
+      ])
+      ->execute();
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'format' => 'array',
+      'savedSearch' => 'TestContactActivity',
+      'filters' => ['subject' => $subject],
+      'afform' => NULL,
+      'appendDate' => TRUE,
+      'reportName' => 'Save File Test',
+      'fileName' => 'Test_File',
+      'folderName' => 'TestDirectory',
+    ];
+
+    $data = civicrm_api4('SearchDisplay', 'saveFile', $params);
+    $file = $data['file'];
+    $config = \CRM_Core_Config::singleton();
+    $directoryName = $config->customFileUploadDir;
+
+    // Assert file creation.
+    // ---------------------------------
+    // Make sure report name is correct.
+    $this->assertEquals('Save File Test', $file->description);
+    $this->assertEquals('application/json', $file->mime_type);
+
+    // The following directory and name checks may not be needed if the
+    // overall file exists check passes, it would mean these aren't needed.
+    // --------------------
+    // Make sure we have base CiviCRM Upload Directory.
+    $this->assertDirectoryExists($directoryName);
+    // Make sure our custom directory from the API call is created.
+    $this->assertDirectoryExists($directoryName . 'TestDirectory/');
+    // Check to see if our test file name is found in the returned URL.
+    $this->assertStringStartsWith($directoryName . 'TestDirectory/Test_File', $file->uri);
+    // Check to see if our test file name, with current date,
+    // is found in the returned URL.
+    $this->assertStringStartsWith($directoryName . 'TestDirectory/Test_File' . date("_Ymd", time()), $file->uri);
+
+    // --------------------
+    // Make sure our saved file exists in the file system.
+    $this->assertFileExists($file->uri);
+
+    // Assert entity file creation.
+    $entityFiles = civicrm_api4('EntityFile', 'get', [
+      'where' => [
+        ['entity_table', '=', 'civicrm_saved_search'],
+        ['file_id', '=', $file->id],
+      ],
+    ]);
+
+    // Make sure we have a result record.
+    $this->assertCount(1, $entityFiles);
+
+    // Make sure we are getting back the correct entity_table.
+    $this->assertEquals('civicrm_saved_search', $entityFiles->first()['entity_table']);
+
+    // Make sure the file_id matches.
+    $this->assertEquals($file->id, $entityFiles->first()['file_id']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
There isn't a way to save SK reports to the file system for historical/snapshot recording. This will allow for saving files to the system and you can also schedule jobs with the new action to have your reports saved automatically. A CiviRule could likely send an email out when the file is created, but that is not for this PR.

Before
----------------------------------------
Currently the only option is to download the report from the browser. We have a need to be able to keep historical/snapshot reports but there isn't a way unless you manually download and save yourself.

After
----------------------------------------
With a new `saveFile` API4 action, this allows you to save a report output to the file system.

Technical Details
----------------------------------------
This adds a new bool to the Download action which prevents the headers from being written when not array format and also prevents the exit once the file contents are available. Secondly, this adds a new action, `saveFile`, for `SearchDisplay` which then leverages the new bool property of the Download to capture the file data and it then saves it to the file system. It is also recording the file to the `File` and `EntityFile` entities so that you can pull reports back out. This doesn't include any reports, just the ability to save the report to a file on the system and log it in the File entities.

In the new action, you can specify a file name and also a new folder that the file can be saved to. It is using the `AbstractRunAction` in order to capture the additional run fields that are just passed on to the `Download` action. With the bool, we can then capture the results of the download and save to a file.