### PR TITLE
ensure api4 dedupe uses numeric phone

### DIFF
--- a/Civi/Api4/Action/Contact/GetDuplicates.php
+++ b/Civi/Api4/Action/Contact/GetDuplicates.php
@@ -103,6 +103,9 @@ class GetDuplicates extends \Civi\Api4\Generic\DAOCreateAction {
       $entityValues = \CRM_Utils_Array::filterByPrefix($item, $prefix);
       $this->transformCustomParams($entityValues, $dedupeParams);
       if ($entityValues) {
+        if ($entity == 'Phone' && array_key_exists('phone', $entityValues)) {
+          $entityValues['phone_numeric'] = preg_replace('/[^\d]/', '', $entityValues['phone']);
+        }
         $dedupeParams['civicrm_' . strtolower($entity)] = $entityValues;
       }
     }

--- a/tests/phpunit/api/v4/Action/ContactDuplicatesTest.php
+++ b/tests/phpunit/api/v4/Action/ContactDuplicatesTest.php
@@ -231,4 +231,33 @@ class ContactDuplicatesTest extends Api4TestBase {
     $this->assertEquals($testContacts[0], $mergedFromID);
   }
 
+  public function testPhoneNumeric(): void {
+    // Create a dedupe rule that matches on phone.
+    $phone = '(123) 456-7890';
+    $phoneRuleGroup = $this->createTestRecord('DedupeRuleGroup', [
+      'contact_type' => 'Individual',
+      'name' => 'phoneRule',
+      'used' => 'General',
+      'threshold' => 1,
+    ]);
+    $this->createTestRecord('DedupeRule', [
+      'dedupe_rule_group_id' => $phoneRuleGroup['id'],
+      'rule_weight' => 1,
+      'rule_table' => 'civicrm_phone',
+      'rule_field' => 'phone_numeric',
+    ]);
+
+    $this->createTestRecord('Contact', [
+      'first_name' => 'Phoney',
+      'first_name' => 'Numerals',
+      'phone_primary.phone' => $phone,
+    ]);
+
+    $found = Contact::getDuplicates(FALSE)
+      ->setDedupeRule('phoneRule')
+      ->addValue('phone_primary.phone', $phone)
+      ->execute()->column('id');
+    $this->assertCount(1, $found);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

See: https://lab.civicrm.org/dev/core/-/issues/5760

Before
----------------------------------------

If you have a contact record with a phone number and your run the apiv4 `Contact::getDuplicates()` method with the same phone number (but with periods or dashes), the deduper fails to find the matching contact.

After
----------------------------------------
By converting the phone number to numerals only and inserting the `phone_numeric` key, the match is made.


Technical Details
----------------------------------------
I'm not sure if this is the right place to strip out the non-numeric characters. I noticed that @eileenmcnaughton did some recent work on deprecating the `CRM_Dedupe_Finder()` so hoping you might have suggestions on this?

