### PR TITLE
RiverLea 1.4.2 Colour Contrast Darkmode issues (/riverlea/-/issues/123)

### DIFF
--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -1,3 +1,6 @@
+1.4.2-6-2alpha
+ - CHANGED - emphasis colours in dark mode to resolve multiple colour contrast issues (https://lab.civicrm.org/extensions/riverlea/-/issues/123)
+
 1.4.1-6.2alpha
  - FIXED - start/end date appears inline (https://lab.civicrm.org/extensions/riverlea/-/issues/120)
  - FIXED - float of prev/next on contact dashboard on WordPress in some contexts (https://lab.civicrm.org/extensions/riverlea/-/issues/118).

--- a/ext/riverlea/core/css/_core.css
+++ b/ext/riverlea/core/css/_core.css
@@ -4,5 +4,5 @@
    can be merged later. */
 
 @import url(components/_accordion.css); @import url(components/_alerts.css); @import url(components/_buttons.css); @import url(components/_form.css); @import url(components/_icons.css); @import url(components/_nav.css); @import url(components/_tabs.css); @import url(components/_dropdowns.css); @import url(components/_tables.css); @import url(components/_dialogs.css); @import url(components/_page.css); @import url(components/_components.css); @import url(components/_front.css); :root {
-  --crm-release: '1.4.1-6.2alpha';
+  --crm-release: '1.4.2-6.2alpha';
 }

--- a/ext/riverlea/info.xml
+++ b/ext/riverlea/info.xml
@@ -12,7 +12,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>[civicrm.releaseDate]</releaseDate>
-  <version>1.4.1-[civicrm.version]</version>
+  <version>1.4.2-[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>

--- a/ext/riverlea/streams/hackneybrook/css/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/css/_dark.css
@@ -18,12 +18,8 @@
   --crm-c-red: #b3001b;
   --crm-c-red-dark: #a11b1f;
   --crm-c-red-light: #f1b6bd;
-  --crm-c-blue-light: #195e80;
+  /* --crm-c-blue-light: #195e80; */
   --crm-c-teal: #a3ebe6;
-  --crm-c-green-light: #1d3d1d;
-  --crm-c-green: #236225;
-  --crm-c-green-dark: #dff0d8;
-  --crm-c-success: var(--crm-c-green-light);
   --crm-c-gray-900: #2a2a2a;
   --crm-c-gray-800: #3b3b3b;
   --crm-c-gray-700: #535252;
@@ -35,6 +31,15 @@
   --crm-checkbox-list-bg: #665800;
   --crm-checkbox-list-bg2: #525209;
   --crm-checkbox-list-col: var(--crm-c-text-light);
+  --crm-c-info: var(--crm-c-blue-light);
+  --crm-c-info-text: var(--crm-c-blue-dark);
+  --crm-c-warning: var(--crm-c-yellow-light);
+  --crm-c-warning-text: var(--crm-c-text-dark);
+  --crm-c-success: var(--crm-c-green-light);
+  --crm-c-success-text: var(--crm-c-text-dark);
+  --crm-c-danger: var(--crm-c-red-light);
+  --crm-c-alert: var(--crm-c-red-light);
+  --crm-c-alert-text: var(--crm-c-text-dark);
   /* And others */
   --crm-c-focus: #00a3a5;
   --crm-btn-icon-bg: var(--crm-c-gray-700);
@@ -65,11 +70,7 @@
   --crm-table-odd-hover: var(--crm-c-gray-700);
   --crm-table-even-row: var(--crm-c-gray-700);
   --crm-table-even-hover: var(--crm-c-gray-600);
-  --crm-alert-text-help: var(--crm-c-text-light);
-  --crm-alert-text-warning: var(--crm-c-text-light);
-  --crm-alert-text-info: var(--crm-c-text-light);
-  --crm-alert-background-info: var(--crm-c-blue-dark);
-  --crm-alert-background-danger: #fcf3f5;
+  --crm-alert-text-help: var(--crm-c-green-dark);
   --crm-input-color: var(--crm-c-text);
   --crm-input-description: var(--crm-c-gray-300);
   --crm-dialog-header-border-col: transparent;
@@ -85,4 +86,7 @@
   --crm-icon-info-color: #39deff;
   --crm-icon-success-color: #4dc447;
   --crm-icon-warning-color: #fab488;
+}
+.crm-container .text-primary {
+  color: var(--crm-c-text);
 }

--- a/ext/riverlea/streams/minetta/css/_dark.css
+++ b/ext/riverlea/streams/minetta/css/_dark.css
@@ -12,14 +12,17 @@
   --crm-c-background2: var(--crm-c-gray-800);
   --crm-c-background3: var(--crm-c-gray-700);
   --crm-c-background4: var(--crm-c-gray-600);
+  --crm-c-info: var(--crm-c-blue-light);
+  --crm-c-info-text: var(--crm-alert-text-info);
+  --crm-c-warning: var(--crm-c-yellow-light);
+  --crm-c-warning-text: var(--crm-c-text-dark);
   --crm-c-success: var(--crm-c-green-light);
-  --crm-c-amber: #993b00;
-  --crm-c-red: #b3001b;
-  --crm-c-blue-light: #195e80;
+  --crm-c-success-text: var(--crm-alert-text-help);
+  --crm-c-danger: var(--crm-c-red-light);
+  --crm-c-alert: var(--crm-c-red-light);
+  --crm-c-alert-text: var(--crm-alert-text-danger);
+  /* --crm-c-blue-light: #195e80; */
   --crm-c-teal: #a3ebe6;
-  --crm-c-green-light: #366336;
-  --crm-c-green: #55aa57;
-  --crm-c-green-dark: #dff0d8;
   --crm-c-gray-900: #363636;
   --crm-c-gray-800: #464646;
   --crm-c-gray-700: #535252;
@@ -54,17 +57,10 @@
   --crm-table-odd-hover: var(--crm-c-gray-700);
   --crm-table-even-row: var(--crm-c-page-background);
   --crm-table-even-hover: var(--crm-c-gray-700);
-  --crm-alert-text-help: var(--crm-c-text-light);
-  --crm-alert-background-info: var(--crm-c-blue-dark);
-  --crm-alert-text-info: var(--crm-c-text-light);
   --crm-c-inactive: var(--crm-c-gray-400);
   --crm-input-color: var(--crm-c-text);
   --crm-input-description: var(--crm-c-gray-300);
   --crm-input-radio-color: #38c4b4;
-  --crm-alert-text-help: var(--crm-c-text);
-  --crm-btn-cancel-bg: #9b3d4b;
-  --crm-btn-alert-bg: var(--crm-btn-cancel-bg);
-  --crm-btn-alert-text: var(--crm-c-text);
   --crm-dialog-header-border-col: transparent;
   --crm-dialog-header-bg: var(--crm-c-background2);
   --crm-dialog-body-bg: var(--crm-c-background2);
@@ -73,4 +69,7 @@
   --crm-form-block-background: var(--crm-c-background2);
   --crm-c-code-background: var(--crm-c-background2);
   --crm-filter-item-background: var(--crm-c-background2);
+}
+.crm-container .text-primary {
+  color: var(--crm-c-text);
 }

--- a/ext/riverlea/streams/thames/css/_dark.css
+++ b/ext/riverlea/streams/thames/css/_dark.css
@@ -55,6 +55,19 @@
   --crm-input-description: var(--crm-input-label-color);
   --crm-c-warning-text: black;
   --crm-filter-bg: var(--crm-c-dkblue-02);
+  --crm-c-info: var(--crm-c-secondary);
+  --crm-c-info-text: var(--crm-c-secondary-text);
+  --crm-c-warning: var(--crm-c-yellow-light);
+  --crm-c-warning-text: var(--crm-c-text-dark);
+  --crm-c-success: var(--crm-c-green-dark);
+  --crm-btn-success-text: var(--crm-c-secondary-text);
+  --crm-c-danger: var(--crm-c-red);
+  --crm-c-alert: var(--crm-c-red);
+  --crm-c-alert-text: var(--crm-c-red-dark);
+}
+
+.crm-container .text-primary {
+  color: var(--crm-c-text);
 }
 
 .crm-container div.crm-summary-row div.crm-label {

--- a/ext/riverlea/streams/walbrook/css/_dark.css
+++ b/ext/riverlea/streams/walbrook/css/_dark.css
@@ -12,15 +12,22 @@
   --crm-c-background3: var(--crm-c-gray-800);
   --crm-c-background4: var(--crm-c-gray-700);
   --crm-alert-background-danger: var(--crm-c-red);
+  --crm-alert-background-help: var(--crm-c-green-dark);
   --crm-c-blue-dark: #043353;
-  --crm-c-green-light: #468847;
-  --crm-c-green: #376237;
-  --crm-c-green-dark: #dff0d8;
   --crm-c-gray-700: #353842;
   --crm-c-gray-600: #67676a;
   --crm-c-gray-500: #b3b3b3;
   --crm-c-gray-800: #222831;
   --crm-c-divider: 1px solid var(--crm-c-gray-500);
+  --crm-c-info: var(--crm-c-blue-light);
+  --crm-c-info-text: var(--crm-c-blue-dark);
+  --crm-c-warning: var(--crm-c-yellow-light);
+  --crm-c-warning-text: var(--crm-c-text-dark);
+  --crm-c-success: var(--crm-c-green-light);
+  --crm-c-success-text: var(--crm-c-text-dark);
+  --crm-c-danger: var(--crm-c-red-light);
+  --crm-c-alert: var(--crm-c-red-light);
+  --crm-c-alert-text: var(--crm-c-text-dark);
   /* And others */
   --crm-block-shadow: 0 3px 18px 0 rgb(0,0,0);
   --crm-popup-shadow: 0 3px 18px 0 rgb(0,0,0);
@@ -52,7 +59,6 @@
   --crm-table-odd-hover: var(--crm-alert-border-info);
   --crm-table-even-row: var(--crm-c-gray-800);
   --crm-table-even-hover: var(--crm-alert-border-info);
-  --crm-alert-text-help: var(--crm-c-text);
   --crm-alert-background-info: var(--crm-c-blue-dark);
   --crm-alert-text-info: var(--crm-c-blue-light);
   --crm-c-inactive: var(--crm-c-gray-400);
@@ -63,15 +69,18 @@
   --crm-dialog-body-bg: var(--crm-c-background2);
   --crm-notify-background: var(--crm-c-background);
   --crm-form-block-background: var(--crm-c-background2);
-  --crm-btn-cancel-bg: #9b3d4b;
-  --crm-btn-warning-bg: #7b4e14;
-  --crm-c-success-text: var(--crm-c-text-light);
-  --crm-c-warning-text: var(--crm-c-text-light);
-  --crm-c-alert: var(--crm-btn-cancel-bg);
+  /* --crm-btn-cancel-bg: #9b3d4b; */
+  /* --crm-btn-warning-bg: #7b4e14; */
+  /* --crm-c-success-text: var(--crm-c-text-light);
+  --crm-c-warning-text: var(--crm-c-text-light); */
+  /* --crm-c-alert: var(--crm-btn-cancel-bg);
   --crm-c-warning: var(--crm-btn-warning-bg);
-  --crm-btn-alert-bg: var(--crm-btn-cancel-bg);
+  --crm-btn-alert-bg: var(--crm-btn-cancel-bg); */
   --crm-wizard-active-bg: var(--crm-c-primary);
   --crm-wizard-active-col: var(--crm-c-primary-text);
   --crm-dash-edit-border: 1px solid var(--crm-c-link-hover);
   --crm-filter-bg: var(--crm-c-blue-dark);
+}
+.crm-container .text-primary {
+  color: var(--crm-c-text);
 }


### PR DESCRIPTION
Overview
----------------------------------------
In response to contrast ratio failures with `text-success`/etc in dark-mode (https://lab.civicrm.org/dev/core/-/issues/5798), a shift across all streams to make the emphasis colours (used in buttons, bg-*, label-*, text-* and alerts) mostly to be light in dark mode, so they contrast against the background in a similar way.

This work was helped by [adding all the emphasis styles to a new category](https://lab.civicrm.org/dev/core/-/issues/5798#note_179247) of [Theme Test](https://lab.civicrm.org/extensions/themetest).

Before
----------------------------------------
(to come)

After
----------------------------------------
![image](https://github.com/user-attachments/assets/9ba028c1-62ae-4760-b3f3-7aa656142048)
![image](https://github.com/user-attachments/assets/05ac8db2-50d8-4692-b12c-dd7a9ae6db3f)
![image](https://github.com/user-attachments/assets/0f5eaccf-3999-4bdd-8e71-b30b8bbe8fa2)
![image](https://github.com/user-attachments/assets/fdbd08ab-5927-4ef6-a202-5c6cc087000a)

Comments
----------------------------------------
Draft for discussion before further testing / better screengrabbing. cc @ufundo & @artfulrobot. 