### PR TITLE
Riverlea theme: fix offscreen right column in contact summary

### DIFF
--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -199,6 +199,7 @@ div.crm-inline-edit-form div.crm-clear {
 .crm-container div.contactCardLeft,
 .crm-container div.contactCardRight {
   width: 100%;
+  overflow: auto;
 }
 .crm-container div.contact_panel table {
   margin-bottom: 0;
@@ -244,6 +245,11 @@ div.crm-inline-edit-form div.crm-clear {
   padding: var(--crm-m);
   min-width: var(--crm-input-label-width);
   text-align: left;
+}
+/* Prevent wide content over-spilling page */
+.crm-container div.crm-summary-row div.crm-label {
+  max-width: calc(100% - var(--crm-input-label-width));
+  overflow: auto;
 }
 .crm-container div.crm-summary-row div.crm-content {
   padding: var(--crm-m);

--- a/ext/riverlea/streams/thames/css/civicrm.css
+++ b/ext/riverlea/streams/thames/css/civicrm.css
@@ -263,6 +263,25 @@ div.crm-summary-contactname-block+.crm-actions-ribbon {
 /* .crm-container div.contact_panel { display: grid; grid-template-columns: subgrid; grid-column: 1 / 3; } */
 /* .contact_details { grid-template-columns: subgrid; grid-column: 1/ 3; } */
 
+
+/* Override contactSummary.css */
+/*#contact-summary div.contact_panel {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	column-gap: var(--crm-dash-panel-padding);
+}
+*/
+
+/* The following 2 rules are to help things work when there's long data, e.g. URL in contact source. */
+.crm-container div.contactCardLeft, .crm-container div.contactCardRight {
+  overflow: auto;
+}
+.crm-container div.crm-summary-row div.crm-label + div {
+  max-width: calc(100% - var(--crm-input-label-width));
+  overflow: auto;
+}
+
+
 /* Decorations to indicate an editable chunk. */
 #contact-summary .crm-edit-help {
   color: transparent;

--- a/ext/riverlea/streams/thames/css/civicrm.css
+++ b/ext/riverlea/streams/thames/css/civicrm.css
@@ -263,25 +263,6 @@ div.crm-summary-contactname-block+.crm-actions-ribbon {
 /* .crm-container div.contact_panel { display: grid; grid-template-columns: subgrid; grid-column: 1 / 3; } */
 /* .contact_details { grid-template-columns: subgrid; grid-column: 1/ 3; } */
 
-
-/* Override contactSummary.css */
-/*#contact-summary div.contact_panel {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	column-gap: var(--crm-dash-panel-padding);
-}
-*/
-
-/* The following 2 rules are to help things work when there's long data, e.g. URL in contact source. */
-.crm-container div.contactCardLeft, .crm-container div.contactCardRight {
-  overflow: auto;
-}
-.crm-container div.crm-summary-row div.crm-label + div {
-  max-width: calc(100% - var(--crm-input-label-width));
-  overflow: auto;
-}
-
-
 /* Decorations to indicate an editable chunk. */
 #contact-summary .crm-edit-help {
   color: transparent;


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/ef034826-7934-4ae0-bdb3-466188f56a3b)


After:

![image](https://github.com/user-attachments/assets/5ccf8067-1398-44a0-9fe2-be87053e8744)


@vingle This fix is probably useful at the top level, e.g. 

![image](https://github.com/user-attachments/assets/f894596d-f76a-485e-8913-f38da9b54a95)

<del>Shall I move the code into the main bit?</del>

So this is not a thames issue, and I've moved the changes into the main project.
