### PR TITLE
Freeze price_set_id when freezing total_amount

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1786,6 +1786,8 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
   /**
    * Returns all contribution related object ids.
    *
+   * @deprecated since 6.2 will be removed when core callers fully removed.
+   *
    * @param $contributionId
    *
    * @return array

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -970,15 +970,13 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
     $financialType = $this->createFinancialType();
     $financialAccount = $this->addTaxAccountToFinancialType($financialType['id']);
     /** @var CRM_Contribute_Form_Contribution $form */
-    $form = $this->getFormObject('CRM_Contribute_Form_Contribution', [
+    $this->getTestForm('CRM_Contribute_Form_Contribution', [
       'total_amount' => $params['total_amount'],
       'financial_type_id' => $financialType['id'],
       'contact_id' => $contactId,
       'contribution_status_id' => $isCompleted ? 1 : 2,
       'price_set_id' => 0,
-    ]);
-    $form->buildForm();
-    $form->postProcess();
+    ])->processForm();
     $contribution = $this->callAPISuccessGetSingle('Contribution',
       [
         'contact_id' => $contactId,


### PR DESCRIPTION
Overview
----------------------------------------
Work has been done to freeze the total amount when editing membership or participant related contributions - however, `price_set_id` is not frozen. This looks like an oversight as it would not always be a visible option. Further there is no suitable post process handling for if this is edited.

Before
----------------------------------------


![image](https://github.com/user-attachments/assets/e1eb7b94-7eb8-43e0-99e0-d926778e6431)


After
----------------------------------------
![image](https://github.com/user-attachments/assets/c41da33b-8433-449d-9432-cbe8ad5abc64)

Technical Details
----------------------------------------

Comments
----------------------------------------
