### PR TITLE
Remove some of the hacks to run quickform alongside civiimport

### DIFF
--- a/CRM/Activity/Import/Form/MapField.php
+++ b/CRM/Activity/Import/Form/MapField.php
@@ -63,7 +63,6 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
     ];
 
     foreach ($requiredFields as $field => $title) {
-      $field = str_replace('__', '.', $field);
       if (!in_array($field, $importKeys, TRUE)) {
         $errors[] = ts('Missing required field: %1', [1 => $title]) . '<br />';
       }

--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -103,13 +103,6 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
       if ($this->isUpdateExisting() && in_array($name, ['id', 'invoice_id', 'trxn_id'], TRUE)) {
         $field['title'] .= (' ' . ts('(match to contribution record)'));
       }
-      // Swap out dots for double underscores so as not to break the quick form js.
-      // We swap this back on postProcess.
-      // Arg - we need to swap out _. first as it seems some groups end in a trailing underscore,
-      // which is indistinguishable to convert back - ie ___ could be _. or ._.
-      // https://lab.civicrm.org/dev/core/-/issues/4317#note_91322
-      $name = str_replace('_.', '~~', $name);
-      $name = str_replace('.', '__', $name);
       if (($field['entity'] ?? '') === 'Contact' && $this->isFilterContactFields() && empty($field['match_rule'])) {
         // Filter out metadata that is intended for create & update - this is not available in the quick-form
         // but is now loaded in the Parser for the LexIM variant.
@@ -219,7 +212,7 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
         if (!empty($entityData)) {
           $softCreditTypeID = (int) $entityData['soft_credit']['soft_credit_type_id'];
         }
-        $fieldName = $this->isQuickFormMode ? str_replace('.', '__', $fieldMapping['name']) : $fieldMapping['name'];
+        $fieldName = $fieldMapping['name'];
         $defaults["mapper[$rowNumber]"] = [$fieldName, $softCreditTypeID];
       }
     }

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -629,8 +629,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
    */
   public function getMappingFieldFromMapperInput(array $fieldMapping, int $mappingID, int $columnNumber): array {
     return [
-      // The double __ is a quickform hack - the 'real' name is dotted - eg. 'soft_credit.contact.id'
-      'name' => str_replace('__', '.', $fieldMapping[0]),
+      'name' => $fieldMapping[0],
       'mapping_id' => $mappingID,
       'column_number' => $columnNumber,
       'entity_data' => !empty($fieldMapping[1]) ? ['soft_credit' => ['soft_credit_type_id' => $fieldMapping[1]]] : NULL,

--- a/CRM/Custom/Import/Form/MapField.php
+++ b/CRM/Custom/Import/Form/MapField.php
@@ -5,22 +5,6 @@
  */
 class CRM_Custom_Import_Form_MapField extends CRM_Import_Form_MapField {
 
-
-  /**
-   * Does the form layer convert field names to support QuickForm widgets.
-   *
-   * (e.g) if 'yes' we swap
-   * `soft_credit.external_identifier` to `soft_credit__external_identifier`
-   * because the contribution form would break on the . as it would treat it as
-   * javascript.
-   *
-   * In the case of the custom field import the array is flatter and there
-   * is no hierarchical select so we do not need to do this.
-   *
-   * @var bool
-   */
-  protected bool $supportsDoubleUnderscoreFields = FALSE;
-
   /**
    * Get the name of the type to be stored in civicrm_user_job.type_id.
    *

--- a/CRM/Event/Import/Form/MapField.php
+++ b/CRM/Event/Import/Form/MapField.php
@@ -21,21 +21,6 @@
 class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
 
   /**
-   * Does the form layer convert field names to support QuickForm widgets.
-   *
-   * (e.g) if 'yes' we swap
-   * `soft_credit.external_identifier` to `soft_credit__external_identifier`
-   * because the contribution form would break on the . as it would treat it as
-   * javascript.
-   *
-   * In the case of the participant import the array is flatter and there
-   * is no hierarchical select so we do not need to do this.
-   *
-   * @var bool
-   */
-  protected bool $supportsDoubleUnderscoreFields = FALSE;
-
-  /**
    * Get the name of the type to be stored in civicrm_user_job.type_id.
    *
    * @return string

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -25,18 +25,6 @@ use Civi\Api4\MappingField;
 abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
 
   /**
-   * Does the form layer convert field names to support QuickForm widgets.
-   *
-   * (e.g) if 'yes' we swap
-   * `soft_credit.external_identifier` to `soft_credit__external_identifier`
-   * because the contribution form would break on the . as it would treat it as
-   * javascript.
-   *
-   * @var bool
-   */
-  protected bool $supportsDoubleUnderscoreFields = TRUE;
-
-  /**
    * Mapper fields
    *
    * @var array
@@ -547,7 +535,7 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
       // Because api v4 style fields have a . and QuickForm multiselect js does
       // not cope with a . the quick form layer will use a double underscore
       // as a stand in (the angular layer will not)
-      $fieldName = str_replace('__', '.', $mapping[0]);
+      $fieldName = $mapping[0];
       if (str_contains($fieldName, '.')) {
         // If the field name contains a . - eg. address_primary.street_address
         // we just want the part after the .

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -705,14 +705,6 @@ class CRM_Import_Forms extends CRM_Core_Form {
         // but is now loaded in the Parser for the LexIM variant.
         continue;
       }
-      if (isset($this->supportsDoubleUnderscoreFields) && !empty($this->supportsDoubleUnderscoreFields)) {
-        // Swap out dots for double underscores so as not to break the quick form js.
-        // We swap this back on postProcess.
-        // Arg - we need to swap out _. first as it seems some groups end in a trailing underscore.
-        // https://lab.civicrm.org/dev/core/-/issues/4317#note_91322
-        $name = str_replace('_.', '~~', $name);
-        $name = str_replace('.', '__', $name);
-      }
       $return[$name] = $field['title'];
     }
     return $return;

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1006,10 +1006,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
 
     $fieldMap = $this->getOddlyMappedMetadataFields();
     $fieldMapName = empty($fieldMap[$fieldName]) ? $fieldName : $fieldMap[$fieldName];
-    $fieldMapName = str_replace('__', '.', $fieldMapName);
-    // See https://lab.civicrm.org/dev/core/-/issues/4317#note_91322 - a further hack for quickform not
-    // handling dots in field names. One day we will get rid of the Quick form screen...
-    $fieldMapName = str_replace('~~', '_.', $fieldMapName);
     foreach ($this->getImportEntities() as $entity) {
       if (empty($this->getImportableFieldsMetadata()[$fieldMapName]) && $entity['entity_field_prefix'] && str_starts_with($fieldMapName, $entity['entity_field_prefix'])) {
         // e.g if the field name is 'contact.external_identifier' then it is just a case of looking

--- a/CRM/Member/Import/Form/MapField.php
+++ b/CRM/Member/Import/Form/MapField.php
@@ -21,21 +21,6 @@
 class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
 
   /**
-   * Does the form layer convert field names to support QuickForm widgets.
-   *
-   * (e.g) if 'yes' we swap
-   * `soft_credit.external_identifier` to `soft_credit__external_identifier`
-   * because the contribution form would break on the . as it would treat it as
-   * javascript.
-   *
-   * In the case of the membership import the array is flatter and there
-   * is no hierarchical select so we do not need to do this.
-   *
-   * @var bool
-   */
-  protected bool $supportsDoubleUnderscoreFields = FALSE;
-
-  /**
    * Build the form object.
    *
    * @throws \CRM_Core_Exception

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -68,7 +68,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
    */
   public function tearDown(): void {
     $this->quickCleanUpFinancialEntities();
-    $this->quickCleanup(['civicrm_user_job', 'civicrm_queue', 'civicrm_queue_item', 'civicrm_campaign'], TRUE);
+    $this->quickCleanup(['civicrm_user_job', 'civicrm_queue', 'civicrm_queue_item', 'civicrm_campaign', 'civicrm_note'], TRUE);
     OptionValue::delete()->addWhere('name', '=', 'random')->execute();
     DedupeRule::delete()
       ->addWhere('rule_table', '!=', 'civicrm_email')
@@ -130,27 +130,6 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $this->assertEquals(1, $dataSource->getRowCount([CRM_Import_Parser::ERROR]));
     $this->assertEquals(1, $dataSource->getRowCount([CRM_Contribute_Import_Parser_Contribution::SOFT_CREDIT]));
     $this->assertEquals(1, $dataSource->getRowCount([CRM_Import_Parser::VALID]));
-
-    // Now try the import with the dots swapped to double underscores. The parser
-    // layer and api understand the dots - but QuickForm has to play switcheroo as the dots
-    // break the hierarchical multiselect js. QuickForm uses a double underscore as a stand in.;
-    $this->validateSoftCreditImport([
-      ['name' => 'total_amount'],
-      ['name' => 'receive_date'],
-      ['name' => 'financial_type_id'],
-      ['name' => 'contact__external_identifier'],
-      ['name' => 'soft_credit__contact__external_identifier', 'soft_credit_type_id' => 1],
-    ]);
-    $this->validateSoftCreditImport([
-      ['name' => 'total_amount'],
-      ['name' => 'receive_date'],
-      ['name' => 'financial_type_id'],
-      ['name' => 'external_identifier'],
-      [],
-      [],
-      [],
-      ['name' => 'soft_credit__contact__id', 'soft_credit_type_id' => 1],
-    ]);
   }
 
   /**
@@ -517,24 +496,6 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ->addWhere('entity_table', '=', 'civicrm_contribution')->execute()->first();
     $this->assertEquals('Call him back', $note['note']);
 
-  }
-
-  /**
-   * Tests the form flow copes with QuickForm style dots.
-   *
-   * Because the QuickForm hierarchical select won't cope with dots
-   * we are using a double underscore on that form. The test checks that works.
-   */
-  public function testImportQuickFormEmailMatch() :void {
-    $this->individualCreate(['email' => 'jenny@example.com']);
-    $this->importCSV('checkboxes.csv', [
-      ['name' => 'total_amount'],
-      ['name' => 'receive_date'],
-      ['name' => 'financial_type_id'],
-      ['name' => ''],
-      ['name' => 'contact__email_primary__email'],
-      ['name' => ''],
-    ]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Remove some of the hacks to run quickform alongside civiimport

Before
----------------------------------------
In order to support a quick form UI AND an angular UI we had to do some weird field-foo

After
----------------------------------------
Some of the weird stuff gone.

Technical Details
----------------------------------------

Comments
----------------------------------------
