### PR TITLE
Api4 - More efficient ACL clause handling

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -85,7 +85,7 @@ class Api4SelectQuery extends Api4Query {
     $this->entityAccess[$this->getEntity()] = TRUE;
 
     // Add ACLs first to avoid redundant subclauses
-    $this->query->where($this->getAclClause(self::MAIN_TABLE_ALIAS, $this->getEntity(), [], $this->getWhere()));
+    $this->query->where($this->getAclClause(self::MAIN_TABLE_ALIAS, $this->getEntity(), NULL, $this->getWhere()));
 
     // Add required conditions if specified by entity
     $requiredConditions = CoreUtil::getInfoItem($this->getEntity(), 'where') ?? [];
@@ -327,18 +327,12 @@ class Api4SelectQuery extends Api4Query {
    *
    * @param string $tableAlias
    * @param string $entityName
-   * @param array $stack
+   * @param array|null $stack
    * @param array[] $conditions
    * @return array
    */
-  public function getAclClause($tableAlias, $entityName, $stack = [], $conditions = []) {
+  public function getAclClause(string $tableAlias, string $entityName, ?array $stack = NULL, array $conditions = []): array {
     if (!$this->getCheckPermissions()) {
-      return [];
-    }
-    // Prevent (most) redundant acl sub clauses if they have already been applied to the main entity.
-    // FIXME: Currently this only works 1 level deep, but tracking through multiple joins would increase complexity
-    // and just doing it for the first join takes care of most acl clause deduping.
-    if (count($stack) === 1 && in_array(reset($stack), $this->aclFields, TRUE)) {
       return [];
     }
     // Glean entity values from the WHERE or ON clause conditions
@@ -363,9 +357,32 @@ class Api4SelectQuery extends Api4Query {
     }
     $baoName = CoreUtil::getBAOFromApiName($entityName);
     $clauses = $baoName::getSelectWhereClause($tableAlias, $entityName, $entityValues);
-    if (!$stack) {
+    if ($stack === NULL) {
       // Track field clauses added to the main entity
       $this->aclFields = array_keys($clauses);
+    }
+    // Dedupe these clauses with ones that have already been applied to the entity being joined on
+    else {
+      $stackLast = array_pop($stack);
+      $stackPrev = array_pop($stack);
+      $lastField = $stackLast;
+      if ($stackLast && $stackPrev) {
+        // Implicit join
+        if (str_starts_with($lastField, "$stackPrev.")) {
+          $lastField = substr($lastField, strlen($stackPrev) + 1);
+        }
+        // Explicit join
+        elseif (str_starts_with($lastField, "$tableAlias.")) {
+          $lastField = substr($lastField, strlen($tableAlias) + 1);
+        }
+        foreach ($clauses as $fieldName => $clause) {
+          if ($fieldName === $lastField && in_array($stackPrev, $this->aclFields, TRUE)) {
+            unset($clauses[$fieldName]);
+            $this->aclFields[] = $stackLast;
+          }
+          $this->aclFields[] = $stackPrev . '.' . $fieldName;
+        }
+      }
     }
     return array_filter($clauses);
   }
@@ -522,10 +539,8 @@ class Api4SelectQuery extends Api4Query {
    */
   private function getJoinConditions($joinTree, $joinEntity, $alias, $joinEntityFields) {
     $conditions = [];
-    // getAclClause() expects a stack of 1-to-1 join fields to help it dedupe, but this is more flexible,
-    // so unless this is a direct 1-to-1 join with the main entity, we'll just hack it
-    // with a padded empty stack to bypass its deduping.
-    $aclStack = [NULL, NULL];
+    // Used to dedupe acl clauses
+    $aclStack = [];
     // See if the ON clause already contains an FK reference to joinEntity
     $explicitFK = array_filter($joinTree, function($clause) use ($alias, $joinEntityFields, &$aclStack) {
       [$sideA, $op, $sideB] = array_pad((array) $clause, 3, NULL);
@@ -538,17 +553,18 @@ class Api4SelectQuery extends Api4Query {
         }
         $joinField = str_replace("$alias.", '', $expr);
         // Check for explicit link to FK entity (include entity_id for dynamic FKs)
-        // FIXME: This is just guessing. We ought to check the schema for all unique fields and foreign keys.
         if (
           // Unique field - might be a link FROM the other entity
+          // FIXME: This is just guessing. We ought to check the schema for all unique fields
           in_array($joinField, ['id', 'name'], TRUE) ||
           // FK field - might be a link TO the other entity
-          $joinField === 'entity_id' || !empty($joinEntityFields[$joinField]['fk_entity'])) {
-          // If the join links to a field on the main entity, ACL clauses can be deduped
-          if (preg_match('/^[_a-z0-9]+$/i', $clause[$otherSide])) {
-            $aclStack = [$clause[$otherSide]];
+          !empty($joinEntityFields[$joinField]['dfk_entities']) || !empty($joinEntityFields[$joinField]['fk_entity'])
+        ) {
+          // If the join links to a field on another entity
+          if (preg_match('/^[_a-z0-9.]+$/i', $clause[$otherSide])) {
+            $aclStack = [$clause[$otherSide], $expr];
+            return TRUE;
           }
-          return TRUE;
         }
       }
       return FALSE;
@@ -565,12 +581,12 @@ class Api4SelectQuery extends Api4Query {
         }
         elseif (str_starts_with($name, "$alias.") && substr_count($name, '.') === 1 && $field['fk_entity'] === $this->getEntity()) {
           $conditions[] = $this->treeWalkClauses([$name, '=', 'id'], 'ON');
-          $aclStack = ['id'];
+          $aclStack = ['id', $name];
         }
       }
       // Hmm, if we came up with > 1 condition, then it's ambiguous how it should be joined so we won't return anything but the generic ACLs
       if (count($conditions) > 1) {
-        $aclStack = [NULL, NULL];
+        $aclStack = [];
         $conditions = [];
       }
     }
@@ -609,7 +625,7 @@ class Api4SelectQuery extends Api4Query {
     $this->registerBridgeJoinFields($bridgeEntity, $joinRef, $baseRef, $alias, $bridgeAlias);
 
     // Used to dedupe acl clauses
-    $aclStack = [NULL, NULL];
+    $aclStack = [];
 
     $linkConditions = $this->getBridgeLinkConditions($bridgeAlias, $alias, $joinEntity, $joinRef);
 
@@ -743,7 +759,7 @@ class Api4SelectQuery extends Api4Query {
       if ($op === '=' && $sideB && ($sideA === "$alias.{$baseRef->getReferenceKey()}" || $sideB === "$alias.{$baseRef->getReferenceKey()}")) {
         $expr = $sideA === "$alias.{$baseRef->getReferenceKey()}" ? $sideB : $sideA;
         $bridgeConditions[] = "`$bridgeAlias`.`{$baseRef->getReferenceKey()}` = " . $this->getExpression($expr)->render($this);
-        $aclStack = [$expr];
+        $aclStack = [$expr, $bridgeAlias . '.' . $baseRef->getReferenceKey()];
         return FALSE;
       }
       // Explicit link with dynamic "entity_table" column
@@ -760,7 +776,7 @@ class Api4SelectQuery extends Api4Query {
         throw new \CRM_Core_Exception("Unable to join $bridgeEntity to " . $this->getEntity());
       }
       $bridgeConditions[] = "`$bridgeAlias`.`{$baseRef->getReferenceKey()}` = a.`{$baseRef->getTargetKey()}`";
-      $aclStack = [$baseRef->getTargetKey()];
+      $aclStack = [$baseRef->getTargetKey(), $bridgeAlias . '.' . $baseRef->getReferenceKey()];
       if ($baseRef->getTypeColumn()) {
         $dfkOption = array_search($this->getEntity(), $baseRef->getTargetEntities());
         $bridgeConditions[] = "`$bridgeAlias`.`{$baseRef->getTypeColumn()}` = '$dfkOption'";
@@ -791,10 +807,11 @@ class Api4SelectQuery extends Api4Query {
     if ($explicitJoin) {
       $baseTableAlias = array_shift($pathArray);
     }
+    $explicitJoinPrefix = $explicitJoin ? $explicitJoin['alias'] . '.' : '';
 
     // Ensure joinTree array contains base table
     $this->joinTree[$baseTableAlias]['#table_alias'] = $baseTableAlias;
-    $this->joinTree[$baseTableAlias]['#path'] = $explicitJoin ? $baseTableAlias . '.' : '';
+    $this->joinTree[$baseTableAlias]['#path'] = $explicitJoinPrefix;
     // During iteration this variable will refer to the current position in the tree
     $joinTreeNode =& $this->joinTree[$baseTableAlias];
 
@@ -819,7 +836,13 @@ class Api4SelectQuery extends Api4Query {
       }
     }
 
+    // Used to dedupe acl clauses
+    if (isset($pathArray[0])) {
+      $aclStack = [$explicitJoinPrefix . $pathArray[0]];
+    }
+
     foreach ($joinPath as $joinName => $link) {
+      $aclStack[] = $joinName . '.' . $link->getTargetColumn();
       if (!isset($joinTreeNode[$joinName])) {
         $target = $link->getTargetTable();
         $tableAlias = $link->getAlias() . '_' . ++$this->autoJoinSuffix;
@@ -874,7 +897,7 @@ class Api4SelectQuery extends Api4Query {
         if (!$virtualField) {
           $conditions = $link->getConditionsForJoin($baseTableAlias, $tableAlias, $this->openJoin);
           if ($joinEntity) {
-            $conditions = array_merge($conditions, $this->getAclClause($tableAlias, $joinEntity, $joinPath));
+            $conditions = array_merge($conditions, $this->getAclClause($tableAlias, $joinEntity, $aclStack));
           }
           $this->addJoin('LEFT', $target, $tableAlias, $baseTableAlias, $conditions);
         }

--- a/tests/phpunit/api/v4/Action/HookSelectWhereTest.php
+++ b/tests/phpunit/api/v4/Action/HookSelectWhereTest.php
@@ -1,0 +1,185 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace Civi\tests\phpunit\api\v4\Action;
+
+use api\v4\Api4TestBase;
+use Civi\Api4\Address;
+use Civi\Api4\Contact;
+use Civi\Api4\Phone;
+use Civi\Core\HookInterface;
+use Civi\Test\ACLPermissionTrait;
+
+/**
+ * @group headless
+ */
+class HookSelectWhereTest extends Api4TestBase implements HookInterface {
+
+  use ACLPermissionTrait;
+
+  private $hookEntity;
+  private $hookCondition = [];
+
+  public function testHookPhoneClause(): void {
+    $cid = $this->createTestRecord('Individual')['id'];
+    $this->saveTestRecords('Phone', [
+      'records' => [
+        ['phone' => '111-1111', 'location_type_id' => 1, 'contact_id' => $cid],
+        ['phone' => '222-2222', 'location_type_id' => 2, 'contact_id' => $cid],
+        ['phone' => '333-3333', 'location_type_id' => 3, 'contact_id' => $cid],
+      ],
+    ]);
+
+    $this->hookEntity = 'Phone';
+    $this->hookCondition = [
+      'location_type_id' => ['= 1'],
+    ];
+    $result = Phone::get()
+      ->addWhere('contact_id', '=', $cid)
+      ->execute();
+
+    $this->assertCount(1, $result);
+    $this->assertEquals('111-1111', $result[0]['phone']);
+
+    $result = Contact::get()
+      ->addWhere('id', '=', $cid)
+      ->addJoin('Phone AS phone', 'INNER', ['phone.contact_id', '=', 'id'])
+      ->addSelect('phone.phone')
+      ->execute();
+
+    $this->assertCount(1, $result);
+    $this->assertEquals('111-1111', $result[0]['phone.phone']);
+  }
+
+  public function testDedupeACLClauses(): void {
+    $cidDisallowed = $this->createTestRecord('Individual')['id'];
+    $cidAllowed = $this->createTestRecord('Individual', [
+      'first_name' => 'Allowed',
+    ])['id'];
+
+    $this->saveTestRecords('Address', [
+      'records' => [
+        ['location_type_id' => 1, 'contact_id' => $cidDisallowed],
+        ['location_type_id' => 1, 'contact_id' => $cidAllowed, 'street_address' => '111 Allowed'],
+        ['location_type_id' => 2, 'contact_id' => $cidAllowed, 'street_address' => '222 Allowed'],
+        ['location_type_id' => 3, 'contact_id' => $cidAllowed, 'street_address' => '333 Allowed'],
+      ],
+    ]);
+
+    $this->createLoggedInUser();
+
+    $this->allowedContactId = $cidAllowed;
+    \CRM_Utils_Hook_UnitTests::singleton()->setHook('civicrm_aclWhereClause', [
+      $this,
+      'aclWhereOnlyOne',
+    ]);
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'view debug output'];
+
+    $this->hookEntity = 'Address';
+    $this->hookCondition = [
+      'location_type_id' => ['IN (1,2)'],
+    ];
+
+    $result = Address::get()
+      ->addSelect('id')
+      ->setDebug(TRUE)
+      ->execute();
+
+    $this->assertCount(2, $result);
+
+    // Ensure our selectWhereClause has been inserted exactly once
+    $selectWhereCount = substr_count($result->debug['sql'][0], '`location_type_id` IN (1,2)');
+    $this->assertEquals(1, $selectWhereCount);
+
+    $result = Address::get()
+      ->addWhere('location_type_id', '=', 1)
+      ->addSelect('id', 'contact_id.first_name')
+      ->setDebug(TRUE)
+      ->execute();
+
+    $this->assertCount(1, $result);
+    $this->assertEquals('Allowed', $result[0]['contact_id.first_name']);
+
+    $selectWhereCount = substr_count($result->debug['sql'][0], '`location_type_id` IN (1,2)');
+    $this->assertEquals(1, $selectWhereCount);
+
+    // We only want to see one contact ACL where clause
+    $aclCount = substr_count($result->debug['sql'][0], 'civicrm_acl_contact_cache');
+    $this->assertEquals(1, $aclCount);
+
+    // Try with explicit join
+    $result = Address::get()
+      ->addWhere('location_type_id', '=', 1)
+      ->addSelect('id', 'contact.first_name')
+      ->addJoin('Contact AS contact', 'INNER', ['contact.id', '=', 'contact_id'])
+      ->setDebug(TRUE)
+      ->execute();
+
+    $this->assertCount(1, $result);
+    $this->assertEquals('Allowed', $result[0]['contact.first_name']);
+
+    $selectWhereCount = substr_count($result->debug['sql'][0], '`location_type_id` IN (1,2)');
+    $this->assertEquals(1, $selectWhereCount);
+
+    // We only want to see one contact ACL where clause
+    $aclCount = substr_count($result->debug['sql'][0], 'civicrm_acl_contact_cache');
+    $this->assertEquals(1, $aclCount);
+
+    // Try joining through another entity
+    $phone = $this->createTestRecord('Phone', [
+      'contact_id' => $cidAllowed,
+    ]);
+
+    $this->hookEntity = 'Address';
+    $this->hookCondition = [
+      'location_type_id' => ['IN (2)'],
+    ];
+
+    $result = Phone::get()
+      ->addWhere('id', '=', $phone['id'])
+      ->addSelect('id', 'contact.first_name', 'address.street_address')
+      ->addJoin('Contact AS contact', 'INNER', ['contact.id', '=', 'contact_id'])
+      ->addJoin('Address AS address', 'INNER', ['address.contact_id', '=', 'contact.id'])
+      ->setDebug(TRUE)
+      ->execute();
+
+    $this->assertCount(1, $result);
+    $this->assertEquals('Allowed', $result[0]['contact.first_name']);
+    $this->assertEquals('222 Allowed', $result[0]['address.street_address']);
+
+    $selectWhereCount = substr_count($result->debug['sql'][0], '`location_type_id` IN (2)');
+    $this->assertEquals(1, $selectWhereCount);
+
+    // We only want to see one contact ACL where clause
+    $aclCount = substr_count($result->debug['sql'][0], 'civicrm_acl_contact_cache');
+    $this->assertEquals(1, $aclCount);
+  }
+
+  /**
+   * Implements hook_civicrm_selectWhereClause().
+   */
+  public function hook_civicrm_selectWhereClause($entity, &$clauses) {
+    if ($entity == $this->hookEntity) {
+      foreach ($this->hookCondition as $field => $clause) {
+        $clauses[$field] = array_merge(($clauses[$field] ?? []), $clause);
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Improves old code ported over from api3 that wasn't well-tuned to working with Api4 explicit joins. Deduping is important for efficiency so the same clauses don't get added to the sql multiple times.

Before
----------------------------------------
Deduping only worked for implicit joins

After
----------------------------------------
Deduping works for any combination of explicit and implicit joins