### PR TITLE
Alter activity import prefixing to new agreed version

### DIFF
--- a/CRM/Activity/Import/Form/MapField.php
+++ b/CRM/Activity/Import/Form/MapField.php
@@ -57,9 +57,9 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
   protected function validateRequiredFields(array $importKeys): ?array {
     $errors = [];
     $requiredFields = [
-      'activity_date_time' => ts('Activity Date'),
-      'subject' => ts('Activity Subject'),
-      'activity_type_id' => ts('Activity Type ID'),
+      'Activity.activity_date_time' => ts('Activity Date'),
+      'Activity.subject' => ts('Activity Subject'),
+      'Activity.activity_type_id' => ts('Activity Type ID'),
     ];
 
     foreach ($requiredFields as $field => $title) {
@@ -94,8 +94,6 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
    *
    * @return array
    *   e.g ['first_name' => 'First Name', 'last_name' => 'Last Name'....
-   *
-   * @throws \CRM_Core_Exception
    */
   protected function getAvailableFields(): array {
     $return = [];
@@ -105,14 +103,7 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
         // but is now loaded in the Parser for the LexIM variant.
         continue;
       }
-      $prefix = '';
-      $entityInstance = $field['entity_instance'] ?? '';
-      if ($entityInstance === 'TargetContact' && !str_starts_with($name, 'target_contact.')) {
-        $prefix = 'target_contact.';
-      }
-      if ($entityInstance === 'SourceContact' && !str_starts_with($name, 'source_contact.')) {
-        $prefix = 'source_contact.';
-      }
+      $prefix = empty($field['entity_name']) ? '' : $field['entity_name'] . '.';
       $return[$prefix . $name] = $field['title'];
     }
     return $return;

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -27,6 +27,8 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
 
   private $externalIdentifiers = [];
 
+  protected $baseEntity = 'Contact';
+
   /**
    * Relationship labels.
    *

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -516,7 +516,7 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
       if (!isset($defaults["mapper[$i]"]) && $this->getSubmittedValue('skipColumnHeader')) {
         $defaults["mapper[$i]"] = $this->defaultFromHeader($columnHeader, $headerPatterns);
       }
-      else {
+      elseif (!isset($defaults["mapper[$i]"])) {
         $defaults["mapper[$i]"] = $this->isQuickFormMode ? NULL : [];
       }
     }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -214,16 +214,16 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   protected function getContactFields(string $contactType, ?string $prefix = ''): array {
     $contactFields = $this->getAllContactFields('');
     $dedupeFields = $this->getDedupeFields($contactType);
-
+    $matchText = ' ' . ts('(match to %1)', [1 => $prefix]);
     foreach ($dedupeFields as $fieldName => $dedupeField) {
       if (!isset($contactFields[$fieldName])) {
         continue;
       }
-      $contactFields[$fieldName]['title'] . ' ' . ts('(match to contact)');
+      $contactFields[$fieldName]['title'] .= $matchText;
       $contactFields[$fieldName]['match_rule'] = $this->getDefaultRuleForContactType($contactType);
     }
 
-    $contactFields['external_identifier']['title'] .= (' ' . ts('(match to contact)'));
+    $contactFields['external_identifier']['title'] .= $matchText;
     $contactFields['external_identifier']['match_rule'] = '*';
     if ($prefix) {
       $prefixedFields = [];
@@ -1161,7 +1161,15 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    */
   protected function validateParams(array $params): void {
     if (empty($params['id']) && empty($params[$this->baseEntity]['id'])) {
-      $this->validateRequiredFields($this->getRequiredFields(), $params[$this->baseEntity] ?? $params, $this->getImportEntities()[$this->baseEntity]['entity_field_prefix']);
+      $entityConfiguration = $this->getImportEntities()[$this->baseEntity];
+      $entity = '';
+      if (!empty($entityConfiguration['entity_field_prefix'])) {
+        // entity_field_prefix is our current way of showing if a table is prefixed
+        // it might change to only using entity_name based on thinking in
+        // https://github.com/civicrm/civicrm-core/pull/32317
+        $entity = $entityConfiguration['entity_name'];
+      }
+      $this->validateRequiredFields($this->getRequiredFields(), $params[$this->baseEntity] ?? $params, $entity);
     }
     $errors = [];
     foreach ($params as $key => $value) {
@@ -1198,6 +1206,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     }
     elseif (is_array($value)) {
       foreach ($value as $innerKey => $innerValue) {
+        if (!$prefixString && !isset($this->importableFieldsMetadata[$innerKey]) && isset($this->importableFieldsMetadata[$key . '.' . $innerKey])) {
+          $innerKey = $key . '.' . $innerKey;
+        }
         $result = $this->getInvalidValues($innerValue, $innerKey, $prefixString);
         if ($result === [TRUE]) {
           $metadata = $this->getFieldMetadata($key);
@@ -1348,12 +1359,12 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   public function getMappedRow(array $values): array {
     $params = [];
     foreach ($this->getFieldMappings() as $i => $mappedField) {
-      if ($mappedField['name'] === 'do_not_import') {
+      if (!isset($mappedField['name']) || $mappedField['name'] === 'do_not_import') {
         continue;
       }
       if ($mappedField['name']) {
         $fieldSpec = $this->getFieldMetadata($mappedField['name']);
-        $entity = $fieldSpec['entity_instance'] ?? $fieldSpec['entity'] ?? $fieldSpec['extends'] ?? NULL;
+        $entity = $fieldSpec['entity_instance'] ?? $fieldSpec['entity_name'] ?? $fieldSpec['entity'] ?? $fieldSpec['extends'] ?? NULL;
         if ($entity) {
           // Split values into arrays by entity.
           // Apiv4 name is currently only set for contact, & only in cases where it would
@@ -1378,15 +1389,17 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    * @return array
    */
   protected function getFieldMappings(): array {
-    $mappedFields = [];
-    $mapper = $this->getSubmittedValue('mapper');
-    foreach ($mapper as $i => $mapperRow) {
-      // Cast to an array as it will be a string for membership
-      // and any others we simplify away from using hierselect for a single option.
-      $mappedField = $this->getMappingFieldFromMapperInput((array) $mapperRow, 0, $i);
-      // Just for clarity since 0 is a pseudo-value
-      unset($mappedField['mapping_id']);
-      $mappedFields[] = $mappedField;
+    $mappedFields = $this->getUserJob()['metadata']['import_mappings'] ?? [];
+    if (empty($mappedFields)) {
+      $mapper = $this->getSubmittedValue('mapper');
+      foreach ($mapper as $i => $mapperRow) {
+        // Cast to an array as it will be a string for membership
+        // and any others we simplify away from using hierselect for a single option.
+        $mappedField = $this->getMappingFieldFromMapperInput((array) $mapperRow, 0, $i);
+        // Just for clarity since 0 is a pseudo-value
+        unset($mappedField['mapping_id']);
+        $mappedFields[] = $mappedField;
+      }
     }
     return $mappedFields;
   }

--- a/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
@@ -57,12 +57,12 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
   public function testImport(): void {
     $this->createCustomGroupWithFieldOfType(['extends' => 'Activity'], 'checkbox');
     $values = [
-      'details' => 'fascinating',
-      'activity_type_id' => 1,
-      'activity_date_time' => '2010-01-06',
-      'target_contact.id' => $this->individualCreate(),
-      'subject' => 'riveting stuff',
-      $this->getCustomFieldName('checkbox', 4) => 'L',
+      'Activity.details' => 'fascinating',
+      'Activity.activity_type_id' => 1,
+      'Activity.activity_date_time' => '2010-01-06',
+      'TargetContact.id' => $this->individualCreate(),
+      'Activity.subject' => 'riveting stuff',
+      'Activity.' . $this->getCustomFieldName('checkbox', 4) => 'L',
     ];
     $this->importValues($values);
     $this->callAPISuccessGetSingle('Activity', [$this->getCustomFieldName('checkbox') => 'L']);
@@ -118,7 +118,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
       return CRM_Import_Parser::VALID;
     }
     if ($expectedOutcome === 4) {
-      $this->assertEquals('ERROR', $row['_status']);
+      $this->assertEquals('ERROR', $row['_status'], $row['_status_message']);
       return $row['_status_message'];
     }
   }
@@ -135,12 +135,12 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
    */
   public function testActivityImportValidation(array $input, string $expectedError): void {
     // Supplement some values that can't be done in a data provider because of timing.
-    if (!isset($input['target_contact.id'])) {
-      $input['target_contact.id'] = $this->individualCreate();
+    if (!isset($input['TargetContact.id'])) {
+      $input['TargetContact.id'] = $this->individualCreate();
     }
     if (isset($input['replace_me_custom_field'])) {
       $this->createCustomGroupWithFieldOfType(['extends' => 'Activity'], 'radio');
-      $input[$this->getCustomFieldName('radio', 4)] = $input['replace_me_custom_field'];
+      $input['Activity.' . $this->getCustomFieldName('radio', 4)] = $input['replace_me_custom_field'];
       unset($input['replace_me_custom_field']);
     }
 
@@ -172,18 +172,18 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
       // explicit index number so easier to find when it fails
       0 => [
         'input' => [
-          'activity_type_id' => 1,
-          'activity_date_time' => $some_date,
-          'subject' => 'asubj',
+          'Activity.activity_type_id' => 1,
+          'Activity.activity_date_time' => $some_date,
+          'Activity.subject' => 'asubj',
         ],
         'expected_error' => '',
       ],
 
       1 => [
         'input' => [
-          'activity_type_id' => 1,
-          'activity_date_time' => $some_date,
-          'subject' => 'asubj',
+          'Activity.activity_type_id' => 1,
+          'Activity.activity_date_time' => $some_date,
+          'Activity.subject' => 'asubj',
           'replace_me_custom_field' => '3',
         ],
         'expected_error' => '',
@@ -191,70 +191,70 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
 
       2 => [
         'input' => [
-          'activity_type_id' => 'Meeting',
-          'activity_date_time' => $some_date,
-          'subject' => 'asubj',
+          'Activity.activity_type_id' => 'Meeting',
+          'Activity.activity_date_time' => $some_date,
+          'Activity.subject' => 'asubj',
         ],
         'expected_error' => '',
       ],
 
       3 => [
         'input' => [
-          'activity_type_id' => 1,
-          'activity_date_time' => $some_date,
-          'subject' => 'asubj',
+          'Activity.activity_type_id' => 1,
+          'Activity.activity_date_time' => $some_date,
+          'Activity.subject' => 'asubj',
         ],
         'expected_error' => '',
       ],
 
       5 => [
         'input' => [
-          'activity_type_id' => 1,
-          'activity_date_time' => $some_date,
-          'subject' => 'asubj',
+          'Activity.activity_type_id' => 1,
+          'Activity.activity_date_time' => $some_date,
+          'Activity.subject' => 'asubj',
         ],
         'expected_error' => '',
       ],
 
       6 => [
         'input' => [
-          'activity_type_id' => 'Meeting',
-          'activity_date_time' => $some_date,
-          'subject' => 'asubj',
+          'Activity.activity_type_id' => 'Meeting',
+          'Activity.activity_date_time' => $some_date,
+          'Activity.subject' => 'asubj',
         ],
         'expected_error' => '',
       ],
 
       7 => [
         'input' => [
-          'activity_date_time' => $some_date,
-          'subject' => 'asubj',
+          'Activity.activity_date_time' => $some_date,
+          'Activity.subject' => 'asubj',
         ],
         'expected_error' => 'Missing required fields',
       ],
 
       8 => [
         'input' => [
-          'activity_type_id' => '',
-          'activity_date_time' => $some_date,
-          'subject' => 'asubj',
+          'Activity.activity_type_id' => '',
+          'Activity.activity_date_time' => $some_date,
+          'Activity.subject' => 'asubj',
         ],
         'expected_error' => 'Missing required fields',
       ],
 
       9 => [
         'input' => [
-          'activity_type_id' => 'Meeting',
-          'subject' => 'asubj',
+          'Activity.activity_type_id' => 'Meeting',
+          'Activity.subject' => 'asubj',
         ],
         'expected_error' => 'Missing required fields',
       ],
 
       10 => [
         'input' => [
-          'activity_type_id' => 'Meeting',
-          'activity_date_time' => '',
-          'subject' => 'asubj',
+          'Activity.activity_type_id' => 'Meeting',
+          'Activity.activity_date_time' => '',
+          'Activity.subject' => 'asubj',
         ],
         'expected_error' => 'Missing required fields',
       ],
@@ -264,8 +264,8 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
       // is correct and it shouldn't be required in UI.
       11 => [
         'input' => [
-          'activity_type_id' => 'Meeting',
-          'activity_date_time' => $some_date,
+          'Activity.activity_type_id' => 'Meeting',
+          'Activity.activity_date_time' => $some_date,
         ],
         'expected_error' => '',
       ],
@@ -275,18 +275,18 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
       // is correct and it shouldn't be required in UI.
       12 => [
         'input' => [
-          'activity_type_id' => 'Meeting',
-          'activity_date_time' => $some_date,
-          'subject' => '',
+          'Activity.activity_type_id' => 'Meeting',
+          'Activity.activity_date_time' => $some_date,
+          'Activity.subject' => '',
         ],
         'expected_error' => '',
       ],
 
       'invalid_custom_field' => [
         'input' => [
-          'activity_type_id' => 'Meeting',
-          'activity_date_time' => $some_date,
-          'subject' => 'asubj',
+          'Activity.activity_type_id' => 'Meeting',
+          'Activity.activity_date_time' => $some_date,
+          'Activity.subject' => 'asubj',
           'replace_me_custom_field' => 'InvalidValue',
         ],
         'expected_error' => 'Invalid value for field(s) : Group with field radio: Integer radio',
@@ -294,9 +294,9 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
 
       'present_but_empty_custom_field' => [
         'input' => [
-          'activity_type_id' => 'Meeting',
-          'activity_date_time' => $some_date,
-          'subject' => 'asubj',
+          'Activity.activity_type_id' => 'Meeting',
+          'Activity.activity_date_time' => $some_date,
+          'Activity.subject' => 'asubj',
           'replace_me_custom_field' => '',
         ],
         'expected_error' => '',
@@ -304,10 +304,10 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
       // a way to find the contact id is required.
       'missing_target_contact_id' => [
         'input' => [
-          'target_contact.id' => '',
-          'activity_type_id' => 'Meeting',
-          'activity_date_time' => $some_date,
-          'subject' => 'asubj',
+          'TargetContact.id' => '',
+          'Activity.activity_type_id' => 'Meeting',
+          'Activity.activity_date_time' => $some_date,
+          'Activity.subject' => 'asubj',
         ],
         'expected_error' => 'No matching TargetContact found',
       ],
@@ -334,15 +334,15 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
   public function testImportCSV() :void {
     $this->individualCreate(['email' => 'mum@example.com']);
     $this->importCSV('activity.csv', [
-      ['name' => 'activity_date_time'],
-      ['name' => 'status_id'],
-      ['name' => 'target_contact.email_primary.email'],
-      ['name' => 'activity_type_id'],
-      ['name' => 'details'],
-      ['name' => 'duration'],
-      ['name' => 'priority_id'],
-      ['name' => 'location'],
-      ['name' => 'subject'],
+      ['name' => 'Activity.activity_date_time'],
+      ['name' => 'Activity.status_id'],
+      ['name' => 'TargetContact.email_primary.email'],
+      ['name' => 'Activity.activity_type_id'],
+      ['name' => 'Activity.details'],
+      ['name' => 'Activity.duration'],
+      ['name' => 'Activity.priority_id'],
+      ['name' => 'Activity.location'],
+      ['name' => 'Activity.subject'],
       ['name' => 'do_not_import'],
     ]);
     $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
@@ -360,18 +360,18 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
     $contactID1 = $this->individualCreate(['email' => 'mum@example.com', 'external_identifier' => 'individual1']);
     $contactID2 = $this->individualCreate(['email' => 'mum@example.com', 'external_identifier' => 'individual2'], 'individual_2');
     $this->importCSV('activityexternalidentifier.csv', [
-      ['name' => 'activity_date_time'],
-      ['name' => 'status_id'],
-      ['name' => 'target_contact.email_primary.email'],
-      ['name' => 'activity_type_id'],
-      ['name' => 'details'],
-      ['name' => 'duration'],
-      ['name' => 'priority_id'],
-      ['name' => 'location'],
-      ['name' => 'subject'],
+      ['name' => 'Activity.activity_date_time'],
+      ['name' => 'Activity.status_id'],
+      ['name' => 'TargetContact.email_primary.email'],
+      ['name' => 'Activity.activity_type_id'],
+      ['name' => 'Activity.details'],
+      ['name' => 'Activity.duration'],
+      ['name' => 'Activity.priority_id'],
+      ['name' => 'Activity.location'],
+      ['name' => 'Activity.subject'],
       ['name' => 'do_not_import'],
-      ['name' => 'source_contact.external_identifier'],
-      ['name' => 'target_contact.external_identifier'],
+      ['name' => 'SourceContact.external_identifier'],
+      ['name' => 'TargetContact.external_identifier'],
     ]);
     $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
     $row = $dataSource->getRow();

--- a/tests/phpunit/CRM/Upgrade/Incremental/php/SixTwoTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/php/SixTwoTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use Civi\Api4\Mapping;
+use Civi\Api4\MappingField;
+use Civi\Api4\UserJob;
+
+/**
+ * Class CRM_Upgrade_Incremental_php_SixOneTest
+ * @group headless
+ */
+class CRM_Upgrade_Incremental_php_SixTwoTest extends CiviUnitTestCase {
+
+  public function testUpdateUserJobs(): void {
+    $mapping = Mapping::create(FALSE)
+      ->setValues([
+        'name' => 'Activity import',
+        'mapping_type_id:name' => 'Import Activity',
+      ])->execute()->single();
+    $fields = [
+      'activity_date_time',
+      'do_not_import',
+      'target_contact.email_primary.email',
+      'source_contact.id',
+    ];
+    foreach ($fields as $index => $field) {
+      MappingField::create()
+        ->setValues(['name' => $field, 'mapping_id' => $mapping['id'], 'column_number' => $index])
+        ->execute();
+    }
+
+    $userJobParameters = [
+      'metadata' => [
+        'DataSource' => ['table_name' => 'abc', 'column_headers' => ['Date Time', 'Something', 'Email']],
+        'submitted_values' => [
+          'dataSource' => 'CRM_Import_DataSource_SQL',
+          'dateFormats' => CRM_Utils_Date::DATE_yyyy_mm_dd,
+        ],
+        'import_mappings' => [
+          ['name' => 'activity_date_time'],
+          ['name' => ''],
+          ['name' => 'target_contact.email_primary.email'],
+          ['name' => 'source_contact.id'],
+        ],
+      ],
+      'status_id:name' => 'draft',
+      'job_type' => 'activity_import',
+    ];
+    $userJobID = UserJob::create()->setValues($userJobParameters)->execute()->first()['id'];
+    CRM_Upgrade_Incremental_php_SixTwo::upgradeImportMappingFields(NULL, 'Activity');
+
+    $mappings = MappingField::get()
+      ->addWhere('mapping_id', '=', $mapping['id'])
+      ->execute();
+    $this->assertEquals('Activity.activity_date_time', $mappings[0]['name']);
+    $this->assertEquals('do_not_import', $mappings[1]['name']);
+    $this->assertEquals('TargetContact.email_primary.email', $mappings[2]['name']);
+    $this->assertEquals('SourceContact.id', $mappings[3]['name']);
+    $job = UserJob::get(FALSE)->addWhere('id', '=', $userJobID)->execute()->single();
+    $this->assertEquals([
+      ['name' => 'Activity.activity_date_time'],
+      ['name' => ''],
+      ['name' => 'TargetContact.email_primary.email'],
+      ['name' => 'SourceContact.id'],
+    ], $job['metadata']['import_mappings']);
+
+    $templateJob = UserJob::get(FALSE)
+      ->addWhere('name', '=', 'import_Activity import')
+      ->addWhere('is_template', '=', TRUE)->execute()->single();
+    $this->assertEquals([
+      ['name' => 'Activity.activity_date_time'],
+      ['name' => ''],
+      ['name' => 'TargetContact.email_primary.email'],
+      ['name' => 'SourceContact.id'],
+    ], $templateJob['metadata']['import_mappings']);
+
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

We've had a bit of back & forth about prefixing on Import Mappings - from the base entity having a no prefix to it having a lower case prefix & back to it having no prefix & slightly path with the other related entities.

However @colemanw has put a stake in the ground for consolidating on all entities having a prefix and using CamelCase for entity names - so I'm hoping to be sure to consolidate on that prefixing in the 6.2 release & this coverts the activity import & where possible uses the code @colemanw was doing

Before
----------------------------------------
fields are 
activity_type_id 
source_contact.id
target_contact.id

After
----------------------------------------
fields are 
Activity.activity_type_id 
SourceContact.id
TargetContact.id

- in addition AssigneeContact is added and the upgrade script ensures a template UserJob exists - if we get far enough we can drop the use of MapField before the rc is cut, meaning the standardisation part will be done

Technical Details
----------------------------------------

Comments
----------------------------------------
