### PR TITLE
dev/core#5780 Fix tell-a-friend not rendering on Manage events

### DIFF
--- a/ext/tellafriend/tellafriend.php
+++ b/ext/tellafriend/tellafriend.php
@@ -54,9 +54,13 @@ function tellafriend_civicrm_tabset($tabsetName, &$tabs, $context) {
       'template' => FALSE,
       'count' => FALSE,
       'icon' => FALSE,
-      'url' => $tabsetName === 'civicrm/event/manage' ? 'civicrm/event/manage/friend' : '',
+      'url' => '',
       'field' => 'friend',
     ];
+    $isFromBrowsePage = ($tabs['settings']['url'] ?? '') === 'civicrm/event/manage/settings' && empty($tabs['friend']);
+    if ($isFromBrowsePage) {
+      $default['url'] = 'civicrm/event/manage/friend';
+    }
     $tabs['friend'] = ['title' => ts('Tell a Friend')] + $default;
   }
 }


### PR DESCRIPTION
Overview
----------------------------------------
Tab broken on event (OK on contribution) - per @demeritcowboy "It seems to be doubling up the relative link, e.g. it points to /civicrm/event/manage/civicrm/event/manage/friend"

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/1f0096e5-633e-47f6-b411-48c611869e09)


After
----------------------------------------
![image](https://github.com/user-attachments/assets/38048d8e-8df1-4091-b6b3-3bfe4b76beac)

![image](https://github.com/user-attachments/assets/06b3a92a-af41-401d-bb0e-ff1f18a6b935)




Technical Details
----------------------------------------

Comments
----------------------------------------
