### PR TITLE
Standalone - check logged in before logging out; avoid deprecated System function

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -303,13 +303,10 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
   }
 
   /**
-   * Immediately stop script execution and log out the user
+   * @inheritdoc
    */
   public function logout() {
     _authx_uf()->logoutSession();
-    // redirect to the home page?
-    // breaks tests in standaloneusers-e2e
-    // \CRM_Utils_System::redirect('/civicrm/login');
   }
 
   /**

--- a/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
@@ -36,6 +36,10 @@ class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
    * Log out.
    */
   public static function logout() {
+    if (!self::isUserLoggedIn()) {
+      throw new \CRM_Core_Exception(ts('You cannot log out because you are not logged in.'));
+    }
+
     _authx_uf()->logoutSession();
 
     // Dump them back on the log-IN page.

--- a/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
@@ -36,9 +36,10 @@ class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
    * Log out.
    */
   public static function logout() {
-    CRM_Core_Config::singleton()->userSystem->logout();
+    _authx_uf()->logoutSession();
+
     // Dump them back on the log-IN page.
-    CRM_Utils_System::redirect('/civicrm/login?justLoggedOut');
+    \CRM_Utils_System::redirect('/civicrm/login?justLoggedOut');
   }
 
 }


### PR DESCRIPTION
Before
----------------------------------------
- Logout route ( `civicrm/logout` ) uses a deprecated function on `CRM_Utils_System_Standalone`
- You can log out when you aren't logged in

After
----------------------------------------
- Logout route ( `civicrm/logout` ) avoids deprecated function 
- Trying to log out when you aren't logged in gives an error
