### PR TITLE
Catch throwable (e.g typehint) in queue handler

### DIFF
--- a/CRM/Queue/BasicHandlerTrait.php
+++ b/CRM/Queue/BasicHandlerTrait.php
@@ -118,7 +118,7 @@ trait CRM_Queue_BasicHandlerTrait {
         $this->runItem($item, $queue);
         $outcome = 'ok';
       }
-      catch (\Exception $e) {
+      catch (Throwable $e) {
         $outcome = $queue->getSpec('error');
         $exception = $e;
       }


### PR DESCRIPTION
Overview
----------------------------------------
Catch throwable (e.g typehint) in queue handler

Before
----------------------------------------
Type Hint errors result in queue items failing & being retried etc but the exception is not available to the `queueError` hook

After
----------------------------------------
The exception is availble

Technical Details
----------------------------------------
[You asked!](https://chat.civicrm.org/civicrm/pl/895jq1wmapdype51pnjixb3eda)

Comments
----------------------------------------

