### PR TITLE
Use get permissions for getMergedTo, getMergedFrom

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1084,6 +1084,9 @@ class CRM_Core_Permission {
       ],
       // managed by query object
       'get' => [],
+      'getMergedTo' => [],
+      'getMergedFrom' => [],
+
       // managed by _civicrm_api3_check_edit_permissions
       'update' => [],
       'duplicatecheck' => [

--- a/Civi/Api4/Action/Contact/GetMergedFrom.php
+++ b/Civi/Api4/Action/Contact/GetMergedFrom.php
@@ -43,7 +43,7 @@ class GetMergedFrom extends \Civi\Api4\Generic\AbstractAction {
    */
   public function _run(Result $result): void {
     $activities = [];
-    $deleteActivities = \Civi\Api4\ActivityContact::get(FALSE)
+    $deleteActivities = \Civi\Api4\ActivityContact::get($this->checkPermissions)
       ->addSelect('activity_id')
       ->addWhere('contact_id', '=', $this->contactId)
       ->addWhere('activity_id.activity_type_id:name', '=', 'Contact Merged')
@@ -59,7 +59,7 @@ class GetMergedFrom extends \Civi\Api4\Generic\AbstractAction {
       return;
     }
 
-    $activityContacts = \Civi\Api4\ActivityContact::get(FALSE)
+    $activityContacts = \Civi\Api4\ActivityContact::get($this->checkPermissions)
       ->addSelect('contact_id')
       ->addWhere('activity_id.parent_id', 'IN', $activities)
       ->addWhere('record_type_id:name', '=', 'Activity Targets')

--- a/Civi/Api4/Action/Contact/GetMergedTo.php
+++ b/Civi/Api4/Action/Contact/GetMergedTo.php
@@ -28,6 +28,7 @@ class GetMergedTo extends \Civi\Api4\Generic\AbstractAction {
    * ID of contact to find ultimate contact for
    *
    * @var int
+   *
    * @required
    */
   protected $contactId;
@@ -43,7 +44,7 @@ class GetMergedTo extends \Civi\Api4\Generic\AbstractAction {
    */
   public function _run(Result $result): void {
     $returnId = [];
-    $deleteActivity = \Civi\Api4\ActivityContact::get(FALSE)
+    $deleteActivity = \Civi\Api4\ActivityContact::get($this->checkPermissions)
       ->addSelect('activity_id.parent_id')
       ->addWhere('contact_id', '=', $this->contactId)
       ->addWhere('activity_id.activity_type_id:name', '=', 'Contact Deleted by Merge')
@@ -55,7 +56,7 @@ class GetMergedTo extends \Civi\Api4\Generic\AbstractAction {
       ->execute()
       ->first();
     if (!empty($deleteActivity)) {
-      $returnId = \Civi\Api4\ActivityContact::get(FALSE)
+      $returnId = \Civi\Api4\ActivityContact::get($this->checkPermissions)
         ->addSelect('contact_id')
         ->addWhere('activity_id', '=', $deleteActivity['activity_id.parent_id'])
         ->addWhere('record_type_id:name', '=', 'Activity Targets')


### PR DESCRIPTION
Overview
----------------------------------------
Use get permissions for getMergedTo, getMergedFrom

Before
----------------------------------------
the api added in https://github.com/civicrm/civicrm-core/pull/31336 require Administer CiviCRM and would throw an exception for lower permissioned users

After
----------------------------------------
They should follow the get acls

Technical Details
----------------------------------------
@johntwyman I spotted this trying to use the api & thinking the permissions might cause problems - it would be great if you could test this change

Comments
----------------------------------------
