### PR TITLE
actually suppress event templates in event autocomplete

### DIFF
--- a/Civi/Api4/Service/Autocomplete/EventAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/EventAutocompleteProvider.php
@@ -37,9 +37,10 @@ class EventAutocompleteProvider extends \Civi\Core\Service\AutoService implement
     $apiRequest = $event->getApiRequest();
     if (is_object($apiRequest) && is_a($apiRequest, 'Civi\Api4\Generic\AutocompleteAction')) {
       [$entityName, $fieldName] = array_pad(explode('.', (string) $apiRequest->getFieldName(), 2), 2, '');
-
-      if ($entityName === 'Event' && $fieldName === 'template_id') {
-        $apiRequest->addFilter('is_template', TRUE);
+      $entityName = !empty($entityName) ? $entityName : $apiRequest->getEntityName();
+      if (($entityName === 'Event' && $fieldName === 'id') || $fieldName === 'event_id') {
+        $showTemplates = $fieldName === 'template_id';
+        $apiRequest->addFilter('is_template', $showTemplates);
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Event template autocomplete uses trickery to not show templates. This improves the trickery.
To replicate, on a default buildkit site, run: `cv api4 Event.autocomplete input=4` (event 4 is a template).

Before
----------------------------------------
```
[
    {
        "id": 4,
        "label": "",
        "icon": null,
        "description": [
            "#4 Meeting",
            ""
        ]
    }
]
```

After
----------------------------------------
```
[]
```

Comments
----------------------------------------
Event templates don't have `title`s, they instead have `template_title`s.  And because the label is `NULL`, event autocompletes hide event templates.

However, in `CRM_Import_Parser`, there's a TODO that I'm doing to make the code for importing event IDs, campaign IDs, and anything else with a large option list generic.  That requires autocomplete to actually not _return_ anything, not just not _display_ anything.

Additionally - we can't convert the API3 EntityRef autocompletes for `Participant.event_id` with the API4 version because we're only filtering templates on `Event.id`.  So I'm capturing all uses of `event_id`.

Question: Should I be concerned that `event_id` might mean something other than an FK to event?  Because if I limit it to `Participant.event_id` it won't filter templates on any custom fields of type EntityReference that references events.