### PR TITLE
DAO - Remove unused debugging function

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2659,23 +2659,6 @@ SELECT contact_id
   }
 
   /**
-   * @param null $message
-   * @param bool $printDAO
-   */
-  public static function debugPrint($message = NULL, $printDAO = TRUE) {
-    CRM_Utils_System::xMemory("{$message}: ");
-
-    if ($printDAO) {
-      global $_DB_DATAOBJECT;
-      $q = [];
-      foreach (array_keys($_DB_DATAOBJECT['RESULTS']) as $id) {
-        $q[] = $_DB_DATAOBJECT['RESULTS'][$id]->query;
-      }
-      CRM_Core_Error::debug('_DB_DATAOBJECT', $q);
-    }
-  }
-
-  /**
    * Build a list of triggers via hook and add them to (err, reconcile them
    * with) the database.
    *


### PR DESCRIPTION
Overview
----------------------------------------
Removes unused function that cannot possibly be for runtime use.

Technical Details
----------------------------------------
Debuggers are a lot better than they were in 2005. I think we can live without this function.