### PR TITLE
dev/core#5797 standalone - implement minimal header in maintenance mode

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -336,13 +336,18 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
       // if maintenance, we need to wrap in a minimal header
       $headerContent = CRM_Core_Region::instance('html-header', FALSE)->render('');
 
+      // note - now adding #crm-container is a hacky way to avoid rendering
+      // the civicrm menubar. @todo a better way
       $content = <<<HTML
-        <html>
+        <!DOCTYPE html >
+        <html class="crm-standalone">
           <head>
             {$headerContent}
           </head>
           <body>
-            {$content}
+            <div class="crm-container standalone-page-padding">
+              {$content}
+            </div>
           </body>
         </html>
       HTML;

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -332,6 +332,22 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    * @inheritDoc
    */
   public function theme(&$content, $print = FALSE, $maintenance = FALSE) {
+    if ($maintenance) {
+      // if maintenance, we need to wrap in a minimal header
+      $headerContent = CRM_Core_Region::instance('html-header', FALSE)->render('');
+
+      $content = <<<HTML
+        <html>
+          <head>
+            {$headerContent}
+          </head>
+          <body>
+            {$content}
+          </body>
+        </html>
+      HTML;
+    }
+
     print $content;
     return NULL;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix Standalone web upgrader - robbed of its html header.

Before
----------------------------------------
- setting `CIVICRM_UF_HEAD` prevents the header being rendered for minimal queue runner and upgrade complete pages. Without the required javascript, nothing happens.

After
----------------------------------------
- header is printed in `theme` function if `$maintenance` param is set, which fixes these cases

Technical Details
----------------------------------------
The implementation ignores the `$print` param and just prints anyway. I think this works coincidentally, as the callers tend to print the output anyway. I'll make another PR against `master` to "fix" this as it seems wrong. But probably safer not to change the pre-existing behaviour with this patch.

Comments
----------------------------------------
It might be nicer to include minimal Javascript for running the queue runner in the Runner.tpl template? But not sure exactly what is required.
