### PR TITLE
Get ContributionID from LineItem instead of MembershipPayment in more places

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -101,7 +101,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
    */
   public function getCurrentRowContributionID(): int {
     if (!isset($this->currentRowContributionID)) {
-      $this->currentRowContributionID = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipPayment', $this->getCurrentRowMembershipID(), 'contribution_id', 'membership_id');
+      $this->currentRowContributionID = CRM_Member_BAO_MembershipPayment::getLatestContributionIDFromLineitemAndFallbackToMembershipPayment($this->getCurrentRowMembershipID());
     }
     return $this->currentRowContributionID;
   }

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1849,8 +1849,8 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
   }
 
   /**
+   *
    * Retrieve the contribution id for the associated Membership id.
-   * @todo we should get this off the line item
    *
    * @param int $membershipId
    *   Membership id.
@@ -1859,10 +1859,11 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
    *
    * @return int|int[]|null
    *   contribution id
-   * @todo we should get this off the line item
    *
+   * @deprecated
    */
   public static function getMembershipContributionId($membershipId, $all = FALSE) {
+    CRM_Core_Error::deprecatedFunctionWarning('use LineItems');
     $membershipPayment = new CRM_Member_DAO_MembershipPayment();
     $membershipPayment->membership_id = $membershipId;
     if ($all && $membershipPayment->find()) {

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -157,7 +157,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     $this->assign('priceSetId', $_GET['priceSetId'] ?? NULL);
 
     if ($this->_action & CRM_Core_Action::DELETE) {
-      $contributionID = CRM_Member_BAO_Membership::getMembershipContributionId($this->_id);
+      $contributionID = CRM_Member_BAO_MembershipPayment::getLatestContributionIDFromLineitemAndFallbackToMembershipPayment($this->_id);
       // check delete permission for contribution
       if ($this->_id && $contributionID && !CRM_Core_Permission::checkActionPermission('CiviContribute', $this->_action)) {
         CRM_Core_Error::statusBounce(ts("This Membership is linked to a contribution. You must have 'delete in CiviContribute' permission in order to delete this record."));
@@ -1280,7 +1280,7 @@ DESC limit 1");
         // Test cover in `CRM_Member_Form_MembershipTest::testOverrideSubmit()`.
         $isPaymentPending = FALSE;
         if ($this->getMembershipID()) {
-          $contributionId = CRM_Member_BAO_Membership::getMembershipContributionId($this->getMembershipID());
+          $contributionId = CRM_Member_BAO_MembershipPayment::getLatestContributionIDFromLineitemAndFallbackToMembershipPayment($this->getMembershipID());
           if ($contributionId) {
             $isPaymentPending = \Civi\Api4\Contribution::get(FALSE)
               ->addSelect('contribution_status_id:name')
@@ -1339,7 +1339,7 @@ DESC limit 1");
     }
     $this->assign('lineItem', !empty($lineItem) && !$isQuickConfig ? $lineItem : FALSE);
 
-    $contributionId = $this->ids['Contribution'] ?? CRM_Member_BAO_Membership::getMembershipContributionId($this->getMembershipID());
+    $contributionId = $this->ids['Contribution'] ?? CRM_Member_BAO_MembershipPayment::getLatestContributionIDFromLineitemAndFallbackToMembershipPayment($this->getMembershipID());
     $membershipIds = $this->_membershipIDs;
     if ($this->getSubmittedValue('send_receipt') && $contributionId && !empty($membershipIds)) {
       $contributionStatus = \Civi\Api4\Contribution::get(FALSE)


### PR DESCRIPTION
Overview
----------------------------------------
Replace some more instances where MembershipPayment record is being used instead of LineItem.

Before
----------------------------------------
Inconsistent.

After
----------------------------------------
Consistently checks lineitems.

Technical Details
----------------------------------------


Comments
----------------------------------------

