### PR TITLE
6.2 upgrade fixes

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixTwo.php
+++ b/CRM/Upgrade/Incremental/php/SixTwo.php
@@ -152,7 +152,7 @@ class CRM_Upgrade_Incremental_php_SixTwo extends CRM_Upgrade_Incremental_Base {
     $mappingFields = self::getMappingFields($entity);
     $fieldsToConvert = [];
     while ($mappingFields->fetch()) {
-      $fieldsToConvert[$mappingFields->name] = self::getConvertedName($mappingFields->name, $entity);
+      $fieldsToConvert[$mappingFields->name] = self::getConvertedName((string) $mappingFields->name, $entity);
       // Convert the field.
       CRM_Core_DAO::executeQuery(' UPDATE civicrm_mapping_field SET name = %1 WHERE id = %2', [
         1 => [$fieldsToConvert[$mappingFields->name], 'String'],
@@ -171,7 +171,14 @@ class CRM_Upgrade_Incremental_php_SixTwo extends CRM_Upgrade_Incremental_Base {
       }
       foreach ($metadata['import_mappings'] as &$mapping) {
         if (!empty($mapping['name'])) {
-          $mapping['name'] = self::getConvertedName($mapping['name'], $entity);
+          $convertedName = self::getConvertedName($mapping['name'], $entity);
+          if ($convertedName === 'do_not_import') {
+            $convertedName = '';
+          }
+          $mapping['name'] = $convertedName;
+        }
+        else {
+          $mapping['name'] = '';
         }
       }
       $userJob->metadata = json_encode($metadata);
@@ -214,7 +221,7 @@ class CRM_Upgrade_Incremental_php_SixTwo extends CRM_Upgrade_Incremental_Base {
       'soft_credit.contact' => 'SoftCreditContact',
     ];
     if (empty($mappingFieldsName) || $mappingFieldsName === 'do_not_import') {
-      return $mappingFieldsName;
+      return 'do_not_import';
     }
     $parts = explode('.', $mappingFieldsName);
     // For contribution imports we may have failed to convert these fields in 6.1

--- a/CRM/Upgrade/Incremental/php/SixTwo.php
+++ b/CRM/Upgrade/Incremental/php/SixTwo.php
@@ -89,9 +89,9 @@ class CRM_Upgrade_Incremental_php_SixTwo extends CRM_Upgrade_Incremental_Base {
     $this->addExtensionTask('Enable CiviImport extension', ['civiimport']);
     $this->addTask('Fix Unique index on acl cache table with domain id', 'fixAclUniqueIndex');
     $this->addTask('Update Activity mappings', 'upgradeImportMappingFields', 'Activity');
-    $this->addTask('Update Activity mappings', 'upgradeImportMappingFields', 'Membership');
-    $this->addTask('Update Activity mappings', 'upgradeImportMappingFields', 'Contribution');
-    $this->addTask('Update Activity mappings', 'upgradeImportMappingFields', 'Participant');
+    $this->addTask('Update Membership mappings', 'upgradeImportMappingFields', 'Membership');
+    $this->addTask('Update Contribution mappings', 'upgradeImportMappingFields', 'Contribution');
+    $this->addTask('Update Participant mappings', 'upgradeImportMappingFields', 'Participant');
   }
 
   public static function setFileUploadDate(): bool {
@@ -217,6 +217,37 @@ class CRM_Upgrade_Incremental_php_SixTwo extends CRM_Upgrade_Incremental_Base {
       return $mappingFieldsName;
     }
     $parts = explode('.', $mappingFieldsName);
+    // For contribution imports we may have failed to convert these fields in 6.1
+    // as they are not generally available for other imports.
+    $contactFields = [
+      'first_name',
+      'last_name',
+      'middle_name',
+      'email_primary.email',
+      'nick_name',
+      'do_not_trade',
+      'do_not_email',
+      'do_not_mail',
+      'do_not_sms',
+      'do_not_phone',
+      'is_opt_out',
+      'external_identifier',
+      'legal_identifier',
+      'legal_name',
+      'preferred_communication_method',
+      'preferred_language',
+      'gender_id',
+      'prefix_id',
+      'suffix_id',
+      'job_title',
+      'birth_date',
+      'deceased_date',
+      'household_name',
+    ];
+    if (in_array($mappingFieldsName, $contactFields)) {
+      // This would happen for Contribution fields that were not correctly updated in 6.1.
+      return 'Contact.' . $mappingFieldsName;
+    }
     if (!isset($prefixMap[$parts[0]])) {
       // This is a 'native' mapping, add a prefix.
       return $type . '.' . $mappingFieldsName;

--- a/tests/phpunit/CRM/Upgrade/Incremental/php/SixTwoTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/php/SixTwoTest.php
@@ -75,4 +75,90 @@ class CRM_Upgrade_Incremental_php_SixTwoTest extends CiviUnitTestCase {
 
   }
 
+  /**
+   * Checks the upgrade copes with contribution contact fields not correctly updated in 6.1.
+   *
+   * These fields are available in contribution import with civiimport but not other imports &
+   * were missed out in 6.1
+   *
+   * @return void
+   * @throws \CRM_Core_Exception
+   */
+  public function testUpdateContributionUserJobs(): void {
+    $mapping = Mapping::create(FALSE)
+      ->setValues([
+        'name' => 'Contribution import',
+        'mapping_type_id:name' => 'Import Contribution',
+      ])->execute()->single();
+    $fields = [
+      'first_name',
+      // this should still be handled.
+      'contact.first_name',
+      'last_name',
+      'middle_name',
+      'nick_name',
+      'do_not_trade',
+      'do_not_email',
+      'do_not_mail',
+      'do_not_sms',
+      'do_not_phone',
+      'is_opt_out',
+      'external_identifier',
+      'legal_identifier',
+      'legal_name',
+      'preferred_communication_method',
+      'preferred_language',
+      'gender_id',
+      'prefix_id',
+      'suffix_id',
+      'job_title',
+      'birth_date',
+      'deceased_date',
+      'household_name',
+    ];
+    $importMappings = [];
+    $expectedImportMappings = [];
+    foreach ($fields as $index => $field) {
+      MappingField::create()
+        ->setValues(['name' => $field, 'mapping_id' => $mapping['id'], 'column_number' => $index])
+        ->execute();
+      $importMappings[] = ['name' => $field];
+      if ($field === 'contact.first_name') {
+        $expectedImportMappings[] = ['name' => 'Contact.first_name'];
+      }
+      else {
+        $expectedImportMappings[] = ['name' => 'Contact.' . $field];
+      }
+    }
+
+    $userJobParameters = [
+      'metadata' => [
+        'DataSource' => ['table_name' => 'abc', 'column_headers' => ['Date Time', 'Something', 'Email']],
+        'submitted_values' => [
+          'dataSource' => 'CRM_Import_DataSource_SQL',
+          'dateFormats' => CRM_Utils_Date::DATE_yyyy_mm_dd,
+        ],
+        'import_mappings' => $importMappings,
+      ],
+      'status_id:name' => 'draft',
+      'job_type' => 'contribution_import',
+    ];
+    $userJobID = UserJob::create()->setValues($userJobParameters)->execute()->first()['id'];
+    CRM_Upgrade_Incremental_php_SixTwo::upgradeImportMappingFields(NULL, 'Contribution');
+
+    $mappings = MappingField::get()
+      ->addWhere('mapping_id', '=', $mapping['id'])
+      ->execute();
+    $this->assertEquals('Contact.first_name', $mappings[0]['name']);
+    $this->assertEquals('Contact.first_name', $mappings[1]['name']);
+    $job = UserJob::get(FALSE)->addWhere('id', '=', $userJobID)->execute()->single();
+    $this->assertEquals($expectedImportMappings, $job['metadata']['import_mappings']);
+
+    $templateJob = UserJob::get(FALSE)
+      ->addWhere('name', '=', 'import_Contribution import')
+      ->addWhere('is_template', '=', TRUE)->execute()->single();
+    $this->assertEquals($expectedImportMappings, $templateJob['metadata']['import_mappings']);
+
+  }
+
 }

--- a/tests/phpunit/CRM/Upgrade/Incremental/php/SixTwoTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/php/SixTwoTest.php
@@ -115,6 +115,7 @@ class CRM_Upgrade_Incremental_php_SixTwoTest extends CiviUnitTestCase {
       'birth_date',
       'deceased_date',
       'household_name',
+      NULL,
     ];
     $importMappings = [];
     $expectedImportMappings = [];
@@ -125,6 +126,9 @@ class CRM_Upgrade_Incremental_php_SixTwoTest extends CiviUnitTestCase {
       $importMappings[] = ['name' => $field];
       if ($field === 'contact.first_name') {
         $expectedImportMappings[] = ['name' => 'Contact.first_name'];
+      }
+      elseif ($field === NULL) {
+        $expectedImportMappings[] = ['name' => ''];
       }
       else {
         $expectedImportMappings[] = ['name' => 'Contact.' . $field];


### PR DESCRIPTION
I found that the 6.2 upgrade was giving the wrong title for the upgrade tasks And that it was not handling some fields that got missed in the six one upgrade
- specifically contact fields that are available in the contribution civiimport but not other imports
