### PR TITLE
dev/core#5791 Address rc regression on handling ambigous 'source' in contribution import

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -97,10 +97,10 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
         // Duplicates are being skipped so id matching is not available.
         continue;
       }
-      if ($this->isUpdateExisting() && in_array($name, ['contribution_contact_id', 'email', 'first_name', 'last_name', 'external_identifier', 'email_primary.email'], TRUE)) {
+      if ($this->isUpdateExisting() && in_array($name, ['contact_id', 'email', 'contact.first_name', 'contact.last_name', 'external_identifier', 'email_primary.email'], TRUE)) {
         continue;
       }
-      if ($this->isUpdateExisting() && in_array($name, ['contribution_id', 'invoice_id', 'trxn_id'], TRUE)) {
+      if ($this->isUpdateExisting() && in_array($name, ['id', 'invoice_id', 'trxn_id'], TRUE)) {
         $field['title'] .= (' ' . ts('(match to contribution record)'));
       }
       // Swap out dots for double underscores so as not to break the quick form js.
@@ -234,13 +234,13 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
     //invoice id or trxn id or contribution id is required.
     if ($this->isUpdateExisting()) {
       //modify field title only for update mode. CRM-3245
-      foreach (['contribution_id', 'invoice_id', 'trxn_id'] as $key) {
+      foreach (['id', 'invoice_id', 'trxn_id'] as $key) {
         $highlightedFields[] = $key;
       }
     }
     elseif ($this->isSkipExisting()) {
       $highlightedFieldsArray = [
-        'contribution_contact_id',
+        'contact_id',
         'email',
         'first_name',
         'last_name',

--- a/CRM/Event/Import/Form/MapField.php
+++ b/CRM/Event/Import/Form/MapField.php
@@ -21,6 +21,21 @@
 class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
 
   /**
+   * Does the form layer convert field names to support QuickForm widgets.
+   *
+   * (e.g) if 'yes' we swap
+   * `soft_credit.external_identifier` to `soft_credit__external_identifier`
+   * because the contribution form would break on the . as it would treat it as
+   * javascript.
+   *
+   * In the case of the participant import the array is flatter and there
+   * is no hierarchical select so we do not need to do this.
+   *
+   * @var bool
+   */
+  protected bool $supportsDoubleUnderscoreFields = FALSE;
+
+  /**
    * Get the name of the type to be stored in civicrm_user_job.type_id.
    *
    * @return string
@@ -94,14 +109,15 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
 
     if (!array_key_exists('savedMapping', $fields)) {
       $importKeys = [];
-      foreach ($fields['mapper'] as $mapperPart) {
-        $importKeys[] = $mapperPart[0];
+      $importKeys = [];
+      foreach ($fields['mapper'] as $field) {
+        $importKeys[] = [$field];
       }
       $parser = $self->getParser();
       $rule = $parser->getDedupeRule($self->getContactType(), $self->getUserJob()['metadata']['entity_configuration']['Contact']['dedupe_rule'] ?? NULL);
-      $requiredError = $self->validateContactFields($rule, $fields['mapper'], ['external_identifier', 'contact_id', 'contact__id']);
+      $requiredError = $self->validateContactFields($rule, $importKeys, ['external_identifier', 'contact_id']);
 
-      if (!in_array('id', $importKeys) && !in_array('event_id', $importKeys)) {
+      if (!in_array('id', $fields['mapper']) && !in_array('event_id', $fields['mapper'])) {
         // ID is the only field we need, if present.
         $requiredError[] = ts('Missing required field: Provide %1 or %2',
             [1 => 'Event ID', 2 => 'Event Title']

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -142,9 +142,9 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
         ],
         $allParticipantFields
       );
-      $contactFields = $this->getContactFields($this->getContactType());
-      $fields['contact_id'] = $contactFields['id'];
-      unset($contactFields['id']);
+      $contactFields = $this->getContactFields($this->getContactType(), 'contact');
+      $fields['contact_id'] = $contactFields['contact.id'];
+      unset($contactFields['contact.id']);
       $fields['contact_id']['title'] .= ' ' . ts('(match to contact)');
       $fields['contact_id']['html']['label'] = $fields['contact_id']['title'];
       $fields += $contactFields;

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -315,23 +315,14 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     $formName = 'document.forms.' . $this->_name;
 
     foreach ($this->getColumnHeaders() as $i => $columnHeader) {
-      $sel = &$this->addElement('hierselect', "mapper[$i]", ts('Mapper for Field %1', [1 => $i]), NULL);
-      $jsSet = FALSE;
       if ($this->getSubmittedValue('savedMapping')) {
         $fieldMapping = $fieldMappings[$i] ?? NULL;
         if (isset($fieldMappings[$i])) {
           if ($fieldMapping['name'] !== ts('do_not_import')) {
-            $js .= "{$formName}['mapper[$i][3]'].style.display = 'none';\n";
             $defaults["mapper[$i]"] = [$fieldMapping['name']];
-            $jsSet = TRUE;
           }
           else {
             $defaults["mapper[$i]"] = [];
-          }
-          if (!$jsSet) {
-            for ($k = 1; $k < 4; $k++) {
-              $js .= "{$formName}['mapper[$i][$k]'].style.display = 'none';\n";
-            }
           }
         }
         else {
@@ -345,7 +336,6 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
         //end of load mapping
       }
       else {
-        $js .= "swapOptions($formName, 'mapper[$i]', 0, 3, 'hs_mapper_" . $i . "_');\n";
         if ($hasHeaders) {
           // Infer the default from the skipped headers if we have them
           $defaults["mapper[$i]"] = [
@@ -357,10 +347,9 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
           ];
         }
       }
-      $sel->setOptions([$sel1]);
+      $sel = &$this->addElement('select', "mapper[$i]", ts('Mapper for Field %1', [1 => $i]), $sel1);
+
     }
-    $js .= "</script>\n";
-    $this->assign('initHideBoxes', $js);
     $this->setDefaults($defaults);
     return [$sel, $headerPatterns];
   }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -260,11 +260,12 @@ abstract class CRM_Import_Parser implements UserJobInterface {
 
   /**
    * @param string $contactType
+   * @param string|null $prefix
    *
    * @return array[]
    * @throws \CRM_Core_Exception
    */
-  protected function getContactFields(string $contactType): array {
+  protected function getContactFields(string $contactType, ?string $prefix = ''): array {
     $contactFields = $this->getAllContactFields('');
     $dedupeFields = $this->getDedupeFields($contactType);
 
@@ -278,6 +279,16 @@ abstract class CRM_Import_Parser implements UserJobInterface {
 
     $contactFields['external_identifier']['title'] .= (' ' . ts('(match to contact)'));
     $contactFields['external_identifier']['match_rule'] = '*';
+    if ($prefix) {
+      $prefixedFields = [];
+      foreach ($contactFields as $name => $contactField) {
+        $contactField['entity_prefix'] = $prefix . '.';
+        $contactField['entity'] = 'Contact';
+        $contactField['entity_instance'] = ucfirst($prefix);
+        $prefixedFields[$prefix . '.' . $name] = $contactField;
+      }
+      return $prefixedFields;
+    }
     return $contactFields;
   }
 

--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -256,7 +256,7 @@ WHERE pcp.id = %1 AND cc.contribution_status_id = %2 AND cc.is_test = 0";
     ];
     $dao = CRM_Core_DAO::executeQuery($query, $params);
     $honor = [];
-    while ($dao->fetch()) {
+    while ($dao->find()) {
       $honor[$dao->id]['nickname'] = ucwords($dao->pcp_roll_nickname);
       $honor[$dao->id]['total_amount'] = CRM_Utils_Money::format($dao->total_amount, $dao->currency);
       $honor[$dao->id]['personal_note'] = $dao->pcp_personal_note;

--- a/CRM/Upgrade/Incremental/php/SixOne.php
+++ b/CRM/Upgrade/Incremental/php/SixOne.php
@@ -111,6 +111,8 @@ class CRM_Upgrade_Incremental_php_SixOne extends CRM_Upgrade_Incremental_Base {
       $fieldsToConvert['source'] = 'contact.source';
       $fieldsToConvert['id'] = 'contact.id';
       $fieldsToConvert['contribution_source'] = 'source';
+      $fieldsToConvert['contribution_id'] = 'id';
+      $fieldsToConvert['contribution_contact_id'] = 'contact_id';
     }
 
     $customFields = CRM_Core_DAO::executeQuery('

--- a/CRM/Upgrade/Incremental/php/SixOne.php
+++ b/CRM/Upgrade/Incremental/php/SixOne.php
@@ -57,7 +57,7 @@ class CRM_Upgrade_Incremental_php_SixOne extends CRM_Upgrade_Incremental_Base {
     // together (from Contribution convert in FiveFiftyFour) feels like
     // it has merit
     $contactPrefix = '';
-    if ($importType === 'Import Membership' || $importType === 'Import Contribution') {
+    if ($importType === 'Import Membership' || $importType === 'Import Contribution' || $importType === 'Import Participant') {
       $contactPrefix = 'contact.';
     }
     if ($importType === 'Import Activity') {

--- a/CRM/Upgrade/Incremental/php/SixOne.php
+++ b/CRM/Upgrade/Incremental/php/SixOne.php
@@ -39,13 +39,14 @@ class CRM_Upgrade_Incremental_php_SixOne extends CRM_Upgrade_Incremental_Base {
   }
 
   /**
+   * @param \CRM_Queue_TaskContext|null $context
    * @param string $importType
    *
-   * @return void
+   * @return true
    * @throws \CRM_Core_Exception
    * @throws \Civi\Core\Exception\DBQueryException
    */
-  public static function upgradeImportMappingFields(string $importType): void {
+  public static function upgradeImportMappingFields($context, string $importType): bool {
     $mappingFields = CRM_Core_DAO::executeQuery('
       SELECT field.id, field.name FROM civicrm_mapping_field field
         INNER JOIN civicrm_mapping mapping
@@ -56,7 +57,7 @@ class CRM_Upgrade_Incremental_php_SixOne extends CRM_Upgrade_Incremental_Base {
     // together (from Contribution convert in FiveFiftyFour) feels like
     // it has merit
     $contactPrefix = '';
-    if ($importType === 'Import Membership') {
+    if ($importType === 'Import Membership' || $importType === 'Import Contribution') {
       $contactPrefix = 'contact.';
     }
     if ($importType === 'Import Activity') {
@@ -106,6 +107,12 @@ class CRM_Upgrade_Incremental_php_SixOne extends CRM_Upgrade_Incremental_Base {
       'activity_is_star' => 'is_star',
     ];
 
+    if ($importType === 'Import Contribution') {
+      $fieldsToConvert['source'] = 'contact.source';
+      $fieldsToConvert['id'] = 'contact.id';
+      $fieldsToConvert['contribution_source'] = 'source';
+    }
+
     $customFields = CRM_Core_DAO::executeQuery('
       SELECT custom_field.id, custom_field.name, custom_group.name as custom_group_name, custom_group.extends
       FROM civicrm_custom_field custom_field INNER JOIN civicrm_custom_group custom_group
@@ -125,6 +132,23 @@ class CRM_Upgrade_Incremental_php_SixOne extends CRM_Upgrade_Incremental_Base {
         ]);
       }
     }
+    if ($importType === 'Import Contribution') {
+      $userJob = new \CRM_Core_DAO_UserJob();
+      $userJob->job_type = 'contribution_import';
+      $userJob->find();
+      while ($userJob->fetch()) {
+        $metadata = json_decode($userJob->metadata, TRUE);
+        foreach ($metadata['import_mappings'] as &$mapping) {
+          if (isset($fieldsToConvert[$mapping['name']])) {
+            $mapping['name'] = $fieldsToConvert[$mapping['name']];
+          }
+          $userJob->metadata = json_encode($metadata);
+          $userJob->save();
+        }
+
+      }
+    }
+    return TRUE;
   }
 
   /**
@@ -139,6 +163,16 @@ class CRM_Upgrade_Incremental_php_SixOne extends CRM_Upgrade_Incremental_Base {
     $this->addTask('Update import mappings', 'updateFieldMappingsForImport');
     $this->addTask('Replace Clear Caches & Reset Paths with Clear Caches in Nav Menu', 'updateUpdateConfigBackendNavItem');
     $this->addTask('Install ImportTemplateField entity', 'createEntityTable', '6.1.alpha1.ImportTemplateField.entityType.php');
+  }
+
+  /**
+   * Upgrade step; adds tasks including 'runSql'.
+   *
+   * @param string $rev
+   *   The version number matching this function name
+   */
+  public function upgrade_6_1_beta1(string $rev): void {
+    $this->addTask('Update import mappings', 'upgradeImportMappingFields', 'Import Contribution');
   }
 
   /**
@@ -261,7 +295,7 @@ class CRM_Upgrade_Incremental_php_SixOne extends CRM_Upgrade_Incremental_Base {
   public static function updateFieldMappingsForImport(): bool {
     $importTypes = ['Import Participant', 'Import Membership', 'Import Activity'];
     foreach ($importTypes as $importType) {
-      self::upgradeImportMappingFields($importType);
+      self::upgradeImportMappingFields(NULL, $importType);
     }
     return TRUE;
   }

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -137,7 +137,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => 'total_amount'],
       ['name' => 'receive_date'],
       ['name' => 'financial_type_id'],
-      ['name' => 'external_identifier'],
+      ['name' => 'contact__external_identifier'],
       ['name' => 'soft_credit__contact__external_identifier', 'soft_credit_type_id' => 1],
     ]);
     $this->validateSoftCreditImport([
@@ -203,12 +203,12 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $this->addRandomOption();
     $contactID = $this->individualCreate();
 
-    $values = ['contribution_contact_id' => $contactID, 'total_amount' => 10, 'financial_type_id' => 'Donation', 'payment_instrument_id' => 'Check'];
+    $values = ['contact_id' => $contactID, 'total_amount' => 10, 'financial_type_id' => 'Donation', 'payment_instrument_id' => 'Check'];
     $this->runImport($values, CRM_Import_Parser::DUPLICATE_SKIP);
     $contribution = $this->callAPISuccessGetSingle('Contribution', ['contact_id' => $contactID]);
     $this->assertEquals('Check', $contribution['payment_instrument']);
 
-    $values = ['contribution_contact_id' => $contactID, 'total_amount' => 10, 'financial_type_id' => 'Donation', 'payment_instrument_id' => 'not at all random'];
+    $values = ['contact_id' => $contactID, 'total_amount' => 10, 'financial_type_id' => 'Donation', 'payment_instrument_id' => 'not at all random'];
     $this->runImport($values, CRM_Import_Parser::DUPLICATE_SKIP);
     $contribution = $this->callAPISuccessGetSingle('Contribution', ['contact_id' => $contactID, 'payment_instrument_id' => 'random']);
     $this->assertEquals('not at all random', $contribution['payment_instrument']);
@@ -221,7 +221,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
    */
   public function testContributionStatusLabel(): void {
     $contactID = $this->individualCreate();
-    $values = ['contribution_contact_id' => $contactID, 'total_amount' => 10, 'financial_type_id' => 'Donation', 'payment_instrument_id' => 'Check', 'contribution_status_id' => 'Pending'];
+    $values = ['contact_id' => $contactID, 'total_amount' => 10, 'financial_type_id' => 'Donation', 'payment_instrument_id' => 'Check', 'contribution_status_id' => 'Pending'];
     // Note that the expected result should logically be CRM_Import_Parser::valid but writing test to reflect not fix here
     $this->runImport($values, CRM_Import_Parser::DUPLICATE_SKIP);
     $contribution = $this->callAPISuccessGetSingle('Contribution', ['contact_id' => $contactID]);
@@ -349,12 +349,12 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
    */
   public function testParsedCustomOption(): void {
     $contactID = $this->individualCreate();
-    $values = ['contribution_contact_id' => $contactID, 'total_amount' => 10, 'financial_type_id' => 'Donation', 'payment_instrument_id' => 'Check', 'contribution_status_id' => 'Pending'];
+    $values = ['contact_id' => $contactID, 'total_amount' => 10, 'financial_type_id' => 'Donation', 'payment_instrument_id' => 'Check', 'contribution_status_id' => 'Pending'];
     // Note that the expected result should logically be CRM_Import_Parser::valid but writing test to reflect not fix here
     $this->runImport($values, CRM_Import_Parser::DUPLICATE_SKIP);
     $contribution = $this->callAPISuccess('Contribution', 'getsingle', ['contact_id' => $contactID]);
     $this->createCustomGroupWithFieldOfType([], 'radio');
-    $values['contribution_id'] = $contribution['id'];
+    $values['id'] = $contribution['id'];
     $values[$this->getCustomFieldName('radio', 4)] = 'Red Testing';
     unset(Civi::$statics['CRM_Core_BAO_OptionGroup']);
     $this->runImport($values, CRM_Import_Parser::DUPLICATE_UPDATE);
@@ -371,7 +371,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $contactID = $this->individualCreate(['email' => 'mum@example.com']);
     $pledgeID = $this->pledgeCreate(['contact_id' => $contactID]);
     $this->importCSV('pledge.csv', [
-      ['name' => 'email_primary.email'],
+      ['name' => 'contact.email_primary.email'],
       ['name' => 'total_amount'],
       ['name' => 'pledge_id'],
       ['name' => 'receive_date'],
@@ -418,7 +418,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $parser = new CRM_Contribute_Import_Parser_Contribution();
     $parser->setUserJobID($this->getUserJobID());
     $fields = $parser->getFieldsMetadata();
-    $this->assertArrayHasKey('phone_primary.phone', $fields);
+    $this->assertArrayHasKey('contact.phone_primary.phone', $fields);
     $this->callAPISuccess('RuleGroup', 'create', [
       'id' => $unsupervisedRuleGroup['id'],
       'used' => 'Unsupervised',
@@ -436,7 +436,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $this->createCustomGroupWithFieldOfType([], 'checkbox');
     $customField = $this->getCustomFieldName('checkbox', 4);
     $contactID = $this->individualCreate();
-    $values = ['contribution_contact_id' => $contactID, 'total_amount' => 10, 'financial_type_id' => 'Donation', $customField => 'L,V'];
+    $values = ['contact_id' => $contactID, 'total_amount' => 10, 'financial_type_id' => 'Donation', $customField => 'L,V'];
     $this->runImport($values, CRM_Import_Parser::DUPLICATE_SKIP);
     $initialContribution = Contribution::get()->addWhere('contact_id', '=', $contactID)
       ->addSelect($customField)
@@ -445,7 +445,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $this->assertContains('V', $initialContribution[$customField], 'Contribution Duplicate Skip Import contains V');
 
     // Now update.
-    $values['contribution_id'] = $initialContribution['id'];
+    $values['id'] = $initialContribution['id'];
     $values[$customField] = 'V';
     $this->runImport($values, CRM_Import_Parser::DUPLICATE_UPDATE);
 
@@ -511,7 +511,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => 'receive_date'],
       ['name' => 'financial_type_id'],
       ['name' => ''],
-      ['name' => 'email_primary__email'],
+      ['name' => 'contact__email_primary__email'],
       ['name' => ''],
     ]);
   }
@@ -548,7 +548,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => 'total_amount'],
     ];
     foreach ($data['fields'] as $field) {
-      $mappings[] = ['name' => $field === 'custom' ? $this->getCustomFieldName() : $field];
+      $mappings[] = ['name' => $field === 'custom' ? ('contact.' . $this->getCustomFieldName('text', 4)) : $field];
     }
     $this->submitDataSourceForm('contributions.csv', ['onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP]);
     $form = $this->getMapFieldForm([
@@ -597,12 +597,12 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => ''],
       ['name' => 'receive_date'],
       ['name' => 'financial_type_id'],
-      ['name' => 'email_primary.email'],
+      ['name' => 'contact.email_primary.email'],
       ['name' => ''],
       ['name' => ''],
       ['name' => 'trxn_id'],
       ['name' => 'campaign_id'],
-      ['name' => 'contribution_contact_id'],
+      ['name' => 'contact_id'],
     ];
     // First we try to create without total_amount mapped.
     // It will fail in create mode as total_amount is required for create.
@@ -845,7 +845,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       'financial_type_id:name' => 'Event Fee',
     ]);
     $mapping = [
-      ['name' => 'contribution_id'],
+      ['name' => 'id'],
       ['name' => 'invoice_id'],
       ['name' => 'trxn_id'],
       ['name' => ''],

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -110,7 +110,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => 'total_amount'],
       ['name' => 'receive_date'],
       ['name' => 'financial_type_id'],
-      ['name' => 'external_identifier'],
+      ['name' => 'contact.external_identifier'],
       ['name' => 'soft_credit.contact.external_identifier', 'soft_credit_type_id' => 1],
       ['name' => 'note'],
     ];
@@ -178,7 +178,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => 'financial_type_id'],
       ['name' => ''],
       ['name' => ''],
-      ['name' => 'email_primary.email'],
+      ['name' => 'contact.email_primary.email'],
       ['name' => 'soft_credit.contact.email_primary.email', 'soft_credit_type_id' => 1],
     ];
     $this->importCSV('contributions_amount_validate.csv', $mapping, ['onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP]);
@@ -270,7 +270,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       // Note that default_value is supported via the parser and the angular form
       // but there is no way to enter it on the quick form.
       ['name' => 'financial_type_id', 'default_value' => 'Donation'],
-      ['name' => 'source'],
+      ['name' => 'contact.source'],
       ['name' => 'receive_date'],
       ['name' => 'external_identifier'],
       ['name' => 'soft_credit.contact.email_primary.email', 'entity_data' => ['soft_credit' => ['soft_credit_type_id' => 5]]],
@@ -634,7 +634,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => ''],
       ['name' => ''],
       ['name' => ''],
-      ['name' => 'contribution_source'],
+      ['name' => 'source'],
       ['name' => 'trxn_id'],
       ['name' => 'campaign_id'],
     ];
@@ -660,7 +660,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => ''],
       ['name' => 'receive_date'],
       ['name' => 'financial_type_id'],
-      ['name' => 'email_primary.email'],
+      ['name' => 'contact.email_primary.email'],
       ['name' => ''],
       ['name' => ''],
       ['name' => 'trxn_id'],
@@ -852,7 +852,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => 'total_amount'],
       ['name' => 'receive_date'],
       ['name' => 'financial_type_id'],
-      ['name' => 'source'],
+      ['name' => 'contact.source'],
       ['name' => ''],
     ];
     $this->importCSV('contributions_update.csv', $mapping, ['onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE]);
@@ -934,12 +934,12 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
    */
   private function importContributionsDotCSV(array $submittedValues = []): CRM_Import_DataSource_CSV {
     $this->importCSV('contributions.csv', [
-      ['name' => 'first_name'],
+      ['name' => 'contact.first_name'],
       ['name' => 'total_amount'],
       ['name' => 'receive_date'],
       ['name' => 'financial_type_id'],
-      ['name' => 'email_primary.email'],
-      ['name' => 'contribution_source'],
+      ['name' => 'contact.email_primary.email'],
+      ['name' => 'source'],
       ['name' => 'note'],
       ['name' => 'trxn_id'],
     ], $submittedValues);

--- a/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
@@ -118,8 +118,7 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
   protected function getMapperFromFieldMappings(array $mappings): array {
     $mapper = [];
     foreach ($mappings as $mapping) {
-      $fieldInput = [$mapping['name']];
-      $mapper[] = $fieldInput;
+      $mapper[] = $mapping['name'];
     }
     return $mapper;
   }
@@ -135,7 +134,7 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
     $this->importCSV('participant_with_ext_id.csv', [
       ['name' => 'event_id'],
       ['name' => 'do_not_import'],
-      ['name' => 'external_identifier'],
+      ['name' => 'contact.external_identifier'],
       ['name' => 'fee_amount'],
       ['name' => 'fee_currency'],
       ['name' => 'fee_level'],
@@ -228,7 +227,7 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
     $this->importCSV('participant_with_ext_id.csv', [
       ['name' => 'event_id'],
       ['name' => 'do_not_import'],
-      ['name' => 'external_identifier'],
+      ['name' => 'contact.external_identifier'],
       ['name' => 'fee_amount'],
       ['name' => 'fee_currency'],
       ['name' => 'fee_level'],
@@ -274,7 +273,7 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
     $this->importCSV('participant_with_ext_id.csv', [
       ['name' => 'event_id'],
       ['name' => 'do_not_import'],
-      ['name' => 'external_identifier'],
+      ['name' => 'contact.external_identifier'],
       ['name' => 'fee_amount'],
       ['name' => 'fee_currency'],
       ['name' => 'fee_level'],
@@ -319,7 +318,7 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
     $this->importCSV('participant_with_ext_id.csv', [
       ['name' => 'event_id'],
       ['name' => 'do_not_import'],
-      ['name' => 'external_identifier'],
+      ['name' => 'contact.external_identifier'],
       ['name' => 'fee_amount'],
       ['name' => 'fee_currency'],
       ['name' => 'fee_level'],
@@ -365,9 +364,9 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
     $this->individualCreate([$this->getCustomFieldName() => 'secret code', 'first_name' => 'Bob', 'last_name' => 'Smith'], 'bob');
     $this->importCSV('participant_with_dedupe_match.csv', [
       ['name' => 'event_id'],
-      ['name' => 'first_name'],
-      ['name' => 'last_name'],
-      ['name' => $this->getCustomFieldName('text', 4)],
+      ['name' => 'contact.first_name'],
+      ['name' => 'contact.last_name'],
+      ['name' => 'contact.' . $this->getCustomFieldName('text', 4)],
       ['name' => 'role_id'],
       ['name' => 'status_id'],
       ['name' => 'register_date'],
@@ -393,8 +392,8 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
       ['name' => 'event_id'],
       ['name' => 'participant_id'],
       ['name' => 'contact_id'],
-      ['name' => 'external_identifier'],
-      ['name' => 'email_primary.email'],
+      ['name' => 'contact.external_identifier'],
+      ['name' => 'contact.email_primary.email'],
       ['name' => 'status_id'],
     ];
     foreach ($mapper as $index => $field) {
@@ -412,8 +411,8 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
   public function requiredFields(): array {
     return [
       'contact_id' => [['contact_id', 'status_id', 'event_id']],
-      'external_identifier' => [['external_identifier', 'status_id', 'event_id']],
-      'email' => [['email_primary.email', 'status_id', 'event_id']],
+      'external_identifier' => [['contact.external_identifier', 'status_id', 'event_id']],
+      'email' => [['contact.email_primary.email', 'status_id', 'event_id']],
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5791 Address rc regression on handling ambigous 'source' in contribution import 

 https://lab.civicrm.org/dev/core/-/issues/5791

Before
----------------------------------------
both `source` and `contribution_source` mapped to `contribution.source`

After
----------------------------------------
Switched to `contact.source` and `source` via upgrade, correctly mapped

Technical Details
----------------------------------------
Switching in upgrade is inline with the activity import and the rc is the release we will be 'testing in production' - but it would be better to convert `contribution_id` to `id` and `contribution_contact_id` to `contact_id` in keeping with 'use apiv4 style with no prefix for the base entity. I'm of two minds as to whether to do this as well - mostly because I think if we do then WMF will test it in production but if we leave to next month's rc it might get less pre-release testing

Comments
----------------------------------------

