### PR TITLE
[NFC] riverlea - remove some double definitions

### DIFF
--- a/ext/riverlea/streams/hackneybrook/css/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/css/_dark.css
@@ -8,7 +8,6 @@
   --crm-c-background2: var(--crm-c-gray-800);
   --crm-c-background3: var(--crm-c-gray-700);
   --crm-c-background4: var(--crm-c-gray-600);
-  --crm-c-code-background: var(--crm-c-gray-200);
   --crm-c-primary: var(--crm-c-background);
   --crm-c-primary-text: var(--crm-c-text);
   --crm-c-primary-hover: var(--crm-c-darkest);

--- a/ext/riverlea/streams/minetta/css/_dark.css
+++ b/ext/riverlea/streams/minetta/css/_dark.css
@@ -12,7 +12,6 @@
   --crm-c-background2: var(--crm-c-gray-800);
   --crm-c-background3: var(--crm-c-gray-700);
   --crm-c-background4: var(--crm-c-gray-600);
-  --crm-c-code-background: var(--crm-c-gray-200);
   --crm-c-success: var(--crm-c-green-light);
   --crm-c-amber: #993b00;
   --crm-c-red: #b3001b;

--- a/ext/riverlea/streams/thames/css/_variables.css
+++ b/ext/riverlea/streams/thames/css/_variables.css
@@ -303,7 +303,6 @@
   --crm-tab-bg-hover: var(--crm-c-blue-overlay);
   --crm-tab-bg-active: white;
   --crm-tab-hang: 0 0 calc(-1 * var(--crm-s)) 0; /* lip to extend tab flush with active region - set to 0 for no lip */ /* thames todo check */
-  --crm-tab-padding: var(--crm-s3) var(--crm-m) var(--crm-s) var(--crm-m);
   --crm-tab-padding: var(--crm-m2) var(--crm-r1) var(--crm-m); /* thames todo check */
   --crm-tab-col: var(--crm-c-text);
   --crm-tab-weight: normal;

--- a/ext/riverlea/streams/thames/css/civicrm.css
+++ b/ext/riverlea/streams/thames/css/civicrm.css
@@ -108,7 +108,6 @@ html.cms-standalone body {
   color: #fff;
   content: "\f0eb";
   display: inline-block;
-  font-size: 2rem;
   font: normal normal normal 14px/1 FontAwesome;
   font-size: inherit;
   margin-left: -2.3rem;

--- a/ext/riverlea/streams/walbrook/css/_dark.css
+++ b/ext/riverlea/streams/walbrook/css/_dark.css
@@ -11,9 +11,6 @@
   --crm-c-background2: var(--crm-c-gray-900);
   --crm-c-background3: var(--crm-c-gray-800);
   --crm-c-background4: var(--crm-c-gray-700);
-  --crm-c-green: #58a458;
-  --crm-c-green-light: #077d09;
-  --crm-c-alert: #ffc7cf;
   --crm-alert-background-danger: var(--crm-c-red);
   --crm-c-blue-dark: #043353;
   --crm-c-green-light: #468847;
@@ -65,7 +62,6 @@
   --crm-dialog-header-bg: var(--crm-c-background2);
   --crm-dialog-body-bg: var(--crm-c-background2);
   --crm-notify-background: var(--crm-c-background);
-  --crm-wizard-active-bg: var(--crm-c-dark-teal);
   --crm-form-block-background: var(--crm-c-background2);
   --crm-btn-cancel-bg: #9b3d4b;
   --crm-btn-warning-bg: #7b4e14;


### PR DESCRIPTION
Overview
----------------------------------------
Remove some properties that are declared again later in the same css block, so are non-functional, and source of confusion when working on the code.

Technical Details
----------------------------------------
Having stumbled across a few of these, I found you can get VSCode to highlight duplicate definitions like this as errors by adding 
```
  "css.lint.duplicateProperties": "error"
```
to your `settings.json`.


cc @vingle and @artfulrobot (not sure if the one in Thames was possibly deliberate as a reference? if so should probably be a comment?)