### PR TITLE
dev/core#5708 Fix failure to save Custom fields on backoffice submit card membership

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -602,6 +602,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
    */
   public static function getLongNameFromShortName(string $shortName): ?string {
     [, $id] = explode('_', $shortName);
+    $id = (int) $id;
     foreach (CRM_Core_BAO_CustomGroup::getAll() as $customGroup) {
       if (isset($customGroup['fields'][$id])) {
         return $customGroup['name'] . '.' . $customGroup['fields'][$id]['name'];

--- a/CRM/Custom/Form/CustomDataTrait.php
+++ b/CRM/Custom/Form/CustomDataTrait.php
@@ -188,11 +188,18 @@ trait CRM_Custom_Form_CustomDataTrait {
    *
    * @return array
    */
-  protected function getSubmittedCustomFields(): array {
+  protected function getSubmittedCustomFields($version = 3): array {
     $fields = [];
     foreach ($this->getSubmittedValues() as $label => $field) {
-      if (CRM_Core_BAO_CustomField::getKeyID($label)) {
-        $fields[$label] = $field;
+      if ($version === 3) {
+        if (CRM_Core_BAO_CustomField::getKeyID($label)) {
+          $fields[$label] = $field;
+        }
+      }
+      else {
+        if (str_starts_with($label, 'custom_')) {
+          $fields[CRM_Core_BAO_CustomField::getLongNameFromShortName($label)] = $field;
+        }
       }
     }
     return $fields;

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1779,7 +1779,7 @@ DESC limit 1");
    * @throws \CRM_Core_Exception
    */
   protected function getFormMembershipParams(): array {
-    return [
+    $params = [
       'status_id' => $this->getSubmittedValue('status_id'),
       'source' => $this->getSubmittedValue('source') ?? $this->getContributionSource(),
       'contact_id' => $this->getMembershipContactID(),
@@ -1796,6 +1796,8 @@ DESC limit 1");
       'exclude_is_admin' => !$this->getSubmittedValue('is_override'),
       'contribution_recur_id' => $this->getContributionRecurID(),
     ];
+    $params += $this->getSubmittedCustomFields(4);
+    return $params;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5708 Fix failure to save Custom fields on backoffice submit card membership

Before
----------------------------------------
Custom fields not saved when submitting a membership card payment via backoffice

After
----------------------------------------
Saved
![image](https://github.com/user-attachments/assets/44bfe825-c470-4106-9e6e-1ca9063d7915)

Technical Details
----------------------------------------
The membership.save on this path is going through apiv4 but the parameters were not being formatted into apiv4 style

Comments
----------------------------------------
