### PR TITLE
Api4 - Support entities in alternate databases

### DIFF
--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -66,6 +66,10 @@ class Entity extends Generic\AbstractEntity {
       'description' => 'Name of sql table, if applicable',
     ],
     [
+      'name' => 'database_name',
+      'description' => 'Name of sql database, if different from CiviCRM',
+    ],
+    [
       'name' => 'primary_key',
       'data_type' => 'Array',
       'description' => 'Name of unique identifier field(s) (e.g. [id])',

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -136,6 +136,22 @@ class CoreUtil {
   }
 
   /**
+   * Get sql for table, including database prefix if needed
+   *
+   * @param string $entityName
+   *
+   * @return string|null
+   */
+  public static function getTableExpr(string $entityName): ?string {
+    $tableName = self::getInfoItem($entityName, 'table_name');
+    $databaseName = self::getInfoItem($entityName, 'database_name');
+    if ($databaseName) {
+      return "`$databaseName`.`$tableName`";
+    }
+    return "`$tableName`";
+  }
+
+  /**
    * Given a sql table name, return the name of the api entity.
    *
    * @param string $tableName

--- a/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
+++ b/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
@@ -67,7 +67,7 @@ class Api4SelectQueryTest extends Api4TestBase {
     $query = new Api4SelectQuery($api);
     $this->assertEquals(
       'SELECT SUM(`a`.`amount`) AS `SUM_amount`
-FROM civicrm_pledge a',
+FROM `civicrm_pledge` a',
       trim($query->getSql())
     );
   }


### PR DESCRIPTION
Overview
----------------------------------------
Allows Api4 entities to exist in different sql databases from CiviCRM.

Technical Details
------------
To use this, add the following to an Api4 entity file:

```php
  public static function getInfo():array {
    $info = parent::getInfo();
    if ($entityIsInAnotherDatabase) {
      $info['database_name'] = 'name_of_other_db';
    }
    return $info;
  }
```