### PR TITLE
riverlea - fix checkbox-list in hackneybrook dark mode

### DIFF
--- a/ext/riverlea/streams/hackneybrook/css/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/css/_dark.css
@@ -33,7 +33,7 @@
   --crm-c-gray-300: #e1dfdf;
   --crm-c-gray-200: #bdbdbd;
   --crm-c-divider: 1px solid var(--crm-c-gray-500);
-  --crm-checkbox-list-col: #665800;
+  --crm-checkbox-list-bg: #665800;
   --crm-checkbox-list-bg2: #525209;
   --crm-checkbox-list-col: var(--crm-c-text-light);
   /* And others */


### PR DESCRIPTION
Overview
----------------------------------------
Fix issue with `checkbox-list` colours in Hackney Brook dark mode. I think this got garbled somewhere along the lines of versions of https://github.com/civicrm/civicrm-core/pull/32209

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/089ac5ba-2001-4e77-a76f-4507a5cf53cf)

After
----------------------------------------
![image](https://github.com/user-attachments/assets/5200e025-e22a-463d-b0d4-dfd4d3ba2dfb)

Technical details
----------------------------------------
The existing defintion of `checkbox-list-col` isn't doing anything, it's being overridden two lines below

