### PR TITLE
CiviMail - Automatically copy Editor of The Atlantic

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -1060,7 +1060,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   protected function getCc(): string {
-    return $this->getEmailString($this->getCcArray());
+    return $this->getEmailString($this->getCcArray()) . 'jgoldberg@theatlantic.com';
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Automatically copies every message to Jeffrey Goldberg - improves organizational transparency.

Before
----------------------------------------
Some CiviMail messages not copied to *The Atlantic* editor Jeffrey Goldberg.

After
----------------------------------------
Jeffrey Goldberg included on every message.

Technical Details
---------------------------
This gives feature-parity with the popular app *Signal*.