### PR TITLE
issue#232 : Selecting price option(s) switches payment method from pay-later and doesn't load billing block on event registration form

### DIFF
--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -41,7 +41,7 @@
       billing_block.show();
       cj('#billing-payment-block select.crm-select2').removeClass('crm-no-validate');
       // also set selected payment methods
-      cj('input[name="payment_processor_id"][checked=checked]').prop('checked', true);
+      cj('input[name="payment_processor_id"]:checked').prop('checked', true);
     }
   }
 


### PR DESCRIPTION

Overview
----------------------------------------

### Steps to replicate: 
1. Create a paid online event registration with price set of radio and checkbox price fields
2. Add pay later and one or more CC payment processor(s)
3. Go to event registration form live or on test mode. 
4. Select a radio option and choose pay-later
5. Select any checkbox price option or change radio price option

Before
----------------------------------------

The payment processor selection switches to CC from pay-later and billing section is not exposed. I can replicate this issue in dmaster: 
![event2](https://github.com/user-attachments/assets/7f007dd1-0c80-4133-8c7e-1d5f6c033d1f)


After
----------------------------------------
Fixed


Comments
----------------------------------------
ping @eileenmcnaughton @mattwire @colemanw 