### PR TITLE
EFv2 - Implement $entity->getReferenceCounts

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2779,10 +2779,12 @@ SELECT contact_id
         $counts[] = $count;
       }
     }
-
+    // TODO: Switch components to use same hook as everyone else
     foreach (CRM_Core_Component::getEnabledComponents() as $component) {
       $counts = array_merge($counts, $component->getReferenceCounts($this));
     }
+    // TODO: Fix hook to work with non-dao entities
+    // (probably need to add 2 params for $entityName and $record and deprecate the $dao param)
     CRM_Utils_Hook::referenceCounts($this, $counts);
 
     return $counts;

--- a/CRM/Core/Reference/Dynamic.php
+++ b/CRM/Core/Reference/Dynamic.php
@@ -36,6 +36,7 @@ class CRM_Core_Reference_Dynamic extends CRM_Core_Reference_Basic {
     foreach ($targetTables as $value => $name) {
       // Old-style: Flat arrays of ['table_name' => 'Entity Label']
       // will be formatted like ['table_name' => 'table_name'] in 'validate' mode.
+      // Note: Adding strtolower ensures both values are also lowercase && not something like 'Contact' => 'Contact'
       if (strtolower($value) === $name) {
         $targetEntities[$value] = CRM_Core_DAO_AllCoreTables::getEntityNameForTable($value);
       }

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -12,7 +12,6 @@
 
 namespace Civi\Api4\Utils;
 
-use Civi\API\Exception\NotImplementedException;
 use Civi\API\Exception\UnauthorizedException;
 use Civi\API\Request;
 use Civi\Api4\Generic\AbstractAction;
@@ -329,17 +328,11 @@ class CoreUtil {
    * @param string $entityName
    * @param int $entityId
    * @return array{name: string, type: string, count: int, table: string|null, key: string|null}[]
-   * @throws NotImplementedException
    */
   public static function getRefCount(string $entityName, $entityId): array {
-    $daoName = self::getInfoItem($entityName, 'dao');
-    if (!$daoName) {
-      throw new NotImplementedException("Cannot getRefCount for $entityName - dao not found.");
-    }
-    /** @var \CRM_Core_DAO $dao */
-    $dao = new $daoName();
-    $dao->id = $entityId;
-    return $dao->getReferenceCounts();
+    $entity = \Civi::entity($entityName);
+    $idField = self::getIdFieldName($entityName);
+    return $entity->getReferenceCounts([$idField => $entityId]);
   }
 
   /**
@@ -348,11 +341,10 @@ class CoreUtil {
    * @param string $entityName
    * @param $entityId
    * @return int
-   * @throws NotImplementedException
    */
   public static function getRefCountTotal(string $entityName, $entityId): int {
     $total = 0;
-    foreach ((array) self::getRefCount($entityName, $entityId) as $ref) {
+    foreach (self::getRefCount($entityName, $entityId) as $ref) {
       $total += $ref['count'] ?? 0;
     }
     return $total;

--- a/Civi/Schema/EntityProvider.php
+++ b/Civi/Schema/EntityProvider.php
@@ -90,6 +90,10 @@ final class EntityProvider {
     return $this->getStorageProvider()->deleteRecords($records);
   }
 
+  public function getReferenceCounts (array $record): array {
+    return $this->getStorageProvider()->getReferenceCounts($record);
+  }
+
   private function getMetaProvider(): EntityMetadataInterface {
     if (!isset($this->meta)) {
       $entity = EntityRepository::getEntity($this->entityName);

--- a/Civi/Schema/EntityStorageInterface.php
+++ b/Civi/Schema/EntityStorageInterface.php
@@ -17,4 +17,8 @@ interface EntityStorageInterface {
 
   public function deleteRecords(array $records): array;
 
+  public function findReferences(array $record): array;
+
+  public function getReferenceCounts(array $record): array;
+
 }

--- a/Civi/Schema/SqlEntityStorage.php
+++ b/Civi/Schema/SqlEntityStorage.php
@@ -30,4 +30,107 @@ class SqlEntityStorage implements EntityStorageInterface {
     // TODO: Implement deleteRecords() method.
   }
 
+  public function findReferences(array $record): array {
+    // TODO
+  }
+
+  public function getReferenceCounts(array $record): array {
+    $counts = [];
+    $links = $this->getReferenceLinkSql($record);
+    foreach ($links as $link) {
+      $select = $link['select'];
+      $select->select('COUNT(*) AS count');
+      $count = \CRM_Core_DAO::singleValueQuery($select->toSQL());
+      if ($count) {
+        $counts[] = [
+          'name' => $link['entity'],
+          'field' => $link['field'],
+          'count' => $count,
+          'table' => $link['table'],
+          'column' => $link['column'],
+          'key' => $link['key'],
+        ];
+      }
+    }
+    $daoClass = \Civi::entity($this->entityName)->getMeta('class');
+    if ($daoClass) {
+      $dao = new $daoClass();
+      $dao->copyValues($record);
+      // TODO: Switch components to use same hook as everyone else
+      foreach (\CRM_Core_Component::getEnabledComponents() as $component) {
+        $counts = array_merge($counts, $component->getReferenceCounts($dao));
+      }
+      // TODO: Fix hook to work with non-dao entities
+      // (probably need to add 2 params for $entityName and $record and deprecate the $dao param)
+      \CRM_Utils_Hook::referenceCounts($dao, $counts);
+    }
+    return $counts;
+  }
+
+  private function getReferenceLinkSql(array $record): array {
+    $links = [];
+    $sep = \CRM_Core_DAO::VALUE_SEPARATOR;
+    foreach ($this->getLinksToTable() as $link) {
+      if (!isset($record[$link['key']])) {
+        continue;
+      }
+      $select = \CRM_Utils_SQL_Select::from($link['table']);
+      $args = ['!col' => $link['column'], '!op' => '=', '@val' => $record[$link['key']]];
+      if (!empty($link['serialize'])) {
+        $args['!op'] = 'LIKE';
+        $args['@val'] = "%$sep{$record[$link['key']]}$sep%";
+      }
+      $select->where('`!col` !op @val', $args);
+      foreach ($link['condition'] ?? [] as $key => $value) {
+        $select->where("`!key` = @val", ['!key' => $key, '@val' => $value]);
+      }
+      $link['select'] = $select;
+      $links[] = $link;
+    }
+    return $links;
+  }
+
+  public function getLinksToTable(): array {
+    $links = [];
+    $thisTableName = \Civi::entity($this->entityName)->getMeta('table');
+    foreach (EntityRepository::getEntities() as $entityName => $entityInfo) {
+      $entity = \Civi::entity($entityName);
+      $entityFields = array_merge($entity->getFields(), $entity->getCustomFields(['is_active' => NULL]));
+      foreach ($entityFields as $fieldName => $fieldInfo) {
+        if (($fieldInfo['entity_reference']['entity'] ?? NULL) === $this->entityName) {
+          $links[] = [
+            'entity' => $entityName,
+            'field' => $fieldName,
+            'table' => $fieldInfo['table_name'] ?? $entity->getMeta('table'),
+            'column' => $fieldInfo['column_name'] ?? $fieldName,
+            'key' => $fieldInfo['entity_reference']['key'] ?? $entity->getMeta('primary_key'),
+            'serialize' => $fieldInfo['serialize'] ?? FALSE,
+          ];
+        }
+        elseif (!empty($fieldInfo['entity_reference']['dynamic_entity'])) {
+          foreach ($entity->getOptions($fieldInfo['entity_reference']['dynamic_entity']) ?? [] as $option) {
+            if (
+              // Old-style: Flat arrays of ['table_name' => 'Entity Label'] will be formatted with identical id & name
+              // Note: Adding strtolower ensures both values are also lowercase && not something like 'Contact' => 'Contact'
+              (strtolower($option['id']) === $option['name'] && $option['id'] === $thisTableName) ||
+              // New-style: ['id' => 'value', 'name' => 'EntityName', 'label' => 'Entity Label'][]
+              (strtolower($option['id']) !== $option['name'] && $option['name'] === $this->entityName)
+            ) {
+              $links[] = [
+                'entity' => $entityName,
+                'field' => $fieldName,
+                'table' => $fieldInfo['table_name'] ?? $entity->getMeta('table'),
+                'column' => $fieldInfo['column_name'] ?? $fieldName,
+                'key' => $fieldInfo['entity_reference']['key'] ?? $entity->getMeta('primary_key'),
+                'serialize' => $fieldInfo['serialize'] ?? FALSE,
+                'condition' => [$fieldInfo['entity_reference']['dynamic_entity'] => $option['id']],
+              ];
+            }
+          }
+        }
+      }
+    }
+    return $links;
+  }
+
 }


### PR DESCRIPTION
Overview
---------------------------------------
Adds more functionality to Entity Framework v2.


Technical Details
----------------------------------------
This function mirrors the DAO function of the same name, but as part of EFv2 it is unconstrained by DAOs,
and can work for any entity in the system.