### PR TITLE
(dev/core#5594) Upgrade - Don't drop the current user ID after upgrade

### DIFF
--- a/CRM/Core/Session.php
+++ b/CRM/Core/Session.php
@@ -155,10 +155,10 @@ class CRM_Core_Session {
    * @param int|string $mode
    *   1: Default mode. Deletes the `CiviCRM` data from $_SESSION.
    *   2: More invasive version of that. (somehow)
-   *   'partial': Less invasive. Preserve basic data (eg current user ID) from this session. Reset everything else.
+   *   'keep_login': Less invasive. Preserve basic data (current user ID) from this session. Reset everything else.
    */
   public function reset($mode = 1) {
-    if ($mode === 'partial') {
+    if ($mode === 'keep_login') {
       if (!empty($this->_session[$this->_key])) {
         $this->_session[$this->_key] = CRM_Utils_Array::subset(
           $this->_session[$this->_key],

--- a/CRM/Core/Session.php
+++ b/CRM/Core/Session.php
@@ -152,10 +152,21 @@ class CRM_Core_Session {
   /**
    * Resets the session store.
    *
-   * @param int $all
+   * @param int|string $mode
+   *   1: Default mode. Deletes the `CiviCRM` data from $_SESSION.
+   *   2: More invasive version of that. (somehow)
+   *   'partial': Less invasive. Preserve basic data (eg current user ID) from this session. Reset everything else.
    */
-  public function reset($all = 1) {
-    if ($all != 1) {
+  public function reset($mode = 1) {
+    if ($mode === 'partial') {
+      if (!empty($this->_session[$this->_key])) {
+        $this->_session[$this->_key] = CRM_Utils_Array::subset(
+          $this->_session[$this->_key],
+          ['ufID', 'userID', 'authx']
+        );
+      }
+    }
+    elseif ($mode != 1) {
       $this->initialize();
 
       // to make certain we clear it, first initialize it to empty

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -833,7 +833,7 @@ SET    version = '$version'
    */
   public static function doFinish(): bool {
     $session = CRM_Core_Session::singleton();
-    $session->reset('partial');
+    $session->reset('keep_login');
     return TRUE;
   }
 

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -833,7 +833,7 @@ SET    version = '$version'
    */
   public static function doFinish(): bool {
     $session = CRM_Core_Session::singleton();
-    $session->reset(2);
+    $session->reset('partial');
     return TRUE;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

At the end of a web-based upgrade (eg `civicrm/upgrade?action=finish`), it clears out session-data for the current user. The effect of this feels different based on environment:

* On most CMS/UF environments (Drupal, WordPress, Joomla), the effect is pretty subtle. (*The reset only affects Civi QuickForm -- e.g. if the admin was filling out a contribution-page during the upgrade-process, then the pending form-state would be lost. The regular CMS session survives.*)
* On "Standalone", the effect is heavy-handed -- a complete logout. The admin-user must login again after upgrade.

https://lab.civicrm.org/dev/core/-/issues/5594 (ping @ufundo)

Before
----------------------------------------

After upgrade, destroy all CiviCRM session-state for current user.

After
----------------------------------------

After upgrade, destroy _most_ CiviCRM session-state for current user. (But not their ID.)

Comments
----------------------------------------

There's more discussion about ways to respond to this bug in https://lab.civicrm.org/dev/core/-/issues/5594.
* I kinda think `CRM_Upgrade_Form::doFinish()` could drop the entire reference to `$session->reset()`, but I don't know how to QA that. 
* This PR is moderately-conservative. It generally retains the reset, but excludes key data. It applies the same behavior to all UFs. (I suspect it also fixes some low-priority edge-cases on other UFs.)

I have `r-run` locally on an upgrade with `Standalone` for 5.81=>6., and (for me) this fixes the logout.