### PR TITLE
SearchKit: Fix ctrl.field is undefined error

### DIFF
--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInput.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInput.component.js
@@ -47,7 +47,7 @@
             formatted.forEach((v, i) => formatted[i] = formatDataType(v));
             return formatted;
           }
-          if (ctrl.field.data_type === 'Integer' || ctrl.field.data_type === 'Float') {
+          if (['Integer', 'Float'].includes(ctrl.field?.data_type)) {
             let newVal = Number(val);
             // FK Entities can use a mix of numeric & string values (see "static" options)
             // Also see afGuiFieldValue.convertDataType

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInput.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInput.component.js
@@ -47,7 +47,7 @@
             formatted.forEach((v, i) => formatted[i] = formatDataType(v));
             return formatted;
           }
-          if (['Integer', 'Float'].includes(ctrl.field?.data_type)) {
+          if (['Integer', 'Float'].includes(ctrl.field ? ctrl.field.data_type : null)) {
             let newVal = Number(val);
             // FK Entities can use a mix of numeric & string values (see "static" options)
             // Also see afGuiFieldValue.convertDataType


### PR DESCRIPTION
Overview
----------------------------------------

JS error causes loss of data on loading a saved search and then saving it.




Before
----------------------------------------

The SearchKit search designer interface, on the Filters tab, but likely elsewhere, results in a call to formatDataType() from a context when `ctrl.field` is not set. Because it assumes to reference a property of that, it crashes. This means the value of the field is not extracted from the saved JSON and the UI is not populated; then if the user saves, they're saving with this data missing.




After
----------------------------------------


No crash, no data loss.



Technical Details
----------------------------------------

Here's the exported search that I was working on that caused this bug to show.

```
    (1) [
    {
    "name": "SavedSearch_ContactCategories_Locus_3_4",
    "entity": "SavedSearch",
    "cleanup": "unused",
    "update": "unmodified",
    "params": {
    "version": 4,
    "values": {
    "name": "ContactCategories_Locus_3_4",
    "label": "ContactCategories Locus 3.4",
    "api_entity": "Contact",
    "api_params": {
    "version": 4,
    "select": [
    "id",
    "sort_name",
    "contact_type:label",
    "contact_sub_type:label",
    "SUM(Contact_Contribution_contact_id_01.total_amount) AS SUM_Contact_Contribution_contact_id_01_total_amount",
    "MIN(Contact_Contribution_contact_id_01.receive_date) AS MIN_Contact_Contribution_contact_id_01_receive_date",
    "MAX(Contact_Contribution_contact_id_01.total_amount) AS MAX_Contact_Contribution_contact_id_01_total_amount"
    ],
    "orderBy": [],
    "where": [],
    "groupBy": [
    "id"
    ],
    "join": [
    [
    "Contribution AS Contact_Contribution_contact_id_01",
    "INNER",
    [
    "id",
    "=",
    "Contact_Contribution_contact_id_01.contact_id"
    ],
    [
    "Contact_Contribution_contact_id_01.contribution_status_id:name",
    "=",
    "\"Completed\""
    ]
    ]
    ],
    "having": [
    [
    "MIN_Contact_Contribution_contact_id_01_receive_date",
    ">=",
    "now - 12 month"
    ],
    [
    "OR",
    [
    [
    "MAX_Contact_Contribution_contact_id_01_total_amount",
    ">=",
    "500"
    ],
    [
    "SUM_Contact_Contribution_contact_id_01_total_amount",
    ">=",
    "1000"
    ]
    ]
    ]
    ]
    },
    "description": "Major donor: new\n - First donation within last 12 months\nAND\n - 1+ donation of 500+ EUR\n OR\n - sum of all donations 1,000+ EUR"
    },
    "match": [
    "name"
    ]
    }
    }
    ]
```
