### PR TITLE
(dev/core#5700) Extensions - "Add New" is supposed to install new extensions

### DIFF
--- a/CRM/Admin/Form/Extensions.php
+++ b/CRM/Admin/Form/Extensions.php
@@ -205,7 +205,7 @@ class CRM_Admin_Form_Extensions extends CRM_Admin_Form {
       // FIXME: It would be nice to accept a list of exts and/or use transitive dependencies (Manager::findInstallRequirements()).
       $runner = new CRM_Queue_Runner([
         'title' => $qd->getTitle(),
-        'queue' => $qd->fillQueue($downloads),
+        'queue' => $qd->addDownloads($downloads)->fillQueue(),
         'onEnd' => [static::class, 'onFinishDownload'],
         'onEndUrl' => (string) Civi::url('backend://civicrm/admin/extensions?reset=1&action=browse'),
         'errorMode' => CRM_Queue_Runner::ERROR_ABORT,

--- a/CRM/Admin/Form/Extensions.php
+++ b/CRM/Admin/Form/Extensions.php
@@ -205,7 +205,7 @@ class CRM_Admin_Form_Extensions extends CRM_Admin_Form {
       // FIXME: It would be nice to accept a list of exts and/or use transitive dependencies (Manager::findInstallRequirements()).
       $runner = new CRM_Queue_Runner([
         'title' => $qd->getTitle(),
-        'queue' => $qd->fillQueue($qd->createQueue(), $downloads),
+        'queue' => $qd->fillQueue($downloads),
         'onEnd' => [static::class, 'onFinishDownload'],
         'onEndUrl' => (string) Civi::url('backend://civicrm/admin/extensions?reset=1&action=browse'),
         'errorMode' => CRM_Queue_Runner::ERROR_ABORT,

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -188,7 +188,7 @@ class CRM_Extension_Manager {
       // the extension does not exist in any container; we're free to put it anywhere
       $tgtPath = $this->defaultContainer->getBaseDir() . DIRECTORY_SEPARATOR . $newInfo->key;
     }
-    if (!CRM_Utils_File::isChildPath($this->defaultContainer->getBaseDir(), $tgtPath)) {
+    if (!CRM_Utils_File::isChildPath($this->defaultContainer->getBaseDir(), $tgtPath, FALSE)) {
       // But if we don't control the folder, then force installation in the default-container
       $oldPath = $tgtPath;
       $tgtPath = $this->defaultContainer->getBaseDir() . DIRECTORY_SEPARATOR . $newInfo->key;

--- a/CRM/Extension/QueueDownloader.php
+++ b/CRM/Extension/QueueDownloader.php
@@ -15,15 +15,45 @@
  * The general idea is:
  *
  *   $dl = new CRM_Extension_QueueDownloader();
- *   $queue = $dl->fillQueue(
+ *   $dl->addDownloads(
  *     ['ext-1' => 'https://example.com/ext-1/releases/1.2.3./zip']
  *   );
- *   $runner = new CRM_Queue_Runner(...$queue...);
+ *   $runner = new CRM_Queue_Runner([
+ *     'queue' => $dl->fillQueue(), ...
+ *   ]);
  *   $runner->runAllViaWeb();
  *
- * NOTE: When upgrading extensions, you MUST have a chance to reset the PHP process (loading new PHP files).
+ * == NOTE: Using subprocesses
+ *
+ * When upgrading extensions, you MUST provide a chance to reset the PHP process (loading new PHP files).
+ *
  * We will assume that every task runs in a new PHP process. This is compatible with runAllViaWeb() not but runAll().
- * Headless clients (like `cv`) will need to use a different implementation that spawns new subprocesses.
+ *
+ * Headless clients (like `cv`) will need to use a suitable runner that spawns new subprocesses.
+ *
+ * == NOTE: Sequencing
+ *
+ * When you have multiple extensions to download/enable (and each may come with different start-state
+ * and version; and each may have differing versioned-dependencies)... then there is an interesting
+ * question about how to sequence/group the operations.
+ *
+ * Some operations target multiple ext's concurrently (like "rebuild" or "hook_upgrade" or "enable(keys=>A,B,C)").
+ * It's nice to lean into this style ("fetch A+B+C" then "rebuild system" then "upgrade A+B+C")
+ * because it's a good facsimile of the behavior in SCM (git/gzr/svn)-based workflows.
+ *
+ * However, it's not perfect, and there may still be edge-cases where that doesn't work. I'm pessimistic
+ * that this class will be able to automatically form perfect+universal plans based only on a declared
+ * list of downloads.
+ *
+ * So if a problematic edge-case comes up, how could you resolve it? The caller can decide sequencing/batching.
+ * Compare:
+ *
+ * ## Ex 1: Download 'a' and 'b' in the same batch. They will be fetched, swapped, and rebuilt in tandem.
+ *   $dl->addDownloads(['a' => ..., 'b' => ...]);
+ *
+ * ## Ex 2: Download 'a' and 'b' as separate batches. 'a' will be fully handled before 'b'.
+ *   $dl->addDownloads(['a' => ...]);
+ *   $dl->addDownloads(['b' => ...]);
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
@@ -40,22 +70,24 @@ class CRM_Extension_QueueDownloader {
    */
   protected string $upId;
 
-  protected bool $autoApply;
-
   protected CRM_Queue_Queue $queue;
 
   protected bool $cleanup;
 
   /**
-   * @param bool $autoApply
-   *   TRUE if the downloader should also execute the installation/upgrade routines
+   * @var array
+   *   Ex: [0 => ['type' => 'download', 'urls' => ['my.extension' => 'https://example/my.extension-1.0.zip']]]
+   *   Ex: [0 => ['type' => 'enable', 'keys' => ['my.extension']]]
+   */
+  protected array $batches = [];
+
+  /**
    * @param bool $cleanup
    *    Whether to delete temporary files and backup files at the end.
    * @param CRM_Queue_Queue|null $queue
    */
-  public function __construct(bool $autoApply = TRUE, bool $cleanup = TRUE, ?CRM_Queue_Queue $queue = NULL) {
+  public function __construct(bool $cleanup = TRUE, ?CRM_Queue_Queue $queue = NULL) {
     $this->upId = (CRM_Utils_Time::date('Y-m-d') . '-' . CRM_Utils_String::createRandom(16, CRM_Utils_String::ALPHANUMERIC));
-    $this->autoApply = $autoApply;
     $this->cleanup = $cleanup;
     $this->queue = $queue ?: $this->createQueue();
   }
@@ -92,15 +124,37 @@ class CRM_Extension_QueueDownloader {
   }
 
   /**
+   * Add a set of extensions to download and enable.
+   *
    * @param array $downloads
    *   Ex: ['ext1' => 'https://example.com/ext1/releases/1.0.zip']
-   * @return \CRM_Queue_Queue
+   * @param bool $autoApply
+   *   TRUE if the downloader should execute the installation/upgrade routines
+   *   FALSE if the downloader should only get the files and put them in place
+   * @return $this
    */
-  public function fillQueue(array $downloads): CRM_Queue_Queue {
+  public function addDownloads(array $downloads, bool $autoApply = TRUE) {
+    $this->batches[] = ['type' => 'download', 'urls' => $downloads, 'autoApply' => $autoApply];
+    return $this;
+  }
+
+  /**
+   * Add a set of keys which should be enabled. (Use this if you -only- want to enable. If you are actually downloading, then use addDownloads().)
+   *
+   * @param array $keys
+   *   Ex: ['my.ext1', 'my.ext2']
+   * @return $this
+   */
+  public function addEnable(array $keys) {
+    $this->batches[] = ['type' => 'enable', 'keys' => $keys];
+    return $this;
+  }
+
+  /**
+   * Take the list of pending updates (from addDownload, addEnable)
+   */
+  public function fillQueue(): CRM_Queue_Queue {
     $queue = $this->queue;
-    if (empty($downloads)) {
-      throw new CRM_Core_Exception("Cannot build download queue. No downloads requested!");
-    }
 
     // Store some metadata about what's going on. This may help with debugging.
     CRM_Utils_File::createDir($this->getStagingPath(), 'exception');
@@ -108,99 +162,54 @@ class CRM_Extension_QueueDownloader {
       'startTime' => CRM_Utils_Time::date('c'),
       'upId' => $this->upId,
       'queue' => $queue->getName(),
-      'downloads' => $downloads,
+      'batches' => $this->batches,
       'statuses' => CRM_Extension_System::singleton()->getManager()->getStatuses(),
     ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 
-    // Download and extract zip files. This is I/O dependent (error-prone), so we do each as a separate (retriable) step.
-    foreach ($downloads as $ext => $url) {
-      $queue->createItem(
-        static::task(ts('Fetch "%1" from "%2"', [1 => $ext, 2 => $url]), 'fetch', [$ext, $url]),
-        ['weight' => 100]
-      );
-    }
+    foreach ($this->batches as $batch) {
+      switch ($batch['type']) {
+        case 'enable':
+          $queue->createItem(static::task(ts('Enable %1', [1 => $this->quotedList($batch['keys'])]), 'enable', [$batch['keys']]));
+          break;
 
-    // Verify all requirements with a single operation.
-    // We won't be sensitive to (re)ordering of fetch-tasks, because we only care if the final set is coherent.
-    $queue->createItem(
-      static::task(ts('Verify requirements'), 'preverify', [array_keys($downloads)]),
-      ['weight' => 200]
-    );
+        case 'download':
+          $downloads = $batch['urls'];
 
-    // Swap-in new folders with a single operation. This should be similar to more sophisticated site-builder
-    // workflows. (f you manage a site in git, then "git pull" swaps all code at the same time.) This
-    // can't guarantee that all combinations of $downloads work, but at least they'll behave consistently.
-    $queue->createItem(
-      static::task(ts('Swap folders'), 'swap', [array_keys($downloads)]),
-      ['weight' => 200]
-    );
+          // Download and extract zip files. This is I/O dependent (error-prone), so we do each as a separate (retriable) step.
+          foreach ($downloads as $ext => $url) {
+            $queue->createItem(static::task(ts('Fetch "%1" from "%2"', [1 => $ext, 2 => $url]), 'fetch', [$ext, $url]));
+          }
 
-    // The "swap" and "rebuild" must happen in separate steps.
-    $queue->createItem(
-      static::task(ts('Rebuild system'), 'rebuild'),
-      ['weight' => 300]
-    );
+          // Verify all requirements with a single operation -- _before_ loading the new code.
+          // We won't be sensitive to (re)ordering of fetch-tasks, because we only care if the final set is coherent.
+          $queue->createItem(static::task(ts('Verify requirements'), 'preverify', [array_keys($downloads)]));
 
-    if ($this->autoApply) {
-      // We need to figure out the mix of activation-steps (enable/upgrade).
-      // If you have multiple (e.g. enable $X and also upgrade $Y), then... which runs first?
-      // In theory, there is no simple rule of ordering that will work for all imaginable scenarios.
-      // The main mitigating factor is that actual usage will be biased toward simple-cases.
-      // (Ex: The web UI only lets you add one extension at a time. The CLI allows multiple -- but user must explicitly choose each.)
-      // This implementation defers to the user -- applying extensions in the order requested.
+          // Swap-in new folders with a single operation. This should be similar to more sophisticated site-builder
+          // workflows. (f you manage a site in git, then "git pull" swaps all code at the same time.) This
+          // can't guarantee that all combinations of $downloads work, but at least they'll behave consistently.
+          $queue->createItem(static::task(ts('Swap folders'), 'swap', [array_keys($downloads)]));
 
-      $statuses = CRM_Extension_System::singleton()->getManager()->getStatuses();
-      $todos = [];
-      foreach (array_keys($downloads) as $key) {
-        switch ($statuses[$key] ?? CRM_Extension_Manager::STATUS_UNINSTALLED) {
-          case CRM_Extension_Manager::STATUS_UNINSTALLED:
-            $todos[] = ['enable', $key];
-            break;
+          // The "swap" and "rebuild" must happen in separate steps.
+          if ($batch['autoApply']) {
+            $queue->createItem(static::task(ts('Rebuild system'), 'rebuild'));
+          }
 
-          case CRM_Extension_Manager::STATUS_DISABLED:
-          case CRM_Extension_Manager::STATUS_DISABLED_MISSING:
-            $todos[] = ['enable', $key];
-            $todos[] = ['upgrade', $key];
-            break;
+          $statuses = CRM_Extension_System::singleton()->getManager()->getStatuses();
+          $findByStatus = fn(array $matchStatuses) => array_filter(
+            array_keys($downloads),
+            fn($key) => in_array($statuses[$key] ?? CRM_Extension_Manager::STATUS_UNINSTALLED, $matchStatuses, TRUE)
+          );
+          $needEnable = $findByStatus([CRM_Extension_Manager::STATUS_UNINSTALLED, CRM_Extension_Manager::STATUS_DISABLED, CRM_Extension_Manager::STATUS_DISABLED_MISSING]);
+          $needUpgrade = $findByStatus([CRM_Extension_Manager::STATUS_INSTALLED, CRM_Extension_Manager::STATUS_DISABLED, CRM_Extension_Manager::STATUS_DISABLED_MISSING]);
+          if ($batch['autoApply'] && $needEnable) {
+            $queue->createItem(static::task(ts('Enable %1', [1 => $this->quotedList($needEnable)]), 'enable', [$needEnable]));
+          }
+          if ($batch['autoApply'] && $needUpgrade) {
+            $queue->createItem(static::task(ts('Upgrade database'), 'upgradeDb'));
+          }
 
-          case CRM_Extension_Manager::STATUS_INSTALLED:
-          case CRM_Extension_Manager::STATUS_INSTALLED_MISSING:
-            $todos[] = ['upgrade', $key];
-            break;
+          break;
 
-          default:
-            throw new \CRM_Extension_Exception('Unknown status: ' . $statuses[$key]);
-        }
-      }
-
-      // Optimization: Combine any adjacent todos of the same type (e.g. "enable A + enable B ==> enable A+B").
-      $nextType = fn() => $todos[0][0];
-      $nextKey = fn() => $todos[0][1];
-      while (!empty($todos)) {
-        $targetType = $nextType();
-
-        $contiguousSegment = [];
-        while (!empty($todos) && $nextType() === $targetType) {
-          $contiguousSegment[] = $nextKey();
-          array_shift($todos);
-        }
-
-        switch ($targetType) {
-          case 'enable':
-            $queue->createItem(
-              static::task(ts('Enable %1', [1 => '"' . implode('", "', $contiguousSegment) . '"']), 'enable', [$contiguousSegment]),
-              ['weight' => 400]
-            );
-
-            break;
-
-          case 'upgrade':
-            $queue->createItem(
-              static::task(ts('Upgrade database'), 'upgradeDb'),
-              ['weight' => 400]
-            );
-            break;
-        }
       }
     }
 
@@ -212,6 +221,12 @@ class CRM_Extension_QueueDownloader {
     }
 
     return $queue;
+  }
+
+  private function quotedList(array $items) {
+    // This can at least adapt to quotes and guillemets... we should probably have some more general helpers for lists and conjunctions...
+    $template = ts('"%1"');
+    return implode(', ', array_map(fn($item) => str_replace('%1', $item, $template), $items));
   }
 
   /**

--- a/CRM/Extension/QueueDownloader.php
+++ b/CRM/Extension/QueueDownloader.php
@@ -108,7 +108,7 @@ class CRM_Extension_QueueDownloader {
     // Download and extract zip files. This is I/O dependent (error-prone), so we do each as a separate (retriable) step.
     foreach ($downloads as $ext => $url) {
       $queue->createItem(
-        static::subtask(ts('Fetch "%1" from "%2"', [1 => $ext, 2 => $url]), 'fetch', [$ext, $url]),
+        static::task(ts('Fetch "%1" from "%2"', [1 => $ext, 2 => $url]), 'fetch', [$ext, $url]),
         ['weight' => 100]
       );
     }
@@ -116,7 +116,7 @@ class CRM_Extension_QueueDownloader {
     // Verify all requirements with a single operation.
     // We won't be sensitive to (re)ordering of fetch-tasks, because we only care if the final set is coherent.
     $queue->createItem(
-      static::subtask(ts('Verify requirements'), 'verify', [array_keys($downloads)]),
+      static::task(ts('Verify requirements'), 'preverify', [array_keys($downloads)]),
       ['weight' => 200]
     );
 
@@ -124,13 +124,13 @@ class CRM_Extension_QueueDownloader {
     // workflows. (f you manage a site in git, then "git pull" swaps all code at the same time.) This
     // can't guarantee that all combinations of $downloads work, but at least they'll behave consistently.
     $queue->createItem(
-      static::subtask(ts('Swap folders'), 'swap', [array_keys($downloads)]),
+      static::task(ts('Swap folders'), 'swap', [array_keys($downloads)]),
       ['weight' => 200]
     );
 
     // The "swap" and "rebuild" must happen in separate steps.
     $queue->createItem(
-      static::subtask(ts('Rebuild system'), 'rebuild'),
+      static::task(ts('Rebuild system'), 'rebuild'),
       ['weight' => 300]
     );
 
@@ -181,7 +181,7 @@ class CRM_Extension_QueueDownloader {
         switch ($targetType) {
           case 'enable':
             $queue->createItem(
-              static::subtask(ts('Enable %1', [1 => '"' . implode('", "', $contiguousSegment) . '"']), 'enable', [$contiguousSegment]),
+              static::task(ts('Enable %1', [1 => '"' . implode('", "', $contiguousSegment) . '"']), 'enable', [$contiguousSegment]),
               ['weight' => 400]
             );
 
@@ -189,7 +189,7 @@ class CRM_Extension_QueueDownloader {
 
           case 'upgrade':
             $queue->createItem(
-              static::subtask(ts('Upgrade database'), 'upgradeDb'),
+              static::task(ts('Upgrade database'), 'upgradeDb'),
               ['weight' => 400]
             );
             break;
@@ -199,7 +199,7 @@ class CRM_Extension_QueueDownloader {
 
     if ($cleanup) {
       $queue->createItem(
-        static::subtask(ts('Cleanup workspace'), 'cleanup'),
+        static::task(ts('Cleanup workspace'), 'cleanup'),
         ['weight' => 2000]
       );
     }
@@ -216,135 +216,12 @@ class CRM_Extension_QueueDownloader {
    *
    * @return \CRM_Queue_Task
    */
-  protected function subtask(string $title, string $method, array $args = []): CRM_Queue_Task {
-    $realMethod = 'subtask' . ucfirst($method);
+  protected function task(string $title, string $method, array $args = []): CRM_Queue_Task {
     return new CRM_Queue_Task(
-      [static::class, $realMethod],
+      [CRM_Extension_QueueTasks::class, $method],
       [$this->getStagingPath(), ...$args],
       $title
     );
-  }
-
-  /**
-   * Download extension ($key) from $url and store it in {$stagingPath}/new/{$key}.
-   */
-  public static function subtaskFetch(CRM_Queue_TaskContext $ctx, string $stagingPath, string $key, string $url): bool {
-    $tmpDir = "$stagingPath/tmp";
-    $zipFile = "$stagingPath/fetch/$key.zip";
-    $stageDir = "$stagingPath/new/$key";
-
-    CRM_Utils_File::createDir($tmpDir, 'exception');
-    CRM_Utils_File::createDir(dirname($zipFile), 'exception');
-    CRM_Utils_File::createDir(dirname($stageDir), 'exception');
-
-    if (file_exists($stageDir)) {
-      // In case we're retrying from a prior failure.
-      CRM_Utils_File::cleanDir($stageDir, TRUE, FALSE);
-    }
-
-    $downloader = CRM_Extension_System::singleton()->getDownloader();
-    if (!$downloader->fetch($url, $zipFile)) {
-      throw new CRM_Extension_Exception("Failed to download: $url");
-    }
-
-    $extractedZipPath = $downloader->extractFiles($key, $zipFile, $tmpDir);
-    if (!$extractedZipPath) {
-      throw new CRM_Extension_Exception("Failed to extract: $zipFile");
-    }
-
-    if (!$downloader->validateFiles($key, $extractedZipPath)) {
-      throw new CRM_Extension_Exception("Failed to validate $extractedZipPath. Consult CiviCRM log for details.");
-      // FIXME: Might be nice to show errors immediately, but we've got bigger fish to fry right now.
-    }
-
-    if (!rename($extractedZipPath, $stageDir)) {
-      throw new CRM_Extension_Exception("Failed to rename $extractedZipPath to $stageDir");
-    }
-
-    return TRUE;
-  }
-
-  /**
-   * Scan the downloaded extensions and verify that their requirements are satisfied.
-   */
-  public static function subtaskVerify(CRM_Queue_TaskContext $ctx, string $stagingPath, array $keys): bool {
-    $infos = CRM_Extension_System::singleton()->getMapper()->getAllInfos();
-    foreach ($keys as $key) {
-      $infos[$key] = CRM_Extension_Info::loadFromFile("$stagingPath/new/$key/" . CRM_Extension_Info::FILENAME);
-    }
-
-    $errors = CRM_Extension_System::singleton()->getManager()->checkInstallRequirements($keys, $infos);
-    if (!empty($errors)) {
-      Civi::log()->error('Failed to verify requirements for new downloads in {path}', [
-        'path' => $stagingPath,
-        'installKeys' => $keys,
-        'errors' => $errors,
-      ]);
-      throw new CRM_Extension_Exception(implode("\n", [
-        "Failed to verify requirements for new downloads in {$stagingPath}.",
-        ...array_column($errors, 'title'),
-        "Consult CiviCRM log for details.",
-      ]));
-    }
-
-    return TRUE;
-  }
-
-  /**
-   * Take the extracted code (`stagingDir/new/{key}`) and put it into its final place.
-   * Move any old code to the backup (`stagingDir/old/{key}`).
-   * Delete the container-cache
-   */
-  public static function subtaskSwap(CRM_Queue_TaskContext $ctx, string $stagingPath, array $keys): bool {
-    CRM_Utils_File::createDir("$stagingPath/old", 'exception');
-    try {
-      foreach ($keys as $key) {
-        $tmpCodeDir = "$stagingPath/new/$key";
-        $backupCodeDir = "$stagingPath/old/$key";
-
-        CRM_Extension_System::singleton()->getManager()->replace($tmpCodeDir, $backupCodeDir, FALSE);
-        // What happens when you call replace(.., refresh: false)? Varies by type:
-        // - For report/search/payment-extensions, it runs the uninstallation/reinstallation routines.
-        // - For module-extensions, it swaps the folders and clears the class-index.
-
-        // Arguably, for DownloadQueue, we should only clear class-index after all code is swapped,
-        // but it's messier to write that patch, and it's not clear if it's needed.
-      }
-    }
-    finally {
-      // Delete `CachedCiviContainer.*.php`, `CachedExtLoader.*.php`, and similar.
-      $config = CRM_Core_Config::singleton();
-      // $config->cleanup(1);
-      $config->cleanupCaches(FALSE);
-    }
-
-    return TRUE;
-  }
-
-  public static function subtaskRebuild(CRM_Queue_TaskContext $ctx): bool {
-    CRM_Core_Invoke::rebuildMenuAndCaches(TRUE, FALSE);
-    // FIXME: For 6.1+:, use: Civi::rebuild(['*' => TRUE, 'sessions' => FALSE]);
-    return TRUE;
-  }
-
-  /**
-   * Scan the downloaded extensions and verify that their requirements are satisfied.
-   */
-  public static function subtaskEnable(CRM_Queue_TaskContext $ctx, string $stagingPath, array $keys): bool {
-    CRM_Extension_System::singleton()->getManager()->enable($keys);
-    return TRUE;
-  }
-
-  public static function subtaskUpgradeDb(CRM_Queue_TaskContext $ctx): bool {
-    if (CRM_Extension_Upgrades::hasPending()) {
-      CRM_Extension_Upgrades::fillQueue($ctx->queue);
-    }
-    return TRUE;
-  }
-
-  public static function subtaskCleanup(CRM_Queue_TaskContext $ctx, string $stagingPath): bool {
-    CRM_Utils_File::cleanDir($stagingPath, TRUE, FALSE);
-    return TRUE;
   }
 
 }

--- a/CRM/Extension/QueueDownloader.php
+++ b/CRM/Extension/QueueDownloader.php
@@ -96,7 +96,7 @@ class CRM_Extension_QueueDownloader {
     }
 
     // Store some metadata about what's going on. This may help with debugging.
-    $this->mkdir($this->getStagingPath());
+    CRM_Utils_File::createDir($this->getStagingPath(), 'exception');
     file_put_contents($this->getStagingPath('details.json'), json_encode([
       'startTime' => CRM_Utils_Time::date('c'),
       'upId' => $this->upId,
@@ -238,7 +238,10 @@ class CRM_Extension_QueueDownloader {
     $tmpDir = $this->getStagingPath('tmp');
     $zipFile = $this->getStagingPath('fetch', $key . '.zip');
     $stageDir = $this->getStagingPath('new', $key);
-    $this->mkdir([$tmpDir, dirname($zipFile), dirname($stageDir)]);
+
+    CRM_Utils_File::createDir($tmpDir, 'exception');
+    CRM_Utils_File::createDir(dirname($zipFile), 'exception');
+    CRM_Utils_File::createDir(dirname($stageDir), 'exception');
 
     if (file_exists($stageDir)) {
       // In case we're retrying from a prior failure.
@@ -296,7 +299,7 @@ class CRM_Extension_QueueDownloader {
    * Delete the container-cache
    */
   public function subtaskSwap(CRM_Queue_TaskContext $ctx, array $keys): void {
-    $this->mkdir($this->getStagingPath('old'));
+    CRM_Utils_File::createDir($this->getStagingPath('old'), 'exception');
     try {
       foreach ($keys as $key) {
         $tmpCodeDir = $this->getStagingPath('new', $key);
@@ -339,17 +342,6 @@ class CRM_Extension_QueueDownloader {
 
   public function subtaskCleanup(): void {
     CRM_Utils_File::cleanDir($this->getStagingPath(), TRUE, FALSE);
-  }
-
-  private function mkdir($paths): void {
-    $paths = (array) $paths;
-    foreach ($paths as $path) {
-      if (!is_dir($path)) {
-        if (!mkdir($path, 0777, TRUE)) {
-          throw new CRM_Core_Exception("Failed to create directory: $path");
-        }
-      }
-    }
   }
 
 }

--- a/CRM/Extension/QueueDownloader.php
+++ b/CRM/Extension/QueueDownloader.php
@@ -84,13 +84,13 @@ class CRM_Extension_QueueDownloader {
    * @param CRM_Queue_Queue $queue
    * @param array $downloads
    *   Ex: ['ext1' => 'https://example.com/ext1/releases/1.0.zip']
-   * @param bool $upgradeDb
-   *   Whether to run database updates
+   * @param bool $autoApply
+   * *   TRUE if the downloader should also execute the installation/upgrade routines
    * @param bool $cleanup
    *   Whether to delete temporary files and backup files at the end.
    * @return \CRM_Queue_Queue
    */
-  public function fillQueue(CRM_Queue_Queue $queue, array $downloads, bool $upgradeDb = TRUE, bool $cleanup = TRUE): CRM_Queue_Queue {
+  public function fillQueue(CRM_Queue_Queue $queue, array $downloads, bool $autoApply = TRUE, bool $cleanup = TRUE): CRM_Queue_Queue {
     if (empty($downloads)) {
       throw new CRM_Core_Exception("Cannot build download queue. No downloads requested!");
     }
@@ -102,6 +102,7 @@ class CRM_Extension_QueueDownloader {
       'upId' => $this->upId,
       'queue' => $queue->getName(),
       'downloads' => $downloads,
+      'statuses' => CRM_Extension_System::singleton()->getManager()->getStatuses(),
     ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 
     // Download and extract zip files. This is I/O dependent (error-prone), so we do each as a separate (retriable) step.
@@ -133,11 +134,67 @@ class CRM_Extension_QueueDownloader {
       ['weight' => 300]
     );
 
-    if ($upgradeDb) {
-      $queue->createItem(
-        static::subtask(ts('Upgrade database'), 'upgradeDb'),
-        ['weight' => 400]
-      );
+    if ($autoApply) {
+      // We need to figure out the mix of activation-steps (enable/upgrade).
+      // If you have multiple (e.g. enable $X and also upgrade $Y), then... which runs first?
+      // In theory, there is no simple rule of ordering that will work for all imaginable scenarios.
+      // The main mitigating factor is that actual usage will be biased toward simple-cases.
+      // (Ex: The web UI only lets you add one extension at a time. The CLI allows multiple -- but user must explicitly choose each.)
+      // This implementation defers to the user -- applying extensions in the order requested.
+
+      $statuses = CRM_Extension_System::singleton()->getManager()->getStatuses();
+      $todos = [];
+      foreach (array_keys($downloads) as $key) {
+        switch ($statuses[$key] ?? CRM_Extension_Manager::STATUS_UNINSTALLED) {
+          case CRM_Extension_Manager::STATUS_UNINSTALLED:
+            $todos[] = ['enable', $key];
+            break;
+
+          case CRM_Extension_Manager::STATUS_DISABLED:
+          case CRM_Extension_Manager::STATUS_DISABLED_MISSING:
+            $todos[] = ['enable', $key];
+            $todos[] = ['upgrade', $key];
+            break;
+
+          case CRM_Extension_Manager::STATUS_INSTALLED:
+          case CRM_Extension_Manager::STATUS_INSTALLED_MISSING:
+            $todos[] = ['upgrade', $key];
+            break;
+
+          default:
+            throw new \CRM_Extension_Exception('Unknown status: ' . $statuses[$key]);
+        }
+      }
+
+      // Optimization: Combine any adjacent todos of the same type (e.g. "enable A + enable B ==> enable A+B").
+      $nextType = fn() => $todos[0][0];
+      $nextKey = fn() => $todos[0][1];
+      while (!empty($todos)) {
+        $targetType = $nextType();
+
+        $contiguousSegment = [];
+        while (!empty($todos) && $nextType() === $targetType) {
+          $contiguousSegment[] = $nextKey();
+          array_shift($todos);
+        }
+
+        switch ($targetType) {
+          case 'enable':
+            $queue->createItem(
+              static::subtask(ts('Enable %1', [1 => '"' . implode('", "', $contiguousSegment) . '"']), 'enable', [$contiguousSegment]),
+              ['weight' => 400]
+            );
+
+            break;
+
+          case 'upgrade':
+            $queue->createItem(
+              static::subtask(ts('Upgrade database'), 'upgradeDb'),
+              ['weight' => 400]
+            );
+            break;
+        }
+      }
     }
 
     if ($cleanup) {
@@ -265,6 +322,13 @@ class CRM_Extension_QueueDownloader {
   public function subtaskRebuild(CRM_Queue_TaskContext $ctx): void {
     CRM_Core_Invoke::rebuildMenuAndCaches(TRUE, FALSE);
     // FIXME: For 6.1+:, use: Civi::rebuild(['*' => TRUE, 'sessions' => FALSE]);
+  }
+
+  /**
+   * Scan the downloaded extensions and verify that their requirements are satisfied.
+   */
+  public function subtaskEnable(CRM_Queue_TaskContext $ctx, array $keys): void {
+    CRM_Extension_System::singleton()->getManager()->enable($keys);
   }
 
   public function subtaskUpgradeDb(CRM_Queue_TaskContext $ctx): void {

--- a/CRM/Extension/QueueTasks.php
+++ b/CRM/Extension/QueueTasks.php
@@ -1,0 +1,140 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Library of queue-tasks which are useful for extension-management.
+ */
+class CRM_Extension_QueueTasks {
+
+  /**
+   * Download extension ($key) from $url and store it in {$stagingPath}/new/{$key}.
+   */
+  public static function fetch(CRM_Queue_TaskContext $ctx, string $stagingPath, string $key, string $url): bool {
+    $tmpDir = "$stagingPath/tmp";
+    $zipFile = "$stagingPath/fetch/$key.zip";
+    $stageDir = "$stagingPath/new/$key";
+
+    CRM_Utils_File::createDir($tmpDir, 'exception');
+    CRM_Utils_File::createDir(dirname($zipFile), 'exception');
+    CRM_Utils_File::createDir(dirname($stageDir), 'exception');
+
+    if (file_exists($stageDir)) {
+      // In case we're retrying from a prior failure.
+      CRM_Utils_File::cleanDir($stageDir, TRUE, FALSE);
+    }
+
+    $downloader = CRM_Extension_System::singleton()->getDownloader();
+    if (!$downloader->fetch($url, $zipFile)) {
+      throw new CRM_Extension_Exception("Failed to download: $url");
+    }
+
+    $extractedZipPath = $downloader->extractFiles($key, $zipFile, $tmpDir);
+    if (!$extractedZipPath) {
+      throw new CRM_Extension_Exception("Failed to extract: $zipFile");
+    }
+
+    if (!$downloader->validateFiles($key, $extractedZipPath)) {
+      throw new CRM_Extension_Exception("Failed to validate $extractedZipPath. Consult CiviCRM log for details.");
+      // FIXME: Might be nice to show errors immediately, but we've got bigger fish to fry right now.
+    }
+
+    if (!rename($extractedZipPath, $stageDir)) {
+      throw new CRM_Extension_Exception("Failed to rename $extractedZipPath to $stageDir");
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Scan the downloaded extensions and verify that their requirements are satisfied.
+   * This checks requirements as declared in the staging area.
+   */
+  public static function preverify(CRM_Queue_TaskContext $ctx, string $stagingPath, array $keys): bool {
+    $infos = CRM_Extension_System::singleton()->getMapper()->getAllInfos();
+    foreach ($keys as $key) {
+      $infos[$key] = CRM_Extension_Info::loadFromFile("$stagingPath/new/$key/" . CRM_Extension_Info::FILENAME);
+    }
+
+    $errors = CRM_Extension_System::singleton()->getManager()->checkInstallRequirements($keys, $infos);
+    if (!empty($errors)) {
+      Civi::log()->error('Failed to verify requirements for new downloads in {path}', [
+        'path' => $stagingPath,
+        'installKeys' => $keys,
+        'errors' => $errors,
+      ]);
+      throw new CRM_Extension_Exception(implode("\n", [
+        "Failed to verify requirements for new downloads in {$stagingPath}.",
+        ...array_column($errors, 'title'),
+        "Consult CiviCRM log for details.",
+      ]));
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Take the extracted code (`stagingDir/new/{key}`) and put it into its final place.
+   * Move any old code to the backup (`stagingDir/old/{key}`).
+   * Delete the container-cache
+   */
+  public static function swap(CRM_Queue_TaskContext $ctx, string $stagingPath, array $keys): bool {
+    CRM_Utils_File::createDir("$stagingPath/old", 'exception');
+    try {
+      foreach ($keys as $key) {
+        $tmpCodeDir = "$stagingPath/new/$key";
+        $backupCodeDir = "$stagingPath/old/$key";
+
+        CRM_Extension_System::singleton()->getManager()->replace($tmpCodeDir, $backupCodeDir, FALSE);
+        // What happens when you call replace(.., refresh: false)? Varies by type:
+        // - For report/search/payment-extensions, it runs the uninstallation/reinstallation routines.
+        // - For module-extensions, it swaps the folders and clears the class-index.
+
+        // Arguably, for DownloadQueue, we should only clear class-index after all code is swapped,
+        // but it's messier to write that patch, and it's not clear if it's needed.
+      }
+    }
+    finally {
+      // Delete `CachedCiviContainer.*.php`, `CachedExtLoader.*.php`, and similar.
+      $config = CRM_Core_Config::singleton();
+      // $config->cleanup(1);
+      $config->cleanupCaches(FALSE);
+    }
+
+    return TRUE;
+  }
+
+  public static function rebuild(CRM_Queue_TaskContext $ctx): bool {
+    CRM_Core_Invoke::rebuildMenuAndCaches(TRUE, FALSE);
+    // FIXME: For 6.1+:, use: Civi::rebuild(['*' => TRUE, 'sessions' => FALSE]);
+    return TRUE;
+  }
+
+  /**
+   * Scan the downloaded extensions and verify that their requirements are satisfied.
+   */
+  public static function enable(CRM_Queue_TaskContext $ctx, string $stagingPath, array $keys): bool {
+    CRM_Extension_System::singleton()->getManager()->enable($keys);
+    return TRUE;
+  }
+
+  public static function upgradeDb(CRM_Queue_TaskContext $ctx): bool {
+    if (CRM_Extension_Upgrades::hasPending()) {
+      CRM_Extension_Upgrades::fillQueue($ctx->queue);
+    }
+    return TRUE;
+  }
+
+  public static function cleanup(CRM_Queue_TaskContext $ctx, string $stagingPath): bool {
+    CRM_Utils_File::cleanDir($stagingPath, TRUE, FALSE);
+    return TRUE;
+  }
+
+}

--- a/CRM/Extension/QueueTasks.php
+++ b/CRM/Extension/QueueTasks.php
@@ -134,6 +134,11 @@ class CRM_Extension_QueueTasks {
 
   public static function cleanup(CRM_Queue_TaskContext $ctx, string $stagingPath): bool {
     CRM_Utils_File::cleanDir($stagingPath, TRUE, FALSE);
+    $parent = dirname($stagingPath);
+    $siblings = preg_grep('/^\.\.?$/', scandir($parent), PREG_GREP_INVERT);
+    if (empty($siblings)) {
+      rmdir($parent);
+    }
     return TRUE;
   }
 

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -59,8 +59,11 @@ class CRM_Utils_File {
    *
    * @param string $path
    *   The path name.
-   * @param bool $abort
-   *   Should we abort or just return an invalid code.
+   * @param bool|string $abort
+   *   How should we respond to a failure when creating the directory?
+   *   FALSE: Do not abort. Proceed. The return-value indicates outcome.
+   *   TRUE: Abort the process (echo+exit).
+   *   'exception': Throw an ordinary exception.
    * @return bool|NULL
    *   NULL: Folder already exists or was not specified.
    *   TRUE: Creation succeeded.
@@ -73,7 +76,10 @@ class CRM_Utils_File {
 
     CRM_Utils_File::createDir(dirname($path), $abort);
     if (@mkdir($path, 0777) == FALSE) {
-      if ($abort) {
+      if ($abort === 'exception') {
+        throw new CRM_Core_Exception("Failed to create directory: $path");
+      }
+      elseif ($abort) {
         $docLink = CRM_Utils_System::docURL2('Moving an Existing Installation to a New Server or Location', NULL, NULL, NULL, NULL, "wiki");
         echo "Error: Could not create directory: $path.<p>If you have moved an existing CiviCRM installation from one location or server to another there are several steps you will need to follow. They are detailed on this CiviCRM wiki page - {$docLink}. A fix for the specific problem that caused this error message to be displayed is to set the value of the config_backend column in the civicrm_domain table to NULL. However we strongly recommend that you review and follow all the steps in that document.</p>";
 


### PR DESCRIPTION
Overview
---------

When using the "Manage Extensions" UI, it presents the "Add New" tab -- and each extension has an "Install" option:

![Screenshot from 2025-04-07 20-49-41](https://github.com/user-attachments/assets/9bada0b8-e90d-40ab-8a18-cf1c45d310e5)

As you proceed, it clearly says that it will both "Download and install" the extension.

![Screenshot from 2025-04-07 19-04-56](https://github.com/user-attachments/assets/fe2e80bb-a5d7-4f8e-9727-193f022cbbe3)

However, after #32285 was merged for 6.1.alpha, it subtly changed the behavior for "Add New" -- it downloads but does NOT install.

Before + After
--------------

* (CiviCRM 4.x-6.0): "Add New" performs both download and install.
* (CiviCRM 6.1.0): "Add New" only downloads -- it skips installation. The new extension is locally available (but not yet installed).
    
    ![Screenshot from 2025-04-07 20-48-11](https://github.com/user-attachments/assets/7bec6760-e081-424b-b8ea-162840871f4d)

    This means that you must run another "Install".

* (Patch): "Add New" performs both download and install. You see the new extension is live.

    ![Screenshot from 2025-04-07 20-19-54](https://github.com/user-attachments/assets/c42ae9b9-807d-4cb5-8b5d-5da011171a8d)

Comments
----------------------------------------

I noticed this while working on adapting #32285 for use with `cv dl` -- but the `cv` patch isn't ready. Since there is some interdependence, I'd like to keep this in "Draft" for an extra couple days so that it can be tested with contemporaneous updates for `cv dl`.

Also, some of the options/functionality aren't currently offered within civicrm-core's web UI -- but they do have corresponding options in `cv dl`. So testing on `cv dl` gives an opportunity to test this patch.
