### PR TITLE
Fix fatal error when a user with limited permissions edits their own contact using the contact summary interface

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -1031,7 +1031,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     elseif (!empty($params['contact_id']) && ($this->_action & CRM_Core_Action::UPDATE)) {
       // figure out which all groups are intended to be removed
       $contactGroupList = CRM_Contact_BAO_GroupContact::getContactGroup($params['contact_id'], 'Added', NULL, FALSE, TRUE, FALSE, TRUE, NULL, TRUE);
-      if (is_array($contactGroupList)) {
+      if (is_array($contactGroupList) && is_array($params['group'] ?? NULL)) {
         foreach ($contactGroupList as $key) {
           if ((!array_key_exists($key['group_id'], $params['group']) || $params['group'][$key['group_id']] != 1) && empty($key['is_hidden'])) {
             $params['group'][$key['group_id']] = -1;


### PR DESCRIPTION
Overview
----------------------------------------
1. Login as a user who has permission to edit only themselves and is not in any groups
2. go to your contact summary
3. make an edit
4. click save

Before
----------------------------------------
PHP Fatal error:  Uncaught TypeError: array_key_exists(): Argument #2 ($array) must be of type array, null given in /srv/www/dev/public_html/wp-content/plugins/civicrm/civicrm/CRM/Contact/Form/Contact.php:1036

After
----------------------------------------
Edits save

