### PR TITLE
dev/core#5798 - fix contrast on standaloneusers role display

### DIFF
--- a/ext/standaloneusers/managed/SavedSearch_Permissions.mgd.php
+++ b/ext/standaloneusers/managed/SavedSearch_Permissions.mgd.php
@@ -117,7 +117,7 @@ foreach ($roles as $roleName => $roleLabel) {
     ],
     'cssRules' => [
       [
-        'text-success',
+        'bg-success',
         'granted_' . $roleName,
         '=',
         TRUE,


### PR DESCRIPTION
Overview
----------------------------------------
Update the role permissions screen to fix contrast issue https://lab.civicrm.org/dev/core/-/issues/5798

~~Incorporate icon change based on @vingle suggestion to use all circular checks. (Square checks suggest you can click to untick them, which in this case you cant)~~

(unbundled this change, screenshots are out of date in that regard)

Before
----------------------------------------
- ~~permissions are indicated by unfilled squares (granted) and unfilled circles (implied)~~
- permissions use `text-success` which currently has contrast issues
![image](https://github.com/user-attachments/assets/eba44389-b13b-4358-9273-64bda1739624)

![image](https://github.com/user-attachments/assets/cd74e466-c77f-4482-8fd2-f639f8450cc2)


After
----------------------------------------
- ~~permissions are indicated by filled circles (granted) and unfilled circles (implied)~~
- use `bg-success` which should always contrast well
![image](https://github.com/user-attachments/assets/e62fb15b-7b01-4560-9165-e0d754543c3a)

![image](https://github.com/user-attachments/assets/d6c6d3af-c4c8-4612-a221-f54c55c5d576)

