### PR TITLE
RiverLea: fixes inline checkbox regression

### DIFF
--- a/ext/riverlea/core/css/components/_front.css
+++ b/ext/riverlea/core/css/components/_front.css
@@ -133,7 +133,6 @@ af-form > fieldset > legend {
 }
 .crm-container.crm-public input[type="checkbox"] {
   margin: var(--crm-s2) var(--crm-s3) 0 0;
-  float: left;
   min-width: auto;
 }
 .crm-container.crm-public .crm-checkbox-list input[type="checkbox"] {


### PR DESCRIPTION
Port of @yashodha's fix: https://lab.civicrm.org/extensions/riverlea/-/merge_requests/51.

Overview
----------------------------------------
It appears some CSS from before the flexbox changes in May 2024 (#30162) remained in RiverLea, but causes the regression found by @yashodha in https://lab.civicrm.org/extensions/riverlea/-/issues/127.

Before
----------------------------------------
<img width="645" alt="image" src="https://github.com/user-attachments/assets/00b0a240-ff2c-4dd6-89c7-49b3a94df44a" />

After
----------------------------------------
<img width="642" alt="image" src="https://github.com/user-attachments/assets/6ba18e7b-2722-47ac-8bed-c4210054a180" />

Technical Details
----------------------------------------
This fixes RiverLea core so doesn't need testing across Streams: all will have the regression, all will be fixed with this.