### PR TITLE
Mark tests that regularly fail as ornery

### DIFF
--- a/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormBrowserTest.php
+++ b/ext/afform/mock/tests/phpunit/E2E/AfformMock/MockPublicFormBrowserTest.php
@@ -26,6 +26,8 @@ class MockPublicFormBrowserTest extends Civi\Test\MinkBase {
    * Create a contact with middle name "Donald". Use the custom form to change the middle
    * name to "Donny".
    *
+   * @group ornery
+   *
    * @return void
    * @throws \Behat\Mink\Exception\ElementNotFoundException
    * @throws \CRM_Core_Exception

--- a/ext/civicrm_admin_ui/tests/phpunit/E2E/CivicrmAdminUi/ManageGroupsTest.php
+++ b/ext/civicrm_admin_ui/tests/phpunit/E2E/CivicrmAdminUi/ManageGroupsTest.php
@@ -17,6 +17,18 @@ class E2E_CivicrmAdminUi_ManageGroupsTest extends \Civi\Test\MinkBase {
     \Civi\Test::e2e()->installMe(__DIR__)->apply();
   }
 
+  /**
+   * @group ornery
+   *
+   * @return void
+   * @throws \Behat\Mink\Exception\DriverException
+   * @throws \Behat\Mink\Exception\ElementNotFoundException
+   * @throws \Behat\Mink\Exception\ElementTextException
+   * @throws \Behat\Mink\Exception\ExpectationException
+   * @throws \Behat\Mink\Exception\UnsupportedDriverActionException
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
   public function testManageGroups() {
     $session = $this->mink->getSession();
     $page = $session->getPage();


### PR DESCRIPTION
Overview
----------------------------------------
Mark tests that regularly fail as ornery

Before
----------------------------------------
We constantly have to re-run these on PR tests

After
----------------------------------------
they will be skipped on PR tests

Technical Details
----------------------------------------
@totten 

Comments
----------------------------------------
