### PR TITLE
afform core: remove settings mixins since the settings were removed

### DIFF
--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -40,8 +40,6 @@
     <mixin>smarty@1.0.3</mixin>
     <mixin>entity-types-php@2.0.0</mixin>
     <mixin>menu-xml@1.0.0</mixin>
-    <mixin>setting-php@1.0.0</mixin>
-    <mixin>setting-admin@1.0.1</mixin>
   </mixins>
   <upgrader>CiviMix\Schema\Afform\AutomaticUpgrader</upgrader>
 </extension>


### PR DESCRIPTION
Overview
----------------------------------------

In 4fba6b06a5b074b9f50a41b3ba38e2565a80e510 (#31151), the afform core settings were removed. However, since the mixins were not removed, a "Form Core Settings" page remained (but the page was empty).

Before
----------------------------------------

Menu item that leads to an empty page.

After
----------------------------------------

No menu item.

Technical Details
----------------------------------------

- Removed: 4fba6b06a5b074b9f50a41b3ba38e2565a80e510 in PR #31151
- Added: 3d598cae6e6

cc @totten  