### PR TITLE
Remove top buttons from backend Membership Renewal form

### DIFF
--- a/templates/CRM/Member/Form/MembershipRenewal.tpl
+++ b/templates/CRM/Member/Form/MembershipRenewal.tpl
@@ -42,7 +42,6 @@
     {/if}
   {/if}
   <div class="crm-block crm-form-block crm-member-membershiprenew-form-block">
-    <div>{include file="CRM/common/formButtons.tpl" location="top"}</div>
     <table class="form-layout">
       <tr class="crm-member-membershiprenew-form-block-contact-id">
         <td class="label">{$form.contact_id.label}</td>
@@ -119,10 +118,8 @@
     {/if}
 
     {include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='Membership' cid=false}
-
-    <div>{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
-
     <div class="spacer"></div>
+    <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
   </div>
   {if $accessContribution and ! $membershipMode}
     {include file="CRM/common/showHideByFieldValue.tpl"


### PR DESCRIPTION
Overview
----------------------------------------

Removes the top buttons from backend Membership Renewal forms. They are shown at the bottom.

Also fixes the class around buttons, so that they are shown in the usual way in popups.

Top buttons were removed a while back from many forms. 

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/f7994ec9-d389-4ebc-a7a0-899b0d6f8d64)

After
----------------------------------------

![image](https://github.com/user-attachments/assets/f4b38e01-3439-4789-a467-26011b097743)
