### PR TITLE
fix viewing PCP info page

### DIFF
--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -256,7 +256,7 @@ WHERE pcp.id = %1 AND cc.contribution_status_id = %2 AND cc.is_test = 0";
     ];
     $dao = CRM_Core_DAO::executeQuery($query, $params);
     $honor = [];
-    while ($dao->find()) {
+    while ($dao->fetch()) {
       $honor[$dao->id]['nickname'] = ucwords($dao->pcp_roll_nickname);
       $honor[$dao->id]['total_amount'] = CRM_Utils_Money::format($dao->total_amount, $dao->currency);
       $honor[$dao->id]['personal_note'] = $dao->pcp_personal_note;


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5859


Before
----------------------------------------
PCP Info page won't load.

After
----------------------------------------
It loads.

Technical Details
----------------------------------------
This regressed with https://github.com/civicrm/civicrm-core/pull/32360.

Comments
----------------------------------------
I can't figure out why this might have changed, it may have been unintentional?
