### PR TITLE
dev/core#5845 setup: move Sample Data lower, tweak the wording

### DIFF
--- a/setup/plugins/blocks/header.tpl.php
+++ b/setup/plugins/blocks/header.tpl.php
@@ -1,17 +1,13 @@
 <?php if (!defined('CIVI_SETUP')): exit("Installation plugins must only be loaded by the installer.\n");
 endif; ?>
 <div class="civicrm-setup-header">
-    <div class="title">
-        <h1><?php echo ts("Thanks for choosing CiviCRM. You're nearly there!"); ?><hr></h1>
-    </div>
-    <div class="civicrm-logo"><strong><?php echo ts('Version %1', array(1 => "{$civicrm_version} {$model->cms}")); ?></strong>
-        <span><img src=<?php echo $installURLPath . "updated-logo.jpg"?> /></span>
-     </div>
+  <p><strong><?php echo ts('Version %1', array(1 => "{$civicrm_version} {$model->cms}")); ?></strong></p>
+  <div class="civicrm-logo">
+    <img src=<?php echo $installURLPath . "updated-logo.jpg"?> />
+  </div>
 </div>
-<h2><?php echo ts("CiviCRM Installer"); ?></h2>
-
 <noscript>
 <p class="error"><?php echo ts("Error: Javascipt appears to be disabled. The CiviCRM web-based installer requires Javascript.");?></p>
 </noscript>
-
-<p><?php echo ts("Thanks for choosing CiviCRM! Please follow the instructions below to install CiviCRM."); ?></p>
+<h2><?php echo ts("CiviCRM Installer"); ?></h2>
+<p class="crm-slide-effect"><?php echo ts("Thanks for choosing CiviCRM! You're nearly there!") . ' ' . ts("Please follow the instructions below to install CiviCRM."); ?> &#x1f331;</p>

--- a/setup/plugins/blocks/sample-data.civi-setup.php
+++ b/setup/plugins/blocks/sample-data.civi-setup.php
@@ -12,12 +12,12 @@ if (!defined('CIVI_SETUP')) {
      */
     $ctrl = $e->getCtrl();
 
-    $ctrl->blocks['sample-data'] = array(
+    $ctrl->blocks['sample-data'] = [
       'is_active' => TRUE,
       'file' => __DIR__ . DIRECTORY_SEPARATOR . 'sample-data.tpl.php',
       'class' => 'if-no-errors',
-      'weight' => 40,
-    );
+      'weight' => 50,
+    ];
 
     if ($e->getMethod() === 'POST') {
       $e->getModel()->loadGenerated = !empty($e->getField('loadGenerated'));

--- a/setup/plugins/blocks/sample-data.tpl.php
+++ b/setup/plugins/blocks/sample-data.tpl.php
@@ -3,8 +3,8 @@ endif; ?>
 <h2><?php echo ts('Sample Data'); ?></h2>
 
 <p>
-  <label for="loadGenerated"><span>Load sample data:</span><input id="loadGenerated" type="checkbox" name="civisetup[loadGenerated]" value=1 <?php echo $model->loadGenerated ? "checked='checked'" : ""; ?> /></label> <br />
-  <span class="advancedTip"><?php echo ts("Fill the database with randomly-generated individuals, organizations, households, contributions, activities, etc. (English only). Sample data is mainly used for demo and testing sites, not for real installs."); ?></span><br />
+  <label for="loadGenerated"><span><?php echo ts('Test data'); ?></span> <input id="loadGenerated" type="checkbox" name="civisetup[loadGenerated]" value=1 <?php echo $model->loadGenerated ? "checked='checked'" : ""; ?> /></label> <br />
+  <span class="advancedTip"><?php echo ts("Fill the database with randomly-generated contacts, contributions, activities, etc. Only availble for English (United-States). Mainly used for demo and testing sites, not for real installations."); ?></span><br />
 </p>
 
 <script type="text/javascript">

--- a/setup/plugins/blocks/sync-users.tpl.php
+++ b/setup/plugins/blocks/sync-users.tpl.php
@@ -4,7 +4,7 @@ endif; ?>
 <h2><?php echo ts('Users'); ?></h2>
 
 <p>
-  <label for="syncUsers"><span>Synchronize all existing users:</span><input id="syncUsers" type="checkbox" name="civisetup[syncUsers]" value=1 <?php echo $model->syncUsers ? "checked='checked'" : ""; ?> /></label> <br />
+  <label for="syncUsers"><span><?php echo ts('Synchronize all existing users'); ?></span> <input id="syncUsers" type="checkbox" name="civisetup[syncUsers]" value=1 <?php echo $model->syncUsers ? "checked='checked'" : ""; ?> /></label> <br />
   <span class="advancedTip">
   <?php $cmsTitle = ($model->cms === 'Drupal8') ? 'Drupal' : $model->cms; ?>
   <?php echo ts("To help manage communication preferences, each <em>%1 User record</em> should be internally linked to a <em>CiviCRM Contact record</em>.", [1 => $cmsTitle]); ?><br />

--- a/setup/res/template.css
+++ b/setup/res/template.css
@@ -21,22 +21,20 @@ body {
 
 /* Header */
 .civicrm-setup-header {
-  width: 100%;
-  display: flex;
-  gap: 2rem;
+  text-align: right;
 }
 
-.civicrm-setup-header > * {
-  flex: 1;
+.civicrm-setup-header hr {
+  border: 0;
 }
 
-.civicrm-setup-header h1 {
-  margin: 0;
-  color: #fff;
+.civicrm-setup-body .civicrm-logo img {
+  max-width: 500px;
+}
+
+.crm-slide-effect {
   position: relative;
   left: -40px;
-  -webkit-animation: slide 1s forwards;
-  -webkit-animation-delay: 0.25s;
   animation: slide 1s forwards;
   animation-delay: 0.25s;
 }
@@ -53,14 +51,6 @@ body {
     left: 0;
     color: #000;
   }
-}
-
-.civicrm-setup-header hr {
-  border: 0;
-}
-
-.civicrm-setup-body .civicrm-logo img {
-  width: 100%;
 }
 
 /* Header End */
@@ -116,7 +106,6 @@ body {
 
 .civicrm-setup-body .advancedTip {
   border-collapse: collapse;
-  font-size: 80%;
 }
 
 .civicrm-setup-body .install-validate-ok {
@@ -291,16 +280,12 @@ body {
 }
 
 @media only screen and (max-width: 635px) {
-
   .civicrm-setup-body .settingsTable {
     display: block;
     overflow-x: auto;
     white-space: nowrap;
     width: 95%;
     margin: 10px 2% 10px 2%;
-  }
-  .civicrm-setup-header {
-    flex-direction: column-reverse;
   }
 }
 


### PR DESCRIPTION
Overview
----------------------------------------

In the web installer, move the part about "Sample Data" towards the bottom of the install page, and clarify the wording a bit, normal font size.

Also removes the redundant "Thank you for choosing CiviCRM" and "CiviCRM Installer" title.

Related to: https://lab.civicrm.org/dev/core/-/issues/5845 and #32610

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/2ed73c56-6064-4a5e-85d7-80c7de39b378)

After
----------------------------------------

![image](https://github.com/user-attachments/assets/7ca4946a-fbcb-4ab6-96ba-18d57e3484a7)

Comments
------------------------------

The slide effect on the top h1 was entertaining, and I tried to keep it on the first paragraph, but it felt off.