### PR TITLE
Enable custom data for phones on contact summary

### DIFF
--- a/CRM/Contact/Form/Edit/Phone.php
+++ b/CRM/Contact/Form/Edit/Phone.php
@@ -28,11 +28,12 @@ class CRM_Contact_Form_Edit_Phone {
    * @param int $addressBlockCount
    *   Block number to build.
    * @param bool $blockEdit
-   *   Is it block edit.
+   *   deprecated variable.
    */
   public static function buildQuickForm(&$form, $addressBlockCount = NULL, $blockEdit = FALSE) {
     // passing this via the session is AWFUL. we need to fix this
     if (!$addressBlockCount) {
+      CRM_Core_Error::deprecatedWarning('pass in blockCount');
       $blockId = ($form->get('Phone_Block_Count')) ? $form->get('Phone_Block_Count') : 1;
     }
     else {

--- a/CRM/Contact/Form/Edit/PhoneBlockTrait.php
+++ b/CRM/Contact/Form/Edit/PhoneBlockTrait.php
@@ -1,0 +1,70 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+use Civi\Api4\Phone;
+use Civi\Api4\Generic\Result;
+
+/**
+ * Form helper trait for including phones in forms.
+ *
+ * @internal not supported for use outside core - if you do use it ensure your
+ *  code has adequate unit test cover.
+ */
+trait CRM_Contact_Form_Edit_PhoneBlockTrait {
+  use CRM_Contact_Form_Edit_BlockCustomDataTrait;
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  protected function addPhoneBlockFields(int $blockNumber): void {
+
+    $this->applyFilter('__ALL__', 'trim');
+
+    //phone type select
+    $this->addField("phone[$blockNumber][phone_type_id]", [
+      'entity' => 'phone',
+      'class' => 'eight',
+      'placeholder' => NULL,
+      'title' => ts('Phone Type %1', [1 => $blockNumber]),
+    ]);
+    //main phone number with crm_phone class
+    $this->addField("phone[$blockNumber][phone]", [
+      'entity' => 'phone',
+      'class' => 'crm_phone twelve',
+      'aria-label' => ts('Phone %1', [1 => $blockNumber]),
+      'label' => ts('Phone %1:', [1 => $blockNumber]),
+    ]);
+    $this->addField("phone[$blockNumber][phone_ext]", [
+      'entity' => 'phone',
+      'aria-label' => ts('Phone Extension %1', [1 => $blockNumber]),
+      'label' => ts('ext.', ['context' => 'phone_ext']),
+    ]);
+    //Block type select
+    $this->addField("phone[$blockNumber][location_type_id]", [
+      'entity' => 'phone',
+      'class' => 'eight',
+      'placeholder' => NULL,
+      'option_url' => NULL,
+      'title' => ts('Phone Location %1', [1 => $blockNumber]),
+    ]);
+
+    //is_Primary radio
+    $js = ['id' => 'Phone_' . $blockNumber . '_IsPrimary', 'onClick' => 'singleSelect( this.id );', 'aria-label' => ts('Phone %1 is primary?', [1 => $blockNumber])];
+    $this->addElement('radio', "phone[$blockNumber][is_primary]", '', '', '1', $js);
+  }
+
+}

--- a/CRM/Contact/Form/Inline/Phone.php
+++ b/CRM/Contact/Form/Inline/Phone.php
@@ -20,6 +20,9 @@
  */
 class CRM_Contact_Form_Inline_Phone extends CRM_Contact_Form_Inline {
 
+  use CRM_Contact_Form_Edit_PhoneBlockTrait;
+  use CRM_Contact_Form_ContactFormTrait;
+
   /**
    * Phones of the contact that is been viewed
    * @var array
@@ -40,7 +43,7 @@ class CRM_Contact_Form_Inline_Phone extends CRM_Contact_Form_Inline {
 
     //get all the existing phones
     $phone = new CRM_Core_BAO_Phone();
-    $phone->contact_id = $this->_contactId;
+    $phone->contact_id = $this->getContactID();
 
     $this->_phones = CRM_Core_BAO_Block::retrieveBlock($phone);
   }
@@ -68,10 +71,8 @@ class CRM_Contact_Form_Inline_Phone extends CRM_Contact_Form_Inline {
     $this->assign('actualBlockCount', $actualBlockCount);
     $this->assign('totalBlocks', $totalBlocks);
 
-    $this->applyFilter('__ALL__', 'trim');
-
     for ($blockId = 1; $blockId < $totalBlocks; $blockId++) {
-      CRM_Contact_Form_Edit_Phone::buildQuickForm($this, $blockId, TRUE);
+      $this->addPhoneBlockFields($blockId);
     }
 
     $this->addFormRule(['CRM_Contact_Form_Inline_Phone', 'formRule']);

--- a/CRM/Contact/Page/Inline/Phone.php
+++ b/CRM/Contact/Page/Inline/Phone.php
@@ -20,6 +20,8 @@
  */
 class CRM_Contact_Page_Inline_Phone extends CRM_Core_Page {
 
+  use CRM_Custom_Page_CustomDataTrait;
+
   /**
    * Run the page.
    *
@@ -27,7 +29,7 @@ class CRM_Contact_Page_Inline_Phone extends CRM_Core_Page {
    *
    * @throws \CRM_Core_Exception
    */
-  public function run() {
+  public function run(): void {
     // get the emails for this contact
     $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE);
 
@@ -40,6 +42,7 @@ class CRM_Contact_Page_Inline_Phone extends CRM_Core_Page {
       foreach ($phones as $key => & $value) {
         $value['location_type'] = $locationTypes[$value['location_type_id']];
         $value['phone_type'] = $phoneTypes[$value['phone_type_id']];
+        $value['custom'] = $this->getCustomDataFieldsForEntityDisplay('Phone', $value['id']);
       }
     }
 

--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -192,7 +192,11 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
     }
     $this->assign('email', $emails);
     $defaults['openid'] = $this->getLocationValues($this->_contactId, 'OpenID');
-    $defaults['phone'] = $this->getLocationValues($this->_contactId, 'Phone');
+    $phones = $this->getLocationValues($this->_contactId, 'Phone');
+    foreach ($phones as $blockId => $phone) {
+      $phones[$blockId]['custom'] = $this->addBlockCustomData('Phone', $phone['id']);
+    }
+    $this->assign('phone', $phones);
     $defaults['website'] = $this->getLocationValues($this->_contactId, 'Website');
     // Copy employer fields to the current_employer keys.
     if (($defaults['contact_type'] === 'Individual') && !empty($defaults['employer_id']) && !empty($defaults['organization_name'])) {

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -2128,6 +2128,20 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
         'table_name' => 'civicrm_address',
         'allow_is_multiple' => FALSE,
       ],
+      [
+        'id' => 'Phone',
+        'label' => ts('Phones'),
+        'grouping' => NULL,
+        'table_name' => 'civicrm_phone',
+        'allow_is_multiple' => FALSE,
+      ],
+      [
+        'id' => 'Email',
+        'label' => ts('Emails'),
+        'grouping' => NULL,
+        'table_name' => 'civicrm_email',
+        'allow_is_multiple' => FALSE,
+      ],
       // TODO: Move to civi_campaign extension (example: OptionValue_cg_extends_objects_grant.mgd.php)
       [
         'id' => 'Campaign',

--- a/templates/CRM/Contact/Form/Inline/Phone.tpl
+++ b/templates/CRM/Contact/Form/Inline/Phone.tpl
@@ -29,7 +29,7 @@
     </tr>
     {section name='i' start=1 loop=$totalBlocks}
     {assign var='blockId' value=$smarty.section.i.index}
-    <tr id="Phone_Block_{$blockId}" {if $blockId gt $actualBlockCount}class="hiddenElement"{/if}>
+      <tr data-entity='phone' data-block-number={$blockId} id="Phone_Block_{$blockId}" {if $blockId gt $actualBlockCount}class="hiddenElement"{/if}>
         <td>{$form.phone.$blockId.phone.html}<span class="crm-phone-ext"> {ts context="phone_ext"}ext.{/ts}&nbsp;{$form.phone.$blockId.phone_ext.html|crmAddClass:four}&nbsp;</span></td>
         <td>{$form.phone.$blockId.location_type_id.html}</td>
         <td>{$form.phone.$blockId.phone_type_id.html}</td>

--- a/templates/CRM/Contact/Form/Inline/Phone.tpl
+++ b/templates/CRM/Contact/Form/Inline/Phone.tpl
@@ -39,6 +39,7 @@
             <a class="crm-delete-inline crm-hover-button" href="#" title="{ts escape='htmlattribute'}Delete phone{/ts}"><span class="icon delete-icon"></span></a>
           {/if}
         </td>
+        {include file="CRM/Contact/Form/Inline/BlockCustomData.tpl" entity=phone customFields=$custom_fields_phone blockId=$blockId actualBlockCount=$actualBlockCount}
     </tr>
     {/section}
 </table>

--- a/templates/CRM/Contact/Page/Inline/Phone.tpl
+++ b/templates/CRM/Contact/Page/Inline/Phone.tpl
@@ -37,6 +37,7 @@
             {$item.phone}{if !empty($item.phone_ext)}&nbsp;&nbsp;{ts}ext.{/ts} {$item.phone_ext}{/if}
           </div>
         </div>
+        {include file="CRM/Contact/Page/Inline/BlockCustomData.tpl" entity='phone' customGroups=$item.custom identifier=$blockId}
       {/if}
     {/foreach}
    </div>


### PR DESCRIPTION
Overview
----------------------------------------
Enable custom data for phones on contact summary

Before
----------------------------------------
It is possible to extend phones with custom data but not to edit or view this data on the contact summary

After
----------------------------------------
![image](https://github.com/user-attachments/assets/311e7f5e-3a57-4642-a3f3-50410db2e881)
![image](https://github.com/user-attachments/assets/fc58af12-0173-4ee8-8131-ce29c4a761da)


Technical Details
----------------------------------------
it could look better theme wise but out of scope

Comments
----------------------------------------
It looks like it would be easy to make the same fixes for OpenID & IM & while they are not very high priority it would be cleaner, removing some legacy calls