### PR TITLE
iframe - Fix PHP error about `print` function

### DIFF
--- a/ext/iframe/Civi/Iframe/Iframe.php
+++ b/ext/iframe/Civi/Iframe/Iframe.php
@@ -16,6 +16,15 @@ class Iframe extends AutoService implements EventSubscriberInterface {
   }
 
   /**
+   * Is there a driver that supports IFRAMEs for this environment?
+   *
+   * @return bool
+   */
+  public function isSupported(): bool {
+    return CIVICRM_UF === 'WordPress' || class_exists($this->getTemplate());
+  }
+
+  /**
    * Determine which template to use for the iframe entry-point.
    *
    * @return string

--- a/ext/iframe/Civi/Iframe/Router.php
+++ b/ext/iframe/Civi/Iframe/Router.php
@@ -79,7 +79,7 @@ class Router extends AutoService {
       $pageContent = $printedContent;
     }
 
-    $printPage = $params['printPage'] ?? 'print';
+    $printPage = $params['printPage'] ?? '\Civi\Iframe\Router::print';
     $printPage($pageContent);
   }
 
@@ -113,7 +113,7 @@ class Router extends AutoService {
       'body' => $pageContent,
     ]);
 
-    $printPage = $params['printPage'] ?? 'print';
+    $printPage = $params['printPage'] ?? '\Civi\Iframe\Router::print';
     $printPage($fullPage);
   }
 
@@ -145,6 +145,14 @@ class Router extends AutoService {
       default:
         throw new \CRM_Core_Exception("Unimplemented: invokeCms(" . CIVICRM_UF . ")");
     }
+  }
+
+  /**
+   * Wrapper around print because we cannot call lagnuage constructs using a
+   * variable name
+   */
+  protected static function print(string $html):void {
+    echo $html;
   }
 
 }

--- a/ext/iframe/phpunit.xml.dist
+++ b/ext/iframe/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" cacheResult="false" bootstrap="tests/phpunit/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <testsuites>
+    <testsuite name="Iframe Tests">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/ext/iframe/tests/phpunit/CRM/Iframe/IframeTest.php
+++ b/ext/iframe/tests/phpunit/CRM/Iframe/IframeTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use CRM_Iframe_ExtensionUtil as E;
+use Civi\Test\EndToEndInterface;
+
+/**
+ * @group e2e
+ */
+class CRM_Iframe_IframeTest extends \PHPUnit\Framework\TestCase implements EndToEndInterface {
+
+  use \Civi\Test\HttpTestTrait;
+
+  public static function setUpBeforeClass(): void {
+    \Civi\Test::e2e()->installMe(__DIR__)->apply();
+  }
+
+  /**
+   * Enable iframe connector and send a request.
+   */
+  public function testBasicRequest(): void {
+    if (!Civi::service('iframe')->isSupported()) {
+      $this->markTestSkipped('iframe extension does not support activation in this environment');
+    }
+
+    \Civi\Api4\Iframe::installScript()->setCheckPermissions(FALSE)->execute();
+
+    $eventId = CRM_Core_DAO::singleValueQuery('SELECT min(id) FROM civicrm_event');
+    $this->assertTrue(is_numeric($eventId), 'Database should have at least one event');
+
+    $url = Civi::url('iframe://civicrm/event/info')->addQuery([
+      'reset' => 1,
+      'id' => $eventId,
+    ]);
+    $response = $this->createGuzzle()->get((string) $url);
+    $this->assertContentType('text/html', $response);
+    $this->assertStatusCode(200, $response);
+    $this->assertBodyRegexp('/crm-register-button/', $response);
+    $this->assertBodyRegexp('/civicrm-iframe-page/', $response);
+    $this->assertNotBodyRegexp(';misc/drupal.js;', $response);
+  }
+
+}

--- a/ext/iframe/tests/phpunit/bootstrap.php
+++ b/ext/iframe/tests/phpunit/bootstrap.php
@@ -1,0 +1,65 @@
+<?php
+
+ini_set('memory_limit', '2G');
+
+// phpcs:disable
+eval(cv('php:boot --level=classloader', 'phpcode'));
+// phpcs:enable
+// Allow autoloading of PHPUnit helper classes in this extension.
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->add('CRM_', [__DIR__ . '/../..', __DIR__]);
+$loader->addPsr4('Civi\\', [__DIR__ . '/../../Civi', __DIR__ . '/Civi']);
+$loader->add('api_', [__DIR__ . '/../..', __DIR__]);
+$loader->addPsr4('api\\', [__DIR__ . '/../../api', __DIR__ . '/api']);
+
+$loader->register();
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return mixed
+ *   Response output (if the command executed normally).
+ *   For 'raw' or 'phpcode', this will be a string. For 'json', it could be any JSON value.
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv(string $cmd, string $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => STDERR];
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv('CV_OUTPUT=json');
+
+  // Execute `cv` in the original folder. This is a work-around for
+  // phpunit/codeception, which seem to manipulate PWD.
+  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== '/*BEGINPHP*/' || substr(trim($result), -10) !== '/*ENDPHP*/') {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}


### PR DESCRIPTION
Overview
----------------------------------------

This is port of @mlutfy's #32645 from master to 6.2-rc. It fixes an error when displaying `/iframe.php` on D7 (and possibly D10 or Backdrop). (*I've also added some test-coverage.*)

Before
----------------------------------------

If you access a page like `/iframe.php/civicrm/event/info?id=123` on D7, then it fails (WSOD).

After
----------------------------------------

Same request works.

