### PR TITLE
RiverLea 1.4.1: inline data fields, contact dashboard prev/next on WP, .crm-buttons

### DIFF
--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.4.0-6.2alpha
+ - FIXED - right-align of event participant contact details removed (https://lab.civicrm.org/extensions/riverlea/-/issues/119).
+ - FIXED - FormBuilder left tabs squash and become illegible when too many items (https://lab.civicrm.org/extensions/riverlea/-/issues/116)
+ - CHANGED - only bottom align delete button when there are a limited number of custom activities (default list plus up to three more custom activities), otherwise keep inline (https://lab.civicrm.org/extensions/riverlea/-/issues/117#note_178676)
+
 1.3.8-6.0alpha
  - FIXED - solves various issues around the naming of crm-text-light and crm-text-dark (https://github.com/civicrm/civicrm-core/pull/31994);
  - FIXED - Bootstrap Time input fields limit width, not 100%.

--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -1,7 +1,12 @@
+1.4.1-6.2alpha
+ - FIXED - start/end date appears inline (https://lab.civicrm.org/extensions/riverlea/-/issues/120)
+ - FIXED - float of prev/next on contact dashboard on WordPress in some contexts (https://lab.civicrm.org/extensions/riverlea/-/issues/118).
+ - ADDED - new multi-buttons wrapper `.crm-buttons` to provide uniform gap and wrap around multiple buttons, as no other class provides this - and instead it's handled on a case-by-case basis which is a waste of css. Not used anywhere currently, but referenced in discussion: https://github.com/civicrm/civicrm-core/pull/32344 & https://lab.civicrm.org/extensions/riverlea/-/issues/101.
+
 1.4.0-6.2alpha
  - FIXED - right-align of event participant contact details removed (https://lab.civicrm.org/extensions/riverlea/-/issues/119).
  - FIXED - FormBuilder left tabs squash and become illegible when too many items (https://lab.civicrm.org/extensions/riverlea/-/issues/116)
- - CHANGED - only bottom align delete button when there are a limited number of custom activities (default list plus up to three more custom activities), otherwise keep inline (https://lab.civicrm.org/extensions/riverlea/-/issues/117#note_178676)
+ - CHANGED - only bottom align delete button when there are a limited number of custom activities (default list plus up to three more custom activities), otherwise keep inline (https://lab.civicrm.org/extensions/riverlea/-/issues/117)
 
 1.3.8-6.0alpha
  - FIXED - solves various issues around the naming of crm-text-light and crm-text-dark (https://github.com/civicrm/civicrm-core/pull/31994);

--- a/ext/riverlea/README.md
+++ b/ext/riverlea/README.md
@@ -17,6 +17,7 @@ Overwriting CSS variables for the front is straightforward (they can be nested w
 
 ## [Changelog](CHANGELOG.md)
 
+- 1.4.x-6.2.alpha - ongoing fixes/changes against 6.2
 - 1.3.x-6.0.alpha - Contrast ratios, responsive and Front-end changes, including new variables, plus fixes (see changelog)
 - 1.2.x-5.81 - Regression fixes against 5.81 RC
 - 1.1 (5.80) - Release for packaging with CiviCRM core, v5.80

--- a/ext/riverlea/core/css/_cms.css
+++ b/ext/riverlea/core/css/_cms.css
@@ -157,7 +157,7 @@ body.wp-admin .crm-container input:not([type=checkbox]):not([type=radio]):not(.c
 }
 body.wp-admin .crm-container p,
 body.wp-admin .crm-container li {
-  margin: 0; /* resets WP li bottom margin */
+  margin-bottom: 0; /* resets WP li bottom margin */
   list-style: none;
   white-space: inherit;
 }

--- a/ext/riverlea/core/css/_core.css
+++ b/ext/riverlea/core/css/_core.css
@@ -4,5 +4,5 @@
    can be merged later. */
 
 @import url(components/_accordion.css); @import url(components/_alerts.css); @import url(components/_buttons.css); @import url(components/_form.css); @import url(components/_icons.css); @import url(components/_nav.css); @import url(components/_tabs.css); @import url(components/_dropdowns.css); @import url(components/_tables.css); @import url(components/_dialogs.css); @import url(components/_page.css); @import url(components/_components.css); @import url(components/_front.css); :root {
-  --crm-release: '1.4.0-6.2alpha';
+  --crm-release: '1.4.1-6.2alpha';
 }

--- a/ext/riverlea/core/css/_core.css
+++ b/ext/riverlea/core/css/_core.css
@@ -4,5 +4,5 @@
    can be merged later. */
 
 @import url(components/_accordion.css); @import url(components/_alerts.css); @import url(components/_buttons.css); @import url(components/_form.css); @import url(components/_icons.css); @import url(components/_nav.css); @import url(components/_tabs.css); @import url(components/_dropdowns.css); @import url(components/_tables.css); @import url(components/_dialogs.css); @import url(components/_page.css); @import url(components/_components.css); @import url(components/_front.css); :root {
-  --crm-release: '1.3.8-6.0alpha';
+  --crm-release: '1.4.0-6.2alpha';
 }

--- a/ext/riverlea/core/css/_fixes.css
+++ b/ext/riverlea/core/css/_fixes.css
@@ -567,9 +567,6 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
   background: transparent;
   padding: 0;
 }
-.crm-case-activity-form-block-followup_activity_type_id .crm-form-date-wrapper {
-  display: inline-block;
-}
 .crm-case-activity-form-block table.form-layout-compressed {
   width: 100%;
 }

--- a/ext/riverlea/core/css/components/_buttons.css
+++ b/ext/riverlea/core/css/components/_buttons.css
@@ -297,9 +297,11 @@
 
 /* BS3 Button groups and dropdowns  */
 
-#bootstrap-theme td.text-right:has(.btn + .btn) {
+#bootstrap-theme td.text-right:has(.btn + .btn),
+.crm-container .crm-buttons {
   display: flex;
   gap: var(--crm-s);
+  flex-wrap: wrap;
 }
 #bootstrap-theme td.text-right:has(.btn + .btn) {
   justify-content: end;

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -682,7 +682,7 @@ input.crm-form-checkbox) + label {
   gap: var(--crm-xs);
 }
 .crm-form-date-wrapper {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   flex-flow: wrap;
   gap: var(--crm-flex-gap);

--- a/ext/riverlea/core/css/components/_tables.css
+++ b/ext/riverlea/core/css/components/_tables.css
@@ -95,7 +95,7 @@ table.dataTable.order-column.stripe tbody tr.extension-installed.even > .sorting
   border-right: var(--crm-table-column-border);
 }
 .crm-container table td:has(.btn-slide),
-.crm-container table td:not(.crm-case-date):has(.action-item) {
+.crm-container table:not(.crm-info-panel) td:not(.crm-case-date):has(.action-item) {
   text-align: right;
 }
 .crm-container table.crm-mailing-ab-table td:has(.action-item) {

--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -285,7 +285,7 @@ div.crm-inline-edit-form div.crm-clear {
 #crm-contact-actions-list ul a {
   display: block;
 }
-.crm-contact-crm-contact-delete {
+.crm-contact-actions-list-inner:not(:has(.crm-activity-type_6)) .crm-contact-crm-contact-delete {
   margin-top: auto;
 }
 #crm-contact-actions-list .crm-contact_activities-list select {

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -93,6 +93,7 @@
 #afGuiEditor .panel-heading ul.nav-tabs li.fluid-width-tab {
   white-space: nowrap;
   overflow: hidden;
+  max-width: unset !important; /* vs inline max-width set by Form Builder UI */
 }
 #afGuiEditor .panel-heading .form-inline.pull-right button {
   max-height: 32px;

--- a/ext/riverlea/info.xml
+++ b/ext/riverlea/info.xml
@@ -12,7 +12,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>[civicrm.releaseDate]</releaseDate>
-  <version>1.3.8-[civicrm.version]</version>
+  <version>1.4.0-[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>

--- a/ext/riverlea/info.xml
+++ b/ext/riverlea/info.xml
@@ -12,7 +12,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>[civicrm.releaseDate]</releaseDate>
-  <version>1.4.0-[civicrm.version]</version>
+  <version>1.4.1-[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>


### PR DESCRIPTION
Overview
----------------------------------------
This includes all the [changes from version 1.4.0](https://github.com/civicrm/civicrm-core/pull/32351) plus two fixes and an addition.
 - FIXED - start/end date appears inline (https://lab.civicrm.org/extensions/riverlea/-/issues/120). This has an added benefit of removing a fix in fixes.css ht @anil-circle.
 - FIXED - float of prev/next on contact dashboard on WordPress in some contexts (https://lab.civicrm.org/extensions/riverlea/-/issues/118). ht @Upperholme 
 - ADDED - new multi-buttons wrapper `.crm-buttons` to provide uniform gap and wrap around multiple buttons, as no other class provides this - and instead it's handled on a case-by-case basis which is a waste of css. Not used anywhere currently, but referenced in discussion: https://github.com/civicrm/civicrm-core/pull/32344 & https://lab.civicrm.org/extensions/riverlea/-/issues/101.

Before
----------------------------------------
**Start/end date**
![image](https://github.com/user-attachments/assets/71dd6de6-f9c7-414c-b278-9bf79f3b4911)
and in add CiviCase/Activity:
![image](https://github.com/user-attachments/assets/d3adb1a8-d9d7-4abb-a29c-50d0c7ab6144)

**WordPress prev/next**
![image](https://github.com/user-attachments/assets/83000710-e282-425a-b73b-01bf78190c38)
(there's a bigger bug displayed [here](https://lab.civicrm.org/extensions/riverlea/-/issues/118), which renders a button illegible, but I couldn't recreate it)

**Multi-buttons:**
There is no container class to put multiple buttons together with a consistent gap around them - just lots of specific code doing that, and hacks (ie adding margin around button css).

After
----------------------------------------
**Start/end date**
![image](https://github.com/user-attachments/assets/8cd360bd-b779-423b-9dfa-7263fa54118a)
and in add CiviCase/Activity
![image](https://github.com/user-attachments/assets/778bbdc4-5525-4a3a-ac69-97f51a5158e5)

Use of class when only one date or dates are stacked (on 'add event') are unaffected:
![image](https://github.com/user-attachments/assets/6f9087bd-06c9-4d15-98e9-bcecb5568dac)
![image](https://github.com/user-attachments/assets/73b70f5c-dbdd-4a38-9b74-3ba49d1a4427)

**WordPress prev/next**
![image](https://github.com/user-attachments/assets/452025cc-016f-4f07-9534-06cf4fa6ad91)

**Multi-buttons:**
There's now a new utility class `.crm-buttons` that extends an existing flexbox pattern, and adds flex-box wrap. cc @ufundo, this was inspired on from seeing the lack of gap in the Customiser buttons and realising there's not utility class to solve that. 

Comments
----------------------------------------
Apologies for including https://github.com/civicrm/civicrm-core/pull/32351 - my bad for not putting that in a branch I guess – am new to having multiple PRs open on the same files that are different versions.. but I suppose I can either merge this with both PRs, or after the other one is merged, I can rebase this?