### PR TITLE
(Performance) ManagedEntities - Only update an entity if its declaration has changed

### DIFF
--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -67,6 +67,10 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Core\
 
     $caseTypeDAO->copyValues($params);
     $result = $caseTypeDAO->save();
+
+    // Reset CRM_Case_PseudoConstant::caseType() to ensure that we can generate any new managed activity-types.
+    CRM_Core_PseudoConstant::flush();
+
     return $result;
   }
 

--- a/CRM/Core/DAO/Managed.php
+++ b/CRM/Core/DAO/Managed.php
@@ -14,6 +14,7 @@
  * @property string $entity_type
  * @property int|string|null $entity_id
  * @property string $cleanup
+ * @property string $checksum
  * @property string $entity_modified_date
  */
 class CRM_Core_DAO_Managed extends CRM_Core_DAO_Base {

--- a/CRM/Upgrade/Incremental/php/SixTwo.php
+++ b/CRM/Upgrade/Incremental/php/SixTwo.php
@@ -29,6 +29,13 @@ class CRM_Upgrade_Incremental_php_SixTwo extends CRM_Upgrade_Incremental_Base {
    */
   public function upgrade_6_2_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask('Add column "civicrm_managed.checksum"', 'alterSchemaField', 'Managed', 'checksum', [
+      'title' => ts('Checksum'),
+      'sql_type' => 'varchar(45)',
+      'input_type' => 'Text',
+      'required' => FALSE,
+      'description' => ts('Configuration of the managed-entity when last stored'),
+    ]);
     $this->addTask('Set upload_date in file table', 'setFileUploadDate');
     $this->addTask('Set default for upload_date in file table', 'alterSchemaField', 'File', 'upload_date', [
       'title' => ts('File Upload Date'),

--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -582,6 +582,25 @@ class CRM_Utils_Array {
   }
 
   /**
+   * Example:
+   *   $data = deepSort($data, fn(array &$a) => sort($a)))
+   *   $data = deepSort($data, fn(array &$a) => uksort($a, 'strnatcmp'))
+   *
+   * @param array $array
+   *   The array that should be sorted.
+   * @param callable $sort
+   *   A function which sorts an array.
+   */
+  public static function deepSort(array &$array, callable $sort): void {
+    $sort($array);
+    foreach ($array as &$value) {
+      if (is_array($value)) {
+        self::deepSort($value, $sort);
+      }
+    }
+  }
+
+  /**
    * Unsets an arbitrary list of array elements from an associative array.
    *
    * @param array $items

--- a/schema/Core/Managed.entityType.php
+++ b/schema/Core/Managed.entityType.php
@@ -72,6 +72,14 @@ return [
       'description' => ts('Soft foreign key to the referenced item.'),
       'add' => '4.2',
     ],
+    'checksum' => [
+      'title' => ts('Checksum'),
+      'sql_type' => 'varchar(45)',
+      'input_type' => 'Text',
+      'required' => FALSE,
+      'description' => ts('Configuration of the managed-entity when last stored'),
+      'add' => '6.2',
+    ],
     'cleanup' => [
       'title' => ts('Cleanup Setting'),
       'sql_type' => 'varchar(16)',

--- a/tests/phpunit/CRM/Utils/ArrayTest.php
+++ b/tests/phpunit/CRM/Utils/ArrayTest.php
@@ -528,4 +528,30 @@ class CRM_Utils_ArrayTest extends CiviUnitTestCase {
     $this->assertEquals(NULL, CRM_Utils_Array::value('c', $list, 'fruit'));
   }
 
+  public function testDeepSort() {
+    $unsorted = [
+      '1-bbb' => '1-BBB',
+      '1-aaa' => '1-AAA',
+      '1-ddd' => [
+        '2-bbb' => '2-BBB',
+        '2-ccc' => '2-ccc',
+        '2-aaa' => '2-AAA',
+      ],
+      '1-ccc' => '1-CCC',
+    ];
+    $expected = [
+      '1-aaa' => '1-AAA',
+      '1-bbb' => '1-BBB',
+      '1-ccc' => '1-CCC',
+      '1-ddd' => [
+        '2-aaa' => '2-AAA',
+        '2-bbb' => '2-BBB',
+        '2-ccc' => '2-ccc',
+      ],
+    ];
+    $sorted = $unsorted;
+    CRM_Utils_Array::deepSort($sorted, fn(array &$a) => ksort($a));
+    $this->assertEquals($expected, $sorted);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

Generally, the purpose of `ManagedEntities` is to keep a database-record up-to-date with the description in code.

This optimization should improve the performance of a typical system-flush/cache-clear. For example, on my local `drupal-clean` build (*with ~65 managed entities*), the typical runtime of `cv flush` drops from 5.1s to 1.6s. 

The benefits should be more significant for systems with more managed-entities.

Before
----------------------------------------

To reconcile, we walk through _all the entities_ and issue API calls (`create`, `update`, `delete`) to ensure that the database is up-to-date with the declaration.

However, during most flushes, there has been no real change in either the entity-declaration or the live-entity. Consequently, the `update` (usually) isn't doing anything useful.

After
----------------------------------------

We only perform an `update` if the entity-declaration has changed in some way.

Comments
----------------------------------------

* While working on #32339 with the wmff build, I noticed that `rebuildMenuAndCaches()` was slow -- and that the configuration declared *almost 1,000 managed-entities*. That's a huge number -- much more than `ManagedEntities` was originally designed for. This kind of configuration should see bigger gains.
* I haven't done very deep testing. I wouldn't be surprised if there are some test-failures. I've only done the quick benchmark.
* This does change the interpretation of [the `update` policy](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed/):

    | Policy | Old Interpretation | New Interpretation |
    | -- | -- | -- | 
    |  `always` | Re-save whenever there is a system-flush | Re-save whenever there is a change in the canonical declaration |
    | `unmodified` | Re-save whenever there is a system-flush _and the user has not edited the live record_. | Re-save whenever there is a change in the canonical declaration _and the user has not edited the live record_. |
    | `never` | Never try to re-save. Lock-in the original value. | (*Unchanged*) |

    The new interpretation still follows the same *configuration precedence* (e.g. `always` prioritizes canonical-declarations; `never` prioritizes local-configuration) -- but it applies enforcement less frequently.

* What if you want strict enforcement -- i.e. your intent is to *strictly prevent* edits to the managed-entity? 
    * Well, `update=>always` was the closest to doing that, but it was never strict. (You might say it was 66% of the way there.)
    * With this formulation, it still gives precedence, but it's even less strict. (You might say it's only 33% of the way there.)
    * To get this use-case to 100%, we probably need some kind of _read-only_ flag on the record -- whenever someone tries to edit the live entity, we first ensure that it is not protected by a read-only flag.

* ~~On a gut-level, I expect there will be some scenarios where one wants to forcibly re-save. But I'm not exactly sure where that ends-up. An advanced flush-option? Something you do for full core-upgrades... but not for intermediate `cv flush`es? I'm not sure For the moment, there's just a discreet PHP flag as a nod in that direction.~~ (*This has been re-worked. It does a full re-save whenever you upgrade the system, and it does a targeted re-save when you (re)enable an extension.*)
