### PR TITLE
[REF] CiviImport - Pass full values array to import function

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -60,6 +60,7 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
    *   The array of values belonging to this line.
    */
   public function import(array $values): void {
+    $values = array_values($values);
     $rowNumber = (int) ($values[array_key_last($values)]);
     // First make sure this is a valid line
     try {

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -112,6 +112,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    *   The array of values belonging to this line.
    */
   public function import(array $values): void {
+    $values = array_values($values);
     $rowNumber = (int) $values[array_key_last($values)];
 
     // Put this here for now since we're gettting run by a job and need to

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -384,6 +384,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
    *   The array of values belonging to this line.
    */
   public function import(array $values): void {
+    $values = array_values($values);
     $rowNumber = (int) ($values[array_key_last($values)]);
     try {
       $params = $this->getMappedRow($values);

--- a/CRM/Custom/Import/Parser/Api.php
+++ b/CRM/Custom/Import/Parser/Api.php
@@ -79,6 +79,7 @@ class CRM_Custom_Import_Parser_Api extends CRM_Import_Parser {
    *   The array of values belonging to this line.
    */
   public function import(array $values): void {
+    $values = array_values($values);
     $rowNumber = (int) $values[array_key_last($values)];
     try {
       $params = $this->getMappedRow($values);

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -101,6 +101,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
    *   The array of values belonging to this line.
    */
   public function import(array $values): void {
+    $values = array_values($values);
     $rowNumber = (int) ($values[array_key_last($values)]);
     try {
       $params = $this->getMappedRow($values);

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1426,8 +1426,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     $dataSource->setLimit($limit);
 
     while ($row = $dataSource->getRow()) {
-      $values = array_values($row);
-      $parser->import($values);
+      $parser->import($row);
     }
     $parser->doPostImportActions();
     return TRUE;

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -161,6 +161,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
    *   the result of this processing - which is ignored
    */
   public function import(array $values) {
+    $values = array_values($values);
     $rowNumber = (int) ($values[array_key_last($values)]);
     try {
       $params = $this->getMappedRow($values);


### PR DESCRIPTION
Overview
----------------------------------------
Makes import code a little easier to work with.

Technical Details
----------------------------------------
For some reason all these import functions want an unkeyed array, but the array keys are useful. So this moves the key removal into the functions so they can decide whether or not they want them.