### PR TITLE
dev/core#5837 FormBuilder add context information when generating a link to the form

### DIFF
--- a/ext/afform/core/Civi/Afform/Tokens.php
+++ b/ext/afform/core/Civi/Afform/Tokens.php
@@ -14,6 +14,7 @@ namespace Civi\Afform;
 use Civi\Core\Event\GenericHookEvent;
 use Civi\Core\Service\AutoService;
 use Civi\Crypto\Exception\CryptoException;
+use Civi\Token\TokenRow;
 use CRM_Afform_ExtensionUtil as E;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -100,7 +101,7 @@ class Tokens extends AutoService implements EventSubscriberInterface {
             if (empty($row->context['contactId'])) {
               continue;
             }
-            $url = self::createUrl($afform, $row->context['contactId']);
+            $url = self::createUrl($afform, $row->context['contactId'], self::getAfformArgsFromTokenContext($row));
             $row->format('text/plain')->tokens(static::$prefix, $afform['name'] . 'Url', $url);
             $row->format('text/html')->tokens(static::$prefix, $afform['name'] . 'Link', sprintf('<a href="%s">%s</a>', htmlentities($url), htmlentities($afform['title'] ?? $afform['name'])));
           }
@@ -183,11 +184,13 @@ class Tokens extends AutoService implements EventSubscriberInterface {
    *
    * @param array $afform
    * @param int $contactId
+   * @param array $afformArgs
+   *   Additional Args for the Afform. E.g. as case_id.
    *
    * @return string
    * @throws \Civi\Crypto\Exception\CryptoException
    */
-  public static function createUrl($afform, $contactId): string {
+  public static function createUrl($afform, $contactId, array $afformArgs = []): string {
     $expires = \CRM_Utils_Time::time() +
       (\Civi::settings()->get('checksum_timeout') * 24 * 60 * 60);
 
@@ -204,8 +207,28 @@ class Tokens extends AutoService implements EventSubscriberInterface {
       'sub' => "cid:" . $contactId,
       'scope' => static::$jwtScope,
       'afform' => $afform['name'],
+      'afformArgs' => $afformArgs,
     ]);
     return $url->addQuery(['_aff' => $bearerToken]);
+  }
+
+  /**
+   * Get Additional args from the row context.
+   *
+   * This supports args for the contact being viewed and for the case being viewed.
+   *
+   * @param \Civi\Token\TokenRow $row
+   * @return array
+   */
+  private static function getAfformArgsFromTokenContext(TokenRow $row): array {
+    $afformArgs = [];
+    if (!empty($row->context['contactId'])) {
+      $afformArgs['contact_id'] = $row->context['contactId'];
+    }
+    if (!empty($row->context['caseId'])) {
+      $afformArgs['case_id'] = $row->context['caseId'];
+    }
+    return $afformArgs;
   }
 
 }

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -85,6 +85,22 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     if (empty($this->_afform['submit_currently_open'])) {
       throw new UnauthorizedException(E::ts('This form is not currently open for submissions.'), ['show_detailed_error' => TRUE]);
     }
+
+    // Set args based on extra data in authx bearer token. E.g. a link to the form could contain a case id when the link
+    // is send by email from the manage case screen.
+    $session = \CRM_Core_Session::singleton();
+    $authx = $session->get('authx');
+    if ($authx && isset($authx['jwt']['afformArgs'])) {
+      // It could be that afformArgs is stdClass
+      // so this way we convert it to an array.
+      $afformOptions = json_decode(json_encode($authx['jwt']['afformArgs']), TRUE);
+      if (is_array($afformOptions)) {
+        foreach ($afformOptions as $afformOption => $afformOptionValue) {
+          $this->args[$afformOption] = $afformOptionValue;
+        }
+      }
+    }
+
     $this->_formDataModel = new FormDataModel($this->_afform['layout']);
     $this->loadEntities();
     $result->exchangeArray($this->processForm());


### PR DESCRIPTION
Overview
----------------------------------------

When a link is geneated to the form in form builder (with the token functionality). Then add context information to the `Bearer`  token. 

The use case is for sending out emails from civicase with a link about a form to fill in information which ends up on the civicase.

E.g. an evaluation form to all persons with a role on the case. 


Before
----------------------------------------

No information about the context where the token came from. 

After
----------------------------------------

The `Bearer`  token holds information about the CiviCase (and potentially for other entities as well). 

Technical Details
----------------------------------------

Adds `afformArgs` to the *jwt bearer token*. 

See https://lab.civicrm.org/dev/core/-/issues/5837
