### PR TITLE
Advanced Search: standardize labels (singular, no question mark)

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -456,7 +456,7 @@ class CRM_Activity_BAO_Query {
     $form->addRadio('activity_option', '', CRM_Core_SelectValues::activityTextOptions());
     $form->setDefaults(['activity_option' => 6]);
 
-    $form->addYesNo('activity_test', ts('Activity is a Test?'));
+    $form->addYesNo('activity_test', ts('Activity is a Test'));
     $activity_tags = CRM_Core_BAO_Tag::getColorTags('civicrm_activity');
 
     if ($activity_tags) {

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -31,7 +31,7 @@ class CRM_Contact_Form_Search_Criteria {
       $contactTypes = CRM_Contact_BAO_ContactType::getSelectElements();
 
       if ($contactTypes) {
-        $form->add('select', 'contact_type', ts('Contact Type(s)'), $contactTypes, FALSE,
+        $form->add('select', 'contact_type', ts('Contact Type'), $contactTypes, FALSE,
           ['id' => 'contact_type', 'multiple' => 'multiple', 'class' => 'crm-select2', 'style' => 'width: 100%;']
         );
       }
@@ -63,7 +63,7 @@ class CRM_Contact_Form_Search_Criteria {
       $contactTags = CRM_Core_BAO_Tag::getTags();
 
       if ($contactTags) {
-        $form->add('select', 'contact_tags', ts('Select Tag(s)'), $contactTags, FALSE,
+        $form->add('select', 'contact_tags', ts('Tag'), $contactTags, FALSE,
           ['id' => 'contact_tags', 'multiple' => 'multiple', 'class' => 'crm-select2', 'style' => 'width: 100%;']
         );
       }
@@ -109,7 +109,7 @@ class CRM_Contact_Form_Search_Criteria {
     }
 
     // add checkbox for cms users only
-    $form->addYesNo('uf_user', ts('CMS User?'), TRUE);
+    $form->addYesNo('uf_user', ts('CMS User'), TRUE);
 
     // tag all search
     $form->add('text', 'tag_search', ts('All Tags'));
@@ -212,7 +212,7 @@ class CRM_Contact_Form_Search_Criteria {
 
     $options = [
       1 => ts('Exclude'),
-      2 => ts('Include by Privacy Option(s)'),
+      2 => ts('Include by Privacy Option'),
     ];
     $form->addRadio('privacy_toggle', ts('Privacy Options'), $options, ['allowClear' => FALSE]);
 
@@ -247,13 +247,13 @@ class CRM_Contact_Form_Search_Criteria {
   public static function getSearchFieldMetadata() {
     $fields = [
       'sort_name' => [
-        'title' => ts('Complete OR Partial Name'),
+        'title' => ts('Name'),
         'template_grouping' => 'basic',
         'template' => 'CRM/Contact/Form/Search/Criteria/Fields/sort_name.tpl',
       ],
       'first_name' => ['template_grouping' => 'basic'],
       'last_name' => ['template_grouping' => 'basic'],
-      'email' => ['title' => ts('Complete OR Partial Email'), 'entity' => 'Email', 'template_grouping' => 'basic'],
+      'email' => ['title' => ts('Email'), 'entity' => 'Email', 'template_grouping' => 'basic'],
       'contact_tags' => ['name' => 'contact_tags', 'type' => CRM_Utils_Type::T_INT, 'is_pseudofield' => TRUE, 'template_grouping' => 'basic'],
       'created_date' => ['name' => 'created_date', 'template_grouping' => 'changeLog'],
       'modified_date' => ['name' => 'modified_date', 'template_grouping' => 'changeLog'],

--- a/CRM/Mailing/BAO/Query.php
+++ b/CRM/Mailing/BAO/Query.php
@@ -401,7 +401,7 @@ class CRM_Mailing_BAO_Query {
     $mailings = CRM_Mailing_BAO_Mailing::getMailingsList();
 
     if (!empty($mailings)) {
-      $form->add('select', 'mailing_id', ts('Mailing Name(s)'), $mailings, FALSE,
+      $form->add('select', 'mailing_id', ts('Mailing Name'), $mailings, FALSE,
         ['id' => 'mailing_id', 'multiple' => 'multiple', 'class' => 'crm-select2']
       );
     }

--- a/templates/CRM/Activity/Form/Search.tpl
+++ b/templates/CRM/Activity/Form/Search.tpl
@@ -21,7 +21,7 @@
               <td colspan="2">
                 {$form.sort_name.label}&nbsp;&nbsp;{$form.sort_name.html|crmAddClass:'twenty'}
                 <div>
-                  <div class="description font-italic">{ts}Complete OR Partial Name{/ts}
+                  <div class="description font-italic">{ts}Name{/ts}
                     <span class="contact-name-option option-1">{ts} of the Source Contact{/ts}</span>
                     <span class="contact-name-option option-2">{ts} of the Assignee Contact{/ts}</span>
                     <span class="contact-name-option option-3">{ts} of the Target Contact{/ts}</span>

--- a/templates/CRM/Activity/Form/Search/Common.tpl
+++ b/templates/CRM/Activity/Form/Search/Common.tpl
@@ -44,14 +44,14 @@
     <table>
       <tr><td>
         {if !empty($form.parent_id)}
-          <label>{ts}Has a Followup Activity?{/ts}</label>
+          <label>{ts}Has a Followup Activity{/ts}</label>
           <br/>
           {$form.parent_id.html}
         {/if}
       </td></tr>
       <tr><td>
       {if !empty($form.followup_parent_id)}
-          <label>{ts}Is a Followup Activity?{/ts}</label>
+          <label>{ts}Is a Followup Activity{/ts}</label>
           <br/>
           {$form.followup_parent_id.html}
         {/if}

--- a/templates/CRM/Campaign/Form/Search/Common.tpl
+++ b/templates/CRM/Campaign/Form/Search/Common.tpl
@@ -50,7 +50,7 @@
         </tr>
         <tr>
           <td>
-            <label>{ts}Contact Type(s){/ts}</label>
+            <label>{ts}Contact Type{/ts}</label>
           </td>
           <td>
             {$form.contact_type.html}

--- a/templates/CRM/Contact/Form/Search/Criteria/Fields/group.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Fields/group.tpl
@@ -1,5 +1,5 @@
 <div id='groupselect'>
-  <label>{ts}Group(s){/ts}
+  <label>{ts}Group{/ts}
     <span class="description">
       (<a href="#" id='searchbygrouptype'>{ts}search by group type{/ts}</a>)
     </span>
@@ -9,7 +9,7 @@
 </div>
 <div id='grouptypeselect'>
   <label>
-    {ts}Group Type(s){/ts}
+    {ts}Group Types{/ts}
     <span class="description">
       (<a href="#" id='searchbygroup'>{ts}search by group{/ts}</a>)
     </span>

--- a/templates/CRM/Contact/Form/Search/Criteria/Fields/sort_name.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Fields/sort_name.tpl
@@ -1,9 +1,9 @@
 <div id="sortnameselect">
-  <label>{ts}Complete OR Partial Name{/ts} <span class="description">(<a href="#" id='searchbyindivflds'>{ts}search by individual name fields{/ts}</a>)</span></label><br />
+  <label>{ts}Name{/ts} <span class="description">(<a href="#" id='searchbyindivflds'>{ts}search by individual name fields{/ts}</a>)</span></label><br />
   {$form.sort_name.html}
 </div>
 <div id="indivfldselect">
-  <label>{ts}First/Last Name{/ts}<span class="description"> (<a href="#" id='searchbysortname'>{ts}search by complete or partial name{/ts}</a>)</span></label><br />
+  <label>{ts}First/Last Name{/ts}<span class="description"> (<a href="#" id='searchbysortname'>{ts}search by full name{/ts}</a>)</span></label><br />
   {$form.first_name.html} {$form.last_name.html}
 </div>
 


### PR DESCRIPTION
Overview
----------------------------------------

Simplifies the labels on the Advanced Search.

Because sometimes we like stating the obvious OR something confusing. Looking at other systems, usually the partial/strict matching is not explained, and it becomes obvious after a search or two.

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/e7d055fc-77b3-4ef7-b81a-c7a02f076812)

After
----------------------------------------

![image](https://github.com/user-attachments/assets/2fb78867-3444-4e4f-9223-73ac8e8404cf)

Comments
----------------------------------------

The "search by individual name fields" and "search by group type" annoy me as well, it should be an icon, but I'm not sure what would be a good icon for both of these fields.

cc @vingle 