### PR TITLE
Civi-Import UI permissions

### DIFF
--- a/ext/civiimport/Civi/Api4/Event/Subscriber/ImportSubscriber.php
+++ b/ext/civiimport/Civi/Api4/Event/Subscriber/ImportSubscriber.php
@@ -176,6 +176,10 @@ class ImportSubscriber extends AutoService implements EventSubscriberInterface {
       if (!UserJob::get(TRUE)->addWhere('id', '=', $userJobID)->selectRowCount()->execute()->count()) {
         throw new UnauthorizedException('Import access not permitted');
       }
+      if ($event->getActionName() === 'get') {
+        // User can access UserJob::get so authorize them to access the imports as well
+        $event->authorize();
+      }
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
A user who is able to run imports is unable to view the results of the import - they appear in "My Imports" ie. API4 `UserJob.get` is authorized for them but they can't run eg. `Import_208.get` which is the autogenerated API for Import number 208 that has their contact ID in `civicrm_user_job.created_id`.

Before
----------------------------------------
Cannot view own import details.

After
----------------------------------------
1. Can view own import details.

Technical Details
----------------------------------------

Comments
----------------------------------------
@eileenmcnaughton I would appreciate your thoughts on this please.
