### PR TITLE
Extensions - Fix new error in cv's ExtensionLifecycleTest

### DIFF
--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -443,6 +443,7 @@ class CRM_Extension_Mapper {
   /**
    * @return CRM_Extension_Info[]
    *   Ex: $result['org.civicrm.foobar'] = new CRM_Extension_Info(...).
+   *   Note: This only returns well-formed/available info's.
    * @throws \CRM_Extension_Exception
    * @throws \Exception
    */
@@ -457,6 +458,12 @@ class CRM_Extension_Mapper {
           2 => $e->getMessage(),
         ]), '', 'error');
         CRM_Core_Error::debug_log_message("Parse error in extension " . $key . ": " . $e->getMessage());
+        continue;
+      }
+      catch (CRM_Extension_Exception_MissingException $e) {
+        // If we're in here, it suggests that someone has deleted an extension that was previously stored in the index.
+        // In particular, the extension was probably inactive and deleted. (If it was active+deleted, then errors would arise elsewhere.)
+        // getAllInfos() is for inspecting available exts. If it's not there, then it's not there. 🙈🙊
         continue;
       }
     }

--- a/CRM/Extension/System.php
+++ b/CRM/Extension/System.php
@@ -336,7 +336,6 @@ class CRM_Extension_System {
       $extensionRow['path'] = '';
     }
     $extensionRow['status'] = $manager->getStatus($obj->key);
-    $requiredExtensions = $mapper->getKeysByTag('mgmt:required');
 
     switch ($extensionRow['status']) {
       case CRM_Extension_Manager::STATUS_UNINSTALLED:
@@ -368,7 +367,7 @@ class CRM_Extension_System {
     if ($manager->isIncompatible($obj->key)) {
       $extensionRow['statusLabel'] = ts('Obsolete') . ($extensionRow['statusLabel'] ? (' - ' . $extensionRow['statusLabel']) : '');
     }
-    elseif (in_array($obj->key, $requiredExtensions)) {
+    elseif (in_array('mgmt:required', $obj->tags)) {
       $extensionRow['statusLabel'] = ts('Required');
     }
     return $extensionRow;


### PR DESCRIPTION
Overview
----------------------------------------

If you have an *uninstalled* extension and then *delete* the files, there may still be stale references to it in some caches. Some consumers of these caches will then throw exceptions because they can't find the (uninstalled+nonexistent) extension.

That's silly. If it's not installed, then we don't care if it's deleted!

This fixes a recent test-regression caused by #32345 (*same version, 6.2.alpha; cc @colemanw @seamuslee001*). Specifically, `cv`'s `ExtensionLifecycleTest`  alternately installs/removes extensions, and it is only failing on `civicrm-core`@`master`  ([examples](https://test.civicrm.org/duderino/batch/Cv-PR/20875749)). 


Steps to Reproduce
----------------------------------------

Run `cv`'s `ExtensionLifecycleTest`. In summary, the test does several variations on these steps:

* Test 1
    * (a) Extract sample extension (either manually or using `Extension.download` API)
    * (b) Install sample extension (*including flush/rebuild*)
    * (c) Disable sample extension (*including flush/rebuild*)
    * (d) Uninstall sample extension (*including flush/rebuild*)
    * (e) Delete sample extension
* Test 2
    * (a) Extract sample extension (either manually or using `Extension.download` API)
    * (b) Install sample extension (*including flush/rebuild*)
    * (c) Disable sample extension (*including flush/rebuild*)
    * (d) Uninstall sample extension (*including flush/rebuild*)
    * (e) Delete sample extension

I found that I could get errors by either:

* Running two sub-tests (`--filter '(testLifecycleWithShortNames|testDownloadWithExplicitUrl)'`). (The test fails.)
* Running one sub-test (`--filter 'testLifecycleWithShortNames'`) and then manually logging into the site. (On login, the status-check throws a fatal.)

There may be some other/manual variations. (Note that some variations are pre-existing and non-fatal. My main concern is that the problems are now fatal for testing+login.)

Before/After
---------------------------------------

The problem arises in the middle (around 1d=>1e=>2a). Step 1d does (*or does not*) put some information about the sample-extension into its caches; and then step 2a does (*or does not*) crash because of missing sample-extension.

* (Up to v6.1; before [32345](https://github.com/civicrm/civicrm-core/pull/32345)): It works (*for the wrong reasons*)
    * At step 1d, it refills caches and then calls `ManagedEntities::reconcile()`, which re-saves _everything_. In particular, it re-saves `Navigation` records, and `Navigation` BAO then _re-flushes_ random caches (such as `CRM_Extension_System::$cache`).
    * At step 1e, it deletes the sample extension (outside of Civi).
    * At step 2a, it finds nothing in `CRM_Extension_System::$cache`. (Lucky coincidence! The last real interaction at step 1d covertly deleted them at the end!) So now it can refill caches anew.
* (`master`; after [32345](https://github.com/civicrm/civicrm-core/pull/32345)): It fails
    * At step 1d, it refills caches and  calls `ManagedEntities::reconcile()`, which is now optimized. (___No redundant saves; no redundant flushes___)
    * At step 1e, it deletes the sample extension (outside of Civi).
    * At step 2a, it finds hydrated caches and indices from (1d) -- __but__ (1e) means that they're now stale. Other things work badly with the stale data, esp:
        * `CRM_Utils_Check_Env::checkExtensions()` scans all extensions for their tags (`getAllTags()`, `getAllInfos()`) -- but this fails when looking for the deleted+uninstalled sample-extension.
        * `CRM_Extension_Manager::replace()` picks incorrect statuses and then hits exceptions.
* (`master`; with this patch): It works (*for better reasons*)
    * At step 1d, it refills caches and the calls, `ManagedEntities::reconcile()`, but this is now optimized. (___No redundant saves; no redundant flushes___)
    * At step 1e, it deletes the sample extension (outside of Civi).
    * At step 2a, it's more guarded. It doesn't care if an inactive-extension has gone missing -- you can still continue with testing and/or logins.

