### PR TITLE
dev/core#5295 🪲 🇫🇯 📅 Form Builder / Afform: Date elements have the wrong default value between midnight and UTC offset

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -407,7 +407,11 @@
             offset *= 365;
         }
         let newDate = new Date(baseDate.getTime() + offset * 24 * 60 * 60 * 1000);
-        let defaultDate = newDate.toISOString().split('T')[0];
+        let localYear = newDate.getFullYear();
+        let localMonth = String(newDate.getMonth() + 1).padStart(2, '0'); // Months are 0-indexed
+        let localDay = String(newDate.getDate()).padStart(2, '0');
+        let defaultDate = `${localYear}-${localMonth}-${localDay}`; // Format YYYY-MM-DD
+
         if (includeTime) {
           defaultDate += ' ' + newDate.toTimeString().slice(0,8);
         }


### PR DESCRIPTION
issues/5295 Form Builder / Afform: Date elements have the wrong default value between midnight and UTC offset

Overview
----------------------------------------
Relative date in default values use Javascript Date.prototype.toISOString() to get yyyy-mm-dd format, causing all defaults to be in UTC, but submitted as though they are not.

When the form is loaded inside the TZ offset of the user’s browser timezone, the date will be offset by 1 day in the form, and submitted as such.

Read more at https://lab.civicrm.org/dev/core/-/issues/5295

Before
----------------------------------------

Steps to reproduce:

1. Be in Fiji / set your computer's timezone to Pacific/Fiji; this gives you 12 hours of incorrectness for the purposes of example – although any offset exhibits the same behaviour.
2. Create a form with a date field, with default set to relative date \[now\]. Do not include time.
3. Load the form at any time before noon.
4. Note that the date in the field is yesterday.

After
----------------------------------------

Repeat same steps. Correct date shown and recorded.

Technical Details
----------------------------------------


Comments
----------------------------------------

Agileware Ref: SUP-72298 and CIVICRM-2256