### PR TITLE
Afform - Fix creating content block

### DIFF
--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -143,7 +143,7 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
 
     if ($info['definition']['type'] === 'block') {
       $blockEntity = $info['definition']['join_entity'] ?? $info['definition']['entity_type'] ?? NULL;
-      if ($blockEntity) {
+      if ($blockEntity && $blockEntity !== '*') {
         $entities[] = $blockEntity;
       }
       $scanBlocks($info['definition']['layout']);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes fatal error when creating a content block in the FormBuilder UI.

Before
----------------------------------------
Clicking on "Content Block" gives a fatal error:
![image](https://github.com/user-attachments/assets/972b76a8-ecd0-4084-b9dd-3a79065df20e)


After
----------------------------------------
Works.