### PR TITLE
Fix incorrect hook name: `hook_civicrm_permission`

### DIFF
--- a/CRM/Core/Permission/Base.php
+++ b/CRM/Core/Permission/Base.php
@@ -357,7 +357,7 @@ class CRM_Core_Permission_Base {
   /**
    * Determine whether the permission store allows us to store
    * a list of permissions generated dynamically (eg by
-   * hook_civicrm_permissions.)
+   * hook_civicrm_permission.)
    *
    * @return bool
    */

--- a/CRM/Core/Permission/Standalone.php
+++ b/CRM/Core/Permission/Standalone.php
@@ -66,7 +66,7 @@ class CRM_Core_Permission_Standalone extends CRM_Core_Permission_Base {
   /**
    * Determine whether the permission store allows us to store
    * a list of permissions generated dynamically (eg by
-   * hook_civicrm_permissions.)
+   * hook_civicrm_permission.)
    *
    * @return bool
    */

--- a/release-notes/4.7.21.md
+++ b/release-notes/4.7.21.md
@@ -169,12 +169,12 @@ Released July 5, 2017
 ### Joomla Integration
 
 - **[CRM-12059](https://issues.civicrm.org/jira/browse/CRM-12059) Support
-  hook_civicrm_permissions on Joomla
+  hook_civicrm_permission on Joomla
   ([10344](https://github.com/civicrm/civicrm-core/pull/10344) and
   [43](https://github.com/civicrm/civicrm-joomla/pull/43))**
 
   CiviCRM permissions in Joomla can now be defined dynamically, allowing
-  extensions using `hook_civicrm_permissions` to work properly
+  extensions using `hook_civicrm_permission` to work properly
 
 ## <a name="bugs"></a>Bugs resolved
 


### PR DESCRIPTION
## **Overview**  
This PR corrects the hook name from `hook_civicrm_permissions` to `hook_civicrm_permission` across the CiviCRM core repository.  

The official CiviCRM documentation [link](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/) specifies that the correct function name is `hook_civicrm_permission`. However, multiple instances in the codebase and release notes used the incorrect plural form, which may lead to confusion.  


## **Before**  
- The incorrect hook name `hook_civicrm_permissions` was referenced in:  
  - `CRM/Core/Permission/Base.php`  
  - `CRM/Core/Permission/Standalone.php`  
  - `release-notes/4.7.21.md`  

Example of incorrect reference:  
```php
 * hook_civicrm_permissions.
```


## **After**  
- The hook name is now correctly updated to `hook_civicrm_permission` in all instances.  

Corrected reference:  
```php
 * hook_civicrm_permission.
```

This ensures that developers following the documentation use the correct hook name without confusion.  


## **Technical Details**  
- The function name in the codebase did not match the officially documented hook name.  
- This update ensures consistency across the code and release notes, preventing potential issues with permission-based extensions.  
- No functional changes; this is a documentation and naming correction.  


## **Comments**  
- This change does not impact existing functionality but aligns the codebase with CiviCRM’s documentation standards.  
