### PR TITLE
dev/core#5676 Unit & fix  for test for tokens in url

### DIFF
--- a/CRM/Utils/HTMLPurifier/URIFilter.php
+++ b/CRM/Utils/HTMLPurifier/URIFilter.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Class to re-convert curly braces that have been encoded as %7B and %7D
+ * back curly braces when they look like CiviCRM tokens.
+ *
+ * See also:
+ * https://lab.civicrm.org/dev/core/-/issues/5676
+ */
+class CRM_Utils_HTMLPurifier_URIFilter extends HTMLPurifier_URIFilter {
+
+  public $name = 'CiviToken';
+
+  public function prepare($config): bool {
+    return TRUE;
+  }
+
+  public function filter(&$uri, $config, $context): bool {
+    if ($uri->query) {
+      // Replace %7B with { and %7D with } if they look like CiviCRM tokens.
+      // Looking for {entity.string}
+      $uri->query = preg_replace_callback('/%7B([A-Za-z0-9_]*\.[A-Za-z0-9_.]*?)%7D/', function ($matches) {
+        return '{' . $matches[1] . '}';
+      }, $uri->query);
+    }
+    return TRUE;
+
+  }
+
+}

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -647,6 +647,9 @@ class CRM_Utils_String {
       $config->set('HTML.MaxImgLength', NULL);
       $config->set('CSS.MaxImgLength', NULL);
       $def = $config->maybeGetRawHTMLDefinition();
+      $uri = $config->getDefinition('URI');
+      $uri->addFilter(new CRM_Utils_HTMLPurifier_URIFilter(), $config);
+
       if (!empty($def)) {
         $def->addElement('figcaption', 'Block', 'Flow', 'Common');
         $def->addElement('figure', 'Block', 'Optional: (figcaption, Flow) | (Flow, figcaption) | Flow', 'Common');

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -351,10 +351,14 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
   }
 
   public function purifyHTMLProvider(): array {
-    $tests = [];
-    $tests[] = ['<span onmouseover=alert(0)>HOVER</span>', '<span>HOVER</span>'];
-    $tests[] = ['<a href="https://civicrm.org" target="_blank" class="button-purple">hello</a>', '<a href="https://civicrm.org" target="_blank" class="button-purple" rel="noreferrer noopener">hello</a>'];
-    return $tests;
+    return [
+      'tokens' => [
+        '<p>To view your dashboard, <a href="https://mysite.org/civicrm/?civiwp=CiviCRM&amp;q=civicrm/user&reset=1&id={contact.contact_id}&{contact.checksum}">click here.</a></p>',
+        '<p>To view your dashboard, <a href="https://mysite.org/civicrm/?civiwp=CiviCRM&amp;q=civicrm/user&amp;reset=1&amp;id={contact.contact_id}&amp;{contact.checksum}">click here.</a></p>',
+      ],
+      'hover' => ['<span onmouseover=alert(0)>HOVER</span>', '<span>HOVER</span>'],
+      'target' => ['<a href="https://civicrm.org" target="_blank" class="button-purple">hello</a>', '<a href="https://civicrm.org" target="_blank" class="button-purple" rel="noreferrer noopener">hello</a>'],
+    ];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5676 Unit test for tokens in url

Before
----------------------------------------
Problem exists, no test

After
----------------------------------------
Problem exists, failing test

Technical Details
----------------------------------------
Here is the back trace to the line where we hit the issue - this shows that the code is deep in the url-specific handling & would need `{` and `}` to be added to the reserved characters list to fix here.


![image](https://github.com/user-attachments/assets/d5c7af4f-329c-4de7-abf0-2e8253cb6287)

However, it looks like it must be possible to register additional custom pre & post filters & to do something like @demeritcowboy's suggestion in them - ie swap them for something unique in the pre & then back again.

@seamuslee001 do you have any idea how we would register these? 

![image](https://github.com/user-attachments/assets/c0bc5263-2002-4f5e-af8c-7994e42f0b7b)


![image](https://github.com/user-attachments/assets/bfe838e7-2840-47b0-870b-5ccfbb0a93cc)


Comments
----------------------------------------
_Anything else you would like the reviewer to note_
