### PR TITLE
File - deprecate 'document' field from File entity.

### DIFF
--- a/schema/Core/File.entityType.php
+++ b/schema/Core/File.entityType.php
@@ -50,8 +50,9 @@ return [
       'title' => ts('File Contents'),
       'sql_type' => 'mediumblob',
       'input_type' => NULL,
-      'description' => ts('contents of the document'),
+      'description' => ts('Unused deprecated column.'),
       'add' => '1.5',
+      'deprecated' => TRUE,
     ],
     'description' => [
       'title' => ts('File Description'),

--- a/tests/phpunit/CRM/Core/BAO/FileTest.php
+++ b/tests/phpunit/CRM/Core/BAO/FileTest.php
@@ -122,7 +122,6 @@ class CRM_Core_BAO_FileTest extends CiviUnitTestCase {
       'file_type_id' => NULL,
       'mime_type' => 'image/png',
       'uri' => 'fake_file.png',
-      'document' => NULL,
       'description' => 'Fake file',
       'upload_date' => '2023-05-10 15:00:00',
       'created_id' => $contactId,


### PR DESCRIPTION

Overview
----------------------------------------
The 'document' field is kind of antithetical to the File table's purpose, and I can't find any core uses so marking deprecated.
