### PR TITLE
Allow JobLog date to be used as formbuilder filter

### DIFF
--- a/schema/Core/JobLog.entityType.php
+++ b/schema/Core/JobLog.entityType.php
@@ -43,9 +43,10 @@ return [
       ],
     ],
     'run_time' => [
-      'title' => ts('Timestamp'),
+      'title' => ts('Log date'),
       'sql_type' => 'timestamp',
-      'input_type' => NULL,
+      'input_type' => 'Select Date',
+      'readonly' => TRUE,
       'description' => ts('Log entry date'),
       'required' => TRUE,
       'default' => 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',


### PR DESCRIPTION
Overview
----------------------------------------
Allows you to add a filter by "log date" in the scheduled Job Logs.

Before
----------------------------------------
Can't filter by log date.

After
----------------------------------------
Can filter by log date.

Technical Details
----------------------------------------


Comments
----------------------------------------

