### PR TITLE
Installer - Tweak prose for "Sample Data" and "Users"

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -273,7 +273,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     $return = [];
     foreach ($this->getImportableFieldsMetadata() as $name => $field) {
       if ($name === 'id' && $this->isSkipDuplicates()) {
-        // Duplicates are being skipped so id matching is not availble.
+        // Duplicates are being skipped so id matching is not available.
         continue;
       }
       $return[$name] = $field['html']['label'] ?? $field['title'];

--- a/setup/plugins/blocks/sample-data.tpl.php
+++ b/setup/plugins/blocks/sample-data.tpl.php
@@ -3,8 +3,8 @@ endif; ?>
 <h2><?php echo ts('Sample Data'); ?></h2>
 
 <p>
-  <label for="loadGenerated"><span><?php echo ts('Test data'); ?></span> <input id="loadGenerated" type="checkbox" name="civisetup[loadGenerated]" value=1 <?php echo $model->loadGenerated ? "checked='checked'" : ""; ?> /></label> <br />
-  <span class="advancedTip"><?php echo ts("Fill the database with randomly-generated contacts, contributions, activities, etc. Only availble for English (United-States). Mainly used for demo and testing sites, not for real installations."); ?></span><br />
+  <label for="loadGenerated"><span><?php echo ts('Fill system with fake information'); ?></span> <input id="loadGenerated" type="checkbox" name="civisetup[loadGenerated]" value=1 <?php echo $model->loadGenerated ? "checked='checked'" : ""; ?> /></label> <br />
+  <span class="advancedTip"><?php echo ts("To initialize a demo site, load sample data about fake people. Only available in English (United States)."); ?></span><br />
 </p>
 
 <script type="text/javascript">

--- a/setup/plugins/blocks/sync-users.tpl.php
+++ b/setup/plugins/blocks/sync-users.tpl.php
@@ -7,7 +7,7 @@ endif; ?>
   <label for="syncUsers"><span><?php echo ts('Synchronize all existing users'); ?></span> <input id="syncUsers" type="checkbox" name="civisetup[syncUsers]" value=1 <?php echo $model->syncUsers ? "checked='checked'" : ""; ?> /></label> <br />
   <span class="advancedTip">
   <?php $cmsTitle = ($model->cms === 'Drupal8') ? 'Drupal' : $model->cms; ?>
-  <?php echo ts("To help manage communication preferences, each <em>%1 User record</em> should be internally linked to a <em>CiviCRM Contact record</em>.", [1 => $cmsTitle]); ?><br />
+  <?php echo ts("To help manage communication preferences, each \"<em>%1 User</em>\" should be internally linked to a \"<em>CiviCRM Contact</em>\".", [1 => $cmsTitle]); ?><br />
   </span>
 </p>
 

--- a/setup/res/template.css
+++ b/setup/res/template.css
@@ -106,6 +106,8 @@ body {
 
 .civicrm-setup-body .advancedTip {
   border-collapse: collapse;
+  font-style: italic;
+  font-size: 0.9em;
 }
 
 .civicrm-setup-body .install-validate-ok {


### PR DESCRIPTION
Overview
----------------------------------------

More tweaks to the installer

Before
----------------------------------------

<img width="1268" alt="Screenshot 2025-04-25 at 1 46 47 PM" src="https://github.com/user-attachments/assets/3a5f58b5-50b4-4263-b4a6-44114c157366" />

After
----------------------------------------

<img width="1265" alt="Screenshot 2025-04-25 at 1 45 14 PM" src="https://github.com/user-attachments/assets/44cd4618-f934-4388-929b-6ba0f0aa23ca" />

Comments
----------------------------------------

* I originally went to fix a typo.
* Text has a tendency to get burdensome unless you re-prune periodically.
* This uses more consistent grammatical structures. Neighboring options should be phrased similarly.
* As a reader, I need _some_ visual cue to differentiate the label/action from the detail/description.  I guess [32627 implied that 80% was too small](https://github.com/civicrm/civicrm-core/pull/32627/files#diff-e87e73748b83c7891af17eb9534eb7b8f63d2e66375dfd6aa193a0492bb983cbL119). But 100% is too indistinguishable. So... 90% w/italics? 🙃 