### PR TITLE
SchemaHelper - Tweak compatibility and docblocks

### DIFF
--- a/mixin/lib/civimix-schema@5/src/SchemaHelper.php
+++ b/mixin/lib/civimix-schema@5/src/SchemaHelper.php
@@ -94,7 +94,9 @@ return new class() implements SchemaHelperInterface {
    * @throws \CRM_Core_Exception
    */
   public function alterSchemaField(string $entityName, string $fieldName, array $fieldSpec): bool {
-    $tableName = \Civi::entity($entityName)->getMeta('table');
+    $tableName = method_exists('Civi', 'entity')
+      ? \Civi::entity($entityName)->getMeta('table')
+      : \CRM_Core_DAO_AllCoreTables::getTableForEntityName($entityName);
     $fieldSql = $this->arrayToSql($fieldSpec);
     if (\CRM_Core_BAO_SchemaHandler::checkIfFieldExists($tableName, $fieldName, FALSE)) {
       $query = "ALTER TABLE `$tableName` CHANGE `$fieldName` `$fieldName` $fieldSql";

--- a/mixin/lib/civimix-schema@5/src/SchemaHelperInterface.php
+++ b/mixin/lib/civimix-schema@5/src/SchemaHelperInterface.php
@@ -10,17 +10,22 @@ namespace CiviMix\Schema;
  * newer revisions of the library can be loaded, the implementation is an anonymous-class,
  * and the interface uses soft type-hints.
  *
- * @method bool hasSchema()
+ * [[ CiviCRM 5.74+ / civimix-schema@5.74+ ]]
  *
+ * @method bool hasSchema()
  * @method void install()
  * @method void uninstall()
- *
  * @method string generateInstallSql()
  * @method string generateUninstallSql()
+ *
+ * [[ CiviCRM 5.76+ / civimix-schema@5.76+ ]]
+ *
  * @method string arrayToSql(array $defn) Converts an entity or field definition to SQL statement.
  *
- * TODO: void addTables(string[] $tables)
- * TODO: void addColumn(string $table, string $column)
+ * [[ CiviCRM 6.2+ / civimix-schema@5.85+ ]]
+ *
+ * @method bool createEntityTable(string $filePath)
+ * @method bool alterSchemaField(string $entityName, string $fieldName, array $fieldSpec)
  *
  * To see the latest implementation:
  *


### PR DESCRIPTION
Overview
----------------------------------------

This is a follow-up to @colemanw's #32603.

Technical Details
----------------------------------------

* A small compatibility tweaks  makes it easier to use updated `SchemaHelper` on more versions.
* I added some notes to `SchemaHelperInterface` so that `E::schema()->alt` `TAB` can autocomplete.
* The validity is demonstrated by https://github.com/totten/civix/pull/403. Note how...
    * It adds test-coverage -- wherein it creates a new extension and calls `alterSchemaField()`.
    * The tests run across a range of core versions (5.69, 5.81, 6.1, master)
    * One commit (*based on the current 6.2-HEAD*) has a failing test-run;  the next commit (*with this update*) has a successful test-run.
        
        > <img width="871" alt="Screenshot 2025-04-15 at 11 41 27 PM" src="https://github.com/user-attachments/assets/04f90072-a815-4734-9cfa-c88e2a450d30" />
