### PR TITLE
Fix formatLocaleNumericRoundedByOptionalPrecision to correctly handle strings

### DIFF
--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -284,7 +284,7 @@ class CRM_Utils_Money {
    * Format money for display with rounding to the supplied precision but without padding.
    *
    * If the string is shorter than the precision trailing zeros are not added to reach the precision
-   * beyond the 2 required for normally currency formatting.
+   * beyond the 2 required for normal currency formatting.
    *
    * This handles both rounding & replacement of the currency separators for the locale.
    *
@@ -296,6 +296,11 @@ class CRM_Utils_Money {
    */
   public static function formatLocaleNumericRoundedByOptionalPrecision($amount, $precision) {
     $decimalPlaces = self::getDecimalPlacesForAmount((string) $amount);
+    $defaultDecimals = self::getCurrencyPrecision(CRM_Core_Config::singleton()->defaultCurrency);
+    if ($decimalPlaces < $defaultDecimals) {
+      $decimalPlaces = $defaultDecimals;
+    }
+
     $amount = self::formatUSLocaleNumericRounded($amount, $precision > $decimalPlaces ? $decimalPlaces : $precision);
     return self::replaceCurrencySeparators($amount);
   }
@@ -368,6 +373,14 @@ class CRM_Utils_Money {
    * @return int
    */
   protected static function getDecimalPlacesForAmount(string $amount): int {
+    if (!str_contains($amount, '.')) {
+      return 0;
+    }
+
+    if (is_string($amount) && str_contains($amount, '.')) {
+      $amount = rtrim($amount, '0');
+    }
+
     $decimalPlaces = strlen(substr($amount, strpos($amount, '.') + 1));
     return $decimalPlaces;
   }

--- a/tests/phpunit/CRM/Utils/MoneyTest.php
+++ b/tests/phpunit/CRM/Utils/MoneyTest.php
@@ -97,11 +97,20 @@ class CRM_Utils_MoneyTest extends CiviUnitTestCase {
    */
   public function testFormatLocaleNumericRoundedByOptionalPrecision($thousandSeparator) {
     $this->setCurrencySeparators($thousandSeparator);
-    $result = CRM_Utils_Money::formatLocaleNumericRoundedByOptionalPrecision(8950.3678, 8);
+
+    $result = CRM_Utils_Money::formatLocaleNumericRoundedByOptionalPrecision("8950", 8);
+    $expected = ($thousandSeparator === ',') ? '8,950.00' : '8.950,00';
+    $this->assertEquals($expected, $result);
+
+    $result = CRM_Utils_Money::formatLocaleNumericRoundedByOptionalPrecision("8950.000000000", 8);
+    $expected = ($thousandSeparator === ',') ? '8,950.00' : '8.950,00';
+    $this->assertEquals($expected, $result);
+
+    $result = CRM_Utils_Money::formatLocaleNumericRoundedByOptionalPrecision("8950.3678", 8);
     $expected = ($thousandSeparator === ',') ? '8,950.3678' : '8.950,3678';
     $this->assertEquals($expected, $result);
 
-    $result = CRM_Utils_Money::formatLocaleNumericRoundedByOptionalPrecision(123456789.987654321, 9);
+    $result = CRM_Utils_Money::formatLocaleNumericRoundedByOptionalPrecision("123456789.987654321", 5);
     $expected = ($thousandSeparator === ',') ? '123,456,789.98765' : '123.456.789,98765';
     $this->assertEquals($result, $expected);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix to the `formatLocaleNumericRoundedByOptionalPrecision` function.

Before
----------------------------------------
In the docblock comment for `formatLocaleNumericRoundedByOptionalPrecision` it states:

> If the string is shorter than the precision trailing zeros are not added to reach the precision
> beyond the 2 required for normally currency formatting.

However, this was only working under certain conditions. `formatLocaleNumericRoundedByOptionalPrecision` is looking at the number of characters after the "." symbol. If passing in a float, when converted to a string PHP will only add the number of digits required. However, when a `decimal` SQL type is read from the database, a fixed number of digits will be returned. So values coming from the database (with 9 decimal places) will be `"10.200000000"`, whereas `(string) 10.20` will be simply`"10.2"`.

After
----------------------------------------
If the value is a decimal (based on the presence of a `.`) then we trim any training `0` characters. The `getDecimalPlacesForAmount` function already assumes the `.` is the decimal seperator, so we don't need to consider other number formatting in this context.

Technical Details
----------------------------------------
The documentation for `formatLocaleNumericRoundedByOptionalPrecision` showed it was meant to be passed a `string`, but the tests were all passing in `float` values. Whilst the function does work with floats, using strings is safer to avoid floating point precision issues. Therefore the tests have been updated to use strings.

Comments
----------------------------------------
I'm really fixing this as a follow-up to https://github.com/civicrm/civicrm-core/pull/30804 and https://github.com/civicrm/civicrm-core/pull/30800. 

I've had a few collegues comment that the price table looks "broken" as it's displaying too many decimal places:

<img width="557" alt="Screenshot 2025-03-16 at 09 32 34" src="https://github.com/user-attachments/assets/d495ae08-aafc-488a-809e-41406f986b20" />

Following this change, only the number of decimal places actually needed will be shown (2 decimal places, unless the value has more decimal places than this)

<img width="591" alt="Screenshot 2025-03-16 at 09 30 12" src="https://github.com/user-attachments/assets/6b60c248-cd35-4eca-afb9-76b6c21df464" />
