### PR TITLE
dev/core#5716 Fix Regression with CheckBox custom fields not respecti…

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -813,10 +813,18 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
           // TODO: I'm not sure if this is supposed to exclude whatever might be
           // in $field->attributes (available in array format as
           // $fieldAttributes).  Leaving as-is for now.
-          $check[] = &$qf->addElement('advcheckbox', $v, NULL, $l, $customFieldAttributes);
+          if ($field->options_per_line) {
+            $customFieldAttributes['options_per_line'] = $field->options_per_line;
+          }
+          $check[] = &$qf->addElement('advcheckbox_with_div', $v, NULL, $l, $customFieldAttributes);
         }
-
-        $group = $element = $qf->addGroup($check, $elementName, $label);
+        if ($field->options_per_line) {
+          $group = $element = $qf->addElement('group_with_div', $elementName, $label, $check, '', TRUE);
+          $group->setAttribute('options_per_line', $field->options_per_line);
+        }
+        else {
+          $group = $element = $qf->addGroup($check, $elementName, $label);
+        }
         $optionEditKey = 'data-option-edit-path';
         if (isset($customFieldAttributes[$optionEditKey])) {
           $group->setAttribute($optionEditKey, $customFieldAttributes[$optionEditKey]);

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -392,6 +392,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $this->_action = (int) $action;
     $this->registerElementType('radio_with_div', 'CRM/Core/QuickForm/RadioWithDiv.php', 'CRM_Core_QuickForm_RadioWithDiv');
     $this->registerElementType('group_with_div', 'CRM/Core/QuickForm/GroupWithDiv.php', 'CRM_Core_QuickForm_GroupWithDiv');
+    $this->registerElementType('advcheckbox_with_div', 'CRM/Core/QuickForm/AdvCheckBoxWithDiv.php', 'CRM_Core_QuickForm_AdvCheckBoxWithDiv');
     $this->registerRules();
 
     // let the constructor initialize this, should happen only once

--- a/CRM/Core/QuickForm/AdvCheckBoxWithDiv.php
+++ b/CRM/Core/QuickForm/AdvCheckBoxWithDiv.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * @package CRM
+ */
+
+require_once 'HTML/QuickForm/advcheckbox.php';
+
+/**
+ * Class CRM_Core_QuickForm_AdvCheckBoxWithDiv
+ */
+class CRM_Core_QuickForm_AdvCheckBoxWithDiv extends HTML_QuickForm_advcheckbox {
+
+  /**
+   * Returns the advcheckbox element in HTML
+   *
+   * @since     1.0
+   * @access    public
+   * @return    string
+   */
+  public function toHtml(): string {
+    $html = parent::toHtml();
+    if (is_numeric($this->getAttribute('options_per_line'))) {
+      return '<div class="crm-option-label-pair" >' . $html . '</div>';
+    }
+    return $html;
+  }
+
+}


### PR DESCRIPTION
…ng the options per line setting

Overview
----------------------------------------
If you create a cusotm field of type checkbox that has options_per_line set that setting is not resepected when the field is added to a Profile and shown on Event Registration / Contribution Pages. 

Before
----------------------------------------
Options Per Line setting not respected for checkbox custom fields

After
----------------------------------------
Options per line setting respected

Technical Details
----------------------------------------
I believe this is a regression from https://github.com/civicrm/civicrm-core/pull/31706  as this div being removed https://github.com/civicrm/civicrm-core/pull/31706/files#diff-6848a25bfee634154a321db3c9c9125345b96609e62dcf7155ecbdd4d4fe4f64L33 affected both Radios and Checkboxes

ping @eileenmcnaughton @Edzelopez @vingle @artfulrobot 