### PR TITLE
Fix 6.1 regression, type error on invalid fields

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -196,31 +196,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
   }
 
   /**
-   * Override parent to cope with params being separated by entity already.
-   *
-   * @todo - make this the parent method...
-   *
-   * @param array $params
-   *
-   * @throws \CRM_Core_Exception
-   */
-  protected function validateParams(array $params): void {
-
-    if (empty($params['Contribution']['id'])) {
-      $this->validateRequiredFields($this->getRequiredFields(), $params['Contribution']);
-    }
-    $errors = [];
-    foreach ($params as $entity => $values) {
-      foreach ($values as $key => $value) {
-        $errors = array_merge($this->getInvalidValues($value, $key), $errors);
-      }
-    }
-    if ($errors) {
-      throw new CRM_Core_Exception('Invalid value for field(s) : ' . implode(',', $errors));
-    }
-  }
-
-  /**
    * The initializer code, called before the processing
    */
   public function init() {

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1076,6 +1076,11 @@ abstract class CRM_Import_Parser implements UserJobInterface {
       // @todo - remove this again - we are switching to NOT namespacing the base entity & using the getImportEntities above.
       $fieldMapName = str_replace(strtolower($this->baseEntity) . '.', '', $fieldMapName);
     }
+    if (!isset($this->importableFieldsMetadata[$fieldMapName]) && isset($this->importableFieldsMetadata['contact.' . $fieldMapName])) {
+      // Our metadata is a bit in flux in the early 6.x versions but this should catch the mapping in 6.1
+      // and has cover in testImportFromUserJobConfigurationInvalidCountry.
+      $fieldMapName = 'contact.' . $fieldMapName;
+    }
     // This whole business of only loading metadata for one type when we actually need it for all is ... dubious.
     if (empty($this->getImportableFieldsMetadata()[$fieldMapName])) {
       if ($loadOptions || !$limitToContactType) {


### PR DESCRIPTION

Overview
----------------------------------------
Fix 6.1 regression, type error on invalid fields

Addresses TypeError: CRM_Import_Parser::getFieldMetadata(): Return value must be of type array, null returned in CRM_Import_Parser->getFieldMetadata() (line 1149 of /srv/civi-sites/dmaster/web/sites/all/modules/civicrm/CRM/Import/Parser.php).

Before
----------------------------------------
During the validate routine the field for the address fields (`contact.address_primary.country_id`) is not found when trying to look up the title resulting in a type hint error - this is hit only when the `country_id` value is invalid

After
----------------------------------------
Fall back mechanism for finding the field

Technical Details
----------------------------------------
This metadata is a bit of a moving target across 6.1-6.3. The 6.2 version of this patch is a test only as the bug does not appear there https://github.com/civicrm/civicrm-core/pull/32620

Comments
----------------------------------------
