### PR TITLE
Use civiimport for participant import

### DIFF
--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -586,4 +586,54 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     return $mapperError;
   }
 
+  /**
+   * @param $mapper
+   *
+   * @return array
+   */
+  protected function getImportKeys($mapper): array {
+    $importKeys = [];
+    foreach ($mapper as $field) {
+      if (is_array($field)) {
+        $importKeys[] = $field;
+      }
+      else {
+        $importKeys[] = [$field];
+      }
+    }
+    return $importKeys;
+  }
+
+  /**
+   * @param array $mapper
+   *
+   * @return array
+   */
+  protected static function getMappedFields(array $mapper): array {
+    $mappedFields = [];
+    foreach ($mapper as $field) {
+      if (is_array($field)) {
+        $mappedFields[] = $field[0];
+      }
+      else {
+        $mappedFields[] = $field;
+      }
+    }
+    return $mappedFields;
+  }
+
+  /**
+   * @param array $mapper
+   *
+   * @param string $entity
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  protected function validateRequiredContactFields(array $mapper, string $entity = 'Contact'): array {
+    $parser = $this->getParser();
+    $rule = $parser->getDedupeRule($this->getContactType(), $this->getUserJob()['metadata']['entity_configuration'][$entity]['dedupe_rule'] ?? NULL);
+    return $this->validateContactFields($rule, $this->getImportKeys($mapper), ['external_identifier', 'contact_id']);
+  }
+
 }

--- a/CRM/Member/Import/Form/MapField.php
+++ b/CRM/Member/Import/Form/MapField.php
@@ -89,23 +89,10 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
    *   list of errors to be posted back to the form
    */
   public static function formRule($fields, $files, $self) {
-    $importKeys = [];
-    $mappedFields = [];
-    foreach ($fields['mapper'] as $field) {
-      if (is_array($field)) {
-        $importKeys[] = $field;
-        $mappedFields[] = $field[0];
-      }
-      else {
-        $importKeys[] = [$field];
-        $mappedFields[] = $field;
-      }
-    }
-    $parser = $self->getParser();
-    $rule = $parser->getDedupeRule($self->getContactType(), $self->getUserJob()['metadata']['entity_configuration']['Contact']['dedupe_rule'] ?? NULL);
-    $errors = $self->validateContactFields($rule, $importKeys, ['external_identifier', 'contact_id', 'contact_id']);
-
+    $errors = [];
+    $mappedFields = $self->getMappedFields($fields['mapper']);
     if (!in_array('id', $mappedFields)) {
+      $errors = $self->validateRequiredContactFields($fields['mapper']);
       // FIXME: should use the schema titles, not redeclare them
       $requiredFields = [
         'membership_type_id' => ts('Membership Type'),

--- a/ext/civiimport/civiimport.php
+++ b/ext/civiimport/civiimport.php
@@ -251,5 +251,5 @@ function civiimport_civicrm_buildForm(string $formName, $form) {
 }
 
 function civiimport_enabled_forms() {
-  return ['CRM_Contribute_Import_Form_MapField', 'CRM_Member_Import_Form_MapField'];
+  return ['CRM_Contribute_Import_Form_MapField', 'CRM_Member_Import_Form_MapField', 'CRM_Event_Import_Form_MapField'];
 }


### PR DESCRIPTION
Overview
----------------------------------------
Use civiimport for participant import

Before
----------------------------------------
- not possible to set default values for partiicipant import fields
- not possible to create or update participant contacts during import

After
----------------------------------------
ciimport functionality available on participant import

Technical Details
----------------------------------------

Comments
----------------------------------------
