### PR TITLE
dev/core#5801 Form Builder: repeating with join gives an error

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -616,7 +616,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
           foreach ($joinValues as $index => $vals) {
             // $vals could be NULL when a join is in a repeating group.
             // Then $joinValues[0] = null and $joinValues[1] = array
-            if ($vals === null) {
+            if ($vals === NULL) {
               unset($joinValues[$index]);
               continue;
             }

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -614,6 +614,12 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
           // Enforce the limit set by join[max]
           $joinValues = array_slice($joinValues, 0, $entity['joins'][$joinEntity]['max'] ?? NULL);
           foreach ($joinValues as $index => $vals) {
+            // $vals could be NULL when a join is in a repeating group.
+            // Then $joinValues[0] = null and $joinValues[1] = array
+            if ($vals === null) {
+              unset($joinValues[$index]);
+              continue;
+            }
             // As with the main entity, use default values from DisplayOnly fields + values from submittable fields
             $joinValues[$index] = $this->getForcedDefaultValues($entity['joins'][$joinEntity]['fields'] ?? []);
             $joinValues[$index] += array_intersect_key($vals, $allowedFields);


### PR DESCRIPTION
Overview
----------------------------------------

When creating a form with a repeating contact fieldset on it (with the fields for name and email address) submitting the form with more than one entry gives an error.

Reproduction steps
----------------------------------------
1. Create a new Form Builder form
1. Keep the fields for first name, middle name and last name
1. Add an email block. Set the block to primary and location type home
1. Set the fieldset for Contact 1 to repeating (do this by clicking on the configure icon)
3. Save the form
4. Now try to use the form and enter more than one contact

Current behaviour
----------------------------------------

The form is not submitted and gives an error.

Expected behaviour
----------------------------------------

Form submitted succesfully.

Technical Details
----------------------------------------

A follow up join in a repeating entity (e.g. the second item) has index 0 set to `NULL` and index 1 set to an array.

Comments
----------------------------------------

See https://lab.civicrm.org/dev/core/-/issues/5801
