### PR TITLE
dev/core#5781 Afform - Prevent jquery validate from messing up validation

### DIFF
--- a/CRM/Core/Resources/Common.php
+++ b/CRM/Core/Resources/Common.php
@@ -201,7 +201,6 @@ class CRM_Core_Resources_Common {
       "bower_components/datatables/media/css/jquery.dataTables.min.css",
       "bower_components/jquery-validation/dist/jquery.validate.min.js",
       "bower_components/jquery-validation/dist/additional-methods.min.js",
-      "packages/jquery/plugins/jquery.ui.datepicker.validation.min.js",
       "js/Common.js",
       "js/crm.datepicker.js",
       "js/crm.ajax.js",


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5781](https://lab.civicrm.org/dev/core/-/issues/5781)

Before
----------------------------------------
If a datepicker appears on an Afform then it will mess up the entire form's validation, notably maxlength.

After
----------------------------------------
No more `datepicker.validation`... what were we even using it for?

Technical Details
----------------------------------------
This was a weird one. jQuery validate isn't supposed to kick in unless called for... however it had a back door: if a datepicker element appears on the form, then the `datepicker.validation` script would force-enable validation on the form.