### PR TITLE
CiviImport - Remove non-functional code in import function

### DIFF
--- a/ext/civiimport/Civi/Api4/Import/Import.php
+++ b/ext/civiimport/Civi/Api4/Import/Import.php
@@ -28,7 +28,7 @@ class Import extends DAOGetAction {
     $this->getImportRows($result);
     $parser = $this->getParser($userJobID);
     foreach ($result as $row) {
-      if (!in_array($row['_status'], ['new', 'valid'], TRUE) && !$parser->validateRow($row)) {
+      if (!$parser->validateRow($row)) {
         continue;
       }
       $parser->import(array_values($row));


### PR DESCRIPTION
Overview
----------------------------------------
Removes non-function code from import api.

Before
----------
Condition never true so always skipped.

After
--------
Condition removed. Before/after behavior is the same.

Technical Details
-------
Because this condition was checking the wrong strings ("new" instead of "NEW", "valid" instead of "VALID"), the condition was always false so can just be removed.

It's best to not check the status anyway because this is an API, conditions like this belong in the WHERE clause, not in the run function.