### PR TITLE
dev/core#5790 Added API4 query function IS NOT NULL

### DIFF
--- a/Civi/Api4/Query/SqlFunctionISNOTNULL.php
+++ b/Civi/Api4/Query/SqlFunctionISNOTNULL.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Sql function
+ */
+class SqlFunctionISNOTNULL extends SqlFunction {
+
+  protected static $category = self::CATEGORY_COMPARISON;
+
+  protected static $dataType = 'Boolean';
+
+  protected static function params(): array {
+    return [
+      [
+        'optional' => FALSE,
+      ],
+    ];
+  }
+
+  /**
+   * @return string
+   */
+  public static function getTitle(): string {
+    return ts('Is not null');
+  }
+
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('FALSE if the value is NULL, otherwise TRUE.');
+  }
+
+  /**
+   * Render the final expression
+   *
+   * @param string $output
+   * @return string
+   */
+  public static function renderExpression(string $output): string {
+    return "!ISNULL($output)";
+  }
+
+}

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -231,6 +231,7 @@ class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
       ->addSelect('GREATEST(duration, 0200) AS greatest_of_duration_or_200')
       ->addSelect('LEAST(duration, 300) AS least_of_duration_and_300')
       ->addSelect('ISNULL(duration) AS duration_isnull')
+      ->addSelect('ISNOTNULL(duration) AS duration_isnotnull')
       ->addSelect('IFNULL(duration, 2) AS ifnull_duration_2')
       ->addSelect('created_date')
       ->addSelect('activity_date_time')
@@ -266,6 +267,10 @@ class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals(FALSE, $result[$aids[0]]['duration_isnull']);
     $this->assertEquals(TRUE, $result[$aids[1]]['duration_isnull']);
     $this->assertEquals(FALSE, $result[$aids[2]]['duration_isnull']);
+
+    $this->assertEquals(TRUE, $result[$aids[0]]['duration_isnotnull']);
+    $this->assertEquals(FALSE, $result[$aids[1]]['duration_isnotnull']);
+    $this->assertEquals(TRUE, $result[$aids[2]]['duration_isnotnull']);
 
     $this->assertEquals(123, $result[$aids[0]]['ifnull_duration_2']);
     $this->assertEquals(2, $result[$aids[1]]['ifnull_duration_2']);


### PR DESCRIPTION
Overview
----------------------------------------

Added an APIv4 function for IS NOT NULL. So that this function is available in search kit.

Before
----------------------------------------

The Fx in search kit for IS NOT NULL was missing.

![2025-03-12_19-18](https://github.com/user-attachments/assets/26a85fee-4cf2-423d-b39d-bb12832e7638)


After
----------------------------------------

The Fx in search kit for IS NOT NULL is available. Which is the inverse of the IS NULL function.

![2025-03-12_21-18](https://github.com/user-attachments/assets/971efb5c-f471-4488-a3e0-4ae52121cc36)



Comments
----------------------------------------

See https://lab.civicrm.org/dev/core/-/issues/5790
