### PR TITLE
Import entityreference fields; generalize loading options on large option list fields on import

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -452,6 +452,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
         $fields[$id]['column_name'] = $customField['column_name'];
         $fields[$id]['serialize'] = $customField['serialize'];
         $fields[$id]['where'] = $customGroup['table_name'] . '.' . $customField['column_name'];
+        $fields[$id]['fk_entity'] = $customField['fk_entity'];
         // Probably we should use a different fn to get the extends tables but this is a refactor so not changing that now.
         $fields[$id]['extends_table'] = array_key_exists($customGroup['extends'], CRM_Core_BAO_CustomQuery::$extendsMap) ? CRM_Core_BAO_CustomQuery::$extendsMap[$customGroup['extends']] : '';
         if ($extendsSubtypes) {

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -512,6 +512,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'serialize' => 0,
+        'fk_entity' => NULL,
         'pseudoconstant' => [
           'table' => 'civicrm_country',
           'keyColumn' => 'id',
@@ -551,6 +552,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'serialize' => 1,
+        'fk_entity' => NULL,
         'pseudoconstant' => [
           'table' => 'civicrm_country',
           'keyColumn' => 'id',
@@ -590,6 +592,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'serialize' => 0,
+        'fk_entity' => NULL,
       ],
       $this->getCustomFieldName('text') => [
         'name' => $this->getCustomFieldName('text'),
@@ -624,6 +627,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'search_table' => 'contact_a',
         'maxlength' => 300,
         'serialize' => 0,
+        'fk_entity' => NULL,
       ],
       $this->getCustomFieldName('select_string') => [
         'name' => $this->getCustomFieldName('select_string'),
@@ -657,6 +661,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'serialize' => 0,
+        'fk_entity' => NULL,
         'pseudoconstant' => [
           'optionGroupName' => $this->callAPISuccessGetValue('CustomField', ['id' => $this->getCustomFieldID('select_string'), 'return' => 'option_group_id.name']),
           'optionEditPath' => 'civicrm/admin/options/' . $this->callAPISuccessGetValue('CustomField', ['id' => $this->getCustomFieldID('select_string'), 'return' => 'option_group_id.name']),
@@ -694,6 +699,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'serialize' => 0,
+        'fk_entity' => NULL,
       ],
       $this->getCustomFieldName('link') => [
         'name' => $this->getCustomFieldName('link'),
@@ -727,6 +733,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'serialize' => 0,
+        'fk_entity' => NULL,
       ],
       $this->getCustomFieldName('int') => [
         'name' => $this->getCustomFieldName('int'),
@@ -760,6 +767,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'serialize' => 0,
+        'fk_entity' => NULL,
       ],
       $this->getCustomFieldName('contact_reference') => [
         'name' => $this->getCustomFieldName('contact_reference'),
@@ -793,6 +801,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'serialize' => 0,
+        'fk_entity' => NULL,
       ],
       $this->getCustomFieldName('state') => [
         'name' => $this->getCustomFieldName('state'),
@@ -819,6 +828,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'serialize' => 0,
+        'fk_entity' => NULL,
         'pseudoconstant' => [
           'table' => 'civicrm_state_province',
           'keyColumn' => 'id',
@@ -856,6 +866,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'serialize' => 1,
+        'fk_entity' => NULL,
         'pseudoconstant' => [
           'table' => 'civicrm_state_province',
           'keyColumn' => 'id',
@@ -902,6 +913,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'options_per_line' => NULL,
         'is_search_range' => '0',
         'serialize' => 0,
+        'fk_entity' => NULL,
         'pseudoconstant' => [
           'callback' => 'CRM_Core_SelectValues::boolean',
         ],
@@ -938,6 +950,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'options_per_line' => NULL,
         'is_search_range' => '0',
         'serialize' => '1',
+        'fk_entity' => NULL,
         'pseudoconstant' => [
           'optionGroupName' => $this->getOptionGroupName('checkbox'),
           'optionEditPath' => 'civicrm/admin/options/' . $this->getOptionGroupName('checkbox'),

--- a/tests/phpunit/CRM/Core/BAO/CustomQueryTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomQueryTest.php
@@ -86,8 +86,9 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
       'where' => 'civicrm_value_testsearchcus_' . $ids['custom_group_id'] . '.date_field_' . $dateCustomField['id'],
       'import' => 1,
       'serialize' => 0,
+      'fk_entity' => NULL,
     ], $queryObj->getFieldSpec('custom_' . $dateCustomField['id']));
-
+$temp = 1;
   }
 
   /**

--- a/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
@@ -213,7 +213,7 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
     $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
     $row = $dataSource->getRow();
     $this->assertEquals('ERROR', $row['_status']);
-    $this->assertEquals('Missing required fields: Participant ID OR Event ID', $row['_status_message']);
+    $this->assertEquals('Invalid value for field(s) : Event', $row['_status_message']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
**Note:** #32400 must be merged first.
https://lab.civicrm.org/dev/core/-/issues/5799
It's not currently possible to import an EntityReference custom field by anything but an ID.

Before
----------------------------------------
Import organization name "Default Organization" to an organization EntityReference custom field fails.

After
----------------------------------------
Succeeds.

Comments
----------------------------------------
I let the scope creep and tried to implement the TODO of making the code for event ID and campaign ID generic.  This led me to the bug fixed in #32400.

As a side effect, this gives a better error message when a field has an invalid value. I mentioned one example on the lab.c.o ticket but there's another one in the test I changed.