### PR TITLE
[REF] Add in Symfony event to permit Extensions (multisite) to determ…

### DIFF
--- a/Civi/Core/Event/AclContactCacheFilledEvent.php
+++ b/Civi/Core/Event/AclContactCacheFilledEvent.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+ namespace Civi\Core\Event;
+
+ /**
+  * Class AuthorizeEvent
+  * @package Civi\API\Event
+  */
+class AclContactCacheFilledEvent extends GenericHookEvent {
+
+  /**
+   * Are we forcing building of the ACL Cache
+   * @var bool
+   */
+  public $forceBuild = FALSE;
+
+  /**
+   * Has the ACL Cache for a contact been built in the current PHP Process
+   * @var bool
+   */
+  public $aclCacheProcessed = FALSE;
+
+
+  /**
+   * Contact the ACL Cache is being built for
+   * @var int
+   */
+  public $userID;
+
+  /**
+   * Class constructor.
+   *
+   * @param string $forceBuild
+   * @param string $entiaclCacheProcessedty
+   * @param int|null $userID
+   * @param array $params
+   */
+  public function __construct($forceBuild, $aclCacheProcessed, $userID) {
+    $this->forceBuild = $forceBuild;
+    $this->aclCacheProcessed = $aclCacheProcessed;
+    $this->userID = $userID;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getHookValues() {
+    return [$this->forceBuild, $this->aclCacheProcessed, $this->userID];
+  }
+
+}


### PR DESCRIPTION
…ine if an ACL cache needs to be populated or not

Overview
----------------------------------------
This adds a Symfony event that might allow extensions such as the multisite extension to flush the ACL Contact Cache table if say a user was switching between domains.

Before
----------------------------------------
No way for extensions to determine if ACL cache needs to be rebuilt or not

After
----------------------------------------
Symfony Hook

This PR should be seen as slightly complementary but also slightly conflicting with https://github.com/civicrm/civicrm-core/pull/32371. However I think this still has some potential merit on its own. Whilst if 32371 gets accepted it might not make sense in a Multisite context anymore because the ACL Contact Cache would now be multidomain aware It might be helpful for some extensions to prevent the filling of the contact cache as well.  But am open to not continuing with this PR if people don't see there would be utility in this

ping @johntwyman @mattwire @eileenmcnaughton 