### PR TITLE
Ext - Move new upgrade functions to SchemaHelper

### DIFF
--- a/CRM/Extension/Upgrader/SchemaTrait.php
+++ b/CRM/Extension/Upgrader/SchemaTrait.php
@@ -72,48 +72,4 @@ trait CRM_Extension_Upgrader_SchemaTrait {
     return TRUE;
   }
 
-  /**
-   * Create table (if not exists) from a given php schema file.
-   *
-   * The original entityType.php file should be copied to a directory (e.g. `my_extension/upgrade/schema`)
-   * and prefixed with the version-added.
-   *
-   * @param string $filePath
-   *   Relative path to copied schema file (relative to extension directory).
-   * @return bool
-   * @throws CRM_Core_Exception
-   */
-  public function createEntityTable(string $filePath): bool {
-    $absolutePath = $this->getExtensionDir() . DIRECTORY_SEPARATOR . $filePath;
-    $entityDefn = include $absolutePath;
-    $schemaHelper = Civi::schemaHelper($this->getExtensionKey());
-    $sql = $schemaHelper->arrayToSql($entityDefn);
-    CRM_Core_DAO::executeQuery($sql, [], TRUE, NULL, FALSE, FALSE);
-    return TRUE;
-  }
-
-  /**
-   * Task to add or change a column definition, based on the php schema spec.
-   *
-   * @param string $entityName
-   * @param string $fieldName
-   * @param array $fieldSpec
-   *   As definied in the .entityType.php file for $entityName
-   * @return bool
-   * @throws CRM_Core_Exception
-   */
-  public function alterSchemaField(string $entityName, string $fieldName, array $fieldSpec): bool {
-    $tableName = Civi::entity($entityName)->getMeta('table');
-    $schemaHelper = Civi::schemaHelper($this->getExtensionKey());
-    $fieldSql = $schemaHelper->arrayToSql($fieldSpec);
-    if (CRM_Core_BAO_SchemaHandler::checkIfFieldExists($tableName, $fieldName, FALSE)) {
-      $query = "ALTER TABLE `$tableName` CHANGE `$fieldName` `$fieldName` $fieldSql";
-      CRM_Core_DAO::executeQuery($query, [], TRUE, NULL, FALSE, FALSE);
-      return TRUE;
-    }
-    else {
-      return self::addColumn($tableName, $fieldName, $fieldSql);
-    }
-  }
-
 }

--- a/mixin/lib/civimix-schema@5/src/SchemaHelper.php
+++ b/mixin/lib/civimix-schema@5/src/SchemaHelper.php
@@ -64,15 +64,47 @@ return new class() implements SchemaHelperInterface {
     }
   }
 
-  // FIXME: You can add more utility methods here
+  /**
+   * Create table (if not exists) from a given php schema file.
+   *
+   * The original entityType.php file should be copied to a directory (e.g. `my_extension/upgrade/schema`)
+   * and prefixed with the version-added.
+   *
+   * @param string $filePath
+   *   Relative path to copied schema file (relative to extension directory).
+   * @return bool
+   * @throws \CRM_Core_Exception
+   */
+  public function createEntityTable(string $filePath): bool {
+    $absolutePath = $this->getExtensionDir() . DIRECTORY_SEPARATOR . $filePath;
+    $entityDefn = include $absolutePath;
+    $sql = $this->arrayToSql($entityDefn);
+    \CRM_Core_DAO::executeQuery($sql, [], TRUE, NULL, FALSE, FALSE);
+    return TRUE;
+  }
 
-  // public function addTables(array $names): void {
-  //   throw new \RuntimeException("TODO: Install a single tables");
-  // }
-  //
-  // public function addColumn(string $table, string $column): void {
-  //   throw new \RuntimeException("TODO: Install a single tables");
-  // }
+  /**
+   * Task to add or change a column definition, based on the php schema spec.
+   *
+   * @param string $entityName
+   * @param string $fieldName
+   * @param array $fieldSpec
+   *   As definied in the .entityType.php file for $entityName
+   * @return bool
+   * @throws \CRM_Core_Exception
+   */
+  public function alterSchemaField(string $entityName, string $fieldName, array $fieldSpec): bool {
+    $tableName = \Civi::entity($entityName)->getMeta('table');
+    $fieldSql = $this->arrayToSql($fieldSpec);
+    if (\CRM_Core_BAO_SchemaHandler::checkIfFieldExists($tableName, $fieldName, FALSE)) {
+      $query = "ALTER TABLE `$tableName` CHANGE `$fieldName` `$fieldName` $fieldSql";
+    }
+    else {
+      $query = "ALTER TABLE `$tableName` ADD COLUMN `$fieldName` $fieldSql";
+    }
+    \CRM_Core_DAO::executeQuery($query, [], TRUE, NULL, FALSE, FALSE);
+    return TRUE;
+  }
 
   /**
    * @param array $sqls


### PR DESCRIPTION
Overview
----------------------------------------
Followup from [#32597](https://github.com/civicrm/civicrm-core/pull/32597), this moves new functions to a better location.

Technical Details
-------------
These are new, as-yet-unreleased functions.
They were added to SchemaTrait but that class is now deprecated, so moving them to SchemHelper.

This means they can be backported by civix into extensions targeting older versions of Civi.