### PR TITLE
Aria-label afform: Remove element label from radio option and add for to label

### DIFF
--- a/ext/afform/core/ang/af/fields/Radio.html
+++ b/ext/afform/core/ang/af/fields/Radio.html
@@ -1,5 +1,5 @@
-<label ng-repeat="opt in getOptions() track by opt.id" >
-  <input class="crm-form-radio" name="{{:: fieldId }}" type="radio" ng-model="getSetValue" ng-required="$ctrl.defn.required" ng-model-options="{getterSetter: true}" ng-value="opt.id"  aria-label="{{$ctrl.defn.label}} {{opt.label}}" />
+<label ng-repeat="opt in getOptions() track by opt.id" for="{{:: fieldId }}">
+  <input class="crm-form-radio" name="{{:: fieldId }}" type="radio" ng-model="getSetValue" ng-required="$ctrl.defn.required" ng-model-options="{getterSetter: true}" ng-value="opt.id"  aria-label="{{opt.label}}" />
   {{:: opt.label }}
 </label>
 	<a ng-if="!$ctrl.defn.required" class="crm-hover-button" title="{{:: ts('Clear') }}" ng-show="!!dataProvider.getFieldData()[$ctrl.fieldName] || dataProvider.getFieldData()[$ctrl.fieldName] === false || dataProvider.getFieldData()[$ctrl.fieldName] === 0" ng-click="dataProvider.getFieldData()[$ctrl.fieldName] = null" aria-label="{{:: ts('Clear') }}">


### PR DESCRIPTION
Overview
----------------------------------------
Follow up from https://github.com/civicrm/civicrm-core/pull/32088 incorporating feedback.


Before
----------------------------------------
afform aria-label on radio inputs included the group label as a prefix. 
afform label on radio inputs lacked for attribute

After
----------------------------------------
afform aria-label on radio inputs include only the label for that option.
afform label on radio inputs have a for attribute


Comments
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/32088