### PR TITLE
Fix Financial Type wrench on select

### DIFF
--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -320,13 +320,22 @@ class CRM_Core_PseudoConstant {
       if (!$daoName) {
         return NULL;
       }
-      // We don't have good mapping so have to do a bit of guesswork from the menu
-      [, $parent, , $child] = explode('_', $daoName);
-      $sql = "SELECT path FROM civicrm_menu
+
+      $dao = new $daoName();
+      $path = $dao::getEntityPaths()['browse'] ?? NULL;
+
+      if (!$path) {
+        // We don't have good mapping so have to do a bit of guesswork from the menu
+        // @todo Get rid of this! It's unreliable and doesn't work if the path is replaced by
+        // an afform one because the callback changes to CRM_Afform_Page_AfformBase
+        [, $parent, , $child] = explode('_', $daoName);
+        $sql = "SELECT path FROM civicrm_menu
         WHERE page_callback LIKE '%CRM_Admin_Page_$child%' OR page_callback LIKE '%CRM_{$parent}_Page_$child%'
         ORDER BY page_callback
         LIMIT 1";
-      return CRM_Core_DAO::singleValueQuery($sql);
+        $path = CRM_Core_DAO::singleValueQuery($sql);
+      }
+      return $path;
     }
     return NULL;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Eg. on Manage Event Fees:
![image](https://github.com/user-attachments/assets/ee0bf785-19d3-4e10-aa39-8a97112f4a1c)


Before
----------------------------------------
Click the link - get the error "No Financial Accounts found for the Financial Type"

After
----------------------------------------
Click the link - get the financial types popup

Technical Details
----------------------------------------
If you have adminui enabled the page_callback in `civicrm_menu` changes to `CRM_Afform_Page_AfformBase`. We really should be using our nice modern getPaths() function anyway instead of pattern matching on menu items. But probably not all entities have paths defined.

Comments
----------------------------------------
This is a regression but probably not very recent