### PR TITLE
[regression][TEST ONLY] Fix broken domain address test

### DIFF
--- a/tests/phpunit/CRM/Mailing/MailingSystemTestBase.php
+++ b/tests/phpunit/CRM/Mailing/MailingSystemTestBase.php
@@ -186,7 +186,7 @@ abstract class CRM_Mailing_MailingSystemTestBase extends CiviUnitTestCase {
         ";" .
         // Default header
         "Sample Header for TEXT formatted content.\n" .
-        "BEWARE children need regular infusions of toys. Santa knows your .*\\. There is no http.*civicrm/mailing/optout.*\\.\n" .
+        "BEWARE children need regular infusions of toys. Santa knows your 15 Main St\nCollinsville, CT 6022\nUnited States\n. There is no http.*civicrm/mailing/optout.*\\.\n" .
         // Default footer
         "Opt out of any future emails: http.*civicrm/mailing/optout" .
         ";",


### PR DESCRIPTION
Overview
----------------------------------------
{domain.address} is not returning a value in the `master` branch (the future 6.3).

This test uses `assertMatchesRegularExpression` against `$message->body->text`.  And uses a regex to handle the domain address.

But the regex doesn't account for the domain address being completely blank - and in fact I'm not sure how it would pass a test if it were NOT blank, since the address is multiline and the regex expects a period after the token.

When I run the test against the rc (6.2) the domain address doesn't render, but the problem doesn't exist if I send via "Quick Email".

`git bisect` flags this commit: `9b3712a8dd Set version to 6.3.alpha1` and in manual testing, the token fails on that commit but renders correctly on the previous commit.  That commit looks pretty innocuous though.

Before
----------------------------------------
`{domain.address}` renders blank.

After
----------------------------------------
`{domain.address}` renders blank, but we fail a test about it.

Comments
----------------------------------------
#32665 fixes this, but fails the current incorrect test.