### PR TITLE
Merging tags update the name instead of the label

### DIFF
--- a/CRM/Tag/Form/Merge.php
+++ b/CRM/Tag/Form/Merge.php
@@ -47,8 +47,8 @@ class CRM_Tag_Form_Merge extends CRM_Core_Form {
    * Build the form object.
    */
   public function buildQuickForm() {
-    $this->add('text', 'name', ts('Name of combined tag'), TRUE);
-    $this->assign('tags', CRM_Utils_Array::collect('name', $this->_tags));
+    $this->add('text', 'label', ts('Label of combined tag'), TRUE);
+    $this->assign('tags', CRM_Utils_Array::collect('label', $this->_tags));
 
     $this->addButtons([
         [
@@ -72,7 +72,7 @@ class CRM_Tag_Form_Merge extends CRM_Core_Form {
   public function setDefaultValues() {
     $primary = CRM_Utils_Array::first($this->_tags);
     return [
-      'name' => $primary['name'],
+      'label' => $primary['label'],
     ];
   }
 
@@ -81,24 +81,19 @@ class CRM_Tag_Form_Merge extends CRM_Core_Form {
    */
   public function postProcess() {
     $params = $this->exportValues();
-    $deleted = CRM_Utils_Array::collect('name', $this->_tags);
+    $deleted = CRM_Utils_Array::collect('label', $this->_tags);
     $primary = array_shift($this->_tags);
 
     foreach ($this->_tags as $tag) {
       CRM_Core_BAO_EntityTag::mergeTags($primary['id'], $tag['id']);
     }
 
-    if ($params['name'] != $primary['name']) {
-      civicrm_api3('Tag', 'create', ['id' => $primary['id'], 'name' => $params['name']]);
-    }
-
-    $key = array_search($params['name'], $deleted);
-    if ($key !== FALSE) {
-      unset($deleted[$key]);
+    if ($params['label'] != $primary['label']) {
+      civicrm_api3('Tag', 'create', ['id' => $primary['id'], 'label' => $params['label']]);
     }
 
     CRM_Core_Session::setStatus(
-      ts('All records previously tagged %1 are now tagged %2.', [1 => implode(' ' . ts('or') . ' ', $deleted), 2 => $params['name']]),
+      ts('All records previously tagged %1 are now tagged %2.', [1 => implode(' ' . ts('or') . ' ', $deleted), 2 => $params['label']]),
       ts('%1 Tags Merged', [1 => count($this->_id)]),
       'success'
     );

--- a/templates/CRM/Tag/Form/Merge.tpl
+++ b/templates/CRM/Tag/Form/Merge.tpl
@@ -15,8 +15,8 @@
   </div>
   <table class="form-layout-compressed">
     <tr class="crm-tag-form-block-label">
-      <td class="label">{$form.name.label}</td>
-      <td>{$form.name.html}</td>
+      <td class="label">{$form.label.label}</td>
+      <td>{$form.label.html}</td>
     </tr>
   </table>
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>


### PR DESCRIPTION
Overview
----------------------------------------
Merging 2 tags ask for the new tag name. The user expect it to be the new label but instead, it updates the internal name of the tag, giving the impression that the merge is not working properly.

Before
----------------------------------------
- in Manage tags, select 2+ tags with CTRL clic
- use the `Merge Tags` button
- enter the name of the new tag and submit
- the merge is working but the resulting tag still has its old label

![Screenshot 2025-04-22 at 11-41-11 Tags](https://github.com/user-attachments/assets/69654867-542b-45e2-a6d6-322a7afb1592)

After
----------------------------------------
- the label is updated instead of the internal name

