### PR TITLE
Stop passing self to private non-static form function

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -383,7 +383,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       // build price set form.
       $this->set('priceSetId', $this->_priceSetId);
       if (empty($this->_ccid)) {
-        $this->buildPriceSet($this);
+        $this->buildPriceSet();
       }
       if ($this->_values['is_monetary'] &&
         $this->_values['is_recur'] && empty($this->_values['pledge_id'])
@@ -505,20 +505,18 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
   /**
    * Build the price set form.
    *
-   * @param CRM_Core_Form $form
-   *
    * @return void
    * @throws \CRM_Core_Exception
    */
-  private function buildPriceSet($form) {
+  private function buildPriceSet() {
     $validPriceFieldIds = array_keys($this->getPriceFieldMetaData());
-    $form->assign('priceSet', $form->_priceSet);
+    $this->assign('priceSet', $this->_priceSet);
     $this->assign('membershipFieldID');
 
     // @todo - this hook wrangling can be done earlier if we set the form on $this->>order.
-    $feeBlock = &$form->_values['fee'];
+    $feeBlock = &$this->_values['fee'];
     // Call the buildAmount hook.
-    CRM_Utils_Hook::buildAmount($this->getFormContext(), $form, $feeBlock);
+    CRM_Utils_Hook::buildAmount($this->getFormContext(), $this, $feeBlock);
 
     // CRM-14492 Admin price fields should show up on event registration if user has 'administer CiviCRM' permissions
     $adminFieldVisible = CRM_Core_Permission::check('administer CiviCRM');
@@ -573,7 +571,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
             }
           }
 
-          CRM_Price_BAO_PriceField::addQuickFormElement($form,
+          CRM_Price_BAO_PriceField::addQuickFormElement($this,
             'price_' . $fieldID,
             $field['id'],
             FALSE,
@@ -586,7 +584,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         }
       }
     }
-    $form->assign('hasExistingLifetimeMembership', $checklifetime);
+    $this->assign('hasExistingLifetimeMembership', $checklifetime);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Stop passing self to private non-static form function

Before
----------------------------------------
Previously shared code still refers to `$this` as `$form`

After
----------------------------------------
Fixed

Technical Details
----------------------------------------

Comments
----------------------------------------
