### PR TITLE
dev/core#5715 check civicontribute is enabled before loading Payment Processor admin

### DIFF
--- a/CRM/Admin/Page/PaymentProcessor.php
+++ b/CRM/Admin/Page/PaymentProcessor.php
@@ -40,6 +40,19 @@ class CRM_Admin_Page_PaymentProcessor extends CRM_Core_Page_Basic {
    * Finally it calls the parent's run method.
    */
   public function run() {
+
+    $civiContribute = \Civi\Api4\Extension::get(FALSE)
+      ->addWhere('status', '=', 'installed')
+      ->addWhere('key', '=', 'civi_contribute')
+      ->execute()
+      ->first();
+
+    if (!$civiContribute) {
+      $extensionsAdminUrl = \Civi::url('backend://civicrm/admin/extensions?reset=1');
+      \CRM_Core_Error::statusBounce(ts('You must enable CiviContribute before configuring Payment Processors'), $extensionsAdminUrl);
+      return;
+    }
+
     // set title and breadcrumb
     CRM_Utils_System::setTitle(ts('Settings - Payment Processor'));
     $breadCrumb = [


### PR DESCRIPTION
Overview
----------------------------------------
Fix for payment processor config page crash when civi_contribute and civicrm_admin_ui are disabled - https://lab.civicrm.org/dev/core/-/issues/5715

Before
----------------------------------------
- page crashes

After
----------------------------------------
- page bounces to the extension page, with a note that you need CiviContribute to get payment processors



Comments
----------------------------------------
With AdminUI enabed and CiviContribute disabled, you get a slightly broken/empty searchkit on this page. I think it might make sense to move the Payment Processor Admin search kit from AdminUI to CiviContribute.

Then if you had CiviContribute you would get the SearchKit page, and if you didn't you would get the statusBounce. At that point the rest of this QuickForm could be gutted (but worth keeping the status bounce for now at least, given the link is hard coded into the Config Checklist)
