### PR TITLE
Fix undefined _paymentFields PHP warning

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -36,6 +36,15 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
   private array $optionsCount;
 
+  /**
+   * Array of payment related fields to potentially display on this form (generally credit card or debit card fields).
+   *
+   * This is rendered via billingBlock.tpl.
+   *
+   * @var array
+   */
+  public $_paymentFields = [];
+
   protected function getOrder(): CRM_Financial_BAO_Order {
     if (!isset($this->order)) {
       $this->initializeOrder();

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -63,15 +63,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
   public $_feeBlock;
 
   /**
-   * Array of payment related fields to potentially display on this form (generally credit card or debit card fields).
-   *
-   * This is rendered via billingBlock.tpl.
-   *
-   * @var array
-   */
-  public $_paymentFields = [];
-
-  /**
    * Is this submission incurring no costs.
    *
    * @param array $fields


### PR DESCRIPTION
Overview
----------------------------------------
This is used on Confirm when setting enables payment on confirm and you get a PHP warning.

Before
----------------------------------------
PHP warning

After
----------------------------------------
Gone

Technical Details
----------------------------------------


Comments
----------------------------------------

