### PR TITLE
[REF][PHP8.2] Replace undeclared property with local variable (CRM_Grant_Form_Grant)

### DIFF
--- a/ext/civigrant/CRM/Grant/Form/Grant.php
+++ b/ext/civigrant/CRM/Grant/Form/Grant.php
@@ -46,9 +46,7 @@ class CRM_Grant_Form_Grant extends CRM_Core_Form {
    */
   public function preProcess() {
 
-    $this->_grantType = NULL;
     if ($this->getGrantID()) {
-      $this->_grantType = CRM_Core_DAO::getFieldValue('CRM_Grant_DAO_Grant', $this->_id, 'grant_type_id');
       $this->_contactID = CRM_Core_DAO::getFieldValue('CRM_Grant_DAO_Grant', $this->_id, 'contact_id');
     }
     else {
@@ -170,7 +168,8 @@ class CRM_Grant_Form_Grant extends CRM_Core_Form {
     $this->addSelect('grant_type_id', ['placeholder' => ts('- select type -'), 'onChange' => "CRM.buildCustomData( 'Grant', this.value );"], TRUE);
 
     //need to assign custom data subtype to the template
-    $this->assign('customDataSubType', $this->_grantType);
+    $grantType = $this->getGrantID() ? CRM_Core_DAO::getFieldValue('CRM_Grant_DAO_Grant', $this->_id, 'grant_type_id') : NULL;
+    $this->assign('customDataSubType', $grantType);
     $this->assign('entityID', $this->_id);
 
     $this->addSelect('status_id', ['placeholder' => ts('- select status -')], TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
Replace undeclared property with local variable (CRM_Grant_Form_Grant)

Before
----------------------------------------
<img width="986" alt="Screenshot 2025-03-22 at 09 57 02" src="https://github.com/user-attachments/assets/ca27afca-1da5-4ddc-a167-b1e30258d1e6" />


After
----------------------------------------
As this property was only used once, and is unlikely to be needed in extensions, I've replaced it with a local variable, thereby getting rid of the "Creation of dynamic property" deprecation warning.
