### PR TITLE
Re-enable caching in html purifier

### DIFF
--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -640,7 +640,7 @@ class CRM_Utils_String {
       $config = HTMLPurifier_Config::createDefault();
       $config->set('Core.Encoding', 'UTF-8');
       $config->set('Attr.AllowedFrameTargets', ['_blank', '_self', '_parent', '_top']);
-      $config->set('HTML.DefinitionID', 'enduser-customize.html tutorial');
+      $config->set('HTML.DefinitionID', 'civicrm-custom');
       $config->set('HTML.DefinitionRev', 1);
       $config->set('HTML.MaxImgLength', NULL);
       $config->set('CSS.MaxImgLength', NULL);

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -640,8 +640,6 @@ class CRM_Utils_String {
       $config = HTMLPurifier_Config::createDefault();
       $config->set('Core.Encoding', 'UTF-8');
       $config->set('Attr.AllowedFrameTargets', ['_blank', '_self', '_parent', '_top']);
-      // Disable the cache entirely
-      $config->set('Cache.DefinitionImpl', NULL);
       $config->set('HTML.DefinitionID', 'enduser-customize.html tutorial');
       $config->set('HTML.DefinitionRev', 1);
       $config->set('HTML.MaxImgLength', NULL);


### PR DESCRIPTION
Overview
----------------------------------------
This looks a lot to me like something that was done for development purposes & left in - see the dosc

![image](https://github.com/user-attachments/assets/eb05bb1b-3182-4571-a776-9b6034d3f8a6)


http://htmlpurifier.org/docs/enduser-customize.html

Before
----------------------------------------
Caching disabled

After
----------------------------------------
Enabled

Technical Details
----------------------------------------
We could make this setting dependent? But we also so rarely work on this??

Comments
----------------------------------------
