### PR TITLE
EntityTag - Remove redundant deletes already handled by hook

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -877,14 +877,6 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
         $deleteParams = ['id' => $activityId];
         $moveToTrash = CRM_Case_BAO_Case::isCaseActivity($activityId);
         CRM_Activity_BAO_Activity::deleteActivity($deleteParams, $moveToTrash);
-
-        // delete tags for the entity
-        $tagParams = [
-          'entity_table' => 'civicrm_activity',
-          'entity_id' => $activityId,
-        ];
-
-        CRM_Core_BAO_EntityTag::del($tagParams);
       }
 
       CRM_Core_Session::setStatus(

--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -364,12 +364,6 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
         $statusMsg = ts("Selected Activity cannot be deleted.");
       }
 
-      $tagParams = [
-        'entity_table' => 'civicrm_activity',
-        'entity_id' => $this->_activityId,
-      ];
-      CRM_Core_BAO_EntityTag::del($tagParams);
-
       CRM_Core_Session::setStatus('', $statusMsg, 'info');
       return;
     }

--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -255,13 +255,6 @@ class CRM_Core_BAO_File extends CRM_Core_DAO_File implements \Civi\Core\HookInte
 
     if (!empty($cfIDs)) {
       foreach ($cfIDs as $fileID => $fUri) {
-        $tagParams = [
-          'entity_table' => 'civicrm_file',
-          'entity_id' => $fileID,
-        ];
-        // Delete tags from entity tag table.
-        CRM_Core_BAO_EntityTag::del($tagParams);
-
         // sequentially deletes EntityFile entry and then deletes File record
         CRM_Core_DAO_EntityFile::deleteRecord(['id' => $cefIDs[$fileID]]);
         // Delete file only if there are no longer any entities using this file.


### PR DESCRIPTION
Overview
----------------------------------------
In 9d4c4ffd82a9db747fb10e9f15c8bf3e818a0c13 a hook was added to automatically delete entityTag records when the parent record was deleted. However there was still some redundant coupling hanging around, so I removed it and added a test to ensure it wasn't needed.