### PR TITLE
dev/core#5802 Add option to modify Recurring Membership Contribution when modifying Membership Type

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -98,6 +98,17 @@
             <span class="description">{ts}Select Membership Organization and then Membership Type.{/ts}{if $hasPriceSets} {ts}Alternatively, you can use a price set.{/ts}{/if}</span>
           </td>
         </tr>
+        {if $isRecur && '{$form.update_recur.label}'}
+        <tr id="crm-membership-form-block-update-recurring">
+          <td class="label">{$form.update_recur.label}</td>
+          <td class="mem_recur_contribution">
+             <span class="UpdateRecur">{$form.update_recur.html}</span>
+             <span class="description">
+                {ts}Update Recurring Contribution to match the current membership pricing on this change.{/ts}
+              </span>
+          </td>
+        </tr>
+        {/if}
         <tr id="maxRelated" class="crm-membership-form-block-max_related">
           <td class="label">{$form.max_related.label}</td>
           <td>{$form.max_related.html}<br />
@@ -340,6 +351,9 @@
         cj('#membership_type_id_1-readonly').text(cj('#membership_type_id_1 option:selected').text());
         cj('#mem_type_id-readonly').show();
         cj('#mem_type_id-editable').hide();
+        {if '{$form.update_recur.label}'}
+          cj('#crm-membership-form-block-update-recurring').hide();
+        {/if}
       {else}
         cj('#mem_type_id-readonly').hide();
         cj('#mem_type_id-editable').show();
@@ -350,6 +364,9 @@
         e.preventDefault();
         cj('#mem_type_id-readonly').hide();
         cj('#mem_type_id-editable').show();
+        {if '{$form.update_recur.label}'}
+          cj('#crm-membership-form-block-update-recurring').show();
+        {/if}
       });
 
       // give option to override end-date for auto-renew memberships


### PR DESCRIPTION
Overview
----------------------------------------

We have a situation where Members transition from one type to another. We recently setup recurring memberships, but are running into the scenario that the recurring payments are not updated.

I'm aware that there are reasons that some don't want this done automatically, which is totally fine with me. But I was wondering if we couldn't provide a checkbox allowing the update to happen since I feel that it makes sense to provide out-of-the-box.

Example use-case
----------------------------------------
1. Member uses a Contribution page and pays for a Recurring Membership
2. Member contacts the Organization to have their Membership changed to another one
3. The organization goes to the Members page and attempts to change their Membership
4. They override the Membership but the recurring transaction still charges the _original_ amount

Current behaviour
----------------------------------------

![Selection_004](https://github.com/user-attachments/assets/822a77e1-c089-4360-bd9f-60e892c0ee6c)


Proposed behaviour
----------------------------------------
![Selection_006](https://github.com/user-attachments/assets/69bb0c50-70ab-4679-beaf-1bb6fe6d4fdc)


We provide the option to allow them to update the actual _next recurring_ amount. I can see there is already a place that we could handle this and modify the Recurring contribution amount with the new total amount.

Comments
------------------

I already implemented the UI to handle this, but wanted to ensure there wasn't something I am missing here in terms Payment Processors prior to proposing a patch.