### PR TITLE
dev/core#5806 Fix fatal error regression on custom data save

### DIFF
--- a/CRM/Custom/Form/CustomDataTrait.php
+++ b/CRM/Custom/Form/CustomDataTrait.php
@@ -86,18 +86,21 @@ trait CRM_Custom_Form_CustomDataTrait {
 
     $formValues = [];
     foreach ($fields as $field) {
-      // Filter for fields in "Inline" style custom groups only, as others are not added to forms via Ajax. Not removing
-      // them here would register them in the QuickForm but not have POST values for them, which might result in data
-      // loss (most notably radio fields, for which no POST value will be interpreted as a reset).
+      // Filter for fields in "Inline" style custom groups only
+      // hack alert hack alert hack alert
+      // per previous comments the above section was intended to be extended to non-contact
+      // entities rather than this section being messed with
+      // @todo remove the inline check below while
+      // walking the tightrope between not breaking core supported usage per
+      // https://lab.civicrm.org/dev/core/-/issues/5806
+      // and non-core implementations of non-inline custom groups.
       // See https://lab.civicrm.org/dev/core/-/issues/5613
-      if (!isset(Civi::$statics[__CLASS__]['customGroups'][$field['custom_group']])) {
-        Civi::$statics[__CLASS__]['customGroups'][$field['custom_group']] = \Civi\Api4\CustomGroup::get(FALSE)
-          ->addSelect('style')
-          ->addWhere('name', '=', $field['custom_group'])
-          ->execute()
-          ->single();
-      }
-      if ('Inline' !== Civi::$statics[__CLASS__]['customGroups'][$field['custom_group']]['style']) {
+      $field += CRM_Core_BAO_CustomField::getField($field['custom_field_id']);
+      $inlineGroup = CRM_Core_BAO_CustomGroup::getGroup([
+        'id' => $field['custom_group_id'],
+        'style' => 'Inline',
+      ]);
+      if (!$inlineGroup) {
         continue;
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a 6.0.1 regression from https://github.com/civicrm/civicrm-core/pull/31495

Before
----------------------------------------
Fatal error on the Edit contact screen if trying to save custom fields extending the Address entity (actually I think they just need to exists)

After
----------------------------------------
Saves

Technical Details
----------------------------------------
Core has supported custom fields extending the address entity for a long time.  This PR https://github.com/civicrm/civicrm-core/pull/31495 broke it by assuming a field was present in `$fields` that is not present in this case (unsure when it would be). 

Note that core only supports `tab` fields for `Contact` entity - the PR that broke it was trying to support `tab` fields for non contact entities so I added some comments to try to point to the fact there was already some code pointers as to where this should be handled - ie the comments point to it

```
      // Ideally this would not be contact specific but the function being
      // called here does not handle the filters as received.
```


Comments
---------------------------------------