### PR TITLE
(dev/core#5787) ClassScanner - Ignore stale files during Joomla upgrade

### DIFF
--- a/Civi/Core/ClassScanner.php
+++ b/Civi/Core/ClassScanner.php
@@ -141,7 +141,10 @@ class ClassScanner {
     // Excludes internal and legacy classes, upgraders, pages & other classes that don't need to be scanned.
     $classes = [];
     static::scanFolders($classes, $civicrmRoot, 'Civi/Test/ExampleData', '\\');
-    // Most older CRM_ stuff doesn't implement event listeners & services so can be skipped.
+
+    // We skip scanning for some files+folders from core, for a few reasons:
+    // (1) Save time. Many older classes in `CRM_*` (esp `Page`, `Controller`, `DAO`) have lifecycles which don't need scanning.
+    // (2) Avoid dead classes. In a couple cases (`Cxn`, `Dedupe_BAO`), it mitigates Joomla upgrade issue dev/core#5787.
     static::scanFolders($classes, $civicrmRoot, 'CRM', '_', ';(Upgrade|Utils|Exception|_DAO|_Page|_Form|_Controller|_StateMachine|_Selector|_CodeGen|_Cxn|_QuickForm|CRM_Dedupe_BAO_QueryBuilder);');
     static::scanFolders($classes, $civicrmRoot, 'Civi', '\\', ';\\\(Security|Test)\\\;');
 

--- a/Civi/Core/ClassScanner.php
+++ b/Civi/Core/ClassScanner.php
@@ -142,7 +142,7 @@ class ClassScanner {
     $classes = [];
     static::scanFolders($classes, $civicrmRoot, 'Civi/Test/ExampleData', '\\');
     // Most older CRM_ stuff doesn't implement event listeners & services so can be skipped.
-    static::scanFolders($classes, $civicrmRoot, 'CRM', '_', ';(Upgrade|Utils|Exception|_DAO|_Page|_Form|_Controller|_StateMachine|_Selector|_CodeGen|_Cxn|_QuickForm);');
+    static::scanFolders($classes, $civicrmRoot, 'CRM', '_', ';(Upgrade|Utils|Exception|_DAO|_Page|_Form|_Controller|_StateMachine|_Selector|_CodeGen|_Cxn|_QuickForm|CRM_Dedupe_BAO_QueryBuilder);');
     static::scanFolders($classes, $civicrmRoot, 'Civi', '\\', ';\\\(Security|Test)\\\;');
 
     if (CIVICRM_UF === 'UnitTests') {

--- a/Civi/Core/ClassScanner.php
+++ b/Civi/Core/ClassScanner.php
@@ -142,7 +142,7 @@ class ClassScanner {
     $classes = [];
     static::scanFolders($classes, $civicrmRoot, 'Civi/Test/ExampleData', '\\');
     // Most older CRM_ stuff doesn't implement event listeners & services so can be skipped.
-    static::scanFolders($classes, $civicrmRoot, 'CRM', '_', ';(Upgrade|Utils|Exception|_DAO|_Page|_Form|_Controller|_StateMachine|_Selector|_CodeGen|_QuickForm);');
+    static::scanFolders($classes, $civicrmRoot, 'CRM', '_', ';(Upgrade|Utils|Exception|_DAO|_Page|_Form|_Controller|_StateMachine|_Selector|_CodeGen|_Cxn|_QuickForm);');
     static::scanFolders($classes, $civicrmRoot, 'Civi', '\\', ';\\\(Security|Test)\\\;');
 
     if (CIVICRM_UF === 'UnitTests') {


### PR DESCRIPTION
Overview
----------------------------------------

When upgrading CiviCRM-Joomla from 5.x to 6.0.0, some old files are retained 

Before
----------------------------------------

After upgrading to 6.0.0, all pages fail with `Class "Civi\Cxn\Rpc\Http\PhpHttp" not found`. They will continue failing until the administrator deletes some old files.

However, there is no way for the admin to see that old files need to be deleted... because the "System Status" throws the fatal!

After
----------------------------------------

The old files do not provoke fatal errors.

The admin can browse the UI well enough to see the "System Status" and learn about the pending deletions.
