### PR TITLE
Afform: Confirmation message

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -39,7 +39,24 @@ class AfformAdminMeta {
       'placement_filters' => self::getPlacementFilterOptions(),
       'afform_tags' => $afformTags,
       'search_operators' => \Civi\Afform\Utils::getSearchOperators(),
+      'confirmation_types' => self::getConfirmationTypes(),
     ];
+  }
+
+  /**
+   * Get confirmation types
+   *
+   * @return array
+   */
+  public static function getConfirmationTypes(): array {
+    $confirmationTypes = (array) \Civi\Api4\OptionValue::get(FALSE)
+      ->addSelect('label', 'name', 'value')
+      ->addWhere('is_active', '=', TRUE)
+      ->addWhere('option_group_id:name', '=', 'afform_confirmation_type')
+      ->addOrderBy('weight', 'ASC')
+      ->execute();
+
+    return $confirmationTypes;
   }
 
   /**

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -144,6 +144,10 @@
         }
 
         editor.afform.permission_operator = editor.afform.permission_operator || 'AND';
+        // set redirect to url as default if not set
+        if (!editor.afform.confirmation_type && editor.meta.confirmation_types.length > 0) {
+          editor.afform.confirmation_type = editor.meta.confirmation_types[0].value;
+        }
 
         // Initialize undo history
         undoAction = 'initialLoad';

--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -179,7 +179,19 @@
         </div>
       </div>
 
-      <div class="form-group" ng-class="{'has-error': !!config_form.redirect.$error.pattern}">
+      <div class="form-group">
+        <label>
+          {{:: ts('Confirmation type') }}
+        </label>
+        <p class="form-inline">
+          <label class="radio" ng-repeat="ctype in editor.meta.confirmation_types">
+            <input class="crm-form-radio" type="radio" name="confirmation_type" ng-model="editor.afform.confirmation_type" ng-value="ctype.value">
+            {{:: ctype.label }}
+          </label>
+        </p>
+      </div>
+
+      <div class="form-group" ng-class="{'has-error': !!config_form.redirect.$error.pattern}" ng-if="editor.afform.confirmation_type === 'redirect_to_url'">
         <label for="af_config_redirect">
           {{:: ts('Post-Submit Page') }}
         </label>
@@ -190,5 +202,14 @@
         <p class="help-block">{{:: ts('Enter a URL or path that the form should redirect to following a successful submission.') }}</p>
       </div>
     </div>
+
+    <div class="form-group" ng-if="editor.afform.confirmation_type === 'show_confirmation_message'">
+      <label for="af_config_confirmation_message">
+        {{:: ts('Confirmation message') }}
+      </label>
+      <textarea ng-model="editor.afform.confirmation_message" class="form-control" id="af_config_confirmation_message" ng-model-options="editor.debounceMode"></textarea>
+      <p class="help-block">{{:: ts("This message wil be displayed when the form is submitted.") }}</p>
+    </div>
+
   </fieldset>
 </ng-form>

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -298,6 +298,16 @@ class Afform extends Generic\AbstractEntity {
           'data_type' => 'Timestamp',
           'readonly' => TRUE,
         ],
+        [
+          'name' => 'confirmation_type',
+          'pseudoconstant' => ['optionGroupName' => 'afform_confirmation_type'],
+          'default_value' => 'redirect_to_url',
+        ],
+        [
+          'name' => 'confirmation_message',
+          'title' => E::ts('Confirmation Message'),
+          'input_type' => 'Text',
+        ],
       ];
       // Calculated fields returned by get action
       if ($self->getAction() === 'get') {

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -233,7 +233,7 @@ function afform_civicrm_buildAsset($asset, $params, &$mimeType, &$content) {
   $moduleName = _afform_angular_module_name($params['name'], 'camel');
   $formMetaData = (array) civicrm_api4('Afform', 'get', [
     'checkPermissions' => FALSE,
-    'select' => ['redirect', 'name', 'title', 'autosave_draft'],
+    'select' => ['redirect', 'name', 'title', 'autosave_draft', 'confirmation_type', 'confirmation_message'],
     'where' => [['name', '=', $params['name']]],
   ], 0);
   $smarty = CRM_Core_Smarty::singleton();

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -302,7 +302,14 @@
           dialog.dialog('close');
         }
 
-        else if (metaData.redirect) {
+        else if (metaData.confirmation_type && metaData.confirmation_type === 'show_confirmation_message') {
+          $element.hide();
+          const $confirmation = $('<div class="afform-confirmation" />');
+          $confirmation.text(metaData.confirmation_message);
+          $confirmation.insertAfter($element);
+        }
+
+        else if ((!metaData.confirmation_type && metaData.redirect ) || (metaData.confirmation_type && metaData.confirmation_type === 'redirect_to_url' && metaData.redirect)) {
           var url = replaceTokens(metaData.redirect, submissionResponse[0]);
           if (url.indexOf('civicrm/') === 0) {
             url = CRM.url(url);

--- a/ext/afform/core/managed/AfformConfirmationType.mgd.php
+++ b/ext/afform/core/managed/AfformConfirmationType.mgd.php
@@ -1,0 +1,64 @@
+<?php
+
+use CRM_Afform_ExtensionUtil as E;
+
+// Adds option group for Afform.confirmation type
+return [
+  [
+    'name' => 'AfformConfirmationType',
+    'entity' => 'OptionGroup',
+    'update' => 'always',
+    'cleanup' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'afform_confirmation_type',
+        'title' => E::ts('Afform Confirmation Type'),
+        'is_reserved' => TRUE,
+        'option_value_fields' => [
+          'name',
+          'label',
+          'icon',
+          'description',
+        ],
+      ],
+      'match' => ['name'],
+    ],
+  ],
+  [
+    'name' => 'AfformConfirmationType:redirect_to_url',
+    'entity' => 'OptionValue',
+    'cleanup' => 'always',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'option_group_id.name' => 'afform_confirmation_type',
+        'name' => 'redirect_to_url',
+        'value' => 'redirect_to_url',
+        'label' => E::ts('Redirect to a URL'),
+        'icon' => 'fa-turn-up',
+        'is_reserved' => TRUE,
+      ],
+      'match' => ['option_group_id', 'name'],
+    ],
+  ],
+  [
+    'name' => 'AfformConfirmationType:afform_confirmation_type',
+    'entity' => 'OptionValue',
+    'cleanup' => 'always',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'option_group_id.name' => 'afform_confirmation_type',
+        'name' => 'show_confirmation_message',
+        'value' => 'show_confirmation_message',
+        'label' => E::ts('Show confirmation message'),
+        'icon' => 'fa-message',
+        'is_reserved' => TRUE,
+      ],
+      'match' => ['option_group_id', 'name'],
+    ],
+  ],
+];


### PR DESCRIPTION
Overview
----------------------------------------
Add an ability to configure confirmation which is displayed after form is submitted.

Related to:
- [Possibility to add a status message (alert box) after screen submission in FormBuilder](https://lab.civicrm.org/dev/core/-/issues/2957)
- [Proposal: Adding confirmation messages flexibly to Form Builder](https://lab.civicrm.org/dev/core/-/issues/4569)

Before
----------------------------------------
- There was no option to configure confirmation message

After
----------------------------------------
- Form confirguration
![2025-03-15-161138_hyprshot](https://github.com/user-attachments/assets/18177440-5992-42a0-b032-9db0d01834f3)

- After submission
![2025-03-15-161235_hyprshot](https://github.com/user-attachments/assets/093ba267-dc79-44de-b214-33f72bf0cde8)



