### PR TITLE
(dev/core#5846) Fix dedupe error when no data is passed in

### DIFF
--- a/CRM/Dedupe/BAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/BAO/DedupeRuleGroup.php
@@ -198,7 +198,8 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup impl
   }
 
   public static function hook_civicrm_findDuplicates(GenericHookEvent $event): void {
-    if (!empty($event->dedupeResults['handled'])) {
+    $lookupParameters = $event->dedupeParams['match_params'];
+    if (!$lookupParameters || !empty($event->dedupeResults['handled'])) {
       // @todo - in time we can deprecate this & expect them to use stopPropagation().
       return;
     }
@@ -207,7 +208,7 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup impl
     $ruleGroup->find(TRUE);
     $contactType = $ruleGroup->contact_type;
     $threshold = $ruleGroup->threshold;
-    $optimizer = new CRM_Dedupe_FinderQueryOptimizer($id, [], $event->dedupeParams['match_params']);
+    $optimizer = new CRM_Dedupe_FinderQueryOptimizer($id, [], $lookupParameters);
     $tableQueries = $optimizer->getFindQueries();
     if (empty($tableQueries)) {
       $event->dedupeResults['ids'] = [];

--- a/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
+++ b/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types = 1);
+use Civi\Api4\Contact;
 use Civi\Api4\DedupeRuleGroup;
 use Civi\Api4\DedupeRule;
 
@@ -21,6 +22,16 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
    */
   public function tearDown(): void {
     $this->quickCleanup(['civicrm_contact', 'civicrm_group_contact', 'civicrm_group'], TRUE);
+    if (!empty($this->ids['DedupeRuleGroup'])) {
+      DedupeRule::delete(FALSE)->addWhere('dedupe_rule_group_id', 'IN', $this->ids['DedupeRuleGroup'])
+        ->execute();
+      DedupeRuleGroup::delete(FALSE)->addWhere('id', 'IN', $this->ids['DedupeRuleGroup'])
+        ->execute();
+    }
+    DedupeRuleGroup::update(FALSE)
+      ->setValues(['used' => 'Supervised'])
+      ->addWhere('name', '=', 'IndividualSupervised')
+      ->execute();
     parent::tearDown();
   }
 
@@ -826,6 +837,120 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
     $fields = array_merge($fields, $params);
     $ids = CRM_Contact_BAO_Contact::getDuplicateContacts($fields, 'Individual', 'General', [], TRUE, $ruleGroup['id'], ['event_id' => 1]);
     $this->assertCount(2, $ids);
+  }
+
+  public function testFindDuplicateNonReservedRule(): void {
+    $this->createTestEntity('Contact', [
+      'last_name' => 'bob@example.org',
+      'first_name' => 'Bob',
+      'contact_type' => 'Individual',
+    ]);
+    $this->createTestEntity('Contact', [
+      'last_name' => '',
+      'first_name' => 'Bob',
+      'contact_type' => 'Individual',
+    ]);
+    $this->createTestEntity('DedupeRuleGroup', [
+      'contact_type' => 'Individual',
+      'threshold' => 5,
+      'used' => 'Supervised',
+      'name' => 'test-rule',
+    ]);
+    $this->createTestEntity('DedupeRule', [
+      'dedupe_rule_group_id.name' => 'test-rule',
+      'rule_table' => 'civicrm_contact',
+      'rule_field' => 'first_name',
+      'rule_weight' => 3,
+    ]);
+    $this->createTestEntity('DedupeRule', [
+      'dedupe_rule_group_id.name' => 'test-rule',
+      'rule_table' => 'civicrm_contact',
+      'rule_field' => 'last_name',
+      'rule_weight' => 2,
+    ]);
+    DedupeRuleGroup::update(FALSE)
+      ->setValues(['used' => 'General'])
+      ->addWhere('name', '=', 'IndividualSupervised')
+      ->execute();
+
+    // Test finding the match on apiv3 & 4.
+    $matches = Contact::getDuplicates(FALSE)
+      ->setDedupeRule('test-rule')
+      ->setValues([
+        'last_name' => 'bob@example.org',
+        'first_name' => 'Bob',
+      ])
+      ->execute();
+    $this->assertCount(1, $matches);
+    $matches = $this->callAPISuccess('Contact', 'duplicatecheck', [
+      'rule_type' => 'Supervised',
+      'rule_group_id' => $this->ids['DedupeRuleGroup']['default'],
+      'match' => [
+        'contact_type' => 'Individual',
+        'first_name' => 'Bob',
+        'last_name' => 'bob@example.org',
+      ],
+    ]);
+    $this->assertEquals(1, $matches['count']);
+
+    // Test again on a non-matched one - apiv3 & 4 again.
+    $matches = Contact::getDuplicates(FALSE)
+      ->setDedupeRule('test-rule')
+      ->setValues([
+        'last_name' => 'bob@example.org',
+        'first_name' => 'Bobby',
+      ])
+      ->execute();
+    $this->assertCount(0, $matches);
+    $matches = $this->callAPISuccess('Contact', 'duplicatecheck', [
+      'rule_type' => 'Supervised',
+      'rule_group_id' => $this->ids['DedupeRuleGroup']['default'],
+      'match' => [
+        'contact_type' => 'Individual',
+      ],
+    ]);
+    $this->assertEquals(0, $matches['count']);
+
+    $matches = $this->callAPISuccess('Contact', 'duplicatecheck', [
+      'rule_type' => 'Supervised',
+      'rule_group_id' => $this->ids['DedupeRuleGroup']['default'],
+      'match' => [
+        'contact_type' => 'Individual',
+        'first_name' => 'Bob',
+      ],
+    ]);
+    $this->assertEquals(0, $matches['count']);
+
+    $matches = $this->callAPISuccess('Contact', 'duplicatecheck', [
+      'rule_type' => 'Supervised',
+      'rule_group_id' => $this->ids['DedupeRuleGroup']['default'],
+      'match' => [
+        'contact_type' => 'Individual',
+        'first_name' => 'Bob',
+        'last_name' => '',
+      ],
+    ]);
+    $this->assertEquals(0, $matches['count']);
+
+    $matches = Contact::getDuplicates(FALSE)
+      ->setDedupeRule('test-rule')
+      ->setValues([
+        'last_name' => '',
+        'first_name' => 'Bob',
+      ])
+      ->execute();
+    $this->assertCount(0, $matches);
+  }
+
+  public function testDedupeApiCallLackingData(): void {
+    $matches = $this->callAPISuccess('Contact', 'duplicatecheck', [
+      'rule_type' => 'Supervised',
+      'contact_type' => 'Individual',
+      'match' => [
+        'contact_type' => 'Individual',
+      ],
+    ]);
+    $this->assertEquals(0, $matches['count']);
   }
 
 }


### PR DESCRIPTION
(dev/core#5846) Fix dedupe error when no data is passed in

When 
1) the legacydedupefinder is disabled and
2) the Check Matching Contacts buttons is used when there is insufficient data on the New individual form

The apiv3 is called without any lookup values - per https://github.com/civicrm/civicrm-core/pull/32630#issuecomment-2817488764

This results in an error - but this PR adds an early return in this case

More on https://github.com/civicrm/civicrm-core/pull/32630

@demeritcowboy 