### PR TITLE
dev/core#5824 Misleading System Status message when CIVICRM_MAIL_LOG_AND_SEND is set

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -150,7 +150,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
 
     $mailingInfo = Civi::settings()->get('mailing_backend');
     if (($mailingInfo['outBound_option'] == CRM_Mailing_Config::OUTBOUND_OPTION_REDIRECT_TO_DB
-      || (defined('CIVICRM_MAIL_LOG') && CIVICRM_MAIL_LOG)
+      || (defined('CIVICRM_MAIL_LOG') && CIVICRM_MAIL_LOG && !defined('CIVICRM_MAIL_LOG_AND_SEND'))
       || $mailingInfo['outBound_option'] == CRM_Mailing_Config::OUTBOUND_OPTION_DISABLED
       || $mailingInfo['outBound_option'] == CRM_Mailing_Config::OUTBOUND_OPTION_MOCK)
     ) {


### PR DESCRIPTION
Overview
----------------------------------------
According to the documentation here: https://docs.civicrm.org/dev/en/latest/tools/debugging/#changing-file-based-settings to turn on CIVICRM_MAIL_LOG_AND_SEND you must also turn on CIVICRM_MAIL_LOG.

Turning on CIVICRM_MAIL_LOG throws a system status warning saying outbound email is off but if you have CIVICRM_MAIL_LOG_AND_SEND on too its not.

More details here: https://lab.civicrm.org/dev/core/-/issues/5824

Before
----------------------------------------
Turning on CIVICRM_MAIL_LOG_AND_SEND and CIVICRM_MAIL_LOG throws a system status warning that outbound email is off even though it is on.

After
----------------------------------------
no system status warning in this scenario.

Comments
----------------------------------------
There are perhaps more thorough ways this could be approached.
