### PR TITLE
avoid errors with canary table when using READ-COMMITTED

### DIFF
--- a/Civi/Core/InstallationCanary.php
+++ b/Civi/Core/InstallationCanary.php
@@ -37,7 +37,7 @@ class InstallationCanary {
       throw new \CRM_Core_Exception("Found installation canary. This suggests that something went wrong with tracking installation process. Please post to forum or JIRA.");
     }
     \Civi::log()->info('Creating canary table');
-    \CRM_Core_DAO::executeQuery('CREATE TABLE civicrm_install_canary (id int(10) unsigned NOT NULL) ENGINE=InnoDB');
+    \CRM_Core_DAO::executeQuery('CREATE TABLE civicrm_install_canary (id int(10) unsigned NOT NULL, PRIMARY KEY (id)) ENGINE=InnoDB');
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
See: https://lab.civicrm.org/dev/core/-/issues/5312

Ensure we can set the database to use "READ-COMMITTED" and not generate an error with the `civicrm_install_canary`.


Before
----------------------------------------
When using READ-COMMITTED, every table must have a primary key defined. The `civicrm_install_canary` does not define a primary key (because it is not really used as a table, but instead an indication that the install is happening). This causes an error if you uare using READ-COMMITTED.

After
----------------------------------------

By simply adding a key, we avoid the error and presumably have no side effects.

