### PR TITLE
dev/core#5843 Move full space trim to DataSource on write

### DIFF
--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -165,7 +165,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
       $first = FALSE;
 
       // CRM-17859 Trim non-breaking spaces from columns.
-      $row = array_map([__CLASS__, 'trimNonBreakingSpaces'], $row);
+      $row = array_map([__CLASS__, 'trimWhiteSpace'], $row);
       $row = array_map(['CRM_Core_DAO', 'escapeString'], $row);
       $sql .= "('" . implode("', '", $row) . "')";
       $count++;

--- a/Civi/Import/DataSource/DataSourceTrait.php
+++ b/Civi/Import/DataSource/DataSourceTrait.php
@@ -267,6 +267,14 @@ trait DataSourceTrait {
    * See also dev/core#2127 - avoid breaking strings ending in à or any other
    * unicode character sharing the same 0xA0 byte as a non-breaking space.
    *
+   * See https://lab.civicrm.org/dev/core/-/issues/5843 for history, discussion.
+   * We can probably switch to mb_trim but need the 8.4 polyfill.
+   *
+   * @internal Note there is one known extension calling this directly
+   * (import_extensions, which offers importing an already-uploaded csv), but that
+   * will be fixed by 6.3. Extensions should expect this function to be removed/
+   * consolidated into trimWhiteSpace.
+   *
    * @param string $string
    * @return string The trimmed string
    */
@@ -284,6 +292,10 @@ trait DataSourceTrait {
       $string = mb_convert_encoding($string, 'UTF-8', [$encoding]);
     }
     return preg_replace("/^(\u{a0})+|(\u{a0})+$/", '', $string);
+  }
+
+  public static function trimWhitespace(string $string): string {
+    return trim(self::trimNonBreakingSpaces($string), " \t\r\n");
   }
 
 }

--- a/ext/civiimport/Civi/Import/DataSource/Spreadsheet.php
+++ b/ext/civiimport/Civi/Import/DataSource/Spreadsheet.php
@@ -157,7 +157,7 @@ class Spreadsheet extends \CRM_Import_DataSource implements DataSourceInterface 
     $sql = [];
     foreach ($dataRows as $row) {
       // CRM-17859 Trim non-breaking spaces from columns.
-      $row = array_map([__CLASS__, 'trimNonBreakingSpaces'], $row);
+      $row = array_map([__CLASS__, 'trimWhiteSpace'], $row);
       $row = array_map(['CRM_Core_DAO', 'escapeString'], $row);
       $sql[] = "('" . implode("', '", $row) . "')";
 

--- a/tests/phpunit/CRM/Contribute/Import/Parser/data/contributions_need_trim.csv
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/data/contributions_need_trim.csv
@@ -1,0 +1,2 @@
+External Identifier,Total Amount,Receive Date,Financial Type,Soft Credit to,State,Source,Note,Transaction ID,Campaign ID,Blank column
+bob,65,2008-09-20,Donation,mum@example.com, , ,Call him back,999,1,


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5843 Move full space trim to DataSource on write

Before
----------------------------------------
When importing through the UI non-breaking spaces are trimmed before saving to the import table and 'plain' spaces are trimmed when the row is retrieved from the import table. BUT if you import via the api (eg. if you turn on background processing) the 'plain' spaces are never trimmed

After
----------------------------------------
All trimming is done by the CSV class when loading the data to the import table. Other datasources are responsible for their own but this is low impact as

1) Core SQL datasource- sql writers would reasonably expect that whitespace would be trimmed in the sql if appropriate (& generally no present)
2) Core Civiimport datasource - spreadsheet - fixed here
3) import_extensions Extension - import from uploaded file - I can fix this one
4) import_extensions Extension - import from json - not relevant
5) import_extensions Extension - import from previous import - not relevant
6) DataSources not widely implemented otherwise - ie not in @mlutfy extension

Technical Details
----------------------------------------
It was crazy-hard to find this trimming so the new location should make more sense

Comments
----------------------------------------
