### PR TITLE
Look up existing line items, not participant payments, to find participant line items

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -810,15 +810,8 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
           'id',
           'contribution_id'
         );
-        if ($pledgePaymentId) {
+        if ($pledgePaymentId || $this->getOrder()->getParticipantLineItems()) {
           $buildPriceSet = FALSE;
-        }
-        $participantID = $componentDetails['participant'] ?? NULL;
-        if ($participantID) {
-          $participantLI = CRM_Price_BAO_LineItem::getLineItems($participantID);
-          if (!CRM_Utils_System::isNull($participantLI)) {
-            $buildPriceSet = FALSE;
-          }
         }
       }
 
@@ -955,7 +948,12 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
    */
   protected function initializeOrder(): void {
     $this->order = new CRM_Financial_BAO_Order();
-    $this->order->setPriceSetID($this->getPriceSetID());
+    if ($this->getContributionID()) {
+      $this->order->setTemplateContributionID($this->getContributionID());
+    }
+    if ($this->getPriceSetID()) {
+      $this->order->setPriceSetID($this->getPriceSetID());
+    }
     $this->order->setForm($this);
     $this->order->setPriceSelectionFromUnfilteredInput($this->getSubmittedValues());
   }

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -898,6 +898,24 @@ class CRM_Financial_BAO_Order {
   }
 
   /**
+   * Get line items that specifically relate to participants.
+   *
+   * return array
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function getParticipantLineItems():array {
+    $lines = $this->getLineItems();
+    foreach ($lines as $index => $line) {
+      if ($line['entity_table'] !== 'civicrm_participant') {
+        unset($lines[$index]);
+        continue;
+      }
+    }
+    return $lines;
+  }
+
+  /**
    * Get an array of all membership types included in the order.
    *
    * @return array


### PR DESCRIPTION

Overview
----------------------------------------
Look up existing line items, not participant payments, to find participant line items

Before
----------------------------------------
Very round about check to determine whether there are existing participant line items - which involves looking up the participant payment to get the participant IDs and then looking up the participant object

After
----------------------------------------
Simplified

Technical Details
----------------------------------------

Comments
----------------------------------------
