### PR TITLE
Add `Vinay Gawade` to `contributor-key.yml` for release notes credit

### DIFF
--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -1753,6 +1753,10 @@
   name        : Vinay Gawade
   organization: OSSeed Technologies LLP
 
+- github      : vinugawade
+  name        : Vinay Gawade
+  organization: OSSeed Technologies LLP
+  
 - github      : vinuvarshith
   name        : Vinu Varshith Sekar
   organization: CompuCorp
@@ -1896,6 +1900,3 @@
   name        : Peter Klausing
   organization: 5Knoten
 
-- github      : vinugawade
-  name        : Vinay Gawade
-  organization: OSSeed Technologies LLP

--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -1895,3 +1895,7 @@
 - github      : peetcreative
   name        : Peter Klausing
   organization: 5Knoten
+
+- github      : vinugawade
+  name        : Vinay Gawade
+  organization: OSSeed Technologies LLP


### PR DESCRIPTION
## **Overview**  
Adding my contributor details to `contributor-key.yml` for release notes credit, as suggested by @demeritcowboy  in PR #32467 .  

## **Before**  
My contributions were not yet listed in `contributor-key.yml`, so they wouldn't be credited in the release notes.  


## **After**  
I've added my details to `contributor-key.yml` as follows:  

```yaml
- github      : vinugawade
  name        : Vinay Gawade
  organization: OSSeed Technologies LLP
```

This ensures that my contributions are properly credited in future CiviCRM release notes.  

## **Technical Details**  
- Updated `contributor-key.yml` by adding my GitHub username, full name, and organization.  
- No functional or code changes—just a metadata update for contributor recognition.  

## **Comments**  
- Thanks @demeritcowboy for the suggestion! 🙌  