### PR TITLE
Fix form validation error for street address

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1857,7 +1857,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
         }
         elseif ($ruleField['rule_table'] === 'civicrm_address') {
           $fields[$ruleField['rule_field']] = $ruleField['rule_weight'];
-          $fields['address_primary' . $ruleField['rule_field']] = $ruleField['rule_weight'];
+          $fields['address_primary.' . $ruleField['rule_field']] = $ruleField['rule_weight'];
         }
         else {
           // At this point it must be a custom field.

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -535,20 +535,18 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test import parser will consider a rule valid including a custom field.
+   * Test import parser will pass MapField validation with rules including email and a custom field.
    *
    * @dataProvider validateData
    */
   public function testValidateMappingWithCustomDedupeRule($data): void {
     $this->addToDedupeRule();
-    // First we try to create without total_amount mapped.
-    // It will fail in create mode as total_amount is required for create.
     $mappings = [
       ['name' => 'financial_type_id'],
       ['name' => 'total_amount'],
     ];
     foreach ($data['fields'] as $field) {
-      $mappings[] = ['name' => $field === 'custom' ? ('contact.' . $this->getCustomFieldName('text', 4)) : $field];
+      $mappings[] = ['name' => 'contact.' . ($field === 'custom' ? $this->getCustomFieldName('text', 4) : $field)];
     }
     $this->submitDataSourceForm('contributions.csv', ['onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP]);
     $form = $this->getMapFieldForm([
@@ -570,16 +568,17 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
    */
   public function validateData(): array {
     return [
-      'email_first_name_last_name' => [['fields' => ['email', 'first_name', 'last_name'], 'valid' => TRUE]],
-      'email_last_name' => [['fields' => ['email', 'last_name'], 'valid' => TRUE]],
-      'email_first_name' => [['fields' => ['email', 'first_name'], 'valid' => TRUE]],
+      'email_first_name_last_name' => [['fields' => ['email_primary.email', 'first_name', 'last_name'], 'valid' => TRUE]],
+      'email_last_name' => [['fields' => ['email_primary.email', 'last_name'], 'valid' => TRUE]],
+      'email_first_name' => [['fields' => ['email_primary.email', 'first_name'], 'valid' => TRUE]],
       'first_name_last_name' => [['fields' => ['first_name', 'last_name'], 'valid' => TRUE]],
-      'email' => [['fields' => ['email'], 'valid' => TRUE]],
+      'email' => [['fields' => ['email_primary.email'], 'valid' => TRUE]],
       'first_name' => [['fields' => ['first_name'], 'valid' => FALSE]],
       'last_name' => [['fields' => ['last_name'], 'valid' => FALSE]],
       'last_name_custom' => [['fields' => ['last_name', 'custom'], 'valid' => TRUE]],
       'first_name_custom' => [['fields' => ['first_name', 'custom'], 'valid' => TRUE]],
       'custom' => [['fields' => ['custom'], 'valid' => FALSE]],
+      'first_name_street_address' => [['fields' => ['address_primary.street_address', 'first_name'], 'valid' => TRUE]],
     ];
   }
 

--- a/tests/phpunit/CRMTraits/Import/ParserTrait.php
+++ b/tests/phpunit/CRMTraits/Import/ParserTrait.php
@@ -169,6 +169,12 @@ trait CRMTraits_Import_ParserTrait {
       'rule_table' => 'civicrm_contact',
       'rule_field' => 'last_name',
     ]);
+    $this->createTestEntity('DedupeRule', [
+      'dedupe_rule_group_id' => $dedupeRuleGroupID,
+      'rule_weight' => 5,
+      'rule_table' => 'civicrm_address',
+      'rule_field' => 'street_address',
+    ]);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix form validation error for street address

Before
----------------------------------------
1) Create an Organization rule with the threshold of 10 where BOTH organization_name and street_address are required to reach it
2) Attempt to import using this rule - the form rule blocks it
![image](https://github.com/user-attachments/assets/9278c351-1bfe-4bd2-9d1f-85a34d35d4fd)


After
----------------------------------------
Can submit

Technical Details
----------------------------------------
This may not be a regression as the surrounding code makes it clear this is basically a typo & it might have just surfaced because of rc testing on the import.

But even if not it makes sense to put it with the other import changes since 6.1 is a testing focus

Comments
----------------------------------------
