### PR TITLE
Remove create membershipPayment code - it's already created by lineitem

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1505,15 +1505,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
         $this->set('renewal_mode', $renewalMode);
 
-        if (!empty($membershipContribution)) {
-          // Next line is probably redundant. Checks prevent it happening twice.
-          $membershipPaymentParams = [
-            'membership_id' => $membership->id,
-            'membership_type_id' => $membership->membership_type_id,
-            'contribution_id' => $membershipContribution->id,
-          ];
-          civicrm_api3('MembershipPayment', 'create', $membershipPaymentParams);
-        }
         if ($membership) {
           CRM_Core_BAO_CustomValueTable::postProcess($this->_params, 'civicrm_membership', $membership->id, 'Membership');
           $this->_params['createdMembershipIDs'][] = $membership->id;

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2165,17 +2165,6 @@ WHERE {$whereClause}";
     // store contribution id
     $params['contribution_id'] = $contribution->id;
 
-    // Create membership payment if it does not already exist
-    $membershipPayment = civicrm_api3('MembershipPayment', 'get', [
-      'contribution_id' => $contribution->id,
-    ]);
-    if (empty($membershipPayment['count'])) {
-      civicrm_api3('MembershipPayment', 'create', [
-        'membership_id' => $params['membership_id'],
-        'contribution_id' => $contribution->id,
-      ]);
-    }
-
     return $contribution;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
See #32222

LineItem BAO takes care of creating membershipPayment records.

Before
----------------------------------------
Code checks to create membershipPayment

After
----------------------------------------
Gone!

Technical Details
----------------------------------------


Comments
----------------------------------------

