### PR TITLE
don't allow payment on a canceled invoice

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1362,6 +1362,9 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     if (!$this->getContactID()) {
       CRM_Core_Error::statusBounce(ts('Returning since there is no contact attached to this contribution id.'));
     }
+    if ($this->getContributionValue('contribution_status_id:name') === 'Cancelled') {
+      throw new CRM_Core_Exception(ts('Sorry, this contribution has been cancelled.'));
+    }
 
     $paymentBalance = CRM_Contribute_BAO_Contribution::getContributionBalance($this->_ccid);
     //bounce if the contribution is not pending.


### PR DESCRIPTION
Overview
----------------------------------------
If you email a link to pay an invoice, then cancel the contribution, the email recipient can still click the link and pay the invoice.

To replicate:
* Turn on invoicing in the CiviContribute Component Settings.
* Create a pending contribution.
* Generate the URL for paying the invoice online (the [Invoice Helper](https://civicrm.org/extensions/invoice-helper) extension will show it when viewing a pending contribution, much easier than figuring it out by hand).
* Cancel the contribution.
* As an anonymous user, visit the payment URL.

Before
----------------------------------------
You can pay a canceled invoice.

After
----------------------------------------
Throws an exception.

Comments
----------------------------------------
I don't like the "statusBounce" approach used elsewhere in this function because anonymous users don't see them. But if that's controversial I can make it a statusBounce.
