### PR TITLE
Events: further simplify messaging when registration requires approval

### DIFF
--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -18,7 +18,7 @@
         {ts}Please verify your information.{/ts} <strong>{ts}If space becomes available you will receive an email with a link to complete your registration.{/ts}</strong>
         {ts 1=$register}Click <strong>%1</strong> to be added to the WAIT LIST for this event.{/ts}
     {elseif $isRequireApproval}
-        {ts}Please verify your information.{/ts} <strong>{ts}Once approved, you will receive an email with a link to complete the registration process.{/ts}</strong>
+        {ts}Please verify your information.{/ts}
         {ts 1=$register}Click <strong>%1</strong> to submit your registration for approval.{/ts}
     {else}
         {ts}Please verify your information.{/ts}

--- a/templates/CRM/Event/Form/Registration/ThankYou.tpl
+++ b/templates/CRM/Event/Form/Registration/ThankYou.tpl
@@ -41,8 +41,7 @@
              </p>
         {elseif $isRequireApproval}
             <p>
-                <span class="bold">{ts}Your registration has been submitted.{/ts}
-                {ts}Once your registration has been reviewed, you will receive an email with a link to a web page where you can complete the registration process.{/ts}</span>
+                <span class="bold">{ts}Your registration has been submitted.{/ts}</span>
             </p>
         {elseif $is_pay_later and $paidEvent and !$isAmountzero}
             <div class="bold">{$pay_later_receipt}</div>


### PR DESCRIPTION
Overview
----------------------------------------

When an event requires registration approval, the message does not make sense for free events, and overall the message makes too many assumptions about the next steps. The instructions can be in the Thank You message editable by admins.

See also: https://civicrm.stackexchange.com/q/33250/39

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/70a73813-1944-4130-8385-11c44d788400)

![image](https://github.com/user-attachments/assets/bf0f2a26-7afa-4ff4-89ac-1047d16c9738)


After
----------------------------------------

Message removed.

Comments
----------------------------------------

This is an old issue first reported 5 years ago, and some simplifications have happened since then, but it was raised again recently on the chat (spark channel, https://chat.civicrm.org/civicrm/pl/3p6kn1y17bnujxs1wz4ca47uwr).

cc @mattwire any objections? (I noticed you had previously done some cleanup here)