### PR TITLE
Manage Contribution Page: fix search form layout, remove PCP button

### DIFF
--- a/CRM/Contribute/Form/SearchContribution.php
+++ b/CRM/Contribute/Form/SearchContribution.php
@@ -20,15 +20,10 @@ class CRM_Contribute_Form_SearchContribution extends CRM_Core_Form {
    * Build the form object.
    */
   public function buildQuickForm() {
-    $attributes = CRM_Core_DAO::getAttribute('CRM_Contribute_DAO_ContributionPage', 'title');
-    $attributes['style'] = 'width: 90%';
+    $this->add('text', 'title', ts('Title'), CRM_Core_DAO::getAttribute('CRM_Contribute_DAO_ContributionPage', 'title'));
 
-    $this->add('text', 'title', ts('Find'), $attributes);
-
-    $financial_account = CRM_Contribute_PseudoConstant::financialType();
-    foreach ($financial_account as $contributionId => $contributionName) {
-      $this->addElement('checkbox', "financial_type_id[$contributionId]", 'Financial Type', $contributionName);
-    }
+    $financialType = CRM_Contribute_PseudoConstant::financialType();
+    $this->add('select', 'financial_type_id', ts('Financial Type'), $financialType, FALSE, ['class' => 'crm-select2', 'multiple' => 'multiple']);
 
     CRM_Campaign_BAO_Campaign::addCampaignInComponentSearch($this);
 
@@ -48,9 +43,7 @@ class CRM_Contribute_Form_SearchContribution extends CRM_Core_Form {
     if (!empty($params)) {
       $fields = ['title', 'financial_type_id', 'campaign_id'];
       foreach ($fields as $field) {
-        if (isset($params[$field]) &&
-          !CRM_Utils_System::isNull($params[$field])
-        ) {
+        if (isset($params[$field]) && !CRM_Utils_System::isNull($params[$field])) {
           $parent->set($field, $params[$field]);
         }
         else {

--- a/CRM/Contribute/Page/ContributionPage.php
+++ b/CRM/Contribute/Page/ContributionPage.php
@@ -592,17 +592,8 @@ ORDER BY is_active desc, title asc
     }
 
     $value = $this->get('financial_type_id');
-    $val = [];
-    if ($value) {
-      if (is_array($value)) {
-        foreach ($value as $k => $v) {
-          if ($v) {
-            $val[$k] = $k;
-          }
-        }
-        $type = implode(',', $val);
-      }
-      // @todo Variable 'type' might not have been defined.
+    if (!empty($value)) {
+      $type = CRM_Utils_Type::validate(implode(',', $value), 'CommaSeparatedIntegers');
       $clauses[] = "financial_type_id IN ({$type})";
     }
 

--- a/templates/CRM/Contribute/Form/SearchContribution.tpl
+++ b/templates/CRM/Contribute/Form/SearchContribution.tpl
@@ -8,26 +8,25 @@
  +--------------------------------------------------------------------+
 *}
 <div class="crm-block crm-form-block crm-contribution-search_contribution-form-block">
-<h3>{ts}Find Contribution Pages{/ts}</h3>
-<table class="form-layout-compressed">
-    <tr>
-        <td>{$form.title.html}</td>
-        <td>
-            <label>{ts}Financial Type{/ts}</label>
-            <div class="listing-box">
-                {foreach from=$form.financial_type_id item="contribution_val"}
-                <div class="{cycle values="odd-row,even-row"}">
-                     {$contribution_val.html}
-                  </div>
-                {/foreach}
-            </div>
-        </td>
-    </tr>
-
-    {* campaign in contribution page search *}
-    {include file="CRM/Campaign/Form/addCampaignToSearch.tpl"
-    campaignTrClass='' campaignTdClass=''}
-
- </table>
- <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>
+  <details class="crm-accordion-bold crm-block crm-form-block crm-contribution-search_contribution-form-block" open="">
+    <summary>{ts}Find Contribution Pages{/ts}</summary>
+    <div class="crm-accordion-body">
+      <div class="float-right">
+        {include file="CRM/common/formButtons.tpl" location=''}
+      </div>
+      <div class="advanced-search-fields form-layout" style="max-width: 90%;">
+        <div class="search-field">
+          {$form.title.label}
+          {$form.title.html|crmAddClass:twenty}
+        </div>
+        <div class="search-field">
+          {$form.financial_type_id.label}
+          {$form.financial_type_id.html}
+        </div>
+        <div class="search-field">
+          {include file="CRM/Campaign/Form/addCampaignToSearch.tpl" campaignTrClass='' campaignTdClass=''}
+        </div>
+      </div>
+    </div>
+  </details>
 </div>

--- a/templates/CRM/Contribute/Page/ContributionPage.tpl
+++ b/templates/CRM/Contribute/Page/ContributionPage.tpl
@@ -14,12 +14,9 @@
 
     {include file="CRM/Contribute/Form/SearchContribution.tpl"}
     {if NOT ($action eq 1 or $action eq 2)}
-      <table class="form-layout-compressed">
-      <tr>
-      <td><a href="{$newPageURL}" class="button"><span><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}Add Contribution Page{/ts}</span></a></td>
-            <td style="vertical-align: top"><a class="button" href="{crmURL p="civicrm/admin/pcp" q="reset=1"}"><span>{ts}Manage Personal Campaign Pages{/ts}</span></a> {help id="id-pcp-intro" file="CRM/PCP/Page/PCP.hlp"}</td>
-      </tr>
-      </table>
+      <div class="action-link">
+        <a href="{$newPageURL}" class="button"><span><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}Add Contribution Page{/ts}</span></a>
+      </div>
     {/if}
 
     {if $rows}
@@ -35,7 +32,7 @@
                <tr>
                  <th>{ts}Title{/ts}</th>
                <th>{ts}ID{/ts}</th>
-               <th>{ts}Enabled?{/ts}</th>
+               <th>{ts}Enabled{/ts}</th>
              {if call_user_func(array('CRM_Campaign_BAO_Campaign','isComponentEnabled'))}
              <th>{ts}Campaign{/ts}</th>
             {/if}


### PR DESCRIPTION
Overview
----------------------------------------

Tweaks the Manage Contribution Page to make it look a bit more normal.

- Makes the search form collapsible, like most other similar-ish forms (Event Search, Advanced Search)
- Displays the "title" label
- Converts the Financial Type checkboxes to a select2
- Floats the "Search" button to the right
- Removes the "Manage Personal Campaign Pages" button, because there is already a menu item for it, and it's  a niche feature.

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/25ca5acf-9378-4d9f-a5ff-f2ae052d8c25)

After
----------------------------------------

![image](https://github.com/user-attachments/assets/d29868f1-0531-4c8a-b441-0d5237b6f435)

Technical Details
----------------------------------------

Minor hack: I used a `width: 90%` so that the Search button displays correctly, and not on another line. Those kind of forms will go away at some point, with auto-updating forms.
