### PR TITLE
RiverLea Thames Dark Mode / Extensions colour fix

### DIFF
--- a/ext/riverlea/streams/thames/css/_dark.css
+++ b/ext/riverlea/streams/thames/css/_dark.css
@@ -11,6 +11,7 @@
   --crm-c-code-background: var(--crm-c-dkblue-04);
   --crm-dashlet-bg: var(--crm-c-dkblue-02);
   --crm-c-green: #335417;
+  --crm-c-green-light: var(--crm-c-green);
   --crm-c-link: var(--crm-c-dkblue-08);
   --crm-c-link-hover: color-mix(in srgb, white, var(--crm-c-dkblue-08) 70%);
   --crm-dash-header-col: var(--crm-c-blue-light);


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a regression caused by https://github.com/civicrm/civicrm-core/pull/31994. I tested that PR and made a bunch of changes to regressions in https://github.com/civicrm/civicrm-core/pull/32209, but hadn't tested Extensions layout in Thames dark-mode, so am adding this. @artfulrobot feel free to change/resubmit your own, trying to be helpful here.

I'm going for the simplest fix - change bg to be dark, using a shade of green used elsewhere in Thames/DarkMode. 

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/c186459e-1e28-4fb7-8238-4c0aa91cedf7)

After
----------------------------------------
![image](https://github.com/user-attachments/assets/1ea6d73f-0604-47ec-81aa-b48b417ad8ee)

Technical Details
----------------------------------------
The important question for a reviewer: does this new CSS variable create other regressions in the theme? The answer is a little complex: there are two instances in RiverLea core which are direct ports of Bootstrap css but with RL variables, where this would create a contrast clash between FG and BG colours:
 - `#bootstrap-theme .has-success .input-group-addon` in `_bootsstrap.css` line 1808
 - `.crm-container .panel-success > .panel-heading` in `_components.css` line 278. 
 
So because these aren't used in Civi core *as far as I am aware* I think this is safe, especially as this only impacts dark mode for one stream. However, because some extensions might use those classes now or in the future - these should be adjusted BUT the fix a) would need a bit of testing across all streams as it's a change to RiverLea core; and b) overlaps with a structural change @ufundo and I have discussed about being more rigorous with bg and foreground text colours existing in pairs, so it becomes very hard to end up with these kinds of contrast ratio clashes (which will only increase as more streams  + customisations emerge). 

So I would recommend merging this as it fixes a common screen that's currently not readable, and I will try to tackle the two potential colour ratio clashes in a future PR perhaps with the wider bg/fg contrast ratio pair cleanup.
