### PR TITLE
(dev/core#5796) message_admin - Enable more sorting options

### DIFF
--- a/ext/message_admin/ang/crmMsgadm/User.html
+++ b/ext/message_admin/ang/crmMsgadm/User.html
@@ -1,5 +1,6 @@
 <div id="bootstrap-theme">
   <div crm-ui-debug="$ctrl"></div>
+  <span crm-ui-order="{var: 'myOrder', defaults: ['+msg_title']}"></span>
 
   <div ng-include="'~/crmMsgadm/ListNav.html'"></div>
 
@@ -16,14 +17,14 @@
   <table class="table table-striped">
     <thead>
     <tr>
-      <th>{{:: ts('Title') }}</th>
-      <th>{{:: ts('Subject') }}</th>
-      <th>{{:: ts('Enabled?') }}</th>
+      <th><a crm-ui-order-by="[myOrder, 'msg_title']">{{:: ts('Title') }}</a></th>
+      <th><a crm-ui-order-by="[myOrder, 'msg_subject']">{{:: ts('Subject') }}</a></th>
+      <th><a crm-ui-order-by="[myOrder, 'is_acctive']">{{:: ts('Enabled?') }}</a></th>
       <th></th>
     </tr>
     </thead>
     <tbody>
-    <tr ng-repeat="record in $ctrl.records | filter:filters.text">
+    <tr ng-repeat="record in $ctrl.records | filter:filters.text | orderBy:myOrder.get()">
       <td>{{record.msg_title}}</td>
       <td>{{record.msg_subject}}</td>
       <td>{{record.is_active ? ts('Yes') : ts('No')}}</td>

--- a/ext/message_admin/ang/crmMsgadm/Workflow.html
+++ b/ext/message_admin/ang/crmMsgadm/Workflow.html
@@ -1,5 +1,6 @@
 <div id="bootstrap-theme">
   <div crm-ui-debug="$ctrl"></div>
+  <span crm-ui-order="{var: 'wfOrder', defaults: ['msg_title','_is_translation','tx_language_label']}"></span>
 
   <div ng-include="'~/crmMsgadm/ListNav.html'"></div>
 
@@ -11,12 +12,12 @@
   <table class="table table-striped">
     <thead>
     <tr>
-      <th>{{:: ts('Title') }}</th>
+      <th><a crm-ui-order-by="[wfOrder, 'msg_title']">{{:: ts('Title') }}</a></th>
       <th></th>
     </tr>
     </thead>
     <tbody>
-    <tr ng-repeat="record in $ctrl.records | filter:filters.text | orderBy:['msg_title','_is_translation','tx_language_label']">
+    <tr ng-repeat="record in $ctrl.records | filter:filters.text | orderBy:wfOrder.get()">
       <td>{{record.msg_title}}</td>
       <td  class="text-right">
         <a ng-show="record.master_id" class="btn btn-xs btn-default" ng-click="$ctrl.revert(record)">{{:: ts('Revert') }}</a>

--- a/ext/message_admin/ang/crmMsgadm/WorkflowTranslated.html
+++ b/ext/message_admin/ang/crmMsgadm/WorkflowTranslated.html
@@ -1,5 +1,6 @@
 <div id="bootstrap-theme">
   <div crm-ui-debug="$ctrl"></div>
+  <span crm-ui-order="{var: 'wfOrder', defaults: ['msg_title','!_is_primary','tx_language_label']}"></span>
 
   <div ng-include="'~/crmMsgadm/ListNav.html'"></div>
 
@@ -11,15 +12,15 @@
   <table class="table table-striped">
     <thead>
     <tr>
-      <th>{{:: ts('Title') }}</th>
-      <th>{{:: ts('Locale') }}</th>
+      <th><a crm-ui-order-by="[wfOrder, 'msg_title']">{{:: ts('Title') }}</a></th>
+      <th><a crm-ui-order-by="[wfOrder, 'tx_language_label']">{{:: ts('Locale') }}</a></th>
       <th></th>
       <th></th>
       <th></th>
     </tr>
     </thead>
     <tbody>
-    <tr ng-repeat="record in $ctrl.records | filter:filters.text | filter:{_is_visible: true} | orderBy:['msg_title','!_is_primary','tx_language_label']">
+    <tr ng-repeat="record in $ctrl.records | filter:filters.text | filter:{_is_visible: true} | orderBy:wfOrder.get()">
       <td>{{record.msg_title}}</td>
       <td  class="text-right">
         <a ng-show="record.master_id" class="btn btn-xs btn-default" ng-click="$ctrl.revert(record)">{{:: ts('Revert') }}</a>


### PR DESCRIPTION
Overview
----------------------------------------

When browsing "Administer => Communications => Message Templates", you see a list of templates. What order are they shown in?

Traditionally? Order by title (*with options to sort in other ways*). Now-a-days? This UI has being reimplemented by the extension `message_admin` (*which is enabled by default on new sites*). As discussed in dev/core#5796, the sorting is a bit different. This adds similar sorting options to `message_admin`.

(See: https://lab.civicrm.org/dev/core/-/issues/5796)

Before
----------------------------------------

For user-templates, order is undefined (with __no options__ to change).

![Screenshot from 2025-05-01 23-32-55](https://github.com/user-attachments/assets/de463af8-2d86-4d37-a866-a72b71bf7657)

For workflow-templates, order by `Title`,`Locale` (with __no options__ to change).

After
----------------------------------------

For user-templates, order by `Title` (__with options__ to change).

![Screenshot from 2025-05-01 23-33-18](https://github.com/user-attachments/assets/4c1907e1-41fd-4a69-9474-ff87f5d2e640)

For workflow-templates, order by `Title`,`Locale` (__with options__ to change).

Technical Details
----------------------------------------

* This uses the existing `crm-ui-order` component, because that fits cleanly.
* In workflow-templates, the default order has been (_was, is, should be_) based on the composite-key `Title`,`Locale`. (*You want records grouped predictably...*) The widget `crm-ui-order` _basically_ works with a composite key. It respects the default perfectly, and it responds to you as you shift the ordering -- in a way that basically follows your instruction.

    However, when I tried to stress-test (by clicking many different headers, ordering different ways)... it kind of left me with a feeling like... "What the heck was that?" It's hard to explain with one sentence. I think it might be good to revisit how `crm-ui-order` works with multiple keys. But there's also a chance that I'm more persnickity and most people won't notice.

    In any case, this PR does provide sorting-options.