### PR TITLE
InstanceList: translate the component names

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -1828,10 +1828,6 @@ input.crm-form-entityref {
   vertical-align: top;
 }
 
-#crm-container table.report-layout tr {
-  font-size: 0.95em;
-}
-
 #crm-container .report-label {
   text-align: right;
   font-weight: bold;

--- a/templates/CRM/Report/Page/InstanceList.tpl
+++ b/templates/CRM/Report/Page/InstanceList.tpl
@@ -20,16 +20,14 @@
     <div class="crm-block crm-form-block crm-report-instanceList-form-block">
       {counter start=0 skip=1 print=false}
       {foreach from=$list item=rows key=report}
-        <details class="crm-accordion-bold crm-accordion_{$report}-accordion " open>
-          <summary>
-            {if $title}{$title}{elseif $report EQ 'Contribute'}{ts}Contribution Reports{/ts}{else}{ts 1=$report}%1 Reports{/ts}{/if}</a>
-          </summary>
+        <details class="crm-accordion-bold " open>
+          <summary>{$rows.label}</summary>
           <div class="crm-accordion-body">
             <div id="{$report}" class="boxBlock">
               <table class="report-layout">
-                {foreach from=$rows item=row}
+                {foreach from=$rows.list item=row}
                   <tr id="row_{counter}" class="crm-report-instanceList">
-                    <td class="crm-report-instanceList-title" style="width:35%"><a href="{$row.url}" title="{ts escape='htmlattribute'}Run this report{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> <strong>{$row.title}</strong></a></td>
+                    <td class="crm-report-instanceList-title" style="width:35%"><a href="{$row.url}" title="{ts escape='htmlattribute'}Run this report{/ts}"><strong>{$row.title}</strong></a></td>
                     <td class="crm-report-instanceList-description">{$row.description}</td>
                     <td>
                     <a href="{$row.viewUrl}" class="action-item crm-hover-button">{ts}View Results{/ts}</a>

--- a/templates/CRM/Report/Page/TemplateList.tpl
+++ b/templates/CRM/Report/Page/TemplateList.tpl
@@ -9,34 +9,29 @@
 *}
 
 <div class="help">
-  {ts}Create reports for your users from any of the report templates listed below. Click on a template title to get started. Click Existing Report(s) to see any reports that have already been created from that template.{/ts}
+  {ts}Create reports from any of the report templates listed below. Click on a template title to get started. Click Existing Reports to see any reports that have already been created from that template.{/ts}
 </div>
-
 <div class="crm-block crm-form-block crm-report-templateList-form-block">
   {strip}
     {if $list}
       {counter start=0 skip=1 print=false}
       {foreach from=$list item=rows key=report}
         <details class="crm-accordion-bold crm-accordion_{$report}-accordion " open>
-          <summary>
-            {if $report}{if $report EQ 'Contribute'}{ts}Contribution{/ts}{else}{$report}{/if}{else}{ts}Contact{/ts}{/if} Report Templates
-          </summary>
+          <summary>{$rows.label}</summary>
           <div class="crm-accordion-body">
             <div id="{$report}" class="boxBlock">
               <table class="report-layout">
-                {foreach from=$rows item=row}
+                {foreach from=$rows.list item=row}
                   <tr id="row_{counter}" class="crm-report-templateList">
                     <td class="crm-report-templateList-title" style="width:35%;">
-                      <a href="{$row.url}" title="{ts escape='htmlattribute'}Create report from this template{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> <strong>{$row.title}</strong></a>
+                      <a href="{$row.url}" title="{ts escape='htmlattribute'}Create report from this template{/ts}"><strong>{$row.title}</strong></a>
                       {if !empty($row.instanceUrl)}
-                        <div style="font-size:10px;text-align:right;margin-top:3px;">
-                          <a href="{$row.instanceUrl}">{ts}Existing Report(s){/ts}</a>
+                        <div style="text-align:right;">
+                          <a href="{$row.instanceUrl}">{ts}Existing Reports{/ts}</a>
                         </div>
                       {/if}
                     </td>
-                    <td style="cursor:help;" class="crm-report-templateList-description">
-                      {$row.description}
-                    </td>
+                    <td class="crm-report-templateList-description">{$row.description}</td>
                   </tr>
                 {/foreach}
               </table>
@@ -50,5 +45,4 @@
       </div>
     {/if}
   {/strip}
-
 </div>


### PR DESCRIPTION
Overview
----------------------------------------

Fixes the translation of component names in "Reports > All Reports".

Before
----------------------------------------

Incorrect use of `ts` to concatenate strings. Often translations didn't make sense, either because of an awkward ordering of the words, or because the component name it not correctly translated.

Ex: "Contact Reports" in English translates to "Contact Доклади" in Bulgarian, or "Contact Rapports" in French.

![image](https://github.com/user-attachments/assets/1ace5f31-ca43-4f8a-8ea7-3e5f75d9cbcf)

![image](https://github.com/user-attachments/assets/fccb18e6-61a8-4e99-bd7a-1c4faaf1ef20)

After
----------------------------------------

Translated component names, and I don't think it is necessary to repeat "Report" all the time.

![image](https://github.com/user-attachments/assets/c79d0455-b4bc-42c5-b46d-a2d28879292c)

Comments
----------------------------------------

I removed some CSS IDs and classes that were using the component names, because it becomes a bit unpredictable, and I don't see why anyone would need this.

The screen also shows `fr_CA`, where we chose to translate component names such as "CiviEvent" to just "Événements" (Events), because "CiviÉvénements" looks silly, and keeping it in English is not an option. I noticed some other languages just keep it in English (such as Bulgarian).