### PR TITLE
standaloneusers - use only circle icons on permissions display

### DIFF
--- a/ext/standaloneusers/managed/SavedSearch_Permissions.mgd.php
+++ b/ext/standaloneusers/managed/SavedSearch_Permissions.mgd.php
@@ -97,7 +97,7 @@ foreach ($roles as $roleName => $roleLabel) {
     'rewrite' => ' ',
     'icons' => [
       [
-        'icon' => 'fa-square-check',
+        'icon' => 'fa-circle-check fa-solid',
         'side' => 'left',
         'if' => [
           'granted_' . $roleName,


### PR DESCRIPTION
Overview
----------------------------------------
This pulls out the change of icon from https://github.com/civicrm/civicrm-core/pull/32411 (screenshots on that PR)

Before
----------------------------------------
- granted/implied permissions are distinguished by square/circular checks

After
----------------------------------------
- granted/implied permissions are distinguished by filled/hollow circular checks


Comments
----------------------------------------
Rationale from @vingle was that square checks invite you to click on them. I had noticed myself doing that before and thinking the page was broken, so I think it's a good rationale!
