### PR TITLE
Standardise implementation of `civicrm/logout` route

### DIFF
--- a/CRM/Core/Page/Logout.php
+++ b/CRM/Core/Page/Logout.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Controller for civicrm/logout route
+ */
+class CRM_Core_Page_Logout extends CRM_Core_Page {
+
+  public function run() {
+    $userSystem = \CRM_Core_Config::singleton()->userSystem;
+
+    if (!$userSystem->isUserLoggedIn()) {
+      throw new \CRM_Core_Exception(ts('You cannot log out because you are not logged in.'));
+    }
+
+    $userSystem->logout();
+
+    $postLogoutUrl = $userSystem->postLogoutUrl();
+    \CRM_Utils_System::redirect($postLogoutUrl);
+  }
+
+}

--- a/CRM/Core/xml/Menu/Misc.xml
+++ b/CRM/Core/xml/Menu/Misc.xml
@@ -57,7 +57,7 @@
      <title>Assign Users to ACL Roles</title>
      <page_callback>CRM_ACL_Form_EntityRole</page_callback>
      <access_arguments>administer CiviCRM,access CiviCRM</access_arguments>
-  </item>>
+  </item>
   <item>
      <path>civicrm/file</path>
      <title>Browse Uploaded files</title>
@@ -73,10 +73,9 @@
   <item>
      <path>civicrm/logout</path>
      <title>Log out</title>
-     <page_callback>CRM_Utils_System::logout</page_callback>
-     <access_arguments>access CiviCRM</access_arguments>
+     <access_arguments>*always allow*</access_arguments>
+     <page_callback>CRM_Core_Page_Logout</page_callback>
      <weight>9999</weight>
-     <page_type>1</page_type>
   </item>
   <item>
     <path>civicrm/i18n</path>

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -521,14 +521,6 @@ AND    u.status = 1
   }
 
   /**
-   * @inheritDoc
-   */
-  public function logout() {
-    module_load_include('inc', 'user', 'user.pages');
-    user_logout();
-  }
-
-  /**
    * Get the default location for CiviCRM blocks.
    *
    * @return string

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -302,12 +302,22 @@ abstract class CRM_Utils_System_Base {
   }
 
   /**
-   * Immediately stop script execution, log out the user and redirect to the home page.
+   * Logout the current user session
    *
-   * @deprecated
-   *   This function should be removed in favor of linking to the CMS's logout page
+   * Alias for _authx_uf()->logoutSession
    */
   public function logout() {
+    _authx_uf()->logoutSession();
+  }
+
+  /**
+   * Url to redirect users to after logging out, in the context of an HTTP session
+   *
+   * @see CRM_Core_Page_Logout
+   * @return string
+   */
+  public function postLogoutUrl(): string {
+    return '/';
   }
 
   /**

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -436,14 +436,6 @@ AND    u.status = 1
   }
 
   /**
-   * @inheritDoc
-   */
-  public function logout() {
-    module_load_include('inc', 'user', 'user.pages');
-    return user_logout();
-  }
-
-  /**
    * Get the default location for CiviCRM blocks.
    *
    * @return string

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -384,14 +384,6 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   }
 
   /**
-   * In previous versions, this function was the controller for logging out. In Drupal 8, we rewrite the route
-   * to hand off logout to the standard Drupal logout controller. This function should therefore never be called.
-   */
-  public function logout() {
-    // Pass
-  }
-
-  /**
    * Load drupal bootstrap.
    *
    * @param array $params

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -530,9 +530,8 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    */
-  public function logout() {
-    session_destroy();
-    CRM_Utils_System::setHttpHeader("Location", "index.php");
+  public function postLogoutUrl(): string {
+    return "/index.php";
   }
 
   /**

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -303,13 +303,10 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
   }
 
   /**
-   * Immediately stop script execution and log out the user
+   * @inheritdoc
    */
-  public function logout() {
-    _authx_uf()->logoutSession();
-    // redirect to the home page?
-    // breaks tests in standaloneusers-e2e
-    // \CRM_Utils_System::redirect('/civicrm/login');
+  public function postLogoutUrl(): string {
+    return '/civicrm/login?justLoggedOut';
   }
 
   /**

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -612,13 +612,8 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    */
-  public function logout() {
-    // destroy session
-    if (session_id()) {
-      session_destroy();
-    }
-    wp_logout();
-    wp_redirect(wp_login_url());
+  public function postLogoutUrl(): string {
+    return wp_login_url();
   }
 
   /**

--- a/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
@@ -32,13 +32,4 @@ class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
     parent::run();
   }
 
-  /**
-   * Log out.
-   */
-  public static function logout() {
-    CRM_Core_Config::singleton()->userSystem->logout();
-    // Dump them back on the log-IN page.
-    CRM_Utils_System::redirect('/civicrm/login?justLoggedOut');
-  }
-
 }

--- a/ext/standaloneusers/xml/Menu/standaloneusers.xml
+++ b/ext/standaloneusers/xml/Menu/standaloneusers.xml
@@ -7,11 +7,6 @@
     <access_arguments>*always allow*</access_arguments>
   </item>
   <item>
-    <path>civicrm/logout</path>
-    <page_callback>CRM_Standaloneusers_Page_Login::logout</page_callback>
-    <access_arguments>*always allow*</access_arguments>
-  </item>
-  <item>
     <path>civicrm/admin/user/password</path>
     <page_callback>CRM_Standaloneusers_Page_ChangePassword</page_callback>
     <title>Change Password</title>


### PR DESCRIPTION
Overview
----------------------------------------
- undeprecate and improve `CRM_Utils_System::logout`
- split out the bundling of HTTP controller from the functional logging out
- hand off to `_authx_uf()->logoutSession` for doing the logout - this is a newer implementation which is available for all UFs
- add `CRM_Core_Page_Logout` as a dedicated controller
- add a secondary function to system util for "where to redirect to after logout"
- remove permission check (which prevents users without access CiviCRM from logging out) and add a guard to check you are logged in
- use all of the above for `civicrm/logout` route in Standalone, rather than reimplementing the wheel

Technical Details
----------------------------------------
The `CRM_Utils_System_Base::logout` function this uses was marked as deprecated 11 years ago https://github.com/civicrm/civicrm-core/commit/17f443df7d2235655cbbfe68bfcf7a13a570b606

It also clashes with [the route declaration in Standaloneusers](https://github.com/civicrm/civicrm-core/blob/3d2c4c2a3c0209fbb61ceaeddfc29aabaf5b6431/ext/standaloneusers/xml/Menu/standaloneusers.xml#L10), which has a different permission, which can cause weird issues when migrating.

It is still used so lets step back the deprecation
