### PR TITLE
Catch Exceptions caused by CRM_Utils_Array::single()

### DIFF
--- a/CRM/Custom/Page/CustomDataTrait.php
+++ b/CRM/Custom/Page/CustomDataTrait.php
@@ -35,15 +35,21 @@ trait CRM_Custom_Page_CustomDataTrait {
    *
    */
   protected function getCustomDataFieldsForEntityDisplay(string $entity, int $id): array {
-    $values = civicrm_api4($entity, 'get', [
-      'select' => [
-        'custom.*',
-      ],
-      'where' => [
-        ['id', '=', $id],
-      ],
-      'checkPermissions' => TRUE,
-    ])->single();
+    try {
+      $values = civicrm_api4($entity, 'get', [
+        'select' => [
+          'custom.*',
+        ],
+        'where' => [
+          ['id', '=', $id],
+        ],
+        'checkPermissions' => TRUE,
+      ])->single();
+    }
+    catch (CRM_Core_Exception $e) {
+      Civi::log()->warning('Tried loading Custom field data for Entity ' . $entity . ' id: ' . $id . ' and got the following message ' . $e->getMessage());
+      return [];
+    }
     $formValues = [];
     // We have api style field names not IDs so can't use the BAO function AFAIK.
     $fields = civicrm_api4($entity, 'getfields', [


### PR DESCRIPTION
…s either no record found for potential permission reasons

Overview
----------------------------------------
It is possible that 0 records might be returned if permissions don't get checked or the cache is stale for some reason. I figure catching the exceptions thrown here https://github.com/civicrm/civicrm-core/blob/master/CRM/Utils/Array.php#L1218 is probably useful and logging them

Before
----------------------------------------
Potential for Expected to find one record but found nothing errors

After
----------------------------------------
Contact pages load

ping @eileenmcnaughton @andrew-cormick-dockery @johntwyman 