### PR TITLE
don't emit error on wordpress if using symlinked web dir

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -122,7 +122,17 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
         elseif ($oldExists && $newExists) {
           // situation ambiguous. encourage admin to set value explicitly.
           if (!isset($GLOBALS['civicrm_paths']['civicrm.files'])) {
-            \Civi::log()->warning("The system has data from both old+new conventions. Please use civicrm.settings.php to set civicrm.files explicitly.");
+            // Let's ensure these are different paths before issuing a warning.
+            // Because WordPress uses __DIR__ to calculate paths, symlinks get
+            // resolved with the new path, but not the old path. Replace
+            // backslash with forward slash (in case we are on Windows) and
+            // remove trailing slashes to normalize each path.
+            $oldNormalizedPath = rtrim(str_replace('\\', '/', realpath($old['path'])), '/');
+            $newNormalizedPath = rtrim(str_replace('\\', '/', $new['path']), '/');
+            if ($oldNormalizedPath != $newNormalizedPath) {
+              // If these paths really are different, display a warning.
+              \Civi::log()->warning("The system has data from both old+new conventions. Please use civicrm.settings.php to set civicrm.files explicitly.");
+            }
           }
           return $new;
         }


### PR DESCRIPTION
Overview
----------------------------------------

If WordPress is installed in a web directory that has a symlink, CiviCRM gives a spurious warning about files being set with both new and old settings, when in fact it's ultimately the same directory being used.

Before
----------------------------------------
CiviCRM reports: [warning] The system has data from both
old+new conventions. Please use civicrm.settings.php to set
civicrm.files explicitly.

After
----------------------------------------

When resolving symlinks on the new directory and then comparing the old and new, we can see if they are the same and skip the warning.


Comments
----------------------------------------

This fixes an admittedly small corner case, so I'm honestly not sure it warrants this fix.  Also, would love to get feedback and confirmation that it works from @MegaphoneJon 

