### PR TITLE
Fix Membership import inline with fixes on participant, contribution

### DIFF
--- a/CRM/Custom/Import/Form/MapField.php
+++ b/CRM/Custom/Import/Form/MapField.php
@@ -5,6 +5,22 @@
  */
 class CRM_Custom_Import_Form_MapField extends CRM_Import_Form_MapField {
 
+
+  /**
+   * Does the form layer convert field names to support QuickForm widgets.
+   *
+   * (e.g) if 'yes' we swap
+   * `soft_credit.external_identifier` to `soft_credit__external_identifier`
+   * because the contribution form would break on the . as it would treat it as
+   * javascript.
+   *
+   * In the case of the custom field import the array is flatter and there
+   * is no hierarchical select so we do not need to do this.
+   *
+   * @var bool
+   */
+  protected bool $supportsDoubleUnderscoreFields = FALSE;
+
   /**
    * Get the name of the type to be stored in civicrm_user_job.type_id.
    *
@@ -39,13 +55,8 @@ class CRM_Custom_Import_Form_MapField extends CRM_Import_Form_MapField {
     // todo - this could be shared with other mapFields forms.
     $errors = [];
     if (!array_key_exists('savedMapping', $fields)) {
-      $importKeys = [];
-      foreach ($fields['mapper'] as $mapperPart) {
-        $importKeys[] = $mapperPart[0];
-      }
-
       // check either contact id or external identifier
-      if (!in_array('contact_id', $importKeys) && !in_array('external_identifier', $importKeys)) {
+      if (!in_array('contact_id', $fields['mapper']) && !in_array('external_identifier', $fields['mapper'])) {
         if (!isset($errors['_qf_default'])) {
           $errors['_qf_default'] = '';
         }

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -311,7 +311,6 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     }
     $sel1 = $this->_mapperFields;
 
-    $js = "<script type='text/javascript'>\n";
     $formName = 'document.forms.' . $this->_name;
 
     foreach ($this->getColumnHeaders() as $i => $columnHeader) {
@@ -326,9 +325,6 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
           }
         }
         else {
-          // this load section to help mapping if we ran out of saved columns when doing Load Mapping
-          $js .= "swapOptions($formName, 'mapper[$i]', 0, 3, 'hs_mapper_" . $i . "_');\n";
-
           if ($hasHeaders) {
             $defaults["mapper[$i]"] = [$this->defaultFromHeader($columnHeader, $headerPatterns)];
           }

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -260,13 +260,13 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
           ->addOrderBy('title')
           ->execute()->indexBy('name');
 
-      $contactFields = $this->getContactFields($this->getContactType());
-      $fields['contact_id'] = $contactFields['id'];
+      $contactFields = $this->getContactFields($this->getContactType(), 'contact');
+      $fields['contact_id'] = $contactFields['contact.id'];
       $fields['contact_id']['match_rule'] = '*';
       $fields['contact_id']['entity'] = 'Contact';
       $fields['contact_id']['html']['label'] = $fields['contact_id']['title'];
       $fields['contact_id']['title'] .= ' ' . ts('(match to contact)');
-      unset($contactFields['id']);
+      unset($contactFields['contact.id']);
       $fields += $contactFields;
       Civi::cache('fields')->set('membership_importable_fields' . $contactType, $fields);
     }

--- a/tests/phpunit/CRM/Custom/Import/Parser/ApiTest.php
+++ b/tests/phpunit/CRM/Custom/Import/Parser/ApiTest.php
@@ -52,6 +52,19 @@ class CRM_Custom_Import_Parser_ApiTest extends CiviUnitTestCase {
   }
 
   /**
+   * @param array $mappings
+   *
+   * @return array
+   */
+  protected function getMapperFromFieldMappings(array $mappings): array {
+    $mapper = [];
+    foreach ($mappings as $mapping) {
+      $mapper[] = $mapping['name'];
+    }
+    return $mapper;
+  }
+
+  /**
    * Get the import's datasource form.
    *
    * Defaults to contribution - other classes should override.


### PR DESCRIPTION

Overview
----------------------------------------
This is the same as the recently-merged-to-rc fix to the Membership & Contribution import. In discussion with @colemanw I went from aligning the fields to

first_name => contact.first_name

to

contact.first_name => first_name
as I worked through updating these imports to apiv4 - but some of the ones I did first didn't get the memo so Im going back & re-testing / aligning them all. The only outlier is the contact import which still uses apiv3 - primarily because I need to check what actually happens when the key 'address' is passed (via apiv3) to Contact.create & in particular does it ? replace, add to , update? existing addresses which it matches by location / is_primary

Before
----------------------------------------
The field `email` is converted to `contact.email_primary.email` in the saved mapping - but it does not load properly as a default

After
----------------------------------------
Now it does

Technical Details
----------------------------------------

Comments
----------------------------------------
