### PR TITLE
RiverLea Thames Dark Mode / Extensions colour fix 

### DIFF
--- a/ext/riverlea/streams/thames/css/_dark.css
+++ b/ext/riverlea/streams/thames/css/_dark.css
@@ -11,6 +11,7 @@
   --crm-c-code-background: var(--crm-c-dkblue-04);
   --crm-dashlet-bg: var(--crm-c-dkblue-02);
   --crm-c-green: #335417;
+  --crm-c-green-light: var(--crm-c-green);
   --crm-c-link: var(--crm-c-dkblue-08);
   --crm-c-link-hover: color-mix(in srgb, white, var(--crm-c-dkblue-08) 70%);
   --crm-dash-header-col: var(--crm-c-blue-light);


### PR DESCRIPTION
Port-forward (Forport?) of https://github.com/civicrm/civicrm-core/pull/32370 in response to @Stoob's issue: https://lab.civicrm.org/dev/core/-/issues/5793 

Overview
----------------------------------------
This fixes a regression caused by https://github.com/civicrm/civicrm-core/pull/31994. I tested that PR and made a bunch of changes to regressions in https://github.com/civicrm/civicrm-core/pull/32209, but hadn't tested Extensions layout in Thames dark-mode, so am adding this. @artfulrobot feel free to change/resubmit your own, trying to be helpful here.

I'm going for the simplest fix - change bg to be dark, using a shade of green used elsewhere in Thames/DarkMode.

More info and screengrabs - please see the first PR.