### PR TITLE
[REF] CiviCase - Move component quasi-hook to real hook

### DIFF
--- a/CRM/Case/Info.php
+++ b/CRM/Case/Info.php
@@ -70,9 +70,9 @@ class CRM_Case_Info extends CRM_Core_Component_Info {
   }
 
   /**
-   * @inheritDoc
+   * Called via hook to include references from case xml
    */
-  public function getReferenceCounts($dao) {
+  public static function getReferenceCounts($dao): array {
     $result = [];
     if ($dao instanceof CRM_Core_DAO_OptionValue) {
       /** @var CRM_Core_DAO_OptionValue $dao */

--- a/CRM/Core/Component/Info.php
+++ b/CRM/Core/Component/Info.php
@@ -147,21 +147,6 @@ abstract class CRM_Core_Component_Info {
   abstract public function getPermissions();
 
   /**
-   * Determine how many other records refer to a given record.
-   *
-   * @param CRM_Core_DAO $dao
-   *   The item for which we want a reference count.
-   * @return array
-   *   each item in the array is an array with keys:
-   *   - name: string, eg "sql:civicrm_email:contact_id"
-   *   - type: string, eg "sql"
-   *   - count: int, eg "5" if there are 5 email addresses that refer to $dao
-   */
-  public function getReferenceCounts($dao) {
-    return [];
-  }
-
-  /**
    * Provides information about user dashboard element.
    * offered by this component.
    *

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2779,10 +2779,6 @@ SELECT contact_id
         $counts[] = $count;
       }
     }
-    // TODO: Switch components to use same hook as everyone else
-    foreach (CRM_Core_Component::getEnabledComponents() as $component) {
-      $counts = array_merge($counts, $component->getReferenceCounts($this));
-    }
     // TODO: Fix hook to work with non-dao entities
     // (probably need to add 2 params for $entityName and $record and deprecate the $dao param)
     CRM_Utils_Hook::referenceCounts($this, $counts);

--- a/Civi/Schema/SqlEntityStorage.php
+++ b/Civi/Schema/SqlEntityStorage.php
@@ -56,10 +56,6 @@ class SqlEntityStorage implements EntityStorageInterface {
     if ($daoClass) {
       $dao = new $daoClass();
       $dao->copyValues($record);
-      // TODO: Switch components to use same hook as everyone else
-      foreach (\CRM_Core_Component::getEnabledComponents() as $component) {
-        $counts = array_merge($counts, $component->getReferenceCounts($dao));
-      }
       // TODO: Fix hook to work with non-dao entities
       // (probably need to add 2 params for $entityName and $record and deprecate the $dao param)
       \CRM_Utils_Hook::referenceCounts($dao, $counts);

--- a/ext/civi_case/civi_case.php
+++ b/ext/civi_case/civi_case.php
@@ -38,3 +38,10 @@ function civi_case_civicrm_selectWhereClause($entityName, &$clauses, $userId, $c
     $clauses['id'][] = $orGroup;
   }
 }
+
+/**
+ * @implements CRM_Utils_Hook::referenceCounts
+ */
+function civi_case_civicrm_referenceCounts($dao, &$refCounts) {
+  $refCounts = array_merge($refCounts, CRM_Case_Info::getReferenceCounts($dao));
+}


### PR DESCRIPTION
Overview
----------------------------------------
Refactor for improved code organization: now there's just one hook for referenceCounts.

Before
----------------------------------------
Extra quasi-hook called on components but only used for CiviCase.

After
----------------------------------------
Now implemented as a real hook in CiviCase extension.

