### PR TITLE
Make it easier to extract totals from LineItems client-side

### DIFF
--- a/templates/CRM/Price/Page/LineItem.tpl
+++ b/templates/CRM/Price/Page/LineItem.tpl
@@ -84,7 +84,7 @@
   {if $getTaxDetails && $totalTaxAmount}
     <div class="crm-grid-row">
       <div class="crm-grid-cell bold right text-right">{ts 1=$taxTerm}Total %1{/ts}</div>
-      <div class="crm-grid-cell right text-right">{$totalTaxAmount|crmMoney:$currency}</div>
+      <div class="crm-grid-cell right text-right" id="totalTaxAmount" data-totalTaxAmount="{$totalTaxAmount}">{$totalTaxAmount|crmMoney:$currency}</div>
     </div>
   {/if}
   {if $context EQ "Event"}
@@ -92,13 +92,13 @@
       {assign var=eventSubTotal value=$totalAmount-$totalTaxAmount}
       <div class="crm-grid-row">
         <div class="crm-grid-cell bold right text-right">{ts}Subtotal{/ts}</div>
-        <div class="crm-grid-cell right text-right">{$eventSubTotal|crmMoney:$currency}</div>
+        <div class="crm-grid-cell right text-right" id="eventSubTotal" data-eventSubTotal="{$eventSubTotal}">{$eventSubTotal|crmMoney:$currency}</div>
       </div>
     {/if}
   {/if}
   <div class="crm-grid-row">
     <div class="crm-grid-cell bold right text-right">{ts}Total{/ts}</div>
-    <div class="crm-grid-cell right text-right">{$totalAmount|crmMoney:$currency}</div>
+    <div class="crm-grid-cell right text-right" id="totalAmount" data-totalAmount="{$totalAmount}">{$totalAmount|crmMoney:$currency}</div>
   </div>
   {* set by CRM/Contribute/Page/PaymentInfo.tpl *}
   <div class="hiddenElement">
@@ -125,7 +125,7 @@
           {assign var="totalcount" value=$totalcount+$lineItemCount}
         {/if}
       {/foreach}
-      <div class="crm-grid-cell right text-right">{$totalcount}</div>
+      <div class="crm-grid-cell right text-right" id="participantTotalCount" data-participantTotalCount="{$totalcount}">{$totalcount}</div>
     </div>
   {/if}
 </div>

--- a/tests/phpunit/CRM/Contribute/Form/ContributionViewTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionViewTest.php
@@ -71,7 +71,7 @@ class CRM_Contribute_Form_ContributionViewTest extends CiviUnitTestCase {
     unset($_GET['id'], $_REQUEST['id']);
     unset($_GET['cid'], $_REQUEST['cid']);
 
-    $this->assertMatchesRegularExpression('/>Total<\/div>\s*<div class="[^"]+">\$10\.00/', $contents);
+    $this->assertMatchesRegularExpression('/>Total<\/div>\s*<div class="[^"]+" id="totalAmount" data-totalAmount="10">\$10\.00/', $contents);
     $this->assertStringContainsString('Mr. Anthony Anderson II', $contents);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Totals are formatted for display. Currently have to try and do various unreliable string parsing things to extract totals from the list of lineitems.

Before
----------------------------------------
Have to use string-parsing etc.

After
----------------------------------------
Can extract directly from `data-` elements.

Technical Details
----------------------------------------
The lineitem.tpl gets included in various places including the contribution page when in invoice mode (if a priceset was used). Various totals are assigned to it via smarty variables and then formatted using smarty modifiers. Monetary amounts in particular are very difficult to extract reliably using javascript etc. because the format is locale-specific. By adding data attributes we have the raw values available for easy use by client-side scripts.

Comments
----------------------------------------
This allows us to fix issues such as https://lab.civicrm.org/extensions/stripe/-/issues/348
