### PR TITLE
Correctly output group label in basic criteria form

### DIFF
--- a/templates/CRM/Contact/Form/Search/BasicCriteria.tpl
+++ b/templates/CRM/Contact/Form/Search/BasicCriteria.tpl
@@ -51,10 +51,10 @@
         <div class="crm-section group_selection-section">
           <div class="label">
             {if $context EQ 'smog'}
-                    {$form.group_contact_status.label}
-                {else}
-                    {ts}in{/ts} &nbsp;
-                {/if}
+              {$form.group_contact_status.label}
+            {else}
+              {$form.group.label}
+            {/if}
           </div>
           <div class="content">
             {if $context EQ 'smog'}


### PR DESCRIPTION
Overview
----------------------------------------
Correctly output group label in basic criteria form.

Before
----------------------------------------
The third label ("in") is the only label that is not in bold (whilst using one of the new Riverlea themes):

<img width="632" alt="Screenshot 2025-05-04 at 18 08 59" src="https://github.com/user-attachments/assets/2ed534a6-e678-4a3e-a8e1-b8abe85c0710" />

After
----------------------------------------
Properly bold:

<img width="617" alt="Screenshot 2025-05-04 at 18 10 20" src="https://github.com/user-attachments/assets/11df1d70-30d9-4b41-a3b2-c020f41fa2f9" />

Technical Details
----------------------------------------
The label was previously only using a label" class, and not a proper HTML `label`. Therefore it wasn't matching the Riverlea selector:

```
.crm-container .form-layout label,
.crm-container .form-layout-compressed label,
.crm-container .form-item label,
.crm-container .crm-accordion-body label,
.crm-container .crm-form-block label,
.crm-container #task-section label
```

Using a proper label is also more sematically correct (although I'm not sure how much of an accessibility impact it has as we're using a Select2 here).

This part of the template dates back to the SVN days, so there is no recent history of why a proper label was not used originally.

Comments
----------------------------------------
This BasicCriteria template is used in a few contexts:

1. Basic contact search
2. View group contacts
3. Add contacts to group

I've checked for regressions across these 3 contexts.
