### PR TITLE
dev/core#5806 Fix fatal error regression on custom data save

### DIFF
--- a/CRM/Custom/Form/CustomDataTrait.php
+++ b/CRM/Custom/Form/CustomDataTrait.php
@@ -90,15 +90,17 @@ trait CRM_Custom_Form_CustomDataTrait {
       // them here would register them in the QuickForm but not have POST values for them, which might result in data
       // loss (most notably radio fields, for which no POST value will be interpreted as a reset).
       // See https://lab.civicrm.org/dev/core/-/issues/5613
-      if (!isset(Civi::$statics[__CLASS__]['customGroups'][$field['custom_group']])) {
-        Civi::$statics[__CLASS__]['customGroups'][$field['custom_group']] = \Civi\Api4\CustomGroup::get(FALSE)
-          ->addSelect('style')
-          ->addWhere('name', '=', $field['custom_group'])
-          ->execute()
-          ->single();
-      }
-      if ('Inline' !== Civi::$statics[__CLASS__]['customGroups'][$field['custom_group']]['style']) {
-        continue;
+      if (isset($field['custom_group'])) {
+        if (!isset(Civi::$statics[__CLASS__]['customGroups'][$field['custom_group']])) {
+          Civi::$statics[__CLASS__]['customGroups'][$field['custom_group']] = \Civi\Api4\CustomGroup::get(FALSE)
+            ->addSelect('style')
+            ->addWhere('name', '=', $field['custom_group'])
+            ->execute()
+            ->single();
+        }
+        if ('Inline' !== Civi::$statics[__CLASS__]['customGroups'][$field['custom_group']]['style']) {
+          continue;
+        }
       }
 
       // Here we add the custom fields to the form


### PR DESCRIPTION
Overview
----------------------------------------
Fixes dev/core#5806

More efficient replacement for #32443

Before
----------------------------------------
Code attempts to waste time filtering fields that have already been filtered, and crashes in the process.

After
----------------------------------------
Skip the already-filtered fields and avoid the crash