### PR TITLE
Upgrades - Port civicrm-upgrade-test to PHPUnit

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -692,6 +692,9 @@ class Container {
     $bootServices['lockManager'] = self::createLockManager();
 
     if ($loadFromDB && $runtime->dsn) {
+      if (defined('CIVICRM_BOOTSTRAP_FORBIDDEN')) {
+        throw new \LogicException("This process should not bootstrap CiviCRM. (CIVICRM_BOOTSTRAP_FORBIDDEN)");
+      }
       \CRM_Core_DAO::init($runtime->dsn);
       $bootServices['settings_manager']->dbAvailable();
       \CRM_Utils_Hook::singleton(TRUE);

--- a/Civi/Test/Exception/ProcessErrorException.php
+++ b/Civi/Test/Exception/ProcessErrorException.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Civi\Test\Exception;
+
+use Civi\Test\ProcessHelper;
+
+class ProcessErrorException extends \RuntimeException {
+
+  private ?string $cmd;
+
+  private ?string $stdout;
+
+  private ?string $stderr;
+
+  private ?int $exit;
+
+  public function __construct(?string $cmd, ?string $stdout, ?string $stderr, ?int $exit, $message = "", $code = 0, ?\Throwable $previous = NULL) {
+    $this->cmd = $cmd;
+    $this->stdout = $stdout;
+    $this->stderr = $stderr;
+    $this->exit = $exit;
+    if (empty($message)) {
+      $message = ProcessHelper::formatOutput($cmd, $stdout, $stdout, $exit);
+    }
+    parent::__construct($message, $code, $previous);
+  }
+
+}

--- a/Civi/Test/ProcessHelper.php
+++ b/Civi/Test/ProcessHelper.php
@@ -1,0 +1,104 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Test;
+
+use Civi\Test\Exception\ProcessErrorException;
+
+/**
+ * Define some utility functions for running subprocesses as part of an end-to-end test.
+ */
+class ProcessHelper {
+
+  /**
+   * Run a command. Assert that it succeeds. Otherwise, throw an exception.
+   *
+   * If the env-var `DEBUG` is set, then print debug information.
+   *
+   * @param string $cmd
+   * @return string
+   *   Upon success, this is the command-output.
+   */
+  public static function runOk(string $cmd): string {
+    static::run($cmd, $stdout, $stderr, $exit);
+    if ($exit !== 0) {
+      throw new ProcessErrorException($cmd, $stdout, $stderr, $exit);
+    }
+    return $stdout;
+  }
+
+  public static function run(string $cmd, ?string &$stdout, ?string &$stderr, ?int &$exit): void {
+    if (getenv('DEBUG') > 0) {
+      fprintf(STDERR, "[CRM_Utils_Process::runOk] %s\n", $cmd);
+    }
+    $ignoreStdErr = ';^Xdebug:;';
+
+    // In other projects, I use symfony/process for this -- it's nicer for passing-through STDOUT/STDERR. But it's a bit of dephell.
+    $descriptorSpec = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+    $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+    fclose($pipes[0]);
+    $stdout = stream_get_contents($pipes[1]);
+    $stderr = stream_get_contents($pipes[2]);
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+
+    $stderr = implode("\n", preg_grep($ignoreStdErr, explode("\n", $stderr), PREG_GREP_INVERT));
+    $exit = proc_close($process);
+    if (getenv('DEBUG') > 1) {
+      fwrite(STDERR, static::formatOutput($cmd, $stdout, $stderr, $exit));
+    }
+  }
+
+  public static function formatOutput(string $cmd, ?string $stdout, ?string $stderr, ?int $exit): string {
+    $buf = sprintf("========================\n")
+      . sprintf("==== COMMAND RESULT ====\n")
+      . sprintf("========================\n")
+      . sprintf("== PWD: %s\n", getcwd())
+      . sprintf("== CMD: %s\n", $cmd)
+      . sprintf("== EXIT: %s\n", $exit);
+    if (trim($stdout) !== '') {
+      $buf .= sprintf("== STDOUT:\n%s\n", $stdout);
+    }
+    if (trim($stderr) !== '') {
+      $buf .= sprintf("== STDERR:\n%s\n", $stderr);
+    }
+    return $buf;
+  }
+
+  /**
+   * Determine full path to an external command (by searching PATH).
+   *
+   * @param string $name
+   * @return null|string
+   */
+  public static function findCommand($name) {
+    $paths = explode(PATH_SEPARATOR, getenv('PATH'));
+    foreach ($paths as $path) {
+      if (file_exists("$path/$name")) {
+        return "$path/$name";
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Determine if $file is a shell script.
+   *
+   * @param string $file
+   * @return bool
+   */
+  public static function isShellScript($file) {
+    $firstLine = file_get_contents($file, FALSE, NULL, 0, 120);
+    [$firstLine] = explode("\n", $firstLine);
+    return (bool) preg_match(';^#.*bin.*sh;', $firstLine);
+  }
+
+}

--- a/tests/phpunit/CiviTest/bootstrap.php
+++ b/tests/phpunit/CiviTest/bootstrap.php
@@ -26,6 +26,9 @@ function civitest_civicrm_scanClasses(array &$classes): void {
 # Crank up the memory
 ini_set('memory_limit', '2G');
 define('CIVICRM_TEST', 1);
+if (getenv('CIVICRM_UPGRADE_EVIL')) {
+  define('CIVICRM_BOOTSTRAP_FORBIDDEN', TRUE);
+}
 // phpcs:disable
 eval(cv('php:boot --level=settings', 'phpcode'));
 // phpcs:enable

--- a/tests/phpunit/CiviTest/bootstrap.php
+++ b/tests/phpunit/CiviTest/bootstrap.php
@@ -85,7 +85,7 @@ function cv($cmd, $decode = 'json') {
   $oldOutput = getenv('CV_OUTPUT');
   putenv("CV_OUTPUT=json");
   $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
-  putenv("CV_OUTPUT=$oldOutput");
+  putenv($oldOutput === FALSE ? "CV_OUTPUT" : "CV_OUTPUT=$oldOutput");
   fclose($pipes[0]);
   $result = stream_get_contents($pipes[1]);
   fclose($pipes[1]);

--- a/tests/phpunit/Upgrade/UpgradeSnapshotTest.php
+++ b/tests/phpunit/Upgrade/UpgradeSnapshotTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Upgrade;
+
+use Civi\Test\ProcessHelper;
+
+/**
+ * The UpgradeSnapshotTest walks through a list of MySQL snapshots. It loads each of them into the
+ * CiviCRM database and runs the upgrader.
+ *
+ * The test can be controlled by setting environment variables:
+ *
+ * - [required] `CIVICRM_UPGRADE_EVIL=1`: Enable the test to perform
+ *   highly destructive operations. The test will not run unless you enable it.
+ * - [optional] `UPGRADE_TEST_FILTER=...`: Focus testing on a specific SQL datadump.
+ * - [optional] `DEBUG=1`: Enable extra output for subcommands
+ * - [optional] `DEBUG=2`: Enable very verbose output for subcommands
+ *
+ * The test is generally dependent on two major tools:
+ *
+ * - `civicrm-upgrade-examples`: This command from `civicrm/upgrade-test` provides a list of available examples.
+ * - `cv`: This provides way to interact with the site.
+ *
+ * Here are a few examples of using the test:
+ *
+ * ## Run all tests
+ * $ CIVICRM_UPGRADE_EVIL=1 phpunit9 tests/phpunit/Upgrade
+ *
+ * ## Run tests with detailed command output
+ * $ CIVICRM_UPGRADE_EVIL=1 DEBUG=2 phpunit9 tests/phpunit/Upgrade
+ *
+ * ## Focus on snapshots from 5.45.*
+ * $ CIVICRM_UPGRADE_EVIL=1 UPGRADE_TEST_FILTER='5.45.*' phpunit9 tests/phpunit/Upgrade
+ *
+ * ## Focus on snapshots from 4.7.30 through 5.70
+ * $ CIVICRM_UPGRADE_EVIL=1 UPGRADE_TEST_FILTER='@4.7.30..5.70' phpunit9 tests/phpunit/Upgrade
+ *
+ * @group upgrade
+ */
+class UpgradeSnapshotTest extends \PHPUnit\Framework\TestCase {
+
+  private static $logDir;
+
+  /**
+   * When scanning available examples, choose up-to $limit snapshots for testing.
+   * The algorithm in civicrm-upgrade-examples will choose a stable and wide-spread list of versions.
+   *
+   * @var int
+   */
+  private static $limit = 10;
+
+  public static function setUpBeforeClass(): void {
+    parent::setUpBeforeClass();
+    $mysql = \Civi\Test\ProcessHelper::findCommand('mysql');
+    if (\Civi\Test\ProcessHelper::isShellScript($mysql)) {
+      fprintf(STDERR, "WARNING: The mysql command (%s) appears to be a wrapper script. In some environments, this may interfere with credential passing.\n", $mysql);
+    }
+
+    static::$logDir = cv("path -c configAndLogDir")[0]['value'];
+    static::assertTrue(is_dir(static::$logDir), sprintf('configAndLogDir (%s) could not be found.', static::$logDir));
+  }
+
+  public function setUp(): void {
+    parent::setUp();
+    $this->assertTrue((bool) getenv('CIVICRM_UPGRADE_EVIL'), 'Upgrade tests are destructive. Please set CIVICRM_UPGRADE_EVIL=1 to confirm that destructive tests are OK.');
+    $this->assertTrue(defined('CIVICRM_BOOTSTRAP_FORBIDDEN'), 'Upgrade tests should run in a basic environment without relying on the CiviCRM runtime services');
+    \CRM_Utils_File::cleanDir(static::$logDir, FALSE, FALSE);
+  }
+
+  /**
+   * Get a list of MySQL example files.
+   *
+   * @return array
+   *   Ex: [['/path/to/civicrm-5.99.88.mysql.gz']]
+   * @throws \CRM_Core_Exception
+   */
+  public static function getExamples(): array {
+    if (getenv('CIVICRM_UPGRADE_FILE')) {
+      fprintf(STDERR, "Detected CIVICRM_UPGRADE_FILE. We will only evaluate one snapshot (%s).\n", getenv('CIVICRM_UPGRADE_FILE'));
+      return [[getenv('CIVICRM_UPGRADE_FILE')]];
+    }
+
+    $cmd = ['civicrm-upgrade-examples'];
+    if (CIVICRM_UF === 'Standalone') {
+      $cmd[] = '--snapshot-library';
+      $cmd[] = 'databases_standalone';
+    }
+    if (!empty(getenv('UPGRADE_TEST_FILTER'))) {
+      fprintf(STDERR, "Detected UPGRADE_TEST_FILTER. Test focused on \"%s\".\n", getenv('UPGRADE_TEST_FILTER'));
+      $cmd[] = getenv('UPGRADE_TEST_FILTER');
+    }
+    else {
+      $cmd[] = sprintf('5.13.3-multilingual_af_bg_en* "@4.7.30..%s:%d"', \CRM_Utils_System::version(), static::$limit);
+    }
+    // TODO: It may be nice to move the filtering logic from `civicrm-upgrade-examples` to the PHPUnit class.
+    $cmdStr = implode(' ', $cmd);
+    $stdout = ProcessHelper::runOk($cmdStr);
+    $result = [];
+    foreach (explode("\n", trim($stdout)) as $line) {
+      if ($line = trim($line)) {
+        $result[basename($line)] = [$line];
+      }
+    }
+    return $result;
+  }
+
+  /**
+   * Load a SQL snapshot and run the upgrade.
+   *
+   * @param string $snapshot
+   *   Ex: '/path/to/civicrm-5.99.88.mysql.gz'
+   * @dataProvider getExamples
+   */
+  public function testSnapshot(string $snapshot): void {
+    \Civi\Test::schema()->dropAll()->loadSnapshot($snapshot);
+    $cmd = sprintf('cd %s && cv updb -vv --no-interaction', escapeshellarg($GLOBALS['civicrm_root']));
+
+    ProcessHelper::run($cmd, $stdout, $stderr, $exit);
+    $logs = [];
+    foreach ((array) glob(static::$logDir . '/CiviCRM.*.log') as $logFile) {
+      $logs[$logFile] = file_get_contents($logFile);
+    }
+
+    $hasProblem = ($exit > 0)
+      || !preg_match(';Have a nice day;', $stdout)
+      || preg_grep('/(warning|error)/', $logs);
+
+    if ($hasProblem) {
+      echo ProcessHelper::formatOutput($cmd, $stdout, $stderr, $exit);
+      foreach ($logs as $logFile => $content) {
+        echo $this->formatLog($logFile, $content);
+      }
+      $this->fail(sprintf('Upgrade of %s encountered problem', basename($snapshot)));
+    }
+    else {
+      $this->assertTrue(TRUE, 'Upgrade succeeded');
+    }
+  }
+
+  private function formatLog(string $logFile, string $content): string {
+    return sprintf("========================\n")
+      . sprintf("====    LOG DATA    ====\n")
+      . sprintf("========================\n")
+      . sprintf("== FILE: %s\n", $logFile)
+      . sprintf("== DATA:\n%s\n", $content);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

The project `civicrm/upgrade-test` supports upgrade testing. It's main feature is a list of example databases (which are, essentially, large data blobs).  Additionally, it has helper commands like `bin/civicrm-upgrade-examples` and `bin/civicrm-upgrade-test`. The latter script reads example databases, runs upgrades, and generates a report about errors.

However, iterating on the logic of  `bin/civicrm-upgrade-test` is a bit unusual. This PR aims to make that more familiar -- by porting that part to phpunit. (*~~This is currently a draft; it will likely take several iterations with CI to get it ready.~~*)

Before
----------------------------------------

Get both the data-blobs and the test-logic from `civicrm/upgrade-test`.

After
----------------------------------------

Get the data-blobs from `civicrm/upgrade-test` -- and _use PHPUnit for test-logic_.

Comments
----------------------------------------

At the moment, CI will continue running `civicrm-upgrade-test`. To evaluate this, I'll need to arrange some supplemental CI jobs. Once those jobs are passing, then we can merge and switch-over.
