### PR TITLE
[REF][PHP8.2] Declare property on CRM_PCP_Form_PCP

### DIFF
--- a/CRM/PCP/Form/PCP.php
+++ b/CRM/PCP/Form/PCP.php
@@ -23,6 +23,14 @@ class CRM_PCP_Form_PCP extends CRM_Core_Form {
   public $_context;
 
   /**
+   * The ID of the personal campaign page being acted upon
+   *
+   * @var int
+   * @internal
+   */
+  public $_id;
+
+  /**
    * Set variables up before form is built.
    *
    * @throws \CRM_Core_Exception


### PR DESCRIPTION
Overview
----------------------------------------
Declare property on `CRM_PCP_Form_PCP`

Before
----------------------------------------
As seen on the demo site:

<img width="785" alt="Screenshot 2025-03-16 at 19 32 01" src="https://github.com/user-attachments/assets/3285d073-6676-4110-8ca4-dbda4285610d" />


After
----------------------------------------
Property declared. It probably could have been protected, but I kept it public and `@internal` to play it safe.