### PR TITLE
filter empty contact IDs from legacydedupefinder SQL

### DIFF
--- a/ext/legacydedupefinder/Civi/LegacyFinder/Finder.php
+++ b/ext/legacydedupefinder/Civi/LegacyFinder/Finder.php
@@ -27,6 +27,7 @@ class Finder extends AutoSubscriber {
     $contactIDs = [];
     if ($event->tableName) {
       $contactIDs = explode(',', \CRM_Core_DAO::singleValueQuery('SELECT GROUP_CONCAT(id) FROM ' . $event->tableName));
+      $contactIDs = array_filter($contactIDs);
     }
     $ruleGroup->contactIds = $contactIDs;
     $tempTable = self::fillTable($ruleGroup, $ruleGroup->id, $contactIDs, []);


### PR DESCRIPTION
Overview
----------------------------------------
Running the dedupe function with legacy dedupe finder enabled can sometimes give an error.

Before
----------------------------------------
```
(value: ) is not of the type Integer
```

After
----------------------------------------
No error.

Comments
----------------------------------------
I haven't looked into what the circumstances are here - it's running a query on a temp table and must be getting a trailing comma in some instances.  But I'd wager the issue is `group_concat_max_len`, which is a MySQL setting.  Depending on what's done with these contact IDs, there may be a more pernicious bug here - if we get cut off on a comma, that's not great, but if we pass through a truncated ID, we could potentially be taking action on a contact we don't intend to be.

Placing against the rc since it's a regression.
