### PR TITLE
Fix notice in help text on settings pages

### DIFF
--- a/CRM/Core/Smarty/plugins/function.help.php
+++ b/CRM/Core/Smarty/plugins/function.help.php
@@ -34,6 +34,13 @@
  *   the help html to be inserted
  */
 function smarty_function_help($params, $smarty) {
+  if (isset($params['values']) && is_array($params['values'])) {
+    // Passing in values is way easier at the smarty level as it likely already
+    // has a field spec. Use/ prefer values.
+    $params = array_merge($params, $params['values']);
+    unset($params['values']);
+  }
+
   if (!isset($params['id']) || !isset($smarty->getTemplateVars()['config'])) {
     return NULL;
   }

--- a/templates/CRM/Core/Form/Field.tpl
+++ b/templates/CRM/Core/Form/Field.tpl
@@ -11,7 +11,9 @@
   {include file=$fieldSpec.template}
 {else}
   <td class="label">{$form.$fieldName.label}
-    {if array_key_exists('help', $fieldSpec) && $fieldSpec.help.id}{help id=$fieldSpec.help.id file=$fieldSpec.help.file}{/if}
+    {if array_key_exists('help', $fieldSpec) && $fieldSpec.help.id}
+      {help values=$fieldSpec.help title=$fieldSpec.title}
+    {/if}
     {if $action == 2 && array_key_exists('is_add_translate_dialog', $fieldSpec)}{include file='CRM/Core/I18n/Dialog.tpl' table=$entityTable field=$fieldName id=$entityID}{/if}
   </td>
   <td>


### PR DESCRIPTION
Overview
----------------------------------------
Fix notice in help text on settings pages

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/0747578b-7e5f-494d-89c0-e43dd1b46a46)


After
----------------------------------------
Notice gone, help text still works

![image](https://github.com/user-attachments/assets/d094f42d-7fee-4247-9e75-081282c797fc)


Technical Details
----------------------------------------
I'm pretty sure `title` would always be set at the `fieldSpec` level here - so we can add it as a fallback & avoid the really bonkers stuff in that function. But, if it isn't I think it will get flushed out pretty quickly as a new notice on master & there is 6 weeks before that would go live - we will push it out to prod now-ish

Comments
----------------------------------------
