### PR TITLE
Queue.run API - Log an alert for unhandled exceptions

### DIFF
--- a/Civi/Api4/Action/Queue/Run.php
+++ b/Civi/Api4/Action/Queue/Run.php
@@ -101,6 +101,7 @@ class Run extends \Civi\Api4\Generic\AbstractAction {
       catch (\Throwable $t) {
         $errors++;
         $message = sprintf('Queue-item raised unhandled exception (%s: %s)', get_class($t), $t->getMessage());
+        \Civi::log('queue')->alert($message, ['subject' => 'Queue-item raised unhandled exception (' . get_class($t)]);
         break;
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Queue.run API - Log an alert for unhandled exceptions 

Before
----------------------------------------
When an exception is unhandled it has hard to see that it has happened

After
----------------------------------------
Details are now logged  - sites that use the [`monolog` extension](https://civicrm.org/extensions/replace-core-logging-monolog) can leverage these to receive emails should they wish

Technical Details
----------------------------------------
https://chat.civicrm.org/civicrm/pl/895jq1wmapdype51pnjixb3eda

Comments
----------------------------------------

