### PR TITLE
Unhide legacydedupefinder so that it can be disabled

### DIFF
--- a/ext/legacydedupefinder/info.xml
+++ b/ext/legacydedupefinder/info.xml
@@ -20,10 +20,7 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
-  <tags>
-    <tag>mgmt:hidden</tag>
-  </tags>
-  <comments>This adds backwards compatibility for dedupe hooks. If you do not need them you can improve dedupe performance by disabling this</comments>
+  <comments>Adds backwards compatibility for dedupe hooks. If you do not need them, you can improve dedupe performance by disabling this extension.</comments>
   <mixins>
     <mixin>scan-classes@1.0.0</mixin>
   </mixins>


### PR DESCRIPTION
Overview
----------------------------------------

Unhides the Legacy Dedupe Finder core extension, so that it can be disabled.

Before
----------------------------------------

Extension cannot easily be disabled.

After
----------------------------------------

Yes.

Comments
----------------------------------------

I encountered this bug during Contact import on a site running CiviCRM 6.1, and then 6.2 RC:

> Uncaught TypeError: uksort(): Argument #2 ($callback) must be a valid callback, class Civi\LegacyFinder\Finder does not have a method "isTableBigger" in  vendor/civicrm/civicrm-core/ext/legacydedupefinder/Civi/LegacyFinder/Finder.php:327"

I could not reproduce it on smaster, even with legacydedupefinder enabled (at least, I think it was enabled?). So I ended up disabling the extension on my local site, and that seems to have helped.

cc @eileenmcnaughton 