### PR TITLE
dev/core#5767 Ensure total_amount is not null

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -373,7 +373,9 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
     }
     if (!isset($params['net_amount'])) {
       if (!$contributionID) {
-        $params['net_amount'] = $params['total_amount'] - $params['fee_amount'];
+        // It is unclear how total_amount could be null
+        // see https://lab.civicrm.org/dev/core/-/issues/5767
+        $params['net_amount'] = ($params['total_amount'] ?? 0) - $params['fee_amount'];
       }
       else {
         if (isset($params['fee_amount']) || isset($params['total_amount'])) {


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5767 Ensure total_amount is not null

Before
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/5767 under some (unknown?) circumstances `total_amount` is incorrectly `NULL` and hits a `TypeError`

After
----------------------------------------
Value cast to 0

Technical Details
----------------------------------------
I'm not totally sure why it would be NULL but per my comments on the issue I think it's fine to ensure it is 0 rather than NULL in this point in the code - perhaps there is some fugly flow around creating $0 donations for event registrations - either way casting here seems OK & the advantage of having a harder error seems low

Comments
----------------------------------------
