### PR TITLE
[PHP 8] Fix warning and lack of error on empty API3 getOptions result

### DIFF
--- a/api/v3/Generic.php
+++ b/api/v3/Generic.php
@@ -442,7 +442,7 @@ function civicrm_api3_generic_getoptions($apiRequest) {
     }
     $options = $baoName::buildOptions($fieldName, $context, $apiRequest['params']);
   }
-  if ($options === FALSE) {
+  if (empty($options)) {
     return civicrm_api3_create_error("The field '{$fieldName}' has no associated option list.");
   }
   // Support 'sequential' output as a non-associative array


### PR DESCRIPTION
Overview
----------------------------------------
When calling API3 `getOptions` on a field that has no options, we get a PHP warning, and we don't return an error.

To replicate:
run `cv api3 Activity.getoptions sequential=1 field=id`.

Before
----------------------------------------
```
[PHP Warning] foreach() argument must be of type array|object, null given at /home/jon/local/leonardo/web/sites/all/modules/civicrm/CRM/Utils/Array.php:936
{
    "is_error": 0,
    "version": 3,
    "count": 0,
    "values": []
}
```

After
----------------------------------------
```
{
    "is_error": 1,
    "error_message": "The field 'id' has no associated option list."
}
```

Technical Details
----------------------------------------
I guess `buildOptions()` didn't used to return `NULL`? And maybe it doesn't in all scenarios?  I tried accounting for the fact that perhaps some BAOs might still return `FALSE`.