### PR TITLE
core-5773 Prevent survey from wrongly setting checkboxes

### DIFF
--- a/templates/CRM/Campaign/Form/Task/Interview.tpl
+++ b/templates/CRM/Campaign/Form/Task/Interview.tpl
@@ -278,7 +278,9 @@ function registerInterview( voterId ) {
     if (fldId.indexOf('_custom_') == -1 &&
       fldId.indexOf('_result') == -1  &&
       fldId.indexOf('_note') == -1 ) {
-      data[fldId] = CRM.$(this).val( );
+      data[fldId] = CRM.$(this).prop('type') == 'checkbox' ?
+        (CRM.$(this).is(':checked') ? '1' : '0') :
+        CRM.$(this).val();
     }
   });
 


### PR DESCRIPTION
Overview
----------------------------------------
Corrects [#5773](https://lab.civicrm.org/dev/core/-/issues/5773).

Before
----------------------------------------
Upon recording the response in a survey containing non-custom checkboxes, e.g. `Do Not Phone`, the checkbox value was evaluated with `CRM.$(this).val()`. This returns the value of the `value` attribute (always set to 1 in the HTML), rather than the `checked` property (the state of the checkbox). For input types other than checkboxes, the `value` attribute is returned as it was before this change.

After
----------------------------------------
The `checked` property is returned.