### PR TITLE
increase length of display_name in SiteEmailAddress

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixOne.php
+++ b/CRM/Upgrade/Incremental/php/SixOne.php
@@ -175,6 +175,7 @@ class CRM_Upgrade_Incremental_php_SixOne extends CRM_Upgrade_Incremental_Base {
    */
   public function upgrade_6_1_beta1(string $rev): void {
     $this->addTask('Update import mappings', 'upgradeImportMappingFields', 'Import Contribution');
+    $this->addTask('Increase site email display name length', 'alterSchemaField', 'SiteEmailAddress', 'display_name');
   }
 
   /**

--- a/CRM/Upgrade/Incremental/schema/6.0.alpha1.SiteEmailAddress.entityType.php
+++ b/CRM/Upgrade/Incremental/schema/6.0.alpha1.SiteEmailAddress.entityType.php
@@ -36,7 +36,7 @@ return [
     ],
     'display_name' => [
       'title' => ts('Display Name'),
-      'sql_type' => 'varchar(63)',
+      'sql_type' => 'varchar(127)',
       'input_type' => 'Text',
       'required' => TRUE,
       'description' => ts('Full name of the sender'),

--- a/schema/Core/SiteEmailAddress.entityType.php
+++ b/schema/Core/SiteEmailAddress.entityType.php
@@ -40,7 +40,7 @@ return [
     ],
     'display_name' => [
       'title' => ts('Display Name'),
-      'sql_type' => 'varchar(63)',
+      'sql_type' => 'varchar(127)',
       'input_type' => 'Text',
       'required' => TRUE,
       'description' => ts('Full name of the sender'),


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/5805.
If you had a "From" email address that had a name >63 characters in the past, your upgrade will fail.

Comments
----------------------------------------
Details on the lab.c.o issue.
