### PR TITLE
phpstorm - Add autocomplete for permission names

### DIFF
--- a/tools/extensions/phpstorm/Civi/PhpStorm/PermissionsGenerator.php
+++ b/tools/extensions/phpstorm/Civi/PhpStorm/PermissionsGenerator.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Civi\PhpStorm;
+
+use Civi\Core\Service\AutoService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @service civi.phpstorm.permissions
+ */
+class PermissionsGenerator extends AutoService implements EventSubscriberInterface {
+
+  public static function getSubscribedEvents() {
+    return ['civi.phpstorm.flush' => 'generate'];
+  }
+
+  public function generate() {
+    $permissions = \Civi\Api4\Permission::get(FALSE)->execute()->column('name');
+    $methods = ['check'];
+    $builder = new PhpStormMetadata('permissions', __CLASS__);
+    $builder->registerArgumentsSet('permissionNames', ...$permissions);
+    foreach ($methods as $method) {
+      $builder->addExpectedArguments('\CRM_Core_Permission::' . $method . '()', 0, 'permissionNames');
+    }
+    $builder->write();
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

Add PhpStorm auto-complete hints for `CRM_Core_Permission::check()`

Before
----------------------------------------

No auto-complete

After
----------------------------------------

![Screenshot from 2025-04-29 18-32-16](https://github.com/user-attachments/assets/a1d0e84b-f248-4171-bfe0-4ffbe7a3cd6f)

