### PR TITLE
SearchKit - Fix expanding links in toolbar

### DIFF
--- a/Civi/Api4/Action/GetLinks.php
+++ b/Civi/Api4/Action/GetLinks.php
@@ -146,7 +146,8 @@ class GetLinks extends BasicGetAction {
           }
           // If $values was supplied, treat all tokens as mandatory and remove links with null values
           // This hides invalid links from SearchKit e.g. `civicrm/group/edit?id=null`
-          else {
+          // Note: skip if expandMultiple is true to give hooks the chance to fill in missing tokens
+          elseif (!$this->expandMultiple) {
             unset($links[$index]);
             break;
           }


### PR DESCRIPTION
Overview
----------------------------------------
There was a catch-22 with some links e.g. those generated by ECK. They have a placeholder token that's meant to be expanded into multiple toolbar links, but in the initial pass the token can't be resolved so the link was getting removed.

This allows them to work.

Before
----------------------------------------
ECK links in SK toolbar were broken. No button would appear for "Add New"

After
----------------------------------------
![image](https://github.com/user-attachments/assets/d777e37c-c6d5-429d-b94e-9f8a0afed686)

