### PR TITLE
Qf search icon

### DIFF
--- a/ext/afform/admin/ang/afAdmin/afAdminList.html
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.html
@@ -12,7 +12,7 @@
 
   <div class="form-inline">
     <label for="afform-list-filter">{{:: ts('Filter:') }}</label>
-    <input class="form-control" type="search" id="afform-list-filter" ng-model="$ctrl.searchAfformList" placeholder="&#xf002">
+    <input class="form-control" type="search" id="afform-list-filter" ng-model="$ctrl.searchAfformList" placeholder="&#x1f50d;">
     <div class="btn-group pull-right" ng-if="types[$ctrl.tab].options !== false" af-gui-menu>
       <a ng-if="types[$ctrl.tab].default" ng-href="{{ types[$ctrl.tab].default }}" class="btn btn-primary">
         {{ ts('New %1', {1: types[$ctrl.tab].label }) }}
@@ -23,7 +23,7 @@
       </button>
       <ul class="dropdown-menu" ng-if="menu.open">
         <li ng-class="{disabled: !types[$ctrl.tab].options || !types[$ctrl.tab].options.length}">
-          <input ng-if="types[$ctrl.tab].options && types[$ctrl.tab].options.length" type="search" class="form-control" placeholder="&#xf002" ng-model="searchCreateLinks.label">
+          <input ng-if="types[$ctrl.tab].options && types[$ctrl.tab].options.length" type="search" class="form-control" placeholder="&#x1f50d;" ng-model="searchCreateLinks.label">
           <a href ng-if="!types[$ctrl.tab].options"><i class="crm-i fa-spinner fa-spin"></i></a>
           <a href ng-if="types[$ctrl.tab].options && !types[$ctrl.tab].options.length">{{:: ts('None Found') }}</a>
         </li>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditorPalette.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditorPalette.html
@@ -41,7 +41,7 @@
         </a>
         <ul class="dropdown-menu" ng-if="menu.open">
           <li ng-class="{disabled: !editor.searchOptions || !editor.searchOptions.length}">
-            <input ng-if="editor.searchOptions && editor.searchOptions.length" type="search" class="form-control" placeholder="&#xf002" ng-model="searchDisplayListFilter.label">
+            <input ng-if="editor.searchOptions && editor.searchOptions.length" type="search" class="form-control" placeholder="&#x1f50d;" ng-model="searchDisplayListFilter.label">
             <a href ng-if="!editor.searchOptions"><i class="crm-i fa-spinner fa-spin"></i></a>
             <a href ng-if="editor.searchOptions && !editor.searchOptions.length">{{:: ts('None Found') }}</a>
           </li>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.html
@@ -33,7 +33,7 @@
   <fieldset class="af-gui-entity-palette">
     <legend class="form-inline">
       {{:: ts('Add:') }}
-      <input ng-model="controls.fieldSearch" ng-change="$ctrl.buildPaletteLists()" class="form-control" type="search" placeholder="&#xf002" title="{{:: ts('Search fields') }}" />
+      <input ng-model="controls.fieldSearch" ng-change="$ctrl.buildPaletteLists()" class="form-control" type="search" placeholder="&#x1f50d;" title="{{:: ts('Search fields') }}" />
     </legend>
     <div class="af-gui-entity-palette-select-list">
       <div ng-if="elementList.length">

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
@@ -38,7 +38,7 @@
   <fieldset class="af-gui-entity-palette">
     <legend class="form-inline">
       {{:: ts('Add:') }}
-      <input ng-model="controls.fieldSearch" ng-change="$ctrl.buildPaletteLists()" class="form-control" type="search" placeholder="&#xf002" title="{{:: ts('Search fields') }}" />
+      <input ng-model="controls.fieldSearch" ng-change="$ctrl.buildPaletteLists()" class="form-control" type="search" placeholder="&#x1f50d;" title="{{:: ts('Search fields') }}" />
     </legend>
     <div class="af-gui-entity-palette-select-list">
       <div ng-if="elementList.length">

--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -417,7 +417,7 @@
           label = $selection.parent().text(),
           // Set name because the mini-form submits directly to adv search
           value = $selection.data('advSearchLegacy') || $selection.val();
-        $('#crm-qsearch-input').attr({name: value, placeholder: '\uf002 ' + label, title: label});
+        $('#crm-qsearch-input').attr({name: value, placeholder: '\ud83d\udd0d ' + label, title: label});
       }
       $('.crm-quickSearchField').click(function() {
         var input = $('input', this);
@@ -466,7 +466,7 @@
         '<a href="#"> ' +
           '<form action="<%= CRM.url(\'civicrm/contact/search/advanced\') %>" name="search_block" method="post">' +
             '<div>' +
-              '<input type="text" id="crm-qsearch-input" name="sort_name" placeholder="\uf002" accesskey="q" />' +
+              '<input type="text" id="crm-qsearch-input" name="sort_name" placeholder="\ud83d\udd0d" accesskey="q" />' +
               '<input type="hidden" name="hidden_location" value="1" />' +
               '<input type="hidden" name="hidden_custom" value="1" />' +
               '<input type="hidden" name="qfKey" />' +

--- a/js/jquery/jquery.crmIconPicker.js
+++ b/js/jquery/jquery.crmIconPicker.js
@@ -112,7 +112,7 @@
         function displayDialog() {
           dialog.append(
             '<div class="icon-ctrls crm-clearfix">' +
-            '<input class="crm-form-text" name="search" placeholder="&#xf002"/>' +
+            '<input class="crm-form-text" name="search" placeholder="&#x1f50d;"/>' +
             '<select class="crm-form-select"></select>' +
             // Add "No Icon" button unless field is required
             ($input.is('[required]') ? '' : '<button type="button" class="cancel" title=""><i class="crm-i fa-ban" aria-hidden="true"></i> ' + ts('No icon') + '</button>') +


### PR DESCRIPTION
Overview
----------------------------------------

Fix for 
https://lab.civicrm.org/dev/core/-/issues/5789



Before
----------------------------------------

- fl ligature used in place of magnifying glass - meaninless to screenreader
- magnifying glass not displaying properly on quicksearch and elsewhere.

![sceenshot showing wrong icon in quicksearch box](https://github.com/user-attachments/assets/9574aad6-5f2f-4e34-8680-947c2e33e20f)

![screenshot showing form builder problem](https://github.com/user-attachments/assets/f77994f1-3dee-4b32-9606-662b4683d09b)



After
----------------------------------------

- replaced fl ligature with emoji magnifying glass. 
- fixed RiverLea CSS that prevents fa icon font working.

![screenshot showing magnifying glass icon in quicksearch](https://github.com/user-attachments/assets/14cc2af8-74b0-4288-bc39-86dfbf6e37ad)

![screenshot showing fixed icon](https://github.com/user-attachments/assets/0c3c8c9e-b72c-46f4-aeba-96b86ea46d6e)

Interestingly (I'm using that word in respect of the likely audience), the following screenshot of the icon picker looks right, but it already looked right. But now it's rendered with 🔍 not .
![image](https://github.com/user-attachments/assets/d6644aa2-71d9-4b2b-8af8-2b22f4c240c3)



Technical notes:

- I also corrected HTML numeric entities lacking a trailing ; 
- Interestingly (that word again), in Javascript we have to specify the magnifying glass using two consecutive `\unnnn` codes.