### PR TITLE
Make Civiimport required

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixTwo.php
+++ b/CRM/Upgrade/Incremental/php/SixTwo.php
@@ -36,6 +36,14 @@ class CRM_Upgrade_Incremental_php_SixTwo extends CRM_Upgrade_Incremental_Base {
       'required' => FALSE,
       'description' => ts('Configuration of the managed-entity when last stored'),
     ]);
+    $this->addTask('Add in domain_id column to the civicrm_acl_contact_cache_table', 'alterSchemaField', 'ACLContactCache', 'domain_id', [
+      'title'  => ts('Domain'),
+      'sql_type' => 'int unsigned',
+      'input_type' => 'Number',
+      'description' => ts('Implicit FK to civicrm_domain'),
+      'required' => TRUE,
+      'default' => 1,
+    ]);
     $this->addTask('Set upload_date in file table', 'setFileUploadDate');
     $this->addTask('Set default for upload_date in file table', 'alterSchemaField', 'File', 'upload_date', [
       'title' => ts('File Upload Date'),
@@ -78,14 +86,7 @@ class CRM_Upgrade_Incremental_php_SixTwo extends CRM_Upgrade_Incremental_Base {
         'callback' => ['CRM_Core_SelectValues', 'customGroupStyle'],
       ],
     ]);
-    $this->addTask('Add in domain_id column to the civicrm_acl_contact_cache_table', 'alterSchemaField', 'ACLContactCache', 'domain_id', [
-      'title'  => ts('Domain'),
-      'sql_type' => 'int unsigned',
-      'input_type' => 'Number',
-      'description' => ts('Implicit FK to civicrm_domain'),
-      'required' => TRUE,
-      'default' => 1,
-    ]);
+    $this->addExtensionTask('Enable CiviImport extension', ['civiimport']);
     $this->addTask('Fix Unique index on acl cache table with domain id', 'fixAclUniqueIndex');
   }
 

--- a/ext/civiimport/info.xml
+++ b/ext/civiimport/info.xml
@@ -16,11 +16,14 @@
   </urls>
   <releaseDate>[civicrm.releaseDate]</releaseDate>
   <version>[civicrm.version]</version>
-  <develStage>alpha</develStage>
+  <develStage>stable</develStage>
+  <tags>
+    <tag>mgmt:required</tag>
+  </tags>
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
-  <comments>This extension contains import functionality which was previously in CiviCRM Core. If you use the import functionality it is recommended to enable this extension.</comments>
+  <comments>CiviCRM import functionality</comments>
   <requires>
     <ext>org.civicrm.afform</ext>
     <ext>org.civicrm.search_kit</ext>

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -40,24 +40,8 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
    */
   protected $enableBackgroundQueueOriginalValue;
 
-  /**
-   * These extensions are inactive at the start. They may be activated during the test. They should be deactivated at the end.
-   *
-   * For the moment, the test is simply hard-coded to cleanup in a specific order. It's tempting to auto-detect and auto-uninstall these.
-   * However, the shape of their dependencies makes it tricky to auto-uninstall (e.g. some extensions have managed-entities that rely on other
-   * extensions -- you need to fully disable+uninstall the downstream managed-entity-ext before disabling or uninstalling the upstream
-   * entity-provider-ext).
-   *
-   * You may need to edit `$toggleExtensions` whenever the dependency-graph changes.
-   *
-   * @var string[]
-   */
-  protected $toggleExtensions = ['civiimport'];
-
   protected function setUp(): void {
     parent::setUp();
-    $originalExtensions = array_column(CRM_Extension_System::singleton()->getMapper()->getActiveModuleFiles(), 'fullName');
-    $this->assertEquals([], array_values(array_intersect($originalExtensions, $this->toggleExtensions)), 'These extensions may be enabled and disabled during the test. The start-state and end-state should be the same. It appears that we have an unexpected start-state. Perhaps another test left us with a weird start-state?');
     $this->enableBackgroundQueueOriginalValue = Civi::settings()->get('enableBackgroundQueue');
   }
 
@@ -73,10 +57,6 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     DedupeRule::delete()
       ->addWhere('rule_table', '!=', 'civicrm_email')
       ->addWhere('dedupe_rule_group_id.name', '=', 'IndividualUnsupervised')->execute();
-    foreach ($this->toggleExtensions as $ext) {
-      CRM_Extension_System::singleton()->getManager()->disable([$ext]);
-      CRM_Extension_System::singleton()->getManager()->uninstall([$ext]);
-    }
     Civi::settings()->set('enableBackgroundQueue', $this->enableBackgroundQueueOriginalValue);
     parent::tearDown();
   }


### PR DESCRIPTION
Overview
----------------------------------------
Make Civiimport required

When civiimport was added it was not required to allow for a transitional phase (read bug-finding) - however, we are now at the point where maintaining both the civiimport UI and the old UI is not manageable. 

In 6.2 Participant, Membership imports have been transitioned over to the new UI but prior to this PR it is still possible to disable civiimport and use the old UI (which would need more testing if we want to keep it live but which we get little value from) and we are planning to migrate some or all of the remaining Activity, CustomData and contact


Before
----------------------------------------
optional

After
----------------------------------------
required

Technical Details
----------------------------------------

Comments
----------------------------------------
