### PR TITLE
Chartkit - support multiple dimension columns, add HeatMap chart type

### DIFF
--- a/ext/chart_kit/ang/crmChartKit/chartKitChartTypes.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartKitChartTypes.service.js
@@ -12,7 +12,33 @@
 
     const ts = CRM.ts('chart_kit');
 
-    return [
+    const legacySettingsAdaptor = (settings) => {
+      let updated = false;
+      // for pie/row charts, x axis was moved to w. if pie/row chart has x
+      // columns but no y columns, then transfer them
+      if (settings.chartType === 'pie' || settings.chartType === 'row') {
+        // if no cols for w axis
+        if (!settings.columns.find((col) => col.axis === 'w')) {
+
+          // update any x cols to w
+          settings.columns.forEach((col, i) => {
+            if (col.axis === 'x') {
+              settings.columns[i].axis = 'w';
+              updated = true;
+            }
+          });
+        }
+      }
+
+
+      if (updated) {
+        CRM.alert(ts("Please resave charts in SearchKit to avoid this message"), ts("Deprecated chart settings detected"));
+      }
+      return settings;
+    };
+
+
+    const types = [
       {
         key: 'pie',
         label: ts('Pie'),
@@ -56,5 +82,10 @@
         service: chartKitComposite
       },
     ];
+
+    return {
+      types: types,
+      legacySettingsAdaptor: legacySettingsAdaptor,
+    };
   });
 })(angular, CRM.$, CRM._);

--- a/ext/chart_kit/ang/crmChartKit/chartKitChartTypes.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartKitChartTypes.service.js
@@ -7,7 +7,8 @@
     chartKitRow,
     chartKitStack,
     chartKitComposite,
-    chartKitSeries
+    chartKitSeries,
+    chartKitHeatMap
   ) => {
 
     const ts = CRM.ts('chart_kit');
@@ -80,6 +81,12 @@
         label: ts('Combined'),
         icon: 'fa-layer-group',
         service: chartKitComposite
+      },
+      {
+        key: 'heatmap',
+        label: ts('Heat Map'),
+        icon: 'fa-table-cells-large',
+        service: chartKitHeatMap
       },
     ];
 

--- a/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitComposite.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitComposite.service.js
@@ -14,7 +14,8 @@
         label: ts('X-Axis'),
         // prefer date/categorical
         scaleTypes: ['date', 'numeric', 'categorical'],
-        reduceTypes: []
+        reduceTypes: [],
+        isDimension: true,
       },
       'y': {
         key: 'y',

--- a/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitHeatMap.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitHeatMap.service.js
@@ -1,0 +1,101 @@
+(function (angular, $, _, dc, d3) {
+  "use strict";
+
+  angular.module('crmChartKit').factory('chartKitHeatMap', () => ({
+    adminTemplate: '~/crmChartKit/chartTypes/chartKitHeatMapAdmin.html',
+
+    getAxes: () => ({
+      'w': {
+        label: ts('Columns'),
+        reduceTypes: ['list'],
+        scaleTypes: ['categorical'],
+        dataLabelTypes: ['title', 'label', 'none'],
+        multiColumn: true,
+        isDimension: true,
+      },
+      'v': {
+        label: ts('Rows'),
+        reduceTypes: ['list'],
+        scaleTypes: ['categorical'],
+        dataLabelTypes: ['title', 'label', 'none'],
+        isDimension: true,
+      },
+      'y': {
+        label: ts('Color'),
+        dataLabelTypes: ['title', 'label', 'none'],
+      },
+      'z': {
+        label: ts('Additional labels'),
+        dataLabelTypes: ['label', 'title'],
+        prepopulate: false,
+        multiColumn: true,
+      }
+    }),
+
+    hasCoordinateGrid: () => false,
+
+    getInitialDisplaySettings: () => ({
+      colorScaleMin: '#91223c',
+      colorScaleMax: '#2e562e',
+    }),
+
+    getChartConstructor: () => dc.heatMap,
+
+    loadChartData: (displayCtrl) => {
+      const colColumn = displayCtrl.getFirstColumnForAxis('w');
+      const rowColumn = displayCtrl.getFirstColumnForAxis('v');
+      const colorColumn = displayCtrl.getFirstColumnForAxis('y');
+
+      displayCtrl.chart
+        .dimension(displayCtrl.dimension)
+        .group(displayCtrl.group)
+        .keyAccessor(displayCtrl.getValueAccessor(colColumn), colColumn.label)
+        .colsLabel((d) => displayCtrl.renderDataValue(d[0], colColumn))
+        .colOrdering((a, b) => d3.ascending(a[0], b[0]))
+        .valueAccessor(displayCtrl.getValueAccessor(rowColumn), rowColumn.label)
+        .rowsLabel((d) => displayCtrl.renderDataValue(d[0], rowColumn))
+        .rowOrdering((a, b) => {
+          return d3.ascending(displayCtrl.renderDataValue(a, rowColumn), displayCtrl.renderDataValue(b, rowColumn));
+        });
+
+      // set up color scale
+      displayCtrl.chart
+        .colorAccessor(displayCtrl.getValueAccessor(colorColumn))
+        .calculateColorDomain();
+      const colorScale = d3.scaleLinear(displayCtrl.chart.colorDomain(), [displayCtrl.settings.colorScaleMin, displayCtrl.settings.colorScaleMax]);
+      displayCtrl.chart.colors(colorScale);
+
+
+      // add labels
+      displayCtrl.chart
+        .on('renderlet', () => {
+          // add additional text box to each heatbox
+          const boxGroups = displayCtrl.chart.selectAll('.box-group');
+
+          // remove any existing labels to avoid duplication
+          boxGroups.selectAll('text.heat-box-label').remove();
+
+          // regen label text node for each box group
+          boxGroups.append(function (d) {
+            const rect = this.querySelector('rect.heat-box');
+            const getFloatAttrFromRect = (attr) => parseFloat(rect.getAttribute(attr));
+            const x = getFloatAttrFromRect('x') + getFloatAttrFromRect('width') / 2;
+            const y = getFloatAttrFromRect('y') + getFloatAttrFromRect('height') / 2;
+
+            const label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+            label.classList.add('heat-box-label');
+            label.setAttribute('x', x);
+            label.setAttribute('y', y);
+            label.setAttribute('fill', displayCtrl.settings.format.labelColor);
+            label.style.textAnchor = 'middle';
+
+            return label;
+          });
+
+          // assign the text content
+          boxGroups.select('.heat-box-label').text((d) => displayCtrl.renderDataLabel(d, displayCtrl.dataPointLabelMask('label')(d)).replaceAll('\n', ' - '));
+        });
+    }
+  }));
+})(angular, CRM.$, CRM._, CRM.chart_kit.dc, CRM.chart_kit.d3);
+

--- a/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitHeatMapAdmin.html
+++ b/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitHeatMapAdmin.html
@@ -1,0 +1,22 @@
+<div class="crm-chart-kit-pie-admin">
+
+  <div ng-include="'~/crmChartKit/chartKitAdminColumns.html'"></div>
+
+  <div class="crm-chart-kit-admin-presentation">
+
+    <div ng-include="'~/crmChartKit/chartKitAdminCanvas.html'"></div>
+
+    <fieldset>
+      <legend>{{:: ts('Heat map options') }}</legend>
+      <div class="form-inline">
+        <label>{{:: ts('Color Min') }}</label>
+        <input type="color" class="form-control" ng-model="$ctrl.display.settings.colorScaleMin">
+      </div>
+      <div class="form-inline">
+        <label>{{:: ts('Color Max') }}</label>
+        <input type="color" class="form-control" ng-model="$ctrl.display.settings.colorScaleMax">
+      </div>
+
+    </fieldset>
+
+</div>

--- a/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitPie.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitPie.service.js
@@ -5,12 +5,14 @@
     adminTemplate: '~/crmChartKit/chartTypes/chartKitPieAdmin.html',
 
     getAxes: () => ({
-      'x': {
+      'w': {
         label: ts('Category'),
-        reduceTypes: [],
+        reduceTypes: ['list'],
         scaleTypes: ['categorical'],
         // label is default to show what things are
         dataLabelTypes: ['label', 'title', 'none'],
+        multiColumn: true,
+        isDimension: true,
       },
       'y': {
         label: ts('Values'),
@@ -29,7 +31,7 @@
     showLegend: (displayCtrl) => (displayCtrl.settings.showLegend && displayCtrl.settings.showLegend !== 'none'),
 
     // for pie chart the legend is showing column values, which benefit from rendering
-    legendTextAccessor: (displayCtrl) => ((d) => (d.name === 'Others') ? 'Others' : displayCtrl.renderColumnValue(d.data, displayCtrl.getFirstColumnForAxis('x'))),
+    legendTextAccessor: (displayCtrl) => ((d) => (d.name === 'Others') ? 'Others' : displayCtrl.renderColumnValue(d.data, displayCtrl.getFirstColumnForAxis('w'))),
 
     getInitialDisplaySettings: () => ({
       showLegend: 'left',

--- a/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitRow.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitRow.service.js
@@ -5,12 +5,14 @@
     adminTemplate: '~/crmChartKit/chartTypes/chartKitRowAdmin.html',
 
     getAxes: () => ({
-      'x': {
+      'w': {
         label: ts('Category'),
-        reduceTypes: [],
+        reduceTypes: ['list'],
         scaleTypes: ['categorical'],
         // label is default to show what things are
         dataLabelTypes: ['label', 'title', 'none'],
+        multiColumn: true,
+        isDimension: true,
       },
       'y': {
         label: ts('Values'),

--- a/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitSeries.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitSeries.service.js
@@ -16,11 +16,13 @@
         label: ts('X-Axis'),
         scaleTypes: ['date', 'numeric', 'categorical'],
         reduceTypes: [],
+        isDimension: true,
       },
       'w': {
         label: ts('Grouping'),
         scaleTypes: ['categorical'],
         reduceTypes: [],
+        isDimension: true,
       },
       'y': {
         label: ts('Value'),
@@ -43,20 +45,6 @@
 
     // fallback to a line chart if we dont have a grouping column yet
     getChartConstructor: (displayCtrl) => displayCtrl.getColumnsForAxis('w') ? dc.seriesChart : dc.lineChart,
-
-    buildDimension: (displayCtrl) => {
-      // we need to add the series values in the dimension or they will get
-      // aggregated
-      displayCtrl.dimension = displayCtrl.ndx.dimension((d) => {
-        const xValue = d[displayCtrl.getFirstColumnForAxis('x').index];
-        const seriesCol = displayCtrl.getFirstColumnForAxis('w');
-        const seriesVal = seriesCol ? d[seriesCol.index] : null;
-
-        // we use a string separator rather than array to
-        // not corrupt ordering on xValue
-        return [xValue, seriesVal];
-      });
-    },
 
     loadChartData: (displayCtrl) => {
       displayCtrl.chart.chart((displayCtrl.settings.seriesDisplayType === 'bar') ? dc.barChart : dc.lineChart);

--- a/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitStack.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitStack.service.js
@@ -12,7 +12,8 @@
       'x': {
         label: ts('X-Axis'),
         scaleTypes: ['date', 'numeric', 'categorical'],
-        reduceTypes: []
+        reduceTypes: [],
+        isDimension: true,
       },
       'y': {
         key: 'y',

--- a/ext/chart_kit/ang/crmChartKit/crmSearchDisplayChartKit.component.js
+++ b/ext/chart_kit/ang/crmChartKit/crmSearchDisplayChartKit.component.js
@@ -339,7 +339,7 @@
           this.formatCoordinateGrid();
         }
 
-        if (this.chartType.showLegend(this)) {
+        if (this.chartType.showLegend && this.chartType.showLegend(this)) {
           this.addLegend();
         }
       };

--- a/ext/chart_kit/ang/crmChartKit/crmSearchDisplayChartKit.component.js
+++ b/ext/chart_kit/ang/crmChartKit/crmSearchDisplayChartKit.component.js
@@ -47,11 +47,14 @@
       };
 
       this.initChartType = () => {
+        // run initial settings through our legacy adaptor
+        this.settings = chartKitChartTypes.legacySettingsAdaptor(this.settings);
+
         if (!this.settings.chartType) {
           this.chartContainer.innerText = ts('No chart type selected.');
           return false;
         }
-        const type = chartKitChartTypes.find((type) => type.key === this.settings.chartType);
+        const type = chartKitChartTypes.types.find((type) => type.key === this.settings.chartType);
         if (!type || !type.service) {
           this.chartContainer.innerText = ts('No chart type selected.');
           return false;

--- a/ext/chart_kit/ang/crmChartKit/searchAdminDisplayChartKit.component.js
+++ b/ext/chart_kit/ang/crmChartKit/searchAdminDisplayChartKit.component.js
@@ -28,7 +28,7 @@
         return this.getColumns().filter((col) => col.axis === axisKey);
       };
 
-      this.getChartTypeOptions = () => chartKitChartTypes.map((type) => ({ key: type.key, label: type.label, icon: type.icon }));
+      this.getChartTypeOptions = () => chartKitChartTypes.types.map((type) => ({ key: type.key, label: type.label, icon: type.icon }));
 
       this.getInitialDisplaySettings = () => ({
         columns: [],
@@ -57,13 +57,17 @@
       this.$onInit = () => {
         this.searchColumns = this.apiParams.select.map((col) => searchMeta.fieldToColumn(col, { label: true }));
 
-        this.chartTypeOptions = this.getChartTypeOptions();
-
         if (!this.display.settings) {
           this.display.settings = {
             chartType: null
           };
         }
+        else {
+          // run initial settings through our legacy adaptor
+          this.display.settings = chartKitChartTypes.legacySettingsAdaptor(this.display.settings);
+        }
+
+        this.chartTypeOptions = this.getChartTypeOptions();
 
         $scope.$watch('$ctrl.display.settings.chartType', () => this.onSetChartType(), true);
       };
@@ -81,7 +85,7 @@
       };
 
       this.initChartType = () => {
-        const type = chartKitChartTypes.find((type) => type.key === this.display.settings.chartType);
+        const type = chartKitChartTypes.types.find((type) => type.key === this.display.settings.chartType);
         this.chartType = type.service;
       };
 


### PR DESCRIPTION
Overview
----------------------------------------
Updates `buildDimension` in the general chart renderer to support multiple dimension columns, and adds HeatMap chart type to use this functionality. _(edit: added the heatmap to this PR to demonstrate the use for the refactoring)_

Before
----------------------------------------
- no Heatmap chart type
- Pie/Row are limited to one column for the "Grouping" axis, 
- Series chart overrides `buildDimension` to include x and w columns in the crossfilter dimension

After
----------------------------------------

- Heat Map chart type, potentially very useful in CiviCRM context for cohort analysis type charts.

e.g. visualise membership retention by cohort (membership expiration date by membership start date)
![image](https://github.com/user-attachments/assets/ddc7a449-f285-4b73-b9f8-db3eb450a82c)


e.g. visualise annual patterns in contributions (contribution amounts by year and month)
![image](https://github.com/user-attachments/assets/1d4170a8-2668-4d1e-9d4d-0c9af67c617a)


- Pie and Row can set multiple Grouping columns to show the intersections of categories. 
 
E.g. grouping by Financial Type AND Contribution Status
![image](https://github.com/user-attachments/assets/4c625756-bbea-4eed-9d50-ff29b0b3a2da)

![image](https://github.com/user-attachments/assets/5a580cf6-8e13-4b9c-b7c1-a88105dca705)



- Series Chart doesn't need to implement its own `buildDimension` - it can use the generic logic in the renderer


Technical Details
----------------------------------------
The Pie and Row charts switch to using `w` axis for the grouping - this provides a better experience if switching between chart types in the admin, as the Grouping in Pie/Row charts is more analagous to the Grouping in Series charts than the "x" axis on those charts.

A "legacy settings adaptor" is added to ensure pie/row charts made prior to this change (i.e. using x axis) still render correctly. A CRM alert is triggered directing re-saving in order to update the SearchDisplay settings in the database. (They may also need updating in Managed Records, if the search kit has been exported. Given that ChartKit is still listed as "beta" I am hoping folks using it are prepared for this kind of migration nudge)

