### PR TITLE
dev/core#5830 Fix Unit Test for CaseType api (v4) returns empty definition

### DIFF
--- a/tests/phpunit/api/v4/Entity/CaseTest.php
+++ b/tests/phpunit/api/v4/Entity/CaseTest.php
@@ -116,17 +116,9 @@ class CaseTest extends Api4TestBase {
   }
 
   public function testCaseTypeDefinition(): void {
-    $caseType = $this->createTestRecord('CaseType', [
-      'title' => 'Test Case Type',
-      'name' => 'test_case_type3',
-      'definition' => [
-        'statuses' => ['Testing', 'Closed'],
-      ],
-    ]);
-
     $caseTypeToTest = CaseType::get(FALSE)
       ->addSelect('definition')
-      ->addWhere('name', '=', 'test_case_type3')
+      ->addWhere('name', '=', 'housing_support')
       ->execute()
       ->first();
     $this->assertArrayHasKey('definition', $caseTypeToTest);


### PR DESCRIPTION
Overview
----------------------------------------

This is a follow up PR fixing the unit test in #32592 which got merged before I fixed the unit test.

The unit test would never fail this new one fails without the patch from (#32592) and with the patch of #32592 it succeeds.

The reason was the way how the test case type was created. Inspecting it further we could the standard case type housing support.