### PR TITLE
iframe: wrapper function for print keyword

### DIFF
--- a/ext/iframe/Civi/Iframe/Router.php
+++ b/ext/iframe/Civi/Iframe/Router.php
@@ -79,7 +79,7 @@ class Router extends AutoService {
       $pageContent = $printedContent;
     }
 
-    $printPage = $params['printPage'] ?? 'print';
+    $printPage = $params['printPage'] ?? '\Civi\Iframe\Router::print';
     $printPage($pageContent);
   }
 
@@ -113,7 +113,7 @@ class Router extends AutoService {
       'body' => $pageContent,
     ]);
 
-    $printPage = $params['printPage'] ?? 'print';
+    $printPage = $params['printPage'] ?? '\Civi\Iframe\Router::print';
     $printPage($fullPage);
   }
 
@@ -145,6 +145,14 @@ class Router extends AutoService {
       default:
         throw new \CRM_Core_Exception("Unimplemented: invokeCms(" . CIVICRM_UF . ")");
     }
+  }
+
+  /**
+   * Wrapper around print because we cannot call lagnuage constructs using a
+   * variable name
+   */
+  protected static function print(string $html):void {
+    echo $html;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

The iframe.php was broken on Drupal7 because we cannot do:

```
$foo = 'print';
$foo($html);
```

because `print` is a PHP language construct.

Noticed this on CiviCRM Spark, which uses Drupal7. WordPress should not be impacted, but D10 might be.

Before
----------------------------------------

WSOD

After
----------------------------------------

Fixed

cc @totten 