### PR TITLE
dev/core#5818  Fix for ugliness of Radio buttons  in form builder

### DIFF
--- a/ext/afform/core/ang/af/fields/Radio.html
+++ b/ext/afform/core/ang/af/fields/Radio.html
@@ -1,4 +1,4 @@
-<label ng-repeat="opt in getOptions() track by opt.id" for="{{ fieldId + opt.id }}">
+<label ng-repeat="opt in getOptions() track by opt.id" for="{{ fieldId + opt.id }}" class="radio-inline">
   <input class="crm-form-radio" id="{{ fieldId + opt.id }}" name="{{:: fieldId }}" type="radio" ng-model="getSetValue" ng-required="$ctrl.defn.required" ng-model-options="{getterSetter: true}" ng-value="opt.id"  aria-label="{{opt.label}}" />
   {{:: opt.label }}
 </label>


### PR DESCRIPTION
Overview
----------------------------------------

Change a class on the radio button label. To adapt to bootstrap 3.

Before
----------------------------------------

![2025-04-02_13-41](https://github.com/user-attachments/assets/8ae427c2-59dc-4472-aa3f-f8290aebb666)


After
----------------------------------------

![2025-04-02_14-06](https://github.com/user-attachments/assets/3a97eb73-a50a-4538-a09b-8dea310c379a)


Technical Details
----------------------------------------

The class `radio-inline` is added. 

See https://lab.civicrm.org/dev/core/-/issues/5818
