### PR TITLE
dev/core#5822 Do not merge relationship cache if not merging relationship

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -96,7 +96,7 @@ class CRM_Dedupe_Merger {
         ],
         'rel_table_relationships' => [
           'title' => ts('Relationships'),
-          'tables' => ['civicrm_relationship'],
+          'tables' => ['civicrm_relationship', 'civicrm_relationship_cache'],
           'url' => CRM_Utils_System::url('civicrm/contact/view', 'reset=1&force=1&cid=$cid&selectedChild=rel'),
         ],
         'rel_table_custom_groups' => [


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5822)](https://lab.civicrm.org/dev/core/-/issues/5822

Before
----------------------------------------
@petednz reported the relationship is being carried across - but actually just the cache is being updated

After
----------------------------------------
The relationship not carried

Technical Details
----------------------------------------
This fix is fine to merge regardless - but what does this say about the relationship cache - is the trigger not working - or is it being bypassed somehow?

Comments
----------------------------------------
