### PR TITLE
composer.lock - Update civicrm/composer-compile-plugin for php84

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -295,16 +295,16 @@
         },
         {
             "name": "civicrm/composer-compile-plugin",
-            "version": "v0.20",
+            "version": "v0.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/civicrm/composer-compile-plugin.git",
-                "reference": "0933ff53cd720ddcb24bdc5984879673ea1e0cbe"
+                "reference": "9129c3588e15e7744be2d740d3aff6b3215dff09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/civicrm/composer-compile-plugin/zipball/0933ff53cd720ddcb24bdc5984879673ea1e0cbe",
-                "reference": "0933ff53cd720ddcb24bdc5984879673ea1e0cbe",
+                "url": "https://api.github.com/repos/civicrm/composer-compile-plugin/zipball/9129c3588e15e7744be2d740d3aff6b3215dff09",
+                "reference": "9129c3588e15e7744be2d740d3aff6b3215dff09",
                 "shasum": ""
             },
             "require": {
@@ -338,9 +338,9 @@
             "description": "Define a 'compile' event for all packages in the dependency-graph",
             "support": {
                 "issues": "https://github.com/civicrm/composer-compile-plugin/issues",
-                "source": "https://github.com/civicrm/composer-compile-plugin/tree/v0.20"
+                "source": "https://github.com/civicrm/composer-compile-plugin/tree/v0.21"
             },
-            "time": "2023-03-01T06:55:29+00:00"
+            "time": "2025-05-05T07:08:54+00:00"
         },
         {
             "name": "civicrm/composer-downloads-plugin",


### PR DESCRIPTION
Overview
----------------------------------------

Bump version

Before
----------------------------------------

When running `composer install` or `composer compile`:

```
Deprecation Notice: Civi\CompilePlugin\Event\CompileListEvent::__construct(): Implicitly marking parameter $tasks as nullable is deprecated,
   the explicit nullable type must be used instead in /Users/myuser/bknix/build/s3/web/core/vendor/civicrm/composer-compile-plugin/src/Event/CompileListEvent.php:47
Compiling additional files (For full details, use verbose "-v" mode.)
Compile: Generate CCL wrapper functions
```

After
----------------------------------------

Happy time