### PR TITLE
Fix rejection of activity import if id not mapped

### DIFF
--- a/CRM/Activity/Import/Form/MapField.php
+++ b/CRM/Activity/Import/Form/MapField.php
@@ -131,9 +131,9 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
         }
         $parser = $self->getParser();
         $rule = $parser->getDedupeRule('Individual', $self->getUserJob()['metadata']['entity_configuration']['TargetContact']['dedupe_rule'] ?? NULL);
-        $errors = $self->validateContactFields($rule, $importKeys, ['target_contact.external_identifier', 'target_contact.id']);
+        $missingFields = $self->validateContactFields($rule, $importKeys, ['external_identifier', 'id']);
 
-        $missingFields = $self->validateRequiredFields($fields['mapper']);
+        $missingFields += $self->validateRequiredFields($fields['mapper']);
         if ($missingFields) {
           $errors['_qf_default'] = implode(',', $missingFields);
         }


### PR DESCRIPTION
Overview
----------------------------------------
Fix rejection of activity import if id not mapped

Before
----------------------------------------
The presence of the Target Contact ID is not being treated as enough to create a valid mapping on the MapField screen. Validation fails (& confusingly there is no message as the error is not assigned a key)


After
----------------------------------------
Target Contact ID is now enough - imports can procede

Technical Details
----------------------------------------
It's possible this could be a little too loose now - but it is only a convenience validation - the 'real' validation happens once import starts


Comments
----------------------------------------
