### PR TITLE
[REF][PHP8.2] Declare properties CRM_Campaign_Selector_Search

### DIFF
--- a/CRM/Campaign/Selector/Search.php
+++ b/CRM/Campaign/Selector/Search.php
@@ -94,18 +94,25 @@ class CRM_Campaign_Selector_Search extends CRM_Core_Selector_Base implements CRM
   protected $_action;
 
   /**
-   * The additional clause that we restrict the search with.
-   *
-   * @var string
-   */
-  protected $_surveyClause = NULL;
-
-  /**
    * The query object.
    *
    * @var CRM_Contact_BAO_Query
    */
   protected $_query;
+
+  /**
+   * The "from" clause for the SQL query.
+   *
+   * @var string
+   */
+  protected $_campaignFromClause;
+
+  /**
+   * The "where" clause for the SQL query.
+   *
+   * @var string
+   */
+  protected $_campaignWhereClause;
 
   /**
    * Class constructor.
@@ -139,7 +146,6 @@ class CRM_Campaign_Selector_Search extends CRM_Core_Selector_Base implements CRM
     $this->_limit = $limit;
     $this->_context = $context;
 
-    $this->_campaignClause = $surveyClause;
     $this->_campaignFromClause = $surveyClause['fromClause'] ?? NULL;
     $this->_campaignWhereClause = $surveyClause['whereClause'] ?? NULL;
 


### PR DESCRIPTION
Overview
----------------------------------------
Declare properties in `CRM_Campaign_Selector_Search`

Before
----------------------------------------
<img width="1137" alt="Screenshot 2025-03-22 at 10 41 19" src="https://github.com/user-attachments/assets/3b9d695f-ffb6-41ad-8d00-60f827c50bee" />

After
----------------------------------------
1. `_surveyClause` was declared but not used: Now removed,
2. `_campaignClause` was created dynamically, but not used: Now removed,
3. `_campaignFromClause` and `_campaignWhereClause` were created dyanmically: Now created properly.
