### PR TITLE
When merging tags the form field is added with the wrong number of params to add()

### DIFF
--- a/CRM/Tag/Form/Merge.php
+++ b/CRM/Tag/Form/Merge.php
@@ -47,7 +47,7 @@ class CRM_Tag_Form_Merge extends CRM_Core_Form {
    * Build the form object.
    */
   public function buildQuickForm() {
-    $this->add('text', 'label', ts('Label of combined tag'), TRUE);
+    $this->add('text', 'label', ts('Label of combined tag'), NULL, TRUE);
     $this->assign('tags', CRM_Utils_Array::collect('label', $this->_tags));
 
     $this->addButtons([


### PR DESCRIPTION
Overview
----------------------------------------
Followup from https://github.com/civicrm/civicrm-core/pull/32639

Before
----------------------------------------
1. Select two tags from the tags admin screen (shift-click).
2. Click Merge.
3. In the box that comes up the field is supposed to be required. (It doesn't make sense any other way, and why else pass in TRUE.)
4. Warning in log about param array something.

After
----------------------------------------
There's another warning but it's from smarty - join vs implode, but can't remember off the top of my head if can just replace and still work in smarty 2. Will deal with separately.

Technical Details
----------------------------------------


Comments
----------------------------------------

