### PR TITLE
EntityBatch: clarify the entityType description

### DIFF
--- a/schema/Batch/EntityBatch.entityType.php
+++ b/schema/Batch/EntityBatch.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Entity Batch'),
     'title_plural' => ts('Entity Batches'),
-    'description' => ts('Batch entities (Contributions, Participants, Contacts) to a batch.'),
+    'description' => ts('Batch of Entities typically used for batch data entry (ex: Contribution, Participants, Contacts)'),
     'add' => '3.3',
   ],
   'getIndices' => fn() => [


### PR DESCRIPTION
Overview
----------------------------------------

Folks were confused about this description (initially raised by translators).

Before
----------------------------------------

Batch to batch.

After
----------------------------------------

Sounds like English but still cryptic because this is a less-known feature of CiviCRM.

Technical Details
----------------------------------------

This string is probably only visible in the API Explorer.

Reported by @dev-allinappli, with feedback from @wmortada and @demeritcowboy 