### PR TITLE
Migrate HookInterface references from class_alias

### DIFF
--- a/Civi/Test/HookInterface.php
+++ b/Civi/Test/HookInterface.php
@@ -3,4 +3,7 @@
 // The interface `Civi\Test\HookInterface` was originally written for use in unit-tests.
 // It got promoted for use in more cases, but then the name became misleading.
 // Leave behind alias for backward compatibility.
+/**
+ * @deprecated use Civi\Core\HookInterface instead.
+ */
 class_alias('Civi\Core\HookInterface', 'Civi\Test\HookInterface');

--- a/Civi/Test/Legacy/CiviTestListener.php
+++ b/Civi/Test/Legacy/CiviTestListener.php
@@ -82,7 +82,7 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
       $this->tx->rollback()->commit();
       $this->tx = NULL;
     }
-    if ($test instanceof \Civi\Test\HookInterface) {
+    if ($test instanceof \Civi\Core\HookInterface) {
       \CRM_Utils_Hook::singleton()->reset();
     }
     \CRM_Utils_Time::resetTime();
@@ -129,7 +129,7 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
    * @return bool
    */
   protected function isCiviTest(\PHPUnit_Framework_Test $test) {
-    return $test instanceof \Civi\Test\HookInterface || $test instanceof \Civi\Test\HeadlessInterface;
+    return $test instanceof \Civi\Core\HookInterface || $test instanceof \Civi\Test\HeadlessInterface;
   }
 
   /**

--- a/ext/civi_contribute/tests/phpunit/Civi/Entity/ContributionRecurTest.php
+++ b/ext/civi_contribute/tests/phpunit/Civi/Entity/ContributionRecurTest.php
@@ -7,7 +7,7 @@ use Civi\Test;
 use Civi\Test\EntityTrait;
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 use PHPUnit\Framework\TestCase;
 

--- a/ext/civi_report/tests/phpunit/ReportInstanceTest.php
+++ b/ext/civi_report/tests/phpunit/ReportInstanceTest.php
@@ -9,7 +9,7 @@ use Civi\Api4\ReportInstance;
 use Civi\Test;
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 use CRM_Core_Config;
 use PHPUnit\Framework\TestCase;

--- a/ext/civi_report/tests/phpunit/ReportTest.php
+++ b/ext/civi_report/tests/phpunit/ReportTest.php
@@ -5,7 +5,7 @@ declare(strict_types = 1);
 use Civi\Test;
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 use PHPUnit\Framework\TestCase;
 

--- a/ext/civiimport/tests/phpunit/CiviApiImportTest.php
+++ b/ext/civiimport/tests/phpunit/CiviApiImportTest.php
@@ -3,7 +3,7 @@
 use Civi\Api4\Import;
 use Civi\Api4\UserJob;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\CiviEnvBuilder;
 use PHPUnit\Framework\TestCase;
 

--- a/ext/contributioncancelactions/tests/phpunit/CancelTest.php
+++ b/ext/contributioncancelactions/tests/phpunit/CancelTest.php
@@ -6,7 +6,7 @@ use Civi\Test\Api3TestTrait;
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\FormTrait;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 use Civi\Api4\Contact;
 use Civi\Api4\MembershipType;

--- a/ext/elavon/tests/phpunit/CRM/Core/Payment/ElavonTest.php
+++ b/ext/elavon/tests/phpunit/CRM/Core/Payment/ElavonTest.php
@@ -2,7 +2,7 @@
 
 use CRM_Elavon_ExtensionUtil as E;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 use Civi\Test\CiviEnvBuilder;
 

--- a/ext/ewaysingle/tests/phpunit/CRM/Core/Payment/EwayTest.php
+++ b/ext/ewaysingle/tests/phpunit/CRM/Core/Payment/EwayTest.php
@@ -2,7 +2,7 @@
 
 use CRM_Ewaysingle_ExtensionUtil as E;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 
 /**
  * FIXME - Add test description.

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/BaseTestClass.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/BaseTestClass.php
@@ -11,7 +11,7 @@ use Civi\Api4\Product;
 use Civi\Test;
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\ContactTestTrait;
 use Civi\Test\Api3TestTrait;
 use PHPUnit\Framework\TestCase;

--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ClickTrackerTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ClickTrackerTest.php
@@ -2,7 +2,7 @@
 namespace Civi\FlexMailer;
 
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 use Civi\FlexMailer\ClickTracker\TextClickTracker;

--- a/ext/legacycustomsearches/tests/phpunit/CRM/Core/InnoDBIndexerTest.php
+++ b/ext/legacycustomsearches/tests/phpunit/CRM/Core/InnoDBIndexerTest.php
@@ -2,7 +2,7 @@
 
 use Civi\Test;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/ext/legacycustomsearches/tests/phpunit/CRM/Utils/QueryFormatterTest.php
+++ b/ext/legacycustomsearches/tests/phpunit/CRM/Utils/QueryFormatterTest.php
@@ -2,7 +2,7 @@
 
 use Civi\Test;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/ext/legacycustomsearches/tests/phpunit/Civi/Searches/FullTextTest.php
+++ b/ext/legacycustomsearches/tests/phpunit/Civi/Searches/FullTextTest.php
@@ -4,7 +4,7 @@ namespace Civi\Searches;
 
 use Civi\Test;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 use CRM_Contact_Form_Search_Custom_FullText;
 use CRM_Core_Config;

--- a/ext/legacycustomsearches/tests/phpunit/Civi/Searches/GroupTest.php
+++ b/ext/legacycustomsearches/tests/phpunit/Civi/Searches/GroupTest.php
@@ -31,7 +31,7 @@ namespace Civi\Searches;
 
 use Civi\Test;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 use CRM_Core_DAO;
 use PHPUnit\Framework\TestCase;

--- a/ext/legacycustomsearches/tests/phpunit/Civi/Searches/PriceSetTest.php
+++ b/ext/legacycustomsearches/tests/phpunit/Civi/Searches/PriceSetTest.php
@@ -32,7 +32,7 @@ use Civi\Test\Api3TestTrait;
 use Civi\Test\ContactTestTrait;
 use Civi\Test\EventTestTrait;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 use PHPUnit\Framework\TestCase;
 

--- a/ext/legacycustomsearches/tests/phpunit/Civi/Searches/SampleTest.php
+++ b/ext/legacycustomsearches/tests/phpunit/Civi/Searches/SampleTest.php
@@ -6,7 +6,7 @@ use Civi\Api4\Address;
 use Civi\Api4\Contact;
 use Civi\Test;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 use Civi\Api4\SavedSearch;
 use Civi\Api4\OptionValue;

--- a/ext/legacydedupefinder/tests/phpunit/Civi/LegacyFinderTest.php
+++ b/ext/legacydedupefinder/tests/phpunit/Civi/LegacyFinderTest.php
@@ -7,7 +7,7 @@ use Civi\Api4\Group;
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\EntityTrait;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 
 /**
  * FIXME - Add test description.

--- a/ext/oauth-client/tests/phpunit/CRM/OAuth/MailSetupTest.php
+++ b/ext/oauth-client/tests/phpunit/CRM/OAuth/MailSetupTest.php
@@ -2,7 +2,7 @@
 
 use CRM_OAuth_ExtensionUtil as E;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**

--- a/ext/oauth-client/tests/phpunit/Civi/OAuth/AuthCodeFlowTest.php
+++ b/ext/oauth-client/tests/phpunit/Civi/OAuth/AuthCodeFlowTest.php
@@ -3,7 +3,7 @@
 namespace Civi\OAuth;
 
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**

--- a/ext/oauth-client/tests/phpunit/Civi/OAuth/CiviGenericProviderTest.php
+++ b/ext/oauth-client/tests/phpunit/Civi/OAuth/CiviGenericProviderTest.php
@@ -3,7 +3,7 @@
 namespace Civi\OAuth;
 
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthClientGrantTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthClientGrantTest.php
@@ -2,7 +2,7 @@
 
 use CRM_OAuth_ExtensionUtil as E;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthClientTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthClientTest.php
@@ -2,7 +2,7 @@
 
 use CRM_OAuth_ExtensionUtil as E;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthContactTokenTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthContactTokenTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthProviderTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 use CRM_OAuth_ExtensionUtil as E;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthSessionTokenTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthSessionTokenTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthSysTokenTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthSysTokenTest.php
@@ -2,7 +2,7 @@
 
 use CRM_OAuth_ExtensionUtil as E;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**

--- a/ext/oembed/tests/phpunit/CRM/Oembed/Page/OembedDiscoveryTest.php
+++ b/ext/oembed/tests/phpunit/CRM/Oembed/Page/OembedDiscoveryTest.php
@@ -3,7 +3,7 @@
 use CRM_Oembed_ExtensionUtil as E;
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 use Civi\Test\LocalHttpClient;
 use GuzzleHttp\Psr7\Request;

--- a/ext/oembed/tests/phpunit/CRM/Oembed/Page/OembedTest.php
+++ b/ext/oembed/tests/phpunit/CRM/Oembed/Page/OembedTest.php
@@ -3,7 +3,7 @@
 use CRM_Oembed_ExtensionUtil as E;
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 use Civi\Test\LocalHttpClient;
 use GuzzleHttp\Psr7\Request;

--- a/ext/payflowpro/tests/phpunit/CRM/Core/Payment/PayflowProTest.php
+++ b/ext/payflowpro/tests/phpunit/CRM/Core/Payment/PayflowProTest.php
@@ -2,7 +2,7 @@
 
 use CRM_PayflowPro_ExtensionUtil as E;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 
 /**
  * FIXME - Add test description.

--- a/ext/scheduled_communications/tests/phpunit/Civi/ScheduledCommunications/SendTest.php
+++ b/ext/scheduled_communications/tests/phpunit/Civi/ScheduledCommunications/SendTest.php
@@ -5,7 +5,7 @@ use CRM_ScheduledCommunications_ExtensionUtil as E;
 use Civi\Api4\Activity;
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/ManagedSearchTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/ManagedSearchTest.php
@@ -3,7 +3,7 @@ namespace api\v4\SearchDisplay;
 
 use Civi\Api4\SavedSearch;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**

--- a/ext/sequentialcreditnotes/tests/phpunit/SequentialcreditnotesTest.php
+++ b/ext/sequentialcreditnotes/tests/phpunit/SequentialcreditnotesTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**

--- a/tests/events/civi_region_render.evch.php
+++ b/tests/events/civi_region_render.evch.php
@@ -1,5 +1,5 @@
 <?php
-return new class() extends \Civi\Test\EventCheck implements \Civi\Test\HookInterface {
+return new class() extends \Civi\Test\EventCheck implements \Civi\Core\HookInterface {
 
   private $validSnippetTypes = [
     'callback',

--- a/tests/events/hook_civicrm_alterMailParams.evch.php
+++ b/tests/events/hook_civicrm_alterMailParams.evch.php
@@ -1,7 +1,7 @@
 <?php
 
 use Civi\Test\EventCheck;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 
 return new class() extends EventCheck implements HookInterface {
 

--- a/tests/events/hook_civicrm_config.evch.php
+++ b/tests/events/hook_civicrm_config.evch.php
@@ -1,7 +1,7 @@
 <?php
 
 use Civi\Test\EventCheck;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 
 return new class() extends EventCheck implements HookInterface {
 

--- a/tests/events/hook_civicrm_links.evch.php
+++ b/tests/events/hook_civicrm_links.evch.php
@@ -1,7 +1,7 @@
 <?php
 
 use Civi\Test\EventCheck;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 
 return new class() extends EventCheck implements HookInterface {
 

--- a/tests/phpunit/api/v4/Action/AutocompleteTest.php
+++ b/tests/phpunit/api/v4/Action/AutocompleteTest.php
@@ -26,7 +26,7 @@ use Civi\Api4\MockBasicEntity;
 use Civi\Api4\EntitySet;
 use Civi\Api4\SavedSearch;
 use Civi\Core\Event\GenericHookEvent;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**

--- a/tests/phpunit/api/v4/Action/BasicActionsTest.php
+++ b/tests/phpunit/api/v4/Action/BasicActionsTest.php
@@ -24,7 +24,7 @@ use Civi\Api4\MockBasicEntity;
 use Civi\Api4\Utils\CoreUtil;
 use Civi\Core\Event\GenericHookEvent;
 use Civi\Test\CiviEnvBuilder;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\Invasive;
 use Civi\Test\TransactionalInterface;
 

--- a/tests/phpunit/api/v4/Action/GetActionsTest.php
+++ b/tests/phpunit/api/v4/Action/GetActionsTest.php
@@ -22,7 +22,7 @@ namespace api\v4\Action;
 use api\v4\Api4TestBase;
 use Civi\Api4\Membership;
 use Civi\Core\Event\GenericHookEvent;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -33,7 +33,7 @@ use Civi\Core\Event\PostEvent;
 use Civi\Core\Event\PreEvent;
 use Civi\Test;
 use Civi\Test\CiviEnvBuilder;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 
 /**
  * @group headless

--- a/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
+++ b/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
@@ -28,7 +28,7 @@ use Civi\Api4\SavedSearch;
 use Civi\Test;
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 use CRM_Core_ManagedEntities;
 use CRM_Core_Module;


### PR DESCRIPTION
Overview
----------------------------------------
Migrate HookInterface references from class_alias in line with code comments

```
// The interface `Civi\Test\HookInterface` was originally written for use in unit-tests.
// It got promoted for use in more cases, but then the name became misleading.
// Leave behind alias for backward compatibility.

```

Before
----------------------------------------
references to ` \Civi\Test\HookInterface` - ie the class_alias

After
----------------------------------------
references to `\Civi\Core\HookInterface`

Technical Details
----------------------------------------
I also added a deprecation tag - it barely shows up in phpstorm - but per the screenshot here https://youtrack.jetbrains.com/issue/WI-34715/Option-to-mark-a-class-alias-as-deprecated#focus=Comments-27-4710647.0-0 - it is just visible if you squint

Comments
----------------------------------------
