### PR TITLE
ChartKit - fix priority of text color setting

### DIFF
--- a/ext/chart_kit/ang/crmChartKit/crmSearchDisplayChartKit.component.js
+++ b/ext/chart_kit/ang/crmChartKit/crmSearchDisplayChartKit.component.js
@@ -276,11 +276,11 @@
         this.chart
           .width(() => (this.settings.format.width))
           .height(() => (this.settings.format.height))
-          .on('pretransition', chart => {
-            chart.selectAll('text').attr('fill', this.settings.format.labelColor);
+          .on('pretransition', () => {
+            this.chart.selectAll('text').style('fill', this.settings.format.labelColor);
             // we need to add the background here as well as to the containing div
             // in order for inclusion in exports
-            chart.svg().style('background', this.settings.format.backgroundColor);
+            this.chart.svg().style('background', this.settings.format.backgroundColor);
           });
 
         if (this.chartType.hasCoordinateGrid()) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes issue where the local text color setting is overridden by styles (either from the base dc styles, or Riverlea).

Before
----------------------------------------
- Chart Kit renderer sets `fill` attribute for text elements, which can be overridden by global styles

e.g. on pie chart, Riverlea and DC styles are fixing the chart text to white, when the chart settings say black:
![image](https://github.com/user-attachments/assets/741d9b36-fdb0-4e22-8562-866d2424bf51)


After
----------------------------------------
- ChartKit sets a local style declaration, which takes priority over global styles

Pie charts are fixed
![image](https://github.com/user-attachments/assets/ed90d529-db88-47d7-b8c9-54b42bbbdd3b)


Comments
----------------------------------------
In the long run, it would be nice if ChartKit could gracefully inherit styles from the global style sheet. But given e.g. pie chart labels need to be visible over the DC chart scheme, it makes sense to fix the text color in the display settings for now.
