### PR TITLE
CustomGroup - Fix mismatched css vs style attr on custom group form

### DIFF
--- a/templates/CRM/Custom/Form/Group.tpl
+++ b/templates/CRM/Custom/Form/Group.tpl
@@ -19,27 +19,27 @@
         <td class="label">{$form.extends.label} {help id="id-extends"}</td>
         <td>
             {$form.extends.html}
-            <span class="{if $emptyEntityColumnId}hiddenElement{/if} field-extends_entity_column_id">{$form.extends_entity_column_id.html}</span>
-            <span class="{if $emptyEntityColumnValue}hiddenElement{/if} field-extends_entity_column_value">{$form.extends_entity_column_value.html}</span>
+            <span {if $emptyEntityColumnId}style="display:none"{/if} class="field-extends_entity_column_id">{$form.extends_entity_column_id.html}</span>
+            <span {if $emptyEntityColumnValue}style="display:none"{/if} class="field-extends_entity_column_value">{$form.extends_entity_column_value.html}</span>
         </td>
     </tr>
     <tr>
         <td class="label">{$form.weight.label} {help id="id-weight"}</td>
         <td>{$form.weight.html}</td>
     </tr>
-    <tr class="hiddenElement field-is_multiple">
+    <tr style="display:none" class="field-is_multiple">
         <td class="right">{help id="id-is_multiple"}</td>
         <td class="html-adjust">{$form.is_multiple.html}&nbsp;{$form.is_multiple.label}</td>
     </tr>
-    <tr class="hiddenElement field-max_multiple">
+    <tr style="display:none" class="field-max_multiple">
         <td class="label">{$form.max_multiple.label} {help id="id-max_multiple"}</td>
         <td>{$form.max_multiple.html}</td>
     </tr>
-    <tr class="hiddenElement field-style">
+    <tr style="display:none" class="field-style">
         <td class="label">{$form.style.label} {help id="id-display_style"}</td>
         <td>{$form.style.html}</td>
     </tr>
-    <tr class="hiddenElement field-icon">
+    <tr style="display:none" class="field-icon">
         <td class="label">{$form.icon.label}</td>
         <td>{$form.icon.html}</td>
     </tr>


### PR DESCRIPTION
Overview
----------------------------------------
I spotted this as a bug but it turned out to only affect older versions of Riverlea.

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/94a994b3-3702-4067-95f6-612111747435)



After
-------
<img width="828" alt="Screenshot 2025-05-02 at 11 08 43 AM" src="https://github.com/user-attachments/assets/2f61a5bb-3e02-4ad7-93f1-42cb798e2030" />



Technical Details
----------------------------------------
This fix will work on any theme and is more consistent with what the javascript does anyway.