### PR TITLE
Alternate to 32595 - fix for legacydedupefinder

### DIFF
--- a/ext/legacydedupefinder/Civi/LegacyFinder/Finder.php
+++ b/ext/legacydedupefinder/Civi/LegacyFinder/Finder.php
@@ -327,4 +327,23 @@ class Finder extends AutoSubscriber {
     uksort($tableQueries, [__CLASS__, 'isTableBigger']);
   }
 
+  /**
+   * Is the table extracted from the first string larger than the second string.
+   *
+   * @param array $a
+   *   e.g civicrm_contact.first_name
+   * @param array $b
+   *   e.g civicrm_address.street_address
+   *
+   * @return int
+   */
+  public static function isTableBigger(array $a, array $b): int {
+    $tableA = $a['table'];
+    $tableB = $b['table'];
+    if ($tableA === $tableB) {
+      return 0;
+    }
+    return \CRM_Core_BAO_SchemaHandler::getRowCountForTable($tableA) <=> \CRM_Core_BAO_SchemaHandler::getRowCountForTable($tableB);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Errors about isTableBigger.

Before
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/32595

After
----------------------------------------
Extension still hidden, but not crash.

Technical Details
----------------------------------------
I don't know if the work on legacydedupefinder is finished - from its README you still need it if you have code or extensions that implement some hooks, so disabling it might not be good on those sites.

Comments
----------------------------------------

