### PR TITLE
RiverLea, Fix SearchKit Admin, Trash Icon regression

### DIFF
--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
@@ -131,6 +131,7 @@
   border-top: var(--crm-c-divider);
   margin-block: var(--crm-s);
   border-radius: var(--crm-roundness);
+  position: relative;
 }
 .crm-search fieldset fieldset {
   padding-top: 0;


### PR DESCRIPTION
Overview
----------------------------------------
Ref: https://civicrm.stackexchange.com/questions/49327/how-do-i-delete-these-searchkit-search-options

The trash icon container fieldset was lacking `position: relative`, meaning the icons jumped to the wrong place. This positions them correctly.

Before
----------------------------------------
Trash icons appear top right; the wrong place.

<img width="1082" alt="image" src="https://github.com/user-attachments/assets/f287bbbc-e8bb-4716-9021-3819a49dcdeb" />

After
----------------------------------------
They appear in the right place.

<img width="1084" alt="image" src="https://github.com/user-attachments/assets/93f6a264-8532-4c8f-aea7-6c08459c2d53" />

Technical Details
----------------------------------------
This restores a CSS value ('position: relative;') that's present in default / Greenwich, so isn't something new. ie it's already proven and tested in core.