### PR TITLE
dev/core#5838 Formbuilder autofill case

### DIFF
--- a/ext/civi_case/Civi/Afform/Behavior/CaseAutofill.php
+++ b/ext/civi_case/Civi/Afform/Behavior/CaseAutofill.php
@@ -1,0 +1,66 @@
+<?php
+namespace Civi\Afform\Behavior;
+
+use Civi\Afform\AbstractBehavior;
+use Civi\Afform\Event\AfformPrefillEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use CRM_Case_ExtensionUtil as E;
+
+/**
+ * @service
+ * @internal
+ */
+class CaseAutofill extends AbstractBehavior implements EventSubscriberInterface {
+
+  /**
+   * @return array
+   */
+  public static function getSubscribedEvents() {
+    return [
+      'civi.afform.prefill' => ['onAfformPrefill', 99],
+    ];
+  }
+
+  public static function getEntities():array {
+    return ['Case'];
+  }
+
+  public static function getTitle():string {
+    return E::ts('Autofill');
+  }
+
+  public static function getDescription():string {
+    return E::ts('Automatically identify this case based on the case being viewed when this form is placed on the case summary screen or when email with the link to the form is send from the Case.');
+  }
+
+  public static function getModes(string $type):array {
+    $modes = [];
+    if ($type == 'Case') {
+      $modes[] = [
+        'name' => 'entity_id',
+        'label' => E::ts('Case being Viewed'),
+        'description' => E::ts('For use on the case summary page'),
+        'icon' => 'fa-folder-open',
+      ];
+    }
+    return $modes;
+  }
+
+  public static function onAfformPrefill(AfformPrefillEvent $event): void {
+    /* @var \Civi\Api4\Action\Afform\Prefill $apiRequest */
+    $apiRequest = $event->getApiRequest();
+    if ($event->getEntityType() == 'Case') {
+      $entity = $event->getEntity();
+      $id = $event->getEntityId();
+      $autoFillMode = $entity['case-autofill'] ?? '';
+      // Autofill with current entity (e.g. on the case summary screen)
+      if (!$id && $autoFillMode === 'entity_id' && $apiRequest->getFillMode() === 'form') {
+        $id = $apiRequest->getArgs()['case_id'] ?? NULL;
+        if ($id) {
+          $apiRequest->loadEntity($entity, [['id' => $id]]);
+        }
+      }
+    }
+  }
+
+}

--- a/ext/civi_case/civi_case.php
+++ b/ext/civi_case/civi_case.php
@@ -4,6 +4,24 @@ require_once 'civi_case.civix.php';
 use CRM_Case_ExtensionUtil as E;
 
 /**
+ * Implements hook_civicrm_scanClasses().
+ */
+function civi_case_civicrm_scanClasses(array &$classes) {
+  /**
+   * CiviCase is a CiviCRM Component. Which means it is loaded
+   * before the afform extension is enabled.
+   * And if afform is not enabled the classes under Civi\Afform\ will give a fatal error
+   * because their parent class could not be found (yet).
+   *
+   * The code below checks whether the Afform is enabled and if not it will the skip the classes under the
+   * Civi\Afform namespace.
+   */
+  $extMap = CRM_Extension_System::singleton()->getMapper();
+  $excludeRegex = $extMap->isActiveModule('afform') ? NULL : '/Afform/';
+  \Civi\Core\ClassScanner::scanFolders($classes, __DIR__ . '/', 'Civi', '\\', $excludeRegex);
+}
+
+/**
  * Implements hook_civicrm_managed().
  */
 function civi_case_civicrm_managed(&$entities, $modules) {

--- a/ext/civi_case/info.xml
+++ b/ext/civi_case/info.xml
@@ -29,7 +29,6 @@
   </classloader>
   <mixins>
     <mixin>ang-php@1.0.0</mixin>
-    <mixin>scan-classes@1.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
   </mixins>
   <civix>


### PR DESCRIPTION
Overview
----------------------------------------

It is not possible to autofil a Case on a form builder based on the case being viewed.

There are two use cases when this could be useful:
- When the form is shown on the manage case screen
- When a person (anonymous user) receives a link to the form by email which is send from the manage case screen (this is possible with PR #32599)

Before
----------------------------------------

Not possible to load a case based the case being viewed

After
----------------------------------------

Autofil the case. 

![2025-04-11_17-44](https://github.com/user-attachments/assets/b52a343c-e9f3-4b08-9b05-7fb139f93918)
