### PR TITLE
RiverLea 1.4.2: four fixes

### DIFF
--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -1,3 +1,6 @@
+1.4.2-6.2alpha
+ - FIXED - today's date background on date-picker (https://lab.civicrm.org/dev/core/-/issues/5807)
+
 1.4.1-6.2alpha
  - FIXED - start/end date appears inline (https://lab.civicrm.org/extensions/riverlea/-/issues/120)
  - FIXED - float of prev/next on contact dashboard on WordPress in some contexts (https://lab.civicrm.org/extensions/riverlea/-/issues/118).

--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -1,5 +1,6 @@
 1.4.2-6.2alpha
  - FIXED - today's date background on date-picker (https://lab.civicrm.org/dev/core/-/issues/5807)
+ - FIXED - restore .nowrap class (https://lab.civicrm.org/extensions/riverlea/-/issues/125)
 
 1.4.1-6.2alpha
  - FIXED - start/end date appears inline (https://lab.civicrm.org/extensions/riverlea/-/issues/120)

--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -2,6 +2,7 @@
  - FIXED - today's date background on date-picker (https://lab.civicrm.org/dev/core/-/issues/5807).
  - FIXED - restore .nowrap class (https://lab.civicrm.org/extensions/riverlea/-/issues/125).
  - FIXED - inconsistent padding around 'add address' block on contact dashboard (https://lab.civicrm.org/extensions/riverlea/-/issues/122).
+ - FIXED - stange alignment on summary modals (https://lab.civicrm.org/extensions/riverlea/-/issues/121).
 
 1.4.1-6.2alpha
  - FIXED - start/end date appears inline (https://lab.civicrm.org/extensions/riverlea/-/issues/120)

--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -1,6 +1,7 @@
 1.4.2-6.2alpha
- - FIXED - today's date background on date-picker (https://lab.civicrm.org/dev/core/-/issues/5807)
- - FIXED - restore .nowrap class (https://lab.civicrm.org/extensions/riverlea/-/issues/125)
+ - FIXED - today's date background on date-picker (https://lab.civicrm.org/dev/core/-/issues/5807).
+ - FIXED - restore .nowrap class (https://lab.civicrm.org/extensions/riverlea/-/issues/125).
+ - FIXED - inconsistent padding around 'add address' block on contact dashboard (https://lab.civicrm.org/extensions/riverlea/-/issues/122).
 
 1.4.1-6.2alpha
  - FIXED - start/end date appears inline (https://lab.civicrm.org/extensions/riverlea/-/issues/120)

--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -436,6 +436,9 @@ dl dl {
 .crm-container .element-right {
   float: right;
 }
+.crm-container .nowrap {
+  white-space: nowrap
+}
 /* Responsive  */
 
 @media (max-width: 991px) {

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -774,7 +774,6 @@ input.crm-form-checkbox) + label {
 }
 .ui-datepicker-calendar [data-handler],
 .ui-datepicker-calendar .ui-state-disabled {
-  background-color: var(--crm-gray-50) !important;
   border: 0;
   font-size: var(--crm-small-font-size);
   opacity: 1;
@@ -796,6 +795,10 @@ input.crm-form-checkbox) + label {
   padding: var(--crm-s);
   text-align: center;
   color: var(--crm-c-text);
+}
+.ui-datepicker-today a {
+  background: var(--crm-c-gray-100) !important /* vs other bg */;
+  border-radius: var(--crm-roundness);
 }
 
 /* JQ spinner */

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -49,6 +49,9 @@
 .crm-container .crm-summary-group .crm-section .label {
   width: 40%;
 }
+.crm-container .crm-summary-group .crm-section .content {
+  margin-left: 40%;
+}
 .crm-container .radio-inline label,
 .crm-container .checkbox-inline label {
   font-family: inherit;

--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -223,12 +223,6 @@ div.crm-inline-edit-form div.crm-clear {
   border-bottom: var(--crm-c-divider);
   border-width: 2px;
 }
-.crm-container div.contact_panel .crm-address-block {
-  margin-bottom: 6px;
-}
-.crm-container .crm-add-address-wrapper {
-  height: 25px;
-}
 .crm-container .crm-summary-row:after {
   clear: both;
   content: ".";

--- a/ext/riverlea/info.xml
+++ b/ext/riverlea/info.xml
@@ -12,7 +12,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>[civicrm.releaseDate]</releaseDate>
-  <version>1.4.1-[civicrm.version]</version>
+  <version>1.4.2-[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>


### PR DESCRIPTION
Overview
----------------------------------------
 1. FIXED - today's date background on date-picker (https://lab.civicrm.org/dev/core/-/issues/5807).
 2. FIXED - restore .nowrap class (https://lab.civicrm.org/extensions/riverlea/-/issues/125).
 3. FIXED - inconsistent padding around 'add address' block on contact dashboard (https://lab.civicrm.org/extensions/riverlea/-/issues/122).
 4. FIXED - strange alignment on summary modals (https://lab.civicrm.org/extensions/riverlea/-/issues/121).

Before
----------------------------------------
1 - today's date background on date-picker
![image](https://github.com/user-attachments/assets/5bee3a4f-3f29-4133-b7af-911543fc671c)

2 - no support for `.nowrap` in Civi

3 - inconsistent padding around 'add address' block on contact dashboard 
![image](https://github.com/user-attachments/assets/39212ec8-86f1-40f3-943a-618ac84b0707)

4 - strange alignment on summary modals
![image](https://github.com/user-attachments/assets/f4e3fdb8-99c4-451c-a5e1-7da193ce1df9)

After
----------------------------------------
1 - today's date background on date-picker
![image](https://github.com/user-attachments/assets/dae69bfa-b441-4701-8ea1-7fb08a1547c5)

2 - support for `.nowrap`

3 - inconsistent padding around 'add address' block on contact dashboard 
![image](https://github.com/user-attachments/assets/7d197da9-a419-42d0-a833-340887bf38c9)

4 - strange alignment on summary modals
![image](https://github.com/user-attachments/assets/244ffbda-f66c-498a-80a7-e2dea2dd30be)

Technical Details
----------------------------------------
This PR contains four commits, one for each bug/fix.