### PR TITLE
(Un)Installer - Fix testing issue on D7

### DIFF
--- a/setup/plugins/uninstallDatabase/CleanupDrupalSession.civi-setup.php
+++ b/setup/plugins/uninstallDatabase/CleanupDrupalSession.civi-setup.php
@@ -23,7 +23,7 @@ if (!defined('CIVI_SETUP')) {
     // more surgical approach would get messy (due to variations of session-encoding),
     // and... it seems to work...
 
-    db_query('UPDATE sessions SET session = NULL');
+    db_query('UPDATE sessions SET session = ?', ['']);
 
     //    foreach(db_query('SELECT sid FROM sessions') as $sid) {
     //      $sessionResult = db_query('SELECT session FROM sessions WHERE sid = :sid', array(


### PR DESCRIPTION
Overview
----------------------------------------

Fix a bug with the uninstall routine on D7.

This is a niche thing. IMHO, the main impact is on manual testing of the installer (*where you repeatedly install=>uninstall=>install=>uninstall=>...*) -- which is occasionally important for me, but most people never need to do that.

If you're reading this, the main thing that should put your mind at ease is that... the patch is entirely limited to the `uninstallDatabase` event (and only on D7), so potential impact is small. (And I am `r-run`ning the patch from a few angles.)

Steps to Reproduce
----------------------------------------

* Install (eg `cv core:install`; or use `civicrm/setup` web UI)
* Login to Drupal-Civi
* Uninstall (eg `cv core:uninstall`)
* Re-install (eg `cv core:install`; or use `civicrm/setup` web UI)
* Open any CiviCRM page

Before
----------------------------------------

* The nav-bar fails to render.
* The Drupal "Logout" button doesn't work.
* It doesn't matter how many times you flush Drupal or Civi caches.
* Under the hood, the SQL column `sessions.session` appears to be stuck with `NULL`.
* The only way out is to manually clean the browser-cookies or manually clean the SQL `sessions` data.

After
----------------------------------------

* Nav-bar and logout are more normal.

Technical Details
----------------------------------------

This patch is based on grepping to find out how `sessions.session` is usually written. There is a unit-test in the final public release of D7 which does a similar session-reset, but it writes `''` instead of `NULL`.

 https://github.com/drupal/drupal/blob/7.103/modules/simpletest/tests/upgrade/upgrade.test#L74



