### PR TITLE
ChartKit - fix secondary grouping columns missing from legend text

### DIFF
--- a/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitPie.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitPie.service.js
@@ -31,7 +31,11 @@
     showLegend: (displayCtrl) => (displayCtrl.settings.showLegend && displayCtrl.settings.showLegend !== 'none'),
 
     // for pie chart the legend is showing column values, which benefit from rendering
-    legendTextAccessor: (displayCtrl) => ((d) => (d.name === 'Others') ? 'Others' : displayCtrl.renderColumnValue(d.data, displayCtrl.getFirstColumnForAxis('w'))),
+    legendTextAccessor: (displayCtrl) => ((d) =>
+      (d.name === 'Others') ?
+        'Others' :
+        displayCtrl.getColumnsForAxis('w').map((col) => displayCtrl.renderColumnValue(d.data, col)).join(' - ')
+    ),
 
     getInitialDisplaySettings: () => ({
       showLegend: 'left',

--- a/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitPie.service.js
+++ b/ext/chart_kit/ang/crmChartKit/chartTypes/chartKitPie.service.js
@@ -33,7 +33,7 @@
     // for pie chart the legend is showing column values, which benefit from rendering
     legendTextAccessor: (displayCtrl) => ((d) =>
       (d.name === 'Others') ?
-        'Others' :
+        ts('Others') :
         displayCtrl.getColumnsForAxis('w').map((col) => displayCtrl.renderColumnValue(d.data, col)).join(' - ')
     ),
 


### PR DESCRIPTION
Before
----------------------------------------
- you can select multiple columns for the Grouping for a pie chart
- only the values from the first column are shown in the Legend labels, so you get strange duplicates

![image](https://github.com/user-attachments/assets/4654552d-df17-4f18-8a9b-3e6d98e739a4)

After
----------------------------------------
- Legend labels correctly show all Grouping columns

![image](https://github.com/user-attachments/assets/9ad0e7be-434f-4936-80ec-7f9b4cc9ef9a)


Technical Details
----------------------------------------
This got inadvertently dropped from https://github.com/civicrm/civicrm-core/pull/32583
