### PR TITLE
Make PriceSetEntity entity_table work with searchkit/formbuilder

### DIFF
--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1513,4 +1513,24 @@ WHERE     ct.id = cp.financial_type_id AND
     }
   }
 
+  /**
+   * Whitelist of possible values for the entity_table field in PriceSetEntity
+   *
+   * @return array
+   */
+  public static function entityTables(): array {
+    return [
+      [
+        'id' => 'civicrm_contribution_page',
+        'name' => 'ContributionPage',
+        'label' => ts('Contribution Page'),
+      ],
+      [
+        'id' => 'civicrm_event',
+        'name' => 'Event',
+        'label' => ts('Event'),
+      ],
+    ];
+  }
+
 }

--- a/schema/Price/PriceSetEntity.entityType.php
+++ b/schema/Price/PriceSetEntity.entityType.php
@@ -35,10 +35,13 @@ return [
     'entity_table' => [
       'title' => ts('Entity Table'),
       'sql_type' => 'varchar(64)',
-      'input_type' => 'Text',
+      'input_type' => 'Select',
       'required' => TRUE,
       'description' => ts('Table which uses this price set'),
       'add' => '1.8',
+      'pseudoconstant' => [
+        'callback' => ['CRM_Price_BAO_PriceSet', 'entityTables'],
+      ],
     ],
     'entity_id' => [
       'title' => ts('Entity ID'),


### PR DESCRIPTION
Overview
----------------------------------------
Update metadata to match other Entities that implement the `entity_table`/`entity_id` dynamic foreign key.

Before
----------------------------------------
Does not work when exposed to searchkit/formbuilder.

After
----------------------------------------
Works.

Technical Details
----------------------------------------
Change from `Text` to `Select` and add a mapping table function.

Comments
----------------------------------------
There are a few of these "mapping table functions" and most of them can't be overridden. It would be good to introduce a hook or similar to do that at some point but that can be done later.
