### PR TITLE
SearchKit - Fix php warning when an entity has no fields

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -167,6 +167,9 @@ class Admin {
           }
           $entity['fields'][] = $field;
         }
+        if (empty($entity['fields'])) {
+          continue;
+        }
         $entity['default_columns'] = self::getDefaultColumns($entity, $getFields);
         $params = $entity['get'][0];
         // Entity must support at least these params or it is too weird for search kit


### PR DESCRIPTION
Overview
----------------------------------------
Fixes php warning when iframe extension is enabled.


Technical Details
----------------------------------------
Apparently the iframe entity has no fields.
That's weird... but at least this fixes the warning.