### PR TITLE
Standalone - check logged in User's locale in multilingual mode

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -578,6 +578,21 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
 
   /**
    * @inheritDoc
+   */
+  public function getUFLocale(): ?string {
+    $userId = $this->getLoggedInUfID();
+    if ($userId) {
+      $user = $this->getUserById($userId);
+      if ($user && !empty($user['language'])) {
+        return $user['language'];
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * @inheritDoc
    * @todo implement language negotiation for Standalone?
    */
   public function languageNegotiationURL($url, $addLanguagePart = TRUE, $removeLanguagePart = FALSE) {

--- a/ext/standaloneusers/standaloneusers.php
+++ b/ext/standaloneusers/standaloneusers.php
@@ -18,22 +18,6 @@ function standaloneusers_civicrm_alterBundle(CRM_Core_Resources_Bundle $bundle) 
 }
 
 /**
- * Hide the inherit CMS language on the Settings - Localization form.
- *
- * Implements hook_civicrm_buildForm().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_buildForm/
- */
-function standaloneusers_civicrm_buildForm($formName, CRM_Core_Form $form) {
-  // Administer / Localization / Languages, Currency, Locations
-  if ($formName == 'CRM_Admin_Form_Setting_Localization') {
-    if ($inheritLocaleElement = $form->getElement('inheritLocale')) {
-      $inheritLocaleElement->freeze();
-    }
-  }
-}
-
-/**
  * Implements hook_civicrm_config().
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config/
@@ -129,4 +113,16 @@ function standaloneusers_civicrm_searchKitTasks(array &$tasks, bool $checkPermis
       'errorMsg' => E::ts('An error occurred while attempting to send password reset email(s).'),
     ],
   ];
+}
+
+/**
+ * Alter settings meta where the Standalone meaning is different from CMS meaning
+ *
+ * @todo more settings that could use this. Also some settings that might be best removed?
+ *
+ * Implements hook_civicrm_alterSettingsMetaData.
+ */
+function standaloneusers_civicrm_alterSettingsMetaData(&$settings) {
+  $settings['inheritLocale']['title'] = E::ts('Use User Language');
+  $settings['inheritLocale']['description'] = E::ts('If Yes, the system will use the Language set on the logged-in user\'s record. This can be changed later if using the CiviCRM language switcher.');
 }


### PR DESCRIPTION
Update
--------------------------------
Following https://github.com/civicrm/civicrm-core/pull/32525 this now just contains the implementation of `getUFLocale` for Standalone to read the logged in User's locale setting as part of the `applyLocale` cascade.

This behaviour is controlled by the `inheritLocale` setting.



Overview
----------------------------------------
 Attempt to unbreak multilingual on Standalone.

Before
----------------------------------------
- in the system bootstrap, UF `postContainerBoot` is the first thing that runs after the container has booted
- in Standalone, this initiates the user session and sets user timezone
- if you enable multilingual, it causes a crash because it tries to load the user data (to set the timezone) before any locale is set
- none of the other UFs do anything in the `postContainerBoot` hook
- inheritLocale is disabled on Standalone, so never checks user language
- getUFLocale isn't implemented for Standalone, so can't check user language

After
----------------------------------------
- ~~move `postContainerBoot` two steps later: after `Settings` is fully booted (can load db values) and after `applyLocale` is called~~
- move setTimeZone call later => bootstrap doesnt crash when enabling multilingual
- potential bad consequences of setting user timezone/session later? => seem ok from testing, but it slightly worries me that another extension's hook_civicrm_config could come in earlier, before the timezone is set (note: this would be the case already on other UFs, so `hook_civicrm_config` shouldn't expect timezone as it stands)
- remove block on setting inheritLocale on standalone, make wording reference User rather than CMS
- implement the getUFLocale check => note this requires the session is initialised, suggesting `postContainerBoot` should come _before_ `applyLocale`. There's also a note about temporarily setting dbLocale before checking `getUFLocale`, which sounds like related issue to the initial crash


Comments
----------------------------------------
Is there any reason `postContainerBoot` is exactly where it is? I remember in the work to get Standalone stable there used to be a crash in `applyLocale`, though I can't remember exact details, or if it had any interaction with `postContainerBoot`, and so that was an important constraint. But looking at the commit history, I suspect it's just "where it always was".~~

It would be good to retest the various bugs we found in Standalone timezone handling (PHP + MySQL) for any regressions on that front.

And see what Jenkins says.
