### PR TITLE
ClickTrackerTest - Switch from runkit7 to civi.mailing.track (for php84)

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -477,6 +477,7 @@ class Container {
 
     $dispatcher->addListener('civi.core.install', ['\Civi\Core\InstallationCanary', 'check']);
     $dispatcher->addListener('civi.core.install', ['\Civi\Core\DatabaseInitializer', 'initialize']);
+    $dispatcher->addListener('&civi.mailing.track', ['CRM_Mailing_BAO_MailingTrackableURL', 'on_civi_mailing_track'], -500);
     $dispatcher->addListener('hook_civicrm_post', ['\CRM_Core_Transaction', 'addPostCommit'], -1000);
     $dispatcher->addListener('hook_civicrm_pre', $aliasEvent('hook_civicrm_pre', 'entity'), 100);
     $dispatcher->addListener('civi.dao.preDelete', ['\CRM_Core_BAO_EntityTag', 'preDeleteOtherEntity']);

--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ClickTrackerTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ClickTrackerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Civi\FlexMailer;
 
+use Civi\Core\Event\GenericHookEvent;
 use Civi\Test\HeadlessInterface;
 use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
@@ -15,6 +16,8 @@ use Civi\FlexMailer\ClickTracker\HtmlClickTracker;
  */
 class ClickTrackerTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
 
+  protected static $mockTrackedUrl = 'http://example.com/extern?u=1';
+
   protected $mailing_id;
 
   public function setUpHeadless() {
@@ -25,20 +28,11 @@ class ClickTrackerTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
       ->apply();
   }
 
-  public function setUp(): void {
-    // Mock the getTrackerURL call; we don't need to test creating a row in a table.
-    // If you want this to work without runkit, then either (a) make the dummy rows or (b) switch this to a hook/event that is runtime-configurable.
-    require_once 'CRM/Mailing/BAO/TrackableURL.php';
-    \runkit7_method_rename('\CRM_Mailing_BAO_MailingTrackableURL', 'getBasicTrackerURL', 'orig_getBasicTrackerURL');
-    \runkit7_method_add('\CRM_Mailing_BAO_MailingTrackableURL', 'getBasicTrackerURL', '$a, $b, $c', 'return \'http://example.com/extern?u=1&qid=1\';', RUNKIT7_ACC_STATIC | RUNKIT7_ACC_PRIVATE);
-    parent::setUp();
-  }
-
-  public function tearDown(): void {
-    // Reset the class.
-    \runkit7_method_remove('\CRM_Mailing_BAO_MailingTrackableURL', 'getBasicTrackerURL');
-    \runkit7_method_rename('\CRM_Mailing_BAO_MailingTrackableURL', 'orig_getBasicTrackerURL', 'getBasicTrackerURL');
-    parent::tearDown();
+  public static function on_civi_mailing_track(GenericHookEvent $event) {
+    if (static::$mockTrackedUrl) {
+      $event->url = static::$mockTrackedUrl;
+      $event->stopPropagation();
+    }
   }
 
   /**
@@ -152,13 +146,10 @@ class ClickTrackerTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
   }
 
   public function testTraditionalViewMailingTokenFormat(): void {
+    static::$mockTrackedUrl = NULL;
     $filter = new HtmlClickTracker();
     $msg = '<p><a href="http://civicrm.org/civicrm/mailing/view?id={mailing.key}&{contact.checksum}&cid={contact.contact_id}">View online</a></p>';
-    \runkit7_method_rename('\CRM_Mailing_BAO_MailingTrackableURL', 'getBasicTrackerURL', 'new_getBasicTrackerURL');
-    \runkit7_method_rename('\CRM_Mailing_BAO_MailingTrackableURL', 'orig_getBasicTrackerURL', 'getBasicTrackerURL');
     $result = $filter->filterContent($msg, 1, 1);
-    \runkit7_method_rename('\CRM_Mailing_BAO_MailingTrackableURL', 'getBasicTrackerURL', 'orig_getBasicTrackerURL');
-    \runkit7_method_rename('\CRM_Mailing_BAO_MailingTrackableURL', 'new_getBasicTrackerURL', 'getBasicTrackerURL');
     $this->assertEquals('<p><a href="http://civicrm.org/civicrm/mailing/view?id={mailing.key}&amp;{contact.checksum}&amp;cid={contact.contact_id}" rel=\'nofollow\'>View online</a></p>', $result);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

This addresses an issue with `ClickTrackerTest` on PHP 8.4.

Before
----------------------------------------

ClickTrackerTest sets mock URLs by using runkit7 to change the output of `getBasicTrackerURL()`.

However, AFAICS, runkit7 hasn't updated to PHP 8.4. And we only have this one test-case which relies on it.

After
----------------------------------------

ClickTrackerTest sets mock URLs by using an event (civi.mailing.track) to change the output of `getBasicTrackerURL()`.

So we don't need runkit7.