### PR TITLE
Sessions - Fix TypeError when detecting an invalid key

### DIFF
--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -859,7 +859,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
 
   public function invalidKeyCommon() {
     throw new CRM_Core_Exception(
-      ts("Sorry, your session has expired. Please reload the page or go back and try again."), 419, ts("Could not find a valid session key."));
+      ts("Sorry, your session has expired. Please reload the page or go back and try again."), 419, [ts("Could not find a valid session key.")]);
   }
 
   /**

--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -567,7 +567,7 @@ class CRM_Core_Page {
   }
 
   public function invalidKey() {
-    throw new CRM_Core_Exception(ts("Sorry, your session has expired. Please reload the page or go back and try again."), 419, ts("Could not find a valid session key."));
+    throw new CRM_Core_Exception(ts("Sorry, your session has expired. Please reload the page or go back and try again."), 419, [ts("Could not find a valid session key.")]);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
In Civi 6.0+, an "invalid key" error becomes a fatal error.  Details on https://lab.civicrm.org/dev/core/-/issues/5808.

Before
----------------------------------------
```
TypeError: Unsupported operand types: string + array in CRM_Core_Exception->__construct() (line 57 of /home/jon/local/civicrm-buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/Exception.php).
```

After
----------------------------------------
```
Sorry, your session has expired. Please reload the page or go back and try again.
```

Technical Details
----------------------------------------
The error above describes where the problem arises and what it is.
@shaneonabike 