### PR TITLE
Creating a repeating activity fails with 'Mandatory values missing from API4' message - ActionSchedule::save:start_action_condition

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/ActionScheduleSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ActionScheduleSpecProvider.php
@@ -30,7 +30,7 @@ class ActionScheduleSpecProvider extends \Civi\Core\Service\AutoService implemen
       // Repeat events do not require mapping_id or start_action_unit (or seemingly start_action_condition)- although
       // we don't have that level of nuance available so we make them optional for all events.
       $spec->getFieldByName('mapping_id')->setRequiredIf('empty($values.used_for)');
-      $spec->getFieldByName('start_action_condition')->setRequiredIf('empty($values.absolute_date) && (empty($values.used_for) || $values.used_for !== "civicrm_event")');
+      $spec->getFieldByName('start_action_condition')->setRequiredIf('empty($values.absolute_date) && empty($values.start_action_date)');
       $spec->getFieldByName('entity_value')->setRequired(TRUE);
       $spec->getFieldByName('start_action_offset')->setRequiredIf('empty($values.absolute_date)');
       $spec->getFieldByName('start_action_date')->setRequiredIf('empty($values.absolute_date)');


### PR DESCRIPTION
Overview
----------------------------------------
Ref - https://lab.civicrm.org/dev/core/-/issues/5811

Before
----------------------------------------
Steps to reproduce:

1. Go to any contact
2. Add basic details to a meeting activity (using dummy data contacts) 

   Scroll down and set the Repeat Activity to a once a year for three occurances:

3. Press **Save**- the 3 occurances are displayed

4. Press **Continue** - the screen darkend and will remain until dismissed

5. On dimissal we get confirmation that the activity has been created, but an error relating to the API4 is displayed

6. The logs display two warnings:

   _Warning_: Trying to access array offset on value of type null in _CRM_Core_Page_RecurringEntityPreview-\>run()_ (line _28_ of _/var/www/html/vendor/civicrm/civicrm-core/CRM/Core/Page/RecurringEntityPreview.php_)

   _Warning_: Undefined array key "intervalDateColumns" in _CRM_Core_Page_RecurringEntityPreview-\>run()_ (line _28_ of _/var/www/html/vendor/civicrm/civicrm-core/CRM/Core/Page/RecurringEntityPreview.php_)

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
This is not a regression but fixes an existing issue. Earlier https://github.com/civicrm/civicrm-core/pull/32255 fixes similar validation error for two other ActionSchedule parameters on New Activity form submission. This patch fixes issue for start_action_condition 

Comments
----------------------------------------
ping @colemanw @eileenmcnaughton 