### PR TITLE
Cast NULL to string for php 8.4

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -508,7 +508,7 @@ class CRM_Utils_File {
    * @return mixed
    */
   public static function duplicate($filePath) {
-    $oldName = pathinfo($filePath, PATHINFO_FILENAME);
+    $oldName = pathinfo((string) $filePath, PATHINFO_FILENAME);
     $uniqID = bin2hex(random_bytes(16));
     $newName = preg_replace('/(_[\w]{32})$/', '', $oldName) . '_' . $uniqID;
     $newPath = str_replace($oldName, $newName, $filePath);


### PR DESCRIPTION
Overview
----------------------------------------
CRM_Case_BAO_CaseTest::testCaseReassignForCustomFiles
pathinfo(): Passing null to parameter #1 ($path) of type string is deprecated

![image](https://github.com/user-attachments/assets/ac33fbad-2876-4771-9d50-8827c526021e)
