### PR TITLE
[REF] riverlea - rename crm-c-alert and friends to crm-c-danger

### DIFF
--- a/ext/riverlea/core/ang/crmStatusPage.css
+++ b/ext/riverlea/core/ang/crmStatusPage.css
@@ -18,8 +18,8 @@
 #crm-status-list .crm-severity-alert,
 #crm-status-list .crm-severity-critical,
 #crm-status-list .crm-severity-error {
-  background-color: var(--crm-c-alert);
-  color: var(--crm-c-alert-text);
+  background-color: var(--crm-c-danger);
+  color: var(--crm-c-danger-text);
 }
 /* Warning Severity */
 #crm-status-list .crm-severity-warning {

--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -236,7 +236,7 @@ dl dl {
 #bootstrap-theme .has-error.checkbox label,
 #bootstrap-theme .has-error.radio-inline label,
 #bootstrap-theme .has-error.checkbox-inline label {
-  color: var(--crm-c-alert);
+  color: var(--crm-c-danger);
 }
 .crm-container .font-red {
   color: var(--crm-c-red-dark);
@@ -325,7 +325,7 @@ dl dl {
   color: var(--crm-c-warning);
 }
 .crm-container .text-danger {
-  color: var(--crm-c-alert);
+  color: var(--crm-c-danger);
 }
 .crm-container h1,
 .crm-container h2,

--- a/ext/riverlea/core/css/_bootstrap.css
+++ b/ext/riverlea/core/css/_bootstrap.css
@@ -1829,18 +1829,18 @@ fieldset[disabled] #bootstrap-theme .btn-link:focus {
 }
 #bootstrap-theme .has-error .form-control,
 #bootstrap-theme .has-error .form-control a.select2-default {
-  border-color: var(--crm-c-alert);
+  border-color: var(--crm-c-danger);
 }
 #bootstrap-theme .has-error .form-control:focus {
-  border-color: var(--crm-c-alert);
+  border-color: var(--crm-c-danger);
 }
 #bootstrap-theme .has-error .input-group-addon {
-  color: var(--crm-c-alert);
+  color: var(--crm-c-danger);
   background-color: # var(--crm-c-red-light);
-  border-color: var(--crm-c-alert);
+  border-color: var(--crm-c-danger);
 }
 #bootstrap-theme .has-error .form-control-feedback {
-  color: var(--crm-c-alert);
+  color: var(--crm-c-danger);
 }
 
 /* Nav */
@@ -2641,7 +2641,7 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
   background-image: linear-gradient(45deg, rgba(255, 255, 255, .15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .15) 50%, rgba(255, 255, 255, .15) 75%, transparent 75%, transparent);
 }
 #bootstrap-theme .progress-bar-danger {
-  background-color: var(--crm-c-alert);
+  background-color: var(--crm-c-danger);
 }
 .progress-striped #bootstrap-theme .progress-bar-danger {
   background-image: linear-gradient(45deg, rgba(255, 255, 255, .15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .15) 50%, rgba(255, 255, 255, .15) 75%, transparent 75%, transparent);
@@ -2902,9 +2902,9 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 #bootstrap-theme button.list-group-item-danger.active,
 #bootstrap-theme button.list-group-item-danger.active:hover,
 #bootstrap-theme button.list-group-item-danger.active:focus {
-  color: var(--crm-c-alert-text);
-  background-color: var(--crm-c-alert);
-  border-color: var(--crm-c-alert);
+  color: var(--crm-c-danger-text);
+  background-color: var(--crm-c-danger);
+  border-color: var(--crm-c-danger);
 }
 #bootstrap-theme .list-group-item-heading {
   margin-top: 0;
@@ -3445,12 +3445,12 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
   background: linear-gradient(to top,rgba(0, 0, 0, 0.125),rgba(0, 0, 0, 0.125)) var(--crm-c-warning);
 }
 #bootstrap-theme .label-danger {
-  background: var(--crm-c-alert);
-  color: var(--crm-c-alert-text);
+  background: var(--crm-c-danger);
+  color: var(--crm-c-danger-text);
 }
 #bootstrap-theme .label-danger[href]:hover,
 #bootstrap-theme .label-danger[href]:focus {
-  background: linear-gradient(to top,rgba(0, 0, 0, 0.125),rgba(0, 0, 0, 0.125)) var(--crm-c-alert);
+  background: linear-gradient(to top,rgba(0, 0, 0, 0.125),rgba(0, 0, 0, 0.125)) var(--crm-c-danger);
 }
 #bootstrap-theme .label i.crm-i {
   color: inherit; /* resets icons inside lables to use the label text colour */

--- a/ext/riverlea/core/css/_fixes.css
+++ b/ext/riverlea/core/css/_fixes.css
@@ -182,7 +182,7 @@ a.crm-expand-row:focus {
 .crm-container .status-past,
 .crm-contact-deceased,
 .crm-container .status-warning {
-  color: var(--crm-c-alert);
+  color: var(--crm-c-danger);
 }
 .crm-container .alert.alert-info.font-red { /* for when an info alert wants to be a danger alert! */
   background-color: var(--crm-alert-background-danger);

--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -68,8 +68,8 @@
   --crm-c-secondary-hover-text: var(--crm-c-text-light);
   --crm-c-success: var(--crm-c-green-dark);
   --crm-c-success-text: var(--crm-c-text-light);
-  --crm-c-alert: var(--crm-c-red-dark);
-  --crm-c-alert-text: var(--crm-c-text-light);
+  --crm-c-danger: var(--crm-c-red-dark);
+  --crm-c-danger-text: var(--crm-c-text-light);
   --crm-c-warning: var(--crm-c-amber);
   --crm-c-warning-text: var(--crm-c-text-light);
   --crm-c-info: var(--crm-c-blue-dark);
@@ -138,16 +138,16 @@
   --crm-btn-height: 28px;
   --crm-btn-icon-spacing: var(--crm-s);
   --crm-btn-icon-size: auto;
-  --crm-btn-cancel-bg: var(--crm-c-alert);
-  --crm-btn-cancel-text: var(--crm-c-alert-text);
+  --crm-btn-cancel-bg: var(--crm-c-danger);
+  --crm-btn-cancel-text: var(--crm-c-danger-text);
   --crm-btn-info-bg: var(--crm-c-info);
   --crm-btn-info-text: var(--crm-c-info-text);
   --crm-btn-warning-bg: var(--crm-c-warning);
   --crm-btn-warning-text: var(--crm-c-warning-text);
   --crm-btn-success-bg: var(--crm-c-success);
   --crm-btn-success-text: var(--crm-c-success-text);
-  --crm-btn-alert-bg: var(--crm-c-alert);
-  --crm-btn-alert-text: var(--crm-c-alert-text);
+  --crm-btn-danger-bg: var(--crm-c-danger);
+  --crm-btn-danger-text: var(--crm-c-danger-text);
   --crm-btn-icon-bg: unset; /* btn-icon-* supports distinct border/bg for icons. If applied, set btn-icon-padding to 0px to make the icon bg stretch to the button */
   --crm-btn-icon-border: unset;
   --crm-btn-icon-padding: var(--crm-btn-padding-block);
@@ -370,7 +370,7 @@
   --crm-dropdown-hover-bg: var(--crm-c-page-background);
   --crm-dropdown-border: 0;
   --crm-dropdown-width: 180px;
-  --crm-dropdown-alert-bg: var(--crm-c-alert); /* for delete links in dropdowns */
+  --crm-dropdown-danger-bg: var(--crm-c-danger); /* for delete links in dropdowns */
   --crm-dropdown-2-bg: var(--crm-c-secondary);
   --crm-dropdown-2-col: var(--crm-c-text);
   --crm-dropdown-2-padding: var(--crm-padding-small);
@@ -380,19 +380,19 @@
   --crm-notify-col: var(--crm-c-text-light);
   --crm-notify-accent-border: 2px 0 0 0; /* adds a border to one/several sides of the notification - set to 0 for none */
   --crm-notify-radius: var(--crm-roundness);
-  --crm-notify-alert: #d02e2e;
+  --crm-notify-danger: #d02e2e;
   --crm-notify-warning: #f6721e;
   --crm-notify-success: #9bc27b;
   --crm-notify-info: #34a0cf;
 /* Icons */
-  --crm-icon-alert: "\f071";
+  --crm-icon-danger: "\f071";
   --crm-icon-success: "\f058";
   --crm-icon-info: "\f05a";
   --crm-icon-close: "\f00d";
   --crm-icon-sort: "\f0dc";
   --crm-icon-sort-desc: "\f0dd";
   --crm-icon-sort-asc: "\f0de";
-  --crm-icon-alert-color: inherit;
+  --crm-icon-danger-color: inherit;
   --crm-icon-success-color: inherit;
   --crm-icon-warning-color: inherit;
   --crm-icon-info-color: inherit;

--- a/ext/riverlea/core/css/components/_buttons.css
+++ b/ext/riverlea/core/css/components/_buttons.css
@@ -153,13 +153,13 @@
   color: var(--crm-btn-success-text);
 }
 #bootstrap-theme .btn-danger {
-  background: var(--crm-btn-alert-bg);
-  color: var(--crm-btn-alert-text);
+  background: var(--crm-btn-danger-bg);
+  color: var(--crm-btn-danger-text);
 }
 #bootstrap-theme .btn.btn-danger:hover,
 #bootstrap-theme .btn.btn-danger:focus {
-  background: linear-gradient(to top,rgba(0, 0, 0, 0.125),rgba(0, 0, 0, 0.125)) var(--crm-btn-alert-bg);
-  color: var(--crm-btn-alert-text);
+  background: linear-gradient(to top,rgba(0, 0, 0, 0.125),rgba(0, 0, 0, 0.125)) var(--crm-btn-danger-bg);
+  color: var(--crm-btn-danger-text);
 }
 
 /* BS3 size options */

--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -300,12 +300,12 @@ table.advmultiselect {
   color: var(--crm-c-warning-text);
 }
 .crm-container .panel-danger > .panel-heading {
-  color: var(--crm-c-alert);
+  color: var(--crm-c-danger);
   background-color: var(--crm-c-red-light);
 }
 .crm-container .panel-danger > .panel-heading .badge,
 .crm-container .panel-danger > .panel-heading a {
-  color: var(--crm-c-alert);
+  color: var(--crm-c-danger);
 }
 .crm-container .panel:has(.nav.nav-tabs) {
   border: var(--crm-tabs-border);
@@ -386,14 +386,14 @@ table.advmultiselect {
   border-color: transparent;
 }
 .crm-container #civicrm-footer .status.crm-error {
-  background-color: var(--crm-c-alert);
-  color: var(--crm-c-alert-text);
+  background-color: var(--crm-c-danger);
+  color: var(--crm-c-danger-text);
 }
 #civicrm-footer .status a {
   color: inherit;
 }
 .crm-container #civicrm-footer .status.crm-error a {
-  color: var(--crm-c-alert-text);
+  color: var(--crm-c-danger-text);
 }
 
 /* Upgrade screen (overwrites inline css) */
@@ -507,7 +507,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
   background: var(--crm-c-success);
 }
 .crm-status-box-outer.status-error .crm-status-box-inner {
-  background: var(--crm-c-alert);
+  background: var(--crm-c-danger);
 }
 
 /* Background regions */
@@ -576,18 +576,18 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
 #bootstrap-theme .bg-danger,
 #bootstrap-theme .dropdown-menu .bg-danger a,
 #bootstrap-theme .dropdown-menu a.bg-danger {
-  background-color: var(--crm-c-alert);
-  color: var(--crm-c-alert-text);
+  background-color: var(--crm-c-danger);
+  color: var(--crm-c-danger-text);
 }
 #bootstrap-theme a.bg-danger:hover,
 #bootstrap-theme a.bg-danger:focus,
 #bootstrap-theme .dropdown-menu .bg-danger a:hover,
 #bootstrap-theme .dropdown-menu a.bg-danger:hover {
-  background: linear-gradient(to top,rgba(0, 0, 0, 0.125),rgba(0, 0, 0, 0.125)) var(--crm-c-alert);
-  color: var(--crm-c-alert-text);
+  background: linear-gradient(to top,rgba(0, 0, 0, 0.125),rgba(0, 0, 0, 0.125)) var(--crm-c-danger);
+  color: var(--crm-c-danger-text);
 }
 #bootstrap-theme .dropdown-menu .bg-danger .crm-i::before {
-  color: var(--crm-c-alert-text);
+  color: var(--crm-c-danger-text);
 }
 #bootstrap-theme .dropdown-menu .bg-warning .crm-i::before {
   color: var(--crm-c-warning-text);

--- a/ext/riverlea/core/css/components/_dialogs.css
+++ b/ext/riverlea/core/css/components/_dialogs.css
@@ -174,7 +174,7 @@
   text-decoration: underline;
 }
 #crm-notification-container div.ui-notify-message-style.error {
-  border-color: var(--crm-notify-alert);
+  border-color: var(--crm-notify-danger);
 }
 #crm-notification-container div.ui-notify-message-style.alert,
 #crm-notification-container div.ui-notify-message-style.warning {
@@ -220,7 +220,7 @@
 #crm-notification-container div.ui-notify-message-style a.ui-button.ui-widget,
 #crm-notification-container div.ui-notify-message-style a.ui-button.ui-widget:hover,
 #crm-notification-container div.ui-notify-message-style a.ui-button.ui-widget:focus {
-  background: var(--crm-notify-alert);
+  background: var(--crm-notify-danger);
   border: 0;
 }
 

--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -414,10 +414,10 @@
 #afGuiEditor  .af-gui-bar .dropdown-menu a:has(.text-danger) {
   display: flex;
   justify-content: center;
-  background: var(--crm-dropdown-alert-bg);
+  background: var(--crm-dropdown-danger-bg);
 }
 #afGuiEditor  .af-gui-bar .dropdown-menu .text-danger {
-  color: var(--crm-c-alert-text);
+  color: var(--crm-c-danger-text);
 }
 
 /* JsTree Dropdown - all of Vakata Context, from jstree/dist has to be overwritten with !important */

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -85,7 +85,7 @@
   margin-bottom: var(--crm-flex-gap);
 }
 .crm-container .crm-marker {
-  color: var(--crm-c-alert);
+  color: var(--crm-c-danger);
 }
 .crm-container .form-inline {
   padding: var(--crm-s) 0;
@@ -115,7 +115,7 @@
 
 /* Required Mark */
 .crm-container .required-mark::after {
-  color: var(--crm-c-alert);
+  color: var(--crm-c-danger);
   content: "*";
   margin-left: var(--crm-s);
 }
@@ -182,7 +182,7 @@ select.crm-form-select:focus,
 .crm-container input.error,
 input.crm-error,
 select.crm-error {
-  border-color: var(--crm-c-alert);
+  border-color: var(--crm-c-danger);
 }
 .crm-container :focus,
 .crm-container .ui-dialog :focus {
@@ -261,7 +261,7 @@ input.crm-form-entityref {
   color: var(--crm-c-success) !important;
 }
 .crm-container .crm-editable-form [type="cancel"] {
-  color: var(--crm-c-alert) !important;
+  color: var(--crm-c-danger) !important;
 }
 /* in place edit  */
 .crm-container .crm-inline-edit,

--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -39,8 +39,8 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 }
 .crm-container #crm-notification-container div.ui-notify-message.error h1::before,
 .crm-container span.batch-invalid::before {
-  content: var(--crm-icon-alert);
-  color: var(--crm-notify-alert);
+  content: var(--crm-icon-danger);
+  color: var(--crm-notify-danger);
 }
 .crm-container #crm-notification-container div.ui-notify-message.success h1::before,
 .crm-container span.batch-valid::before {
@@ -54,7 +54,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 }
 .crm-container #crm-notification-container div.ui-notify-message.alert h1::before,
 .crm-container #crm-notification-container div.ui-notify-message.warning h1::before {
-  content: var(--crm-icon-alert);
+  content: var(--crm-icon-danger);
   color: var(--crm-notify-warning);
 }
 .crm-container .messages.crm-empty-table > i.crm-i {
@@ -109,7 +109,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 .crm-container .crm-i.fa-times,
 .crm-container .btn-danger .crm-i,
 .crm-container button .fa-times {
-  color: var(--crm-icon-alert-color);
+  color: var(--crm-icon-danger-color);
 }
 .crm-container .crm-dashlet-header a.fa-times {
   color: var(--crm-dashlet-header-col);
@@ -219,11 +219,11 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 .crm-container .delete-icon::before,
 .crm-container .crm-i.fa-trash::before {
   content: "\f1f8";
-  color: var(--crm-icon-alert-color);
+  color: var(--crm-icon-danger-color);
 }
 .crm-container .delete-icon:hover::before,
 .crm-container .delete-icon:focus::before {
-  color: var(--crm-icon-alert-color);
+  color: var(--crm-icon-danger-color);
 }
 
 /* Jqueery UI icons (tags) */
@@ -265,7 +265,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
   color: var(--crm-c-text);
 }
 .crm-container .jstree-default .jstree-search {
-  color: var(--crm-c-alert);
+  color: var(--crm-c-danger);
   font-weight: normal;
 }
 .crm-container #navigation-tree li.jstree-node {

--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -296,17 +296,17 @@ div.crm-inline-edit-form div.crm-clear {
   margin-bottom: .25em;
 }
 #crm-contact-actions-list a.delete {
-  background: var(--crm-dropdown-alert-bg);
-  color: var(--crm-c-alert-text);
+  background: var(--crm-dropdown-danger-bg);
+  color: var(--crm-c-danger-text);
   border-radius: var(--crm-roundness);
 }
 #crm-contact-actions-list a.delete .crm-i.fa-trash::before {
-  color: var(--crm-c-alert-text);
+  color: var(--crm-c-danger-text);
 }
 #crm-contact-actions-list a.delete:hover,
 #crm-contact-actions-list a.delete:focus {
-  color: var(--crm-c-alert-text);
-  background: linear-gradient(to top,rgba(0, 0, 0, 0.125),rgba(0, 0, 0, 0.125)) var(--crm-c-alert);
+  color: var(--crm-c-danger-text);
+  background: linear-gradient(to top,rgba(0, 0, 0, 0.125),rgba(0, 0, 0, 0.125)) var(--crm-c-danger);
 }
 
 /* Tags */

--- a/ext/riverlea/core/css/crm.designer.css
+++ b/ext/riverlea/core/css/crm.designer.css
@@ -100,11 +100,11 @@
   min-height: 500px;
 }
 .crm-designer-duplicate .crm-designer-row {
-  background: var(--crm-c-alert);
+  background: var(--crm-c-danger);
 }
 .crm-designer-duplicate .field-location_type_id,
 .crm-designer-duplicate .field-phone_type_id {
-  color: var(--crm-c-alert-text);
+  color: var(--crm-c-danger-text);
 }
 .crm-designer-row .crm-designer-buttons {
   right: 5px;
@@ -153,8 +153,8 @@ button#crm-designer-add-custom-set {
   text-decoration: none;
 }
 .crm-designer-row .crm-designer-buttons a.crm-designer-action-remove:hover {
-  background-color: var(--crm-c-alert);
-  color: var(--crm-c-alert-text);
+  background-color: var(--crm-c-danger);
+  color: var(--crm-c-danger-text);
   text-decoration: none;
 }
 .crm-designer-row,

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -425,7 +425,7 @@ af-gui-container > .af-gui-bar,
 }
 #afGuiEditor .af-gui-field-required:after {
   content: '*';
-  color: var(--crm-c-alert);
+  color: var(--crm-c-danger);
   position: relative;
   left: -4px;
 }

--- a/ext/riverlea/streams/empty/css/_dark.css
+++ b/ext/riverlea/streams/empty/css/_dark.css
@@ -10,7 +10,7 @@
   --crm-c-background4: var(--crm-c-gray-600);
   --crm-c-code-background: var(--crm-c-gray-200);
   --crm-c-success: #58a458;
-  --crm-c-alert: #ff899a;
+  --crm-c-danger: #ff899a;
   --crm-c-green-light: #468847;
   --crm-c-green: #55aa57;
   --crm-c-green-dark: #dff0d8;

--- a/ext/riverlea/streams/empty/css/_variables.css
+++ b/ext/riverlea/streams/empty/css/_variables.css
@@ -69,8 +69,8 @@
 --crm-c-secondary-hover-text: var(--crm-c-text-light);
 --crm-c-success: var(--crm-c-green-dark);
 --crm-c-success-text: var(--crm-c-text-light);
---crm-c-alert: var(--crm-c-red-dark);
---crm-c-alert-text: var(--crm-c-text-light);
+--crm-c-danger: var(--crm-c-red-dark);
+--crm-c-danger-text: var(--crm-c-text-light);
 --crm-c-warning: var(--crm-c-amber);
 --crm-c-warning-text: var(--crm-c-text-light);
 --crm-c-info: var(--crm-c-blue-dark);
@@ -137,16 +137,16 @@
 --crm-btn-height: 28px;
 --crm-btn-icon-spacing: var(--crm-s);
 --crm-btn-icon-size: auto;
---crm-btn-cancel-bg: var(--crm-c-alert);
---crm-btn-cancel-text: var(--crm-c-alert-text);
+--crm-btn-cancel-bg: var(--crm-c-danger);
+--crm-btn-cancel-text: var(--crm-c-danger-text);
 --crm-btn-info-bg: var(--crm-c-info);
 --crm-btn-info-text: var(--crm-c-info-text);
 --crm-btn-warning-bg: var(--crm-c-warning);
 --crm-btn-warning-text: var(--crm-c-warning-text);
 --crm-btn-success-bg: var(--crm-c-success);
 --crm-btn-success-text: var(--crm-c-success-text);
---crm-btn-alert-bg: var(--crm-c-alert);
---crm-btn-alert-text: var(--crm-c-alert-text);
+--crm-btn-danger-bg: var(--crm-c-danger);
+--crm-btn-danger-text: var(--crm-c-danger-text);
 --crm-btn-icon-bg: ; /* btn-icon-* supports distinct border/bg for icons. If applied, set btn-icon-padding to 0px to make the icon bg stretch to the button *
 --crm-btn-icon-border: ;
 --crm-btn-icon-padding: var(--crm-btn-padding-block);
@@ -366,7 +366,7 @@
 --crm-dropdown-hover-bg: var(--crm-c-page-background);
 --crm-dropdown-border: 0;
 --crm-dropdown-width: 180px;
---crm-dropdown-alert-bg: var(--crm-c-alert); /* for delete links in dropdowns *
+--crm-dropdown-danger-bg: var(--crm-c-danger); /* for delete links in dropdowns *
 --crm-dropdown-2-bg: var(--crm-c-secondary);
 --crm-dropdown-2-col: var(--crm-c-text);
 --crm-dropdown-2-padding: var(--crm-padding-small);
@@ -377,14 +377,14 @@
 --crm-notify-accent-border: 2px 0 0 0; /* adds a border to one/several sides of the notification - set to 0 for none *
 --crm-notify-radius: var(--crm-roundness);
 /* Icons *
---crm-icon-alert: "\f06a";
+--crm-icon-danger: "\f06a";
 --crm-icon-success: "\f058";
 --crm-icon-info: "\f05a";
 --crm-icon-close: "\f00d";
 --crm-icon-sort: "\f0dc";
 --crm-icon-sort-desc: "\f0dd";
 --crm-icon-sort-asc: "\f0de";
---crm-icon-alert-color: inherit;
+--crm-icon-danger-color: inherit;
 --crm-icon-success-color: inherit;
 --crm-icon-warning-color: inherit;
 --crm-icon-info-color: inherit;

--- a/ext/riverlea/streams/hackneybrook/css/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/css/_dark.css
@@ -81,7 +81,7 @@
   --crm-form-block-background: var(--crm-c-background2);
   --crm-c-code-background: var(--crm-c-background2);
   --crm-filter-item-background: var(--crm-c-background2);
-  --crm-icon-alert-color: #ef415a;
+  --crm-icon-danger-color: #ef415a;
   --crm-icon-info-color: #39deff;
   --crm-icon-success-color: #4dc447;
   --crm-icon-warning-color: #fab488;

--- a/ext/riverlea/streams/hackneybrook/css/_variables.css
+++ b/ext/riverlea/streams/hackneybrook/css/_variables.css
@@ -47,8 +47,8 @@
   --crm-btn-warning-text: var(--crm-c-text);
   --crm-btn-success-bg: var(--crm-c-primary);
   --crm-btn-success-text: var(--crm-c-text);
-  --crm-btn-alert-bg: var(--crm-c-primary);
-  --crm-btn-alert-text: var(--crm-c-text);
+  --crm-btn-danger-bg: var(--crm-c-primary);
+  --crm-btn-danger-text: var(--crm-c-text);
   --crm-btn-icon-bg: rgba(256,256,256,0.25);
   --crm-btn-icon-border: var(--crm-btn-border);
   --crm-btn-icon-padding: 0px;
@@ -132,7 +132,7 @@
   --crm-notify-accent-border: 0 0 0 4px; /* adds a border to one/several sides of the notification - set to 0 for none */
   --crm-notify-radius: 0;
   /* Icons */
-  --crm-icon-alert-color: var(--crm-c-alert);
+  --crm-icon-danger-color: var(--crm-c-danger);
   --crm-icon-success-color: var(--crm-c-success);
   --crm-icon-warning-color: var(--crm-c-warning);
   --crm-icon-info-color: var(--crm-c-info);

--- a/ext/riverlea/streams/minetta/css/_dark.css
+++ b/ext/riverlea/streams/minetta/css/_dark.css
@@ -63,8 +63,8 @@
   --crm-input-radio-color: #38c4b4;
   --crm-alert-text-help: var(--crm-c-text);
   --crm-btn-cancel-bg: #9b3d4b;
-  --crm-btn-alert-bg: var(--crm-btn-cancel-bg);
-  --crm-btn-alert-text: var(--crm-c-text);
+  --crm-btn-danger-bg: var(--crm-btn-cancel-bg);
+  --crm-btn-danger-text: var(--crm-c-text);
   --crm-dialog-header-border-col: transparent;
   --crm-dialog-header-bg: var(--crm-c-background2);
   --crm-dialog-body-bg: var(--crm-c-background2);

--- a/ext/riverlea/streams/thames/css/_dark.css
+++ b/ext/riverlea/streams/thames/css/_dark.css
@@ -125,7 +125,7 @@
 .crm-container .status-past,
 .crm-contact-deceased,
 .crm-container .status-warning {
-  --crm-c-alert: var(--crm-c-red);
+  --crm-c-danger: var(--crm-c-red);
 }
 #civicrm-footer a,
 nav.breadcrumb a {

--- a/ext/riverlea/streams/thames/css/_variables.css
+++ b/ext/riverlea/streams/thames/css/_variables.css
@@ -83,8 +83,8 @@
   --crm-c-secondary-hover-text: var(--crm-c-text-light); /* thames todo */
   --crm-c-success: var(--crm-c-green-dark);
   --crm-c-success-text: var(--crm-c-text-light);
-  --crm-c-alert: var(--crm-c-red-dark); /* thames */
-  --crm-c-alert-text: var(--crm-c-text-light);
+  --crm-c-danger: var(--crm-c-red-dark); /* thames */
+  --crm-c-danger-text: var(--crm-c-text-light);
   --crm-c-warning: var(--crm-c-amber); /* bg on .btn-warning, .label-warming but border on notification .alert */
   --crm-c-warning-text: var(--crm-c-text);
   --crm-c-info: var(--crm-c-blue-dark);
@@ -168,8 +168,8 @@
   --crm-btn-warning-text: var(--crm-c-warning-text);
   --crm-btn-success-bg: var(--crm-c-info); /* thames */
   --crm-btn-success-text: #fff; /* thames */
-  --crm-btn-alert-bg: var(--crm-c-red);
-  --crm-btn-alert-text: var(--crm-c-red-dark);
+  --crm-btn-danger-bg: var(--crm-c-red);
+  --crm-btn-danger-text: var(--crm-c-red-dark);
   --crm-btn-icon-bg: unset;
   --crm-btn-icon-border: unset;
   --crm-btn-margin: var(--crm-m) 0;
@@ -410,7 +410,7 @@
   --crm-dropdown-hover-bg: var(--crm-c-blue-light); /* thames */
   --crm-dropdown-border: 0;
   --crm-dropdown-width: 23ch; /* thames */
-  --crm-dropdown-alert-bg: transparent; /* thames */
+  --crm-dropdown-danger-bg: transparent; /* thames */
   --crm-dropdown-2-bg: var(--crm-c-secondary);
   --crm-dropdown-2-col: var(--crm-c-text);
   --crm-dropdown-2-padding: var(--crm-padding-small);
@@ -422,21 +422,21 @@
   --crm-notify-col: var(--crm-c-text); /* thames */
   --crm-notify-accent-border: 0.875rem 0 0 0; /* adds a border to one/several sides of the notification - set to 0 for none */ /* thames */
   --crm-notify-radius: 4px; /* thames */
-  --crm-notify-alert: var(--crm-c-alert);
+  --crm-notify-danger: var(--crm-c-danger);
   --crm-notify-warning: var(--crm-c-warning);
   --crm-notify-success: var(--crm-c-success);
   --crm-notify-info: var(--crm-c-info);
 }
 :root {
 /* Icons */
-  --crm-icon-alert: "\f06a";
+  --crm-icon-danger: "\f06a";
   --crm-icon-success: "\f058";
   --crm-icon-info: "\f05a";
   --crm-icon-close: "\f00d";
   --crm-icon-sort: "\f0dc";
   --crm-icon-sort-desc: "\f0dd";
   --crm-icon-sort-asc: "\f0de";
-  --crm-icon-alert-color: inherit;
+  --crm-icon-danger-color: inherit;
   --crm-icon-success-color: inherit;
   --crm-icon-warning-color: inherit;
   --crm-icon-info-color: inherit;

--- a/ext/riverlea/streams/thames/css/civicrm.css
+++ b/ext/riverlea/streams/thames/css/civicrm.css
@@ -607,16 +607,16 @@ html.crm-standalone  nav.breadcrumb>ol {
 
 /* Override _dropdowns.css */
 #afGuiEditor .af-gui-bar .dropdown-menu {
-  --crm-c-alert-text: var(--crm-c-red-dark);
+  --crm-c-danger-text: var(--crm-c-red-dark);
 }
 /* Override contactSummary.css */
 #crm-contact-actions-list a.delete {
-  --crm-c-alert-text: var(--crm-c-red-dark);
+  --crm-c-danger-text: var(--crm-c-red-dark);
 }
 #crm-contact-actions-list a.delete:hover,
 #crm-contact-actions-list a.delete:focus {
   /* the hover state gives crm-c-red-dark to the background */
-  --crm-c-alert-text: var(--crm-c-red-light);
+  --crm-c-danger-text: var(--crm-c-red-light);
 }
 
 /* Fix Mosaico wizard */

--- a/ext/riverlea/streams/walbrook/css/_dark.css
+++ b/ext/riverlea/streams/walbrook/css/_dark.css
@@ -67,9 +67,9 @@
   --crm-btn-warning-bg: #7b4e14;
   --crm-c-success-text: var(--crm-c-text-light);
   --crm-c-warning-text: var(--crm-c-text-light);
-  --crm-c-alert: var(--crm-btn-cancel-bg);
+  --crm-c-danger: var(--crm-btn-cancel-bg);
   --crm-c-warning: var(--crm-btn-warning-bg);
-  --crm-btn-alert-bg: var(--crm-btn-cancel-bg);
+  --crm-btn-danger-bg: var(--crm-btn-cancel-bg);
   --crm-wizard-active-bg: var(--crm-c-primary);
   --crm-wizard-active-col: var(--crm-c-primary-text);
   --crm-dash-edit-border: 1px solid var(--crm-c-link-hover);

--- a/ext/riverlea/streams/walbrook/css/_variables.css
+++ b/ext/riverlea/streams/walbrook/css/_variables.css
@@ -49,7 +49,7 @@
   --crm-c-secondary-hover: var(--crm-c-purple-dark);
   --crm-c-success: var(--crm-c-green);
   --crm-c-success-text: var(--crm-c-text-dark);
-  --crm-c-alert: var(--crm-c-red);
+  --crm-c-danger: var(--crm-c-red);
   --crm-c-warning-text: var(--crm-c-text-dark);
   --crm-c-info-text: var(--crm-c-text-light);
 /* Shadows */
@@ -206,7 +206,7 @@
   --crm-notify-background: var(--crm-c-background);
   --crm-notify-col: var(--crm-c-text);
   --crm-notify-accent-border: 0 0 0 3px; /* adds a border to one/several sides of the notification - set to 0 for none */
-  --crm-notify-alert: #d02e2e;
+  --crm-notify-danger: #d02e2e;
   --crm-notify-warning: #c45008;
   --crm-notify-success: #5a803c;
   --crm-notify-info: #277fa5;


### PR DESCRIPTION
Overview
----------------------------------------
This renames `crm-c-alert` and associated vars to `crm-c-danger`.

This matches our colour palettes (info/success/danger/warning/info)  to bootstrap (currently this is the odd one out).

It also avoids the clash with alert components, which use these colour schemes. Currently we have `crm-alert-background-info`, `crm-alert-background-success`, `crm-alert-background-.... alert?` - but `danger` is already used for the last of those. So this makes it consistent.

It's just a relabelling exercise, so shouldn't have any functional impact.

Before
----------------------------------------
- inconsistency with familiar Bootstrap color schemes
- inconsistency in the alert component colours - `crm-alert-background-danger` uses `crm-c-alert`, and most alerts dont use `crm-c-alert`

After
----------------------------------------
- consistency with Bootstrap color schemes
- no confusion around alert components having different colours
- inconsistent use of colour and color in this description...

Technical Details
----------------------------------------
All vars affected:
`--crm-c-alert`
`--crm-c-alert-text`
`--crm-notify-alert`
`--crm-btn-alert-bg`
`--crm-btn-alert-text`
`--crm-icon-alert`
`--crm-icon-alert-color`
`--crm-dropdown-alert-bg`
