### PR TITLE
Afform - Fix setting default values

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
@@ -48,11 +48,10 @@
           // Decide whether the input should be multivalued
           if (ctrl.op) {
             multi = ['IN', 'NOT IN'].includes(ctrl.op);
-          } else if (inputType) {
-            multi = (dataType !== 'Boolean' &&
-              (inputType === 'CheckBox' || (field.input_attrs && field.input_attrs.multiple)));
+          } else if (inputType && dataType !== 'Boolean') {
+            multi = (inputType === 'CheckBox' || (field.input_attrs && field.input_attrs.multiple));
             // Hidden fields are multi-select if the original input type is.
-            if (inputType === 'Hidden') {
+            if (inputType === 'Hidden' || inputType === 'DisplayOnly') {
               multi = _.contains(['CheckBox', 'Radio', 'Select'], field.original_input_type);
             }
           } else {
@@ -96,7 +95,7 @@
               }, []);
               $el.select2({data: options, multiple: multi, separator: '\u0001'});
             } else if (dataType === 'Boolean') {
-              $el.attr('placeholder', ts('- select -')).crmSelect2({allowClear: false, multiple: multi, separator: '\u0001', placeholder: ts('- select -'), data: [
+              $el.attr('placeholder', ts('- select -')).crmSelect2({allowClear: false, separator: '\u0001', placeholder: ts('- select -'), data: [
                   {id: '1', text: ts('Yes')},
                   {id: '0', text: ts('No')}
                 ]});

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -93,7 +93,7 @@
     </select>
   </form>
 </li>
-<li ng-if="$ctrl.hasDefaultValue && $ctrl.defaultDateType() === 'fixed'">
+<li ng-if="$ctrl.hasDefaultValueInput()">
   <form ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown form-inline">
     <input class="form-control" af-gui-field-value="$ctrl.fieldDefn" ng-model="getSet('afform_default')" ng-model-options="{getterSetter: true}" >
   </form>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -21,8 +21,8 @@
         rangeElements = ['', '2'],
         dateRangeElements = ['1', '2'],
         yesNo = [
-          {id: '1', label: ts('Yes')},
-          {id: '0', label: ts('No')}
+          {id: true, label: ts('Yes')},
+          {id: false, label: ts('No')}
         ];
       $scope.editingOptions = false;
 
@@ -290,7 +290,16 @@
           ctrl.hasDefaultValue = false;
         } else {
           ctrl.hasDefaultValue = true;
+          // Boolean default value should be set right away, as there are no options
+          if (ctrl.getDefn().data_type === 'Boolean') {
+            getSet('afform_default', true);
+          }
         }
+      };
+
+      // Return `true` if field has a default value and it's not a boolean or relative date
+      this.hasDefaultValueInput = function() {
+        return ctrl.hasDefaultValue && ctrl.getDefn().data_type !== 'Boolean' && ctrl.defaultDateType() === 'fixed';
       };
 
       this.defaultDateType = function(newValue) {
@@ -340,13 +349,11 @@
       };
 
       $scope.defaultValueContains = function(val) {
-        val = '' + val;
         var defaultVal = getSet('afform_default');
         return defaultVal === val || (_.isArray(defaultVal) && _.includes(defaultVal, val));
       };
 
       $scope.toggleDefaultValueItem = function(val) {
-        val = '' + val;
         if (defaultValueShouldBeArray()) {
           if (!_.isArray(getSet('afform_default'))) {
             ctrl.node.defn = ctrl.node.defn || {};

--- a/ext/afform/admin/ang/afGuiEditor/inputType/CheckBox.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/CheckBox.html
@@ -5,7 +5,7 @@
   </li>
 </ul>
 <div class="form-inline" ng-if="$ctrl.getDefn().data_type === 'Boolean'">
-  <input type="checkbox" ng-checked="defaultValueContains('1')" ng-click="toggleDefaultValueItem('1') ">
+  <input type="checkbox" ng-checked="defaultValueContains(true)" ng-click="toggleDefaultValueItem(true) ">
   <label class="af-gui-node-title" ng-if="$ctrl.node.defn.label != false">{{:: $ctrl.getDefn().label }}
   <span class="crm-marker" title="{{:: ts('Required') }}" ng-if="getProp('required')">*</span>
   </label>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a couple bugs when setting default values on an Afform.

Technical Details
----------------------------------------
Booleans cannot be multi-valued, so this ensures they are always single-valued and removes the redundant dropdown select.

Also fixes the in-form setting of defaults which was incorrectly casting integers to string.