### PR TITLE
dev/core#5830 CaseType api (v4) returns empty definition

### DIFF
--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -239,8 +239,8 @@ class FormattingUtil {
         }
       }
       foreach ($result as $key => $value) {
-        // Skip null values or values that have already been unset by `formatOutputValue` functions
-        if (!isset($result[$key])) {
+        // Skip values that have already been unset by `formatOutputValue` functions
+        if (!array_key_exists($key, $result)) {
           continue;
         }
         // Use ??= to only convert each column once

--- a/tests/phpunit/api/v4/Entity/CaseTest.php
+++ b/tests/phpunit/api/v4/Entity/CaseTest.php
@@ -23,6 +23,7 @@ use api\v4\Api4TestBase;
 use Civi\API\Exception\UnauthorizedException;
 use Civi\Api4\Activity;
 use Civi\Api4\CaseActivity;
+use Civi\Api4\CaseType;
 use Civi\Api4\CiviCase;
 use Civi\Api4\Relationship;
 
@@ -112,6 +113,24 @@ class CaseTest extends Api4TestBase {
     $options = array_column($field['options'], 'name');
 
     $this->assertEquals(['Closed', 'Testing'], $options);
+  }
+
+  public function testCaseTypeDefinition(): void {
+    $caseType = $this->createTestRecord('CaseType', [
+      'title' => 'Test Case Type',
+      'name' => 'test_case_type3',
+      'definition' => [
+        'statuses' => ['Testing', 'Closed'],
+      ],
+    ]);
+
+    $caseTypeToTest = CaseType::get(FALSE)
+      ->addSelect('definition')
+      ->addWhere('name', '=', 'test_case_type3')
+      ->execute()
+      ->first();
+    $this->assertArrayHasKey('definition', $caseTypeToTest);
+    $this->assertNotNull($caseTypeToTest['definition']);
   }
 
   public function testCaseActivity(): void {


### PR DESCRIPTION
Overview
----------------------------------------

The CaseType api V4) returns an empty definition.

Reproduction steps
----------------------------------------
1. Go to **Support** > **Developers** > **Api explorer v4**
2. Select as **Entity**: CaseType
3. Select as **Action**: get
4. Select `definition` at the **Add select** dropdown
5. Press execute

Current behaviour
----------------------------------------

The field `definition` is empty

Expected behaviour
----------------------------------------

The field `definition` contains the case type definition.

Environment information
----------------------------------------

<!-- Some of the items below may not be relevant for every bug - if in doubt please include more information than you think is neccessary. -->


* __CiviCRM:__ Standalone 6.1.0_ 
* __PHP:__ _8.3_

Comments
----------------------------------------

The api v3 does return a definition. 

See as well: https://lab.civicrm.org/dev/core/-/issues/5830
