### PR TITLE
Show the "Public Pages" visibility group in the email the contact is subscribed to it

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1007,8 +1007,8 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup implements \Civi\Core\Ho
             if ($g['visibility'] != 'User and User Admin Only' ||
               CRM_Utils_Array::key(CRM_Core_Permission::VIEW, $groupPerm)
             ) {
-              $title[] = $g['title'];
               if ($g['visibility'] == 'Public Pages') {
+                $title[] = $g['title'];
                 $ids[] = $g['group_id'];
               }
             }


### PR DESCRIPTION

Overview
----------------------------------------
The group field is used in the profile; it shows the group with visibility set to "Public Pages". However, when the user selects the group and submits the form, when the email is received, it contains other groups of contacts if the contact has other groups with other visibility types. 

Before
----------------------------------------
All contact groups were displayed.

Group field in profile used on donation page: 
<img width="659" alt="Screenshot 2025-04-30 at 3 47 55 PM" src="https://github.com/user-attachments/assets/a53b36bd-ce0a-4339-83a1-c91e40e0fc69" />

Email:
<img width="670" alt="Screenshot 2025-04-30 at 3 48 16 PM" src="https://github.com/user-attachments/assets/4f043c99-cd8a-40a8-b94d-b4584954dcd4" />



After
----------------------------------------
Only a limited group is disabled with visibility set to "Public Pages".

