### PR TITLE
searchkit display run - default col type 

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -200,7 +200,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    * @return array{val: mixed, links: array, edit: array, label: string, title: string, image: array, cssClass: string}
    */
   private function formatColumn(array $column, array $data, array $settings) {
-    $column += ['rewrite' => NULL, 'label' => NULL, 'key' => ''];
+    $column += ['rewrite' => NULL, 'label' => NULL, 'key' => '', 'type' => NULL];
     $out = [];
     switch ($column['type']) {
       case 'field':


### PR DESCRIPTION
Overview
----------------------------------------
ChartKit displays don't set any "type" key for columns, as they don't actually use the column value (it uses the `data` for each row in the response rather than the column values).

But currently you get a lot of Undefined array key warnings with the switch statement the line below.

This change prevents those errors (and more explicitly skips any column type specific formatting if no column type is set).

@colemanw what do you think? 