### PR TITLE
RiverLea 1.4.0: GL116, GL117, GL119: UX improvements

### DIFF
--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.4.0-6.2alpha
+ - FIXED - right-align of event participant contact details removed (https://lab.civicrm.org/extensions/riverlea/-/issues/119).
+ - FIXED - FormBuilder left tabs squash and become illegible when too many items (https://lab.civicrm.org/extensions/riverlea/-/issues/116)
+ - CHANGED - only bottom align delete button when there are a limited number of custom activities (default list plus up to three more custom activities), otherwise keep inline (https://lab.civicrm.org/extensions/riverlea/-/issues/117#note_178676)
+
 1.3.8-6.0alpha
  - FIXED - solves various issues around the naming of crm-text-light and crm-text-dark (https://github.com/civicrm/civicrm-core/pull/31994);
  - FIXED - Bootstrap Time input fields limit width, not 100%.

--- a/ext/riverlea/README.md
+++ b/ext/riverlea/README.md
@@ -17,6 +17,7 @@ Overwriting CSS variables for the front is straightforward (they can be nested w
 
 ## [Changelog](CHANGELOG.md)
 
+- 1.4.x-6.2.alpha - ongoing fixes/changes against 6.2
 - 1.3.x-6.0.alpha - Contrast ratios, responsive and Front-end changes, including new variables, plus fixes (see changelog)
 - 1.2.x-5.81 - Regression fixes against 5.81 RC
 - 1.1 (5.80) - Release for packaging with CiviCRM core, v5.80

--- a/ext/riverlea/core/css/_core.css
+++ b/ext/riverlea/core/css/_core.css
@@ -4,5 +4,5 @@
    can be merged later. */
 
 @import url(components/_accordion.css); @import url(components/_alerts.css); @import url(components/_buttons.css); @import url(components/_form.css); @import url(components/_icons.css); @import url(components/_nav.css); @import url(components/_tabs.css); @import url(components/_dropdowns.css); @import url(components/_tables.css); @import url(components/_dialogs.css); @import url(components/_page.css); @import url(components/_components.css); @import url(components/_front.css); :root {
-  --crm-release: '1.3.8-6.0alpha';
+  --crm-release: '1.4.0-6.2alpha';
 }

--- a/ext/riverlea/core/css/components/_tables.css
+++ b/ext/riverlea/core/css/components/_tables.css
@@ -95,7 +95,7 @@ table.dataTable.order-column.stripe tbody tr.extension-installed.even > .sorting
   border-right: var(--crm-table-column-border);
 }
 .crm-container table td:has(.btn-slide),
-.crm-container table td:not(.crm-case-date):has(.action-item) {
+.crm-container table:not(.crm-info-panel) td:not(.crm-case-date):has(.action-item) {
   text-align: right;
 }
 .crm-container table.crm-mailing-ab-table td:has(.action-item) {

--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -285,7 +285,7 @@ div.crm-inline-edit-form div.crm-clear {
 #crm-contact-actions-list ul a {
   display: block;
 }
-.crm-contact-crm-contact-delete {
+.crm-contact-actions-list-inner:not(:has(.crm-activity-type_6)) .crm-contact-crm-contact-delete {
   margin-top: auto;
 }
 #crm-contact-actions-list .crm-contact_activities-list select {

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -93,6 +93,7 @@
 #afGuiEditor .panel-heading ul.nav-tabs li.fluid-width-tab {
   white-space: nowrap;
   overflow: hidden;
+  max-width: unset !important; /* vs inline max-width set by Form Builder UI */
 }
 #afGuiEditor .panel-heading .form-inline.pull-right button {
   max-height: 32px;

--- a/ext/riverlea/info.xml
+++ b/ext/riverlea/info.xml
@@ -12,7 +12,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>[civicrm.releaseDate]</releaseDate>
-  <version>1.3.8-[civicrm.version]</version>
+  <version>1.4.0-[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>


### PR DESCRIPTION
Overview
----------------------------------------
Resolves RiverLea/Gitlab issues:
https://lab.civicrm.org/extensions/riverlea/-/issues/116
https://lab.civicrm.org/extensions/riverlea/-/issues/117
https://lab.civicrm.org/extensions/riverlea/-/issues/119
 
Before
----------------------------------------
[116: Formbuilder: Hard to enter filter values](
https://lab.civicrm.org/extensions/riverlea/-/issues/116)

![image](https://github.com/user-attachments/assets/cfb57eec-f6d3-4a70-9ab0-641fa75a83cf)

[117: Delete option located bottom right corner of Actions screen with many items](
https://lab.civicrm.org/extensions/riverlea/-/issues/117)

![image](https://github.com/user-attachments/assets/4556e26b-3cea-484e-8ca0-03ebedec2479)

[119: View Event Registration screen - Display Name and print options misaligned](
https://lab.civicrm.org/extensions/riverlea/-/issues/119)

![image](https://github.com/user-attachments/assets/35f45f55-4ec6-480c-a9c5-064e9c20b102)

After
----------------------------------------
[116: Formbuilder: Tabs showed in full, then wrap](
https://lab.civicrm.org/extensions/riverlea/-/issues/116)
NB - this overwrites a hardcoded FormBuilder setting which calculates and fixes the width, hence uses `!important` 

![image](https://github.com/user-attachments/assets/1366270a-c489-412c-9db7-e2879484c51a)

[117: Delete option located bottom right corner of Actions screen only if three custom activities or fewer](
https://lab.civicrm.org/extensions/riverlea/-/issues/117)

No custom actions:
![image](https://github.com/user-attachments/assets/2f1f2c53-83ed-43b9-ab30-e385ef089d34)

Three custom activities:
![image](https://github.com/user-attachments/assets/f20d10d3-1fe7-462e-9b34-60768e88044a)

Four+ custom activities:
![image](https://github.com/user-attachments/assets/a4c90db7-e828-4751-9222-c23d5ec87f14)

[119: View Event Registration screen - Display Name and print options correctly aligned](
https://lab.civicrm.org/extensions/riverlea/-/issues/119)

![image](https://github.com/user-attachments/assets/3a164648-a1b5-402f-85b9-cbc4ae343d34)


Technical Details
----------------------------------------
Each fix is one line of CSS, so it seems safe to bundle these three fixes together. In addition there's some metadata changes from increasing the version number.

Comments
----------------------------------------
These shouldn't impact Streams unless they contain custom css interacting with the changed selector (cc @artfulrobot). 