### PR TITLE
Only set crm-public on profiles when public

### DIFF
--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -215,11 +215,9 @@ class CRM_Core_Invoke {
       }
 
       $template = CRM_Core_Smarty::singleton();
-      if (!empty($item['is_public'])) {
-        $template->assign('urlIsPublic', TRUE);
-      }
-      else {
-        $template->assign('urlIsPublic', FALSE);
+
+      $template->assign('urlIsPublic', CRM_Core_Config::singleton()->userFrameworkFrontend);
+      if (empty($item['is_public'])) {
         self::statusCheck($template);
       }
 

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -30,9 +30,9 @@
 {* Replace div id "crm-container" only when profile is not loaded in civicrm container, i.e for profile shown in my account and in profile standalone mode otherwise id should be "crm-profile-block" *}
 
   {if $action eq 1 or $action eq 2 or $action eq 4}
-  <div id="crm-profile-block" class="crm-container crm-public">
+  <div id="crm-profile-block" class="crm-container{if $urlIsPublic} crm-public{/if}">
     {else}
-  <div id="crm-container" class="crm-container crm-public" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
+  <div id="crm-container" class="crm-container{if $urlIsPublic} crm-public{/if}" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
   {/if}
 
   {if $showSaveDuplicateButton}


### PR DESCRIPTION
Overview
----------------------------------------
See: https://chat.civicrm.org/civicrm/pl/kmhhwbftnbd55mji1nz3t73rjw

Only add crm-public class if public.

Before
----------------------------------------
Always added to profiles

After
----------------------------------------
Only added if public (following pattern used in other templates)

Technical Details
----------------------------------------


Comments
----------------------------------------
@vingle I didn't test this change. But looks like it's probably the right approach.
