### PR TITLE
RiverLea regression: FormBuilder drag/drop grab region had shrunk, this returns it to original size.

### DIFF
--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -268,7 +268,6 @@
 #afGuiEditor .af-gui-node-title {
   position: absolute;
   top: 1px;
-  width: calc(100% - var(--crm-r4));
 }
 #afGuiEditor-canvas:not(.af-gui-menu-open) .af-gui-bar,
 #afGuiEditor-canvas:not(.af-gui-menu-open) .af-gui-container-title span:empty {


### PR DESCRIPTION
As flagged by @JGaunt here: https://lab.civicrm.org/extensions/riverlea/-/issues/126.

Overview
----------------------------------------
The whole titlebar in FormBuilder fileds and regions should be dragable, in RL this got shrunk to the left-hand-side because the title region had taken up the full width. This restore the title width to only the text, and so makes the entire title region dragable.

Before
----------------------------------------
Only the small dotted region on the left can be grabbed:
<img width="267" alt="image" src="https://github.com/user-attachments/assets/72d133eb-ad59-4d05-8e7d-ad0997ef51c7" />

After
----------------------------------------
All of the titlebar can be grabbed.