### PR TITLE
(NFC) IframeTest - Fix test-failure on wp

### DIFF
--- a/ext/iframe/tests/phpunit/CRM/Iframe/IframeTest.php
+++ b/ext/iframe/tests/phpunit/CRM/Iframe/IframeTest.php
@@ -22,7 +22,9 @@ class CRM_Iframe_IframeTest extends \PHPUnit\Framework\TestCase implements EndTo
       $this->markTestSkipped('iframe extension does not support activation in this environment');
     }
 
-    \Civi\Api4\Iframe::installScript()->setCheckPermissions(FALSE)->execute();
+    if (CIVICRM_UF !== 'WordPress') {
+      \Civi\Api4\Iframe::installScript()->setCheckPermissions(FALSE)->execute();
+    }
 
     $eventId = CRM_Core_DAO::singleValueQuery('SELECT min(id) FROM civicrm_event');
     $this->assertTrue(is_numeric($eventId), 'Database should have at least one event');


### PR DESCRIPTION
Overview
----------------------------------------

Small correction for #32649, which added a new test. This is only a correction for the test, so there's no effect on real runtime.

Before
-------

Test fails on WP because it attempts to run an unnecessary step. (WP doesn't need you install the `iframe.php` script -- it works a different way.) ([example](https://test.civicrm.org/job/CiviCRM-Test/71001/testReport/junit/(root)/CRM_Iframe_IframeTest/testBasicRequest/))

After
-----

Test passes on WP.