### PR TITLE
Add region to ManageEvent/Form/Tab so we can change/replace ConfirmRepeatMode template

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/Tab.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Tab.tpl
@@ -81,4 +81,6 @@ CRM.$(function($) {
 });
 </script>
 {/literal}
+{crmRegion name="event-manageevent-confirmrepeatmode"}
 {include file="CRM/Event/Form/ManageEvent/ConfirmRepeatMode.tpl" entityID=$id entityTable="civicrm_event"}
+{/crmRegion}


### PR DESCRIPTION
Overview
----------------------------------------
Advanced Events extension (https://lab.civicrm.org/extensions/civicrm-advanced-events) overrides the ManageEvent/Form/Tab template to remove the ConfirmRepeatMode template/functionality.
Adding a crmRegion around that allows the extension to stop overriding the template.

Before
----------------------------------------
No region

After
----------------------------------------
A region

Technical Details
----------------------------------------


Comments
----------------------------------------

