### PR TITLE
Stop using deprecated function to calculate already-calculated values

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -990,23 +990,17 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
           $errors['_qf_default'] = ts('Please select at least one membership option.');
         }
       }
-      // @todo - processAmount is to be deprectated - can we use getTotalAmount or
-      // a function of self->order here?
-      CRM_Price_BAO_PriceSet::processAmount($self->_values['fee'],
-        $fields
-      );
 
+      $amount = $self->getOrder()->getTotalAmount();
       $minAmt = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $fields['priceSetId'], 'min_amount');
-      if ($fields['amount'] < 0) {
+      if ($amount < 0) {
         $errors['_qf_default'] = ts('Contribution can not be less than zero. Please select the options accordingly');
       }
-      elseif (!empty($minAmt) && $fields['amount'] < $minAmt) {
+      elseif (!empty($minAmt) && $amount < $minAmt) {
         $errors['_qf_default'] = ts('A minimum amount of %1 should be selected from Contribution(s).', [
           1 => CRM_Utils_Money::format($minAmt),
         ]);
       }
-
-      $amount = $fields['amount'];
     }
 
     if (isset($fields['selectProduct']) &&


### PR DESCRIPTION
Overview
----------------------------------------
Stop using deprecated function to calculate already-calculated values

Before
----------------------------------------
`processAmount` is being called to determine the submitted amount - but that is already done & stored in `$this->_values['fee']` - the call just overwrites it - it also uses the calculated line items to calculate the total amount - also, already done without using the deprecated function

After
----------------------------------------
use already calculated values 


Technical Details
----------------------------------------
Running through https://github.com/civicrm/civicrm-core/pull/32514 to check the thesis always holds

Comments
----------------------------------------
