### PR TITLE
Dispatch hook to allow modifying API4 SQL

### DIFF
--- a/Civi/Api4/Query/Api4Query.php
+++ b/Civi/Api4/Query/Api4Query.php
@@ -77,7 +77,12 @@ abstract class Api4Query {
     $this->buildLimit();
     $this->buildGroupBy();
     $this->buildHavingClause();
-    return $this->query->toSQL();
+    $sql = $this->query->toSQL();
+
+    $event = GenericHookEvent::create(['sql' => &$sql]);
+    \Civi::dispatcher()->dispatch('civi.api4.generatedSql', $event);
+
+    return $sql;
   }
 
   public function getResults(): array {


### PR DESCRIPTION
Overview
----------------------------------------
Dispatch hook to allow modifying API4 SQL.

Before
----------------------------------------
Any API4 request gets boiled down to a SQL query, based on the fields being selected, joined, updated etc. Extension authors have little opportunity to modify this final SQL, which is needed for a small number of advanced use-cases.

After
----------------------------------------
A hook `civi.api4.generatedSql` has been introduced (Question: is there a better name for this?). The SQL query is passed in by reference, allowing it to be edited.

Comments
----------------------------------------
You might be wondering _why_ I'd want this...

I've been experimenting with making WordPress tables available through API4/ SearchKit/ FormBuilder (in theory the same would be possible with Drupal or Joomla too). This leads to some really interesting use-cases. For example, here I've added a tab to the contact screen, showing WordPress usermetadata associated with the contact's user (via joining `uf_match`):
<img width="996" alt="Screenshot 2025-03-23 at 11 19 43" src="https://github.com/user-attachments/assets/5b0919f0-5ba1-41a3-a9b0-b0ce6c25ec4c" />

There are any number of use-cases this unblocks. For example, showing WooCommerce orders, WordPress comments or Caldera Forms submissions against a CiviCRM contact summary, creating reports combining WooCommerce income with CiviCRM contribution income etc.

The catch is that the WordPress and CiviCRM database are often different. From [the installation guide](https://docs.civicrm.org/installation/en/latest/wordpress/):

> CiviCRM may be configured to use your existing WordPress database, or a separate (new) database. Using a separate database is generally preferred - as it makes backups and upgrades easier.

So whilst CiviCRM would usually create a query like this:
```
SELECT id, wp_users.id
FROM civicrm_contact a
LEFT JOIN (`civicrm_uf_match` `uf_match`) ON `uf_match`.`contact_id` = `a`.`id`
LEFT JOIN (`wp_users` `wp_users`) ON `uf_match`.`uf_id` = `wp_users`.`id`
WHERE (`a`.`is_deleted` = \"0\")
LIMIT 25
OFFSET 0
```

I need to be able to add the database name for the WordPress table(s):
```
SELECT id, wp_users.id
FROM civicrm_contact a
LEFT JOIN (`civicrm_uf_match` `uf_match`) ON `uf_match`.`contact_id` = `a`.`id`
LEFT JOIN (wordpress_db.`wp_users` `wp_users`) ON `uf_match`.`uf_id` = `wp_users`.`id`
WHERE (`a`.`is_deleted` = \"0\")
LIMIT 25
OFFSET 0
```

The addition of `civi.api4.generatedSql` allows for that. It does require doing some string manipulation, which isn't particuarly nice, but as this is a very niche requirement it's fine (I could have opened a PR allowing the API to natively add the database name, but that would have been a _much_ bigger PR, and felt overkill for such a niche use-case).

There are likely to also be other use-cases for `civi.api4.generatedSql` that I've not thought of. 