### PR TITLE
Correct form name for qfKey on delete file through drupal user civicrm profile.

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1140,7 +1140,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
       // If the call is initiated from the profile loaded from drupal, we
       // need to change the form name. otherwise we will get : Error: Could
       // not find a valid session key.
-      if (strpos($key, 'CRMProfileFormDynamic') !== FALSE) {
+      if (str_contains($key, 'CRMProfileFormDynamic')) {
         $formName = 'CRM_Profile_Form_Dynamic';
       }
     }

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1135,6 +1135,15 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
     // retrieve contact id in case of Profile context
     $id = CRM_Utils_Request::retrieve('id', 'Positive');
     $formName = $pcp ? 'CRM_PCP_Form_PCPAccount' : ($cid ? 'CRM_Contact_Form_Contact' : 'CRM_Profile_Form_Edit');
+    if ($formName == 'CRM_Profile_Form_Edit') {
+      $key = $_POST['qfKey'] ?? $_GET['qfKey'] ?? $_REQUEST['qfKey'] ?? NULL;
+      // If the call is initiated from the profile loaded from drupal, we
+      // need to change the form name. otherwise we will get : Error: Could
+      // not find a valid session key.
+      if (strpos($key, 'CRMProfileFormDynamic') !== FALSE) {
+        $formName = 'CRM_Profile_Form_Dynamic';
+      }
+    }
     $cid = $cid ?: $id;
     if ($action & CRM_Core_Action::DELETE) {
       if (CRM_Utils_Request::retrieve('confirmed', 'Boolean')) {


### PR DESCRIPTION
Overview
----------------------------------------

**Problem**: We have an issue with deleting the image from the profile.

**Details**:

The profile is enabled for user edit, and the profile has a file field (custom or contact image).

It shows a delete link; the link contains a `qfKey`, and the value of the `qfKey` is dynamically created using the form name.

If we have a contact image field in the profile and we have already uploaded the image, then the profile shows a link to delete the image.

Whenever we call for deleting an image, it prepares the URL and qfKey.

Example:

1: URL shows when we load the profile from the Drupal user page. E.g., http://drupal11.localhost/user/1/edit/profile/1

http://drupal11.localhost/civicrm/contact/image?reset=1&id=2&gid=1&action=delete&qfKey=CRMProfileFormDynamic28pi33f18cbocs44owwws8k8ow08wcsk04sogkowkgwwo4c0w0_7432

2: URL shows when we load a profile from the CiviCRM URL of the profile, e.g., http://drupal11.localhost/civicrm/profile/edit?gid=1

http://drupal11.localhost/civicrm/contact/image?reset=1&id=2&gid=1&action=delete&qfKey=CRMProfileFormEdit5sa0q3fq9mgw008cw4ssw84cks0c0sskwo8s4co4g0cccc8ks8_7078&confirmed=1

3: URL shows when we edit the contact form summary screen. e.g.: http://drupal11.localhost/civicrm/contact/add?reset=1&action=update&cid=2

http://drupal11.localhost/civicrm/contact/image?reset=1&cid=2&action=delete&qfKey=CRMContactFormContact65l0xz3xz14wc8wc8ocsww44gcs84044w080kwksck8c0gw84k_6428

See the difference in the `qfKey` format starting string:

- CRMProfileFormDynamic28pi33f18cbocs44owwws8k8ow08wcsk04sogkowkgwwo4c0w0_7432
- CRMProfileFormEdit5sa0q3fq9mgw008cw4ssw84cks0c0sskwo8s4co4g0cccc8ks8_7078
- CRMContactFormContact65l0xz3xz14wc8wc8ocsww44gcs84044w080kwksck8c0gw84k_6428

These represent the form you have accessed to prepare the image delete URL.

Before deleting, CiviCRM does verify that the form name and `qfKey` are matching. For points 2 and 3, work without any issue, but for point 1, CiviCRM uses the form name `CRM_Profile_Form_Edit` for the `qfKey` key `CRMProfileFormDynamic28pi33f18cbocs44owwws8k8ow08wcsk04sogkowkgwwo4c0w0_7432`; instead, it should be `CRM_Profile_Form_Dynamic`.


Before
----------------------------------------
Error: Could not find a valid session key.

After
----------------------------------------
File gets deleted from user profile.
