### PR TITLE
SearchKit: "Show linebreaks" should work when copying HTML

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -283,7 +283,12 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       $cssClass[] = $column['alignment'];
     }
     if (!empty($column['show_linebreaks'])) {
-      $cssClass[] = 'crm-search-field-show-linebreaks';
+      if ($column['type'] === 'html') {
+        $out['val'] = nl2br($out['val']);
+      }
+      else {
+        $cssClass[] = 'crm-search-field-show-linebreaks';
+      }
     }
     if ($cssClass) {
       $out['cssClass'] = implode(' ', $cssClass);


### PR DESCRIPTION
Overview
----------------------------------------
This follows up on https://github.com/civicrm/civicrm-core/pull/31427/files.

That PR adds CSS to display a multiline field with line breaks.  However, when copy/pasting the HTML, the formatting isn't preserved.  This adds actual `<br>` tags so that the linebreaks are preserved on copy. 

Before
----------------------------------------
Can't copy a multiline field and preserve line breaks.

After
----------------------------------------
Line breaks are preserved.

Comments
----------------------------------------
Replication steps are the same as those on https://lab.civicrm.org/dev/core/-/issues/5565.
