### PR TITLE
Fix PHP 8.2 deprecation in backdrop's mapConfigToSSL

### DIFF
--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -267,7 +267,7 @@ class CRM_Utils_System_Backdrop extends CRM_Utils_System_DrupalBase {
    */
   public function mapConfigToSSL() {
     global $base_url;
-    $base_url = str_replace('http://', 'https://', $base_url);
+    $base_url = str_replace('http://', 'https://', (string) $base_url);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

Backdrop's mapConfigToSSL assumes there is a url which is not the case for cli use.


Before
----------------------------------------

> [PHP Deprecation] str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated at .../modules/civicrm/CRM/Utils/System/Backdrop.php:270 


After
----------------------------------------

no warning.

