### PR TITLE
Add spaces between concatenated translated strings

### DIFF
--- a/CRM/Admin/Form/RelationshipType.php
+++ b/CRM/Admin/Form/RelationshipType.php
@@ -63,7 +63,14 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
    * We do this from the constructor in order to do a translation.
    */
   public function setDeleteMessage() {
-    $this->deleteMessage = ts('WARNING: Deleting this option will result in the loss of all Relationship records of this type.') . ts('This may mean the loss of a substantial amount of data, and the action cannot be undone.') . ts('Do you want to continue?');
+    $this->deleteMessage = implode(
+      ' ',
+      [
+        ts('WARNING: Deleting this option will result in the loss of all Relationship records of this type.'),
+        ts('This may mean the loss of a substantial amount of data, and the action cannot be undone.'),
+        ts('Do you want to continue?'),
+      ]
+    );
   }
 
   /**

--- a/CRM/Financial/Form/FinancialType.php
+++ b/CRM/Financial/Form/FinancialType.php
@@ -75,7 +75,14 @@ class CRM_Financial_Form_FinancialType extends CRM_Core_Form {
    * We do this from the constructor in order to do a translation.
    */
   public function setDeleteMessage() {
-    $this->deleteMessage = ts('WARNING: You cannot delete a financial type if it is currently used by any Contributions, Contribution Pages or Membership Types. Consider disabling this option instead.') . ts('Deleting a financial type cannot be undone.') . ts('Do you want to continue?');
+    $this->deleteMessage = implode(
+      ' ',
+      [
+        ts('WARNING: You cannot delete a financial type if it is currently used by any Contributions, Contribution Pages or Membership Types. Consider disabling this option instead.'),
+        ts('Deleting a financial type cannot be undone.'),
+        ts('Do you want to continue?'),
+      ]
+    );
   }
 
   /**

--- a/CRM/Member/Form/MembershipType.php
+++ b/CRM/Member/Form/MembershipType.php
@@ -126,7 +126,14 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
    * We do this from the constructor in order to do a translation.
    */
   public function setDeleteMessage() {
-    $this->deleteMessage = ts('WARNING: Deleting this option will result in the loss of all membership records of this type.') . ts('This may mean the loss of a substantial amount of data, and the action cannot be undone.') . ts('Do you want to continue?');
+    $this->deleteMessage = $this->deleteMessage = implode(
+      ' ',
+      [
+        ts('WARNING: Deleting this option will result in the loss of all membership records of this type.'),
+        ts('This may mean the loss of a substantial amount of data, and the action cannot be undone.'),
+        ts('Do you want to continue?'),
+      ]
+    );
   }
 
   /**

--- a/sql/civicrm_data/civicrm_option_group/accept_creditcard.sqldata.php
+++ b/sql/civicrm_data/civicrm_option_group/accept_creditcard.sqldata.php
@@ -2,7 +2,13 @@
 return CRM_Core_CodeGen_OptionGroup::create('accept_creditcard', 'a/0009')
   ->addMetadata([
     'title' => ts('Accepted Credit Cards'),
-    'description' => ts('The following credit card options will be offered to contributors using Online Contribution pages. You will need to verify which cards are accepted by your chosen Payment Processor and update these entries accordingly.') . ts('IMPORTANT: These options do not control credit card/payment method choices for sites and/or contributors using the PayPal Express service (e.g. where billing information is collected on the Payment Processor\\\'s website).'),
+    'description' => implode(
+      ' ',
+      [
+        ts('The following credit card options will be offered to contributors using Online Contribution pages. You will need to verify which cards are accepted by your chosen Payment Processor and update these entries accordingly.'),
+        ts('IMPORTANT: These options do not control credit card/payment method choices for sites and/or contributors using the PayPal Express service (e.g. where billing information is collected on the Payment Processor\\\'s website).'),
+      ]
+    ),
   ])
   ->addValueTable(['name', 'value'], [
     ['Visa', 1],


### PR DESCRIPTION
Overview
----------------------------------------
Add spaces between concatenated translated strings.

Before
----------------------------------------
Handful of messages with no spaces between sentences:

<img width="414" alt="Screenshot 2025-05-05 at 10 02 42" src="https://github.com/user-attachments/assets/6712ba44-24c2-42e3-97eb-210e20b999b7" />

After
----------------------------------------
Spaces added between concatenated strings.

Comments
----------------------------------------
This does assume that all languages use spaces to seperate sentances. There are a handful of languages where this isn't usually the case (e.g. Chinese, Thai). However, a quick bit of research suggests that even for these languages the use of spaces is becoming more common: https://en.wikipedia.org/wiki/Scriptio_continua. I assume that these languages consist of a very small percentage of CiviCRM installations.

The alternative would have been to replace this concatenated translated strings with a single translated string. That would require re-translation of the strings, which would not have been ideal.