### PR TITLE
Add support to ISO8601 time formatting supported for imports

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -783,12 +783,25 @@ class CRM_Utils_Date {
   /**
    * Get the regex to extract the time portion.
    *
+   * This is accessed when importing date fields from CSV files.
+   *
+   * The time could be in ISO8601 or just hyphen separated (preceded by a space)
+   * - ie
+   *
+   * T13:15:30-01:00
+   * T13:15:30+01:00
+   * T13:15:30Z
+   *  13:15:30
+   *
+   *
+   * @see https://www.w3.org/TR/NOTE-datetime
+   *
    * @internal
    *
    * @return string
    */
   protected static function getTimeRegex(): string {
-    return "/(\s(([01]*\d)|[2][0-3])(:([0-5]\d)){1,2})$/";
+    return "/([T\s](([01]*\d)|[2][0-3])(:([0-5]\d)){1,2}([+|-]\d{2}:\d{2}|Z)?)$/";
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/DateTest.php
+++ b/tests/phpunit/CRM/Utils/DateTest.php
@@ -26,12 +26,20 @@
  */
 class CRM_Utils_DateTest extends CiviUnitTestCase {
 
+  private string $timeZone;
+
   /**
    * Set up for tests.
    */
   public function setUp(): void {
     parent::setUp();
     $this->useTransaction();
+    $this->timeZone = date_default_timezone_get();
+  }
+
+  public function tearDown(): void {
+    date_default_timezone_set($this->timeZone);
+    parent::tearDown();
   }
 
   /**
@@ -2661,10 +2669,9 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
    * Test the format function used in imports. Note most forms
    * are able to format pre-submit but the import needs to parse the date.
    */
-  public function testFormatDate($date, $format, $expected, $ignoreReason = NULL): void {
-    if ($ignoreReason) {
-      $this->markTestSkipped($ignoreReason);
-    }
+  public function testFormatDate($date, $format, $expected): void {
+    // Specify the system tz so we can be sure that the date value is predictable when it contains a timezone.
+    date_default_timezone_set('UTC');
     $this->assertEquals($expected, CRM_Utils_Date::formatDate($date, $format));
   }
 
@@ -2690,6 +2697,9 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
       '2022-10-01 3:54' => ['date' => '2022-10-01 3:54', 'format' => CRM_Utils_Date::DATE_yyyy_mm_dd, 'expected' => '20221001035400'],
       '2022-10-01 15:54:56' => ['date' => '2022-10-01 15:54:56', 'format' => CRM_Utils_Date::DATE_yyyy_mm_dd, 'expected' => '20221001155456'],
       '2022-10-01 3:54:56' => ['date' => '2022-10-01 3:54:56', 'format' => CRM_Utils_Date::DATE_yyyy_mm_dd, 'expected' => '20221001035456'],
+      'ISO 8601 2022-10-01T14:56-01:00' => ['2022-10-01T14:56-01:00', 'format' => CRM_Utils_Date::DATE_yyyy_mm_dd, 'expected' => '20221001155600'],
+      'ISO 8601 2022-10-01T14:56+03:00' => ['2022-10-01T18:56+03:00', 'format' => CRM_Utils_Date::DATE_yyyy_mm_dd, 'expected' => '20221001155600'],
+      'ISO 8601-Z 2022-10-01T15:56Z' => ['2022-10-01T15:56Z', 'format' => CRM_Utils_Date::DATE_yyyy_mm_dd, 'expected' => '20221001155600'],
 
       // mm_dd_yy format - eg. US Style 10-01-22 OR 10/01/22 where 10 is the month. 2 digit year.
       '10-01-30-mapped-to-1934-not-2034-per-strtotime' => ['date' => '10-01-34', 'format' => CRM_Utils_Date::DATE_mm_dd_yy, 'expected' => '19341001000000'],


### PR DESCRIPTION
Overview
----------------------------------------
Add support to ISO8601 time formatting supported for imports

Before
----------------------------------------
ISO8601 formatted treated as invalid

After
----------------------------------------
ISO8601 formatted handled, tested

Technical Details
----------------------------------------

https://www.w3.org/TR/NOTE-datetime

Comments
----------------------------------------
I wondered about adding this to the UI but we don't show time at all at this point & it's already noisy

@colemanw at one point suggested changing this selection to a drop down - I would probably move to the MapField screen if touching it

![image](https://github.com/user-attachments/assets/bf59342e-1afb-495e-b96d-d1f0e3cb9d77)
