### PR TITLE
[backport] dev/core#5715 Payment processor config requires civicontribute 

### DIFF
--- a/CRM/Admin/Page/PaymentProcessor.php
+++ b/CRM/Admin/Page/PaymentProcessor.php
@@ -40,6 +40,19 @@ class CRM_Admin_Page_PaymentProcessor extends CRM_Core_Page_Basic {
    * Finally it calls the parent's run method.
    */
   public function run() {
+
+    $civiContribute = \Civi\Api4\Extension::get(FALSE)
+      ->addWhere('status', '=', 'installed')
+      ->addWhere('key', '=', 'civi_contribute')
+      ->execute()
+      ->first();
+
+    if (!$civiContribute) {
+      $extensionsAdminUrl = \Civi::url('backend://civicrm/admin/extensions?reset=1');
+      \CRM_Core_Error::statusBounce(ts('You must enable CiviContribute before configuring Payment Processors'), $extensionsAdminUrl);
+      return;
+    }
+
     // set title and breadcrumb
     CRM_Utils_System::setTitle(ts('Settings - Payment Processor'));
     $breadCrumb = [


### PR DESCRIPTION
Overview
----------------------------------------
Backport of https://github.com/civicrm/civicrm-core/pull/32445

Not sure if this is needed as [the original issue](https://lab.civicrm.org/dev/core/-/issues/5715) seems not to be a new regression?
