### PR TITLE
Use non-deprecated smarty5 syntax for join/implode modifier [requires civicrm/civicrm-packages#423 to keep smarty2 support and civicrm-packages#424 for smarty4]

### DIFF
--- a/templates/CRM/Case/Page/CustomDataView.tpl
+++ b/templates/CRM/Case/Page/CustomDataView.tpl
@@ -32,7 +32,7 @@
                 {elseif $element.field_data_type == 'Money' && $element.field_type == 'Text'}
                   {$element.data|crmMoney}
                 {elseif $element.field_data_type == 'ContactReference' && $element.contact_ref_links}
-                  {', '|implode:$element.contact_ref_links}
+                  {$element.contact_ref_links|join:', '}
                 {else}
                   {$element.field_value}
                 {/if}

--- a/templates/CRM/Contact/Form/Merge.tpl
+++ b/templates/CRM/Contact/Form/Merge.tpl
@@ -106,7 +106,7 @@
             {elseif $row.other.fileName}
               {$row.other.fileName|escape}
             {else}
-              {', '|implode:$row.other}
+              {$row.other|join:', '}
             {/if}
             </span>
           </td>
@@ -132,7 +132,7 @@
                 {elseif $row.main.fileName}
                   {$row.main.fileName|escape}
                 {else}
-                  {', '|implode:$row.main}
+                  {$row.main|join:', '}
                 {/if}
                 </span>
               {/strip}
@@ -185,7 +185,7 @@
                 {elseif $row.main.fileName}
                   {$row.main.fileName|escape}
                 {else}
-                  {', '|implode:$row.main}
+                  {$row.main|join:', '}
                 {/if}
               </span>
             </td>

--- a/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
+++ b/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
@@ -30,7 +30,7 @@
           {if $element.field_data_type EQ 'ContactReference' && $element.contact_ref_links}
             {*Contact ref id passed if user has sufficient permissions - so make a link.*}
             <div class="crm-content crm-custom-data crm-contact-reference">
-              {', '|implode:$element.contact_ref_links}
+              {$element.contact_ref_links|join:', '}
             </div>
           {else}
             <div class="crm-content crm-custom-data">{$element.field_value}</div>

--- a/templates/CRM/Custom/Page/CustomDataView.tpl
+++ b/templates/CRM/Custom/Page/CustomDataView.tpl
@@ -68,7 +68,7 @@
                             {/if}
                           {else}
                             {if $element.field_data_type EQ 'ContactReference' && $element.contact_ref_links}
-                              {', '|implode:$element.contact_ref_links}
+                              {$element.contact_ref_links|join:', '}
                             {else}
                               {$element.field_value}
                             {/if}
@@ -120,7 +120,7 @@
                 {else}
                   <div class="content">
                     {if $element.field_data_type EQ 'ContactReference' && $element.contact_ref_links}
-                      {', '|implode:$element.contact_ref_links}
+                      {$element.contact_ref_links|join:', '}
                     {else}
                       {if $element.field_value}{$element.field_value} {else}<br/>{/if}
                     {/if}

--- a/templates/CRM/Tag/Form/Merge.tpl
+++ b/templates/CRM/Tag/Form/Merge.tpl
@@ -11,7 +11,7 @@
 <div class="crm-block crm-form-block crm-tag-form-block">
   <div class="status">
     {ts 1=$tags|@count}You are about to combine the following %1 tags into a single tag:{/ts}<br />
-    {', '|implode:$tags}
+    {$tags|join:', '}
   </div>
   <table class="form-layout-compressed">
     <tr class="crm-tag-form-block-label">


### PR DESCRIPTION
Overview
----------------------------------------
This requires https://github.com/civicrm/civicrm-packages/pull/423 to keep working with smarty2 and https://github.com/civicrm/civicrm-packages/pull/424 to keep working with smarty4.

Before
----------------------------------------
Deprecations about `|implode` being deprecated and also the order of params.

After
----------------------------------------
The only syntax that works in smarty5 without deprecations.

Technical Details
----------------------------------------
| | smarty2 | smarty5 |
| - | - | - |
| join with modern syntax | TypeError | ok |
| implode with modern syntax | TypeError | deprecation warning (implode is completely deprecated) |
| join with "backwards" syntax | ok | deprecation warning (about param ordering) |
| implode with "backwards" syntax | ok | deprecation warning (implode is completely deprecated) |

With the packages PR above it changes to this, so this PR changes them to use join with modern syntax.

| | smarty2 | smarty5 |
| - | - | - |
| join with modern syntax | ok | ok |
| implode with modern syntax | TypeError | deprecation warning (implode is completely deprecated) |
| join with "backwards" syntax | ok | deprecation warning (about param ordering) |
| implode with "backwards" syntax | ok | deprecation warning (implode is completely deprecated) |

Comments
----------------------------------------
smarty4 behaves the same as smarty2

For templates/CRM/Contact/Form/Merge.tpl, there are code comments that suggest it's possibly never an array. I wasn't able to see how to make it an array - multivalue custom fields and multivalue custom field groups don't trigger it. So I don't know how to reproduce a deprecation there but it's the same change as everywhere else.
