### PR TITLE
Remove invalid table markup on event tab

### DIFF
--- a/templates/CRM/Event/Page/Tab.tpl
+++ b/templates/CRM/Event/Page/Tab.tpl
@@ -12,7 +12,8 @@
 {elseif $action eq 4}
     {include file="CRM/Event/Form/ParticipantView.tpl"}
 {else}
-    {if $permission EQ 'edit'}{capture assign=newEventURL}{crmURL p="civicrm/contact/view/participant" q="reset=1&action=add&cid=`$contactId`&context=participant"}{/capture}
+    {if $permission EQ 'edit'}
+      {capture assign=newEventURL}{crmURL p="civicrm/contact/view/participant" q="reset=1&action=add&cid=`$contactId`&context=participant"}{/capture}
     {/if}
 
     <div class="help">
@@ -38,15 +39,12 @@
 
     {if $rows}
       {include file="CRM/common/pager.tpl" location="top"}
-        {include file="CRM/Event/Form/Selector.tpl"}
-  {include file="CRM/common/pager.tpl" location="bottom"}
+      {include file="CRM/Event/Form/Selector.tpl"}
+      {include file="CRM/common/pager.tpl" location="bottom"}
     {else}
        <div class="messages status no-popup">
-           <table class="form-layout">
-             <tr>{icon icon="fa-info-circle"}{/icon}
-                   {ts}No event registrations have been recorded for this contact.{/ts}
-             </tr>
-           </table>
+          {icon icon="fa-info-circle"}{/icon}
+          {ts}No event registrations have been recorded for this contact.{/ts}
        </div>
     {/if}
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Avoids this empty table, caused by invalid HTML markup, which is causing unneccesary whitespace to be shown.

<img width="949" alt="Screenshot 2025-03-16 at 21 49 14" src="https://github.com/user-attachments/assets/aaa0aeb6-1880-42a7-b4e4-be27012c7ad0" />

There was no need for a table to be used here.

I've also tidied up some whitespace in the rest of the file.