### PR TITLE
Allow using "abbr" for domain.state_province_id token

### DIFF
--- a/CRM/Core/DomainTokens.php
+++ b/CRM/Core/DomainTokens.php
@@ -50,6 +50,7 @@ class CRM_Core_DomainTokens extends AbstractTokenSubscriber {
       'city' => ts('Domain (Organization) City'),
       'postal_code' => ts('Domain (Organization) Postal Code'),
       'state_province_id:label' => ts('Domain (Organization) State'),
+      'state_province_id:abbr' => ts('Domain (Organization) State Abbreviation'),
       'country_id:label' => ts('Domain (Organization) Country'),
       'phone' => ts('Domain (Organization) Phone'),
       'email' => ts('Domain (Organization) Email'),
@@ -123,6 +124,7 @@ class CRM_Core_DomainTokens extends AbstractTokenSubscriber {
       $tokens['city'] = $loc['address'][1]['city'] ?? '';
       $tokens['postal_code'] = $loc['address'][1]['postal_code'] ?? '';
       $tokens['state_province_id:label'] = $loc['address'][1]['state_province'] ?? '';
+      $tokens['state_province_id:abbr'] = $loc['address'][1]['state_province_abbreviation'] ?? '';
       $tokens['country_id:label'] = $loc['address'][1]['country'] ?? '';
       $phone = reset($loc['phone']);
       $email = reset($loc['email']);

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -885,6 +885,7 @@ $100.00
     $this->assertStringContainsString('Beverley Hills
 90210
 California
+CA
 United States', $tokenProcessor->getRow(0)->render('message'));
   }
 
@@ -950,6 +951,7 @@ United States', $tokenProcessor->getRow(0)->render('message'));
       '{domain.city}' => 'Domain (Organization) City',
       '{domain.postal_code}' => 'Domain (Organization) Postal Code',
       '{domain.state_province_id:label}' => 'Domain (Organization) State',
+      '{domain.state_province_id:abbr}' => 'Domain (Organization) State Abbreviation',
       '{domain.country_id:label}' => 'Domain (Organization) Country',
       '{domain.empowered_by_civicrm_image_url}' => 'Empowered By CiviCRM Image',
       '{site.message_header}' => 'Message Header',


### PR DESCRIPTION
Overview
----------------------------------------
Allow using "abbr" for domain.state_province_id token

Before
----------------------------------------
{domain.state_province_id:abbr} is blank

After
----------------------------------------
{domain.state_province_id:abbr} is not blank

Technical Details
----------------------------------------
It's already there in the values array, just not exposed. It's also already an available token suffix for _contact_ addresses, just not the _domain_ address.

Comments
----------------------------------------
