### PR TITLE
Switch 'smtp' form to use metadata rather than legacy method

### DIFF
--- a/CRM/Admin/Form/Setting/Smtp.php
+++ b/CRM/Admin/Form/Setting/Smtp.php
@@ -22,19 +22,6 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
   protected $_testButtonName;
 
   /**
-   * Subset of settings on the page as defined using the legacy method.
-   *
-   * @var array
-   *
-   * @deprecated - do not add new settings here - the page to display
-   * settings on should be defined in the setting metadata.
-   */
-  protected $_settings = [
-    // @todo remove these, define any not yet defined in the setting metadata.
-    'allow_mail_from_logged_in_contact' => CRM_Core_BAO_Setting::DIRECTORY_PREFERENCES_NAME,
-  ];
-
-  /**
    * Build the form object.
    */
   public function buildQuickForm() {
@@ -239,37 +226,35 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
    * Set default values for the form.
    */
   public function setDefaultValues() {
-    if (!$this->_defaults) {
-      $this->_defaults = [];
+    parent::setDefaultValues();
 
-      $mailingBackend = Civi::settings()->get('mailing_backend');
-      if (!empty($mailingBackend)) {
-        $this->_defaults = $mailingBackend;
+    $mailingBackend = Civi::settings()->get('mailing_backend');
+    if (!empty($mailingBackend)) {
+      $this->_defaults += $mailingBackend;
 
-        if (!empty($this->_defaults['smtpPassword'])) {
-          try {
-            $this->_defaults['smtpPassword'] = \Civi::service('crypto.token')->decrypt($this->_defaults['smtpPassword']);
-          }
-          catch (Exception $e) {
-            Civi::log()->error($e->getMessage());
-            CRM_Core_Session::setStatus(ts('Unable to retrieve the encrypted password. Please check your configured encryption keys. The error message is: %1', [1 => $e->getMessage()]), ts("Encryption key error"), "error");
-          }
+      if (!empty($mailingBackend['smtpPassword'])) {
+        try {
+          $this->_defaults['smtpPassword'] = \Civi::service('crypto.token')->decrypt($this->_defaults['smtpPassword']);
         }
-      }
-      else {
-        if (!isset($this->_defaults['smtpServer'])) {
-          $this->_defaults['smtpServer'] = 'localhost';
-          $this->_defaults['smtpPort'] = 25;
-          $this->_defaults['smtpAuth'] = 0;
-        }
-
-        if (!isset($this->_defaults['sendmail_path'])) {
-          $this->_defaults['sendmail_path'] = '/usr/sbin/sendmail';
-          $this->_defaults['sendmail_args'] = '-i';
+        catch (Exception $e) {
+          Civi::log()->error($e->getMessage());
+          CRM_Core_Session::setStatus(ts('Unable to retrieve the encrypted password. Please check your configured encryption keys. The error message is: %1', [1 => $e->getMessage()]), ts("Encryption key error"), "error");
         }
       }
     }
-    $this->_defaults['allow_mail_from_logged_in_contact'] = Civi::settings()->get('allow_mail_from_logged_in_contact');
+    else {
+      if (!isset($mailingBackend['smtpServer'])) {
+        $this->_defaults['smtpServer'] = 'localhost';
+        $this->_defaults['smtpPort'] = 25;
+        $this->_defaults['smtpAuth'] = 0;
+      }
+
+      if (!isset($mailingBackend['sendmail_path'])) {
+        $this->_defaults['sendmail_path'] = '/usr/sbin/sendmail';
+        $this->_defaults['sendmail_args'] = '-i';
+      }
+    }
+
     return $this->_defaults;
   }
 

--- a/settings/Mailing.setting.php
+++ b/settings/Mailing.setting.php
@@ -398,8 +398,9 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => ts('Allow sending email from the logged in contact\'s email address.'),
-    'help_text' => 'CiviCRM allows you to send email from the domain from email addresses and the logged in contact id addresses by default. Disable this if you only want to allow the domain from addresses to be used.',
+    'help_text' => ts('CiviCRM allows you to send email from the domain from email addresses and the logged in contact id addresses by default. Disable this if you only want to allow the domain from addresses to be used.'),
     'add' => '4.7.31',
+    'settings_pages' => ['smtp' => ['weight' => 10]],
   ],
   'url_tracking_default' => [
     'group_name' => 'Mailing Preferences',

--- a/templates/CRM/Admin/Form/Setting/SettingField.tpl
+++ b/templates/CRM/Admin/Form/Setting/SettingField.tpl
@@ -4,7 +4,7 @@
     {$form.$setting_name.label}
     {if array_key_exists('help_text', $fieldSpec) && $fieldSpec.help_text}
       {* @todo the appended -id here appears to be inconsistent in the hlp files *}
-      {assign var='tplhelp_id' value = $setting_name|cat:'-id'|replace:'_':'-'}{help id="$tplhelp_id"}
+      {assign var='tplhelp_id' value = $setting_name|cat:'-id'|replace:'_':'-'}{help id="$tplhelp_id" title=$fieldSpec['title']}
     {/if}
   </td>
   <td>

--- a/templates/CRM/Admin/Form/Setting/Smtp.hlp
+++ b/templates/CRM/Admin/Form/Setting/Smtp.hlp
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 
-{htxt id='allow_mail_contact_email'}
+{htxt id='allow-mail-from-logged-in-contact-id'}
 {capture assign=adminFromEmailURL}{crmURL p="civicrm/admin/options/site_email_address" q="reset=1"}{/capture}
 {ts 1=$adminFromEmailURL}If this is enabled a logged in user can send email from their own email address as well as the configured
   <a href="%1"><strong>Site Email Addresses</strong></a>.  This applies to actions such as "Send Email", "Email Invoice" and "Send Receipt". If this setting

--- a/templates/CRM/Admin/Form/Setting/Smtp.tpl
+++ b/templates/CRM/Admin/Form/Setting/Smtp.tpl
@@ -10,12 +10,11 @@
 <div class="crm-block crm-form-block crm-smtp-form-block">
   <div>
   <h3>{ts}General{/ts}</h3>
-     <table class="form-layout-compressed">
-       <tr class="crm-smtp-form-block-allow_mail_from_logged_in_contact">
-         <td>{$form.allow_mail_from_logged_in_contact.label} {help id=allow_mail_contact_email}</td>
-         <td class="label">{$form.allow_mail_from_logged_in_contact.html}</td>
-       </tr>
-     </table>
+    <table class="form-layout-compressed">
+      {foreach from=$settings_fields key="setting_name" item="fieldSpec"}
+        {include file="CRM/Admin/Form/Setting/SettingField.tpl"}
+      {/foreach}
+    </table>
   </div>
   {crmRegion name="smtp-mailer-config"}
   <div class="crm-smtp-mailer-form-block">


### PR DESCRIPTION
Overview
----------------------------------------
Switch 'smtp' form to use metadata rather than legacy method

Before
----------------------------------------
Deprecated method used

After
----------------------------------------
New method - no change

![image](https://github.com/user-attachments/assets/d13e595d-fef6-42ce-860e-3b77c2448f6c)

But - the new method & more standardised functions permit injection by extensions

![image](https://github.com/user-attachments/assets/5fe28198-317b-42be-abdc-d0b4cf407f7d)


Technical Details
----------------------------------------

Comments
----------------------------------------
