### PR TITLE
Allow EntityPrefix to be passed to validateRequiredFields

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -27,6 +27,8 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
 
   private $externalIdentifiers = [];
 
+  protected $baseEntity = 'Contact';
+
   /**
    * Relationship labels.
    *


### PR DESCRIPTION
Overview
----------------------------------------
We've had a bit of back & forth about prefixing on Import Mappings - from the base entity having a no prefix to it having a lower case prefix & back to it having no prefix & slightly path with the other related entities. 

However @colemanw has put a stake in the ground for consolidating on all entities having a prefix and using CamelCase for entity names - so I'm hoping to be sure to consolidate on that prefixing in the 6.2 release & this is a small part of that pr towards that (but softened to make it possible to do import by import)

https://github.com/civicrm/civicrm-core/pull/32317

https://github.com/civicrm/civicrm-core/pull/32317/files#diff-a2daa0eb4d93f084aa2ad66b42fd4a351f38c8f230a0895870c7da8c520ab6dcR685

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
