### PR TITLE
dev#issues/5831 : EntityReference Custom field in export causes DB error : data too long

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -1448,7 +1448,7 @@ class CRM_Export_BAO_ExportProcessor {
       switch ($type) {
         case CRM_Utils_Type::T_INT:
         case CRM_Utils_Type::T_BOOLEAN:
-          if (in_array($fieldSpec['data_type'] ?? NULL, ['Country', 'StateProvince', 'ContactReference'])) {
+          if (in_array($fieldSpec['data_type'] ?? NULL, ['Country', 'StateProvince', 'ContactReference', 'EntityReference'])) {
             return "`$fieldName` text";
           }
           // some of those will be exported as a (localisable) string


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate :

1. Create a EntityReference custom field used for contact. Choose entity- organization
2. Create a organization with long name say 'Northwestern University School of Medicine Program in xyxyxyxyxyxxyyxyxyxyxyxyx'
3. Save the entityreference custom field against any individual contact.
4. Then search and export the custom field.


Before
----------------------------------------
![event2](https://github.com/user-attachments/assets/872ed831-f799-4a02-b831-98e41ef307f8)


After
----------------------------------------
Fixed

Technical Details
----------------------------------------
Extending https://lab.civicrm.org/dev/core/-/commit/a6349d3669da13729ac0aee6dfe8ae192ab67034

Comments
----------------------------------------
ping @colemanw @eileenmcnaughton 