### PR TITLE
Check contribution tab exists before marking it as valid

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/TabHeader.php
+++ b/CRM/Contribute/Form/ContributionPage/TabHeader.php
@@ -140,7 +140,7 @@ class CRM_Contribute_Form_ContributionPage_TabHeader {
       $contriPageInfo = CRM_Contribute_BAO_ContributionPage::getSectionInfo([$contribPageId]);
 
       foreach ($contriPageInfo[$contribPageId] as $section => $info) {
-        if (!$info) {
+        if (!$info && isset($tabs[$section])) {
           $tabs[$section]['valid'] = FALSE;
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Check contribution tab exists before marking it as valid.

Before
----------------------------------------
In a few projects we have some code like this, which was working fine on CiviCRM 5.58:
```
function hook_civicrm_tabset($tabset_name, &$tabs)  {
	if ($tabset_name == 'civicrm/admin/contribute') {
		if (isset($tabs['premium'])) {
			unset($tabs['premium']);
		}
		if (isset($tabs['widget'])) {
			unset($tabs['widget']);
		}
		if (isset($tabs['pcp'])) {
			unset($tabs['pcp']);
		}
	}
}
```

We're doing this to simplify the UI for our uses, who are never interested in premiums, widgets and personal campaign pages.

I've not been able to track down exactly where this broke, but on CiviCRM 6 we're getting the tabs output as puzzle pieces:

![Screenshot 2025-03-20 at 18 20 58](https://github.com/user-attachments/assets/017452fc-b7b0-4da2-9b7f-aafa603c02fa)

(it's possibly that the tabs were being output on older versions, but were effectively invisible if the icon wasn't output)

After
----------------------------------------
By checking the tab exists before writing `$tabs[$section]['valid']` we ensure the removed tab isn't re-added.

Comments
----------------------------------------
I'm not sure if this counts as a regression, and therefore which branch it should be targetting.
