### PR TITLE
Fix validation regression on 6.1

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -137,7 +137,7 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
     try {
       $parser = $self->getParser();
       $rule = $parser->getDedupeRule($self->getContactType(), $self->getUserJob()['metadata']['entity_configuration']['Contact']['dedupe_rule'] ?? NULL);
-      $mapperError = $self->validateContactFields($rule, $fields['mapper'], ['external_identifier', 'contribution_contact_id', 'contact__id']);
+      $mapperError = $self->validateContactFields($rule, $fields['mapper'], ['contact_id', 'external_identifier']);
       $parser->validateMapping($fields['mapper']);
     }
     catch (CRM_Core_Exception $e) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix validation regression on 6.1  - import contribution

Before
----------------------------------------
It is using the wrong field name when confirming if the contact ID is present

After
----------------------------------------
FIxed

Technical Details
----------------------------------------
These field names were standardised in 6.1

Comments
----------------------------------------
