### PR TITLE
SK: Rewrite tokens in 'Link' metadata correctly

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -568,6 +568,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    */
   protected function formatLink(array $link, array $data, bool $allowMultiple = FALSE, ?string $text = NULL, $index = 0): ?array {
     $useApi = (!empty($link['entity']) && !empty($link['action']));
+    $originalData = $data;
     if (isset($index)) {
       foreach ($data as $key => $value) {
         if (is_array($value)) {
@@ -596,6 +597,8 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     elseif (!$this->checkLinkAccess($link, $data)) {
       return NULL;
     }
+    // FIXME: We should use $originalData so button links can render tokens correctly. But
+    // this doesn't match the getLinks() behavior so is out of scope for now.
     $link['text'] = $text ?? $this->replaceTokens($link['text'], $data, 'view');
     if (!empty($link['task'])) {
       $keys = ['task', 'text', 'title', 'icon', 'style'];
@@ -605,7 +608,8 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       if (($link['csrf'] ?? NULL) === 'qfKey') {
         $query['qfKey'] = $this->getQfKey($link['path']);
       }
-      $path = $this->replaceTokens($link['path'], $data, 'url');
+      // We use original data so that tokens which rely on array-based columns are correctly rendered.
+      $path = $this->replaceTokens($link['path'], $originalData, 'url');
       if (!$path) {
         // Return null if `$link[path]` is empty or if any tokens do not resolve
         return NULL;


### PR DESCRIPTION
Overview
----------------------------------------
The last comment on [core#3197](https://lab.civicrm.org/dev/core/-/issues/3197#note_181291) explains this.

Before
----------------------------------------
In SK displays, using a token of a `GROUP_CONCAT` field works correctly when used in the "Rewrite" metadata, but in "Link", it chops off all but the first value.

After
----------------------------------------
Tokens are rendered correctly in both places.

Comments
----------------------------------------
The use case that prompted my attention is wanting to connect two SK/FB displays comparable to how "Contribution Summary" and "Contribution Details" work in CiviReport.

Unlike CiviReport, FB won't let us pass the filters from the "Summary" display to the "Detail" display.  So instead I'm passing the list of contribution IDs.  However, `formatLink()` was written assuming it'll mostly be used for "View/Update/Delete $entity" buttons, where there'll only be one ID passed.

I focused on rewriting links for fields, and didn't touch the code that affects the behavior/labels of buttons.  Fixing the FIXME (by changing `$data` in the next line to `$originalData`) fixes the button labels, but changing the button behavior requires a much bigger change. So leaving that out of scope - but I'd argue that a token should render identically in all contexts.