### PR TITLE
dev/core#5798 (Riverlea) avoid .text-success => better assurances about colour contrast

### DIFF
--- a/ext/afform/core/ang/af/afCharacterCount.component.js
+++ b/ext/afform/core/ang/af/afCharacterCount.component.js
@@ -17,12 +17,12 @@
       this.getStatusClass = function() {
         let fraction = this.getLength() / (this.maxlength || 1);
         if (fraction > 0.9) {
-          return 'text-danger';
+          return 'label-danger';
         }
         if (fraction > 0.7) {
-          return 'text-warning';
+          return 'label-warning';
         }
-        return 'text-success';
+        return 'label-success';
       };
 
     }

--- a/ext/message_admin/ang/crmMsgadm/Edit.html
+++ b/ext/message_admin/ang/crmMsgadm/Edit.html
@@ -45,7 +45,7 @@
             </a>
           </li>
           <li role="presentation" class="navitem pull-right" ng-show="$ctrl.tab.match('txActive|original') && !$ctrl.hasDraft() && $ctrl.allowDraft()">
-            <a crm-icon="fa-plus" class="nav-link text-success" ng-click="$ctrl.createDraft($ctrl.records[$ctrl.tab])">
+            <a crm-icon="fa-plus" class="nav-link btn-success" ng-click="$ctrl.createDraft($ctrl.records[$ctrl.tab])">
               {{:: ts('Create draft') }}
             </a>
           </li>
@@ -60,7 +60,7 @@
             </a>
           </li>
           <li role="presentation" class="navitem pull-right" ng-show="$ctrl.tab === 'txDraft'">
-            <a crm-icon="fa-rocket" class="nav-link text-success" crm-confirm="{title: ts('Activate draft?'), message: ts('Are you sure you want to activate this draft?')}" on-yes="$ctrl.activateDraft()">
+            <a crm-icon="fa-rocket" class="nav-link btn-success" crm-confirm="{title: ts('Activate draft?'), message: ts('Are you sure you want to activate this draft?')}" on-yes="$ctrl.activateDraft()">
               {{:: ts('Activate draft') }}
             </a>
           </li>

--- a/ext/message_admin/ang/crmMsgadm/WorkflowTranslated.html
+++ b/ext/message_admin/ang/crmMsgadm/WorkflowTranslated.html
@@ -27,7 +27,7 @@
       <td>{{record.tx_language_label || ts('Standard')}}</td>
       <td>
         <span ng-if="!record.tx_language || !!record.tx_statuses.active">
-          <a class="text-success" crm-icon="fa-file-text" title="{{ts('Edit current revision, &quot;%1&quot;, &quot;%2&quot;', {1: record.msg_title, 2: record.tx_language_label || ts('Standard')})}}" ng-href="{{$ctrl.editUrl(record)}}">{{:: ts('Current') }}</a>
+          <a class="btn-success" crm-icon="fa-file-text" title="{{ts('Edit current revision, &quot;%1&quot;, &quot;%2&quot;', {1: record.msg_title, 2: record.tx_language_label || ts('Standard')})}}" ng-href="{{$ctrl.editUrl(record)}}">{{:: ts('Current') }}</a>
         </span>
         <span ng-if="!(!record.tx_language || !!record.tx_statuses.active)">
           <span class="text-danger" crm-icon="fa-file-text" title="{{ts('No current revision, &quot;%1&quot;, &quot;%2&quot;', {1: record.msg_title, 2: record.tx_language_label || ts('Standard')})}}">{{:: ts('Current') }}</span>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplayHeader.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplayHeader.html
@@ -3,10 +3,10 @@
     <label for="crm-search-admin-display-label">{{:: ts('Name') }} <span class="crm-marker">*</span></label>
     <input id="crm-search-admin-display-label" type="text" class="form-control" ng-model="$ctrl.display.label" required placeholder="{{:: ts('Untitled') }}"/>
     <div class="form-control" ng-class="{disabled: !$ctrl.parent.isSuperAdmin}" title="{{:: $ctrl.parent.aclBypassHelp }}">
-      <label>
+      <label ng-class="$ctrl.display.acl_bypass ? 'label-danger' : 'label-success'">
         <input type="checkbox" ng-if="$ctrl.parent.isSuperAdmin" ng-model="$ctrl.display.acl_bypass" style="display: none;">
-        <i class="crm-i fa-lock text-success" ng-if="!$ctrl.display.acl_bypass"></i>
-        <i class="crm-i fa-unlock text-danger" ng-if="$ctrl.display.acl_bypass"></i>
+        <i class="crm-i fa-lock" ng-if="!$ctrl.display.acl_bypass"></i>
+        <i class="crm-i fa-unlock" ng-if="$ctrl.display.acl_bypass"></i>
         <span>{{ $ctrl.display.acl_bypass ? ts('Bypass Permissions') : ts('Enforce Permissions') }}</span>
       </label>
     </div>

--- a/ext/standaloneusers/managed/SavedSearch_Permissions.mgd.php
+++ b/ext/standaloneusers/managed/SavedSearch_Permissions.mgd.php
@@ -117,7 +117,7 @@ foreach ($roles as $roleName => $roleLabel) {
     ],
     'cssRules' => [
       [
-        'text-success',
+        'bg-success',
         'granted_' . $roleName,
         '=',
         TRUE,


### PR DESCRIPTION
Overview
----------------------------------------
This is an approach to fix https://lab.civicrm.org/dev/core/-/issues/5798 by avoiding `.text-success`.


Before
----------------------------------------
- `.text-success` is used in a few places. This sets a green text which is generally fine in stream light modes, but not good in dark modes.

After
----------------------------------------
- use a mixture of `.label-success`, `.btn-success` and new `.bg-success` classes to ensure contrast


Technical Details
----------------------------------------
`.label-success` and `.bg-success` assure contrast using fairly simple method: set the text and background using a color pair, and then streams just need to make those pairs contrast.

`.btn-success` is relying on `--crm-icon-success-color` contrasting against the background for the button - which it seems to be doing fine on current streams, but seems a little fiddlier to assure in the long term.


Comments
----------------------------------------
If this approach was generally agreed, I think it could be good to repeat for `-info`, `-danger` etc and then remove the `text-XXX` utility classes whilst they are still fairly new and shouldn't be used much downstream.
