### PR TITLE
Fix display of pay later instructions on thankyou and skipping when payment on confirmation page

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -556,16 +556,15 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
     $this->assign('address', CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($params));
 
-    if ($this->getSubmittedValue('credit_card_number')) {
-      if (isset($params['credit_card_exp_date'])) {
-        $date = CRM_Utils_Date::format($params['credit_card_exp_date']);
-        $date = CRM_Utils_Date::mysqlToIso($date);
-      }
-      $this->assign('credit_card_exp_date', $date ?? NULL);
-      $this->assign('credit_card_number',
-        CRM_Utils_System::mungeCreditCard($params['credit_card_number'] ?? NULL)
-      );
+    $this->assign('credit_card_type', $this->getSubmittedValue('credit_card_type'));
+    if ($this->getSubmittedValue('credit_card_exp_date')) {
+      $date = CRM_Utils_Date::format($this->getSubmittedValue('credit_card_exp_date'));
+      $date = CRM_Utils_Date::mysqlToIso($date);
     }
+    $this->assign('credit_card_exp_date', $date ?? NULL);
+    $this->assign('credit_card_number',
+      CRM_Utils_System::mungeCreditCard($this->getSubmittedValue('credit_card_number') ?? '')
+    );
 
     $this->assign('is_email_confirm', $this->_values['event']['is_email_confirm'] ?? NULL);
     // assign pay later stuff

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -453,13 +453,9 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
         }
       }
       if ($this->isShowPaymentOnConfirm()) {
-        // "is_pay_later" may have been set by the registration page. Reset it here.
-        $params[$participantNum]['is_pay_later'] = 0;
-        // Again, here we have to use getSubmitValue because getSubmittedValue is not set.
-        if ($this->getSubmitValue('hidden_processor') === NULL || $this->getSubmitValue('payment_processor_id') == 0) {
-          // If we submitted with no payment processor then we must be pay later - set it here.
-          $params[$participantNum]['is_pay_later'] = 1;
-        }
+        // If payment_processor_id is 0 or unset we are pay later.
+        // Otherwise we are using a payment processor
+        $params[$participantNum]['is_pay_later'] = $this->_values['event']['is_pay_later'] = empty($this->getSubmittedValue('payment_processor_id'));
       }
     }
     $taxAmount = $totalTaxAmount;

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -252,6 +252,9 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
         $this->assign('pay_later_receipt', '');
         // @fixme These functions all seem to do similar things but take one away and the house of cards falls down..
         $this->assignPaymentProcessor($this->_values['event']['is_pay_later']);
+        // This is required only after the form is submitted to repopulate form fields so that eg. credit card fields
+        //   can be retrieved via getSubmittedValue() from the ThankYou page. Otherwise they are lost.
+        $this->preProcessPaymentOptions();
         CRM_Core_Payment_ProcessorForm::buildQuickForm($this);
         $this->addPaymentProcessorFieldsToForm();
       }

--- a/settings/Event.setting.php
+++ b/settings/Event.setting.php
@@ -42,7 +42,7 @@ return [
     'type' => 'Array',
     'default' => [],
     'add' => '5.58',
-    'title' => ts('EXPERIMENTAL: Show Event Payment on Confirm?'),
+    'title' => ts('Show Event Payment on Confirm?'),
     'html_type' => 'select',
     'html_attributes' => [
       'class' => 'crm-select2',

--- a/templates/CRM/Event/Form/Registration/ThankYou.tpl
+++ b/templates/CRM/Event/Form/Registration/ThankYou.tpl
@@ -160,9 +160,9 @@
             {ts}Credit Card Information{/ts}
           </div>
           <div class="crm-section no-label credit_card_details-section">
-            <div class="content">{$credit_card_type}</div>
-            <div class="content">{$credit_card_number}</div>
-            <div class="content">{if $credit_card_exp_date}{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}{/if}</div>
+            <div class="content credit_card_type">{$credit_card_type}</div>
+            <div class="content credit_card_number">{$credit_card_number}</div>
+            <div class="content credit_card_exp_date">{if $credit_card_exp_date}{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}{/if}</div>
             <div class="clear"></div>
           </div>
         </div>


### PR DESCRIPTION
Overview
----------------------------------------
When a payment processor and pay later are enabled pay later instructions are always displayed on the ThankYou page.

Before
----------------------------------------
is_pay_later always set on ThankYou page.

After
----------------------------------------
Set per actual pay later status.

Technical Details
----------------------------------------
Explained via comments on this PR

Comments
----------------------------------------

