### PR TITLE
Api4 - Improve efficiency of FormattingUtil::formatOutputValues

### DIFF
--- a/Civi/Api4/Generic/Traits/CustomValueActionTrait.php
+++ b/Civi/Api4/Generic/Traits/CustomValueActionTrait.php
@@ -85,8 +85,8 @@ trait CustomValueActionTrait {
         $tableName = CoreUtil::getTableName($this->getEntityName());
         $items[$idx]['id'] = (int) \CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM ' . $tableName);
       }
-      FormattingUtil::formatOutputValues($items[$idx], $fields, 'create');
     }
+    FormattingUtil::formatOutputValues($items, $fields, 'create');
     return $items;
   }
 

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -148,9 +148,7 @@ trait DAOActionTrait {
     }
 
     \CRM_Utils_API_HTMLInputCoder::singleton()->decodeRows($result);
-    foreach ($result as &$row) {
-      FormattingUtil::formatOutputValues($row, $this->entityFields());
-    }
+    FormattingUtil::formatOutputValues($result, $this->entityFields());
     return $result;
   }
 

--- a/Civi/Api4/Generic/Traits/PseudoconstantOutputTrait.php
+++ b/Civi/Api4/Generic/Traits/PseudoconstantOutputTrait.php
@@ -42,9 +42,9 @@ trait PseudoconstantOutputTrait {
           }
         }
       }
-      // Swap raw values with pseudoconstants
-      FormattingUtil::formatOutputValues($values, $fields, $this->getActionName());
     }
+    // Swap raw values with pseudoconstants
+    FormattingUtil::formatOutputValues($records, $fields, $this->getActionName());
   }
 
 }

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -104,9 +104,7 @@ class Api4SelectQuery extends Api4Query {
    */
   public function run(): array {
     $results = $this->getResults();
-    foreach ($results as &$result) {
-      FormattingUtil::formatOutputValues($result, $this->apiFieldSpec, 'get', $this->selectAliases);
-    }
+    FormattingUtil::formatOutputValues($results, $this->apiFieldSpec, 'get', $this->selectAliases);
     return $results;
   }
 

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -216,71 +216,76 @@ class FormattingUtil {
   }
 
   /**
-   * Unserialize raw DAO values and convert to correct type
+   * Unserialize raw field values and convert to correct type
    *
-   * @param array $result
+   * @param array $records
    * @param array $fields
    * @param string $action
    * @param array $selectAliases
    * @throws \CRM_Core_Exception
    */
-  public static function formatOutputValues(&$result, $fields, $action = 'get', $selectAliases = []) {
-    $contactTypePaths = [];
-    // Save an array of unprocessed values which are useful when replacing pseudocontants
-    $rawValues = $result;
-    foreach ($rawValues as $key => $value) {
-      // Pseudoconstants haven't been replaced yet so strip suffixes from raw values
-      if (strpos($key, ':') > strrpos($key, ')')) {
-        [$fieldName] = explode(':', $key);
-        $rawValues[$fieldName] = $value;
-        unset($rawValues[$key]);
-      }
-    }
-    foreach ($result as $key => $value) {
-      // Skip null values or values that have already been unset by `formatOutputValue` functions
-      if (!isset($result[$key])) {
-        continue;
-      }
-      $fieldExpr = SqlExpression::convert($selectAliases[$key] ?? $key);
-      $fieldName = \CRM_Utils_Array::first($fieldExpr->getFields());
-      $baseName = $fieldName ? \CRM_Utils_Array::first(explode(':', $fieldName)) : NULL;
-      $field = $fields[$fieldName] ?? $fields[$baseName] ?? NULL;
-      $dataType = $field['data_type'] ?? ($fieldName == 'id' ? 'Integer' : NULL);
-      // Allow Sql Functions to alter the value and/or $dataType
-      if (method_exists($fieldExpr, 'formatOutputValue') && is_string($value)) {
-        $fieldExpr->formatOutputValue($dataType, $result, $key);
-        $value = $result[$key];
-      }
-      if (!empty($field['output_formatters'])) {
-        self::applyFormatters($result, $fieldExpr, $field, $value);
-        $dataType = NULL;
-      }
-      // Evaluate pseudoconstant suffixes
-      $suffix = self::getSuffix($fieldName);
-      $fieldOptions = NULL;
-      if (isset($value) && $suffix) {
-        $fieldOptions = self::getPseudoconstantList($field, $fieldName, $rawValues, $action);
-        $dataType = NULL;
-      }
-      // Store contact_type value before replacing pseudoconstant (e.g. transforming it to contact_type:label)
-      // Used by self::contactFieldsToRemove below
-      if ($value && isset($field['entity']) && $field['entity'] === 'Contact' && $field['name'] === 'contact_type') {
-        $prefix = strrpos($fieldName, '.');
-        $contactTypePaths[$prefix ? substr($fieldName, 0, $prefix + 1) : ''] = $value;
-      }
-      if ($fieldExpr->supportsExpansion) {
-        if (!empty($field['serialize']) && is_string($value)) {
-          $value = \CRM_Core_DAO::unSerializeField($value, $field['serialize']);
-        }
-        if (isset($fieldOptions)) {
-          $value = self::replacePseudoconstant($fieldOptions, $value);
+  public static function formatOutputValues(&$records, $fields, $action = 'get', $selectAliases = []) {
+    $fieldExprs = [];
+    foreach ($records as &$result) {
+      $contactTypePaths = [];
+      // Save an array of unprocessed values which are useful when replacing pseudocontants
+      $rawValues = $result;
+      foreach ($rawValues as $key => $value) {
+        // Pseudoconstants haven't been replaced yet so strip suffixes from raw values
+        if (strpos($key, ':') > strrpos($key, ')')) {
+          [$fieldName] = explode(':', $key);
+          $rawValues[$fieldName] = $value;
+          unset($rawValues[$key]);
         }
       }
-      $result[$key] = self::convertDataType($value, $dataType);
-    }
-    // Remove inapplicable contact fields
-    foreach ($contactTypePaths as $prefix => $contactType) {
-      \CRM_Utils_Array::remove($result, self::contactFieldsToRemove($contactType, $prefix));
+      foreach ($result as $key => $value) {
+        // Skip null values or values that have already been unset by `formatOutputValue` functions
+        if (!isset($result[$key])) {
+          continue;
+        }
+        // Use ??= to only convert each column once
+        $fieldExprs[$key] ??= SqlExpression::convert($selectAliases[$key] ?? $key);
+        $fieldExpr = $fieldExprs[$key];
+        $fieldName = \CRM_Utils_Array::first($fieldExpr->getFields());
+        $baseName = $fieldName ? \CRM_Utils_Array::first(explode(':', $fieldName)) : NULL;
+        $field = $fields[$fieldName] ?? $fields[$baseName] ?? NULL;
+        $dataType = $field['data_type'] ?? ($fieldName == 'id' ? 'Integer' : NULL);
+        // Allow Sql Functions to alter the value and/or $dataType
+        if (method_exists($fieldExpr, 'formatOutputValue') && is_string($value)) {
+          $fieldExpr->formatOutputValue($dataType, $result, $key);
+          $value = $result[$key];
+        }
+        if (!empty($field['output_formatters'])) {
+          self::applyFormatters($result, $fieldExpr, $field, $value);
+          $dataType = NULL;
+        }
+        // Evaluate pseudoconstant suffixes
+        $suffix = self::getSuffix($fieldName);
+        $fieldOptions = NULL;
+        if (isset($value) && $suffix) {
+          $fieldOptions = self::getPseudoconstantList($field, $fieldName, $rawValues, $action);
+          $dataType = NULL;
+        }
+        // Store contact_type value before replacing pseudoconstant (e.g. transforming it to contact_type:label)
+        // Used by self::contactFieldsToRemove below
+        if ($value && isset($field['entity']) && $field['entity'] === 'Contact' && $field['name'] === 'contact_type') {
+          $prefix = strrpos($fieldName, '.');
+          $contactTypePaths[$prefix ? substr($fieldName, 0, $prefix + 1) : ''] = $value;
+        }
+        if ($fieldExpr->supportsExpansion) {
+          if (!empty($field['serialize']) && is_string($value)) {
+            $value = \CRM_Core_DAO::unSerializeField($value, $field['serialize']);
+          }
+          if (isset($fieldOptions)) {
+            $value = self::replacePseudoconstant($fieldOptions, $value);
+          }
+        }
+        $result[$key] = self::convertDataType($value, $dataType);
+      }
+      // Remove inapplicable contact fields
+      foreach ($contactTypePaths as $prefix => $contactType) {
+        \CRM_Utils_Array::remove($result, self::contactFieldsToRemove($contactType, $prefix));
+      }
     }
   }
 

--- a/ext/civi_contribute/Civi/Api4/Action/Payment/Create.php
+++ b/ext/civi_contribute/Civi/Api4/Action/Payment/Create.php
@@ -169,9 +169,7 @@ class Create extends \Civi\Api4\Generic\AbstractCreateAction {
     $savedRecords = [];
     $savedRecords[] = $this->baoToArray($trxn, $this->values);
     \CRM_Utils_API_HTMLInputCoder::singleton()->decodeRows($savedRecords);
-    foreach ($savedRecords as &$row) {
-      FormattingUtil::formatOutputValues($row, $this->entityFields());
-    }
+    FormattingUtil::formatOutputValues($savedRecords, $this->entityFields());
     $result->exchangeArray($savedRecords);
   }
 

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetDefault.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetDefault.php
@@ -95,9 +95,10 @@ class GetDefault extends \Civi\Api4\Generic\AbstractAction {
         $display[$fieldExpr] = $display[$fieldName];
       }
     }
+    $displays = [$display];
     // Replace pseudoconstants e.g. type:icon
-    FormattingUtil::formatOutputValues($display, $fields);
-    $result->exchangeArray($this->selectArray([$display]));
+    FormattingUtil::formatOutputValues($displays, $fields);
+    $result->exchangeArray($this->selectArray($displays));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Code optimization in Api4

See https://lab.civicrm.org/dev/core/-/issues/5804#note_179353



Technical Details
----------------------------------------
Avoids calling `SqlExpression::convert()` more than once per column when formatting output values.

This required refactoring the function to accept the entire result set instead of one row at a time.

