### PR TITLE
Fix Participant Fee Calculation On Contribution Edit

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -2029,13 +2029,17 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         $entityTable = 'participant';
         $entityID = $pId;
         $isRelatedId = FALSE;
-        $participantParams = [
-          'fee_amount' => $submittedValues['total_amount'],
-          'id' => $entityID,
-        ];
-        CRM_Event_BAO_Participant::add($participantParams);
-        if (empty($this->_lineItems)) {
-          $this->_lineItems[] = CRM_Price_BAO_LineItem::getLineItems($entityID, 'participant', TRUE);
+        $participantIds = CRM_Event_BAO_Participant::getParticipantIds($this->_id);
+        $fee = CRM_Utils_Money::format($submittedValues['total_amount'] / count($participantIds), NULL, NULL, TRUE);
+        foreach ($participantIds as $participantId) {
+          $participantParams = [
+            'fee_amount' => $fee,
+            'id'         => $participantId,
+          ];
+          CRM_Event_BAO_Participant::add($participantParams);
+          if (empty($this->_lineItems)) {
+            $this->_lineItems[] = CRM_Price_BAO_LineItem::getLineItems($participantId, 'participant', TRUE);
+          }
         }
       }
       else {


### PR DESCRIPTION
Overview
----------------------------------------
Currently when someone registers multiple participants for an event, editing the contribution will change the participant's fee_amount for the last participant.

This is in explained in detail here https://lab.civicrm.org/dev/core/-/issues/3859

Technical Details
----------------------------------------
This happens at `CRM_Contribute_Form_Contribution::submit()` [line 1580](https://github.com/civicrm/civicrm-core/blob/76fd5a1cea97f280e24604e741dafa0dad303af5/CRM/Contribute/Form/Contribution.php#L1580).

We call `CRM_Contribute_BAO_Contribution::getComponentDetails()` which claims it "Returns all contribution related object ids" but assumes that there is only one participant (and membership) record tied to a contribution. So it returns the participant ID of the last person registered, and then at line 1611-1614, resaves the participant record with the total amount of the contribution.This happens at CRM_Contribute_Form_Contribution::submit() [line 1580](https://github.com/civicrm/civicrm-core/blob/76fd5a1cea97f280e24604e741dafa0dad303af5/CRM/Contribute/Form/Contribution.php#L1580).
We call CRM_Contribute_BAO_Contribution::getComponentDetails() which claims it "Returns all contribution related object ids" but assumes that there is only one participant (and membership) record tied to a contribution.  So it returns the participant ID of the last person registered, and then it resaves the participant record with the total amount of the contribution.

This pr fixes the issue by looping through the list of all related participants.
