### PR TITLE
[REF] dev/core#5803 CRM_Utils_System::theme  - split out maintenance calls

### DIFF
--- a/CRM/Queue/Page/Runner.php
+++ b/CRM/Queue/Page/Runner.php
@@ -53,7 +53,16 @@ class CRM_Queue_Page_Runner extends CRM_Core_Page {
     if ($runner->isMinimal) {
       $smarty = CRM_Core_Smarty::singleton();
       $content = $smarty->fetch('CRM/Queue/Page/Runner.tpl');
-      echo CRM_Utils_System::theme($content, $this->_print, TRUE);
+      if ($this->_print) {
+        // unexpected - trying to print the output of the upgrader?
+        // @todo remove this case and just ignore $this->_print entirely
+        // for now we use the original call, to maintain preexisting behaviour (however strange that is)
+        \CRM_Core_Error::deprecatedWarning('Calling CRM_Utils_System::theme with $print and $maintenance is unexpected and may behave strangely. This codepath will be removed in a future release. If you need it, please comment on https://lab.civicrm.org/dev/core/-/issues/5803');
+        echo CRM_Utils_System::theme($content, $this->_print, TRUE);
+      }
+      else {
+        echo CRM_Utils_System::renderMaintenanceMessage($content);
+      }
     }
     else {
       parent::run();

--- a/CRM/Upgrade/Page/Upgrade.php
+++ b/CRM/Upgrade/Page/Upgrade.php
@@ -108,7 +108,17 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
     }
 
     $content = $template->fetch('CRM/common/success.tpl');
-    echo CRM_Utils_System::theme($content, $this->_print, TRUE);
+
+    if ($this->_print) {
+      // unexpected - trying to print the output of the upgrader?
+      // @todo remove this case and just ignore $this->_print entirely
+      // for now we use the original call, to maintain preexisting behaviour (however strange that is)
+      \CRM_Core_Error::deprecatedWarning('Calling CRM_Utils_System::theme with $print and $maintenance is unexpected and may behave strangely. This codepath will be removed in a future release. If you need it, please comment on https://lab.civicrm.org/dev/core/-/issues/5803');
+      echo CRM_Utils_System::theme($content, $this->_print, TRUE);
+    }
+    else {
+      echo CRM_Utils_System::renderMaintenanceMessage($content);
+    }
   }
 
   /**
@@ -181,7 +191,17 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
     $template->assign('sid', CRM_Utils_System::getSiteID());
 
     $content = $template->fetch('CRM/common/success.tpl');
-    echo CRM_Utils_System::theme($content, $this->_print, TRUE);
+
+    if ($this->_print) {
+      // unexpected - trying to print the output of the upgrader?
+      // @todo remove this case and just ignore $this->_print entirely
+      // for now we use the original call, to maintain preexisting behaviour (however strange that is)
+      \CRM_Core_Error::deprecatedWarning('Calling CRM_Utils_System::theme with $print and $maintenance is unexpected and may behave strangely. This codepath will be removed in a future release. If you need it, please comment on https://lab.civicrm.org/dev/core/-/issues/5803');
+      echo CRM_Utils_System::theme($content, $this->_print, TRUE);
+    }
+    else {
+      echo CRM_Utils_System::renderMaintenanceMessage($content);
+    }
   }
 
 }

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -1204,16 +1204,15 @@ AND    u.status = 1
    * @inheritdoc
    */
   public function theme(&$content, $print = FALSE, $maintenance = FALSE) {
+    if ($maintenance) {
+      \CRM_Core_Error::deprecationMessage('CRM_Utils_System::theme called with $maintenance = TRUE - please use renderMaintenanceMessage instead');
+    }
+
     $ret = FALSE;
 
     if (!$print) {
       if ($maintenance) {
-        backdrop_set_breadcrumb('');
-        backdrop_maintenance_theme();
-        if ($region = CRM_Core_Region::instance('html-header', FALSE)) {
-          $this->addHTMLHead($region->render(''));
-        }
-        print theme('maintenance_page', ['content' => $content]);
+        print $this->renderMaintanceMessage($content);
         exit();
       }
       $ret = TRUE;
@@ -1227,6 +1226,18 @@ AND    u.status = 1
       print $out;
       return NULL;
     }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function renderMaintanceMessage(string $content): string {
+    backdrop_set_breadcrumb('');
+    backdrop_maintenance_theme();
+    if ($region = CRM_Core_Region::instance('html-header', FALSE)) {
+      $this->addHTMLHead($region->render(''));
+    }
+    return theme('maintenance_page', ['content' => $content]);
   }
 
   /**

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -347,26 +347,42 @@ abstract class CRM_Utils_System_Base {
   }
 
   /**
+   * @see https://lab.civicrm.org/dev/core/-/issues/5803
+   *
    * If we are using a theming system, invoke theme, else just print the content.
    *
    * @param string $content
    *   The content that will be themed.
    * @param bool $print
-   *   Are we displaying to the screen or bypassing theming?.
    * @param bool $maintenance
-   *   For maintenance mode.
+   *   DEPRECATED - use renderMaintenanceMessage instead,
    *
    * @throws Exception
    * @return string|null
    *   NULL, If $print is FALSE, and some other criteria match up.
    *   The themed string, otherwise.
    *
+   * @todo Remove maintenance param
    * @todo The return value is inconsistent.
    * @todo Better to always return, and never print.
    */
   public function theme(&$content, $print = FALSE, $maintenance = FALSE) {
+    if ($maintenance) {
+      \CRM_Core_Error::deprecatedWarning('Calling CRM_Utils_System::theme with $maintenance is deprecated - use renderMaintenanceMessage instead');
+      $content = $this->renderMaintenanceMessage($content);
+    }
     print $content;
     return NULL;
+  }
+
+  /**
+   * Wrap content in maintenance template
+   *
+   * @param string $content
+   * @return string
+   */
+  public function renderMaintenanceMessage(string $content): string {
+    return $content;
   }
 
   /**

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -890,16 +890,14 @@ AND    u.status = 1
    * @inheritdoc
    */
   public function theme(&$content, $print = FALSE, $maintenance = FALSE) {
+    if ($maintenance) {
+      \CRM_Core_Error::deprecatedWarning('Calling CRM_Utils_Base::theme with $maintenance is deprecated - use renderMaintenanceMessage instead');
+    }
     $ret = FALSE;
 
     if (!$print) {
       if ($maintenance) {
-        drupal_set_breadcrumb('');
-        drupal_maintenance_theme();
-        if ($region = CRM_Core_Region::instance('html-header', FALSE)) {
-          $this->addHTMLHead($region->render(''));
-        }
-        print theme('maintenance_page', ['content' => $content]);
+        print $this->renderMaintenanceMessage($content);
         exit();
       }
       $ret = TRUE;
@@ -913,6 +911,18 @@ AND    u.status = 1
       print $out;
       return NULL;
     }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function renderMaintenanceMode(string $content): string {
+    drupal_set_breadcrumb('');
+    drupal_maintenance_theme();
+    if ($region = CRM_Core_Region::instance('html-header', FALSE)) {
+      $this->addHTMLHead($region->render(''));
+    }
+    return theme('maintenance_page', ['content' => $content]);
   }
 
   /**

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -952,12 +952,10 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
 
   /**
    * @inheritdoc
+   * @todo use Drupal "maintenance page" template and theme during installation
    */
-  public function theme(&$content, $print = FALSE, $maintenance = FALSE) {
-    // @todo use Drupal "maintenance page" template and theme during installation
-    // or upgrade.
-    print $content;
-    return NULL;
+  public function renderMaintenanceMessage(string $content): string {
+    return $content;
   }
 
   /**

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -326,28 +326,35 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    */
   public function theme(&$content, $print = FALSE, $maintenance = FALSE) {
     if ($maintenance) {
-      // if maintenance, we need to wrap in a minimal header
-      $headerContent = CRM_Core_Region::instance('html-header', FALSE)->render('');
-
-      // note - now adding #crm-container is a hacky way to avoid rendering
-      // the civicrm menubar. @todo a better way
-      $content = <<<HTML
-        <!DOCTYPE html >
-        <html class="crm-standalone">
-          <head>
-            {$headerContent}
-          </head>
-          <body>
-            <div class="crm-container standalone-page-padding">
-              {$content}
-            </div>
-          </body>
-        </html>
-      HTML;
+      \CRM_Core_Error::deprecatedWarning('Calling CRM_Utils_Base::theme with $maintenance is deprecated - use renderMaintenanceMessage instead');
+      $content = $this->renderMaintenanceMessage($content, $print);
     }
-
     print $content;
     return NULL;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function renderMaintenanceMessage(string $content): string {
+    // wrap in a minimal header
+    $headerContent = CRM_Core_Region::instance('html-header', FALSE)->render('');
+
+    // note - not adding #crm-container is a hacky way to avoid rendering
+    // the civicrm menubar. @todo a better way
+    return <<<HTML
+      <!DOCTYPE html >
+      <html class="crm-standalone">
+        <head>
+          {$headerContent}
+        </head>
+        <body>
+          <div class="crm-container standalone-page-padding">
+            {$content}
+          </div>
+        </body>
+      </html>
+    HTML;
   }
 
   /**

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -1686,8 +1686,12 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
 
   /**
    * @inheritdoc
+   * @todo why are the environment checks here? could they be removed
    */
   public function theme(&$content, $print = FALSE, $maintenance = FALSE) {
+    if ($maintenance) {
+      \CRM_Core_Error::deprecatedWarning('Calling CRM_Utils_Base::theme with $maintenance is deprecated - use renderMaintenanceMessage instead');
+    }
     if (!$print) {
       if (!function_exists('is_admin')) {
         throw new \Exception('Function "is_admin()" is missing, even though WordPress is the user framework.');
@@ -1705,6 +1709,28 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
 
     print $content;
     return NULL;
+  }
+
+  /**
+   * @inheritdoc
+   * @todo environment checks are copied from the original implementation of `theme` above and should probably
+   * be removed
+   */
+  public function renderMaintenanceMessage(string $content): string {
+    if (!function_exists('is_admin')) {
+      throw new \Exception('Function "is_admin()" is missing, even though WordPress is the user framework.');
+    }
+    if (!defined('ABSPATH')) {
+      throw new \Exception('Constant "ABSPATH" is not defined, even though WordPress is the user framework.');
+    }
+    if (is_admin()) {
+      require_once ABSPATH . 'wp-admin/admin-header.php';
+    }
+    else {
+      // FIXME: we need to figure out to replace civicrm content on the frontend pages
+    }
+
+    return $content;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
A small step to cleaning up strange `theme` function. Acting on [quixotic 10 year old todo  message](https://github.com/civicrm/civicrm-core/commit/26659f0c3aaf438e25acd7c23da1207e764b0da5).

Before
----------------------------------------
- theme function has two additional params for $print and $maintenance
- it's called in 3 places in core with `$maintenance = TRUE`
- handling for `$maintenance = TRUE` and `$print = [truthy]` looks haphazard
- looks like callers to `theme` expect a return value to `echo` - but in most cases `theme` just prints itself and returns nothing

After
----------------------------------------
- split out calls with `$maintenance = TRUE` to a separate function with a well-defined signature
- add deprecation notices to unexpected calls to theme


Comments
--------------------------------------
Inscrutability here didn't help when trying to work on https://github.com/civicrm/civicrm-core/pull/32398